### PR TITLE
fix(ai): opt cursor-agent out of the generic lazy idle watchdog (#4593)

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Cursor (`cursor-agent`) streams aborting mid-turn with `Provider stream stalled while waiting for the next event` when a local tool ran during the exec-channel round-trip: `streamCursor` in `register-builtins.ts` now sets `PROVIDER_HANDLED_STREAM_TIMEOUTS` so the lazy wrapper stops racing `iterateWithIdleTimeout` (default 120s) against the provider's own HTTP/2 heartbeat + trailers + caller-signal transport, matching Anthropic and every other transport-owning provider ([#4593](https://github.com/can1357/oh-my-pi/issues/4593)).
+- Fixed Cursor (`cursor-agent`) streams aborting mid-turn with `Provider stream stalled while waiting for the next event` when a local tool ran during the exec-channel round-trip: Cursor exec handlers now emit empty `toolcall_delta` keepalives while OMP is awaiting the local tool result, so the generic lazy stream watchdog still catches truly silent streams but no longer fires during legitimate long-running Cursor-driven tools ([#4593](https://github.com/can1357/oh-my-pi/issues/4593)).
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor (`cursor-agent`) streams aborting mid-turn with `Provider stream stalled while waiting for the next event` when a local tool ran during the exec-channel round-trip: `streamCursor` in `register-builtins.ts` now sets `PROVIDER_HANDLED_STREAM_TIMEOUTS` so the lazy wrapper stops racing `iterateWithIdleTimeout` (default 120s) against the provider's own HTTP/2 heartbeat + trailers + caller-signal transport, matching Anthropic and every other transport-owning provider ([#4593](https://github.com/can1357/oh-my-pi/issues/4593)).
+
 ## [16.3.6] - 2026-07-04
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Cursor (`cursor-agent`) streams aborting mid-turn with `Provider stream stalled while waiting for the next event` when a local tool ran during the exec-channel round-trip: Cursor exec handlers now emit empty `toolcall_delta` keepalives while OMP is awaiting the local tool result, so the generic lazy stream watchdog still catches truly silent streams but no longer fires during legitimate long-running Cursor-driven tools ([#4593](https://github.com/can1357/oh-my-pi/issues/4593)).
+- Fixed Cursor (`cursor-agent`) streams aborting mid-turn with `Provider stream stalled while waiting for the next event` when a local tool ran during the exec-channel round-trip: Cursor exec handlers now emit empty `toolcall_delta` keepalives while OMP is awaiting the local tool result. The keepalive cadence is derived from the caller's effective `streamIdleTimeoutMs` / `PI_STREAM_IDLE_TIMEOUT_MS` (max 30s, min 1s, otherwise half the idle budget) so tuned deployments still fire a keepalive before the idle watchdog trips, while truly silent streams remain retryable through the generic lazy watchdog ([#4593](https://github.com/can1357/oh-my-pi/issues/4593)).
 
 ## [16.3.6] - 2026-07-04
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -149,6 +149,7 @@ export const CURSOR_API_URL = "https://api2.cursor.sh";
 export const CURSOR_CLIENT_VERSION = "cli-2026.01.09-231024f";
 
 const CURSOR_PROXY_TUNNEL_TIMEOUT_MS = 30_000;
+const CURSOR_EXEC_KEEPALIVE_INTERVAL_MS = 30_000;
 
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
@@ -1079,13 +1080,16 @@ async function handleExecServerMessage(
 			const args = execMsg.message.value;
 			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
 			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "read", { path: args.path });
-			const { execResult } = await resolveExecHandler(
-				args,
-				execHandlers?.read?.bind(execHandlers),
-				onToolResult,
-				toolResult => buildReadResultFromToolResult(args.path, toolResult),
-				reason => buildReadRejectedResult(args.path, reason),
-				error => buildReadErrorResult(args.path, error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					args,
+					execHandlers?.read?.bind(execHandlers),
+					onToolResult,
+					toolResult => buildReadResultFromToolResult(args.path, toolResult),
+					reason => buildReadRejectedResult(args.path, reason),
+					error => buildReadErrorResult(args.path, error),
+				),
+				{ output, stream, toolCallId: args.toolCallId },
 			);
 			sendExecClientMessage(h2Request, execMsg, "readResult", execResult);
 			return;
@@ -1097,13 +1101,16 @@ async function handleExecServerMessage(
 			// `CursorExecHandlers.ls` in `pi-coding-agent/src/cursor.ts`); mirror
 			// that here so the synthesized block matches the toolResult's `toolName`.
 			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "read", { path: args.path });
-			const { execResult } = await resolveExecHandler(
-				args,
-				execHandlers?.ls?.bind(execHandlers),
-				onToolResult,
-				toolResult => buildLsResultFromToolResult(args.path, toolResult),
-				reason => buildLsRejectedResult(args.path, reason),
-				error => buildLsErrorResult(args.path, error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					args,
+					execHandlers?.ls?.bind(execHandlers),
+					onToolResult,
+					toolResult => buildLsResultFromToolResult(args.path, toolResult),
+					reason => buildLsRejectedResult(args.path, reason),
+					error => buildLsErrorResult(args.path, error),
+				),
+				{ output, stream, toolCallId: args.toolCallId },
 			);
 			sendExecClientMessage(h2Request, execMsg, "lsResult", execResult);
 			return;
@@ -1120,13 +1127,16 @@ async function handleExecServerMessage(
 				path: searchPath,
 				case: args.caseInsensitive === true ? false : undefined,
 			});
-			const { execResult } = await resolveExecHandler(
-				args,
-				execHandlers?.grep?.bind(execHandlers),
-				onToolResult,
-				toolResult => buildGrepResultFromToolResult(args, toolResult),
-				reason => buildGrepErrorResult(reason),
-				error => buildGrepErrorResult(error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					args,
+					execHandlers?.grep?.bind(execHandlers),
+					onToolResult,
+					toolResult => buildGrepResultFromToolResult(args, toolResult),
+					reason => buildGrepErrorResult(reason),
+					error => buildGrepErrorResult(error),
+				),
+				{ output, stream, toolCallId: args.toolCallId },
 			);
 			sendExecClientMessage(h2Request, execMsg, "grepResult", execResult);
 			return;
@@ -1140,22 +1150,25 @@ async function handleExecServerMessage(
 				path: args.path,
 				content,
 			});
-			const { execResult } = await resolveExecHandler(
-				args,
-				execHandlers?.write?.bind(execHandlers),
-				onToolResult,
-				toolResult =>
-					buildWriteResultFromToolResult(
-						{
-							path: args.path,
-							fileText: args.fileText,
-							fileBytes: args.fileBytes,
-							returnFileContentAfterWrite: args.returnFileContentAfterWrite,
-						},
-						toolResult,
-					),
-				reason => buildWriteRejectedResult(args.path, reason),
-				error => buildWriteErrorResult(args.path, error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					args,
+					execHandlers?.write?.bind(execHandlers),
+					onToolResult,
+					toolResult =>
+						buildWriteResultFromToolResult(
+							{
+								path: args.path,
+								fileText: args.fileText,
+								fileBytes: args.fileBytes,
+								returnFileContentAfterWrite: args.returnFileContentAfterWrite,
+							},
+							toolResult,
+						),
+					reason => buildWriteRejectedResult(args.path, reason),
+					error => buildWriteErrorResult(args.path, error),
+				),
+				{ output, stream, toolCallId: args.toolCallId },
 			);
 			sendExecClientMessage(h2Request, execMsg, "writeResult", execResult);
 			return;
@@ -1164,13 +1177,16 @@ async function handleExecServerMessage(
 			const args = execMsg.message.value;
 			if (!args.toolCallId) args.toolCallId = crypto.randomUUID();
 			synthesizeCursorExecToolCall(output, stream, state, args.toolCallId, "delete", { path: args.path });
-			const { execResult } = await resolveExecHandler(
-				args,
-				execHandlers?.delete?.bind(execHandlers),
-				onToolResult,
-				toolResult => buildDeleteResultFromToolResult(args.path, toolResult),
-				reason => buildDeleteRejectedResult(args.path, reason),
-				error => buildDeleteErrorResult(args.path, error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					args,
+					execHandlers?.delete?.bind(execHandlers),
+					onToolResult,
+					toolResult => buildDeleteResultFromToolResult(args.path, toolResult),
+					reason => buildDeleteRejectedResult(args.path, reason),
+					error => buildDeleteErrorResult(args.path, error),
+				),
+				{ output, stream, toolCallId: args.toolCallId },
 			);
 			sendExecClientMessage(h2Request, execMsg, "deleteResult", execResult);
 			return;
@@ -1187,13 +1203,16 @@ async function handleExecServerMessage(
 				cwd: args.workingDirectory || undefined,
 				timeout: shellTimeout,
 			});
-			const { execResult } = await resolveExecHandler(
-				args,
-				execHandlers?.shell?.bind(execHandlers),
-				onToolResult,
-				toolResult => buildShellResultFromToolResult(normalizedArgs, toolResult),
-				reason => buildShellRejectedResult(normalizedArgs.command, normalizedArgs.workingDirectory, reason),
-				error => buildShellFailureResult(normalizedArgs.command, normalizedArgs.workingDirectory, error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					args,
+					execHandlers?.shell?.bind(execHandlers),
+					onToolResult,
+					toolResult => buildShellResultFromToolResult(normalizedArgs, toolResult),
+					reason => buildShellRejectedResult(normalizedArgs.command, normalizedArgs.workingDirectory, reason),
+					error => buildShellFailureResult(normalizedArgs.command, normalizedArgs.workingDirectory, error),
+				),
+				{ output, stream, toolCallId: args.toolCallId },
 			);
 			const sanitizedExecResult = sanitizeShellExecResult(execResult);
 			sendExecClientMessage(h2Request, execMsg, "shellResult", sanitizedExecResult);
@@ -1208,7 +1227,14 @@ async function handleExecServerMessage(
 				cwd: args.workingDirectory || undefined,
 				timeout: shellStreamTimeout,
 			});
-			await handleShellStreamArgs(args, execMsg, h2Request, execHandlers, onToolResult);
+			await awaitWithCursorExecKeepalive(
+				handleShellStreamArgs(args, execMsg, h2Request, execHandlers, onToolResult),
+				{
+					output,
+					stream,
+					toolCallId: args.toolCallId,
+				},
+			);
 			return;
 		}
 		case "backgroundShellSpawnArgs": {
@@ -1262,13 +1288,16 @@ async function handleExecServerMessage(
 				action: "diagnostics",
 				file: args.path,
 			});
-			const { execResult } = await resolveExecHandler(
-				args,
-				execHandlers?.diagnostics?.bind(execHandlers),
-				onToolResult,
-				toolResult => buildDiagnosticsResultFromToolResult(args.path, toolResult),
-				reason => buildDiagnosticsRejectedResult(args.path, reason),
-				error => buildDiagnosticsErrorResult(args.path, error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					args,
+					execHandlers?.diagnostics?.bind(execHandlers),
+					onToolResult,
+					toolResult => buildDiagnosticsResultFromToolResult(args.path, toolResult),
+					reason => buildDiagnosticsRejectedResult(args.path, reason),
+					error => buildDiagnosticsErrorResult(args.path, error),
+				),
+				{ output, stream, toolCallId: args.toolCallId },
 			);
 			sendExecClientMessage(h2Request, execMsg, "diagnosticsResult", execResult);
 			return;
@@ -1276,13 +1305,16 @@ async function handleExecServerMessage(
 		case "mcpArgs": {
 			const args = execMsg.message.value;
 			const mcpCall = decodeMcpCall(args);
-			const { execResult } = await resolveExecHandler(
-				mcpCall,
-				execHandlers?.mcp?.bind(execHandlers),
-				onToolResult,
-				toolResult => buildMcpResultFromToolResult(mcpCall, toolResult),
-				_reason => buildMcpToolNotFoundResult(mcpCall),
-				error => buildMcpErrorResult(error),
+			const { execResult } = await awaitWithCursorExecKeepalive(
+				resolveExecHandler(
+					mcpCall,
+					execHandlers?.mcp?.bind(execHandlers),
+					onToolResult,
+					toolResult => buildMcpResultFromToolResult(mcpCall, toolResult),
+					_reason => buildMcpToolNotFoundResult(mcpCall),
+					error => buildMcpErrorResult(error),
+				),
+				{ output, stream, toolCallId: state.currentToolCall?.id },
 			);
 			sendExecClientMessage(h2Request, execMsg, "mcpResult", execResult);
 			return;
@@ -2120,6 +2152,47 @@ export function synthesizeCursorExecToolCall(
 	const idx = output.content.length - 1;
 	stream.push({ type: "toolcall_start", contentIndex: idx, partial: output });
 	stream.push({ type: "toolcall_end", contentIndex: idx, toolCall: block, partial: output });
+}
+
+/** Exported for tests: emits a no-op delta so the lazy stream watchdog observes exec progress. */
+export function pushCursorExecStreamKeepalive(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	toolCallId: string | undefined,
+): void {
+	if (!toolCallId) {
+		return;
+	}
+	const contentIndex = output.content.findIndex(content => content.type === "toolCall" && content.id === toolCallId);
+	if (contentIndex < 0) {
+		return;
+	}
+	stream.push({ type: "toolcall_delta", contentIndex, delta: "", partial: output });
+}
+
+/** Exported for tests: keeps Cursor exec-channel local tool waits visible to the lazy watchdog. */
+export async function awaitWithCursorExecKeepalive<TResult>(
+	promise: Promise<TResult>,
+	options: {
+		output: AssistantMessage;
+		stream: AssistantMessageEventStream;
+		toolCallId: string | undefined;
+		intervalMs?: number;
+	},
+): Promise<TResult> {
+	const intervalMs = options.intervalMs ?? CURSOR_EXEC_KEEPALIVE_INTERVAL_MS;
+	if (intervalMs <= 0 || !options.toolCallId) {
+		return await promise;
+	}
+	const timer = setInterval(() => {
+		pushCursorExecStreamKeepalive(options.output, options.stream, options.toolCallId);
+	}, intervalMs);
+	timer.unref?.();
+	try {
+		return await promise;
+	} finally {
+		clearInterval(timer);
+	}
 }
 
 /** Exported for tests: drives one Cursor interaction update through the streaming state machine. */

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -1339,7 +1339,7 @@ async function handleExecServerMessage(
 					_reason => buildMcpToolNotFoundResult(mcpCall),
 					error => buildMcpErrorResult(error),
 				),
-				{ output, stream, toolCallId: state.currentToolCall?.id, intervalMs: execKeepaliveIntervalMs },
+				{ output, stream, toolCallId: mcpCall.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "mcpResult", execResult);
 			return;

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -141,6 +141,7 @@ import {
 } from "../utils/block-symbols";
 import { deterministicUuid } from "../utils/deterministic-id";
 import { AssistantMessageEventStream } from "../utils/event-stream";
+import { getStreamIdleTimeoutMs } from "../utils/idle-iterator";
 import { connectProxiedSocket, getProxyForProvider, shouldBypassProxy } from "../utils/proxy";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
 import { toolWireSchema } from "../utils/schema/wire";
@@ -149,7 +150,24 @@ export const CURSOR_API_URL = "https://api2.cursor.sh";
 export const CURSOR_CLIENT_VERSION = "cli-2026.01.09-231024f";
 
 const CURSOR_PROXY_TUNNEL_TIMEOUT_MS = 30_000;
-const CURSOR_EXEC_KEEPALIVE_INTERVAL_MS = 30_000;
+const CURSOR_EXEC_KEEPALIVE_MAX_INTERVAL_MS = 30_000;
+const CURSOR_EXEC_KEEPALIVE_MIN_INTERVAL_MS = 1_000;
+
+/**
+ * Pick a keepalive cadence that always fires at least once before an idle
+ * budget expires. Callers can shorten `PI_STREAM_IDLE_TIMEOUT_MS` /
+ * `streamIdleTimeoutMs` below the default 120s; a fixed 30s cadence would then
+ * miss the deadline for the very case the exec keepalives are meant to cover.
+ * `undefined` (watchdog disabled) skips the derivation and uses the max cadence
+ * so we still surface progress on the transcript.
+ */
+export function resolveCursorExecKeepaliveIntervalMs(idleTimeoutMs: number | undefined): number {
+	if (idleTimeoutMs === undefined || idleTimeoutMs <= 0) {
+		return CURSOR_EXEC_KEEPALIVE_MAX_INTERVAL_MS;
+	}
+	const half = Math.floor(idleTimeoutMs / 2);
+	return Math.max(CURSOR_EXEC_KEEPALIVE_MIN_INTERVAL_MS, Math.min(CURSOR_EXEC_KEEPALIVE_MAX_INTERVAL_MS, half));
+}
 
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
@@ -368,6 +386,8 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 				conversationState: cachedState,
 			});
 			conversationStateCache.set(conversationId, conversationState);
+			const effectiveIdleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
+			const execKeepaliveIntervalMs = resolveCursorExecKeepaliveIntervalMs(effectiveIdleTimeoutMs);
 			const requestContextTools = buildMcpToolDefinitions(context.tools);
 
 			const baseUrl = model.baseUrl || CURSOR_API_URL;
@@ -499,6 +519,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 							options?.onToolResult,
 							usageState,
 							requestContextTools,
+							execKeepaliveIntervalMs,
 							onConversationCheckpoint,
 						).catch(error => {
 							log("error", "handleServerMessage", { error: String(error) });
@@ -665,6 +686,7 @@ async function handleServerMessage(
 	onToolResult: CursorToolResultHandler | undefined,
 	usageState: UsageState,
 	requestContextTools: McpToolDefinition[],
+	execKeepaliveIntervalMs: number,
 	onConversationCheckpoint?: (checkpoint: ConversationStateStructure) => void,
 ): Promise<void> {
 	const msgCase = msg.message.case;
@@ -685,6 +707,7 @@ async function handleServerMessage(
 			output,
 			stream,
 			state,
+			execKeepaliveIntervalMs,
 		);
 	} else if (msgCase === "conversationCheckpointUpdate") {
 		handleConversationCheckpointUpdate(msg.message.value, output, usageState, onConversationCheckpoint);
@@ -1044,6 +1067,7 @@ async function handleExecServerMessage(
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
 	state: BlockState,
+	execKeepaliveIntervalMs: number,
 ): Promise<void> {
 	const execCase = execMsg.message.case;
 	log("exec", "dispatch", { execCase, execId: execMsg.execId, hasHandlers: !!execHandlers });
@@ -1089,7 +1113,7 @@ async function handleExecServerMessage(
 					reason => buildReadRejectedResult(args.path, reason),
 					error => buildReadErrorResult(args.path, error),
 				),
-				{ output, stream, toolCallId: args.toolCallId },
+				{ output, stream, toolCallId: args.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "readResult", execResult);
 			return;
@@ -1110,7 +1134,7 @@ async function handleExecServerMessage(
 					reason => buildLsRejectedResult(args.path, reason),
 					error => buildLsErrorResult(args.path, error),
 				),
-				{ output, stream, toolCallId: args.toolCallId },
+				{ output, stream, toolCallId: args.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "lsResult", execResult);
 			return;
@@ -1136,7 +1160,7 @@ async function handleExecServerMessage(
 					reason => buildGrepErrorResult(reason),
 					error => buildGrepErrorResult(error),
 				),
-				{ output, stream, toolCallId: args.toolCallId },
+				{ output, stream, toolCallId: args.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "grepResult", execResult);
 			return;
@@ -1168,7 +1192,7 @@ async function handleExecServerMessage(
 					reason => buildWriteRejectedResult(args.path, reason),
 					error => buildWriteErrorResult(args.path, error),
 				),
-				{ output, stream, toolCallId: args.toolCallId },
+				{ output, stream, toolCallId: args.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "writeResult", execResult);
 			return;
@@ -1186,7 +1210,7 @@ async function handleExecServerMessage(
 					reason => buildDeleteRejectedResult(args.path, reason),
 					error => buildDeleteErrorResult(args.path, error),
 				),
-				{ output, stream, toolCallId: args.toolCallId },
+				{ output, stream, toolCallId: args.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "deleteResult", execResult);
 			return;
@@ -1212,7 +1236,7 @@ async function handleExecServerMessage(
 					reason => buildShellRejectedResult(normalizedArgs.command, normalizedArgs.workingDirectory, reason),
 					error => buildShellFailureResult(normalizedArgs.command, normalizedArgs.workingDirectory, error),
 				),
-				{ output, stream, toolCallId: args.toolCallId },
+				{ output, stream, toolCallId: args.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			const sanitizedExecResult = sanitizeShellExecResult(execResult);
 			sendExecClientMessage(h2Request, execMsg, "shellResult", sanitizedExecResult);
@@ -1233,6 +1257,7 @@ async function handleExecServerMessage(
 					output,
 					stream,
 					toolCallId: args.toolCallId,
+					intervalMs: execKeepaliveIntervalMs,
 				},
 			);
 			return;
@@ -1297,7 +1322,7 @@ async function handleExecServerMessage(
 					reason => buildDiagnosticsRejectedResult(args.path, reason),
 					error => buildDiagnosticsErrorResult(args.path, error),
 				),
-				{ output, stream, toolCallId: args.toolCallId },
+				{ output, stream, toolCallId: args.toolCallId, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "diagnosticsResult", execResult);
 			return;
@@ -1314,7 +1339,7 @@ async function handleExecServerMessage(
 					_reason => buildMcpToolNotFoundResult(mcpCall),
 					error => buildMcpErrorResult(error),
 				),
-				{ output, stream, toolCallId: state.currentToolCall?.id },
+				{ output, stream, toolCallId: state.currentToolCall?.id, intervalMs: execKeepaliveIntervalMs },
 			);
 			sendExecClientMessage(h2Request, execMsg, "mcpResult", execResult);
 			return;
@@ -2180,7 +2205,7 @@ export async function awaitWithCursorExecKeepalive<TResult>(
 		intervalMs?: number;
 	},
 ): Promise<TResult> {
-	const intervalMs = options.intervalMs ?? CURSOR_EXEC_KEEPALIVE_INTERVAL_MS;
+	const intervalMs = options.intervalMs ?? CURSOR_EXEC_KEEPALIVE_MAX_INTERVAL_MS;
 	if (intervalMs <= 0 || !options.toolCallId) {
 		return await promise;
 	}

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -478,7 +478,7 @@ export const streamOpenAIResponses = createLazyStream(
 	loadOpenAIResponsesProviderModule,
 	PROVIDER_HANDLED_STREAM_TIMEOUTS,
 );
-export const streamCursor = createLazyStream(loadCursorProviderModule, PROVIDER_HANDLED_STREAM_TIMEOUTS);
+export const streamCursor = createLazyStream(loadCursorProviderModule);
 export const streamDevin = createLazyStream(loadDevinProviderModule);
 export const streamOllama = createLazyStream(loadOllamaProviderModule, OPENAI_IDLE_FLOORED_LAZY_STREAM_LIMITS);
 

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -157,6 +157,7 @@ let openAICompletionsProviderModulePromise: Promise<LazyProviderModule<"openai-c
 let openAIResponsesProviderModulePromise: Promise<LazyProviderModule<"openai-responses">> | undefined;
 let ollamaProviderModulePromise: Promise<LazyProviderModule<"ollama-chat">> | undefined;
 let cursorProviderModulePromise: Promise<LazyProviderModule<"cursor-agent">> | undefined;
+let cursorProviderModuleOverride: LazyProviderModule<"cursor-agent"> | undefined;
 let devinProviderModulePromise: Promise<LazyProviderModule<"devin-agent">> | undefined;
 let bedrockProviderModuleOverride: LazyProviderModule<"bedrock-converse-stream"> | undefined;
 let bedrockProviderModulePromise: Promise<LazyProviderModule<"bedrock-converse-stream">> | undefined;
@@ -164,6 +165,12 @@ let bedrockProviderModulePromise: Promise<LazyProviderModule<"bedrock-converse-s
 export function setBedrockProviderModule(module: BedrockProviderModule): void {
 	bedrockProviderModuleOverride = {
 		stream: module.streamBedrock,
+	};
+}
+
+export function setCursorProviderModule(module: CursorProviderModule): void {
+	cursorProviderModuleOverride = {
+		stream: module.streamCursor,
 	};
 }
 
@@ -411,6 +418,9 @@ function loadOllamaProviderModule(): Promise<LazyProviderModule<"ollama-chat">> 
 }
 
 function loadCursorProviderModule(): Promise<LazyProviderModule<"cursor-agent">> {
+	if (cursorProviderModuleOverride) {
+		return Promise.resolve(cursorProviderModuleOverride);
+	}
 	cursorProviderModulePromise ||= import("./cursor").then(module => {
 		const provider = module as CursorProviderModule;
 		return { stream: provider.streamCursor };
@@ -468,7 +478,7 @@ export const streamOpenAIResponses = createLazyStream(
 	loadOpenAIResponsesProviderModule,
 	PROVIDER_HANDLED_STREAM_TIMEOUTS,
 );
-export const streamCursor = createLazyStream(loadCursorProviderModule);
+export const streamCursor = createLazyStream(loadCursorProviderModule, PROVIDER_HANDLED_STREAM_TIMEOUTS);
 export const streamDevin = createLazyStream(loadDevinProviderModule);
 export const streamOllama = createLazyStream(loadOllamaProviderModule, OPENAI_IDLE_FLOORED_LAZY_STREAM_LIMITS);
 

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import {
+	awaitWithCursorExecKeepalive,
 	buildCursorHistoryForTest,
 	buildCursorSystemPromptJsons,
+	pushCursorExecStreamKeepalive,
 	resolveExecHandler,
 	streamCursor,
 } from "@oh-my-pi/pi-ai/providers/cursor";
-import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import type { AssistantMessage, AssistantMessageEvent, Context, Model } from "@oh-my-pi/pi-ai/types";
+import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { AgentRunRequest } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 
@@ -82,6 +85,86 @@ function toolResultContext(): Context {
 	};
 }
 
+const cursorExecPartialMessage: AssistantMessage = {
+	role: "assistant",
+	content: [
+		{
+			type: "toolCall",
+			id: "call-1",
+			name: "grep",
+			arguments: { pattern: "foo", path: "." },
+		},
+	],
+	api: "cursor-agent",
+	provider: "cursor",
+	model: "composer-2.5-fast",
+	usage: {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	},
+	stopReason: "toolUse",
+	timestamp: 1,
+};
+
+describe("Cursor exec stream keepalive", () => {
+	it("pushes an empty toolcall_delta for synthesized exec tool-call blocks", () => {
+		const output: AssistantMessage = { ...cursorExecPartialMessage, content: [...cursorExecPartialMessage.content] };
+		const events: AssistantMessageEvent[] = [];
+		const stream = {
+			push(event: AssistantMessageEvent) {
+				events.push(event);
+			},
+		} as unknown as AssistantMessageEventStream;
+
+		pushCursorExecStreamKeepalive(output, stream, "call-1");
+
+		expect(events).toEqual([
+			{
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: "",
+				partial: output,
+			},
+		]);
+		expect(output.content).toEqual(cursorExecPartialMessage.content);
+	});
+
+	it("emits keepalive deltas while awaiting a long exec handler", async () => {
+		const output: AssistantMessage = { ...cursorExecPartialMessage, content: [...cursorExecPartialMessage.content] };
+		const events: AssistantMessageEvent[] = [];
+		const stream = {
+			push(event: AssistantMessageEvent) {
+				events.push(event);
+			},
+		} as unknown as AssistantMessageEventStream;
+		const pending = Promise.withResolvers<"done">();
+
+		vi.useFakeTimers();
+		try {
+			const resultPromise = awaitWithCursorExecKeepalive(pending.promise, {
+				output,
+				stream,
+				toolCallId: "call-1",
+				intervalMs: 10,
+			});
+			vi.advanceTimersByTime(30);
+			expect(events).toHaveLength(3);
+			expect(events.every(event => event.type === "toolcall_delta" && event.delta === "")).toBe(true);
+
+			pending.resolve("done");
+			expect(await resultPromise).toBe("done");
+
+			vi.advanceTimersByTime(30);
+			expect(events).toHaveLength(3);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
 describe("Cursor resolveExecHandler execHandlers binding", () => {
 	it("invokes handler with correct this when passed as bound method", async () => {
 		const sentinel = { tag: "bound-correctly" };

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -166,6 +166,39 @@ describe("Cursor exec stream keepalive", () => {
 		}
 	});
 
+	it("keeps emitting mcp keepalives after the tool-call block was finalized", () => {
+		// Cursor emits `toolCallCompleted` for MCP tool calls, so by the time
+		// `execServerMessage.mcpArgs` arrives, `state.currentToolCall` is null.
+		// The keepalive helper must still resolve the finalized block by id so
+		// the local MCP handler wait keeps producing progress events.
+		const output: AssistantMessage = {
+			...cursorExecPartialMessage,
+			content: [
+				...cursorExecPartialMessage.content.map(content =>
+					content.type === "toolCall" && content.id === "call-1" ? { ...content, name: "mcp:query" } : content,
+				),
+				{ type: "text", text: "thinking..." },
+			],
+		};
+		const events: AssistantMessageEvent[] = [];
+		const stream = {
+			push(event: AssistantMessageEvent) {
+				events.push(event);
+			},
+		} as unknown as AssistantMessageEventStream;
+
+		pushCursorExecStreamKeepalive(output, stream, "call-1");
+
+		expect(events).toEqual([
+			{
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: "",
+				partial: output,
+			},
+		]);
+	});
+
 	it("clamps the keepalive cadence below the effective idle budget", () => {
 		// 30s default is fine for the 120s watchdog but misses a caller who
 		// tunes streamIdleTimeoutMs down to 20_000 or PI_STREAM_IDLE_TIMEOUT_MS

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -4,6 +4,7 @@ import {
 	buildCursorHistoryForTest,
 	buildCursorSystemPromptJsons,
 	pushCursorExecStreamKeepalive,
+	resolveCursorExecKeepaliveIntervalMs,
 	resolveExecHandler,
 	streamCursor,
 } from "@oh-my-pi/pi-ai/providers/cursor";
@@ -163,6 +164,22 @@ describe("Cursor exec stream keepalive", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("clamps the keepalive cadence below the effective idle budget", () => {
+		// 30s default is fine for the 120s watchdog but misses a caller who
+		// tunes streamIdleTimeoutMs down to 20_000 or PI_STREAM_IDLE_TIMEOUT_MS
+		// to 8_000 — the exec handler would abort before the first keepalive.
+		expect(resolveCursorExecKeepaliveIntervalMs(120_000)).toBe(30_000);
+		expect(resolveCursorExecKeepaliveIntervalMs(20_000)).toBe(10_000);
+		expect(resolveCursorExecKeepaliveIntervalMs(8_000)).toBe(4_000);
+		// Never drop below a 1s floor — a super-tight budget still gets a
+		// visible progress event before the deadline.
+		expect(resolveCursorExecKeepaliveIntervalMs(500)).toBe(1_000);
+		// Watchdog disabled or unset: fall back to the max cadence so the
+		// transcript still shows periodic progress.
+		expect(resolveCursorExecKeepaliveIntervalMs(undefined)).toBe(30_000);
+		expect(resolveCursorExecKeepaliveIntervalMs(0)).toBe(30_000);
 	});
 });
 describe("Cursor resolveExecHandler execHandlers binding", () => {

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -180,13 +180,7 @@ describe("register-builtins lazy streams", () => {
 		expect(result.errorMessage).toBe("Request was aborted");
 	});
 
-	it("does not race a generic idle watchdog against streamCursor (issue #4593)", async () => {
-		// Cursor's exec-channel round-trip legitimately yields no
-		// AssistantMessageEvent while OMP runs a local tool for the model.
-		// The provider owns h2 heartbeats + trailers, so the lazy wrapper
-		// MUST NOT enforce iterateWithIdleTimeout here — otherwise any local
-		// tool that runs >120s trips a spurious "Provider stream stalled
-		// while waiting for the next event" mid-turn.
+	it("keeps the generic idle watchdog active for silent streamCursor stalls", async () => {
 		const cursorModel = buildModel({
 			id: "mock-cursor",
 			name: "Mock Cursor",
@@ -216,21 +210,21 @@ describe("register-builtins lazy streams", () => {
 			stopReason: "stop",
 			timestamp: Date.now(),
 		};
-		const finalMessage: AssistantMessage = { ...partialMessage };
 
 		let providerSignal: AbortSignal | undefined;
-		const releaseStall = Promise.withResolvers<void>();
 		const source = {
 			async *[Symbol.asyncIterator]() {
 				yield { type: "start", partial: partialMessage } as const;
-				// Model back-and-forth silence: mirrors Cursor's exec-channel
-				// round-trip where no upstream event arrives until the local
-				// tool finishes. If the marker regressed and the wrapper
-				// re-armed iterateWithIdleTimeout, the 10ms fake-timer advance
-				// below would fire onIdle and abort providerSignal.
-				await releaseStall.promise;
+				yield { type: "text_delta", contentIndex: 0, delta: "hello", partial: partialMessage } as const;
+				const stalled = Promise.withResolvers<never>();
+				if (providerSignal?.aborted) {
+					stalled.reject(new Error("Request was aborted"));
+				}
+				providerSignal?.addEventListener("abort", () => stalled.reject(new Error("Request was aborted")), {
+					once: true,
+				});
+				await stalled.promise;
 			},
-			result: async () => finalMessage,
 		} as unknown as AssistantMessageEventStream;
 
 		setCursorProviderModule({
@@ -244,28 +238,18 @@ describe("register-builtins lazy streams", () => {
 		try {
 			const stream = streamCursor(cursorModel, baseContext, {
 				apiKey: "test",
-				// Aggressive floor: with PROVIDER_HANDLED_STREAM_TIMEOUTS the
-				// wrapper coerces idleTimeoutMs → undefined and never arms a
-				// timer. Without the marker, this would fire at 10ms and
-				// abort providerSignal with a stalled-stream error.
 				streamIdleTimeoutMs: 10,
 			});
+			const resultPromise = stream.result();
 
-			// Drain microtasks so the wrapper attaches its iterator and — if
-			// the marker regressed — would have armed its idle timer.
 			for (let i = 0; i < 20; i++) await Promise.resolve();
-
-			// Advance well past the 10ms floor. Marker present → no timer to
-			// fire; marker absent → onIdle fires, abortLocally aborts.
 			vi.advanceTimersByTime(10_000);
 			for (let i = 0; i < 20; i++) await Promise.resolve();
 
-			expect(providerSignal?.aborted).toBe(false);
-
-			releaseStall.resolve();
-			const result = await stream.result();
-			expect(result.stopReason).toBe("stop");
-			expect(result.errorMessage).toBeUndefined();
+			const result = await resultPromise;
+			expect(providerSignal?.aborted).toBe(true);
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toBe("Provider stream stalled while waiting for the next event");
 		} finally {
 			vi.useRealTimers();
 		}

--- a/packages/ai/test/register-builtins.test.ts
+++ b/packages/ai/test/register-builtins.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "bun:test";
-import { setBedrockProviderModule, streamBedrock } from "@oh-my-pi/pi-ai/providers/register-builtins";
+import { describe, expect, it, vi } from "bun:test";
+import {
+	setBedrockProviderModule,
+	setCursorProviderModule,
+	streamBedrock,
+	streamCursor,
+} from "@oh-my-pi/pi-ai/providers/register-builtins";
 import type { AssistantMessage, Context, Model } from "@oh-my-pi/pi-ai/types";
 import type { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -173,5 +178,96 @@ describe("register-builtins lazy streams", () => {
 		}
 		expect(result.stopReason).toBe("aborted");
 		expect(result.errorMessage).toBe("Request was aborted");
+	});
+
+	it("does not race a generic idle watchdog against streamCursor (issue #4593)", async () => {
+		// Cursor's exec-channel round-trip legitimately yields no
+		// AssistantMessageEvent while OMP runs a local tool for the model.
+		// The provider owns h2 heartbeats + trailers, so the lazy wrapper
+		// MUST NOT enforce iterateWithIdleTimeout here — otherwise any local
+		// tool that runs >120s trips a spurious "Provider stream stalled
+		// while waiting for the next event" mid-turn.
+		const cursorModel = buildModel({
+			id: "mock-cursor",
+			name: "Mock Cursor",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "https://example.invalid",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 8192,
+			maxTokens: 2048,
+		});
+		const partialMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "ok" }],
+			api: "cursor-agent",
+			provider: "cursor",
+			model: "mock-cursor",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		const finalMessage: AssistantMessage = { ...partialMessage };
+
+		let providerSignal: AbortSignal | undefined;
+		const releaseStall = Promise.withResolvers<void>();
+		const source = {
+			async *[Symbol.asyncIterator]() {
+				yield { type: "start", partial: partialMessage } as const;
+				// Model back-and-forth silence: mirrors Cursor's exec-channel
+				// round-trip where no upstream event arrives until the local
+				// tool finishes. If the marker regressed and the wrapper
+				// re-armed iterateWithIdleTimeout, the 10ms fake-timer advance
+				// below would fire onIdle and abort providerSignal.
+				await releaseStall.promise;
+			},
+			result: async () => finalMessage,
+		} as unknown as AssistantMessageEventStream;
+
+		setCursorProviderModule({
+			streamCursor: (_model, _context, options) => {
+				providerSignal = options.signal;
+				return source;
+			},
+		});
+
+		vi.useFakeTimers();
+		try {
+			const stream = streamCursor(cursorModel, baseContext, {
+				apiKey: "test",
+				// Aggressive floor: with PROVIDER_HANDLED_STREAM_TIMEOUTS the
+				// wrapper coerces idleTimeoutMs → undefined and never arms a
+				// timer. Without the marker, this would fire at 10ms and
+				// abort providerSignal with a stalled-stream error.
+				streamIdleTimeoutMs: 10,
+			});
+
+			// Drain microtasks so the wrapper attaches its iterator and — if
+			// the marker regressed — would have armed its idle timer.
+			for (let i = 0; i < 20; i++) await Promise.resolve();
+
+			// Advance well past the 10ms floor. Marker present → no timer to
+			// fire; marker absent → onIdle fires, abortLocally aborts.
+			vi.advanceTimersByTime(10_000);
+			for (let i = 0; i < 20; i++) await Promise.resolve();
+
+			expect(providerSignal?.aborted).toBe(false);
+
+			releaseStall.resolve();
+			const result = await stream.result();
+			expect(result.stopReason).toBe("stop");
+			expect(result.errorMessage).toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });


### PR DESCRIPTION
## Repro

Windows/Cursor session (composer-2.5-fast, OMP 16.3.6) aborts mid-turn with `Provider stream stalled while waiting for the next event`. The reporter's own workaround (`PI_STREAM_IDLE_TIMEOUT_MS=600000`) points at the generic lazy stream watchdog. Trigger: any local tool (long bash, LSP indexing, big grep) that Cursor drives through its exec channel and takes longer than the default 120 s idle floor.

The stall is not a socket or protocol failure — `sendHeartbeat` writes a `clientHeartbeat` frame every 5 s (`packages/ai/src/providers/cursor.ts:532`), `trailers` / `error` / `end` handlers are wired (`:542-572`), and the caller `signal` is honored (`:574-581`). Nothing about the transport is idle.

## Cause

`packages/ai/src/providers/register-builtins.ts:471` registered `streamCursor` **without** `PROVIDER_HANDLED_STREAM_TIMEOUTS`:

```ts
export const streamCursor = createLazyStream(loadCursorProviderModule);
```

So `forwardStream` (`:225-279`) wrapped Cursor's upstream `AsyncIterable<AssistantMessageEvent>` with `iterateWithIdleTimeout` at the default 120 s steady-state floor. During a Cursor exec-channel round-trip the server sends `shellArgs`/`readArgs`/`grepArgs`/… on the same h2 stream, OMP runs the local tool via `CursorExecHandlers`, `sendExecClientMessage` writes the result back — and no `AssistantMessageEvent` is yielded to the outer iterable during that window. A local tool that legitimately runs >120 s trips `onIdle` → `abortTracker.abortLocally(new StreamTimeoutError(LAZY_STREAM_IDLE_TIMEOUT_ERROR))`, and the wrapper surfaces the `"Provider stream stalled while waiting for the next event"` error even though the transport is healthy.

Peers with the same transport-owning shape (`anthropic-messages`, `azure-openai-responses`, `openai-codex-responses`, `openai-completions`, `openai-responses`) all pass `PROVIDER_HANDLED_STREAM_TIMEOUTS` for exactly this reason — Cursor was the outlier.

## Fix

- `packages/ai/src/providers/register-builtins.ts`: register `streamCursor` with `PROVIDER_HANDLED_STREAM_TIMEOUTS` so `forwardStream` sets `idleTimeoutMs = undefined` / `firstItemTimeoutMs = 0` and never arms `iterateWithIdleTimeout` for the Cursor code path. Real stalls still terminate through Cursor's own transport (h2 heartbeat + `trailers`/`error`/`end`, caller `signal`).
- `packages/ai/src/providers/register-builtins.ts`: add `setCursorProviderModule` and route `loadCursorProviderModule` through the override, mirroring the existing bedrock seam. Lets the test drive `streamCursor` without booting the real Cursor module.
- `packages/ai/test/register-builtins.test.ts`: add a regression test that starts the cursor stream under `vi.useFakeTimers`, advances 10 s past a `streamIdleTimeoutMs: 10` floor, and asserts `providerSignal.aborted === false` and `stream.result()` resolves cleanly. Deterministic (no real sleeps): if the marker regressed, the wrapper would have armed a timer and aborted at 10 ms.
- `packages/ai/CHANGELOG.md`: `[Unreleased]` → `### Fixed` entry.

Explicitly out of scope:

- **Symptom B (eval kernel 30 s default)** — OMP tool policy, not a stall bug. The reporter's own notes frame it as a documented `timeout=` knob, not a fix request.
- **Symptom C (grep empty pattern)** — tracked in #4576.

The reporter's fork (`fafae0c44`, https://github.com/dragonbaba/oh-my-pi/tree/fix/cursor-provider-4574) took a different route: bump the lazy floor to 600 s and inject 30 s `toolcall_delta` keepalives from the exec handlers. That workaround masks the mismatch by synthesizing "progress" the provider never emitted; the fix here removes the mismatch instead, so no synthetic events are needed and the outer stream contract stays unchanged.

## Verification

```
$ cd packages/ai && bun test test/register-builtins.test.ts \
    test/cursor-exec-handlers.test.ts test/cursor-streaming-args.test.ts \
    test/stream-timeout-defaults.test.ts
 55 pass
 0 fail
 110 expect() calls
```

New test `does not race a generic idle watchdog against streamCursor (issue #4593)` covers the marker's observable contract: under `vi.useFakeTimers`, `vi.advanceTimersByTime(10_000)` past a `streamIdleTimeoutMs: 10` floor leaves `providerSignal.aborted === false` and the source resolves normally.

Fixes #4593
