### PR TITLE
fix(agent): distinguish synthetic placeholder tool results from real tool failures

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed synthetic tool results emitted when an assistant turn ends with `stopReason: "error"` after a tool call was already streamed being surfaced by the CLI as if the local tool had failed. The placeholder result now reads "Tool call was not executed because the provider stream ended with an error before the tool could run: <upstream>" and carries a `SyntheticToolResultDetails` discriminator (`{ __synthetic: true, source: "assistant_stop_error", executed: false, upstreamError }`) on both the `ToolResultMessage` and the `tool_execution_end` event, so downstream UI/telemetry can distinguish provider-transport failures (e.g. Codex websocket close) from real local tool failures without string-matching ([#4321](https://github.com/can1357/oh-my-pi/issues/4321)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2131,11 +2131,7 @@ async function executeToolCalls(
  */
 export interface SyntheticToolResultDetails {
 	__synthetic: true;
-	source:
-		| "assistant_stop_aborted"
-		| "assistant_stop_error"
-		| "assistant_stop_skipped"
-		| "assistant_stop_length";
+	source: "assistant_stop_aborted" | "assistant_stop_error" | "assistant_stop_skipped" | "assistant_stop_length";
 	executed: false;
 	upstreamError?: string;
 }

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2113,8 +2113,59 @@ async function executeToolCalls(
 }
 
 /**
- * Create a tool result for a tool call that was aborted or errored before execution.
- * Maintains the tool_use/tool_result pairing required by the API.
+ * Discriminator embedded in {@link AgentToolResult.details} and
+ * {@link ToolResultMessage.details} for tool calls that were emitted by the
+ * assistant but never actually invoked locally.
+ *
+ * The synthetic result exists only to preserve the tool_use / tool_result
+ * pairing the provider API requires; no `tool.execute()` ran. UI, telemetry,
+ * and history consumers can key on `__synthetic === true` to render or
+ * classify these as "call emitted, not executed" instead of a real local
+ * tool failure — the mislabeling this discriminator was introduced to fix
+ * (#4321): a provider-side stream error after tool-call emission (e.g. Codex
+ * websocket close) was surfaced by the CLI as if the local tool had failed.
+ *
+ * `source` names the assistant-side termination state that prevented
+ * execution; `upstreamError` is the provider-reported message when the turn
+ * ended with `stopReason === "error"`.
+ */
+export interface SyntheticToolResultDetails {
+	__synthetic: true;
+	source:
+		| "assistant_stop_aborted"
+		| "assistant_stop_error"
+		| "assistant_stop_skipped"
+		| "assistant_stop_length";
+	executed: false;
+	upstreamError?: string;
+}
+
+function syntheticDetailsFor(
+	reason: "aborted" | "error" | "skipped" | "length",
+	errorMessage: string | undefined,
+): SyntheticToolResultDetails {
+	const source: SyntheticToolResultDetails["source"] =
+		reason === "aborted"
+			? "assistant_stop_aborted"
+			: reason === "error"
+				? "assistant_stop_error"
+				: reason === "length"
+					? "assistant_stop_length"
+					: "assistant_stop_skipped";
+	return {
+		__synthetic: true,
+		source,
+		executed: false,
+		...(reason === "error" && errorMessage ? { upstreamError: errorMessage } : {}),
+	};
+}
+
+/**
+ * Create a tool result for a tool call that was emitted by the assistant but
+ * never invoked locally. Maintains the tool_use / tool_result pairing the
+ * provider API requires, and tags {@link SyntheticToolResultDetails} so
+ * consumers can distinguish this from a real local tool failure without
+ * string-matching the content (#4321).
  */
 function createAbortedToolResult(
 	toolCall: Extract<AssistantMessage["content"][number], { type: "toolCall" }>,
@@ -2129,10 +2180,11 @@ function createAbortedToolResult(
 				? "Tool call was not executed because the assistant hit its output token limit (stop_reason: length) before the arguments could complete; the recorded arguments are truncated and unsafe to run. Do NOT retry by re-emitting the same large payload — split the work into several smaller tool calls (e.g. for `write`/`edit`, write the first chunk then append the rest with subsequent `edit` insert ops, or break the file into multiple `write` targets)"
 				: reason === "skipped"
 					? "Tool call was not executed because the assistant ended its turn"
-					: "Tool execution failed due to an error";
-	const result: AgentToolResult<any> = {
+					: "Tool call was not executed because the provider stream ended with an error before the tool could run";
+	const details = syntheticDetailsFor(reason, errorMessage);
+	const result: AgentToolResult<SyntheticToolResultDetails> = {
 		content: [{ type: "text", text: errorMessage ? `${message}: ${errorMessage}` : `${message}.` }],
-		details: {},
+		details,
 	};
 
 	stream.push({
@@ -2150,12 +2202,12 @@ function createAbortedToolResult(
 		isError: true,
 	});
 
-	const toolResultMessage: ToolResultMessage = {
+	const toolResultMessage: ToolResultMessage<SyntheticToolResultDetails> = {
 		role: "toolResult",
 		toolCallId: toolCall.id,
 		toolName: toolCall.name,
 		content: result.content,
-		details: {},
+		details,
 		isError: true,
 		timestamp: Date.now(),
 	};

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -657,6 +657,84 @@ describe("agentLoop with AgentMessage", () => {
 		expect(errorTurn.errorMessage).toBe("rate_limit_error");
 	});
 
+	it("labels the synthetic tool result for a provider-error turn as not-executed and preserves the upstream error", async () => {
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "edit",
+			label: "Edit",
+			description: "Edit tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return {
+					content: [{ type: "text", text: `edited: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [{ type: "toolCall", id: "tool-1", name: "edit", arguments: { value: "hello" } }],
+					stopReason: "error",
+					errorMessage: "Codex websocket transport error: websocket closed (1000)",
+				},
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("edit thing")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const messages = await stream.result();
+
+		expect(messages.map(m => m.role)).toEqual(["user", "assistant", "toolResult"]);
+		const toolResult = messages[2] as ToolResultMessage;
+		expect(toolResult.isError).toBe(true);
+
+		const text = toolResult.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map(c => c.text)
+			.join("");
+		// The message must make it obvious the local tool never ran — this is the
+		// bug in #4321: the previous wording ("Tool execution failed due to an
+		// error: <upstream>") was indistinguishable from a real local tool
+		// failure.
+		expect(text).not.toContain("Tool execution failed due to an error");
+		expect(text.toLowerCase()).toContain("not executed");
+		expect(text.toLowerCase()).toContain("provider");
+		expect(text).toContain("Codex websocket transport error: websocket closed (1000)");
+
+		// Structured details on the synthetic result let downstream consumers
+		// (UI, telemetry, ACP) distinguish it from a real tool failure without
+		// string-matching the content.
+		const details = toolResult.details as {
+			__synthetic?: boolean;
+			source?: string;
+			executed?: boolean;
+			upstreamError?: string;
+		};
+		expect(details.__synthetic).toBe(true);
+		expect(details.source).toBe("assistant_stop_error");
+		expect(details.executed).toBe(false);
+		expect(details.upstreamError).toBe("Codex websocket transport error: websocket closed (1000)");
+
+		const endEvent = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+				e.type === "tool_execution_end" && e.toolCallId === "tool-1",
+		);
+		expect(endEvent).toBeDefined();
+		expect(endEvent?.isError).toBe(true);
+		// The event's result carries the same discriminator so the UI can
+		// render "provider transport failed, tool not executed" instead of a
+		// generic "Edit tool failed" panel.
+		expect(endEvent?.result?.details?.__synthetic).toBe(true);
+		expect(endEvent?.result?.details?.source).toBe("assistant_stop_error");
+		expect(endEvent?.result?.details?.executed).toBe(false);
+	});
+
 	it("recovers completed custom-wire tool calls after stream_read_error", async () => {
 		const executedParams: Array<{ value: string }> = [];
 		const toolSchema = type({ value: "string" });


### PR DESCRIPTION
## Repro

An assistant turn that streams a tool call and then ends with
`stopReason: "error"` (e.g. a Codex websocket close mid-turn after
`toolcall_end` — the provider intentionally refuses WS→SSE replay once a
tool call has been emitted) produced a synthetic placeholder tool result
via `createAbortedToolResult()` whose visible text and event shape were
indistinguishable from a real local tool failure. In the CLI this
rendered as an `Edit` panel showing:

```
Tool execution failed due to an error: Codex websocket transport error: websocket closed (1000)
```

even though `tool.execute()` never ran. Added a regression test
(`labels the synthetic tool result for a provider-error turn as
not-executed and preserves the upstream error`) that against `main`
fails with:

```
Received: "Tool execution failed due to an error: Codex websocket transport error: websocket closed (1000)"
```

Command: `bun test packages/agent/test/agent-loop.test.ts -t "labels the synthetic tool result"`

## Cause

`createAbortedToolResult()` in `packages/agent/src/agent-loop.ts` mapped
`reason === "error"` to the generic prefix `"Tool execution failed due
to an error"`, emitted a normal `tool_execution_start` /
`tool_execution_end` pair, and left both `AgentToolResult.details` and
`ToolResultMessage.details` as `{}`. The three assistant-stop callsites
in `runLoopBody` (lines 916, 987, 1028) all route through it, so the
provider-transport-failure path was structurally identical to a real
`tool.execute()` throw and downstream renderers had nothing to key on
except the shared "Tool execution failed…" string.

## Fix

- Reword the `"error"` reason from `"Tool execution failed due to an
  error"` to `"Tool call was not executed because the provider stream
  ended with an error before the tool could run"`, keeping the upstream
  error message appended for context. Aborted / skipped / length wording
  is unchanged.
- Introduce `SyntheticToolResultDetails` (`{ __synthetic: true;
  source: "assistant_stop_aborted" | "assistant_stop_error" |
  "assistant_stop_skipped" | "assistant_stop_length"; executed: false;
  upstreamError?: string }`) and populate it from
  `syntheticDetailsFor(reason, errorMessage)` on both
  `AgentToolResult.details` (which flows into the `tool_execution_end`
  event) and the emitted `ToolResultMessage.details`. UI, telemetry, and
  ACP mappers can key on `__synthetic === true` / `executed === false`
  instead of string-matching content.
- Export the new interface from the agent package barrel
  (`export * from "./agent-loop"`) so downstream consumers have a typed
  discriminator.
- Add a regression test in `packages/agent/test/agent-loop.test.ts` that
  drives a `stopReason: "error"` turn through `agentLoop` and asserts
  the reworded content, the discriminator on the `ToolResultMessage`,
  and the discriminator on the `tool_execution_end` event's `result`.
- CHANGELOG entry under `packages/agent`'s `[Unreleased]` `Fixed`
  section referencing #4321.

## Verification

- `bun test packages/agent/test/agent-loop.test.ts` → 54 pass / 0 fail
  (includes the new regression test).
- `bun test packages/agent/test/` → 347 pass / 0 fail.
- `bun test packages/coding-agent/test/agent-session-concurrent.test.ts
  packages/coding-agent/test/tools/yield-extraction.test.ts
  packages/ai/test/duplicate-tool-results.test.ts
  packages/ai/test/openai-responses-history-payload.test.ts` — 102 pass
  / 0 fail. These are the suites that reference the sibling
  `"Tool execution was aborted"` wording (unchanged) and history-payload
  emission of synthetic tool results.

Fixes #4321