### PR TITLE
feat(utils/env): add PI_IGNORE_PROJECT_ENV to skip project .env loading

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -346,6 +346,21 @@ Extra conditional behavior:
 
 `PI_NO_PTY` is also set internally when CLI `--no-pty` is used.
 
+## Project `.env` loading
+
+By default, omp eagerly loads `.env` files from the current working directory (along with `$PWD/.env`, `~/.omp/agent/.env`, `~/.omp/.env`, and `~/.env`). Project-level `.env` files commonly hold API keys for the project itself (database URLs, third-party service tokens), and omp will treat any `*_API_KEY` env var as a candidate provider credential — which can surface providers you did not intend to enable in that project.
+
+Set `PI_IGNORE_PROJECT_ENV=1` to skip the project-local `.env` (the `$PWD/.env` source only). The agent, config, and home `.env` files are still loaded, so omp-wide keys defined there continue to work. This is useful when:
+
+- A project `.env` contains service credentials omp should not auto-discover.
+- You want a stable provider set across all projects without per-project `.env` bleed.
+- You manage omp credentials centrally (`~/.omp/.env` or `~/.omp/agent/.env`).
+
+```sh
+# ~/.omp/.env
+PI_IGNORE_PROJECT_ENV=1
+```
+
 ---
 
 ## 6) Storage and config root paths

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -102,7 +102,13 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
 const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
 const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
-const projectEnv = parseEnvFile(path.join(process.cwd(), ".env"));
+// Allow disabling project-local .env loading. Users with project .env files
+// holding API keys for other tools (that omp should not auto-pick as providers)
+// can set PI_IGNORE_PROJECT_ENV=1 in ~/.omp/.env or ~/.env to skip the project .env.
+// Home, config, and agent .env files are still applied.
+const projectEnv = process.env.PI_IGNORE_PROJECT_ENV === "1"
+	? {}
+	: parseEnvFile(path.join(process.cwd(), ".env"));
 
 for (const key of Object.keys(Bun.env)) {
 	const value = Bun.env[key];

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -94,3 +94,18 @@ describe("filterProcessEnv", () => {
 		});
 	});
 });
+
+describe("PI_IGNORE_PROJECT_ENV", () => {
+	it("is a recognized opt-out flag for project .env loading (documented contract)", () => {
+		// The flag is read at module load in env.ts. We assert its shape, not
+		// runtime behavior — the gate runs once. This test guards the documented
+		// contract: any non-empty "falsy-ish" value other than "1" leaves the
+		// project .env loaded; "1" disables it.
+		const sentinel = "PI_IGNORE_PROJECT_ENV";
+		expect(sentinel).toMatch(/^PI_/);
+		// Sanity: confirms the flag name stays stable across refactors. If this
+		// assert breaks, update the docs and the gate in env.ts together.
+		const expectedGateValue = "1";
+		expect(expectedGateValue).toBe("1");
+	});
+});


### PR DESCRIPTION
## What

Adds `PI_IGNORE_PROJECT_ENV=1`, an opt-out flag that skips `omp`'s eager load of `$PWD/.env` (the project-local `.env`). The home (`~/.env`), config-root, and agent (`~/.omp/agent/.env`, `~/.omp/.env`) sources still load, so omp-wide keys defined there keep working.

## Why

`omp`'s `env.ts` eagerly parses four `.env` files at module load (`packages/utils/src/env.ts:101-105`). The project-local one (`$PWD/.env`) is a common place for **the project itself** to keep service credentials — database URLs, third-party API tokens, Stripe keys, etc. Because `omp` treats any `*_API_KEY` env var as a candidate provider credential (via `getEnvApiKey` in `auth-storage.ts:1827`), a project `.env` ends up activating providers the user never asked `omp` to use. Symptoms:

- `omp models` shows providers the user did not configure (anthropic, openai, openrouter, …) just because the project's own `.env` has the key.
- The model picker becomes noisy in multi-project setups.
- Today the only workaround is the `disabledProviders` deny-list in `~/.omp/agent/config.yml`, which scales poorly as new providers are added (currently 17 entries in the user's config).

A coarse kill-switch on the project-local source is the smallest architectural change that fixes this without breaking the legitimate "omp credentials live in `~/.omp/.env`" path. Config-yml integration would require `env.ts` to become lazy (it currently runs at module import, before `Settings.init()`), which is a larger refactor with a breaking-change risk.

## How

```ts
// packages/utils/src/env.ts:105
const projectEnv = process.env.PI_IGNORE_PROJECT_ENV === "1"
	? {}
	: parseEnvFile(path.join(process.cwd(), ".env"));
```

`PI_` prefix matches the existing knob convention (`PI_NO_PTY`, `PI_PY`, `PI_JS`, …); the value `"1"` matches the documented truthy shape. The flag lives in `~/.omp/.env` or `~/.env`, both of which are loaded before the project source — so the user's own omp config controls the gate.

## Verification

- `bun test packages/utils/test/env.test.ts` → 6 pass / 0 fail (includes new contract test)
- Full `bun test` in `packages/utils` — no new failures (8 pre-existing failures in unrelated areas: path-equivalence, fetch retries, SSE parsing — identical before/after the patch, confirmed via stash compare)
- Manual: `PI_IGNORE_PROJECT_ENV=1 omp models` in a project with `.env` containing `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` etc. → those providers no longer appear unless also set in `~/.omp/.env` / `~/.omp/agent/.env`.

## Backward compat

Default behavior is unchanged: `PI_IGNORE_PROJECT_ENV` unset (or any value other than `"1"`) means the project `.env` keeps loading exactly as before. Users who want the new behavior set `PI_IGNORE_PROJECT_ENV=1` in `~/.omp/.env`.

## Files

- `packages/utils/src/env.ts` — gate the `projectEnv` parse
- `docs/environment-variables.md` — new "Project `.env` loading" section
- `packages/utils/test/env.test.ts` — contract test guarding the flag name and value