### PR TITLE
fix(agent): preserve tool results in branch summaries

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed branch summaries to preserve informative tool results from abandoned branches while still dropping useless tool output. ([#4076](https://github.com/can1357/oh-my-pi/issues/4076))
+
 ## [16.2.4] - 2026-06-28
 
 ### Changed

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -168,6 +168,12 @@ export function collectEntriesForBranchSummary(
 function getMessageFromEntry(entry: SessionEntry): AgentMessage | undefined {
 	switch (entry.type) {
 		case "message":
+			// Useless non-error tool results are dropped by serializeConversation()
+			// downstream. Skip them here so a large useless payload can't eat the
+			// branch-summary token budget and starve older useful entries.
+			if (entry.message.role === "toolResult" && entry.message.useless === true && entry.message.isError !== true) {
+				return undefined;
+			}
 			return entry.message;
 
 		case "custom_message":

--- a/packages/agent/src/compaction/branch-summarization.ts
+++ b/packages/agent/src/compaction/branch-summarization.ts
@@ -168,8 +168,6 @@ export function collectEntriesForBranchSummary(
 function getMessageFromEntry(entry: SessionEntry): AgentMessage | undefined {
 	switch (entry.type) {
 		case "message":
-			// Skip tool results - context is in assistant's tool call
-			if (entry.message.role === "toolResult") return undefined;
 			return entry.message;
 
 		case "custom_message":

--- a/packages/agent/test/branch-summarization.test.ts
+++ b/packages/agent/test/branch-summarization.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	type GenerateBranchSummaryOptions,
 	generateBranchSummary,
+	prepareBranchEntries,
 	type SessionEntry,
 } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, Model, Usage } from "@oh-my-pi/pi-ai";
@@ -136,5 +137,57 @@ describe("branch summarization", () => {
 
 		expect(capturedPrompt).toContain("BRANCH_ONLY_FACT_4076=enabled");
 		expect(capturedPrompt).not.toContain("NO_MATCH_SENTINEL_4076");
+	});
+
+	test("useless tool results do not consume the token budget", () => {
+		const uselessBlob = "USELESS_".repeat(4000);
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "user-1",
+				parentId: null,
+				timestamp: new Date(0).toISOString(),
+				message: { role: "user", content: "OLDER_USEFUL_FACT_4076", timestamp: 0 },
+			},
+			{
+				type: "message",
+				id: "assistant-1",
+				parentId: "user-1",
+				timestamp: new Date(1).toISOString(),
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-search", name: "search", arguments: { pattern: "absent" } }],
+					api: "mock",
+					provider: "mock",
+					model: "mock-model",
+					usage: ZERO_USAGE,
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+			},
+			{
+				type: "message",
+				id: "tool-1",
+				parentId: "assistant-1",
+				timestamp: new Date(2).toISOString(),
+				message: {
+					role: "toolResult",
+					toolCallId: "call-search",
+					toolName: "search",
+					content: [{ type: "text", text: uselessBlob }],
+					isError: false,
+					useless: true,
+					timestamp: 2,
+				},
+			},
+		];
+
+		// Budget tight enough that the useless blob alone would blow it out.
+		const { messages } = prepareBranchEntries(entries, 100);
+
+		const userMessages = messages.filter((m): m is Extract<typeof m, { role: "user" }> => m.role === "user");
+		expect(userMessages).toHaveLength(1);
+		expect(userMessages[0].content).toBe("OLDER_USEFUL_FACT_4076");
+		expect(messages.some(m => m.role === "toolResult")).toBe(false);
 	});
 });

--- a/packages/agent/test/branch-summarization.test.ts
+++ b/packages/agent/test/branch-summarization.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type GenerateBranchSummaryOptions,
+	generateBranchSummary,
+	type SessionEntry,
+} from "@oh-my-pi/pi-agent-core/compaction";
+import type { AssistantMessage, Model, Usage } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const MODEL: Model = buildModel({
+	id: "mock-model",
+	name: "mock-model",
+	api: "mock",
+	provider: "mock",
+	baseUrl: "mock://",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 32_768,
+});
+
+const ZERO_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+describe("branch summarization", () => {
+	test("includes informative tool results and drops useless ones", async () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "user-1",
+				parentId: null,
+				timestamp: new Date(0).toISOString(),
+				message: { role: "user", content: "Inspect the branch-only state.", timestamp: 0 },
+			},
+			{
+				type: "message",
+				id: "assistant-1",
+				parentId: "user-1",
+				timestamp: new Date(1).toISOString(),
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-read", name: "read", arguments: { path: "config.txt" } }],
+					api: "mock",
+					provider: "mock",
+					model: "mock-model",
+					usage: ZERO_USAGE,
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+			},
+			{
+				type: "message",
+				id: "tool-1",
+				parentId: "assistant-1",
+				timestamp: new Date(2).toISOString(),
+				message: {
+					role: "toolResult",
+					toolCallId: "call-read",
+					toolName: "read",
+					content: [{ type: "text", text: "BRANCH_ONLY_FACT_4076=enabled" }],
+					isError: false,
+					timestamp: 2,
+				},
+			},
+			{
+				type: "message",
+				id: "assistant-2",
+				parentId: "tool-1",
+				timestamp: new Date(3).toISOString(),
+				message: {
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-search", name: "search", arguments: { pattern: "absent" } }],
+					api: "mock",
+					provider: "mock",
+					model: "mock-model",
+					usage: ZERO_USAGE,
+					stopReason: "toolUse",
+					timestamp: 3,
+				},
+			},
+			{
+				type: "message",
+				id: "tool-2",
+				parentId: "assistant-2",
+				timestamp: new Date(4).toISOString(),
+				message: {
+					role: "toolResult",
+					toolCallId: "call-search",
+					toolName: "search",
+					content: [{ type: "text", text: "NO_MATCH_SENTINEL_4076" }],
+					isError: false,
+					useless: true,
+					timestamp: 4,
+				},
+			},
+		];
+		let capturedPrompt = "";
+		const completeImpl: GenerateBranchSummaryOptions["completeImpl"] = async (_model, ctx) => {
+			const message = ctx.messages[0];
+			if (message?.role !== "user") {
+				throw new Error("branch summary request did not contain a user prompt");
+			}
+			if (typeof message.content === "string") {
+				capturedPrompt = message.content;
+			} else {
+				for (const block of message.content) {
+					if (block.type === "text") capturedPrompt += block.text;
+				}
+			}
+			const response: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "branch summary text" }],
+				api: "mock",
+				provider: "mock",
+				model: "mock-model",
+				usage: ZERO_USAGE,
+				stopReason: "stop",
+				timestamp: 5,
+			};
+			return response;
+		};
+
+		await generateBranchSummary(entries, {
+			model: MODEL,
+			apiKey: "test-api-key",
+			signal: new AbortController().signal,
+			completeImpl,
+		});
+
+		expect(capturedPrompt).toContain("BRANCH_ONLY_FACT_4076=enabled");
+		expect(capturedPrompt).not.toContain("NO_MATCH_SENTINEL_4076");
+	});
+});


### PR DESCRIPTION
## Repro
`bun test packages/agent/test/branch-summarization.test.ts` failed before the fix because the captured branch-summary prompt contained the assistant `read`/`search` tool calls but omitted the only occurrence of `BRANCH_ONLY_FACT_4076=enabled` from the `toolResult` message.

## Cause
`packages/agent/src/compaction/branch-summarization.ts` dropped every `message.role === "toolResult"` in `getMessageFromEntry()`, so `prepareBranchEntries()` never forwarded tool observations to `generateBranchSummary()` for conversion and `serializeConversation()`.

## Fix
- Keep `toolResult` session entries in branch-summary preparation so serialized branch transcripts include real tool observations.
- Added regression coverage for an abandoned branch where a fact exists only in a tool result.
- Covered the existing useless-result pruning path by asserting a useless tool result stays out of the branch-summary prompt.
- Added the agent changelog entry.

## Verification
`bun test packages/agent/test/branch-summarization.test.ts packages/agent/test/serialize-conversation.test.ts` passed: 5 tests, 14 assertions. `bun run check` passed in `packages/agent`. Pre-publish `gh_push_branch` gate passed. Fixes #4076