### PR TITLE
fix(tool): reject root glob paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed `glob path:"/"` and `path:"//"` returning ordinary empty results by rejecting slash-only root searches with the documented error. ([#4516](https://github.com/can1357/oh-my-pi/issues/4516))
+
 - Fixed raw `read` ranges not contributing to edit seen-line provenance, so re-reading an anchor range with `:raw` now unblocks hashline edits without adding non-raw line prefixes.
 - Fixed replan-driven session title refresh updating the statusline but not the terminal window title: terminal-title updates now fire from the session-name-changed listener, so every `setSessionName` path (first-input titling, `/rename`, plan seeding, replan refresh) sets the OSC title consistently.
 - Fixed user-interrupt aborts rendering the persisted `Interrupted by user` label in assistant transcripts; replay and live views now suppress that redundant line again while preserving generic/custom abort labels.

--- a/packages/coding-agent/src/tools/__tests__/glob.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/glob.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { Settings } from "../../config/settings";
+import type { ToolSession } from "..";
+import { GlobTool } from "../glob";
+import { ToolError } from "../tool-errors";
+
+const ROOT_SEARCH_ERROR = "Searching from root directory '/' is not allowed";
+
+async function expectRootSearchRejected(searchPath: string): Promise<void> {
+	const session: ToolSession = {
+		cwd: process.cwd(),
+		hasUI: false,
+		settings: Settings.isolated({}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+	};
+	const tool = new GlobTool(session);
+	let thrown: unknown;
+	try {
+		await tool.execute("glob-root-regression", { path: searchPath });
+	} catch (error) {
+		thrown = error;
+	}
+
+	if (!(thrown instanceof Error)) {
+		throw new Error(`Expected glob path ${JSON.stringify(searchPath)} to reject`);
+	}
+
+	expect(thrown).toBeInstanceOf(ToolError);
+	expect(thrown.message).toBe(ROOT_SEARCH_ERROR);
+}
+
+describe("GlobTool.execute", () => {
+	test.each(["/", "//"])("rejects bare root search path %s", async searchPath => {
+		await expectRootSearchRejected(searchPath);
+	});
+});

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -153,6 +153,9 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 				? effectivePaths
 				: await expandDelimitedPathEntries(effectivePaths, this.session.cwd, { splitter: parseFindPattern });
 			const rawPatterns = rawPatternInputs.map(input => normalizePathLikeInput(input).replace(/\\/g, "/"));
+			if (rawPatterns.some(pattern => /^\/+$/.test(pattern))) {
+				throw new ToolError("Searching from root directory '/' is not allowed");
+			}
 			const internalRouter = InternalUrlRouter.instance();
 			const normalizedPatterns: string[] = [];
 			for (const rawPattern of rawPatterns) {


### PR DESCRIPTION
## Repro
Calling the coding-agent `GlobTool.execute` surface with a session rooted at an empty temp directory and inputs `{ path: "/", limit: 5 }` or `{ path: "//", limit: 5 }` returned success with `No files found matching pattern` instead of raising `ToolError: Searching from root directory '/' is not allowed`.

## Cause
`packages/coding-agent/src/tools/glob.ts` checked `target.searchPath === "/"` only after each input passed through `resolveToCwd`; `packages/coding-agent/src/tools/path-utils.ts` intentionally collapses slash-only paths to the session cwd, so bare root inputs reached native glob as ordinary workspace searches and could return empty/successful results.

## Fix
- Reject slash-only glob inputs in `GlobTool.execute` before internal URL handling and `resolveToCwd` resolution.
- Added `packages/coding-agent/src/tools/__tests__/glob.test.ts` coverage for both `/` and `//` rejecting with the documented `ToolError` message.
- Added a `packages/coding-agent` changelog entry for the root-path validation fix.

## Verification
`bun test packages/coding-agent/src/tools/__tests__/glob.test.ts` passed: 2 tests, 4 assertions. `gh_push_branch` pre-publish gate completed and pushed the branch after running the repository gate. Fixes #4516