### PR TITLE
feat(statusline): make git segment jj-aware

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line/component.jj-cache.test.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.jj-cache.test.ts
@@ -183,4 +183,47 @@ describe("StatusLineComponent jj cache coherence", () => {
 		await flushMicrotasks();
 		expect(visible(statusLine.getTopBorder(WIDTH).content)).toContain("branch-B");
 	});
+
+	it("a jj lookup that resolves after a same-root invalidation never lands as stale", async () => {
+		// The finding-6 race: a HEAD/bookmark move invalidates the caches while a
+		// branch query for the SAME root is still in flight. #invalidateGitCaches
+		// resets #jjRoot, but the next render re-resolves it to the identical root
+		// string — so a guard keyed only on root equality would accept the
+		// pre-invalidation result. The generation token must reject it.
+		const deferred = Promise.withResolvers<string | null>();
+		let call = 0;
+		const branchSpy = spyOn(jjInfo, "queryJjBranch").mockImplementation(async () => {
+			call++;
+			// First query (pre-invalidation) hangs; later queries return the fresh label.
+			return call === 1 ? deferred.promise : "bookmark-fresh";
+		});
+		spies.push(branchSpy);
+
+		const statusLine = new StatusLineComponent(makeSession());
+
+		// Render in ROOT_A: starts the (hanging) first lookup. Nothing cached yet.
+		statusLine.getTopBorder(WIDTH);
+		await flushMicrotasks();
+		expect(branchSpy).toHaveBeenCalledTimes(1);
+
+		// A HEAD/bookmark move fires the watcher → invalidate(). The cwd is
+		// unchanged, so the next #jjRootFor re-resolves #jjRoot to the SAME ROOT_A.
+		statusLine.invalidate();
+		statusLine.getTopBorder(WIDTH);
+		await flushMicrotasks();
+
+		// The stale first query now resolves. The generation captured at its launch
+		// no longer matches (invalidate bumped it), so its label must be dropped —
+		// never cached, and the throttle must NOT be advanced on it.
+		deferred.resolve("bookmark-stale");
+		await flushMicrotasks();
+		const paintedImmediate = visible(statusLine.getTopBorder(WIDTH).content);
+		expect(paintedImmediate).not.toContain("bookmark-stale");
+
+		// Because the stale result did not advance the throttle, the post-invalidate
+		// cache is free to refetch and paint the fresh label.
+		await flushMicrotasks();
+		expect(visible(statusLine.getTopBorder(WIDTH).content)).toContain("bookmark-fresh");
+		expect(branchSpy).toHaveBeenCalledTimes(2);
+	});
 });

--- a/packages/coding-agent/src/modes/components/status-line/component.jj-cache.test.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.jj-cache.test.ts
@@ -1,0 +1,187 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { settings, Settings } from "../../../config/settings";
+import type { AgentSession } from "../../../session/agent-session";
+import * as git from "../../../utils/git";
+import { getThemeByName, setThemeInstance } from "../../theme/theme";
+import { StatusLineComponent } from "./component";
+import * as jjInfo from "./jj-info";
+
+// Minimal session the git-only status line render path touches: state.messages
+// (token-rate scan), model window, streaming flag, and the async-job snapshot.
+// The `git` segment reads none of these — they only keep #buildStatusLine from
+// throwing while it renders the single segment under test.
+function makeSession(): AgentSession {
+	const model = { contextWindow: 128000 } as const;
+	return {
+		state: { messages: [], model },
+		messages: [],
+		model,
+		isStreaming: false,
+		sessionFile: undefined,
+		getAsyncJobSnapshot: () => null,
+		getContextUsage: () => ({ tokens: 0, contextWindow: 128000 }),
+	} as unknown as AgentSession;
+}
+
+// Drain the microtask queue so the fire-and-forget async jj lookups started by a
+// render() have applied their result to the cache. No real timers: only
+// already-resolved promises are awaited, so this stays deterministic.
+async function flushMicrotasks(): Promise<void> {
+	for (let i = 0; i < 8; i++) await Promise.resolve();
+}
+
+// Strip SGR/OSC escapes so assertions match on the visible branch label text.
+function visible(s: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: matching terminal escapes
+	return s.replace(/\x1b\][^\x07]*\x07/g, "").replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const WIDTH = 200;
+
+let spies: Array<{ mockRestore(): void }> = [];
+let tmpA: string;
+let tmpB: string;
+let originalProjectDir: string;
+const ROOT_A = "/virtual/jj-root-a";
+const ROOT_B = "/virtual/jj-root-b";
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+	const loaded = await getThemeByName("dark");
+	if (!loaded) throw new Error("theme unavailable");
+	setThemeInstance(loaded);
+	// Render only the git segment: shrinks the render surface to the code under
+	// test and keeps the fake session tiny. Constructor snapshots these, so they
+	// must be set before any `new StatusLineComponent`.
+	settings.override("statusLine.preset", "custom");
+	settings.override("statusLine.leftSegments", ["git"]);
+	settings.override("statusLine.rightSegments", []);
+	originalProjectDir = getProjectDir();
+	tmpA = fs.mkdtempSync(path.join(os.tmpdir(), "jjcache-a-"));
+	tmpB = fs.mkdtempSync(path.join(os.tmpdir(), "jjcache-b-"));
+});
+
+afterAll(() => {
+	settings.clearOverride("statusLine.preset");
+	settings.clearOverride("statusLine.leftSegments");
+	settings.clearOverride("statusLine.rightSegments");
+	setProjectDir(originalProjectDir);
+	fs.rmSync(tmpA, { recursive: true, force: true });
+	fs.rmSync(tmpB, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+	// Force the jj fallback branch in #buildSegmentContext: git HEAD resolves to
+	// null (so gitBranch === null triggers #getJjBranch), and no repo/worktree is
+	// detected (so effectiveGitCwd stays the raw project dir we control).
+	spies = [
+		spyOn(git.head, "resolveSync").mockReturnValue(null),
+		spyOn(git.repo, "resolveSync").mockReturnValue(null),
+		spyOn(git.repo, "linkedWorktreeSync").mockReturnValue(null),
+		// jj status: return a clean summary so #getJjStatus never falls through to
+		// the real `git status` subprocess. Keeps the git segment's status empty so
+		// the visible content is exactly the branch label.
+		spyOn(jjInfo, "queryJjStatus").mockResolvedValue({ staged: 0, unstaged: 0, untracked: 0 }),
+		// Map each controlled project dir to a stable virtual jj root.
+		spyOn(jjInfo, "findJjRoot").mockImplementation(cwd => {
+			if (cwd === tmpA) return ROOT_A;
+			if (cwd === tmpB) return ROOT_B;
+			return null;
+		}),
+	];
+	setProjectDir(tmpA);
+});
+
+afterEach(() => {
+	for (const s of spies) s.mockRestore();
+	spies = [];
+});
+
+describe("StatusLineComponent jj cache coherence", () => {
+	it("invalidate() drops the throttled jj branch cache within its TTL and refetches", async () => {
+		// A live jj bookmark label; a second query for the SAME root returns a new
+		// label, simulating a colocated bookmark/HEAD move mid-TTL.
+		const branchSpy = spyOn(jjInfo, "queryJjBranch").mockResolvedValue("bookmark-v1");
+		spies.push(branchSpy);
+
+		const statusLine = new StatusLineComponent(makeSession());
+
+		// First render kicks off the async lookup (returns the empty cache); after
+		// it resolves, a second render paints the fetched label.
+		statusLine.getTopBorder(WIDTH);
+		await flushMicrotasks();
+		expect(visible(statusLine.getTopBorder(WIDTH).content)).toContain("bookmark-v1");
+		expect(branchSpy).toHaveBeenCalledTimes(1);
+
+		// Move the bookmark: a plain render within the 5s TTL must keep serving the
+		// cached label without a refetch (guards that the TTL is real, so the next
+		// assertion proves invalidate() — not TTL expiry — forces the refresh).
+		branchSpy.mockResolvedValue("bookmark-v2");
+		const throttled = visible(statusLine.getTopBorder(WIDTH).content);
+		await flushMicrotasks();
+		expect(throttled).toContain("bookmark-v1");
+		expect(branchSpy).toHaveBeenCalledTimes(1);
+
+		// invalidate() (public watcher trigger) must reset the jj caches so the
+		// next render refetches despite being inside the TTL, and paint the new
+		// label — the finding-1 contract.
+		statusLine.invalidate();
+		statusLine.getTopBorder(WIDTH);
+		await flushMicrotasks();
+		expect(branchSpy).toHaveBeenCalledTimes(2);
+		expect(visible(statusLine.getTopBorder(WIDTH).content)).toContain("bookmark-v2");
+		expect(visible(statusLine.getTopBorder(WIDTH).content)).not.toContain("bookmark-v1");
+	});
+
+	it("a jj lookup that resolves after the root changed never lands in the new root's cache", async () => {
+		// Root A's query hangs on a deferred so it is still in flight when we
+		// switch repos; root B resolves with its own label.
+		const deferredA = Promise.withResolvers<string | null>();
+		const branchSpy = spyOn(jjInfo, "queryJjBranch").mockImplementation(async root => {
+			if (root === ROOT_A) return deferredA.promise;
+			if (root === ROOT_B) return "branch-B";
+			return null;
+		});
+		spies.push(branchSpy);
+
+		const statusLine = new StatusLineComponent(makeSession());
+
+		// Render in repo A: starts the (hanging) lookup for ROOT_A. Nothing painted
+		// yet — the cache is empty and the query is unresolved.
+		expect(visible(statusLine.getTopBorder(WIDTH).content)).not.toContain("branch-A-STALE");
+		expect(branchSpy).toHaveBeenCalledTimes(1);
+
+		// Switch to repo B mid-flight. #jjRootFor(tmpB) re-points #jjRoot to ROOT_B
+		// and resets the jj caches; ROOT_A's lookup is now stale. The render can't
+		// start B's lookup yet — the single in-flight flag is still held by A.
+		setProjectDir(tmpB);
+		statusLine.getTopBorder(WIDTH);
+		await flushMicrotasks();
+		expect(branchSpy).toHaveBeenCalledTimes(1);
+
+		// Let ROOT_A's slow query finish, then drain its continuation. The
+		// root-keyed guard must DROP it: #jjRoot is ROOT_B, so A's label must never
+		// become B's cached branch, and A's completion must not advance B's
+		// throttle (leaving B free to refetch) — the finding-2/4 contract.
+		deferredA.resolve("branch-A-STALE");
+		await flushMicrotasks();
+
+		// The very next render paints synchronously from the current cache BEFORE
+		// any new fetch resolves. This is the only window the transient stale is
+		// observable: with the fix the cache is empty here (A's result was
+		// dropped), so this render both refuses to paint A's label AND is free to
+		// launch B's refetch. Without the fix, A's stale label is already sitting
+		// in B's cache and paints here.
+		const paintedImmediate = visible(statusLine.getTopBorder(WIDTH).content);
+		expect(paintedImmediate).not.toContain("branch-A-STALE");
+
+		// Steady state: B's (now unthrottled) refetch resolves and paints B's real
+		// label — confirming the switch left B's cache coherent, not poisoned.
+		await flushMicrotasks();
+		expect(visible(statusLine.getTopBorder(WIDTH).content)).toContain("branch-B");
+	});
+});

--- a/packages/coding-agent/src/modes/components/status-line/component.jj-cache.test.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.jj-cache.test.ts
@@ -1,9 +1,9 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
-import { settings, Settings } from "../../../config/settings";
+import { Settings, settings } from "../../../config/settings";
 import type { AgentSession } from "../../../session/agent-session";
 import * as git from "../../../utils/git";
 import { getThemeByName, setThemeInstance } from "../../theme/theme";
@@ -36,7 +36,6 @@ async function flushMicrotasks(): Promise<void> {
 
 // Strip SGR/OSC escapes so assertions match on the visible branch label text.
 function visible(s: string): string {
-	// biome-ignore lint/suspicious/noControlCharactersInRegex: matching terminal escapes
 	return s.replace(/\x1b\][^\x07]*\x07/g, "").replace(/\x1b\[[0-9;]*m/g, "");
 }
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -293,6 +293,13 @@ export class StatusLineComponent implements Component {
 	#cachedJjStatus: { staged: number; unstaged: number; untracked: number } | null = null;
 	#jjStatusLastFetch = 0;
 	#jjStatusInFlight = false;
+	// Bumped on every jj-cache reset — a cwd switch (#jjRootFor) or a HEAD /
+	// bookmark move (#invalidateGitCaches). An in-flight jj query captures this
+	// at launch; a mismatch on resolve means the caches were reset underneath it
+	// (including a reset that re-resolves to the SAME root, which a root-equality
+	// check cannot detect), so the result is stale and must be dropped rather
+	// than poison the fresh cache or advance its throttle.
+	#jjCacheGeneration = 0;
 
 	// PR lookup caching (invalidated on branch/repo context changes)
 	#cachedPr: { number: number; url: string } | null | undefined = undefined;
@@ -604,6 +611,7 @@ export class StatusLineComponent implements Component {
 		this.#jjBranchLastFetch = 0;
 		this.#cachedJjStatus = null;
 		this.#jjStatusLastFetch = 0;
+		this.#jjCacheGeneration++;
 	}
 	#getCurrentBranch(effectiveGitCwd?: string): string | null {
 		if (!this.#gitEnabled()) return null;
@@ -696,6 +704,7 @@ export class StatusLineComponent implements Component {
 			this.#jjBranchLastFetch = 0;
 			this.#cachedJjStatus = null;
 			this.#jjStatusLastFetch = 0;
+			this.#jjCacheGeneration++;
 		}
 		return this.#jjRoot;
 	}
@@ -711,19 +720,22 @@ export class StatusLineComponent implements Component {
 			return this.#cachedJjBranch;
 		}
 		this.#jjBranchInFlight = true;
+		const generation = this.#jjCacheGeneration;
 		(async () => {
 			let next: string | null = null;
 			try {
 				next = await jjInfo.queryJjBranch(root);
 			} finally {
 				this.#jjBranchInFlight = false;
-				// Only advance this root's throttle; a mid-flight cwd/root switch
-				// leaves the new root's reset TTL intact so it refetches.
-				if (this.#jjRoot === root) this.#jjBranchLastFetch = Date.now();
+				// Advance the throttle only if no reset raced this query; a reset
+				// leaves LastFetch at 0 so the current root refetches instead of
+				// being throttled on a superseded result.
+				if (this.#jjCacheGeneration === generation) this.#jjBranchLastFetch = Date.now();
 			}
-			// Drop a result whose root is no longer current (repo switched or
-			// caches invalidated mid-flight) so A's label never lands in B's cache.
-			if (this.#jjRoot !== root || this.#disposed) return;
+			// Drop a result whose caches were reset mid-flight — a repo switch OR a
+			// same-root HEAD/bookmark move — so a superseded label never lands in
+			// the live cache.
+			if (this.#jjCacheGeneration !== generation || this.#disposed) return;
 			const changed = next !== this.#cachedJjBranch;
 			this.#cachedJjBranch = next;
 			if (changed && this.#onBranchChange) this.#onBranchChange();
@@ -742,15 +754,16 @@ export class StatusLineComponent implements Component {
 			return this.#cachedJjStatus;
 		}
 		this.#jjStatusInFlight = true;
+		const generation = this.#jjCacheGeneration;
 		(async () => {
 			let next: { staged: number; unstaged: number; untracked: number } | null = null;
 			try {
 				next = await jjInfo.queryJjStatus(root);
 			} finally {
 				this.#jjStatusInFlight = false;
-				if (this.#jjRoot === root) this.#jjStatusLastFetch = Date.now();
+				if (this.#jjCacheGeneration === generation) this.#jjStatusLastFetch = Date.now();
 			}
-			if (this.#jjRoot !== root || this.#disposed) return;
+			if (this.#jjCacheGeneration !== generation || this.#disposed) return;
 			const prev = this.#cachedJjStatus;
 			this.#cachedJjStatus = next;
 			if (this.#onBranchChange && JSON.stringify(prev) !== JSON.stringify(next)) this.#onBranchChange();

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -595,6 +595,15 @@ export class StatusLineComponent implements Component {
 		this.#cachedBranchRepoId = undefined;
 		this.#cachedBranchCwd = undefined;
 		this.#cachedPrContext = undefined;
+		// jj label/status share the git segment's lifecycle: a HEAD move (e.g. a
+		// colocated `jj new`/bookmark move) must drop the throttled jj caches too,
+		// mirroring #jjRootFor's per-cwd reset so the next render refetches.
+		this.#jjRoot = undefined;
+		this.#jjRootCwd = undefined;
+		this.#cachedJjBranch = null;
+		this.#jjBranchLastFetch = 0;
+		this.#cachedJjStatus = null;
+		this.#jjStatusLastFetch = 0;
 	}
 	#getCurrentBranch(effectiveGitCwd?: string): string | null {
 		if (!this.#gitEnabled()) return null;
@@ -694,25 +703,30 @@ export class StatusLineComponent implements Component {
 	// jj working-copy bookmark label (nearest bookmark, change-id fallback), shown
 	// in the `git` segment where git HEAD is detached/absent under jj. Throttled,
 	// cached, and repaints on resolve.
-	#getJjBranch(): string | null {
-		const root = this.#jjRootFor(getProjectDir());
+	#getJjBranch(effectiveGitCwd?: string): string | null {
+		const cwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
+		const root = this.#jjRootFor(cwd);
 		if (!root) return null;
 		if (this.#jjBranchInFlight || Date.now() - this.#jjBranchLastFetch < jjInfo.JJ_BRANCH_TTL_MS) {
 			return this.#cachedJjBranch;
 		}
 		this.#jjBranchInFlight = true;
 		(async () => {
+			let next: string | null = null;
 			try {
-				const next = await jjInfo.queryJjBranch(root);
-				const changed = next !== this.#cachedJjBranch;
-				this.#cachedJjBranch = next;
-				if (changed && !this.#disposed && this.#onBranchChange) {
-					this.#onBranchChange();
-				}
+				next = await jjInfo.queryJjBranch(root);
 			} finally {
-				this.#jjBranchLastFetch = Date.now();
 				this.#jjBranchInFlight = false;
+				// Only advance this root's throttle; a mid-flight cwd/root switch
+				// leaves the new root's reset TTL intact so it refetches.
+				if (this.#jjRoot === root) this.#jjBranchLastFetch = Date.now();
 			}
+			// Drop a result whose root is no longer current (repo switched or
+			// caches invalidated mid-flight) so A's label never lands in B's cache.
+			if (this.#jjRoot !== root || this.#disposed) return;
+			const changed = next !== this.#cachedJjBranch;
+			this.#cachedJjBranch = next;
+			if (changed && this.#onBranchChange) this.#onBranchChange();
 		})();
 		return this.#cachedJjBranch;
 	}
@@ -720,24 +734,26 @@ export class StatusLineComponent implements Component {
 	// jj working-copy status counts (`@` vs its parent), used in place of git
 	// status in a jj repo where `git status` has no `.git` to read. Throttled,
 	// cached, and repaints on resolve like #getJjBranch.
-	#getJjStatus(): { staged: number; unstaged: number; untracked: number } | null {
-		const root = this.#jjRootFor(getProjectDir());
+	#getJjStatus(effectiveGitCwd?: string): { staged: number; unstaged: number; untracked: number } | null {
+		const cwd = effectiveGitCwd ?? this.#resolveActiveRepoCache().effectiveGitCwd;
+		const root = this.#jjRootFor(cwd);
 		if (!root) return null;
 		if (this.#jjStatusInFlight || Date.now() - this.#jjStatusLastFetch < jjInfo.JJ_BRANCH_TTL_MS) {
 			return this.#cachedJjStatus;
 		}
 		this.#jjStatusInFlight = true;
 		(async () => {
-			const prev = this.#cachedJjStatus;
+			let next: { staged: number; unstaged: number; untracked: number } | null = null;
 			try {
-				this.#cachedJjStatus = await jjInfo.queryJjStatus(root);
+				next = await jjInfo.queryJjStatus(root);
 			} finally {
-				this.#jjStatusLastFetch = Date.now();
 				this.#jjStatusInFlight = false;
+				if (this.#jjRoot === root) this.#jjStatusLastFetch = Date.now();
 			}
-			if (!this.#disposed && this.#onBranchChange && JSON.stringify(prev) !== JSON.stringify(this.#cachedJjStatus)) {
-				this.#onBranchChange();
-			}
+			if (this.#jjRoot !== root || this.#disposed) return;
+			const prev = this.#cachedJjStatus;
+			this.#cachedJjStatus = next;
+			if (this.#onBranchChange && JSON.stringify(prev) !== JSON.stringify(next)) this.#onBranchChange();
 		})();
 		return this.#cachedJjStatus;
 	}
@@ -1109,11 +1125,18 @@ export class StatusLineComponent implements Component {
 			? this.#resolveActiveRepoCache()
 			: { projectDir, activeRepo: null, effectiveGitCwd: projectDir, worktree: null };
 		let gitBranch = includeGit || includePr ? this.#getCurrentBranch(activeRepoCache.effectiveGitCwd) : null;
-		if (includeGit && (gitBranch === "detached" || gitBranch === null)) {
-			gitBranch = this.#getJjBranch() ?? gitBranch;
+		// A jj repo has no git branch to read: git HEAD is detached (colocated) or
+		// absent. Gate BOTH the jj branch label and the jj status counts on that
+		// same condition, captured before the label overlay rewrites gitBranch, so
+		// a nested ordinary git checkout under a parent jj workspace keeps its own
+		// git branch AND its own git status instead of the ancestor jj status.
+		const gitHeadIsJjLike = gitBranch === "detached" || gitBranch === null;
+		if (includeGit && gitHeadIsJjLike) {
+			gitBranch = this.#getJjBranch(activeRepoCache.effectiveGitCwd) ?? gitBranch;
 		}
 		const gitStatus = includeGit
-			? (this.#getJjStatus() ?? this.#getGitStatus(activeRepoCache.effectiveGitCwd))
+			? ((gitHeadIsJjLike ? this.#getJjStatus(activeRepoCache.effectiveGitCwd) : null) ??
+				this.#getGitStatus(activeRepoCache.effectiveGitCwd))
 			: null;
 		const gitPr = includePr ? this.#lookupPr(activeRepoCache.effectiveGitCwd) : null;
 		return {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -14,6 +14,7 @@ import { getSessionAccentAnsi, getSessionAccentHex } from "../../../utils/sessio
 import { sanitizeStatusText } from "../../shared";
 import { theme } from "../../theme/theme";
 import { canReuseCachedPr, createPrCacheContext, isSamePrCacheContext, type PrCacheContext } from "./git-utils";
+import * as jjInfo from "./jj-info";
 import { getPreset } from "./presets";
 import { renderSegment, type SegmentContext } from "./segments";
 import { getSeparator } from "./separators";
@@ -284,6 +285,14 @@ export class StatusLineComponent implements Component {
 	#cachedGitStatusCwd: string | undefined = undefined;
 	#gitStatusLastFetch = 0;
 	#gitStatusInFlightCwd: string | undefined = undefined;
+	#jjRoot: string | null | undefined = undefined;
+	#jjRootCwd: string | undefined = undefined;
+	#cachedJjBranch: string | null = null;
+	#jjBranchLastFetch = 0;
+	#jjBranchInFlight = false;
+	#cachedJjStatus: { staged: number; unstaged: number; untracked: number } | null = null;
+	#jjStatusLastFetch = 0;
+	#jjStatusInFlight = false;
 
 	// PR lookup caching (invalidated on branch/repo context changes)
 	#cachedPr: { number: number; url: string } | null | undefined = undefined;
@@ -653,15 +662,84 @@ export class StatusLineComponent implements Component {
 				nextStatus = null;
 			} finally {
 				if (this.#gitStatusInFlightCwd === gitCwd) {
+					const prev = this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
 					this.#cachedGitStatus = nextStatus;
 					this.#cachedGitStatusCwd = gitCwd;
 					this.#gitStatusLastFetch = Date.now();
 					this.#gitStatusInFlightCwd = undefined;
+					if (!this.#disposed && this.#onBranchChange && JSON.stringify(prev) !== JSON.stringify(nextStatus)) {
+						this.#onBranchChange();
+					}
 				}
 			}
 		})();
 
 		return this.#cachedGitStatusCwd === gitCwd ? this.#cachedGitStatus : null;
+	}
+
+	// Resolve (and cache per cwd) the jj workspace root, resetting both jj caches
+	// on a cwd change so a directory switch refetches label + status.
+	#jjRootFor(cwd: string): string | null {
+		if (this.#jjRoot === undefined || this.#jjRootCwd !== cwd) {
+			this.#jjRootCwd = cwd;
+			this.#jjRoot = jjInfo.findJjRoot(cwd);
+			this.#cachedJjBranch = null;
+			this.#jjBranchLastFetch = 0;
+			this.#cachedJjStatus = null;
+			this.#jjStatusLastFetch = 0;
+		}
+		return this.#jjRoot;
+	}
+
+	// jj working-copy bookmark label (nearest bookmark, change-id fallback), shown
+	// in the `git` segment where git HEAD is detached/absent under jj. Throttled,
+	// cached, and repaints on resolve.
+	#getJjBranch(): string | null {
+		const root = this.#jjRootFor(getProjectDir());
+		if (!root) return null;
+		if (this.#jjBranchInFlight || Date.now() - this.#jjBranchLastFetch < jjInfo.JJ_BRANCH_TTL_MS) {
+			return this.#cachedJjBranch;
+		}
+		this.#jjBranchInFlight = true;
+		(async () => {
+			try {
+				const next = await jjInfo.queryJjBranch(root);
+				const changed = next !== this.#cachedJjBranch;
+				this.#cachedJjBranch = next;
+				if (changed && !this.#disposed && this.#onBranchChange) {
+					this.#onBranchChange();
+				}
+			} finally {
+				this.#jjBranchLastFetch = Date.now();
+				this.#jjBranchInFlight = false;
+			}
+		})();
+		return this.#cachedJjBranch;
+	}
+
+	// jj working-copy status counts (`@` vs its parent), used in place of git
+	// status in a jj repo where `git status` has no `.git` to read. Throttled,
+	// cached, and repaints on resolve like #getJjBranch.
+	#getJjStatus(): { staged: number; unstaged: number; untracked: number } | null {
+		const root = this.#jjRootFor(getProjectDir());
+		if (!root) return null;
+		if (this.#jjStatusInFlight || Date.now() - this.#jjStatusLastFetch < jjInfo.JJ_BRANCH_TTL_MS) {
+			return this.#cachedJjStatus;
+		}
+		this.#jjStatusInFlight = true;
+		(async () => {
+			const prev = this.#cachedJjStatus;
+			try {
+				this.#cachedJjStatus = await jjInfo.queryJjStatus(root);
+			} finally {
+				this.#jjStatusLastFetch = Date.now();
+				this.#jjStatusInFlight = false;
+			}
+			if (!this.#disposed && this.#onBranchChange && JSON.stringify(prev) !== JSON.stringify(this.#cachedJjStatus)) {
+				this.#onBranchChange();
+			}
+		})();
+		return this.#cachedJjStatus;
 	}
 
 	#lookupPr(effectiveGitCwd?: string): { number: number; url: string } | null {
@@ -1030,8 +1108,13 @@ export class StatusLineComponent implements Component {
 		const activeRepoCache = shouldResolveActiveRepo
 			? this.#resolveActiveRepoCache()
 			: { projectDir, activeRepo: null, effectiveGitCwd: projectDir, worktree: null };
-		const gitBranch = includeGit || includePr ? this.#getCurrentBranch(activeRepoCache.effectiveGitCwd) : null;
-		const gitStatus = includeGit ? this.#getGitStatus(activeRepoCache.effectiveGitCwd) : null;
+		let gitBranch = includeGit || includePr ? this.#getCurrentBranch(activeRepoCache.effectiveGitCwd) : null;
+		if (includeGit && (gitBranch === "detached" || gitBranch === null)) {
+			gitBranch = this.#getJjBranch() ?? gitBranch;
+		}
+		const gitStatus = includeGit
+			? (this.#getJjStatus() ?? this.#getGitStatus(activeRepoCache.effectiveGitCwd))
+			: null;
 		const gitPr = includePr ? this.#lookupPr(activeRepoCache.effectiveGitCwd) : null;
 		return {
 			session: this.session,

--- a/packages/coding-agent/src/modes/components/status-line/jj-info.ts
+++ b/packages/coding-agent/src/modes/components/status-line/jj-info.ts
@@ -1,0 +1,127 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { $ } from "bun";
+import type { GitStatusSummary } from "../../../utils/git";
+
+/**
+ * Throttle for the working-copy jj query. The statusline calls into jj only
+ * while the `git` segment is shown in a colocated jj repo (where git HEAD is
+ * parked detached), so a moderate TTL keeps the subprocess rate negligible
+ * while a HEAD change still forces an immediate refresh (see
+ * `#invalidateGitCaches`).
+ */
+export const JJ_BRANCH_TTL_MS = 5000;
+
+/**
+ * The statusline labels the working copy by its bookmark, not its commit — in
+ * jj a bookmark doesn't follow `@`, so `@` itself is usually unbookmarked and
+ * the meaningful name lives on the nearest ancestor. The revset selects `@`
+ * plus that nearest ancestor bookmark; the template emits one
+ * `change_id|local_bookmarks` line per commit (newest — `@` — first).
+ */
+const JJ_BRANCH_REVSET = "@ | heads(::@ & bookmarks())";
+const JJ_BRANCH_TEMPLATE = 'change_id.shortest(8) ++ "|" ++ local_bookmarks ++ "\\n"';
+
+/**
+ * Walk up from `cwd` to the colocated jj workspace root — the nearest ancestor
+ * directory holding a `.jj` entry. Returns `null` when none exists. Sync on
+ * purpose: it feeds the synchronous statusline render path and is cached per
+ * cwd by the caller, so it runs at most once per directory.
+ */
+export function findJjRoot(cwd: string): string | null {
+	let dir = path.resolve(cwd);
+	for (;;) {
+		if (fs.existsSync(path.join(dir, ".jj"))) return dir;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+/**
+ * Parse the `change_id|local_bookmarks` lines (newest first, so `@` leads) into
+ * the display label: the nearest bookmark wins — `@`'s own when it has one, else
+ * the nearest ancestor's — falling back to `@`'s change-id when no bookmark
+ * exists in the ancestry. Returns `null` for empty output.
+ */
+export function formatJjBranch(raw: string): string | null {
+	let changeId: string | null = null;
+	for (const line of raw.split("\n")) {
+		const sep = line.indexOf("|");
+		const change = (sep === -1 ? line : line.slice(0, sep)).trim();
+		const bookmarks = sep === -1 ? "" : line.slice(sep + 1).trim();
+		if (changeId === null && change) changeId = change;
+		if (bookmarks) return bookmarks.replace(/\s+/g, " ");
+	}
+	return changeId;
+}
+
+/** Runs the jj query in `root`; injectable so the parse boundary is testable without jj. */
+export type JjRunner = (root: string) => Promise<{ exitCode: number; stdout: string }>;
+
+const defaultRunner: JjRunner = async root => {
+	// `--ignore-working-copy` keeps the query read-only (never snapshots the
+	// working copy), so it is safe to run on every refresh.
+	const res =
+		await $`jj log --no-graph --ignore-working-copy --color never -r ${JJ_BRANCH_REVSET} -T ${JJ_BRANCH_TEMPLATE}`
+			.cwd(root)
+			.quiet()
+			.nothrow();
+	return { exitCode: res.exitCode, stdout: res.text() };
+};
+
+/**
+ * Query the jj working-copy bookmark label for `root`. Returns
+ * `null` on any failure — non-zero exit (not a jj repo) or a missing `jj`
+ * binary — so the caller cleanly falls back to git's detached-HEAD label.
+ */
+export async function queryJjBranch(root: string, runner: JjRunner = defaultRunner): Promise<string | null> {
+	try {
+		const res = await runner(root);
+		if (res.exitCode !== 0) return null;
+		return formatJjBranch(res.stdout);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * jj working-copy status: `jj diff -r @ --summary` emits one `<type> <path>`
+ * line per changed file (M/A/D/R/C). Mapped to the git status shape for the
+ * shared renderer — jj has no index, so `staged` is always 0; added files (new
+ * in `@`) read as untracked, every other change as unstaged.
+ */
+export function parseJjStatus(raw: string): GitStatusSummary {
+	let unstaged = 0;
+	let untracked = 0;
+	for (const line of raw.split("\n")) {
+		const type = line.trim()[0];
+		if (!type) continue;
+		if (type === "A") untracked++;
+		else unstaged++;
+	}
+	return { staged: 0, unstaged, untracked };
+}
+
+const defaultStatusRunner: JjRunner = async root => {
+	const res = await $`jj diff -r @ --summary --ignore-working-copy --color never`.cwd(root).quiet().nothrow();
+	return { exitCode: res.exitCode, stdout: res.text() };
+};
+
+/**
+ * Query the jj working-copy status counts for `root` — the changes in `@`
+ * relative to its parent. Returns `null` on any failure (not a jj repo, no `jj`
+ * binary) so the caller falls back to git status; a clean `@` yields all zeros.
+ */
+export async function queryJjStatus(
+	root: string,
+	runner: JjRunner = defaultStatusRunner,
+): Promise<GitStatusSummary | null> {
+	try {
+		const res = await runner(root);
+		if (res.exitCode !== 0) return null;
+		return parseJjStatus(res.stdout);
+	} catch {
+		return null;
+	}
+}

--- a/packages/coding-agent/test/status-line-jj-info.test.ts
+++ b/packages/coding-agent/test/status-line-jj-info.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	findJjRoot,
+	formatJjBranch,
+	parseJjStatus,
+	queryJjBranch,
+	queryJjStatus,
+} from "@oh-my-pi/pi-coding-agent/modes/components/status-line/jj-info";
+
+describe("formatJjBranch", () => {
+	test("returns the bookmark on @ over the change-id", () => {
+		expect(formatJjBranch("kvisqosn|feature-x\n")).toBe("feature-x");
+	});
+
+	test("returns the nearest ancestor bookmark when @ has none", () => {
+		expect(formatJjBranch("kvisqosn|\nqlnsqysu|polo-integration\n")).toBe("polo-integration");
+	});
+
+	test("prefers @'s own bookmark over an ancestor bookmark", () => {
+		expect(formatJjBranch("kvisqosn|on-branch\nqlnsqysu|ancestor\n")).toBe("on-branch");
+	});
+
+	test("collapses multiple bookmarks at the nearest commit", () => {
+		expect(formatJjBranch("qlnsqysu|foo bar\n")).toBe("foo bar");
+	});
+
+	test("falls back to @'s change-id when no bookmark in ancestry", () => {
+		expect(formatJjBranch("kvisqosn|\n")).toBe("kvisqosn");
+	});
+
+	test("returns null for empty or whitespace-only output", () => {
+		expect(formatJjBranch("")).toBeNull();
+		expect(formatJjBranch("  \n\t ")).toBeNull();
+	});
+});
+
+describe("findJjRoot", () => {
+	test("walks up to the nearest ancestor holding .jj", async () => {
+		const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "jj-root-"));
+		try {
+			await fs.promises.mkdir(path.join(root, ".jj"));
+			const nested = path.join(root, "packages", "coding-agent");
+			await fs.promises.mkdir(nested, { recursive: true });
+			expect(findJjRoot(nested)).toBe(root);
+			expect(findJjRoot(root)).toBe(root);
+		} finally {
+			await fs.promises.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("returns null when no .jj ancestor exists", async () => {
+		const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "no-jj-"));
+		try {
+			expect(findJjRoot(dir)).toBeNull();
+		} finally {
+			await fs.promises.rm(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("queryJjBranch", () => {
+	test("returns the nearest bookmark from runner stdout", async () => {
+		const desc = await queryJjBranch("/repo", async () => ({
+			exitCode: 0,
+			stdout: "kvisqosn|\nqlnsqysu|polo-integration\n",
+		}));
+		expect(desc).toBe("polo-integration");
+	});
+
+	test("returns null on non-zero exit (not a jj repo)", async () => {
+		const desc = await queryJjBranch("/repo", async () => ({ exitCode: 1, stdout: "" }));
+		expect(desc).toBeNull();
+	});
+
+	test("returns null when the runner throws (jj binary absent)", async () => {
+		const desc = await queryJjBranch("/repo", async () => {
+			throw new Error("spawn jj ENOENT");
+		});
+		expect(desc).toBeNull();
+	});
+
+	test("treats empty successful output as null", async () => {
+		const desc = await queryJjBranch("/repo", async () => ({ exitCode: 0, stdout: "\n" }));
+		expect(desc).toBeNull();
+	});
+});
+
+describe("parseJjStatus / queryJjStatus", () => {
+	test("maps jj diff --summary types to the status shape (A -> untracked, else unstaged)", () => {
+		expect(parseJjStatus("M a.ts\nA b.ts\nA c.ts\nD d.ts\nM e.ts\n")).toEqual({
+			staged: 0,
+			unstaged: 3,
+			untracked: 2,
+		});
+	});
+
+	test("a clean working copy is all zeros", () => {
+		expect(parseJjStatus("")).toEqual({ staged: 0, unstaged: 0, untracked: 0 });
+	});
+
+	test("queryJjStatus parses runner stdout", async () => {
+		expect(await queryJjStatus("/repo", async () => ({ exitCode: 0, stdout: "M x.ts\nA y.ts\n" }))).toEqual({
+			staged: 0,
+			unstaged: 1,
+			untracked: 1,
+		});
+	});
+
+	test("queryJjStatus returns null on non-zero exit (not a jj repo)", async () => {
+		expect(await queryJjStatus("/repo", async () => ({ exitCode: 1, stdout: "" }))).toBeNull();
+	});
+
+	test("queryJjStatus returns null when the runner throws (jj binary absent)", async () => {
+		expect(
+			await queryJjStatus("/repo", async () => {
+				throw new Error("spawn jj ENOENT");
+			}),
+		).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/status-line-vcs-refresh.test.ts
+++ b/packages/coding-agent/test/status-line-vcs-refresh.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression: StatusLineComponent's VCS segment was blank on the first (cold)
+ * paint and only appeared after an unrelated re-render (e.g. flipping a
+ * statusline setting and back). The async git-status and jj-label fetches
+ * filled their caches but never called #onBranchChange, so the resolved value
+ * had no way to reach the screen until something else forced a repaint. Worst
+ * in a jj workspace, where there is no git branch so the PR / default-branch
+ * lookups (which do fire #onBranchChange) never run.
+ *
+ * Contract: when an async VCS fetch resolves with a value, the component
+ * requests a repaint via #onBranchChange. (Post-dispose suppression of the
+ * same callback is covered by status-line-dispose-async-leak.test.ts.)
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { StatusLineSettings } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import * as jjInfo from "@oh-my-pi/pi-coding-agent/modes/components/status-line/jj-info";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { GitRefHead } from "@oh-my-pi/pi-coding-agent/utils/git";
+import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+type GitStatus = { staged: number; unstaged: number; untracked: number };
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "vcs-refresh test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+const fakeRefHead: GitRefHead = {
+	kind: "ref",
+	branchName: "main",
+	ref: "refs/heads/main",
+	commit: null,
+	commonDir: "/fake/.git",
+	gitDir: "/fake/.git",
+	gitEntryPath: "/fake/.git",
+	headPath: "/fake/.git/HEAD",
+	repoRoot: "/fake",
+	headContent: "ref: refs/heads/main\n",
+};
+
+const gitSegment: StatusLineSettings = {
+	preset: "custom",
+	leftSegments: ["git"],
+	rightSegments: ["session_name"],
+	separator: "powerline-thin",
+	sessionAccent: false,
+	transparent: false,
+};
+
+describe("StatusLineComponent repaints when an async VCS fetch resolves", () => {
+	it("fires #onBranchChange when git status resolves on the cold paint", async () => {
+		vi.spyOn(git.head, "resolveSync").mockReturnValue(fakeRefHead);
+		vi.spyOn(git.branch, "default").mockReturnValue(Promise.withResolvers<string | null>().promise);
+		const status = Promise.withResolvers<GitStatus | null>();
+		vi.spyOn(git.status, "summary").mockReturnValue(status.promise);
+
+		const onBranchChange = vi.fn();
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(onBranchChange);
+
+		component.getTopBorder(80); // cold paint kicks off the git-status fetch
+		expect(onBranchChange).not.toHaveBeenCalled();
+
+		status.resolve({ staged: 1, unstaged: 2, untracked: 3 });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBranchChange).toHaveBeenCalled();
+		component.dispose();
+	});
+
+	it("fires #onBranchChange when the jj label resolves on the cold paint", async () => {
+		vi.spyOn(git.head, "resolveSync").mockReturnValue(null); // no git branch -> jj overlay
+		vi.spyOn(git.branch, "default").mockReturnValue(Promise.withResolvers<string | null>().promise);
+		vi.spyOn(git.status, "summary").mockReturnValue(Promise.withResolvers<GitStatus | null>().promise); // isolate the jj fire
+		vi.spyOn(jjInfo, "findJjRoot").mockReturnValue("/fake/jj/root");
+		const label = Promise.withResolvers<string | null>();
+		vi.spyOn(jjInfo, "queryJjBranch").mockReturnValue(label.promise);
+
+		const onBranchChange = vi.fn();
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(onBranchChange);
+
+		component.getTopBorder(80); // cold paint kicks off the jj-label fetch
+		expect(onBranchChange).not.toHaveBeenCalled();
+
+		label.resolve("feature-x");
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBranchChange).toHaveBeenCalled();
+		component.dispose();
+	});
+
+	it("fires #onBranchChange when jj status resolves on the cold paint", async () => {
+		vi.spyOn(git.head, "resolveSync").mockReturnValue(null); // no git -> jj repo
+		vi.spyOn(git.branch, "default").mockReturnValue(Promise.withResolvers<string | null>().promise);
+		vi.spyOn(git.status, "summary").mockReturnValue(Promise.withResolvers<GitStatus | null>().promise);
+		vi.spyOn(jjInfo, "findJjRoot").mockReturnValue("/fake/jj/root");
+		vi.spyOn(jjInfo, "queryJjBranch").mockReturnValue(Promise.withResolvers<string | null>().promise); // isolate the status fire
+		const status = Promise.withResolvers<GitStatus | null>();
+		vi.spyOn(jjInfo, "queryJjStatus").mockReturnValue(status.promise);
+
+		const onBranchChange = vi.fn();
+		const component = new StatusLineComponent(makeSession());
+		component.updateSettings(gitSegment);
+		component.watchBranch(onBranchChange);
+
+		component.getTopBorder(80); // cold paint kicks off the jj-status fetch
+		expect(onBranchChange).not.toHaveBeenCalled();
+
+		status.resolve({ staged: 0, unstaged: 4, untracked: 1 });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onBranchChange).toHaveBeenCalled();
+		component.dispose();
+	});
+});


### PR DESCRIPTION
## What

Make the `git` statusline segment jj-aware. When the working directory is a jj repo, the segment shows the working copy's **bookmark** instead of git's unhelpful `detached` (colocated repo) or nothing (secondary jj workspace with no git). Because a jj bookmark doesn't follow `@`, it resolves the nearest one — `@`'s own bookmark, or the closest ancestor's — and falls back to the short change-id when no bookmark exists in the ancestry. The status counts go jj-aware the same way: where there's no `.git` to read, the segment shows jj's working-copy changes (`@` vs its parent).

New `jj-info.ts` supplies both halves — `findJjRoot` (walk up to the nearest `.jj`); a read-only injectable `queryJjBranch` (`jj log --ignore-working-copy -r '@ | heads(::@ & bookmarks())'`) + `formatJjBranch` for the label; and `queryJjStatus` (`jj diff -r @ --summary --ignore-working-copy`) + `parseJjStatus` for the counts (mapped to the git status shape — jj has no index so `staged` is 0, added files read as untracked). `component.ts` overlays the label onto `ctx.git.branch` when the branch is `detached`/`null`, and prefers `#getJjStatus()` over `#getGitStatus()` in a jj repo; both are throttled (5s TTL), cached, and request a repaint when they resolve.

## Why

Fixes #3582. In a colocated jj repo, jj parks git `HEAD` detached, so the `git` segment renders `detached`. In a secondary jj workspace there is no `.git` at all, so the segment renders nothing. The segment set is a closed enum and extensions can only render on a separate line (`setStatus`), so the fix lives in the built-in segment's context provider.

## Testing

- `status-line-jj-info.test.ts` (17 tests): `formatJjBranch` (bookmark on `@`, nearest ancestor, `@`-own over ancestor, multi-bookmark collapse, change-id fallback, empty → null), `findJjRoot` (walk-up, no-`.jj` → null), `queryJjBranch` (nearest bookmark, non-zero exit/throw/empty → null), `parseJjStatus`/`queryJjStatus` (M/A/D → status shape, clean → zeros, exit/throw → null).
- Verified the real `jj log`/`jj diff` queries against live jj workspaces.
- `status-line-vcs-refresh.test.ts` (3 tests): the async git-status, jj-label, and jj-status fetches each fire `#onBranchChange` on resolution so the cold paint repaints.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
