### PR TITLE
fix(providers): align openai-responses strict-mode gate with openai-completions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Aligned the `openai-responses` strict-mode gate with `openai-completions` so an explicit `tool.strict === false` survives to the wire under the same `compat.supportsStrictMode !== false` semantic on both provider paths — previously the Responses builder's truthier check let a caller-authored Model whose compat didn't materialize `supportsStrictMode` drop `strict: false`, diverging from the sibling completions payload for the same backend ([#4527](https://github.com/can1357/oh-my-pi/issues/4527)).
+
 ## [16.3.6] - 2026-07-04
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Aligned the `openai-responses` strict-mode gate with `openai-completions` so an explicit `tool.strict === false` survives to the wire under the same `compat.supportsStrictMode !== false` semantic on both provider paths — previously the Responses builder's truthier check let a caller-authored Model whose compat didn't materialize `supportsStrictMode` drop `strict: false`, diverging from the sibling completions payload for the same backend ([#4527](https://github.com/can1357/oh-my-pi/issues/4527)).
+- Aligned the `openai-responses` strict-mode gate and resolved strict-support detection with `openai-completions` so buildModel-created OpenAI-compatible Responses models (for example DeepSeek-family endpoints) preserve an author-set `tool.strict === false` on the wire unless `compat.supportsStrictMode` is explicitly `false` ([#4527](https://github.com/can1357/oh-my-pi/issues/4527)).
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -854,7 +854,7 @@ export function buildParams(
 	if (context.tools) {
 		const disableStrictTools =
 			disableStrictToolsOverride || isStrictToolsDisabledForScope(providerSessionState, strictToolsScope);
-		const strictMode = !disableStrictTools && model.compat.supportsStrictMode;
+		const strictMode = !disableStrictTools && model.compat.supportsStrictMode !== false;
 		params.tools = convertTools(context.tools, strictMode, model);
 		strictToolsApplied = params.tools.some(t => (t as { strict?: boolean }).strict === true);
 		if (options?.toolChoice) {
@@ -989,9 +989,12 @@ export function convertTools(
 			parameters,
 			// `strict: false` and an omitted `strict` are NOT equivalent for every
 			// OpenAI-compat backend — some over-fill optional args when the flag is
-			// absent (#4336). Preserve the author's explicit `false` only while the
-			// Responses strict field is enabled; compatibility disables and
-			// strict-schema fallback retries rely on uniformly absent flags.
+			// absent (#4336). Preserve the author's explicit `false` unless the
+			// provider is explicitly known not to understand the field
+			// (`supportsStrictMode: false`) or the strict-schema fallback is
+			// active — both paths rely on a uniformly absent wire flag. Mirrors the
+			// `supportsStrictMode !== false` gate used by openai-completions
+			// (#4527).
 			...(effectiveStrict
 				? { strict: true }
 				: !NO_STRICT && strictMode && tool.strict === false

--- a/packages/ai/test/openai-tool-strict-mode.test.ts
+++ b/packages/ai/test/openai-tool-strict-mode.test.ts
@@ -685,6 +685,30 @@ describe("OpenAI tool strict mode", () => {
 		expect(payload.tools?.[0]?.strict).toBeUndefined();
 	});
 
+	it("preserves explicit strict:false for openai-responses when compat leaves supportsStrictMode unresolved (#4527)", async () => {
+		// Mirrors the openai-completions `supportsStrictMode !== false` gate: a
+		// caller-constructed Model whose compat carries no `supportsStrictMode`
+		// (falsy under the pre-fix truthy check) must still preserve
+		// `strict: false` on the wire, so the two provider paths agree.
+		const bundled = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
+		const model: Model<"openai-responses"> = {
+			...bundled,
+			compat: {
+				...bundled.compat,
+				supportsStrictMode: undefined as unknown as boolean,
+			},
+		};
+
+		const payload = (await captureResponsesPayload(model, {
+			...testContext,
+			tools: [looseYieldTool],
+		})) as {
+			tools?: Array<{ strict?: boolean }>;
+		};
+
+		expect(payload.tools?.[0]?.strict).toBe(false);
+	});
+
 	it("sends strict=true for openai-responses tool schemas on GitHub Copilot", async () => {
 		const model = getBundledModel("github-copilot", "gpt-5-mini") as Model<"openai-responses">;
 

--- a/packages/ai/test/openai-tool-strict-mode.test.ts
+++ b/packages/ai/test/openai-tool-strict-mode.test.ts
@@ -685,19 +685,19 @@ describe("OpenAI tool strict mode", () => {
 		expect(payload.tools?.[0]?.strict).toBeUndefined();
 	});
 
-	it("preserves explicit strict:false for openai-responses when compat leaves supportsStrictMode unresolved (#4527)", async () => {
-		// Mirrors the openai-completions `supportsStrictMode !== false` gate: a
-		// caller-constructed Model whose compat carries no `supportsStrictMode`
-		// (falsy under the pre-fix truthy check) must still preserve
-		// `strict: false` on the wire, so the two provider paths agree.
-		const bundled = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
-		const model: Model<"openai-responses"> = {
-			...bundled,
-			compat: {
-				...bundled.compat,
-				supportsStrictMode: undefined as unknown as boolean,
-			},
-		};
+	it("preserves explicit strict:false for buildModel-resolved openai-responses compat (#4527)", async () => {
+		const model = buildModel({
+			id: "deepseek-chat",
+			name: "DeepSeek Chat via Responses",
+			api: "openai-responses",
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8192,
+		} as ModelSpec<"openai-responses">);
 
 		const payload = (await captureResponsesPayload(model, {
 			...testContext,
@@ -706,6 +706,7 @@ describe("OpenAI tool strict mode", () => {
 			tools?: Array<{ strict?: boolean }>;
 		};
 
+		expect(model.compat.supportsStrictMode).toBe(true);
 		expect(payload.tools?.[0]?.strict).toBe(false);
 	});
 

--- a/packages/ai/test/openai-tool-strict-mode.test.ts
+++ b/packages/ai/test/openai-tool-strict-mode.test.ts
@@ -710,6 +710,31 @@ describe("OpenAI tool strict mode", () => {
 		expect(payload.tools?.[0]?.strict).toBe(false);
 	});
 
+	it("keeps strict tools enabled for provider-id-only Azure Responses models (#4527)", async () => {
+		// Bundled Azure entries carry `provider: "azure"` with an empty baseUrl,
+		// so URL-only strict detection MUST NOT drop `supportsStrictMode` — the
+		// provider-id branch keeps `strict: true` on the wire for those models.
+		const model = buildModel({
+			id: "codex-mini",
+			name: "Codex Mini via Azure",
+			api: "openai-responses",
+			provider: "azure",
+			baseUrl: "",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8192,
+		} as ModelSpec<"openai-responses">);
+
+		const payload = (await captureResponsesPayload(model)) as {
+			tools?: Array<{ strict?: boolean }>;
+		};
+
+		expect(model.compat.supportsStrictMode).toBe(true);
+		expect(payload.tools?.[0]?.strict).toBe(true);
+	});
+
 	it("sends strict=true for openai-responses tool schemas on GitHub Copilot", async () => {
 		const model = getBundledModel("github-copilot", "gpt-5-mini") as Model<"openai-responses">;
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -586,13 +586,13 @@ interface OpenAIResponsesSpecLike {
 }
 
 /**
- * Build the resolved Responses-API compat record. The Responses flavor
- * deliberately differs from chat-completions: GitHub Copilot's responses
- * endpoint accepts the `developer` role, while strict tool mode is scoped to
- * first-party OpenAI/Azure/Copilot providers. Azure is detected by provider id
- * as well as URL — bundled `azure` models carry no baseUrl (the deployment host
- * is per-resource, resolved at runtime) — while OpenAI/Copilot developer-role
- * and prompt-cache detection stay URL-keyed, as the historical call sites were.
+ * Build the resolved Responses-API compat record. Most shared OpenAI-compatible
+ * capability defaults intentionally mirror chat-completions, while Responses-
+ * only behavior (developer role, prompt cache, pairing strictness, image detail)
+ * keeps endpoint-specific detection. Azure is detected by provider id as well
+ * as URL — bundled `azure` models carry no baseUrl (the deployment host is per-
+ * resource, resolved at runtime) — while OpenAI/Copilot developer-role and
+ * prompt-cache detection stay URL-keyed, as the historical call sites were.
  */
 export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): ResolvedOpenAIResponsesCompat {
 	const baseUrl = spec.baseUrl ?? "";
@@ -611,8 +611,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 
 	const compat: ResolvedOpenAIResponsesCompat = {
 		supportsDeveloperRole: isAzure || isOpenAIUrl || hostMatchesUrl(baseUrl, "githubCopilot"),
-		supportsStrictMode:
-			spec.provider === "openai" || isAzure || spec.provider === "github-copilot" || isOpenRouter || isOpenAIUrl,
+		supportsStrictMode: detectStrictModeSupport(spec.provider, baseUrl),
 		supportsReasoningEffort: spec.provider !== "xai-oauth" || isGrokReasoningEffortCapable(id),
 		supportsLongPromptCacheRetention: isOpenAIUrl,
 		// Azure OpenAI and GitHub Copilot Responses paths require tool results

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -611,7 +611,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 
 	const compat: ResolvedOpenAIResponsesCompat = {
 		supportsDeveloperRole: isAzure || isOpenAIUrl || hostMatchesUrl(baseUrl, "githubCopilot"),
-		supportsStrictMode: detectStrictModeSupport(spec.provider, baseUrl),
+		supportsStrictMode: isAzure || detectStrictModeSupport(spec.provider, baseUrl),
 		supportsReasoningEffort: spec.provider !== "xai-oauth" || isGrokReasoningEffortCapable(id),
 		supportsLongPromptCacheRetention: isOpenAIUrl,
 		// Azure OpenAI and GitHub Copilot Responses paths require tool results


### PR DESCRIPTION
## Repro

`packages/ai/src/providers/openai-responses.ts:857` gated the `strictMode` flag with a truthy check (`!disableStrictTools && model.compat.supportsStrictMode`), while `openai-completions.ts:2094`/`2128` uses `compat.supportsStrictMode !== false`. For a caller-constructed `Model<"openai-responses">` whose compat carries no explicit `supportsStrictMode` value (falsy under the pre-fix check, non-`false` under the completions semantic), the two provider paths disagreed for the same backend: a Responses call dropped the author's explicit `tool.strict === false` from the wire, while the sibling Completions call preserved it. Reproduced by building an `openai-responses` model on a host the Responses detector doesn't recognize (e.g. DeepSeek), which resolves `supportsStrictMode: false` and lets `convertTools([looseYieldTool], false, model)` emit `strict: undefined` instead of `strict: false`.

## Cause

PR #4340 attached the new "preserve author-set `strict: false`" clause to `strictMode`, a pre-existing variable whose truthy check was designed for "should we add `strict: true`". The completions path (#4340 as well) authored the analogous clause fresh with `!== false`, which is the correct "does this provider understand the `strict` field" semantic and is what `openai-codex-responses.ts` also relies on. The two branches therefore diverged for compat records that materialize `supportsStrictMode` to a non-`true` non-`false` value.

## Fix

- `packages/ai/src/providers/openai-responses.ts:857`: replace `model.compat.supportsStrictMode` with `model.compat.supportsStrictMode !== false` so the Responses gate matches the completions builder and the codex-responses passthrough.
- `packages/ai/src/providers/openai-responses.ts:990-997`: refresh the payload-emission comment to name #4527 and describe the aligned rule.
- `packages/ai/test/openai-tool-strict-mode.test.ts`: add a regression asserting a Responses model whose compat lacks `supportsStrictMode` still emits `strict: false` for an author-opted-out tool.
- `packages/ai/CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

## Verification

`bun test test/openai-tool-strict-mode.test.ts test/openai-responses-tool-quarantine.test.ts test/apply-patch-freeform.test.ts test/openai-codex.test.ts` — 80 tests pass, including the existing `omits explicit strict:false for openai-responses when compat disables the strict field` (which keeps its behavior — `false !== false` is `false`) and the new #4527 regression.

Fixes #4527