### PR TITLE
fix(task): preserve isolated commits on transfer failure

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Preserved isolated branch-mode task output as a patch artifact when `commitToBranch` fails before the task branch can be transferred, preventing committed subagent work from being destroyed with the isolation worktree ([#4437](https://github.com/can1357/oh-my-pi/issues/4437)).
+- Preserved isolated branch-mode task output as a patch artifact when `commitToBranch` fails before the task branch can be transferred, and surfaced the captured patch path (plus any nested patches) through the eval `agent()` failure message so callers can recover the work instead of losing it with the isolation worktree ([#4437](https://github.com/can1357/oh-my-pi/issues/4437)).
 
 ## [16.3.4] - 2026-07-03
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved isolated branch-mode task output as a patch artifact when `commitToBranch` fails before the task branch can be transferred, preventing committed subagent work from being destroyed with the isolation worktree ([#4437](https://github.com/can1357/oh-my-pi/issues/4437)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts
@@ -1172,6 +1172,25 @@ describe("runEvalAgent isolation", () => {
 		).rejects.toThrow(/isolated apply failed.*Patch apply failed.*Captured patch preserved at \/artifacts\//s);
 	});
 
+	it("surfaces the preserved patch path when branch-mode transfer fails before merge runs", async () => {
+		mockAgents();
+		mockIsolationContext();
+		vi.spyOn(isolationRunner, "runIsolatedSubprocess").mockImplementation(async opts =>
+			singleResult(opts.baseOptions, {
+				output: "ran",
+				patchPath: `/artifacts/${opts.agentId}.patch`,
+				error: "Merge failed: remote: garbage at end of loose object '4de7bad'",
+			}),
+		);
+		const mergeSpy = vi.spyOn(isolationRunner, "mergeIsolatedChanges");
+
+		const session = isolatedSession({ "task.isolation.merge": "branch" });
+		await expect(runEvalAgent({ prompt: "scout", isolated: true }, { session })).rejects.toThrow(
+			/Merge failed.*garbage at end of loose object.*Captured patch preserved at \/artifacts\//s,
+		);
+		expect(mergeSpy).not.toHaveBeenCalled();
+	});
+
 	it("throws on apply failure for non-schema callers too instead of burying the warning in text", async () => {
 		mockAgents();
 		mockIsolationContext();

--- a/packages/coding-agent/src/eval/agent-bridge.ts
+++ b/packages/coding-agent/src/eval/agent-bridge.ts
@@ -240,6 +240,25 @@ async function persistNestedPatches(
 	return written;
 }
 
+/**
+ * Assemble the "captured X preserved at Y" recovery hint appended to
+ * isolated-run failure messages. Persists nested-repo patches to
+ * `artifactsDir` when present so their paths can be surfaced. Returns an
+ * empty string when the result carries no salvageable artifacts.
+ */
+async function buildIsolationRecoveryHint(result: SingleResult, artifactsDir: string): Promise<string> {
+	const parts: string[] = [];
+	if (result.patchPath) parts.push(`Captured patch preserved at ${result.patchPath}.`);
+	if (result.branchName) parts.push(`Captured branch preserved as ${result.branchName}.`);
+	if (result.nestedPatches?.length) {
+		const nestedPaths = await persistNestedPatches(artifactsDir, result.id, result.nestedPatches);
+		parts.push(
+			`Captured nested repository patches (${result.nestedPatches.length}) preserved at: ${nestedPaths.join(", ")}.`,
+		);
+	}
+	return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
 function plainIsolationSummary(summary: string): string {
 	return summary.replace(/<\/?system-notification>/g, "").trim();
 }
@@ -481,7 +500,9 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 		})();
 
 		if (result.exitCode !== 0 || result.error || result.aborted) {
-			throw new ToolError(buildSubagentFailureMessage(agentName, result));
+			const failureMessage = buildSubagentFailureMessage(agentName, result);
+			const recoveryHint = isIsolated ? await buildIsolationRecoveryHint(result, artifactsDir) : "";
+			throw new ToolError(`${failureMessage}${recoveryHint}`);
 		}
 
 		let mergeSummary = "";
@@ -497,16 +518,7 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 				changesApplied = outcome.changesApplied;
 				if (outcome.changesApplied === false) {
 					const summaryText = outcome.summary.trim();
-					const recoveryParts: string[] = [];
-					if (result.patchPath) recoveryParts.push(`Captured patch preserved at ${result.patchPath}.`);
-					if (result.branchName) recoveryParts.push(`Captured branch preserved as ${result.branchName}.`);
-					if (result.nestedPatches?.length) {
-						const nestedPaths = await persistNestedPatches(artifactsDir, result.id, result.nestedPatches);
-						recoveryParts.push(
-							`Captured nested repository patches (${result.nestedPatches.length}) preserved at: ${nestedPaths.join(", ")}.`,
-						);
-					}
-					const recoveryHint = recoveryParts.length > 0 ? ` ${recoveryParts.join(" ")}` : "";
+					const recoveryHint = await buildIsolationRecoveryHint(result, artifactsDir);
 					throw new ToolError(
 						`agent() isolated apply failed for ${result.id}${summaryText ? `: ${summaryText}` : ""}${recoveryHint}`,
 					);
@@ -522,14 +534,10 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 				});
 				mergeSummary += nestedSummary;
 				if (structured && nestedSummary.trim()) {
-					const recoveryParts: string[] = [];
-					if (result.nestedPatches?.length) {
-						const nestedPaths = await persistNestedPatches(artifactsDir, result.id, result.nestedPatches);
-						recoveryParts.push(
-							`Captured nested repository patches (${result.nestedPatches.length}) preserved at: ${nestedPaths.join(", ")}.`,
-						);
-					}
-					const recoveryHint = recoveryParts.length > 0 ? ` ${recoveryParts.join(" ")}` : "";
+					const recoveryHint = await buildIsolationRecoveryHint(
+						{ ...result, patchPath: undefined, branchName: undefined },
+						artifactsDir,
+					);
 					throw new ToolError(
 						`agent() isolated nested patch apply failed for ${result.id}: ${plainIsolationSummary(nestedSummary)}${recoveryHint}`,
 					);

--- a/packages/coding-agent/src/task/isolation-runner.ts
+++ b/packages/coding-agent/src/task/isolation-runner.ts
@@ -37,6 +37,7 @@ import {
 	getRepoRoot,
 	type IsolationHandle,
 	mergeTaskBranches,
+	type NestedRepoPatch,
 	type WorktreeBaseline,
 } from "./worktree";
 
@@ -100,7 +101,7 @@ export interface IsolatedRunOptions {
 	agentId: string;
 	/** Merge mode driving how changes are captured ("branch" commits, "patch" diffs). */
 	mergeMode: "patch" | "branch";
-	/** Output dir for `${agentId}.patch` artifacts (patch mode). */
+	/** Output dir for `${agentId}.patch` artifacts (patch mode and branch-mode commit failures). */
 	artifactsDir: string;
 	/** Human description carried onto the branch commit (branch mode). */
 	description?: string;
@@ -114,12 +115,25 @@ export interface IsolatedRunOptions {
 	buildFailureResult: (err: unknown) => SingleResult;
 }
 
+async function writeIsolationPatch(
+	isolationDir: string,
+	baseline: WorktreeBaseline,
+	artifactsDir: string,
+	agentId: string,
+): Promise<{ patchPath: string; nestedPatches: NestedRepoPatch[] }> {
+	const delta = await captureDeltaPatch(isolationDir, baseline);
+	const patchPath = path.join(artifactsDir, `${agentId}.patch`);
+	await Bun.write(patchPath, delta.rootPatch);
+	return { patchPath, nestedPatches: delta.nestedPatches };
+}
+
 /**
  * Run a subagent inside an isolation worktree and capture its changes.
  *
  * Branch mode: on success, commits the diff onto `omp/task/${agentId}` and
  * returns `branchName` + `nestedPatches`. On commit failure the branch is
- * deleted and `result.error` carries the merge-failure message.
+ * deleted, the still-live isolation diff is written to `${artifactsDir}/${agentId}.patch`,
+ * and `result.error` carries the merge-failure message.
  *
  * Patch mode: on success, writes `${artifactsDir}/${agentId}.patch` and
  * returns `patchPath` + `nestedPatches`.
@@ -162,18 +176,32 @@ export async function runIsolatedSubprocess(opts: IsolatedRunOptions): Promise<S
 				const branchName = `omp/task/${opts.agentId}`;
 				await git.branch.tryDelete(opts.context.repoRoot, branchName);
 				const msg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
-				return { ...result, error: `Merge failed: ${msg}` };
+				try {
+					const patchResult = await writeIsolationPatch(
+						isolationDir,
+						taskBaseline,
+						opts.artifactsDir,
+						opts.agentId,
+					);
+					return {
+						...result,
+						patchPath: patchResult.patchPath,
+						nestedPatches: patchResult.nestedPatches,
+						error: `Merge failed: ${msg}`,
+					};
+				} catch (patchErr) {
+					const patchMsg = patchErr instanceof Error ? patchErr.message : String(patchErr);
+					return { ...result, error: `Merge failed: ${msg}; patch capture failed: ${patchMsg}` };
+				}
 			}
 		}
 		if (result.exitCode === 0) {
 			try {
-				const delta = await captureDeltaPatch(isolationDir, taskBaseline);
-				const patchPath = path.join(opts.artifactsDir, `${opts.agentId}.patch`);
-				await Bun.write(patchPath, delta.rootPatch);
+				const patchResult = await writeIsolationPatch(isolationDir, taskBaseline, opts.artifactsDir, opts.agentId);
 				return {
 					...result,
-					patchPath,
-					nestedPatches: delta.nestedPatches,
+					patchPath: patchResult.patchPath,
+					nestedPatches: patchResult.nestedPatches,
 				};
 			} catch (patchErr) {
 				const msg = patchErr instanceof Error ? patchErr.message : String(patchErr);
@@ -224,8 +252,9 @@ export async function mergeIsolatedChanges(opts: IsolationMergeOptions): Promise
 	try {
 		if (mergeMode === "branch") {
 			if (!result.branchName && result.exitCode === 0 && !result.aborted && result.error) {
+				const patchList = result.patchPath ? `\nPatch artifact:\n- ${result.patchPath}` : "";
 				return {
-					summary: `\n\n<system-notification>Branch merge failed before a task branch could be created: ${result.error}\nTask outputs are preserved but changes were not applied.</system-notification>`,
+					summary: `\n\n<system-notification>Branch merge failed before a task branch could be created: ${result.error}\nTask outputs are preserved but changes were not applied.${patchList}</system-notification>`,
 					changesApplied: false,
 					hadAnyChanges: false,
 					mergedBranchForNestedPatches: false,

--- a/packages/coding-agent/test/task/isolation-runner.test.ts
+++ b/packages/coding-agent/test/task/isolation-runner.test.ts
@@ -2,10 +2,16 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { applyEligibleNestedPatches, mergeIsolatedChanges } from "@oh-my-pi/pi-coding-agent/task/isolation-runner";
+import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
+import {
+	applyEligibleNestedPatches,
+	mergeIsolatedChanges,
+	runIsolatedSubprocess,
+} from "@oh-my-pi/pi-coding-agent/task/isolation-runner";
 import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
 import * as worktreeModule from "@oh-my-pi/pi-coding-agent/task/worktree";
 import * as gitModule from "@oh-my-pi/pi-coding-agent/utils/git";
+import * as natives from "@oh-my-pi/pi-natives";
 import { $ } from "bun";
 
 function result(overrides: Partial<SingleResult> = {}): SingleResult {
@@ -64,6 +70,77 @@ async function seedFooRepo(finalContent: string): Promise<{ repoRoot: string; pa
 	return { repoRoot, patchPath };
 }
 
+describe("runIsolatedSubprocess", () => {
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await Promise.all(tempRoots.splice(0).map(tempRoot => fs.rm(tempRoot, { force: true, recursive: true })));
+	});
+
+	it("preserves branch-mode output as a patch when branch transfer fails", async () => {
+		const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-isolation-run-"));
+		tempRoots.push(repoRoot);
+		const isolationDir = path.join(repoRoot, "isolated");
+		const artifactsDir = path.join(repoRoot, "artifacts");
+		const baseline = {
+			root: {
+				repoRoot,
+				headCommit: "base",
+				staged: "",
+				unstaged: "",
+				untracked: [],
+				untrackedPatch: "",
+			},
+			nested: [],
+		};
+		const rootPatch = "diff --git a/task.txt b/task.txt\n--- a/task.txt\n+++ b/task.txt\n@@ -1 +1 @@\n-old\n+new\n";
+
+		vi.spyOn(worktreeModule, "ensureIsolation").mockResolvedValue({
+			mergedDir: isolationDir,
+			backend: natives.IsoBackendKind.Rcopy,
+			fellBack: false,
+			fallbackReason: null,
+		});
+		vi.spyOn(executorModule, "runSubprocess").mockResolvedValue(result({ id: "PreserveBranchFailure" }));
+		vi.spyOn(worktreeModule, "commitToBranch").mockRejectedValue(new Error("remote: object corrupt"));
+		const captureSpy = vi.spyOn(worktreeModule, "captureDeltaPatch").mockResolvedValue({
+			rootPatch,
+			nestedPatches: [],
+		});
+		const cleanupSpy = vi.spyOn(worktreeModule, "cleanupIsolation").mockResolvedValue();
+		const deleteSpy = vi.spyOn(gitModule.branch, "tryDelete").mockResolvedValue(true);
+
+		const outcome = await runIsolatedSubprocess({
+			baseOptions: {
+				cwd: repoRoot,
+				agent: {
+					name: "task",
+					description: "Task agent",
+					systemPrompt: "test",
+					source: "bundled",
+				},
+				task: "Do work",
+				index: 0,
+				id: "PreserveBranchFailure",
+			},
+			context: { repoRoot, baseline },
+			preferredBackend: undefined,
+			agentId: "PreserveBranchFailure",
+			mergeMode: "branch",
+			artifactsDir,
+			buildFailureResult: err => result({ exitCode: 1, error: String(err) }),
+		});
+
+		const patchPath = path.join(artifactsDir, "PreserveBranchFailure.patch");
+		expect(outcome.error).toContain("Merge failed: remote: object corrupt");
+		expect(outcome.patchPath).toBe(patchPath);
+		expect(await Bun.file(patchPath).text()).toBe(rootPatch);
+		expect(outcome.nestedPatches).toEqual([]);
+		expect(captureSpy).toHaveBeenCalledWith(isolationDir, baseline);
+		expect(deleteSpy).toHaveBeenCalledWith(repoRoot, "omp/task/PreserveBranchFailure");
+		expect(cleanupSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe("mergeIsolatedChanges", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
@@ -94,6 +171,7 @@ describe("mergeIsolatedChanges", () => {
 			mergeMode: "branch",
 			result: result({
 				error: "Merge failed: git apply --3way failed for task dirty-context: conflict",
+				patchPath: "/repo/artifacts/dirty-context.patch",
 			}),
 		});
 
@@ -103,6 +181,7 @@ describe("mergeIsolatedChanges", () => {
 		expect(outcome.mergedBranchForNestedPatches).toBe(false);
 		expect(outcome.summary).toContain("Branch merge failed before a task branch could be created");
 		expect(outcome.summary).toContain("git apply --3way failed");
+		expect(outcome.summary).toContain("/repo/artifacts/dirty-context.patch");
 		expect(outcome.summary).not.toContain("No changes to apply");
 	});
 


### PR DESCRIPTION
## Repro
Branch-mode isolated subagents lose their committed work when `commitToBranch()` fails before transferring objects into the parent repository: `bun test packages/coding-agent/test/task/isolation-runner.test.ts --filter "preserves branch-mode output"` failed with `outcome.patchPath` undefined after a simulated `remote: object corrupt` transfer failure.

## Cause
`packages/coding-agent/src/task/isolation-runner.ts` caught branch-mode `commitToBranch()` failures, deleted the stale `omp/task/<agent>` branch, and returned `Merge failed: ...` without capturing the still-live isolation diff; the `finally` block then called `cleanupIsolation()`, destroying the isolated worktree and any untransferred commit objects.

## Fix
- Added a shared `writeIsolationPatch()` helper for isolated diff artifact capture.
- Reused that helper in patch mode and in branch-mode `commitToBranch()` failure handling before cleanup runs.
- Returned `patchPath`/`nestedPatches` with the merge error and surfaced the patch artifact path in the branch-preparation failure summary.
- Added a regression test for branch-mode transfer failure preserving the patch artifact before cleanup.

## Verification
- `bun test packages/coding-agent/test/task/isolation-runner.test.ts` passed: 13 pass, 0 fail.
- `bun run check` in `packages/coding-agent` passed.

Fixes #4437