### PR TITLE
fix(coding-agent): route SIGTERM/SIGHUP/uncaughtException through session teardown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `SIGTERM`/`SIGHUP`/`uncaughtException` skipping the editor draft save, the extension `session_shutdown` event, and background async-job disposal, so closing the terminal or a process manager killing `omp` no longer drops the in-progress draft or orphans background bash/task processes ([#4080](https://github.com/can1357/oh-my-pi/issues/4080)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { isEnoent, logger, ptree, untilAborted } from "@oh-my-pi/pi-utils";
+import { isEnoent, logger, postmortem, ptree, untilAborted } from "@oh-my-pi/pi-utils";
 import { MessageFramer } from "../jsonrpc/message-framing";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { applyWorkspaceEdit } from "./edits";
@@ -1232,21 +1232,18 @@ export function getActiveClients(): LspServerStatus[] {
 // Process Cleanup
 // =============================================================================
 
-// Register cleanup on module unload
+// Route signal-triggered LSP cleanup through the shared `postmortem` cleanup
+// list so it runs alongside every other session teardown (draft save,
+// `session.dispose()`, kernels, MCP) instead of racing them via a
+// module-owned `SIGINT`/`SIGTERM` handler + `process.exit(0)`. Historically
+// this file registered its own signal handlers that called `shutdownAll()`
+// then `process.exit(0)` — winning the race would drop `session_shutdown`
+// extensions, orphan background bash/task jobs, and skip the editor draft
+// save (issue #4080). `beforeExit` stays as-is: it fires only when the event
+// loop drains with no more work, distinct from signal delivery.
 if (typeof process !== "undefined") {
 	process.on("beforeExit", () => {
 		void shutdownAll();
 	});
-	process.on("SIGINT", () => {
-		void (async () => {
-			await shutdownAll();
-			process.exit(0);
-		})();
-	});
-	process.on("SIGTERM", () => {
-		void (async () => {
-			await shutdownAll();
-			process.exit(0);
-		})();
-	});
+	postmortem.register("lsp-shutdown", () => shutdownAll());
 }

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -155,6 +155,7 @@ import { OAuthManualInputManager } from "./oauth-manual-input";
 import { countRunningSubagentBadgeAgents, getRunningSubagentBadgeRegistry } from "./running-subagent-badge";
 import type { ObservableSession } from "./session-observer-registry";
 import { SessionObserverRegistry } from "./session-observer-registry";
+import { createSessionTeardown, type SessionTeardown } from "./session-teardown";
 import { runProviderSetupWizard } from "./setup-wizard/lazy";
 import { interruptHint } from "./shared";
 import { clearMermaidCache } from "./theme/mermaid-cache";
@@ -485,6 +486,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#pendingSlashCommands: SlashCommand[] = [];
 	#cleanupUnsubscribe?: () => void;
+	#signalTeardown?: SessionTeardown;
 	readonly #version: string;
 	readonly #changelogMarkdown: string | undefined;
 	#planModePreviousTools: string[] | undefined;
@@ -768,8 +770,22 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		this.keybindings = logger.time("InteractiveMode.init:keybindings", () => KeybindingsManager.create());
 
-		// Register session manager flush for signal handlers (SIGINT, SIGTERM, SIGHUP)
-		this.#cleanupUnsubscribe = postmortem.register("session-manager-flush", () => this.sessionManager.flush());
+		// Route SIGINT/SIGTERM/SIGHUP/uncaughtException through the same teardown
+		// the TUI Ctrl+C keypress path performs: persist the in-progress editor
+		// draft for `--resume`, then dispose the session (which emits the extension
+		// `session_shutdown` event, cancels the owned async job manager, disposes
+		// eval kernels, releases owned browser tabs, and closes the session
+		// manager). Without this callback a real kernel signal would drop the
+		// draft, skip the `session_shutdown` contract from `shared-events.ts`,
+		// and orphan background bash/task processes (issue #4080). The registered
+		// callback and `shutdown()` share one promise-memoized teardown, so a
+		// signal arriving mid-Ctrl+C no-ops instead of racing a second dispose.
+		this.#signalTeardown = createSessionTeardown({
+			getDraftText: () => this.editor.getText(),
+			saveDraft: text => this.sessionManager.saveDraft(text),
+			disposeSession: () => this.session.dispose(),
+		});
+		this.#cleanupUnsubscribe = postmortem.register("session-teardown", () => this.#signalTeardown!());
 
 		// Wire the report_tool_issue consent gate to the Yes/No dialog popup.
 		// The handler is process-global — subagent tools (which can't reach
@@ -3277,24 +3293,21 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.#isShuttingDown) return;
 		this.#isShuttingDown = true;
 
-		// Snapshot the editor before any teardown empties it. Persisting the draft
-		// here covers Ctrl+D shutdown with non-empty text; for /exit the editor is
-		// already cleared so saveDraft("") just removes any stale sidecar.
-		const draftText = this.editor.getText();
-
-		// Flush pending session writes before shutdown
-		await this.sessionManager.flush();
-		try {
-			await this.sessionManager.saveDraft(draftText);
-		} catch (err) {
-			logger.warn("Failed to save session draft", { error: String(err) });
-		}
 		this.#btwController.dispose();
 		this.#omfgController.dispose();
 		this.#focusController.dispose();
 
-		// Emit shutdown event to hooks
-		await this.session.dispose();
+		// Persist the draft and dispose the session through the shared teardown
+		// so a signal that arrives mid-shutdown cannot fire a second dispose.
+		// The teardown is a promise-memoized singleton; whichever path calls it
+		// first runs the work, the other awaits the same settled promise.
+		// The teardown is registered lazily in `init()` — a `/exit` reached
+		// before `init()` completed falls back to a direct dispose.
+		if (this.#signalTeardown) {
+			await this.#signalTeardown();
+		} else {
+			await this.session.dispose();
+		}
 
 		// Do not force a final render during teardown: disposed session/UI state can
 		// collapse to an empty frame, clearing the viewport and leaving the parent

--- a/packages/coding-agent/src/modes/session-teardown.test.ts
+++ b/packages/coding-agent/src/modes/session-teardown.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import { createSessionTeardown } from "./session-teardown";
+
+/**
+ * Signal-safe session teardown contract (issue #4080). The callback body
+ * registered on `postmortem` for `SIGINT`/`SIGTERM`/`SIGHUP`/`uncaughtException`
+ * must persist the in-progress editor draft and emit the extension
+ * `session_shutdown` event (via `session.dispose()`) — the same steps the TUI
+ * Ctrl+C keypress path performs. Both paths funnel through
+ * `createSessionTeardown`, so exercising it directly proves the acceptance
+ * criteria hold regardless of the trigger.
+ */
+describe("createSessionTeardown", () => {
+	it("persists the draft, then disposes the session, in that order", async () => {
+		const order: string[] = [];
+		const saved: string[] = [];
+
+		const teardown = createSessionTeardown({
+			getDraftText: () => "unsent draft",
+			saveDraft: async text => {
+				order.push("saveDraft");
+				saved.push(text);
+			},
+			disposeSession: async () => {
+				order.push("disposeSession");
+			},
+		});
+
+		await teardown();
+
+		expect(order).toEqual(["saveDraft", "disposeSession"]);
+		expect(saved).toEqual(["unsent draft"]);
+	});
+
+	it("still disposes when saveDraft rejects — never leaves session_shutdown unemitted", async () => {
+		let disposed = false;
+
+		const teardown = createSessionTeardown({
+			getDraftText: () => "draft",
+			saveDraft: async () => {
+				throw new Error("disk full");
+			},
+			disposeSession: async () => {
+				disposed = true;
+			},
+		});
+
+		await teardown();
+
+		expect(disposed).toBe(true);
+	});
+
+	it("passes the empty snapshot through so a stale sidecar is cleared on clean exit", async () => {
+		const seen: string[] = [];
+		const teardown = createSessionTeardown({
+			getDraftText: () => "",
+			saveDraft: async text => {
+				seen.push(text);
+			},
+			disposeSession: async () => {},
+		});
+
+		await teardown();
+
+		expect(seen).toEqual([""]);
+	});
+
+	it("memoizes: concurrent and repeat calls run the teardown exactly once", async () => {
+		let getDraftCalls = 0;
+		let saveDraftCalls = 0;
+		let disposeCalls = 0;
+		const release = Promise.withResolvers<void>();
+
+		const teardown = createSessionTeardown({
+			getDraftText: () => {
+				getDraftCalls++;
+				return `draft-${getDraftCalls}`;
+			},
+			saveDraft: async () => {
+				saveDraftCalls++;
+			},
+			disposeSession: async () => {
+				disposeCalls++;
+				await release.promise;
+			},
+		});
+
+		// Kick off two concurrent invocations while the first is still awaiting
+		// disposeSession — this is exactly what happens if a SIGTERM arrives
+		// mid-`InteractiveMode.shutdown()`.
+		const first = teardown();
+		const second = teardown();
+		release.resolve();
+		await Promise.all([first, second]);
+
+		// A third call after settlement must still be a no-op.
+		await teardown();
+
+		expect(getDraftCalls).toBe(1);
+		expect(saveDraftCalls).toBe(1);
+		expect(disposeCalls).toBe(1);
+	});
+
+	it("snapshots the draft text at first call — later editor mutations do not leak in", async () => {
+		let editorText = "before";
+		let captured: string | undefined;
+
+		const teardown = createSessionTeardown({
+			getDraftText: () => editorText,
+			saveDraft: async text => {
+				captured = text;
+			},
+			disposeSession: async () => {},
+		});
+
+		const running = teardown();
+		editorText = "after"; // A late edit must not overwrite the persisted draft.
+		await running;
+
+		expect(captured).toBe("before");
+	});
+});

--- a/packages/coding-agent/src/modes/session-teardown.ts
+++ b/packages/coding-agent/src/modes/session-teardown.ts
@@ -1,0 +1,57 @@
+/**
+ * Signal-safe session teardown: persists the in-progress editor draft, then
+ * disposes the session (which emits `session_shutdown`, cancels the session's
+ * background async jobs, and closes the session manager). Shared by the TUI
+ * Ctrl+C/Ctrl+D/`/exit` keypress path in `InteractiveMode.shutdown()` and by
+ * the postmortem `SIGINT`/`SIGTERM`/`SIGHUP`/`uncaughtException` handlers so a
+ * real kernel signal executes the exact same teardown as a keypress exit.
+ *
+ * Extracted (rather than inlined into `InteractiveMode`) so the callback body
+ * is directly unit-testable without instantiating the full TUI stack.
+ */
+import { logger } from "@oh-my-pi/pi-utils";
+
+/** Dependencies the teardown captures at construction time. */
+export interface SessionTeardownDeps {
+	/** Snapshot the current editor text; called once, before disposal touches session state. */
+	getDraftText: () => string;
+	/**
+	 * Persist the snapshotted draft. Called even for an empty string so a
+	 * previously-persisted draft sidecar is cleared on a clean exit.
+	 */
+	saveDraft: (text: string) => Promise<void>;
+	/** Dispose the session — emits `session_shutdown`, drains async jobs, closes the manager. */
+	disposeSession: () => Promise<void>;
+}
+
+/** Idempotent teardown: concurrent/repeat invocations share one settled promise. */
+export type SessionTeardown = () => Promise<void>;
+
+/**
+ * Build a promise-memoized teardown function. The first call snapshots the
+ * draft text, runs `saveDraft` (draft-loss protection for `--resume`), then
+ * `disposeSession`; subsequent calls await the same settled promise, so the
+ * keypress `InteractiveMode.shutdown()` path and the postmortem signal
+ * callback cannot double-emit `session_shutdown`, double-dispose the
+ * session's async-job manager, or race each other.
+ *
+ * `saveDraft` failures are logged but never abort the disposal chain — a
+ * draft-write error must not leak background bash/task jobs or skip the
+ * extension `session_shutdown` event.
+ */
+export function createSessionTeardown(deps: SessionTeardownDeps): SessionTeardown {
+	let pending: Promise<void> | undefined;
+	const run = async (): Promise<void> => {
+		const draftText = deps.getDraftText();
+		try {
+			await deps.saveDraft(draftText);
+		} catch (err) {
+			logger.warn("Failed to save session draft during teardown", { error: String(err) });
+		}
+		await deps.disposeSession();
+	};
+	return () => {
+		if (!pending) pending = run();
+		return pending;
+	};
+}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5104,8 +5104,20 @@ export class AgentSession {
 	/**
 	 * Remove all listeners, flush pending writes, and disconnect from agent.
 	 * Call this when completely done with the session.
+	 *
+	 * Idempotent: concurrent or repeated calls share one settled promise. The
+	 * keypress `InteractiveMode.shutdown()` path and the postmortem
+	 * `SIGTERM`/`SIGHUP`/`uncaughtException` callback can both target this
+	 * method, so a second invocation must never re-emit `session_shutdown` or
+	 * double-drain the owned `AsyncJobManager` (issue #4080).
 	 */
-	async dispose(): Promise<void> {
+	#disposeCall?: Promise<void>;
+	dispose(): Promise<void> {
+		if (!this.#disposeCall) this.#disposeCall = this.#doDispose();
+		return this.#disposeCall;
+	}
+
+	async #doDispose(): Promise<void> {
 		this.beginDispose();
 		try {
 			if (this.#extensionRunner?.hasHandlers("session_shutdown")) {


### PR DESCRIPTION
## Repro

Type an unsent message into the `omp` editor, then send `SIGTERM` (e.g. `kill -TERM <pid>` from a process manager, or close the terminal window and let the shell forward `SIGHUP`). Reopen with `omp --resume <id>` — the draft is gone. Any extension registered on `session_shutdown` never observed its handler fire, and background `bash`/`task` jobs the session had spawned outlive `omp` until OS reaping. `SIGINT` (Ctrl+C) is unaffected, because that keypress path routes through `InteractiveMode.shutdown()`.

## Cause

`packages/utils/src/postmortem.ts:90-148` — the `SIGINT`/`SIGTERM`/`SIGHUP`/`uncaughtException`/`unhandledRejection` handlers only `await runCleanup(reason)` then `process.exit`. `runCleanup` iterates only registered callbacks (`session-manager-flush`, LSP shutdown via a separate mechanism, kernels, MCP notification-cleanup, terminal-restore, ssh, sshfs, shell-snapshot, otel). None of them invoked `InteractiveMode.shutdown()`, `AgentSession.dispose()` (which is where `session_shutdown` emits, `#cancelOwnAsyncJobs` runs, and the owned `AsyncJobManager` is drained), or `SessionManager.saveDraft`. Meanwhile `packages/coding-agent/src/lsp/client.ts` registered its own `SIGINT`/`SIGTERM` handlers that called `shutdownAll()` then `process.exit(0)` — potentially winning the race and short-circuiting postmortem's async `runCleanup`. The `SessionShutdownEvent` docstring in `packages/coding-agent/src/extensibility/shared-events.ts:91` explicitly promises delivery on `SIGINT`/`SIGTERM`; that contract was not honored on `SIGTERM`/`SIGHUP`.

## Fix

- New `packages/coding-agent/src/modes/session-teardown.ts` — a promise-memoized `createSessionTeardown` helper that snapshots the editor draft, persists it via `sessionManager.saveDraft`, then invokes `session.dispose()`. A `saveDraft` failure is logged but never aborts disposal (the extension `session_shutdown` contract and job disposal must still run).
- `packages/coding-agent/src/session/agent-session.ts` — memoize `AgentSession.dispose()` with a `#disposeCall` promise so the TUI keypress path and the postmortem signal callback share one settled promise. Prevents double-emission of `session_shutdown` and double-drain of the owned `AsyncJobManager` when both paths converge.
- `packages/coding-agent/src/modes/interactive-mode.ts` — replace the narrower `session-manager-flush` postmortem callback with `session-teardown`, wired through the shared helper. `InteractiveMode.shutdown()` now delegates the draft-save + dispose steps to the same helper, so keypress and signal paths converge on identical work.
- `packages/coding-agent/src/lsp/client.ts` — drop the module-owned `SIGINT`/`SIGTERM` handlers; register `postmortem.register("lsp-shutdown", () => shutdownAll())` instead so LSP cleanup runs alongside every other session teardown instead of racing them via `process.exit(0)`. `beforeExit` is unchanged (fires only when the loop drains naturally, not during signal delivery).
- `packages/coding-agent/src/modes/session-teardown.test.ts` — covers draft-then-dispose ordering, disposal after `saveDraft` rejects, empty-string clears stale sidecar, promise memoization under concurrent invocation, and snapshot-at-first-call semantics.

## Verification

`bun test packages/coding-agent/src/modes/session-teardown.test.ts` → 5 pass. `bun test packages/coding-agent/src/session/ packages/coding-agent/src/modes/session-teardown.test.ts packages/coding-agent/src/lsp/` → 10 pass. `bun check` → passed. The wider `bun test packages/coding-agent/src/` shows one pre-existing failure across six files due to a missing generated `tool-views.generated.js` in `src/export/html/index.ts`; the same failure reproduces on the branch with the changes stashed (verified via `git stash`), so it is unrelated to this diff.

Fixes #4080