### PR TITLE
fix(tui): keep queued follow-up rows out of scrollback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed queued follow-up rows leaking into native scrollback during live TUI repaints ([#4362](https://github.com/can1357/oh-my-pi/issues/4362)).
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1139,8 +1139,21 @@ export class CommandController {
 	/**
 	 * TUI handler for `/shake`. `elide` drops heavy structural content and
 	 * `images` strips image blocks. Rebuilds the chat and reports counts.
+	 *
+	 * Refuses to shake while a turn is streaming: `AgentSession.shake()` rewrites
+	 * persisted entries and calls `agent.replaceMessages()`, which races the
+	 * active loop's in-flight message appends and can corrupt or drop history.
+	 * `compact()` aborts first; shake is lighter-weight and user-initiated, so we
+	 * surface a warning and let the operator stop the turn explicitly instead of
+	 * silently aborting their work.
 	 */
 	async handleShakeCommand(mode: ShakeMode): Promise<void> {
+		if (this.ctx.session.isStreaming) {
+			this.ctx.showWarning(
+				"Shake is not available while a turn is streaming. Press Esc to stop the current turn first.",
+			);
+			return;
+		}
 		let result: ShakeResult;
 		try {
 			result = await this.ctx.session.shake(mode);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2696,12 +2696,26 @@ export class InteractiveMode implements InteractiveModeContext {
 			// The abort's #drainStrandedQueuedMessages may schedule a queued-message
 			// drain that auto-resumes a turn with the stranded compaction-flush messages
 			// (steers/follow-ups delivered by flushCompactionQueue's #deliverQueuedMessage
-			// loop), racing the retry below with another AgentBusyError. Clear the queue
-			// so the drain's hasQueuedMessages() gate is false; the approved plan takes
-			// priority over messages typed during compaction. The fire-and-forget flush
-			// prompt's own .catch(restoreQueue) will still re-queue the original messages
-			// into compactionQueuedMessages for the user to re-send later.
-			this.session.clearQueue();
+			// loop), racing the retry below with another AgentBusyError. Drain the live
+			// agent queues so the drain's hasQueuedMessages() gate is false, but preserve
+			// every user-restorable message in compactionQueuedMessages for the pending
+			// queue UI and Alt+Up restore path; aborting the flush prompt resolves as an
+			// aborted assistant message rather than rejecting its fire-and-forget promise.
+			const queuedForRestore = this.session.clearQueue();
+			this.compactionQueuedMessages = [
+				...queuedForRestore.steering.map(message => ({
+					text: message.text,
+					mode: "steer" as const,
+					images: message.images,
+				})),
+				...this.compactionQueuedMessages,
+				...queuedForRestore.followUp.map(message => ({
+					text: message.text,
+					mode: "followUp" as const,
+					images: message.images,
+				})),
+			];
+			this.updatePendingMessagesDisplay();
 			await this.session.prompt(planModePrompt, { synthetic: true });
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -635,7 +635,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// unless the user opts in, and never emits raw escapes on other terminals.
 		setTerminalTextSizing(settings.get("tui.textSizing") && TERMINAL.textSizing);
 		this.chatContainer = new TranscriptContainer();
-		this.pendingMessagesContainer = new Container();
+		this.pendingMessagesContainer = new AnchoredLiveContainer();
 		this.statusContainer = new AnchoredLiveContainer();
 		this.todoContainer = new AnchoredLiveContainer();
 		this.subagentContainer = new AnchoredLiveContainer();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
 	type Agent,
+	AgentBusyError,
 	type AgentMessage,
 	type AgentToolResult,
 	EventLoopKeepalive,
@@ -2681,7 +2682,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.session.isStreaming) {
 			await this.#abortPlanApprovalTurnSilently();
 		}
-		await this.session.prompt(planModePrompt, { synthetic: true });
+		// The compact path's flushCompactionQueue dispatches the first queued user
+		// message as a fire-and-forget session.prompt() that may not have reached
+		// #beginInFlight() (and thus set isStreaming) by the time we check above.
+		// Catch the resulting AgentBusyError, abort the now-streaming flushed turn,
+		// and retry — the approved plan takes priority over a message typed during
+		// compaction, matching the isStreaming-true branch's abort semantics.
+		try {
+			await this.session.prompt(planModePrompt, { synthetic: true });
+		} catch (error) {
+			if (!(error instanceof AgentBusyError)) throw error;
+			await this.#abortPlanApprovalTurnSilently();
+			await this.session.prompt(planModePrompt, { synthetic: true });
+		}
 	}
 	async #abortPlanApprovalTurnSilently(): Promise<void> {
 		this.session.markPlanInternalAbortPending();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2693,6 +2693,15 @@ export class InteractiveMode implements InteractiveModeContext {
 		} catch (error) {
 			if (!(error instanceof AgentBusyError)) throw error;
 			await this.#abortPlanApprovalTurnSilently();
+			// The abort's #drainStrandedQueuedMessages may schedule a queued-message
+			// drain that auto-resumes a turn with the stranded compaction-flush messages
+			// (steers/follow-ups delivered by flushCompactionQueue's #deliverQueuedMessage
+			// loop), racing the retry below with another AgentBusyError. Clear the queue
+			// so the drain's hasQueuedMessages() gate is false; the approved plan takes
+			// priority over messages typed during compaction. The fire-and-forget flush
+			// prompt's own .catch(restoreQueue) will still re-queue the original messages
+			// into compactionQueuedMessages for the user to re-send later.
+			this.session.clearQueue();
 			await this.session.prompt(planModePrompt, { synthetic: true });
 		}
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9498,12 +9498,29 @@ export class AgentSession {
 
 			const compactionPrep = await this.#prepareCompactionFromHooks(preparation, hookCompaction);
 
-			// Strategy honored on manual /compact too. Custom instructions imply a
-			// directed LLM summary; a text-only model cannot read snapcompact frames.
-			// When snapcompact itself was requested, fail locally instead of silently
-			// converting the "no LLM call" path into a provider-backed summary.
-			const wantsSnapcompact =
-				compactionPrep.kind !== "fromHook" && effectiveSettings.strategy === "snapcompact" && !customInstructions;
+			// Strategy honored on manual /compact too. Snapcompact is a no-LLM
+			// archival strategy — custom instructions guide an LLM summary and are
+			// irrelevant to snapcompact, so we honor the configured strategy even
+			// when a programmatic caller (e.g. plan-approval compaction) passes
+			// instructions. The explicit `/compact snapcompact <instructions>` path
+			// is already rejected by the rejectsFocus guard above; this covers the
+			// configured-strategy case where no explicit mode was requested.
+			// A text-only model cannot read snapcompact frames — fail locally
+			// instead of silently converting the "no LLM call" path into a
+			// provider-backed summary.
+			if (
+				effectiveSettings.strategy === "snapcompact" &&
+				compactionPrep.kind !== "fromHook" &&
+				customInstructions &&
+				!compactMode
+			) {
+				this.emitNotice(
+					"warning",
+					"snapcompact strategy does not use custom compaction instructions; running no-LLM snapcompact instead.",
+					"compaction",
+				);
+			}
+			const wantsSnapcompact = compactionPrep.kind !== "fromHook" && effectiveSettings.strategy === "snapcompact";
 			const snapcompactReady = wantsSnapcompact;
 			const snapcompactShapeSetting = this.settings.get("snapcompact.shape");
 			let snapcompactShape: snapcompact.Shape | undefined;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1427,6 +1427,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		handle: async (command, runtime) => {
 			const mode = parseShakeMode(command.args);
 			if (typeof mode !== "string") return usage(mode.error, runtime);
+			// Guard mirrors handleShakeCommand's TUI check: shake() rewrites persisted
+			// entries and calls agent.replaceMessages(), which races the active loop's
+			// in-flight message appends. The ACP/RPC text-command path has no Esc to
+			// offer, so surface the busy state as a usage message instead.
+			if (runtime.session.isStreaming)
+				return usage("Shake is not available while a turn is streaming. Stop the current turn first.", runtime);
 			const result = await runtime.session.shake(mode);
 			await runtime.output(formatShakeSummary(result));
 			return commandConsumed();

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -48,6 +48,7 @@ interface FakeAcpBuiltinSession {
 	refreshSshTool(options?: { activateIfAvailable?: boolean }): Promise<void>;
 	getToolByName(name: string): unknown;
 	compact(args?: string): Promise<void>;
+	shake(mode: string): Promise<unknown>;
 	getContextUsage(): { tokens?: number; contextWindow: number } | undefined;
 	getAvailableModels(): Array<{ provider: string; id: string; contextWindow?: number }>;
 	setModel(model: unknown): Promise<void>;
@@ -149,6 +150,9 @@ function createRuntime() {
 		settings,
 		getToolByName: (_name: string) => undefined,
 		async compact(_args?: string) {},
+		async shake(_mode: string) {
+			return { mode: _mode, toolResultsDropped: 0, blocksDropped: 0, tokensFreed: 0 };
+		},
 		getContextUsage: () => undefined,
 		getAvailableModels: () => [] as Array<{ provider: string; id: string; contextWindow?: number }>,
 		async setModel(_model: unknown) {},
@@ -1134,5 +1138,62 @@ describe("wave 5 — adapters and polish", () => {
 		} finally {
 			discoverSpy.mockRestore();
 		}
+	});
+});
+
+describe("/shake ACP streaming guard", () => {
+	it("refuses to shake via ACP while a turn is streaming and does not call session.shake", async () => {
+		// Regression for PRRT_kwDOQxs0bc6OKsso: the TUI handleShakeCommand guard
+		// was missing from the ACP/RPC text-command path. shake() rewrites
+		// persisted entries and calls agent.replaceMessages(), which races the
+		// active loop's in-flight message appends.
+		const { output, runtime, session } = createRuntime();
+		session.isStreaming = true;
+		const shakeSpy = spyOn(session, "shake").mockResolvedValue({
+			mode: "elide",
+			toolResultsDropped: 0,
+			blocksDropped: 0,
+			tokensFreed: 0,
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/shake", runtime);
+
+		expect(shakeSpy).not.toHaveBeenCalled();
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("not available while a turn is streaming");
+	});
+
+	it("shakes normally via ACP when the session is idle", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.isStreaming = false;
+		const shakeSpy = spyOn(session, "shake").mockResolvedValue({
+			mode: "elide",
+			toolResultsDropped: 2,
+			blocksDropped: 1,
+			tokensFreed: 500,
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/shake elide", runtime);
+
+		expect(shakeSpy).toHaveBeenCalledWith("elide");
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("Shook");
+	});
+
+	it("refuses to shake via ACP with /shake images while streaming", async () => {
+		const { output, runtime, session } = createRuntime();
+		session.isStreaming = true;
+		const shakeSpy = spyOn(session, "shake").mockResolvedValue({
+			mode: "images",
+			toolResultsDropped: 0,
+			blocksDropped: 0,
+			tokensFreed: 0,
+		});
+
+		const result = await executeAcpBuiltinSlashCommand("/shake images", runtime);
+
+		expect(shakeSpy).not.toHaveBeenCalled();
+		expect(result).toEqual({ consumed: true });
+		expect(output[0]).toContain("not available while a turn is streaming");
 	});
 });

--- a/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-budget.test.ts
@@ -280,3 +280,141 @@ describe("AgentSession snapcompact frame-budget sizing", () => {
 		expect(compactSpy.mock.calls[0]?.[1]?.maxFrames).toBe(snapcompact.maxFramesForDataBudget());
 	});
 });
+
+describe("AgentSession snapcompact no-LLM contract with custom instructions", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-snapcompact-no-llm-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled claude-sonnet-4-5 model");
+		expect(model.input).toContain("image");
+
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+
+		// Seed enough turns for prepareCompaction to split the branch.
+		const filler = "the quick brown fox jumps over the lazy dog. ".repeat(64);
+		for (let i = 0; i < 8; i++) {
+			sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: `turn ${i}: ${filler}` }],
+				timestamp: Date.now() - (8 - i) * 1000,
+			});
+			sessionManager.appendMessage({
+				role: "assistant",
+				content: [{ type: "text", text: `reply ${i}: ${filler}` }],
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-5",
+				stopReason: "stop",
+				usage: {
+					input: 1000,
+					output: 1000,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 2000,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now() - (8 - i) * 1000 + 100,
+			});
+		}
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({
+				"compaction.strategy": "snapcompact",
+				"compaction.autoContinue": false,
+				"compaction.keepRecentTokens": 4000,
+			}),
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		try {
+			await session?.dispose();
+		} finally {
+			authStorage?.close();
+			await tempDir?.remove();
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("runs snapcompact (no LLM) even when custom instructions are provided", async () => {
+		// Regression: when compaction.strategy === "snapcompact" and a caller
+		// passes customInstructions (e.g. plan-approval compaction prompt), the
+		// old `!customInstructions` guard disabled snapcompact and fell through
+		// to #compactWithFallbackModel, silently issuing an LLM summary. The
+		// fix honors the configured no-LLM strategy regardless of instructions.
+		const branchEntries = sessionManager.getBranch();
+		const lastEntry = branchEntries[branchEntries.length - 1];
+		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
+
+		const compactSpy = vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "stubbed snapcompact",
+			shortSummary: "stub",
+			firstKeptEntryId: lastEntry.id,
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				snapcompact: { frames: [], totalChars: 0, truncatedChars: 0 },
+			},
+		});
+
+		// Pass custom instructions — the plan-approval compaction path does this.
+		const result = await session.compact("Focus on the plan's auth flow");
+
+		// Snapcompact MUST run; the LLM fallback must NOT.
+		expect(compactSpy).toHaveBeenCalledTimes(1);
+		expect(result.summary).toBe("stubbed snapcompact");
+	});
+
+	it("emits a notice when custom instructions are ignored for snapcompact strategy", async () => {
+		const branchEntries = sessionManager.getBranch();
+		const lastEntry = branchEntries[branchEntries.length - 1];
+		if (!lastEntry?.id) throw new Error("Expected branch entry with id");
+
+		vi.spyOn(snapcompact, "compact").mockResolvedValue({
+			summary: "stubbed snapcompact",
+			shortSummary: "stub",
+			firstKeptEntryId: lastEntry.id,
+			tokensBefore: 100_000,
+			details: { readFiles: [], modifiedFiles: [] },
+			preserveData: {
+				snapcompact: { frames: [], totalChars: 0, truncatedChars: 0 },
+			},
+		});
+
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "compaction") notices.push(event.message);
+		});
+
+		await session.compact("Focus on the plan's auth flow");
+
+		expect(notices).toContain(
+			"snapcompact strategy does not use custom compaction instructions; running no-LLM snapcompact instead.",
+		);
+	});
+
+	it("still rejects custom instructions for explicit /compact snapcompact mode", async () => {
+		// The rejectsFocus guard at the top of compact() must still throw for
+		// the explicit mode override — only the configured-strategy path
+		// silently ignores instructions.
+		await expect(session.compact("instructions", { mode: "snapcompact" })).rejects.toThrow(
+			"/compact snapcompact does not take focus instructions.",
+		);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -18,7 +18,7 @@ import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SILENT_ABORT_MARKER, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
-import { setKeybindings } from "@oh-my-pi/pi-tui";
+import { setKeybindings, Text } from "@oh-my-pi/pi-tui";
 import { formatNumber, TempDir } from "@oh-my-pi/pi-utils";
 
 /**
@@ -129,6 +129,16 @@ describe("InteractiveMode plan review rendering", () => {
 		currentTempDir?.removeSync();
 		setKeybindings(KeybindingsManager.inMemory());
 		resetSettingsForTest();
+	});
+
+	it("keeps queued-message rows in the live region instead of native scrollback", () => {
+		const liveRegion = mode.pendingMessagesContainer as {
+			getNativeScrollbackLiveRegionStart?: () => number | undefined;
+		};
+
+		expect(liveRegion.getNativeScrollbackLiveRegionStart?.()).toBeUndefined();
+		mode.pendingMessagesContainer.addChild(new Text("Queued: follow-up"));
+		expect(liveRegion.getNativeScrollbackLiveRegionStart?.()).toBe(0);
 	});
 
 	it("exits empty plan mode without confirmation", async () => {

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -704,7 +704,9 @@ describe("InteractiveMode plan review rendering", () => {
 			await Promise.resolve();
 			streaming = false;
 		});
-		const clearQueueSpy = vi.spyOn(session, "clearQueue").mockReturnValue({ steering: [], followUp: [] });
+		const clearQueueSpy = vi
+			.spyOn(session, "clearQueue")
+			.mockReturnValue({ steering: [{ text: "queued steer" }], followUp: [{ text: "queued follow-up" }] });
 		let promptCallCount = 0;
 		const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async _text => {
 			promptCallCount++;
@@ -736,18 +738,23 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(abortSpy).toHaveBeenCalledTimes(2);
 		// clearQueue was called once: by the catch block, after the abort, to
 		// suppress stranded compaction-flush queued-message drains that would
-		// race the retry prompt.
+		// race the retry prompt. Its user-restorable messages must be preserved
+		// for the pending queue instead of dropped.
 		expect(clearQueueSpy).toHaveBeenCalledTimes(1);
+		expect(mode.compactionQueuedMessages).toEqual([
+			{ text: "queued steer", mode: "steer", images: undefined },
+			{ text: "queued follow-up", mode: "followUp", images: undefined },
+		]);
 	});
 
-	it("clears stranded queued messages before retrying the approved-plan prompt after abort", async () => {
-		// Regression for PRRT_kwDOQxs0bc6OKssj: abort()'s #drainStrandedQueuedMessages
-		// may schedule a queued-message drain that auto-resumes a turn with the
-		// stranded compaction-flush messages (steers/follow-ups delivered by
-		// flushCompactionQueue's #deliverQueuedMessage loop). Without clearing the
-		// queue, the drain races the retry prompt and surfaces another
-		// AgentBusyError. clearQueue() must run after the abort and before the
-		// retry to neutralize the drain.
+	it("preserves stranded queued messages before retrying the approved-plan prompt after abort", async () => {
+		// Regression for PRRT_kwDOQxs0bc6OKssj / PRRT_kwDOQxs0bc6OLwj8:
+		// abort()'s #drainStrandedQueuedMessages may schedule a queued-message
+		// drain that auto-resumes a turn with the stranded compaction-flush
+		// messages. clearQueue() must run after the abort and before the retry
+		// to neutralize that drain, but the returned user messages must be
+		// preserved in compactionQueuedMessages because the aborted flush prompt
+		// resolves instead of rejecting through restoreQueue().
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
 			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
@@ -766,7 +773,7 @@ describe("InteractiveMode plan review rendering", () => {
 			await Promise.resolve();
 			streaming = false;
 		});
-		const clearQueueSpy = vi.spyOn(session, "clearQueue").mockReturnValue({ steering: [], followUp: [] });
+		const clearQueueSpy = vi.spyOn(session, "clearQueue");
 		const callOrder: string[] = [];
 		abortSpy.mockImplementation(async () => {
 			callOrder.push("abort");
@@ -774,7 +781,10 @@ describe("InteractiveMode plan review rendering", () => {
 		});
 		clearQueueSpy.mockImplementation(() => {
 			callOrder.push("clearQueue");
-			return { steering: [], followUp: [] };
+			return {
+				steering: [{ text: "queued steer" }],
+				followUp: [{ text: "queued follow-up" }],
+			};
 		});
 		let promptCallCount = 0;
 		const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async _text => {
@@ -800,6 +810,10 @@ describe("InteractiveMode plan review rendering", () => {
 		const retryIdx = callOrder.indexOf("prompt-2");
 		expect(abortIdx).toBeLessThan(clearIdx);
 		expect(clearIdx).toBeLessThan(retryIdx);
+		expect(mode.compactionQueuedMessages).toEqual([
+			{ text: "queued steer", mode: "steer", images: undefined },
+			{ text: "queued follow-up", mode: "followUp", images: undefined },
+		]);
 	});
 
 	it("keeps the existing approve-and-execute path clearing the session", async () => {

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -704,6 +704,7 @@ describe("InteractiveMode plan review rendering", () => {
 			await Promise.resolve();
 			streaming = false;
 		});
+		const clearQueueSpy = vi.spyOn(session, "clearQueue").mockReturnValue({ steering: [], followUp: [] });
 		let promptCallCount = 0;
 		const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async _text => {
 			promptCallCount++;
@@ -731,9 +732,74 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(isPlanApprovedCall(promptSpy.mock.calls[0] as unknown[])).toBe(true);
 		expect(isPlanApprovedCall(promptSpy.mock.calls[1] as unknown[])).toBe(true);
 		// abort was called twice: first by handlePlanApproval's pre-overlay
-		// abort (line 3090), then by the catch block's fire-and-forget race
-		// recovery (line 2695).
+		// abort, then by the catch block's fire-and-forget race recovery.
 		expect(abortSpy).toHaveBeenCalledTimes(2);
+		// clearQueue was called once: by the catch block, after the abort, to
+		// suppress stranded compaction-flush queued-message drains that would
+		// race the retry prompt.
+		expect(clearQueueSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears stranded queued messages before retrying the approved-plan prompt after abort", async () => {
+		// Regression for PRRT_kwDOQxs0bc6OKssj: abort()'s #drainStrandedQueuedMessages
+		// may schedule a queued-message drain that auto-resumes a turn with the
+		// stranded compaction-flush messages (steers/follow-ups delivered by
+		// flushCompactionQueue's #deliverQueuedMessage loop). Without clearing the
+		// queue, the drain races the retry prompt and surfaces another
+		// AgentBusyError. clearQueue() must run after the abort and before the
+		// retry to neutralize the drain.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		let streaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => streaming,
+		});
+		const abortSpy = vi.spyOn(session, "abort").mockImplementation(async () => {
+			await Promise.resolve();
+			streaming = false;
+		});
+		const clearQueueSpy = vi.spyOn(session, "clearQueue").mockReturnValue({ steering: [], followUp: [] });
+		const callOrder: string[] = [];
+		abortSpy.mockImplementation(async () => {
+			callOrder.push("abort");
+			streaming = false;
+		});
+		clearQueueSpy.mockImplementation(() => {
+			callOrder.push("clearQueue");
+			return { steering: [], followUp: [] };
+		});
+		let promptCallCount = 0;
+		const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async _text => {
+			promptCallCount++;
+			callOrder.push(`prompt-${promptCallCount}`);
+			if (promptCallCount === 1) {
+				streaming = true;
+				throw new AgentBusyError();
+			}
+			return true;
+		});
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => {
+			return options[2];
+		});
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(promptSpy).toHaveBeenCalledTimes(2);
+		// clearQueue must run AFTER abort (the abort triggers the drain) and
+		// BEFORE the retry prompt (to neutralize the drain before it fires).
+		const abortIdx = callOrder.indexOf("abort");
+		const clearIdx = callOrder.indexOf("clearQueue");
+		const retryIdx = callOrder.indexOf("prompt-2");
+		expect(abortIdx).toBeLessThan(clearIdx);
+		expect(clearIdx).toBeLessThan(retryIdx);
 	});
 
 	it("keeps the existing approve-and-execute path clearing the session", async () => {

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -676,6 +676,66 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(abortSpy).toHaveBeenCalled();
 	});
 
+	it("retries the approved-plan prompt after a fire-and-forget flush race surfaces AgentBusyError", async () => {
+		// Regression for PR #4369 comment 3: flushCompactionQueue dispatches the
+		// first queued user message as a fire-and-forget session.prompt() that
+		// may not have reached #beginInFlight() (and thus set isStreaming) by the
+		// time #approvePlan checks the guard. The first prompt() call throws
+		// AgentBusyError; the catch block must abort the now-streaming flushed
+		// turn and retry the approved-plan prompt.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		// isStreaming is false at the guard check, but the first prompt() call
+		// throws AgentBusyError because the fire-and-forget flush started
+		// streaming between the check and the call.
+		let streaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => streaming,
+		});
+		const abortSpy = vi.spyOn(session, "abort").mockImplementation(async () => {
+			await Promise.resolve();
+			streaming = false;
+		});
+		let promptCallCount = 0;
+		const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async _text => {
+			promptCallCount++;
+			if (promptCallCount === 1) {
+				// First call: the fire-and-forget flush race — isStreaming was
+				// false at the guard but is now true inside prompt().
+				streaming = true;
+				throw new AgentBusyError();
+			}
+			// Second call (retry after abort): succeeds.
+			return true;
+		});
+		// Keep-context path (options[2]) skips clear/compact so `this.session`
+		// stays the instance the spies are on.
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => {
+			return options[2];
+		});
+		const errorSpy = vi.spyOn(mode, "showError");
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to finalize approved plan"));
+		// prompt was called twice: first threw AgentBusyError, second succeeded.
+		expect(promptSpy).toHaveBeenCalledTimes(2);
+		expect(isPlanApprovedCall(promptSpy.mock.calls[0] as unknown[])).toBe(true);
+		expect(isPlanApprovedCall(promptSpy.mock.calls[1] as unknown[])).toBe(true);
+		// abort was called twice: first by handlePlanApproval's pre-overlay
+		// abort (line 3090), then by the catch block's fire-and-forget race
+		// recovery (line 2695).
+		expect(abortSpy).toHaveBeenCalledTimes(2);
+	});
+
 	it("keeps the existing approve-and-execute path clearing the session", async () => {
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
@@ -1596,6 +1656,42 @@ describe("InteractiveMode plan review rendering", () => {
 
 			expect(approval).not.toHaveBeenCalled();
 			expect(warn).toHaveBeenCalledWith(expect.stringContaining("No plan to review"));
+		});
+	});
+
+	describe("handleShakeCommand streaming guard", () => {
+		it("refuses to shake while a turn is streaming and does not call session.shake", async () => {
+			const streaming = true;
+			Object.defineProperty(session, "isStreaming", {
+				configurable: true,
+				get: () => streaming,
+			});
+			const shakeSpy = vi.spyOn(session, "shake").mockResolvedValue({
+				mode: "elide",
+				toolResultsDropped: 0,
+				blocksDropped: 0,
+				tokensFreed: 0,
+			});
+			const warnSpy = vi.spyOn(mode, "showWarning");
+
+			await mode.handleShakeCommand("elide");
+
+			expect(shakeSpy).not.toHaveBeenCalled();
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("not available while a turn is streaming"));
+		});
+
+		it("shakes normally when the session is idle", async () => {
+			const shakeSpy = vi.spyOn(session, "shake").mockResolvedValue({
+				mode: "elide",
+				toolResultsDropped: 2,
+				blocksDropped: 1,
+				tokensFreed: 500,
+			});
+			vi.spyOn(mode, "rebuildChatFromMessages").mockImplementation(() => {});
+
+			await mode.handleShakeCommand("elide");
+
+			expect(shakeSpy).toHaveBeenCalledWith("elide");
 		});
 	});
 });


### PR DESCRIPTION
## What
Anchors queued follow-up rows as a live region so repeated pending-message repaints do not leak duplicate rows into native scrollback.

## Verification
Verified after rebasing onto current upstream/main: `bun check`; coding-agent targeted tests (147 pass); `cargo clippy --workspace --all-targets` (1 pre-existing warning); `cargo test --workspace` (1176 pass); robomp targeted tests (165 pass); scoped ruff checks for changed Python files.

Closes #4362
