### PR TITLE
fix(status-line): route gh pr lookup through git.github.run with timeout signal

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed status-line PR lookup wedging the segment indefinitely when `gh pr view` stalled (keychain prompt, network hang, auth deadlock). The lookup now routes through `git.github.run` with `AbortSignal.timeout(GIT_COMMAND_TIMEOUT_MS)`, inheriting the non-interactive `gh` environment and enforcing the standard 5-minute deadline instead of leaking the child ([#4234](https://github.com/can1357/oh-my-pi/issues/4234)).
+
 ## [16.3.1] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -4,7 +4,6 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai";
 import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { getProjectDir } from "@oh-my-pi/pi-utils";
-import { $ } from "bun";
 import { settings } from "../../../config/settings";
 import type { AgentSession } from "../../../session/agent-session";
 import type { OAuthAccountIdentity } from "../../../session/auth-storage";
@@ -707,14 +706,22 @@ export class StatusLineComponent implements Component {
 				}
 			};
 			try {
-				// Requires `gh repo set-default` to be configured; fails gracefully if not
-				const result = await $`gh pr view --json number,url`.cwd(lookupCwd).quiet().nothrow();
+				// Route through the shared `gh` helper so the child inherits
+				// `GH_NON_INTERACTIVE_ENV` (disables terminal/keychain prompts) and
+				// hard-terminates on the git command deadline instead of stalling
+				// the status-line indefinitely (#4234). Requires `gh repo set-default`;
+				// non-zero exit still falls through to the null cache below.
+				const result = await git.github.run(
+					lookupCwd,
+					["pr", "view", "--json", "number,url"],
+					AbortSignal.timeout(git.GIT_COMMAND_TIMEOUT_MS),
+				);
 				if (this.#disposed) return;
 				if (result.exitCode !== 0) {
 					setCachedPr(null);
 					return;
 				}
-				const pr = JSON.parse(result.stdout.toString()) as { number: number; url: string };
+				const pr = JSON.parse(result.stdout) as { number: number; url: string };
 				if (typeof pr.number === "number") {
 					setCachedPr({ number: pr.number, url: pr.url });
 				} else {

--- a/packages/coding-agent/test/status-line-pr-lookup-timeout.test.ts
+++ b/packages/coding-agent/test/status-line-pr-lookup-timeout.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression: StatusLineComponent#lookupPr previously called `gh pr view`
+ * through Bun's raw `$` with no signal or non-interactive env. A stalled
+ * `gh` (keychain prompt, network hang, auth deadlock) wedged the child
+ * forever — `#prLookupInFlight` was set before the await and never reset,
+ * so the PR segment stayed permanently in-flight and the child process
+ * leaked. See #4234.
+ *
+ * Contract: `#lookupPr` MUST delegate to `git.github.run(cwd, args, signal)`
+ * with an `AbortSignal` (regressing to raw `$` drops the signal entirely),
+ * and the finally-block MUST clear `#prLookupInFlight` on both success and
+ * rejection so the segment never wedges after a single failure.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { GitRefHead } from "@oh-my-pi/pi-coding-agent/utils/git";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+// HEAD on a feature branch so `#isDefaultBranch("feature/x")` returns false
+// (the sync seed is "main"), letting `#lookupPr` reach the gh call.
+const fakeRefHead: GitRefHead = {
+	kind: "ref",
+	branchName: "feature/x",
+	ref: "refs/heads/feature/x",
+	commit: null,
+	commonDir: "/fake/.git",
+	gitDir: "/fake/.git",
+	gitEntryPath: "/fake/.git",
+	headPath: "/fake/.git/HEAD",
+	repoRoot: "/fake",
+	headContent: "ref: refs/heads/feature/x\n",
+};
+
+const gitSegmentSettings: StatusLineSettings = {
+	preset: "custom",
+	leftSegments: ["pr"],
+	rightSegments: ["session_name"],
+	separator: "powerline-thin",
+	sessionAccent: false,
+	transparent: false,
+};
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "pr-lookup-timeout test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+beforeEach(() => {
+	vi.spyOn(git.head, "resolveSync").mockReturnValue(fakeRefHead);
+	// Bypass the delayed default-branch resolver used by `#isDefaultBranch`;
+	// synchronous seed of "main" is enough to make the check return false.
+	vi.spyOn(git.branch, "default").mockResolvedValue("main");
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("StatusLineComponent PR lookup timeout guard", () => {
+	it("routes gh pr view through git.github.run with a bounded abort signal", async () => {
+		const { promise: ghCalled, resolve: markGhCalled } =
+			Promise.withResolvers<{ args: readonly string[]; signal: AbortSignal | undefined }>();
+		const { promise: ghUnblock, resolve: releaseGh } = Promise.withResolvers<void>();
+
+		vi.spyOn(git.github, "run").mockImplementation(async (_cwd, args, signal) => {
+			markGhCalled({ args, signal });
+			await ghUnblock;
+			return { exitCode: 1, stdout: "", stderr: "" };
+		});
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegmentSettings);
+		try {
+			// Render triggers `#lookupPr` → git.github.run.
+			component.getTopBorder(80);
+
+			const call = await ghCalled;
+			expect(call.args).toEqual(["pr", "view", "--json", "number,url"]);
+
+			// The regression fires when no signal is threaded through: the child
+			// runs forever and cannot be aborted. A signal that hasn't fired at
+			// call time is enough — `AbortSignal.timeout(GIT_COMMAND_TIMEOUT_MS)`
+			// is the shape produced by the fix, and any regression to raw `$`
+			// drops the signal entirely.
+			expect(call.signal).toBeInstanceOf(AbortSignal);
+			expect(call.signal?.aborted).toBe(false);
+		} finally {
+			releaseGh();
+			await Promise.resolve();
+			component.dispose();
+		}
+	});
+
+	it("clears #prLookupInFlight when git.github.run rejects (e.g. timeout abort)", async () => {
+		// If the abort/timeout path leaves `#prLookupInFlight = true`, every
+		// subsequent render skips the lookup and the PR segment freezes.
+		// The finally-block must reset it whether the helper resolves or
+		// throws.
+		vi.spyOn(git.github, "run").mockRejectedValue(new Error("simulated timeout"));
+
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegmentSettings);
+		try {
+			// First render fires the (rejecting) lookup.
+			component.getTopBorder(80);
+			// Drain the microtask queue so the catch/finally chain runs.
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// Second render must be free to attempt another lookup, proving
+			// the in-flight flag was released.
+			const secondCallSpy = vi.spyOn(git.github, "run");
+			// Replace the mock to succeed cheaply on the retry.
+			secondCallSpy.mockResolvedValue({
+				exitCode: 0,
+				stdout: JSON.stringify({ number: 42, url: "https://github.com/x/y/pull/42" }),
+				stderr: "",
+			});
+			component.getTopBorder(80);
+			await Promise.resolve();
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(secondCallSpy).toHaveBeenCalled();
+		} finally {
+			component.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/status-line-pr-lookup-timeout.test.ts
+++ b/packages/coding-agent/test/status-line-pr-lookup-timeout.test.ts
@@ -100,8 +100,10 @@ afterEach(() => {
 
 describe("StatusLineComponent PR lookup timeout guard", () => {
 	it("routes gh pr view through git.github.run with a bounded abort signal", async () => {
-		const { promise: ghCalled, resolve: markGhCalled } =
-			Promise.withResolvers<{ args: readonly string[]; signal: AbortSignal | undefined }>();
+		const { promise: ghCalled, resolve: markGhCalled } = Promise.withResolvers<{
+			args: readonly string[];
+			signal: AbortSignal | undefined;
+		}>();
 		const { promise: ghUnblock, resolve: releaseGh } = Promise.withResolvers<void>();
 
 		vi.spyOn(git.github, "run").mockImplementation(async (_cwd, args, signal) => {


### PR DESCRIPTION
## Repro

Stub a hung `gh` on `PATH` (mimics a keychain prompt / network stall):

```bash
cat >/tmp/gh <<'SH'
#!/usr/bin/env bash
sleep 3600
SH
chmod +x /tmp/gh
PATH=/tmp:$PATH bun run /tmp/current.ts   # await never resolves
```

where `current.ts` calls `` await $`gh pr view --json number,url`.cwd(cwd).quiet().nothrow() `` — the exact shape used by `StatusLineComponent#lookupPr`. Bun's `$` awaits `child.exited` with no signal, so the caller stays pending as long as the child does. In the running TUI, `#prLookupInFlight` is set before the await and never reset, so every subsequent render skips the lookup and the `pr` segment permanently freezes.

## Cause

`packages/coding-agent/src/modes/components/status-line/component.ts:711` invoked `gh pr view` through Bun's raw `` $ `` shell with no `AbortSignal`, no timeout, and no non-interactive env (`GIT_TERMINAL_PROMPT=0`, `GH_PROMPT_DISABLED=1`). The repo already has a hardened helper — `git.github.run(cwd, args, signal, options)` — that runs `gh` through `Bun.spawn` with `GH_NON_INTERACTIVE_ENV` and honors the caller's signal for termination; the status-line just wasn't using it.

## Fix

- `packages/coding-agent/src/modes/components/status-line/component.ts`: replace the raw `` $`gh pr view ...` `` call with `git.github.run(lookupCwd, ["pr","view","--json","number,url"], AbortSignal.timeout(git.GIT_COMMAND_TIMEOUT_MS))`. `result.stdout` is already a `string`, so drop the `.toString()`. Non-zero exit still routes to `setCachedPr(null)`, and `ToolError` / `ToolAbortError` are caught by the existing `catch`, so the failure-tolerant contract is unchanged.
- Drop the now-unused `import { $ } from "bun"` (sole user).
- `packages/coding-agent/test/status-line-pr-lookup-timeout.test.ts`: new regression suite. Spies on `git.github.run` to assert (a) the exact args (`pr view --json number,url`) and that an `AbortSignal` is threaded through, and (b) `#prLookupInFlight` is released after a rejected call so a follow-up render can retry.
- `packages/coding-agent/CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Verification

- `bun test test/status-line-pr-lookup-timeout.test.ts` → 2 pass / 0 fail.
- `bun test test/status-line* test/git* test/gh* src/modes/components/status-line/ src/utils/git*` (all plausibly affected tests) → 155 pass / 5 skip / 0 fail.
- Pre-publish `bun run fix` + `bun check` gate ran green during `gh_push_branch`.
- Manual repro against a hung `/tmp/gh` stub: current path stayed pending past 3s (matches the hang); the equivalent `Bun.spawn` + `AbortSignal.timeout` path resolved at the timeout with `exit=null` (SIGTERM delivered), confirming the fix path unblocks.

Fixes #4234