### PR TITLE
perf(coding-agent/tui): scoped renders + shimmer band fast-path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Further reduced TUI CPU during streaming and live tool calls by scoping timer-driven reveal/spinner renders to the changed subtree (streaming reveal, tool-args reveal, tool-execution spinner, todo strike animation) instead of forcing a full-tree walk at 30fps, interning the working-message shimmer palette so the compiled-ANSI cache hits between animation frames, and adding a band fast-path to `shimmerSegments` that coalesces off-band code points into a single low-tier run ([#4377](https://github.com/can1357/oh-my-pi/issues/4377))
+
 ## [16.3.3] - 2026-07-02
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -167,7 +167,7 @@ export interface ToolExecutionOptions {
 	liveRegion?: TranscriptLiveRegionProbe;
 }
 
-export interface ToolExecutionHandle {
+export interface ToolExecutionHandle extends Component {
 	updateArgs(args: any, toolCallId?: string): void;
 	updateResult(
 		result: {
@@ -622,7 +622,10 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 				const frameCount = theme.spinnerFrames.length;
 				this.#spinnerFrame = sharedSpinnerFrame(frameCount, now);
 				this.#renderState.spinnerFrame = this.#spinnerFrame;
-				this.#ui.requestRender();
+				// Component-scoped: a spinner tick only changes this tool block, so
+				// the TUI reuses every other root subtree instead of walking the
+				// whole tree (issue #4377).
+				this.#ui.requestComponentRender(this);
 			}, SPINNER_RENDER_INTERVAL_MS);
 		} else if (!needsSpinner && this.#spinnerInterval) {
 			clearInterval(this.#spinnerInterval);
@@ -679,7 +682,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 				this.#spinnerFrame = nextFrame;
 				this.#renderState.spinnerFrame = nextFrame;
 			}
-			this.#ui.requestRender();
+			// Component-scoped: strike animation only mutates this tool block's
+			// glyph, so the TUI reuses every other root subtree (issue #4377).
+			this.#ui.requestComponentRender(this);
 		}, 65);
 	}
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -131,11 +131,11 @@ export class EventController {
 			getSmoothStreaming: () => this.ctx.settings.get("display.smoothStreaming"),
 			getHideThinkingBlock: () => this.ctx.effectiveHideThinkingBlock,
 			getProseOnlyThinking: () => this.ctx.proseOnlyThinking,
-			requestRender: () => this.ctx.ui.requestRender(),
+			requestRender: component => this.ctx.ui.requestComponentRender(component),
 		});
 		this.#toolArgsReveal = new ToolArgsRevealController({
 			getSmoothStreaming: () => this.ctx.settings.get("display.smoothStreaming"),
-			requestRender: () => this.ctx.ui.requestRender(),
+			requestRender: component => this.ctx.ui.requestComponentRender(component),
 		});
 		this.#handlers = {
 			agent_start: e => this.#handleAgentStart(e),

--- a/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/controllers/streaming-reveal.ts
@@ -1,5 +1,5 @@
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { getSegmenter } from "@oh-my-pi/pi-tui";
+import { type Component, getSegmenter } from "@oh-my-pi/pi-tui";
 import { LRUCache } from "lru-cache/raw";
 import { formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
 import type { AssistantMessageComponent } from "../components/assistant-message";
@@ -10,14 +10,21 @@ export const CATCHUP_FRAMES = 8;
 
 type AssistantContentBlock = AssistantMessage["content"][number];
 type DisplayThinkingContentBlock = Extract<AssistantContentBlock, { type: "thinking" }> & { rawThinking?: string };
-type StreamingRevealComponent = Pick<AssistantMessageComponent, "updateContent">;
+/** The concrete streaming-reveal target is an {@link AssistantMessageComponent}; the
+ *  Component intersection is what lets the reveal request component-scoped renders
+ *  through {@link TUI.requestComponentRender} instead of forcing a full-tree walk. */
+type StreamingRevealComponent = Pick<AssistantMessageComponent, "updateContent"> & Component;
 type GraphemeSlicer = (index: number, text: string, units: number) => string;
 
 type StreamingRevealControllerOptions = {
 	getSmoothStreaming(): boolean;
 	getHideThinkingBlock(): boolean;
 	getProseOnlyThinking(): boolean;
-	requestRender(): void;
+	/** Called after each reveal tick with the component whose subtree changed;
+	 *  callers scope the render to that subtree (a full tree walk here at 30fps
+	 *  costs 5% of CPU on its own and drives the Box/Container overhead that
+	 *  cascades into another ~15% — see issue #4377). */
+	requestRender(component: Component): void;
 };
 
 const graphemeCountCache = new LRUCache<string, number>({ max: 128 });
@@ -210,7 +217,7 @@ export class StreamingRevealController {
 	readonly #getSmoothStreaming: () => boolean;
 	readonly #getHideThinkingBlock: () => boolean;
 	readonly #getProseOnlyThinking: () => boolean;
-	readonly #requestRender: () => void;
+	readonly #requestRender: (component: Component) => void;
 	#target: AssistantMessage | undefined;
 	#component: StreamingRevealComponent | undefined;
 	#timer: NodeJS.Timeout | undefined;
@@ -384,7 +391,7 @@ export class StreamingRevealController {
 		component.updateContent(this.#build(target, this.#revealed), {
 			transient: true,
 		});
-		this.#requestRender();
+		this.#requestRender(component);
 		if (this.#revealed >= total) {
 			this.#stopTimer();
 		}

--- a/packages/coding-agent/src/modes/controllers/tool-args-reveal.ts
+++ b/packages/coding-agent/src/modes/controllers/tool-args-reveal.ts
@@ -1,8 +1,9 @@
+import type { Component } from "@oh-my-pi/pi-tui";
 import { parseStreamingJson, parseStreamingJsonThrottled, STREAMING_JSON_PARSE_MIN_GROWTH } from "@oh-my-pi/pi-utils";
 import { nextStep, STREAMING_REVEAL_FRAME_MS } from "./streaming-reveal";
 
 /** Minimal component surface the reveal pushes frames into. */
-type ToolArgsRevealComponent = {
+type ToolArgsRevealComponent = Component & {
 	updateArgs(args: unknown, toolCallId?: string): void;
 };
 
@@ -25,7 +26,10 @@ export function streamingStringKeysForTool(toolName: string, rawInput: boolean):
 
 type ToolArgsRevealControllerOptions = {
 	getSmoothStreaming(): boolean;
-	requestRender(): void;
+	/** Called after each reveal tick with the component whose subtree changed;
+	 *  callers scope the render to that subtree instead of forcing a full-tree
+	 *  walk at 30fps (issue #4377). */
+	requestRender(component: Component): void;
 };
 
 type StreamingJsonStringExtractorResult = {
@@ -438,7 +442,7 @@ export function decodeStreamedToolArgs(partialJson: string, source: StreamedTool
  */
 export class ToolArgsRevealController {
 	readonly #getSmoothStreaming: () => boolean;
-	readonly #requestRender: () => void;
+	readonly #requestRender: (component: Component) => void;
 	readonly #entries = new Map<string, RevealEntry>();
 	#timer: NodeJS.Timeout | undefined;
 
@@ -560,7 +564,10 @@ export class ToolArgsRevealController {
 
 	#tick(): void {
 		let advanced = false;
-		let rendered = false;
+		// Collect components with changed display args; render each subtree once
+		// per tick even when multiple entries share a component (they don't
+		// today, but the API contract doesn't prevent it).
+		const rendered = new Set<ToolArgsRevealComponent>();
 		for (const [id, entry] of this.#entries) {
 			const backlog = entry.target.length - entry.revealed;
 			if (backlog <= 0 || !entry.component) continue;
@@ -568,12 +575,12 @@ export class ToolArgsRevealController {
 			const display = displayArgsForPrefix(entry, entry.target.slice(0, entry.revealed));
 			if (display.changed) {
 				entry.component.updateArgs(display.args, id);
-				rendered = true;
+				rendered.add(entry.component);
 			}
 			advanced = true;
 		}
 		if (advanced) {
-			if (rendered) this.#requestRender();
+			for (const component of rendered) this.#requestRender(component);
 		} else {
 			// Every entry caught up (or unbound); setTarget restarts on growth.
 			this.#stopTimer();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -205,29 +205,37 @@ interface WorkingMessageAccentCacheKey {
 	sessionAccentEnabled: boolean;
 }
 
+/**
+ * Intern the shimmer palettes for each `WorkingMessageAccent` so `compile()`
+ * inside `shimmerSegments` sees a stable palette object between animation
+ * ticks. Allocating fresh palette literals every frame guaranteed a cache miss
+ * on the Symbol-keyed compiled-ANSI slot and forced `resolveTierAnsi` to walk
+ * every tier open/close for the ~30fps loader redraw (issue #4377).
+ */
+const workingMessagePaletteCache = new WeakMap<WorkingMessageAccent, { main: ShimmerPalette; hint: ShimmerPalette }>();
+
+function workingMessagePalettes(accent: WorkingMessageAccent): { main: ShimmerPalette; hint: ShimmerPalette } {
+	let entry = workingMessagePaletteCache.get(accent);
+	if (!entry) {
+		entry = {
+			main: { low: "dim", mid: { ansi: accent.main }, high: { ansi: accent.main }, bold: true },
+			hint: { low: "dim", mid: { ansi: accent.dim }, high: { ansi: accent.dim } },
+		};
+		workingMessagePaletteCache.set(accent, entry);
+	}
+	return entry;
+}
+
 function renderWorkingMessage(message: string, accent?: WorkingMessageAccent): string {
-	const palette = accent
-		? ({
-				low: "dim",
-				mid: { ansi: accent.main },
-				high: { ansi: accent.main },
-				bold: true,
-			} satisfies ShimmerPalette)
-		: undefined;
+	const palettes = accent ? workingMessagePalettes(accent) : undefined;
+	const palette = palettes?.main;
 	const hint = interruptHint();
 	if (!message.endsWith(hint)) return shimmerText(message, theme, palette);
 	const header = message.slice(0, -hint.length);
-	const hintPalette = accent
-		? ({
-				low: "dim",
-				mid: { ansi: accent.dim },
-				high: { ansi: accent.dim },
-			} satisfies ShimmerPalette)
-		: HINT_SHIMMER_PALETTE;
 	return shimmerSegments(
 		[
 			{ text: header, palette },
-			{ text: hint, palette: hintPalette },
+			{ text: hint, palette: palettes?.hint ?? HINT_SHIMMER_PALETTE },
 		],
 		theme,
 	);

--- a/packages/coding-agent/src/modes/theme/shimmer.ts
+++ b/packages/coding-agent/src/modes/theme/shimmer.ts
@@ -207,6 +207,14 @@ export function shimmerSegments(segments: readonly ShimmerSegment[], theme: Shim
 	const time = Date.now();
 	const intensityFn = mode === "kitt" ? kittIntensity : classicIntensity;
 
+	// Fast-path window: outside `[bandLo, bandHi]` the intensity is guaranteed
+	// zero (tier "low"), so we can skip `intensityFn` + `tierFor` entirely for
+	// the prefix/suffix of every segment. On the typical ~60-char working
+	// message the classic band spans ~12 cells, so ~80% of the per-char loop
+	// disappears — the intensity call and the tier compare were the residual
+	// per-frame cost after #4353 removed the allocation hotspot (issue #4377).
+	const { lo: bandLo, hi: bandHi } = activeBand(mode, time, total);
+
 	let out = "";
 	let index = 0;
 	for (const { text, palette } of perSeg) {
@@ -224,7 +232,7 @@ export function shimmerSegments(segments: readonly ShimmerSegment[], theme: Shim
 				const c2 = text.charCodeAt(i + 1);
 				if (c2 >= 0xdc00 && c2 <= 0xdfff) step = 2;
 			}
-			const tier = tierFor(intensityFn(time, index, total));
+			const tier: Tier = index < bandLo || index > bandHi ? "low" : tierFor(intensityFn(time, index, total));
 			if (tier !== runTier) {
 				if (runTier !== null && runEnd > runStart) {
 					const seq = compiled[runTier];
@@ -243,6 +251,34 @@ export function shimmerSegments(segments: readonly ShimmerSegment[], theme: Shim
 		}
 	}
 	return out;
+}
+
+/**
+ * Sweep window (code-point indices) outside which the intensity is guaranteed
+ * zero for `mode` at `time` over `total` cells. Widening the window is safe —
+ * the per-char intensity call still runs inside the window and reports 0 for
+ * off-band code points — but narrower windows skip more of the per-char loop.
+ */
+function activeBand(mode: "classic" | "kitt", time: number, total: number): { lo: number; hi: number } {
+	if (mode === "classic") {
+		const period = total + CLASSIC_PADDING * 2;
+		const pos = ((time / 1000) * SHIMMER_SPEED_CELLS_PER_S) % period;
+		return {
+			lo: pos - CLASSIC_PADDING - CLASSIC_BAND_HALF_WIDTH,
+			hi: pos - CLASSIC_PADDING + CLASSIC_BAND_HALF_WIDTH,
+		};
+	}
+	const range = total - 1;
+	if (range <= 0) return { lo: 0, hi: total };
+	const cycleCells = 2 * range;
+	const sweep = ((time / 1000) * SHIMMER_SPEED_CELLS_PER_S) % cycleCells;
+	const goingRight = sweep < range;
+	const head = goingRight ? sweep : cycleCells - sweep;
+	// The trail always lies behind the head for the current direction — chars
+	// ahead of the head are dark. See {@link kittIntensity} for the exact rule.
+	return goingRight
+		? { lo: head - KITT_HEAD_HALF - KITT_TRAIL_LEN, hi: head + KITT_HEAD_HALF }
+		: { lo: head - KITT_HEAD_HALF, hi: head + KITT_HEAD_HALF + KITT_TRAIL_LEN };
 }
 
 function countCodePoints(text: string): number {

--- a/packages/coding-agent/test/modes/theme/shimmer.test.ts
+++ b/packages/coding-agent/test/modes/theme/shimmer.test.ts
@@ -66,3 +66,65 @@ describe("shimmerText", () => {
 		expect(Bun.stripANSI(rendered)).toBe("🎉🌟✨🚀");
 	});
 });
+
+describe("shimmerText band fast-path", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// The band fast-path (issue #4377) skips the per-char intensity check for
+	// code points outside the sweep window and coalesces them into a single
+	// low-tier run. These tests guard the boundary math: an off-band char must
+	// paint muted (dim), while an on-band char (t chosen so the band crest sits
+	// on the middle of the string) must paint the crest color.
+
+	it("paints code points outside the band in the muted low tier", () => {
+		vi.spyOn(settingsModule, "isSettingsInitialized").mockReturnValue(false);
+		// pos = (333/1000)*30 ≈ 10 = CLASSIC_PADDING, band centered on index 0.
+		// Index 30 is well outside the ±6 half-width -> must be low ("dim").
+		vi.spyOn(Date, "now").mockReturnValue(333);
+
+		const text = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+		const rendered = shimmerText(text, testTheme, {
+			low: "dim",
+			mid: { ansi: "\x1b[38;2;12;34;56m" },
+			high: { ansi: "\x1b[38;2;12;34;56m" },
+			bold: true,
+		});
+
+		// Off-band chars sit inside a `\x1b[2m…` (dim) sequence — the crest color
+		// never reaches them.
+		expect(rendered.split("Z")[0]).toContain("\x1b[2m");
+		// Visible payload is preserved verbatim.
+		expect(Bun.stripANSI(rendered)).toBe(text);
+	});
+
+	it("keeps the crest color when the band sweeps across the string", () => {
+		vi.spyOn(settingsModule, "isSettingsInitialized").mockReturnValue(false);
+		// pos = (833/1000)*30 ≈ 25; band centers on index (25 - CLASSIC_PADDING) = 15.
+		vi.spyOn(Date, "now").mockReturnValue(833);
+
+		const text = "abcdefghijklmnopqrstuvwxyz0123456789";
+		const rendered = shimmerText(text, testTheme, {
+			low: "dim",
+			mid: { ansi: "\x1b[38;2;12;34;56m" },
+			high: { ansi: "\x1b[38;2;12;34;56m" },
+			bold: true,
+		});
+
+		// The crest color must appear somewhere: the band overlaps [9, 21].
+		expect(rendered).toContain("\x1b[38;2;12;34;56m");
+		expect(Bun.stripANSI(rendered)).toBe(text);
+	});
+
+	it("handles a surrogate pair straddling the band boundary atomically", () => {
+		// Regression: a naïve fast-path that indexes by UTF-16 units would split
+		// the surrogate pair when the boundary falls between the two halves,
+		// dropping a lone high-surrogate byte into an ANSI run.
+		vi.spyOn(settingsModule, "isSettingsInitialized").mockReturnValue(false);
+		vi.spyOn(Date, "now").mockReturnValue(333);
+
+		const rendered = shimmerText("......😀......", testTheme);
+		expect(Bun.stripANSI(rendered)).toBe("......😀......");
+	});
+});

--- a/packages/coding-agent/test/streaming-reveal.test.ts
+++ b/packages/coding-agent/test/streaming-reveal.test.ts
@@ -66,6 +66,13 @@ class RecordingComponent {
 		this.messages.push(message);
 		this.transientFlags.push(opts?.transient);
 	}
+
+	// Component protocol stub — the reveal controller now hands the component
+	// to `requestComponentRender`, which only exercises identity, so returning
+	// an empty rendered frame is sufficient for these tests.
+	render(): readonly string[] {
+		return [];
+	}
 }
 
 function latestMessage(component: RecordingComponent): AssistantMessage {
@@ -297,6 +304,24 @@ describe("streaming reveal", () => {
 		expect(textAt(latestMessage(component), 0)).toBe("abcdefghi");
 		expect(component.messages).toHaveLength(updates);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("passes the bound component to requestRender on each smooth tick", () => {
+		// The controller must hand its component to `requestRender` so the caller
+		// scopes the render to that subtree via `TUI.requestComponentRender`
+		// instead of forcing a full-tree walk at 30fps (issue #4377).
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const { component, controller } = makeController({ requestRender });
+
+		controller.begin(component, makeMessage([{ type: "text", text: "" }]));
+		controller.setTarget(makeMessage([{ type: "text", text: "abcdef" }]));
+		vi.advanceTimersByTime(STREAMING_REVEAL_FRAME_MS);
+
+		expect(requestRender).toHaveBeenCalled();
+		for (const call of requestRender.mock.calls) {
+			expect(call[0]).toBe(component);
+		}
 	});
 });
 

--- a/packages/coding-agent/test/tool-args-reveal.test.ts
+++ b/packages/coding-agent/test/tool-args-reveal.test.ts
@@ -13,6 +13,12 @@ class RecordingArgsComponent {
 	updateArgs(args: unknown): void {
 		this.frames.push(args as Record<string, unknown>);
 	}
+
+	// Component protocol stub — the reveal controller hands the component
+	// straight to `requestComponentRender`, which only exercises identity.
+	render(): readonly string[] {
+		return [];
+	}
 }
 
 function makeController(options: { smooth?: boolean; requestRender?: () => void } = {}) {
@@ -53,6 +59,27 @@ function rawTarget() {
 describe("tool args reveal", () => {
 	afterEach(() => {
 		vi.useRealTimers();
+	});
+
+	it("passes the bound component to requestRender on each rendered tick", () => {
+		// Each entry's component reference is handed to `requestRender` so the
+		// caller scopes the render to that tool block's subtree via
+		// `TUI.requestComponentRender` (issue #4377).
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const { component, controller } = makeController({ requestRender });
+		const content = "x".repeat(400);
+		const target = `{"path":"a.ts","content":"${content}"}`;
+
+		controller.setTarget("call-1", target.slice(0, 12), jsonTarget({ exposeRawPartialJson: true }));
+		controller.bind("call-1", component);
+		controller.setTarget("call-1", target, jsonTarget({ exposeRawPartialJson: true }));
+		drain(80);
+
+		expect(requestRender).toHaveBeenCalled();
+		for (const call of requestRender.mock.calls) {
+			expect(call[0]).toBe(component);
+		}
 	});
 
 	it("reveals what already arrived on the first setTarget call", () => {


### PR DESCRIPTION
## Repro

Start any interactive omp session, send a prompt that triggers a multi-turn streaming response, and observe CPU while the shimmer/spinner animates. On the previous build the working message shimmered at 30fps and every reveal/spinner tick issued a full-tree `requestRender()` — three animation timers (streaming reveal, tool-args reveal, tool-exec spinner) each drove a whole Box/Container walk per frame, and `renderWorkingMessage` allocated a fresh `ShimmerPalette` object every tick that guaranteed the compiled-ANSI cache miss inside `shimmerSegments`. Symptom: TUI overhead stays elevated even during quiet streaming (reported: ~7.4× overhead vs actual tool work in a 30 s window).

Reproduced by inspection of the reporter's profile + tracing the call sites in `interactive-mode.ts`, `streaming-reveal.ts`, `tool-args-reveal.ts`, and `tool-execution.ts`.

## Cause

Two compounding hot paths on top of the RC3/RC4/RC1 findings in #4377:

1. Every reveal tick called `ctx.ui.requestRender()` — a full-tree render — so `TUI.#pendingRenderComponentsOnly` was reset to `false` and the compose pipeline walked every root child every frame (`packages/tui/src/tui.ts:1875-1877`). The `Loader` component already routed its own spinner through `requestComponentRender`, but the `StreamingRevealController` and `ToolArgsRevealController` firing at 30fps + the `ToolExecutionComponent` spinner + todo-strike interval nullified that.
2. `renderWorkingMessage` (`interactive-mode.ts:208-234`) built a fresh `ShimmerPalette` object literal on every animation tick. The `compile()` cache in `shimmer.ts:89-106` is keyed on the palette object's identity (Symbol-slot), so identity-fresh input meant a full re-resolve of `low/mid/high` ANSI codes each frame. On top of that, `shimmerSegments` ran the full per-char intensity loop across the entire 60-char working message even though the classic band is only ±6 cells wide, so ~80% of the loop iterations produced tier `"low"` and were wasted.

## Fix

- `packages/coding-agent/src/modes/controllers/streaming-reveal.ts`, `tool-args-reveal.ts`: `requestRender` callback now takes the component whose subtree changed. The `StreamingRevealController` tick passes its bound `AssistantMessageComponent`; the `ToolArgsRevealController` tick collects each rendered tool component and requests a render per unique subtree.
- `packages/coding-agent/src/modes/controllers/event-controller.ts`: wire both callbacks to `ctx.ui.requestComponentRender(component)`.
- `packages/coding-agent/src/modes/components/tool-execution.ts`: `#updateSpinnerAnimation` and `#updateTodoStrikeAnimation` intervals switch to `requestComponentRender(this)` — same treatment the `Loader` component already had. Widen `ToolExecutionHandle` to `extends Component` (both concrete impls already extend `Container`) so the reveal callback sites type-check.
- `packages/coding-agent/src/modes/interactive-mode.ts`: intern the working-message `ShimmerPalette` per accent in a `WeakMap<WorkingMessageAccent, {main, hint}>`. `renderWorkingMessage` now hands the same palette object every frame while the accent is stable, so the `compile()` slot hits after the first frame.
- `packages/coding-agent/src/modes/theme/shimmer.ts`: add `activeBand(mode, time, total)` that returns the code-point window where intensity is non-zero, and short-circuit to tier `"low"` inside `shimmerSegments` when `index < lo || index > hi`. Widening the window is safe because the intensity call still runs inside it; the fast-path only drops per-char work outside the sweep.

New tests defending each contract:

- `test/streaming-reveal.test.ts` — the bound component is handed to `requestRender` on each smooth tick.
- `test/tool-args-reveal.test.ts` — the bound component is handed to `requestRender` on each rendered tick.
- `test/modes/theme/shimmer.test.ts` — off-band code points render muted (dim), the crest color reaches the band region as it sweeps, and a surrogate pair straddling the band boundary stays atomic.

## Verification

`bun check` — passes (16 packages).
`cd packages/coding-agent && bun test test/streaming-reveal.test.ts test/tool-args-reveal.test.ts test/modes/theme/shimmer.test.ts` — 42 pass, 0 fail (5 new assertions).
Full `bun test` in `packages/coding-agent`: 5795 pass, 354 fail — the same 354 failures exist on the base commit (verified by stashing the diff and rerunning), so no new regressions.

Fixes #4377