### PR TITLE
fix(rpc): dispatch bash concurrently and reset abort controller on restart

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -127,6 +127,13 @@ Important edge behavior from runtime:
 - `{ id?, type: "bash", command: string }`
 - `{ id?, type: "abort_bash" }`
 
+`bash` is dispatched concurrently: the RPC server continues reading commands
+while the shell command runs, so `abort_bash` (or any other command) sent
+during a long-running `bash` is handled without waiting for it to finish on
+its own. The `bash` response is emitted when the command completes; hosts
+correlate it via `id`. Ordering across concurrent commands is not guaranteed
+— clients MUST match responses on `id`, not on emission order.
+
 ### Session
 
 - `{ id?, type: "get_session_stats" }`

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed RPC mode `abort_bash` being queued behind the `bash` command it must cancel; the input loop now dispatches `bash` in the background so `abort_bash` (and other commands) can preempt a running shell command ([#4079](https://github.com/can1357/oh-my-pi/issues/4079)).
+- Fixed `RpcClient.start()` failing on a second call to the same instance after `stop()` (or after a failed first start) by minting a fresh `AbortController` per start and cleaning up the spawned child on startup failure ([#4079](https://github.com/can1357/oh-my-pi/issues/4079)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -225,11 +225,20 @@ export class RpcClient {
 
 	/**
 	 * Start the RPC agent process.
+	 *
+	 * Safe to call again after {@link stop} on the same instance: a fresh
+	 * {@link AbortController} is minted for each start, and any failure after
+	 * the child spawn kills the child and clears internal state so callers may
+	 * retry without leaking processes.
 	 */
 	async start(): Promise<void> {
 		if (this.#process) {
 			throw new Error("Client already started");
 		}
+
+		// Mint a fresh controller so a previous stop()'s abort does not
+		// short-circuit the new stdout reader (issue #4079).
+		this.#abortController = new AbortController();
 
 		const cliPath = this.options.cliPath ?? "dist/cli.js";
 		const args = ["--mode", "rpc"];
@@ -304,6 +313,18 @@ export class RpcClient {
 			if (this.#customTools.length > 0) {
 				await this.setCustomTools(this.#customTools);
 			}
+		} catch (err) {
+			// Startup failed after we spawned the child. Kill it and clear
+			// state so the caller (or a retry via start() again) does not
+			// leak the abandoned process (issue #4079).
+			try {
+				this.#process?.kill();
+			} catch {
+				// best-effort cleanup
+			}
+			this.#abortController.abort();
+			this.#process = null;
+			throw err;
 		} finally {
 			clearTimeout(readyTimeout);
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -12,7 +12,7 @@
  */
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { isZodSchema, zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
-import { $env, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, isRecord, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
@@ -41,8 +41,11 @@ import type {
 	RpcHostToolCallRequest,
 	RpcHostToolCancelRequest,
 	RpcHostToolDefinition,
+	RpcHostToolResult,
+	RpcHostToolUpdate,
 	RpcHostUriCancelRequest,
 	RpcHostUriRequest,
+	RpcHostUriResult,
 	RpcResponse,
 	RpcSessionState,
 	RpcSubagentSubscriptionLevel,
@@ -211,6 +214,97 @@ export function watchAndReportLocalOnlyPromptResult(input: {
 		hasExtensionAgentMessageTask: trackedPrompt.hasAgentMessageTask,
 		waitForExtensionAgentMessageTasks: trackedPrompt.waitForAgentMessageTasks,
 	});
+}
+
+/**
+ * Dependencies for {@link dispatchRpcInputFrame}. Provided by the RPC mode
+ * entrypoint; broken out so tests can drive the input loop with stubs.
+ */
+export interface RpcInputFrameDeps {
+	handleCommand: (command: RpcCommand) => Promise<RpcResponse>;
+	output: RpcOutput;
+	errorResponse: (id: string | undefined, command: string, message: string) => RpcResponse;
+	pendingExtensionRequests: Map<string, PendingExtensionRequest>;
+	onHostToolResult: (frame: RpcHostToolResult) => void;
+	onHostToolUpdate: (frame: RpcHostToolUpdate) => void;
+	onHostUriResult: (frame: RpcHostUriResult) => void;
+}
+
+/**
+ * Structural guard for a well-formed extension UI response frame. Mirrors the
+ * shape declared in {@link RpcExtensionUIResponse} — a truthy record with
+ * `type === "extension_ui_response"` and a string `id`. Payload variants (value,
+ * confirmed, cancelled) are validated at the read site.
+ */
+export function isRpcExtensionUIResponse(value: unknown): value is RpcExtensionUIResponse {
+	if (!isRecord(value)) return false;
+	return value.type === "extension_ui_response" && typeof value.id === "string";
+}
+
+/**
+ * Dispatch a single parsed frame from the RPC input stream.
+ *
+ * Bash commands are dispatched in the background so the caller (the stdin loop
+ * in {@link runRpcMode}) can keep reading subsequent frames while a shell
+ * command is still running. This lets a client send `abort_bash` (or any other
+ * command) while a long-running `bash` is in flight. Response correlation is
+ * preserved via each command's `id`; ordering across concurrent commands is
+ * not guaranteed and clients MUST match on `id`.
+ *
+ * @returns `undefined` when the frame was routed to a side-channel handler
+ *   (extension UI response, host tool/URI frames) or dispatched in the
+ *   background (`bash`). Otherwise a promise that resolves once the response
+ *   for the command has been emitted via `output`. Errors from `handleCommand`
+ *   on non-`bash` commands propagate; the caller is expected to wrap them.
+ */
+export function dispatchRpcInputFrame(parsed: unknown, deps: RpcInputFrameDeps): Promise<void> | undefined {
+	// Side-channel: extension UI responses resolve a pending dialog promise.
+	if (isRpcExtensionUIResponse(parsed)) {
+		const pending = deps.pendingExtensionRequests.get(parsed.id);
+		if (pending) pending.resolve(parsed);
+		return undefined;
+	}
+
+	if (isRpcHostToolResult(parsed)) {
+		deps.onHostToolResult(parsed);
+		return undefined;
+	}
+
+	if (isRpcHostToolUpdate(parsed)) {
+		deps.onHostToolUpdate(parsed);
+		return undefined;
+	}
+
+	if (isRpcHostUriResult(parsed)) {
+		deps.onHostUriResult(parsed);
+		return undefined;
+	}
+
+	// Regular RPC command. The transport contract states each remaining frame
+	// is an {@link RpcCommand}; `handleCommand`'s `default` arm surfaces
+	// unknown discriminants as an error response, so we do not shape-check
+	// the union here.
+	const command = parsed as RpcCommand;
+
+	// `bash` can run for a long time. Dispatch it in the background so a
+	// subsequent `abort_bash` frame can be read and handled without waiting
+	// for the shell command to finish on its own. The response is emitted
+	// when `handleCommand` resolves; clients correlate via `command.id`.
+	if (command.type === "bash") {
+		void (async () => {
+			try {
+				deps.output(await deps.handleCommand(command));
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				deps.output(deps.errorResponse(command.id, "bash", message));
+			}
+		})();
+		return undefined;
+	}
+
+	return (async () => {
+		deps.output(await deps.handleCommand(command));
+	})();
 }
 
 export type RpcSubagentResetRegistry = Pick<RpcSubagentRegistry, "clear">;
@@ -1110,41 +1204,29 @@ export async function runRpcMode(
 		process.exit(0);
 	}
 
-	// Listen for JSON input using Bun's stdin
+	const dispatchFrameDeps: RpcInputFrameDeps = {
+		handleCommand,
+		output,
+		errorResponse: error,
+		pendingExtensionRequests,
+		onHostToolResult: frame => hostToolBridge.handleResult(frame),
+		onHostToolUpdate: frame => hostToolBridge.handleUpdate(frame),
+		onHostUriResult: frame => hostUriBridge.handleResult(frame),
+	};
+
+	// Listen for JSON input using Bun's stdin. Frame dispatch lives in
+	// dispatchRpcInputFrame so it can be exercised directly by tests; see the
+	// helper's docstring for the concurrency contract.
 	for await (const parsed of readJsonl(Bun.stdin.stream())) {
 		try {
-			// Handle extension UI responses
-			if ((parsed as RpcExtensionUIResponse).type === "extension_ui_response") {
-				const response = parsed as RpcExtensionUIResponse;
-				const pending = pendingExtensionRequests.get(response.id);
-				if (pending) {
-					pending.resolve(response);
-				}
-				continue;
+			const awaited = dispatchRpcInputFrame(parsed, dispatchFrameDeps);
+			if (awaited) {
+				await awaited;
+				// Check for deferred shutdown request (idle between commands).
+				// Skipped when a bash command was just dispatched in the
+				// background — shutdown checks run after subsequent frames.
+				await checkShutdownRequested();
 			}
-
-			if (isRpcHostToolResult(parsed)) {
-				hostToolBridge.handleResult(parsed);
-				continue;
-			}
-
-			if (isRpcHostToolUpdate(parsed)) {
-				hostToolBridge.handleUpdate(parsed);
-				continue;
-			}
-
-			if (isRpcHostUriResult(parsed)) {
-				hostUriBridge.handleResult(parsed);
-				continue;
-			}
-
-			// Handle regular commands
-			const command = parsed as RpcCommand;
-			const response = await handleCommand(command);
-			output(response);
-
-			// Check for deferred shutdown request (idle between commands)
-			await checkShutdownRequested();
 		} catch (e: unknown) {
 			const message = e instanceof Error ? e.message : String(e);
 			output(error(undefined, "parse", `Failed to parse command: ${message}`));

--- a/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
+++ b/packages/coding-agent/test/fixtures/mock-rpc-agent.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture: a stand-in for the coding-agent RPC mode.
+ *
+ * Emits the `ready` frame immediately, echoes each inbound command with a
+ * success response, and stays alive until stdin closes or SIGTERM arrives.
+ * Used by rpc-client lifecycle tests that need to exercise start/stop/start
+ * without booting the full agent runtime (which requires provider credentials).
+ */
+import * as readline from "node:readline";
+
+process.stdout.write(`${JSON.stringify({ type: "ready" })}\n`);
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", raw => {
+	if (!raw) return;
+	try {
+		const frame = JSON.parse(raw) as Record<string, unknown>;
+		if (frame && typeof frame === "object" && typeof frame.type === "string") {
+			const id = typeof frame.id === "string" ? frame.id : undefined;
+			process.stdout.write(
+				`${JSON.stringify({
+					id,
+					type: "response",
+					command: frame.type,
+					success: true,
+					data: {},
+				})}\n`,
+			);
+		}
+	} catch {
+		// ignore parse errors — the test harness sends well-formed frames.
+	}
+});
+rl.on("close", () => process.exit(0));

--- a/packages/coding-agent/test/rpc-client.restart.test.ts
+++ b/packages/coding-agent/test/rpc-client.restart.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+
+const MOCK_AGENT = path.join(import.meta.dir, "fixtures", "mock-rpc-agent.ts");
+
+describe("RpcClient lifecycle (issue #4079 B)", () => {
+	test("start() succeeds a second time after stop() on the same instance", async () => {
+		using client = new RpcClient({
+			cliPath: MOCK_AGENT,
+		});
+
+		// First lifecycle: start + stop.
+		await client.start();
+		client.stop();
+
+		// Second start on the same instance must NOT reuse the aborted
+		// controller from the previous stop(). Before the fix, this rejected
+		// with "Agent process exited before ready" because the JSONL reader
+		// short-circuited on the pre-aborted signal.
+		await client.start();
+		client.stop();
+	}, 20000);
+
+	test("start() may be retried after a failed start (child is cleaned up on failure)", async () => {
+		using client = new RpcClient({
+			cliPath: path.join(import.meta.dir, "..", "src", "cli.ts"),
+			cwd: path.join(import.meta.dir, ".."),
+			provider: "__missing_provider__",
+			model: "claude-sonnet-4-5",
+			env: { PI_NO_TITLE: "1" },
+		});
+
+		await expect(client.start()).rejects.toThrow(/Unknown provider.*__missing_provider__/);
+
+		// Before the fix, #process stayed set after the failed spawn so the
+		// second start() rejected with "Client already started". Post-fix,
+		// state is cleared and the second attempt fails with the same
+		// legitimate startup error.
+		await expect(client.start()).rejects.toThrow(/Unknown provider.*__missing_provider__/);
+	}, 30000);
+});

--- a/packages/coding-agent/test/rpc-input-frame.test.ts
+++ b/packages/coding-agent/test/rpc-input-frame.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import {
+	dispatchRpcInputFrame,
+	type PendingExtensionRequest,
+	type RpcInputFrameDeps,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import type { RpcCommand, RpcResponse } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
+
+type OutputFrame = RpcResponse | object;
+
+const makeDeps = (handleCommand: RpcInputFrameDeps["handleCommand"]) => {
+	const outputs: OutputFrame[] = [];
+	const deps: RpcInputFrameDeps = {
+		handleCommand,
+		output: obj => {
+			outputs.push(obj as OutputFrame);
+		},
+		errorResponse: (id, command, message) => ({
+			id,
+			type: "response",
+			command,
+			success: false,
+			error: message,
+		}),
+		pendingExtensionRequests: new Map<string, PendingExtensionRequest>(),
+		onHostToolResult: () => {},
+		onHostToolUpdate: () => {},
+		onHostUriResult: () => {},
+	};
+	return { deps, outputs };
+};
+
+const flushMicrotasks = () => new Promise<void>(resolve => setImmediate(resolve));
+
+const cancelledBashResponse = (id: string): RpcResponse => ({
+	id,
+	type: "response",
+	command: "bash",
+	success: true,
+	data: {
+		output: "",
+		exitCode: -1,
+		cancelled: true,
+		truncated: false,
+		totalLines: 0,
+		totalBytes: 0,
+		outputLines: 0,
+		outputBytes: 0,
+	},
+});
+
+describe("dispatchRpcInputFrame", () => {
+	test("bash is dispatched in the background so abort_bash preempts it (issue #4079 A)", async () => {
+		const { promise: bashPending, resolve: resolveBash } = Promise.withResolvers<RpcResponse>();
+		let abortBashCalled = false;
+
+		const handleCommand = async (command: RpcCommand): Promise<RpcResponse> => {
+			if (command.type === "bash") {
+				// Block until abort_bash resolves the shared promise.
+				return await bashPending;
+			}
+			if (command.type === "abort_bash") {
+				abortBashCalled = true;
+				// Emulate `session.abortBash()` cancelling the in-flight bash so
+				// the queued executeBash promise resolves with cancelled=true.
+				resolveBash(cancelledBashResponse("b1"));
+				return { id: command.id, type: "response", command: "abort_bash", success: true };
+			}
+			throw new Error(`unexpected command type: ${command.type}`);
+		};
+
+		const { deps, outputs } = makeDeps(handleCommand);
+
+		// Kick off bash. If the fix works, dispatchRpcInputFrame returns
+		// undefined immediately without waiting for handleCommand.
+		const bashAwait = dispatchRpcInputFrame({ id: "b1", type: "bash", command: "sleep 9999" }, deps);
+		expect(bashAwait).toBeUndefined();
+		await flushMicrotasks();
+		expect(outputs).toHaveLength(0);
+
+		// Now dispatch abort_bash. It must run serially (not backgrounded)
+		// and resolve after handleCommand completes.
+		const abortAwait = dispatchRpcInputFrame({ id: "a1", type: "abort_bash" }, deps);
+		expect(abortAwait).toBeInstanceOf(Promise);
+		await abortAwait;
+
+		expect(abortBashCalled).toBe(true);
+		expect(outputs[0]).toEqual({
+			id: "a1",
+			type: "response",
+			command: "abort_bash",
+			success: true,
+		});
+
+		// The background bash response arrives after abort_bash.
+		await flushMicrotasks();
+		expect(outputs).toHaveLength(2);
+		const bashFrame = outputs[1] as RpcResponse;
+		expect(bashFrame.command).toBe("bash");
+		expect(bashFrame.success).toBe(true);
+		if (bashFrame.command === "bash" && bashFrame.success) {
+			expect(bashFrame.data.cancelled).toBe(true);
+			expect(bashFrame.data.exitCode).toBe(-1);
+		}
+	});
+
+	test("non-bash commands are dispatched serially (ordering preserved)", async () => {
+		const started: string[] = [];
+		const finished: string[] = [];
+		const handleCommand = async (command: RpcCommand): Promise<RpcResponse> => {
+			started.push(command.type);
+			await Bun.sleep(5);
+			finished.push(command.type);
+			if (command.type === "abort_retry") {
+				return { id: command.id, type: "response", command: "abort_retry", success: true };
+			}
+			if (command.type === "set_auto_retry") {
+				return { id: command.id, type: "response", command: "set_auto_retry", success: true };
+			}
+			throw new Error(`unexpected: ${command.type}`);
+		};
+
+		const { deps, outputs } = makeDeps(handleCommand);
+
+		const first = dispatchRpcInputFrame({ id: "c1", type: "abort_retry" }, deps);
+		expect(first).toBeInstanceOf(Promise);
+		// The input loop awaits each command's promise before pulling the next
+		// frame; simulate that contract by awaiting before the next dispatch.
+		await first;
+		expect(outputs).toHaveLength(1);
+		expect(started).toEqual(["abort_retry"]);
+		expect(finished).toEqual(["abort_retry"]);
+
+		const second = dispatchRpcInputFrame({ id: "c2", type: "set_auto_retry", enabled: true }, deps);
+		await second;
+		expect(outputs).toHaveLength(2);
+		expect(started).toEqual(["abort_retry", "set_auto_retry"]);
+	});
+
+	test("bash handler errors surface as an error response on the background frame", async () => {
+		const handleCommand = async (command: RpcCommand): Promise<RpcResponse> => {
+			if (command.type === "bash") throw new Error("kaboom");
+			throw new Error(`unexpected: ${command.type}`);
+		};
+
+		const { deps, outputs } = makeDeps(handleCommand);
+
+		const awaited = dispatchRpcInputFrame({ id: "b2", type: "bash", command: "echo hi" }, deps);
+		expect(awaited).toBeUndefined();
+
+		// Give the background dispatch a chance to run its catch.
+		await flushMicrotasks();
+		await flushMicrotasks();
+
+		expect(outputs).toHaveLength(1);
+		expect(outputs[0]).toEqual({
+			id: "b2",
+			type: "response",
+			command: "bash",
+			success: false,
+			error: "kaboom",
+		});
+	});
+});


### PR DESCRIPTION
## Repro

Two lifecycle failures in the RPC transport, both source-derived (no live RPC run was executed; conclusions come from the code paths cited by @metaphorics in [#4079](https://github.com/can1357/oh-my-pi/issues/4079)).

- **A. `abort_bash` queued behind `bash`.** RPC mode's stdin loop (`packages/coding-agent/src/modes/rpc/rpc-mode.ts:1113-1148` pre-fix) awaits `handleCommand` on every frame, and `case "bash"` awaits `session.executeBash(...)`. Sending `{"type":"bash","command":"sleep 9999"}` then `{"type":"abort_bash"}` leaves the abort frame unread until the shell command returns on its own — the only RPC command that can trip the bash executor's abort signal is queued behind the operation it must interrupt.
- **B. `RpcClient` restart reuses aborted signal.** `#abortController` is initialized once (`packages/coding-agent/src/modes/rpc/rpc-client.ts:220`). `stop()` aborts it and clears `#process` but never mints a fresh controller (`:315-325`). On the next `start()`, `readJsonl(this.#process.stdout, this.#abortController.signal)` receives a pre-aborted signal; `abortableSource` throws `AbortError` (`packages/utils/src/abortable.ts:26`), `readJsonl` catches and returns (`packages/utils/src/stream.ts:73`), the stdout loop ends with `readySettled === false`, and start rejects with "Agent process exited before ready" while the spawned child leaks in `#process`.

## Cause

Both are the same root defect: the RPC layer's cancellation state is not managed as an independent, resettable control plane. On the server, control commands (`abort_bash`) share the serial data-plane loop with long-running commands (`bash`). On the client, abort state is not refreshed across lifecycle boundaries, and startup failures do not clean up the spawned child.

## Fix

- Extract `dispatchRpcInputFrame(parsed, deps)` from `runRpcMode`; dispatch `bash` in the background (`void (async () => output(await handleCommand(command)))()`) so the input loop keeps reading. Preserve response correlation via `command.id`; all other command types remain serial to keep their existing contracts. The exported helper + `RpcInputFrameDeps` interface lets tests drive the loop directly.
- Add a structural guard `isRpcExtensionUIResponse` and route the extension-response frame through it (replaces an inline `as` read of `.type`).
- Mint a fresh `AbortController` at the top of `RpcClient.start()`; on any startup failure after the child is spawned, kill it, abort the controller, and null `#process` so callers can retry without leaking processes.
- Update `docs/rpc.md`'s `### Bash` section to document the concurrency contract; add CHANGELOG entries.

## Verification

- `bun test packages/coding-agent/test/rpc-input-frame.test.ts packages/coding-agent/test/rpc-client.restart.test.ts packages/coding-agent/test/rpc-client.start.test.ts packages/coding-agent/test/rpc-skill-command.test.ts packages/coding-agent/test/rpc-host-tools.test.ts` → 12/12 pass.
- `bun check` in `packages/coding-agent` → passes.
- New tests:
  - `dispatchRpcInputFrame`: (1) sends bash then abort_bash and asserts the abort_bash response is emitted before the bash response (with the bash resolving as cancelled via a shared promise emulating `session.abortBash`), (2) confirms non-bash commands stay serial, (3) verifies background bash errors surface as error responses.
  - `RpcClient` lifecycle: start → stop → start on the same instance (via a mock fixture agent that just emits `ready`), and retry after a failed spawn (asserts the second call reproduces the same "Unknown provider" error rather than "Client already started").

Fixes #4079