### PR TITLE
feat: add Task Manager — markdown-native project task management

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
 
+- Added Task Manager — a markdown-native project task manager with `omp task` (init, create, list, view, edit, archive, delete, search, milestone, doc, decision, overview), `omp board` (kanban table + export), and `omp taskbrowser` (web UI). Gated behind `tasks.taskManager` setting (disabled by default). Adds a `taskMgr` model role for AI-assisted overview and `--ai` acceptance criteria generation.
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -44,6 +44,9 @@ export const commands: CommandEntry[] = [
 	{ name: "ttsr", load: () => import("./commands/ttsr").then(m => m.default) },
 	{ name: "worktree", load: () => import("./commands/worktree").then(m => m.default), aliases: ["wt"] },
 	{ name: "search", load: () => import("./commands/web-search").then(m => m.default), aliases: ["q"] },
+	{ name: "task", load: () => import("./commands/task").then(m => m.default) },
+	{ name: "board", load: () => import("./commands/board").then(m => m.default) },
+	{ name: "taskbrowser", load: () => import("./commands/taskbrowser").then(m => m.default) },
 ];
 
 // Documented-looking plugin-management verbs that are NOT registered top-level

--- a/packages/coding-agent/src/commands/board.ts
+++ b/packages/coding-agent/src/commands/board.ts
@@ -38,7 +38,7 @@ export default class BoardCommand extends Command {
 		const { args, flags } = await this.parse(BoardCommand);
 		const action = args.action ?? "view";
 
-		const core = new Core(process.cwd());
+		const core = new Core(getProjectDir());
 		await core.ensureConfigLoaded();
 		const tasks = await core.listTasks();
 
@@ -58,6 +58,11 @@ export default class BoardCommand extends Command {
 			const content = `${header}${table}\n`;
 
 			const fullPath = path.resolve(filePath);
+			if (!flags.force && (await Bun.file(fullPath).exists())) {
+				process.stderr.write(`Error: ${fullPath} already exists. Use --force to overwrite.\n`);
+				process.exitCode = 1;
+				return;
+			}
 			await Bun.write(fullPath, content);
 			process.stdout.write(`Exported board to ${fullPath}\n`);
 			return;

--- a/packages/coding-agent/src/commands/board.ts
+++ b/packages/coding-agent/src/commands/board.ts
@@ -1,0 +1,76 @@
+/**
+ * `omp board` — Task Manager kanban board.
+ *
+ * Renders a kanban table to stdout using `Bun.stringWidth` for column
+ * alignment. Non-interactive table — an interactive TUI board is a later
+ * enhancement using `@oh-my-pi/pi-tui`.
+ */
+
+import * as path from "node:path";
+import { getProjectDir } from "@oh-my-pi/pi-utils";
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { Settings, settings } from "../config/settings";
+import { generateKanbanBoardWithMetadata, renderKanbanTable } from "../task-manager/board";
+import { Core } from "../task-manager/core";
+
+export default class BoardCommand extends Command {
+	static description = "View Task Manager kanban board";
+
+	static args = {
+		action: Args.string({ description: "Board action (view, export)", required: false }),
+		file: Args.string({ description: "Export file path", required: false }),
+	};
+
+	static flags = {
+		force: Flags.boolean({ description: "Overwrite existing export file" }),
+		readme: Flags.boolean({ description: "Include README header in export" }),
+		"export-version": Flags.string({ description: "Export format version" }),
+	};
+
+	async run(): Promise<void> {
+		await Settings.init({ cwd: getProjectDir() });
+		if (settings.get("tasks.taskManager") !== true) {
+			process.stderr.write("Task Manager is disabled. Enable with: omp config set tasks.taskManager true\n");
+			process.exitCode = 1;
+			return;
+		}
+
+		const { args, flags } = await this.parse(BoardCommand);
+		const action = args.action ?? "view";
+
+		const core = new Core(process.cwd());
+		await core.ensureConfigLoaded();
+		const tasks = await core.listTasks();
+
+		if (action === "export") {
+			const filePath = args.file;
+			if (!filePath) {
+				process.stderr.write("Error: export file path required\n");
+				process.exitCode = 1;
+				return;
+			}
+			const metadata = generateKanbanBoardWithMetadata(tasks, core.config.statuses);
+			const header = flags.readme
+				? `# Task Manager — powered by Oh My Pi\n\nGenerated: ${metadata.generatedAt}\nTotal tasks: ${metadata.totalTasks}\n\n`
+				: `Task Manager — powered by Oh My Pi\n\nGenerated: ${metadata.generatedAt}\nTotal tasks: ${metadata.totalTasks}\n\n`;
+
+			const table = renderKanbanTable({ columns: metadata.columns, totalTasks: metadata.totalTasks });
+			const content = `${header}${table}\n`;
+
+			const fullPath = path.resolve(filePath);
+			await Bun.write(fullPath, content);
+			process.stdout.write(`Exported board to ${fullPath}\n`);
+			return;
+		}
+
+		// Default: view
+		if (tasks.length === 0) {
+			process.stdout.write("No tasks found. Create some with `omp task create`.\n");
+			return;
+		}
+
+		const board = generateKanbanBoardWithMetadata(tasks, core.config.statuses);
+		process.stdout.write(`\nTask Manager — Kanban Board (${board.totalTasks} tasks)\n\n`);
+		process.stdout.write(`${renderKanbanTable({ columns: board.columns, totalTasks: board.totalTasks })}\n`);
+	}
+}

--- a/packages/coding-agent/src/commands/task.ts
+++ b/packages/coding-agent/src/commands/task.ts
@@ -87,7 +87,7 @@ export default class TaskCommand extends Command {
 			return;
 		}
 		const idArgs = Array.isArray(args.id) ? args.id : args.id ? [args.id] : [];
-		const core = new Core(process.cwd());
+		const core = new Core(getProjectDir());
 		switch (subcommand) {
 			case "init":
 				await this.#init(core, idArgs, flags);
@@ -114,7 +114,7 @@ export default class TaskCommand extends Command {
 				await this.#search(core, idArgs, flags);
 				break;
 			case "draft":
-				await this.#setDraft(core, idArgs, true);
+				await this.#createDraft(core, idArgs);
 				break;
 			case "promote":
 				await this.#setDraft(core, idArgs, false);
@@ -151,7 +151,7 @@ export default class TaskCommand extends Command {
 			}
 		}
 		name = name || "Project";
-		const config = await core.initializeProject(name, Boolean(flags.defaults));
+		const config = await core.initializeProject(name, Boolean(flags.defaults), !flags["no-git"]);
 		process.stdout.write(`Initialized Task Manager in ${core.fs.rootDir}/.omp/tasks/\n`);
 		process.stdout.write(`Project: ${config.projectName}\n`);
 	}
@@ -171,7 +171,7 @@ export default class TaskCommand extends Command {
 			: [];
 		const ac = flags.ac
 			? String(flags.ac)
-					.split("|")
+					.split(",")
 					.map(s => s.trim())
 					.filter(Boolean)
 			: [];
@@ -297,17 +297,17 @@ export default class TaskCommand extends Command {
 			process.stdout.write(`Added comment to ${id}\n`);
 			return;
 		}
-		await core.updateTask(id, {
-			description: flags.desc as string | undefined,
-			status: flags.status as string | undefined,
-			assignee: flags.assignee as string | null,
-			labels,
-			priority: flags.priority as string | null,
-			milestone: flags.milestone as string | null,
-			taskPlan: flags.plan as string | null,
-			notes: flags.notes as string | null,
-			finalSummary: flags["final-summary"] as string | null,
-		});
+		const update: Record<string, unknown> = {};
+		if (flags.desc !== undefined) update.description = flags.desc;
+		if (flags.status !== undefined) update.status = flags.status;
+		if (flags.assignee !== undefined) update.assignee = flags.assignee;
+		if (labels !== undefined) update.labels = labels;
+		if (flags.priority !== undefined) update.priority = flags.priority;
+		if (flags.milestone !== undefined) update.milestone = flags.milestone;
+		if (flags.plan !== undefined) update.taskPlan = flags.plan;
+		if (flags.notes !== undefined) update.notes = flags.notes;
+		if (flags["final-summary"] !== undefined) update.finalSummary = flags["final-summary"];
+		await core.updateTask(id, update);
 		process.stdout.write(`Updated task ${id}\n`);
 	}
 	// ─── archive ────────────────────────────────────────────────────────────
@@ -368,6 +368,17 @@ export default class TaskCommand extends Command {
 		await core.updateTask(id, { draft } as never);
 		process.stdout.write(`${draft ? "Marked" : "Promoted"} task ${id}\n`);
 	}
+	async #createDraft(core: Core, idArgs: string[]): Promise<void> {
+		const title = idArgs.join(" ");
+		if (!title) {
+			process.stderr.write("Error: title is required\n");
+			process.exitCode = 1;
+			return;
+		}
+		const task = await core.createTask({ title, draft: true });
+		process.stdout.write(`Created draft ${task.id}: ${task.title}\n`);
+	}
+
 	// ─── milestone / doc / decision (Phase 2 stubs) ─────────────────────────
 	async #milestone(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
 		const action = idArgs[0];

--- a/packages/coding-agent/src/commands/task.ts
+++ b/packages/coding-agent/src/commands/task.ts
@@ -1,0 +1,497 @@
+/**
+ * `omp task` — Task Manager CLI command.
+ *
+ * Dispatches to subcommands: init, create, list, view, edit, archive, delete,
+ * search, draft, promote, demote, milestone, doc, decision, overview, cleanup.
+ *
+ * Uses omp's `Command`/`Flags`/`Args` from `@oh-my-pi/pi-utils/cli`.
+ * For interactive prompts (init wizard), uses `node:readline/promises`.
+ */
+import { stdin, stdout } from "node:process";
+import * as readline from "node:readline/promises";
+import { getProjectDir } from "@oh-my-pi/pi-utils";
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { ModelRegistry } from "../config/model-registry";
+import { Settings, settings } from "../config/settings";
+import { discoverAuthStorage, loadCliExtensionProviders } from "../sdk";
+import { Core } from "../task-manager/core";
+import { serializeTask } from "../task-manager/markdown/serializer";
+import { SearchService } from "../task-manager/search";
+import { generateAcceptanceCriteria, generateOverview } from "../task-manager/task-mgr-consumers";
+
+const SUBCOMMANDS = [
+	"init",
+	"create",
+	"list",
+	"view",
+	"edit",
+	"archive",
+	"delete",
+	"search",
+	"draft",
+	"promote",
+	"demote",
+	"milestone",
+	"doc",
+	"decision",
+	"overview",
+	"cleanup",
+] as const;
+type Subcommand = (typeof SUBCOMMANDS)[number];
+export default class TaskCommand extends Command {
+	static description = "Manage markdown-native project tasks";
+	static args = {
+		subcommand: Args.string({
+			description: `Task action (${SUBCOMMANDS.join(", ")})`,
+			required: false,
+			options: [...SUBCOMMANDS],
+		}),
+		id: Args.string({ description: "Task ID or name", required: false, multiple: true }),
+	};
+	static flags = {
+		// Init
+		defaults: Flags.boolean({ description: "Use defaults (non-interactive)" }),
+		"no-git": Flags.boolean({ description: "Skip git setup" }),
+		// Create
+		desc: Flags.string({ char: "d", description: "Description" }),
+		assignee: Flags.string({ char: "a", description: "Assignee" }),
+		status: Flags.string({ char: "s", description: "Status" }),
+		labels: Flags.string({ char: "l", description: "Comma-separated labels" }),
+		priority: Flags.string({ description: "Priority" }),
+		plan: Flags.string({ description: "Implementation plan" }),
+		ac: Flags.string({ description: "Comma-separated acceptance criteria" }),
+		dep: Flags.string({ description: "Comma-separated dependencies" }),
+		parent: Flags.string({ description: "Parent task ID" }),
+		draft: Flags.boolean({ description: "Create as draft" }),
+		ai: Flags.boolean({ description: "Auto-generate AC and plan via taskMgr model (Phase 2)" }),
+		// List / search
+		plain: Flags.boolean({ description: "Plain text output (no color)" }),
+		limit: Flags.integer({ description: "Limit results" }),
+		// Edit
+		comment: Flags.string({ description: "Add a comment" }),
+		"comment-author": Flags.string({ description: "Comment author" }),
+		// Search
+		search: Flags.string({ description: "Search query for list filter" }),
+	};
+	async run(): Promise<void> {
+		await Settings.init({ cwd: getProjectDir() });
+		if (settings.get("tasks.taskManager") !== true) {
+			process.stderr.write("Task Manager is disabled. Enable with: omp config set tasks.taskManager true\n");
+			process.exitCode = 1;
+			return;
+		}
+		const { args, flags } = await this.parse(TaskCommand);
+		const subcommand = args.subcommand as Subcommand | undefined;
+		if (!subcommand) {
+			this.#printHelp();
+			return;
+		}
+		const idArgs = Array.isArray(args.id) ? args.id : args.id ? [args.id] : [];
+		const core = new Core(process.cwd());
+		switch (subcommand) {
+			case "init":
+				await this.#init(core, idArgs, flags);
+				break;
+			case "create":
+				await this.#create(core, idArgs, flags);
+				break;
+			case "list":
+				await this.#list(core, flags);
+				break;
+			case "view":
+				await this.#view(core, idArgs, flags);
+				break;
+			case "edit":
+				await this.#edit(core, idArgs, flags);
+				break;
+			case "archive":
+				await this.#archive(core, idArgs);
+				break;
+			case "delete":
+				await this.#delete(core, idArgs);
+				break;
+			case "search":
+				await this.#search(core, idArgs, flags);
+				break;
+			case "draft":
+				await this.#setDraft(core, idArgs, true);
+				break;
+			case "promote":
+				await this.#setDraft(core, idArgs, false);
+				break;
+			case "demote":
+				await this.#setDraft(core, idArgs, true);
+				break;
+			case "milestone":
+				await this.#milestone(core, idArgs, flags);
+				break;
+			case "doc":
+				await this.#doc(core, idArgs, flags);
+				break;
+			case "decision":
+				await this.#decision(core, idArgs, flags);
+				break;
+			case "overview":
+				await this.#overview(core);
+				break;
+			case "cleanup":
+				process.stdout.write("Task cleanup is available in Phase 2.\n");
+				break;
+		}
+	}
+	// ─── init ───────────────────────────────────────────────────────────────
+	async #init(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		let name = idArgs[0] ?? "";
+		if (!flags.defaults && !name) {
+			const rl = readline.createInterface({ input: stdin, output: stdout });
+			try {
+				name = (await rl.question("Project name: ")).trim() || "Project";
+			} finally {
+				rl.close();
+			}
+		}
+		name = name || "Project";
+		const config = await core.initializeProject(name, Boolean(flags.defaults));
+		process.stdout.write(`Initialized Task Manager in ${core.fs.rootDir}/.omp/tasks/\n`);
+		process.stdout.write(`Project: ${config.projectName}\n`);
+	}
+	// ─── create ──────────────────────────────────────────────────────────────
+	async #create(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		const title = idArgs.join(" ");
+		if (!title) {
+			process.stderr.write("Error: title is required\n");
+			process.exitCode = 1;
+			return;
+		}
+		const labels = flags.labels
+			? String(flags.labels)
+					.split(",")
+					.map(s => s.trim())
+					.filter(Boolean)
+			: [];
+		const ac = flags.ac
+			? String(flags.ac)
+					.split("|")
+					.map(s => s.trim())
+					.filter(Boolean)
+			: [];
+		const dep = flags.dep
+			? String(flags.dep)
+					.split(",")
+					.map(s => s.trim())
+					.filter(Boolean)
+			: [];
+		let aiAc = ac;
+		let aiPlan = flags.plan as string | null;
+		if (flags.ai) {
+			const authStorage = await discoverAuthStorage();
+			const modelRegistry = new ModelRegistry(authStorage);
+			await loadCliExtensionProviders(modelRegistry, settings, getProjectDir());
+			const generated = await generateAcceptanceCriteria(core, modelRegistry, settings, title, flags.desc as string);
+			if (generated) {
+				if (generated.acceptanceCriteria.length > 0) aiAc = generated.acceptanceCriteria;
+				if (generated.taskPlan) aiPlan = generated.taskPlan;
+			}
+			authStorage.close();
+		}
+		const task = await core.createTask({
+			title,
+			description: flags.desc as string | undefined,
+			status: flags.status as string | undefined,
+			assignee: flags.assignee as string | null,
+			labels,
+			priority: flags.priority as string | null,
+			parentTaskId: flags.parent as string | null,
+			dependencies: dep,
+			acceptanceCriteria: aiAc,
+			taskPlan: aiPlan,
+			draft: Boolean(flags.draft),
+		});
+		process.stdout.write(`Created task ${task.id}: ${task.title}\n`);
+		if (!flags.plain) {
+			process.stdout.write(`  Status: ${task.status}\n`);
+			if (task.assignee) process.stdout.write(`  Assignee: ${task.assignee}\n`);
+			if (task.labels.length > 0) process.stdout.write(`  Labels: ${task.labels.join(", ")}\n`);
+		}
+	}
+	// ─── list ───────────────────────────────────────────────────────────────
+	async #list(core: Core, flags: Record<string, unknown>): Promise<void> {
+		const tasks = await core.listTasks({
+			status: flags.status as string | null,
+			assignee: flags.assignee as string | null,
+			parentTaskId: flags.parent as string | null,
+			limit: flags.limit as number | null,
+		});
+		if (tasks.length === 0) {
+			process.stdout.write("No tasks found.\n");
+			return;
+		}
+		if (flags.plain) {
+			for (const task of tasks) {
+				process.stdout.write(`${task.id}\t${task.status}\t${task.title}\n`);
+			}
+			return;
+		}
+		for (const task of tasks) {
+			const draftTag = task.draft ? " [draft]" : "";
+			process.stdout.write(`${task.id}  [${task.status}]  ${task.title}${draftTag}\n`);
+			if (task.assignee) process.stdout.write(`    assignee: ${task.assignee}\n`);
+			if (task.labels.length > 0) process.stdout.write(`    labels: ${task.labels.join(", ")}\n`);
+		}
+	}
+	// ─── view ───────────────────────────────────────────────────────────────
+	async #view(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		const id = idArgs[0];
+		if (!id) {
+			process.stderr.write("Error: task ID required\n");
+			process.exitCode = 1;
+			return;
+		}
+		const task = await core.loadTask(id);
+		const content = serializeTask(task);
+		if (flags.plain) {
+			process.stdout.write(`${content}\n`);
+			return;
+		}
+		process.stdout.write(`\n${task.id}: ${task.title}\n`);
+		process.stdout.write(`${"─".repeat(Math.max(task.id.length + task.title.length + 2, 40))}\n`);
+		process.stdout.write(`Status:     ${task.status}\n`);
+		if (task.assignee) process.stdout.write(`Assignee:   ${task.assignee}\n`);
+		if (task.priority) process.stdout.write(`Priority:   ${task.priority}\n`);
+		if (task.labels.length > 0) process.stdout.write(`Labels:     ${task.labels.join(", ")}\n`);
+		if (task.milestone) process.stdout.write(`Milestone:  ${task.milestone}\n`);
+		if (task.parentTaskId) process.stdout.write(`Parent:     ${task.parentTaskId}\n`);
+		if (task.dependencies.length > 0) process.stdout.write(`Depends on: ${task.dependencies.join(", ")}\n`);
+		if (task.description) process.stdout.write(`\n${task.description}\n`);
+		if (task.acceptanceCriteria.length > 0) {
+			process.stdout.write(`\nAcceptance Criteria:\n`);
+			for (const ac of task.acceptanceCriteria) {
+				process.stdout.write(`  [${ac.checked ? "x" : " "}] ${ac.text}\n`);
+			}
+		}
+		if (task.notes) process.stdout.write(`\nNotes:\n${task.notes}\n`);
+		if (task.comments.length > 0) {
+			process.stdout.write(`\nComments:\n`);
+			for (const c of task.comments) {
+				process.stdout.write(`  ${c.author} (${c.createdDate}): ${c.text}\n`);
+			}
+		}
+	}
+	// ─── edit ───────────────────────────────────────────────────────────────
+	async #edit(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		const id = idArgs[0];
+		if (!id) {
+			process.stderr.write("Error: task ID required\n");
+			process.exitCode = 1;
+			return;
+		}
+		const labels = flags.labels
+			? String(flags.labels)
+					.split(",")
+					.map(s => s.trim())
+					.filter(Boolean)
+			: undefined;
+		if (flags.comment) {
+			const author = (flags["comment-author"] as string) ?? "unknown";
+			await core.addComment(id, author, flags.comment as string);
+			process.stdout.write(`Added comment to ${id}\n`);
+			return;
+		}
+		await core.updateTask(id, {
+			description: flags.desc as string | undefined,
+			status: flags.status as string | undefined,
+			assignee: flags.assignee as string | null,
+			labels,
+			priority: flags.priority as string | null,
+			milestone: flags.milestone as string | null,
+			taskPlan: flags.plan as string | null,
+			notes: flags.notes as string | null,
+			finalSummary: flags["final-summary"] as string | null,
+		});
+		process.stdout.write(`Updated task ${id}\n`);
+	}
+	// ─── archive ────────────────────────────────────────────────────────────
+	async #archive(core: Core, idArgs: string[]): Promise<void> {
+		const id = idArgs[0];
+		if (!id) {
+			process.stderr.write("Error: task ID required\n");
+			process.exitCode = 1;
+			return;
+		}
+		await core.archiveTask(id);
+		process.stdout.write(`Archived task ${id}\n`);
+	}
+	// ─── delete ─────────────────────────────────────────────────────────────
+	async #delete(core: Core, idArgs: string[]): Promise<void> {
+		const id = idArgs[0];
+		if (!id) {
+			process.stderr.write("Error: task ID required\n");
+			process.exitCode = 1;
+			return;
+		}
+		await core.deleteTask(id);
+		process.stdout.write(`Deleted task ${id}\n`);
+	}
+	// ─── search ─────────────────────────────────────────────────────────────
+	async #search(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		const query = idArgs.join(" ");
+		if (!query) {
+			process.stderr.write("Error: search query required\n");
+			process.exitCode = 1;
+			return;
+		}
+		const search = new SearchService(core);
+		const results = await search.search(query, {
+			filters: { status: flags.status as string | null, priority: flags.priority as string | null },
+			limit: flags.limit as number | null,
+		});
+		if (results.length === 0) {
+			process.stdout.write("No matches found.\n");
+			return;
+		}
+		for (const result of results) {
+			if (flags.plain) {
+				process.stdout.write(`${result.id}\t${result.type}\t${result.status}\t${result.title}\n`);
+			} else {
+				process.stdout.write(`${result.id}  [${result.type}]  ${result.title}  (${result.status})\n`);
+			}
+		}
+	}
+	// ─── draft / promote / demote ───────────────────────────────────────────
+	async #setDraft(core: Core, idArgs: string[], draft: boolean): Promise<void> {
+		const id = idArgs[0];
+		if (!id) {
+			process.stderr.write("Error: task ID required\n");
+			process.exitCode = 1;
+			return;
+		}
+		await core.updateTask(id, { draft } as never);
+		process.stdout.write(`${draft ? "Marked" : "Promoted"} task ${id}\n`);
+	}
+	// ─── milestone / doc / decision (Phase 2 stubs) ─────────────────────────
+	async #milestone(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		const action = idArgs[0];
+		if (action === "list") {
+			const milestones = await core.listMilestones();
+			if (milestones.length === 0) {
+				process.stdout.write("No milestones found.\n");
+				return;
+			}
+			for (const m of milestones) {
+				process.stdout.write(`${m.id}  [${m.status}]  ${m.name}\n`);
+				if (m.description) process.stdout.write(`    ${m.description}\n`);
+			}
+			return;
+		}
+		if (action === "add") {
+			const name = idArgs.slice(1).join(" ");
+			if (!name) {
+				process.stderr.write("Error: milestone name required\n");
+				process.exitCode = 1;
+				return;
+			}
+			const desc = (flags.description as string) ?? "";
+			const m = await core.createMilestone(name, desc);
+			process.stdout.write(`Created milestone ${m.id}: ${m.name}\n`);
+			return;
+		}
+		process.stdout.write("Milestone rename/remove/archive available in Phase 2.\n");
+	}
+	async #doc(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		const action = idArgs[0];
+		if (action === "list") {
+			const docs = await core.listDocuments();
+			if (docs.length === 0) {
+				process.stdout.write("No documents found.\n");
+				return;
+			}
+			for (const doc of docs) {
+				process.stdout.write(`${doc.id}  [${doc.type}]  ${doc.title}\n`);
+			}
+			return;
+		}
+		if (action === "create") {
+			const title = idArgs.slice(1).join(" ");
+			if (!title) {
+				process.stderr.write("Error: document title required\n");
+				process.exitCode = 1;
+				return;
+			}
+			const type = (flags.type as string) ?? "doc";
+			const tags = flags.tags
+				? String(flags.tags)
+						.split(",")
+						.map(s => s.trim())
+						.filter(Boolean)
+				: [];
+			const doc = await core.createDocument(title, type, "", tags);
+			process.stdout.write(`Created document ${doc.id}: ${doc.title}\n`);
+			return;
+		}
+		process.stdout.write("Document view/search/update available in Phase 2.\n");
+	}
+	async #decision(core: Core, idArgs: string[], flags: Record<string, unknown>): Promise<void> {
+		const title = idArgs.join(" ");
+		if (!title) {
+			process.stderr.write("Error: decision title required\n");
+			process.exitCode = 1;
+			return;
+		}
+		const status = (flags.status as string) ?? "proposed";
+		const decision = await core.createDecision(title, status);
+		process.stdout.write(`Created decision ${decision.id}: ${decision.title}\n`);
+	}
+	// ─── overview ───────────────────────────────────────────────────────────
+	async #overview(core: Core): Promise<void> {
+		const authStorage = await discoverAuthStorage();
+		const modelRegistry = new ModelRegistry(authStorage);
+		await loadCliExtensionProviders(modelRegistry, settings, getProjectDir());
+		try {
+			const overview = await generateOverview(core, modelRegistry, settings);
+			process.stdout.write(`${overview}\n`);
+		} finally {
+			authStorage.close();
+		}
+	}
+	// ─── help ────────────────────────────────────────────────────────────────
+	#printHelp(): void {
+		process.stdout.write(`omp task — Task Manager
+USAGE
+  omp task <subcommand> [args] [flags]
+SUBCOMMANDS
+  init [name]              Initialize Task Manager in the current project
+  create [title]           Create a new task
+  list                     List tasks
+  view [id]                View a task
+  edit [id]                Edit a task
+  archive [id]             Archive a task
+  delete [id]              Delete a task (hard delete + git rm)
+  search [query]           Search tasks, docs, and decisions
+  draft [title]            Create a draft task
+  promote [id]             Promote a draft to a real task
+  demote [id]              Demote a task to a draft
+  milestone <action>       Manage milestones (list, add)
+  doc <action>             Manage documents (list, create)
+  decision create [title]  Create a decision record
+  overview                 AI-assisted project overview (Phase 2)
+  cleanup                  Clean up stale data (Phase 2)
+FLAGS
+  --defaults               Use defaults for init (non-interactive)
+  -d, --desc <text>        Description
+  -a, --assignee <name>    Assignee
+  -s, --status <status>    Status
+  -l, --labels <csv>       Comma-separated labels
+  --priority <p>           Priority
+  --plan <text>            Implementation plan
+  --ac <csv>               Comma-separated acceptance criteria
+  --dep <csv>              Comma-separated dependencies
+  --parent <id>            Parent task ID
+  --draft                  Create as draft
+  --plain                  Plain text output
+  --limit <n>              Limit results
+  --comment <text>         Add a comment (edit)
+  --comment-author <name>  Comment author (edit)
+Enable with: omp config set tasks.taskManager true
+`);
+	}
+}

--- a/packages/coding-agent/src/commands/taskbrowser.ts
+++ b/packages/coding-agent/src/commands/taskbrowser.ts
@@ -28,7 +28,7 @@ export default class TaskBrowserCommand extends Command {
 		}
 
 		const { flags } = await this.parse(TaskBrowserCommand);
-		const core = new Core(process.cwd());
+		const core = new Core(getProjectDir());
 		await core.ensureConfigLoaded();
 
 		await startTaskManagerWebServer(core, {
@@ -37,9 +37,9 @@ export default class TaskBrowserCommand extends Command {
 		});
 
 		// Keep the process alive
-		await new Promise<void>(resolve => {
-			process.on("SIGINT", () => resolve());
-			process.on("SIGTERM", () => resolve());
-		});
+		const done = Promise.withResolvers<void>();
+		process.on("SIGINT", () => done.resolve());
+		process.on("SIGTERM", () => done.resolve());
+		await done.promise;
 	}
 }

--- a/packages/coding-agent/src/commands/taskbrowser.ts
+++ b/packages/coding-agent/src/commands/taskbrowser.ts
@@ -1,0 +1,45 @@
+/**
+ * `omp taskbrowser` — Task Manager web UI.
+ *
+ * Server-side rendered HTML + vanilla JS, served via `Bun.serve`.
+ * Opens browser via omp's `openPath` from `utils/open.ts`.
+ */
+
+import { getProjectDir } from "@oh-my-pi/pi-utils";
+import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { Settings, settings } from "../config/settings";
+import { Core } from "../task-manager/core";
+import { startTaskManagerWebServer } from "../task-manager/web-server";
+
+export default class TaskBrowserCommand extends Command {
+	static description = "Open Task Manager web UI";
+
+	static flags = {
+		port: Flags.integer({ char: "p", description: "Port for the web server", default: 6420 }),
+		"no-open": Flags.boolean({ description: "Do not open browser automatically" }),
+	};
+
+	async run(): Promise<void> {
+		await Settings.init({ cwd: getProjectDir() });
+		if (settings.get("tasks.taskManager") !== true) {
+			process.stderr.write("Task Manager is disabled. Enable with: omp config set tasks.taskManager true\n");
+			process.exitCode = 1;
+			return;
+		}
+
+		const { flags } = await this.parse(TaskBrowserCommand);
+		const core = new Core(process.cwd());
+		await core.ensureConfigLoaded();
+
+		await startTaskManagerWebServer(core, {
+			port: flags.port,
+			open: !flags["no-open"],
+		});
+
+		// Keep the process alive
+		await new Promise<void>(resolve => {
+			process.on("SIGINT", () => resolve());
+			process.on("SIGTERM", () => resolve());
+		});
+	}
+}

--- a/packages/coding-agent/src/config/model-roles.ts
+++ b/packages/coding-agent/src/config/model-roles.ts
@@ -15,7 +15,8 @@ export type ModelRole =
 	| "commit"
 	| "tiny"
 	| "task"
-	| "advisor";
+	| "advisor"
+	| "taskMgr";
 
 export interface ModelRoleInfo {
 	tag?: string;
@@ -36,6 +37,7 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 	tiny: { tag: "TINY", name: "Tiny", color: "dim" },
 	task: { tag: "TASK", name: "Subtask", color: "muted" },
 	advisor: { tag: "ADVISOR", name: "Advisor", color: "accent" },
+	taskMgr: { tag: "TASK MGR", name: "Task Mgr", color: "muted" },
 };
 
 export const MODEL_ROLE_IDS: ModelRole[] = [
@@ -49,6 +51,7 @@ export const MODEL_ROLE_IDS: ModelRole[] = [
 	"tiny",
 	"task",
 	"advisor",
+	"taskMgr",
 ];
 
 export type RoleInfo = ModelRoleInfo;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -144,7 +144,7 @@ export const TAB_GROUPS: Record<SettingTab, readonly string[]> = {
 		"Discovery & MCP",
 		"Developer",
 	],
-	tasks: ["Modes", "Subagents", "Isolation", "Commands & Skills"],
+	tasks: ["Modes", "Subagents", "Isolation", "Commands & Skills", "Task Manager"],
 	providers: ["Services", "Fireworks", "Tiny Model", "Protocol", "Timeouts", "Privacy"],
 };
 
@@ -4194,6 +4194,17 @@ export const SETTINGS_SCHEMA = {
 				{ value: "3600", label: "1 hour" },
 				{ value: "-1", label: "Never" },
 			],
+		},
+	},
+
+	"tasks.taskManager": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tasks",
+			group: "Task Manager",
+			label: "Enable Task Manager",
+			description: "Enable omp task/board/taskbrowser commands for markdown-native project task management",
 		},
 	},
 

--- a/packages/coding-agent/src/prompts/task-ac-generation.md
+++ b/packages/coding-agent/src/prompts/task-ac-generation.md
@@ -1,0 +1,5 @@
+You are a software engineering assistant. Generate acceptance criteria and an implementation plan for the given task.
+
+Format:
+- List acceptance criteria as bullet points starting with "- "
+- After the criteria, add a section "## Plan" with the implementation plan

--- a/packages/coding-agent/src/prompts/task-overview.md
+++ b/packages/coding-agent/src/prompts/task-overview.md
@@ -1,0 +1,9 @@
+You are a project management assistant. You will receive a JSON object containing project task statistics.
+
+Generate a concise 3-5 paragraph natural-language overview covering:
+1. Overall project health and progress
+2. Blocked items that need attention
+3. Milestone progress and deadlines
+4. Recommendations for next steps
+
+Keep it concise and actionable. Do not repeat raw data — synthesize insights.

--- a/packages/coding-agent/src/task-manager/board.ts
+++ b/packages/coding-agent/src/task-manager/board.ts
@@ -1,0 +1,149 @@
+/**
+ * Board generation — pure functions for kanban board views.
+ *
+ * Produces status-grouped and milestone-grouped board data that the
+ * `omp board` command renders to stdout.
+ */
+
+import type { Milestone, Task } from "./types";
+
+export interface KanbanColumn {
+	status: string;
+	tasks: Task[];
+}
+
+export interface KanbanBoard {
+	columns: KanbanColumn[];
+	totalTasks: number;
+}
+
+export interface MilestoneGroupedBoard {
+	milestones: Array<{
+		milestone: Milestone | null;
+		columns: KanbanColumn[];
+		taskCount: number;
+	}>;
+	totalTasks: number;
+}
+
+export interface BoardMetadata {
+	generatedAt: string;
+	totalTasks: number;
+	statusCounts: Record<string, number>;
+	columns: KanbanColumn[];
+}
+
+/** Group tasks into columns by status, preserving config status order. */
+export function buildKanbanStatusGroups(tasks: Task[], statuses: string[]): KanbanBoard {
+	const columns: KanbanColumn[] = statuses.map(status => ({
+		status,
+		tasks: tasks.filter(t => t.status === status),
+	}));
+
+	// Include any statuses that exist on tasks but aren't in the config
+	const knownStatuses = new Set(statuses);
+	const extraStatuses = new Set<string>();
+	for (const task of tasks) {
+		if (!knownStatuses.has(task.status)) {
+			extraStatuses.add(task.status);
+		}
+	}
+	for (const status of extraStatuses) {
+		columns.push({
+			status,
+			tasks: tasks.filter(t => t.status === status),
+		});
+	}
+
+	return {
+		columns,
+		totalTasks: tasks.length,
+	};
+}
+
+/** Generate a kanban board with metadata (counts, timestamp). */
+export function generateKanbanBoardWithMetadata(tasks: Task[], statuses: string[]): BoardMetadata {
+	const board = buildKanbanStatusGroups(tasks, statuses);
+	const statusCounts: Record<string, number> = {};
+	for (const col of board.columns) {
+		statusCounts[col.status] = col.tasks.length;
+	}
+	return {
+		generatedAt: new Date().toISOString(),
+		totalTasks: board.totalTasks,
+		statusCounts,
+		columns: board.columns,
+	};
+}
+
+/** Group tasks by milestone, then build kanban columns within each group. */
+export function generateMilestoneGroupedBoard(
+	tasks: Task[],
+	milestones: Milestone[],
+	statuses: string[],
+): MilestoneGroupedBoard {
+	const groups: MilestoneGroupedBoard["milestones"] = [];
+	let totalTasks = 0;
+
+	for (const milestone of milestones) {
+		const milestoneTasks = tasks.filter(t => t.milestone === milestone.id);
+		if (milestoneTasks.length === 0) continue;
+		const board = buildKanbanStatusGroups(milestoneTasks, statuses);
+		groups.push({
+			milestone,
+			columns: board.columns,
+			taskCount: board.totalTasks,
+		});
+		totalTasks += board.totalTasks;
+	}
+
+	// Tasks with no milestone
+	const unassigned = tasks.filter(t => !t.milestone || !milestones.some(m => m.id === t.milestone));
+	if (unassigned.length > 0) {
+		const board = buildKanbanStatusGroups(unassigned, statuses);
+		groups.push({
+			milestone: null,
+			columns: board.columns,
+			taskCount: board.totalTasks,
+		});
+		totalTasks += board.totalTasks;
+	}
+
+	return { milestones: groups, totalTasks };
+}
+
+/** Render a kanban board as a formatted text table for terminal output. */
+export function renderKanbanTable(board: KanbanBoard): string {
+	const lines: string[] = [];
+	const colWidth = 20;
+	const sep = "│";
+
+	// Header
+	const header = board.columns
+		.map(col => {
+			const label = `${col.status} (${col.tasks.length})`;
+			return padColumn(label, colWidth);
+		})
+		.join(` ${sep} `);
+	lines.push(header);
+	lines.push(board.columns.map(() => "─".repeat(colWidth)).join(`${sep}─${sep}`));
+
+	// Rows
+	const maxRows = Math.max(...board.columns.map(c => c.tasks.length), 0);
+	for (let i = 0; i < maxRows; i++) {
+		const row = board.columns
+			.map(col => {
+				const task = col.tasks[i];
+				return task ? padColumn(`${task.id}: ${task.title}`, colWidth) : " ".repeat(colWidth);
+			})
+			.join(` ${sep} `);
+		lines.push(row);
+	}
+
+	return lines.join("\n");
+}
+
+function padColumn(text: string, width: number): string {
+	const trimmed = text.length > width ? `${text.slice(0, width - 1)}…` : text;
+	return trimmed.padEnd(width);
+}

--- a/packages/coding-agent/src/task-manager/constants.ts
+++ b/packages/coding-agent/src/task-manager/constants.ts
@@ -1,0 +1,53 @@
+/**
+ * Task Manager constants.
+ *
+ * On-disk layout uses `.omp/tasks/` — omp-native, following the existing
+ * `.omp/` convention used for `.omp/agents`, `.omp/rules`, `.omp/ssh.json`.
+ */
+
+import type { TaskConfig } from "./types";
+
+export const DEFAULT_DIRECTORIES = {
+	tasks: ".omp/tasks/tasks",
+	decisions: ".omp/tasks/decisions",
+	documents: ".omp/tasks/documents",
+	milestones: ".omp/tasks/milestones",
+	archive: ".omp/tasks/archive",
+};
+
+export const DEFAULT_FILES = {
+	config: ".omp/tasks/config.yml",
+	sequences: ".omp/tasks/sequences.json",
+};
+
+export const DEFAULT_STATUSES = ["todo", "in-progress", "done", "blocked"];
+
+export const FALLBACK_STATUS = "todo";
+
+export const DEFAULT_PREFIXES = {
+	task: "task",
+	decision: "decision",
+	document: "doc",
+	milestone: "milestone",
+};
+
+export const DEFAULT_INIT_CONFIG: TaskConfig = {
+	projectName: "Project",
+	directories: { ...DEFAULT_DIRECTORIES },
+	files: { ...DEFAULT_FILES },
+	statuses: [...DEFAULT_STATUSES],
+	defaultStatus: FALLBACK_STATUS,
+	prefixes: { ...DEFAULT_PREFIXES },
+	git: {
+		enabled: true,
+		autoCommit: true,
+		commitPrefix: "task:",
+	},
+	taskTemplate: null,
+};
+
+/** File extension for all task entities. */
+export const ENTITY_EXTENSION = ".md";
+
+/** Max search results when no explicit limit is set. */
+export const DEFAULT_SEARCH_LIMIT = 50;

--- a/packages/coding-agent/src/task-manager/content-store.ts
+++ b/packages/coding-agent/src/task-manager/content-store.ts
@@ -1,0 +1,42 @@
+/**
+ * Content store — caches parsed task content to avoid re-reading files.
+ *
+ * Keyed by entity type + id. The cache is per-Core-instance and not shared
+ * across processes — file locking handles cross-process safety.
+ */
+
+import type { Decision, Document, Milestone, Task } from "./types";
+
+type EntityType = "tasks" | "decisions" | "documents" | "milestones";
+
+type Entity<T extends EntityType> = T extends "tasks"
+	? Task
+	: T extends "decisions"
+		? Decision
+		: T extends "documents"
+			? Document
+			: Milestone;
+
+export class ContentStore {
+	#cache = new Map<string, unknown>();
+
+	key(type: EntityType, id: string): string {
+		return `${type}/${id}`;
+	}
+
+	get<T extends EntityType>(type: T, id: string): Entity<T> | undefined {
+		return this.#cache.get(this.key(type, id)) as Entity<T> | undefined;
+	}
+
+	set<T extends EntityType>(type: T, id: string, entity: Entity<T>): void {
+		this.#cache.set(this.key(type, id), entity);
+	}
+
+	delete(type: EntityType, id: string): void {
+		this.#cache.delete(this.key(type, id));
+	}
+
+	clear(): void {
+		this.#cache.clear();
+	}
+}

--- a/packages/coding-agent/src/task-manager/core.ts
+++ b/packages/coding-agent/src/task-manager/core.ts
@@ -85,11 +85,14 @@ export class Core {
 
 	// ─── Init ────────────────────────────────────────────────────────────────
 
-	async initializeProject(name: string, _defaults: boolean = false): Promise<TaskConfig> {
-		const config: TaskConfig = {
+	async initializeProject(name: string, _defaults: boolean = false, enableGit: boolean = true): Promise<TaskConfig> {
+		const baseConfig: TaskConfig = {
 			...DEFAULT_INIT_CONFIG,
 			projectName: name,
 		};
+		const config: TaskConfig = enableGit
+			? baseConfig
+			: { ...baseConfig, git: { ...baseConfig.git, enabled: false, autoCommit: false } };
 
 		this.fs.setConfig(config);
 		this.#config = config;
@@ -187,9 +190,10 @@ export class Core {
 
 	async updateTask(id: string, input: TaskUpdateInput): Promise<Task> {
 		const task = await this.loadTask(id);
+		const filtered = Object.fromEntries(Object.entries(input).filter(([, v]) => v !== undefined));
 		const updated: Task = {
 			...task,
-			...input,
+			...filtered,
 			updatedAt: new Date().toISOString(),
 		};
 		const content = serializeTask(updated);
@@ -264,7 +268,7 @@ export class Core {
 		if (this.config.git.enabled && (await this.git.isRepo())) {
 			const filePath = this.fs.filePathFor("tasks", resolvedId);
 			await this.git.rm([filePath]);
-			await this.git.commit(`${this.config.git.commitPrefix} delete ${resolvedId}`);
+			await this.git.commit([filePath], `${this.config.git.commitPrefix} delete ${resolvedId}`);
 		}
 	}
 

--- a/packages/coding-agent/src/task-manager/core.ts
+++ b/packages/coding-agent/src/task-manager/core.ts
@@ -1,0 +1,414 @@
+/**
+ * Core Task Manager — task CRUD, config loading, and entity operations.
+ *
+ * Strips TUI rendering and MCP server methods from the source. Keeps only
+ * data operations: createTask, loadTask, updateTask, listTasks, archiveTask,
+ * deleteTask (NEW — hard delete + git rm), ensureConfigLoaded, ensureConfigMigrated.
+ */
+
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { DEFAULT_INIT_CONFIG } from "./constants";
+import { ContentStore } from "./content-store";
+import { FileSystem } from "./file-system";
+import { GitOperations } from "./git-ops";
+import { parseDecision, parseDocument, parseMilestone, parseTask } from "./markdown/parser";
+import {
+	makeComment,
+	serializeDecision,
+	serializeDocument,
+	serializeMilestone,
+	serializeTask,
+} from "./markdown/serializer";
+import { Sequences } from "./sequences";
+import type {
+	Decision,
+	Document,
+	Milestone,
+	Task,
+	TaskConfig,
+	TaskCreateInput,
+	TaskListFilter,
+	TaskUpdateInput,
+} from "./types";
+
+const CONFIG_VERSION = 1;
+
+export class Core {
+	readonly fs: FileSystem;
+	readonly git: GitOperations;
+	readonly content = new ContentStore();
+	#config: TaskConfig | null = null;
+	#sequences: Sequences | null = null;
+
+	constructor(rootDir: string = process.cwd()) {
+		this.fs = new FileSystem(rootDir);
+		this.git = new GitOperations(rootDir, true);
+	}
+
+	// ─── Config ─────────────────────────────────────────────────────────────
+
+	get config(): TaskConfig {
+		if (!this.#config) throw new Error("Task Manager config not loaded — call ensureConfigLoaded() first");
+		return this.#config;
+	}
+
+	get sequences(): Sequences {
+		if (!this.#sequences) throw new Error("Task Manager config not loaded — call ensureConfigLoaded() first");
+		return this.#sequences;
+	}
+
+	async ensureConfigLoaded(): Promise<TaskConfig> {
+		if (this.#config) return this.#config;
+		const raw = await this.fs.readConfig();
+		if (raw) {
+			const parsed = YAML.parse(raw) as TaskConfig;
+			this.#config = { ...DEFAULT_INIT_CONFIG, ...parsed };
+		} else {
+			this.#config = { ...DEFAULT_INIT_CONFIG };
+		}
+		this.fs.setConfig(this.#config);
+		this.#sequences = new Sequences(this.#config, this.fs.rootDir);
+		return this.#config;
+	}
+
+	async ensureConfigMigrated(): Promise<void> {
+		const config = await this.ensureConfigLoaded();
+		const raw = await this.fs.readConfig();
+		if (!raw) return;
+		const parsed = YAML.parse(raw) as Record<string, unknown>;
+		if ((parsed._version as number | undefined) === CONFIG_VERSION) return;
+		const migrated: TaskConfig & { _version?: number } = { ...config, _version: CONFIG_VERSION };
+		await this.fs.writeConfig(YAML.stringify(migrated, null, 2));
+	}
+
+	// ─── Init ────────────────────────────────────────────────────────────────
+
+	async initializeProject(name: string, _defaults: boolean = false): Promise<TaskConfig> {
+		const config: TaskConfig = {
+			...DEFAULT_INIT_CONFIG,
+			projectName: name,
+		};
+
+		this.fs.setConfig(config);
+		this.#config = config;
+		this.#sequences = new Sequences(config, this.fs.rootDir);
+
+		await this.fs.ensureDirs();
+		await this.fs.writeConfig(YAML.stringify({ ...config, _version: CONFIG_VERSION }, null, 2));
+
+		if (config.git.enabled && (await this.git.isRepo())) {
+			const gitignore = path.join(this.fs.rootDir, ".gitignore");
+			const lockLine = `${config.files.sequences}.lock`;
+			try {
+				const existing = await Bun.file(gitignore).text();
+				if (!existing.includes(lockLine)) {
+					await Bun.write(gitignore, `${existing.trimEnd()}\n${lockLine}\n`);
+				}
+			} catch (err) {
+				if (isEnoent(err)) {
+					await Bun.write(gitignore, `${lockLine}\n`);
+				} else {
+					throw err;
+				}
+			}
+		}
+
+		return config;
+	}
+
+	// ─── Task CRUD ──────────────────────────────────────────────────────────
+
+	async createTask(input: TaskCreateInput): Promise<Task> {
+		await this.ensureConfigLoaded();
+		const id = await this.sequences.next("task");
+		const now = new Date().toISOString();
+
+		const task: Task = {
+			id,
+			title: input.title,
+			description: input.description ?? "",
+			status: input.status ?? this.config.defaultStatus,
+			assignee: input.assignee ?? null,
+			labels: input.labels ?? [],
+			priority: input.priority ?? null,
+			parentTaskId: input.parentTaskId ?? null,
+			dependencies: input.dependencies ?? [],
+			createdAt: now,
+			updatedAt: now,
+			milestone: input.milestone ?? null,
+			taskPlan: input.taskPlan ?? null,
+			acceptanceCriteria: (input.acceptanceCriteria ?? []).map(text => ({ text, checked: false })),
+			definitionOfDone: (input.definitionOfDone ?? []).map(text => ({ text, checked: false })),
+			comments: [],
+			notes: null,
+			finalSummary: null,
+			draft: input.draft ?? false,
+			archived: false,
+			archivedAt: null,
+			milestoneOrder: null,
+		};
+
+		const content = serializeTask(task);
+		await this.fs.writeEntity("tasks", id, content);
+		this.content.set("tasks", id, task);
+
+		if (this.config.git.autoCommit) {
+			const filePath = this.fs.filePathFor("tasks", id);
+			await this.git.addAndCommit([filePath], `${this.config.git.commitPrefix} create ${id}`);
+		}
+
+		return task;
+	}
+
+	/**
+	 * Resolve a short numeric ID (e.g. "1") to its full prefixed form (e.g. "task-1")
+	 * by checking if the raw ID exists, then trying `${prefix}-${id}`.
+	 */
+	async resolveTaskId(id: string): Promise<string> {
+		await this.ensureConfigLoaded();
+		if (await this.fs.entityExists("tasks", id)) return id;
+		const prefixed = `${this.config.prefixes.task}-${id}`;
+		if (await this.fs.entityExists("tasks", prefixed)) return prefixed;
+		return id; // let loadTask throw the not-found error
+	}
+
+	async loadTask(id: string): Promise<Task> {
+		const resolvedId = await this.resolveTaskId(id);
+		await this.ensureConfigLoaded();
+		const cached = this.content.get("tasks", resolvedId);
+		if (cached) return cached;
+		const raw = await this.fs.readEntity("tasks", resolvedId);
+		const task = parseTask(raw);
+		this.content.set("tasks", resolvedId, task);
+		return task;
+	}
+
+	async updateTask(id: string, input: TaskUpdateInput): Promise<Task> {
+		const task = await this.loadTask(id);
+		const updated: Task = {
+			...task,
+			...input,
+			updatedAt: new Date().toISOString(),
+		};
+		const content = serializeTask(updated);
+		await this.fs.writeEntity("tasks", task.id, content);
+		this.content.set("tasks", task.id, updated);
+
+		if (this.config.git.autoCommit) {
+			const filePath = this.fs.filePathFor("tasks", task.id);
+			await this.git.addAndCommit([filePath], `${this.config.git.commitPrefix} update ${task.id}`);
+		}
+
+		return updated;
+	}
+
+	async listTasks(filter?: TaskListFilter): Promise<Task[]> {
+		await this.ensureConfigLoaded();
+		const ids = await this.fs.listEntityFiles("tasks");
+		const tasks: Task[] = [];
+		for (const id of ids) {
+			try {
+				const task = await this.loadTask(id);
+				if (task.archived) continue;
+				tasks.push(task);
+			} catch {
+				// Skip files that fail to parse
+			}
+		}
+
+		let filtered = tasks;
+		if (filter?.status) filtered = filtered.filter(t => t.status === filter.status);
+		if (filter?.assignee) filtered = filtered.filter(t => t.assignee === filter.assignee);
+		if (filter?.parentTaskId) filtered = filtered.filter(t => t.parentTaskId === filter.parentTaskId);
+		if (filter?.labels && filter.labels.length > 0) {
+			filtered = filtered.filter(t => filter.labels!.some(l => t.labels.includes(l)));
+		}
+		if (filter?.limit) filtered = filtered.slice(0, filter.limit);
+
+		return filtered;
+	}
+
+	async archiveTask(id: string): Promise<void> {
+		const task = await this.loadTask(id);
+		const archived: Task = {
+			...task,
+			archived: true,
+			archivedAt: new Date().toISOString(),
+			updatedAt: new Date().toISOString(),
+		};
+		const content = serializeTask(archived);
+		await this.fs.writeEntity("tasks", task.id, content);
+		await this.fs.archiveEntity("tasks", task.id);
+		this.content.delete("tasks", task.id);
+
+		if (this.config.git.autoCommit) {
+			const oldPath = this.fs.filePathFor("tasks", task.id);
+			const newPath = this.fs.archivePathFor("tasks", task.id);
+			await this.git.addAndCommit([oldPath, newPath], `${this.config.git.commitPrefix} archive ${task.id}`);
+		}
+	}
+
+	// ─── deleteTask (NEW — hard delete + git rm) ──────────────────────────────
+
+	async deleteTask(id: string): Promise<void> {
+		await this.ensureConfigLoaded();
+		const resolvedId = await this.resolveTaskId(id);
+		const exists = await this.fs.entityExists("tasks", resolvedId);
+		if (!exists) throw new Error(`Task not found: ${id}`);
+
+		await this.fs.deleteEntity("tasks", resolvedId);
+		this.content.delete("tasks", resolvedId);
+
+		if (this.config.git.enabled && (await this.git.isRepo())) {
+			const filePath = this.fs.filePathFor("tasks", resolvedId);
+			await this.git.rm([filePath]);
+			await this.git.commit(`${this.config.git.commitPrefix} delete ${resolvedId}`);
+		}
+	}
+
+	// ─── Task edit helpers ───────────────────────────────────────────────────
+
+	async addComment(id: string, author: string, text: string): Promise<Task> {
+		const task = await this.loadTask(id);
+		const comment = makeComment(author, text);
+		return this.updateTask(id, { comments: [...task.comments, comment] } as Partial<Task>);
+	}
+
+	// ─── Decisions ───────────────────────────────────────────────────────────
+
+	async createDecision(
+		title: string,
+		status: string = "proposed",
+		context: string = "",
+		decision: string = "",
+	): Promise<Decision> {
+		await this.ensureConfigLoaded();
+		const id = await this.sequences.next("decision");
+		const now = new Date().toISOString();
+		const entity: Decision = {
+			id,
+			title,
+			status,
+			context,
+			decision,
+			consequences: null,
+			createdAt: now,
+			updatedAt: now,
+			tags: [],
+		};
+		const content = serializeDecision(entity);
+		await this.fs.writeEntity("decisions", id, content);
+		this.content.set("decisions", id, entity);
+		return entity;
+	}
+
+	async loadDecision(id: string): Promise<Decision> {
+		await this.ensureConfigLoaded();
+		const cached = this.content.get("decisions", id);
+		if (cached) return cached;
+		const raw = await this.fs.readEntity("decisions", id);
+		const entity = parseDecision(raw);
+		this.content.set("decisions", id, entity);
+		return entity;
+	}
+
+	// ─── Documents ───────────────────────────────────────────────────────────
+
+	async createDocument(
+		title: string,
+		type: string = "doc",
+		content: string = "",
+		tags: string[] = [],
+		filePath: string | null = null,
+	): Promise<Document> {
+		await this.ensureConfigLoaded();
+		const id = await this.sequences.next("document");
+		const now = new Date().toISOString();
+		const entity: Document = {
+			id,
+			title,
+			type,
+			tags,
+			path: filePath,
+			content,
+			createdAt: now,
+			updatedAt: now,
+		};
+		const serialized = serializeDocument(entity);
+		await this.fs.writeEntity("documents", id, serialized);
+		this.content.set("documents", id, entity);
+		return entity;
+	}
+
+	async loadDocument(id: string): Promise<Document> {
+		await this.ensureConfigLoaded();
+		const cached = this.content.get("documents", id);
+		if (cached) return cached;
+		const raw = await this.fs.readEntity("documents", id);
+		const entity = parseDocument(raw);
+		this.content.set("documents", id, entity);
+		return entity;
+	}
+
+	async listDocuments(): Promise<Document[]> {
+		await this.ensureConfigLoaded();
+		const ids = await this.fs.listEntityFiles("documents");
+		const docs: Document[] = [];
+		for (const id of ids) {
+			try {
+				docs.push(await this.loadDocument(id));
+			} catch {
+				// Skip files that fail to parse
+			}
+		}
+		return docs;
+	}
+
+	// ─── Milestones ──────────────────────────────────────────────────────────
+
+	async createMilestone(name: string, description: string = ""): Promise<Milestone> {
+		await this.ensureConfigLoaded();
+		const id = await this.sequences.next("milestone");
+		const now = new Date().toISOString();
+		const entity: Milestone = {
+			id,
+			name,
+			description,
+			status: "active",
+			createdAt: now,
+			updatedAt: now,
+			archived: false,
+			archivedAt: null,
+		};
+		const content = serializeMilestone(entity);
+		await this.fs.writeEntity("milestones", id, content);
+		this.content.set("milestones", id, entity);
+		return entity;
+	}
+
+	async loadMilestone(id: string): Promise<Milestone> {
+		await this.ensureConfigLoaded();
+		const cached = this.content.get("milestones", id);
+		if (cached) return cached;
+		const raw = await this.fs.readEntity("milestones", id);
+		const entity = parseMilestone(raw);
+		this.content.set("milestones", id, entity);
+		return entity;
+	}
+
+	async listMilestones(): Promise<Milestone[]> {
+		await this.ensureConfigLoaded();
+		const ids = await this.fs.listEntityFiles("milestones");
+		const milestones: Milestone[] = [];
+		for (const id of ids) {
+			try {
+				milestones.push(await this.loadMilestone(id));
+			} catch {
+				// Skip files that fail to parse
+			}
+		}
+		return milestones;
+	}
+}

--- a/packages/coding-agent/src/task-manager/file-system.ts
+++ b/packages/coding-agent/src/task-manager/file-system.ts
@@ -1,0 +1,172 @@
+/**
+ * File system operations for Task Manager.
+ *
+ * Replaces `proper-lockfile` with omp's `withFileLock` from `config/file-lock.ts`.
+ * Keeps the `CreateLockError` pattern — wraps `withFileLock` failures into
+ * the same error code `ECREATELOCK`.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import { withFileLock } from "../config/file-lock";
+import { DEFAULT_FILES, ENTITY_EXTENSION } from "./constants";
+import type { TaskConfig } from "./types";
+
+export class CreateLockError extends Error {
+	code = "ECREATELOCK" as const;
+	constructor(
+		message: string,
+		public readonly path: string,
+	) {
+		super(message);
+		this.name = "CreateLockError";
+	}
+}
+
+export class FileSystem {
+	#config: TaskConfig | null = null;
+	#rootDir: string;
+
+	constructor(rootDir: string = process.cwd()) {
+		this.#rootDir = rootDir;
+	}
+
+	setConfig(config: TaskConfig): void {
+		this.#config = config;
+	}
+
+	get config(): TaskConfig {
+		if (!this.#config) throw new Error("Task Manager config not loaded");
+		return this.#config;
+	}
+
+	get rootDir(): string {
+		return this.#rootDir;
+	}
+
+	dirFor(type: "tasks" | "decisions" | "documents" | "milestones" | "archive"): string {
+		return path.join(this.#rootDir, this.config.directories[type]);
+	}
+
+	filePathFor(type: "tasks" | "decisions" | "documents" | "milestones", id: string): string {
+		return path.join(this.dirFor(type), `${id}${ENTITY_EXTENSION}`);
+	}
+
+	archivePathFor(type: "tasks" | "decisions" | "documents" | "milestones", id: string): string {
+		return path.join(this.dirFor("archive"), type, `${id}${ENTITY_EXTENSION}`);
+	}
+
+	configPath(): string {
+		return path.join(this.#rootDir, this.#config?.files.config ?? DEFAULT_FILES.config);
+	}
+
+	async ensureDirs(): Promise<void> {
+		const dirs = [
+			this.dirFor("tasks"),
+			this.dirFor("decisions"),
+			this.dirFor("documents"),
+			this.dirFor("milestones"),
+			this.dirFor("archive"),
+			path.join(this.dirFor("archive"), "tasks"),
+			path.join(this.dirFor("archive"), "decisions"),
+			path.join(this.dirFor("archive"), "documents"),
+			path.join(this.dirFor("archive"), "milestones"),
+		];
+		await Promise.all(dirs.map(d => fs.mkdir(d, { recursive: true })));
+	}
+
+	async readEntity(type: "tasks" | "decisions" | "documents" | "milestones", id: string): Promise<string> {
+		const filePath = this.filePathFor(type, id);
+		try {
+			return await Bun.file(filePath).text();
+		} catch (err) {
+			if (isEnoent(err)) throw new Error(`Task not found: ${id}`);
+			throw err;
+		}
+	}
+
+	async writeEntity(
+		type: "tasks" | "decisions" | "documents" | "milestones",
+		id: string,
+		content: string,
+	): Promise<void> {
+		const filePath = this.filePathFor(type, id);
+		await this.#writeWithLock(filePath, content);
+	}
+
+	async deleteEntity(type: "tasks" | "decisions" | "documents" | "milestones", id: string): Promise<void> {
+		const filePath = this.filePathFor(type, id);
+		try {
+			await fs.unlink(filePath);
+		} catch (err) {
+			if (isEnoent(err)) throw new Error(`Task not found: ${id}`);
+			throw err;
+		}
+	}
+
+	async archiveEntity(type: "tasks" | "decisions" | "documents" | "milestones", id: string): Promise<void> {
+		const srcPath = this.filePathFor(type, id);
+		const destPath = this.archivePathFor(type, id);
+		try {
+			const content = await Bun.file(srcPath).text();
+			await this.#writeWithLock(destPath, content);
+			await fs.unlink(srcPath);
+		} catch (err) {
+			if (isEnoent(err)) throw new Error(`Task not found: ${id}`);
+			throw err;
+		}
+	}
+
+	async listEntityFiles(type: "tasks" | "decisions" | "documents" | "milestones"): Promise<string[]> {
+		const dir = this.dirFor(type);
+		try {
+			const entries = await fs.readdir(dir);
+			return entries.filter(f => f.endsWith(ENTITY_EXTENSION)).map(f => f.slice(0, -ENTITY_EXTENSION.length));
+		} catch (err) {
+			if (isEnoent(err)) return [];
+			throw err;
+		}
+	}
+
+	async entityExists(type: "tasks" | "decisions" | "documents" | "milestones", id: string): Promise<boolean> {
+		try {
+			const stat = await fs.stat(this.filePathFor(type, id));
+			return stat.isFile();
+		} catch (err) {
+			if (isEnoent(err)) return false;
+			throw err;
+		}
+	}
+
+	async readConfig(): Promise<string | null> {
+		try {
+			return await Bun.file(this.configPath()).text();
+		} catch (err) {
+			if (isEnoent(err)) return null;
+			throw err;
+		}
+	}
+
+	async writeConfig(content: string): Promise<void> {
+		await this.#writeWithLock(this.configPath(), content);
+	}
+
+	/**
+	 * Write a file under a file lock, wrapping lock-acquisition failures into
+	 * `CreateLockError` (code `ECREATELOCK`) to match the source contract.
+	 */
+	async #writeWithLock(filePath: string, content: string): Promise<void> {
+		try {
+			await withFileLock(filePath, async () => {
+				await Bun.write(filePath, content);
+			});
+		} catch (err) {
+			if (err instanceof CreateLockError) throw err;
+			throw new CreateLockError(
+				`Failed to acquire lock for ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+				filePath,
+			);
+		}
+	}
+}

--- a/packages/coding-agent/src/task-manager/git-ops.ts
+++ b/packages/coding-agent/src/task-manager/git-ops.ts
@@ -1,0 +1,91 @@
+/**
+ * Git operations for Task Manager.
+ *
+ * Uses Bun's `$` shell directly for git operations not covered by omp's
+ * `utils/git.ts` exports (git add, git branch list, git show branch:path).
+ * Where omp's git utils do cover an operation (commit), they are used.
+ */
+
+import { $ } from "bun";
+
+export class GitOperations {
+	#cwd: string;
+	#enabled: boolean;
+
+	constructor(cwd: string = process.cwd(), enabled: boolean = true) {
+		this.#cwd = cwd;
+		this.#enabled = enabled;
+	}
+
+	get enabled(): boolean {
+		return this.#enabled;
+	}
+
+	get cwd(): string {
+		return this.#cwd;
+	}
+
+	async isRepo(): Promise<boolean> {
+		if (!this.#enabled) return false;
+		const result = await $`git rev-parse --is-inside-work-tree`.cwd(this.#cwd).quiet().nothrow();
+		return result.exitCode === 0;
+	}
+
+	async add(paths: string[]): Promise<void> {
+		if (!this.#enabled || paths.length === 0) return;
+		await $`git add ${paths}`.cwd(this.#cwd).quiet().nothrow();
+	}
+
+	async rm(paths: string[]): Promise<void> {
+		if (!this.#enabled || paths.length === 0) return;
+		await $`git rm ${paths}`.cwd(this.#cwd).quiet().nothrow();
+	}
+
+	async commit(message: string): Promise<void> {
+		if (!this.#enabled) return;
+		await $`git commit -m ${message}`.cwd(this.#cwd).quiet().nothrow();
+	}
+
+	async addAndCommit(paths: string[], message: string): Promise<void> {
+		await this.add(paths);
+		await this.commit(message);
+	}
+
+	async currentBranch(): Promise<string | null> {
+		if (!this.#enabled) return null;
+		const result = await $`git rev-parse --abbrev-ref HEAD`.cwd(this.#cwd).quiet().nothrow();
+		if (result.exitCode !== 0) return null;
+		const branch = result.text().trim();
+		return branch === "HEAD" ? null : branch;
+	}
+
+	async listBranches(): Promise<string[]> {
+		if (!this.#enabled) return [];
+		const result = await $`git branch --list --format=%(refname:short)`.cwd(this.#cwd).quiet().nothrow();
+		if (result.exitCode !== 0) return [];
+		return result
+			.text()
+			.split("\n")
+			.map(b => b.trim())
+			.filter(Boolean);
+	}
+
+	async showFile(branch: string, filePath: string): Promise<string | null> {
+		if (!this.#enabled) return null;
+		const result = await $`git show ${`${branch}:${filePath}`}`.cwd(this.#cwd).quiet().nothrow();
+		if (result.exitCode !== 0) return null;
+		return result.text();
+	}
+
+	async hasFile(path: string): Promise<boolean> {
+		if (!this.#enabled) return false;
+		const result = await $`git cat-file -e ${`HEAD:${path}`}`.cwd(this.#cwd).quiet().nothrow();
+		return result.exitCode === 0;
+	}
+}
+
+/** Check whether a directory is inside a git repository. */
+export async function isGitRepo(cwd: string): Promise<boolean> {
+	const result = await $`git rev-parse --is-inside-work-tree`.cwd(cwd).quiet().nothrow();
+	return result.exitCode === 0;
+}

--- a/packages/coding-agent/src/task-manager/git-ops.ts
+++ b/packages/coding-agent/src/task-manager/git-ops.ts
@@ -33,22 +33,27 @@ export class GitOperations {
 
 	async add(paths: string[]): Promise<void> {
 		if (!this.#enabled || paths.length === 0) return;
-		await $`git add ${paths}`.cwd(this.#cwd).quiet().nothrow();
+		const result = await $`git add ${paths}`.cwd(this.#cwd).quiet().nothrow();
+		if (result.exitCode !== 0) throw new Error(`git add failed: ${result.stderr.toString().trim()}`);
 	}
 
 	async rm(paths: string[]): Promise<void> {
 		if (!this.#enabled || paths.length === 0) return;
-		await $`git rm ${paths}`.cwd(this.#cwd).quiet().nothrow();
+		const result = await $`git rm ${paths}`.cwd(this.#cwd).quiet().nothrow();
+		if (result.exitCode !== 0) throw new Error(`git rm failed: ${result.stderr.toString().trim()}`);
 	}
 
-	async commit(message: string): Promise<void> {
+	async commit(paths: string[] | null, message: string): Promise<void> {
 		if (!this.#enabled) return;
-		await $`git commit -m ${message}`.cwd(this.#cwd).quiet().nothrow();
+		const result = paths
+			? await $`git commit --only ${paths} -m ${message}`.cwd(this.#cwd).quiet().nothrow()
+			: await $`git commit -m ${message}`.cwd(this.#cwd).quiet().nothrow();
+		if (result.exitCode !== 0) throw new Error(`git commit failed: ${result.stderr.toString().trim()}`);
 	}
 
 	async addAndCommit(paths: string[], message: string): Promise<void> {
 		await this.add(paths);
-		await this.commit(message);
+		await this.commit(paths, message);
 	}
 
 	async currentBranch(): Promise<string | null> {

--- a/packages/coding-agent/src/task-manager/markdown/parser.ts
+++ b/packages/coding-agent/src/task-manager/markdown/parser.ts
@@ -1,0 +1,162 @@
+/**
+ * Markdown parser for Task Manager entities.
+ *
+ * Replaces gray-matter with omp's `parseFrontmatter` from `@oh-my-pi/pi-utils`.
+ * Pass `{ normalize: false }` to preserve snake_case keys used by the on-disk
+ * format (`created_date`, `parent_task_id`, etc.).
+ */
+
+import { parseFrontmatter } from "@oh-my-pi/pi-utils";
+import { FALLBACK_STATUS } from "../constants";
+import type { Decision, Document, Milestone, Task } from "../types";
+import {
+	parseAcceptanceCriteria,
+	parseComments,
+	parseDefinitionOfDone,
+	parseFreeTextSection,
+	SECTION_HEADERS,
+} from "./structured-sections";
+
+// ─── Task ──────────────────────────────────────────────────────────────────
+
+export function parseTask(rawContent: string): Task {
+	const { frontmatter, body } = parseFrontmatter(rawContent, { normalize: false });
+
+	const fm = frontmatter as Record<string, unknown>;
+	const id = str(fm.id) ?? "";
+	const title = str(fm.title) ?? "";
+	const status = str(fm.status) ?? FALLBACK_STATUS;
+	const description = str(fm.description) ?? "";
+	const assignee = str(fm.assignee) ?? null;
+	const labels = arr(fm.labels);
+	const priority = str(fm.priority) ?? null;
+	const parentTaskId = str(fm.parent_task_id) ?? null;
+	const dependencies = arr(fm.dependencies);
+	const createdAt = str(fm.created_date) ?? new Date().toISOString();
+	const updatedAt = str(fm.updated_date) ?? createdAt;
+	const milestone = str(fm.milestone) ?? null;
+	const taskPlan = str(fm.task_plan) ?? null;
+	const draft = bool(fm.draft);
+	const archived = bool(fm.archived);
+	const archivedAt = str(fm.archived_date) ?? null;
+	const milestoneOrder = num(fm.milestone_order) ?? null;
+
+	const acceptanceCriteria = parseAcceptanceCriteria(body);
+	const definitionOfDone = parseDefinitionOfDone(body);
+	const comments = parseComments(body);
+	const notes = parseFreeTextSection(body, SECTION_HEADERS.NOTES, [
+		SECTION_HEADERS.FINAL_SUMMARY,
+		SECTION_HEADERS.PLAN,
+	]);
+	const finalSummary = parseFreeTextSection(body, SECTION_HEADERS.FINAL_SUMMARY, [SECTION_HEADERS.PLAN]);
+
+	return {
+		id,
+		title,
+		description,
+		status,
+		assignee,
+		labels,
+		priority,
+		parentTaskId,
+		dependencies,
+		createdAt,
+		updatedAt,
+		milestone,
+		taskPlan,
+		acceptanceCriteria,
+		definitionOfDone,
+		comments,
+		notes,
+		finalSummary,
+		draft,
+		archived,
+		archivedAt,
+		milestoneOrder,
+		rawContent,
+		rawFrontmatter: fm,
+	};
+}
+
+// ─── Decision ──────────────────────────────────────────────────────────────
+
+export function parseDecision(rawContent: string): Decision {
+	const { frontmatter, body } = parseFrontmatter(rawContent, { normalize: false });
+	const fm = frontmatter as Record<string, unknown>;
+
+	return {
+		id: str(fm.id) ?? "",
+		title: str(fm.title) ?? "",
+		status: str(fm.status) ?? "proposed",
+		context: str(fm.context) ?? body.trim(),
+		decision: str(fm.decision) ?? "",
+		consequences: str(fm.consequences) ?? null,
+		createdAt: str(fm.created_date) ?? new Date().toISOString(),
+		updatedAt: str(fm.updated_date) ?? str(fm.created_date) ?? new Date().toISOString(),
+		tags: arr(fm.tags),
+		rawContent,
+		rawFrontmatter: fm,
+	};
+}
+
+// ─── Document ──────────────────────────────────────────────────────────────
+
+export function parseDocument(rawContent: string): Document {
+	const { frontmatter, body } = parseFrontmatter(rawContent, { normalize: false });
+	const fm = frontmatter as Record<string, unknown>;
+
+	return {
+		id: str(fm.id) ?? "",
+		title: str(fm.title) ?? "",
+		type: str(fm.type) ?? "doc",
+		tags: arr(fm.tags),
+		path: str(fm.path) ?? null,
+		content: body.trim(),
+		createdAt: str(fm.created_date) ?? new Date().toISOString(),
+		updatedAt: str(fm.updated_date) ?? str(fm.created_date) ?? new Date().toISOString(),
+		rawContent,
+		rawFrontmatter: fm,
+	};
+}
+
+// ─── Milestone ─────────────────────────────────────────────────────────────
+
+export function parseMilestone(rawContent: string): Milestone {
+	const { frontmatter } = parseFrontmatter(rawContent, { normalize: false });
+	const fm = frontmatter as Record<string, unknown>;
+
+	return {
+		id: str(fm.id) ?? "",
+		name: str(fm.name) ?? "",
+		description: str(fm.description) ?? "",
+		status: str(fm.status) ?? "active",
+		createdAt: str(fm.created_date) ?? new Date().toISOString(),
+		updatedAt: str(fm.updated_date) ?? str(fm.created_date) ?? new Date().toISOString(),
+		archived: bool(fm.archived),
+		archivedAt: str(fm.archived_date) ?? null,
+		rawContent,
+		rawFrontmatter: fm,
+	};
+}
+
+// ─── Coercion helpers ───────────────────────────────────────────────────────
+
+function str(v: unknown): string | null {
+	if (v === null || v === undefined) return null;
+	return String(v);
+}
+
+function arr(v: unknown): string[] {
+	if (!Array.isArray(v)) return [];
+	return v.map(String);
+}
+
+function bool(v: unknown): boolean {
+	return v === true || v === "true";
+}
+
+function num(v: unknown): number | null {
+	if (v === null || v === undefined) return null;
+	const n = Number(v);
+	return Number.isNaN(n) ? null : n;
+}

--- a/packages/coding-agent/src/task-manager/markdown/serializer.ts
+++ b/packages/coding-agent/src/task-manager/markdown/serializer.ts
@@ -1,0 +1,136 @@
+/**
+ * Markdown serializer for Task Manager entities.
+ *
+ * Replaces gray-matter's `stringify` with `Bun.YAML.stringify` for frontmatter
+ * and manual `---\n${yaml}\n---\n${body}` assembly.
+ */
+
+import { YAML } from "bun";
+import type { Decision, Document, Milestone, Task, TaskComment } from "../types";
+import {
+	serializeAcceptanceCriteria,
+	serializeComments,
+	serializeDefinitionOfDone,
+	serializeFreeTextSection,
+} from "./structured-sections";
+
+// ─── Task ──────────────────────────────────────────────────────────────────
+
+export function serializeTask(task: Task): string {
+	const fm: Record<string, unknown> = {
+		id: task.id,
+		title: task.title,
+		status: task.status,
+	};
+	if (task.description) fm.description = task.description;
+	if (task.assignee) fm.assignee = task.assignee;
+	if (task.labels.length > 0) fm.labels = task.labels;
+	if (task.priority) fm.priority = task.priority;
+	if (task.parentTaskId) fm.parent_task_id = task.parentTaskId;
+	if (task.dependencies.length > 0) fm.dependencies = task.dependencies;
+	if (task.milestone) fm.milestone = task.milestone;
+	if (task.taskPlan) fm.task_plan = task.taskPlan;
+	if (task.draft) fm.draft = true;
+	if (task.archived) {
+		fm.archived = true;
+		if (task.archivedAt) fm.archived_date = task.archivedAt;
+	}
+	if (task.milestoneOrder !== null) fm.milestone_order = task.milestoneOrder;
+	fm.created_date = task.createdAt;
+	fm.updated_date = task.updatedAt;
+
+	const sections: string[] = [];
+	if (task.acceptanceCriteria.length > 0) {
+		sections.push(serializeAcceptanceCriteria(task.acceptanceCriteria));
+	}
+	if (task.definitionOfDone.length > 0) {
+		sections.push(serializeDefinitionOfDone(task.definitionOfDone));
+	}
+	if (task.taskPlan) {
+		sections.push(serializeFreeTextSection("Implementation Plan", task.taskPlan));
+	}
+	if (task.notes) {
+		sections.push(serializeFreeTextSection("Notes", task.notes));
+	}
+	if (task.finalSummary) {
+		sections.push(serializeFreeTextSection("Final Summary", task.finalSummary));
+	}
+	if (task.comments.length > 0) {
+		sections.push(serializeComments(task.comments));
+	}
+
+	const body = sections.filter(Boolean).join("\n\n");
+	return assembleFrontmatter(fm, body);
+}
+
+// ─── Decision ──────────────────────────────────────────────────────────────
+
+export function serializeDecision(decision: Decision): string {
+	const fm: Record<string, unknown> = {
+		id: decision.id,
+		title: decision.title,
+		status: decision.status,
+		context: decision.context,
+		decision: decision.decision,
+	};
+	if (decision.consequences) fm.consequences = decision.consequences;
+	if (decision.tags.length > 0) fm.tags = decision.tags;
+	fm.created_date = decision.createdAt;
+	fm.updated_date = decision.updatedAt;
+
+	return assembleFrontmatter(fm, decision.decision);
+}
+
+// ─── Document ───────────────────────────────────────────────────────────────
+
+export function serializeDocument(doc: Document): string {
+	const fm: Record<string, unknown> = {
+		id: doc.id,
+		title: doc.title,
+		type: doc.type,
+	};
+	if (doc.tags.length > 0) fm.tags = doc.tags;
+	if (doc.path) fm.path = doc.path;
+	fm.created_date = doc.createdAt;
+	fm.updated_date = doc.updatedAt;
+
+	return assembleFrontmatter(fm, doc.content);
+}
+
+// ─── Milestone ──────────────────────────────────────────────────────────────
+
+export function serializeMilestone(milestone: Milestone): string {
+	const fm: Record<string, unknown> = {
+		id: milestone.id,
+		name: milestone.name,
+		status: milestone.status,
+	};
+	if (milestone.description) fm.description = milestone.description;
+	if (milestone.archived) {
+		fm.archived = true;
+		if (milestone.archivedAt) fm.archived_date = milestone.archivedAt;
+	}
+	fm.created_date = milestone.createdAt;
+	fm.updated_date = milestone.updatedAt;
+
+	return assembleFrontmatter(fm, milestone.description);
+}
+
+// ─── Comment (standalone helper for edit --comment) ──────────────────────────
+
+export function makeComment(author: string, text: string): TaskComment {
+	return {
+		id: `comment-${Date.now()}`,
+		author,
+		text,
+		createdDate: new Date().toISOString().slice(0, 10),
+	};
+}
+
+// ─── Frontmatter assembly ───────────────────────────────────────────────────
+
+function assembleFrontmatter(fm: Record<string, unknown>, body: string): string {
+	const yaml = YAML.stringify(fm, null, 2).trimEnd();
+	const trimmedBody = body.trim();
+	return `---\n${yaml}\n---\n${trimmedBody ? `\n${trimmedBody}\n` : ""}`;
+}

--- a/packages/coding-agent/src/task-manager/markdown/structured-sections.ts
+++ b/packages/coding-agent/src/task-manager/markdown/structured-sections.ts
@@ -1,0 +1,171 @@
+/**
+ * Structured section managers for markdown task bodies.
+ *
+ * These parse and serialize the markdown-list sections embedded in a task's
+ * body: acceptance criteria, definition of done, and comments. No external
+ * dependencies — pure string manipulation.
+ */
+
+import type { AcceptanceCriterion, DefinitionOfDoneItem, TaskComment } from "../types";
+
+// ─── Headers ───────────────────────────────────────────────────────────────
+
+const AC_HEADER = /##\s*Acceptance Criteria/i;
+const DOD_HEADER = /##\s*Definition of Done/i;
+const COMMENTS_HEADER = /##\s*Comments/i;
+const NOTES_HEADER = /##\s*Notes/i;
+const FINAL_SUMMARY_HEADER = /##\s*Final Summary/i;
+const PLAN_HEADER = /##\s*Implementation Plan/i;
+
+/** Match a checkbox list item: `- [ ] text` or `- [x] text` */
+const CHECKBOX_RE = /^\s*-\s*\[([ xX])\]\s*(.+)$/;
+
+// ─── Acceptance Criteria ───────────────────────────────────────────────────
+
+export function parseAcceptanceCriteria(body: string): AcceptanceCriterion[] {
+	const section = extractSection(body, AC_HEADER, [
+		DOD_HEADER,
+		COMMENTS_HEADER,
+		NOTES_HEADER,
+		FINAL_SUMMARY_HEADER,
+		PLAN_HEADER,
+	]);
+	if (!section) return [];
+	return parseCheckboxList(section);
+}
+
+export function serializeAcceptanceCriteria(items: AcceptanceCriterion[]): string {
+	if (items.length === 0) return "";
+	const lines = ["## Acceptance Criteria", ""];
+	for (const item of items) {
+		const box = item.checked ? "[x]" : "[ ]";
+		lines.push(`- ${box} ${item.text}`);
+	}
+	return lines.join("\n");
+}
+
+// ─── Definition of Done ────────────────────────────────────────────────────
+
+export function parseDefinitionOfDone(body: string): DefinitionOfDoneItem[] {
+	const section = extractSection(body, DOD_HEADER, [COMMENTS_HEADER, NOTES_HEADER, FINAL_SUMMARY_HEADER, PLAN_HEADER]);
+	if (!section) return [];
+	return parseCheckboxList(section);
+}
+
+export function serializeDefinitionOfDone(items: DefinitionOfDoneItem[]): string {
+	if (items.length === 0) return "";
+	const lines = ["## Definition of Done", ""];
+	for (const item of items) {
+		const box = item.checked ? "[x]" : "[ ]";
+		lines.push(`- ${box} ${item.text}`);
+	}
+	return lines.join("\n");
+}
+
+// ─── Comments ──────────────────────────────────────────────────────────────
+
+export function parseComments(body: string): TaskComment[] {
+	const section = extractSection(body, COMMENTS_HEADER, [NOTES_HEADER, FINAL_SUMMARY_HEADER, PLAN_HEADER]);
+	if (!section) return [];
+	const comments: TaskComment[] = [];
+	const lines = section.split("\n");
+	let current: Partial<TaskComment> | null = null;
+	let textLines: string[] = [];
+
+	for (const line of lines) {
+		const metaMatch = line.match(/^\s*>\s*\*\*(.+?)\s*\((\S+)\)\s*\*\*\s*(.*)?$/);
+		if (metaMatch) {
+			if (current) {
+				comments.push({
+					...(current as TaskComment),
+					text: textLines.join("\n").trim(),
+				});
+			}
+			current = {
+				author: metaMatch[1],
+				createdDate: metaMatch[2],
+				id: `comment-${comments.length + 1}`,
+			};
+			textLines = metaMatch[3] ? [metaMatch[3]] : [];
+		} else if (line.trim() === "" && current) {
+			// blank line separates comment text
+		} else if (current) {
+			textLines.push(line.replace(/^\s*>\s?/, ""));
+		}
+	}
+	if (current) {
+		comments.push({
+			...(current as TaskComment),
+			text: textLines.join("\n").trim(),
+		});
+	}
+	return comments;
+}
+
+export function serializeComments(comments: TaskComment[]): string {
+	if (comments.length === 0) return "";
+	const lines = ["## Comments", ""];
+	for (const c of comments) {
+		const date = c.createdDate || new Date().toISOString().slice(0, 10);
+		lines.push(`> **${c.author} (${date})** ${c.text}`);
+		lines.push("");
+	}
+	return lines.join("\n");
+}
+
+// ─── Free-text sections ────────────────────────────────────────────────────
+
+export function parseFreeTextSection(body: string, headerRe: RegExp, stopHeaders: RegExp[]): string | null {
+	const section = extractSection(body, headerRe, stopHeaders);
+	return section?.trim() || null;
+}
+
+export function serializeFreeTextSection(header: string, content: string | null): string {
+	if (!content) return "";
+	return `## ${header}\n\n${content.trim()}`;
+}
+
+export const SECTION_HEADERS = {
+	AC: AC_HEADER,
+	DOD: DOD_HEADER,
+	COMMENTS: COMMENTS_HEADER,
+	NOTES: NOTES_HEADER,
+	FINAL_SUMMARY: FINAL_SUMMARY_HEADER,
+	PLAN: PLAN_HEADER,
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function extractSection(body: string, headerRe: RegExp, stopHeaders: RegExp[]): string | null {
+	const lines = body.split("\n");
+	let start = -1;
+	for (let i = 0; i < lines.length; i++) {
+		if (headerRe.test(lines[i])) {
+			start = i + 1;
+			break;
+		}
+	}
+	if (start === -1) return null;
+
+	const sectionLines: string[] = [];
+	for (let i = start; i < lines.length; i++) {
+		const line = lines[i];
+		if (stopHeaders.some(re => re.test(line))) break;
+		sectionLines.push(line);
+	}
+	return sectionLines.join("\n");
+}
+
+function parseCheckboxList(text: string): AcceptanceCriterion[] {
+	const items: AcceptanceCriterion[] = [];
+	for (const line of text.split("\n")) {
+		const match = line.match(CHECKBOX_RE);
+		if (match) {
+			items.push({
+				checked: match[1].toLowerCase() === "x",
+				text: match[2].trim(),
+			});
+		}
+	}
+	return items;
+}

--- a/packages/coding-agent/src/task-manager/search.ts
+++ b/packages/coding-agent/src/task-manager/search.ts
@@ -1,0 +1,102 @@
+/**
+ * Search service for Task Manager.
+ *
+ * Replaces `fuse.js` with omp's `fuzzyRank` from `@oh-my-pi/pi-tui`.
+ * Searches across tasks, documents, and decisions — returns results sorted
+ * by fuzzy match score (lower score = better match).
+ */
+
+import { fuzzyRank } from "@oh-my-pi/pi-tui";
+import { DEFAULT_SEARCH_LIMIT } from "./constants";
+import type { Core } from "./core";
+import type { SearchFilters, SearchOptions, SearchResult } from "./types";
+
+interface SearchableItem {
+	id: string;
+	type: "task" | "decision" | "document";
+	title: string;
+	status: string;
+	priority: string | null;
+}
+
+export class SearchService {
+	#core: Core;
+
+	constructor(core: Core) {
+		this.#core = core;
+	}
+
+	async search(query: string, options?: SearchOptions): Promise<SearchResult[]> {
+		const items = await this.#collectSearchableItems(options?.filters);
+		const ranked = fuzzyRank(items, query, item => `${item.title} ${item.id} ${item.status}`);
+		const limit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
+		return ranked.slice(0, limit).map(({ item, score }) => ({
+			id: item.id,
+			type: item.type,
+			title: item.title,
+			status: item.status,
+			score,
+		}));
+	}
+
+	async #collectSearchableItems(filters?: SearchFilters): Promise<SearchableItem[]> {
+		await this.#core.ensureConfigLoaded();
+		const items: SearchableItem[] = [];
+
+		// Tasks
+		const taskIds = await this.#core.fs.listEntityFiles("tasks");
+		for (const id of taskIds) {
+			try {
+				const task = await this.#core.loadTask(id);
+				if (task.archived) continue;
+				if (filters?.status && task.status !== filters.status) continue;
+				if (filters?.priority && task.priority !== filters.priority) continue;
+				items.push({
+					id: task.id,
+					type: "task",
+					title: task.title,
+					status: task.status,
+					priority: task.priority,
+				});
+			} catch {
+				// Skip unparseable files
+			}
+		}
+
+		// Documents
+		const docIds = await this.#core.fs.listEntityFiles("documents");
+		for (const id of docIds) {
+			try {
+				const doc = await this.#core.loadDocument(id);
+				items.push({
+					id: doc.id,
+					type: "document",
+					title: doc.title,
+					status: "n/a",
+					priority: null,
+				});
+			} catch {
+				// Skip unparseable files
+			}
+		}
+
+		// Decisions
+		const decisionIds = await this.#core.fs.listEntityFiles("decisions");
+		for (const id of decisionIds) {
+			try {
+				const decision = await this.#core.loadDecision(id);
+				items.push({
+					id: decision.id,
+					type: "decision",
+					title: decision.title,
+					status: decision.status,
+					priority: null,
+				});
+			} catch {
+				// Skip unparseable files
+			}
+		}
+
+		return items;
+	}
+}

--- a/packages/coding-agent/src/task-manager/sequences.ts
+++ b/packages/coding-agent/src/task-manager/sequences.ts
@@ -1,0 +1,71 @@
+/**
+ * Sequence counter for Task Manager entity IDs.
+ *
+ * Each entity type has its own monotonic counter persisted to
+ * `.omp/tasks/sequences.json`. IDs are `${prefix}-${n}` (e.g. `task-1`).
+ */
+
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import { withFileLock } from "../config/file-lock";
+import type { TaskConfig } from "./types";
+
+interface SequenceMap {
+	task: number;
+	decision: number;
+	document: number;
+	milestone: number;
+}
+
+const EMPTY: SequenceMap = { task: 0, decision: 0, document: 0, milestone: 0 };
+
+export class Sequences {
+	#config: TaskConfig;
+	#rootDir: string;
+	#cache: SequenceMap | null = null;
+
+	constructor(config: TaskConfig, rootDir: string = process.cwd()) {
+		this.#config = config;
+		this.#rootDir = rootDir;
+	}
+
+	get filePath(): string {
+		return path.join(this.#rootDir, this.#config.files.sequences);
+	}
+
+	async next(entity: keyof SequenceMap): Promise<string> {
+		return withFileLock(this.filePath, async () => {
+			const seq = await this.#load();
+			seq[entity] += 1;
+			await this.#save(seq);
+			const prefix = this.#config.prefixes[entity];
+			return `${prefix}-${seq[entity]}`;
+		});
+	}
+
+	async peek(entity: keyof SequenceMap): Promise<number> {
+		const seq = await this.#load();
+		return seq[entity];
+	}
+
+	async #load(): Promise<SequenceMap> {
+		if (this.#cache) return { ...this.#cache };
+		try {
+			const text = await Bun.file(this.filePath).text();
+			const parsed = JSON.parse(text) as Partial<SequenceMap>;
+			this.#cache = { ...EMPTY, ...parsed };
+		} catch (err) {
+			if (isEnoent(err)) {
+				this.#cache = { ...EMPTY };
+			} else {
+				throw err;
+			}
+		}
+		return { ...this.#cache };
+	}
+
+	async #save(seq: SequenceMap): Promise<void> {
+		this.#cache = { ...seq };
+		await Bun.write(this.filePath, JSON.stringify(seq, null, 2));
+	}
+}

--- a/packages/coding-agent/src/task-manager/sequences.ts
+++ b/packages/coding-agent/src/task-manager/sequences.ts
@@ -49,7 +49,9 @@ export class Sequences {
 	}
 
 	async #load(): Promise<SequenceMap> {
-		if (this.#cache) return { ...this.#cache };
+		// Always re-read from disk — the cache is only a write buffer,
+		// never a read short-circuit. A separate process may have
+		// advanced the counter between our lock and our read.
 		try {
 			const text = await Bun.file(this.filePath).text();
 			const parsed = JSON.parse(text) as Partial<SequenceMap>;

--- a/packages/coding-agent/src/task-manager/statistics.ts
+++ b/packages/coding-agent/src/task-manager/statistics.ts
@@ -1,0 +1,70 @@
+/**
+ * Statistics — aggregate counts for the Task Manager overview.
+ *
+ * Pure functions over the task/milestone/document arrays.
+ */
+
+import type { Milestone, Task } from "./types";
+
+export interface TaskStatistics {
+	total: number;
+	byStatus: Record<string, number>;
+	byPriority: Record<string, number>;
+	byAssignee: Record<string, number>;
+	blocked: Task[];
+	drafts: number;
+	archived: number;
+	milestoneProgress: Array<{
+		milestone: Milestone;
+		total: number;
+		done: number;
+		percentage: number;
+	}>;
+}
+
+export function computeStatistics(tasks: Task[], milestones: Milestone[]): TaskStatistics {
+	const byStatus: Record<string, number> = {};
+	const byPriority: Record<string, number> = {};
+	const byAssignee: Record<string, number> = {};
+	let drafts = 0;
+	let archived = 0;
+	const blocked: Task[] = [];
+
+	for (const task of tasks) {
+		if (task.archived) {
+			archived++;
+			continue;
+		}
+		if (task.draft) drafts++;
+
+		byStatus[task.status] = (byStatus[task.status] ?? 0) + 1;
+		if (task.priority) byPriority[task.priority] = (byPriority[task.priority] ?? 0) + 1;
+		if (task.assignee) byAssignee[task.assignee] = (byAssignee[task.assignee] ?? 0) + 1;
+		if (task.status === "blocked") blocked.push(task);
+	}
+
+	const milestoneProgress = milestones
+		.map(milestone => {
+			const milestoneTasks = tasks.filter(t => t.milestone === milestone.id && !t.archived);
+			const done = milestoneTasks.filter(t => t.status === "done").length;
+			const total = milestoneTasks.length;
+			return {
+				milestone,
+				total,
+				done,
+				percentage: total === 0 ? 0 : Math.round((done / total) * 100),
+			};
+		})
+		.filter(m => m.total > 0);
+
+	return {
+		total: tasks.filter(t => !t.archived).length,
+		byStatus,
+		byPriority,
+		byAssignee,
+		blocked,
+		drafts,
+		archived,
+		milestoneProgress,
+	};
+}

--- a/packages/coding-agent/src/task-manager/task-loader.ts
+++ b/packages/coding-agent/src/task-manager/task-loader.ts
@@ -1,0 +1,79 @@
+/**
+ * Task loader — loads tasks from local branches and remote branches.
+ *
+ * Uses GitOperations for `git branch`, `git show`. Builds a unified index
+ * that resolves conflicts between branches (local takes priority).
+ */
+
+import type { Core } from "./core";
+import type { GitOperations } from "./git-ops";
+import type { Task } from "./types";
+
+export interface BranchTaskEntry {
+	task: Task;
+	branch: string;
+	isLocal: boolean;
+}
+
+export class TaskLoader {
+	#core: Core;
+	#git: GitOperations;
+
+	constructor(core: Core) {
+		this.#core = core;
+		this.#git = core.git;
+	}
+
+	async loadLocalBranchTasks(_branch?: string): Promise<Task[]> {
+		await this.#core.ensureConfigLoaded();
+		const ids = await this.#core.fs.listEntityFiles("tasks");
+		const tasks: Task[] = [];
+		for (const id of ids) {
+			try {
+				tasks.push(await this.#core.loadTask(id));
+			} catch {
+				// Skip files that fail to parse
+			}
+		}
+		return tasks;
+	}
+
+	async loadRemoteTasks(): Promise<BranchTaskEntry[]> {
+		if (!this.#git.enabled) return [];
+		const branches = await this.#git.listBranches();
+		const current = await this.#git.currentBranch();
+		const entries: BranchTaskEntry[] = [];
+
+		for (const branch of branches) {
+			if (branch === current) continue;
+			const config = await this.#core.config;
+			const tasksDir = config.directories.tasks;
+			const result = await this.#git.showFile(branch, tasksDir);
+			if (!result) continue;
+
+			// The git show output for a directory won't work; we need individual files.
+			// ponytail: listing remote branch files requires git ls-tree, but for Phase 1
+			// we only load local tasks — remote loading is a Phase 2 enhancement.
+		}
+
+		return entries;
+	}
+
+	async buildRemoteTaskIndex(): Promise<Map<string, BranchTaskEntry[]>> {
+		const index = new Map<string, BranchTaskEntry[]>();
+		const remote = await this.loadRemoteTasks();
+		for (const entry of remote) {
+			const existing = index.get(entry.task.id) ?? [];
+			existing.push(entry);
+			index.set(entry.task.id, existing);
+		}
+		return index;
+	}
+
+	resolveTaskConflict(entries: BranchTaskEntry[]): BranchTaskEntry {
+		// Local branches take priority over remote; newest updatedAt wins within a tier.
+		const local = entries.filter(e => e.isLocal);
+		const pool = local.length > 0 ? local : entries;
+		return pool.reduce((best, cur) => (cur.task.updatedAt > best.task.updatedAt ? cur : best));
+	}
+}

--- a/packages/coding-agent/src/task-manager/task-mgr-consumers.ts
+++ b/packages/coding-agent/src/task-manager/task-mgr-consumers.ts
@@ -13,7 +13,7 @@ import type { Settings } from "../config/settings";
 import acGenerationPrompt from "../prompts/task-ac-generation.md" with { type: "text" };
 import overviewPrompt from "../prompts/task-overview.md" with { type: "text" };
 import type { Core } from "./core";
-import { computeStatistics } from "./statistics";
+import { computeStatistics, type TaskStatistics } from "./statistics";
 
 /** Resolve the taskMgr model, falling back to default. */
 function resolveTaskMgrModel(registry: ModelRegistry, settings: Settings): Model<Api> | undefined {
@@ -140,7 +140,7 @@ export async function generateAcceptanceCriteria(
 }
 
 /** Text fallback for overview when no model is available. */
-function formatOverviewText(core: Core, stats: ReturnType<typeof computeStatistics>): string {
+function formatOverviewText(core: Core, stats: TaskStatistics): string {
 	const lines: string[] = [];
 	lines.push(`Project: ${core.config.projectName}`);
 	lines.push(`Total tasks: ${stats.total} (${stats.drafts} drafts, ${stats.archived} archived)`);

--- a/packages/coding-agent/src/task-manager/task-mgr-consumers.ts
+++ b/packages/coding-agent/src/task-manager/task-mgr-consumers.ts
@@ -1,0 +1,167 @@
+/**
+ * Task Manager LLM consumers — `overview` and `create --ai`.
+ *
+ * Both use the `taskMgr` model role, falling back to `default` when unset.
+ * The LLM call uses `completeSimple` from `@oh-my-pi/pi-ai`.
+ */
+
+import { type Api, completeSimple, type Model } from "@oh-my-pi/pi-ai";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { ModelRegistry } from "../config/model-registry";
+import { resolveModelRoleValue } from "../config/model-resolver";
+import type { Settings } from "../config/settings";
+import acGenerationPrompt from "../prompts/task-ac-generation.md" with { type: "text" };
+import overviewPrompt from "../prompts/task-overview.md" with { type: "text" };
+import type { Core } from "./core";
+import { computeStatistics } from "./statistics";
+
+/** Resolve the taskMgr model, falling back to default. */
+function resolveTaskMgrModel(registry: ModelRegistry, settings: Settings): Model<Api> | undefined {
+	const available = registry.getAvailable();
+	if (available.length === 0) return undefined;
+
+	const roleValue = settings.getModelRole("taskMgr") ?? settings.getModelRole("default");
+	const resolved = resolveModelRoleValue(roleValue, available, { settings });
+	return resolved.model ?? available[0];
+}
+
+/** Extract plain text from an AssistantMessage content array. */
+function extractText(content: { type: string; text?: string }[]): string {
+	return content
+		.filter(block => block.type === "text")
+		.map(block => block.text ?? "")
+		.join("");
+}
+
+/** Generate a natural-language project overview via the taskMgr model. */
+export async function generateOverview(core: Core, registry: ModelRegistry, settings: Settings): Promise<string> {
+	await core.ensureConfigLoaded();
+	const tasks = await core.listTasks();
+	const milestones = await core.listMilestones();
+	const stats = computeStatistics(tasks, milestones);
+
+	const model = resolveTaskMgrModel(registry, settings);
+	if (!model) {
+		return formatOverviewText(core, stats);
+	}
+
+	const userMessage = JSON.stringify(
+		{
+			projectName: core.config.projectName,
+			totalTasks: stats.total,
+			drafts: stats.drafts,
+			archived: stats.archived,
+			byStatus: stats.byStatus,
+			blocked: stats.blocked.map(t => ({ id: t.id, title: t.title })),
+			milestoneProgress: stats.milestoneProgress.map(m => ({
+				name: m.milestone.name,
+				done: m.done,
+				total: m.total,
+				percentage: m.percentage,
+			})),
+		},
+		null,
+		2,
+	);
+
+	try {
+		const response = await completeSimple(
+			model,
+			{
+				systemPrompt: [overviewPrompt],
+				messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
+			},
+			{
+				apiKey: registry.resolver(model),
+				maxTokens: 1024,
+				disableReasoning: true,
+			},
+		);
+
+		if (response.stopReason === "error") {
+			logger.warn("task-manager: overview LLM error", { errorMessage: response.errorMessage });
+			return formatOverviewText(core, stats);
+		}
+
+		const text = extractText(response.content);
+		return text || formatOverviewText(core, stats);
+	} catch (err) {
+		logger.warn("task-manager: overview failed, using text fallback", { error: String(err) });
+		return formatOverviewText(core, stats);
+	}
+}
+
+/** Generate acceptance criteria and plan via the taskMgr model (--ai flag). */
+export async function generateAcceptanceCriteria(
+	_core: Core,
+	registry: ModelRegistry,
+	settings: Settings,
+	title: string,
+	description: string,
+): Promise<{ acceptanceCriteria: string[]; taskPlan: string } | null> {
+	const model = resolveTaskMgrModel(registry, settings);
+	if (!model) return null;
+
+	const userMessage = `Title: ${title}\nDescription: ${description}\n\nGenerate acceptance criteria (one per line) and an implementation plan.`;
+
+	try {
+		const response = await completeSimple(
+			model,
+			{
+				systemPrompt: [acGenerationPrompt],
+				messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
+			},
+			{
+				apiKey: registry.resolver(model),
+				maxTokens: 1024,
+				disableReasoning: true,
+			},
+		);
+
+		if (response.stopReason === "error") return null;
+
+		const content = extractText(response.content);
+		if (!content) return null;
+		const acMatch = content.match(/^(.*?)(?:##\s*Plan|$)/s);
+		const planMatch = content.match(/##\s*Plan\s*\n([\s\S]*?)$/);
+
+		const acceptanceCriteria = (acMatch?.[1] ?? "")
+			.split("\n")
+			.map(line => line.replace(/^\s*-\s*/, "").trim())
+			.filter(Boolean);
+
+		const taskPlan = planMatch?.[1]?.trim() ?? "";
+
+		return { acceptanceCriteria, taskPlan };
+	} catch (err) {
+		logger.warn("task-manager: --ai generation failed", { error: String(err) });
+		return null;
+	}
+}
+
+/** Text fallback for overview when no model is available. */
+function formatOverviewText(core: Core, stats: ReturnType<typeof computeStatistics>): string {
+	const lines: string[] = [];
+	lines.push(`Project: ${core.config.projectName}`);
+	lines.push(`Total tasks: ${stats.total} (${stats.drafts} drafts, ${stats.archived} archived)`);
+	lines.push("");
+	lines.push("By status:");
+	for (const [status, count] of Object.entries(stats.byStatus)) {
+		lines.push(`  ${status}: ${count}`);
+	}
+	if (stats.blocked.length > 0) {
+		lines.push("");
+		lines.push("Blocked tasks:");
+		for (const task of stats.blocked) {
+			lines.push(`  ${task.id}: ${task.title}`);
+		}
+	}
+	if (stats.milestoneProgress.length > 0) {
+		lines.push("");
+		lines.push("Milestone progress:");
+		for (const m of stats.milestoneProgress) {
+			lines.push(`  ${m.milestone.name}: ${m.done}/${m.total} done (${m.percentage}%)`);
+		}
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/task-manager/types.ts
+++ b/packages/coding-agent/src/task-manager/types.ts
@@ -1,0 +1,191 @@
+/**
+ * Task Manager type definitions.
+ *
+ * Markdown-native task entity model: tasks, decisions, documents, milestones.
+ * All entities serialize to frontmatter + markdown body on disk.
+ */
+
+// ─── Entities ──────────────────────────────────────────────────────────────
+
+export type EntityType = "task" | "decision" | "document" | "milestone";
+
+export type TaskStatus = string;
+
+export interface AcceptanceCriterion {
+	text: string;
+	checked: boolean;
+}
+
+export interface TaskComment {
+	id: string;
+	author: string;
+	text: string;
+	createdDate: string;
+}
+
+export interface DefinitionOfDoneItem {
+	text: string;
+	checked: boolean;
+}
+
+export interface Task {
+	id: string;
+	title: string;
+	description: string;
+	status: TaskStatus;
+	assignee: string | null;
+	labels: string[];
+	priority: string | null;
+	parentTaskId: string | null;
+	dependencies: string[];
+	createdAt: string;
+	updatedAt: string;
+	milestone: string | null;
+	taskPlan: string | null;
+	acceptanceCriteria: AcceptanceCriterion[];
+	definitionOfDone: DefinitionOfDoneItem[];
+	comments: TaskComment[];
+	notes: string | null;
+	finalSummary: string | null;
+	draft: boolean;
+	archived: boolean;
+	archivedAt: string | null;
+	milestoneOrder: number | null;
+	readonly rawContent?: string;
+	readonly rawFrontmatter?: Record<string, unknown>;
+}
+
+export interface Decision {
+	id: string;
+	title: string;
+	status: string;
+	context: string;
+	decision: string;
+	consequences: string | null;
+	createdAt: string;
+	updatedAt: string;
+	tags: string[];
+	readonly rawContent?: string;
+	readonly rawFrontmatter?: Record<string, unknown>;
+}
+
+export interface Document {
+	id: string;
+	title: string;
+	type: string;
+	tags: string[];
+	path: string | null;
+	content: string;
+	createdAt: string;
+	updatedAt: string;
+	readonly rawContent?: string;
+	readonly rawFrontmatter?: Record<string, unknown>;
+}
+
+export interface Milestone {
+	id: string;
+	name: string;
+	description: string;
+	status: string;
+	createdAt: string;
+	updatedAt: string;
+	archived: boolean;
+	archivedAt: string | null;
+	readonly rawContent?: string;
+	readonly rawFrontmatter?: Record<string, unknown>;
+}
+
+// ─── Config ───────────────────────────────────────────────────────────────
+
+export interface PrefixConfig {
+	task: string;
+	decision: string;
+	document: string;
+	milestone: string;
+}
+
+export interface TaskConfig {
+	projectName: string;
+	directories: {
+		tasks: string;
+		decisions: string;
+		documents: string;
+		milestones: string;
+		archive: string;
+	};
+	files: {
+		config: string;
+		sequences: string;
+	};
+	statuses: string[];
+	defaultStatus: string;
+	prefixes: PrefixConfig;
+	git: {
+		enabled: boolean;
+		autoCommit: boolean;
+		commitPrefix: string;
+	};
+	taskTemplate: string | null;
+}
+
+// ─── Inputs ───────────────────────────────────────────────────────────────
+
+export interface TaskCreateInput {
+	title: string;
+	description?: string;
+	status?: string;
+	assignee?: string | null;
+	labels?: string[];
+	priority?: string | null;
+	parentTaskId?: string | null;
+	dependencies?: string[];
+	milestone?: string | null;
+	taskPlan?: string | null;
+	acceptanceCriteria?: string[];
+	definitionOfDone?: string[];
+	draft?: boolean;
+}
+
+export interface TaskUpdateInput {
+	title?: string;
+	description?: string;
+	status?: string;
+	assignee?: string | null;
+	labels?: string[];
+	priority?: string | null;
+	parentTaskId?: string | null;
+	dependencies?: string[];
+	milestone?: string | null;
+	taskPlan?: string | null;
+	notes?: string | null;
+	finalSummary?: string | null;
+}
+
+export interface TaskListFilter {
+	status?: string | null;
+	assignee?: string | null;
+	parentTaskId?: string | null;
+	labels?: string[];
+	search?: string | null;
+	limit?: number | null;
+}
+
+// ─── Search ───────────────────────────────────────────────────────────────
+
+export interface SearchFilters {
+	status?: string | null;
+	priority?: string | null;
+}
+
+export interface SearchOptions {
+	filters?: SearchFilters;
+	limit?: number | null;
+}
+
+export interface SearchResult {
+	id: string;
+	type: EntityType;
+	title: string;
+	status: string;
+	score: number;
+}

--- a/packages/coding-agent/src/task-manager/web-server.ts
+++ b/packages/coding-agent/src/task-manager/web-server.ts
@@ -1,0 +1,196 @@
+/**
+ * Task Manager web UI — server-side rendered HTML + vanilla JS.
+ *
+ * Follows the omp stats pattern: `Bun.serve` with embedded HTML. No build
+ * step, no React, no Tailwind — just server-rendered HTML with fetch-based
+ * updates. All text says "Task Manager".
+ */
+
+import { openPath } from "../utils/open";
+import type { Core } from "./core";
+
+export interface WebServerOptions {
+	port: number;
+	open?: boolean;
+}
+
+export async function startTaskManagerWebServer(core: Core, options: WebServerOptions): Promise<void> {
+	const server = Bun.serve({
+		port: options.port,
+		hostname: "127.0.0.1",
+		async fetch(req) {
+			const url = new URL(req.url);
+			const path = url.pathname;
+
+			// API routes
+			if (path.startsWith("/api/")) {
+				return handleApiRoute(core, path, req);
+			}
+
+			// Main page
+			if (path === "/" || path === "/index.html") {
+				return new Response(renderPage(), {
+					headers: { "content-type": "text/html; charset=utf-8" },
+				});
+			}
+
+			return new Response("Not found", { status: 404 });
+		},
+	});
+
+	process.stdout.write(`Task Manager web UI running at http://${server.hostname}:${server.port}\n`);
+
+	if (options.open) {
+		openPath(`http://${server.hostname}:${server.port}`);
+	}
+}
+
+async function handleApiRoute(core: Core, path: string, req: Request): Promise<Response> {
+	await core.ensureConfigLoaded();
+
+	if (path === "/api/tasks") {
+		const tasks = await core.listTasks();
+		return jsonResponse(tasks);
+	}
+
+	if (path.startsWith("/api/tasks/")) {
+		const id = path.split("/")[3];
+		try {
+			const task = await core.loadTask(id);
+			return jsonResponse(task);
+		} catch {
+			return new Response("Task not found", { status: 404 });
+		}
+	}
+
+	if (path === "/api/milestones") {
+		const milestones = await core.listMilestones();
+		return jsonResponse(milestones);
+	}
+
+	if (path === "/api/documents") {
+		const docs = await core.listDocuments();
+		return jsonResponse(docs);
+	}
+
+	if (path === "/api/board") {
+		const tasks = await core.listTasks();
+		const { generateKanbanBoardWithMetadata } = await import("./board");
+		const board = generateKanbanBoardWithMetadata(tasks, core.config.statuses);
+		return jsonResponse(board);
+	}
+
+	if (path === "/api/create-task" && req.method === "POST") {
+		try {
+			const body = (await req.json()) as { title: string; description?: string; status?: string };
+			const task = await core.createTask({
+				title: body.title,
+				description: body.description,
+				status: body.status,
+			});
+			return jsonResponse(task, 201);
+		} catch (err) {
+			return new Response(`Error: ${err instanceof Error ? err.message : String(err)}`, { status: 400 });
+		}
+	}
+
+	return new Response("Not found", { status: 404 });
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: {
+			"content-type": "application/json; charset=utf-8",
+			"access-control-allow-origin": "*",
+		},
+	});
+}
+
+function renderPage(): string {
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Task Manager</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #1a1a2e; color: #e0e0e0; }
+header { background: #16213e; padding: 1rem 2rem; border-bottom: 1px solid #0f3460; }
+header h1 { font-size: 1.5rem; color: #e94560; }
+.container { display: flex; gap: 1rem; padding: 1rem; overflow-x: auto; }
+.column { min-width: 250px; background: #16213e; border-radius: 8px; padding: 0.5rem; }
+.column h2 { font-size: 0.9rem; text-transform: uppercase; color: #8a8a9a; margin-bottom: 0.5rem; padding: 0.5rem; }
+.task-card { background: #1a1a2e; border: 1px solid #0f3460; border-radius: 6px; padding: 0.75rem; margin-bottom: 0.5rem; cursor: pointer; }
+.task-card:hover { border-color: #e94560; }
+.task-card .id { font-size: 0.75rem; color: #8a8a9a; }
+.task-card .title { font-size: 0.9rem; margin-top: 0.25rem; }
+.task-detail { position: fixed; right: 0; top: 0; height: 100vh; width: 400px; background: #16213e; padding: 2rem; overflow-y: auto; transform: translateX(100%); transition: transform 0.3s; }
+.task-detail.open { transform: translateX(0); }
+.task-detail h2 { color: #e94560; margin-bottom: 1rem; }
+.task-detail .field { margin-bottom: 0.75rem; }
+.task-detail .label { font-size: 0.75rem; color: #8a8a9a; text-transform: uppercase; }
+.task-detail .value { font-size: 0.9rem; }
+.create-form { margin: 1rem 2rem; }
+.create-form input, .create-form textarea { background: #16213e; border: 1px solid #0f3460; color: #e0e0e0; padding: 0.5rem; border-radius: 4px; width: 300px; }
+.create-form button { background: #e94560; color: white; border: none; padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; }
+</style>
+</head>
+<body>
+<header><h1>Task Manager — powered by Oh My Pi</h1></header>
+<div class="create-form">
+<input type="text" id="new-title" placeholder="Task title...">
+<button onclick="createTask()">Create Task</button>
+</div>
+<div class="container" id="board"></div>
+<div class="task-detail" id="detail">
+<span style="cursor:pointer" onclick="closeDetail()">&times; Close</span>
+<div id="detail-content"></div>
+</div>
+<script>
+function escapeHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+async function loadBoard() {
+const res = await fetch('/api/board');
+const board = await res.json();
+const el = document.getElementById('board');
+el.innerHTML = '';
+for (const col of board.columns) {
+const colEl = document.createElement('div');
+colEl.className = 'column';
+colEl.innerHTML = '<h2>' + col.status + ' (' + col.tasks.length + ')</h2>';
+for (const task of col.tasks) {
+const card = document.createElement('div');
+card.className = 'task-card';
+card.innerHTML = '<div class="id">' + escapeHtml(task.id) + '</div><div class="title">' + escapeHtml(task.title) + '</div>';
+card.onclick = () => showDetail(task.id);
+colEl.appendChild(card);
+}
+el.appendChild(colEl);
+}
+}
+async function showDetail(id) {
+const res = await fetch('/api/tasks/' + id);
+const task = await res.json();
+const el = document.getElementById('detail-content');
+el.innerHTML = '<h2>' + escapeHtml(task.title) + '</h2>' +
+'<div class="field"><div class="label">ID</div><div class="value">' + escapeHtml(task.id) + '</div></div>' +
+'<div class="field"><div class="label">Status</div><div class="value">' + escapeHtml(task.status) + '</div></div>' +
+'<div class="field"><div class="label">Description</div><div class="value">' + escapeHtml(task.description || '—') + '</div></div>' +
+'<div class="field"><div class="label">Assignee</div><div class="value">' + escapeHtml(task.assignee || '—') + '</div></div>' +
+'<div class="field"><div class="label">Created</div><div class="value">' + new Date(task.createdAt).toLocaleString() + '</div></div>';
+document.getElementById('detail').classList.add('open');
+}
+function closeDetail() { document.getElementById('detail').classList.remove('open'); }
+async function createTask() {
+const title = document.getElementById('new-title').value.trim();
+if (!title) return;
+await fetch('/api/create-task', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ title }) });
+document.getElementById('new-title').value = '';
+loadBoard();
+}
+loadBoard();
+</script>
+</body>
+</html>`;
+}

--- a/packages/coding-agent/src/task-manager/web-server.ts
+++ b/packages/coding-agent/src/task-manager/web-server.ts
@@ -7,6 +7,7 @@
  */
 
 import { openPath } from "../utils/open";
+import { generateKanbanBoardWithMetadata } from "./board";
 import type { Core } from "./core";
 
 export interface WebServerOptions {
@@ -75,7 +76,6 @@ async function handleApiRoute(core: Core, path: string, req: Request): Promise<R
 
 	if (path === "/api/board") {
 		const tasks = await core.listTasks();
-		const { generateKanbanBoardWithMetadata } = await import("./board");
 		const board = generateKanbanBoardWithMetadata(tasks, core.config.statuses);
 		return jsonResponse(board);
 	}
@@ -102,7 +102,6 @@ function jsonResponse(data: unknown, status = 200): Response {
 		status,
 		headers: {
 			"content-type": "application/json; charset=utf-8",
-			"access-control-allow-origin": "*",
 		},
 	});
 }
@@ -158,7 +157,7 @@ el.innerHTML = '';
 for (const col of board.columns) {
 const colEl = document.createElement('div');
 colEl.className = 'column';
-colEl.innerHTML = '<h2>' + col.status + ' (' + col.tasks.length + ')</h2>';
+colEl.innerHTML = '<h2>' + escapeHtml(col.status) + ' (' + col.tasks.length + ')</h2>';
 for (const task of col.tasks) {
 const card = document.createElement('div');
 card.className = 'task-card';


### PR DESCRIPTION
## Summary

Adds a built-in markdown-native task manager to omp with three commands: `omp task`, `omp board`, and `omp taskbrowser`. Gated behind the `tasks.taskManager` setting (disabled by default). Adds a `taskMgr` model role for AI-assisted features.

## What's included

### Phase 1 — core data model + CLI

- **Settings toggle**: `tasks.taskManager` (boolean, default `false`) + "Task Manager" group in the tasks tab
- **Model role**: `taskMgr` — appears in `/models` selector, falls back to default model when unset
- **Task CRUD**: create, load, update, list, archive, and **delete** (hard delete + `git rm` — the upstream source project lacked this)
- **Markdown parser/serializer**: uses omp's `parseFrontmatter` + `Bun.YAML.stringify` (round-trip verified)
- **File system**: uses omp's `withFileLock` from `config/file-lock.ts`
- **Git operations**: uses Bun's `$` shell, `git commit --only` to limit to task files
- **Fuzzy search**: uses omp's `fuzzyRank` from `@oh-my-pi/pi-tui`
- **16 subcommands**: `init`, `create`, `list`, `view`, `edit`, `archive`, `delete`, `search`, `draft`, `promote`, `demote`, `milestone`, `doc`, `decision`, `overview`, `cleanup`
- **Unconditional registration**: commands are always registered in `cli-commands.ts` to prevent the argv-leak regression (#1496/#2935); execution is gated inside `run()`
- **Project dir consistency**: all commands use `getProjectDir()` (not `process.cwd()`) so task stores are project-local

### Phase 2 — board + web UI + AI consumers

- **`omp board`**: renders a kanban table to stdout; `omp board export` writes to file with `--force` overwrite protection and "Task Manager — powered by Oh My Pi" header
- **`omp taskbrowser`**: server-side rendered HTML + vanilla JS via `Bun.serve` (same-origin, no wildcard CORS), with `escapeHtml` sanitization on all user-controlled values including status headers
- **`omp task overview`**: LLM-assisted project summary using the `taskMgr` model role (falls back to text summary when no model available)
- **`omp task create --ai`**: auto-generates acceptance criteria + implementation plan via the `taskMgr` model
- **Static prompt files** at `prompts/task-overview.md` and `prompts/task-ac-generation.md`
- **Statistics, milestones, docs, decisions** support

### `omp task init` flags

- `--defaults`: non-interactive init
- `--no-git`: disables git integration (sets `git.enabled: false`, `autoCommit: false`)

## Dependency-stack replacement

No new dependencies added to `package.json`. All third-party deps from the source replaced:

| Source dep | omp replacement |
|---|---|
| `gray-matter` | `parseFrontmatter` from `@oh-my-pi/pi-utils` |
| `fuse.js` | `fuzzyRank` from `@oh-my-pi/pi-tui` |
| `proper-lockfile` | `withFileLock` from `config/file-lock.ts` |
| `commander` | `Command`/`Flags`/`Args` from `@oh-my-pi/pi-utils/cli` |
| `@clack/prompts` | `node:readline/promises` |
| React + Tailwind | SSR HTML + vanilla JS (no build step) |

## On-disk layout

```
.omp/tasks/
├── config.yml          # project-local task config
├── sequences.json      # ID counters (re-read from disk under lock)
├── tasks/              # task-1.md, task-2.md, ...
├── decisions/          # decision-1.md, ...
├── documents/          # doc-1.md, ...
├── milestones/         # milestone-1.md, ...
└── archive/            # archived entities
```

## Verification

- `bun check` passes (all packages type-check + lint)
- E2e tested: init → create → list → view → search → edit (comment) → delete → empty dir
- Edit without `--labels` preserves existing fields (undefined values stripped in `updateTask`)
- `draft [title]` creates a new draft task (not `updateTask` on non-existent ID)
- Board export honors `--force` (refuses overwrite without it)
- `--no-git` flag disables git in config
- Board view + export with rebranded header
- Taskbrowser web UI + API returns task data (same-origin, no CORS)
- Disabled setting prints enable hint and exits 1

## Review fixes (commit d0908bcb)

Addressed all blocking and should-fix findings from @roboomp and @chatgpt-codex-connector:

**Blocking:**
- Use `getProjectDir()` instead of `process.cwd()` in all three commands — prevents per-subdirectory task stores
- Strip `undefined` values in `Core.updateTask` — partial edits no longer clobber existing fields (labels, etc.)
- `draft [title]` now creates a draft task via `createTask({ draft: true })` instead of calling `updateTask` on a non-existent ID
- `board export` honors `--force` flag — refuses overwrite without it
- Removed wildcard CORS from taskbrowser API (same-origin, not needed)
- Escape `col.status` in board header `innerHTML` (XSS prevention)
- Git ops: remove `.nothrow()` swallow, check `exitCode`, throw on non-zero; use `git commit --only` to limit to task files
- Sequences: re-read from disk while holding lock (prevent stale cache in long-running processes)

**Should-fix conventions:**
- `--ac` splits on comma (matches help text contract)
- Replace inline `import()` with top-level import in web-server
- Replace `ReturnType<>` with `TaskStatistics` type
- Replace `new Promise` with `Promise.withResolvers()`
- Honor `--no-git` flag during init (disable `git.enabled`/`autoCommit`)