### PR TITLE
fix(tui): scope autocomplete in slash command arguments

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/rename` title arguments treating `#` prompt-action tokens as autocomplete triggers instead of literal session title text. ([#4600](https://github.com/can1357/oh-my-pi/issues/4600))
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -95,11 +95,13 @@ function getPromptActionPrefix(textBeforeCursor: string): string | null {
 }
 
 export class PromptActionAutocompleteProvider implements AutocompleteProvider {
+	#commands: SlashCommand[];
 	#baseProvider: CombinedAutocompleteProvider;
 	#actions: PromptActionDefinition[];
 	#basePath: string;
 
 	constructor(commands: SlashCommand[], basePath: string, actions: PromptActionDefinition[]) {
+		this.#commands = commands;
 		this.#baseProvider = new CombinedAutocompleteProvider(commands, basePath);
 		this.#basePath = basePath;
 		this.#actions = actions;
@@ -118,8 +120,13 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			leadingSlashStart !== null && !hasPromptTextBeforeCursorLine
 				? textBeforeCursor.slice(leadingSlashStart)
 				: null;
-		if (commandText?.includes(" ")) {
-			return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+		const spaceIndex = commandText?.indexOf(" ") ?? -1;
+		if (commandText !== null && spaceIndex !== -1) {
+			const commandName = commandText.slice(1, spaceIndex);
+			const command = this.#commands.find(cmd => cmd.name === commandName || cmd.aliases?.includes(commandName));
+			if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
+				return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+			}
 		}
 
 		const promptActionPrefix = getPromptActionPrefix(textBeforeCursor);

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -2,6 +2,7 @@ import {
 	type AutocompleteItem,
 	type AutocompleteProvider,
 	CombinedAutocompleteProvider,
+	findLeadingSlashCommandStart,
 	getKeybindings,
 	type SlashCommand,
 } from "@oh-my-pi/pi-tui";
@@ -111,6 +112,16 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
+		const leadingSlashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		const hasPromptTextBeforeCursorLine = lines.slice(0, cursorLine).some(line => (line || "").trim() !== "");
+		const commandText =
+			leadingSlashStart !== null && !hasPromptTextBeforeCursorLine
+				? textBeforeCursor.slice(leadingSlashStart)
+				: null;
+		if (commandText?.includes(" ")) {
+			return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+		}
+
 		const promptActionPrefix = getPromptActionPrefix(textBeforeCursor);
 		if (promptActionPrefix) {
 			const query = promptActionPrefix.slice(1).toLowerCase();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2437,6 +2437,7 @@ export const BUILTIN_SLASH_COMMAND_DEFS: ReadonlyArray<BuiltinSlashCommand> = BU
 	command => ({
 		name: command.name,
 		aliases: command.aliases,
+		allowArgs: command.allowArgs === true,
 		description: command.description,
 		subcommands: command.subcommands,
 		inlineHint: command.inlineHint,

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -16,6 +16,8 @@ export interface BuiltinSlashCommand {
 	name: string;
 	aliases?: string[];
 	description: string;
+	/** Whether the command consumes text after the command name. */
+	allowArgs?: boolean;
 	/** Subcommands for dropdown completion (e.g. /mcp add, /mcp list). */
 	subcommands?: SubcommandDef[];
 	/** Static inline hint when command takes a simple argument (no subcommands). */

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -113,7 +113,7 @@ describe("prompt action autocomplete", () => {
 
 	it("treats # prompt-action tokens as literal text inside slash command arguments without completions", async () => {
 		const provider = createPromptActionAutocompleteProvider({
-			commands: [{ name: "rename", description: "Rename current session" }],
+			commands: [{ name: "rename", description: "Rename current session", allowArgs: true }],
 			basePath: "/tmp",
 			keybindings: AppKeybindingsManager.inMemory(),
 			copyCurrentLine: () => {},
@@ -131,12 +131,34 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions).toBeNull();
 	});
 
+	it("returns # prompt-action completions for matched slash commands that reject arguments", async () => {
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [{ name: "settings", description: "Open settings", allowArgs: false }],
+			basePath: "/tmp",
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const line = "/settings #copy";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions?.prefix).toBe("#copy");
+		expect(suggestions?.items.map(item => item.label)).toEqual(["Copy current line", "Copy whole prompt"]);
+	});
+
 	it("returns slash command argument completions instead of # prompt actions when the command defines them", async () => {
 		const provider = createPromptActionAutocompleteProvider({
 			commands: [
 				{
 					name: "rename",
 					description: "Rename current session",
+					allowArgs: true,
 					getArgumentCompletions: argumentPrefix =>
 						argumentPrefix === "repro #copy"
 							? [{ value: "repro #copy-title", label: "Keep #copy in the title" }]

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -111,6 +111,58 @@ describe("prompt action autocomplete", () => {
 		expect(suggestions).toBeNull();
 	});
 
+	it("treats # prompt-action tokens as literal text inside slash command arguments without completions", async () => {
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [{ name: "rename", description: "Rename current session" }],
+			basePath: "/tmp",
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const line = "/rename repro #copy";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions).toBeNull();
+	});
+
+	it("returns slash command argument completions instead of # prompt actions when the command defines them", async () => {
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [
+				{
+					name: "rename",
+					description: "Rename current session",
+					getArgumentCompletions: argumentPrefix =>
+						argumentPrefix === "repro #copy"
+							? [{ value: "repro #copy-title", label: "Keep #copy in the title" }]
+							: null,
+				},
+			],
+			basePath: "/tmp",
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const line = "/rename repro #copy";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions).toEqual({
+			prefix: "repro #copy",
+			items: [{ value: "repro #copy-title", label: "Keep #copy in the title" }],
+		});
+	});
+
 	it("delegates trySyncSlashCompletion to CombinedAutocompleteProvider", () => {
 		const provider = createPromptActionAutocompleteProvider({
 			commands: [{ name: "model", description: "Switch AI model" }],

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed submitted slash-command arguments treating `@` file-reference tokens as prompt-composer autocomplete triggers when the command does not define argument completions. ([#4600](https://github.com/can1357/oh-my-pi/issues/4600))
+
 ## [16.3.6] - 2026-07-04
 
 ### Added

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -387,6 +387,70 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const currentLine = lines[cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, cursorCol);
 
+		const leadingSlashStart = findLeadingSlashCommandStart(textBeforeCursor);
+		const trailingSlashStart = findTrailingSlashCommandStart(textBeforeCursor);
+		const hasPromptTextBeforeTrailingSlash =
+			trailingSlashStart !== null &&
+			hasPromptTextBeforeSlash(lines, cursorLine, textBeforeCursor, trailingSlashStart);
+		const hasPromptTextBeforeLeadingSlash =
+			leadingSlashStart !== null && hasPromptTextBeforeSlash(lines, cursorLine, textBeforeCursor, leadingSlashStart);
+		const slashStart = hasPromptTextBeforeTrailingSlash
+			? trailingSlashStart
+			: hasPromptTextBeforeLeadingSlash
+				? null
+				: leadingSlashStart;
+		if (slashStart !== null) {
+			const commandText = textBeforeCursor.slice(slashStart);
+			const spaceIndex = commandText.indexOf(" ");
+			const isMidPromptSkillLookup = hasPromptTextBeforeTrailingSlash;
+
+			if (spaceIndex === -1) {
+				// No space yet - complete command names
+				const prefix = commandText.slice(1); // Remove the "/"
+				const lowerPrefix = prefix.toLowerCase();
+
+				const matches = isMidPromptSkillLookup
+					? buildMidPromptSkillCompletions(this.#commands, lowerPrefix)
+					: buildSlashCommandCompletions(this.#commands, lowerPrefix);
+
+				if (matches.length > 0) {
+					return {
+						items: matches,
+						// Preserve the full text-before-cursor for submitted slash
+						// commands so the editor's Enter-staleness check still applies
+						// completion for `  /sk`. Mid-prompt skill lookup keeps only
+						// the slash token because accepting it replaces the whole draft.
+						prefix: isMidPromptSkillLookup ? commandText : textBeforeCursor,
+					};
+				}
+				if (!isMidPromptSkillLookup) return null;
+				// A mid-prompt slash token with no matching skill may still be an
+				// absolute path (`see /tmp`); fall through to file-path completion.
+			} else if (!isMidPromptSkillLookup) {
+				// Submitted slash commands own their argument text. Prompt-composer
+				// completions like `@` file references must not leak into literal
+				// arguments such as `/rename <title>`.
+				const commandName = commandText.slice(1, spaceIndex); // Command without "/"
+				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
+
+				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
+				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
+					return null; // No argument completion for this command
+				}
+
+				const argumentSuggestions = await command.getArgumentCompletions(argumentText);
+				if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
+					return null;
+				}
+
+				return {
+					items: argumentSuggestions,
+					prefix: argumentText,
+				};
+			}
+			if (!isMidPromptSkillLookup) return null;
+		}
+
 		// Check for @ file reference (fuzzy search) - must be after a delimiter or at start
 		const atPrefix = this.#extractAtPrefix(textBeforeCursor);
 		if (atPrefix) {
@@ -417,62 +481,6 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				items: suggestions,
 				prefix: atPrefix,
 			};
-		}
-
-		const leadingSlashStart = findLeadingSlashCommandStart(textBeforeCursor);
-		const trailingSlashStart = findTrailingSlashCommandStart(textBeforeCursor);
-		const hasPromptTextBeforeTrailingSlash =
-			trailingSlashStart !== null &&
-			hasPromptTextBeforeSlash(lines, cursorLine, textBeforeCursor, trailingSlashStart);
-		const slashStart = hasPromptTextBeforeTrailingSlash ? trailingSlashStart : leadingSlashStart;
-		if (slashStart !== null) {
-			const commandText = textBeforeCursor.slice(slashStart);
-			const spaceIndex = commandText.indexOf(" ");
-			const isMidPromptSkillLookup = hasPromptTextBeforeTrailingSlash;
-
-			if (spaceIndex === -1) {
-				// No space yet - complete command names
-				const prefix = commandText.slice(1); // Remove the "/"
-				const lowerPrefix = prefix.toLowerCase();
-
-				const matches = isMidPromptSkillLookup
-					? buildMidPromptSkillCompletions(this.#commands, lowerPrefix)
-					: buildSlashCommandCompletions(this.#commands, lowerPrefix);
-
-				if (matches.length > 0) {
-					return {
-						items: matches,
-						// Preserve the full text-before-cursor for submitted slash
-						// commands so the editor's Enter-staleness check still applies
-						// completion for `  /sk`. Mid-prompt skill lookup keeps only
-						// the slash token because accepting it replaces the whole draft.
-						prefix: isMidPromptSkillLookup ? commandText : textBeforeCursor,
-					};
-				}
-				if (!isMidPromptSkillLookup) return null;
-				// A mid-prompt slash token with no matching skill may still be an
-				// absolute path (`see /tmp`); fall through to file-path completion.
-			} else if (!isMidPromptSkillLookup) {
-				// Space found - complete command arguments
-				const commandName = commandText.slice(1, spaceIndex); // Command without "/"
-				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
-
-				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
-				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
-					return null; // No argument completion for this command
-				}
-
-				const argumentSuggestions = await command.getArgumentCompletions(argumentText);
-				if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
-					return null;
-				}
-
-				return {
-					items: argumentSuggestions,
-					prefix: argumentText,
-				};
-			}
-			if (!isMidPromptSkillLookup) return null;
 		}
 
 		// Check for file paths - triggered by Tab or if we detect a path pattern

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -182,6 +182,8 @@ export interface SlashCommand {
 	aliases?: string[];
 	description?: string;
 	argumentHint?: string;
+	/** Whether the command consumes argument text after the command name. False means the full input stays normal prompt text once args are present. */
+	allowArgs?: boolean;
 	/** Dynamic display-only description for slash-command autocomplete. Must be synchronous and side-effect free. */
 	getAutocompleteDescription?: () => string | undefined;
 	// Function to get argument completions for this command
@@ -427,28 +429,30 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// A mid-prompt slash token with no matching skill may still be an
 				// absolute path (`see /tmp`); fall through to file-path completion.
 			} else if (!isMidPromptSkillLookup) {
-				// Submitted slash commands own their argument text. Prompt-composer
-				// completions like `@` file references must not leak into literal
-				// arguments such as `/rename <title>`.
+				// Submitted slash commands own their argument text only when the
+				// matched command accepts args. No-arg slash-looking prompts such
+				// as `/settings @file` still fall through to prompt-composer
+				// completions because submit treats them as normal prompt text.
 				const commandName = commandText.slice(1, spaceIndex); // Command without "/"
 				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
 				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
-				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
-					return null; // No argument completion for this command
-				}
+				if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
+					if (!("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
+						return null; // No argument completion for this command
+					}
 
-				const argumentSuggestions = await command.getArgumentCompletions(argumentText);
-				if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
-					return null;
-				}
+					const argumentSuggestions = await command.getArgumentCompletions(argumentText);
+					if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
+						return null;
+					}
 
-				return {
-					items: argumentSuggestions,
-					prefix: argumentText,
-				};
+					return {
+						items: argumentSuggestions,
+						prefix: argumentText,
+					};
+				}
 			}
-			if (!isMidPromptSkillLookup) return null;
 		}
 
 		// Check for @ file reference (fuzzy search) - must be after a delimiter or at start

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -124,13 +124,31 @@ describe("CombinedAutocompleteProvider", () => {
 			try {
 				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
 				const provider = new CombinedAutocompleteProvider(
-					[{ name: "rename", description: "Rename current session" }],
+					[{ name: "rename", description: "Rename current session", allowArgs: true }],
 					baseDir,
 				);
 				const line = "/rename repro @";
 				const result = await provider.getSuggestions([line], 0, line.length);
 
 				expect(result).toBeNull();
+			} finally {
+				fs.rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns @ file-reference completions for matched slash commands that reject arguments", async () => {
+			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-settings-args-"));
+			try {
+				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
+				const provider = new CombinedAutocompleteProvider(
+					[{ name: "settings", description: "Open settings", allowArgs: false }],
+					baseDir,
+				);
+				const line = "/settings @";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result?.prefix).toBe("@");
+				expect(result?.items.map(item => item.value)).toContain("@copy-target.ts");
 			} finally {
 				fs.rmSync(baseDir, { recursive: true, force: true });
 			}
@@ -145,6 +163,7 @@ describe("CombinedAutocompleteProvider", () => {
 						{
 							name: "rename",
 							description: "Rename current session",
+							allowArgs: true,
 							getArgumentCompletions: argumentPrefix =>
 								argumentPrefix === "repro @"
 									? [{ value: "repro @literal", label: "Keep @ in the title" }]

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -118,6 +118,52 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result?.prefix).toBe("/tmp");
 			expect(result?.items.map(item => item.value)).toContain("/tmp/");
 		});
+
+		it("treats @ file-reference tokens as literal text inside slash command arguments without completions", async () => {
+			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-rename-args-"));
+			try {
+				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
+				const provider = new CombinedAutocompleteProvider(
+					[{ name: "rename", description: "Rename current session" }],
+					baseDir,
+				);
+				const line = "/rename repro @";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result).toBeNull();
+			} finally {
+				fs.rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns slash command argument completions instead of @ file references when the command defines them", async () => {
+			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-rename-args-"));
+			try {
+				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
+				const provider = new CombinedAutocompleteProvider(
+					[
+						{
+							name: "rename",
+							description: "Rename current session",
+							getArgumentCompletions: argumentPrefix =>
+								argumentPrefix === "repro @"
+									? [{ value: "repro @literal", label: "Keep @ in the title" }]
+									: null,
+						},
+					],
+					baseDir,
+				);
+				const line = "/rename repro @";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result).toEqual({
+					prefix: "repro @",
+					items: [{ value: "repro @literal", label: "Keep @ in the title" }],
+				});
+			} finally {
+				fs.rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
 	});
 	describe("applyCompletion", () => {
 		it("replaces the live slash command prefix when rendered suggestions are stale", () => {


### PR DESCRIPTION
## Repro
`/rename` is entered through the same prompt editor as normal prompt composition, so the existing provider tests reproduce the leak: `bun test packages/coding-agent/test/prompt-action-autocomplete.test.ts` failed before the fix because `/rename repro #copy` returned prompt-action items with prefix `#copy`; `bun test packages/tui/test/autocomplete.test.ts` failed before the fix because `/rename repro @` returned a file-reference item with prefix `@`.

## Cause
`PromptActionAutocompleteProvider.getSuggestions` in `packages/coding-agent/src/modes/prompt-action-autocomplete.ts` checked `#` prompt actions before delegating to slash-command argument completion, and `CombinedAutocompleteProvider.getSuggestions` in `packages/tui/src/autocomplete.ts` checked `@` file references before submitted slash-command argument handling. Commands such as `/rename` have `allowArgs: true` but no `getArgumentCompletions`, so title text was still treated as prompt-composer autocomplete input.

## Fix
- Short-circuit prompt-action/internal-url/emoji layers for submitted slash-command arguments in `PromptActionAutocompleteProvider`, delegating directly to the base slash-command provider.
- Move submitted slash-command argument handling ahead of `@` file-reference lookup in `CombinedAutocompleteProvider`, while preserving explicit `getArgumentCompletions` results.
- Add regression coverage for `/rename repro #copy`, `/rename repro @`, and commands that do define explicit argument completions.
- Add changelog entries for the coding-agent and TUI packages.

## Verification
- `bun test packages/coding-agent/test/prompt-action-autocomplete.test.ts packages/tui/test/autocomplete.test.ts` passed: 50 tests, 109 assertions.
- `bun run fix` passed with no fixes applied.
- `bun check` passed.

Fixes #4600