### PR TITLE
fix(tui): stop /move overlay from statting every entry per keystroke

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/move` overlay running an `fs.statSync` per directory entry per keystroke; the directory listing cache now stores `Dirent[]` and classifies entries without a syscall, falling back to `statSync` only for symlink entries ([#4199](https://github.com/can1357/oh-my-pi/issues/4199)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/modes/components/__tests__/move-overlay.test.ts
+++ b/packages/coding-agent/src/modes/components/__tests__/move-overlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
@@ -162,5 +162,36 @@ describe("MoveOverlay", () => {
 		overlay.handleInput("\r");
 		expect(result).toBeDefined();
 		expect(result!.directory).toBe(path.join(cwd, "alpha"));
+	});
+
+	it("does not stat every directory entry per keystroke", async () => {
+		// Regression: `readDirCached` used to cache names and re-`statSync` every
+		// entry per keystroke. Populate with mostly files so the old code path
+		// would have stat'd all of them; the fix classifies via `Dirent` and only
+		// falls back to `statSync` on symlink entries.
+		const bulk = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-move-overlay-bulk-"));
+		try {
+			for (let i = 0; i < 60; i++) {
+				fs.writeFileSync(path.join(bulk, `f_${String(i).padStart(3, "0")}.txt`), "x");
+			}
+			for (let i = 0; i < 10; i++) fs.mkdirSync(path.join(bulk, `sub_${i}`));
+
+			const statSpy = spyOn(fs, "statSync");
+			try {
+				const overlay = new MoveOverlay(bulk, () => {});
+				statSpy.mockClear();
+				overlay.handleInput("s");
+				overlay.handleInput("u");
+				overlay.handleInput("b");
+				// Each keystroke may `statSync` at most once — the
+				// `resolveExistingDirectory` probe on the typed prefix. Entries
+				// are classified via `Dirent`, not one stat apiece.
+				expect(statSpy.mock.calls.length).toBeLessThanOrEqual(3);
+			} finally {
+				statSpy.mockRestore();
+			}
+		} finally {
+			await fsp.rm(bulk, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/coding-agent/src/modes/components/__tests__/move-overlay.test.ts
+++ b/packages/coding-agent/src/modes/components/__tests__/move-overlay.test.ts
@@ -194,4 +194,44 @@ describe("MoveOverlay", () => {
 			await fsp.rm(bulk, { recursive: true, force: true });
 		}
 	});
+
+	it("classifies unknown-type Dirents via statSync fallback", async () => {
+		// Regression: filesystems that report UV_DIRENT_UNKNOWN return Dirents
+		// whose isDirectory()/isFile()/isSymbolicLink() all report false. Those
+		// entries must fall back to statSync so /move still lists real
+		// directories on NFS/FUSE/older SMB.
+		const unknownFs = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-move-overlay-unknown-"));
+		try {
+			const realDir = path.join(unknownFs, "real-dir");
+			const realFile = path.join(unknownFs, "real-file.txt");
+			fs.mkdirSync(realDir);
+			fs.writeFileSync(realFile, "x");
+
+			const fakeDirent = (name: string): fs.Dirent =>
+				({
+					name,
+					isDirectory: () => false,
+					isFile: () => false,
+					isSymbolicLink: () => false,
+					isBlockDevice: () => false,
+					isCharacterDevice: () => false,
+					isFIFO: () => false,
+					isSocket: () => false,
+				}) as fs.Dirent;
+			const readdirSpy = spyOn(fs, "readdirSync").mockReturnValue([
+				fakeDirent("real-dir"),
+				fakeDirent("real-file.txt"),
+			] as never);
+			try {
+				const overlay = new MoveOverlay(unknownFs, () => {});
+				const text = strip(overlay.render(80));
+				expect(text).toContain("real-dir/");
+				expect(text).not.toContain("real-file.txt");
+			} finally {
+				readdirSpy.mockRestore();
+			}
+		} finally {
+			await fsp.rm(unknownFs, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/src/modes/components/move-overlay.ts
+++ b/packages/coding-agent/src/modes/components/move-overlay.ts
@@ -29,18 +29,33 @@ const OVERLAY_WIDTH = 68;
 
 /** TTL for the directory listing cache (ms). */
 const DIR_CACHE_TTL = 500;
-const dirCache = new Map<string, { time: number; entries: string[] }>();
+const dirCache = new Map<string, { time: number; entries: fs.Dirent[] }>();
 
-function readDirCached(dir: string): string[] {
+function readDirCached(dir: string): fs.Dirent[] {
 	const now = Date.now();
 	const cached = dirCache.get(dir);
 	if (cached && now - cached.time < DIR_CACHE_TTL) return cached.entries;
 	try {
-		const entries = fs.readdirSync(dir);
+		const entries = fs.readdirSync(dir, { withFileTypes: true });
 		dirCache.set(dir, { time: now, entries });
 		return entries;
 	} catch {
 		return [];
+	}
+}
+
+/**
+ * `Dirent.isDirectory()` reports the entry type, not the link target, so a
+ * `statSync` fallback is still needed for symlinks that point at a directory.
+ * Every other entry is classified without a syscall.
+ */
+function entryIsDirectory(dir: string, entry: fs.Dirent): boolean {
+	if (entry.isDirectory()) return true;
+	if (!entry.isSymbolicLink()) return false;
+	try {
+		return fs.statSync(path.join(dir, entry.name)).isDirectory();
+	} catch {
+		return false;
 	}
 }
 
@@ -76,17 +91,13 @@ export function resolveExistingDirectory(input: string, cwd: string): string | n
 
 function listChildDirectories(dirPath: string, max: number, includeHidden = false): DirEntry[] {
 	const results: DirEntry[] = [];
-	const names = readDirCached(dirPath);
-	for (const name of names) {
+	const entries = readDirCached(dirPath);
+	for (const entry of entries) {
 		if (results.length >= max) break;
+		const { name } = entry;
 		if (!includeHidden && name.startsWith(".")) continue;
-		const full = path.join(dirPath, name);
-		try {
-			if (!fs.statSync(full).isDirectory()) continue;
-		} catch {
-			continue;
-		}
-		results.push({ value: full, label: `${name}/` });
+		if (!entryIsDirectory(dirPath, entry)) continue;
+		results.push({ value: path.join(dirPath, name), label: `${name}/` });
 	}
 	results.sort((a, b) => a.label.localeCompare(b.label));
 	return results;
@@ -118,19 +129,14 @@ function searchDirectories(prefix: string, cwd: string, max: number): DirEntry[]
 
 	const lower = query.toLowerCase();
 	const results: DirEntry[] = [];
-	const names = readDirCached(baseDir);
-	for (const name of names) {
+	const entries = readDirCached(baseDir);
+	for (const entry of entries) {
 		if (results.length >= max) break;
+		const { name } = entry;
 		if (!includeHidden && name.startsWith(".")) continue;
-		const full = path.join(baseDir, name);
-		try {
-			if (!fs.statSync(full).isDirectory()) continue;
-		} catch {
-			continue;
-		}
-		if (!query || name.toLowerCase().includes(lower)) {
-			results.push({ value: full, label: `${name}/` });
-		}
+		if (query && !name.toLowerCase().includes(lower)) continue;
+		if (!entryIsDirectory(baseDir, entry)) continue;
+		results.push({ value: path.join(baseDir, name), label: `${name}/` });
 	}
 	return results;
 }

--- a/packages/coding-agent/src/modes/components/move-overlay.ts
+++ b/packages/coding-agent/src/modes/components/move-overlay.ts
@@ -47,11 +47,17 @@ function readDirCached(dir: string): fs.Dirent[] {
 /**
  * `Dirent.isDirectory()` reports the entry type, not the link target, so a
  * `statSync` fallback is still needed for symlinks that point at a directory.
- * Every other entry is classified without a syscall.
+ * Some filesystems (NFS, FUSE, older SMB) report `UV_DIRENT_UNKNOWN` — every
+ * `isX()` returns false — so those entries also fall back to `statSync` rather
+ * than being silently dropped from the results.
  */
 function entryIsDirectory(dir: string, entry: fs.Dirent): boolean {
 	if (entry.isDirectory()) return true;
-	if (!entry.isSymbolicLink()) return false;
+	// Fast reject only for entry types we can confidently identify as non-directory.
+	if (entry.isFile() || entry.isBlockDevice() || entry.isCharacterDevice() || entry.isFIFO() || entry.isSocket()) {
+		return false;
+	}
+	// Symlink (need target type) or unknown (filesystem didn't provide a type) — stat to find out.
 	try {
 		return fs.statSync(path.join(dir, entry.name)).isDirectory();
 	} catch {


### PR DESCRIPTION
## Repro

Open `/move` in a directory with mixed contents and type. Every keystroke ran an `fs.statSync` per cached entry. Measured against a 120-entry directory (100 files + 20 subdirs) by spying on `fs.statSync` and driving `MoveOverlay.handleInput` — each keystroke produced **121 `statSync` calls** (120 entry classifications + 1 from `resolveExistingDirectory` on the typed prefix).

## Cause

`readDirCached` in `packages/coding-agent/src/modes/components/move-overlay.ts` cached the `string[]` from `fs.readdirSync`. `listChildDirectories` and `searchDirectories` then called `fs.statSync(full).isDirectory()` on every cached entry per keystroke to decide whether it was a directory. The cache dodged `readdirSync` but not the stat storm — cost scales with the target directory size, and on Windows the syncronous stats are latency-heavy in an interactive path.

## Fix

- `dirCache` now stores `fs.Dirent[]` via `fs.readdirSync(dir, { withFileTypes: true })`.
- New `entryIsDirectory(dir, entry)` classifies via `entry.isDirectory()` and only falls back to `fs.statSync` when `entry.isSymbolicLink()` — preserving the previous follow-symlink-to-directory behavior since `Dirent.isDirectory()` reports the entry type, not the link target.
- `listChildDirectories` and `searchDirectories` iterate `Dirent[]` and use `entryIsDirectory` for classification. `searchDirectories` also applies the name filter before classification so symlink stats only fire for entries the user's query already matches.
- Regression test `does not stat every directory entry per keystroke` spies on `fs.statSync` and asserts that three keystrokes over a 70-entry directory (60 files + 10 dirs) issue at most one stat apiece (the `resolveExistingDirectory` probe on the typed prefix).

## Verification

`bun test src/modes/components/__tests__/move-overlay.test.ts` — 17 pass / 0 fail. The new test locks in an O(1) stat budget per keystroke; the manual repro above dropped from 121 stats/keystroke to 1 (only the `resolveExistingDirectory` probe remains). Fixes #4199.