### PR TITLE
refactor(session): extract BashRuntime from AgentSession

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -193,7 +193,7 @@ import {
 } from "../eval/py/executor";
 import { disposeRubyKernelSessionsByOwner } from "../eval/rb/executor";
 import { defaultEvalSessionId } from "../eval/session-id";
-import { type BashResult, executeBash as executeBashCommand } from "../exec/bash-executor";
+import type { BashResult } from "../exec/bash-executor";
 import type { TtsrManager, TtsrMatchContext } from "../export/ttsr";
 import type { LoadedCustomCommand } from "../extensibility/custom-commands";
 import type { CustomTool, CustomToolContext } from "../extensibility/custom-tools/types";
@@ -307,7 +307,6 @@ import { isAutoQaEnabled } from "../tools/report-tool-issue";
 import { buildResolveReminderMessage } from "../tools/resolve";
 import { getLatestTodoPhasesFromEntries, type TodoItem, type TodoPhase } from "../tools/todo";
 import { ToolAbortError, ToolError } from "../tools/tool-errors";
-import { clampTimeout } from "../tools/tool-timeouts";
 import { parseCommandArgs } from "../utils/command-args";
 import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
@@ -317,6 +316,7 @@ import { describeAttachedImagesForTextModel } from "../utils/image-vision-fallba
 import { generateSessionTitle } from "../utils/title-generator";
 import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
 import type { AuthStorage } from "./auth-storage";
+import { BashRuntime } from "./bash-runtime";
 import type { ClientBridge, ClientBridgePermissionOption, ClientBridgePermissionOutcome } from "./client-bridge";
 import {
 	type CodexAutoRedeemRedeemDecision,
@@ -335,7 +335,6 @@ import {
 	type ToolExecutionStartData,
 } from "./exit-diagnostics";
 import {
-	type BashExecutionMessage,
 	type CustomMessage,
 	convertToLlm,
 	demoteInterruptedThinking,
@@ -1631,8 +1630,7 @@ export class AgentSession {
 	#toolChoiceQueue = new ToolChoiceQueue();
 
 	// Bash execution state
-	#bashAbortControllers = new Set<AbortController>();
-	#pendingBashMessages: BashExecutionMessage[] = [];
+	#bashRuntime: BashRuntime;
 
 	// Python execution state
 	#evalAbortControllers = new Set<AbortController>();
@@ -2219,6 +2217,30 @@ export class AgentSession {
 					},
 					{ deliverAs: message.deliverAs },
 				);
+			},
+		});
+		this.#bashRuntime = new BashRuntime({
+			isStreaming: () => this.isStreaming,
+			getCwd: () => this.sessionManager.getCwd(),
+			getSessionKey: () => this.sessionId,
+			appendToAgent: message => this.agent.appendMessage(message),
+			appendToSession: message => this.sessionManager.appendMessage(message),
+			saveOriginalArtifact: async text => {
+				try {
+					return await this.sessionManager.saveArtifact(text, "bash-original");
+				} catch {
+					return undefined;
+				}
+			},
+			runUserBashHook: async input => {
+				if (!this.#extensionRunner?.hasHandlers("user_bash")) return undefined;
+				const hookResult = await this.#extensionRunner.emitUserBash({
+					type: "user_bash",
+					command: input.command,
+					excludeFromContext: input.excludeFromContext,
+					cwd: input.cwd,
+				});
+				return hookResult?.result;
 			},
 		});
 		this.#cancelExitRecorder = postmortem.register(`agent-session:${this.sessionManager.getSessionId()}`, reason => {
@@ -7487,7 +7509,7 @@ export class AgentSession {
 		const generation = this.#promptGeneration;
 		try {
 			// Flush any pending bash messages before the new prompt
-			this.#flushPendingBashMessages();
+			this.#bashRuntime.flushPendingMessages();
 			this.#flushPendingPythonMessages();
 			this.#flushPendingIrcAsides();
 
@@ -13688,14 +13710,6 @@ export class AgentSession {
 	// Bash Execution
 	// =========================================================================
 
-	async #saveBashOriginalArtifact(originalText: string): Promise<string | undefined> {
-		try {
-			return await this.sessionManager.saveArtifact(originalText, "bash-original");
-		} catch {
-			return undefined;
-		}
-	}
-
 	/**
 	 * Execute a bash command.
 	 * Adds result to agent context and session.
@@ -13709,41 +13723,7 @@ export class AgentSession {
 		onChunk?: (chunk: string) => void,
 		options?: { excludeFromContext?: boolean; useUserShell?: boolean },
 	): Promise<BashResult> {
-		const excludeFromContext = options?.excludeFromContext === true;
-		const cwd = this.sessionManager.getCwd();
-
-		if (this.#extensionRunner?.hasHandlers("user_bash")) {
-			const hookResult = await this.#extensionRunner.emitUserBash({
-				type: "user_bash",
-				command,
-				excludeFromContext,
-				cwd,
-			});
-			if (hookResult?.result) {
-				this.recordBashResult(command, hookResult.result, options);
-				return hookResult.result;
-			}
-		}
-
-		const abortController = new AbortController();
-		this.#bashAbortControllers.add(abortController);
-
-		try {
-			const result = await executeBashCommand(command, {
-				onChunk,
-				signal: abortController.signal,
-				sessionKey: this.sessionId,
-				cwd,
-				timeout: clampTimeout("bash") * 1000,
-				onMinimizedSave: originalText => this.#saveBashOriginalArtifact(originalText),
-				useUserShell: options?.useUserShell,
-			});
-
-			this.recordBashResult(command, result, options);
-			return result;
-		} finally {
-			this.#bashAbortControllers.delete(abortController);
-		}
+		return this.#bashRuntime.execute(command, onChunk, options);
 	}
 
 	/**
@@ -13751,67 +13731,24 @@ export class AgentSession {
 	 * Used by executeBash and by extensions that handle bash execution themselves.
 	 */
 	recordBashResult(command: string, result: BashResult, options?: { excludeFromContext?: boolean }): void {
-		const meta = outputMeta().truncationFromSummary(result, { direction: "tail" }).get();
-		const bashMessage: BashExecutionMessage = {
-			role: "bashExecution",
-			command,
-			output: result.output,
-			exitCode: result.exitCode,
-			cancelled: result.cancelled,
-			truncated: result.truncated,
-			meta,
-			timestamp: Date.now(),
-			excludeFromContext: options?.excludeFromContext,
-		};
-
-		// If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
-		if (this.isStreaming) {
-			// Queue for later - will be flushed on agent_end
-			this.#pendingBashMessages.push(bashMessage);
-		} else {
-			// Add to agent state immediately
-			this.agent.appendMessage(bashMessage);
-
-			// Save to session
-			this.sessionManager.appendMessage(bashMessage);
-		}
+		return this.#bashRuntime.record(command, result, options);
 	}
 
 	/**
 	 * Cancel running bash command.
 	 */
 	abortBash(): void {
-		for (const abortController of this.#bashAbortControllers) {
-			abortController.abort();
-		}
+		return this.#bashRuntime.abort();
 	}
 
 	/** Whether a bash command is currently running */
 	get isBashRunning(): boolean {
-		return this.#bashAbortControllers.size > 0;
+		return this.#bashRuntime.isRunning;
 	}
 
 	/** Whether there are pending bash messages waiting to be flushed */
 	get hasPendingBashMessages(): boolean {
-		return this.#pendingBashMessages.length > 0;
-	}
-
-	/**
-	 * Flush pending bash messages to agent state and session.
-	 * Called after agent turn completes to maintain proper message ordering.
-	 */
-	#flushPendingBashMessages(): void {
-		if (this.#pendingBashMessages.length === 0) return;
-
-		for (const bashMessage of this.#pendingBashMessages) {
-			// Add to agent state
-			this.agent.appendMessage(bashMessage);
-
-			// Save to session
-			this.sessionManager.appendMessage(bashMessage);
-		}
-
-		this.#pendingBashMessages = [];
+		return this.#bashRuntime.hasPendingMessages;
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/session/bash-runtime.ts
+++ b/packages/coding-agent/src/session/bash-runtime.ts
@@ -1,0 +1,162 @@
+import type { BashResult } from "../exec/bash-executor";
+import { executeBash as executeBashCommand } from "../exec/bash-executor";
+import { outputMeta } from "../tools/output-meta";
+import { clampTimeout } from "../tools/tool-timeouts";
+import type { BashExecutionMessage } from "./messages";
+
+/**
+ * Host interface for {@link BashRuntime}. The owning session supplies these
+ * callbacks so the runtime stays free of direct session / agent references.
+ */
+export interface BashRuntimeHost {
+	/** Whether the agent is currently streaming a response. */
+	isStreaming(): boolean;
+	/** Current working directory for the session. */
+	getCwd(): string;
+	/** Stable session identifier passed to the bash executor. */
+	getSessionKey(): string;
+	/** Append a message to the in-memory agent state. */
+	appendToAgent(message: BashExecutionMessage): void;
+	/** Persist a message to the session store. */
+	appendToSession(message: BashExecutionMessage): void;
+	/** Persist the original (pre-minimisation) artifact. */
+	saveOriginalArtifact(text: string): Promise<string | undefined>;
+	/**
+	 * Invoke the `user_bash` extension hook. Returns the hook result when an
+	 * extension handled the command, or `undefined` to fall through to the
+	 * built-in executor.
+	 */
+	runUserBashHook(input: {
+		command: string;
+		excludeFromContext: boolean;
+		cwd: string;
+	}): Promise<BashResult | undefined>;
+}
+
+/**
+ * Owns the abort-controller set and pending-message buffer for bash
+ * execution. Extracted from {@link AgentSession} to shrink the host class;
+ * every public method maps 1-to-1 to the previous private/inline code.
+ */
+export class BashRuntime {
+	readonly #host: BashRuntimeHost;
+	readonly #abortControllers = new Set<AbortController>();
+	#pendingMessages: BashExecutionMessage[] = [];
+
+	constructor(host: BashRuntimeHost) {
+		this.#host = host;
+	}
+
+	/**
+	 * Execute a bash command.
+	 * Adds result to agent context and session.
+	 * @param command The bash command to execute
+	 * @param onChunk Optional streaming callback for output
+	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
+	 * @param options.useUserShell If true, allow caller to request configured user-shell routing
+	 */
+	async execute(
+		command: string,
+		onChunk?: (chunk: string) => void,
+		options?: { excludeFromContext?: boolean; useUserShell?: boolean },
+	): Promise<BashResult> {
+		const excludeFromContext = options?.excludeFromContext === true;
+		const cwd = this.#host.getCwd();
+
+		const hookResult = await this.#host.runUserBashHook({
+			command,
+			excludeFromContext,
+			cwd,
+		});
+		if (hookResult) {
+			this.record(command, hookResult, options);
+			return hookResult;
+		}
+
+		const abortController = new AbortController();
+		this.#abortControllers.add(abortController);
+
+		try {
+			const result = await executeBashCommand(command, {
+				onChunk,
+				signal: abortController.signal,
+				sessionKey: this.#host.getSessionKey(),
+				cwd,
+				timeout: clampTimeout("bash") * 1000,
+				onMinimizedSave: originalText => this.#host.saveOriginalArtifact(originalText),
+				useUserShell: options?.useUserShell,
+			});
+
+			this.record(command, result, options);
+			return result;
+		} finally {
+			this.#abortControllers.delete(abortController);
+		}
+	}
+
+	/**
+	 * Record a bash execution result in session history.
+	 * Used by execute and by extensions that handle bash execution themselves.
+	 */
+	record(command: string, result: BashResult, options?: { excludeFromContext?: boolean }): void {
+		const meta = outputMeta().truncationFromSummary(result, { direction: "tail" }).get();
+		const bashMessage: BashExecutionMessage = {
+			role: "bashExecution",
+			command,
+			output: result.output,
+			exitCode: result.exitCode,
+			cancelled: result.cancelled,
+			truncated: result.truncated,
+			meta,
+			timestamp: Date.now(),
+			excludeFromContext: options?.excludeFromContext,
+		};
+
+		// If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
+		if (this.#host.isStreaming()) {
+			// Queue for later - will be flushed on agent_end
+			this.#pendingMessages.push(bashMessage);
+		} else {
+			// Add to agent state immediately
+			this.#host.appendToAgent(bashMessage);
+
+			// Save to session
+			this.#host.appendToSession(bashMessage);
+		}
+	}
+
+	/** Cancel all running bash commands. */
+	abort(): void {
+		for (const abortController of this.#abortControllers) {
+			abortController.abort();
+		}
+	}
+
+	/** Whether a bash command is currently running. */
+	get isRunning(): boolean {
+		return this.#abortControllers.size > 0;
+	}
+
+	/** Whether there are pending bash messages waiting to be flushed. */
+	get hasPendingMessages(): boolean {
+		return this.#pendingMessages.length > 0;
+	}
+
+	/**
+	 * Flush pending bash messages to agent state and session.
+	 * Called after agent turn completes to maintain proper message ordering.
+	 */
+	flushPendingMessages(): void {
+		if (this.#pendingMessages.length === 0) return;
+
+		for (const bashMessage of this.#pendingMessages) {
+			// Add to agent state
+			this.#host.appendToAgent(bashMessage);
+
+			// Save to session
+			this.#host.appendToSession(bashMessage);
+		}
+
+		this.#pendingMessages = [];
+	}
+}

--- a/packages/coding-agent/test/agent-session-bash-runtime.test.ts
+++ b/packages/coding-agent/test/agent-session-bash-runtime.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Behavior-pinning tests for the session-side bash API.
+ *
+ * These tests exercise only the public API surface of AgentSession:
+ *   executeBash · recordBashResult · abortBash · isBashRunning · hasPendingBashMessages
+ *
+ * They must pass against the current (unmodified) agent-session.ts AND survive
+ * the internal BashRuntime refactor, because they assert only observable
+ * behaviour through the public contract — zero references to BashRuntime, #bash,
+ * or any private field.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { MockModel as MockModelType, MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import type { BashExecutionMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
+import type { SessionMessageEntry } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stopReply(text: string): MockResponse {
+	return {
+		content: [{ type: "text", text }],
+		stopReason: "stop",
+	};
+}
+
+function findBashMessages(messages: readonly { role?: string }[]): BashExecutionMessage[] {
+	return messages.filter((m): m is BashExecutionMessage => m.role === "bashExecution");
+}
+
+function findBashEntries(sessionManager: SessionManager): BashExecutionMessage[] {
+	return sessionManager
+		.getEntries()
+		.filter((e): e is SessionMessageEntry => e.type === "message")
+		.map(e => e.message)
+		.filter((m): m is BashExecutionMessage => m.role === "bashExecution");
+}
+
+/** A minimal BashResult-shaped object for recordBashResult calls in tests. */
+function syntheticResult(output: string, exitCode = 0) {
+	return {
+		output,
+		exitCode,
+		cancelled: false,
+		truncated: false,
+		totalLines: 1,
+		totalBytes: output.length,
+		outputLines: 1,
+		outputBytes: output.length,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("AgentSession bash runtime (public API)", () => {
+	let tempDir: string;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let mock: MockModelType;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-bash-runtime-test-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: tempDir });
+
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("expected claude-sonnet-4-5 to be bundled");
+
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"todo.enabled": false,
+			"todo.eager": "default",
+			"todo.reminders": false,
+			"async.enabled": false,
+			"bash.autoBackground.enabled": false,
+		});
+		sessionManager = SessionManager.inMemory(tempDir);
+
+		mock = createMockModel({
+			handler: () => stopReply("done"),
+		});
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: mock.stream,
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+		});
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage?.close();
+		authStorage = undefined;
+		if (fs.existsSync(tempDir)) {
+			removeSyncWithRetries(tempDir);
+		}
+		resetSettingsForTest();
+	});
+
+	// -------------------------------------------------------------------
+	// Contract 1: executeBash while idle
+	// -------------------------------------------------------------------
+	it("executeBash returns output/exitCode and appends a bashExecution message immediately", async () => {
+		const result = await session.executeBash("echo hello-world");
+
+		expect(result.output).toContain("hello-world");
+		expect(result.exitCode).toBe(0);
+
+		// Message is in session.messages
+		const bashMsgs = findBashMessages(session.messages);
+		expect(bashMsgs.length).toBeGreaterThanOrEqual(1);
+
+		const msg = bashMsgs[bashMsgs.length - 1]!;
+		expect(msg.role).toBe("bashExecution");
+		expect(msg.command).toBe("echo hello-world");
+		expect(msg.output).toContain("hello-world");
+		expect(msg.exitCode).toBe(0);
+		expect(msg.timestamp).toBeGreaterThan(0);
+
+		// Persisted via session manager
+		const entries = findBashEntries(sessionManager);
+		expect(entries.length).toBeGreaterThanOrEqual(1);
+		expect(entries[entries.length - 1]!.command).toBe("echo hello-world");
+
+		// No pending messages when idle
+		expect(session.hasPendingBashMessages).toBe(false);
+	});
+
+	// -------------------------------------------------------------------
+	// Contract 2: excludeFromContext
+	// -------------------------------------------------------------------
+	it("executeBash with excludeFromContext carries the flag on the recorded message", async () => {
+		await session.executeBash("echo hidden", undefined, { excludeFromContext: true });
+
+		const bashMsgs = findBashMessages(session.messages);
+		const msg = bashMsgs[bashMsgs.length - 1]!;
+		expect(msg.excludeFromContext).toBe(true);
+	});
+
+	// -------------------------------------------------------------------
+	// Contract 3: deferred ordering while streaming
+	// -------------------------------------------------------------------
+	it("recordBashResult mid-stream defers the message; it appears after the next prompt()", async () => {
+		// Push a handler onto the mock's extras queue. Because MockModel.stream
+		// binds to `this`, the extras handler is consumed on the NEXT prompt
+		// call (pullHandler checks extras before the fallback). The handler
+		// fires inside the mock's async runMock, which runs while
+		// #promptInFlightCount > 0 → isStreaming === true → record defers.
+		mock.push(() => {
+			// isStreaming is true at this point (#promptInFlightCount > 0)
+			session.recordBashResult("echo deferred", syntheticResult("deferred-output"));
+			return stopReply("streaming-turn");
+		});
+
+		// Before any prompt: nothing pending
+		expect(session.hasPendingBashMessages).toBe(false);
+
+		// First prompt: the extras handler runs, records bash mid-stream.
+		// flushPendingMessages() runs at the START of the next prompt, so
+		// after this prompt returns the message is still pending.
+		await session.prompt("first turn");
+		await session.waitForIdle();
+
+		expect(session.hasPendingBashMessages).toBe(true);
+		expect(findBashMessages(session.messages).some(m => m.command === "echo deferred")).toBe(false);
+
+		// Second prompt: flushPendingMessages() fires at the top of
+		// #promptWithMessage, draining the pending buffer → message appears.
+		await session.prompt("second turn");
+		await session.waitForIdle();
+
+		expect(session.hasPendingBashMessages).toBe(false);
+		expect(findBashMessages(session.messages).some(m => m.command === "echo deferred")).toBe(true);
+		expect(findBashEntries(sessionManager).some(e => e.command === "echo deferred")).toBe(true);
+	});
+
+	// -------------------------------------------------------------------
+	// Contract 4: abortBash mid-execution
+	// -------------------------------------------------------------------
+	it("abortBash cancels a running command; result has cancelled=true", async () => {
+		// Not running before
+		expect(session.isBashRunning).toBe(false);
+
+		// Start a long command — fire-and-forget to observe mid-flight state.
+		const resultPromise = session.executeBash("sleep 30");
+
+		// Give the shell time to spawn so the abort controller is registered.
+		await Bun.sleep(50);
+		expect(session.isBashRunning).toBe(true);
+
+		// Abort
+		session.abortBash();
+
+		const result = await resultPromise;
+		expect(result.cancelled).toBe(true);
+		expect(session.isBashRunning).toBe(false);
+	});
+
+	// -------------------------------------------------------------------
+	// Contract 5: isBashRunning lifecycle
+	// -------------------------------------------------------------------
+	it("isBashRunning is false before, true during, false after a short command", async () => {
+		expect(session.isBashRunning).toBe(false);
+
+		// "during" can only be observed for a long-running command
+		const resultPromise = session.executeBash("sleep 2");
+		await Bun.sleep(50);
+		expect(session.isBashRunning).toBe(true);
+
+		// Abort so we don't wait the full 2 s
+		session.abortBash();
+		await resultPromise;
+
+		expect(session.isBashRunning).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

First subsystem extraction for #1161. Moves the session-side bash execution orchestration out of the 15.8k-line `AgentSession` class into a composed `BashRuntime` (`session/bash-runtime.ts`, 162 lines), following the `GoalRuntime` host-interface pattern:

- `BashRuntime` owns the abort-controller set and the pending-message buffer; the logic is moved verbatim (streaming-defer branch in `record`, try/finally controller cleanup, `user_bash` extension-hook short-circuit).
- `BashRuntimeHost` (7 callbacks) is wired in the `AgentSession` constructor next to `GoalRuntime`; closures go through the live getters (`this.isStreaming`, `this.sessionId`) — nothing is cached at construction.
- Public API unchanged: `executeBash`, `recordBashResult`, `abortBash`, `isBashRunning`, `hasPendingBashMessages` remain as one-line delegations. Callsites in `modes/controllers/*` and `modes/rpc/*` are untouched.
- Net −63 lines on `agent-session.ts`.

Named `BashRuntime` rather than the `BashExecutor` floated in the issue thread: `src/exec/bash-executor.ts` already owns low-level execution on current `main`; this class is the remaining session-side orchestration.

Commit 1 adds behavior-pinning tests asserting only through the public API — verified green against the **unmodified** class before the move. Commit 2 is the extraction, keeping them green.

## Why

#1161 — the approved extraction sequence (leaf subsystems first: bash → python → retry/fallback; `GoalRuntime`-shaped host interface per controller). Deliberately sized to be reviewable in one sitting and mergeable before drift — the failure mode that killed #1174. Python execution is the natural next PR in the same shape.

## Testing

```
bun test packages/coding-agent/test/agent-session-bash-runtime.test.ts   # 5 pass (also 5/5 against pre-extraction base)
bun test packages/coding-agent/test/agent-session-bash-detach.test.ts    # pass
bun node_modules/.bin/tsgo -p packages/coding-agent/tsconfig.json --noEmit  # clean
bun run check:tools                                                       # biome: ok
```

Note: `test/bash-executor.test.ts` has one pre-existing local failure (symlink-CWD, environmental); its import graph does not intersect this diff.

---

- [x] `bun check` passes — TS side (`check:tools` + coding-agent `tsgo`) clean; `check:rs` fails locally on stable rustfmt (nightly-only options), no Rust files touched
- [x] Tested locally
- [ ] CHANGELOG updated — internal refactor, not user-facing

Refs #1161 (first of the extraction series — intentionally not `Fixes`, the issue tracks the whole sequence).
