### PR TITLE
fix(mnemopi): preserve empty structured extraction

### DIFF
--- a/packages/mnemopi/src/core/extraction.ts
+++ b/packages/mnemopi/src/core/extraction.ts
@@ -115,9 +115,7 @@ export function parseFacts(rawOutput: string | null | undefined): string[] {
 						}
 					}
 				}
-				if (out.length > 0) {
-					return out.slice(0, 5);
-				}
+				return out.slice(0, 5);
 			}
 		} catch {
 			const matches = [...raw.matchAll(/"([^"]{10,})"/g)].map(m => m[1]).filter((v): v is string => v !== undefined);

--- a/packages/mnemopi/test/extraction.test.ts
+++ b/packages/mnemopi/test/extraction.test.ts
@@ -52,6 +52,13 @@ describe("structured extraction", () => {
 		expect(parseFacts("NO_FACTS")).toEqual([]);
 	});
 
+	it("treats a valid empty structured extraction as no facts", () => {
+		expect(parseFacts('{"facts": [], "instructions": [], "preferences": [], "timelines": [], "kg": []}')).toEqual([]);
+		expect(
+			parseFacts('```json\n{"facts": [], "instructions": [], "preferences": [], "timelines": [], "kg": []}\n```'),
+		).toEqual([]);
+	});
+
 	it("uses deterministic heuristic extraction when no LLM is configured", async () => {
 		process.env.MNEMOPI_LLM_ENABLED = "false";
 		const facts = await extractFactsSafe("My name is Ada. I work at Example Corp and I prefer dark mode.");


### PR DESCRIPTION
## Repro
A valid empty mnemopi extractor response should mean no memory items, but `parseFacts('{"facts": [], "instructions": [], "preferences": [], "timelines": [], "kg": []}')` returned the JSON body as a fact. Reproduced with `bun test packages/mnemopi/test/extraction.test.ts -t "valid empty structured extraction"`, which failed before the fix with the JSON string in the received array.

## Cause
`packages/mnemopi/src/core/extraction.ts` parsed structured JSON in `parseFacts`, collected supported categories, and only returned early when `out.length > 0`; successfully parsed empty objects then fell through to the legacy line heuristic over the raw JSON body.

## Fix
- Return the structured parse result from `parseFacts` even when the result is empty.
- Cover both plain and fenced empty extractor JSON in `packages/mnemopi/test/extraction.test.ts`.

## Verification
`bun test packages/mnemopi/test/extraction.test.ts` passed: 9 tests, 24 expectations. `bun run --cwd packages/mnemopi check` passed: Biome checked 135 files and `tsgo -p tsconfig.json --noEmit` completed. Fixes #4390