### PR TITLE
fix(tui): bound status-line gh pr lookup with timeout and non-interactive env

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bound status-line GitHub PR lookup with a timeout and non-interactive environment to prevent hangs ([#4234](https://github.com/can1357/oh-my-pi/issues/4234))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -4,7 +4,6 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { getProjectDir } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
 import { settings } from "../../../config/settings";
 import type { AgentSession } from "../../../session/agent-session";
 import type { OAuthAccountIdentity } from "../../../session/auth-storage";
@@ -708,13 +707,17 @@ export class StatusLineComponent implements Component {
 			};
 			try {
 				// Requires `gh repo set-default` to be configured; fails gracefully if not
-				const result = await $`gh pr view --json number,url`.cwd(lookupCwd).quiet().nothrow();
+				const result = await git.github.run(
+					lookupCwd,
+					["pr", "view", "--json", "number,url"],
+					AbortSignal.timeout(git.GIT_COMMAND_TIMEOUT_MS),
+				);
 				if (this.#disposed) return;
 				if (result.exitCode !== 0) {
 					setCachedPr(null);
 					return;
 				}
-				const pr = JSON.parse(result.stdout.toString()) as { number: number; url: string };
+				const pr = JSON.parse(result.stdout) as { number: number; url: string };
 				if (typeof pr.number === "number") {
 					setCachedPr({ number: pr.number, url: pr.url });
 				} else {


### PR DESCRIPTION
Closes #4234

## Problem

`#lookupPr` in `packages/coding-agent/src/modes/components/status-line/component.ts` invoked `gh pr view --json number,url` through Bun's `$` shell with no timeout, abort signal, or non-interactive environment. If `gh` stalled on a network request or auth prompt, the `await` never resolved, `#prLookupInFlight` stayed `true`, and the child process leaked.

## Change

Replaced the raw shell call with `git.github.run(lookupCwd, ["pr", "view", "--json", "number,url"], AbortSignal.timeout(git.GIT_COMMAND_TIMEOUT_MS))`. This routes through the repo's existing `Bun.spawn`-based GitHub helper, which supplies `GH_NON_INTERACTIVE_ENV`/`GIT_NON_INTERACTIVE_ENV` and returns a non-throwing `{ exitCode, stdout, stderr }` result, preserving the original `.nothrow()` failure handling. Removed the now-unused `import { $ } from "bun"`.

## Verification

- `bun tsc --noEmit` in `packages/coding-agent` passes.
- `bun test status-line` passes.