### PR TITLE
fix(coding-agent): handle inline image PDF delimiters

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed raw `read` ranges not contributing to edit seen-line provenance, so re-reading an anchor range with `:raw` now unblocks hashline edits without adding non-raw line prefixes.
+- Fixed `omp read` hanging on PDFs whose inline-image binary payload contains delimiter-looking bytes, while preserving text and table extraction after the image. ([#4512](https://github.com/can1357/oh-my-pi/issues/4512))
 - Fixed replan-driven session title refresh updating the statusline but not the terminal window title: terminal-title updates now fire from the session-name-changed listener, so every `setSessionName` path (first-input titling, `/rename`, plan seeding, replan refresh) sets the OSC title consistently.
 - Fixed user-interrupt aborts rendering the persisted `Interrupted by user` label in assistant transcripts; replay and live views now suppress that redundant line again while preserving generic/custom abort labels.
 - Fixed streamed assistant text and thinking disappearing from terminal scrollback while a long turn ran, and Ctrl+O-expanded tool results showing up half-rendered above the viewport: everything that scrolls off the window now reaches native scrollback (exact bytes for settled content, a frozen what-you-saw snapshot for still-running blocks, repaired at most once when the block finalizes). Streaming eval/bash boxes no longer spray duplicated stale copies; user-initiated `!`/`$` execution blocks report a finalization contract.

--- a/packages/coding-agent/src/markit/converters/pdf/extract.ts
+++ b/packages/coding-agent/src/markit/converters/pdf/extract.ts
@@ -398,12 +398,13 @@ function extractSegmentsFromContentStream(raw: string, pageNumber: number): Segm
 
 /**
  * Fast tokenizer for PDF content streams.
- * Splits on whitespace, skipping comments and string literals.
+ * Splits on whitespace, skipping comments, string literals, and inline image payloads.
  */
 function tokenizeContentStream(raw: string): string[] {
 	const tokens: string[] = [];
 	const len = raw.length;
 	let i = 0;
+	let inInlineImage = false;
 	while (i < len) {
 		const ch = raw.charCodeAt(i);
 		// Skip whitespace
@@ -449,6 +450,12 @@ function tokenizeContentStream(raw: string): string[] {
 			i += 2;
 			continue;
 		}
+		// Skip stray closing delimiters from malformed streams. They cannot start
+		// a token, so leaving i unchanged would spin forever.
+		if (ch === 41 || ch === 62) {
+			i++;
+			continue;
+		}
 		// Regular token: read until whitespace or delimiter
 		const start = i;
 		while (i < len) {
@@ -457,7 +464,24 @@ function tokenizeContentStream(raw: string): string[] {
 			i++;
 		}
 		if (i > start) {
-			tokens.push(raw.substring(start, i));
+			const token = raw.substring(start, i);
+			tokens.push(token);
+			if (token === "BI") {
+				inInlineImage = true;
+			} else if (token === "ID" && inInlineImage) {
+				while (i < len && raw.charCodeAt(i) <= 32) i++;
+				while (i < len) {
+					const c = raw.charCodeAt(i);
+					const prev = i === 0 ? 32 : raw.charCodeAt(i - 1);
+					const next = i + 2 >= len ? 32 : raw.charCodeAt(i + 2);
+					if (c === 69 && raw.charCodeAt(i + 1) === 73 && prev <= 32 && next <= 32) {
+						i += 2;
+						break;
+					}
+					i++;
+				}
+				inInlineImage = false;
+			}
 		}
 	}
 	return tokens;

--- a/packages/coding-agent/test/fixtures/pdf-inline-image-repro/bad-inline-image-delimiter.pdf
+++ b/packages/coding-agent/test/fixtures/pdf-inline-image-repro/bad-inline-image-delimiter.pdf
@@ -1,0 +1,51 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 401 >>
+stream
+BT /F1 16 Tf 72 730 Td (Inline image tokenizer repro issue) Tj ET
+q
+BI
+/W 5 /H 1 /CS /DeviceGray /BPC 8
+ID
+#>5G
+EI
+Q
+0.5 w
+100 650 m 260 650 l S
+100 620 m 260 620 l S
+100 590 m 260 590 l S
+100 650 m 100 590 l S
+180 650 m 180 590 l S
+260 650 m 260 590 l S
+BT /F1 10 Tf 115 633 Td (Name) Tj ET
+BT /F1 10 Tf 195 633 Td (Qty) Tj ET
+BT /F1 10 Tf 115 603 Td (Wire) Tj ET
+BT /F1 10 Tf 195 603 Td (12) Tj ET
+
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+763
+%%EOF

--- a/packages/coding-agent/test/markit-converters.test.ts
+++ b/packages/coding-agent/test/markit-converters.test.ts
@@ -155,6 +155,9 @@ describe("markit converters", () => {
 
 	it("reads PDF text after inline image binary data containing delimiter bytes", async () => {
 		const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-pdf-inline-home-"));
+		const homeRoot = path.parse(homeDir).root;
+		const homeDrive = homeRoot.endsWith(path.sep) ? homeRoot.slice(0, -1) : homeRoot;
+		const homePath = homeDir.slice(homeDrive.length) || path.sep;
 		try {
 			const pdfPath = path.join(
 				import.meta.dir,
@@ -168,7 +171,12 @@ describe("markit converters", () => {
 				stderr: "pipe",
 				env: {
 					...process.env,
+					APPDATA: path.join(homeDir, "AppData", "Roaming"),
 					HOME: homeDir,
+					HOMEDRIVE: homeDrive,
+					HOMEPATH: homePath,
+					LOCALAPPDATA: path.join(homeDir, "AppData", "Local"),
+					USERPROFILE: homeDir,
 					NO_COLOR: "1",
 					OMP_PROFILE: "",
 					PI_CODING_AGENT_DIR: path.join(homeDir, ".omp", "agent"),

--- a/packages/coding-agent/test/markit-converters.test.ts
+++ b/packages/coding-agent/test/markit-converters.test.ts
@@ -154,41 +154,58 @@ describe("markit converters", () => {
 	});
 
 	it("reads PDF text after inline image binary data containing delimiter bytes", async () => {
-		const pdfPath = path.join(
-			import.meta.dir,
-			"fixtures",
-			"pdf-inline-image-repro",
-			"bad-inline-image-delimiter.pdf",
-		);
-		const proc = Bun.spawn([process.execPath, cliEntry, "read", pdfPath], {
-			cwd: repoRoot,
-			stdout: "pipe",
-			stderr: "pipe",
-			env: { ...process.env, NO_COLOR: "1", PI_NO_TITLE: "1" },
-		});
-		const stdout = new Response(proc.stdout).text();
-		const stderr = new Response(proc.stderr).text();
-		// The regression is a synchronous child-process spin; there is no in-process signal to await.
-		const outcome = await Promise.race([
-			proc.exited.then(exitCode => ({ type: "exit" as const, exitCode })),
-			Bun.sleep(5_000).then(() => ({ type: "timeout" as const })),
-		]);
-		if (outcome.type === "timeout") {
-			try {
-				proc.kill("SIGKILL");
-			} catch {
-				// already exited
+		const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-pdf-inline-home-"));
+		try {
+			const pdfPath = path.join(
+				import.meta.dir,
+				"fixtures",
+				"pdf-inline-image-repro",
+				"bad-inline-image-delimiter.pdf",
+			);
+			const proc = Bun.spawn([process.execPath, cliEntry, "read", pdfPath], {
+				cwd: repoRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					HOME: homeDir,
+					NO_COLOR: "1",
+					OMP_PROFILE: "",
+					PI_CODING_AGENT_DIR: path.join(homeDir, ".omp", "agent"),
+					PI_CONFIG_DIR: ".omp",
+					PI_NO_TITLE: "1",
+					PI_PROFILE: "",
+					XDG_CACHE_HOME: path.join(homeDir, ".cache"),
+					XDG_DATA_HOME: path.join(homeDir, ".local", "share"),
+					XDG_STATE_HOME: path.join(homeDir, ".local", "state"),
+				},
+			});
+			const stdout = new Response(proc.stdout).text();
+			const stderr = new Response(proc.stderr).text();
+			// The regression is a synchronous child-process spin; there is no in-process signal to await.
+			const outcome = await Promise.race([
+				proc.exited.then(exitCode => ({ type: "exit" as const, exitCode })),
+				Bun.sleep(5_000).then(() => ({ type: "timeout" as const })),
+			]);
+			if (outcome.type === "timeout") {
+				try {
+					proc.kill("SIGKILL");
+				} catch {
+					// already exited
+				}
+				await proc.exited;
+				throw new Error("read command timed out on inline image PDF");
 			}
-			await proc.exited;
-			throw new Error("read command timed out on inline image PDF");
-		}
 
-		const [out, err] = await Promise.all([stdout, stderr]);
-		expect(outcome.exitCode).toBe(0);
-		expect(err).toBe("");
-		expect(out).toContain("Inline image tokenizer repro issue");
-		expect(out).toContain("| Name | Qty |");
-		expect(out).toContain("| Wire | 12 |");
+			const [out, err] = await Promise.all([stdout, stderr]);
+			expect(outcome.exitCode).toBe(0);
+			expect(err).toBe("");
+			expect(out).toContain("Inline image tokenizer repro issue");
+			expect(out).toContain("| Name | Qty |");
+			expect(out).toContain("| Wire | 12 |");
+		} finally {
+			await removeWithRetries(homeDir);
+		}
 	});
 
 	it("reports an unsupported format instead of emitting garbage", async () => {

--- a/packages/coding-agent/test/markit-converters.test.ts
+++ b/packages/coding-agent/test/markit-converters.test.ts
@@ -17,7 +17,8 @@ import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
 const WML = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
-
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
 function makeDocx(bodyXml: string): Uint8Array {
 	return zip({
 		"[Content_Types].xml": enc(
@@ -150,6 +151,44 @@ describe("markit converters", () => {
 		// normalizeTablesHtml promotes the first row to a header so GFM renders a table.
 		expect(result.content).toContain("| A | B |");
 		expect(result.content).toContain("| --- | --- |");
+	});
+
+	it("reads PDF text after inline image binary data containing delimiter bytes", async () => {
+		const pdfPath = path.join(
+			import.meta.dir,
+			"fixtures",
+			"pdf-inline-image-repro",
+			"bad-inline-image-delimiter.pdf",
+		);
+		const proc = Bun.spawn([process.execPath, cliEntry, "read", pdfPath], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, NO_COLOR: "1", PI_NO_TITLE: "1" },
+		});
+		const stdout = new Response(proc.stdout).text();
+		const stderr = new Response(proc.stderr).text();
+		// The regression is a synchronous child-process spin; there is no in-process signal to await.
+		const outcome = await Promise.race([
+			proc.exited.then(exitCode => ({ type: "exit" as const, exitCode })),
+			Bun.sleep(5_000).then(() => ({ type: "timeout" as const })),
+		]);
+		if (outcome.type === "timeout") {
+			try {
+				proc.kill("SIGKILL");
+			} catch {
+				// already exited
+			}
+			await proc.exited;
+			throw new Error("read command timed out on inline image PDF");
+		}
+
+		const [out, err] = await Promise.all([stdout, stderr]);
+		expect(outcome.exitCode).toBe(0);
+		expect(err).toBe("");
+		expect(out).toContain("Inline image tokenizer repro issue");
+		expect(out).toContain("| Name | Qty |");
+		expect(out).toContain("| Wire | 12 |");
 	});
 
 	it("reports an unsupported format instead of emitting garbage", async () => {


### PR DESCRIPTION
## Repro
`timeout 10 bun src/cli.ts read test/fixtures/pdf-inline-image-repro/bad-inline-image-delimiter.pdf` reproduced the hang before the fix: no stdout/stderr and exit `124` after 10.07s, while the control PDF returned the expected table markdown in 0.82s.

## Cause
`packages/coding-agent/src/markit/converters/pdf/extract.ts` tokenized the whole raw PDF content stream as text. Inline image payload bytes after the `ID` operator were scanned as normal operator text, so a delimiter-looking byte such as standalone `>` could enter the regular-token scanner, break without advancing `i`, and spin forever.

## Fix
- Skip inline image payload bytes after `BI ... ID` until a whitespace-delimited `EI` terminator, then resume tokenizing post-image drawing/text operators.
- Advance past stray standalone `)` and `>` delimiters while recovering malformed content streams to avoid zero-width tokenizer iterations.
- Add a regression fixture and CLI-level converter test that verifies the bad PDF returns and preserves visible heading/table content after the inline image.
- Add the coding-agent changelog entry for issue #4512.

## Verification
`bun test test/markit-converters.test.ts` passed with 8 tests and 30 assertions; `timeout 10 bun src/cli.ts read test/fixtures/pdf-inline-image-repro/bad-inline-image-delimiter.pdf` completed in 0.51s and emitted the expected heading/table markdown; `bun check` passed. Fixes #4512