### PR TITLE
fix(ai): drop hidden-empty Responses replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot OpenAI Responses replay persisting hidden-empty assistant turns as native history, preventing reasoning-only empty completions from poisoning later requests with stale assistant summaries. ([#4597](https://github.com/can1357/oh-my-pi/issues/4597))
+
 ## [16.3.6] - 2026-07-04
 
 ### Added

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -43,6 +43,7 @@ import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
 	normalizeSystemPrompts,
+	sanitizeOpenAIResponsesAssistantFallbackItemsForReplay,
 	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 } from "../utils";
 import { clearStreamingPartialJson, kStreamingLastParseLen, kStreamingPartialJson } from "../utils/block-symbols";
@@ -3202,6 +3203,7 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 					? getOpenAIResponsesHistoryPayload(assistantMsg.providerPayload, model.provider, assistantMsg.provider)
 					: undefined;
 			const historyItems = providerPayload?.items as Array<Record<string, unknown>> | undefined;
+			let suppressHiddenEmptyFallback = false;
 			if (historyItems) {
 				const sanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(historyItems);
 				if (sanitizedHistoryItems) {
@@ -3220,16 +3222,20 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 					msgIndex += 1;
 					continue;
 				}
+				suppressHiddenEmptyFallback = true;
 			}
 
-			const outputItems = convertResponsesAssistantMessage(
+			const convertedOutputItems = convertResponsesAssistantMessage(
 				msg as AssistantMessage,
 				model,
 				msgIndex,
 				knownCallIds,
-				true,
+				!suppressHiddenEmptyFallback,
 				customCallIds,
 			);
+			const outputItems = suppressHiddenEmptyFallback
+				? sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(convertedOutputItems)
+				: convertedOutputItems;
 			if (outputItems.length > 0) {
 				messages.push(...outputItems);
 			}

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -43,6 +43,7 @@ import {
 	getOpenAIResponsesHistoryItems,
 	getOpenAIResponsesHistoryPayload,
 	normalizeSystemPrompts,
+	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 } from "../utils";
 import { clearStreamingPartialJson, kStreamingLastParseLen, kStreamingPartialJson } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
@@ -3200,22 +3201,25 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 				assistantMsg.api === model.api && assistantMsg.model === model.id
 					? getOpenAIResponsesHistoryPayload(assistantMsg.providerPayload, model.provider, assistantMsg.provider)
 					: undefined;
-			const historyItems = providerPayload?.items as Array<ResponseInput[number]> | undefined;
+			const historyItems = providerPayload?.items as Array<Record<string, unknown>> | undefined;
 			if (historyItems) {
-				for (const item of historyItems) {
-					const maybe = item as { type?: string; call_id?: string };
-					if (maybe.type === "custom_tool_call" && typeof maybe.call_id === "string") {
-						customCallIds.add(maybe.call_id);
+				const sanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(historyItems);
+				if (sanitizedHistoryItems) {
+					for (const item of sanitizedHistoryItems) {
+						const maybe = item as { type?: string; call_id?: string };
+						if (maybe.type === "custom_tool_call" && typeof maybe.call_id === "string") {
+							customCallIds.add(maybe.call_id);
+						}
 					}
+					if (providerPayload?.dt) {
+						messages.push(...sanitizedHistoryItems);
+					} else {
+						messages.splice(0, messages.length, ...sanitizedHistoryItems);
+						// Keep customCallIds from the pre-splice state since historyItems may re-introduce them.
+					}
+					msgIndex += 1;
+					continue;
 				}
-				if (providerPayload?.dt) {
-					messages.push(...historyItems);
-				} else {
-					messages.splice(0, messages.length, ...historyItems);
-					// Keep customCallIds from the pre-splice state since historyItems may re-introduce them.
-				}
-				msgIndex += 1;
-				continue;
 			}
 
 			const outputItems = convertResponsesAssistantMessage(

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -20,7 +20,7 @@ import {
 	createOpenAIResponsesHistoryPayload,
 	normalizeSystemPrompts,
 	resolveCacheRetention,
-	sanitizeOpenAIResponsesHistoryItemsForReplay,
+	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
 import { withEmptyCompletionRetry } from "../utils/empty-completion-retry";
@@ -687,22 +687,27 @@ const streamOpenAIResponsesOnce = (
 			}
 
 			output.providerPayload = createOpenAIResponsesHistoryPayload(model.provider, nativeOutputItems);
-			if (providerSessionState) providerSessionState.nativeHistoryReplayWarmed = true;
-			if (chainState) {
-				chainState.lastParams = structuredCloneJSON(activeParams);
-				if (output.responseId) {
-					chainState.lastResponseId = output.responseId;
-					chainState.lastResponseItems = sanitizeOpenAIResponsesHistoryItemsForReplay(
-						structuredCloneJSON(nativeOutputItems),
-					);
-					chainState.canAppend = true;
-					// Only a successful CHAINED completion clears the stale counter — a
-					// full-context success must not mask categorical rejection.
-					if (sentPreviousResponseId) chainState.staleFailures = 0;
-				} else {
-					// Without a response id the append baseline cannot be trusted.
-					chainState.canAppend = false;
+			const replayableResponseItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
+				structuredCloneJSON(nativeOutputItems),
+			);
+			if (replayableResponseItems) {
+				if (providerSessionState) providerSessionState.nativeHistoryReplayWarmed = true;
+				if (chainState) {
+					chainState.lastParams = structuredCloneJSON(activeParams);
+					if (output.responseId) {
+						chainState.lastResponseId = output.responseId;
+						chainState.lastResponseItems = replayableResponseItems;
+						chainState.canAppend = true;
+						// Only a successful CHAINED completion clears the stale counter — a
+						// full-context success must not mask categorical rejection.
+						if (sentPreviousResponseId) chainState.staleFailures = 0;
+					} else {
+						// Without a response id the append baseline cannot be trusted.
+						chainState.canAppend = false;
+					}
 				}
+			} else if (chainState) {
+				resetOpenAIResponsesChainState(chainState);
 			}
 
 			output.duration = performance.now() - startTime;

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -57,6 +57,7 @@ import {
 	normalizeResponsesToolCallId,
 	normalizeSystemPrompts,
 	resolveCacheRetention,
+	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 	sanitizeOpenAIResponsesHistoryItemsForReplay,
 } from "../utils";
 import {
@@ -1417,16 +1418,20 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 					: undefined;
 			const historyItems = providerPayload?.items;
 			if (historyItems) {
-				const sanitizedHistoryItems = sanitizeOpenAIResponsesHistoryItemsForReplay(filterReasoning(historyItems));
-				if (providerPayload?.dt) {
-					messages.push(...sanitizedHistoryItems);
-				} else {
-					messages.splice(0, messages.length, ...sanitizedHistoryItems);
+				const sanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
+					filterReasoning(historyItems),
+				);
+				if (sanitizedHistoryItems) {
+					if (providerPayload?.dt) {
+						messages.push(...sanitizedHistoryItems);
+					} else {
+						messages.splice(0, messages.length, ...sanitizedHistoryItems);
+					}
+					knownCallIds = collectKnownCallIds(messages);
+					for (const id of collectCustomCallIds(messages)) customCallIds.add(id);
+					msgIndex++;
+					continue;
 				}
-				knownCallIds = collectKnownCallIds(messages);
-				for (const id of collectCustomCallIds(messages)) customCallIds.add(id);
-				msgIndex++;
-				continue;
 			}
 
 			const outputItems = convertResponsesAssistantMessage(

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -57,6 +57,7 @@ import {
 	normalizeResponsesToolCallId,
 	normalizeSystemPrompts,
 	resolveCacheRetention,
+	sanitizeOpenAIResponsesAssistantFallbackItemsForReplay,
 	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 	sanitizeOpenAIResponsesHistoryItemsForReplay,
 } from "../utils";
@@ -1417,6 +1418,7 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 						)
 					: undefined;
 			const historyItems = providerPayload?.items;
+			let suppressHiddenEmptyFallback = false;
 			if (historyItems) {
 				const sanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
 					filterReasoning(historyItems),
@@ -1432,17 +1434,21 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 					msgIndex++;
 					continue;
 				}
+				suppressHiddenEmptyFallback = true;
 			}
 
-			const outputItems = convertResponsesAssistantMessage(
+			const convertedOutputItems = convertResponsesAssistantMessage(
 				assistantMsg,
 				options.model,
 				msgIndex,
 				knownCallIds,
-				includeThinkingSignatures,
+				suppressHiddenEmptyFallback ? false : includeThinkingSignatures,
 				customCallIds,
 				options.preserveAssistantMessageIds,
 			);
+			const outputItems = suppressHiddenEmptyFallback
+				? sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(convertedOutputItems)
+				: convertedOutputItems;
 			if (outputItems.length === 0) continue;
 			messages.push(...outputItems);
 		} else if (msg.role === "toolResult") {

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1407,23 +1407,26 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 			});
 		} else if (msg.role === "assistant") {
 			const assistantMsg = msg as AssistantMessage;
+			// Providers replay stale native items even when the current request has
+			// disabled native replay (cold session state, filter policy). Consult
+			// the payload sanitizer directly so hidden-empty turns are recognized
+			// on both the warm and cold paths.
 			const providerPayload =
-				options.nativeHistory?.replay &&
-				assistantMsg.api === options.model.api &&
-				assistantMsg.model === options.model.id
+				assistantMsg.api === options.model.api && assistantMsg.model === options.model.id
 					? getOpenAIResponsesHistoryPayload(
 							assistantMsg.providerPayload,
 							options.model.provider,
 							assistantMsg.provider,
 						)
 					: undefined;
+			const nativeReplayEnabled = options.nativeHistory?.replay === true;
 			const historyItems = providerPayload?.items;
 			let suppressHiddenEmptyFallback = false;
 			if (historyItems) {
 				const sanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
 					filterReasoning(historyItems),
 				);
-				if (sanitizedHistoryItems) {
+				if (nativeReplayEnabled && sanitizedHistoryItems) {
 					if (providerPayload?.dt) {
 						messages.push(...sanitizedHistoryItems);
 					} else {
@@ -1434,7 +1437,7 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 					msgIndex++;
 					continue;
 				}
-				suppressHiddenEmptyFallback = true;
+				if (!sanitizedHistoryItems) suppressHiddenEmptyFallback = true;
 			}
 
 			const convertedOutputItems = convertResponsesAssistantMessage(

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -115,6 +115,41 @@ export function sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
 	return hasReplayableAssistantOutput ? sanitized : undefined;
 }
 
+/**
+ * Drop hidden-only fallback assistant replay after a native Responses snapshot is rejected.
+ */
+export function sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(items: ResponseInput): ResponseInput {
+	const sanitized: ResponseInput = [];
+
+	for (const item of items) {
+		if (item.type === "reasoning") continue;
+		if (item.type !== "message" || item.role !== "assistant") {
+			sanitized.push(item);
+			continue;
+		}
+
+		let hasVisibleText = false;
+		if (typeof item.content === "string") {
+			hasVisibleText = NON_WHITESPACE_RE.test(item.content);
+		} else {
+			for (const part of item.content) {
+				if (part.type === "output_text" && NON_WHITESPACE_RE.test(part.text)) {
+					hasVisibleText = true;
+					break;
+				}
+				if (part.type === "refusal" && NON_WHITESPACE_RE.test(part.refusal)) {
+					hasVisibleText = true;
+					break;
+				}
+			}
+		}
+
+		if (hasVisibleText) sanitized.push(item);
+	}
+
+	return sanitized;
+}
+
 function sanitizeOpenAIResponsesHistoryItemForReplay(
 	item: Record<string, unknown>,
 	normalizedCallIds: Map<string, string>,

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -3,6 +3,7 @@ import type { ResponseInput, ResponseInputItem } from "./providers/openai-respon
 import type { CacheRetention, OpenAIResponsesHistoryPayload, ProviderPayload } from "./types";
 
 type OpenAIResponsesReplayItem = ResponseInput[number];
+const NON_WHITESPACE_RE = /\S/;
 
 export { isRecord } from "@oh-my-pi/pi-utils";
 export function normalizeSystemPrompts(systemPrompt: readonly string[] | string | undefined | null): string[] {
@@ -70,6 +71,48 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record
 		const sanitized = sanitizeOpenAIResponsesHistoryItemForReplay(item, normalizedCallIds);
 		return sanitized ? [sanitized] : [];
 	});
+}
+
+/**
+ * Sanitize assistant-native Responses history for replay.
+ *
+ * Returns `undefined` for hidden-empty turns that only contain reasoning and an
+ * empty assistant message, allowing callers to rebuild visible transcript
+ * history instead of replaying stale native state.
+ */
+export function sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
+	items: Array<Record<string, unknown>>,
+): ResponseInput | undefined {
+	const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay(items);
+	let hasReplayableAssistantOutput = false;
+
+	for (const item of sanitized) {
+		if (item.type === "function_call" || item.type === "custom_tool_call" || item.type === "image_generation_call") {
+			hasReplayableAssistantOutput = true;
+			break;
+		}
+		if (item.type !== "message" || item.role !== "assistant") continue;
+		if (typeof item.content === "string") {
+			if (NON_WHITESPACE_RE.test(item.content)) {
+				hasReplayableAssistantOutput = true;
+				break;
+			}
+			continue;
+		}
+		for (const part of item.content) {
+			if (part.type === "output_text" && NON_WHITESPACE_RE.test(part.text)) {
+				hasReplayableAssistantOutput = true;
+				break;
+			}
+			if (part.type === "refusal" && NON_WHITESPACE_RE.test(part.refusal)) {
+				hasReplayableAssistantOutput = true;
+				break;
+			}
+		}
+		if (hasReplayableAssistantOutput) break;
+	}
+
+	return hasReplayableAssistantOutput ? sanitized : undefined;
 }
 
 function sanitizeOpenAIResponsesHistoryItemForReplay(

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -614,6 +614,48 @@ describe("OpenAI responses history payload", () => {
 		expect(containsAssistantOutputText(payload.input, "")).toBe(false);
 	});
 
+	it("does not replay GitHub Copilot hidden-empty assistant fallback on cold provider session state", async () => {
+		const hiddenEmptyNativeItems = [
+			{ type: "reasoning", encrypted_content: "enc_hidden_empty_cold" },
+			{
+				type: "message",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "", annotations: [] }],
+			},
+		];
+		const followUp = "continue after hidden empty assistant turn (cold)";
+		const context: Context = {
+			messages: [
+				{
+					...makeAssistantMessage(hiddenEmptyNativeItems, false, "github-copilot", "gpt-5.4"),
+					content: [
+						{ type: "text", text: "" },
+						{
+							type: "thinking",
+							thinking: "",
+							thinkingSignature: JSON.stringify({
+								type: "reasoning",
+								id: "rs_hidden_empty_cold_fallback",
+								encrypted_content: "enc_hidden_empty_cold_fallback",
+							}),
+						},
+					],
+				},
+				{ role: "user", content: followUp, timestamp: Date.now() },
+			],
+		};
+		const model = getBundledModel("github-copilot", "gpt-5.4") as Model<"openai-responses">;
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const payload = (await captureResponsesPayload(model, context, providerSessionState)) as {
+			input?: unknown[];
+		};
+
+		expect(containsUserInputText(payload.input, followUp)).toBe(true);
+		expect(findResponsesInputItem(payload.input, "reasoning")).toBeUndefined();
+		expect(containsAssistantOutputText(payload.input, "")).toBe(false);
+	});
+
 	it("builds up history incrementally from multiple assistant messages", async () => {
 		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
 		const payload = (await captureResponsesPayload(model, incrementalContext)) as { input?: unknown[] };

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -575,7 +575,7 @@ describe("OpenAI responses history payload", () => {
 		expect(containsAssistantOutputText(payload.input, "generic assistant that should be rebuilt")).toBe(true);
 	});
 
-	it("does not replay GitHub Copilot hidden-empty assistant native history into the next request", async () => {
+	it("does not replay GitHub Copilot hidden-empty assistant native or fallback history into the next request", async () => {
 		const hiddenEmptyNativeItems = [
 			{ type: "reasoning", encrypted_content: "enc_hidden_empty" },
 			{
@@ -590,7 +590,18 @@ describe("OpenAI responses history payload", () => {
 			messages: [
 				{
 					...makeAssistantMessage(hiddenEmptyNativeItems, false, "github-copilot", "gpt-5.4"),
-					content: [],
+					content: [
+						{ type: "text", text: "" },
+						{
+							type: "thinking",
+							thinking: "",
+							thinkingSignature: JSON.stringify({
+								type: "reasoning",
+								id: "rs_hidden_empty_fallback",
+								encrypted_content: "enc_hidden_empty_fallback",
+							}),
+						},
+					],
 				},
 				{ role: "user", content: followUp, timestamp: Date.now() },
 			],

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -575,6 +575,34 @@ describe("OpenAI responses history payload", () => {
 		expect(containsAssistantOutputText(payload.input, "generic assistant that should be rebuilt")).toBe(true);
 	});
 
+	it("does not replay GitHub Copilot hidden-empty assistant native history into the next request", async () => {
+		const hiddenEmptyNativeItems = [
+			{ type: "reasoning", encrypted_content: "enc_hidden_empty" },
+			{
+				type: "message",
+				role: "assistant",
+				status: "completed",
+				content: [{ type: "output_text", text: "", annotations: [] }],
+			},
+		];
+		const followUp = "continue after hidden empty assistant turn";
+		const context: Context = {
+			messages: [
+				{
+					...makeAssistantMessage(hiddenEmptyNativeItems, false, "github-copilot", "gpt-5.4"),
+					content: [],
+				},
+				{ role: "user", content: followUp, timestamp: Date.now() },
+			],
+		};
+		const model = getBundledModel("github-copilot", "gpt-5.4") as Model<"openai-responses">;
+		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
+
+		expect(containsUserInputText(payload.input, followUp)).toBe(true);
+		expect(findResponsesInputItem(payload.input, "reasoning")).toBeUndefined();
+		expect(containsAssistantOutputText(payload.input, "")).toBe(false);
+	});
+
 	it("builds up history incrementally from multiple assistant messages", async () => {
 		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
 		const payload = (await captureResponsesPayload(model, incrementalContext)) as { input?: unknown[] };


### PR DESCRIPTION
## Repro
A focused GitHub Copilot `openai-responses` payload regression reproduces the bug with `bun test packages/ai/test/openai-responses-history-payload.test.ts -t "does not replay GitHub Copilot hidden-empty assistant native history into the next request"`: before the fix, the next request payload included the prior hidden-empty assistant turn's native `reasoning` item and completed assistant `message` with empty `output_text` instead of only grounding on the follow-up user prompt.

## Cause
`packages/ai/src/providers/openai-shared.ts` replayed same-model assistant `providerPayload.items` whenever native history replay was enabled, and `packages/ai/src/providers/openai-responses.ts` warmed replay/chaining for every successful Responses turn. `packages/ai/src/utils.ts` sanitized IDs and tool call IDs but did not distinguish replayable assistant output from hidden reasoning plus empty assistant messages, so successful `content: []` Copilot turns could be persisted and re-injected as native assistant history.

## Fix
- Added assistant-native Responses replay sanitization in `packages/ai/src/utils.ts` that rejects payloads with no replayable assistant output while preserving normal message, tool-call, custom-tool, and image-generation replay.
- Routed OpenAI Responses and Codex Responses assistant replay through that guard so hidden-empty provider payloads fall back to rebuilt visible transcript history instead of native replay.
- Stopped warming OpenAI Responses native replay/`previous_response_id` chain baselines for hidden-empty successful turns while still preserving the raw provider payload for observability.
- Added regression coverage for GitHub Copilot hidden-empty assistant native history in `packages/ai/test/openai-responses-history-payload.test.ts` and documented the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/openai-responses-history-payload.test.ts` passed: 25 tests, 74 assertions. `bun run check` in `packages/ai` passed. Fixes #4597