### PR TITLE
fix(tool): detect macOS sshfs mounts without mountpoint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed macOS SSHFS mount detection to skip remounting an already-mounted remote when `mountpoint` is unavailable. ([#4319](https://github.com/can1357/oh-my-pi/issues/4319))
+
 ## [16.3.1] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/ssh/__tests__/sshfs-mount.test.ts
+++ b/packages/coding-agent/src/ssh/__tests__/sshfs-mount.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { isMounted } from "../sshfs-mount";
+
+describe("isMounted", () => {
+	it("detects a macOS mount point when mountpoint is unavailable", async () => {
+		const parentPath = import.meta.dir;
+		const mountPath = path.join(parentPath, "mounted");
+		const stat = async (filePath: string) => ({ dev: filePath === mountPath ? 2 : 1 });
+
+		await expect(isMounted(mountPath, { platform: "darwin", stat, which: () => null })).resolves.toBe(true);
+	});
+});

--- a/packages/coding-agent/src/ssh/sshfs-mount.ts
+++ b/packages/coding-agent/src/ssh/sshfs-mount.ts
@@ -16,6 +16,16 @@ const CONTROL_PATH = getControlPathTemplate();
 
 const mountedPaths = new Set<string>();
 
+type MountPointStatReader = (filePath: string) => Promise<{ dev: number }>;
+
+interface MountCheckOptions {
+	platform?: NodeJS.Platform;
+	stat?: MountPointStatReader;
+	which?: (command: string) => string | null;
+}
+
+const readMountPointStats: MountPointStatReader = async filePath => fs.promises.stat(filePath);
+
 async function ensureDir(path: string, mode = 0o700): Promise<void> {
 	try {
 		await fs.promises.mkdir(path, { recursive: true, mode });
@@ -79,10 +89,23 @@ export function hasSshfs(): boolean {
 	return $which("sshfs") !== null;
 }
 
-export async function isMounted(path: string): Promise<boolean> {
-	const mountpoint = $which("mountpoint");
-	if (!mountpoint) return false;
-	const result = await $`${mountpoint} -q ${path}`.quiet().nothrow();
+async function isMountedByDeviceBoundary(mountPath: string, stat = readMountPointStats): Promise<boolean> {
+	try {
+		const [mountStats, parentStats] = await Promise.all([stat(mountPath), stat(path.dirname(mountPath))]);
+		return mountStats.dev !== parentStats.dev;
+	} catch {
+		return false;
+	}
+}
+
+export async function isMounted(mountPath: string, options: MountCheckOptions = {}): Promise<boolean> {
+	const which = options.which ?? $which;
+	const mountpoint = which("mountpoint");
+	if (!mountpoint) {
+		const platform = options.platform ?? process.platform;
+		return platform === "darwin" ? isMountedByDeviceBoundary(mountPath, options.stat) : false;
+	}
+	const result = await $`${mountpoint} -q ${mountPath}`.quiet().nothrow();
 	return result.exitCode === 0;
 }
 


### PR DESCRIPTION
## Repro
A focused regression test simulates macOS with `mountpoint` unavailable and an already-mounted SSHFS target by making `stat(mountPath).dev` differ from `stat(dirname(mountPath)).dev`; before the fix, `bun test packages/coding-agent/src/ssh/__tests__/sshfs-mount.test.ts` failed with `Expected: true`, `Received: false`.

## Cause
`packages/coding-agent/src/ssh/sshfs-mount.ts` implemented `isMounted()` as `mountpoint -q <path>` when the utility exists and `false` otherwise. On macOS, where `mountpoint` is commonly unavailable, `mountRemote()` treated an existing macFUSE mount as unmounted and invoked `sshfs` again.

## Fix
- Added a macOS fallback in `isMounted()` that compares the device id of the mount path and its parent directory when `mountpoint` is unavailable.
- Added an injectable mount-check seam used by a focused regression test for the macOS no-`mountpoint` path.
- Added a coding-agent changelog entry for #4319.

## Verification
Ran `bun test packages/coding-agent/src/ssh/__tests__/sshfs-mount.test.ts` (1 pass) and `bun check` (passed). `gh_push_branch` also completed its pre-publish gate before pushing. Fixes #4319