### PR TITLE
fix(tui): emit BEL under Zellij so notifications flag backgrounded panes

### DIFF
--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -122,6 +122,13 @@ export class TerminalInfo {
 			process.stdout.write(`${wrapTmuxPassthrough(formatted)}\x07`);
 			return;
 		}
+		// Zellij drops OSC 9/99 and has no DCS passthrough envelope, but raises its
+		// `[!]` bell flag on a bare BEL — the same backgrounded-pane signal tmux
+		// users get. So follow the (Zellij-swallowed) OSC with a plain BEL.
+		if (this.notifyProtocol !== NotifyProtocol.Bell && isInsideZellij()) {
+			process.stdout.write(`${formatted}\x07`);
+			return;
+		}
 		process.stdout.write(formatted);
 		// VTE-family terminals (Ptyxis, GNOME Terminal, Tilix, …) plus Alacritty
 		// and bare xterm-on-Wayland have no in-band escape that surfaces an
@@ -154,6 +161,15 @@ export function isInsideTerminalMultiplexer(env: NodeJS.ProcessEnv = Bun.env): b
 	if (env.CMUX_WORKSPACE_ID || env.CMUX_SURFACE_ID) return true;
 	const term = env.TERM?.toLowerCase() ?? "";
 	return term.startsWith("tmux") || term.startsWith("screen");
+}
+
+/**
+ * Whether the agent process is running inside a Zellij session. Read fresh on
+ * each call (like {@link isInsideTmux}) so a session attached/detached mid-run
+ * is observed and tests can toggle `Bun.env.ZELLIJ` per case.
+ */
+export function isInsideZellij(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	return Boolean(env.ZELLIJ);
 }
 
 /**

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -4,6 +4,7 @@ import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
 import {
 	getTerminalInfo,
 	isInsideTmux,
+	isInsideZellij,
 	isOsc99Supported,
 	NotifyProtocol,
 	setOsc99Supported,
@@ -17,6 +18,7 @@ const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "i
 const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
 const originalOsc99Probe = Bun.env.PI_TUI_OSC99_PROBE;
 const originalTmux = Bun.env.TMUX;
+const originalZellij = Bun.env.ZELLIJ;
 const originalPiNotifications = Bun.env.PI_NOTIFICATIONS;
 const mutableTerminal = TERMINAL as unknown as { notifyProtocol: NotifyProtocol };
 const originalNotifyProtocol = mutableTerminal.notifyProtocol;
@@ -71,6 +73,7 @@ describe("terminal notifications", () => {
 		// Default the suite to the "outside tmux" baseline so probe/format
 		// assertions never see a stray inherited TMUX leaking the DCS wrap in.
 		delete Bun.env.TMUX;
+		delete Bun.env.ZELLIJ;
 		// `PI_NOTIFICATIONS=off` is set in this workspace's CI env, which would
 		// short-circuit `sendNotification` before it writes anything. Clear it
 		// so the delivery-path assertions actually observe stdout writes.
@@ -84,6 +87,7 @@ describe("terminal notifications", () => {
 		mutableTerminal.notifyProtocol = originalNotifyProtocol;
 		restoreEnv("PI_TUI_OSC99_PROBE", originalOsc99Probe);
 		restoreEnv("TMUX", originalTmux);
+		restoreEnv("ZELLIJ", originalZellij);
 		restoreEnv("PI_NOTIFICATIONS", originalPiNotifications);
 		restoreProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
 		restoreProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
@@ -261,6 +265,30 @@ describe("terminal notifications", () => {
 		TERMINAL.sendNotification("ping");
 
 		expect(writes).toEqual(["\x1b]99;;ping\x1b\\"]);
+	});
+
+	it("isInsideZellij reads the ZELLIJ env fresh on each call", () => {
+		expect(isInsideZellij()).toBe(false);
+		Bun.env.ZELLIJ = "0";
+		expect(isInsideZellij()).toBe(true);
+		delete Bun.env.ZELLIJ;
+		expect(isInsideZellij()).toBe(false);
+	});
+
+	it("under Zellij, OSC-protocol sendNotification appends a plain BEL (no DCS wrap)", () => {
+		Bun.env.ZELLIJ = "0";
+		mutableTerminal.notifyProtocol = NotifyProtocol.Osc99;
+		const writes: string[] = [];
+		vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+			return true;
+		});
+
+		TERMINAL.sendNotification("ping");
+
+		// Zellij raises its [!] bell flag on a bare BEL; it has no DCS passthrough,
+		// so the OSC (which Zellij drops) is followed by a plain BEL — no wrap.
+		expect(writes).toEqual(["\x1b]99;;ping\x1b\\\x07"]);
 	});
 
 	it("under tmux, the OSC 99 capability probe is wrapped in DCS passthrough", () => {


### PR DESCRIPTION
## What

Add `isInsideZellij()` and a Zellij branch in `sendNotification`: for non-`Bell` protocols inside Zellij, follow the (Zellij-swallowed) OSC with a bare `\x07`, raising Zellij's `[!]` bell flag.

## Why

Fixes #3583. `TerminalInfo.sendNotification` appended a `BEL` only inside tmux. Under Zellij, OSC 9/99 desktop notifications are dropped (Zellij doesn't forward them and has no DCS passthrough) and no `BEL` was emitted, so a backgrounded Zellij pane got no attention indicator when the agent finished a turn or blocked on input. This mirrors the existing tmux behavior; the tmux branch stays first so a nested tmux-inside-Zellij session still takes the passthrough path.

## Testing

`packages/tui/test/notifications.test.ts` — `isInsideZellij` reads `ZELLIJ` fresh; under Zellij an OSC-protocol `sendNotification` writes the OSC followed by a bare `BEL` (no DCS wrap). `ZELLIJ` env is cleaned up per-test alongside the existing `TMUX` handling.

## Rebase note

Upstream added a generic `NotifyProtocol.Bell` since; the branch's `notifyProtocol !== Bell && isInsideZellij()` guard sits correctly on top of it (the Zellij path is still absent upstream).

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
