### PR TITLE
fix(catalog): enable keyless ZenMux discovery and normalize base URL to /api/v1

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ZenMux runtime model discovery: without a `ZENMUX_API_KEY` no manager was constructed so new models never reached the `models.db` cache, and with a key discovery derived the wrong base URL (`.../api/anthropic/models`, which does not exist) from the bundled Anthropic-routed default model. The runtime now discovers keylessly against the public `/api/v1/models` endpoint and always normalizes the discovery URL to `/api/v1` regardless of the bundled model's route. ([#4213](https://github.com/can1357/oh-my-pi/issues/4213))
+
 ### Removed
 
 - Removed reasoning suppression prompt logic for GPT-5 models

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -453,6 +453,10 @@ export const CATALOG_PROVIDERS = [
 		defaultModel: "anthropic/claude-opus-4.8",
 		envVars: ["ZENMUX_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => zenmuxModelManagerOptions(config),
+		// ZenMux's `/api/v1/models` endpoint is public — enable runtime discovery
+		// without a key so newly published models refresh into `models.db`
+		// without waiting for a `models.json` regen (#4213).
+		allowUnauthenticated: true,
 		catalogDiscovery: { label: "ZenMux" },
 	},
 	{

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2041,9 +2041,7 @@ function normalizeZenMuxOpenAiBaseUrl(baseUrl?: string): string {
 	// OpenAI-style /models catalog only lives on the /api/v1 route — remap
 	// so discovery hits the real endpoint regardless of which route the
 	// resolver picked.
-	return trimmed.endsWith("/api/anthropic")
-		? `${trimmed.slice(0, -"/api/anthropic".length)}/api/v1`
-		: trimmed;
+	return trimmed.endsWith("/api/anthropic") ? `${trimmed.slice(0, -"/api/anthropic".length)}/api/v1` : trimmed;
 }
 
 function toZenMuxAnthropicBaseUrl(openAiBaseUrl: string): string {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2035,7 +2035,15 @@ function normalizeZenMuxOpenAiBaseUrl(baseUrl?: string): string {
 	if (!value) {
 		return ZENMUX_OPENAI_BASE_URL;
 	}
-	return value.endsWith("/") ? value.slice(0, -1) : value;
+	const trimmed = value.endsWith("/") ? value.slice(0, -1) : value;
+	// The bundled Anthropic-routed baseUrl (.../api/anthropic) is what
+	// getProviderBaseUrl() surfaces for zenmux at runtime, but the
+	// OpenAI-style /models catalog only lives on the /api/v1 route — remap
+	// so discovery hits the real endpoint regardless of which route the
+	// resolver picked.
+	return trimmed.endsWith("/api/anthropic")
+		? `${trimmed.slice(0, -"/api/anthropic".length)}/api/v1`
+		: trimmed;
 }
 
 function toZenMuxAnthropicBaseUrl(openAiBaseUrl: string): string {
@@ -2103,37 +2111,38 @@ export function zenmuxModelManagerOptions(config?: ZenMuxModelManagerConfig): Mo
 	const anthropicBaseUrl = toZenMuxAnthropicBaseUrl(openAiBaseUrl);
 	return {
 		providerId: "zenmux",
-		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels<Api>({
-					api: "openai-completions",
-					provider: "zenmux",
-					baseUrl: openAiBaseUrl,
-					apiKey,
-					mapModel: (entry, defaults) => {
-						const pricings = isRecord(entry.pricings) ? entry.pricings : undefined;
-						const capabilities = isRecord(entry.capabilities) ? entry.capabilities : undefined;
-						const isAnthropicModel = isZenMuxAnthropicModel(entry, defaults.id);
-						return {
-							...defaults,
-							name: toModelName(entry.display_name, defaults.name),
-							api: isAnthropicModel ? "anthropic-messages" : "openai-completions",
-							baseUrl: isAnthropicModel ? anthropicBaseUrl : openAiBaseUrl,
-							reasoning: capabilities?.reasoning === true || defaults.reasoning,
-							input: toInputCapabilities(entry.input_modalities),
-							cost: {
-								input: getZenMuxPricingValue(pricings, "prompt"),
-								output: getZenMuxPricingValue(pricings, "completion"),
-								cacheRead: getZenMuxPricingValue(pricings, "input_cache_read"),
-								cacheWrite: getZenMuxCacheWritePrice(pricings),
-							},
-							contextWindow: toPositiveNumber(entry.context_length, defaults.contextWindow),
-							maxTokens: toPositiveNumber(entry.max_completion_tokens, defaults.maxTokens),
-						};
-					},
-					fetch: config?.fetch,
-				}),
-		}),
+		fetchDynamicModels: () =>
+			fetchOpenAICompatibleModels<Api>({
+				api: "openai-completions",
+				provider: "zenmux",
+				baseUrl: openAiBaseUrl,
+				// Public /api/v1/models does not require credentials — pass the
+				// key when present, omit otherwise so keyless discovery still
+				// runs (see #4213).
+				apiKey,
+				mapModel: (entry, defaults) => {
+					const pricings = isRecord(entry.pricings) ? entry.pricings : undefined;
+					const capabilities = isRecord(entry.capabilities) ? entry.capabilities : undefined;
+					const isAnthropicModel = isZenMuxAnthropicModel(entry, defaults.id);
+					return {
+						...defaults,
+						name: toModelName(entry.display_name, defaults.name),
+						api: isAnthropicModel ? "anthropic-messages" : "openai-completions",
+						baseUrl: isAnthropicModel ? anthropicBaseUrl : openAiBaseUrl,
+						reasoning: capabilities?.reasoning === true || defaults.reasoning,
+						input: toInputCapabilities(entry.input_modalities),
+						cost: {
+							input: getZenMuxPricingValue(pricings, "prompt"),
+							output: getZenMuxPricingValue(pricings, "completion"),
+							cacheRead: getZenMuxPricingValue(pricings, "input_cache_read"),
+							cacheWrite: getZenMuxCacheWritePrice(pricings),
+						},
+						contextWindow: toPositiveNumber(entry.context_length, defaults.contextWindow),
+						maxTokens: toPositiveNumber(entry.max_completion_tokens, defaults.maxTokens),
+					};
+				},
+				fetch: config?.fetch,
+			}),
 	};
 }
 

--- a/packages/catalog/test/zenmux-provider.test.ts
+++ b/packages/catalog/test/zenmux-provider.test.ts
@@ -95,4 +95,50 @@ describe("zenmux provider support", () => {
 		expect(openai?.baseUrl).toBe("https://zenmux.ai/api/v1");
 		expect(openai?.cost.output).toBe(10);
 	});
+
+	test("keyless discovery hits /api/v1/models without an Authorization header (#4213)", async () => {
+		const calls: { url: string; auth: string | null }[] = [];
+		const fetchMock: FetchImpl = vi.fn(async (url, init) => {
+			const headers = (init?.headers ?? {}) as Record<string, string>;
+			calls.push({ url: url.toString(), auth: headers.Authorization ?? null });
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as unknown as FetchImpl;
+
+		const options = zenmuxModelManagerOptions({ fetch: fetchMock });
+		expect(options.fetchDynamicModels).toBeDefined();
+		await options.fetchDynamicModels?.();
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toBe("https://zenmux.ai/api/v1/models");
+		expect(calls[0].auth).toBeNull();
+	});
+
+	test("remaps the bundled /api/anthropic baseUrl to /api/v1 for discovery (#4213)", async () => {
+		const calls: string[] = [];
+		const fetchMock: FetchImpl = vi.fn(async url => {
+			calls.push(url.toString());
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as unknown as FetchImpl;
+
+		// getProviderBaseUrl("zenmux") returns the first bundled model's baseUrl,
+		// which is anthropic-routed (.../api/anthropic). Discovery must still
+		// target the OpenAI-style /api/v1 catalog route.
+		const options = zenmuxModelManagerOptions({
+			apiKey: "zenmux-test-key",
+			baseUrl: "https://zenmux.ai/api/anthropic",
+			fetch: fetchMock,
+		});
+		await options.fetchDynamicModels?.();
+		expect(calls).toEqual(["https://zenmux.ai/api/v1/models"]);
+	});
+
+	test("descriptor allows unauthenticated runtime discovery (#4213)", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "zenmux");
+		expect(descriptor?.allowUnauthenticated).toBe(true);
+	});
 });


### PR DESCRIPTION
## Repro

Two coupled defects hide newly published ZenMux models from runtime discovery until the bundled `models.json` is regenerated. Reproduced end to end:

```
$ bun -e '
  const { zenmuxModelManagerOptions } = await import(
    "./packages/catalog/src/provider-models/openai-compat.ts");
  const keyless = zenmuxModelManagerOptions({});
  console.log("keyless.fetchDynamicModels =", typeof keyless.fetchDynamicModels);
  const calls=[]; const spy=async(u)=>{calls.push(u);
    return new Response("{}",{status:200,headers:{"Content-Type":"application/json"}})};
  const keyed = zenmuxModelManagerOptions({ apiKey:"sk-fake",
    baseUrl:"https://zenmux.ai/api/anthropic", fetch: spy });
  await keyed.fetchDynamicModels?.();
  console.log("keyed fetched =", calls[0]);'
keyless.fetchDynamicModels = undefined
keyed fetched = https://zenmux.ai/api/anthropic/models
```

Meanwhile `curl https://zenmux.ai/api/v1/models` returns 200 with the actual model list without an `Authorization` header, while `.../api/anthropic/models` returns an HTML page (not JSON), so discovery silently drops it.

## Cause

- `zenmuxModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` attached `fetchDynamicModels` only inside `...(apiKey && { ... })`, so without a `ZENMUX_API_KEY` no fetcher exists.
- The `zenmux` descriptor in `packages/catalog/src/provider-models/descriptors.ts` had no top-level `allowUnauthenticated`, so `ModelRegistry.#collectBuiltInModelManagerOptions` (`packages/coding-agent/src/config/model-registry.ts:1598`) never built a manager without a key and the `models.db` write path never ran.
- `normalizeZenMuxOpenAiBaseUrl` only trimmed trailing slashes, so a bundled Anthropic-routed base URL (`https://zenmux.ai/api/anthropic`, which `getProviderBaseUrl("zenmux")` returns because ZenMux's first bundled entries are anthropic-owned) fell through unchanged; discovery then fetched `.../api/anthropic/models`, which does not exist.

## Fix

- `openai-compat.ts`: `normalizeZenMuxOpenAiBaseUrl` now rewrites a trailing `/api/anthropic` back to `/api/v1` before returning, and `zenmuxModelManagerOptions` attaches `fetchDynamicModels` unconditionally — `fetchOpenAICompatibleModels` already skips the `Authorization` header when `apiKey` is undefined, so keyless discovery is safe.
- `descriptors.ts`: the `zenmux` entry gains `allowUnauthenticated: true`. The `catalogDiscovery` half is intentionally left unchanged — this issue scopes only the runtime `models.db` path.
- `test/zenmux-provider.test.ts`: three regression tests covering keyless URL + omitted `Authorization`, remap of a bundled `/api/anthropic` base URL, and the descriptor flag.

ZenMux is not added to the `#keylessProviders` set (that set is populated only by explicit config or the auto-registered local providers), so discovered models remain gated behind credentials for inference, matching the acceptance criteria.

## Verification

`bun test test/zenmux-provider.test.ts` in `packages/catalog`:

```
 7 pass
 0 fail
 24 expect() calls
Ran 7 tests across 1 file. [273.00ms]
```

Manual: hand-run the repro against the patched source confirms `fetchDynamicModels` is defined without a key, and both keyless and keyed calls hit `https://zenmux.ai/api/v1/models`; the keyless call sends no `Authorization` header.

Fixes #4213