### PR TITLE
fix(catalog): restore Zhipu Coding Plan availability

### DIFF
--- a/packages/ai/test/zhipu-coding-plan-login.test.ts
+++ b/packages/ai/test/zhipu-coding-plan-login.test.ts
@@ -13,7 +13,8 @@ describe("zhipu coding plan login", () => {
 				"Content-Type": "application/json",
 				Authorization: "Bearer zhipu-key",
 			});
-			validationBody = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+			validationBody =
+				typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
 			return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },

--- a/packages/ai/test/zhipu-coding-plan-login.test.ts
+++ b/packages/ai/test/zhipu-coding-plan-login.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "bun:test";
+import { loginZhipuCodingPlan } from "@oh-my-pi/pi-ai/registry/zhipu-coding-plan";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+describe("zhipu coding plan login", () => {
+	it("validates against the domestic Coding Plan base and model used as provider default", async () => {
+		let validationBody: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			expect(url).toBe("https://open.bigmodel.cn/api/coding/paas/v4/chat/completions");
+			expect(init?.method).toBe("POST");
+			expect(init?.headers).toEqual({
+				"Content-Type": "application/json",
+				Authorization: "Bearer zhipu-key",
+			});
+			validationBody = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+			return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		const apiKey = await loginZhipuCodingPlan({
+			onPrompt: async () => "  zhipu-key  ",
+			fetch: fetchMock,
+		});
+
+		expect(apiKey).toBe("zhipu-key");
+		expect(validationBody).toMatchObject({
+			model: "glm-5.1",
+			messages: [{ role: "user", content: "ping" }],
+			max_tokens: 1,
+			temperature: 0,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Zhipu Coding Plan runtime discovery so account-scoped model lists replace bundled fallback models, preventing valid non-z.ai keys from being routed to unavailable GLM variants. ([#4296](https://github.com/can1357/oh-my-pi/issues/4296))
+
 ## [16.3.1] - 2026-07-02
 
 ### Removed

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -8330,10 +8330,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 11,
-				"output": 55,
-				"cacheRead": 1.1,
-				"cacheWrite": 13.75
+				"input": 10,
+				"output": 50,
+				"cacheRead": 1,
+				"cacheWrite": 12.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -12658,23 +12658,33 @@
 	"cerebras": {
 		"gemma-4-31b": {
 			"id": "gemma-4-31b",
-			"name": "gemma-4-31b",
+			"name": "Gemma 4 31B IT",
 			"api": "openai-completions",
 			"provider": "cerebras",
 			"baseUrl": "https://api.cerebras.ai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.99,
+				"output": 1.49,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 8192
+			"contextWindow": 131072,
+			"maxTokens": 40960,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"gpt-oss-120b": {
 			"id": "gpt-oss-120b",
@@ -17558,7 +17568,7 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
-			"name": "MiniMax-M3 (3x usage)",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "fireworks",
 			"baseUrl": "https://api.fireworks.ai/inference/v1",
@@ -18094,6 +18104,48 @@
 				"effortMap": {
 					"minimal": "low"
 				}
+			}
+		},
+		"claude-sonnet-5": {
+			"id": "claude-sonnet-5",
+			"name": "Claude Sonnet 5",
+			"api": "anthropic-messages",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 10,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15",
+				"X-GitHub-Api-Version": "2026-06-01"
+			},
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				},
+				"supportsDisplay": true
 			}
 		},
 		"gemini-2.5-pro": {
@@ -20148,7 +20200,7 @@
 		},
 		"gemma-4-31b": {
 			"id": "gemma-4-31b",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "google-generative-ai",
 			"provider": "google",
 			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
@@ -60067,7 +60119,7 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
-			"name": "MiniMax-M3 (3x usage)",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -63775,8 +63827,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.19999999999999998,
-				"output": 0.77,
+				"input": 0.24,
+				"output": 0.8999999999999999,
 				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
@@ -64032,9 +64084,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.098,
-				"output": 0.196,
-				"cacheRead": 0.02,
+				"input": 0.08900000000000001,
+				"output": 0.18,
+				"cacheRead": 0.018,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -65283,12 +65335,12 @@
 			],
 			"cost": {
 				"input": 0.255,
-				"output": 1,
+				"output": 1.02,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 196608,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -65310,13 +65362,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.29,
-				"output": 0.95,
+				"input": 0.3,
+				"output": 1.2,
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 196608,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -66037,11 +66089,11 @@
 			"cost": {
 				"input": 0.6,
 				"output": 2.5,
-				"cacheRead": 0.6,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 100352,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -68788,13 +68840,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.39999999999999997,
+				"input": 0.13,
+				"output": 1.56,
 				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -68901,8 +68953,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.049999999999999996,
-				"output": 0.39999999999999997,
+				"input": 0.117,
+				"output": 0.45499999999999996,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
@@ -71329,7 +71381,7 @@
 	"synthetic": {
 		"hf:MiniMaxAI/MiniMax-M3": {
 			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71344,7 +71396,7 @@
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -71389,26 +71441,37 @@
 		},
 		"hf:moonshotai/Kimi-K2.7-Code": {
 			"id": "hf:moonshotai/Kimi-K2.7-Code",
-			"name": "moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.95,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8192
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71437,7 +71500,7 @@
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71464,7 +71527,7 @@
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71493,7 +71556,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -71551,7 +71614,7 @@
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73126,6 +73189,36 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"claude-sonnet-5": {
+			"id": "claude-sonnet-5",
+			"name": "Claude Sonnet 5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"deepseek-v3.2": {
 			"id": "deepseek-v3.2",
 			"name": "DeepSeek V3.2",
@@ -74395,7 +74488,7 @@
 		},
 		"minimax-m3": {
 			"id": "minimax-m3",
-			"name": "MiniMax-M3 (3x usage)",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
@@ -82295,6 +82388,14 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82307,14 +82408,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-4.3": {
@@ -82336,6 +82429,14 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82348,14 +82449,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-build": {

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -457,9 +457,10 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "zhipu-coding-plan",
-		defaultModel: "glm-5.2",
+		defaultModel: "glm-5.1",
 		envVars: ["ZHIPU_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => zhipuCodingPlanModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
 		catalogDiscovery: { label: "Zhipu Coding Plan" },
 	},
 ] as const satisfies readonly ProviderCatalogEntry[];

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1283,6 +1283,7 @@ export function zhipuCodingPlanModelManagerOptions(
 	const baseUrl = config?.baseUrl ?? "https://open.bigmodel.cn/api/coding/paas/v4";
 	return {
 		providerId: "zhipu-coding-plan",
+		dynamicModelsAuthoritative: true,
 		...(apiKey && {
 			fetchDynamicModels: () =>
 				fetchOpenAICompatibleModels({

--- a/packages/catalog/test/zhipu-compat.test.ts
+++ b/packages/catalog/test/zhipu-compat.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { buildOpenAICompat } from "@oh-my-pi/pi-catalog/compat/openai";
+import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
 import { zhipuCodingPlanModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
 import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
@@ -58,6 +59,13 @@ function zhipuGlm52ByOfficialBaseUrl(): ModelSpec<"openai-completions"> {
 		baseUrl: "https://open.bigmodel.cn/api/paas/v4",
 	};
 }
+
+describe("zhipu-coding-plan descriptor", () => {
+	it("defaults to the same Zhipu-hosted model used by login validation", () => {
+		expect(DEFAULT_MODEL_PER_PROVIDER["zhipu-coding-plan"]).toBe("glm-5.1");
+		expect(DEFAULT_MODEL_PER_PROVIDER.zai).toBe("glm-5.2");
+	});
+});
 
 describe("openai-completions compat — zhipu-coding-plan branch", () => {
 	it("forces zai thinking format and disables reasoning_effort before GLM-5.2", () => {
@@ -127,6 +135,7 @@ describe("zhipu-coding-plan model discovery", () => {
 
 		const options = zhipuCodingPlanModelManagerOptions({ apiKey: "test-key", fetch: mockFetch });
 		expect(typeof options.fetchDynamicModels).toBe("function");
+		expect(options.dynamicModelsAuthoritative).toBe(true);
 		const models = await options.fetchDynamicModels?.();
 
 		expect(requestedUrl).toBe("https://open.bigmodel.cn/api/coding/paas/v4/models");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -369,9 +369,7 @@ describe("ModelRegistry", () => {
 			const calls: Array<{
 				provider: string;
 				sessionId: string | undefined;
-				options:
-					| { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal }
-					| undefined;
+				options: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal } | undefined;
 			}> = [];
 			const originalGetApiKey = authStorage.getApiKey.bind(authStorage);
 			authStorage.getApiKey = async (
@@ -394,7 +392,10 @@ describe("ModelRegistry", () => {
 				},
 			});
 
-			const resolved = await registry.resolver(model, sessionId)({
+			const resolved = await registry.resolver(
+				model,
+				sessionId,
+			)({
 				lastChance: false,
 				error: undefined,
 				signal: undefined,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -359,6 +359,59 @@ describe("ModelRegistry", () => {
 				else Bun.env.OPENAI_API_KEY = originalOpenAiKey;
 			}
 		});
+		test("zhipu-coding-plan glm-5.2 chat resolves the zhipu credential with model-scoped hints", async () => {
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("zhipu-coding-plan", "glm-5.2");
+			if (!model) throw new Error("expected bundled zhipu-coding-plan/glm-5.2 model");
+			await authStorage.set("zhipu-coding-plan", { type: "api_key", key: "zhipu-domestic-key" });
+			await authStorage.set("zai", { type: "api_key", key: "zai-international-key" });
+
+			const calls: Array<{
+				provider: string;
+				sessionId: string | undefined;
+				options:
+					| { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal }
+					| undefined;
+			}> = [];
+			const originalGetApiKey = authStorage.getApiKey.bind(authStorage);
+			authStorage.getApiKey = async (
+				provider: string,
+				sessionId?: string,
+				options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
+			): Promise<string | undefined> => {
+				calls.push({ provider, sessionId, options });
+				return originalGetApiKey(provider, sessionId, options);
+			};
+
+			const sessionId = "session-zhipu-auth-path";
+			await expect(registry.getApiKey(model, sessionId)).resolves.toBe("zhipu-domestic-key");
+			expect(calls.at(-1)).toEqual({
+				provider: "zhipu-coding-plan",
+				sessionId,
+				options: {
+					baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+					modelId: "glm-5.2",
+				},
+			});
+
+			const resolved = await registry.resolver(model, sessionId)({
+				lastChance: false,
+				error: undefined,
+				signal: undefined,
+			});
+			expect(resolved).toBe("zhipu-domestic-key");
+			expect(calls.at(-1)).toEqual({
+				provider: "zhipu-coding-plan",
+				sessionId,
+				options: {
+					baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+					modelId: "glm-5.2",
+					forceRefresh: undefined,
+					signal: undefined,
+				},
+			});
+		});
+
 		test("baseUrl-only override does not affect other providers", () => {
 			const googleModels = getModelsForProvider(anthropicProxy, "google");
 			// Google models should still have their original baseUrl
@@ -2039,6 +2092,20 @@ describe("ModelRegistry", () => {
 
 			expect(syntheticModels.map(model => model.id)).toEqual(["hf:zai-org/GLM-5.1"]);
 			expect(registry.find("synthetic", "hf:moonshotai/Kimi-K2.5")).toBeUndefined();
+		});
+
+		test("does not re-add bundled Zhipu Coding Plan models after account discovery", async () => {
+			authStorage.setRuntimeApiKey("zhipu-coding-plan", "zhipu-test-key");
+			const fetchMock = mockOpenAiCompatibleModels("https://open.bigmodel.cn/api/coding/paas/v4/models", [
+				"glm-5.1",
+			]);
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+
+			await registry.refreshProvider("zhipu-coding-plan", "online");
+			const zhipuModels = getModelsForProvider(registry, "zhipu-coding-plan");
+
+			expect(zhipuModels.map(model => model.id)).toEqual(["glm-5.1"]);
+			expect(registry.find("zhipu-coding-plan", "glm-5.2")).toBeUndefined();
 		});
 
 		test("keeps bundled google-vertex fallback when cached project catalog is non-authoritative", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -321,6 +321,50 @@ describe("pickDefaultAvailableModel", () => {
 		expect(result?.provider).toBe("anthropic");
 		expect(result?.id).toBe(DEFAULT_MODEL_PER_PROVIDER.anthropic);
 	});
+
+	test("uses the Zhipu Coding Plan login-validated model before newer z.ai defaults", () => {
+		const zhipuGlm51 = buildModel({
+			id: "glm-5.1",
+			name: "GLM-5.1",
+			api: "openai-completions",
+			provider: "zhipu-coding-plan",
+			baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 131072,
+		});
+		const zhipuGlm52 = buildModel({
+			id: "glm-5.2",
+			name: "GLM-5.2",
+			api: "openai-completions",
+			provider: "zhipu-coding-plan",
+			baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1000000,
+			maxTokens: 131072,
+		});
+		const zaiGlm52 = buildModel({
+			id: "glm-5.2",
+			name: "GLM-5.2",
+			api: "anthropic-messages",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/anthropic",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1000000,
+			maxTokens: 131072,
+		});
+
+		const result = pickDefaultAvailableModel([zhipuGlm51, zhipuGlm52, zaiGlm52]);
+
+		expect(result?.provider).toBe("zhipu-coding-plan");
+		expect(result?.id).toBe("glm-5.1");
+	});
 });
 
 describe("parseModelPattern", () => {


### PR DESCRIPTION
## Repro
A minimal `ModelRegistry` repro with a `zhipu-coding-plan` runtime key and mocked `https://open.bigmodel.cn/api/coding/paas/v4/models` response containing only `glm-5.1` still kept bundled `zhipu-coding-plan/glm-5.2` selectable after `refreshProvider("zhipu-coding-plan", "online")`, matching the reporter's valid-login/unavailable-chat path.

## Cause
`packages/catalog/src/provider-models/descriptors.ts` let non-z.ai `zhipu-coding-plan` default to a newer GLM variant than the login probe in `packages/ai/src/registry/zhipu-coding-plan.ts` validates, and `packages/catalog/src/provider-models/openai-compat.ts` did not mark Zhipu runtime discovery as authoritative, so authenticated account-scoped model lists were merged with bundled fallbacks instead of replacing unavailable models.

## Fix
- Set the Zhipu Coding Plan default back to the login-validated `glm-5.1` while leaving Z.AI on `glm-5.2`.
- Mark Zhipu Coding Plan dynamic discovery authoritative so `/models` results remove bundled GLM variants the account cannot use.
- Added login, descriptor, resolver, and registry regressions for the Zhipu/non-z.ai path.
- Regenerated the bundled catalog.

## Verification
`bun test packages/ai/test/zhipu-coding-plan-login.test.ts packages/catalog/test/zhipu-compat.test.ts packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/model-registry.test.ts` passed: 204 pass, 0 fail, 3175 expect() calls. `gh_push_branch` pre-publish gate also completed before push. Fixes #4296