### PR TITLE
fix(tui): repaint write first partial results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed streamed `write` tool previews leaving stale pending rows above the first partial-result frame in the TUI ([#4477](https://github.com/can1357/oh-my-pi/issues/4477)).
+
 ## [16.3.4] - 2026-07-03
 
 ### Fixed

--- a/packages/coding-agent/src/modes/components/tool-execution.test.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { type Terminal, type TerminalAppearance, TUI } from "@oh-my-pi/pi-tui";
+
+import { Settings } from "../../config/settings";
+import { getThemeByName, setThemeInstance } from "../theme/theme";
+import { ToolExecutionComponent } from "./tool-execution";
+
+class CapturingTerminal implements Terminal {
+	writes: string[] = [];
+	columns = 80;
+	rows = 8;
+	kittyProtocolActive = false;
+	kittyEnableSequence: string | null = null;
+	keyboardEnhancementEnterSequence: string | null = null;
+	keyboardEnhancementExitSequence: string | null = null;
+	appearance: TerminalAppearance | undefined;
+
+	start(): void {}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(data: string): void {
+		this.writes.push(data);
+	}
+	moveBy(): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(): void {}
+	setProgress(): void {}
+	onAppearanceChange(): void {}
+}
+
+function makeToolBlock(toolName: string, args: Record<string, unknown>) {
+	const terminal = new CapturingTerminal();
+	const ui = new TUI(terminal);
+	const block = new ToolExecutionComponent(toolName, args, { showImages: false }, undefined, ui, "/tmp/project");
+	ui.addChild(block);
+	return { terminal, block };
+}
+
+function renderPendingThenUpdateFirstPartial(
+	toolName: string,
+	args: Record<string, unknown>,
+	text = "running",
+): string {
+	const { terminal, block } = makeToolBlock(toolName, args);
+	try {
+		block.render(80);
+		terminal.writes = [];
+		block.updateResult({ content: [{ type: "text", text }] }, true);
+		return terminal.writes.join("");
+	} finally {
+		block.stopAnimation();
+	}
+}
+
+beforeAll(async () => {
+	await Settings.init({ inMemory: true });
+	const loaded = await getThemeByName("dark");
+	if (!loaded) throw new Error("theme unavailable");
+	setThemeInstance(loaded);
+});
+
+describe("ToolExecutionComponent first partial result repaint", () => {
+	it("replays the viewport when a collapsed write pending tail becomes the first partial result", () => {
+		const content = Array.from({ length: 20 }, (_, index) => `line ${index + 1}`).join("\n");
+		const output = renderPendingThenUpdateFirstPartial("write", { path: "out.txt", content }, "Writing out.txt...");
+
+		expect(output).toContain("\x1b[2J\x1b[H");
+	});
+
+	it("keeps SSH first-result repaint scoped to streamed placeholder args", () => {
+		const output = renderPendingThenUpdateFirstPartial("ssh", { host: "prod", command: "uptime" });
+
+		expect(output).not.toContain("\x1b[2J\x1b[H");
+	});
+
+	it("replays the viewport when SSH replaces a streamed placeholder", () => {
+		const output = renderPendingThenUpdateFirstPartial("ssh", {
+			host: "prod",
+			command: "uptime",
+			__partialJson: '{"host":"prod","command":"upt',
+		});
+
+		expect(output).toContain("\x1b[2J\x1b[H");
+	});
+});

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -283,13 +283,13 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 	// history, so progress renders static gray and further partial snapshots are
 	// dropped (see #maybeFreezeBackgroundTask).
 	#backgroundTaskFrozen = false;
-	// Set on each `render()` when the last painted shape carried the streamed
-	// SSH-style placeholder / partial-result chrome. Reset gates key off these
-	// so a topology-changing update that lands before the shape reaches the
-	// terminal never triggers a full-viewport replay (which on direct terminals
-	// wipes native scrollback and flashes the user's history — reviewer note on
-	// PR #4315).
-	#placeholderShapePainted = false;
+	// Set on each `render()` when the last painted pending shape must be replayed
+	// wholesale before the first result arrives. Reset gates key off this so a
+	// topology-changing update that lands before the shape reaches the terminal
+	// never triggers a full-viewport replay (which on direct terminals wipes
+	// native scrollback and flashes the user's history — reviewer note on PR
+	// #4315).
+	#firstResultViewportRepaintShapePainted = false;
 	#partialResultShapePainted = false;
 	#renderState: {
 		spinnerFrame?: number;
@@ -497,9 +497,9 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		}
 		const hadNoResult = this.#result === undefined;
 		const wasPartialResult = this.#result !== undefined && this.#isPartial;
-		const placeholderPainted = this.#placeholderShapePainted;
+		const firstResultRepaintShapePainted = this.#firstResultViewportRepaintShapePainted;
 		const partialResultPainted = this.#partialResultShapePainted;
-		this.#placeholderShapePainted = false;
+		this.#firstResultViewportRepaintShapePainted = false;
 		this.#partialResultShapePainted = false;
 		this.#result = result;
 		this.#resultVersion++;
@@ -513,7 +513,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#updateTodoStrikeAnimation();
 		this.#updateDisplay();
 		this.#resetDisplayForResultTopologyChange(
-			hadNoResult && placeholderPainted,
+			hadNoResult && firstResultRepaintShapePainted,
 			wasPartialResult && partialResultPainted,
 			isPartial,
 		);
@@ -851,22 +851,26 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		this.#displayBuilt = true;
 	}
 
-	#rendererFlag(name: "forceFirstResultViewportRepaint" | "forceResultViewportRepaintOnSettle"): boolean {
+	#rendererFlag(name: "forceResultViewportRepaintOnSettle"): boolean {
 		const toolValue = (this.#tool as Record<string, unknown> | undefined)?.[name];
 		const rendererValue = toolRenderers[this.#toolName]?.[name];
 		return toolValue === true || (toolValue === undefined && rendererValue === true);
 	}
 
 	/**
-	 * True while the last painted shape uses the streamed placeholder path
-	 * (`⏳ SSH: […]` / `$ …`) — the render call ran with `__partialJson` args
-	 * and no result. Kept as a per-paint fact so a topology-changing update
-	 * that lands before the placeholder reaches the terminal skips the reset.
+	 * True while the last painted pending-call shape opted into a full viewport
+	 * repaint before the first result. Kept as a per-paint fact so a
+	 * topology-changing update that lands before the pending rows reach the
+	 * terminal skips the reset.
 	 */
-	#isPlaceholderShapeAtRender(): boolean {
+	#needsFirstResultViewportRepaintAtRender(): boolean {
 		if (this.#result !== undefined) return false;
-		if (!this.#rendererFlag("forceFirstResultViewportRepaint")) return false;
-		return partialJsonOf(this.#args) !== undefined;
+		const toolValue = (this.#tool as { forceFirstResultViewportRepaint?: unknown } | undefined)
+			?.forceFirstResultViewportRepaint;
+		const rendererValue = toolRenderers[this.#toolName]?.forceFirstResultViewportRepaint;
+		const value = toolValue === undefined ? rendererValue : toolValue;
+		if (typeof value === "function") return value(this.#args, { ...this.#renderState, isPartial: this.#isPartial });
+		return value === true;
 	}
 
 	#resetDisplayForResultTopologyChange(
@@ -874,11 +878,10 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		partialResultPaintedBeforeSettle: boolean,
 		isPartial: boolean,
 	): void {
-		const firstResultReplacesStreamedPlaceholder =
-			firstResultAfterPlaceholderPaint && this.#rendererFlag("forceFirstResultViewportRepaint");
+		const firstResultReplacesRepaintShape = firstResultAfterPlaceholderPaint;
 		const provisionalResultSettled =
 			partialResultPaintedBeforeSettle && !isPartial && this.#rendererFlag("forceResultViewportRepaintOnSettle");
-		if (firstResultReplacesStreamedPlaceholder || provisionalResultSettled) {
+		if (firstResultReplacesRepaintShape || provisionalResultSettled) {
 			this.#ui.resetDisplay();
 		}
 	}
@@ -889,7 +892,7 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		// override runs on every compose the parent Container performs, so a
 		// frame that never gets composed leaves the flags false and prevents a
 		// spurious `resetDisplay()`.
-		this.#placeholderShapePainted = this.#isPlaceholderShapeAtRender();
+		this.#firstResultViewportRepaintShapePainted = this.#needsFirstResultViewportRepaintAtRender();
 		this.#partialResultShapePainted = this.#result !== undefined && this.#isPartial;
 		return lines;
 	}

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -32,6 +32,8 @@ import { sshToolRenderer } from "./ssh";
 import { todoToolRenderer } from "./todo";
 import { writeToolRenderer } from "./write";
 
+export type FirstResultViewportRepaint = boolean | ((args: unknown, options: RenderResultOptions) => boolean);
+
 export type ToolRenderer = {
 	renderCall: (args: unknown, options: RenderResultOptions, theme: Theme) => Component;
 	renderResult: (
@@ -75,12 +77,11 @@ export type ToolRenderer = {
 	 */
 	animatedPartialResult?: boolean | ((args: unknown) => boolean);
 	/**
-	 * Whether replacing a streamed pending placeholder with the first result
-	 * requires a full viewport repaint. Use for merged renderers whose pending
-	 * streamed args may have committed placeholder rows that the result render
-	 * re-anchors instead of preserving.
+	 * Whether replacing a pending call render with the first result requires a
+	 * full viewport repaint. Use for merged renderers whose pending rows can be
+	 * re-anchored instead of preserved by the result render.
 	 */
-	forceFirstResultViewportRepaint?: boolean;
+	forceFirstResultViewportRepaint?: FirstResultViewportRepaint;
 	/**
 	 * Whether settling a provisional partial result into the final render requires
 	 * a full viewport repaint. Use when the result renderer changes chrome or

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -244,6 +244,11 @@ interface SshRenderArgs {
 	timeout?: number;
 }
 
+function hasStreamedRenderArgs(args: unknown): boolean {
+	if (args == null || typeof args !== "object" || !("__partialJson" in args)) return false;
+	return typeof args.__partialJson === "string";
+}
+
 interface SshRenderContext {
 	/** Visual lines for truncated output (pre-computed by tool-execution) */
 	visualLines?: string[];
@@ -404,9 +409,9 @@ export const sshToolRenderer = {
 	provisionalPartialResult: true,
 	// Streamed args can initially render the SSH placeholder (`⏳ SSH: […]` /
 	// `$ …`), then the first partial result inserts the `Output` section and
-	// re-anchors the frame. Force a full repaint at that seam so placeholder rows
-	// do not survive in viewport/native scrollback.
-	forceFirstResultViewportRepaint: true,
+	// re-anchors the frame. Force a full repaint only at that streamed-placeholder
+	// seam so placeholder rows do not survive in viewport/native scrollback.
+	forceFirstResultViewportRepaint: hasStreamedRenderArgs,
 	// The provisional pending-result frame settles into the final `⇄ SSH: [host]`
 	// frame, so clear/replay the viewport at that topology flip too.
 	forceResultViewportRepaintOnSettle: true,

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -985,6 +985,12 @@ function countLines(text: string): number {
 	return text.split("\n").length;
 }
 
+function writeContentOf(args: unknown): string {
+	if (args == null || typeof args !== "object" || !("content" in args)) return "";
+	const content = args.content;
+	return typeof content === "string" ? content : "";
+}
+
 function formatLineCountSuffix(lineCount: number, uiTheme: Theme): string {
 	if (lineCount <= 0) return "";
 	return uiTheme.fg("dim", ` · ${lineCount} line${lineCount === 1 ? "" : "s"}`);
@@ -1209,4 +1215,6 @@ export const writeToolRenderer = {
 		});
 	},
 	mergeCallAndResult: true,
+	forceFirstResultViewportRepaint: (args: unknown, options: RenderResultOptions) =>
+		!options.expanded && countLines(writeContentOf(args)) > WRITE_STREAMING_PREVIEW_LINES,
 };


### PR DESCRIPTION
## Repro
A focused `ToolExecutionComponent` regression renders a collapsed `write` pending preview with 20 lines, delivers the first partial result, and reproduces the bug when no viewport replay sequence is emitted. Command: `bun run gen:tool-views && bun test packages/coding-agent/src/modes/components/tool-execution.test.ts` failed before the fix with `Expected to contain: "\u001B[2J\u001B[H"; Received: ""`.

## Cause
`packages/coding-agent/src/modes/components/tool-execution.ts` only treated first-result viewport repaint as a streamed `__partialJson` placeholder case. That covered SSH, but `packages/coding-agent/src/tools/write.ts` paints a collapsed pending tail from decoded `content`, then the partial-result renderer re-anchors to the top preview, so stale pending rows could survive without the replay.

## Fix
- Resolve first-result viewport repaint through each renderer’s `forceFirstResultViewportRepaint` value or predicate.
- Keep SSH scoped to the streamed-placeholder args shape that actually needs the repaint.
- Opt collapsed long `write` pending previews into the first partial-result viewport replay.
- Add regression tests for write first partial repaint and both SSH placeholder/non-placeholder boundaries.

## Verification
Ran `bun test packages/coding-agent/src/modes/components/tool-execution.test.ts` → 3 pass, 0 fail. Ran `bun run check:types` in `packages/coding-agent` → passed. `gh_push_branch` pre-publish gate passed before pushing. Fixes #4477