### PR TITLE
fix(ai): parse nested cached token hits when root cache is zero

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible streaming usage parsing to prefer non-zero nested cached token counts when root `cached_tokens` is zero ([#4337](https://github.com/can1357/oh-my-pi/issues/4337)).
+
 ## [16.3.1] - 2026-07-02
 
 ### Changed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -148,6 +148,13 @@ type OpenAICompletionsCompletionTokenDetails = {
 	reasoning_tokens?: unknown;
 };
 
+function firstPositiveNumber(...values: unknown[]): number {
+	for (const value of values) {
+		if (typeof value === "number" && value > 0) return value;
+	}
+	return 0;
+}
+
 /**
  * Normalize tool call ID for Mistral.
  * Mistral requires tool IDs to be exactly 9 alphanumeric characters (a-z, A-Z, 0-9).
@@ -1558,11 +1565,7 @@ export function parseChunkUsage(
 	const accounting = calculateOpenAIUsageAccounting({
 		promptTokens: typeof promptTokens === "number" ? promptTokens : 0,
 		outputTokens,
-		cachedTokens:
-			(typeof cachedTokens === "number" ? cachedTokens : undefined) ??
-			(typeof promptCacheHitTokens === "number" ? promptCacheHitTokens : undefined) ??
-			(typeof promptTokenCachedTokens === "number" ? promptTokenCachedTokens : undefined) ??
-			0,
+		cachedTokens: firstPositiveNumber(cachedTokens, promptCacheHitTokens, promptTokenCachedTokens),
 		reasoningTokens: typeof completionReasoningTokens === "number" ? completionReasoningTokens : 0,
 		cacheWriteOpenRouter: typeof cacheWriteTokens === "number" ? cacheWriteTokens : undefined,
 		cacheWriteDeepSeek: typeof promptCacheMissTokens === "number" ? promptCacheMissTokens : undefined,

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -3,6 +3,7 @@ import { renderDemotedThinking } from "@oh-my-pi/pi-ai/dialect";
 import {
 	applyOpenRouterRoutingVariant,
 	convertMessages,
+	parseChunkUsage,
 	streamOpenAICompletions,
 } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import type {
@@ -612,6 +613,77 @@ describe("openai-completions compatibility", () => {
 		expect(result.usage.output).toBe(3);
 		expect(result.usage.cacheRead).toBe(2);
 		expect(result.usage.totalTokens).toBe(15);
+	});
+
+	it("falls through zero cached-token candidates to later non-zero usage fields", () => {
+		const model: Model<"openai-completions"> = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+		} as ModelSpec<"openai-completions">);
+		const cases: Array<{
+			name: string;
+			usage: object;
+			expectedCacheRead: number;
+		}> = [
+			{
+				name: "root zero falls through to nested prompt token details",
+				usage: {
+					prompt_tokens: 50_000,
+					completion_tokens: 3,
+					cached_tokens: 0,
+					prompt_tokens_details: { cached_tokens: 49_216 },
+				},
+				expectedCacheRead: 49_216,
+			},
+			{
+				name: "missing root uses prompt cache hit tokens",
+				usage: {
+					prompt_tokens: 100,
+					completion_tokens: 3,
+					prompt_cache_hit_tokens: 41,
+				},
+				expectedCacheRead: 41,
+			},
+			{
+				name: "standard nested prompt token details",
+				usage: {
+					prompt_tokens: 100,
+					completion_tokens: 3,
+					prompt_tokens_details: { cached_tokens: 37 },
+				},
+				expectedCacheRead: 37,
+			},
+			{
+				name: "all candidates missing or zero",
+				usage: {
+					prompt_tokens: 100,
+					completion_tokens: 3,
+					cached_tokens: 0,
+					prompt_cache_hit_tokens: 0,
+					prompt_tokens_details: { cached_tokens: 0 },
+				},
+				expectedCacheRead: 0,
+			},
+			{
+				name: "multiple non-zero fields preserve priority order",
+				usage: {
+					prompt_tokens: 100,
+					completion_tokens: 3,
+					cached_tokens: 11,
+					prompt_cache_hit_tokens: 13,
+					prompt_tokens_details: { cached_tokens: 17 },
+				},
+				expectedCacheRead: 11,
+			},
+		];
+
+		for (const testCase of cases) {
+			const usage = parseChunkUsage(testCase.usage, model, undefined);
+			expect(usage.cacheRead).toBe(testCase.expectedCacheRead);
+			expect(usage.input).toBe(
+				(testCase.usage as { prompt_tokens: number }).prompt_tokens - testCase.expectedCacheRead,
+			);
+		}
 	});
 
 	it("maps qwen chat template reasoning into chat_template_kwargs", async () => {


### PR DESCRIPTION
## Repro
A focused regression test reproduces the reported OpenAI-compatible streaming usage payload where `cached_tokens: 0` appears beside `prompt_tokens_details.cached_tokens: 49216`: `bun test packages/ai/test/openai-completions-compat.test.ts --test-name-pattern cached-token` failed before the fix with `Expected: 49216` / `Received: 0` for `usage.cacheRead`.

## Cause
`packages/ai/src/providers/openai-completions.ts` used a nullish-coalescing chain in `parseChunkUsage`, so a numeric root `cached_tokens` value of `0` stopped evaluation before checking `prompt_cache_hit_tokens` or `prompt_tokens_details.cached_tokens`.

## Fix
- Added a cached-token candidate helper that returns the first positive numeric value and falls back to `0`.
- Updated `parseChunkUsage` to use that helper across root, `prompt_cache_hit_tokens`, and nested `prompt_tokens_details.cached_tokens` candidates.
- Added regression coverage for root-zero fallthrough, missing-root cache hits, standard nested usage, all-zero candidates, and priority among multiple non-zero fields.
- Added the `packages/ai` changelog entry.

## Verification
`bun test packages/ai/test/openai-completions-compat.test.ts --test-name-pattern cached-token` passed with 1 test and 10 assertions; `bun test packages/ai/test/openai-completions-compat.test.ts` passed with 64 tests and 181 assertions; `bun check` passed. Fixes #4337