### PR TITLE
fix(tools): prefer literal filesystem match over trailing `:selector` peel

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `read` and `grep` refusing to access filesystem paths whose names end in a selector-shaped suffix (e.g. `test:1-2`, `log:raw`) by preferring a literal match over the trailing `:<selector>` peel when the raw path exists on disk ([#4618](https://github.com/can1357/oh-my-pi/issues/4618)).
+
 ## [16.3.7] - 2026-07-05
 
 ### Added

--- a/packages/coding-agent/src/prompts/tools/grep.md
+++ b/packages/coding-agent/src/prompts/tools/grep.md
@@ -2,7 +2,7 @@ Greps files using regex.
 
 <instruction>
 - Rust regex (RE2-style): alternation is `foo|bar`, not GNU BRE-style `foo\|bar`; Rust word boundaries like `\bword\b` are supported. Use line anchors or post-filters instead of lookaround/backreferences.
-- `path`: SHOULD scope to a known path (e.g. `src`); pass several as a delimited list (`src; tests`).
+- `path`: SHOULD scope to a known path (e.g. `src`); pass several as a delimited list (`src; tests`). Literal colon filename + line range? Use `selector` (e.g. `{"path":"test:1-2","selector":"1-2"}`), not recursive `path:"test:1-2:1-2"`.
 - Cross-line patterns detected from literal `\n` or `\\n` in `pattern`.
 </instruction>
 

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -1,4 +1,4 @@
-Read files, directories, archives, SQLite, images, documents, internal resources, and web URLs via one `path`.
+Read files, directories, archives, SQLite, images, documents, internal resources, and web URLs via `path` plus optional `selector`.
 
 <instruction>
 - SHOULD parallelize independent reads.
@@ -7,7 +7,8 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 
 ## Parameters
 
-- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`, `omp://`, `issue://`, `pr://`, `ssh://`), or URL. Append `:<sel>` for ranges/modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
+- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`, `omp://`, `issue://`, `pr://`, `ssh://`), or URL. Inline `:<sel>` still works for ranges/modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
+- `selector` — optional selector without leading `:` (e.g. `"50-200"`, `"raw"`, `"raw:50-100"`, `"conflicts"`). Use when `path` contains literal colons: `{"path":"test:1-2","selector":"1-2"}`.
 
 ## Selectors
 
@@ -72,6 +73,6 @@ All URI schemes take the same line selectors. `artifact://<id>` recovers spilled
 `ssh://host/<absolute-path>` reads a remote text file (UTF-8, ≤1 MiB) or lists a directory one level deep, on a pre-configured SSH host or `~/.ssh/config` alias; `ssh://host/` lists the remote root and bare `ssh://` lists the configured hosts. Files are also writable via `write` and searchable via `search`; a directory only lists (`search` refuses a directory, `write` refuses to overwrite one). A literal `:`, `?`, or `#` in the remote path must be percent-encoded (`%3A`/`%3F`/`%23`) — a trailing `:sel` is read as a line selector, and `?`/`#` start a URL query/fragment. Requires a POSIX login shell (`sh`/`bash`/`zsh`); a Windows host or a non-POSIX shell (fish, csh/tcsh) is rejected — use the `ssh` tool there.
 
 <critical>
-- Line ranges go in the selector: `path="src/foo.ts:50-200"`.
+- Literal colon filename + selector? Use `selector`, not recursive `path:"file:sel:sel"`.
 - Summary footer names elided ranges? Re-issue ONLY those ranges. NEVER guess `..`/`…` content.
 </critical>

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -53,6 +53,7 @@ import {
 	resolveToolSearchScope,
 	selectorLineRanges,
 	splitInternalUrlSel,
+	splitPathAndSel,
 	splitPathAndSelPreferringLiteral,
 	toPathList,
 } from "./path-utils";
@@ -119,6 +120,7 @@ const SEARCH_GREP_TIMEOUT_MS = 30_000;
 interface GrepPathSpec {
 	original: string;
 	clean: string;
+	literalFilesystemMatch?: boolean;
 	ranges?: [LineRange, ...LineRange[]];
 }
 
@@ -170,7 +172,9 @@ async function parsePathSpecs(rawEntries: readonly string[], cwd: string): Promi
 		}
 		// Prefer a literal filesystem match when one exists — a real file named
 		// `test:1-2` outranks the `:1-2` selector interpretation (issue #4618).
+		const strictSplit = splitPathAndSel(entry);
 		const split = await splitPathAndSelPreferringLiteral(entry, cwd);
+		const literalFilesystemMatch = strictSplit.sel !== undefined && split.sel === undefined;
 		let clean = entry;
 		let ranges: [LineRange, ...LineRange[]] | undefined;
 		if (split.sel) {
@@ -186,7 +190,7 @@ async function parsePathSpecs(rawEntries: readonly string[], cwd: string): Promi
 			clean = split.path;
 			ranges = parsed;
 		}
-		specs.push({ original: entry, clean, ranges });
+		specs.push({ original: entry, clean, literalFilesystemMatch, ranges });
 	}
 	return specs;
 }
@@ -222,7 +226,7 @@ function matchAbsolutePath(matchPath: string, searchPath: string): string {
  * cleanup hook the caller MUST invoke in a `finally`.
  */
 async function resolveArchiveSearchPaths(
-	paths: string[],
+	pathSpecs: readonly GrepPathSpec[],
 	cwd: string,
 ): Promise<{
 	resolvedPaths: string[];
@@ -231,17 +235,18 @@ async function resolveArchiveSearchPaths(
 	unreadable: string[];
 	cleanup: () => Promise<void>;
 }> {
-	const resolvedPaths = paths.slice();
+	const resolvedPaths = pathSpecs.map(spec => spec.clean);
 	const displayMap = new Map<string, string>();
 	const displaySet = new Set<string>();
 	const unreadable: string[] = [];
 	let tempDir: string | undefined;
 	const archiveCache = new Map<string, ArchiveReader>();
 
-	for (let idx = 0; idx < paths.length; idx++) {
-		const entry = paths[idx];
+	for (let idx = 0; idx < pathSpecs.length; idx++) {
+		const spec = pathSpecs[idx];
+		if (!spec || spec.literalFilesystemMatch) continue;
+		const entry = spec.clean;
 		const candidates = parseArchivePathCandidates(entry);
-		// Longest archive prefix first; we want the one whose member portion is non-empty.
 		const member = candidates.find(c => c.subPath !== "" && c.archivePath !== entry);
 		if (!member) continue;
 
@@ -900,7 +905,6 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 			const effectivePaths = scopedPaths.length > 0 ? scopedPaths : ["."];
 			const rawEntries = await expandDelimitedPathEntries(effectivePaths, this.session.cwd);
 			const pathSpecs = await parsePathSpecs(rawEntries, this.session.cwd);
-			const paths = pathSpecs.map(spec => spec.clean);
 			const materializedExternalPaths = new Map<string, string>();
 			const materializeExternalUrlForSearch = async (rawPath: string) => {
 				const target = parseReadUrlTarget(rawPath);
@@ -919,7 +923,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 				displaySet: archiveDisplaySet,
 				unreadable: archiveUnreadable,
 				cleanup: cleanupArchiveScratch,
-			} = await resolveArchiveSearchPaths(paths, this.session.cwd);
+			} = await resolveArchiveSearchPaths(pathSpecs, this.session.cwd);
 			try {
 				const internalResolution = await resolveInternalSearchInputs({
 					pathSpecs,

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -175,9 +175,9 @@ async function parsePathSpecs(rawEntries: readonly string[], cwd: string): Promi
 		const strictSplit = splitPathAndSel(entry);
 		const split = await splitPathAndSelPreferringLiteral(entry, cwd);
 		const literalFilesystemMatch = strictSplit.sel !== undefined && split.sel === undefined;
-		let clean = entry;
+		let clean = literalFilesystemMatch ? resolveReadPath(entry, cwd) : entry;
 		let ranges: [LineRange, ...LineRange[]] | undefined;
-		if (split.sel) {
+		if (!literalFilesystemMatch && split.sel) {
 			const parsed = parseLineRanges(split.sel);
 			if (!parsed) {
 				throw new ToolError(

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -53,7 +53,7 @@ import {
 	resolveToolSearchScope,
 	selectorLineRanges,
 	splitInternalUrlSel,
-	splitPathAndSel,
+	splitPathAndSelPreferringLiteral,
 	toPathList,
 } from "./path-utils";
 import {
@@ -147,7 +147,7 @@ function isReadSelectorGrammar(sel: string): boolean {
 	return lower === "raw" || lower === "conflicts" || parseLineRanges(sel) !== null;
 }
 
-function parsePathSpecs(rawEntries: readonly string[]): GrepPathSpec[] {
+async function parsePathSpecs(rawEntries: readonly string[], cwd: string): Promise<GrepPathSpec[]> {
 	const specs: GrepPathSpec[] = [];
 	for (const entry of rawEntries) {
 		// Internal URLs (`artifact://`, `skill://`, …) use the URL-aware splitter,
@@ -168,7 +168,9 @@ function parsePathSpecs(rawEntries: readonly string[]): GrepPathSpec[] {
 			specs.push({ original: entry, clean: internalSplit.path, ranges: selectorLineRanges(internalSplit.sel) });
 			continue;
 		}
-		const split = splitPathAndSel(entry);
+		// Prefer a literal filesystem match when one exists — a real file named
+		// `test:1-2` outranks the `:1-2` selector interpretation (issue #4618).
+		const split = await splitPathAndSelPreferringLiteral(entry, cwd);
 		let clean = entry;
 		let ranges: [LineRange, ...LineRange[]] | undefined;
 		if (split.sel) {
@@ -897,7 +899,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 			const scopedPaths = toPathList(rawPath);
 			const effectivePaths = scopedPaths.length > 0 ? scopedPaths : ["."];
 			const rawEntries = await expandDelimitedPathEntries(effectivePaths, this.session.cwd);
-			const pathSpecs = parsePathSpecs(rawEntries);
+			const pathSpecs = await parsePathSpecs(rawEntries, this.session.cwd);
 			const paths = pathSpecs.map(spec => spec.clean);
 			const materializedExternalPaths = new Map<string, string>();
 			const materializeExternalUrlForSearch = async (rawPath: string) => {

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -49,6 +49,7 @@ import {
 	parseLineRanges,
 	pathTargetsSsh,
 	type ResolvedSearchTarget,
+	resolveExistingReadPath,
 	resolveReadPath,
 	resolveToolSearchScope,
 	selectorLineRanges,
@@ -77,6 +78,9 @@ const searchSchema = type({
 	pattern: type("string").describe("regex pattern"),
 	"path?": searchPathEntry.describe(
 		'file, directory, glob, internal URL, or "<file>:<lines>" selector to search; pass several as a semicolon-delimited list ("src; tests"). Omitted -> searches the workspace root (".")',
+	),
+	"selector?": type("string").describe(
+		'line selector without a leading colon (e.g. "50-100", "50+10", "50-100,200-300"); keeps `path` literal when filenames contain colons',
 	),
 	"case?": type("boolean").describe("case-sensitive search"),
 	"gitignore?": type("boolean").describe("respect gitignore"),
@@ -149,9 +153,35 @@ function isReadSelectorGrammar(sel: string): boolean {
 	return lower === "raw" || lower === "conflicts" || parseLineRanges(sel) !== null;
 }
 
-async function parsePathSpecs(rawEntries: readonly string[], cwd: string): Promise<GrepPathSpec[]> {
+async function parsePathSpecs(
+	rawEntries: readonly string[],
+	cwd: string,
+	explicitSelector?: string,
+): Promise<GrepPathSpec[]> {
+	const explicitRanges =
+		explicitSelector === undefined || explicitSelector.length === 0 ? undefined : parseLineRanges(explicitSelector);
+	if (explicitSelector !== undefined && !explicitRanges) {
+		throw new ToolError(
+			`selector "${explicitSelector}" is invalid — use line ranges like "50-100", "50+10", or "50-100,200-300" without a leading colon`,
+		);
+	}
 	const specs: GrepPathSpec[] = [];
 	for (const entry of rawEntries) {
+		if (explicitRanges) {
+			// Separate selector parameter makes `path` deterministic: first try the
+			// exact local filesystem path (with read-path normalization), then let
+			// archive/internal/URL resolution handle non-literal structured paths.
+			const localPath = /^[a-z][a-z0-9+.-]*:\/\//i.test(entry)
+				? undefined
+				: await resolveExistingReadPath(entry, cwd);
+			specs.push({
+				original: entry,
+				clean: localPath ?? entry,
+				literalFilesystemMatch: localPath !== undefined,
+				ranges: explicitRanges,
+			});
+			continue;
+		}
 		// Internal URLs (`artifact://`, `skill://`, …) use the URL-aware splitter,
 		// which peels selector-shaped tails only for selector-capable schemes and
 		// leaves opaque ones (`mcp://`) intact. Unlike filesystem paths, their
@@ -886,7 +916,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 		_onUpdate?: AgentToolUpdateCallback<GrepToolDetails>,
 		_toolContext?: AgentToolContext,
 	): Promise<AgentToolResult<GrepToolDetails>> {
-		const { pattern, path: rawPath, case: caseSensitive, gitignore, skip } = params;
+		const { pattern, path: rawPath, selector, case: caseSensitive, gitignore, skip } = params;
 
 		return untilAborted(signal, async () => {
 			// Preserve the pattern verbatim — leading/trailing whitespace is
@@ -904,7 +934,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 			const scopedPaths = toPathList(rawPath);
 			const effectivePaths = scopedPaths.length > 0 ? scopedPaths : ["."];
 			const rawEntries = await expandDelimitedPathEntries(effectivePaths, this.session.cwd);
-			const pathSpecs = await parsePathSpecs(rawEntries, this.session.cwd);
+			const pathSpecs = await parsePathSpecs(rawEntries, this.session.cwd, selector);
 			const materializedExternalPaths = new Map<string, string>();
 			const materializeExternalUrlForSearch = async (rawPath: string) => {
 				const target = parseReadUrlTarget(rawPath);

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -48,8 +48,8 @@ import {
 	type LineRange,
 	parseLineRanges,
 	pathTargetsSsh,
+	probeLiteralPathExists,
 	type ResolvedSearchTarget,
-	resolveExistingReadPath,
 	resolveReadPath,
 	resolveToolSearchScope,
 	selectorLineRanges,
@@ -171,13 +171,16 @@ async function parsePathSpecs(
 			// Separate selector parameter makes `path` deterministic: first try the
 			// exact local filesystem path (with read-path normalization), then let
 			// archive/internal/URL resolution handle non-literal structured paths.
-			const localPath = /^[a-z][a-z0-9+.-]*:\/\//i.test(entry)
-				? undefined
-				: await resolveExistingReadPath(entry, cwd);
+			const rawPathHasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(entry);
+			const probe = rawPathHasScheme ? "missing" : await probeLiteralPathExists(entry, cwd);
+			// `"unknown"` covers EACCES/IO where we cannot confirm existence — treat
+			// it as a literal so a real file such as `test:1-2` under an unreadable
+			// parent is never silently reinterpreted as `test` + selector.
+			const literalMatch = probe !== "missing";
 			specs.push({
 				original: entry,
-				clean: localPath ?? entry,
-				literalFilesystemMatch: localPath !== undefined,
+				clean: literalMatch && !rawPathHasScheme ? resolveReadPath(entry, cwd) : entry,
+				literalFilesystemMatch: literalMatch,
 				ranges: explicitRanges,
 			});
 			continue;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -316,6 +316,28 @@ export function splitPathAndSel(rawPath: string): { path: string; sel?: string }
 }
 
 /**
+ * Async sibling of {@link splitPathAndSel} that prefers a literal filesystem
+ * path over selector interpretation when the raw input exists on disk.
+ * Filenames whose tail matches the selector grammar (e.g. `test:1-2`, `log:raw`)
+ * are legal on POSIX; without this the strict splitter peels the tail and both
+ * `read` and `grep` refuse to open the real file (see issue #4618). Mirrors
+ * {@link parseSearchPathPreferringLiteral} for glob-shaped literal paths.
+ */
+export async function splitPathAndSelPreferringLiteral(
+	rawPath: string,
+	cwd: string,
+): Promise<{ path: string; sel?: string }> {
+	const strict = splitPathAndSel(rawPath);
+	if (strict.sel === undefined) return strict;
+	try {
+		await fs.promises.stat(resolveToCwd(rawPath, cwd));
+		return { path: rawPath };
+	} catch {
+		return strict;
+	}
+}
+
+/**
  * Variant of {@link splitPathAndSel} for internal URLs (`scheme://...`).
  *
  * The filesystem-path splitter is intentionally conservative: it refuses to

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -315,25 +315,35 @@ export function splitPathAndSel(rawPath: string): { path: string; sel?: string }
 	return { path: basePath, sel };
 }
 
-/** Resolve a read-tool path variant and return it only when it already exists on disk. */
-export async function resolveExistingReadPath(filePath: string, cwd: string): Promise<string | undefined> {
+/**
+ * Three-way probe for whether the exact filesystem entry named by `filePath`
+ * exists. `stat` (used earlier) failed for reasons other than "no such file"
+ * (dangling symlink, `EACCES` on a parent, transient I/O), and each of those
+ * silently reinterpreted a real literal path such as `test:1-2` as `test`
+ * plus selector `1-2` (issue #4618). `lstat` inspects the entry itself, so a
+ * dangling symlink is still detected as present; ambiguous errors resolve to
+ * `"unknown"` so callers keep the raw path instead of guessing.
+ */
+export async function probeLiteralPathExists(filePath: string, cwd: string): Promise<"exists" | "missing" | "unknown"> {
 	const resolved = resolveReadPath(filePath, cwd);
 	try {
-		await fs.promises.stat(resolved);
-		return resolved;
+		await fs.promises.lstat(resolved);
+		return "exists";
 	} catch (err) {
-		if (isEnoent(err) || isEnotdir(err)) return undefined;
-		return resolved;
+		if (isEnoent(err) || isEnotdir(err)) return "missing";
+		return "unknown";
 	}
 }
 
 /**
  * Async sibling of {@link splitPathAndSel} that prefers a literal filesystem
- * path over selector interpretation when the raw input exists on disk.
- * Filenames whose tail matches the selector grammar (e.g. `test:1-2`, `log:raw`)
- * are legal on POSIX; without this the strict splitter peels the tail and both
- * `read` and `grep` refuse to open the real file (see issue #4618). Mirrors
- * {@link parseSearchPathPreferringLiteral} for glob-shaped literal paths.
+ * path over selector interpretation. Filenames whose tail matches the selector
+ * grammar (e.g. `test:1-2`, `log:raw`) are legal on POSIX; without this the
+ * strict splitter peels the tail and both `read` and `grep` refuse to open the
+ * real file (issue #4618). The literal wins on a confirmed `lstat`, and also
+ * on `"unknown"` (`EACCES` on a parent, transient I/O), so an unreachable
+ * literal is never silently reinterpreted as `path + selector`. Only a
+ * definitive `ENOENT`/`ENOTDIR` falls back to the strict split.
  */
 export async function splitPathAndSelPreferringLiteral(
 	rawPath: string,
@@ -341,9 +351,8 @@ export async function splitPathAndSelPreferringLiteral(
 ): Promise<{ path: string; sel?: string }> {
 	const strict = splitPathAndSel(rawPath);
 	if (strict.sel === undefined) return strict;
-	const resolved = await resolveExistingReadPath(rawPath, cwd);
-	if (resolved !== undefined) return { path: rawPath };
-	return strict;
+	const probe = await probeLiteralPathExists(rawPath, cwd);
+	return probe === "missing" ? strict : { path: rawPath };
 }
 
 /**

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -330,7 +330,7 @@ export async function splitPathAndSelPreferringLiteral(
 	const strict = splitPathAndSel(rawPath);
 	if (strict.sel === undefined) return strict;
 	try {
-		await fs.promises.stat(resolveToCwd(rawPath, cwd));
+		await fs.promises.stat(resolveReadPath(rawPath, cwd));
 		return { path: rawPath };
 	} catch {
 		return strict;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -709,7 +709,12 @@ export async function splitDelimitedPathEntry(
 	const normalizedEntry = normalizePathLikeInput(entry);
 	if (!hasTopLevelPathDelimiter(normalizedEntry)) return null;
 	if (isInternalUrlPath(normalizedEntry)) return null;
-
+	// A real POSIX file may contain the delimiter and a selector-shaped tail
+	// (`a;b:1-2`, `a b:1-2`). Preserve the raw entry whenever the full literal
+	// resolves — or is only ambiguous — so downstream literal-preferring
+	// splitters see it before delimiter expansion peels or splits (issue #4618
+	// reviewer feedback: delimited expansion ran before the literal check).
+	if ((await probeLiteralPathExists(normalizedEntry, cwd)) !== "missing") return null;
 	const splitter = options.splitter ?? parseSearchPath;
 	const peeledEntry = splitPathAndSel(normalizedEntry).path;
 	if (!hasGlobPathChars(peeledEntry) && (await delimitedPathPartResolves(normalizedEntry, cwd, splitter))) {

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -315,6 +315,18 @@ export function splitPathAndSel(rawPath: string): { path: string; sel?: string }
 	return { path: basePath, sel };
 }
 
+/** Resolve a read-tool path variant and return it only when it already exists on disk. */
+export async function resolveExistingReadPath(filePath: string, cwd: string): Promise<string | undefined> {
+	const resolved = resolveReadPath(filePath, cwd);
+	try {
+		await fs.promises.stat(resolved);
+		return resolved;
+	} catch (err) {
+		if (isEnoent(err) || isEnotdir(err)) return undefined;
+		return resolved;
+	}
+}
+
 /**
  * Async sibling of {@link splitPathAndSel} that prefers a literal filesystem
  * path over selector interpretation when the raw input exists on disk.
@@ -329,12 +341,9 @@ export async function splitPathAndSelPreferringLiteral(
 ): Promise<{ path: string; sel?: string }> {
 	const strict = splitPathAndSel(rawPath);
 	if (strict.sel === undefined) return strict;
-	try {
-		await fs.promises.stat(resolveReadPath(rawPath, cwd));
-		return { path: rawPath };
-	} catch {
-		return strict;
-	}
+	const resolved = await resolveExistingReadPath(rawPath, cwd);
+	if (resolved !== undefined) return { path: rawPath };
+	return strict;
 }
 
 /**

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2206,48 +2206,62 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// resolution share misses instead of re-globbing the workspace.
 		const suffixCache: SuffixMatchCache = new Map();
 
-		const archivePath = await this.#resolveArchiveReadPath(readPath, suffixCache, signal);
-		if (archivePath) {
-			const archiveSubPath = splitPathAndSel(archivePath.archiveSubPath);
-			const archiveParsed = parseSel(archiveSubPath.sel);
-			return this.#readArchive(
-				readPath,
-				archiveParsed,
-				{ ...archivePath, archiveSubPath: archiveSubPath.path },
-				signal,
-			);
-		}
+		// Prefer a literal filesystem match over the strict `:<sel>` peel so real
+		// POSIX filenames whose tail matches the selector grammar (e.g. `test:1-2`,
+		// `data.zip:1-2`, `notes.db:raw`) win over the structured-path resolvers
+		// below. When the raw path resolves literally on disk AND the strict
+		// splitter would have peeled a selector, the archive / sqlite / pdf-image
+		// dispatchers must decline — otherwise `data.zip:1-2` still opens
+		// `data.zip` and errors on the phantom member (issue #4618).
+		const literalSplit = await splitPathAndSelPreferringLiteral(readPath, this.session.cwd);
+		// Literal wins whenever the strict grammar would have peeled a suffix but
+		// the async splitter decided to keep the raw path (fs.stat succeeded).
+		const rawPathIsLiteral = literalSplit.sel === undefined && splitPathAndSel(readPath).sel !== undefined;
 
-		const sqlitePath = await this.#resolveSqliteReadPath(readPath, suffixCache, signal);
-		if (sqlitePath) {
-			return this.#readSqlite(sqlitePath, signal);
-		}
-
-		const pdfImageMemberPath = splitPdfImageMemberReadPath(readPath);
-		if (pdfImageMemberPath) {
-			let absolutePdfPath = resolveReadPath(pdfImageMemberPath.pdfPath, this.session.cwd);
-			let suffixResolution: { from: string; to: string } | undefined;
-			try {
-				const stat = await Bun.file(absolutePdfPath).stat();
-				if (stat.isDirectory())
-					throw new ToolError(`Path '${pdfImageMemberPath.pdfPath}' is a directory, not a PDF file`);
-			} catch (error) {
-				if (!isNotFoundError(error) || isRemoteMountPath(absolutePdfPath)) throw error;
-				const suffixMatch = await this.#findSuffixMatchCached(suffixCache, pdfImageMemberPath.pdfPath, signal);
-				if (!suffixMatch) throw new ToolError(`Path '${pdfImageMemberPath.pdfPath}' not found`);
-				absolutePdfPath = suffixMatch.absolutePath;
-				suffixResolution = { from: pdfImageMemberPath.pdfPath, to: suffixMatch.displayPath };
+		if (!rawPathIsLiteral) {
+			const archivePath = await this.#resolveArchiveReadPath(readPath, suffixCache, signal);
+			if (archivePath) {
+				const archiveSubPath = splitPathAndSel(archivePath.archiveSubPath);
+				const archiveParsed = parseSel(archiveSubPath.sel);
+				return this.#readArchive(
+					readPath,
+					archiveParsed,
+					{ ...archivePath, archiveSubPath: archiveSubPath.path },
+					signal,
+				);
 			}
-			return this.#readPdfImageMember(
-				absolutePdfPath,
-				pdfImageMemberPath.pdfPath,
-				pdfImageMemberPath.member,
-				suffixResolution,
-				signal,
-			);
+
+			const sqlitePath = await this.#resolveSqliteReadPath(readPath, suffixCache, signal);
+			if (sqlitePath) {
+				return this.#readSqlite(sqlitePath, signal);
+			}
+
+			const pdfImageMemberPath = splitPdfImageMemberReadPath(readPath);
+			if (pdfImageMemberPath) {
+				let absolutePdfPath = resolveReadPath(pdfImageMemberPath.pdfPath, this.session.cwd);
+				let suffixResolution: { from: string; to: string } | undefined;
+				try {
+					const stat = await Bun.file(absolutePdfPath).stat();
+					if (stat.isDirectory())
+						throw new ToolError(`Path '${pdfImageMemberPath.pdfPath}' is a directory, not a PDF file`);
+				} catch (error) {
+					if (!isNotFoundError(error) || isRemoteMountPath(absolutePdfPath)) throw error;
+					const suffixMatch = await this.#findSuffixMatchCached(suffixCache, pdfImageMemberPath.pdfPath, signal);
+					if (!suffixMatch) throw new ToolError(`Path '${pdfImageMemberPath.pdfPath}' not found`);
+					absolutePdfPath = suffixMatch.absolutePath;
+					suffixResolution = { from: pdfImageMemberPath.pdfPath, to: suffixMatch.displayPath };
+				}
+				return this.#readPdfImageMember(
+					absolutePdfPath,
+					pdfImageMemberPath.pdfPath,
+					pdfImageMemberPath.member,
+					suffixResolution,
+					signal,
+				);
+			}
 		}
 
-		const localTarget = await splitPathAndSelPreferringLiteral(readPath, this.session.cwd);
+		const localTarget = literalSplit;
 		const localReadPath = localTarget.path;
 		const parsed = parseSel(localTarget.sel);
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -103,6 +103,7 @@ import {
 	splitDelimitedPathEntry,
 	splitInternalUrlSel,
 	splitPathAndSel,
+	splitPathAndSelPreferringLiteral,
 } from "./path-utils";
 import { formatBytes, replaceTabs, shortenPath, wrapBrackets } from "./render-utils";
 import {
@@ -2246,7 +2247,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			);
 		}
 
-		const localTarget = splitPathAndSel(readPath);
+		const localTarget = await splitPathAndSelPreferringLiteral(readPath, this.session.cwd);
 		const localReadPath = localTarget.path;
 		const parsed = parseSel(localTarget.sel);
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -99,7 +99,7 @@ import {
 	type LineRange,
 	parseLineRanges,
 	pathTargetsSsh,
-	resolveExistingReadPath,
+	probeLiteralPathExists,
 	resolveReadPath,
 	splitDelimitedPathEntry,
 	splitInternalUrlSel,
@@ -2249,7 +2249,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				: { path: readPath, sel: explicitSelector };
 		const rawPathIsLiteral =
 			explicitSelector !== undefined
-				? readPath.includes(":") && (await resolveExistingReadPath(readPath, this.session.cwd)) !== undefined
+				? readPath.includes(":") && (await probeLiteralPathExists(readPath, this.session.cwd)) !== "missing"
 				: literalSplit.sel === undefined && splitPathAndSel(readPath).sel !== undefined;
 
 		if (!rawPathIsLiteral) {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2118,8 +2118,8 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		_toolContext?: AgentToolContext,
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
-		const explicitSelector = params.selector?.trim();
-		const explicitParsedSelector = explicitSelector === undefined ? undefined : parseSel(explicitSelector);
+		let explicitSelector = params.selector?.trim();
+		let explicitParsedSelector = explicitSelector === undefined ? undefined : parseSel(explicitSelector);
 		if (
 			params.selector !== undefined &&
 			(explicitSelector === undefined || explicitSelector.length === 0 || explicitParsedSelector?.kind === "none")
@@ -2221,10 +2221,16 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					skills: this.session.skills,
 				});
 				if (localFile) {
-					readPath =
-						explicitSelector !== undefined || internalTarget.sel === undefined
-							? localFile.path
-							: `${localFile.path}:${internalTarget.sel}`;
+					readPath = localFile.path;
+					// Promote the URL-embedded selector into the explicit-selector state so
+					// downstream literal-preferring routing does NOT re-split the synthesized
+					// `${localFile.path}:${sel}` string — a sibling literal file at that name
+					// would otherwise shadow the intended local:// URL selector semantics
+					// (issue #4618 reviewer feedback on c493d12).
+					if (explicitSelector === undefined && internalTarget.sel !== undefined) {
+						explicitSelector = internalTarget.sel;
+						explicitParsedSelector = parsed;
+					}
 				} else {
 					return this.#handleInternalUrl(internalTarget.path, parsed, signal);
 				}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -99,6 +99,7 @@ import {
 	type LineRange,
 	parseLineRanges,
 	pathTargetsSsh,
+	resolveExistingReadPath,
 	resolveReadPath,
 	splitDelimitedPathEntry,
 	splitInternalUrlSel,
@@ -747,7 +748,10 @@ function splitPdfImageMemberReadPath(readPath: string): { pdfPath: string; membe
 
 const readSchema = type({
 	path: type("string").describe(
-		'Local path, internal URI (e.g. "omp://", "issue://123", "pr://123"), or URL; append :<sel> for line ranges or raw mode (e.g. "src/foo.ts:50-100")',
+		'Local path, internal URI (e.g. "omp://", "issue://123", "pr://123"), or URL. Inline :<sel> is still accepted for compatibility.',
+	),
+	"selector?": type("string").describe(
+		'selector without a leading colon (e.g. "50-100", "raw", "raw:50-100", "conflicts"); keeps `path` literal when filenames contain colons',
 	),
 });
 
@@ -2114,6 +2118,14 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		_toolContext?: AgentToolContext,
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
+		const explicitSelector = params.selector?.trim();
+		const explicitParsedSelector = explicitSelector === undefined ? undefined : parseSel(explicitSelector);
+		if (
+			params.selector !== undefined &&
+			(explicitSelector === undefined || explicitSelector.length === 0 || explicitParsedSelector?.kind === "none")
+		) {
+			throw invalidSelector(params.selector);
+		}
 		if (readPath.startsWith("file://")) {
 			readPath = expandPath(readPath);
 		}
@@ -2134,40 +2146,55 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			if (!this.session.settings.get("fetch.enabled")) {
 				throw new ToolError("URL reads are disabled by settings.");
 			}
-			if (parsedUrlTarget.ranges !== undefined) {
+			if (explicitParsedSelector?.kind === "conflicts") {
+				throw new ToolError("The explicit read selector `conflicts` is only supported for local files.");
+			}
+			const urlRaw =
+				explicitParsedSelector === undefined ? parsedUrlTarget.raw : isRawSelector(explicitParsedSelector);
+			const urlRanges =
+				explicitParsedSelector?.kind === "lines" ? explicitParsedSelector.ranges : parsedUrlTarget.ranges;
+			if (urlRanges !== undefined && urlRanges.length > 1) {
 				const cached = await loadReadUrlCacheEntry(
 					this.session,
-					{ path: parsedUrlTarget.path, raw: parsedUrlTarget.raw },
+					{ path: parsedUrlTarget.path, raw: urlRaw },
 					signal,
 					{ ensureArtifact: true, preferCached: true },
 				);
-				return this.#buildInMemoryMultiRangeResult(cached.output, parsedUrlTarget.ranges, {
+				return this.#buildInMemoryMultiRangeResult(cached.output, urlRanges, {
 					details: { ...cached.details },
 					sourceUrl: cached.details.finalUrl,
 					entityLabel: "URL output",
-					raw: parsedUrlTarget.raw,
+					raw: urlRaw,
 					immutable: true,
 				});
 			}
-			if (parsedUrlTarget.offset !== undefined || parsedUrlTarget.limit !== undefined) {
+			const urlRange = urlRanges?.[0];
+			const urlOffset = explicitParsedSelector?.kind === "lines" ? urlRange?.startLine : parsedUrlTarget.offset;
+			const urlLimit =
+				explicitParsedSelector?.kind === "lines" && urlRange
+					? urlRange.endLine !== undefined
+						? urlRange.endLine - urlRange.startLine + 1
+						: undefined
+					: parsedUrlTarget.limit;
+			if (urlOffset !== undefined || urlLimit !== undefined) {
 				const cached = await loadReadUrlCacheEntry(
 					this.session,
-					{ path: parsedUrlTarget.path, raw: parsedUrlTarget.raw },
+					{ path: parsedUrlTarget.path, raw: urlRaw },
 					signal,
 					{
 						ensureArtifact: true,
 						preferCached: true,
 					},
 				);
-				return this.#buildInMemoryTextResult(cached.output, parsedUrlTarget.offset, parsedUrlTarget.limit, {
+				return this.#buildInMemoryTextResult(cached.output, urlOffset, urlLimit, {
 					details: { ...cached.details },
 					sourceUrl: cached.details.finalUrl,
 					entityLabel: "URL output",
-					raw: parsedUrlTarget.raw,
+					raw: urlRaw,
 					immutable: true,
 				});
 			}
-			return executeReadUrl(this.session, { path: parsedUrlTarget.path, raw: parsedUrlTarget.raw }, signal);
+			return executeReadUrl(this.session, { path: parsedUrlTarget.path, raw: urlRaw }, signal);
 		}
 
 		// Handle internal URLs (agent://, artifact://, memory://, skill://, rule://, local://, mcp://, omp://, issue://, pr://).
@@ -2175,8 +2202,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// off the URL and surfaced via parseSel rather than confusing handlers.
 		const internalRouter = InternalUrlRouter.instance();
 		if (internalRouter.canHandle(readPath)) {
-			const internalTarget = splitInternalUrlSel(readPath);
-			const parsed = parseSel(internalTarget.sel);
+			const internalTarget =
+				explicitSelector === undefined ? splitInternalUrlSel(readPath) : { path: readPath, sel: explicitSelector };
+			const parsed = explicitParsedSelector ?? parseSel(internalTarget.sel);
 			if (internalTarget.sel !== undefined && parsed.kind === "none") {
 				throw new ToolError(
 					`Invalid selector ':${internalTarget.sel}' on '${internalTarget.path}'. Use :N, :N-M, :N+K, :N- (open-ended), a comma-separated list of ranges, :raw, or a range combined with raw (e.g. :raw:50-100).`,
@@ -2193,7 +2221,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					skills: this.session.skills,
 				});
 				if (localFile) {
-					readPath = internalTarget.sel === undefined ? localFile.path : `${localFile.path}:${internalTarget.sel}`;
+					readPath =
+						explicitSelector !== undefined || internalTarget.sel === undefined
+							? localFile.path
+							: `${localFile.path}:${internalTarget.sel}`;
 				} else {
 					return this.#handleInternalUrl(internalTarget.path, parsed, signal);
 				}
@@ -2206,22 +2237,28 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// resolution share misses instead of re-globbing the workspace.
 		const suffixCache: SuffixMatchCache = new Map();
 
-		// Prefer a literal filesystem match over the strict `:<sel>` peel so real
-		// POSIX filenames whose tail matches the selector grammar (e.g. `test:1-2`,
-		// `data.zip:1-2`, `notes.db:raw`) win over the structured-path resolvers
-		// below. When the raw path resolves literally on disk AND the strict
-		// splitter would have peeled a selector, the archive / sqlite / pdf-image
-		// dispatchers must decline — otherwise `data.zip:1-2` still opens
-		// `data.zip` and errors on the phantom member (issue #4618).
-		const literalSplit = await splitPathAndSelPreferringLiteral(readPath, this.session.cwd);
-		// Literal wins whenever the strict grammar would have peeled a suffix but
-		// the async splitter decided to keep the raw path (fs.stat succeeded).
-		const rawPathIsLiteral = literalSplit.sel === undefined && splitPathAndSel(readPath).sel !== undefined;
+		// Prefer a literal filesystem match over selector interpretation so real
+		// POSIX filenames containing selector-looking suffixes win over structured
+		// archive / sqlite / pdf-image dispatch. With explicit `selector`, `path`
+		// is exact: `path: "test:1-2", selector: "1-2"` means "lines 1-2 from
+		// the literal file test:1-2", without recursively depending on whether a
+		// longer `test:1-2:1-2` filename also exists (issue #4618).
+		const literalSplit =
+			explicitSelector === undefined
+				? await splitPathAndSelPreferringLiteral(readPath, this.session.cwd)
+				: { path: readPath, sel: explicitSelector };
+		const rawPathIsLiteral =
+			explicitSelector !== undefined
+				? readPath.includes(":") && (await resolveExistingReadPath(readPath, this.session.cwd)) !== undefined
+				: literalSplit.sel === undefined && splitPathAndSel(readPath).sel !== undefined;
 
 		if (!rawPathIsLiteral) {
 			const archivePath = await this.#resolveArchiveReadPath(readPath, suffixCache, signal);
 			if (archivePath) {
-				const archiveSubPath = splitPathAndSel(archivePath.archiveSubPath);
+				const archiveSubPath =
+					explicitSelector === undefined
+						? splitPathAndSel(archivePath.archiveSubPath)
+						: { path: archivePath.archiveSubPath, sel: explicitSelector };
 				const archiveParsed = parseSel(archiveSubPath.sel);
 				return this.#readArchive(
 					readPath,

--- a/packages/coding-agent/test/tools/grep-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/grep-internal-urls.test.ts
@@ -450,6 +450,35 @@ describe("GrepTool internal URL resolution", () => {
 		expect(text).toMatch(/^\*\d+:.*needle/m);
 	});
 
+	it("read local://<name>:<sel> honors URL selector even when a sibling literal `<name>:<sel>` file exists (issue #4618)", async () => {
+		const localRoot = path.join(artifactsDir, "local");
+		await fs.mkdir(localRoot, { recursive: true });
+		// Base file targeted by `local://notes.md`; selector should slice this one.
+		await Bun.write(
+			path.join(localRoot, "notes.md"),
+			`${Array.from({ length: 10 }, (_, i) => `url-target line ${i + 1}`).join("\n")}\n`,
+		);
+		// Sibling literal `notes.md:1-2` under the same local root — must NOT
+		// shadow the URL selector semantics of `local://notes.md:1-2`.
+		await Bun.write(path.join(localRoot, "notes.md:1-2"), "sibling literal shadow\n");
+
+		LocalProtocolHandler.setOverride({ getArtifactsDir: () => artifactsDir, getSessionId: () => "session" });
+
+		const session = createSession({ hasEditTool: true });
+		session.settings.set("read.summarize.enabled", false);
+		const result = await new ReadTool(session).execute("test-read-local-url-selector", {
+			path: "local://notes.md:1-2",
+		});
+
+		const text = getResultText(result);
+		// The base file was targeted (URL selector semantics preserved), not the
+		// sibling literal. Content check is enough — the read tool's context
+		// expansion around the requested range is unrelated to the shadow bug.
+		expect(text).toContain("url-target line 1");
+		expect(text).toContain("url-target line 2");
+		expect(text).not.toContain("sibling literal shadow");
+	});
+
 	it("keeps hashlines on mutable files when mixed with immutable artifact:// inputs", async () => {
 		const content = "alpha line\nbeta needle line\ngamma line\n";
 		await Bun.write(path.join(artifactsDir, "11.bash.log"), content);

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -126,6 +126,46 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			expect(output).not.toContain("line 30");
 			expect(output).not.toContain("line 40");
 		});
+
+		it("reads a literal file that looks like an archive selector (`data.zip:1-2`)", async () => {
+			// A real POSIX file whose name ends in a selector-shaped tail after an
+			// archive extension. The archive resolver would otherwise open `data.zip`
+			// alongside it and error on the phantom member.
+			const baseArchive = path.join(tmpDir, "data.zip");
+			// Empty zip bytes — the file just needs to stat as a real archive so
+			// the archive resolver would happily accept it.
+			await Bun.write(
+				baseArchive,
+				new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+			);
+			const literal = path.join(tmpDir, "data.zip:1-2");
+			await Bun.write(literal, "literal archive-shaped file\n");
+
+			const tool = new ReadTool(createSession());
+			const result = await tool.execute("read-literal-zip-selector", { path: literal });
+			const output = getText(result);
+
+			expect(output).toContain("literal archive-shaped file");
+		});
+
+		it("reads a literal file that looks like a sqlite selector (`notes.db:1-2`)", async () => {
+			// A real POSIX file whose base name matches a sqlite-shaped path plus a
+			// selector-shaped tail. The sqlite resolver would misroute this to
+			// `notes.db` and try to open a table named `1-2`.
+			const baseDb = path.join(tmpDir, "notes.db");
+			// SQLite database header (16-byte magic string plus zero-padding).
+			const header = new Uint8Array(4096);
+			header.set(Buffer.from("SQLite format 3\0", "utf-8"), 0);
+			await Bun.write(baseDb, header);
+			const literal = path.join(tmpDir, "notes.db:1-2");
+			await Bun.write(literal, "literal db-shaped file\n");
+
+			const tool = new ReadTool(createSession());
+			const result = await tool.execute("read-literal-db-selector", { path: literal });
+			const output = getText(result);
+
+			expect(output).toContain("literal db-shaped file");
+		});
 	});
 
 	describe("grep tool", () => {

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -289,6 +289,24 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			expect(output).toContain("escaped literal needle");
 		});
 
+		it("searches a literal file whose name contains a semicolon and selector-shaped tail (`a;b:1-2`)", async () => {
+			// Semicolon is the delimited-path separator; without a raw-literal
+			// probe in `splitDelimitedPathEntry`, expandDelimitedPathEntries would
+			// split `a;b:1-2` into `["a", "b:1-2"]` before grep saw the literal file.
+			const literal = path.join(tmpDir, "a;b:1-2");
+			await Bun.write(literal, "delimited literal needle\n");
+
+			const tool = new GrepTool(createSession());
+			const result = await tool.execute("grep-literal-semicolon-selector", {
+				pattern: "needle",
+				path: literal,
+			});
+			const output = getText(result);
+
+			expect(output).toContain("delimited literal needle");
+			expect(output).not.toMatch(/not found/i);
+		});
+
 		it("searches a literal file that looks like an archive selector (`data.zip:1-2`)", async () => {
 			// The base archive exists too; grep must not rematerialize the raw
 			// literal path as archive `data.zip` plus phantom member `1-2`.

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { splitPathAndSel, splitPathAndSelPreferringLiteral } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { GrepTool } from "../../src/tools/grep";
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter(entry => entry.type === "text")
+		.map(entry => entry.text ?? "")
+		.join("\n");
+}
+
+// Regression: filenames whose tail matches the read-tool selector grammar
+// (e.g. `test:1-2`, `log:raw`) used to be shredded by `splitPathAndSel` before
+// either tool checked the filesystem — see issue #4618. Both `read` and `grep`
+// must prefer a real literal file over the selector interpretation.
+describe("literal colon filename resolution (issue #4618)", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "literal-colon-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(tmpDir);
+	});
+
+	function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
+		return {
+			cwd: tmpDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated({ "grep.contextBefore": 0, "grep.contextAfter": 0 }),
+			...overrides,
+		};
+	}
+
+	describe("splitPathAndSelPreferringLiteral", () => {
+		it("keeps the raw path intact when a literal colon file exists on disk", async () => {
+			const literal = "test:1-2";
+			await Bun.write(path.join(tmpDir, literal), "test\n");
+
+			// Strict splitter still peels — this documents the contract the
+			// literal-preferring variant sits on top of.
+			expect(splitPathAndSel(literal)).toEqual({ path: "test", sel: "1-2" });
+
+			expect(await splitPathAndSelPreferringLiteral(literal, tmpDir)).toEqual({ path: literal });
+		});
+
+		it("falls back to selector interpretation when the literal path does not exist", async () => {
+			// No file created — the selector split wins because the raw path
+			// cannot be stat'd.
+			expect(await splitPathAndSelPreferringLiteral("test:1-2", tmpDir)).toEqual({
+				path: "test",
+				sel: "1-2",
+			});
+		});
+
+		it("also protects `:raw`-shaped literal filenames", async () => {
+			const literal = "log:raw";
+			await Bun.write(path.join(tmpDir, literal), "line one\nline two\n");
+			expect(await splitPathAndSelPreferringLiteral(literal, tmpDir)).toEqual({ path: literal });
+		});
+
+		it("returns the strict split unchanged when there is no selector tail", async () => {
+			expect(await splitPathAndSelPreferringLiteral("plain.txt", tmpDir)).toEqual({
+				path: "plain.txt",
+			});
+		});
+	});
+
+	describe("read tool", () => {
+		it("reads a literal file whose name ends in a selector-shaped suffix", async () => {
+			const literal = "test:1-2";
+			const absolute = path.join(tmpDir, literal);
+			await Bun.write(absolute, "test\n");
+
+			const tool = new ReadTool(createSession());
+			const result = await tool.execute("read-literal", { path: absolute });
+			const output = getText(result);
+
+			expect(output).toContain("test");
+			// The strict split would have opened `test` (which doesn't exist)
+			// and thrown "Path 'test' not found".
+			expect(output).not.toMatch(/not found/i);
+		});
+
+		it("prefers a real `foo:1-2` file over interpreting `:1-2` as a range on `foo`", async () => {
+			await Bun.write(path.join(tmpDir, "foo"), "line 1\nline 2\nline 3\n");
+			await Bun.write(path.join(tmpDir, "foo:1-2"), "colon file wins\n");
+
+			const tool = new ReadTool(createSession());
+			const result = await tool.execute("read-literal-wins", {
+				path: path.join(tmpDir, "foo:1-2"),
+			});
+			const output = getText(result);
+
+			expect(output).toContain("colon file wins");
+			expect(output).not.toContain("line 1");
+		});
+
+		it("still honors the `:5-10` selector when only the base file exists on disk", async () => {
+			const absolute = path.join(tmpDir, "notes");
+			const lines = Array.from({ length: 40 }, (_, i) => `line ${i + 1}`).join("\n");
+			await Bun.write(absolute, `${lines}\n`);
+
+			const session = createSession();
+			session.settings.set("read.summarize.enabled", false);
+			const tool = new ReadTool(session);
+			const result = await tool.execute("read-selector-preserved", {
+				path: `${absolute}:5-10`,
+			});
+			const output = getText(result);
+
+			expect(output).toContain("line 5");
+			expect(output).toContain("line 10");
+			// Lines well outside the requested range must not appear — the selector
+			// still peels because the raw `notes:5-10` path does not exist literally.
+			expect(output).not.toContain("line 30");
+			expect(output).not.toContain("line 40");
+		});
+	});
+
+	describe("grep tool", () => {
+		it("searches inside a literal `test:1-2` file", async () => {
+			const literal = "test:1-2";
+			const absolute = path.join(tmpDir, literal);
+			await Bun.write(absolute, "needle\n");
+
+			const tool = new GrepTool(createSession());
+			const result = await tool.execute("grep-literal", {
+				pattern: "needle",
+				path: absolute,
+			});
+			const output = getText(result);
+
+			expect(output).toContain("needle");
+			expect(output).not.toMatch(/not found/i);
+		});
+
+		it("preserves `:N-M` line-range filtering when the literal file does not exist", async () => {
+			const absolute = path.join(tmpDir, "notes.txt");
+			await Bun.write(absolute, "one\ntwo\nthree\nfour\n");
+
+			const tool = new GrepTool(createSession());
+			const rangedResult = await tool.execute("grep-range-filter", {
+				pattern: ".",
+				path: `${absolute}:1-2`,
+			});
+			const rangedOutput = getText(rangedResult);
+
+			expect(rangedOutput).toContain("one");
+			expect(rangedOutput).toContain("two");
+			// Lines outside the range are filtered out.
+			expect(rangedOutput).not.toContain("three");
+			expect(rangedOutput).not.toContain("four");
+		});
+	});
+});

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -16,6 +16,8 @@ function getText(result: { content: Array<{ type: string; text?: string }> }): s
 		.join("\n");
 }
 
+const EMPTY_ZIP_EOCD = new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
 // Regression: filenames whose tail matches the read-tool selector grammar
 // (e.g. `test:1-2`, `log:raw`) used to be shredded by `splitPathAndSel` before
 // either tool checked the filesystem — see issue #4618. Both `read` and `grep`
@@ -134,10 +136,7 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			const baseArchive = path.join(tmpDir, "data.zip");
 			// Empty zip bytes — the file just needs to stat as a real archive so
 			// the archive resolver would happily accept it.
-			await Bun.write(
-				baseArchive,
-				new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-			);
+			await Bun.write(baseArchive, EMPTY_ZIP_EOCD);
 			const literal = path.join(tmpDir, "data.zip:1-2");
 			await Bun.write(literal, "literal archive-shaped file\n");
 
@@ -183,6 +182,24 @@ describe("literal colon filename resolution (issue #4618)", () => {
 
 			expect(output).toContain("needle");
 			expect(output).not.toMatch(/not found/i);
+		});
+
+		it("searches a literal file that looks like an archive selector (`data.zip:1-2`)", async () => {
+			// The base archive exists too; grep must not rematerialize the raw
+			// literal path as archive `data.zip` plus phantom member `1-2`.
+			const baseArchive = path.join(tmpDir, "data.zip");
+			await Bun.write(baseArchive, EMPTY_ZIP_EOCD);
+			const literal = path.join(tmpDir, "data.zip:1-2");
+			await Bun.write(literal, "literal archive needle\n");
+
+			const tool = new GrepTool(createSession());
+			const result = await tool.execute("grep-literal-zip-selector", {
+				pattern: "needle",
+				path: literal,
+			});
+			const output = getText(result);
+
+			expect(output).toContain("literal archive needle");
 		});
 
 		it("preserves `:N-M` line-range filtering when the literal file does not exist", async () => {

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -149,6 +149,28 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			expect(output).not.toContain("line 40");
 		});
 
+		it("uses explicit `selector` to read lines from a literal selector-shaped filename deterministically", async () => {
+			const literal = path.join(tmpDir, "test:1-2");
+			const longerLiteral = path.join(tmpDir, "test:1-2:5-6");
+			const lines = Array.from({ length: 40 }, (_, i) => `literal line ${i + 1}`).join("\n");
+			await Bun.write(literal, `${lines}\n`);
+			await Bun.write(longerLiteral, "wrong longer literal\n");
+
+			const session = createSession();
+			session.settings.set("read.summarize.enabled", false);
+			const tool = new ReadTool(session);
+			const result = await tool.execute("read-explicit-selector-literal", {
+				path: literal,
+				selector: "5-6",
+			});
+			const output = getText(result);
+
+			expect(output).toContain("literal line 5");
+			expect(output).toContain("literal line 6");
+			expect(output).not.toContain("literal line 30");
+			expect(output).not.toContain("wrong longer literal");
+		});
+
 		it("reads a literal file that looks like an archive selector (`data.zip:1-2`)", async () => {
 			// A real POSIX file whose name ends in a selector-shaped tail after an
 			// archive extension. The archive resolver would otherwise open `data.zip`
@@ -202,6 +224,25 @@ describe("literal colon filename resolution (issue #4618)", () => {
 
 			expect(output).toContain("needle");
 			expect(output).not.toMatch(/not found/i);
+		});
+
+		it("uses explicit `selector` to grep a literal selector-shaped filename deterministically", async () => {
+			const literal = path.join(tmpDir, "test:1-2");
+			const longerLiteral = path.join(tmpDir, "test:1-2:2-2");
+			await Bun.write(literal, "needle outside\nneedle inside\nneedle outside again\n");
+			await Bun.write(longerLiteral, "wrong longer literal needle\n");
+
+			const tool = new GrepTool(createSession());
+			const result = await tool.execute("grep-explicit-selector-literal", {
+				pattern: "needle",
+				path: literal,
+				selector: "2-2",
+			});
+			const output = getText(result);
+
+			expect(output).toContain("needle inside");
+			expect(output).not.toContain("needle outside again");
+			expect(output).not.toContain("wrong longer literal");
 		});
 
 		it("searches a shell-escaped literal file whose name ends in a selector-shaped suffix", async () => {

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -56,6 +56,15 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			expect(await splitPathAndSelPreferringLiteral(literal, tmpDir)).toEqual({ path: literal });
 		});
 
+		it("keeps a shell-escaped literal path intact when the resolved file exists", async () => {
+			await fs.mkdir(path.join(tmpDir, "dir"), { recursive: true });
+			await Bun.write(path.join(tmpDir, "dir", "a b:1-2"), "escaped literal\n");
+
+			expect(await splitPathAndSelPreferringLiteral("dir/a\\ b:1-2", tmpDir)).toEqual({
+				path: "dir/a\\ b:1-2",
+			});
+		});
+
 		it("falls back to selector interpretation when the literal path does not exist", async () => {
 			// No file created — the selector split wins because the raw path
 			// cannot be stat'd.
@@ -92,6 +101,17 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			// The strict split would have opened `test` (which doesn't exist)
 			// and thrown "Path 'test' not found".
 			expect(output).not.toMatch(/not found/i);
+		});
+
+		it("reads a shell-escaped literal file whose name ends in a selector-shaped suffix", async () => {
+			await fs.mkdir(path.join(tmpDir, "dir"), { recursive: true });
+			await Bun.write(path.join(tmpDir, "dir", "a b:1-2"), "escaped literal read\n");
+
+			const tool = new ReadTool(createSession());
+			const result = await tool.execute("read-escaped-literal", { path: "dir/a\\ b:1-2" });
+			const output = getText(result);
+
+			expect(output).toContain("escaped literal read");
 		});
 
 		it("prefers a real `foo:1-2` file over interpreting `:1-2` as a range on `foo`", async () => {
@@ -182,6 +202,20 @@ describe("literal colon filename resolution (issue #4618)", () => {
 
 			expect(output).toContain("needle");
 			expect(output).not.toMatch(/not found/i);
+		});
+
+		it("searches a shell-escaped literal file whose name ends in a selector-shaped suffix", async () => {
+			await fs.mkdir(path.join(tmpDir, "dir"), { recursive: true });
+			await Bun.write(path.join(tmpDir, "dir", "a b:1-2"), "escaped literal needle\n");
+
+			const tool = new GrepTool(createSession());
+			const result = await tool.execute("grep-escaped-literal", {
+				pattern: "needle",
+				path: "dir/a\\ b:1-2",
+			});
+			const output = getText(result);
+
+			expect(output).toContain("escaped literal needle");
 		});
 
 		it("searches a literal file that looks like an archive selector (`data.zip:1-2`)", async () => {

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -4,7 +4,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
-import { splitPathAndSel, splitPathAndSelPreferringLiteral } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
+import {
+	probeLiteralPathExists,
+	splitPathAndSel,
+	splitPathAndSelPreferringLiteral,
+} from "@oh-my-pi/pi-coding-agent/tools/path-utils";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 import { GrepTool } from "../../src/tools/grep";
@@ -80,10 +84,36 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			expect(await splitPathAndSelPreferringLiteral(literal, tmpDir)).toEqual({ path: literal });
 		});
 
+		it("keeps a literal dangling symlink intact (lstat exists even though stat fails)", async () => {
+			const literal = path.join(tmpDir, "test:1-2");
+			await fs.symlink(path.join(tmpDir, "missing-target"), literal);
+
+			expect(await probeLiteralPathExists(literal, tmpDir)).toBe("exists");
+			expect(await splitPathAndSelPreferringLiteral(literal, tmpDir)).toEqual({ path: literal });
+		});
+
 		it("returns the strict split unchanged when there is no selector tail", async () => {
 			expect(await splitPathAndSelPreferringLiteral("plain.txt", tmpDir)).toEqual({
 				path: "plain.txt",
 			});
+		});
+	});
+
+	describe("probeLiteralPathExists", () => {
+		it('returns "missing" for a path that clearly does not exist', async () => {
+			expect(await probeLiteralPathExists(path.join(tmpDir, "never-here:1-2"), tmpDir)).toBe("missing");
+		});
+
+		it('returns "exists" for a regular file', async () => {
+			const literal = path.join(tmpDir, "regular:1-2");
+			await Bun.write(literal, "hi\n");
+			expect(await probeLiteralPathExists(literal, tmpDir)).toBe("exists");
+		});
+
+		it('returns "exists" for a dangling symlink', async () => {
+			const literal = path.join(tmpDir, "dangling:1-2");
+			await fs.symlink(path.join(tmpDir, "nowhere"), literal);
+			expect(await probeLiteralPathExists(literal, tmpDir)).toBe("exists");
 		});
 	});
 


### PR DESCRIPTION
## Repro

On POSIX, filenames may legitimately contain colons, but `read` and `grep` unconditionally treated a trailing `:<selector>` as a line/raw selector. Given a real file whose name looks like `test:1-2`:

```
printf 'test\n' > 'test:1-2'
# read tool: {"path":"test:1-2"} -> Path 'test' not found
# grep tool: {"pattern":"test","path":"test:1-2"} -> Path not found: test
```

Reported in #4618.

## Cause

`splitPathAndSel` in `packages/coding-agent/src/tools/path-utils.ts` (~L290) peels a trailing `:<chunk>` whenever the tail matches the selector grammar (`raw`, `conflicts`, `N`, `N-M`, `N+K`, `N,M`, `raw:N-M`, …), with no filesystem check. `ReadTool.execute` (`read.ts` L2249) and `parsePathSpecs` in `grep.ts` (L171) both consume the strict split, so they open `test` / `log` before ever stat'ing the raw path.

## Fix

- Added `splitPathAndSelPreferringLiteral(rawPath, cwd)` in `path-utils.ts` — falls back to `splitPathAndSel` unless `fs.stat(rawPath)` succeeds against the raw input. Mirrors the existing `parseSearchPathPreferringLiteral` sibling for glob-shaped literal paths.
- Wired `ReadTool.execute` (non-URL, non-archive, non-sqlite, non-pdf-image branch) to the async variant.
- Wired `parsePathSpecs` in `grep.ts` to the async variant for the local-filesystem branch; converted the function and its single call site to `async`. Internal-URL splitting (`splitInternalUrlSel`) is untouched — URL schemes have unambiguous selector grammar.
- Added regression coverage in `packages/coding-agent/test/tools/path-literal-colon-selector.test.ts`: splitter fallbacks (literal wins when file exists, selector wins when it does not, `:raw`-shaped names), `read` on a literal `test:1-2` file and precedence when both `foo` and `foo:1-2` exist, and `grep` searching inside `test:1-2` — plus a positive check that `:5-10` still filters as before when only the base file exists.

## Verification

`bun test test/tools/path-literal-colon-selector.test.ts` — 9 pass. `bun test test/tools/path-utils-dotdot-selector.test.ts test/tools/split-internal-url-sel.test.ts test/tools/grep-path-lists.test.ts test/tools/grep-internal-urls.test.ts test/read-multi-range.test.ts test/read-summary.test.ts test/read-tool-group.test.ts` — 115 pass, no regressions. `bun check` — clean. The one unrelated failure emitted by `grep-path-lists.test.ts` (`Cannot find module './tool-views.generated.js'`) reproduces on `main` without any changes on this branch and is pre-existing.

Fixes #4618