### PR TITLE
fix(advisor): degrade thinking rendering on provider refusals

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `advisor.includeThinking` setting (default `true`) to control whether the primary agent's thinking blocks are rendered in the transcript delta shipped to the advisor. Turn off if the advisor model's provider refuses requests that echo reasoning content (e.g. Anthropic's `reasoning_extraction` classifier). ([#4210](https://github.com/can1357/oh-my-pi/issues/4210))
+
+### Fixed
+
+- Fixed the advisor blind-retrying provider refusals (e.g. Anthropic Fable's `reasoning_extraction` classifier) with the identical rendered batch. After the first refusal-shaped failure the runtime now latches `_thinking:_` rendering off for the rest of the session, re-primes the advisor transcript without thinking, and surfaces an info notice so the user can flip `advisor.includeThinking: false` to skip them from the start. ([#4210](https://github.com/can1357/oh-my-pi/issues/4210))
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1368,6 +1368,188 @@ describe("advisor", () => {
 			expect(promptInputs[1]).toContain("new-conversation");
 			expect(promptInputs[1]).not.toContain("old-conversation");
 		});
+
+		it("on refusal, latches thinking off and re-renders without _thinking:_ instead of blind-retrying", async () => {
+			// Anthropic's Fable 5 `reasoning_extraction` classifier returns HTTP 200 +
+			// stop_reason:"refusal", which pi-ai flattens into `Refusal (<category>):
+			// ...`. The runtime historically re-sent the identical rendered batch on
+			// the same model — the docs' "usually earns another refusal" case,
+			// guaranteed during a strict-classifier window. It now strips thinking
+			// once and latches off for the rest of the session.
+			const promptInputs: string[] = [];
+			const failures: unknown[] = [];
+			let strippedNotices = 0;
+			const shouldRefuse = true;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					if (shouldRefuse && input.includes("_thinking:_")) {
+						throw new Error(
+							"Refusal (reasoning_extraction): This request was blocked as it seems to violate Anthropic's Terms of Service.",
+						);
+					}
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const thinkingContent = "Considering the edge case for empty input first.";
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "review this", timestamp: 1 } as AgentMessage,
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: thinkingContent },
+						{ type: "text", text: "Response body." },
+					],
+					timestamp: 2,
+				} as unknown as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyFailure: error => failures.push(error),
+				notifyThinkingStripped: () => {
+					strippedNotices++;
+				},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			// One refusal, then a stripped re-render — bounded even without turning
+			// off shouldRefuse, because the stripped batch no longer carries thinking.
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(2);
+			expect(promptInputs[0]).toContain("_thinking:_");
+			expect(promptInputs[0]).toContain(thinkingContent);
+			expect(promptInputs[1]).not.toContain("_thinking:_");
+			expect(promptInputs[1]).not.toContain(thinkingContent);
+			// Body of the assistant turn is still delivered.
+			expect(promptInputs[1]).toContain("Response body.");
+			expect(strippedNotices).toBe(1);
+			// The single stripped success cleared the backlog; no watchdog notice fired.
+			expect(failures).toHaveLength(0);
+			expect(runtime.backlog).toBe(0);
+
+			// A subsequent turn with new thinking still ships stripped (latched).
+			messages.push({
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "Latched off means this never leaks." },
+					{ type: "text", text: "Second reply." },
+				],
+				timestamp: 3,
+			} as unknown as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(3);
+			expect(promptInputs[2]).not.toContain("_thinking:_");
+			expect(promptInputs[2]).not.toContain("Latched off means this never leaks.");
+			expect(promptInputs[2]).toContain("Second reply.");
+			expect(strippedNotices).toBe(1); // fired exactly once, not per turn
+		});
+
+		it("respects an explicit includeThinking:false at construction time", async () => {
+			// The `advisor.includeThinking` escape hatch: user opts out proactively,
+			// so no thinking ever renders and no auto-degrade path runs.
+			const promptInputs: string[] = [];
+			let strippedNotices = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const thinkingContent = "Never rendered when opt-out is on.";
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "hi", timestamp: 1 } as AgentMessage,
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: thinkingContent },
+						{ type: "text", text: "visible." },
+					],
+					timestamp: 2,
+				} as unknown as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyThinkingStripped: () => {
+					strippedNotices++;
+				},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0, false);
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(1);
+			expect(promptInputs[0]).not.toContain("_thinking:_");
+			expect(promptInputs[0]).not.toContain(thinkingContent);
+			expect(promptInputs[0]).toContain("visible.");
+			expect(strippedNotices).toBe(0);
+		});
+
+		it("falls through to the watchdog if refusals keep coming after the strip", async () => {
+			// If the classifier keeps refusing even without thinking blocks, the
+			// degrade path fires once and the second refusal falls through to the
+			// normal consecutive-failure counter — no infinite auto-recovery loop.
+			const promptInputs: string[] = [];
+			const failures: unknown[] = [];
+			let strippedNotices = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					throw new Error("Refusal (reasoning_extraction): still refusing.");
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "review this", timestamp: 1 } as AgentMessage,
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "reasoning here" },
+						{ type: "text", text: "Body." },
+					],
+					timestamp: 2,
+				} as unknown as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyFailure: error => failures.push(error),
+				notifyThinkingStripped: () => {
+					strippedNotices++;
+				},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			// 1 with thinking → refusal → strip → 3 without → watchdog fires.
+			expect(strippedNotices).toBe(1);
+			expect(promptInputs).toHaveLength(4);
+			expect(promptInputs[0]).toContain("_thinking:_");
+			for (const p of promptInputs.slice(1)) {
+				expect(p).not.toContain("_thinking:_");
+			}
+			expect(failures).toHaveLength(1);
+			expect(runtime.backlog).toBe(0);
+		});
 	});
 
 	describe("advisor default tools", () => {

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1454,6 +1454,63 @@ describe("advisor", () => {
 			expect(strippedNotices).toBe(1); // fired exactly once, not per turn
 		});
 
+		it("counts turns queued during a refusal before requeueing the stripped re-prime", async () => {
+			const promptInputs: string[] = [];
+			const { promise: firstPromptStarted, resolve: startFirstPrompt } = Promise.withResolvers<void>();
+			const { promise: firstPrompt, reject: rejectFirstPrompt } = Promise.withResolvers<void>();
+			let promptCalls = 0;
+			const agent: AdvisorAgent = {
+				prompt: input => {
+					promptInputs.push(input);
+					promptCalls++;
+					if (promptCalls === 1) {
+						startFirstPrompt();
+						return firstPrompt;
+					}
+					return Promise.resolve();
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "first turn", timestamp: 1 } as AgentMessage,
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "thinking that triggers refusal" },
+						{ type: "text", text: "first reply" },
+					],
+					timestamp: 2,
+				} as unknown as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await firstPromptStarted;
+			expect(runtime.backlog).toBe(1);
+
+			messages.push({ role: "user", content: "second queued turn", timestamp: 3 } as AgentMessage);
+			runtime.onTurnEnd(messages);
+			expect(runtime.backlog).toBe(2);
+
+			rejectFirstPrompt(new Error("Refusal (reasoning_extraction): refused while backlog queued."));
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(promptInputs).toHaveLength(2);
+			expect(promptInputs[0]).toContain("_thinking:_");
+			expect(promptInputs[1]).not.toContain("_thinking:_");
+			expect(promptInputs[1]).toContain("first turn");
+			expect(promptInputs[1]).toContain("second queued turn");
+			expect(runtime.backlog).toBe(0);
+		});
+
 		it("respects an explicit includeThinking:false at construction time", async () => {
 			// The `advisor.includeThinking` escape hatch: user opts out proactively,
 			// so no thinking ever renders and no auto-degrade path runs.

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1511,6 +1511,106 @@ describe("advisor", () => {
 			expect(runtime.backlog).toBe(0);
 		});
 
+		it("degrades on category-less `Refusal: <explanation>` and bare `Refusal` shapes", async () => {
+			// pi-ai's Anthropic branch drops the parenthesized category when
+			// `stop_details.category` is null, producing `Refusal: <explanation>`; a
+			// missing explanation collapses to bare `Refusal`. Both must trip the
+			// strip-and-reprime recovery just like the category-tagged form.
+			for (const shape of ["Refusal: policy violation.", "Refusal"]) {
+				const promptInputs: string[] = [];
+				let strippedNotices = 0;
+				const agent: AdvisorAgent = {
+					prompt: async input => {
+						promptInputs.push(input);
+						if (input.includes("_thinking:_")) throw new Error(shape);
+					},
+					abort: () => {},
+					reset: () => {},
+					state: { messages: [] },
+				};
+				const messages: AgentMessage[] = [
+					{ role: "user", content: "review this", timestamp: 1 } as AgentMessage,
+					{
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: `thinking that triggers ${shape}` },
+							{ type: "text", text: "Response body." },
+						],
+						timestamp: 2,
+					} as unknown as AgentMessage,
+				];
+				const host: AdvisorRuntimeHost = {
+					snapshotMessages: () => messages,
+					enqueueAdvice: () => {},
+					notifyThinkingStripped: () => {
+						strippedNotices++;
+					},
+				};
+				const runtime = new AdvisorRuntime(agent, host, 0);
+
+				runtime.onTurnEnd(messages);
+				await Bun.sleep(0);
+				await Bun.sleep(0);
+				await Bun.sleep(0);
+
+				expect(promptInputs).toHaveLength(2);
+				expect(promptInputs[0]).toContain("_thinking:_");
+				expect(promptInputs[1]).not.toContain("_thinking:_");
+				expect(promptInputs[1]).toContain("Response body.");
+				expect(strippedNotices).toBe(1);
+				expect(runtime.backlog).toBe(0);
+			}
+		});
+
+		it("does not degrade on unrelated errors that merely contain the word `Refusal`", async () => {
+			// Guard against a broad `includes("Refusal")` predicate: an upstream
+			// stack trace or a tool error mentioning "refusal" must NOT hijack the
+			// degrade path — the runtime should still trip the normal watchdog.
+			const promptInputs: string[] = [];
+			let strippedNotices = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					throw new Error("HTTP 500: internal error while logging Refusal metadata");
+				},
+				abort: () => {},
+				reset: () => {},
+				state: { messages: [] },
+			};
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "review this", timestamp: 1 } as AgentMessage,
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "reasoning" },
+						{ type: "text", text: "Body." },
+					],
+					timestamp: 2,
+				} as unknown as AgentMessage,
+			];
+			const failures: unknown[] = [];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				notifyFailure: err => failures.push(err),
+				notifyThinkingStripped: () => {
+					strippedNotices++;
+				},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+			await Bun.sleep(0);
+
+			expect(strippedNotices).toBe(0);
+			expect(promptInputs).toHaveLength(3);
+			for (const p of promptInputs) expect(p).toContain("_thinking:_");
+			expect(failures).toHaveLength(1);
+		});
+
 		it("respects an explicit includeThinking:false at construction time", async () => {
 			// The `advisor.includeThinking` escape hatch: user opts out proactively,
 			// so no thinking ever renders and no auto-degrade path runs.

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -41,15 +41,16 @@ export interface AdvisorRuntimeHost {
 	 * the primary's next compaction triggers {@link AdvisorRuntime.reset}).
 	 */
 	maintainContext?(incomingTokens: number): Promise<boolean>;
-	/**
-	 * Called immediately before each `agent.prompt(batch)` cycle. Lets the host
-	 * clear per-update advisor state — currently the one-advise-per-update gate
-	 * in {@link AdvisorEmissionGuard}, which the host owns because it is the
-	 * one that routes `advise()` results back to the primary.
-	 */
 	beginAdvisorUpdate?(): void;
 	/** Surface a non-recovering advisor failure to the host UI without adding model-visible context. */
 	notifyFailure?(error: unknown): void;
+	/**
+	 * Fired once, the first time a provider refusal triggers the runtime to
+	 * latch thinking-block rendering off for the rest of the session. Hosts
+	 * surface a notice so the user understands the automatic degradation.
+	 * See {@link AdvisorRuntime} refusal handling in `#drain`.
+	 */
+	notifyThinkingStripped?(): void;
 }
 
 interface PendingDelta {
@@ -90,7 +91,20 @@ export class AdvisorRuntime {
 		private readonly agent: AdvisorAgent,
 		private readonly host: AdvisorRuntimeHost,
 		private readonly retryDelayMs = 1000,
-	) {}
+		includeThinking = true,
+	) {
+		this.#includeThinking = includeThinking;
+	}
+
+	/** Whether the advisor's rendered transcript deltas include assistant
+	 *  thinking blocks. Starts at the constructor-provided value (mirroring
+	 *  `advisor.includeThinking`) and latches off when a provider refusal
+	 *  triggers the auto-degrade path in {@link #drain}. */
+	#includeThinking: boolean;
+	/** Guards the refusal auto-degrade from firing more than once per runtime.
+	 *  A second refusal after strip already applied falls through to the normal
+	 *  failure counter instead of looping. */
+	#refusalStripApplied = false;
 
 	get backlog(): number {
 		return this.#backlog;
@@ -205,7 +219,7 @@ export class AdvisorRuntime {
 		const obfuscator = this.host.obfuscator;
 		const formattedDelta = obfuscator?.hasSecrets() ? obfuscateAdvisorDelta(obfuscator, delta) : delta;
 		const md = formatSessionHistoryMarkdown(formattedDelta, {
-			includeThinking: true,
+			includeThinking: this.#includeThinking,
 			includeToolIntent: true,
 			watchedRoles: true,
 			expandPrimaryContext: true,
@@ -351,6 +365,33 @@ export class AdvisorRuntime {
 					// requeuing it into the post-reset conversation.
 					if (this.#epoch !== epoch) continue;
 					this.#rollbackFailedTurn(messageSnapshot);
+					// Provider refusal (e.g. Anthropic Fable's `reasoning_extraction`
+					// classifier flagging thinking-block passthrough): retrying the
+					// identical rendered batch on the same model "usually earns another
+					// refusal" per Anthropic's refusals-and-fallback docs. Latch thinking
+					// off for the rest of the session, drop dedupe state so the re-primed
+					// transcript replays primary-context in full, and re-render the
+					// current transcript without thinking so the failed batch's coverage
+					// is restored on the next drain iteration.
+					if (isRefusalError(err) && this.#includeThinking && !this.#refusalStripApplied) {
+						this.#includeThinking = false;
+						this.#refusalStripApplied = true;
+						this.#resetAdvisorContext(false, false);
+						const restripped = this.#renderDelta(this.#latestMessages);
+						if (restripped) {
+							this.#pending.unshift({ text: restripped, turns: finalTurns });
+						} else {
+							this.#backlog = Math.max(0, this.#backlog - finalTurns);
+							this.#notifyWaiters();
+						}
+						try {
+							this.host.notifyThinkingStripped?.();
+						} catch (notifyErr) {
+							logger.warn("advisor notifyThinkingStripped failed", { err: String(notifyErr) });
+						}
+						logger.debug("advisor refusal: latching thinking off and re-priming", { err: String(err) });
+						continue;
+					}
 					logger.debug("advisor turn failed", { err: String(err) });
 					this.#consecutiveFailures++;
 					if (this.#consecutiveFailures >= 3) {
@@ -384,6 +425,21 @@ export class AdvisorRuntime {
 			this.#busy = false;
 		}
 	}
+}
+
+/**
+ * Match the stable prefix `pi-ai` emits for provider refusal `stop_reason`s
+ * (`Refusal`, optionally `Refusal (<category>)`), independent of whether the
+ * refusal reached the runtime as a rejection or via `state.error` re-thrown
+ * inside `#drain`. See `anthropic.ts` refusal branch: category-tagged messages
+ * take the form `Refusal (reasoning_extraction): ...`; missing-details
+ * fallbacks surface as `Refusal (no details provided)`. Kept as a text match
+ * because `Agent.state.error` collapses the structured `stopDetails` down to
+ * `errorMessage`; the prefix is the last stable signal we have.
+ */
+function isRefusalError(err: unknown): boolean {
+	const msg = err instanceof Error ? err.message : String(err);
+	return msg.startsWith("Refusal (") || msg === "Refusal";
 }
 
 type TextualContent = string | readonly (TextContent | ImageContent)[];

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -371,17 +371,20 @@ export class AdvisorRuntime {
 					// refusal" per Anthropic's refusals-and-fallback docs. Latch thinking
 					// off for the rest of the session, drop dedupe state so the re-primed
 					// transcript replays primary-context in full, and re-render the
-					// current transcript without thinking so the failed batch's coverage
-					// is restored on the next drain iteration.
+					// current transcript without thinking so the failed batch plus any
+					// turns queued while it was in flight are restored on the next drain
+					// iteration.
 					if (isRefusalError(err) && this.#includeThinking && !this.#refusalStripApplied) {
+						const queuedTurns = this.#pending.reduce((sum, b) => sum + b.turns, 0);
+						const restoredTurns = finalTurns + queuedTurns;
 						this.#includeThinking = false;
 						this.#refusalStripApplied = true;
 						this.#resetAdvisorContext(false, false);
 						const restripped = this.#renderDelta(this.#latestMessages);
 						if (restripped) {
-							this.#pending.unshift({ text: restripped, turns: finalTurns });
+							this.#pending.unshift({ text: restripped, turns: restoredTurns });
 						} else {
-							this.#backlog = Math.max(0, this.#backlog - finalTurns);
+							this.#backlog = Math.max(0, this.#backlog - restoredTurns);
 							this.#notifyWaiters();
 						}
 						try {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -431,18 +431,22 @@ export class AdvisorRuntime {
 }
 
 /**
- * Match the stable prefix `pi-ai` emits for provider refusal `stop_reason`s
- * (`Refusal`, optionally `Refusal (<category>)`), independent of whether the
- * refusal reached the runtime as a rejection or via `state.error` re-thrown
- * inside `#drain`. See `anthropic.ts` refusal branch: category-tagged messages
- * take the form `Refusal (reasoning_extraction): ...`; missing-details
- * fallbacks surface as `Refusal (no details provided)`. Kept as a text match
- * because `Agent.state.error` collapses the structured `stopDetails` down to
- * `errorMessage`; the prefix is the last stable signal we have.
+ * Match every shape `pi-ai` emits for provider refusal `stop_reason`s,
+ * independent of whether the refusal reached the runtime as a rejection or via
+ * `state.error` re-thrown inside `#drain`. See `anthropic.ts` refusal branch:
+ * category-tagged messages take the form `Refusal (reasoning_extraction): ...`,
+ * category-less refusals with an explanation collapse to `Refusal: ...`,
+ * missing-details fallbacks surface as `Refusal (no details provided)`, and
+ * bare `Refusal` is used when neither category nor explanation is populated.
+ * Kept as a text match because `Agent.state.error` collapses the structured
+ * `stopDetails` down to `errorMessage`; the prefix is the last stable signal
+ * we have.
  */
 function isRefusalError(err: unknown): boolean {
 	const msg = err instanceof Error ? err.message : String(err);
-	return msg.startsWith("Refusal (") || msg === "Refusal";
+	// Anchor to a boundary so unrelated `Refusal…` prose in an error text can't
+	// masquerade as an Anthropic refusal envelope.
+	return /^Refusal(?::| \(|$)/.test(msg);
 }
 
 type TextualContent = string | readonly (TextContent | ImageContent)[];

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -447,6 +447,18 @@ export const SETTINGS_SCHEMA = {
 			condition: "advisorEnabled",
 		},
 	},
+	"advisor.includeThinking": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Include Thinking in Advisor Transcript",
+			description:
+				"Render the primary agent's `_thinking:_` blocks in the incremental transcript delivered to the advisor. Turn off if the advisor model's provider refuses requests that echo reasoning content (Anthropic's `reasoning_extraction` classifier). The runtime also auto-latches this off for the rest of the session after the first refusal-shaped failure.",
+			condition: "advisorEnabled",
+		},
+	},
 	shellPath: { type: "string", default: undefined },
 	"git.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -141,6 +141,7 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	"advisor.subagents",
 	"advisor.syncBacklog",
 	"advisor.immuneTurns",
+	"advisor.includeThinking",
 	"tier.advisor",
 ];
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2408,21 +2408,34 @@ export class AgentSession {
 				// so two SessionManagers never hold the same file at once.
 				this.#advisorRecorderClosed,
 			);
-			const runtime = new AdvisorRuntime(advisorAgentFacade, {
-				snapshotMessages: () => this.agent.state.messages,
-				enqueueAdvice: (note, severity) => this.#routeAdvice(advisorRef, note, severity),
-				maintainContext: incomingTokens => this.#maintainAdvisorContext(advisorRef, incomingTokens),
-				obfuscator: this.#obfuscator,
-				beginAdvisorUpdate: () => advisorRef.emissionGuard.beginUpdate(),
-				notifyFailure: error => {
-					const message = error instanceof Error ? error.message : String(error);
-					this.emitNotice(
-						"warning",
-						`Advisor${slug ? ` "${advisorName}"` : ""} unavailable for ${formatModelString(advisorModel)}: ${message}`,
-						"advisor",
-					);
+			const includeThinking = this.settings.get("advisor.includeThinking") as boolean;
+			const runtime = new AdvisorRuntime(
+				advisorAgentFacade,
+				{
+					snapshotMessages: () => this.agent.state.messages,
+					enqueueAdvice: (note, severity) => this.#routeAdvice(advisorRef, note, severity),
+					maintainContext: incomingTokens => this.#maintainAdvisorContext(advisorRef, incomingTokens),
+					obfuscator: this.#obfuscator,
+					beginAdvisorUpdate: () => advisorRef.emissionGuard.beginUpdate(),
+					notifyFailure: error => {
+						const message = error instanceof Error ? error.message : String(error);
+						this.emitNotice(
+							"warning",
+							`Advisor${slug ? ` "${advisorName}"` : ""} unavailable for ${formatModelString(advisorModel)}: ${message}`,
+							"advisor",
+						);
+					},
+					notifyThinkingStripped: () => {
+						this.emitNotice(
+							"info",
+							`Advisor${slug ? ` "${advisorName}"` : ""} (${formatModelString(advisorModel)}) refused a delta carrying thinking blocks. Latching \`_thinking:_\` off for the rest of this session; set \`advisor.includeThinking: false\` to skip them from the start.`,
+							"advisor",
+						);
+					},
 				},
-			});
+				undefined,
+				includeThinking,
+			);
 
 			const advisorRef: ActiveAdvisor = {
 				name: advisorName,


### PR DESCRIPTION
## Repro

Enable the advisor with an Anthropic Fable-5 model (or any provider that runs a `reasoning_extraction`-shaped refusal classifier) while the classifier is in a strict phase, run turns where the primary emits `thinking` blocks. The advisor's rendered delta includes `_thinking:_ <text>` lines and the provider refuses with HTTP 200 + `stop_reason: "refusal"` (surfaced by pi-ai as `Refusal (reasoning_extraction): ...`). The runtime re-queued the identical batch on the same model at `packages/coding-agent/src/advisor/runtime.ts:373`, tripped the 3-strike watchdog after two more refusals, dropped the backlog, and repeated the cycle on the next turn — 1,164 refusals in ~4 hours in the reporter's window, zero successful advisor turns.

```
{"level":"debug","message":"advisor turn failed","err":"Error: Refusal (reasoning_extraction): This request was blocked ..."}
{"level":"warn","message":"advisor failed consecutively 3 times; dropping backlog to prevent stall"}
```

## Cause

Two coupled defects in the advisor path:

- `AdvisorRuntime.#renderDelta` (`packages/coding-agent/src/advisor/runtime.ts:207-215`) hardcoded `includeThinking: true` and there was no `advisor.*` setting to override it.
- The retry branch (`runtime.ts:373`) replayed the identical rendered `batch` string on the same model. Per Anthropic's refusals-and-fallback semantics a refused request "usually earns another refusal" when re-sent unchanged, so the watchdog always drained through the 3-strike drop path and the next turn regenerated the same payload shape.

## Fix

- Add `advisor.includeThinking` boolean setting (default `true`) with condition `advisorEnabled`, in the "Advisor" section of the Model tab. Register it in `HOST_DEFAULTED_SETTING_PATHS` so protocol hosts inherit OMP's default.
- Thread a `includeThinking` constructor arg into `AdvisorRuntime`; store it on the internal `#includeThinking` field that `#renderDelta` reads instead of the hardcoded literal.
- On a refusal-shaped error (`isRefusalError`: matches the stable `Refusal` / `Refusal (…)` prefix pi-ai emits from `stop_details.type === "refusal"` in `packages/ai/src/providers/anthropic.ts`), latch `#includeThinking` off, mark `#refusalStripApplied`, `#resetAdvisorContext(false, false)` to rewind the transcript cursor + drop dedupe state, re-render the current transcript through `#renderDelta` (now with thinking off) and unshift the stripped batch back onto `#pending`. Fire `host.notifyThinkingStripped` once so the host surfaces an info notice. A second refusal after the strip falls through to the existing consecutive-failure watchdog — no infinite auto-recovery loop.
- Wire the setting + a `notifyThinkingStripped` notice through the agent-session construction site in `packages/coding-agent/src/session/agent-session.ts`.
- Cover with three unit tests in `advisor.test.ts`: the refusal triggers a stripped re-render and latches subsequent turns; `includeThinking: false` at construction time skips thinking upfront with no degrade path; persistent refusals after the strip still trip the watchdog exactly once.

## Verification

- `bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts` — 69/69 pass (three new tests cover the refusal degrade / opt-out / watchdog fallthrough contracts).
- `bun test packages/coding-agent/src/advisor` — 95/95 pass.
- `bun check` — passes (biome + tsc + rust).
- Broader `packages/coding-agent` suite has 347 pre-existing failures on this branch caused by a missing generated module (`packages/coding-agent/src/export/html/tool-views.generated.js`); verified the same failures occur with my changes stashed. Not caused by this diff.

Fixes #4210