### PR TITLE
fix(coding-agent): reuse legacy extension graph source reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy Pi extension loading to reuse source already read while building the source graph, avoiding a duplicate disk read for each own-source module on startup. ([#4196](https://github.com/can1357/oh-my-pi/issues/4196))
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -882,8 +882,10 @@ function escapeRegExp(value: string): string {
 
 // Match source modules in an extension graph (relative imports and package
 // `imports` aliases such as `#src/*`). Bare third-party dependencies remain
-// native Bun resolutions.
-const EXTENSION_GRAPH_SPECIFIER_REGEX = /(?:from\s+|import\s+|import\s*\(\s*)["']((?:\.\.?\/|#)[^"']+)["']/g;
+// native Bun resolutions. Capture the import introducer so graph collection can
+// distinguish modules loaded during startup's static import phase from modules
+// that may not be read by Bun until a later `import()` call.
+const EXTENSION_GRAPH_SPECIFIER_REGEX = /(from\s+|import\s*\(\s*|import\s+)["']((?:\.\.?\/|#)[^"']+)["']/g;
 
 // Extension entry realpaths that already have a load-time rewrite hook
 // installed. Each `Bun.plugin()` registration is process-global and permanent,
@@ -908,47 +910,71 @@ async function realpathOrSelf(p: string): Promise<string> {
 	}
 }
 
+interface ExtensionModuleGraph {
+	modules: Set<string>;
+	startupSources: Map<string, string>;
+}
+
+interface ExtensionGraphQueueItem {
+	file: string;
+	cacheStartupSource: boolean;
+}
+
 /**
- * Walk the extension's relative-import graph starting at `entryRealPath`,
- * returning each reachable source module's realpath and already-read source.
- * Only relative specifiers (`./`, `../`) are followed — bare and absolute
- * imports are left to Bun's native resolver — so the map is exactly the
- * extension's own source, wherever it physically lives (a `../src` sibling,
- * a symlinked sub-tree, …). This mirrors the module set the old temp-dir mirror
- * tracked, minus the copy.
+ * Walk the extension's relative-import graph starting at `entryRealPath`.
+ * The returned `modules` set scopes the rewrite hook to every own-source module,
+ * including dynamic `import()` targets. `startupSources` only includes modules
+ * reached through static imports, because dynamic-import targets can be created
+ * or edited before their actual load time and must then fall through to disk.
  */
-async function collectExtensionModules(entryRealPath: string): Promise<Map<string, string>> {
-	const modules = new Map<string, string>();
-	const queue = [entryRealPath];
+async function collectExtensionModules(entryRealPath: string): Promise<ExtensionModuleGraph> {
+	const moduleSources = new Map<string, string>();
+	const startupSources = new Map<string, string>();
+	const processedStates = new Set<string>();
+	const queue: ExtensionGraphQueueItem[] = [{ file: entryRealPath, cacheStartupSource: true }];
 	while (queue.length > 0) {
-		const file = queue.pop();
-		if (!file || modules.has(file)) {
+		const item = queue.pop();
+		if (!item) {
 			continue;
 		}
-		let source: string;
-		try {
-			source = await Bun.file(file).text();
-		} catch {
+		const stateKey = `${item.cacheStartupSource ? "startup" : "lazy"}:${item.file}`;
+		if (processedStates.has(stateKey)) {
 			continue;
 		}
-		modules.set(file, source);
-		const dir = path.dirname(file);
+		processedStates.add(stateKey);
+		let source = moduleSources.get(item.file);
+		if (source === undefined) {
+			try {
+				source = await Bun.file(item.file).text();
+			} catch {
+				continue;
+			}
+			moduleSources.set(item.file, source);
+		}
+		if (item.cacheStartupSource) {
+			startupSources.set(item.file, source);
+		}
+		const dir = path.dirname(item.file);
 		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
-			const specifier = match[1];
-			if (!specifier) continue;
+			const importIntroducer = match[1];
+			const specifier = match[2];
+			if (!importIntroducer || !specifier) continue;
 			try {
 				const resolved = specifier.startsWith("#")
-					? await resolvePackageImportSpecifier(specifier, file)
+					? await resolvePackageImportSpecifier(specifier, item.file)
 					: await realpathOrSelf(Bun.resolveSync(specifier, dir));
-				if (resolved && !modules.has(resolved)) {
-					queue.push(resolved);
+				if (resolved) {
+					queue.push({
+						file: resolved,
+						cacheStartupSource: item.cacheStartupSource && !/^import\s*\(/.test(importIntroducer),
+					});
 				}
 			} catch {
 				// Unresolvable relative import (e.g. a type-only path); skip it.
 			}
 		}
 	}
-	return modules;
+	return { modules: new Set(moduleSources.keys()), startupSources };
 }
 
 /**
@@ -967,10 +993,10 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<stri
 		// repeat loads. Return `null` so the caller skips the extra reads.
 		return null;
 	}
-	const moduleSources = await collectExtensionModules(entryRealPath);
+	const graph = await collectExtensionModules(entryRealPath);
 	hookedExtensionEntries.add(entryRealPath);
 
-	const alternation = [...moduleSources.keys()].map(escapeRegExp).join("|");
+	const alternation = [...graph.modules].map(escapeRegExp).join("|");
 	const filter = new RegExp(`^(?:${alternation})$`);
 	Bun.plugin({
 		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
@@ -989,7 +1015,7 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<stri
 			});
 		},
 	});
-	return moduleSources;
+	return graph.startupSources;
 }
 
 /**

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -890,6 +890,15 @@ const EXTENSION_GRAPH_SPECIFIER_REGEX = /(?:from\s+|import\s+|import\s*\(\s*)["'
 // so we register at most one hook per entry.
 const hookedExtensionEntries = new Set<string>();
 
+// Source read while walking each entry's graph, keyed by entry realpath, so
+// the rewrite hook can consume it during the entry's synchronous initial load
+// instead of re-reading the same file. `loadLegacyPiModule` populates the
+// inner map immediately before its `await import(...)` and clears it in a
+// `finally` — lazy `import()`s that fire after that window fall through to a
+// fresh disk read so file edits between startup and the eventual dynamic
+// import are never masked by stale startup source.
+const extensionSourceCache = new Map<string, Map<string, string>>();
+
 /** Resolve symlinks in a path, falling back to the input if realpath fails. */
 async function realpathOrSelf(p: string): Promise<string> {
 	try {
@@ -951,28 +960,36 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
  * never matches the host, other extensions, `node_modules` deps, or unrelated
  * project source.
  */
-async function ensureExtensionGraphHook(entryRealPath: string): Promise<void> {
+async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<string, string> | null> {
 	if (hookedExtensionEntries.has(entryRealPath)) {
-		return;
+		// Hook is already installed; the graph walk would only re-read every
+		// module for a cache that Bun's module cache already short-circuits on
+		// repeat loads. Return `null` so the caller skips the extra reads.
+		return null;
 	}
+	const moduleSources = await collectExtensionModules(entryRealPath);
 	hookedExtensionEntries.add(entryRealPath);
 
-	const moduleSources = await collectExtensionModules(entryRealPath);
 	const alternation = [...moduleSources.keys()].map(escapeRegExp).join("|");
 	const filter = new RegExp(`^(?:${alternation})$`);
 	Bun.plugin({
 		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
 		setup(build) {
 			build.onLoad({ filter, namespace: "file" }, async args => {
-				const hasCachedSource = moduleSources.has(args.path);
-				const raw = hasCachedSource ? (moduleSources.get(args.path) ?? "") : await Bun.file(args.path).text();
-				if (hasCachedSource) {
-					moduleSources.delete(args.path);
+				const cache = extensionSourceCache.get(entryRealPath);
+				const cached = cache?.get(args.path);
+				let raw: string;
+				if (cached !== undefined) {
+					raw = cached;
+					cache?.delete(args.path);
+				} else {
+					raw = await Bun.file(args.path).text();
 				}
 				return { contents: await rewriteLegacyExtensionSource(raw, args.path), loader: getLoader(args.path) };
 			});
 		},
 	});
+	return moduleSources;
 }
 
 /**
@@ -991,9 +1008,20 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	// `bun link`/pnpm installs) so the rewrite filter matches the path Bun
 	// actually hands the hook.
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
-	await ensureExtensionGraphHook(entryRealPath);
-	// `?mtime` busts Bun's module cache so repeat loads pick up edited source.
-	return import(`${toImportSpecifier(entryRealPath)}?mtime=${Date.now()}`);
+	const moduleSources = await ensureExtensionGraphHook(entryRealPath);
+	if (moduleSources !== null) {
+		extensionSourceCache.set(entryRealPath, moduleSources);
+	}
+	try {
+		// `?mtime` busts Bun's module cache so repeat loads pick up edited source.
+		return await import(`${toImportSpecifier(entryRealPath)}?mtime=${Date.now()}`);
+	} finally {
+		// The synchronous entry evaluation just resolved. Any source still in
+		// the cache belongs to a lazy `import()` reachable from the graph but
+		// not yet triggered — drop it so its eventual `onLoad` re-reads fresh
+		// from disk instead of serving startup-time bytes.
+		extensionSourceCache.delete(entryRealPath);
+	}
 }
 
 function getLoader(path: string): "js" | "jsx" | "ts" | "tsx" {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -901,14 +901,15 @@ async function realpathOrSelf(p: string): Promise<string> {
 
 /**
  * Walk the extension's relative-import graph starting at `entryRealPath`,
- * returning the realpath of every reachable source module. Only relative
- * specifiers (`./`, `../`) are followed — bare and absolute imports are left to
- * Bun's native resolver — so the set is exactly the extension's own source,
- * wherever it physically lives (a `../src` sibling, a symlinked sub-tree, …).
- * This mirrors the module set the old temp-dir mirror tracked, minus the copy.
+ * returning each reachable source module's realpath and already-read source.
+ * Only relative specifiers (`./`, `../`) are followed — bare and absolute
+ * imports are left to Bun's native resolver — so the map is exactly the
+ * extension's own source, wherever it physically lives (a `../src` sibling,
+ * a symlinked sub-tree, …). This mirrors the module set the old temp-dir mirror
+ * tracked, minus the copy.
  */
-async function collectExtensionModules(entryRealPath: string): Promise<Set<string>> {
-	const modules = new Set<string>();
+async function collectExtensionModules(entryRealPath: string): Promise<Map<string, string>> {
+	const modules = new Map<string, string>();
 	const queue = [entryRealPath];
 	while (queue.length > 0) {
 		const file = queue.pop();
@@ -921,7 +922,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Set<strin
 		} catch {
 			continue;
 		}
-		modules.add(file);
+		modules.set(file, source);
 		const dir = path.dirname(file);
 		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
 			const specifier = match[1];
@@ -956,14 +957,18 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<void> {
 	}
 	hookedExtensionEntries.add(entryRealPath);
 
-	const modules = await collectExtensionModules(entryRealPath);
-	const alternation = [...modules].map(escapeRegExp).join("|");
+	const moduleSources = await collectExtensionModules(entryRealPath);
+	const alternation = [...moduleSources.keys()].map(escapeRegExp).join("|");
 	const filter = new RegExp(`^(?:${alternation})$`);
 	Bun.plugin({
 		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
 		setup(build) {
 			build.onLoad({ filter, namespace: "file" }, async args => {
-				const raw = await Bun.file(args.path).text();
+				const hasCachedSource = moduleSources.has(args.path);
+				const raw = hasCachedSource ? (moduleSources.get(args.path) ?? "") : await Bun.file(args.path).text();
+				if (hasCachedSource) {
+					moduleSources.delete(args.path);
+				}
 				return { contents: await rewriteLegacyExtensionSource(raw, args.path), loader: getLoader(args.path) };
 			});
 		},

--- a/packages/coding-agent/test/legacy-pi-compat.test.ts
+++ b/packages/coding-agent/test/legacy-pi-compat.test.ts
@@ -87,4 +87,22 @@ describe("legacy Pi extension source graph", () => {
 		await Bun.write(child, `export const value = 2;\n`);
 		expect(await loaded.loadChild()).toBe(2);
 	});
+
+	it("re-reads dynamic imports edited during startup evaluation", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "legacy-pi-startup-dynamic-import-test-"));
+		tempDirs.push(root);
+		const entry = path.join(root, "entry.ts");
+		const child = path.join(root, "child.ts");
+		await Bun.write(
+			entry,
+			`await Bun.write(${JSON.stringify(child)}, "export const value = 2;\\n");\nconst mod = await import("./child");\nexport const loaded = (mod as { value: number }).value;\n`,
+		);
+		await Bun.write(child, `export const value = 1;\n`);
+
+		const loaded = await loadLegacyPiModule(entry);
+		if (!isLoadedFixtureModule(loaded)) {
+			throw new Error("Legacy Pi fixture did not export a numeric loaded value");
+		}
+		expect(loaded.loaded).toBe(2);
+	});
 });

--- a/packages/coding-agent/test/legacy-pi-compat.test.ts
+++ b/packages/coding-agent/test/legacy-pi-compat.test.ts
@@ -13,6 +13,14 @@ function isLoadedFixtureModule(value: unknown): value is LoadedFixtureModule {
 	return typeof value === "object" && value !== null && "loaded" in value && typeof value.loaded === "number";
 }
 
+interface LazyFixtureModule {
+	loadChild: () => Promise<number>;
+}
+
+function isLazyFixtureModule(value: unknown): value is LazyFixtureModule {
+	return typeof value === "object" && value !== null && "loadChild" in value && typeof value.loadChild === "function";
+}
+
 describe("legacy Pi extension source graph", () => {
 	const tempDirs: string[] = [];
 
@@ -55,5 +63,28 @@ describe("legacy Pi extension source graph", () => {
 		} finally {
 			fileSpy.mockRestore();
 		}
+	});
+
+	it("re-reads lazily imported modules edited after startup", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "legacy-pi-lazy-import-test-"));
+		tempDirs.push(root);
+		const entry = path.join(root, "entry.ts");
+		const child = path.join(root, "child.ts");
+		await Bun.write(
+			entry,
+			`export async function loadChild() {\n\tconst mod = await import("./child");\n\treturn (mod as { value: number }).value;\n}\n`,
+		);
+		await Bun.write(child, `export const value = 1;\n`);
+
+		const loaded = await loadLegacyPiModule(entry);
+		if (!isLazyFixtureModule(loaded)) {
+			throw new Error("Legacy Pi fixture did not export loadChild");
+		}
+
+		// Simulate an update between the entry's initial load and the eventual
+		// dynamic import: the hook must see the edited source, not the copy
+		// buffered during the startup graph walk.
+		await Bun.write(child, `export const value = 2;\n`);
+		expect(await loaded.loadChild()).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/legacy-pi-compat.test.ts
+++ b/packages/coding-agent/test/legacy-pi-compat.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadLegacyPiModule } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+interface LoadedFixtureModule {
+	loaded: number;
+}
+
+function isLoadedFixtureModule(value: unknown): value is LoadedFixtureModule {
+	return typeof value === "object" && value !== null && "loaded" in value && typeof value.loaded === "number";
+}
+
+describe("legacy Pi extension source graph", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(async () => {
+		await Promise.all(tempDirs.splice(0).map(dir => removeWithRetries(dir)));
+	});
+
+	it("serves collected source to the rewrite hook once per module", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "legacy-pi-source-graph-test-"));
+		tempDirs.push(root);
+		const entry = path.join(root, "entry.ts");
+		const child = path.join(root, "child.ts");
+		await Bun.write(entry, `import { value } from "./child";\nexport const loaded = value + 1;\n`);
+		await Bun.write(child, `export const value = 41;\n`);
+
+		const tracked = new Set([entry, child]);
+		const readCounts = new Map<string, number>();
+		const originalFile = Bun.file;
+		const fileSpy = spyOn(Bun, "file").mockImplementation((input, options) => {
+			if (typeof input === "string" && tracked.has(input)) {
+				readCounts.set(input, (readCounts.get(input) ?? 0) + 1);
+			}
+			if (typeof input === "number") {
+				return originalFile(input, options);
+			}
+			if (typeof input === "string" || input instanceof URL) {
+				return originalFile(input, options);
+			}
+			return originalFile(input, options);
+		});
+
+		try {
+			const first = await loadLegacyPiModule(entry);
+			if (!isLoadedFixtureModule(first)) {
+				throw new Error("Legacy Pi fixture did not export a numeric loaded value");
+			}
+			expect(first.loaded).toBe(42);
+			expect(readCounts.get(entry)).toBe(1);
+			expect(readCounts.get(child)).toBe(1);
+		} finally {
+			fileSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A two-module legacy Pi extension fixture loaded through `loadLegacyPiModule()` reproduced the duplicate reads before the fix with `bun /tmp/repro-4196-extension-reads.ts`, reporting `entryReads: 2` and `childReads: 2` for one load.

## Cause
`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` read every reachable own-source module in `collectExtensionModules()` to build the exact `Bun.plugin()` filter, then `ensureExtensionGraphHook()` read the same `args.path` again inside the `onLoad` rewrite hook before calling `rewriteLegacyExtensionSource()`.

## Fix
- Changed `collectExtensionModules()` to return a `Map<realpath, source>` instead of only a `Set` of realpaths.
- Threaded that map into the extension rewrite hook and consume cached source on first `onLoad`, falling back to `Bun.file(args.path).text()` on misses.
- Added a regression test that loads an entry plus transitive module fixture and asserts each tracked source file is read once.
- Added the `packages/coding-agent` changelog entry for #4196.

## Verification
`bun /tmp/repro-4196-extension-reads.ts` now reports `entryReads: 1` and `childReads: 1`; `bun test packages/coding-agent/test/legacy-pi-compat.test.ts` passed; `bun run check:types` in `packages/coding-agent` passed. Fixes #4196