### PR TITLE
fix(ai): omit stale Responses assistant item ids

### DIFF
--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -301,6 +301,11 @@ function isOpenAIResponsesStalePreviousResponseError(error: unknown): boolean {
 	);
 }
 
+function isOpenAIResponsesToolPairingChainError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	return /No tool (?:call|output) found/i.test(error.message);
+}
+
 function registerOpenAIResponsesChainStaleFailure(chain: OpenAIResponsesChainState, error: unknown): void {
 	resetOpenAIResponsesChainState(chain);
 	chain.staleFailures += 1;
@@ -614,7 +619,11 @@ const streamOpenAIResponsesOnce = (
 						error instanceof Error &&
 						/previous[ _]?response/i.test(error.message) &&
 						/zero[ _-]?data[ _-]?retention/i.test(error.message);
-					if (!zdrRejection && !isOpenAIResponsesStalePreviousResponseError(error)) {
+					if (
+						!zdrRejection &&
+						!isOpenAIResponsesStalePreviousResponseError(error) &&
+						!isOpenAIResponsesToolPairingChainError(error)
+					) {
 						throw error;
 					}
 					// Server rejected the chain baseline: reset, count the failure (or

--- a/packages/ai/test/openai-responses-stateful.test.ts
+++ b/packages/ai/test/openai-responses-stateful.test.ts
@@ -44,6 +44,29 @@ function createStatefulSse(text: string, responseId: string): Response {
 	});
 }
 
+function createStatefulFunctionCallSse(responseId: string, callId: string): Response {
+	const args = JSON.stringify({ path: "README.md" });
+	const item = { type: "function_call", id: `fc_${responseId}`, call_id: callId, name: "read", arguments: args };
+	const events = [
+		{ type: "response.created", response: { id: responseId } },
+		{ type: "response.output_item.added", item: { ...item, arguments: "" } },
+		{ type: "response.function_call_arguments.done", arguments: args },
+		{ type: "response.output_item.done", item },
+		{
+			type: "response.completed",
+			response: {
+				id: responseId,
+				status: "completed",
+				usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8, input_tokens_details: { cached_tokens: 0 } },
+			},
+		},
+	];
+	return new Response(`${events.map(event => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\n`, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
 function createCapturingFetch(sentRequests: Array<Record<string, unknown>>): FetchImpl {
 	return vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
 		sentRequests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
@@ -231,6 +254,66 @@ describe("openai-responses stateful chaining", () => {
 		expect(sentRequests[2]?.previous_response_id).toBeUndefined();
 		expect(JSON.stringify(sentRequests[2]?.input)).toContain("First question");
 		expect(JSON.stringify(sentRequests[2]?.input)).toContain("Second question");
+	});
+
+	it("retries a chained tool-output pairing rejection with the full transcript", async () => {
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const callId = "call_read_stateful";
+		const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			const request = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			sentRequests.push(request);
+			if (sentRequests.length === 1) return createStatefulFunctionCallSse("resp_1", callId);
+			if (typeof request.previous_response_id === "string") {
+				return new Response(
+					JSON.stringify({
+						error: {
+							message: `No tool call found for function call output with call_id ${callId}.`,
+							type: "invalid_request_error",
+						},
+					}),
+					{ status: 400, headers: { "content-type": "application/json" } },
+				);
+			}
+			return createStatefulSse(`Answer ${sentRequests.length}`, `resp_${sentRequests.length}`);
+		}) as FetchImpl;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const options = {
+			apiKey: "test-key",
+			sessionId: "stateful-tool-pairing-session",
+			providerSessionState,
+			statefulResponses: true,
+			reasoning: "low" as const,
+			fetch: fetchMock,
+		};
+
+		const firstUser = { role: "user" as const, content: "Read the file", timestamp: 1000 };
+		const firstResponse = await streamOpenAIResponses(
+			model,
+			{ systemPrompt, messages: [firstUser] },
+			options,
+		).result();
+		const toolResult = {
+			role: "toolResult" as const,
+			toolCallId: callId,
+			toolName: "read",
+			content: [{ type: "text" as const, text: "file contents" }],
+			isError: false,
+			timestamp: 1001,
+		};
+		const secondResponse = await streamOpenAIResponses(
+			model,
+			{ systemPrompt, messages: [firstUser, firstResponse, toolResult] },
+			options,
+		).result();
+
+		expect(secondResponse.stopReason).toBe("stop");
+		expect(sentRequests).toHaveLength(3);
+		expect(sentRequests[1]?.previous_response_id).toBe("resp_1");
+		expect(sentRequests[2]?.previous_response_id).toBeUndefined();
+		const retryInput = JSON.stringify(sentRequests[2]?.input);
+		expect(retryInput).toContain('"function_call"');
+		expect(retryInput).toContain('"function_call_output"');
+		expect(retryInput).toContain(callId);
 	});
 
 	it("disables chaining for the session after repeated stale failures and stops forcing store", async () => {


### PR DESCRIPTION
## Summary

- Fix poisoned OpenAI Responses history that replays locally rebuilt assistant item IDs (`msg_*`, `fc_*`, `fcr_*`, `ctc_*`) without the matching OpenAI reasoning item (`rs_*`).
- When replay cannot include a valid reasoning item, omit those server-issued assistant item IDs and keep the semantic payload instead:
  - assistant `message` content still replays as text,
  - `function_call` / `custom_tool_call` still replay with `call_id`, name, and arguments/input,
  - paired tool outputs still match by `call_id`.
- Preserve assistant item IDs when the same assistant turn does include a replayable OpenAI `reasoning` item.
- Add regression coverage for replaying `message`, `function_call`, and `custom_tool_call` blocks without reasoning.
- Update the `packages/ai` changelog entry.

## Why

OpenAI reasoning Responses can bind returned assistant output item IDs to the reasoning item from the same response. Poisoned local history can retain rebuilt `msg_*` / `fc_*` / `ctc_*` IDs while the required `rs_*` reasoning item is absent. OpenAI then rejects the full-context replay with errors such as:

```text
Item 'fc_...' of type 'function_call' was provided without its required reasoning item ...
Item 'msg_...' of type 'message' was provided without its required reasoning item ...
```

The Codex Responses path already avoids this class by stripping input item IDs before send. This change applies the same principle only when normal OpenAI Responses replay lacks a valid reasoning item: drop the stale item ID, keep the usable transcript content and `call_id` pairing.

## Verification

- `bun test packages/ai/test/apply-patch-freeform.test.ts packages/ai/test/openai-responses-orphan-repair.test.ts`: pass (`34 pass`, `0 fail`, `85 expect() calls`)
- `bun check`: pass
