### PR TITLE
fix(task): isolate OverlayFS lowerdir from live repo

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed OverlayFS isolated subagents using the live writable repository as their lower layer by creating a detached dirty-state worktree snapshot before mounting the overlay ([#4621](https://github.com/can1357/oh-my-pi/issues/4621)).
+- Fixed OverlayFS isolated subagents using the live writable repository as their lower layer by creating a detached dirty-state worktree snapshot, including live ignored files and initialized submodule contents, before mounting the overlay ([#4621](https://github.com/can1357/oh-my-pi/issues/4621)).
 
 ## [16.3.8] - 2026-07-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OverlayFS isolated subagents using the live writable repository as their lower layer by creating a detached dirty-state worktree snapshot before mounting the overlay ([#4621](https://github.com/can1357/oh-my-pi/issues/4621)).
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@oh-my-pi/pi-natives";
-import { getWorktreeDir, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, isEnoent, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import * as git from "../utils/git";
 import * as jj from "../utils/jj";
 import { mapWithConcurrencyLimit } from "./parallel";
@@ -417,28 +417,30 @@ function getTaskIsolationSegment(repoRoot: string, id: string): string {
 	return `${TASK_ISOLATION_DIR_PREFIX}${digest}`;
 }
 
-async function copyUntrackedEntries(
-	repoRoot: string,
-	snapshotDir: string,
-	untracked: readonly string[],
-): Promise<void> {
-	for (const entry of untracked) {
+async function copyLiveEntries(repoRoot: string, snapshotDir: string, entries: readonly string[]): Promise<void> {
+	for (const entry of new Set(entries)) {
 		const source = path.join(repoRoot, entry);
 		const destination = path.join(snapshotDir, entry);
 		await fs.mkdir(path.dirname(destination), { recursive: true });
-		await fs.cp(source, destination, {
-			force: true,
-			recursive: true,
-			verbatimSymlinks: true,
-		});
+		try {
+			await fs.cp(source, destination, {
+				force: true,
+				recursive: true,
+				verbatimSymlinks: true,
+			});
+		} catch (err) {
+			if (!isEnoent(err)) throw err;
+		}
 	}
 }
 
 async function seedOverlaySnapshotDirtyState(repoRoot: string, snapshotDir: string): Promise<void> {
-	const [staged, unstaged, untracked] = await Promise.all([
+	const [staged, unstaged, untracked, ignored, submodules] = await Promise.all([
 		git.diff(repoRoot, { binary: true, cached: true }),
 		git.diff(repoRoot, { binary: true }),
 		git.ls.untracked(repoRoot),
+		git.ls.ignored(repoRoot),
+		git.ls.submodules(repoRoot),
 	]);
 
 	if (staged.trim()) {
@@ -448,7 +450,7 @@ async function seedOverlaySnapshotDirtyState(repoRoot: string, snapshotDir: stri
 	if (unstaged.trim()) {
 		await git.patch.applyText(snapshotDir, unstaged);
 	}
-	await copyUntrackedEntries(repoRoot, snapshotDir, untracked);
+	await copyLiveEntries(repoRoot, snapshotDir, [...untracked, ...ignored, ...submodules]);
 }
 
 async function removeOverlaySnapshot(

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -13,6 +13,7 @@ const { IsoBackendKind } = natives;
 const TASK_ISOLATION_DIR_PREFIX = "t";
 const TASK_ISOLATION_DIR_DIGEST_CHARS = 9;
 const TASK_ISOLATION_MOUNT_DIR = "m";
+const TASK_ISOLATION_SNAPSHOT_DIR = "s";
 type IsoBackendKind = natives.IsoBackendKind;
 
 /** Baseline state for a single git repository. */
@@ -389,6 +390,15 @@ export interface IsolationHandle {
 	fellBack: boolean;
 	/** Optional reason associated with `fellBack`. */
 	fallbackReason: string | null;
+	/** Detached worktree lowerdir used only by OverlayFS. */
+	overlaySnapshot?: OverlaySnapshotLower;
+}
+
+interface OverlaySnapshotLower {
+	/** Repository that owns the temporary detached worktree. */
+	repoRoot: string;
+	/** Frozen lowerdir passed to the OverlayFS backend. */
+	snapshotDir: string;
 }
 
 /**
@@ -397,7 +407,6 @@ export interface IsolationHandle {
  * caller learns about that through `IsolationHandle.fellBack` +
  * `fallbackReason`.
  */
-
 function errorMessage(err: unknown): string {
 	return err instanceof Error ? err.message : String(err);
 }
@@ -406,6 +415,73 @@ function getTaskIsolationSegment(repoRoot: string, id: string): string {
 	const key = `${path.resolve(repoRoot)}\0${id}`;
 	const digest = Bun.hash(key).toString(16).padStart(16, "0").slice(-TASK_ISOLATION_DIR_DIGEST_CHARS);
 	return `${TASK_ISOLATION_DIR_PREFIX}${digest}`;
+}
+
+async function copyUntrackedEntries(
+	repoRoot: string,
+	snapshotDir: string,
+	untracked: readonly string[],
+): Promise<void> {
+	for (const entry of untracked) {
+		const source = path.join(repoRoot, entry);
+		const destination = path.join(snapshotDir, entry);
+		await fs.mkdir(path.dirname(destination), { recursive: true });
+		await fs.cp(source, destination, {
+			force: true,
+			recursive: true,
+			verbatimSymlinks: true,
+		});
+	}
+}
+
+async function seedOverlaySnapshotDirtyState(repoRoot: string, snapshotDir: string): Promise<void> {
+	const [staged, unstaged, untracked] = await Promise.all([
+		git.diff(repoRoot, { binary: true, cached: true }),
+		git.diff(repoRoot, { binary: true }),
+		git.ls.untracked(repoRoot),
+	]);
+
+	if (staged.trim()) {
+		await git.patch.applyText(snapshotDir, staged, { cached: true });
+		await git.patch.applyText(snapshotDir, staged);
+	}
+	if (unstaged.trim()) {
+		await git.patch.applyText(snapshotDir, unstaged);
+	}
+	await copyUntrackedEntries(repoRoot, snapshotDir, untracked);
+}
+
+async function removeOverlaySnapshot(
+	snapshot: OverlaySnapshotLower,
+	options: { repoLockHeld?: boolean } = {},
+): Promise<void> {
+	const remove = async () => {
+		if (!(await git.worktree.tryRemove(snapshot.repoRoot, snapshot.snapshotDir))) {
+			await fs.rm(snapshot.snapshotDir, { recursive: true, force: true });
+		}
+	};
+
+	if (options.repoLockHeld) {
+		await remove();
+	} else {
+		await git.withRepoLock(snapshot.repoRoot, remove);
+	}
+}
+
+async function createOverlaySnapshotLower(repoRoot: string, baseDir: string): Promise<OverlaySnapshotLower> {
+	const snapshotDir = path.join(baseDir, TASK_ISOLATION_SNAPSHOT_DIR);
+	const snapshot = { repoRoot, snapshotDir };
+	await fs.mkdir(baseDir, { recursive: true });
+	await git.withRepoLock(repoRoot, async () => {
+		await git.worktree.add(repoRoot, snapshotDir, "HEAD", { detach: true });
+		try {
+			await seedOverlaySnapshotDirtyState(repoRoot, snapshotDir);
+		} catch (err) {
+			await removeOverlaySnapshot(snapshot, { repoLockHeld: true });
+			throw err;
+		}
+	});
+	return snapshot;
 }
 
 export async function ensureIsolation(
@@ -422,15 +498,20 @@ export async function ensureIsolation(
 
 	for (const candidate of candidates) {
 		await fs.rm(baseDir, { recursive: true, force: true });
+		let overlaySnapshot: OverlaySnapshotLower | undefined;
 		try {
-			await natives.isoStart(candidate, repoRoot, mergedDir);
+			overlaySnapshot =
+				candidate === IsoBackendKind.Overlayfs ? await createOverlaySnapshotLower(repoRoot, baseDir) : undefined;
+			await natives.isoStart(candidate, overlaySnapshot?.snapshotDir ?? repoRoot, mergedDir);
 			return {
 				mergedDir,
 				backend: candidate,
 				fellBack: candidate !== resolution.kind || resolution.fellBack,
 				fallbackReason,
+				overlaySnapshot,
 			};
 		} catch (err) {
+			if (overlaySnapshot) await removeOverlaySnapshot(overlaySnapshot);
 			await fs.rm(baseDir, { recursive: true, force: true });
 			const message = errorMessage(err);
 			if (!natives.isoIsUnavailableError(message)) {
@@ -456,8 +537,17 @@ export async function cleanupIsolation(handle: IsolationHandle): Promise<void> {
 			});
 		}
 	} finally {
-		// baseDir is the parent of the merged directory
 		const baseDir = path.dirname(handle.mergedDir);
+		if (handle.overlaySnapshot) {
+			try {
+				await removeOverlaySnapshot(handle.overlaySnapshot);
+			} catch (err) {
+				logger.warn("overlayfs snapshot worktree removal failed during cleanup", {
+					snapshotDir: handle.overlaySnapshot.snapshotDir,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
 		await fs.rm(baseDir, { recursive: true, force: true });
 	}
 }

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1926,17 +1926,23 @@ export const ls = {
 	/** List files tracked or untracked by git. */
 	async files(
 		cwd: string,
-		options: { others?: boolean; excludeStandard?: boolean; signal?: AbortSignal } = {},
+		options: { others?: boolean; ignored?: boolean; excludeStandard?: boolean; signal?: AbortSignal } = {},
 	): Promise<string[]> {
 		const args = ["ls-files"];
 		if (options.others) args.push("--others");
+		if (options.ignored) args.push("--ignored");
 		if (options.excludeStandard) args.push("--exclude-standard");
 		return splitLines(await runText(cwd, args, { readOnly: true, signal: options.signal }));
 	},
 
-	/** List untracked files (excludes ignored). */
+	/** List untracked files that are not ignored. */
 	async untracked(cwd: string, signal?: AbortSignal): Promise<string[]> {
 		return ls.files(cwd, { others: true, excludeStandard: true, signal });
+	},
+
+	/** List ignored live files that are not tracked by git. */
+	async ignored(cwd: string, signal?: AbortSignal): Promise<string[]> {
+		return ls.files(cwd, { others: true, ignored: true, excludeStandard: true, signal });
 	},
 
 	/** List paths present in a ref, optionally filtered to specific paths. */

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -121,6 +121,12 @@ describe("worktree isolation helpers", () => {
 			let handle: IsolationHandle | undefined;
 
 			try {
+				await fs.writeFile(path.join(repo, ".gitignore"), [".env", "ignored-dir/", ""].join("\n"));
+				await runGit(repo, ["add", ".gitignore"]);
+				await runGit(repo, ["commit", "-q", "-m", "ignore overlayfs fixtures"]);
+				await fs.writeFile(path.join(repo, ".env"), "ignored snapshot\n");
+				await fs.mkdir(path.join(repo, "ignored-dir"), { recursive: true });
+				await fs.writeFile(path.join(repo, "ignored-dir", "generated.txt"), "ignored generated snapshot\n");
 				await fs.writeFile(path.join(repo, "staged.txt"), "staged snapshot\n");
 				await runGit(repo, ["add", "staged.txt"]);
 				await fs.writeFile(path.join(repo, "merged.txt"), "unstaged snapshot\n");
@@ -146,15 +152,30 @@ describe("worktree isolation helpers", () => {
 				await expect(fs.readFile(path.join(lowerDir, "untracked.txt"), "utf8")).resolves.toBe(
 					"untracked snapshot\n",
 				);
+				await expect(fs.readFile(path.join(lowerDir, ".env"), "utf8")).resolves.toBe("ignored snapshot\n");
+				await expect(fs.readFile(path.join(lowerDir, "ignored-dir", "generated.txt"), "utf8")).resolves.toBe(
+					"ignored generated snapshot\n",
+				);
 
 				await fs.writeFile(path.join(repo, "merged.txt"), "parent edit after ensure\n");
 				await fs.writeFile(path.join(repo, "untracked.txt"), "parent untracked after ensure\n");
 				await fs.writeFile(path.join(repo, "late-parent.txt"), "late parent file\n");
+				await fs.writeFile(path.join(repo, ".env"), "parent ignored after ensure\n");
+				await fs.writeFile(
+					path.join(repo, "ignored-dir", "generated.txt"),
+					"parent ignored generated after ensure\n",
+				);
+				await fs.writeFile(path.join(repo, "ignored-dir", "late-generated.txt"), "late ignored parent file\n");
 
 				await expect(fs.readFile(path.join(lowerDir, "merged.txt"), "utf8")).resolves.toBe("unstaged snapshot\n");
 				await expect(fs.readFile(path.join(lowerDir, "untracked.txt"), "utf8")).resolves.toBe(
 					"untracked snapshot\n",
 				);
+				await expect(fs.readFile(path.join(lowerDir, ".env"), "utf8")).resolves.toBe("ignored snapshot\n");
+				await expect(fs.readFile(path.join(lowerDir, "ignored-dir", "generated.txt"), "utf8")).resolves.toBe(
+					"ignored generated snapshot\n",
+				);
+				expect(await Bun.file(path.join(lowerDir, "ignored-dir", "late-generated.txt")).exists()).toBe(false);
 				expect(await Bun.file(path.join(lowerDir, "late-parent.txt")).exists()).toBe(false);
 			} finally {
 				if (handle !== undefined) {

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -6,11 +6,13 @@ import {
 	applyNestedPatches,
 	captureBaseline,
 	captureDeltaPatch,
+	cleanupIsolation,
 	cleanupTaskBranches,
 	commitToBranch,
 	ensureIsolation,
 	getGitNoIndexNullPath,
 	getRepoRoot,
+	type IsolationHandle,
 	mergeTaskBranches,
 	parseIsolationMode,
 } from "@oh-my-pi/pi-coding-agent/task/worktree";
@@ -37,6 +39,24 @@ async function runGit(repo: string, args: string[]): Promise<string> {
 		throw new Error(stderr.trim() || stdout.trim() || `git ${args.join(" ")} failed with exit code ${exitCode ?? 0}`);
 	}
 	return stdout.trim();
+}
+
+async function runGitOutput(repo: string, args: string[]): Promise<string> {
+	const proc = Bun.spawn(["git", ...args], {
+		cwd: repo,
+		stderr: "pipe",
+		stdout: "pipe",
+		windowsHide: true,
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	if ((exitCode ?? 0) !== 0) {
+		throw new Error(stderr.trim() || stdout.trim() || `git ${args.join(" ")} failed with exit code ${exitCode ?? 0}`);
+	}
+	return stdout;
 }
 
 async function createGitRepo(): Promise<{ baseBranch: string; repo: string }> {
@@ -80,6 +100,133 @@ describe("worktree isolation helpers", () => {
 		expect(parseIsolationMode("block-clone")).toBe(natives.IsoBackendKind.WindowsBlockClone);
 		expect(parseIsolationMode("rcopy")).toBe(natives.IsoBackendKind.Rcopy);
 		expect(parseIsolationMode("worktree")).toBe(natives.IsoBackendKind.Rcopy);
+	});
+
+	describe("Overlayfs isolation", () => {
+		it("passes a detached dirty-state worktree snapshot as the Overlayfs lower", async () => {
+			const { repo } = await createGitRepo();
+			const worktreeBase = await fs.mkdtemp(path.join(os.tmpdir(), "omp-overlayfs-worktree-"));
+			tempDirs.push(worktreeBase);
+			const originalWorktreeDir = process.env.OMP_WORKTREE_DIR;
+			delete process.env.OMP_WORKTREE_DIR;
+			setWorktreesDir(worktreeBase);
+			vi.spyOn(natives, "isoResolve").mockReturnValue({
+				kind: natives.IsoBackendKind.Overlayfs,
+				candidates: [natives.IsoBackendKind.Overlayfs],
+				fellBack: false,
+				reason: undefined,
+			});
+			const isoStart = vi.spyOn(natives, "isoStart").mockResolvedValue(undefined);
+			vi.spyOn(natives, "isoStop").mockResolvedValue(undefined);
+			let handle: IsolationHandle | undefined;
+
+			try {
+				await fs.writeFile(path.join(repo, "staged.txt"), "staged snapshot\n");
+				await runGit(repo, ["add", "staged.txt"]);
+				await fs.writeFile(path.join(repo, "merged.txt"), "unstaged snapshot\n");
+				await fs.writeFile(path.join(repo, "untracked.txt"), "untracked snapshot\n");
+				const parentHead = await runGit(repo, ["rev-parse", "HEAD"]);
+
+				handle = await ensureIsolation(repo, "overlayfs-dirty-snapshot", natives.IsoBackendKind.Overlayfs);
+				const lowerDir = isoStart.mock.calls[0]?.[1];
+				if (lowerDir === undefined) {
+					throw new Error("Overlayfs isoStart was not called with a lower directory.");
+				}
+				if (path.resolve(lowerDir) === path.resolve(repo)) {
+					throw new Error("Overlayfs isoStart lower must be a frozen snapshot, not the live repo root.");
+				}
+
+				const worktreeList = await runGit(repo, ["worktree", "list", "--porcelain"]);
+				expect(worktreeList).toContain(`worktree ${lowerDir}\nHEAD ${parentHead}\ndetached`);
+				expect(await runGitOutput(lowerDir, ["status", "--porcelain=v1"])).toBe(
+					[" M merged.txt", "M  staged.txt", "?? untracked.txt", ""].join("\n"),
+				);
+				await expect(fs.readFile(path.join(lowerDir, "merged.txt"), "utf8")).resolves.toBe("unstaged snapshot\n");
+				await expect(fs.readFile(path.join(lowerDir, "staged.txt"), "utf8")).resolves.toBe("staged snapshot\n");
+				await expect(fs.readFile(path.join(lowerDir, "untracked.txt"), "utf8")).resolves.toBe(
+					"untracked snapshot\n",
+				);
+
+				await fs.writeFile(path.join(repo, "merged.txt"), "parent edit after ensure\n");
+				await fs.writeFile(path.join(repo, "untracked.txt"), "parent untracked after ensure\n");
+				await fs.writeFile(path.join(repo, "late-parent.txt"), "late parent file\n");
+
+				await expect(fs.readFile(path.join(lowerDir, "merged.txt"), "utf8")).resolves.toBe("unstaged snapshot\n");
+				await expect(fs.readFile(path.join(lowerDir, "untracked.txt"), "utf8")).resolves.toBe(
+					"untracked snapshot\n",
+				);
+				expect(await Bun.file(path.join(lowerDir, "late-parent.txt")).exists()).toBe(false);
+			} finally {
+				if (handle !== undefined) {
+					await cleanupIsolation(handle);
+				}
+				if (originalWorktreeDir === undefined) {
+					delete process.env.OMP_WORKTREE_DIR;
+				} else {
+					process.env.OMP_WORKTREE_DIR = originalWorktreeDir;
+				}
+				setWorktreesDir(undefined);
+			}
+		});
+
+		it("stops the backend before removing the registered Overlayfs snapshot worktree", async () => {
+			const { repo } = await createGitRepo();
+			const worktreeBase = await fs.mkdtemp(path.join(os.tmpdir(), "omp-overlayfs-cleanup-"));
+			tempDirs.push(worktreeBase);
+			const originalWorktreeDir = process.env.OMP_WORKTREE_DIR;
+			delete process.env.OMP_WORKTREE_DIR;
+			setWorktreesDir(worktreeBase);
+			vi.spyOn(natives, "isoResolve").mockReturnValue({
+				kind: natives.IsoBackendKind.Overlayfs,
+				candidates: [natives.IsoBackendKind.Overlayfs],
+				fellBack: false,
+				reason: undefined,
+			});
+			const isoStart = vi.spyOn(natives, "isoStart").mockResolvedValue(undefined);
+			let lowerDir: string | undefined;
+			let snapshotExistedDuringStop = false;
+			const isoStop = vi.spyOn(natives, "isoStop").mockImplementation(async () => {
+				snapshotExistedDuringStop =
+					lowerDir !== undefined &&
+					(await fs.stat(lowerDir).then(
+						stat => stat.isDirectory(),
+						() => false,
+					));
+			});
+
+			try {
+				const handle = await ensureIsolation(repo, "overlayfs-cleanup", natives.IsoBackendKind.Overlayfs);
+				lowerDir = isoStart.mock.calls[0]?.[1];
+				if (lowerDir === undefined) {
+					throw new Error("Overlayfs isoStart was not called with a lower directory.");
+				}
+				if (path.resolve(lowerDir) === path.resolve(repo)) {
+					throw new Error(
+						"Overlayfs isoStart lower must be a registered snapshot worktree, not the live repo root.",
+					);
+				}
+				expect(await runGit(repo, ["worktree", "list", "--porcelain"])).toContain(`worktree ${lowerDir}\n`);
+
+				await cleanupIsolation(handle);
+
+				expect(isoStop).toHaveBeenCalledWith(natives.IsoBackendKind.Overlayfs, handle.mergedDir);
+				expect(snapshotExistedDuringStop).toBe(true);
+				expect(
+					await fs.stat(lowerDir).then(
+						() => true,
+						() => false,
+					),
+				).toBe(false);
+				expect(await runGit(repo, ["worktree", "list", "--porcelain"])).not.toContain(`worktree ${lowerDir}\n`);
+			} finally {
+				if (originalWorktreeDir === undefined) {
+					delete process.env.OMP_WORKTREE_DIR;
+				} else {
+					process.env.OMP_WORKTREE_DIR = originalWorktreeDir;
+				}
+				setWorktreesDir(undefined);
+			}
+		});
 	});
 
 	// Real git worktree/stash/merge I/O is the contract under test and cannot be


### PR DESCRIPTION
## Repro
A focused regression test shows `ensureIsolation(..., Overlayfs)` must not pass the live repository as the native lowerdir: before the fix, `bun test packages/coding-agent/test/task/overlayfs-live-lower-repro.test.ts` failed because `natives.isoStart(Overlayfs, repoRoot, mergedDir)` received the mutable parent checkout. The local host did not have `fuse-overlayfs`, so I reproduced the contract failure directly instead of the kernel copy-up race.

## Cause
`packages/coding-agent/src/task/worktree.ts` called `natives.isoStart(candidate, repoRoot, mergedDir)` for every backend. For `IsoBackendKind.Overlayfs`, that made the live writable checkout the overlay lower layer, so subagent copy-up and git lock files could race parent writes against the same underlying tree.

## Fix
- Create a compact detached git worktree snapshot under the isolation base directory when the selected backend is `Overlayfs`.
- Seed the snapshot with the parent repo's staged, unstaged, and untracked dirty state before calling `natives.isoStart`.
- Pass the snapshot path, not `repoRoot`, as the OverlayFS lowerdir and remove the registered snapshot worktree during `cleanupIsolation` after `isoStop`.
- Add regression tests for dirty-state snapshot lowerdir semantics and cleanup ordering.
- Add a coding-agent changelog entry for #4621.

## Verification
`bun test packages/coding-agent/test/task/worktree.test.ts` passed: 34 tests, 149 assertions. `bun check` passed. Fixes #4621