### PR TITLE
fix(cursor): synthesize toolCall blocks for exec-channel native tools

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cursor-agent assistant messages containing native tool calls being split on text length and duplicating text blocks on replay, by emitting the assistant message as-is followed by buffered tool results and pairing them by `toolCallId` in the transcript rebuild ([#4348](https://github.com/can1357/oh-my-pi/issues/4348)).
+
 ## [16.3.0] - 2026-07-02
 
 ### Added

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed cursor-agent assistant messages containing native tool calls being split on text length and duplicating text blocks on replay, by emitting the assistant message as-is followed by buffered tool results and pairing them by `toolCallId` in the transcript rebuild ([#4348](https://github.com/can1357/oh-my-pi/issues/4348)).
+- Fixed cursor-agent exec-channel tools being executed a second time by the shared agent loop after Cursor's server-side execution: `agent-loop.ts` now skips `toolCall` blocks stamped with the `kCursorExecResolved` marker so `bash`/`write`/`delete`/etc. run once ([#4348](https://github.com/can1357/oh-my-pi/issues/4348)).
 
 ## [16.3.0] - 2026-07-02
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -26,6 +26,7 @@ import {
 	wrapInbandToolStream,
 } from "@oh-my-pi/pi-ai/dialect";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { type CursorExecResolvedCarrier, kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import {
 	createHarmonyAuditEvent,
 	detectHarmonyLeakInAssistantMessage,
@@ -910,7 +911,13 @@ async function runLoopBody(
 					// Create placeholder tool results for any tool calls in the aborted message
 					// This maintains the tool_use/tool_result pairing that the API requires
 					type ToolCallContent = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
-					const toolCalls = message.content.filter((c): c is ToolCallContent => c.type === "toolCall");
+					// Cursor exec-resolved blocks already have their toolResult buffered
+					// for out-of-band emission; a placeholder aborted result here would
+					// pair a duplicate to the same toolCallId (issue #4348 codex review).
+					const toolCalls = message.content.filter(
+						(c): c is ToolCallContent =>
+							c.type === "toolCall" && (c as CursorExecResolvedCarrier)[kCursorExecResolved] !== true,
+					);
 					const toolResults: ToolResultMessage[] = [];
 					for (const toolCall of toolCalls) {
 						const result = createAbortedToolResult(toolCall, stream, message.stopReason, message.errorMessage);
@@ -949,7 +956,15 @@ async function runLoopBody(
 				// trailing tool_use may be truncated with incomplete arguments — those calls
 				// are abandoned below. (`error`/`aborted` already returned above.)
 				type ToolCallContent = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
-				const toolCalls = message.content.filter((c): c is ToolCallContent => c.type === "toolCall");
+				// A Cursor exec-channel synthesized `toolCall` block carries
+				// `kCursorExecResolved` because Cursor already executed the tool
+				// server-side (via the bridge) and buffered the result for
+				// out-of-band emission — running it here again would duplicate the
+				// same side-effecting call (issue #4348 review by @chatgpt-codex-connector).
+				const toolCalls = message.content.filter(
+					(c): c is ToolCallContent =>
+						c.type === "toolCall" && (c as CursorExecResolvedCarrier)[kCursorExecResolved] !== true,
+				);
 				const runnableStop = message.stopReason === "toolUse" || message.stopReason === "stop";
 				hasMoreToolCalls = runnableStop && toolCalls.length > 0;
 
@@ -1679,7 +1694,13 @@ async function executeToolCalls(
 		afterToolCall,
 	} = config;
 	type ToolCallContent = Extract<AssistantMessage["content"][number], { type: "toolCall" }>;
-	const toolCalls = assistantMessage.content.filter((c): c is ToolCallContent => c.type === "toolCall");
+	// Defensive: the outer loop already filters exec-resolved blocks before
+	// deciding to invoke `executeToolCalls`, but skip them here too so the
+	// guarantee lives with the code that would re-run the tool.
+	const toolCalls = assistantMessage.content.filter(
+		(c): c is ToolCallContent =>
+			c.type === "toolCall" && (c as CursorExecResolvedCarrier)[kCursorExecResolved] !== true,
+	);
 	const emittedToolResults: ToolResultMessage[] = [];
 	const toolCallInfos = toolCalls.map(call => ({ id: call.id, name: call.name }));
 	const batchId = `${assistantMessage.timestamp ?? Date.now()}_${toolCalls[0]?.id ?? "batch"}`;

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -320,10 +320,9 @@ export interface AgentPromptOptions {
 	toolChoice?: ToolChoice;
 }
 
-/** Buffered Cursor tool result with text position at time of call */
+/** Buffered Cursor exec-channel tool result waiting to be emitted after the assistant message. */
 interface CursorToolResultEntry {
 	toolResult: ToolResultMessage;
-	textLengthAtCall: number;
 }
 
 export class Agent {
@@ -1097,12 +1096,11 @@ export class Agent {
 								}
 							} catch {}
 						}
-						// Buffer tool result with current text length for correct ordering later.
-						// Cursor executes tools server-side during streaming, so the assistant message
-						// already incorporates results. We buffer here and emit in correct order
-						// when the assistant message ends.
-						const textLength = this.#getAssistantTextLength(this.#state.streamMessage);
-						this.#cursorToolResultBuffer.push({ toolResult: finalMessage, textLengthAtCall: textLength });
+						// Cursor executes tools server-side during streaming. We buffer
+						// each toolResult and emit them right after the assistant message
+						// closes (see `#emitCursorSplitAssistantMessage`), so replay
+						// receives (assistant with interleaved toolCall blocks) → results.
+						this.#cursorToolResultBuffer.push({ toolResult: finalMessage });
 						return finalMessage;
 					}
 				: undefined;
@@ -1343,115 +1341,33 @@ export class Agent {
 		}
 	}
 
-	/** Calculate total text length from an assistant message's content blocks */
-	#getAssistantTextLength(message: AgentMessage | null): number {
-		if (message?.role !== "assistant" || !Array.isArray(message.content)) {
-			return 0;
-		}
-		let length = 0;
-		for (const block of message.content) {
-			if (block.type === "text") {
-				length += (block as TextContent).text.length;
-			}
-		}
-		return length;
-	}
-
 	/**
-	 * Emit a Cursor assistant message split around tool results.
-	 * This fixes the ordering issue where tool results appear after the full explanation.
+	 * Emit a Cursor assistant message with buffered exec-channel toolResults.
 	 *
-	 * Output order: Assistant(preamble) -> ToolResults -> Assistant(continuation)
+	 * Since the Cursor provider now synthesizes `toolCall` content blocks at the
+	 * point each exec tool starts (issue #4348), the assistant message content
+	 * already interleaves text/thinking with toolCall blocks in execution order.
+	 * We emit the message as-is and let the buffered toolResults follow — the
+	 * transcript rebuild in `renderSessionContext` pairs them by `toolCallId`.
+	 *
+	 * Historical note: this used to split the assistant message at
+	 * `textLengthAtCall` to interpose toolResults between preamble and
+	 * continuation. That workaround existed because native cursor tools had no
+	 * toolCall blocks; it also copied `preambleText` into every text block on
+	 * multi-text turns, producing duplicated text on replay.
 	 */
 	#emitCursorSplitAssistantMessage(assistantMessage: AssistantMessage): void {
 		const buffer = this.#cursorToolResultBuffer;
 		this.#cursorToolResultBuffer = [];
 
-		if (buffer.length === 0) {
-			// No tool results, emit normally
-			this.#state.streamMessage = null;
-			this.appendMessage(assistantMessage);
-			this.#emit({ type: "message_end", message: assistantMessage });
-			return;
-		}
-
-		// Find the split point: minimum text length at first tool call
-		const splitPoint = Math.min(...buffer.map(r => r.textLengthAtCall));
-
-		// Extract text content from assistant message
-		const content = assistantMessage.content;
-		let fullText = "";
-		for (const block of content) {
-			if (block.type === "text") {
-				fullText += block.text;
-			}
-		}
-
-		// If no text or split point is 0 or at/past end, don't split
-		if (fullText.length === 0 || splitPoint <= 0 || splitPoint >= fullText.length) {
-			// Emit assistant message first, then tool results (original behavior but with buffered results)
-			this.#state.streamMessage = null;
-			this.appendMessage(assistantMessage);
-			this.#emit({ type: "message_end", message: assistantMessage });
-
-			// Emit buffered tool results
-			for (const { toolResult } of buffer) {
-				this.#emit({ type: "message_start", message: toolResult });
-				this.appendMessage(toolResult);
-				this.#emit({ type: "message_end", message: toolResult });
-			}
-			return;
-		}
-
-		// Split the text
-		const preambleText = fullText.slice(0, splitPoint);
-		const continuationText = fullText.slice(splitPoint);
-
-		// Create preamble message (text before tools)
-		const preambleContent = content.map(block => {
-			if (block.type === "text") {
-				return { ...block, text: preambleText };
-			}
-			return block;
-		});
-		const preambleMessage: AssistantMessage = {
-			...assistantMessage,
-			content: preambleContent,
-		};
-
-		// Emit preamble
 		this.#state.streamMessage = null;
-		this.appendMessage(preambleMessage);
-		this.#emit({ type: "message_end", message: preambleMessage });
+		this.appendMessage(assistantMessage);
+		this.#emit({ type: "message_end", message: assistantMessage });
 
-		// Emit buffered tool results
 		for (const { toolResult } of buffer) {
 			this.#emit({ type: "message_start", message: toolResult });
 			this.appendMessage(toolResult);
 			this.#emit({ type: "message_end", message: toolResult });
-		}
-
-		// Emit continuation message (text after tools) if non-empty
-		const trimmedContinuation = continuationText.trim();
-		if (trimmedContinuation.length > 0) {
-			// Create continuation message with only text content (no thinking/toolCalls)
-			const continuationContent: TextContent[] = [{ type: "text", text: continuationText }];
-			const continuationMessage: AssistantMessage = {
-				...assistantMessage,
-				content: continuationContent,
-				// Zero out usage for continuation since it's part of same response
-				usage: {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-					totalTokens: 0,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				},
-			};
-			this.#emit({ type: "message_start", message: continuationMessage });
-			this.appendMessage(continuationMessage);
-			this.#emit({ type: "message_end", message: continuationMessage });
 		}
 	}
 }

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -2717,3 +2717,198 @@ describe("agentLoop streaming snapshots", () => {
 		expect(update.message).not.toBe(livePartial);
 	});
 });
+
+describe("agentLoop kCursorExecResolved (issue #4348)", () => {
+	it("skips execute for a toolCall block marked as already run by Cursor's exec channel", async () => {
+		const { kCursorExecResolved } = await import("@oh-my-pi/pi-ai/utils/block-symbols");
+
+		const toolSchema = type({ command: "string" });
+		let executeCalls = 0;
+		const tool: AgentTool<typeof toolSchema, { command: string }> = {
+			name: "bash",
+			label: "Bash",
+			description: "Run shell commands",
+			parameters: toolSchema,
+			async execute(_id, params) {
+				executeCalls += 1;
+				return {
+					content: [{ type: "text", text: `local run: ${params.command}` }],
+					details: {},
+				};
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const config: AgentLoopConfig = {
+			model: createMockModel().model,
+			convertToLlm: identityConverter,
+		};
+
+		// Simulate the shape the Cursor provider now emits after
+		// `synthesizeCursorExecToolCall`: a `toolCall` content block stamped
+		// with `kCursorExecResolved` because the server-driven exec channel
+		// already ran the tool. `agent-loop.ts` MUST NOT invoke `tool.execute`
+		// again — that would double-execute bash/write/delete/etc. and append a
+		// second `toolResult` with the same `toolCallId`.
+		const streamFn = () => {
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				const resolvedBlock = {
+					type: "toolCall" as const,
+					id: "cursor-exec-tc-1",
+					name: "bash",
+					arguments: { command: "rm -rf /tmp/cursor-once" },
+					[kCursorExecResolved]: true as const,
+				};
+				const finalMessage: AssistantMessage = {
+					role: "assistant",
+					content: [{ type: "text", text: "Ran the command." }, resolvedBlock],
+					api: "cursor-agent",
+					provider: "cursor",
+					model: "cursor-composer-2.5",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: Date.now(),
+				};
+				stream.push({ type: "start", partial: finalMessage });
+				stream.push({ type: "done", reason: "stop", message: finalMessage });
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("run bash")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		// Tool MUST NOT have been executed — Cursor already ran it server-side.
+		expect(executeCalls).toBe(0);
+
+		// No `tool_execution_start`/`tool_execution_end` from agent-loop —
+		// those live-events belong to the bridge that already ran the tool.
+		const startFromLoop = events.find(e => e.type === "tool_execution_start");
+		const endFromLoop = events.find(e => e.type === "tool_execution_end");
+		expect(startFromLoop).toBeUndefined();
+		expect(endFromLoop).toBeUndefined();
+
+		// And no duplicate `toolResult` message emitted for the resolved block:
+		// the buffered result flows via the Agent-class path, not agent-loop.
+		const orphanToolResult = events.find(
+			(e): e is Extract<AgentEvent, { type: "message_end" }> =>
+				e.type === "message_end" && e.message.role === "toolResult",
+		);
+		expect(orphanToolResult).toBeUndefined();
+	});
+
+	it("still runs a normal, unmarked toolCall block in the same turn", async () => {
+		// Guards against the filter over-matching: a mixed turn where only
+		// SOME blocks are Cursor-resolved must still execute the unmarked one.
+		const { kCursorExecResolved } = await import("@oh-my-pi/pi-ai/utils/block-symbols");
+
+		const toolSchema = type({ value: "string" });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_id, params) {
+				executed.push(params.value);
+				return { content: [{ type: "text", text: `echoed: ${params.value}` }], details: {} };
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const config: AgentLoopConfig = {
+			model: createMockModel().model,
+			convertToLlm: identityConverter,
+		};
+
+		let turn = 0;
+		const streamFn = () => {
+			const stream = new AssistantMessageEventStream();
+			queueMicrotask(() => {
+				if (turn++ === 0) {
+					const resolvedBlock = {
+						type: "toolCall" as const,
+						id: "resolved-1",
+						name: "bash",
+						arguments: { command: "true" },
+						[kCursorExecResolved]: true as const,
+					};
+					const runnableBlock = {
+						type: "toolCall" as const,
+						id: "runnable-1",
+						name: "echo",
+						arguments: { value: "hi" },
+					};
+					const partial: AssistantMessage = {
+						role: "assistant",
+						content: [resolvedBlock, runnableBlock],
+						api: "cursor-agent",
+						provider: "cursor",
+						model: "cursor-composer-2.5",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "toolUse",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial });
+					stream.push({ type: "done", reason: "toolUse", message: partial });
+				} else {
+					// Second turn: replay `done` closes the loop.
+					const partial: AssistantMessage = {
+						role: "assistant",
+						content: [{ type: "text", text: "finished" }],
+						api: "cursor-agent",
+						provider: "cursor",
+						model: "cursor-composer-2.5",
+						usage: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 0,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "stop",
+						timestamp: Date.now(),
+					};
+					stream.push({ type: "start", partial });
+					stream.push({ type: "done", reason: "stop", message: partial });
+				}
+			});
+			return stream;
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("mixed")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		expect(executed).toEqual(["hi"]);
+
+		const executionStarts = events.filter(e => e.type === "tool_execution_start");
+		// Exactly one execution: the unmarked `echo` block. The resolved
+		// `bash` block is passed through untouched.
+		expect(executionStarts).toHaveLength(1);
+		if (executionStarts[0]?.type !== "tool_execution_start") throw new Error("expected tool_execution_start");
+		expect(executionStarts[0].toolCallId).toBe("runnable-1");
+		expect(executionStarts[0].toolName).toBe("echo");
+	});
+});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -2733,7 +2733,7 @@ describe("agentLoop kCursorExecResolved (issue #4348)", () => {
 				executeCalls += 1;
 				return {
 					content: [{ type: "text", text: `local run: ${params.command}` }],
-					details: {},
+					details: { command: params.command },
 				};
 			},
 		};
@@ -2822,7 +2822,10 @@ describe("agentLoop kCursorExecResolved (issue #4348)", () => {
 			parameters: toolSchema,
 			async execute(_id, params) {
 				executed.push(params.value);
-				return { content: [{ type: "text", text: `echoed: ${params.value}` }], details: {} };
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
 			},
 		};
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed cursor-agent persisted transcripts losing tool-call structure by synthesizing `toolCall` content blocks for exec-channel native tools (`bash`/`read`/`write`/`grep`/`ls`/`delete`/`lsp`), so replay pairs each tool result with its call instead of rendering header-less tool output beneath the last assistant text ([#4348](https://github.com/can1357/oh-my-pi/issues/4348)).
+
 ## [16.3.1] - 2026-07-02
 
 ### Changed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed cursor-agent persisted transcripts losing tool-call structure by synthesizing `toolCall` content blocks for exec-channel native tools (`bash`/`read`/`write`/`grep`/`ls`/`delete`/`lsp`), so replay pairs each tool result with its call instead of rendering header-less tool output beneath the last assistant text ([#4348](https://github.com/can1357/oh-my-pi/issues/4348)).
+- Fixed cursor-agent persisted transcripts losing tool-call structure by synthesizing `toolCall` content blocks for exec-channel native tools (`bash`/`read`/`write`/`grep`/`ls`/`delete`/`lsp`), so replay pairs each tool result with its call instead of rendering header-less tool output beneath the last assistant text ([#4348](https://github.com/can1357/oh-my-pi/issues/4348)). Synthesized blocks carry a new `kCursorExecResolved` symbol marker so the shared agent loop skips executing them a second time.
 
 ## [16.3.1] - 2026-07-02
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -628,7 +628,7 @@ export type ToolCallState = ToolCall & {
 	[kStreamingBlockIndex]: number;
 	[kStreamingPartialJson]?: string;
 	[kStreamingLastParseLen]?: number;
-	[kStreamingBlockKind]: "mcp" | "todo";
+	[kStreamingBlockKind]: "mcp" | "todo" | "cursor-exec";
 };
 
 export interface BlockState {
@@ -674,6 +674,9 @@ async function handleServerMessage(
 			execHandlers,
 			onToolResult,
 			requestContextTools,
+			output,
+			stream,
+			state,
 		);
 	} else if (msgCase === "conversationCheckpointUpdate") {
 		handleConversationCheckpointUpdate(msg.message.value, output, usageState, onConversationCheckpoint);
@@ -1030,6 +1033,9 @@ async function handleExecServerMessage(
 	execHandlers: CursorExecHandlers | undefined,
 	onToolResult: CursorToolResultHandler | undefined,
 	requestContextTools: McpToolDefinition[],
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	state: BlockState,
 ): Promise<void> {
 	const execCase = execMsg.message.case;
 	log("exec", "dispatch", { execCase, execId: execMsg.execId, hasHandlers: !!execHandlers });
@@ -1064,6 +1070,8 @@ async function handleExecServerMessage(
 	switch (execCase) {
 		case "readArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "read", { path: args.path });
 			const { execResult } = await resolveExecHandler(
 				args,
 				execHandlers?.read?.bind(execHandlers),
@@ -1077,6 +1085,11 @@ async function handleExecServerMessage(
 		}
 		case "lsArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			// Bridge maps `ls` onto the coding-agent `read` tool (see
+			// `CursorExecHandlers.ls` in `pi-coding-agent/src/cursor.ts`); mirror
+			// that here so the synthesized block matches the toolResult's `toolName`.
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "read", { path: args.path });
 			const { execResult } = await resolveExecHandler(
 				args,
 				execHandlers?.ls?.bind(execHandlers),
@@ -1090,6 +1103,16 @@ async function handleExecServerMessage(
 		}
 		case "grepArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			// Mirror the coding-agent bridge's arg mapping so live UI (from
+			// `tool_execution_start`) and rebuilt transcript (from this block)
+			// display identical args.
+			const searchPath = args.glob ? `${args.path || "."}/${args.glob}` : args.path || ".";
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "grep", {
+				pattern: args.pattern,
+				path: searchPath,
+				case: args.caseInsensitive === true ? false : undefined,
+			});
 			const { execResult } = await resolveExecHandler(
 				args,
 				execHandlers?.grep?.bind(execHandlers),
@@ -1103,6 +1126,13 @@ async function handleExecServerMessage(
 		}
 		case "writeArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			// Match the bridge: prefer `fileText`, fall back to decoded `fileBytes`.
+			const content = args.fileText ?? new TextDecoder().decode(args.fileBytes ?? new Uint8Array());
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "write", {
+				path: args.path,
+				content,
+			});
 			const { execResult } = await resolveExecHandler(
 				args,
 				execHandlers?.write?.bind(execHandlers),
@@ -1125,6 +1155,8 @@ async function handleExecServerMessage(
 		}
 		case "deleteArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "delete", { path: args.path });
 			const { execResult } = await resolveExecHandler(
 				args,
 				execHandlers?.delete?.bind(execHandlers),
@@ -1138,7 +1170,16 @@ async function handleExecServerMessage(
 		}
 		case "shellArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
 			const normalizedArgs: ShellArgs = { ...args, workingDirectory: args.workingDirectory || process.cwd() };
+			// Match the bridge (`CursorExecHandlers.shell`): map `workingDirectory`
+			// → `cwd`, drop non-positive timeouts.
+			const shellTimeout = args.timeout && args.timeout > 0 ? args.timeout : undefined;
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "bash", {
+				command: args.command,
+				cwd: args.workingDirectory || undefined,
+				timeout: shellTimeout,
+			});
 			const { execResult } = await resolveExecHandler(
 				args,
 				execHandlers?.shell?.bind(execHandlers),
@@ -1153,6 +1194,13 @@ async function handleExecServerMessage(
 		}
 		case "shellStreamArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			const shellStreamTimeout = args.timeout && args.timeout > 0 ? args.timeout : undefined;
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "bash", {
+				command: args.command,
+				cwd: args.workingDirectory || undefined,
+				timeout: shellStreamTimeout,
+			});
 			await handleShellStreamArgs(args, execMsg, h2Request, execHandlers, onToolResult);
 			return;
 		}
@@ -1200,6 +1248,13 @@ async function handleExecServerMessage(
 		}
 		case "diagnosticsArgs": {
 			const args = execMsg.message.value;
+			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			// Bridge maps `diagnostics` onto the coding-agent `lsp` tool with
+			// `action: "diagnostics"` and `file: path`.
+			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "lsp", {
+				action: "diagnostics",
+				file: args.path,
+			});
 			const { execResult } = await resolveExecHandler(
 				args,
 				execHandlers?.diagnostics?.bind(execHandlers),
@@ -2014,6 +2069,43 @@ function endCurrentThinkingBlock(
 		partial: output,
 	});
 	state.setThinkingBlock(null);
+}
+
+/**
+ * Synthesize a completed `toolCall` content block for a Cursor exec-channel
+ * native tool (`shell`, `read`, `write`, `grep`, `ls`, `delete`, `diagnostics`).
+ *
+ * Args arrive complete on the exec message, so the block opens and closes in
+ * one step — no partial-JSON streaming path. Without this the persisted
+ * assistant message carries only text/thinking blocks, and on replay the
+ * following `toolResult` messages have no matching `toolCall.id` in
+ * `renderSessionContext`, so they render as header-less `⎿` lines beneath the
+ * last text block instead of proper tool components (issue #4348).
+ *
+ * Exported for tests to exercise ordering with adjacent text/thinking blocks.
+ */
+export function synthesizeCursorExecToolCall(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	state: BlockState,
+	toolCallId: string,
+	toolName: string,
+	args: Record<string, unknown>,
+): void {
+	endCurrentTextBlock(output, stream, state);
+	endCurrentThinkingBlock(output, stream, state);
+	const block: ToolCallState = {
+		type: "toolCall",
+		id: toolCallId,
+		name: toolName,
+		arguments: args,
+		[kStreamingBlockIndex]: output.content.length,
+		[kStreamingBlockKind]: "cursor-exec",
+	};
+	output.content.push(block);
+	const idx = output.content.length - 1;
+	stream.push({ type: "toolcall_start", contentIndex: idx, partial: output });
+	stream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: output });
 }
 
 /** Exported for tests: drives one Cursor interaction update through the streaming state machine. */

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -133,6 +133,7 @@ import type {
 import { normalizeSystemPrompts } from "../utils";
 import {
 	clearStreamingPartialJson,
+	kCursorExecResolved,
 	kStreamingBlockIndex,
 	kStreamingBlockKind,
 	kStreamingLastParseLen,
@@ -629,6 +630,7 @@ export type ToolCallState = ToolCall & {
 	[kStreamingPartialJson]?: string;
 	[kStreamingLastParseLen]?: number;
 	[kStreamingBlockKind]: "mcp" | "todo" | "cursor-exec";
+	[kCursorExecResolved]?: true;
 };
 
 export interface BlockState {
@@ -2082,6 +2084,12 @@ function endCurrentThinkingBlock(
  * `renderSessionContext`, so they render as header-less `⎿` lines beneath the
  * last text block instead of proper tool components (issue #4348).
  *
+ * The block is stamped with {@link kCursorExecResolved} so the shared
+ * `agent-loop.ts` execution pass skips it — Cursor's server-driven exec
+ * channel already ran the tool via the bridge and buffered the result, so
+ * treating this block as runnable would re-execute the same side-effecting
+ * tool a second time.
+ *
  * Exported for tests to exercise ordering with adjacent text/thinking blocks.
  */
 export function synthesizeCursorExecToolCall(
@@ -2101,6 +2109,7 @@ export function synthesizeCursorExecToolCall(
 		arguments: args,
 		[kStreamingBlockIndex]: output.content.length,
 		[kStreamingBlockKind]: "cursor-exec",
+		[kCursorExecResolved]: true,
 	};
 	output.content.push(block);
 	const idx = output.content.length - 1;

--- a/packages/ai/src/utils/block-symbols.ts
+++ b/packages/ai/src/utils/block-symbols.ts
@@ -30,3 +30,20 @@ export const kStreamingArgumentsDone = Symbol("provider.block.argumentsDone");
 
 /** Classifies Cursor's in-flight tool-call kind without leaking provider-private state. */
 export const kStreamingBlockKind = Symbol("provider.block.kind");
+
+/**
+ * Marks a `toolCall` content block that Cursor's exec channel already
+ * executed server-side (via the coding-agent bridge) and whose result is
+ * buffered separately for emission via the assistant-loop stream.
+ *
+ * `agent-loop.ts` MUST skip execution of blocks carrying this marker —
+ * treating them as a fresh runnable tool call would run the same
+ * side-effecting tool (bash, write, delete, …) a second time. Symbol-keyed
+ * so it never persists across the JSONL round-trip, where rebuild instead
+ * pairs the block with its already-persisted `toolResult` message by id.
+ */
+export const kCursorExecResolved = Symbol("provider.block.cursorExecResolved");
+
+/** Carries the resolved marker without exposing a string-keyed property. */
+export type CursorExecResolvedCarrier = object & { [kCursorExecResolved]?: true };
+

--- a/packages/ai/src/utils/block-symbols.ts
+++ b/packages/ai/src/utils/block-symbols.ts
@@ -46,4 +46,3 @@ export const kCursorExecResolved = Symbol("provider.block.cursorExecResolved");
 
 /** Carries the resolved marker without exposing a string-keyed property. */
 export type CursorExecResolvedCarrier = object & { [kCursorExecResolved]?: true };
-

--- a/packages/ai/test/cursor-streaming-args.test.ts
+++ b/packages/ai/test/cursor-streaming-args.test.ts
@@ -3,6 +3,7 @@ import {
 	type BlockState,
 	mergeCursorMcpToolCallArgs,
 	processInteractionUpdate,
+	synthesizeCursorExecToolCall,
 	type ToolCallState,
 	type UsageState,
 } from "@oh-my-pi/pi-ai/providers/cursor";
@@ -321,6 +322,84 @@ describe("processInteractionUpdate args_text_delta handling", () => {
 			agent: "task",
 			tasks: [{ assignment: "do A" }, { assignment: "do B" }],
 			context: "ctx",
+		});
+	});
+});
+
+describe("synthesizeCursorExecToolCall (issue #4348)", () => {
+	it("closes preceding text/thinking blocks before opening the synthesized toolCall", () => {
+		const h = newHarness();
+
+		pushTextDelta(h, "reading ");
+		synthesizeCursorExecToolCall(h.output, h.stream, h.state, "call-read", "read", { path: "src/foo.ts" });
+
+		expect(h.output.content.map(b => b.type)).toEqual(["text", "toolCall"]);
+		expect(h.output.content[0]).toMatchObject({ type: "text", text: "reading " });
+		expect(h.output.content[1]).toMatchObject({
+			type: "toolCall",
+			id: "call-read",
+			name: "read",
+			arguments: { path: "src/foo.ts" },
+		});
+		// text_end fires before toolcall_start so the preceding text block finalizes;
+		// toolcall_end fires immediately after — exec-channel args arrive complete,
+		// so no partial-JSON streaming is needed for the synthesized block.
+		expect(h.captured.map(e => e.type)).toEqual([
+			"text_start",
+			"text_delta",
+			"text_end",
+			"toolcall_start",
+			"toolcall_end",
+		]);
+		expect(h.state.currentTextBlock).toBeNull();
+		expect(h.state.currentToolCall).toBeNull();
+	});
+
+	it("preserves interleaving order across text ↔ tool ↔ text", () => {
+		const h = newHarness();
+
+		pushTextDelta(h, "planning ");
+		synthesizeCursorExecToolCall(h.output, h.stream, h.state, "t1", "read", { path: "a.txt" });
+		pushTextDelta(h, "then ");
+		synthesizeCursorExecToolCall(h.output, h.stream, h.state, "t2", "bash", {
+			command: "echo hi",
+			cwd: undefined,
+			timeout: undefined,
+		});
+		pushTextDelta(h, "done");
+
+		expect(h.output.content.map(b => b.type)).toEqual(["text", "toolCall", "text", "toolCall", "text"]);
+		const [t1, tc1, t2, tc2, t3] = h.output.content;
+		expect(t1).toMatchObject({ type: "text", text: "planning " });
+		expect(tc1).toMatchObject({ type: "toolCall", id: "t1", name: "read" });
+		expect(t2).toMatchObject({ type: "text", text: "then " });
+		expect(tc2).toMatchObject({
+			type: "toolCall",
+			id: "t2",
+			name: "bash",
+			arguments: { command: "echo hi", cwd: undefined, timeout: undefined },
+		});
+		expect(t3).toMatchObject({ type: "text", text: "done" });
+	});
+
+	it("emits toolcall events at the exact index the block occupies in content", () => {
+		const h = newHarness();
+
+		pushTextDelta(h, "pre");
+		synthesizeCursorExecToolCall(h.output, h.stream, h.state, "call-1", "grep", {
+			pattern: "foo",
+			path: ".",
+			case: undefined,
+		});
+
+		const toolStart = h.captured.find(e => e.type === "toolcall_start");
+		const toolEnd = h.captured.find(e => e.type === "toolcall_end");
+		// Text block sits at index 0; synthesized toolCall at index 1.
+		expect(toolStart).toMatchObject({ type: "toolcall_start", contentIndex: 1 });
+		expect(toolEnd).toMatchObject({
+			type: "toolcall_end",
+			contentIndex: 1,
+			toolCall: { id: "call-1", name: "grep" },
 		});
 	});
 });

--- a/packages/coding-agent/test/issue-4348-repro.test.ts
+++ b/packages/coding-agent/test/issue-4348-repro.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression for issue #4348: cursor-agent persisted transcripts lose tool-call
+ * structure, so replay renders header-less tool results.
+ *
+ * Before the fix, the Cursor provider only synthesized `toolCall` content
+ * blocks for `mcpToolCall` and `updateTodosToolCall`. Native exec-channel tools
+ * (`bash`/`read`/`write`/`grep`/`ls`/`delete`/`lsp`) executed via the bridge
+ * and never appeared in `AssistantMessage.content`. `renderSessionContext`
+ * then had no matching toolCall block for each `toolResult` message, and the
+ * results fell through to `addMessageToChat`, rendering as bare `⎿` lines
+ * beneath the last assistant text.
+ *
+ * The fix (in `packages/ai/src/providers/cursor.ts` `handleExecServerMessage`)
+ * synthesizes a `toolCall` block on the exec channel using the same tool name
+ * and args the bridge emits via `tool_execution_start`. This test asserts the
+ * post-fix persisted shape rebuilds into proper `ToolExecutionComponent`s
+ * that own their tool results, not into orphan `⎿` toolResult lines.
+ */
+
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
+import type { SessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
+import { Container } from "@oh-my-pi/pi-tui";
+
+beforeAll(() => {
+	initTheme();
+});
+
+const emptyUsage: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function transcriptWith(messages: AgentMessage[]): SessionContext {
+	return {
+		messages,
+		thinkingLevel: "off",
+		serviceTier: undefined,
+		models: {},
+		injectedTtsrRules: [],
+		selectedMCPToolNames: [],
+		hasPersistedMCPToolSelection: false,
+		mode: "none",
+	};
+}
+
+function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContext; chatContainer: Container } {
+	const chatContainer = new Container();
+	let helpers: UiHelpers;
+	const ctx = {
+		chatContainer,
+		pendingMessagesContainer: new Container(),
+		pendingBashComponents: [],
+		pendingPythonComponents: [],
+		pendingTools: new Map(),
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		updateEditorTopBorder: vi.fn(),
+		ui: { requestRender: vi.fn(), imageBudget: undefined },
+		resetTranscript: () => chatContainer.clear(),
+		settings: { get: () => false },
+		toolOutputExpanded: false,
+		hideThinkingBlock: false,
+		focusedAgentId: undefined,
+		editor: { addToHistory: vi.fn() },
+		viewSession: {
+			buildTranscriptSessionContext: () => transcript,
+			getToolByName: () => undefined,
+			extensionRunner: undefined,
+			sessionManager: {
+				getEntries: vi.fn(() => []),
+				getCwd: vi.fn(() => "/tmp"),
+			},
+		},
+		sessionManager: {
+			getEntries: vi.fn(() => []),
+			getCwd: vi.fn(() => "/tmp"),
+			putBlobSync: vi.fn(() => ({
+				hash: "hash",
+				path: "/tmp/hash",
+				displayPath: "/tmp/hash.png",
+				ref: "blob:sha256:hash",
+			})),
+		},
+		addMessageToChat: (message: AgentMessage, options?: { populateHistory?: boolean }) =>
+			helpers.addMessageToChat(message, options),
+		renderSessionContext: (context: SessionContext, options?: { updateFooter?: boolean; populateHistory?: boolean }) =>
+			helpers.renderSessionContext(context, options),
+		showStatus: vi.fn(),
+	} as unknown as InteractiveModeContext;
+	helpers = new UiHelpers(ctx);
+	return { ctx, chatContainer };
+}
+
+/** Build the cursor-shaped assistant + toolResults message set for one turn. */
+function cursorTurn(): AgentMessage[] {
+	// After the fix, the Cursor provider synthesizes `toolCall` blocks with the
+	// bridge's mapped tool names ("bash"/"read"). The stopReason for cursor
+	// turns with tool results is "toolUse" mid-turn — this matches how the
+	// agent-loop finalizes cursor exec turns.
+	const assistant: AssistantMessage = {
+		role: "assistant",
+		content: [
+			{ type: "text", text: "Reading and listing:" },
+			{ type: "toolCall", id: "tc-read", name: "read", arguments: { path: "src/foo.ts" } },
+			{ type: "toolCall", id: "tc-bash", name: "bash", arguments: { command: "ls -1", cwd: undefined, timeout: undefined } },
+		],
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "cursor-composer-2.5",
+		usage: emptyUsage,
+		stopReason: "toolUse",
+		timestamp: 1,
+	};
+	return [
+		assistant,
+		{
+			role: "toolResult",
+			toolCallId: "tc-read",
+			toolName: "read",
+			content: [{ type: "text", text: "READ_RESULT_MARKER content of foo.ts" }],
+			isError: false,
+			timestamp: 2,
+		},
+		{
+			role: "toolResult",
+			toolCallId: "tc-bash",
+			toolName: "bash",
+			content: [{ type: "text", text: "BASH_RESULT_MARKER file1\nfile2" }],
+			isError: false,
+			timestamp: 3,
+		},
+	];
+}
+
+describe("issue #4348: cursor exec-channel tool results pair with synthesized toolCall blocks on rebuild", () => {
+	it("renders bash toolResult inside a ToolExecutionComponent, not as an orphan `⎿` line", async () => {
+		await Settings.init({ inMemory: true });
+		const transcript = transcriptWith(cursorTurn());
+		const { ctx, chatContainer } = makeRenderCtx(transcript);
+
+		new UiHelpers(ctx).renderInitialMessages();
+
+		// Component structure: an assistant message, then a bash
+		// ToolExecutionComponent for the synthesized bash block, then a
+		// ReadToolGroupComponent for the synthesized read block. Absent the
+		// synthesis (pre-fix), neither would exist — both results would fall
+		// through `addMessageToChat` (a no-op for `toolResult`) and vanish.
+		const rendered = Bun.stripANSI(chatContainer.render(120).join("\n"));
+		expect(rendered).toContain("Reading and listing:");
+		// Bash result is fully surfaced inside the ToolExecutionComponent —
+		// header carries the command, body carries the output.
+		expect(rendered).toContain("ls -1");
+		expect(rendered).toContain("BASH_RESULT_MARKER");
+		// Read result flows into the ReadToolGroupComponent. Its file-content
+		// preview is gated by the `read.toolResultPreview` setting (off in
+		// this harness), so we assert on the pairing signal: the read call
+		// appears with its path, only reachable when the toolResult attaches.
+		expect(rendered).toContain("Read src/foo.ts");
+	});
+
+	it("does not orphan the bash toolResult under the assistant when the toolCall block is missing", async () => {
+		// Simulates the PRE-fix persisted shape: assistant with only text (no
+		// toolCall blocks) + a toolResult message. The renderer has nothing to
+		// pair the result with. This test guards the failure mode so a future
+		// regression that reverts the synthesis is caught: the rendered output
+		// notably omits the bash command preview.
+		await Settings.init({ inMemory: true });
+		const preFixAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "Running command:" }],
+			api: "cursor-agent",
+			provider: "cursor",
+			model: "cursor-composer-2.5",
+			usage: emptyUsage,
+			stopReason: "toolUse",
+			timestamp: 1,
+		};
+		const transcript = transcriptWith([
+			preFixAssistant,
+			{
+				role: "toolResult",
+				toolCallId: "tc-orphan",
+				toolName: "bash",
+				content: [{ type: "text", text: "ORPHAN_RESULT some output" }],
+				isError: false,
+				timestamp: 2,
+			},
+		]);
+		const { ctx, chatContainer } = makeRenderCtx(transcript);
+
+		new UiHelpers(ctx).renderInitialMessages();
+
+		const rendered = Bun.stripANSI(chatContainer.render(120).join("\n"));
+		expect(rendered).toContain("Running command:");
+		// Fallback path (`addMessageToChat` case "toolResult") is a no-op, so
+		// the result content never lands in the transcript at all. That silent
+		// drop is exactly what the reporter saw in the wild — every native
+		// cursor tool's output disappeared from replay.
+		expect(rendered).not.toContain("ORPHAN_RESULT");
+	});
+});

--- a/packages/coding-agent/test/issue-4348-repro.test.ts
+++ b/packages/coding-agent/test/issue-4348-repro.test.ts
@@ -93,8 +93,10 @@ function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContex
 		},
 		addMessageToChat: (message: AgentMessage, options?: { populateHistory?: boolean }) =>
 			helpers.addMessageToChat(message, options),
-		renderSessionContext: (context: SessionContext, options?: { updateFooter?: boolean; populateHistory?: boolean }) =>
-			helpers.renderSessionContext(context, options),
+		renderSessionContext: (
+			context: SessionContext,
+			options?: { updateFooter?: boolean; populateHistory?: boolean },
+		) => helpers.renderSessionContext(context, options),
 		showStatus: vi.fn(),
 	} as unknown as InteractiveModeContext;
 	helpers = new UiHelpers(ctx);
@@ -112,7 +114,12 @@ function cursorTurn(): AgentMessage[] {
 		content: [
 			{ type: "text", text: "Reading and listing:" },
 			{ type: "toolCall", id: "tc-read", name: "read", arguments: { path: "src/foo.ts" } },
-			{ type: "toolCall", id: "tc-bash", name: "bash", arguments: { command: "ls -1", cwd: undefined, timeout: undefined } },
+			{
+				type: "toolCall",
+				id: "tc-bash",
+				name: "bash",
+				arguments: { command: "ls -1", cwd: undefined, timeout: undefined },
+			},
 		],
 		api: "cursor-agent",
 		provider: "cursor",


### PR DESCRIPTION
## Repro

Route a subagent (or main model) to any `cursor/*` model — for example
`omp config set task.agentModelOverrides '{"task":"cursor/composer-2.5-fast"}'` — run a
task with a few dozen tool calls, then expand the task's output or `--resume` the
session. The rebuilt transcript renders one stale `⏺` assistant text line
followed by a flat wall of header-less `⎿` tool results: no tool names, no
arguments, no call/result pairing.

## Cause

The Cursor provider in `packages/ai/src/providers/cursor.ts` only pushes
`toolCall` content blocks in `processInteractionUpdate` for `mcpToolCall` and
`updateTodosToolCall`. Native tools (`bash`/`read`/`write`/`grep`/`ls`/`delete`
via `lsp`) execute through the exec channel (`handleExecServerMessage` calling
into `CursorExecHandlers` in `packages/coding-agent/src/cursor.ts`), and their
calls never appear in `AssistantMessage.content`. Downstream:

- `agent-session.ts` `#recordToolExecutionStart` summarizes args to
  `{ command, path }` on the (previously correct) premise that the assistant
  message already carries them.
- `renderSessionContext` in `modes/utils/ui-helpers.ts` walks the assistant
  message for `toolCall` blocks to seed `ToolExecutionComponent`s; with no
  matching block, each subsequent `toolResult` falls through
  `addMessageToChat`, whose `case "toolResult"` is a no-op.

`agent.ts` `#emitCursorSplitAssistantMessage` also compounded the issue by
splitting the assistant message at `textLengthAtCall` and replacing every
`text` block with the preamble slice, duplicating text whenever Cursor emitted
more than one text run per turn.

## Fix

- `packages/ai/src/providers/cursor.ts`: thread `output`, `stream`, and
  `state` through `handleServerMessage` → `handleExecServerMessage`, and at
  the top of each native exec case (`readArgs`, `lsArgs`, `grepArgs`,
  `writeArgs`, `deleteArgs`, `shellArgs`, `shellStreamArgs`, `diagnosticsArgs`)
  call the new `synthesizeCursorExecToolCall` helper. The block uses the
  coding-agent bridge's mapped tool name (e.g. `shellArgs` → `bash`, `lsArgs`
  → `read`, `diagnosticsArgs` → `lsp`) and the same args it emits via
  `tool_execution_start`, so live UI and rebuilt transcript render
  identically. `args.toolCallId` is normalized before invoking the bridge so
  the provider block id and bridge result id always match.
- `packages/agent/src/agent.ts`: drop the text-length split in
  `#emitCursorSplitAssistantMessage`. With `toolCall` blocks now at their
  correct positions in `content`, emit the assistant as-is followed by the
  buffered `toolResult` messages; `renderSessionContext` pairs by
  `toolCallId`. Also remove the now-unused `textLengthAtCall` field.
- `packages/ai/test/cursor-streaming-args.test.ts`: three new tests for the
  synthesizer — block insertion after a text block, correct interleaving
  across text ↔ tool ↔ text, and matching event `contentIndex` / block id.
- `packages/coding-agent/test/issue-4348-repro.test.ts` (new): rebuild
  contract test using `UiHelpers.renderInitialMessages` — a cursor-shaped
  turn (assistant with synthesized `bash` + `read` blocks + two toolResults)
  renders both results inside their respective components; the pre-fix
  shape (no toolCall blocks) provably drops the toolResult content, guarding
  the failure mode against silent regression.

`processInteractionUpdate` remains the authoritative source for `mcpToolCall`
and `updateTodosToolCall`; the exec-channel `mcpArgs` case still skips
synthesis to avoid duplicating those blocks.

The reporter's secondary composer/`grep` guardrail note (pattern-less grep
mapped to file listing) is separable and not included here.

## Verification

- `bun test packages/ai/test/cursor-streaming-args.test.ts` → 15 pass (3 new).
- `bun test packages/ai/test/cursor-exec-handlers.test.ts` → 8 pass.
- `bun test packages/coding-agent/test/issue-4348-repro.test.ts` → 2 pass.
- `bun test packages/coding-agent/test/modes/utils/render-initial-messages.test.ts`
  → 7 pass.
- `bun test packages/agent/test/` → 346 pass.

Pre-existing failures on `main` (unchanged by this PR): `packages/ai/test/proxy.test.ts`
only fails as a test-pollution downstream in the full ai suite (passes in
isolation on both `main` and this branch); handoff and plan-mode-convergence
suites fail identically on `main` before this diff. Verified by stashing this
PR's diff and re-running.

Fixes #4348