### PR TITLE
fix(agent): add retry path diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added retry-path diagnostics for assistant-tail removal and scheduled continuations after transient provider errors ([#4070](https://github.com/can1357/oh-my-pi/issues/4070)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1272,6 +1272,38 @@ type MessageEndPersistenceSlot = {
 	release: () => void;
 };
 
+type PostPromptSkipReason = "aborted" | "stale-generation";
+
+type AgentContinueSkipReason =
+	| PostPromptSkipReason
+	| "session-unavailable"
+	| "should-continue-false"
+	| "post-restore-unavailable";
+
+type ScheduledAgentContinueOptions = {
+	delayMs?: number;
+	generation?: number;
+	shouldContinue?: () => boolean;
+	onSkip?: (reason: AgentContinueSkipReason) => void;
+	onError?: () => void;
+};
+
+type AssistantContextRemovalResult = {
+	reason: string;
+	removed: boolean;
+	beforeLength: number;
+	afterLength: number;
+	lastRole: AgentMessage["role"] | undefined;
+	candidateTimestamp: number;
+	lastTimestamp: number | undefined;
+	candidateProvider: string;
+	lastProvider: string | undefined;
+	candidateModel: string;
+	lastModel: string | undefined;
+	candidateStopReason: AssistantMessage["stopReason"];
+	lastStopReason: AssistantMessage["stopReason"] | undefined;
+};
+
 const REPLAN_TITLE_CONTEXT_TURN_LIMIT = 6;
 
 type SessionTitleSource = "auto" | "user";
@@ -3624,7 +3656,7 @@ export class AgentSession {
 
 	#schedulePostPromptTask(
 		task: (signal: AbortSignal) => Promise<void>,
-		options?: { delayMs?: number; generation?: number; onSkip?: () => void },
+		options?: { delayMs?: number; generation?: number; onSkip?: (reason: PostPromptSkipReason) => void },
 	): void {
 		const delayMs = options?.delayMs ?? 0;
 		const signal = this.#postPromptTasksAbortController.signal;
@@ -3637,11 +3669,11 @@ export class AgentSession {
 				}
 			}
 			if (signal.aborted) {
-				options?.onSkip?.();
+				options?.onSkip?.("aborted");
 				return;
 			}
 			if (options?.generation !== undefined && this.#promptGeneration !== options.generation) {
-				options.onSkip?.();
+				options.onSkip?.("stale-generation");
 				return;
 			}
 			await task(signal);
@@ -3649,13 +3681,35 @@ export class AgentSession {
 		this.#trackPostPromptTask(scheduled);
 	}
 
-	#scheduleAgentContinue(options?: {
-		delayMs?: number;
-		generation?: number;
-		shouldContinue?: () => boolean;
-		onSkip?: () => void;
-		onError?: () => void;
-	}): void {
+	#agentContinueState(options: ScheduledAgentContinueOptions | undefined, signal: AbortSignal | undefined) {
+		const messages = this.agent.state.messages;
+		return {
+			signalAborted: signal?.aborted === true,
+			disposed: this.#isDisposed,
+			compacting: this.isCompacting,
+			handoff: this.isGeneratingHandoff,
+			generation: this.#promptGeneration,
+			expectedGeneration: options?.generation,
+			messageCount: messages.length,
+			lastRole: messages.at(-1)?.role,
+			steeringQueueLength: this.agent.peekSteeringQueue().length,
+			followUpQueueLength: this.agent.peekFollowUpQueue().length,
+		};
+	}
+
+	#skipAgentContinue(
+		reason: AgentContinueSkipReason,
+		options: ScheduledAgentContinueOptions | undefined,
+		signal: AbortSignal | undefined,
+	): void {
+		logger.debug("agent.continue skipped after scheduling", {
+			reason,
+			...this.#agentContinueState(options, signal),
+		});
+		options?.onSkip?.(reason);
+	}
+
+	#scheduleAgentContinue(options?: ScheduledAgentContinueOptions): void {
 		this.#schedulePostPromptTask(
 			async signal => {
 				// Defense in depth: if compaction/handoff slipped onto the post-prompt queue
@@ -3664,25 +3718,28 @@ export class AgentSession {
 				// reset. The first-class fix is in #checkCompaction/the agent_end handler,
 				// but this guard catches anything that bypasses that path.
 				if (signal.aborted || this.#isDisposed || this.isCompacting || this.isGeneratingHandoff) {
-					options?.onSkip?.();
+					this.#skipAgentContinue("session-unavailable", options, signal);
 					return;
 				}
 				if (options?.shouldContinue && !options.shouldContinue()) {
-					options?.onSkip?.();
+					this.#skipAgentContinue("should-continue-false", options, signal);
 					return;
 				}
 				this.#beginInFlight();
 				try {
 					await this.#maybeRestoreRetryFallbackPrimary();
 					if (signal.aborted || this.#isDisposed) {
-						options?.onSkip?.();
+						this.#skipAgentContinue("post-restore-unavailable", options, signal);
 						return;
 					}
+					logger.debug("agent.continue starting after scheduling", this.#agentContinueState(options, signal));
 					await this.agent.continue();
 				} catch (error) {
 					logger.warn("agent.continue failed after scheduling", {
 						error: error instanceof Error ? error.message : String(error),
+						stack: error instanceof Error ? error.stack : undefined,
 					});
+					logger.debug("agent.continue failed state after scheduling", this.#agentContinueState(options, signal));
 					options?.onError?.();
 				} finally {
 					this.#endInFlight();
@@ -3691,7 +3748,7 @@ export class AgentSession {
 			{
 				delayMs: options?.delayMs,
 				generation: options?.generation,
-				onSkip: options?.onSkip,
+				onSkip: reason => this.#skipAgentContinue(reason, options, undefined),
 			},
 		);
 	}
@@ -9957,15 +10014,35 @@ export class AgentSession {
 		});
 	}
 
-	#removeAssistantMessageFromActiveContext(assistantMessage: AssistantMessage): void {
+	#removeAssistantMessageFromActiveContext(
+		assistantMessage: AssistantMessage,
+		reason = "assistant-context-cleanup",
+	): AssistantContextRemovalResult {
 		const messages = this.agent.state.messages;
+		const beforeLength = messages.length;
 		const lastMessage = messages[messages.length - 1];
-		if (
-			lastMessage?.role === "assistant" &&
-			this.#isSameAssistantMessage(lastMessage as AssistantMessage, assistantMessage)
-		) {
+		const lastAssistant: AssistantMessage | undefined = lastMessage?.role === "assistant" ? lastMessage : undefined;
+		const removed = lastAssistant !== undefined && this.#isSameAssistantMessage(lastAssistant, assistantMessage);
+		if (removed) {
 			this.agent.replaceMessages(messages.slice(0, -1));
 		}
+		const result: AssistantContextRemovalResult = {
+			reason,
+			removed,
+			beforeLength,
+			afterLength: this.agent.state.messages.length,
+			lastRole: lastMessage?.role,
+			candidateTimestamp: assistantMessage.timestamp,
+			lastTimestamp: lastAssistant?.timestamp,
+			candidateProvider: assistantMessage.provider,
+			lastProvider: lastAssistant?.provider,
+			candidateModel: assistantMessage.model,
+			lastModel: lastAssistant?.model,
+			candidateStopReason: assistantMessage.stopReason,
+			lastStopReason: lastAssistant?.stopReason,
+		};
+		logger.debug("agent active context assistant removal", result);
+		return result;
 	}
 
 	/**
@@ -12662,7 +12739,7 @@ export class AgentSession {
 		});
 
 		// Remove the failed assistant message from active context before retrying.
-		this.#removeAssistantMessageFromActiveContext(message);
+		this.#removeAssistantMessageFromActiveContext(message, "auto-retry");
 
 		// A thinking/response loop retried into identical context loops again. Inject a
 		// hidden redirect so the retried turn sees a directive to break the repeated

--- a/packages/coding-agent/test/agent-session-retry-diagnostics.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-diagnostics.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { scheduler } from "node:timers/promises";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Api, AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { logger, TempDir } from "@oh-my-pi/pi-utils";
+
+function emptyUsage(): AssistantMessage["usage"] {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function transientErrorStream(model: Model<Api>): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage(),
+			stopReason: "error",
+			errorMessage: "socket closed",
+			errorId: AIError.create(AIError.Flag.Transient),
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "error", reason: "error", error: message });
+	});
+	return stream;
+}
+
+function successStream(model: Model<Api>): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+	queueMicrotask(() => {
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "recovered" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: emptyUsage(),
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		stream.push({ type: "done", reason: "stop", message });
+	});
+	return stream;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await Bun.sleep(1);
+	}
+	throw new Error("Timed out waiting for retry diagnostics");
+}
+
+function isRemovalMissDebugCall(call: unknown[]): boolean {
+	const payload = call[1];
+	return (
+		call[0] === "agent active context assistant removal" &&
+		typeof payload === "object" &&
+		payload !== null &&
+		"removed" in payload &&
+		payload.removed === false
+	);
+}
+
+describe("AgentSession retry diagnostics", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-retry-diagnostics-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		authStorage.close();
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	it("logs the active-context state when retry removal misses the assistant tail", async () => {
+		const model = createMockModel({ provider: "openrouter", id: "glm-test" }).model;
+		const calls: string[] = [];
+		const agent = new Agent({
+			getApiKey: requestedModel => `${requestedModel.provider}-test-key`,
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: requestedModel => {
+				calls.push(`${requestedModel.provider}/${requestedModel.id}`);
+				if (calls.length === 1) return transientErrorStream(requestedModel);
+				return successStream(requestedModel);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.enabled": true,
+			"retry.baseDelayMs": 0,
+			"retry.maxRetries": 1,
+			"retry.modelFallback": false,
+			"todo.enabled": false,
+		});
+		settings.setModelRole("default", `${model.provider}/${model.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		agent.subscribe(event => {
+			if (event.type !== "message_end" || event.message.role !== "assistant") return;
+			if (event.message.stopReason !== "error") return;
+			const messages = agent.state.messages;
+			const last = messages.at(-1);
+			if (last?.role !== "assistant") return;
+			agent.replaceMessages([...messages.slice(0, -1), { ...last, timestamp: last.timestamp + 1 }]);
+		});
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+
+		const promptPromise = session.prompt("trigger transient error").catch(() => undefined);
+		await waitFor(() => debugSpy.mock.calls.some(isRemovalMissDebugCall));
+		await waitFor(() => debugSpy.mock.calls.some(call => call[0] === "agent.continue failed state after scheduling"));
+
+		expect(debugSpy.mock.calls).toContainEqual([
+			"agent active context assistant removal",
+			expect.objectContaining({ reason: "auto-retry", removed: false, lastRole: "assistant" }),
+		]);
+		expect(debugSpy.mock.calls).toContainEqual([
+			"agent.continue failed state after scheduling",
+			expect.objectContaining({ lastRole: "assistant", messageCount: 2 }),
+		]);
+		await session.abort();
+		await promptPromise;
+	});
+});


### PR DESCRIPTION
## Repro
A focused retry test mutates the active assistant tail after `message_end` so the auto-retry candidate no longer matches the current `agent.state.messages` tail, then runs `bun test packages/coding-agent/test/agent-session-retry-diagnostics.test.ts`; before the fix, only `agent_end maintenance routing` was logged and no active-context removal or scheduled-continue state was visible.

## Cause
`packages/coding-agent/src/session/agent-session.ts` removed failed assistant turns inside `#removeAssistantMessageFromActiveContext` and scheduled recovery through `#scheduleAgentContinue`, but both private paths hid their decision state: removal misses returned silently, scheduler skips had no reason, and `agent.continue` failures logged only the error message without the active message-tail state.

## Fix
- Log assistant-tail removal outcomes with before/after message counts and candidate/tail metadata.
- Log scheduled continuation start, skip reason, and failure state, including generation, tail role, queue lengths, and error stack.
- Add a regression test that forces a retry removal miss and asserts both diagnostics are emitted.
- Record the change in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/agent-session-retry-diagnostics.test.ts` passed; `bun test packages/coding-agent/test/agent-session-retry-cap.test.ts` passed; `bun run check:types` passed in `packages/coding-agent`; pre-publish `gh_push_branch` completed its formatter/check gate. Fixes #4070