### PR TITLE
fix(pi-iso): drain git-apply stderr while writing patch to stdin

### DIFF
--- a/crates/pi-iso/src/rcopy.rs
+++ b/crates/pi-iso/src/rcopy.rs
@@ -245,7 +245,7 @@ fn git_capture(cwd: &Path, args: &[&str]) -> IsoResult<Vec<u8>> {
 }
 
 fn git_apply(cwd: &Path, patch: &[u8], extra: &[&str]) -> IsoResult<()> {
-	use std::io::Write as _;
+	use std::io::{Read as _, Write as _};
 	let mut child = std::process::Command::new("git")
 		.arg("-C")
 		.arg(cwd)
@@ -264,6 +264,18 @@ fn git_apply(cwd: &Path, patch: &[u8], extra: &[&str]) -> IsoResult<()> {
 				IsoError::other(format!("spawn git apply: {err}"))
 			}
 		})?;
+
+	let mut child_stderr = child
+		.stderr
+		.take()
+		.ok_or_else(|| IsoError::other("git apply: child stderr was not piped".to_string()))?;
+
+	let stderr_reader = std::thread::spawn(move || -> std::io::Result<Vec<u8>> {
+		let mut buf = Vec::new();
+		child_stderr.read_to_end(&mut buf)?;
+		Ok(buf)
+	});
+
 	{
 		let stdin = child
 			.stdin
@@ -273,17 +285,21 @@ fn git_apply(cwd: &Path, patch: &[u8], extra: &[&str]) -> IsoResult<()> {
 			.write_all(patch)
 			.map_err(|err| IsoError::other(format!("write patch to git apply: {err}")))?;
 	}
-	let output = child
-		.wait_with_output()
+	drop(child.stdin.take());
+
+	let stderr_bytes = stderr_reader
+		.join()
+		.map_err(|_| IsoError::other("git apply: stderr reader thread panicked".to_string()))?
+		.map_err(|err| IsoError::other(format!("read git apply stderr: {err}")))?;
+
+	let status = child
+		.wait()
 		.map_err(|err| IsoError::other(format!("wait git apply: {err}")))?;
-	if output.status.success() {
+	if status.success() {
 		return Ok(());
 	}
-	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-	Err(IsoError::other(format!(
-		"git apply (exit {}): {stderr}",
-		output.status.code().unwrap_or(-1)
-	)))
+	let stderr = String::from_utf8_lossy(&stderr_bytes).trim().to_string();
+	Err(IsoError::other(format!("git apply (exit {}): {stderr}", status.code().unwrap_or(-1))))
 }
 
 /// Copy a single path (regular file, symlink, or directory) from `src`


### PR DESCRIPTION
Closes #4231

## Problem

`git_apply` piped `stdin` and `stderr` for the `git apply` child but wrote the full patch with `write_all()` before `wait_with_output()` could drain `stderr`. If the child filled the stderr pipe buffer while the parent was still writing to `stdin`, both sides blocked: a classic pipe deadlock.

## Change

- Spawn a thread to read `stderr` into a `Vec<u8>` while the parent writes the patch to `stdin`.
- Drop `stdin` after `write_all` completes so `git apply` sees EOF and can finish.
- Join the stderr reader and reap the child with `wait()` instead of `wait_with_output()`.
- Preserve the existing error message format: exit code plus trimmed stderr text.
- Keep the "child stderr was not piped" error path and add a thread-panic fallback.

## Verification

- `cargo check -p pi-iso` passes.
- `cargo test -p pi-iso` passes (2 tests).