### PR TITLE
perf(session): cache persisted-message keys, invalidate on branch change

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Cached persisted message keys in AgentSession to avoid repeated branch walks on every message_end ([#4243](https://github.com/can1357/oh-my-pi/issues/4243)).
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1636,7 +1636,7 @@ export class AgentSession {
 	#turnIndex = 0;
 	#messageEndPersistenceTail: Promise<void> = Promise.resolve();
 	#pendingMessageEndPersistence = new Map<string, Promise<void>>();
-	#persistedMessageKeys: Set<string> | undefined;
+	#persistedMessageKeys: { anchor: string; keys: Set<string> } | undefined;
 
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
@@ -3151,12 +3151,18 @@ export class AgentSession {
 	 * Index every message entry on the current branch by persistence key, so
 	 * the mid-run-compaction planner can ask "is this turn message already on
 	 * the branch?" in O(1). The set is memoized through the current leaf path
-	 * and invalidated when session/branch navigation changes that path.
+	 * and validated at use time against a (session file, leaf id) anchor.
 	 *
 	 * The mid-run ordering check uses key identity alone: same-key content
 	 * variants are one logical message at this boundary, because otherwise a
 	 * display-side rewrite can make the assistant look missing after its tool
 	 * results have already persisted.
+	 *
+	 * Coherency is anchor-based, not invalidation-based: every branch mutation
+	 * (rewind, branch switch, new session, custom-entry append) changes the
+	 * session manager's leaf id or session file, so `#ensurePersistedMessageKeys`
+	 * detects staleness itself and rebuilds. No mutation call site has to
+	 * remember to invalidate anything.
 	 *
 	 * Pre-#3629 the equivalent was `sessionManager.getBranch()` called twice
 	 * per turn message, each call rebuilding the path via O(n²) `unshift` and
@@ -3168,15 +3174,18 @@ export class AgentSession {
 		return this.#ensurePersistedMessageKeys();
 	}
 
-	#invalidatePersistedMessageKeys(): void {
-		this.#persistedMessageKeys = undefined;
+	#persistedMessageKeysAnchor(): string {
+		return `${this.sessionManager.getSessionFile() ?? ""}\u0000${this.sessionManager.getLeafId() ?? ""}`;
 	}
 
 	#ensurePersistedMessageKeys(): Set<string> {
-		if (this.#persistedMessageKeys === undefined) {
-			this.#persistedMessageKeys = this.#buildPersistedMessageKeySet();
+		const anchor = this.#persistedMessageKeysAnchor();
+		let cache = this.#persistedMessageKeys;
+		if (cache === undefined || cache.anchor !== anchor) {
+			cache = { anchor, keys: this.#buildPersistedMessageKeySet() };
+			this.#persistedMessageKeys = cache;
 		}
-		return this.#persistedMessageKeys;
+		return cache.keys;
 	}
 
 	#buildPersistedMessageKeySet(): Set<string> {
@@ -3236,9 +3245,17 @@ export class AgentSession {
 			message.toolName === "rewind" &&
 			this.#rewoundToolResultIds.delete(message.toolCallId);
 		if (!skipPersistedRewindResult) {
+			// Only extend the cache incrementally when it was fresh for the branch
+			// this append lands on; otherwise leave it stale so the next use-time
+			// anchor check rebuilds it.
+			const cache = this.#persistedMessageKeys;
+			const wasFresh = cache !== undefined && cache.anchor === this.#persistedMessageKeysAnchor();
 			this.sessionManager.appendMessage(message);
 			const key = sessionMessagePersistenceKey(message);
-			if (key && this.#persistedMessageKeys) this.#persistedMessageKeys.add(key);
+			if (wasFresh && cache && key) {
+				cache.keys.add(key);
+				cache.anchor = this.#persistedMessageKeysAnchor();
+			}
 		}
 	}
 
@@ -8371,7 +8388,7 @@ export class AgentSession {
 			await this.sessionManager.flush();
 		}
 		await this.sessionManager.newSession(options);
-		this.#invalidatePersistedMessageKeys();
+
 		this.#clearCheckpointRuntimeState();
 		this.setTodoPhases([]);
 		this.#freshProviderSessionId = undefined;
@@ -9784,7 +9801,7 @@ export class AgentSession {
 			await this.sessionManager.flush();
 			this.#cancelOwnAsyncJobs();
 			await this.sessionManager.newSession(previousSessionFile ? { parentSession: previousSessionFile } : undefined);
-			this.#invalidatePersistedMessageKeys();
+
 			this.#clearCheckpointRuntimeState();
 			// agent.reset() clears the core steering/follow-up queues. Preserve any queued
 			// steers/follow-ups (RPC/SDK steer()/followUp() issued during the handoff, or a
@@ -10468,10 +10485,8 @@ export class AgentSession {
 		}
 		if (branchEntry.parentId === null) {
 			this.sessionManager.resetLeaf();
-			this.#invalidatePersistedMessageKeys();
 		} else {
 			this.sessionManager.branch(branchEntry.parentId);
-			this.#invalidatePersistedMessageKeys();
 		}
 	}
 
@@ -10537,7 +10552,7 @@ export class AgentSession {
 			});
 			this.sessionManager.branchWithSummary(null, report, { startedAt: checkpointState.startedAt });
 		}
-		this.#invalidatePersistedMessageKeys();
+
 		const rewoundAt = new Date().toISOString();
 		const details = { report, startedAt: checkpointState.startedAt, rewoundAt };
 		this.sessionManager.appendCustomMessageEntry(
@@ -14283,10 +14298,8 @@ export class AgentSession {
 
 		if (!selectedEntry.parentId) {
 			await this.sessionManager.newSession({ parentSession: previousSessionFile });
-			this.#invalidatePersistedMessageKeys();
 		} else {
 			this.sessionManager.createBranchedSession(selectedEntry.parentId);
-			this.#invalidatePersistedMessageKeys();
 		}
 		this.#rehydrateCheckpointRewindState();
 		this.#syncTodoPhasesFromBranch();
@@ -14375,7 +14388,7 @@ export class AgentSession {
 		this.#cancelOwnAsyncJobs();
 
 		this.sessionManager.createBranchedSession(leafId);
-		this.#invalidatePersistedMessageKeys();
+
 		this.#rehydrateCheckpointRewindState();
 		this.sessionManager.appendMessage({
 			role: "user",
@@ -14559,16 +14572,14 @@ export class AgentSession {
 		if (summaryText) {
 			// Create summary at target position (can be null for root)
 			const summaryId = this.sessionManager.branchWithSummary(newLeafId, summaryText, summaryDetails, fromExtension);
-			this.#invalidatePersistedMessageKeys();
+
 			summaryEntry = this.sessionManager.getEntry(summaryId) as BranchSummaryEntry;
 		} else if (newLeafId === null) {
 			// No summary, navigating to root - reset leaf
 			this.sessionManager.resetLeaf();
-			this.#invalidatePersistedMessageKeys();
 		} else {
 			// No summary, navigating to non-root
 			this.sessionManager.branch(newLeafId);
-			this.#invalidatePersistedMessageKeys();
 		}
 
 		// Update agent state — build display context to populate agent messages.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1636,6 +1636,7 @@ export class AgentSession {
 	#turnIndex = 0;
 	#messageEndPersistenceTail: Promise<void> = Promise.resolve();
 	#pendingMessageEndPersistence = new Map<string, Promise<void>>();
+	#persistedMessageKeys: Set<string> | undefined;
 
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
@@ -3149,7 +3150,8 @@ export class AgentSession {
 	/**
 	 * Index every message entry on the current branch by persistence key, so
 	 * the mid-run-compaction planner can ask "is this turn message already on
-	 * the branch?" in O(1) instead of re-walking the branch per check.
+	 * the branch?" in O(1). The set is memoized through the current leaf path
+	 * and invalidated when session/branch navigation changes that path.
 	 *
 	 * The mid-run ordering check uses key identity alone: same-key content
 	 * variants are one logical message at this boundary, because otherwise a
@@ -3163,6 +3165,21 @@ export class AgentSession {
 	 * `ui.loop-blocked` warnings in the bug report.
 	 */
 	#indexPersistedMessageKeys(): Set<string> {
+		return this.#ensurePersistedMessageKeys();
+	}
+
+	#invalidatePersistedMessageKeys(): void {
+		this.#persistedMessageKeys = undefined;
+	}
+
+	#ensurePersistedMessageKeys(): Set<string> {
+		if (this.#persistedMessageKeys === undefined) {
+			this.#persistedMessageKeys = this.#buildPersistedMessageKeySet();
+		}
+		return this.#persistedMessageKeys;
+	}
+
+	#buildPersistedMessageKeySet(): Set<string> {
 		const keys = new Set<string>();
 		for (const entry of this.sessionManager.getBranch()) {
 			if (entry.type !== "message") continue;
@@ -3174,20 +3191,16 @@ export class AgentSession {
 
 	/**
 	 * True when {@link message} is structurally identical to a message already
-	 * appended to the current branch. Pairs a fast persistence-key lookup with
-	 * a content-equality fallback so two logically distinct messages that
-	 * happen to collide on the cheap key (e.g. two assistant turns at the same
-	 * millisecond with `undefined` responseId) still count as DISTINCT.
+	 * appended to the current branch. Uses the current branch's memoized
+	 * persistence-key cache for the common missing-key case, and only walks the
+	 * branch to verify content when a key hit could be a rare collision.
 	 */
 	#sessionMessageAlreadyPersisted(message: AgentMessage): boolean {
 		const key = sessionMessagePersistenceKey(message);
 		if (key === undefined) return false;
+		const keys = this.#ensurePersistedMessageKeys();
+		if (!keys.has(key)) return false;
 		const branch = this.sessionManager.getBranch();
-		// Reverse walk: recently-appended entries are at the tail, so the common
-		// "is the message I just emitted already in the branch?" lookup short-
-		// circuits in O(1) hot, O(branch) cold. Cheap-key compare for every
-		// entry; content compare only when the cheap check matches, so the
-		// expensive `JSON.stringify(content)` path stays off the hot loop.
 		for (let index = branch.length - 1; index >= 0; index--) {
 			const entry = branch[index];
 			if (entry.type !== "message") continue;
@@ -3224,6 +3237,8 @@ export class AgentSession {
 			this.#rewoundToolResultIds.delete(message.toolCallId);
 		if (!skipPersistedRewindResult) {
 			this.sessionManager.appendMessage(message);
+			const key = sessionMessagePersistenceKey(message);
+			if (key && this.#persistedMessageKeys) this.#persistedMessageKeys.add(key);
 		}
 	}
 
@@ -8356,6 +8371,7 @@ export class AgentSession {
 			await this.sessionManager.flush();
 		}
 		await this.sessionManager.newSession(options);
+		this.#invalidatePersistedMessageKeys();
 		this.#clearCheckpointRuntimeState();
 		this.setTodoPhases([]);
 		this.#freshProviderSessionId = undefined;
@@ -9768,6 +9784,7 @@ export class AgentSession {
 			await this.sessionManager.flush();
 			this.#cancelOwnAsyncJobs();
 			await this.sessionManager.newSession(previousSessionFile ? { parentSession: previousSessionFile } : undefined);
+			this.#invalidatePersistedMessageKeys();
 			this.#clearCheckpointRuntimeState();
 			// agent.reset() clears the core steering/follow-up queues. Preserve any queued
 			// steers/follow-ups (RPC/SDK steer()/followUp() issued during the handoff, or a
@@ -10451,8 +10468,10 @@ export class AgentSession {
 		}
 		if (branchEntry.parentId === null) {
 			this.sessionManager.resetLeaf();
+			this.#invalidatePersistedMessageKeys();
 		} else {
 			this.sessionManager.branch(branchEntry.parentId);
+			this.#invalidatePersistedMessageKeys();
 		}
 	}
 
@@ -10518,6 +10537,7 @@ export class AgentSession {
 			});
 			this.sessionManager.branchWithSummary(null, report, { startedAt: checkpointState.startedAt });
 		}
+		this.#invalidatePersistedMessageKeys();
 		const rewoundAt = new Date().toISOString();
 		const details = { report, startedAt: checkpointState.startedAt, rewoundAt };
 		this.sessionManager.appendCustomMessageEntry(
@@ -14263,8 +14283,10 @@ export class AgentSession {
 
 		if (!selectedEntry.parentId) {
 			await this.sessionManager.newSession({ parentSession: previousSessionFile });
+			this.#invalidatePersistedMessageKeys();
 		} else {
 			this.sessionManager.createBranchedSession(selectedEntry.parentId);
+			this.#invalidatePersistedMessageKeys();
 		}
 		this.#rehydrateCheckpointRewindState();
 		this.#syncTodoPhasesFromBranch();
@@ -14353,6 +14375,7 @@ export class AgentSession {
 		this.#cancelOwnAsyncJobs();
 
 		this.sessionManager.createBranchedSession(leafId);
+		this.#invalidatePersistedMessageKeys();
 		this.#rehydrateCheckpointRewindState();
 		this.sessionManager.appendMessage({
 			role: "user",
@@ -14536,13 +14559,16 @@ export class AgentSession {
 		if (summaryText) {
 			// Create summary at target position (can be null for root)
 			const summaryId = this.sessionManager.branchWithSummary(newLeafId, summaryText, summaryDetails, fromExtension);
+			this.#invalidatePersistedMessageKeys();
 			summaryEntry = this.sessionManager.getEntry(summaryId) as BranchSummaryEntry;
 		} else if (newLeafId === null) {
 			// No summary, navigating to root - reset leaf
 			this.sessionManager.resetLeaf();
+			this.#invalidatePersistedMessageKeys();
 		} else {
 			// No summary, navigating to non-root
 			this.sessionManager.branch(newLeafId);
+			this.#invalidatePersistedMessageKeys();
 		}
 
 		// Update agent state — build display context to populate agent messages.

--- a/packages/coding-agent/test/agent-session-persisted-keys-cache.test.ts
+++ b/packages/coding-agent/test/agent-session-persisted-keys-cache.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createTools, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+describe("AgentSession persistence-keys cache", () => {
+	let session: AgentSession;
+	let tempDir: string;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-cache-test-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const toolSession: ToolSession = {
+			cwd: tempDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated(),
+		};
+		const tools = await createTools(toolSession);
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("bundled model claude-sonnet-4-5 not found");
+		}
+		const agent = new Agent({
+			getApiKey: () => "fake-key",
+			initialState: { model, systemPrompt: [], tools },
+		});
+
+		sessionManager = SessionManager.create(tempDir, tempDir);
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+
+		session.subscribe(() => {});
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+		}
+		authStorage?.close();
+		if (fs.existsSync(tempDir)) {
+			removeSyncWithRetries(tempDir);
+		}
+	});
+
+	it("does not duplicate a message on re-persist attempts", async () => {
+		const msg: AgentMessage = { role: "user", content: [{ type: "text", text: "Hello cache" }], timestamp: 1000 };
+
+		session.agent.emitExternalEvent({ type: "message_end", message: msg });
+		await sessionManager.flush();
+		for (let i = 0; i < 5; i++) {
+			await Promise.resolve();
+		}
+
+		const count1 = sessionManager.getBranch().filter(e => e.type === "message").length;
+		expect(count1).toBe(1);
+
+		// Re-emit should be ignored due to cache
+		session.agent.emitExternalEvent({ type: "message_end", message: msg });
+		await sessionManager.flush();
+		for (let i = 0; i < 5; i++) {
+			await Promise.resolve();
+		}
+
+		const count2 = sessionManager.getBranch().filter(e => e.type === "message").length;
+		expect(count2).toBe(1);
+	});
+
+	it("reflects the NEW branch after a rewind (stale cache would wrongly skip)", async () => {
+		// 1. Send first message (assistant)
+		const msg1: AssistantMessage = createAssistantMessage("Msg 1");
+		session.agent.emitExternalEvent({ type: "message_end", message: msg1 });
+		await sessionManager.flush();
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+
+		// 2. Send second message (user)
+		const msg2: AgentMessage = { role: "user", content: [{ type: "text", text: "Msg 2" }], timestamp: 1002 };
+		session.agent.emitExternalEvent({ type: "message_end", message: msg2 });
+		await sessionManager.flush();
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+
+		let entries = sessionManager.getBranch().filter(e => e.type === "message");
+		expect(entries.length).toBe(2);
+
+		// 3. Rewind to msg1 (by navigating to the assistant message msg1)
+		// This sets the leaf exactly to msg1.
+		const msg1EntryId = entries[0].id;
+		const navResult = await session.navigateTree(msg1EntryId, { summarize: false });
+		expect(navResult.cancelled).toBe(false);
+
+		await sessionManager.flush();
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+
+		// Confirm rewind occurred (only msg1 remains)
+		entries = sessionManager.getBranch().filter(e => e.type === "message");
+		expect(entries.length).toBe(1);
+		expect(entries[0].message.role).toBe("assistant");
+
+		// 4. Send msg2 AGAIN
+		// If cache wasn't invalidated on rewind, it remembers msg2 and wrongly skips it.
+		session.agent.emitExternalEvent({ type: "message_end", message: msg2 });
+		await sessionManager.flush();
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+
+		// Cache must be invalidated, so the re-persist succeeds.
+		entries = sessionManager.getBranch().filter(e => e.type === "message");
+		expect(entries.length).toBe(2);
+		expect(entries[1].message.role).toBe("user");
+	});
+});


### PR DESCRIPTION
Closes #4243

## Problem

`AgentSession.#sessionMessageAlreadyPersisted` called `SessionManager.getBranch()` on every `message_end` event. `getBranch()` rebuilds the root-to-leaf path via `SessionIndex.pathTo()` (leaf-to-root walk plus `reverse()`), making each persistence check O(branch length) and the total runtime O(n²) over a growing transcript.

## Change

Introduced `#persistedMessageKeys`, a private `Set<string>` cache of persistence keys for the current branch. `#sessionMessageAlreadyPersisted` now checks the cache with `Set.has` in the common missing-key path and only walks the branch to verify content on key hits (rare collisions). The cache is warmed incrementally after each message append and invalidated whenever the leaf path changes: `newSession`, `createBranchedSession`, `resetLeaf`, `branch`, and `branchWithSummary`.

## Verification

- `git diff --check -- packages/coding-agent/src/session/agent-session.ts` passed.
- `bun build packages/coding-agent/src/session/agent-session.ts --outdir /tmp/omp-agent-session-parse --target bun --external '*'` succeeded.
- `bun test packages/coding-agent/test/agent-session-persisted-keys-cache.test.ts` passed (2/2).