### PR TITLE
fix(providers): hydrate runtime model cache before selection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Fixed `/shake` and mid-stream chat rebuilds erasing active LLM output.
 - Fixed Tavily web search to retry without recency filters if no content is returned.
 - Fixed user-configured LiteLLM discovery providers keeping stale reseller display-name suffixes for up to 24 hours after upgrade by invalidating the warm model cache.
+- Fixed cold-start `--model` resolution for extension providers whose catalogs come only from `fetchDynamicModels`, so fresh cached runtime models are available before session startup falls back or hard-fails. ([#4216](https://github.com/can1357/oh-my-pi/issues/4216))
 
 ## [16.2.13] - 2026-07-01
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cold-start `--model` resolution for extension providers whose catalogs come only from `fetchDynamicModels`, so fresh cached runtime models are available before session startup falls back or hard-fails. ([#4216](https://github.com/can1357/oh-my-pi/issues/4216))
+
 ## [16.3.0] - 2026-07-02
 
 ### Added
@@ -42,7 +46,6 @@
 - Fixed `/shake` and mid-stream chat rebuilds erasing active LLM output.
 - Fixed Tavily web search to retry without recency filters if no content is returned.
 - Fixed user-configured LiteLLM discovery providers keeping stale reseller display-name suffixes for up to 24 hours after upgrade by invalidating the warm model cache.
-- Fixed cold-start `--model` resolution for extension providers whose catalogs come only from `fetchDynamicModels`, so fresh cached runtime models are available before session startup falls back or hard-fails. ([#4216](https://github.com/can1357/oh-my-pi/issues/4216))
 
 ## [16.2.13] - 2026-07-01
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1904,11 +1904,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 			extensionsResult.runtime.pendingProviderRegistrations = [];
 		}
-		// Discover runtime (extension) provider catalogs now that they are
-		// registered. The startup refreshInBackground() ran before extensions
-		// loaded, so dynamic extension providers are only discovered here. Runs in
-		// the background (cache-aware) so startup is never blocked on the fetch; the
-		// model list re-renders when the catalog arrives, like other dynamic providers.
+		// Hydrate cached runtime (extension) provider catalogs before model
+		// resolution. Dynamic-only providers have no synchronous registration side
+		// effect, so a cold --model/provider resume must see the same fresh SQLite
+		// cache that `omp models find` uses before the online refresh continues in
+		// the background.
+		await modelRegistry.refreshRuntimeProviders("offline");
+		// Continue runtime discovery in the background (cache-aware) so startup is
+		// only blocked on local cache reads, not provider network fetches.
 		void modelRegistry.refreshRuntimeProviders().catch(error => {
 			logger.warn("runtime provider discovery failed", {
 				error: error instanceof Error ? error.message : String(error),

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -58,6 +58,27 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		});
 	};
 
+	const dynamicOnlyProviderConfig: ProviderConfigInput = {
+		baseUrl: "https://runtime.example.com/v1",
+		apiKey: "RUNTIME_KEY",
+		api: "openai-completions",
+		fetchDynamicModels: async () => [
+			{
+				id: "cached-runtime-model",
+				name: "Cached Runtime Model",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 8192,
+			},
+		],
+	};
+
+	const dynamicOnlyProviderExtension: ExtensionFactory = pi => {
+		pi.registerProvider("runtime-provider", dynamicOnlyProviderConfig);
+	};
+
 	async function buildSessionOptions(modelPattern: string) {
 		// Pass an explicit ModelRegistry so createAgentSession skips its implicit
 		// ModelRegistry.refreshInBackground() — a network model-discovery pass
@@ -94,6 +115,42 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		expect(session.model?.provider).toBe("runtime-provider");
 		expect(session.model?.id).toBe("runtime-model");
 		expect(modelFallbackMessage).toBeUndefined();
+	});
+
+	test("resolves explicit dynamic-only modelPattern from fresh runtime cache", async () => {
+		const authStorage = await AuthStorage.create(path.join(tempDir, "dynamic-auth.db"));
+		authStoragesToClose.push(authStorage);
+		const modelsPath = path.join(tempDir, "models.yml");
+		const primerRegistry = new ModelRegistry(authStorage, modelsPath);
+		primerRegistry.registerProvider("runtime-provider", dynamicOnlyProviderConfig, "ext://runtime");
+		await primerRegistry.refreshRuntimeProviders("online");
+		const modelRegistry = new ModelRegistry(authStorage, modelsPath);
+
+		const { session, modelFallbackMessage } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			extensions: [dynamicOnlyProviderExtension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			modelPattern: "runtime-provider/cached-runtime-model",
+		});
+
+		try {
+			expect(session.model?.provider).toBe("runtime-provider");
+			expect(session.model?.id).toBe("cached-runtime-model");
+			expect(modelFallbackMessage).toBeUndefined();
+		} finally {
+			await session.dispose();
+		}
 	});
 
 	test("does not silently fallback when explicit modelPattern is unresolved", async () => {


### PR DESCRIPTION
## Repro
A dynamic-only extension provider registered with `fetchDynamicModels` can have a fresh SQLite cache row but still fail cold `--model` selection because startup resolves the selector before the runtime provider refresh merges cached models. Reproduced with an in-process runtime provider test that primes `models.db`, then starts `createAgentSession({ modelPattern: "runtime-provider/cached-runtime-model" })`; before the fix, `bun test packages/coding-agent/test/sdk-model-selection.test.ts` failed with `session.model?.provider` undefined for that case.

## Cause
`packages/coding-agent/src/sdk.ts` drained `pendingProviderRegistrations` and started `modelRegistry.refreshRuntimeProviders()` fire-and-forget before resolving deferred `options.modelPattern` and retrying restored session models. Dynamic-only providers registered in `packages/coding-agent/src/config/model-registry.ts` only populate `#runtimeModelManagers`, so their cached catalog is not visible in `modelRegistry.getAll()` until the async refresh continuation reaches `#refreshRuntimeDiscoveries` and assigns `#models`.

## Fix
- Await `modelRegistry.refreshRuntimeProviders("offline")` after extension provider registration so cached runtime provider catalogs are merged before model selection.
- Keep the existing cache-aware runtime provider refresh running in the background for online discovery, preserving startup behavior when no cache exists.
- Add a regression test for a cold dynamic-only runtime provider whose catalog was primed into `models.db` by an earlier runtime refresh.
- Add the coding-agent changelog entry for #4216.

## Verification
`bun test packages/coding-agent/test/sdk-model-selection.test.ts` passed with 11 tests and 32 assertions. `bun run check:types` in `packages/coding-agent` passed. `bun run fix` in `packages/coding-agent` reported no fixes needed. Fixes #4216