### PR TITLE
fix(plan): queue approved plan after compact busy

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed approved plan execution after context compaction racing with queued turns ([#4358](https://github.com/can1357/oh-my-pi/issues/4358)).
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
 	type Agent,
+	AgentBusyError,
 	type AgentMessage,
 	type AgentToolResult,
 	EventLoopKeepalive,
@@ -2672,16 +2673,26 @@ export class InteractiveMode implements InteractiveModeContext {
 			planFilePath: options.planFilePath,
 			contextPreserved: options.preserveContext === true,
 		});
-		// The executor's first turn must start on an idle session. The agent may still
-		// be streaming the post-`resolve` continuation (Agent.#emit is fire-and-forget)
-		// or a turn kicked off by the compaction/clear above; prompt() would then throw
-		// AgentBusyError ("Failed to finalize approved plan"). Abort the now-irrelevant
-		// in-flight turn first — abort() bumps the prompt generation and cancels pending
-		// continuations, so nothing re-streams in the synchronous gap before prompt().
+		// A queued compaction message may have started a turn while compaction was
+		// flushing. Preserve that in-flight work and append the hidden execution
+		// directive behind it; if the session becomes busy in the narrow dispatch
+		// window, catch the core guard and queue the same synthetic prompt instead.
+		await this.#dispatchApprovedPlanPrompt(planModePrompt);
+	}
+	async #dispatchApprovedPlanPrompt(planModePrompt: string): Promise<void> {
 		if (this.session.isStreaming) {
-			await this.#abortPlanApprovalTurnSilently();
+			await this.session.followUp(planModePrompt, undefined, { synthetic: true });
+			return;
 		}
-		await this.session.prompt(planModePrompt, { synthetic: true });
+
+		try {
+			await this.session.prompt(planModePrompt, { synthetic: true });
+		} catch (error) {
+			if (!(error instanceof AgentBusyError)) {
+				throw error;
+			}
+			await this.session.followUp(planModePrompt, undefined, { synthetic: true });
+		}
 	}
 	async #abortPlanApprovalTurnSilently(): Promise<void> {
 		this.session.markPlanInternalAbortPending();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -837,6 +837,15 @@ export interface PromptOptions {
 	skipCompactionCheck?: boolean;
 }
 
+export interface FollowUpOptions {
+	/** Queue as a hidden developer/system message instead of a user-attributed follow-up. */
+	synthetic?: boolean;
+	/** Whether to expand file-based prompt templates (default: true). */
+	expandPromptTemplates?: boolean;
+	/** Explicit billing/initiator attribution. Defaults to `agent` for synthetic prompts. */
+	attribution?: MessageAttribution;
+}
+
 /** Result from a handoff operation. */
 export interface HandoffResult {
 	document: string;
@@ -7793,13 +7802,42 @@ export class AgentSession {
 	/**
 	 * Queue a follow-up message to process after the agent would otherwise stop.
 	 */
-	async followUp(text: string, images?: ImageContent[]): Promise<void> {
+	async followUp(text: string, images?: ImageContent[], options?: FollowUpOptions): Promise<void> {
 		if (text.startsWith("/")) {
 			this.#throwIfExtensionCommand(text);
 		}
 
-		const expandedText = expandPromptTemplate(text, [...this.#promptTemplates]);
+		const expandedText =
+			options?.expandPromptTemplates === false ? text : expandPromptTemplate(text, [...this.#promptTemplates]);
+		if (options?.synthetic) {
+			await this.#queueSyntheticFollowUp(expandedText, images, options.attribution ?? "agent");
+			return;
+		}
+
 		await this.#queueUserMessage(expandedText, images, "followUp");
+	}
+
+	async #queueSyntheticFollowUp(
+		text: string,
+		images: ImageContent[] | undefined,
+		attribution: MessageAttribution,
+	): Promise<void> {
+		const normalizedImages = await this.#normalizeImagesForModel(images);
+		const content: (TextContent | ImageContent)[] = [{ type: "text", text }];
+		if (normalizedImages?.length) {
+			content.push(...normalizedImages);
+		}
+		const imageDescriptionNotice = normalizedImages?.length
+			? await this.#buildImageDescriptionNotice(normalizedImages)
+			: undefined;
+		if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);
+		this.agent.followUp({
+			role: "developer",
+			content,
+			attribution,
+			timestamp: Date.now(),
+		});
+		this.#scheduleIdleQueueDrain();
 	}
 
 	async #queueUserMessage(

--- a/packages/coding-agent/test/interactive-mode-plan-approve-compact-busy.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-approve-compact-busy.test.ts
@@ -1,0 +1,213 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, AgentBusyError } from "@oh-my-pi/pi-agent-core";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { setKeybindings } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function isPlanApprovedPrompt(text: string): boolean {
+	return text.includes("Plan approved.") && text.includes("You MUST read");
+}
+
+describe("InteractiveMode plan approve compact busy", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	let sharedTempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeAll(async () => {
+		initTheme();
+		resetSettingsForTest();
+		sharedTempDir = TempDir.createSync("@pi-plan-review-shared-");
+		await Settings.init({ inMemory: true, cwd: sharedTempDir.path() });
+		authStorage = await AuthStorage.create(path.join(sharedTempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage?.close();
+		sharedTempDir?.removeSync();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-plan-review-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		}
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		const currentMode = mode;
+		const currentSession = session;
+		const currentTempDir = tempDir;
+		mode = undefined as unknown as InteractiveMode;
+		session = undefined as unknown as AgentSession;
+		tempDir = undefined as unknown as TempDir;
+		currentMode?.stop();
+		await currentSession?.dispose();
+		currentTempDir?.removeSync();
+		setKeybindings(KeybindingsManager.inMemory());
+		resetSettingsForTest();
+	});
+
+	it("avoids AgentBusyError during plan approval with compaction when user message is queued", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		let streaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => streaming,
+		});
+
+		const abortSpy = vi.spyOn(session, "abort").mockImplementation(async () => {
+			// Do NOT clear streaming, simulating the race where isStreaming remains/becomes true
+		});
+
+		const calls: {
+			type: "prompt" | "followUp";
+			text: string;
+			options?: { streamingBehavior?: string; synthetic?: boolean };
+		}[] = [];
+
+		vi.spyOn(session, "prompt").mockImplementation(async (text, opts) => {
+			calls.push({ type: "prompt", text, options: opts });
+			if (text === "queued message") {
+				streaming = true;
+			}
+			if (streaming && !(opts as { streamingBehavior?: string } | undefined)?.streamingBehavior) {
+				throw new AgentBusyError();
+			}
+			return true;
+		});
+
+		vi.spyOn(session, "followUp").mockImplementation(async (text, _images, options) => {
+			calls.push({ type: "followUp", text, options });
+		});
+
+		session.sessionManager.appendMessage({ role: "user", content: "seed one", timestamp: Date.now() - 2 });
+		session.sessionManager.appendMessage({ role: "user", content: "seed two", timestamp: Date.now() - 1 });
+		vi.spyOn(session, "compact").mockImplementation(async () => {
+			mode.queueCompactionMessage("queued message", "followUp");
+			return undefined as never;
+		});
+
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => {
+			return options[1]; // Approve and compact context
+		});
+
+		const errorSpy = vi.spyOn(mode, "showError");
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to finalize approved plan"));
+
+		// Find the index of the queued message in `calls`
+		const queuedMessageIndex = calls.findIndex(c => c.text === "queued message");
+		expect(queuedMessageIndex).toBeGreaterThanOrEqual(0);
+
+		// Find the index of the plan-approved message in `calls`
+		const planApprovedIndex = calls.findIndex(c => isPlanApprovedPrompt(c.text));
+		expect(planApprovedIndex).toBeGreaterThanOrEqual(0);
+
+		// Assert that the plan-approved prompt lands AFTER the queued message as a hidden synthetic follow-up.
+		expect(planApprovedIndex).toBeGreaterThan(queuedMessageIndex);
+		expect(calls[planApprovedIndex]).toMatchObject({
+			type: "followUp",
+			options: { synthetic: true },
+		});
+
+		expect(abortSpy).toHaveBeenCalled();
+	});
+
+	it("queues approved plan as synthetic follow-up when prompt dispatch becomes busy", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => false,
+		});
+
+		vi.spyOn(session, "abort").mockResolvedValue();
+
+		const calls: {
+			type: "prompt" | "followUp";
+			text: string;
+			options?: { synthetic?: boolean };
+		}[] = [];
+
+		vi.spyOn(session, "prompt").mockImplementation(async (text, opts) => {
+			calls.push({ type: "prompt", text, options: opts });
+			throw new AgentBusyError();
+		});
+
+		vi.spyOn(session, "followUp").mockImplementation(async (text, _images, options) => {
+			calls.push({ type: "followUp", text, options });
+		});
+
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => {
+			return options[2]; // Approve and keep context
+		});
+
+		const errorSpy = vi.spyOn(mode, "showError");
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to finalize approved plan"));
+
+		const planPromptIndex = calls.findIndex(c => c.type === "prompt" && isPlanApprovedPrompt(c.text));
+		expect(planPromptIndex).toBeGreaterThanOrEqual(0);
+		expect(calls[planPromptIndex]?.options).toMatchObject({ synthetic: true });
+
+		const queuedPlanIndex = calls.findIndex(c => c.type === "followUp" && isPlanApprovedPrompt(c.text));
+		expect(queuedPlanIndex).toBeGreaterThan(planPromptIndex);
+		expect(calls[queuedPlanIndex]).toMatchObject({
+			type: "followUp",
+			options: { synthetic: true },
+		});
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -622,7 +622,7 @@ describe("InteractiveMode plan review rendering", () => {
 		});
 	});
 
-	it("aborts an in-flight turn before dispatching the approved plan instead of surfacing AgentBusyError", async () => {
+	it("queues the approved plan behind an in-flight turn instead of surfacing AgentBusyError", async () => {
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
 			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
@@ -638,9 +638,6 @@ describe("InteractiveMode plan review rendering", () => {
 			get: () => streaming,
 		});
 		const abortSpy = vi.spyOn(session, "abort").mockImplementation(async () => {
-			// Clear the streaming flag only after an awaited tick, so the test fails
-			// if #approvePlan dispatches the prompt without awaiting abort() — the
-			// real abort() resolves only once the agent loop is idle.
 			await Promise.resolve();
 			streaming = false;
 		});
@@ -649,6 +646,7 @@ describe("InteractiveMode plan review rendering", () => {
 				throw new AgentBusyError();
 			return true;
 		});
+		const followUpSpy = vi.spyOn(session, "followUp").mockResolvedValue();
 		// Simulate a re-stream landing during the overlay, then pick keep-context
 		// (options[2]) — that branch skips clear/compact so `this.session` stays the
 		// instance the spies are on.
@@ -661,8 +659,11 @@ describe("InteractiveMode plan review rendering", () => {
 		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
 
 		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to finalize approved plan"));
-		expect(promptSpy).toHaveBeenCalledTimes(1);
-		expect(isPlanApprovedCall(promptSpy.mock.calls[0] as unknown[])).toBe(true);
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(followUpSpy).toHaveBeenCalledTimes(1);
+		const [text, _images, options] = followUpSpy.mock.calls[0] as unknown[];
+		expect(isPlanApprovedCall([text, options])).toBe(true);
+		expect(options).toMatchObject({ synthetic: true });
 		expect(abortSpy).toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## What
Routes the synthetic approved-plan prompt through the busy-aware follow-up path when compaction flushes queued turns first.

## Verification
Verified after rebasing onto current upstream/main: `bun check`; coding-agent targeted tests (147 pass); `cargo clippy --workspace --all-targets` (1 pre-existing warning); `cargo test --workspace` (1176 pass); robomp targeted tests (165 pass); scoped ruff checks for changed Python files.

Closes #4358
