### PR TITLE
fix(cursor): reject empty grepArgs.pattern at exec dispatch (#4574)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cursor provider: reject `grepArgs` frames with an empty `pattern` at the exec dispatch (returning an actionable, glob-aware `GrepResult.error`) instead of surfacing the coding-agent grep tool's bare "Pattern must not be empty" and persisting a synthesized tool-call block whose pattern rendered as `?` in the TUI ([#4574](https://github.com/can1357/oh-my-pi/issues/4574)).
+
 ## [16.3.6] - 2026-07-04
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1111,6 +1111,17 @@ async function handleExecServerMessage(
 		case "grepArgs": {
 			const args = execMsg.message.value;
 			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
+			// Cursor's model sometimes emits `grepArgs` with an empty `pattern` and a
+			// non-empty `glob`, expecting grep to list files matching the glob. Reject
+			// that up front with an actionable error so the model retries with a real
+			// regex or switches to `ls`/`read`, instead of the local grep tool
+			// surfacing a bare "Pattern must not be empty" (issue #4574) after the
+			// synthesized block has already been persisted with a placeholder pattern.
+			const emptyPatternError = emptyGrepPatternRejection(args.pattern, args.glob);
+			if (emptyPatternError !== null) {
+				sendExecClientMessage(h2Request, execMsg, "grepResult", buildGrepErrorResult(emptyPatternError));
+				return;
+			}
 			// Mirror the coding-agent bridge's arg mapping so live UI (from
 			// `tool_execution_start`) and rebuilt transcript (from this block)
 			// display identical args.
@@ -1833,6 +1844,31 @@ function buildGrepErrorResult(error: string) {
 			value: create(GrepErrorSchema, { error }),
 		},
 	});
+}
+
+/**
+ * Reject a Cursor exec-channel `grepArgs` frame whose `pattern` is empty or
+ * whitespace-only. Returns an actionable error message when the pattern is
+ * unusable (with a `glob`-aware hint when the model likely meant to list
+ * files), or `null` when the pattern is valid and grep should run.
+ *
+ * Exported for tests. Cursor's model sometimes sends `pattern=""` together
+ * with a non-empty `glob`, expecting grep to enumerate matching files; the
+ * downstream coding-agent `grep` tool rejects that with a bare "Pattern must
+ * not be empty", which the TUI renders as `?` in the tool preview (issue
+ * #4574). Handling it at the Cursor exec dispatch keeps the synthesized
+ * `toolCall` block off the persisted assistant message and gives the model a
+ * specific recovery hint.
+ */
+export function emptyGrepPatternRejection(pattern: string | undefined, glob: string | undefined): string | null {
+	if (pattern && pattern.trim().length > 0) return null;
+	if (glob && glob.length > 0) {
+		return (
+			`grep pattern is required (received an empty pattern). To list files matching "${glob}", ` +
+			`pass a non-empty regex (e.g. ".") and set path to that glob, or use the ls/read tool instead.`
+		);
+	}
+	return "grep pattern is required (received an empty pattern).";
 }
 
 function buildDiagnosticsResultFromToolResult(path: string, toolResult: ToolResultMessage) {

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	buildCursorHistoryForTest,
 	buildCursorSystemPromptJsons,
+	emptyGrepPatternRejection,
 	resolveExecHandler,
 	streamCursor,
 } from "@oh-my-pi/pi-ai/providers/cursor";
@@ -327,5 +328,36 @@ describe("Cursor history encoding", () => {
 		expect(history.turnStepMessagesJson).toEqual([
 			[expect.objectContaining({ assistantMessage: { text: "[Tool Error]\nPattern must not be empty" } })],
 		]);
+	});
+});
+
+describe("Cursor grepArgs empty-pattern guard (issue #4574)", () => {
+	it("returns null when the pattern is a non-empty regex", () => {
+		expect(emptyGrepPatternRejection("foo", undefined)).toBeNull();
+		expect(emptyGrepPatternRejection("foo", "**/*.ts")).toBeNull();
+		// Whitespace-only patterns count as valid: leading/trailing whitespace is
+		// meaningful in regexes (indentation anchors), matching the coding-agent
+		// grep tool's own contract at packages/coding-agent/src/tools/grep.ts.
+		expect(emptyGrepPatternRejection(" \tfoo ", undefined)).toBeNull();
+	});
+
+	it("rejects an empty pattern with a glob-aware hint when only a glob is present", () => {
+		const message = emptyGrepPatternRejection("", "**/*snapcompact*");
+		expect(message).not.toBeNull();
+		expect(message).toContain("grep pattern is required");
+		expect(message).toContain('"**/*snapcompact*"');
+		expect(message).toContain("ls/read tool");
+	});
+
+	it("rejects an empty pattern with a plain message when no glob is present", () => {
+		expect(emptyGrepPatternRejection("", undefined)).toBe("grep pattern is required (received an empty pattern).");
+		expect(emptyGrepPatternRejection(undefined, undefined)).toBe(
+			"grep pattern is required (received an empty pattern).",
+		);
+	});
+
+	it("rejects a whitespace-only pattern the same way as an empty one", () => {
+		expect(emptyGrepPatternRejection("   ", undefined)).toBe("grep pattern is required (received an empty pattern).");
+		expect(emptyGrepPatternRejection("\t\n", "src/**/*.ts")).toContain('"src/**/*.ts"');
 	});
 });


### PR DESCRIPTION
## Repro

Under the Cursor provider, the reporter's model (`composer-2.5-fast` and similar Cursor-agent SKUs) occasionally emits a `grepArgs` frame with `pattern=""` alongside a non-empty `glob` (e.g. `path="."`, `glob="**/*snapcompact*"`), expecting `grep` to behave like a file lister. The downstream `coding-agent` `grep` tool rejected this with a bare `Pattern must not be empty` at `packages/coding-agent/src/tools/grep.ts:887-889`, but by then `handleExecServerMessage`'s `grepArgs` case had already synthesized a persisted `toolCall` block whose empty `pattern` rendered as `?` in the TUI (`args.pattern || "?"` in the grep renderer):

```text
⏳ Grep: ? in ./**/*snapcompact*
✘ Error: Pattern must not be empty
```

That's the concrete case behind the "空参数" symptom in the original report.

## Cause

`packages/ai/src/providers/cursor.ts` `handleExecServerMessage` `case "grepArgs"` unconditionally called `synthesizeCursorExecToolCall(...)` with `args.pattern` verbatim and then handed the frame to `resolveExecHandler(execHandlers.grep, ...)`. When `args.pattern` was empty or whitespace-only:

- The synthesized block ended up on the persisted assistant message with an empty `pattern`, which the TUI's `grepToolRenderer.renderCall` displayed as `?`.
- The bridge (`packages/coding-agent/src/cursor.ts:178-187`) forwarded the empty pattern to the local `grep` tool, which threw `ToolError("Pattern must not be empty")`.
- The model saw only that terse tool error and typically retried the same shape, not realizing it should either provide a real regex or use `ls`/`read` for glob-style enumeration.

## Fix

- Extract a pure, exported helper `emptyGrepPatternRejection(pattern, glob)` in `packages/ai/src/providers/cursor.ts` that returns a specific, glob-aware rejection message when the pattern is empty/whitespace-only and `null` otherwise. Whitespace-only patterns count as empty here (matching the coding-agent grep tool's own reject-at-`!pattern.trim()` contract). A `glob`-aware branch names the received glob and points the model at the correct recovery (`"."` regex + glob path, or the `ls`/`read` tool).
- In the `grepArgs` case of `handleExecServerMessage`, call the helper first: on rejection, respond with `sendExecClientMessage(..., "grepResult", buildGrepErrorResult(message))` and return **before** `synthesizeCursorExecToolCall`, so the persisted assistant message stays clean and the model sees an actionable exec error instead of a placeholder-`?` toolCall followed by a bare local tool error.
- Add unit tests in `packages/ai/test/cursor-exec-handlers.test.ts` covering non-empty regex (with and without glob), glob-aware rejection wording, plain rejection with no glob, whitespace-only patterns, and `undefined` patterns.
- Changelog entry under `packages/ai` `[Unreleased] › Fixed`.

## Verification

- `bun test packages/ai/test/cursor-exec-handlers.test.ts packages/ai/test/cursor-streaming-args.test.ts` — 30/30 pass.
- `bun test packages/ai/test/cursor-exec-handlers.test.ts packages/ai/test/cursor-streaming-args.test.ts packages/ai/test/proxy.test.ts` — 66/66 pass. (The full `packages/ai` suite has one pre-existing test-isolation failure in `test/proxy.test.ts > normalizes hyphenated provider ids to underscores` when run alongside every other file, unrelated to this diff — the same test passes cleanly in isolation and in the mixed subset above; the diff only touches `providers/cursor.ts` + its test file + CHANGELOG.)

Fixes #4574</parameter>
