### PR TITLE
fix(lsp): dedupe identical replacement edits

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `lsp rename_file` aborting when an LSP server returns duplicate byte-identical non-empty text edits for the same range, such as tsserver `willRenameFiles` edits through barrel re-exports ([#4458](https://github.com/can1357/oh-my-pi/issues/4458)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/lsp/edits.ts
+++ b/packages/coding-agent/src/lsp/edits.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs/promises";
-import path from "node:path";
+import * as path from "node:path";
 import { formatPathRelativeToCwd } from "../tools/path-utils";
 import { ToolError } from "../tools/tool-errors";
 import type {
@@ -48,6 +48,17 @@ export function applyTextEditsToString(content: string, edits: TextEdit[]): stri
 function comparePosition(a: Position, b: Position): number {
 	return a.line === b.line ? a.character - b.character : a.line - b.line;
 }
+function positionsEqual(a: Position, b: Position): boolean {
+	return a.line === b.line && a.character === b.character;
+}
+
+function rangesEqual(a: Range, b: Range): boolean {
+	return positionsEqual(a.start, b.start) && positionsEqual(a.end, b.end);
+}
+
+function isEmptyRange(range: Range): boolean {
+	return positionsEqual(range.start, range.end);
+}
 
 function formatRange(range: Range): string {
 	return `${range.start.line + 1}:${range.start.character + 1}-${range.end.line + 1}:${range.end.character + 1}`;
@@ -63,6 +74,8 @@ export function rangesOverlap(a: Range, b: Range): boolean {
  * Equal start positions tiebreak by original array index descending so that,
  * applied bottom-up, inserts at the same position land in array order
  * (LSP spec: the order of edits in the array defines the order in the result).
+ * Byte-identical non-empty range edits are idempotent, so duplicate server
+ * output is collapsed before overlap validation.
  */
 export function sortAndValidateTextEdits(edits: TextEdit[]): TextEdit[] {
 	const sorted = edits
@@ -77,21 +90,29 @@ export function sortAndValidateTextEdits(edits: TextEdit[]): TextEdit[] {
 			return b.index - a.index;
 		})
 		.map(entry => entry.edit);
+	const unique: TextEdit[] = [];
+	for (const edit of sorted) {
+		const prev = unique[unique.length - 1];
+		if (prev && !isEmptyRange(edit.range) && rangesEqual(prev.range, edit.range) && prev.newText === edit.newText) {
+			continue;
+		}
+		unique.push(edit);
+	}
 
 	// Detect overlapping ranges: in reverse-sorted order, each edit's start
 	// must be >= the next edit's end. If not, the edits would clobber each other
-	// once applied bottom-up (typically a multi-server rename with stale positions).
-	for (let i = 0; i < sorted.length - 1; i++) {
-		const later = sorted[i].range;
-		const earlier = sorted[i + 1].range;
+	// once applied bottom-up.
+	for (let i = 0; i < unique.length - 1; i++) {
+		const later = unique[i].range;
+		const earlier = unique[i + 1].range;
 		if (comparePosition(earlier.end, later.start) > 0) {
 			throw new ToolError(
-				`overlapping LSP edits: ${formatRange(earlier)} conflicts with ${formatRange(later)}; multi-server rename produced inconsistent edits`,
+				`overlapping LSP edits: ${formatRange(earlier)} conflicts with ${formatRange(later)}; LSP produced inconsistent edits`,
 			);
 		}
 	}
 
-	return sorted;
+	return unique;
 }
 
 /**

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -8,7 +8,11 @@ import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
 import * as lspConfig from "@oh-my-pi/pi-coding-agent/lsp/config";
 import { getServersForFile, type LspConfig, loadConfig } from "@oh-my-pi/pi-coding-agent/lsp/config";
-import { applyTextEditsToString, applyWorkspaceEdit } from "@oh-my-pi/pi-coding-agent/lsp/edits";
+import {
+	applyTextEditsToString,
+	applyWorkspaceEdit,
+	sortAndValidateTextEdits,
+} from "@oh-my-pi/pi-coding-agent/lsp/edits";
 import { renderCall, renderResult } from "@oh-my-pi/pi-coding-agent/lsp/render";
 import type {
 	CodeAction,
@@ -1817,6 +1821,35 @@ describe("lsp regressions", () => {
 		} finally {
 			tempDir.removeSync();
 		}
+	});
+
+	it("dedupes byte-identical non-empty text edits before overlap validation", () => {
+		const edit = {
+			range: { start: { line: 9, character: 55 }, end: { line: 9, character: 62 } },
+			newText: "./megaMenu",
+		};
+
+		expect(sortAndValidateTextEdits([edit, { ...edit }])).toEqual([edit]);
+		expect(
+			applyTextEditsToString("import x from './menu';\n", [
+				{
+					range: { start: { line: 0, character: 15 }, end: { line: 0, character: 21 } },
+					newText: "./megaMenu",
+				},
+				{
+					range: { start: { line: 0, character: 15 }, end: { line: 0, character: 21 } },
+					newText: "./megaMenu",
+				},
+			]),
+		).toBe("import x from './megaMenu';\n");
+	});
+
+	it("keeps byte-identical zero-width inserts because they are not idempotent", () => {
+		const result = applyTextEditsToString("abc", [
+			{ range: { start: { line: 0, character: 1 }, end: { line: 0, character: 1 } }, newText: "X" },
+			{ range: { start: { line: 0, character: 1 }, end: { line: 0, character: 1 } }, newText: "X" },
+		]);
+		expect(result).toBe("aXXbc");
 	});
 
 	it("applies equal-position inserts in array order", () => {


### PR DESCRIPTION
## Repro
The unit-level repro from #4458 imports `sortAndValidateTextEdits` and passes two byte-identical non-empty edits for `9:55-9:62`; before the fix, `bun /tmp/lsp-dup-edit-repro.ts` threw `overlapping LSP edits: 10:56-10:63 conflicts with 10:56-10:63`.

## Cause
`packages/coding-agent/src/lsp/edits.ts` sorted edits and immediately treated every overlapping pair as conflicting. Duplicate non-empty replacements from a single LSP server survived `rename_file` coalescing and reached `sortAndValidateTextEdits`, where the same range compared against itself as an overlap.

## Fix
- Collapse byte-identical non-empty replacement edits after bottom-to-top sorting and before overlap validation.
- Keep zero-width inserts untouched because duplicate inserts are not idempotent and LSP insert ordering is observable.
- Update LSP regression coverage and the coding-agent changelog.

## Verification
`bun /tmp/lsp-dup-edit-repro.ts` exits 0 after the fix. `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` passed: 55 tests, 195 assertions. `bun run fix` reported no fixes applied. `bun check` passed. Fixes #4458