### PR TITLE
fix(rpc): restore lifecycle cancellation

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -127,6 +127,10 @@ Important edge behavior from runtime:
 - `{ id?, type: "bash", command: string }`
 - `{ id?, type: "abort_bash" }`
 
+`abort_bash` is processed out-of-band from the regular command queue so it can
+cancel an in-flight `bash` command. Hosts must correlate responses by `id`;
+the `abort_bash` response can arrive before the earlier `bash` response.
+
 ### Session
 
 - `{ id?, type: "get_session_stats" }`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed RPC bash cancellation so `abort_bash` bypasses the regular command queue, and fixed `RpcClient` cleanup so a client can restart after `stop()`. ([#4027](https://github.com/can1357/oh-my-pi/issues/4027))
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -230,6 +230,7 @@ export class RpcClient {
 		if (this.#process) {
 			throw new Error("Client already started");
 		}
+		this.#abortController = new AbortController();
 
 		const cliPath = this.options.cliPath ?? "dist/cli.js";
 		const args = ["--mode", "rpc"];
@@ -304,6 +305,9 @@ export class RpcClient {
 			if (this.#customTools.length > 0) {
 				await this.setCustomTools(this.#customTools);
 			}
+		} catch (error) {
+			this.stop();
+			throw error;
 		} finally {
 			clearTimeout(readyTimeout);
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1110,6 +1110,19 @@ export async function runRpcMode(
 		process.exit(0);
 	}
 
+	const sendCommandResponse = async (command: RpcCommand): Promise<void> => {
+		try {
+			const response = await handleCommand(command);
+			output(response);
+			await checkShutdownRequested();
+		} catch (e: unknown) {
+			const message = e instanceof Error ? e.message : String(e);
+			output(error(command.id, command.type, `Failed to handle command: ${message}`));
+		}
+	};
+
+	let regularCommandQueue: Promise<void> = Promise.resolve();
+
 	// Listen for JSON input using Bun's stdin
 	for await (const parsed of readJsonl(Bun.stdin.stream())) {
 		try {
@@ -1138,13 +1151,14 @@ export async function runRpcMode(
 				continue;
 			}
 
-			// Handle regular commands
+			// Keep normal commands serialized while letting abort_bash bypass the
+			// queue so it can cancel an in-flight bash command.
 			const command = parsed as RpcCommand;
-			const response = await handleCommand(command);
-			output(response);
-
-			// Check for deferred shutdown request (idle between commands)
-			await checkShutdownRequested();
+			if (command.type === "abort_bash") {
+				await sendCommandResponse(command);
+				continue;
+			}
+			regularCommandQueue = regularCommandQueue.then(() => sendCommandResponse(command));
 		} catch (e: unknown) {
 			const message = e instanceof Error ? e.message : String(e);
 			output(error(undefined, "parse", `Failed to parse command: ${message}`));

--- a/packages/coding-agent/test/rpc-client.start.test.ts
+++ b/packages/coding-agent/test/rpc-client.start.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import * as path from "node:path";
 import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("RpcClient.start", () => {
 	test("rejects when RPC process exits immediately", async () => {
@@ -13,5 +14,27 @@ describe("RpcClient.start", () => {
 		});
 
 		await expect(client.start()).rejects.toThrow(/Unknown provider.*__missing_provider__/);
+	});
+
+	test("can start again after stop", async () => {
+		using tempDir = TempDir.createSync("@omp-rpc-client-restart-");
+		const cliPath = tempDir.join("fake-rpc.ts");
+		await Bun.write(
+			cliPath,
+			[
+				'process.stdout.write(JSON.stringify({ type: "ready" }) + "\\n");',
+				"for await (const _chunk of Bun.stdin.stream()) {}",
+			].join("\n"),
+		);
+		using client = new RpcClient({
+			cliPath,
+			cwd: path.join(import.meta.dir, ".."),
+			env: { PI_NO_TITLE: "1" },
+		});
+
+		await client.start();
+		client.stop();
+
+		await expect(client.start()).resolves.toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/rpc-mode-bash-abort.test.ts
+++ b/packages/coding-agent/test/rpc-mode-bash-abort.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import type { ReadableStream as NodeReadableStream, ReadableStreamDefaultReader } from "node:stream/web";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import type { FileSink } from "bun";
+
+type RpcFrame = Record<string, unknown>;
+
+class RpcJsonlReader {
+	#buffer = "";
+	#decoder = new TextDecoder();
+	#reader: ReadableStreamDefaultReader<Uint8Array>;
+
+	constructor(stream: NodeReadableStream<Uint8Array>) {
+		this.#reader = stream.getReader();
+	}
+
+	async nextFrame(timeoutMs: number): Promise<RpcFrame | null> {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			const newline = this.#buffer.indexOf("\n");
+			if (newline >= 0) {
+				const line = this.#buffer.slice(0, newline);
+				this.#buffer = this.#buffer.slice(newline + 1);
+				if (line.trim().length === 0) continue;
+				const parsed: unknown = JSON.parse(line);
+				if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+					throw new Error(`RPC frame is not an object: ${line}`);
+				}
+				return parsed as RpcFrame;
+			}
+
+			const remainingMs = Math.max(1, deadline - Date.now());
+			const chunk = await Promise.race([this.#reader.read(), Bun.sleep(remainingMs).then(() => null)]);
+			if (!chunk || chunk.done) return null;
+			this.#buffer += this.#decoder.decode(chunk.value, { stream: true });
+		}
+		return null;
+	}
+}
+
+describe("RPC mode bash abort", () => {
+	test("processes abort_bash while a bash command is still pending", async () => {
+		using tempDir = TempDir.createSync("@omp-rpc-mode-bash-abort-");
+		const harnessPath = tempDir.join("rpc-mode-harness.ts");
+		const rpcModePath = path.join(import.meta.dir, "..", "src", "modes", "rpc", "rpc-mode.ts");
+		const agentSessionPath = path.join(import.meta.dir, "..", "src", "session", "agent-session.ts");
+		const bashExecutorPath = path.join(import.meta.dir, "..", "src", "exec", "bash-executor.ts");
+		await Bun.write(
+			harnessPath,
+			`
+import type { BashResult } from ${JSON.stringify(bashExecutorPath)};
+import { runRpcMode } from ${JSON.stringify(rpcModePath)};
+import type { AgentSession } from ${JSON.stringify(agentSessionPath)};
+
+let finishBash: ((result: BashResult) => void) | undefined;
+const abortedResult: BashResult = {
+	output: "aborted",
+	exitCode: 1,
+	cancelled: true,
+	truncated: false,
+	totalLines: 1,
+	totalBytes: 7,
+	outputLines: 1,
+	outputBytes: 7,
+};
+const session = {
+	customCommands: [],
+	skills: [],
+	skillsSettings: {},
+	sessionManager: { getCwd: () => ${JSON.stringify(tempDir.path())} },
+	setSlashCommands: () => {},
+	refreshSshTool: async () => {},
+	subscribe: () => {},
+	subscribeCommandMetadataChanged: () => {},
+	executeBash: async () => {
+		return await new Promise<BashResult>(resolve => {
+			finishBash = resolve;
+		});
+	},
+	abortBash: () => {
+		finishBash?.(abortedResult);
+	},
+} as unknown as AgentSession;
+
+await runRpcMode(session);
+`,
+		);
+		const proc = Bun.spawn(["bun", harnessPath], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+			cwd: path.join(import.meta.dir, ".."),
+		});
+		const reader = new RpcJsonlReader(proc.stdout as NodeReadableStream<Uint8Array>);
+		const stdin = proc.stdin as FileSink;
+		try {
+			await expect(reader.nextFrame(2_000)).resolves.toMatchObject({ type: "ready" });
+			stdin.write(`${JSON.stringify({ id: "b1", type: "bash", command: "block" })}\n`);
+			await stdin.flush();
+			await Bun.sleep(50);
+			stdin.write(`${JSON.stringify({ id: "a1", type: "abort_bash" })}\n`);
+			await stdin.flush();
+
+			let abortResponse: RpcFrame | null = null;
+			let bashResponse: RpcFrame | null = null;
+			const deadline = Date.now() + 2_000;
+			while (Date.now() < deadline && (!abortResponse || !bashResponse)) {
+				const frame = await reader.nextFrame(Math.max(1, deadline - Date.now()));
+				if (!frame) break;
+				if (frame.type !== "response") continue;
+				if (frame.id === "a1") abortResponse = frame;
+				if (frame.id === "b1") bashResponse = frame;
+			}
+
+			expect(abortResponse).toMatchObject({ id: "a1", type: "response", command: "abort_bash", success: true });
+			expect(bashResponse).toMatchObject({
+				id: "b1",
+				type: "response",
+				command: "bash",
+				success: true,
+				data: { cancelled: true },
+			});
+		} finally {
+			proc.kill();
+			await proc.exited.catch(() => undefined);
+		}
+	}, 10_000);
+});


### PR DESCRIPTION
## Repro
A harness around `runRpcMode` with a fake `AgentSession.executeBash` that only resolves from `abortBash` received `ready`, then no `abort_bash` response within 1s after `{ id: "b1", type: "bash" }` followed by `{ id: "a1", type: "abort_bash" }`. A `RpcClient` harness against a ready-only child reproduced `start(); stop(); start()` rejecting with `Agent process exited before ready`, then a third `start()` rejecting with `Client already started`.

## Cause
`packages/coding-agent/src/modes/rpc/rpc-mode.ts` awaited every regular `handleCommand()` inside the stdin `for await` loop, so the loop could not read the `abort_bash` frame while an earlier `bash` command was awaiting `AgentSession.executeBash`. `packages/coding-agent/src/modes/rpc/rpc-client.ts` kept using the same aborted `#abortController` after `stop()` and only cleared the startup timeout on failed `start()`, leaving the spawned process in `#process`.

## Fix
- Kept normal RPC commands serialized through an internal promise queue while processing `abort_bash` out-of-band so cancellation reaches an in-flight bash command.
- Reset `RpcClient`'s abort controller before each new process start and call `stop()` on startup failure to kill and clear the half-started child.
- Added focused regression coverage for out-of-band `abort_bash` handling and `RpcClient` restart after `stop()`.
- Documented `abort_bash` response ordering and added the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/rpc-client.start.test.ts packages/coding-agent/test/rpc-mode-bash-abort.test.ts` passed: 3 tests, 0 failures. `bun run check` in `packages/coding-agent` passed. Fixes #4027