### PR TITLE
fix(open): report Windows opener failures via Start-Process exit codes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows browser-launch failures being unobservable: the opener now uses `%SystemRoot%`-resolved PowerShell `Start-Process` (via `-EncodedCommand`) instead of `rundll32`, which exits 0 unconditionally. Failures ShellExecute itself reports — missing target, no handler executable, access denied — now surface as non-zero exits and are logged; the encoded payload also keeps OAuth query strings (`&`-bearing) opaque to shell metacharacter parsing.
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/utils/open.ts
+++ b/packages/coding-agent/src/utils/open.ts
@@ -32,22 +32,48 @@ function getExistingWslLocalPath(urlOrPath: string): string | undefined {
 }
 
 /**
- * Resolve the Windows `rundll32.exe` command used to hand a URL/path to the
- * user's registered protocol handler. Anchoring to `%SystemRoot%\System32`
- * (rather than relying on `rundll32` being on `PATH`) survives environments
- * where the machine `PATH` no longer references `System32` — a common
- * real-world misconfiguration where `System32\Wbem` / `WindowsPowerShell` /
- * `OpenSSH` survive but `System32` itself is dropped. Bare `rundll32` on
- * such boxes throws `Executable not found in $PATH: "rundll32"` from
- * `Bun.spawn` before ShellExecute ever sees the URL.
+ * Resolve the Windows opener used to hand a URL/path to the user's registered
+ * protocol handler. PowerShell's `Start-Process` goes through ShellExecute
+ * like the previous `rundll32 url.dll,FileProtocolHandler`, with two
+ * advantages that make the delayed-failure telemetry in {@link openPath}
+ * actually observable on Windows:
+ *
+ * - `rundll32` exits 0 unconditionally, so no launch failure ever reaches the
+ *   non-zero-exit logging below. `Start-Process` surfaces the failures
+ *   ShellExecute itself reports — missing target file, no handler executable,
+ *   access denied — as exit code 1 (verified live: a nonexistent file path
+ *   exits 1; `$ErrorActionPreference='Stop'` additionally promotes any
+ *   non-terminating error classes). Known limitation shared by every opener:
+ *   an unregistered URL scheme exits 0 because Windows "handles" it by
+ *   offering the app-picker.
+ * - `-EncodedCommand` carries the target as a UTF-16LE/base64 payload, so no
+ *   cmd/PowerShell metacharacter parsing ever sees it (OAuth authorize URLs
+ *   carry `&`); inside the decoded script the target is a single-quoted
+ *   literal (no `$` expansion) with embedded quotes doubled.
+ *
+ * PowerShell is anchored to `%SystemRoot%\System32` for the same reason the
+ * previous revision anchored `rundll32`: machine PATHs that dropped
+ * `System32` are a real-world occurrence, and bare names throw
+ * `Executable not found in $PATH` from `Bun.spawn`. A bare-name fallback
+ * remains for exotic SystemRoot layouts.
  */
 function windowsOpenerCommand(target: string): string[] {
 	const systemRoot = process.env.SystemRoot?.trim() || process.env.SYSTEMROOT?.trim() || "C:\\Windows";
 	// `path.win32` (not the platform-adaptive `path.join`) keeps Windows path
 	// separators when tests run under a POSIX host and matches Windows call
 	// conventions on the real target.
-	const rundll32 = path.win32.join(systemRoot, "System32", "rundll32.exe");
-	return [rundll32, "url.dll,FileProtocolHandler", target];
+	const absolute = path.win32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+	const powershell = fs.existsSync(absolute) ? absolute : "powershell.exe";
+	const script = `$ErrorActionPreference='Stop';Start-Process '${target.replaceAll("'", "''")}'`;
+	return [
+		powershell,
+		"-NoProfile",
+		"-NonInteractive",
+		"-WindowStyle",
+		"Hidden",
+		"-EncodedCommand",
+		Buffer.from(script, "utf16le").toString("base64"),
+	];
 }
 /** Open a URL or file path in the default browser/application. Best-effort, never throws. */
 export function openPath(urlOrPath: string): void {

--- a/packages/coding-agent/test/utils/open.test.ts
+++ b/packages/coding-agent/test/utils/open.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { openPath } from "@oh-my-pi/pi-coding-agent/utils/open";
 import * as piUtils from "@oh-my-pi/pi-utils";
 import type { Subprocess } from "bun";
@@ -91,6 +92,12 @@ describe("openPath", () => {
 	it("opens existing WSL mount files through wslview with a Windows path", () => {
 		setPlatform("linux");
 		process.env.WSL_DISTRO_NAME = "Ubuntu";
+		// Keep the mocked linux platform deterministic on a Windows dev host:
+		// the real path.resolve would rewrite /mnt/c/… against the drive root.
+		const realResolve = path.resolve;
+		vi.spyOn(path, "resolve").mockImplementation((...segments: string[]) =>
+			segments.length === 1 && segments[0] === existingLinuxPath ? existingLinuxPath : realResolve(...segments),
+		);
 		vi.spyOn(piUtils, "$which").mockImplementation(command => (command === "wslview" ? "/usr/bin/wslview" : null));
 		vi.spyOn(fs, "existsSync").mockImplementation(candidate => candidate === existingLinuxPath);
 
@@ -133,50 +140,100 @@ describe("openPath", () => {
 		expect(spawnCalls.map(call => call.cmd)).toEqual([["xdg-open", existingLinuxPath]]);
 	});
 
-	it("resolves rundll32 through %SystemRoot% so a broken machine PATH cannot silence the opener", () => {
+	it("resolves PowerShell through %SystemRoot% so a broken machine PATH cannot silence the opener", () => {
 		setPlatform("win32");
 		const originalSystemRoot = process.env.SystemRoot;
 		process.env.SystemRoot = "D:\\CustomWindows";
+		const powershellPath = "D:\\CustomWindows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+		vi.spyOn(fs, "existsSync").mockImplementation(candidate => candidate === powershellPath);
 		try {
 			const spawnCalls: SpawnCall[] = [];
 			spySpawn(spawnCalls);
 
-			openPath("https://mcp.linear.app/authorize?state=xyz&code_challenge_method=S256");
+			const url = "https://mcp.linear.app/authorize?state=xyz&code_challenge_method=S256";
+			openPath(url);
 
 			expect(spawnCalls).toHaveLength(1);
 			const [call] = spawnCalls;
-			// Absolute rundll32 path — bare `rundll32` was the whole bug on Windows
-			// boxes where the machine PATH no longer references System32.
-			expect(call?.cmd[0]).toBe("D:\\CustomWindows\\System32\\rundll32.exe");
-			// Handler + URL forwarded verbatim as a single argv slot so `&` in the
-			// query string cannot be interpreted as a shell separator.
-			expect(call?.cmd.slice(1)).toEqual([
-				"url.dll,FileProtocolHandler",
-				"https://mcp.linear.app/authorize?state=xyz&code_challenge_method=S256",
+			// Absolute PowerShell path — bare executable names were the whole bug
+			// on Windows boxes where the machine PATH no longer references
+			// System32.
+			expect(call?.cmd[0]).toBe(powershellPath);
+			expect(call?.cmd.slice(1, -1)).toEqual([
+				"-NoProfile",
+				"-NonInteractive",
+				"-WindowStyle",
+				"Hidden",
+				"-EncodedCommand",
 			]);
+			// The target rides inside the UTF-16LE payload: no cmd/PowerShell
+			// metacharacter parsing ever sees the `&` in the query string, and the
+			// terminating error preference makes Start-Process failures exit 1 so
+			// openPath's non-zero-exit telemetry observes them (rundll32 always
+			// exited 0).
+			const decoded = Buffer.from(String(call?.cmd.at(-1)), "base64").toString("utf16le");
+			expect(decoded).toBe(`$ErrorActionPreference='Stop';Start-Process '${url}'`);
 		} finally {
 			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
 			else process.env.SystemRoot = originalSystemRoot;
 		}
 	});
 
-	it("falls back to C:\\Windows for rundll32 when SystemRoot is unset", () => {
+	it("doubles embedded single quotes so the target stays one PowerShell literal", () => {
+		setPlatform("win32");
+		vi.spyOn(fs, "existsSync").mockReturnValue(true);
+		const spawnCalls: SpawnCall[] = [];
+		spySpawn(spawnCalls);
+
+		openPath("C:\\Users\\o'brien\\report.html");
+
+		const decoded = Buffer.from(String(spawnCalls[0]?.cmd.at(-1)), "base64").toString("utf16le");
+		expect(decoded).toBe("$ErrorActionPreference='Stop';Start-Process 'C:\\Users\\o''brien\\report.html'");
+	});
+
+	it("falls back to C:\\Windows for PowerShell when SystemRoot is unset, and to the bare name when absent", () => {
 		setPlatform("win32");
 		const originalSystemRoot = process.env.SystemRoot;
 		const originalSystemRootLower = process.env.SYSTEMROOT;
 		delete process.env.SystemRoot;
 		delete process.env.SYSTEMROOT;
 		try {
+			const defaultPath = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+			const existsSpy = vi.spyOn(fs, "existsSync").mockImplementation(candidate => candidate === defaultPath);
 			const spawnCalls: SpawnCall[] = [];
 			spySpawn(spawnCalls);
 
 			openPath("https://example.com");
+			expect(spawnCalls[0]?.cmd[0]).toBe(defaultPath);
 
-			expect(spawnCalls).toHaveLength(1);
-			expect(spawnCalls[0]?.cmd[0]).toBe("C:\\Windows\\System32\\rundll32.exe");
+			// Exotic layout: resolved path missing → bare name via PATH.
+			existsSpy.mockReturnValue(false);
+			openPath("https://example.com");
+			expect(spawnCalls[1]?.cmd[0]).toBe("powershell.exe");
 		} finally {
 			if (originalSystemRoot !== undefined) process.env.SystemRoot = originalSystemRoot;
 			if (originalSystemRootLower !== undefined) process.env.SYSTEMROOT = originalSystemRootLower;
 		}
+	});
+
+	it("logs when the opener exits non-zero so Start-Process failures are diagnosable", async () => {
+		setPlatform("win32");
+		vi.spyOn(fs, "existsSync").mockReturnValue(true);
+		const warnSpy = vi.spyOn(piUtils.logger, "warn").mockImplementation((() => {}) as never);
+		const failing = {
+			pid: 1,
+			exited: Promise.resolve(1),
+			kill: () => true,
+		} as unknown as Subprocess;
+		vi.spyOn(Bun, "spawn").mockImplementation(() => failing);
+
+		openPath("https://example.com");
+		await failing.exited;
+		await Promise.resolve();
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			"External opener exited with non-zero status",
+			expect.objectContaining({ exitCode: 1 }),
+		);
 	});
 });


### PR DESCRIPTION
Follow-up to #4420, as discussed there (the opener change was deferred to a dedicated PR). Refs #4418.

## Problem

#4420 hardened the Windows opener by resolving `rundll32.exe` through `%SystemRoot%\System32` and added delayed-failure telemetry (`child.exited` → non-zero exits logged). But `rundll32 url.dll,FileProtocolHandler` **exits 0 unconditionally** — it never propagates handler failures — so on the one platform that opener serves, the non-zero-exit logging can never fire. A Windows launch failure past the spawn boundary (missing target, no handler executable, access denied) remains invisible: the transcript shows the attempt, the logs show nothing, and the user is silently routed onto the copy-URL fallback that #4418 was about.

## Fix

Replace the Windows opener command with `%SystemRoot%`-resolved PowerShell `Start-Process` via `-EncodedCommand`:

- **Failures become observable.** Failures ShellExecute itself reports — missing target file, no handler executable, access denied — surface as exit code 1 and reach the existing telemetry. Verified live on Windows 11: a nonexistent file path exits 1; `$ErrorActionPreference='Stop'` additionally promotes non-terminating error classes. Documented limitation shared by every opener: an *unregistered URL scheme* exits 0, because Windows "handles" it by offering the app-picker.
- **Quoting-proof by construction.** The target rides inside a UTF-16LE/base64 `-EncodedCommand` payload, so no cmd/PowerShell metacharacter parsing ever sees it (OAuth authorize URLs carry `&`); inside the decoded script it is a single-quoted PowerShell literal (no `$` expansion) with embedded quotes doubled.
- **PATH resilience preserved.** PowerShell is anchored to `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe` (with a bare-name PATH fallback), same rationale as #4420's rundll32 anchoring — the reporting machine's PATH genuinely lacked `System32`. `Start-Process` handles URLs, files, and directories uniformly, covering all existing `openPath` call sites.

## Verification

- Live A/B on the affected Windows 11 machine with a local HTTP listener capturing exactly what the browser requests: the PowerShell opener launches the default browser with a 256-char OAuth-shaped query string intact (`code_challenge_method=S256` preserved); failure probe (missing file) exits 1 and is logged; unregistered-scheme limitation confirmed and documented in the code comment.
- `bun test packages/coding-agent/test/utils/open.test.ts` — 7 pass: absolute-path resolution from a pinned `SystemRoot`, exact flag sequence, UTF-16LE payload decoding with `&`-bearing URL preserved byte-for-byte, single-quote doubling, bare-name fallback when the resolved path is absent, never-throws with `logger.warn` on spawn failure, and non-zero-exit logging (the case rundll32 could never produce). Also pins the pre-existing WSL-mount test's `path.resolve` so its mocked linux platform stays deterministic on Windows dev hosts.
- `bun run check` green in `packages/coding-agent`.
