### PR TITLE
fix(providers): prefer xAI OAuth for web search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed xAI `web_search` to use `xai-oauth` credentials before falling back to `xai` API-key credentials, and to treat xAI OAuth as available in provider selection. ([#4536](https://github.com/can1357/oh-my-pi/issues/4536))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -265,24 +265,23 @@ function parseResponse(response: XAIResponsesResponse, resultCap: number): Searc
 }
 
 /**
- * Prefer a dedicated `xai-oauth` credential when the user has one, otherwise
- * resolve `xai` directly. Gating on `hasNonEnvCredential("xai-oauth")` (plus
- * `XAI_OAUTH_TOKEN`) is deliberate: `AuthStorage.hasAuth("xai-oauth")` also
- * fires when only `XAI_API_KEY` is set, because the catalog maps `xai-oauth`
- * to `["XAI_OAUTH_TOKEN", "XAI_API_KEY"]`. Without this narrower gate, an
- * `xai-oauth`-preferring wrapper would return `XAI_API_KEY` before an
- * explicit `xai` runtime/config credential ever ran, and web_search would
- * ignore/mis-bill against the wrong xAI account.
+ * Prefer `xai-oauth` only when its resolver cannot be shadowed by the shared
+ * `XAI_API_KEY` fallback before reaching a lower-priority dedicated source.
  */
-function hasDedicatedXAIOAuth(authStorage: AuthStorage): boolean {
-	return authStorage.hasNonEnvCredential("xai-oauth") || Boolean($env.XAI_OAUTH_TOKEN);
+function shouldPreferXAIOAuth(authStorage: AuthStorage): boolean {
+	if ($env.XAI_OAUTH_TOKEN) return true;
+
+	const origin = authStorage.getCredentialOrigin("xai-oauth");
+	if (!origin || origin.kind === "env") return false;
+	if ((origin.kind === "api_key" || origin.kind === "fallback") && $env.XAI_API_KEY) return false;
+	return true;
 }
 
 function resolveXAIWebSearchApiKey(params: SearchParams): ApiKeyResolver {
 	const xaiResolver = params.authStorage.resolver("xai", {
 		sessionId: params.sessionId,
 	});
-	if (!hasDedicatedXAIOAuth(params.authStorage)) {
+	if (!shouldPreferXAIOAuth(params.authStorage)) {
 		return xaiResolver;
 	}
 
@@ -314,7 +313,7 @@ export class XAIProvider extends SearchProvider {
 	readonly label = "xAI";
 
 	isAvailable(authStorage: AuthStorage): boolean {
-		return hasDedicatedXAIOAuth(authStorage) || authStorage.hasAuth("xai");
+		return shouldPreferXAIOAuth(authStorage) || authStorage.hasAuth("xai");
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -1,4 +1,4 @@
-import { type ApiKey, type AuthStorage, withAuth } from "@oh-my-pi/pi-ai";
+import { type ApiKey, type ApiKeyResolver, type AuthStorage, withAuth } from "@oh-my-pi/pi-ai";
 import type { SearchCitation, SearchResponse, SearchSource, SearchUsage } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { clampNumResults } from "../utils";
@@ -263,11 +263,27 @@ function parseResponse(response: XAIResponsesResponse, resultCap: number): Searc
 	};
 }
 
-/** Execute xAI Responses API web search. */
-export async function searchXAI(params: SearchParams): Promise<SearchResponse> {
-	const keyOrResolver: ApiKey = params.authStorage.resolver("xai", {
+function resolveXAIWebSearchApiKey(params: SearchParams): ApiKeyResolver {
+	const xaiResolver = params.authStorage.resolver("xai", {
 		sessionId: params.sessionId,
 	});
+	if (!params.authStorage.hasAuth("xai-oauth")) {
+		return xaiResolver;
+	}
+
+	const xaiOAuthResolver = params.authStorage.resolver("xai-oauth", {
+		sessionId: params.sessionId,
+	});
+	return async ctx => {
+		const xaiOAuthKey = await xaiOAuthResolver(ctx);
+		if (xaiOAuthKey) return xaiOAuthKey;
+		return xaiResolver(ctx);
+	};
+}
+
+/** Execute xAI Responses API web search. */
+export async function searchXAI(params: SearchParams): Promise<SearchResponse> {
+	const keyOrResolver: ApiKey = resolveXAIWebSearchApiKey(params);
 
 	const resultCap = clampNumResults(params.numSearchResults ?? params.limit, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
 	const response = await withAuth(keyOrResolver, (key: string) => callXAIResponses(key, params), {
@@ -283,7 +299,7 @@ export class XAIProvider extends SearchProvider {
 	readonly label = "xAI";
 
 	isAvailable(authStorage: AuthStorage): boolean {
-		return authStorage.hasAuth("xai");
+		return authStorage.hasAuth("xai-oauth") || authStorage.hasAuth("xai");
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -1,4 +1,5 @@
 import { type ApiKey, type ApiKeyResolver, type AuthStorage, withAuth } from "@oh-my-pi/pi-ai";
+import { $env } from "@oh-my-pi/pi-utils";
 import type { SearchCitation, SearchResponse, SearchSource, SearchUsage } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { clampNumResults } from "../utils";
@@ -263,11 +264,25 @@ function parseResponse(response: XAIResponsesResponse, resultCap: number): Searc
 	};
 }
 
+/**
+ * Prefer a dedicated `xai-oauth` credential when the user has one, otherwise
+ * resolve `xai` directly. Gating on `hasNonEnvCredential("xai-oauth")` (plus
+ * `XAI_OAUTH_TOKEN`) is deliberate: `AuthStorage.hasAuth("xai-oauth")` also
+ * fires when only `XAI_API_KEY` is set, because the catalog maps `xai-oauth`
+ * to `["XAI_OAUTH_TOKEN", "XAI_API_KEY"]`. Without this narrower gate, an
+ * `xai-oauth`-preferring wrapper would return `XAI_API_KEY` before an
+ * explicit `xai` runtime/config credential ever ran, and web_search would
+ * ignore/mis-bill against the wrong xAI account.
+ */
+function hasDedicatedXAIOAuth(authStorage: AuthStorage): boolean {
+	return authStorage.hasNonEnvCredential("xai-oauth") || Boolean($env.XAI_OAUTH_TOKEN);
+}
+
 function resolveXAIWebSearchApiKey(params: SearchParams): ApiKeyResolver {
 	const xaiResolver = params.authStorage.resolver("xai", {
 		sessionId: params.sessionId,
 	});
-	if (!params.authStorage.hasAuth("xai-oauth")) {
+	if (!hasDedicatedXAIOAuth(params.authStorage)) {
 		return xaiResolver;
 	}
 
@@ -299,7 +314,7 @@ export class XAIProvider extends SearchProvider {
 	readonly label = "xAI";
 
 	isAvailable(authStorage: AuthStorage): boolean {
-		return authStorage.hasAuth("xai-oauth") || authStorage.hasAuth("xai");
+		return hasDedicatedXAIOAuth(authStorage) || authStorage.hasAuth("xai");
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {

--- a/packages/coding-agent/test/tools/web-search-xai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-xai.test.ts
@@ -33,11 +33,16 @@ function makeAuthStorage(credentials: string | FakeAuthCredentials | undefined) 
 			};
 		},
 		hasAuth(provider: string) {
-			let credentialExists = false;
 			if (provider === "xai-oauth" || provider === "xai") {
-				credentialExists = Boolean(credentialsByProvider[provider]);
+				return Boolean(credentialsByProvider[provider]);
 			}
-			return credentialExists;
+			return false;
+		},
+		hasNonEnvCredential(provider: string) {
+			if (provider === "xai-oauth" || provider === "xai") {
+				return Boolean(credentialsByProvider[provider]);
+			}
+			return false;
 		},
 	} as unknown as AuthStorage;
 }
@@ -166,6 +171,47 @@ describe("xAI web search provider", () => {
 		});
 
 		expect(provider.isAvailable(authStorage)).toBe(true);
+	});
+
+	it("routes through xai when only XAI_API_KEY is set and an xai credential exists", async () => {
+		const capture = captureFetch({
+			id: "resp_xai_env_only",
+			model: "grok-4.3",
+			output_text: "xAI env answer",
+		});
+		const originalOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+		const originalApiKey = Bun.env.XAI_API_KEY;
+		delete Bun.env.XAI_OAUTH_TOKEN;
+		Bun.env.XAI_API_KEY = "shared-xai-env-key";
+		try {
+			await searchXAI(makeParams(capture.fetchMock, makeAuthStorage({ xai: "explicit-xai-runtime-key" })));
+		} finally {
+			if (originalOAuthToken === undefined) delete Bun.env.XAI_OAUTH_TOKEN;
+			else Bun.env.XAI_OAUTH_TOKEN = originalOAuthToken;
+			if (originalApiKey === undefined) delete Bun.env.XAI_API_KEY;
+			else Bun.env.XAI_API_KEY = originalApiKey;
+		}
+
+		expect(capture.capturedRequest).not.toBeNull();
+		expect(capture.capturedRequest?.headers).toMatchObject({
+			Authorization: "Bearer explicit-xai-runtime-key",
+		});
+	});
+
+	it("does not report xAI available when only XAI_API_KEY is set", () => {
+		const provider = new XAIProvider();
+		const originalOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+		const originalApiKey = Bun.env.XAI_API_KEY;
+		delete Bun.env.XAI_OAUTH_TOKEN;
+		Bun.env.XAI_API_KEY = "shared-xai-env-key";
+		try {
+			expect(provider.isAvailable(makeAuthStorage(undefined))).toBe(false);
+		} finally {
+			if (originalOAuthToken === undefined) delete Bun.env.XAI_OAUTH_TOKEN;
+			else Bun.env.XAI_OAUTH_TOKEN = originalOAuthToken;
+			if (originalApiKey === undefined) delete Bun.env.XAI_API_KEY;
+			else Bun.env.XAI_API_KEY = originalApiKey;
+		}
 	});
 
 	it("omits search_parameters for minimal web_search requests", async () => {

--- a/packages/coding-agent/test/tools/web-search-xai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-xai.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, setSystemTime, vi } from "bun:test";
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
-import { searchXAI } from "@oh-my-pi/pi-coding-agent/web/search/providers/xai";
+import { searchXAI, XAIProvider } from "@oh-my-pi/pi-coding-agent/web/search/providers/xai";
 import { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
 
 type CapturedRequest = {
@@ -10,15 +10,34 @@ type CapturedRequest = {
 	body: Record<string, unknown> | null;
 };
 
-function makeAuthStorage(apiKey: string | undefined) {
+type FakeAuthProvider = "xai" | "xai-oauth";
+type FakeAuthCredentials = Partial<Record<FakeAuthProvider, string>>;
+
+function makeAuthStorage(credentials: string | FakeAuthCredentials | undefined) {
+	const credentialsByProvider: FakeAuthCredentials = {};
+	if (typeof credentials === "string") {
+		credentialsByProvider.xai = credentials;
+	} else if (credentials !== undefined) {
+		Object.assign(credentialsByProvider, credentials);
+	}
+
 	return {
-		resolver(provider: string, options?: { sessionId?: string }) {
-			expect(provider).toBe("xai");
+		resolver(provider: string, options?: { sessionId?: string; baseUrl?: string; modelId?: string }) {
 			expect(options?.sessionId).toBe("session-xai-test");
-			return async () => apiKey;
+			const credentialProvider = provider === "xai-oauth" || provider === "xai" ? provider : undefined;
+			return async () => {
+				if (credentialProvider === undefined) {
+					return undefined;
+				}
+				return credentialsByProvider[credentialProvider];
+			};
 		},
 		hasAuth(provider: string) {
-			return provider === "xai" && Boolean(apiKey);
+			let credentialExists = false;
+			if (provider === "xai-oauth" || provider === "xai") {
+				credentialExists = Boolean(credentialsByProvider[provider]);
+			}
+			return credentialExists;
 		},
 	} as unknown as AuthStorage;
 }
@@ -97,6 +116,56 @@ describe("xAI web search provider", () => {
 		});
 		expect(capture.capturedRequest?.body?.tools).toEqual([{ type: "web_search" }]);
 		expect(capture.capturedRequest?.body).not.toHaveProperty("search_parameters");
+	});
+
+	it("uses dedicated xAI OAuth credentials for Responses API bearer auth", async () => {
+		const capture = captureFetch({ id: "resp_xai_oauth", model: "grok-4.3", output_text: "xAI OAuth answer" });
+
+		await searchXAI(
+			makeParams(
+				capture.fetchMock,
+				makeAuthStorage({
+					"xai-oauth": "test-xai-oauth-token",
+				}),
+			),
+		);
+
+		expect(capture.capturedRequest).not.toBeNull();
+		expect(capture.capturedRequest?.headers).toMatchObject({
+			Authorization: "Bearer test-xai-oauth-token",
+		});
+	});
+
+	it("prefers dedicated xAI OAuth credentials over xAI API keys", async () => {
+		const capture = captureFetch({
+			id: "resp_xai_oauth_priority",
+			model: "grok-4.3",
+			output_text: "xAI OAuth answer",
+		});
+
+		await searchXAI(
+			makeParams(
+				capture.fetchMock,
+				makeAuthStorage({
+					"xai-oauth": "test-xai-oauth-token",
+					xai: "test-xai-api-key",
+				}),
+			),
+		);
+
+		expect(capture.capturedRequest).not.toBeNull();
+		expect(capture.capturedRequest?.headers).toMatchObject({
+			Authorization: "Bearer test-xai-oauth-token",
+		});
+	});
+
+	it("reports available when only dedicated xAI OAuth credentials exist", () => {
+		const provider = new XAIProvider();
+		const authStorage = makeAuthStorage({
+			"xai-oauth": "test-xai-oauth-token",
+		});
+
+		expect(provider.isAvailable(authStorage)).toBe(true);
 	});
 
 	it("omits search_parameters for minimal web_search requests", async () => {
@@ -482,7 +551,7 @@ describe("xAI web search provider", () => {
 		const fetchMock = vi.fn(() => Promise.resolve(new Response("{}", { status: 200 }))) as unknown as FetchImpl;
 
 		try {
-			await searchXAI(makeParams(fetchMock, makeAuthStorage(undefined)));
+			await searchXAI(makeParams(fetchMock, makeAuthStorage({})));
 			expect.unreachable("missing xAI credentials should reject");
 		} catch (error) {
 			expect(error).toBeInstanceOf(Error);

--- a/packages/coding-agent/test/tools/web-search-xai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-xai.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, setSystemTime, vi } from "bun:test";
-import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import type { AuthStorage, CredentialOriginKind, FetchImpl } from "@oh-my-pi/pi-ai";
 import { searchXAI, XAIProvider } from "@oh-my-pi/pi-coding-agent/web/search/providers/xai";
 import { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
 
@@ -11,14 +11,27 @@ type CapturedRequest = {
 };
 
 type FakeAuthProvider = "xai" | "xai-oauth";
-type FakeAuthCredentials = Partial<Record<FakeAuthProvider, string>>;
+type FakeAuthCredential = string | { key: string; kind: CredentialOriginKind };
+type FakeAuthCredentials = Partial<Record<FakeAuthProvider, FakeAuthCredential>>;
+type NormalizedFakeAuthCredential = { key: string; kind: CredentialOriginKind };
 
 function makeAuthStorage(credentials: string | FakeAuthCredentials | undefined) {
-	const credentialsByProvider: FakeAuthCredentials = {};
+	const credentialsByProvider: Partial<Record<FakeAuthProvider, NormalizedFakeAuthCredential>> = {};
 	if (typeof credentials === "string") {
-		credentialsByProvider.xai = credentials;
+		credentialsByProvider.xai = { key: credentials, kind: "api_key" };
 	} else if (credentials !== undefined) {
-		Object.assign(credentialsByProvider, credentials);
+		const xaiCredential = credentials.xai;
+		if (typeof xaiCredential === "string") {
+			credentialsByProvider.xai = { key: xaiCredential, kind: "api_key" };
+		} else if (xaiCredential) {
+			credentialsByProvider.xai = xaiCredential;
+		}
+		const xaiOAuthCredential = credentials["xai-oauth"];
+		if (typeof xaiOAuthCredential === "string") {
+			credentialsByProvider["xai-oauth"] = { key: xaiOAuthCredential, kind: "oauth" };
+		} else if (xaiOAuthCredential) {
+			credentialsByProvider["xai-oauth"] = xaiOAuthCredential;
+		}
 	}
 
 	return {
@@ -29,20 +42,37 @@ function makeAuthStorage(credentials: string | FakeAuthCredentials | undefined) 
 				if (credentialProvider === undefined) {
 					return undefined;
 				}
-				return credentialsByProvider[credentialProvider];
+				return credentialsByProvider[credentialProvider]?.key;
 			};
 		},
 		hasAuth(provider: string) {
-			if (provider === "xai-oauth" || provider === "xai") {
-				return Boolean(credentialsByProvider[provider]);
+			if (provider === "xai") {
+				return Boolean(credentialsByProvider.xai) || Boolean(Bun.env.XAI_API_KEY);
+			}
+			if (provider === "xai-oauth") {
+				return (
+					Boolean(credentialsByProvider["xai-oauth"]) ||
+					Boolean(Bun.env.XAI_OAUTH_TOKEN) ||
+					Boolean(Bun.env.XAI_API_KEY)
+				);
 			}
 			return false;
 		},
 		hasNonEnvCredential(provider: string) {
 			if (provider === "xai-oauth" || provider === "xai") {
-				return Boolean(credentialsByProvider[provider]);
+				const credential = credentialsByProvider[provider];
+				return Boolean(credential && credential.kind !== "env");
 			}
 			return false;
+		},
+		getCredentialOrigin(provider: string) {
+			if (provider === "xai-oauth" || provider === "xai") {
+				const credential = credentialsByProvider[provider];
+				if (credential) return { kind: credential.kind };
+				if (provider === "xai-oauth" && (Bun.env.XAI_OAUTH_TOKEN || Bun.env.XAI_API_KEY)) return { kind: "env" };
+				if (provider === "xai" && Bun.env.XAI_API_KEY) return { kind: "env" };
+			}
+			return undefined;
 		},
 	} as unknown as AuthStorage;
 }
@@ -184,7 +214,12 @@ describe("xAI web search provider", () => {
 		delete Bun.env.XAI_OAUTH_TOKEN;
 		Bun.env.XAI_API_KEY = "shared-xai-env-key";
 		try {
-			await searchXAI(makeParams(capture.fetchMock, makeAuthStorage({ xai: "explicit-xai-runtime-key" })));
+			await searchXAI(
+				makeParams(
+					capture.fetchMock,
+					makeAuthStorage({ xai: { key: "explicit-xai-runtime-key", kind: "runtime" } }),
+				),
+			);
 		} finally {
 			if (originalOAuthToken === undefined) delete Bun.env.XAI_OAUTH_TOKEN;
 			else Bun.env.XAI_OAUTH_TOKEN = originalOAuthToken;
@@ -198,14 +233,47 @@ describe("xAI web search provider", () => {
 		});
 	});
 
-	it("does not report xAI available when only XAI_API_KEY is set", () => {
+	it("skips stored xai-oauth API keys when XAI_API_KEY would shadow them", async () => {
+		const capture = captureFetch({
+			id: "resp_xai_env_shadow",
+			model: "grok-4.3",
+			output_text: "xAI explicit account answer",
+		});
+		const originalOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+		const originalApiKey = Bun.env.XAI_API_KEY;
+		delete Bun.env.XAI_OAUTH_TOKEN;
+		Bun.env.XAI_API_KEY = "shared-xai-env-key";
+		try {
+			await searchXAI(
+				makeParams(
+					capture.fetchMock,
+					makeAuthStorage({
+						"xai-oauth": { key: "stored-xai-oauth-api-key", kind: "api_key" },
+						xai: { key: "explicit-xai-runtime-key", kind: "runtime" },
+					}),
+				),
+			);
+		} finally {
+			if (originalOAuthToken === undefined) delete Bun.env.XAI_OAUTH_TOKEN;
+			else Bun.env.XAI_OAUTH_TOKEN = originalOAuthToken;
+			if (originalApiKey === undefined) delete Bun.env.XAI_API_KEY;
+			else Bun.env.XAI_API_KEY = originalApiKey;
+		}
+
+		expect(capture.capturedRequest).not.toBeNull();
+		expect(capture.capturedRequest?.headers).toMatchObject({
+			Authorization: "Bearer explicit-xai-runtime-key",
+		});
+	});
+
+	it("reports xAI available through xai when only XAI_API_KEY is set", () => {
 		const provider = new XAIProvider();
 		const originalOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
 		const originalApiKey = Bun.env.XAI_API_KEY;
 		delete Bun.env.XAI_OAUTH_TOKEN;
 		Bun.env.XAI_API_KEY = "shared-xai-env-key";
 		try {
-			expect(provider.isAvailable(makeAuthStorage(undefined))).toBe(false);
+			expect(provider.isAvailable(makeAuthStorage(undefined))).toBe(true);
 		} finally {
 			if (originalOAuthToken === undefined) delete Bun.env.XAI_OAUTH_TOKEN;
 			else Bun.env.XAI_OAUTH_TOKEN = originalOAuthToken;


### PR DESCRIPTION
## Repro
Added focused coverage in `packages/coding-agent/test/tools/web-search-xai.test.ts` and ran `bun test packages/coding-agent/test/tools/web-search-xai.test.ts` before the fix. Current production failed three xAI web_search contracts: xai-oauth-only auth threw `xAI credentials not found...`, xai-oauth lost precedence to an `xai` API key, and `XAIProvider.isAvailable()` returned false for xai-oauth-only auth.

## Cause
`packages/coding-agent/src/web/search/providers/xai.ts` resolved credentials with `params.authStorage.resolver("xai", ...)` inside `searchXAI`, so the Responses API path never asked `AuthStorage` for `xai-oauth`. The same file's `XAIProvider.isAvailable()` checked only `authStorage.hasAuth("xai")`, so provider selection skipped xAI web search for OAuth-only users.

## Fix
- Added xAI web_search credential resolution that tries the `xai-oauth` resolver first when that provider has auth, then falls back to the existing `xai` resolver.
- Updated `XAIProvider.isAvailable()` to consider either `xai-oauth` or `xai` auth.
- Added regression tests for xai-oauth-only bearer auth, xai-oauth-over-xai precedence, provider availability, and the unchanged missing-credentials path.
- Added an unreleased changelog entry for `packages/coding-agent`.

## Verification
`bun test packages/coding-agent/test/tools/web-search-xai.test.ts` → 20 pass / 0 fail. `bun check` → passed. Fixes #4536