### PR TITLE
fix(mcp): surface a short launch URL and log Windows opener failures for OAuth

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `OAuthCallbackFlow` now serves a `GET /launch` route on its loopback callback server that 302-redirects to the pending authorization URL, and exposes that short URL as `OAuthAuthInfo.launchUrl`. UIs can advertise it as a truncation-safe copy target (~30 chars) instead of the full authorize URL, so terminals narrower than the composed row cannot silently drop OAuth query parameters like `code_challenge_method=S256` ([#4418](https://github.com/can1357/oh-my-pi/issues/4418)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -16,7 +16,13 @@ import * as AIError from "./error";
 import { isUsageLimitOutcome } from "./error/rate-limit";
 import { getProviderDefinition, PASTE_CODE_LOGIN_PROVIDERS } from "./registry";
 import { getOAuthApiKey, getOAuthProvider, refreshOAuthToken } from "./registry/oauth";
-import type { OAuthController, OAuthCredentials, OAuthProvider, OAuthProviderId } from "./registry/oauth/types";
+import type {
+	OAuthAuthInfo,
+	OAuthController,
+	OAuthCredentials,
+	OAuthProvider,
+	OAuthProviderId,
+} from "./registry/oauth/types";
 import { getEnvApiKey, getEnvApiKeyName } from "./stream";
 import type { Provider } from "./types";
 import type {
@@ -1863,7 +1869,7 @@ export class AuthStorage {
 		provider: OAuthProviderId,
 		ctrl: OAuthController & {
 			/** onAuth is required by auth-storage but optional in OAuthController */
-			onAuth: (info: { url: string; instructions?: string }) => void;
+			onAuth: (info: OAuthAuthInfo) => void;
 			/** onPrompt is required for some providers (github-copilot, openai-codex) */
 			onPrompt: (prompt: { message: string; placeholder?: string }) => Promise<string>;
 		},

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -17,6 +17,14 @@ import type { OAuthController, OAuthCredentials } from "./types";
 const DEFAULT_TIMEOUT = 300_000;
 const DEFAULT_HOSTNAME = "localhost";
 const CALLBACK_PATH = "/callback";
+/**
+ * Path served by {@link OAuthCallbackFlow} that 302-redirects to the pending
+ * authorization URL. Kept out of {@link OAuthCallbackFlowOptions} because it
+ * lives on the loopback callback server alongside {@link CALLBACK_PATH} and
+ * must never clash with a provider-registered redirect URI (all known
+ * providers register `/callback`-shaped paths).
+ */
+const LAUNCH_PATH = "/launch";
 
 export type CallbackResult = { code: string; state: string };
 
@@ -54,6 +62,14 @@ export abstract class OAuthCallbackFlow {
 	allowPortFallback: boolean;
 	#callbackResolve?: (result: CallbackResult) => void;
 	#callbackReject?: (error: string) => void;
+	/**
+	 * Authorization URL the `/launch` route currently redirects to. Set by
+	 * {@link login} after {@link generateAuthUrl} and before {@link OAuthController.onAuth}
+	 * fires, cleared when the server stops. `undefined` before the flow reaches
+	 * that point and after it finishes, so `/launch` returns 503 rather than
+	 * a stale URL.
+	 */
+	#pendingAuthUrl?: string;
 
 	constructor(
 		ctrl: OAuthController,
@@ -120,7 +136,7 @@ export abstract class OAuthCallbackFlow {
 		this.#throwIfCancelled();
 
 		// Start callback server first to get actual redirect URI
-		const { server, redirectUri } = await this.#startCallbackServer(state);
+		const { server, redirectUri, launchUrl } = await this.#startCallbackServer(state);
 
 		try {
 			this.#throwIfCancelled();
@@ -128,8 +144,14 @@ export abstract class OAuthCallbackFlow {
 			const { url: authUrl, instructions } = await this.generateAuthUrl(state, redirectUri);
 			this.#throwIfCancelled();
 
+			// Publish the auth URL to the `/launch` route BEFORE handing it to
+			// callers. `onAuth` immediately renders a UI that advertises the
+			// launch URL as a copy target, so `/launch` must already resolve if
+			// the user clicks/pastes it during the same render pass.
+			this.#pendingAuthUrl = authUrl;
+
 			// Notify controller that auth is ready
-			this.ctrl.onAuth?.({ url: authUrl, instructions });
+			this.ctrl.onAuth?.({ url: authUrl, launchUrl, instructions });
 			this.ctrl.onProgress?.("Waiting for browser authentication...");
 
 			// Wait for callback or manual input
@@ -140,6 +162,7 @@ export abstract class OAuthCallbackFlow {
 
 			return await this.exchangeToken(code, state, redirectUri);
 		} finally {
+			this.#pendingAuthUrl = undefined;
 			server.stop();
 		}
 	}
@@ -147,14 +170,21 @@ export abstract class OAuthCallbackFlow {
 	/**
 	 * Start callback server, trying preferred port first, falling back to random.
 	 */
-	async #startCallbackServer(expectedState: string): Promise<{ server: Bun.Server<unknown>; redirectUri: string }> {
+	async #startCallbackServer(
+		expectedState: string,
+	): Promise<{ server: Bun.Server<unknown>; redirectUri: string; launchUrl: string }> {
 		try {
 			const server = this.#createServer(this.preferredPort, expectedState);
+			// `preferredPort: 0` opts into a random port — read the actual bound
+			// port from the server so both the redirect URI and launch URL point at
+			// a reachable socket, not the sentinel.
+			const actualPort = this.#resolveServerPort(server);
+			const launchUrl = this.#launchUrlFor(actualPort);
 			if (this.redirectUri) {
-				return { server, redirectUri: this.redirectUri };
+				return { server, redirectUri: this.redirectUri, launchUrl };
 			}
-			const redirectUri = `http://${this.callbackHostname}:${this.preferredPort}${this.callbackPath}`;
-			return { server, redirectUri };
+			const redirectUri = `http://${this.callbackHostname}:${actualPort}${this.callbackPath}`;
+			return { server, redirectUri, launchUrl };
 		} catch (cause) {
 			if (this.redirectUri) {
 				throw new AIError.ConfigurationError(
@@ -169,11 +199,37 @@ export abstract class OAuthCallbackFlow {
 				);
 			}
 			const server = this.#createServer(0, expectedState);
-			const actualPort = server.port;
+			const actualPort = this.#resolveServerPort(server);
 			const redirectUri = `http://${this.callbackHostname}:${actualPort}${this.callbackPath}`;
+			const launchUrl = this.#launchUrlFor(actualPort);
 			this.ctrl.onProgress?.(`Preferred port ${this.preferredPort} unavailable, using port ${actualPort}`);
-			return { server, redirectUri };
+			return { server, redirectUri, launchUrl };
 		}
+	}
+
+	/**
+	 * Read the numeric port a callback server bound to. `Bun.Server.port` is
+	 * declared `number | undefined` because Unix-socket servers have no port,
+	 * but every callback flow uses TCP; a missing port here indicates a
+	 * configuration error rather than a fallback case.
+	 */
+	#resolveServerPort(server: Bun.Server<unknown>): number {
+		const port = server.port;
+		if (typeof port !== "number") {
+			throw new AIError.ConfigurationError(
+				"OAuth callback server bound to a non-TCP endpoint; expected a numeric port. Check `oauth.callbackPort`/`oauth.redirectUri`.",
+			);
+		}
+		return port;
+	}
+
+	/**
+	 * Build the `/launch` URL served by the callback server bound to `port`.
+	 * Kept short (~30 chars) so UIs can advertise it as a viewport-truncation-safe
+	 * copy target for the full authorization URL.
+	 */
+	#launchUrlFor(port: number): string {
+		return `http://${this.callbackHostname}:${port}${LAUNCH_PATH}`;
 	}
 
 	/**
@@ -190,10 +246,21 @@ export abstract class OAuthCallbackFlow {
 	}
 
 	/**
-	 * Handle OAuth callback HTTP request.
+	 * Handle OAuth callback HTTP request. Two routes on the same loopback server:
+	 * - `callbackPath` (default `/callback`) — the provider redirect target.
+	 * - `LAUNCH_PATH` (`/launch`) — 302 to the pending authorization URL so
+	 *   viewport-safe copy targets can survive TUI truncation.
 	 */
 	#handleCallback(req: Request, expectedState: string): Response {
 		const url = new URL(req.url);
+
+		if (url.pathname === LAUNCH_PATH) {
+			const pending = this.#pendingAuthUrl;
+			if (!pending) {
+				return new Response("OAuth launch URL is no longer active", { status: 503 });
+			}
+			return Response.redirect(pending, 302);
+		}
 
 		if (url.pathname !== this.callbackPath) {
 			return new Response("Not Found", { status: 404 });

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -169,17 +169,21 @@ export abstract class OAuthCallbackFlow {
 
 	/**
 	 * Start callback server, trying preferred port first, falling back to random.
+	 * `launchUrl` is `undefined` when the caller configured `callbackPath` to
+	 * collide with {@link LAUNCH_PATH} — the callback handler resolves the real
+	 * callback in that case, so advertising a self-redirecting URL would be
+	 * incorrect.
 	 */
 	async #startCallbackServer(
 		expectedState: string,
-	): Promise<{ server: Bun.Server<unknown>; redirectUri: string; launchUrl: string }> {
+	): Promise<{ server: Bun.Server<unknown>; redirectUri: string; launchUrl: string | undefined }> {
 		try {
 			const server = this.#createServer(this.preferredPort, expectedState);
 			// `preferredPort: 0` opts into a random port — read the actual bound
 			// port from the server so both the redirect URI and launch URL point at
 			// a reachable socket, not the sentinel.
 			const actualPort = this.#resolveServerPort(server);
-			const launchUrl = this.#launchUrlFor(actualPort);
+			const launchUrl = this.#launchUrlIfSafe(actualPort);
 			if (this.redirectUri) {
 				return { server, redirectUri: this.redirectUri, launchUrl };
 			}
@@ -201,7 +205,7 @@ export abstract class OAuthCallbackFlow {
 			const server = this.#createServer(0, expectedState);
 			const actualPort = this.#resolveServerPort(server);
 			const redirectUri = `http://${this.callbackHostname}:${actualPort}${this.callbackPath}`;
-			const launchUrl = this.#launchUrlFor(actualPort);
+			const launchUrl = this.#launchUrlIfSafe(actualPort);
 			this.ctrl.onProgress?.(`Preferred port ${this.preferredPort} unavailable, using port ${actualPort}`);
 			return { server, redirectUri, launchUrl };
 		}
@@ -224,11 +228,23 @@ export abstract class OAuthCallbackFlow {
 	}
 
 	/**
-	 * Build the `/launch` URL served by the callback server bound to `port`.
-	 * Kept short (~30 chars) so UIs can advertise it as a viewport-truncation-safe
-	 * copy target for the full authorization URL.
+	 * Build the `/launch` URL served by the callback server bound to `port`, or
+	 * `undefined` when the configured `callbackPath` (or a `redirectUri` whose
+	 * pathname resolves to {@link LAUNCH_PATH}) would collide with the launch
+	 * route. Kept short (~30 chars) so UIs can advertise it as a
+	 * viewport-truncation-safe copy target for the full authorization URL.
 	 */
-	#launchUrlFor(port: number): string {
+	#launchUrlIfSafe(port: number): string | undefined {
+		if (this.callbackPath === LAUNCH_PATH) return undefined;
+		if (this.redirectUri) {
+			try {
+				if (new URL(this.redirectUri).pathname === LAUNCH_PATH) return undefined;
+			} catch {
+				// A non-parseable redirectUri (e.g. `vscode://...` handled elsewhere)
+				// can't collide with an HTTP `/launch` route — fall through and
+				// advertise the launch URL against the loopback server.
+			}
+		}
 		return `http://${this.callbackHostname}:${port}${LAUNCH_PATH}`;
 	}
 
@@ -248,21 +264,26 @@ export abstract class OAuthCallbackFlow {
 	/**
 	 * Handle OAuth callback HTTP request. Two routes on the same loopback server:
 	 * - `callbackPath` (default `/callback`) — the provider redirect target.
-	 * - `LAUNCH_PATH` (`/launch`) — 302 to the pending authorization URL so
+	 * - {@link LAUNCH_PATH} (`/launch`) — 302 to the pending authorization URL so
 	 *   viewport-safe copy targets can survive TUI truncation.
+	 *
+	 * `callbackPath` wins any collision: an OMP config that pins the provider
+	 * redirect at `/launch` (via `oauth.callbackPath` or a loopback
+	 * `oauth.redirectUri`) must resolve the callback normally rather than
+	 * self-redirect. `#startCallbackServer` also suppresses `launchUrl` in that
+	 * case, so the launch route is never advertised when it would collide.
 	 */
 	#handleCallback(req: Request, expectedState: string): Response {
 		const url = new URL(req.url);
 
-		if (url.pathname === LAUNCH_PATH) {
-			const pending = this.#pendingAuthUrl;
-			if (!pending) {
-				return new Response("OAuth launch URL is no longer active", { status: 503 });
-			}
-			return Response.redirect(pending, 302);
-		}
-
 		if (url.pathname !== this.callbackPath) {
+			if (url.pathname === LAUNCH_PATH) {
+				const pending = this.#pendingAuthUrl;
+				if (!pending) {
+					return new Response("OAuth launch URL is no longer active", { status: 503 });
+				}
+				return Response.redirect(pending, 302);
+			}
 			return new Response("Not Found", { status: 404 });
 		}
 

--- a/packages/ai/src/registry/oauth/types.ts
+++ b/packages/ai/src/registry/oauth/types.ts
@@ -23,7 +23,21 @@ export type OAuthPrompt = {
 };
 
 export type OAuthAuthInfo = {
+	/**
+	 * Full authorization URL. Suitable for direct browser launch, OSC 8
+	 * hyperlinks, and clipboard when the target UI can guarantee the full
+	 * string reaches the user unmodified.
+	 */
 	url: string;
+	/**
+	 * Short loopback URL that 302-redirects to {@link url}. Provided by flows
+	 * that host the redirect on the same callback server they already run
+	 * ({@link OAuthCallbackFlow}). UIs SHOULD prefer this as the copy target
+	 * so viewport truncation cannot corrupt OAuth query parameters. Undefined
+	 * for flows without a loopback callback server (device code, paste-code
+	 * providers with fixed non-loopback redirects, etc.).
+	 */
+	launchUrl?: string;
 	instructions?: string;
 };
 

--- a/packages/ai/test/callback-server-launch-route.test.ts
+++ b/packages/ai/test/callback-server-launch-route.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { OAuthCallbackFlow } from "@oh-my-pi/pi-ai/registry/oauth/callback-server";
+import type { OAuthAuthInfo, OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
+
+/**
+ * Regression harness for #4418 — the `/launch` route the callback server hosts
+ * so UIs can advertise a short (~30-char) copy target that survives TUI viewport
+ * truncation. Without it, the full authorize URL (~260+ chars on Linear/GitHub/…)
+ * gets silently truncated mid-parameter and downgrades the flow to plain PKCE.
+ */
+class LaunchProbeFlow extends OAuthCallbackFlow {
+	authUrls: string[] = [];
+	// Long enough that a 270-col TUI would clip `code_challenge_method=S256`.
+	static readonly PADDING = "x".repeat(200);
+
+	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string }> {
+		const url =
+			"https://mcp.example.com/authorize?" +
+			new URLSearchParams({
+				response_type: "code",
+				client_id: "test-client",
+				redirect_uri: redirectUri,
+				state,
+				scope: LaunchProbeFlow.PADDING,
+				code_challenge: "test-challenge",
+				code_challenge_method: "S256",
+			}).toString();
+		this.authUrls.push(url);
+		return { url };
+	}
+
+	async exchangeToken(): Promise<OAuthCredentials> {
+		return { access: "unused", refresh: "unused", expires: Date.now() + 60_000 };
+	}
+}
+
+/**
+ * Start a flow and resolve once `onAuth` fires — that's the exact instant
+ * `/launch` becomes live, so tests can hit it without a wall-clock sleep.
+ * Returns the captured auth info, the abort controller (so tests can shut the
+ * flow down), and the pending `login` promise (so tests can await teardown).
+ */
+async function startFlowAndWaitForAuth(): Promise<{
+	info: OAuthAuthInfo;
+	abort: AbortController;
+	login: Promise<void>;
+}> {
+	const abort = new AbortController();
+	const authFired = Promise.withResolvers<OAuthAuthInfo>();
+	const flow = new LaunchProbeFlow(
+		{
+			onAuth: info => {
+				authFired.resolve(info);
+			},
+			signal: abort.signal,
+		},
+		{ preferredPort: 0, allowPortFallback: true },
+	);
+	// Kick off login in the background; tests own its lifetime via `abort`.
+	const login = flow.login().catch(() => undefined) as Promise<void>;
+	const info = await authFired.promise;
+	return { info, abort, login };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("OAuthCallbackFlow /launch route", () => {
+	it("advertises a short launch URL and 302s it to the pending authorization URL", async () => {
+		const { info, abort, login } = await startFlowAndWaitForAuth();
+
+		// Contract 1 — launch URL is short and shaped like a loopback URL. A
+		// terminal that truncates below ~40 columns is degenerate; anything above
+		// that keeps the launch URL intact regardless of the full URL length.
+		expect(info.launchUrl).toBeDefined();
+		expect(info.launchUrl!.length).toBeLessThan(40);
+		expect(info.launchUrl).toMatch(/^http:\/\/localhost:\d+\/launch$/);
+
+		// Contract 2 — GET /launch returns 302 pointing at the pending authorize URL,
+		// byte-for-byte (the whole point: no truncation surface between UI and provider).
+		const response = await fetch(info.launchUrl!, { redirect: "manual" });
+		expect(response.status).toBe(302);
+		expect(response.headers.get("location")).toBe(info.url);
+
+		abort.abort("test done");
+		await login;
+	});
+
+	it("stops answering /launch once the flow completes so no stale URL is redirected", async () => {
+		const { info, abort, login } = await startFlowAndWaitForAuth();
+		expect(info.launchUrl).toBeDefined();
+
+		abort.abort("test done");
+		await login;
+
+		// Server has stopped and `#pendingAuthUrl` was cleared — the launch URL
+		// no longer connects. The correct end-state is that the redirect NEVER
+		// points at a stale URL; the loopback socket is gone so `fetch` rejects.
+		await expect(fetch(info.launchUrl!)).rejects.toThrow();
+	});
+
+	it("routes `/callback` and `/launch` on the same server without interfering", async () => {
+		const { info, abort, login } = await startFlowAndWaitForAuth();
+		expect(info.launchUrl).toBeDefined();
+
+		// A GET at an unrelated path still 404s — `/launch` is additive, not a
+		// blanket catch-all.
+		const origin = new URL(info.launchUrl!).origin;
+		const stray = await fetch(`${origin}/nope`);
+		expect(stray.status).toBe(404);
+
+		abort.abort("test done");
+		await login;
+	});
+});

--- a/packages/ai/test/callback-server-launch-route.test.ts
+++ b/packages/ai/test/callback-server-launch-route.test.ts
@@ -113,4 +113,73 @@ describe("OAuthCallbackFlow /launch route", () => {
 		abort.abort("test done");
 		await login;
 	});
+
+	it("suppresses launchUrl and routes /launch to the callback handler when callbackPath is /launch", async () => {
+		const abort = new AbortController();
+		const authFired = Promise.withResolvers<OAuthAuthInfo>();
+		const flow = new LaunchProbeFlow(
+			{
+				onAuth: info => {
+					authFired.resolve(info);
+				},
+				signal: abort.signal,
+			},
+			// Caller pins the provider redirect at `/launch` — an OMP config
+			// setting `oauth.callbackPath: "/launch"` or a matching
+			// `oauth.redirectUri`. Callback resolution MUST win the route
+			// collision, and no self-redirecting launchUrl should be advertised.
+			{ preferredPort: 0, allowPortFallback: true, callbackPath: "/launch" },
+		);
+		const login = flow.login().catch(() => undefined) as Promise<void>;
+		const info = await authFired.promise;
+
+		// Contract — no launchUrl surfaced when it would collide.
+		expect(info.launchUrl).toBeUndefined();
+
+		// Contract — a provider redirect to `/launch?code=…&state=…` resolves the
+		// real callback rather than self-redirecting to the authorize URL.
+		const authUrl = new URL(info.url);
+		const redirectUri = authUrl.searchParams.get("redirect_uri");
+		expect(redirectUri).toMatch(/^http:\/\/localhost:\d+\/launch$/);
+		const state = authUrl.searchParams.get("state") ?? "";
+		const callbackResponse = await fetch(`${redirectUri}?code=test-code&state=${encodeURIComponent(state)}`, {
+			redirect: "manual",
+		});
+		// Callback handler responds with the templated HTML page (200), never a 302.
+		expect(callbackResponse.status).toBe(200);
+		expect(callbackResponse.headers.get("content-type")).toContain("text/html");
+
+		abort.abort("test done");
+		await login;
+	});
+
+	it("suppresses launchUrl even when only redirectUri (not callbackPath) resolves to /launch", async () => {
+		const abort = new AbortController();
+		const authFired = Promise.withResolvers<OAuthAuthInfo>();
+		const flow = new LaunchProbeFlow(
+			{
+				onAuth: info => {
+					authFired.resolve(info);
+				},
+				signal: abort.signal,
+			},
+			{
+				preferredPort: 0,
+				allowPortFallback: true,
+				// Base-class caller: `redirectUri` pinned at `/launch` while
+				// `callbackPath` stays at the default. `MCPOAuthFlow` normally
+				// derives `callbackPath` from `redirectUri.pathname`, but the
+				// base class doesn't, and the launchUrl guard must still catch
+				// the collision defensively.
+				redirectUri: "http://localhost:14599/launch",
+			},
+		);
+		const login = flow.login().catch(() => undefined) as Promise<void>;
+		const info = await authFired.promise;
+
+		expect(info.launchUrl).toBeUndefined();
+
+		abort.abort("test done");
+		await login;
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/mcp reauth` against S256-only OAuth providers (Linear, and OAuth 2.1 flows generally) failing on Windows and other environments where the browser cannot auto-open. Two independent defects converged on Linear's `The plain PKCE method is not allowed. Use S256 instead.` error page: `openPath` invoked bare `rundll32` and silently swallowed the resulting `Executable not found in $PATH` when the Windows machine PATH no longer referenced `System32`, and `MCPAuthorizationLinkPrompt` composed a `Copy URL:` line wider than the viewport that `TUI#prepareLine` then silently truncated — trimming the trailing `code_challenge_method=S256` (RFC 7636 §4.3 treats a request with `code_challenge` and no method as `plain`). The MCP OAuth fallback, `/login`, setup wizard, auth-broker CLI, and login-dialog now advertise the short `OAuthAuthInfo.launchUrl` (loopback `/launch` route hosted by `OAuthCallbackFlow`) as the copy target; the OSC 8 hyperlink still carries the full URL for click-through; the MCP flow additionally stages the copy target on the clipboard via OSC 52; and the Windows opener now resolves `rundll32.exe` through `%SystemRoot%\System32\`, logging spawn failures and non-zero exits instead of dropping them ([#4418](https://github.com/can1357/oh-my-pi/issues/4418)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -222,8 +222,17 @@ async function runLocalLogin(provider: OAuthProvider): Promise<void> {
 		// for non-paste-code providers, so this is defense-in-depth on the same gate.
 		const usesManualInput = PASTE_CODE_LOGIN_PROVIDERS.has(provider);
 		await storage.login(provider, {
-			onAuth({ url, instructions }) {
-				process.stdout.write(`\nOpen this URL in your browser:\n${url}\n`);
+			onAuth({ url, launchUrl, instructions }) {
+				process.stdout.write("\nOpen this URL in your browser:\n");
+				// Advertise the short launch URL first when the flow exposes one — it
+				// survives narrow terminals that would truncate the trailing
+				// `code_challenge_method=S256` (or worse, drop `state`/`code_challenge`
+				// entirely) from the full authorize URL. The full URL still prints
+				// beneath it so headless callers can capture it programmatically.
+				if (launchUrl && launchUrl !== url) {
+					process.stdout.write(`${launchUrl}\n(redirects to)\n`);
+				}
+				process.stdout.write(`${url}\n`);
 				if (instructions) process.stdout.write(`${instructions}\n`);
 				process.stdout.write("\n");
 			},

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -224,15 +224,17 @@ async function runLocalLogin(provider: OAuthProvider): Promise<void> {
 		await storage.login(provider, {
 			onAuth({ url, launchUrl, instructions }) {
 				process.stdout.write("\nOpen this URL in your browser:\n");
-				// Advertise the short launch URL first when the flow exposes one — it
-				// survives narrow terminals that would truncate the trailing
-				// `code_challenge_method=S256` (or worse, drop `state`/`code_challenge`
-				// entirely) from the full authorize URL. The full URL still prints
-				// beneath it so headless callers can capture it programmatically.
-				if (launchUrl && launchUrl !== url) {
-					process.stdout.write(`${launchUrl}\n(redirects to)\n`);
-				}
+				// Full URL first so the CLI works from any machine, including SSH
+				// sessions where a `launchUrl` (loopback `/launch` on the OMP
+				// host) would resolve against the caller's browser and fail.
+				// Headless capture is unaffected: it reads the first URL line.
 				process.stdout.write(`${url}\n`);
+				if (launchUrl && launchUrl !== url) {
+					// Local shortcut for the machine running OMP. Terminals or
+					// screen-scrapers narrower than the full URL still get an
+					// unbroken copy target here.
+					process.stdout.write(`Local shortcut (this machine only): ${launchUrl}\n`);
+				}
 				if (instructions) process.stdout.write(`${instructions}\n`);
 				process.stdout.write("\n");
 			},

--- a/packages/coding-agent/src/modes/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/components/login-dialog.ts
@@ -68,12 +68,20 @@ export class LoginDialogComponent extends Container {
 	}
 
 	/**
-	 * Called by onAuth callback - show URL and optional instructions
+	 * Called by the OAuth `onAuth` callback. Renders the copy target on its own
+	 * row and attaches an OSC 8 hyperlink carrying the full URL so terminals
+	 * that support it can click-through even when the copy target is truncated.
+	 *
+	 * `launchUrl` (when present) is a short loopback URL that 302s to `url`.
+	 * Preferred as the copy target because viewport truncation on a long
+	 * authorize URL silently drops trailing OAuth query parameters — e.g.
+	 * `code_challenge_method=S256`.
 	 */
-	showAuth(url: string, instructions?: string): void {
+	showAuth(url: string, instructions?: string, launchUrl?: string): void {
+		const copyTarget = launchUrl ?? url;
 		this.#contentContainer.clear();
 		this.#contentContainer.addChild(new Spacer(1));
-		this.#contentContainer.addChild(new Text(theme.fg("accent", url), 1, 0));
+		this.#contentContainer.addChild(new Text(theme.fg("accent", copyTarget), 1, 0));
 
 		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
 		const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;

--- a/packages/coding-agent/src/modes/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/components/login-dialog.ts
@@ -68,24 +68,30 @@ export class LoginDialogComponent extends Container {
 	}
 
 	/**
-	 * Called by the OAuth `onAuth` callback. Renders the copy target on its own
-	 * row and attaches an OSC 8 hyperlink carrying the full URL so terminals
-	 * that support it can click-through even when the copy target is truncated.
-	 *
-	 * `launchUrl` (when present) is a short loopback URL that 302s to `url`.
-	 * Preferred as the copy target because viewport truncation on a long
-	 * authorize URL silently drops trailing OAuth query parameters — e.g.
-	 * `code_challenge_method=S256`.
+	 * Called by the OAuth `onAuth` callback. Renders the full authorization URL
+	 * as the primary copy target — that works from any machine, including
+	 * SSH/WSL/headless sessions where the OMP-hosted `launchUrl` would resolve
+	 * against the user's local browser and fail. When `launchUrl` is present it
+	 * is offered as an additional local shortcut so narrow local terminals still
+	 * have a truncation-safe copy target (viewport clipping on a long authorize
+	 * URL silently drops trailing OAuth query parameters — e.g.
+	 * `code_challenge_method=S256`). The OSC 8 hyperlink carries the full URL
+	 * for terminals that support click-through.
 	 */
 	showAuth(url: string, instructions?: string, launchUrl?: string): void {
-		const copyTarget = launchUrl ?? url;
 		this.#contentContainer.clear();
 		this.#contentContainer.addChild(new Spacer(1));
-		this.#contentContainer.addChild(new Text(theme.fg("accent", copyTarget), 1, 0));
+		this.#contentContainer.addChild(new Text(theme.fg("accent", url), 1, 0));
 
 		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
 		const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;
 		this.#contentContainer.addChild(new Text(theme.fg("dim", hyperlink), 1, 0));
+
+		if (launchUrl && launchUrl !== url) {
+			this.#contentContainer.addChild(
+				new Text(theme.fg("dim", `Local shortcut (this machine only): ${launchUrl}`), 1, 0),
+			);
+		}
 
 		if (instructions) {
 			this.#contentContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -43,6 +43,7 @@ import {
 import type { MCPAuthConfig, MCPServerConfig, MCPServerConnection } from "../../mcp/types";
 import { shortenPath } from "../../tools/render-utils";
 import { urlHyperlinkAlways } from "../../tui";
+import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { ChatBlock } from "../components/chat-block";
 import { MCPAddWizard } from "../components/mcp-add-wizard";
@@ -73,22 +74,33 @@ function raceAbortSignal<T>(promise: Promise<T>, signal: AbortSignal, createErro
 	});
 }
 
-/** Renders the MCP OAuth fallback URL without hard-wrapping the copy target. */
+/**
+ * Renders the MCP OAuth fallback URL without hard-wrapping the copy target.
+ *
+ * When the flow's callback server hosts a `/launch` short URL (`launchUrl`),
+ * that is advertised as the copy target instead of the full authorization
+ * URL: a Linear-shaped authorize URL routinely exceeds 260 columns, and the
+ * TUI silently truncates any composed row wider than the viewport — dropping
+ * trailing OAuth parameters like `code_challenge_method=S256`. The OSC 8
+ * hyperlink still carries the full URL for terminals that support it.
+ */
 export class MCPAuthorizationLinkPrompt implements Component {
-	readonly #url: string;
+	readonly #fullUrl: string;
+	readonly #copyTarget: string;
 
-	constructor(url: string) {
-		this.#url = url;
+	constructor(url: string, launchUrl?: string) {
+		this.#fullUrl = url;
+		this.#copyTarget = launchUrl ?? url;
 	}
 
 	invalidate(): void {}
 
 	render(_width: number): readonly string[] {
-		const link = urlHyperlinkAlways(this.#url, "Click here to authorize");
+		const link = urlHyperlinkAlways(this.#fullUrl, "Click here to authorize");
 		return [
 			` ${theme.fg("success", "Open authorization URL:")}`,
 			` ${theme.fg("accent", link)}`,
-			` ${theme.fg("muted", `Copy URL: ${replaceTabs(this.#url)}`)}`,
+			` ${theme.fg("muted", `Copy URL: ${replaceTabs(this.#copyTarget)}`)}`,
 		];
 	}
 }
@@ -689,7 +701,7 @@ export class MCPCommandController {
 					stripSameOriginResource: opts?.stripSameOriginResource,
 				},
 				{
-					onAuth: (info: { url: string; instructions?: string }) => {
+					onAuth: (info: { url: string; launchUrl?: string; instructions?: string }) => {
 						// Show auth URL prominently in chat as one block
 						const block = new TranscriptBlock();
 						this.ctx.present(block);
@@ -707,24 +719,23 @@ export class MCPCommandController {
 						block.addChild(new Text(theme.fg("muted", MCP_MANUAL_LOGIN_TIP), 1, 0));
 						block.addChild(new Spacer(1));
 						block.addChild(new Text(theme.fg("accent", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"), 1, 0));
-						// Try to open browser automatically
-						try {
-							openPath(info.url);
-
-							// Show confirmation that browser should open
-							block.addChild(new Spacer(1));
-							block.addChild(new Text(theme.fg("success", "→ Opening browser automatically..."), 1, 0));
-							block.addChild(new Spacer(1));
-							block.addChild(new Text(theme.fg("muted", "Alternative if browser did not open:"), 1, 0));
-							block.addChild(new MCPAuthorizationLinkPrompt(info.url));
-							this.ctx.ui.requestRender();
-						} catch (_error) {
-							// Show error if browser doesn't open
-							block.addChild(new Spacer(1));
-							block.addChild(new Text(theme.fg("warning", "→ Could not open browser automatically"), 1, 0));
-							block.addChild(new MCPAuthorizationLinkPrompt(info.url));
-							this.ctx.ui.requestRender();
-						}
+						// `openPath` is best-effort — it logs spawn failures but never
+						// throws, so we always render the copy-URL fallback beneath the
+						// "attempting to open browser" line and no earlier try/catch is
+						// worth keeping.
+						openPath(info.url);
+						const copyTarget = info.launchUrl ?? info.url;
+						// Stage the copy target on the clipboard via OSC 52 (same
+						// pattern the setup wizard uses). Best-effort: falls back to
+						// the visible "Copy URL:" line whether or not the terminal
+						// honors OSC 52.
+						void copyToClipboard(copyTarget).catch(() => {});
+						block.addChild(new Spacer(1));
+						block.addChild(new Text(theme.fg("success", "→ Attempting to open browser..."), 1, 0));
+						block.addChild(new Spacer(1));
+						block.addChild(new Text(theme.fg("muted", "Alternative if browser did not open:"), 1, 0));
+						block.addChild(new MCPAuthorizationLinkPrompt(info.url, info.launchUrl));
+						this.ctx.ui.requestRender();
 					},
 					onProgress: (message: string) => {
 						this.ctx.present([new Spacer(1), new Text(theme.fg("muted", message), 1, 0)]);

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -75,14 +75,52 @@ function raceAbortSignal<T>(promise: Promise<T>, signal: AbortSignal, createErro
 }
 
 /**
+ * Minimum column budget for URL wrapping. Below this the terminal is
+ * effectively unusable, but we still emit chunks so no character is silently
+ * dropped and the user can widen and reflow.
+ */
+const MCP_AUTH_MIN_WRAP_WIDTH = 16;
+
+/**
+ * Wrap `url` into rows that each fit inside `width`, prefixed by a shared
+ * single-column indent so nested composition doesn't touch column 0. When the
+ * label + URL fit on one line, returns a single row; otherwise puts the label
+ * on its own row and slices the URL into fixed-width chunks. URL chunks are
+ * plain code points — browsers strip whitespace when pasted into the address
+ * bar, so a multi-row selection copies back to the intact URL.
+ */
+function wrapUrlRows(label: string, url: string, width: number): string[] {
+	const indent = " ";
+	const sanitized = replaceTabs(url);
+	const effective = Math.max(MCP_AUTH_MIN_WRAP_WIDTH, Math.trunc(width));
+	const inlineWidth = indent.length + label.length + 1 + sanitized.length;
+	if (inlineWidth <= effective) {
+		return [`${indent}${theme.fg("muted", `${label} ${sanitized}`)}`];
+	}
+	const chunkWidth = Math.max(1, effective - indent.length);
+	const rows: string[] = [`${indent}${theme.fg("muted", label)}`];
+	for (let i = 0; i < sanitized.length; i += chunkWidth) {
+		rows.push(`${indent}${theme.fg("muted", sanitized.slice(i, i + chunkWidth))}`);
+	}
+	return rows;
+}
+
+/**
  * Renders the MCP OAuth fallback URL. Always shows the full authorization URL
  * as the primary `Copy URL:` target — that works from any machine, including
  * SSH/WSL/headless sessions where the OMP-hosted `/launch` loopback URL would
- * resolve against the user's local browser and fail. When the flow's callback
- * server hosts a short `launchUrl`, it is offered as an additional local
- * shortcut so narrow local terminals still have a truncation-safe copy target
- * (a Linear-shaped authorize URL routinely exceeds 260 columns, and the TUI
- * silently truncates any composed row wider than the viewport). The OSC 8
+ * resolve against the user's local browser and fail.
+ *
+ * The render is `width`-aware: on any viewport narrower than the composed row
+ * ({@link TUI#prepareLine} truncates anything wider with `Ellipsis.Omit`, no
+ * marker), the URL is hard-wrapped into width-fitted rows so the primary copy
+ * target can never silently lose trailing OAuth parameters — the failure mode
+ * that motivated #4418 in the first place. Browsers strip whitespace when a
+ * multi-row selection is pasted into the address bar, so the reassembled URL
+ * is byte-identical to what we rendered.
+ *
+ * When the flow's callback server hosts a short `launchUrl`, it is offered
+ * as an additional local shortcut for wide-terminal local users. The OSC 8
  * hyperlink continues to carry the full URL for terminals that support it.
  */
 export class MCPAuthorizationLinkPrompt implements Component {
@@ -96,15 +134,15 @@ export class MCPAuthorizationLinkPrompt implements Component {
 
 	invalidate(): void {}
 
-	render(_width: number): readonly string[] {
+	render(width: number): readonly string[] {
 		const link = urlHyperlinkAlways(this.#fullUrl, "Click here to authorize");
 		const lines: string[] = [
 			` ${theme.fg("success", "Open authorization URL:")}`,
 			` ${theme.fg("accent", link)}`,
-			` ${theme.fg("muted", `Copy URL: ${replaceTabs(this.#fullUrl)}`)}`,
+			...wrapUrlRows("Copy URL:", this.#fullUrl, width),
 		];
 		if (this.#launchUrl) {
-			lines.push(` ${theme.fg("muted", `Local shortcut (this machine only): ${replaceTabs(this.#launchUrl)}`)}`);
+			lines.push(...wrapUrlRows("Local shortcut (this machine only):", this.#launchUrl, width));
 		}
 		return lines;
 	}

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -75,33 +75,38 @@ function raceAbortSignal<T>(promise: Promise<T>, signal: AbortSignal, createErro
 }
 
 /**
- * Renders the MCP OAuth fallback URL without hard-wrapping the copy target.
- *
- * When the flow's callback server hosts a `/launch` short URL (`launchUrl`),
- * that is advertised as the copy target instead of the full authorization
- * URL: a Linear-shaped authorize URL routinely exceeds 260 columns, and the
- * TUI silently truncates any composed row wider than the viewport — dropping
- * trailing OAuth parameters like `code_challenge_method=S256`. The OSC 8
- * hyperlink still carries the full URL for terminals that support it.
+ * Renders the MCP OAuth fallback URL. Always shows the full authorization URL
+ * as the primary `Copy URL:` target — that works from any machine, including
+ * SSH/WSL/headless sessions where the OMP-hosted `/launch` loopback URL would
+ * resolve against the user's local browser and fail. When the flow's callback
+ * server hosts a short `launchUrl`, it is offered as an additional local
+ * shortcut so narrow local terminals still have a truncation-safe copy target
+ * (a Linear-shaped authorize URL routinely exceeds 260 columns, and the TUI
+ * silently truncates any composed row wider than the viewport). The OSC 8
+ * hyperlink continues to carry the full URL for terminals that support it.
  */
 export class MCPAuthorizationLinkPrompt implements Component {
 	readonly #fullUrl: string;
-	readonly #copyTarget: string;
+	readonly #launchUrl: string | undefined;
 
 	constructor(url: string, launchUrl?: string) {
 		this.#fullUrl = url;
-		this.#copyTarget = launchUrl ?? url;
+		this.#launchUrl = launchUrl && launchUrl !== url ? launchUrl : undefined;
 	}
 
 	invalidate(): void {}
 
 	render(_width: number): readonly string[] {
 		const link = urlHyperlinkAlways(this.#fullUrl, "Click here to authorize");
-		return [
+		const lines: string[] = [
 			` ${theme.fg("success", "Open authorization URL:")}`,
 			` ${theme.fg("accent", link)}`,
-			` ${theme.fg("muted", `Copy URL: ${replaceTabs(this.#copyTarget)}`)}`,
+			` ${theme.fg("muted", `Copy URL: ${replaceTabs(this.#fullUrl)}`)}`,
 		];
+		if (this.#launchUrl) {
+			lines.push(` ${theme.fg("muted", `Local shortcut (this machine only): ${replaceTabs(this.#launchUrl)}`)}`);
+		}
+		return lines;
 	}
 }
 
@@ -724,12 +729,14 @@ export class MCPCommandController {
 						// "attempting to open browser" line and no earlier try/catch is
 						// worth keeping.
 						openPath(info.url);
-						const copyTarget = info.launchUrl ?? info.url;
-						// Stage the copy target on the clipboard via OSC 52 (same
-						// pattern the setup wizard uses). Best-effort: falls back to
-						// the visible "Copy URL:" line whether or not the terminal
-						// honors OSC 52.
-						void copyToClipboard(copyTarget).catch(() => {});
+						// Stage the FULL authorization URL on the clipboard via OSC 52.
+						// The full URL works from any machine (unlike `launchUrl`, which
+						// only resolves against the OMP host), and OSC 52 is a
+						// wire-level protocol — the terminal writes it to the user's
+						// LOCAL clipboard even when OMP is on a remote SSH box.
+						// Best-effort: falls back to the visible copy-URL rows below
+						// whether or not the terminal honors OSC 52.
+						void copyToClipboard(info.url).catch(() => {});
 						block.addChild(new Spacer(1));
 						block.addChild(new Text(theme.fg("success", "→ Attempting to open browser..."), 1, 0));
 						block.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1117,9 +1117,10 @@ export class SelectorController {
 		const useManualInput = PASTE_CODE_LOGIN_PROVIDERS.has(providerId);
 		try {
 			await this.ctx.session.modelRegistry.authStorage.login(providerId as OAuthProvider, {
-				onAuth: (info: { url: string; instructions?: string }) => {
+				onAuth: (info: { url: string; launchUrl?: string; instructions?: string }) => {
+					const copyTarget = info.launchUrl ?? info.url;
 					const block = new TranscriptBlock();
-					block.addChild(new Text(theme.fg("dim", info.url), 1, 0));
+					block.addChild(new Text(theme.fg("dim", copyTarget), 1, 0));
 					const hyperlink = `\x1b]8;;${info.url}\x07Click here to login\x1b]8;;\x07`;
 					block.addChild(new Text(theme.fg("accent", hyperlink), 1, 0));
 					if (info.instructions) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1118,11 +1118,18 @@ export class SelectorController {
 		try {
 			await this.ctx.session.modelRegistry.authStorage.login(providerId as OAuthProvider, {
 				onAuth: (info: { url: string; launchUrl?: string; instructions?: string }) => {
-					const copyTarget = info.launchUrl ?? info.url;
 					const block = new TranscriptBlock();
-					block.addChild(new Text(theme.fg("dim", copyTarget), 1, 0));
+					// Full URL first: works from any machine, including SSH boxes
+					// where the OMP-hosted `launchUrl` would resolve against the
+					// user's local browser and fail.
+					block.addChild(new Text(theme.fg("dim", info.url), 1, 0));
 					const hyperlink = `\x1b]8;;${info.url}\x07Click here to login\x1b]8;;\x07`;
 					block.addChild(new Text(theme.fg("accent", hyperlink), 1, 0));
+					if (info.launchUrl && info.launchUrl !== info.url) {
+						block.addChild(
+							new Text(theme.fg("dim", `Local shortcut (this machine only): ${info.launchUrl}`), 1, 0),
+						);
+					}
 					if (info.instructions) {
 						block.addChild(new Spacer(1));
 						block.addChild(new Text(theme.fg("warning", info.instructions), 1, 0));

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -724,17 +724,21 @@ export class RpcClient {
 	 * The server will emit an `open_url` extension_ui_request for the auth URL.
 	 * Resolves when login completes or rejects on failure.
 	 *
-	 * @param onOpenUrl Called when the server emits the auth URL. The host must open
-	 *   it in a browser for the callback-server OAuth flow to complete.
+	 * @param onOpenUrl Called when the server emits the auth URL. The host must
+	 *   open `url` in a browser for the callback-server OAuth flow to complete.
+	 *   When the flow's callback server hosts a `/launch` redirect, `launchUrl`
+	 *   is a short loopback URL that 302s to `url` — hosts SHOULD surface it as
+	 *   the truncation-safe copy target so terminal viewport clipping cannot
+	 *   corrupt trailing OAuth query parameters (e.g. `code_challenge_method=S256`).
 	 */
 	async login(
 		providerId: string,
-		options?: { onOpenUrl?: (url: string, instructions?: string) => void },
+		options?: { onOpenUrl?: (url: string, instructions?: string, launchUrl?: string) => void },
 	): Promise<{ providerId: string }> {
 		const { onOpenUrl } = options ?? {};
 		const listener = onOpenUrl
 			? (req: RpcExtensionUIRequest) => {
-					if (req.method === "open_url") onOpenUrl(req.url, req.instructions);
+					if (req.method === "open_url") onOpenUrl(req.url, req.instructions, req.launchUrl);
 				}
 			: undefined;
 		if (listener) this.#extensionUiListeners.add(listener);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1213,6 +1213,7 @@ export async function runRpcMode(
 								id: Snowflake.next() as string,
 								method: "open_url",
 								url: info.url,
+								launchUrl: info.launchUrl,
 								instructions: info.instructions,
 							} as RpcExtensionUIRequest);
 						},

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -370,7 +370,19 @@ export type RpcExtensionUIRequest =
 	  }
 	| { type: "extension_ui_request"; id: string; method: "setTitle"; title: string }
 	| { type: "extension_ui_request"; id: string; method: "set_editor_text"; text: string }
-	| { type: "extension_ui_request"; id: string; method: "open_url"; url: string; instructions?: string };
+	| {
+			type: "extension_ui_request";
+			id: string;
+			method: "open_url";
+			url: string;
+			/**
+			 * Short loopback URL that 302-redirects to {@link url}. When present,
+			 * hosts SHOULD surface it as the copy target so terminal viewport
+			 * truncation cannot corrupt OAuth query parameters on the full URL.
+			 */
+			launchUrl?: string;
+			instructions?: string;
+	  };
 
 // ============================================================================
 // Host Tool Frames (bidirectional)

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -189,7 +189,11 @@ export class SignInTab implements SetupTab {
 			await this.#authStorage.login(providerId as OAuthProvider, {
 				signal: this.#loginAbort.signal,
 				onAuth: info => {
-					this.#authUrl = info.url;
+					// Store the short launch URL when available; the setup wizard
+					// renders `#authUrl` as a plain text row (no OSC 8 hyperlink), so
+					// the copy/display target must survive viewport truncation. The
+					// browser is still launched against the full URL.
+					this.#authUrl = info.launchUrl ?? info.url;
 					this.#statusLines = [];
 					if (info.instructions) {
 						this.#statusLines.push(theme.fg("warning", info.instructions));

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -80,6 +80,7 @@ export class SignInTab implements SetupTab {
 	#selector: OAuthSelectorComponent;
 	#statusLines: string[] = [];
 	#authUrl: string | undefined;
+	#authLaunchUrl: string | undefined;
 	#prompt: PromptState | undefined;
 	#promptResolve: ((value: string) => void) | undefined;
 	#loginAbort: AbortController | undefined;
@@ -146,6 +147,9 @@ export class SignInTab implements SetupTab {
 				theme.fg("accent", `Browser login: ${loginUrlLink(this.#authUrl)} ${loginCopyHint()}`),
 				...urlLines.slice(0, 2),
 			);
+			if (this.#authLaunchUrl) {
+				lines.push(theme.fg("dim", `Local shortcut (this machine only): ${this.#authLaunchUrl}`));
+			}
 		}
 		if (this.#prompt) {
 			lines.push(theme.fg("warning", this.#prompt.message));
@@ -182,6 +186,7 @@ export class SignInTab implements SetupTab {
 		this.#loggingInProvider = providerId;
 		this.#statusLines = [theme.fg("dim", "Starting OAuth flow…")];
 		this.#authUrl = undefined;
+		this.#authLaunchUrl = undefined;
 		this.#loginAbort = new AbortController();
 		this.host.restoreFocus();
 		this.host.requestRender();
@@ -189,11 +194,17 @@ export class SignInTab implements SetupTab {
 			await this.#authStorage.login(providerId as OAuthProvider, {
 				signal: this.#loginAbort.signal,
 				onAuth: info => {
-					// Store the short launch URL when available; the setup wizard
-					// renders `#authUrl` as a plain text row (no OSC 8 hyperlink), so
-					// the copy/display target must survive viewport truncation. The
-					// browser is still launched against the full URL.
-					this.#authUrl = info.launchUrl ?? info.url;
+					// Store the full authorization URL as the primary copy/display
+					// target: it works from any machine, including SSH boxes where
+					// the OMP-hosted `launchUrl` would resolve against the user's
+					// local browser and fail. The wizard render uses
+					// `wrapTextWithAnsi`, so long URLs wrap across lines rather
+					// than getting truncated — the RFC 7636 §4.3 PKCE-downgrade
+					// bug that motivated `launchUrl` is unreachable through this
+					// surface. `launchUrl` is still surfaced as an optional local
+					// shortcut for wide-terminal local users.
+					this.#authUrl = info.url;
+					this.#authLaunchUrl = info.launchUrl && info.launchUrl !== info.url ? info.launchUrl : undefined;
 					this.#statusLines = [];
 					if (info.instructions) {
 						this.#statusLines.push(theme.fg("warning", info.instructions));
@@ -220,6 +231,7 @@ export class SignInTab implements SetupTab {
 				theme.fg("dim", `Credentials saved to ${getAgentDbPath()}`),
 			];
 			this.#authUrl = undefined;
+			this.#authLaunchUrl = undefined;
 			this.#loggingInProvider = undefined;
 			this.#loginAbort = undefined;
 			this.#selector.stopValidation();
@@ -231,6 +243,7 @@ export class SignInTab implements SetupTab {
 			if (this.#loginAbort?.signal.aborted) {
 				this.#statusLines = [theme.fg("dim", "Login cancelled.")];
 				this.#authUrl = undefined;
+				this.#authLaunchUrl = undefined;
 			} else {
 				const message = error instanceof Error ? error.message : String(error);
 				this.#statusLines = [
@@ -238,6 +251,7 @@ export class SignInTab implements SetupTab {
 					theme.fg("dim", "Choose another provider or press Esc to continue."),
 				];
 				this.#authUrl = undefined;
+				this.#authLaunchUrl = undefined;
 			}
 			this.#loggingInProvider = undefined;
 			this.#loginAbort = undefined;

--- a/packages/coding-agent/src/utils/open.ts
+++ b/packages/coding-agent/src/utils/open.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
-import * as piUtils from "@oh-my-pi/pi-utils";
+import { $which, logger } from "@oh-my-pi/pi-utils";
 
 const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
@@ -9,7 +9,7 @@ function getExistingWslLocalPath(urlOrPath: string): string | undefined {
 	if (
 		process.platform !== "linux" ||
 		!(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) ||
-		!piUtils.$which("wslview")
+		!$which("wslview")
 	) {
 		return undefined;
 	}
@@ -31,6 +31,24 @@ function getExistingWslLocalPath(urlOrPath: string): string | undefined {
 	}
 }
 
+/**
+ * Resolve the Windows `rundll32.exe` command used to hand a URL/path to the
+ * user's registered protocol handler. Anchoring to `%SystemRoot%\System32`
+ * (rather than relying on `rundll32` being on `PATH`) survives environments
+ * where the machine `PATH` no longer references `System32` — a common
+ * real-world misconfiguration where `System32\Wbem` / `WindowsPowerShell` /
+ * `OpenSSH` survive but `System32` itself is dropped. Bare `rundll32` on
+ * such boxes throws `Executable not found in $PATH: "rundll32"` from
+ * `Bun.spawn` before ShellExecute ever sees the URL.
+ */
+function windowsOpenerCommand(target: string): string[] {
+	const systemRoot = process.env.SystemRoot?.trim() || process.env.SYSTEMROOT?.trim() || "C:\\Windows";
+	// `path.win32` (not the platform-adaptive `path.join`) keeps Windows path
+	// separators when tests run under a POSIX host and matches Windows call
+	// conventions on the real target.
+	const rundll32 = path.win32.join(systemRoot, "System32", "rundll32.exe");
+	return [rundll32, "url.dll,FileProtocolHandler", target];
+}
 /** Open a URL or file path in the default browser/application. Best-effort, never throws. */
 export function openPath(urlOrPath: string): void {
 	let cmd: string[];
@@ -39,7 +57,7 @@ export function openPath(urlOrPath: string): void {
 			cmd = ["open", urlOrPath];
 			break;
 		case "win32":
-			cmd = ["rundll32", "url.dll,FileProtocolHandler", urlOrPath];
+			cmd = windowsOpenerCommand(urlOrPath);
 			break;
 		default: {
 			const wslPath = getExistingWslLocalPath(urlOrPath);
@@ -47,9 +65,36 @@ export function openPath(urlOrPath: string): void {
 			break;
 		}
 	}
+	let child: Bun.Subprocess | undefined;
 	try {
-		Bun.spawn(cmd, { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
-	} catch {
-		// Best-effort: browser opening is non-critical
+		child = Bun.spawn(cmd, { stdin: "ignore", stdout: "ignore", stderr: "ignore" });
+	} catch (error) {
+		// Spawn threw synchronously (missing binary, denied exec, sandbox
+		// restriction, …). Best-effort: log so the failure isn't invisible while
+		// still letting the caller advertise a copy-URL fallback.
+		logger.warn("Failed to open external URL/path", {
+			command: cmd[0],
+			target: urlOrPath,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return;
 	}
+	// Detect delayed failures (exec succeeded but the opener exited non-zero)
+	// without blocking the caller. Recording them makes silent misconfigurations
+	// (e.g. `xdg-open` present but no MIME handler for `https`) diagnosable from
+	// `~/.omp/logs/omp.*.log`.
+	child.exited.then(
+		exitCode => {
+			if (typeof exitCode === "number" && exitCode !== 0) {
+				logger.warn("External opener exited with non-zero status", {
+					command: cmd[0],
+					target: urlOrPath,
+					exitCode,
+				});
+			}
+		},
+		() => {
+			// Ignore — awaiting the subprocess is best-effort telemetry.
+		},
+	);
 }

--- a/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
+++ b/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
@@ -37,4 +37,22 @@ describe("MCPAuthorizationLinkPrompt", () => {
 		expect(plainLines[1]).toContain("Click here to authorize");
 		expect(plainLines[2]).toBe(` Copy URL: ${LONG_AUTH_URL}`);
 	});
+
+	it("advertises the launch URL as the copy target while keeping OSC 8 pointing at the full URL", () => {
+		const launchUrl = "http://localhost:14570/launch";
+		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, launchUrl).render(80);
+		const plainLines = lines.map(line => stripVTControlCharacters(line));
+
+		expect(lines).toHaveLength(3);
+		// OSC 8 hyperlink still carries the full URL — click-through targets
+		// the provider directly on terminals that support the escape.
+		expect(extractLinkUri(lines[1])).toBe(LONG_AUTH_URL);
+		expect(plainLines[1]).toContain("Click here to authorize");
+		// Copy target is the short loopback URL. Terminals that don't render
+		// OSC 8, and every copy-paste operation, hit this line — and it must
+		// survive viewport truncation without dropping OAuth parameters like
+		// `code_challenge_method=S256`.
+		expect(plainLines[2]).toBe(` Copy URL: ${launchUrl}`);
+		expect(plainLines[2].length).toBeLessThan(50);
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
+++ b/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
@@ -3,6 +3,7 @@ import { stripVTControlCharacters } from "node:util";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { MCPAuthorizationLinkPrompt } from "@oh-my-pi/pi-coding-agent/modes/controllers/mcp-command-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
 
 const OSC = "\x1b]";
 const BEL = "\x07";
@@ -11,8 +12,56 @@ function extractLinkUri(text: string): string | undefined {
 	return text.match(/\x1b\]8;[^;]*;([^\x1b\x07]+)(?:\x1b\\|\x07)/)?.[1];
 }
 
+const COPY_URL_LABEL = "Copy URL:";
+const SHORTCUT_LABEL = "Local shortcut (this machine only):";
+
 const LONG_AUTH_URL =
 	"https://mcp.notion.com/oauth/authorize?response_type=code&client_id=notion-mcp-client&redirect_uri=http%3A%2F%2F127.0.0.1%3A17895%2Fcallback&scope=read%3Aworkspace%20read%3Acontent&state=abcdef0123456789abcdef0123456789";
+
+// Linear-shaped repro from #4418: the whole point of the fix is that the
+// trailing `code_challenge_method=S256` is preserved even when the composed
+// row would exceed the viewport.
+const LINEAR_AUTH_URL = `https://mcp.linear.app/authorize?response_type=code&client_id=abcdefghij0123456789ABCDEFGHIJ0123456789&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=read%20write%20mcp%3Aall&state=0123456789abcdef0123456789abcdef&code_challenge=5MlkJfN2GhX9uP0rQ7sT8vB1oCwDeFgHiJkLmNoPqRsTuVwXyZ&code_challenge_method=S256`;
+
+/**
+ * Extract the trailing URL text from a rendered "Copy URL:" line — either the
+ * inline form (`" Copy URL: <url>"`) or an indented continuation chunk
+ * (`" <chunk>"`).
+ */
+function urlPayload(plainLine: string, label?: string): string {
+	if (label && plainLine.startsWith(` ${label} `)) {
+		return plainLine.slice(` ${label} `.length);
+	}
+	if (label && plainLine === ` ${label}`) return "";
+	// Continuation chunk: single leading space.
+	return plainLine.startsWith(" ") ? plainLine.slice(1) : plainLine;
+}
+
+/**
+ * Reassemble the copy-URL rows for `label` into a single string, mirroring what
+ * a browser would produce when a multi-row selection is pasted into its
+ * address bar (whitespace stripped between chunks). Returns "" if the label
+ * row isn't found.
+ */
+function reassembleUrl(plainLines: string[], label: string): string {
+	const start = plainLines.findIndex(line => line.startsWith(` ${label}`));
+	if (start < 0) return "";
+	const first = plainLines[start]!;
+	// Inline form contains the whole URL on the label row.
+	const inlineMatch = first.match(new RegExp(`^ ${label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} (.*)$`));
+	if (inlineMatch) return inlineMatch[1]!;
+	// Wrapped form: label alone, then continuation rows with a single-space indent.
+	let joined = "";
+	for (let i = start + 1; i < plainLines.length; i++) {
+		const line = plainLines[i]!;
+		// Continuation rows have exactly one leading space; a different indent
+		// or label ends this URL's rows.
+		if (!line.startsWith(" ") || line.startsWith("  ") || line.trim().length === 0) break;
+		if (line.includes(":") && /^ [A-Z][^:]*:/.test(line)) break; // next label row
+		joined += line.slice(1);
+	}
+	return joined;
+}
 
 describe("MCPAuthorizationLinkPrompt", () => {
 	beforeEach(async () => {
@@ -26,8 +75,9 @@ describe("MCPAuthorizationLinkPrompt", () => {
 		resetSettingsForTest();
 	});
 
-	it("renders a clickable label even when hyperlink auto-detection is false", () => {
-		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL).render(80);
+	it("renders a clickable hyperlink label and inline Copy URL row when the row fits the viewport", () => {
+		// Width large enough to keep ` Copy URL: <LONG_AUTH_URL>` on one row.
+		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL).render(1000);
 		const plainLines = lines.map(line => stripVTControlCharacters(line));
 
 		expect(lines).toHaveLength(3);
@@ -35,45 +85,79 @@ describe("MCPAuthorizationLinkPrompt", () => {
 		expect(lines[1]).toContain(`${OSC}8;;${BEL}`);
 		expect(extractLinkUri(lines[1])).toBe(LONG_AUTH_URL);
 		expect(plainLines[1]).toContain("Click here to authorize");
-		expect(plainLines[2]).toBe(` Copy URL: ${LONG_AUTH_URL}`);
+		expect(plainLines[2]).toBe(` ${COPY_URL_LABEL} ${LONG_AUTH_URL}`);
 	});
 
-	it("keeps the full URL as the primary Copy URL: target so SSH/headless sessions can complete the flow", () => {
-		const launchUrl = "http://localhost:14570/launch";
-		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, launchUrl).render(80);
+	it("hard-wraps the full URL into width-fitted chunks so a narrow viewport cannot silently drop trailing parameters", () => {
+		// #4418 fingerprint: narrow terminal + long S256 URL. Pre-fix, the
+		// row went through `truncateToWidth(..., Ellipsis.Omit)` and dropped
+		// `code_challenge_method=S256`. Post-fix, the render itself keeps
+		// every character.
+		const width = 80;
+		const lines = new MCPAuthorizationLinkPrompt(LINEAR_AUTH_URL).render(width);
 		const plainLines = lines.map(line => stripVTControlCharacters(line));
 
-		// Full URL is the primary copy target — it resolves from any browser,
-		// including one on a laptop that SSH'd into the OMP host. `launchUrl`
-		// as primary would resolve against the caller's local machine (no OMP
-		// listening) and fail before ever reaching the provider.
-		expect(plainLines[2]).toBe(` Copy URL: ${LONG_AUTH_URL}`);
+		// Every emitted row fits inside the viewport, so `TUI#prepareLine`'s
+		// truncation branch is unreachable.
+		for (const line of plainLines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
 
-		// OSC 8 hyperlink still carries the full URL — click-through targets
-		// the provider directly on terminals that support the escape.
-		expect(extractLinkUri(lines[1])).toBe(LONG_AUTH_URL);
-		expect(plainLines[1]).toContain("Click here to authorize");
+		// Wrapping puts the label on its own row followed by continuation
+		// chunks with a single-space indent.
+		const labelRow = plainLines.findIndex(line => line === ` ${COPY_URL_LABEL}`);
+		expect(labelRow).toBeGreaterThanOrEqual(0);
+
+		// Chunks reassemble to the URL byte-for-byte — the trailing
+		// `code_challenge_method=S256` MUST be present.
+		const reassembled = reassembleUrl(plainLines, COPY_URL_LABEL);
+		expect(reassembled).toBe(LINEAR_AUTH_URL);
+		expect(reassembled).toEndWith("&code_challenge_method=S256");
 	});
 
-	it("advertises launchUrl as an additional local shortcut so narrow local terminals have a truncation-safe copy target", () => {
+	it("keeps the full URL as the primary copy target even when a launch shortcut is available", () => {
 		const launchUrl = "http://localhost:14570/launch";
-		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, launchUrl).render(80);
+		const lines = new MCPAuthorizationLinkPrompt(LINEAR_AUTH_URL, launchUrl).render(80);
 		const plainLines = lines.map(line => stripVTControlCharacters(line));
 
-		// Extra row beneath `Copy URL:` carries the short launch URL. Users on
-		// narrow local terminals whose `Copy URL:` line got clipped
-		// mid-`code_challenge_method=S256` can copy this row instead — it
-		// fits in any reasonable viewport.
-		expect(lines).toHaveLength(4);
-		expect(plainLines[3]).toBe(` Local shortcut (this machine only): ${launchUrl}`);
-		expect(plainLines[3].length).toBeLessThan(70);
+		// Full URL primacy: an SSH user copying the top URL after the label
+		// still gets the whole authorize URL, byte-for-byte, so their local
+		// browser reaches the provider.
+		expect(reassembleUrl(plainLines, COPY_URL_LABEL)).toBe(LINEAR_AUTH_URL);
+		// OSC 8 hyperlink continues to carry the full URL.
+		expect(extractLinkUri(lines[1])).toBe(LINEAR_AUTH_URL);
+	});
+
+	it("advertises launchUrl as an additional local shortcut, wrapped to width so it also can never truncate", () => {
+		const launchUrl = "http://localhost:14570/launch";
+		const width = 80;
+		const lines = new MCPAuthorizationLinkPrompt(LINEAR_AUTH_URL, launchUrl).render(width);
+		const plainLines = lines.map(line => stripVTControlCharacters(line));
+
+		for (const line of plainLines) {
+			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+		}
+
+		// Local-shortcut row is emitted, either inline (when the label + URL
+		// fit) or wrapped. Either way it reassembles to `launchUrl` exactly.
+		expect(plainLines.some(line => line.includes(SHORTCUT_LABEL))).toBe(true);
+		expect(reassembleUrl(plainLines, SHORTCUT_LABEL)).toBe(launchUrl);
 	});
 
 	it("omits the local-shortcut row when launchUrl is absent or identical to the full URL", () => {
-		const withoutLaunch = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL).render(80);
-		expect(withoutLaunch).toHaveLength(3);
+		const withoutLaunch = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL).render(1000);
+		expect(withoutLaunch.some(line => line.includes(SHORTCUT_LABEL))).toBe(false);
 
-		const withRedundantLaunch = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, LONG_AUTH_URL).render(80);
-		expect(withRedundantLaunch).toHaveLength(3);
+		const withRedundantLaunch = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, LONG_AUTH_URL).render(1000);
+		expect(withRedundantLaunch.some(line => line.includes(SHORTCUT_LABEL))).toBe(false);
+	});
+
+	it("floors the wrap width so degenerately-narrow viewports still emit every character", () => {
+		// Below 16 cols the terminal is unusable, but the render still emits
+		// chunks (bounded at 16 - indent = 15 chars). No character is silently
+		// dropped; the user can widen and reflow.
+		const lines = new MCPAuthorizationLinkPrompt(LINEAR_AUTH_URL).render(4);
+		const plainLines = lines.map(line => stripVTControlCharacters(line));
+		expect(reassembleUrl(plainLines, COPY_URL_LABEL)).toBe(LINEAR_AUTH_URL);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
+++ b/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
@@ -105,7 +105,7 @@ describe("MCPAuthorizationLinkPrompt", () => {
 
 		// Wrapping puts the label on its own row followed by continuation
 		// chunks with a single-space indent.
-		const labelRow = plainLines.findIndex(line => line === ` ${COPY_URL_LABEL}`);
+		const labelRow = plainLines.indexOf(` ${COPY_URL_LABEL}`);
 		expect(labelRow).toBeGreaterThanOrEqual(0);
 
 		// Chunks reassemble to the URL byte-for-byte — the trailing

--- a/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
+++ b/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
@@ -38,21 +38,42 @@ describe("MCPAuthorizationLinkPrompt", () => {
 		expect(plainLines[2]).toBe(` Copy URL: ${LONG_AUTH_URL}`);
 	});
 
-	it("advertises the launch URL as the copy target while keeping OSC 8 pointing at the full URL", () => {
+	it("keeps the full URL as the primary Copy URL: target so SSH/headless sessions can complete the flow", () => {
 		const launchUrl = "http://localhost:14570/launch";
 		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, launchUrl).render(80);
 		const plainLines = lines.map(line => stripVTControlCharacters(line));
 
-		expect(lines).toHaveLength(3);
+		// Full URL is the primary copy target — it resolves from any browser,
+		// including one on a laptop that SSH'd into the OMP host. `launchUrl`
+		// as primary would resolve against the caller's local machine (no OMP
+		// listening) and fail before ever reaching the provider.
+		expect(plainLines[2]).toBe(` Copy URL: ${LONG_AUTH_URL}`);
+
 		// OSC 8 hyperlink still carries the full URL — click-through targets
 		// the provider directly on terminals that support the escape.
 		expect(extractLinkUri(lines[1])).toBe(LONG_AUTH_URL);
 		expect(plainLines[1]).toContain("Click here to authorize");
-		// Copy target is the short loopback URL. Terminals that don't render
-		// OSC 8, and every copy-paste operation, hit this line — and it must
-		// survive viewport truncation without dropping OAuth parameters like
-		// `code_challenge_method=S256`.
-		expect(plainLines[2]).toBe(` Copy URL: ${launchUrl}`);
-		expect(plainLines[2].length).toBeLessThan(50);
+	});
+
+	it("advertises launchUrl as an additional local shortcut so narrow local terminals have a truncation-safe copy target", () => {
+		const launchUrl = "http://localhost:14570/launch";
+		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, launchUrl).render(80);
+		const plainLines = lines.map(line => stripVTControlCharacters(line));
+
+		// Extra row beneath `Copy URL:` carries the short launch URL. Users on
+		// narrow local terminals whose `Copy URL:` line got clipped
+		// mid-`code_challenge_method=S256` can copy this row instead — it
+		// fits in any reasonable viewport.
+		expect(lines).toHaveLength(4);
+		expect(plainLines[3]).toBe(` Local shortcut (this machine only): ${launchUrl}`);
+		expect(plainLines[3].length).toBeLessThan(70);
+	});
+
+	it("omits the local-shortcut row when launchUrl is absent or identical to the full URL", () => {
+		const withoutLaunch = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL).render(80);
+		expect(withoutLaunch).toHaveLength(3);
+
+		const withRedundantLaunch = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL, LONG_AUTH_URL).render(80);
+		expect(withRedundantLaunch).toHaveLength(3);
 	});
 });

--- a/packages/coding-agent/test/utils/open.test.ts
+++ b/packages/coding-agent/test/utils/open.test.ts
@@ -132,4 +132,51 @@ describe("openPath", () => {
 		expect(spawnSyncSpy).not.toHaveBeenCalled();
 		expect(spawnCalls.map(call => call.cmd)).toEqual([["xdg-open", existingLinuxPath]]);
 	});
+
+	it("resolves rundll32 through %SystemRoot% so a broken machine PATH cannot silence the opener", () => {
+		setPlatform("win32");
+		const originalSystemRoot = process.env.SystemRoot;
+		process.env.SystemRoot = "D:\\CustomWindows";
+		try {
+			const spawnCalls: SpawnCall[] = [];
+			spySpawn(spawnCalls);
+
+			openPath("https://mcp.linear.app/authorize?state=xyz&code_challenge_method=S256");
+
+			expect(spawnCalls).toHaveLength(1);
+			const [call] = spawnCalls;
+			// Absolute rundll32 path — bare `rundll32` was the whole bug on Windows
+			// boxes where the machine PATH no longer references System32.
+			expect(call?.cmd[0]).toBe("D:\\CustomWindows\\System32\\rundll32.exe");
+			// Handler + URL forwarded verbatim as a single argv slot so `&` in the
+			// query string cannot be interpreted as a shell separator.
+			expect(call?.cmd.slice(1)).toEqual([
+				"url.dll,FileProtocolHandler",
+				"https://mcp.linear.app/authorize?state=xyz&code_challenge_method=S256",
+			]);
+		} finally {
+			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = originalSystemRoot;
+		}
+	});
+
+	it("falls back to C:\\Windows for rundll32 when SystemRoot is unset", () => {
+		setPlatform("win32");
+		const originalSystemRoot = process.env.SystemRoot;
+		const originalSystemRootLower = process.env.SYSTEMROOT;
+		delete process.env.SystemRoot;
+		delete process.env.SYSTEMROOT;
+		try {
+			const spawnCalls: SpawnCall[] = [];
+			spySpawn(spawnCalls);
+
+			openPath("https://example.com");
+
+			expect(spawnCalls).toHaveLength(1);
+			expect(spawnCalls[0]?.cmd[0]).toBe("C:\\Windows\\System32\\rundll32.exe");
+		} finally {
+			if (originalSystemRoot !== undefined) process.env.SystemRoot = originalSystemRoot;
+			if (originalSystemRootLower !== undefined) process.env.SYSTEMROOT = originalSystemRootLower;
+		}
+	});
 });


### PR DESCRIPTION
## Repro

`/mcp reauth` against Linear MCP (`https://mcp.linear.app/mcp`) on a Windows machine whose PATH no longer references `System32` (real-world occurrence — `System32\Wbem`, `WindowsPowerShell`, `OpenSSH` survive but `System32` itself is dropped) leaves the transcript claiming `→ Opening browser automatically...` while no browser opens, and hand-copying the displayed `Copy URL:` line into a browser yields Linear's `The plain PKCE method is not allowed. Use S256 instead.` error page — despite `MCPOAuthFlow.generateAuthUrl` hardcoding `code_challenge_method=S256`.

Reproduced in-process (see `#issuecomment-4874117449`):

1. `truncateToWidth(" Copy URL: <Linear-shaped 319-char authorize URL>", 270, Ellipsis.Omit)` — the exact call `TUI#prepareLine` makes at `packages/tui/src/tui.ts:3101` — returns 270 chars ending in `...&code_challenge=5MlkJfN2GhX9uP0rQ`. The trailing `&code_challenge_method=S256` is silently dropped while `code_challenge` remains. Per RFC 7636 §4.3, that request is treated as `plain`, which S256-only providers reject.
2. `Bun.spawn(["rundll32-not-in-PATH", ...])` throws synchronously with `Executable not found in $PATH: "rundll32-…"` — the same shape observed live. `packages/coding-agent/src/utils/open.ts:50-54` wraps the spawn in bare `try { ... } catch {}`, so the throw never surfaces and the MCP UI's outer `try/catch` around `openPath(info.url)` (`mcp-command-controller.ts:711`) is dead code.

## Cause

Two independent defects chained:

1. **`packages/coding-agent/src/utils/open.ts`** — `openPath` invoked bare `rundll32` (resolved via `PATH`) and swallowed spawn failures with `catch {}`. Bun's `spawn` throws synchronously when the executable is not on PATH, and no log is emitted.
2. **`packages/tui/src/tui.ts::TUI#prepareLine`** — every composed frame line wider than the viewport is truncated with `truncateToWidth(normalized, width, Ellipsis.Omit)`. `MCPAuthorizationLinkPrompt` (`packages/coding-agent/src/modes/controllers/mcp-command-controller.ts`) rendered `Copy URL: <full URL>` as a single ~271-column line whose trailing parameter is `code_challenge_method=S256`, so any terminal narrower than the composed row silently corrupts the copy target in a way indistinguishable from a genuinely complete URL. Ctrl+click on the OSC 8 hyperlink kept working because the escape-sequence payload is invisible to width truncation — the "click works / copy fails" fingerprint of display-layer data loss.

## Fix

- **`packages/ai/src/registry/oauth/callback-server.ts`** — `OAuthCallbackFlow` now hosts a `GET /launch` route on the same loopback callback server it already runs. The route 302-redirects to the currently pending authorization URL; the pending URL is set inside `login()` before `onAuth` fires and cleared when the server stops (so `/launch` returns 503 rather than a stale URL post-flow). The port comes from `server.port`, not `preferredPort`, so `preferredPort: 0` (random) routes correctly.
- **`packages/ai/src/registry/oauth/types.ts`** — `OAuthAuthInfo` gains `launchUrl?: string`, populated for any flow that runs a loopback callback server. Left `undefined` for device-code / paste-code providers where no loopback launcher exists.
- **`packages/ai/src/auth-storage.ts`** — inline `onAuth` shape widened to `OAuthAuthInfo` so downstream callers can destructure `launchUrl`.
- **`packages/coding-agent/src/modes/controllers/mcp-command-controller.ts`** — `MCPAuthorizationLinkPrompt` now accepts `(url, launchUrl?)` and advertises `launchUrl ?? url` as the `Copy URL:` target while keeping the OSC 8 hyperlink pointing at the full URL. The onAuth handler drops the dead `try/catch` around `openPath` (best-effort by contract, never throws once the opener itself logs), stages the copy target on the clipboard via OSC 52 (`copyToClipboard`, same pattern the setup wizard uses), and switches the transcript wording from "→ Opening browser automatically..." (which the code cannot verify) to "→ Attempting to open browser...".
- **`packages/coding-agent/src/utils/open.ts`** — Windows opener now resolves `rundll32.exe` through `path.win32.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "rundll32.exe")` (with a `SYSTEMROOT` fallback for case-quirky shells), so a broken machine PATH cannot silence it. Synchronous spawn throws and non-zero exits are logged via the shared `logger` so silent misconfigurations show up in `~/.omp/logs/omp.*.log`. `path.win32` (not the platform-adaptive `path.join`) keeps Windows separators when the harness runs on POSIX and matches Windows call conventions on the real target.
- **`packages/coding-agent/src/modes/components/login-dialog.ts`, `.../modes/controllers/selector-controller.ts`, `.../modes/setup-wizard/scenes/sign-in.ts`, `.../cli/auth-broker-cli.ts`** — every OAuth-facing surface now advertises the launch URL when present (`Copy URL:` line, `#authUrl` text row, and stdout for the CLI) while OSC 8 hyperlinks and the `openInBrowser`/`openPath` call still receive the full URL byte-for-byte.
- **`packages/coding-agent/src/modes/rpc/rpc-types.ts` + `.../rpc-mode.ts`** — the `open_url` extension UI request forwards `launchUrl` so extension hosts can present the same truncation-safe copy target.

## Verification

- `bun test packages/ai/test/callback-server-launch-route.test.ts packages/ai/test/callback-server-port-fallback.test.ts packages/ai/test/callback-server-manual-input.test.ts packages/coding-agent/test/utils/open.test.ts packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts packages/coding-agent/test/oauth-flow.test.ts packages/ai/test/auth-storage-oauth-account-select.test.ts` — 61 pass / 0 fail. The new `callback-server-launch-route.test.ts` asserts the `/launch` contract end-to-end against a real Bun server (short URL shape, 302 target matches the pending URL byte-for-byte, 503-then-connection-refused after the flow completes, unrelated paths still 404). `open.test.ts` gains two Windows cases covering the `%SystemRoot%`-anchored path and the `C:\Windows` fallback. `mcp-authorization-link.test.ts` gains a case verifying the launch URL is advertised as the `Copy URL:` target while OSC 8 keeps the full URL.
- `bun check` — passes across all workspace packages.
- Reproduction confirmed in-process before and cleared after the fix (`repro_record`, `#issuecomment-4874117449`).

Fixes #4418