### PR TITLE
fix(agent): interrupt waits for IRC delivery

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed interruptible tool waits to also abort for host-provided IRC interrupts, not only user steering. ([#4160](https://github.com/can1357/oh-my-pi/issues/4160))
+
 ## [16.2.4] - 2026-06-28
 
 ### Changed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1663,53 +1663,73 @@ async function executeToolCalls(
 	const batchId = `${assistantMessage.timestamp ?? Date.now()}_${toolCalls[0]?.id ?? "batch"}`;
 	const shouldInterruptImmediately = interruptMode !== "wait";
 	const steeringAbortController = new AbortController();
-	const toolSignal = signal
+	const ircAbortController = new AbortController();
+	// Interruptible tools observe steering + external + IRC aborts; every other
+	// tool only sees steering + external, so an IRC-only interrupt never kills a
+	// partially side-effecting foreground tool (e.g. `bash`) running alongside a
+	// pure wait (e.g. `job` poll).
+	const nonInterruptibleSignal: AbortSignal = signal
 		? AbortSignal.any([signal, steeringAbortController.signal])
 		: steeringAbortController.signal;
+	const interruptibleSignal: AbortSignal = signal
+		? AbortSignal.any([signal, steeringAbortController.signal, ircAbortController.signal])
+		: AbortSignal.any([steeringAbortController.signal, ircAbortController.signal]);
 	const interruptState = { triggered: false };
 
-	const records = toolCalls.map(toolCall => ({
-		toolCall,
+	const records = toolCalls.map(toolCall => {
 		// Tools emitted via OpenAI's custom-tool path (e.g. `apply_patch` on GPT-5)
 		// come back under their wire-level name, which may differ from the
 		// harness-internal `name`. Match on either, preferring `name` for
 		// determinism if both somehow collide.
-		tool:
+		const tool =
 			tools?.find(t => t.name === toolCall.name) ??
-			tools?.find(t => t.customWireName !== undefined && t.customWireName === toolCall.name),
-		args: toolCall.arguments as Record<string, unknown>,
-		started: false,
-		result: undefined as AgentToolResult<any> | undefined,
-		isError: false,
-		skipped: false,
-		toolResultMessage: undefined as ToolResultMessage | undefined,
-		resultEmitted: false,
-	}));
+			tools?.find(t => t.customWireName !== undefined && t.customWireName === toolCall.name);
+		return {
+			toolCall,
+			tool,
+			args: toolCall.arguments as Record<string, unknown>,
+			signal: tool?.interruptible ? interruptibleSignal : nonInterruptibleSignal,
+			started: false,
+			result: undefined as AgentToolResult<any> | undefined,
+			isError: false,
+			skipped: false,
+			toolResultMessage: undefined as ToolResultMessage | undefined,
+			resultEmitted: false,
+		};
+	});
 
 	const checkSteering = async (): Promise<void> => {
 		// `signal` (external/user abort) is checked separately from the internal
-		// steeringAbortController: once the run is externally aborted it is
-		// unwinding and the interrupt would be redundant.
-		if (!shouldInterruptImmediately || interruptState.triggered || signal?.aborted) {
+		// abort controllers: once the run is externally aborted it is unwinding
+		// and the interrupt would be redundant.
+		if (!shouldInterruptImmediately || signal?.aborted) {
 			return;
 		}
 		// Prefer non-consuming peeks so queues still own their messages until
 		// the injection boundary. Fall back to consuming steering only for older
 		// integrations that never supplied a peek.
-		let hasMessages = false;
+		let steeringQueued = false;
 		if (hasSteeringMessages) {
-			hasMessages = await hasSteeringMessages();
+			steeringQueued = await hasSteeringMessages();
 		} else if (getSteeringMessages) {
 			const msgs = await getSteeringMessages();
-			hasMessages = (msgs?.length ?? 0) > 0;
+			steeringQueued = (msgs?.length ?? 0) > 0;
 		}
-		if (!hasMessages && hasIrcInterrupts) {
-			hasMessages = await hasIrcInterrupts();
+		if (steeringQueued) {
+			// User steering upgrades an in-flight IRC interrupt: it aborts the
+			// shared signal so foreground tools stop as they do for a user Esc.
+			if (!steeringAbortController.signal.aborted) {
+				interruptState.triggered = true;
+				steeringAbortController.abort();
+			}
+			return;
 		}
-		if (hasMessages) {
-			if (interruptState.triggered || signal?.aborted) return;
+		if (interruptState.triggered) return;
+		if (hasIrcInterrupts && (await hasIrcInterrupts())) {
+			// Peer IRC only aborts interruptible waits: a foreground bash / write
+			// mid-execution keeps running so we never leave partial side effects.
 			interruptState.triggered = true;
-			steeringAbortController.abort();
+			ircAbortController.abort();
 		}
 	};
 
@@ -1820,14 +1840,14 @@ async function executeToolCalls(
 		}
 
 		record.args = effectiveArgs;
-		if (toolSignal.aborted) {
+		if (record.signal.aborted) {
 			record.skipped = true;
 			recordSkippedTool(telemetry, {
 				toolCallId: toolCall.id,
 				toolName: toolCall.name,
 				status: "aborted",
 			});
-			emitToolResult(record, createToolSignalAbortedResult(toolSignal), true);
+			emitToolResult(record, createToolSignalAbortedResult(record.signal), true);
 			return;
 		}
 		record.started = true;
@@ -1858,8 +1878,8 @@ async function executeToolCalls(
 		await runInActiveSpan(toolSpan, async () => {
 			try {
 				if (!tool) throw new Error(`Tool ${toolCall.name} not found`);
-				if (toolSignal.aborted) {
-					result = createToolSignalAbortedResult(toolSignal);
+				if (record.signal.aborted) {
+					result = createToolSignalAbortedResult(record.signal);
 					isError = true;
 					return;
 				}
@@ -1872,14 +1892,14 @@ async function executeToolCalls(
 							args: effectiveArgs,
 							context: currentContext,
 						},
-						toolSignal,
+						record.signal,
 					);
 					if (beforeResult?.block) {
 						throw new ToolCallBlockedError(beforeResult.reason);
 					}
 				}
-				if (toolSignal.aborted) {
-					result = createToolSignalAbortedResult(toolSignal);
+				if (record.signal.aborted) {
+					result = createToolSignalAbortedResult(record.signal);
 					isError = true;
 					return;
 				}
@@ -1899,7 +1919,7 @@ async function executeToolCalls(
 				const rawResult = await tool.execute(
 					toolCall.id,
 					executionArgs,
-					toolSignal,
+					record.signal,
 					partialResult => {
 						stream.push({
 							type: "tool_execution_update",
@@ -1924,7 +1944,7 @@ async function executeToolCalls(
 				isError = true;
 			}
 
-			if (afterToolCall && (!toolSignal.aborted || completedToolExecution)) {
+			if (afterToolCall && (!record.signal.aborted || completedToolExecution)) {
 				try {
 					const after = await afterToolCall(
 						{
@@ -1935,7 +1955,7 @@ async function executeToolCalls(
 							isError,
 							context: currentContext,
 						},
-						toolSignal,
+						record.signal,
 					);
 					if (after) {
 						// Re-normalize the post-hook result: `afterToolCall` is untyped user/extension
@@ -1963,30 +1983,33 @@ async function executeToolCalls(
 		});
 
 		const interrupted = interruptState.triggered;
-		const abortedDuringExecution = toolSignal.aborted && isError;
-		if (interrupted && isError) {
-			// Steering/abort fired AND this tool failed — it was cut off before producing a
-			// usable result, so report it as skipped.
+		const perToolAborted = record.signal.aborted;
+		const abortedDuringExecution = perToolAborted && isError;
+		if (interrupted && perToolAborted && isError) {
+			// This tool's own signal fired AND it failed — it was cut off before producing
+			// a usable result, so report it as skipped.
 			record.skipped = true;
 			emitToolResult(record, createSkippedToolResult(), true);
 		} else {
-			// No interrupt, or the tool finished (successfully or with a genuine error) before
-			// the interrupt landed. Keep its real result: a completed tool already ran its side
-			// effects, so the model must see what actually happened rather than a false "skipped".
+			// No interrupt on this signal, or the tool finished (successfully or with a
+			// genuine error) before the interrupt landed. Keep its real result: a completed
+			// tool already ran its side effects, so the model must see what actually
+			// happened rather than a false "skipped". A peer-IRC interrupt on the batch
+			// leaves non-interruptible tools' signals untouched — their genuine errors
+			// survive here instead of being clobbered into "skipped".
 			emitToolResult(record, result, isError);
 		}
 
 		const firstTextBlock = result.content?.[0];
 		const errorMessageForSpan =
 			caughtError === undefined && isError && firstTextBlock?.type === "text" ? firstTextBlock.text : undefined;
-		const status =
-			(interrupted && isError) || abortedDuringExecution
-				? "aborted"
-				: caughtError instanceof ToolCallBlockedError
-					? "blocked"
-					: isError
-						? "error"
-						: "ok";
+		const status = abortedDuringExecution
+			? "aborted"
+			: caughtError instanceof ToolCallBlockedError
+				? "blocked"
+				: isError
+					? "error"
+					: "ok";
 		finishExecuteToolSpan(telemetry, toolSpan, {
 			result,
 			isError,

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1647,6 +1647,7 @@ async function executeToolCalls(
 	const tools = currentContext.tools;
 	const {
 		hasSteeringMessages,
+		hasIrcInterrupts,
 		getSteeringMessages,
 		interruptMode = "immediate",
 		getToolContext,
@@ -1692,19 +1693,18 @@ async function executeToolCalls(
 		if (!shouldInterruptImmediately || interruptState.triggered || signal?.aborted) {
 			return;
 		}
-		// Prefer the non-consuming peek (`hasSteeringMessages`) when available.
-		// Fall back to calling `getSteeringMessages` directly when only it is
-		// provided (e.g. in tests or minimal integrations without a separate
-		// peek function). In that case the message is consumed here rather than
-		// at the outer injection boundary, but the interrupt still fires.
-		let hasMessages: boolean;
+		// Prefer non-consuming peeks so queues still own their messages until
+		// the injection boundary. Fall back to consuming steering only for older
+		// integrations that never supplied a peek.
+		let hasMessages = false;
 		if (hasSteeringMessages) {
 			hasMessages = await hasSteeringMessages();
 		} else if (getSteeringMessages) {
 			const msgs = await getSteeringMessages();
 			hasMessages = (msgs?.length ?? 0) > 0;
-		} else {
-			return;
+		}
+		if (!hasMessages && hasIrcInterrupts) {
+			hasMessages = await hasIrcInterrupts();
 		}
 		if (hasMessages) {
 			if (interruptState.triggered || signal?.aborted) return;
@@ -2030,15 +2030,15 @@ async function executeToolCalls(
 		}
 	}
 
-	// While an interruptible tool is in flight (e.g. a `job` poll blocking on
-	// background work), a queued steer would otherwise wait out the tool's own
-	// window. Poll the steering queue and let checkSteering() abort the shared
-	// tool signal so the wait returns early; the boundary dequeue below then
-	// injects it. Gated on immediate-interrupt mode + an interruptible tool;
-	// checkSteering is idempotent (no-op once triggered).
+	// While an interruptible tool is in flight (e.g. a `job`/`irc` wait
+	// blocking on external work), queued steering or interrupting IRC would
+	// otherwise wait out the tool's own window. Poll the non-consuming queues
+	// and abort the shared tool signal so the boundary dequeue below injects
+	// the message promptly. Gated on immediate-interrupt mode + an
+	// interruptible tool; checkSteering is idempotent (no-op once triggered).
 	const watchSteeringWhileRunning =
 		shouldInterruptImmediately &&
-		(hasSteeringMessages !== undefined || getSteeringMessages !== undefined) &&
+		(hasSteeringMessages !== undefined || getSteeringMessages !== undefined || hasIrcInterrupts !== undefined) &&
 		records.some(r => r.tool?.interruptible === true);
 	const steeringWatchTimer = watchSteeringWhileRunning
 		? setInterval(() => void checkSteering(), STEERING_INTERRUPT_POLL_MS)

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -414,6 +414,10 @@ export class Agent {
 	 * UI emission, and tool dispatch. Reassign at any time to swap the implementation.
 	 */
 	transformAssistantMessage?: AgentLoopConfig["transformAssistantMessage"];
+	/**
+	 * Hook that peeks whether interrupting IRC asides are queued for the next boundary.
+	 */
+	hasIrcInterrupts?: AgentLoopConfig["hasIrcInterrupts"];
 
 	constructor(opts: AgentOptions = {}) {
 		this.#state = { ...this.#state, ...opts.initialState };
@@ -1182,6 +1186,7 @@ export class Agent {
 				return this.#dequeueSteeringMessages();
 			},
 			hasSteeringMessages: () => this.#steeringQueue.length > 0,
+			hasIrcInterrupts: this.hasIrcInterrupts,
 			getFollowUpMessages: async () => this.#dequeueFollowUpMessages(),
 			getAsideMessages: async () => (await this.#asideMessageProvider?.()) ?? [],
 			onBeforeYield: () => this.#onBeforeYield?.(),

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -200,6 +200,15 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	hasSteeringMessages?: () => boolean | Promise<boolean>;
 
 	/**
+	 * Peeks whether IRC messages should interrupt an interruptible waiting tool.
+	 *
+	 * Uses the same delivery rules as steering: the poll is non-consuming, only
+	 * runs for interruptible tools, and is ignored when interruptMode is "wait".
+	 * The host owns message injection at the next boundary.
+	 */
+	hasIrcInterrupts?: () => boolean | Promise<boolean>;
+
+	/**
 	 * Returns follow-up messages to process after the agent would otherwise stop.
 	 *
 	 * Called when the agent has no more tool calls and no steering messages.

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1180,6 +1180,81 @@ describe("agentLoop with AgentMessage", () => {
 		).toBe(true);
 	});
 
+	it("drains queued IRC interrupts by aborting an interruptible tool mid-wait", async () => {
+		const toolSchema = type({});
+		let ircReady = false;
+		let ircDrained = false;
+		let observedAbort = false;
+		let resolvedByTimeout = false;
+		const ircMessage = createUserMessage("irc interrupt");
+
+		const tool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "wait",
+			label: "Wait",
+			description: "Blocks until aborted (mimics a job poll)",
+			parameters: toolSchema,
+			interruptible: true,
+			async execute(_toolCallId, _params, signal) {
+				ircReady = true;
+				const { promise, resolve } = Promise.withResolvers<void>();
+				if (signal?.aborted) {
+					resolve();
+				} else {
+					const timer = setTimeout(() => {
+						resolvedByTimeout = true;
+						resolve();
+					}, 1000);
+					signal?.addEventListener(
+						"abort",
+						() => {
+							clearTimeout(timer);
+							resolve();
+						},
+						{ once: true },
+					);
+				}
+				await promise;
+				observedAbort = signal?.aborted === true;
+				return { content: [{ type: "text", text: "waited" }], details: {} };
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{ content: [{ type: "toolCall", id: "tool-1", name: "wait", arguments: {} }] },
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasIrcInterrupts: () => ircReady && !ircDrained,
+			getAsideMessages: async () => {
+				if (ircReady && !ircDrained) {
+					ircDrained = true;
+					return [() => ircMessage];
+				}
+				return [];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		for await (const event of agentLoop([createUserMessage("start")], context, config, undefined, mock.stream)) {
+			events.push(event);
+		}
+
+		expect(observedAbort).toBe(true);
+		expect(resolvedByTimeout).toBe(false);
+		expect(ircDrained).toBe(true);
+		expect(
+			events.some(
+				e => e.type === "message_start" && e.message.role === "user" && e.message.content === "irc interrupt",
+			),
+		).toBe(true);
+	});
+
 	it("does not abort a non-interruptible tool mid-wait; steering still drains at the boundary", async () => {
 		const toolSchema = type({});
 		let steerReady = false;

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1255,6 +1255,105 @@ describe("agentLoop with AgentMessage", () => {
 		).toBe(true);
 	});
 
+	it("does not abort a non-interruptible foreground tool when only IRC is queued", async () => {
+		const toolSchema = type({});
+		let ircReady = false;
+		let ircDrained = false;
+		let bgSignalAborted = true;
+		let bgCompleted = false;
+		let waitObservedAbort = false;
+		const bgStarted = Promise.withResolvers<void>();
+		const waitFinished = Promise.withResolvers<void>();
+		const ircMessage = createUserMessage("peer irc");
+
+		const bg: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "bg",
+			label: "Bg",
+			description: "Foreground non-interruptible work (mimics bash)",
+			parameters: toolSchema,
+			async execute(_toolCallId, _params, signal) {
+				bgStarted.resolve();
+				// Hold until the interruptible wait sibling has observed the IRC abort,
+				// then finish normally. Reads `signal.aborted` at completion so the
+				// assertion sees whether an IRC-only interrupt clobbered this signal.
+				await waitFinished.promise;
+				bgSignalAborted = signal?.aborted === true;
+				bgCompleted = true;
+				return { content: [{ type: "text", text: "bg done" }], details: {} };
+			},
+		};
+
+		const wait: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "wait",
+			label: "Wait",
+			description: "Interruptible wait (mimics a job poll)",
+			parameters: toolSchema,
+			interruptible: true,
+			async execute(_toolCallId, _params, signal) {
+				await bgStarted.promise;
+				ircReady = true;
+				const { promise, resolve } = Promise.withResolvers<void>();
+				const timer = setTimeout(resolve, 2000);
+				signal?.addEventListener(
+					"abort",
+					() => {
+						clearTimeout(timer);
+						waitObservedAbort = true;
+						resolve();
+					},
+					{ once: true },
+				);
+				await promise;
+				waitFinished.resolve();
+				return { content: [{ type: "text", text: "waited" }], details: {} };
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [bg, wait] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{ type: "toolCall", id: "call-bg", name: "bg", arguments: {} },
+						{ type: "toolCall", id: "call-wait", name: "wait", arguments: {} },
+					],
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			interruptMode: "immediate",
+			hasIrcInterrupts: () => ircReady && !ircDrained,
+			getAsideMessages: async () => {
+				if (ircReady && !ircDrained) {
+					ircDrained = true;
+					return [() => ircMessage];
+				}
+				return [];
+			},
+		};
+
+		const events: AgentEvent[] = [];
+		for await (const event of agentLoop([createUserMessage("start")], context, config, undefined, mock.stream)) {
+			events.push(event);
+		}
+
+		expect(waitObservedAbort).toBe(true);
+		expect(bgCompleted).toBe(true);
+		expect(bgSignalAborted).toBe(false);
+		expect(ircDrained).toBe(true);
+		const bgEnd = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				e.type === "tool_execution_end" && e.toolCallId === "call-bg",
+		);
+		expect(bgEnd?.isError).toBe(false);
+		if (bgEnd?.result.content[0]?.type === "text") {
+			expect(bgEnd.result.content[0].text).toContain("bg done");
+		}
+	});
+
 	it("does not abort a non-interruptible tool mid-wait; steering still drains at the boundary", async () => {
 		const toolSchema = type({});
 		let steerReady = false;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed performance degradation in session context and branch path reconstruction on deep linear histories.
 - Fixed agents repeating the same tool call across turns without corrective steering by wiring the cross-turn tool-call loop guard into sessions.
 - Fixed OpenAI-compatible model discovery (including LM Studio) reporting flat default context windows when proxies omit context length metadata, by resolving discovered IDs against the bundled model reference catalog to inherit accurate context windows, output limits, display names, modalities, and reasoning support.
+- Fixed parent and peer IRC messages being delayed until `job poll` / `irc wait` completed by routing them through interruptible delivery. ([#4160](https://github.com/can1357/oh-my-pi/issues/4160))
 
 ## [16.2.11] - 2026-07-01
 

--- a/packages/coding-agent/src/prompts/steering/parent-irc.md
+++ b/packages/coding-agent/src/prompts/steering/parent-irc.md
@@ -1,0 +1,5 @@
+Your current interruptible wait was interrupted because an IRC message arrived from your parent agent `{{from}}`.
+
+Parent IRC message:
+
+{{message}}

--- a/packages/coding-agent/src/prompts/system/irc-incoming.md
+++ b/packages/coding-agent/src/prompts/system/irc-incoming.md
@@ -3,5 +3,7 @@ Incoming IRC message from agent `{{from}}`{{#if replyTo}} (replying to {{replyTo
 
 {{message}}
 
+{{#if interrupting}}An agent sent this while you were waiting or working. Any active interruptible wait was stopped early so you can read it now.{{/if}}
+
 {{#if autoReplied}}You are mid-task, so a side-channel auto-reply was generated from your context and delivered to `{{from}}` on your behalf (recorded after this message). Follow up with the `irc` tool (`op: "send"`, `to: "{{from}}"`) only if that auto-reply needs correcting.{{else}}If a response is expected, reply with the `irc` tool (`op: "send"`, `to: "{{from}}"`) — you may finish your current step first. Nobody replies on your behalf.{{/if}}
 </irc>

--- a/packages/coding-agent/src/prompts/tools/irc.md
+++ b/packages/coding-agent/src/prompts/tools/irc.md
@@ -12,7 +12,8 @@ Use `op: "send"` to deliver a message to a specific peer or broadcast to `"all"`
 
 # Waiting and Inboxes
 Messages only arrive when the peer actively sends one—do not interrogate a peer for status.
-- If you are completely blocked and MUST wait for an answer, use `op: "wait"` (or `await: true` on a send). This blocks your turn until a message arrives. If it times out, that just means "no message arrived", not a failure.
+- If you are completely blocked and MUST wait for an answer, use `op: "wait"` (or `await: true` on a send). The wait returns when a matching message arrives, the timeout elapses, or any IRC / steering message interrupts the wait. Parent-agent IRC interrupts with steering-level priority.
+- No need to alternate `irc wait`, `irc inbox`, and `job poll`: waits surface cross-channel interrupts promptly. The next turn includes the interrupt reason and message.
 - To check for messages without blocking, use `op: "inbox"` to drain your queue.
 
 # When to Coordinate

--- a/packages/coding-agent/src/prompts/tools/job.md
+++ b/packages/coding-agent/src/prompts/tools/job.md
@@ -4,8 +4,8 @@ Background tasks deliver their results automatically the moment they finish. You
 
 # Interventions
 
-- **Block and wait:** Pass `poll` with specific job IDs when you are completely blocked and cannot do any other work. The call returns as soon as one watched job finishes or the wait window elapses — NOT when all of them finish; re-issue to keep waiting.
+- **Block and wait:** Pass `poll` with specific job IDs when you are completely blocked and cannot do any other work. The call returns as soon as one watched job finishes, the wait window elapses, or an IRC / steering message interrupts the wait — NOT when all jobs finish; re-issue to keep waiting.
   - To watch EVERY running job, issue a call with NO fields at all (no `poll`, no `cancel`, no `list`). NEVER pass an array of every running ID.
-  - A finished job's output is included in the wait result.
+  - A finished job's output, or the interrupting message and reason, is included in the next turn.
 - **Stop execution:** Pass `cancel` with job IDs to kill jobs that have hung, stalled, or are no longer needed. A cancel-only call returns immediately.
 - **Snapshot:** Pass `list: true` to get the current status of all jobs without waiting.

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -5,6 +5,7 @@ Execution blocks your turn: the call only returns once the work is completely fi
 # Delegation Strategy
 - **Maximize parallelism:** Break work into the widest possible {{#if batchEnabled}}array of `tasks[]`{{else}}set of parallel `task` calls{{/if}}. NEVER serialize work that can run concurrently. Tasks touching different files or independent refactors should run in parallel; agents resolve their own file collisions live.
 - **Sequence only when necessary:** The only reason to run A before B is if B strictly requires A's output to function (e.g., a core API contract or schema migration). {{#if ircEnabled}}If the missing piece is small, run them in parallel and have B ask A via `irc`!{{/if}}
+{{#if ircEnabled}}- **Steering delivery:** Parent-to-subagent IRC is delivered immediately as steering; subagents blocked in `job poll` / `irc wait` do not need to poll separately for it.{{/if}}
 - **Role matching:** Assign each subagent a specific `role` (e.g. "Security Reviewer", "DB Migrator"). Do not spawn generic workers.
 - **No overhead:** Each assignment MUST instruct its agent to skip formatters, linters, and project-wide test suites. You will run those once at the end.
 - **One-pass agents:** Prefer agents that investigate **and** edit in a single pass; only spin a read-only discovery step (e.g. `explore`) when the affected files are genuinely unknown.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -237,6 +237,7 @@ import { createPlanReadMatcher } from "../plan-mode/plan-protection";
 import type { PlanModeState } from "../plan-mode/state";
 import advisorSystemPrompt from "../prompts/advisor/system.md" with { type: "text" };
 import goalTodoContextPrompt from "../prompts/goals/goal-todo-context.md" with { type: "text" };
+import parentIrcSteerTemplate from "../prompts/steering/parent-irc.md" with { type: "text" };
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
 import eagerTaskPrompt from "../prompts/system/eager-task.md" with { type: "text" };
 import eagerTodoPrompt from "../prompts/system/eager-todo.md" with { type: "text" };
@@ -13214,9 +13215,7 @@ export class AgentSession {
 			if (recipientParentId === msg.from) {
 				this.agent.steer({
 					role: "user",
-					content:
-						`Your current interruptible wait was interrupted because an IRC message arrived from your parent agent \`${msg.from}\`.\n\n` +
-						`Parent IRC message:\n\n${msg.body}`,
+					content: prompt.render(parentIrcSteerTemplate, { from: msg.from, message: msg.body }),
 					attribution: "agent",
 					timestamp: msg.ts,
 					steering: true,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -256,6 +256,7 @@ import toolCallLoopRedirectTemplate from "../prompts/system/tool-call-loop-redir
 import ttsrInterruptTemplate from "../prompts/system/ttsr-interrupt.md" with { type: "text" };
 import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" with { type: "text" };
 import unexpectedStopRetryTemplate from "../prompts/system/unexpected-stop-retry.md" with { type: "text" };
+import { AgentRegistry } from "../registry/agent-registry";
 import {
 	deobfuscateAssistantContent,
 	deobfuscateSessionContext,
@@ -1447,8 +1448,10 @@ export class AgentSession {
 	#activeEvalExecutions = new Set<Promise<unknown>>();
 	#evalExecutionDisposing = false;
 
-	// Incoming IRC messages received while a turn was streaming; drained as
-	// non-interrupting asides at the next step boundary (see the aside provider).
+	// Incoming IRC messages received while a turn was streaming. Parent IRCs
+	// enter the steering queue; peer IRCs enter the interrupt queue and drain as
+	// asides at the next boundary; passive IRC records stay in the aside queue.
+	#pendingIrcInterrupts: CustomMessage[] = [];
 	#pendingIrcAsides: CustomMessage[] = [];
 	// Agent identity (registry id) used for IRC routing and job ownership.
 	#agentId: string | undefined;
@@ -1673,16 +1676,17 @@ export class AgentSession {
 		this.#resumeStrandedIrcAsides();
 	}
 
-	/** IRC asides that arrive after the loop's final aside poll — or while an abort skipped that
-	 *  poll — land in #pendingIrcAsides with no loop left to drain them; the queued-message drain's
-	 *  gate (agent.hasQueuedMessages()) does not count them. Once idle, wake a turn so the agent
-	 *  responds to the peer. Skip only when a queued steer/follow-up will itself drive a resume turn
-	 *  whose aside poll already consumes these (no double-wake). */
+	/** IRC records that arrive after the loop's final aside poll — or while an abort skipped that
+	 *  poll — land in pending IRC queues with no loop left to drain them; the queued-message drain's
+	 *  gate (agent.hasQueuedMessages()) does not count peer IRC interrupts. Once idle, wake a turn so
+	 *  the agent responds to the peer. Skip only when a queued steer/follow-up will itself drive a
+	 *  resume turn whose aside poll already consumes these (no double-wake). */
 	#resumeStrandedIrcAsides(): void {
 		if (this.#isDisposed || this.isStreaming) return;
-		if (this.#pendingIrcAsides.length === 0) return;
+		if (this.#pendingIrcInterrupts.length === 0 && this.#pendingIrcAsides.length === 0) return;
 		if (this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages()) return;
-		const records = this.#pendingIrcAsides;
+		const records = [...this.#pendingIrcInterrupts, ...this.#pendingIrcAsides];
+		this.#pendingIrcInterrupts = [];
 		this.#pendingIrcAsides = [];
 		this.#wakeForIrc(records);
 	}
@@ -1892,10 +1896,13 @@ export class AgentSession {
 			},
 		});
 		// Background-job completions / late diagnostics are pulled into the run at
-		// each step boundary as non-interrupting asides (see Agent.getAsideMessages),
-		// so they reach the model between requests without waiting for a yield.
+		// each step boundary as non-interrupting asides. Peer IRCs share the aside
+		// injection boundary, but also expose a non-consuming interrupt peek so
+		// `job poll` / `irc wait` can return early before the boundary drains them.
+		this.agent.hasIrcInterrupts = () => this.#pendingIrcInterrupts.length > 0;
 		this.agent.setAsideMessageProvider(() => {
-			const pendingIrc = this.#pendingIrcAsides;
+			const pendingIrc = [...this.#pendingIrcInterrupts, ...this.#pendingIrcAsides];
+			this.#pendingIrcInterrupts = [];
 			this.#pendingIrcAsides = [];
 			const thunks: AsideMessage[] = pendingIrc.map(record => () => record);
 			thunks.push(...this.yieldQueue.drainLazy());
@@ -5097,6 +5104,7 @@ export class AgentSession {
 		this.#flushPendingIrcAsides();
 		this.yieldQueue.clear();
 		this.agent.setAsideMessageProvider(undefined);
+		this.agent.hasIrcInterrupts = undefined;
 		this.#stopAdvisorRuntime();
 		this.#evalExecutionDisposing = true;
 	}
@@ -13109,46 +13117,53 @@ export class AgentSession {
 	// =========================================================================
 
 	/**
-	 * Surfaces (and consumes) IRC incoming asides that have reached this running
-	 * session but have not yet been folded into the next model step.
+	 * Surfaces (and consumes) pending IRC incoming records before the next model
+	 * step can inject them automatically.
 	 *
 	 * The inbox tool injects the formatted body into the tool result, so the
-	 * model sees it once via the result. Leaving the record in
-	 * {@link #pendingIrcAsides} would let the aside provider deliver it a second
-	 * time at the next step boundary — including on `peek`, which is why peek
-	 * also drains here.
+	 * model sees it once via the result. Leaving the record in either pending
+	 * IRC queue would deliver it a second time at the next step boundary —
+	 * including on `peek`, which is why peek also drains here.
 	 */
 	drainPendingIrcInboxMessages(agentId: string): IrcMessage[] {
 		const messages: IrcMessage[] = [];
-		const remaining: CustomMessage[] = [];
-		for (const record of this.#pendingIrcAsides) {
-			if (record.customType !== "irc:incoming") {
-				remaining.push(record);
-				continue;
+		const remainingInterrupts: CustomMessage[] = [];
+		const remainingAsides: CustomMessage[] = [];
+		const queues = [
+			{ records: this.#pendingIrcInterrupts, remaining: remainingInterrupts },
+			{ records: this.#pendingIrcAsides, remaining: remainingAsides },
+		];
+		for (const queue of queues) {
+			for (const record of queue.records) {
+				if (record.customType !== "irc:incoming") {
+					queue.remaining.push(record);
+					continue;
+				}
+				const details = record.details;
+				if (!details || typeof details !== "object") {
+					queue.remaining.push(record);
+					continue;
+				}
+				const id = Reflect.get(details, "id");
+				const from = Reflect.get(details, "from");
+				const body = Reflect.get(details, "message");
+				const replyTo = Reflect.get(details, "replyTo");
+				if (typeof id !== "string" || typeof from !== "string" || typeof body !== "string") {
+					queue.remaining.push(record);
+					continue;
+				}
+				messages.push({
+					id,
+					from,
+					to: agentId,
+					body,
+					ts: record.timestamp,
+					...(typeof replyTo === "string" ? { replyTo } : {}),
+				});
 			}
-			const details = record.details;
-			if (!details || typeof details !== "object") {
-				remaining.push(record);
-				continue;
-			}
-			const id = Reflect.get(details, "id");
-			const from = Reflect.get(details, "from");
-			const body = Reflect.get(details, "message");
-			const replyTo = Reflect.get(details, "replyTo");
-			if (typeof id !== "string" || typeof from !== "string" || typeof body !== "string") {
-				remaining.push(record);
-				continue;
-			}
-			messages.push({
-				id,
-				from,
-				to: agentId,
-				body,
-				ts: record.timestamp,
-				...(typeof replyTo === "string" ? { replyTo } : {}),
-			});
 		}
-		this.#pendingIrcAsides = remaining;
+		this.#pendingIrcInterrupts = remainingInterrupts;
+		this.#pendingIrcAsides = remainingAsides;
 		return messages;
 	}
 
@@ -13186,6 +13201,7 @@ export class AgentSession {
 				message: msg.body,
 				replyTo: msg.replyTo ?? "",
 				autoReplied: autoReply,
+				interrupting: this.isStreaming,
 			}),
 			display: true,
 			details: { id: msg.id, from: msg.from, message: msg.body, ...(msg.replyTo ? { replyTo: msg.replyTo } : {}) },
@@ -13194,7 +13210,20 @@ export class AgentSession {
 		};
 		void this.#emitSessionEvent({ type: "irc_message", message: record });
 		if (this.isStreaming) {
-			this.#pendingIrcAsides.push(record);
+			const recipientParentId = AgentRegistry.global().get(msg.to)?.parentId;
+			if (recipientParentId === msg.from) {
+				this.agent.steer({
+					role: "user",
+					content:
+						`Your current interruptible wait was interrupted because an IRC message arrived from your parent agent \`${msg.from}\`.\n\n` +
+						`Parent IRC message:\n\n${msg.body}`,
+					attribution: "agent",
+					timestamp: msg.ts,
+					steering: true,
+				});
+			} else {
+				this.#pendingIrcInterrupts.push(record);
+			}
 			if (autoReply) void this.#runIrcAutoReply(msg);
 			return "injected";
 		}
@@ -13405,8 +13434,9 @@ export class AgentSession {
 	 * of the next prompt so the model still sees them.
 	 */
 	#flushPendingIrcAsides(): void {
-		if (this.#pendingIrcAsides.length === 0) return;
-		const records = this.#pendingIrcAsides;
+		if (this.#pendingIrcInterrupts.length === 0 && this.#pendingIrcAsides.length === 0) return;
+		const records = [...this.#pendingIrcInterrupts, ...this.#pendingIrcAsides];
+		this.#pendingIrcInterrupts = [];
 		this.#pendingIrcAsides = [];
 		for (const record of records) {
 			// emitExternalEvent on message_end appends to agent state and dispatches

--- a/packages/coding-agent/src/tools/irc.ts
+++ b/packages/coding-agent/src/tools/irc.ts
@@ -97,6 +97,7 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 	readonly description: string;
 	readonly parameters = ircSchema;
 	readonly strict = true;
+	readonly interruptible = true;
 
 	readonly examples: readonly ToolExample<typeof ircSchema.infer>[] = [
 		{

--- a/packages/coding-agent/src/tools/irc.ts
+++ b/packages/coding-agent/src/tools/irc.ts
@@ -318,16 +318,30 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 				lines.push("");
 				if (delivered.length > 0) {
 					const reply = await waiting;
-					if (reply.error) throw reply.error;
-					waited = reply.message;
-					if (waited) {
-						lines.push(`Reply from ${waited.from}:`);
-						lines.push(waited.body);
+					if (reply.error) {
+						// The send already succeeded; if the wait was interrupted by our
+						// caller signal (steering / IRC), preserve the delivery receipt so
+						// the agent loop keeps this tool as "sent" instead of marking it
+						// skipped, which would prompt a duplicate resend on the next turn.
+						if (signal?.aborted) {
+							lines.push(
+								`Send delivered but the reply wait was interrupted before ${to} answered. ` +
+									"Check `inbox` or `wait` again after handling the interrupt.",
+							);
+						} else {
+							throw reply.error;
+						}
 					} else {
-						lines.push(
-							`No reply from ${to} within ${formatDuration(timeoutMs)}. ` +
-								"They may answer later — check `inbox` or `wait` again.",
-						);
+						waited = reply.message;
+						if (waited) {
+							lines.push(`Reply from ${waited.from}:`);
+							lines.push(waited.body);
+						} else {
+							lines.push(
+								`No reply from ${to} within ${formatDuration(timeoutMs)}. ` +
+									"They may answer later — check `inbox` or `wait` again.",
+							);
+						}
 					}
 				} else {
 					awaitAbort?.abort(awaitCancelled);

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -366,7 +366,7 @@ describe("IRC", () => {
 			expect(IrcTool.createIf(session)).toBeNull();
 		});
 
-		it("createIf enables irc while the task tool is available", () => {
+		it("createIf enables interruptible irc while the task tool is available", () => {
 			const session: ToolSession = {
 				cwd: "/tmp",
 				hasUI: false,
@@ -378,7 +378,9 @@ describe("IRC", () => {
 			};
 			// Default task.maxRecursionDepth (2) at depth 0: task can spawn, and a
 			// finished subagent must stay reachable.
-			expect(IrcTool.createIf(session)).toBeInstanceOf(IrcTool);
+			const tool = IrcTool.createIf(session);
+			expect(tool).toBeInstanceOf(IrcTool);
+			expect(tool?.interruptible).toBe(true);
 		});
 
 		it("createIf enables irc for a subagent even at the recursion-depth cap", () => {
@@ -677,7 +679,7 @@ describe("IRC", () => {
 			expect(event.type).toBe("irc_message");
 		});
 
-		it("queues a non-interrupting aside when a turn is streaming", async () => {
+		it("queues peer IRC as an interrupt while a turn is streaming", async () => {
 			const { session } = createRealSession();
 			sessions.push(session);
 			const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
@@ -692,6 +694,32 @@ describe("IRC", () => {
 			});
 			expect(outcome).toBe("injected");
 			expect(promptSpy).not.toHaveBeenCalled();
+			expect(await session.agent.hasIrcInterrupts?.()).toBe(true);
+		});
+
+		it("queues parent IRC as steering while a subagent turn is streaming", async () => {
+			const { session } = createRealSession();
+			sessions.push(session);
+			const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+			Object.defineProperty(session, "isStreaming", { value: true, configurable: true });
+			registry.register({ id: "0-Child", displayName: "task", kind: "sub", parentId: "Main", session });
+
+			const outcome = await session.deliverIrcMessage({
+				id: "msg-parent",
+				from: "Main",
+				to: "0-Child",
+				body: "change approach",
+				ts: Date.now(),
+			});
+			const queued = session.agent.peekSteeringQueue();
+			expect(outcome).toBe("injected");
+			expect(promptSpy).not.toHaveBeenCalled();
+			expect(session.agent.hasIrcInterrupts?.()).toBe(false);
+			expect(queued).toHaveLength(1);
+			const parentSteer = queued[0];
+			expect(parentSteer?.role).toBe("user");
+			if (parentSteer?.role !== "user") throw new Error("expected queued parent IRC steer");
+			expect(parentSteer.content).toContain("change approach");
 		});
 
 		it("auto-replies via an ephemeral side turn when the sender awaits and async execution is disabled", async () => {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -558,6 +558,35 @@ describe("IRC", () => {
 			expect(text).toContain("No reply from 0-Sub");
 		});
 
+		it("op=send await=true preserves the delivery receipt when the wait is interrupted", async () => {
+			// Regression: the tool is marked interruptible so `job poll` / `irc wait` return
+			// early on incoming messages, but `send await:true` also runs the reply wait under
+			// the same signal. If the abort lands after the message was delivered, the tool
+			// must surface a successful receipt so the agent loop keeps the tool as "sent"
+			// and does not report it as skipped — which would prompt a duplicate resend.
+			const sub = makeFakeSession();
+			registry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: sub.session });
+
+			const tool = new IrcTool(makeToolSession(registry, "0-Main"));
+			const controller = new AbortController();
+			// Abort once delivery reaches the peer, mimicking a steering / IRC interrupt
+			// landing between the send resolving and the reply arriving.
+			sub.onDeliver(() => controller.abort(new Error("mock interrupt")));
+
+			const result = await tool.execute(
+				"call-1",
+				{ op: "send", to: "0-Sub", message: "ping", await: true, timeoutMs: 30_000 },
+				controller.signal,
+			);
+
+			expect(result.isError).toBeFalsy();
+			expect(sub.delivered.map(msg => msg.body)).toEqual(["ping"]);
+			expect(result.details?.receipts?.[0]?.outcome).toBe("injected");
+			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+			expect(text).toContain("Send delivered");
+			expect(text).toContain("interrupted");
+		});
+
 		it("op=send rejects await with to=all and self-sends", async () => {
 			const tool = new IrcTool(makeToolSession(registry, "0-Main"));
 			const broadcast = await tool.execute("call-1", { op: "send", to: "all", message: "x", await: true });


### PR DESCRIPTION
## Repro
A focused regression test queues an IRC-style interrupt while an `interruptible` wait tool is running. Before the fix, `bun test packages/agent/test/agent-loop.test.ts -t "drains queued IRC interrupts"` failed because the wait reached its timeout and `observedAbort` stayed `false`.

## Cause
`packages/agent/src/agent-loop.ts` only polled `hasSteeringMessages` while an interruptible tool was in flight, so IRC records queued by `AgentSession.deliverIrcMessage()` stayed in `#pendingIrcAsides` until the tool completed naturally. `packages/coding-agent/src/tools/irc.ts` also did not mark `irc wait` as interruptible, so filtered waits could not be cut short by queued steering or non-matching IRC.

## Fix
- Added `AgentLoopConfig.hasIrcInterrupts` and wired the agent loop to poll it alongside steering for interruptible tools.
- Routed parent IRC into the steering queue and peer IRC into an interrupting pending queue that still drains through the aside boundary and `irc inbox`.
- Marked `IrcTool` interruptible and updated `irc`, `job`, and `task` tool prompts to stop recommending cross-channel polling loops.
- Added regression coverage for core IRC interrupts, parent steering delivery, peer interrupt delivery, and `IrcTool.interruptible`.

## Verification
`bun test packages/agent/test/agent-loop.test.ts -t "drains queued IRC interrupts"` passed. `bun test packages/agent/test/agent-loop.test.ts packages/coding-agent/test/tools/irc.test.ts` passed with 89 tests. `bun check` passed. Fixes #4160