### PR TITLE
Add first-party LongCat (Meituan) provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- `/login longcat` API-key login for the first-party LongCat (Meituan) provider, validating the key against `https://api.longcat.chat/openai/v1/models`.
 
 ## [16.3.5] - 2026-07-04
 

--- a/packages/ai/src/registry/longcat.ts
+++ b/packages/ai/src/registry/longcat.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginLongcat = createApiKeyLogin({
+	providerLabel: "LongCat",
+	authUrl: "https://longcat.chat/platform/api_keys",
+	instructions: "Copy your API key from the LongCat platform console",
+	promptMessage: "Paste your LongCat API key",
+	placeholder: "...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "longcat",
+		modelsUrl: "https://api.longcat.chat/openai/v1/models",
+	},
+});
+
+export const longcatProvider = {
+	id: "longcat",
+	name: "LongCat",
+	login: (cb: OAuthLoginCallbacks) => loginLongcat(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/longcat.ts
+++ b/packages/ai/src/registry/longcat.ts
@@ -7,7 +7,7 @@ export const loginLongcat = createApiKeyLogin({
 	authUrl: "https://longcat.chat/platform/api_keys",
 	instructions: "Copy your API key from the LongCat platform console",
 	promptMessage: "Paste your LongCat API key",
-	placeholder: "...",
+	placeholder: "ak_...",
 	validation: {
 		kind: "models-endpoint",
 		provider: "longcat",

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -28,6 +28,7 @@ import { kimiCodeProvider } from "./kimi-code";
 import { litellmProvider } from "./litellm";
 import { llamaCppProvider } from "./llama-cpp";
 import { lmStudioProvider } from "./lm-studio";
+import { longcatProvider } from "./longcat";
 import { minimaxProvider } from "./minimax";
 import { minimaxCodeProvider } from "./minimax-code";
 import { minimaxCodeCnProvider } from "./minimax-code-cn";
@@ -105,6 +106,7 @@ const ALL = [
 	firepassProvider,
 	deepseekProvider,
 	moonshotProvider,
+	longcatProvider,
 	cerebrasProvider,
 	basetenProvider,
 	fireworksProvider,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- First-party LongCat (Meituan) provider (`longcat`) serving `LongCat-2.0` from the native `api.longcat.chat` OpenAI-compatible endpoint: bundled seed + `catalogDiscovery` against `/openai/v1/models`, `LONGCAT_API_KEY` env var, featured `mapModel` baking pricing (in $0.75 / out $2.95 / cached $0.015 per Mtok), 1M-token context, 128K output. LongCat's API only accepts the binary `thinking:{type:"enabled"|"disabled"}` toggle (DeepSeek-style `reasoning_content`) and 400s on `reasoning_effort:"minimal"`/`"xhigh"`, so the provider is classified as a `zai`-protocol host (`hosts.ts`) — omp derives `thinkingFormat:"zai"` + `supportsReasoningEffort:false` and never emits `reasoning_effort`. The model id is case-sensitive (`LongCat-2.0`).
 
 ## [16.3.4] - 2026-07-03
 

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -36,6 +36,7 @@ import {
 	clampKimiK27CodeMaxTokens,
 	isFireworksKimiK2ModelId,
 	isKimiK27CodeModelId,
+	LONGCAT_STATIC_MODELS,
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,
 	SAKANA_FUGU_STATIC_MODELS,
@@ -501,6 +502,11 @@ async function generateModels() {
 	// Sakana is authoritative and stale seed IDs must stay out.
 	if (!authoritativeCatalogProviders.has("sakana")) {
 		allModels.push(...SAKANA_FUGU_STATIC_MODELS);
+	}
+	// Seed LongCat-2.0 so the provider is usable when catalog generation has no
+	// live API key. If live `/v1/models` succeeds the live rows are deduped ahead.
+	if (!authoritativeCatalogProviders.has("longcat")) {
+		allModels.push(...LONGCAT_STATIC_MODELS);
 	}
 	// Seed the GitLab Duo Agent fallback model so a fresh install (no credentialed
 	// dynamic discovery/cache yet) still surfaces the provider's default model in the

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -42,7 +42,7 @@ export const KNOWN_HOSTS = {
 	// protocol + `reasoning_content`, so it shares the zai host classification
 	// (binary thinkingFormat, supportsReasoningEffort=false, reasoning_content
 	// replay). Provider id stays "longcat"; only the host match widens.
-	zai: { providers: ["zai", "longcat"], urlMarkers: ["api.z.ai"] },
+	zai: { providers: ["zai", "longcat"], urlMarkers: ["api.z.ai", "api.longcat.chat"] },
 	zhipu: { providers: ["zhipu-coding-plan"], urlMarkers: ["open.bigmodel.cn"] },
 	kilo: { providers: ["kilo"], urlMarkers: ["api.kilo.ai"] },
 	alibabaDashscope: { providers: ["alibaba-coding-plan"], urlMarkers: ["dashscope"] },

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -38,7 +38,11 @@ export const KNOWN_HOSTS = {
 	/** Any DeepSeek-operated host (first-party API, web-chat fronts). Wider than `deepseekDirect` on purpose. */
 	deepseekFamily: { providers: ["deepseek"], urlMarkers: ["deepseek.com"] },
 	cerebras: { providers: ["cerebras"], urlMarkers: ["cerebras.ai"] },
-	zai: { providers: ["zai"], urlMarkers: ["api.z.ai"] },
+	// LongCat (Meituan) speaks the same z.ai-style binary `thinking:{type}`
+	// protocol + `reasoning_content`, so it shares the zai host classification
+	// (binary thinkingFormat, supportsReasoningEffort=false, reasoning_content
+	// replay). Provider id stays "longcat"; only the host match widens.
+	zai: { providers: ["zai", "longcat"], urlMarkers: ["api.z.ai"] },
 	zhipu: { providers: ["zhipu-coding-plan"], urlMarkers: ["open.bigmodel.cn"] },
 	kilo: { providers: ["kilo"], urlMarkers: ["api.kilo.ai"] },
 	alibabaDashscope: { providers: ["alibaba-coding-plan"], urlMarkers: ["dashscope"] },

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -35122,7 +35122,7 @@
 	"longcat": {
 		"LongCat-2.0": {
 			"id": "LongCat-2.0",
-			"name": "LongCat-2.0",
+			"name": "LongCat 2.0",
 			"api": "openai-completions",
 			"provider": "longcat",
 			"baseUrl": "https://api.longcat.chat/openai/v1",

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -34939,7 +34939,7 @@
 		},
 		"z-ai/glm-5.2": {
 			"id": "z-ai/glm-5.2",
-			"name": "GLM 5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -35032,6 +35032,11 @@
 					"medium",
 					"high"
 				]
+			},
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
 			}
 		},
 		"kimi-k2": {
@@ -35111,6 +35116,41 @@
 					"medium",
 					"high"
 				]
+			}
+		}
+	},
+	"longcat": {
+		"LongCat-2.0": {
+			"id": "LongCat-2.0",
+			"name": "LongCat-2.0",
+			"api": "openai-completions",
+			"provider": "longcat",
+			"baseUrl": "https://api.longcat.chat/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 2.95,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
 			}
 		}
 	},
@@ -57125,7 +57165,7 @@
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
-			"name": "GLM-5.1",
+			"name": "GLM 5.1",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -57150,6 +57190,38 @@
 					"high",
 					"xhigh"
 				]
+			}
+		},
+		"z-ai/glm-5.2": {
+			"id": "z-ai/glm-5.2",
+			"name": "GLM-5.2",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"xhigh": "max"
+				}
 			}
 		},
 		"z-ai/glm4.7": {
@@ -67039,8 +67111,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08499999999999999,
-				"output": 0.39999999999999997,
+				"input": 0.08,
+				"output": 0.44999999999999996,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
@@ -71776,7 +71848,7 @@
 		},
 		"z-ai/glm-5.2": {
 			"id": "z-ai/glm-5.2",
-			"name": "GLM 5.2",
+			"name": "GLM-5.2",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -71785,13 +71857,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.9299999999999999,
-				"output": 3,
-				"cacheRead": 0.18,
+				"input": 0.9099999999999999,
+				"output": 2.8600000000000003,
+				"cacheRead": 0.16899999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 32768,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -72007,7 +72079,7 @@
 	"synthetic": {
 		"hf:MiniMaxAI/MiniMax-M3": {
 			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -72022,7 +72094,7 @@
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -72037,7 +72109,7 @@
 		},
 		"hf:moonshotai/Kimi-K2.7-Code": {
 			"id": "hf:moonshotai/Kimi-K2.7-Code",
-			"name": "moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -72067,7 +72139,7 @@
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -72096,7 +72168,7 @@
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -72123,7 +72195,7 @@
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -72152,7 +72224,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -72181,7 +72253,7 @@
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -74441,9 +74513,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.1625,
-				"output": 0.5,
-				"cacheRead": 0,
+				"input": 0.13,
+				"output": 0.4,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -74848,9 +74920,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.9,
-				"output": 4.3,
-				"cacheRead": 0.2,
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -75008,9 +75080,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.34,
-				"output": 1.19,
-				"cacheRead": 0.04,
+				"input": 0.27,
+				"output": 0.95,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 198000,
@@ -75091,7 +75163,8 @@
 			"baseUrl": "https://api.venice.ai/api/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.3,
@@ -75272,9 +75345,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.8,
-				"cacheRead": 0,
+				"input": 0.07,
+				"output": 0.4,
+				"cacheRead": 0.035,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -75952,9 +76025,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.5,
-				"cacheRead": 0,
+				"input": 0.21,
+				"output": 1.9,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -76063,9 +76136,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.175,
-				"output": 0.35,
-				"cacheRead": 0.0625,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -76265,9 +76338,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.75,
-				"output": 5.5,
-				"cacheRead": 0.325,
+				"input": 1.54,
+				"output": 4.84,
+				"cacheRead": 0.286,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -82955,6 +83028,14 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -82967,14 +83048,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-4.3": {
@@ -82996,6 +83069,14 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -83008,14 +83089,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-build": {
@@ -86070,7 +86143,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": null,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -26,6 +26,7 @@ import {
 	kimiCodeModelManagerOptions,
 	litellmModelManagerOptions,
 	lmStudioModelManagerOptions,
+	longcatModelManagerOptions,
 	mistralModelManagerOptions,
 	moonshotModelManagerOptions,
 	nanoGptModelManagerOptions,
@@ -226,6 +227,13 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["LM_STUDIO_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => lmStudioModelManagerOptions(config),
 		allowUnauthenticated: true,
+	},
+	{
+		id: "longcat",
+		defaultModel: "LongCat-2.0",
+		envVars: ["LONGCAT_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => longcatModelManagerOptions(config),
+		catalogDiscovery: { label: "LongCat" },
 	},
 	{
 		id: "minimax",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2845,6 +2845,95 @@ export function sakanaModelManagerOptions(config?: SakanaModelManagerConfig): Mo
 }
 
 // ---------------------------------------------------------------------------
+// 16.6 LongCat (Meituan)
+// ---------------------------------------------------------------------------
+
+const LONGCAT_DEFAULT_BASE_URL = "https://api.longcat.chat/openai/v1";
+
+export interface LongcatModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function longcatModelManagerOptions(
+	config?: LongcatModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? LONGCAT_DEFAULT_BASE_URL;
+	// LongCat's `/v1/models` returns only `{id, object, owned_by}` — no pricing,
+	// context, or capability hints — and its model id is case-sensitive
+	// (`LongCat-2.0`, not `longcat-2.0`, else HTTP 400 "Unsupported model").
+	// Bake the documented metadata onto every discovered entry so the live row
+	// is complete without relying on a bundled reference (which can't bootstrap
+	// for a brand-new provider: the live entry wins first-source dedup before
+	// any reference exists to merge from).
+	return {
+		providerId: "longcat",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "longcat",
+					baseUrl,
+					apiKey,
+					mapModel: (
+						_entry: OpenAICompatibleModelRecord,
+						defaults: ModelSpec<"openai-completions">,
+					): ModelSpec<"openai-completions"> => ({
+						...defaults,
+						reasoning: true,
+						input: ["text"],
+						contextWindow: 1_000_000,
+						maxTokens: 131_072,
+						cost: { input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 },
+						// Binary `thinking:{type:"enabled"|"disabled"}` only —
+						// LongCat ignores `reasoning_effort` and 400s on
+						// minimal/xhigh. The zai host classification (hosts.ts)
+						// derives supportsReasoningEffort=false so omp never
+						// emits it.
+						compat: {
+							thinkingFormat: "zai",
+							reasoningContentField: "reasoning_content",
+							supportsDeveloperRole: false,
+						},
+					}),
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// Seed LongCat-2.0 so the provider is usable when catalog generation has no
+// live API key. If live `/v1/models` succeeds (longcat is NOT marked
+// dynamicModelsAuthoritative), live rows are deduped ahead of this seed.
+export const LONGCAT_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	{
+		id: "LongCat-2.0",
+		name: "LongCat 2.0",
+		api: "openai-completions",
+		provider: "longcat",
+		baseUrl: LONGCAT_DEFAULT_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 131_072,
+		// LongCat's OpenAI endpoint only supports the binary
+		// `thinking: {type:"enabled"|"disabled"}` toggle (DeepSeek-style),
+		// surfaced via `message.reasoning_content`; it ignores `reasoning_effort`
+		// and returns an empty body for `minimal`/`xhigh`. The `zai`
+		// thinkingFormat sends exactly that binary toggle and never emits
+		// `reasoning_effort` for a non-GLM id. (#longcat)
+		compat: {
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			supportsDeveloperRole: false,
+		},
+	},
+];
+
+// ---------------------------------------------------------------------------
 // 17. Qwen Portal
 // ---------------------------------------------------------------------------
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2849,6 +2849,34 @@ export function sakanaModelManagerOptions(config?: SakanaModelManagerConfig): Mo
 // ---------------------------------------------------------------------------
 
 const LONGCAT_DEFAULT_BASE_URL = "https://api.longcat.chat/openai/v1";
+const LONGCAT_MODEL_ID = "LongCat-2.0";
+
+/**
+ * Shared LongCat-2.0 metadata, applied to both the static seed and discovered
+ * models so the rows can't drift. LongCat's `/v1/models` returns only
+ * `{id, object, owned_by}` (no pricing/context/capability hints), and the id
+ * is case-sensitive (`LongCat-2.0`, else HTTP 400 "Unsupported model").
+ */
+const LONGCAT_2_MODEL_META: Pick<
+	ModelSpec<"openai-completions">,
+	"name" | "reasoning" | "input" | "contextWindow" | "maxTokens" | "cost" | "compat"
+> = {
+	name: "LongCat 2.0",
+	reasoning: true,
+	input: ["text"],
+	contextWindow: 1_000_000,
+	maxTokens: 131_072,
+	cost: { input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 },
+	// Binary `thinking:{type:"enabled"|"disabled"}` only — LongCat ignores
+	// `reasoning_effort` and 400s on minimal/xhigh. The zai host
+	// classification (hosts.ts) derives supportsReasoningEffort=false so omp
+	// never emits it.
+	compat: {
+		thinkingFormat: "zai",
+		reasoningContentField: "reasoning_content",
+		supportsDeveloperRole: false,
+	},
+};
 
 export interface LongcatModelManagerConfig {
 	apiKey?: string;
@@ -2861,13 +2889,6 @@ export function longcatModelManagerOptions(
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? LONGCAT_DEFAULT_BASE_URL;
-	// LongCat's `/v1/models` returns only `{id, object, owned_by}` — no pricing,
-	// context, or capability hints — and its model id is case-sensitive
-	// (`LongCat-2.0`, not `longcat-2.0`, else HTTP 400 "Unsupported model").
-	// Bake the documented metadata onto every discovered entry so the live row
-	// is complete without relying on a bundled reference (which can't bootstrap
-	// for a brand-new provider: the live entry wins first-source dedup before
-	// any reference exists to merge from).
 	return {
 		providerId: "longcat",
 		...(apiKey && {
@@ -2877,27 +2898,17 @@ export function longcatModelManagerOptions(
 					provider: "longcat",
 					baseUrl,
 					apiKey,
+					// Stamp the documented metadata only onto the known id — a
+					// future sibling served from the same endpoint must not
+					// silently inherit LongCat-2.0's pricing/context. Baking it
+					// here (vs. relying on a bundled reference) lets live rows
+					// self-describe for a brand-new provider where the live
+					// entry wins first-source dedup before any reference exists.
 					mapModel: (
 						_entry: OpenAICompatibleModelRecord,
 						defaults: ModelSpec<"openai-completions">,
-					): ModelSpec<"openai-completions"> => ({
-						...defaults,
-						reasoning: true,
-						input: ["text"],
-						contextWindow: 1_000_000,
-						maxTokens: 131_072,
-						cost: { input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 },
-						// Binary `thinking:{type:"enabled"|"disabled"}` only —
-						// LongCat ignores `reasoning_effort` and 400s on
-						// minimal/xhigh. The zai host classification (hosts.ts)
-						// derives supportsReasoningEffort=false so omp never
-						// emits it.
-						compat: {
-							thinkingFormat: "zai",
-							reasoningContentField: "reasoning_content",
-							supportsDeveloperRole: false,
-						},
-					}),
+					): ModelSpec<"openai-completions"> =>
+						defaults.id === LONGCAT_MODEL_ID ? { ...defaults, ...LONGCAT_2_MODEL_META } : defaults,
 					fetch: config?.fetch,
 				}),
 		}),
@@ -2909,27 +2920,11 @@ export function longcatModelManagerOptions(
 // dynamicModelsAuthoritative), live rows are deduped ahead of this seed.
 export const LONGCAT_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
 	{
-		id: "LongCat-2.0",
-		name: "LongCat 2.0",
+		id: LONGCAT_MODEL_ID,
 		api: "openai-completions",
 		provider: "longcat",
 		baseUrl: LONGCAT_DEFAULT_BASE_URL,
-		reasoning: true,
-		input: ["text"],
-		cost: { input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 },
-		contextWindow: 1_000_000,
-		maxTokens: 131_072,
-		// LongCat's OpenAI endpoint only supports the binary
-		// `thinking: {type:"enabled"|"disabled"}` toggle (DeepSeek-style),
-		// surfaced via `message.reasoning_content`; it ignores `reasoning_effort`
-		// and returns an empty body for `minimal`/`xhigh`. The `zai`
-		// thinkingFormat sends exactly that binary toggle and never emits
-		// `reasoning_effort` for a non-GLM id. (#longcat)
-		compat: {
-			thinkingFormat: "zai",
-			reasoningContentField: "reasoning_content",
-			supportsDeveloperRole: false,
-		},
+		...LONGCAT_2_MODEL_META,
 	},
 ];
 

--- a/packages/catalog/test/hosts.test.ts
+++ b/packages/catalog/test/hosts.test.ts
@@ -37,6 +37,15 @@ describe("modelMatchesHost", () => {
 			modelMatchesHost({ provider: "custom", baseUrl: "https://api.fireworks.ai/inference/v1" }, "fireworks"),
 		).toBe(true);
 	});
+
+	test("classifies the LongCat (Meituan) provider under the zai binary-thinking host", () => {
+		// LongCat speaks the same z.ai-style `thinking:{type}` + reasoning_content
+		// protocol, so it shares the zai host classification (and the downstream
+		// supportsReasoningEffort=false derivation). It must NOT match zhipu.
+		const longcat = { provider: "longcat", baseUrl: "https://api.longcat.chat/openai/v1" };
+		expect(modelMatchesHost(longcat, "zai")).toBe(true);
+		expect(modelMatchesHost(longcat, "zhipu")).toBe(false);
+	});
 });
 
 describe("endpoint shape predicates", () => {

--- a/packages/catalog/test/longcat-compat.test.ts
+++ b/packages/catalog/test/longcat-compat.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { buildOpenAICompat } from "@oh-my-pi/pi-catalog/compat/openai";
+import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
+import { longcatModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+/**
+ * LongCat (Meituan) speaks the z.ai-style binary `thinking:{type}` protocol
+ * with `reasoning_content`. Classified under the `zai` host (hosts.ts), so
+ * omp derives thinkingFormat:"zai" + supportsReasoningEffort:false and never
+ * emits `reasoning_effort` (LongCat ignores it and 400s on minimal/xhigh).
+ * The model id is case-sensitive (`LongCat-2.0`).
+ */
+
+const baseModel: Omit<ModelSpec<"openai-completions">, "provider" | "baseUrl"> = {
+	api: "openai-completions",
+	id: "LongCat-2.0",
+	name: "LongCat 2.0",
+	input: ["text"],
+	cost: { input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 },
+	maxTokens: 131_072,
+	contextWindow: 1_000_000,
+	reasoning: true,
+};
+
+function longcatModel(): ModelSpec<"openai-completions"> {
+	return {
+		...baseModel,
+		provider: "longcat",
+		baseUrl: "https://api.longcat.chat/openai/v1",
+	};
+}
+
+describe("longcat descriptor", () => {
+	it("defaults to the case-sensitive LongCat-2.0 id served by the API", () => {
+		expect(DEFAULT_MODEL_PER_PROVIDER.longcat).toBe("LongCat-2.0");
+	});
+});
+
+describe("openai-completions compat — longcat branch", () => {
+	it("derives zai thinking format and disables reasoning_effort", () => {
+		const compat = buildOpenAICompat(longcatModel());
+
+		// Binary `thinking:{type:"enabled"|"disabled"}` only — never reasoning_effort.
+		expect(compat.thinkingFormat).toBe("zai");
+		expect(compat.supportsReasoningEffort).toBe(false);
+		expect(compat.reasoningContentField).toBe("reasoning_content");
+		// `longcat` participates in the zai/non-standard set.
+		expect(compat.supportsDeveloperRole).toBe(false);
+		expect(compat.supportsMultipleSystemMessages).toBe(true);
+		expect(compat.supportsStore).toBe(false);
+	});
+
+	it("detects longcat by baseUrl when the provider id is custom", () => {
+		const compat = buildOpenAICompat({
+			...baseModel,
+			provider: "custom",
+			baseUrl: "https://api.longcat.chat/openai/v1",
+		});
+
+		expect(compat.thinkingFormat).toBe("zai");
+		expect(compat.supportsReasoningEffort).toBe(false);
+	});
+});
+
+describe("longcat model discovery", () => {
+	function mockFetch(data: { id: string }[]): FetchImpl {
+		return Object.assign(
+			async (input: string | Request | URL): Promise<Response> => {
+				const url = input instanceof Request ? input.url : String(input);
+				if (url.endsWith("/models")) {
+					return new Response(JSON.stringify({ data }), { headers: { "content-type": "application/json" } });
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: fetch.preconnect },
+		);
+	}
+
+	it("stamps documented metadata onto LongCat-2.0 and leaves unknown ids untouched", async () => {
+		const fetchImpl = mockFetch([{ id: "LongCat-2.0" }, { id: "LongCat-3.0" }]);
+		const options = longcatModelManagerOptions({ apiKey: "test-key", fetch: fetchImpl });
+		expect(typeof options.fetchDynamicModels).toBe("function");
+		const models = (await options.fetchDynamicModels?.()) ?? [];
+
+		// Request hit the OpenAI-compatible models endpoint.
+		expect(models.length).toBe(2);
+
+		const known = models.find(m => m.id === "LongCat-2.0");
+		expect(known?.reasoning).toBe(true);
+		expect(known?.cost).toEqual({ input: 0.75, output: 2.95, cacheRead: 0.015, cacheWrite: 0 });
+		expect(known?.contextWindow).toBe(1_000_000);
+		expect(known?.compat?.thinkingFormat).toBe("zai");
+
+		// A future sibling must NOT inherit LongCat-2.0's pricing/context — the
+		// mapper falls through to discovery defaults for unknown ids.
+		const unknown = models.find(m => m.id === "LongCat-3.0");
+		expect(unknown?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		expect(unknown?.contextWindow).not.toBe(1_000_000);
+	});
+});


### PR DESCRIPTION
## Summary

Adds `longcat` as a first-party native OpenAI-compatible provider serving **LongCat-2.0** (Meituan) from `https://api.longcat.chat/openai/v1`, so it reaches Meituan's own API directly instead of only through third-party aggregators (`kilo`/`openrouter`/`vercel-ai-gateway`/`zenmux`/`nanogpt`).

## What's included

- **Catalog** (`packages/catalog/`): `longcatModelManagerOptions` featured factory + `LONGCAT_STATIC_MODELS` seed in `openai-compat.ts`; `longcat` entry in `CATALOG_PROVIDERS` (`descriptors.ts`); guarded seed push in `generate-models.ts`; `longcat` classified as a `zai`-protocol host in `hosts.ts`; regenerated `models.json`.
- **Auth** (`packages/ai/`): new `registry/longcat.ts` (`/login longcat`, validates against `/openai/v1/models`); wired into `registry.ts`.

## Key technical detail — binary thinking

Live testing against the LongCat API (`GET /openai/v1/models`, chat completions across effort levels) showed:

- The API **only accepts the binary `thinking:{type:"enabled"|"disabled"}` toggle** (DeepSeek-style, surfaced via `message.reasoning_content`). It **ignores `reasoning_effort`** and returns **HTTP 200 with an empty body for `reasoning_effort:"minimal"`/`"xhigh"`**.
- The model id is **case-sensitive** — only `LongCat-2.0` is accepted; `longcat-2.0` returns `400 Unsupported model`.

So the simple `createSimpleOpenAICompletionsOptions` template alone was insufficient (its rebaked effort ladder would emit breaking `reasoning_effort` values, and live discovery couldn't bootstrap the seed metadata). The fix:

1. **`hosts.ts`**: classify `longcat` under the `zai` host profile → omp derives `thinkingFormat:"zai"` + `supportsReasoningEffort:false`, so it sends only the binary `thinking:{type}` toggle and **never** emits `reasoning_effort`. Safe: all `modelMatchesHost(_,"zai")` checks are OR'd with `isZhipu`; no standalone `provider==="zai"` literal is affected (longcat's provider id stays `"longcat"`).
2. **Featured `mapModel`**: bakes pricing/context/capabilities/compat directly onto discovered entries (the `/v1/models` endpoint returns only `{id,object,owned_by}`), and dedupes cleanly against the seed without a bundled-reference bootstrap.

## Verified

- `check:ts` passes (17 packages + biome); `hosts.test.ts` 7/7, `build.test.ts` 26/26.
- Wire body (`resolveOpenAICompatPolicy` + `applyChatCompletionsCompatPolicy`): for every effort level → `thinking:{type:"enabled"}`, `reasoning_effort` **absent**; reasoning disabled → `thinking:{type:"disabled"}`.
- Live streaming with omp's exact wire body: HTTP 200, `reasoning_content` + content deltas, `finish:stop`.
- Tool calling: standard OpenAI `tool_calls` array + `reasoning_content` (used read/bash/edit successfully in the TUI).

## Notes

- LongCat retired all `LongCat-Flash-*` models on 2026-05-29; only `LongCat-2.0` is served. Existing aggregator-sourced `meituan/longcat-flash-*` catalog rows reference retired ids — left untouched here (out of scope; can be pruned separately).
- LongCat-2.0: 1M-token context, 128K output, text-only, pricing $0.75 / $2.95 (cached $0.015) per Mtok.

## Checklist

- [x] Catalog descriptor + factory + static seed
- [x] Auth registry entry (`/login longcat`)
- [x] `catalogDiscovery` + `bun run gen:models` produces `longcat/LongCat-2.0`
- [x] `bun check` (TS + biome) passes
- [x] Live-tested against the real API with a key
- [x] CHANGELOG entries (`packages/catalog`, `packages/ai`)
