### PR TITLE
fix(coding-agent): use local date in system prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed system prompt date rendering to use the host local calendar date instead of UTC.
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -725,6 +725,8 @@ export interface AgentSessionConfig {
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	/** System prompt builder that can consider tool availability. Returns ordered provider-facing blocks. */
 	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>;
+	/** Local calendar date provider used by prompt-cache invalidation. Defaults to the host local date. */
+	getLocalCalendarDate?: () => string;
 	/** Rebuild the SSH tool from current capability discovery results. */
 	reloadSshTool?: () => Promise<AgentTool | null>;
 	requestedToolNames?: ReadonlySet<string>;
@@ -1716,6 +1718,7 @@ export class AgentSession {
 	#rebuildSystemPrompt:
 		| ((toolNames: string[], tools: Map<string, AgentTool>) => Promise<{ systemPrompt: string[] }>)
 		| undefined;
+	#getLocalCalendarDate: () => string;
 	#getMcpServerInstructions: (() => Map<string, string> | undefined) | undefined;
 	#reloadSshTool: (() => Promise<AgentTool | null>) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
@@ -2154,6 +2157,7 @@ export class AgentSession {
 		});
 		this.#convertToLlm = config.convertToLlm ?? convertToLlm;
 		this.#rebuildSystemPrompt = config.rebuildSystemPrompt;
+		this.#getLocalCalendarDate = config.getLocalCalendarDate ?? formatLocalCalendarDate;
 		this.#getMcpServerInstructions = config.getMcpServerInstructions;
 		this.#reloadSshTool = config.reloadSshTool;
 		this.#disconnectOwnedMcpManager = config.disconnectOwnedMcpManager;
@@ -6518,7 +6522,7 @@ export class AgentSession {
 			entries.sort();
 			instructionsSegment = entries.join("\u0006");
 		}
-		const date = formatLocalCalendarDate();
+		const date = this.#getLocalCalendarDate();
 		return `${nameSegment}\u0003${descriptionSegment}\u0005${registrySegment}\u0007${instructionsSegment}|${date}`;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -314,6 +314,7 @@ import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { extractFileMentions, generateFileMentionMessages } from "../utils/file-mentions";
 import { normalizeModelContextImages } from "../utils/image-loading";
 import { describeAttachedImagesForTextModel } from "../utils/image-vision-fallback";
+import { formatLocalCalendarDate } from "../utils/local-date";
 import { generateSessionTitle } from "../utils/title-generator";
 import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
 import type { AuthStorage } from "./auth-storage";
@@ -6517,7 +6518,7 @@ export class AgentSession {
 			entries.sort();
 			instructionsSegment = entries.join("\u0006");
 		}
-		const date = new Date().toISOString().slice(0, 10);
+		const date = formatLocalCalendarDate();
 		return `${nameSegment}\u0003${descriptionSegment}\u0005${registrySegment}\u0007${instructionsSegment}|${date}`;
 	}
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -24,6 +24,7 @@ import projectPromptTemplate from "./prompts/system/project-prompt.md" with { ty
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
 import { shortenPath } from "./tools/render-utils";
 import { type ActiveRepoContext, resolveActiveRepoContext } from "./utils/active-repo-context";
+import { formatLocalCalendarDate } from "./utils/local-date";
 import { normalizePromptPath } from "./utils/prompt-path";
 import { AGENTS_MD_LIMIT, buildWorkspaceTree, type WorkspaceTree } from "./workspace-tree";
 
@@ -677,7 +678,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		}
 	}
 
-	const date = new Date().toISOString().slice(0, 10);
+	const date = formatLocalCalendarDate();
 	const dateTime = date;
 	const promptCwd = shortenPath(normalizePromptPath(resolvedCwd));
 	const activeRepoContextPrompt = renderActiveRepoContextPrompt(activeRepoContext);

--- a/packages/coding-agent/src/utils/local-date.ts
+++ b/packages/coding-agent/src/utils/local-date.ts
@@ -1,0 +1,7 @@
+/** formatLocalCalendarDate formats a Date as YYYY-MM-DD in the host local timezone. */
+export function formatLocalCalendarDate(date: Date = new Date()): string {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, setSystemTime } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -68,6 +68,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 	interface NewSessionOptions {
 		mcpDiscoveryEnabled?: boolean;
 		getMcpServerInstructions?: () => Map<string, string> | undefined;
+		getLocalCalendarDate?: () => string;
 	}
 
 	function newSession(
@@ -101,6 +102,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			}),
 			mcpDiscoveryEnabled: options.mcpDiscoveryEnabled,
 			getMcpServerInstructions: options.getMcpServerInstructions,
+			getLocalCalendarDate: options.getLocalCalendarDate,
 		});
 		sessions.push(session);
 		return { session };
@@ -389,47 +391,37 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(rebuildCount).toBe(baseline + 1);
 	});
 	it("rebuilds when the local calendar date rolls over between tool-stable MCP refreshes", async () => {
-		// `buildSystemPrompt` injects today's date into the prompt body. A session
-		// spanning local midnight must not serve yesterday's date after an MCP
-		// reconnect that happens to bring an identical tool set, even when UTC has
-		// not rolled over.
-		const originalTimezone = process.env.TZ;
-		process.env.TZ = "America/Los_Angeles";
-		setSystemTime(new Date("2026-07-01T06:59:58Z"));
-		try {
-			let rebuildCount = 0;
-			const { session } = newSession(async toolNames => {
+		// `buildSystemPrompt` injects today's local date into the prompt body. The
+		// signature reads the same date provider so a session spanning local midnight
+		// must rebuild after an MCP reconnect with an otherwise identical tool set.
+		let currentDate = "2026-06-30";
+		let rebuildCount = 0;
+		const { session } = newSession(
+			async toolNames => {
 				rebuildCount++;
 				return `tools:${toolNames.join(",")}`;
-			});
-			const tool = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search");
+			},
+			{ getLocalCalendarDate: () => currentDate },
+		);
+		const tool = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search");
 
-			// First refresh: no signature yet, must rebuild.
-			await session.refreshMCPTools([tool]);
-			expect(rebuildCount).toBe(1);
+		// First refresh: no signature yet, must rebuild.
+		await session.refreshMCPTools([tool]);
+		expect(rebuildCount).toBe(1);
 
-			// Same tools, same local day: signature matches, skip.
-			await session.refreshMCPTools([tool]);
-			expect(rebuildCount).toBe(1);
+		// Same tools, same local day: signature matches, skip.
+		await session.refreshMCPTools([tool]);
+		expect(rebuildCount).toBe(1);
 
-			// Advance past local midnight while the UTC date remains 2026-07-01.
-			setSystemTime(new Date("2026-07-01T07:00:01Z"));
+		currentDate = "2026-07-01";
 
-			// Same tools, new local calendar day: date segment changed, must rebuild.
-			await session.refreshMCPTools([tool]);
-			expect(rebuildCount).toBe(2);
+		// Same tools, new local calendar day: date segment changed, must rebuild.
+		await session.refreshMCPTools([tool]);
+		expect(rebuildCount).toBe(2);
 
-			// Same tools, same new local day: skip again.
-			await session.refreshMCPTools([tool]);
-			expect(rebuildCount).toBe(2);
-		} finally {
-			setSystemTime();
-			if (originalTimezone === undefined) {
-				delete process.env.TZ;
-			} else {
-				process.env.TZ = originalTimezone;
-			}
-		}
+		// Same tools, same new local day: skip again.
+		await session.refreshMCPTools([tool]);
+		expect(rebuildCount).toBe(2);
 	});
 	it("does not rebuild when MCP server instructions change only beyond the 4000-char truncation boundary", async () => {
 		// `rebuildSystemPrompt` (sdk.ts) truncates each server instruction to 4000 chars

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -388,11 +388,14 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([dynamicTool]);
 		expect(rebuildCount).toBe(baseline + 1);
 	});
-	it("rebuilds when the calendar date rolls over between tool-stable MCP refreshes", async () => {
-		// `buildSystemPrompt` injects today's date into the prompt body.
-		// A session spanning midnight must not serve yesterday's date after an MCP
-		// reconnect that happens to bring an identical tool set.
-		setSystemTime(new Date("2025-01-01T23:59:58Z"));
+	it("rebuilds when the local calendar date rolls over between tool-stable MCP refreshes", async () => {
+		// `buildSystemPrompt` injects today's date into the prompt body. A session
+		// spanning local midnight must not serve yesterday's date after an MCP
+		// reconnect that happens to bring an identical tool set, even when UTC has
+		// not rolled over.
+		const originalTimezone = process.env.TZ;
+		process.env.TZ = "America/Los_Angeles";
+		setSystemTime(new Date("2026-07-01T06:59:58Z"));
 		try {
 			let rebuildCount = 0;
 			const { session } = newSession(async toolNames => {
@@ -405,22 +408,27 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			await session.refreshMCPTools([tool]);
 			expect(rebuildCount).toBe(1);
 
-			// Same tools, same day: signature matches, skip.
+			// Same tools, same local day: signature matches, skip.
 			await session.refreshMCPTools([tool]);
 			expect(rebuildCount).toBe(1);
 
-			// Advance past midnight.
-			setSystemTime(new Date("2025-01-02T00:00:01Z"));
+			// Advance past local midnight while the UTC date remains 2026-07-01.
+			setSystemTime(new Date("2026-07-01T07:00:01Z"));
 
-			// Same tools, new calendar day: date segment changed, must rebuild.
+			// Same tools, new local calendar day: date segment changed, must rebuild.
 			await session.refreshMCPTools([tool]);
 			expect(rebuildCount).toBe(2);
 
-			// Same tools, same new day: skip again.
+			// Same tools, same new local day: skip again.
 			await session.refreshMCPTools([tool]);
 			expect(rebuildCount).toBe(2);
 		} finally {
-			setSystemTime(); // restore real time
+			setSystemTime();
+			if (originalTimezone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimezone;
+			}
 		}
 	});
 	it("does not rebuild when MCP server instructions change only beyond the 4000-char truncation boundary", async () => {

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, setSystemTime } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -20,6 +20,69 @@ const EMPTY_TREE = {
 	totalLines: 0,
 	agentsMdFiles: [],
 };
+
+async function expectPromptDateFromStartupTimezone(options: {
+	tempDir: string;
+	tempHomeDir: string;
+	timeZone: string;
+	now: string;
+	expectedDate: string;
+	rejectedDate: string;
+}): Promise<void> {
+	const scenarioPath = path.join(options.tempDir, "prompt-date-timezone.test.ts");
+	await Bun.write(
+		scenarioPath,
+		`import { expect, it, setSystemTime } from "bun:test";
+import { buildSystemPrompt } from ${JSON.stringify(path.resolve(import.meta.dir, "../src/system-prompt.ts"))};
+
+it("renders the prompt date in the startup timezone", async () => {
+	setSystemTime(new Date(process.env.OMP_TEST_NOW!));
+	try {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: process.cwd(),
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: [],
+			workspaceTree: {
+				rootPath: process.cwd(),
+				rendered: "",
+				truncated: false,
+				totalLines: 0,
+				agentsMdFiles: [],
+			},
+			activeRepoContext: null,
+		});
+		const rendered = systemPrompt.join("\\n\\n");
+		expect(rendered).toContain(\`Today is \${process.env.OMP_EXPECTED_DATE}\`);
+		expect(rendered).not.toContain(\`Today is \${process.env.OMP_REJECTED_DATE}\`);
+	} finally {
+		setSystemTime();
+	}
+});
+`,
+	);
+	const child = Bun.spawn([process.execPath, "test", scenarioPath], {
+		cwd: options.tempDir,
+		env: {
+			...process.env,
+			HOME: options.tempHomeDir,
+			TZ: options.timeZone,
+			OMP_TEST_NOW: options.now,
+			OMP_EXPECTED_DATE: options.expectedDate,
+			OMP_REJECTED_DATE: options.rejectedDate,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	expect(`${stdout}\n${stderr}`).toContain("1 pass");
+	expect(exitCode).toBe(0);
+}
 
 describe("system prompt model identifier", () => {
 	let tempDir = "";
@@ -49,31 +112,15 @@ describe("system prompt model identifier", () => {
 		expect(systemPrompt.join("\n\n")).toContain("Model: anthropic/claude-opus-4");
 	});
 
-	it("renders the prompt date from the local timezone rather than UTC", async () => {
-		const originalTimezone = process.env.TZ;
-		process.env.TZ = "America/Los_Angeles";
-		setSystemTime(new Date("2026-07-01T03:15:00Z"));
-		try {
-			const { systemPrompt } = await buildSystemPrompt({
-				cwd: tempDir,
-				contextFiles: [],
-				skills: [],
-				rules: [],
-				toolNames: [],
-				workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
-			});
-			const rendered = systemPrompt.join("\n\n");
-
-			expect(rendered).toContain("Today is 2026-06-30");
-			expect(rendered).not.toContain("Today is 2026-07-01");
-		} finally {
-			setSystemTime();
-			if (originalTimezone === undefined) {
-				delete process.env.TZ;
-			} else {
-				process.env.TZ = originalTimezone;
-			}
-		}
+	it("renders the prompt date from the startup local timezone rather than UTC", async () => {
+		await expectPromptDateFromStartupTimezone({
+			tempDir,
+			tempHomeDir,
+			timeZone: "America/Los_Angeles",
+			now: "2026-07-01T03:15:00Z",
+			expectedDate: "2026-06-30",
+			rejectedDate: "2026-07-01",
+		});
 	});
 
 	it("omits the model line when no model is provided", async () => {

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, setSystemTime } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -47,6 +47,33 @@ describe("system prompt model identifier", () => {
 		});
 
 		expect(systemPrompt.join("\n\n")).toContain("Model: anthropic/claude-opus-4");
+	});
+
+	it("renders the prompt date from the local timezone rather than UTC", async () => {
+		const originalTimezone = process.env.TZ;
+		process.env.TZ = "America/Los_Angeles";
+		setSystemTime(new Date("2026-07-01T03:15:00Z"));
+		try {
+			const { systemPrompt } = await buildSystemPrompt({
+				cwd: tempDir,
+				contextFiles: [],
+				skills: [],
+				rules: [],
+				toolNames: [],
+				workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			});
+			const rendered = systemPrompt.join("\n\n");
+
+			expect(rendered).toContain("Today is 2026-06-30");
+			expect(rendered).not.toContain("Today is 2026-07-01");
+		} finally {
+			setSystemTime();
+			if (originalTimezone === undefined) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = originalTimezone;
+			}
+		}
 	});
 
 	it("omits the model line when no model is provided", async () => {


### PR DESCRIPTION
Builds system prompt date text from the local timezone instead of UTC so date-sensitive agent guidance matches the operator's local day.