### PR TITLE
fix(ssh): bound pre-command SSH helpers with ptree.exec timeout

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed SSH tool hanging indefinitely on unreachable or wedged hosts: the pre-command `runSshSync` / `runSshCaptureSync` helpers (used by `ensureConnection` / `probeHostInfo`) previously invoked `ssh` through the Bun shell with no timeout or abort signal and sat outside the `SshTool.execute` command-timeout wrapper. They now run through `ptree.exec` with a 30s bound and `allowNonZero`/`allowAbort`, returning a failure result instead of blocking forever. ([#4232](https://github.com/can1357/oh-my-pi/issues/4232))
+
 ## [16.3.1] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/ssh/__tests__/connection-manager-timeout.test.ts
+++ b/packages/coding-agent/src/ssh/__tests__/connection-manager-timeout.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression for #4232: `runSshSync` / `runSshCaptureSync` sit on the
+ * `ensureHostInfo` → `probeHostInfo` / `ensureConnection` path that runs before
+ * `SshTool.execute` applies the user's command timeout. Previously they invoked
+ * `ssh` through `$`ssh ${args}`.quiet().nothrow()` with no timeout and no
+ * abort signal, so an unreachable host or wedged control-master hung forever.
+ *
+ * The contract now is: each helper is bounded by `timeoutMs`, aborts a stalled
+ * child, and returns a failure result (`exitCode !== 0`, non-empty
+ * `stderr`) instead of throwing or blocking.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { _sshHelpersForTests } from "../connection-manager";
+
+const { runSshSync, runSshCaptureSync } = _sshHelpersForTests;
+
+let binDir: string;
+let originalPath: string | undefined;
+
+beforeAll(async () => {
+	binDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-ssh-timeout-"));
+	// Fake `ssh` that traps SIGTERM and sleeps far past any test bound.
+	// Simulates a wedged control-master / unreachable host.
+	const fake = path.join(binDir, "ssh");
+	await fs.writeFile(fake, "#!/usr/bin/env bash\ntrap '' TERM\nsleep 300\n", { mode: 0o755 });
+	originalPath = process.env.PATH;
+	process.env.PATH = `${binDir}${path.delimiter}${originalPath ?? ""}`;
+});
+
+afterAll(async () => {
+	if (originalPath === undefined) delete process.env.PATH;
+	else process.env.PATH = originalPath;
+	await fs.rm(binDir, { recursive: true, force: true });
+});
+
+describe("SSH pre-command helpers bound their own runtime (#4232)", () => {
+	it("runSshSync returns a failure result within the timeout on a wedged host", async () => {
+		const timeoutMs = 200;
+		const started = Date.now();
+		const result = await runSshSync(["-o", "BatchMode=yes", "unreachable", "true"], timeoutMs);
+		const elapsed = Date.now() - started;
+
+		expect(elapsed).toBeLessThan(5_000);
+		// timeout → aborted child, so exit code is null (aborted) or non-zero.
+		expect(result.exitCode).not.toBe(0);
+	}, 10_000);
+
+	it("runSshCaptureSync returns a failure result within the timeout on a wedged host", async () => {
+		const timeoutMs = 200;
+		const started = Date.now();
+		const result = await runSshCaptureSync(["-o", "BatchMode=yes", "unreachable", "true"], timeoutMs);
+		const elapsed = Date.now() - started;
+
+		expect(elapsed).toBeLessThan(5_000);
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stdout).toBe("");
+	}, 10_000);
+});

--- a/packages/coding-agent/src/ssh/connection-manager.ts
+++ b/packages/coding-agent/src/ssh/connection-manager.ts
@@ -1,7 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { $which, getRemoteHostDir, getSshControlDir, isEnoent, logger, postmortem } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
+import { $which, getRemoteHostDir, getSshControlDir, isEnoent, logger, postmortem, ptree } from "@oh-my-pi/pi-utils";
 import { buildSshTarget, sanitizeHostName } from "./utils";
 
 export interface SSHConnectionTarget {
@@ -116,19 +115,53 @@ function buildCommonArgs(host: SSHConnectionTarget, options?: SSHArgsOptions): s
 	return args;
 }
 
-async function runSshSync(args: string[]): Promise<{ exitCode: number | null; stderr: string }> {
-	const result = await $`ssh ${args}`.quiet().nothrow();
-	return { exitCode: result.exitCode, stderr: result.stderr.toString().trim() };
+/**
+ * Per-call timeout for the pre-command SSH setup/probe helpers. These sit on
+ * the `ensureHostInfo` → `probeHostInfo` / `ensureConnection` path that runs
+ * *before* `SshTool.execute` applies the user-provided command timeout, so an
+ * unreachable host or wedged control-master would otherwise hang forever
+ * (#4232). `allowNonZero`/`allowAbort` keep the "return a failure result"
+ * contract that these helpers had under `.quiet().nothrow()`.
+ */
+const SSH_HELPER_TIMEOUT_MS = 30_000;
+
+async function runSshSync(
+	args: string[],
+	timeoutMs = SSH_HELPER_TIMEOUT_MS,
+): Promise<{ exitCode: number | null; stderr: string }> {
+	const result = await ptree.exec(["ssh", ...args], {
+		timeout: timeoutMs,
+		allowNonZero: true,
+		allowAbort: true,
+		stderr: "full",
+	});
+	return { exitCode: result.exitCode, stderr: result.stderr.trim() };
 }
 
-async function runSshCaptureSync(args: string[]): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
-	const result = await $`ssh ${args}`.quiet().nothrow();
+async function runSshCaptureSync(
+	args: string[],
+	timeoutMs = SSH_HELPER_TIMEOUT_MS,
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+	const result = await ptree.exec(["ssh", ...args], {
+		timeout: timeoutMs,
+		allowNonZero: true,
+		allowAbort: true,
+		stderr: "full",
+	});
 	return {
 		exitCode: result.exitCode,
-		stdout: result.stdout.toString().trim(),
-		stderr: result.stderr.toString().trim(),
+		stdout: result.stdout.trim(),
+		stderr: result.stderr.trim(),
 	};
 }
+
+/**
+ * Test-only surface for exercising the pre-command SSH helpers against a
+ * fake `ssh` binary with a shortened timeout. External code MUST NOT depend
+ * on this — call `ensureConnection` / `ensureHostInfo` instead.
+ * @internal
+ */
+export const _sshHelpersForTests = { runSshSync, runSshCaptureSync };
 
 function ensureSshBinary(): void {
 	if (!$which("ssh")) {


### PR DESCRIPTION
## Repro

Against an unreachable/wedged remote (fake `ssh` binary that traps `SIGTERM` and `sleep 300`), the byte-identical `$\`ssh ${args}\`.quiet().nothrow()` pattern used by `runSshSync` / `runSshCaptureSync` never returns:

```
$ PATH="/tmp/repro-4232/bin:$PATH" bun run repro.ts
{"hung":true,"elapsedMs":3001}
```

The 3s guard fires with the helper still blocked. Because `SshTool.execute` calls `ensureHostInfo(...)` — which in turn calls `ensureConnection` / `probeHostInfo` — *before* wrapping the user command in its own timeout, a wedged host hung the SSH tool indefinitely.

## Cause

`packages/coding-agent/src/ssh/connection-manager.ts::runSshSync` and `::runSshCaptureSync` invoked `ssh` through the Bun shell (`$\`ssh ${args}\`.quiet().nothrow()`) with no `timeout` and no `AbortSignal`. Bun's shell awaits the child's exit and never cancels it, so a control-master `-O check`, a `-M -N -f` start, a POSIX probe, or a Windows-compat probe (`bash -lc`/`sh -lc`) would sit on a stalled `ssh` process forever.

## Fix

- Replace both helpers with `ptree.exec(["ssh", ...args], { timeout: 30_000, allowNonZero: true, allowAbort: true, stderr: "full" })`, matching the pattern already used in `packages/coding-agent/src/ssh/file-transfer.ts`.
- Keep the same failure-result shape (`exitCode` / `stdout` / `stderr`, all trimmed), so `ensureConnection` still surfaces a `Failed to start SSH master ...` error and probes still fall through their existing `exitCode !== 0` branches.
- Make the timeout a parameter (default `SSH_HELPER_TIMEOUT_MS = 30_000`) so tests can override it with a short bound.
- Drop the now-unused `import { $ } from "bun"`; add `ptree` to the `@oh-my-pi/pi-utils` import.
- Expose `_sshHelpersForTests = { runSshSync, runSshCaptureSync }` (marked `@internal`) purely for the regression test.

## Verification

New regression test `packages/coding-agent/src/ssh/__tests__/connection-manager-timeout.test.ts` stages a fake `ssh` that traps `SIGTERM` and `sleep 300`, prepends it to `PATH`, and invokes both helpers with `timeoutMs = 200`. Each returns within the 5s ceiling with a non-zero exit code.

```
$ bun test packages/coding-agent/src/ssh/__tests__/connection-manager-timeout.test.ts
 2 pass
 0 fail
 5 expect() calls

$ bun test packages/coding-agent/src/ssh/__tests__ packages/coding-agent/test/ssh
 36 pass
 0 fail
```

Two SSH tool tests (`test/tools/ssh-commit-stability.test.ts`, `test/tools/ssh-url-approval-gate.test.ts`) fail with `Cannot find module './tool-views.generated.js' from …/export/html/index.ts` — verified pre-existing on `main` at `chore: bump version to 16.3.1` with the diff stashed, so unrelated to this change.

Fixes #4232