### PR TITLE
fix(tui): preserve unicode fuzzy search terms

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed fuzzy-search filtering for CJK and other non-ASCII queries by preserving Unicode letters and numbers during query normalization ([#4114](https://github.com/can1357/oh-my-pi/issues/4114)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Fixed

--- a/packages/tui/src/fuzzy.ts
+++ b/packages/tui/src/fuzzy.ts
@@ -47,7 +47,7 @@ function normalizeForSearch(value: string): string {
 		.replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
 		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
 		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, " ")
+		.replace(/[^\p{Letter}\p{Mark}\p{Number}]+/gu, " ")
 		.trim()
 		.replace(/\s+/g, " ");
 }

--- a/packages/tui/test/fuzzy.test.ts
+++ b/packages/tui/test/fuzzy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { fuzzyFilter } from "@oh-my-pi/pi-tui/fuzzy";
+import { fuzzyFilter, fuzzyMatch } from "@oh-my-pi/pi-tui/fuzzy";
 
 describe("fuzzyFilter", () => {
 	it("does not satisfy long tokens by scattering letters across unrelated words", () => {
@@ -34,5 +34,12 @@ describe("fuzzyFilter", () => {
 		const items = ["Ollama", "Kagi", "OpenCode Go", "Tavily"];
 
 		expect(fuzzyFilter(items, "og", item => item)).toEqual(["OpenCode Go"]);
+	});
+
+	it("filters CJK queries instead of treating them as match-all", () => {
+		const items = ["文件搜索", "搜索历史", "Settings"];
+
+		expect(fuzzyFilter(items, "搜索", item => item)).toEqual(["搜索历史", "文件搜索"]);
+		expect(fuzzyMatch("搜索", "Settings").matches).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
A Chinese fuzzy query collapsed to an empty normalized query, so `fuzzyFilter(["文件搜索", "搜索历史", "Settings"], "搜索", item => item)` returned all three items and `fuzzyMatch("搜索", "Settings")` returned `matches: true`.

## Cause
`packages/tui/src/fuzzy.ts` normalized search text with `normalizeForSearch()`, which lowercased the input and then replaced every non-ASCII character via `/[^a-z0-9]+/g`. CJK, Cyrillic, Japanese, Korean, and other non-Latin query/text characters were erased before matching, and an erased query triggered `fuzzyMatch()`'s empty-query match-all path.

## Fix
- Preserve Unicode letters, combining marks, and numbers in `normalizeForSearch()` while still treating punctuation and symbols as separators.
- Add a regression test proving a Chinese query filters matching CJK items and rejects an unrelated ASCII item.
- Add a `packages/tui` changelog entry for the fuzzy-search fix.

## Verification
`bun test packages/tui/test/fuzzy.test.ts` passed with 3 tests and 7 assertions. `bun run check` passed in `packages/tui`. The push pre-publish gate also passed before publishing. Fixes #4114