### PR TITLE
fix(shell): bound native bash output bridge

### DIFF
--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -90,36 +90,40 @@ impl From<ShellOptions> for CoreShellOptions {
 #[napi(object)]
 pub struct ShellRunOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:    String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:        Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:        Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
 	pub timeout_ms: Option<u32>,
+	/// Maximum UTF-8 bytes forwarded to `on_chunk` before output is dropped.
+	pub output_stream_byte_limit: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:     Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 }
 
 /// Options for executing a shell command via brush-core.
 #[napi(object)]
 pub struct ShellExecuteOptions<'env> {
 	/// Command string to execute in the shell.
-	pub command:       String,
+	pub command: String,
 	/// Working directory for the command.
-	pub cwd:           Option<String>,
+	pub cwd: Option<String>,
 	/// Environment variables to apply for this command only.
-	pub env:           Option<HashMap<String, String>>,
+	pub env: Option<HashMap<String, String>>,
 	/// Environment variables to apply once per session.
-	pub session_env:   Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
 	/// Timeout in milliseconds before cancelling the command.
-	pub timeout_ms:    Option<u32>,
+	pub timeout_ms: Option<u32>,
 	/// Optional snapshot file to source on session creation.
 	pub snapshot_path: Option<String>,
 	/// Optional per-command output minimizer configuration.
-	pub minimizer:     Option<MinimizerOptions>,
+	pub minimizer: Option<MinimizerOptions>,
+	/// Maximum UTF-8 bytes forwarded to `on_chunk` before output is dropped.
+	pub output_stream_byte_limit: Option<u32>,
 	/// Abort signal for cancelling the operation.
-	pub signal:        Option<Unknown<'env>>,
+	pub signal: Option<Unknown<'env>>,
 }
 
 /// Telemetry for a single minimization.
@@ -217,10 +221,11 @@ impl Shell {
 		let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 		let inner = Arc::clone(&self.inner);
 		let run_options = CoreShellRunOptions {
-			command:    options.command,
-			cwd:        options.cwd,
-			env:        options.env,
+			command: options.command,
+			cwd: options.cwd,
+			env: options.env,
 			timeout_ms: options.timeout_ms,
+			output_stream_byte_limit: output_stream_limit(options.output_stream_byte_limit),
 		};
 		task::future(env, "shell.run", async move {
 			let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
@@ -269,13 +274,14 @@ pub fn execute_shell<'env>(
 ) -> Result<PromiseRaw<'env, ShellRunResult>> {
 	let cancel_token = task::CancelToken::new(options.timeout_ms, options.signal);
 	let exec_options = CoreShellExecuteOptions {
-		command:       options.command,
-		cwd:           options.cwd,
-		env:           options.env,
-		session_env:   options.session_env,
-		timeout_ms:    options.timeout_ms,
+		command: options.command,
+		cwd: options.cwd,
+		env: options.env,
+		session_env: options.session_env,
+		timeout_ms: options.timeout_ms,
 		snapshot_path: options.snapshot_path,
-		minimizer:     options.minimizer.map(Into::into),
+		minimizer: options.minimizer.map(Into::into),
+		output_stream_byte_limit: output_stream_limit(options.output_stream_byte_limit),
 	};
 	task::future(env, "shell.execute", async move {
 		let (chunk_tx, drain_handle) = bridge_chunks(on_chunk);
@@ -290,13 +296,20 @@ pub fn execute_shell<'env>(
 	})
 }
 
+const BRIDGE_CHUNK_QUEUE_CAPACITY: usize = 64;
+
+fn output_stream_limit(limit: Option<u32>) -> Option<usize> {
+	let limit = limit?;
+	Some(usize::try_from(limit).unwrap_or(usize::MAX))
+}
+
 fn bridge_chunks(
 	on_chunk: Option<ThreadsafeFunction<String>>,
 ) -> (Option<flume::Sender<String>>, Option<napi::tokio::task::JoinHandle<()>>) {
 	let Some(on_chunk) = on_chunk else {
 		return (None, None);
 	};
-	let (tx, rx) = flume::unbounded::<String>();
+	let (tx, rx) = flume::bounded::<String>(BRIDGE_CHUNK_QUEUE_CAPACITY);
 	let handle = napi::tokio::spawn(async move {
 		// Hard cap on one coalesced batch so the JS main thread never sees a
 		// multi-MB napi callback (a giant single string would stall sanitize +
@@ -416,10 +429,11 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command:    "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
-						cwd:        None,
-						env:        None,
+						command: "/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 0.5'".to_string(),
+						cwd: None,
+						env: None,
 						timeout_ms: None,
+						output_stream_byte_limit: None,
 					},
 					Some(tx),
 					CancelToken::default(),
@@ -463,10 +477,11 @@ mod tests {
 			shell
 				.run(
 					CoreShellRunOptions {
-						command:    "sh -c 'sleep 30 & wait'".to_string(),
-						cwd:        None,
-						env:        None,
+						command: "sh -c 'sleep 30 & wait'".to_string(),
+						cwd: None,
+						env: None,
 						timeout_ms: None,
+						output_stream_byte_limit: None,
 					},
 					None,
 					cancel,

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -23,6 +23,7 @@ use brush_core::{
 use bytes::Bytes;
 use clap::Parser;
 use flume::Sender;
+use parking_lot::Mutex;
 #[cfg(not(unix))]
 use tokio::io::AsyncReadExt as _;
 use tokio::{sync::Mutex as TokioMutex, time};
@@ -58,6 +59,82 @@ impl ShellAbortState {
 		}
 	}
 }
+const OUTPUT_STREAM_LIMIT_NOTICE: &str = "\n[Output truncated by native shell stream limit]\n";
+
+#[derive(Clone)]
+struct OutputStream {
+	sender: Sender<String>,
+	state:  Arc<Mutex<OutputStreamState>>,
+	limit:  Option<usize>,
+}
+
+#[derive(Default)]
+struct OutputStreamState {
+	forwarded_bytes: usize,
+	closed:          bool,
+}
+
+fn output_stream(
+	sender: Option<Sender<String>>,
+	byte_limit: Option<usize>,
+) -> Option<OutputStream> {
+	let sender = sender?;
+	Some(OutputStream {
+		sender,
+		state: Arc::new(Mutex::new(OutputStreamState::default())),
+		limit: byte_limit,
+	})
+}
+
+impl OutputStream {
+	fn send(&self, text: &str) {
+		if text.is_empty() {
+			return;
+		}
+
+		let mut state = self.state.lock();
+		if state.closed {
+			return;
+		}
+
+		let Some(limit) = self.limit else {
+			let _ = self.sender.try_send(text.to_string());
+			return;
+		};
+
+		let remaining = limit.saturating_sub(state.forwarded_bytes);
+		if remaining == 0 {
+			let _ = self.sender.try_send(OUTPUT_STREAM_LIMIT_NOTICE.to_string());
+			state.closed = true;
+			return;
+		}
+
+		let chunk = truncate_to_utf8_boundary(text, remaining);
+		if chunk.is_empty() {
+			let _ = self.sender.try_send(OUTPUT_STREAM_LIMIT_NOTICE.to_string());
+			state.closed = true;
+			return;
+		}
+
+		state.forwarded_bytes = state.forwarded_bytes.saturating_add(chunk.len());
+		let _ = self.sender.try_send(chunk.to_string());
+		if chunk.len() < text.len() {
+			let _ = self.sender.try_send(OUTPUT_STREAM_LIMIT_NOTICE.to_string());
+			state.closed = true;
+		}
+	}
+}
+
+fn truncate_to_utf8_boundary(text: &str, max_bytes: usize) -> &str {
+	if text.len() <= max_bytes {
+		return text;
+	}
+	let mut end = max_bytes;
+	while end > 0 && !text.is_char_boundary(end) {
+		end -= 1;
+	}
+	&text[..end]
+}
 
 #[derive(Clone)]
 struct ShellConfig {
@@ -82,10 +159,13 @@ struct ShellRunConfig {
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellRunOptions {
-	pub command:    String,
-	pub cwd:        Option<String>,
-	pub env:        Option<HashMap<String, String>>,
+	pub command: String,
+	pub cwd: Option<String>,
+	pub env: Option<HashMap<String, String>>,
 	pub timeout_ms: Option<u32>,
+	/// Maximum UTF-8 bytes forwarded to the streaming callback before output is
+	/// dropped.
+	pub output_stream_byte_limit: Option<usize>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -107,13 +187,16 @@ pub struct ShellRunResult {
 
 #[derive(Debug, Clone, Default)]
 pub struct ShellExecuteOptions {
-	pub command:       String,
-	pub cwd:           Option<String>,
-	pub env:           Option<HashMap<String, String>>,
-	pub session_env:   Option<HashMap<String, String>>,
-	pub timeout_ms:    Option<u32>,
+	pub command: String,
+	pub cwd: Option<String>,
+	pub env: Option<HashMap<String, String>>,
+	pub session_env: Option<HashMap<String, String>>,
+	pub timeout_ms: Option<u32>,
 	pub snapshot_path: Option<String>,
-	pub minimizer:     Option<minimizer::MinimizerOptions>,
+	pub minimizer: Option<minimizer::MinimizerOptions>,
+	/// Maximum UTF-8 bytes forwarded to the streaming callback before output is
+	/// dropped.
+	pub output_stream_byte_limit: Option<usize>,
 }
 
 pub type ShellExecuteResult = ShellRunResult;
@@ -154,6 +237,7 @@ impl Shell {
 		on_chunk: Option<Sender<String>>,
 		mut cancel_token: CancelToken,
 	) -> Result<ShellRunResult> {
+		let stream = output_stream(on_chunk, options.output_stream_byte_limit);
 		let run_config = ShellRunConfig {
 			command:   options.command,
 			cwd:       options.cwd,
@@ -165,7 +249,7 @@ impl Shell {
 			self.abort_state.clone(),
 			self.config.clone(),
 			run_config,
-			on_chunk,
+			stream,
 			&mut cancel_token,
 		)
 		.await
@@ -210,6 +294,7 @@ pub async fn execute_shell(
 	on_chunk: Option<Sender<String>>,
 	cancel_token: CancelToken,
 ) -> Result<ShellExecuteResult> {
+	let stream = output_stream(on_chunk, options.output_stream_byte_limit);
 	let minimizer = options
 		.minimizer
 		.as_ref()
@@ -221,7 +306,7 @@ pub async fn execute_shell(
 	};
 	let run_config =
 		ShellRunConfig { command: options.command, cwd: options.cwd, env: options.env, minimizer };
-	run_shell_oneshot(config, run_config, on_chunk, cancel_token).await
+	run_shell_oneshot(config, run_config, stream, cancel_token).await
 }
 
 /// Optional per-stream raw byte sinks for [`execute_shell_streams`].
@@ -265,7 +350,7 @@ async fn run_shell_session(
 	abort_state: ShellAbortState,
 	config: ShellConfig,
 	run_config: ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	ct: &mut CancelToken,
 ) -> Result<ShellRunResult> {
 	let tokio_cancel = CancellationToken::new();
@@ -351,7 +436,7 @@ async fn run_shell_session(
 async fn run_shell_oneshot(
 	config: ShellConfig,
 	run_config: ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	ct: CancelToken,
 ) -> Result<ShellExecuteResult> {
 	let tokio_cancel = CancellationToken::new();
@@ -757,7 +842,7 @@ impl ChainCapture {
 async fn run_shell_command(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 ) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
@@ -808,7 +893,7 @@ async fn run_shell_command(
 async fn run_shell_command_single(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 	minimizer_mode: minimizer::engine::MinimizerMode,
@@ -891,7 +976,7 @@ async fn run_shell_command_single(
 async fn run_shell_command_segmented_chain(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 ) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
@@ -1033,7 +1118,7 @@ async fn run_shell_command_once(
 	session: &mut ShellSessionCore,
 	mut command: String,
 	mut params: ExecutionParameters,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	cancel_token: CancellationToken,
 	spawn_registry: Arc<process::SpawnRegistry>,
 	capture_mode: CommandCaptureMode,
@@ -1562,7 +1647,7 @@ struct BufferedOutput {
 
 async fn read_output(
 	reader: fs::File,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	cancel_token: CancellationToken,
 	activity: Sender<()>,
 ) {
@@ -1670,7 +1755,7 @@ async fn read_output(
 
 async fn read_output_buffered(
 	reader: fs::File,
-	on_chunk: Option<Sender<String>>,
+	on_chunk: Option<OutputStream>,
 	cancel_token: CancellationToken,
 	activity: Sender<()>,
 	max_capture_bytes: usize,
@@ -1830,9 +1915,9 @@ fn read_nonblocking<T: std::os::fd::AsRawFd>(file: &T, buf: &mut [u8]) -> io::Re
 	}
 }
 
-fn emit_chunk(text: &str, callback: Option<&Sender<String>>) {
+fn emit_chunk(text: &str, callback: Option<&OutputStream>) {
 	if let Some(callback) = callback {
-		let _ = callback.send(text.to_string());
+		callback.send(text);
 	}
 }
 
@@ -3860,6 +3945,59 @@ replace = [{ pattern = "^.+$", replacement = "PWD" }]
 			.await
 			.expect("reader task should stop after cancellation")
 			.expect("reader task should not panic");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn streaming_output_limit_drops_without_blocking_pipe_reader() {
+		let (tx, rx) = flume::bounded::<String>(1);
+		let options = ShellExecuteOptions {
+			command: "yes x | head -c 1048576".to_string(),
+			output_stream_byte_limit: Some(1024),
+			..Default::default()
+		};
+
+		let result = time::timeout(
+			Duration::from_secs(5),
+			execute_shell(options, Some(tx), CancelToken::default()),
+		)
+		.await
+		.expect("streaming output bridge should not block pipe draining")
+		.expect("execute should succeed");
+
+		assert_eq!(result.exit_code, Some(0));
+		assert!(!result.cancelled);
+		assert!(!result.timed_out);
+		assert!(rx.len() <= 1, "bounded callback queue grew past capacity");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn buffered_output_limit_drops_without_blocking_pipe_reader() {
+		let (reader, mut writer) = pipe_to_files("test").expect("test pipe should be created");
+		let (tx, rx) = flume::bounded::<String>(1);
+		let stream = output_stream(Some(tx), Some(1024));
+		let cancel = CancellationToken::new();
+		let (activity_tx, _activity_rx) = flume::bounded(1);
+		let reader_handle =
+			tokio::spawn(read_output_buffered(reader, stream, cancel, activity_tx, 512));
+		let writer_handle = tokio::task::spawn_blocking(move || {
+			let chunk = vec![b'x'; 1024 * 1024];
+			writer.write_all(&chunk).expect("write pipe");
+		});
+
+		time::timeout(Duration::from_secs(5), writer_handle)
+			.await
+			.expect("bounded output stream should not block the pipe writer")
+			.expect("writer task should not panic");
+		let output = time::timeout(Duration::from_secs(5), reader_handle)
+			.await
+			.expect("buffered reader should finish after writer closes")
+			.expect("reader task should not panic");
+
+		assert!(output.exceeded);
+		assert_eq!(output.input_bytes, 1024 * 1024);
+		assert!(rx.len() <= 1, "bounded callback queue grew past capacity");
 	}
 
 	#[cfg(unix)]

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed performance degradation in session context and branch path reconstruction on deep linear histories.
 - Fixed agents repeating the same tool call across turns without corrective steering by wiring the cross-turn tool-call loop guard into sessions.
 - Fixed OpenAI-compatible model discovery (including LM Studio) reporting flat default context windows when proxies omit context length metadata, by resolving discovered IDs against the bundled model reference catalog to inherit accurate context windows, output limits, display names, modalities, and reasoning support.
+- Fixed native bash output streaming to stop forwarding chunks after the tool-result byte budget and to use a bounded native bridge queue, preventing fast producers from growing memory before JS truncation. ([#4078](https://github.com/can1357/oh-my-pi/issues/4078))
 
 ## [16.2.11] - 2026-07-01
 

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -8,7 +8,7 @@ import { ExponentialYield } from "@oh-my-pi/pi-agent-core/utils/yield";
 import { executeShell, type MinimizerOptions, Shell, type ShellRunResult } from "@oh-my-pi/pi-natives";
 import { isExecutable, type ShellConfig } from "@oh-my-pi/pi-utils/procmgr";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
-import { OutputSink } from "../session/streaming-output";
+import { DEFAULT_MAX_BYTES, OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
 import { getOrCreateSnapshot } from "../utils/shell-snapshot";
 import { buildNonInteractiveEnv } from "./non-interactive-env";
@@ -229,12 +229,15 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 			? buildUserShellCommand(shell, args, prefixedCommand)
 			: prefixedCommand;
 
+	const headBytes = resolveOutputSinkHeadBytes(settings);
+	const outputStreamByteLimit = DEFAULT_MAX_BYTES + headBytes;
+
 	// Create output sink for truncation and artifact handling
 	const sink = new OutputSink({
 		onChunk: options?.onChunk,
 		artifactPath: options?.artifactPath,
 		artifactId: options?.artifactId,
-		headBytes: resolveOutputSinkHeadBytes(settings),
+		headBytes,
 		maxColumns: resolveOutputMaxColumns(settings),
 		chunkThrottleMs: options?.onChunk ? (options.chunkThrottleMs ?? 50) : 0,
 	});
@@ -319,6 +322,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 						env: commandEnv,
 						timeoutMs: options?.timeout,
 						signal: runAbortController.signal,
+						outputStreamByteLimit,
 					},
 					(err, chunk) => {
 						if (!err) {
@@ -336,6 +340,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 						minimizer,
 						timeoutMs: options?.timeout,
 						signal: runAbortController.signal,
+						outputStreamByteLimit,
 					},
 					(err, chunk) => {
 						if (!err) {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed shell output streaming to drop after a caller-provided byte limit and to use a bounded native callback bridge queue, preventing fast producers from growing memory before JS truncation. ([#4078](https://github.com/can1357/oh-my-pi/issues/4078))
+
 ## [16.2.11] - 2026-07-01
 
 ### Fixed

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -1394,6 +1394,8 @@ export interface ShellExecuteOptions {
   snapshotPath?: string
   /** Optional per-command output minimizer configuration. */
   minimizer?: MinimizerOptions
+  /** Maximum UTF-8 bytes forwarded to `on_chunk` before output is dropped. */
+  outputStreamByteLimit?: number
   /** Abort signal for cancelling the operation. */
   signal?: unknown
 }
@@ -1418,6 +1420,8 @@ export interface ShellRunOptions {
   env?: Record<string, string>
   /** Timeout in milliseconds before cancelling the command. */
   timeoutMs?: number
+  /** Maximum UTF-8 bytes forwarded to `on_chunk` before output is dropped. */
+  outputStreamByteLimit?: number
   /** Abort signal for cancelling the operation. */
   signal?: unknown
 }


### PR DESCRIPTION
## Repro
The local non-PTY bash path streamed decoded shell chunks into `crates/pi-natives/src/shell.rs::bridge_chunks`, which used `flume::unbounded::<String>()` and forwarded batches to a non-blocking N-API callback before the TypeScript `OutputSink` cap. Source repro recorded with `read crates/pi-natives/src/shell.rs:293-323 and crates/pi-shell/src/shell.rs:1833-1836` showed every decoded chunk was sent upstream without a byte or queue bound.

## Cause
`crates/pi-shell/src/shell.rs::emit_chunk` synchronously sent every decoded chunk into the callback channel, and `crates/pi-natives/src/shell.rs::bridge_chunks` allocated an unbounded bridge queue before `ThreadsafeFunctionCallMode::NonBlocking`. `packages/coding-agent/src/exec/bash-executor.ts` only applied the output cap after JS received the native callback, so native and queued callback memory were outside the existing truncation budget.

## Fix
- Added an internal `OutputStream` wrapper in `pi-shell` that uses non-blocking sends, honors a caller-provided UTF-8 byte limit, and keeps draining child pipes after the stream cap is reached.
- Changed the N-API shell bridge to use a bounded flume queue and plumbed `outputStreamByteLimit` through `Shell.run` / `executeShell`.
- Passed the bash tool’s retained output budget from `bash-executor.ts` into the native shell calls.
- Added streaming and buffered regression tests that run fast-output paths against a saturated bounded callback queue.

## Verification
Ran `cargo test -p pi-shell output_limit` (2 passed), `cargo test -p pi-natives bridge_chunks` (compiled native crate; 129 filtered), `bun run build` in `packages/natives`, and `bun check` (passed). Fixes #4078