### PR TITLE
fix(ai): isolate batched tool call arguments

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed identifierless parallel OpenAI-compatible tool-call argument streams so sibling bash JSON cannot bleed into the first command.
+
 ## [16.3.4] - 2026-07-03
 
 ### Added

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1112,8 +1112,7 @@ const streamOpenAICompletionsOnce = (
 							// opening chunk that carries per-entry names, or a continuation whose
 							// entries are argument-only. Either way, route by array offset so
 							// sibling calls stay isolated.
-							const unkeyedBatchedArrayEntry =
-								toolCalls.length > 1 && streamIndex === undefined && !toolCall.id;
+							const unkeyedBatchedArrayEntry = toolCalls.length > 1 && streamIndex === undefined && !toolCall.id;
 							let block = streamIndex !== undefined ? toolCallBlockByIndex.get(streamIndex) : undefined;
 							if (!block && toolCall.id) {
 								block = pendingToolCallBlocks.find(candidate => candidate.id === toolCall.id);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1092,14 +1092,20 @@ const streamOpenAICompletionsOnce = (
 					}
 
 					if (choice?.delta?.tool_calls && choice.delta.tool_calls.length > 0) {
-						for (const toolCall of choice.delta.tool_calls) {
+						const toolCalls = choice.delta.tool_calls;
+						for (let toolCallOffset = 0; toolCallOffset < toolCalls.length; toolCallOffset++) {
+							const toolCall = toolCalls[toolCallOffset]!;
 							const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
+							const incomingName = toolCall.function?.name || "";
+							const unkeyedNamedBatchEntry =
+								toolCalls.length > 1 && streamIndex === undefined && !toolCall.id && incomingName.length > 0;
 							let block = streamIndex !== undefined ? toolCallBlockByIndex.get(streamIndex) : undefined;
 							if (!block && toolCall.id) {
 								block = pendingToolCallBlocks.find(candidate => candidate.id === toolCall.id);
 							}
 							if (
 								!block &&
+								!unkeyedNamedBatchEntry &&
 								currentBlock?.type === "toolCall" &&
 								(!toolCall.id || currentBlock.id === toolCall.id)
 							) {
@@ -1113,7 +1119,7 @@ const streamOpenAICompletionsOnce = (
 								block = {
 									type: "toolCall",
 									id: toolCall.id || "",
-									name: toolCall.function?.name || "",
+									name: incomingName,
 									arguments: {},
 									partialArgs: "",
 									streamIndex,
@@ -1141,7 +1147,7 @@ const streamOpenAICompletionsOnce = (
 							}
 
 							if (toolCall.id) block.id = toolCall.id;
-							if (toolCall.function?.name) block.name = toolCall.function.name;
+							if (incomingName) block.name = incomingName;
 							let delta = "";
 							// The OpenAI SDK types `function.arguments` as a JSON string, but MiniMax-compatible
 							// hosts stream a fully-formed object instead. Model both shapes so the branches below

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -759,6 +759,16 @@ const streamOpenAICompletionsOnce = (
 			type OpenAIStreamBlock = TextContent | ThinkingContent | ToolCallStreamBlock;
 			const pendingToolCallBlocks: ToolCallStreamBlock[] = [];
 			const toolCallBlockByIndex = new Map<number, ToolCallStreamBlock>();
+			// Blocks born from an unkeyed multi-entry `tool_calls` array (no `id`,
+			// no `index`), tracked by array offset so continuation chunks that omit
+			// the entry name still route back to the sibling created earlier
+			// instead of collapsing onto `currentBlock`.
+			const unkeyedBatchBlocks: (ToolCallStreamBlock | undefined)[] = [];
+			const clearUnkeyedBatchSlot = (block: ToolCallStreamBlock): void => {
+				for (let index = 0; index < unkeyedBatchBlocks.length; index++) {
+					if (unkeyedBatchBlocks[index] === block) unkeyedBatchBlocks[index] = undefined;
+				}
+			};
 			let currentBlock: OpenAIStreamBlock | undefined;
 			const blockIndex = (block: OpenAIStreamBlock | undefined): number => {
 				if (!block) return Math.max(0, output.content.length - 1);
@@ -791,6 +801,7 @@ const streamOpenAICompletionsOnce = (
 				}
 				const pendingIndex = pendingToolCallBlocks.indexOf(block);
 				if (pendingIndex >= 0) pendingToolCallBlocks.splice(pendingIndex, 1);
+				clearUnkeyedBatchSlot(block);
 				stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial: output });
 			};
 			const finishPendingToolCallBlocks = (): void => {
@@ -1097,15 +1108,23 @@ const streamOpenAICompletionsOnce = (
 							const toolCall = toolCalls[toolCallOffset]!;
 							const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
 							const incomingName = toolCall.function?.name || "";
-							const unkeyedNamedBatchEntry =
-								toolCalls.length > 1 && streamIndex === undefined && !toolCall.id && incomingName.length > 0;
+							// Multi-entry `tool_calls` arrays without `id`/`index` — either the
+							// opening chunk that carries per-entry names, or a continuation whose
+							// entries are argument-only. Either way, route by array offset so
+							// sibling calls stay isolated.
+							const unkeyedBatchedArrayEntry =
+								toolCalls.length > 1 && streamIndex === undefined && !toolCall.id;
 							let block = streamIndex !== undefined ? toolCallBlockByIndex.get(streamIndex) : undefined;
 							if (!block && toolCall.id) {
 								block = pendingToolCallBlocks.find(candidate => candidate.id === toolCall.id);
 							}
+							if (!block && unkeyedBatchedArrayEntry) {
+								const offsetBlock = unkeyedBatchBlocks[toolCallOffset];
+								if (offsetBlock && offsetBlock.partialArgs !== undefined) block = offsetBlock;
+							}
 							if (
 								!block &&
-								!unkeyedNamedBatchEntry &&
+								!unkeyedBatchedArrayEntry &&
 								currentBlock?.type === "toolCall" &&
 								(!toolCall.id || currentBlock.id === toolCall.id)
 							) {
@@ -1133,6 +1152,7 @@ const streamOpenAICompletionsOnce = (
 									contentIndex: blockIndex(block),
 									partial: output,
 								});
+								if (unkeyedBatchedArrayEntry) unkeyedBatchBlocks[toolCallOffset] = block;
 							} else {
 								// Resuming a pending call after interleaved text/thinking:
 								// close the text/thinking block we drifted into.

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1909,7 +1909,6 @@ export async function processResponsesStream<TApi extends Api>(
 		return false;
 	};
 
-
 	const lookupOpenToolCallAlias = (
 		event: { output_index?: number; item_id?: string },
 		type: "function_call" | "custom_tool_call",

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1874,6 +1874,28 @@ export async function processResponsesStream<TApi extends Api>(
 	};
 	const hasOpenItemKey = (event: { output_index?: number; item_id?: string }): boolean =>
 		typeof event.output_index === "number" || event.item_id !== undefined;
+	const startsJsonObjectDelta = (delta: unknown): boolean => {
+		if (typeof delta !== "string") return false;
+		for (let index = 0; index < delta.length; index++) {
+			const code = delta.charCodeAt(index);
+			if (code === 0x09 || code === 0x0a || code === 0x0d || code === 0x20) continue;
+			return code === 0x7b;
+		}
+		return false;
+	};
+	const shouldAdvanceIdentifierlessFunctionDelta = (
+		event: { output_index?: number; item_id?: string; delta?: unknown },
+		candidate: StreamingItem,
+	): boolean => {
+		return (
+			!hasOpenItemKey(event) &&
+			startsJsonObjectDelta(event.delta) &&
+			candidate.item.type === "function_call" &&
+			candidate.block.type === "toolCall" &&
+			candidate.block[kStreamingPartialJson].trim().length > 0
+		);
+	};
+
 	const lookupOpenToolCallAlias = (
 		event: { output_index?: number; item_id?: string },
 		type: "function_call" | "custom_tool_call",
@@ -1902,17 +1924,24 @@ export async function processResponsesStream<TApi extends Api>(
 	const lookupOpenFunctionCallItem = (event: {
 		output_index?: number;
 		item_id?: string;
+		delta?: unknown;
 	}): StreamingItem | undefined => {
 		if (hasOpenItemKey(event)) return lookupOpenToolCallAlias(event, "function_call");
+		let skippedStartedCandidate = false;
 		for (const candidate of openItemsInOrder) {
 			if (
 				candidate.item.type === "function_call" &&
 				candidate.block.type === "toolCall" &&
 				!candidate.block[kStreamingArgumentsDone]
 			) {
+				if (shouldAdvanceIdentifierlessFunctionDelta(event, candidate)) {
+					skippedStartedCandidate = true;
+					continue;
+				}
 				return candidate;
 			}
 		}
+		if (skippedStartedCandidate && startsJsonObjectDelta(event.delta)) return undefined;
 		return lastOpenItem?.item.type === "function_call" ? lastOpenItem : undefined;
 	};
 	const closeOpenItem = (
@@ -2150,9 +2179,11 @@ export async function processResponsesStream<TApi extends Api>(
 				const block = entry?.block.type === "toolCall" ? entry.block : undefined;
 				const args = block?.[kStreamingArgumentsDone]
 					? block.arguments
-					: block?.[kStreamingPartialJson]
-						? parseStreamingJson(block[kStreamingPartialJson])
-						: parseStreamingJson(item.arguments || "{}");
+					: item.arguments
+						? parseStreamingJson(item.arguments)
+						: block?.[kStreamingPartialJson]
+							? parseStreamingJson(block[kStreamingPartialJson])
+							: parseStreamingJson("{}");
 				const toolCall: ToolCall = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1895,6 +1895,20 @@ export async function processResponsesStream<TApi extends Api>(
 			candidate.block[kStreamingPartialJson].trim().length > 0
 		);
 	};
+	const hasLaterUnfinishedFunctionCall = (start: number): boolean => {
+		for (let index = start + 1; index < openItemsInOrder.length; index++) {
+			const candidate = openItemsInOrder[index];
+			if (
+				candidate?.item.type === "function_call" &&
+				candidate.block.type === "toolCall" &&
+				!candidate.block[kStreamingArgumentsDone]
+			) {
+				return true;
+			}
+		}
+		return false;
+	};
+
 
 	const lookupOpenToolCallAlias = (
 		event: { output_index?: number; item_id?: string },
@@ -1928,13 +1942,14 @@ export async function processResponsesStream<TApi extends Api>(
 	}): StreamingItem | undefined => {
 		if (hasOpenItemKey(event)) return lookupOpenToolCallAlias(event, "function_call");
 		let skippedStartedCandidate = false;
-		for (const candidate of openItemsInOrder) {
+		for (let index = 0; index < openItemsInOrder.length; index++) {
+			const candidate = openItemsInOrder[index]!;
 			if (
 				candidate.item.type === "function_call" &&
 				candidate.block.type === "toolCall" &&
 				!candidate.block[kStreamingArgumentsDone]
 			) {
-				if (shouldAdvanceIdentifierlessFunctionDelta(event, candidate)) {
+				if (shouldAdvanceIdentifierlessFunctionDelta(event, candidate) && hasLaterUnfinishedFunctionCall(index)) {
 					skippedStartedCandidate = true;
 					continue;
 				}

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -654,10 +654,7 @@ describe("openai-completions compatibility", () => {
 		}).result();
 
 		const calls = result.content.filter(content => content.type === "toolCall");
-		expect(calls.map(call => call.arguments)).toEqual([
-			{ command: "echo hello" },
-			{ command: "echo goodbye" },
-		]);
+		expect(calls.map(call => call.arguments)).toEqual([{ command: "echo hello" }, { command: "echo goodbye" }]);
 	});
 
 	it("falls through zero cached-token candidates to later non-zero usage fields", () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -689,10 +689,7 @@ describe("openai-completions compatibility", () => {
 					{
 						index: 0,
 						delta: {
-							tool_calls: [
-								{ function: { arguments: "}" } },
-								{ function: { arguments: "}" } },
-							],
+							tool_calls: [{ function: { arguments: "}" } }, { function: { arguments: "}" } }],
 						},
 					},
 				],

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -657,6 +657,65 @@ describe("openai-completions compatibility", () => {
 		expect(calls.map(call => call.arguments)).toEqual([{ command: "echo hello" }, { command: "echo goodbye" }]);
 	});
 
+	it("routes unindexed batched tool-call continuation chunks back by array offset", async () => {
+		const model: Model<"openai-completions"> = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+		} as ModelSpec<"openai-completions">);
+		const fetchMock = createMockFetch([
+			{
+				id: "chatcmpl-batched-continuation",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{ function: { name: "bash", arguments: '{"command":"echo hello"' } },
+								{ function: { name: "bash", arguments: '{"command":"echo goodbye"' } },
+							],
+						},
+					},
+				],
+			},
+			{
+				id: "chatcmpl-batched-continuation",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{ function: { arguments: "}" } },
+								{ function: { arguments: "}" } },
+							],
+						},
+					},
+				],
+			},
+			{
+				id: "chatcmpl-batched-continuation",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		const calls = result.content.filter(content => content.type === "toolCall");
+		expect(calls.map(call => call.arguments)).toEqual([{ command: "echo hello" }, { command: "echo goodbye" }]);
+	});
+
 	it("falls through zero cached-token candidates to later non-zero usage fields", () => {
 		const model: Model<"openai-completions"> = buildModel({
 			...gpt4oMiniSpec,

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -615,6 +615,51 @@ describe("openai-completions compatibility", () => {
 		expect(result.usage.totalTokens).toBe(15);
 	});
 
+	it("keeps unindexed batched tool-call arguments isolated", async () => {
+		const model: Model<"openai-completions"> = buildModel({
+			...gpt4oMiniSpec,
+			api: "openai-completions",
+		} as ModelSpec<"openai-completions">);
+		const fetchMock = createMockFetch([
+			{
+				id: "chatcmpl-batched-tools",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [
+					{
+						index: 0,
+						delta: {
+							tool_calls: [
+								{ function: { name: "bash", arguments: '{"command":"echo hello"}' } },
+								{ function: { name: "bash", arguments: '{"command":"echo goodbye"}' } },
+							],
+						},
+					},
+				],
+			},
+			{
+				id: "chatcmpl-batched-tools",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		const calls = result.content.filter(content => content.type === "toolCall");
+		expect(calls.map(call => call.arguments)).toEqual([
+			{ command: "echo hello" },
+			{ command: "echo goodbye" },
+		]);
+	});
+
 	it("falls through zero cached-token candidates to later non-zero usage fields", () => {
 		const model: Model<"openai-completions"> = buildModel({
 			...gpt4oMiniSpec,

--- a/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
+++ b/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
@@ -316,6 +316,63 @@ describe("processResponsesStream: parallel function_call items", () => {
 		expect(byCallId.get("call_b")?.toolCall.arguments).toEqual({ command: "printf b" });
 	});
 
+	test("routes identifierless argument deltas to sibling calls when a new JSON object starts", async () => {
+		const output = makeOutput();
+		const emitted: EmittedEvent[] = [];
+		const stream = { push: (e: unknown) => emitted.push(e as EmittedEvent), end: () => {} } as never;
+
+		const argsA = JSON.stringify({ command: "echo hello" });
+		const argsB = JSON.stringify({ command: "echo goodbye" });
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "bash", arguments: "" },
+				},
+				{
+					type: "response.output_item.added",
+					output_index: 1,
+					item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "bash", arguments: "" },
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					delta: '{"command":"echo hello\n',
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					delta: argsB,
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "bash", arguments: argsA },
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 1,
+					item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "bash", arguments: argsB },
+				},
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		const [blockA, blockB] = output.content;
+		if (blockA?.type !== "toolCall" || blockB?.type !== "toolCall") throw new Error("expected toolCalls");
+		expect(blockA.arguments).toEqual({ command: "echo hello" });
+		expect(blockB.arguments).toEqual({ command: "echo goodbye" });
+		expect(String(blockA.arguments.command)).not.toContain('{"command');
+
+		const deltas = emitted.filter(e => e.type === "toolcall_delta") as Array<{
+			delta: string;
+			contentIndex: number;
+		}>;
+		expect(deltas.map(delta => delta.contentIndex)).toEqual([0, 1]);
+	});
+
 	test("routes deltas by item.call_id when llama.cpp omits item.id and output_index (issue #2015)", async () => {
 		// llama.cpp's `to_json_oaicompat_resp` (tools/server/server-task.cpp) emits a
 		// function_call's `output_item.added` with only `item.call_id` — no `item.id`,

--- a/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
+++ b/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
@@ -373,6 +373,43 @@ describe("processResponsesStream: parallel function_call items", () => {
 		expect(deltas.map(delta => delta.contentIndex)).toEqual([0, 1]);
 	});
 
+	test("keeps brace-prefixed chunks on a single identifierless function call", async () => {
+		const output = makeOutput();
+		const emitted: EmittedEvent[] = [];
+		const stream = { push: (e: unknown) => emitted.push(e as EmittedEvent), end: () => {} } as never;
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.added",
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "bash", arguments: "" },
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					delta: '{"command":"echo ',
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					delta: '{1..3}"}',
+				},
+				{
+					type: "response.output_item.done",
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "bash", arguments: "" },
+				},
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		const [block] = output.content;
+		if (block?.type !== "toolCall") throw new Error("expected toolCall");
+		expect(block.arguments).toEqual({ command: "echo {1..3}" });
+
+		const deltas = emitted.filter(e => e.type === "toolcall_delta") as Array<{ contentIndex: number }>;
+		expect(deltas.map(delta => delta.contentIndex)).toEqual([0, 0]);
+	});
+
 	test("routes deltas by item.call_id when llama.cpp omits item.id and output_index (issue #2015)", async () => {
 		// llama.cpp's `to_json_oaicompat_resp` (tools/server/server-task.cpp) emits a
 		// function_call's `output_item.added` with only `item.call_id` — no `item.id`,


### PR DESCRIPTION
## Repro
An OpenAI-compatible stream that opens two `bash` function calls and then emits identifierless argument deltas can append the second call’s JSON prefix to the first command. Reproduced with `streamOpenAICompletions` using one chunk containing two unindexed `bash` `tool_calls`: the first parsed command became `echo hello\n{"command`.

## Cause
`packages/ai/src/providers/openai-shared.ts` routed fully identifierless `response.function_call_arguments.delta` events to the first unfinished function call, so a sibling JSON object starting with `{"command"` could be appended to an already-started bash argument buffer. `packages/ai/src/providers/openai-completions.ts` also reused `currentBlock` for every unindexed, idless named entry in the same `tool_calls` array, collapsing batched chat-completion calls into one block.

## Fix
- Advance identifierless Responses argument deltas to the next open function call when the delta starts a new JSON object and the current call already has argument bytes.
- Prefer authoritative `output_item.done.item.arguments` over partial buffers when Responses finalization provides final arguments.
- Split unindexed, idless, named chat-completions tool-call entries in the same delta array into separate tool-call blocks.
- Added regressions for Responses and chat-completions batched bash argument isolation.

## Verification
`bun test packages/ai/test/openai-responses-parallel-tool-calls.test.ts packages/ai/test/openai-completions-compat.test.ts` passed: 73 tests, 244 assertions. `gh_push_branch` pre-publish gate completed and pushed the branch. Fixes #4414