### PR TITLE
fix(collab-web): avoid O(n²) array copies on guest entry frames

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Avoid O(n²) per-entry array copies in guest snapshot commits by keeping a mutable entries accumulator and rebuilding the readonly snapshot only when entries change ([#4252](https://github.com/can1357/oh-my-pi/issues/4252))
+- Avoid O(n²) per-entry array copies in the guest client by accumulating into a mutable entries buffer and materializing the readonly snapshot lazily on `getSnapshot` (so a burst of frames collapses to one copy) ([#4252](https://github.com/can1357/oh-my-pi/issues/4252))
 
 
 ## [16.3.0] - 2026-07-02

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid O(n²) per-entry array copies in guest snapshot commits by keeping a mutable entries accumulator and rebuilding the readonly snapshot only when entries change ([#4252](https://github.com/can1357/oh-my-pi/issues/4252))
+
+
 ## [16.3.0] - 2026-07-02
 
 ### Fixed

--- a/packages/collab-web/src/lib/client.ts
+++ b/packages/collab-web/src/lib/client.ts
@@ -122,6 +122,8 @@ export class GuestClient {
 	#uiRequestQueue: CollabUiRequest[] = [];
 	#notices: readonly Notice[] = [];
 	#snapshot: GuestSnapshot;
+	/** True after {@link #commit} until the next {@link getSnapshot} materializes. */
+	#snapshotDirty = false;
 
 	/** @throws Error when the link does not parse. */
 	constructor(link: string, displayName: string) {
@@ -167,8 +169,16 @@ export class GuestClient {
 		};
 	}
 
-	/** Cached stable reference; replaced (with fresh collection refs) per applied frame. */
+	/**
+	 * Cached stable reference for `useSyncExternalStore`. Rebuilt only when
+	 * {@link #commit} has marked the cache dirty since the previous read; the
+	 * entries array is re-copied only when `#entriesVersion` advanced.
+	 */
 	getSnapshot(): GuestSnapshot {
+		if (this.#snapshotDirty) {
+			this.#snapshot = this.#buildSnapshot();
+			this.#snapshotDirty = false;
+		}
 		return this.#snapshot;
 	}
 
@@ -316,8 +326,10 @@ export class GuestClient {
 			case "snapshot-chunk": {
 				// Stream transcript fragments into the live snapshot. The host
 				// always closes the train with `final: true`; that flip is what
-				// moves the guest from "waiting" to "live".
-				this.#mutableEntries.push(...frame.entries);
+				// moves the guest from "waiting" to "live". Chunks are capped by
+				// bytes, not entry count — append one-by-one so a large chunk
+				// cannot blow the engine's argument limit via `push(...entries)`.
+				for (const entry of frame.entries) this.#mutableEntries.push(entry);
 				this.#entriesVersion++;
 				if (frame.final) {
 					this.#clearSnapshotProgressTimer();
@@ -525,7 +537,9 @@ export class GuestClient {
 	}
 
 	#commit(): void {
-		this.#snapshot = this.#buildSnapshot();
+		// Defer materialization to getSnapshot so a burst of frames between
+		// renders collapses to one entries copy (when entries changed at all).
+		this.#snapshotDirty = true;
 		for (const listener of this.#listeners) listener();
 	}
 }

--- a/packages/collab-web/src/lib/client.ts
+++ b/packages/collab-web/src/lib/client.ts
@@ -105,7 +105,10 @@ export class GuestClient {
 	#phase: ConnectionPhase = "connecting";
 	#endedReason: string | null = null;
 	#header: SessionHeader | null = null;
-	#entries: readonly SessionEntry[] = [];
+	#mutableEntries: SessionEntry[] = [];
+	#entriesVersion = 0;
+	#entriesSnapshotVersion = -1;
+	#entriesSnapshot: readonly SessionEntry[] = [];
 	#state: SessionState | null = null;
 	#agents: readonly AgentSnapshot[] = [];
 	#progress: ReadonlyMap<string, SubagentProgressPayload> = new Map();
@@ -288,7 +291,8 @@ export class GuestClient {
 				// Reset accumulator: a fresh welcome arriving mid-load (reconnect)
 				// supersedes any partially-streamed snapshot from the prior session.
 				this.#header = frame.header;
-				this.#entries = [];
+				this.#mutableEntries = [];
+				this.#entriesVersion++;
 				this.#state = frame.state;
 				this.#agents = [...frame.agents];
 				this.#stream = null;
@@ -313,7 +317,8 @@ export class GuestClient {
 				// Stream transcript fragments into the live snapshot. The host
 				// always closes the train with `final: true`; that flip is what
 				// moves the guest from "waiting" to "live".
-				this.#entries = [...this.#entries, ...frame.entries];
+				this.#mutableEntries.push(...frame.entries);
+				this.#entriesVersion++;
 				if (frame.final) {
 					this.#clearSnapshotProgressTimer();
 					this.#phase = "live";
@@ -323,7 +328,8 @@ export class GuestClient {
 				break;
 			}
 			case "entry":
-				this.#entries = [...this.#entries, frame.entry];
+				this.#mutableEntries.push(frame.entry);
+				this.#entriesVersion++;
 				if (this.#streamDone && frame.entry.type === "message" && frame.entry.message.role === "assistant") {
 					this.#stream = null;
 					this.#streamDone = false;
@@ -494,11 +500,16 @@ export class GuestClient {
 	}
 
 	#buildSnapshot(): GuestSnapshot {
+		if (this.#entriesSnapshotVersion !== this.#entriesVersion) {
+			this.#entriesSnapshot = [...this.#mutableEntries];
+			this.#entriesSnapshotVersion = this.#entriesVersion;
+		}
+
 		return {
 			phase: this.#phase,
 			endedReason: this.#endedReason,
 			header: this.#header,
-			entries: this.#entries,
+			entries: this.#entriesSnapshot,
 			state: this.#state,
 			agents: this.#agents,
 			progress: this.#progress,


### PR DESCRIPTION
Closes #4252

## Problem

`GuestClient.#applyFrame` in `packages/collab-web/src/lib/client.ts` rebuilt the `entries` array with `[...this.#entries, ...frame.entries]` on every `snapshot-chunk` frame and `[...this.#entries, frame.entry]` on every `entry` frame. For long live sessions this created O(n²) allocation churn as each new frame copied all prior entries.

## Change

Replaced the readonly `#entries` accumulator with `#mutableEntries: SessionEntry[]`, added `#entriesVersion` and `#entriesSnapshotVersion` counters, and cached the readonly `#entriesSnapshot`. `snapshot-chunk` and `entry` handlers now `push()` and bump the version; `#buildSnapshot` only copies the mutable list when the version changed, so non-mutating commits reuse the same reference. The readonly `GuestSnapshot.entries` contract is preserved; `Transcript.tsx` relies on reference equality via `useMemo(..., [entries])` and the tail-scroll effect dependency list, both of which remain correct because a new snapshot reference is produced only on actual entry mutations.

## Verification

- `bun run check:types` passes
- `bun test packages/collab-web/test/client.test.ts` passes (16 pass, 0 fail)