### PR TITLE
fix(providers): remove xAI web_search search_parameters

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed xAI `web_search` sending unsupported request-level `search_parameters` to the Responses Agent Tools API; result counts are now enforced locally without adding deprecated live-search date bounds. ([#4537](https://github.com/can1357/oh-my-pi/issues/4537))
+
 - Fixed raw `read` ranges not contributing to edit seen-line provenance, so re-reading an anchor range with `:raw` now unblocks hashline edits without adding non-raw line prefixes.
 - Fixed replan-driven session title refresh updating the statusline but not the terminal window title: terminal-title updates now fire from the session-name-changed listener, so every `setSessionName` path (first-input titling, `/rename`, plan seeding, replan refresh) sets the OSC title consistently.
 - Fixed user-interrupt aborts rendering the persisted `Interrupted by user` label in assistant transcripts; replay and live views now suppress that redundant line again while preserving generic/custom abort labels.

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -10,32 +10,6 @@ const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
 const XAI_WEB_SEARCH_MODEL = "grok-4.3";
 const DEFAULT_NUM_RESULTS = 10;
 const MAX_NUM_RESULTS = 30;
-const RECENCY_DAYS: Record<NonNullable<SearchParams["recency"]>, number> = {
-	day: 1,
-	week: 7,
-	month: 30,
-	year: 365,
-};
-
-function formatUtcDate(date: Date): string {
-	return date.toISOString().slice(0, 10);
-}
-
-function buildRecencyDateBounds(
-	recency: NonNullable<SearchParams["recency"]>,
-	now = new Date(),
-): {
-	from_date: string;
-	to_date: string;
-} {
-	const toDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-	const fromDate = new Date(toDate);
-	fromDate.setUTCDate(fromDate.getUTCDate() - RECENCY_DAYS[recency]);
-	return {
-		from_date: formatUtcDate(fromDate),
-		to_date: formatUtcDate(toDate),
-	};
-}
 
 interface XAIUrlCitationAnnotation {
 	type?: string;
@@ -85,22 +59,6 @@ function buildRequestBody(params: SearchParams): Record<string, unknown> {
 		],
 		tools: [{ type: "web_search" }],
 	};
-
-	const requestedSearchResults = params.numSearchResults ?? params.limit;
-	const searchParameters: Record<string, unknown> = {};
-	if (requestedSearchResults !== undefined) {
-		searchParameters.max_search_results = clampNumResults(
-			requestedSearchResults,
-			DEFAULT_NUM_RESULTS,
-			MAX_NUM_RESULTS,
-		);
-	}
-	if (params.recency) {
-		Object.assign(searchParameters, buildRecencyDateBounds(params.recency));
-	}
-	if (Object.keys(searchParameters).length > 0) {
-		body.search_parameters = searchParameters;
-	}
 
 	if (params.maxOutputTokens !== undefined) {
 		body.max_output_tokens = params.maxOutputTokens;

--- a/packages/coding-agent/test/tools/web-search-xai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-xai.test.ts
@@ -111,17 +111,12 @@ describe("xAI web search provider", () => {
 	});
 
 	it.each([
-		["limit", { limit: 6 }, { max_search_results: 6 }],
-		["numSearchResults", { numSearchResults: 7 }, { max_search_results: 7 }],
-		["limit and numSearchResults", { limit: 2, numSearchResults: 50 }, { max_search_results: 30 }],
-		["recency", { recency: "week" }, { from_date: "2026-06-19", to_date: "2026-06-26" }],
-		[
-			"limit, numSearchResults, and recency",
-			{ limit: 0, numSearchResults: 30, recency: "day" },
-			{ max_search_results: 30, from_date: "2026-06-25", to_date: "2026-06-26" },
-		],
-	] as const)("maps %s to xAI search_parameters", async (_caseName, searchParams, expectedSearchParameters) => {
-		setSystemTime(new Date("2026-06-26T12:34:56.000Z"));
+		["limit", { limit: 6 }],
+		["numSearchResults", { numSearchResults: 7 }],
+		["recency", { recency: "week" }],
+		["limit, numSearchResults, and recency", { limit: 0, numSearchResults: 30, recency: "day" }],
+		["oversized numSearchResults", { numSearchResults: 99 }],
+	] as const)("keeps %s local instead of sending xAI search_parameters", async (_caseName, searchParams) => {
 		const capture = captureFetch({ id: "resp_agent_tools", model: "grok-4.3", output_text: "xAI answer" });
 
 		await searchXAI({
@@ -132,8 +127,8 @@ describe("xAI web search provider", () => {
 		expect(capture.capturedRequest).not.toBeNull();
 		const body = capture.capturedRequest?.body;
 		expect(body?.tools).toEqual([{ type: "web_search" }]);
-		expect(body?.search_parameters).toEqual(expectedSearchParameters);
-		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "search_parameters", "tools"]);
+		expect(body).not.toHaveProperty("search_parameters");
+		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "tools"]);
 	});
 
 	it("rejects deprecated live-search 410 responses without retrying", async () => {
@@ -159,11 +154,8 @@ describe("xAI web search provider", () => {
 		expect(capture.capturedRequests).toHaveLength(1);
 		const body = capture.capturedRequests[0]?.body;
 		expect(body?.tools).toEqual([{ type: "web_search" }]);
-		expect(body?.search_parameters).toEqual({
-			max_search_results: 5,
-			from_date: expect.any(String),
-			to_date: expect.any(String),
-		});
+		expect(body).not.toHaveProperty("search_parameters");
+		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "tools"]);
 	});
 
 	it("maps output_text, URL citation annotations, top-level citations, id, model, usage, and auth mode", async () => {
@@ -317,8 +309,8 @@ describe("xAI web search provider", () => {
 		expect(capture.capturedRequest).not.toBeNull();
 		const body = capture.capturedRequest?.body;
 		expect(body?.tools).toEqual([{ type: "web_search" }]);
-		expect(body?.search_parameters).toEqual({ max_search_results: 30 });
-		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "search_parameters", "tools"]);
+		expect(body).not.toHaveProperty("search_parameters");
+		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "tools"]);
 	});
 
 	it("caps parsed sources and citations locally without changing Agent Tools request shape", async () => {
@@ -385,8 +377,8 @@ describe("xAI web search provider", () => {
 		expect(capture.capturedRequest).not.toBeNull();
 		const body = capture.capturedRequest?.body;
 		expect(body?.tools).toEqual([{ type: "web_search" }]);
-		expect(body?.search_parameters).toEqual({ max_search_results: 4 });
-		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "search_parameters", "tools"]);
+		expect(body).not.toHaveProperty("search_parameters");
+		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "tools"]);
 	});
 
 	it("uses numSearchResults before limit for the local xAI output cap", async () => {
@@ -429,8 +421,8 @@ describe("xAI web search provider", () => {
 		expect(capture.capturedRequest).not.toBeNull();
 		const body = capture.capturedRequest?.body;
 		expect(body?.tools).toEqual([{ type: "web_search" }]);
-		expect(body?.search_parameters).toEqual({ max_search_results: 3 });
-		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "search_parameters", "tools"]);
+		expect(body).not.toHaveProperty("search_parameters");
+		expect(Object.keys(body ?? {}).sort()).toEqual(["input", "model", "tools"]);
 	});
 
 	it("falls back to output content parts when output_text is absent", async () => {


### PR DESCRIPTION
## Repro
A focused xAI provider test captured the body sent by `searchXAI` with `limit: 2` and `recency: "week"`; before the fix, `bun test packages/coding-agent/test/tools/repro-xai-search-parameters.test.ts` failed because the request body contained `search_parameters` with `max_search_results`, `from_date`, and `to_date`.

## Cause
`packages/coding-agent/src/web/search/providers/xai.ts` built `search_parameters` in `buildRequestBody` from `limit`, `numSearchResults`, and `recency`, then sent those request-level live-search fields to xAI's Responses Agent Tools endpoint even though that path only accepts the Agent Tools-compatible `tools: [{ type: "web_search" }]` request shape.

## Fix
- Removed xAI request-level `search_parameters` construction and the now-unused recency date-bound helpers.
- Kept `limit` / `numSearchResults` handling in `searchXAI` as the local cap applied after parsing returned sources and citations.
- Updated xAI web search regression tests to assert Agent Tools-compatible request bodies for count, recency, oversized count, and local-cap scenarios.
- Added the coding-agent changelog entry for #4537.

## Verification
Reproduced before the fix with `bun test packages/coding-agent/test/tools/repro-xai-search-parameters.test.ts` failing on the unexpected `search_parameters` object. After the fix, `bun test packages/coding-agent/test/tools/web-search-xai.test.ts` passed with 17 tests, 0 failures, and 111 assertions. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #4537