### PR TITLE
fix(memories): preserve non-list content in learned.md across lesson saves

### DIFF
--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -1341,12 +1341,24 @@ async function appendLearnedLine(filePath: string, line: string): Promise<void> 
 	} catch (err) {
 		if (!isEnoent(err)) throw err;
 	}
-	const prior = existing
-		.split("\n")
-		.map(l => l.trim())
-		.filter(l => l.startsWith("- ") && l !== line);
-	const lessons = [line, ...prior].slice(0, MAX_LEARNED_LESSONS);
-	await Bun.write(filePath, `${lessons.join("\n")}\n`);
+	// Split existing content, preserving non-list lines (headers, prose,
+	// blank lines, blockquotes, etc.) while deduping and capping only the
+	// bullet-list lesson entries.  Hand-edited content outside the list
+	// region survives every write — the read path already preserves all
+	// lines (readLearnedLessons), so this brings the write path in line.
+	const preserved: string[] = [];
+	const priorLessons: string[] = [];
+	for (const l of existing.split("\n")) {
+		const trimmed = l.trim();
+		if (trimmed.startsWith("- ")) {
+			if (trimmed !== line) priorLessons.push(trimmed);
+		} else {
+			preserved.push(l);
+		}
+	}
+	const lessons = [line, ...priorLessons].slice(0, MAX_LEARNED_LESSONS);
+	const output = [...preserved, ...lessons].join("\n").trim();
+	await Bun.write(filePath, `${output}\n`);
 }
 
 /**

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -258,6 +258,30 @@ describe("learned-lesson read-back", () => {
 		expect(out).toContain("[REDACTED]");
 	});
 
+	it("preserves non-list content across subsequent lesson saves", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local" });
+		const root = getMemoryRoot(agentDir, settings.getCwd());
+		// Hand-edit learned.md with a header, prose, and blank lines
+		// interspersed with list entries.
+		await Bun.write(
+			path.join(root, "learned.md"),
+			"# Project Lessons\n\nRemember these conventions:\n\n- existing 1\n- existing 2\n",
+		);
+		// Save a new lesson — must not destroy the header or prose.
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "new lesson" });
+		const raw = await Bun.file(path.join(root, "learned.md")).text();
+		expect(raw).toContain("# Project Lessons");
+		expect(raw).toContain("Remember these conventions:");
+		expect(raw).toContain("- new lesson");
+		expect(raw).toContain("- existing 1");
+		expect(raw).toContain("- existing 2");
+		// Dedup: saving the same lesson twice should not duplicate it.
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "new lesson" });
+		const deduped = await Bun.file(path.join(root, "learned.md")).text();
+		const count = [...deduped.matchAll(/^- new lesson$/gm)].length;
+		expect(count).toBe(1);
+	});
+
 	it("drops learned lessons when the summary already fills the injection budget", async () => {
 		const settings = Settings.isolated({ "memory.backend": "local" });
 		const root = getMemoryRoot(agentDir, settings.getCwd());


### PR DESCRIPTION
## Summary

Fixes #4107 — `appendLearnedLine` was silently destroying all non-list content (headers, prose, blank lines, blockquotes) from hand-edited `learned.md` files on every lesson save.

## Root Cause

The existing `appendLearnedLine` filter:

```ts
.filter(l => l.startsWith("- ") && l !== line)
```

drops every line that is not a list bullet. If a user hand-edits `learned.md` to add a `# Project Lessons` header or prose commentary, all non-list content is irreversibly destroyed on the next write.

## Fix

Separate list lines from non-list lines during the read-modify-write:

- **Non-list lines** (headers, prose, blank lines, blockquotes, etc.) are preserved verbatim
- **List lines** continue to be deduped and capped at `MAX_LEARNED_LESSONS` (100)
- The new lesson is prepended to the list section (newest-first, existing behavior)

The read path (`readLearnedLessons`) already preserves all lines — this fix brings the write path into alignment.

## Test

Added `"preserves non-list content across subsequent lesson saves"` test that:

1. Hand-edits `learned.md` with a header, prose, and existing list entries
2. Saves a new lesson via `saveLearnedLesson`
3. Asserts header and prose survive
4. Asserts list entries are correctly deduped (saving the same lesson twice does not duplicate it)

## Files Changed

- `packages/coding-agent/src/memories/index.ts` — fix `appendLearnedLine` (lines 1337–1362)
- `packages/coding-agent/test/autolearn-learn-local.test.ts` — add regression test

Closes #4107