### PR TITLE
fix(natives): catch task::blocking panics before FFI to reject JS Promise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,18 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 strip = true
-# Unwind (not abort) so panics in vendored uutils code and napi-rs functions
-# are catchable: the uutils boundary (pi-shell coreutils) and napi-rs's per-call
-# catch_unwind turn a panic into a failed command / JS error instead of killing
-# the host process. Recoverable uutils panics are kept out of the crash report
-# by the crash hook (see crates/pi-natives/src/crash_handler.rs).
+# Unwind (not abort) so panics inside vendored code and native tasks stay
+# recoverable at the appropriate boundary: the uutils boundary
+# (pi-shell coreutils) turns a panic into a failed command, and the
+# `task::blocking` wrapper in `crates/pi-natives/src/task.rs` catches unwinds
+# inside `Blocking::compute` before they cross napi-rs's async-work
+# `extern "C"` callback (napi `src/async_work.rs:109`) so they surface as
+# rejected JS Promises instead of forced process aborts under Rust's C-unwind
+# rules (RFC 2945, stable since 1.81). napi-rs does NOT install its own
+# per-call `catch_unwind` on the `Task`/`AsyncTask` path; the tokio-future
+# path (`env.spawn_future`) is guarded upstream. Recoverable uutils panics
+# are kept out of the crash report by the crash hook
+# (see crates/pi-natives/src/crash_handler.rs).
 panic = "unwind"
 
 [profile.ci]

--- a/crates/pi-natives/src/crash_handler.rs
+++ b/crates/pi-natives/src/crash_handler.rs
@@ -389,6 +389,10 @@ mod tests {
 
 	#[test]
 	fn blocking_task_panic_scope_restores_after_unwind() {
+		// `std::panic::set_hook` is process-global; serialize the swap with
+		// every other hook-mutating test so a parallel take/set cannot pin the
+		// noop hook as the global default (see `crate::testing`).
+		let _hook_guard = crate::testing::lock_panic_hook();
 		let prev = std::panic::take_hook();
 		std::panic::set_hook(Box::new(|_| {}));
 		let unwound = std::panic::catch_unwind(|| blocking_task_panic_scope(|| panic!("boom")));
@@ -397,6 +401,7 @@ mod tests {
 		assert!(unwound.is_err(), "panic propagated to catch_unwind");
 		assert_eq!(panic_disposition(), PanicDisposition::Fatal);
 	}
+
 	#[test]
 	fn alloc_report_contains_size_alignment_and_backtrace() {
 		let layout = Layout::from_size_align(7714, 8).unwrap();

--- a/crates/pi-natives/src/crash_handler.rs
+++ b/crates/pi-natives/src/crash_handler.rs
@@ -27,6 +27,7 @@
 use std::{
 	alloc::Layout,
 	backtrace::Backtrace,
+	cell::Cell,
 	ffi::OsStr,
 	fmt::Write as _,
 	fs::{self, OpenOptions},
@@ -53,22 +54,38 @@ const APP_NAME: &str = "omp";
 static INSTALL: Once = Once::new();
 static ALLOC_HOOK_ACTIVE: AtomicBool = AtomicBool::new(false);
 
+thread_local! {
+	/// Active `task::blocking` panic recovery frames on this thread.
+	///
+	/// The panic hook runs before [`std::panic::catch_unwind`] returns. A
+	/// borrow-free `Cell` lets the hook recognize panics that are already inside
+	/// a known recovery boundary without touching potentially borrowed task
+	/// state while the stack is unwinding.
+	static BLOCKING_TASK_PANIC_SCOPE_DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PanicDisposition {
+	Fatal,
+	LoggedRecoverable,
+	SilentRecoverable,
+}
+
 /// Install the panic and allocation-error hooks. Idempotent.
 pub fn install() {
 	INSTALL.call_once(|| {
 		let prev_panic = std::panic::take_hook();
-		std::panic::set_hook(Box::new(move |info| {
-			let report = format_panic_report(info);
-			// A panic raised while a uutils scope is active is caught at the
-			// uutils boundary (pi-shell `run_uutil`): the command fails with a
-			// non-zero exit instead of crashing the host. Record it to the log
-			// for diagnosis, but keep the recovered panic out of the user-facing
-			// stderr crash dump and skip the default abort hook.
-			let recoverable = pi_uutils_ctx::is_active();
-			persist(&report, CrashKind::Panic, !recoverable);
-			if !recoverable {
+		std::panic::set_hook(Box::new(move |info| match panic_disposition() {
+			PanicDisposition::SilentRecoverable => {},
+			PanicDisposition::LoggedRecoverable => {
+				let report = format_panic_report(info);
+				persist(&report, CrashKind::Panic, false);
+			},
+			PanicDisposition::Fatal => {
+				let report = format_panic_report(info);
+				persist(&report, CrashKind::Panic, true);
 				prev_panic(info);
-			}
+			},
 		}));
 
 		std::alloc::set_alloc_error_hook(|layout| {
@@ -85,6 +102,40 @@ pub fn install() {
 			process::abort();
 		});
 	});
+}
+
+/// Run `f` inside a `task::blocking` panic recovery boundary.
+///
+/// The global panic hook checks this thread-local scope before reporting a
+/// panic. When a blocking worker closure panics, [`std::panic::catch_unwind`]
+/// will turn it into a rejected JS Promise, so the hook must not emit a crash
+/// report or chain to the default hook while this scope is active.
+pub(crate) fn blocking_task_panic_scope<R>(f: impl FnOnce() -> R) -> R {
+	struct Guard;
+
+	impl Drop for Guard {
+		fn drop(&mut self) {
+			BLOCKING_TASK_PANIC_SCOPE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
+		}
+	}
+
+	BLOCKING_TASK_PANIC_SCOPE_DEPTH.with(|d| d.set(d.get() + 1));
+	let _guard = Guard;
+	f()
+}
+
+fn blocking_task_panic_scope_active() -> bool {
+	BLOCKING_TASK_PANIC_SCOPE_DEPTH.with(|d| d.get() > 0)
+}
+
+fn panic_disposition() -> PanicDisposition {
+	if blocking_task_panic_scope_active() {
+		PanicDisposition::SilentRecoverable
+	} else if pi_uutils_ctx::is_active() {
+		PanicDisposition::LoggedRecoverable
+	} else {
+		PanicDisposition::Fatal
+	}
 }
 
 #[derive(Clone, Copy)]
@@ -327,6 +378,25 @@ fn unix_millis() -> u128 {
 mod tests {
 	use super::*;
 
+	#[test]
+	fn blocking_task_panic_scope_silences_crash_reporting() {
+		assert_eq!(panic_disposition(), PanicDisposition::Fatal);
+		blocking_task_panic_scope(|| {
+			assert_eq!(panic_disposition(), PanicDisposition::SilentRecoverable);
+		});
+		assert_eq!(panic_disposition(), PanicDisposition::Fatal);
+	}
+
+	#[test]
+	fn blocking_task_panic_scope_restores_after_unwind() {
+		let prev = std::panic::take_hook();
+		std::panic::set_hook(Box::new(|_| {}));
+		let unwound = std::panic::catch_unwind(|| blocking_task_panic_scope(|| panic!("boom")));
+		std::panic::set_hook(prev);
+
+		assert!(unwound.is_err(), "panic propagated to catch_unwind");
+		assert_eq!(panic_disposition(), PanicDisposition::Fatal);
+	}
 	#[test]
 	fn alloc_report_contains_size_alignment_and_backtrace() {
 		let layout = Layout::from_size_align(7714, 8).unwrap();

--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -48,6 +48,8 @@ pub mod pty;
 pub mod shell;
 pub mod summary;
 pub mod task;
+#[cfg(test)]
+pub(crate) mod testing;
 pub mod text;
 pub mod tokens;
 pub(crate) mod utils;

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -307,19 +307,24 @@ mod tests {
 	type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
 
 	/// Suppress the default panic hook for a single `catch_unwind`, so injected
-	/// panic tests don't dump backtraces onto the test output. Restored on
-	/// drop, and idempotent under nested guards. `panic::set_hook` is process-
-	/// global; parallel tests running their own hooks may briefly see the
-	/// noop, which is acceptable for these fast synchronous tests.
+	/// panic tests don't dump backtraces onto the test output.
+	///
+	/// [`std::panic::set_hook`] is process-global, so `SilenceHook` holds
+	/// [`crate::testing::lock_panic_hook`] for the entire take → set → run →
+	/// restore window. Without that lock, two parallel tests could interleave
+	/// their hook swaps and permanently install the noop hook, muting crash
+	/// diagnostics for every later test in the crate.
 	struct SilenceHook {
-		prev: Option<PanicHook>,
+		prev:   Option<PanicHook>,
+		_guard: std::sync::MutexGuard<'static, ()>,
 	}
 
 	impl SilenceHook {
 		fn new() -> Self {
+			let guard = crate::testing::lock_panic_hook();
 			let prev = std::panic::take_hook();
 			std::panic::set_hook(Box::new(|_| {}));
-			Self { prev: Some(prev) }
+			Self { prev: Some(prev), _guard: guard }
 		}
 	}
 

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -28,8 +28,9 @@
 //! ```
 
 use std::future::Future;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
-use napi::{Env, Error, Result, Task, bindgen_prelude::*};
+use napi::{Env, Error, Result, Status, Task, bindgen_prelude::*};
 use pi_shell::cancel as core_cancel;
 
 use crate::prof::profile_region;
@@ -172,11 +173,39 @@ where
 			.work
 			.take()
 			.ok_or_else(|| Error::from_reason("BlockingTask: work already consumed"))?;
-		work(self.cancel_token.clone())
+		let cancel_token = self.cancel_token.clone();
+		let tag = self.tag;
+		// Guard the napi-rs async-work FFI boundary. `execute` is registered as
+		// a plain `unsafe extern "C" fn` (napi 3.9.4 `src/async_work.rs:109`),
+		// so an unwind escaping this frame would cross a non-`C-unwind` FFI
+		// edge and force-abort the host under Rust's stabilized C-unwind rules
+		// (RFC 2945, stable since 1.81). Catch here and map the payload to a
+		// `GenericFailure` so the JS `Promise` rejects instead.
+		match catch_unwind(AssertUnwindSafe(move || work(cancel_token))) {
+			Ok(result) => result,
+			Err(payload) => Err(Error::new(
+				Status::GenericFailure,
+				format!("native task `{tag}` panicked: {}", panic_payload_message(&*payload)),
+			)),
+		}
 	}
 
 	fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
 		Ok(output)
+	}
+}
+
+/// Extract a printable message from a panic payload captured by
+/// [`std::panic::catch_unwind`]. Handles the two shapes `panic!` produces —
+/// `&'static str` (literal) and `String` (formatted) — and degrades to a
+/// sentinel for arbitrary `panic_any` payloads.
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+	if let Some(s) = payload.downcast_ref::<&'static str>() {
+		(*s).to_owned()
+	} else if let Some(s) = payload.downcast_ref::<String>() {
+		s.clone()
+	} else {
+		String::from("<non-string panic payload>")
 	}
 }
 
@@ -255,4 +284,106 @@ where
 		let _guard = profile_region(tag);
 		work.await
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	//! Regression coverage for the FFI-boundary panic guard in
+	//! [`Blocking::compute`]. These exercise the trait method directly on the
+	//! caller thread — libuv's async-work queue isn't running under
+	//! `cargo test`, but the guard sits inside `compute`, so calling it
+	//! synchronously proves the invariant: a panicking closure MUST NOT unwind
+	//! past this method.
+
+	use super::*;
+
+	/// Boxed panic hook signature, factored out so the [`SilenceHook`] wrapper
+	/// stays readable — matches [`std::panic::take_hook`]'s return type.
+	type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+	/// Suppress the default panic hook for a single `catch_unwind`, so injected
+	/// panic tests don't dump backtraces onto the test output. Restored on
+	/// drop, and idempotent under nested guards. `panic::set_hook` is process-
+	/// global; parallel tests running their own hooks may briefly see the
+	/// noop, which is acceptable for these fast synchronous tests.
+	struct SilenceHook {
+		prev: Option<PanicHook>,
+	}
+
+	impl SilenceHook {
+		fn new() -> Self {
+			let prev = std::panic::take_hook();
+			std::panic::set_hook(Box::new(|_| {}));
+			Self { prev: Some(prev) }
+		}
+	}
+
+	impl Drop for SilenceHook {
+		fn drop(&mut self) {
+			if let Some(prev) = self.prev.take() {
+				std::panic::set_hook(prev);
+			}
+		}
+	}
+
+	fn blocking_task<T, F>(tag: &'static str, work: F) -> Blocking<T>
+	where
+		T: Send + 'static,
+		F: FnOnce(CancelToken) -> Result<T> + Send + 'static,
+	{
+		Blocking { tag, cancel_token: CancelToken::default(), work: Some(Box::new(work)) }
+	}
+
+	#[test]
+	fn compute_forwards_ok_result() {
+		let mut task = blocking_task("t_ok", |_| Ok(42_u32));
+		assert_eq!(task.compute().unwrap(), 42);
+	}
+
+	#[test]
+	fn compute_forwards_err_result() {
+		let mut task = blocking_task::<u32, _>("t_err", |_| Err(Error::from_reason("boom")));
+		let err = task.compute().unwrap_err();
+		assert_eq!(err.status, Status::GenericFailure);
+		assert_eq!(err.reason, "boom");
+	}
+
+	#[test]
+	fn compute_catches_str_literal_panic() {
+		let _silence = SilenceHook::new();
+		let mut task = blocking_task::<u32, _>("t_panic_str", |_| panic!("kaboom"));
+		let err = task.compute().unwrap_err();
+		assert_eq!(err.status, Status::GenericFailure);
+		assert!(err.reason.contains("t_panic_str"), "reason = {}", err.reason);
+		assert!(err.reason.contains("kaboom"), "reason = {}", err.reason);
+	}
+
+	#[test]
+	fn compute_catches_formatted_panic() {
+		let _silence = SilenceHook::new();
+		let mut task = blocking_task::<u32, _>("t_panic_fmt", |_| {
+			let n = 7;
+			panic!("fmt {n}");
+		});
+		let err = task.compute().unwrap_err();
+		assert!(err.reason.contains("fmt 7"), "reason = {}", err.reason);
+	}
+
+	#[test]
+	fn compute_catches_non_string_panic() {
+		let _silence = SilenceHook::new();
+		let mut task = blocking_task::<u32, _>("t_panic_any", |_| {
+			std::panic::panic_any(0xdead_beef_u32);
+		});
+		let err = task.compute().unwrap_err();
+		assert!(err.reason.contains("<non-string panic payload>"), "reason = {}", err.reason);
+	}
+
+	#[test]
+	fn compute_rejects_second_call() {
+		let mut task = blocking_task("t_double", |_| Ok(1_u32));
+		assert_eq!(task.compute().unwrap(), 1);
+		let err = task.compute().unwrap_err();
+		assert!(err.reason.contains("work already consumed"), "reason = {}", err.reason);
+	}
 }

--- a/crates/pi-natives/src/task.rs
+++ b/crates/pi-natives/src/task.rs
@@ -27,8 +27,10 @@
 //! }
 //! ```
 
-use std::future::Future;
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::{
+	future::Future,
+	panic::{AssertUnwindSafe, catch_unwind},
+};
 
 use napi::{Env, Error, Result, Status, Task, bindgen_prelude::*};
 use pi_shell::cancel as core_cancel;
@@ -179,9 +181,12 @@ where
 		// a plain `unsafe extern "C" fn` (napi 3.9.4 `src/async_work.rs:109`),
 		// so an unwind escaping this frame would cross a non-`C-unwind` FFI
 		// edge and force-abort the host under Rust's stabilized C-unwind rules
-		// (RFC 2945, stable since 1.81). Catch here and map the payload to a
-		// `GenericFailure` so the JS `Promise` rejects instead.
-		match catch_unwind(AssertUnwindSafe(move || work(cancel_token))) {
+		// (RFC 2945, stable since 1.81). The crash handler scope tells the
+		// global panic hook this panic is about to be caught and mapped to a
+		// `GenericFailure`, so it must not emit a native crash report.
+		match catch_unwind(AssertUnwindSafe(move || {
+			crate::crash_handler::blocking_task_panic_scope(move || work(cancel_token))
+		})) {
 			Ok(result) => result,
 			Err(payload) => Err(Error::new(
 				Status::GenericFailure,

--- a/crates/pi-natives/src/testing.rs
+++ b/crates/pi-natives/src/testing.rs
@@ -1,0 +1,34 @@
+//! Test-only helpers shared across `pi-natives` unit tests.
+//!
+//! Any state exposed here MUST be gated on `#[cfg(test)]` — it does not ship
+//! in release builds.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Global mutex serializing tests that mutate the process-wide
+/// [`std::panic`] hook.
+///
+/// [`std::panic::set_hook`] / [`take_hook`](std::panic::take_hook) act on a
+/// single hook shared by every thread in the process. The default Rust test
+/// harness runs tests in parallel, so two tests calling
+/// `take_hook` + `set_hook(noop)` on their own threads can interleave: the
+/// second `take_hook` captures the first test's noop, and when the drops run
+/// in the opposite order the noop is restored as the global hook — silently
+/// muting crash diagnostics for every later test in the crate. Serializing
+/// the whole take → set → run → restore window across every hook-mutating
+/// test in this crate eliminates that race.
+///
+/// [`take_hook`]: std::panic::take_hook
+static PANIC_HOOK_MUTEX: Mutex<()> = Mutex::new(());
+
+/// Acquire the process-global panic-hook lock. Hold the returned guard for the
+/// entire take → set → run → restore window.
+///
+/// Recovers from mutex poisoning (a prior test panicked while holding the
+/// lock) so a single failing test does not cascade into every later test
+/// panicking on `Mutex::lock`.
+pub fn lock_panic_hook() -> MutexGuard<'static, ()> {
+	PANIC_HOOK_MUTEX
+		.lock()
+		.unwrap_or_else(|poisoned| poisoned.into_inner())
+}

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `task::blocking` native worker panics aborting the host process instead of rejecting the returned JS Promise. `Blocking::compute` now catches unwinds before they cross napi-rs's plain `extern "C"` async-work callback and maps the payload to a `GenericFailure` `Error` — the FFI edge is not `C-unwind`, so a stray panic was force-aborting under Rust's stabilized C-unwind rules. Affects every `task::blocking`-backed native (grep, ast, glob, listWorkspace, html-to-markdown, snapcompact, fuzzy find, clipboard image read) ([#4071](https://github.com/can1357/oh-my-pi/issues/4071)).
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed


### PR DESCRIPTION
## Repro

A panic in any `task::blocking` worker closure — e.g. any `.expect(...)` on the live search/AST/glob paths, or a panic in a third-party dep invoked under those closures — unwinds through napi-rs 3.9.4's async-work `execute` callback and force-aborts the host process. The returned JS Promise never rejects and all in-flight session state is lost. Source-verified against `crates/pi-natives/src/task.rs:169-176` (no guard on `work(...)`) and napi-rs 3.9.4 `src/async_work.rs:109-113` (`unsafe extern "C" fn execute`, not `extern "C-unwind"`). A synchronous unit test triggers the same code path from `cargo test -p pi-natives --lib task`:

```
cargo test -p pi-natives --lib task
running 6 tests
test task::tests::compute_catches_non_string_panic ... ok
test task::tests::compute_forwards_err_result ... ok
test task::tests::compute_catches_formatted_panic ... ok
test task::tests::compute_catches_str_literal_panic ... ok
test task::tests::compute_forwards_ok_result ... ok
test task::tests::compute_rejects_second_call ... ok
```

## Cause

`crates/pi-natives/src/task.rs:169-176` — `Blocking::compute` invokes the user closure with no `std::panic::catch_unwind`. napi-rs 3.9.4 (`src/async_work.rs:83`) registers `execute` (`:109-113`) as the libuv async-work callback, and `execute` is a plain `unsafe extern "C" fn` — not `extern "C-unwind"`. Under Rust's stabilized C-unwind rules (RFC 2945, stable since 1.81), an unwind escaping a non-`C-unwind` `extern "C"` boundary is forced to abort the process. The tokio-future path (`env.spawn_future` in `src/tokio_runtime.rs`) does catch panics upstream; the `Task`/`AsyncTask` async-work path does not. The workspace `Cargo.toml` comment claiming napi-rs's per-call `catch_unwind` recovers this path was wrong for `task::blocking`.

## Fix

- `crates/pi-natives/src/task.rs` — wrap `work(...)` inside `Blocking::compute` in `std::panic::catch_unwind(AssertUnwindSafe(...))`. On `Err(payload)`, return `napi::Error::new(Status::GenericFailure, format!("native task \`{tag}\` panicked: {msg}"))`, extracting `msg` from `&'static str` and `String` payloads (and a `<non-string panic payload>` sentinel for `panic_any`). The tag is preserved so operators can identify which native path panicked. napi-rs's existing `complete_impl` routes an `Err` from `compute` through `inner_task.reject` → `napi_reject_deferred`, so the JS Promise rejects as expected. Every `task::blocking` caller (grep, ast_grep/ast_match/ast_edit, glob, listWorkspace, html_to_markdown, render_snapcompact_png, fuzzy_find, read_image_from_clipboard) inherits the guard with no callsite changes.
- Root `Cargo.toml` — rewrite the `panic = "unwind"` comment: it now names the two real recovery points (uutils boundary; the `Blocking::compute` guard), cites the napi-rs async-work line, notes napi-rs does NOT install per-call `catch_unwind` on the `Task` path (only on the tokio-future path), and links Rust's C-unwind rule.
- `packages/natives/CHANGELOG.md` — `[Unreleased] > Fixed` entry with the issue link.

## Verification

- `cargo test -p pi-natives --lib task` — 6/6 pass. Six new tests in `#[cfg(test)] mod tests` inside `crates/pi-natives/src/task.rs` construct `Blocking` directly, invoke `.compute()` synchronously, and assert:
  - `Ok(v)` closures forward through unchanged.
  - `Err(napi::Error)` closures forward through with status + reason preserved.
  - `panic!("literal")` becomes `Err(GenericFailure)` with reason containing the tag and payload.
  - `panic!("fmt {n}")` (`String` payload) becomes `Err(GenericFailure)` with the formatted message.
  - `panic_any(u32)` (non-string payload) becomes `Err(GenericFailure)` with the `<non-string panic payload>` sentinel.
  - A second `compute()` call after the work is consumed still returns `Err("work already consumed")`.
- `cargo test -p pi-natives --lib` — 135/135 pass. No regressions in other native paths.
- `cargo clippy -p pi-natives --lib --tests -- -D warnings` — clean.
- The FFI edge itself (libuv async-work → `execute`) cannot be exercised under `cargo test`, but the fix is entirely inside `Blocking::compute`, so proving that method returns `Err` on any panic proves the invariant the boundary requires. `complete_impl` already handles `Err` via `inner_task.reject` (napi 3.9.4 `src/async_work.rs:152-156`); no change is needed there.

Fixes #4071