### PR TITLE
fix(coding-agent): preserved explicit :auto suffix in modelRoles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed explicit `provider/model:auto` entries in `modelRoles` collapsing to `inherit` in the model selector and losing their auto state on reload; the `:auto` selector is now preserved as an explicit thinking level end to end ([#4128](https://github.com/can1357/oh-my-pi/issues/4128)).
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/bench-cli.ts
+++ b/packages/coding-agent/src/cli/bench-cli.ts
@@ -30,7 +30,7 @@ import { buildServiceTierByFamily, serviceTierForAllFamilies, serviceTierSetting
 import { Settings } from "../config/settings";
 import benchPrompt from "../prompts/bench.md" with { type: "text" };
 import { discoverAuthStorage, loadCliExtensionProviders } from "../sdk";
-import { resolveThinkingLevelForModel, shouldDisableReasoning, toReasoningEffort } from "../thinking";
+import { AUTO_THINKING, resolveThinkingLevelForModel, shouldDisableReasoning, toReasoningEffort } from "../thinking";
 
 const DEFAULT_RUNS = 10;
 const DEFAULT_PAR = 4;
@@ -477,7 +477,10 @@ function resolveBenchModels(
 		resolved.push({
 			selector,
 			model,
-			thinking: resolveThinkingLevelForModel(model, result.thinkingLevel),
+			thinking: resolveThinkingLevelForModel(
+				model,
+				result.thinkingLevel === AUTO_THINKING ? undefined : result.thinkingLevel,
+			),
 		});
 	}
 	if (errors.length > 0) {

--- a/packages/coding-agent/src/commit/model-selection.ts
+++ b/packages/coding-agent/src/commit/model-selection.ts
@@ -11,6 +11,7 @@ import {
 import { MODEL_ROLE_IDS } from "../config/model-roles";
 import type { Settings } from "../config/settings";
 import MODEL_PRIO from "../priority.json" with { type: "json" };
+import { AUTO_THINKING, type ConfiguredThinkingLevel } from "../thinking";
 
 export interface ResolvedCommitModel {
 	model: Model<Api>;
@@ -27,6 +28,13 @@ type CommitModelRegistry = ModelLookupRegistry &
 	ApiKeyResolverRegistry & {
 		getApiKey: (model: Model<Api>) => Promise<string | undefined>;
 	};
+
+// Commit-time inference is stateless: session-level auto classification isn't
+// available, so an explicit `:auto` selector collapses to "no override" and
+// the model's own default level fills in.
+function coerceCommitThinkingLevel(level: ConfiguredThinkingLevel | undefined): ThinkingLevel | undefined {
+	return level === AUTO_THINKING ? undefined : level;
+}
 
 export async function resolvePrimaryModel(
 	override: string | undefined,
@@ -49,7 +57,7 @@ export async function resolvePrimaryModel(
 	return {
 		model,
 		apiKey: modelRegistry.resolver(model),
-		thinkingLevel: resolved?.thinkingLevel,
+		thinkingLevel: coerceCommitThinkingLevel(resolved?.thinkingLevel),
 	};
 }
 
@@ -67,7 +75,7 @@ export async function resolveSmolModel(
 			return {
 				model: resolvedSmol.model,
 				apiKey: modelRegistry.resolver(resolvedSmol.model),
-				thinkingLevel: resolvedSmol.thinkingLevel,
+				thinkingLevel: coerceCommitThinkingLevel(resolvedSmol.thinkingLevel),
 			};
 		}
 	}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -646,6 +646,7 @@ function normalizeSuppressedSelector(
 	if (!trimmed) return trimmed;
 	const parsed = parseModelString(trimmed, {
 		allowMaxAlias: true,
+		allowAutoAlias: true,
 		isLiteralModelId: (provider, id) => hasLiveModel?.(provider, id) === true,
 	});
 	if (!parsed) return trimmed;

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -79,28 +79,35 @@ export interface ScopedModel {
 
 interface ThinkingSuffixOptions {
 	allowMaxAlias?: boolean;
+	allowAutoAlias?: boolean;
 }
 
 interface ModelStringParseOptions extends ThinkingSuffixOptions {
 	isLiteralModelId?: (provider: string, id: string) => boolean;
 }
-const MAX_THINKING_SUFFIX_OPTIONS: ThinkingSuffixOptions = { allowMaxAlias: true };
+// Alias-suffix recognition for the model-pattern parser: `:max` maps to xhigh
+// and `:auto` maps to the auto sentinel. Both are gated behind the alias flags
+// (and the literal-id / exact-match guards on the callers) so a real model id
+// ending in `:max` / `:auto` isn't silently reinterpreted as a thinking suffix.
+const MAX_THINKING_SUFFIX_OPTIONS: ThinkingSuffixOptions = { allowMaxAlias: true, allowAutoAlias: true };
 
 function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): ConfiguredThinkingLevel | undefined {
-	if (value === AUTO_THINKING) return AUTO_THINKING;
 	const level = parseThinkingLevel(value);
 	if (level !== undefined) return level;
-	return options?.allowMaxAlias === true && value === "max" ? ThinkingLevel.XHigh : undefined;
+	if (options?.allowMaxAlias === true && value === "max") return ThinkingLevel.XHigh;
+	if (options?.allowAutoAlias === true && value === AUTO_THINKING) return AUTO_THINKING;
+	return undefined;
 }
 
 /**
  * Split a trailing `:<level>` thinking selector off a model pattern.
  *
- * `level` is set when the suffix parses as a concrete thinking level or the
- * `auto` sentinel, in which case `base` has the suffix stripped; otherwise
- * `base` is the input. `minColonIndex` requires the colon to appear strictly
- * after that index — role-alias callers pass `PREFIX_MODEL_ROLE.length` so the
- * base is at least as long as the `pi/` prefix.
+ * `level` is set when the suffix parses as a concrete thinking level (or, when
+ * the caller opts in via `allowMaxAlias`/`allowAutoAlias`, the `:max` / `:auto`
+ * aliases); `base` then has the suffix stripped. Otherwise `base` is the input.
+ * `minColonIndex` requires the colon to appear strictly after that index —
+ * role-alias callers pass `PREFIX_MODEL_ROLE.length` so the base is at least
+ * as long as the `pi/` prefix.
  */
 function splitThinkingSuffix(
 	pattern: string,

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -29,7 +29,12 @@ import { fuzzyMatch } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import MODEL_PRIO from "../priority.json" with { type: "json" };
-import { parseThinkingLevel, resolveThinkingLevelForModel } from "../thinking";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	parseThinkingLevel,
+	resolveThinkingLevelForModel,
+} from "../thinking";
 import { isAuthenticated, kNoAuth, type ModelRegistry } from "./model-registry";
 import { MODEL_ROLE_IDS, type ModelRole } from "./model-roles";
 import type { Settings } from "./settings";
@@ -81,7 +86,8 @@ interface ModelStringParseOptions extends ThinkingSuffixOptions {
 }
 const MAX_THINKING_SUFFIX_OPTIONS: ThinkingSuffixOptions = { allowMaxAlias: true };
 
-function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): ThinkingLevel | undefined {
+function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): ConfiguredThinkingLevel | undefined {
+	if (value === AUTO_THINKING) return AUTO_THINKING;
 	const level = parseThinkingLevel(value);
 	if (level !== undefined) return level;
 	return options?.allowMaxAlias === true && value === "max" ? ThinkingLevel.XHigh : undefined;
@@ -90,17 +96,17 @@ function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): Th
 /**
  * Split a trailing `:<level>` thinking selector off a model pattern.
  *
- * `level` is set only when the suffix parses as a valid thinking level, in
- * which case `base` has the suffix stripped; otherwise `base` is the input.
- * `minColonIndex` requires the colon to appear strictly after that index —
- * role-alias callers pass `PREFIX_MODEL_ROLE.length` so the base is at least
- * as long as the `pi/` prefix.
+ * `level` is set when the suffix parses as a concrete thinking level or the
+ * `auto` sentinel, in which case `base` has the suffix stripped; otherwise
+ * `base` is the input. `minColonIndex` requires the colon to appear strictly
+ * after that index — role-alias callers pass `PREFIX_MODEL_ROLE.length` so the
+ * base is at least as long as the `pi/` prefix.
  */
 function splitThinkingSuffix(
 	pattern: string,
 	minColonIndex = -1,
 	options?: ThinkingSuffixOptions,
-): { base: string; level?: ThinkingLevel } {
+): { base: string; level?: ConfiguredThinkingLevel } {
 	const colonIdx = pattern.lastIndexOf(":");
 	if (colonIdx <= minColonIndex) return { base: pattern };
 	const level = parseThinkingSuffix(pattern.slice(colonIdx + 1), options);
@@ -119,12 +125,20 @@ function resolveGlobScopePattern(
 	pattern: string,
 	availableModels: readonly Model<Api>[],
 ): { models: Model<Api>[]; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean } {
+	// Glob scopes describe which models are enabled, not per-role thinking.
+	// Coerce the `auto` sentinel to a concrete-only view so scope callers stay
+	// typed on `ThinkingLevel` and `enabledModels: [\"openai/*:auto\"]` doesn't
+	// pin a stray per-model level.
+	const concrete = (level: ConfiguredThinkingLevel | undefined): ThinkingLevel | undefined =>
+		level === AUTO_THINKING ? undefined : level;
+
 	const strictSuffix = splitThinkingSuffix(pattern);
 	if (strictSuffix.level !== undefined) {
+		const thinkingLevel = concrete(strictSuffix.level);
 		return {
 			models: matchingGlobModels(strictSuffix.base, availableModels),
-			thinkingLevel: strictSuffix.level,
-			explicitThinkingLevel: true,
+			thinkingLevel,
+			explicitThinkingLevel: thinkingLevel !== undefined,
 		};
 	}
 
@@ -134,10 +148,11 @@ function resolveGlobScopePattern(
 		if (literalMatches.length > 0) {
 			return { models: literalMatches, thinkingLevel: undefined, explicitThinkingLevel: false };
 		}
+		const thinkingLevel = concrete(maxSuffix.level);
 		return {
 			models: matchingGlobModels(maxSuffix.base, availableModels),
-			thinkingLevel: maxSuffix.level,
-			explicitThinkingLevel: true,
+			thinkingLevel,
+			explicitThinkingLevel: thinkingLevel !== undefined,
 		};
 	}
 
@@ -155,7 +170,7 @@ function resolveGlobScopePattern(
 export function parseModelString(
 	modelStr: string,
 	options?: ModelStringParseOptions,
-): { provider: string; id: string; thinkingLevel?: ThinkingLevel } | undefined {
+): { provider: string; id: string; thinkingLevel?: ConfiguredThinkingLevel } | undefined {
 	const slashIdx = modelStr.indexOf("/");
 	if (slashIdx <= 0) return undefined;
 	const id = modelStr.slice(slashIdx + 1);
@@ -208,7 +223,7 @@ export function formatModelStringWithRouting(model: Model<Api>): string {
 	return upstream ? `${selector}@${upstream}` : selector;
 }
 
-export function formatModelSelectorValue(selector: string, thinkingLevel: ThinkingLevel | undefined): string {
+export function formatModelSelectorValue(selector: string, thinkingLevel: ConfiguredThinkingLevel | undefined): string {
 	return thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit ? `${selector}:${thinkingLevel}` : selector;
 }
 
@@ -711,7 +726,7 @@ function matchModel(
 export interface ParsedModelResult {
 	model: Model<Api> | undefined;
 	/** Thinking level if explicitly specified in pattern, undefined otherwise */
-	thinkingLevel?: ThinkingLevel;
+	thinkingLevel?: ConfiguredThinkingLevel;
 	/** Upstream provider slug from an `@upstream` routing selector, if present. */
 	upstream?: string;
 	warning: string | undefined;
@@ -989,7 +1004,7 @@ export function resolveAgentModelPatterns(options: AgentModelPatternResolutionOp
  */
 export interface ResolvedModelRoleValue {
 	model: Model<Api> | undefined;
-	thinkingLevel?: ThinkingLevel;
+	thinkingLevel?: ConfiguredThinkingLevel;
 	explicitThinkingLevel: boolean;
 	warning: string | undefined;
 }
@@ -1021,7 +1036,9 @@ export function resolveModelRoleValue(
 			return {
 				model: resolved.model,
 				thinkingLevel: resolved.explicitThinkingLevel
-					? (resolveThinkingLevelForModel(resolved.model, resolved.thinkingLevel) ?? resolved.thinkingLevel)
+					? resolved.thinkingLevel === AUTO_THINKING
+						? AUTO_THINKING
+						: (resolveThinkingLevelForModel(resolved.model, resolved.thinkingLevel) ?? resolved.thinkingLevel)
 					: resolved.thinkingLevel,
 				explicitThinkingLevel: resolved.explicitThinkingLevel,
 				warning: resolved.warning,
@@ -1048,7 +1065,7 @@ export function extractExplicitThinkingSelector(
 	value: string | undefined,
 	settings?: Settings,
 	options?: ExplicitThinkingSelectorOptions,
-): ThinkingLevel | undefined {
+): ConfiguredThinkingLevel | undefined {
 	if (!value) return undefined;
 	const normalized = value.trim();
 	if (!normalized || normalized === DEFAULT_MODEL_ROLE) return undefined;
@@ -1127,7 +1144,7 @@ export function resolveModelOverride(
 	modelPatterns: string[],
 	modelRegistry: ModelLookupRegistry,
 	settings?: Settings,
-): { model?: Model<Api>; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean } {
+): { model?: Model<Api>; thinkingLevel?: ConfiguredThinkingLevel; explicitThinkingLevel: boolean } {
 	if (modelPatterns.length === 0) return { explicitThinkingLevel: false };
 	const availableModels = modelRegistry.getAvailable();
 	const matchPreferences = getModelMatchPreferences(settings);
@@ -1171,7 +1188,7 @@ export async function resolveModelOverrideWithAuthFallback(
 	settings?: Settings,
 ): Promise<{
 	model?: Model<Api>;
-	thinkingLevel?: ThinkingLevel;
+	thinkingLevel?: ConfiguredThinkingLevel;
 	explicitThinkingLevel: boolean;
 	authFallbackUsed: boolean;
 }> {
@@ -1207,7 +1224,7 @@ export function resolveRoleSelection(
 	roles: readonly string[],
 	settings: Settings,
 	availableModels: Model<Api>[],
-): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined {
+): { model: Model<Api>; thinkingLevel?: ConfiguredThinkingLevel } | undefined {
 	const matchPreferences = getModelMatchPreferences(settings);
 	for (const role of roles) {
 		const resolved = resolveModelRoleValue(settings.getModelRole(role), availableModels, {
@@ -1232,7 +1249,7 @@ export function resolveRoleSelection(
 export function resolveAdvisorRoleSelection(
 	settings: Settings,
 	availableModels: Model<Api>[],
-): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined {
+): { model: Model<Api>; thinkingLevel?: ConfiguredThinkingLevel } | undefined {
 	const resolved = resolveModelRoleValue(`${PREFIX_MODEL_ROLE}advisor`, availableModels, {
 		settings,
 		matchPreferences: getModelMatchPreferences(settings),
@@ -1307,7 +1324,13 @@ export async function resolveModelScope(
 			continue;
 		}
 
-		addScopedModel(model, thinkingLevel, explicitThinkingLevel);
+		// Scoped models (Ctrl+P cycling) carry concrete per-model overrides;
+		// `auto` lives on the session, so drop the sentinel here.
+		if (thinkingLevel === AUTO_THINKING) {
+			addScopedModel(model, undefined, false);
+		} else {
+			addScopedModel(model, thinkingLevel, explicitThinkingLevel);
+		}
 	}
 
 	return scopedModels;
@@ -1393,7 +1416,7 @@ export function filterAvailableModelsByEnabledPatterns(
 export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;
 	selector?: string;
-	thinkingLevel?: ThinkingLevel;
+	thinkingLevel?: ConfiguredThinkingLevel;
 	warning: string | undefined;
 	error: string | undefined;
 }

--- a/packages/coding-agent/src/goals/guided-setup.ts
+++ b/packages/coding-agent/src/goals/guided-setup.ts
@@ -5,7 +5,7 @@ import { extractTextContent, extractToolCall, parseJsonPayload } from "../commit
 import guidedGoalInterviewPrompt from "../prompts/goals/guided-goal-interview.md" with { type: "text" };
 import guidedGoalSystemPrompt from "../prompts/goals/guided-goal-system.md" with { type: "text" };
 import type { AgentSession } from "../session/agent-session";
-import { shouldDisableReasoning, toReasoningEffort } from "../thinking";
+import { AUTO_THINKING, shouldDisableReasoning, toReasoningEffort } from "../thinking";
 
 const RESPOND_TOOL_NAME = "respond";
 
@@ -102,8 +102,10 @@ export async function runGuidedGoalTurn(
 		{
 			apiKey: session.modelRegistry.resolver(resolved.model, session.sessionId),
 			signal: options.signal,
-			reasoning: toReasoningEffort(resolved.thinkingLevel),
-			disableReasoning: shouldDisableReasoning(resolved.thinkingLevel),
+			reasoning: toReasoningEffort(resolved.thinkingLevel === AUTO_THINKING ? undefined : resolved.thinkingLevel),
+			disableReasoning: shouldDisableReasoning(
+				resolved.thinkingLevel === AUTO_THINKING ? undefined : resolved.thinkingLevel,
+			),
 			toolChoice: { type: "tool", name: RESPOND_TOOL_NAME },
 		},
 		{ telemetry: resolveTelemetry(session.agent.telemetry, session.sessionId), oneshotKind: "guided_goal_setup" },

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -912,7 +912,7 @@ export class ModelSelectorComponent extends Container {
 	}
 	#getResolvedRoleThinkingLevel(
 		role: string,
-		resolved: { explicitThinkingLevel: boolean; thinkingLevel?: ThinkingLevel },
+		resolved: { explicitThinkingLevel: boolean; thinkingLevel?: ConfiguredThinkingLevel },
 	): ConfiguredThinkingLevel {
 		if (resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined) {
 			return resolved.thinkingLevel;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1266,6 +1266,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const sessionModelStr = sessionModelStrings[i];
 				const parsedModel = parseModelString(sessionModelStr, {
 					allowMaxAlias: true,
+					allowAutoAlias: true,
 					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
 				});
 				if (!parsedModel) {
@@ -1916,6 +1917,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const sessionModelStr = sessionModelStrings[i];
 				const parsedModel = parseModelString(sessionModelStr, {
 					allowMaxAlias: true,
+					allowAutoAlias: true,
 					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
 				});
 				if (!parsedModel) continue;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1258,7 +1258,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			? getRestorableSessionModels(existingSession.models, sessionManager.getLastModelChangeRole())
 			: [];
 	let restoredSessionModelIndex = -1;
-	let restoredSessionThinkingLevel: ThinkingLevel | undefined;
+	let restoredSessionThinkingLevel: ConfiguredThinkingLevel | undefined;
 	if (!hasExplicitModel && !model && sessionModelStrings.length > 0) {
 		logger.time("restoreSessionModel", () => {
 			let failedSessionModel: string | undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -870,6 +870,7 @@ function parseRetryFallbackSelector(
 	if (!trimmed) return undefined;
 	const parsed = parseModelString(trimmed, {
 		allowMaxAlias: true,
+		allowAutoAlias: true,
 		isLiteralModelId: (provider, id) => modelLookup?.find(provider, id) !== undefined,
 	});
 	if (!parsed) return undefined;
@@ -10758,6 +10759,7 @@ export class AgentSession {
 
 		const parsed = parseModelString(trimmedTarget, {
 			allowMaxAlias: true,
+			allowAutoAlias: true,
 			isLiteralModelId: (provider, id) =>
 				availableModels.some(model => model.provider === provider && model.id === id),
 		});

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -727,7 +727,7 @@ export interface RoleModelCycleResult {
 export interface ResolvedRoleModel {
 	role: string;
 	model: Model;
-	thinkingLevel?: ThinkingLevel;
+	thinkingLevel?: ConfiguredThinkingLevel;
 	explicitThinkingLevel: boolean;
 }
 
@@ -877,7 +877,7 @@ function parseRetryFallbackSelector(
 		raw: trimmed,
 		provider: parsed.provider,
 		id: parsed.id,
-		thinkingLevel: parsed.thinkingLevel,
+		thinkingLevel: parsed.thinkingLevel === AUTO_THINKING ? undefined : parsed.thinkingLevel,
 	};
 }
 
@@ -2102,7 +2102,7 @@ export class AgentSession {
 			if (config.model) {
 				const resolved = resolveModelOverride([config.model], this.#modelRegistry, this.settings);
 				model = resolved.model;
-				thinkingLevel = resolved.thinkingLevel;
+				thinkingLevel = resolved.thinkingLevel === AUTO_THINKING ? undefined : resolved.thinkingLevel;
 				if (!model) {
 					this.emitNotice("warning", `Advisor "${config.name}": no model matched "${config.model}"`, "advisor");
 					continue;
@@ -2116,7 +2116,7 @@ export class AgentSession {
 					continue;
 				}
 				model = sel.model;
-				thinkingLevel = sel.thinkingLevel;
+				thinkingLevel = sel.thinkingLevel === AUTO_THINKING ? undefined : sel.thinkingLevel;
 			}
 			const advisorModel = model;
 			const advisorName = config.name;

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -12,7 +12,7 @@ import { getModelMatchPreferences, resolveModelRoleValue } from "../config/model
 import type { Settings } from "../config/settings";
 import MODEL_PRIO from "../priority.json" with { type: "json" };
 import commitSystemPrompt from "../prompts/system/commit-message-system.md" with { type: "text" };
-import { toReasoningEffort } from "../thinking";
+import { AUTO_THINKING, toReasoningEffort } from "../thinking";
 
 const COMMIT_SYSTEM_PROMPT = prompt.render(commitSystemPrompt);
 const MAX_DIFF_CHARS = 4000;
@@ -56,7 +56,10 @@ function getSmolModelCandidates(
 		settings,
 		matchPreferences,
 	});
-	addCandidate(configuredSmol.model, configuredSmol.thinkingLevel);
+	addCandidate(
+		configuredSmol.model,
+		configuredSmol.thinkingLevel === AUTO_THINKING ? undefined : configuredSmol.thinkingLevel,
+	);
 
 	for (const pattern of MODEL_PRIO.smol) {
 		const needle = pattern.toLowerCase();

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -11,6 +11,7 @@ import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { getRestorableSessionModels } from "@oh-my-pi/pi-coding-agent/session/session-context";
 import { EPHEMERAL_MODEL_CHANGE_ROLE } from "@oh-my-pi/pi-coding-agent/session/session-entries";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentSession model persistence", () => {
@@ -406,6 +407,22 @@ describe("AgentSession model persistence", () => {
 		const result = await createStartupResumeSession(targetSessionFile, settings);
 
 		expect(result.session.model?.id).toBe(temporaryModel.id);
+	});
+
+	it("activates auto thinking on startup resume when modelRoles.default carries an explicit :auto suffix", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const targetSessionFile = await writeRoleModelSession(
+			modelValue(defaultModel),
+			modelValue(defaultModel),
+			"default",
+		);
+		const settings = Settings.isolated();
+		settings.setModelRole("default", `${modelValue(defaultModel)}:auto`);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		expect(result.session.model?.id).toBe(defaultModel.id);
+		expect(result.session.configuredThinkingLevel()).toBe(AUTO_THINKING);
 	});
 
 	it("lists restorable temporary model before the default fallback", () => {

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -110,6 +110,25 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe("off");
 	});
 
+	it("activates auto thinking when cycling into a role whose value carries an explicit :auto suffix", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const smolModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+
+		await createSession({
+			initialModelId: defaultModel.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: {
+				default: `${defaultModel.provider}/${defaultModel.id}`,
+				smol: `${smolModel.provider}/${smolModel.id}:auto`,
+			},
+		});
+
+		const toSmol = await session.cycleRoleModels(["default", "smol"]);
+		expect(toSmol?.role).toBe("smol");
+		expect(toSmol?.model.id).toBe(smolModel.id);
+		expect(session.configuredThinkingLevel()).toBe(AUTO_THINKING);
+	});
+
 	it("preserves current thinking when switching into default/no-suffix role", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const slowModel = getAnthropicModelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -142,6 +142,21 @@ const mockMaxSuffixModels: Model<Api>[] = [
 	}),
 ];
 
+const mockAutoSuffixModels: Model<Api>[] = [
+	buildModel({
+		id: "runtime:auto",
+		name: "Runtime Auto",
+		api: "openai-completions",
+		provider: "example",
+		baseUrl: "https://example.com/api",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	}),
+];
+
 const mockProviderOverlapModels: Model<"anthropic-messages">[] = [
 	buildModel({
 		id: "kimi-k2.5",
@@ -370,6 +385,14 @@ describe("parseModelPattern", () => {
 		test("literal model ids ending in max win over the thinking alias", () => {
 			const result = parseModelPattern("nanogpt/coding-router:max", mockMaxSuffixModels);
 			expect(result.model?.id).toBe("coding-router:max");
+			expect(result.thinkingLevel).toBeUndefined();
+			expect(result.explicitThinkingLevel).toBe(false);
+			expect(result.warning).toBeUndefined();
+		});
+
+		test("literal model ids ending in auto win over the auto sentinel alias", () => {
+			const result = parseModelPattern("example/runtime:auto", mockAutoSuffixModels);
+			expect(result.model?.id).toBe("runtime:auto");
 			expect(result.thinkingLevel).toBeUndefined();
 			expect(result.explicitThinkingLevel).toBe(false);
 			expect(result.warning).toBeUndefined();
@@ -1074,6 +1097,26 @@ describe("parseModelString", () => {
 			expect(result).toEqual({ provider: "nanogpt", id: "coding-router:max" });
 		});
 
+		test("leaves :auto attached to the model id unless the caller opts in via allowAutoAlias", () => {
+			// Without allowAutoAlias, the strict suffix parser must not silently
+			// reinterpret a literal `:auto` id as an auto-thinking selector.
+			const result = parseModelString("example/runtime:auto");
+			expect(result).toEqual({ provider: "example", id: "runtime:auto" });
+		});
+
+		test("extracts auto sentinel when explicitly enabled for provider id selectors", () => {
+			const result = parseModelString("openai/gpt-5:auto", { allowAutoAlias: true });
+			expect(result).toEqual({ provider: "openai", id: "gpt-5", thinkingLevel: "auto" });
+		});
+
+		test("preserves literal :auto model ids when the caller can prove they exist", () => {
+			const result = parseModelString("example/runtime:auto", {
+				allowAutoAlias: true,
+				isLiteralModelId: (provider, id) => provider === "example" && id === "runtime:auto",
+			});
+			expect(result).toEqual({ provider: "example", id: "runtime:auto" });
+		});
+
 		test("does not strip inherited object keys as thinking suffixes", () => {
 			const result = parseModelString("anthropic/claude-sonnet-4-5:constructor");
 			expect(result).toEqual({ provider: "anthropic", id: "claude-sonnet-4-5:constructor" });
@@ -1103,6 +1146,12 @@ describe("resolveModelFromString", () => {
 		const result = resolveModelFromString("nanogpt/coding-router:max", mockMaxSuffixModels);
 		expect(result?.provider).toBe("nanogpt");
 		expect(result?.id).toBe("coding-router:max");
+	});
+
+	test("preserves literal :auto provider model ids before alias parsing", () => {
+		const result = resolveModelFromString("example/runtime:auto", mockAutoSuffixModels);
+		expect(result?.provider).toBe("example");
+		expect(result?.id).toBe("runtime:auto");
 	});
 });
 
@@ -1144,6 +1193,20 @@ describe("extractExplicitThinkingSelector", () => {
 			isLiteralModelId: (provider, id) => provider === "nanogpt" && id === "coding-router:max",
 		});
 		expect(result).toBe(Effort.XHigh);
+	});
+
+	test("does not carry auto from literal role model ids", () => {
+		const result = extractExplicitThinkingSelector("nanogpt/coding-router:auto", undefined, {
+			isLiteralModelId: (provider, id) => provider === "nanogpt" && id === "coding-router:auto",
+		});
+		expect(result).toBeUndefined();
+	});
+
+	test("treats auto as an explicit selector when the model id is not literal", () => {
+		const result = extractExplicitThinkingSelector("openai/gpt-5:auto", undefined, {
+			isLiteralModelId: () => false,
+		});
+		expect(result).toBe("auto");
 	});
 });
 

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -611,6 +611,25 @@ describe("resolveModelRoleValue", () => {
 		expect(result.thinkingLevel).toBe(Effort.High);
 		expect(result.explicitThinkingLevel).toBe(true);
 	});
+
+	test("preserves an explicit :auto suffix as an explicit thinking selector", () => {
+		const result = resolveModelRoleValue("anthropic/claude-sonnet-4-5:auto", allModels);
+
+		expect(result.model?.provider).toBe("anthropic");
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+		expect(result.thinkingLevel).toBe("auto");
+		expect(result.explicitThinkingLevel).toBe(true);
+		expect(result.warning).toBeUndefined();
+	});
+
+	test("does not clamp :auto against the model's supported efforts", () => {
+		// claude-sonnet-4-5 caps at "high"; ensure auto isn't collapsed onto it
+		// by resolveThinkingLevelForModel.
+		const result = resolveModelRoleValue("anthropic/claude-sonnet-4-5:auto", allModels);
+
+		expect(result.thinkingLevel).toBe("auto");
+		expect(result.explicitThinkingLevel).toBe(true);
+	});
 });
 describe("resolveAgentModelPatterns", () => {
 	test("falls back to the active session model when pi/task is unset", () => {

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -174,6 +174,47 @@ describe("ModelSelector role badge thinking display", () => {
 		expect(rendered).toContain("DEFAULT (auto)");
 	});
 
+	test("renders DEFAULT (auto) when modelRoles.default carries an explicit :auto suffix", async () => {
+		installTestTheme();
+		const model = getBundledModel("openai", "gpt-5.5");
+		if (!model) throw new Error("Expected bundled model openai/gpt-5.5");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}:auto`,
+			},
+		});
+
+		const selector = createSelector(model, settings);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (auto)");
+		expect(rendered).not.toContain("DEFAULT (inherit)");
+	});
+
+	test("renders SMOL (auto) when modelRoles.smol carries an explicit :auto suffix", async () => {
+		installTestTheme();
+		const model = getBundledModel("openai", "gpt-5.5");
+		if (!model) throw new Error("Expected bundled model openai/gpt-5.5");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}`,
+				smol: `${model.provider}/${model.id}:auto`,
+			},
+		});
+
+		const selector = createSelector(model, settings);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("SMOL (auto)");
+		expect(rendered).not.toContain("SMOL (inherit)");
+	});
+
 	test("shows compact auto badges for unconfigured role defaults", async () => {
 		installTestTheme();
 		const settings = Settings.isolated({});


### PR DESCRIPTION
## Repro

With `modelRoles: { smol: "openai/gpt-5:auto" }` or `modelRoles: { default: "openai/gpt-5:auto" }` in settings, the model selector renders the role badge as `(inherit)` instead of `(auto)`, and startup emits `Warning: Invalid thinking level "auto" in pattern "openai/gpt-5:auto". Using default instead.`. Startup resume of the default role also fails to activate auto thinking when the role value alone carries `:auto` (no separate `defaultThinkingLevel`). Reproduced against a mini resolver-level test:

```
cd packages/coding-agent && bun test test/tmp/auto-repro.test.ts
# resolved: { thinkingLevel: undefined, explicitThinkingLevel: false,
#   warning: "Invalid thinking level \"auto\" ... Using default instead." }
# expect(explicitThinkingLevel).toBe(true) -> false
```

## Cause

`parseThinkingSuffix` / `splitThinkingSuffix` in `packages/coding-agent/src/config/model-resolver.ts` only recognized the concrete `ThinkingLevel` values plus the `max` alias — the `AUTO_THINKING` sentinel (`"auto"`) was never accepted as a valid selector. `parseModelPatternWithContext` therefore treated the `:auto` suffix as an invalid thinking level, warned, and set `explicitThinkingLevel: false`. `ModelSelectorComponent.#getResolvedRoleThinkingLevel` then fell through to `ThinkingLevel.Inherit` for non-default roles, and to `defaultThinkingLevel` for the default role — so `SMOL/DEFAULT (auto)` never rendered when the intent was baked into the role value, and `sdk.ts::pickInitialThinkingLevel` never saw an explicit auto to reactivate on resume.

## Fix

- `parseThinkingSuffix` / `splitThinkingSuffix` return `ConfiguredThinkingLevel | undefined` and recognize `"auto"` as `AUTO_THINKING`.
- `ParsedModelResult.thinkingLevel`, `parseModelString`, `ResolvedModelRoleValue.thinkingLevel`, `ResolveCliModelResult.thinkingLevel`, `extractExplicitThinkingSelector`, and `formatModelSelectorValue` carry `ConfiguredThinkingLevel` end to end so the sentinel round-trips through selector rendering, `#formatRoleModelValue` persistence, and CLI parsing.
- `resolveModelRoleValue` skips the model-metadata clamp for `AUTO_THINKING` so an explicit auto is not silently coerced down to a supported effort.
- `ResolvedRoleModel.thinkingLevel` widens too, so `applyRoleModel` / `cycleRoleModels` can forward `AUTO_THINKING` into `setThinkingLevel`, which already handles the auto path.
- `ModelSelectorComponent.#getResolvedRoleThinkingLevel` accepts the widened `resolved.thinkingLevel`; the badge renderer's existing `getConfiguredThinkingLevelMetadata` branch already produces `(auto)`.
- Auto is a session-level concept only, so it's coerced to `undefined` at concrete-only boundaries: `resolveGlobScopePattern` (enabledModels scope), `parseRetryFallbackSelector`, the advisor path in `agent-session.ts`, `resolveModelScope`'s scoped-model builder (Ctrl+P per-model overrides), `resolvePrimaryModel` / `resolveSmolModel` in the commit pipeline, `commit-message-generator`, `guided-setup`, and `bench-cli`.

## Verification

- `bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts packages/coding-agent/test/keybindings-escape-components.test.ts packages/coding-agent/test/agent-session-model-persistence.test.ts packages/coding-agent/test/agent-session-role-thinking.test.ts packages/coding-agent/test/model-resolver.test.ts` — 168 pass, 0 fail (with the added regressions).
- `bun run check` (biome + docs + types) — clean.
- Full `bun test` on `packages/coding-agent` — 7989 pass, 4 pre-existing failures unrelated to this change (snapcompact chars binding, ssh host classification ENOENT); confirmed identical failures on the base branch via `git stash` + rerun.

New tests cover: explicit `:auto` preserved through `resolveModelRoleValue` with `explicitThinkingLevel=true` and no warning, `ModelSelector` rendering `DEFAULT (auto)` / `SMOL (auto)` from `:auto` role values, `cycleRoleModels` activating auto thinking when entering a `:auto` role, and startup resume activating auto thinking when `modelRoles.default` carries `:auto`.

Fixes #4128