### PR TITLE
perf(extensibility): read extension source graph once per load

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced extension startup cost, especially on Windows, by reading each extension source-graph module from disk once per load instead of twice (the graph scan now feeds the load-time rewrite hook) ([#4196](https://github.com/can1357/oh-my-pi/issues/4196)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -907,8 +907,8 @@ async function realpathOrSelf(p: string): Promise<string> {
  * wherever it physically lives (a `../src` sibling, a symlinked sub-tree, …).
  * This mirrors the module set the old temp-dir mirror tracked, minus the copy.
  */
-async function collectExtensionModules(entryRealPath: string): Promise<Set<string>> {
-	const modules = new Set<string>();
+async function collectExtensionModules(entryRealPath: string): Promise<Map<string, string>> {
+	const modules = new Map<string, string>();
 	const queue = [entryRealPath];
 	while (queue.length > 0) {
 		const file = queue.pop();
@@ -921,7 +921,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Set<strin
 		} catch {
 			continue;
 		}
-		modules.add(file);
+		modules.set(file, source);
 		const dir = path.dirname(file);
 		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
 			const specifier = match[1];
@@ -957,13 +957,21 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<void> {
 	hookedExtensionEntries.add(entryRealPath);
 
 	const modules = await collectExtensionModules(entryRealPath);
-	const alternation = [...modules].map(escapeRegExp).join("|");
+	const alternation = [...modules.keys()].map(escapeRegExp).join("|");
 	const filter = new RegExp(`^(?:${alternation})$`);
 	Bun.plugin({
 		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
 		setup(build) {
 			build.onLoad({ filter, namespace: "file" }, async args => {
-				const raw = await Bun.file(args.path).text();
+				const cached = modules.get(args.path);
+				let raw: string;
+				if (cached !== undefined) {
+					// consume-once: preserves ?mtime edit-pickup for the re-imported entry
+					modules.delete(args.path);
+					raw = cached;
+				} else {
+					raw = await Bun.file(args.path).text();
+				}
 				return { contents: await rewriteLegacyExtensionSource(raw, args.path), loader: getLoader(args.path) };
 			});
 		},

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -1,75 +1,75 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn, type Mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, type Mock, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { BunFile } from "bun";
 import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import type { BunFile } from "bun";
 
 describe("Extension Loader Graph Read Dedup", () => {
-    let tempDir: TempDir;
-    let reads: Map<string, number>;
-    let fileSpy: Mock<typeof Bun.file>;
+	let tempDir: TempDir;
+	let reads: Map<string, number>;
+	let fileSpy: Mock<typeof Bun.file>;
 
-    beforeEach(() => {
-        tempDir = TempDir.createSync("@pi-ext-dedup-");
-        reads = new Map<string, number>();
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-ext-dedup-");
+		reads = new Map<string, number>();
 
-        const realBunFile = Bun.file.bind(Bun);
-        
-        const spyImpl = (path: string | URL, options?: BlobPropertyBag): BunFile => {
-            const handle = realBunFile(path, options);
-            if (typeof path === "string") {
-                const key = fs.existsSync(path) ? fs.realpathSync(path) : path;
-                const bump = () => {
-                    reads.set(key, (reads.get(key) ?? 0) + 1);
-                };
+		const realBunFile = Bun.file.bind(Bun);
 
-                return new Proxy(handle, {
-                    get(target: BunFile, prop: string | symbol, recv: unknown): unknown {
-                        if (prop === "text" || prop === "arrayBuffer" || prop === "bytes" || prop === "json") {
-                            const original = Reflect.get(target, prop, recv) as ((...a: unknown[]) => unknown) | undefined;
-                            if (typeof original === "function") {
-                                return (...methodArgs: unknown[]): unknown => {
-                                    bump();
-                                    return original.apply(target, methodArgs);
-                                };
-                            }
-                        }
-                        return Reflect.get(target, prop, recv);
-                    },
-                });
-            }
-            return handle;
-        };
-        fileSpy = spyOn(Bun, "file").mockImplementation(spyImpl as typeof Bun.file);
-    });
+		const spyImpl = (path: string | URL, options?: BlobPropertyBag): BunFile => {
+			const handle = realBunFile(path, options);
+			if (typeof path === "string") {
+				const key = fs.existsSync(path) ? fs.realpathSync(path) : path;
+				const bump = () => {
+					reads.set(key, (reads.get(key) ?? 0) + 1);
+				};
 
-    afterEach(() => {
-        if (fileSpy) {
-            fileSpy.mockRestore();
-        }
-        if (tempDir) {
-            tempDir.removeSync();
-        }
-    });
+				return new Proxy(handle, {
+					get(target: BunFile, prop: string | symbol, recv: unknown): unknown {
+						if (prop === "text" || prop === "arrayBuffer" || prop === "bytes" || prop === "json") {
+							const original = Reflect.get(target, prop, recv) as ((...a: unknown[]) => unknown) | undefined;
+							if (typeof original === "function") {
+								return (...methodArgs: unknown[]): unknown => {
+									bump();
+									return original.apply(target, methodArgs);
+								};
+							}
+						}
+						return Reflect.get(target, prop, recv);
+					},
+				});
+			}
+			return handle;
+		};
+		fileSpy = spyOn(Bun, "file").mockImplementation(spyImpl as typeof Bun.file);
+	});
 
-    it("should read each extension module from disk exactly once", async () => {
-        const cwd = tempDir.absolute();
-        const extDir = path.join(cwd, "ext");
-        fs.mkdirSync(extDir, { recursive: true });
+	afterEach(() => {
+		if (fileSpy) {
+			fileSpy.mockRestore();
+		}
+		if (tempDir) {
+			tempDir.removeSync();
+		}
+	});
 
-        const numModules = 120;
-        for (let i = 0; i < numModules; i++) {
-            const modPath = path.join(extDir, `mod-${i}.ts`);
-            let content = `export const v${i} = ${i};\n`;
-            if (i < numModules - 1) {
-                content += `import "./mod-${i + 1}.ts";\n`;
-            }
-            fs.writeFileSync(modPath, content, "utf-8");
-        }
+	it("should read each extension module from disk exactly once", async () => {
+		const cwd = tempDir.absolute();
+		const extDir = path.join(cwd, "ext");
+		fs.mkdirSync(extDir, { recursive: true });
 
-        const entryPath = path.join(extDir, "index.ts");
-        const entryContent = `import "./mod-0.ts";
+		const numModules = 120;
+		for (let i = 0; i < numModules; i++) {
+			const modPath = path.join(extDir, `mod-${i}.ts`);
+			let content = `export const v${i} = ${i};\n`;
+			if (i < numModules - 1) {
+				content += `import "./mod-${i + 1}.ts";\n`;
+			}
+			fs.writeFileSync(modPath, content, "utf-8");
+		}
+
+		const entryPath = path.join(extDir, "index.ts");
+		const entryContent = `import "./mod-0.ts";
 export default function(pi) {
     const { Type } = pi.typebox;
     pi.registerTool({
@@ -81,21 +81,21 @@ export default function(pi) {
     });
 }
 `;
-        fs.writeFileSync(entryPath, entryContent, "utf-8");
+		fs.writeFileSync(entryPath, entryContent, "utf-8");
 
-        const result = await loadExtensions([entryPath], cwd);
+		const result = await loadExtensions([entryPath], cwd);
 
-        expect(result.errors).toHaveLength(0);
-        expect(result.extensions[0].tools.has("dedup-tool")).toBe(true);
+		expect(result.errors).toHaveLength(0);
+		expect(result.extensions[0].tools.has("dedup-tool")).toBe(true);
 
-        const checkReadCount = (filePath: string) => {
-            const real = fs.existsSync(filePath) ? fs.realpathSync(filePath) : filePath;
-            expect(reads.get(real) ?? 0).toBe(1);
-        };
+		const checkReadCount = (filePath: string) => {
+			const real = fs.existsSync(filePath) ? fs.realpathSync(filePath) : filePath;
+			expect(reads.get(real) ?? 0).toBe(1);
+		};
 
-        checkReadCount(entryPath);
-        for (let i = 0; i < numModules; i++) {
-            checkReadCount(path.join(extDir, `mod-${i}.ts`));
-        }
-    });
+		checkReadCount(entryPath);
+		for (let i = 0; i < numModules; i++) {
+			checkReadCount(path.join(extDir, `mod-${i}.ts`));
+		}
+	});
 });

--- a/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
+++ b/packages/coding-agent/test/extension-loader-graph-read-dedup.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn, type Mock } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { BunFile } from "bun";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("Extension Loader Graph Read Dedup", () => {
+    let tempDir: TempDir;
+    let reads: Map<string, number>;
+    let fileSpy: Mock<typeof Bun.file>;
+
+    beforeEach(() => {
+        tempDir = TempDir.createSync("@pi-ext-dedup-");
+        reads = new Map<string, number>();
+
+        const realBunFile = Bun.file.bind(Bun);
+        
+        const spyImpl = (path: string | URL, options?: BlobPropertyBag): BunFile => {
+            const handle = realBunFile(path, options);
+            if (typeof path === "string") {
+                const key = fs.existsSync(path) ? fs.realpathSync(path) : path;
+                const bump = () => {
+                    reads.set(key, (reads.get(key) ?? 0) + 1);
+                };
+
+                return new Proxy(handle, {
+                    get(target: BunFile, prop: string | symbol, recv: unknown): unknown {
+                        if (prop === "text" || prop === "arrayBuffer" || prop === "bytes" || prop === "json") {
+                            const original = Reflect.get(target, prop, recv) as ((...a: unknown[]) => unknown) | undefined;
+                            if (typeof original === "function") {
+                                return (...methodArgs: unknown[]): unknown => {
+                                    bump();
+                                    return original.apply(target, methodArgs);
+                                };
+                            }
+                        }
+                        return Reflect.get(target, prop, recv);
+                    },
+                });
+            }
+            return handle;
+        };
+        fileSpy = spyOn(Bun, "file").mockImplementation(spyImpl as typeof Bun.file);
+    });
+
+    afterEach(() => {
+        if (fileSpy) {
+            fileSpy.mockRestore();
+        }
+        if (tempDir) {
+            tempDir.removeSync();
+        }
+    });
+
+    it("should read each extension module from disk exactly once", async () => {
+        const cwd = tempDir.absolute();
+        const extDir = path.join(cwd, "ext");
+        fs.mkdirSync(extDir, { recursive: true });
+
+        const numModules = 120;
+        for (let i = 0; i < numModules; i++) {
+            const modPath = path.join(extDir, `mod-${i}.ts`);
+            let content = `export const v${i} = ${i};\n`;
+            if (i < numModules - 1) {
+                content += `import "./mod-${i + 1}.ts";\n`;
+            }
+            fs.writeFileSync(modPath, content, "utf-8");
+        }
+
+        const entryPath = path.join(extDir, "index.ts");
+        const entryContent = `import "./mod-0.ts";
+export default function(pi) {
+    const { Type } = pi.typebox;
+    pi.registerTool({
+        name: "dedup-tool",
+        label: "dedup-tool",
+        description: "Test tool",
+        parameters: Type.Object({}),
+        execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    });
+}
+`;
+        fs.writeFileSync(entryPath, entryContent, "utf-8");
+
+        const result = await loadExtensions([entryPath], cwd);
+
+        expect(result.errors).toHaveLength(0);
+        expect(result.extensions[0].tools.has("dedup-tool")).toBe(true);
+
+        const checkReadCount = (filePath: string) => {
+            const real = fs.existsSync(filePath) ? fs.realpathSync(filePath) : filePath;
+            expect(reads.get(real) ?? 0).toBe(1);
+        };
+
+        checkReadCount(entryPath);
+        for (let i = 0; i < numModules; i++) {
+            checkReadCount(path.join(extDir, `mod-${i}.ts`));
+        }
+    });
+});


### PR DESCRIPTION
Closes #4196

## Problem
On startup the legacy-pi extension loader reads every own-source module from disk **twice**: `collectExtensionModules` reads each module's text to scan its `./`/`#` imports and build the graph, then the `Bun.plugin` `onLoad` rewrite hook installed by `ensureExtensionGraphHook` reads each file again before rewriting. On Windows (expensive per-file syscalls) this doubles the extension graph read cost on the cold-start path.

## Change
- `collectExtensionModules` now returns `Map<path, source>` instead of `Set<path>` (it already had the source in hand).
- The `onLoad` hook serves that collected source **consume-once**: it deletes the entry on first hit and falls back to a disk read on a miss.

This preserves the entry module's `?mtime` re-import contract — `ensureExtensionGraphHook` early-returns after the first install and the entry's map slot is consumed, so a repeat load re-reads the entry fresh from disk exactly as before. Transitive modules (loaded once per process by Bun's module cache) are served from memory.

## Verification
- `tsgo -p tsconfig.json --noEmit`: clean.
- New regression test `extension-loader-graph-read-dedup.test.ts` asserts each graph module is read exactly once (fails at 2 on the pre-change code); passes.
- Existing extension suites (`extensions-discovery`, `extension-loader-self-import`, `pi-scope-aliases`, `issue-973`, `issue-1215`, `extension-loader-process-exit`) pass unchanged.
