### PR TITLE
refactor(crates): clean up first-party Rust crates

### DIFF
--- a/crates/pi-ast/src/ops.rs
+++ b/crates/pi-ast/src/ops.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use ast_grep_core::{
-	MatchStrictness, Position,
+	MatchStrictness,
 	matcher::{Pattern, PatternError},
 	source::Edit,
-	tree_sitter::{LanguageExt, StrDoc},
+	tree_sitter::LanguageExt,
 };
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
@@ -148,11 +148,12 @@ pub fn collect_matches(source: &str, language: SupportLang, patterns: &[Pattern]
 			let start = matched.start_pos();
 			let end = matched.end_pos();
 			let range = matched.range();
+			let node = matched.get_node();
 			matches.push(AstMatch {
 				line:       start.line() + 1,
-				column:     char_column(start, matched.get_node()) + 1,
+				column:     start.column(node) + 1,
 				end_line:   end.line() + 1,
-				end_column: char_column(end, matched.get_node()) + 1,
+				end_column: end.column(node) + 1,
 				byte_start: range.start,
 				byte_end:   range.end,
 				text:       matched.text().into_owned(),
@@ -204,9 +205,9 @@ pub fn apply_edits(content: &str, edits: &[Edit<String>]) -> Result<String> {
 		if end > output.len() || start > end {
 			return Err(anyhow!("Computed edit range is out of bounds"));
 		}
-		let replacement = String::from_utf8(edit.inserted_text.clone())
+		let replacement = std::str::from_utf8(&edit.inserted_text)
 			.map_err(|err| anyhow!("Replacement text is not valid UTF-8: {err}"))?;
-		output.replace_range(start..end, &replacement);
+		output.replace_range(start..end, replacement);
 	}
 	Ok(output)
 }
@@ -266,10 +267,6 @@ fn build_globset(patterns: &[String]) -> Result<GlobSet, std::io::Error> {
 #[must_use]
 pub fn has_glob_syntax(pattern: &str) -> bool {
 	pattern.contains('*') || pattern.contains('?') || pattern.contains('[')
-}
-
-fn char_column(position: Position, node: &ast_grep_core::Node<'_, StrDoc<SupportLang>>) -> usize {
-	position.column(node)
 }
 
 fn compile_rust_contextual_pattern(pattern: &str) -> Option<Pattern> {

--- a/crates/pi-iso/src/btrfs.rs
+++ b/crates/pi-iso/src/btrfs.rs
@@ -220,15 +220,17 @@ mod imp {
 	}
 
 	fn command_message(stderr: &[u8], stdout: &[u8]) -> String {
-		let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+		let stderr = String::from_utf8_lossy(stderr);
+		let stderr = stderr.trim();
 		if !stderr.is_empty() {
-			return stderr;
+			return stderr.to_owned();
 		}
-		let stdout = String::from_utf8_lossy(stdout).trim().to_string();
+		let stdout = String::from_utf8_lossy(stdout);
+		let stdout = stdout.trim();
 		if stdout.is_empty() {
 			"no command output".to_string()
 		} else {
-			stdout
+			stdout.to_owned()
 		}
 	}
 

--- a/crates/pi-iso/src/diff.rs
+++ b/crates/pi-iso/src/diff.rs
@@ -150,7 +150,8 @@ const fn git_null_path() -> &'static str {
 async fn git_run(cwd: &Path, args: &[&str]) -> IsoResult<Vec<u8>> {
 	let output = git_spawn(cwd, args).await?;
 	if !output.status.success() {
-		let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+		let stderr = String::from_utf8_lossy(&output.stderr);
+		let stderr = stderr.trim();
 		return Err(IsoError::other(format!(
 			"git {} (exit {}): {stderr}",
 			args.join(" "),
@@ -170,7 +171,8 @@ async fn git_run_allow_exit1(cwd: &Path, args: &[&str]) -> IsoResult<Vec<u8>> {
 	if output.status.success() || output.status.code() == Some(1) {
 		return Ok(output.stdout);
 	}
-	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	let stderr = stderr.trim();
 	Err(IsoError::other(format!(
 		"git {} (exit {}): {stderr}",
 		args.join(" "),

--- a/crates/pi-iso/src/overlayfs.rs
+++ b/crates/pi-iso/src/overlayfs.rs
@@ -138,16 +138,12 @@ mod imp {
 
 		match kernel_mount(&merged, &opts) {
 			Ok(()) => {
-				ACTIVE_MOUNTS
-					.lock()
-					.insert(merged.clone(), MountFlavor::Kernel);
+				ACTIVE_MOUNTS.lock().insert(merged, MountFlavor::Kernel);
 				Ok(())
 			},
 			Err(err) if err.is_unavailable() => {
 				fuse_mount(&lower, &upper, &work, &merged)?;
-				ACTIVE_MOUNTS
-					.lock()
-					.insert(merged.clone(), MountFlavor::Fuse);
+				ACTIVE_MOUNTS.lock().insert(merged, MountFlavor::Fuse);
 				Ok(())
 			},
 			Err(err) => Err(err),

--- a/crates/pi-iso/src/rcopy.rs
+++ b/crates/pi-iso/src/rcopy.rs
@@ -140,7 +140,8 @@ fn git_worktree_add(lower: &Path, merged: &Path) -> IsoResult<()> {
 	if output.status.success() {
 		return Ok(());
 	}
-	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	let stderr = stderr.trim();
 	Err(IsoError::other(format!(
 		"git worktree add (exit {}): {stderr}",
 		output.status.code().unwrap_or(-1)
@@ -161,7 +162,8 @@ fn git_worktree_remove(merged: &Path) -> IsoResult<()> {
 	if output.status.success() {
 		return Ok(());
 	}
-	let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+	let stderr = String::from_utf8_lossy(&output.stderr);
+	let stderr = stderr.trim();
 	Err(IsoError::other(format!(
 		"git worktree remove (exit {}): {stderr}",
 		output.status.code().unwrap_or(-1)
@@ -234,7 +236,8 @@ fn git_capture(cwd: &Path, args: &[&str]) -> IsoResult<Vec<u8>> {
 			}
 		})?;
 	if !output.status.success() {
-		let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+		let stderr = String::from_utf8_lossy(&output.stderr);
+		let stderr = stderr.trim();
 		return Err(IsoError::other(format!(
 			"git {} (exit {}): {stderr}",
 			args.join(" "),
@@ -304,7 +307,8 @@ fn git_apply_with_program(
 		write_result.map_err(|err| IsoError::other(format!("write patch to git apply: {err}")))?;
 		return Ok(());
 	}
-	let stderr = String::from_utf8_lossy(&stderr).trim().to_string();
+	let stderr = String::from_utf8_lossy(&stderr);
+	let stderr = stderr.trim();
 	Err(IsoError::other(format!("git apply (exit {}): {stderr}", status.code().unwrap_or(-1))))
 }
 
@@ -422,7 +426,7 @@ fn filetime_set(path: &Path, mtime: std::time::SystemTime) -> std::io::Result<()
 	use std::os::unix::ffi::OsStrExt;
 	let dur = mtime
 		.duration_since(std::time::UNIX_EPOCH)
-		.map_err(|err| std::io::Error::other(err.to_string()))?;
+		.map_err(std::io::Error::other)?;
 	let times =
 		[libc::timespec { tv_sec: dur.as_secs() as libc::time_t, tv_nsec: 0 }, libc::timespec {
 			tv_sec:  dur.as_secs() as libc::time_t,

--- a/crates/pi-natives/src/ast.rs
+++ b/crates/pi-natives/src/ast.rs
@@ -543,8 +543,9 @@ fn normalize_pattern_list(patterns: Option<Vec<String>>) -> Result<Vec<String>> 
 		if pattern.is_empty() {
 			continue;
 		}
-		if seen.insert(pattern.to_string()) {
-			normalized.push(pattern.to_string());
+		let owned = pattern.to_string();
+		if seen.insert(owned.clone()) {
+			normalized.push(owned);
 		}
 	}
 	if normalized.is_empty() {

--- a/crates/pi-shell/src/minimizer.rs
+++ b/crates/pi-shell/src/minimizer.rs
@@ -42,7 +42,6 @@ pub struct MinimizerOutput {
 	/// Byte length of the captured buffer before minimization.
 	pub input_bytes:   usize,
 	/// Byte length of `text` after minimization.
-	#[allow(dead_code, reason = "test-only API surface")]
 	pub output_bytes:  usize,
 	/// Label for the dispatch path that produced this output (e.g. `"git"`,
 	/// `"pipeline:gradle"`, or `"passthrough"`). For non-rewrite misses, this
@@ -111,7 +110,6 @@ impl MinimizerOutput {
 	}
 
 	/// Byte count saved by this filter (0 for passthrough).
-	#[allow(dead_code, reason = "test-only API surface")]
 	#[must_use]
 	pub const fn bytes_saved(&self) -> usize {
 		self.input_bytes.saturating_sub(self.output_bytes)

--- a/crates/pi-shell/src/minimizer/engine.rs
+++ b/crates/pi-shell/src/minimizer/engine.rs
@@ -62,7 +62,6 @@ pub fn mode_for(command: &str, config: &MinimizerConfig) -> MinimizerMode {
 }
 
 /// Return true when the command should be captured for minimization.
-#[allow(dead_code, reason = "test-only API surface")]
 #[must_use]
 pub fn should_minimize(command: &str, config: &MinimizerConfig) -> bool {
 	!matches!(mode_for(command, config), MinimizerMode::None)
@@ -484,14 +483,12 @@ fn record_unknown_command(_command: &str) {
 
 /// Total number of commands that fell through `apply` without any matching
 /// filter. Useful for a "coverage gap" indicator in telemetry dashboards.
-#[allow(dead_code, reason = "test-only API surface")]
 pub fn unknown_command_count() -> u64 {
 	UNKNOWN_COMMAND_COUNT.load(Ordering::Relaxed)
 }
 
 /// Reset the unknown-command counter (intended for tests).
 #[doc(hidden)]
-#[allow(dead_code, reason = "test-only API surface")]
 pub fn reset_unknown_command_count() {
 	UNKNOWN_COMMAND_COUNT.store(0, Ordering::Relaxed);
 }
@@ -512,7 +509,6 @@ fn builtin_pipelines() -> &'static PipelineRegistry {
 }
 
 /// Expose the built-in registry's inline tests for the verify CLI surface.
-#[allow(dead_code, reason = "test-only API surface")]
 #[must_use]
 pub fn verify_builtin_filters() -> Vec<pipeline::TestOutcome> {
 	pipeline::run_tests(builtin_pipelines())

--- a/crates/pi-shell/src/minimizer/pipeline.rs
+++ b/crates/pi-shell/src/minimizer/pipeline.rs
@@ -95,7 +95,6 @@ pub struct MatchOutputDef {
 /// `[[tests.NAME]]`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-#[allow(dead_code, reason = "test-only API surface")]
 pub struct PipelineTest {
 	pub name:     String,
 	pub input:    String,
@@ -132,9 +131,7 @@ pub struct CompiledMatchOutput {
 /// A pipeline with every regex pre-compiled.
 #[derive(Debug)]
 pub struct CompiledPipeline {
-	#[allow(dead_code, reason = "test-only API surface")]
 	pub name:              String,
-	#[allow(dead_code, reason = "test-only API surface")]
 	pub description:       Option<String>,
 	pub match_command:     Regex,
 	pub match_subcommand:  Option<Regex>,
@@ -377,7 +374,6 @@ pub type ParsedPipelineFile = (Vec<CompiledPipeline>, Vec<(String, Vec<PipelineT
 #[derive(Debug, Default)]
 pub struct PipelineRegistry {
 	pub pipelines: Vec<CompiledPipeline>,
-	#[allow(dead_code, reason = "test-only API surface")]
 	pub tests:     Vec<(String, Vec<PipelineTest>)>,
 }
 
@@ -425,7 +421,6 @@ pub fn parse_file(contents: &str, source_label: &str) -> Result<ParsedPipelineFi
 
 /// Outcome for a single inline test.
 #[derive(Debug, Clone)]
-#[allow(dead_code, reason = "test-only API surface")]
 pub struct TestOutcome {
 	pub filter_name: String,
 	pub test_name:   String,
@@ -435,7 +430,6 @@ pub struct TestOutcome {
 }
 
 /// Run every inline test in `registry` and return the outcomes.
-#[allow(dead_code, reason = "test-only API surface")]
 #[must_use]
 pub fn run_tests(registry: &PipelineRegistry) -> Vec<TestOutcome> {
 	let mut out = Vec::new();

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -1159,15 +1159,13 @@ async fn run_shell_command_once(
 
 	if !reader_finished {
 		reader_cancel.cancel();
-		if let Ok(res) = time::timeout(READER_SHUTDOWN_TIMEOUT, &mut reader_handle).await {
-			if let Ok(output) = res
-				&& let Ok(output) = output
-			{
-				reader_output = Some(output);
-			}
-		} else {
-			reader_handle.abort();
-			let _ = reader_handle.await;
+		match time::timeout(READER_SHUTDOWN_TIMEOUT, &mut reader_handle).await {
+			Ok(Ok(Ok(output))) => reader_output = Some(output),
+			Ok(_) => {},
+			Err(_) => {
+				reader_handle.abort();
+				let _ = reader_handle.await;
+			},
 		}
 	}
 	cancel_bridge.abort();

--- a/crates/pi-uu-grep/src/rg.rs
+++ b/crates/pi-uu-grep/src/rg.rs
@@ -927,11 +927,12 @@ fn process_file<W: Write>(
 	opts: &SearchOptions,
 	out: &mut W,
 ) -> SearchOutcome {
-	match File::open(path).and_then(|file| process_reader(matcher, searcher, file, display, opts, out)) {
+	match File::open(path)
+		.and_then(|file| process_reader(matcher, searcher, file, display, opts, out))
+	{
 		Ok(any_match) => SearchOutcome { any_match, had_error: false },
-		Err(err) => SearchOutcome {
-			any_match: false,
-			had_error: report_path_error(display, path, err, opts),
+		Err(err) => {
+			SearchOutcome { any_match: false, had_error: report_path_error(display, path, err, opts) }
 		},
 	}
 }

--- a/crates/pi-uu-grep/src/rg.rs
+++ b/crates/pi-uu-grep/src/rg.rs
@@ -927,16 +927,11 @@ fn process_file<W: Write>(
 	opts: &SearchOptions,
 	out: &mut W,
 ) -> SearchOutcome {
-	match File::open(path) {
-		Ok(file) => match process_reader(matcher, searcher, file, display, opts, out) {
-			Ok(any_match) => SearchOutcome { any_match, had_error: false },
-			Err(err) => SearchOutcome {
-				any_match: false,
-				had_error: report_path_error(display, path, err, opts),
-			},
-		},
-		Err(err) => {
-			SearchOutcome { any_match: false, had_error: report_path_error(display, path, err, opts) }
+	match File::open(path).and_then(|file| process_reader(matcher, searcher, file, display, opts, out)) {
+		Ok(any_match) => SearchOutcome { any_match, had_error: false },
+		Err(err) => SearchOutcome {
+			any_match: false,
+			had_error: report_path_error(display, path, err, opts),
 		},
 	}
 }

--- a/crates/pi-walker/src/cache.rs
+++ b/crates/pi-walker/src/cache.rs
@@ -128,10 +128,7 @@ where
 	E: Send,
 {
 	if !should_parallelize(items.len()) {
-		for item in items {
-			operation(item)?;
-		}
-		return Ok(());
+		return items.iter().try_for_each(operation);
 	}
 	with_walk_pool(|| items.par_iter().try_for_each(operation))
 }

--- a/crates/pi-walker/src/lib.rs
+++ b/crates/pi-walker/src/lib.rs
@@ -314,10 +314,9 @@ impl WalkFilter {
 	}
 
 	fn accepts_path(&self, relative_path: &str) -> bool {
-		match &self.glob {
-			Some(glob) => glob.is_match(relative_path),
-			None => true,
-		}
+		self.glob
+			.as_ref()
+			.is_none_or(|glob| glob.is_match(relative_path))
 	}
 
 	fn accepts_collected(&self, entry: &CollectedEntry) -> bool {
@@ -362,12 +361,13 @@ impl WalkFilter {
 		}) {
 			return WalkDecision::Skip;
 		}
-		match self.kind {
-			WalkFilterKind::All => {},
-			WalkFilterKind::Files if meta.file_type == FileType::File => {},
-			WalkFilterKind::Files => return WalkDecision::Skip,
-			WalkFilterKind::Dirs if meta.file_type == FileType::Dir => {},
-			WalkFilterKind::Dirs => return WalkDecision::Skip,
+		let accepts_kind = match self.kind {
+			WalkFilterKind::All => true,
+			WalkFilterKind::Files => meta.file_type == FileType::File,
+			WalkFilterKind::Dirs => meta.file_type == FileType::Dir,
+		};
+		if !accepts_kind {
+			return WalkDecision::Skip;
 		}
 		if self.accepts_path(meta.relative_path) {
 			WalkDecision::Include
@@ -2038,21 +2038,16 @@ impl<H> WalkContext<'_, H> {
 		V: EntryVisitor,
 		H: FnMut() -> std::result::Result<(), V::Error>,
 	{
-		let identity = if self.options.follow_links == FollowLinks::Always {
-			directory_identity(dir).ok()
-		} else {
-			None
-		};
-		if let Some(id) = &identity {
-			self.symlink_ancestors.push(id.clone());
-		}
-
-		let result = self.walk_dir_inner(dir, relative_dir, depth, ignore_state, visitor);
-
-		if identity.is_some() {
+		if self.options.follow_links == FollowLinks::Always
+			&& let Ok(identity) = directory_identity(dir)
+		{
+			self.symlink_ancestors.push(identity);
+			let result = self.walk_dir_inner(dir, relative_dir, depth, ignore_state, visitor);
 			self.symlink_ancestors.pop();
+			return result;
 		}
-		result
+
+		self.walk_dir_inner(dir, relative_dir, depth, ignore_state, visitor)
 	}
 
 	fn walk_dir_inner<V>(
@@ -2068,26 +2063,15 @@ impl<H> WalkContext<'_, H> {
 		H: FnMut() -> std::result::Result<(), V::Error>,
 	{
 		let mut raw_entries = Vec::new();
-		match self.options.order {
-			WalkOrder::Path => {
-				match platform::read_dir_entries(dir, self.options.detail, |entry| {
-					raw_entries.push(entry.into_owned());
-					Ok(ReadDirControl::Continue)
-				}) {
-					Ok(_) => {},
-					Err(err) => return handle_read_dir_error(dir, err, self.options, visitor),
-				}
-				raw_entries.sort_unstable_by(|a, b| a.name.cmp(&b.name));
-			},
-			WalkOrder::Unordered => {
-				match platform::read_dir_entries(dir, self.options.detail, |entry| {
-					raw_entries.push(entry.into_owned());
-					Ok(ReadDirControl::Continue)
-				}) {
-					Ok(_) => {},
-					Err(err) => return handle_read_dir_error(dir, err, self.options, visitor),
-				}
-			},
+		match platform::read_dir_entries(dir, self.options.detail, |entry| {
+			raw_entries.push(entry.into_owned());
+			Ok(ReadDirControl::Continue)
+		}) {
+			Ok(_) => {},
+			Err(err) => return handle_read_dir_error(dir, err, self.options, visitor),
+		}
+		if self.options.order == WalkOrder::Path {
+			raw_entries.sort_unstable_by(|a, b| a.name.cmp(&b.name));
 		}
 
 		for entry in raw_entries {
@@ -2150,7 +2134,7 @@ impl<H> WalkContext<'_, H> {
 							}
 						}
 						return Err(WalkError::InvalidData {
-							path:    absolute.clone(),
+							path:    absolute,
 							message: err.to_string(),
 						});
 					},
@@ -2222,7 +2206,7 @@ impl<H> WalkContext<'_, H> {
 								continue;
 							}
 							return Err(WalkError::InvalidData {
-								path:    absolute.clone(),
+								path:    absolute,
 								message: "filesystem loop detected".to_string(),
 							});
 						}
@@ -2245,7 +2229,7 @@ impl<H> WalkContext<'_, H> {
 							}
 						}
 						return Err(WalkError::InvalidData {
-							path:    absolute.clone(),
+							path:    absolute,
 							message: err.to_string(),
 						});
 					},

--- a/crates/pi-walker/src/lib.rs
+++ b/crates/pi-walker/src/lib.rs
@@ -314,7 +314,8 @@ impl WalkFilter {
 	}
 
 	fn accepts_path(&self, relative_path: &str) -> bool {
-		self.glob
+		self
+			.glob
 			.as_ref()
 			.is_none_or(|glob| glob.is_match(relative_path))
 	}


### PR DESCRIPTION
## What
Behavior-preserving cleanup across first-party Rust crates, with one commit per crate plus formatting after cherry-picking onto current upstream.

## Verification
Verified after rebasing onto current upstream/main: `cargo clippy --workspace --all-targets` (1 pre-existing warning), `cargo test --workspace` (1176 pass), and `bun check`.
