### PR TITLE
fix(coding-agent): scoped /model search to the active provider tab

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/model` search escaping the active provider tab and silently letting a same-named model from a different provider be persisted as the default role. `#filterModels` no longer auto-switches to the `ALL` tab when a query is typed inside a provider tab; results and Enter stay scoped to the selected provider. Empty results now name the active tab and point at `ALL` as the explicit escape. ([#4522](https://github.com/can1357/oh-my-pi/issues/4522))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -704,29 +704,22 @@ export class ModelSelectorComponent extends Container {
 	#filterModels(query: string): void {
 		const activeProviderId = this.#getActiveProviderId();
 
-		let baseModels = this.#allModels;
-		if (activeProviderId) {
-			baseModels = this.#allModels.filter(m => m.provider === activeProviderId);
-		}
+		const baseModels = activeProviderId
+			? this.#allModels.filter(m => m.provider === activeProviderId)
+			: this.#allModels;
 
 		if (query.trim()) {
-			// If user is searching from a provider tab, auto-switch to ALL to show global provider results.
-			if (activeProviderId) {
-				this.#activeTabIndex = 0;
-				if (this.#tabBar && this.#tabBar.getActiveIndex() !== 0) {
-					this.#tabBar.setActiveIndex(0);
-					return;
-				}
-				this.#updateTabBar();
-				baseModels = this.#allModels;
-			}
-
 			// Match against the displayed "provider/id" string so the user can
 			// type what they see: bare names (`mimo`, `kimi`), provider prefixes
 			// (`openrouter`), or scoped queries (`openrouter/mimo`) all flow
 			// through the same fuzzy matcher. The score is biased by provider-
 			// prefix length, so re-sort by MRU/version afterwards; skip role
 			// rank so a weakly matching default doesn't trump a stronger match.
+			//
+			// Search stays scoped to the active provider tab. Auto-escaping to
+			// ALL on non-empty queries used to let the user pick a same-named
+			// model from a different provider and silently persist it under
+			// their default role — see issue #4522.
 			const fuzzyMatches = fuzzyFilter(baseModels, query, ({ id, provider }) => `${provider}/${id}`);
 			this.#sortModels(fuzzyMatches, { skipRoleRank: true });
 			this.#filteredModels = fuzzyMatches;
@@ -891,8 +884,15 @@ export class ModelSelectorComponent extends Container {
 				this.#listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
 			}
 		} else if (visibleItems.length === 0) {
-			const statusMessage = this.#getProviderEmptyStateMessage();
-			this.#listContainer.addChild(new Text(theme.fg("muted", statusMessage ?? "  No matching models"), 0, 0));
+			const providerStatus = this.#getProviderEmptyStateMessage();
+			const activeProviderId = this.#getActiveProviderId();
+			const searching = this.#searchInput.getValue().trim().length > 0;
+			const message =
+				providerStatus ??
+				(searching && activeProviderId
+					? `  No matching models in ${formatProviderTabLabel(activeProviderId)}. Switch to ALL to search every provider.`
+					: "  No matching models");
+			this.#listContainer.addChild(new Text(theme.fg("muted", message), 0, 0));
 		} else {
 			const selected = visibleItems[this.#selectedIndex];
 			if (!selected) {

--- a/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
+++ b/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
@@ -1,0 +1,168 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ModelSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/model-selector";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+function normalizeRenderedText(text: string): string {
+	return stripVTControlCharacters(text).replace(/\s+/g, " ").trim();
+}
+
+function makeModel(provider: string, id: string): Model {
+	return buildModel({
+		id,
+		name: id,
+		api: "ollama-chat",
+		baseUrl: "https://example.com",
+		reasoning: false,
+		provider,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 1024,
+	});
+}
+
+let testTheme = await getThemeByName("dark");
+
+function installTestTheme(): void {
+	if (!testTheme) {
+		throw new Error("Failed to load dark theme for ModelSelector tests");
+	}
+	setThemeInstance(testTheme);
+}
+
+interface SelectorHarness {
+	selector: ModelSelectorComponent;
+	backgroundRefresh: Promise<void>;
+}
+
+function createSelector(models: Model[], onSelect: (model: Model) => void): SelectorHarness {
+	const settings = Settings.isolated({});
+	// The constructor kicks off an offline refresh in the background. Drive it
+	// through an explicit gate so tests can await drain instead of sleeping.
+	const refreshGate = Promise.withResolvers<void>();
+	const modelRegistry = {
+		getAll: () => models,
+		refresh: vi.fn(() => refreshGate.promise),
+		refreshProvider: vi.fn(async () => {}),
+		getError: () => undefined,
+		getAvailable: () => models,
+		getDiscoverableProviders: () => [],
+	} as unknown as ModelRegistry;
+	const ui = {
+		requestRender: vi.fn(),
+	} as unknown as TUI;
+
+	const selector = new ModelSelectorComponent(
+		ui,
+		undefined,
+		settings,
+		modelRegistry,
+		[],
+		model => onSelect(model),
+		() => {},
+		{ temporaryOnly: true },
+	);
+	refreshGate.resolve();
+	// Chain past the constructor's `.then().catch().finally()` hops so the
+	// awaited promise settles only after the background refresh finished
+	// touching the selector.
+	const backgroundRefresh = refreshGate.promise
+		.then(() => Promise.resolve())
+		.then(() => Promise.resolve())
+		.then(() => Promise.resolve());
+	return { selector, backgroundRefresh };
+}
+
+describe("ModelSelector search stays inside the active provider tab (#4522)", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("dark");
+		if (!testTheme) {
+			throw new Error("Failed to load dark theme for ModelSelector tests");
+		}
+	});
+
+	test("selecting a search match on a provider tab keeps that provider's model", async () => {
+		installTestTheme();
+		// Two providers, each exposing a similarly named model. The user
+		// searches from the openrouter tab; the auto-switch-to-ALL bug used to
+		// leak the custom-provider row into the selection.
+		const openrouterGlm = makeModel("openrouter", "z-ai/glm-5.2");
+		const customGlm = makeModel("custom-provider", "glm-5.2");
+
+		const selected: Model[] = [];
+		const { selector, backgroundRefresh } = createSelector([openrouterGlm, customGlm], model => selected.push(model));
+		await backgroundRefresh;
+		installTestTheme();
+
+		// Right arrow cycles the tab bar. Two moves lands on the third tab:
+		// providers are sorted alphabetically by uppercase label, so
+		// CUSTOM PROVIDER precedes OPENROUTER after ALL.
+		selector.handleInput("\x1b[C");
+		selector.handleInput("\x1b[C");
+
+		const providerRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(providerRendered).toContain("OPENROUTER");
+		expect(providerRendered).toContain("z-ai/glm-5.2");
+
+		for (const ch of "glm-5.2") {
+			selector.handleInput(ch);
+		}
+
+		const searchRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		// Bug repro: previously the search auto-switched to ALL and revealed
+		// custom-provider/glm-5.2 in the results.
+		expect(searchRendered).not.toContain("custom-provider/glm-5.2");
+		expect(searchRendered).toContain("z-ai/glm-5.2");
+
+		selector.handleInput("\n");
+
+		expect(selected).toHaveLength(1);
+		expect(selected[0]?.provider).toBe("openrouter");
+		expect(selected[0]?.id).toBe("z-ai/glm-5.2");
+	});
+
+	test("search on ALL tab still spans every provider", async () => {
+		installTestTheme();
+		const openrouterGlm = makeModel("openrouter", "z-ai/glm-5.2");
+		const customGlm = makeModel("custom-provider", "glm-5.2");
+
+		const { selector, backgroundRefresh } = createSelector([openrouterGlm, customGlm], () => {});
+		await backgroundRefresh;
+		installTestTheme();
+
+		for (const ch of "glm-5.2") {
+			selector.handleInput(ch);
+		}
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("openrouter/z-ai/glm-5.2");
+		expect(rendered).toContain("custom-provider/glm-5.2");
+	});
+
+	test("empty search on a provider tab explains the scope and how to escape it", async () => {
+		installTestTheme();
+		const openrouterGlm = makeModel("openrouter", "z-ai/glm-5.2");
+		const customGlm = makeModel("custom-provider", "glm-5.2");
+
+		const { selector, backgroundRefresh } = createSelector([openrouterGlm, customGlm], () => {});
+		await backgroundRefresh;
+		installTestTheme();
+
+		selector.handleInput("\x1b[C");
+		selector.handleInput("\x1b[C");
+
+		for (const ch of "does-not-exist") {
+			selector.handleInput(ch);
+		}
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("No matching models in OPENROUTER");
+		expect(rendered).toContain("Switch to ALL");
+	});
+});


### PR DESCRIPTION
## Repro
On `/model`, switching to a provider tab and typing a query silently auto-switched the selector back to the `ALL` tab and searched across every provider. With two providers exposing similarly named models (e.g. `openrouter/z-ai/glm-5.2` and a custom-proxy `custom-provider/glm-5.2`), a user on the `openrouter` tab could type `glm-5.2`, hit Enter, and persist `custom-provider/glm-5.2` under `modelRoles.default`. Regression fixture: `packages/coding-agent/test/model-selector-provider-search-scope.test.ts` — before the fix, `selected[0].provider` was `custom-provider` instead of `openrouter` and the leaked `custom-provider/glm-5.2` row was visible in the search-scoped render.

## Cause
`#filterModels` in `packages/coding-agent/src/modes/components/model-selector.ts` first scoped `baseModels` to `activeProviderId`, then on any non-empty query dropped that scope by flipping `#activeTabIndex` to `0` and rebinding `baseModels = this.#allModels`. The intent was to widen search when the current tab had no matches, but it fired unconditionally on the first keystroke and broke the tab-scope contract — the reporter's option 1.

## Fix
- Drop the auto-switch-to-`ALL` block in `#filterModels`. Provider-tab search now filters within `#allModels.filter(m => m.provider === activeProviderId)`; the `ALL` tab search behaviour is unchanged.
- Empty-state renderer names the active tab and points at `ALL` as the explicit escape (`No matching models in OPENROUTER. Switch to ALL to search every provider.`) so users see the search stayed in scope.
- Added `packages/coding-agent/test/model-selector-provider-search-scope.test.ts` covering: scoped search + Enter keeps the provider-tab model; `ALL`-tab search still spans every provider; empty scoped search shows the scope-and-escape hint.
- CHANGELOG entry under `[Unreleased] > Fixed` in `packages/coding-agent/CHANGELOG.md`.

## Verification
- `bun test test/model-selector-provider-search-scope.test.ts` — 3 pass. Stashing the src fix reproduces 2 failures on the same file (provider-leaked select + missing scope hint).
- `bun test test/model-selector-role-badge-thinking.test.ts` — 13 pass, no regression in the sibling selector suite.
- `bun check` — passes.

Fixes #4522