### PR TITLE
perf(extensibility,plugins): memoize plugin/extension resolution with shared invalidation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced repeated startup filesystem work (notably on Windows) by memoizing plugin enumeration (`getEnabledPlugins`) per working directory and caching legacy-pi bare-dependency, package-manifest, node-package-root, and realpath resolution, all invalidated through the existing plugin-cache reset path ([#4197](https://github.com/can1357/oh-my-pi/issues/4197)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -1007,8 +1007,24 @@ export async function listClaudePluginRoots(
 /**
  * Clear the plugin roots cache (useful for testing or when plugins change).
  */
+// Cache-invalidation subscribers registered by dependent modules (e.g. the
+// plugin loader's enabled-plugins memo) so they clear on the same choke point
+// that clears the plugin roots cache — without importing back into this module
+// (keeps the loader→helpers dependency one-directional).
+const pluginCacheInvalidators = new Set<() => void>();
+
+/**
+ * Register a callback invoked whenever the plugin roots cache is cleared
+ * (project switch, plugin install/enable/disable). Returns an unsubscribe fn.
+ */
+export function registerPluginCacheInvalidator(fn: () => void): () => void {
+	pluginCacheInvalidators.add(fn);
+	return () => pluginCacheInvalidators.delete(fn);
+}
+
 export function clearClaudePluginRootsCache(): void {
 	pluginRootsCache.clear();
+	for (const invalidate of pluginCacheInvalidators) invalidate();
 	preloadedPluginRoots = [...injectedPluginDirRoots];
 	// Re-warm preloaded roots asynchronously so sync LSP config reads stay valid
 	if (lastPreloadHome) {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -3,6 +3,7 @@ import { isBuiltin } from "node:module";
 import * as path from "node:path";
 import * as url from "node:url";
 import { isCompiledBinary, stripWindowsExtendedLengthPathPrefix } from "@oh-my-pi/pi-utils";
+import { registerPluginCacheInvalidator } from "../../discovery/helpers";
 import { BUNDLED_PI_REGISTRY_KEYS } from "./legacy-pi-bundled-keys";
 
 const IS_COMPILED_BINARY = isCompiledBinary();
@@ -202,6 +203,26 @@ const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", 
 const SUPPORTED_PACKAGE_IMPORT_CONDITIONS = new Set(["bun", "node", "import", "default"]);
 const packageRootCache = new Map<string, string | null>();
 const packageImportsCache = new Map<string, Record<string, unknown> | null>();
+const bareDependencyResolutionCache = new Map<string, string | null>();
+const packageManifestCache = new Map<string, Record<string, unknown> | null>();
+const nodePackageRootCache = new Map<string, string | null>();
+const realpathCache = new Map<string, string>();
+
+// The four caches above (bare-dep resolution, package manifest, node-package
+// root, realpath) are process-global and keyed by absolute path/specifier. A
+// plugin install/upgrade/reload can rewrite a `node_modules` junction or a
+// symlink target in-process, which would otherwise make these caches serve a
+// stale pre-upgrade path. Self-registered on the plugin-cache invalidation
+// choke point (fired by clearClaudePluginRootsCache) from this cache-owning
+// module so the hook exists whenever the caches can populate, regardless of
+// which loader imported us — a reloaded extension re-resolves fresh.
+function clearLegacyPiCompatCaches(): void {
+	bareDependencyResolutionCache.clear();
+	packageManifestCache.clear();
+	nodePackageRootCache.clear();
+	realpathCache.clear();
+}
+registerPluginCacheInvalidator(clearLegacyPiCompatCaches);
 const PACKAGE_IMPORT_EXCLUDED = Symbol("packageImportExcluded");
 
 // Extensions that imported TypeBox directly used to resolve against a real
@@ -730,14 +751,21 @@ function splitBarePackageSpecifier(specifier: string): BarePackageSpecifier | nu
 }
 
 async function findNodePackageRoot(packageName: string, importerPath: string): Promise<string | null> {
+	const cacheKey = `${path.dirname(importerPath)}\u0000${packageName}`;
+	const cached = nodePackageRootCache.get(cacheKey);
+	if (cached !== undefined) {
+		return cached;
+	}
 	let dir = path.dirname(importerPath);
 	while (true) {
 		const candidate = path.join(dir, "node_modules", packageName);
 		if (await pathExists(path.join(candidate, "package.json"))) {
+			nodePackageRootCache.set(cacheKey, candidate);
 			return candidate;
 		}
 		const parent = path.dirname(dir);
 		if (parent === dir) {
+			nodePackageRootCache.set(cacheKey, null);
 			return null;
 		}
 		dir = parent;
@@ -745,12 +773,19 @@ async function findNodePackageRoot(packageName: string, importerPath: string): P
 }
 
 async function readPackageManifest(packageRoot: string): Promise<Record<string, unknown> | null> {
-	try {
-		const manifest = await Bun.file(path.join(packageRoot, "package.json")).json();
-		return isRecord(manifest) ? manifest : null;
-	} catch {
-		return null;
+	const cached = packageManifestCache.get(packageRoot);
+	if (cached !== undefined) {
+		return cached;
 	}
+	let manifest: Record<string, unknown> | null = null;
+	try {
+		const parsed = await Bun.file(path.join(packageRoot, "package.json")).json();
+		manifest = isRecord(parsed) ? parsed : null;
+	} catch {
+		manifest = null;
+	}
+	packageManifestCache.set(packageRoot, manifest);
+	return manifest;
 }
 
 async function resolvePackageExportTarget(
@@ -841,15 +876,26 @@ async function resolveExtensionBareDependency(specifier: string, importerPath: s
 	if (!isBareExtensionDependencySpecifier(specifier)) {
 		return null;
 	}
+	const dir = path.dirname(importerPath);
+	const cacheKey = `${dir}\u0000${specifier}`;
+	const cached = bareDependencyResolutionCache.get(cacheKey);
+	if (cached !== undefined) {
+		return cached;
+	}
+	let result: string | null = null;
 	try {
-		const resolved = Bun.resolveSync(specifier, path.dirname(importerPath));
+		const resolved = Bun.resolveSync(specifier, dir);
 		if (resolved && resolved !== specifier && !resolved.startsWith("node:") && !resolved.startsWith("bun:")) {
-			return resolved;
+			result = resolved;
 		}
 	} catch {
 		// Compiled binaries do not reliably resolve runtime extension node_modules.
 	}
-	return resolveNodePackageDependency(specifier, importerPath);
+	if (result === null) {
+		result = await resolveNodePackageDependency(specifier, importerPath);
+	}
+	bareDependencyResolutionCache.set(cacheKey, result);
+	return result;
 }
 
 async function rewriteExtensionBareImports(source: string, importerPath: string): Promise<string> {
@@ -892,8 +938,14 @@ const hookedExtensionEntries = new Set<string>();
 
 /** Resolve symlinks in a path, falling back to the input if realpath fails. */
 async function realpathOrSelf(p: string): Promise<string> {
+	const cached = realpathCache.get(p);
+	if (cached !== undefined) {
+		return cached;
+	}
 	try {
-		return await fs.promises.realpath(p);
+		const resolved = await fs.promises.realpath(p);
+		realpathCache.set(p, resolved);
+		return resolved;
 	} catch {
 		return p;
 	}

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { getPluginsDir, getPluginsLockfile, isEnoent } from "@oh-my-pi/pi-utils";
 import { getConfigDirPaths } from "../../config";
-import { resolveActiveProjectRegistryPath } from "../../discovery/helpers";
+import { registerPluginCacheInvalidator, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import { installLegacyPiSpecifierShim } from "./legacy-pi-compat";
 import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type { InstalledPlugin, PluginManifest, PluginRuntimeConfig, ProjectPluginOverrides } from "./types";
@@ -161,8 +161,37 @@ async function collectPluginsAtRoot(
  * need to enumerate plugins relative to a non-default home (tests with a
  * tempdir, discovery loaders threaded with `LoadContext.home`).
  */
-export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<ScopedInstalledPlugin[]> {
+// Per-(cwd,home) memo for the enabled-plugins enumeration. A single discovery
+// pass calls getEnabledPlugins up to ~11 times (7 omp-plugin capability loaders
+// via listOmpExtensionRoots + getAllPlugin{Tool,Hook,Command,Extension}Paths),
+// each otherwise re-reading user+project package.json/lockfiles and every
+// plugin manifest from disk — a syscall storm that dominates Windows startup.
+// Inputs are (cwd, home, on-disk plugin state); every plugin-state mutation
+// routes through clearPluginRootsAndCaches -> clearClaudePluginRootsCache, which
+// fires the registered invalidator below, mirroring pluginRootsCache's lifecycle.
+const enabledPluginsCache = new Map<string, Promise<ScopedInstalledPlugin[]>>();
+registerPluginCacheInvalidator(() => enabledPluginsCache.clear());
+
+export function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<ScopedInstalledPlugin[]> {
 	const { home } = opts;
+	const cacheKey = `${home ?? ""}\u0000${cwd}`;
+	const cached = enabledPluginsCache.get(cacheKey);
+	if (cached) return cached;
+	// Cache the promise (not the resolved value) so concurrent callers in one
+	// pass share a single enumeration. On rejection, evict so a transient
+	// failure is retried — but only if this exact promise is still the cached
+	// entry, so a clear()+repopulate that raced ahead of us is not clobbered.
+	const pending = computeEnabledPlugins(cwd, home).catch((err: unknown) => {
+		if (enabledPluginsCache.get(cacheKey) === pending) {
+			enabledPluginsCache.delete(cacheKey);
+		}
+		throw err;
+	});
+	enabledPluginsCache.set(cacheKey, pending);
+	return pending;
+}
+
+async function computeEnabledPlugins(cwd: string, home: string | undefined): Promise<ScopedInstalledPlugin[]> {
 	const projectOverrides = await loadProjectOverrides(cwd);
 
 	const userRoot = getPluginsDir(home);


### PR DESCRIPTION
Closes #4197

## Problem
Plugin/extension resolution repeats uncached filesystem work every discovery pass, worst on Windows:
- `getEnabledPlugins` runs ~11×/startup (7 omp-plugin capability loaders via `listOmpExtensionRoots` + `getAllPlugin{Tool,Hook,Command,Extension}Paths`), each re-reading user+project `package.json`/`omp-plugins.lock.json` and every installed plugin's `package.json`.
- Legacy-pi bare-dependency resolution (`resolveExtensionBareDependency` → `findNodePackageRoot` → `readPackageManifest`) and `realpathOrSelf` are uncached, re-running per bare import per module. (The `#`-alias path already caches via `packageRootCache`/`packageImportsCache`; the node-dep path did not.)

## Change
- Memoize `getEnabledPlugins` per `(cwd, home)`. The promise (not the resolved value) is cached so concurrent callers in one pass share a single enumeration; on rejection the entry is evicted **only if it is still the cached promise** (so a racing invalidate+repopulate is not clobbered).
- Add four process-global resolution caches in `legacy-pi-compat.ts` (bare-dep, manifest, node-root, realpath).
- Introduce `registerPluginCacheInvalidator` in `discovery/helpers.ts`, fired from `clearClaudePluginRootsCache` — the choke point every plugin install/enable/disable/project-switch already routes through. The memo clears via it; the legacy caches self-register from their owning module so the clear hook exists whenever they can populate (independent of load order). This mirrors the existing `pluginRootsCache` lifecycle, keeping mutate→read correct.

## Verification
- `tsgo -p tsconfig.json --noEmit`: clean.
- 296 pass / 0 fail across `marketplace/`, `plugin-extensions-discovery`, `plugin-config`, `extensions-discovery`, `issue-973`, `pi-scope-aliases` — including the marketplace mutate-then-read paths that pin the freshness contract.
- Independent review + adversarial critic confirmed no stale-read path (all plugin-state mutations route through the invalidation choke point) and the rejection-race guard.
