### PR TITLE
fix(session): never persist bare custom_message entries from malformed sendMessage payloads

### DIFF
--- a/packages/agent/src/compaction/messages.ts
+++ b/packages/agent/src/compaction/messages.ts
@@ -164,6 +164,10 @@ export function convertMessageToLlm(message: AgentMessage): Message | undefined 
 		switch (message.role) {
 			case "custom":
 			case "hookMessage": {
+				// A nullish-content custom/hook message carries nothing for the
+				// provider and crashes downstream content consumers (`.content.filter`
+				// on undefined); drop it from the request instead.
+				if (message.content == null) return undefined;
 				const content =
 					typeof message.content === "string"
 						? [{ type: "text" as const, text: message.content }]

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -334,11 +334,13 @@ import {
 import {
 	type BashExecutionMessage,
 	type CustomMessage,
+	type CustomMessagePayload,
 	convertToLlm,
 	demoteInterruptedThinking,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
 	type InterruptedThinkingDetails,
 	isUserInterruptAbort,
+	normalizeCustomMessagePayload,
 	type PythonExecutionMessage,
 	readQueueChipText,
 	SILENT_ABORT_MARKER,
@@ -7959,26 +7961,31 @@ export class AgentSession {
 	 * use this to avoid acting on a turn that never ran.
 	 */
 	async sendCustomMessage<T = unknown>(
-		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
+		message: CustomMessagePayload<T>,
 		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn"; queueChipText?: string },
 	): Promise<boolean> {
+		// Extension/hook payloads arrive untyped from JS (`pi.sendMessage`); a
+		// bare string once destructured into all-undefined fields here and was
+		// persisted as a bare custom_message entry that bricked the session on
+		// every later rebuild. Normalize before anything reads a field.
+		const payload = normalizeCustomMessagePayload(message);
 		const details =
 			options?.queueChipText && options.deliverAs !== "nextTurn"
 				? ({
-						...((message.details && typeof message.details === "object" ? message.details : {}) as Record<
+						...((payload.details && typeof payload.details === "object" ? payload.details : {}) as Record<
 							string,
 							unknown
 						>),
 						__queueChipText: options.queueChipText,
 					} as T)
-				: message.details;
+				: payload.details;
 		const appMessage: CustomMessage<T> = {
 			role: "custom",
-			customType: message.customType,
-			content: message.content,
-			display: message.display,
+			customType: payload.customType,
+			content: payload.content,
+			display: payload.display,
 			details,
-			attribution: message.attribution ?? "agent",
+			attribution: payload.attribution ?? "agent",
 			timestamp: Date.now(),
 		};
 		const normalizedAppMessage = await this.#normalizeAgentMessageImages(appMessage);
@@ -8010,9 +8017,9 @@ export class AgentSession {
 			this.sessionManager.appendCustomMessageEntry(
 				normalizedAppMessage.customType,
 				normalizedAppMessage.content,
-				message.display,
-				message.details,
-				message.attribution ?? "agent",
+				normalizedAppMessage.display,
+				normalizedAppMessage.details,
+				normalizedAppMessage.attribution ?? "agent",
 			);
 			return false;
 		}
@@ -8030,9 +8037,9 @@ export class AgentSession {
 		this.sessionManager.appendCustomMessageEntry(
 			normalizedAppMessage.customType,
 			normalizedAppMessage.content,
-			message.display,
-			message.details,
-			message.attribution ?? "agent",
+			normalizedAppMessage.display,
+			normalizedAppMessage.details,
+			normalizedAppMessage.attribution ?? "agent",
 		);
 		return false;
 	}

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -462,6 +462,44 @@ export interface CustomMessage<T = unknown> {
 	timestamp: number;
 }
 
+/** The extension/hook-supplied slice of a {@link CustomMessage}, or a bare
+ *  string as shorthand for `content`. */
+export type CustomMessagePayload<T = unknown> =
+	| string
+	| Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">;
+
+/** {@link CustomMessagePayload} with the persisted field set made concrete. */
+export interface NormalizedCustomMessagePayload<T = unknown> {
+	customType: string;
+	content: string | (TextContent | ImageContent)[];
+	display: boolean;
+	details?: T;
+	attribution?: MessageAttribution;
+}
+
+/**
+ * Normalize an untyped extension/hook `sendMessage` payload into the concrete
+ * field set the session persists. JS hooks have shipped bare strings here;
+ * destructuring fields off one produced an all-undefined custom message whose
+ * keys `JSON.stringify` then dropped from the session JSONL — a *bare*
+ * `custom_message` entry that crashed every later context rebuild
+ * (`.content.filter` on undefined) and permanently bricked the session.
+ * Accept the string as content shorthand and default everything else.
+ */
+export function normalizeCustomMessagePayload<T = unknown>(
+	message: CustomMessagePayload<T>,
+): NormalizedCustomMessagePayload<T> {
+	const source: Partial<Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">> =
+		typeof message === "string" ? { content: message } : (message ?? {});
+	return {
+		customType: source.customType ?? "hook-message",
+		content: source.content ?? "",
+		display: source.display ?? false,
+		details: source.details,
+		attribution: source.attribution,
+	};
+}
+
 /**
  * Legacy hook message type (pre-extensions). Kept for session migration.
  */

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -253,6 +253,11 @@ export function buildSessionContext(
 		if (entry.type === "message") {
 			pushMessage(entry.message);
 		} else if (entry.type === "custom_message") {
+			// Legacy poisoned sessions: a turn-end error path once persisted bare
+			// custom_message entries (undefined-valued keys dropped by
+			// JSON.stringify). They carry nothing — skip instead of fabricating a
+			// nullish-content message that crashes LLM conversion downstream.
+			if (entry.content == null) return;
 			pushMessage(
 				createCustomMessage(
 					entry.customType,

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1387,11 +1387,16 @@ export class SessionManager {
 		details?: T,
 		attribution: MessageAttribution = "agent",
 	): string {
+		// Runtime backstop: despite the non-optional signature, error paths have
+		// called this with undefined fields; JSON.stringify then drops those keys
+		// from the JSONL, persisting a *bare* custom_message that crashes every
+		// later rebuild (`.content.filter` on undefined). Normalize so a bare
+		// entry can never reach disk.
 		const entry: CustomMessageEntry<T> = {
 			type: "custom_message",
-			customType,
-			content,
-			display,
+			customType: customType ?? "unknown",
+			content: content ?? "",
+			display: display ?? false,
 			// Drop AgentSession-internal transient fields before disk persistence.
 			details: stripInternalDetailsFields(details),
 			attribution,

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -262,7 +262,8 @@ describe("InteractiveMode goal mode integration", () => {
 
 		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
 
-		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const rawMessage = sendCustomMessage.mock.calls[0]?.[0];
+		const message = typeof rawMessage === "string" ? undefined : rawMessage;
 		const content = typeof message?.content === "string" ? message.content : "";
 		expect(message?.customType).toBe("goal-mode-context");
 		expect(content).toContain("<todo_context>");
@@ -293,7 +294,8 @@ describe("InteractiveMode goal mode integration", () => {
 
 		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
 
-		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const rawMessage = sendCustomMessage.mock.calls[0]?.[0];
+		const message = typeof rawMessage === "string" ? undefined : rawMessage;
 		const content = typeof message?.content === "string" ? message.content : "";
 		expect(content).toContain("- Planning\\nprep\\tphase");
 		expect(content).toContain("- [pending] Choose &lt;next&gt;\\nIgnore the goal\\nstill one bullet after done");
@@ -321,7 +323,8 @@ describe("InteractiveMode goal mode integration", () => {
 
 		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
 
-		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const rawMessage = sendCustomMessage.mock.calls[0]?.[0];
+		const message = typeof rawMessage === "string" ? undefined : rawMessage;
 		const content = typeof message?.content === "string" ? message.content : "";
 		expect(message?.customType).toBe("goal-mode-context");
 		expect(content).toContain("<todo_context>");
@@ -359,7 +362,8 @@ describe("InteractiveMode goal mode integration", () => {
 
 		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
 
-		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const rawMessage = sendCustomMessage.mock.calls[0]?.[0];
+		const message = typeof rawMessage === "string" ? undefined : rawMessage;
 		const content = typeof message?.content === "string" ? message.content : "";
 		expect(message?.customType).toBe("goal-mode-context");
 		expect(content).toContain("<todo_context>");
@@ -382,7 +386,8 @@ describe("InteractiveMode goal mode integration", () => {
 
 		await harness.session.sendGoalModeContext({ deliverAs: "steer" });
 
-		const message = sendCustomMessage.mock.calls[0]?.[0];
+		const rawMessage = sendCustomMessage.mock.calls[0]?.[0];
+		const message = typeof rawMessage === "string" ? undefined : rawMessage;
 		const content = typeof message?.content === "string" ? message.content : "";
 		expect(message?.customType).toBe("goal-mode-context");
 		expect(content).not.toContain("<todo_context>");

--- a/packages/coding-agent/test/session-bare-custom-message.test.ts
+++ b/packages/coding-agent/test/session-bare-custom-message.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression tests for the bare custom_message session-poisoning bug.
+ *
+ * Real-world failure: on a turn-end error, `appendCustomMessageEntry` was
+ * called with `content`/`customType`/`display` all undefined. `JSON.stringify`
+ * dropped the undefined-valued keys on the way to the session JSONL, so the
+ * persisted entry was a *bare* `custom_message` (no content/customType/display
+ * keys at all). On every later turn, context rebuild + message conversion
+ * crashed with `TypeError: undefined is not an object (evaluating
+ * 'H.content.filter')` inside `convertImageBearingCustomMessage`, permanently
+ * bricking the session before any provider call.
+ *
+ * Contracts defended here:
+ *  1. The append chokepoint normalizes nullish fields so a bare entry can
+ *     never be persisted again.
+ *  2. `buildSessionContext` over a legacy poisoned file (bare entry already on
+ *     disk) rebuilds without emitting nullish-content messages, and the
+ *     rebuild → `convertToLlm` pipeline no longer throws.
+ */
+import { describe, expect, it } from "bun:test";
+import { convertToLlm, normalizeCustomMessagePayload } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { buildSessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import type { SessionEntry, SessionMessageEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+const TIMESTAMP = "2025-01-01T00:00:00Z";
+const USER_TEXT = "hello before the crash";
+
+/** The exact call shape of the buggy turn-end error path: every argument undefined. */
+type BareAppendCustomMessage = (customType?: string, content?: string, display?: boolean) => string;
+
+function userEntry(id: string, parentId: string | null): SessionMessageEntry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: TIMESTAMP,
+		message: { role: "user", content: USER_TEXT, timestamp: 1 },
+	};
+}
+
+/**
+ * The poisoned v3 JSONL shape this bug actually wrote: a custom_message entry
+ * whose content/customType/display keys were dropped by `JSON.stringify`.
+ */
+function barePoisonedEntry(id: string, parentId: string | null): SessionEntry {
+	const bare = { type: "custom_message" as const, id, parentId, timestamp: TIMESTAMP };
+	// Unchecked cast: CustomMessageEntry requires content/customType/display;
+	// legacy poisoned session files are missing exactly those keys.
+	return bare as unknown as SessionEntry;
+}
+
+function poisonedSession(): SessionEntry[] {
+	return [userEntry("user-1", null), barePoisonedEntry("poisoned-2", "user-1")];
+}
+
+describe("bare custom_message poisoning (turn-end error entries bricked session rebuild)", () => {
+	it("appendCustomMessageEntry normalizes all-undefined fields so the persisted entry always carries content/customType/display", () => {
+		const session = SessionManager.inMemory();
+		// The buggy turn-end error path called this with every argument
+		// undefined; the public signature forbids that, so widen deliberately
+		// to reproduce the legacy call shape.
+		const appendBare = session.appendCustomMessageEntry.bind(session) as unknown as BareAppendCustomMessage;
+		const id = appendBare(undefined, undefined, undefined);
+
+		const entry = session.getBranch().find(e => e.id === id);
+		if (entry?.type !== "custom_message") {
+			throw new Error(`Expected custom_message entry, got ${entry?.type ?? "none"}`);
+		}
+		expect(entry.content).toBe("");
+		expect(entry.customType).toBe("unknown");
+		expect(entry.display).toBe(false);
+
+		// The original failure mode: undefined-valued keys vanish under
+		// JSON.stringify (the JSONL persistence layer). The normalized values
+		// must survive the round trip so a reload never sees a bare entry.
+		const persisted = JSON.parse(JSON.stringify(entry)) as Record<string, unknown>; // JSONL round trip of a plain entry object
+		expect(Object.hasOwn(persisted, "content")).toBe(true);
+		expect(Object.hasOwn(persisted, "customType")).toBe(true);
+		expect(Object.hasOwn(persisted, "display")).toBe(true);
+	});
+
+	it("buildSessionContext over a legacy bare entry yields no nullish-content messages and keeps the real conversation", () => {
+		const context = buildSessionContext(poisonedSession(), "poisoned-2");
+
+		expect(context.messages.length).toBeGreaterThanOrEqual(1);
+		for (const message of context.messages) {
+			const content = "content" in message ? message.content : undefined;
+			expect(content ?? null).not.toBeNull();
+		}
+		const userMessage = context.messages.find(m => m.role === "user");
+		expect(userMessage?.content).toBe(USER_TEXT);
+	});
+
+	it("rebuild + LLM conversion over a poisoned session no longer throws the `.content.filter` TypeError", () => {
+		const context = buildSessionContext(poisonedSession(), "poisoned-2");
+
+		// Pre-fix this crashed with `TypeError: undefined is not an object
+		// (evaluating 'H.content.filter')` before any provider call.
+		expect(() => convertToLlm(context.messages)).not.toThrow();
+
+		const llmMessages = convertToLlm(context.messages);
+		const userTurn = llmMessages.find(m => m.role === "user");
+		expect(userTurn?.content).toBe(USER_TEXT);
+		for (const message of llmMessages) {
+			expect(message.content ?? null).not.toBeNull();
+		}
+	});
+});
+
+describe("sendCustomMessage payload normalization (the hook-side injection vector)", () => {
+	it("coerces the bare-string payload real hooks sent (pi.sendMessage(warning)) into content", () => {
+		const normalized = normalizeCustomMessagePayload("warning: MANAGED region edit");
+		expect(normalized.content).toBe("warning: MANAGED region edit");
+		expect(normalized.customType).toBe("hook-message");
+		expect(normalized.display).toBe(false);
+		// The persisted JSONL shape must carry every key even after stringify.
+		const persisted = JSON.parse(JSON.stringify(normalized)) as Record<string, unknown>;
+		expect(Object.hasOwn(persisted, "content")).toBe(true);
+		expect(Object.hasOwn(persisted, "customType")).toBe(true);
+		expect(Object.hasOwn(persisted, "display")).toBe(true);
+	});
+
+	it("keeps provided fields and fills only the nullish ones", () => {
+		const normalized = normalizeCustomMessagePayload({
+			customType: "aienv:protect-regions",
+			content: "warning text",
+			display: true,
+		});
+		expect(normalized.customType).toBe("aienv:protect-regions");
+		expect(normalized.content).toBe("warning text");
+		expect(normalized.display).toBe(true);
+	});
+
+	it("survives a field-free object (the exact legacy crash shape) without producing nullish fields", () => {
+		const normalized = normalizeCustomMessagePayload({} as never);
+		expect(normalized.content).toBe("");
+		expect(normalized.customType).toBe("hook-message");
+		expect(normalized.display).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #4345 — see the issue for the full chain and repro.