### PR TITLE
fix(agent): support chat completions remote compaction endpoints

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -240,9 +240,9 @@ Prompt selection:
 
 Remote summarization modes:
 
-- If `compaction.remoteEndpoint` is set and remote compaction is enabled, local summary generation POSTs:
-  - `{ systemPrompt, prompt }`
-- Expects JSON containing at least `{ summary }`.
+- If `compaction.remoteEndpoint` is set and remote compaction is enabled, local summary generation POSTs one of two wire formats:
+  - custom omp summarizer endpoints receive `{ systemPrompt, prompt }` and must return JSON containing at least `{ summary }`.
+  - OpenAI-compatible endpoints whose path ends in `/chat/completions` receive `{ model, messages, stream: false }`, where `messages` contains one system prompt and one user prompt. The summary is read from `choices[0].message.content`, which lets self-hosted servers such as llama.cpp and vLLM act as remote compactors without a separate summarizer shim.
 - For OpenAI/OpenAI Codex models, compaction first tries the provider-native `/responses/compact` endpoint when remote compaction is enabled. It preserves provider replacement history in `preserveData.openaiRemoteCompaction` and falls back to local summarization if that native request fails.
 
 ### Handoff generation

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed generic remote compaction against OpenAI-compatible `/chat/completions` endpoints (for example llama.cpp `openai-completions`) by sending chat messages instead of the custom `{ systemPrompt, prompt }` summarizer payload. ([#4630](https://github.com/can1357/oh-my-pi/issues/4630))
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -813,14 +813,17 @@ export async function generateSummary(
 	];
 
 	if (options?.remoteEndpoint) {
-		const remote = await requestRemoteCompaction(
-			options.remoteEndpoint,
-			{
-				systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
-				prompt: promptText,
-			},
-			signal,
-			{ fetch: options.fetch },
+		const endpoint = options.remoteEndpoint;
+		const remote = await withAuth(
+			apiKey,
+			key =>
+				requestRemoteCompaction(
+					endpoint,
+					{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, prompt: promptText },
+					signal,
+					{ fetch: options.fetch, model, apiKey: key },
+				),
+			{ signal, missingKeyMessage: "Remote compaction credentials unavailable" },
 		);
 		return remote.summary;
 	}
@@ -1001,14 +1004,17 @@ async function generateShortSummary(
 	promptText += SHORT_SUMMARY_PROMPT;
 
 	if (options?.remoteEndpoint) {
-		const remote = await requestRemoteCompaction(
-			options.remoteEndpoint,
-			{
-				systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
-				prompt: promptText,
-			},
-			signal,
-			{ fetch: options?.fetch },
+		const endpoint = options.remoteEndpoint;
+		const remote = await withAuth(
+			apiKey,
+			key =>
+				requestRemoteCompaction(
+					endpoint,
+					{ systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, prompt: promptText },
+					signal,
+					{ fetch: options?.fetch, model, apiKey: key },
+				),
+			{ signal, missingKeyMessage: "Remote compaction credentials unavailable" },
 		);
 		return remote.summary;
 	}

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -558,7 +558,7 @@ export async function requestOpenAiRemoteCompaction(
  * local summarization, and context grew unbounded.
  *
  * When `context.model` is provided the chat-completions body is tagged with
- * that model id (llama.cpp requires the field) and `context.apiKey` is
+ * that model's wire id (llama.cpp requires the field) and `context.apiKey` is
  * forwarded as `Authorization: Bearer`. Callers wrap this in `withAuth` so
  * 401s force-refresh through the standard credential rotation policy.
  */
@@ -583,7 +583,7 @@ export async function requestRemoteCompaction(
 
 	const body: Record<string, unknown> = isChatCompletions
 		? {
-				model: opts?.model?.id,
+				model: opts?.model ? resolveOpenAiCompactModel(opts.model) : undefined,
 				messages: [
 					{ role: "system", content: request.systemPrompt },
 					{ role: "user", content: request.prompt },

--- a/packages/agent/src/compaction/openai.ts
+++ b/packages/agent/src/compaction/openai.ts
@@ -547,16 +547,55 @@ export async function requestOpenAiRemoteCompaction(
 	return { provider: model.provider, replacementHistory, compactionItem };
 }
 
+/**
+ * Generic remote-compaction POST. Two wire shapes are auto-selected by
+ * endpoint suffix so a single `compaction.remoteEndpoint` setting can point at
+ * either a purpose-built omp summarizer (`{systemPrompt, prompt}` → `{summary}`)
+ * or any OpenAI-compatible chat-completions server (`/chat/completions`,
+ * `/v1/chat/completions`, …) as reported for llama.cpp / vLLM / etc. in
+ * issue #4630: without this, the omp payload was rejected with
+ * HTTP 400 `"'messages' is required"`, compaction silently fell back to
+ * local summarization, and context grew unbounded.
+ *
+ * When `context.model` is provided the chat-completions body is tagged with
+ * that model id (llama.cpp requires the field) and `context.apiKey` is
+ * forwarded as `Authorization: Bearer`. Callers wrap this in `withAuth` so
+ * 401s force-refresh through the standard credential rotation policy.
+ */
 export async function requestRemoteCompaction(
 	endpoint: string,
 	request: RemoteCompactionRequest,
 	signal?: AbortSignal,
-	opts?: { fetch?: FetchImpl; timeoutMs?: number },
+	opts?: { fetch?: FetchImpl; timeoutMs?: number; model?: Model; apiKey?: string },
 ): Promise<RemoteCompactionResponse> {
+	let endpointPath = endpoint;
+	try {
+		endpointPath = new URL(endpoint).pathname;
+	} catch {
+		// Keep the raw endpoint for relative/custom fetch implementations.
+	}
+	const isChatCompletions = /\/chat\/completions\/?$/.test(endpointPath);
+	const headers: Record<string, string> = { "content-type": "application/json" };
+	if (isChatCompletions) {
+		if (opts?.apiKey) headers.Authorization = `Bearer ${opts.apiKey}`;
+		if (opts?.model?.headers) Object.assign(headers, opts.model.headers);
+	}
+
+	const body: Record<string, unknown> = isChatCompletions
+		? {
+				model: opts?.model?.id,
+				messages: [
+					{ role: "system", content: request.systemPrompt },
+					{ role: "user", content: request.prompt },
+				],
+				stream: false,
+			}
+		: { systemPrompt: request.systemPrompt, prompt: request.prompt };
+
 	const response = await (opts?.fetch ?? fetch)(endpoint, {
 		method: "POST",
-		headers: { "content-type": "application/json" },
-		body: JSON.stringify(request),
+		headers,
+		body: JSON.stringify(body),
 		signal: withRequestTimeout(signal, opts?.timeoutMs ?? REMOTE_COMPACTION_TIMEOUT_MS),
 	});
 
@@ -575,6 +614,31 @@ export async function requestRemoteCompaction(
 				headers: response.headers,
 			},
 		);
+	}
+
+	if (isChatCompletions) {
+		type ChatCompletionsResponse = {
+			choices?: Array<{
+				message?: {
+					content?: string | Array<{ type?: string; text?: string }> | null;
+				};
+			}>;
+		};
+		const data = (await response.json()) as ChatCompletionsResponse | undefined;
+		const choice = data?.choices?.[0]?.message?.content;
+		let summary: string | undefined;
+		if (typeof choice === "string") {
+			summary = choice;
+		} else if (Array.isArray(choice)) {
+			summary = choice
+				.filter((part): part is { type?: string; text: string } => typeof part?.text === "string")
+				.map(part => part.text)
+				.join("");
+		}
+		if (typeof summary !== "string" || summary.length === 0) {
+			throw new Error("Remote compaction response missing choices[0].message.content");
+		}
+		return { summary };
 	}
 
 	const data = (await response.json()) as RemoteCompactionResponse | undefined;

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -544,8 +544,10 @@ describe("requestOpenAiRemoteCompaction timeout", () => {
 describe("requestRemoteCompaction wire formats", () => {
 	test("uses OpenAI chat completions format for /chat/completions endpoints", async () => {
 		const model = buildModel({
-			id: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			id: "catalog-selection-id",
 			name: "Qwopus 3.6 35B-A3B Coder",
+			requestModelId: "provider-wire-id",
+			remoteCompaction: { model: "provider-compact-wire-id" },
 			api: "openai-completions",
 			provider: "local-llama",
 			baseUrl: "http://127.0.0.1:8001/v1",
@@ -577,7 +579,7 @@ describe("requestRemoteCompaction wire formats", () => {
 
 		expect(result).toEqual({ summary: "remote summary" });
 		expect(sentBody).toEqual({
-			model: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			model: "provider-compact-wire-id",
 			messages: [
 				{ role: "system", content: "summarize" },
 				{ role: "user", content: "<conversation>hello</conversation>" },
@@ -849,8 +851,9 @@ describe("compact() remote compaction failure handling", () => {
 			remoteStreamingV2Enabled: false,
 		};
 		const model = buildModel({
-			id: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			id: "catalog-selection-id",
 			name: "Qwopus 3.6 35B-A3B Coder",
+			requestModelId: "provider-wire-id",
 			api: "openai-completions",
 			provider: "local-llama",
 			baseUrl: "http://127.0.0.1:8001/v1",
@@ -880,7 +883,7 @@ describe("compact() remote compaction failure handling", () => {
 		expect(completeSpy).not.toHaveBeenCalled();
 		expect(requestBodies).toHaveLength(2);
 		expect(requestBodies[0]).toMatchObject({
-			model: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			model: "provider-wire-id",
 			messages: [{ role: "system" }, { role: "user", content: expect.stringContaining("long history") }],
 			stream: false,
 		});

--- a/packages/agent/test/remote-compaction.test.ts
+++ b/packages/agent/test/remote-compaction.test.ts
@@ -13,6 +13,7 @@ import {
 	getCompactionV2PreserveData,
 	requestCompactionV2Streaming,
 	requestOpenAiRemoteCompaction,
+	requestRemoteCompaction,
 	shouldUseCompactionV2Streaming,
 	shouldUseOpenAiRemoteCompaction,
 } from "@oh-my-pi/pi-agent-core/compaction/openai";
@@ -540,6 +541,74 @@ describe("requestOpenAiRemoteCompaction timeout", () => {
 	});
 });
 
+describe("requestRemoteCompaction wire formats", () => {
+	test("uses OpenAI chat completions format for /chat/completions endpoints", async () => {
+		const model = buildModel({
+			id: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			name: "Qwopus 3.6 35B-A3B Coder",
+			api: "openai-completions",
+			provider: "local-llama",
+			baseUrl: "http://127.0.0.1:8001/v1",
+			headers: { "x-local-llama": "1" },
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 131072,
+			maxTokens: 4096,
+		});
+		let sentBody: unknown;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			if (typeof init?.body !== "string") throw new Error("missing remote compaction request body");
+			sentBody = JSON.parse(init.body) as unknown;
+			const headers = new Headers(init.headers);
+			expect(headers.get("authorization")).toBe("Bearer local-key");
+			expect(headers.get("x-local-llama")).toBe("1");
+			return new Response(JSON.stringify({ choices: [{ message: { content: "remote summary" } }] }), {
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const result = await requestRemoteCompaction(
+			"http://127.0.0.1:8001/v1/chat/completions",
+			{ systemPrompt: "summarize", prompt: "<conversation>hello</conversation>" },
+			undefined,
+			{ fetch: fetchMock, model, apiKey: "local-key" },
+		);
+
+		expect(result).toEqual({ summary: "remote summary" });
+		expect(sentBody).toEqual({
+			model: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			messages: [
+				{ role: "system", content: "summarize" },
+				{ role: "user", content: "<conversation>hello</conversation>" },
+			],
+			stream: false,
+		});
+	});
+
+	test("keeps the generic omp summarizer format for other endpoints", async () => {
+		let sentBody: unknown;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			if (typeof init?.body !== "string") throw new Error("missing remote compaction request body");
+			sentBody = JSON.parse(init.body) as unknown;
+			expect(new Headers(init.headers).get("authorization")).toBeNull();
+			return new Response(JSON.stringify({ summary: "generic summary", shortSummary: "generic" }), {
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const result = await requestRemoteCompaction(
+			"https://compaction.example.test/summarize",
+			{ systemPrompt: "summarize", prompt: "<conversation>hello</conversation>" },
+			undefined,
+			{ fetch: fetchMock, apiKey: "unused-for-generic" },
+		);
+
+		expect(result).toEqual({ summary: "generic summary", shortSummary: "generic" });
+		expect(sentBody).toEqual({ systemPrompt: "summarize", prompt: "<conversation>hello</conversation>" });
+	});
+});
+
 describe("compact() remote compaction failure handling", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -769,6 +838,52 @@ describe("compact() remote compaction failure handling", () => {
 			}),
 		).rejects.toThrow();
 		expect(completeSpy).not.toHaveBeenCalled();
+	});
+
+	test("uses configured chat completions endpoints for openai-completions remote compaction", async () => {
+		const completeSpy = vi.spyOn(ai, "completeSimple").mockResolvedValue(localSummaryMessage("local fallback"));
+		const preparation = makePreparation();
+		preparation.settings = {
+			...preparation.settings,
+			remoteEndpoint: "http://127.0.0.1:8001/v1/chat/completions",
+			remoteStreamingV2Enabled: false,
+		};
+		const model = buildModel({
+			id: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			name: "Qwopus 3.6 35B-A3B Coder",
+			api: "openai-completions",
+			provider: "local-llama",
+			baseUrl: "http://127.0.0.1:8001/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 131072,
+			maxTokens: 4096,
+		});
+		const requestBodies: unknown[] = [];
+		const fetchMock: FetchImpl = async (_input, init) => {
+			if (typeof init?.body !== "string") throw new Error("missing remote compaction request body");
+			requestBodies.push(JSON.parse(init.body) as unknown);
+			expect(new Headers(init.headers).get("authorization")).toBe("Bearer local-key");
+			const summary = requestBodies.length === 1 ? "remote history summary" : "remote short summary";
+			return new Response(JSON.stringify({ choices: [{ message: { content: summary } }] }), {
+				headers: { "content-type": "application/json" },
+			});
+		};
+
+		const result = await compact(preparation, model, "local-key", undefined, undefined, {
+			fetch: fetchMock,
+		});
+
+		expect(result.summary).toContain("remote history summary");
+		expect(result.shortSummary).toBe("remote short summary");
+		expect(completeSpy).not.toHaveBeenCalled();
+		expect(requestBodies).toHaveLength(2);
+		expect(requestBodies[0]).toMatchObject({
+			model: "Jackrong/Qwopus3.6-35B-A3B-Coder",
+			messages: [{ role: "system" }, { role: "user", content: expect.stringContaining("long history") }],
+			stream: false,
+		});
 	});
 
 	test("remote compact server failure without abort still falls back to local summarization", async () => {


### PR DESCRIPTION
## Repro
Reproduced with a fake llama.cpp-style OpenAI-compatible `/v1/chat/completions` endpoint: `requestRemoteCompaction()` posted `{ systemPrompt, prompt }`, the endpoint rejected it with HTTP 400 `"'messages' is required"`, and no compacted history rewrite was produced. Command recorded for the issue: `bun run repro-4630.ts`.

## Cause
`packages/agent/src/compaction/openai.ts` only supported the custom omp remote summarizer wire format for `compaction.remoteEndpoint`: `{ systemPrompt, prompt }` in, `{ summary }` out. `packages/agent/src/compaction/compaction.ts` used that generic request path whenever `settings.remoteEndpoint` was configured, so an OpenAI-compatible chat completions server such as llama.cpp received no `messages` array and rejected the request.

## Fix
- Detect `compaction.remoteEndpoint` paths ending in `/chat/completions` inside `requestRemoteCompaction()` and send OpenAI chat-completions payloads (`model`, `messages`, `stream: false`) instead of the custom summarizer payload.
- Parse chat-completions summaries from `choices[0].message.content` while preserving the existing `{ systemPrompt, prompt }` / `{ summary }` behavior for non-chat endpoints.
- Pass the compaction model and bearer token through the generic remote compaction call sites so self-hosted `openai-completions` endpoints receive the model id and auth header when needed.
- Added direct wire-format tests and an end-to-end `compact()` regression for an `openai-completions` model using a `/v1/chat/completions` remote endpoint.
- Documented the two supported remote endpoint wire formats.

## Verification
`bun test packages/agent/test/remote-compaction.test.ts` passed: 19 tests, 80 assertions. `bun check` passed across the workspace. Fixes #4630