### PR TITLE
fix(agent): restore legacy DefaultResourceLoader shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy pi extension imports of `DefaultResourceLoader` from `@mariozechner/pi-coding-agent` / `@earendil-works/pi-coding-agent` by adding a compatibility loader shim that translates `resourceLoader` into OMP's native session discovery options. ([#4567](https://github.com/can1357/oh-my-pi/issues/4567))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -17,9 +17,18 @@ import * as path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { TSchema } from "@oh-my-pi/pi-ai";
 import { Text } from "@oh-my-pi/pi-tui";
-import { parseFrontmatter as parseOmpFrontmatter } from "@oh-my-pi/pi-utils";
+import { getAgentDir, getProjectDir, parseFrontmatter as parseOmpFrontmatter } from "@oh-my-pi/pi-utils";
+import type { PromptTemplate } from "../config/prompt-templates";
 import { type SettingPath, Settings } from "../config/settings";
 import { EditTool } from "../edit";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult, LoadExtensionsResult } from "../sdk";
+import {
+	discoverContextFiles,
+	discoverPromptTemplates,
+	discoverSessionExtensionPaths,
+	discoverSkills,
+	createAgentSession as ompCreateAgentSession,
+} from "../sdk";
 import {
 	DEFAULT_MAX_BYTES,
 	DEFAULT_MAX_LINES,
@@ -34,7 +43,12 @@ import { GrepTool } from "../tools/grep";
 import { ReadTool } from "../tools/read";
 import { formatBytes } from "../tools/render-utils";
 import { WriteTool } from "../tools/write";
-import type { ToolDefinition } from "./extensions/types";
+import { EventBus } from "../utils/event-bus";
+import { loadExtensionFromFactory, loadExtensions } from "./extensions";
+import { ExtensionRuntime } from "./extensions/loader";
+import type { ExtensionFactory, ToolDefinition } from "./extensions/types";
+import type { Skill } from "./skills";
+import { loadSkillsFromDir } from "./skills";
 import { Type } from "./typebox";
 
 const TOOL_DEFINITION_MARKER = "__isToolDefinition";
@@ -640,6 +654,534 @@ export const SettingsManager = {
 		return Settings.isolated();
 	},
 } as const;
+
+/**
+ * Resource-loader compatibility layer for legacy pi extensions.
+ *
+ * Upstream `@earendil-works/pi-coding-agent` centralizes extension / skill /
+ * prompt / theme / AGENTS.md discovery inside a `DefaultResourceLoader`
+ * instance that the caller constructs, `reload()`s, and hands to
+ * `createAgentSession({ resourceLoader })`. Every published version of
+ * pi-schedule-prompt (≥0.2.0) and other pi extensions that spawn subagents
+ * import the class at module scope; a missing export takes the whole
+ * extension down at parse time (issue #4567).
+ *
+ * OMP does the same discovery inline inside `createAgentSession()`, so this
+ * shim intentionally does NOT re-implement pi's ResourceLoader plumbing.
+ * Instead the loader captures the caller's intent (`no*` flags, `*Override`
+ * callbacks, `additional*Paths`, `extensionFactories`, `settingsManager`,
+ * `eventBus`) plus the discovery results, and the sibling `createAgentSession`
+ * override below translates them into OMP's native session options
+ * (`disableExtensionDiscovery`, `preloadedExtensionPaths`, `extensions`,
+ * `skills`, `promptTemplates`, `contextFiles`, `settings`, `eventBus`,
+ * `systemPrompt`) before delegating to `../sdk`.
+ *
+ * The pi surface it emulates is the intersection actually used by real
+ * extensions in the wild — themes are silently dropped (OMP has no
+ * session-level themes surface); `extendResources`, `loadProjectTrustExtensions`,
+ * and provider-trust hooks are omitted.
+ */
+
+export type ResourceDiagnostic = {
+	type: "error" | "warning" | "info";
+	message: string;
+	path?: string;
+};
+
+export interface AgentsFile {
+	path: string;
+	content: string;
+}
+
+/** Marker interface preserved for pi extensions that type against upstream. */
+export interface Theme {
+	name: string;
+}
+
+export interface DefaultResourceLoaderOptions {
+	cwd?: string;
+	agentDir?: string;
+	settingsManager?: Settings | Promise<Settings>;
+	eventBus?: EventBus;
+	additionalExtensionPaths?: string[];
+	additionalSkillPaths?: string[];
+	additionalPromptTemplatePaths?: string[];
+	additionalThemePaths?: string[];
+	extensionFactories?: ExtensionFactory[];
+	noExtensions?: boolean;
+	noSkills?: boolean;
+	noPromptTemplates?: boolean;
+	noThemes?: boolean;
+	noContextFiles?: boolean;
+	systemPrompt?: string;
+	appendSystemPrompt?: string[];
+	extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
+	skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
+		skills: Skill[];
+		diagnostics: ResourceDiagnostic[];
+	};
+	promptsOverride?: (base: { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] }) => {
+		prompts: PromptTemplate[];
+		diagnostics: ResourceDiagnostic[];
+	};
+	themesOverride?: (base: { themes: Theme[]; diagnostics: ResourceDiagnostic[] }) => {
+		themes: Theme[];
+		diagnostics: ResourceDiagnostic[];
+	};
+	agentsFilesOverride?: (base: { agentsFiles: AgentsFile[] }) => { agentsFiles: AgentsFile[] };
+	systemPromptOverride?: (base: string | undefined) => string | undefined;
+	appendSystemPromptOverride?: (base: string[]) => string[];
+}
+
+/**
+ * The subset of {@link DefaultResourceLoader} state consumed by the
+ * {@link createAgentSession} adapter. Kept as an explicit interface so tests
+ * (and any future third-party ResourceLoader passed to `createAgentSession`)
+ * only need to satisfy the read surface — not the reload lifecycle.
+ */
+export interface ResourceLoader {
+	getExtensions(): LoadExtensionsResult;
+	getSkills(): { skills: Skill[]; diagnostics: ResourceDiagnostic[] };
+	getPrompts(): { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] };
+	getThemes(): { themes: Theme[]; diagnostics: ResourceDiagnostic[] };
+	getAgentsFiles(): { agentsFiles: AgentsFile[] };
+	getSystemPrompt(): string | undefined;
+	getAppendSystemPrompt(): string[];
+	reload(): Promise<void>;
+	/** @internal — used by the shim's createAgentSession to detect its own loaders. */
+	readonly __ompLegacyPiLoader?: true;
+}
+
+/**
+ * Loader-owned inputs that {@link createAgentSession} needs regardless of
+ * whether the caller provided extra options. `cwd`/`agentDir` fall back to
+ * `getProjectDir()`/`getAgentDir()` at construction time so subsequent
+ * `reload()` and `createAgentSession()` calls read the same directories the
+ * caller thought they were configuring.
+ */
+interface ResolvedLoaderState {
+	cwd: string;
+	agentDir: string;
+	settingsPromise?: Promise<Settings>;
+	eventBus?: EventBus;
+	extensionFactories: ExtensionFactory[];
+	noExtensions: boolean;
+	additionalExtensionPaths: string[];
+	additionalSkillPaths: string[];
+	additionalPromptTemplatePaths: string[];
+}
+
+interface AdditionalSkillLoadResult {
+	skills: Skill[];
+	diagnostics: ResourceDiagnostic[];
+}
+
+interface AdditionalPromptLoadResult {
+	prompts: PromptTemplate[];
+	diagnostics: ResourceDiagnostic[];
+}
+
+export class DefaultResourceLoader implements ResourceLoader {
+	readonly __ompLegacyPiLoader = true as const;
+	#state: ResolvedLoaderState;
+	#options: DefaultResourceLoaderOptions;
+	#extensionsResult: LoadExtensionsResult = { extensions: [], errors: [], runtime: new ExtensionRuntime() };
+	#skills: Skill[] = [];
+	#skillDiagnostics: ResourceDiagnostic[] = [];
+	#prompts: PromptTemplate[] = [];
+	#promptDiagnostics: ResourceDiagnostic[] = [];
+	#themes: Theme[] = [];
+	#themeDiagnostics: ResourceDiagnostic[] = [];
+	#agentsFiles: AgentsFile[] = [];
+	#systemPrompt: string | undefined;
+	#appendSystemPrompt: string[] = [];
+	#loaded = false;
+
+	constructor(options: DefaultResourceLoaderOptions = {}) {
+		this.#options = options;
+		const cwd = options.cwd ?? getProjectDir();
+		const agentDir = options.agentDir ?? getAgentDir();
+		this.#state = {
+			cwd,
+			agentDir,
+			settingsPromise: options.settingsManager ? Promise.resolve(options.settingsManager) : undefined,
+			eventBus: options.eventBus,
+			extensionFactories: options.extensionFactories ?? [],
+			noExtensions: options.noExtensions ?? false,
+			additionalExtensionPaths: options.additionalExtensionPaths ?? [],
+			additionalSkillPaths: options.additionalSkillPaths ?? [],
+			additionalPromptTemplatePaths: options.additionalPromptTemplatePaths ?? [],
+		};
+	}
+
+	getExtensions(): LoadExtensionsResult {
+		return this.#extensionsResult;
+	}
+
+	getSkills(): { skills: Skill[]; diagnostics: ResourceDiagnostic[] } {
+		return { skills: this.#skills, diagnostics: this.#skillDiagnostics };
+	}
+
+	getPrompts(): { prompts: PromptTemplate[]; diagnostics: ResourceDiagnostic[] } {
+		return { prompts: this.#prompts, diagnostics: this.#promptDiagnostics };
+	}
+
+	getThemes(): { themes: Theme[]; diagnostics: ResourceDiagnostic[] } {
+		return { themes: this.#themes, diagnostics: this.#themeDiagnostics };
+	}
+
+	getAgentsFiles(): { agentsFiles: AgentsFile[] } {
+		return { agentsFiles: this.#agentsFiles };
+	}
+
+	getSystemPrompt(): string | undefined {
+		return this.#systemPrompt;
+	}
+
+	getAppendSystemPrompt(): string[] {
+		return this.#appendSystemPrompt;
+	}
+
+	/**
+	 * Discovery snapshot used to seed the session. Emulates upstream pi's
+	 * `reload()` lifecycle: run every enabled discovery arm against the
+	 * resolved cwd/agentDir, then thread each result through the caller's
+	 * `*Override` callback. Discovery arms guarded by an `no*` flag start from
+	 * an empty base — callers that flipped the flag off still get the override
+	 * hook, so overrides can inject synthetic entries without triggering a
+	 * filesystem scan they explicitly opted out of.
+	 */
+	async reload(): Promise<void> {
+		const { cwd, agentDir } = this.#state;
+		const options = this.#options;
+
+		let settingsPromise = this.#state.settingsPromise;
+		if (!settingsPromise) {
+			settingsPromise = Settings.init({ cwd, agentDir });
+			this.#state.settingsPromise = settingsPromise;
+		}
+		const settings = await settingsPromise;
+
+		const [extensionsResult, skillsBase, additionalSkills, prompts, additionalPrompts, agentsFiles] =
+			await Promise.all([
+				this.#loadExtensions(settings),
+				options.noSkills
+					? Promise.resolve({ skills: [], warnings: [] })
+					: discoverSkills(cwd, agentDir, settings.getGroup("skills")),
+				this.#loadAdditionalSkills(),
+				options.noPromptTemplates ? Promise.resolve([]) : discoverPromptTemplates(cwd, agentDir),
+				this.#loadAdditionalPromptTemplates(),
+				options.noContextFiles ? Promise.resolve([]) : discoverContextFiles(cwd, agentDir),
+			]);
+
+		this.#extensionsResult = options.extensionsOverride
+			? options.extensionsOverride(extensionsResult)
+			: extensionsResult;
+
+		const skillsBaseResult = {
+			skills: [...skillsBase.skills, ...additionalSkills.skills],
+			diagnostics: [
+				...skillsBase.warnings.map(w => ({
+					type: "warning" as const,
+					message: w.message,
+					path: w.skillPath,
+				})),
+				...additionalSkills.diagnostics,
+			],
+		};
+		const skillsFinal = options.skillsOverride ? options.skillsOverride(skillsBaseResult) : skillsBaseResult;
+		this.#skills = skillsFinal.skills;
+		this.#skillDiagnostics = skillsFinal.diagnostics;
+
+		const promptsBase = {
+			prompts: [...prompts, ...additionalPrompts.prompts],
+			diagnostics: additionalPrompts.diagnostics,
+		};
+		const promptsFinal = options.promptsOverride ? options.promptsOverride(promptsBase) : promptsBase;
+		this.#prompts = promptsFinal.prompts;
+		this.#promptDiagnostics = promptsFinal.diagnostics;
+
+		const themesBase = { themes: [] as Theme[], diagnostics: [] as ResourceDiagnostic[] };
+		const themesFinal = options.themesOverride ? options.themesOverride(themesBase) : themesBase;
+		this.#themes = themesFinal.themes;
+		this.#themeDiagnostics = themesFinal.diagnostics;
+
+		const agentsFilesBase = { agentsFiles };
+		const agentsFilesFinal = options.agentsFilesOverride
+			? options.agentsFilesOverride(agentsFilesBase)
+			: agentsFilesBase;
+		this.#agentsFiles = agentsFilesFinal.agentsFiles;
+
+		const baseSystemPrompt = options.systemPrompt;
+		this.#systemPrompt = options.systemPromptOverride
+			? options.systemPromptOverride(baseSystemPrompt)
+			: baseSystemPrompt;
+
+		const baseAppend = options.appendSystemPrompt ?? [];
+		this.#appendSystemPrompt = options.appendSystemPromptOverride
+			? options.appendSystemPromptOverride(baseAppend)
+			: baseAppend;
+
+		this.#loaded = true;
+	}
+
+	async #loadExtensions(settings: Settings): Promise<LoadExtensionsResult> {
+		const { cwd, noExtensions, additionalExtensionPaths, extensionFactories, eventBus } = this.#state;
+
+		if (noExtensions && additionalExtensionPaths.length === 0 && extensionFactories.length === 0) {
+			return { extensions: [], errors: [], runtime: new ExtensionRuntime() };
+		}
+
+		const bus = eventBus ?? new EventBus();
+		const paths = await discoverSessionExtensionPaths(
+			{
+				disableExtensionDiscovery: noExtensions,
+				additionalExtensionPaths,
+			},
+			cwd,
+			settings,
+		);
+
+		const result = await loadExtensions(paths, cwd, bus);
+		for (let i = 0; i < extensionFactories.length; i++) {
+			const loaded = await loadExtensionFromFactory(
+				extensionFactories[i],
+				cwd,
+				bus,
+				result.runtime,
+				`<inline-loader-${i}>`,
+			);
+			result.extensions.push(loaded);
+		}
+		return result;
+	}
+
+	async #loadAdditionalSkills(): Promise<AdditionalSkillLoadResult> {
+		const skills: Skill[] = [];
+		const diagnostics: ResourceDiagnostic[] = [];
+
+		for (const resourcePath of this.#state.additionalSkillPaths) {
+			const skillDir =
+				path.basename(resourcePath).toLowerCase() === "skill.md" ? path.dirname(resourcePath) : resourcePath;
+			try {
+				const result = await loadSkillsFromDir({
+					dir: skillDir,
+					source: "legacy-resource-loader",
+				});
+				skills.push(...result.skills);
+				diagnostics.push(
+					...result.warnings.map(w => ({
+						type: "warning" as const,
+						message: w.message,
+						path: w.skillPath,
+					})),
+				);
+			} catch (err) {
+				diagnostics.push({
+					type: "warning",
+					message: `Failed to load additional skill path: ${err instanceof Error ? err.message : String(err)}`,
+					path: resourcePath,
+				});
+			}
+		}
+
+		return { skills, diagnostics };
+	}
+
+	async #loadAdditionalPromptTemplates(): Promise<AdditionalPromptLoadResult> {
+		const prompts: PromptTemplate[] = [];
+		const diagnostics: ResourceDiagnostic[] = [];
+
+		for (const resourcePath of this.#state.additionalPromptTemplatePaths) {
+			const files: string[] = [];
+			try {
+				const stat = await fs.stat(resourcePath);
+				if (stat.isDirectory()) {
+					const glob = new Bun.Glob("**/*.md");
+					for await (const entry of glob.scan({ cwd: resourcePath, absolute: false, onlyFiles: true })) {
+						files.push(path.join(resourcePath, entry));
+					}
+					files.sort();
+				} else if (resourcePath.toLowerCase().endsWith(".md")) {
+					files.push(resourcePath);
+				} else {
+					diagnostics.push({
+						type: "warning",
+						message: "Additional prompt template path is neither a directory nor a Markdown file",
+						path: resourcePath,
+					});
+				}
+			} catch (err) {
+				diagnostics.push({
+					type: "warning",
+					message: `Failed to inspect additional prompt template path: ${err instanceof Error ? err.message : String(err)}`,
+					path: resourcePath,
+				});
+				continue;
+			}
+
+			for (const filePath of files) {
+				try {
+					const raw = await Bun.file(filePath).text();
+					const { frontmatter, body } = parseFrontmatter(raw);
+					const rawDescription = frontmatter.description;
+					let description = typeof rawDescription === "string" ? rawDescription : "";
+					if (!description) {
+						const firstLine = body.split("\n").find(line => line.trim());
+						if (firstLine) {
+							description = firstLine.slice(0, 60);
+							if (firstLine.length > 60) {
+								description += "...";
+							}
+						}
+					}
+
+					const source = "(legacy-resource-loader)";
+					prompts.push({
+						name: path.basename(filePath, path.extname(filePath)),
+						description: description ? `${description} ${source}` : source,
+						content: body,
+						source,
+					});
+				} catch (err) {
+					diagnostics.push({
+						type: "warning",
+						message: `Failed to load additional prompt template: ${err instanceof Error ? err.message : String(err)}`,
+						path: filePath,
+					});
+				}
+			}
+		}
+
+		return { prompts, diagnostics };
+	}
+
+	/** Test seam: whether `reload()` has completed at least once. */
+	get loaded(): boolean {
+		return this.#loaded;
+	}
+
+	/** @internal — used by the shim's createAgentSession to translate options. */
+	__getResolverState(): {
+		cwd: string;
+		agentDir: string;
+		settingsPromise?: Promise<Settings>;
+		eventBus?: EventBus;
+		extensionsResult: LoadExtensionsResult;
+		skills: Skill[];
+		prompts: PromptTemplate[];
+		agentsFiles: AgentsFile[];
+		systemPrompt: string | undefined;
+		appendSystemPrompt: string[];
+		extensionFactories: ExtensionFactory[];
+	} {
+		return {
+			cwd: this.#state.cwd,
+			agentDir: this.#state.agentDir,
+			settingsPromise: this.#state.settingsPromise,
+			eventBus: this.#state.eventBus,
+			extensionsResult: this.#extensionsResult,
+			skills: this.#skills,
+			prompts: this.#prompts,
+			agentsFiles: this.#agentsFiles,
+			systemPrompt: this.#systemPrompt,
+			appendSystemPrompt: this.#appendSystemPrompt,
+			extensionFactories: this.#state.extensionFactories,
+		};
+	}
+}
+
+/**
+ * Legacy pi extensions call `createAgentSession({ resourceLoader })`. OMP's
+ * native option surface has no such field — extension / skill / prompt /
+ * context-file discovery are configured directly on the session options — so
+ * an untranslated call would silently ignore the loader (including its
+ * `noExtensions`/`noSkills` opt-outs), re-run OMP's own discovery, and
+ * happily re-load the calling extension into the subagent. That's exactly
+ * the recursion the caller passed the loader to prevent.
+ *
+ * Translate the loader's captured state into OMP's option fields, then
+ * delegate to the underlying SDK. Explicit fields on `options` override the
+ * loader (matches upstream pi semantics — a caller can partially override a
+ * shared loader).
+ *
+ * `resourceLoader` is not part of {@link CreateAgentSessionOptions}, so it's
+ * accepted through a widened alias and stripped before the underlying call.
+ */
+export type LegacyPiCreateAgentSessionOptions = CreateAgentSessionOptions & {
+	resourceLoader?: ResourceLoader;
+};
+
+export async function createAgentSession(
+	options: LegacyPiCreateAgentSessionOptions = {},
+): Promise<CreateAgentSessionResult> {
+	const loader = options.resourceLoader;
+	if (!loader) {
+		return ompCreateAgentSession(options);
+	}
+
+	if (loader instanceof DefaultResourceLoader && !loader.loaded) {
+		await loader.reload();
+	}
+
+	const state =
+		loader instanceof DefaultResourceLoader
+			? loader.__getResolverState()
+			: {
+					cwd: options.cwd ?? getProjectDir(),
+					agentDir: options.agentDir ?? getAgentDir(),
+					settingsPromise: undefined,
+					eventBus: undefined,
+					extensionsResult: loader.getExtensions(),
+					skills: loader.getSkills().skills,
+					prompts: loader.getPrompts().prompts,
+					agentsFiles: loader.getAgentsFiles().agentsFiles,
+					systemPrompt: loader.getSystemPrompt(),
+					appendSystemPrompt: loader.getAppendSystemPrompt(),
+					extensionFactories: [] as ExtensionFactory[],
+				};
+
+	const { resourceLoader: _, ...rest } = options;
+	const forwarded: CreateAgentSessionOptions = {
+		...rest,
+		cwd: rest.cwd ?? state.cwd,
+		agentDir: rest.agentDir ?? state.agentDir,
+	};
+
+	if (rest.eventBus === undefined && state.eventBus !== undefined) {
+		forwarded.eventBus = state.eventBus;
+	}
+	if (rest.settings === undefined && rest.settingsManager === undefined && state.settingsPromise !== undefined) {
+		forwarded.settingsManager = state.settingsPromise;
+	}
+
+	// Route the loader's already-loaded extension result through the SDK's
+	// `preloadedExtensions` seam. Skipping this branch would let
+	// `createAgentSession` re-run its own discovery and undo the caller's
+	// `noExtensions: true`.
+	if (rest.preloadedExtensions === undefined && rest.preloadedExtensionPaths === undefined) {
+		forwarded.preloadedExtensions = state.extensionsResult;
+	}
+
+	if (rest.skills === undefined) {
+		forwarded.skills = state.skills;
+	}
+	if (rest.promptTemplates === undefined) {
+		forwarded.promptTemplates = state.prompts;
+	}
+	if (rest.contextFiles === undefined) {
+		forwarded.contextFiles = state.agentsFiles;
+	}
+
+	if (rest.systemPrompt === undefined && state.systemPrompt !== undefined) {
+		forwarded.systemPrompt = state.systemPrompt;
+	}
+	if (rest.appendSystemPrompt === undefined && state.appendSystemPrompt.length > 0) {
+		forwarded.appendSystemPrompt = state.appendSystemPrompt.join("\n\n");
+	}
+
+	return ompCreateAgentSession(forwarded);
+}
 
 export * from "../index";
 export { formatBytes as formatSize } from "../tools/render-utils";

--- a/packages/coding-agent/test/extensibility/legacy-pi-default-resource-loader.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-default-resource-loader.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	DefaultResourceLoader,
+	createAgentSession as legacyCreateAgentSession,
+} from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+import type { Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+// Issue #4567: every published version of pi-schedule-prompt (and every pi
+// extension spawning subagents) imports `DefaultResourceLoader` at module
+// scope from `@earendil-works/pi-coding-agent` and hands it to
+// `createAgentSession({ resourceLoader })`. Before the fix the shim never
+// exported the class, so those extensions failed to parse; even once exported,
+// the shim's `createAgentSession` MUST translate the loader's captured state
+// into the SDK's native option surface — otherwise `noExtensions: true` would
+// be silently ignored, re-running discovery inside the subagent and reloading
+// the very extension the caller passed the loader to prevent recursion for.
+// These tests pin both contracts through the public package specifier.
+
+const tempRoots: string[] = [];
+
+afterAll(async () => {
+	for (const dir of tempRoots) {
+		await removeWithRetries(dir);
+	}
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+async function mkTempCwd(prefix: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempRoots.push(dir);
+	return dir;
+}
+
+describe("DefaultResourceLoader.reload() (issue #4567)", () => {
+	it("populates the discovery snapshot honoring no* flags and applying every override", async () => {
+		const tmp = await mkTempCwd("omp-legacy-default-resource-loader-reload-");
+		const injected: Skill = {
+			name: "issue-4567-synthesized",
+			description: "injected via skillsOverride",
+			filePath: path.join(tmp, "synthesized.md"),
+			baseDir: tmp,
+			source: "test-injection",
+		};
+
+		const loader = new DefaultResourceLoader({
+			cwd: tmp,
+			agentDir: tmp,
+			// Isolated in-memory settings sidestep the global Settings.init()
+			// singleton so this test cannot leak state into siblings.
+			settingsManager: Settings.isolated(),
+			noExtensions: true,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+			noContextFiles: true,
+			skillsOverride: base => ({
+				skills: [...base.skills, injected],
+				diagnostics: base.diagnostics,
+			}),
+		});
+
+		// The `loaded` getter starts false; only `reload()` flips it. Guards
+		// against a future regression where the constructor pre-marks the
+		// loader (which would let `createAgentSession` skip the initial reload
+		// and hand an empty snapshot to the SDK).
+		expect(loader.loaded).toBe(false);
+
+		await loader.reload();
+
+		expect(loader.loaded).toBe(true);
+
+		// `noExtensions: true` with no factories + no additional paths means
+		// the discovery arm returns an empty result — proves the loader
+		// actually honors the opt-out instead of scanning cwd.
+		expect(loader.getExtensions().extensions).toEqual([]);
+
+		// The skills override callback ran on the (empty) base result and its
+		// injected entry survived into the stored snapshot. Proves the
+		// override hook is applied even when the discovery arm is disabled,
+		// which is the contract pi extensions rely on to inject synthetic
+		// entries without touching the filesystem.
+		const skillNames = loader.getSkills().skills.map(s => s.name);
+		expect(skillNames).toContain(injected.name);
+
+		// Every other disabled arm stays empty — no override was configured
+		// for them, so the base empty result is what the getters must report.
+		expect(loader.getPrompts().prompts).toEqual([]);
+		expect(loader.getThemes().themes).toEqual([]);
+		expect(loader.getAgentsFiles().agentsFiles).toEqual([]);
+	});
+	it("loads explicit additional skills and prompt templates before override callbacks when discovery is disabled", async () => {
+		const tmp = await mkTempCwd("omp-legacy-default-resource-loader-additional-paths-");
+		const skillName = "issue-4567-explicit-skill";
+		const skillDescription = "Loaded from an explicit additionalSkillPaths directory";
+		const skillRoot = path.join(tmp, "extra-skills");
+		const skillDir = path.join(skillRoot, "extra-skill");
+		const skillFile = path.join(skillDir, "SKILL.md");
+		const promptDir = path.join(tmp, "extra-prompts");
+		const promptName = "issue-4567-explicit-prompt";
+		const promptDescription = "Loaded from an explicit additionalPromptTemplatePaths directory";
+		const promptBody = "Use this explicit prompt template body.";
+		const promptFile = path.join(promptDir, `${promptName}.md`);
+		let skillsOverrideSawExplicit = false;
+		let promptsOverrideSawExplicit = false;
+
+		await fs.mkdir(skillDir, { recursive: true });
+		await fs.writeFile(
+			skillFile,
+			`---\nname: ${skillName}\ndescription: ${skillDescription}\n---\n\n# Explicit Skill\n\nInvoke this explicit skill body.\n`,
+			"utf8",
+		);
+		await fs.mkdir(promptDir, { recursive: true });
+		await fs.writeFile(promptFile, `---\ndescription: ${promptDescription}\n---\n\n${promptBody}\n`, "utf8");
+
+		const loader = new DefaultResourceLoader({
+			cwd: tmp,
+			agentDir: tmp,
+			settingsManager: Settings.isolated(),
+			noExtensions: true,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+			noContextFiles: true,
+			additionalSkillPaths: [skillRoot],
+			additionalPromptTemplatePaths: [promptDir],
+			skillsOverride: base => {
+				skillsOverrideSawExplicit = base.skills.some(
+					skill =>
+						skill.name === skillName && skill.description === skillDescription && skill.filePath === skillFile,
+				);
+				return base;
+			},
+			promptsOverride: base => {
+				promptsOverrideSawExplicit = base.prompts.some(
+					prompt =>
+						prompt.name === promptName &&
+						prompt.description.includes(promptDescription) &&
+						prompt.content.includes(promptBody),
+				);
+				return base;
+			},
+		});
+
+		await loader.reload();
+
+		expect(loader.getSkills().skills.map(skill => skill.name)).toContain(skillName);
+		expect(loader.getPrompts().prompts.map(prompt => prompt.name)).toContain(promptName);
+		expect(skillsOverrideSawExplicit).toBe(true);
+		expect(promptsOverrideSawExplicit).toBe(true);
+	});
+});
+
+describe("createAgentSession({ resourceLoader }) (issue #4567)", () => {
+	it("translates a DefaultResourceLoader into the SDK's option surface without silently discarding it", async () => {
+		const tmp = await mkTempCwd("omp-legacy-default-resource-loader-session-");
+
+		let captured: CreateAgentSessionOptions | undefined;
+		const spy = vi
+			.spyOn(sdkModule, "createAgentSession")
+			.mockImplementation(async (options?: CreateAgentSessionOptions) => {
+				captured = options;
+				// Only the caller's `await` needs to resolve; the shim doesn't
+				// touch the returned session, so the shape is intentionally
+				// minimal and cast through `unknown`.
+				return {
+					session: {} as never,
+					extensionsResult: { extensions: [], errors: [], runtime: undefined as never },
+				} as unknown as CreateAgentSessionResult;
+			});
+
+		const loader = new DefaultResourceLoader({
+			cwd: tmp,
+			agentDir: tmp,
+			settingsManager: Settings.isolated(),
+			noExtensions: true,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+			noContextFiles: true,
+		});
+
+		// Fresh, unloaded loader — the shim MUST reload it before forwarding,
+		// otherwise the SDK would receive an empty extensionsResult only by
+		// accident of the constructor's default field, and any real discovery
+		// arm not gated by an `no*` flag would silently escape.
+		expect(loader.loaded).toBe(false);
+
+		await legacyCreateAgentSession({ resourceLoader: loader });
+
+		// The shim invoked the SDK exactly once — proves it did not fall back
+		// to a "resourceLoader unrecognized, drop it" path.
+		expect(spy).toHaveBeenCalledTimes(1);
+		if (!captured) {
+			throw new Error("Expected shim to forward session options to the SDK");
+		}
+		const forwarded = captured;
+
+		// `resourceLoader` is not a field on `CreateAgentSessionOptions`; the
+		// shim MUST strip it before delegating. Leaking it through would (a)
+		// confuse anyone reading the SDK call site and (b) prove the shim is
+		// not actually translating the option.
+		expect("resourceLoader" in forwarded ? forwarded.resourceLoader : undefined).toBeUndefined();
+
+		// The reload's already-loaded extension snapshot is routed through
+		// the SDK's `preloadedExtensions` seam. Skipping this branch is
+		// exactly the bug the shim exists to prevent — the SDK would re-run
+		// its own discovery inside the subagent and re-load the caller.
+		expect(forwarded.preloadedExtensions).toBeDefined();
+		expect(forwarded.preloadedExtensions?.extensions).toEqual([]);
+
+		// The loader's captured `noSkills` / `noPromptTemplates` /
+		// `noContextFiles` translate into empty arrays on the SDK options.
+		// A `[]` here is meaningful: it overrides the SDK's default
+		// (discover-from-filesystem) behavior, whereas `undefined` would let
+		// the SDK re-scan and negate the caller's opt-out.
+		expect(forwarded.skills).toEqual([]);
+		expect(forwarded.promptTemplates).toEqual([]);
+		expect(forwarded.contextFiles).toEqual([]);
+
+		// `cwd`/`agentDir` fall through from the loader when the caller did
+		// not override them — proves the shim doesn't accidentally re-derive
+		// them from `getProjectDir()` inside the SDK, which would resolve to
+		// the running test's cwd rather than the temp dir the loader owns.
+		expect(forwarded.cwd).toBe(tmp);
+		expect(forwarded.agentDir).toBe(tmp);
+	});
+});


### PR DESCRIPTION
## Repro
`pi-schedule-prompt@0.4.1` imports `DefaultResourceLoader` from `@earendil-works/pi-coding-agent` at module scope (`src/subagent.ts`), and OMP rewrites that package root to `packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts`. The shim and the barrel it re-exported had no `DefaultResourceLoader` binding (`grep -c DefaultResourceLoader packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts packages/coding-agent/src/index.ts` returned `0` for both), so Bun rejected the extension with `Export named 'DefaultResourceLoader' not found in module .../legacy-pi-coding-agent-shim.ts` before any extension tools could register.

## Cause
`packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts` covered legacy tool factories, `SettingsManager`, TypeBox, and the normal coding-agent barrel, but it did not cover pi's `ResourceLoader` abstraction. Legacy extensions call `createAgentSession({ resourceLoader })` to avoid recursively loading extensions/skills in subagents; OMP's SDK configures those same resources directly on `CreateAgentSessionOptions`, so an unimplemented loader was both a missing export and a silent footgun if ignored.

## Fix
- Added a `DefaultResourceLoader` compatibility class to `legacy-pi-coding-agent-shim.ts` that captures pi-style loader options, runs OMP's discovery arms on `reload()`, applies the override callbacks, and exposes pi-compatible getters.
- Added a shim-local `createAgentSession` wrapper that strips `resourceLoader`, reloads the loader if needed, and translates its snapshot into OMP-native options (`preloadedExtensions`, `skills`, `promptTemplates`, `contextFiles`, `settingsManager`, `eventBus`, `systemPrompt`) before delegating to the SDK.
- Added `test/extensibility/legacy-pi-default-resource-loader.test.ts` covering disabled discovery, override execution, and the `createAgentSession({ resourceLoader })` translation path.
- Added an `[Unreleased]` changelog entry for the coding-agent package.

## Verification
`cd packages/coding-agent && bun check` passed. `cd packages/coding-agent && bun test test/extensibility/legacy-pi-default-resource-loader.test.ts` passed with 2 tests / 18 assertions. Fixes #4567