### PR TITLE
fix(ssh): bound control-master/probe calls with 30s timeout via ptree.exec

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bound SSH control-master/probe invocations with a 30s timeout via `ptree.exec` to prevent hangs on unreachable or wedged hosts ([#4232](https://github.com/can1357/oh-my-pi/issues/4232))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/ssh/connection-manager.ts
+++ b/packages/coding-agent/src/ssh/connection-manager.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { $which, getRemoteHostDir, getSshControlDir, isEnoent, logger, postmortem } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
+import { $which, getRemoteHostDir, getSshControlDir, isEnoent, logger, postmortem, ptree } from "@oh-my-pi/pi-utils";
 import { buildSshTarget, sanitizeHostName } from "./utils";
 
 export interface SSHConnectionTarget {
@@ -42,6 +41,7 @@ const CONTROL_DIR = getSshControlDir();
 const CONTROL_PATH = path.join(CONTROL_DIR, "%C.sock");
 const HOST_INFO_DIR = getRemoteHostDir();
 const HOST_INFO_VERSION = 4;
+const SSH_SETUP_TIMEOUT_MS = 30_000;
 
 const activeHosts = new Map<string, SSHConnectionTarget>();
 const pendingConnections = new Map<string, Promise<void>>();
@@ -117,16 +117,26 @@ function buildCommonArgs(host: SSHConnectionTarget, options?: SSHArgsOptions): s
 }
 
 async function runSshSync(args: string[]): Promise<{ exitCode: number | null; stderr: string }> {
-	const result = await $`ssh ${args}`.quiet().nothrow();
-	return { exitCode: result.exitCode, stderr: result.stderr.toString().trim() };
+	const result = await ptree.exec(["ssh", ...args], {
+		timeout: SSH_SETUP_TIMEOUT_MS,
+		allowNonZero: true,
+		allowAbort: true,
+		stderr: "full",
+	});
+	return { exitCode: result.exitCode, stderr: result.stderr.trim() };
 }
 
 async function runSshCaptureSync(args: string[]): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
-	const result = await $`ssh ${args}`.quiet().nothrow();
+	const result = await ptree.exec(["ssh", ...args], {
+		timeout: SSH_SETUP_TIMEOUT_MS,
+		allowNonZero: true,
+		allowAbort: true,
+		stderr: "full",
+	});
 	return {
 		exitCode: result.exitCode,
-		stdout: result.stdout.toString().trim(),
-		stderr: result.stderr.toString().trim(),
+		stdout: result.stdout.trim(),
+		stderr: result.stderr.trim(),
 	};
 }
 


### PR DESCRIPTION
Closes #4232

## Problem

`runSshSync` and `runSshCaptureSync` in `packages/coding-agent/src/ssh/connection-manager.ts` used Bun shell `$ ssh ...` without a timeout, allowing control-master setup and host probing to hang indefinitely when a host is unreachable or the connection wedges.

## Change

Replaced both helpers with `ptree.exec(["ssh", ...args], { timeout: SSH_SETUP_TIMEOUT_MS, allowNonZero: true, allowAbort: true, stderr: "full" })`, where `SSH_SETUP_TIMEOUT_MS = 30_000`. Preserved the existing return shapes (`{ exitCode, stderr }` and `{ exitCode, stdout, stderr }`) with trimmed captured output. Removed the now-unused `import { $ } from "bun"`. Non-zero exits, timeouts, and aborts now return as failure results instead of throwing.

## Verification

- Package typecheck passed.
- `bun test packages/coding-agent/test/ssh/ssh-executor.test.ts` — 2 pass, 0 fail.