### PR TITLE
perf(export): skip TTSR delta buffering when no rule matches text/thinking

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Skip TTSR delta buffering for text/thinking sources when no registered rule can match them ([#4245](https://github.com/can1357/oh-my-pi/issues/4245))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -77,6 +77,8 @@ export class TtsrManager {
 	/** Last snapshot evaluated for AST conditions, keyed by stream key, to dedupe matcher runs. */
 	readonly #lastAstSnapshots = new Map<string, string>();
 	#messageCount = 0;
+	#canMatchText = false;
+	#canMatchThinking = false;
 
 	constructor(settings?: TtsrSettings) {
 		this.#settings = { ...DEFAULT_SETTINGS, ...settings };
@@ -329,6 +331,8 @@ export class TtsrManager {
 			scope,
 			globalPathGlobs,
 		});
+		if (scope.allowText) this.#canMatchText = true;
+		if (scope.allowThinking) this.#canMatchThinking = true;
 
 		logger.debug("TTSR rule registered", {
 			ruleName: rule.name,
@@ -348,6 +352,12 @@ export class TtsrManager {
 	 * assistant prose, thinking text, and unrelated tool argument streams.
 	 */
 	checkDelta(delta: string, context: TtsrMatchContext): Rule[] {
+		if (context.source === "text" && !this.#canMatchText) {
+			return [];
+		}
+		if (context.source === "thinking" && !this.#canMatchThinking) {
+			return [];
+		}
 		const bufferKey = this.#bufferKey(context);
 		const nextBuffer = `${this.#buffers.get(bufferKey) ?? ""}${delta}`;
 		this.#buffers.set(bufferKey, nextBuffer);


### PR DESCRIPTION
Closes #4245

## Problem

`TtsrManager.checkDelta` in `packages/coding-agent/src/export/ttsr.ts` concatenated the full stream buffer on every `text_delta` and `thinking_delta` before scope filtering in `#matchBuffer`. This cost O(n) copies per delta and O(n²) total time for long streams, even when every registered rule was tool-scoped and could never match text/thinking content.

## Change

Added `#canMatchText` and `#canMatchThinking` internal flags. They are set only after a rule is successfully registered from a scope that allows the corresponding source. `checkDelta` now returns an empty match array before computing the buffer key or concatenating strings when the incoming `context.source` is text or thinking and no registered rule can match that source. Tool-argument deltas still follow the original buffered path.

## Verification

Verified by re-reading the modified ranges in `packages/coding-agent/src/export/ttsr.ts`. No typecheck or test suites were run per campaign constraints.