### PR TITLE
fix(gitlab-duo-workflow): bounded signal/timeout on post-start REST setup fetches

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitLab Duo Workflow post-start REST setup fetches (`ensureGitLabDuoWorkflowSettings`, `discoverGitLabDuoWorkflowProject`, `resolveGitLabDuoWorkflowNumericProjectId`, `requestGitLabDuoWorkflowDirectAccess`, `createGitLabDuoWorkflow`, `fetchGitLabDuoWorkflowAvailableModels`, `stopGitLabDuoWorkflow`) missing `signal`/timeout parameters, which could leave the stream without a terminal event when a fetch stalled ([#4227](https://github.com/can1357/oh-my-pi/issues/4227)).
+
 ## [16.3.1] - 2026-07-02
 
 ### Changed

--- a/packages/ai/src/providers/gitlab-duo-workflow.ts
+++ b/packages/ai/src/providers/gitlab-duo-workflow.ts
@@ -48,6 +48,20 @@ const GITLAB_DUO_WORKFLOW_CLIENT_TYPE = "node-websocket";
  */
 const GITLAB_DUO_WORKFLOW_IDLE_TIMEOUT_MS = 90_000;
 /**
+ * Absolute deadline (ms) for each REST setup fetch (`ensureGitLabDuoWorkflowSettings`,
+ * `discoverGitLabDuoWorkflowProject`, `resolveGitLabDuoWorkflowNumericProjectId`,
+ * `requestGitLabDuoWorkflowDirectAccess`, `createGitLabDuoWorkflow`,
+ * `fetchGitLabDuoWorkflowAvailableModels`, `stopGitLabDuoWorkflow`).
+ *
+ * `streamGitLabDuoWorkflow` pushes its `start` event before these calls run and the
+ * `gitlab-duo-agent` bypass in `streamSimple` skips the `register-builtins`
+ * `iterateWithIdleTimeout` wrapper, so a stalled setup fetch would otherwise leave
+ * the stream with no terminal event. 30s covers healthy p99 for every REST endpoint
+ * the workflow touches while still surfacing a real stall as a provider error;
+ * matches the OAuth `TOKEN_REQUEST_TIMEOUT_MS` used by sibling GitLab flows.
+ */
+const GITLAB_DUO_WORKFLOW_REST_TIMEOUT_MS = 30_000;
+/**
  * How many times a single stream may restart on a FRESH workflow after the server
  * reports its per-workflow step (graph-recursion) limit. Long OMP tool-call loops
  * legitimately overrun the cap; each restart resets the budget. Bounded so a task
@@ -913,6 +927,19 @@ export function gitLabDuoWorkflowErrorText(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
+// Absolute-deadline signal for one REST setup fetch (`fetch`, `direct_access`, etc.).
+// The caller's abort signal — when present — is folded in with `AbortSignal.any`, so
+// either the request being cancelled OR the local timeout aborts the fetch. Called
+// per-fetch so each REST call gets its OWN fresh budget; a shared timeout would race
+// several fetches on the same clock and starve the later ones after the first spent
+// the whole budget. The workflow's `start` event already streamed before any of
+// these calls run, so an unbounded fetch would leave the assistant stream with no
+// terminal event — see {@link GITLAB_DUO_WORKFLOW_REST_TIMEOUT_MS}.
+function gitLabDuoWorkflowRestSignal(callerSignal?: AbortSignal): AbortSignal {
+	const timeoutSignal = AbortSignal.timeout(GITLAB_DUO_WORKFLOW_REST_TIMEOUT_MS);
+	return callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal;
+}
+
 async function readGitLabDuoWorkflowResponseErrorMessage(response: Response): Promise<string | undefined> {
 	try {
 		const payload: unknown = await response.json();
@@ -1074,7 +1101,7 @@ async function runGitLabDuoWorkflow(
 			// success or 4xx). A transient network error / 5xx returns false so a later
 			// turn retries instead of permanently skipping the PUT on a namespace whose
 			// flags are still off.
-			if (await ensureGitLabDuoWorkflowSettings(fetchImpl, baseUrl, apiKey, restNamespaceId)) {
+			if (await ensureGitLabDuoWorkflowSettings(fetchImpl, baseUrl, apiKey, restNamespaceId, options.signal)) {
 				markGitLabDuoWorkflowSettingsEnsured(apiKey, baseUrl, options.cwd);
 			}
 		}
@@ -1089,7 +1116,7 @@ async function runGitLabDuoWorkflow(
 			!configuredProjectPath && !configuredProjectId && isGitLabDuoWorkflowInlineFlow(workflowDefinition)
 				? namespaceSelection.projectPath
 					? { path: namespaceSelection.projectPath }
-					: await discoverGitLabDuoWorkflowProject(fetchImpl, baseUrl, apiKey, restNamespaceId)
+					: await discoverGitLabDuoWorkflowProject(fetchImpl, baseUrl, apiKey, restNamespaceId, options.signal)
 				: undefined;
 		if (discoveredProject) {
 			traceGitLabDuoWorkflow("project.discover", {
@@ -1111,7 +1138,7 @@ async function runGitLabDuoWorkflow(
 		const webSocketProjectId =
 			projectId ??
 			(projectPath
-				? await resolveGitLabDuoWorkflowNumericProjectId(fetchImpl, baseUrl, apiKey, projectPath)
+				? await resolveGitLabDuoWorkflowNumericProjectId(fetchImpl, baseUrl, apiKey, projectPath, options.signal)
 				: undefined);
 		const workflowConnection: GitLabDuoWorkflowDirectAccessConnection = options.workflowToken
 			? { token: options.workflowToken, headers: {}, serviceEndpoint: false }
@@ -1122,6 +1149,7 @@ async function runGitLabDuoWorkflow(
 					rootNamespaceId,
 					restProjectId,
 					workflowDefinition,
+					options.signal,
 				);
 		const workflowId =
 			options.workflowId ??
@@ -1135,7 +1163,13 @@ async function runGitLabDuoWorkflow(
 				workflowDefinition,
 				options.signal,
 			));
-		const availableModels = await fetchGitLabDuoWorkflowAvailableModels(fetchImpl, baseUrl, apiKey, rootNamespaceId);
+		const availableModels = await fetchGitLabDuoWorkflowAvailableModels(
+			fetchImpl,
+			baseUrl,
+			apiKey,
+			rootNamespaceId,
+			options.signal,
+		);
 		const selectedModelIdentifier = selectGitLabDuoWorkflowModelRef(model.id, availableModels);
 		// A `toolChoice: "none"` side-request (e.g. handoff keeps live tool definitions
 		// in the cache prefix but disables tool use) must not advertise the tools to
@@ -1466,6 +1500,7 @@ async function fetchGitLabDuoWorkflowAvailableModels(
 	baseUrl: string,
 	apiKey: string,
 	rootNamespaceId: string,
+	signal?: AbortSignal,
 ): Promise<GitLabAvailableModelsPayload | undefined> {
 	try {
 		const response = await fetchImpl(gitLabApiUrl(baseUrl, "/api/graphql"), {
@@ -1478,12 +1513,16 @@ async function fetchGitLabDuoWorkflowAvailableModels(
 				query: GITLAB_DUO_WORKFLOW_AVAILABLE_MODELS_QUERY,
 				variables: { rootNamespaceId: toGitLabGraphQLNamespaceId(rootNamespaceId) },
 			}),
+			signal: gitLabDuoWorkflowRestSignal(signal),
 		});
 		if (!response.ok) return undefined;
 		const payload: unknown = await response.json();
 		const models = getRecord(getRecord(payload, "data"), "aiChatAvailableModels");
 		return parseGitLabAvailableModelsPayload(models);
 	} catch {
+		// Timeout (AbortSignal.timeout) surfaces as an AbortError here; matches the pre-fix
+		// transient-network behavior (undefined -> caller falls back to defaults), so a
+		// stalled models fetch degrades rather than hanging the whole stream.
 		return undefined;
 	}
 }
@@ -1513,6 +1552,7 @@ async function resolveGitLabDuoWorkflowNumericProjectId(
 	baseUrl: string,
 	apiKey: string,
 	projectPath: string,
+	signal?: AbortSignal,
 ): Promise<string | undefined> {
 	try {
 		const response = await fetchImpl(gitLabApiUrl(baseUrl, `/api/v4/projects/${encodeURIComponent(projectPath)}`), {
@@ -1521,11 +1561,15 @@ async function resolveGitLabDuoWorkflowNumericProjectId(
 				Authorization: `Bearer ${apiKey}`,
 				"content-type": "application/json",
 			},
+			signal: gitLabDuoWorkflowRestSignal(signal),
 		});
 		if (!response.ok) return undefined;
 		const payload: unknown = await response.json();
 		return getRecordString(payload, "id");
 	} catch {
+		// Timeout / abort behaves like a transient network fault: undefined leaves the
+		// caller to fall back to the workflow's namespace-only routing rather than block
+		// the stream on a hanging project lookup.
 		return undefined;
 	}
 }
@@ -1549,6 +1593,7 @@ async function discoverGitLabDuoWorkflowProject(
 	baseUrl: string,
 	apiKey: string,
 	restNamespaceId: string,
+	signal?: AbortSignal,
 ): Promise<GitLabDuoWorkflowDiscoveredProject | undefined> {
 	const query = "per_page=1&min_access_level=30&order_by=last_activity_at&sort=desc";
 	const endpoints = [
@@ -1563,6 +1608,7 @@ async function discoverGitLabDuoWorkflowProject(
 					Authorization: `Bearer ${apiKey}`,
 					"content-type": "application/json",
 				},
+				signal: gitLabDuoWorkflowRestSignal(signal),
 			});
 			if (!response.ok) continue;
 			const payload: unknown = await response.json();
@@ -1570,7 +1616,10 @@ async function discoverGitLabDuoWorkflowProject(
 			const id = getRecordString(first, "id");
 			const path = getRecordString(first, "path_with_namespace");
 			if (id && path) return { id, path };
-		} catch {}
+		} catch {
+			// Timeout/abort on one endpoint: fall through to the next fallback rather than
+			// aborting discovery. Each endpoint gets its own fresh REST budget.
+		}
 	}
 	return undefined;
 }
@@ -1582,7 +1631,12 @@ async function requestGitLabDuoWorkflowDirectAccess(
 	rootNamespaceId: string,
 	projectId?: string,
 	workflowDefinition: GitLabDuoWorkflowDefinition = GITLAB_DUO_WORKFLOW_DEFINITION,
+	signal?: AbortSignal,
 ): Promise<GitLabDuoWorkflowDirectAccessConnection> {
+	// A timeout here throws `AbortError`/`TimeoutError` (per `AbortSignal.timeout`),
+	// which surfaces through the outer `streamGitLabDuoWorkflow` catch as a real
+	// stream `error` event — matching the existing HTTP-error path rather than the
+	// swallowed best-effort helpers (settings ensure / project discovery / models).
 	const response = await fetchImpl(gitLabApiUrl(baseUrl, "/api/v4/ai/duo_workflows/direct_access"), {
 		method: "POST",
 		headers: {
@@ -1590,6 +1644,7 @@ async function requestGitLabDuoWorkflowDirectAccess(
 			"content-type": "application/json",
 		},
 		body: JSON.stringify(buildGitLabDuoWorkflowDirectAccessBody(rootNamespaceId, projectId, workflowDefinition)),
+		signal: gitLabDuoWorkflowRestSignal(signal),
 	});
 	traceGitLabDuoWorkflow("direct_access.response", {
 		status: response.status,
@@ -1654,7 +1709,7 @@ async function createGitLabDuoWorkflow(
 			"content-type": "application/json",
 		},
 		body: JSON.stringify(body),
-		signal,
+		signal: gitLabDuoWorkflowRestSignal(signal),
 	});
 	traceGitLabDuoWorkflow("workflow.create.response", {
 		status: response.status,
@@ -1686,14 +1741,30 @@ async function stopGitLabDuoWorkflow(
 	apiKey: string,
 	workflowId: string,
 ): Promise<void> {
-	await fetchImpl(gitLabApiUrl(baseUrl, `/api/v4/ai/duo_workflows/workflows/${encodeURIComponent(workflowId)}`), {
-		method: "PATCH",
-		headers: {
-			Authorization: `Bearer ${apiKey}`,
-			"content-type": "application/json",
-		},
-		body: JSON.stringify(buildGitLabDuoWorkflowStopBody()),
-	});
+	// Stop rides a FRESH timeout signal, deliberately decoupled from `options.signal`
+	// (see the `finally` block in `runGitLabDuoWorkflow`): a run cancelled by the
+	// caller must still fire the server-side stop, but a stalled PATCH here would
+	// otherwise leave the `runGitLabDuoWorkflow` promise unresolved forever — the
+	// bounded budget keeps cleanup best-effort in both directions.
+	try {
+		await fetchImpl(gitLabApiUrl(baseUrl, `/api/v4/ai/duo_workflows/workflows/${encodeURIComponent(workflowId)}`), {
+			method: "PATCH",
+			headers: {
+				Authorization: `Bearer ${apiKey}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify(buildGitLabDuoWorkflowStopBody()),
+			signal: gitLabDuoWorkflowRestSignal(),
+		});
+	} catch (error) {
+		// Server-side stop is best-effort: a timeout / network fault must not reject
+		// the caller (the local stream already emitted its terminal event). Trace and
+		// swallow so the enclosing `finally` never surfaces a spurious rejection.
+		traceGitLabDuoWorkflow("workflow.stop_error", {
+			workflowId,
+			error: gitLabDuoWorkflowErrorText(error),
+		});
+	}
 }
 
 // Body the group PUT carries to turn on exactly the three flags the inline MCP-only
@@ -1721,6 +1792,7 @@ async function ensureGitLabDuoWorkflowSettings(
 	baseUrl: string,
 	apiKey: string,
 	restNamespaceId: string,
+	signal?: AbortSignal,
 ): Promise<boolean> {
 	// Returns whether the attempt was DEFINITIVE (so the caller may stop retrying):
 	// any HTTP response — 2xx (flags now on) or 4xx (insufficient rights / no such
@@ -1735,6 +1807,7 @@ async function ensureGitLabDuoWorkflowSettings(
 				"content-type": "application/json",
 			},
 			body: JSON.stringify(buildGitLabDuoWorkflowSettingsBody()),
+			signal: gitLabDuoWorkflowRestSignal(signal),
 		});
 		traceGitLabDuoWorkflow("settings.ensure", { status: response.status, ok: response.ok });
 		return response.status < 500;

--- a/packages/ai/test/gitlab-duo-workflow-provider.test.ts
+++ b/packages/ai/test/gitlab-duo-workflow-provider.test.ts
@@ -1781,6 +1781,147 @@ describe("GitLab Duo Workflow WebSocket state machine", () => {
 		expect(extractHttpStatusFromError({ message: result.errorMessage })).toBe(403);
 	});
 
+	it("aborts stalled REST setup fetches when the caller cancels the request", async () => {
+		// Every setup endpoint stalls FOREVER unless the request signal aborts it. Before
+		// the fix the setup fetches ignored `options.signal`, so a caller cancel could
+		// not unblock them and the stream would emit `start` and hang without a `done`
+		// or `error` event — the reported #4227 hang.
+		const stalledEndpoints: string[] = [];
+		const fetchImpl: FetchImpl = (input: string | URL | Request, init?: RequestInit) => {
+			const url = String(input);
+			stalledEndpoints.push(url);
+			return new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				if (!signal) {
+					reject(new Error(`no signal on ${url}`));
+					return;
+				}
+				const onAbort = (): void => {
+					reject(signal.reason ?? new DOMException("aborted", "AbortError"));
+				};
+				if (signal.aborted) {
+					onAbort();
+					return;
+				}
+				signal.addEventListener("abort", onAbort, { once: true });
+			});
+		};
+
+		const controller = new AbortController();
+		const stream = streamGitLabDuoWorkflow(model, context, {
+			apiKey: "[REDACTED]",
+			rootNamespaceId: "gid://gitlab/Group/1",
+			fetch: fetchImpl,
+			signal: controller.signal,
+		});
+
+		// Give the setup path one microtask hop to reach the first fetch, then cancel.
+		await Bun.sleep(5);
+		expect(stalledEndpoints.length).toBeGreaterThan(0);
+		controller.abort(new Error("caller cancelled"));
+
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage ?? "").not.toBe("");
+	});
+
+	it("bounds each REST setup fetch with an abort signal even when the caller passes none", async () => {
+		// The reported hang can happen with no caller signal at all: the provider must
+		// still install its own absolute-deadline signal on every setup fetch so a
+		// stalled endpoint cannot leave the stream without a terminal event. Assert
+		// that every REST setup endpoint receives a real AbortSignal on its RequestInit.
+		const capturedSignals = new Map<string, AbortSignal | undefined>();
+		// (method, endpoint-kind) keys distinguish the settings PUT on /api/v4/groups/
+		// from the catalog's discovery GET on the same path.
+		const keyKinds: readonly { method: string; kind: string }[] = [
+			{ method: "POST", kind: "/api/graphql" },
+			{ method: "POST", kind: "/api/v4/ai/duo_workflows/direct_access" },
+			{ method: "POST", kind: "/api/v4/ai/duo_workflows/workflows" },
+			{ method: "GET", kind: "/api/v4/projects/" },
+			{ method: "PUT", kind: "/api/v4/groups/" },
+		];
+		const fetchImpl: FetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+			const url = String(input);
+			const method = init?.method ?? "GET";
+			for (const { method: m, kind } of keyKinds) {
+				const key = `${m} ${kind}`;
+				if (method === m && url.includes(kind) && !capturedSignals.has(key)) {
+					capturedSignals.set(key, init?.signal ?? undefined);
+				}
+			}
+			if (url.includes("/api/graphql")) {
+				return new Response(
+					JSON.stringify({
+						data: {
+							aiChatAvailableModels: {
+								defaultModel: { name: "Claude", ref: "claude_sonnet_4_6_vertex" },
+								selectableModels: [],
+								pinnedModel: null,
+							},
+						},
+					}),
+					{ status: 200 },
+				);
+			}
+			if (url.includes("/api/v4/ai/duo_workflows/direct_access")) {
+				return new Response(JSON.stringify({ gitlab_rails: { token: "rails-token" } }), { status: 200 });
+			}
+			if (url.includes("/api/v4/ai/duo_workflows/workflows/")) {
+				return new Response("{}", { status: 200 });
+			}
+			if (url.includes("/api/v4/ai/duo_workflows/workflows")) {
+				return new Response(JSON.stringify({ id: "workflow-signal-check" }), { status: 200 });
+			}
+			if (url.includes("/api/v4/projects/")) {
+				return new Response(JSON.stringify({ id: "42" }), { status: 200 });
+			}
+			if (url.includes("/api/v4/groups/")) {
+				return new Response("{}", { status: 200 });
+			}
+			return new Response("{}", { status: 404 });
+		};
+		const webSocketFactory: GitLabDuoWorkflowWebSocketFactory = () => {
+			const socket: GitLabDuoWorkflowWebSocketLike = {
+				onopen: null,
+				onmessage: null,
+				onerror: null,
+				onclose: null,
+				send() {},
+				close() {},
+			};
+			queueMicrotask(() => {
+				socket.onopen?.(new Event("open"));
+				socket.onmessage?.(new MessageEvent("message", { data: JSON.stringify({ status: "INPUT_REQUIRED" }) }));
+			});
+			return socket;
+		};
+
+		await streamGitLabDuoWorkflow(
+			// Fresh baseUrl + apiKey so the per-account settings cache in the provider does
+			// not skip the settings PUT (making the /api/v4/groups/ endpoint unobserved).
+			{ ...model, baseUrl: "https://gitlab.rest-signal-check.example.com" } as Model<"gitlab-duo-agent">,
+			context,
+			{
+				apiKey: "rest-signal-check-key",
+				// A namespace + project path forces the runtime through all three REST
+				// fetches beyond direct_access + create: settings PUT (groups), project GET
+				// (projects), available models (graphql).
+				rootNamespaceId: "gid://gitlab/Group/1",
+				projectPath: "group/project",
+				fetch: fetchImpl,
+				webSocketFactory,
+			},
+		).result();
+
+		// Every setup fetch we exercised must carry a real AbortSignal. `undefined` would
+		// mean the timeout regression is back.
+		for (const { method, kind } of keyKinds) {
+			const key = `${method} ${kind}`;
+			const signal = capturedSignals.get(key);
+			expect(signal, `expected ${key} fetch to carry an AbortSignal`).toBeInstanceOf(AbortSignal);
+		}
+	});
+
 	it("preserves the 401 status for an Unauthorized direct_access body so the credential can rotate", async () => {
 		const fetchImpl: FetchImpl = async (input: string | URL | Request) => {
 			const url = String(input);


### PR DESCRIPTION
## Repro

`streamGitLabDuoWorkflow` pushes `{ type: "start" }` before six REST setup fetches (`ensureGitLabDuoWorkflowSettings`, `discoverGitLabDuoWorkflowProject`, `resolveGitLabDuoWorkflowNumericProjectId`, `requestGitLabDuoWorkflowDirectAccess`, `createGitLabDuoWorkflow`, `fetchGitLabDuoWorkflowAvailableModels`) plus the cleanup `stopGitLabDuoWorkflow` PATCH. `streamSimple` special-cases `model.api === "gitlab-duo-agent"` (`packages/ai/src/stream.ts:1171-1180`) and bypasses the `register-builtins` `iterateWithIdleTimeout` wrapper via `healLeakedThinking`, so any stalled setup fetch left the assistant stream with no `error`/`done` terminal event. Test `aborts stalled REST setup fetches when the caller cancels the request` demonstrates: install a fetch impl that stalls until its `AbortSignal` fires, then abort the caller's signal — before the fix the stalled fetch never sees the caller signal and the stream never terminates; after the fix it terminates with `stopReason: "error"`.

## Cause

Setup fetches in `packages/ai/src/providers/gitlab-duo-workflow.ts` were called without `signal` or timeout. `createGitLabDuoWorkflow` already accepted an `AbortSignal` from `options.signal` but never composed it with a timeout, and the others took no signal at all — so neither a caller cancel nor an absolute deadline could unblock a stalled REST endpoint. `stopGitLabDuoWorkflow` (called from the `finally` cleanup path with a deliberately fresh signal per its comment) had the same issue.

## Fix

- Added `GITLAB_DUO_WORKFLOW_REST_TIMEOUT_MS = 30_000` and a per-fetch helper `gitLabDuoWorkflowRestSignal(callerSignal)` returning `AbortSignal.any([caller, AbortSignal.timeout(30_000)])` (matches the OAuth `TOKEN_REQUEST_TIMEOUT_MS` used by sibling GitLab flows).
- Threaded `options.signal` through the six setup helpers and composed the timeout at each `fetchImpl` call; each fetch now gets its own fresh 30s budget so a shared timer cannot starve later calls.
- Best-effort helpers (settings / project-discovery / models / project-id resolve) keep degrading to `undefined`/`false` on timeout — matches the pre-fix transient-network semantics.
- Throwing helpers (`requestGitLabDuoWorkflowDirectAccess`, `createGitLabDuoWorkflow`) let the abort/timeout propagate to the outer `streamGitLabDuoWorkflow` catch, which emits a real `error` event on the stream.
- `stopGitLabDuoWorkflow` gets a fresh timeout-only signal (preserving the existing decoupling from `options.signal` documented in the `runGitLabDuoWorkflow` finally block) plus a swallowing catch so cleanup remains best-effort even if the PATCH times out.
- Two regression tests in `packages/ai/test/gitlab-duo-workflow-provider.test.ts`:
  - `aborts stalled REST setup fetches when the caller cancels the request` — end-to-end behavior test that would have hung without the fix.
  - `bounds each REST setup fetch with an abort signal even when the caller passes none` — structural assertion that every REST setup endpoint receives an `AbortSignal` on its `RequestInit`, so an absolute deadline is always in place.

## Verification

- `bun test packages/ai/test/gitlab-duo-workflow-provider.test.ts` → **77 pass, 0 fail** (2 new tests included).
- `bun test packages/ai/test/gitlab-duo-workflow-oauth.test.ts` → 2 pass, 0 fail.
- `bun test packages/ai/test` → 2910 pass, 1 pre-existing flake unrelated to this change (`getProxyForProvider > normalizes hyphenated provider ids to underscores` — reproduces at `HEAD~1` without any of these files touched; test passes when run alone via `bun test packages/ai/test/proxy.test.ts`).

Fixes #4227