### PR TITLE
fix(tui): accept mid-prompt slash skill autocomplete

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed mid-prompt skill autocomplete so Tab and Enter accept the highlighted `/skill:<name>` suggestion and Backspace dismisses the popup immediately after removing the triggering slash ([#4619](https://github.com/can1357/oh-my-pi/issues/4619)).
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -276,7 +276,7 @@ function commandMatchesNameOrAlias(cmd: CommandEntry, commandName: string): bool
 	return getCommandAliases(cmd).includes(commandName);
 }
 
-function scoreCommandTextMatch(lowerPrefix: string, lowerTarget: string): number {
+export function scoreCommandTextMatch(lowerPrefix: string, lowerTarget: string): number {
 	if (lowerPrefix.length === 0) return 1;
 	if (lowerPrefix === lowerTarget) return 1000;
 	// Flat score for every prefix match so same-prefix commands keep registry

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -21,7 +21,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "../utils";
-import { SelectList, type SelectListLayoutOptions, type SelectListTheme } from "./select-list";
+import { type SelectItem, SelectList, type SelectListLayoutOptions, type SelectListTheme } from "./select-list";
 
 const AUTOCOMPLETE_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 	overflowSearch: false,
@@ -1119,16 +1119,16 @@ export class Editor implements Component, Focusable {
 
 				// If Tab was pressed, always apply the selection
 				if (kb.matches(data, "tui.input.tab")) {
+					const selected = this.#autocompleteList.getSelectedItem();
 					// Check for stale autocomplete state due to buffer edits since last refresh
 					// (destructive keys or paste can outrun the debounced update).
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor)) {
+					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor, selected)) {
 						// Autocomplete is stale - silently cancel; Tab has no fallback action here.
 						this.#cancelAutocomplete();
 						return;
 					}
-					const selected = this.#autocompleteList.getSelectedItem();
 					if (selected && this.#autocompleteProvider) {
 						const shouldChainSlashCommandAutocomplete = this.#isSlashCommandNameAutocompleteSelection();
 						const result = this.#autocompleteProvider.applyCompletion(
@@ -1164,14 +1164,14 @@ export class Editor implements Component, Focusable {
 					(kb.matches(data, "tui.input.submit") || data === "\n") &&
 					findLeadingSlashCommandStart(this.#autocompletePrefix) !== null
 				) {
+					const selected = this.#autocompleteList.getSelectedItem();
 					// Check for stale autocomplete state due to debounce
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor)) {
+					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor, selected)) {
 						// Autocomplete is stale - cancel and fall through to normal submission
 						this.#cancelAutocomplete();
 					} else {
-						const selected = this.#autocompleteList.getSelectedItem();
 						if (selected && this.#autocompleteProvider) {
 							const result = this.#autocompleteProvider.applyCompletion(
 								this.#state.lines,
@@ -1192,14 +1192,14 @@ export class Editor implements Component, Focusable {
 				}
 				// If Enter was pressed on a file path, apply completion
 				else if (kb.matches(data, "tui.input.submit") || data === "\n") {
+					const selected = this.#autocompleteList.getSelectedItem();
 					// Check for stale autocomplete state due to buffer edits since last refresh.
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
 					const currentTextBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor)) {
+					if (!this.#autocompletePrefixMatchesCursorText(currentTextBeforeCursor, selected)) {
 						// Autocomplete is stale - cancel and fall through to normal submission
 						this.#cancelAutocomplete();
 					} else {
-						const selected = this.#autocompleteList.getSelectedItem();
 						if (selected && this.#autocompleteProvider) {
 							const result = this.#autocompleteProvider.applyCompletion(
 								this.#state.lines,
@@ -2068,8 +2068,15 @@ export class Editor implements Component, Focusable {
 		this.#resetKillSequence();
 		this.#recordUndoState();
 
+		let removedMidPromptSlashTrigger = false;
+
 		if (this.#state.cursorCol > 0) {
 			const line = this.#state.lines[this.#state.cursorLine] || "";
+			const textBeforeCursor = line.slice(0, this.#state.cursorCol);
+			const trailingSlashStart = findTrailingSlashCommandStart(textBeforeCursor);
+			removedMidPromptSlashTrigger =
+				trailingSlashStart === this.#state.cursorCol - 1 &&
+				(!this.#hasOnlyWhitespaceBeforeCursorLine() || textBeforeCursor.slice(0, trailingSlashStart).trim() !== "");
 			// An atomic placeholder token (image/paste marker) deletes as a unit, so a single
 			// backspace never leaves a half-eaten `[Paste #1, +30 lines` behind as stray text.
 			const token = this.#atomicTokenAt(line, this.#state.cursorCol - 1);
@@ -2109,7 +2116,12 @@ export class Editor implements Component, Focusable {
 
 		// Update or re-trigger autocomplete after backspace
 		if (this.#autocompleteState) {
-			this.#debouncedUpdateAutocomplete();
+			if (removedMidPromptSlashTrigger) {
+				this.#cancelAutocomplete();
+				this.onAutocompleteUpdate?.();
+			} else {
+				this.#debouncedUpdateAutocomplete();
+			}
 		} else {
 			// If autocomplete was cancelled (no matches), re-trigger if we're in a completable context
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
@@ -2876,12 +2888,23 @@ export class Editor implements Component, Focusable {
 	 * - Slash branch re-anchors when both the prefix and the current text carry a
 	 *   leading slash command and the current slash token is clean (no whitespace or
 	 *   inner slash), matching `applyCompletion`'s slash-branch guard.
+	 * - Mid-prompt skill branch re-anchors when the popup item is a skill and the
+	 *   current text still ends in a trailing slash token, matching the provider's
+	 *   mid-prompt replacement branch.
 	 * - `@`-file branch re-anchors via `#extractAtPrefix`; safe when the current text
 	 *   still ends in a whitespace-anchored `@<token>`.
 	 * - Everything else is stale — accepting it would corrupt the buffer (issue #4295).
 	 */
-	#autocompletePrefixMatchesCursorText(currentTextBeforeCursor: string): boolean {
+	#autocompletePrefixMatchesCursorText(currentTextBeforeCursor: string, item?: SelectItem | null): boolean {
 		if (currentTextBeforeCursor === this.#autocompletePrefix) return true;
+
+		if (item?.value.startsWith("skill:") && findTrailingSlashCommandStart(this.#autocompletePrefix) !== null) {
+			const currentTrailingStart = findTrailingSlashCommandStart(currentTextBeforeCursor);
+			if (currentTrailingStart !== null) {
+				const token = currentTextBeforeCursor.slice(currentTrailingStart);
+				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
+			}
+		}
 
 		if (findLeadingSlashCommandStart(this.#autocompletePrefix) !== null) {
 			const currentLeadingStart = findLeadingSlashCommandStart(currentTextBeforeCursor);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -3,6 +3,7 @@ import {
 	type AutocompleteProvider,
 	findLeadingSlashCommandStart,
 	findTrailingSlashCommandStart,
+	scoreCommandTextMatch,
 } from "../autocomplete";
 import { BracketedPasteHandler, decodeReencodedPasteControls } from "../bracketed-paste";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
@@ -2902,8 +2903,17 @@ export class Editor implements Component, Focusable {
 			const currentTrailingStart = findTrailingSlashCommandStart(currentTextBeforeCursor);
 			if (currentTrailingStart !== null) {
 				const token = currentTextBeforeCursor.slice(currentTrailingStart);
-				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
+				if (!token.includes(" ") && !token.slice(1).includes("/")) {
+					// Guard the timing window where the popup was built for an earlier
+					// query (e.g. bare `/`) and the user typed further characters before
+					// the 100 ms debounced refresh fired: accept the stale skill only
+					// when the current query would still surface it. `tmp` after a bare
+					// slash therefore falls through to file completion instead of
+					// rewriting the user's `/tmp` to `/skill:…`.
+					if (scoreCommandTextMatch(token.slice(1).toLowerCase(), item.value.toLowerCase()) > 0) return true;
+				}
 			}
+			return false;
 		}
 
 		if (findLeadingSlashCommandStart(this.#autocompletePrefix) !== null) {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -134,6 +134,60 @@ class SyncSlashProvider implements AutocompleteProvider {
 }
 
 describe("Editor Enter handler sync slash completion", () => {
+	const skillCommands = [
+		{ name: "skill:security-scan", description: "Security scan" },
+		{ name: "model", description: "Switch model" },
+	];
+
+	function createSkillEditor(): Editor {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new CombinedAutocompleteProvider(skillCommands, "/tmp"));
+		return editor;
+	}
+
+	async function openMidPromptSkillAutocomplete(editor: Editor, prose: string): Promise<void> {
+		editor.handleInput(prose);
+		editor.handleInput("/");
+		await Promise.resolve();
+
+		expect(editor.getText()).toBe(`${prose}/`);
+		expect(editor.isShowingAutocomplete()).toBe(true);
+	}
+
+	it("accepts a bare mid-prompt skill slash with Tab without replacing prose", async () => {
+		const editor = createSkillEditor();
+
+		await openMidPromptSkillAutocomplete(editor, "run a ");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("run a /skill:security-scan ");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
+	it("accepts a bare mid-prompt skill slash with Enter and submits the completed prompt", async () => {
+		const editor = createSkillEditor();
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		await openMidPromptSkillAutocomplete(editor, "run a ");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("run a /skill:security-scan");
+		expect(editor.getText()).toBe("");
+	});
+
+	it("hides mid-prompt skill autocomplete immediately when Backspace removes the slash", async () => {
+		const editor = createSkillEditor();
+
+		await openMidPromptSkillAutocomplete(editor, "run a ");
+		editor.handleInput("\x7f");
+
+		expect(editor.getText()).toBe("run a ");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
 	it("opens mid-prompt skill autocomplete and inserts the skill token without wiping the draft on Tab", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -188,6 +188,19 @@ describe("Editor Enter handler sync slash completion", () => {
 		expect(editor.isShowingAutocomplete()).toBe(false);
 	});
 
+	it("does not apply a stale mid-prompt skill suggestion when the live token stops matching", async () => {
+		const editor = createSkillEditor();
+
+		await openMidPromptSkillAutocomplete(editor, "see ");
+		// Race the 100 ms debounce: type a non-skill token before the popup refreshes.
+		editor.handleInput("tmp");
+		editor.handleInput("\t");
+
+		// The stale `skill:security-scan` popup must not rewrite `/tmp` to `/skill:…`.
+		expect(editor.getText()).toBe("see /tmp");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
 	it("opens mid-prompt skill autocomplete and inserts the skill token without wiping the draft on Tab", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(


### PR DESCRIPTION
## Repro
With `Editor` and `CombinedAutocompleteProvider`, setting the buffer to `explain this `, typing `/`, waiting one autocomplete tick, then pressing Tab reproduced the issue: the popup closed and the buffer stayed `explain this /` instead of inserting `/skill:security-scan`.

## Cause
`packages/tui/src/components/editor.ts` used `#autocompletePrefixMatchesCursorText` to reject stale autocomplete state before applying a selection. Mid-prompt skill lookup stores only the trailing slash token in `#autocompletePrefix`, but the matcher treated any slash-prefixed prefix as a leading slash command via `findLeadingSlashCommandStart`, so text like `run a /` failed the staleness check before `CombinedAutocompleteProvider.applyCompletion` could use its trailing-slash replacement branch. `#handleBackspace` also routed removal of that slash through the debounced autocomplete refresh path, leaving stale suggestions visible until the timeout fired.

## Fix
- Passed the highlighted autocomplete item into the staleness check so skill suggestions can validate against live trailing slash tokens without weakening non-skill slash command stale-state rejection.
- Cancelled autocomplete synchronously when Backspace removes the mid-prompt slash token that opened skill suggestions.
- Added regression tests covering Tab acceptance, Enter acceptance plus submission, and immediate Backspace dismissal for bare mid-prompt skill slash autocomplete.
- Added the `packages/tui` changelog entry for #4619.

## Verification
`bun test packages/tui/test/editor-autocomplete-actions.test.ts` passed with 21 tests and 52 assertions. `bun check` passed. Fixes #4619