### PR TITLE
fix(tui): support command-v image paste in ghostty

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Added retry-path diagnostics for assistant-tail removal and scheduled continuations after transient provider errors.
 - Fixed CJK history rendering issues across repeated compactions.
 - Fixed user-invoked skills failing to identify themselves or resolve relative paths across various execution paths.
+- Fixed macOS `Command+V` image pastes in Ghostty by binding the Kitty `super+v` key event to the image-paste action alongside `Ctrl+V`. ([#4178](https://github.com/can1357/oh-my-pi/issues/4178))
 
 ## [16.2.13] - 2026-07-01
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -65,7 +65,9 @@ declare module "@oh-my-pi/pi-tui" {
  * Resolve default image-paste shortcuts for the current terminal platform.
  */
 export function getDefaultPasteImageKeys(platform: NodeJS.Platform = process.platform): KeyId[] {
-	return platform === "win32" ? ["ctrl+v", "alt+v"] : ["ctrl+v"];
+	if (platform === "win32") return ["ctrl+v", "alt+v"];
+	if (platform === "darwin") return ["ctrl+v", "super+v"];
+	return ["ctrl+v"];
 }
 
 /**

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import { $ } from "bun";
+import { setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";
 import { getEditorTheme, initTheme } from "../theme/theme";
+import { getDefaultPasteImageKeys } from "../../config/keybindings";
 import {
 	CustomEditor,
 	extractBracketedImagePastePaths,
@@ -124,6 +126,25 @@ describe("CustomEditor bracketed path paste", () => {
 		expect(imagePathCalls).toBe(0);
 	});
 });
+describe("CustomEditor configured paste image keys", () => {
+	it("routes Ghostty Cmd+V kitty key events through the macOS image-paste default", () => {
+		const { editor } = makeEditor();
+		const onPasteImage = vi.fn();
+		editor.onPasteImage = onPasteImage;
+		editor.setActionKeys("app.clipboard.pasteImage", getDefaultPasteImageKeys("darwin"));
+		setKittyProtocolActive(true);
+
+		try {
+			editor.handleInput("\x1b[118;9u");
+		} finally {
+			setKittyProtocolActive(false);
+		}
+
+		expect(onPasteImage).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+	});
+});
+
 
 describe("extractImagePathFromText (issue #3506)", () => {
 	it("returns the path when the text is a single image file path", () => {

--- a/packages/coding-agent/src/modes/components/custom-editor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
-import { $ } from "bun";
 import { setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";
-import { getEditorTheme, initTheme } from "../theme/theme";
+import { $ } from "bun";
 import { getDefaultPasteImageKeys } from "../../config/keybindings";
+import { getEditorTheme, initTheme } from "../theme/theme";
 import {
 	CustomEditor,
 	extractBracketedImagePastePaths,
@@ -144,7 +144,6 @@ describe("CustomEditor configured paste image keys", () => {
 		expect(editor.getText()).toBe("");
 	});
 });
-
 
 describe("extractImagePathFromText (issue #3506)", () => {
 	it("returns the path when the text is a single image file path", () => {

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -38,8 +38,8 @@ describe("getDefaultPasteImageKeys", () => {
 		expect(getDefaultPasteImageKeys("win32")).toEqual(["ctrl+v", "alt+v"]);
 	});
 
-	it("uses Ctrl+V as the image-paste shortcut on non-Windows platforms", () => {
+	it("adds the macOS Command key event to Ctrl+V for image paste", () => {
 		expect(getDefaultPasteImageKeys("linux")).toEqual(["ctrl+v"]);
-		expect(getDefaultPasteImageKeys("darwin")).toEqual(["ctrl+v"]);
+		expect(getDefaultPasteImageKeys("darwin")).toEqual(["ctrl+v", "super+v"]);
 	});
 });


### PR DESCRIPTION
## Repro
Copy an image on macOS, focus Ghostty, and press `Command+V`; Ghostty can deliver the paste shortcut as the Kitty `super+v` key event instead of an empty bracketed paste. The focused regression command was `bun test packages/coding-agent/src/modes/components/custom-editor.test.ts -t Ghostty`, which failed before the fix because the image-paste handler was called 0 times.

## Cause
`packages/coding-agent/src/config/keybindings.ts#getDefaultPasteImageKeys` returned only `ctrl+v` for `darwin`, so `InputController` configured `CustomEditor` without the `super+v` key that Ghostty emits for `Command+V` under Kitty keyboard protocol. `packages/coding-agent/src/modes/components/custom-editor.ts` already parses that event, but it did not match `app.clipboard.pasteImage`.

## Fix
- Added `super+v` to the macOS default image-paste bindings while keeping `ctrl+v`.
- Added a `CustomEditor` regression test that feeds Ghostty’s Kitty `Command+V` sequence and verifies it routes to `onPasteImage`.
- Updated the keybinding default test and changelog entry for #4178.

## Verification
`bun test packages/coding-agent/src/modes/components/custom-editor.test.ts packages/coding-agent/test/keybindings-display.test.ts` passed with 31 tests and 52 assertions. Pre-publish gate passed during branch push. Fixes #4178