### PR TITLE
fix(robomp): run sandbox setup/teardown off the event loop safely

### DIFF
--- a/python/robomp/src/natives_cache.py
+++ b/python/robomp/src/natives_cache.py
@@ -152,6 +152,7 @@ def compute_key(repo_dir: Path, *, target: str | None = None) -> str:
         capture_output=True,
         check=True,
         env=_git_safe_directory_env(repo_dir),
+        timeout=120.0,
     )
     lines = proc.stdout.splitlines()
     if len(lines) != len(CACHE_KEY_PATHS):

--- a/python/robomp/src/sandbox.py
+++ b/python/robomp/src/sandbox.py
@@ -819,12 +819,18 @@ class SandboxManager:
                         )
             else:
                 slot_git_env = _git_env_for_repo(repo_dir)
+                symref = ["git", "symbolic-ref", "--quiet", "--short", "HEAD"]
                 current = _safe_run(
-                    ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                    symref,
                     cwd=repo_dir,
                     env=slot_git_env,
                     **slot_git_kwargs,
                 )
+                if current.returncode == 124:
+                    # A timed-out probe is indeterminate, not "detached HEAD".
+                    # Silently keeping the caller-supplied branch could mismatch
+                    # the real checkout; fail so the event retries.
+                    raise GitCommandError(symref, current.returncode, current.stdout, current.stderr)
                 if current.returncode == 0 and current.stdout.strip():
                     branch = current.stdout.strip()
                     if existing_branch is not None and existing_branch != branch:

--- a/python/robomp/src/sandbox.py
+++ b/python/robomp/src/sandbox.py
@@ -958,13 +958,15 @@ class SandboxManager:
             repo_dir = ws_root / "repo"
             if repo_dir.exists():
                 pool = self.pool_path(repo)
-                _safe_run(["git", "worktree", "remove", "--force", str(repo_dir)], cwd=pool)
-                if repo_dir.exists():
-                    # `git worktree remove` did not clean up (nonzero exit, incl. a
-                    # 124 timeout). Delete the checkout ourselves, then prune the
-                    # pool's now-dangling worktree registration so a later
-                    # `git worktree add` for the same path does not trip on stale
-                    # metadata.
+                removed = _safe_run(["git", "worktree", "remove", "--force", str(repo_dir)], cwd=pool)
+                if removed.returncode != 0:
+                    # A failed `git worktree remove` (nonzero exit, incl. a 124
+                    # timeout) may have deleted the checkout but left the pool's
+                    # worktree registration dangling, or vice versa. Delete any
+                    # leftover checkout ourselves, then prune the dangling pool
+                    # registration so a later `git worktree add` for the same path
+                    # does not trip on stale metadata. `repo_dir.exists()` is not a
+                    # reliable proxy: a killed remove can clear the checkout first.
                     shutil.rmtree(repo_dir, ignore_errors=True)
                     _safe_run(["git", "worktree", "prune"], cwd=pool)
             if ws_root.exists():

--- a/python/robomp/src/sandbox.py
+++ b/python/robomp/src/sandbox.py
@@ -354,6 +354,30 @@ def _run(
     return proc
 
 
+def _worktree_add(add_cmd: list[str], *, pool: Path, repo_dir: Path) -> None:
+    """Run `git worktree add`, cleaning partial state on failure.
+
+    A worktree-add killed mid-operation (the 120s `_run` timeout surfaces as
+    GitCommandError 124, or any nonzero git failure) can leave a partial
+    checkout at `repo_dir` and/or a dangling pool worktree registration. Left
+    behind, the event retry hits stale metadata and fails again on the same
+    path. Best-effort remove the checkout and prune the pool, then re-raise so the
+    retry starts from a clean path. If the prune itself fails (incl. a 124
+    timeout), raise that instead — chained from the add error — since a
+    dangling registration left behind is exactly what poisons the retry.
+    """
+    try:
+        _run(add_cmd, cwd=pool)
+    except GitCommandError as add_err:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+        pruned = _safe_run(["git", "worktree", "prune"], cwd=pool)
+        if pruned.returncode != 0:
+            raise GitCommandError(
+                ["git", "worktree", "prune"], pruned.returncode, pruned.stdout, pruned.stderr
+            ) from add_err
+        raise
+
+
 _SHARED_OMP_GID = 2000
 
 
@@ -710,10 +734,17 @@ class SandboxManager:
     def _reset_origin_url(repo_dir: Path, clone_url: str) -> None:
         """`git remote set-url origin <clone_url>` if origin exists and differs.
 
-        Best-effort: silent no-op on failure (probe `get-url` first so we don't
-        spam logs on first-time clones where origin isn't configured yet).
+        Best-effort: silent no-op on a "no origin" failure (probe `get-url`
+        first so we don't spam logs on first-time clones). A timed-out probe
+        (124) is indeterminate and raises instead — see below.
         """
         probe = _safe_run(["git", "remote", "get-url", "origin"], cwd=repo_dir)
+        if probe.returncode == 124:
+            # A timed-out probe is indeterminate: we cannot tell whether origin
+            # embeds a legacy credential that must be rewritten before fetch.
+            # Fail closed so the event retries rather than fetching against a
+            # possibly-credentialed origin.
+            raise GitCommandError(["git", "remote", "get-url", "origin"], probe.returncode, probe.stdout, probe.stderr)
         if probe.returncode != 0:
             return
         if probe.stdout.strip() == clone_url:
@@ -778,7 +809,11 @@ class SandboxManager:
             if not repo_exists:
                 if pr_head is not None:
                     self.transport.fetch_pr_head(repo=repo, pool_dir=pool, pr_number=pr_head)
-                    _run(["git", "worktree", "add", "--detach", str(repo_dir), "FETCH_HEAD"], cwd=pool)
+                    _worktree_add(
+                        ["git", "worktree", "add", "--detach", str(repo_dir), "FETCH_HEAD"],
+                        pool=pool,
+                        repo_dir=repo_dir,
+                    )
                 else:
                     # Make sure the requested start point exists locally (best-effort).
                     # For follow-ups on an existing PR, `existing_branch` is the remote
@@ -793,7 +828,11 @@ class SandboxManager:
                         # start point; fail instead so the event retries.
                         raise GitCommandError(probe, check.returncode, check.stdout, check.stderr)
                     if check.returncode == 0:
-                        _run(["git", "worktree", "add", str(repo_dir), branch], cwd=pool)
+                        _worktree_add(
+                            ["git", "worktree", "add", str(repo_dir), branch],
+                            pool=pool,
+                            repo_dir=repo_dir,
+                        )
                     else:
                         start_point = f"origin/{default_branch}"
                         if existing_branch:
@@ -805,17 +844,10 @@ class SandboxManager:
                                 raise GitCommandError(remote_probe, remote.returncode, remote.stdout, remote.stderr)
                             if remote.returncode == 0:
                                 start_point = f"origin/{existing_branch}"
-                        _run(
-                            [
-                                "git",
-                                "worktree",
-                                "add",
-                                "-b",
-                                branch,
-                                str(repo_dir),
-                                start_point,
-                            ],
-                            cwd=pool,
+                        _worktree_add(
+                            ["git", "worktree", "add", "-b", branch, str(repo_dir), start_point],
+                            pool=pool,
+                            repo_dir=repo_dir,
                         )
             else:
                 slot_git_env = _git_env_for_repo(repo_dir)
@@ -956,19 +988,38 @@ class SandboxManager:
         with self._repo_lock(repo):
             ws_root = self.workspace_root(repo, number)
             repo_dir = ws_root / "repo"
-            if repo_dir.exists():
-                pool = self.pool_path(repo)
-                removed = _safe_run(["git", "worktree", "remove", "--force", str(repo_dir)], cwd=pool)
-                if removed.returncode != 0:
-                    # A failed `git worktree remove` (nonzero exit, incl. a 124
-                    # timeout) may have deleted the checkout but left the pool's
-                    # worktree registration dangling, or vice versa. Delete any
-                    # leftover checkout ourselves, then prune the dangling pool
-                    # registration so a later `git worktree add` for the same path
-                    # does not trip on stale metadata. `repo_dir.exists()` is not a
-                    # reliable proxy: a killed remove can clear the checkout first.
-                    shutil.rmtree(repo_dir, ignore_errors=True)
-                    _safe_run(["git", "worktree", "prune"], cwd=pool)
+            pool = self.pool_path(repo)
+            # `repo_dir.exists()` is not a reliable proxy for "nothing to clean
+            # up in the pool": a worktree-add or a prior remove killed mid-flight
+            # can leave the checkout gone but the pool's worktree registration
+            # dangling, which fails the next `git worktree add` for this path.
+            # Only run git in a REAL pool clone: `ensure_clone` mkdir's the pool
+            # dir BEFORE cloning, so a failed first clone can leave a non-git dir
+            # here, and `git worktree prune` in it would error. Mirror
+            # `ensure_clone`'s own `.git`/`HEAD` validity check.
+            if (pool / ".git").exists() or (pool / "HEAD").exists():
+                needs_prune = False
+                if repo_dir.exists():
+                    removed = _safe_run(["git", "worktree", "remove", "--force", str(repo_dir)], cwd=pool)
+                    if removed.returncode != 0:
+                        shutil.rmtree(repo_dir, ignore_errors=True)
+                        needs_prune = True
+                elif ws_root.exists():
+                    # Checkout gone but the workspace root remains -> a prior op
+                    # was killed mid-flight and may have left a dangling
+                    # registration. A fully-cleaned workspace has no ws_root, so
+                    # a plain repeat close prunes nothing.
+                    needs_prune = True
+                if needs_prune:
+                    pruned = _safe_run(["git", "worktree", "prune"], cwd=pool)
+                    if pruned.returncode != 0:
+                        # Prune is the step that clears the dangling registration.
+                        # If it fails (incl. a 124 timeout), report it so the
+                        # cleanup event retries instead of recording success with
+                        # stale metadata still blocking the next add.
+                        raise GitCommandError(
+                            ["git", "worktree", "prune"], pruned.returncode, pruned.stdout, pruned.stderr
+                        )
             if ws_root.exists():
                 shutil.rmtree(ws_root, ignore_errors=True)
 

--- a/python/robomp/src/sandbox.py
+++ b/python/robomp/src/sandbox.py
@@ -47,6 +47,7 @@ import shutil
 import signal
 import stat
 import subprocess
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -298,16 +299,31 @@ class LocalGitTransport:
 # ---------- low-level helpers retained for callers expecting old shape ----------
 
 
-def _safe_run(cmd: list[str], *, cwd: Path | None = None, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+_DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT = 120.0
+
+
+def _safe_run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: float | None = _DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
     """Run without raising; caller decides on returncode. Credentials are redacted from any captured output."""
-    proc = subprocess.run(
-        cmd,
-        cwd=str(cwd) if cwd else None,
-        check=False,
-        capture_output=True,
-        text=True,
-        **kwargs,
-    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            **kwargs,
+        )
+    except subprocess.TimeoutExpired as exc:
+        out = redact_credentials(exc.stdout or "") if isinstance(exc.stdout, str) else ""
+        err = redact_credentials(exc.stderr or "") if isinstance(exc.stderr, str) else ""
+        return subprocess.CompletedProcess(cmd, 124, out, f"{err}\ntimed out after {timeout:.0f}s")
     if proc.stdout:
         proc.stdout = redact_credentials(proc.stdout)
     if proc.stderr:
@@ -315,15 +331,24 @@ def _safe_run(cmd: list[str], *, cwd: Path | None = None, **kwargs: Any) -> subp
     return proc
 
 
-def _run(cmd: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+def _run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: float | None = _DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT,
+) -> subprocess.CompletedProcess[str]:
     """Legacy raising helper (still used by a sandbox test). Forwards to subprocess.run."""
-    proc = subprocess.run(
-        cmd,
-        cwd=str(cwd) if cwd else None,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GitCommandError(cmd, 124, "", f"git timed out after {timeout:.0f}s") from exc
     if proc.returncode != 0:
         raise GitCommandError(cmd, proc.returncode, proc.stdout, proc.stderr)
     return proc
@@ -607,8 +632,16 @@ def _chown_workspace(ws_root: Path, slot_uid: int | None) -> None:
         return
     uid = slot_uid if slot_uid is not None else os.geteuid()
     gid = slot_uid if slot_uid is not None else os.getegid()
-    subprocess.run(["chown", "-R", f"{uid}:{gid}", str(ws_root)], check=True)
-    subprocess.run(["chmod", "-R", "u=rwX,g=rwX,o=", str(ws_root)], check=True)
+    subprocess.run(
+        ["chown", "-R", f"{uid}:{gid}", str(ws_root)],
+        check=True,
+        timeout=_DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT,
+    )
+    subprocess.run(
+        ["chmod", "-R", "u=rwX,g=rwX,o=", str(ws_root)],
+        check=True,
+        timeout=_DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT,
+    )
 
 
 # ---------- SandboxManager ----------
@@ -634,6 +667,16 @@ class SandboxManager:
         self.natives_cache = natives_cache
         root.mkdir(parents=True, exist_ok=True)
         self.pool.mkdir(parents=True, exist_ok=True)
+        self._repo_locks: dict[str, threading.RLock] = {}
+        self._repo_locks_guard = threading.Lock()
+
+    def _repo_lock(self, repo: str) -> threading.RLock:
+        with self._repo_locks_guard:
+            lock = self._repo_locks.get(repo)
+            if lock is None:
+                lock = threading.RLock()
+                self._repo_locks[repo] = lock
+            return lock
 
     # ---- pool ----
     def pool_path(self, repo: str) -> Path:
@@ -696,121 +739,130 @@ class SandboxManager:
         slot_uid: int | None = None,
     ) -> Workspace:
         """Create or resume a per-issue worktree."""
-        if pr_head is not None and existing_branch is not None:
-            raise ValueError("ensure_workspace accepts either pr_head or existing_branch, not both")
-        pool = self.ensure_clone(repo=repo, clone_url=clone_url, default_branch=default_branch)
-        ws_root = self.workspace_root(repo, number)
-        repo_dir = ws_root / "repo"
-        session_dir = ws_root / ".omp-session"
-        context_dir = ws_root / "context"
-        artifacts_dir = ws_root / "artifacts"
-        for path in (ws_root, session_dir, context_dir, context_dir / "repro", artifacts_dir):
-            path.mkdir(parents=True, exist_ok=True)
+        with self._repo_lock(repo):
+            if pr_head is not None and existing_branch is not None:
+                raise ValueError("ensure_workspace accepts either pr_head or existing_branch, not both")
+            pool = self.ensure_clone(repo=repo, clone_url=clone_url, default_branch=default_branch)
+            ws_root = self.workspace_root(repo, number)
+            repo_dir = ws_root / "repo"
+            session_dir = ws_root / ".omp-session"
+            context_dir = ws_root / "context"
+            artifacts_dir = ws_root / "artifacts"
+            for path in (ws_root, session_dir, context_dir, context_dir / "repro", artifacts_dir):
+                path.mkdir(parents=True, exist_ok=True)
 
-        branch = (
-            f"review/pr-{pr_head}"
-            if pr_head is not None
-            else existing_branch
-            or make_branch(
-                issue_number=number,
-                title=title,
-                seed=f"{repo}#{number}",
+            branch = (
+                f"review/pr-{pr_head}"
+                if pr_head is not None
+                else existing_branch
+                or make_branch(
+                    issue_number=number,
+                    title=title,
+                    seed=f"{repo}#{number}",
+                )
             )
-        )
 
-        repo_exists = (repo_dir / ".git").exists()
-        workspace_prepared = False
-        slot_git_kwargs = _slot_subprocess_kwargs(slot_uid)
-        slot_git_env: dict[str, str] | None = None
-        if repo_exists:
-            # Existing workspaces are already slot-owned from the previous run.
-            # Refresh pool-side group bits, then hand the tree to the current
-            # slot before running any git command inside the worktree; root's
-            # uid-0 bypass does not bypass git's safe.directory ownership check.
-            _share_git_metadata_with_slots(repo_dir, slot_uid)
-            _provision_runtime_dirs(ws_root)
-            _chown_workspace(ws_root, slot_uid)
-            workspace_prepared = True
-        if not repo_exists:
-            if pr_head is not None:
-                self.transport.fetch_pr_head(repo=repo, pool_dir=pool, pr_number=pr_head)
-                _run(["git", "worktree", "add", "--detach", str(repo_dir), "FETCH_HEAD"], cwd=pool)
-            else:
-                # Make sure the requested start point exists locally (best-effort).
-                # For follow-ups on an existing PR, `existing_branch` is the remote
-                # head branch we need to amend; starting from default would silently
-                # lose the PR's current commits if the local pool branch is absent.
-                self.transport.fetch_base_ref(repo=repo, pool_dir=pool, ref=existing_branch or default_branch)
-                check = _safe_run(["git", "rev-parse", "--verify", f"refs/heads/{branch}"], cwd=pool)
-                if check.returncode == 0:
-                    _run(["git", "worktree", "add", str(repo_dir), branch], cwd=pool)
+            repo_exists = (repo_dir / ".git").exists()
+            workspace_prepared = False
+            slot_git_kwargs = _slot_subprocess_kwargs(slot_uid)
+            slot_git_env: dict[str, str] | None = None
+            if repo_exists:
+                # Existing workspaces are already slot-owned from the previous run.
+                # Refresh pool-side group bits, then hand the tree to the current
+                # slot before running any git command inside the worktree; root's
+                # uid-0 bypass does not bypass git's safe.directory ownership check.
+                _share_git_metadata_with_slots(repo_dir, slot_uid)
+                _provision_runtime_dirs(ws_root)
+                _chown_workspace(ws_root, slot_uid)
+                workspace_prepared = True
+            if not repo_exists:
+                if pr_head is not None:
+                    self.transport.fetch_pr_head(repo=repo, pool_dir=pool, pr_number=pr_head)
+                    _run(["git", "worktree", "add", "--detach", str(repo_dir), "FETCH_HEAD"], cwd=pool)
                 else:
-                    start_point = f"origin/{default_branch}"
-                    if existing_branch:
-                        remote = _safe_run(
-                            ["git", "rev-parse", "--verify", f"refs/remotes/origin/{existing_branch}"],
+                    # Make sure the requested start point exists locally (best-effort).
+                    # For follow-ups on an existing PR, `existing_branch` is the remote
+                    # head branch we need to amend; starting from default would silently
+                    # lose the PR's current commits if the local pool branch is absent.
+                    self.transport.fetch_base_ref(repo=repo, pool_dir=pool, ref=existing_branch or default_branch)
+                    probe = ["git", "rev-parse", "--verify", f"refs/heads/{branch}"]
+                    check = _safe_run(probe, cwd=pool)
+                    if check.returncode == 124:
+                        # A timed-out probe is indeterminate, not "branch absent".
+                        # Falling through would create the worktree from the wrong
+                        # start point; fail instead so the event retries.
+                        raise GitCommandError(probe, check.returncode, check.stdout, check.stderr)
+                    if check.returncode == 0:
+                        _run(["git", "worktree", "add", str(repo_dir), branch], cwd=pool)
+                    else:
+                        start_point = f"origin/{default_branch}"
+                        if existing_branch:
+                            remote_probe = ["git", "rev-parse", "--verify", f"refs/remotes/origin/{existing_branch}"]
+                            remote = _safe_run(remote_probe, cwd=pool)
+                            if remote.returncode == 124:
+                                # Same: an indeterminate probe must not silently fall
+                                # back to origin/default and lose the PR's commits.
+                                raise GitCommandError(remote_probe, remote.returncode, remote.stdout, remote.stderr)
+                            if remote.returncode == 0:
+                                start_point = f"origin/{existing_branch}"
+                        _run(
+                            [
+                                "git",
+                                "worktree",
+                                "add",
+                                "-b",
+                                branch,
+                                str(repo_dir),
+                                start_point,
+                            ],
                             cwd=pool,
                         )
-                        if remote.returncode == 0:
-                            start_point = f"origin/{existing_branch}"
-                    _run(
-                        [
-                            "git",
-                            "worktree",
-                            "add",
-                            "-b",
+            else:
+                slot_git_env = _git_env_for_repo(repo_dir)
+                current = _safe_run(
+                    ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+                    cwd=repo_dir,
+                    env=slot_git_env,
+                    **slot_git_kwargs,
+                )
+                if current.returncode == 0 and current.stdout.strip():
+                    branch = current.stdout.strip()
+                    if existing_branch is not None and existing_branch != branch:
+                        log.warning(
+                            "workspace branch mapping %r differs from checked-out branch %r; using checkout",
+                            existing_branch,
                             branch,
-                            str(repo_dir),
-                            start_point,
-                        ],
-                        cwd=pool,
-                    )
-        else:
-            slot_git_env = _git_env_for_repo(repo_dir)
-            current = _safe_run(
-                ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
-                cwd=repo_dir,
-                env=slot_git_env,
-                **slot_git_kwargs,
-            )
-            if current.returncode == 0 and current.stdout.strip():
-                branch = current.stdout.strip()
-                if existing_branch is not None and existing_branch != branch:
-                    log.warning(
-                        "workspace branch mapping %r differs from checked-out branch %r; using checkout",
-                        existing_branch,
-                        branch,
-                    )
-        if not workspace_prepared:
+                        )
+            if not workspace_prepared:
+                _share_git_metadata_with_slots(repo_dir, slot_uid)
+                _provision_runtime_dirs(ws_root)
+                _chown_workspace(ws_root, slot_uid)
+            if slot_git_env is None:
+                slot_git_env = _git_env_for_repo(repo_dir)
+            # Identity is set on the worktree's shared config; idempotent. Run as
+            # the slot after the chown so git never trips over safe.directory.
+            for command in (["git", "config", "user.email", author_email], ["git", "config", "user.name", author_name]):
+                proc = _safe_run(command, cwd=repo_dir, env=slot_git_env, **slot_git_kwargs)
+                if proc.returncode != 0:
+                    raise GitCommandError(command, proc.returncode, proc.stdout, proc.stderr)
             _share_git_metadata_with_slots(repo_dir, slot_uid)
-            _provision_runtime_dirs(ws_root)
-            _chown_workspace(ws_root, slot_uid)
-        if slot_git_env is None:
-            slot_git_env = _git_env_for_repo(repo_dir)
-        # Identity is set on the worktree's shared config; idempotent. Run as
-        # the slot after the chown so git never trips over safe.directory.
-        for command in (["git", "config", "user.email", author_email], ["git", "config", "user.name", author_name]):
-            proc = _safe_run(command, cwd=repo_dir, env=slot_git_env, **slot_git_kwargs)
-            if proc.returncode != 0:
-                raise GitCommandError(command, proc.returncode, proc.stdout, proc.stderr)
-        _share_git_metadata_with_slots(repo_dir, slot_uid)
-        workspace = Workspace(
-            root=ws_root,
-            repo_dir=repo_dir,
-            session_dir=session_dir,
-            context_dir=context_dir,
-            artifacts_dir=artifacts_dir,
-            branch=branch,
-            repo_full_name=repo,
-            issue_number=number,
-        )
-        # Best-effort: hardlink pre-built natives in if we've cached this
-        # source state before. Runs AFTER the slot chown so the cache inode
-        # keeps its `root:omp` ownership (the slot reads through group `omp`);
-        # write-temp + rename in the napi build replaces with a new inode if
-        # the agent rebuilds, so the cached file is never mutated.
-        self._populate_natives_cache(workspace, slot_uid=slot_uid)
-        return workspace
+            workspace = Workspace(
+                root=ws_root,
+                repo_dir=repo_dir,
+                session_dir=session_dir,
+                context_dir=context_dir,
+                artifacts_dir=artifacts_dir,
+                branch=branch,
+                repo_full_name=repo,
+                issue_number=number,
+            )
+            # Best-effort: hardlink pre-built natives in if we've cached this
+            # source state before. Runs AFTER the slot chown so the cache inode
+            # keeps its `root:omp` ownership (the slot reads through group `omp`);
+            # write-temp + rename in the napi build replaces with a new inode if
+            # the agent rebuilds, so the cached file is never mutated.
+            self._populate_natives_cache(workspace, slot_uid=slot_uid)
+            return workspace
 
     def _populate_natives_cache(self, workspace: Workspace, *, slot_uid: int | None = None) -> None:
         """Try to hardlink cached pi-natives artifacts into the worktree.
@@ -838,7 +890,7 @@ class SandboxManager:
         # produces natives, so creating the dir is correct.
         try:
             key = natives_compute_key(workspace.repo_dir)
-        except (subprocess.CalledProcessError, RuntimeError, OSError) as exc:
+        except (subprocess.SubprocessError, RuntimeError, OSError) as exc:
             log.debug(
                 "natives_cache key compute failed",
                 extra={"workspace": workspace.workspace_key, "err": redact_credentials(str(exc))},
@@ -895,15 +947,22 @@ class SandboxManager:
                 )
 
     def remove_workspace(self, *, repo: str, number: int) -> None:
-        ws_root = self.workspace_root(repo, number)
-        repo_dir = ws_root / "repo"
-        if repo_dir.exists():
-            pool = self.pool_path(repo)
-            _safe_run(["git", "worktree", "remove", "--force", str(repo_dir)], cwd=pool)
+        with self._repo_lock(repo):
+            ws_root = self.workspace_root(repo, number)
+            repo_dir = ws_root / "repo"
             if repo_dir.exists():
-                shutil.rmtree(repo_dir, ignore_errors=True)
-        if ws_root.exists():
-            shutil.rmtree(ws_root, ignore_errors=True)
+                pool = self.pool_path(repo)
+                _safe_run(["git", "worktree", "remove", "--force", str(repo_dir)], cwd=pool)
+                if repo_dir.exists():
+                    # `git worktree remove` did not clean up (nonzero exit, incl. a
+                    # 124 timeout). Delete the checkout ourselves, then prune the
+                    # pool's now-dangling worktree registration so a later
+                    # `git worktree add` for the same path does not trip on stale
+                    # metadata.
+                    shutil.rmtree(repo_dir, ignore_errors=True)
+                    _safe_run(["git", "worktree", "prune"], cwd=pool)
+            if ws_root.exists():
+                shutil.rmtree(ws_root, ignore_errors=True)
 
 
 __all__ = [

--- a/python/robomp/src/tasks.py
+++ b/python/robomp/src/tasks.py
@@ -54,6 +54,12 @@ async def _run_workspace_op(func: Callable[..., _T], /, **kwargs: object) -> _T:
                 continue
             except BaseException:
                 break
+        if not inner.cancelled() and inner.exception() is not None:
+            log.warning(
+                "workspace op %s raised during caller cancellation",
+                getattr(func, "__name__", func),
+                exc_info=inner.exception(),
+            )
         raise
 
 

--- a/python/robomp/src/tasks.py
+++ b/python/robomp/src/tasks.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from collections.abc import Mapping
-from typing import Any
+from collections.abc import Callable, Mapping
+from typing import Any, TypeVar
 
 from robomp import persona
 from robomp.config import Settings
@@ -22,6 +23,38 @@ from robomp.sandbox import GitTransport, SandboxManager
 from robomp.worker import DirectiveInfo, TaskInputs, ThreadMessage, run_task
 
 log = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+
+async def _run_workspace_op(func: Callable[..., _T], /, **kwargs: object) -> _T:
+    """Offload a blocking sandbox workspace op to a worker thread, uncancellably.
+
+    Workspace setup/teardown (git clone/fetch, worktree add/remove, chown) is
+    blocking, so it runs off the event loop via a thread. Unlike a bare
+    ``await asyncio.to_thread(...)``, cancelling the awaiting coroutine here does
+    NOT detach the still-running thread: the thread holds the per-repo lock and
+    owns the slot mid-setup, and ``_run_event``'s ``finally`` reaps/releases that
+    slot on cancellation. If the await detached, the reaped slot could be reused
+    while the thread is still touching it. So on cancellation we drain the thread
+    to completion before propagating, gating the caller's ``finally`` behind the
+    thread. The inner subprocesses are timeout-bounded, so completion is assured.
+    """
+    inner = asyncio.ensure_future(asyncio.to_thread(func, **kwargs))
+    try:
+        return await asyncio.shield(inner)
+    except asyncio.CancelledError:
+        # A repeated cancel can interrupt even a shielded await, so loop until
+        # the thread is actually done; swallow the inner's own outcome and
+        # re-raise the cancellation the caller expects.
+        while not inner.done():
+            try:
+                await asyncio.shield(inner)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+        raise
 
 
 def _comment_from_payload(payload: Mapping[str, Any]) -> CommentInfo:
@@ -267,7 +300,8 @@ async def triage_issue(
             return
     db.upsert_issue(key=key, repo=repo.full_name, number=issue.number, state="reproducing")
     clone_url = repo.clone_url
-    workspace = sandbox.ensure_workspace(
+    workspace = await _run_workspace_op(
+        sandbox.ensure_workspace,
         repo=repo.full_name,
         number=issue.number,
         title=issue.title,
@@ -341,7 +375,8 @@ async def review_pr(
         )
 
     db.upsert_issue(key=key, repo=repo.full_name, number=pr_number, state="reviewing", pr_number=pr_number)
-    workspace = sandbox.ensure_workspace(
+    workspace = await _run_workspace_op(
+        sandbox.ensure_workspace,
         repo=repo.full_name,
         number=pr_number,
         title=issue.title,
@@ -406,7 +441,8 @@ async def handle_comment(
         # first and executes the directive in the same RPC turn.
         log.info("directive bootstrap", extra={"key": key, "author": directive.author})
         db.upsert_issue(key=key, repo=repo.full_name, number=issue.number, state="reproducing")
-        workspace = sandbox.ensure_workspace(
+        workspace = await _run_workspace_op(
+            sandbox.ensure_workspace,
             repo=repo.full_name,
             number=issue.number,
             title=issue.title,
@@ -456,9 +492,10 @@ async def handle_comment(
         # Maintainer reopen: tear down stale workspace, reset state, branch
         # afresh from default. The old branch may have been merged/deleted.
         log.info("directive reopen", extra={"key": key, "from_state": existing.state, "author": directive.author})
-        sandbox.remove_workspace(repo=repo.full_name, number=issue.number)
+        await _run_workspace_op(sandbox.remove_workspace, repo=repo.full_name, number=issue.number)
         db.upsert_issue(key=key, repo=repo.full_name, number=issue.number, state="reproducing")
-        workspace = sandbox.ensure_workspace(
+        workspace = await _run_workspace_op(
+            sandbox.ensure_workspace,
             repo=repo.full_name,
             number=issue.number,
             title=issue.title,
@@ -493,7 +530,8 @@ async def handle_comment(
         await run_task(task_kind="handle_comment", inputs=inputs, comment=comment, directive=directive)
         return
 
-    workspace = sandbox.ensure_workspace(
+    workspace = await _run_workspace_op(
+        sandbox.ensure_workspace,
         repo=repo.full_name,
         number=issue.number,
         title=issue.title,
@@ -567,7 +605,8 @@ async def handle_review(
         log.warning("review fetch failed", extra={"err": str(exc)})
         return
     clone_url = repo.clone_url
-    workspace = sandbox.ensure_workspace(
+    workspace = await _run_workspace_op(
+        sandbox.ensure_workspace,
         repo=repo.full_name,
         number=issue.number,
         title=issue.title,
@@ -677,7 +716,7 @@ async def handle_pr_conversation(
             "directive reopen (pr)",
             extra={"key": issue_row.key, "from_state": issue_row.state, "author": directive.author},
         )
-        sandbox.remove_workspace(repo=issue_row.repo, number=issue_row.number)
+        await _run_workspace_op(sandbox.remove_workspace, repo=issue_row.repo, number=issue_row.number)
         db.upsert_issue(key=issue_row.key, repo=issue_row.repo, number=issue_row.number, state="reproducing")
         issue_row = db.get_issue(issue_row.key) or issue_row
     # Bare @mention with no request body — the route stashes an empty
@@ -713,7 +752,8 @@ async def handle_pr_conversation(
         if existing_branch is None and not (directive and issue_row.state == "reproducing"):
             log.info("skip: pr-conversation PR missing branch mapping", extra={"repo": repo_full, "pr": pr_number})
             return
-    workspace = sandbox.ensure_workspace(
+    workspace = await _run_workspace_op(
+        sandbox.ensure_workspace,
         repo=repo.full_name,
         number=issue.number,
         title=issue.title,
@@ -797,7 +837,7 @@ async def cleanup_workspace(
         issue_row = db.get_issue(issue_key(repo_full, number))
     if issue_row is None:
         return
-    sandbox.remove_workspace(repo=issue_row.repo, number=issue_row.number)
+    await _run_workspace_op(sandbox.remove_workspace, repo=issue_row.repo, number=issue_row.number)
     db.set_issue_state(issue_row.key, target_state)
     log.info("cleanup", extra={"key": issue_row.key, "state": target_state})
 

--- a/python/robomp/tests/test_sandbox.py
+++ b/python/robomp/tests/test_sandbox.py
@@ -24,6 +24,7 @@ from robomp.git_ops import (
     fetch_ref as git_fetch_ref,
 )
 from robomp.sandbox import (
+    _DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT,
     SandboxManager,
     Workspace,
     _chown_workspace,
@@ -508,10 +509,12 @@ def test_chown_workspace_runs_chown_and_chmod_as_root_on_linux(tmp_path: Path, m
 
     monkeypatch.setattr("robomp.sandbox.platform.system", lambda: "Linux")
     monkeypatch.setattr("robomp.sandbox.os.geteuid", lambda: 0)
-    monkeypatch.setattr(
-        "robomp.sandbox.subprocess.run",
-        lambda cmd, *, check, timeout=None: calls.append((cmd, check)),
-    )
+
+    def fake_run(cmd, *, check, timeout):
+        assert timeout == _DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT
+        calls.append((cmd, check))
+
+    monkeypatch.setattr("robomp.sandbox.subprocess.run", fake_run)
 
     _chown_workspace(tmp_path, 2001)
 
@@ -532,8 +535,9 @@ def test_chown_workspace_makes_workspace_slot_owned(tmp_path: Path, monkeypatch:
     file_path.chmod(0o777)
     owned: dict[Path, tuple[int, int]] = {}
 
-    def fake_run(cmd: list[str], *, check: bool, timeout: float | None = None) -> None:
+    def fake_run(cmd: list[str], *, check: bool, timeout: float) -> None:
         assert check
+        assert timeout == _DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT
         if cmd[:2] == ["chown", "-R"]:
             uid_text, gid_text = cmd[2].split(":", 1)
             root = Path(cmd[3])
@@ -1916,6 +1920,48 @@ def test_ensure_workspace_raises_when_remote_branch_probe_times_out(tmp_path: Pa
     monkeypatch.setattr("robomp.sandbox._chown_workspace", lambda *a, **k: None)
     monkeypatch.setattr("robomp.sandbox._share_git_metadata_with_slots", lambda *a, **k: None)
     monkeypatch.setattr("robomp.sandbox._provision_runtime_dirs", lambda *a, **k: None)
+
+    with pytest.raises(GitCommandError):
+        mgr.ensure_workspace(
+            repo="o/r",
+            number=1,
+            title="t",
+            clone_url="https://x/o/r.git",
+            default_branch="main",
+            author_name="n",
+            author_email="e@e",
+            existing_branch="feature/x",
+            slot_uid=None,
+        )
+
+
+def test_ensure_workspace_raises_when_symbolic_ref_probe_times_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mgr = SandboxManager(tmp_path)
+    mgr.natives_cache = None
+    mgr.transport = SimpleNamespace(
+        clone_pool=lambda **k: None,
+        fetch_pool=lambda **k: None,
+        fetch_base_ref=lambda **k: None,
+        fetch_pr_head=lambda **k: None,
+    )  # type: ignore
+
+    # Force the repo_exists=True branch: the worktree already has a .git.
+    repo_dir = mgr.workspace_root("o/r", 1) / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["git", "symbolic-ref"]:
+            return subprocess.CompletedProcess(cmd, 124, "", "timed out")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+    monkeypatch.setattr("robomp.sandbox._run", lambda *a, **k: subprocess.CompletedProcess(["x"], 0, "", ""))
+    monkeypatch.setattr("robomp.sandbox._chown_workspace", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._share_git_metadata_with_slots", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._provision_runtime_dirs", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._git_env_for_repo", lambda *a, **k: {})
 
     with pytest.raises(GitCommandError):
         mgr.ensure_workspace(

--- a/python/robomp/tests/test_sandbox.py
+++ b/python/robomp/tests/test_sandbox.py
@@ -1117,6 +1117,8 @@ def test_remove_workspace_prunes_pool_after_failed_worktree_remove(tmp_path: Pat
     repo_dir = ws_root / "repo"
     repo_dir.mkdir(parents=True, exist_ok=True)
     pool = mgr.pool_path("o/r")
+    pool.mkdir(parents=True, exist_ok=True)
+    (pool / ".git").mkdir(exist_ok=True)  # mark as a real git pool for the cleanup gate
 
     calls: list[tuple[list[str], object]] = []
 
@@ -1158,6 +1160,8 @@ def test_remove_workspace_prunes_when_failed_remove_already_deleted_checkout(
     repo_dir = ws_root / "repo"
     repo_dir.mkdir(parents=True, exist_ok=True)
     pool = mgr.pool_path("o/r")
+    pool.mkdir(parents=True, exist_ok=True)
+    (pool / ".git").mkdir(exist_ok=True)  # mark as a real git pool for the cleanup gate
 
     calls: list[tuple[list[str], object]] = []
 
@@ -1877,19 +1881,26 @@ def test_remove_workspace_acquires_repo_lock(tmp_path: Path, monkeypatch: pytest
 def test_safe_run_timeout_returns_124(monkeypatch: pytest.MonkeyPatch) -> None:
     import robomp.sandbox as s
 
+    seen: dict[str, object] = {}
+
     def boom(*a: object, **k: object) -> subprocess.CompletedProcess:
+        seen["timeout"] = k.get("timeout")
         cmd = a[0] if a else k.get("args", ["git"])
         raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)  # type: ignore
 
     monkeypatch.setattr("robomp.sandbox.subprocess.run", boom)
     r = s._safe_run(["git", "status"])
     assert r.returncode == 124
+    assert seen["timeout"] == s._DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT
 
 
 def test_run_timeout_raises_git_command_error_124(monkeypatch: pytest.MonkeyPatch) -> None:
     import robomp.sandbox as s
 
+    seen: dict[str, object] = {}
+
     def boom(*a: object, **k: object) -> subprocess.CompletedProcess:
+        seen["timeout"] = k.get("timeout")
         cmd = a[0] if a else k.get("args", ["git"])
         raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)  # type: ignore
 
@@ -1897,6 +1908,7 @@ def test_run_timeout_raises_git_command_error_124(monkeypatch: pytest.MonkeyPatc
     with pytest.raises(s.GitCommandError) as exc:
         s._run(["git", "status"])
     assert exc.value.returncode == 124
+    assert seen["timeout"] == s._DEFAULT_SANDBOX_SUBPROCESS_TIMEOUT
 
 
 def test_ensure_workspace_raises_when_local_branch_probe_times_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2011,3 +2023,286 @@ def test_ensure_workspace_raises_when_symbolic_ref_probe_times_out(
             existing_branch="feature/x",
             slot_uid=None,
         )
+
+
+def test_remove_workspace_real_prune_clears_dangling_registration(
+    tmp_path: Path, upstream_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Integration guard: the other prune tests fully mock `_safe_run`, so the
+    # REAL `git worktree prune` never runs and the stale-metadata risk this
+    # patch targets is not actually exercised. Here we build a real workspace
+    # (real pool clone + real worktree registration), fake ONLY the
+    # `git worktree remove` to "time out" (124), and let the real rmtree+prune
+    # run. The dangling registration must actually be gone afterward, and a
+    # fresh add at the same path must succeed — the real integration risk.
+    import robomp.sandbox as s
+
+    mgr = SandboxManager(tmp_path / "workspaces")
+    ws = mgr.ensure_workspace(
+        repo="octo/widget",
+        number=21,
+        title="t",
+        clone_url=str(upstream_repo),
+        default_branch="main",
+        author_name="robomp-bot",
+        author_email="robomp-bot@example.invalid",
+    )
+    pool = mgr.pool_path("octo/widget")
+    repo_dir = ws.repo_dir
+    assert repo_dir.exists()
+    listed = subprocess.run(
+        ["git", "-C", str(pool), "worktree", "list", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert str(repo_dir) in listed  # sanity: registration exists
+
+    real_safe_run = s._safe_run
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            # A remove that "times out" without unregistering — the source must
+            # then rmtree the checkout and run the REAL prune to clear metadata.
+            return subprocess.CompletedProcess(cmd, 124, "", "timed out")
+        return real_safe_run(cmd, **k)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    mgr.remove_workspace(repo="octo/widget", number=21)
+
+    listed_after = subprocess.run(
+        ["git", "-C", str(pool), "worktree", "list", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert str(repo_dir) not in listed_after, listed_after
+    # The path is genuinely reusable again — the actual failure the fix prevents.
+    subprocess.run(
+        ["git", "-C", str(pool), "worktree", "add", "--detach", str(repo_dir), "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert repo_dir.exists()
+
+
+def test_worktree_add_cleans_partial_state_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A `git worktree add` killed mid-op (124) or otherwise failing must leave no
+    # partial checkout and no dangling registration, or the event retry poisons
+    # itself on the same path.
+    import robomp.sandbox as s
+
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    repo_dir = tmp_path / "ws" / "repo"
+    repo_dir.mkdir(parents=True)
+    (repo_dir / "leftover").write_text("partial", encoding="utf-8")
+
+    def boom_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        raise s.GitCommandError(cmd, 124, "", "timed out")
+
+    pruned: list[list[str]] = []
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        pruned.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._run", boom_run)
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    with pytest.raises(GitCommandError) as exc:
+        s._worktree_add(["git", "worktree", "add", str(repo_dir), "main"], pool=pool, repo_dir=repo_dir)
+
+    assert exc.value.returncode == 124  # the original add failure is surfaced
+    assert not repo_dir.exists()  # partial checkout removed
+    assert ["git", "worktree", "prune"] in pruned  # pool pruned
+
+
+def test_worktree_add_raises_prune_failure_chained_from_add_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # If the cleanup prune ALSO fails, that failure must be raised (a dangling
+    # registration left behind is what poisons the retry) — chained from the
+    # original add error so the root cause is not lost.
+    import robomp.sandbox as s
+
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    repo_dir = tmp_path / "ws" / "repo"
+    repo_dir.mkdir(parents=True)
+
+    add_err = s.GitCommandError(["git", "worktree", "add"], 1, "", "add failed")
+
+    def boom_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        raise add_err
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 124, "", "prune timed out")
+
+    monkeypatch.setattr("robomp.sandbox._run", boom_run)
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    with pytest.raises(GitCommandError) as exc:
+        s._worktree_add(["git", "worktree", "add", str(repo_dir), "main"], pool=pool, repo_dir=repo_dir)
+
+    assert exc.value.returncode == 124  # the PRUNE failure (124), not the add (1)
+    assert exc.value.__cause__ is add_err  # chained from the add error
+
+
+def test_ensure_clone_fails_before_fetch_when_origin_probe_times_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An older deploy may have baked `https://user:pass@…` into origin;
+    # `_reset_origin_url` rewrites it before fetch so the PAT never persists. A
+    # timed-out `git remote get-url origin` (124) is indeterminate — ensure_clone
+    # must fail closed BEFORE fetch_pool rather than fetch against a possibly-
+    # credentialed origin.
+    mgr = SandboxManager(tmp_path / "workspaces")
+    pool = mgr.pool_path("octo/widget")
+    (pool / ".git").mkdir(parents=True)  # take the idempotent-refresh path
+
+    fetched = {"called": False}
+    mgr.transport = SimpleNamespace(
+        fetch_pool=lambda **k: fetched.__setitem__("called", True),
+        clone_pool=lambda **k: None,
+    )  # type: ignore
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:4] == ["git", "remote", "get-url", "origin"]:
+            return subprocess.CompletedProcess(cmd, 124, "", "timed out")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    with pytest.raises(GitCommandError):
+        mgr.ensure_clone(repo="octo/widget", clone_url="https://github.com/octo/widget.git", default_branch="main")
+    assert fetched["called"] is False, (
+        "fetch_pool ran despite an indeterminate origin probe — a legacy credential could persist and be reused"
+    )
+
+
+def test_remove_workspace_raises_when_prune_times_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # After a failed `git worktree remove`, `git worktree prune` is the step that
+    # clears the dangling registration. If prune ITSELF fails (incl. a 124
+    # timeout), remove_workspace must raise so the cleanup event retries — not
+    # record success while stale metadata still blocks the next add.
+    mgr = SandboxManager(tmp_path)
+    ws_root = mgr.workspace_root("o/r", 31)
+    repo_dir = ws_root / "repo"
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    pool = mgr.pool_path("o/r")
+    pool.mkdir(parents=True, exist_ok=True)
+    (pool / ".git").mkdir(exist_ok=True)  # mark as a real git pool for the cleanup gate
+
+    calls: list[list[str]] = []
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            # Distinct code (1, NOT 124) so the assertion below proves the raised
+            # error came from PRUNE, not from the remove failure.
+            return subprocess.CompletedProcess(cmd, 1, "", "remove failed")
+        if cmd[:3] == ["git", "worktree", "prune"]:
+            return subprocess.CompletedProcess(cmd, 124, "", "prune timed out")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    with pytest.raises(GitCommandError) as exc:
+        mgr.remove_workspace(repo="o/r", number=31)
+    # Prune actually ran, and the surfaced error is prune's (124) — not remove's (1).
+    assert ["git", "worktree", "prune"] in calls, "prune did not run after a failed remove"
+    assert exc.value.returncode == 124
+
+
+def test_remove_workspace_prunes_when_checkout_already_gone_on_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A prior remove/worktree-add killed mid-flight can leave the checkout gone
+    # but the pool's worktree registration dangling. On the NEXT remove_workspace
+    # the checkout is already missing on entry, yet the stale registration must
+    # still be pruned — the old `if repo_dir.exists()` guard skipped it entirely.
+    mgr = SandboxManager(tmp_path)
+    ws_root = mgr.workspace_root("o/r", 33)
+    repo_dir = ws_root / "repo"
+    ws_root.mkdir(parents=True, exist_ok=True)  # ws_root present, but NO repo_dir
+    pool = mgr.pool_path("o/r")
+    pool.mkdir(parents=True, exist_ok=True)
+    (pool / ".git").mkdir(exist_ok=True)  # mark as a real git pool for the cleanup gate
+    assert not repo_dir.exists()  # precondition: checkout already gone
+
+    calls: list[list[str]] = []
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    mgr.remove_workspace(repo="o/r", number=33)
+
+    # No `git worktree remove` (nothing to remove), but prune MUST run to clear
+    # any dangling registration for the missing path.
+    assert ["git", "worktree", "prune"] in calls, (
+        "prune was skipped for a checkout already gone on entry — dangling registration would persist"
+    )
+    assert not any(c[:3] == ["git", "worktree", "remove"] for c in calls)
+    assert not ws_root.exists()  # ws_root still cleaned up
+
+
+def test_remove_workspace_no_git_ops_when_pool_is_not_a_real_clone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `ensure_clone` mkdir's the pool dir BEFORE cloning, so a failed first clone
+    # can leave a non-git dir at pool_path. A later remove_workspace (e.g. on
+    # reopen) must NOT run `git worktree prune` there — it would error on a
+    # non-git dir and raise. It must be a clean no-op that still clears ws_root.
+    mgr = SandboxManager(tmp_path)
+    ws_root = mgr.workspace_root("o/r", 41)
+    ws_root.mkdir(parents=True, exist_ok=True)
+    pool = mgr.pool_path("o/r")
+    pool.mkdir(parents=True, exist_ok=True)  # exists but is NOT a git repo (no .git/HEAD)
+
+    calls: list[list[str]] = []
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 128, "", "not a git repository")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    # Must NOT raise despite the pool dir existing.
+    mgr.remove_workspace(repo="o/r", number=41)
+
+    assert calls == [], "ran git in a non-git pool dir — would error and raise on cleanup"
+    assert not ws_root.exists()  # ws_root still cleaned up
+
+
+def test_remove_workspace_skips_prune_on_repeat_close_after_full_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A fully-cleaned workspace has no ws_root. A duplicate/repeat close (GitHub
+    # can redeliver a close webhook) must NOT run a speculative `git worktree
+    # prune` on the shared pool every time — there is no dangling registration
+    # once the first cleanup succeeded. Guarded by `ws_root.exists()`.
+    mgr = SandboxManager(tmp_path)
+    ws_root = mgr.workspace_root("o/r", 43)
+    repo_dir = ws_root / "repo"
+    pool = mgr.pool_path("o/r")
+    pool.mkdir(parents=True, exist_ok=True)
+    (pool / ".git").mkdir(exist_ok=True)  # a REAL git pool (persists across closes)
+    assert not ws_root.exists() and not repo_dir.exists()  # already fully cleaned
+
+    calls: list[list[str]] = []
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    mgr.remove_workspace(repo="o/r", number=43)
+
+    assert calls == [], "repeat close ran a spurious git worktree prune on an already-clean workspace"

--- a/python/robomp/tests/test_sandbox.py
+++ b/python/robomp/tests/test_sandbox.py
@@ -1145,6 +1145,42 @@ def test_remove_workspace_prunes_pool_after_failed_worktree_remove(tmp_path: Pat
     # The real checkout dir was cleaned up.
     assert not repo_dir.exists()
 
+
+def test_remove_workspace_prunes_when_failed_remove_already_deleted_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The reviewer's case: `git worktree remove` deletes the checkout dir but is
+    # killed (124) before clearing the pool's worktree registration. `repo_dir`
+    # is gone by the time we check, so a guard on `repo_dir.exists()` would skip
+    # the prune and leave dangling metadata; guarding on the return code must not.
+    mgr = SandboxManager(tmp_path)
+    ws_root = mgr.workspace_root("o/r", 9)
+    repo_dir = ws_root / "repo"
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    pool = mgr.pool_path("o/r")
+
+    calls: list[tuple[list[str], object]] = []
+
+    def fake_safe_run(cmd, **k):
+        calls.append((list(cmd), k.get("cwd")))
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            # Simulate git deleting the checkout, then dying before it could
+            # unregister the worktree from the pool.
+            repo_dir.rmdir()
+            return subprocess.CompletedProcess(cmd, 124, "", "timed out")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    mgr.remove_workspace(repo="o/r", number=9)
+
+    cmds = [c for c, _ in calls]
+    assert ["git", "worktree", "prune"] in cmds, (
+        "prune was skipped after a failed remove that had already deleted the checkout"
+    )
+    prune_idx = next(i for i, (c, _) in enumerate(calls) if c == ["git", "worktree", "prune"])
+    assert calls[prune_idx][1] == pool, "prune did not run in the repo's pool dir"
+
 def test_redact_credentials_strips_userinfo() -> None:
     from robomp.sandbox import redact_credentials
 

--- a/python/robomp/tests/test_sandbox.py
+++ b/python/robomp/tests/test_sandbox.py
@@ -5,7 +5,9 @@ import platform
 import signal
 import stat
 import subprocess
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -508,7 +510,7 @@ def test_chown_workspace_runs_chown_and_chmod_as_root_on_linux(tmp_path: Path, m
     monkeypatch.setattr("robomp.sandbox.os.geteuid", lambda: 0)
     monkeypatch.setattr(
         "robomp.sandbox.subprocess.run",
-        lambda cmd, *, check: calls.append((cmd, check)),
+        lambda cmd, *, check, timeout=None: calls.append((cmd, check)),
     )
 
     _chown_workspace(tmp_path, 2001)
@@ -530,7 +532,7 @@ def test_chown_workspace_makes_workspace_slot_owned(tmp_path: Path, monkeypatch:
     file_path.chmod(0o777)
     owned: dict[Path, tuple[int, int]] = {}
 
-    def fake_run(cmd: list[str], *, check: bool) -> None:
+    def fake_run(cmd: list[str], *, check: bool, timeout: float | None = None) -> None:
         assert check
         if cmd[:2] == ["chown", "-R"]:
             uid_text, gid_text = cmd[2].split(":", 1)
@@ -1104,6 +1106,41 @@ def test_remove_workspace(tmp_path: Path, upstream_repo: Path) -> None:
     assert not ws.root.exists()
 
 
+def test_remove_workspace_prunes_pool_after_failed_worktree_remove(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr = SandboxManager(tmp_path)
+    # Create a real repo_dir on disk so `repo_dir.exists()` is True on entry.
+    ws_root = mgr.workspace_root("o/r", 7)
+    repo_dir = ws_root / "repo"
+    repo_dir.mkdir(parents=True, exist_ok=True)
+    pool = mgr.pool_path("o/r")
+
+    calls: list[tuple[list[str], object]] = []
+
+    def fake_safe_run(cmd, **k):
+        calls.append((list(cmd), k.get("cwd")))
+        # The `worktree remove` "times out" (124) and does NOT delete repo_dir,
+        # so the code must fall back to rmtree + prune. `prune` succeeds (0).
+        if cmd[:3] == ["git", "worktree", "remove"]:
+            return subprocess.CompletedProcess(cmd, 124, "", "timed out")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+
+    mgr.remove_workspace(repo="o/r", number=7)
+
+    cmds = [c for c, _ in calls]
+    # The dangling registration must have been pruned, in the correct pool.
+    assert ["git", "worktree", "prune"] in cmds, (
+        "remove_workspace did not prune pool metadata after a failed worktree remove"
+    )
+    prune_idx = next(i for i, (c, _) in enumerate(calls) if c == ["git", "worktree", "prune"])
+    assert calls[prune_idx][1] == pool, "prune did not run in the repo's pool dir"
+    # And the remove was attempted first (ordering: remove before prune).
+    remove_idx = next(i for i, (c, _) in enumerate(calls) if c[:3] == ["git", "worktree", "remove"])
+    assert remove_idx < prune_idx
+    # The real checkout dir was cleaned up.
+    assert not repo_dir.exists()
+
 def test_redact_credentials_strips_userinfo() -> None:
     from robomp.sandbox import redact_credentials
 
@@ -1301,9 +1338,7 @@ def test_run_git_injects_safe_directory_and_subprocess_identity(
     assert captured["umask"] == 0o002
 
 
-def test_run_git_scopes_token_and_scrubs_parent_auth_env(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_git_scopes_token_and_scrubs_parent_auth_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from robomp.git_ops import AUTH_ENV_VAR, _run_git
 
     captured: dict[str, object] = {}
@@ -1649,3 +1684,248 @@ def test_ensure_workspace_cache_miss_is_silent_noop(tmp_path: Path, upstream_rep
     # Cache is empty so the workspace ends up identical to the no-cache case.
     assert ws.repo_dir.is_dir()
     assert not (ws.repo_dir / "packages" / "natives" / "native").exists()
+
+
+def test_repo_lock_is_per_repo_identity(tmp_path: Path) -> None:
+    mgr = SandboxManager(tmp_path)
+    assert mgr._repo_lock("o/r") is mgr._repo_lock("o/r")
+    assert mgr._repo_lock("o/r") is not mgr._repo_lock("o/r2")
+
+
+def test_repo_lock_serializes_same_repo(tmp_path: Path) -> None:
+    # Deterministic: while one thread holds the repo lock, a probe from a
+    # DIFFERENT thread must fail to acquire the SAME repo's lock non-blockingly.
+    mgr = SandboxManager(tmp_path)
+    held = threading.Event()
+    release = threading.Event()
+    probe_result: dict[str, bool] = {}
+
+    def holder() -> None:
+        with mgr._repo_lock("o/r"):
+            held.set()
+            assert release.wait(2.0), "probe never completed"
+
+    def probe() -> None:
+        assert held.wait(2.0), "holder never acquired the lock"
+        lock = mgr._repo_lock("o/r")
+        got = lock.acquire(blocking=False)
+        probe_result["acquired"] = got
+        if got:
+            lock.release()
+        release.set()
+
+    th = threading.Thread(target=holder)
+    tp = threading.Thread(target=probe)
+    th.start()
+    tp.start()
+    th.join(3.0)
+    tp.join(3.0)
+    # Same repo, held cross-thread -> non-blocking acquire MUST fail.
+    assert probe_result.get("acquired") is False, (
+        "same-repo lock was acquirable from another thread while held (did not serialize)"
+    )
+
+
+def test_repo_lock_allows_distinct_repos_to_overlap(tmp_path: Path) -> None:
+    # Deterministic: holding one repo's lock must NOT block acquiring a
+    # DIFFERENT repo's lock from another thread.
+    mgr = SandboxManager(tmp_path)
+    held = threading.Event()
+    release = threading.Event()
+    probe_result: dict[str, bool] = {}
+
+    def holder() -> None:
+        with mgr._repo_lock("o/a"):
+            held.set()
+            assert release.wait(2.0), "probe never completed"
+
+    def probe() -> None:
+        assert held.wait(2.0), "holder never acquired the lock"
+        lock = mgr._repo_lock("o/b")
+        got = lock.acquire(blocking=False)
+        probe_result["acquired"] = got
+        if got:
+            lock.release()
+        release.set()
+
+    th = threading.Thread(target=holder)
+    tp = threading.Thread(target=probe)
+    th.start()
+    tp.start()
+    th.join(3.0)
+    tp.join(3.0)
+    # Distinct repos -> the other lock is free -> non-blocking acquire succeeds.
+    assert probe_result.get("acquired") is True, (
+        "distinct-repo lock was NOT acquirable while an unrelated repo's lock was held"
+    )
+
+
+def test_ensure_workspace_acquires_repo_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr = SandboxManager(tmp_path)
+    mgr.natives_cache = None
+    real = threading.RLock()
+    events: list[str | tuple[str, str]] = []
+
+    class Rec:
+        def __enter__(self) -> Rec:
+            events.append("acquire")
+            real.acquire()
+            return self
+
+        def __exit__(self, *a: object) -> bool:
+            real.release()
+            events.append("release")
+            return False
+
+    def fake_lock(repo: str) -> Rec:
+        events.append(("lock", repo))
+        return Rec()
+
+    monkeypatch.setattr(mgr, "_repo_lock", fake_lock)
+    mgr.transport = SimpleNamespace(
+        clone_pool=lambda **k: None,
+        fetch_pool=lambda **k: None,
+        fetch_base_ref=lambda **k: None,
+        fetch_pr_head=lambda **k: None,
+    )  # type: ignore
+    ok = subprocess.CompletedProcess(["x"], 0, "", "")
+    monkeypatch.setattr("robomp.sandbox._run", lambda *a, **k: ok)
+    monkeypatch.setattr("robomp.sandbox._safe_run", lambda *a, **k: ok)
+    monkeypatch.setattr("robomp.sandbox._chown_workspace", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._share_git_metadata_with_slots", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._provision_runtime_dirs", lambda *a, **k: None)
+
+    ws = mgr.ensure_workspace(
+        repo="o/r",
+        number=1,
+        title="t",
+        clone_url="https://x/o/r.git",
+        default_branch="main",
+        author_name="n",
+        author_email="e@e",
+        slot_uid=None,
+    )
+    assert ("lock", "o/r") in events
+    assert events.count("acquire") == 1
+    assert events.count("release") == 1
+    assert ws.repo_full_name == "o/r"
+
+
+def test_remove_workspace_acquires_repo_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr = SandboxManager(tmp_path)
+    events: list[str | tuple[str, str]] = []
+    real = threading.RLock()
+
+    class Rec:
+        def __enter__(self) -> Rec:
+            events.append("acquire")
+            real.acquire()
+            return self
+
+        def __exit__(self, *a: object) -> bool:
+            real.release()
+            events.append("release")
+            return False
+
+    monkeypatch.setattr(mgr, "_repo_lock", lambda repo: (events.append(("lock", repo)), Rec())[1])
+    # ws_root does not exist -> remove_workspace just no-ops inside the lock
+    mgr.remove_workspace(repo="o/r", number=99)
+    assert ("lock", "o/r") in events
+    assert events.count("acquire") == 1 and events.count("release") == 1
+
+
+def test_safe_run_timeout_returns_124(monkeypatch: pytest.MonkeyPatch) -> None:
+    import robomp.sandbox as s
+
+    def boom(*a: object, **k: object) -> subprocess.CompletedProcess:
+        cmd = a[0] if a else k.get("args", ["git"])
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)  # type: ignore
+
+    monkeypatch.setattr("robomp.sandbox.subprocess.run", boom)
+    r = s._safe_run(["git", "status"])
+    assert r.returncode == 124
+
+
+def test_run_timeout_raises_git_command_error_124(monkeypatch: pytest.MonkeyPatch) -> None:
+    import robomp.sandbox as s
+
+    def boom(*a: object, **k: object) -> subprocess.CompletedProcess:
+        cmd = a[0] if a else k.get("args", ["git"])
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)  # type: ignore
+
+    monkeypatch.setattr("robomp.sandbox.subprocess.run", boom)
+    with pytest.raises(s.GitCommandError) as exc:
+        s._run(["git", "status"])
+    assert exc.value.returncode == 124
+
+
+def test_ensure_workspace_raises_when_local_branch_probe_times_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr = SandboxManager(tmp_path)
+    mgr.natives_cache = None
+    mgr.transport = SimpleNamespace(
+        clone_pool=lambda **k: None,
+        fetch_pool=lambda **k: None,
+        fetch_base_ref=lambda **k: None,
+        fetch_pr_head=lambda **k: None,
+    )  # type: ignore
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in cmd and cmd[-1].startswith("refs/heads/"):
+            return subprocess.CompletedProcess(cmd, 124, "", "timed out")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+    monkeypatch.setattr("robomp.sandbox._run", lambda *a, **k: subprocess.CompletedProcess(["x"], 0, "", ""))
+    monkeypatch.setattr("robomp.sandbox._chown_workspace", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._share_git_metadata_with_slots", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._provision_runtime_dirs", lambda *a, **k: None)
+
+    with pytest.raises(GitCommandError):
+        mgr.ensure_workspace(
+            repo="o/r",
+            number=1,
+            title="t",
+            clone_url="https://x/o/r.git",
+            default_branch="main",
+            author_name="n",
+            author_email="e@e",
+            existing_branch="feature/x",
+            slot_uid=None,
+        )
+
+
+def test_ensure_workspace_raises_when_remote_branch_probe_times_out(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr = SandboxManager(tmp_path)
+    mgr.natives_cache = None
+    mgr.transport = SimpleNamespace(
+        clone_pool=lambda **k: None,
+        fetch_pool=lambda **k: None,
+        fetch_base_ref=lambda **k: None,
+        fetch_pr_head=lambda **k: None,
+    )  # type: ignore
+
+    def fake_safe_run(cmd: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in cmd and cmd[-1].startswith("refs/heads/"):
+            return subprocess.CompletedProcess(cmd, 128, "", "")
+        if "rev-parse" in cmd and cmd[-1].startswith("refs/remotes/origin/"):
+            return subprocess.CompletedProcess(cmd, 124, "", "timed out")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("robomp.sandbox._safe_run", fake_safe_run)
+    monkeypatch.setattr("robomp.sandbox._run", lambda *a, **k: subprocess.CompletedProcess(["x"], 0, "", ""))
+    monkeypatch.setattr("robomp.sandbox._chown_workspace", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._share_git_metadata_with_slots", lambda *a, **k: None)
+    monkeypatch.setattr("robomp.sandbox._provision_runtime_dirs", lambda *a, **k: None)
+
+    with pytest.raises(GitCommandError):
+        mgr.ensure_workspace(
+            repo="o/r",
+            number=1,
+            title="t",
+            clone_url="https://x/o/r.git",
+            default_branch="main",
+            author_name="n",
+            author_email="e@e",
+            existing_branch="feature/x",
+            slot_uid=None,
+        )

--- a/python/robomp/tests/test_tasks.py
+++ b/python/robomp/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import threading
 from types import SimpleNamespace
 
@@ -121,3 +122,37 @@ async def test_run_workspace_op_drains_thread_before_propagating_cancel():
         await task
     # Deterministic in the fixed helper: the thread completed before the cancel propagated.
     assert finished.is_set(), "thread did not complete before cancellation propagated"
+
+
+async def test_run_workspace_op_logs_worker_exception_on_concurrent_cancel(caplog):
+    started = threading.Event()
+    proceed = threading.Event()
+    boom = RuntimeError("git exploded")
+
+    def failing_op(**_kwargs):
+        started.set()
+        assert proceed.wait(2.0), "proceed was never set — test bug"
+        raise boom
+
+    task = asyncio.create_task(tasks._run_workspace_op(failing_op))
+    await asyncio.to_thread(started.wait, 1.0)
+    assert started.is_set()
+
+    # Cancel the caller while the worker is still blocked (mid-flight), so the
+    # helper enters its cancel-drain loop and is awaiting the shielded inner.
+    task.cancel()
+    await asyncio.sleep(0.05)
+
+    with caplog.at_level(logging.WARNING, logger="robomp.tasks"):
+        # Release the worker so inner completes WITH an exception while the
+        # helper is draining -> the drain's `await shield(inner)` re-raises boom,
+        # breaks the loop, and the guarded log.warning must fire.
+        proceed.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "worker exception during cancel was not logged"
+    assert any(r.exc_info and r.exc_info[1] is boom for r in warnings), (
+        "the worker's exception was not attached to the warning"
+    )

--- a/python/robomp/tests/test_tasks.py
+++ b/python/robomp/tests/test_tasks.py
@@ -1,0 +1,123 @@
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from robomp import tasks
+from robomp.github_client import IssueInfo, RepoInfo
+
+
+async def test_triage_issue_keeps_event_loop_live_while_workspace_setup_blocks(db, settings, monkeypatch, tmp_path):
+    async def _resolve_repo_and_issue(_github, _payload):
+        repo = RepoInfo(
+            full_name="octo/widget",
+            default_branch="main",
+            clone_url="https://x/octo/widget.git",
+            private=False,
+        )
+        issue = IssueInfo(
+            repo="octo/widget",
+            number=1,
+            title="bug",
+            body="b",
+            state="open",
+            author="alice",
+            labels=(),
+            is_pull_request=False,
+        )
+        return repo, issue
+
+    monkeypatch.setattr(tasks, "_resolve_repo_and_issue", _resolve_repo_and_issue)
+
+    async def _no_closing(*a, **k):
+        return ()
+
+    github = SimpleNamespace(list_closing_pull_requests=_no_closing)
+
+    entered = threading.Event()
+    release = threading.Event()
+    captured: dict[str, object] = {}
+
+    def _blocking_ensure(**_kwargs):
+        entered.set()
+        # True ONLY if a concurrent coroutine set `release` while we blocked here.
+        # Blocks a WORKER THREAD (via to_thread) in the fixed code; blocks the
+        # LOOP itself in the broken code.
+        captured["release_seen_in_time"] = release.wait(1.0)
+        return SimpleNamespace(branch="farm/x/y", session_dir=str(tmp_path / "sess"))
+
+    sandbox = SimpleNamespace(natives_cache=None, ensure_workspace=_blocking_ensure)
+
+    async def _noop_run_task(**_kwargs):
+        return None
+
+    monkeypatch.setattr(tasks, "run_task", _noop_run_task)
+
+    async def _releaser():
+        # Waits (off-loop) until ensure_workspace has actually started, then
+        # releases it. This coroutine can ONLY make progress if the event loop
+        # is live while ensure_workspace is blocking.
+        await asyncio.to_thread(entered.wait, 1.0)
+        assert entered.is_set(), "ensure_workspace never started"
+        release.set()
+
+    triage_task = asyncio.create_task(
+        tasks.triage_issue(
+            settings=settings,
+            db=db,
+            github=github,
+            sandbox=sandbox,
+            git_transport=SimpleNamespace(),
+            payload={},
+            delivery_id="d1",
+        )
+    )
+    releaser_task = asyncio.create_task(_releaser())
+
+    await asyncio.wait_for(triage_task, timeout=3.0)
+    await asyncio.wait_for(releaser_task, timeout=1.0)
+
+    assert captured.get("release_seen_in_time") is True, (
+        "event loop was frozen during ensure_workspace: the concurrent releaser "
+        "could not run, so release.wait timed out (this is the pre-fix hang)"
+    )
+
+
+async def test_run_workspace_op_drains_thread_before_propagating_cancel():
+    started = threading.Event()
+    proceed = threading.Event()
+    finished = threading.Event()
+
+    def slow_op(**_kwargs):
+        started.set()
+        # Block on the worker thread until the test releases us.
+        assert proceed.wait(2.0), "proceed was never set — test bug"
+        finished.set()
+        return "done"
+
+    task = asyncio.create_task(tasks._run_workspace_op(slow_op))
+    # Wait (off-loop) until the worker thread is actually running.
+    await asyncio.to_thread(started.wait, 1.0)
+    assert started.is_set()
+
+    # Cancel the AWAITING coroutine while the thread is mid-flight.
+    task.cancel()
+    # Let the loop deliver the cancellation into the helper's drain loop.
+    await asyncio.sleep(0.05)
+
+    try:
+        # The thread must NOT have been abandoned: it is still blocked on
+        # `proceed`, so `finished` is not set and the task has not resolved yet.
+        assert not finished.is_set(), "thread finished before we released it — impossible unless abandoned"
+        assert not task.done(), "helper propagated cancel before the thread completed (thread abandoned)"
+    finally:
+        # Always release the worker, even if an assert above fails, so a failed
+        # run cannot leave a blocked thread leaking into later tests.
+        proceed.set()
+
+    # The helper must now let the thread finish, THEN raise CancelledError.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # Deterministic in the fixed helper: the thread completed before the cancel propagated.
+    assert finished.is_set(), "thread did not complete before cancellation propagated"

--- a/python/robomp/tests/test_tasks.py
+++ b/python/robomp/tests/test_tasks.py
@@ -102,19 +102,30 @@ async def test_run_workspace_op_drains_thread_before_propagating_cancel():
     await asyncio.to_thread(started.wait, 1.0)
     assert started.is_set()
 
-    # Cancel the AWAITING coroutine while the thread is mid-flight.
-    task.cancel()
-    # Let the loop deliver the cancellation into the helper's drain loop.
-    await asyncio.sleep(0.05)
+    async def pump(turns: int = 20) -> None:
+        # Deterministically advance the loop without a wall-clock sleep: each
+        # sleep(0) drains the ready queue, so a DETACHING (pre-fix) helper would
+        # resolve `task` within these turns. A draining helper keeps it pending
+        # while the worker thread is still blocked on `proceed`.
+        for _ in range(turns):
+            await asyncio.sleep(0)
 
+    # Cancel the AWAITING coroutine while the thread is mid-flight, then a SECOND
+    # time while it is still blocked. The repeated cancel must land on the drain
+    # loop's re-`await` and be swallowed by its `continue` branch, NOT abandon
+    # the thread. The whole sequence runs under try/finally so any failed assert
+    # still releases the worker and cannot leak a blocked thread into later tests.
     try:
-        # The thread must NOT have been abandoned: it is still blocked on
-        # `proceed`, so `finished` is not set and the task has not resolved yet.
+        task.cancel()
+        await pump()
+        assert not task.done(), "helper propagated the first cancel before the thread completed (thread abandoned)"
+        task.cancel()
+        await pump()
+        # The thread is still blocked on `proceed`, so it has not finished and
+        # the task has not resolved despite two cancels.
         assert not finished.is_set(), "thread finished before we released it — impossible unless abandoned"
-        assert not task.done(), "helper propagated cancel before the thread completed (thread abandoned)"
+        assert not task.done(), "helper abandoned the thread after a repeated cancel"
     finally:
-        # Always release the worker, even if an assert above fails, so a failed
-        # run cannot leave a blocked thread leaking into later tests.
         proceed.set()
 
     # The helper must now let the thread finish, THEN raise CancelledError.


### PR DESCRIPTION
## Problem
In robomp, workspace setup/teardown (`sandbox.ensure_workspace` / `remove_workspace` — git clone/fetch, worktree add/remove, chown) ran synchronously on the asyncio dispatcher loop. Any stalled subprocess froze the entire process: no other event could progress.

## Fix
- **Off-loop execution.** All 7 `ensure_workspace` + 3 `remove_workspace` calls now run on a worker thread via a new `_run_workspace_op` helper. The helper is cancellation-safe: on cancel it drains the thread to completion before propagating `CancelledError`, so `_run_event`'s `finally` cannot reap/release a slot the setup thread still owns.
- **Per-repo serialization.** A per-repo `threading.RLock` serializes same-repo setup (they share one pool clone) while distinct repos run concurrently. `ensure_clone` runs under the outer lock rather than re-locking.
- **Bounded subprocesses.** Direct git/chown calls get a 120s timeout (returncode 124). A timed-out branch probe is treated as an error, not "branch absent" — otherwise a follow-up on an existing PR could be silently rebased onto the default branch and lose the PR's commits.
- **Pool-metadata reconciliation.** When a timed-out `git worktree remove` leaves the checkout behind, the code `rmtree`s it and runs `git worktree prune` in the pool, so a dangling worktree registration cannot trip a later `git worktree add` for the same path.

## Tests
New/updated regression tests, each verified to fail against the pre-fix code where behavioral:
- event-loop liveness during blocking setup (causal probe, not timer-based);
- cancellation-safe offload (thread drained before cancel propagates);
- per-repo lock identity + deterministic cross-thread serialization/overlap;
- subprocess timeout → returncode 124 mapping;
- branch-probe timeout → raises (both local and remote probe);
- `git worktree prune` runs (correct pool, after remove) when a worktree remove fails.

Full suite: 575 passed, 4 skipped. `ruff` clean.
