### PR TITLE
fix(coding-agent): restore fallback model selection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed retry fallback model recovery by exposing `retry.fallbackChains` in `/settings`, adding a `/model` action to assign the selected default fallback model, and clearing a selected model's retry cooldown marker on manual model switches. ([#4533](https://github.com/can1357/oh-my-pi/issues/4533))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2215,6 +2215,15 @@ export class ModelRegistry {
 	}
 
 	/**
+	 * Clear the cooldown suppression for one selector after an explicit user selection.
+	 */
+	clearSuppressedSelector(selector: string): void {
+		this.#suppressedSelectors.delete(
+			normalizeSuppressedSelector(selector, (provider, id) => this.find(provider, id) !== undefined),
+		);
+	}
+
+	/**
 	 * Clear all cooldown suppressions recorded via {@link suppressSelector}.
 	 * Used to reset retry-fallback cooldown state without a full {@link refresh}.
 	 */

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1367,7 +1367,17 @@ export const SETTINGS_SCHEMA = {
 			description: "Allow retry recovery to switch to configured fallback models",
 		},
 	},
-	"retry.fallbackChains": { type: "record", default: {} as Record<string, string[]> },
+	"retry.fallbackChains": {
+		type: "record",
+		default: {} as Record<string, string[]>,
+		ui: {
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Retry Fallback Chains",
+			description:
+				'JSON object mapping model roles to ordered fallback model selectors, e.g. {"default":["openai/gpt-4o-mini"]}.',
+		},
+	},
 	"retry.fallbackRevertPolicy": {
 		type: "enum",
 		values: ["cooldown-expiry", "never"] as const,

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -90,16 +90,20 @@ interface RoleAssignment {
 	autoSelected: boolean;
 }
 
+type ModelSelectorAction = "modelRole" | "retryFallback";
+
 type RoleSelectCallback = (
 	model: Model,
 	role: string | null,
 	thinkingLevel?: ConfiguredThinkingLevel,
 	selector?: string,
+	action?: ModelSelectorAction,
 ) => void;
 type CancelCallback = () => void;
 interface MenuRoleAction {
 	label: string;
-	role: string; // now accepts custom role strings
+	role: string;
+	action: ModelSelectorAction;
 }
 
 interface ProviderTabState {
@@ -284,14 +288,19 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#buildMenuRoleActions(): void {
-		this.#menuRoleActions = getKnownRoleIds(this.#settings).map(role => {
+		const roleActions = getKnownRoleIds(this.#settings).map(role => {
 			const roleInfo = getRoleInfo(role, this.#settings);
 			const roleLabel = roleInfo.tag ? `${roleInfo.tag} (${roleInfo.name})` : roleInfo.name;
 			return {
 				label: `Set as ${roleLabel}`,
 				role,
+				action: "modelRole" as const,
 			};
 		});
+		this.#menuRoleActions = [
+			...roleActions,
+			{ label: "Set as DEFAULT retry fallback", role: "default", action: "retryFallback" },
+		];
 	}
 
 	#loadRoleModels(autoCandidateModels?: ReadonlyArray<Model>): void {
@@ -1195,6 +1204,11 @@ export class ModelSelectorComponent extends Container {
 			if (this.#menuStep === "role") {
 				const action = this.#menuRoleActions[this.#menuSelectedIndex];
 				if (!action) return;
+				if (action.action === "retryFallback") {
+					this.#handleSelect(selectedItem, action.role, undefined, action.action);
+					this.#closeMenu();
+					return;
+				}
 				this.#menuSelectedRole = action.role;
 				this.#menuStep = "thinking";
 				this.#menuSelectedIndex = this.#getThinkingPreselectIndex(action.role, selectedItem.model);
@@ -1206,7 +1220,7 @@ export class ModelSelectorComponent extends Container {
 			const thinkingOptions = this.#getThinkingLevelsForModel(selectedItem.model);
 			const thinkingLevel = thinkingOptions[this.#menuSelectedIndex];
 			if (!thinkingLevel) return;
-			this.#handleSelect(selectedItem, this.#menuSelectedRole, thinkingLevel);
+			this.#handleSelect(selectedItem, this.#menuSelectedRole, thinkingLevel, "modelRole");
 			this.#closeMenu();
 			return;
 		}
@@ -1225,13 +1239,23 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 
-	#handleSelect(item: ModelItem, role: string | null, thinkingLevel?: ConfiguredThinkingLevel): void {
+	#handleSelect(
+		item: ModelItem,
+		role: string | null,
+		thinkingLevel?: ConfiguredThinkingLevel,
+		action: ModelSelectorAction = "modelRole",
+	): void {
 		if (this.#isItemDisabled(item)) {
 			return;
 		}
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
-			this.#onSelectCallback(item.model, null, undefined, item.selector);
+			this.#onSelectCallback(item.model, null, undefined, item.selector, action);
+			return;
+		}
+
+		if (action === "retryFallback") {
+			this.#onSelectCallback(item.model, role, undefined, item.selector, action);
 			return;
 		}
 
@@ -1241,7 +1265,7 @@ export class ModelSelectorComponent extends Container {
 		this.#roles[role] = { model: item.model, thinkingLevel: selectedThinkingLevel, autoSelected: false };
 
 		// Notify caller (for updating agent state if needed)
-		this.#onSelectCallback(item.model, role, selectedThinkingLevel, item.selector);
+		this.#onSelectCallback(item.model, role, selectedThinkingLevel, item.selector, action);
 
 		// Update list to show new badges
 		this.#updateList();

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -180,7 +180,7 @@ function pathToSettingDef(path: SettingPath): SettingDef | null {
 	}
 
 	if (schemaType === "record") {
-		return path === "providers.maxInFlightRequests" ? { ...base, type: "providerLimits" } : null;
+		return path === "providers.maxInFlightRequests" ? { ...base, type: "providerLimits" } : { ...base, type: "text" };
 	}
 
 	return null;

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -593,13 +593,27 @@ export class SelectorController {
 				this.ctx.settings,
 				this.ctx.session.modelRegistry,
 				this.ctx.session.scopedModels,
-				async (model, role, thinkingLevel, selector) => {
+				async (model, role, thinkingLevel, selector, action) => {
 					// `auto` is session-global: never baked into a per-role model value
 					// (it can't round-trip through `model:<level>`). Apply it to the session
 					// separately and persist via `defaultThinkingLevel`.
 					const isAuto = thinkingLevel === AUTO_THINKING;
 					const concreteThinking = isAuto ? undefined : thinkingLevel;
+					const selectorValue = selector ?? `${model.provider}/${model.id}`;
 					try {
+						if (action === "retryFallback" && role !== null) {
+							const fallbackSelector = formatModelSelectorValue(selectorValue, concreteThinking);
+							const fallbackChains = this.ctx.settings.get("retry.fallbackChains");
+							const chain = fallbackChains[role] ?? [];
+							this.ctx.settings.set("retry.fallbackChains", {
+								...fallbackChains,
+								[role]: [fallbackSelector, ...chain.filter(existing => existing !== fallbackSelector)],
+							});
+							const roleInfo = getRoleInfo(role, settings);
+							const roleLabel = roleInfo?.name ?? role;
+							this.ctx.showStatus(`${roleLabel} fallback model: ${fallbackSelector}`);
+							return;
+						}
 						if (role === null) {
 							// Temporary: update agent state but don't persist the model to settings
 							await this.ctx.session.setModelTemporary(model);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13122,10 +13122,7 @@ export class AgentSession {
 		if (
 			Array.isArray(defaultChain) &&
 			defaultChain.length > 0 &&
-			this.#getRetryFallbackPrimarySelector("default") === undefined &&
-			Object.entries(chains).every(
-				([role, chain]) => role === "default" || !Array.isArray(chain) || chain.length === 0,
-			)
+			this.#getRetryFallbackPrimarySelector("default") === undefined
 		) {
 			return "default";
 		}
@@ -13155,11 +13152,7 @@ export class AgentSession {
 			if (
 				Array.isArray(defaultChain) &&
 				defaultChain.length > 0 &&
-				this.#getRetryFallbackPrimarySelector("default") === undefined &&
-				Object.entries(chains).every(
-					([chainRole, roleChain]) =>
-						chainRole === "default" || !Array.isArray(roleChain) || roleChain.length === 0,
-				)
+				this.#getRetryFallbackPrimarySelector("default") === undefined
 			) {
 				const seen = new Set<string>([parsedCurrent.raw]);
 				chain = [parsedCurrent];

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13096,6 +13096,7 @@ export class AgentSession {
 	#resolveRetryFallbackRole(currentSelector: string): string | undefined {
 		const parsedCurrent = parseRetryFallbackSelector(currentSelector, this.#modelRegistry);
 		if (!parsedCurrent) return undefined;
+		const chains = this.#getRetryFallbackChains();
 		const currentBaseSelector = formatRetryFallbackBaseSelector(parsedCurrent);
 		const currentPlainSelector = this.model
 			? formatModelSelectorValue(formatModelString(this.model), parsedCurrent.thinkingLevel)
@@ -13105,17 +13106,28 @@ export class AgentSession {
 				? formatRetryFallbackBaseSelector(parseRetryFallbackSelector(currentPlainSelector) ?? parsedCurrent)
 				: undefined;
 
-		for (const role of Object.keys(this.#getRetryFallbackChains())) {
+		for (const role of Object.keys(chains)) {
 			const primarySelector = this.#getRetryFallbackPrimarySelector(role);
 			if (primarySelector?.raw === currentSelector) return role;
 		}
-		for (const role of Object.keys(this.#getRetryFallbackChains())) {
+		for (const role of Object.keys(chains)) {
 			const primarySelector = this.#getRetryFallbackPrimarySelector(role);
 			if (!primarySelector) continue;
 			if (currentPlainSelector && primarySelector.raw === currentPlainSelector) return role;
 			const primaryBaseSelector = formatRetryFallbackBaseSelector(primarySelector);
 			if (primaryBaseSelector === currentBaseSelector) return role;
 			if (currentPlainBaseSelector && primaryBaseSelector === currentPlainBaseSelector) return role;
+		}
+		const defaultChain = chains.default;
+		if (
+			Array.isArray(defaultChain) &&
+			defaultChain.length > 0 &&
+			this.#getRetryFallbackPrimarySelector("default") === undefined &&
+			Object.entries(chains).every(
+				([role, chain]) => role === "default" || !Array.isArray(chain) || chain.length === 0,
+			)
+		) {
+			return "default";
 		}
 		return undefined;
 	}
@@ -13135,9 +13147,31 @@ export class AgentSession {
 	}
 
 	#findRetryFallbackCandidates(role: string, currentSelector: string): RetryFallbackSelector[] {
-		const chain = this.#getRetryFallbackEffectiveChain(role);
-		if (chain.length <= 1) return [];
+		let chain = this.#getRetryFallbackEffectiveChain(role);
 		const parsedCurrent = parseRetryFallbackSelector(currentSelector, this.#modelRegistry);
+		if (chain.length === 0 && role === "default" && parsedCurrent) {
+			const chains = this.#getRetryFallbackChains();
+			const defaultChain = chains.default;
+			if (
+				Array.isArray(defaultChain) &&
+				defaultChain.length > 0 &&
+				this.#getRetryFallbackPrimarySelector("default") === undefined &&
+				Object.entries(chains).every(
+					([chainRole, roleChain]) =>
+						chainRole === "default" || !Array.isArray(roleChain) || roleChain.length === 0,
+				)
+			) {
+				const seen = new Set<string>([parsedCurrent.raw]);
+				chain = [parsedCurrent];
+				for (const selector of defaultChain) {
+					const parsed = parseRetryFallbackSelector(selector, this.#modelRegistry);
+					if (!parsed || seen.has(parsed.raw)) continue;
+					seen.add(parsed.raw);
+					chain.push(parsed);
+				}
+			}
+		}
+		if (chain.length <= 1) return [];
 		const currentBaseSelector = parsedCurrent ? formatRetryFallbackBaseSelector(parsedCurrent) : undefined;
 		const currentPlainSelector =
 			this.model && parsedCurrent

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8678,6 +8678,7 @@ export class AgentSession {
 
 		const targetModel = await this.#modelRegistry.refreshSelectedModelMetadata(model);
 
+		this.#modelRegistry.clearSuppressedSelector(formatModelStringWithRouting(targetModel));
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(targetModel);
 		this.sessionManager.appendModelChange(`${targetModel.provider}/${targetModel.id}`, role);
@@ -8715,6 +8716,7 @@ export class AgentSession {
 
 		const targetModel = await this.#modelRegistry.refreshSelectedModelMetadata(model);
 
+		this.#modelRegistry.clearSuppressedSelector(formatModelStringWithRouting(targetModel));
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(targetModel);
 		this.sessionManager.appendModelChange(
@@ -8874,6 +8876,7 @@ export class AgentSession {
 		const next = scopedModels[nextIndex];
 
 		// Apply model
+		this.#modelRegistry.clearSuppressedSelector(formatModelStringWithRouting(next.model));
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(next.model);
 		this.sessionManager.appendModelChange(`${next.model.provider}/${next.model.id}`);
@@ -8904,6 +8907,7 @@ export class AgentSession {
 			throw new Error(`No API key for ${nextModel.provider}/${nextModel.id}`);
 		}
 
+		this.#modelRegistry.clearSuppressedSelector(formatModelStringWithRouting(nextModel));
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(nextModel);
 		this.sessionManager.appendModelChange(`${nextModel.provider}/${nextModel.id}`);

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -219,6 +219,57 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
+	it("uses the active initial model as the default fallback primary when the default role is unset", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled test models to exist");
+		}
+
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const agent = createFallbackAgent(primaryModel, requestedModels);
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Recover using implicit default primary");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(session.model?.provider).toBe(fallbackModel.provider);
+		expect(session.model?.id).toBe(fallbackModel.id);
+		expect(fallbackAppliedEvents).toEqual([
+			{
+				type: "retry_fallback_applied",
+				from: `${primaryModel.provider}/${primaryModel.id}`,
+				to: `${fallbackModel.provider}/${fallbackModel.id}`,
+				role: "default",
+			},
+		]);
+	});
+
 	it("falls back on structured classifier refusals and pins the fallback", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -219,10 +219,11 @@ describe("AgentSession retry fallback", () => {
 		]);
 	});
 
-	it("uses the active initial model as the default fallback primary when the default role is unset", async () => {
+	it("uses the active initial model as the default fallback primary when other role fallback chains are configured", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
-		if (!primaryModel || !fallbackModel) {
+		const otherRoleFallbackModel = getBundledModel("openai", "gpt-4o");
+		if (!primaryModel || !fallbackModel || !otherRoleFallbackModel) {
 			throw new Error("Expected bundled test models to exist");
 		}
 
@@ -235,6 +236,7 @@ describe("AgentSession retry fallback", () => {
 			"retry.maxRetries": 1,
 			"retry.fallbackChains": {
 				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+				smol: [`${otherRoleFallbackModel.provider}/${otherRoleFallbackModel.id}`],
 			},
 		});
 

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -14,6 +14,35 @@ function normalizeRenderedText(text: string): string {
 	return stripVTControlCharacters(text).replace(/\s+/g, " ").trim();
 }
 
+const DEFAULT_RETRY_FALLBACK_ACTION_LABEL = "Set as DEFAULT retry fallback";
+const DEFAULT_RETRY_FALLBACK_ACTION = "retryFallback";
+
+type ModelSelectorAction = "modelRole" | typeof DEFAULT_RETRY_FALLBACK_ACTION;
+type TestRoleSelectArgs = [
+	model: Model,
+	role: string | null,
+	thinkingLevel?: ConfiguredThinkingLevel,
+	selector?: string,
+	action?: ModelSelectorAction,
+];
+type TestRoleSelectCallback = (...args: TestRoleSelectArgs) => void;
+
+function isSelectedMenuLine(line: string): boolean {
+	const trimmed = line.trimStart();
+	return trimmed.startsWith("❯") || trimmed.startsWith("▸") || trimmed.startsWith(">") || trimmed.startsWith("\uf054");
+}
+
+function selectMenuAction(selector: ModelSelectorComponent, label: string): void {
+	for (let attempt = 0; attempt < 20; attempt++) {
+		const selectedTarget = stripVTControlCharacters(selector.render(220).join("\n"))
+			.split("\n")
+			.find(line => line.includes(label) && isSelectedMenuLine(line));
+		if (selectedTarget) return;
+		selector.handleInput("\x1b[B");
+	}
+	throw new Error(`Menu action not selectable: ${label}`);
+}
+
 function createSelector(model: Model, settings: Settings): ModelSelectorComponent {
 	const modelRegistry = {
 		getAll: () => [model],
@@ -66,7 +95,7 @@ function createContextTestModel(id: string, contextWindow: number): Model {
 function createScopedSelector(
 	models: Model[],
 	settings: Settings,
-	onSelect: (model: Model, role: string | null, thinkingLevel?: ConfiguredThinkingLevel, selector?: string) => void,
+	onSelect: TestRoleSelectCallback,
 	options?: { temporaryOnly?: boolean; currentContextTokens?: number },
 ): ModelSelectorComponent {
 	const modelRegistry = {
@@ -82,7 +111,13 @@ function createScopedSelector(
 		settings,
 		modelRegistry,
 		models.map(model => ({ model })),
-		(model, role, thinkingLevel, selector) => onSelect(model, role, thinkingLevel, selector),
+		(
+			model: Model,
+			role: string | null,
+			thinkingLevel?: ConfiguredThinkingLevel,
+			selector?: string,
+			action?: ModelSelectorAction,
+		) => onSelect(model, role, thinkingLevel, selector, action),
 		() => {},
 		options,
 	);
@@ -297,6 +332,32 @@ describe("ModelSelector role badge thinking display", () => {
 		expect(onSelect.mock.calls[0]?.[0]).toBe(small);
 		expect(onSelect.mock.calls[0]?.[1]).toBe("default");
 		expect(onSelect.mock.calls[0]?.[3]).toBe("test/only-small");
+	});
+
+	test("assigns selected model as default retry fallback without opening thinking options", () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const fallback = createContextTestModel("retry-fallback-model", 128_000);
+		const onSelect = vi.fn();
+		const selector = createScopedSelector([fallback], settings, onSelect);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		const menuRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(menuRendered).toContain("Action for: retry-fallback-model");
+		expect(menuRendered).toContain(DEFAULT_RETRY_FALLBACK_ACTION_LABEL);
+
+		selectMenuAction(selector, DEFAULT_RETRY_FALLBACK_ACTION_LABEL);
+		selector.handleInput("\n");
+
+		const afterEnter = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(afterEnter).not.toContain("Thinking for:");
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		const call = onSelect.mock.calls[0];
+		expect(call?.[0]).toBe(fallback);
+		expect(call?.[1]).toBe("default");
+		expect(call?.[3]).toBe("test/retry-fallback-model");
+		expect(call?.[4]).toBe(DEFAULT_RETRY_FALLBACK_ACTION);
 	});
 
 	test("uses cached models for Enter while offline refresh is still pending", () => {

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -97,4 +97,22 @@ describe("settings layout", () => {
 			group: "Services",
 		});
 	});
+
+	it("exposes retry fallback chains as editable JSON in the model settings", () => {
+		const def = getSettingsForTab("model").find(item => item.path === "retry.fallbackChains");
+
+		expect(def).toMatchObject({
+			path: "retry.fallbackChains",
+			type: "text",
+			tab: "model",
+			group: "Retry & Fallback",
+			label: "Retry Fallback Chains",
+		});
+		if (!def) throw new Error("retry.fallbackChains setting definition missing");
+
+		const description = def.description.toLowerCase();
+		expect(description).toContain("json");
+		expect(description).toContain("fallback");
+		expect(description).toContain("selector");
+	});
 });


### PR DESCRIPTION
## Repro
`/model` only exposed model-role assignments, and `/settings` hid `retry.fallbackChains` because record settings without a dedicated adapter were filtered out. Reproduced by inspecting `packages/coding-agent/src/modes/components/model-selector.ts`, `packages/coding-agent/src/modes/components/settings-defs.ts`, and `packages/coding-agent/src/config/settings-schema.ts`: there was no retry-fallback action and no settings UI entry for fallback chains.

## Cause
`ModelSelectorComponent.#buildMenuRoleActions` built the action menu exclusively from configured model roles, so users could not assign a fallback model from the model picker. `settings-defs.ts` returned `null` for record settings other than `providers.maxInFlightRequests`, and `retry.fallbackChains` had no UI metadata in `settings-schema.ts`, so the existing fallback-chain setting was unreachable from `/settings`. Manual model switches also cleared the active fallback state but left the selected model's retry cooldown suppression in `ModelRegistry`, making an explicit return to the original model fight the previous fallback cooldown.

## Fix
- Added `/settings` metadata for `retry.fallbackChains` and exposed non-provider-limit record settings as JSON text inputs.
- Added a `/model` action that assigns the selected model as the default retry fallback without entering the thinking submenu.
- Persisted that model-picker fallback action into `retry.fallbackChains.default` while preserving existing fallback-chain order after the selected model.
- Added a single-selector cooldown clear path in `ModelRegistry` and invoke it on manual model switches/cycles so selecting the original model overrides the stale fallback suppression.
- Added regression coverage for the fallback model-picker action and settings visibility.
- Added a coding-agent changelog entry for #4533.

## Verification
`bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts packages/coding-agent/test/modes/components/settings-layout.test.ts` passed: 20 pass, 0 fail. `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts` passed: 23 pass, 0 fail. `bun check` passed across the workspace. Fixes #4533