### PR TITLE
fix(tui): cap subagent live progress output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagent live progress leaking raw large tool output into the parent TUI by reusing notice stripping and viewport-sized output previews. ([#4162](https://github.com/can1357/oh-my-pi/issues/4162))
+
 ## [16.2.12] - 2026-07-01
 
 ### Breaking Changes

--- a/packages/coding-agent/src/task/render.test.ts
+++ b/packages/coding-agent/src/task/render.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Settings } from "../config/settings";
+import { getThemeByName, setThemeInstance, type Theme } from "../modes/theme/theme";
+import { renderResult } from "./render";
+import type { AgentProgress, TaskToolDetails } from "./types";
+
+const strip = (lines: readonly string[]): string =>
+	lines
+		.join("\n")
+		.replace(/\x1b\]8;[^\x1b\x07]*(?:\x07|\x1b\\)/g, "")
+		.replace(/\x1b\[[0-9;]*m/g, "");
+
+const originalRowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+
+function setViewportRows(rows: number): void {
+	Object.defineProperty(process.stdout, "rows", { configurable: true, value: rows });
+}
+
+function restoreViewportRows(): void {
+	if (originalRowsDescriptor) {
+		Object.defineProperty(process.stdout, "rows", originalRowsDescriptor);
+		return;
+	}
+	Reflect.deleteProperty(process.stdout, "rows");
+}
+
+function makeProgress(recentOutput: string[]): AgentProgress {
+	return {
+		index: 0,
+		id: "NoisySubagent",
+		agent: "task",
+		agentSource: "bundled",
+		status: "running",
+		task: "produce noisy output",
+		recentTools: [],
+		recentOutput,
+		toolCount: 1,
+		requests: 1,
+		tokens: 0,
+		cost: 0,
+		durationMs: 0,
+	};
+}
+
+function renderProgressText(progress: AgentProgress, expanded: boolean, uiTheme: Theme): string {
+	const details: TaskToolDetails = {
+		projectAgentsDir: null,
+		results: [],
+		totalDurationMs: 1,
+		progress: [progress],
+	};
+	const component = renderResult(
+		{ content: [{ type: "text", text: "Running 1 agent..." }], details },
+		{ expanded, isPartial: true },
+		uiTheme,
+	);
+	return strip(component.render(120));
+}
+
+describe("task live progress rendering", () => {
+	let uiTheme: Theme;
+
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("theme unavailable");
+		uiTheme = loaded;
+		setThemeInstance(uiTheme);
+	});
+
+	afterEach(() => {
+		restoreViewportRows();
+	});
+
+	it("caps subagent recent output with the viewport budget instead of a fixed six lines", () => {
+		setViewportRows(40);
+		const chronological = Array.from({ length: 8 }, (_, index) => `line ${index + 1}`);
+		const text = renderProgressText(makeProgress([...chronological].reverse()), true, uiTheme);
+
+		expect(text).toContain("line 1");
+		expect(text).toContain("line 8");
+		expect(text).not.toContain("more lines");
+	});
+
+	it("strips bash footer notices from expanded subagent recent output", () => {
+		setViewportRows(40);
+		const chronological = [
+			"line 1",
+			"line 2",
+			"line 3",
+			"line 4",
+			"line 5",
+			"line 6",
+			"Wall time: 0.03 seconds",
+			"[raw output: artifact://123]",
+		];
+		const progress = makeProgress([...chronological].reverse());
+
+		const expandedText = renderProgressText(progress, true, uiTheme);
+		expect(expandedText).toContain("line 1");
+		expect(expandedText).toContain("line 6");
+		expect(expandedText).not.toContain("Wall time:");
+		expect(expandedText).not.toContain("raw output:");
+
+		const collapsedText = renderProgressText(progress, false, uiTheme);
+		expect(collapsedText).not.toContain("line 1");
+		expect(collapsedText).not.toContain("raw output:");
+	});
+});

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -12,6 +12,7 @@ import { settings } from "../config/settings";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
+import { stripGeneratedOutputNotice, stripRawOutputArtifactNotice } from "../tools/output-meta";
 import {
 	formatBadge,
 	formatDuration,
@@ -19,6 +20,7 @@ import {
 	formatMoreItems,
 	formatStatusIcon,
 	previewLine,
+	previewWindowRows,
 	replaceTabs,
 	type ToolUIStatus,
 	truncateToWidth,
@@ -448,6 +450,41 @@ function renderJsonTreeLines(
 	renderRoot(value);
 
 	return { lines, truncated };
+}
+
+const BASH_WALL_TIME_NOTICE_RE = /^Wall time: \d+(?:\.\d+)? seconds$/u;
+const BASH_EXIT_CODE_NOTICE_RE = /^Command exited with code -?\d+$/u;
+
+function stripRecentOutputNoticeLine(text: string): string {
+	const trimmed = text.trimEnd();
+	const lineStart = trimmed.lastIndexOf("\n");
+	const candidateStart = lineStart === -1 ? 0 : lineStart + 1;
+	const line = trimmed.slice(candidateStart);
+	if (!BASH_WALL_TIME_NOTICE_RE.test(line) && !BASH_EXIT_CODE_NOTICE_RE.test(line)) return text;
+	return trimmed.slice(0, lineStart === -1 ? 0 : lineStart).trimEnd();
+}
+
+function sanitizeRecentOutput(output: string): string {
+	let text = output.trimEnd();
+	while (text) {
+		const withoutArtifactNotice = stripRawOutputArtifactNotice(text).text;
+		if (withoutArtifactNotice !== text) {
+			text = withoutArtifactNotice;
+			continue;
+		}
+		const withoutOutputNotice = stripGeneratedOutputNotice(text);
+		if (withoutOutputNotice !== text) {
+			text = withoutOutputNotice;
+			continue;
+		}
+		const withoutRuntimeNotice = stripRecentOutputNoticeLine(text);
+		if (withoutRuntimeNotice !== text) {
+			text = withoutRuntimeNotice;
+			continue;
+		}
+		break;
+	}
+	return text;
 }
 
 function renderOutputSection(
@@ -1016,8 +1053,8 @@ function renderAgentProgress(
 
 	// Expanded view: recent output and tools
 	if (expanded && progress.status === "running") {
-		const output = progress.recentOutput.join("\n");
-		lines.push(...renderOutputSection(output, continuePrefix, true, theme, 2, 6));
+		const output = sanitizeRecentOutput([...progress.recentOutput].reverse().join("\n"));
+		lines.push(...renderOutputSection(output, continuePrefix, expanded, theme, 2, previewWindowRows()));
 	}
 
 	return lines;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -29,7 +29,7 @@ import { checkBashInterception } from "./bash-interceptor";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
 import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
-import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
+import { formatStyledTruncationWarning, stripRawOutputArtifactNotice, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
 import { capPreviewLines, formatToolWorkingDirectory, previewWindowRows, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -292,34 +292,6 @@ function formatExitCodeNotice(exitCode: number): string {
 	return `Command exited with code ${exitCode}`;
 }
 
-const RAW_OUTPUT_ARTIFACT_PREFIX = "[raw output: artifact://";
-const RAW_OUTPUT_ARTIFACT_SUFFIX = "]";
-
-function stripRawOutputArtifactNotice(text: string): { text: string; artifactId?: string } {
-	const trimmed = text.trimEnd();
-	const lineStart = trimmed.lastIndexOf("\n");
-	const candidateStart = lineStart === -1 ? 0 : lineStart + 1;
-	if (
-		!trimmed.startsWith(RAW_OUTPUT_ARTIFACT_PREFIX, candidateStart) ||
-		!trimmed.endsWith(RAW_OUTPUT_ARTIFACT_SUFFIX)
-	) {
-		return { text };
-	}
-
-	const idStart = candidateStart + RAW_OUTPUT_ARTIFACT_PREFIX.length;
-	const idEnd = trimmed.length - RAW_OUTPUT_ARTIFACT_SUFFIX.length;
-	if (idStart === idEnd) return { text };
-	for (let i = idStart; i < idEnd; i++) {
-		const code = trimmed.charCodeAt(i);
-		if (code < 48 || code > 57) return { text };
-	}
-
-	const artifactId = trimmed.slice(idStart, idEnd);
-	return {
-		text: trimmed.slice(0, lineStart === -1 ? 0 : lineStart).trimEnd(),
-		artifactId,
-	};
-}
 
 /**
  * Strip the trailing occurrence of `notice` (plus a single surrounding newline

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -29,7 +29,12 @@ import { checkBashInterception } from "./bash-interceptor";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
 import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
-import { formatStyledTruncationWarning, stripRawOutputArtifactNotice, type OutputMeta, stripOutputNotice } from "./output-meta";
+import {
+	formatStyledTruncationWarning,
+	type OutputMeta,
+	stripOutputNotice,
+	stripRawOutputArtifactNotice,
+} from "./output-meta";
 import { resolveToCwd } from "./path-utils";
 import { capPreviewLines, formatToolWorkingDirectory, previewWindowRows, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
@@ -291,7 +296,6 @@ function formatWallTimeNotice(wallTimeMs: number): string {
 function formatExitCodeNotice(exitCode: number): string {
 	return `Command exited with code ${exitCode}`;
 }
-
 
 /**
  * Strip the trailing occurrence of `notice` (plus a single surrounding newline

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -385,6 +385,56 @@ export function formatFullOutputReference(artifactId: string): string {
 	return `Read artifact://${artifactId} for full output`;
 }
 
+const RAW_OUTPUT_ARTIFACT_PREFIX = "[raw output: artifact://";
+const RAW_OUTPUT_ARTIFACT_SUFFIX = "]";
+
+/** Remove the trailing bash raw-output artifact footer while preserving its artifact id. */
+export function stripRawOutputArtifactNotice(text: string): { text: string; artifactId?: string } {
+	const trimmed = text.trimEnd();
+	const lineStart = trimmed.lastIndexOf("\n");
+	const candidateStart = lineStart === -1 ? 0 : lineStart + 1;
+	if (
+		!trimmed.startsWith(RAW_OUTPUT_ARTIFACT_PREFIX, candidateStart) ||
+		!trimmed.endsWith(RAW_OUTPUT_ARTIFACT_SUFFIX)
+	) {
+		return { text };
+	}
+
+	const idStart = candidateStart + RAW_OUTPUT_ARTIFACT_PREFIX.length;
+	const idEnd = trimmed.length - RAW_OUTPUT_ARTIFACT_SUFFIX.length;
+	if (idStart === idEnd) return { text };
+	for (let i = idStart; i < idEnd; i++) {
+		const code = trimmed.charCodeAt(i);
+		if (code < 48 || code > 57) return { text };
+	}
+
+	const artifactId = trimmed.slice(idStart, idEnd);
+	return {
+		text: trimmed.slice(0, lineStart === -1 ? 0 : lineStart).trimEnd(),
+		artifactId,
+	};
+}
+
+function isGeneratedOutputNoticeLine(line: string): boolean {
+	if (!line.startsWith("[") || !line.endsWith("]")) return false;
+	const body = line.slice(1, -1);
+	return (
+		body.startsWith("Showing ") ||
+		/^\d+ matches limit reached\. Use limit=\d+ for more/u.test(body) ||
+		/^\d+ results limit reached\. Use limit=\d+ for more/u.test(body) ||
+		body.startsWith("Some lines truncated to ")
+	);
+}
+
+/** Remove a trailing generated output notice when metadata is unavailable. */
+export function stripGeneratedOutputNotice(text: string): string {
+	const trimmed = text.trimEnd();
+	const lineStart = trimmed.lastIndexOf("\n");
+	const candidateStart = lineStart === -1 ? 0 : lineStart + 1;
+	if (!isGeneratedOutputNoticeLine(trimmed.slice(candidateStart))) return text;
+	return trimmed.slice(0, lineStart === -1 ? 0 : lineStart).trimEnd();
+}
+
 export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
 	let notice: string;
 


### PR DESCRIPTION
## Repro
Expanded task live progress rendered subagent `recentOutput` newest-first with raw bash footer lines and a fixed six-line cap. Reproduced with `bun test packages/coding-agent/src/task/render.test.ts` before the fix: the renderer showed `[raw output: artifact://123]`, `Wall time: 0.03 seconds`, `… 2 more lines`, and omitted older output still inside the viewport budget.

## Cause
`packages/coding-agent/src/task/render.ts` rendered `AgentProgress.recentOutput` directly via `renderOutputSection(output, ..., true, ..., 6)`, so it bypassed shared output notice stripping, ignored `previewWindowRows()`, and joined the executor's newest-first tail in display order. `stripRawOutputArtifactNotice` was private to `packages/coding-agent/src/tools/bash.ts`, so the task renderer could not reuse it.

## Fix
- Moved raw-output artifact footer stripping into `packages/coding-agent/src/tools/output-meta.ts` and reused it from bash and task rendering.
- Sanitized subagent live `recentOutput` by restoring chronological order and stripping generated output notices, raw artifact footers, and bash runtime footer lines before rendering.
- Replaced the task live progress fixed six-line preview with `previewWindowRows()` and added renderer regression coverage.
- Added an Unreleased changelog entry for `packages/coding-agent`.

## Verification
`bun test packages/coding-agent/src/task/render.test.ts` passed. `bun run check:types` passed in `packages/coding-agent`. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #4162