### PR TITLE
fix(tui): cut TUI CPU overhead during interactive sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed SSH tool hangs on unreachable hosts by enforcing a 30-second timeout on pre-command connection and host probes
 - Fixed models.yml schema validation to surface warnings for invalid custom provider configurations instead of silently ignoring them
 - Fixed potential network hangs in omp update, Hindsight recall, and Smithery registry lookups by adding fetch timeouts
+- Reduced TUI CPU overhead during streaming and idle waits by dropping the redundant pre-render on every session event, iterating shimmer text in place instead of allocating a code-point array per animation frame, and coalescing the live-tool spinner render cadence to its glyph-advance rate ([#4353](https://github.com/can1357/oh-my-pi/issues/4353)).
 
 ## [16.3.2] - 2026-07-02
 

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -182,12 +182,14 @@ export interface ToolExecutionHandle {
 	setExpanded(expanded: boolean): void;
 }
 
-/** Drive pending-tool redraws at 30fps for live tool headers and displaceable
- * poll blocks. The TUI throttles at the same cadence, and static frames diff to
- * a no-op redraw at ~zero cost. */
-export const SPINNER_RENDER_INTERVAL_MS = 1000 / 30;
-/** Advance the spinner glyph at its classic ~12.5fps step, decoupled from the
- * render cadence (mirrors `Loader`). */
+/** Redraw live tool blocks at the spinner's glyph-advance rate. Rendering more
+ * often produced identical frames — the previous 30fps cadence emitted ~2.4
+ * paints per glyph step, and although the terminal I/O layer dedupes those, the
+ * compose pipeline still ran end-to-end per frame (issue #4353). Matching the
+ * render tick to the glyph tick halves the paints during tool execution with no
+ * visible change. */
+export const SPINNER_RENDER_INTERVAL_MS = 80;
+/** Advance the spinner glyph at its classic ~12.5fps step (mirrors `Loader`). */
 export const SPINNER_GLYPH_ADVANCE_MS = 80;
 
 /** Phase-locked spinner glyph index shared by every live tool block so parallel

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -302,9 +302,13 @@ export class EventController {
 			await this.ctx.init();
 		}
 
-		this.ctx.statusLine.invalidate();
-		this.ctx.ui.requestRender();
-
+		// Each handler explicitly requests a render (or leaves it out, when it
+		// changed nothing visible). A blanket pre-render fired on every event —
+		// including the ~hundreds of `message_update` deltas per streaming turn —
+		// doubled the paint rate: the pre-render's frame fires while the handler
+		// is awaiting, then the handler's own final requestRender schedules a
+		// second identical frame. Removing it lets the render cadence follow real
+		// state changes rather than event volume (issue #4353).
 		const run = this.#handlers[event.type] as (e: AgentSessionEvent) => Promise<void>;
 		await run(event);
 	}

--- a/packages/coding-agent/src/modes/theme/shimmer.ts
+++ b/packages/coding-agent/src/modes/theme/shimmer.ts
@@ -180,12 +180,16 @@ export function shimmerSegments(segments: readonly ShimmerSegment[], theme: Shim
 	const mode = resolveMode();
 
 	// Pre-scan: total code-point count (positions the band) and resolved palette.
+	// The per-segment string is kept verbatim — iterating UTF-16 units with a
+	// surrogate-pair guard produces the same code points as `Array.from(text)`
+	// at zero per-frame allocation (previously the #1 hotspot at ~10% of profiled
+	// CPU during streaming — the working message is shimmered every animation
+	// frame at 30fps and `Array.from` reallocated the code-point array each tick).
 	let total = 0;
-	const perSeg: { chars: string[]; palette: ShimmerPalette }[] = [];
+	const perSeg: { text: string; palette: ShimmerPalette }[] = [];
 	for (const seg of segments) {
-		const chars = Array.from(seg.text);
-		total += chars.length;
-		perSeg.push({ chars, palette: seg.palette ?? DEFAULT_SHIMMER_PALETTE });
+		total += countCodePoints(seg.text);
+		perSeg.push({ text: seg.text, palette: seg.palette ?? DEFAULT_SHIMMER_PALETTE });
 	}
 	if (total === 0) return "";
 
@@ -193,9 +197,9 @@ export function shimmerSegments(segments: readonly ShimmerSegment[], theme: Shim
 	// tier so the working line stays legible without movement.
 	if (mode === "disabled") {
 		let out = "";
-		for (const { chars, palette } of perSeg) {
+		for (const { text, palette } of perSeg) {
 			const seq = compile(theme, palette).mid;
-			out += `${seq.open}${chars.join("")}${seq.close}`;
+			out += `${seq.open}${text}${seq.close}`;
 		}
 		return out;
 	}
@@ -205,29 +209,59 @@ export function shimmerSegments(segments: readonly ShimmerSegment[], theme: Shim
 
 	let out = "";
 	let index = 0;
-	for (const { chars, palette } of perSeg) {
+	for (const { text, palette } of perSeg) {
 		const compiled = compile(theme, palette);
 		let runTier: Tier | null = null;
-		let runBuf = "";
-		for (let i = 0; i < chars.length; i++) {
+		let runStart = 0;
+		let runEnd = 0;
+		let i = 0;
+		while (i < text.length) {
+			// Detect a surrogate pair so a single code point (e.g. an emoji) stays
+			// atomic; the band position is measured in code points, not UTF-16 units.
+			const c = text.charCodeAt(i);
+			let step = 1;
+			if (c >= 0xd800 && c <= 0xdbff && i + 1 < text.length) {
+				const c2 = text.charCodeAt(i + 1);
+				if (c2 >= 0xdc00 && c2 <= 0xdfff) step = 2;
+			}
 			const tier = tierFor(intensityFn(time, index, total));
 			if (tier !== runTier) {
-				if (runTier !== null) {
+				if (runTier !== null && runEnd > runStart) {
 					const seq = compiled[runTier];
-					out += `${seq.open}${runBuf}${seq.close}`;
-					runBuf = "";
+					out += `${seq.open}${text.slice(runStart, runEnd)}${seq.close}`;
 				}
 				runTier = tier;
+				runStart = i;
 			}
-			runBuf += chars[i];
+			runEnd = i + step;
 			index++;
+			i += step;
 		}
-		if (runTier !== null && runBuf.length > 0) {
+		if (runTier !== null && runEnd > runStart) {
 			const seq = compiled[runTier];
-			out += `${seq.open}${runBuf}${seq.close}`;
+			out += `${seq.open}${text.slice(runStart, runEnd)}${seq.close}`;
 		}
 	}
 	return out;
+}
+
+function countCodePoints(text: string): number {
+	let n = 0;
+	let i = 0;
+	while (i < text.length) {
+		const c = text.charCodeAt(i);
+		if (c >= 0xd800 && c <= 0xdbff && i + 1 < text.length) {
+			const c2 = text.charCodeAt(i + 1);
+			if (c2 >= 0xdc00 && c2 <= 0xdfff) {
+				i += 2;
+				n++;
+				continue;
+			}
+		}
+		i++;
+		n++;
+	}
+	return n;
 }
 
 export function shimmerText(text: string, theme: ShimmerTheme, palette?: ShimmerPalette): string {

--- a/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts
@@ -222,17 +222,18 @@ describe("EventController IRC expiry", () => {
 		await controller.handleEvent({ type: "irc_message", message });
 
 		expect(chatContainer.children).toHaveLength(2);
-		// handleEvent now requests a repaint up front so the lazy top-border
-		// provider can flush the latest status-line state (#4145); the IRC
-		// handler adds a second request when it mounts the card.
-		expect(requestRender).toHaveBeenCalledTimes(2);
+		// One requestRender from the IRC handler mounting the card. The blanket
+		// pre-render that `handleEvent` used to fire before every dispatch was
+		// removed in #4353 (it doubled the paint rate during streaming and did no
+		// visible work beyond what the handlers already trigger).
+		expect(requestRender).toHaveBeenCalledTimes(1);
 
 		vi.advanceTimersByTime(9_999);
 		expect(chatContainer.children).toHaveLength(2);
 
 		vi.advanceTimersByTime(1);
 		expect(chatContainer.children).toHaveLength(1);
-		expect(requestRender).toHaveBeenCalledTimes(3);
+		expect(requestRender).toHaveBeenCalledTimes(2);
 	});
 
 	it("keeps a card whose rows may already be committed (no live block above)", async () => {
@@ -293,6 +294,6 @@ describe("EventController IRC expiry", () => {
 		vi.advanceTimersByTime(10_000);
 
 		expect(chatContainer.children).toHaveLength(1);
-		expect(requestRender).toHaveBeenCalledTimes(2);
+		expect(requestRender).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/modes/theme/shimmer.test.ts
+++ b/packages/coding-agent/test/modes/theme/shimmer.test.ts
@@ -41,4 +41,28 @@ describe("shimmerText", () => {
 		expect(rendered).toContain("\x1b[38;2;12;34;56m");
 		expect(Bun.stripANSI(rendered)).toBe("x");
 	});
+
+	it("shimmers a mixed BMP + surrogate-pair message correctly (issue #4353 refactor)", () => {
+		// #4353 replaced `Array.from(seg.text)` with in-place UTF-16 iteration to
+		// drop the per-frame allocation that dominated the shimmer render cost.
+		// A surrogate-pair emoji must still count as one code point (the band
+		// index) and stay atomic in the output — an off-by-one would either
+		// double-count the pair (mispositioning the band) or emit one lone
+		// high-surrogate byte inside an ANSI run.
+		vi.spyOn(settingsModule, "isSettingsInitialized").mockReturnValue(false);
+		vi.spyOn(Date, "now").mockReturnValue(0);
+
+		const rendered = shimmerText("a😀b", testTheme);
+		// Strip ANSI: the visible payload must be the exact input, preserving the
+		// surrogate pair intact.
+		expect(Bun.stripANSI(rendered)).toBe("a😀b");
+	});
+
+	it("shimmers an all-emoji message without dropping any code point", () => {
+		vi.spyOn(settingsModule, "isSettingsInitialized").mockReturnValue(false);
+		vi.spyOn(Date, "now").mockReturnValue(0);
+
+		const rendered = shimmerText("🎉🌟✨🚀", testTheme);
+		expect(Bun.stripANSI(rendered)).toBe("🎉🌟✨🚀");
+	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed keyboard fallback behavior (modifyOtherKeys) on unknown SSH terminals, resolving broken Shift input in iOS SSH clients like Redock.
 - Fixed a native scrollback rendering bug where finalized transcript rows below an active block would duplicate when the active block expanded.
 - Fixed autocomplete popups remaining active with stale suggestions after destructive text editing (such as Ctrl+W, Ctrl+U, Ctrl+K, Alt+Backspace, Alt+D, paste, or yank), preventing input corruption when pressing Tab or Enter.
+- Skipped Markdown re-lex + re-wrap when `setText` receives the identical text, mirroring the equality guard on `Text.setText` — cuts one of the top streaming CPU hotspots when providers re-emit unchanged content ([#4353](https://github.com/can1357/oh-my-pi/issues/4353)).
 
 ## [16.3.0] - 2026-07-02
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -842,7 +842,13 @@ export class Markdown implements Component {
 		this.#codeBlockIndent = Math.max(0, Math.floor(codeBlockIndent));
 	}
 
-	setText(text: string): void {
+	setText(text: string): boolean {
+		// Equality guard: streaming re-emits identical text on ticks that carried
+		// no delta (throttled provider frames, reconciled tool-execution updates).
+		// Without this, the caller-side `#cachedLines` gets thrown away and the
+		// full lex + wrap runs per re-emit — one of the top CPU hotspots during
+		// streaming (issue #4353). Mirrors `Text.setText`'s guard.
+		if (text === this.#text) return false;
 		this.#text = text;
 		if (!text.trim()) {
 			// Blank replacement: render() early-returns before #lexTokens can see
@@ -853,6 +859,7 @@ export class Markdown implements Component {
 			this.#streamPrefixLineCache = undefined;
 		}
 		this.invalidate();
+		return true;
 	}
 
 	invalidate(): void {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1533,6 +1533,23 @@ describe("Markdown.render reference stability", () => {
 		expect(md.render(40)).toBe(after);
 	});
 
+	it("skips invalidation when setText receives the same string (streaming re-emit guard)", () => {
+		// #4353: streaming re-emits identical text on ticks with no visible delta
+		// (throttled provider frames, reconciled tool-execution updates). Without
+		// the equality guard, every re-emit would drop `#cachedLines` and force a
+		// full lex + wrap — one of the top CPU hotspots during streaming. The
+		// guard mirrors `Text.setText`.
+		const md = new Markdown("streamed content", 1, 0, defaultMarkdownTheme);
+		const before = md.render(40);
+		const changed = md.setText("streamed content");
+		expect(changed).toBe(false);
+		expect(md.render(40)).toBe(before);
+
+		const changedAgain = md.setText("new content");
+		expect(changedAgain).toBe(true);
+		expect(md.render(40)).not.toBe(before);
+	});
+
 	it("returns a different reference per width, each with correctly fitted rows", () => {
 		const md = new Markdown("Width sentinel content", 1, 0, defaultMarkdownTheme);
 		const narrow = md.render(30);


### PR DESCRIPTION
## Repro

Reporter's CPU profile (`omp-report-2026-07-02T12-35-25-273Z`) captured 13.1 s of profiled CPU against 0.9 s of actual tool work in a 30 s streaming window (93 % TUI overhead), with `ui.loop-blocked` warnings of 586 ms and 2157 ms in `~/.omp/logs/`. Four hotspots were verified against source: `Array.from(seg.text)` at 10.2 % / 1338.7 ms (#1 self-time), `wrapTextWithAnsi` at 8.4 % / 1101.3 ms driven by streaming re-lex, event-driven pre-render doubling every streaming event, and the spinner emitting ~2.4 paints per glyph step. A microbench on 30 000 shimmer frames matched the profile: `Array.from`-based inner loop 45 ms → in-place UTF-16 iteration 18 ms (2.53×, allocations down from ~N per frame to a handful per frame).

## Cause

Four independent hot paths compounded:

1. `EventController.handleEvent` (`packages/coding-agent/src/modes/controllers/event-controller.ts:300`) fired `statusLine.invalidate() + ui.requestRender()` before dispatching every session event. The pre-render was a leftover from #4145 (before `updateEditorTopBorder()` became a lazy provider). During streaming it doubled paints per event: the pre-render's frame fired inside the handler's `await`, then the handler's own `requestRender` scheduled another one.
2. `shimmerSegments` (`packages/coding-agent/src/modes/theme/shimmer.ts:186`) built a fresh code-point array with `Array.from(seg.text)` every animation frame. At 30 fps against a stable working message, each frame reallocated the array, dominating self-time in the profile.
3. `Markdown.setText` (`packages/tui/src/components/markdown.ts:845`) had no equality guard. `Text.setText` short-circuits on `text === #text`, but `Markdown.setText` unconditionally invalidated `#cachedLines`. Providers re-emit identical partials on throttled ticks and reconciled tool-execution updates; each re-emit dropped the cache and forced a full re-lex + re-wrap on the whole accumulated paragraph.
4. `SPINNER_RENDER_INTERVAL_MS` (`packages/coding-agent/src/modes/components/tool-execution.ts:188`) was 33 ms while the glyph advanced at 80 ms (`SPINNER_GLYPH_ADVANCE_MS`). The 30 fps cadence emitted ~2.4 paints per visible glyph step; the differential-output dedup only skips the write, not the compose walk.

## Fix

- **event-controller.ts:** Removed the blanket pre-render. Every handler that mutates visible state already calls `requestRender()`; handlers that don't (`turn_start`/`turn_end` vocalizer-only paths) do not need one. `statusLine.invalidate()` is redundant because the git watcher (`#setupGitWatcher`) invalidates on real branch changes and every explicit state-changing caller invalidates itself.
- **shimmer.ts:** Rewrote `shimmerSegments` to keep `seg.text` verbatim and walk UTF-16 units in place, tracking the current tier run as `[runStart, runEnd)` and emitting a single `text.slice(runStart, runEnd)` per contiguous same-tier run. Surrogate pairs stay atomic and the code-point index still advances by 1 per emoji, so the band position is unchanged. Added `countCodePoints` for the total-code-points pre-scan.
- **markdown.ts:** Added `if (text === this.#text) return false` at the top of `setText`, mirroring `Text.setText`. Return type widened from `void` to `boolean`; callers that currently discard the return value are unaffected. The existing caller at `assistant-message.ts:648` already gates with its own `lastText` comparison.
- **tool-execution.ts:** Aligned `SPINNER_RENDER_INTERVAL_MS` to 80 ms so the render tick matches the glyph tick.
- **Regression tests:** `Markdown.setText` equality (asserts render-reference stability + return-value semantics), shimmer surrogate-pair correctness after the loop refactor (`"a😀b"` and `"🎉🌟✨🚀"`).
- **Test updates:** Two IRC-expiry tests in `event-controller-message-start.test.ts` that explicitly asserted the pre-render's second `requestRender` now expect one.

Explicitly not in scope (called out on the issue as separate PRs):

- Freezing streaming prefix on single `\n` boundaries — CommonMark loose-list continuation makes single-newline freezing correctness-unsafe.
- Compose-phase idle gate + adaptive-backpressure moving-average ceiling — need a component-level dirty flag and a considered replacement for the 200 ms cap in `#scheduleRender` (which #4145 set as a tail-latency guard).

## Verification

- `bun test packages/tui/test/markdown.test.ts` — 112 pass (includes the new equality-guard test).
- `bun test packages/coding-agent/test/modes/theme/shimmer.test.ts` — 3 pass (includes the two new surrogate-pair tests).
- `bun test packages/coding-agent/test/modes/` — 464 pass, 0 fail.
- `bun test packages/coding-agent/test/modes/controllers/event-controller-message-start.test.ts` — 9 pass (the two updated IRC-expiry assertions match the new call count).
- Microbench on the shimmer inner loop over 30 000 frames: `Array.from` variant 45 ms → in-place variant 18 ms, 2.53× speedup, allocations reduced from ~N per frame to a handful per frame.
- `bun test packages/tui/test` full run: three pre-existing failures on the default branch (`emergency-restore-altscreen.test.ts`, `input.test.ts` — `nativeSetHangulCompatJamoWidthOverride is not a function`, a missing native binding unrelated to this diff, confirmed by `git stash` + re-run on `main`).

Fixes #4353