### PR TITLE
fix(lsp): suppress orphan TypeScript project diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed write/edit LSP diagnostics for TypeScript files outside any project root by suppressing project-resolution noise while preserving real syntax errors ([#4401](https://github.com/can1357/oh-my-pi/issues/4401)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -201,6 +201,21 @@ export function hasRootMarkers(cwd: string, markers: string[]): boolean {
 	return false;
 }
 
+/**
+ * Check whether any ancestor directory of a file is an LSP project root.
+ */
+export function hasRootMarkerAncestor(filePath: string, markers: string[]): boolean {
+	if (markers.length === 0) return false;
+
+	let dir = path.dirname(path.resolve(filePath));
+	while (true) {
+		if (hasRootMarkers(dir, markers)) return true;
+		const parent = path.dirname(dir);
+		if (parent === dir) return false;
+		dir = parent;
+	}
+}
+
 // =============================================================================
 // Local Binary Resolution
 // =============================================================================

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -31,7 +31,7 @@ import {
 	waitForProjectLoaded,
 } from "./client";
 import { getLinterClient } from "./clients";
-import { getServersForFile, type LspConfig, loadConfig } from "./config";
+import { getServersForFile, hasRootMarkerAncestor, type LspConfig, loadConfig } from "./config";
 import {
 	applyTextEdits,
 	applyTextEditsToString,
@@ -355,6 +355,41 @@ function limitDiagnosticMessages(messages: string[]): string[] {
 		return messages;
 	}
 	return messages.slice(0, DIAGNOSTIC_MESSAGE_LIMIT);
+}
+
+const ORPHAN_TYPESCRIPT_PROJECT_DIAGNOSTIC_CODES: Record<number, true> = {
+	1375: true,
+	1378: true,
+	2307: true,
+	2580: true,
+	2591: true,
+	2792: true,
+	2867: true,
+};
+
+function diagnosticCodeNumber(diagnostic: Diagnostic): number | null {
+	if (typeof diagnostic.code === "number") return diagnostic.code;
+	if (typeof diagnostic.code === "string" && /^\d+$/.test(diagnostic.code)) return Number(diagnostic.code);
+	return null;
+}
+function isTypeScriptProjectDiagnostic(serverName: string, diagnostic: Diagnostic): boolean {
+	if (diagnostic.source !== "typescript" && !serverName.toLowerCase().includes("typescript")) {
+		return false;
+	}
+	const code = diagnosticCodeNumber(diagnostic);
+	return code !== null && ORPHAN_TYPESCRIPT_PROJECT_DIAGNOSTIC_CODES[code] === true;
+}
+
+function filterOrphanProjectDiagnostics(
+	absolutePath: string,
+	serverName: string,
+	serverConfig: ServerConfig,
+	diagnostics: Diagnostic[],
+): Diagnostic[] {
+	if (!serverConfig.rootMarkers.length || hasRootMarkerAncestor(absolutePath, serverConfig.rootMarkers)) {
+		return diagnostics;
+	}
+	return diagnostics.filter(diagnostic => !isTypeScriptProjectDiagnostic(serverName, diagnostic));
 }
 
 const LOCATION_CONTEXT_LINES = 1;
@@ -709,7 +744,7 @@ async function getDiagnosticsForFile(
 			if (serverConfig.createClient) {
 				const linterClient = getLinterClient(serverName, serverConfig, cwd);
 				const diagnostics = await linterClient.lint(absolutePath);
-				return { serverName, diagnostics };
+				return { serverName, serverConfig, diagnostics };
 			}
 
 			// Default: use LSP
@@ -728,14 +763,21 @@ async function getDiagnosticsForFile(
 				minVersion,
 				expectedDocumentVersion,
 			});
-			return { serverName, diagnostics };
+			return { serverName, serverConfig, diagnostics };
 		}),
 	);
 
 	for (const result of results) {
 		if (result.status === "fulfilled") {
 			serverNames.push(result.value.serverName);
-			allDiagnostics.push(...result.value.diagnostics);
+			allDiagnostics.push(
+				...filterOrphanProjectDiagnostics(
+					absolutePath,
+					result.value.serverName,
+					result.value.serverConfig,
+					result.value.diagnostics,
+				),
+			);
 		}
 	}
 

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -259,4 +259,58 @@ describe("LSP diagnostics freshness", () => {
 		// The edit still landed on disk regardless of diagnostics timing.
 		expect(await Bun.file(filePath).text()).toBe("export const value: number = 'x';\n");
 	});
+
+	it("suppresses TypeScript project diagnostics for orphan files but keeps syntax errors", async () => {
+		const server: ServerConfig = {
+			...TEST_SERVER,
+			rootMarkers: ["package.json", "tsconfig.json", "jsconfig.json"],
+		};
+		const orphanDir = TempDir.createSync("@omp-lsp-orphan-");
+		try {
+			const filePath = path.join(orphanDir.path(), "scratch.ts");
+			const uri = fileToUri(filePath);
+			const client = createClient(tempDir.path(), server);
+			client.openFiles.set(uri, { version: 1, languageId: "typescript" });
+
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "typescript-language-server": server },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["typescript-language-server", server]]);
+			vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
+			vi.spyOn(lspClient, "syncContent").mockImplementation(async (mockClient, syncedFilePath) => {
+				const syncedUri = fileToUri(syncedFilePath);
+				mockClient.openFiles.set(syncedUri, { version: 1, languageId: "typescript" });
+			});
+			vi.spyOn(lspClient, "notifySaved").mockImplementation(async mockClient => {
+				const moduleDiagnostic = createDiagnostic(
+					"Cannot find module 'bun:sqlite' or its corresponding type declarations.",
+				);
+				moduleDiagnostic.code = 2307;
+				const bunDiagnostic = createDiagnostic(
+					"Cannot find name 'Bun'. Do you need to install type definitions for Bun?",
+				);
+				bunDiagnostic.code = 2867;
+				const syntaxDiagnostic = createDiagnostic("';' expected.");
+				syntaxDiagnostic.code = 1005;
+				mockClient.diagnostics.set(uri, {
+					version: 1,
+					diagnostics: [moduleDiagnostic, bunDiagnostic, syntaxDiagnostic],
+				});
+				mockClient.diagnosticsVersion += 1;
+			});
+
+			const writethrough = createLspWritethrough(tempDir.path(), { enableFormat: false, enableDiagnostics: true });
+			const result = await writethrough(filePath, 'import { Database } from "bun:sqlite";\nawait Bun.sleep(1)\n');
+
+			expect(result).toBeDefined();
+			expect(result?.errored).toBe(true);
+			expect(result?.messages.some(message => message.includes("bun:sqlite"))).toBe(false);
+			expect(result?.messages.some(message => message.includes("Cannot find name 'Bun'"))).toBe(false);
+			expect(result?.messages.some(message => message.includes("';' expected."))).toBe(true);
+			expect(await Bun.file(filePath).text()).toBe('import { Database } from "bun:sqlite";\nawait Bun.sleep(1)\n');
+		} finally {
+			orphanDir.removeSync();
+		}
+	});
 });


### PR DESCRIPTION
## Repro
A mocked post-write TypeScript LSP path for a `.ts` Bun scratch file outside any root-marker ancestor reproduced the reported noise: `bun test /tmp/omp-lsp-noise-repro.test.ts` returned `2 error(s)` for `bun:sqlite` (2307) and `Bun` (2867) from `createLspWritethrough()`.

## Cause
`packages/coding-agent/src/lsp/index.ts` selected servers from the session cwd via `loadConfig(cwd)` and then routed files by extension with `getServersForFile()`. For writes outside the configured project root, TS server diagnostics were formatted unchanged, so project-resolution errors from the session workspace leaked into orphan scratch files.

## Fix
- Added `hasRootMarkerAncestor()` in `packages/coding-agent/src/lsp/config.ts` to detect whether a target file belongs to any server root marker.
- Filtered TypeScript project-resolution diagnostic codes for orphan files while keeping syntax diagnostics and all diagnostics for rooted files.
- Added regression coverage proving `bun:sqlite`/`Bun` noise is suppressed while a syntax error still surfaces.
- Added an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts` passed with 4 tests. `bun run check:types` passed in `packages/coding-agent`. `gh_push_branch` pre-publish gate passed. Fixes #4401