### PR TITLE
fix: cramped slash autocomplete menu

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## [Unreleased]
 
-### Changed
-
-- Increased the default autocomplete dropdown from 5 to 10 visible items so slash command menus are less cramped.
 
 ## [16.3.8] - 2026-07-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Increased the default autocomplete dropdown from 5 to 10 visible items so slash command menus are less cramped.
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1493,7 +1493,7 @@ export const SETTINGS_SCHEMA = {
 
 	autocompleteMaxVisible: {
 		type: "number",
-		default: 10,
+		default: 5,
 		ui: {
 			tab: "interaction",
 			group: "Input",
@@ -1502,6 +1502,7 @@ export const SETTINGS_SCHEMA = {
 			options: [
 				{ value: "3", label: "3 items" },
 				{ value: "5", label: "5 items" },
+				{ value: "7", label: "7 items" },
 				{ value: "10", label: "10 items" },
 				{ value: "15", label: "15 items" },
 				{ value: "20", label: "20 items" },

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1493,7 +1493,7 @@ export const SETTINGS_SCHEMA = {
 
 	autocompleteMaxVisible: {
 		type: "number",
-		default: 5,
+		default: 10,
 		ui: {
 			tab: "interaction",
 			group: "Input",
@@ -1502,7 +1502,6 @@ export const SETTINGS_SCHEMA = {
 			options: [
 				{ value: "3", label: "3 items" },
 				{ value: "5", label: "5 items" },
-				{ value: "7", label: "7 items" },
 				{ value: "10", label: "10 items" },
 				{ value: "15", label: "15 items" },
 				{ value: "20", label: "20 items" },

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Kept slash command autocomplete rows compact by truncating descriptions instead of wrapping them into multi-line blocks, and raised the editor's default autocomplete window to 10 items.
+- Kept slash command autocomplete rows compact by truncating descriptions instead of wrapping them into multi-line blocks.
 
 ## [16.3.7] - 2026-07-05
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept slash command autocomplete rows compact by truncating descriptions instead of wrapping them into multi-line blocks, and raised the editor's default autocomplete window to 10 items.
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -422,7 +422,7 @@ export class Editor implements Component, Focusable {
 	#autocompleteState: "regular" | "force" | null = null;
 	#autocompletePrefix: string = "";
 	#autocompleteRequestId: number = 0;
-	#autocompleteMaxVisible: number = 10;
+	#autocompleteMaxVisible: number = 5;
 	onAutocompleteUpdate?: () => void;
 
 	// Paste tracking for large pastes

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -31,7 +31,6 @@ const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 	minPrimaryColumnWidth: 12,
 	maxPrimaryColumnWidth: 32,
 	overflowSearch: false,
-	wrapDescription: true,
 };
 
 function sanitizeLoadedText(text: string): string {
@@ -423,7 +422,7 @@ export class Editor implements Component, Focusable {
 	#autocompleteState: "regular" | "force" | null = null;
 	#autocompletePrefix: string = "";
 	#autocompleteRequestId: number = 0;
-	#autocompleteMaxVisible: number = 5;
+	#autocompleteMaxVisible: number = 10;
 	onAutocompleteUpdate?: () => void;
 
 	// Paste tracking for large pastes

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -311,6 +311,7 @@ describe("Editor component", () => {
 
 		it("renders slash-command suggestions as compact item rows", async () => {
 			const editor = new Editor(defaultEditorTheme);
+			editor.setAutocompleteMaxVisible(10);
 			const longDescription =
 				"Plan and execute non-trivial architectural improvements to the codebase without turning each slash command into a multi-line block.";
 			editor.setAutocompleteProvider(

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -309,6 +309,30 @@ describe("Editor component", () => {
 			await expect(promise).resolves.toBe("/");
 		});
 
+		it("renders slash-command suggestions as compact item rows", async () => {
+			const editor = new Editor(defaultEditorTheme);
+			const longDescription =
+				"Plan and execute non-trivial architectural improvements to the codebase without turning each slash command into a multi-line block.";
+			editor.setAutocompleteProvider(
+				new CombinedAutocompleteProvider(
+					Array.from({ length: 12 }, (_, i) => ({
+						name: `cmd${i}`,
+						description: longDescription,
+					})),
+					"/tmp",
+				),
+			);
+
+			editor.handleInput("/");
+			await Bun.sleep(0);
+
+			const rendered = editor.render(80).map(line => stripVTControlCharacters(line));
+			for (let i = 0; i < 10; i += 1) {
+				expect(rendered.some(line => line.includes(`cmd${i}`))).toBe(true);
+			}
+			expect(rendered.some(line => line.includes("cmd10"))).toBe(false);
+		});
+
 		it("triggers file-reference autocomplete when typing at-sign", async () => {
 			const editor = new Editor(defaultEditorTheme);
 			const { promise, resolve } = Promise.withResolvers<string>();


### PR DESCRIPTION
Keeps the slash autocomplete menu usable when long entries wrap by tightening the TUI editor layout and covering the editor behavior with the existing test file.