### PR TITLE
fix(tui): handle invalid path render args

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed tool-call renderers crashing the TUI when providers send array/object `path` arguments before schema validation can report the invalid call back to the model. ([#4525](https://github.com/can1357/oh-my-pi/issues/4525))
 - Fixed raw `read` ranges not contributing to edit seen-line provenance, so re-reading an anchor range with `:raw` now unblocks hashline edits without adding non-raw line prefixes.
 - Fixed replan-driven session title refresh updating the statusline but not the terminal window title: terminal-title updates now fire from the session-name-changed listener, so every `setSessionName` path (first-input titling, `/rename`, plan seeding, replan refresh) sets the OSC title consistently.
 - Fixed user-interrupt aborts rendering the persisted `Interrupted by user` label in assistant transcripts; replay and live views now suppress that redundant line again while preserving generic/custom abort labels.

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -108,8 +108,8 @@ export interface EditToolDetails {
 // ═══════════════════════════════════════════════════════════════════════════
 
 interface EditRenderArgs {
-	path?: string;
-	file_path?: string;
+	path?: unknown;
+	file_path?: unknown;
 	oldText?: string;
 	newText?: string;
 	patch?: string;
@@ -118,7 +118,7 @@ interface EditRenderArgs {
 	all?: boolean;
 	// Patch mode fields
 	op?: Operation;
-	rename?: string;
+	rename?: unknown;
 	diff?: string;
 	/**
 	 * Computed preview diff (used when tool args don't include a diff, e.g. hashline mode).
@@ -130,9 +130,9 @@ interface EditRenderArgs {
 }
 
 type EditRenderEntry = {
-	path?: string;
-	rename?: string;
-	move?: string;
+	path?: unknown;
+	rename?: unknown;
+	move?: unknown;
 	op?: Operation;
 };
 
@@ -192,8 +192,11 @@ const CALL_TEXT_PREVIEW_LINES = 6;
 const CALL_TEXT_PREVIEW_WIDTH = 80;
 
 /** Extract file path from an edit entry. */
-function filePathFromEditEntry(p: string | undefined): string | undefined {
-	return p ?? undefined;
+function filePathFromEditEntry(p: unknown): string | undefined {
+	if (typeof p !== "string") {
+		return undefined;
+	}
+	return p;
 }
 
 function decodePartialJsonStringFragment(fragment: string): string {
@@ -711,18 +714,20 @@ export const editToolRenderer = {
 		// Extract path from first edit entry when top-level path is absent (new schema)
 		const firstEdit = Array.isArray(editArgs.edits) && editArgs.edits.length > 0 ? editArgs.edits[0] : undefined;
 		const rawPath =
-			editArgs.file_path ||
-			editArgs.path ||
-			filePathFromEditEntry(firstEdit?.path) ||
-			getPartialJsonEditPath(editArgs) ||
-			firstHashlineInputEntry?.path ||
-			firstApplyPatchEntry?.path ||
-			"";
+			typeof editArgs.file_path === "string"
+				? editArgs.file_path
+				: typeof editArgs.path === "string"
+					? editArgs.path
+					: (filePathFromEditEntry(firstEdit?.path) ??
+						getPartialJsonEditPath(editArgs) ??
+						firstHashlineInputEntry?.path ??
+						firstApplyPatchEntry?.path ??
+						"");
 		const rename =
-			editArgs.rename ||
-			firstEdit?.rename ||
-			firstEdit?.move ||
-			firstApplyPatchEntry?.rename ||
+			(typeof editArgs.rename === "string" ? editArgs.rename : undefined) ??
+			filePathFromEditEntry(firstEdit?.rename) ??
+			filePathFromEditEntry(firstEdit?.move) ??
+			firstApplyPatchEntry?.rename ??
 			firstHashlineInputEntry?.rename;
 		const op = editArgs.op || firstEdit?.op || firstApplyPatchEntry?.op || firstHashlineInputEntry?.op;
 		let fileCount = hashlineInputSummary?.entries.length ?? applyPatchSummary?.entries.length ?? 0;
@@ -781,8 +786,9 @@ export const editToolRenderer = {
 		uiTheme: Theme,
 		args?: EditRenderArgs,
 	): Component {
+		const edits = Array.isArray(args?.edits) ? args.edits : undefined;
 		const perFileResults = result.details?.perFileResults;
-		const totalFiles = args?.edits ? countEditFiles(args.edits) : 0;
+		const totalFiles = edits ? countEditFiles(edits) : 0;
 		if (perFileResults && (perFileResults.length > 1 || totalFiles > 1)) {
 			return renderMultiFileResult(perFileResults, totalFiles, options, uiTheme);
 		}
@@ -802,20 +808,26 @@ function renderSingleFileResult(
 ): Component {
 	const details = result.details;
 	const isError = result.isError ?? (details && "isError" in details ? details.isError : false);
-	const firstEdit = args?.edits?.[0];
+	const edits = Array.isArray(args?.edits) ? args.edits : undefined;
+	const firstEdit = edits?.[0];
 	const hashlineInputSummary = getHashlineInputRenderSummary(args ?? {}, options.renderContext?.editMode);
 	const firstHashlineInputEntry = hashlineInputSummary?.entries[0];
-	const moveSource = details && "sourcePath" in details ? details.sourcePath : undefined;
+	const moveSource =
+		details && "sourcePath" in details && typeof details.sourcePath === "string" ? details.sourcePath : undefined;
+	const detailPath = details && "path" in details && typeof details.path === "string" ? details.path : undefined;
 	const rawPath =
-		moveSource ||
-		args?.file_path ||
-		args?.path ||
-		filePathFromEditEntry(firstEdit?.path) ||
-		(details && "path" in details ? details.path : "") ||
-		firstHashlineInputEntry?.path ||
-		"";
+		moveSource ??
+		(typeof args?.file_path === "string"
+			? args.file_path
+			: typeof args?.path === "string"
+				? args.path
+				: (filePathFromEditEntry(firstEdit?.path) ?? detailPath ?? firstHashlineInputEntry?.path ?? ""));
 	const op = args?.op || firstEdit?.op || details?.op;
-	const rename = args?.rename || firstEdit?.rename || firstEdit?.move || details?.move;
+	const rename =
+		(typeof args?.rename === "string" ? args.rename : undefined) ??
+		filePathFromEditEntry(firstEdit?.rename) ??
+		filePathFromEditEntry(firstEdit?.move) ??
+		(details && "move" in details && typeof details.move === "string" ? details.move : undefined);
 
 	const displayErrorText = isError && details && "displayErrorText" in details ? details.displayErrorText : undefined;
 	const errorText = isError

--- a/packages/coding-agent/src/tools/browser/render.ts
+++ b/packages/coding-agent/src/tools/browser/render.ts
@@ -34,8 +34,10 @@ interface BrowserRenderContext {
 }
 
 function describeBrowser(args: BrowserRenderArgs, details: BrowserToolDetails | undefined): string | undefined {
-	if (args.app?.cdp_url) return `connected ${args.app.cdp_url}`;
-	if (args.app?.path) return `spawned ${shortenPath(args.app.path)}`;
+	const cdpUrl = typeof args.app?.cdp_url === "string" ? args.app.cdp_url : "";
+	if (cdpUrl) return `connected ${cdpUrl}`;
+	const appPath = typeof args.app?.path === "string" ? args.app.path : "";
+	if (appPath) return `spawned ${shortenPath(appPath)}`;
 	if (args.app?.cmux !== false && (args.app?.cmux === true || args.app?.surface)) {
 		return args.app.surface ? `cmux ${args.app.surface}` : "cmux";
 	}
@@ -92,7 +94,7 @@ function renderRunCell(
 	const status = cellStatus(options.isPartial, isError);
 
 	const titleParts: string[] = [tabLabel(args, details)];
-	const url = details?.url ?? args.url;
+	const url = typeof details?.url === "string" ? details.url : typeof args.url === "string" ? args.url : "";
 	if (url) titleParts.push(shortenPath(url));
 	const browserDesc = describeBrowser(args, details);
 	if (browserDesc) titleParts.push(browserDesc);
@@ -165,7 +167,7 @@ function renderOpenOrCloseLine(
 	const meta: string[] = [];
 	const browserDesc = describeBrowser(args, details);
 	if (browserDesc) meta.push(browserDesc);
-	const url = details?.url ?? args.url;
+	const url = typeof details?.url === "string" ? details.url : typeof args.url === "string" ? args.url : "";
 	if (url) meta.push(shortenPath(url));
 
 	const header =

--- a/packages/coding-agent/src/tools/inspect-image-renderer.ts
+++ b/packages/coding-agent/src/tools/inspect-image-renderer.ts
@@ -33,10 +33,10 @@ function questionLine(question: string, uiTheme: Theme): string {
 
 export const inspectImageToolRenderer = {
 	renderCall(args: InspectImageRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
-		const rawPath = args.path ?? "";
+		const rawPath = typeof args.path === "string" ? args.path : "";
 		const pathDisplay = rawPath ? shortenPath(rawPath) : "…";
 		const header = renderStatusLine({ icon: "pending", title: "Inspect", description: pathDisplay }, uiTheme);
-		const question = args.question?.trim();
+		const question = typeof args.question === "string" ? args.question.trim() : "";
 		// Call is at most a status line plus a one-line question — too small to box.
 		// The container renders a lone Text cleanly with no chrome.
 		if (!question) return new Text(header, 0, 0);
@@ -51,7 +51,8 @@ export const inspectImageToolRenderer = {
 		args?: InspectImageRenderArgs,
 	): Component {
 		const details = result.details;
-		const rawPath = details?.imagePath ?? args?.path ?? "";
+		const rawPath =
+			typeof details?.imagePath === "string" ? details.imagePath : typeof args?.path === "string" ? args.path : "";
 		const pathDisplay = rawPath ? shortenPath(rawPath) : "image";
 		const success = !result.isError;
 		const header = renderStatusLine(
@@ -69,7 +70,7 @@ export const inspectImageToolRenderer = {
 			uiTheme,
 		);
 
-		const question = args?.question?.trim();
+		const question = typeof args?.question === "string" ? args.question.trim() : "";
 		const outputText = result.content.find(content => content.type === "text")?.text?.trimEnd() ?? "";
 
 		if (result.isError) {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -3254,8 +3254,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 // =============================================================================
 
 interface ReadRenderArgs {
-	path?: string;
-	file_path?: string;
+	path?: unknown;
+	file_path?: unknown;
 	sel?: string;
 	// Legacy fields from old schema — tolerated for in-flight tool calls during transition
 	offset?: number;
@@ -3320,11 +3320,12 @@ function formatReadPathLink(
 
 export const readToolRenderer = {
 	renderCall(args: ReadRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
-		if (isReadableUrlPath(args.file_path || args.path || "")) {
-			return renderReadUrlCall(args, _options, uiTheme);
+		const rawPath =
+			typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : "";
+		if (isReadableUrlPath(rawPath)) {
+			return renderReadUrlCall({ path: rawPath, raw: args.raw }, _options, uiTheme);
 		}
 
-		const rawPath = args.file_path || args.path || "";
 		const offset = args.offset;
 		const limit = args.limit;
 
@@ -3346,7 +3347,9 @@ export const readToolRenderer = {
 		args?: ReadRenderArgs,
 	): Component {
 		const urlDetails = result.details as ReadUrlToolDetails | undefined;
-		if (urlDetails?.kind === "url" || isReadableUrlPath(args?.file_path || args?.path || "")) {
+		const rawPathForKind =
+			typeof args?.file_path === "string" ? args.file_path : typeof args?.path === "string" ? args.path : "";
+		if (urlDetails?.kind === "url" || isReadableUrlPath(rawPathForKind)) {
 			return renderReadUrlResult(
 				result as {
 					content: Array<{ type: string; text?: string }>;
@@ -3361,7 +3364,8 @@ export const readToolRenderer = {
 		if (result.isError) {
 			const rawErrorText = result.content?.find(c => c.type === "text")?.text ?? "";
 			const errorText = (rawErrorText || "Unknown error").replace(/^Error:\s*/, "");
-			const rawPath = args?.file_path || args?.path || "";
+			const rawPath =
+				typeof args?.file_path === "string" ? args.file_path : typeof args?.path === "string" ? args.path : "";
 			const filePath =
 				formatReadPathLink(rawPath, { offset: args?.offset, sourcePath: readSourceFsPath(result.details) }) ||
 				shortenPath(rawPath);
@@ -3388,7 +3392,8 @@ export const readToolRenderer = {
 		// echo next to the styled warning line below.
 		const contentText = details?.displayContent?.text ?? stripOutputNotice(rawText, details?.meta);
 		const imageContent = result.content?.find(c => c.type === "image");
-		const rawPath = args?.file_path || args?.path || "";
+		const rawPath =
+			typeof args?.file_path === "string" ? args.file_path : typeof args?.path === "string" ? args.path : "";
 		const renderPath = splitReadRenderPath(rawPath);
 		const lang = getLanguageFromPath(renderPath.path);
 

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -669,7 +669,10 @@ export function truncateDiffByHunk(
 // Path Utilities
 // =============================================================================
 
-export function shortenPath(filePath: string, homeDir?: string): string {
+export function shortenPath(filePath: unknown, homeDir?: string): string {
+	if (typeof filePath !== "string") {
+		return "";
+	}
 	const home = homeDir ?? os.homedir();
 	if (home && filePath.startsWith(home)) {
 		const suffix = filePath.slice(home.length);

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -972,8 +972,8 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 // =============================================================================
 
 interface WriteRenderArgs {
-	path?: string;
-	file_path?: string;
+	path?: unknown;
+	file_path?: unknown;
 	content?: unknown;
 }
 
@@ -1088,9 +1088,10 @@ function renderContentPreview(
 
 export const writeToolRenderer = {
 	renderCall(args: WriteRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
-		const rawPath = args.file_path || args.path || "";
+		const rawPath =
+			typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : "";
 		const filePath = shortenPath(rawPath);
-		const lang = getLanguageFromPath(rawPath) ?? "text";
+		const lang = rawPath ? (getLanguageFromPath(rawPath) ?? "text") : "text";
 		const langIcon = uiTheme.fg("muted", uiTheme.getLangIcon(lang));
 		const pathDisplay = filePath ? uiTheme.fg("accent", filePath) : uiTheme.fg("toolOutput", "…");
 		// No status icon on the head row: it's the head of the framed block, and
@@ -1135,10 +1136,11 @@ export const writeToolRenderer = {
 		uiTheme: Theme,
 		args?: WriteRenderArgs,
 	): Component {
-		const rawPath = args?.file_path || args?.path || "";
+		const rawPath =
+			typeof args?.file_path === "string" ? args.file_path : typeof args?.path === "string" ? args.path : "";
 		const filePath = shortenPath(rawPath);
 		const fileContent = normalizeDisplayText(args?.content);
-		const lang = getLanguageFromPath(rawPath);
+		const lang = rawPath ? getLanguageFromPath(rawPath) : undefined;
 		const langIcon = uiTheme.fg("muted", uiTheme.getLangIcon(lang));
 		// The header shows the cwd-relative path but links to the absolute path the
 		// write resolved to (args.path may be relative, which would yield a broken

--- a/packages/coding-agent/test/tools/path-renderer-invalid-args.test.ts
+++ b/packages/coding-agent/test/tools/path-renderer-invalid-args.test.ts
@@ -1,0 +1,126 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { editToolRenderer } from "@oh-my-pi/pi-coding-agent/edit/renderer";
+import { getThemeByName, initTheme, type Theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { readToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { writeToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/write";
+import type { Component } from "@oh-my-pi/pi-tui";
+
+interface InvalidPathCase {
+	readonly name: string;
+	readonly path: unknown;
+}
+
+const invalidPathCases: readonly InvalidPathCase[] = [
+	{ name: "array path", path: ["src/example.ts"] },
+	{ name: "object path", path: { value: "src/example.ts" } },
+];
+
+let uiTheme: Theme;
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "dark", "light");
+	const theme = await getThemeByName("dark");
+	if (!theme) throw new Error("dark theme missing");
+	uiTheme = theme;
+});
+
+function renderPlain(component: Component, width = 120): string {
+	let rendered = "";
+	expect(() => {
+		rendered = Bun.stripANSI(component.render(width).join("\n"));
+	}).not.toThrow();
+	return rendered;
+}
+
+describe("tool path renderers with invalid provider arguments", () => {
+	for (const invalid of invalidPathCases) {
+		it(`read renderer does not throw for ${invalid.name}`, () => {
+			let callComponent: Component | undefined;
+			expect(() => {
+				callComponent = readToolRenderer.renderCall(
+					{ path: invalid.path },
+					{ expanded: false, isPartial: true },
+					uiTheme,
+				);
+			}).not.toThrow();
+			expect(renderPlain(callComponent!)).toContain("Read");
+
+			let resultComponent: Component | undefined;
+			expect(() => {
+				resultComponent = readToolRenderer.renderResult(
+					{
+						content: [{ type: "text", text: "hello from read" }],
+						details: {
+							displayContent: { text: "hello from read", startLine: 1 },
+							contentType: "text/plain",
+						},
+					},
+					{ expanded: false, isPartial: false },
+					uiTheme,
+					{ path: invalid.path },
+				);
+			}).not.toThrow();
+			const rendered = renderPlain(resultComponent!);
+			expect(rendered).toContain("Read");
+			expect(rendered).toContain("hello from read");
+		});
+
+		it(`write renderer does not throw for ${invalid.name}`, () => {
+			let callComponent: Component | undefined;
+			expect(() => {
+				callComponent = writeToolRenderer.renderCall(
+					{ path: invalid.path, content: "first line\nsecond line" },
+					{ expanded: false, isPartial: true, spinnerFrame: 0 },
+					uiTheme,
+				);
+			}).not.toThrow();
+			const callText = renderPlain(callComponent!);
+			expect(callText).toContain("Write");
+			expect(callText).toContain("second line");
+
+			let resultComponent: Component | undefined;
+			expect(() => {
+				resultComponent = writeToolRenderer.renderResult(
+					{
+						content: [{ type: "text", text: "Wrote file" }],
+						details: { resolvedPath: "/tmp/example.ts" },
+					},
+					{ expanded: false, isPartial: false },
+					uiTheme,
+					{ path: invalid.path, content: "first line\nsecond line" },
+				);
+			}).not.toThrow();
+			const resultText = renderPlain(resultComponent!);
+			expect(resultText).toContain("Write");
+			expect(resultText).toContain("first line");
+		});
+
+		it(`edit renderer does not throw for ${invalid.name}`, () => {
+			let callComponent: Component | undefined;
+			expect(() => {
+				callComponent = editToolRenderer.renderCall(
+					{ path: invalid.path, oldText: "before", newText: "after" },
+					{ expanded: false, isPartial: true, spinnerFrame: 0, renderContext: { editMode: "replace" } },
+					uiTheme,
+				);
+			}).not.toThrow();
+			expect(renderPlain(callComponent!)).toContain("Edit");
+
+			let resultComponent: Component | undefined;
+			expect(() => {
+				resultComponent = editToolRenderer.renderResult(
+					{
+						content: [{ type: "text", text: "updated" }],
+						details: { diff: "-before\n+after" },
+					},
+					{ expanded: false, isPartial: false, renderContext: { editMode: "replace" } },
+					uiTheme,
+					{ path: invalid.path, oldText: "before", newText: "after" },
+				);
+			}).not.toThrow();
+			const rendered = renderPlain(resultComponent!);
+			expect(rendered).toContain("Edit");
+			expect(rendered).toContain("after");
+		});
+	}
+});


### PR DESCRIPTION
## Repro
Reproduced the crash with a focused renderer call matching the reporter's malformed provider output: `readToolRenderer.renderCall({ path: ["src/a.ts"] }, { expanded: false }, theme)` threw `TypeError: filePath.startsWith is not a function` before tool execution validation could return an error to the model. The same renderer boundary covers the reported array/object `path` failures from GLM 5.2 tool calls.

## Cause
Tool-call renderers trusted provider arguments as already schema-valid while the TUI renders call previews before execution validation. `packages/coding-agent/src/tools/read.ts`, `write.ts`, `inspect-image-renderer.ts`, `browser/render.ts`, and `edit/renderer.ts` passed raw `path` values into `shortenPath`, `getLanguageFromPath`, `fileHyperlink`, or diff rendering; array/object values then reached `node:path` or string helpers and crashed the process instead of letting validation surface the invalid tool call.

## Fix
- Coerced renderer-facing `path`/`file_path` inputs to strings only when they are actually strings; invalid array/object path values now render with the existing placeholder/fallback display.
- Made `shortenPath` return an empty display string for non-string runtime inputs so lazy render callbacks cannot crash on malformed provider arguments.
- Hardened read, write, inspect image, browser, and edit render paths, including the edit result's lazy framed render callback.
- Added regression coverage for read, write, and edit renderer call/result components with array and object `path` values.
- Added a `packages/coding-agent` changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/path-renderer-invalid-args.test.ts` passed: 6 pass, 0 fail, 44 expect() calls. `bun check` passed. Pre-publish `gh_push_branch` also ran its formatter/check gate and pushed `0b7f4865a7d3`. Fixes #4525