### PR TITLE
fix(build): emit NodeNext-consumable .d.ts (explicit .js on relative re-exports)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed published `.d.ts` being unconsumable under `moduleResolution: "node16" | "nodenext"`: the declaration emit ran under Bundler resolution and left relative re-exports extensionless (`export * from "./sdk"`), so a NodeNext consumer failed to resolve the package root (`TS2834`/`TS2305`). The publish pipeline now rewrites emitted relative specifiers to explicit `.js` extensions across every package's `dist/types`.
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -35,6 +35,7 @@ import {
 	generateNpmPackages,
 	LEAF_TARGETS,
 } from "../packages/natives/scripts/gen-npm-packages.ts";
+import { fixDtsExtensions } from "./fix-dts-extensions.ts";
 
 export interface PublishPackage {
 	dir: string;
@@ -161,6 +162,10 @@ async function preparePackage(pkg: PublishPackage): Promise<PackageManifest> {
 	for (const cfg of pkg.extraTypeConfigs ?? []) {
 		await $`bun x tsgo -p ${cfg}`.cwd(pkgDir);
 	}
+	// The declaration emit runs under `moduleResolution: "Bundler"`, so relative
+	// specifiers land extensionless — unresolvable for a `nodenext` consumer.
+	// Rewrite them to explicit `.js` so the published types resolve everywhere.
+	await fixDtsExtensions(path.join(pkgDir, "dist/types"));
 	return rewriteManifest(pkg, !isDryRun);
 }
 

--- a/scripts/fix-dts-extensions.test.ts
+++ b/scripts/fix-dts-extensions.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fixDtsExtensions, fixDtsFile, resolveDtsSpecifier } from "./fix-dts-extensions";
+
+// Each test builds a real `dist/types`-shaped tree under a fresh temp dir, runs
+// the transform, and reads the bytes the code wrote back off disk. We assert on
+// the rewritten content / return counts (the observable contract), never on the
+// source text of the helper.
+const tempDirs: string[] = [];
+
+async function makeTree(files: Record<string, string>): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "fix-dts-"));
+	tempDirs.push(root);
+	for (const [rel, content] of Object.entries(files)) {
+		const abs = path.join(root, rel);
+		await fs.mkdir(path.dirname(abs), { recursive: true });
+		await fs.writeFile(abs, content);
+	}
+	return root;
+}
+
+function read(...segments: string[]): Promise<string> {
+	return fs.readFile(path.join(...segments), "utf8");
+}
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("resolveDtsSpecifier", () => {
+	it("returns null for bare, scoped, node:, and already-suffixed specifiers", async () => {
+		const root = await makeTree({ "placeholder.d.ts": "export {};\n" });
+		for (const spec of ["@oh-my-pi/pi-tui", "zod/v4", "node:fs", "./x.js", "./data.json", "./m.mjs", "./c.cjs"]) {
+			expect(await resolveDtsSpecifier(root, spec)).toBeNull();
+		}
+	});
+
+	it("maps a .d.ts specifier to .js without consulting the filesystem", async () => {
+		// No `foo.d.ts` planted: the .d.ts → .js mapping is a pure rewrite.
+		const root = await makeTree({ "placeholder.d.ts": "export {};\n" });
+		expect(await resolveDtsSpecifier(root, "./foo.d.ts")).toBe("./foo.js");
+	});
+
+	it("resolves relative to the given fromDir, not the tree root", async () => {
+		const root = await makeTree({
+			"sibling.d.ts": "export declare const s: number;\n",
+			"sub/index.d.ts": "export {};\n",
+		});
+		// From the subdir, `../sibling` reaches root/sibling.d.ts.
+		expect(await resolveDtsSpecifier(path.join(root, "sub"), "../sibling")).toBe("../sibling.js");
+		// From root, `./sibling` also reaches it (control: sibling resolution works).
+		expect(await resolveDtsSpecifier(root, "./sibling")).toBe("./sibling.js");
+	});
+});
+
+describe("fixDtsFile", () => {
+	it("appends .js to a sibling declaration re-export and returns count 1", async () => {
+		const root = await makeTree({
+			"sdk.d.ts": "export declare const sdk: number;\n",
+			"index.d.ts": 'export * from "./sdk";\n',
+		});
+		const count = await fixDtsFile(path.join(root, "index.d.ts"));
+		expect(count).toBe(1);
+		expect(await read(root, "index.d.ts")).toBe('export * from "./sdk.js";\n');
+	});
+
+	it("resolves a directory barrel to its index.js", async () => {
+		const root = await makeTree({
+			"modes/index.d.ts": "export declare const X: string;\n",
+			"index.d.ts": 'import { X } from "./modes";\nexport { X };\n',
+		});
+		const count = await fixDtsFile(path.join(root, "index.d.ts"));
+		expect(count).toBe(1);
+		expect(await read(root, "index.d.ts")).toBe('import { X } from "./modes/index.js";\nexport { X };\n');
+	});
+
+	it("rewrites `export type * from` and `export type { A } from` like value exports", async () => {
+		const root = await makeTree({
+			"sdk.d.ts": "export type A = number;\n",
+			"star.d.ts": 'export type * from "./sdk";\n',
+			"named.d.ts": 'export type { A } from "./sdk";\n',
+		});
+		expect(await fixDtsFile(path.join(root, "star.d.ts"))).toBe(1);
+		expect(await fixDtsFile(path.join(root, "named.d.ts"))).toBe(1);
+		expect(await read(root, "star.d.ts")).toBe('export type * from "./sdk.js";\n');
+		expect(await read(root, "named.d.ts")).toBe('export type { A } from "./sdk.js";\n');
+	});
+
+	it("leaves a file of bare and already-suffixed specifiers byte-for-byte unchanged", async () => {
+		const source =
+			'export * from "@oh-my-pi/pi-tui";\n' +
+			'import { z } from "zod/v4";\n' +
+			'import * as nodefs from "node:fs";\n' +
+			'export * from "./x.js";\n' +
+			'import data from "./data.json";\n';
+		const root = await makeTree({ "index.d.ts": source });
+		const count = await fixDtsFile(path.join(root, "index.d.ts"));
+		expect(count).toBe(0);
+		expect(await read(root, "index.d.ts")).toBe(source);
+	});
+
+	it("resolves `../sibling` against the importing file's dir at depth", async () => {
+		const root = await makeTree({
+			"sibling.d.ts": "export declare const s: number;\n",
+			"sub/index.d.ts": 'export * from "../sibling";\n',
+		});
+		const count = await fixDtsFile(path.join(root, "sub", "index.d.ts"));
+		expect(count).toBe(1);
+		expect(await read(root, "sub", "index.d.ts")).toBe('export * from "../sibling.js";\n');
+	});
+
+	it("is idempotent — a second pass returns 0 and never doubles the extension", async () => {
+		const root = await makeTree({
+			"sdk.d.ts": "export declare const sdk: number;\n",
+			"index.d.ts": 'export * from "./sdk";\n',
+		});
+		const file = path.join(root, "index.d.ts");
+		expect(await fixDtsFile(file)).toBe(1);
+		const afterFirst = await read(root, "index.d.ts");
+		expect(await fixDtsFile(file)).toBe(0);
+		expect(await read(root, "index.d.ts")).toBe(afterFirst);
+		expect(afterFirst).toBe('export * from "./sdk.js";\n');
+		expect(afterFirst).not.toContain(".js.js");
+	});
+
+	it("leaves an unresolvable relative specifier unchanged and returns 0", async () => {
+		const source = 'export * from "./does-not-exist";\n';
+		const root = await makeTree({ "index.d.ts": source });
+		expect(await resolveDtsSpecifier(root, "./does-not-exist")).toBeNull();
+		expect(await fixDtsFile(path.join(root, "index.d.ts"))).toBe(0);
+		expect(await read(root, "index.d.ts")).toBe(source);
+	});
+
+	it("counts only resolvable specifiers, excluding an unresolvable one in the same file", async () => {
+		const root = await makeTree({
+			"sdk.d.ts": "export declare const sdk: number;\n",
+			"index.d.ts": 'export * from "./sdk";\nexport * from "./ghost";\n',
+		});
+		const count = await fixDtsFile(path.join(root, "index.d.ts"));
+		expect(count).toBe(1);
+		expect(await read(root, "index.d.ts")).toBe('export * from "./sdk.js";\nexport * from "./ghost";\n');
+	});
+});
+
+describe("fixDtsExtensions", () => {
+	it("recursively fixes every .d.ts and totals files + specifiers", async () => {
+		const root = await makeTree({
+			// 2 resolvable specifiers: ./sdk (sibling) + ./modes (barrel).
+			"index.d.ts": 'export * from "./sdk";\nexport { M } from "./modes";\n',
+			// 0 specifiers.
+			"sdk.d.ts": "export declare const sdk: number;\n",
+			// 1 resolvable specifier: ./config (sibling within modes/).
+			"modes/index.d.ts": 'export * from "./config";\nexport declare const M: string;\n',
+			// 0 specifiers.
+			"modes/config.d.ts": "export declare const config: boolean;\n",
+		});
+		const totals = await fixDtsExtensions(root);
+		expect(totals).toEqual({ files: 2, specifiers: 3 });
+		expect(await read(root, "index.d.ts")).toBe('export * from "./sdk.js";\nexport { M } from "./modes/index.js";\n');
+		expect(await read(root, "modes/index.d.ts")).toBe(
+			'export * from "./config.js";\nexport declare const M: string;\n',
+		);
+	});
+
+	it("integration: leaves the root barrel fully .js-suffixed with no bare forms remaining", async () => {
+		const root = await makeTree({
+			"index.d.ts": 'export * from "./sdk";\nexport { M } from "./modes";\n',
+			"sdk.d.ts": "export declare const sdk: number;\n",
+			"modes/index.d.ts": "export declare const M: string;\n",
+		});
+		await fixDtsExtensions(root);
+		const barrel = await read(root, "index.d.ts");
+		expect(barrel).toContain('from "./sdk.js"');
+		expect(barrel).toContain('from "./modes/index.js"');
+		// The trailing quote disambiguates: `from "./sdk"` is not a substring of
+		// `from "./sdk.js"`, so this proves no bare specifier survived.
+		expect(barrel).not.toContain('from "./sdk"');
+		expect(barrel).not.toContain('from "./modes"');
+	});
+});

--- a/scripts/fix-dts-extensions.ts
+++ b/scripts/fix-dts-extensions.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+/**
+ * Rewrite extensionless relative specifiers in emitted `.d.ts` to explicit
+ * `.js` extensions so the published declarations resolve under
+ * `moduleResolution: "node16" | "nodenext"`.
+ *
+ * The workspace type-checks under `moduleResolution: "Bundler"`
+ * (`tsconfig.base.json`), which permits extensionless relative imports. `tsgo`
+ * therefore emits `export * from "./sdk"` / `import … from "./modes/components"`
+ * into `dist/types`. A downstream consumer on `nodenext` (the modern default)
+ * then can't resolve the barrel — every relative re-export is a `TS2834`, which
+ * cascades into `TS2305` "no exported member" on the whole package root.
+ *
+ * This post-emit pass appends the correct extension to each **relative**
+ * specifier, resolving it against the emitted tree:
+ *   `./sdk`              → `./sdk.js`               (sibling `sdk.d.ts`)
+ *   `./modes/components` → `./modes/components/index.js`  (directory barrel)
+ * Bare (`@scope/pkg`, `zod/v4`) and already-suffixed (`.js`, `.json`)
+ * specifiers are left untouched.
+ *
+ * Applied by `ci-release-publish.ts` after `tsgo -p tsconfig.publish.json`.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+// Matches the specifier in `from "…"` / `import "…"` / `export … from "…"`.
+// Captures the quote-enclosed module string; we filter to relative ones below.
+const SPECIFIER_RE = /((?:from|import)\s*)("|')(\.[^"']*)(\2)/g;
+
+/** Resolve an extensionless relative specifier to its `.js` runtime form,
+ *  given the directory of the importing `.d.ts`. Returns null to leave as-is. */
+export async function resolveDtsSpecifier(fromDir: string, spec: string): Promise<string | null> {
+	// Already has a JS/JSON extension, or a declaration extension we map to .js.
+	if (/\.(js|json|mjs|cjs)$/.test(spec)) return null;
+	if (/\.d\.ts$/.test(spec)) return `${spec.slice(0, -".d.ts".length)}.js`;
+
+	const abs = path.join(fromDir, spec);
+	// Sibling declaration file: `./sdk` → `./sdk.js`.
+	if (await exists(`${abs}.d.ts`)) return `${spec}.js`;
+	// Directory barrel: `./modes/components` → `./modes/components/index.js`.
+	if (await exists(path.join(abs, "index.d.ts"))) return `${spec.replace(/\/$/, "")}/index.js`;
+	// Unresolved (e.g. an asset or a specifier with no emitted `.d.ts`): leave it.
+	return null;
+}
+
+async function exists(p: string): Promise<boolean> {
+	try {
+		await fs.access(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/** Rewrite one `.d.ts` file in place. Returns the number of specifiers changed. */
+export async function fixDtsFile(filePath: string): Promise<number> {
+	const source = await Bun.file(filePath).text();
+	const fromDir = path.dirname(filePath);
+	let changed = 0;
+
+	// Collect async resolutions first (regex replace can't await), then apply.
+	const edits: Array<{ match: string; replacement: string }> = [];
+	for (const m of source.matchAll(SPECIFIER_RE)) {
+		const [full, prefix, quote, spec] = m;
+		const resolved = await resolveDtsSpecifier(fromDir, spec);
+		if (resolved && resolved !== spec) {
+			edits.push({ match: full, replacement: `${prefix}${quote}${resolved}${quote}` });
+		}
+	}
+	if (edits.length === 0) return 0;
+
+	let out = source;
+	for (const { match, replacement } of edits) {
+		out = out.replace(match, replacement);
+		changed++;
+	}
+	await Bun.write(filePath, out);
+	return changed;
+}
+
+/** Walk `dir` recursively and fix every `.d.ts`. Returns totals. */
+export async function fixDtsExtensions(dir: string): Promise<{ files: number; specifiers: number }> {
+	let files = 0;
+	let specifiers = 0;
+	const entries = await fs.readdir(dir, { withFileTypes: true, recursive: true });
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".d.ts")) continue;
+		const filePath = path.join(entry.parentPath, entry.name);
+		const n = await fixDtsFile(filePath);
+		if (n > 0) {
+			files++;
+			specifiers += n;
+		}
+	}
+	return { files, specifiers };
+}
+
+if (import.meta.main) {
+	const target = process.argv[2];
+	if (!target) {
+		console.error("usage: fix-dts-extensions.ts <dist/types dir>");
+		process.exit(1);
+	}
+	const { files, specifiers } = await fixDtsExtensions(target);
+	console.log(`fix-dts-extensions: rewrote ${specifiers} specifiers across ${files} files in ${target}`);
+}


### PR DESCRIPTION
## What

Add a post-emit pass to the publish pipeline that rewrites extensionless relative specifiers in the generated `.d.ts` to explicit `.js`, resolving each against the emitted tree:

- `export * from "./sdk"` → `"./sdk.js"` (sibling declaration)
- `import … from "./modes/components"` → `"./modes/components/index.js"` (directory barrel)

Bare/scoped (`@oh-my-pi/pi-tui`, `zod/v4`, `node:*`) and already-suffixed specifiers are left untouched. New `scripts/fix-dts-extensions.ts`; `ci-release-publish.ts` calls it after `tsgo -p tsconfig.publish.json`, for every published package — so `pi-tui`/`pi-utils` barrels propagate correctly too.

## Why

Fixes #4463. The declaration emit runs under `moduleResolution: "Bundler"` (`tsconfig.base.json`), which permits extensionless relative imports, so `tsgo` emits them into `dist/types`. A downstream consumer on `node16`/`nodenext` (the modern default) then can't resolve the package root — every relative re-export is a `TS2834`, cascading into `TS2305` "no exported member" across the whole barrel (including the names re-exported from `pi-tui`/`pi-utils`, whose own emitted barrels have the same defect). Rewriting relative specifiers to explicit `.js` at publish time makes the shipped types resolve under both Bundler and NodeNext, without changing source (which stays extensionless for local Bundler dev).

Verified against published 16.3.4: the `nodenext` root-import repro fails before and type-checks clean after applying the fix to `pi-coding-agent` + `pi-tui` + `pi-utils` `dist/types`.

## Testing

`scripts/fix-dts-extensions.test.ts` (13 tests) — sibling-file vs directory-barrel resolution, `export type * from` / `export type { … } from` forms, bare/scoped/already-suffixed left byte-identical, `.d.ts`→`.js` mapping, nested-depth `../sibling` resolution relative to the importing file, unresolvable specifiers left as-is, recursion totals, and idempotence (no `.js.js` doubling).

## Note (open question for the maintainer)

This does **not** drop `noCheck: true` from the publish type-builds — that's a separate hardening (it would make a broken declaration emit fail the release instead of shipping silently, but risks surfacing unrelated pre-existing emit errors across all packages, so it's left out of this focused fix). Happy to follow up with a `noCheck`-off gate if wanted.

---

- [x] `bun check` passes
- [x] Tested locally (13/13 unit tests; nodenext repro verified fixed against published 16.3.4)
- [ ] CHANGELOG updated (packages/coding-agent)
