### PR TITLE
perf(tui): avoid per-entry statSync in /move directory autocomplete

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved `/move` directory autocomplete performance on Windows by caching directory entries (`fs.Dirent[]`) and avoiding a `statSync` per entry on every keystroke ([#4199](https://github.com/can1357/oh-my-pi/issues/4199)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/modes/components/move-overlay.ts
+++ b/packages/coding-agent/src/modes/components/move-overlay.ts
@@ -29,19 +29,32 @@ const OVERLAY_WIDTH = 68;
 
 /** TTL for the directory listing cache (ms). */
 const DIR_CACHE_TTL = 500;
-const dirCache = new Map<string, { time: number; entries: string[] }>();
+const dirCache = new Map<string, { time: number; entries: fs.Dirent[] }>();
 
-function readDirCached(dir: string): string[] {
+function readDirCached(dir: string): fs.Dirent[] {
 	const now = Date.now();
 	const cached = dirCache.get(dir);
 	if (cached && now - cached.time < DIR_CACHE_TTL) return cached.entries;
 	try {
-		const entries = fs.readdirSync(dir);
+		const entries = fs.readdirSync(dir, { withFileTypes: true });
 		dirCache.set(dir, { time: now, entries });
 		return entries;
 	} catch {
 		return [];
 	}
+}
+
+/** Directory test that follows symlinks (Dirent.isDirectory reports the entry, not its target). */
+function direntIsDir(dir: string, entry: fs.Dirent): boolean {
+	if (entry.isDirectory()) return true;
+	if (entry.isSymbolicLink()) {
+		try {
+			return fs.statSync(path.join(dir, entry.name)).isDirectory();
+		} catch {
+			return false;
+		}
+	}
+	return false;
 }
 
 function printableInput(data: string): string {
@@ -76,17 +89,11 @@ export function resolveExistingDirectory(input: string, cwd: string): string | n
 
 function listChildDirectories(dirPath: string, max: number, includeHidden = false): DirEntry[] {
 	const results: DirEntry[] = [];
-	const names = readDirCached(dirPath);
-	for (const name of names) {
+	for (const entry of readDirCached(dirPath)) {
 		if (results.length >= max) break;
-		if (!includeHidden && name.startsWith(".")) continue;
-		const full = path.join(dirPath, name);
-		try {
-			if (!fs.statSync(full).isDirectory()) continue;
-		} catch {
-			continue;
-		}
-		results.push({ value: full, label: `${name}/` });
+		if (!includeHidden && entry.name.startsWith(".")) continue;
+		if (!direntIsDir(dirPath, entry)) continue;
+		results.push({ value: path.join(dirPath, entry.name), label: `${entry.name}/` });
 	}
 	results.sort((a, b) => a.label.localeCompare(b.label));
 	return results;
@@ -118,18 +125,12 @@ function searchDirectories(prefix: string, cwd: string, max: number): DirEntry[]
 
 	const lower = query.toLowerCase();
 	const results: DirEntry[] = [];
-	const names = readDirCached(baseDir);
-	for (const name of names) {
+	for (const entry of readDirCached(baseDir)) {
 		if (results.length >= max) break;
-		if (!includeHidden && name.startsWith(".")) continue;
-		const full = path.join(baseDir, name);
-		try {
-			if (!fs.statSync(full).isDirectory()) continue;
-		} catch {
-			continue;
-		}
-		if (!query || name.toLowerCase().includes(lower)) {
-			results.push({ value: full, label: `${name}/` });
+		if (!includeHidden && entry.name.startsWith(".")) continue;
+		if (!direntIsDir(baseDir, entry)) continue;
+		if (!query || entry.name.toLowerCase().includes(lower)) {
+			results.push({ value: path.join(baseDir, entry.name), label: `${entry.name}/` });
 		}
 	}
 	return results;


### PR DESCRIPTION
Closes #4199

## Problem
The `/move` overlay's directory autocomplete caches directory entry **names**, then calls `fs.statSync` on every entry to test if it is a directory — in `listChildDirectories` and `searchDirectories`, which run on **every keystroke**. On Windows this is a per-entry stat storm in a latency-sensitive interactive path.

## Change
- `readDirCached` now caches `fs.Dirent[]` (`readdirSync(dir, { withFileTypes: true })`) instead of names.
- Classification uses `entry.isDirectory()`, with a `statSync` fallback applied **only** to symlink entries (`entry.isSymbolicLink()`), since `Dirent.isDirectory()` reports the entry type, not the link target — preserving the previous follow-symlink behavior.

## Verification
- `tsgo -p tsconfig.json --noEmit`: clean.
- `/move` completion + command suites pass (`slash-commands/move-completion`, `slash-commands/move`, `modes/controllers/move-command`).
- Verified a symlinked directory is still surfaced as a directory (statSync fallback exercised).
