### PR TITLE
fix(fast): enable custom OpenAI-compatible providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom OpenAI-compatible relays serving OpenAI model ids so service-tier resolution can classify them as OpenAI-family targets for fast mode ([#4386](https://github.com/can1357/oh-my-pi/issues/4386)).
+
 ## [16.3.3] - 2026-07-02
 
 ### Added

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -902,7 +902,7 @@ export async function buildTransformedCodexRequestBody(
 	// `{"detail":"Unsupported parameter: temperature"}` etc., so we drop
 	// everything from `StreamOptions` rather than forwarding any of them.
 	// (#3117 — codex-rs sends none of these either.)
-	applyOpenAIServiceTier(params, options?.serviceTier, model.provider);
+	applyOpenAIServiceTier(params, options?.serviceTier, model);
 	if (context.tools && context.tools.length > 0) {
 		params.tools = convertOpenAICodexResponsesTools(context.tools, model);
 		if (options?.toolChoice) {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1433,7 +1433,7 @@ function buildParams(
 	if (options?.frequencyPenalty !== undefined) {
 		params.frequency_penalty = options.frequencyPenalty;
 	}
-	applyOpenAIServiceTier(params, options?.serviceTier, model.provider);
+	applyOpenAIServiceTier(params, options?.serviceTier, model);
 
 	if (context.tools?.length) {
 		const builtTools = convertTools(context.tools, initialCompat, toolStrictModeOverride);

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -39,7 +39,6 @@ import {
 	type MessageAttribution,
 	type Model,
 	OPENAI_MAX_OUTPUT_TOKENS,
-	type Provider,
 	type ServiceTier,
 	type StopReason,
 	type StreamOptions,
@@ -271,9 +270,9 @@ export function resolveOpenAIRequestSetup(
 export function applyOpenAIServiceTier(
 	params: { service_tier?: ServiceTier | null | undefined },
 	serviceTier: ServiceTier | null | undefined,
-	provider: Provider | undefined,
+	model: Pick<Model, "provider" | "api" | "id">,
 ): void {
-	if (!shouldSendServiceTier(serviceTier, provider)) return;
+	if (!shouldSendServiceTier(serviceTier, model)) return;
 	if (serviceTier === "flex" || serviceTier === "scale" || serviceTier === "priority") {
 		params.service_tier = serviceTier;
 	}
@@ -2385,7 +2384,7 @@ type CommonSamplingOptions = Pick<
 export function applyCommonResponsesSamplingParams<P extends CommonResponsesParams>(
 	params: P,
 	options: CommonSamplingOptions | undefined,
-	model: Pick<Model, "provider" | "omitMaxOutputTokens" | "maxTokens">,
+	model: Pick<Model, "provider" | "api" | "id" | "omitMaxOutputTokens" | "maxTokens">,
 ): void {
 	if (options?.maxTokens && !model.omitMaxOutputTokens) {
 		params.max_output_tokens = Math.min(
@@ -2400,7 +2399,7 @@ export function applyCommonResponsesSamplingParams<P extends CommonResponsesPara
 	if (options?.minP !== undefined) params.min_p = options.minP;
 	if (options?.presencePenalty !== undefined) params.presence_penalty = options.presencePenalty;
 	if (options?.repetitionPenalty !== undefined) params.repetition_penalty = options.repetitionPenalty;
-	applyOpenAIServiceTier(params, options?.serviceTier, model.provider);
+	applyOpenAIServiceTier(params, options?.serviceTier, model);
 }
 
 type ReasoningOptions = {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -141,8 +141,14 @@ function isOpenAIServiceTierApi(api: Api | undefined): boolean {
 	return api === "openai-completions" || api === "openai-responses" || api === "openai-codex-responses";
 }
 
+function hasDedicatedServiceTierControl(provider: Provider | undefined): boolean {
+	return provider === "fireworks";
+}
+
 function isOpenAIServiceTierModel(model: ServiceTierModel): boolean {
-	return isOpenAIServiceTierApi(model.api) && isOpenAIModelId(model.id);
+	return (
+		!hasDedicatedServiceTierControl(model.provider) && isOpenAIServiceTierApi(model.api) && isOpenAIModelId(model.id)
+	);
 }
 
 /**
@@ -153,8 +159,7 @@ function isOpenAIServiceTierModel(model: ServiceTierModel): boolean {
  * `openai/`); Claude on Bedrock/Vertex (api `anthropic-messages`) is the
  * anthropic family even though its provider is `amazon-bedrock`/`google-vertex`.
  * Custom OpenAI-compatible relays that serve OpenAI model ids are OpenAI family
- * too: their provider id is user-defined, but their wire API still accepts
- * OpenAI `service_tier`.
+ * too unless that provider owns a separate tier control such as Fireworks.
  */
 export function serviceTierFamily(model: ServiceTierModel): ServiceTierFamily | undefined {
 	const provider = model.provider;

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -19,7 +19,7 @@ import type {
 	WriteResult,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
-import { parseKnownModel } from "@oh-my-pi/pi-catalog/identity/classify";
+import { isOpenAIModelId } from "@oh-my-pi/pi-catalog/identity/family";
 import type { Api, FetchImpl, KnownApi, Model, Provider, ThinkingBudgets, Usage } from "@oh-my-pi/pi-catalog/types";
 import type { Type } from "arktype";
 import type { ZodType, z } from "zod/v4";
@@ -142,7 +142,7 @@ function isOpenAIServiceTierApi(api: Api | undefined): boolean {
 }
 
 function isOpenAIServiceTierModel(model: ServiceTierModel): boolean {
-	return isOpenAIServiceTierApi(model.api) && parseKnownModel(model.id).family === "openai";
+	return isOpenAIServiceTierApi(model.api) && isOpenAIModelId(model.id);
 }
 
 /**

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -19,6 +19,7 @@ import type {
 	WriteResult,
 } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { parseKnownModel } from "@oh-my-pi/pi-catalog/identity/classify";
 import type { Api, FetchImpl, KnownApi, Model, Provider, ThinkingBudgets, Usage } from "@oh-my-pi/pi-catalog/types";
 import type { Type } from "arktype";
 import type { ZodType, z } from "zod/v4";
@@ -134,6 +135,16 @@ export type ServiceTierFamily = "openai" | "anthropic" | "google";
  */
 export type ServiceTierByFamily = Partial<Record<ServiceTierFamily, ServiceTier>>;
 
+type ServiceTierModel = Pick<Model, "provider" | "api" | "id">;
+
+function isOpenAIServiceTierApi(api: Api | undefined): boolean {
+	return api === "openai-completions" || api === "openai-responses" || api === "openai-codex-responses";
+}
+
+function isOpenAIServiceTierModel(model: ServiceTierModel): boolean {
+	return isOpenAIServiceTierApi(model.api) && parseKnownModel(model.id).family === "openai";
+}
+
 /**
  * Classify a model into the service-tier family whose knob governs it, or
  * `undefined` when the model exposes no serving-priority control.
@@ -141,8 +152,11 @@ export type ServiceTierByFamily = Partial<Record<ServiceTierFamily, ServiceTier>
  * OpenRouter models are classified by id namespace (`anthropic/`, `google/`,
  * `openai/`); Claude on Bedrock/Vertex (api `anthropic-messages`) is the
  * anthropic family even though its provider is `amazon-bedrock`/`google-vertex`.
+ * Custom OpenAI-compatible relays that serve OpenAI model ids are OpenAI family
+ * too: their provider id is user-defined, but their wire API still accepts
+ * OpenAI `service_tier`.
  */
-export function serviceTierFamily(model: Pick<Model, "provider" | "api" | "id">): ServiceTierFamily | undefined {
+export function serviceTierFamily(model: ServiceTierModel): ServiceTierFamily | undefined {
 	const provider = model.provider;
 	if (provider === "openrouter") {
 		const id = model.id.toLowerCase();
@@ -154,6 +168,7 @@ export function serviceTierFamily(model: Pick<Model, "provider" | "api" | "id">)
 	if (provider === "openai" || provider === "openai-codex") return "openai";
 	if (model.api === "anthropic-messages") return "anthropic";
 	if (provider === "google" || provider === "google-vertex") return "google";
+	if (isOpenAIServiceTierModel(model)) return "openai";
 	return undefined;
 }
 
@@ -179,10 +194,14 @@ export function resolveModelServiceTier(
  */
 export function shouldSendServiceTier(
 	serviceTier: ServiceTier | null | undefined,
-	provider: Provider | undefined,
+	target: Provider | ServiceTierModel | undefined,
 ): boolean {
 	if (!serviceTier) return false;
+	const provider = typeof target === "string" ? target : target?.provider;
 	if (provider === "openai" || provider === "openai-codex" || provider === "openrouter") {
+		return serviceTier === "flex" || serviceTier === "scale" || serviceTier === "priority";
+	}
+	if (typeof target !== "string" && target && isOpenAIServiceTierModel(target)) {
 		return serviceTier === "flex" || serviceTier === "scale" || serviceTier === "priority";
 	}
 	if (provider === "google") {
@@ -213,7 +232,7 @@ export function realizesPriorityServiceTier(
 		return family === "openai" || family === "google";
 	}
 	if (model.api === "anthropic-messages") return false;
-	return shouldSendServiceTier(serviceTier, model.provider);
+	return shouldSendServiceTier(serviceTier, model);
 }
 
 /**

--- a/packages/ai/test/service-tier-premium-requests.test.ts
+++ b/packages/ai/test/service-tier-premium-requests.test.ts
@@ -22,6 +22,7 @@ const vertexClaude = m("google-vertex", "anthropic-messages", "claude-opus-4-6")
 const gemini = m("google", "google-generative-ai", "gemini-3-flash");
 const vertexGemini = m("google-vertex", "google-vertex", "gemini-3-flash");
 const fireworks = m("fireworks", "openai-completions", "qwen3");
+const fireworksOpenAI = m("fireworks", "openai-completions", "gpt-oss-120b");
 const orOpenAI = m("openrouter", "openai-responses", "openai/gpt-5.5");
 const orGoogle = m("openrouter", "openai-completions", "google/gemini-3-flash");
 const orAnthropic = m("openrouter", "openai-completions", "anthropic/claude-opus-4-6");
@@ -43,6 +44,7 @@ describe("serviceTierFamily", () => {
 		expect(serviceTierFamily(gemini)).toBe("google");
 		expect(serviceTierFamily(vertexGemini)).toBe("google");
 		expect(serviceTierFamily(fireworks)).toBeUndefined();
+		expect(serviceTierFamily(fireworksOpenAI)).toBeUndefined();
 	});
 
 	it("classifies OpenAI-compatible custom providers by api", () => {
@@ -69,6 +71,7 @@ describe("resolveModelServiceTier", () => {
 		expect(resolveModelServiceTier(tiers, orAnthropic)).toBe("priority");
 		expect(resolveModelServiceTier(tiers, customCodex)).toBe("priority");
 		expect(resolveModelServiceTier(tiers, fireworks)).toBeUndefined(); // no family
+		expect(resolveModelServiceTier(tiers, fireworksOpenAI)).toBeUndefined(); // dedicated provider tier
 		expect(resolveModelServiceTier(undefined, openai)).toBeUndefined();
 		expect(resolveModelServiceTier({ google: "priority" }, openai)).toBeUndefined();
 	});
@@ -147,6 +150,7 @@ describe("getPriorityPremiumRequests", () => {
 		expect(getPriorityPremiumRequests("priority", orOpenAI)).toBe(0); // OpenRouter bills its own way
 		expect(getPriorityPremiumRequests("priority", vertexClaude)).toBe(0); // not realized
 		expect(getPriorityPremiumRequests("priority", fireworks)).toBe(0); // realized but not Copilot-premium
+		expect(getPriorityPremiumRequests("priority", fireworksOpenAI)).toBe(0); // dedicated provider tier
 		expect(getPriorityPremiumRequests("flex", openai)).toBe(0);
 		expect(getPriorityPremiumRequests(undefined, openai)).toBe(0);
 	});

--- a/packages/ai/test/service-tier-premium-requests.test.ts
+++ b/packages/ai/test/service-tier-premium-requests.test.ts
@@ -27,6 +27,12 @@ const orGoogle = m("openrouter", "openai-completions", "google/gemini-3-flash");
 const orAnthropic = m("openrouter", "openai-completions", "anthropic/claude-opus-4-6");
 const customOpenAI = m("custom-relay", "openai-completions", "gpt-5.5");
 const customCodex = m("custom-relay", "openai-codex-responses", "gpt-5.5");
+const customOpenAIAliases = [
+	m("custom-relay", "openai-responses", "gpt-4o"),
+	m("custom-relay", "openai-responses", "o3"),
+	m("custom-relay", "openai-responses", "o4-mini"),
+	m("custom-relay", "openai-responses", "codex-mini-latest"),
+];
 
 describe("serviceTierFamily", () => {
 	it("classifies first-party providers by provider/api", () => {
@@ -42,6 +48,9 @@ describe("serviceTierFamily", () => {
 	it("classifies OpenAI-compatible custom providers by api", () => {
 		expect(serviceTierFamily(customOpenAI)).toBe("openai");
 		expect(serviceTierFamily(customCodex)).toBe("openai");
+		for (const model of customOpenAIAliases) {
+			expect(serviceTierFamily(model)).toBe("openai");
+		}
 	});
 
 	it("classifies OpenRouter models by id namespace", () => {
@@ -77,6 +86,9 @@ describe("shouldSendServiceTier", () => {
 		expect(shouldSendServiceTier("priority", customCodex)).toBe(true);
 		expect(shouldSendServiceTier("scale", customOpenAI)).toBe(true);
 		expect(shouldSendServiceTier("default", customOpenAI)).toBe(false);
+		for (const model of customOpenAIAliases) {
+			expect(shouldSendServiceTier("priority", model)).toBe(true);
+		}
 	});
 
 	it("sends flex/priority on direct Google, priority-only on Vertex (no scale)", () => {
@@ -109,6 +121,9 @@ describe("realizesPriorityServiceTier", () => {
 		expect(realizesPriorityServiceTier("priority", orOpenAI)).toBe(true);
 		expect(realizesPriorityServiceTier("priority", orGoogle)).toBe(true);
 		expect(realizesPriorityServiceTier("priority", customCodex)).toBe(true);
+		for (const model of customOpenAIAliases) {
+			expect(realizesPriorityServiceTier("priority", model)).toBe(true);
+		}
 	});
 
 	it("does not realize priority where the wire drops it", () => {

--- a/packages/ai/test/service-tier-premium-requests.test.ts
+++ b/packages/ai/test/service-tier-premium-requests.test.ts
@@ -25,6 +25,8 @@ const fireworks = m("fireworks", "openai-completions", "qwen3");
 const orOpenAI = m("openrouter", "openai-responses", "openai/gpt-5.5");
 const orGoogle = m("openrouter", "openai-completions", "google/gemini-3-flash");
 const orAnthropic = m("openrouter", "openai-completions", "anthropic/claude-opus-4-6");
+const customOpenAI = m("custom-relay", "openai-completions", "gpt-5.5");
+const customCodex = m("custom-relay", "openai-codex-responses", "gpt-5.5");
 
 describe("serviceTierFamily", () => {
 	it("classifies first-party providers by provider/api", () => {
@@ -35,6 +37,11 @@ describe("serviceTierFamily", () => {
 		expect(serviceTierFamily(gemini)).toBe("google");
 		expect(serviceTierFamily(vertexGemini)).toBe("google");
 		expect(serviceTierFamily(fireworks)).toBeUndefined();
+	});
+
+	it("classifies OpenAI-compatible custom providers by api", () => {
+		expect(serviceTierFamily(customOpenAI)).toBe("openai");
+		expect(serviceTierFamily(customCodex)).toBe("openai");
 	});
 
 	it("classifies OpenRouter models by id namespace", () => {
@@ -51,6 +58,7 @@ describe("resolveModelServiceTier", () => {
 		expect(resolveModelServiceTier(tiers, openai)).toBe("priority");
 		expect(resolveModelServiceTier(tiers, gemini)).toBe("flex");
 		expect(resolveModelServiceTier(tiers, orAnthropic)).toBe("priority");
+		expect(resolveModelServiceTier(tiers, customCodex)).toBe("priority");
 		expect(resolveModelServiceTier(tiers, fireworks)).toBeUndefined(); // no family
 		expect(resolveModelServiceTier(undefined, openai)).toBeUndefined();
 		expect(resolveModelServiceTier({ google: "priority" }, openai)).toBeUndefined();
@@ -66,6 +74,9 @@ describe("shouldSendServiceTier", () => {
 			expect(shouldSendServiceTier("default", p)).toBe(false);
 			expect(shouldSendServiceTier("auto", p)).toBe(false);
 		}
+		expect(shouldSendServiceTier("priority", customCodex)).toBe(true);
+		expect(shouldSendServiceTier("scale", customOpenAI)).toBe(true);
+		expect(shouldSendServiceTier("default", customOpenAI)).toBe(false);
 	});
 
 	it("sends flex/priority on direct Google, priority-only on Vertex (no scale)", () => {
@@ -97,6 +108,7 @@ describe("realizesPriorityServiceTier", () => {
 		expect(realizesPriorityServiceTier("priority", fireworks)).toBe(true);
 		expect(realizesPriorityServiceTier("priority", orOpenAI)).toBe(true);
 		expect(realizesPriorityServiceTier("priority", orGoogle)).toBe(true);
+		expect(realizesPriorityServiceTier("priority", customCodex)).toBe(true);
 	});
 
 	it("does not realize priority where the wire drops it", () => {

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -118,9 +118,13 @@ export const isOpenAIGptOssModelId = memo((modelId: string): boolean => {
 	return /(^|\/)gpt-oss[-:]/i.test(modelId);
 });
 
-/** OpenAI model ids (gpt-*, o1-*, o3-*, o4-*, or prefixed with openai/). */
+/** OpenAI model ids (gpt-*, chatgpt-*, o1/o3/o4 SKUs, codex-*, or openai/*). */
 export const isOpenAIModelId = memo((modelId: string): boolean => {
-	return /(^|\/)(gpt|o1|o3|o4)[-.]/i.test(modelId) || modelId.toLowerCase().includes("openai/");
+	return (
+		/(^|\/)(?:gpt|chatgpt|codex)[-.]/i.test(modelId) ||
+		/(^|\/)o[134](?:[-.]|$)/i.test(modelId) ||
+		modelId.toLowerCase().includes("openai/")
+	);
 });
 
 /** OpenAI models at or above the gpt-5.4 wire generation, keyed off the parsed version. */

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -9,6 +9,7 @@ import {
 	isMinimaxM2FamilyModelId,
 	isMinimaxM3FamilyModelId,
 	isOpenAIGptOssModelId,
+	isOpenAIModelId,
 	isReasoningGlmModelId,
 	modelFamilyToken,
 	supportsAdaptiveThinkingDisplay,
@@ -152,6 +153,14 @@ describe("isOpenAIGptOssModelId", () => {
 		expect(isOpenAIGptOssModelId("gpt-4.1-mini")).toBe(false);
 		expect(isOpenAIGptOssModelId("oss-llm")).toBe(false);
 		expect(isOpenAIGptOssModelId("MiniMax-M2.7")).toBe(false);
+	});
+});
+
+describe("isOpenAIModelId", () => {
+	test("matches current OpenAI ids across GPT, o-series, ChatGPT, and Codex aliases", () => {
+		for (const id of ["gpt-4o", "o3", "o4-mini", "chatgpt-4o-latest", "codex-mini-latest"]) {
+			expect(isOpenAIModelId(id)).toBe(true);
+		}
 	});
 });
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `omp usage` hiding sibling-only limits such as Claude 7 Day (Fable) on accounts whose current report omitted that scoped bucket; the account now renders an explicit `not reported` row instead of looking like the usage refresh skipped the column.
+- Fixed `/fast on` for custom OpenAI-compatible providers serving OpenAI models, and report unsupported models as unavailable instead of claiming fast mode was enabled ([#4386](https://github.com/can1357/oh-my-pi/issues/4386)).
 
 ## [16.3.3] - 2026-07-02
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9122,24 +9122,26 @@ export class AgentSession {
 
 	/**
 	 * `/fast on|off` targets the family of the currently selected model: it sets
-	 * (or clears) that family's `priority` tier. Models without a service-tier
-	 * family (Fireworks, or providers with no tier knob) have nothing to toggle.
+	 * (or clears) that family's `priority` tier. Returns `false` when the model
+	 * has no service-tier family, so callers can report that fast mode is
+	 * unavailable instead of claiming success.
 	 */
-	setFastMode(enabled: boolean): void {
+	setFastMode(enabled: boolean): boolean {
 		const family = this.model ? serviceTierFamily(this.model) : undefined;
 		if (!family) {
 			this.emitNotice("info", "The current model has no service-tier control for /fast to toggle.", "priority");
-			return;
+			return false;
 		}
 		if (!enabled) {
 			if (this.#serviceTierByFamily[family] === "priority") this.setServiceTierFamily(family, undefined);
-			return;
+			return true;
 		}
 		this.setServiceTierFamily(family, "priority");
+		return true;
 	}
 
 	toggleFastMode(): boolean {
-		this.setFastMode(!this.isFastModeEnabled());
+		if (!this.setFastMode(!this.isFastModeEnabled())) return false;
 		return this.isFastModeEnabled();
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -380,8 +380,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return commandConsumed();
 			}
 			if (arg === "on") {
-				runtime.session.setFastMode(true);
-				await runtime.output("Fast mode enabled.");
+				const supported = runtime.session.setFastMode(true);
+				await runtime.output(supported ? "Fast mode enabled." : "Fast mode is unavailable for the current model.");
 				return commandConsumed();
 			}
 			if (arg === "off") {
@@ -405,9 +405,11 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return;
 			}
 			if (arg === "on") {
-				runtime.ctx.session.setFastMode(true);
+				const supported = runtime.ctx.session.setFastMode(true);
 				refreshStatusLine(runtime.ctx);
-				runtime.ctx.showStatus("Fast mode enabled.");
+				runtime.ctx.showStatus(
+					supported ? "Fast mode enabled." : "Fast mode is unavailable for the current model.",
+				);
 				runtime.ctx.editor.setText("");
 				return;
 			}

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -336,8 +336,9 @@ class FakeAgentSession {
 		return this.fastMode;
 	}
 
-	setFastMode(enabled: boolean): void {
+	setFastMode(enabled: boolean): boolean {
 		this.fastMode = enabled;
+		return true;
 	}
 
 	isFastModeEnabled(): boolean {

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -25,7 +25,7 @@ interface FakeAcpBuiltinSession {
 	_switchedTo: string | undefined;
 	_movedFromEmptySessionFile: string | undefined;
 	toggleFastMode(): boolean;
-	setFastMode(enabled: boolean): void;
+	setFastMode(enabled: boolean): boolean;
 	isFastModeEnabled(): boolean;
 	setForcedToolChoice(toolName: string): void;
 	fetchUsageReports?: () => Promise<unknown>;
@@ -97,6 +97,7 @@ function createRuntime() {
 		},
 		setFastMode(enabled: boolean) {
 			this.fastMode = enabled;
+			return true;
 		},
 		isFastModeEnabled() {
 			return this.fastMode;

--- a/packages/coding-agent/test/fast-mode-scope.test.ts
+++ b/packages/coding-agent/test/fast-mode-scope.test.ts
@@ -89,6 +89,27 @@ describe("/fast targets the current model's service-tier family", () => {
 		expect(session.isFastModeActive()).toBe(true);
 	});
 
+	it("leaves Fireworks models on the dedicated Fireworks tier control", async () => {
+		const session = await createSessionForModel(
+			buildModel({
+				id: "gpt-oss-120b",
+				name: "GPT OSS 120B",
+				api: "openai-completions",
+				provider: "fireworks",
+				baseUrl: "https://api.fireworks.ai/inference/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 64_000,
+			}),
+		);
+		expect(session.setFastMode(true)).toBe(false);
+		expect(session.serviceTierByFamily).toEqual({});
+		expect(session.isFastModeEnabled()).toBe(false);
+		expect(session.isFastModeActive()).toBe(false);
+	});
+
 	it("clears only the current model's family when disabled", async () => {
 		const session = await createSession("anthropic", "claude-sonnet-4-5");
 		session.setFastMode(true);

--- a/packages/coding-agent/test/fast-mode-scope.test.ts
+++ b/packages/coding-agent/test/fast-mode-scope.test.ts
@@ -71,9 +71,9 @@ describe("/fast targets the current model's service-tier family", () => {
 	it("enables priority for a custom OpenAI-compatible relay serving an OpenAI model", async () => {
 		const session = await createSessionForModel(
 			buildModel({
-				id: "gpt-5.5",
-				name: "GPT-5.5 Relay",
-				api: "openai-codex-responses",
+				id: "o4-mini",
+				name: "O4 Mini Relay",
+				api: "openai-responses",
 				provider: "custom-relay",
 				baseUrl: "https://relay.example/v1",
 				reasoning: true,

--- a/packages/coding-agent/test/fast-mode-scope.test.ts
+++ b/packages/coding-agent/test/fast-mode-scope.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -32,6 +34,10 @@ describe("/fast targets the current model's service-tier family", () => {
 		if (!model) {
 			throw new Error(`Expected bundled test model ${provider}/${modelId} to exist`);
 		}
+		return createSessionForModel(model);
+	}
+
+	async function createSessionForModel(model: Model<Api>): Promise<AgentSession> {
 		const agent = new Agent({
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
 		});
@@ -60,6 +66,27 @@ describe("/fast targets the current model's service-tier family", () => {
 		session.setFastMode(true);
 		expect(session.serviceTierByFamily).toEqual({ openai: "priority" });
 		expect(session.isFastModeEnabled()).toBe(true);
+	});
+
+	it("enables priority for a custom OpenAI-compatible relay serving an OpenAI model", async () => {
+		const session = await createSessionForModel(
+			buildModel({
+				id: "gpt-5.5",
+				name: "GPT-5.5 Relay",
+				api: "openai-codex-responses",
+				provider: "custom-relay",
+				baseUrl: "https://relay.example/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 400_000,
+				maxTokens: 64_000,
+			}),
+		);
+		expect(session.setFastMode(true)).toBe(true);
+		expect(session.serviceTierByFamily).toEqual({ openai: "priority" });
+		expect(session.isFastModeEnabled()).toBe(true);
+		expect(session.isFastModeActive()).toBe(true);
 	});
 
 	it("clears only the current model's family when disabled", async () => {


### PR DESCRIPTION
## Repro
Added a regression to `packages/ai/test/service-tier-premium-requests.test.ts` for a `custom-relay` model using `openai-codex-responses`: before the fix, `bun test packages/ai/test/service-tier-premium-requests.test.ts` failed because `serviceTierFamily()` returned `undefined` instead of `openai`.

## Cause
`packages/ai/src/types.ts` classified OpenAI service-tier families by provider id only (`openai`, `openai-codex`, or OpenRouter namespace), so models from `models.yml` kept their custom provider id and had no family for `AgentSession.setFastMode()` in `packages/coding-agent/src/session/agent-session.ts`. The OpenAI wire helper in `packages/ai/src/providers/openai-shared.ts` also gated `service_tier` by provider id, so eligible custom relays would still have dropped the request field.

## Fix
- Classify custom OpenAI-compatible models serving parsed OpenAI model ids as the OpenAI service-tier family.
- Pass the model object into OpenAI service-tier wire gating so eligible custom relays can emit `service_tier`.
- Return fast-mode support status from `AgentSession.setFastMode()` and make `/fast on` report unavailable when there is no service-tier family.
- Added service-tier and session-level regression coverage for custom OpenAI-compatible relays.

## Verification
`bun test packages/ai/test/service-tier-premium-requests.test.ts` passed; `bun test packages/coding-agent/test/fast-mode-scope.test.ts` passed; `bun test packages/coding-agent/test/acp-builtins.test.ts` passed; `bun check` passed. Fixes #4386