### PR TITLE
fix(ai/devin): bound Connect frame payload at 16 MiB

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Devin Connect streaming reader accepting corrupt frame lengths and buffering unbounded data before the idle-timeout wrapper aborted, by capping payloads at 16 MiB and throwing a `ProviderResponseError({ kind: "envelope" })` as soon as an oversize length prefix is decoded ([#4228](https://github.com/can1357/oh-my-pi/issues/4228)).
+
 ## [16.3.1] - 2026-07-02
 
 ### Changed

--- a/packages/ai/src/providers/devin.ts
+++ b/packages/ai/src/providers/devin.ts
@@ -69,6 +69,15 @@ const DEVIN_DEFAULT_STOP_PATTERNS = ["<|user|>", "<|bot|>", "<|context_request|>
 /** Connect streaming framing: flag byte bit 0x01 = gzip payload, 0x02 = end-of-stream JSON trailers. */
 const CONNECT_COMPRESSED_FLAG = 0x01;
 const CONNECT_END_STREAM_FLAG = 0x02;
+/**
+ * Hard upper bound on a single Connect frame payload. The 4-byte length prefix
+ * is otherwise attacker-controlled (up to `2**32 - 1`), so a malicious or buggy
+ * peer could force {@link streamDevin}'s reader to buffer gigabytes via
+ * `Buffer.concat` before the idle-timeout wrapper aborts. Well above any
+ * legitimate Cascade response but tight enough that a corrupt length prefix
+ * fails fast instead of consuming memory.
+ */
+const MAX_CONNECT_FRAME_PAYLOAD = 16 * 1024 * 1024;
 
 export const streamDevin: StreamFunction<"devin-agent"> = (
 	model: Model<"devin-agent">,
@@ -201,6 +210,12 @@ export const streamDevin: StreamFunction<"devin-agent"> = (
 				while (pending.length >= 5) {
 					const flag = pending[0];
 					const len = pending.readUInt32BE(1);
+					if (len > MAX_CONNECT_FRAME_PAYLOAD) {
+						throw new AIError.ProviderResponseError(
+							`Devin Connect frame length ${len} exceeds ${MAX_CONNECT_FRAME_PAYLOAD}-byte cap`,
+							{ provider: model.provider, kind: "envelope" },
+						);
+					}
 					if (pending.length < 5 + len) break;
 					const payload = pending.subarray(5, 5 + len);
 					pending = pending.subarray(5 + len);

--- a/packages/ai/test/devin-frame-cap.test.ts
+++ b/packages/ai/test/devin-frame-cap.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import { create, toBinary } from "@bufbuild/protobuf";
+import * as AIError from "@oh-my-pi/pi-ai/error";
+import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { GetUserJwtResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/auth_pb/auth_pb";
+
+/**
+ * Regression for #4228: a Devin Connect frame header advertising an outsized
+ * payload length must fail fast with a `ProviderResponseError({ kind:
+ * "envelope" })` instead of buffering unbounded data via `Buffer.concat` until
+ * the idle-timeout wrapper aborts.
+ */
+
+const devinModel: Model<"devin-agent"> = buildModel({
+	id: "devin-test",
+	name: "Devin Test",
+	api: "devin-agent",
+	provider: "devin",
+	baseUrl: "https://server.codeium.com",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1,
+	maxTokens: 1,
+});
+
+const context: Context = {
+	messages: [{ role: "user", content: "hi", timestamp: 1 }],
+};
+
+function corruptFrameHeader(advertisedLen: number): Uint8Array {
+	const out = new Uint8Array(5);
+	const view = new DataView(out.buffer);
+	view.setUint8(0, 0);
+	view.setUint32(1, advertisedLen, false);
+	return out;
+}
+
+describe("streamDevin frame length cap", () => {
+	it("rejects a frame advertising a payload above the 16 MiB cap without buffering it", async () => {
+		const authPayload = toBinary(
+			GetUserJwtResponseSchema,
+			create(GetUserJwtResponseSchema, { userJwt: "jwt" }),
+		);
+		// 32 MiB advertised — twice the cap, well below UINT32_MAX so the
+		// concat-forever bug would silently swallow it on the vulnerable branch.
+		const header = corruptFrameHeader(32 * 1024 * 1024);
+		let concatBytes = 0;
+
+		const fetchImpl = (async (input: string | URL | Request) => {
+			const url = String(input);
+			if (url.includes("GetUserJwt")) return new Response(authPayload);
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					async pull(controller) {
+						// One header + a single 1 MiB filler chunk. The pre-fix reader
+						// would keep polling forever waiting for 32 MiB to arrive.
+						controller.enqueue(header);
+						const filler = new Uint8Array(1024 * 1024);
+						concatBytes += filler.length;
+						controller.enqueue(filler);
+						controller.close();
+					},
+				}),
+				{ status: 200 },
+			);
+		}) as typeof fetch;
+
+		const stream = streamDevin(devinModel, context, { apiKey: "token", fetch: fetchImpl });
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Devin Connect frame length");
+		expect(result.errorMessage).toContain("16777216");
+		// Fewer than 2 MiB should ever flow through: the reader must reject the
+		// frame the moment it decodes the length prefix, not after a payload
+		// arrives.
+		expect(concatBytes).toBeLessThan(2 * 1024 * 1024);
+	});
+
+	it("carries the envelope diagnostic on the error event and finalized message", async () => {
+		const authPayload = toBinary(
+			GetUserJwtResponseSchema,
+			create(GetUserJwtResponseSchema, { userJwt: "jwt" }),
+		);
+		const header = corruptFrameHeader(64 * 1024 * 1024);
+
+		const fetchImpl = (async (input: string | URL | Request) => {
+			const url = String(input);
+			if (url.includes("GetUserJwt")) return new Response(authPayload);
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					async pull(controller) {
+						controller.enqueue(header);
+						controller.close();
+					},
+				}),
+				{ status: 200 },
+			);
+		}) as typeof fetch;
+
+		const stream = streamDevin(devinModel, context, { apiKey: "token", fetch: fetchImpl });
+		let errorEvent:
+			| {
+					type: "error";
+					error: { errorMessage?: string; stopReason?: string };
+			  }
+			| undefined;
+		for await (const event of stream) {
+			if (event.type === "error") {
+				errorEvent = event as typeof errorEvent;
+			}
+		}
+
+		expect(errorEvent).toBeDefined();
+		expect(errorEvent?.error.stopReason).toBe("error");
+		expect(errorEvent?.error.errorMessage).toContain("67108864");
+		expect(errorEvent?.error.errorMessage).toContain("16777216");
+	});
+});

--- a/packages/ai/test/devin-frame-cap.test.ts
+++ b/packages/ai/test/devin-frame-cap.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import { create, toBinary } from "@bufbuild/protobuf";
-import * as AIError from "@oh-my-pi/pi-ai/error";
 import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -40,10 +39,7 @@ function corruptFrameHeader(advertisedLen: number): Uint8Array {
 
 describe("streamDevin frame length cap", () => {
 	it("rejects a frame advertising a payload above the 16 MiB cap without buffering it", async () => {
-		const authPayload = toBinary(
-			GetUserJwtResponseSchema,
-			create(GetUserJwtResponseSchema, { userJwt: "jwt" }),
-		);
+		const authPayload = toBinary(GetUserJwtResponseSchema, create(GetUserJwtResponseSchema, { userJwt: "jwt" }));
 		// 32 MiB advertised — twice the cap, well below UINT32_MAX so the
 		// concat-forever bug would silently swallow it on the vulnerable branch.
 		const header = corruptFrameHeader(32 * 1024 * 1024);
@@ -81,10 +77,7 @@ describe("streamDevin frame length cap", () => {
 	});
 
 	it("carries the envelope diagnostic on the error event and finalized message", async () => {
-		const authPayload = toBinary(
-			GetUserJwtResponseSchema,
-			create(GetUserJwtResponseSchema, { userJwt: "jwt" }),
-		);
+		const authPayload = toBinary(GetUserJwtResponseSchema, create(GetUserJwtResponseSchema, { userJwt: "jwt" }));
 		const header = corruptFrameHeader(64 * 1024 * 1024);
 
 		const fetchImpl = (async (input: string | URL | Request) => {


### PR DESCRIPTION
## Repro

`streamDevin` in `packages/ai/src/providers/devin.ts` reads Connect frames with `Buffer.concat([pending, value])` and only dispatches once `pending.length >= 5 + len`, where `len` is the wire-supplied 4-byte big-endian length prefix. Replaying the loop verbatim with a corrupt header advertising `len = 2**31` and 32 × 1 MiB filler chunks:

```
{ peakBytesMiB: '32.0', concatCalls: 33, framesEmitted: 0, pendingRemaining: 33554437 }
```

The reader buffered 32 MiB across 33 `Buffer.concat` calls and emitted zero frames; in production it keeps growing until `iterateWithIdleTimeout` fires — well after the memory damage is done.

## Cause

`packages/ai/src/providers/devin.ts` decoded `len = pending.readUInt32BE(1)` and then only checked `pending.length < 5 + len` to decide whether to buffer more. There was no upper bound on the advertised length, so any peer could pin the reader on a fabricated header and pull GiB of concat traffic through it.

## Fix

- Added `MAX_CONNECT_FRAME_PAYLOAD = 16 * 1024 * 1024` alongside the existing `CONNECT_*_FLAG` constants, with a doc comment naming the attack surface.
- Immediately after decoding `len`, throw `AIError.ProviderResponseError({ kind: "envelope" })` when it exceeds the cap — before the loop waits for another chunk.
- Added `packages/ai/test/devin-frame-cap.test.ts`:
  - Advertises 32 MiB, feeds a single 1 MiB filler chunk, asserts the stream ends with `stopReason: "error"`, the finalized `errorMessage` names the offending length and the cap, and fewer than 2 MiB flowed through before rejection.
  - Advertises 64 MiB with only the header, asserts the terminal `error` event carries the same envelope diagnostic.
- Changelog entry under `## [Unreleased]` → `### Fixed`.

## Verification

- `bun test test/devin-frame-cap.test.ts test/devin-streaming-args.test.ts` — 3 pass, 0 fail (verified failing without the guard: same tests, 0 pass / 2 fail — the regression is caught).

Fixes #4228