### PR TITLE
fix(coding-agent): add fetch timeouts to update, hindsight, and smithery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Add network timeouts to update check, Hindsight recall, and Smithery registry fetches to prevent indefinite hangs ([#4229](https://github.com/can1357/oh-my-pi/issues/4229))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -239,7 +239,17 @@ async function resolveUpdateTarget(): Promise<UpdateTarget> {
  * Uses npm instead of GitHub API to avoid unauthenticated rate limiting.
  */
 async function getLatestRelease(): Promise<ReleaseInfo> {
-	const response = await fetch(`${NPM_REGISTRY}${PACKAGE}/latest`);
+	let response: Response;
+	try {
+		response = await fetch(`${NPM_REGISTRY}${PACKAGE}/latest`, {
+			signal: AbortSignal.timeout(30_000),
+		});
+	} catch (err) {
+		if (err instanceof DOMException && err.name === "TimeoutError") {
+			throw new Error("Failed to fetch release info: The operation timed out");
+		}
+		throw err;
+	}
 	if (!response.ok) {
 		throw new Error(`Failed to fetch release info: ${response.statusText}`);
 	}
@@ -832,7 +842,18 @@ async function updateViaBinaryAt(targetPath: string, expectedVersion: string): P
 	const backupPath = `${targetPath}.${Date.now()}.${process.pid}.bak`;
 	console.log(chalk.dim(`Downloading ${binaryName}…`));
 
-	const response = await fetch(url, { redirect: "follow" });
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			redirect: "follow",
+			signal: AbortSignal.timeout(15 * 60 * 1000),
+		});
+	} catch (err) {
+		if (err instanceof DOMException && err.name === "TimeoutError") {
+			throw new Error("Download failed: The operation timed out");
+		}
+		throw err;
+	}
 	if (!response.ok || !response.body) {
 		throw new Error(`Download failed: ${response.statusText}`);
 	}

--- a/packages/coding-agent/src/hindsight/client.ts
+++ b/packages/coding-agent/src/hindsight/client.ts
@@ -208,6 +208,8 @@ interface RequestOptions {
 	query?: Record<string, unknown>;
 	/** Return null instead of throwing on a 404 response. */
 	allow404?: boolean;
+	/** Optional caller abort signal; merged with a 30s operation timeout. */
+	signal?: AbortSignal;
 }
 
 export class HindsightApi {
@@ -493,6 +495,9 @@ export class HindsightApi {
 		if (opts?.body !== undefined) {
 			init.body = JSON.stringify(pruneUndefined(opts.body));
 		}
+
+		const timeoutSignal = AbortSignal.timeout(30_000);
+		init.signal = opts?.signal ? AbortSignal.any([opts.signal, timeoutSignal]) : timeoutSignal;
 
 		let response: Response;
 		try {

--- a/packages/coding-agent/src/mcp/smithery-registry.ts
+++ b/packages/coding-agent/src/mcp/smithery-registry.ts
@@ -314,6 +314,7 @@ async function fetchServerDetails(path: string, options?: { apiKey?: string }): 
 	}
 	const response = await fetch(`${SMITHERY_REGISTRY_BASE_URL}/servers/${path}`, {
 		headers,
+		signal: AbortSignal.timeout(10_000),
 	});
 	if (!response.ok) return null;
 	return (await response.json()) as SmitheryServerDetails;
@@ -411,7 +412,7 @@ export async function searchSmitheryRegistry(
 		url.searchParams.set("q", query);
 		url.searchParams.set("pageSize", String(pageSize));
 		if (page > 1) url.searchParams.set("page", String(page));
-		const response = await fetch(url.toString(), { headers });
+		const response = await fetch(url.toString(), { headers, signal: AbortSignal.timeout(10_000) });
 		if (!response.ok) {
 			throw new SmitheryRegistryError(`Smithery search failed with status ${response.status}`, response.status);
 		}


### PR DESCRIPTION
Closes #4229

## Problem

Bare `fetch()` calls in update-cli (`getLatestRelease`, `updateViaBinaryAt`), `HindsightApi.#request`, and the Smithery registry helpers (`fetchServerDetails`, `searchSmitheryRegistry`) had no timeout. Stalled network or unresponsive servers left these promises pending indefinitely, blocking update checks, Hindsight recall, and Smithery searches.

## Change

- `packages/coding-agent/src/cli/update-cli.ts`: added `AbortSignal.timeout(30_000)` to `getLatestRelease` and `AbortSignal.timeout(15 * 60 * 1000)` to `updateViaBinaryAt`; `TimeoutError` is mapped to the existing error contracts (`"Failed to fetch release info: The operation timed out"` / `"Download failed: The operation timed out"`) and other errors are re-thrown unchanged.
- `packages/coding-agent/src/hindsight/client.ts`: added `RequestOptions.signal` and merged it with `AbortSignal.timeout(30_000)` in `HindsightApi.#request`; fetch failures continue to be wrapped in `HindsightError`.
- `packages/coding-agent/src/mcp/smithery-registry.ts`: added `AbortSignal.timeout(10_000)` to `fetchServerDetails` and the `searchSmitheryRegistry` page loop.

## Verification

- `bun run check:types` passed.
- `bun test test/update-cli.test.ts` passed.
- `bun test test/hindsight-client.test.ts` passed.
- `bun test test/mcp-timeout.test.ts` passed.