### PR TITLE
fix(gemini): honor hidden summary requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Google Gemini hidden-thinking-summary requests so direct Google and Cloud Code Assist providers keep the requested reasoning tier while sending `includeThoughts: false`.
+
 ## [16.3.5] - 2026-07-04
 
 ### Added

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -263,6 +263,8 @@ export interface GoogleGeminiCliOptions extends StreamOptions {
 		 */
 		suppress?: { level: GoogleThinkingLevel } | { budget: number };
 	};
+	/** Request that Cloud Code Assist omit human-readable thought summaries while still allowing internal reasoning. */
+	hideThinkingSummary?: boolean;
 	/**
 	 * Upstream wire model id override for collapsed effort-tier variants.
 	 * Serialized as `requestModelId ?? model.requestModelId ?? model.id`.
@@ -1242,7 +1244,7 @@ export function buildRequest(
 	// Thinking config
 	if (options.thinking?.enabled && model.reasoning) {
 		generationConfig.thinkingConfig = {
-			includeThoughts: true,
+			includeThoughts: !options.hideThinkingSummary,
 		};
 		// Gemini 3 models use thinkingLevel, older models use thinkingBudget
 		if (options.thinking.level !== undefined) {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -75,6 +75,8 @@ export interface GoogleSharedStreamOptions extends StreamOptions {
 		budgetTokens?: number;
 		level?: GoogleThinkingLevel;
 	};
+	/** Request that Google omit human-readable thought summaries while still allowing internal reasoning. */
+	hideThinkingSummary?: boolean;
 	/** Gemini/Vertex serving tier (`flex`/`priority`); other values are omitted. */
 	serviceTier?: ServiceTier;
 	/**
@@ -859,7 +861,7 @@ export function buildGoogleGenerateContentParams<T extends "google-generative-ai
 	}
 
 	if (options.thinking?.enabled && model.reasoning) {
-		const cfg: ThinkingConfig = { includeThoughts: true };
+		const cfg: ThinkingConfig = { includeThoughts: !options.hideThinkingSummary };
 		if (options.thinking.level !== undefined) {
 			// GoogleThinkingLevel mirrors the SDK's `ThinkingLevel` string enum values 1:1.
 			cfg.thinkingLevel = options.thinking.level as ThinkingLevel;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1656,6 +1656,7 @@ function mapOptionsForApi<TApi extends Api>(
 						enabled: true,
 						level: mapEffortToGoogleThinkingLevel(effort),
 					},
+					hideThinkingSummary: options?.hideThinkingSummary,
 					toolChoice: mapGoogleToolChoice(options?.toolChoice),
 				});
 			}
@@ -1666,6 +1667,7 @@ function mapOptionsForApi<TApi extends Api>(
 					enabled: true,
 					budgetTokens: getGoogleBudget(googleModel, effort, options?.thinkingBudgets),
 				},
+				hideThinkingSummary: options?.hideThinkingSummary,
 				toolChoice: mapGoogleToolChoice(options?.toolChoice),
 			});
 		}
@@ -1685,6 +1687,7 @@ function mapOptionsForApi<TApi extends Api>(
 							enabled: true,
 							level: mapEffortToGoogleThinkingLevel(effort),
 						},
+						hideThinkingSummary: options?.hideThinkingSummary,
 						toolChoice,
 						antigravityEndpointMode: options?.antigravityEndpointMode,
 					});
@@ -1707,6 +1710,7 @@ function mapOptionsForApi<TApi extends Api>(
 						maxTokens,
 						requestModelId: resolveWireModelId(model, effort),
 						thinking: { enabled: true, budgetTokens: thinkingBudget },
+						hideThinkingSummary: options?.hideThinkingSummary,
 						toolChoice,
 						antigravityEndpointMode: options?.antigravityEndpointMode,
 					});
@@ -1753,6 +1757,7 @@ function mapOptionsForApi<TApi extends Api>(
 						enabled: true,
 						level: mapEffortToGoogleThinkingLevel(effort),
 					},
+					hideThinkingSummary: options?.hideThinkingSummary,
 					toolChoice: mapGoogleToolChoice(options?.toolChoice),
 				});
 			}
@@ -1764,6 +1769,7 @@ function mapOptionsForApi<TApi extends Api>(
 					enabled: true,
 					budgetTokens: getGoogleBudget(geminiModel, effort, options?.thinkingBudgets),
 				},
+				hideThinkingSummary: options?.hideThinkingSummary,
 				toolChoice: mapGoogleToolChoice(options?.toolChoice),
 			});
 		}

--- a/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
+++ b/packages/ai/test/google-gemini-cli-3x-thinking.test.ts
@@ -7,6 +7,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 interface GeminiCliThinkingConfig {
 	thinkingLevel?: string;
 	thinkingBudget?: number;
+	includeThoughts?: boolean;
 }
 
 interface CapturedRequestBody {
@@ -65,6 +66,25 @@ describe("google-gemini-cli Gemini 3.x thinking mapping", () => {
 		const thinking = extractThinking(requestBody);
 		expect(thinking?.thinkingLevel).toBe("HIGH");
 		expect(thinking?.thinkingBudget).toBeUndefined();
+	});
+
+	it("keeps Cloud Code Assist reasoning enabled when only summaries are hidden", async () => {
+		let requestBody: string | undefined;
+		const fetchMock = createFetchMock(body => {
+			requestBody = body;
+		});
+
+		const stream = streamSimple(createModel("gemini-3.1-pro-preview"), context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			reasoning: Effort.High,
+			hideThinkingSummary: true,
+			fetch: fetchMock,
+		});
+		await stream.result();
+
+		const thinking = extractThinking(requestBody);
+		expect(thinking?.includeThoughts).toBe(false);
+		expect(thinking?.thinkingLevel).toBe("HIGH");
 	});
 
 	it("rejects unsupported gemini-3.1-pro-preview efforts instead of promoting them", () => {

--- a/packages/ai/test/google-service-tier.test.ts
+++ b/packages/ai/test/google-service-tier.test.ts
@@ -83,6 +83,24 @@ describe("Google service tier wire encoding", () => {
 		expect(headers.get("X-Vertex-AI-LLM-Shared-Request-Type")).toBeNull();
 	});
 
+	it("Gemini API omits human-readable thought summaries when requested", async () => {
+		const { fetch, captured } = capturingFetch();
+		await drain(
+			streamGoogle(geminiModel, context, {
+				apiKey: "k",
+				fetch,
+				useInteractionsApi: false,
+				thinking: { enabled: true, level: "HIGH" },
+				hideThinkingSummary: true,
+			}),
+		);
+
+		expect((captured().body.generationConfig as { thinkingConfig?: unknown } | undefined)?.thinkingConfig).toEqual({
+			includeThoughts: false,
+			thinkingLevel: "HIGH",
+		});
+	});
+
 	it("Vertex sends priority via header and omits the body tier field", async () => {
 		const { fetch, captured } = capturingFetch();
 		await drain(streamGoogleVertex(vertexModel, context, { apiKey: "k", serviceTier: "priority", fetch }));

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omitThinking` settings propagation so settings-aware streams request hidden thinking summaries when users explicitly enable the option.
+
 ## [16.3.5] - 2026-07-04
 
 ### Fixed

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -66,6 +66,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 				checkAssistantContent: settings.get("model.loopGuard.checkAssistantContent"),
 				...streamOptions?.loopGuard,
 			},
+			hideThinkingSummary: streamOptions?.hideThinkingSummary ?? settings.get("omitThinking"),
 			...(fallbacks !== undefined ? { fallbacks } : {}),
 		};
 		return base(model, context, merged);

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -51,6 +51,36 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(options?.apiKey).toBe("k");
 	});
 
+	it("keeps assistant prose loop scanning at its configured default", () => {
+		const settings = Settings.isolated({});
+		const { fn: base, calls } = captureBase();
+		const wrapped = createSettingsAwareStreamFn(settings, base);
+
+		wrapped(stubModel, stubContext, undefined);
+
+		expect(calls[0]?.options?.loopGuard).toEqual({ enabled: true, checkAssistantContent: true });
+	});
+
+	it("keeps thinking summaries visible unless configured otherwise", () => {
+		const settings = Settings.isolated({});
+		const { fn: base, calls } = captureBase();
+		const wrapped = createSettingsAwareStreamFn(settings, base);
+
+		wrapped(stubModel, stubContext, undefined);
+
+		expect(calls[0]?.options?.hideThinkingSummary).toBe(false);
+	});
+
+	it("forwards configured hidden thinking summaries", () => {
+		const settings = Settings.isolated({ omitThinking: true });
+		const { fn: base, calls } = captureBase();
+		const wrapped = createSettingsAwareStreamFn(settings, base);
+
+		wrapped(stubModel, stubContext, undefined);
+
+		expect(calls[0]?.options?.hideThinkingSummary).toBe(true);
+	});
+
 	it("applies Responses-family text verbosity from settings while preserving caller overrides", () => {
 		const settings = Settings.isolated({ textVerbosity: "low" });
 		const { fn: base, calls } = captureBase();
@@ -110,6 +140,7 @@ describe("createSettingsAwareStreamFn", () => {
 			antigravityEndpointMode: "production",
 			maxInFlightRequests: { openrouter: 1 },
 			loopGuard: { enabled: false },
+			hideThinkingSummary: false,
 		});
 
 		const options = calls[0]?.options;
@@ -120,6 +151,7 @@ describe("createSettingsAwareStreamFn", () => {
 		// the rest (the inline closure the main agent used has the same shape).
 		expect(options?.loopGuard?.enabled).toBe(false);
 		expect(options?.loopGuard?.checkAssistantContent).toBe(true);
+		expect(options?.hideThinkingSummary).toBe(false);
 	});
 	describe("providers.anthropic.serverSideFallback (opt-in)", () => {
 		const stubFableModel = {


### PR DESCRIPTION
### Description

This PR narrows the Gemini hidden-thinking fix to the settings/provider plumbing that is still correct after review feedback: explicit `omitThinking` settings now reach Google providers as `hideThinkingSummary`, and Google/Cloud Code Assist requests keep the selected reasoning tier while sending `includeThoughts: false`.

It does **not** change the global `omitThinking` default, does **not** disable prose loop scanning by default, and does **not** add a CCA-specific suppress/off path. `hideThinkingSummary` keeps its generic contract: omit human-readable thought summaries without silently lowering reasoning.

### Cause

Two plumbing gaps made explicit hidden-summary requests inconsistent:

1. `createSettingsAwareStreamFn` did not forward `omitThinking` as `hideThinkingSummary`, so settings-backed sessions could ignore the user's explicit preference.
2. Google provider request builders always sent `includeThoughts: true` whenever reasoning was enabled, so `hideThinkingSummary` did not affect the Google wire shape.

Live CCA raw SSE checks did not reproduce final-answer misclassification in the tested paths: `thought:true` parts were summary text, while final answer text streamed as `thought:false`. So this PR avoids heuristic demotion or provider-level reclassification without a factual raw SSE boundary.

### Fix

- Propagate `omitThinking` from settings-aware streams as `hideThinkingSummary`.
- Send `includeThoughts: false` for Google direct and Cloud Code Assist when `hideThinkingSummary` is true.
- Preserve the requested reasoning tier for hidden-summary requests.
- Add focused tests for settings propagation and Google request bodies.
- Update changelog entries to describe only the narrowed behavior.

### Verification

- `bun test packages/coding-agent/test/settings-stream-fn.test.ts packages/ai/test/google-gemini-cli-3x-thinking.test.ts packages/ai/test/google-service-tier.test.ts packages/ai/test/thinking-loop.test.ts`
- `bun check`
- Live raw CCA SSE capture with `google-antigravity/gemini-3.5-flash:high`: observed `thought:true` summary parts followed by `thought:false` final-answer parts for both direct supplied-context and prior complex prompt probes.
