### PR TITLE
fix(coding-agent): bound git subprocesses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed git and GitHub CLI subprocesses hanging on credential prompts or buffering unbounded output by forcing non-interactive env, enforcing a timeout, and truncating captured streams. ([#4021](https://github.com/can1357/oh-my-pi/issues/4021))
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { $which, hasFsCode, isEisdir, isEnoent, isEnotdir, Snowflake } from "@oh-my-pi/pi-utils";
+import type { Subprocess } from "bun";
 import {
 	parseDiffHunks as parseCommitDiffHunks,
 	parseFileDiffs,
@@ -150,7 +151,7 @@ export interface GitWorktreeEntry {
 // Error
 // ════════════════════════════════════════════════════════════════════════════
 
-export class GitCommandError extends Error {
+export class GitCommandError extends ToolError {
 	readonly args: readonly string[];
 	readonly result: GitCommandResult;
 
@@ -183,12 +184,28 @@ const AMBIENT_GIT_ENV = {
 	GIT_OBJECT_DIRECTORY: undefined,
 	GIT_ALTERNATE_OBJECT_DIRECTORIES: undefined,
 } satisfies Record<string, undefined>;
+const NON_INTERACTIVE_GIT_ENV = {
+	GIT_TERMINAL_PROMPT: "0",
+	GIT_ASKPASS: "true",
+	SSH_ASKPASS: "/usr/bin/false",
+	GPG_TTY: "not a tty",
+} satisfies Record<string, string>;
+const NON_INTERACTIVE_GH_ENV = {
+	...NON_INTERACTIVE_GIT_ENV,
+	GH_PROMPT_DISABLED: "1",
+} satisfies Record<string, string>;
+const SUBPROCESS_TIMEOUT_ENV = "OMP_GIT_SUBPROCESS_TIMEOUT_MS";
+const SUBPROCESS_MAX_OUTPUT_ENV = "OMP_GIT_SUBPROCESS_MAX_OUTPUT_BYTES";
+const DEFAULT_SUBPROCESS_TIMEOUT_MS = 120_000;
+const DEFAULT_SUBPROCESS_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 interface CommandOptions {
 	readonly env?: Record<string, string | undefined>;
+	readonly maxOutputBytes?: number;
 	readonly readOnly?: boolean;
 	readonly signal?: AbortSignal;
 	readonly stdin?: string | Uint8Array | ArrayBuffer | SharedArrayBuffer;
+	readonly timeoutMs?: number;
 }
 
 function normalizeStdin(input: CommandOptions["stdin"]): "ignore" | Uint8Array {
@@ -203,8 +220,119 @@ function buildGitEnv(overrides?: Record<string, string | undefined>): Record<str
 		...process.env,
 		GIT_OPTIONAL_LOCKS: "0",
 		...AMBIENT_GIT_ENV,
+		...NON_INTERACTIVE_GIT_ENV,
 		...overrides,
 	};
+}
+
+function buildGhEnv(): Record<string, string | undefined> {
+	return {
+		...process.env,
+		...NON_INTERACTIVE_GH_ENV,
+	};
+}
+
+function readByteLimitOverride(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (raw === undefined) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+	return parsed;
+}
+
+function readTimeoutOverride(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (raw === undefined) return fallback;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+	return parsed;
+}
+
+function resolveSubprocessTimeoutMs(timeoutMs?: number): number {
+	return timeoutMs ?? readTimeoutOverride(SUBPROCESS_TIMEOUT_ENV, DEFAULT_SUBPROCESS_TIMEOUT_MS);
+}
+
+function resolveSubprocessMaxOutputBytes(maxOutputBytes?: number): number {
+	return maxOutputBytes ?? readByteLimitOverride(SUBPROCESS_MAX_OUTPUT_ENV, DEFAULT_SUBPROCESS_MAX_OUTPUT_BYTES);
+}
+
+function copyChunks(chunks: readonly Uint8Array[], totalBytes: number): Uint8Array {
+	const output = new Uint8Array(totalBytes);
+	let offset = 0;
+	for (const chunk of chunks) {
+		output.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return output;
+}
+
+async function readCappedStream(stream: ReadableStream<Uint8Array>, maxBytes: number): Promise<string> {
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let capturedBytes = 0;
+	let discardedBytes = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const remaining = Math.max(0, maxBytes - capturedBytes);
+			if (remaining > 0) {
+				const captured = value.byteLength > remaining ? value.slice(0, remaining) : value;
+				chunks.push(captured);
+				capturedBytes += captured.byteLength;
+			}
+			if (value.byteLength > remaining) {
+				discardedBytes += value.byteLength - remaining;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	const decoder = new TextDecoder();
+	const text = decoder.decode(copyChunks(chunks, capturedBytes));
+	if (discardedBytes === 0) return text;
+	const separator = text.length === 0 || text.endsWith("\n") ? "" : "\n";
+	return `${text}${separator}[truncated ${discardedBytes} bytes after ${maxBytes} byte limit]`;
+}
+
+async function waitForExit(
+	command: string,
+	args: readonly string[],
+	child: Subprocess,
+	timeoutMs: number,
+): Promise<number | null> {
+	const timeout = Promise.withResolvers<number | null>();
+	const timer = setTimeout(() => {
+		try {
+			child.kill();
+		} catch {
+			// Process may have exited between timer dispatch and kill.
+		}
+		timeout.reject(new ToolError(`${command} ${args.join(" ")} timed out after ${timeoutMs}ms`));
+	}, timeoutMs);
+	try {
+		return await Promise.race([child.exited, timeout.promise]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+async function captureSubprocessOutput(
+	command: string,
+	args: readonly string[],
+	child: Subprocess,
+	options: Pick<CommandOptions, "maxOutputBytes" | "timeoutMs"> = {},
+): Promise<GitCommandResult> {
+	const maxOutputBytes = resolveSubprocessMaxOutputBytes(options.maxOutputBytes);
+	const timeoutMs = resolveSubprocessTimeoutMs(options.timeoutMs);
+	const [stdout, stderr, exitCode] = await Promise.all([
+		readCappedStream(child.stdout as ReadableStream<Uint8Array>, maxOutputBytes),
+		readCappedStream(child.stderr as ReadableStream<Uint8Array>, maxOutputBytes),
+		waitForExit(command, args, child, timeoutMs),
+	]);
+
+	return { exitCode: exitCode ?? 0, stdout, stderr };
 }
 
 function ensureAvailable(): void {
@@ -240,13 +368,14 @@ async function git(cwd: string, args: readonly string[], options: CommandOptions
 		throw new Error("Failed to capture git command output.");
 	}
 
-	const [stdout, stderr, exitCode] = await Promise.all([
-		new Response(child.stdout).text(),
-		new Response(child.stderr).text(),
-		child.exited,
-	]);
-
-	return { exitCode: exitCode ?? 0, stdout, stderr };
+	try {
+		const result = await captureSubprocessOutput("git", commandArgs, child, options);
+		throwIfAborted(options.signal);
+		return result;
+	} catch (error) {
+		if (options.signal?.aborted) throw new ToolAbortError();
+		throw error;
+	}
 }
 
 function withNoOptionalLocks(args: readonly string[]): string[] {
@@ -1821,7 +1950,9 @@ export interface GhCommandResult {
 }
 
 export interface GhCommandOptions {
+	maxOutputBytes?: number;
 	repoProvided?: boolean;
+	timeoutMs?: number;
 	trimOutput?: boolean;
 }
 
@@ -1857,6 +1988,7 @@ export const github = {
 		try {
 			const child = Bun.spawn(["gh", ...args], {
 				cwd,
+				env: buildGhEnv(),
 				stdin: "ignore",
 				stdout: "pipe",
 				stderr: "pipe",
@@ -1866,17 +1998,13 @@ export const github = {
 			if (!child.stdout || !child.stderr) {
 				throw new ToolError("Failed to capture GitHub CLI output.");
 			}
-			const [stdout, stderr, exitCode] = await Promise.all([
-				new Response(child.stdout).text(),
-				new Response(child.stderr).text(),
-				child.exited,
-			]);
+			const result = await captureSubprocessOutput("gh", args, child, options);
 			throwIfAborted(signal);
 			const trim = options?.trimOutput !== false;
 			return {
-				exitCode: exitCode ?? 0,
-				stdout: trim ? stdout.trim() : stdout,
-				stderr: trim ? stderr.trim() : stderr,
+				exitCode: result.exitCode,
+				stdout: trim ? result.stdout.trim() : result.stdout,
+				stderr: trim ? result.stderr.trim() : result.stderr,
 			};
 		} catch (error) {
 			if (signal?.aborted) throw new ToolAbortError();

--- a/packages/coding-agent/test/git-process-config.test.ts
+++ b/packages/coding-agent/test/git-process-config.test.ts
@@ -21,13 +21,14 @@ function createTextStream(text: string): ReadableStream<Uint8Array> {
 	return body;
 }
 
-function createFakeProcess(stdout = "", stderr = "", exitCode = 0): Subprocess {
+function createFakeProcess(stdout = "", stderr = "", exitCode: number | Promise<number> = 0): Subprocess {
 	return {
 		pid: 12345,
 		stdout: createTextStream(stdout),
 		stderr: createTextStream(stderr),
-		exited: Promise.resolve(exitCode),
-	} as Subprocess;
+		exited: typeof exitCode === "number" ? Promise.resolve(exitCode) : exitCode,
+		kill: vi.fn(),
+	} as unknown as Subprocess;
 }
 
 function createSpawnMock(calls: SpawnCall[]) {
@@ -44,6 +45,26 @@ function createSpawnMock(calls: SpawnCall[]) {
 	}
 
 	return mockSpawn;
+}
+
+async function withEnvOverrides<T>(
+	overrides: readonly (readonly [key: string, value: string | undefined])[],
+	run: () => Promise<T>,
+): Promise<T> {
+	const previous = new Map<string, string | undefined>();
+	for (const [key, value] of overrides) {
+		previous.set(key, process.env[key]);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	try {
+		return await run();
+	} finally {
+		for (const [key, value] of previous) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	}
 }
 
 afterEach(() => {
@@ -109,5 +130,64 @@ describe("git subprocess config", () => {
 			"fork",
 			"HEAD:refs/heads/feature",
 		]);
+	});
+
+	it("forces git subprocesses into non-interactive credential mode", async () => {
+		const spawnCalls: SpawnCall[] = [];
+		vi.spyOn(Bun, "spawn").mockImplementation(createSpawnMock(spawnCalls));
+
+		await withEnvOverrides(
+			[
+				["GIT_TERMINAL_PROMPT", undefined],
+				["GIT_ASKPASS", undefined],
+				["SSH_ASKPASS", undefined],
+				["GPG_TTY", undefined],
+			],
+			() => git.push("/work/pi", { remote: "fork", refspec: "HEAD:refs/heads/feature" }),
+		);
+
+		expect(spawnCalls[0]?.options.env).toMatchObject({
+			GIT_TERMINAL_PROMPT: "0",
+			GIT_ASKPASS: "true",
+			SSH_ASKPASS: "/usr/bin/false",
+			GPG_TTY: "not a tty",
+		});
+	});
+
+	it("rejects when a git subprocess never exits", async () => {
+		const spawnCalls: SpawnCall[] = [];
+		const neverExits = Promise.withResolvers<number>();
+		vi.spyOn(Bun, "spawn").mockImplementation(() => {
+			const process = createFakeProcess("", "", neverExits.promise);
+			spawnCalls.push({ cmd: ["git", "push"], options: {} as SpawnOptions });
+			return process;
+		});
+
+		const result = await withEnvOverrides([["OMP_GIT_SUBPROCESS_TIMEOUT_MS", "1"]], () =>
+			Promise.race([
+				git.push("/work/pi", { remote: "fork", refspec: "HEAD:refs/heads/feature" }).then(
+					() => "resolved",
+					error => error,
+				),
+				Bun.sleep(50).then(() => "still-running"),
+			]),
+		);
+
+		expect(result).toBeInstanceOf(Error);
+		expect(result).not.toBe("still-running");
+		expect(result).not.toBe("resolved");
+		expect(spawnCalls).toHaveLength(1);
+	});
+
+	it("caps captured git subprocess output", async () => {
+		vi.spyOn(Bun, "spawn").mockImplementation(() => createFakeProcess("abcdefghijklmnop"));
+
+		const stdout = await withEnvOverrides([["OMP_GIT_SUBPROCESS_MAX_OUTPUT_BYTES", "8"]], () =>
+			git.diff.tree("/work/pi", "base", "head", { allowFailure: true }),
+		);
+
+		expect(stdout).toContain("abcdefgh");
+		expect(stdout).toContain("truncated 8 bytes after 8 byte limit");
+		expect(stdout).not.toContain("ijklmnop");
 	});
 });


### PR DESCRIPTION
## Repro
A focused regression test in `packages/coding-agent/test/git-process-config.test.ts` reproduced the issue with `bun test packages/coding-agent/test/git-process-config.test.ts`: the git env omitted prompt-suppression fields, a fake subprocess with a never-resolving `exited` promise stayed pending, and capped-output mode returned the full stream.

## Cause
`packages/coding-agent/src/utils/git.ts` spawned `git` and `gh` commands with direct `Response(...).text()` reads and `child.exited` in an unbounded `Promise.all`; `buildGitEnv` also did not force the full non-interactive credential env, so prompt-capable subprocesses could block indefinitely while captured stdout/stderr could grow without limit.

## Fix
- Force git subprocesses to run with `GIT_TERMINAL_PROMPT=0`, `GIT_ASKPASS=true`, `SSH_ASKPASS=/usr/bin/false`, and `GPG_TTY=not a tty`; force `gh` subprocesses through the same git env plus `GH_PROMPT_DISABLED=1`.
- Add a shared subprocess capture path with a default timeout and capped stdout/stderr readers, configurable through options or `OMP_GIT_SUBPROCESS_TIMEOUT_MS` / `OMP_GIT_SUBPROCESS_MAX_OUTPUT_BYTES`.
- Add regression tests for non-interactive env, hung subprocess rejection, and capped output truncation.
- Add the coding-agent changelog entry for #4021.

## Verification
`bun test packages/coding-agent/test/git-process-config.test.ts` passed with 6 tests. `bun check` passed. Fixes #4021