### PR TITLE
fix(tui): anchor queued follow-up rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed queued follow-up rows leaking duplicate pending-message copies into native scrollback by anchoring the pending-message container as a live region ([#4362](https://github.com/can1357/oh-my-pi/issues/4362)).
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -316,13 +316,14 @@ export interface InteractiveModeOptions {
 }
 
 /**
- * Anchored live-region container for the HUD/status rows between the transcript
- * and the editor (working loader, todo + subagent HUDs, transient notification
- * panels). While it has content every row is live: it reports a seam at 0 so the
- * engine never commits these anchored, rebuilt-in-place rows to native
- * scrollback — otherwise stale duplicates pile up above the live copy on short
- * terminals once the loader sits below a tall HUD. The transcript's own seam,
- * when present, sits higher and wins (topmost-seam merge in TUI.render).
+ * Anchored live-region container for transient rows between the transcript and
+ * the editor (queued follow-up rows, working loader, todo + subagent HUDs,
+ * transient notification panels). While it has content every row is live: it
+ * reports a seam at 0 so the engine never commits these anchored,
+ * rebuilt-in-place rows to native scrollback — otherwise stale duplicates pile
+ * up above the live copy on short terminals.
+ * The transcript's own seam, when present, sits higher and wins
+ * (topmost-seam merge in TUI.render).
  */
 class AnchoredLiveContainer extends Container implements NativeScrollbackLiveRegion {
 	getNativeScrollbackLiveRegionStart(): number | undefined {
@@ -635,7 +636,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// unless the user opts in, and never emits raw escapes on other terminals.
 		setTerminalTextSizing(settings.get("tui.textSizing") && TERMINAL.textSizing);
 		this.chatContainer = new TranscriptContainer();
-		this.pendingMessagesContainer = new Container();
+		this.pendingMessagesContainer = new AnchoredLiveContainer();
 		this.statusContainer = new AnchoredLiveContainer();
 		this.todoContainer = new AnchoredLiveContainer();
 		this.subagentContainer = new AnchoredLiveContainer();

--- a/packages/coding-agent/test/interactive-mode-working-accent.test.ts
+++ b/packages/coding-agent/test/interactive-mode-working-accent.test.ts
@@ -5,7 +5,7 @@ import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import * as sessionColor from "@oh-my-pi/pi-coding-agent/utils/session-color";
-import type { Container, NativeScrollbackLiveRegion } from "@oh-my-pi/pi-tui";
+import { type Container, type NativeScrollbackLiveRegion, Text } from "@oh-my-pi/pi-tui";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 type Harness = {
@@ -89,6 +89,15 @@ describe("InteractiveMode working-message session accent cache", () => {
 		// the animating loader out of immutable native scrollback.
 		startStableLoader(mode);
 		expect(statusContainer.getNativeScrollbackLiveRegionStart()).toBe(0);
+	});
+
+	it("reports pending follow-up rows as a live seam while mounted", async () => {
+		const { mode } = await createHarness("Queued follow-up");
+		const pendingContainer = mode.pendingMessagesContainer as Container & Partial<NativeScrollbackLiveRegion>;
+
+		expect(pendingContainer.getNativeScrollbackLiveRegionStart?.()).toBeUndefined();
+		pendingContainer.addChild(new Text("Follow-up: queued", 1, 0));
+		expect(pendingContainer.getNativeScrollbackLiveRegionStart?.()).toBe(0);
 	});
 
 	it("reuses one computed accent across loader spinner and message colorizers", async () => {


### PR DESCRIPTION
## Repro
Queued follow-up rows mounted under `mode.pendingMessagesContainer` did not report a native-scrollback live-region seam. Reproduced with `bun run gen:tool-views && bun test packages/coding-agent/test/interactive-mode-working-accent.test.ts`: the new regression expected `getNativeScrollbackLiveRegionStart?.()` to return `0` after mounting a pending row, but it returned `undefined`.

## Cause
`InteractiveMode` built `pendingMessagesContainer` with a plain `Container` in `packages/coding-agent/src/modes/interactive-mode.ts`, while the neighboring transient HUD containers use `AnchoredLiveContainer`. `updatePendingMessagesDisplay()` clears and rebuilds queued follow-up rows in `packages/coding-agent/src/modes/utils/ui-helpers.ts`, so without `NativeScrollbackLiveRegion` those transient rows could be committed into native scrollback during repeated paints.

## Fix
- Use `AnchoredLiveContainer` for `pendingMessagesContainer` so queued follow-up rows report seam `0` while mounted.
- Extend the live-region regression coverage in `packages/coding-agent/test/interactive-mode-working-accent.test.ts` to cover pending follow-up rows.
- Add the coding-agent changelog entry for #4362.

## Verification
`bun test packages/coding-agent/test/interactive-mode-working-accent.test.ts` passed with 6 tests and 25 assertions. `bun run check:types` passed in `packages/coding-agent`. Fixes #4362