### PR TITLE
fix(session): drop empty session file on close when no messages and no draft

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed empty session `.jsonl` files accumulating in `~/.omp/agent/sessions/<cwd>/` after a draft-then-clear exit cycle. `SessionManager.saveDraft(text)` materializes the session file so the draft sidecar has a parent; a subsequent `saveDraft("")` unlinked the sidecar but left the metadata-only JSONL behind (title slot + session header + any `model_change`/mode/thinking entries, ~500–750 B), and `#shouldHaveSessionFile()` could no longer prune it once `#fileIsCurrent`/`#forceFileCreation` were latched. `SessionManager.close()` now drops the on-disk session (and its artifacts directory) when it has no real user/assistant messages and no saved draft sidecar to reattach to, while keeping real conversations, drafts still pending for `--resume`, and never-materialized sessions untouched ([#4571](https://github.com/can1357/oh-my-pi/issues/4571)).
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed empty session `.jsonl` files accumulating in `~/.omp/agent/sessions/<cwd>/` after a draft-then-clear exit cycle. `SessionManager.saveDraft(text)` materializes the session file so the draft sidecar has a parent; a subsequent `saveDraft("")` unlinked the sidecar but left the metadata-only JSONL behind (title slot + session header + any `model_change`/mode/thinking entries, ~500–750 B), and `#shouldHaveSessionFile()` could no longer prune it once `#fileIsCurrent`/`#forceFileCreation` were latched. `SessionManager.close()` now drops the on-disk session (and its artifacts directory) when it has no real user/assistant messages and no saved draft sidecar to reattach to, while keeping real conversations, drafts still pending for `--resume`, and never-materialized sessions untouched ([#4571](https://github.com/can1357/oh-my-pi/issues/4571)).
+- Fixed empty session `.jsonl` files accumulating in `~/.omp/agent/sessions/<cwd>/` after a draft-then-clear exit cycle. `SessionManager.saveDraft(text)` materializes the session file so the draft sidecar has a parent; a subsequent `saveDraft("")` unlinked the sidecar but left the metadata-only JSONL behind (title slot + session header + startup selector entries, ~500–750 B), and `#shouldHaveSessionFile()` could no longer prune it once `#fileIsCurrent`/`#forceFileCreation` were latched. `SessionManager.close()` now drops only draft-owned metadata-only sessions with no saved draft sidecar to reattach to, while keeping real conversations, meaningful non-message entries such as handoff custom messages, explicit `ensureOnDisk()` sessions, drafts still pending for `--resume`, and never-materialized sessions untouched ([#4571](https://github.com/can1357/oh-my-pi/issues/4571)).
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1134,6 +1134,37 @@ export class SessionManager {
 		if (this.#diskFailure) throw this.#diskFailure;
 	}
 
+	/**
+	 * If the session never carried a real user/assistant message and has no
+	 * saved draft (nothing for `--resume` to reattach to), drop the on-disk
+	 * file and its artifacts directory. Guards against zombie metadata-only
+	 * sessions from a draft-then-clear-then-close cycle: `saveDraft(text)`
+	 * calls `ensureOnDisk()` to materialize the JSONL so the sidecar has a
+	 * parent, and a subsequent `saveDraft("")` only unlinks the sidecar —
+	 * the load-path flips `#fileIsCurrent`/`#forceFileCreation` to `true`,
+	 * so `#shouldHaveSessionFile()` can no longer prune the file itself.
+	 */
+	async #dropIfEmptyAndNoDraft(): Promise<void> {
+		const sessionFile = this.#sessionFile;
+		if (!sessionFile || !this.#storage.existsSync(sessionFile)) return;
+		const hasRealMessages = this.#entries.some(
+			e => e.type === "message" && (e.message.role === "user" || e.message.role === "assistant"),
+		);
+		if (hasRealMessages) return;
+		const draftPath = this.#draftPath();
+		if (draftPath && this.#storage.existsSync(draftPath)) return;
+		try {
+			await this.#storage.deleteSessionWithArtifacts(sessionFile);
+			this.#fileIsCurrent = false;
+			this.#forceFileCreation = false;
+			this.#hasTitleSlot = false;
+		} catch (err) {
+			if (!isEnoent(err)) {
+				logger.warn("Failed to drop empty session on close", { sessionFile, error: String(err) });
+			}
+		}
+	}
+
 	/** Flush, then close the append writer. */
 	async close(): Promise<void> {
 		if (!this.#persist) return;
@@ -1143,6 +1174,7 @@ export class SessionManager {
 			if (hadWriter || (this.#sessionFile && this.#storage.existsSync(this.#sessionFile)))
 				this.#fileIsCurrent = true;
 		});
+		await this.#dropIfEmptyAndNoDraft();
 		// Wait for any queued backing writes (IndexedSessionStorage per-path
 		// tail) to become durable so a graceful shutdown does not exit while
 		// a fire-and-forget publish is still on the wire.

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -146,10 +146,18 @@ function isAssistantEntry(entry: SessionEntry): boolean {
 }
 
 function isDraftOnlyMetadataEntry(entry: SessionEntry): boolean {
+	// Startup-recorded selector state that does not survive as user intent
+	// once the draft is cleared. `mode_change` covers the `plan.defaultOnStartup`
+	// path (interactive-mode.ts enters plan mode before draft restoration) and
+	// `/plan` toggles that leave the session otherwise empty; entries carrying
+	// real conversation state — messages, compactions, branch summaries,
+	// custom/custom_message, session_init, labels, title/tool selection — never
+	// reach this branch and always keep the file resumable.
 	switch (entry.type) {
 		case "model_change":
 		case "thinking_level_change":
 		case "service_tier_change":
+		case "mode_change":
 			return true;
 		default:
 			return false;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -145,6 +145,17 @@ function isAssistantEntry(entry: SessionEntry): boolean {
 	return entry.type === "message" && entry.message.role === "assistant";
 }
 
+function isDraftOnlyMetadataEntry(entry: SessionEntry): boolean {
+	switch (entry.type) {
+		case "model_change":
+		case "thinking_level_change":
+		case "service_tier_change":
+			return true;
+		default:
+			return false;
+	}
+}
+
 function orderedByTimestamp(a: SessionTreeNode, b: SessionTreeNode): number {
 	return new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime();
 }
@@ -317,6 +328,7 @@ interface SessionManagerStateSnapshot {
 	hasTitleSlot: boolean;
 	onDisk: boolean;
 	needsRewrite: boolean;
+	draftOnlySessionCleanupArmed: boolean;
 	header: SessionHeader;
 	entries: SessionEntry[];
 }
@@ -363,6 +375,12 @@ export class SessionManager {
 	#rewriteRequired = false;
 	/** Lazy gate crossed (ensureOnDisk / loaded file): every entry must persist from now on. */
 	#forceFileCreation = false;
+	/**
+	 * Armed only when this manager observed a draft sidecar lifecycle that
+	 * materialized an otherwise metadata-only session file. Explicit
+	 * ensureOnDisk() callers (ACP session/new, handoff) must survive close().
+	 */
+	#draftOnlySessionCleanupArmed = false;
 
 	/**
 	 * Collab replication tap: invoked for every appended entry with the
@@ -748,6 +766,7 @@ export class SessionManager {
 		this.#fileIsCurrent = false;
 		this.#rewriteRequired = false;
 		this.#forceFileCreation = false;
+		this.#draftOnlySessionCleanupArmed = false;
 		this.#turnBudgetTotal = null;
 		this.#turnBudgetHard = false;
 		this.#turnOutputBaseline = 0;
@@ -856,6 +875,7 @@ export class SessionManager {
 			sessionFile: this.#sessionFile,
 			onDisk: this.#fileIsCurrent,
 			needsRewrite: this.#rewriteRequired,
+			draftOnlySessionCleanupArmed: this.#draftOnlySessionCleanupArmed,
 			// Snapshot header + entries by reference: switch/reload replaces the
 			// active header/array wholesale, so rollback needs no deep clone.
 			header: this.#header,
@@ -874,6 +894,7 @@ export class SessionManager {
 		this.#fileIsCurrent = snapshot.onDisk;
 		this.#rewriteRequired = snapshot.needsRewrite;
 		this.#forceFileCreation = snapshot.onDisk;
+		this.#draftOnlySessionCleanupArmed = snapshot.draftOnlySessionCleanupArmed;
 		this.#applyEntries(snapshot.header, [...snapshot.entries]);
 		this.#sessionName = snapshot.sessionName;
 		this.#titleSource = snapshot.titleSource;
@@ -890,6 +911,7 @@ export class SessionManager {
 	async setSessionFile(sessionFile: string): Promise<void> {
 		await this.#drainAndCloseWriter();
 		this.#clearDiskError();
+		this.#draftOnlySessionCleanupArmed = false;
 
 		const resolvedSessionFile = path.resolve(sessionFile);
 		this.#sessionFile = resolvedSessionFile;
@@ -985,6 +1007,7 @@ export class SessionManager {
 		this.#fileIsCurrent = false;
 		this.#rewriteRequired = false;
 		this.#forceFileCreation = true;
+		this.#draftOnlySessionCleanupArmed = false;
 		this.#artifactManager = null;
 		this.#artifactManagerSessionFile = null;
 		this.#rememberBreadcrumb(this.#cwd, this.#sessionFile);
@@ -1135,22 +1158,15 @@ export class SessionManager {
 	}
 
 	/**
-	 * If the session never carried a real user/assistant message and has no
-	 * saved draft (nothing for `--resume` to reattach to), drop the on-disk
-	 * file and its artifacts directory. Guards against zombie metadata-only
-	 * sessions from a draft-then-clear-then-close cycle: `saveDraft(text)`
-	 * calls `ensureOnDisk()` to materialize the JSONL so the sidecar has a
-	 * parent, and a subsequent `saveDraft("")` only unlinks the sidecar —
-	 * the load-path flips `#fileIsCurrent`/`#forceFileCreation` to `true`,
-	 * so `#shouldHaveSessionFile()` can no longer prune the file itself.
+	 * Drop only session files that this manager saw materialized for a draft and
+	 * that still contain no durable conversation or extension state. Explicit
+	 * ensureOnDisk() records (ACP session/new, handoff) stay resumable.
 	 */
 	async #dropIfEmptyAndNoDraft(): Promise<void> {
+		if (!this.#draftOnlySessionCleanupArmed) return;
 		const sessionFile = this.#sessionFile;
 		if (!sessionFile || !this.#storage.existsSync(sessionFile)) return;
-		const hasRealMessages = this.#entries.some(
-			e => e.type === "message" && (e.message.role === "user" || e.message.role === "assistant"),
-		);
-		if (hasRealMessages) return;
+		if (!this.#entries.every(isDraftOnlyMetadataEntry)) return;
 		const draftPath = this.#draftPath();
 		if (draftPath && this.#storage.existsSync(draftPath)) return;
 		try {
@@ -1158,6 +1174,7 @@ export class SessionManager {
 			this.#fileIsCurrent = false;
 			this.#forceFileCreation = false;
 			this.#hasTitleSlot = false;
+			this.#draftOnlySessionCleanupArmed = false;
 		} catch (err) {
 			if (!isEnoent(err)) {
 				logger.warn("Failed to drop empty session on close", { sessionFile, error: String(err) });
@@ -1267,8 +1284,14 @@ export class SessionManager {
 			return;
 		}
 
+		const sessionFile = this.#sessionFile;
+		const draftWillMaterializeMetadataOnlyFile =
+			sessionFile !== undefined &&
+			!this.#storage.existsSync(sessionFile) &&
+			this.#entries.every(isDraftOnlyMetadataEntry);
 		// Force the header onto disk so resume can find the file this draft attaches to.
 		await this.ensureOnDisk();
+		if (draftWillMaterializeMetadataOnlyFile) this.#draftOnlySessionCleanupArmed = true;
 		await this.#storage.writeText(draftPath, text);
 	}
 
@@ -1289,6 +1312,7 @@ export class SessionManager {
 		} catch (err) {
 			if (!isEnoent(err)) throw err;
 		}
+		if (this.#entries.every(isDraftOnlyMetadataEntry)) this.#draftOnlySessionCleanupArmed = true;
 
 		return draft;
 	}

--- a/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
+++ b/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { isEnoent, TempDir } from "@oh-my-pi/pi-utils";
+
+async function fileExists(p: string): Promise<boolean> {
+	try {
+		await Bun.file(p).stat();
+		return true;
+	} catch (err) {
+		if (isEnoent(err)) return false;
+		throw err;
+	}
+}
+
+describe("SessionManager close() drops empty metadata-only sessions", () => {
+	// Repro of issue #4571: saveDraft(text) materializes the JSONL so the
+	// draft sidecar has a parent. A subsequent saveDraft("") only unlinks
+	// the sidecar — before the fix, close() left the metadata-only file
+	// behind and every ctrl+D cycle leaked another 500–750B zombie.
+	it("drops the session file when close() runs with no user/assistant messages and no draft", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-drop-empty-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+		session.appendModelChange("litellm/anthropic--claude-4.7-opus", "default");
+
+		await session.saveDraft("some in-progress text"); // materializes JSONL
+		await session.saveDraft(""); // sidecar unlinked; before fix, file survives
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+
+		await session.close();
+
+		expect(await fileExists(sessionFile)).toBe(false);
+	});
+
+	// A draft still on disk at close time is the whole reason the session
+	// file was materialized in the first place (`--resume` needs to find
+	// this session's file to reattach the draft). Never drop it.
+	it("keeps the session file when a draft sidecar is still present at close", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-keep-draft-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+		await session.saveDraft("queued for next time");
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+		const draftPath = path.join(session.getArtifactsDir()!, "draft.txt");
+		expect(await fileExists(draftPath)).toBe(true);
+
+		await session.close();
+
+		expect(await fileExists(sessionFile)).toBe(true);
+		expect(await fileExists(draftPath)).toBe(true);
+	});
+
+	// Real conversations must survive close() unconditionally.
+	it("keeps the session file when it contains a real user message", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-keep-user-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		await session.saveDraft("draft that will be cleared");
+		await session.saveDraft("");
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+
+		await session.close();
+
+		expect(await fileExists(sessionFile)).toBe(true);
+	});
+
+	// Never-materialized sessions (no draft ever saved, no assistant reply)
+	// must not be summoned into existence by close() itself.
+	it("is a no-op when the session file was never materialized", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-never-materialized-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file path");
+		expect(await fileExists(sessionFile)).toBe(false);
+
+		await session.close();
+
+		expect(await fileExists(sessionFile)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
+++ b/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
@@ -35,6 +35,26 @@ describe("SessionManager close() drops empty metadata-only sessions", () => {
 		expect(await fileExists(sessionFile)).toBe(false);
 	});
 
+	it("drops a resumed draft-only session after consumeDraft removes the sidecar", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-drop-resumed-draft-");
+		const firstRun = SessionManager.create(tempDir.path(), tempDir.path());
+		firstRun.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+		await firstRun.saveDraft("resume me");
+
+		const sessionFile = firstRun.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+		await firstRun.close();
+		expect(await fileExists(sessionFile)).toBe(true);
+
+		const resumed = SessionManager.create(tempDir.path(), tempDir.path());
+		await resumed.setSessionFile(sessionFile);
+		expect(await resumed.consumeDraft()).toBe("resume me");
+		await resumed.saveDraft("");
+		await resumed.close();
+
+		expect(await fileExists(sessionFile)).toBe(false);
+	});
+
 	// A draft still on disk at close time is the whole reason the session
 	// file was materialized in the first place (`--resume` needs to find
 	// this session's file to reattach the draft). Never drop it.
@@ -63,6 +83,33 @@ describe("SessionManager close() drops empty metadata-only sessions", () => {
 		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
 		await session.saveDraft("draft that will be cleared");
 		await session.saveDraft("");
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+
+		await session.close();
+
+		expect(await fileExists(sessionFile)).toBe(true);
+	});
+
+	it("keeps an explicitly ensured empty session discoverable after close", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-keep-explicit-empty-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		await session.ensureOnDisk();
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+
+		await session.close();
+
+		expect(await fileExists(sessionFile)).toBe(true);
+	});
+
+	it("keeps a handoff custom message even before the next user turn", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-keep-handoff-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendCustomMessageEntry("handoff", "handoff context", true, undefined, "agent");
+		await session.ensureOnDisk();
 
 		const sessionFile = session.getSessionFile();
 		if (!sessionFile) throw new Error("Expected persistent session file");

--- a/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
+++ b/packages/coding-agent/test/session-manager/close-drop-empty.test.ts
@@ -35,6 +35,27 @@ describe("SessionManager close() drops empty metadata-only sessions", () => {
 		expect(await fileExists(sessionFile)).toBe(false);
 	});
 
+	// `plan.defaultOnStartup` records a `mode_change` before the composer
+	// restores its draft. Clearing that draft and closing must still drop the
+	// otherwise metadata-only file — mode changes are startup selector state,
+	// not durable conversation.
+	it("drops the session file when only mode/model changes precede a cleared draft", async () => {
+		using tempDir = TempDir.createSync("@pi-session-close-drop-plan-startup-");
+		const session = SessionManager.create(tempDir.path(), tempDir.path());
+		session.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
+		session.appendModeChange("plan", { planFilePath: "local://PLAN.md" });
+
+		await session.saveDraft("plan-mode draft");
+		await session.saveDraft("");
+
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persistent session file");
+
+		await session.close();
+
+		expect(await fileExists(sessionFile)).toBe(false);
+	});
+
 	it("drops a resumed draft-only session after consumeDraft removes the sidecar", async () => {
 		using tempDir = TempDir.createSync("@pi-session-close-drop-resumed-draft-");
 		const firstRun = SessionManager.create(tempDir.path(), tempDir.path());


### PR DESCRIPTION
## Repro

`SessionManager.saveDraft(text)` calls `ensureOnDisk()` so the draft sidecar has a parent JSONL. A follow-up `saveDraft("")` only unlinks the sidecar — the session file is never revisited. Every `omp` launch that drafts text, exits, resumes, backspaces the draft away, and exits again leaks a ~500–750 B metadata-only file into `~/.omp/agent/sessions/<cwd>/` (title slot + session header + a handful of `model_change` / `mode_change` / `thinking_level_change` entries; no user/assistant messages).

Minimal in-process repro:

```ts
const mgr = SessionManager.create(cwd, dir);
mgr.appendModelChange("hai-proxy/anthropic--claude-4.6-opus");
await mgr.saveDraft("some in-progress text"); // materializes JSONL
await mgr.saveDraft("");                       // sidecar unlinked; JSONL survived
await mgr.close();
fs.existsSync(mgr.getSessionFile()!);          // was true; expected false
```

## Cause

- `SessionManager.saveDraft(text)` (`session-manager.ts:1225-1241`) calls `ensureOnDisk()` when `text.length > 0` so the draft sidecar has a parent to attach to.
- The lazy-write gate `#shouldHaveSessionFile()` (`session-manager.ts:521-523`) prunes never-materialized empty sessions, but once `ensureOnDisk()` runs — or the load path resumes an existing file (`setSessionFile`, `session-manager.ts:928-933`) — both `#fileIsCurrent` and `#forceFileCreation` latch to `true` and the gate can never revoke the file.
- `SessionManager.close()` (`session-manager.ts:1137-1151`) drained the writer but never revisited the on-disk file, so the metadata-only JSONL survived every draft-then-clear cycle.
- The codebase already knew this shape for the `/move` flow via `cleanupEmptyMoveSession` (`session-manager.ts:1978-1995`) but never generalized it.

## Fix

- Added `SessionManager.#dropIfEmptyAndNoDraft()`: after the writer closes, if the session file exists, holds no `message` entries with `role in {user, assistant}`, and no `draft.txt` sidecar is present, delete it via `#storage.deleteSessionWithArtifacts` and reset `#fileIsCurrent` / `#forceFileCreation` / `#hasTitleSlot`. ENOENT is swallowed; other errors are logged at `warn`, never thrown, so shutdown stays clean.
- Wired it into `SessionManager.close()` between the writer drain and the storage-level `drain()`, so the deletion is serialized with pending draft unlinks and any queued backing writes on `IndexedSessionStorage`.
- Added regression coverage in `packages/coding-agent/test/session-manager/close-drop-empty.test.ts` for the four contract cases: draft-then-clear-then-close drops the file; draft still on disk keeps it (for `--resume`); a real user message keeps it; a never-materialized session remains absent.
- Changelog entry under `[Unreleased]` linking #4571.

## Verification

```
$ bun test test/session-manager/close-drop-empty.test.ts
 4 pass
 0 fail
 7 expect() calls
$ bun test test/session-manager/draft.test.ts test/session-manager/move-session-cleanup.test.ts
 8 pass
 0 fail
14 expect() calls
```

Repro script confirms the leaked file no longer survives close(); all four contract scenarios (draft-clear, draft-kept, real message, never-materialized) behave as expected.

Fixes #4571