### PR TITLE
fix(lsp): notify servers about harness file writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LSP diagnostics staleness after harness-authored file writes by sending watched-file change notifications to running language servers before edit-time diagnostics are read ([#4459](https://github.com/can1357/oh-my-pi/issues/4459)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -198,7 +198,7 @@ export class HashlineFilesystem extends Filesystem {
 		const finalContent = await serializeEditFileText(absolutePath, relativePath, content);
 
 		// Route through ACP bridge when available; skips internal artifacts.
-		if (await routeWriteThroughBridge(this.session, relativePath, absolutePath, finalContent)) {
+		if (await routeWriteThroughBridge(this.session, relativePath, absolutePath, finalContent, this.#signal)) {
 			this.#diagnosticsByPath.set(relativePath, undefined);
 			return { text: finalContent };
 		}

--- a/packages/coding-agent/src/edit/hashline/filesystem.ts
+++ b/packages/coding-agent/src/edit/hashline/filesystem.ts
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import { Filesystem, NotFoundError, type PreflightWriteOptions, type WriteResult } from "@oh-my-pi/hashline";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 import type { FileDiagnosticsResult, WritethroughCallback, WritethroughDeferredHandle } from "../../lsp";
+import { FileChangeType, notifyWorkspaceWatchedFiles } from "../../lsp/client";
 import type { ToolSession } from "../../tools";
 import { routeWriteThroughBridge } from "../../tools/acp-bridge";
 import { assertEditableFileContent } from "../../tools/auto-generated-guard";
@@ -157,6 +158,13 @@ export class HashlineFilesystem extends Filesystem {
 			if (isEnoent(error)) throw new NotFoundError(relativePath, error);
 			throw error;
 		}
+		if (this.session.enableLsp ?? true) {
+			await notifyWorkspaceWatchedFiles(
+				this.session.cwd,
+				[{ filePath: absolutePath, type: FileChangeType.Deleted }],
+				this.#signal,
+			);
+		}
 		invalidateFsScanAfterWrite(absolutePath);
 	}
 
@@ -169,6 +177,16 @@ export class HashlineFilesystem extends Filesystem {
 			await fs.rm(fromAbsolute);
 		} else {
 			await fs.rename(fromAbsolute, toAbsolute);
+		}
+		if (this.session.enableLsp ?? true) {
+			await notifyWorkspaceWatchedFiles(
+				this.session.cwd,
+				[
+					{ filePath: fromAbsolute, type: FileChangeType.Deleted },
+					{ filePath: toAbsolute, type: FileChangeType.Created },
+				],
+				this.#signal,
+			);
 		}
 		invalidateFsScanAfterWrite(fromAbsolute);
 		invalidateFsScanAfterWrite(toAbsolute);

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -1733,7 +1733,7 @@ class LspFileSystem implements FileSystem {
 		const finalContent = await serializeEditFileText(path, path, content);
 
 		// Route through ACP bridge when available; skips internal artifacts and local:// paths.
-		if (await routeWriteThroughBridge(this.session, this.requestedPath, path, finalContent)) {
+		if (await routeWriteThroughBridge(this.session, this.requestedPath, path, finalContent, this.signal)) {
 			return;
 		}
 

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -16,6 +16,7 @@ import {
 	type WritethroughCallback,
 	type WritethroughDeferredHandle,
 } from "../../lsp";
+import { FileChangeType, notifyWorkspaceWatchedFiles } from "../../lsp/client";
 import type { ToolSession } from "../../tools";
 import { routeWriteThroughBridge } from "../../tools/acp-bridge";
 import { assertEditableFile } from "../../tools/auto-generated-guard";
@@ -1753,6 +1754,13 @@ class LspFileSystem implements FileSystem {
 
 	async delete(path: string): Promise<void> {
 		await this.#getFile(path).unlink();
+		if (this.session.enableLsp ?? true) {
+			await notifyWorkspaceWatchedFiles(
+				this.session.cwd,
+				[{ filePath: path, type: FileChangeType.Deleted }],
+				this.signal,
+			);
+		}
 	}
 
 	async mkdir(path: string): Promise<void> {

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -1103,7 +1103,7 @@ export async function executeReplaceSingle(
 
 	// Route through ACP bridge when available; skips internal artifacts.
 	let diagnostics: FileDiagnosticsResult | undefined;
-	if (await routeWriteThroughBridge(session, path, absolutePath, finalContent)) {
+	if (await routeWriteThroughBridge(session, path, absolutePath, finalContent, signal)) {
 		// bridge handled the write; diagnostics not available via writethrough
 	} else {
 		diagnostics = await writethrough(absolutePath, finalContent, signal, Bun.file(absolutePath), batchRequest, dst =>

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -161,6 +161,10 @@ const CLIENT_CAPABILITIES = {
 				valueSet: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26],
 			},
 		},
+		didChangeWatchedFiles: {
+			dynamicRegistration: true,
+			relativePatternSupport: true,
+		},
 		fileOperations: {
 			dynamicRegistration: false,
 			willCreate: false,
@@ -175,6 +179,19 @@ const CLIENT_CAPABILITIES = {
 		snippetTextEdit: true,
 	},
 };
+
+/** LSP `FileChangeType` values for workspace/didChangeWatchedFiles notifications. */
+export enum FileChangeType {
+	Created = 1,
+	Changed = 2,
+	Deleted = 3,
+}
+
+/** Filesystem change authored by the harness and announced to active LSP clients. */
+export interface WatchedFileChange {
+	filePath: string;
+	type: FileChangeType;
+}
 
 // =============================================================================
 // LSP Message Protocol
@@ -942,6 +959,52 @@ export async function notifySaved(client: LspClient, filePath: string, signal?: 
 		signal,
 	);
 	client.lastActivity = Date.now();
+}
+
+function isPathInsideWorkspace(filePath: string, workspace: string): boolean {
+	const relative = path.relative(workspace, path.resolve(filePath));
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+/**
+ * Announce harness-authored filesystem changes to active LSP clients for `cwd`.
+ *
+ * This covers sibling files that are not open text documents, such as generated
+ * CSS modules or type files that another edited document imports immediately.
+ */
+export async function notifyWorkspaceWatchedFiles(
+	cwd: string,
+	changes: readonly WatchedFileChange[],
+	signal?: AbortSignal,
+): Promise<void> {
+	throwIfAborted(signal);
+	if (changes.length === 0) return;
+
+	const workspace = path.resolve(cwd);
+	const activeClients = Array.from(clients.values()).filter(
+		client => client.status === "ready" && path.resolve(client.cwd) === workspace,
+	);
+	if (activeClients.length === 0) return;
+
+	const results = await Promise.allSettled(
+		activeClients.map(async client => {
+			const clientChanges = changes
+				.filter(change => isPathInsideWorkspace(change.filePath, workspace))
+				.map(change => {
+					const uri = fileToUri(change.filePath);
+					client.diagnostics.delete(uri);
+					return { uri, type: change.type };
+				});
+			if (clientChanges.length === 0) return;
+			await sendNotification(client, "workspace/didChangeWatchedFiles", { changes: clientChanges }, signal);
+		}),
+	);
+	throwIfAborted(signal);
+	for (const result of results) {
+		if (result.status === "rejected") {
+			logger.debug("LSP watched-files notification failed", { cwd, error: String(result.reason) });
+		}
+	}
 }
 
 /**

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -1116,10 +1116,15 @@ async function runLspWritethrough(
 	const writeContent = async (value: string) => (file ? file.write(value) : Bun.write(dst, value));
 	const getWritePromise = once(() => writeContent(finalContent));
 	let writeNotified = false;
-	const notifyWriteCommitted = async () => {
+	const notifyWriteCommitted = async (notifySignal: AbortSignal | undefined = signal) => {
 		if (writeNotified) return;
 		writeNotified = true;
-		await notifyWorkspaceWatchedFiles(cwd, [{ filePath: dst, type: changeType }], signal);
+		try {
+			await notifyWorkspaceWatchedFiles(cwd, [{ filePath: dst, type: changeType }], notifySignal);
+		} catch (error) {
+			if (notifySignal?.aborted && !signal?.aborted) return;
+			throw error;
+		}
 	};
 	if (servers.length === 0) {
 		await getWritePromise();
@@ -1139,6 +1144,7 @@ async function runLspWritethrough(
 	let diagnostics: FileDiagnosticsResult | undefined;
 	let timedOut = false;
 	let synced = false;
+	let operationSignal: AbortSignal | undefined;
 	try {
 		const timeoutSignal = AbortSignal.timeout(5_000);
 		timeoutSignal.addEventListener(
@@ -1148,7 +1154,7 @@ async function runLspWritethrough(
 			},
 			{ once: true },
 		);
-		const operationSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+		operationSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 		await untilAborted(operationSignal, async () => {
 			if (useCustomFormatter) {
 				// Custom linters (e.g. Biome CLI) require on-disk input.
@@ -1156,7 +1162,7 @@ async function runLspWritethrough(
 				finalContent = await formatContent(dst, content, cwd, customLinterServers, operationSignal);
 				formatter = finalContent !== content ? FileFormatResult.FORMATTED : FileFormatResult.UNCHANGED;
 				await writeContent(finalContent);
-				await notifyWriteCommitted();
+				await notifyWriteCommitted(operationSignal);
 				await syncFileContent(dst, finalContent, cwd, lspServers, operationSignal);
 			} else {
 				// 1. Sync original content to LSP servers
@@ -1175,7 +1181,7 @@ async function runLspWritethrough(
 
 				// 4. Write to disk
 				await getWritePromise();
-				await notifyWriteCommitted();
+				await notifyWriteCommitted(operationSignal);
 			}
 
 			if (enableDiagnostics) {
@@ -1204,7 +1210,7 @@ async function runLspWritethrough(
 			}
 		}
 		await getWritePromise();
-		await notifyWriteCommitted();
+		await notifyWriteCommitted(operationSignal);
 	}
 
 	if (synced && enableDiagnostics) {

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -18,10 +18,12 @@ import { ToolAbortError, ToolError, throwIfAborted } from "../tools/tool-errors"
 import { clampTimeout } from "../tools/tool-timeouts";
 import {
 	ensureFileOpen,
+	FileChangeType,
 	getActiveClients,
 	getOrCreateClient,
 	type LspServerStatus,
 	notifySaved,
+	notifyWorkspaceWatchedFiles,
 	refreshFile,
 	sendNotification,
 	sendRequest,
@@ -904,6 +906,7 @@ interface PendingWritethrough {
 	dst: string;
 	content: string;
 	file?: BunFile;
+	changeType: FileChangeType;
 }
 
 interface LspWritethroughBatchRequest {
@@ -1097,6 +1100,7 @@ async function runLspWritethrough(
 	content: string,
 	cwd: string,
 	options: ResolvedWritethroughOptions,
+	changeType: FileChangeType,
 	signal?: AbortSignal,
 	file?: BunFile,
 	deferred?: {
@@ -1107,14 +1111,22 @@ async function runLspWritethrough(
 	const { enableFormat, enableDiagnostics } = options;
 	const config = getConfig(cwd);
 	const servers = getServersForFile(config, dst);
-	if (servers.length === 0) {
-		return writethroughNoop(dst, content, signal, file);
-	}
-	const { lspServers, customLinterServers } = splitServers(servers);
 
 	let finalContent = content;
 	const writeContent = async (value: string) => (file ? file.write(value) : Bun.write(dst, value));
 	const getWritePromise = once(() => writeContent(finalContent));
+	let writeNotified = false;
+	const notifyWriteCommitted = async () => {
+		if (writeNotified) return;
+		writeNotified = true;
+		await notifyWorkspaceWatchedFiles(cwd, [{ filePath: dst, type: changeType }], signal);
+	};
+	if (servers.length === 0) {
+		await getWritePromise();
+		await notifyWriteCommitted();
+		return undefined;
+	}
+	const { lspServers, customLinterServers } = splitServers(servers);
 	const useCustomFormatter = enableFormat && customLinterServers.length > 0;
 
 	// Capture diagnostic versions BEFORE syncing to detect stale diagnostics
@@ -1144,6 +1156,7 @@ async function runLspWritethrough(
 				finalContent = await formatContent(dst, content, cwd, customLinterServers, operationSignal);
 				formatter = finalContent !== content ? FileFormatResult.FORMATTED : FileFormatResult.UNCHANGED;
 				await writeContent(finalContent);
+				await notifyWriteCommitted();
 				await syncFileContent(dst, finalContent, cwd, lspServers, operationSignal);
 			} else {
 				// 1. Sync original content to LSP servers
@@ -1162,6 +1175,7 @@ async function runLspWritethrough(
 
 				// 4. Write to disk
 				await getWritePromise();
+				await notifyWriteCommitted();
 			}
 
 			if (enableDiagnostics) {
@@ -1190,6 +1204,7 @@ async function runLspWritethrough(
 			}
 		}
 		await getWritePromise();
+		await notifyWriteCommitted();
 	}
 
 	if (synced && enableDiagnostics) {
@@ -1237,7 +1252,16 @@ async function flushWritethroughBatch(
 				onDeferredDiagnostics: bundle.onDeferredDiagnostics,
 				signal: bundle.signal,
 			} as const);
-		const diag = await runLspWritethrough(entry.dst, entry.content, cwd, options, signal, entry.file, deferredInner);
+		const diag = await runLspWritethrough(
+			entry.dst,
+			entry.content,
+			cwd,
+			options,
+			entry.changeType,
+			signal,
+			entry.file,
+			deferredInner,
+		);
 		bundle?.finalize(diag);
 		results.push(diag);
 	}
@@ -1251,9 +1275,6 @@ export function createLspWritethrough(cwd: string, options?: WritethroughOptions
 		enableDiagnostics: options?.enableDiagnostics ?? false,
 		transformDiagnostics: options?.transformDiagnostics,
 	};
-	if (!resolvedOptions.enableFormat && !resolvedOptions.enableDiagnostics) {
-		return writethroughNoop;
-	}
 	return async (
 		dst: string,
 		content: string,
@@ -1262,6 +1283,7 @@ export function createLspWritethrough(cwd: string, options?: WritethroughOptions
 		batch?: LspWritethroughBatchRequest,
 		getDeferred?: (dst: string) => WritethroughDeferredHandle | undefined,
 	) => {
+		const changeType = (await Bun.file(dst).exists()) ? FileChangeType.Changed : FileChangeType.Created;
 		if (!batch) {
 			const bundle = getDeferred?.(dst);
 			const deferredInner =
@@ -1270,13 +1292,22 @@ export function createLspWritethrough(cwd: string, options?: WritethroughOptions
 					onDeferredDiagnostics: bundle.onDeferredDiagnostics,
 					signal: bundle.signal,
 				} as const);
-			const diagnostics = await runLspWritethrough(dst, content, cwd, resolvedOptions, signal, file, deferredInner);
+			const diagnostics = await runLspWritethrough(
+				dst,
+				content,
+				cwd,
+				resolvedOptions,
+				changeType,
+				signal,
+				file,
+				deferredInner,
+			);
 			bundle?.finalize(diagnostics);
 			return diagnostics;
 		}
 
 		const state = getOrCreateWritethroughBatch(batch.id, resolvedOptions);
-		state.entries.set(dst, { dst, content, file });
+		state.entries.set(dst, { dst, content, file, changeType });
 
 		if (!batch.flush) {
 			await writethroughNoop(dst, content, signal, file);

--- a/packages/coding-agent/src/tools/acp-bridge.ts
+++ b/packages/coding-agent/src/tools/acp-bridge.ts
@@ -55,6 +55,7 @@ export async function routeWriteThroughBridge(
 	requestedPath: string,
 	absolutePath: string,
 	content: string,
+	signal?: AbortSignal,
 ): Promise<boolean> {
 	if (!shouldRouteWriteThroughBridge(session, requestedPath, absolutePath)) return false;
 
@@ -68,7 +69,7 @@ export async function routeWriteThroughBridge(
 		throw new ToolError(error instanceof Error ? error.message : String(error));
 	}
 	if (session.enableLsp ?? true) {
-		await notifyWorkspaceWatchedFiles(session.cwd, [{ filePath: absolutePath, type: changeType }]);
+		await notifyWorkspaceWatchedFiles(session.cwd, [{ filePath: absolutePath, type: changeType }], signal);
 	}
 	invalidateFsScanAfterWrite(absolutePath);
 	session.bumpFileMutationVersion?.(absolutePath);

--- a/packages/coding-agent/src/tools/acp-bridge.ts
+++ b/packages/coding-agent/src/tools/acp-bridge.ts
@@ -7,6 +7,8 @@
  * URLs) are always written directly to disk — those are OMP-owned and should
  * never be pushed into the editor.
  */
+
+import { FileChangeType, notifyWorkspaceWatchedFiles } from "../lsp/client";
 import type { ToolSession } from ".";
 import { invalidateFsScanAfterWrite } from "./fs-cache-invalidation";
 import { isInternalUrlPath } from "./path-utils";
@@ -59,12 +61,15 @@ export async function routeWriteThroughBridge(
 	const bridge = session.getClientBridge?.();
 	if (!bridge?.capabilities.writeTextFile || !bridge.writeTextFile) return false;
 
+	const changeType = (await Bun.file(absolutePath).exists()) ? FileChangeType.Changed : FileChangeType.Created;
 	try {
 		await bridge.writeTextFile({ path: absolutePath, content });
 	} catch (error) {
 		throw new ToolError(error instanceof Error ? error.message : String(error));
 	}
-
+	if (session.enableLsp ?? true) {
+		await notifyWorkspaceWatchedFiles(session.cwd, [{ filePath: absolutePath, type: changeType }]);
+	}
 	invalidateFsScanAfterWrite(absolutePath);
 	session.bumpFileMutationVersion?.(absolutePath);
 	return true;

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -914,7 +914,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 
 			// Try ACP bridge first for editor-visible filesystem paths. Internal
 			// artifacts such as local:// plans are owned by OMP, not the editor.
-			if (await routeWriteThroughBridge(this.session, path, absolutePath, cleanContent)) {
+			if (await routeWriteThroughBridge(this.session, path, absolutePath, cleanContent, signal)) {
 				const madeExecutable = await maybeMarkExecutableForShebang(absolutePath, cleanContent);
 				const header = maybeWriteSnapshotHeader(this.session, absolutePath, cleanContent);
 				const writeLine = `Successfully wrote ${cleanContent.length} bytes to ${displayPath}`;

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -139,13 +139,15 @@ describe("LSP diagnostics freshness", () => {
 		const tsUri = fileToUri(tsPath);
 		const client = createClient(tempDir.path(), TEST_SERVER);
 		const events: string[] = [];
+		const notifySignals: Array<AbortSignal | undefined> = [];
 
 		vi.spyOn(lspConfig, "loadConfig").mockReturnValue({ servers: {}, idleTimeoutMs: undefined });
 		vi.spyOn(lspConfig, "getServersForFile").mockImplementation((_config, filePath) =>
 			filePath.endsWith(".module.scss") ? [] : [["test-lsp", TEST_SERVER]],
 		);
 		vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
-		vi.spyOn(lspClient, "notifyWorkspaceWatchedFiles").mockImplementation(async (_cwd, changes) => {
+		vi.spyOn(lspClient, "notifyWorkspaceWatchedFiles").mockImplementation(async (_cwd, changes, notifySignal) => {
+			notifySignals.push(notifySignal);
 			for (const change of changes) {
 				events.push(`watched:${path.basename(change.filePath)}:${change.type}`);
 			}
@@ -171,6 +173,7 @@ describe("LSP diagnostics freshness", () => {
 
 		expect(result?.summary).toBe("no issues");
 		expect(events[0]).toBe(`watched:probe.module.scss:${lspClient.FileChangeType.Created}`);
+		expect(notifySignals.some(signal => signal instanceof AbortSignal)).toBe(true);
 		expect(events).toContain("sync:probe.tsx");
 	});
 

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -112,6 +112,68 @@ describe("LSP diagnostics freshness", () => {
 		tempDir.removeSync();
 	});
 
+	it("announces watched-file creates even when no server owns the file type", async () => {
+		const filePath = path.join(tempDir.path(), "probe.module.scss");
+		vi.spyOn(lspConfig, "loadConfig").mockReturnValue({ servers: {}, idleTimeoutMs: undefined });
+		vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([]);
+		const notify = vi.spyOn(lspClient, "notifyWorkspaceWatchedFiles").mockResolvedValue();
+
+		const writethrough = createLspWritethrough(tempDir.path(), {
+			enableFormat: false,
+			enableDiagnostics: false,
+		});
+		const result = await writethrough(filePath, ".section {}\n");
+
+		expect(result).toBeUndefined();
+		expect(await Bun.file(filePath).text()).toBe(".section {}\n");
+		expect(notify).toHaveBeenCalledWith(
+			tempDir.path(),
+			[{ filePath, type: lspClient.FileChangeType.Created }],
+			undefined,
+		);
+	});
+
+	it("announces batched sibling writes before syncing the diagnostic target", async () => {
+		const stylesPath = path.join(tempDir.path(), "probe.module.scss");
+		const tsPath = path.join(tempDir.path(), "probe.tsx");
+		const tsUri = fileToUri(tsPath);
+		const client = createClient(tempDir.path(), TEST_SERVER);
+		const events: string[] = [];
+
+		vi.spyOn(lspConfig, "loadConfig").mockReturnValue({ servers: {}, idleTimeoutMs: undefined });
+		vi.spyOn(lspConfig, "getServersForFile").mockImplementation((_config, filePath) =>
+			filePath.endsWith(".module.scss") ? [] : [["test-lsp", TEST_SERVER]],
+		);
+		vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
+		vi.spyOn(lspClient, "notifyWorkspaceWatchedFiles").mockImplementation(async (_cwd, changes) => {
+			for (const change of changes) {
+				events.push(`watched:${path.basename(change.filePath)}:${change.type}`);
+			}
+		});
+		vi.spyOn(lspClient, "syncContent").mockImplementation(async (mockClient, syncedFilePath) => {
+			events.push(`sync:${path.basename(syncedFilePath)}`);
+			const syncedUri = fileToUri(syncedFilePath);
+			mockClient.openFiles.set(syncedUri, { version: 1, languageId: "typescript" });
+		});
+		vi.spyOn(lspClient, "notifySaved").mockImplementation(async mockClient => {
+			publishDiagnostics(mockClient, tsUri, [], mockClient.openFiles.get(tsUri)?.version ?? null);
+		});
+
+		const writethrough = createLspWritethrough(tempDir.path(), {
+			enableFormat: false,
+			enableDiagnostics: true,
+		});
+		await writethrough(stylesPath, ".section {}\n", undefined, undefined, { id: "batch", flush: false });
+		const result = await writethrough(tsPath, 'import styles from "./probe.module.scss";\n', undefined, undefined, {
+			id: "batch",
+			flush: true,
+		});
+
+		expect(result?.summary).toBe("no issues");
+		expect(events[0]).toBe(`watched:probe.module.scss:${lspClient.FileChangeType.Created}`);
+		expect(events).toContain("sync:probe.tsx");
+	});
+
 	it("suppresses stale write diagnostics until the matching document version arrives", async () => {
 		const filePath = path.join(tempDir.path(), "example.ts");
 		const uri = fileToUri(filePath);


### PR DESCRIPTION
## Repro
Confirmed the LSP layer had no watched-file notification path: searching `packages/coding-agent/src/lsp` for `didChangeWatchedFiles`, `FileChangeType`, and related symbols returned no matches, so harness-authored sibling creates/changes/deletes could only reach language servers through their own filesystem watchers.

## Cause
`packages/coding-agent/src/lsp/client.ts` advertised no `workspace.didChangeWatchedFiles` capability and exposed no helper to send `workspace/didChangeWatchedFiles`; `packages/coding-agent/src/lsp/index.ts` only synced/saved the edited text document, while delete, move, ACP-bridge, and non-LSP sibling writes in `edit`/`write` paths bypassed any workspace file-change notification before diagnostics were read.

## Fix
- Added `workspace.didChangeWatchedFiles` client capability plus a `notifyWorkspaceWatchedFiles` helper that announces harness-authored create/change/delete events to active LSP clients.
- Routed LSP writethrough writes, batched sibling writes, ACP bridge writes, patch deletes, and hashline deletes/moves through watched-file notifications before diagnostics are fetched.
- Added regression coverage for a batched non-LSP sibling file write so diagnostics sync only happens after the sibling create has been announced.
- Added an Unreleased changelog entry for `packages/coding-agent`.

## Verification
`bun test packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts` passed: 5 tests, 19 assertions. `bun check` passed. Fixes #4459