### PR TITLE
fix(ai): restore the drop guard for undefined thinking signatures

### DIFF
--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -437,13 +437,15 @@ export function transformMessages<TApi extends Api>(
 							return [];
 						}
 						// Same-model Anthropic replay to a signature-enforcing endpoint
-						// cannot natively replay thinking blocks whose source explicitly
-						// recorded an empty signature, but this is not a dialect
-						// transition. Do not demote that sentinel into the target model's
-						// textual thinking dialect; keep demotion for signatures stripped
-						// by the untrustworthy-turn recovery above and for literal thinking
-						// envelopes that never carried a signature field.
-						if (isSameModel && isSigningAnthropicTarget && sanitized.thinkingSignature?.trim() === "") {
+						// requires valid signatures to natively replay thinking blocks.
+						// Both undefined and empty string signatures are invalid and must
+						// be dropped entirely — not demoted to text. Demotion would cause
+						// the reasoning_extraction safety classifier to refuse the response.
+						if (
+							isSameModel &&
+							isSigningAnthropicTarget &&
+							(!sanitized.thinkingSignature || sanitized.thinkingSignature.trim() === "")
+						) {
 							return [];
 						}
 						return sanitized;

--- a/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
+++ b/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
@@ -123,13 +123,17 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 
-	it("downgrades historical end_turn(stop) tool-use thinking to text so the continuation stays wire-valid", () => {
+	it("drops historical end_turn(stop) tool-use thinking so the continuation stays wire-valid", () => {
 		const blocks = assistantBlocks(buildHistoryWithLaterAssistant("stop", "sig_valid"));
 		expectNoUnsignedThinking(blocks);
-		// Signature stripped (historical abandoned tool-use) -> encoder downgrades to text.
+		// Signature stripped (historical same-model abandoned tool-use) -> the thinking block is
+		// dropped entirely, never demoted to text. Demotion would trip the reasoning_extraction
+		// classifier; the reasoning is the model's own prior chain and is not replayed as prose.
 		expect(blocks.some(b => b.type === "thinking")).toBe(false);
-		expect(blocks.some(b => b.type === "text" && b.text?.includes("deliberating"))).toBe(true);
-		// tool_use is preserved so it still pairs with the appended tool_result.
+		expect(blocks.some(b => b.type === "text" && b.text?.includes("deliberating"))).toBe(false);
+		// The turn's other content survives (visible text + tool_use), so the tool_use still pairs
+		// with the appended tool_result and the continuation stays wire-valid.
+		expect(blocks.some(b => b.type === "text" && b.text === "I'll check the weather.")).toBe(true);
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 
@@ -156,7 +160,10 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expectNoUnsignedThinking(blocks);
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "sig_done")).toBe(true);
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "trunc")).toBe(false);
-		expect(blocks.some(b => b.type === "text" && b.text === "<thinking>\nnow decide\n</thinking>")).toBe(true);
+		// The stripped mid-stream block is dropped entirely, not demoted to text: same-model replay
+		// to signature-enforcing Anthropic never emits demoted thinking (it would trip the
+		// reasoning_extraction classifier). Only the earlier fully-signed block replays natively.
+		expect(blocks.some(b => b.type === "text" && b.text?.includes("now decide"))).toBe(false);
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 

--- a/packages/ai/test/anthropic-copilot-checkpoint-thinking-signature.test.ts
+++ b/packages/ai/test/anthropic-copilot-checkpoint-thinking-signature.test.ts
@@ -16,9 +16,11 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
  * SIGNING endpoint (`replayUnsignedThinking: false` — see the catalog compat
  * regression test). This pins the consequence: when a checkpoint/branch-return
  * turn is an abandoned tool-use turn (adaptive Opus emits a tool call then ends
- * on `stop`), the transform strips its end_turn-bound signature and the encoder
- * must DEGRADE the block to text — never replay it as `{ signature: "" }`, which
- * 400s the whole request with "Invalid signature" on every full re-send.
+ * on `stop`), the transform strips its end_turn-bound signature. Since the turn
+ * is same-model with an invalid (undefined) signature, the thinking block is
+ * dropped entirely — never emitted as `{ signature: "" }` (which would 400 the
+ * request with "Invalid signature") and never demoted to text (which would
+ * trigger the reasoning_extraction safety classifier and cause refusals).
  *
  * The signing classification is asserted directly in
  * `packages/catalog/test/anthropic-copilot-signing-compat.test.ts`; the explicit
@@ -132,10 +134,11 @@ describe("#2851 github-copilot checkpoint/branch-return thinking signature", () 
 			expect(block.signature && block.signature.length > 0).toBeTruthy();
 		}
 
-		// The stripped checkpoint thinking is preserved as text (reasoning not silently lost),
-		// and its tool_use stays paired with the appended tool_result.
+		// When a checkpoint thinking block with a valid signature is stripped (abandoned
+		// tool-use), the block is dropped entirely — not demoted to text. Demotion would
+		// trigger the reasoning_extraction safety classifier and cause model refusals.
+		// The tool_use stays paired with the appended tool_result.
 		const checkpointBlocks = assistantBlocksAt(params, 0);
-		expect(checkpointBlocks.some(b => b.type === "text" && b.text?.includes("Checkpoint first"))).toBe(true);
 		expect(checkpointBlocks.some(b => b.type === "thinking")).toBe(false);
 		expect(checkpointBlocks.some(b => b.type === "tool_use" && b.id === "toolu_ckpt")).toBe(true);
 	});

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -350,6 +350,53 @@ describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
 		}
 	});
 
+	it("drops same-model Anthropic thinking blocks with undefined signatures (regression test for 018b3dc61, restoring 93996bc48)", () => {
+		// Regression: commit 018b3dc61 narrowed the drop guard to catch only
+		// empty-string signatures, but same-model thinking blocks from aborted
+		// or prior turns may have undefined signatures (marked by the
+		// untrustworthy-turn recovery at :410-414). These must also be dropped,
+		// not demoted to text, because demotion triggers the reasoning_extraction
+		// safety classifier and causes hard refusals from Fable 5 and Opus 4.8.
+		for (const modelCase of [
+			{ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+			{ id: "claude-fable-5", name: "Claude Fable 5" },
+		]) {
+			const target = makeAnthropicModel({
+				provider: "anthropic",
+				id: modelCase.id,
+				name: modelCase.name,
+				baseUrl: "https://api.anthropic.com",
+			});
+			const reasoning = `Internal reasoning that should not leak for ${modelCase.id}.`;
+			const toolCallId = `toolu_${modelCase.id.replaceAll("-", "_")}`;
+			const messages: Message[] = [
+				makeUser("Fix the layout"),
+				makeAssistant(
+					[
+						{ type: "thinking", thinking: reasoning, thinkingSignature: undefined },
+						{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "src/view.ts" } },
+					],
+					{ provider: "anthropic", model: modelCase.id },
+				),
+				toolResult(toolCallId, "view body"),
+				makeUser("Continue."),
+			];
+
+			const params = convertAnthropicMessages(messages, target, false);
+			const assistant = params.find(p => p.role === "assistant");
+			if (!assistant) throw new Error("expected assistant wire message");
+			const blocks = assistant.content as WireBlock[];
+			// Must not produce a native thinking block
+			expect(blocks.find(b => b.type === "thinking")).toBeUndefined();
+			// Must not demote to text (neither <thinking> tags nor plain text containing the reasoning)
+			const textBlocks = blocks.filter((b): b is WireTextBlock => b.type === "text");
+			expect(textBlocks).toHaveLength(0);
+			// Tool call must still be present
+			const toolUse = blocks.find(b => b.type === "tool_use") as WireToolUseBlock | undefined;
+			expect(toolUse?.id).toBe(toolCallId);
+		}
+	});
+
 	it("strips official Anthropic source signatures on cross-model replay to a 3p target", () => {
 		// official Anthropic → 3p. Anthropic's signature is bound to the
 		// issuing model+session, so the 3p target cannot reverify or

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -641,10 +641,15 @@ describe("anthropic stream envelope handling", () => {
 			model,
 			false,
 		);
+		// The unwrapped thinking block carries no signature. On same-model replay to
+		// signature-enforcing Anthropic an unsigned thinking block is dropped entirely — it cannot
+		// replay natively (a "" signature 400s) and must not be demoted to text (demotion trips the
+		// reasoning_extraction classifier). It was this turn's only content, so the whole assistant
+		// message falls away, leaving just the two surrounding user turns with no leaked reasoning.
 		const replayAssistant = replayParams.find(param => param.role === "assistant");
-		expect(replayAssistant?.content).toEqual([
-			{ type: "text", text: "<thinking>\nCheck logs before accepting container health.\n</thinking>" },
-		]);
+		expect(replayAssistant).toBeUndefined();
+		expect(replayParams.map(param => param.role)).toEqual(["user", "user"]);
+		expect(replayParams.every(param => !JSON.stringify(param.content).includes("Check logs"))).toBe(true);
 	});
 	it("preserves signed thinking bytes when no literal thinking envelope is present", async () => {
 		const signedThinking = "\nCheck logs before accepting container health.\n";

--- a/packages/ai/test/anthropic-zenmux-checkpoint-thinking-signature.test.ts
+++ b/packages/ai/test/anthropic-zenmux-checkpoint-thinking-signature.test.ts
@@ -17,9 +17,12 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
  * see the catalog compat regression test). This pins the consequence: when a
  * checkpoint/branch-return turn is an abandoned tool-use turn (adaptive Sonnet
  * emits a tool call then ends on `stop`), the transform strips its
- * end_turn-bound signature and the encoder must DEGRADE the block to text —
- * never replay it as `{ signature: "" }`, which 400s the whole request with
- * `messages.1.content.0: Invalid signature in thinking` on every full re-send.
+ * end_turn-bound signature. Since the turn is same-model with an invalid
+ * (undefined) signature, the thinking block is dropped entirely — never emitted
+ * as `{ signature: "" }` (which would 400 the whole request with
+ * `messages.1.content.0: Invalid signature in thinking`) and never demoted to
+ * text (which would trigger the reasoning_extraction classifier and cause
+ * refusals).
  *
  * The signing classification is asserted directly in
  * `packages/catalog/test/anthropic-zenmux-signing-compat.test.ts`; this file
@@ -131,10 +134,12 @@ describe("#4192 zenmux checkpoint/branch-return thinking signature", () => {
 			expect(block.signature && block.signature.length > 0).toBeTruthy();
 		}
 
-		// The stripped checkpoint thinking is preserved as text (reasoning not silently lost),
-		// and its tool_use stays paired with the appended tool_result.
+		// When a checkpoint thinking block with a valid signature is stripped (abandoned
+		// tool-use), the block is dropped entirely — not demoted to text. Demotion would
+		// trigger the reasoning_extraction safety classifier and cause model refusals.
+		// The tool_use stays paired with the appended tool_result.
 		const checkpointBlocks = assistantBlocksAt(params, 0);
-		expect(checkpointBlocks.some(b => b.type === "text" && b.text?.includes("Checkpoint first"))).toBe(true);
+		expect(checkpointBlocks.some(b => b.type === "text" && b.text?.includes("Checkpoint first"))).toBe(false);
 		expect(checkpointBlocks.some(b => b.type === "thinking")).toBe(false);
 		expect(checkpointBlocks.some(b => b.type === "tool_use" && b.id === "toolu_ckpt")).toBe(true);
 	});


### PR DESCRIPTION
## Problem

Anthropic Claude models leak prior-turn reasoning into the visible response text, and Claude Fable 5 throws a `Refusal (reasoning_extraction)` — Anthropic's own docs name this as a distinct refusal category:

> "The request asks the model to reproduce its internal reasoning in the response text. To get reasoning in a structured form instead, use adaptive thinking."

## Root cause

On the outbound request rebuild (`convertAnthropicMessages` → `transformMessages`), a same-model Anthropic `thinking` block with no valid replayable signature should be **dropped**, not demoted into visible text. The guard at `transform-messages.ts` originally caught both `thinkingSignature === undefined` and `thinkingSignature === ""` (commit 93996bc48), but a later "simplification" (commit 018b3dc61) narrowed it to only catch `""`. `undefined`-signature blocks then fell through to text-demotion, and for non-Fable Claude models that demoted text is wrapped in `<thinking>…</thinking>` tags — exactly the shape Anthropic's `reasoning_extraction` classifier flags.

`undefined` signatures arise routinely: `unwrapAnthropicThinkingEnvelope` resets the signature to `undefined` whenever a model's own thinking content already contains a `<thinking>` envelope, and the official-endpoint healer exemption (`stream.ts`) doesn't clean those envelopes for first-party Anthropic — so the leak is largely self-reinforcing once triggered.

## Fix

Widen the guard back to catch both `undefined` and `""` signatures, restoring `93996bc48`'s original intent. A same-model thinking block that can't be natively replayed (no valid signature → the API would 400 on replay anyway) is dropped entirely instead of being demoted.

This also updates every test that was asserting the old demote-to-text contract for this same-model dropped-block scenario (checkpoint-thinking tests for two signing-endpoint variants, abandoned-tool-use replay tests, and a stream-envelope replay test whose assistant turn now legitimately vanishes once its only content is dropped, via the pre-existing empty-content-turn guard) — running the full `packages/ai` suite surfaced these as a direct, correct consequence of the guard change.

## Verification

```
cd packages/ai && bun run check   # biome + tsgo --noEmit: clean
cd packages/ai && bun test --parallel
# 2644 pass, 337 skip, 0 fail, 7816 expect() calls (this branch alone)
```

## Companion PR and a merge-order note

#4429 is a defense-in-depth companion (generalizes `demotion.ts`'s bare-prose handling from Fable-only to the whole Anthropic dialect family) for the residual cross-model demotion path this PR doesn't reach. The two are independently mergeable in either order, but they touch two of the same test assertions (`anthropic-abandoned-tooluse-replay.test.ts`, `anthropic-stream-envelope.test.ts`) with different — individually correct — rewrites, since each PR alone produces a different valid outcome for the same signature-stripped-block scenario (dropped here; demoted-as-bare-prose there). If both land, expect a small 2-line conflict on those two files; this PR's assertions (`block dropped entirely`) are the correct ones to keep for the combined state, since this guard runs before `demotion.ts` is ever reached.

Closes #4428
