### PR TITLE
perf(extensibility): load only native provider for extension-module discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced startup filesystem work by loading only the native provider during extension-module discovery (`discoverExtensionPaths`), instead of walking all providers and discarding non-native results ([#4198](https://github.com/can1357/oh-my-pi/issues/4198)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -521,8 +521,13 @@ export async function discoverExtensionPaths(
 		}
 	};
 
-	// 1. Discover extension modules via capability API (native .omp/.pi only)
-	const discovered = await loadCapability<ExtensionModule>(extensionModuleCapability.id, loadOptions);
+	// 1. Discover extension modules via capability API. Only the native provider's
+	// modules are used below, so restrict the load to it — this skips the foreign
+	// provider dir-walks (claude/codex/gemini/opencode) whose results we discard.
+	const discovered = await loadCapability<ExtensionModule>(extensionModuleCapability.id, {
+		...loadOptions,
+		providers: ["native"],
+	});
 	for (const ext of discovered.items) {
 		if (ext._source.provider !== "native") continue;
 		addPath(ext.path);


### PR DESCRIPTION
Closes #4198

## Problem
`discoverExtensionPaths` loads the extension-module capability across **all** registered providers (native, claude, codex, gemini, opencode), then discards everything whose `_source.provider !== "native"`. Four foreign-provider directory walks run each startup only to have their results thrown away — wasted filesystem work, worst on Windows.

## Change
Scope the extension-module `loadCapability` to `providers: ["native"]` (the existing `LoadOptions.providers` filter). Output is identical (the loop already kept only `native`); the four discarded provider dir-walks are skipped. The hook-capability load in the same function is left unchanged — hooks legitimately span providers.

## Verification
- `tsgo -p tsconfig.json --noEmit`: clean.
- Extension discovery suites pass unchanged.
