### PR TITLE
fix(auth): quarantine Anthropic OAuth org denial

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -13,6 +13,7 @@ import * as path from "node:path";
 import { getAgentDbPath, logger } from "@oh-my-pi/pi-utils";
 import type { ApiKeyResolver } from "./auth-retry";
 import * as AIError from "./error";
+import { isAnthropicOAuthNotAllowedError } from "./error/auth-classify";
 import { isUsageLimitOutcome } from "./error/rate-limit";
 import { getProviderDefinition, PASTE_CODE_LOGIN_PROVIDERS } from "./registry";
 import { getOAuthApiKey, getOAuthProvider, refreshOAuthToken } from "./registry/oauth";
@@ -4259,6 +4260,22 @@ export class AuthStorage {
 		);
 		const target = this.#getStoredCredentials(provider)[sessionCredential.index];
 		this.#clearSessionCredential(provider, sessionId);
+
+		if (
+			target &&
+			provider === "anthropic" &&
+			sessionCredential.type === "oauth" &&
+			isAnthropicOAuthNotAllowedError(error)
+		) {
+			this.#tryDisableCredentialAtIfMatches(
+				provider,
+				sessionCredential.index,
+				target.credential,
+				"anthropic oauth not allowed for organization",
+			);
+			return hasSibling;
+		}
+
 		this.#markCredentialBlocked(providerKey, sessionCredential.index, Date.now() + AuthStorage.#defaultBackoffMs);
 
 		if (target) {

--- a/packages/ai/src/error/auth-classify.ts
+++ b/packages/ai/src/error/auth-classify.ts
@@ -20,11 +20,28 @@ export function isDefinitiveOAuthFailure(errorMsg: string): boolean {
  * Transient 429s (`Too many requests`, per-minute caps) stay in the
  * upstream-backoff lane.
  */
+const ANTHROPIC_OAUTH_NOT_ALLOWED_MESSAGE = "OAuth authentication is currently not allowed for this organization";
+
+/**
+ * Anthropic returns this 403 when an OAuth credential belongs to an org that
+ * is not permitted to use Claude Code-style OAuth requests. This is
+ * credential/org-specific, not a generic WAF/egress 403 and not a dead OAuth
+ * grant, so callers should rotate away from that stored account.
+ */
+export function isAnthropicOAuthNotAllowedError(error: unknown): boolean {
+	const httpStatus = extractHttpStatusFromError(error);
+	const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
+	const embeddedStatus = message ? extractHttpStatusFromError({ message }) : undefined;
+	const status = httpStatus ?? embeddedStatus;
+	return status === 403 && message?.includes(ANTHROPIC_OAUTH_NOT_ALLOWED_MESSAGE) === true;
+}
+
 export function isAuthRetryableError(error: unknown): boolean {
 	const httpStatus = extractHttpStatusFromError(error);
 	if (httpStatus === 401) return true;
 	const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 	const embeddedStatus = message ? extractHttpStatusFromError({ message }) : undefined;
 	if (embeddedStatus === 401) return true;
+	if (isAnthropicOAuthNotAllowedError(error)) return true;
 	return isUsageLimitOutcome(httpStatus ?? embeddedStatus, message);
 }

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -52,6 +52,16 @@ describe("isAuthRetryableError", () => {
 		// credentials won't help an org/global limit.
 		expect(isAuthRetryableError(Object.assign(new Error("429 too many requests"), { status: 429 }))).toBe(false);
 		expect(isAuthRetryableError("Error: 401 unauthorized")).toBe(true);
+		expect(
+			isAuthRetryableError(
+				Object.assign(
+					new Error(
+						'403 {"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization."}}',
+					),
+					{ status: 403 },
+				),
+			),
+		).toBe(true);
 		expect(isAuthRetryableError(authError(403))).toBe(false);
 		expect(isAuthRetryableError(authError(500))).toBe(false);
 		expect(isAuthRetryableError(new Error("network blip"))).toBe(false);

--- a/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
+++ b/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
@@ -31,6 +31,15 @@ function invalidRequestError(): Error & { status: number } {
 	return Object.assign(new Error("400 invalid_request_error: model unsupported"), { status: 400 });
 }
 
+function anthropicOAuthNotAllowedError(): Error & { status: number } {
+	return Object.assign(
+		new Error(
+			'403 {"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization."}}',
+		),
+		{ status: 403 },
+	);
+}
+
 describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 	let tempDir = "";
 	let store: AuthCredentialStore | undefined;
@@ -39,7 +48,10 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 	beforeEach(async () => {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-rotate-"));
 		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
-		authStorage = new AuthStorage(store);
+		authStorage = new AuthStorage(store, {
+			rankingStrategyResolver: () => undefined,
+			usageProviderResolver: () => undefined,
+		});
 	});
 
 	afterEach(async () => {
@@ -194,6 +206,33 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 		await authStorage.rotateSessionCredential(PROVIDER, "invalid-request", { error: invalidRequestError() });
 
 		expect(usageLimitSpy).not.toHaveBeenCalled();
+	});
+
+	test("rotateSessionCredential disables Anthropic OAuth org-not-allowed accounts", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+		registerProvider();
+		await authStorage.set("anthropic", [
+			{ type: "oauth", access: "acc-A", refresh: "ref-A", expires: farExpiry(), email: "bad@example.com" },
+			{ type: "oauth", access: "acc-B", refresh: "ref-B", expires: farExpiry(), email: "good@example.com" },
+		]);
+
+		const first = await authStorage.getApiKey("anthropic", "sess");
+		expect(["acc-A", "acc-B"]).toContain(first ?? "");
+		const expectedNext = first === "acc-A" ? "acc-B" : "acc-A";
+
+		const usageLimitSpy = vi.spyOn(authStorage, "markUsageLimitReached");
+		const rotated = await authStorage.rotateSessionCredential("anthropic", "sess", {
+			error: anthropicOAuthNotAllowedError(),
+		});
+
+		expect(rotated).toBe(true);
+		expect(usageLimitSpy).not.toHaveBeenCalled();
+		expect(
+			store
+				.listAuthCredentials("anthropic")
+				.map(row => (row.credential.type === "oauth" ? row.credential.access : undefined)),
+		).toEqual([expectedNext]);
+		expect(await authStorage.getApiKey("anthropic", "sess")).toBe(expectedNext);
 	});
 
 	test("rotateSessionCredential leaves informative transient 429s out of the quota block path", async () => {


### PR DESCRIPTION
## Problem

When multiple Anthropic OAuth accounts are stored, one account can belong to an organization where Anthropic rejects Claude Code-style OAuth requests with:

```json
{
  "type": "error",
  "error": {
    "type": "permission_error",
    "message": "OAuth authentication is currently not allowed for this organization."
  }
}
```

OMP currently treats this as an ordinary provider failure. If session stickiness selected that bad credential, Claude requests can keep failing even though sibling Anthropic OAuth credentials work.

## Change

- Adds an exact classifier for Anthropic's OAuth org-not-allowed 403.
- Treats that exact failure as auth-rotatable.
- In `AuthStorage.rotateSessionCredential`, disables only the failing Anthropic OAuth credential and clears session stickiness.
- Leaves generic/bare 403 handling unchanged to avoid disabling healthy credentials for WAF, egress, account-verification, or transient permission failures.

## Tests

- Adds classifier coverage in `auth-retry.test.ts`.
- Adds rotation/storage regression coverage proving:
  - the bad Anthropic OAuth credential is disabled
  - usage-limit handling is not used
  - the next credential is selected

## Verification

```bash
bun test packages/ai/test/auth-retry.test.ts packages/ai/test/auth-storage-force-refresh-rotate.test.ts packages/ai/test/oauth-definitive-failure.test.ts
bun --cwd=packages/ai run check
```
