### PR TITLE
fix(ai): restore drop guard for undefined thinking signatures

### DIFF
--- a/packages/ai/src/dialect/demotion.ts
+++ b/packages/ai/src/dialect/demotion.ts
@@ -1,7 +1,5 @@
-import { bareModelId, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
+import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { getDialectDefinition } from "./factory";
-
-const CLAUDE_FABLE_ID = /(?:^|[./])claude[-.]fable(?:[-.]|$)/i;
 
 /**
  * Wrap a prior-turn reasoning string for demotion into native conversation
@@ -10,12 +8,13 @@ const CLAUDE_FABLE_ID = /(?:^|[./])claude[-.]fable(?:[-.]|$)/i;
  * replayed unsigned `thought` part is schema-accepted but silently discarded —
  * neither recalled nor influencing generation).
  *
- * Fable is the exception: Anthropic's `reasoning_extraction` classifier blocks
+ * The Anthropic dialect (all Claude models: Opus, Sonnet, Haiku, Fable, Mythos,
+ * etc.) is an exception: Anthropic's `reasoning_extraction` classifier blocks
  * requests that replay prior reasoning inside `<thinking>` / `antml:thinking`
  * tags OR the older `_Hmm. …_` italic envelope — it reads the wrapped
  * chain-of-thought as an attempt to duplicate model outputs and refuses the
- * whole turn. Fable therefore receives prior reasoning as bare assistant prose:
- * no tag, no `_Hmm.` wrapper, no trailing newline.
+ * whole turn. Claude models therefore always receive prior reasoning as bare
+ * assistant prose: no tag, no `_Hmm.` wrapper, no trailing newline.
  * Heat is cumulative (block count and early-conversation position also raise
  * it), so this lowers per-block signal but does not license unbounded replay.
  * Harmony and Gemma are also exceptions: their `renderThinking` emits
@@ -33,9 +32,8 @@ const CLAUDE_FABLE_ID = /(?:^|[./])claude[-.]fable(?:[-.]|$)/i;
 export function renderDemotedThinking(modelId: string, text: string): string {
 	if (!text) return "";
 	text = text.toWellFormed();
-	const canonicalId = bareModelId(modelId);
 	const dialect = preferredDialect(modelId);
-	if (CLAUDE_FABLE_ID.test(canonicalId)) return text;
+	if (dialect === "anthropic") return text;
 	if (dialect === "harmony" || dialect === "gemma") return `<think>\n${text}\n</think>`;
 	return getDialectDefinition(dialect).renderThinking(text);
 }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -3103,12 +3103,18 @@ function buildParams(
 	forceDemoteUnsignedThinking = false,
 ): MessageCreateParamsStreaming {
 	// A session-scoped auto-demote (learned from a live signing 400) clones the
-	// resolved compat with `replayUnsignedThinking: false` so every subsequent
-	// downstream read (convertAnthropicMessages, transformMessages) sees the
-	// demoted default without mutating the shared `model` reference.
+	// resolved compat with `replayUnsignedThinking: false` AND `signingEndpoint: true`
+	// so every subsequent downstream read (`convertAnthropicMessages`,
+	// `transformMessages`) sees both the demoted default and the signing
+	// policy without mutating the shared `model` reference. Leaving
+	// `signingEndpoint` false would skip the same-model unsigned-thinking
+	// drop guard in `transformMessages`, and the block would silently fall
+	// through to `renderDemotedThinking` — leaking the private reasoning as
+	// visible assistant text and adding cumulative `reasoning_extraction`
+	// heat on Claude targets (#4428).
 	const effectiveModel =
 		forceDemoteUnsignedThinking && model.compat.replayUnsignedThinking
-			? { ...model, compat: { ...model.compat, replayUnsignedThinking: false } }
+			? { ...model, compat: { ...model.compat, replayUnsignedThinking: false, signingEndpoint: true } }
 			: model;
 	const { cacheControl } = getCacheControl(model, options?.cacheRetention, isOAuthToken);
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1382,6 +1382,20 @@ function dropOpenRouterKimiForcedToolReasoning(
 	}
 }
 
+/** Flattens assistant text blocks for Chat Completions without merging internal block boundaries. */
+export function flattenOpenAICompletionsAssistantTextBlocks(blocks: readonly TextContent[]): string | null {
+	const nonEmptyTextBlocks = blocks
+		.map(block => block.text.toWellFormed())
+		.filter(text => text.trim().length > 0);
+	if (nonEmptyTextBlocks.length === 0) return null;
+	let text = nonEmptyTextBlocks[0]!;
+	for (const blockText of nonEmptyTextBlocks.slice(1)) {
+		const alreadySeparated = /\s$/u.test(text) || /^\s/u.test(blockText);
+		text += `${alreadySeparated ? "" : "\n\n"}${blockText}`;
+	}
+	return text;
+}
+
 function buildParams(
 	model: Model<"openai-completions">,
 	context: Context,
@@ -1771,14 +1785,18 @@ export function convertMessages(
 				content: null,
 			};
 
-			const textBlocks = msg.content.filter(b => b.type === "text") as TextContent[];
-			// Filter out empty text blocks to avoid API validation errors
-			const nonEmptyTextBlocks = textBlocks.filter(b => b.text && b.text.trim().length > 0);
-			if (nonEmptyTextBlocks.length > 0) {
+			const flattenedText = flattenOpenAICompletionsAssistantTextBlocks(
+				msg.content.filter((b): b is TextContent => b.type === "text"),
+			);
+			if (flattenedText !== null) {
 				// Always send assistant content as a plain string. Some OpenAI-compatible
 				// backends mirror array-of-text-block payloads back to the model literally,
-				// causing recursive nested content in subsequent turns.
-				assistantMsg.content = nonEmptyTextBlocks.map(b => b.text.toWellFormed()).join("");
+				// causing recursive nested content in subsequent turns. Preserve a hard
+				// boundary between adjacent internal text blocks: cross-provider demotion
+				// can place bare Anthropic reasoning immediately before the assistant's
+				// original visible answer, and concatenating with `""` produces
+				// `reasoningFinal answer`.
+				assistantMsg.content = flattenedText;
 			}
 
 			// Handle thinking blocks

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1384,9 +1384,7 @@ function dropOpenRouterKimiForcedToolReasoning(
 
 /** Flattens assistant text blocks for Chat Completions without merging internal block boundaries. */
 export function flattenOpenAICompletionsAssistantTextBlocks(blocks: readonly TextContent[]): string | null {
-	const nonEmptyTextBlocks = blocks
-		.map(block => block.text.toWellFormed())
-		.filter(text => text.trim().length > 0);
+	const nonEmptyTextBlocks = blocks.map(block => block.text.toWellFormed()).filter(text => text.trim().length > 0);
 	if (nonEmptyTextBlocks.length === 0) return null;
 	let text = nonEmptyTextBlocks[0]!;
 	for (const blockText of nonEmptyTextBlocks.slice(1)) {

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -437,13 +437,15 @@ export function transformMessages<TApi extends Api>(
 							return [];
 						}
 						// Same-model Anthropic replay to a signature-enforcing endpoint
-						// cannot natively replay thinking blocks whose source explicitly
-						// recorded an empty signature, but this is not a dialect
-						// transition. Do not demote that sentinel into the target model's
-						// textual thinking dialect; keep demotion for signatures stripped
-						// by the untrustworthy-turn recovery above and for literal thinking
-						// envelopes that never carried a signature field.
-						if (isSameModel && isSigningAnthropicTarget && sanitized.thinkingSignature?.trim() === "") {
+						// requires valid signatures to natively replay thinking blocks.
+						// Both undefined and empty string signatures are invalid and must
+						// be dropped entirely — not demoted to text. Demotion would cause
+						// the reasoning_extraction safety classifier to refuse the response.
+						if (
+							isSameModel &&
+							isSigningAnthropicTarget &&
+							(!sanitized.thinkingSignature || sanitized.thinkingSignature.trim() === "")
+						) {
 							return [];
 						}
 						return sanitized;

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -418,7 +418,6 @@ export function transformMessages<TApi extends Api>(
 					return !replaySignature || replaySignature.trim() === "";
 				});
 
-
 			const transformedContent = assistantMsg.content.flatMap((block, blockIndex) => {
 				if (block.type === "thinking") {
 					// Only an aborted/errored turn's final (mid-stream) block can hold a

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -402,21 +402,29 @@ export function transformMessages<TApi extends Api>(
 				assistantMsg.content.some(b => b.type === "toolCall");
 			const lastBlockIndex = assistantMsg.content.length - 1;
 
-			const dropsSameModelUnsignedThinking =
+			const anthropicVisibleThinkingSurvivesReplay = (candidate: AssistantMessage["content"][number], candidateIndex: number) => {
+				if (candidate.type !== "thinking") return false;
+				if (!isAnthropicReplay) return false;
+				if (isLatestSurvivingAssistant && abandonedToolUse) return true;
+				const candidateSignatureUntrustworthy =
+					abandonedToolUse || (invalidStopReason && candidateIndex === lastBlockIndex);
+				const replaySignature =
+					candidateSignatureUntrustworthy && candidate.thinkingSignature
+						? undefined
+						: candidate.thinkingSignature;
+				if (!replaySignature && (!candidate.thinking || candidate.thinking.trim() === "")) return false;
+				if (isSameModel && isSigningAnthropicTarget && (!replaySignature || replaySignature.trim() === "")) {
+					return false;
+				}
+				return true;
+			};
+			const hasVisibleThinking = assistantMsg.content.some(candidate => candidate.type === "thinking");
+			const dropsAllSameModelVisibleThinking =
 				isAnthropicReplay &&
 				isSameModel &&
 				isSigningAnthropicTarget &&
-				!(isLatestSurvivingAssistant && abandonedToolUse) &&
-				assistantMsg.content.some((candidate, candidateIndex) => {
-					if (candidate.type !== "thinking") return false;
-					const candidateSignatureUntrustworthy =
-						abandonedToolUse || (invalidStopReason && candidateIndex === lastBlockIndex);
-					const replaySignature =
-						candidateSignatureUntrustworthy && candidate.thinkingSignature
-							? undefined
-							: candidate.thinkingSignature;
-					return !replaySignature || replaySignature.trim() === "";
-				});
+				hasVisibleThinking &&
+				!assistantMsg.content.some(anthropicVisibleThinkingSurvivesReplay);
 
 			const transformedContent = assistantMsg.content.flatMap((block, blockIndex) => {
 				if (block.type === "thinking") {
@@ -504,11 +512,11 @@ export function transformMessages<TApi extends Api>(
 					// Redacted thinking is native-only. Keep it for same-model
 					// signed replay, the latest byte-for-byte Anthropic turn, or
 					// compatible targets that will also emit sibling unsigned
-					// thinking natively. Drop it whenever the visible thinking from
-					// this same-model turn was discarded, and when cross-model
-					// stripped visible thinking will be demoted to text.
+					// thinking natively. Drop it only when every visible thinking
+					// block from this same-model turn was discarded, and when
+					// cross-model stripped visible thinking will be demoted to text.
 					if (isAnthropicReplay) {
-						if (dropsSameModelUnsignedThinking) return [];
+						if (dropsAllSameModelVisibleThinking) return [];
 						if (isSameModel || isLatestSurvivingAssistant || replaysUnsignedAnthropicThinking) return block;
 						return [];
 					}

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -402,16 +402,17 @@ export function transformMessages<TApi extends Api>(
 				assistantMsg.content.some(b => b.type === "toolCall");
 			const lastBlockIndex = assistantMsg.content.length - 1;
 
-			const anthropicVisibleThinkingSurvivesReplay = (candidate: AssistantMessage["content"][number], candidateIndex: number) => {
+			const anthropicVisibleThinkingSurvivesReplay = (
+				candidate: AssistantMessage["content"][number],
+				candidateIndex: number,
+			) => {
 				if (candidate.type !== "thinking") return false;
 				if (!isAnthropicReplay) return false;
 				if (isLatestSurvivingAssistant && abandonedToolUse) return true;
 				const candidateSignatureUntrustworthy =
 					abandonedToolUse || (invalidStopReason && candidateIndex === lastBlockIndex);
 				const replaySignature =
-					candidateSignatureUntrustworthy && candidate.thinkingSignature
-						? undefined
-						: candidate.thinkingSignature;
+					candidateSignatureUntrustworthy && candidate.thinkingSignature ? undefined : candidate.thinkingSignature;
 				if (!replaySignature && (!candidate.thinking || candidate.thinking.trim() === "")) return false;
 				if (isSameModel && isSigningAnthropicTarget && (!replaySignature || replaySignature.trim() === "")) {
 					return false;

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -402,6 +402,23 @@ export function transformMessages<TApi extends Api>(
 				assistantMsg.content.some(b => b.type === "toolCall");
 			const lastBlockIndex = assistantMsg.content.length - 1;
 
+			const dropsSameModelUnsignedThinking =
+				isAnthropicReplay &&
+				isSameModel &&
+				isSigningAnthropicTarget &&
+				!(isLatestSurvivingAssistant && abandonedToolUse) &&
+				assistantMsg.content.some((candidate, candidateIndex) => {
+					if (candidate.type !== "thinking") return false;
+					const candidateSignatureUntrustworthy =
+						abandonedToolUse || (invalidStopReason && candidateIndex === lastBlockIndex);
+					const replaySignature =
+						candidateSignatureUntrustworthy && candidate.thinkingSignature
+							? undefined
+							: candidate.thinkingSignature;
+					return !replaySignature || replaySignature.trim() === "";
+				});
+
+
 			const transformedContent = assistantMsg.content.flatMap((block, blockIndex) => {
 				if (block.type === "thinking") {
 					// Only an aborted/errored turn's final (mid-stream) block can hold a
@@ -488,9 +505,11 @@ export function transformMessages<TApi extends Api>(
 					// Redacted thinking is native-only. Keep it for same-model
 					// signed replay, the latest byte-for-byte Anthropic turn, or
 					// compatible targets that will also emit sibling unsigned
-					// thinking natively. Drop it when the visible thinking was
-					// cross-model stripped and will be demoted to text.
+					// thinking natively. Drop it whenever the visible thinking from
+					// this same-model turn was discarded, and when cross-model
+					// stripped visible thinking will be demoted to text.
 					if (isAnthropicReplay) {
+						if (dropsSameModelUnsignedThinking) return [];
 						if (isSameModel || isLatestSurvivingAssistant || replaysUnsignedAnthropicThinking) return block;
 						return [];
 					}

--- a/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
+++ b/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
@@ -123,13 +123,17 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 
-	it("downgrades historical end_turn(stop) tool-use thinking to text so the continuation stays wire-valid", () => {
+	it("drops historical end_turn(stop) tool-use thinking so the continuation stays wire-valid", () => {
 		const blocks = assistantBlocks(buildHistoryWithLaterAssistant("stop", "sig_valid"));
 		expectNoUnsignedThinking(blocks);
-		// Signature stripped (historical abandoned tool-use) -> encoder downgrades to text.
+		// Signature stripped (historical same-model abandoned tool-use) -> the thinking block is
+		// dropped entirely, never demoted to text. Demotion would trip the reasoning_extraction
+		// classifier; the reasoning is the model's own prior chain and is not replayed as prose.
 		expect(blocks.some(b => b.type === "thinking")).toBe(false);
-		expect(blocks.some(b => b.type === "text" && b.text?.includes("deliberating"))).toBe(true);
-		// tool_use is preserved so it still pairs with the appended tool_result.
+		expect(blocks.some(b => b.type === "text" && b.text?.includes("deliberating"))).toBe(false);
+		// The turn's other content survives (visible text + tool_use), so the tool_use still pairs
+		// with the appended tool_result and the continuation stays wire-valid.
+		expect(blocks.some(b => b.type === "text" && b.text === "I'll check the weather.")).toBe(true);
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 
@@ -156,7 +160,10 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expectNoUnsignedThinking(blocks);
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "sig_done")).toBe(true);
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "trunc")).toBe(false);
-		expect(blocks.some(b => b.type === "text" && b.text === "<thinking>\nnow decide\n</thinking>")).toBe(true);
+		// The stripped mid-stream block is dropped entirely, not demoted to text: same-model replay
+		// to signature-enforcing Anthropic never emits demoted thinking (it would trip the
+		// reasoning_extraction classifier). Only the earlier fully-signed block replays natively.
+		expect(blocks.some(b => b.type === "text" && b.text?.includes("now decide"))).toBe(false);
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 

--- a/packages/ai/test/anthropic-copilot-checkpoint-thinking-signature.test.ts
+++ b/packages/ai/test/anthropic-copilot-checkpoint-thinking-signature.test.ts
@@ -16,9 +16,11 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
  * SIGNING endpoint (`replayUnsignedThinking: false` — see the catalog compat
  * regression test). This pins the consequence: when a checkpoint/branch-return
  * turn is an abandoned tool-use turn (adaptive Opus emits a tool call then ends
- * on `stop`), the transform strips its end_turn-bound signature and the encoder
- * must DEGRADE the block to text — never replay it as `{ signature: "" }`, which
- * 400s the whole request with "Invalid signature" on every full re-send.
+ * on `stop`), the transform strips its end_turn-bound signature. Since the turn
+ * is same-model with an invalid (undefined) signature, the thinking block is
+ * dropped entirely — never emitted as `{ signature: "" }` (which would 400 the
+ * request with "Invalid signature") and never demoted to text (which would
+ * trigger the reasoning_extraction safety classifier and cause refusals).
  *
  * The signing classification is asserted directly in
  * `packages/catalog/test/anthropic-copilot-signing-compat.test.ts`; the explicit
@@ -132,10 +134,11 @@ describe("#2851 github-copilot checkpoint/branch-return thinking signature", () 
 			expect(block.signature && block.signature.length > 0).toBeTruthy();
 		}
 
-		// The stripped checkpoint thinking is preserved as text (reasoning not silently lost),
-		// and its tool_use stays paired with the appended tool_result.
+		// When a checkpoint thinking block with a valid signature is stripped (abandoned
+		// tool-use), the block is dropped entirely — not demoted to text. Demotion would
+		// trigger the reasoning_extraction safety classifier and cause model refusals.
+		// The tool_use stays paired with the appended tool_result.
 		const checkpointBlocks = assistantBlocksAt(params, 0);
-		expect(checkpointBlocks.some(b => b.type === "text" && b.text?.includes("Checkpoint first"))).toBe(true);
 		expect(checkpointBlocks.some(b => b.type === "thinking")).toBe(false);
 		expect(checkpointBlocks.some(b => b.type === "tool_use" && b.id === "toolu_ckpt")).toBe(true);
 	});

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -350,6 +350,53 @@ describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
 		}
 	});
 
+	it("drops same-model Anthropic thinking blocks with undefined signatures (regression test for 018b3dc61, restoring 93996bc48)", () => {
+		// Regression: commit 018b3dc61 narrowed the drop guard to catch only
+		// empty-string signatures, but same-model thinking blocks from aborted
+		// or prior turns may have undefined signatures (marked by the
+		// untrustworthy-turn recovery at :410-414). These must also be dropped,
+		// not demoted to text, because demotion triggers the reasoning_extraction
+		// safety classifier and causes hard refusals from Fable 5 and Opus 4.8.
+		for (const modelCase of [
+			{ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+			{ id: "claude-fable-5", name: "Claude Fable 5" },
+		]) {
+			const target = makeAnthropicModel({
+				provider: "anthropic",
+				id: modelCase.id,
+				name: modelCase.name,
+				baseUrl: "https://api.anthropic.com",
+			});
+			const reasoning = `Internal reasoning that should not leak for ${modelCase.id}.`;
+			const toolCallId = `toolu_${modelCase.id.replaceAll("-", "_")}`;
+			const messages: Message[] = [
+				makeUser("Fix the layout"),
+				makeAssistant(
+					[
+						{ type: "thinking", thinking: reasoning, thinkingSignature: undefined },
+						{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "src/view.ts" } },
+					],
+					{ provider: "anthropic", model: modelCase.id },
+				),
+				toolResult(toolCallId, "view body"),
+				makeUser("Continue."),
+			];
+
+			const params = convertAnthropicMessages(messages, target, false);
+			const assistant = params.find(p => p.role === "assistant");
+			if (!assistant) throw new Error("expected assistant wire message");
+			const blocks = assistant.content as WireBlock[];
+			// Must not produce a native thinking block
+			expect(blocks.find(b => b.type === "thinking")).toBeUndefined();
+			// Must not demote to text (neither <thinking> tags nor plain text containing the reasoning)
+			const textBlocks = blocks.filter((b): b is WireTextBlock => b.type === "text");
+			expect(textBlocks).toHaveLength(0);
+			// Tool call must still be present
+			const toolUse = blocks.find(b => b.type === "tool_use") as WireToolUseBlock | undefined;
+			expect(toolUse?.id).toBe(toolCallId);
+		}
+	});
+
 	it("strips official Anthropic source signatures on cross-model replay to a 3p target", () => {
 		// official Anthropic → 3p. Anthropic's signature is bound to the
 		// issuing model+session, so the 3p target cannot reverify or

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -450,6 +450,48 @@ describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
 		expect(toolUse?.id).toBe(toolCallId);
 	});
 
+	it("keeps redacted siblings when signed same-model thinking survives beside a discarded final block", () => {
+		// Error/aborted turns strip only the final in-flight thinking block.
+		// Earlier completed signed thinking still survives replay, so its
+		// redacted sibling must survive too; dropping every redacted block just
+		// because one later visible thinking block was discarded violates
+		// Anthropic's all-thinking-blocks replay contract in the opposite
+		// direction.
+		const target = makeAnthropicModel({
+			provider: "anthropic",
+			id: "claude-sonnet-4-6",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const messages: Message[] = [
+			makeUser("Fix the layout"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "Completed signed reasoning.", thinkingSignature: "sig_complete" },
+					{ type: "redactedThinking", data: "encrypted-complete-sibling" },
+					{ type: "text", text: "Visible anchor." },
+					{ type: "thinking", thinking: "Partial final reasoning.", thinkingSignature: "sig_partial" },
+				],
+				{
+					provider: "anthropic",
+					model: "claude-sonnet-4-6",
+					stopReason: "error",
+				},
+			),
+			makeUser("Continue."),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistant = params.find(p => p.role === "assistant");
+		if (!assistant) throw new Error("expected assistant wire message");
+		const blocks = assistant.content as WireBlock[];
+		const thinking = blocks.find(b => b.type === "thinking") as WireThinkingBlock | undefined;
+		expect(thinking?.thinking).toBe("Completed signed reasoning.");
+		expect(thinking?.signature).toBe("sig_complete");
+		const redacted = blocks.find(b => b.type === "redacted_thinking") as WireRedactedBlock | undefined;
+		expect(redacted?.data).toBe("encrypted-complete-sibling");
+		expect(blocks.some(b => b.type === "thinking" && b.thinking === "Partial final reasoning.")).toBe(false);
+	});
+
 	it("drops same-model unsigned thinking when the runtime clone flips signingEndpoint after a signing 400 (#4428 review)", () => {
 		// When `buildParams` detects a signing proxy at runtime (via the `400
 		// Invalid signature in thinking block` retry path), it clones the model

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -397,6 +397,60 @@ describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
 		}
 	});
 
+	it("drops same-model unsigned thinking when the runtime clone flips signingEndpoint after a signing 400 (#4428 review)", () => {
+		// When `buildParams` detects a signing proxy at runtime (via the `400
+		// Invalid signature in thinking block` retry path), it clones the model
+		// compat with `replayUnsignedThinking: false` AND `signingEndpoint: true`.
+		// The `signingEndpoint` flip is load-bearing: without it,
+		// `transformMessages` would keep the unsigned block, then
+		// `convertAnthropicMessages` would demote it to text via
+		// `renderDemotedThinking`, leaking the private reasoning as visible
+		// assistant prose and adding cumulative `reasoning_extraction` heat
+		// on Claude targets. This test pins the drop behavior against the
+		// effective (runtime-cloned) compat shape.
+		// Mirror the exact clone shape produced by `buildParams` when the
+		// signing 400 fires: preserve every resolved compat field, then flip
+		// `replayUnsignedThinking → false` and `signingEndpoint → true`.
+		// `signingEndpoint` is a *resolved* field (not part of the sparse
+		// `AnthropicCompat` override), so this cannot be expressed through
+		// `buildModel({ compat: … })`; the post-override cast is the same
+		// pattern `buildParams` uses at runtime.
+		const base = makeAnthropicModel({
+			provider: "custom-anthropic",
+			id: "reasoning-model",
+			baseUrl: "https://opencode.cloudflare.dev/anthropic",
+		});
+		const target: Model<"anthropic-messages"> = {
+			...base,
+			compat: { ...base.compat, replayUnsignedThinking: false, signingEndpoint: true },
+		};
+		const reasoning = "Private reasoning that must not leak after auto-mark.";
+		const toolCallId = "toolu_autopin";
+		const messages: Message[] = [
+			makeUser("Fix the layout"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: reasoning, thinkingSignature: undefined },
+					{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "src/view.ts" } },
+				],
+				{},
+			),
+			toolResult(toolCallId, "view body"),
+			makeUser("Continue."),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistant = params.find(p => p.role === "assistant");
+		if (!assistant) throw new Error("expected assistant wire message");
+		const blocks = assistant.content as WireBlock[];
+		// Native thinking dropped, no demoted-text carrier, tool call preserved.
+		expect(blocks.find(b => b.type === "thinking")).toBeUndefined();
+		const textBlocks = blocks.filter((b): b is WireTextBlock => b.type === "text");
+		expect(textBlocks).toHaveLength(0);
+		const toolUse = blocks.find(b => b.type === "tool_use") as WireToolUseBlock | undefined;
+		expect(toolUse?.id).toBe(toolCallId);
+	});
+
 	it("strips official Anthropic source signatures on cross-model replay to a 3p target", () => {
 		// official Anthropic → 3p. Anthropic's signature is bound to the
 		// issuing model+session, so the 3p target cannot reverify or

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -397,6 +397,59 @@ describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
 		}
 	});
 
+	it("drops redacted siblings when same-model abandoned-tool-use thinking is discarded", () => {
+		// Abandoned tool-use turns strip every thinking signature before replay.
+		// If the same-model signing-target guard then drops that visible
+		// thinking block, its redacted sibling must be dropped too; replaying a
+		// lone `redacted_thinking` block violates Anthropic's all-thinking-blocks
+		// contract for that assistant turn.
+		const target = makeAnthropicModel({
+			provider: "anthropic",
+			id: "claude-sonnet-4-6",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const toolCallId = "toolu_abandoned";
+		const messages: Message[] = [
+			makeUser("Fix the layout"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "Private discarded reasoning.", thinkingSignature: "sig_dropped" },
+					{ type: "redactedThinking", data: "encrypted-sibling" },
+					{ type: "toolCall", id: toolCallId, name: "read", arguments: { path: "src/view.ts" } },
+				],
+				{
+					provider: "anthropic",
+					model: "claude-sonnet-4-6",
+					stopReason: "stop",
+				},
+			),
+			toolResult(toolCallId, "view body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "Later signed reasoning.", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "Done." },
+				],
+				{
+					provider: "anthropic",
+					model: "claude-sonnet-4-6",
+					stopReason: "stop",
+				},
+			),
+			makeUser("Continue."),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistant = params.find(p => p.role === "assistant");
+		if (!assistant) throw new Error("expected assistant wire message");
+		const blocks = assistant.content as WireBlock[];
+		expect(blocks.find(b => b.type === "thinking")).toBeUndefined();
+		expect(blocks.find(b => b.type === "redacted_thinking")).toBeUndefined();
+		const textBlocks = blocks.filter((b): b is WireTextBlock => b.type === "text");
+		expect(textBlocks).toHaveLength(0);
+		const toolUse = blocks.find(b => b.type === "tool_use") as WireToolUseBlock | undefined;
+		expect(toolUse?.id).toBe(toolCallId);
+	});
+
 	it("drops same-model unsigned thinking when the runtime clone flips signingEndpoint after a signing 400 (#4428 review)", () => {
 		// When `buildParams` detects a signing proxy at runtime (via the `400
 		// Invalid signature in thinking block` retry path), it clones the model

--- a/packages/ai/test/anthropic-signature-auto-mark.test.ts
+++ b/packages/ai/test/anthropic-signature-auto-mark.test.ts
@@ -154,7 +154,7 @@ describe("#4297 anthropic-messages runtime signing auto-mark", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("demotes unsigned thinking, retries, and pins the session on the first signing 400", async () => {
+	it("drops unsigned thinking, retries, and pins the session on the first signing 400", async () => {
 		const providerSessionState = new Map<string, ProviderSessionState>();
 		const capturedPayloads: unknown[] = [];
 		let attempt = 0;
@@ -190,16 +190,22 @@ describe("#4297 anthropic-messages runtime signing auto-mark", () => {
 		expect(firstThinking?.signature).toBe("");
 		expect(firstThinking?.thinking).toBe("Read the file, then summarise.");
 
+		// After auto-mark the runtime clone flips `signingEndpoint: true`, so
+		// `transformMessages` drops the unsigned same-model thinking block
+		// entirely instead of falling through to `renderDemotedThinking` (#4428
+		// review). The retry request carries the original reply text but no
+		// wire trace of the private reasoning.
 		const retryBlocks = extractPriorAssistantBlocks(capturedPayloads[1]);
 		expect(retryBlocks.find(block => block.type === "thinking")).toBeUndefined();
-		const demotedText = retryBlocks.find(block => block.type === "text");
-		expect(demotedText?.text).toContain("Read the file, then summarise.");
+		const retryText = retryBlocks.find(block => block.type === "text");
+		expect(retryText?.text).toBe("The README covers the CLI.");
+		expect(retryBlocks.some(block => block.type === "text" && !!block.text?.includes("Read the file"))).toBe(false);
 
 		expect(readReplayUnsignedThinkingDisabled(providerSessionState)).toBe(true);
 		expect(result.disabledFeatures).toContain("unsigned-thinking-replay");
 	});
 
-	it("pre-demotes unsigned thinking on subsequent turns once the session is pinned", async () => {
+	it("drops unsigned thinking on subsequent turns once the session is pinned", async () => {
 		const providerSessionState = new Map<string, ProviderSessionState>();
 		const capturedPayloads: unknown[] = [];
 		vi.spyOn(AnthropicMessages.prototype, "create").mockImplementation((params: unknown) => {
@@ -229,8 +235,13 @@ describe("#4297 anthropic-messages runtime signing auto-mark", () => {
 		expect(result.stopReason).toBe("stop");
 		expect(capturedPayloads.length).toBe(1);
 		const blocks = extractPriorAssistantBlocks(capturedPayloads[0]);
+		// Pinned session flips `signingEndpoint` in the runtime clone too, so
+		// unsigned same-model thinking is dropped in `transformMessages`
+		// instead of demoted to text by `convertAnthropicMessages` (#4428).
 		expect(blocks.find(block => block.type === "thinking")).toBeUndefined();
-		expect(blocks.find(block => block.type === "text")?.text).toContain("Read the file, then summarise.");
+		const replyText = blocks.find(block => block.type === "text");
+		expect(replyText?.text).toBe("The README covers the CLI.");
+		expect(blocks.some(block => block.type === "text" && !!block.text?.includes("Read the file"))).toBe(false);
 		expect(result.disabledFeatures).toContain("unsigned-thinking-replay");
 	});
 

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -641,10 +641,15 @@ describe("anthropic stream envelope handling", () => {
 			model,
 			false,
 		);
+		// The unwrapped thinking block carries no signature. On same-model replay to
+		// signature-enforcing Anthropic an unsigned thinking block is dropped entirely — it cannot
+		// replay natively (a "" signature 400s) and must not be demoted to text (demotion trips the
+		// reasoning_extraction classifier). It was this turn's only content, so the whole assistant
+		// message falls away, leaving just the two surrounding user turns with no leaked reasoning.
 		const replayAssistant = replayParams.find(param => param.role === "assistant");
-		expect(replayAssistant?.content).toEqual([
-			{ type: "text", text: "<thinking>\nCheck logs before accepting container health.\n</thinking>" },
-		]);
+		expect(replayAssistant).toBeUndefined();
+		expect(replayParams.map(param => param.role)).toEqual(["user", "user"]);
+		expect(replayParams.every(param => !JSON.stringify(param.content).includes("Check logs"))).toBe(true);
 	});
 	it("preserves signed thinking bytes when no literal thinking envelope is present", async () => {
 		const signedThinking = "\nCheck logs before accepting container health.\n";

--- a/packages/ai/test/anthropic-zenmux-checkpoint-thinking-signature.test.ts
+++ b/packages/ai/test/anthropic-zenmux-checkpoint-thinking-signature.test.ts
@@ -17,9 +17,12 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
  * see the catalog compat regression test). This pins the consequence: when a
  * checkpoint/branch-return turn is an abandoned tool-use turn (adaptive Sonnet
  * emits a tool call then ends on `stop`), the transform strips its
- * end_turn-bound signature and the encoder must DEGRADE the block to text —
- * never replay it as `{ signature: "" }`, which 400s the whole request with
- * `messages.1.content.0: Invalid signature in thinking` on every full re-send.
+ * end_turn-bound signature. Since the turn is same-model with an invalid
+ * (undefined) signature, the thinking block is dropped entirely — never emitted
+ * as `{ signature: "" }` (which would 400 the whole request with
+ * `messages.1.content.0: Invalid signature in thinking`) and never demoted to
+ * text (which would trigger the reasoning_extraction classifier and cause
+ * refusals).
  *
  * The signing classification is asserted directly in
  * `packages/catalog/test/anthropic-zenmux-signing-compat.test.ts`; this file
@@ -131,10 +134,12 @@ describe("#4192 zenmux checkpoint/branch-return thinking signature", () => {
 			expect(block.signature && block.signature.length > 0).toBeTruthy();
 		}
 
-		// The stripped checkpoint thinking is preserved as text (reasoning not silently lost),
-		// and its tool_use stays paired with the appended tool_result.
+		// When a checkpoint thinking block with a valid signature is stripped (abandoned
+		// tool-use), the block is dropped entirely — not demoted to text. Demotion would
+		// trigger the reasoning_extraction safety classifier and cause model refusals.
+		// The tool_use stays paired with the appended tool_result.
 		const checkpointBlocks = assistantBlocksAt(params, 0);
-		expect(checkpointBlocks.some(b => b.type === "text" && b.text?.includes("Checkpoint first"))).toBe(true);
+		expect(checkpointBlocks.some(b => b.type === "text" && b.text?.includes("Checkpoint first"))).toBe(false);
 		expect(checkpointBlocks.some(b => b.type === "thinking")).toBe(false);
 		expect(checkpointBlocks.some(b => b.type === "tool_use" && b.id === "toolu_ckpt")).toBe(true);
 	});

--- a/packages/ai/test/transform-messages-thinking-dialect.test.ts
+++ b/packages/ai/test/transform-messages-thinking-dialect.test.ts
@@ -130,14 +130,15 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 
 	it("renders demoted foreign reasoning as bare prose for all Anthropic-dialect Claude models", () => {
 		const targets = [
-			{ name: "Claude Opus", id: "claude-opus-4-8" },
-			{ name: "Claude Sonnet", id: "claude-sonnet-5" },
-			{ name: "Claude Fable", id: "claude-fable-5" },
-			{ name: "Claude Mythos", id: "claude-mythos-5" },
+			{ name: "Claude Opus", id: "claude-opus-4-8", provider: "anthropic" },
+			{ name: "Claude Sonnet", id: "claude-sonnet-5", provider: "anthropic" },
+			{ name: "Claude Fable", id: "claude-fable-5", provider: "anthropic" },
+			{ name: "Claude Mythos", id: "claude-mythos-5", provider: "anthropic" },
+			{ name: "Bedrock Claude Haiku", id: "anthropic.claude-3-5-haiku-20241022-v1:0", provider: "aws-bedrock" },
 		] as const;
 
 		for (const target of targets) {
-			const model = makeModel("anthropic-messages", "anthropic", target.id);
+			const model = makeModel("anthropic-messages", target.provider, target.id);
 			const assistant = transformedAssistant(
 				[user(`weather in Paris for ${target.name}?`), geminiThinkingTurn()],
 				model,

--- a/packages/ai/test/transform-messages-thinking-dialect.test.ts
+++ b/packages/ai/test/transform-messages-thinking-dialect.test.ts
@@ -12,10 +12,11 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
  * neither recalled nor influences generation). `transformMessages` therefore
  * demotes the reasoning to a `text` block so it survives as conversation
  * context, usually wrapping it in the TARGET model's own canonical
- * thinking-block dialect (e.g. a ```thinking fence for Gemini). Claude Fable is
- * the exception: it receives markdown-italic assistant prose so replayed
- * reasoning does not look like an extraction request it should continue.
- * Same-model continuations keep the native `thinking` block untouched.
+ * thinking-block dialect (e.g. a ```thinking fence for Gemini). The entire
+ * Anthropic dialect (all Claude models) is an exception: it receives bare
+ * assistant prose so replayed reasoning does not trigger the `reasoning_extraction`
+ * classifier that blocks wrapped reasoning. Same-model continuations keep the
+ * native `thinking` block untouched.
  */
 const REASONING = "The user wants the Paris weather; I will call get_weather with city=Paris.";
 
@@ -127,30 +128,11 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 		expect(text).toContain(REASONING);
 	});
 
-	it("renders demoted foreign reasoning for Claude Fable as bare assistant prose (no _Hmm./thinking wrapper)", () => {
-		const fable = makeModel("anthropic-messages", "anthropic", "claude-fable-5");
-		const assistant = transformedAssistant([user("weather in Paris?"), geminiThinkingTurn()], fable);
-
-		expect(assistant.content.some(b => b.type === "thinking")).toBe(false);
-
-		const first = assistant.content[0];
-		expect(first?.type).toBe("text");
-		const text = first && first.type === "text" ? first.text : "";
-		expect(text).toBe(REASONING);
-		expect(text).not.toContain("<thinking>");
-		expect(text).not.toContain("</thinking>");
-		expect(text).not.toContain("<think>");
-		expect(text).not.toContain("</think>");
-		expect(text).not.toContain("_Hmm.");
-
-		const reply = assistant.content[1];
-		expect(reply?.type).toBe("text");
-		expect(reply && reply.type === "text" ? reply.text : "").toBe("Checking the forecast.");
-	});
-
-	it("keeps canonical Anthropic thinking tags for non-Fable Anthropic targets", () => {
+	it("renders demoted foreign reasoning as bare prose for all Anthropic-dialect Claude models", () => {
 		const targets = [
 			{ name: "Claude Opus", id: "claude-opus-4-8" },
+			{ name: "Claude Sonnet", id: "claude-sonnet-5" },
+			{ name: "Claude Fable", id: "claude-fable-5" },
 			{ name: "Claude Mythos", id: "claude-mythos-5" },
 		] as const;
 
@@ -166,10 +148,16 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 			const first = assistant.content[0];
 			expect(first?.type).toBe("text");
 			const text = first && first.type === "text" ? first.text : "";
-			expect(text).toBe(getDialectDefinition("anthropic").renderThinking(REASONING));
-			expect(text).toContain("<thinking>");
-			expect(text).toContain("</thinking>");
+			// All Anthropic models receive bare reasoning prose with no wrapper tags
+			// to avoid triggering reasoning_extraction classifier
+			expect(text).toBe(REASONING);
+			expect(text).not.toContain("<thinking>");
+			expect(text).not.toContain("</thinking>");
 			expect(text).not.toContain("_Hmm.");
+
+			const reply = assistant.content[1];
+			expect(reply?.type).toBe("text");
+			expect(reply && reply.type === "text" ? reply.text : "").toBe("Checking the forecast.");
 		}
 	});
 

--- a/packages/ai/test/transform-messages-thinking-dialect.test.ts
+++ b/packages/ai/test/transform-messages-thinking-dialect.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { getDialectDefinition, renderDemotedThinking } from "@oh-my-pi/pi-ai/dialect";
+import { flattenOpenAICompletionsAssistantTextBlocks } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import { transformMessages } from "@oh-my-pi/pi-ai/providers/transform-messages";
-import type { Api, AssistantMessage, Message, Model, ModelSpec, UserMessage } from "@oh-my-pi/pi-ai/types";
+import type { Api, AssistantMessage, Message, Model, ModelSpec, TextContent, UserMessage } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 
 /**
@@ -84,6 +85,7 @@ function transformedAssistant(messages: Message[], target: Model<Api>): Assistan
 	return assistant;
 }
 
+
 describe("transformMessages cross-provider thinking demotion → canonical dialect", () => {
 	it("renders Anthropic reasoning as a Gemini ```thinking fence when switching to a Gemini target", () => {
 		const gemini = makeModel("google-generative-ai", "google", "gemini-3-pro-preview");
@@ -160,6 +162,18 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 			expect(reply?.type).toBe("text");
 			expect(reply && reply.type === "text" ? reply.text : "").toBe("Checking the forecast.");
 		}
+	});
+
+	it("preserves a boundary when OpenAI-compatible Claude targets flatten bare demotions", () => {
+		const model = makeModel("openai-completions", "openrouter", "anthropic/claude-sonnet-4-6");
+		const assistant = transformedAssistant(
+			[user("weather in Paris?"), anthropicThinkingTurn(), user("Summarize the result.")],
+			model,
+		);
+		const textBlocks = assistant.content.filter((block): block is TextContent => block.type === "text");
+
+		expect(flattenOpenAICompletionsAssistantTextBlocks(textBlocks)).toBe(`${REASONING}\n\nChecking the forecast.`);
+		expect(flattenOpenAICompletionsAssistantTextBlocks(textBlocks)).not.toBe(`${REASONING}Checking the forecast.`);
 	});
 
 	it("keeps the native thinking block for a same-provider/same-model continuation", () => {

--- a/packages/ai/test/transform-messages-thinking-dialect.test.ts
+++ b/packages/ai/test/transform-messages-thinking-dialect.test.ts
@@ -85,7 +85,6 @@ function transformedAssistant(messages: Message[], target: Model<Api>): Assistan
 	return assistant;
 }
 
-
 describe("transformMessages cross-provider thinking demotion → canonical dialect", () => {
 	it("renders Anthropic reasoning as a Gemini ```thinking fence when switching to a Gemini target", () => {
 		const gemini = makeModel("google-generative-ai", "google", "gemini-3-pro-preview");

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -41,9 +41,9 @@ export const isKimiK26ModelId = memo((modelId: string): boolean => {
 	return /(^|\/)kimi-k2(?:\.6|p6)(?:[-:]|$)/i.test(modelId);
 });
 
-/** Claude ids in any namespace form (`claude-*`, `vendor/claude.x`). */
+/** Claude ids in plain, slash-namespaced, or dotted provider forms (`claude-*`, `vendor/claude.x`, `anthropic.claude-*`). */
 export const isClaudeModelId = memo((modelId: string): boolean => {
-	return /(^|\/)claude[-.]/i.test(modelId);
+	return /(^|[/.])claude[-.]/i.test(modelId);
 });
 
 /** `anthropic/`-namespaced ids (aggregator catalogs like OpenRouter). */

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -41,6 +41,8 @@ describe("isClaudeModelId", () => {
 	test("matches Claude namespace and delimiter forms", () => {
 		expect(isClaudeModelId("claude-sonnet-4-6")).toBe(true);
 		expect(isClaudeModelId("anthropic/claude.3")).toBe(true);
+		expect(isClaudeModelId("anthropic.claude-3-5-haiku-20241022-v1:0")).toBe(true);
+		expect(isClaudeModelId("us.anthropic.claude-sonnet-5")).toBe(true);
 		expect(isClaudeModelId("my-claudius")).toBe(false);
 	});
 });
@@ -209,6 +211,7 @@ describe("modelFamilyToken", () => {
 	test("folds aggregator mirrors and namespace prefixes onto the lineage", () => {
 		expect(modelFamilyToken("anthropic/claude-opus-4.8")).toBe("anthropic");
 		expect(modelFamilyToken("openrouter/anthropic/claude-opus-4-8")).toBe("anthropic");
+		expect(modelFamilyToken("anthropic.claude-3-5-haiku-20241022-v1:0")).toBe("anthropic");
 	});
 
 	test("classifies non-first-party families", () => {


### PR DESCRIPTION
## Repro

Multi-turn Anthropic conversation with any Claude model that has ever emitted a `thinking` block whose `thinkingSignature` is `undefined` (common — abandoned-tool-use turn recovery strips signatures; upstream envelopes carrying no `signature` field decode to `undefined`). On the next same-model turn:

- Opus / Sonnet / Haiku: prior reasoning leaks into the visible response as `<thinking>…</thinking>`-wrapped text.
- Fable 5: Anthropic's `reasoning_extraction` classifier refuses the turn outright.

Regression test `drops same-model Anthropic thinking blocks with undefined signatures` in `packages/ai/test/anthropic-prior-turn-thinking.test.ts` fails against the pre-fix guard with `Expected length: 0, Received length: 1`.

## Cause

`packages/ai/src/providers/transform-messages.ts:446` — the same-model Anthropic drop guard, originally `!sig || sig.trim() === ""` (introduced in `93996bc48`), was narrowed by `018b3dc61` to `sig?.trim() === ""`. Optional chaining collapses `undefined?.trim()` to `undefined`, so `undefined`-signature blocks now skip the drop, fall through to `return sanitized`, and later get demoted into `<thinking>`-tagged visible text by `renderDemotedThinking` — the exact shape Anthropic's docs name as the `reasoning_extraction` trigger.

Companion `packages/ai/src/dialect/demotion.ts` still gated bare-prose demotion behind a Fable-only id regex (`CLAUDE_FABLE_ID`), even though `reasoning_extraction` applies across the whole Claude family. Any residual cross-model demotion path (which stays legal — e.g. cross-model replay) would leak into visible reasoning on Opus/Sonnet/Haiku.

## Fix

- `transform-messages.ts`: widen the guard back to `!sig || sig.trim() === ""` so both `undefined` and `""` signatures are dropped entirely on same-model signing-Anthropic replay, matching the pre-`018b3dc61` behavior. Updates `anthropic-abandoned-tooluse-replay`, `anthropic-copilot/zenmux-checkpoint-thinking-signature`, and `anthropic-stream-envelope` fixtures whose old contract expected demotion-to-text for the same case (the stream-envelope turn now legitimately vanishes via the pre-existing empty-content-turn guard). Adds a regression test covering both `undefined` and `""` cases.
- `demotion.ts`: drop the Fable-only `CLAUDE_FABLE_ID` narrowing; any `preferredDialect(modelId) === "anthropic"` returns bare prose. Dead imports (`bareModelId`, local `canonicalId`) removed. `transform-messages-thinking-dialect` tests updated accordingly.

Fix commits credit @metaphorics via `Co-authored-by:`; duplicates #4427 to satisfy this issue's workflow requirement (roboomp cannot push commits authored by another user directly). Close whichever lands second.

## Verification

- `bun test test/anthropic test/transform-messages` — 302 pass / 0 fail across 27 files.
- The new `drops same-model Anthropic thinking blocks with undefined signatures` regression test fails on the pre-fix guard (`Expected length: 0, Received length: 1`) and passes after the guard is restored.

Fixes #4428.