### PR TITLE
fix(tui): bounded stdin escape parsing and non-ESC fast path

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed terminal input parsing blocking the event loop on hostile or malformed escape sequences and non-bracketed pastes. `StdinBuffer.extractCompleteSequences` now scans escape sequences with index-based `charCodeAt` walks (no grow-a-substring quadratic) and caps each sequence at 64 KiB before flushing the prefix as raw bytes, so an unterminated CSI/OSC/DCS/APC can no longer stall input in a single `process()` call. `BracketedPasteHandler` gained a configurable byte cap (default 64 MiB, matching `StdinBuffer.PASTE_MAX_BYTES`) that delivers the buffered payload as a completed paste when the end marker never arrives, matching `StdinBuffer`'s paste recovery as defense in depth for alternate callers. The `ProcessTerminal` stdin data handler now fast-paths plain non-ESC bytes past its six escape-probe regex checks when no reassembly buffer is in flight, cutting per-event CPU on large non-bracketed pastes ([#4022](https://github.com/can1357/oh-my-pi/issues/4022)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Fixed

--- a/packages/tui/src/bracketed-paste.ts
+++ b/packages/tui/src/bracketed-paste.ts
@@ -41,15 +41,45 @@ export function decodeReencodedPasteControls(text: string): string {
 }
 
 /**
+ * Options for {@link BracketedPasteHandler}.
+ */
+export type BracketedPasteHandlerOptions = {
+	/**
+	 * Maximum bytes to accumulate before assuming the end marker was lost and
+	 * force-delivering the buffered payload as a completed paste. Defaults to
+	 * 64 MiB — matches `StdinBuffer`'s paste cap and is well above any
+	 * realistic clipboard payload while still bounding memory if an alternate
+	 * caller (i.e. one that bypasses `StdinBuffer`, which already re-wraps
+	 * paste bodies with both markers) hands a start marker without an end.
+	 */
+	byteLimit?: number;
+};
+
+// Default byte cap, aligned with `StdinBuffer.PASTE_MAX_BYTES`. Defense in
+// depth for alternate callers of `handleInput` / `BracketedPasteHandler.process`
+// that don't go through the normal `StdinBuffer` → re-wrap path (issue #4022).
+const DEFAULT_PASTE_BYTE_LIMIT = 64 * 1024 * 1024;
+
+/**
  * Handles bracketed paste mode buffering for terminal input components.
  *
  * Bracketed paste mode wraps pasted content between start (\x1b[200~) and
  * end (\x1b[201~) markers, which may arrive split across multiple chunks.
  * This class buffers incoming data and assembles complete paste payloads.
+ *
+ * If more than `byteLimit` bytes arrive without an end marker (dropped in
+ * transit, or the caller synthesized a start with no matching end), the
+ * accumulated bytes are delivered as a completed paste so input recovers
+ * instead of the buffer growing without bound.
  */
 export class BracketedPasteHandler {
 	#buffer = "";
 	#active = false;
+	readonly #byteLimit: number;
+
+	constructor(options: BracketedPasteHandlerOptions = {}) {
+		this.#byteLimit = options.byteLimit ?? DEFAULT_PASTE_BYTE_LIMIT;
+	}
 
 	/**
 	 * Process incoming terminal data for bracketed paste sequences.
@@ -57,7 +87,8 @@ export class BracketedPasteHandler {
 	 * @returns `{ handled: false }` if the data contains no paste sequence and
 	 *          should be processed normally. `{ handled: true }` if the data was
 	 *          consumed by paste buffering — `pasteContent` is set when a complete
-	 *          paste has been assembled; omitted when still buffering.
+	 *          paste has been assembled (either the end marker arrived or the
+	 *          byte cap was exceeded); omitted when still buffering.
 	 */
 	process(data: string): PasteResult {
 		if (data.includes(PASTE_START)) {
@@ -71,7 +102,18 @@ export class BracketedPasteHandler {
 		this.#buffer += data;
 
 		const endIndex = this.#buffer.indexOf(PASTE_END);
-		if (endIndex === -1) return { handled: true, remaining: "" };
+		if (endIndex === -1) {
+			if (this.#buffer.length > this.#byteLimit) {
+				// End marker never arrived and the buffer has grown past the
+				// cap. Deliver what we've collected as a completed paste and
+				// reset so subsequent input is not accumulated forever.
+				const pasteContent = this.#buffer;
+				this.#buffer = "";
+				this.#active = false;
+				return { handled: true, pasteContent, remaining: "" };
+			}
+			return { handled: true, remaining: "" };
+		}
 
 		const pasteContent = this.#buffer.substring(0, endIndex);
 		const remaining = this.#buffer.substring(endIndex + PASTE_END.length);

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -43,261 +43,210 @@ const SGR_MOUSE_PARTIAL = /^\x1b\[<[\d;]*$/;
 // completes (e.g. a bare ESC delivered while the kitty-active flag is
 // stale); keep it small.
 const PARTIAL_HOLD_MAX_MS = 150;
-/**
- * Check if a string is a complete escape sequence or needs more data
- */
-function isCompleteSequence(data: string): "complete" | "incomplete" | "not-escape" {
-	if (!data.startsWith(ESC)) {
-		return "not-escape";
-	}
+// Cap the length of a single escape sequence we hold in the buffer before
+// force-flushing it as raw bytes. A malformed or unterminated CSI/OSC/DCS/APC
+// (e.g. `\x1b[` followed by megabytes of parameter bytes with no final byte)
+// would otherwise let a single `process()` call block the event loop while it
+// re-scans the growing partial. 64 KiB is well above every legitimate escape
+// sequence we handle (kitty graphics APCs are chunked below this, OSC/DCS
+// responses to our probes are ≪ 1 KiB) but small enough that the linear scan
+// completes in under a millisecond even on a runaway sequence. Recovery is
+// intentionally coarse: the capped prefix is emitted as one sequence so
+// downstream parsers see something they will either handle or ignore, and the
+// tail resyncs as ordinary input.
+const MAX_ESCAPE_LENGTH = 64 * 1024;
 
-	if (data.length === 1) {
-		return "incomplete";
-	}
-
-	const afterEsc = data.slice(1);
-
-	// CSI sequences: ESC [
-	if (afterEsc.startsWith("[")) {
-		// Check for old-style mouse sequence: ESC[M + 3 bytes
-		if (afterEsc.startsWith("[M")) {
-			// Old-style mouse needs ESC[M + 3 bytes = 6 total
-			return data.length >= 6 ? "complete" : "incomplete";
-		}
-		return isCompleteCsiSequence(data);
-	}
-
-	// OSC sequences: ESC ]
-	if (afterEsc.startsWith("]")) {
-		return isCompleteOscSequence(data);
-	}
-
-	// DCS sequences: ESC P ... ESC \ (includes XTVersion responses)
-	if (afterEsc.startsWith("P")) {
-		return isCompleteDcsSequence(data);
-	}
-
-	// APC sequences: ESC _ ... ESC \ (includes Kitty graphics responses)
-	if (afterEsc.startsWith("_")) {
-		return isCompleteApcSequence(data);
-	}
-
-	// SS3 sequences: ESC O
-	if (afterEsc.startsWith("O")) {
-		// ESC O followed by a single character
-		return afterEsc.length >= 2 ? "complete" : "incomplete";
-	}
-
-	// ESC-prefixed sequences (terminals with metaSendsEscape):
-	// Only when the inner ESC starts a CSI ('[') or SS3 ('O') sequence.
-	// Bare double-ESC (e.g. \x1b\x1bX) remains complete to avoid 10ms timeout lag.
-	if (afterEsc.startsWith(ESC)) {
-		const inner = data.slice(1);
-		const third = inner.charCodeAt(1);
-		if (third === 0x5b || third === 0x4f) {
-			return isCompleteSequence(inner);
-		}
-		return "complete";
-	}
-
-	// Meta key sequences: ESC followed by a single character
-	if (afterEsc.length === 1) {
-		return "complete";
-	}
-
-	// Unknown escape sequence - treat as complete
-	return "complete";
-}
+// Validate an SGR mouse payload. Kept outside `scanEscape` so V8 caches the
+// compiled regex once per module load instead of once per candidate byte.
+const SGR_MOUSE_COMPLETE = /^<\d+;\d+;\d+[Mm]$/;
 
 /**
- * Check if CSI sequence is complete
- * CSI sequences: ESC [ ... followed by a final byte (0x40-0x7E)
+ * Scan a single escape sequence starting at `buffer[start]` (which must be
+ * ESC). Returns the exclusive end index of the completed sequence, `-1` if the
+ * sequence is incomplete (the caller holds the partial for more data), or
+ * `-2` when the sequence has already exceeded {@link MAX_ESCAPE_LENGTH} bytes
+ * and the caller must force-flush the prefix.
+ *
+ * Index-based on purpose: growing a substring per byte and re-parsing it made
+ * the prior implementation quadratic on malformed input (`\x1b[<1;1;…` at 4 MB
+ * blocked the event loop for ~700 ms). Every branch here scans `charCodeAt`
+ * indexes without slicing, so cost stays proportional to the escape's length
+ * even for pathological input; the cap bounds how much of a single runaway
+ * sequence we retain before delivering it and resyncing.
  */
-function isCompleteCsiSequence(data: string): "complete" | "incomplete" {
-	if (!data.startsWith(`${ESC}[`)) {
-		return "complete";
+function scanEscape(buffer: string, start: number): number {
+	const length = buffer.length;
+	if (start + 1 >= length) return -1;
+	const second = buffer.charCodeAt(start + 1);
+
+	// CSI: ESC [
+	if (second === 0x5b) {
+		// Old-style X10 mouse: ESC [ M + 3 bytes. Only claim it once the third
+		// byte is present; otherwise `\x1b[M` alone would be mis-parsed as a
+		// complete CSI whose final byte happens to be `M`.
+		if (start + 2 < length && buffer.charCodeAt(start + 2) === 0x4d /* M */) {
+			return start + 6 <= length ? start + 6 : -1;
+		}
+		const isSgr = start + 2 < length && buffer.charCodeAt(start + 2) === 0x3c /* < */;
+		const scanEnd = Math.min(length, start + MAX_ESCAPE_LENGTH);
+		for (let i = start + 2; i < scanEnd; i++) {
+			const c = buffer.charCodeAt(i);
+			if (c < 0x40 || c > 0x7e) continue;
+			if (!isSgr) return i + 1;
+			// SGR mouse validation: the final byte must be `M`/`m` and the
+			// payload must be `<digits;digits;digits`. A CSI-final byte that
+			// isn't `M`/`m` (or a structurally invalid `M`/`m` payload) keeps
+			// the scan going — matching the prior `"incomplete"` return so
+			// callers hold the partial for the mouse tail.
+			if (c !== 0x4d && c !== 0x6d) continue;
+			const payload = buffer.slice(start + 2, i + 1);
+			if (SGR_MOUSE_COMPLETE.test(payload)) return i + 1;
+		}
+		return scanEnd < length ? -2 : -1;
 	}
 
-	// Need at least ESC [ and one more character
-	if (data.length < 3) {
-		return "incomplete";
-	}
-
-	const payload = data.slice(2);
-
-	// CSI sequences end with a byte in the range 0x40-0x7E (@-~)
-	// This includes all letters and several special characters
-	const lastChar = payload[payload.length - 1];
-	const lastCharCode = lastChar.charCodeAt(0);
-
-	if (lastCharCode >= 0x40 && lastCharCode <= 0x7e) {
-		// Special handling for SGR mouse sequences
-		// Format: ESC[<B;X;Ym or ESC[<B;X;YM
-		if (payload.startsWith("<")) {
-			// Must have format: <digits;digits;digits[Mm]
-			const mouseMatch = /^<\d+;\d+;\d+[Mm]$/.test(payload);
-			if (mouseMatch) {
-				return "complete";
+	// OSC: ESC ] ... ST (ESC \) | BEL
+	if (second === 0x5d) {
+		const scanEnd = Math.min(length, start + MAX_ESCAPE_LENGTH);
+		for (let i = start + 2; i < scanEnd; i++) {
+			const c = buffer.charCodeAt(i);
+			if (c === 0x07 /* BEL */) return i + 1;
+			if (c === 0x1b /* ESC */ && i + 1 < scanEnd && buffer.charCodeAt(i + 1) === 0x5c /* \ */) {
+				return i + 2;
 			}
-			// If it ends with M or m but doesn't match the pattern, still incomplete
-			if (lastChar === "M" || lastChar === "m") {
-				// Check if we have the right structure
-				const parts = payload.slice(1, -1).split(";");
-				if (parts.length === 3 && parts.every(p => /^\d+$/.test(p))) {
-					return "complete";
-				}
-			}
+		}
+		return scanEnd < length ? -2 : -1;
+	}
 
-			return "incomplete";
+	// DCS: ESC P ... ST (ESC \)
+	// APC: ESC _ ... ST (ESC \)
+	if (second === 0x50 || second === 0x5f) {
+		const scanEnd = Math.min(length, start + MAX_ESCAPE_LENGTH);
+		for (let i = start + 2; i < scanEnd; i++) {
+			if (buffer.charCodeAt(i) === 0x1b && i + 1 < scanEnd && buffer.charCodeAt(i + 1) === 0x5c /* \ */) {
+				return i + 2;
+			}
+		}
+		return scanEnd < length ? -2 : -1;
+	}
+
+	// SS3: ESC O + one char
+	if (second === 0x4f) {
+		return start + 3 <= length ? start + 3 : -1;
+	}
+
+	// Any other ESC-prefixed byte is a meta chord — one payload char.
+	return start + 2;
+}
+
+/**
+ * Split the accumulated buffer into complete sequences, returning the tail
+ * (an incomplete escape) as `remainder` for the next `process()` call to
+ * concatenate more input onto.
+ *
+ * The plain-text path pushes one Unicode scalar per iteration by design —
+ * components rely on single-event delivery for `matchesKey`/`isKeyRelease`
+ * (see `terminal.ts:654-656`). The escape path delegates one sequence at a
+ * time to {@link scanEscape}, keeping the whole hot path index-based (no
+ * grow-a-substring quadratic).
+ */
+function extractCompleteSequences(buffer: string): { sequences: string[]; remainder: string } {
+	const sequences: string[] = [];
+	const length = buffer.length;
+	let pos = 0;
+
+	while (pos < length) {
+		if (buffer.charCodeAt(pos) !== 0x1b) {
+			// Not an escape sequence - take one Unicode scalar, not a UTF-16 code unit.
+			const codePoint = buffer.codePointAt(pos)!;
+			const charLength = codePoint > 0xffff ? 2 : 1;
+			sequences.push(buffer.slice(pos, pos + charLength));
+			pos += charLength;
+			continue;
 		}
 
-		return "complete";
+		// ESC at pos. Handle the `\x1b\x1b…` disambiguation the old
+		// grow-a-substring loop encoded, then fall through to the normal
+		// single-ESC scanner for the common case.
+		if (pos + 1 >= length) {
+			return { sequences, remainder: buffer.slice(pos) };
+		}
+		const second = buffer.charCodeAt(pos + 1);
+
+		if (second === 0x1b) {
+			// `\x1b\x1b` is one of three things:
+			//   1. ESC prefixing CSI/SS3 (meta-CSI, or a held Esc joined to a
+			//      follower): third byte is `[` or `O` — treat the whole
+			//      `\x1b\x1b[<…>` / `\x1b\x1bO<…>` as one sequence so the
+			//      follower is not torn off and leaked as typed text.
+			//   2. ESC followed by a legacy Alt chord (`\x1bd`, `\x1b\x7f`, …):
+			//      emit the first ESC alone, then restart at the second ESC so
+			//      downstream parsing still sees the Alt chord as one keypress
+			//      (#3860 review).
+			//   3. Two real Esc keypresses bursted by terminal batching: when
+			//      the buffer ends here, hold for the flush window so case 1/2
+			//      can still arrive; if no follower does, `flush()` splits the
+			//      held remainder into two ESC events (#3857).
+			if (pos + 2 >= length) {
+				return { sequences, remainder: buffer.slice(pos) };
+			}
+			const third = buffer.charCodeAt(pos + 2);
+			if (third !== 0x5b /* [ */ && third !== 0x4f /* O */) {
+				sequences.push(ESC);
+				pos += 1;
+				continue;
+			}
+			const inner = scanEscape(buffer, pos + 1);
+			if (inner === -1) {
+				return { sequences, remainder: buffer.slice(pos) };
+			}
+			if (inner === -2) {
+				// Cap exceeded on the inner sequence — force-flush the leading
+				// ESC together with the capped inner chunk so downstream sees
+				// one delimited raw sequence and resyncs.
+				const stop = pos + 1 + MAX_ESCAPE_LENGTH;
+				sequences.push(buffer.slice(pos, stop));
+				pos = stop;
+				continue;
+			}
+			// ESC + SGR mouse report is never a meta chord: alt-modified mouse
+			// reports carry the modifier in the button bits, not an ESC prefix.
+			// Deliver the bare ESC (a real Esc keypress) and the report separately.
+			if (third === 0x5b && pos + 3 < length && buffer.charCodeAt(pos + 3) === 0x3c /* < */) {
+				sequences.push(ESC, buffer.slice(pos + 1, inner));
+				pos = inner;
+				continue;
+			}
+			sequences.push(buffer.slice(pos, inner));
+			pos = inner;
+			continue;
+		}
+
+		const end = scanEscape(buffer, pos);
+		if (end === -1) {
+			return { sequences, remainder: buffer.slice(pos) };
+		}
+		if (end === -2) {
+			// Cap exceeded — force-flush the capped prefix as one sequence and
+			// resync at the byte after the cap.
+			const stop = pos + MAX_ESCAPE_LENGTH;
+			sequences.push(buffer.slice(pos, stop));
+			pos = stop;
+			continue;
+		}
+		sequences.push(buffer.slice(pos, end));
+		pos = end;
 	}
 
-	return "incomplete";
+	return { sequences, remainder: "" };
 }
 
-/**
- * Check if OSC sequence is complete
- * OSC sequences: ESC ] ... ST (where ST is ESC \ or BEL)
- */
-function isCompleteOscSequence(data: string): "complete" | "incomplete" {
-	if (!data.startsWith(`${ESC}]`)) {
-		return "complete";
-	}
-
-	// OSC sequences end with ST (ESC \) or BEL (\x07)
-	if (data.endsWith(`${ESC}\\`) || data.endsWith("\x07")) {
-		return "complete";
-	}
-
-	return "incomplete";
-}
-
-/**
- * Check if DCS (Device Control String) sequence is complete
- * DCS sequences: ESC P ... ST (where ST is ESC \)
- * Used for XTVersion responses like ESC P >| ... ESC \
- */
-function isCompleteDcsSequence(data: string): "complete" | "incomplete" {
-	if (!data.startsWith(`${ESC}P`)) {
-		return "complete";
-	}
-
-	// DCS sequences end with ST (ESC \)
-	if (data.endsWith(`${ESC}\\`)) {
-		return "complete";
-	}
-
-	return "incomplete";
-}
-
-/**
- * Check if APC (Application Program Command) sequence is complete
- * APC sequences: ESC _ ... ST (where ST is ESC \)
- * Used for Kitty graphics responses like ESC _ G ... ESC \
- */
-function isCompleteApcSequence(data: string): "complete" | "incomplete" {
-	if (!data.startsWith(`${ESC}_`)) {
-		return "complete";
-	}
-
-	// APC sequences end with ST (ESC \)
-	if (data.endsWith(`${ESC}\\`)) {
-		return "complete";
-	}
-
-	return "incomplete";
-}
-
-/**
- * Split accumulated buffer into complete sequences
- */
 function parseUnmodifiedKittyPrintableCodepoint(sequence: string): number | undefined {
 	const match = sequence.match(/^\x1b\[(\d+)(?::\d*)?(?::\d+)?u$/);
 	if (!match) return undefined;
 
 	const codepoint = parseInt(match[1]!, 10);
 	return codepoint >= 32 ? codepoint : undefined;
-}
-
-function extractCompleteSequences(buffer: string): { sequences: string[]; remainder: string } {
-	const sequences: string[] = [];
-	const length = buffer.length;
-	let pos = 0;
-
-	// Index-based scanning: this is the input hot path. Slicing the remaining
-	// buffer (or Array.from-ing it) per iteration would make plain-text bursts
-	// O(n²) — a 100KB non-bracketed paste must stay O(n).
-	while (pos < length) {
-		if (buffer.charCodeAt(pos) === 0x1b) {
-			// Find the end of this escape sequence by growing the candidate.
-			let end = pos + 1;
-			let consumed = false;
-			while (end <= length) {
-				const candidate = buffer.slice(pos, end);
-				const status = isCompleteSequence(candidate);
-				if (status === "incomplete") {
-					end++;
-					continue;
-				}
-				// "\x1b\x1b" is one of three things:
-				//   1. ESC prefixing CSI/SS3 (meta-CSI, held Esc joined by a follower):
-				//      next byte is "[" or "O" — keep growing so the full sequence stays
-				//      together. Consuming two bytes here would tear the follower and
-				//      leak its tail as typed text (settings search filling with "[B"
-				//      or "[<35;22;17M").
-				//   2. ESC followed by a legacy Alt chord (`\x1bd`, `\x1b\x7f`, …):
-				//      emit the first ESC, then restart at the second ESC so downstream
-				//      parsing still sees the Alt chord as one keypress (#3860 review).
-				//   3. Two real Esc keypresses bursted by terminal input batching:
-				//      when the buffer ends here, hold the partial for the flush window
-				//      so case 1/2 can still arrive; if no follower arrives, `flush()`
-				//      splits the held remainder into two ESC events (#3857).
-				if (candidate === `${ESC}${ESC}`) {
-					if (end >= length) {
-						return { sequences, remainder: buffer.slice(pos) };
-					}
-					const next = buffer.charCodeAt(end);
-					if (next === 0x5b || next === 0x4f) {
-						end++;
-						continue;
-					}
-					sequences.push(ESC);
-					pos += 1;
-					consumed = true;
-					break;
-				}
-				// ESC + SGR mouse report is never a meta chord: alt-modified mouse
-				// reports carry the modifier in the button bits, not an ESC prefix.
-				// Deliver the bare ESC (a real Esc keypress) and the report separately.
-				if (candidate.startsWith(`${ESC}${ESC}[<`)) {
-					sequences.push(ESC, candidate.slice(1));
-					pos = end;
-					consumed = true;
-					break;
-				}
-				// "complete" — or "not-escape", which should not happen when
-				// starting with ESC; both consume the candidate.
-				sequences.push(candidate);
-				pos = end;
-				consumed = true;
-				break;
-			}
-
-			if (!consumed) {
-				return { sequences, remainder: buffer.slice(pos) };
-			}
-		} else {
-			// Not an escape sequence - take one Unicode scalar, not a UTF-16 code unit.
-			const codePoint = buffer.codePointAt(pos)!;
-			const charLength = codePoint > 0xffff ? 2 : 1;
-			sequences.push(buffer.slice(pos, pos + charLength));
-			pos += charLength;
-		}
-	}
-
-	return { sequences, remainder: "" };
 }
 
 export type StdinBufferOptions = {

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -426,6 +426,37 @@ function isPrivateModeSupported(status: string): boolean {
 }
 
 /**
+ * Regex patterns the `#setupStdinBuffer` data handler probes each stdin
+ * sequence against — kitty keyboard protocol reply, Mode 2031 DSR, OSC 11
+ * appearance response, DA1 sentinel, private CSI reassembly prefix, DECRPM
+ * private-mode report, and DEC 2048 in-band resize report.
+ *
+ * Exported so tests can pin the invariant the fast-path guard relies on:
+ * every pattern anchors on `\x1b`, so a non-ESC sequence with no reassembly
+ * buffer in flight can be forwarded to the input handler unconditionally
+ * (issue #4022 — a non-bracketed paste emits one `data` event per Unicode
+ * scalar, and running six regex probes per scalar dominates the paste path).
+ */
+export const STDIN_ESCAPE_PROBE_PATTERNS = {
+	// Kitty protocol response pattern: \x1b[?<flags>u
+	kittyResponse: /^\x1b\[\?(\d+)u$/,
+	// Mode 2031 DSR response: \x1b[?997;{1=dark,2=light}n
+	appearanceDsr: /^\x1b\[\?997;([12])n$/,
+	// OSC 11 response: \x1b]11;rgb:RR/GG/BB or rgba:RR/GG/BB, terminated by BEL or ST.
+	osc11Response: /^\x1b\]11;rgba?:([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})(?:\x07|\x1b\\)$/,
+	// DA1 (Primary Device Attributes) response: \x1b[?...c
+	da1Response: /^\x1b\[\?[\d;]*c$/,
+	// Private CSI partial: \x1b[?<digits/semicolons>... — incomplete probe response
+	// that the StdinBuffer flushed before the terminator arrived (split across
+	// stdin reads). Used to reassemble DA1, kitty, and Mode 2031 replies.
+	privateCsiPartial: /^\x1b\[\?[\d;]*[\x20-\x2f]*$/,
+	// DECRPM private-mode report (DECRQM reply): \x1b[?<mode>;<status>$y
+	decrpmResponse: /^\x1b\[\?(\d+);(\d+)\$y$/,
+	// In-band resize report (DEC mode 2048): \x1b[48;rows;cols;yPixels;xPixels t
+	inBandResize: /^\x1b\[48;(\d+);(\d+);(\d+);(\d+)t$/,
+} as const;
+
+/**
  * Real terminal using process.stdin/stdout
  */
 export class ProcessTerminal implements Terminal {
@@ -667,32 +698,40 @@ export class ProcessTerminal implements Terminal {
 		// proved too tight for split escapes (#1238 covered only probe replies).
 		this.#stdinBuffer = new StdinBuffer({ timeout: 50 });
 
-		// Kitty protocol response pattern: \x1b[?<flags>u
-		const kittyResponsePattern = /^\x1b\[\?(\d+)u$/;
-
-		// Mode 2031 DSR response: \x1b[?997;{1=dark,2=light}n
-		const appearanceDsrPattern = /^\x1b\[\?997;([12])n$/;
-
-		// OSC 11 response: \x1b]11;rgb:RR/GG/BB or rgba:RR/GG/BB, terminated by BEL or ST.
-		const osc11ResponsePattern =
-			/^\x1b\]11;rgba?:([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})(?:\x07|\x1b\\)$/;
-
-		// DA1 (Primary Device Attributes) response: \x1b[?...c
-		const da1ResponsePattern = /^\x1b\[\?[\d;]*c$/;
-
-		// Private CSI partial: \x1b[?<digits/semicolons>... — incomplete probe response
-		// that the StdinBuffer flushed before the terminator arrived (split across
-		// stdin reads). Used to reassemble DA1, kitty, and Mode 2031 replies.
-		const privateCsiPartialPattern = /^\x1b\[\?[\d;]*[\x20-\x2f]*$/;
-
-		// DECRPM private-mode report (DECRQM reply): \x1b[?<mode>;<status>$y
-		const decrpmResponsePattern = /^\x1b\[\?(\d+);(\d+)\$y$/;
-
-		// In-band resize report (DEC mode 2048): \x1b[48;rows;cols;yPixels;xPixels t
-		const inBandResizePattern = /^\x1b\[48;(\d+);(\d+);(\d+);(\d+)t$/;
+		// See {@link STDIN_ESCAPE_PROBE_PATTERNS} at module scope. Local aliases
+		// keep the inline logic below readable.
+		const kittyResponsePattern = STDIN_ESCAPE_PROBE_PATTERNS.kittyResponse;
+		const appearanceDsrPattern = STDIN_ESCAPE_PROBE_PATTERNS.appearanceDsr;
+		const osc11ResponsePattern = STDIN_ESCAPE_PROBE_PATTERNS.osc11Response;
+		const da1ResponsePattern = STDIN_ESCAPE_PROBE_PATTERNS.da1Response;
+		const privateCsiPartialPattern = STDIN_ESCAPE_PROBE_PATTERNS.privateCsiPartial;
+		const decrpmResponsePattern = STDIN_ESCAPE_PROBE_PATTERNS.decrpmResponse;
+		const inBandResizePattern = STDIN_ESCAPE_PROBE_PATTERNS.inBandResize;
 
 		// Forward individual sequences to the input handler
 		this.#stdinBuffer.on("data", (sequence: string) => {
+			// Fast path — plain non-ESC bytes with no reassembly in flight
+			// bypass the entire escape-probe suite (six unconditional regex
+			// checks and four buffered-reassembly branches, all of which
+			// require an ESC-prefixed sequence). Every probe pattern below
+			// starts with `\x1b`, so a non-ESC scalar can only be relevant
+			// when a reassembly buffer is already accumulating a split
+			// response and the next bytes are its tail. Without this guard, a
+			// non-bracketed paste that arrives as one `data` event per Unicode
+			// scalar runs the whole probe suite per event — issue #4022.
+			// (Single-event delivery is preserved so `matchesKey`/
+			// `isKeyRelease` still see the per-scalar boundary — see
+			// `#setupStdinBuffer` comment at line 654.)
+			if (
+				sequence.charCodeAt(0) !== 0x1b &&
+				!this.#privateCsiResponseBuffer &&
+				!this.#inBandResizeBuffer &&
+				!this.#osc11ResponseBuffer &&
+				!this.#osc99ResponseBuffer
+			) {
+				this.#inputHandler?.(sequence);
+				return;
+			}
 			// Reassemble split private CSI responses (DA1, kitty keyboard, Mode 2031).
 			// When the terminal writes the response slowly enough that the StdinBuffer's
 			// flush timeout elapses mid-sequence, the prefix `\x1b[?<digits>` arrives as

--- a/packages/tui/test/bracketed-paste.test.ts
+++ b/packages/tui/test/bracketed-paste.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { BracketedPasteHandler, decodeReencodedPasteControls } from "@oh-my-pi/pi-tui/bracketed-paste";
+
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+
+describe("BracketedPasteHandler", () => {
+	it("passes non-paste bytes through untouched", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process("hello")).toEqual({ handled: false });
+	});
+
+	it("assembles a complete paste delivered in one chunk", () => {
+		const handler = new BracketedPasteHandler();
+		const result = handler.process(`${PASTE_START}hello world${PASTE_END}`);
+		expect(result).toEqual({ handled: true, pasteContent: "hello world", remaining: "" });
+	});
+
+	it("holds until the end marker arrives when split across chunks", () => {
+		const handler = new BracketedPasteHandler();
+		expect(handler.process(`${PASTE_START}part 1 `)).toEqual({ handled: true, remaining: "" });
+		expect(handler.process("part 2")).toEqual({ handled: true, remaining: "" });
+		expect(handler.process(PASTE_END)).toEqual({
+			handled: true,
+			pasteContent: "part 1 part 2",
+			remaining: "",
+		});
+	});
+
+	it("preserves trailing bytes after the end marker as `remaining`", () => {
+		const handler = new BracketedPasteHandler();
+		const result = handler.process(`${PASTE_START}payload${PASTE_END}trailing`);
+		expect(result).toEqual({ handled: true, pasteContent: "payload", remaining: "trailing" });
+	});
+
+	it("delivers the accumulated payload as a completed paste when the byte cap is exceeded", () => {
+		// Defense in depth for callers that bypass `StdinBuffer` (which
+		// re-wraps paste bodies with both markers). Without this cap, a lost
+		// end marker leaks memory forever while input appears dead — see the
+		// contrast with `StdinBuffer`'s `#abortPaste` at stdin-buffer.ts:497.
+		const handler = new BracketedPasteHandler({ byteLimit: 8 });
+		expect(handler.process(`${PASTE_START}0123456789abcdef`)).toEqual({
+			handled: true,
+			pasteContent: "0123456789abcdef",
+			remaining: "",
+		});
+		// After recovery, ordinary input flows again.
+		expect(handler.process("z")).toEqual({ handled: false });
+	});
+
+	it("resumes accepting a new paste after a cap-triggered recovery", () => {
+		const handler = new BracketedPasteHandler({ byteLimit: 4 });
+		handler.process(`${PASTE_START}abcdefgh`);
+		const next = handler.process(`${PASTE_START}small${PASTE_END}`);
+		expect(next).toEqual({ handled: true, pasteContent: "small", remaining: "" });
+	});
+});
+
+describe("decodeReencodedPasteControls", () => {
+	it("decodes tmux csi-u encoding to the raw control byte", () => {
+		expect(decodeReencodedPasteControls("hi\x1b[106;5uworld")).toBe("hi\nworld");
+	});
+
+	it("decodes tmux xterm encoding to the raw control byte", () => {
+		expect(decodeReencodedPasteControls("a\x1b[27;5;106~b")).toBe("a\nb");
+	});
+
+	it("leaves the payload untouched when no re-encoded controls are present", () => {
+		expect(decodeReencodedPasteControls("plain text")).toBe("plain text");
+	});
+});

--- a/packages/tui/test/stdin-buffer.test.ts
+++ b/packages/tui/test/stdin-buffer.test.ts
@@ -374,6 +374,93 @@ describe("StdinBuffer", () => {
 		});
 	});
 
+	describe("Malformed Escape Sequences", () => {
+		// Cap declared in `stdin-buffer.ts` — kept in sync with `MAX_ESCAPE_LENGTH`.
+		const MAX_ESCAPE_LENGTH = 64 * 1024;
+
+		it("processes a runaway CSI in linear time and flushes at the cap", () => {
+			// A malformed CSI with no final byte (megabytes of parameter bytes)
+			// used to be quadratic — a 4 MB partial blocked the event loop for
+			// hundreds of ms of synchronous slice+scan. The rewrite caps the
+			// scan window and flushes the prefix so no single `process()` call
+			// hangs the loop even under a hostile stream (issue #4022).
+			const input = `\x1b[${";".repeat(MAX_ESCAPE_LENGTH * 2)}`;
+			const start = performance.now();
+			processInput(input);
+			const elapsed = performance.now() - start;
+			expect(elapsed).toBeLessThan(500);
+			// First emission is the capped ESC-prefixed chunk; the tail resyncs
+			// as ordinary plain-char events.
+			expect(emittedSequences[0]!.length).toBe(MAX_ESCAPE_LENGTH);
+			expect(emittedSequences[0]!.charCodeAt(0)).toBe(0x1b);
+			expect(emittedSequences.length).toBe(1 + input.length - MAX_ESCAPE_LENGTH);
+			expect(emittedSequences[emittedSequences.length - 1]).toBe(";");
+		});
+
+		it("processes a runaway SGR mouse partial in linear time and flushes at the cap", () => {
+			// SGR-shaped CSI (`\x1b[<...`) is the worst prior offender because
+			// each grow-a-substring iteration re-tested a regex on the full
+			// candidate. The cap now bounds the scan to `MAX_ESCAPE_LENGTH`
+			// regardless of stream size.
+			const input = `\x1b[<${"1;".repeat(MAX_ESCAPE_LENGTH)}`;
+			const start = performance.now();
+			processInput(input);
+			const elapsed = performance.now() - start;
+			expect(elapsed).toBeLessThan(500);
+			expect(emittedSequences[0]!.length).toBe(MAX_ESCAPE_LENGTH);
+			expect(emittedSequences[0]!.charCodeAt(0)).toBe(0x1b);
+		});
+
+		it("processes a runaway OSC without ST/BEL in linear time and flushes at the cap", () => {
+			// OSC endsWith(ST|BEL) was O(n) per iteration on the growing
+			// candidate; the linear scan looks for the terminator once.
+			const input = `\x1b]0;${"x".repeat(MAX_ESCAPE_LENGTH * 2)}`;
+			const start = performance.now();
+			processInput(input);
+			const elapsed = performance.now() - start;
+			expect(elapsed).toBeLessThan(500);
+			expect(emittedSequences[0]!.length).toBe(MAX_ESCAPE_LENGTH);
+			expect(emittedSequences[0]!.startsWith("\x1b]0;")).toBe(true);
+		});
+
+		it("processes a runaway DCS without ST in linear time and flushes at the cap", () => {
+			const input = `\x1bP>|${"x".repeat(MAX_ESCAPE_LENGTH)}`;
+			const start = performance.now();
+			processInput(input);
+			const elapsed = performance.now() - start;
+			expect(elapsed).toBeLessThan(500);
+			expect(emittedSequences[0]!.length).toBe(MAX_ESCAPE_LENGTH);
+			expect(emittedSequences[0]!.startsWith("\x1bP>|")).toBe(true);
+		});
+
+		it("processes a runaway APC without ST in linear time and flushes at the cap", () => {
+			const input = `\x1b_G${"x".repeat(MAX_ESCAPE_LENGTH)}`;
+			const start = performance.now();
+			processInput(input);
+			const elapsed = performance.now() - start;
+			expect(elapsed).toBeLessThan(500);
+			expect(emittedSequences[0]!.length).toBe(MAX_ESCAPE_LENGTH);
+			expect(emittedSequences[0]!.startsWith("\x1b_G")).toBe(true);
+		});
+
+		it("keeps a legitimate long CSI under the cap intact", () => {
+			// 100 numeric parameters is well within the cap and MUST still
+			// parse as one sequence — the cap only trips runaway partials.
+			const params = Array.from({ length: 100 }, () => "1").join(";");
+			const seq = `\x1b[${params}H`;
+			processInput(seq);
+			expect(emittedSequences).toEqual([seq]);
+		});
+
+		it("keeps a legitimate long OSC under the cap intact", () => {
+			// A 32 KiB OSC payload terminated with ST is well below the cap.
+			const payload = "a".repeat(32 * 1024);
+			const seq = `\x1b]52;c;${payload}\x1b\\`;
+			processInput(seq);
+			expect(emittedSequences).toEqual([seq]);
+		});
+	});
+
 	describe("Flush", () => {
 		it("should flush incomplete sequences", () => {
 			processInput("\x1b[<35");

--- a/packages/tui/test/terminal-stdin-fast-path.test.ts
+++ b/packages/tui/test/terminal-stdin-fast-path.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { STDIN_ESCAPE_PROBE_PATTERNS } from "@oh-my-pi/pi-tui/terminal";
+
+// The `#setupStdinBuffer` data handler short-circuits plain non-ESC input when
+// no reassembly buffer is in flight. That is only safe because every probe
+// pattern anchors on `\x1b` — a non-ESC scalar can never satisfy one, so
+// skipping the probes is behavior-preserving. This test pins the invariant:
+// if a future change adds a probe that does NOT require an ESC prefix, the
+// fast path in `terminal.ts` MUST be revisited (issue #4022).
+
+describe("STDIN escape-probe patterns", () => {
+	// Sample of common non-ESC bytes: printable ASCII, whitespace, and a
+	// couple of high-bit code points that terminals may deliver as raw scalars
+	// on legacy (non-UTF-8) encodings. All of these MUST fail every probe.
+	const nonEscBytes = [
+		"a",
+		"Z",
+		"0",
+		" ",
+		"\n",
+		"\t",
+		"~",
+		"\x7f",
+		"\u00e9", // é
+		"\u4e16", // 世
+		"🙂",
+	];
+
+	for (const name in STDIN_ESCAPE_PROBE_PATTERNS) {
+		const pattern = STDIN_ESCAPE_PROBE_PATTERNS[name as keyof typeof STDIN_ESCAPE_PROBE_PATTERNS];
+		it(`${name} requires an ESC-prefixed sequence`, () => {
+			// Static invariant: the source anchors on the literal `\x1b`.
+			expect(pattern.source).toStartWith("^\\x1b");
+			// Dynamic invariant: nothing without an ESC prefix ever matches.
+			for (const b of nonEscBytes) {
+				expect(pattern.test(b)).toBe(false);
+			}
+		});
+	}
+});


### PR DESCRIPTION
## Repro

`StdinBuffer.process()` and the `ProcessTerminal` stdin data handler had three
overlapping paths that could block the Node event loop on a single write.

- **A. Malformed CSI/OSC/DCS/APC.** `extractCompleteSequences` grew a candidate
  substring one code unit at a time and called `isCompleteSequence(candidate)`
  on every prefix. Each check re-sliced/re-scanned the whole candidate, so a
  long unterminated CSI (e.g. `\x1b[` followed by megabytes of `;`) or an OSC
  without ST/BEL took O(n²) worst-case work in one `process()` call. SGR-shaped
  CSI (`\x1b[<…`) was the worst offender because the SGR-mouse validation regex
  ran on every prefix as well.
- **B. Unbounded `BracketedPasteHandler`.** `#buffer` accumulated forever once
  a paste-start marker arrived without a matching end marker. `StdinBuffer` had
  matching cap + inactivity recovery (`stdin-buffer.ts:452-511`), but the
  exported `BracketedPasteHandler` — reachable via `Editor`, `Input`,
  `EditorComponent`, and `custom-editor.ts`'s `#pasteHandler` — did not.
- **C. Per-scalar probe suite.** A non-bracketed paste arrives as one `data`
  event per Unicode scalar, and every event ran the six ESC-anchored regex
  probes (`privateCsiPartialPattern`, `inBandResizePattern`, …) even though
  none can match a plain char. A 100 KB ASCII paste ran ~600 K regex probes
  before the loop could process Ctrl+C.

Reproduction (repro_record on the issue): a 4 MB `\x1b[` + `;`.repeat(n) took
~345 ms; SGR-shaped input, ~695 ms; per-scalar probe cost of 100 K plain chars,
6.6 ms of pure probe work.

## Cause

- `packages/tui/src/stdin-buffer.ts:224-301` — `extractCompleteSequences` inner
  `while (end <= length)` loop grew `end`, sliced `buffer.slice(pos, end)`, and
  called `isCompleteSequence` on the growing candidate.
- `packages/tui/src/stdin-buffer.ts:116-211` — the `isCompleteCsi/Osc/Dcs/Apc`
  helpers all re-scanned the full candidate per prefix (`startsWith`, `slice`,
  `endsWith`, plus a full-payload SGR-mouse regex).
- `packages/tui/src/bracketed-paste.ts:50-84` — `BracketedPasteHandler` had no
  byte cap and no recovery; `#buffer += data` grew unbounded once `#active`
  latched.
- `packages/tui/src/terminal.ts:695-926` — the `#setupStdinBuffer` on-data
  handler always ran six ESC-anchored regex probes even when the sequence
  was a bare printable char and no reassembly buffer was in flight.

## Fix

- **A.** Replaced `extractCompleteSequences` with an index-based scanner
  (`scanEscape` walks `charCodeAt` positions instead of allocating substring
  candidates). CSI/OSC/DCS/APC/SS3 each look for their terminator in one pass;
  the double-ESC / SGR-mouse-split edge cases from the old loop are preserved
  inline. A per-sequence `MAX_ESCAPE_LENGTH` cap (64 KiB) bounds a runaway
  partial: once the scan reaches the cap without a terminator, the capped
  prefix is emitted as one raw sequence and parsing resyncs on the tail. This
  matches the existing `#flush`/hold-partial semantics for anything under the
  cap.
- **B.** `BracketedPasteHandler` gained a `byteLimit` option
  (default 64 MiB, matching `StdinBuffer.PASTE_MAX_BYTES`). When the buffer
  grows past the cap without an end marker, the accumulated bytes are
  delivered as a completed paste (`{ handled: true, pasteContent, remaining: "" }`),
  the handler resets, and subsequent input flows normally. Sync API preserved.
- **C.** Added a non-ESC fast path at the top of the stdin data handler:
  when `sequence.charCodeAt(0) !== 0x1b` **and** no reassembly buffer is in
  flight (private CSI, in-band resize, OSC 11, OSC 99), forward straight to
  the input handler and skip the six probe regexes. The single-event delivery
  contract `matchesKey`/`isKeyRelease` rely on is preserved.
- Extracted the probe regex table to a module-level
  `STDIN_ESCAPE_PROBE_PATTERNS` export so a new test can pin the invariant
  the fast path relies on (every pattern MUST anchor on `\x1b`).

## Verification

- `bun test packages/tui/test/stdin-buffer.test.ts` — 62 pass, 0 fail
  (55 existing + 7 new regression tests: linear-time processing under the cap,
  cap force-flush of runaway CSI/SGR/OSC/DCS/APC, and preservation of
  legitimate long-but-under-cap CSI/OSC).
- `bun test packages/tui/test/bracketed-paste.test.ts` — new suite covering
  pass-through, chunked assembly, trailing `remaining`, cap-triggered recovery,
  and re-arming after recovery.
- `bun test packages/tui/test/terminal-stdin-fast-path.test.ts` — new suite
  proves every probe pattern requires an ESC prefix (static source assertion +
  dynamic run against printable ASCII, whitespace, high-bit code points, and a
  surrogate-pair emoji).
- Benchmarks (from the same probe as the issue's `repro_record`):
  a 4 MB malformed CSI drops from ~345 ms to ~148 ms; the SGR variant from
  ~695 ms to ~248 ms; further paste-time savings come from the terminal
  fast path.
- `bun check` — passes.

Skipped pre-publish gate: N/A. `bun check` was run locally and passes clean.
The unrelated `terminal-appearance.test.ts` / `input.test.ts` failures in
this environment come from a missing `@oh-my-pi/pi-natives` binding
(`nativeSetHangulCompatJamoWidthOverride is not a function`) that exists on
`main` before this diff — confirmed by re-running against the stashed
worktree.

Fixes #4022