### PR TITLE
fix(models): accept list-valued model role entries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `pi/<role>` model resolution crashing on YAML list-valued `modelRoles` entries by normalizing string arrays the same way as comma-separated strings. ([#4492](https://github.com/can1357/oh-my-pi/issues/4492))
+
 ## [16.3.5] - 2026-07-04
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -172,6 +172,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function modelRoleValueFromUnknown(value: unknown): string | undefined {
+	if (typeof value === "string") return value;
+	if (!Array.isArray(value)) return undefined;
+
+	const entries = stringArrayFromUnknown(value);
+	return entries.length === value.length ? entries.join(",") : undefined;
+}
+
 type EditVariantEntry = {
 	patternLower: string;
 	mode: EditMode;
@@ -580,8 +588,8 @@ export class Settings {
 		const roles: Record<string, string> = {};
 		for (const role in value) {
 			if (!Object.hasOwn(value, role)) continue;
-			const modelId = value[role];
-			if (typeof modelId === "string") {
+			const modelId = modelRoleValueFromUnknown(value[role]);
+			if (modelId !== undefined) {
 				roles[role] = modelId;
 			}
 		}
@@ -614,15 +622,27 @@ export class Settings {
 	 * Get a model role (helper for modelRoles record).
 	 */
 	getModelRole(role: ModelRole | string): string | undefined {
-		const roles = this.get("modelRoles");
-		return roles[role];
+		const roles: unknown = this.get("modelRoles");
+		if (!isRecord(roles)) return undefined;
+		return modelRoleValueFromUnknown(roles[role]);
 	}
 
 	/**
 	 * Get all model roles (helper for modelRoles record).
 	 */
 	getModelRoles(): ReadOnlyDict<string> {
-		return { ...this.get("modelRoles") };
+		const roles: unknown = this.get("modelRoles");
+		if (!isRecord(roles)) return {};
+
+		const normalized: Record<string, string> = {};
+		for (const role in roles) {
+			if (!Object.hasOwn(roles, role)) continue;
+			const modelId = modelRoleValueFromUnknown(roles[role]);
+			if (modelId !== undefined) {
+				normalized[role] = modelId;
+			}
+		}
+		return normalized;
 	}
 
 	/*

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -730,6 +730,21 @@ describe("resolveAgentModelPatterns", () => {
 		expect(result).toEqual(["anthropic/claude-sonnet-4-5:high"]);
 	});
 
+	test("accepts YAML list values for configured task role patterns", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				task: ["anthropic/claude-sonnet-4-6", "zai/glm-5.2:high"],
+			},
+		});
+
+		const result = resolveAgentModelPatterns({
+			agentModel: "pi/task",
+			settings,
+		});
+
+		expect(result).toEqual(["anthropic/claude-sonnet-4-6", "zai/glm-5.2:high"]);
+	});
+
 	test("uses default for unconfigured smol, slow, and designer agent roles before priority defaults", () => {
 		const settings = Settings.isolated({
 			modelRoles: { default: "local/llama" },


### PR DESCRIPTION
## Repro
A YAML-equivalent list value for `modelRoles.task` reproduces the crash when resolving `pi/task`: `bun run .wt/repro-4492.ts` called `resolveConfiguredModelPatterns("pi/task", settings)` and `resolveAgentModelPatterns({ agentModel: "pi/task", settings })` with `Settings.isolated({ modelRoles: { task: ["anthropic/claude-sonnet-4-6", "zai/glm-5.2:high"] } })`; before the fix both paths threw `TypeError: settings?.getModelRole(role)?.trim is not a function` at `packages/coding-agent/src/config/model-resolver.ts:960`.

## Cause
`packages/coding-agent/src/config/settings.ts` exposed `Settings.getModelRole()` and `getModelRoles()` as `string`-valued helpers, but the merged settings layer can still contain raw YAML arrays for `modelRoles` entries. `packages/coding-agent/src/config/model-resolver.ts` trusted that accessor contract and called `.trim()` on the returned `modelRoles.task` value during `resolveConfiguredRolePattern()` before the existing comma/list normalization could run.

## Fix
- Normalize string-array `modelRoles` values at the `Settings` accessor boundary by converting YAML-equivalent string arrays into comma-list strings.
- Reuse the same normalization for `#modelRolesFromLayer()` and `getModelRoles()` so settings updates and role enumeration preserve list-valued entries instead of dropping or leaking arrays.
- Added regression coverage for resolving `pi/task` from a list-valued `modelRoles.task` entry.
- Added the coding-agent changelog entry for #4492.

## Verification
`bun run .wt/repro-4492.ts` now prints both resolved pattern lists without throwing; `bun test packages/coding-agent/test/model-resolver.test.ts` passed with 117 tests; `bun check` passed across the repo. Fixes #4492