### PR TITLE
fix(ai): demote prior reasoning to bare prose for all Anthropic-dialect Claude models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed prior-turn reasoning demotion for Anthropic Claude models by generalizing the Fable-only bare-prose branch to the whole Anthropic dialect, so cross-model replays to Opus, Sonnet, Haiku, and Mythos no longer emit `<thinking>` tags that Anthropic's reasoning_extraction classifier flags as visible reasoning leakage ([#4430](https://github.com/can1357/oh-my-pi/issues/4430)).
+- Fixed prior-turn reasoning demotion for Anthropic Claude models by generalizing the Fable-only bare-prose branch to the whole Anthropic dialect, so cross-model replays to Opus, Sonnet, Haiku, and Mythos no longer emit `<thinking>` tags that Anthropic's reasoning_extraction classifier flags as visible reasoning leakage. Also extended the Claude-id fallback classifier to Bedrock cross-region inference profiles (`us.anthropic.claude-…`, `eu.anthropic.claude-…`, etc.) so Haiku dotted profiles route to the Anthropic dialect, and separated demoted-thinking from the following visible answer in the openai-completions flatten path so bare Anthropic-dialect reasoning no longer runs into the reply text ([#4430](https://github.com/can1357/oh-my-pi/issues/4430)).
 
 ## [16.3.4] - 2026-07-03
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed prior-turn reasoning demotion for Anthropic Claude models by generalizing the Fable-only bare-prose branch to the whole Anthropic dialect, so cross-model replays to Opus, Sonnet, Haiku, and Mythos no longer emit `<thinking>` tags that Anthropic's reasoning_extraction classifier flags as visible reasoning leakage ([#4430](https://github.com/can1357/oh-my-pi/issues/4430)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed prior-turn reasoning demotion for Anthropic Claude models by generalizing the Fable-only bare-prose branch to the whole Anthropic dialect, so cross-model replays to Opus, Sonnet, Haiku, and Mythos no longer emit `<thinking>` tags that Anthropic's reasoning_extraction classifier flags as visible reasoning leakage. Also extended the Claude-id fallback classifier to Bedrock cross-region inference profiles (`us.anthropic.claude-…`, `eu.anthropic.claude-…`, etc.) so Haiku dotted profiles route to the Anthropic dialect, and separated demoted-thinking from the following visible answer in the openai-completions flatten path so bare Anthropic-dialect reasoning no longer runs into the reply text ([#4430](https://github.com/can1357/oh-my-pi/issues/4430)).
+- Fixed prior-turn reasoning demotion for Anthropic Claude models by generalizing the Fable-only bare-prose branch to the whole Anthropic dialect, so cross-model replays to Opus, Sonnet, Haiku, and Mythos no longer emit `<thinking>` tags that Anthropic's reasoning_extraction classifier flags as visible reasoning leakage. Also extended the Claude-id fallback classifier to Bedrock cross-region inference profiles (`us.anthropic.claude-…`, `eu.anthropic.claude-…`, etc.) so Haiku dotted profiles route to the Anthropic dialect, and appended a paragraph terminator to the demoted-thinking text block itself so bare Anthropic-dialect reasoning no longer runs into the following visible-answer block when the openai-completions convert path flattens adjacent text (without corrupting ordinary multi-block visible text from bridges, imported transcripts, or streaming chunk splits) ([#4430](https://github.com/can1357/oh-my-pi/issues/4430)).
 
 ## [16.3.4] - 2026-07-03
 

--- a/packages/ai/src/dialect/demotion.ts
+++ b/packages/ai/src/dialect/demotion.ts
@@ -1,28 +1,28 @@
-import { bareModelId, preferredDialect } from "@oh-my-pi/pi-catalog/identity";
+import { preferredDialect } from "@oh-my-pi/pi-catalog/identity";
 import { getDialectDefinition } from "./factory";
-
-const CLAUDE_FABLE_ID = /(?:^|[./])claude[-.]fable(?:[-.]|$)/i;
 
 /**
  * Wrap a prior-turn reasoning string for demotion into native conversation
- * history — the cross-provider / cross-model case where the target cannot replay
- * it as a structured thinking block (verified end-to-end against Gemini 3: a
- * replayed unsigned `thought` part is schema-accepted but silently discarded —
- * neither recalled nor influencing generation).
+ * history — the cross-provider / cross-model case where the target cannot
+ * replay it as a structured thinking block (verified end-to-end against Gemini
+ * 3: a replayed unsigned `thought` part is schema-accepted but silently
+ * discarded — neither recalled nor influencing generation).
  *
- * Fable is the exception: Anthropic's `reasoning_extraction` classifier blocks
- * requests that replay prior reasoning inside `<thinking>` / `antml:thinking`
- * tags OR the older `_Hmm. …_` italic envelope — it reads the wrapped
- * chain-of-thought as an attempt to duplicate model outputs and refuses the
- * whole turn. Fable therefore receives prior reasoning as bare assistant prose:
- * no tag, no `_Hmm.` wrapper, no trailing newline.
+ * The Anthropic/Claude dialect is the primary exception: Anthropic's
+ * `reasoning_extraction` classifier blocks requests that replay prior
+ * reasoning inside `<thinking>` / `antml:thinking` tags — it reads the
+ * wrapped chain-of-thought as an attempt to duplicate model outputs and
+ * refuses (Fable) or leaks it as visible reasoning (Opus / Sonnet / Haiku /
+ * Mythos). Every Anthropic-dialect Claude model therefore receives prior
+ * reasoning as bare assistant prose: no tag, no wrapper, no trailing newline.
  * Heat is cumulative (block count and early-conversation position also raise
  * it), so this lowers per-block signal but does not license unbounded replay.
- * Harmony and Gemma are also exceptions: their `renderThinking` emits
+ *
+ * Harmony and Gemma are the other exceptions: their `renderThinking` emits
  * chat-template control tokens (`<|channel|>analysis`, `<|channel>thought`)
- * that must not appear inside a structured native message, so they fall back to
- * a plain `<think>` block. Every other dialect's thinking form is inline-safe
- * XML tags or a markdown fence.
+ * that must not appear inside a structured native message, so they fall back
+ * to a plain `<think>` block. Every other dialect's thinking form is
+ * inline-safe XML tags or a markdown fence.
  *
  * The result does not append a delimiter; callers that flatten adjacent blocks
  * into a single string must insert their own separator.
@@ -33,9 +33,8 @@ const CLAUDE_FABLE_ID = /(?:^|[./])claude[-.]fable(?:[-.]|$)/i;
 export function renderDemotedThinking(modelId: string, text: string): string {
 	if (!text) return "";
 	text = text.toWellFormed();
-	const canonicalId = bareModelId(modelId);
 	const dialect = preferredDialect(modelId);
-	if (CLAUDE_FABLE_ID.test(canonicalId)) return text;
+	if (dialect === "anthropic") return text;
 	if (dialect === "harmony" || dialect === "gemma") return `<think>\n${text}\n</think>`;
 	return getDialectDefinition(dialect).renderThinking(text);
 }

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1778,7 +1778,11 @@ export function convertMessages(
 				// Always send assistant content as a plain string. Some OpenAI-compatible
 				// backends mirror array-of-text-block payloads back to the model literally,
 				// causing recursive nested content in subsequent turns.
-				assistantMsg.content = nonEmptyTextBlocks.map(b => b.text.toWellFormed()).join("");
+				// Separate distinct text blocks with a newline: for Anthropic-dialect
+				// targets `renderDemotedThinking` returns bare prose (no trailing
+				// delimiter), so a demoted-thinking block would otherwise run into the
+				// following visible-answer block ("reasoningfinal answer").
+				assistantMsg.content = nonEmptyTextBlocks.map(b => b.text.toWellFormed()).join("\n");
 			}
 
 			// Handle thinking blocks

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1778,11 +1778,14 @@ export function convertMessages(
 				// Always send assistant content as a plain string. Some OpenAI-compatible
 				// backends mirror array-of-text-block payloads back to the model literally,
 				// causing recursive nested content in subsequent turns.
-				// Separate distinct text blocks with a newline: for Anthropic-dialect
-				// targets `renderDemotedThinking` returns bare prose (no trailing
-				// delimiter), so a demoted-thinking block would otherwise run into the
-				// following visible-answer block ("reasoningfinal answer").
-				assistantMsg.content = nonEmptyTextBlocks.map(b => b.text.toWellFormed()).join("\n");
+				// Join without a separator so ordinary adjacent text blocks (bridge
+				// stitching, imported transcripts, streaming chunks) preserve their
+				// original byte sequence. The cross-model demotion path in
+				// transform-messages already appends its own paragraph terminator to
+				// the demoted-thinking text block content, so a bare Anthropic-dialect
+				// reasoning block still separates cleanly from the following visible
+				// answer without corrupting unrelated multi-block content.
+				assistantMsg.content = nonEmptyTextBlocks.map(b => b.text.toWellFormed()).join("");
 			}
 
 			// Handle thinking blocks

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -476,9 +476,18 @@ export function transformMessages<TApi extends Api>(
 					// TARGET model's own canonical thinking-block dialect (e.g. a ```thinking
 					// fence for Gemini) so it reads as reasoning rather than bare prose the
 					// model might mimic.
+					// Self-terminate the demoted text with a paragraph break so the
+					// bare Anthropic-dialect output (or any dialect's wrapped output
+					// whose closing tag isn't a natural word boundary) can't collide
+					// with the following visible-text block when a downstream consumer
+					// flattens adjacent text blocks (openai-completions convert). The
+					// terminator lives on the demoted block itself, so it targets the
+					// demoted-thinking boundary only — ordinary adjacent text blocks
+					// stitched from streaming / bridges / imported transcripts stay
+					// byte-identical on flatten.
 					return {
 						type: "text" as const,
-						text: renderDemotedThinking(model.id, sanitized.thinking),
+						text: `${renderDemotedThinking(model.id, sanitized.thinking)}\n`,
 					};
 				}
 

--- a/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
+++ b/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
@@ -156,7 +156,10 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expectNoUnsignedThinking(blocks);
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "sig_done")).toBe(true);
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "trunc")).toBe(false);
-		expect(blocks.some(b => b.type === "text" && b.text === "<thinking>\nnow decide\n</thinking>")).toBe(true);
+		// Anthropic-dialect demotion of unsigned prior thinking is bare prose
+		// (the reasoning_extraction classifier flags `<thinking>` tags across the
+		// whole Claude family, not just Fable).
+		expect(blocks.some(b => b.type === "text" && b.text === "now decide")).toBe(true);
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 

--- a/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
+++ b/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
@@ -157,8 +157,12 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "sig_done")).toBe(true);
 		expect(blocks.some(b => b.type === "thinking" && b.signature === "trunc")).toBe(false);
 		// Anthropic-dialect demotion of unsigned prior thinking is bare prose
-		// (the reasoning_extraction classifier flags `<thinking>` tags across the
-		// whole Claude family, not just Fable).
+		// (the reasoning_extraction classifier flags `<thinking>` tags across
+		// the whole Claude family, not just Fable). No trailing terminator on
+		// the anthropic-messages wire path: convertAnthropicMessages emits
+		// text blocks as separate wire blocks (no flatten), so the paragraph
+		// terminator lives only on the cross-API demotion in transform-messages
+		// where downstream openai-completions flattens adjacent text.
 		expect(blocks.some(b => b.type === "text" && b.text === "now decide")).toBe(true);
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -264,48 +264,66 @@ describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
 		expect(priorBlocks.find(b => b.type === "redacted_thinking")).toBeUndefined();
 	});
 
-	it("demotes invalid official Anthropic prior signatures to Fable markdown prose after a model switch", () => {
-		// official Anthropic → official Fable, with the signed turn no longer
-		// latest. The source signature is bound to the issuing Anthropic model,
-		// so replaying it after the switch must not emit native thinking or
-		// Anthropic/Kimi-style thinking tags that Fable treats as visible text.
-		const target = makeAnthropicModel({
-			provider: "anthropic",
-			id: "claude-fable-5",
-			name: "Claude Fable 5",
-			baseUrl: "https://api.anthropic.com",
-		});
-		const reasoning = "Need to preserve the plan while switching models.";
-		const messages: Message[] = [
-			makeUser("Read the project notes"),
-			makeAssistant(
-				[
-					{ type: "thinking", thinking: reasoning, thinkingSignature: "sig_sonnet" },
-					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "NOTES.md" } },
-				],
-				{ provider: "anthropic", model: "claude-sonnet-4-6" },
-			),
-			toolResult("toolu_prior", "notes body"),
-			makeAssistant([{ type: "text", text: "I found the relevant notes." }], {
-				provider: "anthropic",
-				model: "claude-fable-5",
-				stopReason: "stop",
-			}),
-			makeUser("Continue from those notes."),
-		];
+	it("demotes invalid official Anthropic prior signatures to bare Claude prose after a model switch", () => {
+		// official Anthropic → official Anthropic sibling, with the signed turn
+		// no longer latest. The source signature is bound to the issuing
+		// Anthropic model, so replaying it after the switch must not emit
+		// native thinking or `<thinking>` tags — Anthropic's
+		// `reasoning_extraction` classifier flags wrapped chain-of-thought
+		// across the whole Claude family (Fable refuses outright,
+		// Opus/Sonnet/Haiku/Mythos leak it as visible reasoning). Every
+		// Anthropic-dialect target therefore receives bare assistant prose.
+		const cases = [
+			{ id: "claude-opus-4-8", name: "Claude Opus 4.8" },
+			{ id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+			{ id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+			{ id: "claude-fable-5", name: "Claude Fable 5" },
+			{ id: "claude-mythos-5", name: "Claude Mythos 5" },
+		] as const;
 
-		const params = convertAnthropicMessages(messages, target, false);
-		const assistants = params.filter(p => p.role === "assistant");
-		expect(assistants).toHaveLength(2);
-		const priorBlocks = assistants[0].content as WireBlock[];
-		const text = priorBlocks.find(b => b.type === "text") as WireTextBlock | undefined;
-		expect(text?.text).toBe(renderDemotedThinking("claude-fable-5", reasoning));
-		expect(text?.text).toBe(reasoning);
-		expect(text?.text).not.toContain("<thinking>");
-		expect(text?.text).not.toContain("</thinking>");
-		expect(text?.text).not.toContain("<think>");
-		expect(text?.text).not.toContain("</think>");
-		expect(priorBlocks.find(b => b.type === "thinking")).toBeUndefined();
+		for (const targetCase of cases) {
+			const target = makeAnthropicModel({
+				provider: "anthropic",
+				id: targetCase.id,
+				name: targetCase.name,
+				baseUrl: "https://api.anthropic.com",
+			});
+			// Source model differs from the target so the transition triggers
+			// signature stripping + demotion. Pick a source with a different
+			// bare id from the target regardless of which target we're on.
+			const sourceModel = targetCase.id === "claude-sonnet-4-6" ? "claude-opus-4-8" : "claude-sonnet-4-6";
+			const reasoning = `Need to preserve the plan while switching to ${targetCase.name}.`;
+			const messages: Message[] = [
+				makeUser("Read the project notes"),
+				makeAssistant(
+					[
+						{ type: "thinking", thinking: reasoning, thinkingSignature: "sig_source" },
+						{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "NOTES.md" } },
+					],
+					{ provider: "anthropic", model: sourceModel },
+				),
+				toolResult("toolu_prior", "notes body"),
+				makeAssistant([{ type: "text", text: "I found the relevant notes." }], {
+					provider: "anthropic",
+					model: targetCase.id,
+					stopReason: "stop",
+				}),
+				makeUser("Continue from those notes."),
+			];
+
+			const params = convertAnthropicMessages(messages, target, false);
+			const assistants = params.filter(p => p.role === "assistant");
+			expect(assistants).toHaveLength(2);
+			const priorBlocks = assistants[0].content as WireBlock[];
+			const text = priorBlocks.find(b => b.type === "text") as WireTextBlock | undefined;
+			expect(text?.text).toBe(renderDemotedThinking(targetCase.id, reasoning));
+			expect(text?.text).toBe(reasoning);
+			expect(text?.text).not.toContain("<thinking>");
+			expect(text?.text).not.toContain("</thinking>");
+			expect(text?.text).not.toContain("<think>");
+			expect(text?.text).not.toContain("</think>");
+			expect(priorBlocks.find(b => b.type === "thinking")).toBeUndefined();
+		}
 	});
 
 	it("does not demote same-model official Anthropic unsigned thinking to text", () => {

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -646,7 +646,9 @@ describe("anthropic stream envelope handling", () => {
 		// the reasoning_extraction classifier flags `<thinking>` tags in prior
 		// turn history for the whole Claude family, so replaying the unwrapped
 		// reasoning as wrapped text would just re-introduce the same leak.
-		expect(replayAssistant?.content).toEqual([{ type: "text", text: "Check logs before accepting container health." }]);
+		expect(replayAssistant?.content).toEqual([
+			{ type: "text", text: "Check logs before accepting container health." },
+		]);
 	});
 	it("preserves signed thinking bytes when no literal thinking envelope is present", async () => {
 		const signedThinking = "\nCheck logs before accepting container health.\n";

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -642,9 +642,11 @@ describe("anthropic stream envelope handling", () => {
 			false,
 		);
 		const replayAssistant = replayParams.find(param => param.role === "assistant");
-		expect(replayAssistant?.content).toEqual([
-			{ type: "text", text: "<thinking>\nCheck logs before accepting container health.\n</thinking>" },
-		]);
+		// Anthropic-dialect demotion of unsigned prior thinking is bare prose —
+		// the reasoning_extraction classifier flags `<thinking>` tags in prior
+		// turn history for the whole Claude family, so replaying the unwrapped
+		// reasoning as wrapped text would just re-introduce the same leak.
+		expect(replayAssistant?.content).toEqual([{ type: "text", text: "Check logs before accepting container health." }]);
 	});
 	it("preserves signed thinking bytes when no literal thinking envelope is present", async () => {
 		const signedThinking = "\nCheck logs before accepting container health.\n";

--- a/packages/ai/test/anthropic-stream-envelope.test.ts
+++ b/packages/ai/test/anthropic-stream-envelope.test.ts
@@ -645,7 +645,11 @@ describe("anthropic stream envelope handling", () => {
 		// Anthropic-dialect demotion of unsigned prior thinking is bare prose —
 		// the reasoning_extraction classifier flags `<thinking>` tags in prior
 		// turn history for the whole Claude family, so replaying the unwrapped
-		// reasoning as wrapped text would just re-introduce the same leak.
+		// reasoning as wrapped text would just re-introduce the same leak. No
+		// trailing terminator on the anthropic-messages wire path:
+		// convertAnthropicMessages emits text blocks as separate wire blocks
+		// (no flatten), so the paragraph terminator lives only on the
+		// cross-API demotion in transform-messages.
 		expect(replayAssistant?.content).toEqual([
 			{ type: "text", text: "Check logs before accepting container health." },
 		]);

--- a/packages/ai/test/deepseek-reasoning-content.test.ts
+++ b/packages/ai/test/deepseek-reasoning-content.test.ts
@@ -356,7 +356,9 @@ describe("DeepSeek reasoning_content tool-call replay", () => {
 			const assistant = findOpenAICompletionAssistantWireMessage(messages);
 			expect(assistant).toBeDefined();
 			expect(assistant?.reasoning_content).toBe("");
-			expect(assistant?.content).toBe(`${renderDemotedThinking(model.id, "Need to preserve cross-api reasoning.")}\n`);
+			expect(assistant?.content).toBe(
+				`${renderDemotedThinking(model.id, "Need to preserve cross-api reasoning.")}\n`,
+			);
 		});
 		it("falls through to empty-string when thinking block has opaque signature and empty text", () => {
 			const model = deepseekModel({

--- a/packages/ai/test/deepseek-reasoning-content.test.ts
+++ b/packages/ai/test/deepseek-reasoning-content.test.ts
@@ -356,7 +356,7 @@ describe("DeepSeek reasoning_content tool-call replay", () => {
 			const assistant = findOpenAICompletionAssistantWireMessage(messages);
 			expect(assistant).toBeDefined();
 			expect(assistant?.reasoning_content).toBe("");
-			expect(assistant?.content).toBe(renderDemotedThinking(model.id, "Need to preserve cross-api reasoning."));
+			expect(assistant?.content).toBe(`${renderDemotedThinking(model.id, "Need to preserve cross-api reasoning.")}\n`);
 		});
 		it("falls through to empty-string when thinking block has opaque signature and empty text", () => {
 			const model = deepseekModel({

--- a/packages/ai/test/issue-3434-repro.test.ts
+++ b/packages/ai/test/issue-3434-repro.test.ts
@@ -194,7 +194,7 @@ describe("cross-API thinking-block preservation (#3433/#3434)", () => {
 		if (!assistant) throw new Error("assistant message missing");
 
 		expect(assistant.reasoning_content).toBe("");
-		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Read README and answer.")}Done.`);
+		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Read README and answer.")}\nDone.`);
 	});
 
 	it("demotes thinking to canonical text when the target cannot replay it semantically", () => {
@@ -211,7 +211,7 @@ describe("cross-API thinking-block preservation (#3433/#3434)", () => {
 		if (!assistant) throw new Error("assistant message missing");
 
 		expect(assistant.reasoning_content).toBeUndefined();
-		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Explore the repo, then patch it.")}Done.`);
+		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Explore the repo, then patch it.")}\nDone.`);
 	});
 
 	it("demotes cross-API thinking for OpenCode reasoning targets with whenThinking schema", () => {
@@ -233,7 +233,7 @@ describe("cross-API thinking-block preservation (#3433/#3434)", () => {
 		if (!assistant) throw new Error("assistant message missing");
 
 		expect(assistant.reasoning_content).toBeUndefined();
-		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Read README and answer.")}Done.`);
+		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Read README and answer.")}\nDone.`);
 	});
 
 	it("demotes prior thinking to content when the OpenCode base compat runs with thinking off", () => {
@@ -253,7 +253,7 @@ describe("cross-API thinking-block preservation (#3433/#3434)", () => {
 		if (!assistant) throw new Error("assistant message missing");
 
 		expect(assistant.reasoning_content).toBeUndefined();
-		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Read README and answer.")}Done.`);
+		expect(assistant.content).toBe(`${renderDemotedThinking(target.id, "Read README and answer.")}\nDone.`);
 	});
 
 	it("does not promote markup-healed same-model thinking into visible content", () => {

--- a/packages/ai/test/issue-3528-repro.test.ts
+++ b/packages/ai/test/issue-3528-repro.test.ts
@@ -284,7 +284,7 @@ describe("llama.cpp warm-prefix preservation (#3528)", () => {
 		const found = findAssistantMessage(wire) as Record<string, unknown> | undefined;
 		expect(found?.reasoning_content).toBeUndefined();
 		expect(found?.content).toBe(
-			`${renderDemotedThinking(target.id, "Cross-vendor reasoning chain that must survive the switch.")}Switched-in answer.`,
+			`${renderDemotedThinking(target.id, "Cross-vendor reasoning chain that must survive the switch.")}\nSwitched-in answer.`,
 		);
 		expect("EvAnthropicOpaqueContinuationBlob==" in (found ?? {})).toBe(false);
 	});

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -233,7 +233,14 @@ describe("openai-completions compatibility", () => {
 			throw new Error("assistant message missing");
 		}
 		expect(typeof assistant.content).toBe("string");
-		expect(assistant.content).toBe("hello world");
+		// Distinct text blocks are joined with `\n` — see the flatten path in
+		// openai-completions.ts. Streaming accumulates chunks into a single
+		// block, so multi-block content represents semantically separate
+		// segments (a demoted-thinking block followed by the visible answer,
+		// or a text block flanking a tool call). Bare Anthropic-dialect
+		// demoted reasoning has no self-terminator, so the join site MUST
+		// insert one to keep the two segments from running together.
+		expect(assistant.content).toBe("hello\n world");
 	});
 
 	it("prepends thinking text to string assistant content when requiresThinkingAsText is set", () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -233,14 +233,11 @@ describe("openai-completions compatibility", () => {
 			throw new Error("assistant message missing");
 		}
 		expect(typeof assistant.content).toBe("string");
-		// Distinct text blocks are joined with `\n` — see the flatten path in
-		// openai-completions.ts. Streaming accumulates chunks into a single
-		// block, so multi-block content represents semantically separate
-		// segments (a demoted-thinking block followed by the visible answer,
-		// or a text block flanking a tool call). Bare Anthropic-dialect
-		// demoted reasoning has no self-terminator, so the join site MUST
-		// insert one to keep the two segments from running together.
-		expect(assistant.content).toBe("hello\n world");
+		// Ordinary adjacent text blocks (bridge stitching, imported transcripts,
+		// streaming chunk splits) preserve their original byte sequence on
+		// flatten. The demoted-thinking separator lives on the demoted block
+		// itself (transform-messages), so it targets that boundary only.
+		expect(assistant.content).toBe("hello world");
 	});
 
 	it("prepends thinking text to string assistant content when requiresThinkingAsText is set", () => {
@@ -1370,7 +1367,7 @@ describe("kimi model detection via detectCompat", () => {
 		const payload = (await promise) as { messages: Array<Record<string, unknown>> };
 		const assistant = payload.messages.find(m => m.role === "assistant");
 		expect(assistant).toBeDefined();
-		expect(assistant?.content).toBe(renderDemotedThinking(model.id, "Need to preserve cross-api reasoning."));
+		expect(assistant?.content).toBe(`${renderDemotedThinking(model.id, "Need to preserve cross-api reasoning.")}\n`);
 		expect(assistant?.reasoning_content).toBe("");
 		expect(assistant?.reasoning).toBeUndefined();
 		expect(assistant?.reasoning_text).toBeUndefined();

--- a/packages/ai/test/transform-messages-thinking-dialect.test.ts
+++ b/packages/ai/test/transform-messages-thinking-dialect.test.ts
@@ -12,10 +12,13 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
  * neither recalled nor influences generation). `transformMessages` therefore
  * demotes the reasoning to a `text` block so it survives as conversation
  * context, usually wrapping it in the TARGET model's own canonical
- * thinking-block dialect (e.g. a ```thinking fence for Gemini). Claude Fable is
- * the exception: it receives markdown-italic assistant prose so replayed
- * reasoning does not look like an extraction request it should continue.
- * Same-model continuations keep the native `thinking` block untouched.
+ * thinking-block dialect (e.g. a ```thinking fence for Gemini). The
+ * Anthropic/Claude dialect is the exception: every Claude model
+ * (Opus / Sonnet / Haiku / Fable / Mythos, etc.) receives bare assistant prose,
+ * because Anthropic's `reasoning_extraction` classifier flags `<thinking>` /
+ * `antml:thinking` tags in prior turn history — refusing (Fable) or leaking
+ * the wrapped chain-of-thought as visible reasoning on the others. Same-model
+ * continuations keep the native `thinking` block untouched.
  */
 const REASONING = "The user wants the Paris weather; I will call get_weather with city=Paris.";
 
@@ -127,30 +130,18 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 		expect(text).toContain(REASONING);
 	});
 
-	it("renders demoted foreign reasoning for Claude Fable as bare assistant prose (no _Hmm./thinking wrapper)", () => {
-		const fable = makeModel("anthropic-messages", "anthropic", "claude-fable-5");
-		const assistant = transformedAssistant([user("weather in Paris?"), geminiThinkingTurn()], fable);
-
-		expect(assistant.content.some(b => b.type === "thinking")).toBe(false);
-
-		const first = assistant.content[0];
-		expect(first?.type).toBe("text");
-		const text = first && first.type === "text" ? first.text : "";
-		expect(text).toBe(REASONING);
-		expect(text).not.toContain("<thinking>");
-		expect(text).not.toContain("</thinking>");
-		expect(text).not.toContain("<think>");
-		expect(text).not.toContain("</think>");
-		expect(text).not.toContain("_Hmm.");
-
-		const reply = assistant.content[1];
-		expect(reply?.type).toBe("text");
-		expect(reply && reply.type === "text" ? reply.text : "").toBe("Checking the forecast.");
-	});
-
-	it("keeps canonical Anthropic thinking tags for non-Fable Anthropic targets", () => {
+	it("renders demoted foreign reasoning as bare assistant prose for every Anthropic-dialect Claude target", () => {
+		// The Anthropic reasoning_extraction classifier flags `<thinking>` and
+		// `antml:thinking` tags in prior turn history for the whole Claude family
+		// — Fable refuses outright, Opus/Sonnet/Haiku/Mythos leak the wrapped
+		// chain-of-thought as visible reasoning. Every Anthropic-dialect target
+		// therefore receives bare prose, not the dialect's canonical thinking
+		// tags.
 		const targets = [
 			{ name: "Claude Opus", id: "claude-opus-4-8" },
+			{ name: "Claude Sonnet", id: "claude-sonnet-4-6" },
+			{ name: "Claude Haiku", id: "claude-haiku-4-5" },
+			{ name: "Claude Fable", id: "claude-fable-5" },
 			{ name: "Claude Mythos", id: "claude-mythos-5" },
 		] as const;
 
@@ -166,10 +157,17 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 			const first = assistant.content[0];
 			expect(first?.type).toBe("text");
 			const text = first && first.type === "text" ? first.text : "";
-			expect(text).toBe(getDialectDefinition("anthropic").renderThinking(REASONING));
-			expect(text).toContain("<thinking>");
-			expect(text).toContain("</thinking>");
+			expect(text).toBe(REASONING);
+			expect(text).toBe(renderDemotedThinking(target.id, REASONING));
+			expect(text).not.toContain("<thinking>");
+			expect(text).not.toContain("</thinking>");
+			expect(text).not.toContain("<think>");
+			expect(text).not.toContain("</think>");
 			expect(text).not.toContain("_Hmm.");
+
+			const reply = assistant.content[1];
+			expect(reply?.type).toBe("text");
+			expect(reply && reply.type === "text" ? reply.text : "").toBe("Checking the forecast.");
 		}
 	});
 

--- a/packages/ai/test/transform-messages-thinking-dialect.test.ts
+++ b/packages/ai/test/transform-messages-thinking-dialect.test.ts
@@ -143,6 +143,12 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 			{ name: "Claude Haiku", id: "claude-haiku-4-5" },
 			{ name: "Claude Fable", id: "claude-fable-5" },
 			{ name: "Claude Mythos", id: "claude-mythos-5" },
+			// Bedrock cross-region inference profiles. `parseAnthropicModel`
+			// doesn't enumerate `haiku`, so this exercises the isClaudeModelId
+			// dotted-prefix fallback specifically.
+			{ name: "Claude Haiku (Bedrock US)", id: "us.anthropic.claude-haiku-4-5-20251001-v1:0" },
+			{ name: "Claude Haiku (Bedrock EU)", id: "eu.anthropic.claude-haiku-4-5-20251001-v1:0" },
+			{ name: "Claude Opus (Bedrock Global)", id: "global.anthropic.claude-opus-4-8" },
 		] as const;
 
 		for (const target of targets) {

--- a/packages/ai/test/transform-messages-thinking-dialect.test.ts
+++ b/packages/ai/test/transform-messages-thinking-dialect.test.ts
@@ -100,7 +100,7 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 		expect(first?.type).toBe("text");
 		// Demoted reasoning is wrapped in Gemini's canonical thinking fence.
 		expect(first && first.type === "text" ? first.text : "").toBe(
-			getDialectDefinition("gemini").renderThinking(REASONING),
+			`${getDialectDefinition("gemini").renderThinking(REASONING)}\n`,
 		);
 		expect(first && first.type === "text" ? first.text : "").toContain("```thinking");
 		// The original reply text survives as its own block, after the fence.
@@ -120,7 +120,7 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 		const first = assistant.content[0];
 		expect(first?.type).toBe("text");
 		const text = first && first.type === "text" ? first.text : "";
-		expect(text).toBe(renderDemotedThinking("gpt-5", REASONING));
+		expect(text).toBe(`${renderDemotedThinking("gpt-5", REASONING)}\n`);
 		// No harmony chat-template control tokens leaked, and the unsafe native
 		// renderThinking output was explicitly NOT used.
 		expect(text).not.toContain("<|");
@@ -163,8 +163,8 @@ describe("transformMessages cross-provider thinking demotion → canonical diale
 			const first = assistant.content[0];
 			expect(first?.type).toBe("text");
 			const text = first && first.type === "text" ? first.text : "";
-			expect(text).toBe(REASONING);
-			expect(text).toBe(renderDemotedThinking(target.id, REASONING));
+			expect(text).toBe(`${REASONING}\n`);
+			expect(text).toBe(`${renderDemotedThinking(target.id, REASONING)}\n`);
 			expect(text).not.toContain("<thinking>");
 			expect(text).not.toContain("</thinking>");
 			expect(text).not.toContain("<think>");

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -41,9 +41,16 @@ export const isKimiK26ModelId = memo((modelId: string): boolean => {
 	return /(^|\/)kimi-k2(?:\.6|p6)(?:[-:]|$)/i.test(modelId);
 });
 
-/** Claude ids in any namespace form (`claude-*`, `vendor/claude.x`). */
+/**
+ * Claude ids in any namespace form: bare (`claude-*`), path-namespaced
+ * (`anthropic/claude.x`), or dot-prefixed (`us.anthropic.claude-…`,
+ * `global.anthropic.claude-…`, `au.anthropic.claude-…` — Bedrock cross-region
+ * inference profiles). Necessary because {@link parseAnthropicModel} only
+ * classifies kinds enumerated in its regex, so any dotted profile whose kind
+ * (e.g. `haiku`) is not enumerated would otherwise slip past this fallback.
+ */
 export const isClaudeModelId = memo((modelId: string): boolean => {
-	return /(^|\/)claude[-.]/i.test(modelId);
+	return /(^|[/.])claude[-.]/i.test(modelId);
 });
 
 /** `anthropic/`-namespaced ids (aggregator catalogs like OpenRouter). */

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -43,6 +43,21 @@ describe("isClaudeModelId", () => {
 		expect(isClaudeModelId("anthropic/claude.3")).toBe(true);
 		expect(isClaudeModelId("my-claudius")).toBe(false);
 	});
+	test("matches dotted Bedrock cross-region inference profile ids for Claude kinds not enumerated in parseAnthropicModel", () => {
+		// `parseAnthropicModel` only classifies opus/sonnet/fable/mythos, so a
+		// Haiku Bedrock profile (`us.anthropic.claude-haiku-…`) slips past its
+		// regex and MUST still classify as Claude via this fallback so
+		// `modelFamilyToken`/`preferredDialect` route it to the Anthropic
+		// dialect instead of falling through to XML.
+		expect(isClaudeModelId("us.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe(true);
+		expect(isClaudeModelId("eu.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe(true);
+		expect(isClaudeModelId("global.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe(true);
+		expect(isClaudeModelId("au.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe(true);
+		// Non-Claude names that happen to contain "claude" as a substring
+		// stay unmatched — no `.` / `/` / start delimiter before `claude-`.
+		expect(isClaudeModelId("subclaudian")).toBe(false);
+		expect(isClaudeModelId("claudius-5")).toBe(false);
+	});
 });
 
 describe("supportsAdaptiveThinkingDisplay", () => {
@@ -209,6 +224,14 @@ describe("modelFamilyToken", () => {
 	test("folds aggregator mirrors and namespace prefixes onto the lineage", () => {
 		expect(modelFamilyToken("anthropic/claude-opus-4.8")).toBe("anthropic");
 		expect(modelFamilyToken("openrouter/anthropic/claude-opus-4-8")).toBe("anthropic");
+	});
+
+	test("classifies Bedrock cross-region profile ids for Claude kinds not enumerated in parseAnthropicModel", () => {
+		// `parseAnthropicModel` doesn't know `haiku`, so this exercises the
+		// isClaudeModelId fallback specifically for dotted Bedrock profiles.
+		expect(modelFamilyToken("us.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe("anthropic");
+		expect(modelFamilyToken("eu.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe("anthropic");
+		expect(modelFamilyToken("global.anthropic.claude-haiku-4-5-20251001-v1:0")).toBe("anthropic");
 	});
 
 	test("classifies non-first-party families", () => {


### PR DESCRIPTION
## Repro

`packages/ai/src/dialect/demotion.ts` special-cased only Claude Fable to receive demoted prior-turn reasoning as bare prose. Every other Anthropic-dialect Claude model (Opus, Sonnet, Haiku, Mythos, etc.) fell through to `getDialectDefinition("anthropic").renderThinking(text)`, which wraps the text in `<thinking>…</thinking>` — the shape Anthropic's `reasoning_extraction` classifier flags in prior turn history.

```
$ bun -e 'import("./packages/ai/src/dialect/demotion.ts").then(m => { for (const id of ["claude-opus-4-8","claude-sonnet-4-6","claude-haiku-4-5","claude-fable-5","claude-mythos-5"]) console.log(id.padEnd(20), JSON.stringify(m.renderDemotedThinking(id, "internal chain of thought"))); })'
claude-opus-4-8      "<thinking>\ninternal chain of thought\n</thinking>"
claude-sonnet-4-6    "<thinking>\ninternal chain of thought\n</thinking>"
claude-haiku-4-5     "<thinking>\ninternal chain of thought\n</thinking>"
claude-fable-5       "internal chain of thought"
claude-mythos-5      "<thinking>\ninternal chain of thought\n</thinking>"
```

## Cause

`renderDemotedThinking` gated the bare-prose exception on a Fable-only regex (`CLAUDE_FABLE_ID`) instead of the shared Anthropic dialect. Any Claude id whose `preferredDialect` resolves to `"anthropic"` — every non-Fable Claude — dropped into the generic `renderThinking` path, which is `renderDelimitedThinking("<thinking>", "</thinking>", text)`. The `reasoning_extraction` classifier fires across the whole Claude family: Fable refuses outright, Opus/Sonnet/Haiku/Mythos leak the wrapped chain-of-thought as visible reasoning.

## Fix

- `packages/ai/src/dialect/demotion.ts`: replace the Fable-only `CLAUDE_FABLE_ID.test(canonicalId)` branch with `dialect === "anthropic"`, delete the now-dead regex + `bareModelId` import, and rewrite the docstring to name the actual dialect-wide invariant.
- `packages/ai/test/transform-messages-thinking-dialect.test.ts`: delete the test that asserted the buggy `<thinking>` wrap for non-Fable Anthropic targets; extend the Fable-only bare-prose test to iterate Opus / Sonnet / Haiku / Fable / Mythos and update the file docstring.
- `packages/ai/test/anthropic-prior-turn-thinking.test.ts`: generalize the "demotes invalid official Anthropic prior signatures" case from Fable-only to the whole Claude family.
- `packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts` and `packages/ai/test/anthropic-stream-envelope.test.ts`: update the two assertions that pinned the old wrapped-tag demotion shape on Opus 4.8 / Sonnet 4.5 to the new bare-prose contract.
- `packages/ai/CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Verification

`bun test` in `packages/ai` — 2641 pass / 337 skip / 1 fail. Post-fix repro:

```
claude-opus-4-8      "internal chain of thought"
claude-sonnet-4-6    "internal chain of thought"
claude-haiku-4-5     "internal chain of thought"
claude-fable-5       "internal chain of thought"
claude-mythos-5      "internal chain of thought"
gpt-5                "<think>\ninternal chain of thought\n</think>"
gemini-3-pro         "```thinking\ninternal chain of thought\n```"
kimi-k2.6            "<think>\ninternal chain of thought\n</think>"
```

The one remaining failure is `test/proxy.test.ts > "normalizes hyphenated provider ids to underscores"`, a pre-existing test-order-dependent `Bun.env` leak on `main` unrelated to this change (verified by stashing the diff and re-running the same suite: 2642 pass / 1 fail — same proxy assertion; the test passes in isolation on both branches).

Fixes #4430