### PR TITLE
fix(task): respect deferred task model role selectors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed task-class subagents dropping unresolved explicit model-role selectors before startup, preventing `modelRoles.task` from silently falling through to an unrelated available provider model ([#4421](https://github.com/can1357/oh-my-pi/issues/4421)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -391,9 +391,9 @@ export interface CreateAgentSessionOptions {
 
 	/** Model to use. Default: from settings, else first available */
 	model?: Model;
-	/** Raw model pattern string (e.g. from --model CLI flag) to resolve after extensions load.
+	/** Raw model pattern(s) (e.g. from --model CLI flag) to resolve after extensions load.
 	 * Used when model lookup is deferred because extension-provided models aren't registered yet. */
-	modelPattern?: string;
+	modelPattern?: string | string[];
 	/** Thinking selector. Default: from settings, else unset */
 	thinkingLevel?: ConfiguredThinkingLevel;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
@@ -1245,7 +1245,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const hasThinkingEntry = existingBranch.some(entry => entry.type === "thinking_level_change");
 	const hasServiceTierEntry = existingBranch.some(entry => entry.type === "service_tier_change");
 
-	const hasExplicitModel = options.model !== undefined || options.modelPattern !== undefined;
+	const deferredModelPatterns = Array.isArray(options.modelPattern)
+		? options.modelPattern.map(pattern => pattern.trim()).filter(Boolean)
+		: options.modelPattern?.trim()
+			? [options.modelPattern.trim()]
+			: [];
+	const hasExplicitModel = options.model !== undefined || deferredModelPatterns.length > 0;
 	const modelMatchPreferences = getModelMatchPreferences(settings);
 	const allowedModels = await logger.time("resolveAllowedModels", () =>
 		resolveAllowedModels(modelRegistry, settings, modelMatchPreferences),
@@ -1957,23 +1962,46 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 			}
 		}
-		// Resolve deferred --model pattern now that extension models are registered.
-		if (!model && options.modelPattern) {
+		// Resolve deferred --model/subagent patterns now that extension models are registered.
+		if (!model && deferredModelPatterns.length > 0) {
 			const availableModels = modelRegistry.getAll();
 			const matchPreferences = getModelMatchPreferences(settings);
-			const { model: resolved } = parseModelPattern(options.modelPattern, availableModels, matchPreferences);
-			if (resolved) {
+			for (const pattern of deferredModelPatterns) {
+				const {
+					model: resolved,
+					thinkingLevel: patternThinkingLevel,
+					explicitThinkingLevel,
+				} = parseModelPattern(pattern, availableModels, matchPreferences);
+				if (!resolved) continue;
 				model = resolved;
 				modelFallbackMessage = undefined;
-			} else {
-				modelFallbackMessage = `Model "${options.modelPattern}" not found`;
+				if (explicitThinkingLevel) {
+					restoredSessionThinkingLevel = patternThinkingLevel;
+				}
+				thinkingLevel = pickInitialThinkingLevel(resolved);
+				autoThinking = thinkingLevel === AUTO_THINKING;
+				effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
+				effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
+					autoThinking
+						? resolveProvisionalAutoLevel(resolved)
+						: resolveThinkingLevelForModel(resolved, effectiveThinkingLevel),
+				);
+				preconnectModelHost(resolved.baseUrl);
+				break;
+			}
+			if (!model) {
+				const requested =
+					deferredModelPatterns.length === 1
+						? `"${deferredModelPatterns[0]}"`
+						: `one of ${deferredModelPatterns.map(pattern => `"${pattern}"`).join(", ")}`;
+				modelFallbackMessage = `Model ${requested} not found`;
 			}
 		}
 
 		// Fall back to first available model with a valid API key, honoring the
 		// path-scoped `enabledModels` allow-list when configured. Skip when the
 		// user explicitly requested a model via --model that wasn't found.
-		if (!model && !options.modelPattern) {
+		if (!model && deferredModelPatterns.length === 0) {
 			// Re-resolve the allowed set: extension factories above may have
 			// registered providers/models that weren't visible at startup.
 			const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -31,7 +31,7 @@ import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { bucketRules } from "./capability/rule-buckets";
 import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode";
 import { shouldInlineToolDescriptors } from "./config/inline-tool-descriptors-mode";
-import { ModelRegistry } from "./config/model-registry";
+import { isAuthenticated, kNoAuth, ModelRegistry } from "./config/model-registry";
 import {
 	formatModelString,
 	getModelMatchPreferences,
@@ -394,6 +394,8 @@ export interface CreateAgentSessionOptions {
 	/** Raw model pattern(s) (e.g. from --model CLI flag) to resolve after extensions load.
 	 * Used when model lookup is deferred because extension-provided models aren't registered yet. */
 	modelPattern?: string | string[];
+	/** Authenticated fallback selector for deferred subagent model patterns. */
+	modelPatternAuthFallback?: string;
 	/** Thinking selector. Default: from settings, else unset */
 	thinkingLevel?: ConfiguredThinkingLevel;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
@@ -1967,26 +1969,43 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const availableModels = modelRegistry.getAll();
 			const matchPreferences = getModelMatchPreferences(settings);
 			for (const pattern of deferredModelPatterns) {
-				const {
-					model: resolved,
-					thinkingLevel: patternThinkingLevel,
-					explicitThinkingLevel,
-				} = parseModelPattern(pattern, availableModels, matchPreferences);
-				if (!resolved) continue;
-				model = resolved;
-				modelFallbackMessage = undefined;
-				if (explicitThinkingLevel) {
-					restoredSessionThinkingLevel = patternThinkingLevel;
+				const primary = parseModelPattern(pattern, availableModels, matchPreferences);
+				if (!primary.model) continue;
+				let selectedModel = primary.model;
+				let selectedThinkingLevel = primary.thinkingLevel;
+				let selectedExplicitThinkingLevel = primary.explicitThinkingLevel;
+				if (options.modelPatternAuthFallback) {
+					const primaryKey = await modelRegistry.getApiKey(primary.model);
+					if (primaryKey !== kNoAuth && !isAuthenticated(primaryKey)) {
+						const fallback = parseModelPattern(
+							options.modelPatternAuthFallback,
+							availableModels,
+							matchPreferences,
+						);
+						if (fallback.model) {
+							const fallbackKey = await modelRegistry.getApiKey(fallback.model);
+							if (isAuthenticated(fallbackKey)) {
+								selectedModel = fallback.model;
+								selectedThinkingLevel = fallback.thinkingLevel;
+								selectedExplicitThinkingLevel = fallback.explicitThinkingLevel;
+							}
+						}
+					}
 				}
-				thinkingLevel = pickInitialThinkingLevel(resolved);
+				model = selectedModel;
+				modelFallbackMessage = undefined;
+				if (selectedExplicitThinkingLevel) {
+					restoredSessionThinkingLevel = selectedThinkingLevel;
+				}
+				thinkingLevel = pickInitialThinkingLevel(selectedModel);
 				autoThinking = thinkingLevel === AUTO_THINKING;
 				effectiveThinkingLevel = concreteThinkingLevel(thinkingLevel);
 				effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
 					autoThinking
-						? resolveProvisionalAutoLevel(resolved)
-						: resolveThinkingLevelForModel(resolved, effectiveThinkingLevel),
+						? resolveProvisionalAutoLevel(selectedModel)
+						: resolveThinkingLevelForModel(selectedModel, effectiveThinkingLevel),
 				);
-				preconnectModelHost(resolved.baseUrl);
+				preconnectModelHost(selectedModel.baseUrl);
 				break;
 			}
 			if (!model) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -33,7 +33,9 @@ import { shouldEnableAppendOnlyContext } from "./config/append-only-context-mode
 import { shouldInlineToolDescriptors } from "./config/inline-tool-descriptors-mode";
 import { isAuthenticated, kNoAuth, ModelRegistry } from "./config/model-registry";
 import {
+	formatModelSelectorValue,
 	formatModelString,
+	formatModelStringWithRouting,
 	getModelMatchPreferences,
 	parseModelPattern,
 	parseModelString,
@@ -396,6 +398,8 @@ export interface CreateAgentSessionOptions {
 	modelPattern?: string | string[];
 	/** Authenticated fallback selector for deferred subagent model patterns. */
 	modelPatternAuthFallback?: string;
+	/** Role name used to install retry fallbacks after deferred subagent patterns resolve. */
+	modelPatternFallbackRole?: string;
 	/** Thinking selector. Default: from settings, else unset */
 	thinkingLevel?: ConfiguredThinkingLevel;
 	/** Models available for cycling (Ctrl+P in interactive mode) */
@@ -1968,12 +1972,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (!model && deferredModelPatterns.length > 0) {
 			const availableModels = modelRegistry.getAll();
 			const matchPreferences = getModelMatchPreferences(settings);
-			for (const pattern of deferredModelPatterns) {
+			for (let patternIndex = 0; patternIndex < deferredModelPatterns.length; patternIndex += 1) {
+				const pattern = deferredModelPatterns[patternIndex];
 				const primary = parseModelPattern(pattern, availableModels, matchPreferences);
 				if (!primary.model) continue;
 				let selectedModel = primary.model;
 				let selectedThinkingLevel = primary.thinkingLevel;
 				let selectedExplicitThinkingLevel = primary.explicitThinkingLevel;
+				let authFallbackUsed = false;
 				if (options.modelPatternAuthFallback) {
 					const primaryKey = await modelRegistry.getApiKey(primary.model);
 					if (primaryKey !== kNoAuth && !isAuthenticated(primaryKey)) {
@@ -1988,8 +1994,50 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 								selectedModel = fallback.model;
 								selectedThinkingLevel = fallback.thinkingLevel;
 								selectedExplicitThinkingLevel = fallback.explicitThinkingLevel;
+								authFallbackUsed = true;
 							}
 						}
+					}
+				}
+				if (!authFallbackUsed && options.modelPatternFallbackRole) {
+					const primarySelector = formatModelSelectorValue(
+						formatModelStringWithRouting(primary.model),
+						primary.thinkingLevel,
+					);
+					const seenSelectors = new Set<string>([primarySelector]);
+					const fallbackSelectors: string[] = [];
+					for (const fallbackPattern of deferredModelPatterns.slice(patternIndex + 1)) {
+						const fallback = parseModelPattern(fallbackPattern, availableModels, matchPreferences);
+						if (!fallback.model) continue;
+						const fallbackSelector = formatModelSelectorValue(
+							formatModelStringWithRouting(fallback.model),
+							fallback.thinkingLevel,
+						);
+						if (seenSelectors.has(fallbackSelector)) continue;
+						seenSelectors.add(fallbackSelector);
+						fallbackSelectors.push(fallbackSelector);
+					}
+					if (fallbackSelectors.length > 0) {
+						const modelRoles: Record<string, string> = {};
+						const existingRoles = settings.getModelRoles();
+						for (const role in existingRoles) {
+							const selector = existingRoles[role];
+							if (selector) {
+								modelRoles[role] = selector;
+							}
+						}
+						modelRoles[options.modelPatternFallbackRole] = primarySelector;
+						settings.override("modelRoles", modelRoles);
+						const fallbackChains: Record<string, string[]> = {
+							[options.modelPatternFallbackRole]: fallbackSelectors,
+						};
+						const existingFallbackChains = settings.get("retry.fallbackChains");
+						for (const role in existingFallbackChains) {
+							if (role !== options.modelPatternFallbackRole) {
+								fallbackChains[role] = existingFallbackChains[role];
+							}
+						}
+						settings.override("retry.fallbackChains", fallbackChains);
 					}
 				}
 				model = selectedModel;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2161,6 +2161,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				modelRegistry,
 				settings: subagentSettings,
 				model,
+				modelPattern: model || modelOverride === undefined ? undefined : modelPatterns,
 				thinkingLevel: effectiveThinkingLevel,
 				toolNames,
 				outputSchema,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2164,6 +2164,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				modelPattern: model || modelOverride === undefined ? undefined : modelPatterns,
 				modelPatternAuthFallback:
 					model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,
+				modelPatternFallbackRole:
+					model || modelOverride === undefined ? undefined : `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`,
 				thinkingLevel: effectiveThinkingLevel,
 				toolNames,
 				outputSchema,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2162,6 +2162,8 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				settings: subagentSettings,
 				model,
 				modelPattern: model || modelOverride === undefined ? undefined : modelPatterns,
+				modelPatternAuthFallback:
+					model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,
 				thinkingLevel: effectiveThinkingLevel,
 				toolNames,
 				outputSchema,

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -60,7 +60,7 @@ function createYieldingSession(): AgentSession {
 	return session as unknown as AgentSession;
 }
 
-describe("issue #2750: subagent runtime model fallback", () => {
+describe("subagent runtime model resolution", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
@@ -147,5 +147,37 @@ describe("issue #2750: subagent runtime model fallback", () => {
 		});
 
 		expect(childFallbackChains?.["subagent:issue-2750-routed"]).toEqual(["openrouter/z-ai/glm-4.7@fireworks"]);
+	});
+
+	it("defers unresolved explicit subagent model selectors instead of picking an available default", async () => {
+		const defaultModel = model("zai", "glm-5.2");
+		let childModel: Model | undefined;
+		let childModelPattern: unknown;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childModel = options.model;
+			childModelPattern = options.modelPattern;
+			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "issue-4421",
+			modelOverride: ["openai-codex/gpt-5.5:auto"],
+			settings: Settings.isolated(),
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [defaultModel],
+				getApiKey: async () => "test-key",
+			} as never,
+			enableLsp: false,
+		});
+
+		expect(childModel).toBeUndefined();
+		expect(childModelPattern).toEqual(["openai-codex/gpt-5.5:auto"]);
 	});
 });

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -153,10 +153,12 @@ describe("subagent runtime model resolution", () => {
 		const defaultModel = model("zai", "glm-5.2");
 		let childModel: Model | undefined;
 		let childModelPattern: unknown;
+		let childModelPatternAuthFallback: unknown;
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			if (!options) throw new Error("Expected createAgentSession options");
 			childModel = options.model;
 			childModelPattern = options.modelPattern;
+			childModelPatternAuthFallback = options.modelPatternAuthFallback;
 			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
 		});
 
@@ -168,6 +170,7 @@ describe("subagent runtime model resolution", () => {
 			index: 0,
 			id: "issue-4421",
 			modelOverride: ["openai-codex/gpt-5.5:auto"],
+			parentActiveModelPattern: "openai-codex/gpt-5.5",
 			settings: Settings.isolated(),
 			modelRegistry: {
 				refresh: async () => {},
@@ -179,5 +182,6 @@ describe("subagent runtime model resolution", () => {
 
 		expect(childModel).toBeUndefined();
 		expect(childModelPattern).toEqual(["openai-codex/gpt-5.5:auto"]);
+		expect(childModelPatternAuthFallback).toBe("openai-codex/gpt-5.5");
 	});
 });

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -154,11 +154,13 @@ describe("subagent runtime model resolution", () => {
 		let childModel: Model | undefined;
 		let childModelPattern: unknown;
 		let childModelPatternAuthFallback: unknown;
+		let childModelPatternFallbackRole: unknown;
 		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
 			if (!options) throw new Error("Expected createAgentSession options");
 			childModel = options.model;
 			childModelPattern = options.modelPattern;
 			childModelPatternAuthFallback = options.modelPatternAuthFallback;
+			childModelPatternFallbackRole = options.modelPatternFallbackRole;
 			return { session: createYieldingSession(), extensionsResult: {}, setToolUIContext: () => {} } as never;
 		});
 
@@ -183,5 +185,6 @@ describe("subagent runtime model resolution", () => {
 		expect(childModel).toBeUndefined();
 		expect(childModelPattern).toEqual(["openai-codex/gpt-5.5:auto"]);
 		expect(childModelPatternAuthFallback).toBe("openai-codex/gpt-5.5");
+		expect(childModelPatternFallbackRole).toBe("subagent:issue-4421");
 	});
 });

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -80,7 +80,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		pi.registerProvider("runtime-provider", dynamicOnlyProviderConfig);
 	};
 
-	async function buildSessionOptions(modelPattern: string) {
+	async function buildSessionOptions(modelPattern: string | string[]) {
 		// Pass an explicit ModelRegistry so createAgentSession skips its implicit
 		// ModelRegistry.refreshInBackground() — a network model-discovery pass
 		// (~250ms/session) that contributes nothing here: the model resolves from
@@ -203,6 +203,24 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		} finally {
 			await session.dispose();
 			getApiKeySpy.mockRestore();
+		}
+	});
+
+	test("installs fallback chain for remaining deferred subagent modelPattern candidates", async () => {
+		const { session } = await createAgentSession({
+			...(await buildSessionOptions(["runtime-provider/runtime-model", "runtime-provider/runtime-reasoning-model"])),
+			modelPatternFallbackRole: "subagent:deferred",
+		});
+
+		try {
+			expect(session.model?.provider).toBe("runtime-provider");
+			expect(session.model?.id).toBe("runtime-model");
+			expect(session.settings.getModelRole("subagent:deferred")).toBe("runtime-provider/runtime-model");
+			expect(session.settings.get("retry.fallbackChains")["subagent:deferred"]).toEqual([
+				"runtime-provider/runtime-reasoning-model",
+			]);
+		} finally {
+			await session.dispose();
 		}
 	});
 

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -21,6 +21,7 @@ describe("createAgentSession deferred model pattern resolution", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		for (const authStorage of authStoragesToClose) {
 			authStorage.close();
 		}
@@ -160,6 +161,49 @@ describe("createAgentSession deferred model pattern resolution", () => {
 
 		expect(session.model).toBeUndefined();
 		expect(modelFallbackMessage).toBe('Model "missing-provider/missing-model" not found');
+	});
+
+	test("uses auth fallback when deferred subagent modelPattern resolves without working credentials", async () => {
+		const parentModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!parentModel) {
+			throw new Error("Expected bundled anthropic parent model");
+		}
+		const authStorage = await AuthStorage.create(path.join(tempDir, "fallback-auth.db"));
+		authStoragesToClose.push(authStorage);
+		authStorage.setRuntimeApiKey(parentModel.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "fallback-models.yml"));
+		const getApiKeySpy = vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async requested => {
+			if (requested.provider === "runtime-provider") return undefined;
+			if (requested.provider === parentModel.provider) return "test-key";
+			return undefined;
+		});
+		const { session, modelFallbackMessage } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			extensions: [providerExtension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+			modelPattern: "runtime-provider/runtime-model",
+			modelPatternAuthFallback: `${parentModel.provider}/${parentModel.id}`,
+		});
+
+		try {
+			expect(session.model?.provider).toBe(parentModel.provider);
+			expect(session.model?.id).toBe(parentModel.id);
+			expect(modelFallbackMessage).toBeUndefined();
+		} finally {
+			await session.dispose();
+			getApiKeySpy.mockRestore();
+		}
 	});
 
 	test("does not apply default role thinking override when modelPattern is explicit", async () => {


### PR DESCRIPTION
## Repro
With a task-class subagent selector such as `modelRoles.task: openai-codex/gpt-5.5:auto`, the executor could fail to resolve the selector during preflight and call child startup with neither `model` nor `modelPattern`; the focused repro was `bun run --cwd packages/coding-agent gen:tool-views && bun test packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts -t "defers unresolved explicit subagent model selectors"`, which failed because `options.modelPattern` was `undefined`.

## Cause
`packages/coding-agent/src/task/executor.ts` resolved `modelOverride` before creating the child session, but `packages/coding-agent/src/sdk.ts` only received a concrete `model`; if preflight resolution missed a runtime/discovered model, the explicit subagent selector was discarded and `createAgentSession` could fall through to its default available-model selection path.

## Fix
- Forward unresolved explicit subagent `modelOverride` selectors into `CreateAgentSessionOptions.modelPattern` instead of dropping them.
- Let `createAgentSession` defer-resolve one or more model patterns after extension/runtime providers register, while still treating unresolved explicit patterns as explicit so defaults do not silently replace them.
- Preserve explicit thinking selectors when a deferred model pattern resolves.
- Add regression coverage for the `modelRoles.task`-style selector disappearing before child startup.

## Verification
Ran `bun run --cwd packages/coding-agent gen:tool-views`, `bun test packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts packages/coding-agent/test/sdk-model-selection.test.ts`, `bun run --cwd packages/coding-agent check:types`, and `bun run --cwd packages/coding-agent fix`. `gh_push_branch` also completed the pre-publish gate before pushing. Fixes #4421