### PR TITLE
fix(bash): bound interactive bash live display write queue

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bound interactive bash live display write queue to prevent unbounded PTY chunk backlog ([#4240](https://github.com/can1357/oh-my-pi/issues/4240))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/tools/bash-interactive.ts
+++ b/packages/coding-agent/src/tools/bash-interactive.ts
@@ -31,6 +31,10 @@ function normalizeCaptureChunk(chunk: string): string {
 	return sanitizeWithOptionalSixelPassthrough(normalized, sanitizeText);
 }
 
+// Caps only the live xterm display backlog; OutputSink remains the bounded
+// source of truth for the final captured output.
+const MAX_LIVE_WRITE_QUEUE_CHUNKS = 512;
+
 // @xterm/headless is only needed once an interactive PTY session actually starts,
 // so it is loaded lazily (and memoized) instead of weighing down CLI startup.
 let xtermTerminalCtor: typeof XtermModule.Terminal | undefined;
@@ -141,7 +145,15 @@ class BashInteractiveOverlayComponent implements Component {
 
 	appendOutput(chunk: string): void {
 		this.#writeQueue.push(chunk);
+		this.#trimWriteQueue();
 		this.#drainQueue();
+	}
+
+	#trimWriteQueue(): void {
+		const firstPending = this.#writing ? this.#writeOffset + 1 : this.#writeOffset;
+		while (this.#writeQueue.length - firstPending > MAX_LIVE_WRITE_QUEUE_CHUNKS) {
+			this.#writeQueue.splice(firstPending, 1);
+		}
 	}
 
 	#drainQueue(): void {


### PR DESCRIPTION
Closes #4240

## Problem

`BashInteractiveOverlayComponent.appendOutput` in `packages/coding-agent/src/tools/bash-interactive.ts` pushed every PTY chunk into `#writeQueue` without bounds. xterm drains the queue asynchronously, so fast-producing commands (e.g. `yes`, `find /`, `cat largefile`) could grow the live display backlog unbounded during the tool timeout, consuming memory proportional to `output rate × timeout duration`. `OutputSink` already bounds the captured final output, but the overlay's pending write queue did not.

## Change

- Added `MAX_LIVE_WRITE_QUEUE_CHUNKS = 512` to cap only the live xterm display backlog.
- Added `#trimWriteQueue()` to drop oldest pending chunks at/after the first pending index after each `appendOutput`.
- The trim deliberately preserves `#writing`, `#writeOffset`, and the flush resolver state: it only removes pending chunks, never the chunk currently being written.

## Verification

- `bun run check:types` passed for `packages/coding-agent`.
- Ran a focused JS sanity check covering idle-queue and active-write cases to confirm trim keeps the queue at or below the cap without mutating active write state.