### PR TITLE
fix(mnemopi): surface extracted facts in recall

### DIFF
--- a/packages/mnemopi/src/core/beam/recall.ts
+++ b/packages/mnemopi/src/core/beam/recall.ts
@@ -125,6 +125,8 @@ const FACT_QUERY_FILLER_WORDS = new Set([
 ]);
 
 const FACT_CLITIC_FRAGMENTS = new Set(["d", "ll", "m", "re", "s", "t", "ve"]);
+const FLAT_FACT_SEARCH_NOISE = new Set(["entity", "fact"]);
+
 
 function nowIso(): string {
 	return new Date().toISOString();
@@ -1016,7 +1018,7 @@ export async function recallEnhanced(
 		updateRecallCounts: false,
 	});
 	if (options.includeFacts === true) {
-		const facts = factRecall(beam, query, Math.min(3, topK));
+		const facts = factRecall(beam, query, factRecallLimit(topK));
 		results.push(...facts);
 	}
 	results.sort((left, right) => (right.score ?? 0) - (left.score ?? 0));
@@ -1025,17 +1027,33 @@ export async function recallEnhanced(
 	return finalResults;
 }
 
+function factRecallLimit(topK: number): number {
+	const requested = Math.max(0, Math.floor(topK));
+	if (requested === 0) return 0;
+	return Math.max(1, Math.ceil(requested / 2));
+}
+
 function sandwichOrder(results: readonly RecallResult[]): {
 	high: RecallResult[];
 	medium: RecallResult[];
 	closing: RecallResult[];
 } {
 	const scored = [...results].sort((left, right) => (right.score ?? 0) - (left.score ?? 0));
-	const high = scored.filter(r => (r.score ?? 0) > 0.7).slice(0, 3);
-	const medium = scored.filter(r => (r.score ?? 0) > 0.3 && (r.score ?? 0) <= 0.7).slice(0, 5);
-	const closing = scored.filter(r => !high.includes(r)).slice(0, 3);
-	return { high, medium, closing: closing.length > 0 ? closing : high.slice(0, 2) };
+	const high = scored.slice(0, 3);
+	const medium = scored.slice(high.length, high.length + 5);
+	const closing = scored.slice(high.length + medium.length, high.length + medium.length + 3);
+	return { high, medium, closing };
 }
+function factSearchableText(subject: string, predicate: string, object: string): string {
+	const objectText = object.trim();
+	if (objectText.length === 0) return `${subject} ${predicate}`.trim();
+	const structuralParts = [subject, predicate].filter(part => {
+		const token = part.trim().toLowerCase();
+		return token.length > 0 && !FLAT_FACT_SEARCH_NOISE.has(token);
+	});
+	return [...structuralParts, objectText].join(" ").trim();
+}
+
 
 function factLine(result: RecallResult): string {
 	const content = result.content.slice(0, 200).trim();
@@ -1137,7 +1155,7 @@ export function factRecall(beam: BeamMemoryState, query: string, topK = 30): Fac
 			const object = asString(row.object);
 			const confidence = asNumber(row.confidence, 0.5);
 			const content = object.length > 0 ? object : `${subject} ${predicate}`.trim();
-			const searchable = `${subject} ${predicate} ${object}`.trim();
+			const searchable = factSearchableText(subject, predicate, object);
 			const queryGroups = factExpandedTokenGroups(query, searchable);
 			const queryTokens = tokensFromGroups(queryGroups);
 			const lexical =
@@ -1168,6 +1186,7 @@ export function factRecall(beam: BeamMemoryState, query: string, topK = 30): Fac
 			};
 			return result;
 		})
+		.filter(result => (result.score ?? 0) > 0)
 		.sort((left, right) => (right.score ?? 0) - (left.score ?? 0))
 		.slice(0, topK);
 }

--- a/packages/mnemopi/src/core/beam/recall.ts
+++ b/packages/mnemopi/src/core/beam/recall.ts
@@ -127,7 +127,6 @@ const FACT_QUERY_FILLER_WORDS = new Set([
 const FACT_CLITIC_FRAGMENTS = new Set(["d", "ll", "m", "re", "s", "t", "ve"]);
 const FLAT_FACT_SEARCH_NOISE = new Set(["entity", "fact"]);
 
-
 function nowIso(): string {
 	return new Date().toISOString();
 }
@@ -1053,7 +1052,6 @@ function factSearchableText(subject: string, predicate: string, object: string):
 	});
 	return [...structuralParts, objectText].join(" ").trim();
 }
-
 
 function factLine(result: RecallResult): string {
 	const content = result.content.slice(0, 200).trim();

--- a/packages/mnemopi/test/recall-precision-regressions.test.ts
+++ b/packages/mnemopi/test/recall-precision-regressions.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { BeamMemory } from "@oh-my-pi/pi-mnemopi/core/beam";
+import { storeFactStrings } from "@oh-my-pi/pi-mnemopi/core/beam/consolidate";
 
 type TestBeam = BeamMemory;
 
@@ -37,6 +38,15 @@ async function expectTopContains(beam: TestBeam, query: string, expected: string
 	const results = await beam.recall(query, 5, { queryTime: "2026-05-30T12:00:00.000Z" });
 	expect(results.length).toBeGreaterThan(0);
 	expect(results[0]?.content.toLowerCase()).toContain(expected.toLowerCase());
+}
+
+function bulletLinesUnder(context: string, heading: string): string[] {
+	const start = context.indexOf(heading);
+	if (start < 0) return [];
+	const rest = context.slice(start + heading.length);
+	const nextHeading = rest.search(/\n## /);
+	const section = nextHeading >= 0 ? rest.slice(0, nextHeading) : rest;
+	return section.split("\n").filter(line => line.startsWith("- "));
 }
 
 describe("recall precision regressions", () => {
@@ -131,5 +141,39 @@ describe("recall precision regressions", () => {
 
 		expect(results.length).toBeGreaterThan(0);
 		expect(results[0]?.content).toContain("stable-cluster");
+	});
+
+	it("surfaces extracted flat facts proportionally and buckets each fact once", async () => {
+		const beam = makeBeam();
+		const facts = [
+			"redis cluster runs on port 6379",
+			"api-server depends on redis for session storage",
+			"redis eviction policy is allkeys-lru",
+			"redis maxmemory is set to 4gb",
+			"redis persistence uses append-only file",
+			"worker queues are backed by redis streams",
+			"redis sentinel handles failover",
+			"cache invalidation publishes to redis pubsub",
+		];
+		storeFactStrings(beam, facts, 0, "repro-source");
+
+		const results = await beam.recallEnhanced("redis", 20, { includeFacts: true });
+		const factContents = results.filter(result => result.tier === "fact").map(result => result.content);
+		expect(factContents.toSorted()).toEqual(facts.toSorted());
+
+		const context = beam.formatContext(results, "bullet");
+		expect(bulletLinesUnder(context, "## Top Facts")).toHaveLength(3);
+		expect(bulletLinesUnder(context, "## Supporting Context")).toHaveLength(5);
+		expect(context).not.toContain("## Recent Signals");
+		const bullets = context.split("\n").filter(line => line.startsWith("- "));
+		expect(new Set(bullets).size).toBe(bullets.length);
+	});
+
+	it("does not recall flat facts through storage-only fact/entity fields", () => {
+		const beam = makeBeam();
+		storeFactStrings(beam, ["redis cluster runs on port 6379"], 0, "repro-source");
+
+		expect(beam.factRecall("fact entity", 10)).toEqual([]);
+		expect(beam.factRecall("redis", 10).map(result => result.content)).toEqual(["redis cluster runs on port 6379"]);
 	});
 });


### PR DESCRIPTION
## Repro
The reporter’s in-memory FTS scenario stores 8 extracted flat facts with `storeFactStrings`, then calls `recallEnhanced("redis", 20, { includeFacts: true })`; before the fix it returned only 3 facts, placed 0 facts under `## Top Facts`, and duplicated the same rows across context buckets. Reproduced with `bun /tmp/recall-trio-repro.ts`.

## Cause
`packages/mnemopi/src/core/beam/recall.ts` capped enhanced fact candidates at `Math.min(3, topK)`, used an absolute `score > 0.7` high-bucket gate in `sandwichOrder`, built fact lexical text from flat storage fields (`subject predicate object`), and populated the closing bucket by excluding only high rows, allowing medium rows to be listed again.

## Fix
- Scale enhanced fact recall to half of the requested `topK` instead of a constant 3.
- Bucket formatted context by relative score order and slice disjoint Top Facts, Supporting Context, and Recent Signals sections.
- Score flat extracted facts against object text without `entity`/`fact` storage noise, and drop zero-score fact matches.
- Add regression coverage for topK-scaled extracted fact surfacing, reachable Top Facts, no duplicated context bullets, and storage-only `fact/entity` noise.

## Verification
`bun test packages/mnemopi/test/recall-precision-regressions.test.ts` passed: 7 tests, 24 assertions. Manual repro after the fix returned 8 of 8 facts, 3 Top Facts, 5 Supporting Context rows, and no duplicated Recent Signals section. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #4402