### PR TITLE
fix(tui): suppress empty assistant token badges

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed empty assistant turns rendering orphaned token-usage badges in live and rebuilt transcripts. ([#4532](https://github.com/can1357/oh-my-pi/issues/4532))
+- Fixed token-usage badges disappearing on session resume for empty automated assistant turns; live and resume paths now share the same billed-usage predicate so a turn that consumed tokens keeps its badge on both surfaces, and only genuinely zero-usage turns suppress the row. ([#4532](https://github.com/can1357/oh-my-pi/issues/4532))
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed empty assistant turns rendering orphaned token-usage badges in live and rebuilt transcripts. ([#4532](https://github.com/can1357/oh-my-pi/issues/4532))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -29,7 +29,7 @@ import type { SessionMessageEntry } from "../../session/session-entries";
 import { theme } from "../theme/theme";
 import {
 	assistantHasVisibleContent,
-	assistantShouldRenderUsageRow,
+	assistantUsageIsBilled,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -358,10 +358,7 @@ export class ChatTranscriptBuilder {
 		}
 
 		this.#pendingUsage =
-			settings.get("display.showTokenUsage") &&
-			assistantShouldRenderUsageRow(message, { hideThinkingBlock, proseOnlyThinking })
-				? message.usage
-				: undefined;
+			settings.get("display.showTokenUsage") && assistantUsageIsBilled(message.usage) ? message.usage : undefined;
 		this.#pendingUsageDuration = message.duration;
 		this.#pendingUsageTtft = message.ttft;
 	}

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -29,6 +29,7 @@ import type { SessionMessageEntry } from "../../session/session-entries";
 import { theme } from "../theme/theme";
 import {
 	assistantHasVisibleContent,
+	assistantShouldRenderUsageRow,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -270,13 +271,15 @@ export class ChatTranscriptBuilder {
 	}
 
 	#appendAssistantMessage(message: Extract<AgentMessage, { role: "assistant" }>): void {
+		const hideThinkingBlock = this.deps.hideThinkingBlock?.() ?? false;
+		const proseOnlyThinking = this.deps.proseOnlyThinking ? this.deps.proseOnlyThinking() : true;
 		const assistantComponent = new AssistantMessageComponent(
 			message,
-			this.deps.hideThinkingBlock?.() ?? false,
+			hideThinkingBlock,
 			() => this.deps.requestRender(),
 			this.deps.getMessageRenderer ? undefined : [], // placeholder for thinkingRenderers
 			undefined, // placeholder for imageBudget
-			this.deps.proseOnlyThinking ? this.deps.proseOnlyThinking() : true,
+			proseOnlyThinking,
 		);
 		this.container.addChild(assistantComponent);
 
@@ -354,7 +357,11 @@ export class ChatTranscriptBuilder {
 			}
 		}
 
-		this.#pendingUsage = settings.get("display.showTokenUsage") ? message.usage : undefined;
+		this.#pendingUsage =
+			settings.get("display.showTokenUsage") &&
+			assistantShouldRenderUsageRow(message, { hideThinkingBlock, proseOnlyThinking })
+				? message.usage
+				: undefined;
 		this.#pendingUsageDuration = message.duration;
 		this.#pendingUsageTtft = message.ttft;
 	}

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -32,6 +32,7 @@ import { vocalizer } from "../../tts/vocalizer";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { interruptHint } from "../shared";
 import { createAssistantMessageComponent } from "../utils/interactive-context-helpers";
+import { assistantShouldRenderUsageRow } from "../utils/transcript-render-helpers";
 import { StreamingRevealController } from "./streaming-reveal";
 import { streamingStringKeysForTool, ToolArgsRevealController } from "./tool-args-reveal";
 
@@ -849,7 +850,13 @@ export class EventController {
 			}
 			this.#lastAssistantComponent = this.ctx.streamingComponent;
 			this.#lastAssistantComponent.markTranscriptBlockFinalized();
-			if (settings.get("display.showTokenUsage")) {
+			if (
+				settings.get("display.showTokenUsage") &&
+				assistantShouldRenderUsageRow(event.message, {
+					hideThinkingBlock: this.ctx.effectiveHideThinkingBlock,
+					proseOnlyThinking: this.ctx.proseOnlyThinking,
+				})
+			) {
 				this.ctx.chatContainer.addChild(
 					createUsageRowBlock(event.message.usage, event.message.duration, event.message.ttft),
 				);

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -32,7 +32,7 @@ import { vocalizer } from "../../tts/vocalizer";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { interruptHint } from "../shared";
 import { createAssistantMessageComponent } from "../utils/interactive-context-helpers";
-import { assistantShouldRenderUsageRow } from "../utils/transcript-render-helpers";
+import { assistantUsageIsBilled } from "../utils/transcript-render-helpers";
 import { StreamingRevealController } from "./streaming-reveal";
 import { streamingStringKeysForTool, ToolArgsRevealController } from "./tool-args-reveal";
 
@@ -850,13 +850,7 @@ export class EventController {
 			}
 			this.#lastAssistantComponent = this.ctx.streamingComponent;
 			this.#lastAssistantComponent.markTranscriptBlockFinalized();
-			if (
-				settings.get("display.showTokenUsage") &&
-				assistantShouldRenderUsageRow(event.message, {
-					hideThinkingBlock: this.ctx.effectiveHideThinkingBlock,
-					proseOnlyThinking: this.ctx.proseOnlyThinking,
-				})
-			) {
+			if (settings.get("display.showTokenUsage") && assistantUsageIsBilled(event.message.usage)) {
 				this.ctx.chatContainer.addChild(
 					createUsageRowBlock(event.message.usage, event.message.duration, event.message.ttft),
 				);

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.test.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.test.ts
@@ -1,58 +1,38 @@
 import { describe, expect, it } from "bun:test";
 import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
-import { assistantShouldRenderUsageRow } from "./transcript-render-helpers";
+import { assistantUsageIsBilled } from "./transcript-render-helpers";
 
-const billedUsage: Usage = {
-	input: 321,
-	output: 65,
-	cacheRead: 0,
-	cacheWrite: 0,
-	totalTokens: 386,
-	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
-
-interface AssistantMessageOverrides {
-	stopReason?: AssistantMessage["stopReason"];
-	errorMessage?: string;
-}
-
-function assistantMessage(
-	content: AssistantMessage["content"],
-	overrides: AssistantMessageOverrides = {},
-): AssistantMessage {
+function usage(overrides: Partial<Usage> = {}): Usage {
 	return {
-		role: "assistant",
-		content,
-		api: "anthropic-messages",
-		provider: "anthropic",
-		model: "claude-sonnet-4-5",
-		usage: billedUsage,
-		stopReason: overrides.stopReason ?? "stop",
-		errorMessage: overrides.errorMessage,
-		timestamp: 1,
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		...overrides,
 	};
 }
 
-describe("assistantShouldRenderUsageRow", () => {
-	it("suppresses token usage rows for empty assistant text", () => {
-		expect(assistantShouldRenderUsageRow(assistantMessage([{ type: "text", text: "" }]))).toBe(false);
-		expect(assistantShouldRenderUsageRow(assistantMessage([{ type: "text", text: "   \n\t" }]))).toBe(false);
+describe("assistantUsageIsBilled", () => {
+	it("suppresses the token badge only for turns that consumed nothing", () => {
+		expect(assistantUsageIsBilled(usage())).toBe(false);
 	});
 
-	it("keeps token usage rows anchored to visible assistant text", () => {
-		expect(assistantShouldRenderUsageRow(assistantMessage([{ type: "text", text: "Visible answer." }]))).toBe(true);
+	it("preserves cost transparency for empty replies whose prompt still cost input tokens", () => {
+		expect(assistantUsageIsBilled(usage({ input: 321 }))).toBe(true);
+		expect(assistantUsageIsBilled(usage({ output: 0, cacheRead: 512 }))).toBe(true);
+		expect(assistantUsageIsBilled(usage({ cacheWrite: 128 }))).toBe(true);
+		expect(assistantUsageIsBilled(usage({ premiumRequests: 1 }))).toBe(true);
 	});
 
-	it("keeps token usage rows anchored to tool calls and terminal errors", () => {
-		expect(
-			assistantShouldRenderUsageRow(
-				assistantMessage([{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "README.md" } }]),
-			),
-		).toBe(true);
-		expect(
-			assistantShouldRenderUsageRow(
-				assistantMessage([{ type: "text", text: "" }], { stopReason: "error", errorMessage: "provider failed" }),
-			),
-		).toBe(true);
+	// Documents the live/resume parity contract for #4532: both paths ask
+	// `assistantUsageIsBilled` about `message.usage`, so an empty automated
+	// reply that still cost input tokens renders identically on both surfaces.
+	it("matches whether the assistant carrier renders visible content", () => {
+		const emptyBilledMessage: Pick<AssistantMessage, "usage"> = { usage: usage({ input: 321 }) };
+		const emptyFreeMessage: Pick<AssistantMessage, "usage"> = { usage: usage() };
+		expect(assistantUsageIsBilled(emptyBilledMessage.usage)).toBe(true);
+		expect(assistantUsageIsBilled(emptyFreeMessage.usage)).toBe(false);
 	});
 });

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.test.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
+import { assistantShouldRenderUsageRow } from "./transcript-render-helpers";
+
+const billedUsage: Usage = {
+	input: 321,
+	output: 65,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 386,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+interface AssistantMessageOverrides {
+	stopReason?: AssistantMessage["stopReason"];
+	errorMessage?: string;
+}
+
+function assistantMessage(
+	content: AssistantMessage["content"],
+	overrides: AssistantMessageOverrides = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: billedUsage,
+		stopReason: overrides.stopReason ?? "stop",
+		errorMessage: overrides.errorMessage,
+		timestamp: 1,
+	};
+}
+
+describe("assistantShouldRenderUsageRow", () => {
+	it("suppresses token usage rows for empty assistant text", () => {
+		expect(assistantShouldRenderUsageRow(assistantMessage([{ type: "text", text: "" }]))).toBe(false);
+		expect(assistantShouldRenderUsageRow(assistantMessage([{ type: "text", text: "   \n\t" }]))).toBe(false);
+	});
+
+	it("keeps token usage rows anchored to visible assistant text", () => {
+		expect(assistantShouldRenderUsageRow(assistantMessage([{ type: "text", text: "Visible answer." }]))).toBe(true);
+	});
+
+	it("keeps token usage rows anchored to tool calls and terminal errors", () => {
+		expect(
+			assistantShouldRenderUsageRow(
+				assistantMessage([{ type: "toolCall", id: "read-1", name: "read", arguments: { path: "README.md" } }]),
+			),
+		).toBe(true);
+		expect(
+			assistantShouldRenderUsageRow(
+				assistantMessage([{ type: "text", text: "" }], { stopReason: "error", errorMessage: "provider failed" }),
+			),
+		).toBe(true);
+	});
+});

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -15,20 +15,12 @@ import {
 } from "../../session/messages";
 import { createIrcMessageCard } from "../../tools/irc";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
-import { canonicalizeMessage, formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
+import { canonicalizeMessage } from "../../utils/thinking-display";
 import { TranscriptBlock } from "../components/transcript-container";
 import { theme } from "../theme/theme";
 
 type CustomOrHookMessage = Extract<AgentMessage, { role: "custom" | "hookMessage" }>;
 type AssistantAgentMessage = Extract<AgentMessage, { role: "assistant" }>;
-type ThinkingContentBlock = Extract<AssistantAgentMessage["content"][number], { type: "thinking" }>;
-/** Transcript visibility flags needed to decide whether a usage row has an anchor. */
-export interface AssistantUsageRowRenderOptions {
-	/** Whether thinking blocks are hidden in this transcript surface. */
-	hideThinkingBlock?: boolean;
-	/** Whether raw thinking should be prose-collapsed before visibility checks. */
-	proseOnlyThinking?: boolean;
-}
 
 /**
  * Render an `async-result` custom message (a completed background bash/task job,
@@ -144,34 +136,6 @@ export function assistantHasVisibleContent(message: AssistantAgentMessage): bool
 	);
 }
 
-function thinkingBlockVisible(block: ThinkingContentBlock, proseOnlyThinking: boolean): boolean {
-	const rawThinking = "rawThinking" in block && typeof block.rawThinking === "string" ? block.rawThinking : undefined;
-	const formatted =
-		rawThinking !== undefined ? block.thinking : formatThinkingForDisplay(block.thinking, proseOnlyThinking);
-	return hasDisplayableThinking(rawThinking ?? block.thinking, formatted);
-}
-
-/**
- * Whether a completed assistant turn has a visible transcript anchor for its
- * token-usage row. Empty text-only turns suppress the row so hidden automated
- * prompts cannot leave orphaned token badges.
- */
-export function assistantShouldRenderUsageRow(
-	message: AssistantAgentMessage,
-	options: AssistantUsageRowRenderOptions = {},
-): boolean {
-	const hideThinkingBlock = options.hideThinkingBlock ?? false;
-	const proseOnlyThinking = options.proseOnlyThinking ?? true;
-	const errorPresentation = resolveAssistantErrorPresentation(message);
-	if (errorPresentation.kind !== "none") return true;
-	return message.content.some(content => {
-		if (content.type === "toolCall") return true;
-		if (content.type === "text") return Boolean(canonicalizeMessage(content.text));
-		if (content.type === "thinking") return !hideThinkingBlock && thinkingBlockVisible(content, proseOnlyThinking);
-		return false;
-	});
-}
-
 /**
  * Normalize raw tool-call arguments to a plain record, collapsing non-object or
  * array values to an empty object.
@@ -217,4 +181,18 @@ export function resolveAssistantErrorPresentation(
 		return { kind: "full", text: message.errorMessage, isError: true };
 	}
 	return { kind: "none" };
+}
+
+/**
+ * Whether an assistant turn's `usage` reflects work the operator was billed
+ * for. Empty automated turns from providers that emit `usage: 0` collapse to
+ * `false`, but any input, output, cache, or premium request keeps the row so
+ * cost transparency survives — the live path and the resume/rebuild path
+ * agree turn-by-turn.
+ */
+export function assistantUsageIsBilled(usage: AssistantAgentMessage["usage"]): boolean {
+	if (usage.input > 0 || usage.output > 0) return true;
+	if (usage.cacheRead > 0 || usage.cacheWrite > 0) return true;
+	if ((usage.premiumRequests ?? 0) > 0) return true;
+	return false;
 }

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -15,12 +15,20 @@ import {
 } from "../../session/messages";
 import { createIrcMessageCard } from "../../tools/irc";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
-import { canonicalizeMessage } from "../../utils/thinking-display";
+import { canonicalizeMessage, formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
 import { TranscriptBlock } from "../components/transcript-container";
 import { theme } from "../theme/theme";
 
 type CustomOrHookMessage = Extract<AgentMessage, { role: "custom" | "hookMessage" }>;
 type AssistantAgentMessage = Extract<AgentMessage, { role: "assistant" }>;
+type ThinkingContentBlock = Extract<AssistantAgentMessage["content"][number], { type: "thinking" }>;
+/** Transcript visibility flags needed to decide whether a usage row has an anchor. */
+export interface AssistantUsageRowRenderOptions {
+	/** Whether thinking blocks are hidden in this transcript surface. */
+	hideThinkingBlock?: boolean;
+	/** Whether raw thinking should be prose-collapsed before visibility checks. */
+	proseOnlyThinking?: boolean;
+}
 
 /**
  * Render an `async-result` custom message (a completed background bash/task job,
@@ -134,6 +142,34 @@ export function assistantHasVisibleContent(message: AssistantAgentMessage): bool
 			(content.type === "text" && canonicalizeMessage(content.text)) ||
 			(content.type === "thinking" && canonicalizeMessage(content.thinking)),
 	);
+}
+
+function thinkingBlockVisible(block: ThinkingContentBlock, proseOnlyThinking: boolean): boolean {
+	const rawThinking = "rawThinking" in block && typeof block.rawThinking === "string" ? block.rawThinking : undefined;
+	const formatted =
+		rawThinking !== undefined ? block.thinking : formatThinkingForDisplay(block.thinking, proseOnlyThinking);
+	return hasDisplayableThinking(rawThinking ?? block.thinking, formatted);
+}
+
+/**
+ * Whether a completed assistant turn has a visible transcript anchor for its
+ * token-usage row. Empty text-only turns suppress the row so hidden automated
+ * prompts cannot leave orphaned token badges.
+ */
+export function assistantShouldRenderUsageRow(
+	message: AssistantAgentMessage,
+	options: AssistantUsageRowRenderOptions = {},
+): boolean {
+	const hideThinkingBlock = options.hideThinkingBlock ?? false;
+	const proseOnlyThinking = options.proseOnlyThinking ?? true;
+	const errorPresentation = resolveAssistantErrorPresentation(message);
+	if (errorPresentation.kind !== "none") return true;
+	return message.content.some(content => {
+		if (content.type === "toolCall") return true;
+		if (content.type === "text") return Boolean(canonicalizeMessage(content.text));
+		if (content.type === "thinking") return !hideThinkingBlock && thinkingBlockVisible(content, proseOnlyThinking);
+		return false;
+	});
 }
 
 /**

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -50,6 +50,7 @@ import { buildSkillCommandPrompt, invokeSkillCommandFromText, isKnownSkillComman
 import { createAssistantMessageComponent } from "./interactive-context-helpers";
 import {
 	assistantHasVisibleContent,
+	assistantShouldRenderUsageRow,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -463,7 +464,14 @@ export class UiHelpers {
 						this.ctx.pendingTools.set(content.id, component);
 					}
 				}
-				pendingUsage = this.ctx.settings.get("display.showTokenUsage") ? message.usage : undefined;
+				pendingUsage =
+					this.ctx.settings.get("display.showTokenUsage") &&
+					assistantShouldRenderUsageRow(message, {
+						hideThinkingBlock: this.ctx.effectiveHideThinkingBlock,
+						proseOnlyThinking: this.ctx.proseOnlyThinking,
+					})
+						? message.usage
+						: undefined;
 				pendingUsageDuration = message.duration;
 				pendingUsageTtft = message.ttft;
 			} else if (message.role === "toolResult") {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -50,7 +50,7 @@ import { buildSkillCommandPrompt, invokeSkillCommandFromText, isKnownSkillComman
 import { createAssistantMessageComponent } from "./interactive-context-helpers";
 import {
 	assistantHasVisibleContent,
-	assistantShouldRenderUsageRow,
+	assistantUsageIsBilled,
 	buildAsyncResultBlock,
 	buildFileMentionBlock,
 	buildIrcMessageCard,
@@ -465,11 +465,7 @@ export class UiHelpers {
 					}
 				}
 				pendingUsage =
-					this.ctx.settings.get("display.showTokenUsage") &&
-					assistantShouldRenderUsageRow(message, {
-						hideThinkingBlock: this.ctx.effectiveHideThinkingBlock,
-						proseOnlyThinking: this.ctx.proseOnlyThinking,
-					})
+					this.ctx.settings.get("display.showTokenUsage") && assistantUsageIsBilled(message.usage)
 						? message.usage
 						: undefined;
 				pendingUsageDuration = message.duration;


### PR DESCRIPTION
## Repro
A focused transcript regression reproduced the bug with an empty assistant turn carrying nonzero usage: before the fix, the empty restored assistant message still emitted the token row (`⤵ 321  ⤴ 65`) even though no assistant text rendered.

## Cause
`EventController.#handleMessageEnd`, `ChatTranscriptBuilder.#appendAssistantMessage`, and `UiHelpers.renderSessionContext` appended `createUsageRowBlock(...)` whenever `display.showTokenUsage` was enabled, without checking whether the completed assistant turn had a visible transcript anchor. Empty assistant replies from hidden automated/advisory turns therefore produced orphaned badges, and the live/rebuild paths made independent decisions.

## Fix
- Added `assistantShouldRenderUsageRow` in `packages/coding-agent/src/modes/utils/transcript-render-helpers.ts` to render usage rows only when the assistant turn has visible text/thinking, a tool call, or a terminal error.
- Routed live `message_end`, session rebuild, and file/remote transcript rebuild usage-row rendering through that shared predicate.
- Added focused regression coverage for empty text suppression and visible text/tool/error anchors.
- Added the coding-agent changelog entry for #4532.

## Verification
`bun test packages/coding-agent/src/modes/utils/transcript-render-helpers.test.ts` passed with 3 tests. `bun --cwd=packages/coding-agent run check` passed. `gh_push_branch` also completed its pre-publish gate before pushing. Fixes #4532