### PR TITLE
fix(agent): reload edited legacy Pi modules

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed legacy Pi extension reloads on POSIX so `loadLegacyPiModule` imports the entry through a cache-busting filesystem path and re-imports edited source in the same process. ([#4565](https://github.com/can1357/oh-my-pi/issues/4565))
+- Fixed legacy Pi extension reloads on POSIX so `loadLegacyPiModule` imports the entry through a cache-busting filesystem path and threads the current load's `?mtime` tag through the extension source graph — relative `./helper.ts` siblings, `#alias/*` package-imports, and extension-local bare deps all rekey per reload, so same-process re-imports pick up edits across the whole graph. ([#4565](https://github.com/can1357/oh-my-pi/issues/4565))
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed legacy Pi extension reloads on POSIX so `loadLegacyPiModule` imports the entry through a cache-busting filesystem path, refreshes load-time graph hooks when reloads add new modules, and threads the current load's `?mtime` tag through the extension source graph — relative `./helper.ts` siblings, `#alias/*` package-imports, and extension-local bare deps all rekey per reload, so same-process re-imports pick up edits across the whole graph. ([#4565](https://github.com/can1357/oh-my-pi/issues/4565))
+- Fixed legacy Pi extension reloads on POSIX so `loadLegacyPiModule` imports the entry through a cache-busting filesystem path, refreshes load-time graph hooks when reloads add new modules, and threads the current load's `?mtime` tag through the extension source graph — relative `./helper.ts` siblings, `#alias/*` package-imports, extension-local bare dependency entries, and their relative children all rekey per reload, so same-process re-imports pick up edits across the whole graph. ([#4565](https://github.com/can1357/oh-my-pi/issues/4565))
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed legacy Pi extension reloads on POSIX so `loadLegacyPiModule` imports the entry through a cache-busting filesystem path and threads the current load's `?mtime` tag through the extension source graph — relative `./helper.ts` siblings, `#alias/*` package-imports, and extension-local bare deps all rekey per reload, so same-process re-imports pick up edits across the whole graph. ([#4565](https://github.com/can1357/oh-my-pi/issues/4565))
+- Fixed legacy Pi extension reloads on POSIX so `loadLegacyPiModule` imports the entry through a cache-busting filesystem path, refreshes load-time graph hooks when reloads add new modules, and threads the current load's `?mtime` tag through the extension source graph — relative `./helper.ts` siblings, `#alias/*` package-imports, and extension-local bare deps all rekey per reload, so same-process re-imports pick up edits across the whole graph. ([#4565](https://github.com/can1357/oh-my-pi/issues/4565))
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy Pi extension reloads on POSIX so `loadLegacyPiModule` imports the entry through a cache-busting filesystem path and re-imports edited source in the same process. ([#4565](https://github.com/can1357/oh-my-pi/issues/4565))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -479,8 +479,19 @@ const TYPEBOX_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'
  * or compiled-mode virtual specifiers. Relative siblings and built-in modules
  * are left untouched so Bun resolves them from the extension's real on-disk
  * location.
+ *
+ * When `mtimeTag` is provided, extension-owned graph specifiers (relative
+ * `./`/`../`, package `#alias/*`, and extension-local bare deps) also carry a
+ * `?mtime=<tag>` cache-bust so Bun rekeys them on same-process reloads. Host
+ * package rewrites (legacy `@(scope)/pi-*`, TypeBox shim) always emit
+ * `file://` URLs because they resolve to in-process host code that never
+ * changes between reloads.
  */
-async function rewriteLegacyExtensionSource(source: string, importerPath: string): Promise<string> {
+async function rewriteLegacyExtensionSource(
+	source: string,
+	importerPath: string,
+	mtimeTag: string | null = null,
+): Promise<string> {
 	const withPi = rewriteLegacyPiImports(source);
 	// When the TypeBox shim is missing (release build dropped the entrypoint —
 	// issue #3414), leave bare specifiers untouched so Bun resolves a real
@@ -493,12 +504,48 @@ async function rewriteLegacyExtensionSource(source: string, importerPath: string
 					`${prefix}${toImportSpecifier(TYPEBOX_SHIM_PATH)}${suffix}`,
 			)
 		: withPi;
-	return rewriteExtensionBareImports(await rewriteExtensionPackageImports(withTypeBox, importerPath), importerPath);
+	const withPkg = await rewriteExtensionPackageImports(withTypeBox, importerPath, mtimeTag);
+	const withBare = await rewriteExtensionBareImports(withPkg, importerPath, mtimeTag);
+	if (!mtimeTag) {
+		return withBare;
+	}
+	return withBare.replace(
+		RELATIVE_GRAPH_IMPORT_SPECIFIER_REGEX,
+		(_match, prefix: string, specifier: string, suffix: string) => `${prefix}${specifier}?mtime=${mtimeTag}${suffix}`,
+	);
 }
 
 /** Test seam for compiled-binary legacy extension source rewriting. */
-export async function __rewriteLegacyExtensionSourceForTests(source: string, importerPath: string): Promise<string> {
-	return rewriteLegacyExtensionSource(source, importerPath);
+export async function __rewriteLegacyExtensionSourceForTests(
+	source: string,
+	importerPath: string,
+	mtimeTag: string | null = null,
+): Promise<string> {
+	return rewriteLegacyExtensionSource(source, importerPath, mtimeTag);
+}
+
+// Match relative graph specifiers so their `./foo.ts` /`../foo` targets get a
+// `?mtime=<tag>` cache-bust suffix without disturbing already-rewritten
+// `file://` URLs or bare/host specifiers.
+const RELATIVE_GRAPH_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])(\.\.?\/[^"'?\s]*)(["'])/g;
+
+/**
+ * Build the import specifier for a graph-resolved absolute path. POSIX
+ * emits a bare filesystem path with an optional `?mtime=<tag>` (Bun keys
+ * query strings for bare-path specifiers), so same-process extension
+ * reloads pick up edits to package-alias (`#foo/*`) and extension-local
+ * bare deps. Windows and bundled virtual specifiers keep the current
+ * `file://` / virtual form — Bun ignores queries on `file://` URLs, so
+ * cache-bust does not reach Windows extensions until Bun changes that.
+ */
+function toGraphImportSpecifier(resolvedPath: string, mtimeTag: string | null): string {
+	if (isBundledVirtualSpecifier(resolvedPath)) {
+		return resolvedPath;
+	}
+	if (process.platform === "win32" || !mtimeTag) {
+		return url.pathToFileURL(stripWindowsExtendedLengthPathPrefix(resolvedPath)).href;
+	}
+	return `${stripWindowsExtendedLengthPathPrefix(resolvedPath)}?mtime=${mtimeTag}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -688,7 +735,11 @@ async function resolvePackageImportSpecifier(specifier: string, importerPath: st
 
 const PACKAGE_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])(#[^"'()\s]+)(["'])/g;
 
-async function rewriteExtensionPackageImports(source: string, importerPath: string): Promise<string> {
+async function rewriteExtensionPackageImports(
+	source: string,
+	importerPath: string,
+	mtimeTag: string | null = null,
+): Promise<string> {
 	let rewritten = "";
 	let lastIndex = 0;
 	for (const match of source.matchAll(PACKAGE_IMPORT_SPECIFIER_REGEX)) {
@@ -702,7 +753,7 @@ async function rewriteExtensionPackageImports(source: string, importerPath: stri
 		if (!resolved) continue;
 
 		rewritten += source.slice(lastIndex, matchIndex);
-		rewritten += `${prefix}${toImportSpecifier(resolved)}${suffix}`;
+		rewritten += `${prefix}${toGraphImportSpecifier(resolved, mtimeTag)}${suffix}`;
 		lastIndex = matchIndex + fullMatch.length;
 	}
 
@@ -899,7 +950,11 @@ async function resolveExtensionBareDependencyUncached(specifier: string, importe
 	return resolveNodePackageDependency(specifier, importerPath);
 }
 
-async function rewriteExtensionBareImports(source: string, importerPath: string): Promise<string> {
+async function rewriteExtensionBareImports(
+	source: string,
+	importerPath: string,
+	mtimeTag: string | null = null,
+): Promise<string> {
 	let rewritten = "";
 	let lastIndex = 0;
 	for (const match of source.matchAll(BARE_EXTENSION_IMPORT_SPECIFIER_REGEX)) {
@@ -913,7 +968,7 @@ async function rewriteExtensionBareImports(source: string, importerPath: string)
 		if (!resolved) continue;
 
 		rewritten += source.slice(lastIndex, matchIndex);
-		rewritten += `${prefix}${toImportSpecifier(resolved)}${suffix}`;
+		rewritten += `${prefix}${toGraphImportSpecifier(resolved, mtimeTag)}${suffix}`;
 		lastIndex = matchIndex + fullMatch.length;
 	}
 
@@ -1023,7 +1078,9 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<stri
 		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
 		setup(build) {
 			build.onLoad({ filter, namespace: "file" }, async args => {
-				const sourcePath = args.path.replace(/\?mtime=\d+$/, "");
+				const queryIndex = args.path.indexOf("?mtime=");
+				const sourcePath = queryIndex >= 0 ? args.path.slice(0, queryIndex) : args.path;
+				const mtimeTag = queryIndex >= 0 ? args.path.slice(queryIndex + "?mtime=".length) : null;
 				const cached = modules.get(sourcePath);
 				let raw: string;
 				if (cached !== undefined) {
@@ -1033,7 +1090,10 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<stri
 				} else {
 					raw = await Bun.file(sourcePath).text();
 				}
-				return { contents: await rewriteLegacyExtensionSource(raw, sourcePath), loader: getLoader(sourcePath) };
+				return {
+					contents: await rewriteLegacyExtensionSource(raw, sourcePath, mtimeTag),
+					loader: getLoader(sourcePath),
+				};
 			});
 		},
 	});

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -987,10 +987,11 @@ function escapeRegExp(value: string): string {
 // native Bun resolutions.
 const EXTENSION_GRAPH_SPECIFIER_REGEX = /(?:from\s+|import\s+|import\s*\(\s*)["']((?:\.\.?\/|#)[^"']+)["']/g;
 
-// Extension entry realpaths that already have a load-time rewrite hook
-// installed. Each `Bun.plugin()` registration is process-global and permanent,
-// so we register at most one hook per entry.
-const hookedExtensionEntries = new Set<string>();
+// Extension source realpaths already covered by an installed load-time hook for
+// each entry. `Bun.plugin()` registrations are process-global and permanent, so
+// reloads install supplemental hooks only for modules added to the graph since
+// the previous load.
+const extensionGraphHookModules = new Map<string, Set<string>>();
 
 /** Resolve symlinks in a path, falling back to the input if realpath fails. */
 async function realpathOrSelf(p: string): Promise<string> {
@@ -1053,29 +1054,18 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 }
 
 /**
- * Install a `Bun.plugin()` `onLoad` hook scoped to exactly the modules in an
- * extension's source graph, so their legacy `@(scope)/pi-*`, bare
- * `@sinclair/typebox`, and local package-import aliases are rewritten at load
- * time. A runtime `onLoad` cannot fall through (Bun requires a result object),
- * so the filter is an exact-path alternation of the graph's realpaths — it
- * never matches the host, other extensions, `node_modules` deps, or unrelated
- * project source.
- *
- * Returns the collected path→source map on first install so the caller can
- * drop entries the initial import never consumed; `undefined` when the hook
- * was already installed.
+ * Install a `Bun.plugin()` `onLoad` hook scoped to a set of extension-owned
+ * source modules. Runtime `onLoad` cannot fall through (Bun requires a result
+ * object), so every hook uses an exact-path alternation for modules known to be
+ * part of this entry's graph; reloads add supplemental hooks for newly
+ * discovered modules instead of widening an existing filter to unrelated files.
  */
-async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<string, string> | undefined> {
-	if (hookedExtensionEntries.has(entryRealPath)) {
-		return undefined;
-	}
-	hookedExtensionEntries.add(entryRealPath);
-
-	const modules = await collectExtensionModules(entryRealPath);
+function installExtensionGraphHook(entryRealPath: string, modules: Map<string, string>): void {
 	const alternation = [...modules.keys()].map(escapeRegExp).join("|");
 	const filter = new RegExp(`^(?:${alternation})(?:\\?mtime=\\d+)?$`);
+	const hookId = Bun.hash(`${entryRealPath}\0${[...modules.keys()].join("\0")}`).toString(36);
 	Bun.plugin({
-		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
+		name: `omp:legacy-pi-ext:${hookId}`,
 		setup(build) {
 			build.onLoad({ filter, namespace: "file" }, async args => {
 				const queryIndex = args.path.indexOf("?mtime=");
@@ -1097,7 +1087,39 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<stri
 			});
 		},
 	});
-	return modules;
+}
+
+/**
+ * Ensure every currently reachable extension source module has a load-time
+ * rewrite hook. The entry graph can grow across reloads, so each call collects
+ * the current graph and registers hooks for paths not covered by earlier loads.
+ *
+ * Returns the newly collected path→source map so the caller can drop entries
+ * the import never consumed; `undefined` when no new modules were discovered.
+ */
+async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<string, string> | undefined> {
+	const currentModules = await collectExtensionModules(entryRealPath);
+	let hookedModules = extensionGraphHookModules.get(entryRealPath);
+	if (!hookedModules) {
+		hookedModules = new Set<string>();
+		extensionGraphHookModules.set(entryRealPath, hookedModules);
+	}
+
+	const pendingModules = new Map<string, string>();
+	for (const [modulePath, source] of currentModules) {
+		if (!hookedModules.has(modulePath)) {
+			pendingModules.set(modulePath, source);
+		}
+	}
+	if (pendingModules.size === 0) {
+		return undefined;
+	}
+
+	installExtensionGraphHook(entryRealPath, pendingModules);
+	for (const modulePath of pendingModules.keys()) {
+		hookedModules.add(modulePath);
+	}
+	return pendingModules;
 }
 
 /**

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1018,21 +1018,22 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<Map<stri
 
 	const modules = await collectExtensionModules(entryRealPath);
 	const alternation = [...modules.keys()].map(escapeRegExp).join("|");
-	const filter = new RegExp(`^(?:${alternation})$`);
+	const filter = new RegExp(`^(?:${alternation})(?:\\?mtime=\\d+)?$`);
 	Bun.plugin({
 		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
 		setup(build) {
 			build.onLoad({ filter, namespace: "file" }, async args => {
-				const cached = modules.get(args.path);
+				const sourcePath = args.path.replace(/\?mtime=\d+$/, "");
+				const cached = modules.get(sourcePath);
 				let raw: string;
 				if (cached !== undefined) {
 					// consume-once: preserves ?mtime edit-pickup for the re-imported entry
-					modules.delete(args.path);
+					modules.delete(sourcePath);
 					raw = cached;
 				} else {
-					raw = await Bun.file(args.path).text();
+					raw = await Bun.file(sourcePath).text();
 				}
-				return { contents: await rewriteLegacyExtensionSource(raw, args.path), loader: getLoader(args.path) };
+				return { contents: await rewriteLegacyExtensionSource(raw, sourcePath), loader: getLoader(sourcePath) };
 			});
 		},
 	});
@@ -1057,8 +1058,15 @@ export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown>
 	const entryRealPath = await realpathOrSelf(path.resolve(resolvedPath));
 	const pendingSources = await ensureExtensionGraphHook(entryRealPath);
 	try {
-		// `?mtime` busts Bun's module cache so repeat loads pick up edited source.
-		return await import(`${toImportSpecifier(entryRealPath)}?mtime=${Date.now()}`);
+		// Dynamic import is required: legacy extension entry paths are user/plugin supplied at runtime.
+		// On POSIX, use the raw filesystem path so Bun keys the `?mtime`
+		// suffix as part of the module identity; Bun ignores query strings on
+		// `file://` specifiers, which would serve stale edited source.
+		const entrySpecifier =
+			process.platform === "win32" || isBundledVirtualSpecifier(entryRealPath)
+				? toImportSpecifier(entryRealPath)
+				: entryRealPath;
+		return await import(`${entrySpecifier}?mtime=${Date.now()}`);
 	} finally {
 		// Drop whatever the initial import didn't consume: graph modules only
 		// reached by lazy dynamic imports must be read from disk at their actual

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -982,10 +982,12 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Match source modules in an extension graph (relative imports and package
-// `imports` aliases such as `#src/*`). Bare third-party dependencies remain
-// native Bun resolutions.
-const EXTENSION_GRAPH_SPECIFIER_REGEX = /(?:from\s+|import\s+|import\s*\(\s*)["']((?:\.\.?\/|#)[^"']+)["']/g;
+// Match source modules in an extension graph: relative imports, package
+// `imports` aliases such as `#src/*`, and extension-local bare dependency
+// entries. Bare imports inside node_modules dependencies remain native Bun
+// resolutions; once the dependency entry is hooked, its relative children are
+// still collected and rewritten with the reload mtime tag.
+const EXTENSION_GRAPH_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])([^"'()\s]+)(["'])/g;
 
 // Extension source realpaths already covered by an installed load-time hook for
 // each entry. `Bun.plugin()` registrations are process-global and permanent, so
@@ -1012,12 +1014,12 @@ async function realpathOrSelfUncached(p: string): Promise<string> {
 }
 
 /**
- * Walk the extension's relative-import graph starting at `entryRealPath`,
- * returning the realpath of every reachable source module. Only relative
- * specifiers (`./`, `../`) are followed — bare and absolute imports are left to
- * Bun's native resolver — so the set is exactly the extension's own source,
- * wherever it physically lives (a `../src` sibling, a symlinked sub-tree, …).
- * This mirrors the module set the old temp-dir mirror tracked, minus the copy.
+ * Walk the extension's import graph starting at `entryRealPath`, returning the
+ * realpath of every reachable source module OMP must rewrite at load time.
+ * Relative imports and package `imports` aliases are always graph-owned.
+ * Extension-local bare dependency entries are also included so their relative
+ * children receive the reload mtime tag; bare imports inside those dependencies
+ * remain native Bun resolutions to avoid taking over full third-party graphs.
  */
 async function collectExtensionModules(entryRealPath: string): Promise<Map<string, string>> {
 	const modules = new Map<string, string>();
@@ -1035,18 +1037,39 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 		}
 		modules.set(file, source);
 		const dir = path.dirname(file);
+		const isDependencyModule = file.includes(`${path.sep}node_modules${path.sep}`);
 		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
-			const specifier = match[1];
+			const specifier = match[2];
 			if (!specifier) continue;
 			try {
-				const resolved = specifier.startsWith("#")
-					? await resolvePackageImportSpecifier(specifier, file)
-					: await realpathOrSelf(Bun.resolveSync(specifier, dir));
+				let resolved: string | null = null;
+				if (specifier.startsWith(".")) {
+					resolved = await realpathOrSelf(Bun.resolveSync(specifier, dir));
+				} else if (specifier.startsWith("#")) {
+					resolved = await resolvePackageImportSpecifier(specifier, file);
+				} else if (
+					!isDependencyModule &&
+					isBareExtensionDependencySpecifier(specifier) &&
+					!remapLegacyPiSpecifier(specifier) &&
+					specifier !== "typebox" &&
+					specifier !== "@sinclair/typebox"
+				) {
+					const parsed = splitBarePackageSpecifier(specifier);
+					const packageRoot = parsed ? await findNodePackageRoot(parsed.name, file) : null;
+					const manifest = packageRoot ? await readPackageManifest(packageRoot) : null;
+					const dependencyEntry = manifest ? await resolveExtensionBareDependency(specifier, file) : null;
+					const dependencyExtension = dependencyEntry ? path.extname(dependencyEntry) : null;
+					const isCommonJsEntry =
+						dependencyExtension === ".cjs" ||
+						dependencyExtension === ".cts" ||
+						((dependencyExtension === ".js" || dependencyExtension === ".jsx") && manifest?.type !== "module");
+					resolved = dependencyEntry && !isCommonJsEntry ? await realpathOrSelf(dependencyEntry) : null;
+				}
 				if (resolved && !modules.has(resolved)) {
 					queue.push(resolved);
 				}
 			} catch {
-				// Unresolvable relative import (e.g. a type-only path); skip it.
+				// Unresolvable import (e.g. a type-only path); skip it.
 			}
 		}
 	}

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -97,6 +97,46 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(second.asset).toBe("asset-ok");
 	});
 
+	it("reloads an edited relative helper module on same-process re-import", async () => {
+		const entrySource = (version: string): string =>
+			[
+				'import { fileURLToPath } from "node:url";',
+				'import { H } from "./helper.ts";',
+				"export { H };",
+				"export const entryPath = fileURLToPath(import.meta.url);",
+				`export const entryVersion = ${JSON.stringify(version)};`,
+				"export default function (pi) { void pi; }",
+			].join("\n");
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "helper-mtime-reload-ext", version: "1.0.0" }),
+			"index.ts": entrySource("v1"),
+			"helper.ts": 'export const H = "v1";\n',
+		});
+		const entry = path.join(dir, "index.ts");
+		const helper = path.join(dir, "helper.ts");
+		const expectedEntryPath = await fs.realpath(entry);
+
+		const first = (await loadLegacyPiModule(entry)) as { entryVersion: string; H: string; entryPath: string };
+		expect(first.entryVersion).toBe("v1");
+		expect(first.H).toBe("v1");
+		expect(first.entryPath).toBe(expectedEntryPath);
+
+		const firstEntryStat = await fs.stat(entry);
+		const firstHelperStat = await fs.stat(helper);
+		await fs.writeFile(entry, entrySource("v2"), "utf8");
+		await fs.writeFile(helper, 'export const H = "v2";\n', "utf8");
+		const bumpedEntryMtime = new Date(Math.ceil(firstEntryStat.mtimeMs) + 2_000);
+		const bumpedHelperMtime = new Date(Math.ceil(firstHelperStat.mtimeMs) + 2_000);
+		await fs.utimes(entry, bumpedEntryMtime, bumpedEntryMtime);
+		await fs.utimes(helper, bumpedHelperMtime, bumpedHelperMtime);
+
+		const second = (await loadLegacyPiModule(entry)) as { entryVersion: string; H: string; entryPath: string };
+		expect(second.entryVersion).toBe("v2");
+		expect(second.H).toBe("v2");
+		expect(second.entryPath).toBe(expectedEntryPath);
+		expect(second.entryPath.includes("?")).toBe(false);
+	});
+
 	it("resolves a .css sibling of a relatively-imported submodule", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "multi-file-ext", version: "1.0.0" }),

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -60,6 +60,43 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(mod.html).toBe("<html>PLAN-UI</html>");
 	});
 
+	it("reloads an edited entry module without polluting fileURLToPath-derived paths", async () => {
+		const entrySource = (version: string): string =>
+			[
+				'import { readFileSync } from "node:fs";',
+				'import { fileURLToPath } from "node:url";',
+				'import * as path from "node:path";',
+				"export const entryPath = fileURLToPath(import.meta.url);",
+				"const here = path.dirname(entryPath);",
+				`export const version = ${JSON.stringify(version)};`,
+				'export const asset = readFileSync(path.join(here, "marker.txt"), "utf8");',
+				"export default function (pi) { void pi; }",
+			].join("\n");
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "mtime-reload-ext", version: "1.0.0" }),
+			"marker.txt": "asset-ok",
+			"index.ts": entrySource("v1"),
+		});
+		const entry = path.join(dir, "index.ts");
+		const expectedEntryPath = await fs.realpath(entry);
+
+		const first = (await loadLegacyPiModule(entry)) as { version: string; entryPath: string; asset: string };
+		expect(first.version).toBe("v1");
+		expect(first.entryPath).toBe(expectedEntryPath);
+		expect(first.asset).toBe("asset-ok");
+
+		const firstStat = await fs.stat(entry);
+		await fs.writeFile(entry, entrySource("v2"), "utf8");
+		const bumpedMtime = new Date(Math.ceil(firstStat.mtimeMs) + 2_000);
+		await fs.utimes(entry, bumpedMtime, bumpedMtime);
+
+		const second = (await loadLegacyPiModule(entry)) as { version: string; entryPath: string; asset: string };
+		expect(second.version).toBe("v2");
+		expect(second.entryPath).toBe(expectedEntryPath);
+		expect(second.entryPath.includes("?")).toBe(false);
+		expect(second.asset).toBe("asset-ok");
+	});
+
 	it("resolves a .css sibling of a relatively-imported submodule", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "multi-file-ext", version: "1.0.0" }),

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -137,6 +137,47 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(second.entryPath.includes("?")).toBe(false);
 	});
 
+	it("reloads edited children of an extension-local bare dependency", async () => {
+		const entrySource = (version: string): string =>
+			[
+				'import { depValue } from "localdep";',
+				"export { depValue };",
+				`export const entryVersion = ${JSON.stringify(version)};`,
+				"export default function (pi) { void pi; }",
+			].join("\n");
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "bare-dep-child-reload-ext", version: "1.0.0" }),
+			"node_modules/localdep/package.json": JSON.stringify({
+				name: "localdep",
+				version: "1.0.0",
+				type: "module",
+				main: "index.js",
+			}),
+			"node_modules/localdep/index.js": 'export { depValue } from "./helper.js";\n',
+			"node_modules/localdep/helper.js": 'export const depValue = "dep-v1";\n',
+			"index.ts": entrySource("v1"),
+		});
+		const entry = path.join(dir, "index.ts");
+		const helper = path.join(dir, "node_modules", "localdep", "helper.js");
+
+		const first = (await loadLegacyPiModule(entry)) as { entryVersion: string; depValue: string };
+		expect(first.entryVersion).toBe("v1");
+		expect(first.depValue).toBe("dep-v1");
+
+		const firstEntryStat = await fs.stat(entry);
+		const firstHelperStat = await fs.stat(helper);
+		await fs.writeFile(entry, entrySource("v2"), "utf8");
+		await fs.writeFile(helper, 'export const depValue = "dep-v2";\n', "utf8");
+		const bumpedEntryMtime = new Date(Math.ceil(firstEntryStat.mtimeMs) + 2_000);
+		const bumpedHelperMtime = new Date(Math.ceil(firstHelperStat.mtimeMs) + 2_000);
+		await fs.utimes(entry, bumpedEntryMtime, bumpedEntryMtime);
+		await fs.utimes(helper, bumpedHelperMtime, bumpedHelperMtime);
+
+		const second = (await loadLegacyPiModule(entry)) as { entryVersion: string; depValue: string };
+		expect(second.entryVersion).toBe("v2");
+		expect(second.depValue).toBe("dep-v2");
+	});
+
 	it("reloads modules added to the relative import graph after the first load", async () => {
 		const entrySource = (version: string, includeHelper: boolean): string =>
 			[

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -137,6 +137,69 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(second.entryPath.includes("?")).toBe(false);
 	});
 
+	it("reloads modules added to the relative import graph after the first load", async () => {
+		const entrySource = (version: string, includeHelper: boolean): string =>
+			[
+				'import { fileURLToPath } from "node:url";',
+				includeHelper ? 'export { leafValue } from "./helper.ts";' : "",
+				"export const entryPath = fileURLToPath(import.meta.url);",
+				`export const entryVersion = ${JSON.stringify(version)};`,
+				"export default function (pi) { void pi; }",
+			]
+				.filter(Boolean)
+				.join("\n");
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "expanding-graph-reload-ext", version: "1.0.0" }),
+			"index.ts": entrySource("v1", false),
+		});
+		const entry = path.join(dir, "index.ts");
+		const helper = path.join(dir, "helper.ts");
+		const leaf = path.join(dir, "leaf.ts");
+		const expectedEntryPath = await fs.realpath(entry);
+
+		const first = (await loadLegacyPiModule(entry)) as { entryVersion: string; entryPath: string };
+		expect(first.entryVersion).toBe("v1");
+		expect(first.entryPath).toBe(expectedEntryPath);
+
+		const firstEntryStat = await fs.stat(entry);
+		const firstGraphMtime = new Date(Math.ceil(firstEntryStat.mtimeMs) + 2_000);
+		await fs.writeFile(entry, entrySource("v2", true), "utf8");
+		await fs.writeFile(helper, 'export { leafValue } from "./leaf.ts";\n', "utf8");
+		await fs.writeFile(leaf, 'export const leafValue = "leaf-v1";\n', "utf8");
+		await fs.utimes(entry, firstGraphMtime, firstGraphMtime);
+		await fs.utimes(helper, firstGraphMtime, firstGraphMtime);
+		await fs.utimes(leaf, firstGraphMtime, firstGraphMtime);
+
+		const second = (await loadLegacyPiModule(entry)) as {
+			entryVersion: string;
+			entryPath: string;
+			leafValue: string;
+		};
+		expect(second.entryVersion).toBe("v2");
+		expect(second.leafValue).toBe("leaf-v1");
+		expect(second.entryPath).toBe(expectedEntryPath);
+		expect(second.entryPath.includes("?")).toBe(false);
+
+		const secondEntryStat = await fs.stat(entry);
+		const secondLeafStat = await fs.stat(leaf);
+		await fs.writeFile(entry, entrySource("v3", true), "utf8");
+		await fs.writeFile(leaf, 'export const leafValue = "leaf-v2";\n', "utf8");
+		const bumpedEntryMtime = new Date(Math.ceil(secondEntryStat.mtimeMs) + 2_000);
+		const bumpedLeafMtime = new Date(Math.ceil(secondLeafStat.mtimeMs) + 2_000);
+		await fs.utimes(entry, bumpedEntryMtime, bumpedEntryMtime);
+		await fs.utimes(leaf, bumpedLeafMtime, bumpedLeafMtime);
+
+		const third = (await loadLegacyPiModule(entry)) as {
+			entryVersion: string;
+			entryPath: string;
+			leafValue: string;
+		};
+		expect(third.entryVersion).toBe("v3");
+		expect(third.leafValue).toBe("leaf-v2");
+		expect(third.entryPath).toBe(expectedEntryPath);
+		expect(third.entryPath.includes("?")).toBe(false);
+	});
+
 	it("resolves a .css sibling of a relatively-imported submodule", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "multi-file-ext", version: "1.0.0" }),


### PR DESCRIPTION
## Repro
The standalone Bun repro from #4565 shows `file://` URL imports ignore `?mtime` for module identity: `bun /tmp/issue4565-repro.mjs` printed `bare-path + ?mtime: load2=B` and `file:// URL + ?mtime: load2=A`, proving the current `loadLegacyPiModule` import path served stale edited source in-process.

## Cause
`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` built the extension entry import with `toImportSpecifier(entryRealPath)`, which converts disk paths to `file://` URLs before appending `?mtime`. Bun ignores that query for `file://` module cache keys, and switching to raw POSIX paths also required `ensureExtensionGraphHook` to match and normalize the appended `?mtime` before reading/re-writing the entry source.

## Fix
- Import POSIX legacy extension entries through their raw filesystem path while preserving `file://` for Windows and bundled virtual specifiers.
- Allow the extension graph `onLoad` filter to match the entry path with a trailing `?mtime=<timestamp>` and strip that suffix before cache lookup, disk reads, source rewriting, and loader selection.
- Add a regression test covering same-process reload of an edited entry module plus clean `fileURLToPath(import.meta.url)` path/asset behavior.
- Add a coding-agent changelog entry for the reload freshness fix.

## Verification
`bun /tmp/issue4565-repro.mjs` reproduced the stale `file://` import behavior before the fix. `bun .wt/issue4565-load-smoke.ts` returned `load1=A clean1=true` and `load2=B clean2=true` through the real loader after the fix. `bun test test/extensibility/legacy-pi-inplace-load.test.ts -t "reloads an edited entry module"` passed: 1 pass, 10 filtered out. `bun test test/extensibility/legacy-pi-inplace-load.test.ts -t "loads the extension's own node_modules deps"` passed: 1 pass, 10 filtered out. `bun check` passed. An unfiltered local run of `bun test test/extensibility/legacy-pi-inplace-load.test.ts` still fails three pre-existing generated-asset-dependent cases on this checkout with `Cannot find module './tool-views.generated.js'` from `packages/coding-agent/src/export/html/index.ts`; the focused reload and remap regressions above pass. Fixes #4565.