### PR TITLE
fix(eval): surface unexpected JS eval worker exit via close listener

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Surface unexpected JS eval worker exit via close listener to prevent silent hangs on worker death ([#4244](https://github.com/can1357/oh-my-pi/issues/4244))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -509,11 +509,14 @@ function wrapBunWorker(worker: Worker): WorkerHandle {
 			const onError = (event: ErrorEvent): void => handler(errorFromWorkerEvent(event));
 			const onMessageError = (event: MessageEvent): void =>
 				handler(new ToolError(`JS eval worker message error: ${String(event.data)}`));
+			const onClose = (): void => handler(new Error("JS eval worker exited"));
 			worker.addEventListener("error", onError);
 			worker.addEventListener("messageerror", onMessageError);
+			worker.addEventListener("close", onClose);
 			return () => {
 				worker.removeEventListener("error", onError);
 				worker.removeEventListener("messageerror", onMessageError);
+				worker.removeEventListener("close", onClose);
 			};
 		},
 		async close() {


### PR DESCRIPTION
Closes #4244

## Problem
`wrapBunWorker` only listened for `error` and `messageerror` during normal operation; a `close` listener was added only inside `close()`. Clean worker exits (e.g., `process.exit(0)` in an eval cell) emitted `close` with no handler, leaving `runOnce` pending until the cell timeout.

## Change
Added a normal-operation `close` listener in `wrapBunWorker.onError` (`packages/coding-agent/src/eval/js/context-manager.ts`) that forwards `new Error("JS eval worker exited")` through the existing error handler path. The listener is removed in the returned unsubscribe callback. The Bun Worker `close` event type was verified against `node_modules/bun-types` before use.

## Verification
- `bun run check:types` passes.
- `bun test test/tools/eval-*.test.ts test/core/eval-workflow-helpers.integration.test.ts` passes: 32 pass, 0 fail.