### PR TITLE
fix(extensibility): drain subprocess stdout/stderr to avoid deadlocks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Drain plugin install/uninstall and registry-build subprocess pipes concurrently with exit to prevent pipe-buffer deadlocks ([#4230](https://github.com/can1357/oh-my-pi/issues/4230))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/scripts/generate-legacy-pi-bundled-registry.ts
+++ b/packages/coding-agent/scripts/generate-legacy-pi-bundled-registry.ts
@@ -332,10 +332,13 @@ async function formatInPlace(targets: readonly string[]): Promise<void> {
 		stdout: "pipe",
 		stderr: "pipe",
 	});
-	const exit = await proc.exited;
+	// Start draining both pipes before the process exits to avoid a deadlock
+	// where Biome blocks writing to a full pipe while we wait for it to exit.
+	const stdout = new Response(proc.stdout).text();
+	const stderr = new Response(proc.stderr).text();
+	const [exit, , stderrText] = await Promise.all([proc.exited, stdout, stderr]);
 	if (exit !== 0) {
-		const stderr = await new Response(proc.stderr).text();
-		throw new Error(`biome check --write failed (exit ${exit}): ${stderr}`);
+		throw new Error(`biome check --write failed (exit ${exit}): ${stderrText}`);
 	}
 }
 

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -458,10 +458,13 @@ export class PluginManager {
 				stderr: "pipe",
 				windowsHide: true,
 			});
-			const installExit = await installProc.exited;
+			const [installExit, , installStderr] = await Promise.all([
+				installProc.exited,
+				new Response(installProc.stdout).text(),
+				new Response(installProc.stderr).text(),
+			]);
 			if (installExit !== 0) {
-				const stderr = await new Response(installProc.stderr).text();
-				throw new Error(`bun install failed: ${stderr}`);
+				throw new Error(`bun install failed: ${installStderr}`);
 			}
 			// Resolve actual package name. npm specs encode the name (strip version);
 			// git specs do not, so diff plugins/package.json deps to find the new entry.
@@ -608,7 +611,11 @@ export class PluginManager {
 			windowsHide: true,
 		});
 
-		const exitCode = await proc.exited;
+		const [exitCode] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
 		if (exitCode !== 0) {
 			throw new Error(`npm uninstall failed for ${name}`);
 		}
@@ -1007,7 +1014,12 @@ export class PluginManager {
 				stderr: "pipe",
 				windowsHide: true,
 			});
-			return (await proc.exited) === 0;
+			const [exitCode] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			return exitCode === 0;
 		} catch {
 			return false;
 		}


### PR DESCRIPTION
Closes #4230

## Problem

`PluginManager.install`, `.uninstall`, and `#fixMissingPlugin` in `packages/coding-agent/src/extensibility/plugins/manager.ts` awaited `proc.exited` before draining `stdout`/`stderr`; verbose `bun install`/`uninstall` output could fill the pipe buffer and deadlock the child. `formatInPlace` in `packages/coding-agent/scripts/generate-legacy-pi-bundled-registry.ts` had the same pattern with `bunx biome`.

## Change

After each `Bun.spawn`, start `Response(...).text()` readers for both pipes immediately and await them alongside `proc.exited` via `Promise.all`. This drains the pipes while the process is still running, eliminating the deadlock. Error reporting is unchanged: install still throws with stderr, uninstall keeps its original message, and the registry script's Biome failure still includes stderr.

## Verification

- `bun run --cwd=packages/coding-agent check:types` passes.
- `bun test packages/coding-agent/test/plugin-install-git.test.ts packages/coding-agent/test/plugin-install-local.test.ts packages/coding-agent/test/plugin-install-validation.test.ts packages/coding-agent/test/plugin-command.test.ts packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts` passes (26 tests).