### PR TITLE
fix(ai): cap Devin Connect frame payload length

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Removed automated injection of reasoning suppression prompts in OpenAI responses
 
+### Fixed
+
+- Cap Devin Connect frame payloads at 16 MiB to prevent unbounded buffer growth on corrupt frame headers ([#4228](https://github.com/can1357/oh-my-pi/issues/4228))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -69,6 +69,7 @@ const DEVIN_DEFAULT_STOP_PATTERNS = ["<|user|>", "<|bot|>", "<|context_request|>
 /** Connect streaming framing: flag byte bit 0x01 = gzip payload, 0x02 = end-of-stream JSON trailers. */
 const CONNECT_COMPRESSED_FLAG = 0x01;
 const CONNECT_END_STREAM_FLAG = 0x02;
+const MAX_CONNECT_FRAME_PAYLOAD = 16 * 1024 * 1024;
 
 export const streamDevin: StreamFunction<"devin-agent"> = (
 	model: Model<"devin-agent">,
@@ -201,6 +202,12 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 				while (pending.length >= 5) {
 					const flag = pending[0];
 					const len = pending.readUInt32BE(1);
+					if (len > MAX_CONNECT_FRAME_PAYLOAD) {
+						throw new AIError.ProviderResponseError(`Devin Connect frame too large: ${len}`, {
+							provider: model.provider,
+							kind: "envelope",
+						});
+					}
 					if (pending.length < 5 + len) break;
 					const payload = pending.subarray(5, 5 + len);
 					pending = pending.subarray(5 + len);


### PR DESCRIPTION
Closes #4228

## Problem

`streamDevin` buffered inbound chunks with `Buffer.concat([pending, value])` and only processed a frame once `pending.length >= 5 + len`, where `len` is a 4-byte unsigned length read from the wire. A corrupt or malicious server could announce an arbitrarily large `len`, causing unbounded memory growth before the idle timeout could abort the stream.

## Change

- Added `MAX_CONNECT_FRAME_PAYLOAD = 16 * 1024 * 1024` (16 MiB) beside the Devin Connect flag constants.
- After reading each frame's `flag` and `len`, immediately throw `AIError.ProviderResponseError(..., { kind: "envelope" })` if `len` exceeds the cap, before waiting for the full payload.
- The guard is placed before the `pending.length < 5 + len` break so oversized frames are rejected without reading further chunks for that frame.

## Verification

- `bun check` passes.
- Scoped Bun test with a mocked Devin fetch/body reader: a frame header announcing a 16,777,217-byte payload emitted `["start", "error"]`, preserved the finalized error message, and did not call `reader.read()` a second time for that frame.