### PR TITLE
fix(tui): animate live tool spinners

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed live tool preview spinners staying pinned to their first frame for `eval` and shell-style renderers. ([#4170](https://github.com/can1357/oh-my-pi/issues/4170))
+
 ## [16.2.13] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -557,7 +557,33 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		const isStreamingArgs = !this.#argsComplete && (isEditLikeToolName(this.#toolName) || this.#toolName === "write");
 		const isBackgroundAsyncRunning =
 			(this.#result?.details as { async?: { state?: string } } | undefined)?.async?.state === "running";
-		const isLivePartialTool = this.#isPartial && this.#toolName !== "todo" && !isBackgroundAsyncRunning;
+		const renderer = toolRenderers[this.#toolName] as
+			| {
+					animatedPendingPreview?: boolean | ((args: unknown) => boolean);
+					animatedPartialResult?: boolean | ((args: unknown) => boolean);
+			  }
+			| undefined;
+		const pendingAnimation = renderer?.animatedPendingPreview;
+		const partialAnimation = renderer?.animatedPartialResult;
+		const pendingCallConsumesSpinner =
+			this.#result === undefined &&
+			(renderer === undefined
+				? !this.#tool?.renderCall
+				: typeof pendingAnimation === "function"
+					? pendingAnimation(this.#args)
+					: pendingAnimation === true);
+		const partialResultConsumesSpinner =
+			this.#result !== undefined &&
+			(renderer === undefined
+				? !this.#tool?.renderResult
+				: typeof partialAnimation === "function"
+					? partialAnimation(this.#args)
+					: partialAnimation === true);
+		const isLivePartialTool =
+			this.#isPartial &&
+			this.#toolName !== "todo" &&
+			!isBackgroundAsyncRunning &&
+			(pendingCallConsumesSpinner || partialResultConsumesSpinner);
 		const needsSpinner = isStreamingArgs || isLivePartialTool || this.#displaceableByToolName === "job";
 		if (needsSpinner && !this.#spinnerInterval) {
 			const frameCount = theme.spinnerFrames.length;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -551,14 +551,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	 */
 	#updateSpinnerAnimation(): void {
 		// Live partial tool blocks stay repaintable until a terminal result seals
-		// them. Todo snapshots and detached background task progress are deliberate
+		// them. Todo snapshots and detached background tool progress are deliberate
 		// static exceptions because their rows can be superseded or committed to
 		// scrollback while later updates continue elsewhere.
 		const isStreamingArgs = !this.#argsComplete && (isEditLikeToolName(this.#toolName) || this.#toolName === "write");
 		const isBackgroundAsyncRunning =
 			(this.#result?.details as { async?: { state?: string } } | undefined)?.async?.state === "running";
-		const isBackgroundAsyncTask = this.#toolName === "task" && isBackgroundAsyncRunning;
-		const isLivePartialTool = this.#isPartial && this.#toolName !== "todo" && !isBackgroundAsyncTask;
+		const isLivePartialTool = this.#isPartial && this.#toolName !== "todo" && !isBackgroundAsyncRunning;
 		const needsSpinner = isStreamingArgs || isLivePartialTool || this.#displaceableByToolName === "job";
 		if (needsSpinner && !this.#spinnerInterval) {
 			const frameCount = theme.spinnerFrames.length;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -334,6 +334,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// so keep their horizontal padding even when the user enables tight layout.
 		this.setIgnoreTight(true);
 
+		this.#updateSpinnerAnimation();
 		this.#updateDisplay();
 		this.#schedulePreviewDiff();
 	}
@@ -546,21 +547,19 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	}
 
 	/**
-	 * Start or stop spinner animation for result states that visibly tick.
+	 * Start or stop spinner animation for live states that visibly tick.
 	 */
 	#updateSpinnerAnimation(): void {
-		// Spinner for: task tool with partial result, edit/write while args
-		// streaming, or a still-running job poll. Todo snapshots stay live for
-		// displacement but should remain visually static.
+		// Live partial tool blocks stay repaintable until a terminal result seals
+		// them. Todo snapshots and detached background task progress are deliberate
+		// static exceptions because their rows can be superseded or committed to
+		// scrollback while later updates continue elsewhere.
 		const isStreamingArgs = !this.#argsComplete && (isEditLikeToolName(this.#toolName) || this.#toolName === "write");
 		const isBackgroundAsyncRunning =
 			(this.#result?.details as { async?: { state?: string } } | undefined)?.async?.state === "running";
 		const isBackgroundAsyncTask = this.#toolName === "task" && isBackgroundAsyncRunning;
-		const isPartialTask = this.#isPartial && this.#toolName === "task" && !isBackgroundAsyncTask;
-		// Detached async task progress rows are static now; progress snapshots
-		// still call #maybeFreezeBackgroundTask before applying so rows settle
-		// once the block leaves the live region.
-		const needsSpinner = isStreamingArgs || isPartialTask || this.#displaceableByToolName === "job";
+		const isLivePartialTool = this.#isPartial && this.#toolName !== "todo" && !isBackgroundAsyncTask;
+		const needsSpinner = isStreamingArgs || isLivePartialTool || this.#displaceableByToolName === "job";
 		if (needsSpinner && !this.#spinnerInterval) {
 			const frameCount = theme.spinnerFrames.length;
 			const frame = sharedSpinnerFrame(frameCount);
@@ -1172,8 +1171,14 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	 */
 	#formatToolExecution(contentWidth: number): string {
 		const lines: string[] = [];
-		const icon = this.#isPartial ? "pending" : this.#result?.isError ? "error" : "done";
-		lines.push(renderStatusLine({ icon, title: this.#toolLabel }, theme));
+		const icon = this.#isPartial
+			? this.#spinnerFrame !== undefined
+				? "running"
+				: "pending"
+			: this.#result?.isError
+				? "error"
+				: "done";
+		lines.push(renderStatusLine({ icon, spinnerFrame: this.#spinnerFrame, title: this.#toolLabel }, theme));
 
 		const argsObject = this.#args && typeof this.#args === "object" ? (this.#args as Record<string, unknown>) : null;
 		if (!this.#expanded && argsObject && Object.keys(argsObject).length > 0) {

--- a/packages/coding-agent/src/task/renderer.ts
+++ b/packages/coding-agent/src/task/renderer.ts
@@ -11,4 +11,5 @@ export const taskToolRenderer = {
 	renderCall,
 	renderResult,
 	mergeCallAndResult: true,
+	animatedPartialResult: true,
 } as const;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1175,22 +1175,30 @@ export function createShellRenderer<TArgs>(config: ShellRendererConfig<TArgs>) {
 		renderCall(args: TArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 			const renderArgs = toBashRenderArgs(args, config);
 			const cmdLines = formatBashCommandLines(renderArgs, uiTheme);
-			const header =
-				config.showHeader === false
-					? undefined
-					: renderStatusLine({ icon: "pending", title: config.resolveTitle(args, options) }, uiTheme);
 			const outputBlock = new CachedOutputBlock();
 			return markFramedBlockComponent({
-				render: (width: number): readonly string[] =>
-					outputBlock.render(
+				render: (width: number): readonly string[] => {
+					const header =
+						config.showHeader === false
+							? undefined
+							: renderStatusLine(
+									{
+										icon: options.spinnerFrame !== undefined ? "running" : "pending",
+										spinnerFrame: options.spinnerFrame,
+										title: config.resolveTitle(args, options),
+									},
+									uiTheme,
+								);
+					return outputBlock.render(
 						{
 							header,
-							state: "pending",
+							state: options.spinnerFrame !== undefined ? "running" : "pending",
 							sections: [{ lines: capPreviewLines(cmdLines, uiTheme, { expanded: options.expanded }) }],
 							width,
 						},
 						uiTheme,
-					),
+					);
+				},
 				invalidate: () => {
 					outputBlock.invalidate();
 				},

--- a/packages/coding-agent/src/tools/browser/render.ts
+++ b/packages/coding-agent/src/tools/browser/render.ts
@@ -187,6 +187,8 @@ function extractTextOutput(content: Array<{ type: string; text?: string }> | und
 }
 
 export const browserToolRenderer = {
+	animatedPendingPreview: (args: unknown) => (args as BrowserRenderArgs).action === "run",
+	animatedPartialResult: (args: unknown) => (args as BrowserRenderArgs).action === "run",
 	renderCall(args: BrowserRenderArgs, options: RenderResultOptions, theme: Theme): Component {
 		const action = args.action;
 		if (action === "run") {

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -583,6 +583,7 @@ function summarizeDebugCall(args: DebugRenderArgs): string {
 }
 
 export const debugToolRenderer = {
+	animatedPartialResult: true,
 	renderCall(args: DebugRenderArgs, _options: RenderResultOptions, theme: Theme): Component {
 		const text = renderStatusLine({ icon: "pending", title: "Debug", description: summarizeDebugCall(args) }, theme);
 		return new Text(text, 0, 0);

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -489,6 +489,8 @@ function formatCellOutputLines(
 }
 
 export const evalToolRenderer = {
+	animatedPendingPreview: true,
+	animatedPartialResult: true,
 	renderCall(args: EvalRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const cells = getRenderCells(args);
 

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -502,7 +502,7 @@ export const evalToolRenderer = {
 
 		return markFramedBlockComponent({
 			render: (width: number): readonly string[] => {
-				const key = `${options.expanded ? 1 : 0}|${previewWindowRows()}|${cells.map(c => `${c.language}:${c.title ?? ""}:${c.code.length}`).join("|")}`;
+				const key = `${options.expanded ? 1 : 0}|${options.spinnerFrame ?? "-"}|${previewWindowRows()}|${cells.map(c => `${c.language}:${c.title ?? ""}:${c.code.length}`).join("|")}`;
 				if (cached && cached.key === key && cached.width === width) {
 					return cached.result;
 				}
@@ -518,7 +518,8 @@ export const evalToolRenderer = {
 							index: i,
 							total: cells.length,
 							title: cell.title,
-							status: "pending",
+							status: options.spinnerFrame !== undefined ? "running" : "pending",
+							spinnerFrame: options.spinnerFrame,
 							width,
 							// Viewport-sized tail window following the newest streamed code
 							// line; renderResult keeps the same cap so the cell never snaps

--- a/packages/coding-agent/src/tools/gh-renderer.ts
+++ b/packages/coding-agent/src/tools/gh-renderer.ts
@@ -416,6 +416,7 @@ function renderWatchCall(args: GithubToolRenderArgs, options: RenderResultOption
 }
 
 export const githubToolRenderer = {
+	animatedPendingPreview: true,
 	renderCall(args: GithubToolRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const op = typeof args.op === "string" && args.op.trim().length > 0 ? args.op.trim() : undefined;
 		if (op === "run_watch") {

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -63,6 +63,17 @@ export type ToolRenderer = {
 	 * with the final render and may commit like any settled stream.
 	 */
 	provisionalPartialResult?: boolean;
+	/**
+	 * Whether the renderer's pending-call path visibly consumes
+	 * `options.spinnerFrame`. Used to avoid scheduling repaint ticks for live
+	 * partial calls whose bytes cannot change between spinner frames.
+	 */
+	animatedPendingPreview?: boolean | ((args: unknown) => boolean);
+	/**
+	 * Whether the renderer's partial-result path visibly consumes
+	 * `options.spinnerFrame`.
+	 */
+	animatedPartialResult?: boolean | ((args: unknown) => boolean);
 };
 
 export const toolRenderers: Record<string, ToolRenderer> = {

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -261,6 +261,7 @@ function formatSshCommandLines(command: string, uiTheme: Theme): string[] {
 }
 
 export const sshToolRenderer = {
+	animatedPendingPreview: true,
 	renderCall(args: SshRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const host = args.host || "…";
 		const command = args.command ?? "";

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -261,23 +261,32 @@ function formatSshCommandLines(command: string, uiTheme: Theme): string[] {
 }
 
 export const sshToolRenderer = {
-	renderCall(args: SshRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
+	renderCall(args: SshRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const host = args.host || "…";
 		const command = args.command ?? "";
-		const header = renderStatusLine({ icon: "pending", title: "SSH", description: `[${host}]` }, uiTheme);
 		const cmdLines = formatSshCommandLines(command, uiTheme);
 		const outputBlock = new CachedOutputBlock();
 		return markFramedBlockComponent({
-			render: (width: number): readonly string[] =>
-				outputBlock.render(
+			render: (width: number): readonly string[] => {
+				const header = renderStatusLine(
+					{
+						icon: options.spinnerFrame !== undefined ? "running" : "pending",
+						spinnerFrame: options.spinnerFrame,
+						title: "SSH",
+						description: `[${host}]`,
+					},
+					uiTheme,
+				);
+				return outputBlock.render(
 					{
 						header,
-						state: "pending",
-						sections: [{ lines: capPreviewLines(cmdLines, uiTheme, { expanded: _options.expanded }) }],
+						state: options.spinnerFrame !== undefined ? "running" : "pending",
+						sections: [{ lines: capPreviewLines(cmdLines, uiTheme, { expanded: options.expanded }) }],
 						width,
 					},
 					uiTheme,
-				),
+				);
+			},
 			invalidate: () => {
 				outputBlock.invalidate();
 			},

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -70,6 +70,27 @@ describe("ToolExecutionComponent live preview spinners", () => {
 		}
 	});
 
+	it("does not tick headerless bash pending previews", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"bash",
+			{ command: "sleep 600" },
+			{},
+			undefined,
+			{ requestRender } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			requestRender.mockClear();
+			vi.advanceTimersByTime(500);
+			expect(requestRender).not.toHaveBeenCalled();
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
 	it("does not tick detached async bash result snapshots", () => {
 		vi.useFakeTimers();
 		const requestRender = vi.fn();

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -69,4 +69,35 @@ describe("ToolExecutionComponent live preview spinners", () => {
 			component.stopAnimation();
 		}
 	});
+
+	it("does not tick detached async bash result snapshots", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"bash",
+			{ command: "sleep 600", async: true },
+			{},
+			undefined,
+			{ requestRender } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			component.updateResult(
+				{
+					content: [{ type: "text", text: "started background job" }],
+					details: {
+						command: "sleep 600",
+						async: { state: "running", jobId: "job-1", type: "bash" },
+					},
+				},
+				true,
+			);
+			requestRender.mockClear();
+			vi.advanceTimersByTime(500);
+			expect(requestRender).not.toHaveBeenCalled();
+		} finally {
+			component.stopAnimation();
+		}
+	});
 });

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+// Contract under test: live tool previews that render a pending/running status
+// must keep the spinner glyph tied to the shared tool-frame ticker. This covers
+// both the shared ToolExecutionComponent interval and renderer-local caches that
+// would otherwise keep serving the first pending frame.
+describe("ToolExecutionComponent live preview spinners", () => {
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("animates the eval pending cell while the call is live", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"eval",
+			{ language: "py", code: "import time\ntime.sleep(10)" },
+			{},
+			undefined,
+			{ requestRender } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			const firstFrame = stripVTControlCharacters(component.render(80).join("\n"));
+			vi.advanceTimersByTime(120);
+			const secondFrame = stripVTControlCharacters(component.render(80).join("\n"));
+
+			expect(requestRender).toHaveBeenCalled();
+			expect(firstFrame).toContain("time.sleep(10)");
+			expect(secondFrame).toContain("time.sleep(10)");
+			expect(secondFrame).not.toBe(firstFrame);
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
+	it("animates a shell pending header while the call is live", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"ssh",
+			{ host: "example.test", command: "sleep 10" },
+			{},
+			undefined,
+			{ requestRender } as unknown as TUI,
+			process.cwd(),
+		);
+
+		try {
+			const firstFrame = stripVTControlCharacters(component.render(80).join("\n"));
+			vi.advanceTimersByTime(120);
+			const secondFrame = stripVTControlCharacters(component.render(80).join("\n"));
+
+			expect(requestRender).toHaveBeenCalled();
+			expect(firstFrame).toContain("sleep 10");
+			expect(secondFrame).toContain("sleep 10");
+			expect(secondFrame).not.toBe(firstFrame);
+		} finally {
+			component.stopAnimation();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A focused regression test renders live `eval` and shell-style tool previews, advances the spinner timer, and expects both a repaint request and changed rendered bytes. Before the fix, `bun test packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts` failed because `requestRender` stayed at 0 calls for both live previews.

## Cause
`packages/coding-agent/src/modes/components/tool-execution.ts` only started the spinner interval for edit/write arg streaming, partial task snapshots, and job poll displacement, so live partial tools such as `eval` never advanced `spinnerFrame`. `packages/coding-agent/src/tools/eval-render.ts` also rendered pending cells with a static `pending` status and omitted `spinnerFrame` from the call-preview cache key; shell-style renderers built their pending headers outside the render closure, so cached frames could not tick.

## Fix
- Start the shared spinner interval for live partial tool blocks while keeping `todo` snapshots and detached background task progress static.
- Forward `spinnerFrame` through `eval` pending cells and include it in the preview cache key.
- Render shell-style pending headers from the live render closure so cached output blocks see the current spinner frame.
- Add regression coverage for live `eval` and shell preview spinner animation.
- Add a coding-agent changelog entry for #4170.

## Verification
- `bun test packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts packages/coding-agent/test/modes/components/tool-execution-background-task.test.ts packages/coding-agent/test/streaming-preview-height.test.ts` passed: 10 tests, 59 assertions.
- `bun run check:types` passed in `packages/coding-agent`.
- `gh_push_branch` pre-publish gate passed and pushed `9e7814a6389a`. Fixes #4170