### PR TITLE
fix(hashline): identity-confirm snapshot tags before no-drift path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the streaming edit-diff preview so a short-tag collision with a recorded snapshot no longer previews an anchored edit against unrelated live content — the preview mirrors `Patcher`'s identity-confirmed no-drift check. ([#4024](https://github.com/can1357/oh-my-pi/issues/4024))
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/edit/hashline/diff.ts
+++ b/packages/coding-agent/src/edit/hashline/diff.ts
@@ -199,7 +199,17 @@ function applyPreviewEdits(args: {
 	if (!options.skipHashValidation && expected === undefined) {
 		throw new Error(missingSnapshotTagMessage(section.path));
 	}
-	const liveMatches = expected !== undefined && computeFileHash(normalized) === expected;
+	// Short-tag equality is necessary but not sufficient: the 4-hex tag is a
+	// 16-bit fingerprint and collides across genuinely different content. When
+	// the store retains a snapshot for the tag, require an exact-identity
+	// match on the live text before previewing along the no-drift path. Mirror
+	// of `Patcher.#applyWithRecovery`; keeps preview and apply consistent.
+	const shortMatch = expected !== undefined && computeFileHash(normalized) === expected;
+	const liveMatches =
+		shortMatch &&
+		expected !== undefined &&
+		(snapshots.byHash(absolutePath, expected) === null ||
+			snapshots.byIdentity(absolutePath, normalized)?.hash === expected);
 	const edits = parsePreviewEdits(section, options.streaming);
 	const resolved = resolvePreviewEdits({ section, absolutePath, normalized, snapshots, expected, liveMatches, edits });
 	if (options.skipHashValidation || expected === undefined || liveMatches) return applyEdits(normalized, resolved);

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hashline snapshot identity so a 16-bit tag collision no longer misroutes a `SWAP`/`DEL`/`INS` onto the wrong file: `InMemorySnapshotStore.record` now dedupes by full normalized text (not by the short tag), a new `SnapshotStore.byIdentity(path, text)` performs exact-identity lookup, and `Patcher` verifies full-text identity before taking the no-drift path. When live content collides with a recorded snapshot on the short tag but differs, the patcher raises a distinct `MismatchError` naming the collision instead of silently applying anchored edits to unrelated content. ([#4024](https://github.com/can1357/oh-my-pi/issues/4024))
+
 ## [16.2.8] - 2026-06-30
 
 ### Fixed

--- a/packages/hashline/src/mismatch.ts
+++ b/packages/hashline/src/mismatch.ts
@@ -91,6 +91,16 @@ export class MismatchError extends Error {
 				`The current file hashes to ${HL_FILE_HASH_SEP}${details.actualFileHash}. Re-read the file with \`read\` to copy a current ${HL_FILE_PREFIX}path${HL_FILE_HASH_SEP}tag${HL_FILE_SUFFIX} header — never invent the tag and never reuse one from a prior session.`,
 			];
 		}
+		// Same short tag on both sides but the recorded snapshot's text
+		// differs from live: the 4-hex tag is a 16-bit fingerprint and
+		// collided across genuinely different content. Explain plainly so the
+		// model doesn't chase a "tags match, why does it fail?" red herring.
+		if (details.expectedFileHash === details.actualFileHash) {
+			return [
+				`Edit rejected${pathText}: file content differs from the recorded snapshot despite a matching tag.`,
+				`Two different contents share the short tag ${HL_FILE_HASH_SEP}${details.expectedFileHash} (accidental collision). Re-read the file with \`read\` to refresh the header against the current content before retrying.`,
+			];
+		}
 		return [
 			`Edit rejected${pathText}: file changed between read and edit.`,
 			`Section is bound to ${HL_FILE_HASH_SEP}${details.expectedFileHash}, but the current file hashes to ${HL_FILE_HASH_SEP}${details.actualFileHash}. If a prior edit in this session modified this file, copy the ${HL_FILE_PREFIX}path${HL_FILE_HASH_SEP}newhash${HL_FILE_SUFFIX} header from that edit's response; otherwise re-read the file with \`read\` to refresh the tag before retrying.`,

--- a/packages/hashline/src/patcher.ts
+++ b/packages/hashline/src/patcher.ts
@@ -485,9 +485,16 @@ export class Patcher {
 	 * absent or empty means no provenance was recorded, so the edit applies as
 	 * before. Only runs on the no-drift path, where anchor line numbers index
 	 * the tagged content 1:1.
+	 *
+	 * Prefers {@link SnapshotStore.byIdentity} against the (already-verified)
+	 * live text so a tag-collision on the short hash can't misroute the check
+	 * onto a different snapshot's seen-line set. Falls back to short-tag
+	 * lookup when no exact-identity match is retained (e.g. LRU-evicted).
 	 */
-	#assertSeenLines(section: PatchSection, canonicalPath: string, expected: string): void {
-		const seen = this.snapshots.byHash(canonicalPath, expected)?.seenLines;
+	#assertSeenLines(section: PatchSection, canonicalPath: string, expected: string, normalized: string): void {
+		const seen = (
+			this.snapshots.byIdentity(canonicalPath, normalized) ?? this.snapshots.byHash(canonicalPath, expected)
+		)?.seenLines;
 		if (!seen || seen.size === 0) return;
 		const unseen = section.collectAnchorLines().filter(line => !seen.has(line));
 		if (unseen.length === 0) return;
@@ -520,7 +527,22 @@ export class Patcher {
 	}): ApplyResult {
 		const { section, canonicalPath, exists, normalized, edits } = args;
 		const expected = exists ? section.fileHash : undefined;
-		const liveMatches = expected !== undefined && computeFileHash(normalized) === expected;
+		// Short-tag equality is NECESSARY but not SUFFICIENT for no-drift: the
+		// 4-hex tag is a 16-bit fingerprint and collides across genuinely
+		// different content. When the store holds at least one snapshot for
+		// (path, expected), require an exact-identity match on the live text
+		// before taking the no-drift path — otherwise a collided live file
+		// would be treated as the snapshot and edits would target the wrong
+		// content. When no snapshot is retained (e.g. LRU-evicted, or the tag
+		// was minted in a prior session we no longer track), fall back to the
+		// short-tag match: recovery has nothing to replay against and the
+		// short tag is the only identity signal we have.
+		const shortMatch = expected !== undefined && computeFileHash(normalized) === expected;
+		const liveMatches =
+			shortMatch &&
+			expected !== undefined &&
+			(this.snapshots.byHash(canonicalPath, expected) === null ||
+				this.snapshots.byIdentity(canonicalPath, normalized)?.hash === expected);
 
 		// Resolve `replace_block N:` edits to concrete ranges before recovery
 		// runs. Block anchors are expressed against the snapshot the section tag
@@ -559,7 +581,7 @@ export class Patcher {
 			// The line numbers in `edits` index the exact content the tag names.
 			// Reject any anchor the read never displayed: editing lines the model
 			// has not seen is the off-by-memory mistake that mangles files.
-			if (expected !== undefined) this.#assertSeenLines(section, canonicalPath, expected);
+			if (expected !== undefined) this.#assertSeenLines(section, canonicalPath, expected, normalized);
 			const result = applyEdits(normalized, resolved);
 			return withResolveWarnings(blockResolutions.length > 0 ? { ...result, blockResolutions } : result);
 		}

--- a/packages/hashline/src/snapshots.ts
+++ b/packages/hashline/src/snapshots.ts
@@ -2,17 +2,24 @@
  * Per-session snapshot store used by {@link Recovery} and {@link Patcher} to
  * bind hashline section tags to the exact file content that minted them.
  *
- * A section tag is a content-derived hash of the *whole file* (see
- * {@link computeFileHash}). Any read of byte-identical content mints the same
- * tag, so reads of one file state fuse onto one anchor and a follow-up edit
- * anchored at any line validates whenever the live file still hashes to it.
+ * A section tag ({@link Snapshot.hash}) is a short 4-hex fingerprint of the
+ * whole normalized file (see {@link computeFileHash}). It is model-visible and
+ * intentionally compact, so two genuinely different files can end up sharing
+ * one tag by accident. The store therefore treats the FULL normalized text as
+ * a snapshot's identity: {@link SnapshotStore.record} deduplicates by text
+ * (not by short tag), and {@link SnapshotStore.byIdentity} is the exact
+ * lookup consumers use when they already hold the candidate text. Short-tag
+ * lookups ({@link SnapshotStore.byHash}, {@link SnapshotStore.findByHash})
+ * remain available for recovery flows that only know the tag, but they may
+ * return one of several tag-colliding versions and callers must not treat a
+ * short-tag hit as proof of content identity.
  *
  * Producers (typically `read` / `search` / `write` tools) call
  * {@link SnapshotStore.record} with the full normalized text they observed.
- * The store hashes it, dedups against the per-path history, and returns the
- * tag. Consumers (the patcher) resolve a stale tag back to the recorded full
- * text via {@link SnapshotStore.byHash} and 3-way-merge the would-be edit onto
- * the live content.
+ * The store hashes it, dedups by full text against the per-path history, and
+ * returns the tag. Consumers (the patcher) resolve a stale tag back to the
+ * recorded full text via {@link SnapshotStore.byHash} and 3-way-merge the
+ * would-be edit onto the live content.
  *
  * The abstract base class lets callers plug in whatever storage they like
  * (LRU, persistent SQLite, etc.). {@link InMemorySnapshotStore} ships as a
@@ -25,14 +32,21 @@ import { computeFileHash } from "./format";
 
 /**
  * One full-file version observed at a point in time. The tag the model sees is
- * {@link Snapshot.hash}; recovery replays edits against {@link Snapshot.text}.
+ * {@link Snapshot.hash}; the true snapshot identity is {@link Snapshot.text}
+ * (short hashes may collide across genuinely different content). Recovery
+ * replays edits against {@link Snapshot.text}.
  */
 export interface Snapshot {
 	/** Canonical path this version belongs to. */
 	readonly path: string;
-	/** Full normalized (LF, no BOM) file text as observed. */
+	/** Full normalized (LF, no BOM) file text as observed. Doubles as the snapshot's identity. */
 	readonly text: string;
-	/** Content-derived tag for {@link Snapshot.text} (see {@link computeFileHash}). */
+	/**
+	 * Model-visible short tag for {@link Snapshot.text} (see {@link computeFileHash}).
+	 * The tag is a 4-hex low-bit fingerprint and can collide across different
+	 * texts; consumers proving no-drift MUST compare {@link Snapshot.text}, not
+	 * just the tag.
+	 */
 	readonly hash: string;
 	/** Timestamp (ms since epoch) the version was recorded. */
 	recordedAt: number;
@@ -56,8 +70,24 @@ export abstract class SnapshotStore {
 	/** Most-recently recorded version for `path`, or `null` if none. */
 	abstract head(path: string): Snapshot | null;
 
-	/** Recorded version for `path` whose tag equals `hash`, or `null`. */
+	/**
+	 * Recorded version for `path` whose short tag equals `hash`, or `null`.
+	 *
+	 * Short tags can collide across different texts. When two versions share
+	 * a tag the store returns the most-recently-recorded one; callers that
+	 * need proof of content identity must use {@link byIdentity} or compare
+	 * {@link Snapshot.text} against the candidate text themselves.
+	 */
 	abstract byHash(path: string, hash: string): Snapshot | null;
+
+	/**
+	 * Recorded version for `path` whose full normalized text equals `text`,
+	 * or `null`. Exact snapshot identity — never confuses tag-colliding
+	 * versions. The patcher uses this on the no-drift path to prove the live
+	 * file is byte-identical to a recorded snapshot before applying anchored
+	 * edits.
+	 */
+	abstract byIdentity(path: string, text: string): Snapshot | null;
 
 	/**
 	 * Every retained version whose tag equals `hash`, across all tracked
@@ -76,6 +106,11 @@ export abstract class SnapshotStore {
 	 * Record the full normalized text of `path` and return its content tag.
 	 * `seenLines` (optional) are the 1-indexed lines the producer displayed;
 	 * they merge into {@link Snapshot.seenLines} across reads of identical text.
+	 *
+	 * Deduplication is keyed on {@link Snapshot.text} (full normalized text),
+	 * NOT on the short tag: two texts that happen to share a tag are stored
+	 * as separate versions so the store never fuses genuinely different
+	 * snapshots.
 	 */
 	abstract record(path: string, fullText: string, seenLines?: Iterable<number>): string;
 
@@ -133,7 +168,11 @@ export interface InMemorySnapshotStoreOptions {
  *
  * Recording byte-identical content again refreshes recency and reuses the
  * existing tag (read fusion); recording new content unshifts a fresh version
- * onto the front of the path history.
+ * onto the front of the path history. Fusion is keyed on the FULL normalized
+ * text, not on the short {@link Snapshot.hash} tag: two distinct texts that
+ * happen to collide on the tag are kept as separate versions so a follow-up
+ * lookup via {@link byIdentity} can still resolve the exact snapshot the
+ * caller holds.
  */
 export class InMemorySnapshotStore extends SnapshotStore {
 	readonly #versions: LRUCache<string, Snapshot[]>;
@@ -162,6 +201,11 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		return history?.find(version => version.hash === hash) ?? null;
 	}
 
+	byIdentity(path: string, text: string): Snapshot | null {
+		const history = this.#versions.get(path);
+		return history?.find(version => version.text === text) ?? null;
+	}
+
 	findByHash(hash: string): Snapshot[] {
 		const matches: Snapshot[] = [];
 		for (const history of this.#versions.values()) {
@@ -176,7 +220,10 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		const hash = computeFileHash(fullText);
 		// `get` refreshes LRU recency for `path`.
 		const history = this.#versions.get(path) ?? [];
-		const existing = history.find(version => version.hash === hash);
+		// Dedup by FULL text, not by the short tag: two distinct texts can
+		// share a tag (16-bit fingerprint), and fusing them would collapse
+		// genuinely different snapshots into one stored state.
+		const existing = history.find(version => version.text === fullText);
 		if (existing) {
 			// Same content state observed again: refresh recency and promote to
 			// head (it is the current file content), then reuse the tag. Union any
@@ -196,6 +243,10 @@ export class InMemorySnapshotStore extends SnapshotStore {
 	}
 
 	recordSeenLines(path: string, hash: string, lines: Iterable<number>): void {
+		// Match on short tag: callers reach this from producers that only hold
+		// the freshly-minted tag they just returned to the consumer. When two
+		// versions collide on the tag the most-recent one wins (find order =
+		// insertion order = LRU recency).
 		const version = this.#versions.get(path)?.find(snapshot => snapshot.hash === hash);
 		if (version) mergeSeenLines(version, lines);
 	}
@@ -212,11 +263,14 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		if (destHistory === undefined) {
 			this.#versions.set(to, relocated);
 		} else {
+			// Dedup by FULL text (identity), not by short tag: tag-only dedup
+			// would silently drop a tag-colliding sibling that carries genuinely
+			// different content.
 			const seen = new Set<string>();
 			const merged: Snapshot[] = [];
 			for (const version of [...relocated, ...destHistory]) {
-				if (seen.has(version.hash)) continue;
-				seen.add(version.hash);
+				if (seen.has(version.text)) continue;
+				seen.add(version.text);
 				merged.push(version);
 			}
 			this.#versions.set(to, merged.slice(0, this.#maxVersionsPerPath));

--- a/packages/hashline/test/patcher.test.ts
+++ b/packages/hashline/test/patcher.test.ts
@@ -126,6 +126,51 @@ describe("Patcher snapshot tag integrity", () => {
 		}
 		expect(fs.get(PATH)).toBe("current\n");
 	});
+
+	it("rejects the no-drift path when live text collides with the recorded snapshot on the short tag", async () => {
+		// Reporter-supplied pair: `line one 263\\nline two 4471\\n` and
+		// `line one 410\\nline two 6970\\n` both hash to short tag "1D84".
+		// Snapshot recorded from the first text; live file holds the second.
+		// Applying `SWAP 2.=2` under the shared tag must NOT edit the wrong
+		// file — the patcher's no-drift path must verify full-text identity
+		// before trusting the short tag.
+		const snapshotText = "line one 263\nline two 4471\n";
+		const liveText = "line one 410\nline two 6970\n";
+		expect(computeFileHash(snapshotText)).toBe(computeFileHash(liveText));
+
+		const fs = new InMemoryFilesystem([[PATH, liveText]]);
+		const snapshots = new InMemorySnapshotStore();
+		const tag = snapshots.record(PATH, snapshotText, [2]);
+
+		const patcher = new Patcher({ fs, snapshots });
+		await expect(patcher.apply(Patch.parse(`[${PATH}#${tag}]\nSWAP 2.=2:\n+edited from v1`))).rejects.toBeInstanceOf(
+			MismatchError,
+		);
+		// Disk untouched: the collided live file was NOT rewritten.
+		expect(fs.get(PATH)).toBe(liveText);
+	});
+
+	it("surfaces a collision-specific diagnostic when the tag matches but content differs", async () => {
+		const snapshotText = "line one 263\nline two 4471\n";
+		const liveText = "line one 410\nline two 6970\n";
+		const fs = new InMemoryFilesystem([[PATH, liveText]]);
+		const snapshots = new InMemorySnapshotStore();
+		const tag = snapshots.record(PATH, snapshotText);
+		const patcher = new Patcher({ fs, snapshots });
+
+		try {
+			await patcher.apply(Patch.parse(`[${PATH}#${tag}]\nSWAP 2.=2:\n+X`));
+			throw new Error("expected MismatchError");
+		} catch (error) {
+			expect(error).toBeInstanceOf(MismatchError);
+			const message = (error as MismatchError).displayMessage;
+			// Distinct from the ordinary "file changed" branch: the message must
+			// name the collision so the model doesn't chase a tags-match paradox.
+			expect(message).toMatch(/differs from the recorded snapshot despite a matching tag/);
+			expect(message).toMatch(/accidental collision/);
+		}
+		expect(fs.get(PATH)).toBe(liveText);
+	});
 });
 
 describe("Patcher mandatory snapshot tag policy", () => {

--- a/packages/hashline/test/snapshots.test.ts
+++ b/packages/hashline/test/snapshots.test.ts
@@ -109,4 +109,38 @@ describe("InMemorySnapshotStore", () => {
 		// A tag no retained version carries yields no matches.
 		expect(store.findByHash(tag === "0000" ? "FFFF" : "0000")).toEqual([]);
 	});
+
+	it("keeps two versions that share a short-tag but differ in content (no collision fusion)", () => {
+		const store = new InMemorySnapshotStore();
+		// Reporter-supplied pair: both hash to short tag "1D84" but are
+		// genuinely different files. The store MUST NOT dedupe them into one
+		// entry — that would treat two snapshots as identical and let a
+		// collided live file be accepted as either.
+		const a = "line one 263\nline two 4471\n";
+		const b = "line one 410\nline two 6970\n";
+		expect(computeFileHash(a)).toBe(computeFileHash(b));
+
+		const tag = store.record(PATH, a, [2]);
+		expect(store.record(PATH, b, [1])).toBe(tag);
+
+		// Both versions retained side-by-side; seenLines are per-version, not fused.
+		expect(store.byIdentity(PATH, a)?.text).toBe(a);
+		expect(store.byIdentity(PATH, b)?.text).toBe(b);
+		expect(store.byIdentity(PATH, a)?.seenLines).toEqual(new Set([2]));
+		expect(store.byIdentity(PATH, b)?.seenLines).toEqual(new Set([1]));
+		// findByHash surfaces every retained version with that short tag.
+		const bothByTag = store.findByHash(tag);
+		expect(new Set(bothByTag.map(snapshot => snapshot.text))).toEqual(new Set([a, b]));
+	});
+
+	it("byIdentity resolves the exact snapshot for a given path+text", () => {
+		const store = new InMemorySnapshotStore();
+		const text = "alpha\nbeta\n";
+		store.record(PATH, text);
+		expect(store.byIdentity(PATH, text)?.text).toBe(text);
+		// Different text on the same path → no identity match.
+		expect(store.byIdentity(PATH, "alpha\nBETA\n")).toBeNull();
+		// Cross-path lookup rejected even for identical text.
+		expect(store.byIdentity(OTHER, text)).toBeNull();
+	});
 });


### PR DESCRIPTION
## Repro

The hashline section tag is a 4-hex, low-16-bit fingerprint of the whole normalized file. Two genuinely different files can share one tag by accident, and the snapshot store, patcher, and seen-line guard all keyed on the short tag as if it were identity. As a result, a live file whose text differed from the recorded snapshot but hashed to the same tag was accepted as no-drift, and anchored `SWAP`/`DEL`/`INS` edits ran directly against the wrong content.

Repro through the public APIs (`packages/hashline/src/index.ts`):

```js
const a = "line one 263\nline two 4471\n";
const b = "line one 410\nline two 6970\n";  // both hash to 1D84
const snapshots = new InMemorySnapshotStore();
const fs = new InMemoryFilesystem();
snapshots.record("test.txt", a, [2]);
await fs.writeText("test.txt", b);
await new Patcher({ fs, snapshots }).apply(
    Patch.parse("[test.txt#1D84]\nSWAP 2.=2:\n+edited from v1"),
);
// pre-fix: fs["test.txt"] === "line one 410\nedited from v1\n"
```

## Cause

Three offending seams treated a 16-bit hash equality as identity:

- `packages/hashline/src/snapshots.ts` — `InMemorySnapshotStore.record` deduplicated `history.find(v => v.hash === hash)`, fusing colliding texts. `relocate` deduped by hash too.
- `packages/hashline/src/patcher.ts` — `Patcher.#applyWithRecovery` computed `liveMatches = computeFileHash(normalized) === expected` and took the no-drift branch on short-hash equality alone.
- `packages/hashline/src/patcher.ts` — `Patcher.#assertSeenLines` looked up `seenLines` via `snapshots.byHash(canonicalPath, expected)`, so the guard consulted a tag-colliding snapshot instead of the one whose text actually matched live.

The coding-agent streaming diff preview (`packages/coding-agent/src/edit/hashline/diff.ts`) mirrored the same short-hash `liveMatches` logic.

## Fix

Push identity checks onto full normalized text at every seam; keep the visible 4-hex tag format for backward compat with active model context and downstream regex tests.

- `packages/hashline/src/snapshots.ts`
  - `InMemorySnapshotStore.record` deduplicates by full text (`version.text === fullText`) so two tag-colliding contents remain as separate versions.
  - New `SnapshotStore.byIdentity(path, text)` returns the recorded version whose full text matches `text`; documented as the exact-identity lookup.
  - `relocate` merges by full text, not short hash, so a colliding sibling isn't silently dropped.
  - `Snapshot`, `SnapshotStore`, and the module doc-comments call out that the short tag can collide and identity means full text.
- `packages/hashline/src/patcher.ts`
  - `#applyWithRecovery` requires an identity-confirmed match when the store holds any snapshot for `(path, expected)`: no-drift only fires when `byIdentity(path, normalized)?.hash === expected` (or no recorded snapshot exists for the tag at all, preserving the LRU-eviction fallthrough).
  - `#assertSeenLines` prefers `byIdentity(path, normalized)` over `byHash` on the no-drift path, so a collision cannot misroute seen-line provenance.
- `packages/hashline/src/mismatch.ts` — `MismatchError.rejectionHeader` adds a collision branch that names the collision explicitly instead of the confusing "bound to #1D84 but current file hashes to #1D84".
- `packages/coding-agent/src/edit/hashline/diff.ts` — streaming diff preview mirrors the same identity-confirmed `liveMatches` check.
- Changelog entries in both packages.

## Verification

- `bun test packages/hashline/test/` — 213 pass, 0 fail (including the new `1D84`-collision regressions in `snapshots.test.ts` and `patcher.test.ts`).
- `bun test packages/coding-agent/test/edit/ packages/coding-agent/test/edit-streaming-preview.test.ts` — 60 pass, 0 fail.
- `bun run check` — clean.
- Manual replay of the reporter's scenario (see `## Repro`) now produces a `MismatchError` and leaves the on-disk file untouched.

Fixes #4024