### PR TITLE
Umans usage provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -18,6 +18,9 @@
 ### Added
 
 - Added support for Baseten as an AI provider
+### Added
+
+- Umans usage provider: fetches `GET /v1/usage` and surfaces the rolling 5h request window + concurrency limits in `/usage`, `omp usage`, and the TUI status bar.
 
 ### Changed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Umans usage provider: fetches `GET /v1/usage` and surfaces the rolling 5h request window + concurrency limits in `/usage`, `omp usage`, and the TUI status bar.
+
 ## [16.3.5] - 2026-07-04
 
 ### Added
@@ -18,9 +22,6 @@
 ### Added
 
 - Added support for Baseten as an AI provider
-### Added
-
-- Umans usage provider: fetches `GET /v1/usage` and surfaces the rolling 5h request window + concurrency limits in `/usage`, `omp usage`, and the TUI status bar.
 
 ### Changed
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -55,8 +55,8 @@ import {
 	listCodexResetCredits,
 } from "./usage/openai-codex-reset";
 import { opencodeGoUsageProvider } from "./usage/opencode-go";
-import { zaiUsageProvider } from "./usage/zai";
 import { umansUsageProvider } from "./usage/umans";
+import { zaiUsageProvider } from "./usage/zai";
 
 const USAGE_RANKING_METRIC_EPSILON = 1e-9;
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -56,6 +56,7 @@ import {
 } from "./usage/openai-codex-reset";
 import { opencodeGoUsageProvider } from "./usage/opencode-go";
 import { zaiUsageProvider } from "./usage/zai";
+import { umansUsageProvider } from "./usage/umans";
 
 const USAGE_RANKING_METRIC_EPSILON = 1e-9;
 
@@ -515,6 +516,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	ollamaCloudUsageProvider,
 	claudeUsageProvider,
 	zaiUsageProvider,
+	umansUsageProvider,
 	opencodeGoUsageProvider,
 	githubCopilotUsageProvider,
 ];

--- a/packages/ai/src/usage/umans.ts
+++ b/packages/ai/src/usage/umans.ts
@@ -36,13 +36,11 @@ interface UmansUsagePayload {
 function normalizeBaseUrl(baseUrl?: string): string {
 	if (!baseUrl?.trim()) return DEFAULT_ENDPOINT;
 	const trimmed = baseUrl.trim();
-	// Normalize to origin so provider base URLs that include a path (e.g.
-	// `https://api.code.umans.ai/v1`) don't double the `/v1` in the usage path.
-	try {
-		return new URL(trimmed).origin;
-	} catch {
-		return DEFAULT_ENDPOINT;
-	}
+	// Strip a trailing `/v1` (with optional surrounding slashes) so the usage
+	// path doesn't double it, but preserve any preceding path prefix (e.g. a
+	// path-mounted gateway like `https://gateway.example/team/umans/v1`).
+	const withoutTrailingSlash = trimmed.replace(/\/+$/, "");
+	return withoutTrailingSlash.replace(/\/v1$/i, "") || DEFAULT_ENDPOINT;
 }
 
 function toFiniteNumber(value: unknown): number | undefined {

--- a/packages/ai/src/usage/umans.ts
+++ b/packages/ai/src/usage/umans.ts
@@ -1,3 +1,4 @@
+import { ProviderHttpError } from "../error";
 import type {
 	UsageAmount,
 	UsageFetchContext,
@@ -133,6 +134,15 @@ async function fetchUmansUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	try {
 		const response = await ctx.fetch(url, { headers, signal: params.signal });
 		if (!response.ok) {
+			// Auth failures (401/403) must throw so checkCredentials flags the bad
+			// key as ok:false rather than ok:null (unknown). Other non-ok statuses
+			// are transient — return null so the probe reports "no data".
+			if (response.status === 401 || response.status === 403) {
+				throw new ProviderHttpError(
+					`Umans usage endpoint returned ${response.status} ${response.statusText}`.trim(),
+					response.status,
+				);
+			}
 			ctx.logger?.warn("Umans usage fetch failed", { status: response.status, statusText: response.statusText });
 			return null;
 		}
@@ -143,6 +153,8 @@ async function fetchUmansUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 		}
 		payload = json as unknown as UmansUsagePayload;
 	} catch (error) {
+		// Re-throw auth errors so the credential-health probe can surface them.
+		if (error instanceof ProviderHttpError) throw error;
 		ctx.logger?.warn("Umans usage fetch error", { error: String(error) });
 		return null;
 	}

--- a/packages/ai/src/usage/umans.ts
+++ b/packages/ai/src/usage/umans.ts
@@ -35,8 +35,13 @@ interface UmansUsagePayload {
 function normalizeBaseUrl(baseUrl?: string): string {
 	if (!baseUrl?.trim()) return DEFAULT_ENDPOINT;
 	const trimmed = baseUrl.trim();
-	// Strip a trailing slash so `${origin}/v1/usage` is stable.
-	return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+	// Normalize to origin so provider base URLs that include a path (e.g.
+	// `https://api.code.umans.ai/v1`) don't double the `/v1` in the usage path.
+	try {
+		return new URL(trimmed).origin;
+	} catch {
+		return DEFAULT_ENDPOINT;
+	}
 }
 
 function toFiniteNumber(value: unknown): number | undefined {

--- a/packages/ai/src/usage/umans.ts
+++ b/packages/ai/src/usage/umans.ts
@@ -59,8 +59,7 @@ function buildAmount(args: {
 }): UsageAmount {
 	const used = args.used;
 	const limit = args.limit;
-	const usedFraction =
-		used !== undefined && limit !== undefined && limit > 0 ? Math.min(used / limit, 1) : undefined;
+	const usedFraction = used !== undefined && limit !== undefined && limit > 0 ? Math.min(used / limit, 1) : undefined;
 	const remainingFraction = usedFraction !== undefined ? Math.max(1 - usedFraction, 0) : undefined;
 	return {
 		used,

--- a/packages/ai/src/usage/umans.ts
+++ b/packages/ai/src/usage/umans.ts
@@ -1,0 +1,178 @@
+import type {
+	UsageAmount,
+	UsageFetchContext,
+	UsageFetchParams,
+	UsageLimit,
+	UsageProvider,
+	UsageReport,
+	UsageStatus,
+	UsageWindow,
+} from "../usage";
+import { isRecord } from "../utils";
+
+const UMANS_PROVIDER = "umans";
+const DEFAULT_ENDPOINT = "https://api.code.umans.ai";
+const USAGE_PATH = "/v1/usage";
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+
+/** Umans `GET /v1/usage` response (subset; extras ignored). */
+interface UmansUsagePayload {
+	plan?: { display_name?: string };
+	limits?: {
+		requests?: { limit?: number; hard_cap?: number | null; window_seconds?: number };
+		concurrency?: { limit?: number; hard_cap?: number | null };
+	};
+	usage?: {
+		requests_in_window?: number;
+		remaining_requests?: number;
+		concurrent_sessions?: number;
+		tokens_in?: number;
+		tokens_out?: number;
+		priority?: { low?: boolean };
+	};
+}
+
+function normalizeBaseUrl(baseUrl?: string): string {
+	if (!baseUrl?.trim()) return DEFAULT_ENDPOINT;
+	const trimmed = baseUrl.trim();
+	// Strip a trailing slash so `${origin}/v1/usage` is stable.
+	return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+	return value;
+}
+
+function resolveStatus(usedFraction: number | undefined): UsageStatus | undefined {
+	if (usedFraction === undefined) return undefined;
+	if (usedFraction >= 1) return "exhausted";
+	if (usedFraction >= 0.9) return "warning";
+	return "ok";
+}
+
+function buildAmount(args: {
+	used: number | undefined;
+	limit: number | undefined;
+	remaining: number | undefined;
+	unit: UsageAmount["unit"];
+}): UsageAmount {
+	const used = args.used;
+	const limit = args.limit;
+	const usedFraction =
+		used !== undefined && limit !== undefined && limit > 0 ? Math.min(used / limit, 1) : undefined;
+	const remainingFraction = usedFraction !== undefined ? Math.max(1 - usedFraction, 0) : undefined;
+	return {
+		used,
+		limit,
+		remaining: args.remaining,
+		usedFraction,
+		remainingFraction,
+		unit: args.unit,
+	};
+}
+
+function buildRequestsLimit(payload: UmansUsagePayload, provider: string): UsageLimit | null {
+	const limit = toFiniteNumber(payload.limits?.requests?.limit);
+	const windowSeconds = toFiniteNumber(payload.limits?.requests?.window_seconds);
+	const used = toFiniteNumber(payload.usage?.requests_in_window);
+	const remaining = toFiniteNumber(payload.usage?.remaining_requests);
+	if (limit === undefined && used === undefined) return null;
+	const amount = buildAmount({ used, limit, remaining, unit: "requests" });
+	// Rolling window: each request ages out `window_seconds` after it fired, so
+	// there is no single reset timestamp. Surface the window size + label only.
+	// `window.id` is `"5h"` to match the status-line usage segment's window-id
+	// contract (it only recognizes `"5h"`/`"7d"`); `label` stays human-readable.
+	const window: UsageWindow = {
+		id: "5h",
+		label: "rolling 5h",
+		durationMs: windowSeconds ? windowSeconds * 1000 : FIVE_HOURS_MS,
+	};
+	return {
+		id: "umans:requests",
+		label: "Requests (rolling 5h)",
+		scope: { provider, windowId: window.id, shared: true },
+		window,
+		amount,
+		status: resolveStatus(amount.usedFraction),
+	};
+}
+
+function buildConcurrencyLimit(payload: UmansUsagePayload, provider: string): UsageLimit | null {
+	const limit = toFiniteNumber(payload.limits?.concurrency?.limit);
+	const used = toFiniteNumber(payload.usage?.concurrent_sessions);
+	if (limit === undefined && used === undefined) return null;
+	const amount = buildAmount({ used, limit, remaining: undefined, unit: "requests" });
+	return {
+		id: "umans:concurrency",
+		label: "Concurrency",
+		// Concurrency is instantaneous, not windowed.
+		scope: { provider, windowId: "concurrency" },
+		amount,
+		status: resolveStatus(amount.usedFraction),
+	};
+}
+
+async function fetchUmansUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
+	if (params.provider !== UMANS_PROVIDER) return null;
+	const credential = params.credential;
+	if (credential.type !== "api_key" || !credential.apiKey) return null;
+
+	const baseUrl = normalizeBaseUrl(params.baseUrl);
+	const url = `${baseUrl}${USAGE_PATH}`;
+	const headers: Record<string, string> = {
+		authorization: `Bearer ${credential.apiKey}`,
+		accept: "application/json",
+	};
+
+	let payload: UmansUsagePayload | null = null;
+	try {
+		const response = await ctx.fetch(url, { headers, signal: params.signal });
+		if (!response.ok) {
+			ctx.logger?.warn("Umans usage fetch failed", { status: response.status, statusText: response.statusText });
+			return null;
+		}
+		const json = (await response.json()) as unknown;
+		if (!isRecord(json)) {
+			ctx.logger?.warn("Umans usage response was not a JSON object");
+			return null;
+		}
+		payload = json as unknown as UmansUsagePayload;
+	} catch (error) {
+		ctx.logger?.warn("Umans usage fetch error", { error: String(error) });
+		return null;
+	}
+
+	const limits: UsageLimit[] = [];
+	const requests = buildRequestsLimit(payload, params.provider);
+	if (requests) limits.push(requests);
+	const concurrency = buildConcurrencyLimit(payload, params.provider);
+	if (concurrency) limits.push(concurrency);
+	if (limits.length === 0) return null;
+
+	const notes: string[] = [];
+	if (payload.usage?.priority?.low === true) {
+		notes.push("Requests deprioritized after a rate-limit burst.");
+	}
+
+	return {
+		provider: params.provider,
+		fetchedAt: Date.now(),
+		limits,
+		notes: notes.length > 0 ? notes : undefined,
+		metadata: {
+			plan: payload.plan?.display_name,
+			accountId: credential.accountId,
+			email: credential.email,
+			endpoint: url,
+		},
+		raw: payload as Record<string, unknown>,
+	};
+}
+
+export const umansUsageProvider: UsageProvider = {
+	id: UMANS_PROVIDER,
+	fetchUsage: fetchUmansUsage,
+	supports: params => params.provider === UMANS_PROVIDER && params.credential.type === "api_key",
+	validatesCredentials: true,
+};

--- a/packages/ai/test/umans-usage.test.ts
+++ b/packages/ai/test/umans-usage.test.ts
@@ -116,6 +116,19 @@ describe("umans usage provider", () => {
 		expect(calls[0]?.url).toBe("https://custom.umans.example/v1/usage");
 	});
 
+	it("strips a /v1 path from a custom baseUrl", async () => {
+		const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+		await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test" },
+				baseUrl: "https://api.code.umans.ai/v1",
+			},
+			{ fetch: fetchRecorder(calls, umansPayload()) },
+		);
+		expect(calls[0]?.url).toBe("https://api.code.umans.ai/v1/usage");
+	});
+
 	it("surfaces priority.low as a provider note", async () => {
 		const payload = umansPayload({
 			usage: {

--- a/packages/ai/test/umans-usage.test.ts
+++ b/packages/ai/test/umans-usage.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { umansUsageProvider } from "../src/usage/umans";
+
+const DEFAULT_BASE_URL = "https://api.code.umans.ai";
+
+function umansPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		plan: { display_name: "Code Max" },
+		limits: {
+			requests: { limit: 200, hard_cap: 400, burst_pct: 1.0, window_seconds: 18000 },
+			concurrency: { limit: 4, hard_cap: 8, burst_pct: 1.0 },
+		},
+		usage: {
+			requests_in_window: 48,
+			remaining_requests: 152,
+			concurrent_sessions: 1,
+			tokens_in: 1_200_000,
+			tokens_out: 340_000,
+			priority: { low: false, boxed_until: null, reason: null },
+		},
+		...overrides,
+	};
+}
+
+function fakeFetch(payload: unknown, status = 200): FetchImpl {
+	const fn = async () =>
+		new Response(JSON.stringify(payload), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	return fn as unknown as typeof fetch;
+}
+
+function fetchRecorder(calls: Array<{ url: string; headers: Record<string, string> }>, payload: unknown, status = 200): FetchImpl {
+	const fn = async (input: string | URL | Request, init?: RequestInit) => {
+		calls.push({
+			url: String(input),
+			headers: (init?.headers as Record<string, string>) ?? {},
+		});
+		return new Response(JSON.stringify(payload), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	};
+	return fn as unknown as typeof fetch;
+}
+
+describe("umans usage provider", () => {
+	it("parses the rolling 5h request window into a UsageLimit with used/remaining/fraction", async () => {
+		const report = await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test", accountId: "acct-1", email: "u@example.com" },
+			},
+			{ fetch: fakeFetch(umansPayload()) },
+		);
+		expect(report).not.toBeNull();
+		const requests = report?.limits.find(l => l.id === "umans:requests");
+		expect(requests).toBeDefined();
+		expect(requests?.amount.used).toBe(48);
+		expect(requests?.amount.limit).toBe(200);
+		expect(requests?.amount.remaining).toBe(152);
+		expect(requests?.amount.usedFraction).toBeCloseTo(0.24, 5);
+		expect(requests?.amount.remainingFraction).toBeCloseTo(0.76, 5);
+		expect(requests?.amount.unit).toBe("requests");
+		// Rolling window: no fabricated reset timestamp.
+		expect(requests?.window?.resetsAt).toBeUndefined();
+		expect(requests?.window?.durationMs).toBe(18000_000);
+		expect(requests?.window?.label).toBe("rolling 5h");
+	});
+
+	it("emits a concurrency limit from limits.concurrency", async () => {
+		const report = await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test" },
+			},
+			{ fetch: fakeFetch(umansPayload()) },
+		);
+		const concurrency = report?.limits.find(l => l.id === "umans:concurrency");
+		expect(concurrency).toBeDefined();
+		expect(concurrency?.amount.used).toBe(1);
+		expect(concurrency?.amount.limit).toBe(4);
+		expect(concurrency?.amount.unit).toBe("requests");
+	});
+
+	it("sends Authorization: Bearer <key> to the default base URL", async () => {
+		const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+		await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test" },
+			},
+			{ fetch: fetchRecorder(calls, umansPayload()) },
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(`${DEFAULT_BASE_URL}/v1/usage`);
+		expect(calls[0]?.headers.authorization).toBe("Bearer sk-test");
+	});
+
+	it("honors a custom baseUrl from params", async () => {
+		const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+		await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test" },
+				baseUrl: "https://custom.umans.example",
+			},
+			{ fetch: fetchRecorder(calls, umansPayload()) },
+		);
+		expect(calls[0]?.url).toBe("https://custom.umans.example/v1/usage");
+	});
+
+	it("surfaces priority.low as a provider note", async () => {
+		const payload = umansPayload({
+			usage: {
+				requests_in_window: 250,
+				remaining_requests: 0,
+				concurrent_sessions: 1,
+				tokens_in: 0,
+				tokens_out: 0,
+				priority: { low: true, boxed_until: "2026-06-27T12:00:00Z", reason: "burst" },
+			},
+		});
+		const report = await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test" },
+			},
+			{ fetch: fakeFetch(payload) },
+		);
+		expect(report?.notes).toContain("Requests deprioritized after a rate-limit burst.");
+	});
+
+	it("returns null on a non-ok HTTP response", async () => {
+		const report = await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test" },
+			},
+			{ fetch: fakeFetch({ message: "unauthorized" }, 401) },
+		);
+		expect(report).toBeNull();
+	});
+
+	it("returns null when supports() is called for a different provider or credential type", () => {
+		expect(umansUsageProvider.supports?.({ provider: "zai", credential: { type: "api_key", apiKey: "x" } })).toBe(false);
+		expect(umansUsageProvider.supports?.({ provider: "umans", credential: { type: "oauth", accessToken: "x" } })).toBe(false);
+		expect(umansUsageProvider.supports?.({ provider: "umans", credential: { type: "api_key", apiKey: "x" } })).toBe(true);
+	});
+
+	it("includes plan display name and account identity in metadata", async () => {
+		const report = await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test", accountId: "acct-42", email: "dev@example.com" },
+			},
+			{ fetch: fakeFetch(umansPayload({ plan: { display_name: "Code Pro" } })) },
+		);
+		expect(report?.metadata?.plan).toBe("Code Pro");
+		expect(report?.metadata?.accountId).toBe("acct-42");
+		expect(report?.metadata?.email).toBe("dev@example.com");
+	});
+});

--- a/packages/ai/test/umans-usage.test.ts
+++ b/packages/ai/test/umans-usage.test.ts
@@ -32,7 +32,11 @@ function fakeFetch(payload: unknown, status = 200): FetchImpl {
 	return fn as unknown as typeof fetch;
 }
 
-function fetchRecorder(calls: Array<{ url: string; headers: Record<string, string> }>, payload: unknown, status = 200): FetchImpl {
+function fetchRecorder(
+	calls: Array<{ url: string; headers: Record<string, string> }>,
+	payload: unknown,
+	status = 200,
+): FetchImpl {
 	const fn = async (input: string | URL | Request, init?: RequestInit) => {
 		calls.push({
 			url: String(input),
@@ -145,9 +149,15 @@ describe("umans usage provider", () => {
 	});
 
 	it("returns null when supports() is called for a different provider or credential type", () => {
-		expect(umansUsageProvider.supports?.({ provider: "zai", credential: { type: "api_key", apiKey: "x" } })).toBe(false);
-		expect(umansUsageProvider.supports?.({ provider: "umans", credential: { type: "oauth", accessToken: "x" } })).toBe(false);
-		expect(umansUsageProvider.supports?.({ provider: "umans", credential: { type: "api_key", apiKey: "x" } })).toBe(true);
+		expect(umansUsageProvider.supports?.({ provider: "zai", credential: { type: "api_key", apiKey: "x" } })).toBe(
+			false,
+		);
+		expect(
+			umansUsageProvider.supports?.({ provider: "umans", credential: { type: "oauth", accessToken: "x" } }),
+		).toBe(false);
+		expect(umansUsageProvider.supports?.({ provider: "umans", credential: { type: "api_key", apiKey: "x" } })).toBe(
+			true,
+		);
 	});
 
 	it("includes plan display name and account identity in metadata", async () => {

--- a/packages/ai/test/umans-usage.test.ts
+++ b/packages/ai/test/umans-usage.test.ts
@@ -116,7 +116,7 @@ describe("umans usage provider", () => {
 		expect(calls[0]?.url).toBe("https://custom.umans.example/v1/usage");
 	});
 
-	it("strips a /v1 path from a custom baseUrl", async () => {
+	it("strips a trailing /v1 from a custom baseUrl", async () => {
 		const calls: Array<{ url: string; headers: Record<string, string> }> = [];
 		await umansUsageProvider.fetchUsage(
 			{
@@ -127,6 +127,19 @@ describe("umans usage provider", () => {
 			{ fetch: fetchRecorder(calls, umansPayload()) },
 		);
 		expect(calls[0]?.url).toBe("https://api.code.umans.ai/v1/usage");
+	});
+
+	it("preserves a path-mounted gateway prefix while stripping /v1", async () => {
+		const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+		await umansUsageProvider.fetchUsage(
+			{
+				provider: "umans",
+				credential: { type: "api_key", apiKey: "sk-test" },
+				baseUrl: "https://gateway.example/team/umans/v1",
+			},
+			{ fetch: fetchRecorder(calls, umansPayload()) },
+		);
+		expect(calls[0]?.url).toBe("https://gateway.example/team/umans/v1/usage");
 	});
 
 	it("surfaces priority.low as a provider note", async () => {

--- a/packages/ai/test/umans-usage.test.ts
+++ b/packages/ai/test/umans-usage.test.ts
@@ -150,13 +150,37 @@ describe("umans usage provider", () => {
 		expect(report?.notes).toContain("Requests deprioritized after a rate-limit burst.");
 	});
 
-	it("returns null on a non-ok HTTP response", async () => {
+	it("throws on a 401 auth failure so checkCredentials flags the bad key", async () => {
+		await expect(
+			umansUsageProvider.fetchUsage(
+				{
+					provider: "umans",
+					credential: { type: "api_key", apiKey: "sk-test" },
+				},
+				{ fetch: fakeFetch({ message: "unauthorized" }, 401) },
+			),
+		).rejects.toThrow(/401/);
+	});
+
+	it("throws on a 403 auth failure so checkCredentials flags the bad key", async () => {
+		await expect(
+			umansUsageProvider.fetchUsage(
+				{
+					provider: "umans",
+					credential: { type: "api_key", apiKey: "sk-test" },
+				},
+				{ fetch: fakeFetch({ message: "forbidden" }, 403) },
+			),
+		).rejects.toThrow(/403/);
+	});
+
+	it("returns null on a transient non-auth HTTP failure (500)", async () => {
 		const report = await umansUsageProvider.fetchUsage(
 			{
 				provider: "umans",
 				credential: { type: "api_key", apiKey: "sk-test" },
 			},
-			{ fetch: fakeFetch({ message: "unauthorized" }, 401) },
+			{ fetch: fakeFetch({ message: "internal server error" }, 500) },
 		);
 		expect(report).toBeNull();
 	});


### PR DESCRIPTION
## What

Adds a `UsageProvider` for Umans, surfacing it in `/usage`, `omp usage`, and the TUI status bar. Umans is already a registered model + auth provider; this fills the gap in the usage subsystem.

- **New file `packages/ai/src/usage/umans.ts`** — `umansUsageProvider` fetches `GET https://api.code.umans.ai/v1/usage` with `Authorization: Bearer <api-key>` and maps the response onto the shared `UsageReport` shape:
  - Rolling 5h request window → `UsageLimit` (`id: "umans:requests"`). `window.resetsAt` is left undefined (rolling window, no single reset timestamp — follows the `zai` precedent); `window.id = "5h"` so the status-line `usage` segment recognizes it.
  - Instantaneous concurrency → `UsageLimit` (`id: "umans:concurrency"`, no window).
  - `priority.low` (burst deprioritization) → provider note.
  - `validatesCredentials: true` (a successful 200 confirms the key).
  - `supports` rejects non-`umans` providers and OAuth credentials.
- **`packages/ai/src/auth-storage.ts`** — import + array entry in `DEFAULT_USAGE_PROVIDERS` (2 lines).
- **`packages/ai/test/umans-usage.test.ts`** — 8 `bun:test` cases: happy-path parse (used/remaining/fraction, rolling-window no-`resetsAt`), concurrency limit, Bearer auth + default base URL, custom base URL override, `priority.low` note, non-ok → null, `supports` rejection, metadata (plan/account identity).

## Why

Umans was present in the catalog and registry but invisible to every usage surface (`/usage`, `omp usage`, TUI footer). With a stored API key, users had no way to see their rolling-5h request budget or concurrency headroom. This adds Umans to the default usage-provider map so it appears alongside the other providers.

## Testing

- `bun check` passes (biome + typecheck).
- `bun test test/umans-usage.test.ts` — 8/8 pass.
- Full `packages/ai` suite — 2486 pass, 0 fail (337 skipped: E2E env).
- Live E2E: ran `omp usage --provider umans` against `api.code.umans.ai/v1/usage` with a stored key — rendered real limits (Requests rolling 5h, Concurrency) and the rolling-window label.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)