### PR TITLE
fix(coding-agent/task): keep .git/index clean when stash pop conflicts after task merge

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `mergeTaskBranches` and `applyNestedPatches` leaving stage 1/2/3 unmerged entries in `.git/index` when the post-merge stash pop conflicted with the cherry-picked HEAD. The corrupted index survived indefinitely and every subsequent overlay-isolated task inherited it through the lower layer, causing `captureRepoDeltaPatch` to emit `diff --cc` output that `git apply` rejects with "No valid patches in input". The stash restore now runs behind a 3-way preflight check (`git apply --3way --check`) and a `reset --hard HEAD` cleanup fallback; the stash entry is preserved for manual recovery on conflict, and the merged commits still land on HEAD. ([#4175](https://github.com/can1357/oh-my-pi/issues/4175))
+
 ## [16.2.13] - 2026-07-01
 
 ### Fixed

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -305,16 +305,13 @@ export async function applyNestedPatches(
 			}
 		} finally {
 			if (stashed) {
-				try {
-					await git.stash.pop(nestedDir, { index: true });
-				} catch (popErr) {
-					const message = popErr instanceof Error ? popErr.message : String(popErr);
+				const restored = await git.stash.tryPop(nestedDir, { index: true });
+				if (!restored) {
 					logger.warn("Pre-existing nested-repo dirty state could not be auto-restored", {
 						nestedDir,
-						error: message,
 					});
 					warnings.push(
-						`Pre-existing dirty state in nested repo \`${relativePath}\` could not be auto-restored after the agent commit; stash entry preserved (${message}).`,
+						`Pre-existing dirty state in nested repo \`${relativePath}\` could not be auto-restored after the agent commit; stash entry preserved.`,
 					);
 				}
 			}
@@ -755,13 +752,15 @@ export async function mergeTaskBranches(
 			}
 		} finally {
 			if (didStash) {
-				try {
-					await git.stash.pop(repoRoot, { index: true });
-				} catch {
-					// Stash-pop conflicts mean the replayed changes clash with the user's
-					// uncommitted edits. The cherry-picked commits are already on HEAD, so
-					// the merged branches DID land — report them as merged and surface the
-					// stash conflict separately instead of claiming they are unmerged.
+				const restored = await git.stash.tryPop(repoRoot, { index: true });
+				if (!restored) {
+					// Stash pop would leave stage 1/2/3 unmerged entries in `.git/index`
+					// that overlay-isolated subsequent tasks inherit through the lower
+					// layer, corrupting every downstream `captureRepoDeltaPatch`. `tryPop`
+					// short-circuits the pop when the WIP would conflict with the
+					// cherry-picked HEAD (and reset-cleans up if a rarer conflict slips
+					// past). The merged branches DID land — surface a stash-restore
+					// warning without claiming the merge failed.
 					logger.warn("Failed to restore stashed changes after task merge; stash entry preserved");
 					const stashConflict =
 						"stash pop: cherry-picked changes conflict with uncommitted edits. The merged commits are on HEAD; run `git stash pop` and resolve manually.";

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1635,7 +1635,7 @@ export const stash = {
 			}
 			if (restoredUntracked.length > 0) {
 				try {
-					await clean(cwd, { includeIgnored: true, paths: restoredUntracked });
+					await clean(cwd, { includeIgnored: true, literalPathspecs: true, paths: restoredUntracked });
 				} catch {
 					/* best-effort cleanup — do not mask the primary conflict */
 				}
@@ -1709,9 +1709,18 @@ export async function reset(
 
 export async function clean(
 	cwd: string,
-	options: { ignoredOnly?: boolean; includeIgnored?: boolean; paths?: readonly string[]; signal?: AbortSignal } = {},
+	options: {
+		ignoredOnly?: boolean;
+		includeIgnored?: boolean;
+		literalPathspecs?: boolean;
+		paths?: readonly string[];
+		signal?: AbortSignal;
+	} = {},
 ): Promise<void> {
-	const args = ["clean", options.ignoredOnly ? "-fdX" : options.includeIgnored ? "-fdx" : "-fd"];
+	const args = [options.literalPathspecs ? "--literal-pathspecs" : undefined, "clean"].filter(
+		(arg): arg is string => arg !== undefined,
+	);
+	args.push(options.ignoredOnly ? "-fdX" : options.includeIgnored ? "-fdx" : "-fd");
 	if (options.paths?.length) args.push("--", ...options.paths);
 	await runEffect(cwd, args, { signal: options.signal });
 }

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1635,7 +1635,7 @@ export const stash = {
 			}
 			if (restoredUntracked.length > 0) {
 				try {
-					await clean(cwd, { paths: restoredUntracked });
+					await clean(cwd, { includeIgnored: true, paths: restoredUntracked });
 				} catch {
 					/* best-effort cleanup — do not mask the primary conflict */
 				}
@@ -1709,9 +1709,9 @@ export async function reset(
 
 export async function clean(
 	cwd: string,
-	options: { ignoredOnly?: boolean; paths?: readonly string[]; signal?: AbortSignal } = {},
+	options: { ignoredOnly?: boolean; includeIgnored?: boolean; paths?: readonly string[]; signal?: AbortSignal } = {},
 ): Promise<void> {
-	const args = ["clean", options.ignoredOnly ? "-fdX" : "-fd"];
+	const args = ["clean", options.ignoredOnly ? "-fdX" : options.includeIgnored ? "-fdx" : "-fd"];
 	if (options.paths?.length) args.push("--", ...options.paths);
 	await runEffect(cwd, args, { signal: options.signal });
 }

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1588,11 +1588,16 @@ export const stash = {
 	async showPatch(cwd: string): Promise<string> {
 		return (await tryText(cwd, ["stash", "show", "-p", "--binary", "stash@{0}"], { readOnly: true })) ?? "";
 	},
+	/** Return untracked paths stored in the top stash entry. */
+	async untrackedFiles(cwd: string): Promise<string[]> {
+		const output = await tryText(cwd, ["ls-tree", "-r", "-z", "--name-only", "stash@{0}^3"], { readOnly: true });
+		return output?.split("\0").filter(Boolean) ?? [];
+	},
 	/**
 	 * Attempt to restore the top stash entry. On success returns `true` and
 	 * git drops the stash entry. On conflict returns `false`, leaves the stash
-	 * entry preserved for manual resolution, and guarantees the repo's index
-	 * has no unmerged entries when this call returns.
+	 * entry preserved for manual resolution, and guarantees the failed restore
+	 * leaves no unmerged index entries or partially-restored untracked files.
 	 *
 	 * The historical raw `pop` catches the failure in a `finally` block and
 	 * only logs — it leaves `.git/index` with stage 1/2/3 unmerged entries
@@ -1610,6 +1615,7 @@ export const stash = {
 		if (workingPatch.trim() && !(await patch.canApplyText(cwd, workingPatch, { threeWay: true }))) {
 			return false;
 		}
+		const restoredUntracked = await stash.untrackedFiles(cwd);
 		try {
 			await stash.pop(cwd, options);
 			return true;
@@ -1617,13 +1623,22 @@ export const stash = {
 			// Preflight can still miss mode-only or delete/modify conflicts. If
 			// the pop left unmerged entries, wipe them: HEAD holds the merged
 			// state so `reset --hard HEAD` restores a clean index and working
-			// tree without losing the cherry-picked commits. The stash entry
-			// is preserved by git on failed pop, so the user's WIP is still
-			// recoverable via `git stash pop`.
+			// tree without losing the cherry-picked commits. A failed pop can
+			// still restore unrelated untracked files before exiting while
+			// preserving the stash entry, so clean only the untracked paths
+			// recorded in that stash. The user's WIP remains recoverable via
+			// `git stash pop`.
 			try {
 				await reset(cwd, { hard: true });
 			} catch {
 				/* best-effort cleanup — do not mask the primary conflict */
+			}
+			if (restoredUntracked.length > 0) {
+				try {
+					await clean(cwd, { paths: restoredUntracked });
+				} catch {
+					/* best-effort cleanup — do not mask the primary conflict */
+				}
 			}
 			return false;
 		}

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1580,6 +1580,54 @@ export const stash = {
 		if (options?.index) args.push("--index");
 		await runEffect(cwd, args);
 	},
+	/**
+	 * Return the working-tree patch that `stash@{0}` would apply, in a form
+	 * that `git apply --check` can consume. Empty string when no stash entry
+	 * exists or the stash contains no diffable working-tree changes.
+	 */
+	async showPatch(cwd: string): Promise<string> {
+		return (await tryText(cwd, ["stash", "show", "-p", "--binary", "stash@{0}"], { readOnly: true })) ?? "";
+	},
+	/**
+	 * Attempt to restore the top stash entry. On success returns `true` and
+	 * git drops the stash entry. On conflict returns `false`, leaves the stash
+	 * entry preserved for manual resolution, and guarantees the repo's index
+	 * has no unmerged entries when this call returns.
+	 *
+	 * The historical raw `pop` catches the failure in a `finally` block and
+	 * only logs — it leaves `.git/index` with stage 1/2/3 unmerged entries
+	 * that survive indefinitely, corrupting every subsequent overlay-isolated
+	 * task that reads through this repo's `.git/`. See issue #4175.
+	 */
+	async tryPop(cwd: string, options?: { index?: boolean }): Promise<boolean> {
+		// Preflight: `git stash pop` internally does a 3-way merge, so a plain
+		// `git apply --check` is too strict — it rejects hunks whose context
+		// drifted from HEAD even when 3-way merge would resolve them cleanly.
+		// Match pop's semantics with `--3way --check`, which succeeds iff the
+		// patch either applies directly or merges without conflict against
+		// the patch's `index abc..def` base blobs.
+		const workingPatch = await stash.showPatch(cwd);
+		if (workingPatch.trim() && !(await patch.canApplyText(cwd, workingPatch, { threeWay: true }))) {
+			return false;
+		}
+		try {
+			await stash.pop(cwd, options);
+			return true;
+		} catch {
+			// Preflight can still miss mode-only or delete/modify conflicts. If
+			// the pop left unmerged entries, wipe them: HEAD holds the merged
+			// state so `reset --hard HEAD` restores a clean index and working
+			// tree without losing the cherry-picked commits. The stash entry
+			// is preserved by git on failed pop, so the user's WIP is still
+			// recoverable via `git stash pop`.
+			try {
+				await reset(cwd, { hard: true });
+			} catch {
+				/* best-effort cleanup — do not mask the primary conflict */
+			}
+			return false;
+		}
+	},
 };
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -281,32 +281,52 @@ describe("worktree isolation helpers", () => {
 				expect(delta.rootPatch).toContain("+downstream edit");
 			});
 
-			it("removes untracked files partially restored before failed stash pop exits", async () => {
+			it("removes ignored untracked files partially restored before failed stash pop exits", async () => {
 				// Force the fallback branch: preflight would normally refuse this
 				// pop before Git can restore anything, but mode/delete edge cases can
 				// still pass preflight and fail during the actual stash pop. Git can
 				// restore unrelated untracked files before reporting the tracked
-				// conflict, so the fallback must clean those restored paths too.
-				vi.spyOn(git.patch, "canApplyText").mockResolvedValue(true);
-				await fs.writeFile(path.join(repo, "merged.txt"), "user wip\n");
-				await fs.writeFile(path.join(repo, "note.txt"), "untracked wip\n");
-
-				const result = await mergeTaskBranches(repo, [{ branchName: TASK_BRANCH, taskId: "task-1" }]);
-
-				const [status, unmerged, stashList, headContent] = await Promise.all([
-					runGit(repo, ["status", "--porcelain=v1"]),
-					runGit(repo, ["ls-files", "--unmerged"]),
-					runGit(repo, ["stash", "list"]),
-					fs.readFile(path.join(repo, "merged.txt"), "utf8"),
+				// conflict. If the task branch also adds an ignore rule for that
+				// restored path, default `git clean -fd -- <path>` leaves it behind;
+				// the fallback must clean restored ignored paths too.
+				const ignoredBranch = "task/ignored-restored-untracked";
+				await runGit(repo, ["checkout", "-q", "-b", ignoredBranch]);
+				await Promise.all([
+					fs.writeFile(path.join(repo, "merged.txt"), "task branch change\n"),
+					fs.writeFile(path.join(repo, ".gitignore"), "note.txt\n"),
 				]);
+				await runGit(repo, ["add", ".gitignore", "merged.txt"]);
+				await runGit(repo, ["commit", "-q", "-m", "task-change-ignored-note"]);
+				await runGit(repo, ["checkout", "-q", BASE_BRANCH]);
+				try {
+					vi.spyOn(git.patch, "canApplyText").mockResolvedValue(true);
+					await fs.writeFile(path.join(repo, "merged.txt"), "user wip\n");
+					await fs.writeFile(path.join(repo, "note.txt"), "untracked wip\n");
 
-				expect(result.merged).toEqual([TASK_BRANCH]);
-				expect(result.failed).toEqual([]);
-				expect(result.stashConflict).toBeDefined();
-				expect(unmerged).toBe("");
-				expect(status).toBe("");
-				expect(headContent).toBe("task branch change\n");
-				expect(stashList).toContain("omp-task-merge");
+					const result = await mergeTaskBranches(repo, [{ branchName: ignoredBranch, taskId: "task-1" }]);
+
+					const [status, ignoredStatus, unmerged, stashList, headContent, noteExists] = await Promise.all([
+						runGit(repo, ["status", "--porcelain=v1"]),
+						runGit(repo, ["status", "--porcelain=v1", "--ignored=matching"]),
+						runGit(repo, ["ls-files", "--unmerged"]),
+						runGit(repo, ["stash", "list"]),
+						fs.readFile(path.join(repo, "merged.txt"), "utf8"),
+						Bun.file(path.join(repo, "note.txt")).exists(),
+					]);
+
+					expect(result.merged).toEqual([ignoredBranch]);
+					expect(result.failed).toEqual([]);
+					expect(result.stashConflict).toBeDefined();
+					expect(unmerged).toBe("");
+					expect(status).toBe("");
+					expect(ignoredStatus).toBe("");
+					expect(noteExists).toBe(false);
+					expect(headContent).toBe("task branch change\n");
+					expect(stashList).toContain("omp-task-merge");
+				} finally {
+					await cleanupTaskBranches(repo, [ignoredBranch]);
+					await fs.rm(path.join(repo, "note.txt"), { force: true });
+				}
 			});
 
 			it("commits isolated edits when parent dirt only changes nearby context", async () => {

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -281,19 +281,24 @@ describe("worktree isolation helpers", () => {
 				expect(delta.rootPatch).toContain("+downstream edit");
 			});
 
-			it("removes ignored untracked files partially restored before failed stash pop exits", async () => {
+			it("cleans restored stash files with literal pathspecs", async () => {
 				// Force the fallback branch: preflight would normally refuse this
 				// pop before Git can restore anything, but mode/delete edge cases can
 				// still pass preflight and fail during the actual stash pop. Git can
 				// restore unrelated untracked files before reporting the tracked
 				// conflict. If the task branch also adds an ignore rule for that
-				// restored path, default `git clean -fd -- <path>` leaves it behind;
-				// the fallback must clean restored ignored paths too.
+				// restored path, the fallback must clean the restored ignored path
+				// without interpreting stash-derived filenames as pathspec magic.
+				const magicName = ":(glob)*";
+				const buildLog = path.join(repo, "build.log");
 				const ignoredBranch = "task/ignored-restored-untracked";
+				await fs.writeFile(path.join(repo, ".gitignore"), "*.log\n");
+				await runGit(repo, ["add", ".gitignore"]);
+				await runGit(repo, ["commit", "-q", "-m", "ignore-build-artifacts"]);
 				await runGit(repo, ["checkout", "-q", "-b", ignoredBranch]);
 				await Promise.all([
 					fs.writeFile(path.join(repo, "merged.txt"), "task branch change\n"),
-					fs.writeFile(path.join(repo, ".gitignore"), "note.txt\n"),
+					fs.writeFile(path.join(repo, ".gitignore"), `*.log\n${magicName}\n`),
 				]);
 				await runGit(repo, ["add", ".gitignore", "merged.txt"]);
 				await runGit(repo, ["commit", "-q", "-m", "task-change-ignored-note"]);
@@ -301,17 +306,18 @@ describe("worktree isolation helpers", () => {
 				try {
 					vi.spyOn(git.patch, "canApplyText").mockResolvedValue(true);
 					await fs.writeFile(path.join(repo, "merged.txt"), "user wip\n");
-					await fs.writeFile(path.join(repo, "note.txt"), "untracked wip\n");
+					await fs.writeFile(path.join(repo, magicName), "untracked wip\n");
+					await fs.writeFile(buildLog, "ignored build artifact\n");
 
 					const result = await mergeTaskBranches(repo, [{ branchName: ignoredBranch, taskId: "task-1" }]);
 
-					const [status, ignoredStatus, unmerged, stashList, headContent, noteExists] = await Promise.all([
+					const [status, unmerged, stashList, headContent, magicExists, buildLogExists] = await Promise.all([
 						runGit(repo, ["status", "--porcelain=v1"]),
-						runGit(repo, ["status", "--porcelain=v1", "--ignored=matching"]),
 						runGit(repo, ["ls-files", "--unmerged"]),
 						runGit(repo, ["stash", "list"]),
 						fs.readFile(path.join(repo, "merged.txt"), "utf8"),
-						Bun.file(path.join(repo, "note.txt")).exists(),
+						Bun.file(path.join(repo, magicName)).exists(),
+						Bun.file(buildLog).exists(),
 					]);
 
 					expect(result.merged).toEqual([ignoredBranch]);
@@ -319,13 +325,16 @@ describe("worktree isolation helpers", () => {
 					expect(result.stashConflict).toBeDefined();
 					expect(unmerged).toBe("");
 					expect(status).toBe("");
-					expect(ignoredStatus).toBe("");
-					expect(noteExists).toBe(false);
+					expect(magicExists).toBe(false);
+					expect(buildLogExists).toBe(true);
 					expect(headContent).toBe("task branch change\n");
 					expect(stashList).toContain("omp-task-merge");
 				} finally {
 					await cleanupTaskBranches(repo, [ignoredBranch]);
-					await fs.rm(path.join(repo, "note.txt"), { force: true });
+					await Promise.all([
+						fs.rm(path.join(repo, magicName), { force: true }),
+						fs.rm(buildLog, { force: true }),
+					]);
 				}
 			});
 

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -15,6 +15,7 @@ import {
 	parseIsolationMode,
 } from "@oh-my-pi/pi-coding-agent/task/worktree";
 import * as jj from "@oh-my-pi/pi-coding-agent/utils/jj";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
 import * as natives from "@oh-my-pi/pi-natives";
 import { removeWithRetries, setWorktreesDir } from "@oh-my-pi/pi-utils";
 
@@ -278,6 +279,34 @@ describe("worktree isolation helpers", () => {
 				const delta = await captureDeltaPatch(repo, baseline);
 				expect(delta.rootPatch).not.toContain("diff --cc");
 				expect(delta.rootPatch).toContain("+downstream edit");
+			});
+
+			it("removes untracked files partially restored before failed stash pop exits", async () => {
+				// Force the fallback branch: preflight would normally refuse this
+				// pop before Git can restore anything, but mode/delete edge cases can
+				// still pass preflight and fail during the actual stash pop. Git can
+				// restore unrelated untracked files before reporting the tracked
+				// conflict, so the fallback must clean those restored paths too.
+				vi.spyOn(git.patch, "canApplyText").mockResolvedValue(true);
+				await fs.writeFile(path.join(repo, "merged.txt"), "user wip\n");
+				await fs.writeFile(path.join(repo, "note.txt"), "untracked wip\n");
+
+				const result = await mergeTaskBranches(repo, [{ branchName: TASK_BRANCH, taskId: "task-1" }]);
+
+				const [status, unmerged, stashList, headContent] = await Promise.all([
+					runGit(repo, ["status", "--porcelain=v1"]),
+					runGit(repo, ["ls-files", "--unmerged"]),
+					runGit(repo, ["stash", "list"]),
+					fs.readFile(path.join(repo, "merged.txt"), "utf8"),
+				]);
+
+				expect(result.merged).toEqual([TASK_BRANCH]);
+				expect(result.failed).toEqual([]);
+				expect(result.stashConflict).toBeDefined();
+				expect(unmerged).toBe("");
+				expect(status).toBe("");
+				expect(headContent).toBe("task branch change\n");
+				expect(stashList).toContain("omp-task-merge");
 			});
 
 			it("commits isolated edits when parent dirt only changes nearby context", async () => {

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -235,6 +235,51 @@ describe("worktree isolation helpers", () => {
 				expect(stashList).toBe("");
 			});
 
+			// Regression for #4175: a stash-pop conflict used to leave stage 1/2/3
+			// unmerged entries in `.git/index` (no `MERGE_HEAD`, no way to abort).
+			// The corrupted index survived indefinitely and every subsequent
+			// overlay-isolated task read it through the lower layer, so
+			// `captureRepoDeltaPatch` produced `diff --cc` output that `git apply`
+			// rejects. mergeTaskBranches MUST leave the index clean regardless of
+			// whether the stash could be popped.
+			it("keeps the index clean when stash pop would conflict with a cherry-picked change", async () => {
+				// User's WIP touches the same file the task branch modifies, so a
+				// naive stash push → cherry-pick → stash pop conflicts on pop.
+				await fs.writeFile(path.join(repo, "merged.txt"), "user wip\n");
+
+				const result = await mergeTaskBranches(repo, [{ branchName: TASK_BRANCH, taskId: "task-1" }]);
+
+				const [status, unmerged, stashList, headContent] = await Promise.all([
+					runGit(repo, ["status", "--porcelain=v1"]),
+					runGit(repo, ["ls-files", "--unmerged"]),
+					runGit(repo, ["stash", "list"]),
+					fs.readFile(path.join(repo, "merged.txt"), "utf8"),
+				]);
+
+				// Cherry-pick landed on HEAD; only the WIP restore was declined.
+				expect(result.merged).toEqual([TASK_BRANCH]);
+				expect(result.failed).toEqual([]);
+				expect(result.stashConflict).toBeDefined();
+				// The invariant that was previously broken: no unmerged entries.
+				expect(unmerged).toBe("");
+				// Working tree matches the merged HEAD, and the WIP is preserved
+				// as a stash entry for the user to reconcile manually.
+				expect(status).toBe("");
+				expect(headContent).toBe("task branch change\n");
+				expect(stashList).toContain("omp-task-merge");
+
+				// Downstream contract: with a clean index, captureDeltaPatch
+				// produces a valid unified diff (not `diff --cc`) that a
+				// subsequent isolated task's `git apply --cached` accepts.
+				// Editing a tracked file keeps the shared fixture clean —
+				// `reset --hard` on the next test restores it.
+				const baseline = await captureBaseline(repo);
+				await fs.writeFile(path.join(repo, "staged.txt"), "downstream edit\n");
+				const delta = await captureDeltaPatch(repo, baseline);
+				expect(delta.rootPatch).not.toContain("diff --cc");
+				expect(delta.rootPatch).toContain("+downstream edit");
+			});
+
 			it("commits isolated edits when parent dirt only changes nearby context", async () => {
 				const fixtureName = "EXP_DIRTY_TEST.txt";
 				const fixturePath = path.join(repo, fixtureName);


### PR DESCRIPTION
## Repro

Two isolated tasks in parallel where any task edits a file that also has uncommitted WIP; sequential merge takes the shape `stash push → cherry-pick task → stash pop --index`. The pop conflicts on the WIP-vs-cherry-picked overlap, leaves stage 1/2/3 unmerged entries in `.git/index` with no `MERGE_HEAD`, and neither `git merge --abort` nor `git cherry-pick --abort` can recover. Every subsequent overlay-isolated task inherits the corrupted index through the lower layer; `captureRepoDeltaPatch` then emits `diff --cc` (combined-merge headers) that `git apply` rejects with `No valid patches in input`, so every downstream isolated task fails with `Branch merge failed before a task branch could be created`.

Minimal shell repro:

```bash
git stash push -m omp-task-merge   # WIP on file.txt
git cherry-pick task1              # task1 also edits file.txt
git stash pop --index              # exit 1: unmerged entries, no MERGE_HEAD
git ls-files --unmerged | wc -l    # 3
git diff --binary | git apply --check  # exit 128: "No valid patches in input"
```

## Cause

`packages/coding-agent/src/task/worktree.ts` has two identical broken patterns:

- `mergeTaskBranches` at `worktree.ts:756-774` pops the stash inside a `finally`, catches the throw, and only calls `logger.warn`. No index cleanup, no reset.
- `applyNestedPatches` at `worktree.ts:306-321` does the same for nested repos.

Both leave `.git/index` with unmerged entries that survive the function return.

## Fix

- Added `git.stash.showPatch(cwd)` — returns the working-tree patch that `stash@{0}` would apply, in a form `git apply --check` can consume.
- Added `git.stash.tryPop(cwd, { index? })` at `packages/coding-agent/src/utils/git.ts:1602`. Contract: on success returns `true` (git drops the stash); on refused restore returns `false`, preserves the stash entry, and guarantees a clean index/working tree.
  - Preflight uses `git apply --3way --check` (not plain `--check`, which is too strict against context that drifted after cherry-pick — `stash pop` internally does a 3-way merge, so we match its semantics).
  - Preflight failure short-circuits; the index and working tree are untouched.
  - If preflight passes but pop still fails (mode-only or delete/modify conflicts the preflight can miss), a `reset --hard HEAD` fallback wipes the unmerged entries. HEAD holds the cherry-picked commits, so nothing task-side is lost; the stash entry is preserved by git on failed pop.
- `mergeTaskBranches` (`worktree.ts:753-774`) and `applyNestedPatches` (`worktree.ts:306-318`) now call `tryPop` and derive their `stashConflict` / warning from its boolean return. Same user-facing message; the invariant that the index is clean on return is now enforced.

## Verification

- `bun test test/task/worktree.test.ts` in `packages/coding-agent/`: **24 pass / 0 fail** (91 expect calls). Includes a new regression: with dirty WIP on `merged.txt` and cherry-picking a branch that also touches `merged.txt`, `mergeTaskBranches` returns `merged: [TASK_BRANCH]` with a `stashConflict` set, `git ls-files --unmerged` is empty, `git status --porcelain` is clean, the stash entry is preserved, and a follow-up `captureDeltaPatch` produces a valid unified diff (no `diff --cc`).
- `bun test` on eight adjacent `test/*git*` files: **68 pass / 5 skip / 0 fail**.
- Skipped the pre-publish gate: `bun check` currently fails on the branch because `packages/coding-agent/src/export/html/index.ts:14` imports a generated file `./tool-views.generated.js` that is not committed and this workspace has no build step wired in. Verified by stashing my diff and re-running `bun test test/task/autoload-skills.test.ts`: same "Cannot find module './tool-views.generated.js'" failure, so the breakage is pre-existing on the working branch and unrelated to this fix.

Fixes #4175