### PR TITLE
fix(advisor): clamp default thinking against the resolved model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the advisor being disabled for the entire session when the advisor role resolves to a reasoning model that exposes no controllable effort surface (Devin `devin/glm-5-2*`: `reasoning: true`, `thinking: undefined` — Cascade routes by sibling model id rather than a wire param). `#resolveAdvisorRuntimeDescriptors` in `packages/coding-agent/src/session/agent-session.ts` used to hardcode `ThinkingLevel.Medium`, which tripped `requireSupportedEffort` on the first advisor prompt with `Thinking effort medium is not supported by devin/glm-5-2. Supported efforts:` (empty list). The advisor descriptor now clamps the requested effort against the resolved model via `resolveThinkingLevelForModel` and forwards no explicit effort when the model has no controllable efforts — matching the `auto`-path fix (`clampAutoThinkingEffort`) and the Autonomous Memory stage fix (`clampThinkingLevelForModel`). Explicit `:off` still disables reasoning, and models that support `medium` (e.g. Anthropic) keep receiving it ([#4579](https://github.com/can1357/oh-my-pi/issues/4579)).
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2339,7 +2339,19 @@ export class AgentSession {
 				model = sel.model;
 				thinkingLevel = concreteThinkingLevel(sel.thinkingLevel);
 			}
-			const advisorThinkingLevel = thinkingLevel ?? ThinkingLevel.Medium;
+			// Clamp the effort against the resolved model. Historically we defaulted
+			// to `ThinkingLevel.Medium` unconditionally, which threw at first stream
+			// on reasoning models that expose no controllable effort surface
+			// (e.g. `devin-agent`: Cascade routes by sibling model id, not a wire
+			// param; `getSupportedEfforts` returns `[]`). `resolveThinkingLevelForModel`
+			// preserves an explicit `off`, clamps a concrete effort into the model's
+			// supported range, and returns `undefined` for reasoning models without
+			// controllable efforts — for that case we forward `Inherit` so no effort
+			// is sent and reasoning stays enabled (matching the `auto`-path fix for
+			// Devin models via `clampAutoThinkingEffort`). See #4579.
+			const requestedLevel = thinkingLevel ?? ThinkingLevel.Medium;
+			const resolvedLevel = resolveThinkingLevelForModel(model, requestedLevel);
+			const advisorThinkingLevel: ThinkingLevel = resolvedLevel ?? ThinkingLevel.Inherit;
 			descriptors.push({
 				config,
 				name: config.name,

--- a/packages/coding-agent/test/advisor-devin-thinking.test.ts
+++ b/packages/coding-agent/test/advisor-devin-thinking.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+// Regression for https://github.com/can1357/oh-my-pi/issues/4579.
+//
+// When the advisor role resolves to a reasoning model without a controllable
+// effort surface (Devin `devin-agent`: `reasoning: true`, `thinking: undefined`
+// — Cascade routes by sibling model id, not a wire param), the advisor
+// descriptor MUST NOT hand the Agent a concrete `Effort.Medium` default. That
+// would trip `requireSupportedEffort` inside `stream.ts` on the first prompt
+// and disable the advisor session-wide with an empty
+// `Supported efforts:` warning list.
+//
+// This mirrors the `auto`-path fix already covered by
+// `auto-thinking-classifier.test.ts:145` for `clampAutoThinkingEffort`, at the
+// advisor descriptor boundary.
+describe("AgentSession advisor descriptor thinking level", () => {
+	let sharedDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let anthropicModel: Model;
+	let devinModel: Model;
+
+	beforeAll(async () => {
+		sharedDir = TempDir.createSync("@pi-advisor-devin-thinking-shared-");
+		authStorage = await AuthStorage.create(path.join(sharedDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		// Seeding a runtime API key exposes the bundled Devin catalog for
+		// `resolveAdvisorRoleSelection` / `getAvailable()` without any live
+		// network discovery.
+		authStorage.setRuntimeApiKey("devin", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		const anthropic = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const devin = getBundledModel("devin", "glm-5-2");
+		if (!anthropic) throw new Error("Expected bundled anthropic/claude-sonnet-4-5 to exist");
+		if (!devin) throw new Error("Expected bundled devin/glm-5-2 to exist");
+		anthropicModel = anthropic;
+		devinModel = devin;
+	});
+
+	afterAll(async () => {
+		authStorage.close();
+		try {
+			await sharedDir.remove();
+		} catch {}
+	});
+
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-advisor-devin-thinking-");
+		sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		const agent = new Agent({
+			initialState: {
+				model: anthropicModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			advisorTools: [],
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		try {
+			await tempDir.remove();
+		} catch {}
+	});
+
+	it("Devin advisor with no configured thinking suffix boots without an unsupported-effort throw", () => {
+		// Confirm the catalog shape that triggered the bug: `reasoning: true` with
+		// no controllable `thinking.efforts`. If this drifts upstream the
+		// regression's assumptions no longer hold.
+		expect(devinModel.reasoning).toBe(true);
+		expect(devinModel.thinking).toBeUndefined();
+
+		session.settings.setModelRole("advisor", `${devinModel.provider}/${devinModel.id}`);
+
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		expect(session.isAdvisorActive()).toBe(true);
+
+		// Before the fix, the descriptor hardcoded `ThinkingLevel.Medium` which
+		// flowed to `Agent#state.thinkingLevel` and then tripped
+		// `requireSupportedEffort` inside `mapOptionsForApi`'s `devin-agent`
+		// branch on the first stream. The clamp now forwards no explicit effort
+		// (mirroring `clampAutoThinkingEffort`), so the Agent stores `undefined`
+		// and the provider's default routing applies.
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor Agent to be live");
+		expect(advisor.state.model.provider).toBe(devinModel.provider);
+		expect(advisor.state.model.id).toBe(devinModel.id);
+		expect(advisor.state.thinkingLevel).toBeUndefined();
+		// `Off` is reserved for the explicit "disable reasoning" selector; the
+		// Devin path forwards no effort while keeping reasoning enabled.
+		expect(advisor.state.disableReasoning).toBe(false);
+	});
+
+	it("Anthropic advisor with no configured thinking suffix still gets the medium default", () => {
+		// Guard against over-clamping: models that support `medium` MUST keep
+		// receiving it so the historical advisor thinking budget is preserved.
+		session.settings.setModelRole("advisor", `${anthropicModel.provider}/${anthropicModel.id}`);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor Agent to be live");
+		expect(advisor.state.model.provider).toBe(anthropicModel.provider);
+		expect(advisor.state.thinkingLevel).toBe(Effort.Medium);
+	});
+
+	it("Devin advisor with an explicit :off suffix disables reasoning without clamping to inherit", () => {
+		// `off` is an explicit user opt-out and MUST reach the Agent as
+		// `disableReasoning: true` regardless of the model's effort surface. The
+		// clamp helper preserves `off`; verifying that here so a future change
+		// to the descriptor doesn't route `off` through the Devin
+		// no-controllable-effort fallback and silently re-enable reasoning.
+		session.settings.setModelRole("advisor", `${devinModel.provider}/${devinModel.id}:off`);
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+
+		const advisor = session.getAdvisorAgent();
+		if (!advisor) throw new Error("Expected advisor Agent to be live");
+		expect(advisor.state.thinkingLevel).toBeUndefined();
+		expect(advisor.state.disableReasoning).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro

Configure an advisor whose role resolves to a Devin `devin-agent` model (`devin/glm-5-2`, `devin/glm-5-2-max`, …) without a `:medium`/`:high` thinking suffix and start a session. On the first advisor prompt the runtime emits `Advisor unavailable for devin/glm-5-2: Thinking effort medium is not supported by devin/glm-5-2. Supported efforts:` (empty trailing list) and the advisor stays inactive for the rest of the session.

At the boundary, the failure is exactly:

```
getSupportedEfforts(devinModel)                    // []
requireSupportedEffort(devinModel, Effort.Medium)  // throws with empty list
clampThinkingLevelForModel(devinModel, Effort.Medium) // undefined
```

Confirmed with the unit-level repro recorded in the issue thread.

## Cause

`#resolveAdvisorRuntimeDescriptors` in `packages/coding-agent/src/session/agent-session.ts` used `const advisorThinkingLevel = thinkingLevel ?? ThinkingLevel.Medium;` and forwarded `Effort.Medium` unconditionally into the advisor `Agent`'s `thinkingLevel`. That reaches `mapOptionsForApi`'s `devin-agent` branch in `packages/ai/src/stream.ts:1799`, which calls `requireSupportedEffort(devinModel, Effort.Medium)`. Devin models report `reasoning: true` with no `thinking.efforts` (Cascade routes effort by sibling model id, not a wire param), so `getSupportedEfforts` returns `[]` and the require throws. The `AdvisorRuntime.notifyFailure` handler catches the throw and re-emits it as the session-wide warning.

Same class of defect already fixed for the `auto` path (`clampAutoThinkingEffort` — #3356) and the Autonomous Memory stages (`clampThinkingLevelForModel` — #3291-area); the advisor descriptor was missed.

## Fix

- Route the default through `resolveThinkingLevelForModel(model, requested)` in `#resolveAdvisorRuntimeDescriptors`, then fall back to `ThinkingLevel.Inherit` when the clamp returns `undefined` (reasoning model with no controllable effort surface). `toReasoningEffort(Inherit)` yields `undefined`, so no explicit effort reaches the wire and reasoning stays enabled — matching the `auto`-path behavior for Devin.
- `off` continues to reach the Agent as `disableReasoning: true` (preserved by `resolveThinkingLevelForModel` / `shouldDisableReasoning`); Anthropic still receives `medium` unchanged.
- Added `packages/coding-agent/test/advisor-devin-thinking.test.ts`: three cases covering the Devin (no controllable efforts) default, the Anthropic (`medium` preserved) default, and Devin with an explicit `:off` (still disables reasoning).
- Reverted the source change locally and reran the new test suite — the Devin case fails with `Received: "medium"` on unclamped default, confirming the test catches this regression.
- Changelog entry appended under `## [Unreleased]` in `packages/coding-agent/CHANGELOG.md`.

## Verification

- `bun test packages/coding-agent/test/advisor-devin-thinking.test.ts` — 3 pass, 14 expect calls.
- `bun test packages/coding-agent/test/advisor-toggle.test.ts packages/coding-agent/test/auto-thinking-classifier.test.ts` — 18 pass (both baseline advisor + `auto` clamp suites still green).
- `bun test packages/coding-agent/test/agent-session-role-thinking.test.ts packages/coding-agent/test/agent-session-advisor-suppression.test.ts` — 25 pass (nearest role-thinking + advisor-suppression surfaces).
- `bun x tsgo --noEmit` inside `packages/coding-agent` — clean.

Fixes #4579