### PR TITLE
fix(coding-agent): re-export calculateCost + siblings from legacy pi-ai shim

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy extension plugin validation failing with `Export named 'calculateCost' not found in module '.../legacy-pi-ai-shim.ts'` when the extension imports `calculateCost` (or `modelsAreEqual` / `getBundledProviders`) from `@oh-my-pi/pi-ai`. Those symbols were relocated to `@oh-my-pi/pi-catalog/models` during the catalog split but were never bridged back through the legacy `pi-ai` root shim; the shim now re-exports them alongside the existing `getModel` / `getModels` aliases so plugins written against pre-split pi-ai load again ([#4584](https://github.com/can1357/oh-my-pi/issues/4584)).
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -19,7 +19,13 @@
  * `types.ts` via the `export *` below — pi-ai still exports both as types,
  * only the runtime `Type` builder and `StringEnum()` helper were removed.
  */
-import { getBundledModel, getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import {
+	calculateCost,
+	getBundledModel,
+	getBundledModels,
+	getBundledProviders,
+	modelsAreEqual,
+} from "@oh-my-pi/pi-catalog/models";
 import { type TSchema, Type } from "./typebox";
 
 export interface StringEnumOptions<T extends string> {
@@ -66,8 +72,15 @@ export function StringEnum<T extends string | number>(
 }
 
 export * from "@oh-my-pi/pi-ai";
-export { Type };
-
-/** Compatibility aliases for renamed catalog functions */
+/**
+ * Compatibility re-exports for catalog symbols that pi-ai historically exposed
+ * from its own barrel prior to the `refactor(catalog)!: split model catalog
+ * from pi-ai` change. Legacy extensions still import these from the pi-ai
+ * root, so the shim bridges them through to their new home in
+ * `@oh-my-pi/pi-catalog/models`. `getModel`/`getModels` are the historical
+ * pi-ai names for `getBundledModel`/`getBundledModels`; the remaining symbols
+ * kept their names across the move.
+ */
+export { calculateCost, getBundledProviders, modelsAreEqual, Type };
 export const getModel = getBundledModel;
 export const getModels = getBundledModels;

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -3,7 +3,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
-import { getBundledModel, getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import {
+	calculateCost,
+	getBundledModel,
+	getBundledModels,
+	getBundledProviders,
+	modelsAreEqual,
+} from "@oh-my-pi/pi-catalog/models";
 import {
 	__resetLegacyPiResolutionCache,
 	installLegacyPiSpecifierShim,
@@ -122,6 +128,35 @@ describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
 			),
 		)) as { testGetModels: unknown };
 		expect(loaded.testGetModels).toBe(getBundledModels);
+	});
+
+	it("re-exports calculateCost from @oh-my-pi/pi-catalog/models (issue #4584)", async () => {
+		// `calculateCost` was moved from the `@oh-my-pi/pi-ai` barrel to
+		// `@oh-my-pi/pi-catalog/models` in the catalog split. Legacy extensions
+		// still import it from the pi-ai root, so the shim must bridge it back
+		// to the catalog implementation. The historical regression was a plain
+		// `SyntaxError: Export named 'calculateCost' not found in module
+		// '.../legacy-pi-ai-shim.ts'` at extension-validation time.
+		const loaded = (await loadLegacyPiModule(
+			await writeFixtureExtension(
+				'import { calculateCost } from "@oh-my-pi/pi-ai"; export const probe = calculateCost;',
+			),
+		)) as { probe: unknown };
+		expect(loaded.probe).toBe(calculateCost);
+	});
+
+	it("re-exports modelsAreEqual and getBundledProviders from @oh-my-pi/pi-catalog/models", async () => {
+		const loaded = (await loadLegacyPiModule(
+			await writeFixtureExtension(
+				[
+					'import { modelsAreEqual, getBundledProviders } from "@oh-my-pi/pi-ai";',
+					"export const eq = modelsAreEqual;",
+					"export const providers = getBundledProviders;",
+				].join("\n"),
+			),
+		)) as { eq: unknown; providers: unknown };
+		expect(loaded.eq).toBe(modelsAreEqual);
+		expect(loaded.providers).toBe(getBundledProviders);
 	});
 
 	it("exports StringEnum as a schema builder with options support", async () => {


### PR DESCRIPTION
## Repro

Any legacy (TypeBox-based) extension that imports `calculateCost` from `@oh-my-pi/pi-ai` fails plugin validation at install time. Minimal fixture — one file whose entry is `import { calculateCost } from "@oh-my-pi/pi-ai"; export const probe = calculateCost;` — loaded via `loadLegacyPiModule()` after `installLegacyPiSpecifierShim()` raises:

```
SyntaxError: Export named 'calculateCost' not found in module '.../packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts'.
```

User-facing symptom, from #4584:

```
omp plugin install pi-commandcode-provider@0.4.1
✘ Failed to install pi-commandcode-provider: … Export named 'calculateCost' not found in module '…\legacy-pi-ai-shim.ts'.
```

## Cause

`calculateCost` (and its siblings `modelsAreEqual` and `getBundledProviders`) moved from `packages/ai/src/models.ts` — re-exported through the `@oh-my-pi/pi-ai` barrel — to `packages/catalog/src/models.ts` in commit `1b9d9d0851` (`refactor(catalog)!: split model catalog from pi-ai`).

`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` redirects bare `@oh-my-pi/pi-ai` (and its aliased scopes) root imports to `packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts` so legacy extensions still get the pre-15.1.0 `Type` runtime. That shim already patched the `getBundledModel`/`getBundledModels` rename by re-exporting them as `getModel`/`getModels`, but the other three relocated catalog symbols were never bridged, so `export * from "@oh-my-pi/pi-ai"` on line 68 could not surface them.

## Fix

- `packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts`: import `calculateCost`, `modelsAreEqual`, `getBundledProviders` (plus the existing `getBundledModel`/`getBundledModels`) from `@oh-my-pi/pi-catalog/models` and re-export the three under their canonical names, alongside the existing `getModel`/`getModels` aliases.
- `packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts`: two new fixture-loading tests assert that legacy `import { calculateCost } from "@oh-my-pi/pi-ai"` and `import { modelsAreEqual, getBundledProviders } from "@oh-my-pi/pi-ai"` both resolve to the catalog implementations.
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased] → Fixed` entry citing #4584.

## Verification

Ran `bun test test/extensibility/legacy-pi-ai-type-remap.test.ts` in `packages/coding-agent/`. The two new regression tests pass; the pre-existing "legacy pi package root remaps (issue #1474)" describe block still shows 3 failures caused by `Cannot find module './tool-views.generated.js' from '.../src/export/html/index.ts'` — reproduced on `main` at `98f6e9f0` prior to any diff from this PR, so it is unrelated and out of scope. `11 pass / 3 fail (pre-existing)` with the diff vs `9 pass / 3 fail (pre-existing)` on `main`.

Fixes #4584