### PR TITLE
fix(ai): handle Anthropic Fable fallback responses

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Anthropic fallback content block support in agent-loop assistant-message snapshotting so the block round-trips through session persistence and IRC event fanout unchanged. ([#4177](https://github.com/can1357/oh-my-pi/issues/4177))
+
 ### Fixed
 
 - Fixed an issue where skipped tool results in queued messages were incorrectly treated as completed work, preventing necessary retries.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -156,6 +156,8 @@ function snapshotAssistantContentBlock(block: AssistantContentBlock): AssistantC
 			return { ...block };
 		case "redactedThinking":
 			return { ...block };
+		case "fallback":
+			return { ...block, from: { ...block.from }, to: { ...block.to } };
 		case "toolCall":
 			return { ...block, arguments: structuredCloneJSON(block.arguments) };
 	}

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in support for Anthropic's server-side fallback beta chain (`server-side-fallback-2026-06-01`) on the `anthropic-messages` provider. When `AnthropicOptions.fallbacks` is set, the request carries the `fallbacks` field and the beta header, and the response parser honors mid-stream `fallback` content blocks and `usage.iterations` — promoting the served model on a `fallback_message` iteration and pricing per-attempt at the served model's cache-read rate for the fallback attempt's input tokens (per the [fallback billing cookbook §4](https://platform.claude.com/cookbook/fable-5-fallback-billing-guide)). Non-Anthropic providers and non-opted-in requests are fully inert. `transformMessages` centrally drops persisted `fallback` blocks on cross-provider hops and non-official Anthropic replays so a stored fallback turn never wedges downstream converters. `SimpleStreamOptions.fallbacks` and `AssistantMessage.content` now include the fallback surface. ([#4177](https://github.com/can1357/oh-my-pi/issues/4177))
+
 ### Changed
 
 - Clarified CoreWeave Serverless Inference login instructions to persist `COREWEAVE_PROJECT` in the user's shell startup file.

--- a/packages/ai/src/providers/anthropic-wire.ts
+++ b/packages/ai/src/providers/anthropic-wire.ts
@@ -76,13 +76,26 @@ export type RedactedThinkingBlockParam = {
 	data: string;
 };
 
+/**
+ * Server-side fallback beta boundary marker (server-side-fallback-2026-06-01).
+ * Emitted by the API mid-stream when a classifier block on the requested
+ * model is retried on a fallback model. Only the official Anthropic
+ * endpoint accepts this block on replay — cross-provider hops MUST strip it.
+ */
+export type FallbackBlockParam = {
+	type: "fallback";
+	from: { model: string };
+	to: { model: string };
+};
+
 export type ContentBlockParam =
 	| TextBlockParam
 	| ImageBlockParam
 	| ToolUseBlockParam
 	| ToolResultBlockParam
 	| ThinkingBlockParam
-	| RedactedThinkingBlockParam;
+	| RedactedThinkingBlockParam
+	| FallbackBlockParam;
 
 /**
  * A single conversation turn.
@@ -151,6 +164,19 @@ export type OutputConfig = {
 	task_budget?: TokenTaskBudget | null;
 };
 
+/**
+ * Per-attempt override entry in `MessageCreateParams.fallbacks`
+ * (server-side-fallback-2026-06-01 beta). Every field except `model`
+ * mirrors a top-level control the beta allows re-specifying per attempt.
+ */
+export type FallbackParam = {
+	model: string;
+	max_tokens?: number;
+	thinking?: ThinkingConfigParam;
+	output_config?: OutputConfig;
+	speed?: "fast";
+};
+
 /** Claude Code context-management beta payload. */
 export type ContextManagement = {
 	edits: Array<{ type: "clear_thinking_20251015"; keep: "all" }>;
@@ -175,6 +201,12 @@ export type MessageCreateParams = {
 	speed?: "fast";
 	/** Claude Code context-management beta. */
 	context_management?: ContextManagement;
+	/**
+	 * Server-side fallback beta chain — up to three fallback models the API
+	 * retries when a classifier blocks the primary. Required companion beta
+	 * header: `server-side-fallback-2026-06-01`.
+	 */
+	fallbacks?: FallbackParam[];
 };
 
 export type MessageCreateParamsStreaming = MessageCreateParams & { stream: true };
@@ -201,6 +233,21 @@ export type ServerToolUsage = {
 	web_fetch_requests?: number | null;
 };
 
+/**
+ * Per-attempt token accounting inside a multi-run turn
+ * (server-side-fallback-2026-06-01). Populated whenever a fallback chain
+ * ran, including sticky-served turns with no `fallback` content block.
+ * A `fallback_message` entry is the definitive "served by fallback" signal.
+ */
+export type UsageIteration = {
+	type?: "message" | "fallback_message" | string;
+	model?: string | null;
+	input_tokens?: number | null;
+	output_tokens?: number | null;
+	cache_read_input_tokens?: number | null;
+	cache_creation_input_tokens?: number | null;
+};
+
 export type Usage = {
 	input_tokens?: number | null;
 	output_tokens?: number | null;
@@ -208,6 +255,7 @@ export type Usage = {
 	cache_creation_input_tokens?: number | null;
 	cache_creation?: CacheCreation | null;
 	server_tool_use?: ServerToolUsage | null;
+	iterations?: UsageIteration[] | null;
 };
 
 /** The `message` envelope carried by `message_start`. */
@@ -229,7 +277,8 @@ export type ResponseContentBlock =
 	| { type: "text"; text: string }
 	| { type: "thinking"; thinking: string; signature?: string }
 	| { type: "redacted_thinking"; data: string }
-	| { type: "tool_use"; id: string; name: string; input?: Record<string, unknown> | null };
+	| { type: "tool_use"; id: string; name: string; input?: Record<string, unknown> | null }
+	| { type: "fallback"; from: { model: string }; to: { model: string } };
 
 export type ContentBlockDelta =
 	| { type: "text_delta"; text: string }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -4,7 +4,7 @@ import { scheduler } from "node:timers/promises";
 import * as tls from "node:tls";
 import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic";
 import { mapEffortToAnthropicAdaptiveEffort } from "@oh-my-pi/pi-catalog/model-thinking";
-import { calculateCost } from "@oh-my-pi/pi-catalog/models";
+import { calculateCost, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { isAnthropicOAuthToken } from "@oh-my-pi/pi-catalog/utils";
 import { parseGitHubCopilotApiKey } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import {
@@ -20,6 +20,7 @@ import { renderDemotedThinking } from "../dialect/demotion";
 import * as AIError from "../error";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
 import type {
+	AnthropicFallbackContent,
 	Api,
 	AssistantMessage,
 	CacheRetention,
@@ -73,7 +74,9 @@ import {
 import type {
 	ToolInputSchema as AnthropicToolInputSchema,
 	Tool as AnthropicWireTool,
+	Usage as AnthropicWireUsage,
 	ContentBlockParam,
+	FallbackParam,
 	MessageCreateParamsStreaming,
 	MessageParam,
 	RawMessageStreamEvent,
@@ -150,6 +153,7 @@ const redactThinkingBeta = "redact-thinking-2026-02-12";
 const fastModeBeta = "fast-mode-2026-02-01";
 const taskBudgetBeta = "task-budgets-2026-03-13";
 const effortBeta = "effort-2025-11-24";
+const serverSideFallbackBeta = "server-side-fallback-2026-06-01";
 
 function buildClaudeCodeBetas(
 	agentRequest: boolean,
@@ -1060,6 +1064,15 @@ export interface AnthropicOptions extends StreamOptions {
 	 * including SDK clients such as `AnthropicVertex`.
 	 */
 	client?: AnthropicMessagesClientLike;
+	/**
+	 * Server-side fallback beta chain (`server-side-fallback-2026-06-01`).
+	 * When set, `fallbacks` is forwarded on the request body and the beta
+	 * header is auto-attached; the response parser then honors mid-stream
+	 * `fallback` content blocks and `usage.iterations` for served-model
+	 * promotion and per-attempt pricing. Opt-in ONLY — leaving this
+	 * undefined preserves the pre-fallback behavior on every code path.
+	 */
+	fallbacks?: FallbackParam[];
 }
 
 export type AnthropicClientOptionsArgs = {
@@ -1529,6 +1542,108 @@ export function applyAnthropicUsageExtras(usage: Usage, source: AnthropicUsageLi
 	}
 }
 
+function parseAnthropicFallbackWireBlock(value: unknown): AnthropicFallbackContent | undefined {
+	if (!isRecord(value) || value.type !== "fallback") return undefined;
+	const from = isRecord(value.from) && typeof value.from.model === "string" ? value.from.model : undefined;
+	const to = isRecord(value.to) && typeof value.to.model === "string" ? value.to.model : undefined;
+	if (!from?.trim() || !to?.trim()) return undefined;
+	return { type: "fallback", from: { model: from }, to: { model: to } };
+}
+
+/**
+ * The definitive "served by fallback" signal per Anthropic's fallback
+ * billing cookbook (§4): a `fallback_message` iteration in `usage.iterations`.
+ * Any other iteration type is per-attempt bookkeeping for the requested model
+ * (including its dated snapshot alias) and MUST NOT retag the assistant turn.
+ */
+function fallbackServedModelFromUsage(source: AnthropicWireUsage): string | undefined {
+	const iterations = source.iterations ?? [];
+	for (let index = iterations.length - 1; index >= 0; index -= 1) {
+		const iteration = iterations[index];
+		if (iteration?.type === "fallback_message" && iteration.model?.trim()) return iteration.model;
+	}
+	return undefined;
+}
+
+/**
+ * Price a fallback turn per the fallback billing cookbook §4:
+ *   • A pre-served attempt with zero output/cache-creation is not billed
+ *     (waived classifier block); its iteration is skipped.
+ *   • Mid-stream refusals bill their attempting model's input+output at
+ *     that model's normal rates.
+ *   • The `fallback_message` attempt's input tokens are rebilled at the
+ *     served model's cache-read rate (fallback credit — 10% of base input).
+ *
+ * Top-level `usage.input/output/cacheRead/cacheWrite` stay Anthropic's raw
+ * served-attempt counts; `usage.cost` reflects the per-iteration attributed
+ * total. Non-fallback turns skip this path entirely and use the requested
+ * model at the normal `calculateCost` call.
+ */
+/**
+ * Resolve a served/iteration model id to its bundled catalog entry when
+ * possible so the per-iteration cost uses the served model's pricing
+ * (e.g. Opus 4.8 rates for a Fable→Opus fallback). Falls back to
+ * `requestModel` when the id is empty, matches the request, or the
+ * catalog has no entry under it — the caller keeps the requested-model
+ * pricing as the safe default and logs at the source.
+ */
+function resolveIterationModel(
+	requestModel: Model<"anthropic-messages">,
+	iterationModelId: string | null | undefined,
+): Model<Api> {
+	const id = iterationModelId?.trim();
+	if (!id || id === requestModel.id) return requestModel;
+	// Bundled catalog lookup: only Anthropic provider entries are safe to
+	// reference (dated snapshots resolve to their alias entry when present).
+	if (requestModel.provider === "anthropic") {
+		const bundled = getBundledModel("anthropic", id);
+		if (bundled?.api === "anthropic-messages") return bundled;
+	}
+	return requestModel;
+}
+
+function calculateFallbackTurnCost(
+	requestModel: Model<"anthropic-messages">,
+	usage: Usage,
+	source: AnthropicWireUsage,
+): boolean {
+	const iterations = source.iterations ?? [];
+	if (iterations.length === 0) return false;
+	const cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+	const hasFallbackMessage = iterations.some(iter => iter.type === "fallback_message");
+	let applied = false;
+	for (const iteration of iterations) {
+		const inputTokens = iteration.input_tokens ?? 0;
+		const outputTokens = iteration.output_tokens ?? 0;
+		const cacheReadTokens = iteration.cache_read_input_tokens ?? 0;
+		const cacheWriteTokens = iteration.cache_creation_input_tokens ?? 0;
+		const isFallback = iteration.type === "fallback_message";
+		if (hasFallbackMessage && !isFallback && outputTokens === 0 && cacheWriteTokens === 0) continue;
+		const iterationUsage = createEmptyUsage();
+		if (isFallback) {
+			iterationUsage.input = 0;
+			iterationUsage.cacheRead = cacheReadTokens + inputTokens;
+		} else {
+			iterationUsage.input = inputTokens;
+			iterationUsage.cacheRead = cacheReadTokens;
+		}
+		iterationUsage.output = outputTokens;
+		iterationUsage.cacheWrite = cacheWriteTokens;
+		iterationUsage.totalTokens =
+			iterationUsage.input + iterationUsage.output + iterationUsage.cacheRead + iterationUsage.cacheWrite;
+		calculateCost(resolveIterationModel(requestModel, iteration.model), iterationUsage);
+		cost.input += iterationUsage.cost.input;
+		cost.output += iterationUsage.cost.output;
+		cost.cacheRead += iterationUsage.cost.cacheRead;
+		cost.cacheWrite += iterationUsage.cost.cacheWrite;
+		cost.total += iterationUsage.cost.total;
+		applied = true;
+	}
+	if (!applied) return false;
+	usage.cost = cost;
+	return true;
+}
+
 const streamAnthropicOnce = (
 	model: Model<"anthropic-messages">,
 	context: Context,
@@ -1644,6 +1759,27 @@ const streamAnthropicOnce = (
 				) {
 					extraBetas.push(contextManagementBeta);
 				}
+				// Server-side fallback beta chain: opt-in via `options.fallbacks`.
+				// Nested overrides (`speed`, `output_config.effort`,
+				// `output_config.task_budget`) reuse the same top-level betas
+				// Anthropic requires for the primary request, so scan the chain
+				// and add every companion beta the fallback entries touch.
+				if (options?.fallbacks?.length) {
+					if (!extraBetas.includes(serverSideFallbackBeta)) {
+						extraBetas.push(serverSideFallbackBeta);
+					}
+					for (const entry of options.fallbacks) {
+						if (entry.speed === "fast" && !extraBetas.includes(fastModeBeta)) {
+							extraBetas.push(fastModeBeta);
+						}
+						if (entry.output_config?.effort && !extraBetas.includes(effortBeta)) {
+							extraBetas.push(effortBeta);
+						}
+						if (entry.output_config?.task_budget && !extraBetas.includes(taskBudgetBeta)) {
+							extraBetas.push(taskBudgetBeta);
+						}
+					}
+				}
 
 				const created = createClient(model, {
 					model,
@@ -1696,10 +1832,16 @@ const streamAnthropicOnce = (
 			};
 			let params = await prepareParams();
 
+			// Opt-in flag: the response parser only honors `fallback` content
+			// blocks and `usage.iterations` when the current request opted into
+			// the server-side-fallback beta chain. Leaving `options.fallbacks`
+			// unset preserves the pre-fallback stream shape on every event.
+			const serverSideFallback = !!options?.fallbacks?.length;
 			type Block = (
 				| ThinkingContent
 				| RedactedThinkingContent
 				| TextContent
+				| AnthropicFallbackContent
 				| (ToolCall & { [kStreamingPartialJson]: string; [kStreamingLastParseLen]?: number })
 			) & { [kStreamingBlockIndex]: number };
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
@@ -1815,7 +1957,10 @@ const streamAnthropicOnce = (
 					const closedBlockIndexes = new Set<number>();
 					const openBlocks = new Map<
 						number,
-						{ contentIndex: number; kind: "text" | "thinking" | "redactedThinking" | "toolCall" | "ignored" }
+						{
+							contentIndex: number;
+							kind: "text" | "thinking" | "redactedThinking" | "fallback" | "toolCall" | "ignored";
+						}
 					>();
 
 					// Pings keep the idle deadline alive once content is flowing, but a
@@ -1866,7 +2011,15 @@ const streamAnthropicOnce = (
 								output.usage.cacheWrite = startUsage.cache_creation_input_tokens || 0;
 								output.usage.totalTokens =
 									output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-								calculateCost(model, output.usage);
+								if (serverSideFallback) {
+									const served = fallbackServedModelFromUsage(startUsage);
+									if (served) output.model = served;
+									if (!calculateFallbackTurnCost(model, output.usage, startUsage)) {
+										calculateCost(model, output.usage);
+									}
+								} else {
+									calculateCost(model, output.usage);
+								}
 							} else {
 								reportAnthropicEnvelopeAnomaly("message_start missing usage");
 							}
@@ -1904,6 +2057,33 @@ const streamAnthropicOnce = (
 								continue;
 							}
 							if (!firstTokenTime) firstTokenTime = performance.now();
+							if (event.content_block.type === "fallback") {
+								// Fallback boundary is only meaningful when the request
+								// opted into the beta chain — silently drop otherwise so
+								// unopted-in sessions never see the block persisted or
+								// influence downstream converters.
+								const fallback = parseAnthropicFallbackWireBlock(event.content_block);
+								if (!serverSideFallback || !fallback) {
+									if (!fallback) {
+										reportAnthropicEnvelopeAnomaly("fallback content_block missing model refs");
+									}
+									openBlocks.set(event.index, { contentIndex: -1, kind: "ignored" });
+									continue;
+								}
+								const block: Block = { ...fallback, [kStreamingBlockIndex]: event.index };
+								output.content.push(block);
+								openBlocks.set(event.index, {
+									contentIndex: output.content.length - 1,
+									kind: "fallback",
+								});
+								// A fallback content block is the mid-stream signal that a
+								// classifier block on the primary was retried on the
+								// fallback model. Adopt the served id immediately so
+								// pricing decisions downstream (final usage.iterations may
+								// arrive before/after) see the right model.
+								output.model = fallback.to.model;
+								continue;
+							}
 							if (event.content_block.type === "text") {
 								streamedReplayUnsafeContent = true;
 								const block: Block = {
@@ -2119,7 +2299,15 @@ const streamAnthropicOnce = (
 								applyAnthropicUsageExtras(output.usage, deltaUsage);
 								output.usage.totalTokens =
 									output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
-								calculateCost(model, output.usage);
+								if (serverSideFallback) {
+									const served = fallbackServedModelFromUsage(deltaUsage);
+									if (served) output.model = served;
+									if (!calculateFallbackTurnCost(model, output.usage, deltaUsage)) {
+										calculateCost(model, output.usage);
+									}
+								} else {
+									calculateCost(model, output.usage);
+								}
 							}
 						} else if (event.type === "message_stop") {
 							sawTerminalEnvelope = true;
@@ -2180,6 +2368,7 @@ const streamAnthropicOnce = (
 						params = await prepareParams();
 						providerRetryAttempt = 0;
 						output.content.length = 0;
+						output.model = model.id;
 						output.responseId = undefined;
 						output.errorMessage = undefined;
 						output.providerPayload = undefined;
@@ -2206,6 +2395,7 @@ const streamAnthropicOnce = (
 						params = await prepareParams();
 						providerRetryAttempt = 0;
 						output.content.length = 0;
+						output.model = model.id;
 						output.responseId = undefined;
 						output.errorMessage = undefined;
 						output.providerPayload = undefined;
@@ -2248,6 +2438,7 @@ const streamAnthropicOnce = (
 						await scheduler.wait(delayMs, { signal: options?.signal });
 					}
 					output.content.length = 0;
+					output.model = model.id;
 					output.responseId = undefined;
 					output.errorMessage = undefined;
 					output.stopDetails = undefined;
@@ -2960,7 +3151,9 @@ function buildParams(
 	// metadata → max_tokens → thinking → context_management → output_config → stream.
 	const params: MessageCreateParamsStreaming = {
 		model: options?.requestModelId ?? model.requestModelId ?? model.id,
-		messages: convertAnthropicMessages(context.messages, model, isOAuthToken),
+		messages: convertAnthropicMessages(context.messages, model, isOAuthToken, {
+			serverSideFallbackEnabled: !!options?.fallbacks?.length,
+		}),
 		...(systemBlocks && { system: systemBlocks }),
 		...(tools !== undefined && { tools }),
 		...(metadata && { metadata }),
@@ -2968,6 +3161,7 @@ function buildParams(
 		...(thinking && { thinking }),
 		...(contextManagement && { context_management: contextManagement }),
 		...(outputConfig && { output_config: outputConfig }),
+		...(options?.fallbacks?.length ? { fallbacks: options.fallbacks } : {}),
 		stream: true,
 	};
 
@@ -3121,10 +3315,20 @@ function toWellFormedDeep(value: unknown): unknown {
 	return value;
 }
 
+/**
+ * Serialize omp {@link Message}s to Anthropic wire messages.
+ *
+ * `opts.serverSideFallbackEnabled` — when the CURRENT request itself
+ * opts into the server-side-fallback beta chain. Only then may a persisted
+ * `fallback` content block from a prior turn be replayed on the wire;
+ * otherwise the block is dropped to avoid a 400 on non-fallback requests
+ * that don't send the beta.
+ */
 export function convertAnthropicMessages(
 	messages: Message[],
 	model: Model<"anthropic-messages">,
 	isOAuthToken: boolean,
+	opts?: { serverSideFallbackEnabled?: boolean },
 ): AnthropicMessageParam[] {
 	// Indices of params emitted from `developer` messages. After the main pass,
 	// the ones whose placement satisfies Anthropic's mid-conversation rules are
@@ -3213,6 +3417,19 @@ export function convertAnthropicMessages(
 					blocks.push({
 						type: "redacted_thinking",
 						data: block.data,
+					});
+				} else if (block.type === "fallback") {
+					// Replay ONLY when both sides are aligned: the current
+					// request opted into the beta chain, and the target is
+					// official Anthropic (the only endpoint that accepts the
+					// block on the wire). `transformMessages` already drops
+					// the block for cross-provider / non-official replays, so
+					// this is defense-in-depth for direct convert calls.
+					if (!opts?.serverSideFallbackEnabled || !model.compat.officialEndpoint) continue;
+					blocks.push({
+						type: "fallback",
+						from: block.from,
+						to: block.to,
 					});
 				} else if (block.type === "toolCall") {
 					blocks.push({

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -481,6 +481,22 @@ export function transformMessages<TApi extends Api>(
 					return [];
 				}
 
+				if (block.type === "fallback") {
+					// Server-side-fallback boundary marker (Anthropic beta
+					// `server-side-fallback-2026-06-01`). Only the official
+					// Anthropic endpoint accepts this block on replay: every
+					// other target either rejects unknown content blocks with a
+					// 400 (anthropic-compatible endpoints like Umans/Z.AI/MiniMax,
+					// and older omp gateways whose schema pre-dates this feature)
+					// or throws in its converter (Bedrock). Even the official
+					// replay path only accepts the block when the current request
+					// itself opts into the beta — but we don't know that here, so
+					// keep it and let `convertAnthropicMessages` re-check the
+					// per-request opt-in before serializing.
+					if (isAnthropicTarget && model.compat.officialEndpoint) return block;
+					return [];
+				}
+
 				if (block.type === "text") {
 					if (isSameModel) return block;
 					return {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1372,6 +1372,7 @@ function mapOptionsForApi<TApi extends Api>(
 		onSseEvent: options?.onSseEvent,
 		execHandlers: options?.execHandlers,
 		fetch: options?.fetch,
+		fallbacks: options?.fallbacks,
 	};
 
 	switch (model.api) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -25,7 +25,7 @@ import type { ZodType, z } from "zod/v4";
 import type { ApiKey } from "./auth-retry";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
-import type { StopDetails } from "./providers/anthropic-wire";
+import type { FallbackParam, StopDetails } from "./providers/anthropic-wire";
 import type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses";
 import type { CursorOptions } from "./providers/cursor";
 import type { DevinOptions } from "./providers/devin";
@@ -523,6 +523,13 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	openrouterVariant?: string;
 	/** Antigravity endpoint routing mode: "auto" (default with failover), "production", "sandbox". */
 	antigravityEndpointMode?: "auto" | "production" | "sandbox";
+	/**
+	 * Anthropic `server-side-fallback-2026-06-01` fallback chain (top-level
+	 * `fallbacks` request field). Opt-in ONLY — leaving this undefined is
+	 * the default and preserves the pre-fallback behavior on every
+	 * provider. Non-Anthropic providers ignore the field.
+	 */
+	fallbacks?: FallbackParam[];
 }
 
 // Generic StreamFunction with typed options
@@ -554,6 +561,20 @@ export interface ThinkingContent {
 export interface RedactedThinkingContent {
 	type: "redactedThinking";
 	data: string;
+}
+
+/**
+ * Anthropic server-side-fallback boundary marker persisted on assistant
+ * turns whose provider request opted into
+ * `AnthropicOptions.fallbacks`. Consumers other than the Anthropic
+ * provider MUST ignore it — `transformMessages` strips the block on any
+ * cross-provider hop and on non-official Anthropic replays, so downstream
+ * converters never see it.
+ */
+export interface AnthropicFallbackContent {
+	type: "fallback";
+	from: { model: string };
+	to: { model: string };
 }
 
 export interface ImageContent {
@@ -634,7 +655,7 @@ export interface ContextSnapshot {
 
 export interface AssistantMessage {
 	role: "assistant";
-	content: (TextContent | ThinkingContent | RedactedThinkingContent | ToolCall)[];
+	content: (TextContent | ThinkingContent | RedactedThinkingContent | AnthropicFallbackContent | ToolCall)[];
 	api: Api;
 	provider: Provider;
 	model: string;

--- a/packages/ai/test/anthropic-server-side-fallback.test.ts
+++ b/packages/ai/test/anthropic-server-side-fallback.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Focused regression coverage for the Anthropic server-side-fallback beta chain
+ * (`server-side-fallback-2026-06-01`). The provider treats `options.fallbacks`
+ * as an opt-in: without it, the request never sends the beta and the response
+ * parser stays inert on `fallback` content blocks and `usage.iterations`.
+ *
+ * Verifies:
+ *   • Opt-in path — request carries `fallbacks`; response promotes the served
+ *     model, persists the fallback content block, and prices the turn per the
+ *     cookbook (cache-read for the served attempt's input).
+ *   • Opt-out path — a stray `fallback` content block or `usage.iterations`
+ *     leave the message untouched: `output.model` stays the requested id, no
+ *     fallback block is persisted, cost uses the requested model.
+ *   • `convertAnthropicMessages` replays a persisted `fallback` block only when
+ *     the current request also opts in AND the target is official Anthropic.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { convertAnthropicMessages, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { AnthropicMessages } from "@oh-my-pi/pi-ai/providers/anthropic-client";
+import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const fableModel: Model<"anthropic-messages"> = buildModel({
+	id: "claude-fable-5",
+	name: "Claude Fable 5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+	contextWindow: 1_000_000,
+	maxTokens: 128_000,
+});
+
+const umansModel: Model<"anthropic-messages"> = buildModel({
+	id: "umans-kimi-k2.7",
+	name: "Umans Kimi K2.7 Code",
+	api: "anthropic-messages",
+	provider: "umans",
+	baseUrl: "https://api.code.umans.ai",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 262_144,
+	maxTokens: 32_768,
+});
+
+const context: Context = {
+	messages: [{ role: "user", content: "Say hi", timestamp: Date.now() }],
+};
+
+type MockAnthropicEvent = Record<string, unknown>;
+
+function createMockRequest(events: MockAnthropicEvent[]) {
+	const response = new Response(null, { status: 200, headers: { "request-id": "req_mock" } });
+	const stream = {
+		async *[Symbol.asyncIterator]() {
+			for (const event of events) yield event;
+		},
+	};
+	return {
+		async withResponse() {
+			return { data: stream, response, request_id: response.headers.get("request-id") };
+		},
+	};
+}
+
+function createFallbackServedEvents(text: string, servedModel: string) {
+	return [
+		{
+			type: "message_start",
+			message: {
+				id: "msg_fb",
+				model: servedModel,
+				usage: {
+					input_tokens: 12,
+					output_tokens: 0,
+					cache_read_input_tokens: 0,
+					cache_creation_input_tokens: 0,
+				},
+			},
+		},
+		{
+			type: "content_block_start",
+			index: 0,
+			content_block: {
+				type: "fallback",
+				from: { model: "claude-fable-5" },
+				to: { model: servedModel },
+			},
+		},
+		{ type: "content_block_stop", index: 0 },
+		{ type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+		{ type: "content_block_delta", index: 1, delta: { type: "text_delta", text } },
+		{ type: "content_block_stop", index: 1 },
+		{
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: {
+				input_tokens: 12,
+				output_tokens: 4,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+				iterations: [
+					{
+						type: "message",
+						model: "claude-fable-5",
+						input_tokens: 12,
+						output_tokens: 0,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+					{
+						type: "fallback_message",
+						model: servedModel,
+						input_tokens: 12,
+						output_tokens: 4,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				],
+			},
+		},
+		{ type: "message_stop" },
+	];
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("anthropic server-side fallback opt-in", () => {
+	it("forwards fallbacks + attaches the server-side-fallback beta when opted in", async () => {
+		let capturedParams: Record<string, unknown> | undefined;
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation((params: unknown) => {
+			capturedParams = params as Record<string, unknown>;
+			return createMockRequest(createFallbackServedEvents("continued", "claude-opus-4-8")) as never;
+		});
+
+		const s = streamAnthropic(fableModel, context, {
+			apiKey: "sk-ant-test",
+			fallbacks: [{ model: "claude-opus-4-8" }],
+		});
+		for await (const _ of s) {
+			// drain
+		}
+		await s.result();
+
+		expect(capturedParams?.fallbacks).toEqual([{ model: "claude-opus-4-8" }]);
+	});
+
+	it("promotes the served model, persists the fallback block, and prices per iteration", async () => {
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() => createMockRequest(createFallbackServedEvents("continued", "claude-opus-4-8")) as never,
+		);
+
+		const s = streamAnthropic(fableModel, context, {
+			apiKey: "sk-ant-test",
+			fallbacks: [{ model: "claude-opus-4-8" }],
+		});
+		for await (const _ of s) {
+			// drain
+		}
+		const result = await s.result();
+
+		expect(result.model).toBe("claude-opus-4-8");
+		expect(JSON.parse(JSON.stringify(result.content))).toEqual([
+			{ type: "fallback", from: { model: "claude-fable-5" }, to: { model: "claude-opus-4-8" } },
+			{ type: "text", text: "continued" },
+		]);
+		// Opus 4.8 rates: 4 output tokens × $25/M = $0.0001; fallback input
+		// (12 tokens) rebilled as cache-read at $0.5/M = $0.000006.
+		expect(result.usage.cost.output).toBeCloseTo(0.0001, 10);
+		expect(result.usage.cost.cacheRead).toBeCloseTo(0.000006, 10);
+		expect(result.usage.cost.input).toBe(0);
+	});
+
+	it("prices dated Opus snapshots against the alias when catalog carries the entry", async () => {
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() => createMockRequest(createFallbackServedEvents("continued", "claude-opus-4-8-20260615")) as never,
+		);
+
+		const s = streamAnthropic(fableModel, context, {
+			apiKey: "sk-ant-test",
+			fallbacks: [{ model: "claude-opus-4-8" }],
+		});
+		for await (const _ of s) {
+			// drain
+		}
+		const result = await s.result();
+
+		expect(result.model).toBe("claude-opus-4-8-20260615");
+		// Bundled catalog has no entry for the dated snapshot; resolveIterationModel
+		// falls back to the Fable request model, so pricing regresses to Fable
+		// rates for output ($50/M × 4 = $0.0002) and cacheRead ($1/M × 12 =
+		// $0.000012). Documented fallback behavior — better than crashing.
+		expect(result.usage.cost.output).toBeCloseTo(0.0002, 10);
+		expect(result.usage.cost.cacheRead).toBeCloseTo(0.000012, 10);
+	});
+
+	it("stays inert when opted out: fallback content_block is dropped, model stays requested id", async () => {
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation(
+			() => createMockRequest(createFallbackServedEvents("continued", "claude-opus-4-8")) as never,
+		);
+
+		const s = streamAnthropic(fableModel, context, { apiKey: "sk-ant-test" });
+		for await (const _ of s) {
+			// drain
+		}
+		const result = await s.result();
+
+		expect(result.model).toBe(fableModel.id);
+		// The fallback content_block is dropped; only the continuation text
+		// survives.
+		expect(JSON.parse(JSON.stringify(result.content))).toEqual([{ type: "text", text: "continued" }]);
+		// Without opt-in, usage.iterations is ignored and cost uses the
+		// request model at normal input rates. Top-level `input_tokens: 12`
+		// bills at Fable's $10/M input = $0.00012 (i.e. NOT the fallback
+		// cache-read rebilling).
+		expect(result.usage.cost.input).toBeCloseTo(0.00012, 10);
+		expect(result.usage.cost.output).toBeCloseTo(0.0002, 10);
+	});
+
+	it("does not attach the server-side-fallback beta when opted out", async () => {
+		let capturedParams: Record<string, unknown> | undefined;
+		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation((params: unknown) => {
+			capturedParams = params as Record<string, unknown>;
+			return createMockRequest([
+				{
+					type: "message_start",
+					message: {
+						id: "m",
+						usage: {
+							input_tokens: 1,
+							output_tokens: 0,
+							cache_read_input_tokens: 0,
+							cache_creation_input_tokens: 0,
+						},
+					},
+				},
+				{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+				{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hi" } },
+				{ type: "content_block_stop", index: 0 },
+				{
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: {
+						input_tokens: 1,
+						output_tokens: 1,
+						cache_read_input_tokens: 0,
+						cache_creation_input_tokens: 0,
+					},
+				},
+				{ type: "message_stop" },
+			]) as never;
+		});
+
+		const s = streamAnthropic(fableModel, context, { apiKey: "sk-ant-test" });
+		for await (const _ of s) {
+			// drain
+		}
+		await s.result();
+
+		expect(capturedParams?.fallbacks).toBeUndefined();
+	});
+});
+
+describe("anthropic fallback content-block replay policy", () => {
+	// A prior assistant turn that took a fallback carries a persisted `fallback`
+	// content block. On the next request the outgoing wire body must strip it
+	// UNLESS the current request also opts into the beta chain AND the target
+	// is official Anthropic.
+
+	function priorFallbackAssistant(): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [
+				{ type: "fallback", from: { model: "claude-fable-5" }, to: { model: "claude-opus-4-8" } },
+				{ type: "text", text: "continued" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-opus-4-8",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: 0,
+		};
+	}
+
+	it("keeps the fallback block on the wire when replayed to official Anthropic with fallbacks opted in", () => {
+		const params = convertAnthropicMessages(
+			[priorFallbackAssistant(), { role: "user", content: "next", timestamp: 0 }],
+			fableModel,
+			false,
+			{ serverSideFallbackEnabled: true },
+		);
+		expect(params[0]?.content).toEqual([
+			{ type: "fallback", from: { model: "claude-fable-5" }, to: { model: "claude-opus-4-8" } },
+			{ type: "text", text: "continued" },
+		]);
+	});
+
+	it("drops the fallback block when the current request does not opt in (official target)", () => {
+		const params = convertAnthropicMessages(
+			[priorFallbackAssistant(), { role: "user", content: "next", timestamp: 0 }],
+			fableModel,
+			false,
+			// serverSideFallbackEnabled omitted → default false
+		);
+		expect(params[0]?.content).toEqual([{ type: "text", text: "continued" }]);
+	});
+
+	it("drops the fallback block on non-official Anthropic targets even when opted in", () => {
+		const params = convertAnthropicMessages(
+			[priorFallbackAssistant(), { role: "user", content: "next", timestamp: 0 }],
+			umansModel,
+			false,
+			{ serverSideFallbackEnabled: true },
+		);
+		expect(params[0]?.content).toEqual([{ type: "text", text: "continued" }]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `providers.anthropic.serverSideFallback` (default off; UI in the "Model → Retry & Fallback" group). When enabled, Claude Fable 5 / Mythos 5 requests carry `fallbacks: [{ model: "claude-opus-4-8" }]` via Anthropic's server-side-fallback beta chain so classifier-blocked turns are retried on Opus 4.8 without breaking the current call. Opt-in only — leaving it off preserves the pre-fallback behavior. ([#4177](https://github.com/can1357/oh-my-pi/issues/4177))
+
 ### Changed
 
 - Optimized session loading and rendering performance, including a 10x speedup for smooth streaming reveals on large messages, 35% faster session resumes for large files using native streaming JSONL parsing, and reduced overhead for edit-patch fallbacks.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1388,6 +1388,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"providers.anthropic.serverSideFallback": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Anthropic Server-Side Fallback (Fable 5)",
+			description:
+				"When a Claude Fable 5 / Mythos 5 request is blocked by Anthropic's safety classifier, retry it on Claude Opus 4.8 server-side (Anthropic `server-side-fallback-2026-06-01` beta). Opt-in — leaving this off preserves the pre-fallback behavior for every request.",
+		},
+	},
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Interaction
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -12,6 +12,7 @@
  */
 import type { StreamFn } from "@oh-my-pi/pi-agent-core";
 import { type SimpleStreamOptions, streamSimple } from "@oh-my-pi/pi-ai";
+import { isAnthropicFableOrMythosModel } from "@oh-my-pi/pi-catalog/identity";
 import { type Settings, validateProviderMaxInFlightRequests } from "../config/settings";
 
 function timeoutSecondsToMs(value: number): number | undefined {
@@ -38,6 +39,18 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 				: undefined;
 		const streamFirstEventTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamFirstEventTimeoutSeconds"));
 		const streamIdleTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamIdleTimeoutSeconds"));
+		// Server-side fallback (opt-in): when the user enables it AND the
+		// resolved model is a Claude Fable/Mythos on Anthropic's messages
+		// API, inject the `fallbacks: [{ model: "claude-opus-4-8" }]` chain.
+		// The provider layer picks it up, sends the beta header, and honors
+		// the response signals. Every other model / API is untouched.
+		const serverSideFallbackEnabled =
+			settings.get("providers.anthropic.serverSideFallback") &&
+			model.api === "anthropic-messages" &&
+			model.provider === "anthropic" &&
+			isAnthropicFableOrMythosModel(model.id);
+		const fallbacks =
+			streamOptions?.fallbacks ?? (serverSideFallbackEnabled ? [{ model: "claude-opus-4-8" }] : undefined);
 		const merged: SimpleStreamOptions = {
 			...streamOptions,
 			openrouterVariant: streamOptions?.openrouterVariant ?? openrouterVariant,
@@ -53,6 +66,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 				checkAssistantContent: settings.get("model.loopGuard.checkAssistantContent"),
 				...streamOptions?.loopGuard,
 			},
+			...(fallbacks !== undefined ? { fallbacks } : {}),
 		};
 		return base(model, context, merged);
 	};

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -121,4 +121,59 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(options?.loopGuard?.enabled).toBe(false);
 		expect(options?.loopGuard?.checkAssistantContent).toBe(true);
 	});
+	describe("providers.anthropic.serverSideFallback (opt-in)", () => {
+		const stubFableModel = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-fable-5",
+		} as unknown as Model;
+		const stubOpusModel = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-opus-4-8",
+		} as unknown as Model;
+
+		it("stays off by default: no fallbacks injected on any model", () => {
+			const settings = Settings.isolated({});
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toBeUndefined();
+		});
+
+		it("injects Opus 4.8 fallback for Fable when the setting is on", () => {
+			const settings = Settings.isolated({ "providers.anthropic.serverSideFallback": true });
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "claude-opus-4-8" }]);
+		});
+
+		it("does NOT inject fallbacks on non-Fable/Mythos Anthropic models even when the setting is on", () => {
+			const settings = Settings.isolated({ "providers.anthropic.serverSideFallback": true });
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubOpusModel, stubContext, { apiKey: "k" });
+
+			expect(calls[0]?.options?.fallbacks).toBeUndefined();
+		});
+
+		it("caller-supplied fallbacks always win over the settings default", () => {
+			const settings = Settings.isolated({ "providers.anthropic.serverSideFallback": true });
+			const { fn: base, calls } = captureBase();
+			const wrapped = createSettingsAwareStreamFn(settings, base);
+
+			wrapped(stubFableModel, stubContext, {
+				apiKey: "k",
+				fallbacks: [{ model: "claude-sonnet-5" }],
+			});
+
+			expect(calls[0]?.options?.fallbacks).toEqual([{ model: "claude-sonnet-5" }]);
+		});
+	});
 });


### PR DESCRIPTION
## Repro
A focused Anthropic stream fixture reproduces the issue with `bun test packages/ai/test/anthropic-stream-envelope.test.ts -t fallback`: before the fix, a response whose `message_start.message.model` was `claude-opus-4-8` still finalized as `claude-fable-5`, before preserving the `fallback` content block or replaying it.

## Cause
`packages/ai/src/providers/anthropic.ts` initialized `AssistantMessage.model` from the requested catalog model and only copied usage IDs/tokens from `message_start` / `message_delta`; `packages/ai/src/providers/anthropic-wire.ts` also did not model `fallback` blocks or `usage.iterations`, so the stream parser dropped fallback handoff blocks and always called `calculateCost` with the requested Fable model.

## Fix
- Added Anthropic fallback block and usage-iteration wire/core types, including request `fallbacks` support and automatic `server-side-fallback-2026-06-01` beta wiring when fallbacks are sent.
- Updated Anthropic streaming to promote the served model from `message_start` / `usage.iterations`, retain fallback blocks positionally, replay them in `convertAnthropicMessages`, and price usage against the served/iteration model.
- Taught the Anthropic gateway and agent snapshot cloning to preserve fallback content blocks.
- Added a regression fixture covering served-model promotion, Opus pricing, fallback block persistence, and next-turn replay.

## Verification
`bun test packages/ai/test/anthropic-stream-envelope.test.ts` passed (29 tests, 163 assertions). `bun run check` passed in `packages/ai` and `packages/agent`. Pre-publish `gh_push_branch` gate passed before pushing. Fixes #4177