### PR TITLE
fix(install): add network timeouts to install script downloads

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -239,13 +239,13 @@ function Install-Binary {
     if ($Ref) {
         Write-Host "Fetching release $Ref..."
         try {
-            $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/tags/$Ref"
+            $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/tags/$Ref" -TimeoutSec 60
         } catch {
             throw "Release tag not found: $Ref`nFor branch/commit installs, use -Source with -Ref."
         }
     } else {
         Write-Host "Fetching latest release..."
-        $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+        $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -TimeoutSec 60
     }
 
     $Latest = $Release.tag_name
@@ -260,7 +260,7 @@ function Install-Binary {
     $BinaryUrl = "https://github.com/$Repo/releases/download/$Latest/$BinaryName"
     Write-Host "Downloading $BinaryName..."
     $OutPath = Join-Path $InstallDir "omp.exe"
-    Invoke-WebRequest -Uri $BinaryUrl -OutFile $OutPath
+    Invoke-WebRequest -Uri $BinaryUrl -OutFile $OutPath -TimeoutSec 900
 
     Write-Host ""
     Write-Host "✓ Installed omp to $OutPath" -ForegroundColor Green

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -205,7 +205,7 @@ install_binary() {
     # Get release tag
     if [ -n "$REF" ]; then
         echo "Fetching release $REF..."
-        if RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/tags/${REF}"); then
+        if RELEASE_JSON=$(curl -fsSL --connect-timeout 10 --max-time 60 "https://api.github.com/repos/${REPO}/releases/tags/${REF}"); then
             LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
         else
             echo "Release tag not found: $REF"
@@ -214,7 +214,7 @@ install_binary() {
         fi
     else
         echo "Fetching latest release..."
-        RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")
+        RELEASE_JSON=$(curl -fsSL --connect-timeout 10 --max-time 60 "https://api.github.com/repos/${REPO}/releases/latest")
         LATEST=$(echo "$RELEASE_JSON" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
     fi
 
@@ -228,7 +228,7 @@ install_binary() {
     # Download binary
     BINARY_URL="https://github.com/${REPO}/releases/download/${LATEST}/${BINARY}"
     echo "Downloading ${BINARY}..."
-    curl -fsSL "$BINARY_URL" -o "${INSTALL_DIR}/omp"
+    curl -fsSL --connect-timeout 10 --speed-limit 1024 --speed-time 30 "$BINARY_URL" -o "${INSTALL_DIR}/omp"
     chmod +x "${INSTALL_DIR}/omp"
     echo ""
     echo "✓ Installed omp to ${INSTALL_DIR}/omp"


### PR DESCRIPTION
Closes #4253

## Problem
`install_binary()` in `scripts/install.sh` and `Install-Binary` in `scripts/install.ps1` issue unbounded GitHub API and binary download requests. A stalled connection or unresponsive GitHub endpoint causes the installer to hang indefinitely.

## Change
- `scripts/install.sh`: added `--connect-timeout 10 --max-time 60` to the two release metadata `curl` calls, and `--connect-timeout 10 --speed-limit 1024 --speed-time 30` to the binary download so a stalled transfer is detected without a rigid total-size max-time.
- `scripts/install.ps1`: added `-TimeoutSec 60` to both `Invoke-RestMethod` metadata calls and `-TimeoutSec 900` to `Invoke-WebRequest` for the binary download.

## Verification
- `bash -n scripts/install.sh` passes.
- No TypeScript/typecheck changes are involved.