### PR TITLE
fix(coding-agent/edit): sealed inverse video and preserved gutters in wrapped diff rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed wrapped Edit-diff rows leaking inverse video into the result card's right-edge padding: a row that broke inside an intra-line highlight left inverse active at the row end, so the frame padding after it rendered as a default-foreground block ([#4616](https://github.com/can1357/oh-my-pi/pull/4616) by [@chan1103](https://github.com/chan1103))
+- Fixed Edit-diff continuation rows escaping into the line-number column when the row's gutter was left-padded (line number narrower than the widest in the diff) or blanked by the gutter dedup (the bare `+` row of a single-line replacement); such rows now wrap behind a continuation gutter, while body lines that merely start with `|` keep wrapping generically ([#4616](https://github.com/can1357/oh-my-pi/pull/4616) by [@chan1103](https://github.com/chan1103))
+
 ## [16.3.7] - 2026-07-05
 
 ### Added

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -679,21 +679,35 @@ function wrapEditRendererLine(line: string, width: number): string[] {
 	const startAnsi = line.match(/^((?:\x1b\[[0-9;]*m)*)/)?.[1] ?? "";
 	const bodyWithReset = line.slice(startAnsi.length);
 	const body = bodyWithReset.endsWith("\x1b[39m") ? bodyWithReset.slice(0, -"\x1b[39m".length) : bodyWithReset;
-	const diffMatch = /^([+\-\s])(\s*\d+)([|│])(.*)$/s.exec(body);
+	// Gutter shapes produced by formatCodeFrameLine: "-315│", " 313│", "+322│",
+	// plus the deduplicated forms "   +│" and "    │" whose repeated line number
+	// renderDiff blanked (single-line replacement pairs and insert-then-context
+	// runs) — all │-separated. ASCII "|" gutters exist only in raw canonical
+	// diff rows passed through by the plain fallback ("-42|old", " 42|ctx"),
+	// which always carry a marker column ("+"/"-"/space) and a line number. So
+	// the number is optional for "│", while "|" requires the full canonical
+	// shape; anything else (a body line merely starting with "|", error text
+	// like "123|…") is not a diff row and wraps generically.
+	const diffMatch = /^(\s*[+-]?\s*\d*)([|│])(.*)$/s.exec(body);
 
-	if (!diffMatch) {
+	if (!diffMatch || diffMatch[1].length === 0 || (diffMatch[2] === "|" && !/^[+\-\s]\s*\d+$/.test(diffMatch[1]))) {
 		return wrapTextWithAnsi(line, width);
 	}
 
-	const [, marker, lineNum, separator, content] = diffMatch;
-	const prefix = `${marker}${lineNum}${separator}`;
+	const [, gutter, separator, content] = diffMatch;
+	const prefix = `${gutter}${separator}`;
 	const prefixWidth = visibleWidth(prefix);
 	const contentWidth = Math.max(1, width - prefixWidth);
 	const continuationPrefix = `${" ".repeat(Math.max(0, prefixWidth - 1))}${separator}`;
 	const wrappedContent = wrapTextWithAnsi(content ?? "", contentWidth);
 
+	// Each visual row is a standalone terminal line: wrapTextWithAnsi re-opens
+	// active SGR state at the next row's start, so a row that breaks inside an
+	// intra-line diff highlight still ends with inverse video active. Close it
+	// alongside the foreground reset — otherwise the frame padding appended
+	// after the row is painted as an inverse block (default-foreground cells).
 	return wrappedContent.map(
-		(segment, index) => `${startAnsi}${index === 0 ? prefix : continuationPrefix}${segment}\x1b[39m`,
+		(segment, index) => `${startAnsi}${index === 0 ? prefix : continuationPrefix}${segment}\x1b[27m\x1b[39m`,
 	);
 }
 

--- a/packages/coding-agent/test/tools/edit-renderer.test.ts
+++ b/packages/coding-agent/test/tools/edit-renderer.test.ts
@@ -7,10 +7,12 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { renderGalleryState, resolveFixture } from "@oh-my-pi/pi-coding-agent/cli/gallery-cli";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { editToolRenderer } from "@oh-my-pi/pi-coding-agent/edit/renderer";
+import { renderDiff } from "@oh-my-pi/pi-coding-agent/modes/components/diff";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { Text, type TUI, visibleWidth } from "@oh-my-pi/pi-tui";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import chalk from "chalk";
 
 beforeAll(async () => {
 	resetSettingsForTest();
@@ -517,5 +519,174 @@ describe("editToolRenderer", () => {
 		expect(text).toContain("scripts/archived/prune-changelogs.ts");
 		expect(text).toContain("→");
 		expect(text).not.toContain("No changes");
+	});
+});
+
+describe("editToolRenderer diff line wrapping", () => {
+	// Renders a completed single-line replacement (`-N|old` + `+N|new`) through
+	// the real renderDiff so the result carries its production shapes: a blanked
+	// dedup gutter on the `+` row (`   +│`) and intra-line inverse highlights.
+	async function renderSingleLineReplacement(
+		oldLine: string,
+		newLine: string,
+		width: number,
+	): Promise<readonly string[]> {
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Updated demo.ts" }],
+				details: { diff: `-42|${oldLine}\n+42|${newLine}`, op: "update", path: "demo.ts" },
+			},
+			{ expanded: true, isPartial: false, renderContext: { renderDiff } },
+			uiTheme,
+			{ file_path: "demo.ts" },
+		);
+		return component.render(width);
+	}
+
+	/** Net SGR inverse state after scanning a row; 38/48 extended-color args must not be misread as attribute 7. */
+	function inverseActiveAtRowEnd(row: string): boolean {
+		let inverse = false;
+		for (const match of row.matchAll(/\x1b\[([0-9;]*)m/g)) {
+			const params = match[1].split(";");
+			for (let i = 0; i < params.length; i++) {
+				const param = params[i];
+				if (param === "38" || param === "48") {
+					i += params[i + 1] === "2" ? 4 : params[i + 1] === "5" ? 2 : 0;
+				} else if (param === "" || param === "0") inverse = false;
+				else if (param === "7") inverse = true;
+				else if (param === "27") inverse = false;
+			}
+		}
+		return inverse;
+	}
+
+	it("keeps added-line continuation rows inside the blanked dedup gutter", async () => {
+		// renderDiff blanks the repeated line number on the `+` row of a
+		// single-line replacement (`   +│`); the wrapper must still recognize that
+		// gutter instead of falling back to generic wrapping at column 0.
+		const rows = (
+			await renderSingleLineReplacement(
+				"    the previous synopsis paragraph rambled across quarterly reconciliation notes enumerating every provisional ledger amendment the archival committee had deferred pending review by the regional custodians during the extended winter recess of the auditing season",
+				"    the revised synopsis paragraph now catalogues seasonal festival logistics enumerating lantern shipments drum rehearsals and ribbon inventories that the parade stewards confirmed before dawn, closing with the zephyrQuota tally and the marbledFinale banner",
+				100,
+			)
+		).map(row => Bun.stripANSI(row));
+
+		// The tail of the added line lands on continuation rows, which must carry
+		// the spaces-only continuation gutter rather than start as bare prose.
+		const tailRows = rows.filter(row => row.includes("zephyrQuota") || row.includes("marbledFinale"));
+		expect(tailRows.length).toBeGreaterThanOrEqual(1);
+		for (const row of tailRows) expect(row).toMatch(/^│\s+│/);
+		// Every body row stays inside a code-frame gutter (`-42│`, `   +│`, `    │`).
+		for (const row of rows.slice(1, -1)) expect(row).toMatch(/^│\s*[+-]?\s*\d*│/);
+	});
+
+	it("closes inverse video at every wrapped row end so frame padding stays uninverted", async () => {
+		// A long contiguous rewritten phrase forces the wrap boundary to land
+		// inside an inverse-highlighted span; the frame pads each row with spaces,
+		// so any inverse still active at row end paints those cells as gray blocks.
+		const previousLevel = chalk.level;
+		chalk.level = 3;
+		let rows: readonly string[];
+		try {
+			rows = await renderSingleLineReplacement(
+				"    stanza recounts venerable chronicle passages spanning bygone dynasties whose archivists engraved ledgers onto vellum scrolls",
+				"    stanza celebrates luminous festival processions winding through lantern boulevards while drummers herald jubilant choruses beneath cascading ribbons and fireworks",
+				100,
+			);
+		} finally {
+			chalk.level = previousLevel;
+		}
+
+		// Precondition: some continuation row's content reopens with inverse right
+		// after its gutter, proving a highlighted span crossed a wrap boundary. If
+		// diffWords tokenization ever changes so no span crosses, this fails loudly
+		// instead of letting the row-end assertions pass vacuously.
+		expect(rows.some(row => /│\x1b\[7m/.test(row))).toBe(true);
+		for (const row of rows) expect(inverseActiveAtRowEnd(row)).toBe(false);
+	});
+
+	// Error results reuse the same body-line wrapper as diff rows; these tests
+	// pin the boundary between prose that merely looks pipe-ish and real gutters.
+	async function renderErrorResultRows(errorText: string): Promise<string[]> {
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: errorText }],
+				details: { diff: "", op: "update", path: "demo.ts" },
+				isError: true,
+			},
+			{ expanded: true, isPartial: false, renderContext: { renderDiff } },
+			uiTheme,
+			{ file_path: "demo.ts" },
+		);
+		return component.render(100).map(row => Bun.stripANSI(row));
+	}
+
+	it("does not give pipe-leading error text a phantom diff gutter when wrapping", async () => {
+		// Error text is not a diff row even when it starts with `|`: an empty
+		// gutter must wrap generically, not spawn `|` continuation prefixes.
+		const rows = await renderErrorResultRows(
+			"| pipe-leading diagnostic output that is quite long and should certainly wrap at the render width because it keeps going on and on with more words than fit in one row of the frame",
+		);
+		const bodyRows = rows.slice(1, -1);
+		// Precondition: the text actually wrapped, and the `|` lead survived on row one.
+		expect(bodyRows.length).toBeGreaterThanOrEqual(2);
+		expect(bodyRows[0]).toMatch(/^│\| /);
+		for (const row of bodyRows.slice(1)) expect(row).not.toMatch(/^│\s*\|/);
+	});
+
+	it("wraps spaces-then-bare-pipe error text generically instead of minting a gutter", async () => {
+		// A digit-less ASCII "|" gutter never comes out of formatCodeFrameLine or
+		// canonical diff rows; indented bare-pipe error text must wrap generically.
+		const rows = await renderErrorResultRows(
+			"   | indented bare-pipe diagnostic output that is quite long and should certainly wrap at the render width because it keeps going on and on with more words than fit in one row of the frame",
+		);
+		const bodyRows = rows.slice(1, -1);
+		// Precondition: the text actually wrapped, and the pipe lead survived on row one.
+		expect(bodyRows.length).toBeGreaterThanOrEqual(2);
+		expect(bodyRows[0]).toMatch(/^│\s+\| /);
+		for (const row of bodyRows.slice(1)) expect(row).not.toMatch(/^│\s*\|/);
+	});
+
+	it("wraps digit-leading pipe error text generically when the marker column is missing", async () => {
+		// Canonical ASCII-pipe rows always carry a marker column (`-42|`, ` 42|`);
+		// `123|` prose has a digit there instead, so it is not a diff row.
+		const rows = await renderErrorResultRows(
+			"123| numbered pipe-leading diagnostic output that is quite long and should certainly wrap at the render width because it keeps going on and on with more words than fit in one row of the frame",
+		);
+		const bodyRows = rows.slice(1, -1);
+		// Precondition: the text actually wrapped, and the numbered lead survived on row one.
+		expect(bodyRows.length).toBeGreaterThanOrEqual(2);
+		expect(bodyRows[0]).toMatch(/^│123\| /);
+		for (const row of bodyRows.slice(1)) expect(row).not.toMatch(/^│\s*\|/);
+	});
+
+	it("keeps the numbered ASCII-pipe gutter for canonical rows through the plain fallback", async () => {
+		// Without renderContext the plain fallback passes canonical rows through
+		// verbatim; a numbered "-42|" row must still take the gutter path and
+		// carry an "   |" continuation gutter, not generic prose wrapping.
+		const uiTheme = await getUiTheme();
+		const component = editToolRenderer.renderResult(
+			{
+				content: [{ type: "text", text: "Updated demo.ts" }],
+				details: {
+					diff: "-42|    the previous synopsis paragraph rambled across quarterly reconciliation notes enumerating every provisional ledger amendment the archival committee had deferred pending review by the regional custodians",
+					op: "update",
+					path: "demo.ts",
+				},
+			},
+			{ expanded: true, isPartial: false },
+			uiTheme,
+			{ file_path: "demo.ts" },
+		);
+
+		const rows = component.render(100).map(row => Bun.stripANSI(row));
+		const bodyRows = rows.slice(1, -1);
+		// Precondition: the row actually wrapped past its first visual line.
+		expect(bodyRows.length).toBeGreaterThanOrEqual(2);
+		expect(bodyRows[0]).toMatch(/^│-42\|/);
+		for (const row of bodyRows.slice(1)) expect(row).toMatch(/^│\s+\|/);
 	});
 });


### PR DESCRIPTION
### Symptoms

Long lines in the Edit result card show two wrap artifacts:

1. When a wrapped row breaks inside an intra-line diff highlight, a light-gray block is painted from the end of the text to the card's right border.
2. Continuation rows of some diff lines start flush against the frame border, under the line-number column, instead of behind a continuation gutter. Most visibly on the `+` row of a single-line replacement, but also on any row whose line number is narrower than the widest in the diff.

### Example

Single-line replacement of a long line, rendered at width 100 (ANSI stripped, annotations added). The example text describes the bugs and the fix, so the before render breaks exactly where the old sentence says it does:

Before:

```
╭─── ✎ Edit: renderer.ts ⟦+1/-1⟧ ──────────────────────────────────────────────────────────────────╮
│  41│    "",                                                                                      │
│ -42│····"When a long diff row wraps into several visual rows, the open inverse highlight used to │  ← breaks inside a highlight, inverse stays open → frame padding paints as a gray block
│spill into the frame padding and every continuation slid left under the line-number column.",     │  ← continuation escapes into the line-number column
│   +│····"When a long diff row wraps into several visual rows, each break now closes its inverse  │
│span and each continuation stays aligned behind the code-frame gutter.",                          │  ← same escape on the added row (gutter deduplicated to a bare "+")
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

After:

```
╭─── ✎ Edit: renderer.ts ⟦+1/-1⟧ ──────────────────────────────────────────────────────────────────╮
│  41│    "",                                                                                      │
│ -42│····"When a long diff row wraps into several visual rows, the open inverse highlight used to │
│    │spill into the frame padding and every continuation slid left under the line-number column.",│
│   +│····"When a long diff row wraps into several visual rows, each break now closes its inverse  │
│    │span and each continuation stays aligned behind the code-frame gutter.",                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Repro input, as fed to the edit result renderer (the new regression tests are the executable form of this example):

```
 41|    "",
-42|    "When a long diff row wraps into several visual rows, the open inverse highlight used to spill into the frame padding and every continuation slid left under the line-number column.",
+42|    "When a long diff row wraps into several visual rows, each break now closes its inverse span and each continuation stays aligned behind the code-frame gutter.",
```

### Cause

Both bugs live in `wrapEditRendererLine` (packages/coding-agent/src/edit/renderer.ts), which pre-wraps rendered diff lines to the frame's inner width.

1. `wrapTextWithAnsi` carries SGR state across row breaks and re-opens it at the start of the next row, so a row that breaks inside a `chalk.inverse` span ends with inverse still active. The reassembly appended only `\x1b[39m`. `renderOutputBlock` then pads every row with spaces up to the frame width, and those padding cells render inverted: since the foreground was just reset, the block comes out in the terminal's default foreground color rather than the highlight color.
2. The gutter matcher `/^([+\-\s])(\s*\d+)([|│])/` wanted a marker at column 0 immediately followed by digits, which only holds when marker and number exactly fill the gutter. Left-padded gutters (` -42│`) and gutters blanked by the line-number dedup (`   +│`, the added row of a `-N`/`+N` pair) both fell through to generic wrapping: no continuation gutter, content at column 0.

### Fix

- Seal every wrapped diff row with `\x1b[27m\x1b[39m`. The next row re-opens its own state, so highlights that span the break render the same as before.
- Accept padded and blank line numbers for `│`-separated gutters (formatCodeFrameLine is the only producer of those shapes). ASCII `|` gutters still require the canonical marker+number shape emitted by the plain fallback, so body lines that merely start with `|`, `   |`, or `123|` keep wrapping generically.

### Verification

- Swept the result renderer at widths 72–142 with a diff of two long rewritten prose lines: no row ends with inverse open, no padding cell renders in the default foreground, no row escapes the frame or gutter. Before the fix, 67 of the 71 widths showed at least one artifact.
- `bun test test/tools/edit-renderer.test.ts`: 26 pass (20 existing, 6 new: gutter containment for padded and deduped gutters, net-inverse-off at every row end with a precondition proving a highlight crossed a break, phantom-gutter rejection for `|`/`   |`/`123|`-leading body lines, and the plain-fallback canonical-row path).
- `bun check`: biome and tsgo green (check:rs not run here, no Rust toolchain; the change is TS-only).

### Out of scope

- The streaming call-phase preview doesn't pre-wrap through `wrapEditRendererLine` and can still tint its end-of-row padding while streaming. It's transient (the result render replaces it) and sits on the native-scrollback commit contracts, so it's better handled separately.
- Word-level diff "confetti" on prose rewrites is a display-policy question (similarity gate / semantic cleanup), not bundled here.
