### PR TITLE
feat(todo): add blocked status with block/unblock ops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `block`/`unblock` todo operations and a `blocked` status for tasks waiting on external input; blocked tasks stay visible in the todo HUD and summary but are excluded from the incomplete-todo stop reminder, and an optional blocker note records what the task is waiting for.
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -338,6 +338,7 @@ const todoStatusMap: Record<TodoStatus, "pending" | "in_progress" | "completed">
 	in_progress: "in_progress",
 	completed: "completed",
 	abandoned: "completed",
+	blocked: "pending",
 };
 
 function mapTodoStatus(status: TodoStatus): "pending" | "in_progress" | "completed" {
@@ -401,7 +402,13 @@ function extractTodoEntries(phases: unknown[]): Array<{ content: string; status:
 }
 
 function isTodoStatus(status: unknown): status is TodoStatus {
-	return status === "pending" || status === "in_progress" || status === "completed" || status === "abandoned";
+	return (
+		status === "pending" ||
+		status === "in_progress" ||
+		status === "completed" ||
+		status === "abandoned" ||
+		status === "blocked"
+	);
 }
 export function buildToolCallStartUpdate(input: {
 	toolCallId: string;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1620,12 +1620,15 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	/**
-	 * Auto-complete any pending/in_progress todo whose content matches a
-	 * subagent that has finished successfully. Fires on every observer
+	 * Auto-complete any open todo (pending/in_progress/blocked) whose content
+	 * matches a subagent that has finished successfully. Fires on every observer
 	 * `onChange` so the visual state stays in sync with subagent lifecycle
-	 * without requiring the agent to issue a follow-up `todo`. Failed
-	 * and aborted subagents are intentionally NOT auto-completed — those
-	 * stay open so the user (or the next agent turn) can decide what to do.
+	 * without requiring the agent to issue a follow-up `todo`. A todo `block`ed
+	 * while waiting on a detached subagent is included: that subagent completing
+	 * is exactly the unblock signal, and blocked todos are excluded from the stop
+	 * reminder, so leaving it blocked would strand it silently. Failed and aborted
+	 * subagents are intentionally NOT auto-completed — those stay open so the user
+	 * (or the next agent turn) can decide what to do.
 	 *
 	 * Idempotent: only flips open tasks, never re-touches completed ones.
 	 */
@@ -1644,10 +1647,14 @@ export class InteractiveMode implements InteractiveModeContext {
 		const next: TodoPhase[] = this.todoPhases.map(phase => ({
 			name: phase.name,
 			tasks: phase.tasks.map(task => {
-				if (task.status !== "pending" && task.status !== "in_progress") return task;
+				if (task.status !== "pending" && task.status !== "in_progress" && task.status !== "blocked") {
+					return task;
+				}
 				if (!todoMatchesAnyDescription(task.content, completedDescs)) return task;
 				mutated = true;
-				return { ...task, status: "completed" as const };
+				// Drop any blocker note along with the blocked status — the wait the
+				// note described is over.
+				return { content: task.content, status: "completed" as const };
 			}),
 		}));
 		if (!mutated) return;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1760,7 +1760,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		// stage's `done/total` makes the hidden count obvious, so there is no
 		// "… more" row; expanded lists every task.
 		const renderTasks = (phase: TodoPhase): string[] => {
-			const open = phase.tasks.filter(t => t.status === "pending" || t.status === "in_progress");
+			const open = phase.tasks.filter(
+				t => t.status === "pending" || t.status === "in_progress" || t.status === "blocked",
+			);
 			const base = expanded ? phase.tasks : open.length > 0 ? open : phase.tasks;
 			const items = expanded ? base : base.slice(0, activeTaskCap);
 			return renderTreeList(

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1599,6 +1599,8 @@ export class InteractiveMode implements InteractiveModeContext {
 				return theme.fg("accent", `${prefix}${checkbox.unchecked} ${todo.content}`) + marker;
 			case "abandoned":
 				return theme.fg("error", `${prefix}${checkbox.unchecked} ${chalk.strikethrough(todo.content)}`) + marker;
+			case "blocked":
+				return theme.fg("warning", `${prefix}${checkbox.unchecked} ${todo.content} (blocked)`) + marker;
 			default:
 				if (matched) return theme.fg("accent", `${prefix}${checkbox.unchecked} ${todo.content}`) + marker;
 				return theme.fg("dim", `${prefix}${checkbox.unchecked} ${todo.content}`) + marker;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -70,7 +70,7 @@ export type SubmittedUserInput = {
 	started: boolean;
 };
 
-export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned";
+export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned" | "blocked";
 
 export type TodoItem = {
 	content: string;

--- a/packages/coding-agent/src/prompts/tools/todo.md
+++ b/packages/coding-agent/src/prompts/tools/todo.md
@@ -11,6 +11,8 @@ On each completion the earliest still-open task (in phase order) auto-promotes t
 |`start`|`task`|Mark in progress|
 |`done`|`task` or `phase`|Mark completed|
 |`drop`|`task` or `phase`|Mark abandoned|
+|`block`|`task` or `phase`, optional `reason`|Mark **blocked** — open but waiting on external input; excluded from the stop-time incomplete-todo reminder|
+|`unblock`|`task` or `phase`|Return a blocked task to `pending`|
 |`rm`|`task` or `phase` (optional)|Remove task or phase's tasks; omit both to clear the list|
 |`append`|`phase`, `items: string[]`|Append tasks to `phase`; lazily creates phase|
 |`view`|—|Read-only: echo the list, no modify|
@@ -22,7 +24,7 @@ On each completion the earliest still-open task (in phase order) auto-promotes t
 ## Rules
 - Mark tasks done immediately after finishing.
 - Complete phases in order.
-- Blocked? `append` a task to the active phase to unblock, or `drop`.
+- Waiting on something you can't act on (a user decision, another agent, an external service)? `block` the task (optional `reason`) — it stays in the tracker but won't trip the stop reminder; `unblock` when it's actionable again. If the blocker is itself agent-actionable, `append` an unblocking task instead.
 - Keep `task`/`phase` strings stable once introduced.
 - Lost the exact task text? `view` echoes the list — NEVER guess from memory; a mismatched `task` string is an error.
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8364,7 +8364,11 @@ export class AgentSession {
 	#cloneTodoPhases(phases: TodoPhase[]): TodoPhase[] {
 		return phases.map(phase => ({
 			name: phase.name,
-			tasks: phase.tasks.map(task => ({ content: task.content, status: task.status })),
+			tasks: phase.tasks.map(task =>
+				task.blocker !== undefined
+					? { content: task.content, status: task.status, blocker: task.blocker }
+					: { content: task.content, status: task.status },
+			),
 		}));
 	}
 

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -394,7 +394,12 @@ function applyEntry(phases: TodoPhase[], entry: TodoOpEntryValue, errors: string
 				errors.push("block requires a task or phase target");
 				return phases;
 			}
-			const reason = entry.reason?.trim() || undefined;
+			// Collapse whitespace runs (incl. newlines) to single spaces: a blocker
+			// note rides on one Markdown checklist line (as a trailing HTML comment)
+			// and one HUD/summary line, so an embedded newline from a multi-line
+			// external error or user question would corrupt the round-trip parse and
+			// the rendered line. Normalizing here keeps every consumer one-line-safe.
+			const reason = entry.reason?.replace(/\s+/g, " ").trim() || undefined;
 			for (const task of getTaskTargets(phases, entry, errors)) {
 				// Only actionable open work can be blocked: blocking a phase must not
 				// reopen completed/abandoned tasks or erase finished progress. An

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -18,13 +18,15 @@ import { formatErrorDetail, PREVIEW_LIMITS } from "./render-utils";
 // Types
 // =============================================================================
 
-export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned";
+export type TodoStatus = "pending" | "in_progress" | "completed" | "abandoned" | "blocked";
 /** Operation names accepted by the todo tool and echoed in successful result details. */
-export type TodoOperation = "init" | "start" | "done" | "rm" | "drop" | "append" | "view";
+export type TodoOperation = "init" | "start" | "done" | "rm" | "drop" | "block" | "unblock" | "append" | "view";
 
 export interface TodoItem {
 	content: string;
 	status: TodoStatus;
+	/** When `status === "blocked"`, an optional note on what the task is waiting for. */
+	blocker?: string;
 }
 
 export interface TodoPhase {
@@ -49,7 +51,9 @@ export interface TodoToolDetails {
 // Schema
 // =============================================================================
 
-const TodoOp = type('"init" | "start" | "done" | "rm" | "drop" | "append" | "view"').describe("operation to apply");
+const TodoOp = type('"init" | "start" | "done" | "rm" | "drop" | "block" | "unblock" | "append" | "view"').describe(
+	"operation to apply",
+);
 
 const InitListEntry = type({
 	phase: type("string").describe("phase name"),
@@ -65,6 +69,7 @@ const todoSchema = type({
 	// and both enforce non-empty with op-specific errors. A stray `items: []` on
 	// an op that ignores it (e.g. `view`) must not be a hard schema rejection.
 	"items?": type("string").describe("task content").array().describe("tasks to append"),
+	"reason?": type("string").describe("blocker note (block op)"),
 }).describe("apply a single todo operation");
 
 type TodoParams = TodoSchema;
@@ -89,7 +94,9 @@ function findPhaseByName(phases: TodoPhase[], name: string): TodoPhase | undefin
 }
 
 function cloneTask(task: TodoItem): TodoItem {
-	return { content: task.content, status: task.status };
+	return task.blocker !== undefined
+		? { content: task.content, status: task.status, blocker: task.blocker }
+		: { content: task.content, status: task.status };
 }
 
 function clonePhases(phases: TodoPhase[]): TodoPhase[] {
@@ -382,6 +389,23 @@ function applyEntry(phases: TodoPhase[], entry: TodoOpEntryValue, errors: string
 			}
 			return phases;
 		}
+		case "block": {
+			const reason = entry.reason?.trim() || undefined;
+			for (const task of getTaskTargets(phases, entry, errors)) {
+				task.status = "blocked";
+				task.blocker = reason;
+			}
+			return phases;
+		}
+		case "unblock": {
+			for (const task of getTaskTargets(phases, entry, errors)) {
+				if (task.status === "blocked") {
+					task.status = "pending";
+					task.blocker = undefined;
+				}
+			}
+			return phases;
+		}
 		case "rm":
 			return removeTasks(phases, entry, errors);
 		case "append":
@@ -421,6 +445,7 @@ const STATUS_TO_MARKER: Record<TodoStatus, string> = {
 	in_progress: "/",
 	completed: "x",
 	abandoned: "-",
+	blocked: "!",
 };
 
 export function resolveTodoMarkdownPath(input: string, cwd: string): string {
@@ -451,6 +476,7 @@ const MARKER_TO_STATUS: Record<string, TodoStatus> = {
 	">": "in_progress",
 	"-": "abandoned",
 	"~": "abandoned",
+	"!": "blocked",
 };
 
 /** Parse a Markdown checklist back into todo phases. */
@@ -482,7 +508,7 @@ export function markdownToPhases(md: string): { phases: TodoPhase[]; errors: str
 			const marker = taskMatch[1];
 			const status = MARKER_TO_STATUS[marker];
 			if (!status) {
-				errors.push(`Line ${lineNum + 1}: unknown status marker "[${marker}]" (use [ ], [x], [/], [-])`);
+				errors.push(`Line ${lineNum + 1}: unknown status marker "[${marker}]" (use [ ], [x], [/], [-], [!])`);
 				continue;
 			}
 			currentPhase.tasks.push({ content: taskMatch[2].trim(), status });
@@ -530,6 +556,7 @@ function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false):
 	}
 	// Closed = completed + abandoned, mirroring the per-phase `done` count.
 	const closedAll = tasks.filter(task => task.status === "completed" || task.status === "abandoned").length;
+	const blockedAll = tasks.filter(task => task.status === "blocked").length;
 	// The active phase is the EARLIEST one still holding open work, so the
 	// in-progress pointer can sit in a phase whose successors already have
 	// completed tasks. Detect that "worked ahead" case to explain the
@@ -539,7 +566,9 @@ function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false):
 		(phase, idx) =>
 			idx > currentIdx && phase.tasks.some(task => task.status === "completed" || task.status === "abandoned"),
 	);
-	lines.push(`Overall: ${closedAll}/${tasks.length} done, ${remainingTasks.length} open.`);
+	lines.push(
+		`Overall: ${closedAll}/${tasks.length} done, ${remainingTasks.length} open${blockedAll > 0 ? `, ${blockedAll} blocked` : ""}.`,
+	);
 	lines.push(
 		`Active phase ${currentIdx + 1}/${phases.length} "${current.name}" (${done}/${current.tasks.length})${
 			workedAhead
@@ -551,7 +580,16 @@ function formatSummary(phases: TodoPhase[], errors: string[], readOnly = false):
 		lines.push(`  ${phase.name}:`);
 		for (const task of phase.tasks) {
 			const checkbox = task.status === "completed" ? "[X]" : "[ ]";
-			const tag = task.status === "in_progress" ? " (in progress)" : task.status === "abandoned" ? " (dropped)" : "";
+			const tag =
+				task.status === "in_progress"
+					? " (in progress)"
+					: task.status === "abandoned"
+						? " (dropped)"
+						: task.status === "blocked"
+							? task.blocker
+								? ` (blocked: ${task.blocker})`
+								: " (blocked)"
+							: "";
 			lines.push(`    - ${checkbox} ${task.content}${tag}`);
 		}
 	}

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -396,9 +396,11 @@ function applyEntry(phases: TodoPhase[], entry: TodoOpEntryValue, errors: string
 			}
 			const reason = entry.reason?.trim() || undefined;
 			for (const task of getTaskTargets(phases, entry, errors)) {
-				// Only actionable open work can be blocked: blocking a phase must
-				// not reopen completed/abandoned tasks or erase finished progress.
-				if (task.status !== "pending" && task.status !== "in_progress") continue;
+				// Only actionable open work can be blocked: blocking a phase must not
+				// reopen completed/abandoned tasks or erase finished progress. An
+				// already-blocked task stays eligible so a later block can refine its
+				// blocker note (e.g. first blocked without a reason, then with one).
+				if (task.status !== "pending" && task.status !== "in_progress" && task.status !== "blocked") continue;
 				task.status = "blocked";
 				task.blocker = reason;
 			}
@@ -472,7 +474,12 @@ export function phasesToMarkdown(phases: TodoPhase[]): string {
 		if (i > 0) out.push("");
 		out.push(`# ${phases[i].name}`);
 		for (const task of phases[i].tasks) {
-			out.push(`- [${STATUS_TO_MARKER[task.status]}] ${task.content}`);
+			// A blocked task's reason rides in a trailing HTML comment: invisible in
+			// rendered markdown, unambiguous to parse back (task content can't
+			// contain the comment delimiters), so the note survives `/todo edit` and
+			// export/import round-trips.
+			const blockerNote = task.status === "blocked" && task.blocker ? ` <!-- blocker: ${task.blocker} -->` : "";
+			out.push(`- [${STATUS_TO_MARKER[task.status]}] ${task.content}${blockerNote}`);
 		}
 	}
 	return `${out.join("\n")}\n`;
@@ -522,7 +529,15 @@ export function markdownToPhases(md: string): { phases: TodoPhase[]; errors: str
 				errors.push(`Line ${lineNum + 1}: unknown status marker "[${marker}]" (use [ ], [x], [/], [-], [!])`);
 				continue;
 			}
-			currentPhase.tasks.push({ content: taskMatch[2].trim(), status });
+			// Recover a blocked task's reason from its trailing HTML comment (see
+			// phasesToMarkdown), then strip the comment from the visible content.
+			const rawContent = taskMatch[2].trim();
+			const blockerMatch = /^(.*?)\s*<!--\s*blocker:\s*(.*?)\s*-->$/.exec(rawContent);
+			if (status === "blocked" && blockerMatch) {
+				currentPhase.tasks.push({ content: blockerMatch[1].trim(), status, blocker: blockerMatch[2].trim() });
+			} else {
+				currentPhase.tasks.push({ content: rawContent, status });
+			}
 			continue;
 		}
 

--- a/packages/coding-agent/src/tools/todo.ts
+++ b/packages/coding-agent/src/tools/todo.ts
@@ -390,14 +390,25 @@ function applyEntry(phases: TodoPhase[], entry: TodoOpEntryValue, errors: string
 			return phases;
 		}
 		case "block": {
+			if (!entry.task && !entry.phase) {
+				errors.push("block requires a task or phase target");
+				return phases;
+			}
 			const reason = entry.reason?.trim() || undefined;
 			for (const task of getTaskTargets(phases, entry, errors)) {
+				// Only actionable open work can be blocked: blocking a phase must
+				// not reopen completed/abandoned tasks or erase finished progress.
+				if (task.status !== "pending" && task.status !== "in_progress") continue;
 				task.status = "blocked";
 				task.blocker = reason;
 			}
 			return phases;
 		}
 		case "unblock": {
+			if (!entry.task && !entry.phase) {
+				errors.push("unblock requires a task or phase target");
+				return phases;
+			}
 			for (const task of getTaskTargets(phases, entry, errors)) {
 				if (task.status === "blocked") {
 					task.status = "pending";
@@ -808,6 +819,10 @@ function formatTodoLine(
 			return uiTheme.fg("accent", `${prefix}${checkbox.unchecked} ${item.content}`);
 		case "abandoned":
 			return uiTheme.fg("error", `${prefix}${checkbox.unchecked} ${strikethroughText(item.content)}`);
+		case "blocked": {
+			const note = item.blocker ? `blocked: ${item.blocker}` : "blocked";
+			return uiTheme.fg("warning", `${prefix}${checkbox.unchecked} ${item.content} (${note})`);
+		}
 		default:
 			return uiTheme.fg("dim", `${prefix}${checkbox.unchecked} ${item.content}`);
 	}

--- a/packages/coding-agent/test/agent-session-todo-blocker-clone.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-blocker-clone.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression coverage: `AgentSession.#cloneTodoPhases` used to clone only
+ * `{ content, status }`, dropping the `blocker` note on every set/get. That made
+ * a blocker reason vanish on the first `todo view` or any later op even though it
+ * appeared in the immediate tool result. The contract: a blocked task's reason
+ * survives a `setTodoPhases` → `getTodoPhases` round-trip (the same clone every
+ * storage read/write goes through).
+ */
+describe("AgentSession todo blocker clone", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-todo-blocker-clone-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false, "todo.enabled": true, "todo.reminders": false }),
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		try {
+			await tempDir.remove();
+		} catch {}
+	});
+
+	it("preserves a blocker reason across a setTodoPhases/getTodoPhases round-trip", () => {
+		session.setTodoPhases([
+			{
+				name: "Work",
+				tasks: [
+					{ content: "a", status: "blocked", blocker: "waiting on sign-off" },
+					{ content: "b", status: "pending" },
+				],
+			},
+		]);
+
+		const roundTripped = session.getTodoPhases();
+		const blocked = roundTripped[0]?.tasks.find(task => task.content === "a");
+		expect(blocked?.status).toBe("blocked");
+		expect(blocked?.blocker).toBe("waiting on sign-off");
+		// A task with no blocker must not gain one through the clone.
+		const open = roundTripped[0]?.tasks.find(task => task.content === "b");
+		expect(open?.blocker).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -145,6 +145,36 @@ describe("InteractiveMode todo HUD persistence", () => {
 
 		expect(session.getTodoPhases()[0]?.tasks[0]?.status).toBe("completed");
 	});
+
+	it("completes a blocked todo when the detached subagent it waits on finishes", async () => {
+		await createMode(-1);
+		vi.spyOn(mode.statusLine, "watchBranch").mockImplementation(() => {});
+		// A todo blocked while waiting on a detached subagent. Blocked todos are
+		// excluded from the stop reminder, so if reconciliation skipped them this
+		// would strand silently after the subagent completes.
+		session.setTodoPhases([
+			{
+				name: "Implementation",
+				tasks: [{ content: "Fix review comments", status: "blocked", blocker: "waiting on ReviewFixer" }],
+			},
+		]);
+		mode.setTodos(session.getTodoPhases());
+
+		await mode.init();
+		eventBus.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+			id: "ReviewFixer",
+			index: 0,
+			agent: "task",
+			description: "Fix review comments",
+			status: "completed",
+			detached: true,
+		});
+
+		const task = session.getTodoPhases()[0]?.tasks[0];
+		expect(task?.status).toBe("completed");
+		// The blocker note is dropped with the blocked status — the wait is over.
+		expect(task?.blocker).toBeUndefined();
+	});
 });
 
 describe("InteractiveMode todo HUD anchor", () => {

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -307,6 +307,33 @@ describe("TodoTool operations", () => {
 		expect(parsedA?.blocker).toBe("x");
 	});
 
+	it("normalizes a multi-line blocker reason so the markdown round-trip survives", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a"] }] });
+		// A blocker reason lifted from a multi-line external error or user question.
+		const blocked = await tool.execute("call-2", {
+			op: "block",
+			task: "a",
+			reason: "waiting on user:\nline two\n\tindented three",
+		});
+		const phases = blocked.details?.phases ?? [];
+		const stored = phases[0]?.tasks.find(task => task.content === "a");
+		// Normalized at the source: whitespace runs (incl. newlines) collapse to
+		// single spaces, so every one-line consumer stays intact.
+		expect(stored?.blocker).toBe("waiting on user: line two indented three");
+
+		// Without normalization the embedded newline splits the HTML comment across
+		// two markdown lines: line one is an unclosed `<!-- blocker: …` and line two
+		// parses as unrecognized syntax, losing the reason and adding an error.
+		const md = phasesToMarkdown(phases);
+		expect(md.split("\n").filter(line => line.includes("- [!]"))).toHaveLength(1);
+		const { phases: parsed, errors } = markdownToPhases(md);
+		expect(errors).toEqual([]);
+		const parsedA = parsed[0]?.tasks.find(task => task.content === "a");
+		expect(parsedA?.status).toBe("blocked");
+		expect(parsedA?.blocker).toBe("waiting on user: line two indented three");
+	});
+
 	it("creates a phase when append targets a missing phase", async () => {
 		const tool = new TodoTool(createSession());
 		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["First"] }] });

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -4,7 +4,9 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
+	markdownToPhases,
 	nextActionableTask,
+	phasesToMarkdown,
 	resolveTodoMarkdownPath,
 	TODO_STRIKE_HOLD_FRAMES,
 	type TodoPhase,
@@ -191,6 +193,54 @@ describe("TodoTool operations", () => {
 			{ content: "First", status: "in_progress" },
 			{ content: "Second", status: "pending" },
 		]);
+	});
+
+	it("blocks a task (excluded from remaining, counted distinctly) and unblocks it", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a", "b"] }] });
+
+		const blocked = await tool.execute("call-2", { op: "block", task: "b", reason: "waiting on sign-off" });
+		const bTask = blocked.details?.phases[0]?.tasks.find(task => task.content === "b");
+		expect(bTask?.status).toBe("blocked");
+		expect(bTask?.blocker).toBe("waiting on sign-off");
+		const summary = blocked.content.find(part => part.type === "text");
+		if (summary?.type !== "text") throw new Error("Expected text summary from todo");
+		// `a` stays the only open item; `b` leaves the remaining/open set but is surfaced as blocked.
+		expect(summary.text).toContain("Remaining items (1):");
+		expect(summary.text).toContain("1 blocked");
+
+		const unblocked = await tool.execute("call-3", { op: "unblock", task: "b" });
+		const bAfter = unblocked.details?.phases[0]?.tasks.find(task => task.content === "b");
+		expect(bAfter?.status).toBe("pending");
+		expect(bAfter?.blocker).toBeUndefined();
+	});
+
+	it("does not auto-promote a blocked task to in_progress", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["only"] }] });
+
+		const result = await tool.execute("call-2", { op: "block", task: "only" });
+
+		// `only` was in_progress; blocking it leaves no pending/in_progress, so normalization must not revive it.
+		expect(result.details?.phases[0]?.tasks[0]?.status).toBe("blocked");
+	});
+
+	it("preserves blocked status across the markdown round-trip", () => {
+		const phases: TodoPhase[] = [
+			{
+				name: "Work",
+				tasks: [
+					{ content: "a", status: "blocked", blocker: "x" },
+					{ content: "b", status: "completed" },
+				],
+			},
+		];
+		const md = phasesToMarkdown(phases);
+		expect(md).toContain("- [!] a");
+
+		const { phases: parsed, errors } = markdownToPhases(md);
+		expect(errors).toEqual([]);
+		expect(parsed[0]?.tasks.find(task => task.content === "a")?.status).toBe("blocked");
 	});
 
 	it("creates a phase when append targets a missing phase", async () => {

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -225,6 +225,52 @@ describe("TodoTool operations", () => {
 		expect(result.details?.phases[0]?.tasks[0]?.status).toBe("blocked");
 	});
 
+	it("blocking a phase leaves completed/abandoned tasks closed", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a", "b", "c"] }] });
+		await tool.execute("call-2", { op: "done", task: "a" });
+		await tool.execute("call-3", { op: "drop", task: "c" });
+
+		const result = await tool.execute("call-4", { op: "block", phase: "Work", reason: "waiting on infra" });
+		const tasks = result.details?.phases[0]?.tasks ?? [];
+		const byContent = (content: string) => tasks.find(task => task.content === content);
+		// Completed/abandoned work is untouched; only the open task becomes blocked.
+		expect(byContent("a")?.status).toBe("completed");
+		expect(byContent("c")?.status).toBe("abandoned");
+		expect(byContent("b")?.status).toBe("blocked");
+		expect(byContent("b")?.blocker).toBe("waiting on infra");
+		// A completed task must never carry a blocker note.
+		expect(byContent("a")?.blocker).toBeUndefined();
+	});
+
+	it("rejects a block with neither task nor phase target", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a", "b"] }] });
+
+		const result = await tool.execute("call-2", { op: "block", reason: "oops" });
+		expect(result.isError).toBe(true);
+		const summary = result.content.find(part => part.type === "text");
+		if (summary?.type !== "text") throw new Error("Expected text summary from todo");
+		expect(summary.text).toContain("block requires a task or phase target");
+		// Nothing was blocked — state is unchanged.
+		const tasks = result.details?.phases[0]?.tasks ?? [];
+		expect(tasks.every(task => task.status !== "blocked")).toBe(true);
+	});
+
+	it("rejects an unblock with neither task nor phase target", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a"] }] });
+		await tool.execute("call-2", { op: "block", task: "a", reason: "x" });
+
+		const result = await tool.execute("call-3", { op: "unblock" });
+		expect(result.isError).toBe(true);
+		const summary = result.content.find(part => part.type === "text");
+		if (summary?.type !== "text") throw new Error("Expected text summary from todo");
+		expect(summary.text).toContain("unblock requires a task or phase target");
+		// The blocked task stays blocked — the targetless unblock was rejected.
+		expect(result.details?.phases[0]?.tasks[0]?.status).toBe("blocked");
+	});
+
 	it("preserves blocked status across the markdown round-trip", () => {
 		const phases: TodoPhase[] = [
 			{

--- a/packages/coding-agent/test/tools/todo.test.ts
+++ b/packages/coding-agent/test/tools/todo.test.ts
@@ -243,6 +243,21 @@ describe("TodoTool operations", () => {
 		expect(byContent("a")?.blocker).toBeUndefined();
 	});
 
+	it("re-blocking an already-blocked task refines its blocker note", async () => {
+		const tool = new TodoTool(createSession());
+		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a", "b"] }] });
+		// First block with no reason, then block again to add one — the agent often
+		// learns what it's waiting on only after the initial block.
+		await tool.execute("call-2", { op: "block", task: "b" });
+		const first = await tool.execute("call-3", { op: "block", task: "b" });
+		expect(first.details?.phases[0]?.tasks.find(task => task.content === "b")?.blocker).toBeUndefined();
+
+		const refined = await tool.execute("call-4", { op: "block", task: "b", reason: "waiting on user" });
+		const bTask = refined.details?.phases[0]?.tasks.find(task => task.content === "b");
+		expect(bTask?.status).toBe("blocked");
+		expect(bTask?.blocker).toBe("waiting on user");
+	});
+
 	it("rejects a block with neither task nor phase target", async () => {
 		const tool = new TodoTool(createSession());
 		await tool.execute("call-1", { op: "init", list: [{ phase: "Work", items: ["a", "b"] }] });
@@ -286,7 +301,10 @@ describe("TodoTool operations", () => {
 
 		const { phases: parsed, errors } = markdownToPhases(md);
 		expect(errors).toEqual([]);
-		expect(parsed[0]?.tasks.find(task => task.content === "a")?.status).toBe("blocked");
+		const parsedA = parsed[0]?.tasks.find(task => task.content === "a");
+		expect(parsedA?.status).toBe("blocked");
+		// The blocker reason must survive the round-trip, not just the status.
+		expect(parsedA?.blocker).toBe("x");
 	});
 
 	it("creates a phase when append targets a missing phase", async () => {


### PR DESCRIPTION
## What

Add a `blocked` todo status, with `block`/`unblock` operations and an optional blocker note.

## Why

Fixes #3581. There was no honest status for a task that is open but can't proceed because it waits on something the agent can't act on (a user decision, another agent, an external action). Leaving it `pending`/`in_progress` re-arms the stop-time incomplete-todo reminder every turn; `drop` marks it `abandoned` — wrong, and it leaves the tracker. `blocked` keeps the task visible but excluded from the reminder (via the existing `pending`/`in_progress` allowlist) and from auto-promotion.

## Testing

`packages/coding-agent/test/tools/todo.test.ts` — block/unblock transitions + blocker note; the summary excludes blocked from "remaining/open" and counts it distinctly; the markdown round-trip preserves `blocked` (`[!]` marker); a sole blocked task is not auto-promoted. Existing todo / reminder-loop / command-controller / todo-clear / acp-event-mapper suites pass. The mode-layer `TodoStatus`, the ACP status map + `isTodoStatus` guard, the markdown markers, and the renderers were all synced (tsgo-verified exhaustive).

## Rebase note

Applied cleanly onto upstream's ArkType todo schema (one-line schema merge; `reason` is a new blocked-only field, distinct from the removed task notes).

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)