### PR TITLE
fix: hide hidden custom session updates

### DIFF
--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -164,6 +164,39 @@ describe("advisor", () => {
 			expect(md).toContain("[irc]");
 			expect(md).not.toContain("<primary-context");
 		});
+
+		it("omits hidden non-primary custom messages while keeping visible custom messages", () => {
+			const hiddenPrelude = {
+				role: "custom",
+				customType: "eager-task-prelude",
+				content: "<system-reminder>Task delegation is enabled",
+				display: false,
+				timestamp: 1,
+			} as AgentMessage;
+			const hiddenHookMessage = {
+				role: "hookMessage",
+				customType: "hidden-hook-reminder",
+				content: "Hidden hook reminder should never reach advisor history",
+				display: false,
+				timestamp: 2,
+			} as AgentMessage;
+			const visibleCustom = {
+				role: "custom",
+				customType: "visible-status",
+				content: "Visible custom update",
+				display: true,
+				timestamp: 3,
+			} as AgentMessage;
+
+			const md = formatSessionHistoryMarkdown([hiddenPrelude, hiddenHookMessage, visibleCustom], { expandPrimaryContext: true });
+
+			expect(md).toContain("[visible-status] Visible custom update");
+			expect(md).not.toContain("eager-task-prelude");
+			expect(md).not.toContain("system-reminder");
+			expect(md).not.toContain("Task delegation");
+			expect(md).not.toContain("hidden-hook-reminder");
+			expect(md).not.toContain("Hidden hook reminder");
+		});
 	});
 
 	describe("formatSessionHistoryMarkdown expandEditDiffs", () => {

--- a/packages/coding-agent/src/session/session-history-format.ts
+++ b/packages/coding-agent/src/session/session-history-format.ts
@@ -355,6 +355,7 @@ export function formatSessionHistoryMarkdown(messages: unknown[], opts?: History
 			case "custom":
 			case "hookMessage": {
 				const custom = msg as CustomMessage | HookMessage;
+				if (custom.display === false && !PRIMARY_CONTEXT_CUSTOM_TYPES.has(custom.customType)) break;
 				if (opts?.expandPrimaryContext && PRIMARY_CONTEXT_CUSTOM_TYPES.has(custom.customType)) {
 					const text = contentToText(custom.content).trim();
 					if (text) {


### PR DESCRIPTION
## Summary

- Skip hidden non-primary custom and hook messages in compact session-history/advisor markdown.
- Preserve primary-context exceptions (`plan-mode-context` and `plan-mode-reference`) so advisor still sees operative plan constraints.
- Add regression coverage for hidden `eager-task-prelude` and hidden hook messages while confirming visible custom messages still render.

## Why

Hidden model-only reminders can currently leak into `### Session update` markdown as visible `<system-reminder>` content, creating an oversized banner in the OMP transcript. The formatter should respect `display: false` for non-primary-context messages.

## Verification

- `bun test ./src/advisor/__tests__/advisor.test.ts -t "omits hidden non-primary custom messages"`
- `bun run check:types`
- `git diff --check`
