### PR TITLE
feat(slash-commands): implement colon-delimited taxonomy autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ Setting-gated, off by default: `github`, `inspect_image`, `tts`, `checkpoint`, `
 
 [Full reference →](https://omp.sh/docs/tools)
 
-## Forty-plus providers, hundreds of models, _one /model away_.
+## Forty-plus providers, hundreds of models, _one /cmd:model away_.
 
-Roles route work by intent. `default` for normal turns. `smol` for cheap subagent fan-out. `slow` for deep reasoning. `plan` for plan mode. `commit` for changelogs. Override at launch with `--smol`, `--slow`, or `--plan`; cycle through the configured models for the active role with `Ctrl+P`. Swap the active model mid-session with the `/model` slash command.
+Roles route work by intent. `default` for normal turns. `smol` for cheap subagent fan-out. `slow` for deep reasoning. `plan` for plan mode. `commit` for changelogs. Override at launch with `--smol`, `--slow`, or `--plan`; cycle through the configured models for the active role with `Ctrl+P`. Swap the active model mid-session with the `/cmd:model` slash command.
 
 Auth tags below: `oauth` signs in with your provider account, `plan` routes through a coding-plan subscription, `local` runs against a local server with the key optional.
 

--- a/docs/collab.md
+++ b/docs/collab.md
@@ -89,7 +89,7 @@ Guests with a full link can:
 
 Guests with a view-only link can read everything live — back-transcript, streaming text, tool cards, subagent transcripts — but the host rejects prompting, interrupting, and agent control from them.
 
-Everything that mutates the host session or machine is host-only: `/model`, `/compact`, `/resume`, `/branch`, bash (`!`), python (`$`), skills, etc. Guests keep a small local allowlist (`/dump`, `/export`, `/copy`, `/help`, `/hotkeys`, `/theme`, `/settings`, `/leave`, `/collab`, `/exit`, `/quit`).
+Everything that mutates the host session or machine is host-only: `/cmd:model`, `/cmd:compact`, `/cmd:resume`, `/cmd:branch`, bash (`!`), python (`$`), skills, etc. Guests keep a small local allowlist (`/cmd:dump`, `/cmd:export`, `/cmd:copy`, `/cmd:help`, `/cmd:hotkeys`, `/cmd:theme`, `/cmd:settings`, `/cmd:leave`, `/cmd:collab`, `/cmd:exit`, `/cmd:quit`).
 
 Known v1 limit for guests: a turn already streaming when you join becomes visible from its next message boundary.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -43,12 +43,12 @@ Logins are **provider-scoped**: authenticating `anthropic` does not authenticate
 
 Use the interactive slash commands inside a session:
 
-- `/login` — opens the OAuth/key selector. `/login <provider>` jumps straight to one provider (e.g. `/login anthropic`); for an OAuth flow that needs a pasted callback, run `/login <redirect-url>` to complete it.
-- `/logout` — opens the provider selector to remove stored credentials.
+- `/cmd:login` — opens the OAuth/key selector. `/cmd:login <provider>` jumps straight to one provider (e.g. `/cmd:login anthropic`); for an OAuth flow that needs a pasted callback, run `/cmd:login <redirect-url>` to complete it.
+- `/cmd:logout` — opens the provider selector to remove stored credentials.
 
 For headless or remote setups backed by a shared auth broker, the CLI exposes `omp auth-broker login <provider>` / `omp auth-broker logout` (and `status`, `list`, `import`, `migrate`). See [Secrets and credentials](./secrets.md) for the broker model.
 
-When a model has no credentials, `omp` tells you to run `/login` or set the provider's environment variable.
+When a model has no credentials, `omp` tells you to run `/cmd:login` or set the provider's environment variable.
 
 ### Pinning a key in `models.yml`
 

--- a/docs/slash-command-internals.md
+++ b/docs/slash-command-internals.md
@@ -133,18 +133,26 @@ Current embedded set comes from `src/task/commands.ts` and is used as a fallback
 
 Interactive mode combines multiple command sources for autocomplete and command routing.
 
+Non-skill commands are surfaced with a `cmd:` namespace in the picker:
+
+- built-ins appear as `/cmd:model`, `/cmd:compact`, etc.
+- extension, TypeScript custom, MCP prompt, file, and prompt-template commands appear as `/cmd:<name>`
+- skills remain `/skill:<name>` so typing `/cmd:` narrows to commands and typing `/skill:` narrows to skills
+
+The dispatcher still normalizes `/cmd:<name>` to the underlying command name before execution/expansion, so `/cmd:review args` resolves the same loaded file or custom command as its raw command record. Legacy raw invocations remain accepted for compatibility, but autocomplete advertises the namespaced form.
+
 At construction time it builds a pending command list from:
 
-- built-ins (`BUILTIN_SLASH_COMMANDS`, includes argument completion and inline hints for selected commands)
-- extension-registered slash commands (`extensionRunner.getRegisteredCommands(...)`)
-- TypeScript custom commands (`session.customCommands`), mapped to slash command labels
+- built-ins (`buildTuiBuiltinSlashCommands`, includes argument completion and inline hints for selected commands, materialized as `cmd:` names)
+- extension-registered slash commands (`extensionRunner.getRegisteredCommands(...)`, materialized as `cmd:` names)
+- TypeScript custom commands (`session.customCommands`), mapped to `cmd:` slash command labels
 - optional skill commands (`/skill:<name>`) when `skills.enableSkillCommands` is enabled
 
 Then `init()` calls `refreshSlashCommandState(...)` to load file-based commands and install one autocomplete provider (`createPromptActionAutocompleteProvider`, a `PromptActionAutocompleteProvider` wrapping a `CombinedAutocompleteProvider`) containing:
 
 - pending commands above
-- discovered file-based commands
-- discovered prompt-template commands whose names aren't already taken by a built-in/hook/custom/skill/file command
+- discovered file-based commands, materialized as `cmd:` names
+- discovered prompt-template commands whose raw names aren't already taken by a built-in/hook/custom/skill/file command, materialized as `cmd:` names
 
 `refreshSlashCommandState(...)` also updates `session.setSlashCommands(...)` so prompt expansion uses the same discovered file command set.
 

--- a/issue-cmd-prefix.md
+++ b/issue-cmd-prefix.md
@@ -1,0 +1,19 @@
+### Description
+
+Currently, all slash commands and prompt templates are merged into the same autocomplete picker namespace. Builtin slash commands, extension commands, custom commands, and prompt templates occupy the root namespace (e.g. `/model`, `/review`). This causes a few pain points:
+
+1. **Autocomplete clutter:** When a project defines many prompt templates in its `.omp/prompts` or `.codex/prompts` directory, the root autocomplete picker becomes extremely noisy. Typing `/` floods the UI with templates, burying core session commands like `/compact` or `/settings`.
+2. **Namespace collision and priority inversion:** A prompt template named `model` will silently conflict with or shadow the builtin `/model` command, leading to unpredictable behavior or broken core features.
+3. **Lack of visual distinction:** Users cannot easily distinguish between a hardcoded runtime command, a custom TypeScript hook, and a file-based prompt template.
+
+### Proposed Solution
+
+Namespace all non-skill commands (built-ins, extensions, custom TS commands, file-based commands, and prompt templates) under a `cmd:` prefix in the UI.
+
+- Built-ins and templates will appear as `/cmd:<name>`.
+- Skills remain under the `/skill:<name>` namespace.
+- Typing `/cmd:` will cleanly filter the autocomplete list to commands/templates only.
+- Typing `/skill:` will filter to skills only.
+- The underlying dispatcher should automatically strip the `/cmd:` prefix and route to the raw command, preserving legacy raw invocations for backward compatibility (e.g., executing `/review` still works), while properly supporting edge cases where legacy dynamic commands actually start with `cmd:`.
+
+*Note: The code for this is already implemented locally on the `cmd-prefix-slash-commands` branch (commit `6115ecca7`), but requires manual pushing due to remote GitHub credential constraints.*

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Namespaced non-skill slash commands under `/cmd:<name>` in command autocomplete and ACP command metadata so `/cmd:` filters commands separately from `/skill:<name>`.
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/prompt-templates.ts
+++ b/packages/coding-agent/src/config/prompt-templates.ts
@@ -8,6 +8,7 @@ import {
 	parseFrontmatter,
 	prompt,
 } from "@oh-my-pi/pi-utils";
+import { parseSlashToken } from "../slash-commands/names";
 import { jtdToTypeScript } from "../tools/jtd-to-typescript";
 import { parseCommandArgs, substituteArgs } from "../utils/command-args";
 
@@ -187,11 +188,13 @@ export async function loadPromptTemplates(options: LoadPromptTemplatesOptions = 
 export function expandPromptTemplate(text: string, templates: PromptTemplate[]): string {
 	if (!text.startsWith("/")) return text;
 
-	const spaceIndex = text.indexOf(" ");
-	const templateName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-	const argsString = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+	const parsed = parseSlashToken(text);
+	if (!parsed) return text;
+	const { args: argsString } = parsed;
 
-	const template = templates.find(t => t.name === templateName);
+	const template =
+		(parsed.legacyName ? templates.find(t => t.name === parsed.legacyName) : undefined) ??
+		templates.find(t => t.name === parsed.name);
 	if (template) {
 		const args = parseCommandArgs(argsString);
 		const argsText = args.join(" ");

--- a/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
+++ b/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
@@ -16,7 +16,7 @@
  */
 import type { SkillsSettings } from "../../config/settings";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES } from "../../slash-commands/builtin-registry";
-import { toCommandSlashName } from "../../slash-commands/names";
+import { toExtensionSlashName } from "../../slash-commands/names";
 import type { CustomCommandSource, LoadedCustomCommand } from "../custom-commands";
 import { getSkillSlashCommandName, type Skill } from "../skills";
 import type { SlashCommandInfo, SlashCommandLocation } from "../slash-commands";
@@ -36,7 +36,7 @@ export function getSessionSlashCommands(session: CommandsCapableSession): SlashC
 	if (runner) {
 		for (const cmd of runner.getRegisteredCommands(BUILTIN_SLASH_COMMAND_RESERVED_NAMES)) {
 			out.push({
-				name: toCommandSlashName(cmd.name),
+				name: toExtensionSlashName(cmd.name),
 				description: cmd.description,
 				source: "extension",
 			});
@@ -45,7 +45,7 @@ export function getSessionSlashCommands(session: CommandsCapableSession): SlashC
 
 	for (const cmd of session.customCommands) {
 		out.push({
-			name: toCommandSlashName(cmd.command.name),
+			name: cmd.command.name,
 			description: cmd.command.description,
 			source: "prompt",
 			location: customCommandLocation(cmd.source),

--- a/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
+++ b/packages/coding-agent/src/extensibility/extensions/get-commands-handler.ts
@@ -16,6 +16,7 @@
  */
 import type { SkillsSettings } from "../../config/settings";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES } from "../../slash-commands/builtin-registry";
+import { toCommandSlashName } from "../../slash-commands/names";
 import type { CustomCommandSource, LoadedCustomCommand } from "../custom-commands";
 import { getSkillSlashCommandName, type Skill } from "../skills";
 import type { SlashCommandInfo, SlashCommandLocation } from "../slash-commands";
@@ -35,7 +36,7 @@ export function getSessionSlashCommands(session: CommandsCapableSession): SlashC
 	if (runner) {
 		for (const cmd of runner.getRegisteredCommands(BUILTIN_SLASH_COMMAND_RESERVED_NAMES)) {
 			out.push({
-				name: cmd.name,
+				name: toCommandSlashName(cmd.name),
 				description: cmd.description,
 				source: "extension",
 			});
@@ -44,7 +45,7 @@ export function getSessionSlashCommands(session: CommandsCapableSession): SlashC
 
 	for (const cmd of session.customCommands) {
 		out.push({
-			name: cmd.command.name,
+			name: toCommandSlashName(cmd.command.name),
 			description: cmd.command.description,
 			source: "prompt",
 			location: customCommandLocation(cmd.source),

--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -3,6 +3,7 @@ import { slashCommandCapability } from "../capability/slash-command";
 import { appendInlineArgsFallback, templateUsesInlineArgPlaceholders } from "../config/prompt-templates";
 import type { SlashCommand } from "../discovery";
 import { loadCapability } from "../discovery";
+import { parseSlashToken } from "../slash-commands/names";
 import { EMBEDDED_COMMAND_TEMPLATES } from "../task/commands";
 import { parseCommandArgs, substituteArgs } from "../utils/command-args";
 
@@ -113,11 +114,13 @@ export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}):
 export function expandSlashCommand(text: string, fileCommands: FileSlashCommand[]): string {
 	if (!text.startsWith("/")) return text;
 
-	const spaceIndex = text.indexOf(" ");
-	const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-	const argsString = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+	const parsed = parseSlashToken(text);
+	if (!parsed) return text;
+	const { args: argsString } = parsed;
 
-	const fileCommand = fileCommands.find(cmd => cmd.name === commandName);
+	const fileCommand =
+		(parsed.legacyName ? fileCommands.find(cmd => cmd.name === parsed.legacyName) : undefined) ??
+		fileCommands.find(cmd => cmd.name === parsed.name);
 	if (fileCommand) {
 		const args = parseCommandArgs(argsString);
 		const argsText = args.join(" ");

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -18,6 +18,7 @@ import type { InteractiveModeContext } from "../../modes/types";
 import manualContinuePrompt from "../../prompts/system/manual-continue.md" with { type: "text" };
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
+import { parseSlashCommand } from "../../slash-commands/helpers/parse";
 import { isTinyTitleLocalModelKey } from "../../tiny/models";
 import { isLowSignalTitleInput } from "../../tiny/text";
 import { tinyTitleClient } from "../../tiny/title-client";
@@ -48,21 +49,16 @@ import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title
  * on the earliest whitespace or colon — so /login:?code=... is correctly matched.
  */
 export function shouldSkipHistory(slashText: string): boolean {
-	if (!slashText.startsWith("/")) return false;
-	const body = slashText.slice(1);
-	// Match parseSlashCommand: split on earliest whitespace or colon.
-	const firstWs = body.search(/\s/);
-	const firstColon = body.indexOf(":");
-	const sep = firstWs === -1 ? firstColon : firstColon === -1 ? firstWs : Math.min(firstWs, firstColon);
-	const name = sep === -1 ? body : body.slice(0, sep);
-	const hasArgs = sep !== -1;
+	const parsed = parseSlashCommand(slashText);
+	if (!parsed) return false;
+	const { name, args } = parsed;
+	const hasArgs = args.length > 0;
 	// /login <anything> — parseCallbackInput() accepts redirect URLs, query
 	// strings (?code=...), and raw auth codes, all of which carry secrets.
 	if (name === "login" && hasArgs) return true;
 	// /join <link> — the link carries the 32-byte room key and write token.
 	if (name === "join" && hasArgs) return true;
 	if (name === "mcp") {
-		const args = body.slice(sep + 1).trim();
 		return args.startsWith("add") && /--token\s/.test(args);
 	}
 	return false;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -97,7 +97,7 @@ import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } from "../slash-commands/builtin-registry";
 import { formatDuration } from "../slash-commands/helpers/format";
-import { stripCommandSlashName, toCommandSlashName } from "../slash-commands/names";
+import { stripCommandSlashName, toBuiltinSlashName, toExtensionSlashName, toMcpSlashName, toPromptSlashName } from "../slash-commands/names";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { formatTaskId } from "../task/render";
@@ -670,14 +670,14 @@ export class InteractiveMode implements InteractiveModeContext {
 		const hookCommands: SlashCommand[] = (
 			this.session.extensionRunner?.getRegisteredCommands(BUILTIN_SLASH_COMMAND_RESERVED_NAMES) ?? []
 		).map(cmd => ({
-			name: toCommandSlashName(cmd.name),
+			name: toBuiltinSlashName(cmd.name),
 			description: cmd.description ?? "(hook command)",
 			getArgumentCompletions: cmd.getArgumentCompletions,
 		}));
 
 		// Convert custom commands (TypeScript) to SlashCommand format
 		const customCommands: SlashCommand[] = this.session.customCommands.map(loaded => ({
-			name: toCommandSlashName(loaded.command.name),
+			name: loaded.path?.startsWith("mcp:") ? toMcpSlashName(loaded.command.name) : loaded.command.name,
 			description: `${loaded.command.description} (${loaded.source})`,
 		}));
 
@@ -999,7 +999,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const fileCommands = await loadSlashCommands({ cwd: basePath });
 		this.fileSlashCommands = new Set(fileCommands.map(cmd => cmd.name));
 		const fileSlashCommands: SlashCommand[] = fileCommands.map(cmd => ({
-			name: toCommandSlashName(cmd.name),
+			name: toExtensionSlashName(cmd.name),
 			description: cmd.description,
 		}));
 		// Surface discovered prompt templates in the picker. AgentSession.prompt() expands
@@ -1023,7 +1023,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const promptTemplateCommands: SlashCommand[] = this.session.promptTemplates
 			.filter(template => !reservedNames.has(template.name))
 			.map(template => ({
-				name: toCommandSlashName(template.name),
+				name: toPromptSlashName(template.name),
 				// `PromptTemplate.description` from `loadTemplatesFromDir` already includes the
 				// source suffix (e.g. "Review code (project)"), so pass it through verbatim.
 				description: template.description,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -97,6 +97,7 @@ import type { SessionManager } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { BUILTIN_SLASH_COMMAND_RESERVED_NAMES, buildTuiBuiltinSlashCommands } from "../slash-commands/builtin-registry";
 import { formatDuration } from "../slash-commands/helpers/format";
+import { stripCommandSlashName, toCommandSlashName } from "../slash-commands/names";
 import { STTController, type SttState } from "../stt";
 import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-prompt";
 import { formatTaskId } from "../task/render";
@@ -669,14 +670,14 @@ export class InteractiveMode implements InteractiveModeContext {
 		const hookCommands: SlashCommand[] = (
 			this.session.extensionRunner?.getRegisteredCommands(BUILTIN_SLASH_COMMAND_RESERVED_NAMES) ?? []
 		).map(cmd => ({
-			name: cmd.name,
+			name: toCommandSlashName(cmd.name),
 			description: cmd.description ?? "(hook command)",
 			getArgumentCompletions: cmd.getArgumentCompletions,
 		}));
 
 		// Convert custom commands (TypeScript) to SlashCommand format
 		const customCommands: SlashCommand[] = this.session.customCommands.map(loaded => ({
-			name: loaded.command.name,
+			name: toCommandSlashName(loaded.command.name),
 			description: `${loaded.command.description} (${loaded.source})`,
 		}));
 
@@ -998,7 +999,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const fileCommands = await loadSlashCommands({ cwd: basePath });
 		this.fileSlashCommands = new Set(fileCommands.map(cmd => cmd.name));
 		const fileSlashCommands: SlashCommand[] = fileCommands.map(cmd => ({
-			name: cmd.name,
+			name: toCommandSlashName(cmd.name),
 			description: cmd.description,
 		}));
 		// Surface discovered prompt templates in the picker. AgentSession.prompt() expands
@@ -1007,18 +1008,22 @@ export class InteractiveMode implements InteractiveModeContext {
 		// resolution order by skipping templates whose names already appear in any
 		// builtin/hook/custom/skill/file command token.
 		const reservedNames = new Set<string>();
+		const reserveName = (name: string) => {
+			reservedNames.add(name);
+			reservedNames.add(stripCommandSlashName(name));
+		};
 		for (const command of this.#pendingSlashCommands) {
-			reservedNames.add(command.name);
-			for (const alias of command.aliases ?? []) reservedNames.add(alias);
+			reserveName(command.name);
+			for (const alias of command.aliases ?? []) reserveName(alias);
 		}
 		for (const command of fileSlashCommands) {
-			reservedNames.add(command.name);
-			for (const alias of command.aliases ?? []) reservedNames.add(alias);
+			reserveName(command.name);
+			for (const alias of command.aliases ?? []) reserveName(alias);
 		}
 		const promptTemplateCommands: SlashCommand[] = this.session.promptTemplates
 			.filter(template => !reservedNames.has(template.name))
 			.map(template => ({
-				name: template.name,
+				name: toCommandSlashName(template.name),
 				// `PromptTemplate.description` from `loadTemplatesFromDir` already includes the
 				// source suffix (e.g. "Review code (project)"), so pass it through verbatim.
 				description: template.description,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -263,6 +263,7 @@ import {
 	obfuscateProviderContext,
 	type SecretObfuscator,
 } from "../secrets/obfuscator";
+import { parseSlashToken } from "../slash-commands/names";
 import { invalidateHostMetadata } from "../ssh/connection-manager";
 import {
 	AUTO_THINKING,
@@ -6486,6 +6487,16 @@ export class AgentSession {
 		return this.#promptTemplates;
 	}
 
+	hasRawSlashCommandName(name: string): boolean {
+		return (
+			this.#customCommands.some(command => command.command.name === name) ||
+			this.#mcpPromptCommands.some(command => command.command.name === name) ||
+			this.#slashCommands.some(command => command.name === name) ||
+			this.#promptTemplates.some(template => template.name === name) ||
+			Boolean(this.#extensionRunner?.getCommand(name))
+		);
+	}
+
 	/** Replace file-based slash commands used for prompt expansion. */
 	setSlashCommands(slashCommands: FileSlashCommand[]): void {
 		this.#slashCommands = [...slashCommands];
@@ -7138,13 +7149,14 @@ export class AgentSession {
 	async #tryExecuteExtensionCommand(text: string): Promise<boolean> {
 		if (!this.#extensionRunner) return false;
 
-		// Parse command name and args
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+		const parsed = parseSlashToken(text);
+		if (!parsed) return false;
+		const args = parsed.args;
 
-		const command = this.#extensionRunner.getCommand(commandName);
+		const legacyCommand = parsed.legacyName ? this.#extensionRunner.getCommand(parsed.legacyName) : undefined;
+		const command = legacyCommand ?? this.#extensionRunner.getCommand(parsed.name);
 		if (!command) return false;
+		const commandName = legacyCommand && parsed.legacyName ? parsed.legacyName : parsed.name;
 
 		// Get command context from extension runner (includes session control methods)
 		const ctx = this.#extensionRunner.createCommandContext();
@@ -7229,15 +7241,19 @@ export class AgentSession {
 	async #tryExecuteCustomCommand(text: string): Promise<string | null> {
 		if (this.#customCommands.length === 0 && this.#mcpPromptCommands.length === 0) return null;
 
-		// Parse command name and args
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const argsString = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+		const parsed = parseSlashToken(text);
+		if (!parsed) return null;
+		const argsString = parsed.args;
 
 		// Find matching command
 		const loaded =
-			this.#customCommands.find(c => c.command.name === commandName) ??
-			this.#mcpPromptCommands.find(c => c.command.name === commandName);
+			(parsed.legacyName
+				? (this.#customCommands.find(c => c.command.name === parsed.legacyName) ??
+					this.#mcpPromptCommands.find(c => c.command.name === parsed.legacyName))
+				: undefined) ??
+			this.#customCommands.find(c => c.command.name === parsed.name) ??
+			this.#mcpPromptCommands.find(c => c.command.name === parsed.name);
+		const commandName = loaded?.command.name ?? parsed.name;
 		if (!loaded) return null;
 
 		// Get command context from extension runner (includes session control methods)
@@ -7461,9 +7477,11 @@ export class AgentSession {
 	#throwIfExtensionCommand(text: string): void {
 		if (!this.#extensionRunner) return;
 
-		const spaceIndex = text.indexOf(" ");
-		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-		const command = this.#extensionRunner.getCommand(commandName);
+		const parsed = parseSlashToken(text);
+		if (!parsed) return;
+		const legacyCommand = parsed.legacyName ? this.#extensionRunner.getCommand(parsed.legacyName) : undefined;
+		const command = legacyCommand ?? this.#extensionRunner.getCommand(parsed.name);
+		const commandName = legacyCommand && parsed.legacyName ? parsed.legacyName : parsed.name;
 
 		if (command) {
 			throw new Error(

--- a/packages/coding-agent/src/slash-commands/acp-builtins.ts
+++ b/packages/coding-agent/src/slash-commands/acp-builtins.ts
@@ -1,6 +1,7 @@
 import type { AvailableCommand } from "@agentclientprotocol/sdk";
 import { BUILTIN_SLASH_COMMANDS_INTERNAL, lookupBuiltinSlashCommand } from "./builtin-registry";
 import { parseSlashCommand } from "./helpers/parse";
+import { parseSlashToken, stripCommandSlashName, toCommandSlashName } from "./names";
 import type { AcpBuiltinSlashCommandResult, SlashCommandRuntime } from "./types";
 
 export type { AcpBuiltinSlashCommandResult } from "./types";
@@ -11,9 +12,14 @@ export type { AcpBuiltinSlashCommandResult } from "./types";
  * dispatch time (e.g. `models` is an alias for `/model`, so an extension
  * registering `models` would appear in the palette but execute the builtin).
  */
-export const ACP_BUILTIN_RESERVED_NAMES: ReadonlySet<string> = new Set(
+const RAW_ACP_BUILTIN_RESERVED_NAMES = new Set(
 	BUILTIN_SLASH_COMMANDS_INTERNAL.filter(c => c.handle !== undefined).flatMap(c => [c.name, ...(c.aliases ?? [])]),
 );
+
+export const ACP_BUILTIN_RESERVED_NAMES: ReadonlySet<string> = new Set([
+	...RAW_ACP_BUILTIN_RESERVED_NAMES,
+	...[...RAW_ACP_BUILTIN_RESERVED_NAMES].map(toCommandSlashName),
+]);
 
 /**
  * Whether an extension command named `name` would be captured by ACP builtin
@@ -24,9 +30,10 @@ export const ACP_BUILTIN_RESERVED_NAMES: ReadonlySet<string> = new Set(
  * advertised to ACP clients.
  */
 export function isAcpBuiltinShadowedName(name: string): boolean {
-	if (ACP_BUILTIN_RESERVED_NAMES.has(name)) return true;
-	const colon = name.indexOf(":");
-	return colon !== -1 && ACP_BUILTIN_RESERVED_NAMES.has(name.slice(0, colon));
+	const rawName = stripCommandSlashName(name);
+	if (RAW_ACP_BUILTIN_RESERVED_NAMES.has(rawName) || ACP_BUILTIN_RESERVED_NAMES.has(name)) return true;
+	const colon = rawName.indexOf(":");
+	return colon !== -1 && RAW_ACP_BUILTIN_RESERVED_NAMES.has(rawName.slice(0, colon));
 }
 
 /**
@@ -42,7 +49,7 @@ export const ACP_BUILTIN_SLASH_COMMANDS: AvailableCommand[] = BUILTIN_SLASH_COMM
 	// otherwise fall back to the unified `description` / `inlineHint`.
 	const hint = command.acpInputHint ?? command.inlineHint;
 	return {
-		name: command.name,
+		name: toCommandSlashName(command.name),
 		description: command.acpDescription ?? command.description,
 		input: hint ? { hint } : undefined,
 	};
@@ -60,6 +67,9 @@ export async function executeAcpBuiltinSlashCommand(
 	text: string,
 	runtime: SlashCommandRuntime,
 ): Promise<AcpBuiltinSlashCommandResult> {
+	const token = parseSlashToken(text);
+	if (token?.legacyName && runtime.session.hasRawSlashCommandName?.(token.legacyName)) return false;
+
 	const parsed = parseSlashCommand(text);
 	if (!parsed) return false;
 	const command = lookupBuiltinSlashCommand(parsed.name);

--- a/packages/coding-agent/src/slash-commands/acp-builtins.ts
+++ b/packages/coding-agent/src/slash-commands/acp-builtins.ts
@@ -1,7 +1,7 @@
 import type { AvailableCommand } from "@agentclientprotocol/sdk";
 import { BUILTIN_SLASH_COMMANDS_INTERNAL, lookupBuiltinSlashCommand } from "./builtin-registry";
 import { parseSlashCommand } from "./helpers/parse";
-import { parseSlashToken, stripCommandSlashName, toCommandSlashName } from "./names";
+import { parseSlashToken, stripCommandSlashName, toBuiltinSlashName } from "./names";
 import type { AcpBuiltinSlashCommandResult, SlashCommandRuntime } from "./types";
 
 export type { AcpBuiltinSlashCommandResult } from "./types";
@@ -18,7 +18,7 @@ const RAW_ACP_BUILTIN_RESERVED_NAMES = new Set(
 
 export const ACP_BUILTIN_RESERVED_NAMES: ReadonlySet<string> = new Set([
 	...RAW_ACP_BUILTIN_RESERVED_NAMES,
-	...[...RAW_ACP_BUILTIN_RESERVED_NAMES].map(toCommandSlashName),
+	...[...RAW_ACP_BUILTIN_RESERVED_NAMES].map(toBuiltinSlashName),
 ]);
 
 /**
@@ -49,7 +49,7 @@ export const ACP_BUILTIN_SLASH_COMMANDS: AvailableCommand[] = BUILTIN_SLASH_COMM
 	// otherwise fall back to the unified `description` / `inlineHint`.
 	const hint = command.acpInputHint ?? command.inlineHint;
 	return {
-		name: toCommandSlashName(command.name),
+		name: toBuiltinSlashName(command.name),
 		description: command.acpDescription ?? command.description,
 		input: hint ? { hint } : undefined,
 	};

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -7,7 +7,7 @@ import { getSkillSlashCommandName, type Skill } from "../extensibility/skills";
 import { type FileSlashCommand, loadSlashCommands } from "../extensibility/slash-commands";
 import { ACP_BUILTIN_RESERVED_NAMES, isAcpBuiltinShadowedName } from "./acp-builtins";
 import { BUILTIN_SLASH_COMMANDS_INTERNAL } from "./builtin-registry";
-import { toCommandSlashName } from "./names";
+import { toBuiltinSlashName, toExtensionSlashName, toMcpSlashName, toPromptSlashName } from "./names";
 
 export type AvailableSlashCommandSource =
 	| "builtin"
@@ -54,8 +54,8 @@ export async function buildAvailableSlashCommands(
 		if (!command.handle) continue;
 		const hint = command.acpInputHint ?? command.inlineHint;
 		appendCommand({
-			name: toCommandSlashName(command.name),
-			aliases: command.aliases?.map(toCommandSlashName),
+			name: toBuiltinSlashName(command.name),
+			aliases: command.aliases?.map(toBuiltinSlashName),
 			description: command.acpDescription ?? command.description,
 			input: hint ? { hint } : undefined,
 			subcommands: command.subcommands,
@@ -79,7 +79,7 @@ export async function buildAvailableSlashCommands(
 		for (const command of runner.getRegisteredCommands(ACP_BUILTIN_RESERVED_NAMES)) {
 			if (isAcpBuiltinShadowedName(command.name)) continue;
 			appendCommand({
-				name: toCommandSlashName(command.name),
+				name: toExtensionSlashName(command.name),
 				description: command.description ?? "(extension command)",
 				input: { hint: "arguments" },
 				source: "extension",
@@ -90,7 +90,7 @@ export async function buildAvailableSlashCommands(
 	for (const command of session.customCommands) {
 		const source: AvailableSlashCommandSource = command.path?.startsWith("mcp:") ? "mcp_prompt" : "custom";
 		appendCommand({
-			name: toCommandSlashName(command.command.name),
+			name: source === "mcp_prompt" ? toMcpSlashName(command.command.name) : command.command.name,
 			description: command.command.description,
 			input: { hint: "arguments" },
 			source,
@@ -100,12 +100,12 @@ export async function buildAvailableSlashCommands(
 	const fileCommands = await loadFileCommands(session.sessionManager.getCwd());
 	session.setSlashCommands(fileCommands);
 	for (const command of fileCommands) {
-		appendCommand({ name: toCommandSlashName(command.name), description: command.description, source: "file" });
+		appendCommand({ name: command.name, description: command.description, source: "file" });
 	}
 
 	for (const template of session.promptTemplates ?? []) {
 		appendCommand({
-			name: toCommandSlashName(template.name),
+			name: toPromptSlashName(template.name),
 			description: template.description,
 			input: { hint: "arguments" },
 			source: "prompt_template",

--- a/packages/coding-agent/src/slash-commands/available-commands.ts
+++ b/packages/coding-agent/src/slash-commands/available-commands.ts
@@ -1,4 +1,5 @@
 import type { AvailableCommand } from "@agentclientprotocol/sdk";
+import type { PromptTemplate } from "../config/prompt-templates";
 import type { SkillsSettings } from "../config/settings";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
 import type { ExtensionRunner } from "../extensibility/extensions";
@@ -6,8 +7,16 @@ import { getSkillSlashCommandName, type Skill } from "../extensibility/skills";
 import { type FileSlashCommand, loadSlashCommands } from "../extensibility/slash-commands";
 import { ACP_BUILTIN_RESERVED_NAMES, isAcpBuiltinShadowedName } from "./acp-builtins";
 import { BUILTIN_SLASH_COMMANDS_INTERNAL } from "./builtin-registry";
+import { toCommandSlashName } from "./names";
 
-export type AvailableSlashCommandSource = "builtin" | "skill" | "extension" | "custom" | "mcp_prompt" | "file";
+export type AvailableSlashCommandSource =
+	| "builtin"
+	| "skill"
+	| "extension"
+	| "custom"
+	| "mcp_prompt"
+	| "file"
+	| "prompt_template";
 
 export interface InternalAvailableSlashCommand {
 	name: string;
@@ -22,6 +31,7 @@ export interface AvailableCommandsSession {
 	readonly extensionRunner?: ExtensionRunner;
 	readonly customCommands: ReadonlyArray<LoadedCustomCommand>;
 	readonly mcpPromptCommands?: ReadonlyArray<LoadedCustomCommand>;
+	readonly promptTemplates?: ReadonlyArray<PromptTemplate>;
 	readonly skills: ReadonlyArray<Skill>;
 	readonly skillsSettings?: SkillsSettings;
 	setSlashCommands(slashCommands: FileSlashCommand[]): void;
@@ -44,8 +54,8 @@ export async function buildAvailableSlashCommands(
 		if (!command.handle) continue;
 		const hint = command.acpInputHint ?? command.inlineHint;
 		appendCommand({
-			name: command.name,
-			aliases: command.aliases,
+			name: toCommandSlashName(command.name),
+			aliases: command.aliases?.map(toCommandSlashName),
 			description: command.acpDescription ?? command.description,
 			input: hint ? { hint } : undefined,
 			subcommands: command.subcommands,
@@ -69,7 +79,7 @@ export async function buildAvailableSlashCommands(
 		for (const command of runner.getRegisteredCommands(ACP_BUILTIN_RESERVED_NAMES)) {
 			if (isAcpBuiltinShadowedName(command.name)) continue;
 			appendCommand({
-				name: command.name,
+				name: toCommandSlashName(command.name),
 				description: command.description ?? "(extension command)",
 				input: { hint: "arguments" },
 				source: "extension",
@@ -80,7 +90,7 @@ export async function buildAvailableSlashCommands(
 	for (const command of session.customCommands) {
 		const source: AvailableSlashCommandSource = command.path?.startsWith("mcp:") ? "mcp_prompt" : "custom";
 		appendCommand({
-			name: command.command.name,
+			name: toCommandSlashName(command.command.name),
 			description: command.command.description,
 			input: { hint: "arguments" },
 			source,
@@ -90,7 +100,16 @@ export async function buildAvailableSlashCommands(
 	const fileCommands = await loadFileCommands(session.sessionManager.getCwd());
 	session.setSlashCommands(fileCommands);
 	for (const command of fileCommands) {
-		appendCommand({ name: command.name, description: command.description, source: "file" });
+		appendCommand({ name: toCommandSlashName(command.name), description: command.description, source: "file" });
+	}
+
+	for (const template of session.promptTemplates ?? []) {
+		appendCommand({
+			name: toCommandSlashName(template.name),
+			description: template.description,
+			input: { hint: "arguments" },
+			source: "prompt_template",
+		});
 	}
 
 	return commands;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -46,7 +46,7 @@ import { launchStatsDashboard, parseStatsDashboardArgs } from "./helpers/stats-d
 import { handleTodoAcp } from "./helpers/todo";
 import { buildUsageReportText } from "./helpers/usage-report";
 import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace-install-parser";
-import { parseSlashToken, stripCommandSlashName, toCommandSlashName } from "./names";
+import { parseSlashToken, stripCommandSlashName, toBuiltinSlashName } from "./names";
 import type {
 	BuiltinSlashCommand,
 	ParsedSlashCommand,
@@ -2419,8 +2419,8 @@ function materializeTuiBuiltinSlashCommand(
 ): TuiBuiltinSlashCommand {
 	const materialized: TuiBuiltinSlashCommand = {
 		...cmd,
-		name: toCommandSlashName(cmd.name),
-		aliases: cmd.aliases?.map(toCommandSlashName),
+		name: toBuiltinSlashName(cmd.name),
+		aliases: cmd.aliases?.map(toBuiltinSlashName),
 	};
 	if (cmd.subcommands) {
 		materialized.getArgumentCompletions = buildArgumentCompletions(cmd.subcommands);

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -46,6 +46,7 @@ import { launchStatsDashboard, parseStatsDashboardArgs } from "./helpers/stats-d
 import { handleTodoAcp } from "./helpers/todo";
 import { buildUsageReportText } from "./helpers/usage-report";
 import { parseMarketplaceInstallArgs, parsePluginScopeArgs } from "./marketplace-install-parser";
+import { parseSlashToken, stripCommandSlashName, toCommandSlashName } from "./names";
 import type {
 	BuiltinSlashCommand,
 	ParsedSlashCommand,
@@ -2416,7 +2417,11 @@ function materializeTuiBuiltinSlashCommand(
 	cmd: BuiltinSlashCommand,
 	runtime?: TuiSlashCommandRuntime,
 ): TuiBuiltinSlashCommand {
-	const materialized: TuiBuiltinSlashCommand = { ...cmd };
+	const materialized: TuiBuiltinSlashCommand = {
+		...cmd,
+		name: toCommandSlashName(cmd.name),
+		aliases: cmd.aliases?.map(toCommandSlashName),
+	};
 	if (cmd.subcommands) {
 		materialized.getArgumentCompletions = buildArgumentCompletions(cmd.subcommands);
 		materialized.getInlineHint = buildSubcommandInlineHint(cmd.subcommands);
@@ -2462,6 +2467,9 @@ export async function executeBuiltinSlashCommand(
 	text: string,
 	runtime: BuiltinSlashCommandRuntime,
 ): Promise<string | boolean> {
+	const token = parseSlashToken(text);
+	if (token?.legacyName && runtime.ctx.session?.hasRawSlashCommandName?.(token.legacyName)) return false;
+
 	const parsed = parseSlashCommand(text);
 	if (!parsed) return false;
 
@@ -2516,7 +2524,7 @@ export async function executeBuiltinSlashCommand(
 
 /** Look up a unified spec by name or alias. Used by the ACP dispatcher. */
 export function lookupBuiltinSlashCommand(name: string): SlashCommandSpec | undefined {
-	return BUILTIN_SLASH_COMMAND_LOOKUP.get(name);
+	return BUILTIN_SLASH_COMMAND_LOOKUP.get(stripCommandSlashName(name));
 }
 
 export type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime, SlashCommandSpec, TuiSlashCommandRuntime };

--- a/packages/coding-agent/src/slash-commands/helpers/parse.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/parse.ts
@@ -1,3 +1,4 @@
+import { stripCommandSlashInvocation } from "../names";
 import type { ParsedSlashCommand, SlashCommandResult, SlashCommandRuntime } from "../types";
 
 export interface ParsedSubcommand {
@@ -21,17 +22,18 @@ export interface NamedScopeArgs {
  */
 export function parseSlashCommand(text: string): ParsedSlashCommand | null {
 	if (!text.startsWith("/")) return null;
-	const body = text.slice(1);
+	const normalized = stripCommandSlashInvocation(text);
+	const body = normalized.slice(1);
 	if (!body) return null;
 	const firstWhitespace = body.search(/\s/);
 	const firstColon = body.indexOf(":");
 	const firstSeparator =
 		firstWhitespace === -1 ? firstColon : firstColon === -1 ? firstWhitespace : Math.min(firstWhitespace, firstColon);
-	if (firstSeparator === -1) return { name: body, args: "", text };
+	if (firstSeparator === -1) return { name: body, args: "", text: normalized };
 	return {
 		name: body.slice(0, firstSeparator),
 		args: body.slice(firstSeparator + 1).trim(),
-		text,
+		text: normalized,
 	};
 }
 

--- a/packages/coding-agent/src/slash-commands/names.ts
+++ b/packages/coding-agent/src/slash-commands/names.ts
@@ -1,0 +1,31 @@
+export const COMMAND_SLASH_PREFIX = "cmd:";
+
+export function toCommandSlashName(name: string): string {
+	return `${COMMAND_SLASH_PREFIX}${name}`;
+}
+
+export function stripCommandSlashName(name: string): string {
+	return name.startsWith(COMMAND_SLASH_PREFIX) ? name.slice(COMMAND_SLASH_PREFIX.length) : name;
+}
+
+export function stripCommandSlashInvocation(text: string): string {
+	return text.startsWith(`/${COMMAND_SLASH_PREFIX}`) ? `/${text.slice(COMMAND_SLASH_PREFIX.length + 1)}` : text;
+}
+
+export interface ParsedSlashToken {
+	name: string;
+	args: string;
+	legacyName?: string;
+}
+
+export function parseSlashToken(text: string): ParsedSlashToken | null {
+	if (!text.startsWith("/")) return null;
+	const spaceIndex = text.indexOf(" ");
+	const rawName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	const rawArgs = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1);
+	return {
+		name: stripCommandSlashName(rawName),
+		args: rawArgs,
+		...(rawName.startsWith(COMMAND_SLASH_PREFIX) && { legacyName: rawName }),
+	};
+}

--- a/packages/coding-agent/src/slash-commands/names.ts
+++ b/packages/coding-agent/src/slash-commands/names.ts
@@ -1,15 +1,55 @@
-export const COMMAND_SLASH_PREFIX = "cmd:";
+export const BUILTIN_SLASH_PREFIX = "cmd:";
+export const EXTENSION_SLASH_PREFIX = "ext:";
+export const MCP_SLASH_PREFIX = "mcp:";
+export const PROMPT_SLASH_PREFIX = "prompt:";
 
-export function toCommandSlashName(name: string): string {
-	return `${COMMAND_SLASH_PREFIX}${name}`;
+export function toBuiltinSlashName(name: string): string {
+	return `${BUILTIN_SLASH_PREFIX}${name}`;
+}
+
+export function toExtensionSlashName(name: string): string {
+	return `${EXTENSION_SLASH_PREFIX}${name}`;
+}
+
+export function toMcpSlashName(name: string): string {
+	return `${MCP_SLASH_PREFIX}${name}`;
+}
+
+export function toPromptSlashName(name: string): string {
+	return `${PROMPT_SLASH_PREFIX}${name}`;
 }
 
 export function stripCommandSlashName(name: string): string {
-	return name.startsWith(COMMAND_SLASH_PREFIX) ? name.slice(COMMAND_SLASH_PREFIX.length) : name;
+	const colonPos = name.indexOf(":");
+	if (colonPos !== -1) {
+		const prefix = name.slice(0, colonPos + 1);
+		if (
+			prefix === BUILTIN_SLASH_PREFIX ||
+			prefix === EXTENSION_SLASH_PREFIX ||
+			prefix === MCP_SLASH_PREFIX ||
+			prefix === PROMPT_SLASH_PREFIX
+		) {
+			return name.slice(prefix.length);
+		}
+	}
+	return name;
 }
 
 export function stripCommandSlashInvocation(text: string): string {
-	return text.startsWith(`/${COMMAND_SLASH_PREFIX}`) ? `/${text.slice(COMMAND_SLASH_PREFIX.length + 1)}` : text;
+	if (!text.startsWith("/")) return text;
+	const colonPos = text.indexOf(":");
+	if (colonPos !== -1) {
+		const prefix = text.slice(1, colonPos + 1);
+		if (
+			prefix === BUILTIN_SLASH_PREFIX ||
+			prefix === EXTENSION_SLASH_PREFIX ||
+			prefix === MCP_SLASH_PREFIX ||
+			prefix === PROMPT_SLASH_PREFIX
+		) {
+			return `/${text.slice(1 + prefix.length)}`;
+		}
+	}
+	return text;
 }
 
 export interface ParsedSlashToken {
@@ -26,6 +66,9 @@ export function parseSlashToken(text: string): ParsedSlashToken | null {
 	return {
 		name: stripCommandSlashName(rawName),
 		args: rawArgs,
-		...(rawName.startsWith(COMMAND_SLASH_PREFIX) && { legacyName: rawName }),
+		...((rawName.startsWith(BUILTIN_SLASH_PREFIX) ||
+			rawName.startsWith(EXTENSION_SLASH_PREFIX) ||
+			rawName.startsWith(MCP_SLASH_PREFIX) ||
+			rawName.startsWith(PROMPT_SLASH_PREFIX)) && { legacyName: rawName }),
 	};
 }

--- a/packages/coding-agent/test/available-commands.test.ts
+++ b/packages/coding-agent/test/available-commands.test.ts
@@ -24,6 +24,7 @@ describe("buildAvailableSlashCommands", () => {
 				},
 			],
 			mcpPromptCommands: [mcpPrompt],
+			promptTemplates: [{ name: "review", description: "Review prompt", content: "body", source: "test" }],
 			skills: [{ name: "reviewer", description: "Review code", filePath: "/tmp/reviewer/SKILL.md" }],
 			skillsSettings: { enableSkillCommands: true },
 			sessionManager: { getCwd: () => process.cwd() },
@@ -35,30 +36,33 @@ describe("buildAvailableSlashCommands", () => {
 		const commands = await buildAvailableSlashCommands(session as never, async () => fileCommands);
 		const byName = Object.fromEntries(commands.map(command => [command.name, command]));
 
-		expect(byName.usage.subcommands).toContainEqual({
+		expect(byName["cmd:usage"].subcommands).toContainEqual({
 			name: "show",
 			description: "Show provider usage and limits",
 		});
-		expect(byName.usage.subcommands).toContainEqual({
+		expect(byName["cmd:usage"].subcommands).toContainEqual({
 			name: "reset",
 			description: "Spend a saved Codex rate-limit reset",
 			usage: "[account|active]",
 		});
+		expect(byName.usage).toBeUndefined();
 		expect(byName["reset-usage"]).toBeUndefined();
 
-		expect(byName.fast.description).toBe("Toggle fast mode");
-		expect(byName["ext:hello"].description).toBe("Extension hello");
-		expect(byName["custom:hello"].description).toBe("Custom hello");
-		expect(byName["server:prompt"].description).toBe("MCP prompt");
-		expect(byName.notes.description).toBe("Open notes");
+		expect(byName["cmd:fast"].description).toBe("Toggle fast mode");
+		expect(byName["cmd:ext:hello"].description).toBe("Extension hello");
+		expect(byName["cmd:custom:hello"].description).toBe("Custom hello");
+		expect(byName["cmd:server:prompt"].description).toBe("MCP prompt");
+		expect(byName["cmd:notes"].description).toBe("Open notes");
+		expect(byName["cmd:review"].description).toBe("Review prompt");
 		expect(byName["skill:reviewer"].description).toBe("Review code");
 
-		expect(byName.model.source).toBe("builtin");
+		expect(byName["cmd:model"].source).toBe("builtin");
 		expect(byName["skill:reviewer"].source).toBe("skill");
-		expect(byName["ext:hello"].source).toBe("extension");
-		expect(byName["server:prompt"].source).toBe("mcp_prompt");
-		expect(byName["custom:hello"].source).toBe("custom");
-		expect(byName.notes.source).toBe("file");
+		expect(byName["cmd:ext:hello"].source).toBe("extension");
+		expect(byName["cmd:server:prompt"].source).toBe("mcp_prompt");
+		expect(byName["cmd:custom:hello"].source).toBe("custom");
+		expect(byName["cmd:notes"].source).toBe("file");
+		expect(byName["cmd:review"].source).toBe("prompt_template");
 	});
 
 	test("loads file commands into the session before advertising them", async () => {
@@ -78,7 +82,7 @@ describe("buildAvailableSlashCommands", () => {
 		);
 
 		expect(loadedCommands).toEqual(fileCommands);
-		expect(commands.find(command => command.name === "notes")?.source).toBe("file");
+		expect(commands.find(command => command.name === "cmd:notes")?.source).toBe("file");
 	});
 
 	test("classifies MCP prompts by path and bundled custom commands as custom", async () => {
@@ -106,8 +110,8 @@ describe("buildAvailableSlashCommands", () => {
 		);
 
 		const byName = Object.fromEntries(commands.map(command => [command.name, command]));
-		expect(byName["server:prompt"].source).toBe("mcp_prompt");
-		expect(byName.green.source).toBe("custom");
+		expect(byName["cmd:server:prompt"].source).toBe("mcp_prompt");
+		expect(byName["cmd:green"].source).toBe("custom");
 	});
 
 	test("keeps legacy custom command fixtures without a path classified as custom", async () => {
@@ -121,6 +125,6 @@ describe("buildAvailableSlashCommands", () => {
 			async () => [],
 		);
 
-		expect(commands.find(command => command.name === "legacy")?.source).toBe("custom");
+		expect(commands.find(command => command.name === "cmd:legacy")?.source).toBe("custom");
 	});
 });

--- a/packages/coding-agent/test/available-commands.test.ts
+++ b/packages/coding-agent/test/available-commands.test.ts
@@ -49,20 +49,20 @@ describe("buildAvailableSlashCommands", () => {
 		expect(byName["reset-usage"]).toBeUndefined();
 
 		expect(byName["cmd:fast"].description).toBe("Toggle fast mode");
-		expect(byName["cmd:ext:hello"].description).toBe("Extension hello");
-		expect(byName["cmd:custom:hello"].description).toBe("Custom hello");
-		expect(byName["cmd:server:prompt"].description).toBe("MCP prompt");
-		expect(byName["cmd:notes"].description).toBe("Open notes");
-		expect(byName["cmd:review"].description).toBe("Review prompt");
+		expect(byName["ext:ext:hello"].description).toBe("Extension hello");
+		expect(byName["custom:hello"].description).toBe("Custom hello");
+		expect(byName["mcp:server:prompt"].description).toBe("MCP prompt");
+		expect(byName["notes"].description).toBe("Open notes");
+		expect(byName["prompt:review"].description).toBe("Review prompt");
 		expect(byName["skill:reviewer"].description).toBe("Review code");
 
 		expect(byName["cmd:model"].source).toBe("builtin");
 		expect(byName["skill:reviewer"].source).toBe("skill");
-		expect(byName["cmd:ext:hello"].source).toBe("extension");
-		expect(byName["cmd:server:prompt"].source).toBe("mcp_prompt");
-		expect(byName["cmd:custom:hello"].source).toBe("custom");
-		expect(byName["cmd:notes"].source).toBe("file");
-		expect(byName["cmd:review"].source).toBe("prompt_template");
+		expect(byName["ext:ext:hello"].source).toBe("extension");
+		expect(byName["mcp:server:prompt"].source).toBe("mcp_prompt");
+		expect(byName["custom:hello"].source).toBe("custom");
+		expect(byName["notes"].source).toBe("file");
+		expect(byName["prompt:review"].source).toBe("prompt_template");
 	});
 
 	test("loads file commands into the session before advertising them", async () => {
@@ -82,7 +82,7 @@ describe("buildAvailableSlashCommands", () => {
 		);
 
 		expect(loadedCommands).toEqual(fileCommands);
-		expect(commands.find(command => command.name === "cmd:notes")?.source).toBe("file");
+		expect(commands.find(command => command.name === "notes")?.source).toBe("file");
 	});
 
 	test("classifies MCP prompts by path and bundled custom commands as custom", async () => {
@@ -110,8 +110,8 @@ describe("buildAvailableSlashCommands", () => {
 		);
 
 		const byName = Object.fromEntries(commands.map(command => [command.name, command]));
-		expect(byName["cmd:server:prompt"].source).toBe("mcp_prompt");
-		expect(byName["cmd:green"].source).toBe("custom");
+		expect(byName["mcp:server:prompt"].source).toBe("mcp_prompt");
+		expect(byName["green"].source).toBe("custom");
 	});
 
 	test("keeps legacy custom command fixtures without a path classified as custom", async () => {
@@ -125,6 +125,6 @@ describe("buildAvailableSlashCommands", () => {
 			async () => [],
 		);
 
-		expect(commands.find(command => command.name === "cmd:legacy")?.source).toBe("custom");
+		expect(commands.find(command => command.name === "legacy")?.source).toBe("custom");
 	});
 });

--- a/packages/coding-agent/test/input-controller-slash-history.test.ts
+++ b/packages/coding-agent/test/input-controller-slash-history.test.ts
@@ -70,6 +70,16 @@ describe("input controller — slash command history (#3148)", () => {
 		expect(addToHistory).toHaveBeenCalledWith("/mcp list");
 	});
 
+	it("normalizes cmd-prefixed /mcp before dispatch and history filtering", async () => {
+		const { ctx, editor, addToHistory, handleMCPCommand } = makeCtx();
+		controllerFor(ctx);
+
+		await editor.onSubmit?.("/cmd:mcp list");
+
+		expect(handleMCPCommand).toHaveBeenCalledWith("/mcp list");
+		expect(addToHistory).toHaveBeenCalledWith("/cmd:mcp list");
+	});
+
 	it("does NOT record /mcp add with a --token (would leak the bearer token)", async () => {
 		const { ctx, editor, addToHistory, handleMCPCommand } = makeCtx();
 		controllerFor(ctx);

--- a/packages/coding-agent/test/prompt-templates.test.ts
+++ b/packages/coding-agent/test/prompt-templates.test.ts
@@ -237,18 +237,18 @@ describe("parseCommandArgs + substituteArgs integration", () => {
 // ============================================================================
 
 describe("template expansion fallback", () => {
-	function createSlashCommand(content: string): FileSlashCommand {
+	function createSlashCommand(content: string, name = "test-command"): FileSlashCommand {
 		return {
-			name: "test-command",
+			name,
 			description: "Test command",
 			content,
 			source: "test",
 		};
 	}
 
-	function createPromptTemplate(content: string): PromptTemplate {
+	function createPromptTemplate(content: string, name = "test-template"): PromptTemplate {
 		return {
-			name: "test-template",
+			name,
 			description: "Test template",
 			content,
 			source: "test",
@@ -273,9 +273,35 @@ describe("template expansion fallback", () => {
 		expect(result).toBe("Do something.\n\nsample input text");
 	});
 
+	test("should expand cmd-prefixed slash commands using the underlying command name", () => {
+		const result = expandSlash("/cmd:test-command sample input text", "Do something.");
+		expect(result).toBe("Do something.\n\nsample input text");
+	});
+
+	test("should prefer legacy slash commands whose raw names start with cmd", () => {
+		const result = expandSlashCommand("/cmd:test-command sample input text", [
+			createSlashCommand("Namespaced command."),
+			createSlashCommand("Legacy command.", "cmd:test-command"),
+		]);
+		expect(result).toBe("Legacy command.\n\nsample input text");
+	});
+
 	test("should append trailing inline args for prompt template without placeholders", () => {
 		const result = expandPrompt("/test-template sample input text", "Do something.");
 		expect(result).toBe("Do something.\n\nsample input text");
+	});
+
+	test("should expand cmd-prefixed prompt templates using the underlying template name", () => {
+		const result = expandPrompt("/cmd:test-template sample input text", "Do something.");
+		expect(result).toBe("Do something.\n\nsample input text");
+	});
+
+	test("should prefer legacy prompt templates whose raw names start with cmd", () => {
+		const result = expandPromptTemplate("/cmd:test-template sample input text", [
+			createPromptTemplate("Namespaced template."),
+			createPromptTemplate("Legacy template.", "cmd:test-template"),
+		]);
+		expect(result).toBe("Legacy template.\n\nsample input text");
 	});
 
 	test("should not append fallback text when $ARGUMENTS consumes args", () => {

--- a/packages/coding-agent/test/slash-commands/force.test.ts
+++ b/packages/coding-agent/test/slash-commands/force.test.ts
@@ -5,15 +5,19 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
 import { buildNamedToolChoice } from "@oh-my-pi/pi-coding-agent/utils/tool-choice";
 
-function createRuntimeHarness(overrides?: { setForcedToolChoice?: (toolName: string) => void }) {
+function createRuntimeHarness(overrides?: {
+	setForcedToolChoice?: (toolName: string) => void;
+	hasRawSlashCommandName?: (name: string) => boolean;
+}) {
 	const setForcedToolChoice = vi.fn(overrides?.setForcedToolChoice ?? ((_toolName: string) => {}));
+	const hasRawSlashCommandName = vi.fn(overrides?.hasRawSlashCommandName ?? ((_name: string) => false));
 	const setText = vi.fn();
 	const showStatus = vi.fn();
 	const showError = vi.fn();
 
 	const ctx = {
 		editor: { setText } as unknown as InteractiveModeContext["editor"],
-		session: { setForcedToolChoice } as unknown as InteractiveModeContext["session"],
+		session: { setForcedToolChoice, hasRawSlashCommandName } as unknown as InteractiveModeContext["session"],
 		showStatus,
 		showError,
 	} as unknown as InteractiveModeContext;
@@ -40,6 +44,27 @@ describe("/force slash command", () => {
 		expect(harness.showStatus).toHaveBeenCalledWith("Next turn forced to use write.");
 		expect(harness.showError).not.toHaveBeenCalled();
 		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("accepts cmd-prefixed built-in commands with colon subcommand syntax", async () => {
+		const harness = createRuntimeHarness();
+
+		const result = await executeBuiltinSlashCommand("/cmd:force:write fix the tests", harness.runtime);
+
+		expect(result).toBe("fix the tests");
+		expect(harness.setForcedToolChoice).toHaveBeenCalledWith("write");
+		expect(harness.showStatus).toHaveBeenCalledWith("Next turn forced to use write.");
+		expect(harness.showError).not.toHaveBeenCalled();
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("does not consume a legacy cmd-prefixed raw command before dynamic dispatch", async () => {
+		const harness = createRuntimeHarness({ hasRawSlashCommandName: name => name === "cmd:force:write" });
+
+		const result = await executeBuiltinSlashCommand("/cmd:force:write fix the tests", harness.runtime);
+
+		expect(result).toBe(false);
+		expect(harness.setForcedToolChoice).not.toHaveBeenCalled();
 	});
 
 	it("shows usage when tool name is missing", async () => {

--- a/packages/coding-agent/test/slash-commands/history-security.test.ts
+++ b/packages/coding-agent/test/slash-commands/history-security.test.ts
@@ -25,6 +25,11 @@ describe("shouldSkipHistory — security filter for slash command history", () =
 		expect(shouldSkipHistory("/login:auth-code-xyz")).toBe(true);
 	});
 
+	it("skips cmd-prefixed /login with secret-bearing arguments", () => {
+		expect(shouldSkipHistory("/cmd:login ?code=abc&state=xyz")).toBe(true);
+		expect(shouldSkipHistory("/cmd:login:auth-code-xyz")).toBe(true);
+	});
+
 	it("skips /join with a link argument (carries 32-byte room key and write token)", () => {
 		expect(shouldSkipHistory("/join omp://share/abc123def456...")).toBe(true);
 		expect(shouldSkipHistory("/join omp:abc123def456...")).toBe(true);

--- a/packages/coding-agent/test/slash-commands/memory.test.ts
+++ b/packages/coding-agent/test/slash-commands/memory.test.ts
@@ -38,4 +38,13 @@ describe("/memory slash command", () => {
 		expect(handled).toBe(true);
 		expect(harness.handleMemoryCommand).toHaveBeenCalledWith("/memory    stats");
 	});
+
+	it("normalizes cmd-prefixed invocations before routing to the memory handler", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/cmd:memory stats", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.handleMemoryCommand).toHaveBeenCalledWith("/memory stats");
+	});
 });

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -285,64 +285,121 @@ function scoreCommandTextMatch(lowerPrefix: string, lowerTarget: string): number
 	return fuzzyMatch(lowerPrefix, lowerTarget) ? fuzzyScore(lowerPrefix, lowerTarget) : 0;
 }
 
-function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: string): AutocompleteItem[] {
-	return commands
-		.flatMap(cmd => {
-			const name = getCommandName(cmd);
-			if (!name) return [];
-			const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-			const staticDesc = getStaticCommandDescription(cmd);
-			let fullDescMemo: string | undefined;
-			let fullDescComputed = false;
-			// Resolve the (possibly live) display description lazily, only once a
-			// candidate actually matches — getAutocompleteDescription reads live
-			// session state and must not run for every command on each keystroke.
-			const resolveFullDesc = (): string | undefined => {
-				if (!fullDescComputed) {
-					const displayDesc = getAutocompleteCommandDescription(cmd);
-					fullDescMemo = hint ? (displayDesc ? `${hint} - ${displayDesc}` : hint) : displayDesc;
-					fullDescComputed = true;
-				}
-				return fullDescMemo;
-			};
-			const candidates: Array<AutocompleteItem & { score: number }> = [];
+const KNOWN_NAMESPACES = new Map([
+	["cmd", "Built-in commands"],
+	["ext", "Extension commands"],
+	["mcp", "MCP server commands"],
+	["prompt", "Prompt templates"],
+	["skill", "Agent skills"],
+]);
 
-			const isSkillCommand = name.startsWith("skill:");
-			const nameScore =
-				lowerPrefix.length === 0 && isSkillCommand ? 950 : scoreCommandTextMatch(lowerPrefix, name.toLowerCase());
-			const lowerDesc = staticDesc.toLowerCase();
-			const descScore =
-				lowerDesc && fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-			const primaryScore = Math.max(nameScore, descScore);
-			if (primaryScore > 0) {
-				const fullDesc = resolveFullDesc();
+function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: string, isMidPrompt = false): AutocompleteItem[] {
+	if (isMidPrompt) {
+		return commands
+			.flatMap(cmd => processSlashCommand(cmd, lowerPrefix))
+			.sort((a, b) => b.score - a.score)
+			.map(({ score: _, ...rest }) => rest);
+	}
+
+	const colonIndex = lowerPrefix.indexOf(":");
+	let targetNamespace: string | undefined;
+	let activeCommands = commands;
+
+	if (colonIndex === -1) {
+		const namespacesPresent = new Set<string>();
+		const flatCommands: CommandEntry[] = [];
+		for (const cmd of commands) {
+			const name = getCommandName(cmd);
+			if (!name) continue;
+			const colonPos = name.indexOf(":");
+			if (colonPos !== -1 && KNOWN_NAMESPACES.has(name.slice(0, colonPos))) {
+				namespacesPresent.add(name.slice(0, colonPos));
+			} else {
+				flatCommands.push(cmd);
+			}
+		}
+
+		const candidates: Array<AutocompleteItem & { score: number }> = [];
+		for (const ns of namespacesPresent) {
+			const score = scoreCommandTextMatch(lowerPrefix, ns);
+			if (score > 0) {
 				candidates.push({
-					value: name,
-					label: "name" in cmd ? cmd.name : cmd.label,
-					score: primaryScore,
-					...(fullDesc && { description: fullDesc }),
+					value: `${ns}:`,
+					label: `${ns}:`,
+					description: KNOWN_NAMESPACES.get(ns),
+					score: score === 1 ? 1000 : score,
 				});
 			}
+		}
 
-			if (lowerPrefix.length > 0) {
-				for (const alias of getCommandAliases(cmd)) {
-					if (alias === name) continue;
-					const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase());
-					if (aliasScore === 0) continue;
-					const fullDesc = resolveFullDesc();
-					candidates.push({
-						value: alias,
-						label: alias,
-						score: aliasScore,
-						...(fullDesc && { description: fullDesc }),
-					});
-				}
-			}
+		activeCommands = flatCommands;
+		return activeCommands
+			.flatMap(cmd => processSlashCommand(cmd, lowerPrefix))
+			.concat(candidates)
+			.sort((a, b) => b.score - a.score)
+			.map(({ score: _, ...rest }) => rest);
+	} else {
+		targetNamespace = lowerPrefix.slice(0, colonIndex);
+		activeCommands = commands.filter(cmd => {
+			const name = getCommandName(cmd);
+			return name && name.startsWith(`${targetNamespace}:`);
+		});
+		return activeCommands
+			.flatMap(cmd => processSlashCommand(cmd, lowerPrefix))
+			.sort((a, b) => b.score - a.score)
+			.map(({ score: _, ...rest }) => rest);
+	}
+}
 
-			return candidates;
-		})
-		.sort((a, b) => b.score - a.score)
-		.map(({ score: _, ...rest }) => rest);
+function processSlashCommand(cmd: CommandEntry, lowerPrefix: string): Array<AutocompleteItem & { score: number }> {
+	const name = getCommandName(cmd);
+	if (!name) return [];
+	const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
+	const staticDesc = getStaticCommandDescription(cmd);
+	let fullDescMemo: string | undefined;
+	let fullDescComputed = false;
+	const resolveFullDesc = (): string | undefined => {
+		if (!fullDescComputed) {
+			const displayDesc = getAutocompleteCommandDescription(cmd);
+			fullDescMemo = hint ? (displayDesc ? `${hint} - ${displayDesc}` : hint) : displayDesc;
+			fullDescComputed = true;
+		}
+		return fullDescMemo;
+	};
+	const candidates: Array<AutocompleteItem & { score: number }> = [];
+
+	const isSkillCommand = name.startsWith("skill:");
+	const nameScore =
+		lowerPrefix.length === 0 && isSkillCommand ? 950 : scoreCommandTextMatch(lowerPrefix, name.toLowerCase());
+	const lowerDesc = staticDesc.toLowerCase();
+	const descScore = lowerDesc && fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
+	const primaryScore = Math.max(nameScore, descScore);
+	if (primaryScore > 0) {
+		const fullDesc = resolveFullDesc();
+		candidates.push({
+			value: name,
+			label: "name" in cmd ? cmd.name : cmd.label,
+			score: primaryScore,
+			...(fullDesc && { description: fullDesc }),
+		});
+	}
+
+	if (lowerPrefix.length > 0) {
+		for (const alias of getCommandAliases(cmd)) {
+			if (alias === name) continue;
+			const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase());
+			if (aliasScore === 0) continue;
+			const fullDesc = resolveFullDesc();
+			candidates.push({
+				value: alias,
+				label: alias,
+				score: aliasScore,
+				...(fullDesc && { description: fullDesc }),
+			});
+		}
+	}
+
+	return candidates;
 }
 
 function hasPromptTextBeforeSlash(
@@ -361,6 +418,7 @@ function buildMidPromptSkillCompletions(commands: CommandEntry[], lowerPrefix: s
 	return buildSlashCommandCompletions(
 		commands.filter(cmd => getCommandName(cmd)?.startsWith("skill:")),
 		lowerPrefix,
+		true
 	);
 }
 


### PR DESCRIPTION
This implements the prefix-root autocomplete taxonomy agreed upon in #4131.

- Groups slash commands into root taxa (`/cmd:`, `/ext:`, `/mcp:`, `/prompt:`, `/skill:`).
- Modifies `CombinedAutocompleteProvider` to implement a colon-delimited two-level autocomplete. Typing `/` shows only the taxonomy roots (e.g. `/prompt:`); typing `:` switches the autocomplete list to the contents of that namespace.
- Preserves legacy dispatch: `/review` still routes to the template/command as long as it wasn't shadowed.
- Fixes the edge cases related to legacy names actually beginning with the prefix.
