### PR TITLE
fix(ai): classify quota insufficient gateway errors

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider gateway `quota insufficient` / `额度不足` errors being classified as generic 403 failures instead of usage-limit errors.
+
 ## [16.3.6] - 2026-07-04
 
 ### Added

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -100,7 +100,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?(?:balance|quota)/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?(?:exceeded|reached|insufficient)|额度不足|额度耗尽|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?(?:balance|quota)/i;
 
 /**
  * HTTP status codes that, absent richer body classification, represent an

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -125,6 +125,11 @@ describe("isUsageLimit", () => {
 		expect(isUsageLimit("quota_reached")).toBe(true);
 	});
 
+	it("detects subscription quota insufficient phrasing as usage limit", () => {
+		expect(isUsageLimit("403 订阅额度不足或未配置订阅: subscription quota insufficient, need=14447")).toBe(true);
+		expect(isUsageLimit("quota insufficient")).toBe(true);
+	});
+
 	it("detects OpenAI quota payload codes as credential-rotatable usage limits", () => {
 		for (const message of ["insufficient_quota", "usage_limit_exceeded", "usage_limit_reached"]) {
 			expect(isUsageLimit(message)).toBe(true);


### PR DESCRIPTION
## Summary

- classify `quota insufficient` and Chinese `额度不足` / `额度耗尽` gateway messages as usage-limit errors
- keep these provider gateway quota failures out of the generic 403 path
- add regression coverage for the new phrases

## Test plan

- `bun test packages/ai/test/rate-limit-utils.test.ts`
- `bun check`