### PR TITLE
fix(coding-agent): queue approved plan behind turns flushed by compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed approve-and-compact discarding operator turns queued during compaction and surfacing `Failed to finalize approved plan: Agent is already processing`. `flushCompactionQueue` fires any queued user turn (fire-and-forget) before `#approvePlan` returns, so the previous abort-then-`prompt()` shape aborted the queued turn AND still raced into `AgentBusyError`. `#approvePlan` now queues the plan-approved directive as a synthetic follow-up (`session.followUp(text, undefined, { synthetic: true })`) whenever the session is streaming, and catches a racing `AgentBusyError` from `prompt()` with the same fallback. `AgentSession.followUp()` gained a `{ synthetic, expandPromptTemplates, attribution }` option so the finalize path lands the hidden execution directive as an agent-attributed developer message. ([#4358](https://github.com/can1357/oh-my-pi/issues/4358))
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
 	type Agent,
+	AgentBusyError,
 	type AgentMessage,
 	type AgentToolResult,
 	EventLoopKeepalive,
@@ -2672,16 +2673,24 @@ export class InteractiveMode implements InteractiveModeContext {
 			planFilePath: options.planFilePath,
 			contextPreserved: options.preserveContext === true,
 		});
-		// The executor's first turn must start on an idle session. The agent may still
-		// be streaming the post-`resolve` continuation (Agent.#emit is fire-and-forget)
-		// or a turn kicked off by the compaction/clear above; prompt() would then throw
-		// AgentBusyError ("Failed to finalize approved plan"). Abort the now-irrelevant
-		// in-flight turn first — abort() bumps the prompt generation and cancels pending
-		// continuations, so nothing re-streams in the synchronous gap before prompt().
+		// A user turn queued during compaction was already fired by
+		// `flushCompactionQueue` before we returned from `handleCompactCommand`; the
+		// old abort-then-prompt path would have discarded that operator turn AND
+		// still surfaced `AgentBusyError` when the queued turn kicked off in the
+		// synchronous gap. Preserve the in-flight work and queue the hidden
+		// execution directive behind it as a synthetic follow-up. If `isStreaming`
+		// flips true between the check and dispatch (the same fire-and-forget race
+		// noted below), catch `AgentBusyError` and fall back to the same queue.
 		if (this.session.isStreaming) {
-			await this.#abortPlanApprovalTurnSilently();
+			await this.session.followUp(planModePrompt, undefined, { synthetic: true });
+			return;
 		}
-		await this.session.prompt(planModePrompt, { synthetic: true });
+		try {
+			await this.session.prompt(planModePrompt, { synthetic: true });
+		} catch (error) {
+			if (!(error instanceof AgentBusyError)) throw error;
+			await this.session.followUp(planModePrompt, undefined, { synthetic: true });
+		}
 	}
 	async #abortPlanApprovalTurnSilently(): Promise<void> {
 		this.session.markPlanInternalAbortPending();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -837,6 +837,16 @@ export interface PromptOptions {
 	skipCompactionCheck?: boolean;
 }
 
+/** Options for AgentSession.followUp() */
+export interface FollowUpOptions {
+	/** Enqueue as a hidden developer message (agent-attributed by default) instead of a user follow-up. */
+	synthetic?: boolean;
+	/** Whether to expand file-based prompt templates (default: true). */
+	expandPromptTemplates?: boolean;
+	/** Explicit billing/initiator attribution. Defaults to `agent` for synthetic follow-ups. */
+	attribution?: MessageAttribution;
+}
+
 /** Result from a handoff operation. */
 export interface HandoffResult {
 	document: string;
@@ -7792,14 +7802,42 @@ export class AgentSession {
 
 	/**
 	 * Queue a follow-up message to process after the agent would otherwise stop.
+	 * Set `options.synthetic` to enqueue a hidden developer message (agent-attributed
+	 * by default) instead of a user-attributed follow-up; the plan-approval flow
+	 * uses this to land its execution directive behind a queued user turn without
+	 * flipping advisor auto-resume.
 	 */
-	async followUp(text: string, images?: ImageContent[]): Promise<void> {
+	async followUp(text: string, images?: ImageContent[], options?: FollowUpOptions): Promise<void> {
 		if (text.startsWith("/")) {
 			this.#throwIfExtensionCommand(text);
 		}
 
-		const expandedText = expandPromptTemplate(text, [...this.#promptTemplates]);
-		await this.#queueUserMessage(expandedText, images, "followUp");
+		const expandedText =
+			options?.expandPromptTemplates === false ? text : expandPromptTemplate(text, [...this.#promptTemplates]);
+		if (!options?.synthetic) {
+			await this.#queueUserMessage(expandedText, images, "followUp");
+			return;
+		}
+		// Synthetic branch: agent-initiated hidden developer message. Bypass
+		// #queueUserMessage (which clears advisor auto-resume suppression and
+		// enqueues as a user-attributed message) and place the developer message
+		// directly on the follow-up queue.
+		const normalizedImages = await this.#normalizeImagesForModel(images);
+		const content: (TextContent | ImageContent)[] = [{ type: "text", text: expandedText }];
+		if (normalizedImages?.length) {
+			content.push(...normalizedImages);
+		}
+		const imageDescriptionNotice = normalizedImages?.length
+			? await this.#buildImageDescriptionNotice(normalizedImages)
+			: undefined;
+		if (imageDescriptionNotice) this.agent.followUp(imageDescriptionNotice);
+		this.agent.followUp({
+			role: "developer",
+			content,
+			attribution: options.attribution ?? "agent",
+			timestamp: Date.now(),
+		});
+		this.#scheduleIdleQueueDrain();
 	}
 
 	async #queueUserMessage(

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -622,7 +622,13 @@ describe("InteractiveMode plan review rendering", () => {
 		});
 	});
 
-	it("aborts an in-flight turn before dispatching the approved plan instead of surfacing AgentBusyError", async () => {
+	it("queues the approved plan as a synthetic follow-up when a turn is already in flight", async () => {
+		// Regression: the previous fix aborted the in-flight turn and re-dispatched
+		// the plan-approved prompt. When the in-flight turn was an operator turn
+		// queued during compaction and just flushed by `flushCompactionQueue`, that
+		// abort discarded the operator's work. The correct shape is a synthetic
+		// follow-up: land the hidden execution directive behind the in-flight turn
+		// and preserve it.
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
 			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
@@ -637,18 +643,13 @@ describe("InteractiveMode plan review rendering", () => {
 			configurable: true,
 			get: () => streaming,
 		});
-		const abortSpy = vi.spyOn(session, "abort").mockImplementation(async () => {
-			// Clear the streaming flag only after an awaited tick, so the test fails
-			// if #approvePlan dispatches the prompt without awaiting abort() — the
-			// real abort() resolves only once the agent loop is idle.
-			await Promise.resolve();
-			streaming = false;
-		});
+		vi.spyOn(session, "abort").mockResolvedValue();
 		const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async (_text, opts) => {
 			if (streaming && !(opts as { streamingBehavior?: string } | undefined)?.streamingBehavior)
 				throw new AgentBusyError();
 			return true;
 		});
+		const followUpSpy = vi.spyOn(session, "followUp").mockResolvedValue();
 		// Simulate a re-stream landing during the overlay, then pick keep-context
 		// (options[2]) — that branch skips clear/compact so `this.session` stays the
 		// instance the spies are on.
@@ -661,9 +662,121 @@ describe("InteractiveMode plan review rendering", () => {
 		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
 
 		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to finalize approved plan"));
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(followUpSpy).toHaveBeenCalledTimes(1);
+		const [text, images, options] = followUpSpy.mock.calls[0] as unknown[];
+		expect(isPlanApprovedCall([text, options])).toBe(true);
+		expect(images).toBeUndefined();
+		expect(options).toMatchObject({ synthetic: true });
+		// `handlePlanApproval` aborts once on entry (unrelated to the finalize path);
+		// this test asserts the finalize path routes to followUp instead of prompt.
+	});
+
+	it("falls back to a synthetic follow-up when prompt() races into AgentBusyError", async () => {
+		// Narrow race: `isStreaming` reads false but the fire-and-forget turn queued
+		// by `flushCompactionQueue` flips it true before `session.prompt()` executes.
+		// The core guard throws `AgentBusyError`; the finalize path must catch it and
+		// queue the same synthetic follow-up instead of surfacing the error.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => false,
+		});
+		vi.spyOn(session, "abort").mockResolvedValue();
+		const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async () => {
+			throw new AgentBusyError();
+		});
+		const followUpSpy = vi.spyOn(session, "followUp").mockResolvedValue();
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => options[2]);
+		const errorSpy = vi.spyOn(mode, "showError");
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to finalize approved plan"));
 		expect(promptSpy).toHaveBeenCalledTimes(1);
 		expect(isPlanApprovedCall(promptSpy.mock.calls[0] as unknown[])).toBe(true);
-		expect(abortSpy).toHaveBeenCalled();
+		expect(followUpSpy).toHaveBeenCalledTimes(1);
+		const [text, images, options] = followUpSpy.mock.calls[0] as unknown[];
+		expect(isPlanApprovedCall([text, options])).toBe(true);
+		expect(images).toBeUndefined();
+		expect(options).toMatchObject({ synthetic: true });
+	});
+
+	it("lands the approved plan behind a user turn queued during approve-and-compact", async () => {
+		// End-to-end contract: choosing "Approve and compact context" runs
+		// `handleCompactCommand`, which after compaction calls `flushCompactionQueue`.
+		// A user turn typed during compaction is fired first via `session.prompt(...,
+		// { streamingBehavior: "followUp" })` (which flips `isStreaming` in the
+		// mock). The finalize path must then land the plan-approved prompt as a
+		// synthetic follow-up — not surface `AgentBusyError` (the previous shape)
+		// and not abort the queued user turn.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nbody");
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+
+		let streaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => streaming,
+		});
+		vi.spyOn(session, "abort").mockResolvedValue();
+
+		const calls: { type: "prompt" | "followUp"; text: string; options?: unknown }[] = [];
+		vi.spyOn(session, "prompt").mockImplementation(async (text, opts) => {
+			calls.push({ type: "prompt", text, options: opts });
+			if (text === "queued message") {
+				streaming = true;
+			}
+			if (streaming && !(opts as { streamingBehavior?: string } | undefined)?.streamingBehavior) {
+				throw new AgentBusyError();
+			}
+			return true;
+		});
+		vi.spyOn(session, "followUp").mockImplementation(async (text, _images, options) => {
+			calls.push({ type: "followUp", text, options });
+		});
+
+		// `handleCompactCommand` gates on messageCount >= 2 from `sessionManager.getEntries()`.
+		session.sessionManager.appendMessage({ role: "user", content: "seed one", timestamp: Date.now() - 2 });
+		session.sessionManager.appendMessage({ role: "user", content: "seed two", timestamp: Date.now() - 1 });
+		vi.spyOn(session, "compact").mockImplementation(async () => {
+			// Operator types a follow-up while compaction is running.
+			mode.queueCompactionMessage("queued message", "followUp");
+			return undefined as never;
+		});
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, options) => options[1]);
+		const errorSpy = vi.spyOn(mode, "showError");
+
+		await mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Failed to finalize approved plan"));
+
+		const queuedIndex = calls.findIndex(c => c.text === "queued message");
+		const planIndex = calls.findIndex(c => isPlanApprovedCall([c.text, c.options]));
+		expect(queuedIndex).toBeGreaterThanOrEqual(0);
+		expect(planIndex).toBeGreaterThan(queuedIndex);
+		expect(calls[planIndex]).toMatchObject({
+			type: "followUp",
+			options: { synthetic: true },
+		});
+		// Queued user turn was preserved (not silently aborted by the old fix).
+		expect(calls[queuedIndex]).toMatchObject({
+			type: "prompt",
+			options: { streamingBehavior: "followUp" },
+		});
 	});
 
 	it("keeps the existing approve-and-execute path clearing the session", async () => {


### PR DESCRIPTION
## Repro

Enter plan mode, submit a plan, and when the approval overlay is up choose "Approve and compact context". Type a follow-up while compaction runs (it goes into `compactionQueuedMessages`). `handleCompactCommand` → `flushCompactionQueue` fires that queued turn via `session.prompt(text, { streamingBehavior: "followUp" })` (fire-and-forget) before returning, so the session is streaming when `#approvePlan` resumes. The old shape then aborted the queued user turn *and* still raced into `AgentBusyError`, surfacing `Failed to finalize approved plan: Agent is already processing.` and dropping the plan execution.

```
bun test test/interactive-mode-plan-review.test.ts -t "approve-and-compact"
```

reproduces against `main`: `errorSpy` is called with "Failed to finalize approved plan".

## Cause

`#approvePlan` (`packages/coding-agent/src/modes/interactive-mode.ts`) used `if (isStreaming) await #abortPlanApprovalTurnSilently(); await session.prompt(planModePrompt, { synthetic: true })`. Two problems layered:

1. The queued user turn just flushed by `flushCompactionQueue` was aborted with the in-flight one — silent data loss for the operator.
2. `isStreaming` and `session.prompt()` are separated by an await; a fire-and-forget turn kicked off in that gap (or the post-abort `#queuedMessageDrainScheduled` re-continue) throws `AgentBusyError` from the core guard in `Agent.prompt()`.

## Fix

- `AgentSession.followUp()` (`packages/coding-agent/src/session/agent-session.ts`) accepts a new `FollowUpOptions` (`synthetic`, `expandPromptTemplates`, `attribution`). Synthetic follow-ups enqueue a hidden `developer`-role message with `agent` attribution directly onto `agent.followUp(...)`, skipping the user-attributed `#queueUserMessage` path so advisor auto-resume suppression is not flipped by the finalize path.
- `#approvePlan` now:
  - If `session.isStreaming`, queues the plan-approved directive via `session.followUp(planModePrompt, undefined, { synthetic: true })` and returns. The queued user turn keeps running; the hidden execution directive lands behind it.
  - Otherwise tries `session.prompt(planModePrompt, { synthetic: true })` and catches `AgentBusyError` with the same synthetic follow-up as fallback, covering the narrow race where a turn kicked off between the check and the dispatch.
- `#abortPlanApprovalTurnSilently()` stays — still used by the pre-review abort at `handlePlanApproval` entry (line 3086) that stops the model from re-invoking `resolve` during the popup.

## Verification

- `bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts` — 47 tests pass, including three new/updated tests:
  - Existing test rewritten to assert the streaming branch takes `session.followUp(..., { synthetic: true })` instead of aborting.
  - New test for the narrow `AgentBusyError` race — `prompt()` throws even with `isStreaming` initially false, and the finalize path falls back to synthetic follow-up.
  - New end-to-end test for the "Approve and compact context" flow: mocks `session.compact` to enqueue a follow-up via `mode.queueCompactionMessage`, then asserts the queued user turn fires first (`prompt(..., { streamingBehavior: "followUp" })`) and the plan-approved lands after as `followUp(..., { synthetic: true })`.
- `bun run check:types` and `bun run lint` clean.
- Two `agent-session-handoff.test.ts` failures (`snapcompactSupportedChars is not a function`) reproduce on `main` and are unrelated to this diff.

Fixes #4358