### PR TITLE
fix(catalog): enable codex v2 remote compaction

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed discovered OpenAI Codex models to advertise V2 streaming remote compaction, avoiding the legacy compact endpoint timeout path for Codex sessions. ([#4146](https://github.com/can1357/oh-my-pi/issues/4146))
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -8,6 +8,11 @@ const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
 const DEFAULT_CODEX_CLIENT_VERSION = "0.99.0";
 const NPM_CODEX_LATEST_URL = "https://registry.npmjs.org/@openai%2Fcodex/latest";
+const CODEX_REMOTE_COMPACTION = {
+	enabled: true,
+	api: "openai-codex-responses",
+	v2StreamingEnabled: true,
+} as const;
 
 const codexReasoningPresetSchema = type({
 	"effort?": "unknown",
@@ -269,6 +274,7 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 			reasoning,
 			input,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			remoteCompaction: CODEX_REMOTE_COMPACTION,
 			contextWindow,
 			maxTokens,
 			...(preferWebsockets ? { preferWebsockets: true } : {}),

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -101,7 +101,12 @@ function migrateCacheSchema(db: Database): void {
 	} finally {
 		stmt.finalize();
 	}
-	db.run("UPDATE model_cache SET version = ? WHERE version = 2", [CACHE_SCHEMA_VERSION]);
+	// Delete rows written under any older schema so they cannot be reused. The
+	// legacy `UPDATE ... WHERE version = 2` migration silently promoted the very
+	// first cache version to whatever the current one is, defeating every
+	// subsequent invalidation (see #4146: pre-V2 Codex rows kept the legacy
+	// compaction path even after CACHE_SCHEMA_VERSION was bumped).
+	db.run("DELETE FROM model_cache WHERE version <> ?", [CACHE_SCHEMA_VERSION]);
 }
 
 export function readModelCache<TApi extends Api>(

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -7,14 +7,15 @@ import { getModelDbPath } from "@oh-my-pi/pi-utils";
 import type { Api, Model, ModelSpec } from "./types";
 
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
-// the model manager rebuilds via `buildModel` on load. v7 invalidates rows
-// predating the Antigravity Gemini budget-mode migration (cached specs still
-// carrying `thinking.mode: "google-level"` and the old 3.5-flash effort
-// routing); v6 invalidates rows that may contain the retired unknown-limit
-// sentinels (222222/8888); v5 invalidated rows predating effort-tier variant
-// collapsing (raw `-low`/`-high`/`-thinking` member ids); v4 dropped the
-// pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 7;
+// the model manager rebuilds via `buildModel` on load. v8 invalidates Codex
+// discovery rows predating provider-native V2 compaction metadata; v7
+// invalidated rows predating the Antigravity Gemini budget-mode migration
+// (cached specs still carrying `thinking.mode: "google-level"` and the old
+// 3.5-flash effort routing); v6 invalidated rows that may contain the retired
+// unknown-limit sentinels (222222/8888); v5 invalidated rows predating
+// effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
+// v4 dropped the pre-efforts ThinkingConfig shape.
+const CACHE_SCHEMA_VERSION = 8;
 
 interface CacheRow {
 	provider_id: string;

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { fetchCodexModels } from "@oh-my-pi/pi-catalog/discovery/codex";
+
+describe("Codex model discovery", () => {
+	it("marks discovered models for provider-native V2 compaction", async () => {
+		const fetchFn: typeof fetch = Object.assign(
+			async () =>
+				new Response(
+					JSON.stringify({
+						models: [
+							{
+								slug: "gpt-5.5",
+								display_name: "GPT-5.5",
+								context_window: 272_000,
+								default_reasoning_level: "high",
+								supported_reasoning_levels: ["low", "high", "xhigh"],
+								input_modalities: ["text", "image"],
+								supported_in_api: true,
+							},
+						],
+					}),
+					{ headers: { etag: "models-v1" } },
+				),
+			{ preconnect() {} },
+		);
+		const result = await fetchCodexModels({
+			accessToken: "test-token",
+			baseUrl: "https://codex.example/backend-api",
+			clientVersion: "0.99.0",
+			fetchFn,
+		});
+
+		expect(result?.etag).toBe("models-v1");
+		expect(result?.models).toHaveLength(1);
+		expect(result?.models[0]).toMatchObject({
+			id: "gpt-5.5",
+			provider: "openai-codex",
+			api: "openai-codex-responses",
+			remoteCompaction: {
+				enabled: true,
+				api: "openai-codex-responses",
+				v2StreamingEnabled: true,
+			},
+		});
+	});
+});

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -1,5 +1,13 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { fetchCodexModels } from "@oh-my-pi/pi-catalog/discovery/codex";
+import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
+import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 describe("Codex model discovery", () => {
 	it("marks discovered models for provider-native V2 compaction", async () => {
@@ -42,5 +50,65 @@ describe("Codex model discovery", () => {
 				v2StreamingEnabled: true,
 			},
 		});
+	});
+
+	it("ignores pre-V2 Codex discovery cache rows", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-v7-cache-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const cachedModel: ModelSpec<"openai-codex-responses"> = {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api/codex",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 272_000,
+			maxTokens: 128_000,
+		};
+		const refreshedModel: ModelSpec<"openai-codex-responses"> = {
+			...cachedModel,
+			remoteCompaction: {
+				enabled: true,
+				api: "openai-codex-responses",
+				v2StreamingEnabled: true,
+			},
+		};
+		try {
+			writeModelCache(
+				"openai-codex",
+				Date.now(),
+				[buildModel(cachedModel)],
+				true,
+				"merge-v3:authoritative:merge-v3:empty",
+				dbPath,
+			);
+			const db = new Database(dbPath);
+			try {
+				db.run("UPDATE model_cache SET version = 7 WHERE provider_id = ?", ["openai-codex"]);
+			} finally {
+				db.close();
+			}
+
+			let fetched = false;
+			const result = await resolveProviderModels<"openai-codex-responses">({
+				providerId: "openai-codex",
+				staticModels: [],
+				dynamicModelsAuthoritative: true,
+				cacheDbPath: dbPath,
+				fetchDynamicModels: async () => {
+					fetched = true;
+					return [refreshedModel];
+				},
+			});
+
+			expect(fetched).toBe(true);
+			expect(result.models.find(model => model.id === "gpt-5.5")?.remoteCompaction).toEqual(
+				refreshedModel.remoteCompaction,
+			);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -111,4 +111,59 @@ describe("Codex model discovery", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("does not silently promote legacy v2 Codex cache rows to the current schema", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-v2-cache-"));
+		const dbPath = path.join(tempDir, "models.db");
+		try {
+			// Seed a v2 row directly, mirroring the shape written by very old
+			// installs before schema versioning stabilized. The migration must NOT
+			// resurrect it as the current version — that would keep the pre-V2
+			// compaction metadata alive across cache-schema bumps.
+			const seed = new Database(dbPath, { create: true });
+			try {
+				seed.run(`
+					CREATE TABLE model_cache (
+						provider_id TEXT PRIMARY KEY,
+						version INTEGER NOT NULL,
+						updated_at INTEGER NOT NULL,
+						authoritative INTEGER NOT NULL DEFAULT 0,
+						static_fingerprint TEXT NOT NULL DEFAULT '',
+						models TEXT NOT NULL
+					)
+				`);
+				seed.run(
+					"INSERT INTO model_cache (provider_id, version, updated_at, authoritative, static_fingerprint, models) VALUES (?, 2, ?, 1, '', '[]')",
+					["openai-codex", Date.now()],
+				);
+			} finally {
+				seed.close();
+			}
+
+			let fetched = false;
+			await resolveProviderModels<"openai-codex-responses">({
+				providerId: "openai-codex",
+				staticModels: [],
+				dynamicModelsAuthoritative: true,
+				cacheDbPath: dbPath,
+				fetchDynamicModels: async () => {
+					fetched = true;
+					return [];
+				},
+			});
+			expect(fetched).toBe(true);
+
+			const inspect = new Database(dbPath, { readonly: true });
+			try {
+				const row = inspect
+					.query<{ version: number }, [string]>("SELECT version FROM model_cache WHERE provider_id = ?")
+					.get("openai-codex");
+				expect(row?.version).not.toBe(2);
+			} finally {
+				inspect.close();
+			}
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `models.yml` remote compaction schema support for V2 streaming endpoint fields. ([#4146](https://github.com/can1357/oh-my-pi/issues/4146))
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -127,12 +127,25 @@ const RemoteCompactionSchema = type({
 	"api?": ApiSchema,
 	"endpoint?": "string",
 	"model?": "string",
+	"v2StreamingEnabled?": "boolean",
+	"v2Endpoint?": "string",
+	"streamingEndpoint?": "string",
 }).narrow((value, ctx) => {
 	if (value.endpoint !== undefined && typeof value.endpoint === "string" && value.endpoint.length === 0) {
 		return ctx.mustBe("remoteCompaction.endpoint a non-empty string");
 	}
 	if (value.model !== undefined && typeof value.model === "string" && value.model.length === 0) {
 		return ctx.mustBe("remoteCompaction.model a non-empty string");
+	}
+	if (value.v2Endpoint !== undefined && typeof value.v2Endpoint === "string" && value.v2Endpoint.length === 0) {
+		return ctx.mustBe("remoteCompaction.v2Endpoint a non-empty string");
+	}
+	if (
+		value.streamingEndpoint !== undefined &&
+		typeof value.streamingEndpoint === "string" &&
+		value.streamingEndpoint.length === 0
+	) {
+		return ctx.mustBe("remoteCompaction.streamingEndpoint a non-empty string");
 	}
 	return true;
 });


### PR DESCRIPTION
## Repro
A focused discovery regression test reproduces the metadata gap with `bun test packages/catalog/test/codex-discovery.test.ts`: discovered `openai-codex/gpt-5.5` models normalized as `openai-codex-responses` but lacked `remoteCompaction.v2StreamingEnabled`, so compaction skipped the V2 streaming `compaction_trigger` path and could fall into the legacy compact endpoint timeout/local-summary fallback.

## Cause
`packages/catalog/src/discovery/codex.ts` `normalizeCodexModelEntry()` emitted Codex model specs without `remoteCompaction` metadata, while `packages/agent/src/compaction/compaction-v2-streaming.ts` `shouldUseCompactionV2Streaming()` requires `model.remoteCompaction?.v2StreamingEnabled === true`; `packages/coding-agent/src/config/models-config-schema.ts` also omitted the V2 endpoint fields from the `remoteCompaction` schema.

## Fix
- Add Codex V2 remote compaction metadata to every discovered OpenAI Codex model spec.
- Add a discovery regression test for the `openai-codex/gpt-5.5` metadata contract.
- Expose `v2StreamingEnabled`, `v2Endpoint`, and `streamingEndpoint` in the `models.yml` remote compaction schema.
- Add changelog entries for the catalog and coding-agent packages.

## Verification
`bun test packages/catalog/test/codex-discovery.test.ts` passes; `bun test packages/agent/test/remote-compaction.test.ts` passes; `bun test packages/coding-agent/test/model-registry.test.ts -t "custom Responses providers preserve compaction config"` passes; `bun check` passes. Fixes #4146