### PR TITLE
feat(web-search): add Zhipu (bigmodel.cn) web_search_prime provider

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -621,7 +621,7 @@ searxng:
 
 | Key | Type | Default | Values / notes |
 |---|---|---|---|
-| `providers.webSearch` | enum | `auto` | `auto` plus the configured search providers (`perplexity`, `gemini`, `anthropic`, `codex`, `zai`, `exa`, `jina`, `kagi`, `tavily`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`). |
+| `providers.webSearch` | enum | `auto` | `auto` plus the configured search providers (`perplexity`, `gemini`, `anthropic`, `codex`, `zai`, `zhipu`, `exa`, `jina`, `kagi`, `tavily`, `brave`, `kimi`, `parallel`, `synthetic`, `searxng`). |
 | `providers.webSearchGeminiModel` | string | _(unset)_ | Gemini model ID for Google Search grounding when `web_search` uses Gemini; defaults to `gemini-2.5-flash`, overridden by `GEMINI_SEARCH_MODEL`. |
 | `providers.image` | enum | `auto` | `auto`, `openai`, `antigravity`, `xai`, `gemini`, `openrouter`. |
 | `providers.fetch` | enum | `auto` | `auto`, `native`, `trafilatura`, `lynx`, `parallel`, `jina`. |

--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -28,7 +28,7 @@
   - `packages/coding-agent/src/web/search/providers/tavily.ts` — Tavily search adapter.
   - `packages/coding-agent/src/web/search/providers/tinyfish.ts` — TinyFish search adapter.
   - `packages/coding-agent/src/web/search/providers/xai.ts` — xAI Responses web-search adapter.
-  - `packages/coding-agent/src/web/search/providers/zai.ts` — Z.AI remote MCP adapter.
+  - `packages/coding-agent/src/web/search/providers/zai.ts` — Z.AI / Zhipu (bigmodel.cn) remote MCP adapter.
   - `packages/coding-agent/src/web/parallel.ts` — Parallel search/extract HTTP client.
   - `packages/coding-agent/src/web/kagi.ts` — Kagi HTTP client.
   - `packages/coding-agent/src/tools/index.ts` — built-in tool registration and enable flag.

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -54,6 +54,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.zai,
 		load: async () => new (await import("./providers/zai")).ZaiProvider(),
 	},
+	zhipu: {
+		id: "zhipu",
+		label: SEARCH_PROVIDER_LABELS.zhipu,
+		load: async () => new (await import("./providers/zai")).ZhipuProvider(),
+	},
 	exa: {
 		id: "exa",
 		label: SEARCH_PROVIDER_LABELS.exa,
@@ -130,7 +135,7 @@ export function formatSearchProviderFailure(error: unknown, provider: Pick<Searc
 			return "Anthropic web search returned 404 (model or endpoint not found).";
 		}
 		if (error.status === 401 || error.status === 403) {
-			if (error.provider === "zai") {
+			if (error.provider === "zai" || error.provider === "zhipu") {
 				return error.message;
 			}
 			return `${getSearchProviderLabel(error.provider)} authorization failed (${error.status}). Check API key or base URL.`;

--- a/packages/coding-agent/src/web/search/providers/zai.ts
+++ b/packages/coding-agent/src/web/search/providers/zai.ts
@@ -1,21 +1,51 @@
 /**
- * Z.AI Web Search Provider
+ * Z.AI / Zhipu Web Search Provider
  *
- * Calls Z.AI's remote MCP server (`webSearchPrime`) and adapts results into
- * the unified SearchResponse shape used by the web search tool.
+ * Calls the `webSearchPrime` remote MCP server and adapts results into the
+ * unified SearchResponse shape used by the web search tool. Z.AI (api.z.ai)
+ * and Zhipu's China-mainland open platform (open.bigmodel.cn) expose the same
+ * MCP surface with independently issued credentials, so both search providers
+ * share this implementation and differ only in endpoint and auth provider.
  */
 import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth } from "@oh-my-pi/pi-ai";
 import { isRecord } from "@oh-my-pi/pi-utils";
-import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import type { SearchProviderId, SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { dateToAgeSeconds } from "../utils";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
-const ZAI_MCP_URL = "https://api.z.ai/api/mcp/web_search_prime/mcp";
 const ZAI_TOOL_NAME = "web_search_prime";
 const DEFAULT_NUM_RESULTS = 10;
+
+interface ZaiEndpointConfig {
+	/** Web-search provider id used for errors and `SearchResponse.provider`. */
+	id: Extract<SearchProviderId, "zai" | "zhipu">;
+	/** Human-readable name used in error messages. */
+	label: string;
+	/** Streamable HTTP MCP endpoint serving `web_search_prime`. */
+	mcpUrl: string;
+	/** Auth-broker provider whose credentials authorize the endpoint. */
+	authProvider: "zai" | "zhipu-coding-plan";
+	missingKeyMessage: string;
+}
+
+const ZAI_ENDPOINT: ZaiEndpointConfig = {
+	id: "zai",
+	label: "Z.AI",
+	mcpUrl: "https://api.z.ai/api/mcp/web_search_prime/mcp",
+	authProvider: "zai",
+	missingKeyMessage: "Z.AI credentials not found. Set ZAI_API_KEY or login with 'omp /login zai'.",
+};
+
+const ZHIPU_ENDPOINT: ZaiEndpointConfig = {
+	id: "zhipu",
+	label: "Zhipu",
+	mcpUrl: "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp",
+	authProvider: "zhipu-coding-plan",
+	missingKeyMessage: "Zhipu credentials not found. Set ZHIPU_API_KEY or login with 'omp /login zhipu-coding-plan'.",
+};
 
 export interface ZaiSearchParams {
 	query: string;
@@ -71,7 +101,7 @@ function asString(value: unknown): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
-function parseZaiMcpResponse(rawText: string): unknown {
+function parseZaiMcpResponse(endpoint: ZaiEndpointConfig, rawText: string): unknown {
 	const parsedMessages: unknown[] = [];
 	for (const line of rawText.split("\n")) {
 		const trimmed = line.trim();
@@ -89,7 +119,7 @@ function parseZaiMcpResponse(rawText: string): unknown {
 		try {
 			parsedMessages.push(JSON.parse(rawText));
 		} catch {
-			throw new SearchProviderError("zai", "Failed to parse Z.AI MCP response", 500);
+			throw new SearchProviderError(endpoint.id, `Failed to parse ${endpoint.label} MCP response`, 500);
 		}
 	}
 
@@ -97,6 +127,7 @@ function parseZaiMcpResponse(rawText: string): unknown {
 }
 
 async function postZaiMcp(
+	endpoint: ZaiEndpointConfig,
 	apiKey: string,
 	method: string,
 	params: Record<string, unknown>,
@@ -123,7 +154,7 @@ async function postZaiMcp(
 		body.id = crypto.randomUUID();
 	}
 
-	const response = await fetchImpl(ZAI_MCP_URL, {
+	const response = await fetchImpl(endpoint.mcpUrl, {
 		method: "POST",
 		headers,
 		body: JSON.stringify(body),
@@ -132,9 +163,13 @@ async function postZaiMcp(
 
 	if (!response.ok) {
 		const errorText = await response.text();
-		const classified = classifyProviderHttpError("zai", response.status, errorText);
+		const classified = classifyProviderHttpError(endpoint.id, response.status, errorText);
 		if (classified) throw classified;
-		throw new SearchProviderError("zai", `Z.AI MCP error (${response.status}): ${errorText}`, response.status);
+		throw new SearchProviderError(
+			endpoint.id,
+			`${endpoint.label} MCP error (${response.status}): ${errorText}`,
+			response.status,
+		);
 	}
 
 	const nextSessionId = response.headers.get("Mcp-Session-Id") ?? sessionId;
@@ -144,12 +179,12 @@ async function postZaiMcp(
 	}
 
 	return {
-		parsed: parseZaiMcpResponse(await response.text()),
+		parsed: parseZaiMcpResponse(endpoint, await response.text()),
 		sessionId: nextSessionId,
 	};
 }
 
-function readJsonRpcPayload(parsed: unknown): JsonRpcPayload {
+function readJsonRpcPayload(endpoint: ZaiEndpointConfig, parsed: unknown): JsonRpcPayload {
 	const parsedRecord = isRecord(parsed) ? parsed : null;
 	const directErrorCode = typeof parsedRecord?.code === "number" ? parsedRecord.code : undefined;
 	const directErrorSuccess = parsedRecord?.success;
@@ -157,22 +192,22 @@ function readJsonRpcPayload(parsed: unknown): JsonRpcPayload {
 		asString(parsedRecord?.msg) ?? asString(parsedRecord?.message) ?? asString(parsedRecord?.error_message);
 	if (directErrorSuccess === false && directErrorMessage) {
 		throw new SearchProviderError(
-			"zai",
-			`Z.AI API error${directErrorCode ? ` (${directErrorCode})` : ""}: ${directErrorMessage}`,
+			endpoint.id,
+			`${endpoint.label} API error${directErrorCode ? ` (${directErrorCode})` : ""}: ${directErrorMessage}`,
 			directErrorCode,
 		);
 	}
 
 	if (!isRecord(parsed)) {
-		throw new SearchProviderError("zai", "Failed to parse Z.AI MCP response", 500);
+		throw new SearchProviderError(endpoint.id, `Failed to parse ${endpoint.label} MCP response`, 500);
 	}
 
 	const payload = parsed as JsonRpcPayload;
 	if (payload.error) {
 		const status = typeof payload.error.code === "number" ? payload.error.code : 400;
 		throw new SearchProviderError(
-			"zai",
-			`Z.AI MCP error${payload.error.code ? ` (${payload.error.code})` : ""}: ${payload.error.message ?? "Unknown error"}`,
+			endpoint.id,
+			`${endpoint.label} MCP error${payload.error.code ? ` (${payload.error.code})` : ""}: ${payload.error.message ?? "Unknown error"}`,
 			status,
 		);
 	}
@@ -190,12 +225,14 @@ export async function findApiKey(
 }
 
 async function callZaiTool(
+	endpoint: ZaiEndpointConfig,
 	apiKey: string,
 	args: Record<string, unknown>,
 	signal: AbortSignal | undefined,
 	fetchImpl: FetchImpl,
 ): Promise<unknown> {
 	const initialized = await postZaiMcp(
+		endpoint,
 		apiKey,
 		"initialize",
 		{
@@ -209,12 +246,13 @@ async function callZaiTool(
 		true,
 	);
 	if (initialized.parsed !== undefined) {
-		readJsonRpcPayload(initialized.parsed);
+		readJsonRpcPayload(endpoint, initialized.parsed);
 	}
 
-	await postZaiMcp(apiKey, "notifications/initialized", {}, initialized.sessionId, signal, fetchImpl, false);
+	await postZaiMcp(endpoint, apiKey, "notifications/initialized", {}, initialized.sessionId, signal, fetchImpl, false);
 
 	const toolCall = await postZaiMcp(
+		endpoint,
 		apiKey,
 		"tools/call",
 		{
@@ -226,7 +264,7 @@ async function callZaiTool(
 		fetchImpl,
 		true,
 	);
-	const payload = readJsonRpcPayload(toolCall.parsed);
+	const payload = readJsonRpcPayload(endpoint, toolCall.parsed);
 	const resultRecord = isRecord(payload.result) ? payload.result : null;
 	if (resultRecord?.isError === true) {
 		const content = Array.isArray(resultRecord.content) ? resultRecord.content : [];
@@ -240,7 +278,7 @@ async function callZaiTool(
 			.trim();
 		const statusMatch = errorText.match(/MCP error\s*(-?\d+)/i);
 		const statusCode = statusMatch ? Math.abs(Number.parseInt(statusMatch[1], 10)) : 400;
-		throw new SearchProviderError("zai", errorText || "Z.AI MCP tool call failed", statusCode);
+		throw new SearchProviderError(endpoint.id, errorText || `${endpoint.label} MCP tool call failed`, statusCode);
 	}
 
 	if (payload.result !== undefined) {
@@ -250,7 +288,7 @@ async function callZaiTool(
 	return toolCall.parsed;
 }
 
-async function callZaiSearch(apiKey: string, params: ZaiSearchParams): Promise<unknown> {
+async function callZaiSearch(endpoint: ZaiEndpointConfig, apiKey: string, params: ZaiSearchParams): Promise<unknown> {
 	const count = params.num_results ?? DEFAULT_NUM_RESULTS;
 	const fetchImpl = params.fetch ?? fetch;
 	const attempts: Record<string, unknown>[] = [
@@ -262,7 +300,7 @@ async function callZaiSearch(apiKey: string, params: ZaiSearchParams): Promise<u
 	let lastError: unknown;
 	for (let i = 0; i < attempts.length; i++) {
 		try {
-			return await callZaiTool(apiKey, attempts[i], params.signal, fetchImpl);
+			return await callZaiTool(endpoint, apiKey, attempts[i], params.signal, fetchImpl);
 		} catch (error) {
 			lastError = error;
 			const isLastAttempt = i === attempts.length - 1;
@@ -285,7 +323,7 @@ async function callZaiSearch(apiKey: string, params: ZaiSearchParams): Promise<u
 		}
 	}
 
-	throw lastError ?? new SearchProviderError("zai", "Z.AI search failed", 500);
+	throw lastError ?? new SearchProviderError(endpoint.id, `${endpoint.label} search failed`, 500);
 }
 
 function getSearchResults(value: unknown): ZaiSearchResult[] {
@@ -369,15 +407,14 @@ function toSources(results: ZaiSearchResult[]): SearchSource[] {
 	return sources;
 }
 
-/** Execute Z.AI web search via remote MCP endpoint. */
-export async function searchZai(params: ZaiSearchParams): Promise<SearchResponse> {
-	const keyOrResolver: ApiKey = params.authStorage.resolver("zai", {
+async function searchWebSearchPrime(params: ZaiSearchParams, endpoint: ZaiEndpointConfig): Promise<SearchResponse> {
+	const keyOrResolver: ApiKey = params.authStorage.resolver(endpoint.authProvider, {
 		sessionId: params.sessionId,
 	});
 
-	const rawResult = await withAuth(keyOrResolver, key => callZaiSearch(key, params), {
+	const rawResult = await withAuth(keyOrResolver, key => callZaiSearch(endpoint, key, params), {
 		signal: params.signal,
-		missingKeyMessage: "Z.AI credentials not found. Set ZAI_API_KEY or login with 'omp /login zai'.",
+		missingKeyMessage: endpoint.missingKeyMessage,
 	});
 	const payload = parseSearchPayload(rawResult);
 	let sources = toSources(payload.results);
@@ -387,33 +424,59 @@ export async function searchZai(params: ZaiSearchParams): Promise<SearchResponse
 	}
 
 	return {
-		provider: "zai",
+		provider: endpoint.id,
 		answer: payload.answer,
 		sources,
 		requestId: payload.requestId,
 	};
 }
 
+/** Execute Z.AI web search via remote MCP endpoint. */
+export function searchZai(params: ZaiSearchParams): Promise<SearchResponse> {
+	return searchWebSearchPrime(params, ZAI_ENDPOINT);
+}
+
+/** Execute Zhipu (bigmodel.cn) web search via remote MCP endpoint. */
+export function searchZhipu(params: ZaiSearchParams): Promise<SearchResponse> {
+	return searchWebSearchPrime(params, ZHIPU_ENDPOINT);
+}
+
 type ZaiProviderSearchParams = SearchParams & { fetch?: FetchImpl };
 
-/** Search provider for Z.AI web search MCP. */
-export class ZaiProvider extends SearchProvider {
-	readonly id = "zai";
-	readonly label = "Z.AI";
+/** Shared search provider for the webSearchPrime MCP endpoints. */
+abstract class WebSearchPrimeProvider extends SearchProvider {
+	protected abstract readonly endpoint: ZaiEndpointConfig;
 
 	isAvailable(authStorage: AuthStorage): Promise<boolean> | boolean {
-		return authStorage.hasAuth("zai") || !!getEnvApiKey("zai");
+		return authStorage.hasAuth(this.endpoint.authProvider) || !!getEnvApiKey(this.endpoint.authProvider);
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {
 		const { fetch: fetchOverride } = params as ZaiProviderSearchParams;
-		return searchZai({
-			query: params.query,
-			num_results: params.numSearchResults ?? params.limit,
-			signal: params.signal,
-			authStorage: params.authStorage,
-			sessionId: params.sessionId,
-			fetch: fetchOverride,
-		});
+		return searchWebSearchPrime(
+			{
+				query: params.query,
+				num_results: params.numSearchResults ?? params.limit,
+				signal: params.signal,
+				authStorage: params.authStorage,
+				sessionId: params.sessionId,
+				fetch: fetchOverride,
+			},
+			this.endpoint,
+		);
 	}
+}
+
+/** Search provider for Z.AI web search MCP. */
+export class ZaiProvider extends WebSearchPrimeProvider {
+	readonly id = "zai";
+	readonly label = "Z.AI";
+	protected readonly endpoint = ZAI_ENDPOINT;
+}
+
+/** Search provider for Zhipu (bigmodel.cn) web search MCP. */
+export class ZhipuProvider extends WebSearchPrimeProvider {
+	readonly id = "zhipu";
+	readonly label = "Zhipu";
+	protected readonly endpoint = ZHIPU_ENDPOINT;
 }

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -32,6 +32,11 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	},
 	{ value: "xai", label: "xAI", description: "Grok web search via xAI Responses API (requires XAI_API_KEY)" },
 	{ value: "zai", label: "Z.AI", description: "Calls Z.AI webSearchPrime MCP" },
+	{
+		value: "zhipu",
+		label: "Zhipu",
+		description: "Calls Zhipu (bigmodel.cn) webSearchPrime MCP — Z.AI's China-mainland counterpart",
+	},
 	{ value: "exa", label: "Exa", description: "Uses Exa API when EXA_API_KEY is set; falls back to Exa MCP" },
 	{ value: "tinyfish", label: "TinyFish", description: "Requires TINYFISH_API_KEY" },
 	{ value: "jina", label: "Jina", description: "Requires JINA_API_KEY" },

--- a/packages/coding-agent/test/web/search/zai.test.ts
+++ b/packages/coding-agent/test/web/search/zai.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
-import { searchZai } from "@oh-my-pi/pi-coding-agent/web/search/providers/zai";
+import { searchZai, searchZhipu } from "@oh-my-pi/pi-coding-agent/web/search/providers/zai";
 
 interface CapturedRequest {
 	method: string | undefined;
@@ -101,6 +101,111 @@ describe("Z.AI web search provider", () => {
 			{
 				title: "Z.AI search result",
 				url: "https://example.com/zai",
+				snippet: "Search result content",
+				publishedDate: undefined,
+				ageSeconds: undefined,
+				author: "Example",
+			},
+		]);
+	});
+});
+
+describe("Zhipu web search provider", () => {
+	it("targets the bigmodel.cn MCP endpoint with zhipu-coding-plan credentials", async () => {
+		const capturedUrls: string[] = [];
+		const capturedRequests: CapturedRequest[] = [];
+		const fetchImpl: FetchImpl = (input, init) => {
+			capturedUrls.push(String(input));
+			const request = {
+				method: init?.method,
+				headers: new Headers(init?.headers),
+				body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+			};
+			capturedRequests.push(request);
+
+			if (request.body.method === "initialize") {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							jsonrpc: "2.0",
+							id: request.body.id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "zhipu-web-search", version: "test" },
+							},
+						}),
+						{
+							status: 200,
+							headers: { "Content-Type": "application/json", "Mcp-Session-Id": "zhipu-session-1" },
+						},
+					),
+				);
+			}
+
+			if (request.body.method === "notifications/initialized") {
+				return Promise.resolve(new Response(null, { status: 202 }));
+			}
+
+			expect(request.body.method).toBe("tools/call");
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						jsonrpc: "2.0",
+						id: request.body.id,
+						result: {
+							content: [
+								{
+									type: "text",
+									text: JSON.stringify({
+										search_result: [
+											{
+												title: "Zhipu search result",
+												content: "Search result content",
+												link: "https://example.com/zhipu",
+												media: "Example",
+											},
+										],
+									}),
+								},
+							],
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
+		};
+		const authStorage = {
+			resolver(provider: string, options?: { sessionId?: string }) {
+				expect(provider).toBe("zhipu-coding-plan");
+				expect(options?.sessionId).toBe("session-zhipu-test");
+				return async () => "zhipu-test-key";
+			},
+			hasAuth(provider: string) {
+				return provider === "zhipu-coding-plan";
+			},
+		} as unknown as AuthStorage;
+
+		const response = await searchZhipu({
+			query: "omp zhipu search",
+			authStorage,
+			fetch: fetchImpl,
+			sessionId: "session-zhipu-test",
+		});
+
+		expect(capturedUrls.every(url => url === "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp")).toBe(true);
+		expect(capturedRequests.map(request => request.body.method)).toEqual([
+			"initialize",
+			"notifications/initialized",
+			"tools/call",
+		]);
+		expect(capturedRequests[0]?.headers.get("Authorization")).toBe("Bearer zhipu-test-key");
+		expect(capturedRequests[2]?.headers.get("Mcp-Session-Id")).toBe("zhipu-session-1");
+		expect(response.provider).toBe("zhipu");
+		expect(response.sources).toEqual([
+			{
+				title: "Zhipu search result",
+				url: "https://example.com/zhipu",
 				snippet: "Search result content",
 				publishedDate: undefined,
 				ageSeconds: undefined,


### PR DESCRIPTION
## Problem

Z.AI (api.z.ai) and Zhipu's China-mainland open platform (open.bigmodel.cn) expose the same `web_search_prime` remote MCP surface, but with independently issued credentials. The web search tool only supported the Z.AI side:

- the MCP URL was hardcoded to `https://api.z.ai/api/mcp/web_search_prime/mcp`
- credentials were resolved exclusively from the `zai` auth provider

So users on a China-mainland Zhipu Coding Plan — already a first-class model provider via `zhipu-coding-plan` — could not use their subscription for web search. Their key is only valid against `open.bigmodel.cn`, which the search provider never targets.

## Change

- Parameterize the `zai.ts` implementation over a small endpoint config (MCP URL, auth provider, error labels). The MCP call chain (initialize → notifications/initialized → tools/call, plus response parsing) is shared unchanged.
- Register a `zhipu` search provider targeting `https://open.bigmodel.cn/api/mcp/web_search_prime/mcp` with `zhipu-coding-plan` credentials (`ZHIPU_API_KEY` / `omp /login zhipu-coding-plan`). It lives in the same module, so the lazy registry entry adds no load cost.
- `SEARCH_PROVIDER_OPTIONS` gains the `zhipu` entry right after `zai`; settings enum, auto-chain order, and labels all derive from it as before.
- Extend the 401/403 message passthrough in `formatSearchProviderFailure` to `zhipu` (same upstream error shape as Z.AI).
- Docs: `settings.md` enum list, `web_search.md` adapter description.

## Testing

- New test in `test/web/search/zai.test.ts` asserting the Zhipu provider targets `open.bigmodel.cn`, resolves `zhipu-coding-plan` credentials, and reports `provider: "zhipu"`; existing Z.AI test unchanged and passing.
- `bun test test/web/` — 48 pass, 0 fail
- `bun run check:types` (tsgo), `biome check` on touched files, `bun run check:docs` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)