### PR TITLE
fix(tui): stop stale ssh placeholder rows after settle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed TUI scrollback committing stale pending SSH preview rows and forced-overflow snapshots, which could strand duplicate pending headers or stale tool chrome above the final settled output.
+
 ## [16.2.8] - 2026-06-30
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -484,6 +484,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		if (isPartial && this.#toolName === "task" && this.#maybeFreezeBackgroundTask()) {
 			return;
 		}
+		const wasPartial = this.#isPartial;
 		this.#result = result;
 		this.#resultVersion++;
 		this.#isPartial = isPartial;
@@ -495,6 +496,14 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#updateSpinnerAnimation();
 		this.#updateTodoStrikeAnimation();
 		this.#updateDisplay();
+		// A provisional partial render (pending SSH/tool chrome, streamed edit preview,
+		// etc.) can change row topology when it settles: headers flip state and final
+		// sections like `Output` appear. Force the next repaint through the full-window
+		// update path so an in-window diff cannot strand stale pending rows above the
+		// settled block in the live viewport.
+		if (wasPartial && !isPartial && this.#shouldForceSettleViewportRepaint()) {
+			this.#ui.requestRender(true);
+		}
 		// Convert non-PNG images to PNG for Kitty protocol (async)
 		this.#maybeConvertImagesForKitty();
 	}
@@ -587,6 +596,12 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 				this.#renderState.spinnerFrame = undefined;
 			}
 		}
+	}
+
+	#shouldForceSettleViewportRepaint(): boolean {
+		if (this.#result === undefined) return false;
+		const tool = this.#tool as { provisionalPartialResult?: boolean } | undefined;
+		return tool?.provisionalPartialResult ?? toolRenderers[this.#toolName]?.provisionalPartialResult ?? false;
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -605,7 +605,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 
 	#shouldResetDisplayOnFirstResult(): boolean {
 		const tool = this.#tool as { forceFirstResultViewportRepaint?: boolean } | undefined;
-		return tool?.forceFirstResultViewportRepaint ?? toolRenderers[this.#toolName]?.forceFirstResultViewportRepaint ?? false;
+		return (
+			tool?.forceFirstResultViewportRepaint ??
+			toolRenderers[this.#toolName]?.forceFirstResultViewportRepaint ??
+			false
+		);
 	}
 
 	#shouldResetDisplayOnSettle(): boolean {

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -485,6 +485,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 			return;
 		}
 		const wasPartial = this.#isPartial;
+		const hadResult = this.#result !== undefined;
 		this.#result = result;
 		this.#resultVersion++;
 		this.#isPartial = isPartial;
@@ -496,13 +497,17 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#updateSpinnerAnimation();
 		this.#updateTodoStrikeAnimation();
 		this.#updateDisplay();
-		// A provisional partial render (pending SSH/tool chrome, streamed edit preview,
-		// etc.) can change row topology when it settles: headers flip state and final
-		// sections like `Output` appear. Force the next repaint through the full-window
-		// update path so an in-window diff cannot strand stale pending rows above the
-		// settled block in the live viewport.
-		if (wasPartial && !isPartial && this.#shouldForceSettleViewportRepaint()) {
-			this.#ui.requestRender(true);
+		// Two topology flips need transcript-wide intervention to avoid stranding
+		// stale pending rows above the settled block:
+		// 1) a provisional pending call preview disappears once a merged result
+		//    render takes over, which must retire any frozen snapshots of that
+		//    preview before repainting, and
+		// 2) a provisional partial result settles to its final chrome/body, which
+		//    must also retire any frozen snapshots of the old pending glyph/state.
+		if (!hadResult && this.#shouldResetDisplayOnFirstResult()) {
+			this.#ui.resetDisplay();
+		} else if (wasPartial && !isPartial && this.#shouldResetDisplayOnSettle()) {
+			this.#ui.resetDisplay();
 		}
 		// Convert non-PNG images to PNG for Kitty protocol (async)
 		this.#maybeConvertImagesForKitty();
@@ -598,7 +603,12 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		}
 	}
 
-	#shouldForceSettleViewportRepaint(): boolean {
+	#shouldResetDisplayOnFirstResult(): boolean {
+		const tool = this.#tool as { forceFirstResultViewportRepaint?: boolean } | undefined;
+		return tool?.forceFirstResultViewportRepaint ?? toolRenderers[this.#toolName]?.forceFirstResultViewportRepaint ?? false;
+	}
+
+	#shouldResetDisplayOnSettle(): boolean {
 		if (this.#result === undefined) return false;
 		const tool = this.#tool as { provisionalPartialResult?: boolean } | undefined;
 		return tool?.provisionalPartialResult ?? toolRenderers[this.#toolName]?.provisionalPartialResult ?? false;

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -441,8 +441,13 @@ export class TranscriptContainer
 	// engine must append their scroll-off snapshot rather than drop it. Reported
 	// separately from the byte-stable commit-safe end because these rows may still
 	// drift after commit; the engine commits them audit-exempt. Provisional
-	// (commit-unstable) blocks never extend it.
+	// (commit-unstable) blocks never extend it, and lower siblings below a still-
+	// live block stay out because later live growth above them shifts position.
 	#nativeScrollbackSnapshotSafeEnd: number | undefined;
+	// Local line index up to which rows may still be offered to native scrollback.
+	// Unlike the durable snapshot end, rows offered below a still-live block stay
+	// audited after commit because later live growth above them may shift them.
+	#nativeScrollbackOfferEnd: number | undefined;
 	// Persistent assembled transcript rows. Rows before the stable floor are
 	// byte-identical to the previous render; rows at/after it were re-pushed.
 	#lines: string[] = [];
@@ -489,6 +494,10 @@ export class TranscriptContainer
 
 	getNativeScrollbackSnapshotSafeEnd(): number | undefined {
 		return this.#nativeScrollbackSnapshotSafeEnd;
+	}
+
+	getNativeScrollbackOfferEnd(): number | undefined {
+		return this.#nativeScrollbackOfferEnd;
 	}
 
 	/**
@@ -583,6 +592,7 @@ export class TranscriptContainer
 		this.#nativeScrollbackLiveRegionStart = undefined;
 		this.#nativeScrollbackCommitSafeEnd = undefined;
 		this.#nativeScrollbackSnapshotSafeEnd = undefined;
+		this.#nativeScrollbackOfferEnd = undefined;
 
 		const count = this.children.length;
 
@@ -621,10 +631,14 @@ export class TranscriptContainer
 		// invariant — otherwise re-pushed rows land after the stale frame.
 		if (!chainStable) lines.length = 0;
 
-		// Tracks whether we are still inside the leading run of commit-safe live
-		// blocks. The first still-live volatile block closes it, but rendering
-		// continues so lower blocks remain visible.
+		// Tracks whether we are still inside the leading run of byte-stable live
+		// blocks. The first still-live block closes it, but rendering continues so
+		// lower blocks remain visible. Snapshot-safety is tracked separately below:
+		// a still-live block may expose its own durable body, but lower siblings below
+		// it stay audited because later live growth above them shifts position.
 		let commitSafeOpen = true;
+		let snapshotSafeOpen = true;
+		let offerOpen = true;
 		// The live-region start is recorded at the first visible row at/after
 		// liveStartIndex; empty leading blocks (or a separator) must not claim it
 		// early.
@@ -700,7 +714,11 @@ export class TranscriptContainer
 			// still closes the commit-safe run: if it later gains rows, it pushes
 			// everything below it.
 			if (contribution.length === 0) {
-				if (i >= liveStartIndex && commitSafeOpen && !finalized) commitSafeOpen = false;
+				if (i >= liveStartIndex && !finalized) {
+					if (commitSafeOpen) commitSafeOpen = false;
+					if (snapshotSafeOpen) snapshotSafeOpen = false;
+					if (offerOpen) offerOpen = false;
+				}
 				if (chainStable && !(reusable && previous.rowCount === 0 && previous.startRow === row)) {
 					chainStable = false;
 					lines.length = row;
@@ -750,26 +768,36 @@ export class TranscriptContainer
 			}
 
 			const blockStart = row + sep;
+			const safeLength = finalized ? contribution.length : (liveCommitState?.safeLength ?? 0);
 			if (i >= liveStartIndex && commitSafeOpen) {
-				const safeLength = finalized ? contribution.length : (liveCommitState?.safeLength ?? 0);
 				if (safeLength > 0) {
 					this.#nativeScrollbackCommitSafeEnd = blockStart + safeLength;
 				}
+			}
+			const snapshotLength = finalized || isBlockCommitStable(child) ? contribution.length : safeLength;
+			if (i >= liveStartIndex && snapshotSafeOpen) {
 				// Durable snapshot end: a commit-stable block's whole body is durable
 				// content — its scrolled-off rows are permanent even while interior
 				// rows re-lay-out (a streaming table re-aligning columns), so the
 				// engine must commit their snapshot on scroll-off rather than drop it.
-				// Finalized blocks are wholly durable; provisional (commit-unstable)
-				// blocks offer nothing beyond their byte-stable safe length.
-				const snapshotLength = finalized || isBlockCommitStable(child) ? contribution.length : safeLength;
+				// Lower siblings below a still-live block are excluded here: they may be
+				// final content, but later live growth above them shifts their position,
+				// so they stay audited rather than entering the durable-exempt window.
 				if (snapshotLength > 0) {
 					this.#nativeScrollbackSnapshotSafeEnd = blockStart + snapshotLength;
 				}
-				// A finalized, fully safe block may let the contiguous safe run extend
-				// into blocks rendered below it. A still-live block keeps pushing lower
-				// rows around as it grows, so the run closes there.
-				if (!(finalized && safeLength >= contribution.length)) commitSafeOpen = false;
 			}
+			if (i >= liveStartIndex && offerOpen) {
+				if (snapshotLength > 0) {
+					this.#nativeScrollbackOfferEnd = blockStart + snapshotLength;
+				}
+				if (snapshotLength < contribution.length) offerOpen = false;
+			}
+			if (!finalized) snapshotSafeOpen = false;
+			// A finalized, fully safe block may let the contiguous byte-stable run
+			// extend into blocks rendered below it. A still-live block keeps pushing
+			// lower rows around as it grows, so the run closes there.
+			if (!(finalized && safeLength >= contribution.length)) commitSafeOpen = false;
 
 			segments[i] = {
 				component: child,

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -63,6 +63,11 @@ export type ToolRenderer = {
 	 * with the final render and may commit like any settled stream.
 	 */
 	provisionalPartialResult?: boolean;
+	/**
+	 * Whether the first merged result render must force a full display reset
+	 * because it replaces the pending-call placeholder wholesale.
+	 */
+	forceFirstResultViewportRepaint?: boolean;
 };
 
 export const toolRenderers: Record<string, ToolRenderer> = {

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -377,6 +377,12 @@ export const sshToolRenderer = {
 	// and the pending `╰──╯` footer reused in-place as the new `├── Output ──┤`
 	// separator with a fresh footer pushed below it.
 	provisionalPendingPreview: true,
+	// The earliest args-stream placeholder (`⏳ SSH: […]` / `$ …`) is also a
+	// provisional shape: once the first result lands, `mergeCallAndResult`
+	// suppresses `renderCall()` entirely. Force that first settle through a
+	// full-window repaint so an in-window diff cannot strand the placeholder rows
+	// above the result block.
+	forceFirstResultViewportRepaint: true,
 	// Partial-result chrome (pending icon and frame state) differs from the
 	// final SSH glyph/state, so the block stays commit-unstable while
 	// `options.isPartial` holds. Without this, a long-running SSH command's

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -386,6 +386,19 @@ describe("TranscriptContainer", () => {
 		for (let frame = 0; frame < 4; frame++) container.render(60);
 		expect(container.getNativeScrollbackSnapshotSafeEnd()).toBeGreaterThan(0);
 	});
+
+	it("keeps finalized lower siblings offerable but outside the durable snapshot window under a live block", () => {
+		const container = new TranscriptContainer();
+		container.addChild(new StreamingBlock(["earlier turn"], true));
+		container.addChild(new StreamingBlock(["live-0"]));
+		container.addChild(new MutableBlock(["tail-0", "tail-1"]));
+
+		for (let frame = 0; frame < 40; frame++) container.render(60);
+
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(2);
+		expect(container.getNativeScrollbackSnapshotSafeEnd()).toBe(3);
+		expect(container.getNativeScrollbackOfferEnd()).toBe(6);
+	});
 	it("does not re-render finalized rows already committed to native scrollback", () => {
 		const container = new TranscriptContainer();
 		const committed = new CountingFinalizedBlock(["committed"]);

--- a/packages/coding-agent/test/streaming-output-scrollback.test.ts
+++ b/packages/coding-agent/test/streaming-output-scrollback.test.ts
@@ -466,7 +466,14 @@ describe("streaming tool output never sprays duplicate scrollback banners", () =
 
 		transcript.addChild(new StaticBlock(["lead-0", "lead-1"]));
 		transcript.addChild(new LiveBarrier(["assistant: still working in a parallel tool…"]));
-		const ssh = new ToolExecutionComponent("ssh", { __partialJson: '{"host":"build-host"' }, {}, undefined, tui, process.cwd());
+		const ssh = new ToolExecutionComponent(
+			"ssh",
+			{ __partialJson: '{"host":"build-host"' },
+			{},
+			undefined,
+			tui,
+			process.cwd(),
+		);
 		transcript.addChild(ssh);
 		tui.addChild(transcript);
 		tui.addChild(new Footer(4));
@@ -475,7 +482,10 @@ describe("streaming tool output never sprays duplicate scrollback banners", () =
 			tui.start();
 			await settle();
 
-			const initialViewportText = term.getViewport().map(row => Bun.stripANSI(row).trimEnd()).join("\n");
+			const initialViewportText = term
+				.getViewport()
+				.map(row => Bun.stripANSI(row).trimEnd())
+				.join("\n");
 			expect(initialViewportText).toContain("⏳ SSH: […]");
 			expect(initialViewportText).toContain("$ …");
 

--- a/packages/coding-agent/test/streaming-output-scrollback.test.ts
+++ b/packages/coding-agent/test/streaming-output-scrollback.test.ts
@@ -388,6 +388,68 @@ describe("streaming tool output never sprays duplicate scrollback banners", () =
 		}
 	}, 30_000);
 
+	test("ssh regression: settling a provisional result repaints away the pending header in viewport", async () => {
+		if (process.platform === "win32") return;
+		const rows = 14;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(60, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new TranscriptContainer();
+		const command = ["python3 - <<'PY'", "print('hi')", "PY"].join("\n");
+		const settle = async () => {
+			scheduler.flush();
+			await term.flush();
+		};
+
+		transcript.addChild(new StaticBlock(["lead-0", "lead-1"]));
+		transcript.addChild(new LiveBarrier(["assistant: still working in a parallel tool…"]));
+		const ssh = new ToolExecutionComponent("ssh", { host: "build-host", command }, {}, undefined, tui, process.cwd());
+		transcript.addChild(ssh);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			await settle();
+
+			ssh.setExpanded(true);
+			ssh.setArgsComplete();
+			tui.requestRender();
+			await settle();
+
+			ssh.updateResult({ content: [{ type: "text", text: "REMOTE_PY_BEGIN" }], isError: false }, true);
+			tui.requestRender();
+			await settle();
+
+			const pendingViewportRows = term.getViewport().map(row => Bun.stripANSI(row).trimEnd());
+			expect(pendingViewportRows.join("\n")).toContain("REMOTE_PY_BEGIN");
+			expect(pendingViewportRows.join("\n")).toContain("⏳ SSH: [build-host]");
+			expect(pendingViewportRows.join("\n")).toContain("Output");
+
+			ssh.updateResult(
+				{
+					content: [{ type: "text", text: ["REMOTE_PY_BEGIN", "REMOTE_PY_END"].join("\n") }],
+					isError: false,
+				},
+				false,
+			);
+			tui.requestRender();
+			await settle();
+
+			const viewportRows = term.getViewport().map(row => Bun.stripANSI(row).trimEnd());
+			const viewportText = viewportRows.join("\n");
+			expect(viewportRows.filter(row => row.includes("⏳ SSH: [build-host]"))).toHaveLength(0);
+			expect(viewportText).toContain("⇄ SSH: [build-host]");
+			expect(viewportText).toContain("REMOTE_PY_END");
+			expect(viewportText).toContain("Output");
+		} finally {
+			ssh.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
 	test("transcript regression: a stable live block growing above finalized lower content does not lose rows", async () => {
 		if (process.platform === "win32") return;
 		const rows = 4;

--- a/packages/coding-agent/test/streaming-output-scrollback.test.ts
+++ b/packages/coding-agent/test/streaming-output-scrollback.test.ts
@@ -450,6 +450,87 @@ describe("streaming tool output never sprays duplicate scrollback banners", () =
 		}
 	}, 30_000);
 
+	test("ssh regression: settling after an ellipsis placeholder repaints away the stale placeholder rows", async () => {
+		if (process.platform === "win32") return;
+		const rows = 14;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(60, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new TranscriptContainer();
+		const command = ["python3 - <<'PY'", ...Array.from({ length: 50 }, (_unused, i) => `line_${i}`), "PY"].join("\n");
+		const settle = async () => {
+			scheduler.flush();
+			await term.flush();
+		};
+
+		transcript.addChild(new StaticBlock(["lead-0", "lead-1"]));
+		transcript.addChild(new LiveBarrier(["assistant: still working in a parallel tool…"]));
+		const ssh = new ToolExecutionComponent("ssh", { __partialJson: '{"host":"build-host"' }, {}, undefined, tui, process.cwd());
+		transcript.addChild(ssh);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			await settle();
+
+			const initialViewportText = term.getViewport().map(row => Bun.stripANSI(row).trimEnd()).join("\n");
+			expect(initialViewportText).toContain("⏳ SSH: […]");
+			expect(initialViewportText).toContain("$ …");
+
+			for (let i = 0; i < 60; i++) {
+				term.scrollLines(1_000);
+				tui.requestRender();
+				await settle();
+			}
+
+			ssh.updateArgs({ host: "build-host", command });
+			ssh.setExpanded(true);
+			ssh.setArgsComplete();
+			tui.requestRender();
+			await settle();
+
+			ssh.updateResult({ content: [{ type: "text", text: "REMOTE_PY_BEGIN" }], isError: false }, true);
+			for (let i = 0; i < 60; i++) {
+				term.scrollLines(1_000);
+				tui.requestRender();
+				await settle();
+			}
+
+			ssh.updateResult(
+				{
+					content: [{ type: "text", text: ["REMOTE_PY_BEGIN", "REMOTE_PY_END"].join("\n") }],
+					isError: false,
+				},
+				false,
+			);
+			tui.requestRender();
+			await settle();
+			term.scrollLines(1_000);
+			await term.flush();
+
+			const bufferText = term
+				.getScrollBuffer()
+				.map(row => Bun.stripANSI(row).trimEnd())
+				.join("\n");
+			const viewportText = term
+				.getViewport()
+				.map(row => Bun.stripANSI(row).trimEnd())
+				.join("\n");
+
+			expect(viewportText).not.toContain("⏳ SSH: […]");
+			expect(bufferText).not.toContain("⏳ SSH: […]");
+			expect(bufferText).toContain("⇄ SSH: [build-host]");
+			expect(bufferText).toContain("REMOTE_PY_BEGIN");
+			expect(bufferText).toContain("REMOTE_PY_END");
+		} finally {
+			ssh.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
 	test("transcript regression: a stable live block growing above finalized lower content does not lose rows", async () => {
 		if (process.platform === "win32") return;
 		const rows = 4;

--- a/packages/coding-agent/test/streaming-output-scrollback.test.ts
+++ b/packages/coding-agent/test/streaming-output-scrollback.test.ts
@@ -79,6 +79,23 @@ class LiveBarrier extends StaticBlock {
 	}
 }
 
+class MutableLiveBarrier extends LiveBarrier {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		super(lines);
+		this.#lines = lines;
+	}
+
+	set(lines: string[]): void {
+		this.#lines = lines;
+	}
+
+	override render(_width: number): string[] {
+		return this.#lines;
+	}
+}
+
 // Stand-in for the input editor + status drawn below the transcript.
 class Footer implements Component {
 	#rows: number;
@@ -94,6 +111,26 @@ class Footer implements Component {
 const ORIGINAL_ROWS = Object.getOwnPropertyDescriptor(process.stdout, "rows");
 function stubStdoutRows(rows: number): void {
 	Object.defineProperty(process.stdout, "rows", { configurable: true, value: rows });
+}
+
+function contiguousAt(buffer: string[], needle: string[]): number[] {
+	const hits: number[] = [];
+	outer: for (let start = 0; start <= buffer.length - needle.length; start++) {
+		for (let i = 0; i < needle.length; i++) {
+			if ((buffer[start + i] ?? "") !== needle[i]) continue outer;
+		}
+		hits.push(start);
+	}
+	return hits;
+}
+
+function expectNoLoss(term: VirtualTerminal, frame: string[]): string[] {
+	const buffer = term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+	const hits = contiguousAt(buffer, frame);
+	expect(hits.length).toBeGreaterThan(0);
+	const tailStart = hits.at(-1)! + frame.length;
+	for (let i = tailStart; i < buffer.length; i++) expect(buffer[i]).toBe("");
+	return buffer;
 }
 
 describe("streaming tool output never sprays duplicate scrollback banners", () => {
@@ -137,6 +174,262 @@ describe("streaming tool output never sprays duplicate scrollback banners", () =
 			expect(banners).toBeLessThanOrEqual(1);
 		} finally {
 			bash.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
+	test("ssh: settled native scrollback does not keep a stale pending host header above the final frame", async () => {
+		if (process.platform === "win32") return;
+		const rows = 14;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(60, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new TranscriptContainer();
+		const command = [
+			"python3 - <<'PY'",
+			"import time",
+			'BLOB = """',
+			"alpha",
+			"beta",
+			"gamma",
+			"delta",
+			"epsilon",
+			"zeta",
+			"eta",
+			"theta",
+			"iota",
+			"kappa",
+			"lambda",
+			"mu",
+			"nu",
+			"xi",
+			"omicron",
+			"pi",
+			"rho",
+			"sigma",
+			"tau",
+			"upsilon",
+			"phi",
+			"chi",
+			"psi",
+			"omega",
+			'"""',
+			"",
+			"def chunk(label):",
+			"    print(label)",
+			"    print(BLOB[:40])",
+			"",
+			'print("REMOTE_PY_BEGIN")',
+			'chunk("REMOTE_PY_BLOB")',
+			"time.sleep(1)",
+			'print("REMOTE_PY_TICK_1")',
+			"time.sleep(1)",
+			'print("REMOTE_PY_TICK_2")',
+			"time.sleep(1)",
+			'print("REMOTE_PY_TICK_3")',
+			'print("REMOTE_PY_END")',
+			"PY",
+		].join("\n");
+		const settle = async () => {
+			scheduler.flush();
+			await term.flush();
+		};
+
+		transcript.addChild(
+			new StaticBlock([
+				"Use only the ssh tool on build-host.",
+				"Do not pass cwd and do not use tilde.",
+				"Set command to: python3 - <<'PY'",
+				...command.split("\n"),
+			]),
+		);
+		transcript.addChild(new LiveBarrier(["assistant: still working in a parallel tool…"]));
+		const ssh = new ToolExecutionComponent("ssh", { host: "build-host", command }, {}, undefined, tui, process.cwd());
+		transcript.addChild(ssh);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			await settle();
+
+			ssh.setArgsComplete();
+			tui.requestRender();
+			await settle();
+
+			ssh.updateResult(
+				{
+					content: [
+						{
+							type: "text",
+							text: [
+								"REMOTE_PY_BEGIN",
+								"REMOTE_PY_BLOB",
+								"",
+								"alpha",
+								"beta",
+								"gamma",
+								"delta",
+								"epsilon",
+								"zeta",
+								"eta",
+								"REMOTE_PY_TICK_1",
+								"REMOTE_PY_TICK_2",
+								"REMOTE_PY_TICK_3",
+								"REMOTE_PY_END",
+							].join("\n"),
+						},
+					],
+					isError: false,
+				},
+				false,
+			);
+			tui.requestRender();
+			await settle();
+
+			term.scrollLines(1_000);
+			await term.flush();
+
+			const bufferRows = term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+			const viewportText = term
+				.getViewport()
+				.map(row => Bun.stripANSI(row).trimEnd())
+				.join("\n");
+
+			// Final-state contract: once the SSH block settles, neither the viewport nor
+			// native scrollback should retain a stale pending host header. Use a generic
+			// host label so the oracle is repo-local, not machine-local.
+			expect(viewportText).not.toContain("⏳ SSH: [build-host]");
+			expect(bufferRows.filter(row => row.includes("⇄ SSH: [build-host]")).length).toBe(1);
+			expect(bufferRows.filter(row => row.includes("⏳ SSH: [build-host]")).length).toBe(0);
+		} finally {
+			ssh.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
+	test("ssh regression: settled output must not leave a stale pending host header in native scrollback", async () => {
+		if (process.platform === "win32") return;
+		const rows = 14;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(60, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new TranscriptContainer();
+		const command = ["python3 - <<'PY'", ...Array.from({ length: 50 }, (_unused, i) => `line_${i}`), "PY"].join("\n");
+		const settle = async () => {
+			scheduler.flush();
+			await term.flush();
+		};
+
+		transcript.addChild(new StaticBlock(["lead-0", "lead-1"]));
+		transcript.addChild(new LiveBarrier(["assistant: still working in a parallel tool…"]));
+		const ssh = new ToolExecutionComponent("ssh", { host: "build-host", command }, {}, undefined, tui, process.cwd());
+		transcript.addChild(ssh);
+		tui.addChild(transcript);
+		tui.addChild(new Footer(4));
+
+		try {
+			tui.start();
+			await settle();
+
+			ssh.setExpanded(true);
+			ssh.setArgsComplete();
+			for (let i = 0; i < 60; i++) {
+				term.scrollLines(1_000);
+				tui.requestRender();
+				await settle();
+			}
+
+			ssh.updateResult({ content: [{ type: "text", text: "REMOTE_PY_BEGIN" }], isError: false }, true);
+			for (let i = 0; i < 60; i++) {
+				term.scrollLines(1_000);
+				tui.requestRender();
+				await settle();
+			}
+
+			ssh.updateResult(
+				{
+					content: [{ type: "text", text: ["REMOTE_PY_BEGIN", "REMOTE_PY_END"].join("\n") }],
+					isError: false,
+				},
+				false,
+			);
+			tui.requestRender();
+			await settle();
+			term.scrollLines(1_000);
+			await term.flush();
+
+			const bufferText = term
+				.getScrollBuffer()
+				.map(row => Bun.stripANSI(row).trimEnd())
+				.join("\n");
+			const viewportText = term
+				.getViewport()
+				.map(row => Bun.stripANSI(row).trimEnd())
+				.join("\n");
+
+			// Replay-like regression: the current engine leaves a stale pending host
+			// header in native scrollback even though the settled viewport is clean.
+			// Desired contract: once fixed, the settled state retains only the final
+			// output/content, never the old pending host header.
+			expect(viewportText).not.toContain("⏳ SSH: [build-host]");
+			expect(bufferText).not.toContain("⏳ SSH: [build-host]");
+			expect(bufferText).toContain("Output");
+			expect(bufferText).toContain("REMOTE_PY_BEGIN");
+			expect(bufferText).toContain("REMOTE_PY_END");
+		} finally {
+			ssh.stopAnimation();
+			tui.stop();
+			await term.flush();
+		}
+	}, 30_000);
+
+	test("transcript regression: a stable live block growing above finalized lower content does not lose rows", async () => {
+		if (process.platform === "win32") return;
+		const rows = 4;
+		stubStdoutRows(rows);
+		const term = new VirtualTerminal(40, rows);
+		const scheduler = makeDrainableScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new TranscriptContainer();
+		const live = new MutableLiveBarrier(["live-0"]);
+		const finalFrame1 = ["head-0", "head-1", "", "live-0", "", "tail-0", "tail-1", "tail-2"];
+		const finalFrame2 = ["head-0", "head-1", "", "live-0", "live-1", "", "tail-0", "tail-1", "tail-2"];
+		const settle = async () => {
+			scheduler.flush();
+			await term.flush();
+		};
+
+		transcript.addChild(new StaticBlock(["head-0", "head-1"]));
+		transcript.addChild(live);
+		transcript.addChild(new StaticBlock(["tail-0", "tail-1", "tail-2"]));
+		tui.addChild(transcript);
+
+		try {
+			tui.start();
+			await settle();
+
+			for (let i = 0; i < 40; i++) {
+				tui.requestRender();
+				await settle();
+			}
+
+			expect(transcript.getNativeScrollbackSnapshotSafeEnd()).toBe(4);
+			expect(transcript.getNativeScrollbackOfferEnd()).toBe(8);
+			expectNoLoss(term, finalFrame1);
+
+			live.set(["live-0", "live-1"]);
+			tui.requestRender();
+			await settle();
+
+			const buffer = expectNoLoss(term, finalFrame2);
+			expect(buffer).toContain("live-1");
+			expect(buffer).toContain("tail-2");
+		} finally {
 			tui.stop();
 			await term.flush();
 		}

--- a/packages/coding-agent/test/tools/ssh-commit-stability.test.ts
+++ b/packages/coding-agent/test/tools/ssh-commit-stability.test.ts
@@ -77,7 +77,10 @@ describe("ssh tool block commit stability", () => {
 	it("resets display when the first SSH result replaces a provisional pending preview", () => {
 		const resetDisplay = vi.fn();
 		const requestRender = vi.fn();
-		const component = new ToolExecutionComponent("ssh", {}, {}, undefined, { resetDisplay, requestRender } as unknown as TUI);
+		const component = new ToolExecutionComponent("ssh", {}, {}, undefined, {
+			resetDisplay,
+			requestRender,
+		} as unknown as TUI);
 
 		component.updateResult(partialResult("connecting…"), true);
 
@@ -88,7 +91,10 @@ describe("ssh tool block commit stability", () => {
 	it("resets display again when a provisional SSH result settles", () => {
 		const resetDisplay = vi.fn();
 		const requestRender = vi.fn();
-		const component = new ToolExecutionComponent("ssh", {}, {}, undefined, { resetDisplay, requestRender } as unknown as TUI);
+		const component = new ToolExecutionComponent("ssh", {}, {}, undefined, {
+			resetDisplay,
+			requestRender,
+		} as unknown as TUI);
 
 		component.updateResult(partialResult("connecting…"), true);
 		component.updateResult(partialResult("done\n"), false);

--- a/packages/coding-agent/test/tools/ssh-commit-stability.test.ts
+++ b/packages/coding-agent/test/tools/ssh-commit-stability.test.ts
@@ -17,7 +17,7 @@ import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/componen
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { TUI } from "@oh-my-pi/pi-tui";
 
-const uiStub = { requestRender() {} } as unknown as TUI;
+const uiStub = { requestRender() {}, resetDisplay() {} } as unknown as TUI;
 
 function makeSshComponent() {
 	return new ToolExecutionComponent("ssh", { host: "sccpu", command: "uptime" }, {}, undefined, uiStub);
@@ -74,6 +74,28 @@ describe("ssh tool block commit stability", () => {
 		expect(component.isTranscriptBlockCommitStable()).toBe(false);
 	});
 
+	it("resets display when the first SSH result replaces a provisional pending preview", () => {
+		const resetDisplay = vi.fn();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent("ssh", {}, {}, undefined, { resetDisplay, requestRender } as unknown as TUI);
+
+		component.updateResult(partialResult("connecting…"), true);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
+		expect(requestRender).not.toHaveBeenCalled();
+	});
+
+	it("resets display again when a provisional SSH result settles", () => {
+		const resetDisplay = vi.fn();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent("ssh", {}, {}, undefined, { resetDisplay, requestRender } as unknown as TUI);
+
+		component.updateResult(partialResult("connecting…"), true);
+		component.updateResult(partialResult("done\n"), false);
+
+		expect(resetDisplay).toHaveBeenCalledTimes(2);
+		expect(requestRender).not.toHaveBeenCalled();
+	});
 	it("flips commit-stable as soon as the SSH result settles", () => {
 		const component = makeSshComponent();
 		component.updateResult(partialResult("connecting…"), true);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2787,7 +2787,11 @@ export class TUI extends Container {
 			// or settles, matching the commit-unstable contract used by provisional tool
 			// renders whose top rows would otherwise strand stale history.
 			const commitCeiling =
-				liveRegionStart === undefined ? frameLength : offerBoundary > liveRegionStart ? offerBoundary : liveRegionStart;
+				liveRegionStart === undefined
+					? frameLength
+					: offerBoundary > liveRegionStart
+						? offerBoundary
+						: liveRegionStart;
 			chunkTo = hasVisibleOverlay || geometryChanged ? this.#committedRows : Math.min(windowTop, commitCeiling);
 			if (geometryChanged) {
 				committedPrefixResliced = true;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2782,10 +2782,12 @@ export class TUI extends Container {
 			// cannot erase the stale preview from immutable scrollback. Rows between
 			// durableBoundary and offerBoundary are different: they are permanent enough
 			// to commit, but still audited because live growth above may shift them.
-			// A wholly volatile live region keeps the historical forced-overflow path so
-			// its eventual replacement can be recommitted rather than dropped.
+			// A wholly volatile live region offers nothing past its seam: its scrolled-
+			// off head stays repaint-only until the block either earns a durable prefix
+			// or settles, matching the commit-unstable contract used by provisional tool
+			// renders whose top rows would otherwise strand stale history.
 			const commitCeiling =
-				liveRegionStart !== undefined && offerBoundary > liveRegionStart ? offerBoundary : frameLength;
+				liveRegionStart === undefined ? frameLength : offerBoundary > liveRegionStart ? offerBoundary : liveRegionStart;
 			chunkTo = hasVisibleOverlay || geometryChanged ? this.#committedRows : Math.min(windowTop, commitCeiling);
 			if (geometryChanged) {
 				committedPrefixResliced = true;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -211,16 +211,22 @@ export interface OverlayFocusOwner {
  * dropped row or an audit re-anchor spray. Provisional live blocks (collapsing
  * tool/edit previews whose head is a throwaway tail window) omit it. Defaults to
  * `commitSafeEnd ?? liveRegionStart` when absent.
+ * `getNativeScrollbackOfferEnd` optionally reports an even deeper boundary: rows
+ * up to this line may enter native scrollback, but they MUST stay audited after
+ * commit because their position may still shift when live rows above them grow
+ * (for example, a finalized lower transcript card below a still-live append-only
+ * block). Defaults to `snapshotSafeEnd ?? commitSafeEnd ?? liveRegionStart`.
  *
  * When several root children report a seam in the same frame, the topmost
- * one (and its commit-safe / snapshot-safe extension) defines the boundary:
- * commits are prefix-only, so everything below the first seam is already
- * excluded.
+ * one (and its own commit-safe / snapshot-safe / offer extension) defines the
+ * boundary: commits are prefix-only, so everything below the first seam is
+ * already excluded.
  */
 export interface NativeScrollbackLiveRegion {
 	getNativeScrollbackLiveRegionStart(): number | undefined;
 	getNativeScrollbackCommitSafeEnd?(): number | undefined;
 	getNativeScrollbackSnapshotSafeEnd?(): number | undefined;
+	getNativeScrollbackOfferEnd?(): number | undefined;
 }
 
 export interface NativeScrollbackCommittedRows {
@@ -248,6 +254,10 @@ function getNativeScrollbackCommitSafeEnd(component: Component): number | undefi
 
 function getNativeScrollbackSnapshotSafeEnd(component: Component): number | undefined {
 	return (component as Component & Partial<NativeScrollbackLiveRegion>).getNativeScrollbackSnapshotSafeEnd?.();
+}
+
+function getNativeScrollbackOfferEnd(component: Component): number | undefined {
+	return (component as Component & Partial<NativeScrollbackLiveRegion>).getNativeScrollbackOfferEnd?.();
 }
 
 /**
@@ -637,6 +647,7 @@ interface FrameSegment {
 	liveLocalStart?: number;
 	commitLocalEnd?: number;
 	snapshotLocalEnd?: number;
+	offerLocalEnd?: number;
 }
 
 /** Depth-first identity search through `Container`-shaped children. */
@@ -877,6 +888,7 @@ export function findCommittedPrefixResync(
 			let samples = 0;
 			let mismatches = 0;
 			let scanned = 0;
+			let forcedOverflowMismatch = false;
 			for (let j = 1; j <= committed && scanned < RESYNC_TAIL_LOOKBACK && samples < RESYNC_TAIL_SAMPLES; j++) {
 				const idx = committed - j;
 				if (!audited(idx)) continue;
@@ -889,10 +901,17 @@ export function findCommittedPrefixResync(
 				}
 				if (isBlankRow(row) && isBlankRow(old)) continue;
 				samples++;
-				if (!rowsEquivalent(row, old)) mismatches++;
+				if (!rowsEquivalent(row, old)) {
+					mismatches++;
+					if (idx >= exTo) forcedOverflowMismatch = true;
+				}
 			}
-			// No signal (all-blank/all-exempt tail) or at most one edited row: aligned.
-			if (samples === 0 || mismatches <= 1) return -1;
+			// No signal (all-blank/all-exempt tail): aligned. Byte-stable rows keep the
+			// historic one-row tolerance so a lone offscreen spinner tick or in-place
+			// edit does not spray duplicates. Forced-overflow rows are stricter: any
+			// mismatch there is a stale committed preview under a commit-unstable
+			// barrier, so re-anchor immediately.
+			if (samples === 0 || (!forcedOverflowMismatch && mismatches <= 1)) return -1;
 		}
 	}
 	// Misaligned (hard mismatch, tail-sample shift, or the frame no longer covers
@@ -1028,6 +1047,7 @@ export class TUI extends Container {
 	#nativeScrollbackLiveRegionStart: number | undefined;
 	#nativeScrollbackCommitSafeEnd: number | undefined;
 	#nativeScrollbackSnapshotSafeEnd: number | undefined;
+	#nativeScrollbackOfferEnd: number | undefined;
 	#fullRedrawCount = 0;
 	// Caps how many inline images render as live graphics; older ones fall back
 	// to text via a purge + full redraw. Cap is configured by the host app.
@@ -1147,6 +1167,7 @@ export class TUI extends Container {
 		this.#nativeScrollbackLiveRegionStart = undefined;
 		this.#nativeScrollbackCommitSafeEnd = undefined;
 		this.#nativeScrollbackSnapshotSafeEnd = undefined;
+		this.#nativeScrollbackOfferEnd = undefined;
 		const children = this.children;
 		const previousSegments = this.#frameSegments;
 		const segments: FrameSegment[] = new Array(children.length);
@@ -1169,12 +1190,14 @@ export class TUI extends Container {
 			let liveLocalStart: number | undefined;
 			let commitLocalEnd: number | undefined;
 			let snapshotLocalEnd: number | undefined;
+			let offerLocalEnd: number | undefined;
 			let reported: number | undefined;
 			if (reuse) {
 				childLines = previous.lines;
 				liveLocalStart = previous.liveLocalStart;
 				commitLocalEnd = previous.commitLocalEnd;
 				snapshotLocalEnd = previous.snapshotLocalEnd;
+				offerLocalEnd = previous.offerLocalEnd;
 			} else {
 				// Feed the engine's committed-row claim (from the previous frame's
 				// emit) before rendering so the child can skip re-deriving blocks
@@ -1203,6 +1226,15 @@ export class TUI extends Container {
 							? Math.max(snapshotFloor, Math.min(childLines.length, Math.trunc(snapshotSafeEnd)))
 							: childLines.length;
 					}
+					const offerEnd = getNativeScrollbackOfferEnd(child);
+					if (offerEnd !== undefined) {
+						const offerFloor = snapshotLocalEnd ?? commitLocalEnd ?? liveLocalStart;
+						offerLocalEnd = Number.isFinite(offerEnd)
+							? Math.max(offerFloor, Math.min(childLines.length, Math.trunc(offerEnd)))
+							: childLines.length;
+					} else {
+						offerLocalEnd = snapshotLocalEnd;
+					}
 				}
 				// Consume the stability report unconditionally for implementers:
 				// reading re-bases the component's baseline to the state this
@@ -1213,9 +1245,9 @@ export class TUI extends Container {
 				reported = getRenderStablePrefixRows(child);
 			}
 			// Topmost seam wins. Commits are prefix-only: the first child that
-			// reports a live region (plus its own commit-safe extension) already
-			// bounds everything below it, so a lower sibling's seam (e.g. a
-			// status loader under a streaming transcript) must never overwrite
+			// reports a live region (plus its own commit-safe / snapshot-safe / offer
+			// extension) already bounds everything below it, so a lower sibling's seam
+			// (e.g. a status loader under a streaming transcript) must never overwrite
 			// it — moving the boundary down would commit the earlier child's
 			// still-mutable rows as stale history.
 			if (liveLocalStart !== undefined && this.#nativeScrollbackLiveRegionStart === undefined) {
@@ -1225,6 +1257,9 @@ export class TUI extends Container {
 				}
 				if (snapshotLocalEnd !== undefined) {
 					this.#nativeScrollbackSnapshotSafeEnd = offset + snapshotLocalEnd;
+				}
+				if (offerLocalEnd !== undefined) {
+					this.#nativeScrollbackOfferEnd = offset + offerLocalEnd;
 				}
 			}
 			if (chainStable) {
@@ -1256,6 +1291,7 @@ export class TUI extends Container {
 				liveLocalStart,
 				commitLocalEnd,
 				snapshotLocalEnd,
+				offerLocalEnd,
 			};
 			offset += childLines.length;
 		}
@@ -2597,21 +2633,27 @@ export class TUI extends Container {
 		// The commit floor is windowTop in every non-frozen path (see chunkTo), so
 		// whatever scrolls above the window is committed — never committed nowhere
 		// AND painted nowhere (the loss bug). The boundaries no longer gate the
-		// commit; they define the audit-exempt span. byteStableBoundary: rows below
+		// commit; they classify the committed prefix. byteStableBoundary: rows below
 		// it are byte-stable (never re-layout), audited. durableBoundary: rows in
 		// [byteStableBoundary, durableBoundary) are durable — permanent on scroll-off
 		// but may drift in place (a streaming table re-aligning), committed
-		// audit-EXEMPT. Rows at/beyond durableBoundary committed only because they
-		// scrolled above the window (a commit-unstable barrier over a long tail) are
-		// forced-overflow rows: audited, so a later shift/finalize/removal re-anchors
-		// (duplication, never loss) instead of stranding a stale prefix. Built on the
-		// finalized prefix (live-region start); the whole frame when the root reports
-		// no seam (shell semantics: whatever scrolls is final).
+		// audit-EXEMPT. Rows in [durableBoundary, offerBoundary) are permanent enough
+		// to commit but still audited because live rows above may shift them. Rows at
+		// or beyond offerBoundary committed only because they scrolled above the
+		// window under a commit-unstable barrier are forced-overflow rows: audited,
+		// so a later shift/finalize/removal re-anchors (duplication, never loss)
+		// instead of stranding a stale prefix. Built on the finalized prefix
+		// (live-region start); the whole frame when the root reports no seam (shell
+		// semantics: whatever scrolls is final).
 		const frameLength = rawFrame.length;
 		const byteStableBoundary = Math.max(0, Math.min(frameLength, commitSafeEnd ?? liveRegionStart ?? frameLength));
 		const durableBoundary = Math.max(
 			byteStableBoundary,
 			Math.min(frameLength, snapshotSafeEnd ?? byteStableBoundary),
+		);
+		const offerBoundary = Math.max(
+			durableBoundary,
+			Math.min(frameLength, this.#nativeScrollbackOfferEnd ?? durableBoundary),
 		);
 
 		// 2. Transition state captured before any emitter runs.
@@ -2733,8 +2775,18 @@ export class TUI extends Container {
 			// overlay closes. A multiplexer resize also commits nothing — the
 			// pane keeps its own (old-wrap) history — and re-bases the audit
 			// prefix at the new width so the accepted wrap drift does not read
-			// as a violation on the next ordinary frame.
-			chunkTo = hasVisibleOverlay || geometryChanged ? this.#committedRows : windowTop;
+			// as a violation on the next ordinary frame. When a live region has a
+			// durable prefix followed by commit-unstable rows, the unstable suffix is
+			// only viewport content: if it scrolls into native history before the
+			// settled render replaces it, a later audit can duplicate fresh rows but
+			// cannot erase the stale preview from immutable scrollback. Rows between
+			// durableBoundary and offerBoundary are different: they are permanent enough
+			// to commit, but still audited because live growth above may shift them.
+			// A wholly volatile live region keeps the historical forced-overflow path so
+			// its eventual replacement can be recommitted rather than dropped.
+			const commitCeiling =
+				liveRegionStart !== undefined && offerBoundary > liveRegionStart ? offerBoundary : frameLength;
+			chunkTo = hasVisibleOverlay || geometryChanged ? this.#committedRows : Math.min(windowTop, commitCeiling);
 			if (geometryChanged) {
 				committedPrefixResliced = true;
 				this.#committedPrefix = rawFrame.slice(0, this.#committedRows);
@@ -3662,7 +3714,7 @@ export class TUI extends Container {
 				: `fullPaint(clearScrollback=${intent.clearScrollback})`;
 		const state =
 			`committed=${this.#committedRows}, windowTop=${this.#windowTopRow}, ` +
-			`lrStart=${this.#nativeScrollbackLiveRegionStart}, commitSafeEnd=${this.#nativeScrollbackCommitSafeEnd}`;
+			`lrStart=${this.#nativeScrollbackLiveRegionStart}, commitSafeEnd=${this.#nativeScrollbackCommitSafeEnd}, offerEnd=${this.#nativeScrollbackOfferEnd}`;
 		const msg = `[${new Date().toISOString()}] render: ${detail} (prev=${this.#previousFrameLength}, new=${newLength}, height=${height}, ${state})\n`;
 		fs.appendFileSync(getDebugLogPath(), msg);
 	}

--- a/packages/tui/test/committed-prefix-resync.test.ts
+++ b/packages/tui/test/committed-prefix-resync.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { findCommittedPrefixResync } from "@oh-my-pi/pi-tui/tui";
+
+describe("findCommittedPrefixResync", () => {
+	it("re-anchors at the earliest audited mismatch when a later forced-overflow row also changed", () => {
+		const prefix = ["finalized-old", "stable-1", "durable-drift", "forced-old", "tail"];
+		const frame = ["finalized-new", "stable-1", "durable-drift-next", "forced-new", "tail"];
+
+		// Row 2 is a durable-snapshot exemption window. Row 3 is a formerly
+		// forced-overflow row that became permanent this frame, so its mismatch must
+		// defeat the one-row tail tolerance. The resync point is still row 0: the
+		// earliest audited mismatch, not the later forced-overflow one.
+		expect(findCommittedPrefixResync(frame, prefix, prefix.length, 2, 3, 4)).toBe(0);
+	});
+});


### PR DESCRIPTION
## What

I’ve already requested a vouch in Discussion.

This PR fixes a cluster of TUI/native-scrollback regressions around streaming transcript commits and SSH tool rendering, so settled output no longer strands stale pending chrome in terminal history or the live viewport.

Specifically, it fixes three related bugs:

1. **Committed-prefix / forced-overflow resync bug**
   - Hardened the native-scrollback commit audit so rows that were previously committed only because they scrolled above the viewport under a live barrier are still audited once they become permanent.
   - This fixes cases where a later re-layout could silently strand stale committed rows or drop alignment below the first changed row.

2. **Transcript live-region / commit-stability bug**
   - Taught `TranscriptContainer` to distinguish between **durable live content** and **provisional live previews**.
   - Provisional shapes (for example a pending tool preview that will be replaced wholesale by the result render) are now kept out of native scrollback until they are actually stable.
   - Durable streaming content still earns commit-safe prefix promotion after the stability window, so long-running streams do not read as “cut off”.

3. **SSH settle repaint bug**
   - Fixed the SSH tool’s first-result and settle transitions so the pending placeholder/header/frame cannot survive above the final settled SSH block.
   - This covers both:
     - the pending host header (`⏳ SSH: [host]`) during partial-result streaming, and
     - the earlier ellipsis placeholder form (`⏳ SSH: […]` / `$ …`) shown while args are still incomplete.
   - The first merged result now forces a display reset for SSH, and partial SSH results remain commit-unstable until the final settled frame lands.

## Why

These regressions all came from the same class of problem: rows were being treated as durable native-scrollback history too early, even though later transitions could still re-anchor or replace them wholesale.

That produced several user-visible failure modes:

- stale pending SSH headers left above the final `⇄ SSH: [host]` block,
- stale placeholder rows surviving after the final SSH result,
- forced-overflow rows escaping the committed-prefix audit once they became permanent,
- and long-running live transcript blocks either duplicating stale history or being forced to choose between “spray” and “loss”.

This PR tightens the commit model so the engine now cleanly separates:

- **byte-stable committed rows**,
- **durable but audit-exempt snapshot rows**,
- **audited forced-overflow rows**, and
- **commit-unstable provisional rows** that must remain repaint-only until settle.

## Testing

Targeted tests run for each layer of the fix:

### Native scrollback / audit
- `bun test packages/tui/test/committed-prefix-resync.test.ts`
  - Verifies `findCommittedPrefixResync` re-anchors at the earliest audited mismatch even when a later formerly-forced row also changed.

### Transcript live-region / commit-stability
- `bun test packages/coding-agent/test/modes/components/transcript-container.test.ts`
  - Verifies unfinalized blocks stay in the live region even when finalized blocks are appended below.
  - Verifies commit-unstable provisional blocks never offer settled preview rows to native scrollback.
  - Verifies durable live blocks still promote a settled head after the stability window.
  - Verifies finalized blocks can still repaint current content without corrupting seam tracking.

### End-to-end scrollback / viewport regressions
- `bun test packages/coding-agent/test/streaming-output-scrollback.test.ts`
  - Verifies settled SSH output does not leave a stale pending host header in native scrollback.
  - Verifies settling a provisional SSH result repaints away the pending header in the viewport.
  - Verifies settling after the earlier ellipsis placeholder repaints away stale placeholder rows from both viewport and scrollback.
  - Verifies stable live blocks growing above finalized lower content do not lose rows.

### SSH renderer contract
- `bun test packages/coding-agent/test/tools/ssh-commit-stability.test.ts`
  - Verifies pending SSH previews remain commit-unstable in both collapsed and expanded forms.
  - Verifies the first SSH result replacing a provisional pending preview triggers `resetDisplay()`.
  - Verifies a provisional partial SSH result settling triggers `resetDisplay()` again.
  - Verifies settled SSH results flip back to commit-stable.
  - Verifies the SSH-specific opt-ins do not change bash/other foreground tool behavior.

### Type safety
- `bun run check:types` (in `packages/coding-agent`)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
