### PR TITLE
fix(coding-agent): scope discoverExtensionPaths to native extension-module provider

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `discoverExtensionPaths` invoking every registered extension-module provider (claude, codex, gemini, opencode) on startup and discarding all non-native results. The extension-module capability is now loaded with `providers: ["native"]`, skipping four foreign directory walks per session — noticeable on Windows where the walks are slowest ([#4198](https://github.com/can1357/oh-my-pi/issues/4198)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -521,10 +521,17 @@ export async function discoverExtensionPaths(
 		}
 	};
 
-	// 1. Discover extension modules via capability API (native .omp/.pi only)
-	const discovered = await loadCapability<ExtensionModule>(extensionModuleCapability.id, loadOptions);
+	// 1. Discover extension modules via capability API (native .omp/.pi only).
+	// Scope the load to the native provider — the extension-module capability
+	// also has claude/codex/gemini/opencode providers, and their items were
+	// discarded here anyway (see #4198). The provider filter skips the walk
+	// entirely instead of running four foreign directory scans and dropping
+	// the results.
+	const discovered = await loadCapability<ExtensionModule>(extensionModuleCapability.id, {
+		...loadOptions,
+		providers: ["native"],
+	});
 	for (const ext of discovered.items) {
-		if (ext._source.provider !== "native") continue;
 		addPath(ext.path);
 	}
 

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { type ExtensionModule, extensionModuleCapability } from "@oh-my-pi/pi-coding-agent/capability/extension-module";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { getCapability, initializeWithSettings } from "@oh-my-pi/pi-coding-agent/discovery";
 import {
 	discoverAndLoadExtensions,
@@ -744,5 +744,4 @@ describe("extensions discovery", () => {
 			for (const spy of spies) spy.mockRestore();
 		}
 	});
-
 });

--- a/packages/coding-agent/test/extensions-discovery.test.ts
+++ b/packages/coding-agent/test/extensions-discovery.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { initializeWithSettings } from "@oh-my-pi/pi-coding-agent/discovery";
-import { discoverAndLoadExtensions, loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { type ExtensionModule, extensionModuleCapability } from "@oh-my-pi/pi-coding-agent/capability/extension-module";
+import { getCapability, initializeWithSettings } from "@oh-my-pi/pi-coding-agent/discovery";
+import {
+	discoverAndLoadExtensions,
+	discoverExtensionPaths,
+	loadExtensions,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { filterUserScoped } from "./utils/filter-user-extensions";
 
@@ -711,4 +716,33 @@ describe("extensions discovery", () => {
 		expect(result.errors).toHaveLength(0);
 		expect(result.extensions).toHaveLength(0);
 	});
+	it("discoverExtensionPaths only invokes the native extension-module provider (#4198)", async () => {
+		// The extension-module capability has multiple providers
+		// (native, claude, codex, gemini, opencode), but discoverExtensionPaths
+		// only surfaces native-provider paths. Regression: pre-fix it still
+		// invoked every provider's load() and then dropped foreign items,
+		// running four unused directory walks per startup (worst on Windows).
+		const capability = getCapability<ExtensionModule>(extensionModuleCapability.id);
+		expect(capability, "extension-modules capability must be registered").toBeDefined();
+
+		const providers = capability?.providers ?? [];
+		const foreignIds = providers.map(p => p.id).filter(id => id !== "native");
+		// Guard the invariant this test is defending — without foreign providers
+		// the test would trivially pass and hide a future regression.
+		expect(foreignIds.length).toBeGreaterThan(0);
+
+		const spies = providers.map(provider => vi.spyOn(provider, "load"));
+		try {
+			await discoverExtensionPaths([], tempDir.path());
+
+			const callsById = new Map(providers.map((provider, i) => [provider.id, spies[i].mock.calls.length]));
+			expect(callsById.get("native")).toBe(1);
+			for (const id of foreignIds) {
+				expect(callsById.get(id), `foreign provider ${id} must not be walked`).toBe(0);
+			}
+		} finally {
+			for (const spy of spies) spy.mockRestore();
+		}
+	});
+
 });


### PR DESCRIPTION
## Repro

`discoverExtensionPaths` (`packages/coding-agent/src/extensibility/extensions/loader.ts`) calls `loadCapability<ExtensionModule>(extensionModuleCapability.id, loadOptions)` and then discards every item whose `_source.provider !== "native"`. The `extension-modules` capability has five providers registered (native, claude, codex, gemini, opencode), so four foreign directory walks (`~/.claude/extensions`, `~/.codex/extensions`, `~/.gemini/extensions`, `~/.config/opencode/plugins`, plus each project mirror) run on every startup only for their results to be dropped. A probe that wraps each provider's `.load()` with a counter and calls `discoverExtensionPaths([], tempCwd)` shows all five providers invoked; recorded via `repro_record`.

## Cause

`discoverExtensionPaths` in `packages/coding-agent/src/extensibility/extensions/loader.ts` filters the merged result post-hoc (`if (ext._source.provider !== "native") continue`) instead of scoping the load. `LoadOptions.providers` is a real filter (`packages/coding-agent/src/capability/index.ts` `filterProviders`) — passing it skips the walk entirely instead of running it and discarding the items.

## Fix

- `discoverExtensionPaths` now calls `loadCapability(extensionModuleCapability.id, { ...loadOptions, providers: ["native"] })`, dropping the post-hoc `_source.provider` check. The subsequent hook-capability load is untouched — hooks legitimately span providers. Same convention already used elsewhere in the repo (e.g. `test/discovery/codex-hooks-discovery.test.ts` scopes to `providers: ["codex"]`).
- Added `#4198` regression test in `packages/coding-agent/test/extensions-discovery.test.ts` that spies on every registered extension-module provider's `load()` and asserts only `native` is invoked (foreign providers hit 0). The test guards against the invariant vanishing by first asserting foreign providers exist.
- Changelog entry under `## [Unreleased]` in `packages/coding-agent/CHANGELOG.md`.

## Verification

- `bun test test/extensions-discovery.test.ts` — 39 pass, 0 fail (includes the new regression test).
- Verified the regression test **fails without the fix**: `git stash push` the loader change → same test errors with `foreign provider claude must not be walked` (received 1, expected 0). Restored via `git stash pop`, then rerun of the suite passes.
- Standalone repro script confirmed only the `native` provider's `load` is invoked after the fix (was five providers × 1 each; now `native: 1`, others `0`).

Fixes #4198