### PR TITLE
Add configurable user prompt style

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -896,6 +896,30 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"display.userMessageStyle": {
+		type: "enum",
+		values: ["default", "claude-strip"] as const,
+		default: "default",
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "User Message Style",
+			description: "How submitted user prompts are rendered in the transcript",
+			options: [
+				{
+					value: "default",
+					label: "Default",
+					description: "OMP's standard padded user-message block",
+				},
+				{
+					value: "claude-strip",
+					label: "Claude Strip",
+					description: "Claude Code-style prompt strip with a leading chevron and full-width grey row",
+				},
+			],
+		},
+	},
+
 	"display.showTokenUsage": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -1,4 +1,5 @@
 import { Container, Markdown } from "@oh-my-pi/pi-tui";
+import { isSettingsInitialized, settings } from "../../config/settings";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { imageReferenceHyperlink, renderPlaceholders } from "../image-references";
 import { highlightMagicKeywords } from "../magic-keywords";
@@ -23,6 +24,11 @@ export class UserMessageComponent extends Container {
 
 	constructor(text: string, synthetic = false, imageLinks?: readonly (string | undefined)[]) {
 		super();
+		const useClaudeStrip =
+			!synthetic && isSettingsInitialized() && settings.get("display.userMessageStyle") === "claude-strip";
+		const displayText = useClaudeStrip && text.trim() !== "" ? `\\> ${text}` : text;
+		const horizontalPadding = useClaudeStrip ? 0 : 1;
+		const verticalPadding = useClaudeStrip ? 0 : 1;
 		const bgColor = (value: string) => theme.bg("userMessageBg", value);
 		// Paint the magic keywords ("ultrathink"/"orchestrate"/"workflowz") inside the rendered
 		// bubble too — matching the live editor glow. The Markdown component routes code spans and
@@ -42,7 +48,7 @@ export class UserMessageComponent extends Container {
 						? imageReferenceHyperlink(label, index, imageLinks, imageLabel)
 						: theme.fg("accent", `\x1b[1m${label}\x1b[22m`),
 			});
-		const md = new Markdown(text, 1, 1, getMarkdownTheme(), {
+		const md = new Markdown(displayText, horizontalPadding, verticalPadding, getMarkdownTheme(), {
 			bgColor,
 			color,
 		});

--- a/packages/coding-agent/test/user-message-style.test.ts
+++ b/packages/coding-agent/test/user-message-style.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { getDefault, getEnumValues, getUi } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import { UserMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
+
+const OSC133_ZONE = /\x1b\]133;[AB]\x07/g;
+
+function plain(line: string): string {
+	return Bun.stripANSI(line.replace(OSC133_ZONE, ""));
+}
+
+describe("display.userMessageStyle", () => {
+	beforeAll(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
+		await initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	afterEach(() => {
+		settings.clearOverride("display.userMessageStyle");
+	});
+
+	afterAll(() => {
+		resetSettingsForTest();
+	});
+
+	it("registers the opt-in user-message style setting", () => {
+		expect(getDefault("display.userMessageStyle")).toBe("default");
+		expect(getEnumValues("display.userMessageStyle")).toEqual(["default", "claude-strip"]);
+		expect(getUi("display.userMessageStyle")?.label).toBe("User Message Style");
+	});
+
+	it("keeps the existing padded renderer by default", () => {
+		const component = new UserMessageComponent("hello there");
+		const rendered = component.render(40);
+		const textLine = rendered.map(plain).find(line => line.includes("hello there"));
+
+		expect(textLine).toBeDefined();
+		expect(textLine?.trim()).toBe("hello there");
+		expect(textLine).not.toContain("> hello there");
+	});
+
+	it("renders claude-strip prompts as full-width chevron rows", () => {
+		settings.override("display.userMessageStyle", "claude-strip");
+
+		const component = new UserMessageComponent("hello there");
+		const rendered = component.render(40);
+		const row = rendered[0]!;
+
+		expect(rendered).toHaveLength(1);
+		expect(plain(row).trimEnd()).toBe("> hello there");
+		expect(row).toContain("\x1b[48;");
+		expect(visibleWidth(row)).toBe(40);
+	});
+
+	it("only prefixes the first wrapped claude-strip row", () => {
+		settings.override("display.userMessageStyle", "claude-strip");
+
+		const component = new UserMessageComponent(
+			"And then is there any evidence on what they might have used to source this? Is there a public database?",
+		);
+		const rendered = component.render(50);
+		const rows = rendered.map(line => plain(line).trimEnd());
+
+		expect(rendered.length).toBeGreaterThan(1);
+		expect(rows[0]?.startsWith("> ")).toBe(true);
+		expect(rows.slice(1).every(row => !row.startsWith(">"))).toBe(true);
+		expect(rendered.every(row => row.includes("\x1b[48;") && visibleWidth(row) === 50)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `display.userMessageStyle` setting so users can make submitted prompts stand out from assistant replies without patching installed package files.

The new `claude-strip` style renders real user prompts with:

- a leading `>` prompt marker
- no top/bottom padding
- a full-width user-message background row, including wrapped lines
- the existing `userMessageBg` / `userMessageText` theme tokens

The default remains `default`, preserving OMP's existing padded user-message renderer unless a user opts in.

## Motivation

In longer OMP transcripts, user prompts can visually blend into assistant output. Claude Code's prompt strip makes user input easier to scan because each submitted prompt starts with a clear marker and has a stronger background treatment. This PR makes that style available as a supported setting instead of requiring local edits under `node_modules`, which get overwritten on package updates.

Users can opt in with:

```bash
omp config set display.userMessageStyle claude-strip
```

or YAML:

```yaml
display:
  userMessageStyle: claude-strip
```

## Implementation

- Adds `display.userMessageStyle` to the settings schema with `default` and `claude-strip` values.
- Updates `UserMessageComponent` to read the setting when settings are initialized.
- Keeps synthetic user messages on the existing renderer path.
- Escapes the literal `>` marker before passing text through Markdown so it renders as a prompt marker instead of a blockquote.

## Verification

- `bun test packages/coding-agent/test/user-message-style.test.ts`
- `bun run check:types` from `packages/coding-agent`
- `bun run check` from `packages/coding-agent`
