### PR TITLE
fix(tui): avoid auto-linked token rate format

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed the status-line token-rate segment rendering as `<number>/s`, which Ghostty auto-detected as a hyperlink on Ctrl+hover. ([#4541](https://github.com/can1357/oh-my-pi/issues/4541))
+
 - Fixed raw `read` ranges not contributing to edit seen-line provenance, so re-reading an anchor range with `:raw` now unblocks hashline edits without adding non-raw line prefixes.
 - Fixed replan-driven session title refresh updating the statusline but not the terminal window title: terminal-title updates now fire from the session-name-changed listener, so every `setSessionName` path (first-input titling, `/rename`, plan seeding, replan refresh) sets the OSC title consistently.
 - Fixed user-interrupt aborts rendering the persisted `Interrupted by user` label in assistant transcripts; replay and live views now suppress that redundant line again while preserving generic/custom abort labels.

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -379,7 +379,7 @@ const tokenRateSegment: StatusLineSegment = {
 		const { tokensPerSecond } = ctx.usageStats;
 		if (!tokensPerSecond) return { content: "", visible: false };
 
-		const content = withIcon(theme.icon.throughput, `${tokensPerSecond.toFixed(1)}/s`);
+		const content = withIcon(theme.icon.throughput, `${tokensPerSecond.toFixed(1)} tok/s`);
 		return { content: theme.fg("statusLineOutput", content), visible: true };
 	},
 };

--- a/packages/coding-agent/test/status-line-token-rate.test.ts
+++ b/packages/coding-agent/test/status-line-token-rate.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
 import { calculateTokensPerSecond } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/token-rate";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
 
 function assistantMessage(overrides?: Partial<AssistantMessage>): AssistantMessage {
 	return {
@@ -22,6 +30,33 @@ function assistantMessage(overrides?: Partial<AssistantMessage>): AssistantMessa
 		...overrides,
 	};
 }
+
+function ctxWithTokenRate(tokensPerSecond: number | null): SegmentContext {
+	return {
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond,
+		},
+	} as unknown as SegmentContext;
+}
+
+describe("token_rate status-line segment", () => {
+	it("renders per-second throughput without a numeric slash path", () => {
+		const rendered = renderSegment("token_rate", ctxWithTokenRate(35.5));
+		const content = stripVTControlCharacters(rendered.content);
+
+		expect(rendered.visible).toBe(true);
+		expect(content).toContain("35.5");
+		expect(content).toMatch(/(?:\/s|\bs\b|\bsec(?:ond)?s?\b|\btps\b)/i);
+		expect(content).not.toContain("35.5/s");
+		expect(content).not.toMatch(/\b\d+(?:\.\d+)?\/s\b/);
+	});
+});
 
 describe("token rate calculation", () => {
 	it("computes from completed message duration metadata", () => {


### PR DESCRIPTION
## Repro
Rendering the status-line `token_rate` segment with `tokensPerSecond=35.5` produced the plain text `⚡ 35.5/s`; the numeric slash-path form matches Ghostty's auto-URL detection and becomes hover-underlined on Ctrl+hover.

## Cause
`packages/coding-agent/src/modes/components/status-line/segments.ts` formatted throughput as `${tokensPerSecond.toFixed(1)}/s` inside `tokenRateSegment.render()`, leaving a bare `<number>/s` token in the TUI output.

## Fix
- Changed the `token_rate` segment to render the explicit unit `tok/s`, e.g. `35.5 tok/s`, so the slash is no longer attached to a numeric path-like token.
- Added a regression test in `packages/coding-agent/test/status-line-token-rate.test.ts` that renders the real segment, preserves the numeric value and per-second meaning, and rejects `35.5/s` plus the broader numeric slash-path regex.
- Added the coding-agent changelog entry for #4541.

## Verification
- `bun test packages/coding-agent/test/status-line-token-rate.test.ts` → 6 pass, 0 fail.
- `bun run check` from `packages/coding-agent` → passed.
- `gh_push_branch` pre-publish gate ran `bun run fix`/`bun check` and pushed successfully. Fixes #4541