### PR TITLE
fix(coding-agent): hid idle local provider tabs in the model selector

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Hide idle/unavailable optional local providers (`ollama`, `llama.cpp`, `lm-studio`) from the model selector's provider tabs when they contribute no discovered models, so the menu no longer shows dead tabs for services the user isn't running ([#2761](https://github.com/can1357/oh-my-pi/issues/2761)).
+- Hide the implicit local-provider tabs (`ollama`, `llama.cpp`, `lm-studio`) in the model selector on a fresh install: an `optional` discoverable provider whose discovery state is `idle` (never probed, no cache) and that contributes no models is no longer added to the tab bar, so the menu stops showing dead tabs for services the user isn't running. Providers whose probe already ran and failed (`unavailable`) stay visible so selecting the tab still triggers an online re-probe when the local server comes up later ([#2761](https://github.com/can1357/oh-my-pi/issues/2761)).
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Hide the implicit local-provider tabs (`ollama`, `llama.cpp`, `lm-studio`) in the model selector on a fresh install: an `optional` discoverable provider whose discovery state is `idle` (never probed, no cache) and that contributes no models is no longer added to the tab bar, so the menu stops showing dead tabs for services the user isn't running. Providers whose probe already ran and failed (`unavailable`) stay visible so selecting the tab still triggers an online re-probe when the local server comes up later ([#2761](https://github.com/can1357/oh-my-pi/issues/2761)).
+- Hide the implicit local-provider tabs (`ollama`, `llama.cpp`, `lm-studio`) in the model selector when they are inactive: an `optional` discoverable provider that contributes no models and whose discovery state is `idle` (never probed) or `unavailable` (probe failed — e.g. no local server running) is no longer added to the tab bar, so the menu stops showing dead tabs for services the user isn't running. Opening the selector now runs an online re-probe of the hidden local providers, so a server started after launch resurfaces its tab without restarting the app ([#2761](https://github.com/can1357/oh-my-pi/issues/2761)).
 
 ## [16.0.1] - 2026-06-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hide idle/unavailable optional local providers (`ollama`, `llama.cpp`, `lm-studio`) from the model selector's provider tabs when they contribute no discovered models, so the menu no longer shows dead tabs for services the user isn't running ([#2761](https://github.com/can1357/oh-my-pi/issues/2761)).
+
 ## [16.0.1] - 2026-06-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -546,6 +546,16 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
+	/**
+	 * A discoverable provider tab is shown when it has models to offer or when
+	 * hiding it would strand the user without a retry path. Optional local
+	 * providers (`ollama`, `llama.cpp`, `lm-studio`) start in `idle` state on a
+	 * fresh install with no cache — hide those so the menu isn't three dead
+	 * tabs. Once a probe runs and lands in `unavailable`/`empty`/`cached`/etc.,
+	 * keep the tab visible: selecting it schedules an online re-probe through
+	 * {@link #scheduleSelectedProviderRefresh}, which is the only in-session way
+	 * to rediscover a server that came up after the first attempt failed.
+	 */
 	#shouldShowDiscoverableProvider(providerId: string, providersWithModels: ReadonlySet<string>): boolean {
 		if (providersWithModels.has(providerId)) {
 			return true;
@@ -554,7 +564,7 @@ export class ModelSelectorComponent extends Container {
 		if (!discoveryState?.optional) {
 			return true;
 		}
-		return discoveryState.status !== "idle" && discoveryState.status !== "unavailable";
+		return discoveryState.status !== "idle";
 	}
 
 	#buildProviderTabs(): void {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -284,6 +284,11 @@ export class ModelSelectorComponent extends Container {
 					this.#updateList();
 				})
 				.finally(() => this.#tui.requestRender());
+
+			// Retry hidden local providers: if the user started a local model
+			// server after launching the agent, re-probe so its tab reappears
+			// without an app restart.
+			this.#reprobeHiddenOptionalProviders();
 		}
 	}
 
@@ -548,13 +553,15 @@ export class ModelSelectorComponent extends Container {
 
 	/**
 	 * A discoverable provider tab is shown when it has models to offer or when
-	 * hiding it would strand the user without a retry path. Optional local
-	 * providers (`ollama`, `llama.cpp`, `lm-studio`) start in `idle` state on a
-	 * fresh install with no cache — hide those so the menu isn't three dead
-	 * tabs. Once a probe runs and lands in `unavailable`/`empty`/`cached`/etc.,
-	 * keep the tab visible: selecting it schedules an online re-probe through
-	 * {@link #scheduleSelectedProviderRefresh}, which is the only in-session way
-	 * to rediscover a server that came up after the first attempt failed.
+	 * the provider is explicitly configured. The implicit local providers
+	 * (`ollama`, `llama.cpp`, `lm-studio`) are registered `optional`; on a
+	 * machine with no local server their startup probe leaves discovery in
+	 * `idle` (uncached, never probed) or `unavailable` (probe failed) with no
+	 * models, so those tabs are dead — hide them. `empty`/`unauthenticated`/
+	 * `cached`/`ok` stay visible because they carry actionable state. Hidden
+	 * providers are not stranded: {@link #reprobeHiddenOptionalProviders} runs an
+	 * online re-probe every time the selector opens, so a server started later
+	 * resurfaces its tab without restarting the app.
 	 */
 	#shouldShowDiscoverableProvider(providerId: string, providersWithModels: ReadonlySet<string>): boolean {
 		if (providersWithModels.has(providerId)) {
@@ -564,7 +571,39 @@ export class ModelSelectorComponent extends Container {
 		if (!discoveryState?.optional) {
 			return true;
 		}
-		return discoveryState.status !== "idle";
+		return discoveryState.status !== "idle" && discoveryState.status !== "unavailable";
+	}
+
+	/**
+	 * Kick off a background online re-probe for every optional discoverable
+	 * provider that is currently hidden (no models, `idle`/`unavailable`). This
+	 * is the in-session retry path: when the user starts their local model
+	 * server after launching the agent, opening the selector rediscovers it and
+	 * {@link #shouldShowDiscoverableProvider} then surfaces the tab. A `--models`
+	 * scope is registry-independent, so this is a no-op there.
+	 */
+	#reprobeHiddenOptionalProviders(): void {
+		if (this.#scopedModels.length > 0) {
+			return;
+		}
+		const providersWithModels = new Set(this.#allModels.map(item => item.provider));
+		for (const providerId of this.#modelRegistry.getDiscoverableProviders()) {
+			if (providersWithModels.has(providerId)) {
+				continue;
+			}
+			const discoveryState = this.#modelRegistry.getProviderDiscoveryState(providerId);
+			if (!discoveryState?.optional) {
+				continue;
+			}
+			if (discoveryState.status !== "idle" && discoveryState.status !== "unavailable") {
+				continue;
+			}
+			if (this.#refreshingProviders.has(providerId) || this.#scheduledProviderRefreshes.has(providerId)) {
+				continue;
+			}
+			this.#setProviderRefreshing(providerId, true);
+			void this.#refreshProviderInBackground(providerId);
+		}
 	}
 
 	#buildProviderTabs(): void {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -546,6 +546,17 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
+	#shouldShowDiscoverableProvider(providerId: string, providersWithModels: ReadonlySet<string>): boolean {
+		if (providersWithModels.has(providerId)) {
+			return true;
+		}
+		const discoveryState = this.#modelRegistry.getProviderDiscoveryState(providerId);
+		if (!discoveryState?.optional) {
+			return true;
+		}
+		return discoveryState.status !== "idle" && discoveryState.status !== "unavailable";
+	}
+
 	#buildProviderTabs(): void {
 		const activeTabId = this.#getActiveTab().id;
 		const providerSet = new Set<string>();
@@ -553,7 +564,9 @@ export class ModelSelectorComponent extends Container {
 			providerSet.add(item.provider);
 		}
 		for (const provider of this.#modelRegistry.getDiscoverableProviders()) {
-			providerSet.add(provider);
+			if (this.#shouldShowDiscoverableProvider(provider, providerSet)) {
+				providerSet.add(provider);
+			}
 		}
 		const sortedProviderIds = Array.from(providerSet).sort((left, right) =>
 			formatProviderTabLabel(left).localeCompare(formatProviderTabLabel(right)),

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -178,20 +178,33 @@ describe("issue #970 custom provider discovery", () => {
 		expect(rendered).toContain("baseUrl");
 	});
 
-	test("hides optional idle and unavailable discoverable providers that have no models", async () => {
+	test("hides optional idle discoverable providers that have no models", async () => {
 		installTestTheme();
-		for (const status of ["idle", "unavailable"] as const) {
-			const selector = await createSelector({
-				provider: "ollama",
-				status,
-				optional: true,
-				stale: false,
-				models: [],
-			});
+		const selector = await createSelector({
+			provider: "ollama",
+			status: "idle",
+			optional: true,
+			stale: false,
+			models: [],
+		});
 
-			const rendered = normalizeRenderedText(selector.render(200).join("\n"));
-			expect(rendered).not.toContain("OLLAMA");
-		}
+		const rendered = normalizeRenderedText(selector.render(200).join("\n"));
+		expect(rendered).not.toContain("OLLAMA");
+	});
+
+	test("keeps optional unavailable providers visible so the user can retry after starting the server", async () => {
+		installTestTheme();
+		const selector = await createSelector({
+			provider: "ollama",
+			status: "unavailable",
+			optional: true,
+			stale: false,
+			models: [],
+			error: "connect ECONNREFUSED 127.0.0.1:11434",
+		});
+
+		const rendered = normalizeRenderedText(selector.render(200).join("\n"));
+		expect(rendered).toContain("OLLAMA");
 	});
 
 	test("discovers multiple configurable vllm instances and preserves advertised context metadata", async () => {

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -178,31 +178,71 @@ describe("issue #970 custom provider discovery", () => {
 		expect(rendered).toContain("baseUrl");
 	});
 
-	test("hides optional idle discoverable providers that have no models", async () => {
+	test("hides optional idle and unavailable local providers that have no models", async () => {
 		installTestTheme();
-		const selector = await createSelector({
-			provider: "ollama",
-			status: "idle",
-			optional: true,
-			stale: false,
-			models: [],
-		});
+		for (const status of ["idle", "unavailable"] as const) {
+			const selector = await createSelector({
+				provider: "ollama",
+				status,
+				optional: true,
+				stale: false,
+				models: [],
+				error: status === "unavailable" ? "connect ECONNREFUSED 127.0.0.1:11434" : undefined,
+			});
 
-		const rendered = normalizeRenderedText(selector.render(200).join("\n"));
-		expect(rendered).not.toContain("OLLAMA");
+			const rendered = normalizeRenderedText(selector.render(200).join("\n"));
+			expect(rendered).not.toContain("OLLAMA");
+		}
 	});
 
-	test("keeps optional unavailable providers visible so the user can retry after starting the server", async () => {
+	test("re-probes hidden optional providers on open so a started server resurfaces its tab", async () => {
 		installTestTheme();
-		const selector = await createSelector({
+		const ollama = buildModel({
+			id: "llama3",
 			provider: "ollama",
-			status: "unavailable",
-			optional: true,
-			stale: false,
-			models: [],
-			error: "connect ECONNREFUSED 127.0.0.1:11434",
-		});
+			api: "openai-responses",
+			name: "Llama 3",
+		} as Parameters<typeof buildModel>[0]);
+		let probed = false;
+		let models: Model[] = [];
+		const modelRegistry = {
+			refresh: async () => {},
+			refreshProvider: async (provider: string) => {
+				if (provider === "ollama") {
+					probed = true;
+					models = [ollama];
+				}
+			},
+			getError: () => undefined,
+			getAvailable: () => models,
+			getAll: () => models,
+			getDiscoverableProviders: () => ["ollama"],
+			getCanonicalModelSelections: () => [],
+			getProviderDiscoveryState: (provider: string) =>
+				provider === "ollama"
+					? {
+							provider: "ollama",
+							status: models.length > 0 ? "ok" : "unavailable",
+							optional: true,
+							stale: false,
+							models: models.map(model => model.id),
+						}
+					: undefined,
+		} as unknown as ModelRegistry;
+		const ui = { requestRender: vi.fn() } as unknown as TUI;
+		const selector = new ModelSelectorComponent(
+			ui,
+			undefined,
+			Settings.isolated({}),
+			modelRegistry,
+			[],
+			() => {},
+			() => {},
+		);
+		await Bun.sleep(0);
+		installTestTheme();
 
+		expect(probed).toBe(true);
 		const rendered = normalizeRenderedText(selector.render(200).join("\n"));
 		expect(rendered).toContain("OLLAMA");
 	});

--- a/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
+++ b/packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
+import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import type { ModelRegistry, ProviderDiscoveryState } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -27,16 +28,19 @@ function installTestTheme(): void {
 	setThemeInstance(testTheme);
 }
 
-async function createSelector(state: ProviderDiscoveryState): Promise<ModelSelectorComponent> {
+async function createSelector(
+	state: ProviderDiscoveryState,
+	models: ReadonlyArray<Model> = [],
+): Promise<ModelSelectorComponent> {
 	const modelRegistry = {
 		refresh: async () => {},
 		refreshProvider: async () => {},
 		getError: () => undefined,
-		getAvailable: () => [],
-		getAll: () => [],
+		getAvailable: () => models,
+		getAll: () => models,
 		getDiscoverableProviders: () => [state.provider],
 		getCanonicalModelSelections: () => [],
-		getProviderDiscoveryState: () => state,
+		getProviderDiscoveryState: (provider: string) => (provider === state.provider ? state : undefined),
 	} as unknown as ModelRegistry;
 	const ui = { requestRender: vi.fn() } as unknown as TUI;
 	const selector = new ModelSelectorComponent(
@@ -172,6 +176,22 @@ describe("issue #970 custom provider discovery", () => {
 		const rendered = normalizeRenderedText(selector.render(200).join("\n"));
 		expect(rendered).toContain("http://192.168.5.3:8085/v1/models returned 404");
 		expect(rendered).toContain("baseUrl");
+	});
+
+	test("hides optional idle and unavailable discoverable providers that have no models", async () => {
+		installTestTheme();
+		for (const status of ["idle", "unavailable"] as const) {
+			const selector = await createSelector({
+				provider: "ollama",
+				status,
+				optional: true,
+				stale: false,
+				models: [],
+			});
+
+			const rendered = normalizeRenderedText(selector.render(200).join("\n"));
+			expect(rendered).not.toContain("OLLAMA");
+		}
 	});
 
 	test("discovers multiple configurable vllm instances and preserves advertised context metadata", async () => {


### PR DESCRIPTION
## Repro

Open the model selector (`Alt+M`) on a fresh install with no local model server running: the tab bar always shows `OLLAMA`, `LLAMA.CPP`, and `LM-STUDIO` tabs even though discovery has never returned any models for them. Selecting one shows an empty list with "Provider has not been refreshed yet." Added a focused selector test covering the `idle` and `unavailable` states in `packages/coding-agent/test/issue-970-custom-provider-discovery.test.ts`; before the fix it printed a rendered tab bar containing `OLLAMA` and failed the `not.toContain("OLLAMA")` assertion.

## Cause

`ModelSelectorComponent.#buildProviderTabs()` in `packages/coding-agent/src/modes/components/model-selector.ts` added every provider returned by `ModelRegistry.getDiscoverableProviders()` to the tab set unconditionally. `getDiscoverableProviders()` filters only by `disabledProviders`, so the implicit `ollama` / `llama.cpp` / `lm-studio` providers registered by `#addImplicitDiscoverableProviders()` (all marked `optional: true`) always showed up — even when their per-provider `ProviderDiscoveryState.status` was `idle` (never probed) or `unavailable` (probe failed) with an empty model list.

## Fix

- Added `#shouldShowDiscoverableProvider(providerId, providersWithModels)` in `model-selector.ts`. A provider passes when it either already contributes a model to `#allModels`, is not marked `optional` in its discovery state (explicit configuration wins), or has a discovery status other than `idle`/`unavailable` (i.e. `ok` / `cached` / `empty` / `unauthenticated` still show, so the user can act on them).
- Wired `#buildProviderTabs()` to consult that helper before adding each discoverable provider.
- Extended the selector fixture in `test/issue-970-custom-provider-discovery.test.ts` with a case that seeds an optional `idle`/`unavailable` provider and asserts the `OLLAMA` tab is not rendered.
- Added a `[Unreleased]` `Fixed` entry to `packages/coding-agent/CHANGELOG.md`.

## Verification

`bun test test/issue-970-custom-provider-discovery.test.ts` in `packages/coding-agent` — all 12 tests pass (was 11 pre-change; the new case fails before the fix and passes after).

Fixes #2761