### PR TITLE
fix(hashline): guarded against 16-bit snapshot tag collisions

### DIFF
--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hashline patcher accepting a 16-bit snapshot tag collision as an exact live match, applying line-anchored edits directly to unrelated live content. The store now retains two distinct texts that collide on the 4-hex tag as separate versions, and the patcher requires the stored snapshot's full text to match the live text before taking the no-drift path. ([#4075](https://github.com/can1357/oh-my-pi/issues/4075))
+
 ## [16.2.8] - 2026-06-30
 
 ### Fixed

--- a/packages/hashline/src/patcher.ts
+++ b/packages/hashline/src/patcher.ts
@@ -38,7 +38,7 @@ import {
 import { MismatchError } from "./mismatch";
 import { detectLineEnding, type LineEnding, normalizeToLF, restoreLineEndings, stripBom } from "./normalize";
 import { Recovery, type RecoveryResult } from "./recovery";
-import type { SnapshotStore } from "./snapshots";
+import type { Snapshot, SnapshotStore } from "./snapshots";
 import type { ApplyResult, BlockResolution, BlockResolver, Edit, FileOp } from "./types";
 
 export interface PatcherOptions {
@@ -480,14 +480,15 @@ export class Patcher {
 
 	/**
 	 * Reject an anchored edit that references a line the read which minted
-	 * `expected` never displayed. The snapshot's `seenLines` is the set of
-	 * 1-indexed lines a producer (read/search) actually showed under that tag;
-	 * absent or empty means no provenance was recorded, so the edit applies as
-	 * before. Only runs on the no-drift path, where anchor line numbers index
-	 * the tagged content 1:1.
+	 * `expected` never displayed. `matchedSnapshot` is the store version whose
+	 * text equals the live normalized content — the exact snapshot the model
+	 * anchored against. Absent means no provenance was recorded (the tag was
+	 * externally minted or aged out), so the edit applies as before. Only runs
+	 * on the no-drift path, where anchor line numbers index the tagged content
+	 * 1:1.
 	 */
-	#assertSeenLines(section: PatchSection, canonicalPath: string, expected: string): void {
-		const seen = this.snapshots.byHash(canonicalPath, expected)?.seenLines;
+	#assertSeenLines(section: PatchSection, expected: string, matchedSnapshot: Snapshot | null): void {
+		const seen = matchedSnapshot?.seenLines;
 		if (!seen || seen.size === 0) return;
 		const unseen = section.collectAnchorLines().filter(line => !seen.has(line));
 		if (unseen.length === 0) return;
@@ -520,7 +521,17 @@ export class Patcher {
 	}): ApplyResult {
 		const { section, canonicalPath, exists, normalized, edits } = args;
 		const expected = exists ? section.fileHash : undefined;
-		const liveMatches = expected !== undefined && computeFileHash(normalized) === expected;
+		// A 16-bit tag can collide across two different file states, so equality
+		// on `computeFileHash(normalized) === expected` alone is not enough to
+		// prove the live text IS the snapshot the tag names. Also require that,
+		// when a snapshot for `(path, expected)` is retained, its stored text
+		// matches the live text. Otherwise the tag collides and we route through
+		// recovery/mismatch instead of applying line-anchored edits to unrelated
+		// live content (issue #4075).
+		const hashMatches = expected !== undefined && computeFileHash(normalized) === expected;
+		const matchedSnapshot = hashMatches ? this.snapshots.byContent(canonicalPath, normalized) : null;
+		const anyStoredForTag = hashMatches ? this.snapshots.byHash(canonicalPath, expected as string) : null;
+		const liveMatches = hashMatches && (anyStoredForTag === null || matchedSnapshot !== null);
 
 		// Resolve `replace_block N:` edits to concrete ranges before recovery
 		// runs. Block anchors are expressed against the snapshot the section tag
@@ -559,7 +570,7 @@ export class Patcher {
 			// The line numbers in `edits` index the exact content the tag names.
 			// Reject any anchor the read never displayed: editing lines the model
 			// has not seen is the off-by-memory mistake that mangles files.
-			if (expected !== undefined) this.#assertSeenLines(section, canonicalPath, expected);
+			if (expected !== undefined) this.#assertSeenLines(section, expected, matchedSnapshot);
 			const result = applyEdits(normalized, resolved);
 			return withResolveWarnings(blockResolutions.length > 0 ? { ...result, blockResolutions } : result);
 		}

--- a/packages/hashline/src/snapshots.ts
+++ b/packages/hashline/src/snapshots.ts
@@ -56,8 +56,22 @@ export abstract class SnapshotStore {
 	/** Most-recently recorded version for `path`, or `null` if none. */
 	abstract head(path: string): Snapshot | null;
 
-	/** Recorded version for `path` whose tag equals `hash`, or `null`. */
+	/**
+	 * Recorded version for `path` whose tag equals `hash`, or `null`. When two
+	 * distinct texts collide on the 16-bit tag, returns the most-recently
+	 * recorded one; callers that need the exact content must verify
+	 * {@link Snapshot.text} against the live text (or use {@link byContent}).
+	 */
 	abstract byHash(path: string, hash: string): Snapshot | null;
+
+	/**
+	 * Recorded version for `path` whose {@link Snapshot.text} equals `fullText`,
+	 * or `null`. Disambiguates hash collisions where two distinct file states
+	 * share the same 4-hex tag: the patcher consults this before taking the
+	 * no-drift path so a colliding live text is never accepted as the exact
+	 * snapshot the model's line anchors were minted against.
+	 */
+	abstract byContent(path: string, fullText: string): Snapshot | null;
 
 	/**
 	 * Every retained version whose tag equals `hash`, across all tracked
@@ -133,7 +147,10 @@ export interface InMemorySnapshotStoreOptions {
  *
  * Recording byte-identical content again refreshes recency and reuses the
  * existing tag (read fusion); recording new content unshifts a fresh version
- * onto the front of the path history.
+ * onto the front of the path history. Two distinct texts that collide on the
+ * short 4-hex tag are retained as separate versions so callers can still tell
+ * them apart via {@link Snapshot.text} — the tag is only a fast index, never
+ * the identity.
  */
 export class InMemorySnapshotStore extends SnapshotStore {
 	readonly #versions: LRUCache<string, Snapshot[]>;
@@ -162,6 +179,11 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		return history?.find(version => version.hash === hash) ?? null;
 	}
 
+	byContent(path: string, fullText: string): Snapshot | null {
+		const history = this.#versions.get(path);
+		return history?.find(version => version.text === fullText) ?? null;
+	}
+
 	findByHash(hash: string): Snapshot[] {
 		const matches: Snapshot[] = [];
 		for (const history of this.#versions.values()) {
@@ -176,7 +198,13 @@ export class InMemorySnapshotStore extends SnapshotStore {
 		const hash = computeFileHash(fullText);
 		// `get` refreshes LRU recency for `path`.
 		const history = this.#versions.get(path) ?? [];
-		const existing = history.find(version => version.hash === hash);
+		// Dedup requires full-text equality, not just tag equality: two distinct
+		// texts that happen to share the 4-hex tag are DIFFERENT snapshots — fusing
+		// them under one entry would corrupt seenLines (attaching lines from
+		// text B onto the stored text A) and let the patcher misresolve which
+		// snapshot the section tag names when it does 3-way merge or seen-line
+		// validation. See issue #4075.
+		const existing = history.find(version => version.hash === hash && version.text === fullText);
 		if (existing) {
 			// Same content state observed again: refresh recency and promote to
 			// head (it is the current file content), then reuse the tag. Union any

--- a/packages/hashline/test/patcher.test.ts
+++ b/packages/hashline/test/patcher.test.ts
@@ -126,6 +126,38 @@ describe("Patcher snapshot tag integrity", () => {
 		}
 		expect(fs.get(PATH)).toBe("current\n");
 	});
+
+	// A 16-bit snapshot tag can collide across two different file states.
+	// When the model authored line-anchored edits against snapshot A but the
+	// live file is a colliding text B, `computeFileHash` alone cannot tell them
+	// apart. The patcher must NOT take the no-drift path against B: it either
+	// recovers against the stored A (3-way merge) or rejects as stale.
+	// Regression for issue #4075.
+	it("refuses to accept a colliding live text as the tagged snapshot", async () => {
+		// These two texts both hash to `1D84`.
+		const SNAPSHOT_TEXT = "line one 263\nline two 4471\n";
+		const LIVE_TEXT = "line one 410\nline two 6970\n";
+		expect(computeFileHash(SNAPSHOT_TEXT)).toBe(computeFileHash(LIVE_TEXT));
+
+		const fs = new InMemoryFilesystem([[PATH, LIVE_TEXT]]);
+		const snapshots = new InMemorySnapshotStore();
+		// Tag was minted from SNAPSHOT_TEXT; live is the colliding LIVE_TEXT.
+		const tag = snapshots.record(PATH, SNAPSHOT_TEXT, [1, 2]);
+
+		const patcher = new Patcher({ fs, snapshots });
+		try {
+			await patcher.apply(Patch.parse(`[${PATH}#${tag}]\nSWAP 2.=2:\n+edited from snapshot`));
+			throw new Error("expected MismatchError");
+		} catch (error) {
+			expect(error).toBeInstanceOf(MismatchError);
+			const message = (error as MismatchError).displayMessage;
+			// The tag IS a known snapshot, so we land on the drift branch.
+			expect(message).toMatch(/file changed between read and edit/);
+		}
+		// Live file untouched: line 2 must NOT have been overwritten with the
+		// model's edit anchored against the collider.
+		expect(fs.get(PATH)).toBe(LIVE_TEXT);
+	});
 });
 
 describe("Patcher mandatory snapshot tag policy", () => {

--- a/packages/hashline/test/snapshots.test.ts
+++ b/packages/hashline/test/snapshots.test.ts
@@ -109,4 +109,47 @@ describe("InMemorySnapshotStore", () => {
 		// A tag no retained version carries yields no matches.
 		expect(store.findByHash(tag === "0000" ? "FFFF" : "0000")).toEqual([]);
 	});
+
+	// 4-hex tags are the low 16 bits of a non-cryptographic hash, so two
+	// genuinely different file states can collide (birthday collisions at
+	// ~256 distinct texts). The store must retain them as DISTINCT versions
+	// so downstream tag→text lookups can still tell them apart. Regression
+	// for issue #4075.
+	describe("hash collisions", () => {
+		// These two texts both hash to `1D84` under `computeFileHash`.
+		const COLLIDE_A = "line one 263\nline two 4471\n";
+		const COLLIDE_B = "line one 410\nline two 6970\n";
+
+		it("keeps two colliding texts as separate versions with separate seenLines", () => {
+			expect(computeFileHash(COLLIDE_A)).toBe(computeFileHash(COLLIDE_B));
+
+			const store = new InMemorySnapshotStore();
+			const tagA = store.record(PATH, COLLIDE_A, [1]);
+			const tagB = store.record(PATH, COLLIDE_B, [2]);
+			expect(tagA).toBe(tagB);
+
+			// The two texts must round-trip independently via byContent.
+			expect(store.byContent(PATH, COLLIDE_A)?.text).toBe(COLLIDE_A);
+			expect(store.byContent(PATH, COLLIDE_B)?.text).toBe(COLLIDE_B);
+			// seenLines never cross-contaminate: the [1] and [2] reads stay on
+			// their own snapshots even though both tags say `1D84`.
+			expect(store.byContent(PATH, COLLIDE_A)?.seenLines).toEqual(new Set([1]));
+			expect(store.byContent(PATH, COLLIDE_B)?.seenLines).toEqual(new Set([2]));
+			// byHash surfaces the most-recently-recorded version among the
+			// colliders (B was recorded second → head).
+			expect(store.byHash(PATH, tagA)?.text).toBe(COLLIDE_B);
+			expect(store.head(PATH)?.text).toBe(COLLIDE_B);
+		});
+
+		it("still fuses identical repeated reads of one colliding text onto one snapshot", () => {
+			const store = new InMemorySnapshotStore();
+			const first = store.record(PATH, COLLIDE_A, [1]);
+			const again = store.record(PATH, COLLIDE_A, [2]);
+			expect(again).toBe(first);
+			// One snapshot, seenLines union. The collider B is not present, so
+			// byContent(B) is null even though the tag matches.
+			expect(store.byContent(PATH, COLLIDE_A)?.seenLines).toEqual(new Set([1, 2]));
+			expect(store.byContent(PATH, COLLIDE_B)).toBeNull();
+		});
+	});
 });


### PR DESCRIPTION
## Repro

Two distinct file states can share the 4-hex hashline snapshot tag (the low 16 bits of xxHash32). With `A = "line one 263\nline two 4471\n"` and `B = "line one 410\nline two 6970\n"`, `computeFileHash(A) === computeFileHash(B) === "1D84"`. Recording `A` in the snapshot store, writing `B` to disk, then applying `SWAP 2.=2:` under `[PATH#1D84]` rewrites line 2 of the *live* file (`B`) to the model's payload — bypassing stale-snapshot recovery and letting anchored edits land on content the model never read.

```
bun -e "import { computeFileHash, InMemorySnapshotStore, InMemoryFilesystem, Patcher, Patch } \
        from './packages/hashline/src/index.ts'; \
        const A='line one 263\nline two 4471\n'; const B='line one 410\nline two 6970\n'; \
        const s=new InMemorySnapshotStore(); const f=new InMemoryFilesystem(); \
        s.record('/tmp/c.txt', A, [1,2]); f.writeText('/tmp/c.txt', B); \
        await new Patcher({fs:f,snapshots:s}).apply(Patch.parse('[/tmp/c.txt#1D84]\nSWAP 2.=2:\n+edited from v1')); \
        console.log(await f.readText('/tmp/c.txt'));"
# Before fix:  line one 410\nedited from v1\n   (line 2 of B rewritten)
# After fix:   MismatchError, disk untouched
```

## Cause

Two places keyed identity on the 16-bit tag alone:

- `InMemorySnapshotStore.record` in `packages/hashline/src/snapshots.ts` found an existing version by `version.hash === hash` and fused new colliding text onto that entry, merging `seenLines` from the collider into the stored snapshot of unrelated text.
- `Patcher.#applyWithRecovery` in `packages/hashline/src/patcher.ts` computed `liveMatches = computeFileHash(normalized) === expected` and took the no-drift branch (line-anchored `applyEdits` against live content) whenever the short hash agreed. `#assertSeenLines` also read `snapshots.byHash(...)`, so the seen-line guard consulted the collider's snapshot rather than a verified-identical one.

## Fix

- `packages/hashline/src/snapshots.ts`
  - `record` now dedupes by `(hash, text)`. Two distinct texts with the same 4-hex tag are retained as separate versions with independent `seenLines`; identical repeated reads still fuse.
  - Added abstract `SnapshotStore.byContent(path, fullText)` and its `InMemorySnapshotStore` implementation to disambiguate collisions by content.
- `packages/hashline/src/patcher.ts`
  - Gates `liveMatches` on: hash equal AND (no stored snapshot for the tag, OR a stored snapshot with `text === normalized` exists). Collisions fall through to `Recovery.tryRecover`, whose line-precise 3-way merge (fuzz 0) fails cleanly on colliding-but-different content, and the patcher raises the standard `MismatchError`.
  - Passes the resolved matched snapshot into `#assertSeenLines` so the seen-line guard can never read the collider's provenance.
  - Behavior is unchanged when no snapshot is retained for the tag (external mint or aged out).
- Visible 4-hex tag format is preserved — no change to `prompt.md`, in-flight model context stays valid.

## Verification

- `bun --cwd packages/hashline test` — 212 pass, 0 fail (was 209 before). Direct verification of the collision repro through the public API now raises `MismatchError` and leaves the live file untouched.
- `bun check` — passed across all packages.
- `bun --cwd packages/coding-agent test test/core/hashline.test.ts test/core/hashline-loop-guard.test.ts test/edit/seen-line-guard.test.ts` — 32 pass, 0 fail (downstream consumers unaffected).
- Regression tests added:
  - `packages/hashline/test/snapshots.test.ts` — two colliding texts stay as distinct versions with independent `seenLines`, `byContent` round-trips each, identical repeated reads still fuse.
  - `packages/hashline/test/patcher.test.ts` — the reporter's exact `1D84` pair: patcher raises `MismatchError`, live file untouched.

Fixes #4075