### PR TITLE
perf(hindsight): cache full-session retention transcript incrementally

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Cache full-session retention transcript incrementally instead of re-formatting the entire message history on every retain cycle ([#4246](https://github.com/can1357/oh-my-pi/issues/4246))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -187,6 +187,11 @@ export class HindsightRetainQueue {
 	}
 }
 
+/** Stable fingerprint of a retention-cache boundary message (see #lastRetainedBoundaryKey). */
+function retentionBoundaryKey(message: HindsightMessage): string {
+	return Bun.hash(`${message.role}\u0000${message.content}`).toString(36);
+}
+
 /** Per-session Hindsight runtime state owned by its AgentSession. */
 export class HindsightSessionState {
 	/** Session id used for retain-queue metadata. */
@@ -204,6 +209,13 @@ export class HindsightSessionState {
 	lastRetainedTurn: number;
 	#lastRetainedMessageIndex: number = 0;
 	#cachedTranscript: string = "";
+	// Fingerprint of messages[#lastRetainedMessageIndex - 1] at cache time. The
+	// incremental full-session cache assumes the branch is append-only; a rewind,
+	// branch switch, or compaction rewrites the prefix without changing the
+	// session id. Verifying the boundary message at use time makes the cache
+	// self-healing: on mismatch (or shrink) we rebuild the full transcript
+	// instead of retaining stale content or silently retaining nothing forever.
+	#lastRetainedBoundaryKey: string = "";
 	hasRecalledForFirstTurn: boolean;
 	lastRecallSnippet?: string;
 	/** Cached `<mental_models>` block injected into developer instructions. */
@@ -240,6 +252,7 @@ export class HindsightSessionState {
 		this.lastRetainedTurn = options.lastRetainedTurn ?? 0;
 		this.#lastRetainedMessageIndex = 0;
 		this.#cachedTranscript = "";
+		this.#lastRetainedBoundaryKey = "";
 		this.hasRecalledForFirstTurn = options.hasRecalledForFirstTurn ?? false;
 		this.aliasOf = options.aliasOf;
 		this.retainQueue = new HindsightRetainQueue(this);
@@ -249,6 +262,7 @@ export class HindsightSessionState {
 		this.sessionId = sessionId;
 		this.#lastRetainedMessageIndex = 0;
 		this.#cachedTranscript = "";
+		this.#lastRetainedBoundaryKey = "";
 	}
 
 	resetConversationTracking(): void {
@@ -257,6 +271,7 @@ export class HindsightSessionState {
 		this.lastRecallSnippet = undefined;
 		this.#lastRetainedMessageIndex = 0;
 		this.#cachedTranscript = "";
+		this.#lastRetainedBoundaryKey = "";
 	}
 
 	enqueueRetain(content: string, context?: string): void {
@@ -299,6 +314,16 @@ export class HindsightSessionState {
 
 		if (retainFullWindow) {
 			documentId = this.sessionId;
+			const boundary = this.#lastRetainedMessageIndex;
+			const boundaryMessage = boundary > 0 ? messages[boundary - 1] : undefined;
+			if (
+				boundary > messages.length ||
+				(boundaryMessage !== undefined && retentionBoundaryKey(boundaryMessage) !== this.#lastRetainedBoundaryKey)
+			) {
+				this.#lastRetainedMessageIndex = 0;
+				this.#cachedTranscript = "";
+				this.#lastRetainedBoundaryKey = "";
+			}
 			const newMessages = messages.slice(this.#lastRetainedMessageIndex);
 			const { transcript: newPart } = prepareRetentionTranscript(newMessages, true);
 			if (!newPart) return;
@@ -310,6 +335,7 @@ export class HindsightSessionState {
 			documentId = `${this.sessionId}-${retainedAt.getTime()}`;
 			this.#lastRetainedMessageIndex = 0;
 			this.#cachedTranscript = "";
+			this.#lastRetainedBoundaryKey = "";
 			const { transcript: windowTranscript } = prepareRetentionTranscript(target, true);
 			if (!windowTranscript) return;
 			transcript = windowTranscript;
@@ -327,6 +353,8 @@ export class HindsightSessionState {
 		if (nextCachedTranscript !== undefined) {
 			this.#cachedTranscript = nextCachedTranscript;
 			this.#lastRetainedMessageIndex = messages.length;
+			const last = messages[messages.length - 1];
+			this.#lastRetainedBoundaryKey = last === undefined ? "" : retentionBoundaryKey(last);
 		}
 	}
 

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -187,9 +187,15 @@ export class HindsightRetainQueue {
 	}
 }
 
-/** Stable fingerprint of a retention-cache boundary message (see #lastRetainedBoundaryKey). */
-function retentionBoundaryKey(message: HindsightMessage): string {
-	return Bun.hash(`${message.role}\u0000${message.content}`).toString(36);
+/** Rolling hash of messages[0, count) for retention-cache validation (see #lastRetainedPrefixKey). */
+function retentionPrefixKey(messages: HindsightMessage[], count: number): string {
+	let key = "";
+	for (let i = 0; i < count; i++) {
+		const m = messages[i];
+		if (m === undefined) break;
+		key = Bun.hash(`${key}\u0000${m.role}\u0000${m.content}`).toString(36);
+	}
+	return key;
 }
 
 /** Per-session Hindsight runtime state owned by its AgentSession. */
@@ -209,13 +215,15 @@ export class HindsightSessionState {
 	lastRetainedTurn: number;
 	#lastRetainedMessageIndex: number = 0;
 	#cachedTranscript: string = "";
-	// Fingerprint of messages[#lastRetainedMessageIndex - 1] at cache time. The
-	// incremental full-session cache assumes the branch is append-only; a rewind,
-	// branch switch, or compaction rewrites the prefix without changing the
-	// session id. Verifying the boundary message at use time makes the cache
-	// self-healing: on mismatch (or shrink) we rebuild the full transcript
-	// instead of retaining stale content or silently retaining nothing forever.
-	#lastRetainedBoundaryKey: string = "";
+	// Rolling hash of ALL messages in [0, #lastRetainedMessageIndex) at cache
+	// time. The incremental full-session cache assumes the branch is append-only;
+	// a rewind, branch switch, compaction, or in-place edit rewrites the prefix
+	// without changing the session id. Re-hashing the current prefix at use time
+	// makes the cache self-healing: on ANY prefix change (not just the boundary
+	// message) we rebuild the full transcript instead of retaining stale content
+	// or silently retaining nothing forever. Hashing is orders of magnitude
+	// cheaper than the re-formatting this cache avoids.
+	#lastRetainedPrefixKey: string = "";
 	hasRecalledForFirstTurn: boolean;
 	lastRecallSnippet?: string;
 	/** Cached `<mental_models>` block injected into developer instructions. */
@@ -252,7 +260,7 @@ export class HindsightSessionState {
 		this.lastRetainedTurn = options.lastRetainedTurn ?? 0;
 		this.#lastRetainedMessageIndex = 0;
 		this.#cachedTranscript = "";
-		this.#lastRetainedBoundaryKey = "";
+		this.#lastRetainedPrefixKey = "";
 		this.hasRecalledForFirstTurn = options.hasRecalledForFirstTurn ?? false;
 		this.aliasOf = options.aliasOf;
 		this.retainQueue = new HindsightRetainQueue(this);
@@ -262,7 +270,7 @@ export class HindsightSessionState {
 		this.sessionId = sessionId;
 		this.#lastRetainedMessageIndex = 0;
 		this.#cachedTranscript = "";
-		this.#lastRetainedBoundaryKey = "";
+		this.#lastRetainedPrefixKey = "";
 	}
 
 	resetConversationTracking(): void {
@@ -271,7 +279,7 @@ export class HindsightSessionState {
 		this.lastRecallSnippet = undefined;
 		this.#lastRetainedMessageIndex = 0;
 		this.#cachedTranscript = "";
-		this.#lastRetainedBoundaryKey = "";
+		this.#lastRetainedPrefixKey = "";
 	}
 
 	enqueueRetain(content: string, context?: string): void {
@@ -315,14 +323,10 @@ export class HindsightSessionState {
 		if (retainFullWindow) {
 			documentId = this.sessionId;
 			const boundary = this.#lastRetainedMessageIndex;
-			const boundaryMessage = boundary > 0 ? messages[boundary - 1] : undefined;
-			if (
-				boundary > messages.length ||
-				(boundaryMessage !== undefined && retentionBoundaryKey(boundaryMessage) !== this.#lastRetainedBoundaryKey)
-			) {
+			if (boundary > messages.length || retentionPrefixKey(messages, boundary) !== this.#lastRetainedPrefixKey) {
 				this.#lastRetainedMessageIndex = 0;
 				this.#cachedTranscript = "";
-				this.#lastRetainedBoundaryKey = "";
+				this.#lastRetainedPrefixKey = "";
 			}
 			const newMessages = messages.slice(this.#lastRetainedMessageIndex);
 			const { transcript: newPart } = prepareRetentionTranscript(newMessages, true);
@@ -335,7 +339,7 @@ export class HindsightSessionState {
 			documentId = `${this.sessionId}-${retainedAt.getTime()}`;
 			this.#lastRetainedMessageIndex = 0;
 			this.#cachedTranscript = "";
-			this.#lastRetainedBoundaryKey = "";
+			this.#lastRetainedPrefixKey = "";
 			const { transcript: windowTranscript } = prepareRetentionTranscript(target, true);
 			if (!windowTranscript) return;
 			transcript = windowTranscript;
@@ -353,8 +357,7 @@ export class HindsightSessionState {
 		if (nextCachedTranscript !== undefined) {
 			this.#cachedTranscript = nextCachedTranscript;
 			this.#lastRetainedMessageIndex = messages.length;
-			const last = messages[messages.length - 1];
-			this.#lastRetainedBoundaryKey = last === undefined ? "" : retentionBoundaryKey(last);
+			this.#lastRetainedPrefixKey = retentionPrefixKey(messages, messages.length);
 		}
 	}
 

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -202,6 +202,8 @@ export class HindsightSessionState {
 	session: AgentSession;
 	banksSet: Set<string>;
 	lastRetainedTurn: number;
+	#lastRetainedMessageIndex: number = 0;
+	#cachedTranscript: string = "";
 	hasRecalledForFirstTurn: boolean;
 	lastRecallSnippet?: string;
 	/** Cached `<mental_models>` block injected into developer instructions. */
@@ -236,6 +238,8 @@ export class HindsightSessionState {
 		this.session = options.session;
 		this.banksSet = options.banksSet;
 		this.lastRetainedTurn = options.lastRetainedTurn ?? 0;
+		this.#lastRetainedMessageIndex = 0;
+		this.#cachedTranscript = "";
 		this.hasRecalledForFirstTurn = options.hasRecalledForFirstTurn ?? false;
 		this.aliasOf = options.aliasOf;
 		this.retainQueue = new HindsightRetainQueue(this);
@@ -243,12 +247,16 @@ export class HindsightSessionState {
 
 	setSessionId(sessionId: string): void {
 		this.sessionId = sessionId;
+		this.#lastRetainedMessageIndex = 0;
+		this.#cachedTranscript = "";
 	}
 
 	resetConversationTracking(): void {
 		this.lastRetainedTurn = 0;
 		this.hasRecalledForFirstTurn = false;
 		this.lastRecallSnippet = undefined;
+		this.#lastRetainedMessageIndex = 0;
+		this.#cachedTranscript = "";
 	}
 
 	enqueueRetain(content: string, context?: string): void {
@@ -285,20 +293,27 @@ export class HindsightSessionState {
 	async retainSession(messages: HindsightMessage[]): Promise<void> {
 		const retainedAt = new Date();
 		const retainFullWindow = this.config.retainMode === "full-session";
-		let target: HindsightMessage[];
 		let documentId: string;
+		let transcript: string;
+		let nextCachedTranscript: string | undefined;
 
 		if (retainFullWindow) {
-			target = messages;
 			documentId = this.sessionId;
+			const newMessages = messages.slice(this.#lastRetainedMessageIndex);
+			const { transcript: newPart } = prepareRetentionTranscript(newMessages, true);
+			if (!newPart) return;
+			nextCachedTranscript = this.#cachedTranscript ? `${this.#cachedTranscript}\n\n${newPart}` : newPart;
+			transcript = nextCachedTranscript;
 		} else {
 			const windowTurns = this.config.retainEveryNTurns + this.config.retainOverlapTurns;
-			target = sliceLastTurnsByUserBoundary(messages, windowTurns);
+			const target = sliceLastTurnsByUserBoundary(messages, windowTurns);
 			documentId = `${this.sessionId}-${retainedAt.getTime()}`;
+			this.#lastRetainedMessageIndex = 0;
+			this.#cachedTranscript = "";
+			const { transcript: windowTranscript } = prepareRetentionTranscript(target, true);
+			if (!windowTranscript) return;
+			transcript = windowTranscript;
 		}
-
-		const { transcript } = prepareRetentionTranscript(target, true);
-		if (!transcript) return;
 
 		await ensureBankExists(this.client, this.bankId, this.config, this.banksSet);
 		await this.client.retain(this.bankId, transcript, {
@@ -309,6 +324,10 @@ export class HindsightSessionState {
 			timestamp: retainedAt,
 			async: true,
 		});
+		if (nextCachedTranscript !== undefined) {
+			this.#cachedTranscript = nextCachedTranscript;
+			this.#lastRetainedMessageIndex = messages.length;
+		}
 	}
 
 	async maybeRetainOnAgentEnd(): Promise<void> {

--- a/packages/coding-agent/test/hindsight-retention-cache.test.ts
+++ b/packages/coding-agent/test/hindsight-retention-cache.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "bun:test";
+import type {
+	BankProfileResponse,
+	CreateBankOptions,
+	RetainOptions,
+	RetainResponse,
+} from "@oh-my-pi/pi-coding-agent/hindsight/client";
+import { HindsightApi } from "@oh-my-pi/pi-coding-agent/hindsight/client";
+import type { HindsightConfig } from "@oh-my-pi/pi-coding-agent/hindsight/config";
+import type { HindsightMessage } from "@oh-my-pi/pi-coding-agent/hindsight/content";
+import { HindsightSessionState } from "@oh-my-pi/pi-coding-agent/hindsight/state";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+const makeConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig => ({
+	hindsightApiUrl: "http://localhost:8888",
+	hindsightApiToken: null,
+	bankId: null,
+	bankIdPrefix: "",
+	scoping: "global",
+	bankMission: "",
+	retainMission: null,
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 3,
+	retainOverlapTurns: 2,
+	retainContext: "omp",
+	recallBudget: "mid",
+	recallMaxTokens: 1024,
+	recallTypes: ["world", "experience"],
+	recallContextTurns: 1,
+	recallMaxQueryChars: 800,
+	recallPromptPreamble: "preamble",
+	debug: false,
+	mentalModelsEnabled: false,
+	mentalModelAutoSeed: false,
+	mentalModelRefreshIntervalMs: 5 * 60 * 1000,
+	mentalModelMaxRenderChars: 16_000,
+	...overrides,
+});
+
+class FakeHindsightApi extends HindsightApi {
+	public calls: { bankId: string; transcript: string; options?: RetainOptions }[] = [];
+
+	constructor() {
+		super({ baseUrl: "http://localhost" });
+	}
+
+	override async createBank(_bankId: string, _options?: CreateBankOptions): Promise<BankProfileResponse> {
+		return {};
+	}
+
+	override async retain(bankId: string, transcript: string, options?: RetainOptions): Promise<RetainResponse> {
+		this.calls.push({ bankId, transcript, options });
+		return {};
+	}
+}
+
+describe("Hindsight incremental full-session retention cache", () => {
+	it("Append-only growth: accumulates transcript content incrementally across successive retains", async () => {
+		const client = new FakeHindsightApi();
+		const config = makeConfig({ retainMode: "full-session" });
+		const session = {
+			sessionId: "test-session",
+		} as object as AgentSession;
+		const banksSet = new Set<string>();
+
+		const state = new HindsightSessionState({
+			sessionId: "test-session",
+			client,
+			bankId: "test-bank",
+			config,
+			session,
+			banksSet,
+		});
+
+		const messages1: HindsightMessage[] = [
+			{ role: "user", content: "hello first turn" },
+			{ role: "assistant", content: "hi there first response" },
+		];
+
+		await state.retainSession(messages1);
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toBe(
+			"[role: user]\nhello first turn\n[user:end]\n\n[role: assistant]\nhi there first response\n[assistant:end]",
+		);
+
+		client.calls = [];
+
+		const messages2: HindsightMessage[] = [
+			...messages1,
+			{ role: "user", content: "hello second turn" },
+			{ role: "assistant", content: "hi there second response" },
+		];
+
+		await state.retainSession(messages2);
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toBe(
+			"[role: user]\nhello first turn\n[user:end]\n\n[role: assistant]\nhi there first response\n[assistant:end]\n\n" +
+				"[role: user]\nhello second turn\n[user:end]\n\n[role: assistant]\nhi there second response\n[assistant:end]",
+		);
+	});
+
+	it("Branch shrink (rewind): self-heals when message list shrinks, rebuilding and retaining full shorter transcript", async () => {
+		const client = new FakeHindsightApi();
+		const config = makeConfig({ retainMode: "full-session" });
+		const session = {
+			sessionId: "test-session",
+		} as object as AgentSession;
+		const banksSet = new Set<string>();
+
+		const state = new HindsightSessionState({
+			sessionId: "test-session",
+			client,
+			bankId: "test-bank",
+			config,
+			session,
+			banksSet,
+		});
+
+		const messages: HindsightMessage[] = [
+			{ role: "user", content: "msg1" },
+			{ role: "assistant", content: "msg2" },
+			{ role: "user", content: "msg3" },
+			{ role: "assistant", content: "msg4" },
+		];
+
+		await state.retainSession(messages);
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toContain("msg1");
+		expect(client.calls[0].transcript).toContain("msg4");
+
+		client.calls = [];
+
+		// Shrink/rewind back to first 2 messages
+		const shorter = messages.slice(0, 2);
+		await state.retainSession(shorter);
+
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toBe(
+			"[role: user]\nmsg1\n[user:end]\n\n[role: assistant]\nmsg2\n[assistant:end]",
+		);
+
+		client.calls = [];
+
+		// Subsequent retain with append works on top of the healed shorter branch
+		const appended = [...shorter, { role: "user", content: "msg3_new" }];
+		await state.retainSession(appended);
+
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toBe(
+			"[role: user]\nmsg1\n[user:end]\n\n[role: assistant]\nmsg2\n[assistant:end]\n\n" +
+				"[role: user]\nmsg3_new\n[user:end]",
+		);
+	});
+
+	it("Branch rewrite at same length: self-heals when tail message is replaced, avoiding stale prefix cache", async () => {
+		const client = new FakeHindsightApi();
+		const config = makeConfig({ retainMode: "full-session" });
+		const session = {
+			sessionId: "test-session",
+		} as object as AgentSession;
+		const banksSet = new Set<string>();
+
+		const state = new HindsightSessionState({
+			sessionId: "test-session",
+			client,
+			bankId: "test-bank",
+			config,
+			session,
+			banksSet,
+		});
+
+		const originalBranch: HindsightMessage[] = [
+			{ role: "user", content: "hello" },
+			{ role: "assistant", content: "original tail" },
+		];
+
+		await state.retainSession(originalBranch);
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toContain("original tail");
+
+		client.calls = [];
+
+		// Rewrite the tail (same length) and add one more message
+		const rewrittenBranch: HindsightMessage[] = [
+			{ role: "user", content: "hello" },
+			{ role: "assistant", content: "rewritten tail" },
+			{ role: "user", content: "next message" },
+		];
+
+		await state.retainSession(rewrittenBranch);
+		expect(client.calls.length).toBe(1);
+
+		// The retained transcript should NOT contain the stale "original tail" prefix,
+		// and must contain "rewritten tail" and "next message"
+		const finalTranscript = client.calls[0].transcript;
+		expect(finalTranscript).not.toContain("original tail");
+		expect(finalTranscript).toContain("rewritten tail");
+		expect(finalTranscript).toContain("next message");
+		expect(finalTranscript).toBe(
+			"[role: user]\nhello\n[user:end]\n\n[role: assistant]\nrewritten tail\n[assistant:end]\n\n" +
+				"[role: user]\nnext message\n[user:end]",
+		);
+	});
+});

--- a/packages/coding-agent/test/hindsight-retention-cache.test.ts
+++ b/packages/coding-agent/test/hindsight-retention-cache.test.ts
@@ -203,4 +203,56 @@ describe("Hindsight incremental full-session retention cache", () => {
 				"[role: user]\nnext message\n[user:end]",
 		);
 	});
+
+	it("rebuilds when an earlier retained message is rewritten but the boundary message is unchanged", async () => {
+		const client = new FakeHindsightApi();
+		const config = makeConfig({ retainMode: "full-session" });
+		const session = {
+			sessionId: "test-session",
+		} as object as AgentSession;
+		const banksSet = new Set<string>();
+
+		const state = new HindsightSessionState({
+			sessionId: "test-session",
+			client,
+			bankId: "test-bank",
+			config,
+			session,
+			banksSet,
+		});
+
+		const messages1: HindsightMessage[] = [
+			{ role: "user", content: "A" },
+			{ role: "assistant", content: "B" },
+			{ role: "user", content: "C" },
+		];
+
+		await state.retainSession(messages1);
+		expect(client.calls.length).toBe(1);
+		expect(client.calls[0].transcript).toBe(
+			"[role: user]\nA\n[user:end]\n\n[role: assistant]\nB\n[assistant:end]\n\n[role: user]\nC\n[user:end]",
+		);
+
+		client.calls = [];
+
+		// Rewrite only message A, keep B and C identical, append new message D
+		const messages2: HindsightMessage[] = [
+			{ role: "user", content: "A_rewritten" },
+			{ role: "assistant", content: "B" },
+			{ role: "user", content: "C" },
+			{ role: "assistant", content: "D" },
+		];
+
+		await state.retainSession(messages2);
+		expect(client.calls.length).toBe(1);
+
+		const finalTranscript = client.calls[0].transcript;
+		expect(finalTranscript).not.toContain("A\n");
+		expect(finalTranscript).toContain("A_rewritten");
+		expect(finalTranscript).toContain("D");
+		expect(finalTranscript).toBe(
+			"[role: user]\nA_rewritten\n[user:end]\n\n[role: assistant]\nB\n[assistant:end]\n\n" +
+				"[role: user]\nC\n[user:end]\n\n[role: assistant]\nD\n[assistant:end]",
+		);
+	});
 });


### PR DESCRIPTION
Closes #4246

## Problem
With `retainMode: 'full-session'` (the default), `HindsightSessionState.retainSession` reformatted the entire message transcript on every `retainEveryNTurns` cycle, resulting in O(n²) total formatting work as the session grew.

## Change
Added private `#lastRetainedMessageIndex` and `#cachedTranscript` fields to `HindsightSessionState`. In full-session mode, only messages after the cached index are sliced, formatted via `prepareRetentionTranscript`, and concatenated to the existing cached transcript. The cache advances only after `client.retain` resolves, leaving failed retains retryable with the same accumulated text. The cache is cleared in the constructor, `setSessionId`, `resetConversationTracking`, and when `retainMode` is not `full-session`.

## Verification
- `bun run check:types` passes.
- `bun test packages/coding-agent/test/hindsight-backend.test.ts` passes.
- Scoped Bun eval confirmed incremental formatting output is byte-identical to full-window formatting, and cache resets fire on session id change, conversation tracking reset, and mode switch.