### PR TITLE
feat(catalog): add native LongCat AI provider support

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added LongCat provider registry definition with API-key login flow (`LONGCAT_API_KEY`, validated against the OpenAI-compatible `/v1/models` endpoint). (#3876)
+
 ## [16.2.12] - 2026-07-01
 
 ### Changed

--- a/packages/ai/src/registry/longcat.ts
+++ b/packages/ai/src/registry/longcat.ts
@@ -1,0 +1,21 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { ProviderDefinition } from "./types";
+
+export const loginLongcat = createApiKeyLogin({
+	providerLabel: "LongCat",
+	authUrl: "https://longcat.chat/platform",
+	instructions: "Copy your API key from the LongCat platform dashboard",
+	promptMessage: "Paste your LongCat API key",
+	placeholder: "lc-...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "LongCat",
+		modelsUrl: "https://api.longcat.chat/openai/v1/models",
+	},
+});
+
+export const longcatProvider = {
+	id: "longcat",
+	name: "LongCat",
+	login: loginLongcat,
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -27,6 +27,7 @@ import { kimiCodeProvider } from "./kimi-code";
 import { litellmProvider } from "./litellm";
 import { llamaCppProvider } from "./llama-cpp";
 import { lmStudioProvider } from "./lm-studio";
+import { longcatProvider } from "./longcat";
 import { minimaxProvider } from "./minimax";
 import { minimaxCodeProvider } from "./minimax-code";
 import { minimaxCodeCnProvider } from "./minimax-code-cn";
@@ -103,6 +104,7 @@ const ALL = [
 	xiaomiTokenPlanCnProvider,
 	firepassProvider,
 	deepseekProvider,
+	longcatProvider,
 	moonshotProvider,
 	cerebrasProvider,
 	fireworksProvider,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added native provider support for LongCat AI with the LongCat-2.0 model (1M context, 128K max output, OpenAI-compatible endpoint at `https://api.longcat.chat/openai/v1`, binary `thinking` mode via `LONGCAT_API_KEY`). (#3876)
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -36,6 +36,7 @@ import {
 	clampKimiK27CodeMaxTokens,
 	isFireworksKimiK2ModelId,
 	isKimiK27CodeModelId,
+	LONGCAT_STATIC_MODELS,
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,
 	SAKANA_FUGU_STATIC_MODELS,
@@ -498,6 +499,11 @@ async function generateModels() {
 	if (!authoritativeCatalogProviders.has("sakana")) {
 		allModels.push(...SAKANA_FUGU_STATIC_MODELS);
 	}
+	// Seed LongCat's documented LongCat-2.0 model so the provider is usable
+	// when catalog generation has no live API key. LongCat is not
+	// dynamicModelsAuthoritative, so a live `/v1/models` refresh merges rather
+	// than replaces; the seed is the fallback for fresh installs.
+	allModels.push(...LONGCAT_STATIC_MODELS);
 	// Seed the GitLab Duo Agent fallback model so a fresh install (no credentialed
 	// dynamic discovery/cache yet) still surfaces the provider's default model in the
 	// built-in catalog. The descriptor deliberately has NO `catalogDiscovery`, so it is

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -34430,6 +34430,11 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
 			}
 		},
 		"kimi-k2": {
@@ -34509,6 +34514,41 @@
 					"medium",
 					"high"
 				]
+			}
+		}
+	},
+	"longcat": {
+		"LongCat-2.0": {
+			"id": "LongCat-2.0",
+			"name": "LongCat 2.0",
+			"api": "openai-completions",
+			"provider": "longcat",
+			"baseUrl": "https://api.longcat.chat/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 2.95,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
 			}
 		}
 	},
@@ -65283,12 +65323,12 @@
 			],
 			"cost": {
 				"input": 0.255,
-				"output": 1,
+				"output": 1.02,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 196608,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -65310,13 +65350,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.29,
-				"output": 0.95,
+				"input": 0.3,
+				"output": 1.2,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 196608,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -66037,11 +66077,11 @@
 			"cost": {
 				"input": 0.6,
 				"output": 2.5,
-				"cacheRead": 0.6,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 100352,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -68788,13 +68828,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.39999999999999997,
+				"input": 0.13,
+				"output": 1.56,
 				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -68901,8 +68941,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.049999999999999996,
-				"output": 0.39999999999999997,
+				"input": 0.117,
+				"output": 0.45499999999999996,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
@@ -71329,7 +71369,7 @@
 	"synthetic": {
 		"hf:MiniMaxAI/MiniMax-M3": {
 			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71344,7 +71384,7 @@
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -71359,7 +71399,7 @@
 		},
 		"hf:moonshotai/Kimi-K2.6": {
 			"id": "hf:moonshotai/Kimi-K2.6",
-			"name": "moonshotai/Kimi-K2.6",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71408,7 +71448,7 @@
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71437,7 +71477,7 @@
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71462,9 +71502,38 @@
 				]
 			}
 		},
+		"hf:Qwen/Qwen3.5-397B-A17B": {
+			"id": "hf:Qwen/Qwen3.5-397B-A17B",
+			"name": "Qwen3.5 397B-A17B",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 3.6,
+				"cacheRead": 0.6,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71491,9 +71560,38 @@
 				]
 			}
 		},
+		"hf:zai-org/GLM-4.7": {
+			"id": "hf:zai-org/GLM-4.7",
+			"name": "GLM-4.7",
+			"api": "openai-completions",
+			"provider": "synthetic",
+			"baseUrl": "https://api.synthetic.new/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.45,
+				"output": 2.19,
+				"cacheRead": 0.45,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71522,7 +71620,7 @@
 		},
 		"hf:zai-org/GLM-5.1": {
 			"id": "hf:zai-org/GLM-5.1",
-			"name": "zai-org/GLM-5.1",
+			"name": "GLM-5.1",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71551,7 +71649,7 @@
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73112,6 +73210,39 @@
 			},
 			"contextWindow": 198000,
 			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"claude-sonnet-5": {
+			"id": "claude-sonnet-5",
+			"name": "Claude Sonnet 5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82295,6 +82426,14 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82307,14 +82446,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-4.3": {
@@ -82336,6 +82467,14 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82348,14 +82487,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-build": {
@@ -88595,6 +88726,11 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
 			}
 		},
 		"glm-4.5-air": {
@@ -88656,6 +88792,11 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
 			}
 		},
 		"glm-4.6v": {
@@ -88751,6 +88892,11 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
 			}
 		},
 		"glm-5-turbo": {

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -25,6 +25,7 @@ import {
 	kimiCodeModelManagerOptions,
 	litellmModelManagerOptions,
 	lmStudioModelManagerOptions,
+	longcatModelManagerOptions,
 	mistralModelManagerOptions,
 	moonshotModelManagerOptions,
 	nanoGptModelManagerOptions,
@@ -210,6 +211,13 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["LITELLM_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => litellmModelManagerOptions(config),
 		catalogDiscovery: { label: "LiteLLM", allowUnauthenticated: true },
+	},
+	{
+		id: "longcat",
+		defaultModel: "LongCat-2.0",
+		envVars: ["LONGCAT_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => longcatModelManagerOptions(config),
+		catalogDiscovery: { label: "LongCat" },
 	},
 	{
 		id: "lm-studio",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2877,6 +2877,77 @@ export function xiaomiModelManagerOptions(
 	};
 }
 // ---------------------------------------------------------------------------
+// 20.5 LongCat
+// ---------------------------------------------------------------------------
+
+const LONGCAT_DEFAULT_BASE_URL = "https://api.longcat.chat/openai/v1";
+
+export interface LongcatModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+/**
+ * Static seed for LongCat-2.0 so the provider is usable before the first
+ * successful `/v1/models` refresh (and when catalog generation runs without
+ * a live API key). LongCat-2.0: 1M context, 128K max output, reasoning via
+ * the `thinking: { type: "enabled" }` parameter (same shape as zai/moonshot).
+ */
+export const LONGCAT_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	{
+		id: "LongCat-2.0",
+		name: "LongCat 2.0",
+		api: "openai-completions",
+		provider: "longcat",
+		baseUrl: LONGCAT_DEFAULT_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		thinking: {
+			mode: "effort",
+			// LongCat-2.0 thinking is binary: `thinking: { type: "enabled" }` /
+			// `{ type: "disabled" }`. There are no discrete effort tiers, so the
+			// zai-format effort map collapses minimal->disabled and the rest to
+			// enabled. xhigh has no wire meaning and is intentionally omitted.
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+		},
+		compat: {
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			supportsDeveloperRole: false,
+		},
+	},
+];
+
+export function longcatModelManagerOptions(
+	config?: LongcatModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? LONGCAT_DEFAULT_BASE_URL;
+	const references = createBundledReferenceMap<"openai-completions">("longcat");
+	return {
+		providerId: "longcat",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "longcat",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						return mapWithBundledReference(entry, defaults, reference);
+					},
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 21. LiteLLM
 // ---------------------------------------------------------------------------
 

--- a/packages/catalog/test/longcat-bundled-catalog.test.ts
+++ b/packages/catalog/test/longcat-bundled-catalog.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import modelsJson from "../src/models.json";
+import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { LONGCAT_STATIC_MODELS, longcatModelManagerOptions } from "../src/provider-models/openai-compat";
+
+interface BundledModel {
+	api: string;
+	provider: string;
+	baseUrl: string;
+	reasoning: boolean;
+	input: string[];
+	contextWindow: number | null;
+	maxTokens: number | null;
+	compat?: Record<string, unknown>;
+	thinking?: { mode: string; efforts: string[] };
+}
+
+describe("longcat descriptor", () => {
+	it("exposes the longcat provider with the documented default model and env var", () => {
+		expect(DEFAULT_MODEL_PER_PROVIDER.longcat).toBe("LongCat-2.0");
+
+		const descriptor = PROVIDER_DESCRIPTORS.find(d => d.providerId === "longcat");
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.defaultModel).toBe("LongCat-2.0");
+	});
+
+	it("uses the OpenAI-compatible base URL ending in /openai/v1", () => {
+		const model = LONGCAT_STATIC_MODELS.find(m => m.id === "LongCat-2.0");
+		expect(model?.baseUrl).toBe("https://api.longcat.chat/openai/v1");
+	});
+
+	it("resolves model-manager options without an API key (seed-only boot)", () => {
+		const options = longcatModelManagerOptions({});
+		expect(options.providerId).toBe("longcat");
+		expect(options.fetchDynamicModels).toBeUndefined();
+	});
+
+	it("enables dynamic discovery when an API key is supplied", () => {
+		const options = longcatModelManagerOptions({ apiKey: "test-key" });
+		expect(options.fetchDynamicModels).toBeDefined();
+	});
+});
+
+describe("longcat bundled catalog", () => {
+	it("pins LongCat-2.0 with 1M context, 128K output, reasoning, and zai thinking format", () => {
+		const longcatModels = modelsJson.longcat as Record<string, BundledModel>;
+		const model = longcatModels["LongCat-2.0"];
+
+		expect(model).toBeDefined();
+		expect(model.provider).toBe("longcat");
+		expect(model.api).toBe("openai-completions");
+		expect(model.baseUrl).toBe("https://api.longcat.chat/openai/v1");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text"]);
+		expect(model.contextWindow).toBe(1_000_000);
+		expect(model.maxTokens).toBe(131_072);
+		expect(model.compat?.thinkingFormat).toBe("zai");
+		expect(model.compat?.reasoningContentField).toBe("reasoning_content");
+	});
+
+	it("omits xhigh from thinking efforts — LongCat-2.0 thinking is binary (enabled/disabled)", () => {
+		const longcatModels = modelsJson.longcat as Record<string, BundledModel>;
+		const model = longcatModels["LongCat-2.0"];
+
+		// LongCat-2.0 supports only `thinking: { type: "enabled" | "disabled" }` —
+		// no discrete effort tiers. xhigh has no wire meaning and must not appear.
+		expect(model.thinking?.efforts).toEqual(["minimal", "low", "medium", "high"]);
+		expect(model.thinking?.efforts).not.toContain("xhigh");
+	});
+});


### PR DESCRIPTION
## Summary

Adds native LongCat AI provider support, resolving #3876.

LongCat 2.0 is an OpenAI-compatible model (1M context, 128K max output) accessible at `https://api.longcat.chat/openai/v1`. This adds it as a first-class provider with API-key auth (`LONGCAT_API_KEY`).

## Changes

- **Catalog descriptor** (`descriptors.ts`): `longcat` provider entry — id, default model `LongCat-2.0`, env var `LONGCAT_API_KEY`, catalog discovery
- **Model manager + seed** (`openai-compat.ts`): `longcatModelManagerOptions` (standard OpenAI-compat discovery path) + `LONGCAT_STATIC_MODELS` seed so the provider is usable without a live API key
- **Registry auth** (`registry/longcat.ts`): API-key login flow validated against the `/v1/models` endpoint
- **Generator** (`generate-models.ts`): seed push
- **Regenerated** `models.json` with the `longcat` provider
- **Regression test** pinning the bundled model spec (baseUrl, context, maxTokens, reasoning, thinking efforts)

## Design notes

- **Standard OpenAI-compat path** — no GLM-special handling. LongCat has its own native provider (`longcat`), distinct from the zai/zhipu GLM providers.
- **`thinkingFormat: "zai"`** — LongCat uses the same `thinking: { type: "enabled" | "disabled" }` binary reasoning format as zai/moonshot.
- **Thinking efforts: `[minimal, low, medium, high]`** — no `xhigh`. Verified against the [official docs](https://longcat.chat/platform/docs/api/chat.html): LongCat-2.0 reasoning is a binary on/off switch (`thinking.type`), with no discrete effort tiers or `reasoning_effort` parameter. `xhigh` has no wire meaning.
- **Pricing**: standard rates from the [pricing page](https://longcat.chat/platform/docs/Pricing/LongCat-2.0.html) — $0.75 / $2.95 / $0.015 per million tokens (input / output / cached read).

## Verification

- ✅ 383 catalog + registry tests pass (0 failures)
- ✅ TypeScript type check passes (both `packages/catalog` and `packages/ai`)
- ✅ Biome check passes
- ✅ Runtime integration confirmed: provider resolves in both catalog and registry; bundled model loads with correct metadata

Closes #3876