### PR TITLE
fix(tui): preserve WezTerm scrollback

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved WezTerm's pre-existing terminal scrollback by suppressing ED3 clears during startup, resize, and session replacement ([#4485](https://github.com/can1357/oh-my-pi/issues/4485)).
+
 ## [16.3.5] - 2026-07-04
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -6,9 +6,10 @@
  * history exactly once, in order, when the component-reported commit boundary
  * (`NativeScrollbackLiveRegion`) says they are final. ED3 (`CSI 3 J`) is
  * emitted only for gesture-driven replays (session replace, resize,
- * resetDisplay) where snapping the viewport is acceptable. The engine never
- * probes or guesses the terminal's scroll position, and the hot path clamps
- * over-wide lines instead of throwing. See `docs/tui-core-renderer.md`.
+ * resetDisplay) on terminals where native scrollback is safe to erase. The
+ * engine never probes or guesses the terminal's scroll position, and the hot
+ * path clamps over-wide lines instead of throwing. See
+ * `docs/tui-core-renderer.md`.
  */
 import * as fs from "node:fs";
 import { performance } from "node:perf_hooks";
@@ -391,6 +392,15 @@ function isMultiplexerSession(): boolean {
 	return isInsideTerminalMultiplexer();
 }
 
+/** Detect direct terminals whose normal-buffer scrollback belongs to the user. */
+function preservesUserScrollbackSession(): boolean {
+	return Bun.env.WEZTERM_PANE !== undefined;
+}
+
+function canEraseNativeScrollback(): boolean {
+	return !isMultiplexerSession() && !preservesUserScrollbackSession();
+}
+
 /**
  * Terminals that re-report their size whenever the alternate screen buffer is
  * toggled. The non-multiplexer resize fast path ({@link TUI.#beginResizeViewport})
@@ -412,12 +422,13 @@ function reportsSizeOnAltScreenToggle(): boolean {
 
 /**
  * Resize should repaint the visible window in place — no alternate-screen
- * borrow, no ED3 scrollback rewrap — for multiplexer panes and for terminals
- * that loop on alt-screen toggles. The tradeoff is identical to a multiplexer:
- * scrollback above the window keeps its old wrap instead of being re-flowed.
+ * borrow, no ED3 scrollback rewrap — for multiplexer panes, terminals with
+ * user-owned scrollback, and terminals that loop on alt-screen toggles. The
+ * tradeoff is identical to a multiplexer: scrollback above the window keeps
+ * its old wrap instead of being re-flowed.
  */
 function resizeRepaintsInPlace(): boolean {
-	return isMultiplexerSession() || reportsSizeOnAltScreenToggle();
+	return isMultiplexerSession() || preservesUserScrollbackSession() || reportsSizeOnAltScreenToggle();
 }
 
 /**
@@ -584,10 +595,9 @@ export class Container implements Component {
  * method owns the bytes written and the state update.
  *
  * - `fullPaint`: gesture-driven replay — initial paint, session replacement,
- *   resize, resetDisplay. Clears the viewport and (for destructive replaces,
- *   outside multiplexers) native scrollback via ED3, then writes the
- *   committed prefix and the visible window. The only ED3 callsite in the
- *   engine.
+ *   resize, resetDisplay. Clears the viewport and, where native scrollback is
+ *   safe to erase, sends ED3 before writing the committed prefix and visible
+ *   window. The only ED3 callsite in the engine.
  * - `update`: ordinary frame. Commits the newly settled chunk at the
  *   scrollback seam (if any) and repaints the window with relative moves.
  */
@@ -1827,16 +1837,16 @@ export class TUI extends Container {
 	resetDisplay(): void {
 		if (this.#stopped) return;
 		this.invalidate();
-		// A reset that lands inside a tmux/screen/zellij resize burst would
-		// paint mid-reflow and re-introduce the flash race (issue #2088).
-		// Fold it into the in-flight debounce instead; the settled paint runs
-		// the same `#prepareForcedRender(!isMultiplexerSession())` path via
-		// `requestRender(true)`, so the clear-scrollback intent is preserved.
+		// A reset that lands inside an in-place resize burst would paint
+		// mid-reflow and re-introduce the flash race (issue #2088). Fold it
+		// into the in-flight debounce instead; the settled paint runs the same
+		// `requestRender(true)` path while preserving whether this terminal may
+		// erase native scrollback.
 		if (this.#multiplexerResizeTimer) {
-			this.#armMultiplexerResizeTimer(!isMultiplexerSession());
+			this.#armMultiplexerResizeTimer(canEraseNativeScrollback());
 			return;
 		}
-		this.#prepareForcedRender(!isMultiplexerSession());
+		this.#prepareForcedRender(canEraseNativeScrollback());
 		this.#resizeEventPending = true;
 		this.#renderRequested = false;
 		this.#executeRender();
@@ -2839,7 +2849,10 @@ export class TUI extends Container {
 		const cursorTrackingLineCount = hasVisibleOverlay ? Math.max(frame.length, windowTop + height) : frame.length;
 
 		const intent: RenderIntent = fullPaint
-			? { kind: "fullPaint", clearScrollback: replaceRequested || geometryRebuild ? !isMultiplexerSession() : false }
+			? {
+					kind: "fullPaint",
+					clearScrollback: replaceRequested || geometryRebuild ? canEraseNativeScrollback() : false,
+				}
 			: { kind: "update", chunkTo, windowTop };
 		this.#logRedraw(intent, frameLength, height);
 
@@ -3421,10 +3434,9 @@ export class TUI extends Container {
 			// The drag is quiet: replay the rewrapped transcript authoritatively.
 			// #resizeEventPending was preserved across every viewport-only frame
 			// (the fast path never consumes it), so this classifies as a geometry
-			// rebuild — ED3 + full history — and the clearScrollback intent below
-			// matches the gesture-driven reset path.
+			// rebuild. Only terminals that may erase native scrollback receive ED3.
 			this.#resizeEventPending = true;
-			this.requestRender(true, { clearScrollback: !isMultiplexerSession() });
+			this.requestRender(true, { clearScrollback: canEraseNativeScrollback() });
 		}, TUI.#RESIZE_VIEWPORT_SETTLE_MS);
 	}
 

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -363,6 +363,75 @@ describe("TUI overlays", () => {
 		}
 	});
 
+	it("preserves WezTerm scrollback when clearScrollback is requested", async () => {
+		await withEnv("WEZTERM_PANE", "123", async () => {
+			const term = new VirtualTerminal(40, 4);
+			term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");
+			await flushRender(term);
+			const writes: string[] = [];
+			const realWrite = term.write.bind(term);
+			(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+				writes.push(data);
+				realWrite(data);
+			};
+
+			const tui = new TUI(term);
+			const component = new MutableContentComponent(buildRows(8));
+			tui.addChild(component);
+			try {
+				tui.start({ clearScrollback: true });
+				await flushRender(term);
+
+				expect(writes.join("")).not.toContain("\x1b[3J");
+				expect(term.getScrollBuffer().join("\n").includes("shell-")).toBeTruthy();
+				expect(term.getViewport().join("\n").includes("row-7")).toBeTruthy();
+
+				writes.length = 0;
+				component.setLines(["new-session-0", "new-session-1", "new-session-2", "new-session-3"]);
+				tui.requestRender(true, { clearScrollback: true });
+				await flushRender(term);
+
+				expect(writes.join("")).not.toContain("\x1b[3J");
+				expect(term.getScrollBuffer().join("\n").includes("shell-")).toBeTruthy();
+				expect(term.getViewport().join("\n").includes("new-session-3")).toBeTruthy();
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("preserves WezTerm scrollback on resize", async () => {
+		await withEnv("WEZTERM_PANE", "123", async () => {
+			const term = new VirtualTerminal(40, 4);
+			term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");
+			await flushRender(term);
+
+			const tui = new TUI(term);
+			tui.addChild(new MutableContentComponent(buildRows(20)));
+			const writes: string[] = [];
+			const realWrite = term.write.bind(term);
+			(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+				writes.push(data);
+				realWrite(data);
+			};
+
+			try {
+				tui.start();
+				await flushRender(term);
+				writes.length = 0;
+
+				term.resize(80, 4);
+				await settleResize(term);
+
+				expect(writes.join("")).not.toContain("\x1b[3J");
+				expect(term.getScrollBuffer().join("\n").includes("shell-")).toBeTruthy();
+				expect(term.getViewport().join("\n").includes("row-19")).toBeTruthy();
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
 	it("preserves rendered scrollback on forced redraw after startup", async () => {
 		const term = new VirtualTerminal(40, 4);
 		const tui = new TUI(term);


### PR DESCRIPTION
## Repro
On a WezTerm-marked session, `WEZTERM_PANE=123 bun test packages/tui/test/overlay-scroll.test.ts -t "can clear saved native scrollback on the first paint"` reproduced the destructive startup path: the focused regression observed `CSI 3 J` and verified pre-existing `shell-*` scrollback was removed.

## Cause
`packages/tui/src/tui.ts` only treated terminal multiplexers as unsafe for ED3: `resizeRepaintsInPlace()` excluded direct terminals, and full-paint clear intents used `!isMultiplexerSession()`. WezTerm is detected by `WEZTERM_PANE`, but that marker was not considered before emitting the sole ED3 sequence in `TUI.#emitFullPaint`.

## Fix
- Added a WezTerm user-scrollback guard in `packages/tui/src/tui.ts` and routed ED3 decisions through `canEraseNativeScrollback()`.
- Routed WezTerm resize through the existing in-place resize path so user-owned scrollback keeps its old wrapping instead of being erased and replayed.
- Added coverage for WezTerm startup, session replacement, and resize scrollback preservation in `packages/tui/test/overlay-scroll.test.ts`.
- Added the TUI changelog entry for #4485.

## Verification
`bun test packages/tui/test/overlay-scroll.test.ts packages/tui/test/issue-2088-repro.test.ts` passed: 38 tests, 193 assertions. `bun --cwd=packages/tui run check` passed. Pre-publish `gh_push_branch` gate passed. Fixes #4485