### PR TITLE
feat(tools): hide MCP schemas by context share

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a context-share threshold for MCP tool discovery auto-hiding ([#4365](https://github.com/can1357/oh-my-pi/issues/4365)).
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3788,8 +3788,13 @@ export const SETTINGS_SCHEMA = {
 			group: "Discovery & MCP",
 			label: "Tool Discovery",
 			description:
-				"Hide tools behind a search tool to save tokens. 'auto' hides MCP tools once the tool set has more than 40 tools; 'mcp-only' always hides MCP tools; 'all' hides all non-essential built-ins too.",
+				"Hide tools behind a search tool to save tokens. 'auto' hides MCP tools once the tool set has more than 40 tools or, when tools.discoveryContextShare is greater than 0, once MCP schemas exceed that share of the active context window; 'mcp-only' always hides MCP tools; 'all' hides all non-essential built-ins too.",
 		},
+	},
+
+	"tools.discoveryContextShare": {
+		type: "number",
+		default: 0,
 	},
 
 	"tools.essentialOverride": {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2163,10 +2163,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// MCP tool count pushes `auto` past its threshold; `rebuildSystemPrompt`
 		// below reads the live bindings.
 		const mcpTools = Array.from(toolRegistry.values()).filter(tool => isMCPToolName(tool.name));
-		let effectiveDiscoveryMode = resolveEffectiveToolDiscoveryMode(settings, countToolsForAutoDiscovery(toolRegistry.keys()), {
-			mcpSchemaTokens: estimateMcpToolSchemaTokens(mcpTools),
-			contextWindow: model?.contextWindow ?? 0,
-		});
+		let effectiveDiscoveryMode = resolveEffectiveToolDiscoveryMode(
+			settings,
+			countToolsForAutoDiscovery(toolRegistry.keys()),
+			{
+				mcpSchemaTokens: estimateMcpToolSchemaTokens(mcpTools),
+				contextWindow: model?.contextWindow ?? 0,
+			},
+		);
 		if (effectiveDiscoveryMode !== "off" && !toolRegistry.has("search_tool_bm25")) {
 			const searchTool: Tool = new SearchToolBm25Tool(toolSession);
 			toolRegistry.set(

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2214,12 +2214,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: Map<string, AgentTool>,
 		): Promise<BuildSystemPromptResult> => {
 			toolContextStore.setToolNames(toolNames);
-			const discoverableMCPTools: DiscoverableTool[] = mcpDiscoveryEnabled
+			// Read live discovery state from the session when available; the
+			// closure-captured `mcpDiscoveryEnabled`/`effectiveDiscoveryMode` are
+			// stale after a model switch upgrades discovery session-side.
+			const liveMcpDiscoveryEnabled = hasSession ? session.isMCPDiscoveryEnabled() : mcpDiscoveryEnabled;
+			const liveDiscoveryMode = hasSession ? session.getEffectiveToolDiscoveryMode() : effectiveDiscoveryMode;
+			const discoverableMCPTools: DiscoverableTool[] = liveMcpDiscoveryEnabled
 				? filterBySource(collectDiscoverableTools(tools.values()), "mcp")
 				: [];
 			const activeToolNames = new Set(toolNames);
 			const discoverableBuiltinTools: DiscoverableTool[] =
-				effectiveDiscoveryMode === "all"
+				liveDiscoveryMode === "all"
 					? collectDiscoverableTools(
 							Array.from(tools.values()).filter(
 								tool => tool.loadMode === "discoverable" && !activeToolNames.has(tool.name),
@@ -2230,7 +2235,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const discoverableToolsForDesc: DiscoverableTool[] = [...discoverableBuiltinTools, ...discoverableMCPTools];
 			const discoverableToolSummary = summarizeDiscoverableTools(discoverableToolsForDesc);
 			const hasDiscoverableTools =
-				mcpDiscoveryEnabled && toolNames.includes("search_tool_bm25") && discoverableToolsForDesc.length > 0;
+				liveMcpDiscoveryEnabled && toolNames.includes("search_tool_bm25") && discoverableToolsForDesc.length > 0;
 			const promptTools = buildSystemPromptToolMetadata(tools, {
 				search_tool_bm25: { description: renderSearchToolBm25Description(discoverableToolsForDesc) },
 			});

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2386,12 +2386,21 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const restoredSelectedMCPToolNames = existingSession.selectedMCPToolNames
 				.map(normalizeRenamedBuiltinToolName)
 				.filter(name => toolRegistry.has(name));
-			defaultSelectedMCPToolNames = [
-				...new Set([...discoveryDefaultServerToolNames, ...explicitlyRequestedMCPToolNames]),
-			];
+			// Registry-default server tools (from `mcp.discoveryDefaultServers`) are
+			// defaults — re-derived on every session start from the setting, so they
+			// must NOT be frozen into the persisted selection. Only truly-explicit
+			// `options.toolNames` MCP names should persist. Keep them separate here so
+			// `defaultSelectedMCPToolNames` feeds only the re-derivable defaults.
+			defaultSelectedMCPToolNames = [...new Set(discoveryDefaultServerToolNames)];
 			initialSelectedMCPToolNames = existingSession.hasPersistedMCPToolSelection
 				? restoredSelectedMCPToolNames
-				: [...new Set([...restoredSelectedMCPToolNames, ...defaultSelectedMCPToolNames])];
+				: [
+						...new Set([
+							...restoredSelectedMCPToolNames,
+							...explicitlyRequestedMCPToolNames,
+							...defaultSelectedMCPToolNames,
+						]),
+					];
 			initialToolNames = [
 				...new Set([
 					...initialRequestedActiveToolNames.filter(name => !name.startsWith("mcp__")),

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1743,7 +1743,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 									]);
 								}
 							}
-							await liveSession.refreshMCPTools(mcpResult.tools, { activateAll });
+							// PRRT_kwDOQxs0bc6ON-xd: when the deferred context-share
+							// estimate flips discovery on mid-flight, refreshMCPTools must
+							// treat it as an upgrade so re-derivable default-server
+							// selections are not frozen into mcp_tool_selection.
+							const discoveryUpgradedExternally = discoveryEnabled && !activation.mcpDiscoveryEnabled;
+							await liveSession.refreshMCPTools(mcpResult.tools, {
+								activateAll,
+								discoveryUpgradedExternally,
+							});
 							if (activation.explicitlyRequestedMCPToolNames.length > 0) {
 								if (discoveryEnabled && !activation.mcpDiscoveryEnabled) {
 									// Discovery flipped on mid-flight: route the explicit request
@@ -2765,6 +2773,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				return wrapped;
 			},
 			requestedToolNames: requestedToolNameSet,
+			explicitlyRequestedMCPToolNames,
 			getMcpServerInstructions: mcpManager
 				? () => {
 						const raw = mcpManager.getServerInstructions();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2745,6 +2745,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			convertToLlm: convertToLlmFinal,
 			rebuildSystemPrompt,
 			reloadSshTool,
+			registerSearchTool: () => {
+				const searchTool: Tool = new SearchToolBm25Tool(toolSession);
+				const wrapped = new ExtensionToolWrapper(wrapToolWithMetaNotice(searchTool), extensionRunner) as Tool;
+				return wrapped;
+			},
 			requestedToolNames: requestedToolNameSet,
 			getMcpServerInstructions: mcpManager
 				? () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -143,7 +143,11 @@ import {
 	shouldDisableReasoning,
 	toReasoningEffort,
 } from "./thinking";
-import { countToolsForAutoDiscovery, resolveEffectiveToolDiscoveryMode } from "./tool-discovery/mode";
+import {
+	countToolsForAutoDiscovery,
+	estimateMcpToolSchemaTokens,
+	resolveEffectiveToolDiscoveryMode,
+} from "./tool-discovery/mode";
 import {
 	collectDiscoverableTools,
 	type DiscoverableTool,
@@ -1715,6 +1719,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 								const projectedMode = resolveEffectiveToolDiscoveryMode(
 									settings,
 									countToolsForAutoDiscovery([...nonMCPToolNames, ...mcpResult.tools.map(tool => tool.name)]),
+									{
+										mcpSchemaTokens: estimateMcpToolSchemaTokens(mcpResult.tools),
+										contextWindow: liveSession.model?.contextWindow ?? 0,
+									},
 								);
 								if (projectedMode !== "off") {
 									effectiveDiscoveryMode = projectedMode;
@@ -2154,10 +2162,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// `let`: the deferred MCP discovery closure upgrades these when the real
 		// MCP tool count pushes `auto` past its threshold; `rebuildSystemPrompt`
 		// below reads the live bindings.
-		let effectiveDiscoveryMode = resolveEffectiveToolDiscoveryMode(
-			settings,
-			countToolsForAutoDiscovery(toolRegistry.keys()),
-		);
+		const mcpTools = Array.from(toolRegistry.values()).filter(tool => isMCPToolName(tool.name));
+		let effectiveDiscoveryMode = resolveEffectiveToolDiscoveryMode(settings, countToolsForAutoDiscovery(toolRegistry.keys()), {
+			mcpSchemaTokens: estimateMcpToolSchemaTokens(mcpTools),
+			contextWindow: model?.contextWindow ?? 0,
+		});
 		if (effectiveDiscoveryMode !== "off" && !toolRegistry.has("search_tool_bm25")) {
 			const searchTool: Tool = new SearchToolBm25Tool(toolSession);
 			toolRegistry.set(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -284,7 +284,11 @@ import {
 } from "../thinking";
 import { formatTitleConversationContext, type TitleConversationTurn } from "../tiny/text";
 import { shutdownTinyTitleClient } from "../tiny/title-client";
-import { countToolsForAutoDiscovery, resolveEffectiveToolDiscoveryMode } from "../tool-discovery/mode";
+import {
+	countToolsForAutoDiscovery,
+	estimateMcpToolSchemaTokens,
+	resolveEffectiveToolDiscoveryMode,
+} from "../tool-discovery/mode";
 import {
 	buildDiscoverableToolSearchIndex,
 	collectDiscoverableTools,
@@ -5956,10 +5960,11 @@ export class AgentSession {
 
 	/** Resolve effective discovery mode from the current registry size. */
 	#resolveEffectiveDiscoveryMode(): "off" | "mcp-only" | "all" {
-		const mode = resolveEffectiveToolDiscoveryMode(
-			this.settings,
-			countToolsForAutoDiscovery(this.#toolRegistry.keys()),
-		);
+		const mcpTools = Array.from(this.#toolRegistry.values()).filter(tool => isMCPToolName(tool.name));
+		const mode = resolveEffectiveToolDiscoveryMode(this.settings, countToolsForAutoDiscovery(this.#toolRegistry.keys()), {
+			mcpSchemaTokens: estimateMcpToolSchemaTokens(mcpTools),
+			contextWindow: this.model?.contextWindow ?? 0,
+		});
 		if (mode !== "off") return mode;
 		return this.#mcpDiscoveryEnabled ? "mcp-only" : "off";
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -726,6 +726,15 @@ export interface AgentSessionConfig {
 	registerSearchTool?: () => AgentTool | null;
 	requestedToolNames?: ReadonlySet<string>;
 	/**
+	 * MCP tool names that were truly explicitly requested via `options.toolNames`
+	 * (NOT registry defaults). When `options.toolNames` is omitted this is empty,
+	 * so discovery upgrade/persistence paths do not treat every registry MCP tool
+	 * as an explicit selection. Defaults are re-derived from
+	 * `mcp.discoveryDefaultServers` on every session start and must never be
+	 * frozen into the persisted `mcp_tool_selection`.
+	 */
+	explicitlyRequestedMCPToolNames?: string[];
+	/**
 	 * Optional accessor for live MCP server instructions. Read by the session's
 	 * `rebuildSystemPrompt`-skip optimization to detect server-side instruction
 	 * changes (e.g. an MCP server upgrade) that would otherwise pass the tool-set
@@ -1699,6 +1708,7 @@ export class AgentSession {
 	#getMcpServerInstructions: (() => Map<string, string> | undefined) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#requestedToolNames: ReadonlySet<string> | undefined;
+	#explicitlyRequestedMCPToolNames: string[] = [];
 	#baseSystemPrompt: string[];
 	#baseSystemPromptBeforeMemoryPromotion: string[] | undefined;
 	/**
@@ -2038,6 +2048,7 @@ export class AgentSession {
 		this.#toolRegistry = config.toolRegistry ?? new Map();
 		this.#builtInToolNames = new Set(config.builtInToolNames ?? []);
 		this.#requestedToolNames = config.requestedToolNames;
+		this.#explicitlyRequestedMCPToolNames = config.explicitlyRequestedMCPToolNames ?? [];
 		this.#transformContext = config.transformContext ?? (messages => messages);
 		this.#transformProviderContext = config.transformProviderContext;
 		this.#sideStreamFn = config.sideStreamFn ?? streamSimple;
@@ -2150,9 +2161,7 @@ export class AgentSession {
 		// not registry-default server tools. Defaults are re-derived from
 		// `mcp.discoveryDefaultServers` on every session start, so freezing them
 		// into the persisted selection would make them immune to setting changes.
-		const explicitMCPToolNames = [...(this.#requestedToolNames ?? [])].filter(
-			name => isMCPToolName(name) && this.#toolRegistry.has(name),
-		);
+		const explicitMCPToolNames = this.#getExplicitMCPToolNames();
 		const persistInitialMCPToolSelection =
 			config.persistInitialMCPToolSelection ?? this.sessionManager.getBranch().length === 0;
 		if (
@@ -5821,6 +5830,14 @@ export class AgentSession {
 		return Array.from(toolNames).filter(name => this.#discoverableMCPTools.has(name) && this.#toolRegistry.has(name));
 	}
 
+	/** Truly-explicit MCP tool names from `options.toolNames` (NOT registry defaults),
+	 *  filtered to names currently in the registry. When no `options.toolNames` was
+	 *  passed this is empty, so upgrade/persistence paths never treat the whole
+	 *  registry as explicit. */
+	#getExplicitMCPToolNames(): string[] {
+		return this.#explicitlyRequestedMCPToolNames.filter(name => this.#toolRegistry.has(name));
+	}
+
 	#getConfiguredDefaultSelectedMCPToolNames(): string[] {
 		return this.#filterSelectableMCPToolNames([
 			...this.#defaultSelectedMCPToolNames,
@@ -5952,9 +5969,7 @@ export class AgentSession {
 		// they would be absent from #selectedMCPToolNames and hidden behind
 		// search. The startup and deferred-discovery paths both preserve
 		// explicit selections, so this upgrade path must too.
-		const explicitMCPNames = [...(this.#requestedToolNames ?? [])].filter(
-			name => isMCPToolName(name) && this.#toolRegistry.has(name),
-		);
+		const explicitMCPNames = this.#getExplicitMCPToolNames();
 		if (!this.#enableMCPDiscoveryIfContextBudgetRequiresIt()) return;
 		// Re-apply the active tool set: non-MCP tools + search_tool_bm25 (if
 		// registered) + persisted/default-selected MCP tools. This removes MCP
@@ -5980,7 +5995,7 @@ export class AgentSession {
 		// mcp_tool_selection, making later changes to
 		// mcp.discoveryDefaultServers ineffective. Suppress persistence for
 		// this automatic upgrade path; only truly-explicit selections (from
-		// #requestedToolNames) should persist, and those were already persisted
+		// #getExplicitMCPToolNames) should persist, and those were already persisted
 		// at construction when discovery was on. When discovery was off at
 		// construction, persist only the explicit subset so it survives
 		// without freezing defaults.
@@ -6559,7 +6574,10 @@ export class AgentSession {
 	 *   regardless of prior selection state. Used when an ACP client provisions MCP servers
 	 *   for a session where MCP discovery is disabled.
 	 */
-	async refreshMCPTools(mcpTools: CustomTool[], options?: { activateAll?: boolean }): Promise<void> {
+	async refreshMCPTools(
+		mcpTools: CustomTool[],
+		options?: { activateAll?: boolean; discoveryUpgradedExternally?: boolean },
+	): Promise<void> {
 		const previousSelectedMCPToolNames = this.getSelectedMCPToolNames();
 		const existingNames = Array.from(this.#toolRegistry.keys());
 		for (const name of existingNames) {
@@ -6601,18 +6619,17 @@ export class AgentSession {
 			this.#getConfiguredDefaultSelectedMCPToolNames(),
 		);
 
-		const discoveryUpgraded = this.#enableMCPDiscoveryIfContextBudgetRequiresIt();
+		const discoveryUpgraded =
+			this.#enableMCPDiscoveryIfContextBudgetRequiresIt() || (options?.discoveryUpgradedExternally ?? false);
 		if (discoveryUpgraded) {
 			// Preserve explicit MCP selections that were active before the
 			// refresh. When discovery was off, `previousSelectedMCPToolNames`
 			// captured ALL active MCP names — only the explicit subset (from
-			// `#requestedToolNames`) should survive the upgrade, not tools that
+			// `#getExplicitMCPToolNames`) should survive the upgrade, not tools that
 			// were merely active because discovery hadn't engaged yet. Mirrors
 			// #syncDiscoveryModeAfterModelChange (line 5955-5973).
 			const ctx = this.buildDisplaySessionContext();
-			const explicitMCPNames = [...(this.#requestedToolNames ?? [])].filter(
-				name => isMCPToolName(name) && this.#toolRegistry.has(name),
-			);
+			const explicitMCPNames = this.#getExplicitMCPToolNames();
 			this.#selectedMCPToolNames = new Set([
 				...this.#selectedMCPToolNames,
 				...this.#filterSelectableMCPToolNames(explicitMCPNames),
@@ -6651,9 +6668,7 @@ export class AgentSession {
 		// registry defaults. Suppress persistence so those defaults are not
 		// frozen into mcp_tool_selection; persist only the explicit subset.
 		if (discoveryUpgraded && !hadPersistedSelection) {
-			const explicitMCPNames = this.#filterSelectableMCPToolNames(
-				[...(this.#requestedToolNames ?? [])].filter(name => isMCPToolName(name) && this.#toolRegistry.has(name)),
-			);
+			const explicitMCPNames = this.#filterSelectableMCPToolNames(this.#getExplicitMCPToolNames());
 			await this.#applyActiveToolsByName(nextActive, {
 				previousSelectedMCPToolNames,
 				persistMCPSelection: false,
@@ -8641,15 +8656,13 @@ export class AgentSession {
 					...this.#getActiveNonMCPToolNames(),
 					// PRRT_kwDOQxs0bc6OMvis: seed the next session with both
 					// the re-derivable registry defaults (#defaultSelectedMCPToolNames)
-					// and the per-session explicit MCP tools from #requestedToolNames.
+					// and the per-session explicit MCP tools from #getExplicitMCPToolNames.
 					// Without the explicit subset, /new drops tools the user
 					// requested via --tools even though the same CLI filter is
 					// still in effect.
 					...this.#filterSelectableMCPToolNames([
 						...this.#defaultSelectedMCPToolNames,
-						...[...(this.#requestedToolNames ?? [])].filter(
-							name => isMCPToolName(name) && this.#toolRegistry.has(name),
-						),
+						...this.#getExplicitMCPToolNames(),
 					]),
 				]
 			: undefined;
@@ -8705,8 +8718,13 @@ export class AgentSession {
 		this.sessionManager.appendServiceTierChange(this.#serviceTierEntry());
 		if (nextDiscoverySessionToolNames) {
 			await this.#applyActiveToolsByName(nextDiscoverySessionToolNames, { persistMCPSelection: false });
-			if (this.getSelectedMCPToolNames().length > 0) {
-				this.sessionManager.appendMCPToolSelection(this.getSelectedMCPToolNames());
+			// PRRT_kwDOQxs0bc6ON-xX: persist only truly-explicit MCP selections
+			// (from `options.toolNames`), not re-derivable `mcp.discoveryDefaultServers`
+			// defaults. Freezing defaults into mcp_tool_selection would make later
+			// changes to the default-server setting ineffective on this session.
+			const explicitMCPNames = this.#filterSelectableMCPToolNames(this.#getExplicitMCPToolNames());
+			if (explicitMCPNames.length > 0) {
+				this.sessionManager.appendMCPToolSelection(explicitMCPNames);
 			}
 		}
 		this.#rememberSessionDefaultSelectedMCPToolNames(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5939,19 +5939,7 @@ export class AgentSession {
 	 * path in `createAgentSession`).
 	 */
 	async #syncDiscoveryModeAfterModelChange(): Promise<void> {
-		if (this.#mcpDiscoveryEnabled) return; // already active — mode is lazy-recomputed
-		const mode = this.#resolveEffectiveDiscoveryMode();
-		if (mode === "off") return;
-		// Discovery upgraded: enable it and register the search tool so MCP
-		// schemas can be hidden behind BM25 discovery.
-		this.#mcpDiscoveryEnabled = true;
-		if (!this.#toolRegistry.has("search_tool_bm25") && this.#registerSearchTool) {
-			const searchTool = this.#registerSearchTool();
-			if (searchTool) {
-				this.#toolRegistry.set(searchTool.name, searchTool);
-				this.#builtInToolNames.add(searchTool.name);
-			}
-		}
+		if (!this.#enableMCPDiscoveryIfContextBudgetRequiresIt()) return;
 		// Re-apply the active tool set: non-MCP tools + search_tool_bm25 (if
 		// registered) + default-selected MCP tools. This removes MCP tools that
 		// were force-activated when discovery was off, replacing them with the
@@ -5962,6 +5950,23 @@ export class AgentSession {
 			...this.#filterSelectableMCPToolNames(this.#getConfiguredDefaultSelectedMCPToolNames()),
 		];
 		await this.#applyActiveToolsByName(nextActive);
+	}
+
+	#enableMCPDiscoveryIfContextBudgetRequiresIt(): boolean {
+		if (this.#mcpDiscoveryEnabled) return false;
+		const mode = this.#resolveEffectiveDiscoveryMode();
+		if (mode === "off") return false;
+		// Discovery upgraded: enable it and register the search tool so MCP
+		// schemas can be hidden behind BM25 discovery.
+		this.#mcpDiscoveryEnabled = true;
+		if (!this.#toolRegistry.has("search_tool_bm25") && this.#registerSearchTool) {
+			const searchTool = this.#registerSearchTool();
+			if (searchTool) {
+				this.#toolRegistry.set(searchTool.name, searchTool);
+				this.#builtInToolNames.add(searchTool.name);
+			}
+		}
+		return true;
 	}
 
 	isMCPDiscoveryEnabled(): boolean {
@@ -6540,7 +6545,8 @@ export class AgentSession {
 			this.#getConfiguredDefaultSelectedMCPToolNames(),
 		);
 
-		if (options?.activateAll) {
+		const discoveryUpgraded = this.#enableMCPDiscoveryIfContextBudgetRequiresIt();
+		if (options?.activateAll && !discoveryUpgraded) {
 			// Force-activate every newly registered MCP tool. This path is used
 			// when an ACP client provisions MCP servers for a session where MCP
 			// discovery is disabled — without it, getSelectedMCPToolNames()
@@ -6552,7 +6558,11 @@ export class AgentSession {
 			return;
 		}
 
-		const nextActive = [...this.#getActiveNonMCPToolNames(), ...this.getSelectedMCPToolNames()];
+		const nextActive = [
+			...this.#getActiveNonMCPToolNames(),
+			...(discoveryUpgraded && this.#toolRegistry.has("search_tool_bm25") ? ["search_tool_bm25"] : []),
+			...this.getSelectedMCPToolNames(),
+		];
 		await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5939,19 +5939,32 @@ export class AgentSession {
 	 * path in `createAgentSession`).
 	 */
 	async #syncDiscoveryModeAfterModelChange(): Promise<void> {
+		// Capture explicitly requested MCP tools before the upgrade flips
+		// #mcpDiscoveryEnabled. Explicit --tools/subagent selections are not
+		// persisted when discovery is off at construction time; after the flip
+		// they would be absent from #selectedMCPToolNames and hidden behind
+		// search. The startup and deferred-discovery paths both preserve
+		// explicit selections, so this upgrade path must too.
+		const explicitMCPNames = [...(this.#requestedToolNames ?? [])].filter(
+			name => isMCPToolName(name) && this.#toolRegistry.has(name),
+		);
 		if (!this.#enableMCPDiscoveryIfContextBudgetRequiresIt()) return;
 		// Re-apply the active tool set: non-MCP tools + search_tool_bm25 (if
-		// registered) + default-selected MCP tools. This removes MCP tools that
-		// were force-activated when discovery was off, replacing them with the
-		// discovery-aware selection.
+		// registered) + persisted/default-selected MCP tools. This removes MCP
+		// tools that were force-activated when discovery was off, replacing them
+		// with the discovery-aware selection.
 		const sessionContext = this.buildDisplaySessionContext();
 		const upgradedMcpNames = sessionContext.hasPersistedMCPToolSelection
 			? this.#filterSelectableMCPToolNames(sessionContext.selectedMCPToolNames)
 			: this.#filterSelectableMCPToolNames(this.#getConfiguredDefaultSelectedMCPToolNames());
+		// Union persisted/default selections with explicitly requested MCP
+		// tools so explicit selections survive the discovery upgrade instead
+		// of being dropped and hidden behind search.
+		const mcpNames = [...new Set([...upgradedMcpNames, ...this.#filterSelectableMCPToolNames(explicitMCPNames)])];
 		const nextActive = [
 			...this.#getActiveNonMCPToolNames(),
 			...(this.#toolRegistry.has("search_tool_bm25") ? ["search_tool_bm25"] : []),
-			...upgradedMcpNames,
+			...mcpNames,
 		];
 		await this.#applyActiveToolsByName(nextActive);
 	}
@@ -5960,16 +5973,19 @@ export class AgentSession {
 		if (this.#mcpDiscoveryEnabled) return false;
 		const mode = this.#resolveEffectiveDiscoveryMode();
 		if (mode === "off") return false;
-		// Discovery upgraded: enable it and register the search tool so MCP
-		// schemas can be hidden behind BM25 discovery.
-		this.#mcpDiscoveryEnabled = true;
-		if (!this.#toolRegistry.has("search_tool_bm25") && this.#registerSearchTool) {
+		// Register the search tool BEFORE flipping discovery on. Without
+		// search_tool_bm25 there is no way to rediscover hidden MCP tools, so
+		// a session constructed without a registerSearchTool callback (or one
+		// whose registration fails) must keep discovery off and leave MCP
+		// schemas visible.
+		if (!this.#toolRegistry.has("search_tool_bm25")) {
+			if (!this.#registerSearchTool) return false;
 			const searchTool = this.#registerSearchTool();
-			if (searchTool) {
-				this.#toolRegistry.set(searchTool.name, searchTool);
-				this.#builtInToolNames.add(searchTool.name);
-			}
+			if (!searchTool) return false;
+			this.#toolRegistry.set(searchTool.name, searchTool);
+			this.#builtInToolNames.add(searchTool.name);
 		}
+		this.#mcpDiscoveryEnabled = true;
 		return true;
 	}
 
@@ -6565,6 +6581,16 @@ export class AgentSession {
 					...this.#selectedMCPToolNames,
 					...this.#filterSelectableMCPToolNames(ctx.selectedMCPToolNames),
 				]);
+			}
+		} else if (this.#mcpDiscoveryEnabled && this.#selectedMCPToolNames.size === 0) {
+			// Discovery was enabled externally (e.g. deferred startup called
+			// enableMCPDiscovery() before refreshMCPTools). #selectedMCPToolNames
+			// was never seeded from the persisted selection — restore it now that
+			// the real MCP tools are in the registry, or a resumed session with a
+			// persisted MCP selection would hide that selected tool.
+			const ctx = this.buildDisplaySessionContext();
+			if (ctx.hasPersistedMCPToolSelection) {
+				this.#selectedMCPToolNames = new Set(this.#filterSelectableMCPToolNames(ctx.selectedMCPToolNames));
 			}
 		}
 		if (options?.activateAll && !this.#mcpDiscoveryEnabled) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -716,6 +716,14 @@ export interface AgentSessionConfig {
 	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>;
 	/** Rebuild the SSH tool from current capability discovery results. */
 	reloadSshTool?: () => Promise<AgentTool | null>;
+	/**
+	 * Lazily create and register the `search_tool_bm25` tool when tool
+	 * discovery upgrades mid-session (e.g. after a model switch shrinks the
+	 * context window so MCP schemas now exceed `tools.discoveryContextShare`).
+	 * Returns the fully wrapped tool ready for the registry, or null if the
+	 * tool cannot be created. Mirrors the `reloadSshTool` pattern.
+	 */
+	registerSearchTool?: () => AgentTool | null;
 	requestedToolNames?: ReadonlySet<string>;
 	/**
 	 * Optional accessor for live MCP server instructions. Read by the session's
@@ -1680,6 +1688,8 @@ export class AgentSession {
 	#onSseEvent: SimpleStreamOptions["onSseEvent"] | undefined;
 	#transformProviderContext: ((context: Context, model: Model) => Context | Promise<Context>) | undefined;
 	#sideStreamFn: StreamFn;
+	#reloadSshTool: (() => Promise<AgentTool | null>) | undefined;
+	#registerSearchTool: (() => AgentTool | null) | undefined;
 	#advisorStreamFn: StreamFn | undefined;
 	#preferWebsockets: boolean | undefined;
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
@@ -1687,7 +1697,6 @@ export class AgentSession {
 		| ((toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>)
 		| undefined;
 	#getMcpServerInstructions: (() => Map<string, string> | undefined) | undefined;
-	#reloadSshTool: (() => Promise<AgentTool | null>) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#requestedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
@@ -2126,6 +2135,7 @@ export class AgentSession {
 		this.#rebuildSystemPrompt = config.rebuildSystemPrompt;
 		this.#getMcpServerInstructions = config.getMcpServerInstructions;
 		this.#reloadSshTool = config.reloadSshTool;
+		this.#registerSearchTool = config.registerSearchTool;
 		this.#disconnectOwnedMcpManager = config.disconnectOwnedMcpManager;
 		this.#baseSystemPrompt = this.agent.state.systemPrompt;
 		this.#promptModelKey = this.#currentPromptModelKey();
@@ -5911,6 +5921,47 @@ export class AgentSession {
 		if (editModeChanged || modelChanged) {
 			await this.refreshBaseSystemPrompt();
 		}
+		// Re-evaluate tool-discovery auto mode: a model switch can change the
+		// context window so that MCP schemas that were below the
+		// `tools.discoveryContextShare` threshold on the old model now exceed it.
+		// Without this, every MCP tool stays active and its schema keeps being
+		// sent despite the active context now requiring auto-hide.
+		await this.#syncDiscoveryModeAfterModelChange();
+	}
+
+	/**
+	 * Recompute the effective tool-discovery mode after a model switch and
+	 * apply it if the mode upgraded from "off" to "mcp-only"/"all". This hides
+	 * MCP tool schemas (replacing them with `search_tool_bm25`) so the active
+	 * model's context budget is respected. Downgrade is intentionally NOT
+	 * performed: once discovery is enabled, `#mcpDiscoveryEnabled` keeps it on
+	 * for the session lifetime (consistent with the deferred-discovery upgrade
+	 * path in `createAgentSession`).
+	 */
+	async #syncDiscoveryModeAfterModelChange(): Promise<void> {
+		if (this.#mcpDiscoveryEnabled) return; // already active — mode is lazy-recomputed
+		const mode = this.#resolveEffectiveDiscoveryMode();
+		if (mode === "off") return;
+		// Discovery upgraded: enable it and register the search tool so MCP
+		// schemas can be hidden behind BM25 discovery.
+		this.#mcpDiscoveryEnabled = true;
+		if (!this.#toolRegistry.has("search_tool_bm25") && this.#registerSearchTool) {
+			const searchTool = this.#registerSearchTool();
+			if (searchTool) {
+				this.#toolRegistry.set(searchTool.name, searchTool);
+				this.#builtInToolNames.add(searchTool.name);
+			}
+		}
+		// Re-apply the active tool set: non-MCP tools + search_tool_bm25 (if
+		// registered) + default-selected MCP tools. This removes MCP tools that
+		// were force-activated when discovery was off, replacing them with the
+		// discovery-aware selection.
+		const nextActive = [
+			...this.#getActiveNonMCPToolNames(),
+			...(this.#toolRegistry.has("search_tool_bm25") ? ["search_tool_bm25"] : []),
+			...this.#filterSelectableMCPToolNames(this.#getConfiguredDefaultSelectedMCPToolNames()),
+		];
+		await this.#applyActiveToolsByName(nextActive);
 	}
 
 	isMCPDiscoveryEnabled(): boolean {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5961,10 +5961,14 @@ export class AgentSession {
 	/** Resolve effective discovery mode from the current registry size. */
 	#resolveEffectiveDiscoveryMode(): "off" | "mcp-only" | "all" {
 		const mcpTools = Array.from(this.#toolRegistry.values()).filter(tool => isMCPToolName(tool.name));
-		const mode = resolveEffectiveToolDiscoveryMode(this.settings, countToolsForAutoDiscovery(this.#toolRegistry.keys()), {
-			mcpSchemaTokens: estimateMcpToolSchemaTokens(mcpTools),
-			contextWindow: this.model?.contextWindow ?? 0,
-		});
+		const mode = resolveEffectiveToolDiscoveryMode(
+			this.settings,
+			countToolsForAutoDiscovery(this.#toolRegistry.keys()),
+			{
+				mcpSchemaTokens: estimateMcpToolSchemaTokens(mcpTools),
+				contextWindow: this.model?.contextWindow ?? 0,
+			},
+		);
 		if (mode !== "off") return mode;
 		return this.#mcpDiscoveryEnabled ? "mcp-only" : "off";
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5944,10 +5944,14 @@ export class AgentSession {
 		// registered) + default-selected MCP tools. This removes MCP tools that
 		// were force-activated when discovery was off, replacing them with the
 		// discovery-aware selection.
+		const sessionContext = this.buildDisplaySessionContext();
+		const upgradedMcpNames = sessionContext.hasPersistedMCPToolSelection
+			? this.#filterSelectableMCPToolNames(sessionContext.selectedMCPToolNames)
+			: this.#filterSelectableMCPToolNames(this.#getConfiguredDefaultSelectedMCPToolNames());
 		const nextActive = [
 			...this.#getActiveNonMCPToolNames(),
 			...(this.#toolRegistry.has("search_tool_bm25") ? ["search_tool_bm25"] : []),
-			...this.#filterSelectableMCPToolNames(this.#getConfiguredDefaultSelectedMCPToolNames()),
+			...upgradedMcpNames,
 		];
 		await this.#applyActiveToolsByName(nextActive);
 	}
@@ -6031,6 +6035,14 @@ export class AgentSession {
 
 	isToolDiscoveryEnabled(): boolean {
 		return this.#resolveEffectiveDiscoveryMode() !== "off";
+	}
+
+	/** Effective discovery mode from the current registry + session state.
+	 *  Exposed so the `rebuildSystemPrompt` closure in `sdk.ts` can read live
+	 *  state after a model switch upgrades discovery, instead of stale
+	 *  closure-captured bindings. */
+	getEffectiveToolDiscoveryMode(): "off" | "mcp-only" | "all" {
+		return this.#resolveEffectiveDiscoveryMode();
 	}
 
 	getDiscoverableTools(filter?: { source?: DiscoverableTool["source"] }): DiscoverableTool[] {
@@ -6546,7 +6558,16 @@ export class AgentSession {
 		);
 
 		const discoveryUpgraded = this.#enableMCPDiscoveryIfContextBudgetRequiresIt();
-		if (options?.activateAll && !discoveryUpgraded) {
+		if (discoveryUpgraded) {
+			const ctx = this.buildDisplaySessionContext();
+			if (ctx.hasPersistedMCPToolSelection) {
+				this.#selectedMCPToolNames = new Set([
+					...this.#selectedMCPToolNames,
+					...this.#filterSelectableMCPToolNames(ctx.selectedMCPToolNames),
+				]);
+			}
+		}
+		if (options?.activateAll && !this.#mcpDiscoveryEnabled) {
 			// Force-activate every newly registered MCP tool. This path is used
 			// when an ACP client provisions MCP servers for a session where MCP
 			// discovery is disabled — without it, getSelectedMCPToolNames()

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2146,15 +2146,22 @@ export class AgentSession {
 		this.#defaultSelectedMCPToolNames = new Set(config.defaultSelectedMCPToolNames ?? []);
 		this.#pruneSelectedMCPToolNames();
 		const persistedSelectedMCPToolNames = this.buildDisplaySessionContext().selectedMCPToolNames;
-		const currentSelectedMCPToolNames = this.getSelectedMCPToolNames();
+		// Persist only truly-explicit MCP selections (from `options.toolNames`),
+		// not registry-default server tools. Defaults are re-derived from
+		// `mcp.discoveryDefaultServers` on every session start, so freezing them
+		// into the persisted selection would make them immune to setting changes.
+		const explicitMCPToolNames = [...(this.#requestedToolNames ?? [])].filter(
+			name => isMCPToolName(name) && this.#toolRegistry.has(name),
+		);
 		const persistInitialMCPToolSelection =
 			config.persistInitialMCPToolSelection ?? this.sessionManager.getBranch().length === 0;
 		if (
 			this.#mcpDiscoveryEnabled &&
 			persistInitialMCPToolSelection &&
-			!this.#selectedMCPToolNamesMatch(persistedSelectedMCPToolNames, currentSelectedMCPToolNames)
+			explicitMCPToolNames.length > 0 &&
+			!this.#selectedMCPToolNamesMatch(persistedSelectedMCPToolNames, explicitMCPToolNames)
 		) {
-			this.sessionManager.appendMCPToolSelection(currentSelectedMCPToolNames);
+			this.sessionManager.appendMCPToolSelection(explicitMCPToolNames);
 		}
 		this.#rememberSessionDefaultSelectedMCPToolNames(
 			this.sessionManager.getSessionFile(),
@@ -6575,13 +6582,21 @@ export class AgentSession {
 
 		const discoveryUpgraded = this.#enableMCPDiscoveryIfContextBudgetRequiresIt();
 		if (discoveryUpgraded) {
+			// Preserve explicit MCP selections that were active before the
+			// refresh. When discovery was off, `previousSelectedMCPToolNames`
+			// captured ALL active MCP names — only the explicit subset (from
+			// `#requestedToolNames`) should survive the upgrade, not tools that
+			// were merely active because discovery hadn't engaged yet. Mirrors
+			// #syncDiscoveryModeAfterModelChange (line 5955-5973).
 			const ctx = this.buildDisplaySessionContext();
-			if (ctx.hasPersistedMCPToolSelection) {
-				this.#selectedMCPToolNames = new Set([
-					...this.#selectedMCPToolNames,
-					...this.#filterSelectableMCPToolNames(ctx.selectedMCPToolNames),
-				]);
-			}
+			const explicitMCPNames = [...(this.#requestedToolNames ?? [])].filter(
+				name => isMCPToolName(name) && this.#toolRegistry.has(name),
+			);
+			this.#selectedMCPToolNames = new Set([
+				...this.#selectedMCPToolNames,
+				...this.#filterSelectableMCPToolNames(explicitMCPNames),
+				...(ctx.hasPersistedMCPToolSelection ? this.#filterSelectableMCPToolNames(ctx.selectedMCPToolNames) : []),
+			]);
 		} else if (this.#mcpDiscoveryEnabled && this.#selectedMCPToolNames.size === 0) {
 			// Discovery was enabled externally (e.g. deferred startup called
 			// enableMCPDiscovery() before refreshMCPTools). #selectedMCPToolNames

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5961,7 +5961,8 @@ export class AgentSession {
 		// tools that were force-activated when discovery was off, replacing them
 		// with the discovery-aware selection.
 		const sessionContext = this.buildDisplaySessionContext();
-		const upgradedMcpNames = sessionContext.hasPersistedMCPToolSelection
+		const hadPersistedSelection = sessionContext.hasPersistedMCPToolSelection;
+		const upgradedMcpNames = hadPersistedSelection
 			? this.#filterSelectableMCPToolNames(sessionContext.selectedMCPToolNames)
 			: this.#filterSelectableMCPToolNames(this.#getConfiguredDefaultSelectedMCPToolNames());
 		// Union persisted/default selections with explicitly requested MCP
@@ -5973,7 +5974,26 @@ export class AgentSession {
 			...(this.#toolRegistry.has("search_tool_bm25") ? ["search_tool_bm25"] : []),
 			...mcpNames,
 		];
-		await this.#applyActiveToolsByName(nextActive);
+		// PRRT_kwDOQxs0bc6OMvim: When no persisted selection existed before the
+		// upgrade, the active MCP set is built from re-derivable registry
+		// defaults. Persisting it would freeze those defaults into
+		// mcp_tool_selection, making later changes to
+		// mcp.discoveryDefaultServers ineffective. Suppress persistence for
+		// this automatic upgrade path; only truly-explicit selections (from
+		// #requestedToolNames) should persist, and those were already persisted
+		// at construction when discovery was on. When discovery was off at
+		// construction, persist only the explicit subset so it survives
+		// without freezing defaults.
+		await this.#applyActiveToolsByName(nextActive, {
+			persistMCPSelection: !hadPersistedSelection ? false : undefined,
+		});
+		if (!hadPersistedSelection && explicitMCPNames.length > 0) {
+			const selectableExplicit = this.#filterSelectableMCPToolNames(explicitMCPNames);
+			const currentPersisted = this.buildDisplaySessionContext().selectedMCPToolNames;
+			if (!this.#selectedMCPToolNamesMatch(currentPersisted, selectableExplicit)) {
+				this.sessionManager.appendMCPToolSelection(selectableExplicit);
+			}
+		}
 	}
 
 	#enableMCPDiscoveryIfContextBudgetRequiresIt(): boolean {
@@ -6569,7 +6589,8 @@ export class AgentSession {
 
 		this.#setDiscoverableMCPTools(this.#collectDiscoverableMCPToolsFromRegistry());
 		this.#pruneSelectedMCPToolNames();
-		if (!this.buildDisplaySessionContext().hasPersistedMCPToolSelection) {
+		const hadPersistedSelection = this.buildDisplaySessionContext().hasPersistedMCPToolSelection;
+		if (!hadPersistedSelection) {
 			this.#selectedMCPToolNames = new Set([
 				...this.#selectedMCPToolNames,
 				...this.#getConfiguredDefaultSelectedMCPToolNames(),
@@ -6625,7 +6646,27 @@ export class AgentSession {
 			...(discoveryUpgraded && this.#toolRegistry.has("search_tool_bm25") ? ["search_tool_bm25"] : []),
 			...this.getSelectedMCPToolNames(),
 		];
-		await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });
+		// PRRT_kwDOQxs0bc6OMvim (refresh path): when discovery upgraded and no
+		// persisted selection existed, the active MCP set includes re-derivable
+		// registry defaults. Suppress persistence so those defaults are not
+		// frozen into mcp_tool_selection; persist only the explicit subset.
+		if (discoveryUpgraded && !hadPersistedSelection) {
+			const explicitMCPNames = this.#filterSelectableMCPToolNames(
+				[...(this.#requestedToolNames ?? [])].filter(name => isMCPToolName(name) && this.#toolRegistry.has(name)),
+			);
+			await this.#applyActiveToolsByName(nextActive, {
+				previousSelectedMCPToolNames,
+				persistMCPSelection: false,
+			});
+			if (explicitMCPNames.length > 0) {
+				const currentPersisted = this.buildDisplaySessionContext().selectedMCPToolNames;
+				if (!this.#selectedMCPToolNamesMatch(currentPersisted, explicitMCPNames)) {
+					this.sessionManager.appendMCPToolSelection(explicitMCPNames);
+				}
+			}
+		} else {
+			await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });
+		}
 	}
 
 	/**
@@ -8598,7 +8639,18 @@ export class AgentSession {
 		const nextDiscoverySessionToolNames = this.#mcpDiscoveryEnabled
 			? [
 					...this.#getActiveNonMCPToolNames(),
-					...this.#filterSelectableMCPToolNames(this.#defaultSelectedMCPToolNames),
+					// PRRT_kwDOQxs0bc6OMvis: seed the next session with both
+					// the re-derivable registry defaults (#defaultSelectedMCPToolNames)
+					// and the per-session explicit MCP tools from #requestedToolNames.
+					// Without the explicit subset, /new drops tools the user
+					// requested via --tools even though the same CLI filter is
+					// still in effect.
+					...this.#filterSelectableMCPToolNames([
+						...this.#defaultSelectedMCPToolNames,
+						...[...(this.#requestedToolNames ?? [])].filter(
+							name => isMCPToolName(name) && this.#toolRegistry.has(name),
+						),
+					]),
 				]
 			: undefined;
 

--- a/packages/coding-agent/src/tool-discovery/mode.ts
+++ b/packages/coding-agent/src/tool-discovery/mode.ts
@@ -1,6 +1,6 @@
+import { estimateTokens } from "../commit/map-reduce/utils";
 import type { Settings } from "../config/settings";
 import type { SettingValue } from "../config/settings-schema";
-import { estimateTokens } from "../commit/map-reduce/utils";
 
 export const TOOL_DISCOVERY_AUTO_THRESHOLD = 40;
 export const TOOL_DISCOVERY_SEARCH_TOOL_NAME = "search_tool_bm25";

--- a/packages/coding-agent/src/tool-discovery/mode.ts
+++ b/packages/coding-agent/src/tool-discovery/mode.ts
@@ -13,14 +13,25 @@ export interface ToolDiscoveryContextEstimate {
 	contextWindow: number;
 }
 
-export function estimateMcpToolSchemaTokens(tools: Iterable<{ parameters?: unknown }>): number {
+export function estimateMcpToolSchemaTokens(
+	tools: Iterable<{ name?: string; description?: string; parameters?: unknown }>,
+): number {
 	let total = 0;
 	for (const tool of tools) {
+		// The provider receives each tool's full definition (name, description,
+		// parameters) as part of the tool schema, so the cost estimate must cover
+		// all three — not parameters alone. A few MCP tools with large
+		// descriptions but tiny parameter objects would otherwise stay near zero
+		// and evade the discoveryContextShare auto-hide threshold.
+		const name = tool.name ?? "";
+		const description = tool.description ?? "";
+		let parametersJson: string;
 		try {
-			total += estimateTokens(JSON.stringify(tool.parameters ?? {}) ?? "{}");
+			parametersJson = JSON.stringify(tool.parameters ?? {}) ?? "{}";
 		} catch {
-			total += estimateTokens("{}");
+			parametersJson = "{}";
 		}
+		total += estimateTokens(`${name}${description}${parametersJson}`);
 	}
 	return total;
 }

--- a/packages/coding-agent/src/tool-discovery/mode.ts
+++ b/packages/coding-agent/src/tool-discovery/mode.ts
@@ -1,11 +1,29 @@
 import type { Settings } from "../config/settings";
 import type { SettingValue } from "../config/settings-schema";
+import { estimateTokens } from "../commit/map-reduce/utils";
 
 export const TOOL_DISCOVERY_AUTO_THRESHOLD = 40;
 export const TOOL_DISCOVERY_SEARCH_TOOL_NAME = "search_tool_bm25";
 
 export type ToolDiscoveryModeSetting = SettingValue<"tools.discoveryMode">;
 export type EffectiveToolDiscoveryMode = Exclude<ToolDiscoveryModeSetting, "auto">;
+
+export interface ToolDiscoveryContextEstimate {
+	mcpSchemaTokens: number;
+	contextWindow: number;
+}
+
+export function estimateMcpToolSchemaTokens(tools: Iterable<{ parameters?: unknown }>): number {
+	let total = 0;
+	for (const tool of tools) {
+		try {
+			total += estimateTokens(JSON.stringify(tool.parameters ?? {}) ?? "{}");
+		} catch {
+			total += estimateTokens("{}");
+		}
+	}
+	return total;
+}
 
 export function countToolsForAutoDiscovery(toolNames: Iterable<string>): number {
 	let count = 0;
@@ -15,10 +33,25 @@ export function countToolsForAutoDiscovery(toolNames: Iterable<string>): number 
 	return count;
 }
 
-export function resolveEffectiveToolDiscoveryMode(settings: Settings, toolCount: number): EffectiveToolDiscoveryMode {
+export function resolveEffectiveToolDiscoveryMode(
+	settings: Settings,
+	toolCount: number,
+	contextEstimate?: ToolDiscoveryContextEstimate,
+): EffectiveToolDiscoveryMode {
 	const configuredMode = settings.get("tools.discoveryMode");
 	if (configuredMode === "all" || configuredMode === "mcp-only") return configuredMode;
 	if (settings.get("mcp.discoveryMode")) return "mcp-only";
-	if (configuredMode === "auto" && toolCount > TOOL_DISCOVERY_AUTO_THRESHOLD) return "mcp-only";
+	if (configuredMode === "auto") {
+		if (toolCount > TOOL_DISCOVERY_AUTO_THRESHOLD) return "mcp-only";
+		const discoveryContextShare = settings.get("tools.discoveryContextShare");
+		if (
+			discoveryContextShare > 0 &&
+			contextEstimate !== undefined &&
+			contextEstimate.contextWindow > 0 &&
+			contextEstimate.mcpSchemaTokens > contextEstimate.contextWindow * discoveryContextShare
+		) {
+			return "mcp-only";
+		}
+	}
 	return "off";
 }

--- a/packages/coding-agent/src/tool-discovery/mode.ts
+++ b/packages/coding-agent/src/tool-discovery/mode.ts
@@ -1,4 +1,4 @@
-import { estimateTokens } from "../commit/map-reduce/utils";
+import { countTokens } from "@oh-my-pi/pi-agent-core";
 import type { Settings } from "../config/settings";
 import type { SettingValue } from "../config/settings-schema";
 
@@ -31,7 +31,7 @@ export function estimateMcpToolSchemaTokens(
 		} catch {
 			parametersJson = "{}";
 		}
-		total += estimateTokens(`${name}${description}${parametersJson}`);
+		total += countTokens(`${name}${description}${parametersJson}`);
 	}
 	return total;
 }

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -1201,4 +1201,198 @@ describe("AgentSession MCP discovery", () => {
 		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
 		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
 	});
+
+	it("does not re-expose MCP tools via activateAll when discovery is already enabled", async () => {
+		// PRRT_kwDOQxs0bc6OET8b: activateAll must be gated on current session
+		// discovery state, not only per-call upgrade. When discovery is already
+		// on (from a prior model switch or deferred discovery), a subsequent
+		// refreshMCPTools({ activateAll: true }) must NOT force-activate every
+		// MCP tool — they should stay hidden behind search_tool_bm25.
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const docsTool = createMcpTool("mcp__docs_search", "docs", "search", "Search internal docs", ["query"]);
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[searchTool.name, searchTool],
+			[docsTool.name, docsTool],
+		]);
+		const agent = new Agent({
+			initialState: {
+				model: createModel(),
+				systemPrompt: ["initial"],
+				tools: [readTool, searchTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "mcp.discoveryMode": true }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: true,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+		});
+		sessions.push(session);
+
+		// Discovery is already on; no MCP tools are active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).not.toContain("mcp__docs_search");
+
+		// refreshMCPTools with activateAll: true must NOT re-expose MCP tools.
+		await session.refreshMCPTools(
+			[createMcpCustomTool("mcp__docs_search", "docs", "search", "Search internal docs", ["query"])],
+			{ activateAll: true },
+		);
+
+		expect(session.getActiveToolNames()).not.toContain("mcp__docs_search");
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
+
+	it("preserves persisted MCP selections when model-switch upgrades discovery", async () => {
+		// PRRT_kwDOQxs0bc6OET8e: when discovery upgrades after a model switch,
+		// active MCP names should come from the persisted selection, not only
+		// configured defaults.
+		const largeModel = buildModel({
+			id: "large-ctx",
+			name: "large-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 2048,
+		});
+		const smallModel = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const bigDescTool = createMcpTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]);
+		const otherTool = createMcpTool("mcp__server__other", "server", "other", "Other tool", ["query"]);
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[bigDescTool.name, bigDescTool],
+			[otherTool.name, otherTool],
+			[searchTool.name, searchTool],
+		]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model: largeModel,
+				systemPrompt: ["initial"],
+				tools: [readTool, bigDescTool, otherTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {
+				hasConfiguredAuth: () => true,
+				refreshSelectedModelMetadata: async (m: Model) => m,
+				getApiKey: async () => "key",
+				getAvailable: () => [largeModel, smallModel],
+				find: (provider: string, id: string) =>
+					[largeModel, smallModel].find(m => m.provider === provider && m.id === id),
+			} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		// Pre-switch: discovery off, both MCP tools active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(false);
+		expect(session.getActiveToolNames()).toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).toContain("mcp__server__other");
+
+		// Persist a selection that includes only "other" (not "verbose").
+		sessionManager.appendMCPToolSelection(["mcp__server__other"]);
+
+		// Switch to small-context model: discovery upgrades.
+		await session.setModel(smallModel);
+
+		// Post-switch: discovery on, only the persisted selection is active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).toContain("mcp__server__other");
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
+
+	it("preserves persisted MCP selections when refreshMCPTools upgrades discovery", async () => {
+		// PRRT_kwDOQxs0bc6OET8e (refresh path): when discovery upgrades during
+		// refreshMCPTools and a persisted selection exists, seed
+		// #selectedMCPToolNames from the persisted selection instead of leaving
+		// it empty (which would fall back to configured defaults).
+		const model = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([[readTool.name, readTool]]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["initial"],
+				tools: [readTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		// Persist a selection that includes only "other" (not "verbose").
+		sessionManager.appendMCPToolSelection(["mcp__server__other"]);
+
+		// Refresh with a large-schema MCP tool that triggers discovery upgrade.
+		await session.refreshMCPTools([
+			createMcpCustomTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]),
+			createMcpCustomTool("mcp__server__other", "server", "other", "Other tool", ["query"]),
+		]);
+
+		// Discovery upgraded: verbose is hidden, but the persisted "other" is restored.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).toContain("mcp__server__other");
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
 });

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -15,6 +15,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { estimateMcpToolSchemaTokens } from "@oh-my-pi/pi-coding-agent/tool-discovery/mode";
 import type { OutputMeta } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
@@ -1741,5 +1742,254 @@ describe("AgentSession MCP discovery", () => {
 		expect(session.getActiveToolNames()).toContain("mcp__server__selected");
 		expect(session.getActiveToolNames()).not.toContain("mcp__server__other");
 		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
+
+	// ── PRRT_kwDOQxs0bc6OMvim: suppress persistence of default MCP selections ──
+	it("does not persist re-derivable default MCP selections on model-switch auto-upgrade", async () => {
+		// PRRT_kwDOQxs0bc6OMvim: when a session has mcp.discoveryDefaultServers
+		// but no persisted MCP selection, a context-share upgrade after a model
+		// switch must NOT write an mcp_tool_selection entry containing
+		// re-derivable defaults. Only truly-explicit selections (from
+		// --tools) should persist.
+		const largeModel = buildModel({
+			id: "large-ctx",
+			name: "large-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 2048,
+		});
+		const smallModel = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const verboseTool = createMcpTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]);
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[verboseTool.name, verboseTool],
+			[searchTool.name, searchTool],
+		]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model: largeModel,
+				systemPrompt: ["initial"],
+				tools: [readTool, verboseTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {
+				hasConfiguredAuth: () => true,
+				refreshSelectedModelMetadata: async (m: Model) => m,
+				getApiKey: async () => "key",
+				getAvailable: () => [largeModel, smallModel],
+				find: (provider: string, id: string) =>
+					[largeModel, smallModel].find(m => m.provider === provider && m.id === id),
+			} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			defaultSelectedMCPServerNames: ["server"],
+			defaultSelectedMCPToolNames: ["mcp__server__verbose"],
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		// Pre-switch: no persisted selection, discovery off.
+		expect(sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
+
+		// Switch to small-context model: discovery upgrades from defaults.
+		await session.setModel(smallModel);
+
+		// Post-switch: discovery is on, the default tool is active (re-derived
+		// from the setting), but NO mcp_tool_selection entry was persisted.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+		expect(sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
+	});
+
+	it("does not persist re-derivable default MCP selections on refreshMCPTools upgrade", async () => {
+		// PRRT_kwDOQxs0bc6OMvim (refresh path): same as model-switch but through
+		// refreshMCPTools. When discovery upgrades during a refresh and no
+		// persisted selection existed, defaults must not be frozen.
+		const model = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[searchTool.name, searchTool],
+		]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["initial"],
+				tools: [readTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			defaultSelectedMCPServerNames: ["server"],
+			defaultSelectedMCPToolNames: [],
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		// Pre-refresh: no persisted selection.
+		expect(sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
+
+		// Refresh with a large-description MCP tool that triggers the upgrade.
+		await session.refreshMCPTools([
+			createMcpCustomTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]),
+		]);
+
+		// Post-refresh: discovery on, default tool active, but no persisted entry.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+		expect(sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
+	});
+
+	// ── PRRT_kwDOQxs0bc6OMvis: keep explicit MCP tools across fresh sessions ──
+	it("preserves explicit MCP tools across /new when discovery is enabled", async () => {
+		// PRRT_kwDOQxs0bc6OMvis: when discovery is enabled and a session was
+		// started with an explicit MCP tool in options.toolNames, /new must
+		// preserve that tool in the next session. The non-persisted default
+		// list (#defaultSelectedMCPToolNames) only contains registry defaults;
+		// the explicit subset from #requestedToolNames must also seed the new
+		// session.
+		const readTool = createBasicTool("read", "Read");
+		const explicitTool = createMcpTool("mcp__explicit_tool", "explicit", "tool", "Explicit tool", ["query"]);
+		const defaultTool = createMcpTool("mcp__default_tool", "default", "tool", "Default tool", ["query"]);
+		const toolRegistry = new Map([
+			[readTool.name, readTool],
+			[explicitTool.name, explicitTool],
+			[defaultTool.name, defaultTool],
+		]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model: createModel(),
+				systemPrompt: ["initial"],
+				tools: [readTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "mcp.discoveryMode": true }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: true,
+			defaultSelectedMCPServerNames: ["default"],
+			requestedToolNames: new Set(["read", "mcp__explicit_tool"]),
+			initialSelectedMCPToolNames: ["mcp__explicit_tool", "mcp__default_tool"],
+			defaultSelectedMCPToolNames: ["mcp__default_tool"],
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+		});
+		sessions.push(session);
+
+		// Both explicit and default tools are active at startup.
+		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__explicit_tool", "mcp__default_tool"]);
+
+		// Start a fresh session: explicit tool must survive.
+		await session.newSession();
+
+		expect(session.getSelectedMCPToolNames()).toContain("mcp__explicit_tool");
+		expect(session.getSelectedMCPToolNames()).toContain("mcp__default_tool");
+		expect(session.getActiveToolNames()).toContain("mcp__explicit_tool");
+		expect(session.getActiveToolNames()).toContain("mcp__default_tool");
+	});
+});
+
+// ── PRRT_kwDOQxs0bc6OMvip: token accounting for MCP schema estimates ──────
+describe("estimateMcpToolSchemaTokens", () => {
+	it("uses byte-based token counting, not UTF-16 char length / 4", () => {
+		// PRRT_kwDOQxs0bc6OMvip: the estimator must use the same token
+		// accounting as the context-usage path (countTokens, which divides
+		// UTF-8 byte length by 4), not the old estimateTokens helper (which
+		// divided UTF-16 char length by 4). For CJK text, UTF-8 uses 3 bytes
+		// per character vs 1 UTF-16 code unit, so the old heuristic
+		// undercounted by roughly 3x.
+		const cjkDescription = "データベースを検索するツール".repeat(50);
+		const tool = {
+			name: "mcp__server__search",
+			description: cjkDescription,
+			parameters: { type: "object", properties: {} },
+		};
+		const tokens = estimateMcpToolSchemaTokens([tool]);
+		// countTokens uses (Buffer.byteLength(text, "utf-8") + 3) >> 2.
+		// The old estimateTokens used Math.ceil(text.length / 4).
+		// For CJK: byteLength ≈ 3 × charLength, so the new estimate should
+		// be roughly 3x the old one. Verify it's at least 2x the old
+		// heuristic to confirm byte-based counting is in use.
+		const oldHeuristic = Math.ceil(`${tool.name}${cjkDescription}{"type":"object","properties":{}}`.length / 4);
+		expect(tokens).toBeGreaterThan(oldHeuristic * 2);
+	});
+
+	it("counts name, description, and parameters in the schema cost", () => {
+		// Verify the estimator covers all three parts of the tool definition
+		// by isolating each contribution: name < name+description < name+description+parameters.
+		const nameOnlyTool = {
+			name: "mcp__server__tool",
+			description: "",
+			parameters: {},
+		};
+		const describedTool = {
+			...nameOnlyTool,
+			description: "A".repeat(100),
+		};
+		const parameterizedTool = {
+			...describedTool,
+			parameters: { type: "object", properties: { query: { type: "string" }, filter: { type: "string" } } },
+		};
+		const nameTokens = estimateMcpToolSchemaTokens([nameOnlyTool]);
+		const descTokens = estimateMcpToolSchemaTokens([describedTool]);
+		const paramTokens = estimateMcpToolSchemaTokens([parameterizedTool]);
+		expect(nameTokens).toBeGreaterThan(0);
+		expect(descTokens).toBeGreaterThan(nameTokens);
+		expect(paramTokens).toBeGreaterThan(descTokens);
 	});
 });

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -872,13 +872,16 @@ describe("AgentSession MCP discovery", () => {
 
 		await session.newSession();
 
+		// PRRT_kwDOQxs0bc6ON-xX: re-derivable default MCP selections are NOT
+		// persisted during /new — only truly-explicit selections (from
+		// options.toolNames) persist. The defaults remain active (re-derived
+		// from #defaultSelectedMCPToolNames), but no mcp_tool_selection entry
+		// is written, so later changes to mcp.discoveryDefaultServers still
+		// apply to this session.
 		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__docs_search", "mcp__slack_send_message"]);
 		expect(session.getActiveToolNames()).toEqual(["read", "mcp__docs_search", "mcp__slack_send_message"]);
 		expect(session.systemPrompt).toEqual(["tools:read,mcp__docs_search,mcp__slack_send_message"]);
-		expect(sessionManager.buildSessionContext().selectedMCPToolNames).toEqual([
-			"mcp__docs_search",
-			"mcp__slack_send_message",
-		]);
+		expect(sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(false);
 	});
 
 	it("clears discovered MCP selections when starting a brand-new session", async () => {
@@ -1430,6 +1433,7 @@ describe("AgentSession MCP discovery", () => {
 			mcpDiscoveryEnabled: true,
 			defaultSelectedMCPServerNames: ["default"],
 			requestedToolNames: new Set(["read", "mcp__explicit_tool"]),
+			explicitlyRequestedMCPToolNames: ["mcp__explicit_tool"],
 			// Simulate what the SDK passes: initialSelectedMCPToolNames includes
 			// both explicit and default tools so both are active at startup.
 			initialSelectedMCPToolNames: ["mcp__explicit_tool", "mcp__default_tool"],
@@ -1491,8 +1495,8 @@ describe("AgentSession MCP discovery", () => {
 			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
 			modelRegistry: {} as never,
 			toolRegistry,
-			mcpDiscoveryEnabled: false,
 			requestedToolNames: new Set(["read", "mcp__server__explicit"]),
+			explicitlyRequestedMCPToolNames: ["mcp__server__explicit"],
 			rebuildSystemPrompt: async toolNames => ({
 				systemPrompt: [`tools:${toolNames.join(",")}`],
 			}),
@@ -1582,6 +1586,7 @@ describe("AgentSession MCP discovery", () => {
 			toolRegistry,
 			mcpDiscoveryEnabled: false,
 			requestedToolNames: new Set(["read", "mcp__server__explicit"]),
+			explicitlyRequestedMCPToolNames: ["mcp__server__explicit"],
 			rebuildSystemPrompt: async toolNames => ({
 				systemPrompt: [`tools:${toolNames.join(",")}`],
 			}),
@@ -1923,6 +1928,7 @@ describe("AgentSession MCP discovery", () => {
 			mcpDiscoveryEnabled: true,
 			defaultSelectedMCPServerNames: ["default"],
 			requestedToolNames: new Set(["read", "mcp__explicit_tool"]),
+			explicitlyRequestedMCPToolNames: ["mcp__explicit_tool"],
 			initialSelectedMCPToolNames: ["mcp__explicit_tool", "mcp__default_tool"],
 			defaultSelectedMCPToolNames: ["mcp__default_tool"],
 			rebuildSystemPrompt: async toolNames => ({

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -863,8 +863,11 @@ describe("AgentSession MCP discovery", () => {
 			]),
 		]);
 
-		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__docs_search"]);
-		expect(session.getActiveToolNames()).toEqual(["read", "mcp__docs_search"]);
+		// PRRT_kwDOQxs0bc6OL1Nr: registry-default tools are NOT persisted as
+		// explicit selections, so after refresh both defaults re-derive (the
+		// outage resolved — both are now available, both are defaults).
+		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__docs_search", "mcp__slack_send_message"]);
+		expect(session.getActiveToolNames()).toEqual(["read", "mcp__docs_search", "mcp__slack_send_message"]);
 
 		await session.newSession();
 
@@ -1395,7 +1398,127 @@ describe("AgentSession MCP discovery", () => {
 		expect(session.getActiveToolNames()).toContain("mcp__server__other");
 		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
 	});
+	it("persists only explicit MCP toolNames, not registry defaults", async () => {
+		// PRRT_kwDOQxs0bc6OL1Nr: when a session starts with both explicit
+		// `--tools mcp__explicit_tool` and registry-default server tools, only
+		// the explicit tool should be persisted. The default remains
+		// re-derivable from the setting.
+		const readTool = createBasicTool("read", "Read");
+		const explicitTool = createMcpTool("mcp__explicit_tool", "explicit", "tool", "Explicit tool", ["query"]);
+		const defaultTool = createMcpTool("mcp__default_tool", "default", "tool", "Default tool", ["query"]);
+		const toolRegistry = new Map([
+			[readTool.name, readTool],
+			[explicitTool.name, explicitTool],
+			[defaultTool.name, defaultTool],
+		]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model: createModel(),
+				systemPrompt: ["initial"],
+				tools: [readTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "mcp.discoveryMode": true }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: true,
+			defaultSelectedMCPServerNames: ["default"],
+			requestedToolNames: new Set(["read", "mcp__explicit_tool"]),
+			// Simulate what the SDK passes: initialSelectedMCPToolNames includes
+			// both explicit and default tools so both are active at startup.
+			initialSelectedMCPToolNames: ["mcp__explicit_tool", "mcp__default_tool"],
+			defaultSelectedMCPToolNames: ["mcp__default_tool"],
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+		});
+		sessions.push(session);
 
+		// Both explicit and default tools are active at startup.
+		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__explicit_tool", "mcp__default_tool"]);
+
+		// But only the explicit tool is persisted — defaults are re-derivable
+		// from the setting and must NOT be frozen into the persisted selection.
+		expect(sessionManager.buildSessionContext().hasPersistedMCPToolSelection).toBe(true);
+		expect(sessionManager.buildSessionContext().selectedMCPToolNames).toEqual(["mcp__explicit_tool"]);
+	});
+
+	it("preserves explicit MCP selections when refreshMCPTools upgrades discovery", async () => {
+		// PRRT_kwDOQxs0bc6OL1Nx: when refreshMCPTools first upgrades discovery
+		// (from off to on), the explicit/current MCP selections from
+		// `previousSelectedMCPToolNames` must be preserved — not only persisted
+		// selections. A session with discovery off has active MCP tools that
+		// were explicitly requested; the upgrade must not drop them.
+		const model = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const explicitTool = createMcpTool("mcp__server__explicit", "server", "explicit", "Explicit tool", ["query"]);
+		const verboseTool = createMcpTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]);
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[explicitTool.name, explicitTool],
+			[verboseTool.name, verboseTool],
+		]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["initial"],
+				tools: [readTool, explicitTool, verboseTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			requestedToolNames: new Set(["read", "mcp__server__explicit"]),
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		// Pre-refresh: discovery off, both MCP tools active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(false);
+		expect(session.getActiveToolNames()).toContain("mcp__server__explicit");
+		expect(session.getActiveToolNames()).toContain("mcp__server__verbose");
+
+		// Refresh with large-schema tools that triggers discovery upgrade.
+		await session.refreshMCPTools([
+			createMcpCustomTool("mcp__server__explicit", "server", "explicit", "Explicit tool", ["query"]),
+			createMcpCustomTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]),
+		]);
+
+		// Post-refresh: discovery upgraded. The verbose tool is hidden behind
+		// search, but the explicit tool survives because
+		// `previousSelectedMCPToolNames` (captured before the refresh) is
+		// unioned into #selectedMCPToolNames — not only persisted selections.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).toContain("mcp__server__explicit");
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
 	it("preserves explicit MCP selections on model-switch discovery upgrade", async () => {
 		// PRRT_kwDOQxs0bc6OKqnN: when a session starts with discovery off on a
 		// large-context model but has an explicit MCP tool selected via

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -1069,4 +1069,85 @@ describe("AgentSession MCP discovery", () => {
 		expect(meta?.truncation).toBeDefined();
 		expect(meta?.truncation?.artifactId).toBeUndefined();
 	});
+
+	it("enables MCP discovery after model switch shrinks context window past the schema-cost threshold", async () => {
+		// Start on a large-context model where MCP schemas are below the
+		// discoveryContextShare threshold → discovery stays off, all MCP tools
+		// are active.
+		const largeModel = buildModel({
+			id: "large-ctx",
+			name: "large-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 2048,
+		});
+		const smallModel = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		// MCP tool with a large description so its schema cost exceeds the
+		// threshold on the small model but not the large one.
+		const bigDescTool = createMcpTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]);
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[bigDescTool.name, bigDescTool],
+			[searchTool.name, searchTool],
+		]);
+		const agent = new Agent({
+			initialState: {
+				model: largeModel,
+				systemPrompt: ["initial"],
+				tools: [readTool, bigDescTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {
+				hasConfiguredAuth: () => true,
+				refreshSelectedModelMetadata: async (m: Model) => m,
+				getApiKey: async () => "key",
+				getAvailable: () => [largeModel, smallModel],
+				find: (provider: string, id: string) =>
+					[largeModel, smallModel].find(m => m.provider === provider && m.id === id),
+			} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		// Pre-switch: discovery is off, MCP tool is active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(false);
+		expect(session.getActiveToolNames()).toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).not.toContain("search_tool_bm25");
+
+		// Switch to the small-context model: schema cost now exceeds 0.1 * 5000 = 500.
+		await session.setModel(smallModel);
+
+		// Post-switch: discovery should be enabled, MCP tool hidden, search tool active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
 });

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -1395,4 +1395,228 @@ describe("AgentSession MCP discovery", () => {
 		expect(session.getActiveToolNames()).toContain("mcp__server__other");
 		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
 	});
+
+	it("preserves explicit MCP selections on model-switch discovery upgrade", async () => {
+		// PRRT_kwDOQxs0bc6OKqnN: when a session starts with discovery off on a
+		// large-context model but has an explicit MCP tool selected via
+		// --tools, that selection is not persisted. Switching to a smaller model
+		// upgrades discovery; the explicit MCP tool must survive the upgrade.
+		const largeModel = buildModel({
+			id: "large-ctx",
+			name: "large-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 2048,
+		});
+		const smallModel = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const verboseTool = createMcpTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]);
+		const explicitTool = createMcpTool("mcp__server__explicit", "server", "explicit", "Explicit tool", ["query"]);
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[verboseTool.name, verboseTool],
+			[explicitTool.name, explicitTool],
+			[searchTool.name, searchTool],
+		]);
+		const agent = new Agent({
+			initialState: {
+				model: largeModel,
+				systemPrompt: ["initial"],
+				tools: [readTool, verboseTool, explicitTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {
+				hasConfiguredAuth: () => true,
+				refreshSelectedModelMetadata: async (m: Model) => m,
+				getApiKey: async () => "key",
+				getAvailable: () => [largeModel, smallModel],
+				find: (provider: string, id: string) =>
+					[largeModel, smallModel].find(m => m.provider === provider && m.id === id),
+			} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			requestedToolNames: new Set(["read", "mcp__server__explicit"]),
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		// Pre-switch: discovery off, both MCP tools active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(false);
+		expect(session.getActiveToolNames()).toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).toContain("mcp__server__explicit");
+
+		// Switch to small-context model: discovery upgrades.
+		await session.setModel(smallModel);
+
+		// Post-switch: discovery on, verbose hidden behind search, but explicit
+		// tool preserved because it was explicitly requested.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).toContain("mcp__server__explicit");
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
+
+	it("keeps discovery off when search tool cannot be registered", async () => {
+		// PRRT_kwDOQxs0bc6OKqnP: registerSearchTool is optional and may return
+		// null. When it cannot produce search_tool_bm25, a context-share
+		// upgrade must keep discovery off so MCP tools remain visible and
+		// callable.
+		const largeModel = buildModel({
+			id: "large-ctx",
+			name: "large-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 2048,
+		});
+		const smallModel = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const bigDescTool = createMcpTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"]);
+		const readTool = createBasicTool("read", "Read");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[bigDescTool.name, bigDescTool],
+		]);
+		const agent = new Agent({
+			initialState: {
+				model: largeModel,
+				systemPrompt: ["initial"],
+				tools: [readTool, bigDescTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {
+				hasConfiguredAuth: () => true,
+				refreshSelectedModelMetadata: async (m: Model) => m,
+				getApiKey: async () => "key",
+				getAvailable: () => [largeModel, smallModel],
+				find: (provider: string, id: string) =>
+					[largeModel, smallModel].find(m => m.provider === provider && m.id === id),
+			} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			// No registerSearchTool — discovery cannot provide BM25 search.
+		});
+		sessions.push(session);
+
+		// Pre-switch: discovery off, MCP tool active.
+		expect(session.isMCPDiscoveryEnabled()).toBe(false);
+		expect(session.getActiveToolNames()).toContain("mcp__server__verbose");
+
+		// Switch to small-context model: threshold exceeded, but no search tool.
+		await session.setModel(smallModel);
+
+		// Discovery must stay off — MCP tools remain visible and callable.
+		expect(session.isMCPDiscoveryEnabled()).toBe(false);
+		expect(session.getActiveToolNames()).toContain("mcp__server__verbose");
+		expect(session.getActiveToolNames()).not.toContain("search_tool_bm25");
+	});
+
+	it("restores persisted MCP selections when enableMCPDiscovery precedes refreshMCPTools", async () => {
+		// PRRT_kwDOQxs0bc6OKqnS: deferred-UI startup calls enableMCPDiscovery()
+		// before refreshMCPTools(). Persisted MCP selections that were only
+		// active as pending placeholders must be restored when the real tools
+		// load, not hidden behind search.
+		const model = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[searchTool.name, searchTool],
+		]);
+		const sessionManager = SessionManager.inMemory();
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["initial"],
+				tools: [readTool, searchTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "mcp.discoveryMode": true }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+		});
+		sessions.push(session);
+
+		// Persist an MCP selection (simulating a resumed session).
+		sessionManager.appendMCPToolSelection(["mcp__server__selected"]);
+
+		// Deferred startup: enable discovery externally, then load real tools.
+		session.enableMCPDiscovery();
+		await session.refreshMCPTools([
+			createMcpCustomTool("mcp__server__selected", "server", "selected", "Selected tool", ["query"]),
+			createMcpCustomTool("mcp__server__other", "server", "other", "Other tool", ["query"]),
+		]);
+
+		// The persisted selection must be restored, not hidden behind search.
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).toContain("mcp__server__selected");
+		expect(session.getActiveToolNames()).not.toContain("mcp__server__other");
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+	});
 });

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -1150,4 +1150,55 @@ describe("AgentSession MCP discovery", () => {
 		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
 		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
 	});
+
+	it("enables MCP discovery when refreshed MCP tools exceed the context-share threshold", async () => {
+		const model = buildModel({
+			id: "small-ctx",
+			name: "small-ctx",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 5_000,
+			maxTokens: 2048,
+		});
+		const readTool = createBasicTool("read", "Read");
+		const searchTool = createBasicTool("search_tool_bm25", "Search BM25");
+		const toolRegistry = new Map<string, AgentTool>([[readTool.name, readTool]]);
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["initial"],
+				tools: [readTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryContextShare": 0.1 }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+			registerSearchTool: () => searchTool,
+		});
+		sessions.push(session);
+
+		expect(session.isMCPDiscoveryEnabled()).toBe(false);
+		expect(session.getActiveToolNames()).toEqual(["read"]);
+
+		await session.refreshMCPTools(
+			[createMcpCustomTool("mcp__server__verbose", "server", "verbose", "V".repeat(4000), ["query"])],
+			{ activateAll: true },
+		);
+
+		expect(session.isMCPDiscoveryEnabled()).toBe(true);
+		expect(session.getActiveToolNames()).toContain("search_tool_bm25");
+		expect(session.getActiveToolNames()).not.toContain("mcp__server__verbose");
+	});
 });

--- a/packages/coding-agent/test/tool-discovery/subagent.test.ts
+++ b/packages/coding-agent/test/tool-discovery/subagent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
+	estimateMcpToolSchemaTokens,
 	resolveEffectiveToolDiscoveryMode,
 	TOOL_DISCOVERY_AUTO_THRESHOLD,
 	type ToolDiscoveryContextEstimate,
@@ -79,5 +80,129 @@ describe("effective discovery mode resolution", () => {
 	it("does not trigger context-share flip if contextWindow is zero", () => {
 		const s = Settings.isolated({ "tools.discoveryContextShare": 0.5 });
 		expect(resolveEffectiveMode(s, 1, { mcpSchemaTokens: 501, contextWindow: 0 })).toBe("off");
+	});
+});
+
+// ─── MCP schema-cost estimate tests ───────────────────────────────────────────
+// Verify that the estimate includes the full tool definition (name, description,
+// parameters), not just parameters — so large descriptions tip the threshold.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("estimateMcpToolSchemaTokens", () => {
+	it("counts name and description, not just parameters", () => {
+		const emptyParams = { type: "object", properties: {} };
+		const minimal = estimateMcpToolSchemaTokens([{ name: "a", description: "", parameters: emptyParams }]);
+		const withDescription = estimateMcpToolSchemaTokens([
+			{ name: "a", description: "A".repeat(2000), parameters: emptyParams },
+		]);
+		expect(withDescription).toBeGreaterThan(minimal);
+		// A 2000-char description should add a meaningful token count, not ~0.
+		expect(withDescription - minimal).toBeGreaterThan(50);
+	});
+
+	it("large descriptions tip the estimate past the threshold even with tiny parameters", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0.1 });
+		const tinyParams = { type: "object", properties: {} };
+		// A tool with a very large description but minimal parameters.
+		const tools = [
+			{
+				name: "mcp__server__big_desc",
+				description: "X".repeat(8000),
+				parameters: tinyParams,
+			},
+		];
+		const schemaTokens = estimateMcpToolSchemaTokens(tools);
+		// With a 10_000-token context window and 0.1 share, the threshold is 1000.
+		// The 8000-char description alone should exceed that.
+		expect(schemaTokens).toBeGreaterThan(1000);
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: schemaTokens, contextWindow: 10_000 })).toBe(
+			"mcp-only",
+		);
+		// The same tool with an empty description should stay well below.
+		const emptyDescTokens = estimateMcpToolSchemaTokens([
+			{ name: "mcp__server__big_desc", description: "", parameters: tinyParams },
+		]);
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: emptyDescTokens, contextWindow: 10_000 })).toBe(
+			"off",
+		);
+	});
+
+	it("handles missing fields gracefully", () => {
+		expect(estimateMcpToolSchemaTokens([{}])).toBeGreaterThanOrEqual(0);
+		expect(estimateMcpToolSchemaTokens([])).toBe(0);
+		// Undefined parameters should not throw.
+		expect(estimateMcpToolSchemaTokens([{ name: "x", description: "y" }])).toBeGreaterThan(0);
+	});
+
+	it("does not serialize runtime-only fields", () => {
+		// Tools may carry execute functions and other runtime fields that are
+		// NOT part of the wire schema. The estimate should not be affected by them.
+		const baseTokens = estimateMcpToolSchemaTokens([
+			{ name: "a", description: "desc", parameters: { type: "object" } },
+		]);
+		const withRuntime = estimateMcpToolSchemaTokens([
+			{
+				name: "a",
+				description: "desc",
+				parameters: { type: "object" },
+				// @ts-expect-error — runtime fields not in the type
+				execute: () => {},
+				label: "runtime label",
+			},
+		]);
+		expect(withRuntime).toBe(baseTokens);
+	});
+});
+
+// ─── Model-switch recomputation tests ────────────────────────────────────────
+// Verify that the context-share threshold is re-evaluated when the context
+// window changes (model switch), so MCP tools are hidden/exposed consistently.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("model-switch discovery recomputation", () => {
+	it("mode flips to mcp-only when switching to a smaller context window", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0.5 });
+		const schemaTokens = 600; // 600 tokens of MCP schema
+		// Large context window: 600 < 0.5 * 10_000 = 5_000 → off
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: schemaTokens, contextWindow: 10_000 })).toBe(
+			"off",
+		);
+		// Switch to small context window: 600 > 0.5 * 1_000 = 500 → mcp-only
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: schemaTokens, contextWindow: 1_000 })).toBe(
+			"mcp-only",
+		);
+	});
+
+	it("mode reverts to off when switching to a larger context window", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0.5 });
+		const schemaTokens = 600;
+		// Small context: mcp-only
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: schemaTokens, contextWindow: 1_000 })).toBe(
+			"mcp-only",
+		);
+		// Large context: off
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: schemaTokens, contextWindow: 10_000 })).toBe(
+			"off",
+		);
+	});
+
+	it("large descriptions cause mode flip on model switch even with tiny parameters", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0.1 });
+		const tools = [
+			{
+				name: "mcp__server__verbose",
+				description: "D".repeat(5000),
+				parameters: { type: "object", properties: {} },
+			},
+		];
+		const schemaTokens = estimateMcpToolSchemaTokens(tools);
+		// Large context: below threshold → off
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: schemaTokens, contextWindow: 100_000 })).toBe(
+			"off",
+		);
+		// Small context: above threshold → mcp-only
+		expect(resolveEffectiveToolDiscoveryMode(s, 1, { mcpSchemaTokens: schemaTokens, contextWindow: 5_000 })).toBe(
+			"mcp-only",
+		);
 	});
 });

--- a/packages/coding-agent/test/tool-discovery/subagent.test.ts
+++ b/packages/coding-agent/test/tool-discovery/subagent.test.ts
@@ -3,6 +3,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	resolveEffectiveToolDiscoveryMode,
 	TOOL_DISCOVERY_AUTO_THRESHOLD,
+	type ToolDiscoveryContextEstimate,
 } from "@oh-my-pi/pi-coding-agent/tool-discovery/mode";
 
 // ─── Subagent discovery mode inheritance tests ────────────────────────────────
@@ -11,8 +12,12 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("effective discovery mode resolution", () => {
-	function resolveEffectiveMode(settings: Settings, toolCount = 0): "off" | "mcp-only" | "all" {
-		return resolveEffectiveToolDiscoveryMode(settings, toolCount);
+	function resolveEffectiveMode(
+		settings: Settings,
+		toolCount = 0,
+		contextEstimate?: ToolDiscoveryContextEstimate,
+	): "off" | "mcp-only" | "all" {
+		return resolveEffectiveToolDiscoveryMode(settings, toolCount, contextEstimate);
 	}
 
 	it("tools.discoveryMode=all beats mcp.discoveryMode=false", () => {
@@ -44,5 +49,35 @@ describe("effective discovery mode resolution", () => {
 	it("default auto settings enable mcp-only above the threshold", () => {
 		const s = Settings.isolated({});
 		expect(resolveEffectiveMode(s, TOOL_DISCOVERY_AUTO_THRESHOLD + 1)).toBe("mcp-only");
+	});
+
+	it("auto enables mcp-only when MCP schemas exceed the configured context share", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0.5 });
+		expect(resolveEffectiveMode(s, 1, { mcpSchemaTokens: 501, contextWindow: 1000 })).toBe("mcp-only");
+	});
+
+	it("auto count trigger remains active when context share is disabled", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0 });
+		expect(
+			resolveEffectiveMode(s, TOOL_DISCOVERY_AUTO_THRESHOLD + 1, { mcpSchemaTokens: 0, contextWindow: 1000 }),
+		).toBe("mcp-only");
+	});
+
+	it("zero discoveryContextShare disables the context-share trigger", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0 });
+		expect(resolveEffectiveMode(s, 1, { mcpSchemaTokens: 501, contextWindow: 1000 })).toBe("off");
+	});
+
+	it("explicit all and mcp-only beat the context-share trigger", () => {
+		const contextEstimate = { mcpSchemaTokens: 501, contextWindow: 1000 };
+		expect(resolveEffectiveMode(Settings.isolated({ "tools.discoveryMode": "all" }), 1, contextEstimate)).toBe("all");
+		expect(resolveEffectiveMode(Settings.isolated({ "tools.discoveryMode": "mcp-only" }), 1, contextEstimate)).toBe(
+			"mcp-only",
+		);
+	});
+
+	it("does not trigger context-share flip if contextWindow is zero", () => {
+		const s = Settings.isolated({ "tools.discoveryContextShare": 0.5 });
+		expect(resolveEffectiveMode(s, 1, { mcpSchemaTokens: 501, contextWindow: 0 })).toBe("off");
 	});
 });


### PR DESCRIPTION
## What
Extends MCP tool-discovery auto mode to hide MCP schemas when their estimated token cost exceeds a configured share of model context.

## Verification
Verified after rebasing onto current upstream/main: `bun check`; coding-agent targeted tests (147 pass); `cargo clippy --workspace --all-targets` (1 pre-existing warning); `cargo test --workspace` (1176 pass); robomp targeted tests (165 pass); scoped ruff checks for changed Python files.

Closes #4365
