### PR TITLE
Add Featherless provider support

### DIFF
--- a/packages/ai/src/registry/featherless.ts
+++ b/packages/ai/src/registry/featherless.ts
@@ -1,0 +1,25 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1";
+const FEATHERLESS_MODELS_URL = `${FEATHERLESS_BASE_URL}/models`;
+
+export const loginFeatherless = createApiKeyLogin({
+	providerLabel: "Featherless",
+	authUrl: "https://featherless.ai/account/api-keys",
+	instructions: "Create/copy an API key from the Featherless account API keys page",
+	promptMessage: "Paste your Featherless API key",
+	placeholder: "rc_...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "Featherless",
+		modelsUrl: FEATHERLESS_MODELS_URL,
+	},
+});
+
+export const featherlessProvider = {
+	id: "featherless",
+	name: "Featherless",
+	login: (cb: OAuthLoginCallbacks) => loginFeatherless(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -11,6 +11,7 @@ import { coreWeaveProvider } from "./coreweave";
 import { cursorProvider } from "./cursor";
 import { deepseekProvider } from "./deepseek";
 import { devinProvider } from "./devin";
+import { featherlessProvider } from "./featherless";
 import { firepassProvider } from "./firepass";
 import { fireworksProvider } from "./fireworks";
 import { githubCopilotProvider } from "./github-copilot";
@@ -103,6 +104,7 @@ const ALL = [
 	xiaomiTokenPlanAmsProvider,
 	xiaomiTokenPlanCnProvider,
 	firepassProvider,
+	featherlessProvider,
 	deepseekProvider,
 	moonshotProvider,
 	cerebrasProvider,

--- a/packages/ai/test/provider-registry.test.ts
+++ b/packages/ai/test/provider-registry.test.ts
@@ -15,6 +15,7 @@ import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
 const FIXTURE_SOURCE = "provider-registry-test";
 const ENV_KEYS = [
 	"COREWEAVE_API_KEY",
+	"FEATHERLESS_API_KEY",
 	"ZENMUX_API_KEY",
 	"EXA_API_KEY",
 	"XAI_OAUTH_TOKEN",
@@ -43,6 +44,8 @@ describe("provider registry auth surface", () => {
 		Bun.env.EXA_API_KEY = "exa-env";
 		// Plain name derived from the catalog table's `envVars`.
 		expect(getEnvApiKey("zenmux")).toBe("zenmux-env");
+		Bun.env.FEATHERLESS_API_KEY = "featherless-env";
+		expect(getEnvApiKey("featherless")).toBe("featherless-env");
 		Bun.env.UMANS_AI_CODING_PLAN_API_KEY = "umans-env";
 		expect(getEnvApiKey("umans")).toBe("umans-env");
 		Bun.env.LLAMA_CPP_API_KEY = "llama-env";

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -17,6 +17,7 @@ import {
 	cloudflareAiGatewayModelManagerOptions,
 	coreWeaveModelManagerOptions,
 	deepseekModelManagerOptions,
+	featherlessModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
 	githubCopilotModelManagerOptions,
@@ -139,6 +140,13 @@ export const CATALOG_PROVIDERS = [
 		defaultModel: "kimi-k2.6-turbo",
 		envVars: ["FIREPASS_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => firepassModelManagerOptions(config),
+	},
+	{
+		id: "featherless",
+		defaultModel: "zai-org/GLM-5.2",
+		envVars: ["FEATHERLESS_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => featherlessModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
 	},
 	{
 		id: "fireworks",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -606,6 +606,109 @@ function createSimpleAnthropicProviderOptions(
 }
 
 // ---------------------------------------------------------------------------
+// Featherless
+// ---------------------------------------------------------------------------
+
+const FEATHERLESS_BASE_URL = "https://api.featherless.ai/v1";
+const FEATHERLESS_DEFAULT_MODEL_ID = "zai-org/GLM-5.2";
+const FEATHERLESS_ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+
+const FEATHERLESS_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	{
+		id: FEATHERLESS_DEFAULT_MODEL_ID,
+		name: FEATHERLESS_DEFAULT_MODEL_ID,
+		api: "openai-completions",
+		provider: "featherless",
+		baseUrl: FEATHERLESS_BASE_URL,
+		reasoning: false,
+		input: ["text"],
+		supportsTools: true,
+		cost: FEATHERLESS_ZERO_COST,
+		contextWindow: 262_144,
+		maxTokens: null,
+	},
+	{
+		id: "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+		name: "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+		api: "openai-completions",
+		provider: "featherless",
+		baseUrl: FEATHERLESS_BASE_URL,
+		reasoning: false,
+		input: ["text"],
+		supportsTools: true,
+		cost: FEATHERLESS_ZERO_COST,
+		contextWindow: 32_768,
+		maxTokens: 32_768,
+	},
+	{
+		id: "moonshotai/Kimi-K2-Instruct-0905",
+		name: "moonshotai/Kimi-K2-Instruct-0905",
+		api: "openai-completions",
+		provider: "featherless",
+		baseUrl: FEATHERLESS_BASE_URL,
+		reasoning: false,
+		input: ["text"],
+		supportsTools: true,
+		cost: FEATHERLESS_ZERO_COST,
+		contextWindow: 32_768,
+		maxTokens: 32_768,
+	},
+];
+
+interface FeatherlessModelRecord extends OpenAICompatibleModelRecord {
+	context_length?: unknown;
+	max_completion_tokens?: unknown;
+	available_on_current_plan?: unknown;
+	features?: unknown;
+}
+
+function mapFeatherlessModel(
+	entry: OpenAICompatibleModelRecord,
+	defaults: ModelSpec<"openai-completions">,
+): ModelSpec<"openai-completions"> | null {
+	const record = entry as FeatherlessModelRecord;
+	if (record.available_on_current_plan === false || !isRecord(record.features) || record.features.tool_use !== true) {
+		return null;
+	}
+	return {
+		...defaults,
+		name: toModelName(entry.name, defaults.name),
+		supportsTools: true,
+		contextWindow: toPositiveNumber(record.context_length, defaults.contextWindow),
+		maxTokens: toPositiveNumber(record.max_completion_tokens, defaults.maxTokens),
+	};
+}
+
+export interface FeatherlessModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function featherlessModelManagerOptions(
+	config?: FeatherlessModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? FEATHERLESS_BASE_URL;
+	return {
+		providerId: "featherless",
+		staticModels: FEATHERLESS_STATIC_MODELS.map(model => ({ ...model, baseUrl })),
+		dynamicModelsAuthoritative: true,
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "featherless",
+					baseUrl,
+					apiKey,
+					mapModel: mapFeatherlessModel,
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // Umans AI Coding Plan
 // ---------------------------------------------------------------------------
 

--- a/packages/catalog/test/featherless-provider.test.ts
+++ b/packages/catalog/test/featherless-provider.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import {
+	DEFAULT_MODEL_PER_PROVIDER,
+	getCatalogProviderEntry,
+	PROVIDER_DESCRIPTORS,
+} from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import { featherlessModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Featherless provider support", () => {
+	test("registers descriptor and static fallback for OpenAI-compatible chat completions", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "featherless");
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.defaultModel).toBe("zai-org/GLM-5.2");
+		expect(getCatalogProviderEntry("featherless")?.envVars).toEqual(["FEATHERLESS_API_KEY"]);
+		expect(descriptor?.dynamicModelsAuthoritative).toBe(true);
+		expect(DEFAULT_MODEL_PER_PROVIDER.featherless).toBe("zai-org/GLM-5.2");
+
+		const options = featherlessModelManagerOptions();
+		expect(options.providerId).toBe("featherless");
+		expect(options.dynamicModelsAuthoritative).toBe(true);
+		expect(options.fetchDynamicModels).toBeUndefined();
+		expect(options.staticModels?.find(model => model.id === "zai-org/GLM-5.2")).toMatchObject({
+			id: "zai-org/GLM-5.2",
+			name: "zai-org/GLM-5.2",
+			api: "openai-completions",
+			provider: "featherless",
+			baseUrl: "https://api.featherless.ai/v1",
+			supportsTools: true,
+			contextWindow: 262_144,
+			maxTokens: null,
+		});
+	});
+
+	test("discovers only plan-available tool-use models and preserves Featherless limits", async () => {
+		const calls: Array<{ url: string; authorization: string | null }> = [];
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const headers = new Headers(init?.headers);
+			calls.push({
+				url: input.toString(),
+				authorization: headers.get("authorization"),
+			});
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "zai-org/GLM-5.2",
+							name: "GLM 5.2",
+							features: { tool_use: true },
+							context_length: 262_144,
+							max_completion_tokens: 65_536,
+						},
+						{
+							id: "vendor/tool-model-without-plan-flag",
+							features: { tool_use: true },
+							context_length: 131_072,
+							max_completion_tokens: 32_768,
+						},
+						{
+							id: "vendor/text-only-model",
+							features: { tool_use: false },
+							context_length: 65_536,
+							max_completion_tokens: 16_384,
+						},
+						{
+							id: "vendor/unavailable-tool-model",
+							features: { tool_use: true },
+							available_on_current_plan: false,
+							context_length: 65_536,
+							max_completion_tokens: 16_384,
+						},
+						{
+							id: "vendor/missing-feature-metadata",
+							context_length: 65_536,
+							max_completion_tokens: 16_384,
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		}) as unknown as FetchImpl;
+
+		const options = featherlessModelManagerOptions({ apiKey: "featherless-test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+
+		expect(calls).toEqual([
+			{
+				url: "https://api.featherless.ai/v1/models",
+				authorization: "Bearer featherless-test-key",
+			},
+		]);
+		expect(models?.map(model => model.id)).toEqual(["vendor/tool-model-without-plan-flag", "zai-org/GLM-5.2"]);
+		expect(models?.find(model => model.id === "zai-org/GLM-5.2")).toMatchObject({
+			id: "zai-org/GLM-5.2",
+			name: "GLM 5.2",
+			api: "openai-completions",
+			provider: "featherless",
+			baseUrl: "https://api.featherless.ai/v1",
+			supportsTools: true,
+			contextWindow: 262_144,
+			maxTokens: 65_536,
+		});
+		expect(models?.find(model => model.id === "vendor/tool-model-without-plan-flag")).toMatchObject({
+			provider: "featherless",
+			baseUrl: "https://api.featherless.ai/v1",
+			supportsTools: true,
+			contextWindow: 131_072,
+			maxTokens: 32_768,
+		});
+	});
+});

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -112,6 +112,8 @@ const ALL_TAB = "ALL";
 const STATIC_PROVIDER_TABS: ProviderTabState[] = [{ id: ALL_TAB, label: ALL_TAB }];
 
 const MODEL_TAB_REFRESH_DEBOUNCE_MS = 120;
+const MODEL_SEARCH_REQUIRED_THRESHOLD = 500;
+const ALL_MODELS_SEARCH_REQUIRED_THRESHOLD = 5_000;
 
 function formatProviderTabLabel(providerId: string): string {
 	return providerId.replace(/[-_]+/g, " ").toUpperCase();
@@ -145,6 +147,7 @@ export class ModelSelectorComponent extends Container {
 	#onSelectCallback = (() => {}) as RoleSelectCallback;
 	#onCancelCallback = (() => {}) as CancelCallback;
 	#errorMessage?: unknown;
+	#emptyStateMessage?: string;
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
 	#temporaryOnly: boolean;
@@ -703,13 +706,27 @@ export class ModelSelectorComponent extends Container {
 
 	#filterModels(query: string): void {
 		const activeProviderId = this.#getActiveProviderId();
+		const trimmedQuery = query.trim();
+		this.#emptyStateMessage = undefined;
 
 		let baseModels = this.#allModels;
 		if (activeProviderId) {
 			baseModels = this.#allModels.filter(m => m.provider === activeProviderId);
 		}
 
-		if (query.trim()) {
+		const searchRequiredThreshold = activeProviderId
+			? MODEL_SEARCH_REQUIRED_THRESHOLD
+			: ALL_MODELS_SEARCH_REQUIRED_THRESHOLD;
+		if (!trimmedQuery && baseModels.length > searchRequiredThreshold) {
+			const label = activeProviderId ? formatProviderTabLabel(activeProviderId) : "All providers";
+			this.#filteredModels = [];
+			this.#selectedIndex = 0;
+			this.#emptyStateMessage = `  ${label} has ${formatNumber(baseModels.length).toLowerCase()} API-loaded models. Type to search by provider/model id.`;
+			this.#updateList();
+			return;
+		}
+
+		if (trimmedQuery) {
 			// If user is searching from a provider tab, auto-switch to ALL to show global provider results.
 			if (activeProviderId) {
 				this.#activeTabIndex = 0;
@@ -727,7 +744,7 @@ export class ModelSelectorComponent extends Container {
 			// through the same fuzzy matcher. The score is biased by provider-
 			// prefix length, so re-sort by MRU/version afterwards; skip role
 			// rank so a weakly matching default doesn't trump a stronger match.
-			const fuzzyMatches = fuzzyFilter(baseModels, query, ({ id, provider }) => `${provider}/${id}`);
+			const fuzzyMatches = fuzzyFilter(baseModels, trimmedQuery, ({ id, provider }) => `${provider}/${id}`);
 			this.#sortModels(fuzzyMatches, { skipRoleRank: true });
 			this.#filteredModels = fuzzyMatches;
 		} else {
@@ -891,7 +908,7 @@ export class ModelSelectorComponent extends Container {
 				this.#listContainer.addChild(new Text(theme.fg("error", line), 0, 0));
 			}
 		} else if (visibleItems.length === 0) {
-			const statusMessage = this.#getProviderEmptyStateMessage();
+			const statusMessage = this.#emptyStateMessage ?? this.#getProviderEmptyStateMessage();
 			this.#listContainer.addChild(new Text(theme.fg("muted", statusMessage ?? "  No matching models"), 0, 0));
 		} else {
 			const selected = visibleItems[this.#selectedIndex];

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -63,6 +63,22 @@ function createContextTestModel(id: string, contextWindow: number): Model {
 	});
 }
 
+function createProviderTestModel(provider: string, id: string): Model {
+	return buildModel({
+		id,
+		name: id,
+		api: "openai-completions",
+		baseUrl: "https://example.com/v1",
+		reasoning: false,
+		provider,
+		input: ["text"],
+		supportsTools: true,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 4096,
+	});
+}
+
 function createScopedSelector(
 	models: Model[],
 	settings: Settings,
@@ -506,5 +522,28 @@ describe("ModelSelector role badge thinking display", () => {
 		const finalRendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(finalRendered).toContain("deepseek-v4-pro");
 		expect(finalRendered).not.toContain("Refreshing OLLAMA CLOUD in background");
+	});
+
+	test("requires search before rendering high-cardinality provider tabs and surfaces queried API-loaded models", () => {
+		installTestTheme();
+		const settings = Settings.isolated({});
+		const models = Array.from({ length: 501 }, (_, index) =>
+			createProviderTestModel("featherless", index === 427 ? "needle-context-tool-model" : `bulk-model-${index}`),
+		);
+		const selector = createScopedSelector(models, settings, () => {});
+
+		selector.handleInput("\t");
+		const providerTabRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(providerTabRendered).toContain(
+			"FEATHERLESS has 501 API-loaded models. Type to search by provider/model id.",
+		);
+		expect(providerTabRendered).not.toContain("bulk-model-0");
+		expect(providerTabRendered).not.toContain("needle-context-tool-model");
+
+		for (const ch of "needle") selector.handleInput(ch);
+		const searchRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(searchRendered).toContain("featherless/needle-context-tool-model");
+		expect(searchRendered).not.toContain("Type to search by provider/model id");
+		expect(searchRendered).not.toContain("bulk-model-0");
 	});
 });


### PR DESCRIPTION
## Summary
- Add Featherless as an OpenAI-compatible provider with FEATHERLESS_API_KEY login/validation.
- Register Featherless catalog discovery with dynamic /models loading, static fallbacks, and zai-org/GLM-5.2 as the default model.
- Add a model selector guard for high-cardinality provider/all-model lists so users search API-loaded models instead of scrolling thousands of rows.

## Verification
- bunx biome check --write packages/ai/src/registry/featherless.ts packages/ai/src/registry/registry.ts packages/ai/test/provider-registry.test.ts packages/catalog/src/provider-models/descriptors.ts packages/catalog/src/provider-models/openai-compat.ts packages/catalog/test/featherless-provider.test.ts packages/coding-agent/src/modes/components/model-selector.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
- bun test packages/catalog/test/featherless-provider.test.ts packages/ai/test/provider-registry.test.ts packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
- bun --cwd=packages/catalog run check:types
- bun --cwd=packages/ai run check:types
- bun --cwd=packages/coding-agent run check:types
- FEATHERLESS_API_KEY=... bun packages/coding-agent/src/cli.ts models find featherless/zai-org/GLM-5.2 --json
- FEATHERLESS_API_KEY=... curl https://api.featherless.ai/v1/chat/completions with model zai-org/GLM-5.2