### PR TITLE
fix(ai): reword GPT-5 Responses fallback prompt

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reworded the GPT-5 Responses no-reasoning fallback developer item so it no longer says `# Juice: 0 !important` or implies a zero tool/execution budget. ([#4151](https://github.com/can1357/oh-my-pi/issues/4151))
+
 ## [16.2.12] - 2026-07-01
 
 ### Changed

--- a/packages/ai/src/providers/openai-responses-reasoning-suppression.md
+++ b/packages/ai/src/providers/openai-responses-reasoning-suppression.md
@@ -1,0 +1,1 @@
+Keep internal reasoning brief. Continue following the task and use tools normally.

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -2365,6 +2365,9 @@ export function applyCommonResponsesSamplingParams<P extends CommonResponsesPara
 	applyOpenAIServiceTier(params, options?.serviceTier, model.provider);
 }
 
+const RESPONSES_REASONING_SUPPRESSION_PROMPT =
+	"Keep internal reasoning brief. Continue following the task and use tools normally.";
+
 type ReasoningOptions = {
 	reasoning?: string;
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
@@ -2409,7 +2412,7 @@ export function applyResponsesCompatPolicy<P extends ResponseCreateParamsStreami
 		if (policy.compat.requiresJuiceZeroHack && reasoning.requestedEffort === undefined) {
 			messages.push({
 				role: "developer",
-				content: [{ type: "input_text", text: "# Juice: 0 !important" }],
+				content: [{ type: "input_text", text: RESPONSES_REASONING_SUPPRESSION_PROMPT }],
 			});
 			return 1;
 		}
@@ -2441,7 +2444,7 @@ export function applyResponsesCompatPolicy<P extends ResponseCreateParamsStreami
 	if (policy.compat.requiresJuiceZeroHack) {
 		messages.push({
 			role: "developer",
-			content: [{ type: "input_text", text: "# Juice: 0 !important" }],
+			content: [{ type: "input_text", text: RESPONSES_REASONING_SUPPRESSION_PROMPT }],
 		});
 		return 1;
 	}

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -75,6 +75,7 @@ import {
 } from "./github-copilot-headers";
 import type { ChatCompletionCreateParamsStreaming } from "./openai-chat-wire";
 import type { InputItem } from "./openai-codex/request-transformer";
+import responsesReasoningSuppressionPrompt from "./openai-responses-reasoning-suppression.md" with { type: "text" };
 import type {
 	ResponseContentPartAddedEvent,
 	ResponseCreateParamsStreaming,
@@ -2365,8 +2366,7 @@ export function applyCommonResponsesSamplingParams<P extends CommonResponsesPara
 	applyOpenAIServiceTier(params, options?.serviceTier, model.provider);
 }
 
-const RESPONSES_REASONING_SUPPRESSION_PROMPT =
-	"Keep internal reasoning brief. Continue following the task and use tools normally.";
+const RESPONSES_REASONING_SUPPRESSION_PROMPT = responsesReasoningSuppressionPrompt.trim();
 
 type ReasoningOptions = {
 	reasoning?: string;

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -154,7 +154,12 @@ describe("azure openai responses streaming", () => {
 			{ role: "user", content: [{ type: "input_text", text: "Say hello" }] },
 			{
 				role: "developer",
-				content: [{ type: "input_text", text: "# Juice: 0 !important" }],
+				content: [
+					{
+						type: "input_text",
+						text: "Keep internal reasoning brief. Continue following the task and use tools normally.",
+					},
+				],
 			},
 		]);
 	});

--- a/packages/ai/test/openai-compat-policy.test.ts
+++ b/packages/ai/test/openai-compat-policy.test.ts
@@ -123,6 +123,35 @@ describe("OpenAI compat policy", () => {
 		expect(responseBody.reasoning).toBeUndefined();
 	});
 
+	it("uses a non-budget fallback prompt for Responses no-reasoning compat", () => {
+		const compat: OpenAICompat = { requiresJuiceZeroHack: true };
+		const responseBody = responsesParams();
+		const responseInput: ResponseInput = [];
+
+		const appended = applyResponsesCompatPolicy(
+			responseBody,
+			responseInput,
+			resolveOpenAICompatPolicy(responsesModel(compat), { endpoint: "responses" }),
+			undefined,
+		);
+
+		expect(appended).toBe(1);
+		expect(responseInput.at(-1)).toEqual({
+			role: "developer",
+			content: [
+				{
+					type: "input_text",
+					text: "Keep internal reasoning brief. Continue following the task and use tools normally.",
+				},
+			],
+		});
+		const serialized = JSON.stringify(responseInput.at(-1));
+		expect(serialized).not.toContain("Juice");
+		expect(serialized).not.toContain("!important");
+		expect(serialized).not.toContain("budget");
+		expect(serialized).not.toContain("zero");
+	});
+
 	it("exposes reasoning replay constraints independent of endpoint", () => {
 		const compat: OpenAICompat = {
 			requiresReasoningContentForToolCalls: true,

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -26,9 +26,9 @@ function createCodexToken(accountId: string): string {
 
 /**
  * Returns the bundled `gpt-5-mini` model with `compat.requiresJuiceZeroHack`
- * cleared so it doesn't trigger the GPT-5 "Juice: 0" developer-message hack
- * injected by `applyResponsesReasoningParams`. The hack is exercised by its
- * own targeted tests; these history-replay tests assert raw payload shape and
+ * cleared so it doesn't trigger the GPT-5 no-reasoning developer-message
+ * fallback injected by `applyResponsesReasoningParams`. The fallback is
+ * exercised by its own targeted tests; these history-replay tests assert raw payload shape and
  * should stay independent of it.
  */
 function getOpenAIReasoningModel(

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -101,8 +101,8 @@ describe("openai-responses stateful chaining", () => {
 		const sentRequests: Array<Record<string, unknown>> = [];
 		const fetchMock = createCapturingFetch(sentRequests);
 		const providerSessionState = new Map<string, ProviderSessionState>();
-		// No reasoning option: applyResponsesReasoningParams appends the trailing
-		// "# Juice: 0 !important" developer item to every request's input.
+		// No reasoning option: applyResponsesReasoningParams appends trailing
+		// no-reasoning scaffolding to every request's input.
 		const options = {
 			apiKey: "test-key",
 			sessionId: "stateful-juice-session",
@@ -119,7 +119,7 @@ describe("openai-responses stateful chaining", () => {
 		).result();
 		expect(firstResponse.stopReason).toBe("stop");
 		const firstInput = sentRequests[0]?.input as unknown[];
-		expect(JSON.stringify(firstInput.at(-1))).toContain("# Juice: 0");
+		expect(JSON.stringify(firstInput.at(-1))).toContain("Keep internal reasoning brief");
 
 		const secondResponse = await streamOpenAIResponses(
 			model,
@@ -138,7 +138,7 @@ describe("openai-responses stateful chaining", () => {
 		const deltaInput = sentRequests[1]?.input as Array<{ role?: string }>;
 		expect(deltaInput).toHaveLength(2);
 		expect(deltaInput[0]?.role).toBe("user");
-		expect(JSON.stringify(deltaInput[1])).toContain("# Juice: 0");
+		expect(JSON.stringify(deltaInput[1])).toContain("Keep internal reasoning brief");
 	});
 
 	it("replays the full transcript when history mutates", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated the Responses compat flag docs to describe the no-reasoning fallback without the old `# Juice: 0 !important` wording. ([#4151](https://github.com/can1357/oh-my-pi/issues/4151))
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -332,11 +332,11 @@ export interface OpenAICompat {
 	/** Whether the Responses API accepts the `detail: "original"` image hint. Default: auto-detected (false for GitHub Copilot, which rejects it with a 400). */
 	supportsImageDetailOriginal?: boolean;
 	/**
-	 * Append a trailing `# Juice: 0 !important` developer item when the caller
-	 * did not request reasoning, suppressing default reasoning on models that
-	 * cannot disable it via request params (Responses APIs only; see
+	 * Append a trailing no-reasoning developer item when the caller did not
+	 * request reasoning, suppressing default reasoning on models that cannot
+	 * disable it via request params (Responses APIs only; see
 	 * https://community.openai.com/t/need-reasoning-false-option-for-gpt-5/1351588/7).
-	 * Default: auto-detected (GPT-5-family model names).
+	 * The prompt must not look like an execution or tool budget. Default: auto-detected (GPT-5-family model names).
 	 */
 	requiresJuiceZeroHack?: boolean;
 	/** Whether streamed reasoning deltas for the same field may repeat the full cumulative text snapshot. Default: false. */


### PR DESCRIPTION
## Repro
A focused repro called `applyResponsesCompatPolicy` with `compat.requiresJuiceZeroHack === true` and no requested reasoning, matching GPT-5 Responses no-reasoning sessions. Command: `bun test /tmp/issue-4151-repro.test.ts`; before the fix it passed while asserting the payload appended `{ role: "developer", content: [{ type: "input_text", text: "# Juice: 0 !important" }] }`.

## Cause
`packages/ai/src/providers/openai-shared.ts` used `applyResponsesCompatPolicy` to append the GPT-5 Responses no-reasoning fallback as the natural-language developer instruction `# Juice: 0 !important`. Because that text traveled in a developer-role message, models could treat it as a high-priority zero execution/tool budget instead of provider transport scaffolding; `packages/catalog/src/types.ts` also documented the exact unsafe wording.

## Fix
- Replaced the fallback text with non-budget wording: `Keep internal reasoning brief. Continue following the task and use tools normally.`
- Added a regression assertion in `packages/ai/test/openai-compat-policy.test.ts` that the fallback payload contains no `Juice`, `!important`, `budget`, or `zero` wording.
- Updated Responses/Azure/stateful payload tests and catalog docs/changelogs to describe the fallback without the old zero-juice phrase.

## Verification
`bun test packages/ai/test/openai-compat-policy.test.ts packages/ai/test/azure-openai-responses-stream.test.ts packages/ai/test/openai-responses-stateful.test.ts` passed: 24 tests, 101 expects. `bun run fix` completed and formatted the changed AI test. `bun check` passed across workspace packages. Re-running the original `/tmp/issue-4151-repro.test.ts` after the fix fails on the old exact `# Juice: 0 !important` expectation and shows the new non-budget text instead. Fixes #4151