### PR TITLE
fix(agent): stop attributing skipped tools to a queued user message

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Skipped-tool results no longer claim a "queued user message" caused the skip. The steering queue also carries agent-authored messages (advisor notes, IRC/extension asides), and the loop only peeks a boolean, so the text now says "queued steering message" — previously the model would relay the misattribution to users who had queued nothing.
+
 ## [16.3.3] - 2026-07-02
 
 ### Changed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -2254,7 +2254,7 @@ function createSkippedToolResult(): AgentToolResult<any> {
 		content: [
 			{
 				type: "text",
-				text: "Skipped due to queued user message. Do not count this skipped result as completed work or verification. After the queued message is handled on the next step, retry the skipped tool if it is still needed.",
+				text: "Skipped due to a queued steering message. Do not count this skipped result as completed work or verification. After the queued message is handled on the next step, retry the skipped tool if it is still needed.",
 			},
 		],
 		details: {},

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1165,7 +1165,7 @@ describe("agentLoop with AgentMessage", () => {
 		const skippedContent = toolEnds[1].result.content[0];
 		expect(skippedContent?.type).toBe("text");
 		if (skippedContent?.type !== "text") throw new Error("skipped tool result must be text");
-		expect(skippedContent.text).toContain("Skipped due to queued user message");
+		expect(skippedContent.text).toContain("Skipped due to a queued steering message");
 		expect(skippedContent.text).toContain("Do not count this skipped result as completed work");
 		expect(skippedContent.text).toContain("retry the skipped tool if it is still needed");
 


### PR DESCRIPTION
## Problem

When pending steering aborts in-flight tools under `interruptMode: immediate`, the synthesized tool result says:

> Skipped due to queued **user** message. ...

The steering queue also carries agent-authored messages — advisor `concern`/`blocker` notes, IRC/extension asides — and `createSkippedToolResult()` has no way to know the source (`executeToolCalls` only peeks `hasSteeringMessages(): boolean`). The model reads the misattributed text and relays it to the user verbatim.

Observed in the wild (omp 16.3.4, advisor enabled): four parallel `write` calls skipped at `06:13:49.677`, the only queued items being two advisor `concern` cards appended at `06:13:49.684`; the user's next real input, 42 seconds later, was *"There's a bug I believe, I did not queue anything when the writes failed."* In another turn the model echoed *"Paused — you have a message queued. ... What's your message?"* to a user who had typed nothing.

## Change

- `packages/agent/src/agent-loop.ts` — skip text now says "queued steering message", claiming nothing about the source. String change only.
- `packages/agent/test/agent-loop.test.ts` — matching expectation update.
- `packages/agent/CHANGELOG.md` — Unreleased entry.

Source-specific attribution ("advisor interrupted the turn" at the stop point in the TUI) is deliberately out of scope: the queued message object with its `attribution` lives in `coding-agent`, not here. Happy to follow up there if there's appetite.
