### PR TITLE
fix(coding-agent): write config through symlinks instead of clobbering them

### DIFF
--- a/packages/coding-agent/src/config/atomic-write.ts
+++ b/packages/coding-agent/src/config/atomic-write.ts
@@ -1,0 +1,34 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+
+/**
+ * Atomically write `data` to `targetPath` while preserving a symlink at
+ * `targetPath`. OMP-managed config (e.g. `config.yml`) is often a symlink into a
+ * dotfiles/nix checkout; a plain `rename` onto the link path clobbers the link
+ * into a regular file — stranding the repo copy and forcing a re-symlink. We
+ * resolve the link to its real target first, then write a sibling temp file and
+ * `rename` it onto the real path: the link stays intact and the write is
+ * crash-atomic (no truncate-in-place window). Suitable for any file a user might
+ * symlink, not just config.
+ */
+export async function atomicWriteThroughSymlink(targetPath: string, data: string): Promise<void> {
+	let realPath = targetPath;
+	try {
+		if ((await fs.lstat(targetPath)).isSymbolicLink()) {
+			realPath = await fs.realpath(targetPath);
+		}
+	} catch (error) {
+		// Nothing at the path (or a dangling link) — write at the path itself.
+		if (!isEnoent(error)) throw error;
+	}
+
+	const tmpPath = path.join(path.dirname(realPath), `.${path.basename(realPath)}.${process.pid}.${Date.now()}.tmp`);
+	try {
+		await Bun.write(tmpPath, data);
+		await fs.rename(tmpPath, realPath);
+	} catch (error) {
+		await fs.rm(tmpPath, { force: true }).catch(() => {});
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/config/atomic-write.ts
+++ b/packages/coding-agent/src/config/atomic-write.ts
@@ -13,6 +13,10 @@ import { isEnoent } from "@oh-my-pi/pi-utils";
  * symlink, not just config.
  */
 export async function atomicWriteThroughSymlink(targetPath: string, data: string): Promise<void> {
+	// Resolve `targetPath` to the real file the write should land on, preserving
+	// any symlink(s) at or above it. `realpath` handles the common case (every
+	// hop's referent exists); the fallback below handles a symlink whose final
+	// referent does not exist yet.
 	let realPath = targetPath;
 	try {
 		if ((await fs.lstat(targetPath)).isSymbolicLink()) {
@@ -20,12 +24,29 @@ export async function atomicWriteThroughSymlink(targetPath: string, data: string
 				realPath = await fs.realpath(targetPath);
 			} catch (error) {
 				if (!isEnoent(error)) throw error;
-				// Dangling link (referent not created yet — e.g. a first-run config.yml
-				// symlink into a dotfiles checkout). Resolve the link's referent relative
-				// to the link dir and write there, so the link itself is preserved rather
-				// than clobbered into a regular file.
-				const referent = await fs.readlink(targetPath);
-				realPath = path.resolve(path.dirname(targetPath), referent);
+				// A symlink chain whose FINAL referent is missing (e.g. a first-run
+				// config.yml -> current.yml -> not-yet-created.yml into a dotfiles
+				// checkout). `realpath` throws ENOENT at the missing tail, so walk the
+				// chain hop by hop — following each existing intermediate link — until
+				// the referent is a non-symlink or does not exist. Writing to that
+				// final referent preserves every intermediate link instead of
+				// clobbering one into a regular file.
+				let current = targetPath;
+				for (;;) {
+					const referent = await fs.readlink(current);
+					const resolved = path.resolve(path.dirname(current), referent);
+					let nextIsLink = false;
+					try {
+						nextIsLink = (await fs.lstat(resolved)).isSymbolicLink();
+					} catch (lstatError) {
+						if (!isEnoent(lstatError)) throw lstatError;
+					}
+					if (!nextIsLink) {
+						realPath = resolved;
+						break;
+					}
+					current = resolved;
+				}
 			}
 		}
 	} catch (error) {
@@ -33,21 +54,28 @@ export async function atomicWriteThroughSymlink(targetPath: string, data: string
 		if (!isEnoent(error)) throw error;
 	}
 
-	// Preserve the real target's permissions: Bun.write creates the temp with the
-	// default mode (0644), and the rename would otherwise widen a tightened
-	// (e.g. 0600) config that can hold secrets. Stat before writing; apply the
-	// mode to the temp before it takes the target's place.
+	// Preserve the real target's permissions and never briefly widen them. A
+	// tightened (e.g. 0600) config can hold secrets, so the temp must be created
+	// with a restrictive mode from the start — `Bun.write` would create it at the
+	// umask default (typically 0644), exposing secrets in the window before a
+	// later chmod. Create the temp at the target's mode (0600 when the target
+	// does not exist yet, so a brand-new secret file is never born world-readable)
+	// and chmod after writing to pin it exactly against the process umask.
 	let mode: number | undefined;
 	try {
-		mode = (await fs.stat(realPath)).mode;
+		mode = (await fs.stat(realPath)).mode & 0o777;
 	} catch (error) {
 		if (!isEnoent(error)) throw error;
 	}
+	const createMode = mode ?? 0o600;
 
 	const tmpPath = path.join(path.dirname(realPath), `.${path.basename(realPath)}.${process.pid}.${Date.now()}.tmp`);
 	try {
-		await Bun.write(tmpPath, data);
-		if (mode !== undefined) await fs.chmod(tmpPath, mode & 0o777);
+		// `Bun.write` auto-created missing parents; `fs.writeFile` does not, so
+		// recreate that for a first-run target under a not-yet-existing dir.
+		await fs.mkdir(path.dirname(tmpPath), { recursive: true });
+		await fs.writeFile(tmpPath, data, { mode: createMode });
+		await fs.chmod(tmpPath, createMode);
 		await fs.rename(tmpPath, realPath);
 	} catch (error) {
 		await fs.rm(tmpPath, { force: true }).catch(() => {});

--- a/packages/coding-agent/src/config/atomic-write.ts
+++ b/packages/coding-agent/src/config/atomic-write.ts
@@ -16,16 +16,38 @@ export async function atomicWriteThroughSymlink(targetPath: string, data: string
 	let realPath = targetPath;
 	try {
 		if ((await fs.lstat(targetPath)).isSymbolicLink()) {
-			realPath = await fs.realpath(targetPath);
+			try {
+				realPath = await fs.realpath(targetPath);
+			} catch (error) {
+				if (!isEnoent(error)) throw error;
+				// Dangling link (referent not created yet — e.g. a first-run config.yml
+				// symlink into a dotfiles checkout). Resolve the link's referent relative
+				// to the link dir and write there, so the link itself is preserved rather
+				// than clobbered into a regular file.
+				const referent = await fs.readlink(targetPath);
+				realPath = path.resolve(path.dirname(targetPath), referent);
+			}
 		}
 	} catch (error) {
-		// Nothing at the path (or a dangling link) — write at the path itself.
+		// Nothing at the path — write at the path itself.
+		if (!isEnoent(error)) throw error;
+	}
+
+	// Preserve the real target's permissions: Bun.write creates the temp with the
+	// default mode (0644), and the rename would otherwise widen a tightened
+	// (e.g. 0600) config that can hold secrets. Stat before writing; apply the
+	// mode to the temp before it takes the target's place.
+	let mode: number | undefined;
+	try {
+		mode = (await fs.stat(realPath)).mode;
+	} catch (error) {
 		if (!isEnoent(error)) throw error;
 	}
 
 	const tmpPath = path.join(path.dirname(realPath), `.${path.basename(realPath)}.${process.pid}.${Date.now()}.tmp`);
 	try {
 		await Bun.write(tmpPath, data);
+		if (mode !== undefined) await fs.chmod(tmpPath, mode & 0o777);
 		await fs.rename(tmpPath, realPath);
 	} catch (error) {
 		await fs.rm(tmpPath, { force: true }).catch(() => {});

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -33,6 +33,7 @@ import { isLightTheme, setAutoThemeMapping, setColorBlindMode, setSymbolPreset }
 import { AgentStorage } from "../session/agent-storage";
 import { normalizeToolName } from "../tools/builtin-names";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
+import { atomicWriteThroughSymlink } from "./atomic-write";
 import { withFileLock } from "./file-lock";
 import {
 	type BashInterceptorRule,
@@ -1294,7 +1295,7 @@ export class Settings {
 
 				// Update our global with any external changes we preserved
 				this.#global = current;
-				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
+				await atomicWriteThroughSymlink(configPath, YAML.stringify(this.#global, null, 2));
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });

--- a/packages/coding-agent/test/config-atomic-write.test.ts
+++ b/packages/coding-agent/test/config-atomic-write.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { atomicWriteThroughSymlink } from "@oh-my-pi/pi-coding-agent/config/atomic-write";
+
+describe("atomicWriteThroughSymlink", () => {
+	test("follows a symlink: keeps the link, replaces the real target", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			const real = path.join(dir, "config.yml");
+			await fs.writeFile(real, "old\n");
+			const link = path.join(dir, "linked.yml");
+			await fs.symlink(real, link);
+
+			await atomicWriteThroughSymlink(link, "new\n");
+
+			expect((await fs.lstat(link)).isSymbolicLink()).toBe(true);
+			expect(await fs.readFile(real, "utf8")).toBe("new\n");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("resolves a symlink chain down to the final target", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			const real = path.join(dir, "real.yml");
+			await fs.writeFile(real, "old\n");
+			const mid = path.join(dir, "mid.yml");
+			await fs.symlink(real, mid);
+			const link = path.join(dir, "link.yml");
+			await fs.symlink(mid, link);
+
+			await atomicWriteThroughSymlink(link, "new\n");
+
+			expect((await fs.lstat(link)).isSymbolicLink()).toBe(true);
+			expect((await fs.lstat(mid)).isSymbolicLink()).toBe(true);
+			expect(await fs.readFile(real, "utf8")).toBe("new\n");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("writes a plain file when the path is not a symlink, leaving no temp behind", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			const p = path.join(dir, "config.yml");
+			await atomicWriteThroughSymlink(p, "data\n");
+			expect(await fs.readFile(p, "utf8")).toBe("data\n");
+			expect((await fs.lstat(p)).isSymbolicLink()).toBe(false);
+			expect(await fs.readdir(dir)).toEqual(["config.yml"]);
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("creates the file when nothing exists at the path yet", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			const p = path.join(dir, "nested", "config.yml");
+			await atomicWriteThroughSymlink(p, "fresh\n");
+			expect(await fs.readFile(p, "utf8")).toBe("fresh\n");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/config-atomic-write.test.ts
+++ b/packages/coding-agent/test/config-atomic-write.test.ts
@@ -117,4 +117,44 @@ describe("atomicWriteThroughSymlink", () => {
 			await fs.rm(dir, { recursive: true, force: true });
 		}
 	});
+
+	test("resolves a dangling symlink chain to its final referent, preserving every link", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			// link -> mid -> config.yml, where the FINAL referent does not exist yet
+			// (first-run dotfiles: a chain of links terminating at a not-yet-created
+			// file). realpath throws ENOENT at the tail, so the resolver must walk
+			// every hop rather than clobbering the first intermediate link.
+			const referent = path.join(dir, "config.yml");
+			const mid = path.join(dir, "mid.yml");
+			const link = path.join(dir, "linked.yml");
+			await fs.symlink(referent, mid);
+			await fs.symlink(mid, link);
+
+			await atomicWriteThroughSymlink(link, "fresh\n");
+
+			expect((await fs.lstat(link)).isSymbolicLink()).toBe(true);
+			expect((await fs.lstat(mid)).isSymbolicLink()).toBe(true);
+			expect(await fs.readFile(referent, "utf8")).toBe("fresh\n");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("creates a brand-new file with 0600, never a world-readable default", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		const originalUmask = process.umask(0o022);
+		try {
+			// No existing target: a fresh config that may hold secrets must not be
+			// born 0644. The temp is created at 0600 from the start, so the rename
+			// never exposes contents even briefly under a permissive umask.
+			const p = path.join(dir, "config.yml");
+			await atomicWriteThroughSymlink(p, "secret: fresh\n");
+			expect(await fs.readFile(p, "utf8")).toBe("secret: fresh\n");
+			expect((await fs.stat(p)).mode & 0o777).toBe(0o600);
+		} finally {
+			process.umask(originalUmask);
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/config-atomic-write.test.ts
+++ b/packages/coding-agent/test/config-atomic-write.test.ts
@@ -65,4 +65,56 @@ describe("atomicWriteThroughSymlink", () => {
 			await fs.rm(dir, { recursive: true, force: true });
 		}
 	});
+
+	test("preserves the real target's 0600 permissions across the rename", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			const p = path.join(dir, "config.yml");
+			await fs.writeFile(p, "secret: old\n");
+			await fs.chmod(p, 0o600);
+
+			await atomicWriteThroughSymlink(p, "secret: new\n");
+
+			expect(await fs.readFile(p, "utf8")).toBe("secret: new\n");
+			expect((await fs.stat(p)).mode & 0o777).toBe(0o600);
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("preserves permissions of the symlink's real target, keeping the link", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			const real = path.join(dir, "config.yml");
+			await fs.writeFile(real, "secret: old\n");
+			await fs.chmod(real, 0o600);
+			const link = path.join(dir, "linked.yml");
+			await fs.symlink(real, link);
+
+			await atomicWriteThroughSymlink(link, "secret: new\n");
+
+			expect((await fs.lstat(link)).isSymbolicLink()).toBe(true);
+			expect(await fs.readFile(real, "utf8")).toBe("secret: new\n");
+			expect((await fs.stat(real)).mode & 0o777).toBe(0o600);
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("writes through a dangling symlink to its referent, preserving the link", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-atomic-write-"));
+		try {
+			const referent = path.join(dir, "config.yml");
+			const link = path.join(dir, "linked.yml");
+			// Link points at a referent that does not exist yet (first-run dotfiles case).
+			await fs.symlink(referent, link);
+
+			await atomicWriteThroughSymlink(link, "fresh\n");
+
+			expect((await fs.lstat(link)).isSymbolicLink()).toBe(true);
+			expect(await fs.readFile(referent, "utf8")).toBe("fresh\n");
+		} finally {
+			await fs.rm(dir, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
## What

Route config writes through a symlink-safe atomic helper. New `config/atomic-write.ts` (`atomicWriteThroughSymlink`) resolves the target path to its real location (following a symlink), writes to a temp file alongside the real target, then atomically renames it into place. `settings.ts` uses it for the config save. A symlinked `config.yml` now has its **target** rewritten (link preserved); a plain file is replaced atomically as before.

## Why

Fixes #4452. When `config.yml` is a symlink into a dotfiles/nix checkout, the previous save wrote to the link path and replaced the symlink with a plain file — the version-controlled target went stale and the link was lost. Resolving the symlink and atomically replacing the real target keeps the link intact and the change tracked. The atomic temp-file + rename also avoids a torn write if the process dies mid-save.

## Testing

`packages/coding-agent/test/config-atomic-write.test.ts` — `atomicWriteThroughSymlink` writes through a symlink to its real target (link preserved, target updated); replaces a plain file atomically; creates a new file when the target is absent; the temp file is cleaned up on failure.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)