### PR TITLE
fix(session): keep model switches active after rate limits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Fixed default model switches being persisted without changing the active goal-mode session when the current context exceeded the target model window. ([#4219](https://github.com/can1357/oh-my-pi/issues/4219))
 - Fixed session persistence corrupting Anthropic, OpenAI, and Google signed thinking blocks and reasoning payloads, ensuring cryptographic signatures and encrypted content are preserved verbatim to prevent API replay rejections (HTTP 400).
 - Fixed several issues with the `apply_patch` and edit tools, including preventing dirty buffers on early aborts, rejecting overwrites of pre-existing files, stopping at the first failing file in multi-file operations, and pruning extremely large file snapshots to prevent session inflation.
 - Fixed process termination (SIGTERM, SIGHUP, uncaught exceptions) to ensure editor drafts are saved, sessions shut down cleanly, and background jobs are cleaned up.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8483,12 +8483,10 @@ export class AgentSession {
 	/**
 	 * Set model directly.
 	 * Validates that a credential source is configured (synchronously, without
-	 * refreshing OAuth or running command-backed key programs). The active
-	 * session switches by default; when `currentContextTokens` is provided and
-	 * exceeds the refreshed candidate's context window, the live switch is
-	 * skipped while role persistence still runs. Returns whether the active
-	 * model actually switched, computed against the refreshed metadata so
-	 * dynamic providers (e.g. llama.cpp) honor their post-load contextWindow.
+	 * refreshing OAuth or running command-backed key programs). Active switches
+	 * always take effect; if the current transcript is too large for the target
+	 * model, the next prompt's compaction/error path owns that recovery instead
+	 * of leaving the session pinned to the old model.
 	 * @throws Error if no API key available for the model
 	 */
 	async setModel(
@@ -8508,27 +8506,14 @@ export class AgentSession {
 
 		const targetModel = await this.#modelRegistry.refreshSelectedModelMetadata(model);
 
-		const currentContextTokens = options?.currentContextTokens ?? 0;
-		const targetContextWindow = targetModel.contextWindow ?? 0;
-		const switched = !(
-			currentContextTokens > 0 &&
-			targetContextWindow > 0 &&
-			currentContextTokens > targetContextWindow
-		);
-
-		if (switched) {
-			this.#clearActiveRetryFallback();
-			this.#setModelWithProviderSessionReset(targetModel);
-			this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, role);
-		}
+		this.#clearActiveRetryFallback();
+		this.#setModelWithProviderSessionReset(targetModel);
+		this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, role);
 		if (options?.persist) {
 			this.settings.setModelRole(
 				role,
 				this.#formatRoleModelValue(role, targetModel, options.selector, options.thinkingLevel),
 			);
-		}
-		if (!switched) {
-			return { switched: false };
 		}
 		this.settings.getStorage()?.recordModelUsage(`${targetModel.provider}/${targetModel.id}`);
 

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -190,7 +190,7 @@ describe("AgentSession model persistence", () => {
 		expect(created.settings.getModelRole("default")).toBe(modelValue(nextModel));
 	});
 
-	it("persists the default role without switching the active model when over context", async () => {
+	it("switches the active model even when the live context is over the target window", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const nextModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
 
@@ -208,8 +208,8 @@ describe("AgentSession model persistence", () => {
 			currentContextTokens: overflowTokens,
 		});
 
-		expect(result).toEqual({ switched: false });
-		expect(created.session.model?.id).toBe(defaultModel.id);
+		expect(result).toEqual({ switched: true });
+		expect(created.session.model?.id).toBe(nextModel.id);
 		expect(created.settings.getModelRole("default")).toBe(modelValue(nextModel));
 	});
 


### PR DESCRIPTION
## Repro
A goal-mode session can get pinned to a rate-limited model after opening the model selector and choosing a default model whose context window is smaller than the current transcript. Reproduced with `bun --cwd=packages/collab-web run gen:tool-views && bun test packages/coding-agent/test/agent-session-model-persistence.test.ts -t "switches the active model even when"`, which failed because `AgentSession.setModel()` returned `{ switched: false }` and left the old model active.

## Cause
`packages/coding-agent/src/session/agent-session.ts` used the selector-provided `currentContextTokens` hint inside `AgentSession.setModel()` to skip the live switch when the target model window was smaller than the current context, while still persisting the new default role. `packages/coding-agent/src/modes/controllers/selector-controller.ts` then reported the new default model even though subsequent turns still used the old active model.

## Fix
- Changed `AgentSession.setModel()` so authenticated model selections always update the active session model and clear retry fallback state.
- Left oversized-context recovery to the next prompt's compaction/error path instead of silently pinning the old model.
- Updated the model persistence regression test to cover an over-window default switch that must still become active.
- Added a coding-agent changelog entry for #4219.

## Verification
- `bun test packages/coding-agent/test/agent-session-model-persistence.test.ts -t "switches the active model even when"` passed.
- `bun test packages/coding-agent/test/agent-session-model-persistence.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` passed.
- `bun test packages/coding-agent/test/agent-session-model-switch-auth.test.ts packages/coding-agent/test/agent-session-openai-completions-model-switch.test.ts` passed.
- Pre-publish `gh_push_branch` completed successfully. Fixes #4219