### PR TITLE
fix(session): keep plan compact guidance out of hook instructions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan-mode context compaction leaking internal guidance into extension hook custom instructions ([#4359](https://github.com/can1357/oh-my-pi/issues/4359)).
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -289,6 +289,12 @@ export interface CompactOptions {
 	onComplete?: (result: CompactionResult) => void;
 	onError?: (error: Error) => void;
 	/**
+	 * Host-only guidance for the built-in LLM summarizer. Unlike
+	 * `customInstructions`, this is not user focus text and is not forwarded to
+	 * `session_before_compact` handlers.
+	 */
+	internalInstructions?: string;
+	/**
 	 * Force a one-off compaction mode for this invocation, overriding the
 	 * configured `compaction.strategy` / `remoteEnabled` (the `/compact`
 	 * subcommands: `soft` | `remote` | `snapcompact`). Omitted = configured behavior.

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1121,7 +1121,7 @@ export class CommandController {
 	}
 
 	async handleCompactCommand(
-		customInstructions?: string,
+		customInstructionsOrOptions?: string | CompactOptions,
 		mode?: CompactMode,
 		beforeFlush?: (outcome: CompactionOutcome) => void | Promise<void>,
 	): Promise<CompactionOutcome> {
@@ -1133,7 +1133,7 @@ export class CommandController {
 			return "ok";
 		}
 
-		return this.executeCompaction(customInstructions, false, beforeFlush, mode);
+		return this.executeCompaction(customInstructionsOrOptions, false, beforeFlush, mode);
 	}
 
 	/**

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2606,7 +2606,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				// the try/finally is idempotent and kept for the !compactBeforeExecute
 				// branch.
 				this.session.setPlanReferencePath(options.planFilePath);
-				compactOutcome = await this.handleCompactCommand(compactionPrompt, undefined, outcome =>
+				compactOutcome = await this.handleCompactCommand({ internalInstructions: compactionPrompt }, undefined, outcome =>
 					this.#applyDeferredPlanModelTransition(outcome, options.executionModel),
 				);
 			}
@@ -3897,11 +3897,11 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	handleCompactCommand(
-		customInstructions?: string,
+		customInstructionsOrOptions?: string | CompactOptions,
 		mode?: CompactMode,
 		beforeFlush?: (outcome: CompactionOutcome) => void | Promise<void>,
 	): Promise<CompactionOutcome> {
-		return this.#commandController.handleCompactCommand(customInstructions, mode, beforeFlush);
+		return this.#commandController.handleCompactCommand(customInstructionsOrOptions, mode, beforeFlush);
 	}
 
 	handleHandoffCommand(customInstructions?: string): Promise<void> {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2606,9 +2606,11 @@ export class InteractiveMode implements InteractiveModeContext {
 				// the try/finally is idempotent and kept for the !compactBeforeExecute
 				// branch.
 				this.session.setPlanReferencePath(options.planFilePath);
+				// Force context-full (`"soft"`) so a snapcompact default can't archive
+				// the transcript to images and silently drop the plan-compact guidance.
 				compactOutcome = await this.handleCompactCommand(
 					{ internalInstructions: compactionPrompt },
-					undefined,
+					"soft",
 					outcome => this.#applyDeferredPlanModelTransition(outcome, options.executionModel),
 				);
 			}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2606,8 +2606,10 @@ export class InteractiveMode implements InteractiveModeContext {
 				// the try/finally is idempotent and kept for the !compactBeforeExecute
 				// branch.
 				this.session.setPlanReferencePath(options.planFilePath);
-				compactOutcome = await this.handleCompactCommand({ internalInstructions: compactionPrompt }, undefined, outcome =>
-					this.#applyDeferredPlanModelTransition(outcome, options.executionModel),
+				compactOutcome = await this.handleCompactCommand(
+					{ internalInstructions: compactionPrompt },
+					undefined,
+					outcome => this.#applyDeferredPlanModelTransition(outcome, options.executionModel),
 				);
 			}
 		} finally {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9499,12 +9499,15 @@ export class AgentSession {
 
 			const compactionPrep = await this.#prepareCompactionFromHooks(preparation, hookCompaction);
 
-			// Strategy honored on manual /compact too. Custom/internal instructions imply a
-			// directed LLM summary; a text-only model cannot read snapcompact frames.
+			// Strategy honored on manual /compact too. User focus instructions
+			// (customInstructions) imply a directed LLM summary; a text-only model
+			// cannot read snapcompact frames. Host-only `internalInstructions` is
+			// guidance for the compaction engine, not user focus text, and must NOT
+			// downgrade an explicit `mode: "snapcompact"` to an LLM summary.
 			// When snapcompact itself was requested, fail locally instead of silently
 			// converting the "no LLM call" path into a provider-backed summary.
 			const wantsSnapcompact =
-				compactionPrep.kind !== "fromHook" && effectiveSettings.strategy === "snapcompact" && !summaryInstructions;
+				compactionPrep.kind !== "fromHook" && effectiveSettings.strategy === "snapcompact" && !customInstructions;
 			const snapcompactReady = wantsSnapcompact;
 			const snapcompactShapeSetting = this.settings.get("snapcompact.shape");
 			let snapcompactShape: snapcompact.Shape | undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9404,8 +9404,8 @@ export class AgentSession {
 	/**
 	 * Manually compact the session context.
 	 * Aborts current agent operation first.
-	 * @param customInstructions Optional instructions for the compaction summary
-	 * @param options Optional callbacks for completion/error handling
+	 * @param customInstructions Optional user focus instructions for the compaction summary
+	 * @param options Optional callbacks and host-only compaction options
 	 */
 	async compact(customInstructions?: string, options?: CompactOptions): Promise<CompactionResult> {
 		if (this.#compactionAbortController) {
@@ -9422,6 +9422,7 @@ export class AgentSession {
 		}
 		const compactionAbortController = new AbortController();
 		this.#compactionAbortController = compactionAbortController;
+		const summaryInstructions = [customInstructions, options?.internalInstructions].filter(Boolean).join("\n\n");
 
 		try {
 			this.#disconnectFromAgent();
@@ -9498,12 +9499,12 @@ export class AgentSession {
 
 			const compactionPrep = await this.#prepareCompactionFromHooks(preparation, hookCompaction);
 
-			// Strategy honored on manual /compact too. Custom instructions imply a
+			// Strategy honored on manual /compact too. Custom/internal instructions imply a
 			// directed LLM summary; a text-only model cannot read snapcompact frames.
 			// When snapcompact itself was requested, fail locally instead of silently
 			// converting the "no LLM call" path into a provider-backed summary.
 			const wantsSnapcompact =
-				compactionPrep.kind !== "fromHook" && effectiveSettings.strategy === "snapcompact" && !customInstructions;
+				compactionPrep.kind !== "fromHook" && effectiveSettings.strategy === "snapcompact" && !summaryInstructions;
 			const snapcompactReady = wantsSnapcompact;
 			const snapcompactShapeSetting = this.settings.get("snapcompact.shape");
 			let snapcompactShape: snapcompact.Shape | undefined;
@@ -9636,7 +9637,7 @@ export class AgentSession {
 				try {
 					const result = await this.#compactWithFallbackModel(
 						preparation,
-						customInstructions,
+						summaryInstructions || undefined,
 						compactionAbortController.signal,
 						{
 							promptOverride: this.#obfuscateTextForProvider(compactionPrep.hookPrompt),

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -279,4 +279,33 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 
 		expect(compactSpy.mock.calls[0]?.[1]?.maxFrames).toBe(snapcompact.maxFramesForDataBudget());
 	});
+
+	it("runs snapcompact even when internalInstructions are present (no LLM downgrade)", async () => {
+		// Regression for PR #4368 second-pass review: an explicit
+		// `mode: "snapcompact"` must not fall through to LLM compaction when
+		// `internalInstructions` (host-only guidance, not user focus text) is
+		// supplied. Previously the snapcompact gate checked `!summaryInstructions`
+		// which merged `internalInstructions`, silently downgrading the request.
+		const branchEntries = sessionManager.getBranch();
+		const lastEntry = branchEntries[branchEntries.length - 1];
+		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
+
+		const compactSpy = vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "stubbed snapcompact",
+			shortSummary: "stub",
+			firstKeptEntryId: lastEntry.id,
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				snapcompact: { frames: [], totalChars: 0, truncatedChars: 0 },
+			},
+		});
+
+		await session.compact(undefined, {
+			mode: "snapcompact",
+			internalInstructions: "plan-mode compaction guidance",
+		});
+
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1203,11 +1203,17 @@ describe("InteractiveMode plan review rendering", () => {
 			title: "PLAN",
 		});
 
-		// Compaction was run with the rendered planning-specific custom instruction.
+		// Plan-mode guidance is host-only: it must reach the native compactor through
+		// CompactOptions.internalInstructions, not as user focus text.
 		expect(compactSpy).toHaveBeenCalledTimes(1);
-		const [compactInstruction] = compactSpy.mock.calls[0]!;
-		expect(typeof compactInstruction).toBe("string");
-		expect(compactInstruction as string).toContain(planFilePath);
+		const compactCall = compactSpy.mock.calls[0];
+		expect(compactCall).toBeDefined();
+		if (!compactCall) throw new Error("Expected compact call");
+		const [compactOptions] = compactCall;
+		expect(typeof compactOptions).toBe("object");
+		expect(compactOptions).toMatchObject({
+			internalInstructions: expect.stringContaining(planFilePath),
+		});
 
 		// Plan-approved synthetic prompt was dispatched.
 		const planApprovedIdx = promptSpy.mock.calls.findIndex(isPlanApprovedCall);

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1209,11 +1209,15 @@ describe("InteractiveMode plan review rendering", () => {
 		const compactCall = compactSpy.mock.calls[0];
 		expect(compactCall).toBeDefined();
 		if (!compactCall) throw new Error("Expected compact call");
-		const [compactOptions] = compactCall;
+		const [compactOptions, compactMode] = compactCall;
 		expect(typeof compactOptions).toBe("object");
 		expect(compactOptions).toMatchObject({
 			internalInstructions: expect.stringContaining(planFilePath),
 		});
+		// Force plan-guided compaction off snapcompact: the plan-approval path
+		// must pass `"soft"` so a snapcompact default can't archive the transcript
+		// to images and silently drop the internalInstructions summary guidance.
+		expect(compactMode).toBe("soft");
 
 		// Plan-approved synthetic prompt was dispatched.
 		const planApprovedIdx = promptSpy.mock.calls.findIndex(isPlanApprovedCall);


### PR DESCRIPTION
## What
Separates internal plan compaction guidance from public hook custom instructions so extensions do not treat plan boilerplate as user focus.

## Verification
Verified after rebasing onto current upstream/main: `bun check`; coding-agent targeted tests (147 pass); `cargo clippy --workspace --all-targets` (1 pre-existing warning); `cargo test --workspace` (1176 pass); robomp targeted tests (165 pass); scoped ruff checks for changed Python files.

Closes #4359
