### PR TITLE
fix(tts): stop queued TTS playback on Esc after stream end

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Esc no longer stopping TTS audio playback once the assistant reply had finished streaming; queued Kokoro (and remote) audio kept reading past the response's end because `vocalizer.clear()` only fired from the aborted-stream cascade. Esc now silences a still-audible vocalizer as its first action (ahead of the `tree`/`branch` double-Esc gesture); a second Esc keeps its previous behavior. ([#4521](https://github.com/can1357/oh-my-pi/issues/4521))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -23,6 +23,7 @@ import { isLowSignalTitleInput } from "../../tiny/text";
 import { tinyTitleClient } from "../../tiny/title-client";
 import type { TinyTitleProgressEvent } from "../../tiny/title-protocol";
 import { shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
+import { vocalizer } from "../../tts/vocalizer";
 import {
 	copyToClipboard,
 	readImageFromClipboard,
@@ -390,6 +391,13 @@ export class InputController {
 				// Esc must not destroy an in-progress draft; it only disarms a previous empty-editor Esc.
 				this.ctx.lastEscapeTime = 0;
 				this.#clearStreamingEscapeArm();
+			} else if (vocalizer.isSpeaking()) {
+				// TTS buffers seconds of PCM past the streaming abort, so an Esc
+				// arriving after the model stopped would otherwise fall through to
+				// the double-Esc gesture while Kokoro reads on. Silence first;
+				// tree/branch stays reachable via a second Esc.
+				vocalizer.clear();
+				this.ctx.lastEscapeTime = 0;
 			} else {
 				// Double-interrupt with empty editor triggers /tree, /branch, or nothing based on setting
 				const action = settings.get("doubleEscapeAction");

--- a/packages/coding-agent/src/tts/vocalizer.ts
+++ b/packages/coding-agent/src/tts/vocalizer.ts
@@ -195,6 +195,15 @@ export class Vocalizer {
 		this.#livePlayers.clear();
 	}
 
+	/**
+	 * True while any utterance is still audible or synthesizing — a live
+	 * player, an unfinished stream handle, or an in-flight rewrite is enough.
+	 * Callers (Esc handler) treat this as the "silence me" signal.
+	 */
+	isSpeaking(): boolean {
+		return this.#livePlayers.size > 0 || this.#liveAborts.size > 0 || this.#handle !== null;
+	}
+
 	/** Lower the volume while the user is speaking (push-to-talk), so speech doesn't drown them out. */
 	duck(): void {
 		this.#ducked = true;

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -4,6 +4,7 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
 import type { InteractiveModeContext, SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { vocalizer } from "@oh-my-pi/pi-coding-agent/tts/vocalizer";
 import * as logger from "@oh-my-pi/pi-utils/logger";
 
 type Spy = Mock<(...args: unknown[]) => unknown>;
@@ -701,6 +702,27 @@ describe("InputController escape behavior", () => {
 
 		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
+	});
+
+	it("silences a still-audible vocalizer on Esc instead of opening the tree selector (#4521)", () => {
+		const clear = vi.spyOn(vocalizer, "clear").mockImplementation(() => {});
+		const isSpeaking = vi.spyOn(vocalizer, "isSpeaking").mockReturnValue(true);
+		const { ctx, editor, spies } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(clear).toHaveBeenCalledTimes(1);
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
+		expect(ctx.showUserMessageSelector).not.toHaveBeenCalled();
+		expect(spies.resetDisplay).not.toHaveBeenCalled();
+
+		// A second Esc after silence must NOT immediately fire the double-Esc
+		// gesture — the first press consumed the arm.
+		isSpeaking.mockReturnValue(false);
+		editor.onEscape?.();
+		expect(ctx.showTreeSelector).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Repro

Enable TTS (`speech.enabled`), prompt the model, wait for the reply to finish streaming, then try to interrupt playback with Esc. Kokoro (and the remote path) keep reading the buffered audio to the end because Esc has no handler for "TTS is still audible."

## Cause

`vocalizer.clear()` is only called from `EventController` on `#handleTurnStart` and on an aborted `message_end`. Once the assistant reply completes with `stopReason === "stop"`, `EventController` runs `vocalizer.flush()` — the trailing partial synthesizes and buffers seconds of PCM into `StreamingAudioPlayer`. `InputController.onEscape` (`packages/coding-agent/src/modes/controllers/input-controller.ts:387-410`) then sees `session.isStreaming === false`, no draft, no bash/eval running, and falls straight through to the empty-editor double-Esc `tree`/`branch` gesture, never touching the vocalizer.

## Fix

- `packages/coding-agent/src/tts/vocalizer.ts`: add `Vocalizer.isSpeaking()` — true whenever any live player, unfinished stream handle, or in-flight abort is around. This is the "silence me" probe the escape handler needs, and it has to live on the class because the underlying state (`#livePlayers`, `#liveAborts`, `#handle`) is private.
- `packages/coding-agent/src/modes/controllers/input-controller.ts`: insert a new escape branch after the "draft text" clause. When `vocalizer.isSpeaking()`, first Esc calls `vocalizer.clear()` (kills every live player, aborts synthesis + rewrites) and resets `lastEscapeTime` so the double-Esc gesture stays reachable via a subsequent press. All other escape paths (bash/eval abort, streaming abort, `/btw`, maintenance, focused subagent, tree/branch double-Esc when nothing is audible) are unchanged.
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased] > Fixed` entry linking #4521.
- `packages/coding-agent/test/input-controller-escape.test.ts`: regression test spying on `vocalizer.isSpeaking`/`clear` — a first Esc while speaking silences and does NOT open the tree selector, a second Esc after silence does not immediately trigger the gesture either.

## Verification

- `bun test packages/coding-agent/test/input-controller-escape.test.ts` → 32 pass / 0 fail (100 expect calls), including the new `silences a still-audible vocalizer on Esc instead of opening the tree selector (#4521)` case.
- `bun check` (invoked automatically by the PR gate) → passed.

Fixes #4521