### PR TITLE
fix(coreweave): harden project header setup

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified CoreWeave Serverless Inference login instructions to persist `COREWEAVE_PROJECT` in the user's shell startup file.
+
 ## [16.2.12] - 2026-07-01
 
 ### Changed

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -17,6 +17,7 @@ import {
 	COREWEAVE_PROJECT_HEADER,
 	coreWeaveProjectHeaders,
 	hasCoreWeaveProjectHeader,
+	removeBlankCoreWeaveProjectHeaders,
 } from "@oh-my-pi/pi-catalog/wire/coreweave";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import {
@@ -160,6 +161,7 @@ function resolveSakanaRequestBaseUrl(): string | undefined {
 }
 
 function applyCoreWeaveProjectHeader(headers: Record<string, string>): void {
+	removeBlankCoreWeaveProjectHeaders(headers);
 	if (hasCoreWeaveProjectHeader(headers)) {
 		return;
 	}

--- a/packages/ai/src/registry/coreweave.ts
+++ b/packages/ai/src/registry/coreweave.ts
@@ -5,14 +5,15 @@ import { createApiKeyLogin } from "./api-key-login";
 import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
 
-const PROJECT_SETUP_INSTRUCTIONS =
-	"Create or select a CoreWeave Serverless Inference project, add export COREWEAVE_PROJECT=<team>/<project> to your shell startup file (for example ~/.zshrc, ~/.bashrc, or your shell's profile/rc file) for the OpenAI-Project header, then copy your API key from account settings";
+const PROJECT_PERSIST_INSTRUCTIONS =
+	"add export COREWEAVE_PROJECT=<team>/<project> to your shell startup file (for example ~/.zshrc, ~/.bashrc, or your shell's profile/rc file)";
+const PROJECT_SETUP_INSTRUCTIONS = `Create or select a CoreWeave Serverless Inference project, ${PROJECT_PERSIST_INSTRUCTIONS} for the OpenAI-Project header, then copy your API key from account settings`;
 
 function requireCoreWeaveProjectHeaders(): Record<string, string> {
 	const headers = coreWeaveProjectHeaders($env);
 	if (!headers) {
 		throw new AIError.ConfigurationError(
-			"CoreWeave Serverless Inference requires OpenAI-Project. Set COREWEAVE_PROJECT=<team>/<project> before running /login coreweave. To persist it, add export COREWEAVE_PROJECT=<team>/<project> to your shell startup file, such as ~/.zshrc, ~/.bashrc, or your shell's profile/rc file.",
+			`CoreWeave Serverless Inference requires OpenAI-Project. Set COREWEAVE_PROJECT=<team>/<project> before running /login coreweave. To persist it, ${PROJECT_PERSIST_INSTRUCTIONS}.`,
 		);
 	}
 	return headers;

--- a/packages/ai/src/registry/coreweave.ts
+++ b/packages/ai/src/registry/coreweave.ts
@@ -6,13 +6,13 @@ import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ProviderDefinition } from "./types";
 
 const PROJECT_SETUP_INSTRUCTIONS =
-	"Create or select a CoreWeave Serverless Inference project, set COREWEAVE_PROJECT=<team>/<project> for the OpenAI-Project header, then copy your API key from account settings";
+	"Create or select a CoreWeave Serverless Inference project, add export COREWEAVE_PROJECT=<team>/<project> to your shell startup file (for example ~/.zshrc, ~/.bashrc, or your shell's profile/rc file) for the OpenAI-Project header, then copy your API key from account settings";
 
 function requireCoreWeaveProjectHeaders(): Record<string, string> {
 	const headers = coreWeaveProjectHeaders($env);
 	if (!headers) {
 		throw new AIError.ConfigurationError(
-			"CoreWeave Serverless Inference requires OpenAI-Project. Set COREWEAVE_PROJECT=<team>/<project> before running /login coreweave.",
+			"CoreWeave Serverless Inference requires OpenAI-Project. Set COREWEAVE_PROJECT=<team>/<project> before running /login coreweave. To persist it, add export COREWEAVE_PROJECT=<team>/<project> to your shell startup file, such as ~/.zshrc, ~/.bashrc, or your shell's profile/rc file.",
 		);
 	}
 	return headers;

--- a/packages/ai/test/coreweave-login.test.ts
+++ b/packages/ai/test/coreweave-login.test.ts
@@ -55,6 +55,9 @@ describe("CoreWeave Serverless Inference login", () => {
 
 		expect(apiKey).toBe("coreweave-test-key");
 		expect(authMessages[0]).toContain("COREWEAVE_PROJECT=<team>/<project>");
+		expect(authMessages[0]).toContain("~/.zshrc");
+		expect(authMessages[0]).toContain("~/.bashrc");
+		expect(authMessages[0]).toContain("your shell's profile/rc file");
 		expect(authMessages[0]).toContain("OpenAI-Project");
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
@@ -71,12 +74,13 @@ describe("CoreWeave Serverless Inference login", () => {
 			});
 		});
 
-		await expect(
-			loginCoreWeave({
-				onPrompt: async () => "coreweave-test-key",
-				fetch: fetchMock,
-			}),
-		).rejects.toThrow("Set COREWEAVE_PROJECT=<team>/<project>");
+		const login = loginCoreWeave({
+			onPrompt: async () => "coreweave-test-key",
+			fetch: fetchMock,
+		});
+
+		await expect(login).rejects.toThrow("Set COREWEAVE_PROJECT=<team>/<project>");
+		await expect(login).rejects.toThrow("your shell's profile/rc file");
 		expect(fetchMock).toHaveBeenCalledTimes(0);
 	});
 

--- a/packages/ai/test/coreweave-project-header.test.ts
+++ b/packages/ai/test/coreweave-project-header.test.ts
@@ -96,9 +96,10 @@ describe("CoreWeave Serverless Inference project header", () => {
 		});
 
 		expect(setup.headers["OpenAI-Project"]).toBe("team/project");
+		expect(setup.headers["openai-project"]).toBeUndefined();
 	});
 
-	test("sends OpenAI-Project on chat-completions requests", async () => {
+	test("sends one OpenAI-Project header on chat-completions requests when a blank override is present", async () => {
 		Bun.env.COREWEAVE_PROJECT = "team/project";
 		const requestHeaders: Headers[] = [];
 		const fetchMock: FetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -109,6 +110,7 @@ describe("CoreWeave Serverless Inference project header", () => {
 		await completeSimple(getBundledModel("coreweave", "zai-org/GLM-5.2"), context, {
 			apiKey: "coreweave-key",
 			fetch: fetchMock,
+			headers: { "openai-project": "   " },
 		});
 
 		expect(requestHeaders[0]?.get("OpenAI-Project")).toBe("team/project");

--- a/packages/ai/test/coreweave-project-header.test.ts
+++ b/packages/ai/test/coreweave-project-header.test.ts
@@ -1,5 +1,8 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { completeSimple } from "@oh-my-pi/pi-ai";
 import { resolveOpenAIRequestSetup } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { Context, FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 const COREWEAVE_ENV_KEYS = ["COREWEAVE_PROJECT", "WANDB_INFERENCE_PROJECT", "WANDB_ENTITY", "WANDB_PROJECT"] as const;
 const ORIGINAL_ENV = new Map(COREWEAVE_ENV_KEYS.map(key => [key, Bun.env[key]]));
@@ -18,6 +21,22 @@ function restoreCoreWeaveEnv(): void {
 afterEach(() => {
 	restoreCoreWeaveEnv();
 });
+
+const context: Context = { messages: [{ role: "user", content: "hi", timestamp: 0 }] };
+
+function chatSse(): Response {
+	const chunk = (delta: unknown, finish: string | null) =>
+		JSON.stringify({
+			id: "x",
+			object: "chat.completion.chunk",
+			created: 0,
+			choices: [{ index: 0, delta, finish_reason: finish }],
+		});
+	return new Response(`data: ${chunk({ content: "ok" }, null)}\n\ndata: ${chunk({}, "stop")}\n\ndata: [DONE]\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
 
 describe("CoreWeave Serverless Inference project header", () => {
 	const coreWeaveModel = {
@@ -65,5 +84,33 @@ describe("CoreWeave Serverless Inference project header", () => {
 
 		expect(setup.headers["openai-project"]).toBe("explicit/team");
 		expect(setup.headers["OpenAI-Project"]).toBeUndefined();
+	});
+
+	test("uses COREWEAVE_PROJECT when an explicit blank project header is present", () => {
+		Bun.env.COREWEAVE_PROJECT = "team/project";
+
+		const setup = resolveOpenAIRequestSetup(coreWeaveModel, {
+			apiKey: "coreweave-key",
+			extraHeaders: { "openai-project": "   " },
+			messages: [],
+		});
+
+		expect(setup.headers["OpenAI-Project"]).toBe("team/project");
+	});
+
+	test("sends OpenAI-Project on chat-completions requests", async () => {
+		Bun.env.COREWEAVE_PROJECT = "team/project";
+		const requestHeaders: Headers[] = [];
+		const fetchMock: FetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			requestHeaders.push(new Headers(init?.headers));
+			return chatSse();
+		});
+
+		await completeSimple(getBundledModel("coreweave", "zai-org/GLM-5.2"), context, {
+			apiKey: "coreweave-key",
+			fetch: fetchMock,
+		});
+
+		expect(requestHeaders[0]?.get("OpenAI-Project")).toBe("team/project");
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed CoreWeave Serverless Inference project-header detection so blank `OpenAI-Project` overrides do not block `COREWEAVE_PROJECT` fallback.
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/catalog/src/wire/coreweave.ts
+++ b/packages/catalog/src/wire/coreweave.ts
@@ -40,3 +40,12 @@ export function hasCoreWeaveProjectHeader(headers: Record<string, string>): bool
 	const normalized = COREWEAVE_PROJECT_HEADER.toLowerCase();
 	return Object.entries(headers).some(([header, value]) => header.toLowerCase() === normalized && value.trim() !== "");
 }
+
+export function removeBlankCoreWeaveProjectHeaders(headers: Record<string, string>): void {
+	const normalized = COREWEAVE_PROJECT_HEADER.toLowerCase();
+	for (const [header, value] of Object.entries(headers)) {
+		if (header.toLowerCase() === normalized && value.trim() === "") {
+			delete headers[header];
+		}
+	}
+}

--- a/packages/catalog/src/wire/coreweave.ts
+++ b/packages/catalog/src/wire/coreweave.ts
@@ -38,5 +38,5 @@ export function coreWeaveProjectHeaders(env: CoreWeaveProjectEnv): Record<string
 
 export function hasCoreWeaveProjectHeader(headers: Record<string, string>): boolean {
 	const normalized = COREWEAVE_PROJECT_HEADER.toLowerCase();
-	return Object.keys(headers).some(header => header.toLowerCase() === normalized);
+	return Object.entries(headers).some(([header, value]) => header.toLowerCase() === normalized && value.trim() !== "");
 }


### PR DESCRIPTION
Summary

- treat blank CoreWeave `OpenAI-Project` overrides as absent so `COREWEAVE_PROJECT` can still populate the request header
- add request-path coverage that CoreWeave chat-completions calls include `OpenAI-Project`
- clarify `/login coreweave` setup guidance so users persist `COREWEAVE_PROJECT=<team>/<project>` in their shell startup file

Testing

- `bun test packages/ai/test/coreweave-login.test.ts packages/ai/test/coreweave-project-header.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/catalog run check`