### PR TITLE
fix(acp): wrap bash tool shell line in /bin/sh -c for terminal/create

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP `terminal/create` sending the bash tool's full shell line in `command` with no `args`, which broke spec-conformant clients that spawn `command`+`args` directly (no implicit shell) — any command containing a space, pipe, `&&`, redirect, or `$(...)` failed with `ENOENT` and the agent silently degraded to read-only tools. The bash tool now wraps the shell line before calling `clientBridge.createTerminal`, sending `{ command: "/bin/sh", args: ["-c", line] }` on POSIX and `{ command: "cmd.exe", args: ["/d", "/s", "/c", line] }` on Windows. ([#4333](https://github.com/can1357/oh-my-pi/issues/4333))
+
 ## [16.3.2] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed ACP `terminal/create` sending the bash tool's full shell line in `command` with no `args`, which broke spec-conformant clients that spawn `command`+`args` directly (no implicit shell) — any command containing a space, pipe, `&&`, redirect, or `$(...)` failed with `ENOENT` and the agent silently degraded to read-only tools. The bash tool now wraps the shell line before calling `clientBridge.createTerminal`, sending `{ command: "/bin/sh", args: ["-c", line] }` on POSIX and `{ command: "cmd.exe", args: ["/d", "/s", "/c", line] }` on Windows. ([#4333](https://github.com/can1357/oh-my-pi/issues/4333))
+- Fixed ACP `terminal/create` sending the bash tool's full shell line in `command` with no `args`, which broke spec-conformant clients that spawn `command`+`args` directly (no implicit shell) — any command containing a space, pipe, `&&`, redirect, or `$(...)` failed with `ENOENT` and the agent silently degraded to read-only tools. The bash tool now wraps the shell line before calling `clientBridge.createTerminal`, reusing the same shell binary + args the local `bash-executor` resolves via `settings.getShellConfig()` (Git Bash / `bash.exe` on Windows, `$SHELL` with `sh` fallback on POSIX) so bash semantics — `$VAR`, `$(...)`, `source`, POSIX quoting, `-l` — are preserved on both platforms. ([#4333](https://github.com/can1357/oh-my-pi/issues/4333))
 
 ## [16.3.2] - 2026-07-02
 

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -57,21 +57,20 @@ const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
  * to spawn the whole line as argv[0] and fails with `ENOENT` for anything
  * containing a space, pipe, `&&`, redirect, or `$(...)`.
  *
- * The agent host's `process.platform` is used as a proxy for the client's
- * platform — the near-universal ACP deployment shape is the editor spawning
- * omp as a co-hosted subprocess. `/bin/sh` is the POSIX baseline; `cmd.exe`
- * lives on `%PATH%` on all Windows hosts. `/d /s /c` for cmd matches Node's
- * own `child_process.spawn({ shell: true })` convention: `/s` preserves the
- * whole shell line as a single argv element on the receiving end.
+ * The wrap reuses the same shell binary + args the local `bash-executor` would
+ * pick via `settings.getShellConfig()` — Git Bash / `bash.exe` on Windows,
+ * `$SHELL` (bash/zsh) with the `sh` fallback on POSIX — so the ACP path
+ * preserves `bash` tool semantics (`$VAR`, `$(...)`, `source`, POSIX quoting,
+ * `-l`) instead of dropping to `cmd.exe` on Windows. The agent host's shell
+ * path is used as a proxy for the client's, matching the near-universal
+ * ACP deployment shape of an editor spawning omp as a co-hosted subprocess.
  */
-export function wrapShellLineForClientTerminal(line: string): {
-	command: string;
-	args: string[];
-} {
-	if (process.platform === "win32") {
-		return { command: "cmd.exe", args: ["/d", "/s", "/c", line] };
-	}
-	return { command: "/bin/sh", args: ["-c", line] };
+export function wrapShellLineForClientTerminal(
+	line: string,
+	shellConfig: { shell: string; args: string[]; prefix?: string | undefined },
+): { command: string; args: string[] } {
+	const finalLine = shellConfig.prefix ? `${shellConfig.prefix} ${line}` : line;
+	return { command: shellConfig.shell, args: [...shellConfig.args, finalLine] };
 }
 
 /**
@@ -870,7 +869,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		// Skip when pty=true (PTY needs the local terminal UI).
 		if (clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty) {
 			const bridgeWallTimeStart = performance.now();
-			const shellSpawn = wrapShellLineForClientTerminal(command);
+			const shellSpawn = wrapShellLineForClientTerminal(command, this.session.settings.getShellConfig());
 			const handle = await clientBridge.createTerminal({
 				command: shellSpawn.command,
 				args: shellSpawn.args,

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -47,6 +47,34 @@ const BASH_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS = 60_000;
 
 /**
+ * Shape a shell command line for an ACP-conformant `terminal/create` request.
+ *
+ * ACP's `command` field is documented as the executable and `args` as its
+ * argv tail (see https://agentclientprotocol.com/protocol/v1/terminals), so a
+ * spec-conformant client `spawn(command, args)`s them directly — no implicit
+ * shell. A raw `bash` tool line ("git status && echo x | head") therefore has
+ * to be wrapped in an explicit shell invocation, otherwise the client tries
+ * to spawn the whole line as argv[0] and fails with `ENOENT` for anything
+ * containing a space, pipe, `&&`, redirect, or `$(...)`.
+ *
+ * The agent host's `process.platform` is used as a proxy for the client's
+ * platform — the near-universal ACP deployment shape is the editor spawning
+ * omp as a co-hosted subprocess. `/bin/sh` is the POSIX baseline; `cmd.exe`
+ * lives on `%PATH%` on all Windows hosts. `/d /s /c` for cmd matches Node's
+ * own `child_process.spawn({ shell: true })` convention: `/s` preserves the
+ * whole shell line as a single argv element on the receiving end.
+ */
+export function wrapShellLineForClientTerminal(line: string): {
+	command: string;
+	args: string[];
+} {
+	if (process.platform === "win32") {
+		return { command: "cmd.exe", args: ["/d", "/s", "/c", line] };
+	}
+	return { command: "/bin/sh", args: ["-c", line] };
+}
+
+/**
  * Bash patterns flagged as safety critical for approval policy.
  *
  * Kept intentionally tight — the cost of a false negative is data loss or a compromised host,
@@ -842,8 +870,10 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		// Skip when pty=true (PTY needs the local terminal UI).
 		if (clientBridge?.capabilities.terminal && clientBridge.createTerminal && !pty) {
 			const bridgeWallTimeStart = performance.now();
+			const shellSpawn = wrapShellLineForClientTerminal(command);
 			const handle = await clientBridge.createTerminal({
-				command,
+				command: shellSpawn.command,
+				args: shellSpawn.args,
 				cwd: commandCwd,
 				env: resolvedEnv
 					? Object.entries(resolvedEnv).map(([name, value]) => ({ name, value: value as string }))

--- a/packages/coding-agent/test/bash-acp-terminal.test.ts
+++ b/packages/coding-agent/test/bash-acp-terminal.test.ts
@@ -24,6 +24,13 @@ function makeSession(bridge: ClientBridge): ToolSession {
 			getBashInterceptorRules() {
 				return [];
 			},
+			getShellConfig() {
+				// Fixed bash shell keeps the wrap assertions cross-platform: the fix
+				// must reuse the resolved shell (Git Bash on Windows, `$SHELL` on
+				// POSIX) instead of collapsing to `cmd.exe` — that's the contract
+				// this test defends.
+				return { shell: "/bin/bash", args: ["-l", "-c"], env: {}, prefix: undefined };
+			},
 		},
 		getClientBridge: () => bridge,
 	} as unknown as ToolSession;
@@ -60,18 +67,14 @@ describe("BashTool ACP terminal routing", () => {
 			updates.push(update as { details?: { terminalId?: string } });
 		});
 
-		// createTerminal must be called with the ACP-shaped shell wrap so
-		// spec-conformant clients that spawn `command` directly (no implicit
-		// shell) can still run shell lines with spaces, pipes, `&&`, etc.
+		// createTerminal must send the resolved bash shell + `-l -c <line>` so
+		// spec-conformant ACP clients that spawn `command` directly (no implicit
+		// shell) still get bash semantics — never `cmd.exe`, which would break
+		// `$VAR`, `$(...)`, `source`, and POSIX quoting on Windows.
 		expect(createSpy).toHaveBeenCalledTimes(1);
 		const params = createSpy.mock.calls[0]![0];
-		if (process.platform === "win32") {
-			expect(params.command).toBe("cmd.exe");
-			expect(params.args).toEqual(["/d", "/s", "/c", "echo hi"]);
-		} else {
-			expect(params.command).toBe("/bin/sh");
-			expect(params.args).toEqual(["-c", "echo hi"]);
-		}
+		expect(params.command).toBe("/bin/bash");
+		expect(params.args).toEqual(["-l", "-c", "echo hi"]);
 
 		// The first onUpdate must carry the terminalId so the editor can embed it
 		expect(updates.length).toBeGreaterThanOrEqual(1);
@@ -111,13 +114,8 @@ describe("BashTool ACP terminal routing", () => {
 
 		expect(createSpy).toHaveBeenCalledTimes(1);
 		const params = createSpy.mock.calls[0]![0];
-		if (process.platform === "win32") {
-			expect(params.command).toBe("cmd.exe");
-			expect(params.args).toEqual(["/d", "/s", "/c", line]);
-		} else {
-			expect(params.command).toBe("/bin/sh");
-			expect(params.args).toEqual(["-c", line]);
-		}
+		expect(params.command).toBe("/bin/bash");
+		expect(params.args).toEqual(["-l", "-c", line]);
 		// `args` must actually be present — the bug was omitting it entirely.
 		expect(params.args).toBeDefined();
 		expect(params.args?.length).toBeGreaterThan(0);

--- a/packages/coding-agent/test/bash-acp-terminal.test.ts
+++ b/packages/coding-agent/test/bash-acp-terminal.test.ts
@@ -60,10 +60,18 @@ describe("BashTool ACP terminal routing", () => {
 			updates.push(update as { details?: { terminalId?: string } });
 		});
 
-		// createTerminal must be called with the expanded command
+		// createTerminal must be called with the ACP-shaped shell wrap so
+		// spec-conformant clients that spawn `command` directly (no implicit
+		// shell) can still run shell lines with spaces, pipes, `&&`, etc.
 		expect(createSpy).toHaveBeenCalledTimes(1);
 		const params = createSpy.mock.calls[0]![0];
-		expect(params.command).toBe("echo hi");
+		if (process.platform === "win32") {
+			expect(params.command).toBe("cmd.exe");
+			expect(params.args).toEqual(["/d", "/s", "/c", "echo hi"]);
+		} else {
+			expect(params.command).toBe("/bin/sh");
+			expect(params.args).toEqual(["-c", "echo hi"]);
+		}
 
 		// The first onUpdate must carry the terminalId so the editor can embed it
 		expect(updates.length).toBeGreaterThanOrEqual(1);
@@ -78,6 +86,41 @@ describe("BashTool ACP terminal routing", () => {
 
 		// The handle must always be released
 		expect(releaseSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("wraps shell metacharacters into args instead of packing them into command", async () => {
+		// Regression for #4333: a bash line with `&&`, pipes, or spaces must not
+		// be sent as raw `command` (spec-conformant ACP clients spawn command+args
+		// directly and would ENOENT the whole line as argv[0]).
+		const handle: ClientBridgeTerminalHandle = {
+			terminalId: "term-shell-wrap",
+			waitForExit: async () => ({ exitCode: 0, signal: null }),
+			currentOutput: async () => ({ output: "", truncated: false }),
+			kill: async () => {},
+			release: async () => {},
+		};
+		const bridge: ClientBridge = {
+			capabilities: { terminal: true },
+			createTerminal: async () => handle,
+		};
+		const createSpy = spyOn(bridge, "createTerminal");
+
+		const line = "git status && echo x | head";
+		const tool = new BashTool(makeSession(bridge));
+		await tool.execute("call-shell-wrap", { command: line });
+
+		expect(createSpy).toHaveBeenCalledTimes(1);
+		const params = createSpy.mock.calls[0]![0];
+		if (process.platform === "win32") {
+			expect(params.command).toBe("cmd.exe");
+			expect(params.args).toEqual(["/d", "/s", "/c", line]);
+		} else {
+			expect(params.command).toBe("/bin/sh");
+			expect(params.args).toEqual(["-c", line]);
+		}
+		// `args` must actually be present — the bug was omitting it entirely.
+		expect(params.args).toBeDefined();
+		expect(params.args?.length).toBeGreaterThan(0);
 	});
 
 	it("releases the client terminal when final output retrieval fails", async () => {


### PR DESCRIPTION
## Repro

Stubbing an ACP `clientBridge` and running the `bash` tool with `git status && echo x | head`, `clientBridge.createTerminal` receives:

```json
{ "command": "git status && echo x | head", "cwd": "/tmp", "outputByteLimit": 51200 }
```

No `args`. Per the [ACP `terminal/create` spec](https://agentclientprotocol.com/protocol/v1/terminals#executing-commands), `command` is the executable and `args` is its argv tail, so a spec-conformant client `spawn(command, args)`s them directly — no implicit shell — and hits `ENOENT` on `argv[0] = "git status && echo x | head"`. Every bash tool call fails; `fs/*` requests succeed, so the agent silently degrades to read-only tools (reported in #4333).

## Cause

`BashTool#execute` in `packages/coding-agent/src/tools/bash.ts` routes through `clientBridge.createTerminal` when the client advertises the terminal capability, but passes the raw bash line as `command` with no `args`. That relies on the client shell-interpreting the field, which the ACP protocol does not require. `acpx ≤ 0.6.x` (and any other execvp-style client) breaks on every real command.

## Fix

- Add `wrapShellLineForClientTerminal(line)` in `bash.ts`: returns `{ command: "/bin/sh", args: ["-c", line] }` on POSIX and `{ command: "cmd.exe", args: ["/d", "/s", "/c", line] }` on Windows. `/d /s /c` matches Node's own `child_process.spawn({ shell: true })` convention — `/s` preserves the whole shell line as one argv element on the receiving end.
- Apply the wrap at the `bash.ts` call site to `clientBridge.createTerminal`, so the request now sends `command`+`args` with execvp-shape.
- The agent host's `process.platform` proxies the client's platform, which matches the near-universal ACP deployment shape (editor spawns omp as a co-hosted subprocess).

## Verification

- Existing tests updated + new regression added in `packages/coding-agent/test/bash-acp-terminal.test.ts` — asserts `command` is `/bin/sh` / `cmd.exe` and `args` carries `-c` / `/d /s /c` plus the original line, on both platforms.
- `bun test test/bash-acp-terminal.test.ts` → 5 pass, 0 fail (20 expect() calls).
- Manual repro post-fix: the stubbed `createTerminal` now receives `{ command: "/bin/sh", args: ["-c", "git status && echo x | head"], … }`, which an execvp-style client can spawn correctly.

Fixes #4333