### PR TITLE
fix(plugins): drain subprocess pipes concurrently with proc.exited

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a pipe-buffer deadlock hazard in plugin install/uninstall paths: `PluginManager.install`, `PluginManager.uninstall`, `PluginManager.#fixMissingPlugin`, the git-refresh `bun update` step, the legacy `installer.ts` install/uninstall helpers, and the bundled-registry generator's `formatInPlace` all awaited `proc.exited` before draining stdout/stderr. Verbose `bun install`/`bun uninstall`/`biome check` output above the ~64 KiB OS pipe buffer could block the child on `write(2)` while the parent blocked on exit, and even under Bun's current eager buffering this leaked unbounded bytes into memory. Each site now drains both pipes concurrently with `proc.exited` via `Promise.all`. ([#4230](https://github.com/can1357/oh-my-pi/issues/4230))
+
 ## [16.3.1] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/scripts/generate-legacy-pi-bundled-registry.ts
+++ b/packages/coding-agent/scripts/generate-legacy-pi-bundled-registry.ts
@@ -332,9 +332,15 @@ async function formatInPlace(targets: readonly string[]): Promise<void> {
 		stdout: "pipe",
 		stderr: "pipe",
 	});
-	const exit = await proc.exited;
+	// Drain both pipes concurrently with proc.exited to avoid a pipe-buffer
+	// deadlock — biome check can emit thousands of lines when it rewrites the
+	// generated registry, easily exceeding the ~64 KiB OS pipe buffer.
+	const [exit, , stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
 	if (exit !== 0) {
-		const stderr = await new Response(proc.stderr).text();
 		throw new Error(`biome check --write failed (exit ${exit}): ${stderr}`);
 	}
 }

--- a/packages/coding-agent/src/extensibility/plugins/installer.ts
+++ b/packages/coding-agent/src/extensibility/plugins/installer.ts
@@ -53,9 +53,14 @@ export async function installPlugin(packageName: string): Promise<InstalledPlugi
 		windowsHide: true,
 	});
 
-	const exitCode = await proc.exited;
+	// Drain both pipes concurrently with proc.exited to avoid a pipe-buffer
+	// deadlock if bun install floods stdout/stderr.
+	const [exitCode, , stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
 	if (exitCode !== 0) {
-		const stderr = await new Response(proc.stderr).text();
 		throw new Error(`Failed to install ${packageName}: ${stderr}`);
 	}
 
@@ -95,7 +100,11 @@ export async function uninstallPlugin(name: string): Promise<void> {
 		windowsHide: true,
 	});
 
-	const exitCode = await proc.exited;
+	const [exitCode] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
 	if (exitCode !== 0) {
 		throw new Error(`Failed to uninstall ${name}`);
 	}

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -458,10 +458,17 @@ export class PluginManager {
 				stderr: "pipe",
 				windowsHide: true,
 			});
-			const installExit = await installProc.exited;
+			// Drain stdout+stderr concurrently with proc.exited. Awaiting exited
+			// before reading either pipe risks a >64 KiB OS-pipe-buffer deadlock
+			// once bun install prints enough progress; even where Bun currently
+			// buffers eagerly, doing this leaks unbounded memory.
+			const [installExit, , installStderr] = await Promise.all([
+				installProc.exited,
+				new Response(installProc.stdout).text(),
+				new Response(installProc.stderr).text(),
+			]);
 			if (installExit !== 0) {
-				const stderr = await new Response(installProc.stderr).text();
-				throw new Error(`bun install failed: ${stderr}`);
+				throw new Error(`bun install failed: ${installStderr}`);
 			}
 			// Resolve actual package name. npm specs encode the name (strip version);
 			// git specs do not, so diff plugins/package.json deps to find the new entry.
@@ -508,10 +515,14 @@ export class PluginManager {
 					stderr: "pipe",
 					windowsHide: true,
 				});
-				const updateExit = await updateProc.exited;
+				// Same drain-concurrent-with-exit pattern as the bun install above.
+				const [updateExit, , updateStderr] = await Promise.all([
+					updateProc.exited,
+					new Response(updateProc.stdout).text(),
+					new Response(updateProc.stderr).text(),
+				]);
 				if (updateExit !== 0) {
-					const stderr = await new Response(updateProc.stderr).text();
-					throw new Error(`bun update ${actualName} failed: ${stderr}`);
+					throw new Error(`bun update ${actualName} failed: ${updateStderr}`);
 				}
 			}
 
@@ -608,7 +619,13 @@ export class PluginManager {
 			windowsHide: true,
 		});
 
-		const exitCode = await proc.exited;
+		// Drain both pipes concurrently with proc.exited to avoid a pipe-buffer
+		// deadlock if bun uninstall floods stdout/stderr.
+		const [exitCode] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
 		if (exitCode !== 0) {
 			throw new Error(`npm uninstall failed for ${name}`);
 		}
@@ -1007,7 +1024,14 @@ export class PluginManager {
 				stderr: "pipe",
 				windowsHide: true,
 			});
-			return (await proc.exited) === 0;
+			// Drain pipes concurrently with proc.exited; otherwise a chatty
+			// bun install can block on a full OS pipe buffer.
+			const [exit] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			return exit === 0;
 		} catch {
 			return false;
 		}

--- a/packages/coding-agent/test/plugin-install-git.test.ts
+++ b/packages/coding-agent/test/plugin-install-git.test.ts
@@ -272,6 +272,64 @@ describe("PluginManager.install with git sources", () => {
 		expect(spawnedCommands).toEqual([["bun", "install", "github:foo/bar"]]);
 	});
 
+	test("drains stdout/stderr concurrently with proc.exited (pipe-buffer deadlock, #4230)", async () => {
+		// Model the OS-pipe semantics that caused the deadlock: `exited` cannot
+		// resolve until both pipes have been read. If PluginManager.install
+		// awaits `exited` before starting to drain either stream, this test
+		// hangs — which we catch with Promise.race + a short timeout.
+		await Bun.write(
+			pluginsPkgJson,
+			JSON.stringify({ name: "omp-plugins", private: true, dependencies: {} }, null, 2),
+		);
+
+		const makeGatedStream = (payload: string): { stream: ReadableStream<Uint8Array>; drained: Promise<void> } => {
+			const { promise: drained, resolve: onDrained } = Promise.withResolvers<void>();
+			const stream = new ReadableStream<Uint8Array>({
+				pull(controller) {
+					controller.enqueue(new TextEncoder().encode(payload));
+					controller.close();
+					onDrained();
+				},
+			});
+			return { stream, drained };
+		};
+
+		vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[]) => {
+			expect(cmd).toEqual(["bun", "install", "github:foo/bar"]);
+			const { stream: stdout, drained: stdoutDrained } = makeGatedStream("progress\n");
+			const { stream: stderr, drained: stderrDrained } = makeGatedStream("");
+			const exited = Promise.all([stdoutDrained, stderrDrained]).then(async () => {
+				await Bun.write(
+					pluginsPkgJson,
+					JSON.stringify(
+						{
+							name: "omp-plugins",
+							private: true,
+							dependencies: { "real-name": "github:foo/bar" },
+						},
+						null,
+						2,
+					),
+				);
+				const installedDir = path.join(pluginsNodeModules, "real-name");
+				await fs.mkdir(installedDir, { recursive: true });
+				await Bun.write(
+					path.join(installedDir, "package.json"),
+					JSON.stringify({ name: "real-name", version: "0.1.0" }, null, 2),
+				);
+				return 0;
+			});
+			return { pid: 1, stdout, stderr, exited } as Subprocess;
+		}) as typeof Bun.spawn);
+
+		const mgr = new PluginManager(tmpRoot);
+		const installed = await Promise.race([
+			mgr.install("github:foo/bar"),
+			new Promise<never>((_, reject) => setTimeout(() => reject(new Error("install deadlocked")), 2000)),
+		]);
+		expect(installed.name).toBe("real-name");
+	});
+
 	test("rejects git specs containing shell metacharacters", async () => {
 		const mgr = new PluginManager(tmpRoot);
 		await expect(mgr.install("github:foo/bar; rm -rf /")).rejects.toThrow(/Invalid characters in plugin source/);


### PR DESCRIPTION
## Repro

Every affected call site spawns a child with `stdout: "pipe"` and `stderr: "pipe"`, then awaits `proc.exited` before touching either stream. On Bun 1.3.14 the runtime happens to buffer pipe output eagerly, so a 100 MB payload flushed via `bun -e "…yes | head -c 100000000…"` still exits in ~740 ms rather than hanging — but the pattern is unsound under any spawn implementation with true OS-pipe backpressure, and even under Bun today it silently buffers unbounded bytes into memory. The concrete triggers are `omp plugin install`, `omp plugin uninstall`, `omp plugin doctor --fix`, `bun scripts/generate-legacy-pi-bundled-registry.ts --generate` / `--check`, and every path in `scripts/build-binary.ts` that reaches the generator.

## Cause

Six spawn sites shared the same buggy shape — spawn, `await proc.exited`, then `new Response(stream).text()` only after:

- `packages/coding-agent/src/extensibility/plugins/manager.ts` — `PluginManager.install`'s initial `bun install <spec>`, its git-refresh `bun update <name>` step, `PluginManager.uninstall`'s `bun uninstall <name>`, and `PluginManager.#fixMissingPlugin`'s `bun install`.
- `packages/coding-agent/src/extensibility/plugins/installer.ts` — `installPlugin` and `uninstallPlugin`, exposed to third-party plugins via the `omp-legacy-pi-bundled:` compat surface.
- `packages/coding-agent/scripts/generate-legacy-pi-bundled-registry.ts` — `formatInPlace` invoking `bunx biome check --write`, which readily emits thousands of lines when it rewrites the generated registry.

## Fix

- Each site now spawns, then kicks off `new Response(proc.stdout).text()` and `new Response(proc.stderr).text()` immediately, and awaits all three (readers + `proc.exited`) with `Promise.all`.
- Existing error semantics preserved: `install` still throws `bun install failed: <stderr>`, `uninstall` keeps its original generic error, `#fixMissingPlugin` still returns `false` on non-zero exit, and `formatInPlace` still surfaces Biome's stderr in the thrown message.
- Adds a regression test in `test/plugin-install-git.test.ts` that models the OS-pipe deadlock: the mock `exited` promise resolves only after both stdout and stderr are drained, so any code that awaits `exited` before reading either stream hits the test's 2 s `Promise.race` timeout instead of resolving.

## Verification

- `bun test test/plugin-install-git.test.ts test/plugin-install-local.test.ts test/plugin-install-validation.test.ts test/plugin-command.test.ts test/plugin-config.test.ts` → 27 pass / 0 fail.
- `bun scripts/generate-legacy-pi-bundled-registry.ts --check` now exercises the new drain path in `formatInPlace` (biome runs cleanly). It still reports pre-existing drift on `packages/coding-agent/src/extensibility/plugins/legacy-pi-bundled-{registry,keys}.ts` — reproducible from a clean stash of the branch head and unrelated to this diff.

Fixes #4230