### PR TITLE
fix(web): cap docs.rs gunzip decompressed size at 256 MB

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Capped docs.rs gunzip decompressed size at 256 MB to prevent zip-bomb OOM crashes ([#4249](https://github.com/can1357/oh-my-pi/issues/4249))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/coding-agent/src/web/scrapers/docs-rs.ts
+++ b/packages/coding-agent/src/web/scrapers/docs-rs.ts
@@ -399,7 +399,7 @@ export const handleDocsRs: SpecialHandler = async (
 		}
 
 		const compressed = Buffer.concat(chunks);
-		const jsonStr = gunzipSync(compressed).toString("utf-8");
+		const jsonStr = gunzipSync(compressed, { maxOutputLength: 256 * 1024 * 1024 }).toString("utf-8");
 		crate_ = tryParseJson<RustdocCrate>(jsonStr);
 		if (crate_?.index) {
 			await writeCachedRustdocCrate(target, jsonStr);


### PR DESCRIPTION
Closes #4249

## Problem
`packages/coding-agent/src/web/scrapers/docs-rs.ts:handleDocsRs` downloads up to 50 MB of compressed rustdoc JSON (`MAX_BYTES`) and then decompresses it with `gunzipSync` at lines ~398-399 with no decompressed size cap. Because gzip can decompress 10:1 or more, a 50 MB compressed payload can expand to 500 MB+, blocking the event loop and crashing the process with an OOM.

## Change
Added `{ maxOutputLength: 256 * 1024 * 1024 }` to the `gunzipSync` call in `handleDocsRs` to limit decompressed output to 256 MB. If the limit is exceeded, `gunzipSync` throws and the existing `catch` block returns `null` after checking for an aborted signal, preserving the existing failure contract.

## Verification
- `bun --cwd=packages/coding-agent run check:types` passes.
- `bunx @biomejs/biome check packages/coding-agent/src/web/scrapers/docs-rs.ts --no-errors-on-unmatched` passes.
- No dedicated test currently covers this path.