### PR TITLE
fix(ai): trim whitespace around enum tool args

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed tool-call validation to strip stray trailing whitespace on schema-matching enum values and on well-known path/URL fields (`path`, `paths`, `file`, `file_path`, `url`, `uri`) before dispatch, keeping content-carrying fields (`content`, `input`, etc.) intact ([#4461](https://github.com/can1357/oh-my-pi/issues/4461)).
+- Fixed tool-call validation to strip stray trailing whitespace on schema-matching enum values and on well-known identifier fields (`path`, `paths`, `file`, `file_path`, `url`, `uri`, `title`, `label`) before dispatch, keeping content-carrying fields (`content`, `input`, `code`, `command`, etc.) intact ([#4461](https://github.com/can1357/oh-my-pi/issues/4461)).
 
 ## [16.3.4] - 2026-07-03
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tool-call validation to trim schema-matching enum values with stray surrounding whitespace before dispatch ([#4461](https://github.com/can1357/oh-my-pi/issues/4461)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed tool-call validation to trim schema-matching enum values with stray surrounding whitespace before dispatch ([#4461](https://github.com/can1357/oh-my-pi/issues/4461)).
+- Fixed tool-call validation to strip stray trailing whitespace on schema-matching enum values and on well-known path/URL fields (`path`, `paths`, `file`, `file_path`, `url`, `uri`) before dispatch, keeping content-carrying fields (`content`, `input`, etc.) intact ([#4461](https://github.com/can1357/oh-my-pi/issues/4461)).
 
 ## [16.3.4] - 2026-07-03
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed tool-call validation to strip stray trailing whitespace on schema-matching enum values and on well-known identifier fields (`path`, `paths`, `file`, `file_path`, `url`, `uri`, `title`, `label`) before dispatch, keeping content-carrying fields (`content`, `input`, `code`, `command`, etc.) intact ([#4461](https://github.com/can1357/oh-my-pi/issues/4461)).
+- Fixed tool-call validation to strip stray trailing line terminators on schema-matching enum values and on well-known identifier fields (`path`, `paths`, `file`, `file_path`, `url`, `uri`, `title`, `label`) before dispatch, keeping ordinary trailing spaces and content-carrying fields (`content`, `input`, `code`, `command`, etc.) intact ([#4461](https://github.com/can1357/oh-my-pi/issues/4461)).
 
 ## [16.3.4] - 2026-07-03
 

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -928,24 +928,25 @@ function normalizeEnumStringWhitespace(schema: unknown, value: unknown): { value
 }
 
 // ============================================================================
-// Path-like string trailing-whitespace normalization (LLM quirk).
+// Identifier-string trailing-whitespace normalization (LLM quirk).
 // ============================================================================
 //
 // LLMs sometimes emit tool arguments with a trailing newline dangling off a
-// path/URL — the artifact of a token boundary or a JSON stream heuristic. Path
+// short identifier — a path, URL, or a display label like `title`. These
 // values are never legitimately terminated by whitespace, so we strip trailing
-// whitespace from string values on well-known path/URL properties before the
-// tool ever sees them. Content-carrying properties (`content`, `input`, `body`,
-// `text`, `command`) are excluded so genuine trailing newlines survive.
+// whitespace from string values on the well-known keys below before the tool
+// ever sees them. Content-carrying properties (`content`, `input`, `body`,
+// `text`, `command`, `code`) are intentionally NOT trimmed so genuine trailing
+// newlines survive on writes, patches, shell commands, and eval snippets.
 // ============================================================================
 
 /**
- * Property names whose values are treated as filesystem paths, URLs, or URIs.
- * The trim only fires on strings sitting under one of these keys, so
- * `content: "line1\n"` on `write` and similar content-carrying fields keep
- * their trailing whitespace intact.
+ * Property names whose values are treated as short identifiers — filesystem
+ * paths, URLs, URIs, or display labels. The trim only fires on strings sitting
+ * under one of these keys, so `content: "line1\n"` on `write` and `code:
+ * "console.log('hi')\n"` on `eval` keep their trailing whitespace intact.
  */
-const PATH_LIKE_KEYS: ReadonlySet<string> = new Set([
+const IDENTIFIER_STRING_KEYS: ReadonlySet<string> = new Set([
 	"path",
 	"paths",
 	"file",
@@ -954,6 +955,8 @@ const PATH_LIKE_KEYS: ReadonlySet<string> = new Set([
 	"filepath",
 	"url",
 	"uri",
+	"title",
+	"label",
 ]);
 
 const TRAILING_WHITESPACE_RE = /\s+$/;
@@ -963,7 +966,7 @@ function trimTrailingWhitespaceString(input: string): string {
 	return input.replace(TRAILING_WHITESPACE_RE, "");
 }
 
-function trimPathLikeStringLeaf(input: unknown): unknown {
+function trimIdentifierStringLeaf(input: unknown): unknown {
 	if (typeof input === "string") {
 		const trimmed = trimTrailingWhitespaceString(input);
 		return trimmed === input ? input : trimmed;
@@ -989,15 +992,16 @@ function trimPathLikeStringLeaf(input: unknown): unknown {
 
 /**
  * Recursively strip trailing whitespace from string values whose property key
- * matches {@link PATH_LIKE_KEYS}. Runs by property name only (schema-agnostic)
- * so it fires uniformly across Zod, ArkType, and plain JSON Schema tools.
+ * matches {@link IDENTIFIER_STRING_KEYS}. Runs by property name only
+ * (schema-agnostic) so it fires uniformly across Zod, ArkType, and plain JSON
+ * Schema tools.
  */
-function normalizePathLikeFieldWhitespace(value: unknown): { value: unknown; changed: boolean } {
+function normalizeIdentifierStringWhitespace(value: unknown): { value: unknown; changed: boolean } {
 	if (Array.isArray(value)) {
 		let changed = false;
 		let next = value;
 		for (let i = 0; i < value.length; i += 1) {
-			const normalized = normalizePathLikeFieldWhitespace(value[i]);
+			const normalized = normalizeIdentifierStringWhitespace(value[i]);
 			if (!normalized.changed) continue;
 			if (!changed) {
 				next = [...value];
@@ -1015,11 +1019,11 @@ function normalizePathLikeFieldWhitespace(value: unknown): { value: unknown; cha
 	let out: Record<string, unknown> = source;
 	for (const [key, entry] of Object.entries(source)) {
 		let nextEntry = entry;
-		if (PATH_LIKE_KEYS.has(key)) {
-			const trimmed = trimPathLikeStringLeaf(entry);
+		if (IDENTIFIER_STRING_KEYS.has(key)) {
+			const trimmed = trimIdentifierStringLeaf(entry);
 			if (trimmed !== entry) nextEntry = trimmed;
 		}
-		const nested = normalizePathLikeFieldWhitespace(nextEntry);
+		const nested = normalizeIdentifierStringWhitespace(nextEntry);
 		if (nested.changed) nextEntry = nested.value;
 		if (nextEntry === entry) continue;
 		if (!changed) {
@@ -1687,13 +1691,14 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		changed = true;
 	}
 
-	// Strip trailing whitespace from string values on well-known path/URL
-	// property names. Some models tack a newline onto a path arg from stream
-	// artifacts; downstream tools then either fail to stat the target or
-	// annotate a "corrected from" hint the model misreads as tool corruption.
-	const pathLikeNormalization = normalizePathLikeFieldWhitespace(normalizedArgs);
-	if (pathLikeNormalization.changed) {
-		normalizedArgs = pathLikeNormalization.value;
+	// Strip trailing whitespace from string values on well-known
+	// identifier-like property names (paths, URLs, titles). Some models tack
+	// a newline onto a short-identifier arg from stream artifacts; downstream
+	// tools then either fail to stat the target or annotate a "corrected
+	// from" hint the model misreads as tool corruption.
+	const identifierStringNormalization = normalizeIdentifierStringWhitespace(normalizedArgs);
+	if (identifierStringNormalization.changed) {
+		normalizedArgs = identifierStringNormalization.value;
 		changed = true;
 	}
 
@@ -1744,9 +1749,9 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 			normalizedArgs = enumStringNormalizationPass.value;
 		}
 
-		const pathLikeNormalizationPass = normalizePathLikeFieldWhitespace(normalizedArgs);
-		if (pathLikeNormalizationPass.changed) {
-			normalizedArgs = pathLikeNormalizationPass.value;
+		const identifierStringNormalizationPass = normalizeIdentifierStringWhitespace(normalizedArgs);
+		if (identifierStringNormalizationPass.changed) {
+			normalizedArgs = identifierStringNormalizationPass.value;
 		}
 
 		// Re-run the union-string coercion because `coerceArgsFromIssues` may

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -928,6 +928,110 @@ function normalizeEnumStringWhitespace(schema: unknown, value: unknown): { value
 }
 
 // ============================================================================
+// Path-like string trailing-whitespace normalization (LLM quirk).
+// ============================================================================
+//
+// LLMs sometimes emit tool arguments with a trailing newline dangling off a
+// path/URL — the artifact of a token boundary or a JSON stream heuristic. Path
+// values are never legitimately terminated by whitespace, so we strip trailing
+// whitespace from string values on well-known path/URL properties before the
+// tool ever sees them. Content-carrying properties (`content`, `input`, `body`,
+// `text`, `command`) are excluded so genuine trailing newlines survive.
+// ============================================================================
+
+/**
+ * Property names whose values are treated as filesystem paths, URLs, or URIs.
+ * The trim only fires on strings sitting under one of these keys, so
+ * `content: "line1\n"` on `write` and similar content-carrying fields keep
+ * their trailing whitespace intact.
+ */
+const PATH_LIKE_KEYS: ReadonlySet<string> = new Set([
+	"path",
+	"paths",
+	"file",
+	"file_path",
+	"filePath",
+	"filepath",
+	"url",
+	"uri",
+]);
+
+const TRAILING_WHITESPACE_RE = /\s+$/;
+
+function trimTrailingWhitespaceString(input: string): string {
+	if (!TRAILING_WHITESPACE_RE.test(input)) return input;
+	return input.replace(TRAILING_WHITESPACE_RE, "");
+}
+
+function trimPathLikeStringLeaf(input: unknown): unknown {
+	if (typeof input === "string") {
+		const trimmed = trimTrailingWhitespaceString(input);
+		return trimmed === input ? input : trimmed;
+	}
+	if (Array.isArray(input)) {
+		let changed = false;
+		let next = input;
+		for (let i = 0; i < input.length; i += 1) {
+			const item = input[i];
+			if (typeof item !== "string") continue;
+			const trimmed = trimTrailingWhitespaceString(item);
+			if (trimmed === item) continue;
+			if (!changed) {
+				next = input.slice();
+				changed = true;
+			}
+			next[i] = trimmed;
+		}
+		return changed ? next : input;
+	}
+	return input;
+}
+
+/**
+ * Recursively strip trailing whitespace from string values whose property key
+ * matches {@link PATH_LIKE_KEYS}. Runs by property name only (schema-agnostic)
+ * so it fires uniformly across Zod, ArkType, and plain JSON Schema tools.
+ */
+function normalizePathLikeFieldWhitespace(value: unknown): { value: unknown; changed: boolean } {
+	if (Array.isArray(value)) {
+		let changed = false;
+		let next = value;
+		for (let i = 0; i < value.length; i += 1) {
+			const normalized = normalizePathLikeFieldWhitespace(value[i]);
+			if (!normalized.changed) continue;
+			if (!changed) {
+				next = [...value];
+				changed = true;
+			}
+			next[i] = normalized.value;
+		}
+		return { value: changed ? next : value, changed };
+	}
+
+	if (value === null || typeof value !== "object") return { value, changed: false };
+
+	const source = value as Record<string, unknown>;
+	let changed = false;
+	let out: Record<string, unknown> = source;
+	for (const [key, entry] of Object.entries(source)) {
+		let nextEntry = entry;
+		if (PATH_LIKE_KEYS.has(key)) {
+			const trimmed = trimPathLikeStringLeaf(entry);
+			if (trimmed !== entry) nextEntry = trimmed;
+		}
+		const nested = normalizePathLikeFieldWhitespace(nextEntry);
+		if (nested.changed) nextEntry = nested.value;
+		if (nextEntry === entry) continue;
+		if (!changed) {
+			out = { ...source };
+			changed = true;
+		}
+		out[key] = nextEntry;
+	}
+	return { value: changed ? out : value, changed };
+}
+
+// ============================================================================
 // Double-encoded object-key normalization (LLM quirk).
 // ============================================================================
 //
@@ -1583,6 +1687,16 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		changed = true;
 	}
 
+	// Strip trailing whitespace from string values on well-known path/URL
+	// property names. Some models tack a newline onto a path arg from stream
+	// artifacts; downstream tools then either fail to stat the target or
+	// annotate a "corrected from" hint the model misreads as tool corruption.
+	const pathLikeNormalization = normalizePathLikeFieldWhitespace(normalizedArgs);
+	if (pathLikeNormalization.changed) {
+		normalizedArgs = pathLikeNormalization.value;
+		changed = true;
+	}
+
 	// Then re-shape JSON-stringified arrays whose schema accepts both string
 	// and array (e.g. `paths: string | string[]`). Without this, zod accepts
 	// the literal `'["a","b"]'` as a string and downstream tools treat it as
@@ -1628,6 +1742,11 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		const enumStringNormalizationPass = normalizeEnumStringWhitespace(json, normalizedArgs);
 		if (enumStringNormalizationPass.changed) {
 			normalizedArgs = enumStringNormalizationPass.value;
+		}
+
+		const pathLikeNormalizationPass = normalizePathLikeFieldWhitespace(normalizedArgs);
+		if (pathLikeNormalizationPass.changed) {
+			normalizedArgs = pathLikeNormalizationPass.value;
 		}
 
 		// Re-run the union-string coercion because `coerceArgsFromIssues` may

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -835,6 +835,98 @@ function normalizeOptionalNullsForSchema(
 	return { value: changed ? nextValue : value, changed };
 }
 
+function normalizeEnumStringWhitespace(schema: unknown, value: unknown): { value: unknown; changed: boolean } {
+	if (value === null || value === undefined) return { value, changed: false };
+	if (schema === null || typeof schema !== "object") return { value, changed: false };
+
+	const schemaObject = schema as Record<string, unknown>;
+
+	const normalizeAnyOfLike = (keyword: "anyOf" | "oneOf"): { value: unknown; changed: boolean } => {
+		const branches = schemaObject[keyword];
+		if (!Array.isArray(branches)) return { value, changed: false };
+		if (branches.some(branch => branchMatchesSchema(branch, value))) return { value, changed: false };
+
+		for (const branch of branches) {
+			const normalized = normalizeEnumStringWhitespace(branch, value);
+			if (!normalized.changed) continue;
+			if (branchMatchesSchema(branch, normalized.value)) return normalized;
+		}
+		return { value, changed: false };
+	};
+
+	const anyOfNormalization = normalizeAnyOfLike("anyOf");
+	if (anyOfNormalization.changed) return anyOfNormalization;
+
+	const oneOfNormalization = normalizeAnyOfLike("oneOf");
+	if (oneOfNormalization.changed) return oneOfNormalization;
+
+	if (Array.isArray(schemaObject.allOf)) {
+		let changed = false;
+		let nextValue: unknown = value;
+		for (const branch of schemaObject.allOf) {
+			const normalized = normalizeEnumStringWhitespace(branch, nextValue);
+			if (!normalized.changed) continue;
+			nextValue = normalized.value;
+			changed = true;
+		}
+		if (changed) return { value: nextValue, changed: true };
+	}
+
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (trimmed !== value) {
+			const enumValues = schemaObject.enum;
+			if (Array.isArray(enumValues) && !enumValues.includes(value) && enumValues.includes(trimmed)) {
+				return { value: trimmed, changed: true };
+			}
+			const constValue = schemaObject.const;
+			if (typeof constValue === "string" && trimmed === constValue) {
+				return { value: trimmed, changed: true };
+			}
+		}
+		return { value, changed: false };
+	}
+
+	if (Array.isArray(value)) {
+		const itemSchema = schemaObject.items;
+		if (itemSchema === null || typeof itemSchema !== "object" || Array.isArray(itemSchema)) {
+			return { value, changed: false };
+		}
+		let changed = false;
+		let nextValue = value;
+		for (let i = 0; i < value.length; i += 1) {
+			const normalized = normalizeEnumStringWhitespace(itemSchema, value[i]);
+			if (!normalized.changed) continue;
+			if (!changed) {
+				nextValue = [...value];
+				changed = true;
+			}
+			nextValue[i] = normalized.value;
+		}
+		return { value: changed ? nextValue : value, changed };
+	}
+
+	if (typeof value !== "object") return { value, changed: false };
+	const properties = schemaObject.properties;
+	if (!properties || typeof properties !== "object") return { value, changed: false };
+
+	const propsObject = properties as Record<string, unknown>;
+	const valueObject = value as Record<string, unknown>;
+	let changed = false;
+	let nextValue = valueObject;
+	for (const [key, propertySchema] of Object.entries(propsObject)) {
+		if (!(key in nextValue)) continue;
+		const normalized = normalizeEnumStringWhitespace(propertySchema, nextValue[key]);
+		if (!normalized.changed) continue;
+		if (!changed) {
+			nextValue = { ...nextValue };
+			changed = true;
+		}
+		nextValue[key] = normalized.value;
+	}
+	return { value: changed ? nextValue : valueObject, changed };
+}
+
 // ============================================================================
 // Double-encoded object-key normalization (LLM quirk).
 // ============================================================================
@@ -1485,6 +1577,12 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		changed = true;
 	}
 
+	const enumStringNormalization = normalizeEnumStringWhitespace(json, normalizedArgs);
+	if (enumStringNormalization.changed) {
+		normalizedArgs = enumStringNormalization.value;
+		changed = true;
+	}
+
 	// Then re-shape JSON-stringified arrays whose schema accepts both string
 	// and array (e.g. `paths: string | string[]`). Without this, zod accepts
 	// the literal `'["a","b"]'` as a string and downstream tools treat it as
@@ -1525,6 +1623,11 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		const nullNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
 		if (nullNormalization.changed) {
 			normalizedArgs = nullNormalization.value;
+		}
+
+		const enumStringNormalizationPass = normalizeEnumStringWhitespace(json, normalizedArgs);
+		if (enumStringNormalizationPass.changed) {
+			normalizedArgs = enumStringNormalizationPass.value;
 		}
 
 		// Re-run the union-string coercion because `coerceArgsFromIssues` may

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -927,20 +927,34 @@ function normalizeEnumStringWhitespace(
 	}
 
 	if (Array.isArray(value)) {
-		const itemSchema = schemaObject.items;
-		if (itemSchema === null || typeof itemSchema !== "object" || Array.isArray(itemSchema)) {
-			return { value, changed: false };
-		}
 		let changed = false;
 		let nextValue = value;
-		for (let i = 0; i < value.length; i += 1) {
-			const normalized = normalizeEnumStringWhitespace(itemSchema, value[i], root, refs);
-			if (!normalized.changed) continue;
-			if (!changed) {
-				nextValue = [...value];
-				changed = true;
+		const prefixItems = schemaObject.prefixItems;
+		if (Array.isArray(prefixItems)) {
+			for (let i = 0; i < value.length && i < prefixItems.length; i += 1) {
+				const itemSchema = prefixItems[i];
+				const normalized = normalizeEnumStringWhitespace(itemSchema, value[i], root, refs);
+				if (!normalized.changed) continue;
+				if (!changed) {
+					nextValue = [...value];
+					changed = true;
+				}
+				nextValue[i] = normalized.value;
 			}
-			nextValue[i] = normalized.value;
+		}
+
+		const itemSchema = schemaObject.items;
+		if (itemSchema !== null && typeof itemSchema === "object" && !Array.isArray(itemSchema)) {
+			for (let i = 0; i < value.length; i += 1) {
+				if (Array.isArray(prefixItems) && i < prefixItems.length) continue;
+				const normalized = normalizeEnumStringWhitespace(itemSchema, nextValue[i], root, refs);
+				if (!normalized.changed) continue;
+				if (!changed) {
+					nextValue = [...value];
+					changed = true;
+				}
+				nextValue[i] = normalized.value;
+			}
 		}
 		return { value: changed ? nextValue : value, changed };
 	}
@@ -972,18 +986,19 @@ function normalizeEnumStringWhitespace(
 //
 // LLMs sometimes emit tool arguments with a trailing newline dangling off a
 // short identifier — a path, URL, or a display label like `title`. These
-// values are never legitimately terminated by whitespace, so we strip trailing
-// whitespace from string values on the well-known keys below before the tool
-// ever sees them. Content-carrying properties (`content`, `input`, `body`,
-// `text`, `command`, `code`) are intentionally NOT trimmed so genuine trailing
-// newlines survive on writes, patches, shell commands, and eval snippets.
+// values are never legitimately terminated by line breaks, so we strip trailing
+// line terminators from string values on the well-known keys below before the
+// tool ever sees them. Content-carrying properties (`content`, `input`, `body`,
+// `text`, `command`, `code`) are intentionally not traversed or trimmed so
+// genuine trailing whitespace survives on writes, patches, shell commands, and
+// eval snippets.
 // ============================================================================
 
 /**
  * Property names whose values are treated as short identifiers — filesystem
  * paths, URLs, URIs, or display labels. The trim only fires on strings sitting
- * under one of these keys, so `content: "line1\n"` on `write` and `code:
- * "console.log('hi')\n"` on `eval` keep their trailing whitespace intact.
+ * under one of these keys, so `path: "docs/report "` still targets the file
+ * whose name ends in a space.
  */
 const IDENTIFIER_STRING_KEYS: ReadonlySet<string> = new Set([
 	"path",
@@ -998,16 +1013,18 @@ const IDENTIFIER_STRING_KEYS: ReadonlySet<string> = new Set([
 	"label",
 ]);
 
-const TRAILING_WHITESPACE_RE = /\s+$/;
+const CONTENT_CARRYING_KEYS: ReadonlySet<string> = new Set(["content", "input", "body", "text", "command", "code"]);
 
-function trimTrailingWhitespaceString(input: string): string {
-	if (!TRAILING_WHITESPACE_RE.test(input)) return input;
-	return input.replace(TRAILING_WHITESPACE_RE, "");
+const TRAILING_LINE_TERMINATOR_RE = /[\r\n]+$/;
+
+function trimTrailingLineTerminators(input: string): string {
+	if (!TRAILING_LINE_TERMINATOR_RE.test(input)) return input;
+	return input.replace(TRAILING_LINE_TERMINATOR_RE, "");
 }
 
 function trimIdentifierStringLeaf(input: unknown): unknown {
 	if (typeof input === "string") {
-		const trimmed = trimTrailingWhitespaceString(input);
+		const trimmed = trimTrailingLineTerminators(input);
 		return trimmed === input ? input : trimmed;
 	}
 	if (Array.isArray(input)) {
@@ -1016,7 +1033,7 @@ function trimIdentifierStringLeaf(input: unknown): unknown {
 		for (let i = 0; i < input.length; i += 1) {
 			const item = input[i];
 			if (typeof item !== "string") continue;
-			const trimmed = trimTrailingWhitespaceString(item);
+			const trimmed = trimTrailingLineTerminators(item);
 			if (trimmed === item) continue;
 			if (!changed) {
 				next = input.slice();
@@ -1030,10 +1047,10 @@ function trimIdentifierStringLeaf(input: unknown): unknown {
 }
 
 /**
- * Recursively strip trailing whitespace from string values whose property key
- * matches {@link IDENTIFIER_STRING_KEYS}. Runs by property name only
+ * Recursively strip trailing line terminators from string values whose property
+ * key matches {@link IDENTIFIER_STRING_KEYS}. Runs by property name only
  * (schema-agnostic) so it fires uniformly across Zod, ArkType, and plain JSON
- * Schema tools.
+ * Schema tools while preserving nested payloads under content-carrying keys.
  */
 function normalizeIdentifierStringWhitespace(value: unknown): { value: unknown; changed: boolean } {
 	if (Array.isArray(value)) {
@@ -1058,6 +1075,7 @@ function normalizeIdentifierStringWhitespace(value: unknown): { value: unknown; 
 	let out: Record<string, unknown> = source;
 	for (const [key, entry] of Object.entries(source)) {
 		let nextEntry = entry;
+		if (CONTENT_CARRYING_KEYS.has(key)) continue;
 		if (IDENTIFIER_STRING_KEYS.has(key)) {
 			const trimmed = trimIdentifierStringLeaf(entry);
 			if (trimmed !== entry) nextEntry = trimmed;
@@ -1751,6 +1769,12 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		changed = true;
 	}
 
+	const identifierStringNormalizationAfterArray = normalizeIdentifierStringWhitespace(normalizedArgs);
+	if (identifierStringNormalizationAfterArray.changed) {
+		normalizedArgs = identifierStringNormalizationAfterArray.value;
+		changed = true;
+	}
+
 	// Single-argument tools (e.g. `edit`): if the model put the lone required
 	// string under a different key, adopt the first string field as that key.
 	const singleStringNorm = normalizeSingleStringField(json, normalizedArgs);
@@ -1800,6 +1824,11 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		const stringEncodedArrayNormPass = normalizeStringEncodedArrayUnions(json, normalizedArgs);
 		if (stringEncodedArrayNormPass.changed) {
 			normalizedArgs = stringEncodedArrayNormPass.value;
+		}
+
+		const identifierStringNormalizationAfterArrayPass = normalizeIdentifierStringWhitespace(normalizedArgs);
+		if (identifierStringNormalizationAfterArrayPass.changed) {
+			normalizedArgs = identifierStringNormalizationAfterArrayPass.value;
 		}
 
 		// Re-run single-string remap: `coerceArgsFromIssues` may have just

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -835,21 +835,60 @@ function normalizeOptionalNullsForSchema(
 	return { value: changed ? nextValue : value, changed };
 }
 
-function normalizeEnumStringWhitespace(schema: unknown, value: unknown): { value: unknown; changed: boolean } {
+function decodeJsonPointerToken(token: string): string {
+	return token.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function resolveLocalJsonSchemaRef(root: unknown, ref: string): unknown | undefined {
+	if (ref === "#") return root;
+	if (!ref.startsWith("#/")) return undefined;
+	let current: unknown = root;
+	for (const rawToken of ref.slice(2).split("/")) {
+		const token = decodeJsonPointerToken(rawToken);
+		if (current === null || typeof current !== "object") return undefined;
+		current = (current as Record<string, unknown>)[token];
+	}
+	return current;
+}
+
+function normalizeEnumStringWhitespace(
+	schema: unknown,
+	value: unknown,
+	root: unknown = schema,
+	refs: ReadonlySet<string> = new Set(),
+): { value: unknown; changed: boolean } {
 	if (value === null || value === undefined) return { value, changed: false };
 	if (schema === null || typeof schema !== "object") return { value, changed: false };
 
 	const schemaObject = schema as Record<string, unknown>;
+	const ref = schemaObject.$ref;
+	if (typeof ref === "string") {
+		if (refs.has(ref)) return { value, changed: false };
+		const resolved = resolveLocalJsonSchemaRef(root, ref);
+		if (resolved === undefined) return { value, changed: false };
+		return normalizeEnumStringWhitespace(resolved, value, root, new Set([...refs, ref]));
+	}
+
+	const branchMatches = (branch: unknown, candidate: unknown): boolean => {
+		if (branch !== null && typeof branch === "object") {
+			const branchRef = (branch as Record<string, unknown>).$ref;
+			if (typeof branchRef === "string" && !refs.has(branchRef)) {
+				const resolved = resolveLocalJsonSchemaRef(root, branchRef);
+				if (resolved !== undefined) return branchMatchesSchema(resolved, candidate);
+			}
+		}
+		return branchMatchesSchema(branch, candidate);
+	};
 
 	const normalizeAnyOfLike = (keyword: "anyOf" | "oneOf"): { value: unknown; changed: boolean } => {
 		const branches = schemaObject[keyword];
 		if (!Array.isArray(branches)) return { value, changed: false };
-		if (branches.some(branch => branchMatchesSchema(branch, value))) return { value, changed: false };
+		if (branches.some(branch => branchMatches(branch, value))) return { value, changed: false };
 
 		for (const branch of branches) {
-			const normalized = normalizeEnumStringWhitespace(branch, value);
+			const normalized = normalizeEnumStringWhitespace(branch, value, root, refs);
 			if (!normalized.changed) continue;
-			if (branchMatchesSchema(branch, normalized.value)) return normalized;
+			if (branchMatches(branch, normalized.value)) return normalized;
 		}
 		return { value, changed: false };
 	};
@@ -864,7 +903,7 @@ function normalizeEnumStringWhitespace(schema: unknown, value: unknown): { value
 		let changed = false;
 		let nextValue: unknown = value;
 		for (const branch of schemaObject.allOf) {
-			const normalized = normalizeEnumStringWhitespace(branch, nextValue);
+			const normalized = normalizeEnumStringWhitespace(branch, nextValue, root, refs);
 			if (!normalized.changed) continue;
 			nextValue = normalized.value;
 			changed = true;
@@ -895,7 +934,7 @@ function normalizeEnumStringWhitespace(schema: unknown, value: unknown): { value
 		let changed = false;
 		let nextValue = value;
 		for (let i = 0; i < value.length; i += 1) {
-			const normalized = normalizeEnumStringWhitespace(itemSchema, value[i]);
+			const normalized = normalizeEnumStringWhitespace(itemSchema, value[i], root, refs);
 			if (!normalized.changed) continue;
 			if (!changed) {
 				nextValue = [...value];
@@ -916,7 +955,7 @@ function normalizeEnumStringWhitespace(schema: unknown, value: unknown): { value
 	let nextValue = valueObject;
 	for (const [key, propertySchema] of Object.entries(propsObject)) {
 		if (!(key in nextValue)) continue;
-		const normalized = normalizeEnumStringWhitespace(propertySchema, nextValue[key]);
+		const normalized = normalizeEnumStringWhitespace(propertySchema, nextValue[key], root, refs);
 		if (!normalized.changed) continue;
 		if (!changed) {
 			nextValue = { ...nextValue };

--- a/packages/ai/test/eval-language-whitespace.test.ts
+++ b/packages/ai/test/eval-language-whitespace.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-ai/types";
+import { validateToolArguments } from "@oh-my-pi/pi-ai/utils/validation";
+import { type } from "arktype";
+
+describe("Eval-tool language whitespace normalization", () => {
+	it("trims a trailing newline on the ArkType-emitted language enum", () => {
+		const tool: Tool = {
+			name: "eval",
+			description: "",
+			parameters: type({
+				language: type("'py' | 'js' | 'rb' | 'jl'").describe(""),
+				code: type("string").describe(""),
+				"title?": type("string").describe(""),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-eval-language-newline",
+			name: "eval",
+			arguments: { language: "js\n", code: "console.log('hi')", title: "smoke" },
+		}) as { language: string; code: string; title?: string };
+
+		expect(result.language).toBe("js");
+		expect(result.code).toBe("console.log('hi')");
+		expect(result.title).toBe("smoke");
+	});
+});

--- a/packages/ai/test/todo-op-whitespace.test.ts
+++ b/packages/ai/test/todo-op-whitespace.test.ts
@@ -89,4 +89,33 @@ describe("Tool argument whitespace normalization", () => {
 
 		expect(result).toEqual({ path: "docs/foo.md", content: "hello\n" });
 	});
+
+	it("trims trailing whitespace from title fields while keeping code content", () => {
+		const tool: Tool = {
+			name: "eval",
+			description: "",
+			parameters: z.object({
+				language: z.enum(["py", "js", "rb", "jl"]),
+				code: z.string(),
+				title: z.string().optional(),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-eval-title-newline",
+			name: "eval",
+			arguments: {
+				language: "js\n",
+				title: "read multi_observation lines 36-100\n",
+				code: "console.log('hi')\n",
+			},
+		});
+
+		expect(result).toEqual({
+			language: "js",
+			title: "read multi_observation lines 36-100",
+			code: "console.log('hi')\n",
+		});
+	});
 });

--- a/packages/ai/test/todo-op-whitespace.test.ts
+++ b/packages/ai/test/todo-op-whitespace.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import type { Tool } from "@oh-my-pi/pi-ai/types";
+import { validateToolArguments } from "@oh-my-pi/pi-ai/utils/validation";
+import { z } from "zod/v4";
+
+describe("Tool enum argument whitespace", () => {
+	it("trims trailing whitespace from enum strings before validation", () => {
+		const tool: Tool = {
+			name: "todo",
+			description: "",
+			parameters: z.object({
+				op: z.enum(["append", "done", "drop", "init", "rm", "start", "view"]),
+				items: z.array(z.string()).optional(),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-todo-op-newline",
+			name: "todo",
+			arguments: { op: "init\n", items: ["Fix RNG divergence"] },
+		});
+
+		expect(result).toEqual({ op: "init", items: ["Fix RNG divergence"] });
+	});
+});

--- a/packages/ai/test/todo-op-whitespace.test.ts
+++ b/packages/ai/test/todo-op-whitespace.test.ts
@@ -3,7 +3,7 @@ import type { Tool } from "@oh-my-pi/pi-ai/types";
 import { validateToolArguments } from "@oh-my-pi/pi-ai/utils/validation";
 import { z } from "zod/v4";
 
-describe("Tool enum argument whitespace", () => {
+describe("Tool argument whitespace normalization", () => {
 	it("trims trailing whitespace from enum strings before validation", () => {
 		const tool: Tool = {
 			name: "todo",
@@ -22,5 +22,71 @@ describe("Tool enum argument whitespace", () => {
 		});
 
 		expect(result).toEqual({ op: "init", items: ["Fix RNG divergence"] });
+	});
+
+	it("strips trailing newlines from path fields on read-like tools", () => {
+		const tool: Tool = {
+			name: "read",
+			description: "",
+			parameters: z.object({
+				path: z.string(),
+				offset: z.number().optional(),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-read-path-newline",
+			name: "read",
+			arguments: { path: "examples/multi_observation.py:36-55\n" },
+		});
+
+		expect(result).toEqual({ path: "examples/multi_observation.py:36-55" });
+	});
+
+	it("strips trailing whitespace from every entry in a path array", () => {
+		const tool: Tool = {
+			name: "search",
+			description: "",
+			parameters: z.object({
+				pattern: z.string(),
+				paths: z.array(z.string()),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-search-paths-newline",
+			name: "search",
+			arguments: {
+				pattern: "TODO",
+				paths: ["src/foo.ts\n", "src/bar.ts "],
+			},
+		});
+
+		expect(result).toEqual({
+			pattern: "TODO",
+			paths: ["src/foo.ts", "src/bar.ts"],
+		});
+	});
+
+	it("leaves trailing newlines on content-carrying fields intact", () => {
+		const tool: Tool = {
+			name: "write",
+			description: "",
+			parameters: z.object({
+				path: z.string(),
+				content: z.string(),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-write-content-newline",
+			name: "write",
+			arguments: { path: "docs/foo.md\n", content: "hello\n" },
+		});
+
+		expect(result).toEqual({ path: "docs/foo.md", content: "hello\n" });
 	});
 });

--- a/packages/ai/test/todo-op-whitespace.test.ts
+++ b/packages/ai/test/todo-op-whitespace.test.ts
@@ -24,6 +24,37 @@ describe("Tool argument whitespace normalization", () => {
 		expect(result).toEqual({ op: "init", items: ["Fix RNG divergence"] });
 	});
 
+	it("trims trailing whitespace from enum and const strings behind local JSON Schema refs", () => {
+		const tool: Tool = {
+			name: "todo",
+			description: "",
+			parameters: {
+				type: "object",
+				properties: {
+					op: { $ref: "#/$defs/Op" },
+					view: { $ref: "#/definitions/View" },
+				},
+				required: ["op", "view"],
+				additionalProperties: false,
+				$defs: {
+					Op: { enum: ["init", "done"] },
+				},
+				definitions: {
+					View: { const: "summary" },
+				},
+			},
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-json-schema-ref-enum-newline",
+			name: "todo",
+			arguments: { op: "init\n", view: "summary\n" },
+		});
+
+		expect(result).toEqual({ op: "init", view: "summary" });
+	});
+
 	it("strips trailing newlines from path fields on read-like tools", () => {
 		const tool: Tool = {
 			name: "read",

--- a/packages/ai/test/todo-op-whitespace.test.ts
+++ b/packages/ai/test/todo-op-whitespace.test.ts
@@ -55,6 +55,25 @@ describe("Tool argument whitespace normalization", () => {
 		expect(result).toEqual({ op: "init", view: "summary" });
 	});
 
+	it("trims enum strings inside tuple prefix items", () => {
+		const tool: Tool = {
+			name: "tuple-op",
+			description: "",
+			parameters: z.object({
+				args: z.tuple([z.enum(["init"])]),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-tuple-enum-newline",
+			name: "tuple-op",
+			arguments: { args: ["init\n"] },
+		});
+
+		expect(result).toEqual({ args: ["init"] });
+	});
+
 	it("strips trailing newlines from path fields on read-like tools", () => {
 		const tool: Tool = {
 			name: "read",
@@ -75,7 +94,7 @@ describe("Tool argument whitespace normalization", () => {
 		expect(result).toEqual({ path: "examples/multi_observation.py:36-55" });
 	});
 
-	it("strips trailing whitespace from every entry in a path array", () => {
+	it("strips trailing line terminators but preserves ordinary spaces in path arrays", () => {
 		const tool: Tool = {
 			name: "search",
 			description: "",
@@ -97,8 +116,29 @@ describe("Tool argument whitespace normalization", () => {
 
 		expect(result).toEqual({
 			pattern: "TODO",
-			paths: ["src/foo.ts", "src/bar.ts"],
+			paths: ["src/foo.ts", "src/bar.ts "],
 		});
+	});
+
+	it("trims path line terminators after stringified array coercion", () => {
+		const tool: Tool = {
+			name: "search",
+			description: "",
+			parameters: z.object({
+				paths: z.union([z.string(), z.array(z.string())]),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-search-stringified-paths-newline",
+			name: "search",
+			arguments: {
+				paths: JSON.stringify(["src/foo.ts\n", "src/bar.ts "]),
+			},
+		});
+
+		expect(result).toEqual({ paths: ["src/foo.ts", "src/bar.ts "] });
 	});
 
 	it("leaves trailing newlines on content-carrying fields intact", () => {
@@ -119,6 +159,27 @@ describe("Tool argument whitespace normalization", () => {
 		});
 
 		expect(result).toEqual({ path: "docs/foo.md", content: "hello\n" });
+	});
+
+	it("does not trim identifier-looking fields nested under content payloads", () => {
+		const tool: Tool = {
+			name: "http",
+			description: "",
+			parameters: z.object({
+				body: z.object({
+					title: z.string(),
+				}),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-body-title-space",
+			name: "http",
+			arguments: { body: { title: "Draft \n" } },
+		});
+
+		expect(result).toEqual({ body: { title: "Draft \n" } });
 	});
 
 	it("trims trailing whitespace from title fields while keeping code content", () => {


### PR DESCRIPTION
## Repro
Added and ran `bun test packages/ai/test/todo-op-whitespace.test.ts`; before the fix it reproduced the reporter's failure by rejecting `op: "init\n"` with `Validation failed for tool "todo"`.

## Cause
`packages/ai/src/utils/validation.ts` normalized optional nulls, JSON-string containers, and mislabeled string fields before dispatch, but it did not normalize string enum or const values. Zod reports `z.enum(...)` mismatches as invalid options rather than type errors, so the existing coercion pass never saw `todo.op` and surfaced the raw trailing newline.

## Fix
- Added schema-directed enum/const string whitespace normalization in `validateToolArguments`.
- Re-ran that normalization after JSON-string coercion exposes nested arguments.
- Added a regression test for `todo` receiving `op: "init\n"`.
- Documented the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/todo-op-whitespace.test.ts packages/ai/test/tool-argument-coercion.test.ts` passed with 82 tests. `bun check` passed locally, and `gh_push_branch` completed its pre-publish gate. Fixes #4461