### PR TITLE
fix(ai): time out Cursor proxy tunnels

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor proxy tunnel setup hanging indefinitely before stream start by adding abort and timeout handling. ([#4226](https://github.com/can1357/oh-my-pi/issues/4226))
+
 ## [16.3.1] - 2026-07-02
 
 ### Changed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -147,6 +147,8 @@ import { toolWireSchema } from "../utils/schema/wire";
 export const CURSOR_API_URL = "https://api2.cursor.sh";
 export const CURSOR_CLIENT_VERSION = "cli-2026.01.09-231024f";
 
+const CURSOR_PROXY_TUNNEL_TIMEOUT_MS = 30_000;
+
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
 
@@ -392,7 +394,10 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 
 			const proxyUrl = shouldBypassProxy(new URL(baseUrl)) ? undefined : getProxyForProvider(model.provider);
 			if (proxyUrl) {
-				const tlsSocket = await connectProxiedSocket(proxyUrl, baseUrl);
+				const tlsSocket = await connectProxiedSocket(proxyUrl, baseUrl, {
+					signal: options?.signal,
+					timeoutMs: CURSOR_PROXY_TUNNEL_TIMEOUT_MS,
+				});
 				h2Client = http2.connect(baseUrl, {
 					createConnection: () => tlsSocket,
 				});

--- a/packages/ai/src/utils/proxy.ts
+++ b/packages/ai/src/utils/proxy.ts
@@ -162,11 +162,26 @@ export function wrapFetchForProxy(fetchImpl: FetchImpl, provider: string): Fetch
 	return wrapped;
 }
 
+export interface ConnectProxiedSocketOptions {
+	/** Caller cancellation for the proxy TCP/TLS handshake and CONNECT tunnel. */
+	signal?: AbortSignal;
+	/** Maximum wall-clock time to establish the final TLS tunnel. Disabled when absent or non-positive. */
+	timeoutMs?: number;
+}
+
 /**
  * Tunnel a socket connection through an HTTP CONNECT proxy.
  * This is used specifically to wrap Node's `http2.connect(baseUrl, { createConnection })` for Cursor.
  */
-export async function connectProxiedSocket(proxyUrlStr: string, targetUrlStr: string): Promise<tls.TLSSocket> {
+export async function connectProxiedSocket(
+	proxyUrlStr: string,
+	targetUrlStr: string,
+	options?: ConnectProxiedSocketOptions,
+): Promise<tls.TLSSocket> {
+	if (options?.signal?.aborted) {
+		throw new AIError.AbortError("Proxy tunnel aborted");
+	}
+
 	const proxyUrl = new URL(proxyUrlStr);
 	const targetUrl = new URL(targetUrlStr);
 
@@ -179,23 +194,73 @@ export async function connectProxiedSocket(proxyUrlStr: string, targetUrlStr: st
 
 	const { promise, resolve, reject } = Promise.withResolvers<tls.TLSSocket>();
 
-	let rawSocket: net.Socket;
-	if (useProxySsl) {
-		rawSocket = tls.connect({
-			host: proxyHost,
-			port: proxyPort,
-		});
-	} else {
-		rawSocket = net.connect({
-			host: proxyHost,
-			port: proxyPort,
-		});
-	}
-
-	rawSocket.once("error", reject);
-
 	const readyEvent = useProxySsl ? "secureConnect" : "connect";
-	rawSocket.once(readyEvent, () => {
+	let rawSocket: net.Socket | undefined;
+	let tunnelSocket: tls.TLSSocket | undefined;
+	let timeout: NodeJS.Timeout | undefined;
+	let responseData = "";
+	let settled = false;
+
+	const cleanup = (): void => {
+		if (timeout) {
+			clearTimeout(timeout);
+			timeout = undefined;
+		}
+		options?.signal?.removeEventListener("abort", onAbort);
+		rawSocket?.off("error", onRawError);
+		rawSocket?.off(readyEvent, onProxyReady);
+		rawSocket?.off("data", onProxyData);
+		tunnelSocket?.off("secureConnect", onTunnelReady);
+		tunnelSocket?.off("error", onTunnelError);
+	};
+	const destroyInProgress = (): void => {
+		tunnelSocket?.destroy();
+		rawSocket?.destroy();
+	};
+	const rejectOnce = (error: Error): void => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		destroyInProgress();
+		reject(error);
+	};
+	const resolveOnce = (socket: tls.TLSSocket): void => {
+		if (settled) return;
+		settled = true;
+		cleanup();
+		resolve(socket);
+	};
+	const onAbort = (): void => rejectOnce(new AIError.AbortError("Proxy tunnel aborted"));
+	const onRawError = (error: Error): void => rejectOnce(error);
+	const onTunnelError = (error: Error): void => rejectOnce(error);
+	const onTunnelReady = (): void => {
+		if (!tunnelSocket) return;
+		resolveOnce(tunnelSocket);
+	};
+	const onProxyData = (chunk: Buffer): void => {
+		if (!rawSocket) return;
+		responseData += chunk.toString("binary");
+		if (!responseData.includes("\r\n\r\n")) return;
+
+		rawSocket.off("data", onProxyData);
+		rawSocket.off("error", onRawError);
+
+		const firstLine = responseData.split("\r\n")[0];
+		if (!firstLine.includes(" 200 ")) {
+			rejectOnce(new AIError.ValidationError(`Proxy tunnel failed: ${firstLine}`));
+			return;
+		}
+
+		tunnelSocket = tls.connect({
+			socket: rawSocket,
+			servername: targetHost,
+			ALPNProtocols: ["h2"],
+		});
+		tunnelSocket.once("secureConnect", onTunnelReady);
+		tunnelSocket.once("error", onTunnelError);
+	};
+	const onProxyReady = (): void => {
+		if (!rawSocket) return;
 		let connectReq = `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\n` + `Host: ${targetHost}:${targetPort}\r\n`;
 
 		if (proxyUrl.username || proxyUrl.password) {
@@ -207,34 +272,29 @@ export async function connectProxiedSocket(proxyUrlStr: string, targetUrlStr: st
 		connectReq += "\r\n";
 
 		rawSocket.write(connectReq);
+		rawSocket.on("data", onProxyData);
+	};
 
-		let responseData = "";
-		const onData = (chunk: Buffer) => {
-			responseData += chunk.toString("binary");
-			if (responseData.includes("\r\n\r\n")) {
-				rawSocket.off("data", onData);
-				rawSocket.off("error", reject);
+	options?.signal?.addEventListener("abort", onAbort, { once: true });
+	if (options?.timeoutMs !== undefined && Number.isFinite(options.timeoutMs) && options.timeoutMs > 0) {
+		const timeoutMs = Math.trunc(options.timeoutMs);
+		timeout = setTimeout(() => {
+			rejectOnce(new AIError.StreamTimeoutError(`Proxy tunnel timed out after ${timeoutMs}ms`));
+		}, timeoutMs);
+		timeout.unref?.();
+	}
 
-				const firstLine = responseData.split("\r\n")[0];
-				if (firstLine.includes(" 200 ")) {
-					const tlsSocket = tls.connect({
-						socket: rawSocket,
-						servername: targetHost,
-						ALPNProtocols: ["h2"],
-					});
-
-					tlsSocket.once("secureConnect", () => {
-						resolve(tlsSocket);
-					});
-					tlsSocket.once("error", reject);
-				} else {
-					rawSocket.destroy();
-					reject(new AIError.ValidationError(`Proxy tunnel failed: ${firstLine}`));
-				}
-			}
-		};
-		rawSocket.on("data", onData);
-	});
+	rawSocket = useProxySsl
+		? tls.connect({
+				host: proxyHost,
+				port: proxyPort,
+			})
+		: net.connect({
+				host: proxyHost,
+				port: proxyPort,
+			});
+	rawSocket.once("error", onRawError);
+	rawSocket.once(readyEvent, onProxyReady);
 
 	return promise;
 }

--- a/packages/ai/test/proxy.test.ts
+++ b/packages/ai/test/proxy.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as net from "node:net";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import {
+	connectProxiedSocket,
 	getProxyForProvider,
 	isLocalOrMetadataHost,
 	shouldBypassProxy,
@@ -8,6 +11,55 @@ import {
 } from "@oh-my-pi/pi-ai/utils/proxy";
 
 const PROXY = "http://127.0.0.1:24560";
+
+interface SilentProxyServer {
+	url: string;
+	accepted: Promise<net.Socket>;
+	close(): Promise<void>;
+}
+
+async function createSilentProxyServer(): Promise<SilentProxyServer> {
+	const sockets = new Set<net.Socket>();
+	const accepted = Promise.withResolvers<net.Socket>();
+	const server = net.createServer(socket => {
+		sockets.add(socket);
+		socket.once("close", () => sockets.delete(socket));
+		accepted.resolve(socket);
+	});
+
+	const listening = Promise.withResolvers<void>();
+	const onError = (error: Error): void => listening.reject(error);
+	server.once("error", onError);
+	server.listen(0, "127.0.0.1", () => {
+		server.off("error", onError);
+		listening.resolve();
+	});
+	await listening.promise;
+
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("expected TCP listener address");
+
+	return {
+		url: `http://127.0.0.1:${address.port}`,
+		accepted: accepted.promise,
+		async close() {
+			for (const socket of sockets) socket.destroy();
+			const closed = Promise.withResolvers<void>();
+			server.close(error => {
+				if (error) closed.reject(error);
+				else closed.resolve();
+			});
+			await closed.promise;
+		},
+	};
+}
+
+async function waitForSocketClose(socket: net.Socket): Promise<void> {
+	if (socket.destroyed) return;
+	const closed = Promise.withResolvers<void>();
+	socket.once("close", () => closed.resolve());
+	await closed.promise;
+}
 
 const isProxyEnvKey = (k: string): boolean => k.startsWith("PI_PROXY") || k === "NO_PROXY" || k === "no_proxy";
 
@@ -185,5 +237,48 @@ describe("wrapFetchForProxy", () => {
 		await wrapFetchForProxy(fetch, "wrap-badurl")("not a url");
 		expect(calls).toHaveLength(1);
 		expect(calls[0].proxy).toBeUndefined();
+	});
+});
+
+describe("connectProxiedSocket", () => {
+	it("times out and closes a proxy tunnel that never sends a CONNECT response", async () => {
+		const proxy = await createSilentProxyServer();
+		try {
+			const result = await connectProxiedSocket(proxy.url, "https://cursor.example", { timeoutMs: 20 }).then(
+				() => "resolved",
+				error => error,
+			);
+
+			expect(result).toBeInstanceOf(AIError.StreamTimeoutError);
+			const socket = await proxy.accepted;
+			await waitForSocketClose(socket);
+			expect(socket.destroyed).toBe(true);
+		} finally {
+			await proxy.close();
+		}
+	});
+
+	it("aborts and closes an in-progress proxy tunnel when the caller aborts", async () => {
+		const proxy = await createSilentProxyServer();
+		try {
+			const controller = new AbortController();
+			const pending = connectProxiedSocket(proxy.url, "https://cursor.example", {
+				signal: controller.signal,
+				timeoutMs: 1_000,
+			}).then(
+				() => "resolved",
+				error => error,
+			);
+			const socket = await proxy.accepted;
+
+			controller.abort();
+			const result = await pending;
+
+			expect(result).toBeInstanceOf(AIError.AbortError);
+			await waitForSocketClose(socket);
+			expect(socket.destroyed).toBe(true);
+		} finally {
+			await proxy.close();
+		}
 	});
 });


### PR DESCRIPTION
## Repro
A local TCP proxy that accepts the socket and never sends an HTTP CONNECT response leaves `connectProxiedSocket` pending: `bun .wt/repro-cursor-proxy-hang.ts` exited through the external watchdog with `connectProxiedSocket remained pending after proxy accepted TCP but sent no CONNECT response`.

## Cause
`packages/ai/src/utils/proxy.ts` established the proxy TCP/TLS connection, waited for the CONNECT response, and wrapped the final tunneled TLS socket without a timeout or `AbortSignal`; `packages/ai/src/providers/cursor.ts` awaited that helper before pushing the stream `start` event, so Cursor streams had no active watchdog during proxy tunnel setup.

## Fix
- Added `ConnectProxiedSocketOptions` with caller abort and handshake timeout handling that destroys the in-progress socket and clears listeners/timers once the final TLS tunnel connects.
- Passed `options?.signal` and a 30s Cursor proxy tunnel timeout from `streamCursor`.
- Added proxy regression tests for a silent CONNECT proxy and caller abort teardown.
- Added the package changelog entry for #4226.

## Verification
`bun test packages/ai/test/proxy.test.ts` passed (36 tests). `bun --cwd=packages/ai run check` passed. `gh_push_branch` pre-publish gate passed before pushing. Fixes #4226