### PR TITLE
fix(ai): prevent empty-response retry loop on non-STOP finishReason in Gemini CLI

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Gemini CLI / Antigravity (Google Cloud Code Assist API) incorrectly retrying empty-response failures on non-`STOP` finishReasons (such as safety or recitation blocks) and hiding the specific API error behind a generic "Cloud Code Assist API returned an empty response" message. The provider now breaks early on errors and correctly bubbles up the underlying API error message immediately.
+- Fixed Gemini CLI / Antigravity provider treating thinking-only responses (which contain reasoning but no visible text or tool calls) as empty-response failures, causing them to be discarded and retried. Non-empty thinking blocks are now recognized as meaningful content.
 ## [16.3.6] - 2026-07-04
 
 ### Added

--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -1002,14 +1002,21 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 						}
 
 						const streamed = await streamResponse(currentResponse);
-						if (streamed) {
-							receivedContent = true;
+						if (output.stopReason !== "stop" || streamed) {
+							receivedContent = streamed;
 							break;
 						}
 
 						if (emptyAttempt < MAX_EMPTY_STREAM_RETRIES) {
 							resetOutput();
 						}
+					}
+
+					if (output.stopReason === "aborted" || output.stopReason === "error") {
+						throw new AIError.ProviderResponseError(output.errorMessage ?? "An unknown error occurred", {
+							provider: model.provider,
+							kind: "output",
+						});
 					}
 
 					if (!receivedContent) {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -463,7 +463,7 @@ export const EMPTY_STREAM_BASE_DELAY_MS = 500;
 /**
  * Whether a completed Google assistant message carries content worth delivering.
  *
- * A tool call or any non-whitespace text counts as meaningful. An empty/whitespace-only
+ * A tool call, any non-whitespace text, or a non-empty thinking block counts as meaningful. An empty/whitespace-only
  * text part — or thinking that never produced an answer — is the "empty response" failure:
  * delivered as-is the agent loop has nothing to act on and silently halts, so the request
  * must be retried instead of surfaced.
@@ -472,6 +472,7 @@ export function hasMeaningfulGoogleContent(output: AssistantMessage): boolean {
 	for (const block of output.content) {
 		if (block.type === "toolCall") return true;
 		if (block.type === "text" && block.text.trim().length > 0) return true;
+		if (block.type === "thinking" && block.thinking.trim().length > 0) return true;
 	}
 	return false;
 }

--- a/packages/ai/test/google-empty-response-retry.test.ts
+++ b/packages/ai/test/google-empty-response-retry.test.ts
@@ -283,4 +283,67 @@ describe("Google empty-response retry (Cloud Code Assist path)", () => {
 			thoughtSignature: "function-call-sig",
 		});
 	});
+
+	it("does not retry if finishReason is SAFETY and bubbles up the error", async () => {
+		let calls = 0;
+		const fetchMock: FetchImpl = async () => {
+			calls += 1;
+			const response = sse({
+				response: {
+					candidates: [{ content: { parts: [] }, finishReason: "SAFETY" }],
+				},
+			});
+			Object.defineProperty(response, "url", { value: "https://example.com/v1internal:streamGenerateContent" });
+			return response;
+		};
+
+		const stream = streamGoogleGeminiCli(cliModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			fetch: fetchMock,
+		});
+
+		await drain(stream);
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Generation failed with finish reason: SAFETY");
+		expect(calls).toBe(1);
+	});
+
+	it("does not retry if response contains only a thinking block", async () => {
+		let calls = 0;
+		const fetchMock: FetchImpl = async () => {
+			calls += 1;
+			const response = sse({
+				response: {
+					candidates: [
+						{
+							content: {
+								parts: [{ text: "Thinking text...", thought: true }],
+							},
+							finishReason: "STOP",
+						},
+					],
+				},
+			});
+			Object.defineProperty(response, "url", { value: "https://example.com/v1internal:streamGenerateContent" });
+			return response;
+		};
+
+		const stream = streamGoogleGeminiCli(cliModel, context, {
+			apiKey: JSON.stringify({ token: "token", projectId: "proj-123" }),
+			fetch: fetchMock,
+		});
+
+		await drain(stream);
+		const result = await stream.result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.content).toHaveLength(1);
+		expect(result.content[0]).toMatchObject({
+			type: "thinking",
+			thinking: "Thinking text...",
+		});
+		expect(calls).toBe(1);
+	});
 });


### PR DESCRIPTION
Fixed an issue in the Gemini CLI/Antigravity provider where responses ending with non-STOP finishReasons (such as SAFETY or content filters) but containing no text/tool call would trigger empty-response retries, ultimately obscuring the real error behind a generic 'Cloud Code Assist API returned an empty response' error. By checking the stopReason within the retry loop and breaking early on errors, we correctly bubble up the underlying API error immediately.