### PR TITLE
fix(oauth): copy-safe URL chunks and loopback-only launch URLs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OAuth `launchUrl` advertisement for flows whose redirect never returns to the local callback server: custom-scheme redirects (e.g. GitLab Duo's `vscode://` URI, which `new URL` parses without complaint) and fixed non-loopback hosts no longer receive a `http://localhost:<port>/launch` copy target that misrepresents the callback endpoint and resolves nowhere for remote users.
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/ai/src/registry/oauth/callback-server.ts
+++ b/packages/ai/src/registry/oauth/callback-server.ts
@@ -229,20 +229,32 @@ export abstract class OAuthCallbackFlow {
 
 	/**
 	 * Build the `/launch` URL served by the callback server bound to `port`, or
-	 * `undefined` when the configured `callbackPath` (or a `redirectUri` whose
-	 * pathname resolves to {@link LAUNCH_PATH}) would collide with the launch
-	 * route. Kept short (~30 chars) so UIs can advertise it as a
+	 * `undefined` when it must not be advertised:
+	 * - the configured `callbackPath` (or a `redirectUri` whose pathname
+	 *   resolves to {@link LAUNCH_PATH}) would collide with the launch route;
+	 * - the flow's `redirectUri` never returns to this loopback server: fixed
+	 *   non-loopback hosts, or custom schemes like GitLab Duo's `vscode://`
+	 *   URI — which `new URL` parses without complaint, so a scheme/host check
+	 *   is required, not just the parse failure path. Advertising a localhost
+	 *   `/launch` target for such flows misrepresents the callback endpoint
+	 *   and hands remote users a URL that resolves nowhere.
+	 * Kept short (~30 chars) so UIs can advertise it as a
 	 * viewport-truncation-safe copy target for the full authorization URL.
 	 */
 	#launchUrlIfSafe(port: number): string | undefined {
 		if (this.callbackPath === LAUNCH_PATH) return undefined;
 		if (this.redirectUri) {
 			try {
-				if (new URL(this.redirectUri).pathname === LAUNCH_PATH) return undefined;
+				const parsed = new URL(this.redirectUri);
+				if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return undefined;
+				if (parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1" && parsed.hostname !== "[::1]") {
+					return undefined;
+				}
+				if (parsed.pathname === LAUNCH_PATH) return undefined;
 			} catch {
-				// A non-parseable redirectUri (e.g. `vscode://...` handled elsewhere)
-				// can't collide with an HTTP `/launch` route — fall through and
-				// advertise the launch URL against the loopback server.
+				// A redirectUri even WHATWG URL cannot parse certainly does not
+				// return to this server — never advertise a launch URL for it.
+				return undefined;
 			}
 		}
 		return `http://${this.callbackHostname}:${port}${LAUNCH_PATH}`;

--- a/packages/ai/test/callback-server-launch-route.test.ts
+++ b/packages/ai/test/callback-server-launch-route.test.ts
@@ -182,4 +182,61 @@ describe("OAuthCallbackFlow /launch route", () => {
 		abort.abort("test done");
 		await login;
 	});
+
+	it("suppresses launchUrl for custom-scheme redirects that never return to the loopback server", async () => {
+		const abort = new AbortController();
+		const authFired = Promise.withResolvers<OAuthAuthInfo>();
+		const flow = new LaunchProbeFlow(
+			{
+				onAuth: info => {
+					authFired.resolve(info);
+				},
+				signal: abort.signal,
+			},
+			{
+				preferredPort: 0,
+				allowPortFallback: true,
+				// GitLab Duo shape: `new URL` parses this happily (pathname
+				// `/authentication`), so the guard must check scheme/host, not
+				// rely on a parse failure. A localhost /launch copy target for
+				// this flow would misrepresent the callback endpoint and point
+				// remote users at a URL that resolves nowhere.
+				redirectUri: "vscode://gitlab.gitlab-workflow/authentication",
+			},
+		);
+		const login = flow.login().catch(() => undefined) as Promise<void>;
+		const info = await authFired.promise;
+
+		expect(info.launchUrl).toBeUndefined();
+
+		abort.abort("test done");
+		await login;
+	});
+
+	it("suppresses launchUrl for fixed non-loopback HTTP redirects", async () => {
+		const abort = new AbortController();
+		const authFired = Promise.withResolvers<OAuthAuthInfo>();
+		const flow = new LaunchProbeFlow(
+			{
+				onAuth: info => {
+					authFired.resolve(info);
+				},
+				signal: abort.signal,
+			},
+			{
+				preferredPort: 0,
+				allowPortFallback: true,
+				// The provider redirects to a hosted endpoint; this machine's
+				// callback server never sees the redirect, so no launch URL.
+				redirectUri: "https://auth.example.com/oauth/callback",
+			},
+		);
+		const login = flow.login().catch(() => undefined) as Promise<void>;
+		const info = await authFired.promise;
+
+		expect(info.launchUrl).toBeUndefined();
+
+		abort.abort("test done");
+		await login;
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed wrapped OAuth copy-URL rows corrupting on paste: continuation chunks no longer carry a leading indent, so a multi-row terminal selection reassembles to the exact authorize URL (browsers strip newlines on paste but preserve or percent-encode embedded spaces, which previously corrupted the URL at every chunk boundary).
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -88,12 +88,14 @@ function raceAbortSignal<T>(promise: Promise<T>, signal: AbortSignal, createErro
 const MCP_AUTH_MIN_WRAP_WIDTH = 16;
 
 /**
- * Wrap `url` into rows that each fit inside `width`, prefixed by a shared
- * single-column indent so nested composition doesn't touch column 0. When the
- * label + URL fit on one line, returns a single row; otherwise puts the label
- * on its own row and slices the URL into fixed-width chunks. URL chunks are
- * plain code points — browsers strip whitespace when pasted into the address
- * bar, so a multi-row selection copies back to the intact URL.
+ * Wrap `url` into rows that each fit inside `width`. When the label + URL fit
+ * on one line, returns a single indented row; otherwise puts the label on its
+ * own indented row and slices the URL into fixed-width chunks that start at
+ * column 0. Continuation chunks carry ZERO leading bytes on purpose: a
+ * multi-row terminal selection includes the newline plus any leading indent,
+ * and while address bars strip newlines they preserve or percent-encode
+ * embedded spaces — an indent would corrupt the URL at every chunk boundary
+ * (silently, when the damage lands inside a query value).
  */
 function wrapUrlRows(label: string, url: string, width: number): string[] {
 	const indent = " ";
@@ -103,10 +105,9 @@ function wrapUrlRows(label: string, url: string, width: number): string[] {
 	if (inlineWidth <= effective) {
 		return [`${indent}${theme.fg("muted", `${label} ${sanitized}`)}`];
 	}
-	const chunkWidth = Math.max(1, effective - indent.length);
 	const rows: string[] = [`${indent}${theme.fg("muted", label)}`];
-	for (let i = 0; i < sanitized.length; i += chunkWidth) {
-		rows.push(`${indent}${theme.fg("muted", sanitized.slice(i, i + chunkWidth))}`);
+	for (let i = 0; i < sanitized.length; i += effective) {
+		rows.push(theme.fg("muted", sanitized.slice(i, i + effective)));
 	}
 	return rows;
 }

--- a/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
+++ b/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
@@ -24,10 +24,12 @@ const LONG_AUTH_URL =
 const LINEAR_AUTH_URL = `https://mcp.linear.app/authorize?response_type=code&client_id=abcdefghij0123456789ABCDEFGHIJ0123456789&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&scope=read%20write%20mcp%3Aall&state=0123456789abcdef0123456789abcdef&code_challenge=5MlkJfN2GhX9uP0rQ7sT8vB1oCwDeFgHiJkLmNoPqRsTuVwXyZ&code_challenge_method=S256`;
 
 /**
- * Reassemble the copy-URL rows for `label` into a single string, mirroring what
- * a browser would produce when a multi-row selection is pasted into its
- * address bar (whitespace stripped between chunks). Returns "" if the label
- * row isn't found.
+ * Reassemble the copy-URL rows for `label` into a single string, mirroring a
+ * real multi-row terminal selection pasted into an address bar: browsers
+ * strip the newlines, but any other leading bytes survive (verbatim or
+ * percent-encoded) — so chunks are concatenated RAW, with no indent-stripping
+ * that could mask a corrupting prefix. Returns "" if the label row isn't
+ * found.
  */
 function reassembleUrl(plainLines: string[], label: string): string {
 	const start = plainLines.findIndex(line => line.startsWith(` ${label}`));
@@ -36,15 +38,13 @@ function reassembleUrl(plainLines: string[], label: string): string {
 	// Inline form contains the whole URL on the label row.
 	const inlineMatch = first.match(new RegExp(`^ ${label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} (.*)$`));
 	if (inlineMatch) return inlineMatch[1]!;
-	// Wrapped form: label alone, then continuation rows with a single-space indent.
+	// Wrapped form: indented label row, then UNINDENTED continuation chunks.
+	// Any indented row (the next label) or blank row ends this URL's chunks.
 	let joined = "";
 	for (let i = start + 1; i < plainLines.length; i++) {
 		const line = plainLines[i]!;
-		// Continuation rows have exactly one leading space; a different indent
-		// or label ends this URL's rows.
-		if (!line.startsWith(" ") || line.startsWith("  ") || line.trim().length === 0) break;
-		if (line.includes(":") && /^ [A-Z][^:]*:/.test(line)) break; // next label row
-		joined += line.slice(1);
+		if (line.startsWith(" ") || line.trim().length === 0) break;
+		joined += line;
 	}
 	return joined;
 }
@@ -89,10 +89,12 @@ describe("MCPAuthorizationLinkPrompt", () => {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
 		}
 
-		// Wrapping puts the label on its own row followed by continuation
-		// chunks with a single-space indent.
+		// Wrapping puts the label on its own indented row followed by
+		// UNINDENTED continuation chunks — zero leading bytes, so a multi-row
+		// selection pastes back to the exact URL.
 		const labelRow = plainLines.indexOf(` ${COPY_URL_LABEL}`);
 		expect(labelRow).toBeGreaterThanOrEqual(0);
+		expect(plainLines[labelRow + 1]!.startsWith(" ")).toBe(false);
 
 		// Chunks reassemble to the URL byte-for-byte — the trailing
 		// `code_challenge_method=S256` MUST be present.
@@ -140,7 +142,7 @@ describe("MCPAuthorizationLinkPrompt", () => {
 
 	it("floors the wrap width so degenerately-narrow viewports still emit every character", () => {
 		// Below 16 cols the terminal is unusable, but the render still emits
-		// chunks (bounded at 16 - indent = 15 chars). No character is silently
+		// chunks (bounded at the 16-column floor). No character is silently
 		// dropped; the user can widen and reflow.
 		const lines = new MCPAuthorizationLinkPrompt(LINEAR_AUTH_URL).render(4);
 		const plainLines = lines.map(line => stripVTControlCharacters(line));


### PR DESCRIPTION
Follow-up to #4420: resolves the two Codex P2 review findings that were still open when it merged. Refs #4418.

## 1. Wrapped URL chunks were copy-corrupting (Codex P2, `mcp-command-controller.ts`)

`wrapUrlRows` prefixed every continuation chunk with a one-space indent. A real multi-row terminal selection captures the newline **plus that indent**; browsers strip the newlines but preserve or percent-encode embedded spaces, so the pasted authorize URL was corrupted at every chunk boundary — silently, whenever the boundary landed inside a query value. The test helper stripped the indent during reassembly, masking exactly this defect (as the Codex comment noted).

**Fix:** continuation chunks now start at column 0 with pure URL bytes (label rows keep their indent; the inline single-row form is unchanged). Chunk width uses the full effective width since there is no indent to subtract. The test reassembly helper now concatenates chunks **raw** — no stripping — and a new assertion pins the first continuation row to a non-space first byte.

## 2. `launchUrl` advertised for flows that never return to the loopback server (Codex P2, `callback-server.ts`)

`#launchUrlIfSafe`'s catch-branch comment assumed custom-scheme redirect URIs are "non-parseable" and deliberately fell through to advertise. But `new URL("vscode://gitlab.gitlab-workflow/authentication")` parses without complaint (pathname `/authentication`), so GitLab-Duo-shaped flows sailed through the pathname check and received a `http://localhost:<port>/launch` copy target on the *parseable* path too — misrepresenting the callback endpoint and, per `OAuthAuthInfo.launchUrl`'s documented contract, pointing remote users at a URL that resolves nowhere.

**Fix:** when `redirectUri` is set, the launch URL is advertised only for http(s) loopback redirects (`localhost` / `127.0.0.1` / `[::1]`); custom schemes, non-loopback hosts, and genuinely unparseable URIs all suppress it. The existing `/launch`-pathname collision suppression is preserved. Flows without a configured `redirectUri` are loopback by construction and unaffected.

## Verification

- `bun test packages/ai/test/callback-server-launch-route.test.ts` — 7 pass, including two new regression cases: the GitLab Duo `vscode://` shape and a fixed non-loopback HTTPS redirect, both asserting `launchUrl` is undefined while the flow still proceeds.
- `bun test packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts` — 6 pass with the reassembly helper now mirroring a real clipboard (raw concatenation), plus the zero-leading-byte assertion on continuation chunks; the #4418-fingerprint case (narrow viewport, trailing `code_challenge_method=S256` preserved byte-for-byte) still passes.
- `bun run check` green in `packages/ai` and `packages/coding-agent`.
