### PR TITLE
fix(model-discovery): auto-update ZenMux models into models.db without a key

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Removed reasoning suppression prompt logic for GPT-5 models
 
+### Fixed
+
+- Fixed ZenMux model discovery to run without a `ZENMUX_API_KEY`, so newly published ZenMux models (for example `anthropic/claude-fable-5-free`) auto-update into the runtime `models.db` cache instead of waiting on a regenerated `models.json`.
+- Fixed ZenMux runtime discovery to query the `/api/v1/models` endpoint even when the resolved provider base URL points at the Anthropic-compatible route, so discovery no longer requests a non-existent `/api/anthropic/models` path.
+
 ## [16.3.0] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -453,7 +453,8 @@ export const CATALOG_PROVIDERS = [
 		defaultModel: "anthropic/claude-opus-4.8",
 		envVars: ["ZENMUX_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => zenmuxModelManagerOptions(config),
-		catalogDiscovery: { label: "ZenMux" },
+		allowUnauthenticated: true,
+		catalogDiscovery: { label: "ZenMux", allowUnauthenticated: true },
 	},
 	{
 		id: "zhipu-coding-plan",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2035,7 +2035,11 @@ function normalizeZenMuxOpenAiBaseUrl(baseUrl?: string): string {
 	if (!value) {
 		return ZENMUX_OPENAI_BASE_URL;
 	}
-	return value.endsWith("/") ? value.slice(0, -1) : value;
+	const normalized = value.endsWith("/") ? value.slice(0, -1) : value;
+	if (normalized.endsWith("/api/anthropic")) {
+		return normalized.replace("/api/anthropic", "/api/v1");
+	}
+	return normalized;
 }
 
 function toZenMuxAnthropicBaseUrl(openAiBaseUrl: string): string {
@@ -2103,37 +2107,35 @@ export function zenmuxModelManagerOptions(config?: ZenMuxModelManagerConfig): Mo
 	const anthropicBaseUrl = toZenMuxAnthropicBaseUrl(openAiBaseUrl);
 	return {
 		providerId: "zenmux",
-		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels<Api>({
-					api: "openai-completions",
-					provider: "zenmux",
-					baseUrl: openAiBaseUrl,
-					apiKey,
-					mapModel: (entry, defaults) => {
-						const pricings = isRecord(entry.pricings) ? entry.pricings : undefined;
-						const capabilities = isRecord(entry.capabilities) ? entry.capabilities : undefined;
-						const isAnthropicModel = isZenMuxAnthropicModel(entry, defaults.id);
-						return {
-							...defaults,
-							name: toModelName(entry.display_name, defaults.name),
-							api: isAnthropicModel ? "anthropic-messages" : "openai-completions",
-							baseUrl: isAnthropicModel ? anthropicBaseUrl : openAiBaseUrl,
-							reasoning: capabilities?.reasoning === true || defaults.reasoning,
-							input: toInputCapabilities(entry.input_modalities),
-							cost: {
-								input: getZenMuxPricingValue(pricings, "prompt"),
-								output: getZenMuxPricingValue(pricings, "completion"),
-								cacheRead: getZenMuxPricingValue(pricings, "input_cache_read"),
-								cacheWrite: getZenMuxCacheWritePrice(pricings),
-							},
-							contextWindow: toPositiveNumber(entry.context_length, defaults.contextWindow),
-							maxTokens: toPositiveNumber(entry.max_completion_tokens, defaults.maxTokens),
-						};
-					},
-					fetch: config?.fetch,
-				}),
-		}),
+		fetchDynamicModels: () =>
+			fetchOpenAICompatibleModels<Api>({
+				api: "openai-completions",
+				provider: "zenmux",
+				baseUrl: openAiBaseUrl,
+				apiKey,
+				mapModel: (entry, defaults) => {
+					const pricings = isRecord(entry.pricings) ? entry.pricings : undefined;
+					const capabilities = isRecord(entry.capabilities) ? entry.capabilities : undefined;
+					const isAnthropicModel = isZenMuxAnthropicModel(entry, defaults.id);
+					return {
+						...defaults,
+						name: toModelName(entry.display_name, defaults.name),
+						api: isAnthropicModel ? "anthropic-messages" : "openai-completions",
+						baseUrl: isAnthropicModel ? anthropicBaseUrl : openAiBaseUrl,
+						reasoning: capabilities?.reasoning === true || defaults.reasoning,
+						input: toInputCapabilities(entry.input_modalities),
+						cost: {
+							input: getZenMuxPricingValue(pricings, "prompt"),
+							output: getZenMuxPricingValue(pricings, "completion"),
+							cacheRead: getZenMuxPricingValue(pricings, "input_cache_read"),
+							cacheWrite: getZenMuxCacheWritePrice(pricings),
+						},
+						contextWindow: toPositiveNumber(entry.context_length, defaults.contextWindow),
+						maxTokens: toPositiveNumber(entry.max_completion_tokens, defaults.maxTokens),
+					};
+				},
+				fetch: config?.fetch,
+			}),
 	};
 }
 

--- a/packages/catalog/test/zenmux-provider.test.ts
+++ b/packages/catalog/test/zenmux-provider.test.ts
@@ -95,4 +95,48 @@ describe("zenmux provider support", () => {
 		expect(openai?.baseUrl).toBe("https://zenmux.ai/api/v1");
 		expect(openai?.cost.output).toBe(10);
 	});
+
+	test("discovers models without an API key and sends no Authorization header", async () => {
+		delete Bun.env.ZENMUX_API_KEY;
+		let sentHeaders: RequestInit["headers"];
+		const fetchMock: FetchImpl = vi.fn(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				sentHeaders = init?.headers;
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "anthropic/claude-fable-5-free",
+								display_name: "Anthropic: Claude Fable 5 (Free)",
+								owned_by: "anthropic",
+								input_modalities: ["text", "image"],
+								capabilities: { reasoning: true },
+								context_length: 200000,
+								pricings: {
+									prompt: [{ value: 0, unit: "perMTokens", currency: "USD" }],
+									completion: [{ value: 0, unit: "perMTokens", currency: "USD" }],
+								},
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			},
+		);
+
+		const options = zenmuxModelManagerOptions({ fetch: fetchMock });
+		expect(options.fetchDynamicModels).toBeDefined();
+
+		const models = await options.fetchDynamicModels?.();
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://zenmux.ai/api/v1/models",
+			expect.objectContaining({ method: "GET" }),
+		);
+		expect(sentHeaders).not.toHaveProperty("Authorization");
+
+		const free = models?.find(model => model.id === "anthropic/claude-fable-5-free");
+		expect(free?.api).toBe("anthropic-messages");
+		expect(free?.baseUrl).toBe("https://zenmux.ai/api/anthropic");
+		expect(free?.cost.input).toBe(0);
+	});
 });

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -125,6 +125,87 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(await registry.getApiKey(ollamaModels[0])).toBe(kNoAuth);
 	});
 
+	test("auto-updates zenmux models keylessly and caches to models.db", async () => {
+		const originalKey = Bun.env.ZENMUX_API_KEY;
+		delete Bun.env.ZENMUX_API_KEY;
+		try {
+			// Phase 1: Online keyless discovery
+			let capturedHeaders: RequestInit["headers"];
+			const fetchMock: FetchImpl = async (input, init) => {
+				const url = String(input);
+				capturedHeaders = init?.headers;
+				if (url === "https://zenmux.ai/api/v1/models" || url === "https://zenmux.ai/api/v1/models/") {
+					return new Response(
+						JSON.stringify({
+							data: [
+								{
+									id: "anthropic/claude-fable-5-free",
+									name: "Claude Fable 5 Free",
+									display_name: "Claude Fable 5 Free",
+									object: "model",
+									owned_by: "anthropic",
+									input_modalities: ["text", "image"],
+									capabilities: { reasoning: true, tool_call: true },
+									context_length: 200000,
+									max_completion_tokens: 128000,
+									pricings: {
+										prompt: [{ value: 0, unit: "perMTokens", currency: "USD" }],
+										completion: [{ value: 0, unit: "perMTokens", currency: "USD" }],
+									},
+								},
+							],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				throw new Error(`Unexpected URL: ${url}`);
+			};
+
+			const registry1 = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+			await registry1.refreshProvider("zenmux", "online");
+
+			// Assert Phase 1
+			if (!capturedHeaders) {
+				throw new Error("No headers captured");
+			}
+			const headers = new Headers(capturedHeaders);
+			expect(headers.has("authorization")).toBe(false);
+
+			const zenmuxModels = getModelsForProvider(registry1, "zenmux");
+			const fable = zenmuxModels.find(m => m.id === "anthropic/claude-fable-5-free");
+			expect(fable).toBeDefined();
+			expect(fable?.api).toBe("anthropic-messages");
+			expect(fable?.baseUrl).toBe("https://zenmux.ai/api/anthropic");
+
+			// Boundary: keyless discovery populates the cache and find(), but ZenMux is
+			// a paid gateway (not in #keylessProviders), so without ZENMUX_API_KEY the
+			// model must NOT appear in the selectable set — it would 401 at inference.
+			expect(registry1.find("zenmux", "anthropic/claude-fable-5-free")).toBeDefined();
+			expect(
+				registry1.getAvailable().some(m => m.provider === "zenmux" && m.id === "anthropic/claude-fable-5-free"),
+			).toBe(false);
+
+			// Phase 2: Offline from models.db
+			const fetchOffline: FetchImpl = async () => {
+				throw new Error("Offline fetch should not be called");
+			};
+			const registry2 = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchOffline });
+			await registry2.refreshProvider("zenmux", "offline");
+
+			const offlineZenmuxModels = getModelsForProvider(registry2, "zenmux");
+			const offlineFable = offlineZenmuxModels.find(m => m.id === "anthropic/claude-fable-5-free");
+			expect(offlineFable).toBeDefined();
+			expect(offlineFable?.api).toBe("anthropic-messages");
+			expect(offlineFable?.baseUrl).toBe("https://zenmux.ai/api/anthropic");
+		} finally {
+			if (originalKey === undefined) {
+				delete Bun.env.ZENMUX_API_KEY;
+			} else {
+				Bun.env.ZENMUX_API_KEY = originalKey;
+			}
+		}
+	});
+
 	test("uses OLLAMA_HOST for implicit ollama discovery", async () => {
 		using _baseUrl = withEnv("OLLAMA_BASE_URL", undefined);
 		using _host = withEnv("OLLAMA_HOST", "ollama.lan:12345");


### PR DESCRIPTION
## Summary

Newly published ZenMux models stayed invisible at runtime until the bundled `models.json` was regenerated. Without a `ZENMUX_API_KEY` the runtime never built a ZenMux discovery manager, so nothing reached the local `models.db` cache — and even *with* a key, runtime discovery queried the wrong endpoint and returned nothing. Now ZenMux discovery runs against its public `/api/v1/models` endpoint (no auth required) and caches results to `models.db`, so a freshly published model such as `anthropic/claude-fable-5-free` shows up at runtime without waiting on a catalog regen.

Two independent gates were blocking this:

| Root cause | Fix |
|---|---|
| `fetchDynamicModels` was defined only when an API key was present, and the descriptor lacked the top-level `allowUnauthenticated` flag that gates keyless runtime manager creation. | Make the fetcher unconditional and add top-level `allowUnauthenticated: true`, matching the ollama/lm-studio pattern, so the runtime builds a keyless manager and writes discoveries to `models.db`. |
| `getProviderBaseUrl("zenmux")` returns the first bundled model's base URL, which for ZenMux is the anthropic-routed `/api/anthropic`. Discovery then fetched the nonexistent `/api/anthropic/models` instead of `/api/v1/models` — breaking discovery even for keyed users. | `normalizeZenMuxOpenAiBaseUrl` remaps a trailing `/api/anthropic` back to `/api/v1` before the `/models` fetch (symmetric with `toZenMuxAnthropicBaseUrl`). |

### Deliberate scope boundary

ZenMux is a paid gateway, so it is intentionally **not** added to `#keylessProviders`. Discovered models are cached and reachable via `find()`, but without credentials they are excluded from `getAvailable()`/the picker — they would `401` at inference. A regression test locks this boundary in.

## Validation

- `bun test packages/catalog/test/zenmux-provider.test.ts packages/coding-agent/test/model-discovery.test.ts` — 44 pass, 0 fail (on current `main`).
- New runtime test `auto-updates zenmux models keylessly and caches to models.db` exercises the full chain: keyless `refreshProvider("zenmux", "online")` sends no `Authorization` header and populates `models.db`, then a second registry with a throwing fetch + `"offline"` reads the model back from cache, and asserts the model is in `find()` but absent from `getAvailable()`.
- New catalog-level test asserts keyless `zenmuxModelManagerOptions()` defines `fetchDynamicModels` and sends no `Authorization` header.
- `bun check` clean (typecheck + biome).

No user-visible UI surface; validation is test output rather than a screenshot.
