### PR TITLE
fix(metadata): correct collab package contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
     },
     "packages/collab-web": {
       "name": "@oh-my-pi/collab-web",
-      "version": "15.11.7",
+      "version": "16.3.4",
       "dependencies": {
         "@oh-my-pi/pi-wire": "catalog:",
         "lucide-react": "catalog:",
@@ -232,7 +232,7 @@
         "@types/bun": "^1.3.14",
       },
       "peerDependencies": {
-        "@oh-my-pi/pi-coding-agent": "^13",
+        "@oh-my-pi/pi-coding-agent": "^16",
       },
     },
     "packages/terminal-bench": {

--- a/crates/pi-uu-grep/src/lib.rs
+++ b/crates/pi-uu-grep/src/lib.rs
@@ -122,7 +122,7 @@ struct Cli {
 	quiet: bool,
 
 	/// Print a help message.
-	#[allow(dead_code)]
+	#[allow(dead_code, reason = "clap consumes help before the parsed options are inspected")]
 	#[arg(long = "help", action = clap::ArgAction::Help)]
 	help: Option<bool>,
 
@@ -131,7 +131,7 @@ struct Cli {
 	/// GNU grep ships a `--version`, and shell startup scripts probe it.
 	/// Routed through clap so output lands on the in-process stdout via the
 	/// same path as `--help`.
-	#[allow(dead_code)]
+	#[allow(dead_code, reason = "clap consumes version before the parsed options are inspected")]
 	#[arg(short = 'V', long = "version", action = clap::ArgAction::Version)]
 	version: Option<bool>,
 
@@ -140,7 +140,7 @@ struct Cli {
 	/// (often a pipe consumed by another tool), so injecting ANSI escapes
 	/// would corrupt downstream output. The common `alias grep='grep
 	/// --color=auto'` from distro bashrc files passes through unchanged.
-	#[allow(dead_code)]
+	#[allow(dead_code, reason = "GNU grep compatibility flag is accepted but intentionally ignored")]
 	#[arg(
 		long = "color",
 		alias = "colour",

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the stale package version metadata so the collab web workspace advertises `16.3.4` instead of the old `15.11.7` pin. ([#4549](https://github.com/can1357/oh-my-pi/issues/4549))
+
 ## [16.3.3] - 2026-07-02
 
 ### Fixed

--- a/packages/collab-web/package.json
+++ b/packages/collab-web/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@oh-my-pi/collab-web",
-  "version": "15.11.7",
+  "version": "16.3.4",
   "private": true,
   "description": "Browser guest client and local relay tools for omp collab live sessions",
   "homepage": "https://omp.sh",

--- a/packages/swarm-extension/CHANGELOG.md
+++ b/packages/swarm-extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the peer dependency range for `@oh-my-pi/pi-coding-agent` to match the current `^16` major. ([#4549](https://github.com/can1357/oh-my-pi/issues/4549))
+
 ## [15.9.0] - 2026-06-04
 
 ### Fixed

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -37,7 +37,7 @@
     "@types/bun": "^1.3.14"
   },
   "peerDependencies": {
-    "@oh-my-pi/pi-coding-agent": "^13"
+    "@oh-my-pi/pi-coding-agent": "^16"
   },
   "engines": {
     "bun": ">=1.3.14"


### PR DESCRIPTION
## Repro
The stale metadata reproduces with `bun pm pkg get version` from `packages/collab-web`, which returned `"15.11.7"`, and `bun pm pkg get peerDependencies.@oh-my-pi/pi-coding-agent` from `packages/swarm-extension`, which returned `"^13"`; the expected contracts are `16.3.4` and `^16`.

## Cause
`packages/collab-web/package.json` and the corresponding `bun.lock` workspace entry still carried the old `15.11.7` version, while `packages/swarm-extension/package.json` and its lockfile peer metadata still required `@oh-my-pi/pi-coding-agent` `^13`; `crates/pi-uu-grep/src/lib.rs` also kept clap-consumed compatibility fields under bare `#[allow(dead_code)]` annotations without reasons.

## Fix
- Updated `packages/collab-web` package and lock metadata to `16.3.4`.
- Updated `packages/swarm-extension` peer dependency metadata and lock metadata to `@oh-my-pi/pi-coding-agent` `^16`.
- Added explicit `dead_code` allow reasons for the `pi-uu-grep` `help`, `version`, and `color` clap-only fields.
- Added Unreleased changelog entries for the affected packages.

## Verification
Ran `bun pm pkg get version` in `packages/collab-web` and got `"16.3.4"`; ran `bun pm pkg get peerDependencies.@oh-my-pi/pi-coding-agent` in `packages/swarm-extension` and got `"^16"`; ran `bun run check` in `packages/collab-web`; ran `bun run check` in `packages/swarm-extension`; ran `cargo check -p pi_uu_grep`; `gh_push_branch` also completed its pre-publish gate and pushed the branch. Fixes #4549