### PR TITLE
feat(capability): split /extensions provider toggle from model disabledProviders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Decoupled the `/extensions` provider toggle from the model/login provider filter. The capability registry (skills, rules, MCP servers, hooks, tools, prompts, context files, slash commands) now reads from a dedicated `disabledExtensionProviders` list, so toggling `cursor` off in `/extensions` hides its rules/MCP/context files without also removing `cursor/*` chat models from the model picker or `/login`. The model side keeps its existing `disabledProviders` semantics. Legacy configs that only set `disabledProviders` are read as the seed for the extension list on first init so users who previously wrote `disabledProviders: [cursor]` intending "hide everything from cursor" keep the joint behavior until they explicitly toggle a provider from the `/extensions` UI, which now writes to `disabledExtensionProviders` only. The new key supports the same path-scoped array shape (`{ path/pathPrefix, providers | values | items }`) as `disabledProviders` ([#4507](https://github.com/can1357/oh-my-pi/issues/4507)).
+
 ## [16.3.5] - 2026-07-04
 
 ### Fixed

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -207,19 +207,16 @@ async function loadImpl<T>(
 /**
  * Filter providers based on options and disabled state.
  */
-function syncDisabledExtensionProvidersFromSettings(): void {
+function syncDisabledExtensionProvidersFromSettings(cwd?: string): void {
 	if (!settings) return;
 	disabledExtensionProviders.clear();
-	const source = settings.isConfigured("disabledExtensionProviders")
-		? settings.get("disabledExtensionProviders")
-		: settings.get("disabledProviders");
-	for (const id of source) {
+	for (const id of settings.disabledExtensionProvidersForCwd(cwd)) {
 		disabledExtensionProviders.add(id);
 	}
 }
 
 function filterProviders<T>(capability: Capability<T>, options: LoadOptions): Provider<T>[] {
-	syncDisabledExtensionProvidersFromSettings();
+	syncDisabledExtensionProvidersFromSettings(options.cwd);
 	let providers = (capability.providers as Provider<T>[]).filter(p => !disabledExtensionProviders.has(p.id));
 
 	if (options.providers) {

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -306,17 +306,23 @@ export function enableProvider(providerId: string): void {
 
 /**
  * Check if an extension provider is enabled (capability-registry scope).
+ *
+ * `cwd` selects the workspace whose path-scoped `disabledExtensionProviders`
+ * rules apply; omit it for the active session scope. Display paths that load a
+ * different workspace (`loadAllExtensions`, ACP `_omp/extensions`) MUST pass the
+ * loaded cwd so labels match the target project, not the live singleton.
  */
-export function isProviderEnabled(providerId: string): boolean {
-	syncDisabledExtensionProvidersFromSettings();
+export function isProviderEnabled(providerId: string, cwd?: string): boolean {
+	syncDisabledExtensionProvidersFromSettings(cwd);
 	return !disabledExtensionProviders.has(providerId);
 }
 
 /**
- * Get list of all disabled extension provider IDs.
+ * Get list of all disabled extension provider IDs, resolved against `cwd`
+ * (defaults to the active session scope).
  */
-export function getDisabledProviders(): string[] {
-	syncDisabledExtensionProvidersFromSettings();
+export function getDisabledProviders(cwd?: string): string[] {
+	syncDisabledExtensionProvidersFromSettings(cwd);
 	return Array.from(disabledExtensionProviders);
 }
 
@@ -356,12 +362,13 @@ export function listCapabilities(): string[] {
 }
 
 /**
- * Get capability info for UI display.
+ * Get capability info for UI display, resolved against `cwd` (defaults to the
+ * active session scope).
  */
-export function getCapabilityInfo(capabilityId: string): CapabilityInfo | undefined {
+export function getCapabilityInfo(capabilityId: string, cwd?: string): CapabilityInfo | undefined {
 	const capability = capabilities.get(capabilityId);
 	if (!capability) return undefined;
-	syncDisabledExtensionProvidersFromSettings();
+	syncDisabledExtensionProvidersFromSettings(cwd);
 
 	return {
 		id: capability.id,
@@ -378,20 +385,21 @@ export function getCapabilityInfo(capabilityId: string): CapabilityInfo | undefi
 }
 
 /**
- * Get all capabilities info for UI display.
+ * Get all capabilities info for UI display, resolved against `cwd`.
  */
-export function getAllCapabilitiesInfo(): CapabilityInfo[] {
-	return listCapabilities().map(id => getCapabilityInfo(id)!);
+export function getAllCapabilitiesInfo(cwd?: string): CapabilityInfo[] {
+	return listCapabilities().map(id => getCapabilityInfo(id, cwd)!);
 }
 
 /**
- * Get provider info for UI display.
+ * Get provider info for UI display, resolved against `cwd` (defaults to the
+ * active session scope).
  */
-export function getProviderInfo(providerId: string): ProviderInfo | undefined {
+export function getProviderInfo(providerId: string, cwd?: string): ProviderInfo | undefined {
 	const meta = providerMeta.get(providerId);
 	const caps = providerCapabilities.get(providerId);
 	if (!meta || !caps) return undefined;
-	syncDisabledExtensionProvidersFromSettings();
+	syncDisabledExtensionProvidersFromSettings(cwd);
 
 	// Find priority from first capability's provider list
 	let priority = 0;
@@ -415,13 +423,14 @@ export function getProviderInfo(providerId: string): ProviderInfo | undefined {
 }
 
 /**
- * Get all providers info for UI display (deduplicated across capabilities).
+ * Get all providers info for UI display (deduplicated across capabilities),
+ * resolved against `cwd`.
  */
-export function getAllProvidersInfo(): ProviderInfo[] {
+export function getAllProvidersInfo(cwd?: string): ProviderInfo[] {
 	const providers: ProviderInfo[] = [];
 
 	for (const providerId of providerMeta.keys()) {
-		const info = getProviderInfo(providerId);
+		const info = getProviderInfo(providerId, cwd);
 		if (info) {
 			providers.push(info);
 		}

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -278,9 +278,9 @@ export function initializeWithSettings(activeSettings: Settings): void {
 /**
  * Persist current disabled extension providers to settings.
  */
-function persistDisabledExtensionProviders(): void {
+function persistDisabledExtensionProviders(cwd?: string): void {
 	if (settings) {
-		settings.setDisabledExtensionProviders(Array.from(disabledExtensionProviders));
+		settings.setDisabledExtensionProviders(Array.from(disabledExtensionProviders), cwd);
 	}
 }
 
@@ -288,20 +288,26 @@ function persistDisabledExtensionProviders(): void {
  * Disable an extension provider (hides its capability contributions from
  * `/extensions` and everywhere `loadCapability` runs). Does not affect model
  * discovery or `/login`; those honor the separate `disabledProviders` list.
+ *
+ * `cwd` selects the workspace whose path-scoped `disabledExtensionProviders`
+ * rules are read and written; omit it for the active session scope. Toggles for
+ * a different workspace (ACP `_omp/extensions/toggle`) MUST pass the target cwd
+ * so the sync and the persisted edit both land in that project.
  */
-export function disableProvider(providerId: string): void {
-	syncDisabledExtensionProvidersFromSettings();
+export function disableProvider(providerId: string, cwd?: string): void {
+	syncDisabledExtensionProvidersFromSettings(cwd);
 	disabledExtensionProviders.add(providerId);
-	persistDisabledExtensionProviders();
+	persistDisabledExtensionProviders(cwd);
 }
 
 /**
- * Re-enable a previously disabled extension provider.
+ * Re-enable a previously disabled extension provider, resolved against `cwd`
+ * (defaults to the active session scope).
  */
-export function enableProvider(providerId: string): void {
-	syncDisabledExtensionProvidersFromSettings();
+export function enableProvider(providerId: string, cwd?: string): void {
+	syncDisabledExtensionProvidersFromSettings(cwd);
 	disabledExtensionProviders.delete(providerId);
-	persistDisabledExtensionProviders();
+	persistDisabledExtensionProviders(cwd);
 }
 
 /**

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -259,8 +259,14 @@ export async function loadCapability<T>(capabilityId: string, options: LoadOptio
 export function initializeWithSettings(activeSettings: Settings): void {
 	settings = activeSettings;
 	disabledExtensionProviders.clear();
-	const explicitExt = settings.get("disabledExtensionProviders");
-	const source = explicitExt.length > 0 ? explicitExt : settings.get("disabledProviders");
+	// Legacy read-through: fall back to `disabledProviders` ONLY when the new
+	// key has never been configured. An explicitly-empty configured value is a
+	// deliberate "extension list is empty" signal (e.g. the user re-enabled
+	// the last provider from `/extensions`) and must NOT roll back to the
+	// model-side list on the next boot.
+	const source = settings.isConfigured("disabledExtensionProviders")
+		? settings.get("disabledExtensionProviders")
+		: settings.get("disabledProviders");
 	for (const id of source) {
 		disabledExtensionProviders.add(id);
 	}

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -36,8 +36,8 @@ const providerCapabilities = new Map<string, Set<string>>();
 /** Provider display metadata (shared across capabilities) */
 const providerMeta = new Map<string, { displayName: string; description: string }>();
 
-/** Disabled providers (by ID) */
-const disabledProviders = new Set<string>();
+/** Disabled extension providers (by ID). Controls capability-registry loading only. */
+const disabledExtensionProviders = new Set<string>();
 
 /** Settings manager for persistence (if set) */
 let settings: Settings | null = null;
@@ -208,7 +208,7 @@ async function loadImpl<T>(
  * Filter providers based on options and disabled state.
  */
 function filterProviders<T>(capability: Capability<T>, options: LoadOptions): Provider<T>[] {
-	let providers = (capability.providers as Provider<T>[]).filter(p => !disabledProviders.has(p.id));
+	let providers = (capability.providers as Provider<T>[]).filter(p => !disabledExtensionProviders.has(p.id));
 
 	if (options.providers) {
 		const allowed = new Set(options.providers);
@@ -247,65 +247,75 @@ export async function loadCapability<T>(capabilityId: string, options: LoadOptio
 /**
  * Initialize capability system with settings manager for persistence.
  * Call this once on startup to enable persistent provider state.
+ *
+ * Reads the extension-provider disable list from `disabledExtensionProviders`
+ * (added in this change to decouple the `/extensions` provider toggle from the
+ * model/login `disabledProviders` list). For legacy configs where only the
+ * older `disabledProviders` key is set, its value is copied into the new list
+ * so users who set `disabledProviders: [cursor]` intending "hide all cursor
+ * stuff" keep the joint behavior; toggles from the `/extensions` UI then only
+ * mutate the new key.
  */
 export function initializeWithSettings(activeSettings: Settings): void {
 	settings = activeSettings;
-	// Load disabled providers from settings
-	const disabled = settings.get("disabledProviders");
-	disabledProviders.clear();
-	for (const id of disabled) {
-		disabledProviders.add(id);
+	disabledExtensionProviders.clear();
+	const explicitExt = settings.get("disabledExtensionProviders");
+	const source = explicitExt.length > 0 ? explicitExt : settings.get("disabledProviders");
+	for (const id of source) {
+		disabledExtensionProviders.add(id);
 	}
 }
 
 /**
- * Persist current disabled providers to settings.
+ * Persist current disabled extension providers to settings.
  */
-function persistDisabledProviders(): void {
+function persistDisabledExtensionProviders(): void {
 	if (settings) {
-		settings.set("disabledProviders", Array.from(disabledProviders));
+		settings.set("disabledExtensionProviders", Array.from(disabledExtensionProviders));
 	}
 }
 
 /**
- * Disable a provider globally (across all capabilities).
+ * Disable an extension provider (hides its capability contributions from
+ * `/extensions` and everywhere `loadCapability` runs). Does not affect model
+ * discovery or `/login`; those honor the separate `disabledProviders` list.
  */
 export function disableProvider(providerId: string): void {
-	disabledProviders.add(providerId);
-	persistDisabledProviders();
+	disabledExtensionProviders.add(providerId);
+	persistDisabledExtensionProviders();
 }
 
 /**
- * Enable a previously disabled provider.
+ * Re-enable a previously disabled extension provider.
  */
 export function enableProvider(providerId: string): void {
-	disabledProviders.delete(providerId);
-	persistDisabledProviders();
+	disabledExtensionProviders.delete(providerId);
+	persistDisabledExtensionProviders();
 }
 
 /**
- * Check if a provider is enabled.
+ * Check if an extension provider is enabled (capability-registry scope).
  */
 export function isProviderEnabled(providerId: string): boolean {
-	return !disabledProviders.has(providerId);
+	return !disabledExtensionProviders.has(providerId);
 }
 
 /**
- * Get list of all disabled provider IDs.
+ * Get list of all disabled extension provider IDs.
  */
 export function getDisabledProviders(): string[] {
-	return Array.from(disabledProviders);
+	return Array.from(disabledExtensionProviders);
 }
 
 /**
- * Set disabled providers from a list (replaces current set).
+ * Set disabled extension providers from a list (replaces current set).
  */
 export function setDisabledProviders(providerIds: string[]): void {
-	disabledProviders.clear();
+	disabledExtensionProviders.clear();
 	for (const id of providerIds) {
-		disabledProviders.add(id);
+		disabledExtensionProviders.add(id);
 	}
-	persistDisabledProviders();
+	persistDisabledExtensionProviders();
 }
 
 // =============================================================================
@@ -342,7 +352,7 @@ export function getCapabilityInfo(capabilityId: string): CapabilityInfo | undefi
 			displayName: p.displayName,
 			description: p.description,
 			priority: p.priority,
-			enabled: !disabledProviders.has(p.id),
+			enabled: !disabledExtensionProviders.has(p.id),
 		})),
 	};
 }
@@ -379,7 +389,7 @@ export function getProviderInfo(providerId: string): ProviderInfo | undefined {
 		description: meta.description,
 		priority,
 		capabilities: Array.from(caps),
-		enabled: !disabledProviders.has(providerId),
+		enabled: !disabledExtensionProviders.has(providerId),
 	};
 }
 

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -283,7 +283,7 @@ export function initializeWithSettings(activeSettings: Settings): void {
  */
 function persistDisabledExtensionProviders(): void {
 	if (settings) {
-		settings.set("disabledExtensionProviders", Array.from(disabledExtensionProviders));
+		settings.setDisabledExtensionProviders(Array.from(disabledExtensionProviders));
 	}
 }
 

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -207,7 +207,19 @@ async function loadImpl<T>(
 /**
  * Filter providers based on options and disabled state.
  */
+function syncDisabledExtensionProvidersFromSettings(): void {
+	if (!settings) return;
+	disabledExtensionProviders.clear();
+	const source = settings.isConfigured("disabledExtensionProviders")
+		? settings.get("disabledExtensionProviders")
+		: settings.get("disabledProviders");
+	for (const id of source) {
+		disabledExtensionProviders.add(id);
+	}
+}
+
 function filterProviders<T>(capability: Capability<T>, options: LoadOptions): Provider<T>[] {
+	syncDisabledExtensionProvidersFromSettings();
 	let providers = (capability.providers as Provider<T>[]).filter(p => !disabledExtensionProviders.has(p.id));
 
 	if (options.providers) {
@@ -258,18 +270,12 @@ export async function loadCapability<T>(capabilityId: string, options: LoadOptio
  */
 export function initializeWithSettings(activeSettings: Settings): void {
 	settings = activeSettings;
-	disabledExtensionProviders.clear();
 	// Legacy read-through: fall back to `disabledProviders` ONLY when the new
 	// key has never been configured. An explicitly-empty configured value is a
 	// deliberate "extension list is empty" signal (e.g. the user re-enabled
 	// the last provider from `/extensions`) and must NOT roll back to the
 	// model-side list on the next boot.
-	const source = settings.isConfigured("disabledExtensionProviders")
-		? settings.get("disabledExtensionProviders")
-		: settings.get("disabledProviders");
-	for (const id of source) {
-		disabledExtensionProviders.add(id);
-	}
+	syncDisabledExtensionProvidersFromSettings();
 }
 
 /**
@@ -287,6 +293,7 @@ function persistDisabledExtensionProviders(): void {
  * discovery or `/login`; those honor the separate `disabledProviders` list.
  */
 export function disableProvider(providerId: string): void {
+	syncDisabledExtensionProvidersFromSettings();
 	disabledExtensionProviders.add(providerId);
 	persistDisabledExtensionProviders();
 }
@@ -295,6 +302,7 @@ export function disableProvider(providerId: string): void {
  * Re-enable a previously disabled extension provider.
  */
 export function enableProvider(providerId: string): void {
+	syncDisabledExtensionProvidersFromSettings();
 	disabledExtensionProviders.delete(providerId);
 	persistDisabledExtensionProviders();
 }
@@ -303,6 +311,7 @@ export function enableProvider(providerId: string): void {
  * Check if an extension provider is enabled (capability-registry scope).
  */
 export function isProviderEnabled(providerId: string): boolean {
+	syncDisabledExtensionProvidersFromSettings();
 	return !disabledExtensionProviders.has(providerId);
 }
 
@@ -310,6 +319,7 @@ export function isProviderEnabled(providerId: string): boolean {
  * Get list of all disabled extension provider IDs.
  */
 export function getDisabledProviders(): string[] {
+	syncDisabledExtensionProvidersFromSettings();
 	return Array.from(disabledExtensionProviders);
 }
 
@@ -322,6 +332,12 @@ export function setDisabledProviders(providerIds: string[]): void {
 		disabledExtensionProviders.add(id);
 	}
 	persistDisabledExtensionProviders();
+}
+
+/** Reset provider disable state for tests that tear down the Settings singleton. */
+export function resetProviderStateForTests(): void {
+	settings = null;
+	disabledExtensionProviders.clear();
 }
 
 // =============================================================================
@@ -348,6 +364,7 @@ export function listCapabilities(): string[] {
 export function getCapabilityInfo(capabilityId: string): CapabilityInfo | undefined {
 	const capability = capabilities.get(capabilityId);
 	if (!capability) return undefined;
+	syncDisabledExtensionProvidersFromSettings();
 
 	return {
 		id: capability.id,
@@ -377,6 +394,7 @@ export function getProviderInfo(providerId: string): ProviderInfo | undefined {
 	const meta = providerMeta.get(providerId);
 	const caps = providerCapabilities.get(providerId);
 	if (!meta || !caps) return undefined;
+	syncDisabledExtensionProvidersFromSettings();
 
 	// Find priority from first capability's provider list
 	let priority = 0;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -479,6 +479,8 @@ export const SETTINGS_SCHEMA = {
 
 	disabledExtensions: { type: "array", default: EMPTY_STRING_ARRAY },
 
+	disabledExtensionProviders: { type: "array", default: EMPTY_STRING_ARRAY },
+
 	modelRoles: { type: "record", default: EMPTY_STRING_RECORD },
 
 	modelTags: { type: "record", default: EMPTY_MODEL_TAGS_RECORD },

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -676,10 +676,14 @@ export class Settings {
 
 	/**
 	 * Persist the effective extension-provider denylist without flattening
-	 * path-scoped rules for other projects.
+	 * path-scoped rules for other projects. `cwd` selects the workspace whose
+	 * scoped rules are edited (defaults to the active scope); toggles that target
+	 * a different workspace than the live session MUST pass it so the change
+	 * lands in the intended project.
 	 */
-	setDisabledExtensionProviders(ids: string[]): void {
+	setDisabledExtensionProviders(ids: string[], cwd?: string): void {
 		const settingPath = "disabledExtensionProviders";
+		const scope = cwd ? path.normalize(cwd) : this.#cwd;
 		// Base the edit on whichever raw array currently drives the effective
 		// list: the new key when configured, otherwise the legacy
 		// `disabledProviders` shape the registry reads through. Seeding from the
@@ -694,7 +698,7 @@ export class Settings {
 
 		const prev = this.get(settingPath);
 		const desired = new Set(ids);
-		const current = new Set(resolvePathScopedStringArray(settingPath, raw, this.#cwd) ?? []);
+		const current = new Set(resolvePathScopedStringArray(settingPath, raw, scope) ?? []);
 		const removed = new Set(Array.from(current).filter(id => !desired.has(id)));
 		let additions = ids.filter(id => !current.has(id));
 		let wroteAdditions = false;
@@ -716,7 +720,7 @@ export class Settings {
 				...stringArrayFromUnknown(entry.pathPrefix),
 				...stringArrayFromUnknown(entry.pathPrefixes),
 			];
-			if (prefixes.length === 0 || !prefixes.some(prefix => pathMatchesPrefix(this.#cwd, prefix))) {
+			if (prefixes.length === 0 || !prefixes.some(prefix => pathMatchesPrefix(scope, prefix))) {
 				updated.push(entry);
 				continue;
 			}
@@ -743,7 +747,7 @@ export class Settings {
 		}
 
 		if (!wroteAdditions && additions.length > 0) {
-			updated.push({ path: this.#cwd, providers: additions });
+			updated.push({ path: scope, providers: additions });
 		}
 
 		setByPath(this.#global, [settingPath], updated);

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -657,12 +657,36 @@ export class Settings {
 	}
 
 	/**
+	 * Resolve the effective extension-provider denylist against `cwd` (defaults
+	 * to the active scope). Falls back to the legacy `disabledProviders` list
+	 * only while `disabledExtensionProviders` is unconfigured, mirroring the
+	 * capability registry's read-through migration. Resolving against an explicit
+	 * cwd lets provider filtering honor a target workspace's path-scoped rules
+	 * even when the live singleton is scoped elsewhere (e.g. ACP `cloneForCwd`).
+	 */
+	disabledExtensionProvidersForCwd(cwd?: string): string[] {
+		const key: SettingPath = this.isConfigured("disabledExtensionProviders")
+			? "disabledExtensionProviders"
+			: "disabledProviders";
+		const raw = getByPath(this.#merged, SETTING_PATH_SEGMENTS[key]);
+		if (raw === undefined) return [];
+		const target = cwd ? path.normalize(cwd) : this.#cwd;
+		return resolvePathScopedStringArray(key, raw, target) ?? stringArrayFromUnknown(raw);
+	}
+
+	/**
 	 * Persist the effective extension-provider denylist without flattening
 	 * path-scoped rules for other projects.
 	 */
 	setDisabledExtensionProviders(ids: string[]): void {
 		const settingPath = "disabledExtensionProviders";
-		const raw = getByPath(this.#global, SETTING_PATH_SEGMENTS[settingPath]);
+		// Base the edit on whichever raw array currently drives the effective
+		// list: the new key when configured, otherwise the legacy
+		// `disabledProviders` shape the registry reads through. Seeding from the
+		// legacy *raw* structure (not just the active-cwd ids) preserves scoped
+		// rules authored for other projects when the new key is first written.
+		const rawNew = getByPath(this.#global, SETTING_PATH_SEGMENTS[settingPath]);
+		const raw = Array.isArray(rawNew) ? rawNew : getByPath(this.#global, SETTING_PATH_SEGMENTS.disabledProviders);
 		if (!Array.isArray(raw) || !raw.some(isRecord)) {
 			this.set(settingPath, ids);
 			return;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -477,6 +477,12 @@ export class Settings {
 		const normalized = path.normalize(cwd);
 		if (normalized === this.#cwd) return;
 		this.#cwd = normalized;
+		// `#loadProjectSettings()` uses the capability registry, whose provider
+		// filter reads path-scoped settings such as `disabledExtensionProviders`.
+		// Clear cwd-derived cached values before discovery so provider filtering
+		// resolves against the destination cwd instead of the previous project.
+		this.#resolvedCache.clear();
+		this.#editVariantCache = undefined;
 		if (this.#persist) {
 			this.#project = await this.#loadProjectSettings();
 		}

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -477,13 +477,14 @@ export class Settings {
 		const normalized = path.normalize(cwd);
 		if (normalized === this.#cwd) return;
 		this.#cwd = normalized;
-		// `#loadProjectSettings()` uses the capability registry, whose provider
-		// filter reads path-scoped settings such as `disabledExtensionProviders`.
-		// Clear cwd-derived cached values before discovery so provider filtering
-		// resolves against the destination cwd instead of the previous project.
-		this.#resolvedCache.clear();
-		this.#editVariantCache = undefined;
 		if (this.#persist) {
+			// Project-settings discovery is provider-filtered. Remove the previous
+			// project layer before loading the destination so its
+			// `disabledExtensionProviders` cannot hide the provider needed to read
+			// the new project's settings. Rebuilding also clears cwd-derived caches
+			// while retaining global, overlay, and runtime-override layers.
+			this.#project = {};
+			this.#rebuildMerged();
 			this.#project = await this.#loadProjectSettings();
 		}
 		this.#rebuildMerged();
@@ -653,6 +654,80 @@ export class Settings {
 	 */
 	setDisabledProviders(ids: string[]): void {
 		this.set("disabledProviders", ids);
+	}
+
+	/**
+	 * Persist the effective extension-provider denylist without flattening
+	 * path-scoped rules for other projects.
+	 */
+	setDisabledExtensionProviders(ids: string[]): void {
+		const settingPath = "disabledExtensionProviders";
+		const raw = getByPath(this.#global, SETTING_PATH_SEGMENTS[settingPath]);
+		if (!Array.isArray(raw) || !raw.some(isRecord)) {
+			this.set(settingPath, ids);
+			return;
+		}
+
+		const prev = this.get(settingPath);
+		const desired = new Set(ids);
+		const current = new Set(resolvePathScopedStringArray(settingPath, raw, this.#cwd) ?? []);
+		const removed = new Set(Array.from(current).filter(id => !desired.has(id)));
+		let additions = ids.filter(id => !current.has(id));
+		let wroteAdditions = false;
+		const updated: unknown[] = [];
+
+		for (const entry of raw) {
+			if (typeof entry === "string") {
+				if (!removed.has(entry)) updated.push(entry);
+				continue;
+			}
+			if (!isRecord(entry)) {
+				updated.push(entry);
+				continue;
+			}
+
+			const prefixes = [
+				...stringArrayFromUnknown(entry.path),
+				...stringArrayFromUnknown(entry.paths),
+				...stringArrayFromUnknown(entry.pathPrefix),
+				...stringArrayFromUnknown(entry.pathPrefixes),
+			];
+			if (prefixes.length === 0 || !prefixes.some(prefix => pathMatchesPrefix(this.#cwd, prefix))) {
+				updated.push(entry);
+				continue;
+			}
+
+			const next = { ...entry };
+			if (next.values !== undefined) {
+				next.values = stringArrayFromUnknown(next.values).filter(id => !removed.has(id));
+			}
+			if (next.items !== undefined) {
+				next.items = stringArrayFromUnknown(next.items).filter(id => !removed.has(id));
+			}
+			if (next.providers !== undefined) {
+				next.providers = stringArrayFromUnknown(next.providers).filter(id => !removed.has(id));
+			}
+
+			if (!wroteAdditions && additions.length > 0) {
+				const target = next.providers !== undefined ? "providers" : next.values !== undefined ? "values" : "items";
+				const existing = stringArrayFromUnknown(next[target]);
+				next[target] = Array.from(new Set([...existing, ...additions]));
+				additions = [];
+				wroteAdditions = true;
+			}
+			updated.push(next);
+		}
+
+		if (!wroteAdditions && additions.length > 0) {
+			updated.push({ path: this.#cwd, providers: additions });
+		}
+
+		setByPath(this.#global, [settingPath], updated);
+		this.#modified.add(settingPath);
+		this.#rebuildMerged();
+		const next = this.get(settingPath);
+		this.#queueSave();
+		this.#fireEffectiveSettingChanged(settingPath, next, prev);
 	}
 
 	// ─────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -137,7 +137,11 @@ export function validateProviderMaxInFlightRequests(value: unknown): Record<stri
 	return normalized;
 }
 
-const PATH_SCOPED_ARRAY_SETTINGS = new Set<SettingPath>(["enabledModels", "disabledProviders"]);
+const PATH_SCOPED_ARRAY_SETTINGS: Partial<Record<SettingPath, true>> = {
+	enabledModels: true,
+	disabledProviders: true,
+	disabledExtensionProviders: true,
+};
 type PathScopedStringArrayEntry = {
 	path?: unknown;
 	paths?: unknown;
@@ -178,7 +182,7 @@ type EditVariantEntry = {
 };
 
 function resolvePathScopedStringArray(settingPath: SettingPath, value: unknown, cwd: string): string[] | undefined {
-	if (!PATH_SCOPED_ARRAY_SETTINGS.has(settingPath) || !Array.isArray(value)) return undefined;
+	if (!PATH_SCOPED_ARRAY_SETTINGS[settingPath] || !Array.isArray(value)) return undefined;
 
 	const resolved: string[] = [];
 	for (const entry of value) {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -686,6 +686,25 @@ export class Settings {
 	}
 
 	/**
+	 * Resolve the effective extension-provider denylist against `cwd`, loading the
+	 * target workspace's own project settings layer when `cwd` differs from the
+	 * active scope. Use this from display/listing paths (ACP `_omp/extensions`,
+	 * cross-project dashboard loads) so a target project's local
+	 * `.omp/settings.json` `disabledExtensionProviders` is honored instead of the
+	 * synchronous {@link disabledExtensionProvidersForCwd}, which can only see
+	 * global/overlay path-scoped rules for a foreign cwd. Falls back to the sync
+	 * resolution for the active scope and for non-persisted (in-memory) instances.
+	 */
+	async disabledExtensionProvidersForCwdAsync(cwd?: string): Promise<string[]> {
+		const target = cwd ? path.normalize(cwd) : this.#cwd;
+		if (target === this.#cwd || !this.#persist) {
+			return this.disabledExtensionProvidersForCwd(cwd);
+		}
+		const scoped = await this.cloneForCwd(target);
+		return scoped.disabledExtensionProvidersForCwd();
+	}
+
+	/**
 	 * Persist the effective extension-provider denylist without flattening
 	 * path-scoped rules for other projects. `cwd` selects the workspace whose
 	 * scoped rules are edited (defaults to the active scope); toggles that target

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -660,17 +660,28 @@ export class Settings {
 	 * Resolve the effective extension-provider denylist against `cwd` (defaults
 	 * to the active scope). Falls back to the legacy `disabledProviders` list
 	 * only while `disabledExtensionProviders` is unconfigured, mirroring the
-	 * capability registry's read-through migration. Resolving against an explicit
-	 * cwd lets provider filtering honor a target workspace's path-scoped rules
-	 * even when the live singleton is scoped elsewhere (e.g. ACP `cloneForCwd`).
+	 * capability registry's read-through migration.
+	 *
+	 * When `cwd` differs from the active scope (ACP `_omp/extensions`,
+	 * `cloneForCwd` opening another workspace), the active `#project` layer is
+	 * excluded: its values were loaded for a different workspace and a
+	 * project-local `disabledExtensionProviders` there must not leak into another
+	 * project's resolution. Path-scoped rules in global/overlay config — the
+	 * intended cross-project mechanism — still resolve against the target cwd.
 	 */
 	disabledExtensionProvidersForCwd(cwd?: string): string[] {
-		const key: SettingPath = this.isConfigured("disabledExtensionProviders")
-			? "disabledExtensionProviders"
-			: "disabledProviders";
-		const raw = getByPath(this.#merged, SETTING_PATH_SEGMENTS[key]);
-		if (raw === undefined) return [];
 		const target = cwd ? path.normalize(cwd) : this.#cwd;
+		const source =
+			target === this.#cwd
+				? this.#merged
+				: this.#deepMerge(this.#deepMerge(this.#deepMerge({}, this.#global), this.#configOverlay), this.#overrides);
+		let key: SettingPath = "disabledExtensionProviders";
+		let raw = getByPath(source, SETTING_PATH_SEGMENTS[key]);
+		if (raw === undefined) {
+			key = "disabledProviders";
+			raw = getByPath(source, SETTING_PATH_SEGMENTS[key]);
+		}
+		if (raw === undefined) return [];
 		return resolvePathScopedStringArray(key, raw, target) ?? stringArrayFromUnknown(raw);
 	}
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -976,11 +976,12 @@ export class AcpAgent implements Agent {
 			case "_omp/extensions/toggle": {
 				const providerId = params.providerId;
 				if (typeof providerId !== "string") throw new Error("providerId required");
+				const cwd = typeof params.cwd === "string" ? (params.cwd as string) : undefined;
 				if (params.enabled === false) {
-					disableProvider(providerId);
+					disableProvider(providerId, cwd);
 					return { enabled: false };
 				}
-				enableProvider(providerId);
+				enableProvider(providerId, cwd);
 				return { enabled: true };
 			}
 			default:

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -357,7 +357,7 @@ export class ExtensionDashboard implements Component {
 	}
 
 	#applyDisabledExtensions(disabledIds: string[]): void {
-		this.#state = applyDisabledExtensionsToState(this.#state, disabledIds);
+		this.#state = applyDisabledExtensionsToState(this.#state, disabledIds, this.cwd);
 		this.#mainList.setExtensions(this.#state.searchFiltered);
 		if (this.#state.selected) {
 			this.#inspector.setExtension(this.#state.selected);

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -257,7 +257,7 @@ export class ExtensionDashboard implements Component {
 	}
 
 	#handleProviderToggle(providerId: string): void {
-		toggleProvider(providerId);
+		toggleProvider(providerId, this.cwd);
 		void this.#refreshFromState();
 	}
 

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -63,7 +63,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const id = makeExtensionId(kind, item.name);
 			const isDisabled = disabledExtensions.has(id);
 			const isShadowed = (item as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(item._source.provider);
+			const providerEnabled = isProviderEnabled(item._source.provider, cwd);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -169,7 +169,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const sourceSaysDisabled = server.enabled === false && !forced;
 			const isDisabled = mcpDisabledNames.has(server.name) || disabledExtensions.has(id) || sourceSaysDisabled;
 			const isShadowed = (server as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(server._source.provider);
+			const providerEnabled = isProviderEnabled(server._source.provider, cwd);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -234,7 +234,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const id = makeExtensionId("hook", `${hook.type}:${hook.tool}:${hook.name}`);
 			const isDisabled = disabledExtensions.has(id);
 			const isShadowed = (hook as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(hook._source.provider);
+			const providerEnabled = isProviderEnabled(hook._source.provider, cwd);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -279,7 +279,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const id = makeExtensionId("context-file", `${file.level}:${name}`);
 			const isDisabled = disabledExtensions.has(id);
 			const isShadowed = (file as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(file._source.provider);
+			const providerEnabled = isProviderEnabled(file._source.provider, cwd);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -322,8 +322,8 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
  * Build sidebar tree from extensions.
  * Groups by provider → kind.
  */
-export function buildSidebarTree(extensions: Extension[]): TreeNode[] {
-	const providers = getAllProvidersInfo();
+export function buildSidebarTree(extensions: Extension[], cwd?: string): TreeNode[] {
+	const providers = getAllProvidersInfo(cwd);
 	const tree: TreeNode[] = [];
 
 	// Group extensions by provider and kind
@@ -465,8 +465,8 @@ function getKindDisplayName(kind: ExtensionKind): string {
 /**
  * Build provider tabs from extensions.
  */
-export function buildProviderTabs(extensions: Extension[]): ProviderTab[] {
-	const providers = getAllProvidersInfo();
+export function buildProviderTabs(extensions: Extension[], cwd?: string): ProviderTab[] {
+	const providers = getAllProvidersInfo(cwd);
 	const tabs: ProviderTab[] = [];
 
 	// Count extensions per provider
@@ -538,7 +538,11 @@ function isShadowedExtension(ext: Extension): boolean {
  * Apply setting-backed item disable overrides to an existing dashboard state.
  * This gives the UI immediate feedback while the full capability refresh runs.
  */
-export function applyDisabledExtensionsToState(state: DashboardState, disabledIds: string[]): DashboardState {
+export function applyDisabledExtensionsToState(
+	state: DashboardState,
+	disabledIds: string[],
+	cwd?: string,
+): DashboardState {
 	const disabled = new Set(disabledIds);
 	const updateExtension = (ext: Extension): Extension => {
 		if (disabled.has(ext.id)) {
@@ -547,7 +551,7 @@ export function applyDisabledExtensionsToState(state: DashboardState, disabledId
 		}
 
 		if (ext.state !== "disabled" || ext.disabledReason !== "item-disabled") return ext;
-		if (!isProviderEnabled(ext.source.provider)) {
+		if (!isProviderEnabled(ext.source.provider, cwd)) {
 			return { ...ext, state: "disabled", disabledReason: "provider-disabled" };
 		}
 
@@ -575,7 +579,7 @@ export function applyDisabledExtensionsToState(state: DashboardState, disabledId
  */
 export async function createInitialState(cwd?: string, disabledIds?: string[]): Promise<DashboardState> {
 	const extensions = await loadAllExtensions(cwd, disabledIds);
-	const tabs = buildProviderTabs(extensions);
+	const tabs = buildProviderTabs(extensions, cwd);
 	const tabFiltered = extensions; // "all" tab by default
 	const searchFiltered = tabFiltered;
 
@@ -614,7 +618,7 @@ export async function refreshState(
 	disabledIds?: string[],
 ): Promise<DashboardState> {
 	const extensions = await loadAllExtensions(cwd, disabledIds);
-	const tabs = buildProviderTabs(extensions);
+	const tabs = buildProviderTabs(extensions, cwd);
 
 	// Get current provider from tabs
 	const activeTab = state.tabs[state.activeTabIndex];

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -599,12 +599,12 @@ export async function createInitialState(cwd?: string, disabledIds?: string[]): 
 /**
  * Toggle provider enabled state.
  */
-export function toggleProvider(providerId: string): boolean {
-	if (isProviderEnabled(providerId)) {
-		disableProvider(providerId);
+export function toggleProvider(providerId: string, cwd?: string): boolean {
+	if (isProviderEnabled(providerId, cwd)) {
+		disableProvider(providerId, cwd);
 		return false;
 	} else {
-		enableProvider(providerId);
+		enableProvider(providerId, cwd);
 		return true;
 	}
 }

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -15,6 +15,7 @@ import type { Skill } from "../../../capability/skill";
 import type { SlashCommand } from "../../../capability/slash-command";
 import type { CustomTool } from "../../../capability/tool";
 import type { SourceMeta } from "../../../capability/types";
+import { Settings } from "../../../config/settings";
 import {
 	disableProvider,
 	enableProvider,
@@ -43,11 +44,33 @@ export interface ExtensionSettingsManager {
 }
 
 /**
- * Load all extensions from all capabilities.
+ * Resolve the extension-provider denylist for `cwd`, honoring the target
+ * workspace's own project settings when it differs from the active scope.
+ * Returns an empty set when Settings is uninitialized (mirrors the enabled
+ * default of the singleton-backed provider checks).
  */
-export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): Promise<Extension[]> {
+async function resolveDisabledProviderIds(cwd?: string): Promise<Set<string>> {
+	try {
+		return new Set(await Settings.instance.disabledExtensionProvidersForCwdAsync(cwd));
+	} catch {
+		return new Set<string>();
+	}
+}
+
+/**
+ * Load all extensions from all capabilities. Provider enable/disable labeling is
+ * resolved against `cwd` (honoring a target workspace's project-local rules);
+ * callers that already resolved the set may pass it via `disabledProviderIds` to
+ * avoid a redundant lookup.
+ */
+export async function loadAllExtensions(
+	cwd?: string,
+	disabledIds?: string[],
+	disabledProviderIds?: ReadonlySet<string>,
+): Promise<Extension[]> {
 	const extensions: Extension[] = [];
 	const disabledExtensions = new Set<string>(disabledIds ?? []);
+	const providerDisabled = disabledProviderIds ?? (await resolveDisabledProviderIds(cwd));
 
 	// Helper to convert capability items to extensions
 	function addItems<T extends { name: string; path: string; _source: SourceMeta }>(
@@ -63,7 +86,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const id = makeExtensionId(kind, item.name);
 			const isDisabled = disabledExtensions.has(id);
 			const isShadowed = (item as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(item._source.provider, cwd);
+			const providerEnabled = !providerDisabled.has(item._source.provider);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -169,7 +192,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const sourceSaysDisabled = server.enabled === false && !forced;
 			const isDisabled = mcpDisabledNames.has(server.name) || disabledExtensions.has(id) || sourceSaysDisabled;
 			const isShadowed = (server as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(server._source.provider, cwd);
+			const providerEnabled = !providerDisabled.has(server._source.provider);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -234,7 +257,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const id = makeExtensionId("hook", `${hook.type}:${hook.tool}:${hook.name}`);
 			const isDisabled = disabledExtensions.has(id);
 			const isShadowed = (hook as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(hook._source.provider, cwd);
+			const providerEnabled = !providerDisabled.has(hook._source.provider);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -279,7 +302,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 			const id = makeExtensionId("context-file", `${file.level}:${name}`);
 			const isDisabled = disabledExtensions.has(id);
 			const isShadowed = (file as { _shadowed?: boolean })._shadowed;
-			const providerEnabled = isProviderEnabled(file._source.provider, cwd);
+			const providerEnabled = !providerDisabled.has(file._source.provider);
 
 			let state: ExtensionState;
 			let disabledReason: "shadowed" | "provider-disabled" | "item-disabled" | undefined;
@@ -322,8 +345,8 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
  * Build sidebar tree from extensions.
  * Groups by provider → kind.
  */
-export function buildSidebarTree(extensions: Extension[], cwd?: string): TreeNode[] {
-	const providers = getAllProvidersInfo(cwd);
+export function buildSidebarTree(extensions: Extension[], disabledProviderIds?: ReadonlySet<string>): TreeNode[] {
+	const providers = getAllProvidersInfo();
 	const tree: TreeNode[] = [];
 
 	// Group extensions by provider and kind
@@ -346,6 +369,7 @@ export function buildSidebarTree(extensions: Extension[], cwd?: string): TreeNod
 		// Skip the 'native' provider as it cannot be toggled
 		if (provider.id === "native") continue;
 
+		const providerEnabled = disabledProviderIds ? !disabledProviderIds.has(provider.id) : provider.enabled;
 		const byKind = byProvider.get(provider.id);
 		const kindNodes: TreeNode[] = [];
 		let totalCount = 0;
@@ -357,7 +381,7 @@ export function buildSidebarTree(extensions: Extension[], cwd?: string): TreeNod
 					id: `${provider.id}:${kind}`,
 					label: getKindDisplayName(kind),
 					type: "kind",
-					enabled: provider.enabled,
+					enabled: providerEnabled,
 					collapsed: true,
 					children: [],
 					count: exts.length,
@@ -372,7 +396,7 @@ export function buildSidebarTree(extensions: Extension[], cwd?: string): TreeNod
 			id: provider.id,
 			label: provider.displayName,
 			type: "provider",
-			enabled: provider.enabled,
+			enabled: providerEnabled,
 			collapsed: false,
 			children: kindNodes,
 			count: totalCount,
@@ -465,8 +489,8 @@ function getKindDisplayName(kind: ExtensionKind): string {
 /**
  * Build provider tabs from extensions.
  */
-export function buildProviderTabs(extensions: Extension[], cwd?: string): ProviderTab[] {
-	const providers = getAllProvidersInfo(cwd);
+export function buildProviderTabs(extensions: Extension[], disabledProviderIds?: ReadonlySet<string>): ProviderTab[] {
+	const providers = getAllProvidersInfo();
 	const tabs: ProviderTab[] = [];
 
 	// Count extensions per provider
@@ -491,7 +515,7 @@ export function buildProviderTabs(extensions: Extension[], cwd?: string): Provid
 		tabs.push({
 			id: provider.id,
 			label: provider.displayName,
-			enabled: provider.enabled,
+			enabled: disabledProviderIds ? !disabledProviderIds.has(provider.id) : provider.enabled,
 			count,
 		});
 	}
@@ -578,8 +602,9 @@ export function applyDisabledExtensionsToState(
  * Create initial dashboard state.
  */
 export async function createInitialState(cwd?: string, disabledIds?: string[]): Promise<DashboardState> {
-	const extensions = await loadAllExtensions(cwd, disabledIds);
-	const tabs = buildProviderTabs(extensions, cwd);
+	const providerDisabled = await resolveDisabledProviderIds(cwd);
+	const extensions = await loadAllExtensions(cwd, disabledIds, providerDisabled);
+	const tabs = buildProviderTabs(extensions, providerDisabled);
 	const tabFiltered = extensions; // "all" tab by default
 	const searchFiltered = tabFiltered;
 
@@ -617,8 +642,9 @@ export async function refreshState(
 	cwd?: string,
 	disabledIds?: string[],
 ): Promise<DashboardState> {
-	const extensions = await loadAllExtensions(cwd, disabledIds);
-	const tabs = buildProviderTabs(extensions, cwd);
+	const providerDisabled = await resolveDisabledProviderIds(cwd);
+	const extensions = await loadAllExtensions(cwd, disabledIds, providerDisabled);
+	const tabs = buildProviderTabs(extensions, providerDisabled);
 
 	// Get current provider from tabs
 	const activeTab = state.tabs[state.activeTabIndex];

--- a/packages/coding-agent/test/capability/extension-provider-split.test.ts
+++ b/packages/coding-agent/test/capability/extension-provider-split.test.ts
@@ -141,4 +141,29 @@ describe("capability registry — extension-provider split (#4507)", () => {
 		expect(isProviderEnabled("cursor")).toBe(true);
 		expect(isProviderEnabled("windsurf")).toBe(false);
 	});
+
+	test("isProviderEnabled(cwd) labels providers against the requested workspace", async () => {
+		const projectDir = "/tmp/omp-4507-active";
+		const otherDir = "/tmp/omp-4507-target";
+
+		const settings = await Settings.init({
+			cwd: projectDir,
+			inMemory: true,
+			overrides: {
+				disabledExtensionProviders: [
+					{ pathPrefix: projectDir, providers: ["cursor"] },
+					{ pathPrefix: otherDir, providers: ["windsurf"] },
+				],
+			},
+		});
+		initializeWithSettings(settings);
+
+		// Session stays scoped to projectDir; a display load for otherDir must
+		// label providers against otherDir's mask, not the active singleton cwd.
+		expect(isProviderEnabled("windsurf", otherDir)).toBe(false);
+		expect(isProviderEnabled("cursor", otherDir)).toBe(true);
+		// Active scope still reflects projectDir when cwd is omitted.
+		expect(isProviderEnabled("cursor")).toBe(false);
+		expect(isProviderEnabled("windsurf")).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/capability/extension-provider-split.test.ts
+++ b/packages/coding-agent/test/capability/extension-provider-split.test.ts
@@ -93,6 +93,26 @@ describe("capability registry — extension-provider split (#4507)", () => {
 		expect(getDisabledProviders()).toEqual(["windsurf"]);
 	});
 
+	test("explicitly-empty disabledExtensionProviders is honored over legacy disabledProviders", async () => {
+		// Reproduces the review scenario: user runs with model-side
+		// `disabledProviders: ["cursor"]`, then re-enables the last extension
+		// provider from the `/extensions` UI, which persists
+		// `disabledExtensionProviders: []`. The next boot MUST NOT roll that
+		// choice back by falling through to the legacy list — an explicitly
+		// configured empty value is a deliberate signal.
+		const settings = await Settings.init({
+			inMemory: true,
+			overrides: {
+				disabledProviders: ["cursor"],
+				disabledExtensionProviders: [],
+			},
+		});
+		initializeWithSettings(settings);
+
+		expect(isProviderEnabled("cursor")).toBe(true);
+		expect(getDisabledProviders()).toEqual([]);
+	});
+
 	test("path-scoped disabledExtensionProviders resolves against cwd", async () => {
 		const projectDir = "/tmp/omp-4507-project";
 		const otherDir = "/tmp/omp-4507-other";

--- a/packages/coding-agent/test/capability/extension-provider-split.test.ts
+++ b/packages/coding-agent/test/capability/extension-provider-split.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression test for #4507:
+ * `/extensions` toggle (capability-registry `disableProvider` /
+ * `enableProvider`) must mutate the new `disabledExtensionProviders` list
+ * ONLY — never the model/login `disabledProviders` list. Legacy configs
+ * with only the older key set migrate their value into the new list on
+ * first `initializeWithSettings` so users who wrote `disabledProviders: [x]`
+ * intending "hide everything from x" keep the joint behavior.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	disableProvider,
+	enableProvider,
+	getDisabledProviders,
+	initializeWithSettings,
+	isProviderEnabled,
+} from "@oh-my-pi/pi-coding-agent/capability";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+
+describe("capability registry — extension-provider split (#4507)", () => {
+	afterEach(() => {
+		resetSettingsForTest();
+	});
+
+	test("disableProvider writes disabledExtensionProviders and leaves disabledProviders alone", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		initializeWithSettings(settings);
+
+		disableProvider("cursor");
+
+		expect(settings.get("disabledExtensionProviders")).toEqual(["cursor"]);
+		expect(settings.get("disabledProviders")).toEqual([]);
+		expect(isProviderEnabled("cursor")).toBe(false);
+		expect(getDisabledProviders()).toEqual(["cursor"]);
+
+		enableProvider("cursor");
+		expect(settings.get("disabledExtensionProviders")).toEqual([]);
+		expect(isProviderEnabled("cursor")).toBe(true);
+	});
+
+	test("model-side disabledProviders survives /extensions toggle round-trips", async () => {
+		const settings = await Settings.init({ inMemory: true });
+		initializeWithSettings(settings);
+
+		// Set the model-side list after initialization so the legacy read-through
+		// migration (which fires only when the extension set is empty at init)
+		// doesn't mirror it into the extension set.
+		settings.setDisabledProviders(["github-copilot"]);
+
+		disableProvider("cursor");
+		disableProvider("windsurf");
+		enableProvider("cursor");
+
+		// Model-side list untouched by any extension toggle.
+		expect(settings.get("disabledProviders")).toEqual(["github-copilot"]);
+		expect(settings.get("disabledExtensionProviders")).toEqual(["windsurf"]);
+	});
+
+	test("legacy migration: disabledProviders seeds the extension set when disabledExtensionProviders is empty", async () => {
+		const settings = await Settings.init({
+			inMemory: true,
+			overrides: { disabledProviders: ["cursor", "opencode"] },
+		});
+		initializeWithSettings(settings);
+
+		expect(isProviderEnabled("cursor")).toBe(false);
+		expect(isProviderEnabled("opencode")).toBe(false);
+		expect(getDisabledProviders()).toEqual(["cursor", "opencode"]);
+
+		// Legacy migration is a read-through: the on-disk `disabledProviders`
+		// stays intact until the user explicitly toggles a provider, at which
+		// point only the new key is written.
+		expect(settings.get("disabledProviders")).toEqual(["cursor", "opencode"]);
+		expect(settings.get("disabledExtensionProviders")).toEqual([]);
+
+		disableProvider("windsurf");
+		expect(settings.get("disabledExtensionProviders")).toEqual(["cursor", "opencode", "windsurf"]);
+		expect(settings.get("disabledProviders")).toEqual(["cursor", "opencode"]);
+	});
+
+	test("explicit disabledExtensionProviders wins over legacy disabledProviders", async () => {
+		const settings = await Settings.init({
+			inMemory: true,
+			overrides: {
+				disabledProviders: ["cursor"],
+				disabledExtensionProviders: ["windsurf"],
+			},
+		});
+		initializeWithSettings(settings);
+
+		expect(isProviderEnabled("cursor")).toBe(true);
+		expect(isProviderEnabled("windsurf")).toBe(false);
+		expect(getDisabledProviders()).toEqual(["windsurf"]);
+	});
+
+	test("path-scoped disabledExtensionProviders resolves against cwd", async () => {
+		const projectDir = "/tmp/omp-4507-project";
+		const otherDir = "/tmp/omp-4507-other";
+
+		const settings = await Settings.init({
+			cwd: projectDir,
+			inMemory: true,
+			overrides: {
+				disabledExtensionProviders: [
+					"always",
+					{ pathPrefix: projectDir, providers: ["cursor"] },
+					{ pathPrefix: otherDir, providers: ["windsurf"] },
+				],
+			},
+		});
+
+		expect(settings.get("disabledExtensionProviders")).toEqual(["always", "cursor"]);
+
+		await settings.reloadForCwd(otherDir);
+		expect(settings.get("disabledExtensionProviders")).toEqual(["always", "windsurf"]);
+	});
+});

--- a/packages/coding-agent/test/capability/extension-provider-split.test.ts
+++ b/packages/coding-agent/test/capability/extension-provider-split.test.ts
@@ -14,11 +14,13 @@ import {
 	getDisabledProviders,
 	initializeWithSettings,
 	isProviderEnabled,
+	resetProviderStateForTests,
 } from "@oh-my-pi/pi-coding-agent/capability";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 
 describe("capability registry — extension-provider split (#4507)", () => {
 	afterEach(() => {
+		resetProviderStateForTests();
 		resetSettingsForTest();
 	});
 
@@ -42,9 +44,9 @@ describe("capability registry — extension-provider split (#4507)", () => {
 		const settings = await Settings.init({ inMemory: true });
 		initializeWithSettings(settings);
 
-		// Set the model-side list after initialization so the legacy read-through
-		// migration (which fires only when the extension set is empty at init)
-		// doesn't mirror it into the extension set.
+		// Once the split key is configured, even as an empty list, the model-side
+		// list must stay independent from extension toggles.
+		settings.set("disabledExtensionProviders", []);
 		settings.setDisabledProviders(["github-copilot"]);
 
 		disableProvider("cursor");
@@ -130,8 +132,13 @@ describe("capability registry — extension-provider split (#4507)", () => {
 		});
 
 		expect(settings.get("disabledExtensionProviders")).toEqual(["always", "cursor"]);
+		initializeWithSettings(settings);
+		expect(isProviderEnabled("cursor")).toBe(false);
+		expect(isProviderEnabled("windsurf")).toBe(true);
 
 		await settings.reloadForCwd(otherDir);
 		expect(settings.get("disabledExtensionProviders")).toEqual(["always", "windsurf"]);
+		expect(isProviderEnabled("cursor")).toBe(true);
+		expect(isProviderEnabled("windsurf")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/helpers/settings-test-state.ts
+++ b/packages/coding-agent/test/helpers/settings-test-state.ts
@@ -1,4 +1,5 @@
 import { vi } from "bun:test";
+import { resetProviderStateForTests } from "@oh-my-pi/pi-coding-agent/capability";
 import { resetSettingsForTest } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { isTuiTight, setTuiTight } from "@oh-my-pi/pi-tui";
 import { getAgentDir, getProjectDir, setAgentDir, setProjectDir } from "@oh-my-pi/pi-utils";
@@ -25,12 +26,14 @@ export function beginSettingsTest(): SettingsTestState {
 		tuiTight: isTuiTight(),
 	};
 	resetSettingsForTest();
+	resetProviderStateForTests();
 	return state;
 }
 
 export function restoreSettingsTestState(state: SettingsTestState | undefined): void {
 	vi.restoreAllMocks();
 	resetSettingsForTest();
+	resetProviderStateForTests();
 	if (!state) return;
 
 	restoreEnv(state.env);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -221,6 +221,45 @@ describe("Settings", () => {
 			expect(settings.get("disabledExtensionProviders")).toEqual(["windsurf"]);
 		});
 
+		it("materializes new key from legacy scoped disabledProviders without dropping other-project rules", async () => {
+			const otherDir = path.join(tempDir.toString(), "other-project");
+			await writeSettings({
+				disabledProviders: [
+					{ pathPrefix: projectDir, providers: ["cursor"] },
+					{ pathPrefix: otherDir, providers: ["windsurf"] },
+				],
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			initializeWithSettings(settings);
+			// First /extensions toggle while scoped to project A must not flatten
+			// the legacy scoped shape and lose project B's rule.
+			disableProvider("claude");
+			await settings.flush();
+
+			expect((await readSettings()).disabledExtensionProviders).toEqual([
+				{ pathPrefix: projectDir, providers: ["cursor", "claude"] },
+				{ pathPrefix: otherDir, providers: ["windsurf"] },
+			]);
+
+			await settings.reloadForCwd(otherDir);
+			expect(settings.get("disabledExtensionProviders")).toEqual(["windsurf"]);
+		});
+
+		it("resolves extension-provider mask against an explicit cwd", async () => {
+			const otherDir = path.join(tempDir.toString(), "other-project");
+			await writeSettings({
+				disabledExtensionProviders: [
+					{ pathPrefix: projectDir, providers: ["cursor"] },
+					{ pathPrefix: otherDir, providers: ["windsurf"] },
+				],
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.disabledExtensionProvidersForCwd(projectDir)).toEqual(["cursor"]);
+			expect(settings.disabledExtensionProvidersForCwd(otherDir)).toEqual(["windsurf"]);
+		});
+
 		it("migrates legacy snapcompact system prompt booleans to scoped modes", () => {
 			expect(Settings.isolated({ "snapcompact.systemPrompt": true }).get("snapcompact.systemPrompt")).toBe("all");
 			const nestedLegacy = { snapcompact: { systemPrompt: false } } as Partial<Record<SettingPath, unknown>>;

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -246,6 +246,30 @@ describe("Settings", () => {
 			expect(settings.get("disabledExtensionProviders")).toEqual(["windsurf"]);
 		});
 
+		it("toggling with a target cwd writes into that workspace's scope, not the active one", async () => {
+			const otherDir = path.join(tempDir.toString(), "other-project");
+			await writeSettings({
+				disabledExtensionProviders: [
+					{ pathPrefix: projectDir, providers: ["cursor"] },
+					{ pathPrefix: otherDir, providers: ["windsurf"] },
+				],
+			});
+
+			// Active session is scoped to projectDir; an ACP toggle targets otherDir.
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			initializeWithSettings(settings);
+			disableProvider("claude", otherDir);
+			await settings.flush();
+
+			// projectDir's rule is untouched; the change lands in otherDir's scope.
+			expect((await readSettings()).disabledExtensionProviders).toEqual([
+				{ pathPrefix: projectDir, providers: ["cursor"] },
+				{ pathPrefix: otherDir, providers: ["windsurf", "claude"] },
+			]);
+			expect(settings.disabledExtensionProvidersForCwd(otherDir)).toEqual(["windsurf", "claude"]);
+			expect(settings.disabledExtensionProvidersForCwd(projectDir)).toEqual(["cursor"]);
+		});
+
 		it("resolves extension-provider mask against an explicit cwd", async () => {
 			const otherDir = path.join(tempDir.toString(), "other-project");
 			await writeSettings({

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -6,6 +6,7 @@ import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import { __providerInFlightForTesting, streamSimple } from "@oh-my-pi/pi-ai/stream";
 import type { Context } from "@oh-my-pi/pi-ai/types";
+import { disableProvider, enableProvider, initializeWithSettings } from "@oh-my-pi/pi-coding-agent/capability";
 import {
 	getDefault,
 	getEnumValues,
@@ -175,19 +176,17 @@ describe("Settings", () => {
 			expect(settings.get("disabledProviders")).toEqual(["always-provider", "other-provider"]);
 		});
 
-		it("clears path-scoped provider cache before reloading project settings for a new cwd", async () => {
+		it("clears stale project settings before provider-filtered reloads", async () => {
 			const otherDir = path.join(tempDir.toString(), "other-project");
 			fs.mkdirSync(getProjectAgentDir(otherDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "settings.json"),
+				JSON.stringify({ disabledExtensionProviders: ["native"] }),
+			);
 			await Bun.write(
 				path.join(getProjectAgentDir(otherDir), "settings.json"),
 				JSON.stringify({ terminal: { showProgress: true } }),
 			);
-			await writeSettings({
-				disabledExtensionProviders: [
-					{ pathPrefix: projectDir, providers: ["native"] },
-					{ pathPrefix: otherDir, providers: [] },
-				],
-			});
 
 			const settings = await Settings.init({ cwd: projectDir, agentDir });
 			expect(settings.get("disabledExtensionProviders")).toEqual(["native"]);
@@ -196,6 +195,30 @@ describe("Settings", () => {
 
 			expect(settings.get("disabledExtensionProviders")).toEqual([]);
 			expect(settings.get("terminal.showProgress")).toBe(true);
+		});
+
+		it("preserves unmatched scoped extension-provider rules when toggling", async () => {
+			const otherDir = path.join(tempDir.toString(), "other-project");
+			await writeSettings({
+				disabledExtensionProviders: [
+					{ pathPrefix: projectDir, providers: ["cursor"] },
+					{ pathPrefix: otherDir, providers: ["windsurf"] },
+				],
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			initializeWithSettings(settings);
+			enableProvider("cursor");
+			disableProvider("claude");
+			await settings.flush();
+
+			expect((await readSettings()).disabledExtensionProviders).toEqual([
+				{ pathPrefix: projectDir, providers: ["claude"] },
+				{ pathPrefix: otherDir, providers: ["windsurf"] },
+			]);
+
+			await settings.reloadForCwd(otherDir);
+			expect(settings.get("disabledExtensionProviders")).toEqual(["windsurf"]);
 		});
 
 		it("migrates legacy snapcompact system prompt booleans to scoped modes", () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -175,6 +175,29 @@ describe("Settings", () => {
 			expect(settings.get("disabledProviders")).toEqual(["always-provider", "other-provider"]);
 		});
 
+		it("clears path-scoped provider cache before reloading project settings for a new cwd", async () => {
+			const otherDir = path.join(tempDir.toString(), "other-project");
+			fs.mkdirSync(getProjectAgentDir(otherDir), { recursive: true });
+			await Bun.write(
+				path.join(getProjectAgentDir(otherDir), "settings.json"),
+				JSON.stringify({ terminal: { showProgress: true } }),
+			);
+			await writeSettings({
+				disabledExtensionProviders: [
+					{ pathPrefix: projectDir, providers: ["native"] },
+					{ pathPrefix: otherDir, providers: [] },
+				],
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("disabledExtensionProviders")).toEqual(["native"]);
+
+			await settings.reloadForCwd(otherDir);
+
+			expect(settings.get("disabledExtensionProviders")).toEqual([]);
+			expect(settings.get("terminal.showProgress")).toBe(true);
+		});
+
 		it("migrates legacy snapcompact system prompt booleans to scoped modes", () => {
 			expect(Settings.isolated({ "snapcompact.systemPrompt": true }).get("snapcompact.systemPrompt")).toBe("all");
 			const nestedLegacy = { snapcompact: { systemPrompt: false } } as Partial<Record<SettingPath, unknown>>;

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -284,6 +284,22 @@ describe("Settings", () => {
 			expect(settings.disabledExtensionProvidersForCwd(otherDir)).toEqual(["windsurf"]);
 		});
 
+		it("does not leak the active project's disabledExtensionProviders into another cwd", async () => {
+			const otherDir = path.join(tempDir.toString(), "other-project");
+			fs.mkdirSync(getProjectAgentDir(otherDir), { recursive: true });
+			// projectDir carries a project-LOCAL rule (only valid inside projectDir).
+			await Bun.write(
+				path.join(getProjectAgentDir(projectDir), "settings.json"),
+				JSON.stringify({ disabledExtensionProviders: ["cursor"] }),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			// Active scope sees its own project-local rule.
+			expect(settings.disabledExtensionProvidersForCwd(projectDir)).toEqual(["cursor"]);
+			// A different workspace must NOT inherit projectDir's project-local rule.
+			expect(settings.disabledExtensionProvidersForCwd(otherDir)).toEqual([]);
+		});
+
 		it("migrates legacy snapcompact system prompt booleans to scoped modes", () => {
 			expect(Settings.isolated({ "snapcompact.systemPrompt": true }).get("snapcompact.systemPrompt")).toBe("all");
 			const nestedLegacy = { snapcompact: { systemPrompt: false } } as Partial<Record<SettingPath, unknown>>;

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -300,6 +300,24 @@ describe("Settings", () => {
 			expect(settings.disabledExtensionProvidersForCwd(otherDir)).toEqual([]);
 		});
 
+		it("honors a target workspace's project-local disabledExtensionProviders via the async resolver", async () => {
+			const otherDir = path.join(tempDir.toString(), "other-project");
+			fs.mkdirSync(getProjectAgentDir(otherDir), { recursive: true });
+			// otherDir has its OWN project-local rule; the active session is in projectDir.
+			await Bun.write(
+				path.join(getProjectAgentDir(otherDir), "settings.json"),
+				JSON.stringify({ disabledExtensionProviders: ["cursor"] }),
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			// The sync accessor cannot see otherDir's project file from projectDir's scope.
+			expect(settings.disabledExtensionProvidersForCwd(otherDir)).toEqual([]);
+			// The async resolver loads otherDir's project layer and honors its rule.
+			expect(await settings.disabledExtensionProvidersForCwdAsync(otherDir)).toEqual(["cursor"]);
+			// The active scope is unaffected.
+			expect(await settings.disabledExtensionProvidersForCwdAsync(projectDir)).toEqual([]);
+		});
+
 		it("migrates legacy snapcompact system prompt booleans to scoped modes", () => {
 			expect(Settings.isolated({ "snapcompact.systemPrompt": true }).get("snapcompact.systemPrompt")).toBe("all");
 			const nestedLegacy = { snapcompact: { systemPrompt: false } } as Partial<Record<SettingPath, unknown>>;


### PR DESCRIPTION
## Repro

`omp` currently gates two independent surfaces through the single `disabledProviders` set: the `/extensions` provider tabs (skills, rules, MCP servers, hooks, tools, prompts, context files, slash commands) and the model/login provider filter used by the model picker, `/login`, `/logout`, and local-discovery gates for Ollama / llama.cpp / LM Studio.

Toggling `cursor` off in `/extensions` — which the reporter did to hide the vendor's rules/MCP/context files — also removes every `cursor/*` chat model from the model picker and drops `cursor` from `/login`. There is no way to say "hide cursor's extension contributions but keep me logged in for its models".

## Cause

One `disabledProviders` set lives in `packages/coding-agent/src/capability/index.ts`:

- `filterProviders()` (line 210) drops the provider from every `loadCapability` call.
- The `/extensions` dashboard's provider tabs call `toggleProvider()` (`modes/components/extensions/state-manager.ts:598`) → `disableProvider()`, which persists to `disabledProviders`.
- The same `disabledProviders` value is re-read by `getDisabledProviderIdsFromSettings()` in `config/model-registry.ts` (implicit discovery, standard/special descriptors, availability check) and by the `/login` OAuth selector (`modes/components/oauth-selector.ts:29`).

Because everything reads the same list, an extension-tab toggle unavoidably reaches the model side.

## Fix

- Added a dedicated `disabledExtensionProviders` array setting in `config/settings-schema.ts`. Path-scoped resolution (`config/settings.ts`) extended to include it, sharing the same `{ path/pathPrefix, providers | values | items }` shape as `disabledProviders`.
- `capability/index.ts` swapped over to the new list: `disableProvider`, `enableProvider`, `isProviderEnabled`, `setDisabledProviders`, `getDisabledProviders`, `filterProviders`, and the `getCapabilityInfo` / `getProviderInfo` introspection surface all read/write `disabledExtensionProviders`.
- `initializeWithSettings` performs a read-through legacy migration: when `disabledExtensionProviders` is empty at init, it seeds from `disabledProviders`. Users who wrote `disabledProviders: [cursor]` intending "hide everything from cursor" keep the joint behavior until they explicitly toggle a provider from the `/extensions` UI. Subsequent toggles write only to the new key.
- Model/login sites (`config/model-registry.ts`, `modes/components/oauth-selector.ts`, path-scoped settings for the model side) are untouched — they still read `disabledProviders`.
- CHANGELOG entry under `[Unreleased]` explaining the split and legacy behavior.
- Converted the pre-existing `PATH_SCOPED_ARRAY_SETTINGS` `Set` to a `Partial<Record<SettingPath, true>>` in the same file per the project's static-set-map rule.

Consumer paths verified untouched by the split:

- `_omp/extensions/toggle` in `modes/acp/acp-agent.ts` calls the same `disableProvider`/`enableProvider`, which now mutates the new key only.
- Settings-menu discovery toggles (`selector-controller.ts` `discovery.<providerId>`) go through the same registry API.
- `task/discovery.ts` `omp-plugins` / `claude-plugins` guards read `isProviderEnabled`, which now reflects the new key — extension-only providers, so unchanged intent.

## Verification

- `bun test test/capability/ test/discovery/ test/task/discovery.test.ts test/modes/components/oauth-selector.test.ts test/settings-manager.test.ts test/model-registry.test.ts test/repro-issue-1022-disabled-default-model.test.ts` → 303 pass, 0 fail (5.8 s).
- New `test/capability/extension-provider-split.test.ts` covers the five load-bearing invariants: extension toggle writes only to the new key, model-side `disabledProviders` survives extension round-trips, legacy migration copies old → new when the new list is empty, explicit `disabledExtensionProviders` overrides the legacy read-through, and path-scoped resolution works against `cwd`.
- `bun run check` (root) → passed.

Fixes #4507