### PR TITLE
feat(plan): add approve-and-shake context option

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an Approve and shake context plan-approval option ([#4360](https://github.com/can1357/oh-my-pi/issues/4360)).
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1147,12 +1147,12 @@ export class CommandController {
 	 * surface a warning and let the operator stop the turn explicitly instead of
 	 * silently aborting their work.
 	 */
-	async handleShakeCommand(mode: ShakeMode): Promise<void> {
+	async handleShakeCommand(mode: ShakeMode): Promise<boolean> {
 		if (this.ctx.session.isStreaming) {
 			this.ctx.showWarning(
 				"Shake is not available while a turn is streaming. Press Esc to stop the current turn first.",
 			);
-			return;
+			return false;
 		}
 
 		let result: ShakeResult;
@@ -1160,18 +1160,19 @@ export class CommandController {
 			result = await this.ctx.session.shake(mode);
 		} catch (error) {
 			this.ctx.showError(`Shake failed: ${error instanceof Error ? error.message : String(error)}`);
-			return;
+			return false;
 		}
 
 		const dropped = result.toolResultsDropped + result.blocksDropped + (result.imagesDropped ?? 0);
 		if (dropped === 0) {
 			this.ctx.showStatus("Nothing to shake.");
-			return;
+			return true;
 		}
 		this.ctx.rebuildChatFromMessages();
 		this.ctx.statusLine.invalidate();
 		this.ctx.ui.requestRender();
 		this.ctx.showStatus(formatShakeSummary(result));
+		return true;
 	}
 
 	async executeCompaction(

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1139,8 +1139,22 @@ export class CommandController {
 	/**
 	 * TUI handler for `/shake`. `elide` drops heavy structural content and
 	 * `images` strips image blocks. Rebuilds the chat and reports counts.
+	 *
+	 * Refuses to shake while a turn is streaming: `AgentSession.shake()` rewrites
+	 * persisted entries and calls `agent.replaceMessages()`, which races the
+	 * active loop's in-flight message appends and can corrupt or drop history.
+	 * `compact()` aborts first; shake is lighter-weight and user-initiated, so we
+	 * surface a warning and let the operator stop the turn explicitly instead of
+	 * silently aborting their work.
 	 */
 	async handleShakeCommand(mode: ShakeMode): Promise<void> {
+		if (this.ctx.session.isStreaming) {
+			this.ctx.showWarning(
+				"Shake is not available while a turn is streaming. Press Esc to stop the current turn first.",
+			);
+			return;
+		}
+
 		let result: ShakeResult;
 		try {
 			result = await this.ctx.session.shake(mode);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2612,6 +2612,10 @@ export class InteractiveMode implements InteractiveModeContext {
 					this.#applyDeferredPlanModelTransition(outcome, options.executionModel),
 				);
 			} else if (options.mode === "shake") {
+				// Pin the plan reference path BEFORE shake so plan-read protection
+				// covers the approved `local://...` path during the elision pass.
+				// Reassignment after the try/finally is idempotent.
+				this.session.setPlanReferencePath(options.planFilePath);
 				await this.handleShakeCommand("elide");
 			}
 		} finally {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -282,7 +282,6 @@ function formatHudNoteMarker(count: number): string {
 type GoalSubcommand = "set" | "show" | "pause" | "resume" | "drop" | "budget";
 type PlanApprovalMode = "execute" | "compact" | "shake" | "keep";
 
-
 const GOAL_SUBCOMMANDS = new Set<GoalSubcommand>(["set", "show", "pause", "resume", "drop", "budget"]);
 const PLAN_KEEP_CONTEXT_OPTION_INDEX = 3;
 const PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT = 95;
@@ -3129,7 +3128,13 @@ export class InteractiveMode implements InteractiveModeContext {
 		const choice = await this.showPlanReview(
 			planContent,
 			"Plan mode - next step",
-			["Approve and execute", "Approve and compact context", "Approve and shake context", keepContextLabel, "Refine plan"],
+			[
+				"Approve and execute",
+				"Approve and compact context",
+				"Approve and shake context",
+				keepContextLabel,
+				"Refine plan",
+			],
 			{
 				helpText,
 				onExternalEditor: () => void this.#openPlanInExternalEditor(planFilePath),

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2616,6 +2616,11 @@ export class InteractiveMode implements InteractiveModeContext {
 				// covers the approved `local://...` path during the elision pass.
 				// Reassignment after the try/finally is idempotent.
 				this.session.setPlanReferencePath(options.planFilePath);
+				// A queued steer/followUp/IRC aside can start a fresh streaming turn
+				// while the approval overlay was open; abort it so the shake actually
+				// runs. Otherwise handleShakeCommand swallows the refusal and dispatch
+				// proceeds unshaken (PR #4369).
+				await this.#abortPlanApprovalTurnSilently();
 				await this.handleShakeCommand("elide");
 			}
 		} finally {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2574,6 +2574,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.session.markPlanInternalAbortPending();
 		}
 		let compactOutcome: CompactionOutcome | undefined;
+		let shakeOk = true;
 		try {
 			await this.#exitPlanMode({
 				silent: true,
@@ -2618,10 +2619,14 @@ export class InteractiveMode implements InteractiveModeContext {
 				this.session.setPlanReferencePath(options.planFilePath);
 				// A queued steer/followUp/IRC aside can start a fresh streaming turn
 				// while the approval overlay was open; abort it so the shake actually
-				// runs. Otherwise handleShakeCommand swallows the refusal and dispatch
-				// proceeds unshaken (PR #4369).
-				await this.#abortPlanApprovalTurnSilently();
-				await this.handleShakeCommand("elide");
+				// runs. Otherwise handleShakeCommand refuses (streaming guard) and
+				// returns false, so dispatch would proceed unshaken (PR #4369).
+				// Gate on isStreaming: a broad abort when the session is idle would
+				// kill unrelated idle tool work (PR #4369 review).
+				if (this.session.isStreaming) {
+					await this.#abortPlanApprovalTurnSilently();
+				}
+				shakeOk = await this.handleShakeCommand("elide");
 			}
 		} finally {
 			// Unconditional clear. Idempotent: a no-op when the flag was never set
@@ -2661,6 +2666,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning(
 				"Plan approved, but compaction was cancelled — execution not dispatched. Submit a turn to continue.",
 			);
+			return;
+		}
+
+		if (options.mode === "shake" && !shakeOk) {
+			// Shake refused (streaming guard) or failed (session.shake threw).
+			// `handleShakeCommand` already surfaced the warning/error; we add the
+			// deferred-dispatch warning and exit without dispatching the synthetic
+			// plan-approved prompt. `markPlanReferenceSent` stays unset so
+			// `AgentSession.#buildPlanReferenceMessage` injects the plan reference
+			// on the operator's next `prompt()` call (PR #4369 review).
+			this.showWarning("Plan approved, but shake failed — execution not dispatched. Submit a turn to continue.");
 			return;
 		}
 
@@ -3939,7 +3955,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleHandoffCommand(customInstructions);
 	}
 
-	handleShakeCommand(mode: ShakeMode): Promise<void> {
+	handleShakeCommand(mode: ShakeMode): Promise<boolean> {
 		return this.#commandController.handleShakeCommand(mode);
 	}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -280,9 +280,11 @@ function formatHudNoteMarker(count: number): string {
 }
 
 type GoalSubcommand = "set" | "show" | "pause" | "resume" | "drop" | "budget";
+type PlanApprovalMode = "execute" | "compact" | "shake" | "keep";
+
 
 const GOAL_SUBCOMMANDS = new Set<GoalSubcommand>(["set", "show", "pause", "resume", "drop", "budget"]);
-const PLAN_KEEP_CONTEXT_OPTION_INDEX = 2;
+const PLAN_KEEP_CONTEXT_OPTION_INDEX = 3;
 const PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT = 95;
 
 function parseGoalSubcommand(args: string): { sub: GoalSubcommand | undefined; rest: string } {
@@ -2555,8 +2557,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		options: {
 			planFilePath: string;
 			title: string;
-			preserveContext?: boolean;
-			compactBeforeExecute?: boolean;
+			mode: PlanApprovalMode;
 			executionModel?: ResolvedRoleModel;
 		},
 	): Promise<void> {
@@ -2568,7 +2569,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		// throw) so a leaked flag cannot silence a later unrelated abort.
 		// Branchless mark+clear when !compactBeforeExecute: mark is gated; clear
 		// is unconditional and idempotent.
-		if (options.compactBeforeExecute) {
+		const compactBeforeExecute = options.mode === "compact";
+		const preserveContext = options.mode !== "execute";
+		if (compactBeforeExecute) {
 			this.session.markPlanInternalAbortPending();
 		}
 		let compactOutcome: CompactionOutcome | undefined;
@@ -2576,10 +2579,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.#exitPlanMode({
 				silent: true,
 				paused: false,
-				deferModelRestore: options.compactBeforeExecute === true,
+				deferModelRestore: compactBeforeExecute,
 			});
 
-			if (!options.preserveContext) {
+			if (!preserveContext) {
 				await this.handleClearCommand();
 				// The new session has a fresh local:// root — persist the approved plan there
 				// so `local://<slug>-plan.md` resolves correctly in the execution session.
@@ -2588,7 +2591,7 @@ export class InteractiveMode implements InteractiveModeContext {
 					getSessionId: () => this.sessionManager.getSessionId(),
 				});
 				await Bun.write(newLocalPath, planContent);
-			} else if (options.compactBeforeExecute) {
+			} else if (options.mode === "compact") {
 				// Distill the plan-mode transcript before the execution turn is queued so
 				// the plan-approved synthetic prompt lands as a fresh cache anchor.
 				// Outcome is consumed after tool-restoration and plan-reference-path
@@ -2609,6 +2612,8 @@ export class InteractiveMode implements InteractiveModeContext {
 				compactOutcome = await this.handleCompactCommand(compactionPrompt, undefined, outcome =>
 					this.#applyDeferredPlanModelTransition(outcome, options.executionModel),
 				);
+			} else if (options.mode === "shake") {
+				await this.handleShakeCommand("elide");
 			}
 		} finally {
 			// Unconditional clear. Idempotent: a no-op when the flag was never set
@@ -2632,7 +2637,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// aborted only the compaction, not the approval — so the next turn no longer
 		// lands on the plan model. "failed" stays on the plan model (context
 		// intact) and dispatches best-effort.
-		if (options.compactBeforeExecute) {
+		if (compactBeforeExecute) {
 			await this.#applyDeferredPlanModelTransition(compactOutcome, options.executionModel);
 		} else {
 			await this.#applyPlanExecutionModel(options.executionModel);
@@ -2670,7 +2675,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.session.markPlanReferenceSent();
 		const planModePrompt = prompt.render(planModeApprovedPrompt, {
 			planFilePath: options.planFilePath,
-			contextPreserved: options.preserveContext === true,
+			contextPreserved: preserveContext,
 		});
 		// The executor's first turn must start on an idle session. The agent may still
 		// be streaming the post-`resolve` continuation (Agent.#emit is fire-and-forget)
@@ -3124,7 +3129,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const choice = await this.showPlanReview(
 			planContent,
 			"Plan mode - next step",
-			["Approve and execute", "Approve and compact context", keepContextLabel, "Refine plan"],
+			["Approve and execute", "Approve and compact context", "Approve and shake context", keepContextLabel, "Refine plan"],
 			{
 				helpText,
 				onExternalEditor: () => void this.#openPlanInExternalEditor(planFilePath),
@@ -3140,7 +3145,12 @@ export class InteractiveMode implements InteractiveModeContext {
 			{ slider },
 		);
 
-		if (choice === "Approve and execute" || choice === "Approve and compact context" || choice === keepContextLabel) {
+		if (
+			choice === "Approve and execute" ||
+			choice === "Approve and compact context" ||
+			choice === "Approve and shake context" ||
+			choice === keepContextLabel
+		) {
 			try {
 				// Prefer in-overlay edits (already in memory) over a disk re-read. The
 				// overlay mirrors edits as they happen, and approval awaits one final
@@ -3181,11 +3191,18 @@ export class InteractiveMode implements InteractiveModeContext {
 						: -1;
 				const executionModel =
 					slider && cycle && selectedTierIndex !== restoredIndex ? cycle.models[selectedTierIndex] : undefined;
+				const mode: PlanApprovalMode =
+					choice === "Approve and execute"
+						? "execute"
+						: choice === "Approve and compact context"
+							? "compact"
+							: choice === "Approve and shake context"
+								? "shake"
+								: "keep";
 				await this.#approvePlan(latestPlanContent, {
 					planFilePath,
 					title: details.title,
-					preserveContext: choice !== "Approve and execute",
-					compactBeforeExecute: choice === "Approve and compact context",
+					mode,
 					executionModel,
 				});
 			} catch (error) {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -330,7 +330,7 @@ export interface InteractiveModeContext {
 	handleSSHCommand(text: string): Promise<void>;
 	handleCompactCommand(customInstructions?: string, mode?: CompactMode): Promise<CompactionOutcome>;
 	handleHandoffCommand(customInstructions?: string): Promise<void>;
-	handleShakeCommand(mode: ShakeMode): Promise<void>;
+	handleShakeCommand(mode: ShakeMode): Promise<boolean>;
 	handleMoveCommand(targetPath?: string): Promise<void>;
 	handleRenameCommand(title: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;

--- a/packages/coding-agent/src/prompts/system/plan-mode-active.md
+++ b/packages/coding-agent/src/prompts/system/plan-mode-active.md
@@ -101,9 +101,10 @@ Cut anything that removes no decision: restated invariants, unaffected behavior,
 On approval the user picks one execution mode:
 - **Approve and execute** — execution starts in fresh context (session cleared).
 - **Approve and compact context** — distills this discussion into a summary, then executes here.
+- **Approve and shake context** — mechanically elides bulky tool outputs, then executes here.
 - **Approve and keep context** — executes here, preserving exploration history.
 
-All three rely on the file being self-contained.
+All four rely on the file being self-contained.
 </caution>
 
 <critical>

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1261,6 +1261,39 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(promptText).toContain("Context preserved.");
 	});
 
+	it("Approve and shake context: setPlanReferencePath is pinned BEFORE shake runs", async () => {
+		// Regression for PR #4369 second-pass review: approve-and-shake must set
+		// the plan reference path before calling shake so plan-read protection
+		// covers the approved `local://...` path during the elision pass.
+		const planFilePath = "local://my-task-plan.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nShake and execute.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and shake context");
+		vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		const setPlanRefSpy = vi.spyOn(session, "setPlanReferencePath");
+		let planRefSetWhenShakeRan = false;
+		vi.spyOn(mode, "handleShakeCommand").mockImplementation(async () => {
+			planRefSetWhenShakeRan = setPlanRefSpy.mock.calls.some(call => call[0] === planFilePath);
+		});
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "my-task",
+		});
+
+		// The contract: by the time handleShakeCommand runs, setPlanReferencePath
+		// has already pinned the approved (non-default) plan path, so plan-read
+		// protection covers the approved `local://my-task-plan.md` during elision.
+		expect(planRefSetWhenShakeRan).toBe(true);
+	});
 	it("Approve and compact context: cancelled outcome skips plan-approved dispatch", async () => {
 		// Mock `handleCompactCommand` to surface the "cancelled" outcome directly.
 		// (Testing the consumer — `#approvePlan`'s outcome handling — at the

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1630,4 +1630,39 @@ describe("InteractiveMode plan review rendering", () => {
 			expect(warn).toHaveBeenCalledWith(expect.stringContaining("No plan to review"));
 		});
 	});
+
+	describe("handleShakeCommand streaming guard", () => {
+		it("refuses to shake while a turn is streaming and does not call session.shake", async () => {
+			Object.defineProperty(session, "isStreaming", {
+				configurable: true,
+				get: () => true,
+			});
+			const shakeSpy = vi.spyOn(session, "shake").mockResolvedValue({
+				mode: "elide",
+				toolResultsDropped: 0,
+				blocksDropped: 0,
+				tokensFreed: 0,
+			});
+			const warnSpy = vi.spyOn(mode, "showWarning");
+
+			await mode.handleShakeCommand("elide");
+
+			expect(shakeSpy).not.toHaveBeenCalled();
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("not available while a turn is streaming"));
+		});
+
+		it("shakes normally when the session is idle", async () => {
+			const shakeSpy = vi.spyOn(session, "shake").mockResolvedValue({
+				mode: "elide",
+				toolResultsDropped: 2,
+				blocksDropped: 1,
+				tokensFreed: 500,
+			});
+			vi.spyOn(mode, "rebuildChatFromMessages").mockImplementation(() => {});
+
+			await mode.handleShakeCommand("elide");
+
+			expect(shakeSpy).toHaveBeenCalledWith("elide");
+		});
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -430,6 +430,7 @@ describe("InteractiveMode plan review rendering", () => {
 			[
 				"Approve and execute",
 				"Approve and compact context",
+				"Approve and shake context",
 				"Approve and keep context (~7.3k / 10k)",
 				"Refine plan",
 			],
@@ -504,6 +505,7 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(selector.mock.calls[0]?.[2]).toEqual([
 			"Approve and execute",
 			"Approve and compact context",
+			"Approve and shake context",
 			`Approve and keep context (~${compactNumber(tokens)} / ${compactNumber(executionModel.contextWindow)})`,
 			"Refine plan",
 		]);
@@ -530,7 +532,7 @@ describe("InteractiveMode plan review rendering", () => {
 
 		expect(selector.mock.calls[0]?.[3]).toEqual(
 			expect.objectContaining({
-				disabledIndices: [2],
+				disabledIndices: [3],
 			}),
 		);
 	});
@@ -584,7 +586,7 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(selector).toHaveBeenCalledWith(
 			expect.any(String),
 			"Plan mode - next step",
-			["Approve and execute", "Approve and compact context", "Approve and keep context", "Refine plan"],
+			["Approve and execute", "Approve and compact context", "Approve and shake context", "Approve and keep context", "Refine plan"],
 			expect.any(Object),
 			expect.any(Object),
 		);
@@ -1217,6 +1219,40 @@ describe("InteractiveMode plan review rendering", () => {
 		// turn doesn't double-inject the plan reference (it was just dispatched
 		// inside the synthetic prompt).
 		expect(markSentSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("Approve and shake context: shakes before dispatching the approved plan", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nShake and execute.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and shake context");
+		const shakeSpy = vi.spyOn(mode, "handleShakeCommand").mockResolvedValue();
+		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+		});
+
+		expect(shakeSpy).toHaveBeenCalledWith("elide");
+		const planApprovedIdx = promptSpy.mock.calls.findIndex(isPlanApprovedCall);
+		expect(planApprovedIdx).toBeGreaterThanOrEqual(0);
+		const shakeOrder = shakeSpy.mock.invocationCallOrder[0];
+		const promptOrder = promptSpy.mock.invocationCallOrder[planApprovedIdx];
+		expect(shakeOrder).toBeDefined();
+		expect(promptOrder).toBeDefined();
+		if (shakeOrder === undefined || promptOrder === undefined) throw new Error("Expected shake and prompt calls");
+		expect(shakeOrder).toBeLessThan(promptOrder);
+		const promptText = promptSpy.mock.calls[planApprovedIdx]?.[0];
+		if (typeof promptText !== "string") throw new Error("Expected plan-approved prompt text");
+		expect(promptText).toContain("Context preserved.");
 	});
 
 	it("Approve and compact context: cancelled outcome skips plan-approved dispatch", async () => {

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -586,7 +586,13 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(selector).toHaveBeenCalledWith(
 			expect.any(String),
 			"Plan mode - next step",
-			["Approve and execute", "Approve and compact context", "Approve and shake context", "Approve and keep context", "Refine plan"],
+			[
+				"Approve and execute",
+				"Approve and compact context",
+				"Approve and shake context",
+				"Approve and keep context",
+				"Refine plan",
+			],
 			expect.any(Object),
 			expect.any(Object),
 		);

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1294,6 +1294,69 @@ describe("InteractiveMode plan review rendering", () => {
 		// protection covers the approved `local://my-task-plan.md` during elision.
 		expect(planRefSetWhenShakeRan).toBe(true);
 	});
+	it("Approve and shake context: aborts an in-flight turn before shake so it is not silently swallowed", async () => {
+		// Regression for PR #4369: a queued steer/followUp/IRC aside can start a
+		// fresh streaming turn while the approval overlay was open. Without
+		// aborting it first, handleShakeCommand refuses (streaming guard) and
+		// swallows the refusal, so dispatch proceeds unshaken. The fix calls
+		// #abortPlanApprovalTurnSilently before handleShakeCommand.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nShake and execute.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		let streaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => streaming,
+		});
+		const abortSpy = vi.spyOn(session, "abort").mockImplementation(async () => {
+			await Promise.resolve();
+			streaming = false;
+		});
+		// Simulate a re-stream landing during the overlay, then pick shake.
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async () => {
+			streaming = true;
+			return "Approve and shake context";
+		});
+		const shakeSpy = vi.spyOn(mode, "handleShakeCommand").mockResolvedValue();
+		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+		});
+
+		// The contract: abort runs BEFORE shake so the streaming guard inside
+		// handleShakeCommand does not refuse and swallow the call.
+		expect(abortSpy).toHaveBeenCalledTimes(2);
+		expect(shakeSpy).toHaveBeenCalledWith("elide");
+		// The first abort is handlePlanApproval's own pre-approval abort (line
+		// 3090, before showPlanReview); the second is the shake-branch abort
+		// added by PR #4369. The contract: the shake-branch abort (the LAST
+		// abort call) runs BEFORE shake so the streaming guard inside
+		// handleShakeCommand does not refuse and swallow the call.
+		const abortOrder = abortSpy.mock.invocationCallOrder[1];
+		const shakeOrder = shakeSpy.mock.invocationCallOrder[0];
+		expect(abortOrder).toBeDefined();
+		expect(shakeOrder).toBeDefined();
+		if (abortOrder === undefined || shakeOrder === undefined) throw new Error("Expected abort and shake calls");
+		expect(abortOrder).toBeLessThan(shakeOrder);
+		const planApprovedIdx = promptSpy.mock.calls.findIndex(isPlanApprovedCall);
+		expect(planApprovedIdx).toBeGreaterThanOrEqual(0);
+		const promptOrder = promptSpy.mock.invocationCallOrder[planApprovedIdx];
+		expect(promptOrder).toBeDefined();
+		if (promptOrder === undefined) throw new Error("Expected plan-approved prompt call");
+		expect(shakeOrder).toBeLessThan(promptOrder);
+		// Flag is cleared by the finally.
+		expect(session.isPlanInternalAbortPending).toBe(false);
+	});
 	it("Approve and compact context: cancelled outcome skips plan-approved dispatch", async () => {
 		// Mock `handleCompactCommand` to surface the "cancelled" outcome directly.
 		// (Testing the consumer — `#approvePlan`'s outcome handling — at the

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1238,7 +1238,7 @@ describe("InteractiveMode plan review rendering", () => {
 		mode.planModeEnabled = true;
 		mode.planModePlanFilePath = planFilePath;
 		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and shake context");
-		const shakeSpy = vi.spyOn(mode, "handleShakeCommand").mockResolvedValue();
+		const shakeSpy = vi.spyOn(mode, "handleShakeCommand").mockResolvedValue(true);
 		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
 
 		await mode.handlePlanApproval({
@@ -1281,6 +1281,7 @@ describe("InteractiveMode plan review rendering", () => {
 		let planRefSetWhenShakeRan = false;
 		vi.spyOn(mode, "handleShakeCommand").mockImplementation(async () => {
 			planRefSetWhenShakeRan = setPlanRefSpy.mock.calls.some(call => call[0] === planFilePath);
+			return true;
 		});
 
 		await mode.handlePlanApproval({
@@ -1324,7 +1325,7 @@ describe("InteractiveMode plan review rendering", () => {
 			streaming = true;
 			return "Approve and shake context";
 		});
-		const shakeSpy = vi.spyOn(mode, "handleShakeCommand").mockResolvedValue();
+		const shakeSpy = vi.spyOn(mode, "handleShakeCommand").mockResolvedValue(true);
 		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
 
 		await mode.handlePlanApproval({
@@ -1357,6 +1358,76 @@ describe("InteractiveMode plan review rendering", () => {
 		// Flag is cleared by the finally.
 		expect(session.isPlanInternalAbortPending).toBe(false);
 	});
+	it("Approve and shake context: shake failure skips plan-approved dispatch", async () => {
+		// PR #4369 review: if handleShakeCommand returns false (refused by the
+		// streaming guard or failed with an error), the plan-approved synthetic
+		// prompt must NOT be dispatched. Mirrors the compact "cancelled" branch:
+		// show a warning, leave markPlanReferenceSent unset, and return.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nShake and execute.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and shake context");
+		vi.spyOn(mode, "handleShakeCommand").mockResolvedValue(false);
+		const showWarningSpy = vi.spyOn(mode, "showWarning");
+		const markSentSpy = vi.spyOn(session, "markPlanReferenceSent");
+		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+		});
+
+		// Shake was attempted …
+		expect(promptSpy.mock.calls.some(isPlanApprovedCall)).toBe(false);
+		expect(markSentSpy).not.toHaveBeenCalled();
+		expect(showWarningSpy).toHaveBeenCalledWith(expect.stringContaining("shake failed"));
+	});
+
+	it("Approve and shake context: does not abort when the session is idle at shake time", async () => {
+		// PR #4369 review: the shake-branch abort is gated on isStreaming so it
+		// does not kill unrelated idle tool work. Only the pre-approval abort
+		// (handlePlanApproval's own, before showPlanReview) should fire.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nShake and execute.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		// Session is idle throughout — isStreaming stays false.
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => false,
+		});
+		const abortSpy = vi.spyOn(session, "abort").mockResolvedValue(undefined);
+		vi.spyOn(mode, "showPlanReview").mockResolvedValue("Approve and shake context");
+		const shakeSpy = vi.spyOn(mode, "handleShakeCommand").mockResolvedValue(true);
+		const promptSpy = vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+		});
+
+		// Only the pre-approval abort fires — the shake-branch abort is skipped
+		// because isStreaming is false.
+		expect(abortSpy).toHaveBeenCalledTimes(1);
+		expect(shakeSpy).toHaveBeenCalledWith("elide");
+		// Dispatch still proceeds.
+		expect(promptSpy.mock.calls.some(isPlanApprovedCall)).toBe(true);
+	});
+
 	it("Approve and compact context: cancelled outcome skips plan-approved dispatch", async () => {
 		// Mock `handleCompactCommand` to surface the "cancelled" outcome directly.
 		// (Testing the consumer — `#approvePlan`'s outcome handling — at the


### PR DESCRIPTION
## What
Adds an Approve and shake context plan-review action that reuses existing shake plumbing before approved plan execution.

## Verification
Verified after rebasing onto current upstream/main: `bun check`; coding-agent targeted tests (147 pass); `cargo clippy --workspace --all-targets` (1 pre-existing warning); `cargo test --workspace` (1176 pass); robomp targeted tests (165 pass); scoped ruff checks for changed Python files.

Closes #4360
