### PR TITLE
fix(auth-broker): cache /v1/usage failures for documented 15s TTL

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `RemoteAuthCredentialStore` now caches broker `/v1/usage` fetch failures for the documented 15s TTL fallback, so sequential ranking passes no longer re-hit the broker while it is down ([#4045](https://github.com/can1357/oh-my-pi/issues/4045)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Changed

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -58,7 +58,13 @@ interface CacheEntry {
 }
 
 interface UsageCacheEntry {
-	reports: UsageReport[];
+	/**
+	 * `null` means the last aggregate `/v1/usage` fetch failed. Callers treat
+	 * this the same as a successful empty-report response ("no usage signal
+	 * for this cycle"), and the same 15s TTL applies so transient broker
+	 * outages don't turn every ranking pass into a broker retry storm.
+	 */
+	reports: UsageReport[] | null;
 	fetchedAt: number;
 }
 
@@ -573,6 +579,10 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 			})
 			.catch(error => {
 				logger.warn("auth-broker usage fetch failed", { error: String(error) });
+				// Documented 15s TTL fallback: cache the null so sequential callers
+				// don't re-hit the broker while it's still down. See
+				// docs/auth-broker-gateway.md § "Client-side single-flight".
+				this.#usageCache = { reports: null, fetchedAt: Date.now() };
 				return null;
 			})
 			.finally(() => {

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -210,6 +210,58 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 		remoteStore.close();
 	});
 
+	test("getUsageReport caches broker fetch failure for USAGE_CACHE_TTL_MS", async () => {
+		const brokerClient = new AuthBrokerClient({ url: handle!.url, token });
+		const remoteStore = new RemoteAuthCredentialStore({
+			client: brokerClient,
+			initialSnapshot: {
+				generation: 0,
+				generatedAt: 0,
+				serverNowMs: 0,
+				refresher: { enabled: false, intervalMs: 0, skewMs: 0, nextSweepInMs: Number.MAX_SAFE_INTEGER },
+				credentials: [],
+			},
+		});
+
+		const fetchSpy = vi
+			.spyOn(brokerClient, "fetchUsage")
+			.mockRejectedValue(new Error("broker offline"));
+
+		const nowSpy = vi.spyOn(Date, "now");
+		nowSpy.mockReturnValue(1_000_000);
+
+		// First sequential failure caches null.
+		const first = await remoteStore.fetchUsageReports();
+		expect(first).toBeNull();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		// Second call within 15s TTL is served from the cached null — no new fetch.
+		nowSpy.mockReturnValue(1_000_000 + 14_999);
+		const second = await remoteStore.fetchUsageReports();
+		expect(second).toBeNull();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		// getUsageReport shares the same negative cache.
+		const cred = {
+			type: "oauth" as const,
+			access: "ax",
+			refresh: REMOTE_REFRESH_SENTINEL,
+			expires: Date.now() + 60_000,
+			email: "a@example.com",
+		};
+		const perCred = await remoteStore.getUsageReport("anthropic", cred);
+		expect(perCred).toBeNull();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+		// After the documented 15s TTL expires, the client retries once and hits the broker again.
+		nowSpy.mockReturnValue(1_000_000 + 15_000 + 1);
+		const retried = await remoteStore.fetchUsageReports();
+		expect(retried).toBeNull();
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+		remoteStore.close();
+	});
+
 	test("client AuthStorage.set forwards api_key login to the broker (replace semantics)", async () => {
 		// Pre-existing api_key for the same provider on the server side — a fresh
 		// login should disable it and replace it with the new key.

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -223,9 +223,7 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 			},
 		});
 
-		const fetchSpy = vi
-			.spyOn(brokerClient, "fetchUsage")
-			.mockRejectedValue(new Error("broker offline"));
+		const fetchSpy = vi.spyOn(brokerClient, "fetchUsage").mockRejectedValue(new Error("broker offline"));
 
 		const nowSpy = vi.spyOn(Date, "now");
 		nowSpy.mockReturnValue(1_000_000);


### PR DESCRIPTION
## Repro

`RemoteAuthCredentialStore.fetchUsageReports()` is documented to coalesce concurrent callers into one `GET /v1/usage` and cache the result for 15s — including the null returned on fetch failure, so ranking passes during a transient broker outage don't storm the broker. In practice, sequential callers after a failure immediately re-hit the broker.

Regression test in `packages/ai/test/remote-auth-store.test.ts`:

```
bun test packages/ai/test/remote-auth-store.test.ts -t "caches broker fetch failure"
```

On `main` the second `fetchUsageReports()` call inside the 15s window drives `fetchSpy` to 2 instead of 1.

## Cause

`#loadUsageReports()` in `packages/ai/src/auth-broker/remote-store.ts:562-581` only writes `#usageCache` from the success `.then`. The `.catch` logs the error and returns `null` without recording anything, and the `.finally` clears `#usageInflight`, so the next sequential caller sees no cache and no in-flight promise and starts a fresh `client.fetchUsage()`. The docs at `docs/auth-broker-gateway.md:133-139` describe the fallback as "the client absorbs transient broker outages by suppressing the error, returning `null` to ranking, and re-attempting after the 15s window" — the "after the 15s window" half was never implemented.

## Fix

- `UsageCacheEntry.reports` widens to `UsageReport[] | null`; the field's doc-comment names the failure semantics so the cache write in the `.catch` isn't a surprise for the next reader.
- `#loadUsageReports()` writes `{ reports: null, fetchedAt: Date.now() }` in the `.catch` before returning `null`. The existing `Date.now() - cached.fetchedAt < USAGE_CACHE_TTL_MS` check now serves both positive and negative results with the same TTL, so single-flight coalescing and successful caching are unchanged.
- Changelog note under `packages/ai/CHANGELOG.md` `[Unreleased] › Fixed`.

## Verification

```
bun test packages/ai/test/remote-auth-store.test.ts
# 7 pass, 0 fail, 32 expect() calls
```

New test `getUsageReport caches broker fetch failure for USAGE_CACHE_TTL_MS` covers: rejected `fetchUsage()` → first call returns `null` (1 fetch), second call inside TTL returns `null` (still 1 fetch), `getUsageReport` shares the negative cache (still 1 fetch), advance `Date.now()` past 15s → retry fires the broker again (2 fetches). Existing `getUsageReport coalesces parallel callers and matches by identity` still passes, confirming positive-path caching and coalescing are untouched.

Fixes #4045