### PR TITLE
fix(cli): route update plugin shorthand

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp update -l` rejecting the documented plugin-update shorthand instead of upgrading installed marketplace plugins. ([#4304](https://github.com/can1357/oh-my-pi/issues/4304))
+
 ## [16.3.1] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -82,7 +82,7 @@ export interface BinaryReplacementOptions {
  * Parse update subcommand arguments.
  * Returns undefined if not an update command.
  */
-export function parseUpdateArgs(args: string[]): { force: boolean; check: boolean } | undefined {
+export function parseUpdateArgs(args: string[]): { force: boolean; check: boolean; plugins: boolean } | undefined {
 	if (args.length === 0 || args[0] !== "update") {
 		return undefined;
 	}
@@ -90,6 +90,7 @@ export function parseUpdateArgs(args: string[]): { force: boolean; check: boolea
 	return {
 		force: args.includes("--force") || args.includes("-f"),
 		check: args.includes("--check") || args.includes("-c"),
+		plugins: args.includes("--plugins") || args.includes("-l"),
 	};
 }
 
@@ -914,12 +915,14 @@ ${chalk.bold("Usage:")}
   ${APP_NAME} update [options]
 
 ${chalk.bold("Options:")}
-  -c, --check   Check for updates without installing
-  -f, --force   Force reinstall even if up to date
+  -c, --check     Check for updates without installing
+  -f, --force     Force reinstall even if up to date
+  -l, --plugins   Update installed plugins
 
 ${chalk.bold("Examples:")}
-  ${APP_NAME} update           Update to latest version
-  ${APP_NAME} update --check   Check if updates are available
-  ${APP_NAME} update --force   Force reinstall
+  ${APP_NAME} update              Update to latest version
+  ${APP_NAME} update --check      Check if updates are available
+  ${APP_NAME} update --force      Force reinstall
+  ${APP_NAME} update -l           Update installed plugins
 `);
 }

--- a/packages/coding-agent/src/commands/update.ts
+++ b/packages/coding-agent/src/commands/update.ts
@@ -2,7 +2,8 @@
  * Check for and install updates.
  */
 import { Command, Flags } from "@oh-my-pi/pi-utils/cli";
-import { runUpdateCommand } from "../cli/update-cli";
+import * as pluginCli from "../cli/plugin-cli";
+import * as updateCli from "../cli/update-cli";
 import { initTheme } from "../modes/theme/theme";
 
 export default class Update extends Command {
@@ -11,11 +12,16 @@ export default class Update extends Command {
 	static flags = {
 		force: Flags.boolean({ char: "f", description: "Force update", default: false }),
 		check: Flags.boolean({ char: "c", description: "Check for updates without installing", default: false }),
+		plugins: Flags.boolean({ char: "l", description: "Update installed plugins", default: false }),
 	};
 
 	async run(): Promise<void> {
 		const { flags } = await this.parse(Update);
 		await initTheme();
-		await runUpdateCommand({ force: flags.force, check: flags.check });
+		if (flags.plugins) {
+			await pluginCli.runPluginCommand({ action: "upgrade", args: [], flags: {} });
+		} else {
+			await updateCli.runUpdateCommand({ force: flags.force, check: flags.check });
+		}
 	}
 }

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -1,20 +1,25 @@
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as pluginCli from "@oh-my-pi/pi-coding-agent/cli/plugin-cli";
+import * as updateCli from "@oh-my-pi/pi-coding-agent/cli/update-cli";
 import {
 	buildBunInstallArgs,
 	buildHomebrewUpdateArgs,
 	buildMiseForceInstallArgs,
 	buildMiseUpgradeArgs,
+	parseUpdateArgs,
 	pruneBunInstallCache,
 	replaceBinaryForUpdate,
 	resolveBunGlobalNodeModulesDirFromLocations,
 	resolveUpdateMethodForTest,
 	sweepStaleBackups,
 } from "@oh-my-pi/pi-coding-agent/cli/update-cli";
+import Update from "@oh-my-pi/pi-coding-agent/commands/update";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import type { CliConfig } from "@oh-my-pi/pi-utils/cli";
 
 const tempDirs: string[] = [];
 
@@ -25,7 +30,43 @@ async function makeTempDir(): Promise<string> {
 }
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	await Promise.all(tempDirs.splice(0).map(dir => removeWithRetries(dir)));
+});
+const TEST_CONFIG: CliConfig = {
+	bin: "omp",
+	version: "0.0.0-test",
+	commands: new Map(),
+};
+
+describe("update command plugin dispatch", () => {
+	it("routes -l to plugin upgrade instead of the app updater", async () => {
+		const pluginSpy = spyOn(pluginCli, "runPluginCommand").mockResolvedValue(undefined);
+		const updateSpy = spyOn(updateCli, "runUpdateCommand").mockResolvedValue(undefined);
+
+		const command = new Update(["-l"], TEST_CONFIG);
+		await command.run();
+
+		expect(pluginSpy).toHaveBeenCalledWith({ action: "upgrade", args: [], flags: {} });
+		expect(updateSpy).not.toHaveBeenCalled();
+	});
+
+	it("keeps normal update flags on the app updater path", async () => {
+		const pluginSpy = spyOn(pluginCli, "runPluginCommand").mockResolvedValue(undefined);
+		const updateSpy = spyOn(updateCli, "runUpdateCommand").mockResolvedValue(undefined);
+
+		const command = new Update(["--check", "--force"], TEST_CONFIG);
+		await command.run();
+
+		expect(updateSpy).toHaveBeenCalledWith({ force: true, check: true });
+		expect(pluginSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("parseUpdateArgs", () => {
+	it("preserves the legacy plugin update shorthand", () => {
+		expect(parseUpdateArgs(["update", "-l"])).toEqual({ force: false, check: false, plugins: true });
+	});
 });
 describe("update-cli install target detection", () => {
 	it("uses bun update when prioritized omp is inside bun global bin", () => {


### PR DESCRIPTION
## Repro
`omp update -l` should update installed plugins, but it failed during command parsing before reaching plugin update logic. Reproduced with `bun packages/coding-agent/src/cli.ts update -l`, which returned `ERR_PARSE_ARGS_UNKNOWN_OPTION` for `-l`.

## Cause
`packages/coding-agent/src/commands/update.ts` declared only `--check/-c` and `--force/-f`, so the shared CLI parser rejected `-l`. The legacy `parseUpdateArgs` helper in `packages/coding-agent/src/cli/update-cli.ts` also only modeled app-update flags, leaving no plugin-update path for the documented shorthand.

## Fix
- Added `--plugins/-l` to the `update` command and routed it to `runPluginCommand({ action: "upgrade" })`.
- Kept the normal app update path unchanged for `--check` and `--force`.
- Updated the legacy update parser/help text and added dispatch regression tests.
- Added a changelog entry for the CLI fix.

## Verification
`bun test packages/coding-agent/test/update-cli.test.ts` passed with 22 tests. `HOME=/tmp/omp-4304-home bun packages/coding-agent/src/cli.ts update -l` exits successfully and prints `All marketplace plugins are up to date.` `bun run check` passed in `packages/coding-agent`. Fixes #4304