### PR TITLE
fix(shell): bound native bash output streaming

### DIFF
--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -9,7 +9,7 @@ use napi::{
 };
 use napi_derive::napi;
 use pi_shell::{
-	MinimizerResult as CoreMinimizerResult, Shell as CoreShell,
+	MinimizerResult as CoreMinimizerResult, OutputLimiter, OutputSender, Shell as CoreShell,
 	ShellExecuteOptions as CoreShellExecuteOptions, ShellOptions as CoreShellOptions,
 	ShellRunOptions as CoreShellRunOptions, ShellRunResult as CoreShellRunResult,
 	execute_shell as core_execute_shell,
@@ -90,36 +90,42 @@ impl From<ShellOptions> for CoreShellOptions {
 #[napi(object)]
 pub struct ShellRunOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:    String,
+	pub command:                 String,
 	/// Working directory for the command.
-	pub cwd:        Option<String>,
+	pub cwd:                     Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:        Option<HashMap<String, String>>,
+	pub env:                     Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms: Option<u32>,
+	pub timeout_ms:              Option<u32>,
+	/// Maximum UTF-8 bytes forwarded to `onChunk` before native output is
+	/// dropped.
+	pub stream_output_max_bytes: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal:                  Option<Unknown<'env>>,
 }
 
 /// Options for executing a shell command via brush-core.
 #[napi(object)]
 pub struct ShellExecuteOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:       String,
+	pub command:                 String,
 	/// Working directory for the command.
-	pub cwd:           Option<String>,
+	pub cwd:                     Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:           Option<HashMap<String, String>>,
+	pub env:                     Option<HashMap<String, String>>,
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env:             Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms:    Option<u32>,
+	pub timeout_ms:              Option<u32>,
 	/// Optional snapshot file to source on session creation.
-	pub snapshot_path: Option<String>,
+	pub snapshot_path:           Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer:     Option<MinimizerOptions>,
+	pub minimizer:               Option<MinimizerOptions>,
+	/// Maximum UTF-8 bytes forwarded to `onChunk` before native output is
+	/// dropped.
+	pub stream_output_max_bytes: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:        Option<Unknown<'env>>,
+	pub signal:                  Option<Unknown<'env>>,
 }
 
 /// Telemetry for a single minimization.
@@ -216,6 +222,7 @@ impl Shell {
 	) -> Result<PromiseRaw<'env, ShellRunResult>> {
 		let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 		let inner = Arc::clone(&self.inner);
+		let stream_output_max_bytes = options.stream_output_max_bytes.map(|bytes| bytes as usize);
 		let run_options = CoreShellRunOptions {
 			command:    options.command,
 			cwd:        options.cwd,
@@ -223,7 +230,7 @@ impl Shell {
 			timeout_ms: options.timeout_ms,
 		};
 		task::future(env, "shell.run", async move {
-			let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
+			let (chunk_tx, drain_handle) = bridge_chunks(on_chunk, stream_output_max_bytes);
 			let result = inner
 				.run(run_options, chunk_tx, cancel_token.into_core())
 				.await
@@ -268,6 +275,7 @@ pub fn execute_shell<'env>(
 	on_chunk: Option<ThreadsafeFunction<String>>,
 ) -> Result<PromiseRaw<'env, ShellRunResult>> {
 	let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
+	let stream_output_max_bytes = options.stream_output_max_bytes.map(|bytes| bytes as usize);
 	let exec_options = CoreShellExecuteOptions {
 		command:       options.command,
 		cwd:           options.cwd,
@@ -278,7 +286,7 @@ pub fn execute_shell<'env>(
 		minimizer:     options.minimizer.map(Into::into),
 	};
 	task::future(env, "shell.execute", async move {
-		let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
+		let (chunk_tx, drain_handle) = bridge_chunks(on_chunk, stream_output_max_bytes);
 		let result = core_execute_shell(exec_options, chunk_tx, cancel_token.into_core())
 			.await
 			.map(Into::into)
@@ -292,11 +300,18 @@ pub fn execute_shell<'env>(
 
 fn bridge_chunks(
 	on_chunk: Option<ThreadsafeFunction<String>>,
-) -> (Option<flume::Sender<String>>, Option<napi::tokio::task::JoinHandle<()>>) {
+	stream_output_max_bytes: Option<usize>,
+) -> (Option<OutputSender>, Option<napi::tokio::task::JoinHandle<()>>) {
 	let Some(on_chunk) = on_chunk else {
 		return (None, None);
 	};
-	let (tx, rx) = flume::unbounded::<String>();
+	const MAX_PENDING_CHUNKS: usize = 8;
+	let (tx, rx) = flume::bounded::<String>(MAX_PENDING_CHUNKS);
+	let limiter = stream_output_max_bytes.map(|max_bytes| Arc::new(OutputLimiter::new(max_bytes)));
+	let chunk_tx = limiter.as_ref().map_or_else(
+		|| OutputSender::unbounded(tx.clone()),
+		|limiter| OutputSender::capped(tx.clone(), limiter.clone()),
+	);
 	let handle = napi::tokio::spawn(async move {
 		// Hard cap on one coalesced batch so the JS main thread never sees a
 		// multi-MB napi callback (a giant single string would stall sanitize +
@@ -322,8 +337,19 @@ fn bridge_chunks(
 			let payload = std::mem::replace(&mut batch, String::with_capacity(INITIAL_BATCH_CAP));
 			on_chunk.call(Ok(payload), ThreadsafeFunctionCallMode::NonBlocking);
 		}
+		if let Some(limiter) = limiter {
+			let dropped = limiter.dropped_bytes();
+			if dropped > 0 {
+				let forwarded = limiter.forwarded_bytes();
+				let notice = format!(
+					"\n[output truncated: native bash stream forwarded {forwarded} bytes and discarded \
+					 {dropped} bytes before the JS callback]\n",
+				);
+				on_chunk.call(Ok(notice), ThreadsafeFunctionCallMode::NonBlocking);
+			}
+		}
 	});
-	(Some(tx), Some(handle))
+	(Some(chunk_tx), Some(handle))
 }
 
 /// Result of [`apply_bash_fixups`]: a possibly-rewritten command plus the
@@ -359,7 +385,7 @@ mod tests {
 	#[cfg(unix)]
 	use flume;
 	use pi_shell::{
-		ShellRunOptions as CoreShellRunOptions,
+		OutputSender, ShellRunOptions as CoreShellRunOptions,
 		cancel::{AbortReason, CancelToken},
 	};
 	use tokio::time;
@@ -421,7 +447,7 @@ mod tests {
 						env:        None,
 						timeout_ms: None,
 					},
-					Some(tx),
+					Some(OutputSender::unbounded(tx)),
 					CancelToken::default(),
 				)
 				.await

--- a/crates/pi-shell/src/lib.rs
+++ b/crates/pi-shell/src/lib.rs
@@ -10,6 +10,7 @@ pub mod windows;
 
 pub use brush_core::commands::{ChildSessionAction, child_session_action};
 pub use shell::{
-	MinimizerResult, Shell, ShellExecuteOptions, ShellExecuteResult, ShellOptions, ShellRunOptions,
-	ShellRunResult, StreamSinks, execute_shell, execute_shell_streams,
+	MinimizerResult, OutputLimiter, OutputSender, Shell, ShellExecuteOptions, ShellExecuteResult,
+	ShellOptions, ShellRunOptions, ShellRunResult, StreamSinks, execute_shell,
+	execute_shell_streams,
 };

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -7,7 +7,7 @@ use std::{
 	fs,
 	io::{self, Write},
 	str,
-	sync::Arc,
+	sync::{Arc, Mutex},
 	time::Duration,
 };
 
@@ -22,7 +22,7 @@ use brush_core::{
 };
 use bytes::Bytes;
 use clap::Parser;
-use flume::Sender;
+use flume::{Sender, TrySendError};
 #[cfg(not(unix))]
 use tokio::io::AsyncReadExt as _;
 use tokio::{sync::Mutex as TokioMutex, time};
@@ -117,6 +117,132 @@ pub struct ShellExecuteOptions {
 }
 
 pub type ShellExecuteResult = ShellRunResult;
+/// Shared byte budget for streamed shell output before it crosses into a host
+/// callback.
+#[derive(Debug)]
+pub struct OutputLimiter {
+	max_bytes: usize,
+	state:     Mutex<OutputLimiterState>,
+}
+
+#[derive(Debug, Default)]
+struct OutputLimiterState {
+	forwarded_bytes: usize,
+	dropped_bytes:   usize,
+	closed:          bool,
+}
+
+impl OutputLimiter {
+	/// Create a stream limiter that forwards at most `max_bytes` before
+	/// dropping.
+	#[must_use]
+	pub fn new(max_bytes: usize) -> Self {
+		Self { max_bytes, state: Mutex::new(OutputLimiterState::default()) }
+	}
+
+	/// Bytes accepted into the downstream callback queue.
+	#[must_use]
+	pub fn forwarded_bytes(&self) -> usize {
+		self
+			.state
+			.lock()
+			.expect("output limiter mutex poisoned")
+			.forwarded_bytes
+	}
+
+	/// Bytes discarded after the stream cap or callback queue limit was reached.
+	#[must_use]
+	pub fn dropped_bytes(&self) -> usize {
+		self
+			.state
+			.lock()
+			.expect("output limiter mutex poisoned")
+			.dropped_bytes
+	}
+
+	fn emit(&self, text: &str, sender: &Sender<String>) {
+		if text.is_empty() {
+			return;
+		}
+		let mut state = self.state.lock().expect("output limiter mutex poisoned");
+		if state.closed {
+			state.dropped_bytes = state.dropped_bytes.saturating_add(text.len());
+			return;
+		}
+		let room = self.max_bytes.saturating_sub(state.forwarded_bytes);
+		if room == 0 {
+			state.closed = true;
+			state.dropped_bytes = state.dropped_bytes.saturating_add(text.len());
+			return;
+		}
+		let send_len = utf8_prefix_len(text, room);
+		let dropped_after_prefix = text.len().saturating_sub(send_len);
+		if send_len == 0 {
+			state.closed = true;
+			state.dropped_bytes = state.dropped_bytes.saturating_add(text.len());
+			return;
+		}
+		let payload = text[..send_len].to_string();
+		match sender.try_send(payload) {
+			Ok(()) => {
+				state.forwarded_bytes = state.forwarded_bytes.saturating_add(send_len);
+				state.dropped_bytes = state.dropped_bytes.saturating_add(dropped_after_prefix);
+				if dropped_after_prefix > 0 || state.forwarded_bytes >= self.max_bytes {
+					state.closed = true;
+				}
+			},
+			Err(TrySendError::Full(payload) | TrySendError::Disconnected(payload)) => {
+				state.closed = true;
+				state.dropped_bytes = state
+					.dropped_bytes
+					.saturating_add(payload.len())
+					.saturating_add(dropped_after_prefix);
+			},
+		}
+	}
+}
+
+/// Non-blocking stream handle used by pipe readers to drain output without
+/// unbounded queues.
+#[derive(Clone)]
+pub struct OutputSender {
+	sender:  Sender<String>,
+	limiter: Option<Arc<OutputLimiter>>,
+}
+
+impl OutputSender {
+	/// Wrap an existing channel without a byte cap; sends are still
+	/// non-blocking.
+	#[must_use]
+	pub const fn unbounded(sender: Sender<String>) -> Self {
+		Self { sender, limiter: None }
+	}
+
+	/// Wrap an existing channel with a shared byte cap and drop accounting.
+	#[must_use]
+	pub const fn capped(sender: Sender<String>, limiter: Arc<OutputLimiter>) -> Self {
+		Self { sender, limiter: Some(limiter) }
+	}
+
+	fn send(&self, text: &str) {
+		if let Some(limiter) = self.limiter.as_ref() {
+			limiter.emit(text, &self.sender);
+		} else {
+			let _ = self.sender.try_send(text.to_string());
+		}
+	}
+}
+
+const fn utf8_prefix_len(text: &str, max_bytes: usize) -> usize {
+	if text.len() <= max_bytes {
+		return text.len();
+	}
+	let mut end = max_bytes;
+	while end > 0 && !text.is_char_boundary(end) {
+		end -= 1;
+	}
+	end
+}
 
 pub struct Shell {
 	session:     Arc<TokioMutex<Option<ShellSessionCore>>>,
@@ -151,7 +277,7 @@ impl Shell {
 	pub async fn run(
 		&self,
 		options: ShellRunOptions,
-		on_chunk: Option<Sender<String>>,
+		on_chunk: Option<OutputSender>,
 		mut cancel_token: CancelToken,
 	) -> Result<ShellRunResult> {
 		let run_config = ShellRunConfig {
@@ -207,7 +333,7 @@ impl Shell {
 
 pub async fn execute_shell(
 	options: ShellExecuteOptions,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	cancel_token: CancelToken,
 ) -> Result<ShellExecuteResult> {
 	let minimizer = options
@@ -265,7 +391,7 @@ async fn run_shell_session(
 	abort_state: ShellAbortState,
 	config: ShellConfig,
 	run_config: ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	ct: &mut CancelToken,
 ) -> Result<ShellRunResult> {
 	let tokio_cancel = CancellationToken::new();
@@ -351,7 +477,7 @@ async fn run_shell_session(
 async fn run_shell_oneshot(
 	config: ShellConfig,
 	run_config: ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	ct: CancelToken,
 ) -> Result<ShellExecuteResult> {
 	let tokio_cancel = CancellationToken::new();
@@ -757,7 +883,7 @@ impl ChainCapture {
 async fn run_shell_command(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 ) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
@@ -808,7 +934,7 @@ async fn run_shell_command(
 async fn run_shell_command_single(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 	minimizer_mode: minimizer::engine::MinimizerMode,
@@ -891,7 +1017,7 @@ async fn run_shell_command_single(
 async fn run_shell_command_segmented_chain(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 ) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
@@ -1033,7 +1159,7 @@ async fn run_shell_command_once(
 	session: &mut ShellSessionCore,
 	mut command: String,
 	mut params: ExecutionParameters,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 	capture_mode: CommandCaptureMode,
@@ -1562,7 +1688,7 @@ struct BufferedOutput {
 
 async fn read_output(
 	reader: fs::File,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	cancel_token: CancellationToken,
 	activity: Sender<()>,
 ) {
@@ -1670,7 +1796,7 @@ async fn read_output(
 
 async fn read_output_buffered(
 	reader: fs::File,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputSender>,
 	cancel_token: CancellationToken,
 	activity: Sender<()>,
 	max_capture_bytes: usize,
@@ -1830,9 +1956,9 @@ fn read_nonblocking<T: std::os::fd::AsRawFd>(file: &T, buf: &mut [u8]) -> io::Re
 	}
 }
 
-fn emit_chunk(text: &str, callback: Option<&Sender<String>>) {
+fn emit_chunk(text: &str, callback: Option<&OutputSender>) {
 	if let Some(callback) = callback {
-		let _ = callback.send(text.to_string());
+		callback.send(text);
 	}
 }
 
@@ -2985,7 +3111,7 @@ mod tests {
 			minimizer,
 			..Default::default()
 		};
-		let result = execute_shell(options, Some(tx), cancel_token)
+		let result = execute_shell(options, Some(OutputSender::unbounded(tx)), cancel_token)
 			.await
 			.expect("execute_shell");
 		let mut output = String::new();
@@ -3484,7 +3610,7 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 						command: "/bin/sh -c 'printf \"ready\\n\"; sleep 30'".into(),
 						..Default::default()
 					},
-					Some(tx_b),
+					Some(OutputSender::unbounded(tx_b)),
 					ct_b,
 				)
 				.await
@@ -3516,7 +3642,7 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 						command: "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 2'".into(),
 						..Default::default()
 					},
-					Some(tx_a),
+					Some(OutputSender::unbounded(tx_a)),
 					CancelToken::default(),
 				)
 				.await
@@ -3864,6 +3990,96 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 
 	#[cfg(unix)]
 	#[tokio::test(flavor = "multi_thread")]
+	async fn read_output_drops_after_stream_limit_without_blocking_pipe_drain() {
+		const LIMIT: usize = 1024;
+		const BYTES: usize = 128 * 1024;
+		let (reader, mut writer) = pipe_to_files("test").expect("test pipe should be created");
+		let (chunk_tx, chunk_rx) = flume::bounded(1);
+		let limiter = Arc::new(OutputLimiter::new(LIMIT));
+		let sender = OutputSender::capped(chunk_tx, limiter.clone());
+		let (activity_tx, _activity_rx) = flume::bounded(1);
+		let handle =
+			tokio::spawn(read_output(reader, Some(sender), CancellationToken::new(), activity_tx));
+		let writer_handle = std::thread::spawn(move || {
+			let data = vec![b'x'; BYTES];
+			writer.write_all(&data).expect("write test output");
+		});
+
+		writer_handle.join().expect("writer should not panic");
+		time::timeout(Duration::from_millis(500), handle)
+			.await
+			.expect("reader should drain capped stream")
+			.expect("reader task should not panic");
+
+		assert!(limiter.forwarded_bytes() <= LIMIT);
+		assert!(limiter.dropped_bytes() > 0);
+		assert!(chunk_rx.len() <= 1);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn read_output_buffered_drops_stream_after_limit_while_capturing() {
+		const LIMIT: usize = 1024;
+		const BYTES: usize = 128 * 1024;
+		let (reader, mut writer) = pipe_to_files("test").expect("test pipe should be created");
+		let (chunk_tx, chunk_rx) = flume::bounded(1);
+		let limiter = Arc::new(OutputLimiter::new(LIMIT));
+		let sender = OutputSender::capped(chunk_tx, limiter.clone());
+		let (activity_tx, _activity_rx) = flume::bounded(1);
+		let writer_handle = std::thread::spawn(move || {
+			let data = vec![b'y'; BYTES];
+			writer.write_all(&data).expect("write test output");
+		});
+
+		let output = time::timeout(
+			Duration::from_millis(500),
+			read_output_buffered(
+				reader,
+				Some(sender),
+				CancellationToken::new(),
+				activity_tx,
+				BYTES * 2,
+			),
+		)
+		.await
+		.expect("buffered reader should drain capped stream");
+		writer_handle.join().expect("writer should not panic");
+
+		assert_eq!(output.input_bytes, BYTES);
+		assert!(!output.exceeded);
+		assert!(limiter.forwarded_bytes() <= LIMIT);
+		assert!(limiter.dropped_bytes() > 0);
+		assert!(chunk_rx.len() <= 1);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn execute_shell_finishes_fast_producer_when_stream_queue_is_full() {
+		const LIMIT: usize = 1024;
+		let (chunk_tx, chunk_rx) = flume::bounded(1);
+		let limiter = Arc::new(OutputLimiter::new(LIMIT));
+		let sender = OutputSender::capped(chunk_tx, limiter.clone());
+		let options = ShellExecuteOptions {
+			command: "/bin/sh -c 'yes x | head -c 1048576'".to_string(),
+			..Default::default()
+		};
+
+		let result = time::timeout(
+			Duration::from_secs(5),
+			execute_shell(options, Some(sender), CancelToken::default()),
+		)
+		.await
+		.expect("fast producer should not block on a full callback queue")
+		.expect("execute should succeed");
+
+		assert_eq!(result.exit_code, Some(0));
+		assert!(limiter.forwarded_bytes() <= LIMIT);
+		assert!(limiter.dropped_bytes() > 0);
+		assert!(chunk_rx.len() <= 1);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
 	async fn execute_shell_streams_separates_stdout_and_stderr() {
 		let (stdout_tx, stdout_rx) = flume::unbounded::<Bytes>();
 		let (stderr_tx, stderr_rx) = flume::unbounded::<Bytes>();
@@ -4031,9 +4247,10 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 				.to_string(),
 			..Default::default()
 		};
-		let result = execute_shell(options, Some(tx), CancelToken::default())
-			.await
-			.expect("execute should succeed");
+		let result =
+			execute_shell(options, Some(OutputSender::unbounded(tx)), CancelToken::default())
+				.await
+				.expect("execute should succeed");
 		assert_eq!(result.exit_code, Some(0));
 		assert!(!result.cancelled);
 		assert!(!result.timed_out);
@@ -4055,9 +4272,10 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 	async fn nohup_builtin_without_command_reports_missing_operand() {
 		let (tx, rx) = flume::unbounded::<String>();
 		let options = ShellExecuteOptions { command: "nohup".to_string(), ..Default::default() };
-		let result = execute_shell(options, Some(tx), CancelToken::default())
-			.await
-			.expect("execute should succeed");
+		let result =
+			execute_shell(options, Some(OutputSender::unbounded(tx)), CancelToken::default())
+				.await
+				.expect("execute should succeed");
 		assert_eq!(result.exit_code, Some(125));
 		let mut out = String::new();
 		while let Ok(chunk) = rx.recv_async().await {
@@ -4099,9 +4317,10 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			command: format!("nohup python3 -c \"{probe}\""),
 			..Default::default()
 		};
-		let result = execute_shell(options, Some(tx), CancelToken::default())
-			.await
-			.expect("execute should succeed");
+		let result =
+			execute_shell(options, Some(OutputSender::unbounded(tx)), CancelToken::default())
+				.await
+				.expect("execute should succeed");
 		assert_eq!(result.exit_code, Some(0));
 		let mut out = String::new();
 		while let Ok(chunk) = rx.recv_async().await {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed non-PTY bash execution to pass the output sink budget into the native shell bridge so fast producers cannot grow the Rust→JS queue without bound ([#4026](https://github.com/can1357/oh-my-pi/issues/4026)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -8,7 +8,7 @@ import { ExponentialYield } from "@oh-my-pi/pi-agent-core/utils/yield";
 import { executeShell, type MinimizerOptions, Shell, type ShellRunResult } from "@oh-my-pi/pi-natives";
 import { isExecutable, type ShellConfig } from "@oh-my-pi/pi-utils/procmgr";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
-import { OutputSink } from "../session/streaming-output";
+import { DEFAULT_MAX_BYTES, OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
 import { buildNonInteractiveEnv } from "./non-interactive-env";
@@ -230,11 +230,13 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			: prefixedCommand;
 
 	// Create output sink for truncation and artifact handling
+	const outputHeadBytes = resolveOutputSinkHeadBytes(settings);
+	const nativeStreamOutputMaxBytes = Math.min(DEFAULT_MAX_BYTES + outputHeadBytes, 0xffffffff);
 	const sink = new OutputSink({
 		onChunk: options?.onChunk,
 		artifactPath: options?.artifactPath,
 		artifactId: options?.artifactId,
-		headBytes: resolveOutputSinkHeadBytes(settings),
+		headBytes: outputHeadBytes,
 		maxColumns: resolveOutputMaxColumns(settings),
 		chunkThrottleMs: options?.onChunk ? (options.chunkThrottleMs ?? 50) : 0,
 	});
@@ -319,6 +321,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 						env: commandEnv,
 						timeoutMs: options?.timeout,
 						signal: runAbortController.signal,
+						streamOutputMaxBytes: nativeStreamOutputMaxBytes,
 					},
 					(err, chunk) => {
 						if (!err) {
@@ -336,6 +339,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 						minimizer,
 						timeoutMs: options?.timeout,
 						signal: runAbortController.signal,
+						streamOutputMaxBytes: nativeStreamOutputMaxBytes,
 					},
 					(err, chunk) => {
 						if (!err) {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native shell streaming to bound Rust→JS output queues and drop after the caller's stream budget while continuing to drain child pipes ([#4026](https://github.com/can1357/oh-my-pi/issues/4026)).
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -1394,6 +1394,11 @@ export interface ShellExecuteOptions {
   snapshotPath?: string
   /** Optional per-command output minimizer configuration. */
   minimizer?: MinimizerOptions
+  /**
+   * Maximum UTF-8 bytes forwarded to `onChunk` before native output is
+   * dropped.
+   */
+  streamOutputMaxBytes?: number
   /** Abort signal for cancelling the operation. */
   signal?: unknown
 }
@@ -1418,6 +1423,11 @@ export interface ShellRunOptions {
   env?: Record<string, string>
   /** Timeout in milliseconds before cancelling the command. */
   timeoutMs?: number
+  /**
+   * Maximum UTF-8 bytes forwarded to `onChunk` before native output is
+   * dropped.
+   */
+  streamOutputMaxBytes?: number
   /** Abort signal for cancelling the operation. */
   signal?: unknown
 }


### PR DESCRIPTION
## Repro
The source repro confirmed the non-PTY bash path used `flume::unbounded::<String>()`, forwarded batches with `ThreadsafeFunctionCallMode::NonBlocking`, and only applied `OutputSink` caps after the native callback delivered chunks.

## Cause
`crates/pi-natives/src/shell.rs` built an unbounded Rust→JS chunk bridge, while `crates/pi-shell/src/shell.rs` emitted every decoded stdout/stderr segment through a plain `flume::Sender<String>`. `packages/coding-agent/src/exec/bash-executor.ts` created the `OutputSink` downstream, so fast producers could fill native/JS queues before the sink could truncate.

## Fix
- Added `OutputLimiter`/`OutputSender` in `pi-shell` so pipe readers use non-blocking sends, enforce a shared byte cap, and keep draining child pipes after drops.
- Switched the N-API shell bridge to a bounded channel, surfaced native drop accounting as a final truncation notice, and exposed `streamOutputMaxBytes` on shell run/execute options.
- Passed the bash output sink budget from non-PTY bash execution into the native shell bridge.
- Added Rust regression coverage for streaming, buffered, and fast-producer command paths.

## Verification
`cargo test -p pi-shell stream_limit`; `cargo test -p pi-shell drops_stream_after_limit`; `cargo test -p pi-shell fast_producer`; `cargo test -p pi-natives shell::`; `bun run build` in `packages/natives`; `bun run check` in `packages/natives`; `bun run check` in `packages/coding-agent`; `bun check`. Fixes #4026