### PR TITLE
fix(ai): sanitize Ollama tool schemas

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ollama/Ollama Cloud tool requests failing with HTTP 400 by normalizing boolean subschemas, boolean `additionalProperties`/`unevaluatedProperties`, and nullable `type` arrays before serializing tool parameters. ([#4488](https://github.com/can1357/oh-my-pi/issues/4488))
+
 ## [16.3.5] - 2026-07-04
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Ollama/Ollama Cloud tool requests failing with HTTP 400 by normalizing boolean subschemas, boolean `additionalProperties`/`unevaluatedProperties`, and nullable `type` arrays before serializing tool parameters. ([#4488](https://github.com/can1357/oh-my-pi/issues/4488))
+- Fixed Ollama/Ollama Cloud tool requests failing with HTTP 400 by rewriting boolean subschemas (`true`/`false`) into a value-widening `anyOf` union of primitive types, stripping boolean `additionalProperties`/`unevaluatedProperties`, and flattening nullable `type` arrays before serializing tool parameters, so unconstrained fields still advertise "any JSON value" to grammar-constrained samplers (llama.cpp) instead of collapsing to an empty object. ([#4488](https://github.com/can1357/oh-my-pi/issues/4488))
 
 ## [16.3.5] - 2026-07-04
 

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -23,7 +23,7 @@ import {
 	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
 } from "../utils/idle-iterator";
-import { toolWireSchema } from "../utils/schema/wire";
+import { sanitizeSchemaForOllama, toolWireSchema } from "../utils/schema";
 import {
 	getStreamMarkupHealingPattern,
 	type HealedToolCall,
@@ -280,7 +280,7 @@ function convertTools(tools: Tool[] | undefined): OllamaFunctionTool[] | undefin
 		function: {
 			name: tool.name,
 			description: tool.description,
-			parameters: toolWireSchema(tool),
+			parameters: sanitizeSchemaForOllama(toolWireSchema(tool)),
 		},
 	}));
 }

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1015,6 +1015,111 @@ export function normalizeSchemaForMoonshot(value: unknown): unknown {
 }
 
 // ---------------------------------------------------------------------------
+// Ollama — Go schema parser compatibility
+// ---------------------------------------------------------------------------
+
+const OLLAMA_SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
+const OLLAMA_SCHEMA_MAP_KEYS = new Set([
+	"properties",
+	"patternProperties",
+	"dependencies",
+	"dependentSchemas",
+	"$defs",
+	"definitions",
+]);
+const OLLAMA_SCHEMA_VALUE_KEYS = new Set([
+	"items",
+	"additionalItems",
+	"contains",
+	"contentSchema",
+	"propertyNames",
+	"if",
+	"then",
+	"else",
+	"not",
+	"additionalProperties",
+	"unevaluatedItems",
+	"unevaluatedProperties",
+]);
+
+/**
+ * Rewrites standard JSON Schema forms that Ollama's Go `/api/chat` tool parser
+ * cannot unmarshal into its object-shaped `Schema` struct.
+ */
+export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
+	const cache = new WeakMap<JsonObject, unknown>();
+	const normalizeNode = (value: unknown): unknown => {
+		if (typeof value === "boolean") {
+			return value ? {} : { type: "object", properties: {} };
+		}
+		if (!isJsonObject(value)) {
+			if (!Array.isArray(value)) return value;
+			let changed = false;
+			const output = value.map(item => {
+				const next = normalizeNode(item);
+				if (next !== item) changed = true;
+				return next;
+			});
+			return changed ? output : value;
+		}
+
+		const cached = cache.get(value);
+		if (cached) return cached;
+
+		const output: JsonObject = {};
+		cache.set(value, output);
+
+		let changed = false;
+		for (const key in value) {
+			if (!Object.hasOwn(value, key)) continue;
+			const child = value[key];
+			if ((key === "additionalProperties" || key === "unevaluatedProperties") && typeof child === "boolean") {
+				changed = true;
+				continue;
+			}
+			if (key === "type" && Array.isArray(child)) {
+				const variants = child.filter((entry): entry is string => typeof entry === "string");
+				const nonNull = variants.filter(entry => entry !== "null");
+				output.type = nonNull[0] ?? variants[0] ?? child[0];
+				changed = true;
+				continue;
+			}
+
+			let next = child;
+			if (OLLAMA_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
+				let mapChanged = false;
+				const mapOutput: JsonObject = {};
+				for (const childKey in child) {
+					if (!Object.hasOwn(child, childKey)) continue;
+					const mapChild = child[childKey];
+					const normalizedChild = normalizeNode(mapChild);
+					if (normalizedChild !== mapChild) mapChanged = true;
+					mapOutput[childKey] = normalizedChild;
+				}
+				next = mapChanged ? mapOutput : child;
+			} else if (OLLAMA_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+				let arrayChanged = false;
+				const arrayOutput = child.map(item => {
+					const normalizedItem = normalizeNode(item);
+					if (normalizedItem !== item) arrayChanged = true;
+					return normalizedItem;
+				});
+				next = arrayChanged ? arrayOutput : child;
+			} else if (OLLAMA_SCHEMA_VALUE_KEYS.has(key)) {
+				next = normalizeNode(child);
+			}
+			if (next !== child) changed = true;
+			output[key] = next;
+		}
+
+		const result = changed ? output : value;
+		cache.set(value, result);
+		return result;
+	};
+	return normalizeNode(schema) as JsonObject;
+}
+
+// ---------------------------------------------------------------------------
 // OpenAI Responses — schema-valued normalization
 // ---------------------------------------------------------------------------
 

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1086,6 +1086,7 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 
 		let changed = false;
 		const output: JsonObject = {};
+		let typeAlternatives: JsonObject[] | undefined;
 		for (const key in value) {
 			if (!Object.hasOwn(value, key)) continue;
 			const child = value[key];
@@ -1095,8 +1096,13 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 			}
 			if (key === "type" && Array.isArray(child)) {
 				const variants = child.filter((entry): entry is string => typeof entry === "string");
-				const nonNull = variants.filter(entry => entry !== "null");
-				output.type = nonNull[0] ?? variants[0] ?? child[0];
+				const uniqueVariants = [...new Set(variants)];
+				const nonNull = uniqueVariants.filter(entry => entry !== "null");
+				if (nonNull.length <= 1) {
+					output.type = nonNull[0] ?? uniqueVariants[0] ?? child[0];
+				} else {
+					typeAlternatives = uniqueVariants.map(entry => ({ type: entry }));
+				}
 				changed = true;
 				continue;
 			}
@@ -1126,6 +1132,11 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 			}
 			if (next !== child) changed = true;
 			output[key] = next;
+		}
+
+		if (typeAlternatives) {
+			const existingAnyOf = output.anyOf;
+			output.anyOf = Array.isArray(existingAnyOf) ? [...typeAlternatives, ...existingAnyOf] : typeAlternatives;
 		}
 
 		return changed ? output : value;

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1135,8 +1135,9 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 		}
 
 		if (typeAlternatives) {
-			const existingAnyOf = output.anyOf;
-			output.anyOf = Array.isArray(existingAnyOf) ? [...typeAlternatives, ...existingAnyOf] : typeAlternatives;
+			const existingAllOf = output.allOf;
+			const typeUnion = { anyOf: typeAlternatives };
+			output.allOf = Array.isArray(existingAllOf) ? [typeUnion, ...existingAllOf] : [typeUnion];
 		}
 
 		return changed ? output : value;

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -1043,15 +1043,36 @@ const OLLAMA_SCHEMA_VALUE_KEYS = new Set([
 ]);
 
 /**
+ * Widened stand-in for a `true` / `{}` subschema in an Ollama-bound tool.
+ *
+ * `toolWireSchema()` normalizes empty schemas to boolean `true` upstream so
+ * grammar-constrained samplers (llama.cpp, etc.) don't treat `{}` as
+ * "generate an empty object" (issue #1179). Ollama's Go tool parser can't
+ * unmarshal a boolean into its object-shaped `Schema` struct, so this
+ * sanitizer replaces every open subschema with an explicit union of every
+ * primitive JSON type. Both invariants survive: the wire has no boolean
+ * subschema (Go accepts it), and llama.cpp's grammar sees a real value
+ * union rather than a closed empty object.
+ */
+const OLLAMA_OPEN_SUBSCHEMA_WIDENING = Object.freeze({
+	anyOf: [
+		{ type: "string" },
+		{ type: "number" },
+		{ type: "boolean" },
+		{ type: "object" },
+		{ type: "array" },
+		{ type: "null" },
+	],
+});
+
+/**
  * Rewrites standard JSON Schema forms that Ollama's Go `/api/chat` tool parser
  * cannot unmarshal into its object-shaped `Schema` struct.
  */
 export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
-	const cache = new WeakMap<JsonObject, unknown>();
 	const normalizeNode = (value: unknown): unknown => {
-		if (typeof value === "boolean") {
-			return value ? {} : { type: "object", properties: {} };
-		}
+		if (value === true) return OLLAMA_OPEN_SUBSCHEMA_WIDENING;
+		if (value === false) return { not: OLLAMA_OPEN_SUBSCHEMA_WIDENING };
 		if (!isJsonObject(value)) {
 			if (!Array.isArray(value)) return value;
 			let changed = false;
@@ -1063,13 +1084,8 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 			return changed ? output : value;
 		}
 
-		const cached = cache.get(value);
-		if (cached) return cached;
-
-		const output: JsonObject = {};
-		cache.set(value, output);
-
 		let changed = false;
+		const output: JsonObject = {};
 		for (const key in value) {
 			if (!Object.hasOwn(value, key)) continue;
 			const child = value[key];
@@ -1112,9 +1128,7 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 			output[key] = next;
 		}
 
-		const result = changed ? output : value;
-		cache.set(value, result);
-		return result;
+		return changed ? output : value;
 	};
 	return normalizeNode(schema) as JsonObject;
 }

--- a/packages/ai/test/ollama-thinking-disable.test.ts
+++ b/packages/ai/test/ollama-thinking-disable.test.ts
@@ -103,6 +103,10 @@ describe("Ollama chat thinking controls", () => {
 					nullableName: { type: ["string", "null"] },
 					stringOrNumber: { type: ["string", "number"] },
 					objectOrArray: { type: ["object", "array"] },
+					typedAndConstrained: {
+						type: ["string", "number"],
+						anyOf: [{ enum: ["ok"] }, { minimum: 1 }],
+					},
 					list: { type: "array", items: {} },
 					union: { anyOf: [{}, { type: "string" }] },
 					nested: {
@@ -111,7 +115,16 @@ describe("Ollama chat thinking controls", () => {
 						additionalProperties: false,
 					},
 				},
-				required: ["anything", "nullableName", "stringOrNumber", "objectOrArray", "list", "union", "nested"],
+				required: [
+					"anything",
+					"nullableName",
+					"stringOrNumber",
+					"objectOrArray",
+					"typedAndConstrained",
+					"list",
+					"union",
+					"nested",
+				],
 				additionalProperties: false,
 			},
 		};
@@ -145,10 +158,15 @@ describe("Ollama chat thinking controls", () => {
 		expect(Object.hasOwn(parameters, "additionalProperties")).toBe(false);
 		expect(properties.anything).toEqual(widenedOpen);
 		expect(properties.nullableName?.type).toBe("string");
-		expect(properties.stringOrNumber?.anyOf).toEqual([{ type: "string" }, { type: "number" }]);
+		expect(properties.stringOrNumber?.allOf).toEqual([{ anyOf: [{ type: "string" }, { type: "number" }] }]);
 		expect(Object.hasOwn(properties.stringOrNumber, "type")).toBe(false);
-		expect(properties.objectOrArray?.anyOf).toEqual([{ type: "object" }, { type: "array" }]);
+		expect(Object.hasOwn(properties.stringOrNumber, "anyOf")).toBe(false);
+		expect(properties.objectOrArray?.allOf).toEqual([{ anyOf: [{ type: "object" }, { type: "array" }] }]);
 		expect(Object.hasOwn(properties.objectOrArray, "type")).toBe(false);
+		expect(Object.hasOwn(properties.objectOrArray, "anyOf")).toBe(false);
+		expect(properties.typedAndConstrained?.allOf).toEqual([{ anyOf: [{ type: "string" }, { type: "number" }] }]);
+		expect(properties.typedAndConstrained?.anyOf).toEqual([{ enum: ["ok"], type: "string" }, { minimum: 1 }]);
+		expect(Object.hasOwn(properties.typedAndConstrained, "type")).toBe(false);
 		expect(properties.list?.items).toEqual(widenedOpen);
 		expect(properties.union?.anyOf).toEqual([widenedOpen, { type: "string" }]);
 		expect(Object.hasOwn(properties.nested, "additionalProperties")).toBe(false);

--- a/packages/ai/test/ollama-thinking-disable.test.ts
+++ b/packages/ai/test/ollama-thinking-disable.test.ts
@@ -101,6 +101,8 @@ describe("Ollama chat thinking controls", () => {
 				properties: {
 					anything: {},
 					nullableName: { type: ["string", "null"] },
+					stringOrNumber: { type: ["string", "number"] },
+					objectOrArray: { type: ["object", "array"] },
 					list: { type: "array", items: {} },
 					union: { anyOf: [{}, { type: "string" }] },
 					nested: {
@@ -109,7 +111,7 @@ describe("Ollama chat thinking controls", () => {
 						additionalProperties: false,
 					},
 				},
-				required: ["anything", "nullableName", "list", "union", "nested"],
+				required: ["anything", "nullableName", "stringOrNumber", "objectOrArray", "list", "union", "nested"],
 				additionalProperties: false,
 			},
 		};
@@ -143,6 +145,10 @@ describe("Ollama chat thinking controls", () => {
 		expect(Object.hasOwn(parameters, "additionalProperties")).toBe(false);
 		expect(properties.anything).toEqual(widenedOpen);
 		expect(properties.nullableName?.type).toBe("string");
+		expect(properties.stringOrNumber?.anyOf).toEqual([{ type: "string" }, { type: "number" }]);
+		expect(Object.hasOwn(properties.stringOrNumber, "type")).toBe(false);
+		expect(properties.objectOrArray?.anyOf).toEqual([{ type: "object" }, { type: "array" }]);
+		expect(Object.hasOwn(properties.objectOrArray, "type")).toBe(false);
 		expect(properties.list?.items).toEqual(widenedOpen);
 		expect(properties.union?.anyOf).toEqual([widenedOpen, { type: "string" }]);
 		expect(Object.hasOwn(properties.nested, "additionalProperties")).toBe(false);

--- a/packages/ai/test/ollama-thinking-disable.test.ts
+++ b/packages/ai/test/ollama-thinking-disable.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { AssistantMessage, Context, ToolResultMessage, Usage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Context, Tool, ToolResultMessage, Usage } from "@oh-my-pi/pi-ai";
 import { streamOllama } from "@oh-my-pi/pi-ai/providers/ollama";
 import { NON_VISION_IMAGE_PLACEHOLDER } from "@oh-my-pi/pi-ai/providers/vision-guard";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -10,15 +10,25 @@ interface OllamaChatMessagePayload {
 	images?: unknown;
 }
 
+interface OllamaToolPayload {
+	function?: {
+		parameters?: Record<string, unknown>;
+	};
+}
+
 interface OllamaChatRequestPayload {
 	think?: unknown;
 	messages?: OllamaChatMessagePayload[];
+	tools?: OllamaToolPayload[];
 }
 
 function isOllamaChatRequestPayload(value: unknown): value is OllamaChatRequestPayload {
 	if (value === null || typeof value !== "object") return false;
-	const payload = value as { messages?: unknown };
-	return payload.messages === undefined || Array.isArray(payload.messages);
+	const payload = value as { messages?: unknown; tools?: unknown };
+	return (
+		(payload.messages === undefined || Array.isArray(payload.messages)) &&
+		(payload.tools === undefined || Array.isArray(payload.tools))
+	);
 }
 
 const emptyUsage: Usage = {
@@ -69,6 +79,62 @@ describe("Ollama chat thinking controls", () => {
 		}).result();
 
 		expect(payload?.think).toBe(false);
+	});
+
+	it("normalizes tool schemas for Ollama's Go parser", async () => {
+		let payload: OllamaChatRequestPayload | undefined;
+		const fetchMock = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const parsed: unknown = JSON.parse(String(init?.body));
+			if (!isOllamaChatRequestPayload(parsed)) {
+				throw new Error("Expected Ollama payload object");
+			}
+			payload = parsed;
+			return new Response('{"message":{"content":"ok"},"done":true,"prompt_eval_count":1,"eval_count":1}\n', {
+				status: 200,
+			});
+		};
+		const tool: Tool = {
+			name: "schema_probe",
+			description: "probe schema normalization",
+			parameters: {
+				type: "object",
+				properties: {
+					anything: {},
+					nullableName: { type: ["string", "null"] },
+					list: { type: "array", items: {} },
+					union: { anyOf: [{}, { type: "string" }] },
+					nested: {
+						type: "object",
+						properties: { value: { type: "string" } },
+						additionalProperties: false,
+					},
+				},
+				required: ["anything", "nullableName", "list", "union", "nested"],
+				additionalProperties: false,
+			},
+		};
+		const context: Context = {
+			messages: [{ role: "user", content: "hola", timestamp: 0 }],
+			tools: [tool],
+		};
+
+		await streamOllama(createReasoningOllamaModel(), context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		const parameters = payload?.tools?.[0]?.function?.parameters;
+		if (!parameters || typeof parameters.properties !== "object" || parameters.properties === null) {
+			throw new Error("Expected Ollama tool parameters with properties");
+		}
+		const properties = parameters.properties as Record<string, Record<string, unknown>>;
+
+		expect(Object.hasOwn(parameters, "additionalProperties")).toBe(false);
+		expect(properties.anything).toEqual({});
+		expect(properties.nullableName?.type).toBe("string");
+		expect(properties.list?.items).toEqual({});
+		expect(properties.union?.anyOf).toEqual([{}, { type: "string" }]);
+		expect(Object.hasOwn(properties.nested, "additionalProperties")).toBe(false);
 	});
 	it("sends mid-conversation developer messages as user turns for llama.cpp cache reuse", async () => {
 		let payload: OllamaChatRequestPayload | undefined;

--- a/packages/ai/test/ollama-thinking-disable.test.ts
+++ b/packages/ai/test/ollama-thinking-disable.test.ts
@@ -129,11 +129,22 @@ describe("Ollama chat thinking controls", () => {
 		}
 		const properties = parameters.properties as Record<string, Record<string, unknown>>;
 
+		const widenedOpen = {
+			anyOf: [
+				{ type: "string" },
+				{ type: "number" },
+				{ type: "boolean" },
+				{ type: "object" },
+				{ type: "array" },
+				{ type: "null" },
+			],
+		};
+
 		expect(Object.hasOwn(parameters, "additionalProperties")).toBe(false);
-		expect(properties.anything).toEqual({});
+		expect(properties.anything).toEqual(widenedOpen);
 		expect(properties.nullableName?.type).toBe("string");
-		expect(properties.list?.items).toEqual({});
-		expect(properties.union?.anyOf).toEqual([{}, { type: "string" }]);
+		expect(properties.list?.items).toEqual(widenedOpen);
+		expect(properties.union?.anyOf).toEqual([widenedOpen, { type: "string" }]);
 		expect(Object.hasOwn(properties.nested, "additionalProperties")).toBe(false);
 	});
 	it("sends mid-conversation developer messages as user turns for llama.cpp cache reuse", async () => {


### PR DESCRIPTION
## Repro
A minimal `streamOllama` request with one tool schema reproduced the failure by sending `tools[0].function.parameters.properties.anything` as a boolean subschema; the strict Ollama-style parser returned HTTP 400 with `json: cannot unmarshal bool into Go struct field ToolFunctionParameters.tools.function.parameters.properties`. Command: `bun .wt/ollama-tool-schema-repro.ts` before the fix.

## Cause
`packages/ai/src/providers/ollama.ts` built native `/api/chat` tool definitions with `parameters: toolWireSchema(tool)`. The shared wire schema intentionally emits valid Draft 2020-12 JSON Schema forms (`true` subschemas from empty schemas, `additionalProperties: false`, and nullable `type` arrays), but Ollama's Go tool schema struct expects object-shaped schema nodes and scalar `type` values.

## Fix
- Added `sanitizeSchemaForOllama` in `packages/ai/src/utils/schema/normalize.ts` to normalize only schema-valued positions for Ollama's parser.
- Applied the sanitizer in the native Ollama tool serializer before request construction.
- Added provider-bound regression coverage in `packages/ai/test/ollama-thinking-disable.test.ts`.
- Added the `packages/ai/CHANGELOG.md` unreleased entry.

## Verification
`bun test packages/ai/test/ollama-thinking-disable.test.ts packages/ai/test/schema-normalization.test.ts` passed: 71 tests, 136 assertions. `bun check` passed. `bun run fix` reported no TypeScript fixes and completed Rust checks. Fixes #4488