### PR TITLE
fix(natives): caught task::blocking panics before crossing napi async-work FFI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,22 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 strip = true
-# Unwind (not abort) so panics in vendored uutils code and napi-rs functions
-# are catchable: the uutils boundary (pi-shell coreutils) and napi-rs's per-call
-# catch_unwind turn a panic into a failed command / JS error instead of killing
-# the host process. Recoverable uutils panics are kept out of the crash report
-# by the crash hook (see crates/pi-natives/src/crash_handler.rs).
+# Unwind (not abort) so panics inside the native module have somewhere to be
+# caught. Two boundaries do that catching explicitly — napi-rs itself does
+# NOT wrap the `Task`/`AsyncTask` async-work path (its `execute`/`complete`
+# are plain `extern "C" fn`, so an unwind escaping them would abort under
+# stabilized C-unwind rules, RFC 2945 / rust-lang/rust#115285):
+#
+#   - `pi-shell` `run_uutil`: catches panics from vendored uutils code and
+#     surfaces them as a failed command.
+#   - `pi-natives` `task::Blocking::compute`: wraps the user closure in
+#     `catch_unwind` and turns a panic into a rejected JS promise (see issue
+#     #4020).
+#
+# The crash hook (crates/pi-natives/src/crash_handler.rs) suppresses the
+# stderr echo for panics inside either scope so recoverable errors don't
+# spam the user; they are still written to the on-disk crash log for
+# diagnosis.
 panic = "unwind"
 
 [profile.ci]

--- a/crates/pi-natives/src/crash_handler.rs
+++ b/crates/pi-natives/src/crash_handler.rs
@@ -59,12 +59,15 @@ pub fn install() {
 		let prev_panic = std::panic::take_hook();
 		std::panic::set_hook(Box::new(move |info| {
 			let report = format_panic_report(info);
-			// A panic raised while a uutils scope is active is caught at the
-			// uutils boundary (pi-shell `run_uutil`): the command fails with a
-			// non-zero exit instead of crashing the host. Record it to the log
-			// for diagnosis, but keep the recovered panic out of the user-facing
-			// stderr crash dump and skip the default abort hook.
-			let recoverable = pi_uutils_ctx::is_active();
+			// A panic raised while a recoverable scope is active is caught below
+			// the FFI boundary — either by the uutils dispatcher in
+			// `pi-shell::run_uutil`, which fails the command with a non-zero
+			// exit, or by `task::blocking`'s `catch_unwind` guard in
+			// `crate::task::Blocking::compute`, which rejects the JS promise
+			// with a `napi::Error`. Record it to the log for diagnosis, but
+			// keep the recovered panic out of the user-facing stderr crash dump
+			// and skip the default abort hook.
+			let recoverable = pi_uutils_ctx::is_active() || crate::task::is_recoverable_scope_active();
 			persist(&report, CrashKind::Panic, !recoverable);
 			if !recoverable {
 				prev_panic(info);

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -27,7 +27,9 @@
 //! }
 //! ```
 
+use std::cell::Cell;
 use std::future::Future;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use napi::{Env, Error, Result, Task, bindgen_prelude::*};
 use pi_shell::cancel as core_cancel;
@@ -146,6 +148,64 @@ impl AbortToken {
 // Blocking Task - libuv thread pool integration
 // ─────────────────────────────────────────────────────────────────────────────
 
+thread_local! {
+	/// Number of active [`Blocking::compute`] frames on this thread.
+	///
+	/// The native crash hook consults [`is_recoverable_scope_active`] from
+	/// inside a panic: when the panic is about to be caught by
+	/// [`Blocking::compute`]'s [`catch_unwind`] guard, the hook logs the
+	/// report to disk but skips the user-facing stderr crash dump — the
+	/// promise rejection is the primary signal instead. A borrow-free
+	/// [`Cell`] is used because the panic hook runs while an arbitrary set
+	/// of other borrows are live, and a `RefCell` there could panic again
+	/// and abort the process.
+	static BLOCKING_SCOPE_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+/// RAII guard that marks the current thread as executing inside
+/// [`Blocking::compute`], so a panic on this thread is classified as
+/// recoverable by the native crash hook. Decrements on drop even when the
+/// wrapped work unwinds.
+struct BlockingScopeGuard;
+
+impl BlockingScopeGuard {
+	fn enter() -> Self {
+		BLOCKING_SCOPE_DEPTH.with(|d| d.set(d.get() + 1));
+		Self
+	}
+}
+
+impl Drop for BlockingScopeGuard {
+	fn drop(&mut self) {
+		BLOCKING_SCOPE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+	}
+}
+
+/// Whether a `Blocking::compute` frame is active on the current thread —
+/// i.e. a panic here is about to be caught before it can cross napi-rs's
+/// plain `extern "C" fn` async-work boundary.
+#[must_use]
+pub fn is_recoverable_scope_active() -> bool {
+	BLOCKING_SCOPE_DEPTH.with(|d| d.get() > 0)
+}
+
+/// Best-effort stringification of a panic payload for surfacing in a
+/// [`napi::Error`]. Mirrors the [`std::panic::PanicHookInfo::payload_as_str`]
+/// contract: recognise the two payload types the standard panic runtime
+/// produces (`&'static str` from a bare string panic, `String` from a
+/// formatted panic), and fall back to a diagnostic marker otherwise. The
+/// full panic record (payload, location, backtrace) is still persisted by
+/// the [`crate::crash_handler`] hook on disk.
+fn panic_payload_to_string(payload: &(dyn std::any::Any + Send)) -> String {
+	if let Some(s) = payload.downcast_ref::<&'static str>() {
+		return (*s).to_owned();
+	}
+	if let Some(s) = payload.downcast_ref::<String>() {
+		return s.clone();
+	}
+	String::from("<panic (payload not extractable — see native crash log)>")
+}
+
 /// Task that runs blocking work on libuv's thread pool with profiling.
 ///
 /// This implements napi's `Task` trait, running `compute()` on a libuv worker
@@ -166,13 +226,37 @@ where
 	type JsValue = T;
 	type Output = T;
 
+	/// Runs the user closure on a libuv worker thread.
+	///
+	/// The closure is invoked under [`catch_unwind`] so a panic — from a
+	/// first-party `.expect(...)` invariant, an arithmetic overflow in a
+	/// third-party crate, or anything else — is surfaced as a
+	/// [`napi::Error`] and rejected on the JS `Promise`. Without this
+	/// guard, the unwind would cross napi-rs's plain `extern "C" fn
+	/// execute` async-work callback
+	/// (`napi::async_work::execute`), which under stabilized C-unwind
+	/// semantics (RFC 2945, Rust 1.81+) is a forced process abort. See
+	/// <https://github.com/can1357/oh-my-pi/issues/4020>.
 	fn compute(&mut self) -> Result<Self::Output> {
 		let _guard = profile_region(self.tag);
+		let _scope = BlockingScopeGuard::enter();
 		let work = self
 			.work
 			.take()
 			.ok_or_else(|| Error::from_reason("BlockingTask: work already consumed"))?;
-		work(self.cancel_token.clone())
+		let cancel_token = self.cancel_token.clone();
+		let tag = self.tag;
+		// `FnOnce` closures aren't automatically `UnwindSafe`; `AssertUnwindSafe`
+		// is sound here because we only observe the panic to translate it into
+		// a napi error — no post-panic state on `self` is reused (the closure
+		// was already taken out of `self.work`).
+		match catch_unwind(AssertUnwindSafe(move || work(cancel_token))) {
+			Ok(result) => result,
+			Err(payload) => Err(Error::new(
+				Status::GenericFailure,
+				format!("panic in blocking task '{tag}': {}", panic_payload_to_string(&*payload)),
+			)),
+		}
 	}
 
 	fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -255,4 +339,114 @@ where
 		let _guard = profile_region(tag);
 		work.await
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use napi::{Result, Task};
+
+	use super::*;
+
+	/// Constructs a `Blocking<()>` directly (bypassing `AsyncTask`) so we can
+	/// invoke [`Task::compute`] and observe how it treats a panicking work
+	/// closure. Regression harness for
+	/// <https://github.com/can1357/oh-my-pi/issues/4020>.
+	fn blocking_task_with_panic() -> Blocking<()> {
+		Blocking {
+			tag:          "test_panic",
+			cancel_token: CancelToken::default(),
+			work:         Some(Box::new(|_| -> Result<()> {
+				panic!("injected panic inside blocking work");
+			})),
+		}
+	}
+
+	/// A panic in a `task::blocking` closure MUST NOT unwind out of
+	/// `Task::compute`. napi-rs's async-work `execute` is a plain
+	/// `extern "C" fn`; letting an unwind cross that boundary is a forced
+	/// process abort under stabilized C-unwind rules. The correct behavior is
+	/// to convert the panic into a `napi::Error`.
+	#[test]
+	fn compute_converts_panic_to_error() {
+		let mut task = blocking_task_with_panic();
+		let result = task.compute();
+		let err = result.expect_err("panicking work must surface as Err, not unwind out of compute");
+		assert_eq!(err.status, Status::GenericFailure);
+		assert!(
+			err.reason.starts_with("panic in blocking task 'test_panic':"),
+			"napi Error reason must identify the panicking task by tag: {}",
+			err.reason,
+		);
+		assert!(
+			err.reason.contains("injected panic inside blocking work"),
+			"panic message must be preserved in the napi Error reason: {}",
+			err.reason,
+		);
+	}
+
+	/// A subsequent `compute` call MUST return the "work already consumed"
+	/// error rather than double-taking the `FnOnce`. Guards against a fix
+	/// that accidentally leaves the closure untouched on the panic path.
+	#[test]
+	fn compute_consumes_work_even_when_it_panics() {
+		let mut task = blocking_task_with_panic();
+		let _first = task.compute();
+		let err = task.compute().expect_err("second compute call must Err");
+		assert!(
+			err.reason.contains("work already consumed"),
+			"second call must report work-already-consumed: {}",
+			err.reason,
+		);
+	}
+
+	/// Non-panicking work MUST resolve through `compute` unchanged. Guards
+	/// against a fix that accidentally intercepts normal `Err(napi::Error)`
+	/// returns or mangles the `Ok` payload.
+	#[test]
+	fn compute_still_forwards_ok_and_err_from_work() {
+		let mut ok = Blocking {
+			tag:          "test_ok",
+			cancel_token: CancelToken::default(),
+			work:         Some(Box::new(|_| Ok(42_u32))),
+		};
+		assert_eq!(ok.compute().expect("ok work must not error"), 42_u32);
+
+		let mut err_task = Blocking::<()> {
+			tag:          "test_err",
+			cancel_token: CancelToken::default(),
+			work:         Some(Box::new(|_| {
+				Err(Error::new(Status::InvalidArg, "explicit error".to_owned()))
+			})),
+		};
+		let err = err_task.compute().expect_err("explicit Err must propagate");
+		assert_eq!(err.status, Status::InvalidArg);
+		assert_eq!(err.reason, "explicit error");
+	}
+
+	/// The recoverable-scope flag MUST be raised only while `compute` is on
+	/// the stack and MUST drop back to zero whether the work returned or
+	/// panicked, so the native crash hook classifies subsequent unrelated
+	/// panics correctly.
+	#[test]
+	fn recoverable_scope_flag_tracks_compute_lifetime() {
+		assert!(!is_recoverable_scope_active(), "no compute frame at rest");
+
+		let mut ok = Blocking::<bool> {
+			tag:          "test_scope_ok",
+			cancel_token: CancelToken::default(),
+			work:         Some(Box::new(|_| Ok(is_recoverable_scope_active()))),
+		};
+		assert!(
+			ok.compute().expect("ok work must not error"),
+			"scope flag must be raised inside compute",
+		);
+		assert!(!is_recoverable_scope_active(), "scope flag must clear on return");
+
+		let mut panicky = blocking_task_with_panic();
+		let _ = panicky.compute();
+		assert!(
+			!is_recoverable_scope_active(),
+			"scope flag must clear even when work panicked",
+		);
+	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native `task::blocking` closures aborting the host process when they panicked (via `.expect(...)` invariants, arithmetic overflow, or third-party panics on adversarial input) instead of rejecting the corresponding JS `Promise`. napi-rs's async-work callback is a plain `extern "C" fn`, so an unwind that escaped `Blocking::compute` was a forced process abort under stabilized C-unwind rules — `grep`, `glob`, `astGrep`, `astMatch`, `astEdit`, `listWorkspace`, `fuzzyFind`, `htmlToMarkdown`, `renderSnapcompactPng`, and `readImageFromClipboard` all shared this exposure. `Blocking::compute` now wraps the user closure in `std::panic::catch_unwind` and surfaces the panic as a `napi::Error` (`GenericFailure`), and the native crash hook treats a panic caught here the same way it already treated uutils panics — logged to the on-disk crash record for diagnosis, kept out of the user-facing stderr crash dump ([#4020](https://github.com/can1357/oh-my-pi/issues/4020)).
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed


### PR DESCRIPTION
## Repro

A panicking `task::blocking` closure — an `.expect(...)` invariant, an arithmetic overflow, a third-party library panic on adversarial input — should surface as a rejected JS `Promise`. Instead it aborted the host process. `Blocking::compute` in `crates/pi-natives/src/task.rs` invoked the user closure with no `catch_unwind`, so the unwind escaped into napi-rs's plain `unsafe extern "C" fn execute` async-work callback (`napi-3.9.4 src/async_work.rs:109-113`), which under stabilized C-unwind rules (RFC 2945 / rust-lang/rust#115285, Rust 1.81+) is a forced process abort.

Repro harness added in `crates/pi-natives/src/task.rs`:

```
cd crates/pi-natives && cargo test --lib task::tests::compute_converts_panic_to_error
```

Against the previous source, `Task::compute()` propagated the injected panic instead of returning `Err`:

```
thread 'task::tests::compute_converts_panic_to_error' panicked at task.rs:275:17:
injected panic inside blocking work
test task::tests::compute_converts_panic_to_error ... FAILED
```

In production this unwind would cross the plain `extern "C"` boundary and abort — the JS promise never rejected, in-flight session state was lost.

## Cause

Two layered defects, both in `pi-natives`:

- `crates/pi-natives/src/task.rs` `Blocking::compute` (`impl<T> Task for Blocking<T>`) called `work(self.cancel_token.clone())` with no `catch_unwind`. The `Task` trait's `compute` runs on a libuv worker thread, registered as `Some(execute::<T>)` by `napi::async_work::run`. `execute` is `unsafe extern "C" fn`, not `extern "C-unwind"`, so any unwind is a forced abort.
- `Cargo.toml`'s `[profile.release] panic = "unwind"` comment claimed napi-rs's per-call `catch_unwind` turned panics into JS errors. That's true for the tokio-future path (`napi::tokio_runtime` uses `try_into_panic() -> deferred_for_panic.reject(...)`), but false for `Task` / `AsyncTask<Blocking<T>>`.

Every blocking closure in the codebase shares the exposure: `ast_grep`/`ast_match`/`ast_edit` (`ast.rs`), `grep` (`grep.rs`), `glob` (`glob.rs`), `html_to_markdown` (`html.rs`), `render_snapcompact_png` (`snapcompact.rs`), `listWorkspace` (`workspace.rs`), `fuzzy_find` (`fd.rs`), and `read_image_from_clipboard` (`clipboard.rs`). Panic-capable sites live inside them (e.g. `crates/pi-natives/src/ast.rs:448` `.expect("non-empty inferred set")`, multiple `.expect(...)` invariants in `grep.rs`, `snapcompact.rs`'s `Silver.ttf` parse) plus third-party crates on the search path.

## Fix

- `Blocking::compute` now wraps the work call in `std::panic::catch_unwind(AssertUnwindSafe(...))` and maps the payload to `napi::Error::new(Status::GenericFailure, format!("panic in blocking task '{tag}': {msg}"))`. `AssertUnwindSafe` is sound because the `FnOnce` was already taken out of `self.work`, so no post-panic state is reused. The payload is stringified via a helper that mirrors stdlib's `payload_as_str` contract (`&'static str` and `String`) with a diagnostic fallback pointing at the on-disk crash log.
- A thread-local `BLOCKING_SCOPE_DEPTH` guard tracks active `compute` frames on the current thread, exposed as `task::is_recoverable_scope_active()`. `crash_handler`'s panic hook now treats a panic inside that scope the same way it already treated uutils panics — logged to the on-disk crash record for diagnosis, kept out of the user-facing stderr crash dump. This is symmetrical with the existing `pi_uutils_ctx::is_active()` classification.
- `Cargo.toml`'s `[profile.release] panic = "unwind"` comment now enumerates the two boundaries that actually do the catching (`pi-shell::run_uutil` and `pi-natives::Blocking::compute`) and calls out that napi-rs itself does NOT wrap the async-work path.
- `packages/natives/CHANGELOG.md` gets an `[Unreleased] ### Fixed` entry.

## Verification

`cd crates/pi-natives && cargo test --lib` — 133 passed, 0 failed. The four new tests in `task::tests` cover: panic → `GenericFailure` with tag + message, subsequent `compute` reports work-already-consumed, `Ok`/`Err` returns from the closure pass through unchanged, and the recoverable-scope flag clears on both panic and non-panic paths.

`cargo clippy --workspace -- -D warnings` — clean. (Clippy's `coerce_container_to_any` also caught a latent typo — an early draft passed `&Box<dyn Any>` to `downcast_ref`, silently downcasting against the outer `Box` type; fixed to `&*payload` so downcasts hit the payload's concrete `TypeId`.)

Fixes #4020