### PR TITLE
fix(agent): frame completed rewind context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Fixed post-rewind context to tell the agent the checkpoint completed and to make repeat `rewind` calls recover with guidance instead of a bare no-checkpoint error. ([#4187](https://github.com/can1357/oh-my-pi/issues/4187))
 - Fixed task.maxConcurrency being breachable when a queued spawn was cancelled: the spawn path could release a semaphore permit it never acquired, letting a later task start while the cap was saturated.
 - Fixed session exit diagnostics recording signal and crash exits (SIGTERM, SIGHUP, uncaught exceptions) as a normal "dispose": the postmortem teardown now threads the real reason into session disposal.
 - Fixed the subagent yield-label guard ignoring JTD discriminator (oneOf) output schemas, which let stale incremental labels pass into successful results when final validation was skipped after retries.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Fixed
 
-- Fixed post-rewind context to tell the agent the checkpoint completed and to make repeat `rewind` calls recover with guidance instead of a bare no-checkpoint error. ([#4187](https://github.com/can1357/oh-my-pi/issues/4187))
+- Fixed post-rewind context to tell the agent the checkpoint completed and to make repeat `rewind` calls recover with guidance instead of a bare no-checkpoint error; the branch-scan rehydration now also restores an active checkpoint when a session resumes with the latest checkpoint not yet rewound, so `rewind` can complete instead of failing with "No active checkpoint". ([#4187](https://github.com/can1357/oh-my-pi/issues/4187))
 - Fixed task.maxConcurrency being breachable when a queued spawn was cancelled: the spawn path could release a semaphore permit it never acquired, letting a later task start while the cap was saturated.
 - Fixed session exit diagnostics recording signal and crash exits (SIGTERM, SIGHUP, uncaught exceptions) as a normal "dispose": the postmortem teardown now threads the real reason into session disposal.
 - Fixed the subagent yield-label guard ignoring JTD discriminator (oneOf) output schemas, which let stale incremental labels pass into successful results when final validation was skipped after retries.

--- a/packages/coding-agent/src/prompts/system/rewind-report.md
+++ b/packages/coding-agent/src/prompts/system/rewind-report.md
@@ -1,0 +1,6 @@
+Checkpoint completed. The checkpoint's exploratory branch was rewound; the branch summary and retained report below are now the context.
+
+Do not call `rewind` again for this checkpoint. Continue from this retained report.
+
+Report:
+{{report}}

--- a/packages/coding-agent/src/prompts/tools/rewind.md
+++ b/packages/coding-agent/src/prompts/tools/rewind.md
@@ -9,5 +9,6 @@ Requirements:
 - You MUST call this before yielding if a checkpoint is active.
 
 Behavior:
-- If no checkpoint is active, this tool errors.
-- On success, the session rewinds and keeps your report as retained context.
+- If no checkpoint is active, this tool errors. If the checkpoint already rewound, continue from the retained report instead of retrying.
+- On success, the session rewinds, keeps your report as retained context, and closes the checkpoint.
+- A successful rewind is final for that checkpoint; repeat calls error.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1577,6 +1577,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			activateDiscoveredTools: toolNames => session.activateDiscoveredTools(toolNames),
 			getCheckpointState: () => session.getCheckpointState(),
 			setCheckpointState: state => session.setCheckpointState(state ?? undefined),
+			getLastCompletedRewind: () => session.getLastCompletedRewind(),
 			getToolChoiceQueue: () => session.toolChoiceQueue,
 			buildToolChoice: name => {
 				const m = session.model;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -257,6 +257,7 @@ import planModeReferencePrompt from "../prompts/system/plan-mode-reference.md" w
 import planModeToolDecisionReminderPrompt from "../prompts/system/plan-mode-tool-decision-reminder.md" with {
 	type: "text",
 };
+import rewindReportTemplate from "../prompts/system/rewind-report.md" with { type: "text" };
 import sideChannelNoToolsReminder from "../prompts/system/side-channel-no-tools.md" with { type: "text" };
 import thinkingLoopRedirectTemplate from "../prompts/system/thinking-loop-redirect.md" with { type: "text" };
 import toolCallLoopRedirectTemplate from "../prompts/system/tool-call-loop-redirect.md" with { type: "text" };
@@ -297,7 +298,7 @@ import {
 import { assertEditableFile } from "../tools/auto-generated-guard";
 import { releaseTabsForOwner } from "../tools/browser/tab-supervisor";
 import { normalizeToolNames } from "../tools/builtin-names";
-import type { CheckpointState } from "../tools/checkpoint";
+import type { CheckpointState, CompletedRewindState } from "../tools/checkpoint";
 import { outputMeta, wrapToolWithMetaNotice } from "../tools/output-meta";
 import { normalizeLocalScheme, resolveToCwd } from "../tools/path-utils";
 import { isAutoQaEnabled } from "../tools/report-tool-issue";
@@ -1695,6 +1696,7 @@ export class AgentSession {
 	#pruneToolDescriptions = false;
 	#checkpointState: CheckpointState | undefined = undefined;
 	#pendingRewindReport: string | undefined = undefined;
+	#lastCompletedRewind: CompletedRewindState | undefined = undefined;
 	#rewoundToolResultIds = new Set<string>();
 	#lastSuccessfulYieldToolCallId: string | undefined = undefined;
 	/**
@@ -3537,6 +3539,7 @@ export class AgentSession {
 						startedAt: details?.startedAt ?? new Date().toISOString(),
 					};
 					this.#pendingRewindReport = undefined;
+					this.#lastCompletedRewind = undefined;
 				}
 				if (toolName === "rewind" && !isError && this.#checkpointState) {
 					const detailReport = typeof details?.report === "string" ? details.report.trim() : "";
@@ -6676,9 +6679,15 @@ export class AgentSession {
 		return this.#checkpointState;
 	}
 
+	getLastCompletedRewind(): CompletedRewindState | undefined {
+		return this.#lastCompletedRewind;
+	}
+
 	setCheckpointState(state: CheckpointState | undefined): void {
 		this.#checkpointState = state;
-		if (!state) {
+		if (state) {
+			this.#lastCompletedRewind = undefined;
+		} else {
 			this.#pendingRewindReport = undefined;
 		}
 	}
@@ -10409,8 +10418,16 @@ export class AgentSession {
 			});
 			this.sessionManager.branchWithSummary(null, report, { startedAt: checkpointState.startedAt });
 		}
-		const details = { startedAt: checkpointState.startedAt, rewoundAt: new Date().toISOString() };
-		this.sessionManager.appendCustomMessageEntry("rewind-report", report, false, details, "agent");
+		const rewoundAt = new Date().toISOString();
+		const details = { startedAt: checkpointState.startedAt, rewoundAt };
+		this.sessionManager.appendCustomMessageEntry(
+			"rewind-report",
+			prompt.render(rewindReportTemplate, { report }),
+			false,
+			details,
+			"agent",
+		);
+		this.#lastCompletedRewind = { report, startedAt: checkpointState.startedAt, rewoundAt };
 
 		if (activeMessages) {
 			for (const message of activeMessages) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6719,7 +6719,15 @@ export class AgentSession {
 		this.agent.setTools(activeTools);
 	}
 
+	#clearCheckpointRuntimeState(): void {
+		this.#checkpointState = undefined;
+		this.#pendingRewindReport = undefined;
+		this.#lastCompletedRewind = undefined;
+		this.#rewoundToolResultIds.clear();
+	}
+
 	#rehydrateLastCompletedRewind(): void {
+		this.#clearCheckpointRuntimeState();
 		let completed: CompletedRewindState | undefined;
 		for (const entry of this.sessionManager.getBranch()) {
 			if (isSuccessfulCheckpointEntry(entry)) {
@@ -8308,6 +8316,7 @@ export class AgentSession {
 			await this.sessionManager.flush();
 		}
 		await this.sessionManager.newSession(options);
+		this.#clearCheckpointRuntimeState();
 		this.setTodoPhases([]);
 		this.#freshProviderSessionId = undefined;
 		this.#syncAgentSessionId();
@@ -9718,6 +9727,7 @@ export class AgentSession {
 			await this.sessionManager.flush();
 			this.#cancelOwnAsyncJobs();
 			await this.sessionManager.newSession(previousSessionFile ? { parentSession: previousSessionFile } : undefined);
+			this.#clearCheckpointRuntimeState();
 			// agent.reset() clears the core steering/follow-up queues. Preserve any queued
 			// steers/follow-ups (RPC/SDK steer()/followUp() issued during the handoff, or a
 			// pre-loader TUI steer) so they survive into the post-handoff session instead of
@@ -14243,6 +14253,7 @@ export class AgentSession {
 		} else {
 			this.sessionManager.createBranchedSession(selectedEntry.parentId);
 		}
+		this.#rehydrateLastCompletedRewind();
 		this.#syncTodoPhasesFromBranch();
 		this.#freshProviderSessionId = undefined;
 		this.#syncAgentSessionId();
@@ -14329,6 +14340,7 @@ export class AgentSession {
 		this.#cancelOwnAsyncJobs();
 
 		this.sessionManager.createBranchedSession(leafId);
+		this.#rehydrateLastCompletedRewind();
 		this.sessionManager.appendMessage({
 			role: "user",
 			content: [{ type: "text", text: question }],

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -414,13 +414,25 @@ function completedRewindFromEntry(entry: SessionEntry): CompletedRewindState | u
 	return report.length > 0 ? { report, startedAt, rewoundAt } : undefined;
 }
 
-function isSuccessfulCheckpointEntry(entry: SessionEntry): boolean {
+function isSuccessfulCheckpointEntry(entry: SessionEntry): entry is SessionMessageEntry & {
+	message: { role: "toolResult"; toolName: "checkpoint"; isError?: false };
+} {
 	return (
 		entry.type === "message" &&
 		entry.message.role === "toolResult" &&
 		entry.message.toolName === "checkpoint" &&
 		entry.message.isError !== true
 	);
+}
+
+function checkpointStartedAtFromEntry(entry: SessionEntry): string | undefined {
+	if (!isSuccessfulCheckpointEntry(entry)) return undefined;
+	const details = entry.message.details;
+	if (details && typeof details === "object") {
+		const startedAt = stringProperty(details, "startedAt");
+		if (startedAt) return startedAt;
+	}
+	return entry.timestamp;
 }
 
 // A side-channel assistant response is signed for the hidden prompt/history that
@@ -2150,7 +2162,7 @@ export class AgentSession {
 		this.#advisorEnabled = this.settings.get("advisor.enabled") as boolean;
 		if (this.#advisorEnabled) this.#buildAdvisorRuntime();
 
-		this.#rehydrateLastCompletedRewind();
+		this.#rehydrateCheckpointRewindState();
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, hooks, auto-compaction, retry logic)
@@ -6726,15 +6738,47 @@ export class AgentSession {
 		this.#rewoundToolResultIds.clear();
 	}
 
-	#rehydrateLastCompletedRewind(): void {
+	/**
+	 * Rebuild checkpoint/rewind runtime state from the current branch. Handles two
+	 * cases surfaced by session resume, `switchSession()` reloading the same file,
+	 * and tree navigation:
+	 *   - The branch's most recent checkpoint has already been rewound → restore
+	 *     `#lastCompletedRewind` so a repeat `rewind` call receives the
+	 *     "checkpoint already completed" recovery guidance.
+	 *   - The branch's most recent checkpoint has NOT been rewound (e.g. the run
+	 *     was aborted between `checkpoint` and `rewind`) → restore
+	 *     `#checkpointState` so the next `rewind` call can complete the
+	 *     checkpoint instead of failing with "No active checkpoint".
+	 */
+	#rehydrateCheckpointRewindState(): void {
 		this.#clearCheckpointRuntimeState();
 		let completed: CompletedRewindState | undefined;
+		let pending: { entryId: string; startedAt: string; messageCount: number } | undefined;
+		let messageCount = 0;
 		for (const entry of this.sessionManager.getBranch()) {
+			if (entry.type === "message") messageCount++;
 			if (isSuccessfulCheckpointEntry(entry)) {
 				completed = undefined;
+				pending = {
+					entryId: entry.id,
+					startedAt: checkpointStartedAtFromEntry(entry) ?? entry.timestamp,
+					messageCount,
+				};
 				continue;
 			}
-			completed = completedRewindFromEntry(entry) ?? completed;
+			const completedFromEntry = completedRewindFromEntry(entry);
+			if (completedFromEntry) {
+				completed = completedFromEntry;
+				pending = undefined;
+			}
+		}
+		if (pending) {
+			this.#checkpointState = {
+				checkpointEntryId: pending.entryId,
+				startedAt: pending.startedAt,
+				checkpointMessageCount: pending.messageCount,
+			};
+			return;
 		}
 		this.#lastCompletedRewind = completed;
 	}
@@ -14042,7 +14086,7 @@ export class AgentSession {
 				this.#didSessionMessagesChange(previousSessionContext.messages, sessionContext.messages);
 			const fallbackSelectedMCPToolNames = this.#getSessionDefaultSelectedMCPToolNames(sessionPath);
 			await this.#restoreMCPSelectionsForSessionContext(sessionContext, { fallbackSelectedMCPToolNames });
-			this.#rehydrateLastCompletedRewind();
+			this.#rehydrateCheckpointRewindState();
 
 			// Emit session_switch event to hooks
 			if (this.#extensionRunner) {
@@ -14253,7 +14297,7 @@ export class AgentSession {
 		} else {
 			this.sessionManager.createBranchedSession(selectedEntry.parentId);
 		}
-		this.#rehydrateLastCompletedRewind();
+		this.#rehydrateCheckpointRewindState();
 		this.#syncTodoPhasesFromBranch();
 		this.#freshProviderSessionId = undefined;
 		this.#syncAgentSessionId();
@@ -14340,7 +14384,7 @@ export class AgentSession {
 		this.#cancelOwnAsyncJobs();
 
 		this.sessionManager.createBranchedSession(leafId);
-		this.#rehydrateLastCompletedRewind();
+		this.#rehydrateCheckpointRewindState();
 		this.sessionManager.appendMessage({
 			role: "user",
 			content: [{ type: "text", text: question }],
@@ -14537,7 +14581,7 @@ export class AgentSession {
 		const displayContext = deobfuscateSessionContext(stateContext, this.#obfuscator);
 		await this.#restoreMCPSelectionsForSessionContext(displayContext);
 		this.agent.replaceMessages(displayContext.messages);
-		this.#rehydrateLastCompletedRewind();
+		this.#rehydrateCheckpointRewindState();
 		this.#resetAdvisorSessionState();
 		this.#syncTodoPhasesFromBranch();
 		this.#closeCodexProviderSessionsForHistoryRewrite();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -64,7 +64,6 @@ import {
 	renderHandoffPrompt,
 	resolveBudgetReserveTokens,
 	resolveThresholdTokens,
-	type SessionEntry,
 	type SessionMessageEntry,
 	type ShakeConfig,
 	type ShakeRegion,
@@ -349,7 +348,7 @@ import {
 import type { BuildSessionContextOptions, SessionContext } from "./session-context";
 import { getLatestCompactionEntry, getRestorableSessionModels } from "./session-context";
 import { formatSessionDumpText } from "./session-dump-format";
-import type { BranchSummaryEntry, CompactionEntry, NewSessionOptions } from "./session-entries";
+import type { BranchSummaryEntry, CompactionEntry, NewSessionOptions, SessionEntry } from "./session-entries";
 import { EPHEMERAL_MODEL_CHANGE_ROLE } from "./session-entries";
 import { formatSessionHistoryMarkdown } from "./session-history-format";
 import { cleanupEmptyMoveSession, type SessionManager } from "./session-manager";
@@ -380,6 +379,49 @@ const GEMINI_TOOL_REMINDER_TYPE = "gemini-tool-call-reminder";
  *  thinking/response loop. Steers the model off the repeated content; never displayed. */
 const THINKING_LOOP_REDIRECT_TYPE = "thinking-loop-redirect";
 const TOOL_CALL_LOOP_REDIRECT_TYPE = "tool-call-loop-redirect";
+
+function customMessageContentText(content: string | (TextContent | ImageContent)[]): string {
+	if (typeof content === "string") return content;
+	const parts: string[] = [];
+	for (const part of content) {
+		if (part.type === "text") parts.push(part.text);
+	}
+	return parts.join("\n");
+}
+
+function stringProperty(value: object, key: string): string | undefined {
+	const field = Object.getOwnPropertyDescriptor(value, key)?.value;
+	return typeof field === "string" ? field : undefined;
+}
+
+function reportFromRewindReportContent(content: string): string {
+	const marker = "\nReport:\n";
+	const index = content.lastIndexOf(marker);
+	const report = index >= 0 ? content.slice(index + marker.length) : content;
+	return report.trim();
+}
+
+function completedRewindFromEntry(entry: SessionEntry): CompletedRewindState | undefined {
+	if (entry.type !== "custom_message" || entry.customType !== "rewind-report") return undefined;
+	const details = entry.details;
+	if (!details || typeof details !== "object") return undefined;
+	const startedAt = stringProperty(details, "startedAt");
+	const rewoundAt = stringProperty(details, "rewoundAt");
+	if (!startedAt || !rewoundAt) return undefined;
+	const report =
+		stringProperty(details, "report")?.trim() ||
+		reportFromRewindReportContent(customMessageContentText(entry.content));
+	return report.length > 0 ? { report, startedAt, rewoundAt } : undefined;
+}
+
+function isSuccessfulCheckpointEntry(entry: SessionEntry): boolean {
+	return (
+		entry.type === "message" &&
+		entry.message.role === "toolResult" &&
+		entry.message.toolName === "checkpoint" &&
+		entry.message.isError !== true
+	);
+}
 
 // A side-channel assistant response is signed for the hidden prompt/history that
 // produced it. If we persist that response under a different user turn, native
@@ -2107,6 +2149,8 @@ export class AgentSession {
 
 		this.#advisorEnabled = this.settings.get("advisor.enabled") as boolean;
 		if (this.#advisorEnabled) this.#buildAdvisorRuntime();
+
+		this.#rehydrateLastCompletedRewind();
 
 		// Always subscribe to agent events for internal handling
 		// (session persistence, hooks, auto-compaction, retry logic)
@@ -6675,6 +6719,18 @@ export class AgentSession {
 		this.agent.setTools(activeTools);
 	}
 
+	#rehydrateLastCompletedRewind(): void {
+		let completed: CompletedRewindState | undefined;
+		for (const entry of this.sessionManager.getBranch()) {
+			if (isSuccessfulCheckpointEntry(entry)) {
+				completed = undefined;
+				continue;
+			}
+			completed = completedRewindFromEntry(entry) ?? completed;
+		}
+		this.#lastCompletedRewind = completed;
+	}
+
 	getCheckpointState(): CheckpointState | undefined {
 		return this.#checkpointState;
 	}
@@ -10419,7 +10475,7 @@ export class AgentSession {
 			this.sessionManager.branchWithSummary(null, report, { startedAt: checkpointState.startedAt });
 		}
 		const rewoundAt = new Date().toISOString();
-		const details = { startedAt: checkpointState.startedAt, rewoundAt };
+		const details = { report, startedAt: checkpointState.startedAt, rewoundAt };
 		this.sessionManager.appendCustomMessageEntry(
 			"rewind-report",
 			prompt.render(rewindReportTemplate, { report }),
@@ -13955,6 +14011,8 @@ export class AgentSession {
 			? this.#getSessionDefaultSelectedMCPToolNames(previousSessionFile)
 			: undefined;
 
+		const previousLastCompletedRewind = this.#lastCompletedRewind;
+
 		this.agent.clearAllQueues();
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
@@ -13974,6 +14032,7 @@ export class AgentSession {
 				this.#didSessionMessagesChange(previousSessionContext.messages, sessionContext.messages);
 			const fallbackSelectedMCPToolNames = this.#getSessionDefaultSelectedMCPToolNames(sessionPath);
 			await this.#restoreMCPSelectionsForSessionContext(sessionContext, { fallbackSelectedMCPToolNames });
+			this.#rehydrateLastCompletedRewind();
 
 			// Emit session_switch event to hooks
 			if (this.#extensionRunner) {
@@ -14115,6 +14174,7 @@ export class AgentSession {
 			this.agent.replaceQueues(previousSteeringMessages, previousFollowUpMessages);
 			this.#pendingNextTurnMessages = previousPendingNextTurnMessages;
 			this.#scheduledHiddenNextTurnGeneration = previousScheduledHiddenNextTurnGeneration;
+			this.#lastCompletedRewind = previousLastCompletedRewind;
 			if (previousModel) {
 				this.agent.setModel(previousModel);
 			}
@@ -14465,6 +14525,7 @@ export class AgentSession {
 		const displayContext = deobfuscateSessionContext(stateContext, this.#obfuscator);
 		await this.#restoreMCPSelectionsForSessionContext(displayContext);
 		this.agent.replaceMessages(displayContext.messages);
+		this.#rehydrateLastCompletedRewind();
 		this.#resetAdvisorSessionState();
 		this.#syncTodoPhasesFromBranch();
 		this.#closeCodexProviderSessionsForHistoryRewrite();

--- a/packages/coding-agent/src/tools/checkpoint.ts
+++ b/packages/coding-agent/src/tools/checkpoint.ts
@@ -17,6 +17,15 @@ export interface CheckpointState {
 	startedAt: string;
 }
 
+export interface CompletedRewindState {
+	/** Report retained after a successful rewind. */
+	report: string;
+	/** Timestamp for the checkpoint that was rewound. */
+	startedAt: string;
+	/** Timestamp when the rewind completed. */
+	rewoundAt: string;
+}
+
 const checkpointSchema = type({
 	goal: type("string").describe("investigation goal"),
 });
@@ -123,7 +132,12 @@ export class RewindTool implements AgentTool<typeof rewindSchema, RewindToolDeta
 			throw new ToolError("Checkpoint not available in subagents.");
 		}
 		if (!this.session.getCheckpointState?.()) {
-			throw new ToolError("No active checkpoint.");
+			if (this.session.getLastCompletedRewind?.()) {
+				throw new ToolError(
+					"Checkpoint already completed; continue from the retained rewind report instead of calling rewind again.",
+				);
+			}
+			throw new ToolError("No active checkpoint. Create a checkpoint before calling rewind.");
 		}
 		const report = params.report.trim();
 		if (report.length === 0) {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -40,7 +40,7 @@ import { AstGrepTool } from "./ast-grep";
 import { BashTool } from "./bash";
 import { BrowserTool } from "./browser";
 import { type BuiltinToolName, normalizeToolNames } from "./builtin-names";
-import { type CheckpointState, CheckpointTool, RewindTool } from "./checkpoint";
+import { type CheckpointState, CheckpointTool, type CompletedRewindState, RewindTool } from "./checkpoint";
 import { DebugTool } from "./debug";
 import { EvalTool } from "./eval";
 import { resolveEvalBackends } from "./eval-backends";
@@ -332,6 +332,8 @@ export interface ToolSession {
 	getCheckpointState?: () => CheckpointState | undefined;
 	/** Set or clear active checkpoint state. */
 	setCheckpointState?: (state: CheckpointState | null) => void;
+	/** Get the most recent completed rewind, if this session just rewound a checkpoint. */
+	getLastCompletedRewind?: () => CompletedRewindState | undefined;
 
 	/** Per-session snapshot store of file contents as last shown to the model
 	 *  by `read`/`search`. Used by hashline anchor-stale recovery to

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -10,6 +10,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { RewindTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 const checkpointSchema = z.object({ goal: z.string() });
@@ -115,6 +116,16 @@ function expectLastAssistant(messages: AgentMessage[]): AssistantMessage {
 	if (message?.role !== "assistant") throw new Error("Expected last message to be assistant");
 	return message;
 }
+function createToolSession(overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+		...overrides,
+	};
+}
 
 describe("AgentSession checkpoint rewind branch context", () => {
 	it("rebuilds active history through branch_summary before the post-rewind assistant turn", async () => {
@@ -153,6 +164,13 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		);
 		expect(summaryIndex).toBeGreaterThan(-1);
 		expect(reportIndex).toBeGreaterThan(summaryIndex);
+		const reportMessage = finalCall.context.messages[reportIndex];
+		if (!reportMessage) throw new Error("Expected rewind report context");
+		const reportText = messageText(reportMessage);
+		expect(reportText).toContain("Checkpoint completed.");
+		expect(reportText).toContain("Do not call `rewind` again");
+		expect(reportText).toContain(report);
+
 		expect(
 			finalCall.context.messages.some(message => message.role === "toolResult" && message.toolName === "rewind"),
 		).toBe(false);
@@ -165,5 +183,21 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		const finalThinking = finalAssistant.content.find((block): block is ThinkingContent => block.type === "thinking");
 		expect(finalThinking?.thinking).toBe("answer after rewind");
 		expect(finalThinking?.thinkingSignature).toBe("sig_after_rewind");
+	});
+
+	it("tells the model to continue when rewind is repeated after completion", async () => {
+		const tool = new RewindTool(
+			createToolSession({
+				getLastCompletedRewind: () => ({
+					report: "findings retained",
+					startedAt: "2026-01-01T00:00:00.000Z",
+					rewoundAt: "2026-01-01T00:01:00.000Z",
+				}),
+			}),
+		);
+
+		await expect(tool.execute("repeat_rewind", { report: "retry" })).rejects.toThrow(
+			"Checkpoint already completed; continue from the retained rewind report instead of calling rewind again.",
+		);
 	});
 });

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -45,6 +45,7 @@ const rewindTool: AgentTool<typeof rewindSchema, { report: string; rewound: bool
 type Harness = {
 	session: AgentSession;
 	authStorage: AuthStorage;
+	extraSessions: AgentSession[];
 	tempDir: TempDir;
 };
 
@@ -53,6 +54,9 @@ const activeHarnesses: Harness[] = [];
 afterEach(async () => {
 	while (activeHarnesses.length > 0) {
 		const harness = activeHarnesses.pop();
+		for (const extraSession of harness?.extraSessions ?? []) {
+			await extraSession.dispose();
+		}
 		await harness?.session.dispose();
 		harness?.authStorage.close();
 		harness?.tempDir.removeSync();
@@ -99,7 +103,7 @@ async function createHarness(responses: MockResponse[]): Promise<Harness & { moc
 		modelRegistry,
 		toolRegistry: new Map(tools.map(tool => [tool.name, tool])),
 	});
-	const harness = { session, authStorage, tempDir };
+	const harness = { session, authStorage, tempDir, extraSessions: [] };
 	activeHarnesses.push(harness);
 	return { ...harness, mock };
 }
@@ -183,6 +187,73 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		const finalThinking = finalAssistant.content.find((block): block is ThinkingContent => block.type === "thinking");
 		expect(finalThinking?.thinking).toBe("answer after rewind");
 		expect(finalThinking?.thinkingSignature).toBe("sig_after_rewind");
+	});
+
+	it("rehydrates completed rewind state from the retained report on resume", async () => {
+		const report = "findings: retained after resume";
+		const harness = await createHarness([
+			{
+				content: [{ type: "toolCall", id: "call_checkpoint", name: "checkpoint", arguments: { goal: "inspect" } }],
+				stopReason: "toolUse",
+			},
+			{
+				content: [{ type: "toolCall", id: "call_rewind", name: "rewind", arguments: { report } }],
+				stopReason: "toolUse",
+			},
+			{
+				content: ["DONE"],
+				stopReason: "stop",
+			},
+		]);
+
+		await harness.session.prompt("investigate with a checkpoint");
+
+		const reloadedMock = createMockModel({ responses: [] });
+		const reloadedSettings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.enabled": false,
+			"todo.enabled": false,
+			"todo.eager": "default",
+			"todo.reminders": false,
+		});
+		reloadedSettings.setModelRole("default", `${reloadedMock.provider}/${reloadedMock.id}`);
+		const reloadedTools = [checkpointTool as AgentTool, rewindTool as AgentTool];
+		const reloadedAgent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: reloadedMock,
+				systemPrompt: ["Test"],
+				tools: reloadedTools,
+				messages: harness.session.sessionManager.buildSessionContext().messages,
+			},
+			convertToLlm,
+			streamFn: reloadedMock.stream,
+		});
+		const reloadedSession = new AgentSession({
+			agent: reloadedAgent,
+			sessionManager: harness.session.sessionManager,
+			settings: reloadedSettings,
+			modelRegistry: new ModelRegistry(
+				harness.authStorage,
+				path.join(harness.tempDir.path(), "models-reloaded.yml"),
+			),
+			toolRegistry: new Map(reloadedTools.map(tool => [tool.name, tool])),
+		});
+		harness.extraSessions.push(reloadedSession);
+
+		expect(reloadedSession.getLastCompletedRewind()).toEqual({
+			report,
+			startedAt: "2026-01-01T00:00:00.000Z",
+			rewoundAt: expect.any(String),
+		});
+		const tool = new RewindTool(
+			createToolSession({
+				getLastCompletedRewind: () => reloadedSession.getLastCompletedRewind(),
+			}),
+		);
+		await expect(tool.execute("repeat_rewind", { report: "retry" })).rejects.toThrow(
+			"Checkpoint already completed; continue from the retained rewind report instead of calling rewind again.",
+		);
 	});
 
 	it("tells the model to continue when rewind is repeated after completion", async () => {

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -340,4 +340,83 @@ describe("AgentSession checkpoint rewind branch context", () => {
 			"Checkpoint already completed; continue from the retained rewind report instead of calling rewind again.",
 		);
 	});
+
+	it("rehydrates active checkpoint state when resuming a session with no rewind yet", async () => {
+		const startedAt = "2026-01-01T00:00:00.000Z";
+		const harness = await createHarness([
+			{
+				content: [
+					{ type: "toolCall", id: "call_checkpoint", name: "checkpoint", arguments: { goal: "inspect" } },
+				],
+				stopReason: "toolUse",
+			},
+			{
+				content: [{ type: "toolCall", id: "call_rewind", name: "rewind", arguments: { report: "findings" } }],
+				stopReason: "toolUse",
+			},
+			{
+				content: ["DONE"],
+				stopReason: "stop",
+			},
+		]);
+		await harness.session.prompt("investigate with a checkpoint");
+		const originalCompleted = harness.session.getLastCompletedRewind();
+		expect(originalCompleted).toBeDefined();
+
+		// Simulate "run aborted between checkpoint and rewind" by branching to the
+		// checkpoint entry itself — the rewind and its rewind-report entry drop off
+		// the active branch, leaving the checkpoint tool result as the leaf.
+		const branch = harness.session.sessionManager.getBranch();
+		const checkpointEntry = branch.find(
+			entry => entry.type === "message" && entry.message.role === "toolResult" && entry.message.toolName === "checkpoint",
+		);
+		if (!checkpointEntry) throw new Error("Expected checkpoint tool result entry");
+		harness.session.sessionManager.branch(checkpointEntry.id);
+
+		const reloadedMock = createMockModel({ responses: [] });
+		const reloadedSettings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.enabled": false,
+			"todo.enabled": false,
+			"todo.eager": "default",
+			"todo.reminders": false,
+		});
+		reloadedSettings.setModelRole("default", `${reloadedMock.provider}/${reloadedMock.id}`);
+		const reloadedTools = [checkpointTool as AgentTool, rewindTool as AgentTool];
+		const reloadedAgent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: reloadedMock,
+				systemPrompt: ["Test"],
+				tools: reloadedTools,
+				messages: harness.session.sessionManager.buildSessionContext().messages,
+			},
+			convertToLlm,
+			streamFn: reloadedMock.stream,
+		});
+		const reloadedSession = new AgentSession({
+			agent: reloadedAgent,
+			sessionManager: harness.session.sessionManager,
+			settings: reloadedSettings,
+			modelRegistry: new ModelRegistry(
+				harness.authStorage,
+				path.join(harness.tempDir.path(), "models-reloaded.yml"),
+			),
+			toolRegistry: new Map(reloadedTools.map(tool => [tool.name, tool])),
+		});
+		harness.extraSessions.push(reloadedSession);
+
+		const restored = reloadedSession.getCheckpointState();
+		expect(restored).toBeDefined();
+		expect(restored?.checkpointEntryId).toBe(checkpointEntry.id);
+		expect(restored?.startedAt).toBe(startedAt);
+		expect(reloadedSession.getLastCompletedRewind()).toBeUndefined();
+
+		// The rewind tool must accept the request now that the active checkpoint
+		// has been re-hydrated — previously this threw "No active checkpoint".
+		const rewindResult = await rewindToolForSession(reloadedSession).execute("call_rewind_after_resume", {
+			report: "post-resume findings",
+		});
+		expect(rewindResult.content.some(part => part.type === "text" && part.text.includes("Rewind requested"))).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -345,9 +345,7 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		const startedAt = "2026-01-01T00:00:00.000Z";
 		const harness = await createHarness([
 			{
-				content: [
-					{ type: "toolCall", id: "call_checkpoint", name: "checkpoint", arguments: { goal: "inspect" } },
-				],
+				content: [{ type: "toolCall", id: "call_checkpoint", name: "checkpoint", arguments: { goal: "inspect" } }],
 				stopReason: "toolUse",
 			},
 			{
@@ -368,7 +366,8 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		// the active branch, leaving the checkpoint tool result as the leaf.
 		const branch = harness.session.sessionManager.getBranch();
 		const checkpointEntry = branch.find(
-			entry => entry.type === "message" && entry.message.role === "toolResult" && entry.message.toolName === "checkpoint",
+			entry =>
+				entry.type === "message" && entry.message.role === "toolResult" && entry.message.toolName === "checkpoint",
 		);
 		if (!checkpointEntry) throw new Error("Expected checkpoint tool result entry");
 		harness.session.sessionManager.branch(checkpointEntry.id);
@@ -417,6 +416,8 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		const rewindResult = await rewindToolForSession(reloadedSession).execute("call_rewind_after_resume", {
 			report: "post-resume findings",
 		});
-		expect(rewindResult.content.some(part => part.type === "text" && part.text.includes("Rewind requested"))).toBe(true);
+		expect(rewindResult.content.some(part => part.type === "text" && part.text.includes("Rewind requested"))).toBe(
+			true,
+		);
 	});
 });

--- a/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
+++ b/packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts
@@ -131,6 +131,21 @@ function createToolSession(overrides: Partial<ToolSession> = {}): ToolSession {
 	};
 }
 
+function rewindToolForSession(session: AgentSession): RewindTool {
+	return new RewindTool(
+		createToolSession({
+			getCheckpointState: () => session.getCheckpointState(),
+			getLastCompletedRewind: () => session.getLastCompletedRewind(),
+		}),
+	);
+}
+
+async function expectNoActiveCheckpointError(session: AgentSession): Promise<void> {
+	await expect(rewindToolForSession(session).execute("repeat_rewind", { report: "retry" })).rejects.toThrow(
+		"No active checkpoint. Create a checkpoint before calling rewind.",
+	);
+}
+
 describe("AgentSession checkpoint rewind branch context", () => {
 	it("rebuilds active history through branch_summary before the post-rewind assistant turn", async () => {
 		const report = "findings: kept checkpoint; risks: stale signed thinking";
@@ -254,6 +269,60 @@ describe("AgentSession checkpoint rewind branch context", () => {
 		await expect(tool.execute("repeat_rewind", { report: "retry" })).rejects.toThrow(
 			"Checkpoint already completed; continue from the retained rewind report instead of calling rewind again.",
 		);
+	});
+
+	it("clears completed rewind state when starting a new session", async () => {
+		const harness = await createHarness([
+			{
+				content: [{ type: "toolCall", id: "call_checkpoint", name: "checkpoint", arguments: { goal: "inspect" } }],
+				stopReason: "toolUse",
+			},
+			{
+				content: [{ type: "toolCall", id: "call_rewind", name: "rewind", arguments: { report: "findings" } }],
+				stopReason: "toolUse",
+			},
+			{
+				content: ["DONE"],
+				stopReason: "stop",
+			},
+		]);
+
+		await harness.session.prompt("investigate with a checkpoint");
+		expect(harness.session.getLastCompletedRewind()).toBeDefined();
+
+		await harness.session.newSession();
+
+		expect(harness.session.getLastCompletedRewind()).toBeUndefined();
+		await expectNoActiveCheckpointError(harness.session);
+	});
+
+	it("rehydrates completed rewind state from the branched path", async () => {
+		const harness = await createHarness([
+			{
+				content: [{ type: "toolCall", id: "call_checkpoint", name: "checkpoint", arguments: { goal: "inspect" } }],
+				stopReason: "toolUse",
+			},
+			{
+				content: [{ type: "toolCall", id: "call_rewind", name: "rewind", arguments: { report: "findings" } }],
+				stopReason: "toolUse",
+			},
+			{
+				content: ["DONE"],
+				stopReason: "stop",
+			},
+		]);
+
+		await harness.session.prompt("investigate with a checkpoint");
+		expect(harness.session.getLastCompletedRewind()).toBeDefined();
+		const userEntry = harness.session.sessionManager
+			.getEntries()
+			.find(entry => entry.type === "message" && entry.message.role === "user");
+		if (!userEntry) throw new Error("Expected user entry for branch");
+
+		await harness.session.branch(userEntry.id);
+
+		expect(harness.session.getLastCompletedRewind()).toBeUndefined();
+		await expectNoActiveCheckpointError(harness.session);
 	});
 
 	it("tells the model to continue when rewind is repeated after completion", async () => {

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -14,8 +14,8 @@ import {
 	mergeTaskBranches,
 	parseIsolationMode,
 } from "@oh-my-pi/pi-coding-agent/task/worktree";
-import * as jj from "@oh-my-pi/pi-coding-agent/utils/jj";
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
+import * as jj from "@oh-my-pi/pi-coding-agent/utils/jj";
 import * as natives from "@oh-my-pi/pi-natives";
 import { removeWithRetries, setWorktreesDir } from "@oh-my-pi/pi-utils";
 


### PR DESCRIPTION
## Repro
Added a focused regression test in `packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts` and ran `bun test packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts`; before the fix it failed because the retained `rewind-report` context was only the bare report text and repeat `rewind` threw `No active checkpoint.`.

## Cause
`AgentSession.#applyRewind` appended the retained `rewind-report` custom message as raw report text after pruning the successful rewind tool result, while `RewindTool.execute` had no session signal distinguishing an already-completed rewind from a never-started checkpoint.

## Fix
- Wrapped retained rewind reports with `src/prompts/system/rewind-report.md` so the post-rewind model turn sees that the checkpoint completed and must not call `rewind` again.
- Tracked the most recent completed rewind in `AgentSession`/`ToolSession` and used it to return recovery guidance for repeat `rewind` calls.
- Tightened the `rewind` tool prompt and added regression assertions for retained context framing plus repeat-call error guidance.
- Added the package changelog entry for #4187.

## Verification
`bun test packages/coding-agent/test/agent-session-checkpoint-rewind-branch.test.ts` passed with 2 tests and 13 assertions. `bun check` passed in `packages/coding-agent`. Fixes #4187