### PR TITLE
fix(tui): invalidate autocomplete on destructive edits and guard stale Tab/Enter acceptance

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed destructive editing keys (`Ctrl+W`, `Ctrl+U`, `Ctrl+K`, `Alt+Backspace`, `Alt+D`) and paste/yank leaving the autocomplete popup active with a stale prefix; `Tab` and `Enter` on the file-path branch would then insert the outdated selection into the newly edited buffer. Every text-mutating path now refreshes autocomplete like backspace/forward-delete already do, and the `Tab`/`Enter`+file-path acceptance now applies the same staleness guard the `Enter`+slash path uses, so a stale popup silently cancels instead of corrupting the input ([#4295](https://github.com/can1357/oh-my-pi/issues/4295)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1119,6 +1119,15 @@ export class Editor implements Component, Focusable {
 
 				// If Tab was pressed, always apply the selection
 				if (kb.matches(data, "tui.input.tab")) {
+					// Check for stale autocomplete state due to buffer edits since last refresh
+					// (destructive keys or paste can outrun the debounced update).
+					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
+					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
+					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor)) {
+						// Autocomplete is stale - silently cancel; Tab has no fallback action here.
+						this.#cancelAutocomplete();
+						return;
+					}
 					const selected = this.#autocompleteList.getSelectedItem();
 					if (selected && this.#autocompleteProvider) {
 						const shouldChainSlashCommandAutocomplete = this.#isSlashCommandNameAutocompleteSelection();
@@ -1183,30 +1192,38 @@ export class Editor implements Component, Focusable {
 				}
 				// If Enter was pressed on a file path, apply completion
 				else if (kb.matches(data, "tui.input.submit") || data === "\n") {
-					const selected = this.#autocompleteList.getSelectedItem();
-					if (selected && this.#autocompleteProvider) {
-						const result = this.#autocompleteProvider.applyCompletion(
-							this.#state.lines,
-							this.#state.cursorLine,
-							this.#state.cursorCol,
-							selected,
-							this.#autocompletePrefix,
-						);
-
-						this.#state.lines = result.lines;
-						this.#state.cursorLine = result.cursorLine;
-						this.#setCursorCol(result.cursorCol);
-
+					// Check for stale autocomplete state due to buffer edits since last refresh.
+					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
+					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
+					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor)) {
+						// Autocomplete is stale - cancel and fall through to normal submission
 						this.#cancelAutocomplete();
-						this.onAutocompleteUpdate?.();
+					} else {
+						const selected = this.#autocompleteList.getSelectedItem();
+						if (selected && this.#autocompleteProvider) {
+							const result = this.#autocompleteProvider.applyCompletion(
+								this.#state.lines,
+								this.#state.cursorLine,
+								this.#state.cursorCol,
+								selected,
+								this.#autocompletePrefix,
+							);
 
-						if (this.onChange) {
-							this.onChange(this.getText());
+							this.#state.lines = result.lines;
+							this.#state.cursorLine = result.cursorLine;
+							this.#setCursorCol(result.cursorCol);
+
+							this.#cancelAutocomplete();
+							this.onAutocompleteUpdate?.();
+
+							if (this.onChange) {
+								this.onChange(this.getText());
+							}
+
+							result.onApplied?.();
 						}
-
-						result.onApplied?.();
+						return;
 					}
-					return;
 				}
 			}
 			// For other keys (like regular typing), DON'T return here
@@ -1875,7 +1892,6 @@ export class Editor implements Component, Focusable {
 				// then evaluate autocomplete triggers once at the final cursor position.
 				if (filteredText) {
 					this.#insertTextAtCursor(filteredText);
-					this.#retriggerAutocompleteAtCursor();
 				}
 				return;
 			}
@@ -2351,6 +2367,7 @@ export class Editor implements Component, Focusable {
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}
+		this.#retriggerAutocompleteAtCursor();
 	}
 
 	#yankFromKillRing(): void {
@@ -2457,6 +2474,7 @@ export class Editor implements Component, Focusable {
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}
+		this.#retriggerAutocompleteAtCursor();
 	}
 
 	#deleteToEndOfLine(): void {
@@ -2488,6 +2506,7 @@ export class Editor implements Component, Focusable {
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}
+		this.#retriggerAutocompleteAtCursor();
 	}
 
 	#deleteWordBackwards(): void {
@@ -2522,6 +2541,7 @@ export class Editor implements Component, Focusable {
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}
+		this.#retriggerAutocompleteAtCursor();
 	}
 
 	#deleteWordForwards(): void {
@@ -2553,6 +2573,7 @@ export class Editor implements Component, Focusable {
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}
+		this.#retriggerAutocompleteAtCursor();
 	}
 
 	#handleForwardDelete(): void {
@@ -2844,11 +2865,39 @@ export class Editor implements Component, Focusable {
 		return this.#isInSubmittedSlashCommandContext() || this.#isInMidPromptSkillSlashContext();
 	}
 
+	/**
+	 * Decide whether the popup's `#autocompletePrefix` still safely maps onto the current
+	 * text before the cursor for an accept-time (`applyCompletion`) call. Mirrors the
+	 * re-anchoring branches in `CombinedAutocompleteProvider.applyCompletion`:
+	 *
+	 * - Exact match → always safe.
+	 * - Path branch is safe when the prefix is still a live suffix of the text; the
+	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
+	 * - Slash branch re-anchors when both the prefix and the current text carry a
+	 *   leading slash command and the current slash token is clean (no whitespace or
+	 *   inner slash), matching `applyCompletion`'s slash-branch guard.
+	 * - `@`-file branch re-anchors via `#extractAtPrefix`; safe when the current text
+	 *   still ends in a whitespace-anchored `@<token>`.
+	 * - Everything else is stale — accepting it would corrupt the buffer (issue #4295).
+	 */
 	#autocompletePrefixMatchesCursorText(currentTextBeforeCursor: string): boolean {
 		if (currentTextBeforeCursor === this.#autocompletePrefix) return true;
-		if (findTrailingSlashCommandStart(this.#autocompletePrefix) !== 0) return false;
-		const slashStart = findTrailingSlashCommandStart(currentTextBeforeCursor);
-		return slashStart !== null && currentTextBeforeCursor.slice(slashStart) === this.#autocompletePrefix;
+
+		if (currentTextBeforeCursor.endsWith(this.#autocompletePrefix)) return true;
+
+		if (findLeadingSlashCommandStart(this.#autocompletePrefix) !== null) {
+			const currentLeadingStart = findLeadingSlashCommandStart(currentTextBeforeCursor);
+			if (currentLeadingStart !== null) {
+				const token = currentTextBeforeCursor.slice(currentLeadingStart);
+				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
+			}
+		}
+
+		if (this.#autocompletePrefix.startsWith("@")) {
+			return /(?:^|\s)@[^\s]*$/.test(currentTextBeforeCursor);
+		}
+
+		return false;
 	}
 
 	#isSlashCommandNameAutocompleteSelection(): boolean {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -344,3 +344,186 @@ describe("Editor Enter handler sync slash completion", () => {
 		expect(submitted).toBe("/model");
 	});
 });
+
+/**
+ * Stub provider that recognises `/todo <sub>` slash commands and supports fuzzy prefixes
+ * used to exercise stale autocomplete acceptance (issue #4295).
+ */
+class TodoSubcommandProvider implements AutocompleteProvider {
+	async getSuggestions(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		const line = lines[cursorLine] || "";
+		const before = line.slice(0, cursorCol);
+		if (before.startsWith("/todo ") && !before.includes("\n")) {
+			const query = before.slice("/todo ".length);
+			const all: AutocompleteItem[] = [
+				{ value: "start", label: "start" },
+				{ value: "done", label: "done" },
+			];
+			const items = query ? all.filter(i => i.value.startsWith(query)) : all;
+			if (items.length === 0) return null;
+			return { prefix: before, items };
+		}
+		return null;
+	}
+
+	applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		item: AutocompleteItem,
+		prefix: string,
+	): { lines: string[]; cursorLine: number; cursorCol: number } {
+		const line = lines[cursorLine] || "";
+		// Anchor replacement at the end of the "/todo " literal, so only the query tail
+		// gets rewritten with the selected subcommand value.
+		const replaceStart = cursorCol - prefix.length + "/todo ".length;
+		const before = line.slice(0, replaceStart);
+		const after = line.slice(cursorCol);
+		const nextLines = [...lines];
+		nextLines[cursorLine] = before + item.value + after;
+		return {
+			lines: nextLines,
+			cursorLine,
+			cursorCol: before.length + item.value.length,
+		};
+	}
+}
+
+describe("Editor autocomplete invalidation on destructive edits (issue #4295)", () => {
+	async function primeAutocomplete(editor: Editor) {
+		editor.handleInput("/todo s");
+		await Bun.sleep(0);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+	}
+
+	it("does not insert a stale suggestion when Tab follows Ctrl+W", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new TodoSubcommandProvider());
+		await primeAutocomplete(editor);
+
+		editor.handleInput("\x17"); // Ctrl+W: delete word backward
+		expect(editor.getText()).toBe("/todo ");
+
+		editor.handleInput("\t");
+		// Tab must NOT insert the stale "start" suggestion; buffer stays as-is.
+		expect(editor.getText()).toBe("/todo ");
+	});
+
+	it("does not insert a stale suggestion when Tab follows Ctrl+U", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new TodoSubcommandProvider());
+		await primeAutocomplete(editor);
+
+		editor.handleInput("\x15"); // Ctrl+U: delete to start of line
+		expect(editor.getText()).toBe("");
+
+		editor.handleInput("\t");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("does not insert a stale suggestion when Tab follows Alt+Backspace", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new TodoSubcommandProvider());
+		await primeAutocomplete(editor);
+
+		editor.handleInput("\x1b\x7f"); // Alt+Backspace: delete word backward
+		expect(editor.getText()).toBe("/todo ");
+
+		editor.handleInput("\t");
+		expect(editor.getText()).toBe("/todo ");
+	});
+
+	it("does not insert a stale suggestion when Tab follows Alt+D", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new TodoSubcommandProvider());
+
+		// Prime with `/todo start` and move cursor between "/todo " and "start"
+		editor.setText("/todo start");
+		editor.handleInput("\x01"); // Ctrl+A: cursor to line start
+		for (const _ of "/todo ") editor.handleInput("\x06"); // Ctrl+F: forward one char
+		editor.handleInput("s"); // trigger autocomplete for "/todo s"
+		await Bun.sleep(0);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("\x1bd"); // Alt+D: delete word forward (consumes remaining "tart")
+		// Only the forward "tart" is consumed; cursor sits after "/todo s" and the popup is now stale
+		// because further reduction of the buffer (e.g. following Ctrl+W) should still invalidate.
+		editor.handleInput("\x17"); // Ctrl+W: back through the "s" and "/todo "
+		editor.handleInput("\t");
+		expect(editor.getText()).not.toContain("start");
+	});
+
+	it("does not insert a stale suggestion after Ctrl+Y yank replaces the prefix", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new TodoSubcommandProvider());
+
+		// Seed the kill ring with "hello " via type-then-Ctrl+U
+		editor.setText("hello ");
+		editor.handleInput("\x15"); // Ctrl+U kills into ring
+		expect(editor.getText()).toBe("");
+
+		await primeAutocomplete(editor);
+
+		// Yank inserts "hello " and should invalidate the prefix (`/todo s` no longer at cursor).
+		editor.handleInput("\x19"); // Ctrl+Y
+		expect(editor.getText()).toBe("/todo shello ");
+
+		editor.handleInput("\t");
+		// Tab must not paste the stale "start" over the yanked text.
+		expect(editor.getText()).toBe("/todo shello ");
+	});
+
+	it("falls through to submission when Enter presses on a stale file-path popup", async () => {
+		let forceFileCalls = 0;
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider({
+			async getSuggestions() {
+				return null;
+			},
+			applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+				const line = lines[cursorLine] || "";
+				const nextLines = [...lines];
+				nextLines[cursorLine] = line.slice(0, cursorCol - prefix.length) + item.value + line.slice(cursorCol);
+				return { lines: nextLines, cursorLine, cursorCol: cursorCol - prefix.length + item.value.length };
+			},
+			async getForceFileSuggestions() {
+				forceFileCalls += 1;
+				return {
+					prefix: "tmp",
+					items: [
+						{ value: "tmpA", label: "tmpA" },
+						{ value: "tmpB", label: "tmpB" },
+					],
+				};
+			},
+			shouldTriggerFileCompletion() {
+				return true;
+			},
+		});
+
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.setText("hello tmp");
+		editor.handleInput("\t"); // Force file completion (opens popup with "tmp" prefix)
+		for (let i = 0; i < 10; i += 1) {
+			await Promise.resolve();
+		}
+		expect(editor.isShowingAutocomplete()).toBe(true);
+		expect(forceFileCalls).toBe(1);
+
+		// Destructive edit removes the "tmp" prefix; popup is now stale.
+		editor.handleInput("\x17"); // Ctrl+W: removes "tmp"
+		expect(editor.getText()).toBe("hello ");
+
+		// Enter must fall through to submit, not paste the stale file suggestion.
+		editor.handleInput("\r");
+		expect(submitted).toBe("hello");
+	});
+});


### PR DESCRIPTION
## Repro

With autocomplete showing (e.g. `/todo s` → popup highlights `start`), destructive editing keys — <kbd>Ctrl</kbd>+<kbd>W</kbd>, <kbd>Ctrl</kbd>+<kbd>U</kbd>, <kbd>Ctrl</kbd>+<kbd>K</kbd>, <kbd>Alt</kbd>+<kbd>Backspace</kbd>, <kbd>Alt</kbd>+<kbd>D</kbd> — mutate the buffer without notifying autocomplete. Pressing <kbd>Tab</kbd> (or <kbd>Enter</kbd> on a file-path popup) then calls `applyCompletion` with the old prefix, whose `cursorCol - prefix.length` slice under-runs and produces corrupted output like `/todostart` after the user cleared `s` from `/todo s`. Paste and yank hit the same trap through `#insertTextAtCursor`.

Reproducer runs as `bun test packages/tui/test/editor-autocomplete-actions.test.ts -t "issue #4295"` — six regression cases exercise every destructive keybinding, yank-over-prefix, and the <kbd>Enter</kbd>+file-path stale fall-through.

## Cause

`packages/tui/src/components/editor.ts`:
- `#deleteToStartOfLine`, `#deleteToEndOfLine`, `#deleteWordBackwards`, `#deleteWordForwards`, and `#insertTextAtCursor` all mutate the buffer + fire `onChange` but never call `#retriggerAutocompleteAtCursor()`. `#handleBackspace` and `#handleForwardDelete` already do.
- The <kbd>Tab</kbd> acceptance branch (~line 1121 pre-fix) and the <kbd>Enter</kbd>+file-path branch (~line 1185 pre-fix) call `#autocompleteProvider.applyCompletion` unconditionally. The <kbd>Enter</kbd>+slash branch already had the `#autocompletePrefixMatchesCursorText` staleness guard — the sibling paths never picked it up.
- The old `#autocompletePrefixMatchesCursorText` only handled a mid-prompt trailing-slash edge case. Extending it naively to `Tab` broke the fix from #1748 (typing more chars while the popup is up), so the helper needed to mirror the actual re-anchor branches in `CombinedAutocompleteProvider.applyCompletion`.

## Fix

- Route all four destructive-edit methods and `#insertTextAtCursor` through `#retriggerAutocompleteAtCursor()` so text-mutating paths refresh autocomplete the same way `#handleBackspace`/`#handleForwardDelete` already do. Removed the now-redundant manual call inside `#handlePaste`.
- Added the `#autocompletePrefixMatchesCursorText` guard to the <kbd>Tab</kbd> and <kbd>Enter</kbd>+file-path branches — <kbd>Tab</kbd> silently cancels a stale popup; <kbd>Enter</kbd>+file cancels and falls through to normal submission (matching the <kbd>Enter</kbd>+slash sibling).
- Rewrote `#autocompletePrefixMatchesCursorText` to reflect the provider's real re-anchor branches: exact match, path-branch safe (prefix still a suffix), slash-branch safe (both sides carry a clean leading slash token), and `@`-branch safe (current text still ends in `@<token>`). Everything else is stale.

Added regression tests in `packages/tui/test/editor-autocomplete-actions.test.ts` under a new `Editor autocomplete invalidation on destructive edits (issue #4295)` describe block; CHANGELOG entry under `[Unreleased]`.

## Verification

`bun test packages/tui/test/editor-autocomplete-actions.test.ts` — **18 pass, 0 fail** (12 pre-existing + 6 new regressions).
`bun test packages/tui/test/editor.test.ts test/editor-autocomplete-actions.test.ts test/autocomplete.test.ts test/editor-top-border-provider.test.ts test/slash-autocomplete-viewport.test.ts test/committed-prefix-resync.test.ts` — **221 pass, 0 fail** across the editor/autocomplete surface.

Manual replay of the reporter's steps in a REPL against a stub `/todo <sub>` provider:

```
[after typing "/todo s"]  text = "/todo s"    popup shown = true
[after Ctrl+W]            text = "/todo "
[after Tab]               text = "/todo "     (pre-fix: "/todostart")
```

Unrelated pre-existing failures across `input.test.ts`, terminal-notifications, visibleWidth parity, etc. exist on the default branch already (confirmed via `git stash` + rerun) and are not touched by this change.

Fixes #4295