### PR TITLE
fix(task): abort underlying MCP call when proxy tool timeout fires

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Abort underlying MCP call when proxy tool timeout fires ([#4242](https://github.com/can1357/oh-my-pi/issues/4242))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -215,7 +215,12 @@ function renderIrcPeerRoster(selfId: string): string {
 	return lines.join("\n");
 }
 
-function withAbortTimeout<T>(promise: Promise<T>, timeoutMs: number, signal?: AbortSignal): Promise<T> {
+function withAbortTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+	signal?: AbortSignal,
+	timeoutController?: AbortController,
+): Promise<T> {
 	if (signal?.aborted) {
 		return Promise.reject(new ToolAbortError());
 	}
@@ -225,6 +230,7 @@ function withAbortTimeout<T>(promise: Promise<T>, timeoutMs: number, signal?: Ab
 	const timeoutId = setTimeout(() => {
 		if (settled) return;
 		settled = true;
+		timeoutController?.abort(new DOMException(`MCP tool call timed out after ${timeoutMs}ms`, "TimeoutError"));
 		reject(new Error(`MCP tool call timed out after ${timeoutMs}ms`));
 	}, timeoutMs);
 
@@ -232,6 +238,7 @@ function withAbortTimeout<T>(promise: Promise<T>, timeoutMs: number, signal?: Ab
 		if (settled) return;
 		settled = true;
 		clearTimeout(timeoutId);
+		timeoutController?.abort();
 		reject(new ToolAbortError());
 	};
 
@@ -708,13 +715,21 @@ export function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
 				const serverName = mcpTool.mcpServerName ?? "";
 				const mcpToolName = mcpTool.mcpToolName ?? "";
 				try {
+					const timeoutController = new AbortController();
+					const timeoutSignal = timeoutController.signal;
+					const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 					const result = await withAbortTimeout(
 						(async () => {
-							const connection = await mcpManager.waitForConnection(serverName);
-							return callTool(connection, mcpToolName, params as Record<string, unknown>, { signal });
+							const connection = await untilAborted(combinedSignal, () =>
+								mcpManager.waitForConnection(serverName),
+							);
+							return callTool(connection, mcpToolName, params as Record<string, unknown>, {
+								signal: combinedSignal,
+							});
 						})(),
 						MCP_CALL_TIMEOUT_MS,
 						signal,
+						timeoutController,
 					);
 					return {
 						content: (result.content ?? []).map(item =>

--- a/packages/coding-agent/test/task-executor-mcp-timeout.test.ts
+++ b/packages/coding-agent/test/task-executor-mcp-timeout.test.ts
@@ -1,0 +1,159 @@
+import { expect, test, vi } from "bun:test";
+import type { CustomTool, CustomToolContext } from "../src/extensibility/custom-tools/types";
+import { MCPManager } from "../src/mcp/manager";
+import type { MCPRequestOptions, MCPServerConnection, MCPTransport } from "../src/mcp/types";
+import { createMCPProxyTools } from "../src/task/executor";
+import { ToolAbortError } from "../src/tools/tool-errors";
+
+function createFakeConnection() {
+	let capturedSignal: AbortSignal | undefined;
+	const { promise: requestPromise, reject } = Promise.withResolvers<never>();
+	let isRequestCalled = false;
+
+	const transport: MCPTransport = {
+		async request(_method: string, _params?: Record<string, unknown>, options?: MCPRequestOptions) {
+			isRequestCalled = true;
+			capturedSignal = options?.signal;
+			if (capturedSignal?.aborted) {
+				reject(new Error("aborted"));
+				return requestPromise;
+			}
+			capturedSignal?.addEventListener("abort", () => {
+				reject(new Error("aborted"));
+			});
+			return requestPromise;
+		},
+		async notify() {},
+		async close() {},
+		connected: true,
+	};
+
+	const connection: MCPServerConnection = {
+		name: "test-server",
+		config: { command: "test", args: [] },
+		transport,
+		serverInfo: { name: "test", version: "1" },
+		capabilities: {},
+	};
+
+	return {
+		connection,
+		getCapturedSignal: () => capturedSignal,
+		requestPromise,
+		rejectRequest: reject,
+		requestCalled: () => isRequestCalled,
+	};
+}
+
+test("MCP proxy tool aborts underlying operation on caller abort", async () => {
+	const fake = createFakeConnection();
+	const manager = new MCPManager(process.cwd());
+
+	const toolsData: CustomTool[] = [
+		{
+			name: "test_tool",
+			label: "Test Tool",
+			description: "A test tool",
+			strict: false,
+			mcpToolName: "test_tool",
+			mcpServerName: "test-server",
+			parameters: { type: "object", properties: {} },
+			execute: async () => ({ content: [] }),
+		} as CustomTool,
+	];
+
+	vi.spyOn(manager, "getTools").mockReturnValue(toolsData);
+	vi.spyOn(manager, "waitForConnection").mockResolvedValue(fake.connection);
+
+	const tools = createMCPProxyTools(manager);
+	const proxyTool = tools[0];
+	if (!proxyTool?.execute) {
+		expect.unreachable("Tool execute method missing");
+		return;
+	}
+
+	const ac = new AbortController();
+	const executePromise = proxyTool.execute("call_1", {}, () => {}, {} as CustomToolContext, ac.signal);
+
+	// Let the promise reach transport.request
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+
+	expect(fake.requestCalled()).toBe(true);
+	const capturedSignal = fake.getCapturedSignal();
+	expect(capturedSignal).toBeDefined();
+	if (!capturedSignal) return;
+	expect(capturedSignal.aborted).toBe(false);
+
+	ac.abort();
+
+	try {
+		await executePromise;
+		expect.unreachable("executePromise should throw ToolAbortError");
+	} catch (e: unknown) {
+		expect(e instanceof ToolAbortError).toBe(true);
+	}
+
+	expect(capturedSignal.aborted).toBe(true);
+});
+
+test("MCP proxy tool aborts underlying operation on timeout", async () => {
+	vi.useFakeTimers();
+	try {
+		const fake = createFakeConnection();
+		const manager = new MCPManager(process.cwd());
+
+		const toolsData: CustomTool[] = [
+			{
+				name: "test_tool",
+				label: "Test Tool",
+				description: "A test tool",
+				strict: false,
+				mcpToolName: "test_tool",
+				mcpServerName: "test-server",
+				parameters: { type: "object", properties: {} },
+				execute: async () => ({ content: [] }),
+			} as CustomTool,
+		];
+
+		vi.spyOn(manager, "getTools").mockReturnValue(toolsData);
+		vi.spyOn(manager, "waitForConnection").mockResolvedValue(fake.connection);
+
+		const tools = createMCPProxyTools(manager);
+		const proxyTool = tools[0];
+		if (!proxyTool?.execute) {
+			expect.unreachable("Tool execute method missing");
+			return;
+		}
+
+		const executePromise = proxyTool.execute("call_1", {}, () => {}, {} as CustomToolContext, undefined);
+
+		// Let the promise reach transport.request
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(fake.requestCalled()).toBe(true);
+		const capturedSignal = fake.getCapturedSignal();
+		expect(capturedSignal).toBeDefined();
+		if (!capturedSignal) return;
+		expect(capturedSignal.aborted).toBe(false);
+
+		// MCP_CALL_TIMEOUT_MS is 60_000
+		vi.advanceTimersByTime(65_000);
+
+		// On timeout, the tool returns an error content array rather than throwing ToolAbortError
+		const result = await executePromise;
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type !== "text") {
+			expect.unreachable("Expected text content block");
+			return;
+		}
+		expect(result.content[0].text).toContain("MCP error: MCP tool call timed out");
+
+		expect(capturedSignal.aborted).toBe(true);
+	} finally {
+		vi.useRealTimers();
+	}
+});


### PR DESCRIPTION
Closes #4242

## Problem
`withAbortTimeout` in `packages/coding-agent/src/task/executor.ts` rejected after `MCP_CALL_TIMEOUT_MS` but did not abort the wrapped `waitForConnection` / `callTool` work. When the timeout fired, the inner MCP promises continued running, leaking pending connections.

## Change
- Added an optional `timeoutController?: AbortController` parameter to `withAbortTimeout`.
- In `createMCPProxyTools.execute`, create a per-call `AbortController`, combine its signal with the caller signal via `AbortSignal.any`, and pass the combined signal to `waitForConnection` (through `untilAborted`) and `callTool`.
- Pass the same `timeoutController` to `withAbortTimeout`, which now aborts it both on timeout and on caller abort, so the underlying MCP request is torn down in both paths.

## Verification
- `bun build packages/coding-agent/src/task/executor.ts --target=bun --format=esm --outdir=/tmp/executor-check` succeeded.
- `bun test packages/coding-agent/test/task-executor-mcp-timeout.test.ts` passed (2 tests, caller-abort and timeout-abort paths).