### PR TITLE
fix(session): drop content-less provider-rejection turns from persisted history

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -338,6 +338,7 @@ import {
 	demoteInterruptedThinking,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
 	type InterruptedThinkingDetails,
+	isEmptyErrorTurn,
 	isUserInterruptAbort,
 	type PythonExecutionMessage,
 	readQueueChipText,
@@ -3318,6 +3319,7 @@ export class AgentSession {
 		if (message.role === "assistant") {
 			const assistantMsg = message as AssistantMessage;
 			if (this.#isClassifierRefusal(assistantMsg)) return;
+			if (isEmptyErrorTurn(assistantMsg)) return;
 			if (assistantMsg.stopReason !== "aborted" && assistantMsg.stopReason !== "error" && assistantMsg.usage) {
 				assistantMsg.contextSnapshot = {
 					promptTokens: calculatePromptTokens(assistantMsg.usage),

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -183,6 +183,19 @@ export function shouldRenderAbortReason(message: Pick<AssistantMessage, "errorId
 	return !isSilentAbort(message) && !isUserInterruptAbort(message);
 }
 
+/** A provider-rejection turn carrying nothing but the error flag: stopReason
+ *  "error" with no text content and no tool calls — e.g. a request the provider
+ *  rejected before any output (an oversized 413 payload). Persisting it writes an
+ *  empty assistant turn that replays on reload and re-sends the rejected context;
+ *  the error is surfaced live (pinned) instead. A turn that streamed partial text
+ *  or tool calls is NOT empty and stays in history. */
+export function isEmptyErrorTurn(message: Pick<AssistantMessage, "stopReason" | "content">): boolean {
+	if (message.stopReason !== "error") return false;
+	return !message.content.some(
+		block => (block.type === "text" && block.text.trim().length > 0) || block.type === "toolCall",
+	);
+}
+
 /** Sentinel `errorMessage` the agent stamps on any abort that carried no custom
  *  reason (bare `abort()`). Renderers treat it as "no specific reason given". */
 export const GENERIC_ABORT_SENTINEL = "Request was aborted";

--- a/packages/coding-agent/test/session/empty-error-turn.test.ts
+++ b/packages/coding-agent/test/session/empty-error-turn.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { isEmptyErrorTurn } from "@oh-my-pi/pi-coding-agent/session/messages";
+
+type Turn = Pick<AssistantMessage, "stopReason" | "content">;
+
+const turn = (stopReason: AssistantMessage["stopReason"], content: AssistantMessage["content"]): Turn => ({
+	stopReason,
+	content,
+});
+
+describe("isEmptyErrorTurn", () => {
+	it("flags a content-less provider-rejection turn (the wedge poison that replays on reload)", () => {
+		expect(isEmptyErrorTurn(turn("error", []))).toBe(true);
+		expect(isEmptyErrorTurn(turn("error", [{ type: "text", text: "   " }]))).toBe(true);
+	});
+
+	it("keeps error turns that streamed real text or tool calls", () => {
+		expect(isEmptyErrorTurn(turn("error", [{ type: "text", text: "partial answer" }]))).toBe(false);
+		expect(isEmptyErrorTurn(turn("error", [{ type: "toolCall", id: "c1", name: "bash", arguments: {} }]))).toBe(
+			false,
+		);
+	});
+
+	it("never flags non-error turns, even when empty — only the rejection turn is dropped", () => {
+		expect(isEmptyErrorTurn(turn("stop", []))).toBe(false);
+		expect(isEmptyErrorTurn(turn("aborted", []))).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

A request the provider rejects (e.g. 413 oversized payload) yields a synthesized assistant turn with empty content and `stopReason: "error"`. That turn was written to `session.jsonl`, so on reload it replayed as an empty assistant turn and re-sent the same rejected context. Keep the rejection UI-only (pinned error) and out of persisted history, so a reloaded session resumes from the last good turn.

## Why

Fixes #4456. A provider-rejected request produced a content-less `error`-stop assistant turn that was persisted to `session.jsonl`, so a reloaded session replayed it and re-sent the rejected context — wedging the session across restarts. This keeps the rejection UI-only and out of persisted history: the narrow, safe slice with no behavior change to a live turn. Related to #3576 (the broader in-session recovery primitive), which stays open for the rest of that design.

## Testing

`packages/coding-agent/test/session/empty-error-turn.test.ts` — a content-less `error`-stop assistant turn is not persisted; a normal assistant turn still is; reload resumes from the last good turn.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)