### PR TITLE
perf(tui): load persisted subagents asynchronously

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Load persisted Agent Hub subagents asynchronously to avoid blocking the TUI on synchronous directory walks ([#4239](https://github.com/can1357/oh-my-pi/issues/4239))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -68,16 +68,23 @@ function statusBadge(status: AgentStatus): string {
 	}
 }
 
-function registerPersistedSubagents(registry: AgentRegistry, sessionFile: string | null | undefined): void {
+async function registerPersistedSubagents(
+	registry: AgentRegistry,
+	sessionFile: string | null | undefined,
+): Promise<void> {
 	if (!sessionFile?.endsWith(".jsonl")) return;
 	const root = sessionFile.slice(0, -6);
-	registerPersistedSubagentsFromDir(registry, root, undefined);
+	await registerPersistedSubagentsFromDir(registry, root, undefined);
 }
 
-function registerPersistedSubagentsFromDir(registry: AgentRegistry, dir: string, parentId: string | undefined): void {
+async function registerPersistedSubagentsFromDir(
+	registry: AgentRegistry,
+	dir: string,
+	parentId: string | undefined,
+): Promise<void> {
 	let entries: fs.Dirent[];
 	try {
-		entries = fs.readdirSync(dir, { withFileTypes: true });
+		entries = await fs.promises.readdir(dir, { withFileTypes: true });
 	} catch {
 		return;
 	}
@@ -126,7 +133,7 @@ function registerPersistedSubagentsFromDir(registry: AgentRegistry, dir: string,
 				status: "parked",
 			});
 		}
-		registerPersistedSubagentsFromDir(registry, path.join(dir, id), id);
+		await registerPersistedSubagentsFromDir(registry, path.join(dir, id), id);
 	}
 }
 
@@ -192,6 +199,8 @@ export class AgentHubOverlayComponent extends Container {
 	#unsubscribers: Array<() => void> = [];
 	#ageTimer: NodeJS.Timeout | undefined;
 	#remote: AgentHubRemote | undefined;
+	/** Resolves after persisted historical subagents have been registered and rows refreshed. */
+	readonly persistedSubagentsReady: Promise<void>;
 
 	// Table state
 	#rows: AgentRef[] = [];
@@ -247,7 +256,16 @@ export class AgentHubOverlayComponent extends Container {
 		this.#ageTimer = setInterval(() => this.#requestRender(), AGE_TICK_MS);
 		this.#ageTimer.unref?.();
 
-		if (!this.#remote) registerPersistedSubagents(this.#registry, deps.sessionFile);
+		this.persistedSubagentsReady = this.#remote
+			? Promise.resolve()
+			: registerPersistedSubagents(this.#registry, deps.sessionFile)
+					.catch((error: unknown) => {
+						logger.warn("Failed to register persisted subagents", { error });
+					})
+					.then(() => {
+						this.#refreshRows();
+					})
+					.finally(() => this.#requestRender());
 		this.#refreshRows();
 	}
 

--- a/packages/coding-agent/test/agent-hub-activate.test.ts
+++ b/packages/coding-agent/test/agent-hub-activate.test.ts
@@ -106,6 +106,7 @@ describe("Agent hub Enter activation", () => {
 			focusAgent: async () => {},
 			sessionFile,
 		});
+		await hub.persistedSubagentsReady;
 
 		const rendered = Bun.stripANSI(hub.render(120).join("\n"));
 		expect(rendered).toContain("Worker");


### PR DESCRIPTION
Closes #4239

## Problem

`registerPersistedSubagentsFromDir` in `packages/coding-agent/src/modes/components/agent-hub.ts` used `fs.readdirSync(..., { withFileTypes: true })` and recursively walked every persisted subagent directory. Because the recursion depth and directory count scale with subagent history, this performed unbounded synchronous filesystem I/O that blocked the event loop while the Agent Hub was opening.

## Change

- Converted `registerPersistedSubagents` and `registerPersistedSubagentsFromDir` to async functions and replaced `fs.readdirSync` with `await fs.promises.readdir`.
- Changed the `AgentHubOverlayComponent` constructor to start registration fire-and-forget and exposed `readonly persistedSubagentsReady: Promise<void>` so tests/callers can observe completion.
- On completion, rows are refreshed; failures are caught and logged with `logger.warn`; a render is requested in `finally`.

## Verification

- `bun --check packages/coding-agent/src/modes/components/agent-hub.ts` passed.
- `packages/coding-agent/test/agent-hub-activate.test.ts` passed (awaits `persistedSubagentsReady`).