### PR TITLE
feat(ai): track Claude Fable weekly usage separately in omp usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Claude Fable weekly usage tracking to the Anthropic usage provider: the OAuth usage endpoint's new generic `limits` array is parsed for model-scoped weekly windows (`kind: "weekly_scoped"`), so `omp usage`, `/usage`, and usage history now surface a separate `Claude 7 Day (Fable)` row (id `anthropic:7d:fable`) alongside the shared 5h/7d windows — mirroring how Codex Spark rows are tracked. The `session`/`weekly_all` entries also backfill the shared 5h/7d windows if the legacy `five_hour`/`seven_day` buckets ever go null (as `seven_day_opus`/`seven_day_sonnet` already have).
+- Added `scopeLimits`/`blockScope` to the Anthropic credential-ranking strategy so an exhausted Fable/Mythos weekly cap no longer blocks the whole OAuth credential: credential-wide exhaustion gating now considers only shared umbrella windows plus the requested model family's own scoped cap, and reactive usage-limit blocks for Fable/Mythos requests land in a per-tier backoff scope (mirroring the Antigravity per-counter precedent).
+
 ## [16.3.1] - 2026-07-02
 
 ### Changed

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -1,8 +1,10 @@
 import { scheduler } from "node:timers/promises";
+import { bareModelId, parseAnthropicModel } from "@oh-my-pi/pi-catalog/identity";
 import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import * as AIError from "../error";
 import { claudeCodeVersion } from "../providers/anthropic";
 import type {
+	CredentialRankingContext,
 	CredentialRankingStrategy,
 	UsageAmount,
 	UsageFetchContext,
@@ -61,12 +63,36 @@ interface ParsedUsageBucket {
 	resetsAt?: number;
 }
 type ClaudeUnifiedWindow = "5h" | "7d";
+type ClaudeModelKind = "opus" | "sonnet" | "fable" | "mythos";
 
 interface ClaudeUsageResponse {
 	five_hour?: ClaudeUsageBucket | null;
 	seven_day?: ClaudeUsageBucket | null;
 	seven_day_opus?: ClaudeUsageBucket | null;
 	seven_day_sonnet?: ClaudeUsageBucket | null;
+	limits?: unknown;
+}
+
+interface ClaudeApiLimitModelScope {
+	display_name?: string | null;
+}
+
+interface ClaudeApiLimitScope {
+	model?: ClaudeApiLimitModelScope | null;
+}
+
+interface ClaudeApiLimitEntry {
+	kind?: string;
+	percent?: unknown;
+	resets_at?: string | null;
+	scope?: ClaudeApiLimitScope | null;
+	is_active?: boolean;
+}
+
+interface ParsedApiLimitEntry {
+	kind: string;
+	bucket: ParsedUsageBucket;
+	displayName?: string;
 }
 
 type ClaudeUsagePayload = {
@@ -89,6 +115,43 @@ function parseBucket(bucket: unknown): ParsedUsageBucket | undefined {
 	}
 	return { utilization, resetsAt };
 }
+
+function getApiLimitDisplayName(scope: unknown): string | undefined {
+	if (!isRecord(scope)) return undefined;
+	const model = scope.model;
+	if (!isRecord(model)) return undefined;
+	const displayName = model.display_name;
+	return typeof displayName === "string" && displayName.trim() ? displayName.trim() : undefined;
+}
+
+/**
+ * Anthropic kept the legacy account-wide buckets populated, but as of
+ * 2026-07-02 the legacy per-model weekly buckets (`seven_day_opus` /
+ * `seven_day_sonnet`) are permanently null. Model-scoped weekly caps now arrive
+ * only through generic `limits[]` entries (`kind: "weekly_scoped"`) with the
+ * model family named by `scope.model.display_name`.
+ */
+function parseApiLimitEntries(raw: unknown): ParsedApiLimitEntry[] {
+	if (!Array.isArray(raw)) return [];
+	const entries: ParsedApiLimitEntry[] = [];
+	for (const rawEntry of raw) {
+		if (!isRecord(rawEntry)) continue;
+		const entry = rawEntry as ClaudeApiLimitEntry;
+		if (typeof entry.kind !== "string") continue;
+		if (entry.is_active === false) continue;
+		const utilization = toNumber(entry.percent);
+		const resetsAt = parseIsoTime(typeof entry.resets_at === "string" ? entry.resets_at : undefined);
+		if (utilization === undefined && resetsAt === undefined) continue;
+		const displayName = getApiLimitDisplayName(entry.scope);
+		entries.push({
+			kind: entry.kind,
+			bucket: { utilization, resetsAt },
+			...(displayName ? { displayName } : {}),
+		});
+	}
+	return entries;
+}
+
 function parseUnifiedWindow(
 	headers: Record<string, string>,
 	window: ClaudeUnifiedWindow,
@@ -144,7 +207,8 @@ function hasUsageData(payload: ClaudeUsageResponse): boolean {
 		parseBucket(payload.five_hour)?.utilization !== undefined ||
 		parseBucket(payload.seven_day)?.utilization !== undefined ||
 		parseBucket(payload.seven_day_opus)?.utilization !== undefined ||
-		parseBucket(payload.seven_day_sonnet)?.utilization !== undefined
+		parseBucket(payload.seven_day_sonnet)?.utilization !== undefined ||
+		parseApiLimitEntries(payload.limits).some(entry => entry.bucket.utilization !== undefined)
 	);
 }
 
@@ -334,13 +398,50 @@ function buildUsageLimit(args: {
 		scope: {
 			provider: args.provider,
 			windowId: args.windowId,
-			tier: args.tier,
-			shared: args.shared,
+			...(args.tier !== undefined ? { tier: args.tier } : {}),
+			...(args.shared !== undefined ? { shared: args.shared } : {}),
 		},
 		window,
 		amount,
 		status: buildUsageStatus(amount.usedFraction),
 	};
+}
+
+function slugifyClaudeLimitDisplayName(displayName: string): string {
+	return displayName
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Scoped weekly rows are per-model-family counters, not account-wide windows.
+ * They deliberately leave `scope.shared` unset so credential-wide exhaustion
+ * gating only considers the shared umbrella windows; an exhausted Fable weekly
+ * cap must not block Opus or Sonnet requests on the same credential.
+ */
+function buildScopedWeeklyUsageLimits(entries: readonly ParsedApiLimitEntry[]): UsageLimit[] {
+	const seenSlugs = new Set<string>();
+	const limits: UsageLimit[] = [];
+	for (const entry of entries) {
+		if (entry.kind !== "weekly_scoped" || !entry.displayName) continue;
+		const slug = slugifyClaudeLimitDisplayName(entry.displayName);
+		if (!slug || seenSlugs.has(slug)) continue;
+		seenSlugs.add(slug);
+		const limit = buildUsageLimit({
+			id: `anthropic:7d:${slug}`,
+			label: `Claude 7 Day (${entry.displayName})`,
+			windowId: "7d",
+			windowLabel: "7 Day",
+			durationMs: SEVEN_DAYS_MS,
+			bucket: entry.bucket,
+			provider: "anthropic",
+			tier: slug,
+		});
+		if (limit) limits.push(limit);
+	}
+	return limits;
 }
 
 export function parseClaudeRateLimitHeaders(headers: Record<string, string>, now = Date.now()): UsageReport | null {
@@ -394,8 +495,10 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 	if (!payloadResult || !isRecord(payloadResult.payload)) return null;
 	const { payload, orgId } = payloadResult;
 
-	const fiveHour = parseBucket(payload.five_hour);
-	const sevenDay = parseBucket(payload.seven_day);
+	const apiLimitEntries = parseApiLimitEntries(payload.limits);
+	const fiveHour = parseBucket(payload.five_hour) ?? apiLimitEntries.find(entry => entry.kind === "session")?.bucket;
+	const sevenDay =
+		parseBucket(payload.seven_day) ?? apiLimitEntries.find(entry => entry.kind === "weekly_all")?.bucket;
 	const sevenDayOpus = parseBucket(payload.seven_day_opus);
 	const sevenDaySonnet = parseBucket(payload.seven_day_sonnet);
 
@@ -440,6 +543,7 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 			provider: "anthropic",
 			tier: "sonnet",
 		}),
+		...buildScopedWeeklyUsageLimits(apiLimitEntries),
 	].filter((limit): limit is UsageLimit => limit !== null);
 
 	if (limits.length === 0) return null;
@@ -475,11 +579,40 @@ export const claudeUsageProvider: UsageProvider = {
 	supports: params => params.provider === "anthropic" && params.credential.type === "oauth",
 };
 
+function getClaudeModelKind(context: CredentialRankingContext | undefined): ClaudeModelKind | undefined {
+	const modelId = context?.modelId;
+	if (!modelId) return undefined;
+	return parseAnthropicModel(bareModelId(modelId))?.kind;
+}
+
+/**
+ * Claude model-scoped rows are only relevant to the matching model family.
+ * Credential-wide exhaustion checks stay on shared umbrella windows unless the
+ * request model parses to a concrete Anthropic kind, preventing a Fable cap from
+ * suppressing unrelated Opus/Sonnet traffic.
+ */
+function scopeClaudeLimitsForModel(report: UsageReport, context: CredentialRankingContext | undefined): UsageLimit[] {
+	const kind = getClaudeModelKind(context);
+	return report.limits.filter(
+		limit => limit.scope.shared === true || (kind !== undefined && limit.scope.tier === kind),
+	);
+}
+
 export const claudeRankingStrategy: CredentialRankingStrategy = {
 	findWindowLimits(report) {
 		const primary = report.limits.find(l => l.id === "anthropic:5h");
 		const secondary = report.limits.find(l => l.id === "anthropic:7d");
 		return { primary, secondary };
+	},
+	scopeLimits: scopeClaudeLimitsForModel,
+	/**
+	 * Fable/Mythos usage-limit errors map to tier-local weekly counters. Scope
+	 * reactive backoff blocks for those tiers, mirroring the per-counter
+	 * precedent in packages/ai/src/usage/google-antigravity.ts:466-497.
+	 */
+	blockScope(context) {
+		const kind = getClaudeModelKind(context);
+		return kind === "fable" || kind === "mythos" ? `tier:${kind}` : undefined;
 	},
 	windowDefaults: { primaryMs: 5 * 60 * 60 * 1000, secondaryMs: 7 * 24 * 60 * 60 * 1000 },
 };

--- a/packages/ai/test/claude-usage-headers.test.ts
+++ b/packages/ai/test/claude-usage-headers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { claudeCodeVersion } from "@oh-my-pi/pi-ai/providers/anthropic";
-import type { UsageFetchContext } from "@oh-my-pi/pi-ai/usage";
-import { claudeUsageProvider } from "@oh-my-pi/pi-ai/usage/claude";
+import type { UsageFetchContext, UsageLimit, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { claudeRankingStrategy, claudeUsageProvider } from "@oh-my-pi/pi-ai/usage/claude";
 
 function getHeaderCaseInsensitive(
 	headers: Headers | Record<string, string | ReadonlyArray<string>> | string[][] | undefined,
@@ -116,5 +116,270 @@ describe("claude usage request headers", () => {
 		);
 
 		expect(report?.limits[0]?.window?.resetsAt).toBeUndefined();
+	});
+
+	it("surfaces the Fable weekly scoped limit from the limits array as a tiered UsageLimit", async () => {
+		const now = Date.now();
+		const fiveHourReset = new Date(now + 5 * 60 * 60 * 1000).toISOString();
+		const sevenDayReset = new Date(now + 3 * 24 * 60 * 60 * 1000).toISOString();
+		const fableReset = new Date(now + 4 * 24 * 60 * 60 * 1000).toISOString();
+		const fetchMock = (async () => {
+			return new Response(
+				JSON.stringify({
+					five_hour: { utilization: 16, resets_at: fiveHourReset },
+					seven_day: { utilization: 18, resets_at: sevenDayReset },
+					seven_day_opus: null,
+					seven_day_sonnet: null,
+					limits: [
+						{
+							kind: "session",
+							group: "session",
+							percent: 16,
+							severity: "normal",
+							resets_at: fiveHourReset,
+							scope: null,
+							is_active: true,
+						},
+						{
+							kind: "weekly_all",
+							group: "weekly",
+							percent: 18,
+							severity: "normal",
+							resets_at: sevenDayReset,
+							scope: null,
+							is_active: true,
+						},
+						{
+							kind: "weekly_scoped",
+							group: "weekly",
+							percent: 28,
+							severity: "normal",
+							resets_at: fableReset,
+							scope: { model: { display_name: "Fable", id: null }, surface: null },
+							is_active: true,
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const ctx: UsageFetchContext = { fetch: fetchMock };
+
+		const report = await claudeUsageProvider.fetchUsage(
+			{
+				provider: "anthropic",
+				credential: {
+					type: "oauth",
+					accessToken: "oat-test-access-token",
+					expiresAt: now + 60_000,
+				},
+			},
+			ctx,
+		);
+
+		expect(report?.limits.map(limit => limit.id)).toEqual(["anthropic:5h", "anthropic:7d", "anthropic:7d:fable"]);
+		const fable = report?.limits.find(limit => limit.id === "anthropic:7d:fable");
+		expect(fable?.label).toBe("Claude 7 Day (Fable)");
+		expect(fable?.scope.provider).toBe("anthropic");
+		expect(fable?.scope.tier).toBe("fable");
+		expect(fable?.scope.windowId).toBe("7d");
+		expect(fable?.scope.shared).toBeUndefined();
+		expect(fable?.window?.durationMs).toBe(7 * 24 * 60 * 60 * 1000);
+		expect(fable?.window?.label).toBe("7 Day");
+		expect(fable?.window?.resetsAt).toBe(Date.parse(fableReset));
+		expect(fable?.amount.used).toBe(28);
+		expect(fable?.amount.limit).toBe(100);
+		expect(fable?.amount.remaining).toBe(72);
+		expect(fable?.amount.remainingFraction).toBeCloseTo(0.72);
+		expect(fable?.amount.unit).toBe("percent");
+		expect(fable?.amount.usedFraction).toBeCloseTo(0.28);
+		expect(fable?.status).toBe("ok");
+		const weekly = report?.limits.find(limit => limit.id === "anthropic:7d");
+		expect(weekly?.amount.used).toBe(18);
+		expect(weekly?.scope.shared).toBe(true);
+	});
+
+	it("skips inactive and unnamed scoped limits", async () => {
+		const now = Date.now();
+		const futureReset = new Date(now + 4 * 24 * 60 * 60 * 1000).toISOString();
+		const fetchMock = (async () => {
+			return new Response(
+				JSON.stringify({
+					five_hour: { utilization: 16, resets_at: new Date(now + 5 * 60 * 60 * 1000).toISOString() },
+					limits: [
+						{
+							kind: "weekly_scoped",
+							group: "weekly",
+							percent: 0,
+							severity: "normal",
+							resets_at: null,
+							scope: { model: { display_name: "Fable", id: null }, surface: null },
+							is_active: false,
+						},
+						{
+							kind: "weekly_scoped",
+							group: "weekly",
+							percent: 40,
+							resets_at: futureReset,
+							scope: { model: null, surface: null },
+							is_active: true,
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const ctx: UsageFetchContext = { fetch: fetchMock };
+
+		const report = await claudeUsageProvider.fetchUsage(
+			{
+				provider: "anthropic",
+				credential: {
+					type: "oauth",
+					accessToken: "oat-test-access-token",
+					expiresAt: now + 60_000,
+				},
+			},
+			ctx,
+		);
+
+		expect(report?.limits.some(limit => limit.id.includes(":fable"))).toBe(false);
+		expect(report?.limits.map(limit => limit.id)).toEqual(["anthropic:5h"]);
+	});
+
+	it("falls back to session and weekly_all entries when legacy buckets are absent", async () => {
+		const now = Date.now();
+		const fiveHourReset = new Date(now + 5 * 60 * 60 * 1000).toISOString();
+		const sevenDayReset = new Date(now + 3 * 24 * 60 * 60 * 1000).toISOString();
+		const calls: string[] = [];
+		const fetchMock = (async (input: string | URL) => {
+			calls.push(String(input));
+			return new Response(
+				JSON.stringify({
+					limits: [
+						{
+							kind: "session",
+							group: "session",
+							percent: 16,
+							severity: "normal",
+							resets_at: fiveHourReset,
+							scope: null,
+							is_active: true,
+						},
+						{
+							kind: "weekly_all",
+							group: "weekly",
+							percent: 18,
+							severity: "normal",
+							resets_at: sevenDayReset,
+							scope: null,
+							is_active: true,
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const ctx: UsageFetchContext = { fetch: fetchMock };
+
+		const report = await claudeUsageProvider.fetchUsage(
+			{
+				provider: "anthropic",
+				credential: {
+					type: "oauth",
+					accessToken: "oat-test-access-token",
+					expiresAt: now + 60_000,
+				},
+			},
+			ctx,
+		);
+
+		// Exactly one usage fetch: hasUsageData must accept a limits[]-only payload
+		// instead of burning retries. The trailing /profile call is the expected
+		// identity backfill for a payload/credential carrying no account identity.
+		expect(calls.filter(url => url.endsWith("/usage"))).toEqual(["https://api.anthropic.com/api/oauth/usage"]);
+		expect(report).not.toBeNull();
+		expect(report?.limits.map(limit => limit.id)).toEqual(["anthropic:5h", "anthropic:7d"]);
+		const session = report?.limits.find(limit => limit.id === "anthropic:5h");
+		const weekly = report?.limits.find(limit => limit.id === "anthropic:7d");
+		expect(session?.scope.shared).toBe(true);
+		expect(weekly?.scope.shared).toBe(true);
+		expect(session?.amount.used).toBe(16);
+		expect(weekly?.amount.used).toBe(18);
+	});
+});
+
+describe("claude ranking strategy", () => {
+	it("scopes credential gating to shared umbrella limits plus the requested model tier", () => {
+		const limits: UsageLimit[] = [
+			{
+				id: "anthropic:5h",
+				label: "Claude 5 Hour",
+				scope: { provider: "anthropic", windowId: "5h", shared: true },
+				window: { id: "5h", label: "5 Hour" },
+				amount: {
+					used: 16,
+					limit: 100,
+					remaining: 84,
+					usedFraction: 0.16,
+					remainingFraction: 0.84,
+					unit: "percent",
+				},
+				status: "ok",
+			},
+			{
+				id: "anthropic:7d",
+				label: "Claude 7 Day",
+				scope: { provider: "anthropic", windowId: "7d", shared: true },
+				window: { id: "7d", label: "7 Day" },
+				amount: {
+					used: 18,
+					limit: 100,
+					remaining: 82,
+					usedFraction: 0.18,
+					remainingFraction: 0.82,
+					unit: "percent",
+				},
+				status: "ok",
+			},
+			{
+				id: "anthropic:7d:fable",
+				label: "Claude 7 Day (Fable)",
+				scope: { provider: "anthropic", windowId: "7d", tier: "fable" },
+				window: { id: "7d", label: "7 Day" },
+				amount: {
+					used: 28,
+					limit: 100,
+					remaining: 72,
+					usedFraction: 0.28,
+					remainingFraction: 0.72,
+					unit: "percent",
+				},
+				status: "ok",
+			},
+		];
+		const report: UsageReport = {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits,
+		};
+
+		expect(claudeRankingStrategy.scopeLimits).toBeDefined();
+		const scopeLimits = claudeRankingStrategy.scopeLimits;
+		if (!scopeLimits) throw new Error("expected claude scopeLimits");
+		expect(scopeLimits(report).map(limit => limit.id)).toEqual(["anthropic:5h", "anthropic:7d"]);
+		expect(scopeLimits(report, { modelId: "claude-opus-4-8" }).map(limit => limit.id)).toEqual([
+			"anthropic:5h",
+			"anthropic:7d",
+		]);
+		expect(scopeLimits(report, { modelId: "claude-fable-5" }).map(limit => limit.id)).toEqual([
+			"anthropic:5h",
+			"anthropic:7d",
+			"anthropic:7d:fable",
+		]);
+		expect(claudeRankingStrategy.blockScope?.({ modelId: "claude-fable-5" })).toBe("tier:fable");
+		expect(claudeRankingStrategy.blockScope?.({ modelId: "claude-mythos-5" })).toBe("tier:mythos");
+		expect(claudeRankingStrategy.blockScope?.({ modelId: "claude-opus-4-8" })).toBeUndefined();
+		expect(claudeRankingStrategy.blockScope?.({})).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -100,7 +100,12 @@ function renderUsageReports(
 			for (let index = 0; index < report.limits.length; index++) {
 				const limit = report.limits[index]!;
 				const window = limit.window?.label ?? limit.scope.windowId;
-				const tier = limit.scope.tier ? ` (${limit.scope.tier})` : "";
+				// Skip the tier suffix when the label already names it (e.g. Anthropic's
+				// "Claude 7 Day (Fable)" with scope.tier "fable") — mirrors limitTitle in usage-cli.
+				const tier =
+					limit.scope.tier && !limit.label.toLowerCase().includes(limit.scope.tier.toLowerCase())
+						? ` (${limit.scope.tier})`
+						: "";
 				lines.push(`- ${limit.label}${tier}${window ? ` — ${window}` : ""}`);
 				lines.push(
 					`  ${formatUsageReportAccount(report, limit, index)}: ${formatUsageAmount(limit)}${inUse ? "  ← in use by this session" : ""}`,


### PR DESCRIPTION
## What

Track Claude **Fable** weekly usage as its own row in `omp usage` (and `/usage`, usage history) for the Anthropic provider — mirroring how OpenAI Codex tracks Spark rows separately.

As of 2026-07-02 the Anthropic OAuth usage endpoint (`GET /api/oauth/usage`) ships a generic `limits[]` array; the legacy `seven_day_opus`/`seven_day_sonnet` buckets are now permanently `null`, and the Fable weekly cap arrives **only** as a `limits[]` entry (`kind: "weekly_scoped"`, `scope.model.display_name: "Fable"`). This parses those entries into an `anthropic:7d:<slug>` tier row (`Claude 7 Day (Fable)`).

Changes:
- **`packages/ai/src/usage/claude.ts`** — parse the generic `limits[]` array; emit active `weekly_scoped` entries as non-shared tier rows (`anthropic:7d:fable`, generic slug so Mythos/future models work); backfill the shared `5h`/`7d` windows from `session`/`weekly_all` entries when the legacy `five_hour`/`seven_day` buckets are absent; accept `limits[]`-only payloads in `hasUsageData` so retries aren't burned.
- **Ranking safety** — add `scopeLimits`/`blockScope` to `claudeRankingStrategy` so an exhausted Fable/Mythos weekly cap gates only matching-model requests instead of cooling down the whole OAuth credential (mirrors the `google-antigravity` per-counter precedent). Without this, a 100%-used Fable cap would block Opus/Sonnet traffic on the same account.
- **`packages/coding-agent/.../usage-report.ts`** — dedupe the ACP `/usage` tier suffix when the label already names the tier (avoids `Claude 7 Day (Fable) (fable)`), matching `usage-cli.ts`'s `limitTitle`.

## Why

Fable draws from a separate weekly sub-cap (Anthropic's promotional model-scoped limit); users need to see it distinctly from the shared 5h/7d windows, exactly as Codex Spark is surfaced today. Field naming verified against the live endpoint and corroborated across multiple third-party clients.

## Testing

- 4 new cases in `packages/ai/test/claude-usage-headers.test.ts`: Fable scoped-row parsing, inactive/unnamed skips, `limits[]`-only fallback without extra retry, and the `scopeLimits`/`blockScope` contract.
- `bun run ci:check:full` (biome + tsgo + docs, all workspaces) green; full `packages/ai` suite 2605 pass / 0 fail.
- Live smoke: `omp usage` renders `Claude 7 Day (Fable)  31.0% used · resets in 3d8h` with the 7d capacity line binding to the worst meter.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
