### PR TITLE
fix(tui): evict purged image keys from ImageBudget key map

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Evict purged image keys from `ImageBudget` to prevent unbounded map growth ([#4250](https://github.com/can1357/oh-my-pi/issues/4250))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Fixed

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -185,6 +185,12 @@ export class ImageBudget {
 				this.#purgeIds.push(id);
 				// d=I frees the data too, so the image must re-transmit if it returns.
 				this.#transmitted.delete(id);
+				for (const [k, v] of this.#keyToId) {
+					if (v === id) {
+						this.#keyToId.delete(k);
+						break;
+					}
+				}
 			}
 			this.#onTerminal = this.#planned;
 			this.#applyingReset = false;
@@ -214,6 +220,7 @@ export class ImageBudget {
 		this.#transmitted.clear();
 		this.#purgeIds = [];
 		this.#pendingTransmits = [];
+		this.#keyToId.clear();
 		return ids;
 	}
 

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -135,6 +135,64 @@ describe("ImageBudget", () => {
 		const budget2 = new ImageBudget();
 		expect(budget1.acquireId()).not.toBe(budget2.acquireId());
 	});
+	it("evicts demoted IDs from the key map so a returned key gets a fresh ID", () => {
+		const budget = new ImageBudget(2, () => {});
+		const id1 = budget.acquireId("keyA");
+		const id2 = budget.acquireId("keyB");
+		const id3 = budget.acquireId("keyC");
+
+		// At cap: only 2 images.
+		budget.beginPass();
+		budget.observe(id1);
+		budget.observe(id2);
+		budget.endPass();
+
+		// acquireId should return the same IDs.
+		expect(budget.acquireId("keyA")).toBe(id1);
+		expect(budget.acquireId("keyB")).toBe(id2);
+
+		// Overflow: observe 3 images.
+		budget.beginPass();
+		budget.observe(id1);
+		budget.observe(id2);
+		budget.observe(id3);
+		budget.endPass(); // schedules demotion of id1
+
+		// The key map should STILL hold id1 because it's not purged until the demotion frame.
+		expect(budget.acquireId("keyA")).toBe(id1);
+
+		// Demotion frame: applies the purge of id1.
+		budget.beginPass();
+		budget.observe(id1);
+		budget.observe(id2);
+		budget.observe(id3);
+		const reset = budget.endPass();
+		expect(reset).toBe(true);
+
+		// id1 was purged. Acquiring "keyA" now yields a fresh ID.
+		const id1Fresh = budget.acquireId("keyA");
+		expect(id1Fresh).not.toBe(id1);
+
+		// The other keys are still intact.
+		expect(budget.acquireId("keyB")).toBe(id2);
+		expect(budget.acquireId("keyC")).toBe(id3);
+	});
+
+	it("clears all keys from the map on takeAllTransmittedIds", () => {
+		const budget = new ImageBudget(3, () => {});
+		const id1 = budget.acquireId("keyA");
+		const id2 = budget.acquireId("keyB");
+
+		// ensure they're in the transmit tracking
+		budget.enqueueTransmit(id1, "TX1");
+		budget.enqueueTransmit(id2, "TX2");
+
+		budget.takeAllTransmittedIds();
+
+		// The keys must yield fresh IDs now.
+		expect(budget.acquireId("keyA")).not.toBe(id1);
+		expect(budget.acquireId("keyB")).not.toBe(id2);
+	});
 
 	it("setCap(0) clears a previously applied demotion threshold", () => {
 		const budget = new ImageBudget(2, () => {});


### PR DESCRIPTION
Closes #4250

## Problem
`ImageBudget#acquireId` stores every non-empty `imageKey` in `#keyToId` but never removes entries. `endPass()`, `setCap()`, `takeAllTransmittedIds()`, and `stop()` clear other internal state but leave the key map untouched, causing unbounded growth across a TUI session.

## Change
- In `endPass()` (`packages/tui/src/components/image.ts:188-193`), delete the `#keyToId` entry for each id as it is demoted/purged from live graphics.
- In `takeAllTransmittedIds()` (`packages/tui/src/components/image.ts:223`), clear `#keyToId` on the full transmitted-reset path after clearing pending transmits.
- Added unit tests in `packages/tui/test/image-budget.test.ts` covering demotion eviction and full reset.

## Verification
- `bun run check:types` — not executed per campaign constraints
- `bun test test/image-budget.test.ts` — not executed per campaign constraints