### PR TITLE
fix(coding-agent): guard write renderer content

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the write tool renderer crashing when persisted runtime content is a truthy non-string value; rendering now coerces display content before Windows CR normalization. ([#4495](https://github.com/can1357/oh-my-pi/issues/4495))
+
 ## [16.3.5] - 2026-07-04
 
 ### Fixed

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -974,7 +974,7 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 interface WriteRenderArgs {
 	path?: string;
 	file_path?: string;
-	content?: string;
+	content?: unknown;
 }
 
 const WRITE_PREVIEW_LINES = 6;
@@ -990,8 +990,14 @@ function formatLineCountSuffix(lineCount: number, uiTheme: Theme): string {
 	return uiTheme.fg("dim", ` · ${lineCount} line${lineCount === 1 ? "" : "s"}`);
 }
 
-function normalizeDisplayText(text: string): string {
-	return text.replace(/\r/g, "");
+function normalizeDisplayText(text: unknown): string {
+	let displayText = "";
+	if (typeof text === "string") {
+		displayText = text;
+	} else if (text !== undefined && text !== null) {
+		displayText = String(text);
+	}
+	return displayText.replace(/\r/g, "");
 }
 
 /**
@@ -1098,11 +1104,12 @@ export const writeToolRenderer = {
 			},
 			uiTheme,
 		);
+		const content = normalizeDisplayText(args.content);
 		const streamingCache = createRenderedStringCache();
 		return framedBlock(uiTheme, width => {
-			const body = args.content
+			const body = content
 				? formatStreamingContent(
-						args.content,
+						content,
 						Boolean(options?.expanded),
 						lang,
 						uiTheme,
@@ -1130,7 +1137,7 @@ export const writeToolRenderer = {
 	): Component {
 		const rawPath = args?.file_path || args?.path || "";
 		const filePath = shortenPath(rawPath);
-		const fileContent = args?.content || "";
+		const fileContent = normalizeDisplayText(args?.content);
 		const lang = getLanguageFromPath(rawPath);
 		const langIcon = uiTheme.fg("muted", uiTheme.getLangIcon(lang));
 		// The header shows the cwd-relative path but links to the absolute path the

--- a/packages/coding-agent/test/write-streaming-preview-expand.test.ts
+++ b/packages/coding-agent/test/write-streaming-preview-expand.test.ts
@@ -31,6 +31,18 @@ describe("write streaming preview honors Ctrl+O expansion", () => {
 		return new ToolExecutionComponent("write", { file_path: "/tmp/foo.ts", content }, {}, undefined, uiStub);
 	}
 
+	async function getUiTheme() {
+		if (!initialized) {
+			await themeModule.initTheme();
+			initialized = true;
+		}
+		const uiTheme = (await themeModule.getThemeByName("dark")) ?? (await themeModule.getThemeByName("light"));
+		if (!uiTheme) {
+			throw new Error("expected an initialized theme");
+		}
+		return uiTheme;
+	}
+
 	it("collapses a streaming write to a bounded tail and lifts the cap on expand", async () => {
 		// 40 lines > WRITE_STREAMING_PREVIEW_LINES (12): the head must be hidden
 		// while collapsed and the streaming edge (tail) kept visible.
@@ -85,6 +97,45 @@ describe("write streaming preview honors Ctrl+O expansion", () => {
 		options.spinnerFrame = 1;
 		component.render(120);
 		expect(highlightSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("coerces truthy non-string content for pending write previews", async () => {
+		const uiTheme = await getUiTheme();
+		const runtimeContent = ["object first\r\nobject second"];
+
+		const component = writeToolRenderer.renderCall(
+			{ path: "/tmp/runtime-content.ts", content: runtimeContent },
+			{ expanded: true, isPartial: true, spinnerFrame: 0 },
+			uiTheme,
+		);
+
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("object first");
+		expect(rendered).toContain("object second");
+		expect(rendered).toMatch(/\b2 object second\b/);
+		expect(rendered).not.toContain("\r");
+	});
+
+	it("coerces truthy non-string content for merged write results", async () => {
+		const uiTheme = await getUiTheme();
+		const runtimeContent = ["merged first\r\nmerged second"];
+
+		const component = writeToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Wrote /tmp/runtime-content.ts" }],
+				details: { resolvedPath: "/tmp/runtime-content.ts" },
+			},
+			{ expanded: true, isPartial: false },
+			uiTheme,
+			{ path: "/tmp/runtime-content.ts", content: runtimeContent },
+		);
+
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rendered).toContain("merged first");
+		expect(rendered).toContain("merged second");
+		expect(rendered).toContain("2 lines");
+		expect(rendered).toMatch(/\b2 merged second\b/);
+		expect(rendered).not.toContain("\r");
 	});
 
 	it("renders execution progress as a partial result without diagnostics", async () => {


### PR DESCRIPTION
## Repro
A source-level renderer smoke reproduced the crash by importing `packages/coding-agent/src/tools/write.ts`, initializing the TUI theme, then rendering `writeToolRenderer.renderCall({ path: 'demo.txt', content: { value: 1 } }, { expanded: false, isPartial: true }, theme).render(80)`. Before the fix this threw `TypeError: text.replace is not a function` from the write preview CR-normalization path.

## Cause
`packages/coding-agent/src/tools/write.ts` typed `WriteRenderArgs.content` as `string`, but transcript/render rebuilds can provide runtime values that do not satisfy that static shape. `renderCall` passed `args.content` directly into `formatStreamingContent()`, whose `normalizeDisplayText()` called `.replace(/\r/g, "")`; `renderResult` similarly used `args?.content || ""` before line counting and preview rendering, so a truthy object or array could reach string methods and crash the TUI.

## Fix
- Widened the renderer-only `content` field to `unknown` to match runtime inputs from persisted/transient tool args.
- Normalized write preview display content once at the renderer boundary using string coercion plus CR stripping before line counting, highlighting, and framed rendering.
- Added regression coverage for both pending write call previews and merged write results with truthy non-string runtime content.
- Added the coding-agent changelog entry for the renderer crash fix.

## Verification
`bun test packages/coding-agent/test/write-streaming-preview-expand.test.ts` passed: 7 pass, 0 fail, 27 assertions. `bun run check:types` in `packages/coding-agent` passed. `bun check` at the repo root passed. Fixes #4495