### PR TITLE
fix(mnemopi): preserve extraction categories

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed background LLM fact extraction preserving extractor categories so `instructions`, `preferences`, `timelines`, and `kg` triples populate their MEMORIA tables and graph triples instead of being flattened into generic `fact/entity` rows. ([#4389](https://github.com/can1357/oh-my-pi/issues/4389))
+
 ## [16.2.2] - 2026-06-27
 
 ### Fixed

--- a/packages/mnemopi/src/core/beam/consolidate.ts
+++ b/packages/mnemopi/src/core/beam/consolidate.ts
@@ -3,7 +3,7 @@ import { generateId, stableMemoryId } from "../../util/ids";
 import { aaakEncode } from "../aaak";
 import { REGEX_EXTRACTION_MAX_INPUT_CHARS } from "../entities";
 import { EpisodicGraph } from "../episodic-graph";
-import { heuristicExtractFacts } from "../extraction";
+import { type ExtractedFactCategories, heuristicExtractFacts } from "../extraction";
 import { clampVeracity } from "../veracity-consolidation";
 import { scheduleEmbedding } from "./helpers";
 import type { BeamMemoryState, BeamStats, JsonValue, MemoriaRetrieveResult, Metadata, SleepResult } from "./types";
@@ -292,7 +292,7 @@ function insertFactRows(
 function insertTimeline(
 	beam: BeamMemoryState,
 	messageIdx: number,
-	date: string,
+	date: string | null,
 	description: string,
 	sourceMemoryId: string | null,
 ): void {
@@ -325,6 +325,38 @@ function insertKg(
 		source: sourceMemoryId ?? "extraction",
 		confidence: 0.65,
 	});
+}
+
+function insertPreference(
+	beam: BeamMemoryState,
+	messageIdx: number,
+	preference: string,
+	topic: string | null,
+	sourceMemoryId: string | null,
+): void {
+	beam.db.run(
+		`INSERT INTO memoria_preferences (session_id, message_idx, preference, topic, evolution, context_snippet, source_memory_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		[sourceSession(beam), messageIdx, preference, topic, null, preference, sourceMemoryId],
+	);
+}
+
+function insertInstruction(
+	beam: BeamMemoryState,
+	messageIdx: number,
+	instruction: string,
+	context: string,
+	sourceMemoryId: string | null,
+): void {
+	beam.db.run(
+		`INSERT INTO memoria_instructions (session_id, message_idx, instruction, active, topic, context_snippet, source_memory_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		[sourceSession(beam), messageIdx, instruction, 1, null, context, sourceMemoryId],
+	);
+}
+
+function timelineDate(description: string): string | null {
+	return /\b\d{4}-\d{2}-\d{2}\b/.exec(description)?.[0] ?? null;
 }
 
 /**
@@ -458,33 +490,65 @@ export function detectLanguage(_beam: BeamMemoryState, text: string): string {
 	}
 	return spanish >= 3 ? "es" : "en";
 }
+type StoreFactStringOptions = {
+	routeHeuristicCategories?: boolean;
+};
+
 export function storeFactStrings(
 	beam: BeamMemoryState,
 	facts: readonly string[],
 	messageIdx = 0,
 	sourceMemoryId: string | null = null,
 	importance = 0.7,
+	options: StoreFactStringOptions = {},
 ): number {
+	const routeHeuristicCategories = options.routeHeuristicCategories ?? true;
 	let stored = 0;
 	for (const fact of facts) {
 		insertFactRows(beam, messageIdx, "entity", "fact", fact, fact, importance, sourceMemoryId);
 		stored++;
+		if (!routeHeuristicCategories) continue;
 		const pref = /^The user (prefers|dislikes) (.+)$/i.exec(fact);
 		if (pref?.[2]) {
-			beam.db.run(
-				`INSERT INTO memoria_preferences (session_id, message_idx, preference, topic, evolution, context_snippet, source_memory_id)
-				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-				[sourceSession(beam), messageIdx, fact, pref[2], null, fact, sourceMemoryId],
-			);
+			insertPreference(beam, messageIdx, fact, pref[2], sourceMemoryId);
 		}
 		const instruction = /^Instruction: (.+)$/i.exec(fact);
 		if (instruction?.[1]) {
-			beam.db.run(
-				`INSERT INTO memoria_instructions (session_id, message_idx, instruction, active, topic, context_snippet, source_memory_id)
-				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-				[sourceSession(beam), messageIdx, instruction[1], 1, null, fact, sourceMemoryId],
-			);
+			insertInstruction(beam, messageIdx, instruction[1], fact, sourceMemoryId);
 		}
+	}
+	return stored;
+}
+
+/** Store category-preserving LLM extraction output in MEMORIA and KG tables. */
+export function storeExtractedFactCategories(
+	beam: BeamMemoryState,
+	extracted: ExtractedFactCategories,
+	messageIdx = 0,
+	sourceMemoryId: string | null = null,
+	importance = 0.7,
+): number {
+	let stored = storeFactStrings(beam, extracted.facts, messageIdx, sourceMemoryId, importance);
+	stored += storeFactStrings(beam, extracted.instructions, messageIdx, sourceMemoryId, importance, {
+		routeHeuristicCategories: false,
+	});
+	stored += storeFactStrings(beam, extracted.preferences, messageIdx, sourceMemoryId, importance, {
+		routeHeuristicCategories: false,
+	});
+	stored += storeFactStrings(beam, extracted.timelines, messageIdx, sourceMemoryId, importance, {
+		routeHeuristicCategories: false,
+	});
+	for (const instruction of extracted.instructions) {
+		insertInstruction(beam, messageIdx, instruction, instruction, sourceMemoryId);
+	}
+	for (const preference of extracted.preferences) {
+		insertPreference(beam, messageIdx, preference, null, sourceMemoryId);
+	}
+	for (const timeline of extracted.timelines) {
+		insertTimeline(beam, messageIdx, timelineDate(timeline), timeline, sourceMemoryId);
+	}
+	for (const triple of extracted.kg) {
+		insertKg(beam, messageIdx, triple.subject, triple.predicate, triple.object, sourceMemoryId);
 	}
 	return stored;
 }

--- a/packages/mnemopi/src/core/beam/store.ts
+++ b/packages/mnemopi/src/core/beam/store.ts
@@ -5,9 +5,9 @@ import { toUtcIso } from "../../util/datetime";
 import { generateId } from "../../util/ids";
 import { currentEmbeddingModel, embeddingsDisabled } from "../embeddings";
 import { EpisodicGraph } from "../episodic-graph";
-import { extractFactsSafe } from "../extraction";
+import { countExtractedFactCategories, extractFactCategoriesSafe } from "../extraction";
 import { getMnemopiRuntimeOptions, withMnemopiRuntimeOptions } from "../runtime-options";
-import { storeFactStrings } from "./consolidate";
+import { storeExtractedFactCategories } from "./consolidate";
 import { type EmbedItem, scheduleEmbedding, vecAvailable, vecInsert } from "./helpers";
 import type {
 	BeamEvent,
@@ -223,9 +223,9 @@ function proactiveLinkIfEnabled(
  */
 async function runFactExtraction(beam: BeamMemoryState, memoryId: string, content: string): Promise<void> {
 	try {
-		const facts = await extractFactsSafe(content);
-		if (facts.length === 0) return;
-		storeFactStrings(beam, facts, 0, memoryId);
+		const extracted = await extractFactCategoriesSafe(content);
+		if (countExtractedFactCategories(extracted) === 0) return;
+		storeExtractedFactCategories(beam, extracted, 0, memoryId);
 		invalidateCaches(beam);
 	} catch {
 		// Background fact extraction is best-effort and never surfaces to the caller.

--- a/packages/mnemopi/src/core/extraction.ts
+++ b/packages/mnemopi/src/core/extraction.ts
@@ -82,50 +82,146 @@ function stripFence(raw: string): string {
 	return s.trim();
 }
 
+const FLAT_FACT_LIMIT = 5;
+const STRUCTURED_CATEGORY_LIMIT = 5;
+const STRING_CATEGORY_KEYS = ["facts", "instructions", "preferences", "timelines"] as const;
+
+/** Parsed knowledge-graph edge emitted by the extractor LLM. */
+export interface ExtractedKgTriple {
+	subject: string;
+	predicate: string;
+	object: string;
+}
+
+/** Category-preserving extraction result used by background memory routing. */
+export interface ExtractedFactCategories {
+	facts: string[];
+	instructions: string[];
+	preferences: string[];
+	timelines: string[];
+	kg: ExtractedKgTriple[];
+}
+
+function emptyFactCategories(): ExtractedFactCategories {
+	return { facts: [], instructions: [], preferences: [], timelines: [], kg: [] };
+}
+
 function normalizeFact(fact: string): string {
 	const trimmed = fact.trim();
 	// Remove trailing sentence punctuation (. ! ?) if present
 	return trimmed.replace(/[.!?]+$/, "");
 }
-export function parseFacts(rawOutput: string | null | undefined): string[] {
-	if (rawOutput === null || rawOutput === undefined) {
+
+function normalizeFactArray(items: unknown): string[] {
+	if (!Array.isArray(items)) {
 		return [];
+	}
+	const out: string[] = [];
+	for (const item of items) {
+		if (item !== null && item !== undefined && String(item).trim() !== "") {
+			const normalized = normalizeFact(String(item));
+			if (normalized !== "") {
+				out.push(normalized);
+				if (out.length >= STRUCTURED_CATEGORY_LIMIT) break;
+			}
+		}
+	}
+	return out;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function triplePart(value: unknown): string {
+	return typeof value === "string" ? normalizeFact(value) : "";
+}
+
+function normalizeKgTriple(item: unknown): ExtractedKgTriple | null {
+	let subject = "";
+	let predicate = "";
+	let object = "";
+	if (isRecord(item)) {
+		subject = triplePart(item.subject);
+		predicate = triplePart(item.predicate);
+		object = triplePart(item.object);
+	} else if (Array.isArray(item)) {
+		subject = triplePart(item[0]);
+		predicate = triplePart(item[1]);
+		object = triplePart(item[2]);
+	}
+	return subject !== "" && predicate !== "" && object !== "" ? { subject, predicate, object } : null;
+}
+
+function normalizeKgArray(items: unknown): ExtractedKgTriple[] {
+	if (!Array.isArray(items)) {
+		return [];
+	}
+	const out: ExtractedKgTriple[] = [];
+	for (const item of items) {
+		const triple = normalizeKgTriple(item);
+		if (triple !== null) {
+			out.push(triple);
+			if (out.length >= STRUCTURED_CATEGORY_LIMIT) break;
+		}
+	}
+	return out;
+}
+
+/** Flatten extracted string categories for legacy fact callers. */
+export function flattenExtractedFactCategories(extracted: ExtractedFactCategories): string[] {
+	const out: string[] = [];
+	for (const category of STRING_CATEGORY_KEYS) {
+		for (const item of extracted[category]) {
+			out.push(item);
+		}
+	}
+	return out;
+}
+
+/** Count string facts plus KG triples in a category-preserving extraction result. */
+export function countExtractedFactCategories(extracted: ExtractedFactCategories): number {
+	return (
+		extracted.facts.length +
+		extracted.instructions.length +
+		extracted.preferences.length +
+		extracted.timelines.length +
+		extracted.kg.length
+	);
+}
+
+/** Parse extractor output without discarding MEMORIA categories or KG triples. */
+export function parseExtractedFactCategories(rawOutput: string | null | undefined): ExtractedFactCategories {
+	if (rawOutput === null || rawOutput === undefined) {
+		return emptyFactCategories();
 	}
 	const raw = rawOutput.trim();
 	if (raw === "" || raw.toUpperCase() === "NO_FACTS") {
-		return [];
+		return emptyFactCategories();
 	}
 	const rawClean = stripFence(raw);
 	if (rawClean.startsWith("{")) {
 		try {
-			const parsed = JSON.parse(rawClean) as unknown;
-			if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
-				const obj = parsed as Record<string, unknown>;
-				const out: string[] = [];
-				for (const category of ["facts", "instructions", "preferences", "timelines"] as const) {
-					const items = obj[category];
-					if (Array.isArray(items)) {
-						for (const item of items) {
-							if (item !== null && item !== undefined && String(item).trim() !== "") {
-								const normalized = normalizeFact(String(item));
-								if (normalized !== "") {
-									out.push(normalized);
-								}
-							}
-						}
-					}
-				}
-				if (out.length > 0) {
-					return out.slice(0, 5);
-				}
+			const parsed: unknown = JSON.parse(rawClean);
+			if (isRecord(parsed)) {
+				return {
+					facts: normalizeFactArray(parsed.facts),
+					instructions: normalizeFactArray(parsed.instructions),
+					preferences: normalizeFactArray(parsed.preferences),
+					timelines: normalizeFactArray(parsed.timelines),
+					kg: normalizeKgArray(parsed.kg),
+				};
 			}
 		} catch {
 			const matches = [...raw.matchAll(/"([^"]{10,})"/g)].map(m => m[1]).filter((v): v is string => v !== undefined);
 			if (matches.length > 0) {
-				return matches
-					.map(normalizeFact)
-					.filter(f => f !== "")
-					.slice(0, 5);
+				return {
+					...emptyFactCategories(),
+					facts: matches
+						.map(normalizeFact)
+						.filter(f => f !== "")
+						.slice(0, FLAT_FACT_LIMIT),
+				};
 			}
 		}
 	}
@@ -138,8 +234,14 @@ export function parseFacts(rawOutput: string | null | undefined): string[] {
 				cleaned.push(normalized);
 			}
 		}
+		if (cleaned.length >= FLAT_FACT_LIMIT) break;
 	}
-	return cleaned.slice(0, 5);
+	return { ...emptyFactCategories(), facts: cleaned };
+}
+
+/** Parse extractor output into the legacy flat string fact list. */
+export function parseFacts(rawOutput: string | null | undefined): string[] {
+	return flattenExtractedFactCategories(parseExtractedFactCategories(rawOutput)).slice(0, FLAT_FACT_LIMIT);
 }
 function sentenceCase(value: string): string {
 	const trimmed = value.trim().replace(/[.!?]+$/, "");
@@ -207,39 +309,48 @@ async function tryHostExtraction(prompt: string): Promise<[boolean, string | nul
 	return [true, text === "" ? null : text];
 }
 
-async function localFallback(prompt: string, sourceText: string, diag = getDiagnostics()): Promise<string[]> {
+async function localFallback(
+	prompt: string,
+	sourceText: string,
+	diag = getDiagnostics(),
+): Promise<ExtractedFactCategories> {
 	diag.recordAttempt("local");
 	try {
 		const raw = await callLocalLlm(prompt);
 		if (raw !== null) {
-			const facts = parseFacts(cleanOutput(raw));
-			if (facts.length > 0) {
-				diag.recordSuccess("local", facts.length);
+			const extracted = parseExtractedFactCategories(cleanOutput(raw));
+			const count = countExtractedFactCategories(extracted);
+			if (count > 0) {
+				diag.recordSuccess("local", count);
 				diag.recordCall({ succeeded: true });
-				return facts;
+				return extracted;
 			}
 			diag.recordNoOutput("local");
 		}
 	} catch (exc) {
 		diag.recordFailure("local", exc, "local_llm_raised");
 		diag.recordCall({ succeeded: false });
-		return [];
+		return emptyFactCategories();
 	}
 	diag.recordFailure("local", undefined, "model_not_loaded");
 	const heuristic = heuristicExtractFacts(sourceText);
 	if (heuristic.length > 0) {
 		diag.recordSuccess("local", heuristic.length);
 		diag.recordCall({ succeeded: true });
-		return heuristic;
+		return { ...emptyFactCategories(), facts: heuristic };
 	}
 	diag.recordCall({ succeeded: false, allEmpty: true });
-	return [];
+	return emptyFactCategories();
 }
 
-export async function extractFacts(text: string | null | undefined, options: RemoteLlmOptions = {}): Promise<string[]> {
+/** Extract fact categories from text using configured, host, local, or remote LLMs. */
+export async function extractFactCategories(
+	text: string | null | undefined,
+	options: RemoteLlmOptions = {},
+): Promise<ExtractedFactCategories> {
 	const diag = getDiagnostics();
 	if (typeof text !== "string" || text.trim() === "") {
-		return [];
+		return emptyFactCategories();
 	}
 	const prompt = buildExtractionPrompt(text);
 
@@ -252,11 +363,12 @@ export async function extractFacts(text: string | null | undefined, options: Rem
 		try {
 			const raw = await callConfiguredCompletion(prompt, 0, { maxTokens: llmMaxTokens() });
 			if (typeof raw === "string" && raw.trim() !== "") {
-				const facts = parseFacts(raw);
-				if (facts.length > 0) {
-					diag.recordSuccess("host", facts.length);
+				const extracted = parseExtractedFactCategories(raw);
+				const count = countExtractedFactCategories(extracted);
+				if (count > 0) {
+					diag.recordSuccess("host", count);
 					diag.recordCall({ succeeded: true });
-					return facts;
+					return extracted;
 				}
 			}
 			diag.recordNoOutput("host");
@@ -264,7 +376,7 @@ export async function extractFacts(text: string | null | undefined, options: Rem
 			diag.recordFailure("host", exc, "configured_completion_raised");
 			diag.recordCall({ succeeded: false });
 			console.warn(`extractFacts: configured completion raised: ${safeForLog(exc)}`);
-			return [];
+			return emptyFactCategories();
 		}
 		return localFallback(prompt, text, diag);
 	}
@@ -274,11 +386,12 @@ export async function extractFacts(text: string | null | undefined, options: Rem
 		if (attempted) {
 			diag.recordAttempt("host");
 			if (hostText !== null) {
-				const facts = parseFacts(hostText);
-				if (facts.length > 0) {
-					diag.recordSuccess("host", facts.length);
+				const extracted = parseExtractedFactCategories(hostText);
+				const count = countExtractedFactCategories(extracted);
+				if (count > 0) {
+					diag.recordSuccess("host", count);
 					diag.recordCall({ succeeded: true });
-					return facts;
+					return extracted;
 				}
 			}
 			diag.recordNoOutput("host");
@@ -289,7 +402,7 @@ export async function extractFacts(text: string | null | undefined, options: Rem
 		diag.recordFailure("host", exc, "host_adapter_raised");
 		diag.recordCall({ succeeded: false });
 		console.warn(`extractFacts: host LLM adapter raised: ${safeForLog(exc)}`);
-		return [];
+		return emptyFactCategories();
 	}
 
 	if (!llmAvailable()) {
@@ -298,22 +411,23 @@ export async function extractFacts(text: string | null | undefined, options: Rem
 		if (heuristic.length > 0) {
 			diag.recordSuccess("local", heuristic.length);
 			diag.recordCall({ succeeded: true });
-			return heuristic;
+			return { ...emptyFactCategories(), facts: heuristic };
 		}
 		diag.recordFailure("local", undefined, "llm_unavailable_at_call_site");
 		diag.recordCall({ succeeded: false });
-		return [];
+		return emptyFactCategories();
 	}
 
 	diag.recordAttempt("remote");
 	try {
 		const raw = await callRemoteLlm(prompt, 0, options);
 		if (raw !== null) {
-			const facts = parseFacts(cleanOutput(raw));
-			if (facts.length > 0) {
-				diag.recordSuccess("remote", facts.length);
+			const extracted = parseExtractedFactCategories(cleanOutput(raw));
+			const count = countExtractedFactCategories(extracted);
+			if (count > 0) {
+				diag.recordSuccess("remote", count);
 				diag.recordCall({ succeeded: true });
-				return facts;
+				return extracted;
 			}
 		}
 		diag.recordNoOutput("remote");
@@ -325,14 +439,27 @@ export async function extractFacts(text: string | null | undefined, options: Rem
 	return localFallback(prompt, text, diag);
 }
 
-export async function extractFactsSafe(text: string | null | undefined): Promise<string[]> {
+/** Extract legacy flat fact strings from text. */
+export async function extractFacts(text: string | null | undefined, options: RemoteLlmOptions = {}): Promise<string[]> {
+	const extracted = await extractFactCategories(text, options);
+	return flattenExtractedFactCategories(extracted).slice(0, FLAT_FACT_LIMIT);
+}
+
+/** Safely extract category-preserving facts, swallowing best-effort failures. */
+export async function extractFactCategoriesSafe(text: string | null | undefined): Promise<ExtractedFactCategories> {
 	try {
-		return await extractFacts(text);
+		return await extractFactCategories(text);
 	} catch (exc) {
 		const diag = getDiagnostics();
 		diag.recordFailure("wrapper", exc, "outer_wrapper_caught");
 		diag.recordCall({ succeeded: false });
 		console.warn(`extractFactsSafe: extractFacts() raised: ${safeForLog(exc)}`);
-		return [];
+		return emptyFactCategories();
 	}
+}
+
+/** Safely extract legacy flat fact strings, swallowing best-effort failures. */
+export async function extractFactsSafe(text: string | null | undefined): Promise<string[]> {
+	const extracted = await extractFactCategoriesSafe(text);
+	return flattenExtractedFactCategories(extracted).slice(0, FLAT_FACT_LIMIT);
 }

--- a/packages/mnemopi/test/extraction-wiring.test.ts
+++ b/packages/mnemopi/test/extraction-wiring.test.ts
@@ -47,6 +47,53 @@ describe("remember(extract) wires the LLM fact extractor", () => {
 		expect(memory.beam.factRecall("dark roast", 5).some(fact => fact.content.includes("dark roast"))).toBe(true);
 	});
 
+	it("routes structured LLM categories into MEMORIA and KG tables", async () => {
+		let calls = 0;
+		const memory = makeMemory({
+			complete: () => {
+				calls += 1;
+				return JSON.stringify({
+					facts: ["Ada works at Example Corp"],
+					instructions: ["Always use tabs"],
+					preferences: ["Dislikes blur + fade without slide"],
+					timelines: ["2026-07-03 launch rehearsal"],
+					kg: [{ subject: "Mnemopi", predicate: "uses", object: "SQLite" }],
+				});
+			},
+		});
+
+		memory.remember("Ada works at Example Corp and dislikes blur fades.", {
+			source: "test",
+			extract: true,
+		});
+		await memory.flushExtractions();
+
+		expect(calls).toBe(1);
+		expect(memory.conn.query("SELECT COUNT(*) AS count FROM memoria_instructions").get()).toEqual({ count: 1 });
+		expect(memory.conn.query("SELECT COUNT(*) AS count FROM memoria_preferences").get()).toEqual({ count: 1 });
+		expect(memory.conn.query("SELECT COUNT(*) AS count FROM memoria_timelines").get()).toEqual({ count: 1 });
+		expect(memory.conn.query("SELECT COUNT(*) AS count FROM memoria_kg").get()).toEqual({ count: 1 });
+		expect(memory.conn.query("SELECT COUNT(*) AS count FROM triples").get()).toEqual({ count: 1 });
+		expect(memory.conn.query("SELECT instruction FROM memoria_instructions").get()).toEqual({
+			instruction: "Always use tabs",
+		});
+		expect(memory.conn.query("SELECT preference FROM memoria_preferences").get()).toEqual({
+			preference: "Dislikes blur + fade without slide",
+		});
+		expect(memory.conn.query("SELECT date, description FROM memoria_timelines").get()).toEqual({
+			date: "2026-07-03",
+			description: "2026-07-03 launch rehearsal",
+		});
+		expect(memory.conn.query("SELECT subject, predicate, object FROM memoria_kg").get()).toEqual({
+			subject: "Mnemopi",
+			predicate: "uses",
+			object: "SQLite",
+		});
+		expect(
+			memory.conn.query("SELECT subject, predicate, object FROM facts WHERE object = ?").get("Always use tabs"),
+		).toEqual({ subject: "fact", predicate: "entity", object: "Always use tabs" });
+	});
+
 	it("uses a runtime-configured remote LLM in background extraction", async () => {
 		const previousEnabled = process.env.MNEMOPI_LLM_ENABLED;
 		const previousBaseUrl = process.env.MNEMOPI_LLM_BASE_URL;


### PR DESCRIPTION
## Repro
A focused in-memory mnemopi DB repro parses structured extractor JSON containing `facts`, `instructions`, `preferences`, `timelines`, and `kg`, then stores the parsed result through the background fact path. Before the fix, `parseFacts` returned only four plain strings, `kg` was dropped, all strings were stored as `facts(subject='fact', predicate='entity')`, and `memoria_preferences`, `memoria_instructions`, `memoria_timelines`, `memoria_kg`, and `triples` stayed at `0`.

## Cause
`packages/mnemopi/src/core/extraction.ts` only exposed `parseFacts` / `extractFacts` as flat string APIs, so `packages/mnemopi/src/core/beam/store.ts` handed background LLM output to `storeFactStrings` in `packages/mnemopi/src/core/beam/consolidate.ts`. That storage helper could only infer MEMORIA categories from heuristic string templates and had no representation for extractor `kg` triples.

## Fix
- Added category-preserving parsing/extraction types in `packages/mnemopi/src/core/extraction.ts` while keeping the legacy flat `parseFacts` / `extractFacts` APIs.
- Routed background extraction through `storeExtractedFactCategories` so LLM `instructions`, `preferences`, `timelines`, and `kg` populate MEMORIA and graph tables.
- Kept legacy fact rows stable as `fact/entity` rows for string categories to avoid recall ranking churn.
- Added a `remember(..., { extract: true })` regression test for structured category routing.
- Added a mnemopi changelog entry.

## Verification
`bun test packages/mnemopi/test/extraction-wiring.test.ts packages/mnemopi/test/extraction.test.ts packages/mnemopi/test/extraction-integration.test.ts packages/mnemopi/test/beam-consolidate-unit.test.ts` passed: 29 tests, 124 assertions. `HOME=/tmp/omp-agent-home MNEMOPI_NO_EMBEDDINGS=1 bun test packages/mnemopi/test` passed: 408 tests, 1885 assertions. `bun check` passed. `bun run fix` applied no TypeScript fixes and completed Rust checks. Fixes #4389