### PR TITLE
fix(goal): keep the goal tool available before activation

### DIFF
--- a/packages/coding-agent/src/cli/gallery-fixtures/agentic.ts
+++ b/packages/coding-agent/src/cli/gallery-fixtures/agentic.ts
@@ -324,12 +324,11 @@ export const agenticFixtures: Record<string, GalleryFixture> = {
 
 	goal: {
 		label: "Goal",
-		// Streaming: op is "create"; objective text still being typed.
-		streamingArgs: { op: "create", objective: "Ship the auth hardening" },
+		// Streaming: op is "set"; objective text still being typed.
+		streamingArgs: { op: "set", objective: "Ship the auth hardening" },
 		args: {
-			op: "create",
+			op: "set",
 			objective: "Ship the auth hardening pass: per-account rate limits and sliding session expiry.",
-			token_budget: 500_000,
 		},
 		result: {
 			content: [
@@ -339,7 +338,7 @@ export const agenticFixtures: Record<string, GalleryFixture> = {
 				},
 			],
 			details: {
-				op: "create",
+				op: "set",
 				remainingTokens: 451_800,
 				completionBudgetReport: null,
 				goal: {
@@ -356,8 +355,8 @@ export const agenticFixtures: Record<string, GalleryFixture> = {
 		},
 		errorResult: {
 			isError: true,
-			content: [{ type: "text", text: "Goal tool failed: objective is required when op=create." }],
-			details: { op: "create" },
+			content: [{ type: "text", text: "Goal tool failed: objective is required when op=set." }],
+			details: { op: "set" },
 		},
 	},
 

--- a/packages/coding-agent/src/goals/runtime.ts
+++ b/packages/coding-agent/src/goals/runtime.ts
@@ -366,26 +366,35 @@ export class GoalRuntime {
 		await this.#withAccounting(() => this.#flushUsageLocked(steering, currentUsage));
 	}
 
-	#createGoalState(objective: string, tokenBudget: number | undefined): GoalModeState {
+	#createGoalState(
+		objective: string,
+		tokenBudget: number | undefined,
+		usage?: Pick<Goal, "tokensUsed" | "timeUsedSeconds">,
+	): GoalModeState {
 		const now = this.#now();
+		const tokensUsed = usage?.tokensUsed ?? 0;
 		const goal: Goal = {
 			id: String(Snowflake.next()),
 			objective,
-			status: "active",
+			status: tokenBudget !== undefined && tokensUsed >= tokenBudget ? "budget-limited" : "active",
 			tokenBudget,
-			tokensUsed: 0,
-			timeUsedSeconds: 0,
+			tokensUsed,
+			timeUsedSeconds: usage?.timeUsedSeconds ?? 0,
 			createdAt: now,
 			updatedAt: now,
 		};
 		return { enabled: true, mode: "active", goal };
 	}
 
-	async createGoal(input: { objective: string; tokenBudget?: number }): Promise<GoalModeState> {
+	async createGoal(
+		input: { objective: string; tokenBudget?: number },
+		assertCanStart?: () => void,
+	): Promise<GoalModeState> {
 		const objective = input.objective.trim();
 		if (!objective) throw new Error("objective is required when op=create");
 		validateTokenBudget(input.tokenBudget);
 		return await this.#withAccounting(async () => {
+			assertCanStart?.();
 			const existing = this.#host.getState();
 			if (existing?.goal && existing.goal.status !== "dropped" && existing.goal.status !== "complete") {
 				throw new Error("cannot create a new goal because this session already has a goal");
@@ -394,6 +403,33 @@ export class GoalRuntime {
 			this.#budgetReportedFor = undefined;
 			this.#markActiveAccounting(state.goal);
 			await this.#commitState(state, { persist: "goal" });
+			return state;
+		});
+	}
+
+	async setGoal(
+		input: { objective: string; tokenBudget?: number },
+		assertCanStart?: () => void,
+	): Promise<GoalModeState> {
+		const objective = input.objective.trim();
+		if (!objective) throw new Error("objective is required when op=set");
+		validateTokenBudget(input.tokenBudget);
+		return await this.#withAccounting(async () => {
+			assertCanStart?.();
+			const existing = this.#host.getState();
+			let existingGoal =
+				existing?.goal && existing.goal.status !== "dropped" && existing.goal.status !== "complete"
+					? existing.goal
+					: undefined;
+			if (existing?.enabled && existingGoal && isAccountingStatus(existingGoal)) {
+				await this.#flushUsageLocked("suppressed");
+				existingGoal = this.#host.getState()?.goal;
+			}
+			const state = this.#createGoalState(objective, input.tokenBudget ?? existingGoal?.tokenBudget, existingGoal);
+			this.#budgetReportedFor = undefined;
+			this.#markActiveAccounting(state.goal);
+			await this.#commitState(state, { persist: "goal" });
+			if (state.goal.status === "budget-limited") await this.#sendBudgetLimitSteer(state.goal);
 			return state;
 		});
 	}
@@ -416,19 +452,23 @@ export class GoalRuntime {
 		});
 	}
 
-	async resumeGoal(): Promise<GoalModeState> {
+	async resumeGoal(assertCanStart?: () => void): Promise<GoalModeState> {
 		return await this.#withAccounting(async () => {
+			assertCanStart?.();
 			const state = this.#getStateClone();
 			if (!state?.goal) throw new Error("No paused goal.");
 			if (state.goal.status === "complete") throw new Error("Goal is already complete.");
+			if (state.goal.status !== "paused") throw new Error("No paused goal.");
 			state.enabled = true;
 			state.mode = "active";
 			state.reason = undefined;
-			state.goal.status = "active";
+			const exhausted = state.goal.tokenBudget !== undefined && state.goal.tokensUsed >= state.goal.tokenBudget;
+			state.goal.status = exhausted ? "budget-limited" : "active";
 			state.goal.updatedAt = this.#now();
 			this.#budgetReportedFor = undefined;
 			this.#markActiveAccounting(state.goal);
 			await this.#commitState(state, { persist: "goal" });
+			if (exhausted) await this.#sendBudgetLimitSteer(state.goal);
 			return state;
 		});
 	}

--- a/packages/coding-agent/src/goals/state.ts
+++ b/packages/coding-agent/src/goals/state.ts
@@ -21,7 +21,7 @@ export interface GoalModeState {
 }
 
 export interface GoalToolDetails {
-	op: "create" | "get" | "complete" | "resume" | "drop";
+	op: "set" | "create" | "get" | "complete" | "resume" | "drop";
 	goal?: Goal | null;
 	remainingTokens?: number | null;
 	completionBudgetReport?: string | null;

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -4,20 +4,20 @@ import { Text } from "@oh-my-pi/pi-tui";
 import { formatNumber, prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
+import { sanitizeStatusText } from "../../modes/shared";
 import type { Theme, ThemeColor } from "../../modes/theme/theme";
 import goalDescription from "../../prompts/tools/goal.md" with { type: "text" };
 import { formatDuration } from "../../slash-commands/helpers/format";
 import type { ToolSession } from "../../tools";
-import { formatErrorDetail, TRUNCATE_LENGTHS } from "../../tools/render-utils";
+import { formatErrorDetail, replaceTabs, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { ToolError } from "../../tools/tool-errors";
 import { framedBlock, renderStatusLine, truncateToWidth } from "../../tui";
 import { completionBudgetReport, remainingTokens } from "../runtime";
 import type { Goal, GoalStatus, GoalToolDetails } from "../state";
 
 const goalSchema = type({
-	op: type("'create' | 'get' | 'complete' | 'resume' | 'drop'").describe("goal operation"),
+	op: type("'set' | 'create' | 'get' | 'complete' | 'resume' | 'drop'").describe("goal operation"),
 	"objective?": type("string").describe("goal objective"),
-	"token_budget?": type("number.integer").describe("token budget"),
 });
 
 export type GoalToolInput = typeof goalSchema.infer;
@@ -43,16 +43,15 @@ export function buildGoalToolResponse(
 	};
 }
 
-function validateCreateParams(params: GoalToolInput): { objective: string; tokenBudget?: number } {
+function validateObjectiveParams(params: GoalToolInput, op: "create" | "set"): { objective: string } {
 	const objective = params.objective?.trim();
 	if (!objective) {
-		throw new ToolError("objective is required when op=create");
+		throw new ToolError(`objective is required when op=${op}`);
 	}
-	const tokenBudget = params.token_budget;
-	if (tokenBudget !== undefined && (!Number.isInteger(tokenBudget) || tokenBudget <= 0)) {
-		throw new ToolError("token_budget must be a positive integer when provided");
-	}
-	return { objective, tokenBudget };
+	// The agent sets only the objective and runs until done; token budgets are an
+	// operator concern (`/goal budget`, CLI `--goal-budget`) because the model
+	// cannot estimate token cost reliably.
+	return { objective };
 }
 
 export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
@@ -80,15 +79,23 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 			throw new ToolError("Goal mode is not active.");
 		}
 
+		const startsGoal = params.op === "create" || params.op === "set" || params.op === "resume";
+		const assertCanStart = () => this.#assertCanStartGoal();
+		if (startsGoal) assertCanStart();
+
 		let response: GoalToolResponse;
+
 		if (params.op === "create") {
-			const created = await runtime.createGoal(validateCreateParams(params));
+			const created = await runtime.createGoal(validateObjectiveParams(params, "create"), assertCanStart);
 			response = buildGoalToolResponse(created.goal);
+		} else if (params.op === "set") {
+			const updated = await runtime.setGoal(validateObjectiveParams(params, "set"), assertCanStart);
+			response = buildGoalToolResponse(updated.goal);
 		} else if (params.op === "get") {
 			const state = this.#session.getGoalModeState?.();
 			response = buildGoalToolResponse(state?.goal ?? null);
 		} else if (params.op === "resume") {
-			const resumed = await runtime.resumeGoal();
+			const resumed = await runtime.resumeGoal(assertCanStart);
 			response = buildGoalToolResponse(resumed.goal);
 		} else if (params.op === "drop") {
 			const dropped = await runtime.dropGoal();
@@ -122,10 +129,20 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 			},
 		};
 	}
+
+	#assertCanStartGoal(): void {
+		if (this.#session.getPlanModeState?.()?.enabled || this.#session.isPlanModePaused?.()) {
+			throw new ToolError("Exit plan mode before starting or resuming a goal.");
+		}
+		if (this.#session.getVibeModeState?.()?.enabled) {
+			throw new ToolError("Exit vibe mode before starting or resuming a goal.");
+		}
+	}
 }
 
 function describeOp(op: string | undefined): string {
 	switch (op) {
+		case "set":
 		case "create":
 			return "set";
 		case "complete":
@@ -158,7 +175,6 @@ function goalBadgeColor(status: GoalStatus): ThemeColor {
 interface GoalRenderArgs {
 	op?: GoalToolInput["op"];
 	objective?: string;
-	token_budget?: number;
 }
 
 export const goalToolRenderer = {
@@ -166,12 +182,9 @@ export const goalToolRenderer = {
 		const description = describeOp(args.op);
 		const meta: string[] = [];
 		const trimmedObjective = args.objective?.trim();
-		if (args.op === "create" && trimmedObjective) {
-			const objective = truncateToWidth(trimmedObjective, TRUNCATE_LENGTHS.TITLE);
+		if ((args.op === "create" || args.op === "set") && trimmedObjective) {
+			const objective = truncateToWidth(replaceTabs(sanitizeStatusText(trimmedObjective)), TRUNCATE_LENGTHS.TITLE);
 			meta.push(uiTheme.italic(uiTheme.fg("muted", `"${objective}"`)));
-		}
-		if (args.op === "create" && args.token_budget !== undefined) {
-			meta.push(`budget ${formatNumber(args.token_budget)}`);
 		}
 		return new Text(renderStatusLine({ icon: "pending", title: "Goal", description, meta }, uiTheme), 0, 0);
 	},
@@ -218,7 +231,10 @@ export const goalToolRenderer = {
 		);
 
 		const lines: string[] = [];
-		const objectiveText = truncateToWidth(goal.objective.trim(), TRUNCATE_LENGTHS.LONG);
+		const objectiveText = truncateToWidth(
+			replaceTabs(sanitizeStatusText(goal.objective.trim())),
+			TRUNCATE_LENGTHS.LONG,
+		);
 		lines.push(uiTheme.italic(uiTheme.fg("muted", `"${objectiveText}"`)));
 
 		const used = formatNumber(goal.tokensUsed);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -473,6 +473,8 @@ export class AcpAgent implements Agent {
 	#initialSession: AgentSession | undefined;
 	#createSession: CreateAcpSession;
 	#sessions = new Map<string, ManagedSessionRecord>();
+	#planPreviousTools = new WeakMap<AgentSession, string[]>();
+	#modeTransitionTails = new WeakMap<AgentSession, Promise<void>>();
 	#disposePromise: Promise<void> | undefined;
 	#cleanupRegistered = false;
 	#clientCapabilities: ClientCapabilities | undefined;
@@ -623,7 +625,7 @@ export class AcpAgent implements Agent {
 
 	async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
 		const record = this.#getSessionRecord(params.sessionId);
-		this.#applyModeChange(record.session, params.modeId);
+		await this.#applyModeChange(record.session, params.modeId);
 		await this.#connection.sessionUpdate({
 			sessionId: record.session.sessionId,
 			update: this.#buildCurrentModeUpdate(record.session),
@@ -640,7 +642,7 @@ export class AcpAgent implements Agent {
 
 		switch (params.configId) {
 			case MODE_CONFIG_ID:
-				this.#applyModeChange(record.session, params.value);
+				await this.#applyModeChange(record.session, params.value);
 				break;
 			case MODEL_CONFIG_ID:
 				await this.#setModelById(record.session, params.value);
@@ -1648,27 +1650,68 @@ export class AcpAgent implements Agent {
 		return session.getPlanModeState()?.enabled ? ACP_PLAN_MODE_ID : ACP_DEFAULT_MODE_ID;
 	}
 
-	#applyModeChange(session: AgentSession, modeId: string): void {
+	async #applyModeChange(session: AgentSession, modeId: string): Promise<void> {
+		const previous = this.#modeTransitionTails.get(session) ?? Promise.resolve();
+		const transition = previous.catch(() => {}).then(() => this.#applyModeChangeSerial(session, modeId));
+		this.#modeTransitionTails.set(session, transition);
+		try {
+			await transition;
+		} finally {
+			if (this.#modeTransitionTails.get(session) === transition) this.#modeTransitionTails.delete(session);
+		}
+	}
+
+	async #applyModeChangeSerial(session: AgentSession, modeId: string): Promise<void> {
 		const availableModes = this.#getAvailableModes(session);
 		if (!availableModes.some(mode => mode.id === modeId)) {
 			throw new Error(`Unsupported ACP mode: ${modeId}`);
 		}
+		const goalMode = session.getGoalModeState();
+		if (modeId === ACP_PLAN_MODE_ID && goalMode && (goalMode.enabled || goalMode.goal.status === "paused")) {
+			throw new Error("Cannot enter plan mode while goal mode is active. Exit goal mode first.");
+		}
 		if (modeId === ACP_PLAN_MODE_ID) {
 			const previous = session.getPlanModeState();
+			const previousTools = session.getEnabledToolNames();
+			if (!this.#planPreviousTools.has(session)) this.#planPreviousTools.set(session, previousTools);
 			session.setPlanModeState({
 				enabled: true,
 				planFilePath: previous?.planFilePath ?? DEFAULT_PLAN_FILE_URL,
 				workflow: previous?.workflow ?? "parallel",
 				reentry: previous !== undefined,
 			});
-			// Mirror `InteractiveMode.#enterPlanMode`: register the plan-proposal
-			// handler that consumes `xd://propose` writes from plan mode. Without
-			// this, proposal dispatch falls through and plan mode has no approval
-			// path (issue #1869).
+			try {
+				await session.setActiveToolsByName(
+					session.hasBuiltInTool("goal") ? previousTools.filter(name => name !== "goal") : previousTools,
+				);
+				const currentGoal = session.getGoalModeState();
+				if (currentGoal && (currentGoal.enabled || currentGoal.goal.status === "paused")) {
+					session.setPlanModeState(previous);
+					if (!previous) this.#planPreviousTools.delete(session);
+					await session.setActiveToolsByName(previousTools);
+					throw new Error("Cannot enter plan mode while goal mode is active. Exit goal mode first.");
+				}
+			} catch (error) {
+				session.setPlanModeState(previous);
+				if (!previous) this.#planPreviousTools.delete(session);
+				throw error;
+			}
 			session.setPlanProposalHandler?.(title => this.#handleAcpPlanProposal(session, title));
 		} else {
+			const previous = session.getPlanModeState();
 			session.setPlanProposalHandler?.(null);
 			session.setPlanModeState(undefined);
+			try {
+				const previousTools = this.#planPreviousTools.get(session);
+				if (previousTools) await session.setActiveToolsByName(previousTools);
+			} catch (error) {
+				session.setPlanModeState(previous);
+				if (previous?.enabled) {
+					session.setPlanProposalHandler?.(title => this.#handleAcpPlanProposal(session, title));
+				}
+				throw error;
+			}
+			this.#planPreviousTools.delete(session);
 		}
 	}
 
@@ -1728,8 +1771,7 @@ export class AcpAgent implements Agent {
 		// content as context (the file keeps its agent-chosen name — no rename),
 		// then exit plan mode so the agent regains full tools.
 		session.setPlanReferencePath(planFilePath);
-		session.setPlanProposalHandler?.(null);
-		session.setPlanModeState(undefined);
+		await this.#applyModeChange(session, ACP_DEFAULT_MODE_ID);
 		try {
 			await this.#connection.sessionUpdate({
 				sessionId: session.sessionId,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2216,6 +2216,9 @@ export class InteractiveMode implements InteractiveModeContext {
 						paused: this.planModePaused,
 					}
 				: undefined;
+		// Mirror the paused flag onto the session so tools (e.g. goal) can treat a
+		// paused plan as still in plan mode; runs after every plan-state transition.
+		this.session.setPlanModePaused(this.planModePaused);
 		this.statusLine.setPlanModeStatus(status);
 		this.ui.requestRender();
 	}
@@ -2259,6 +2262,17 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#resetGoalContinuationSuppression(): void {
 		this.#goalSuppressNextContinuation = false;
+	}
+
+	#goalBlocksModeEntry(): boolean {
+		const state = this.session.getGoalModeState();
+		return (
+			this.goalModeEnabled ||
+			this.goalModePaused ||
+			state?.enabled === true ||
+			state?.goal.status === "paused" ||
+			state?.goal.status === "budget-limited"
+		);
 	}
 
 	#getPausedGoalState(): GoalModeState | undefined {
@@ -2526,10 +2540,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			});
 			this.goalModeEnabled = restored?.enabled === true;
 			this.goalModePaused = restored?.enabled !== true && restored?.goal.status === "paused";
-			// sdk.ts excludes "goal" from the initial active tool set unconditionally.
-			// Re-add it now so the agent can call resume, complete, or drop on this goal.
+			// Keep the full enabled tool set (including "goal", which is now always
+			// available when the setting is on) as the restore target, so a later
+			// restore through setActiveToolsByName does not drop the goal tool.
 			if (restored?.goal) {
-				const previousTools = this.session.getEnabledToolNames().filter(name => name !== "goal");
+				const previousTools = this.session.getEnabledToolNames();
 				this.#goalModePreviousTools = previousTools;
 				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
 			}
@@ -2563,22 +2578,29 @@ export class InteractiveMode implements InteractiveModeContext {
 		planFilePath?: string;
 		workflow?: "parallel" | "iterative";
 		preserveRestoredModel?: boolean;
-	}): Promise<void> {
+	}): Promise<boolean> {
 		if (this.planModeEnabled) {
-			return;
+			return true;
 		}
-		if (this.goalModeEnabled || this.goalModePaused) {
+		if (this.#goalBlocksModeEntry()) {
 			this.showWarning("Exit goal mode first.");
-			return;
+			return false;
 		}
 		if (this.vibeModeEnabled) {
 			this.showWarning("Exit vibe mode first.");
-			return;
+			return false;
 		}
 
+		const previousPlanModePaused = this.planModePaused;
 		this.planModePaused = false;
 
 		const planFilePath = options?.planFilePath ?? (await this.#getPlanFilePath());
+		if (this.#goalBlocksModeEntry()) {
+			this.planModePaused = previousPlanModePaused;
+			this.#updatePlanModeStatus();
+			this.showWarning("Exit goal mode first.");
+			return false;
+		}
 		const previousTools = this.session.getEnabledToolNames();
 		// `plan-mode-active.md` instructs the agent to draft the plan file with
 		// `write` and refine it with `edit`, and plan approval itself is a `write`
@@ -2594,22 +2616,43 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (this.session.hasBuiltInTool("write")) {
 			planAugmentations.push("write");
 		}
-		const uniquePlanTools = [...new Set([...previousTools, ...planAugmentations])];
+		// Keep the built-in goal out of the active plan tool set (the two modes are
+		// mutually exclusive), but retain shadowing extension and SDK tools whose
+		// activation remains under the caller's control.
+		const planTools = this.session.hasBuiltInTool("goal")
+			? previousTools.filter(name => name !== "goal")
+			: previousTools;
+		const uniquePlanTools = [...new Set([...planTools, ...planAugmentations])];
 
-		this.#planModePreviousTools = previousTools;
-		this.planModePlanFilePath = planFilePath;
-		this.planModeEnabled = true;
-		// Suppress cache-miss marker on the next turn: plan mode changes the system
-		// prompt, which predictably invalidates the cache.
-		this.lastAssistantUsage = undefined;
-
-		await this.session.setActiveToolsByName(uniquePlanTools);
-		this.session.setPlanModeState({
+		const planModeState = {
 			enabled: true,
 			planFilePath,
 			workflow: options?.workflow ?? "parallel",
 			reentry: this.#planModeHasEntered,
-		});
+		} as const;
+		this.#planModePreviousTools = previousTools;
+		this.planModePlanFilePath = planFilePath;
+		this.planModeEnabled = true;
+		this.session.setPlanModeState(planModeState);
+		try {
+			await this.session.setActiveToolsByName(uniquePlanTools);
+		} catch (error) {
+			this.session.setPlanModeState(undefined);
+			this.#planModePreviousTools = undefined;
+			this.planModePlanFilePath = undefined;
+			this.planModeEnabled = false;
+			this.planModePaused = previousPlanModePaused;
+			this.#updatePlanModeStatus();
+			throw error;
+		}
+		if (this.#goalBlocksModeEntry()) {
+			await this.#exitPlanMode({ silent: true, persistModeChange: false });
+			this.showWarning("Exit goal mode first.");
+			return false;
+		}
+		// Suppress cache-miss marker on the next turn: plan mode changes the system
+		// prompt, which predictably invalidates the cache.
+		this.lastAssistantUsage = undefined;
 		this.session.setPlanProposalHandler?.(title => this.session.preparePlanForReview(title));
 		if (this.session.isStreaming) {
 			await this.session.sendPlanModeContext({ deliverAs: "steer" });
@@ -2624,6 +2667,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#updatePlanModeStatus();
 		this.sessionManager.appendModeChange("plan", { planFilePath });
 		this.showStatus(`Plan mode enabled. Plan file: ${planFilePath}`);
+		return true;
 	}
 
 	async #restorePlanPreviousModel(prev: { model: Model; thinkingLevel?: ConfiguredThinkingLevel }): Promise<void> {
@@ -2660,7 +2704,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	async #exitPlanMode(options?: { silent?: boolean; paused?: boolean; deferModelRestore?: boolean }): Promise<void> {
+	async #exitPlanMode(options?: {
+		silent?: boolean;
+		paused?: boolean;
+		deferModelRestore?: boolean;
+		persistModeChange?: boolean;
+	}): Promise<void> {
 		if (!this.planModeEnabled) {
 			return;
 		}
@@ -2671,6 +2720,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		const planModeModelState = this.session.model
 			? { model: this.session.model, thinkingLevel: this.session.configuredThinkingLevel() }
 			: undefined;
+		const previousPlanModePaused = this.planModePaused;
+		this.planModePaused = options?.paused ?? false;
+		this.session.setPlanModePaused(this.planModePaused);
 		this.session.setPlanModeState(undefined);
 		try {
 			if (this.#planModePreviousTools !== undefined) {
@@ -2688,6 +2740,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			// flushPendingModelSwitch() later clobbers the restored/execution model.
 			if (this.#planModePreviousModelState) this.#clearPendingPlanModelSwitch();
 		} catch (error) {
+			this.planModePaused = previousPlanModePaused;
+			this.session.setPlanModePaused(previousPlanModePaused);
 			this.session.setPlanModeState(planModeState);
 			if (
 				planModeModelState &&
@@ -2721,13 +2775,12 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Suppress cache-miss marker on the next turn: plan exit changes the system
 		// prompt, which predictably invalidates the cache.
 		this.lastAssistantUsage = undefined;
-		this.planModePaused = options?.paused ?? false;
 		this.planModePlanFilePath = undefined;
 		this.#planModePreviousTools = undefined;
 		if (!options?.deferModelRestore) this.#planModePreviousModelState = undefined;
 		this.#updatePlanModeStatus();
 		const paused = options?.paused ?? false;
-		this.sessionManager.appendModeChange(paused ? "plan_paused" : "none");
+		if (options?.persistModeChange !== false) this.sessionManager.appendModeChange(paused ? "plan_paused" : "none");
 		if (!options?.silent) {
 			this.showStatus(paused ? "Plan mode paused." : "Plan mode disabled.");
 		}
@@ -2745,7 +2798,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit vibe mode first.");
 			return;
 		}
-		const previousTools = this.session.getEnabledToolNames().filter(name => name !== "goal");
+		const previousTools = this.session.getEnabledToolNames();
 		const goalTools = [...new Set([...previousTools, "goal"])];
 		this.#goalModePreviousTools = previousTools;
 		this.goalModePaused = false;
@@ -3319,8 +3372,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Plan mode is disabled. Enable it in settings (plan.enabled).");
 			return;
 		}
-		await this.#enterPlanMode();
-		if (initialPrompt && this.onInputCallback) {
+		const entered = await this.#enterPlanMode();
+		if (entered && initialPrompt && this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
 		}
 	}
@@ -3345,23 +3398,23 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit goal mode first.");
 			return;
 		}
-		await this.#enterVibeMode();
-		if (initialPrompt && this.onInputCallback) {
+		const entered = await this.#enterVibeMode();
+		if (entered && initialPrompt && this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
 		}
 	}
 
-	async #enterVibeMode(options?: { persistModeChange?: boolean }): Promise<void> {
+	async #enterVibeMode(options?: { persistModeChange?: boolean }): Promise<boolean> {
 		if (this.vibeModeEnabled) {
-			return;
+			return true;
 		}
 		if (this.planModeEnabled || this.planModePaused) {
 			this.showWarning("Exit plan mode first.");
-			return;
+			return false;
 		}
-		if (this.goalModeEnabled || this.goalModePaused) {
+		if (this.#goalBlocksModeEntry()) {
 			this.showWarning("Exit goal mode first.");
-			return;
+			return false;
 		}
 
 		const vibeRegistry = VibeSessionRegistry.global();
@@ -3370,14 +3423,28 @@ export class InteractiveMode implements InteractiveModeContext {
 		const previousTools = this.session.getEnabledToolNames();
 		const vibeBaseTools = ["read"];
 		if (this.session.hasBuiltInTool("todo")) vibeBaseTools.push("todo");
-		await this.session.activateVibeTools(vibeBaseTools);
 		this.#vibeModePreviousTools = previousTools;
 		this.#vibeModeOwnerScope = ownerScope;
 		this.vibeModeEnabled = true;
+		this.session.setVibeModeState({ enabled: true });
+		try {
+			await this.session.activateVibeTools(vibeBaseTools);
+		} catch (error) {
+			await this.#exitVibeMode();
+			throw error;
+		}
+		if (this.#goalBlocksModeEntry()) {
+			await this.#exitVibeMode();
+			const goalState = this.session.getGoalModeState();
+			if (goalState?.goal) {
+				this.sessionManager.appendModeChange(goalState.enabled ? "goal" : "goal_paused");
+			}
+			this.showWarning("Exit goal mode first.");
+			return false;
+		}
 		// Suppress cache-miss marker on the next turn: vibe mode changes the
 		// injected context, which predictably invalidates the cache.
 		this.lastAssistantUsage = undefined;
-		this.session.setVibeModeState({ enabled: true });
 		if (this.session.isStreaming) {
 			await this.session.sendVibeModeContext({ deliverAs: "steer" });
 		}
@@ -3386,6 +3453,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.showStatus(
 			"Vibe mode enabled. You direct fast/good worker sessions; toolset is read + optional parent Todo + vibe tools.",
 		);
+		return true;
 	}
 
 	async #exitVibeMode(): Promise<void> {
@@ -3507,11 +3575,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 
 			// Expose the goal tool for the interview so the agent can finish by
-			// calling `goal create`. Record the pre-interview toolset first: the
-			// tool-driven create flips goalModeEnabled via `goal_updated`, and the
-			// eventual goal exit restores this set (dropping the goal tool again).
+			// calling `goal create`. Preserve the full pre-interview set so dropping
+			// the created goal returns to the normal default tools.
 			const enabledTools = this.session.getEnabledToolNames();
-			this.#goalModePreviousTools = enabledTools.filter(name => name !== "goal");
+			this.#goalModePreviousTools = enabledTools;
 			if (!enabledTools.includes("goal")) {
 				await this.session.setActiveToolsByName([...enabledTools, "goal"]);
 			}

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -123,13 +123,22 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 	if (planDefaultArmed) {
 		const planFilePath = session.getPlanReferencePath() || "local://PLAN.md";
 		const previousTools = session.getEnabledToolNames();
-		const planTools = session.hasBuiltInTool("write") ? [...new Set([...previousTools, "write"])] : previousTools;
-		await session.setActiveToolsByName(planTools);
-		session.setPlanModeState({
+		const planBaseTools = session.hasBuiltInTool("goal")
+			? previousTools.filter(name => name !== "goal")
+			: previousTools;
+		const planTools = session.hasBuiltInTool("write") ? [...new Set([...planBaseTools, "write"])] : planBaseTools;
+		const planModeState = {
 			enabled: true,
 			planFilePath,
 			workflow: "parallel",
-		});
+		} as const;
+		session.setPlanModeState(planModeState);
+		try {
+			await session.setActiveToolsByName(planTools);
+		} catch (error) {
+			session.setPlanModeState(undefined);
+			throw error;
+		}
 		session.sessionManager.appendModeChange("plan", { planFilePath });
 		abortAfterPlanProposal = true;
 		session.setPlanProposalHandler(async title => {

--- a/packages/coding-agent/src/prompts/goals/guided-goal-interview.md
+++ b/packages/coding-agent/src/prompts/goals/guided-goal-interview.md
@@ -22,7 +22,7 @@ The objective is ready only when all five of the following are pinned down. Keep
 
 1. Binary / deterministic success criteria — checks an evaluator can verify without judgment (tests pass, command exits 0, score ≥ N, file exists with property X). Reject subjective "works well / clean / done".
 2. Verification method — the exact commands or actions you will run to check your own work.
-3. Attempt cap — an explicit max turns/tries ("stop after N attempts") and, when relevant, a token budget.
+3. Attempt cap — an explicit max turns/tries ("stop after N attempts").
 4. Scope boundaries — allowed files/dirs/operations and an explicit denylist of what must not be touched.
 5. Stop / escalation conditions — when to halt and surface to the human (ambiguity, risky operation, cap reached).
 
@@ -32,7 +32,7 @@ Anti-patterns to re-ask until fixed:
 - Uncapped iteration ("until CI is green", "keep going until it works")
 - Self-graded success without a verification command
 
-Once all five are settled, call the `goal` tool with `op: "create"`, the final objective, and `token_budget` if the user gave one. The objective MUST be structured markdown with exactly these sections, in this order:
+Once all five are settled, call the `goal` tool with `op: "create"` and the final objective. The objective MUST be structured markdown with exactly these sections, in this order:
 
 ## Objective
 ## Success criteria

--- a/packages/coding-agent/src/prompts/tools/goal.md
+++ b/packages/coding-agent/src/prompts/tools/goal.md
@@ -1,11 +1,15 @@
 Manage the active goal-mode objective.
 
 Use a single `op` field:
-- `create` starts a goal and enables goal mode. Requires `objective`; optional `token_budget` must be positive. Use only when no goal exists and no goal is paused.
-- `get` returns the current goal (active or paused) and remaining token budget.
+- `set` starts goal mode when no goal exists, or replaces an active or paused goal with a fresh active goal. Requires `objective`.
+- `create` starts a goal. Requires `objective`. Use only when no goal exists and no goal is paused.
+- `get` returns the current goal (active or paused).
 - `resume` re-activates a paused goal so work can continue.
 - `complete` marks the goal complete after you have verified every deliverable against current evidence.
 - `drop` discards the current goal without completing it.
 
+Set a goal by its objective and keep working until it is done and verified. The
+token budget is an operator setting, not yours to size or cap; there is no
+budget parameter.
 NEVER call `complete` because a budget is low or a turn is ending. Call it only when the goal is actually done and verified.
-If `get` shows a paused goal, call `resume` before continuing work on it.
+If `get` shows a paused goal and you intend to continue that same goal, call `resume` before continuing work on it.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -212,7 +212,7 @@ import {
 	xdevDocsAll,
 	xdevEntries,
 } from "./tools";
-import { isMCPToolName, normalizeToolNames } from "./tools/builtin-names";
+import { isMCPToolName, NO_TOOLS_SENTINEL, normalizeToolNames } from "./tools/builtin-names";
 import { ToolContextStore } from "./tools/context";
 import { isIrcEnabled } from "./tools/hub";
 import { getImageGenTools } from "./tools/image-gen";
@@ -1759,6 +1759,8 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getServiceTierByFamily: () => session?.serviceTierByFamily,
 			getImageAttachments: () => session?.getImageAttachments() ?? [],
 			getPlanModeState: () => session?.getPlanModeState(),
+			isPlanModePaused: () => session?.isPlanModePaused() ?? false,
+			getVibeModeState: () => session?.getVibeModeState(),
 			getPlanReferencePath: () => session?.getPlanReferencePath() ?? "local://PLAN.md",
 			getGoalModeState: () => session?.getGoalModeState(),
 			getGoalRuntime: () => session?.goalRuntime,
@@ -2969,6 +2971,15 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		) {
 			explicitlyRequestedToolNames.push("yield");
 		}
+		if (
+			explicitlyRequestedToolNames &&
+			explicitlyRequestedToolNames.length > 0 &&
+			!explicitlyRequestedToolNames.includes(NO_TOOLS_SENTINEL) &&
+			settings.get("goal.enabled") &&
+			builtInRegistryToolNames.has("goal")
+		) {
+			if (!explicitlyRequestedToolNames.includes("goal")) explicitlyRequestedToolNames.push("goal");
+		}
 		// Auto-learn builtins are force-included into the registry by `createTools`
 		// for enabled top-level sessions (tools/index.ts), but — like `yield` above —
 		// an explicit `toolNames` list would otherwise drop them from the ACTIVE set,
@@ -3001,7 +3012,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		const defaultInactiveToolNames = new Set(
 			registeredTools.filter(tool => tool.definition.defaultInactive).map(tool => tool.definition.name),
 		);
-		const requestedActiveToolNames = normalizedRequested.filter(name => name !== "goal");
+		const requestedActiveToolNames = normalizedRequested;
 		const explicitlyRequestedToolNameSet = explicitlyRequestedToolNames
 			? new Set(explicitlyRequestedToolNames)
 			: undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -464,6 +464,11 @@ export class AgentSession {
 	#planModeState: PlanModeState | undefined;
 	/** Session-scoped `/vision` override; undefined = follow persisted `inspect_image.mode`. */
 	#inspectImageModeOverride: InspectImageMode | undefined;
+	// Plan mode paused keeps `planFilePath` state cleared (#planModeState becomes
+	// undefined) while the plan stays logically active, so track it separately for
+	// consumers (e.g. the goal tool) that must treat a paused plan as still in
+	// plan mode. Kept in sync by InteractiveMode#updatePlanModeStatus.
+	#planModePaused = false;
 	#vibeModeState: VibeModeState | undefined;
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
@@ -4530,6 +4535,14 @@ export class AgentSession {
 			// does not inherit a stale `required` tool choice.
 			this.#toolChoiceQueue.removeByLabel("plan-mode-decision");
 		}
+	}
+
+	isPlanModePaused(): boolean {
+		return this.#planModePaused;
+	}
+
+	setPlanModePaused(paused: boolean): void {
+		this.#planModePaused = paused;
 	}
 
 	getGoalModeState(): GoalModeState | undefined {

--- a/packages/coding-agent/src/session/prewalk.ts
+++ b/packages/coding-agent/src/session/prewalk.ts
@@ -207,14 +207,25 @@ export class PrewalkCoordinator {
 		if (!this.#planYolo || this.#planYoloArmed) return;
 		this.#planYoloArmed = true;
 		const previousTools = this.#host.getEnabledToolNames();
+		const planBaseTools = this.#host.hasBuiltInTool("goal")
+			? previousTools.filter(name => name !== "goal")
+			: previousTools;
 		const augmentations = this.#host.hasBuiltInTool("write") ? ["write"] : [];
-		await this.#host.setActiveToolsByName([...new Set([...previousTools, ...augmentations])]);
 		this.#planYoloPreviousTools = previousTools;
-		this.#host.setPlanModeState({
+		const planModeState = {
 			enabled: true,
 			planFilePath: this.#host.getPlanReferencePath() || "local://PLAN.md",
 			workflow: "parallel",
-		});
+		} as const;
+		this.#host.setPlanModeState(planModeState);
+		try {
+			await this.#host.setActiveToolsByName([...new Set([...planBaseTools, ...augmentations])]);
+		} catch (error) {
+			this.#host.setPlanModeState(undefined);
+			this.#planYoloPreviousTools = undefined;
+			this.#planYoloArmed = false;
+			throw error;
+		}
 		this.#host.setPlanProposalHandler(title => this.#finalizePlanYoloProposal(title));
 	}
 

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -37,6 +37,14 @@ export const HIDDEN_TOOL_NAMES = ["yield", "goal"] as const;
 
 export type HiddenToolName = (typeof HIDDEN_TOOL_NAMES)[number];
 
+/**
+ * Explicit `toolNames` value that requests no built-in tools (used by helper
+ * sessions like the agent-spec generator and the agentic commit helper). It
+ * matches no real tool, so it resolves to an empty active set; force-adds such
+ * as `goal` must skip a list that only asks for it.
+ */
+export const NO_TOOLS_SENTINEL = "__none__";
+
 const LEGACY_BUILTIN_TOOL_NAME_ALIASES: ReadonlyMap<string, BuiltinToolName> = new Map([
 	["search", "grep"],
 	["find", "glob"],

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -34,6 +34,7 @@ import type { AgentOutputManager } from "../task/output-manager";
 import { canSpawnAtDepth, type StructuredSubagentSchemaMode } from "../task/types";
 import type { EventBus } from "../utils/event-bus";
 import { type InspectImageMode, isInspectImageToolActive } from "../utils/inspect-image-mode";
+import type { VibeModeState } from "../vibe/state";
 import { WebSearchTool } from "../web/search";
 import type { WorkspaceTree } from "../workspace-tree";
 import { AskTool } from "./ask";
@@ -41,7 +42,7 @@ import { AstEditTool } from "./ast-edit";
 import { AstGrepTool } from "./ast-grep";
 import { BashTool } from "./bash";
 import { BrowserTool } from "./browser";
-import { type BuiltinToolName, type HiddenToolName, normalizeToolNames } from "./builtin-names";
+import { type BuiltinToolName, type HiddenToolName, NO_TOOLS_SENTINEL, normalizeToolNames } from "./builtin-names";
 import { type CheckpointState, CheckpointTool, type CompletedRewindState, RewindTool } from "./checkpoint";
 import { ComputerTool } from "./computer";
 import { DebugTool } from "./debug";
@@ -308,6 +309,10 @@ export interface ToolSession {
 	settings: Settings;
 	/** Plan mode state (if active) */
 	getPlanModeState?: () => PlanModeState | undefined;
+	/** Whether plan mode is paused (plan stays logically active while `getPlanModeState` is cleared). */
+	isPlanModePaused?: () => boolean;
+	/** Vibe mode state (if active). */
+	getVibeModeState?: () => VibeModeState | undefined;
 	/** Path of the session's active plan reference (e.g. `local://<title>.md`); defaults to `local://PLAN.md`. */
 	getPlanReferencePath?: () => string;
 	/** Goal mode state (if active or paused) */
@@ -463,10 +468,6 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 			? normalizeToolNames(toolNames)
 			: undefined;
 	const goalEnabled = session.settings.get("goal.enabled");
-	const goalModeActive = !restrictToolNames && goalEnabled && session.getGoalModeState?.()?.enabled === true;
-	if (goalModeActive && requestedTools && !requestedTools.includes("goal")) {
-		requestedTools.push("goal");
-	}
 	const backends = resolveEvalBackends(session);
 	const allowPython = backends.python;
 	const allowJs = backends.js;
@@ -537,7 +538,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// Auto-include AST counterparts when their text-based sibling is present.
 	// Restricted callers own the active list and must not have it widened.
 	if (requestedTools && !restrictToolNames) {
-		if (goalModeActive && !requestedTools.includes("goal")) {
+		if (goalEnabled && !requestedTools.includes(NO_TOOLS_SENTINEL) && !requestedTools.includes("goal")) {
 			requestedTools.push("goal");
 		}
 		if (
@@ -580,16 +581,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	}
 	const allTools: Record<string, ToolFactory> = { ...BUILTIN_TOOLS, ...HIDDEN_TOOLS };
 	const isToolAllowed = (name: string) => {
-		// Never in the default set. Explicitly activatable while goal.enabled and
-		// no goal record exists yet — /guided-goal enables it so the agent can
-		// finish the interview with `goal create`, which turns goal mode on. Once
-		// a goal record exists, only an enabled goal keeps the tool: a completed
-		// (exiting) or paused goal must stop advertising it on the next rebuild.
-		if (name === "goal") {
-			if (!goalEnabled || restrictToolNames) return false;
-			const goalState = session.getGoalModeState?.();
-			return goalState === undefined || goalState.enabled === true || goalState.goal.status === "dropped";
-		}
+		if (name === "goal") return goalEnabled;
 		if (name === "lsp") return enableLsp && session.settings.get("lsp.enabled");
 		if (name === "bash") return session.settings.get("bash.enabled");
 		if (name === "eval") return allowEval;
@@ -651,7 +643,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 						.filter(([name]) => isToolAllowed(name))
 						.map(([name, factory]) => [name, factory] as const),
 					...(includeYield ? ([["yield", HIDDEN_TOOLS.yield]] as const) : []),
-					...(goalModeActive ? ([["goal", HIDDEN_TOOLS.goal]] as const) : []),
+					...(goalEnabled ? ([["goal", HIDDEN_TOOLS.goal]] as const) : []),
 				];
 
 	const activeToolNames = new Set(baseEntries.map(([name]) => name));

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -20,6 +20,7 @@ import {
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { GoalModeState } from "@oh-my-pi/pi-coding-agent/goals/state";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import {
 	ACP_BOOTSTRAP_RACE_GUARD_MS,
@@ -137,6 +138,11 @@ class FakeAgentSession {
 		this.refreshSkillsCalls++;
 	}
 	planModeState: PlanModeState | undefined;
+	goalModeState: GoalModeState | undefined;
+	activeToolNames: string[] = [];
+	setActiveToolsError: Error | undefined;
+	setActiveToolsBlocker: ((toolNames: string[]) => Promise<void>) | undefined;
+	builtInToolNames = new Set<string>();
 	waitForIdleCalls = 0;
 	waitForIdleBlocker: (() => Promise<void>) | undefined;
 	asyncJobDrain: ((options?: { timeoutMs?: number }) => Promise<boolean>) | undefined;
@@ -316,14 +322,25 @@ class FakeAgentSession {
 	}
 
 	getActiveToolNames(): string[] {
-		return [];
+		return [...this.activeToolNames];
+	}
+	getEnabledToolNames(): string[] {
+		return [...this.activeToolNames];
 	}
 
 	getAllToolNames(): string[] {
-		return [];
+		return [...this.activeToolNames];
 	}
 
-	setActiveToolsByName(_toolNames: string[]): void {}
+	hasBuiltInTool(name: string): boolean {
+		return this.builtInToolNames.has(name);
+	}
+
+	async setActiveToolsByName(toolNames: string[]): Promise<void> {
+		await this.setActiveToolsBlocker?.(toolNames);
+		if (this.setActiveToolsError) throw this.setActiveToolsError;
+		this.activeToolNames = [...toolNames];
+	}
 
 	setClientBridge(_bridge: unknown): void {}
 
@@ -333,6 +350,10 @@ class FakeAgentSession {
 
 	setPlanModeState(state: PlanModeState | undefined): void {
 		this.planModeState = state;
+	}
+
+	getGoalModeState(): GoalModeState | undefined {
+		return this.goalModeState;
 	}
 
 	planProposalHandler: ((title: string) => Promise<unknown> | unknown) | undefined;
@@ -602,9 +623,11 @@ describe("ACP agent", () => {
 		expect(initialModeConfig?.currentValue).toBe("default");
 		expect(initialModeConfig?.options?.map(option => option.value)).toEqual(["default", "plan"]);
 
-		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
-
 		const session = harness.findSession(created.sessionId)!;
+		session.activeToolNames = ["read", "goal"];
+		session.builtInToolNames.add("goal");
+		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
+		expect(session.activeToolNames).toEqual(["read"]);
 		expect(session.planModeState).toEqual(
 			expect.objectContaining({ enabled: true, planFilePath: "local://PLAN.md", workflow: "parallel" }),
 		);
@@ -641,11 +664,98 @@ describe("ACP agent", () => {
 		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "default" });
 		expect(session.planModeState).toBeUndefined();
 		expect(session.planProposalHandler).toBeUndefined();
+		expect(session.activeToolNames).toEqual(["read", "goal"]);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
 	});
 
+	it("serializes overlapping plan and default mode transitions", async () => {
+		const harness = await createHarness();
+		Settings.instance.set("plan.enabled", true);
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		session.activeToolNames = ["read", "goal"];
+		session.builtInToolNames.add("goal");
+		const planRebuild = Promise.withResolvers<void>();
+		const planRebuildStarted = Promise.withResolvers<void>();
+		session.setActiveToolsBlocker = async toolNames => {
+			if (toolNames.length === 1 && toolNames[0] === "read") {
+				planRebuildStarted.resolve();
+				await planRebuild.promise;
+			}
+		};
+
+		const enterPlan = harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
+		await planRebuildStarted.promise;
+		const enterDefault = harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "default" });
+		planRebuild.resolve();
+		await Promise.all([enterPlan, enterDefault]);
+
+		expect(session.planModeState).toBeUndefined();
+		expect(session.planProposalHandler).toBeUndefined();
+		expect(session.activeToolNames).toEqual(["read", "goal"]);
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("restores plan approval when default-mode tool restoration fails", async () => {
+		const harness = await createHarness();
+		Settings.instance.set("plan.enabled", true);
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		session.activeToolNames = ["read", "goal"];
+		session.builtInToolNames.add("goal");
+		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
+		session.setActiveToolsError = new Error("tool rebuild failed");
+
+		await expect(harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "default" })).rejects.toThrow(
+			"tool rebuild failed",
+		);
+		expect(session.planModeState?.enabled).toBe(true);
+		expect(typeof session.planProposalHandler).toBe("function");
+		expect(session.activeToolNames).toEqual(["read"]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("rejects plan mode while a goal is active and allows it after completion", async () => {
+		const harness = await createHarness();
+		Settings.instance.set("plan.enabled", true);
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		session.goalModeState = {
+			enabled: true,
+			mode: "active",
+			goal: {
+				id: "goal-1",
+				objective: "finish",
+				status: "active",
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		};
+
+		await expect(harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" })).rejects.toThrow(
+			"Cannot enter plan mode while goal mode is active",
+		);
+		expect(session.planModeState).toBeUndefined();
+		session.goalModeState = {
+			...session.goalModeState!,
+			enabled: false,
+			mode: "exiting",
+			reason: "completed",
+			goal: { ...session.goalModeState!.goal, status: "complete" },
+		};
+		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
+		expect(session.planModeState?.enabled).toBe(true);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
 	it("plan-proposal handler errors when the plan file is missing", async () => {
 		const harness = await createHarness();
 		Settings.instance.set("plan.enabled", true);
@@ -674,6 +784,8 @@ describe("ACP agent", () => {
 
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
+		session.activeToolNames = ["read", "goal"];
+		session.builtInToolNames.add("goal");
 		await harness.agent.setSessionMode({ sessionId: created.sessionId, modeId: "plan" });
 
 		const localOptions = {
@@ -703,6 +815,7 @@ describe("ACP agent", () => {
 		// Mode + handler are cleared; the agent regains write tools next turn.
 		expect(session.planModeState).toBeUndefined();
 		expect(session.planProposalHandler).toBeUndefined();
+		expect(session.activeToolNames).toEqual(["read", "goal"]);
 		expect(session.planReferencePath).toBe("local://words-counter-plan.md");
 		const approvalUpdates = harness.updates.slice(updatesBefore);
 		// Mode-change notifications reached the client so Zed's UI and config

--- a/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
+++ b/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
@@ -100,6 +100,7 @@ describe("AgentSession plan-mode convergence", () => {
 			sideResponses?: MockResponse[];
 			planYolo?: boolean;
 			rebuildGate?: { fail: boolean };
+			includeGoal?: boolean;
 		},
 	): Promise<PlanHarness> {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
@@ -108,6 +109,7 @@ describe("AgentSession plan-mode convergence", () => {
 		const askTool = makeTool("ask");
 		const writeTool = makeTool("write");
 		const readTool = makeTool("read");
+		const goalTool = makeTool("goal");
 
 		const mock = createMockModel({ responses });
 		const agent = new Agent({
@@ -117,7 +119,9 @@ describe("AgentSession plan-mode convergence", () => {
 			initialState: {
 				model,
 				systemPrompt: ["Test"],
-				tools: options?.planYolo ? [readTool] : [askTool, writeTool, readTool],
+				tools: options?.planYolo
+					? [readTool, ...(options.includeGoal ? [goalTool] : [])]
+					: [askTool, writeTool, readTool],
 				messages: [],
 			},
 			streamFn: mock.stream,
@@ -154,8 +158,9 @@ describe("AgentSession plan-mode convergence", () => {
 				["ask", askTool],
 				["write", writeTool],
 				["read", readTool],
+				...(options?.includeGoal ? ([["goal", goalTool]] as const) : []),
 			]),
-			builtInToolNames: ["ask", "write", "read"],
+			builtInToolNames: ["ask", "write", "read", ...(options?.includeGoal ? ["goal"] : [])],
 			advisorTools: [],
 			advisorStreamFn,
 			sideStreamFn,
@@ -337,6 +342,16 @@ describe("AgentSession plan-mode convergence", () => {
 
 		expect(harness.session.getPlanModeState()).toBeUndefined();
 		expect(harness.session.getActiveToolNames()).toEqual(["read"]);
+	});
+
+	it("removes the built-in goal tool from PlanYolo", async () => {
+		const harness = await createPlanSession([{ content: ["planning"] }], { planYolo: true, includeGoal: true });
+
+		await harness.session.prompt("make a plan");
+		await harness.session.waitForIdle();
+
+		expect(harness.session.getActiveToolNames()).toContain("write");
+		expect(harness.session.getActiveToolNames()).not.toContain("goal");
 	});
 
 	it("keeps PlanYolo retryable when pre-plan tool restoration fails", async () => {

--- a/packages/coding-agent/test/fixtures/computer-schema-construction-probe.ts
+++ b/packages/coding-agent/test/fixtures/computer-schema-construction-probe.ts
@@ -64,7 +64,7 @@ await Promise.all([firstTool.close(), secondTool.close()]);
 process.stdout.write(
 	JSON.stringify({
 		counts,
-		disabledToolCount: disabledTools.length,
+		disabledToolCount: disabledTools.filter(tool => tool.name === "computer").length,
 		schema: {
 			callable: typeof firstSchema === "function",
 			repeatedIdentity: firstSchema === repeatedSchema,

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -72,7 +72,7 @@ async function createGoalHarness(shared: SharedFixture): Promise<GoalHarness> {
 		"plan.enabled": true,
 	});
 	const bootstrapToolSession = createToolSession(tempDir.path(), settings);
-	const initialTools = await createTools(bootstrapToolSession, ["read"]);
+	const initialTools = await createTools(bootstrapToolSession);
 	const toolRegistry = new Map<string, Tool>(initialTools.map(tool => [tool.name, tool] as const));
 
 	const session = new AgentSession({
@@ -170,8 +170,8 @@ describe("InteractiveMode goal mode integration", () => {
 		await harness.cleanup();
 	});
 
-	it("toggles goal tool exposure when goal mode enters and pauses", async () => {
-		expect(await toolNamesFor(harness)).not.toContain("goal");
+	it("keeps goal tool available before, during, and after a paused goal", async () => {
+		expect(await toolNamesFor(harness)).toContain("goal");
 
 		await harness.mode.handleGoalModeCommand("Ship the release");
 
@@ -185,7 +185,20 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.mode.goalModeEnabled).toBe(false);
 		expect(harness.mode.goalModePaused).toBe(true);
 		expect(harness.session.getGoalModeState()?.goal.status).toBe("paused");
-		expect(await toolNamesFor(harness)).not.toContain("goal");
+		expect(await toolNamesFor(harness)).toContain("goal");
+	});
+
+	it("lets the goal tool start a goal from an ordinary session", async () => {
+		const tool = new GoalTool(harness.toolSession);
+
+		await tool.execute("call-set", {
+			op: "set",
+			objective: "Ship from the tool",
+		});
+
+		expect(harness.session.getGoalModeState()?.enabled).toBe(true);
+		expect(harness.session.getGoalModeState()?.goal.objective).toBe("Ship from the tool");
+		expect(await toolNamesFor(harness)).toContain("goal");
 	});
 
 	it("replaces the active goal via /goal set", async () => {
@@ -306,6 +319,7 @@ describe("InteractiveMode goal mode integration", () => {
 
 	it("omits persisted todo state when todo tool is inactive", async () => {
 		await harness.mode.handleGoalModeCommand("Ship the release");
+		await harness.session.setActiveToolsByName(["read", "goal"]);
 		harness.session.setTodoPhases([
 			{
 				name: "Verification",
@@ -460,12 +474,10 @@ describe("InteractiveMode goal mode integration", () => {
 		);
 		expect(completionText).toContain("Goal achieved. Report final budget usage to the user: tokens used: 0 of 50.");
 		expect(harness.session.getGoalModeState()?.mode).toBe("exiting");
-		// Per fix #1: completeGoalFromTool clears state.enabled so subsequent createTools
-		// calls (e.g. mid-turn refreshes) no longer advertise the goal tool. The model's
-		// existing toolset for the in-flight turn is unaffected — what we care about here
-		// is that the next createTools observation reflects the deactivation.
+		// Completion clears active goal state, but sessions that had the goal tool
+		// before goal mode keep it so a later assistant can set the next goal.
 		expect(harness.session.getGoalModeState()?.enabled).toBe(false);
-		expect(await toolNamesFor(harness)).not.toContain("goal");
+		expect(await toolNamesFor(harness)).toContain("goal");
 
 		const nextTurn = harness.mode.getUserInput();
 		// getUserInput observes mode === "exiting" and awaits #exitGoalMode before
@@ -476,7 +488,11 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(harness.mode.goalModeEnabled).toBe(false);
 		expect(harness.mode.goalModePaused).toBe(false);
 		expect(harness.session.getGoalModeState()).toBeUndefined();
-		expect(await toolNamesFor(harness)).not.toContain("goal");
+		// The restored active tool set is rebuilt from #goalModePreviousTools via
+		// setActiveToolsByName without re-running createTools, so goal must survive
+		// there directly (not only in the re-derived toolNamesFor set below).
+		expect(harness.session.getActiveToolNames()).toContain("goal");
+		expect(await toolNamesFor(harness)).toContain("goal");
 		expect(appendCustomEntry).toHaveBeenCalledWith(
 			"goal-completed",
 			expect.objectContaining({

--- a/packages/coding-agent/test/goals/goal-runtime.test.ts
+++ b/packages/coding-agent/test/goals/goal-runtime.test.ts
@@ -52,7 +52,14 @@ function cloneEvent(event: GoalRuntimeEvent): GoalRuntimeEvent {
 	return { ...event };
 }
 
-function createHarness(initial: { state?: GoalModeState; usage?: GoalTokenUsage; now?: number } = {}) {
+function createHarness(
+	initial: {
+		state?: GoalModeState;
+		usage?: GoalTokenUsage;
+		now?: number;
+		onEmit?: (event: GoalRuntimeEvent) => Promise<void>;
+	} = {},
+) {
 	let state = cloneState(initial.state);
 	let usage = createUsage(initial.usage);
 	let now = initial.now ?? 0;
@@ -68,6 +75,7 @@ function createHarness(initial: { state?: GoalModeState; usage?: GoalTokenUsage;
 		getCurrentUsage: () => createUsage(usage),
 		emit: async event => {
 			events.push(cloneEvent(event));
+			await initial.onEmit?.(event);
 		},
 		persist: (mode, persistedState) => {
 			persists.push({ mode, state: cloneState(persistedState) });
@@ -415,6 +423,49 @@ describe("goal runtime", () => {
 		expect(harness.persists.at(-1)?.state?.goal.objective).toBe("Second");
 	});
 
+	it("preserves usage flushed while setting an active goal", async () => {
+		const harness = createHarness({
+			state: {
+				enabled: true,
+				mode: "active",
+				goal: createGoal({ objective: "Existing", tokenBudget: 100, tokensUsed: 3 }),
+			},
+		});
+
+		harness.runtime.onTurnStart("turn-1", createUsage());
+		harness.advance(1_000);
+		harness.setUsage({ input: 12 });
+
+		const next = await harness.runtime.setGoal({ objective: "Second", tokenBudget: 20 });
+
+		expect(next.goal.status).toBe("active");
+		expect(next.goal.tokensUsed).toBe(15);
+		expect(next.goal.timeUsedSeconds).toBe(1);
+	});
+
+	it("sets a fresh active goal over a paused goal", async () => {
+		const harness = createHarness({
+			state: {
+				enabled: false,
+				mode: "active",
+				goal: createGoal({ objective: "Paused", status: "paused", tokenBudget: 100, tokensUsed: 30 }),
+			},
+		});
+
+		const next = await harness.runtime.setGoal({ objective: "Second", tokenBudget: 25 });
+
+		expect(next.enabled).toBe(true);
+		expect(next.goal.objective).toBe("Second");
+		expect(next.goal.status).toBe("budget-limited");
+		expect(next.goal.tokenBudget).toBe(25);
+		expect(next.goal.tokensUsed).toBe(30);
+		expect(next.goal.timeUsedSeconds).toBe(0);
+		expect(next.goal.id).not.toBe("goal-1");
+		expect(harness.persists.at(-1)?.mode).toBe("goal");
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]?.customType).toBe("goal-budget-limit");
+	});
+
 	it("allows creating a new goal after the previous one is complete", async () => {
 		const harness = createHarness({
 			state: {
@@ -429,6 +480,59 @@ describe("goal runtime", () => {
 		expect(next.goal.objective).toBe("Phase 4");
 		expect(next.goal.status).toBe("active");
 		expect(next.enabled).toBe(true);
+	});
+
+	it("revalidates queued goal starts after acquiring runtime ownership", async () => {
+		const completionFanout = Promise.withResolvers<void>();
+		let blockCompletion = true;
+		const harness = createHarness({
+			state: { enabled: true, mode: "active", goal: createGoal() },
+			onEmit: async () => {
+				if (!blockCompletion) return;
+				blockCompletion = false;
+				await completionFanout.promise;
+			},
+		});
+		const completing = harness.runtime.completeGoalFromTool();
+		await Promise.resolve();
+		let planActive = false;
+		const queuedStart = harness.runtime.createGoal({ objective: "Next" }, () => {
+			if (planActive) throw new Error("plan active");
+		});
+		planActive = true;
+		completionFanout.resolve();
+
+		await completing;
+		await expect(queuedStart).rejects.toThrow("plan active");
+		expect(harness.getState()?.goal.status).toBe("complete");
+	});
+
+	it("keeps an exhausted paused goal budget-limited when resumed", async () => {
+		const harness = createHarness({
+			state: {
+				enabled: false,
+				mode: "active",
+				goal: createGoal({ status: "paused", tokenBudget: 20, tokensUsed: 20 }),
+			},
+		});
+
+		const resumed = await harness.runtime.resumeGoal();
+		expect(resumed.enabled).toBe(true);
+		expect(resumed.goal.status).toBe("budget-limited");
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]?.customType).toBe("goal-budget-limit");
+	});
+
+	it("rejects resume when the current goal is not paused", async () => {
+		const harness = createHarness({
+			state: {
+				enabled: true,
+				mode: "active",
+				goal: createGoal({ status: "active" }),
+			},
+		});
+
+		await expect(harness.runtime.resumeGoal()).rejects.toThrow("No paused goal.");
 	});
 
 	it("completeGoalFromTool succeeds for a paused goal (enabled=false)", async () => {

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "bun:test";
 import { completionBudgetReport, GoalRuntime } from "@oh-my-pi/pi-coding-agent/goals/runtime";
 import type { Goal, GoalModeState, GoalTokenUsage } from "@oh-my-pi/pi-coding-agent/goals/state";
-import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
+import { GoalTool, goalToolRenderer } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
+import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
 function createUsage(overrides: Partial<GoalTokenUsage> = {}): GoalTokenUsage {
@@ -56,6 +58,37 @@ function createRuntimeHarness(initialState?: GoalModeState) {
 }
 
 describe("GoalTool", () => {
+	it("refuses to start or resume a goal while plan mode is active or paused", async () => {
+		const planSignals: Array<Partial<ToolSession>> = [
+			{ getPlanModeState: () => ({ enabled: true, planFilePath: "plan.md" }) satisfies PlanModeState },
+			// A paused plan clears getPlanModeState but stays logically active.
+			{ getPlanModeState: () => undefined, isPlanModePaused: () => true },
+		];
+		for (const planSignal of planSignals) {
+			const runtime = {
+				setGoal: vi.fn(),
+				createGoal: vi.fn(),
+				replaceGoal: vi.fn(),
+				resumeGoal: vi.fn(),
+			};
+			const tool = new GoalTool(
+				createToolSession({
+					getGoalRuntime: () => runtime as unknown as GoalRuntime,
+					getGoalModeState: () => undefined,
+					...planSignal,
+				}),
+			);
+
+			for (const op of ["create", "set", "resume"] as const) {
+				await expect(tool.execute("call", { op, objective: "Ship it" })).rejects.toThrow(/plan mode/i);
+			}
+			expect(runtime.setGoal).not.toHaveBeenCalled();
+			expect(runtime.createGoal).not.toHaveBeenCalled();
+			expect(runtime.replaceGoal).not.toHaveBeenCalled();
+			expect(runtime.resumeGoal).not.toHaveBeenCalled();
+		}
+	});
+
 	it("routes create/get/complete operations and returns completion budget details", async () => {
 		const createGoalState: GoalModeState = {
 			enabled: true,
@@ -89,9 +122,8 @@ describe("GoalTool", () => {
 		const created = await tool.execute("call-create", {
 			op: "create",
 			objective: "  Create route  ",
-			token_budget: 10,
 		});
-		expect(runtime.createGoal).toHaveBeenCalledWith({ objective: "Create route", tokenBudget: 10 });
+		expect(runtime.createGoal).toHaveBeenCalledWith({ objective: "Create route" }, expect.any(Function));
 		expect(created.details).toMatchObject({
 			op: "create",
 			goal: createGoalState.goal,
@@ -99,7 +131,7 @@ describe("GoalTool", () => {
 			completionBudgetReport: null,
 		});
 
-		const fetched = await tool.execute("call-get", { op: "get", objective: undefined, token_budget: undefined });
+		const fetched = await tool.execute("call-get", { op: "get", objective: undefined });
 		expect(getGoalModeState).toHaveBeenCalledTimes(1);
 		expect(fetched.details).toMatchObject({
 			op: "get",
@@ -112,7 +144,6 @@ describe("GoalTool", () => {
 		const completed = await tool.execute("call-complete", {
 			op: "complete",
 			objective: undefined,
-			token_budget: undefined,
 		});
 		expect(runtime.completeGoalFromTool).toHaveBeenCalledTimes(1);
 		expect(completed.details).toMatchObject({
@@ -125,6 +156,98 @@ describe("GoalTool", () => {
 			type: "text",
 			text: "Goal: Complete route\nStatus: complete\nTokens: 7 used / 10 budget\nRemaining tokens: 3\n\nGoal achieved. Report final budget usage to the user: tokens used: 7 of 10; time used: 3 seconds.",
 		});
+	});
+
+	it("sets a new goal when no goal is active", async () => {
+		const harness = createRuntimeHarness();
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-set", {
+			op: "set",
+			objective: "  Set from tool  ",
+		});
+
+		expect(result.details).toMatchObject({
+			op: "set",
+			goal: { objective: "Set from tool", status: "active", tokenBudget: undefined },
+			remainingTokens: null,
+		});
+		expect(harness.getState()?.enabled).toBe(true);
+	});
+
+	it("serializes concurrent op=set calls through the runtime owner", async () => {
+		const harness = createRuntimeHarness();
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const [first, second] = await Promise.all([
+			tool.execute("call-set-first", { op: "set", objective: "First goal" }),
+			tool.execute("call-set-second", { op: "set", objective: "Second goal" }),
+		]);
+
+		expect(first.details?.goal?.objective).toBe("First goal");
+		expect(second.details?.goal?.objective).toBe("Second goal");
+		expect(harness.getState()?.goal.objective).toBe("Second goal");
+	});
+
+	it("replaces the active goal with op=set while preserving its operator budget", async () => {
+		const harness = createRuntimeHarness({
+			enabled: true,
+			mode: "active",
+			goal: createGoal({ objective: "Old goal", tokenBudget: 10 }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-set", {
+			op: "set",
+			objective: "New goal",
+		});
+
+		expect(result.details?.goal).toMatchObject({
+			objective: "New goal",
+			status: "active",
+			tokenBudget: 10,
+		});
+		expect(harness.getState()?.goal.objective).toBe("New goal");
+	});
+
+	it("replaces a paused goal with op=set while preserving its operator budget", async () => {
+		const harness = createRuntimeHarness({
+			enabled: false,
+			mode: "active",
+			goal: createGoal({ objective: "Paused", status: "paused", tokenBudget: 20 }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-set", { op: "set", objective: "New goal" });
+
+		expect(result.details?.goal).toMatchObject({
+			objective: "New goal",
+			status: "active",
+			tokenBudget: 20,
+		});
+		const state = harness.getState();
+		expect(state?.enabled).toBe(true);
+		expect(state?.goal.objective).toBe("New goal");
 	});
 
 	it("rejects create when a goal already exists", async () => {
@@ -140,9 +263,9 @@ describe("GoalTool", () => {
 			}),
 		);
 
-		await expect(
-			tool.execute("call-create", { op: "create", objective: "New goal", token_budget: 10 }),
-		).rejects.toThrow("cannot create a new goal because this session already has a goal");
+		await expect(tool.execute("call-create", { op: "create", objective: "New goal" })).rejects.toThrow(
+			"cannot create a new goal because this session already has a goal",
+		);
 	});
 
 	it("rejects complete when no goal is active", async () => {
@@ -154,9 +277,9 @@ describe("GoalTool", () => {
 			}),
 		);
 
-		await expect(
-			tool.execute("call-complete", { op: "complete", objective: undefined, token_budget: undefined }),
-		).rejects.toThrow("cannot complete goal because no goal is active");
+		await expect(tool.execute("call-complete", { op: "complete", objective: undefined })).rejects.toThrow(
+			"cannot complete goal because no goal is active",
+		);
 	});
 
 	it("rejects op=create when the objective is missing or only whitespace", async () => {
@@ -168,26 +291,8 @@ describe("GoalTool", () => {
 			}),
 		);
 
-		await expect(
-			tool.execute("call-empty", { op: "create", objective: "   \t\n", token_budget: undefined }),
-		).rejects.toThrow("objective is required when op=create");
-		expect(harness.getState()).toBeUndefined();
-	});
-
-	it("rejects op=create when the token_budget is zero or negative", async () => {
-		const harness = createRuntimeHarness();
-		const tool = new GoalTool(
-			createToolSession({
-				getGoalRuntime: () => harness.runtime,
-				getGoalModeState: () => harness.getState(),
-			}),
-		);
-
-		await expect(tool.execute("call-zero", { op: "create", objective: "Ship it", token_budget: 0 })).rejects.toThrow(
-			"token_budget must be a positive integer when provided",
-		);
-		await expect(tool.execute("call-neg", { op: "create", objective: "Ship it", token_budget: -5 })).rejects.toThrow(
-			"token_budget must be a positive integer when provided",
+		await expect(tool.execute("call-empty", { op: "create", objective: "   \t\n" })).rejects.toThrow(
+			"objective is required when op=create",
 		);
 		expect(harness.getState()).toBeUndefined();
 	});
@@ -205,7 +310,6 @@ describe("GoalTool", () => {
 		const result = await tool.execute("call-complete", {
 			op: "complete",
 			objective: undefined,
-			token_budget: undefined,
 		});
 
 		expect(result.details).toMatchObject({ op: "complete" });
@@ -232,7 +336,6 @@ describe("GoalTool", () => {
 		const result = await tool.execute("call-complete", {
 			op: "complete",
 			objective: undefined,
-			token_budget: undefined,
 		});
 		expect(result.details?.goal?.status).toBe("complete");
 		expect(harness.getState()?.goal.status).toBe("complete");
@@ -255,7 +358,6 @@ describe("GoalTool", () => {
 		const result = await tool.execute("call-create", {
 			op: "create",
 			objective: "Next goal",
-			token_budget: undefined,
 		});
 		expect(result.details?.goal?.objective).toBe("Next goal");
 		expect(result.details?.goal?.status).toBe("active");
@@ -274,7 +376,7 @@ describe("GoalTool", () => {
 			}),
 		);
 
-		const result = await tool.execute("call-get", { op: "get", objective: undefined, token_budget: undefined });
+		const result = await tool.execute("call-get", { op: "get", objective: undefined });
 		expect(result.details?.goal?.status).toBe("paused");
 		expect(result.details?.goal?.objective).toBe("Ship it");
 	});
@@ -292,7 +394,7 @@ describe("GoalTool", () => {
 			}),
 		);
 
-		const result = await tool.execute("call-resume", { op: "resume", objective: undefined, token_budget: undefined });
+		const result = await tool.execute("call-resume", { op: "resume", objective: undefined });
 		expect(result.details?.op).toBe("resume");
 		expect(result.details?.goal?.status).toBe("active");
 		expect(harness.getState()?.enabled).toBe(true);
@@ -311,9 +413,53 @@ describe("GoalTool", () => {
 			}),
 		);
 
-		const result = await tool.execute("call-drop", { op: "drop", objective: undefined, token_budget: undefined });
+		const result = await tool.execute("call-drop", { op: "drop", objective: undefined });
 		expect(result.details?.op).toBe("drop");
 		expect(result.details?.goal?.status).toBe("dropped");
 		expect(harness.getState()).toBeUndefined();
+	});
+
+	it("expands tabs in pending and completed objective renderings", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+		const options = { expanded: false, isPartial: false };
+		const call = Bun.stripANSI(
+			goalToolRenderer.renderCall({ op: "create", objective: "Ship\tit" }, options, theme!).render(120).join("\n"),
+		);
+		const rawResult = goalToolRenderer
+			.renderResult(
+				{
+					content: [],
+					details: { op: "get", goal: createGoal({ objective: "Ship\t\u001b]8;;https://example.com\u0007it" }) },
+				},
+				options,
+				theme!,
+			)
+			.render(120)
+			.join("\n");
+		const result = Bun.stripANSI(rawResult);
+
+		expect(call).not.toContain("\t");
+		expect(result).not.toContain("\t");
+		expect(result).not.toContain("\u001b");
+		expect(result).not.toContain("\u0007");
+		expect(result).not.toContain("https://example.com");
+		expect(call).toContain("Ship");
+		expect(result).toContain("Ship");
+	});
+
+	it("collapses multiline objectives before truncating the status preview", async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+		const objective = Array.from({ length: 80 }, (_, index) => `part-${index}`).join("\n");
+
+		const lines = goalToolRenderer
+			.renderCall({ op: "set", objective }, { expanded: false, isPartial: false }, theme!)
+			.render(120)
+			.map(Bun.stripANSI);
+
+		expect(lines).toHaveLength(1);
+		expect(lines[0]!.length).toBeLessThanOrEqual(120);
+		expect(lines[0]).toContain("part-0 part-1");
 	});
 });

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -106,6 +106,7 @@ describe("guided goal setup", () => {
 		const harness = await createHarness();
 		try {
 			const promptSpy = vi.spyOn(harness.session, "prompt").mockResolvedValue(true);
+			await harness.session.setActiveToolsByName(["read", "goal"]);
 
 			await harness.mode.handleGuidedGoalCommand("automate flaky test triage");
 
@@ -118,6 +119,10 @@ describe("guided goal setup", () => {
 			expect(text).toContain('op: "create"');
 			// The goal tool is activated up front so the agent can create the goal
 			// once the interview concludes.
+			expect(harness.session.getEnabledToolNames()).toContain("goal");
+			await harness.goalTool.execute("create", { op: "create", objective: "Automate triage" });
+			await harness.goalTool.execute("drop", { op: "drop", objective: undefined });
+			await Promise.resolve();
 			expect(harness.session.getEnabledToolNames()).toContain("goal");
 		} finally {
 			await harness.cleanup();
@@ -251,7 +256,7 @@ describe("guided goal setup", () => {
 		}
 	});
 
-	it("allows explicit goal tool activation without an active goal, but keeps it out of the default set", async () => {
+	it("allows explicit goal tool activation without an active goal and includes it in the default set", async () => {
 		const harness = await createHarness();
 		try {
 			const explicit = await createTools(createToolSession(harness.tempDir.path(), harness.settings), [
@@ -261,7 +266,7 @@ describe("guided goal setup", () => {
 			expect(explicit.map(tool => tool.name)).toContain("goal");
 
 			const defaults = await createTools(createToolSession(harness.tempDir.path(), harness.settings));
-			expect(defaults.map(tool => tool.name)).not.toContain("goal");
+			expect(defaults.map(tool => tool.name)).toContain("goal");
 		} finally {
 			await harness.cleanup();
 		}

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -129,6 +129,141 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		expect(session?.getActiveToolNames()).toContain("read");
 	});
 
+	it("publishes plan mode before rebuilding tools", async () => {
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }));
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const setActiveToolsByName = session!.setActiveToolsByName.bind(session!);
+		vi.spyOn(session!, "setActiveToolsByName").mockImplementation(async toolNames => {
+			started.resolve();
+			await release.promise;
+			await setActiveToolsByName(toolNames);
+		});
+
+		const entering = created.init({ suppressWelcomeIntro: true });
+		await started.promise;
+
+		expect(session?.getPlanModeState()).toMatchObject({ enabled: true, planFilePath: "local://PLAN.md" });
+
+		release.resolve();
+		await entering;
+	});
+
+	it("preserves a goal journal entry that races plan tool activation", async () => {
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }));
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const setActiveToolsByName = session!.setActiveToolsByName.bind(session!);
+		vi.spyOn(session!, "setActiveToolsByName").mockImplementation(async toolNames => {
+			started.resolve();
+			await release.promise;
+			await setActiveToolsByName(toolNames);
+		});
+		const appendModeChange = vi.spyOn(session!.sessionManager, "appendModeChange");
+
+		const entering = created.init({ suppressWelcomeIntro: true });
+		await started.promise;
+		await session!.goalRuntime.createGoal({ objective: "Ship the release", tokenBudget: 100 });
+		release.resolve();
+		await entering;
+
+		const modes = appendModeChange.mock.calls.map(([mode]) => mode);
+		expect(modes.at(-1)).toBe("goal");
+		expect(modes).not.toContain("none");
+		expect(created.planModeEnabled).toBe(false);
+	});
+
+	it("does not submit a plan prompt when a goal races tool activation", async () => {
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": false, "compaction.enabled": false }));
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const setActiveToolsByName = session!.setActiveToolsByName.bind(session!);
+		vi.spyOn(session!, "setActiveToolsByName").mockImplementation(async toolNames => {
+			started.resolve();
+			await release.promise;
+			await setActiveToolsByName(toolNames);
+		});
+		const submit = vi.fn();
+		created.onInputCallback = submit;
+
+		const entering = created.handlePlanModeCommand("draft the plan");
+		await started.promise;
+		await session!.goalRuntime.createGoal({ objective: "Ship the release", tokenBudget: 100 });
+		release.resolve();
+		await entering;
+
+		expect(created.planModeEnabled).toBe(false);
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it("publishes paused plan state before restoring normal tools", async () => {
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }));
+		await created.init({ suppressWelcomeIntro: true });
+		const setActiveToolsByName = session!.setActiveToolsByName.bind(session!);
+		let pausedDuringRestore = false;
+		let sessionPausedDuringRestore = false;
+		vi.spyOn(session!, "setActiveToolsByName").mockImplementation(async toolNames => {
+			pausedDuringRestore = created.planModePaused;
+			sessionPausedDuringRestore = session!.isPlanModePaused();
+			await setActiveToolsByName(toolNames);
+		});
+
+		await created.handlePlanModeCommand();
+
+		expect(pausedDuringRestore).toBe(true);
+		expect(sessionPausedDuringRestore).toBe(true);
+		expect(created.planModePaused).toBe(true);
+	});
+
+	it("restores paused plan state when a goal appears during re-entry", async () => {
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }));
+		await created.init({ suppressWelcomeIntro: true });
+		await created.handlePlanModeCommand();
+		expect(created.planModePaused).toBe(true);
+		expect(session!.isPlanModePaused()).toBe(true);
+		let reads = 0;
+		vi.spyOn(session!, "getGoalModeState").mockImplementation(() => {
+			reads += 1;
+			return reads === 1 ? undefined : ({ enabled: true } as never);
+		});
+
+		await created.handlePlanModeCommand("continue");
+
+		expect(created.planModePaused).toBe(true);
+		expect(session!.isPlanModePaused()).toBe(true);
+	});
+
+	it("rolls back plan mode when rebuilding tools fails", async () => {
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), {
+			rebuildGate: { fail: true },
+		});
+
+		await expect(created.init({ suppressWelcomeIntro: true })).rejects.toThrow("rebuild failed");
+
+		expect(created.planModeEnabled).toBe(false);
+		expect(created.planModePlanFilePath).toBeUndefined();
+		expect(session?.getPlanModeState()).toBeUndefined();
+	});
+
+	it("restores paused plan mode when re-entry tool rebuilding fails", async () => {
+		const rebuildGate = { fail: false };
+		const writeTool = makeTool("write");
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), {
+			rebuildGate,
+			extraRegistryTools: [writeTool],
+			builtInToolNames: ["read", "write"],
+		});
+		await created.init({ suppressWelcomeIntro: true });
+		await created.handlePlanModeCommand();
+		expect(created.planModePaused).toBe(true);
+		rebuildGate.fail = true;
+
+		await expect(created.handlePlanModeCommand("continue")).rejects.toThrow("rebuild failed");
+
+		expect(created.planModeEnabled).toBe(false);
+		expect(created.planModePaused).toBe(true);
+		expect(session?.getPlanModeState()).toBeUndefined();
+	});
 	it("activates write when entering plan mode even if it was hidden by discoveryMode (issue #3165)", async () => {
 		// `plan-mode-active.md` instructs the agent to draft the plan file with
 		// `write` and refine it with `edit`. Under `tools.discoveryMode === "all"`

--- a/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-vibe-toggle.test.ts
@@ -165,6 +165,63 @@ describe("InteractiveMode vibe mode toggle", () => {
 		expect(session.getAllToolNames().toSorted()).toEqual(["read", "todo"]);
 	});
 
+	it("publishes vibe mode before rebuilding tools", async () => {
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const activateVibeTools = session.activateVibeTools.bind(session);
+		vi.spyOn(session, "activateVibeTools").mockImplementation(async toolNames => {
+			started.resolve();
+			await release.promise;
+			await activateVibeTools(toolNames);
+		});
+
+		const entering = mode.handleVibeModeCommand();
+		await started.promise;
+
+		expect(session.getVibeModeState()).toEqual({ enabled: true });
+
+		release.resolve();
+		await entering;
+	});
+
+	it("does not submit a vibe prompt when a goal races tool activation", async () => {
+		const started = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const activateVibeTools = session.activateVibeTools.bind(session);
+		vi.spyOn(session, "activateVibeTools").mockImplementation(async toolNames => {
+			started.resolve();
+			await release.promise;
+			await activateVibeTools(toolNames);
+		});
+		const submit = vi.fn();
+		mode.onInputCallback = submit;
+
+		const entering = mode.handleVibeModeCommand("draft the implementation");
+		await started.promise;
+		await session.goalRuntime.createGoal({ objective: "Ship the release", tokenBudget: 100 });
+		release.resolve();
+		await entering;
+
+		expect(mode.vibeModeEnabled).toBe(false);
+		const lastMode = session.sessionManager
+			.getEntries()
+			.filter(entry => entry.type === "mode_change")
+			.at(-1);
+		expect(lastMode).toMatchObject({ type: "mode_change", mode: "goal" });
+		expect(submit).not.toHaveBeenCalled();
+	});
+
+	it("rolls back vibe mode when rebuilding tools fails", async () => {
+		vi.spyOn(session, "activateVibeTools").mockRejectedValue(new Error("vibe tool rebuild failed"));
+		const deactivate = vi.spyOn(session, "deactivateVibeTools");
+
+		await expect(mode.handleVibeModeCommand()).rejects.toThrow("vibe tool rebuild failed");
+
+		expect(mode.vibeModeEnabled).toBe(false);
+		expect(session.getVibeModeState()).toBeUndefined();
+		expect(deactivate).toHaveBeenCalledTimes(1);
+	});
+
 	it("keeps a same-named non-built-in Todo tool unavailable in Vibe mode", async () => {
 		const model = session.model;
 		if (!model) throw new Error("Expected active model");

--- a/packages/coding-agent/test/print-mode-working-indicator.test.ts
+++ b/packages/coding-agent/test/print-mode-working-indicator.test.ts
@@ -39,13 +39,14 @@ interface DelayedSession {
 	getModeChanges: () => Array<{ mode: string; data?: Record<string, unknown> }>;
 	getPlanProposalHandler: () => PlanProposalHandler | undefined;
 	getCurrentPlanMode: () => PlanModeState | undefined;
+	getEnabledToolNames: () => string[];
 	emit: (event: AgentSessionEvent) => void;
 	getAbortCalls: () => number;
 }
 
 function createDelayedSession(
 	finalMessage: AssistantMessage,
-	options: { defaultPlanMode?: boolean } = {},
+	options: { defaultPlanMode?: boolean; enabledTools?: string[]; builtInTools?: string[] } = {},
 ): DelayedSession {
 	const messages: AssistantMessage[] = [];
 	const { promise: promptStarted, resolve: markPromptStarted } = Promise.withResolvers<void>();
@@ -53,7 +54,7 @@ function createDelayedSession(
 	let advisorDrainPrepared = false;
 	let planModeState: PlanModeState | undefined;
 	let planModeAtPrompt: PlanModeState | undefined;
-	let enabledToolNames = ["read"];
+	let enabledToolNames = options.enabledTools ?? ["read"];
 	const modeChanges: Array<{ mode: string; data?: Record<string, unknown> }> = [];
 	let planProposalHandler: PlanProposalHandler | undefined;
 	let subscriber: ((event: AgentSessionEvent) => void) | undefined;
@@ -79,7 +80,7 @@ function createDelayedSession(
 		isStreaming: false,
 		getPlanReferencePath: () => "",
 		getEnabledToolNames: () => enabledToolNames,
-		hasBuiltInTool: (name: string) => name === "write",
+		hasBuiltInTool: (name: string) => (options.builtInTools ?? ["write"]).includes(name),
 		setActiveToolsByName: async (names: string[]) => {
 			enabledToolNames = names;
 		},
@@ -134,6 +135,7 @@ function createDelayedSession(
 		getModeChanges: () => modeChanges,
 		getPlanProposalHandler: () => planProposalHandler,
 		getCurrentPlanMode: () => planModeState,
+		getEnabledToolNames: () => enabledToolNames,
 		emit: event => subscriber?.(event),
 		getAbortCalls: () => abortCalls,
 	};
@@ -212,6 +214,23 @@ describe("print mode working indicator", () => {
 			});
 			await Promise.resolve();
 			expect(delayed.getAbortCalls()).toBe(1);
+		} finally {
+			delayed.resolvePrompt();
+			await run;
+		}
+	});
+
+	it("removes the built-in goal tool from default print plan mode", async () => {
+		const delayed = createDelayedSession(makeAssistantMessage("plan ready"), {
+			defaultPlanMode: true,
+			enabledTools: ["read", "goal"],
+			builtInTools: ["write", "goal"],
+		});
+		const run = runPrintMode(delayed.session, { mode: "text", initialMessage: "/plan hello" });
+
+		await delayed.promptStarted;
+		try {
+			expect(delayed.getEnabledToolNames()).toEqual(["read", "write"]);
 		} finally {
 			delayed.resolvePrompt();
 			await run;

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -7,9 +7,11 @@ import type { Model, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
-import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CursorExecHandlers } from "@oh-my-pi/pi-coding-agent/cursor";
 import type { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import {
 	type CreateAgentSessionOptions,
 	type CustomTool,
@@ -54,6 +56,19 @@ const sdkCustomTool = {
 		return { content: [{ type: "text", text: "sdk custom" }] };
 	},
 } satisfies CustomTool;
+
+const shadowGoalExtension: ExtensionFactory = pi => {
+	pi.registerTool({
+		name: "goal",
+		label: "Shadow Goal",
+		description: "Extension tool sharing the built-in goal tool name.",
+		parameters: type({}),
+		defaultInactive: true,
+		async execute() {
+			return { content: [{ type: "text", text: "shadow goal" }] };
+		},
+	});
+};
 
 describe("createAgentSession defaultInactive tool activation", () => {
 	const tempDirs: string[] = [];
@@ -216,6 +231,127 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			expect(session.getActiveToolNames()).toContain("yield");
 		} finally {
 			await session.dispose();
+		}
+	});
+
+	it("keeps the goal tool active before a goal exists", async () => {
+		const tempDir = makeTempDir();
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+		});
+
+		try {
+			expect(session.getActiveToolNames()).toContain("goal");
+			const goalTool = session.agent.state.tools.find(tool => tool.name === "goal");
+			expect(goalTool).toBeDefined();
+
+			await goalTool!.execute("goal-set", {
+				op: "set",
+				objective: "Ship the goal tool availability fix.",
+			});
+
+			expect(session.getGoalModeState()?.enabled).toBe(true);
+			expect(session.getGoalModeState()?.goal.objective).toBe("Ship the goal tool availability fix.");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("blocks goal starts while the real SDK session has an incompatible mode", async () => {
+		const tempDir = makeTempDir();
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+		});
+
+		try {
+			session.setPlanModePaused(true);
+			const goalTool = session.agent.state.tools.find(tool => tool.name === "goal");
+			expect(goalTool).toBeDefined();
+
+			for (const op of ["create", "set", "resume"] as const) {
+				await expect(
+					goalTool!.execute(`goal-${op}`, {
+						op,
+						objective: "Must not start during a paused plan.",
+					}),
+				).rejects.toThrow(/plan mode/i);
+			}
+
+			session.setPlanModePaused(false);
+			session.setVibeModeState({ enabled: true });
+			for (const op of ["create", "set", "resume"] as const) {
+				await expect(
+					goalTool!.execute(`goal-vibe-${op}`, {
+						op,
+						objective: "Must not start during vibe mode.",
+					}),
+				).rejects.toThrow(/vibe mode/i);
+			}
+			expect(session.getGoalModeState()).toBeUndefined();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("force-includes the goal tool into explicit toolNames lists", async () => {
+		const tempDir = makeTempDir();
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			toolNames: ["read"],
+		});
+
+		try {
+			expect(session.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "goal"]));
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("does not force-activate a defaultInactive extension tool shadowing goal", async () => {
+		const tempDir = makeTempDir();
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [shadowGoalExtension],
+			toolNames: ["read"],
+		});
+
+		try {
+			expect(session.getAllToolNames()).toContain("goal");
+			expect(session.getActiveToolNames()).toContain("read");
+			expect(session.getActiveToolNames()).not.toContain("goal");
+			expect(session.systemPrompt.join("\n")).not.toContain("shadow goal");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("preserves an active extension tool shadowing goal in plan mode", async () => {
+		const tempDir = makeTempDir();
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			extensions: [shadowGoalExtension],
+			toolNames: ["read", "goal"],
+		});
+		await Settings.init({ inMemory: true, cwd: tempDir });
+		initTheme();
+		const mode = new InteractiveMode(session, "test");
+
+		try {
+			expect(session.hasBuiltInTool("goal")).toBe(false);
+			expect(session.getActiveToolNames()).toContain("goal");
+
+			await mode.handlePlanModeCommand();
+
+			expect(mode.planModeEnabled).toBe(true);
+			expect(session.getActiveToolNames()).toContain("goal");
+		} finally {
+			mode.stop();
+			await session.dispose();
+			resetSettingsForTest();
 		}
 	});
 

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -64,6 +64,7 @@ describe("createTools", () => {
 		expect(names).toContain("task");
 		expect(names).toContain("todo");
 		expect(names).toContain("web_search");
+		expect(names).toContain("goal");
 		expect(names).not.toContain("fetch");
 		expect(names).not.toContain("vim");
 	});
@@ -129,7 +130,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["read", "lsp", "write"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "write"]);
+		expect(names).toEqual(["read", "write", "goal"]);
 	});
 
 	it("excludes lsp tool when disabled", async () => {
@@ -145,7 +146,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["read", "write"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "write"]);
+		expect(names).toEqual(["read", "write", "goal"]);
 	});
 
 	it("creates xd:// presentation state without remounting explicitly requested built-ins", async () => {
@@ -154,7 +155,7 @@ describe("createTools", () => {
 
 		expect(session.xdev).toBeDefined();
 		expect(session.xdev?.mountedNames.size).toBe(0);
-		expect(tools.map(tool => tool.name)).toEqual(["read", "lsp", "write"]);
+		expect(tools.map(tool => tool.name)).toEqual(["read", "lsp", "write", "goal"]);
 	});
 
 	it("skips xd:// state entirely when the session grants no write tool", async () => {
@@ -165,7 +166,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["read", "lsp"]);
 
 		expect(session.xdev).toBeUndefined();
-		expect(tools.map(tool => tool.name)).toEqual(["read", "lsp"]);
+		expect(tools.map(tool => tool.name)).toEqual(["read", "lsp", "goal"]);
 	});
 
 	it("lowercases requested tool subset", async () => {
@@ -173,7 +174,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["Read", "Write"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["read", "write"]);
+		expect(names).toEqual(["read", "write", "goal"]);
 	});
 
 	it("includes hidden tools when explicitly requested", async () => {
@@ -181,7 +182,7 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["yield"]);
 		const names = tools.map(t => t.name);
 
-		expect(names).toEqual(["yield"]);
+		expect(names).toEqual(["yield", "goal"]);
 	});
 
 	it("includes yield tool when required", async () => {
@@ -233,7 +234,7 @@ describe("createTools", () => {
 			}),
 			["ask", "read"],
 		);
-		expect(requested.map(t => t.name)).toEqual(["read"]);
+		expect(requested.map(t => t.name)).toEqual(["read", "goal"]);
 	});
 
 	it("includes ask tool when ask.enabled is true and hasUI is true", async () => {
@@ -273,7 +274,7 @@ describe("createTools", () => {
 		expect(names).not.toContain("inspect_image");
 
 		const requestedTools = await createTools(createTestSession({ settings: session.settings }), ["bash", "read"]);
-		expect(requestedTools.map(t => t.name)).toEqual(["read"]);
+		expect(requestedTools.map(t => t.name)).toEqual(["read", "goal"]);
 	});
 
 	it("auto-includes goal when goal mode is active", async () => {
@@ -301,6 +302,13 @@ describe("createTools", () => {
 		const tools = await createTools(session, ["read", "write"]);
 
 		expect(tools.map(tool => tool.name)).toEqual(["read", "write"]);
+	});
+
+	it("does not force-add goal to an explicit no-tools session", async () => {
+		const session = createTestSession({ settings: createSettingsWithOverrides({ "goal.enabled": true }) });
+		const tools = await createTools(session, ["__none__"]);
+
+		expect(tools.map(t => t.name)).not.toContain("goal");
 	});
 
 	it("records active tools on the original session object", async () => {


### PR DESCRIPTION
Goal mode depends on the goal tool for every lifecycle transition, yet ordinary sessions hid that tool until a goal was already active. Restricted SDK sessions could also receive goal guidance while their active tool set excluded the built-in tool.

Expose the built-in goal tool whenever goal support is enabled. Add the model-facing set operation for creating or replacing goals, preserve the caller's active tool set through goal transitions, and keep shadowing extension tools inactive unless the caller requested them. Remove the model-set token budget because goal budgets remain operator policy through the existing CLI and runtime controls.

Update the goal runtime, prompts, SDK activation, interactive modes, gallery fixture, and lifecycle coverage for new, paused, completed, restricted-tool, and shadowed-extension sessions.