### PR TITLE
perf(cli): parallelize prompt file resolution at startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Parallelize SYSTEM.md, APPEND_SYSTEM.md, and TITLE_SYSTEM.md resolution at startup ([#4247](https://github.com/can1357/oh-my-pi/issues/4247))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -803,11 +803,13 @@ async function buildSessionOptions(
 
 	// Auto-discover SYSTEM.md if no CLI system prompt provided
 	const systemPromptSource = parsed.systemPrompt ?? discoverSystemPromptFile();
-	const resolvedSystemPrompt = await resolvePromptInput(systemPromptSource, "system prompt");
 	const appendPromptSource = parsed.appendSystemPrompt ?? discoverAppendSystemPromptFile();
-	const resolvedAppendPrompt = await resolvePromptInput(appendPromptSource, "append system prompt");
 	const titleSystemPromptSource = discoverTitleSystemPromptFile();
-	const titleSystemPrompt = await resolvePromptInput(titleSystemPromptSource, "title system prompt");
+	const [resolvedSystemPrompt, resolvedAppendPrompt, titleSystemPrompt] = await Promise.all([
+		resolvePromptInput(systemPromptSource, "system prompt"),
+		resolvePromptInput(appendPromptSource, "append system prompt"),
+		resolvePromptInput(titleSystemPromptSource, "title system prompt"),
+	]);
 
 	if (sessionManager) {
 		options.sessionManager = sessionManager;


### PR DESCRIPTION
Closes #4247

## Problem
`buildSessionOptions` awaited three independent `resolvePromptInput` calls sequentially, adding unnecessary I/O latency on the interactive startup critical path.

## Change
Parallelized the three prompt file resolutions using `Promise.all` with destructured assignments to `resolvedSystemPrompt`, `resolvedAppendPrompt`, and `titleSystemPrompt`. No behavioral change: errors still propagate, and the resolved values are assigned to the same variables.

## Verification
- `bun run check:types` passed.
- `bun run test` (`coding-agent-heavy` suite) passed.