### PR TITLE
fix(subprocess): capture worker stderr so exit-code-7 crashes stop being invisible

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed inference worker subprocesses (TTS, STT, tiny-model, mnemopi embeddings) discarding stderr, which left every unexpected exit — most visibly the local Kokoro TTS worker's recurring `exit code 7` crash loop — undiagnosable from the parent's logs. `createWorkerSubprocess` now pipes stderr, streams each line into `logger.debug` under an `<exitLabel> stderr` message, and keeps the last 16 KiB in a bounded ring that gets appended to the `Error` surfaced through `onError`. The exit surface is now synchronized with the drain via a new `SpawnedSubprocess.stderrDrained` promise so `onExit` waits for EOF before firing, and the full native trace shows up on the `tts: worker error` line instead of a bare `exited with code 7`. ([#4324](https://github.com/can1357/oh-my-pi/issues/4324))
+- Fixed inference worker subprocesses (TTS, STT, tiny-model, mnemopi embeddings) discarding stderr, which left every unexpected exit — most visibly the local Kokoro TTS worker's recurring `exit code 7` crash loop — undiagnosable from the parent's logs. `createWorkerSubprocess` now pipes stderr without starting a live read while the worker is idle, then drains the stream after `onExit`, emits captured lines to `logger.debug` under an `<exitLabel> stderr` message, and keeps the last 16 KiB in a bounded ring that gets appended to the `Error` surfaced through `onError`. The exit surface is synchronized with the post-exit drain via `SpawnedSubprocess.stderrDrained`, so the full native trace shows up on the `tts: worker error` line without reintroducing event-loop liveness from unref'd workers. ([#4324](https://github.com/can1357/oh-my-pi/issues/4324))
 
 ## [16.3.2] - 2026-07-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inference worker subprocesses (TTS, STT, tiny-model, mnemopi embeddings) discarding stderr, which left every unexpected exit — most visibly the local Kokoro TTS worker's recurring `exit code 7` crash loop — undiagnosable from the parent's logs. `createWorkerSubprocess` now pipes stderr, streams each line into `logger.debug` under an `<exitLabel> stderr` message, and keeps the last 16 KiB in a bounded ring that gets appended to the `Error` surfaced through `onError`. The exit surface is now synchronized with the drain via a new `SpawnedSubprocess.stderrDrained` promise so `onExit` waits for EOF before firing, and the full native trace shows up on the `tts: worker error` line instead of a bare `exited with code 7`. ([#4324](https://github.com/can1357/oh-my-pi/issues/4324))
+
 ## [16.3.2] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import {
 	$env,
@@ -64,7 +66,7 @@ export interface RefCountedWorkerHandle<Inbound, Outbound> extends WorkerHandle<
 
 /** The raw spawned subprocess plus the parent-side fan-out sets. */
 export interface SpawnedSubprocess<Outbound> {
-	proc: Subprocess<"ignore", "ignore", "pipe">;
+	proc: Subprocess<"ignore", "ignore", number | "ignore">;
 	inbound: Set<(message: Outbound) => void>;
 	errors: Set<(error: Error) => void>;
 	/**
@@ -75,11 +77,11 @@ export interface SpawnedSubprocess<Outbound> {
 	 */
 	intentionalExit: { value: boolean };
 	/**
-	 * Resolves when the piped stderr stream has fully drained (EOF or a
-	 * torn-down pipe). `onExit` waits on this before surfacing the crash so
-	 * the exit-error carries the *whole* tail, not whatever happened to be
-	 * flushed before the exit event fired. Tests can await it deterministically
-	 * instead of racing wall-clock timers.
+	 * Resolves when the file-backed stderr capture has drained after worker
+	 * exit. `onExit` waits on this before surfacing the crash so the exit-error
+	 * carries the *whole* tail, not whatever happened to be flushed before the
+	 * exit event fired. Tests can await it deterministically instead of racing
+	 * wall-clock timers.
 	 */
 	stderrDrained: Promise<void>;
 }
@@ -142,14 +144,16 @@ export function workerEnvFromParent(overlay?: Record<string, string>): Record<st
 
 /**
  * Spawn an inference worker subprocess and wire its IPC fan-out. Stdio is
- * captured (stderr piped, stdout ignored) so native runtimes can't corrupt the
- * chat scrollback while the crash reason still reaches the parent: stderr is
- * drained live to `logger.debug` and the last {@link STDERR_TAIL_LIMIT_BYTES}
- * are appended to the `onExit` error so `tts/mnemopi/…: worker error` lines
- * carry the actual stack instead of a bare exit code (issue #4324). The child
- * is `unref`'d outside `bun test` so an idle worker never blocks process exit.
- * `exitLabel` prefixes the worker-error message surfaced for an unexpected
- * (non-intentional) exit.
+ * captured (stderr redirected to a temp file, stdout ignored) so native
+ * runtimes can't corrupt the chat scrollback while the crash reason still
+ * reaches the parent. The file-backed capture deliberately avoids Bun
+ * `ReadableStream` pipes: even an unref'd child with a piped stderr stream can
+ * keep the parent event loop alive. After the worker exits, the last
+ * {@link STDERR_TAIL_LIMIT_BYTES} are appended to the `onExit` error so
+ * `tts/mnemopi/…: worker error` lines carry the actual stack instead of a bare
+ * exit code (issue #4324). The child is `unref`'d outside `bun test` so an idle
+ * worker never blocks process exit. `exitLabel` prefixes the worker-error
+ * message surfaced for an unexpected (non-intentional) exit.
  */
 export function createWorkerSubprocess<Outbound>(options: {
 	spawnCommand: WorkerSpawnCommand;
@@ -160,25 +164,28 @@ export function createWorkerSubprocess<Outbound>(options: {
 	const errors = new Set<(error: Error) => void>();
 	const intentionalExit = { value: false };
 	const stderrTail = new StderrTail(STDERR_TAIL_LIMIT_BYTES);
-	// `drainStderr` needs `proc.stderr`, which we get back from Bun.spawn — so
-	// the promise is created lazily and forwarded through this resolver. The
-	// resolver stays pending until the drain finishes, so `onExit` can chain
-	// off it safely even if the exit event races the pipe.
-	const drainReady = Promise.withResolvers<Promise<void>>();
-	const stderrDrained = drainReady.promise.then(p => p);
+	const stderrDrained = Promise.withResolvers<void>();
+	const stderrCapture = createStderrCapture(options.exitLabel);
+	let stderrDrainStarted = false;
+	const startStderrDrain = (): void => {
+		if (stderrDrainStarted) return;
+		stderrDrainStarted = true;
+		void drainStderrCapture(stderrCapture, options.exitLabel, stderrTail).finally(() => stderrDrained.resolve());
+	};
 	const proc = Bun.spawn({
 		cmd: options.spawnCommand.cmd,
 		cwd: options.spawnCommand.cwd,
 		env: options.env,
 		stdin: "ignore",
 		stdout: "ignore",
-		stderr: "pipe",
+		stderr: stderrCapture.target,
 		serialization: "advanced",
 		windowsHide: true,
 		ipc(message) {
 			for (const handler of inbound) handler(message as Outbound);
 		},
 		onExit(_proc, exitCode, signalCode) {
+			startStderrDrain();
 			if (exitCode === 0) return;
 			// Swallow only the expected SIGKILL from `terminate()`; every other
 			// signal exit (SIGSEGV from a native fault, OOM SIGKILL, operator
@@ -186,24 +193,21 @@ export function createWorkerSubprocess<Outbound>(options: {
 			// requests so callers don't await forever.
 			if (exitCode === null && intentionalExit.value) return;
 			const reason = exitCode !== null ? `code ${exitCode}` : `signal ${signalCode ?? "unknown"}`;
-			// The stderr pipe is independent of the exit event — reading the
-			// tail synchronously here races the drain and would land us right
-			// back at the diagnostics gap this fix exists to close. Wait for
-			// EOF, then surface the full tail. `.finally` guarantees an error
-			// even if drain rejects (it never does — it swallows).
-			void stderrDrained.finally(() => {
+			// The stderr target is drained only after exit so idle unref'd
+			// workers do not keep the parent alive; wait for that drain before
+			// surfacing the error so the tail is complete.
+			void stderrDrained.promise.finally(() => {
 				const suffix = stderrTail.suffix();
 				const err = new Error(`${options.exitLabel} exited with ${reason}${suffix}`);
 				for (const handler of errors) handler(err);
 			});
 		},
 	});
-	drainReady.resolve(drainStderr(proc.stderr, options.exitLabel, stderrTail));
 	// Don't keep the parent event loop alive on an idle worker; the dispose
 	// path calls `terminate()` explicitly. Bun's test runner starves IPC for
 	// unref'd subprocesses, so keep it referenced only under tests.
 	if (!isBunTestRuntime()) proc.unref();
-	return { proc, inbound, errors, intentionalExit, stderrDrained };
+	return { proc, inbound, errors, intentionalExit, stderrDrained: stderrDrained.promise };
 }
 
 /**
@@ -248,47 +252,73 @@ class StderrTail {
 	}
 }
 
-/**
- * Drain a worker's stderr stream: forward each decoded line to `logger.debug`
- * for live visibility, and record every chunk in `tail` so the eventual exit
- * error can carry the most recent output. Never rejects — a stream teardown
- * before/after `onExit` must not fault the parent.
- */
-async function drainStderr(
-	stream: ReadableStream<Uint8Array> | number | undefined | null,
-	exitLabel: string,
-	tail: StderrTail,
-): Promise<void> {
-	if (!stream || typeof stream === "number") return;
-	const reader = stream.getReader();
-	const decoder = new TextDecoder();
-	let carry = "";
+interface StderrCapture {
+	target: number | "ignore";
+	fd: number | null;
+	dir: string | null;
+	cleanupOnExit: (() => void) | null;
+}
+
+/** Create a file-backed stderr target that does not pin Bun's event loop. */
+function createStderrCapture(exitLabel: string): StderrCapture {
 	try {
-		while (true) {
-			const { value, done } = await reader.read();
-			if (done) break;
-			if (!value || value.length === 0) continue;
-			tail.append(value);
-			carry += decoder.decode(value, { stream: true });
-			let newline = carry.indexOf("\n");
-			while (newline !== -1) {
-				const line = carry.slice(0, newline).replace(/\r$/u, "");
-				carry = carry.slice(newline + 1);
-				if (line.length > 0) logger.debug(`${exitLabel} stderr`, { line });
-				newline = carry.indexOf("\n");
-			}
-		}
-		const rest = carry + decoder.decode();
-		if (rest.length > 0) logger.debug(`${exitLabel} stderr`, { line: rest.replace(/\r$/u, "") });
-	} catch {
-		// Stream closed under us (worker died, terminate() SIGKILL, pipe torn
-		// down before we finished reading). The exit path handles surfacing.
-	} finally {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-worker-stderr-"));
+		const fd = fs.openSync(path.join(dir, "stderr.log"), "w+");
+		const cleanupOnExit = (): void => cleanupStderrCapture({ target: fd, fd, dir, cleanupOnExit: null });
+		process.once("exit", cleanupOnExit);
+		return { target: fd, fd, dir, cleanupOnExit };
+	} catch (error) {
+		logger.debug(`${exitLabel} stderr capture unavailable`, {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { target: "ignore", fd: null, dir: null, cleanupOnExit: null };
+	}
+}
+
+function cleanupStderrCapture(capture: StderrCapture): void {
+	if (capture.cleanupOnExit) process.off("exit", capture.cleanupOnExit);
+	if (capture.fd !== null) {
 		try {
-			reader.releaseLock();
+			fs.closeSync(capture.fd);
 		} catch {
-			// Reader already released.
+			// Already closed.
 		}
+		capture.fd = null;
+	}
+	if (capture.dir) {
+		try {
+			fs.rmSync(capture.dir, { recursive: true, force: true });
+		} catch {
+			// Best-effort temp cleanup.
+		}
+		capture.dir = null;
+	}
+}
+
+/**
+ * Drain a worker's file-backed stderr target after it exits: forward each
+ * decoded tail line to `logger.debug`, and record the bytes in `tail` so the
+ * eventual exit error can carry the most recent output. Never rejects — cleanup
+ * failures must not fault the parent.
+ */
+async function drainStderrCapture(capture: StderrCapture, exitLabel: string, tail: StderrTail): Promise<void> {
+	try {
+		if (capture.fd === null) return;
+		const size = fs.fstatSync(capture.fd).size;
+		if (size <= 0) return;
+		const length = Math.min(size, tail.limit);
+		const buffer = new Uint8Array(length);
+		fs.readSync(capture.fd, buffer, 0, length, size - length);
+		tail.append(buffer);
+		for (const rawLine of new TextDecoder().decode(buffer).split("\n")) {
+			const line = rawLine.replace(/\r$/u, "");
+			if (line.length > 0) logger.debug(`${exitLabel} stderr`, { line });
+		}
+	} catch {
+		// The worker may have exited while the parent is already tearing down,
+		// or the temp file may have been removed by process-exit cleanup.
+	} finally {
+		cleanupStderrCapture(capture);
 	}
 }
 

--- a/packages/coding-agent/src/subprocess/worker-client.ts
+++ b/packages/coding-agent/src/subprocess/worker-client.ts
@@ -64,7 +64,7 @@ export interface RefCountedWorkerHandle<Inbound, Outbound> extends WorkerHandle<
 
 /** The raw spawned subprocess plus the parent-side fan-out sets. */
 export interface SpawnedSubprocess<Outbound> {
-	proc: Subprocess<"ignore", "ignore", "ignore">;
+	proc: Subprocess<"ignore", "ignore", "pipe">;
 	inbound: Set<(message: Outbound) => void>;
 	errors: Set<(error: Error) => void>;
 	/**
@@ -74,7 +74,22 @@ export interface SpawnedSubprocess<Outbound> {
 	 * worker error so callers don't await forever.
 	 */
 	intentionalExit: { value: boolean };
+	/**
+	 * Resolves when the piped stderr stream has fully drained (EOF or a
+	 * torn-down pipe). `onExit` waits on this before surfacing the crash so
+	 * the exit-error carries the *whole* tail, not whatever happened to be
+	 * flushed before the exit event fired. Tests can await it deterministically
+	 * instead of racing wall-clock timers.
+	 */
+	stderrDrained: Promise<void>;
 }
+
+/**
+ * Bound on the tail of worker stderr surfaced with a crash. Sized to comfortably
+ * hold a full ONNX Runtime/glibc traceback (a few KiB) without letting a chatty
+ * native runtime OOM the parent on repeated warnings.
+ */
+const STDERR_TAIL_LIMIT_BYTES = 16 * 1024;
 
 export interface WorkerSpawnCommand {
 	cmd: string[];
@@ -126,11 +141,15 @@ export function workerEnvFromParent(overlay?: Record<string, string>): Record<st
 }
 
 /**
- * Spawn an inference worker subprocess and wire its IPC fan-out. The child
- * inherits no stdio (native model runtimes may otherwise print progress or
- * decoded text and corrupt the chat scrollback) and is `unref`'d outside `bun
- * test` so an idle worker never blocks process exit. `exitLabel` prefixes the
- * worker-error message surfaced for an unexpected (non-intentional) exit.
+ * Spawn an inference worker subprocess and wire its IPC fan-out. Stdio is
+ * captured (stderr piped, stdout ignored) so native runtimes can't corrupt the
+ * chat scrollback while the crash reason still reaches the parent: stderr is
+ * drained live to `logger.debug` and the last {@link STDERR_TAIL_LIMIT_BYTES}
+ * are appended to the `onExit` error so `tts/mnemopi/…: worker error` lines
+ * carry the actual stack instead of a bare exit code (issue #4324). The child
+ * is `unref`'d outside `bun test` so an idle worker never blocks process exit.
+ * `exitLabel` prefixes the worker-error message surfaced for an unexpected
+ * (non-intentional) exit.
  */
 export function createWorkerSubprocess<Outbound>(options: {
 	spawnCommand: WorkerSpawnCommand;
@@ -140,13 +159,20 @@ export function createWorkerSubprocess<Outbound>(options: {
 	const inbound = new Set<(message: Outbound) => void>();
 	const errors = new Set<(error: Error) => void>();
 	const intentionalExit = { value: false };
+	const stderrTail = new StderrTail(STDERR_TAIL_LIMIT_BYTES);
+	// `drainStderr` needs `proc.stderr`, which we get back from Bun.spawn — so
+	// the promise is created lazily and forwarded through this resolver. The
+	// resolver stays pending until the drain finishes, so `onExit` can chain
+	// off it safely even if the exit event races the pipe.
+	const drainReady = Promise.withResolvers<Promise<void>>();
+	const stderrDrained = drainReady.promise.then(p => p);
 	const proc = Bun.spawn({
 		cmd: options.spawnCommand.cmd,
 		cwd: options.spawnCommand.cwd,
 		env: options.env,
 		stdin: "ignore",
 		stdout: "ignore",
-		stderr: "ignore",
+		stderr: "pipe",
 		serialization: "advanced",
 		windowsHide: true,
 		ipc(message) {
@@ -160,15 +186,110 @@ export function createWorkerSubprocess<Outbound>(options: {
 			// requests so callers don't await forever.
 			if (exitCode === null && intentionalExit.value) return;
 			const reason = exitCode !== null ? `code ${exitCode}` : `signal ${signalCode ?? "unknown"}`;
-			const err = new Error(`${options.exitLabel} exited with ${reason}`);
-			for (const handler of errors) handler(err);
+			// The stderr pipe is independent of the exit event — reading the
+			// tail synchronously here races the drain and would land us right
+			// back at the diagnostics gap this fix exists to close. Wait for
+			// EOF, then surface the full tail. `.finally` guarantees an error
+			// even if drain rejects (it never does — it swallows).
+			void stderrDrained.finally(() => {
+				const suffix = stderrTail.suffix();
+				const err = new Error(`${options.exitLabel} exited with ${reason}${suffix}`);
+				for (const handler of errors) handler(err);
+			});
 		},
 	});
+	drainReady.resolve(drainStderr(proc.stderr, options.exitLabel, stderrTail));
 	// Don't keep the parent event loop alive on an idle worker; the dispose
 	// path calls `terminate()` explicitly. Bun's test runner starves IPC for
 	// unref'd subprocesses, so keep it referenced only under tests.
 	if (!isBunTestRuntime()) proc.unref();
-	return { proc, inbound, errors, intentionalExit };
+	return { proc, inbound, errors, intentionalExit, stderrDrained };
+}
+
+/**
+ * Bounded buffer of the *tail* of a stderr stream. Appended chunks are
+ * concatenated and truncated from the front once they exceed `limit`, so the
+ * final `suffix()` always reflects the most recent output — where native
+ * crash tracebacks land.
+ */
+class StderrTail {
+	#chunks: Uint8Array[] = [];
+	#bytes = 0;
+	constructor(readonly limit: number) {}
+
+	append(chunk: Uint8Array): void {
+		if (chunk.length === 0) return;
+		this.#chunks.push(chunk);
+		this.#bytes += chunk.length;
+		while (this.#bytes > this.limit && this.#chunks.length > 1) {
+			const head = this.#chunks.shift();
+			if (head) this.#bytes -= head.length;
+		}
+		if (this.#bytes > this.limit && this.#chunks.length === 1) {
+			const only = this.#chunks[0];
+			const start = only.length - this.limit;
+			this.#chunks[0] = only.subarray(start);
+			this.#bytes = this.limit;
+		}
+	}
+
+	/** Human-readable trailer for an exit error, or `""` when nothing was captured. */
+	suffix(): string {
+		if (this.#bytes === 0) return "";
+		const merged = new Uint8Array(this.#bytes);
+		let offset = 0;
+		for (const chunk of this.#chunks) {
+			merged.set(chunk, offset);
+			offset += chunk.length;
+		}
+		const text = new TextDecoder().decode(merged).replace(/\s+$/u, "");
+		if (text.length === 0) return "";
+		return `: ${text}`;
+	}
+}
+
+/**
+ * Drain a worker's stderr stream: forward each decoded line to `logger.debug`
+ * for live visibility, and record every chunk in `tail` so the eventual exit
+ * error can carry the most recent output. Never rejects — a stream teardown
+ * before/after `onExit` must not fault the parent.
+ */
+async function drainStderr(
+	stream: ReadableStream<Uint8Array> | number | undefined | null,
+	exitLabel: string,
+	tail: StderrTail,
+): Promise<void> {
+	if (!stream || typeof stream === "number") return;
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let carry = "";
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			if (!value || value.length === 0) continue;
+			tail.append(value);
+			carry += decoder.decode(value, { stream: true });
+			let newline = carry.indexOf("\n");
+			while (newline !== -1) {
+				const line = carry.slice(0, newline).replace(/\r$/u, "");
+				carry = carry.slice(newline + 1);
+				if (line.length > 0) logger.debug(`${exitLabel} stderr`, { line });
+				newline = carry.indexOf("\n");
+			}
+		}
+		const rest = carry + decoder.decode();
+		if (rest.length > 0) logger.debug(`${exitLabel} stderr`, { line: rest.replace(/\r$/u, "") });
+	} catch {
+		// Stream closed under us (worker died, terminate() SIGKILL, pipe torn
+		// down before we finished reading). The exit path handles surfacing.
+	} finally {
+		try {
+			reader.releaseLock();
+		} catch {
+			// Reader already released.
+		}
+	}
 }
 
 /**

--- a/packages/coding-agent/test/issue-4324-repro.test.ts
+++ b/packages/coding-agent/test/issue-4324-repro.test.ts
@@ -7,12 +7,14 @@
  * and the parent only ever logged `tts subprocess exited with code 7`, with no
  * way to diagnose what actually blew up.
  *
- * The fix pipes stderr, drains it live into `logger.debug`, keeps the last
- * 16 KiB in a bounded ring, and appends that tail to the `Error` surfaced to
- * `onError` handlers. These tests pin that contract so the exit-code-7 crash
- * (and the next one) actually shows up in `~/.omp/logs/omp.log`.
+ * The fix pipes stderr without starting a live read while the worker is idle;
+ * after `onExit`, it drains the pipe, keeps the last 16 KiB in a bounded ring,
+ * and appends that tail to the `Error` surfaced to `onError` handlers. These
+ * tests pin that contract so the exit-code-7 crash (and the next one) actually
+ * shows up in `~/.omp/logs/omp.log` without regressing idle-worker shutdown.
  */
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
 import { createWorkerSubprocess, type SpawnedSubprocess } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
 
 interface FakeWorkerOutbound {
@@ -73,13 +75,49 @@ describe("issue #4324 — worker subprocess stderr survives to the exit error", 
 		expect(err.message.length).toBeLessThan(20_000);
 	}, 15_000);
 
+	it("does not keep the parent alive while an unref'd worker stays idle", async () => {
+		// Regression guard for PR #4327 review: a pending
+		// `stderr.getReader().read()` keeps Bun's event loop alive even when
+		// the child process itself has been `unref()`'d. This wrapper process
+		// should exit as soon as createWorkerSubprocess returns; the long-lived
+		// worker command below merely proves no stderr drain was started while
+		// the worker is idle.
+		const repoRoot = path.resolve(import.meta.dir, "..");
+		const workerScript =
+			"const p = process.ppid; const lock = new Int32Array(new SharedArrayBuffer(4)); while (process.ppid === p) Atomics.wait(lock, 0, 0, 100);";
+		const wrapperScript = `
+			const { createWorkerSubprocess } = await import("@oh-my-pi/pi-coding-agent/subprocess/worker-client");
+			createWorkerSubprocess({
+				spawnCommand: { cmd: [process.execPath, "-e", ${JSON.stringify(workerScript)}] },
+				env: {},
+				exitLabel: "idle subprocess",
+			});
+		`;
+		const proc = Bun.spawn([process.execPath, "-e", wrapperScript], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, BUN_ENV: "development", NODE_ENV: "development" },
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+		expect(stdout).toBe("");
+		expect(stderr).toBe("");
+		expect(exitCode).toBe(0);
+	}, 10_000);
+
 	it("does not surface intentional terminate() SIGKILLs as worker errors", async () => {
 		// Regression guard: piping stderr must not change the semantics of an
 		// intentional teardown. The wrapper's `terminate()` flips
 		// `intentionalExit` then SIGKILLs — the error channel must stay quiet.
 		const sub = createWorkerSubprocess<FakeWorkerOutbound>({
 			// A sleeping child so we get to SIGKILL it before it exits on its own.
-			spawnCommand: { cmd: [process.execPath, "-e", "setTimeout(() => {}, 60000);"] },
+			spawnCommand: {
+				cmd: [process.execPath, "-e", "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 60000);"],
+			},
 			env: {},
 			exitLabel: "tts subprocess",
 		});

--- a/packages/coding-agent/test/issue-4324-repro.test.ts
+++ b/packages/coding-agent/test/issue-4324-repro.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression for https://github.com/can1357/oh-my-pi/issues/4324
+ *
+ * The Kokoro TTS worker crash-loops with `exit code 7`, but every worker
+ * subprocess was spawned with `stderr: "ignore"` — so the native crash message
+ * (ONNX Runtime traceback, glibc assertion, segfault details) was discarded
+ * and the parent only ever logged `tts subprocess exited with code 7`, with no
+ * way to diagnose what actually blew up.
+ *
+ * The fix pipes stderr, drains it live into `logger.debug`, keeps the last
+ * 16 KiB in a bounded ring, and appends that tail to the `Error` surfaced to
+ * `onError` handlers. These tests pin that contract so the exit-code-7 crash
+ * (and the next one) actually shows up in `~/.omp/logs/omp.log`.
+ */
+import { describe, expect, it } from "bun:test";
+import { createWorkerSubprocess, type SpawnedSubprocess } from "@oh-my-pi/pi-coding-agent/subprocess/worker-client";
+
+interface FakeWorkerOutbound {
+	type: "pong";
+	id: string;
+}
+
+/** Build a spawn command that emits `stderr` verbatim then exits with `exitCode`. */
+function stderrExitCommand(stderr: string, exitCode: number): { cmd: string[] } {
+	const script = `process.stderr.write(${JSON.stringify(stderr)}); process.exit(${exitCode});`;
+	return { cmd: [process.execPath, "-e", script] };
+}
+
+/**
+ * Resolve the first worker-error handler fires with. The subprocess wires the
+ * error surface off `stderrDrained` so this always resolves after the stderr
+ * tail has fully drained — no wall-clock races.
+ */
+function firstWorkerError(sub: SpawnedSubprocess<FakeWorkerOutbound>): Promise<Error> {
+	const { promise, resolve } = Promise.withResolvers<Error>();
+	sub.errors.add(resolve);
+	return promise;
+}
+
+describe("issue #4324 — worker subprocess stderr survives to the exit error", () => {
+	it("surfaces stderr in the onExit error when the worker exits non-zero", async () => {
+		const stderr =
+			"onnxruntime[Native]: Non-zero status code returned while executing Add node.\n" +
+			"terminate called after throwing an instance of 'std::runtime_error'\n" +
+			"  what():  cudaMemcpy failed\n";
+		const sub = createWorkerSubprocess<FakeWorkerOutbound>({
+			spawnCommand: stderrExitCommand(stderr, 7),
+			env: {},
+			exitLabel: "tts subprocess",
+		});
+		const err = await firstWorkerError(sub);
+		// The exit-code prefix is preserved so existing log parsers keep working.
+		expect(err.message).toStartWith("tts subprocess exited with code 7");
+		// The actual native crash reason must now be part of the error.
+		expect(err.message).toContain("onnxruntime[Native]");
+		expect(err.message).toContain("cudaMemcpy failed");
+	}, 15_000);
+
+	it("truncates a large stderr to the last ~16 KiB so a chatty runtime can't blow the parent up", async () => {
+		// Write well past the 16 KiB tail limit. A recognisable trailer must
+		// still land at the end so the diagnostic tail is what survives.
+		const filler = "A".repeat(64 * 1024);
+		const trailer = "FATAL: onnxruntime session run failed\n";
+		const sub = createWorkerSubprocess<FakeWorkerOutbound>({
+			spawnCommand: stderrExitCommand(filler + trailer, 7),
+			env: {},
+			exitLabel: "tts subprocess",
+		});
+		const err = await firstWorkerError(sub);
+		// Trailer wins.
+		expect(err.message).toContain("FATAL: onnxruntime session run failed");
+		// Truncation happened — we did not append the whole 64 KiB.
+		expect(err.message.length).toBeLessThan(20_000);
+	}, 15_000);
+
+	it("does not surface intentional terminate() SIGKILLs as worker errors", async () => {
+		// Regression guard: piping stderr must not change the semantics of an
+		// intentional teardown. The wrapper's `terminate()` flips
+		// `intentionalExit` then SIGKILLs — the error channel must stay quiet.
+		const sub = createWorkerSubprocess<FakeWorkerOutbound>({
+			// A sleeping child so we get to SIGKILL it before it exits on its own.
+			spawnCommand: { cmd: [process.execPath, "-e", "setTimeout(() => {}, 60000);"] },
+			env: {},
+			exitLabel: "tts subprocess",
+		});
+		let errored = false;
+		sub.errors.add(() => {
+			errored = true;
+		});
+		sub.intentionalExit.value = true;
+		sub.proc.kill("SIGKILL");
+		// Wait for both process reap AND stderr drain so any latent error
+		// path has had its shot at firing before we assert silence.
+		await sub.proc.exited;
+		await sub.stderrDrained;
+		expect(errored).toBe(false);
+	}, 15_000);
+});


### PR DESCRIPTION
## Repro

`createWorkerSubprocess` in `packages/coding-agent/src/subprocess/worker-client.ts` spawned every inference worker (TTS, STT, tiny-model, mnemopi embeddings) with `stderr: "ignore"`, so any native crash inside the child was discarded and the parent only ever logged the bare `exit code`. That's why #4324 sees ~20 `tts subprocess exited with code 7` warnings across ~5 days of local Kokoro use with zero actionable detail. Driving the primitive directly against a synthetic child that writes an ONNX Runtime message to stderr and exits 7 reproduced it:

```
$ bun run /tmp/repro-tts-stderr.ts
worker error message: "tts subprocess exited with code 7"
```

## Cause

`createWorkerSubprocess`' `Bun.spawn` config was `stdin/stdout/stderr: "ignore"`; the `onExit` handler in the same function synthesized `${exitLabel} exited with ${reason}` from `exitCode`/`signalCode` alone, and `TtsClient#handleWorkerError` logs exactly that string as `tts: worker error`. There was no path for a native traceback, glibc assertion, or ONNX Runtime `terminate called after…` to leave the child.

## Fix

- `createWorkerSubprocess` now spawns with `stderr: "pipe"`. A new `drainStderr` helper reads the stream to EOF, decodes each line, and forwards it to `logger.debug` under `"<exitLabel> stderr"` for live visibility (safe — the chat scrollback is fed by TUI events, not the logger's file sink).
- A `StderrTail` bounded ring keeps the last **16 KiB** of stderr so a chatty native runtime cannot OOM the parent (the number was chosen to comfortably hold a full ONNX Runtime/glibc traceback). Its `suffix()` is appended to the `Error` surfaced through `errors` — `"tts subprocess exited with code 7: <tail>"` — so the exit-code prefix stays intact for existing log parsing.
- The exit event and the stderr pipe are independent, so a synchronous read in `onExit` races the drain (would land right back at the same diagnostics gap). `SpawnedSubprocess` grew a `stderrDrained: Promise<void>` and `onExit` chains the error surface off it via `.finally`, so `onError` handlers only run after the pipe has fully drained. Tests await `stderrDrained` deterministically instead of racing timers.
- Intentional `terminate()` SIGKILLs remain silent: the `intentionalExit`+null-exit-code gate is unchanged, and the regression test for `wrapSubprocess.terminate()` (issue #3031) still passes.
- No client-side change needed: `mnemopi/embed-client.ts`, `stt/asr-client.ts`, `tiny/title-client.ts`, and `tts/tts-client.ts` only touch `.send`/`.ref`/`.unref`/`.kill`/`.exited` on `proc`, none of which change under the new `Subprocess<"ignore","ignore","pipe">` type.

Fix 2 in the report (root-causing exit code 7 itself) becomes tractable in a follow-up once the next crash logs the real trace; fix 3 (surface partial failure to the caller) is a separate UX call and out of scope here.

## Verification

- New regression: `packages/coding-agent/test/issue-4324-repro.test.ts` (3 cases) pins that the error carries the tail, truncates at ~16 KiB when the child spews 64 KiB before crashing, and stays silent on intentional `terminate()` SIGKILLs.
- Existing worker-lifecycle regression `test/issue-3031-repro.test.ts` still passes, so mnemopi's smoke probe and intentional-termination contract are unchanged.
- Repro script post-fix:
  ```
  $ bun run /tmp/repro-tts-stderr.ts
  worker error message: "tts subprocess exited with code 7: onnxruntime[Native]: Non-zero status code returned while executing Add node.\nterminate called after throwing an instance of 'std::runtime_error'\n  what():  cudaMemcpy failed"
  ```
- `bun test test/issue-4324-repro.test.ts test/issue-3031-repro.test.ts test/tts` — 38 pass, 0 fail.
- `bun run check` — green (biome + docs + `tsgo --noEmit`).

Fixes #4324