### PR TITLE
feat(auth): add Codex home credential chains

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -78,6 +78,15 @@ export type AuthCredentialEntry = AuthCredential | AuthCredential[];
 
 export type AuthStorageData = Record<string, AuthCredentialEntry>;
 
+export interface RuntimeApiKeyChainCredential {
+	key: string;
+	label?: string;
+	accountId?: string;
+	email?: string;
+	projectId?: string;
+	usageType?: UsageCredential["type"];
+}
+
 /**
  * Cascade leg that supplies a provider's active credential, highest precedence
  * first — mirrors {@link AuthStorage.getApiKey}'s resolution order.
@@ -957,6 +966,8 @@ export class AuthStorage {
 	/** Provider -> credentials cache, populated from store on reload(). */
 	#data: Map<string, StoredCredential[]> = new Map();
 	#runtimeOverrides: Map<string, string> = new Map();
+	#runtimeApiKeyChains: Map<string, RuntimeApiKeyChainCredential[]> = new Map();
+	#runtimeChainSessionLastCredential: Map<string, Map<string, number>> = new Map();
 	#configOverrides: Map<string, string> = new Map();
 	/** Tracks next credential index per provider:type key for round-robin distribution (non-session use). */
 	#providerRoundRobinIndex: Map<string, number> = new Map();
@@ -1127,6 +1138,25 @@ export class AuthStorage {
 		this.#runtimeOverrides.delete(provider);
 	}
 
+	setRuntimeApiKeyChain(provider: string, credentials: RuntimeApiKeyChainCredential[]): void {
+		const usable = credentials
+			.map(credential => ({ ...credential, key: credential.key.trim() }))
+			.filter(credential => credential.key.length > 0);
+		if (usable.length === 0) {
+			this.removeRuntimeApiKeyChain(provider);
+			return;
+		}
+		this.#runtimeApiKeyChains.set(provider, usable);
+		this.#runtimeChainSessionLastCredential.delete(provider);
+		this.#clearRuntimeApiKeyChainBackoff(provider);
+	}
+
+	removeRuntimeApiKeyChain(provider: string): void {
+		this.#runtimeApiKeyChains.delete(provider);
+		this.#runtimeChainSessionLastCredential.delete(provider);
+		this.#clearRuntimeApiKeyChainBackoff(provider);
+	}
+
 	/**
 	 * Register a per-provider API key sourced from user configuration
 	 * (e.g. `models.yml` `providers.<name>.apiKey`). Higher priority than
@@ -1287,6 +1317,20 @@ export class AuthStorage {
 	/** Composite key for round-robin tracking: "anthropic:oauth" or "openai:api_key" */
 	#getProviderTypeKey(provider: string, type: AuthCredential["type"]): string {
 		return `${provider}:${type}`;
+	}
+
+	#getRuntimeApiKeyChainProviderKey(provider: string): string {
+		return `${provider}:runtime_chain`;
+	}
+
+	#clearRuntimeApiKeyChainBackoff(provider: string): void {
+		const providerKey = this.#getRuntimeApiKeyChainProviderKey(provider);
+		const scopedPrefix = `${providerKey}\0`;
+		for (const key of this.#credentialBackoff.keys()) {
+			if (key === providerKey || key.startsWith(scopedPrefix)) {
+				this.#credentialBackoff.delete(key);
+			}
+		}
 	}
 
 	/**
@@ -1542,6 +1586,28 @@ export class AuthStorage {
 			this.#store.setCache(cacheKey, "", 0);
 		} catch (err) {
 			logger.debug("Failed to clear session sticky credential from persistent store cache", { err });
+		}
+	}
+
+	#recordRuntimeApiKeyChainSessionCredential(provider: string, sessionId: string | undefined, index: number): void {
+		if (!sessionId) return;
+		const sessionMap = this.#runtimeChainSessionLastCredential.get(provider) ?? new Map<string, number>();
+		sessionMap.set(sessionId, index);
+		this.#runtimeChainSessionLastCredential.set(provider, sessionMap);
+	}
+
+	#getRuntimeApiKeyChainSessionCredential(provider: string, sessionId: string | undefined): number | undefined {
+		if (!sessionId) return undefined;
+		return this.#runtimeChainSessionLastCredential.get(provider)?.get(sessionId);
+	}
+
+	#clearRuntimeApiKeyChainSessionCredential(provider: string, sessionId: string | undefined): void {
+		if (!sessionId) return;
+		const sessionMap = this.#runtimeChainSessionLastCredential.get(provider);
+		if (!sessionMap) return;
+		sessionMap.delete(sessionId);
+		if (sessionMap.size === 0) {
+			this.#runtimeChainSessionLastCredential.delete(provider);
 		}
 	}
 
@@ -1822,6 +1888,7 @@ export class AuthStorage {
 	 */
 	hasAuth(provider: string): boolean {
 		if (this.#runtimeOverrides.has(provider)) return true;
+		if ((this.#runtimeApiKeyChains.get(provider)?.length ?? 0) > 0) return true;
 		if (this.#configOverrides.has(provider)) return true;
 		if (this.#getCredentialsForProvider(provider).length > 0) return true;
 		if (getEnvApiKey(provider)) return true;
@@ -1842,6 +1909,7 @@ export class AuthStorage {
 	 */
 	hasNonEnvCredential(provider: string): boolean {
 		if (this.#runtimeOverrides.has(provider)) return true;
+		if ((this.#runtimeApiKeyChains.get(provider)?.length ?? 0) > 0) return true;
 		if (this.#configOverrides.has(provider)) return true;
 		if (this.#getCredentialsForProvider(provider).length > 0) return true;
 		if (this.#fallbackResolver?.(provider)) return true;
@@ -1858,6 +1926,7 @@ export class AuthStorage {
 	 */
 	getCredentialOrigin(provider: string): CredentialOrigin | undefined {
 		if (this.#runtimeOverrides.has(provider)) return { kind: "runtime" };
+		if ((this.#runtimeApiKeyChains.get(provider)?.length ?? 0) > 0) return { kind: "runtime" };
 		if (this.#configOverrides.has(provider)) return { kind: "config" };
 		const stored = this.#getCredentialsForProvider(provider);
 		if (stored.some(credential => credential.type === "oauth")) return { kind: "oauth" };
@@ -1871,6 +1940,7 @@ export class AuthStorage {
 	 * Check if OAuth credentials are configured for a provider.
 	 */
 	hasOAuth(provider: string): boolean {
+		if (this.#runtimeApiKeyChains.get(provider)?.some(credential => credential.usageType === "oauth")) return true;
 		return this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth");
 	}
 
@@ -1921,6 +1991,9 @@ export class AuthStorage {
 	 * Returns `undefined` when no OAuth credential carries an `accountId`.
 	 */
 	getOAuthAccountId(provider: string, sessionId?: string): string | undefined {
+		const runtimeIndex = this.#getRuntimeApiKeyChainSessionCredential(provider, sessionId) ?? 0;
+		const runtimeCredential = this.#runtimeApiKeyChains.get(provider)?.[runtimeIndex];
+		if (runtimeCredential?.usageType === "oauth" && runtimeCredential.accountId) return runtimeCredential.accountId;
 		const preferred = this.#resolveActiveOAuthCredential(provider, sessionId);
 		const accountId = preferred?.accountId;
 		return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
@@ -1932,6 +2005,15 @@ export class AuthStorage {
 	 * metadata paths; it does not refresh tokens, rank usage, or advance selection.
 	 */
 	getOAuthAccountIdentity(provider: string, sessionId?: string): OAuthAccountIdentity | undefined {
+		const runtimeIndex = this.#getRuntimeApiKeyChainSessionCredential(provider, sessionId) ?? 0;
+		const runtimeCredential = this.#runtimeApiKeyChains.get(provider)?.[runtimeIndex];
+		if (runtimeCredential?.usageType === "oauth") {
+			const identity: OAuthAccountIdentity = {};
+			if (runtimeCredential.accountId) identity.accountId = runtimeCredential.accountId;
+			if (runtimeCredential.email) identity.email = runtimeCredential.email;
+			if (runtimeCredential.projectId) identity.projectId = runtimeCredential.projectId;
+			if (identity.accountId || identity.email || identity.projectId) return identity;
+		}
 		const preferred = this.#resolveActiveOAuthCredential(provider, sessionId);
 		if (!preferred) return undefined;
 		const identity: OAuthAccountIdentity = {};
@@ -2109,6 +2191,33 @@ export class AuthStorage {
 		baseUrl?: string,
 	): UsageRequestDescriptor {
 		return this.#buildUsageRequest(provider, this.#buildUsageCredential(credential), baseUrl);
+	}
+
+	#buildUsageCredentialForRuntimeApiKey(credential: RuntimeApiKeyChainCredential): UsageCredential {
+		if (credential.usageType === "oauth") {
+			return {
+				type: "oauth",
+				accessToken: credential.key,
+				accountId: credential.accountId,
+				email: credential.email,
+				projectId: credential.projectId,
+			};
+		}
+		return {
+			type: "api_key",
+			apiKey: credential.key,
+			accountId: credential.accountId,
+			email: credential.email,
+			projectId: credential.projectId,
+		};
+	}
+
+	#buildUsageRequestForRuntimeApiKey(
+		provider: Provider,
+		credential: RuntimeApiKeyChainCredential,
+		baseUrl?: string,
+	): UsageRequestDescriptor {
+		return this.#buildUsageRequest(provider, this.#buildUsageCredentialForRuntimeApiKey(credential), baseUrl);
 	}
 
 	#buildRefreshableOauthCredential(credential: UsageCredential): OAuthCredential | null {
@@ -2448,6 +2557,11 @@ export class AuthStorage {
 	}
 
 	#resolveObservedUsageCredential(provider: Provider, sessionId?: string): UsageCredential | undefined {
+		const runtimeChain = this.#runtimeApiKeyChains.get(provider);
+		const runtimeIndex = this.#getRuntimeApiKeyChainSessionCredential(provider, sessionId);
+		if (runtimeChain && runtimeIndex !== undefined && runtimeChain[runtimeIndex]) {
+			return this.#buildUsageCredentialForRuntimeApiKey(runtimeChain[runtimeIndex]);
+		}
 		const entries = this.#getStoredCredentials(provider);
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		if (sessionCredential) {
@@ -2563,6 +2677,15 @@ export class AuthStorage {
 			}
 
 			if (entries.length === 0) {
+				const runtimeChain = this.#runtimeApiKeyChains.get(providerId);
+				if (runtimeChain && runtimeChain.length > 0) {
+					for (const credential of runtimeChain) {
+						const request = this.#buildUsageRequestForRuntimeApiKey(provider, credential, baseUrl);
+						if (providerImpl.supports && !providerImpl.supports(request)) continue;
+						requests.push(request);
+					}
+					continue;
+				}
 				const runtimeKey = this.#runtimeOverrides.get(providerId);
 				const envKey = getEnvApiKey(providerId);
 				const apiKey = runtimeKey ?? envKey;
@@ -2765,6 +2888,17 @@ export class AuthStorage {
 		}
 		return this.#fetchUsageCached(
 			this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
+			options?.timeoutMs ?? this.#usageRequestTimeoutMs,
+		);
+	}
+
+	async #getUsageReportForRuntimeApiKey(
+		provider: Provider,
+		credential: RuntimeApiKeyChainCredential,
+		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal },
+	): Promise<UsageReport | null> {
+		return this.#fetchUsageCached(
+			this.#buildUsageRequestForRuntimeApiKey(provider, credential, options?.baseUrl),
 			options?.timeoutMs ?? this.#usageRequestTimeoutMs,
 		);
 	}
@@ -3059,6 +3193,9 @@ export class AuthStorage {
 		sessionId: string | undefined,
 		options?: { retryAfterMs?: number; baseUrl?: string; modelId?: string; signal?: AbortSignal },
 	): Promise<UsageLimitMarkResult> {
+		const runtimeMark = await this.#markRuntimeApiKeyChainUsageLimitReached(provider as Provider, sessionId, options);
+		if (runtimeMark) return runtimeMark;
+
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		if (!sessionCredential) return { switched: false };
 
@@ -3356,6 +3493,116 @@ export class AuthStorage {
 			});
 		}
 		return this.#orderRankedOAuthCandidates(ranked, args.sessionId, args.provider, args.options?.modelId);
+	}
+
+	async #resolveRuntimeApiKeyChain(
+		provider: Provider,
+		sessionId: string | undefined,
+		options?: AuthApiKeyOptions,
+	): Promise<string | undefined> {
+		const credentials = this.#runtimeApiKeyChains.get(provider);
+		if (!credentials || credentials.length === 0) return undefined;
+
+		const providerKey = this.#getRuntimeApiKeyChainProviderKey(provider);
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const blockScope = strategy?.blockScope?.(rankingContext);
+		const requiresProModel = requiresOpenAICodexProModel(provider, options?.modelId);
+		const checkUsage = strategy !== undefined && (credentials.length > 1 || requiresProModel);
+		const sessionPreferredIndex = this.#getRuntimeApiKeyChainSessionCredential(provider, sessionId);
+		if (
+			sessionPreferredIndex !== undefined &&
+			credentials[sessionPreferredIndex] &&
+			!this.#isCredentialBlocked(provider, providerKey, sessionPreferredIndex, blockScope) &&
+			!requiresProModel
+		) {
+			return credentials[sessionPreferredIndex].key;
+		}
+
+		let fallbackIndex = 0;
+		let fallbackBlockedUntil: number | undefined;
+		for (let index = 0; index < credentials.length; index += 1) {
+			const blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, index, blockScope);
+			if (
+				index === 0 ||
+				(blockedUntil !== undefined && (fallbackBlockedUntil === undefined || blockedUntil < fallbackBlockedUntil))
+			) {
+				fallbackIndex = index;
+				fallbackBlockedUntil = blockedUntil;
+			}
+			if (blockedUntil !== undefined) continue;
+
+			const credential = credentials[index]!;
+			if (checkUsage && strategy) {
+				const usage = await this.#getUsageReportForRuntimeApiKey(provider, credential, {
+					...options,
+					timeoutMs: this.#usageRequestTimeoutMs,
+				});
+				if (requiresProModel && !hasOpenAICodexProPlan(usage)) continue;
+				if (usage) {
+					const scopedLimits = this.#getScopedUsageLimits(strategy, usage, rankingContext);
+					if (this.#isUsageLimitReached(scopedLimits)) {
+						const resetAtMs = this.#getUsageResetAtMs(scopedLimits, Date.now());
+						this.#markCredentialBlocked(
+							provider,
+							providerKey,
+							index,
+							resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs,
+							blockScope,
+						);
+						continue;
+					}
+				}
+			}
+
+			this.#recordRuntimeApiKeyChainSessionCredential(provider, sessionId, index);
+			return credential.key;
+		}
+
+		const fallback = credentials[fallbackIndex];
+		if (!fallback) return undefined;
+		this.#recordRuntimeApiKeyChainSessionCredential(provider, sessionId, fallbackIndex);
+		return fallback.key;
+	}
+
+	async #markRuntimeApiKeyChainUsageLimitReached(
+		provider: Provider,
+		sessionId: string | undefined,
+		options?: { retryAfterMs?: number; baseUrl?: string; modelId?: string; signal?: AbortSignal },
+	): Promise<UsageLimitMarkResult | undefined> {
+		const credentials = this.#runtimeApiKeyChains.get(provider);
+		const index = this.#getRuntimeApiKeyChainSessionCredential(provider, sessionId);
+		if (!credentials || index === undefined || !credentials[index]) return undefined;
+
+		const providerKey = this.#getRuntimeApiKeyChainProviderKey(provider);
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const blockScope = strategy?.blockScope?.(rankingContext);
+		const now = Date.now();
+		let blockedUntil = now + (options?.retryAfterMs ?? AuthStorage.#defaultBackoffMs);
+		if (strategy) {
+			const report = await this.#getUsageReportForRuntimeApiKey(provider, credentials[index], options);
+			if (report) {
+				const scopedLimits = this.#getScopedUsageLimits(strategy, report, rankingContext);
+				if (this.#isUsageLimitReached(scopedLimits)) {
+					const resetAtMs = this.#getUsageResetAtMs(scopedLimits, now);
+					if (resetAtMs && resetAtMs > blockedUntil) {
+						blockedUntil = resetAtMs;
+					}
+				}
+			}
+		}
+		this.#markCredentialBlocked(provider, providerKey, index, blockedUntil, blockScope);
+		this.#clearRuntimeApiKeyChainSessionCredential(provider, sessionId);
+
+		let retryAtMs: number | undefined;
+		for (let candidateIndex = 0; candidateIndex < credentials.length; candidateIndex += 1) {
+			if (candidateIndex === index) continue;
+			const candidateBlockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, candidateIndex, blockScope);
+			if (candidateBlockedUntil === undefined) return { switched: true };
+			if (retryAtMs === undefined || candidateBlockedUntil < retryAtMs) retryAtMs = candidateBlockedUntil;
+		}
+		return { switched: false, retryAtMs };
 	}
 
 	/**
@@ -3894,6 +4141,11 @@ export class AuthStorage {
 			return runtimeKey;
 		}
 
+		const runtimeChain = this.#runtimeApiKeyChains.get(provider);
+		if (runtimeChain?.[0]) {
+			return runtimeChain[0].key;
+		}
+
 		const configKey = this.#configOverrides.get(provider);
 		if (configKey) {
 			return configKey;
@@ -3942,6 +4194,11 @@ export class AuthStorage {
 		const runtimeKey = this.#runtimeOverrides.get(provider);
 		if (runtimeKey) {
 			return runtimeKey;
+		}
+
+		const runtimeChainKey = await this.#resolveRuntimeApiKeyChain(provider as Provider, sessionId, options);
+		if (runtimeChainKey) {
+			return runtimeChainKey;
 		}
 
 		// Config override: explicit apiKey pinned in models.yml beats the broker's
@@ -4383,12 +4640,34 @@ export class AuthStorage {
 		sessionId: string | undefined,
 		options?: { error?: unknown; modelId?: string; signal?: AbortSignal },
 	): Promise<boolean> {
-		const sessionCredential = this.#getSessionCredential(provider, sessionId);
-		if (!sessionCredential) return false;
-
 		const error = options?.error;
 		const status = AIError.status(error);
 		const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
+		const runtimeIndex = this.#getRuntimeApiKeyChainSessionCredential(provider, sessionId);
+		const runtimeChain = this.#runtimeApiKeyChains.get(provider);
+		if (runtimeChain && runtimeIndex !== undefined && runtimeChain[runtimeIndex]) {
+			if (isUsageLimitOutcome(status, message)) {
+				return (
+					(
+						await this.#markRuntimeApiKeyChainUsageLimitReached(provider as Provider, sessionId, {
+							modelId: options?.modelId,
+							signal: options?.signal,
+						})
+					)?.switched === true
+				);
+			}
+			const providerKey = this.#getRuntimeApiKeyChainProviderKey(provider);
+			const hasSibling = runtimeChain.some(
+				(_credential, index) => index !== runtimeIndex && !this.#isCredentialBlocked(provider, providerKey, index),
+			);
+			this.#clearRuntimeApiKeyChainSessionCredential(provider, sessionId);
+			this.#markCredentialBlocked(provider, providerKey, runtimeIndex, Date.now() + AuthStorage.#defaultBackoffMs);
+			return hasSibling;
+		}
+
+		const sessionCredential = this.#getSessionCredential(provider, sessionId);
+		if (!sessionCredential) return false;
+
 		if (isUsageLimitOutcome(status, message)) {
 			return (
 				await this.markUsageLimitReached(provider, sessionId, {
@@ -4683,6 +4962,13 @@ export class AuthStorage {
 	describeCredentialSource(provider: string, sessionId?: string): string | undefined {
 		if (this.#runtimeOverrides.has(provider)) {
 			return "runtime override (--api-key)";
+		}
+		const runtimeChain = this.#runtimeApiKeyChains.get(provider);
+		if (runtimeChain && runtimeChain.length > 0) {
+			const index = this.#getRuntimeApiKeyChainSessionCredential(provider, sessionId) ?? 0;
+			const credential = runtimeChain[index] ?? runtimeChain[0];
+			const identity = credential.label ?? credential.email ?? credential.accountId ?? `entry ${index + 1}`;
+			return `runtime credential chain (${identity})`;
 		}
 		if (this.#configOverrides.has(provider)) {
 			return "config override (models.yml)";

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -23,11 +23,14 @@ export interface Args {
 	allowHome?: boolean;
 	provider?: string;
 	model?: string;
+	codexHome?: string;
+	codexHomeChain?: string;
 	config?: string[];
 	smol?: string;
 	slow?: string;
 	plan?: string;
 	maxTime?: number;
+
 	apiKey?: string;
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
@@ -311,6 +314,7 @@ export function getExtraHelpText(): string {
   CLAUDE_CODE_CLIENT_KEY     - Client private key (PEM path or inline PEM) for mTLS
   NODE_EXTRA_CA_CERTS        - CA bundle path (or inline PEM) for server certificate validation
   OPENAI_API_KEY             - OpenAI GPT models
+  CODEX_HOME                 - Codex home whose auth.json can seed OpenAI Codex OAuth auth
   GEMINI_API_KEY             - Google Gemini models
   COPILOT_GITHUB_TOKEN      - GitHub Copilot
 

--- a/packages/coding-agent/src/cli/codex-home.ts
+++ b/packages/coding-agent/src/cli/codex-home.ts
@@ -1,0 +1,171 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export const CODEX_HOME_ENV = "CODEX_HOME";
+export const OPENAI_CODEX_OAUTH_TOKEN_ENV = "OPENAI_CODEX_OAUTH_TOKEN";
+
+export interface CodexHomeSpec {
+	name?: string;
+	path: string;
+}
+
+export interface CodexHomeCredential extends CodexHomeSpec {
+	authPath: string;
+	accessToken: string;
+	refreshToken?: string;
+	accountId?: string;
+	email?: string;
+}
+
+export interface CodexHomeAuthResult {
+	applied: boolean;
+	codexHome?: string;
+	authPath?: string;
+	accessToken?: string;
+	credentials: CodexHomeCredential[];
+	reason?: "codex-home-unset" | "auth-file-unreadable" | "access-token-missing";
+}
+
+export interface ApplyCodexHomeAuthChainOptions {
+	codexHomeFlag?: string;
+	codexHomeChainFlag?: string;
+	configuredHomes?: unknown;
+}
+
+function expandHome(input: string): string {
+	if (input === "~") return os.homedir();
+	if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
+	return input;
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function parseCodexHomeString(value: string): CodexHomeSpec | undefined {
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	const separator = trimmed.indexOf("=");
+	if (separator > 0) {
+		const name = trimmed.slice(0, separator).trim();
+		const homePath = trimmed.slice(separator + 1).trim();
+		if (!homePath) return undefined;
+		return { name: name || undefined, path: expandHome(homePath) };
+	}
+	return { path: expandHome(trimmed) };
+}
+
+function parseCodexHomeEntry(value: unknown): CodexHomeSpec | undefined {
+	if (typeof value === "string") return parseCodexHomeString(value);
+	if (!isRecord(value)) return undefined;
+	const homePath = readString(value.path) ?? readString(value.home) ?? readString(value.codexHome);
+	if (!homePath) return undefined;
+	return {
+		name: readString(value.name) ?? readString(value.id),
+		path: expandHome(homePath),
+	};
+}
+
+function parseCodexHomeList(value: unknown): CodexHomeSpec[] {
+	if (typeof value === "string") {
+		return value
+			.split(",")
+			.map(parseCodexHomeString)
+			.filter((spec): spec is CodexHomeSpec => spec !== undefined);
+	}
+	if (!Array.isArray(value)) return [];
+	return value.map(parseCodexHomeEntry).filter((spec): spec is CodexHomeSpec => spec !== undefined);
+}
+
+function selectCodexHomeSpecs(
+	options: ApplyCodexHomeAuthChainOptions,
+	env: NodeJS.ProcessEnv,
+): { specs: CodexHomeSpec[]; explicitEmpty: boolean } {
+	if (options.codexHomeFlag !== undefined) {
+		const spec = parseCodexHomeString(options.codexHomeFlag);
+		return { specs: spec ? [spec] : [], explicitEmpty: spec === undefined };
+	}
+	const chainSpecs = parseCodexHomeList(options.codexHomeChainFlag);
+	if (chainSpecs.length > 0) return { specs: chainSpecs, explicitEmpty: false };
+	const configured = parseCodexHomeList(options.configuredHomes);
+	if (configured.length > 0) return { specs: configured, explicitEmpty: false };
+	const envHome = env[CODEX_HOME_ENV]?.trim();
+	const envSpec = envHome ? parseCodexHomeString(envHome) : undefined;
+	return { specs: envSpec ? [envSpec] : [], explicitEmpty: false };
+}
+
+function readCodexCredential(spec: CodexHomeSpec): CodexHomeCredential | undefined {
+	const authPath = path.join(spec.path, "auth.json");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(fs.readFileSync(authPath, "utf8"));
+	} catch {
+		return undefined;
+	}
+	if (parsed === null || typeof parsed !== "object" || !("tokens" in parsed)) return undefined;
+	const tokens = parsed.tokens;
+	if (!isRecord(tokens)) return undefined;
+	const accessToken = readString(tokens.access_token);
+	if (!accessToken) return undefined;
+	return {
+		...spec,
+		authPath,
+		accessToken,
+		refreshToken: readString(tokens.refresh_token),
+		accountId: readString(tokens.account_id),
+		email: readString(tokens.email),
+	};
+}
+
+export function applyCodexHomeAuth(
+	codexHomeFlag: string | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): CodexHomeAuthResult {
+	return applyCodexHomeAuthChain({ codexHomeFlag }, env);
+}
+
+export function applyCodexHomeAuthChain(
+	options: ApplyCodexHomeAuthChainOptions,
+	env: NodeJS.ProcessEnv = process.env,
+): CodexHomeAuthResult {
+	const { specs, explicitEmpty } = selectCodexHomeSpecs(options, env);
+	if (options.codexHomeFlag !== undefined) {
+		delete env[CODEX_HOME_ENV];
+		if (explicitEmpty) {
+			delete env[OPENAI_CODEX_OAUTH_TOKEN_ENV];
+			return { applied: false, credentials: [], reason: "codex-home-unset" };
+		}
+	}
+	if (specs.length === 0) return { applied: false, credentials: [], reason: "codex-home-unset" };
+
+	const credentials = specs.map(readCodexCredential).filter((credential): credential is CodexHomeCredential => {
+		return credential !== undefined;
+	});
+	if (credentials.length === 0) {
+		const first = specs[0];
+		const authPath = first ? path.join(first.path, "auth.json") : undefined;
+		if (options.codexHomeFlag !== undefined) delete env[OPENAI_CODEX_OAUTH_TOKEN_ENV];
+		return {
+			applied: false,
+			codexHome: first?.path,
+			authPath,
+			credentials: [],
+			reason: authPath && fs.existsSync(authPath) ? "access-token-missing" : "auth-file-unreadable",
+		};
+	}
+
+	const first = credentials[0];
+	env[OPENAI_CODEX_OAUTH_TOKEN_ENV] = first.accessToken;
+	return {
+		applied: true,
+		codexHome: first.path,
+		authPath: first.authPath,
+		accessToken: first.accessToken,
+		credentials,
+	};
+}

--- a/packages/coding-agent/src/cli/flag-tables.ts
+++ b/packages/coding-agent/src/cli/flag-tables.ts
@@ -112,6 +112,12 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 	"--model": (result, value) => {
 		result.model = value;
 	},
+	"--codex-home": (result, value) => {
+		result.codexHome = value;
+	},
+	"--codex-home-chain": (result, value) => {
+		result.codexHomeChain = value;
+	},
 	"--smol": (result, value) => {
 		result.smol = value;
 	},
@@ -129,6 +135,7 @@ export const STRING_SETTERS: Record<string, StringSetter> = {
 			deps.logger.warn("Invalid seconds passed to --max-time", { value });
 		}
 	},
+
 	"--api-key": (result, value) => {
 		result.apiKey = value;
 	},

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -279,9 +279,15 @@ export interface ModelTagsSettings {
 	[key: string]: ModelTagDef;
 }
 
+export interface CodexHomeSettingsEntry {
+	name?: string;
+	path: string;
+}
+
 // Typed defaults for array/record settings — named constants avoid `as` casts
 // under `as const` while still letting SettingValue infer the correct element type.
 const EMPTY_STRING_ARRAY: string[] = [];
+const EMPTY_CODEX_HOMES: CodexHomeSettingsEntry[] = [];
 const EMPTY_STRING_RECORD: Record<string, string> = {};
 const EMPTY_NUMBER_RECORD: Record<string, number> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
@@ -4329,6 +4335,10 @@ export const SETTINGS_SCHEMA = {
 			label: "Excluded Web Search Providers",
 			description: "Providers that web_search should never use, even as fallbacks",
 		},
+	},
+	"providers.codexHomes": {
+		type: "array",
+		default: EMPTY_CODEX_HOMES,
 	},
 	"providers.webSearchGeminiModel": {
 		type: "string",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -23,6 +23,7 @@ import {
 import chalk from "chalk";
 import { reset as resetCapabilities } from "./capability";
 import { type Args, reportUnrecognizedFlags } from "./cli/args";
+import { applyCodexHomeAuthChain, type CodexHomeCredential } from "./cli/codex-home";
 import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
@@ -65,7 +66,7 @@ import {
 	loadSessionExtensions,
 } from "./sdk";
 import type { AgentSession } from "./session/agent-session";
-import type { AuthStorage } from "./session/auth-storage";
+import type { AuthStorage, RuntimeApiKeyChainCredential } from "./session/auth-storage";
 import { describePendingToolCalls } from "./session/exit-diagnostics";
 import { resolveResumableSession, type SessionInfo } from "./session/session-listing";
 import { SessionManager } from "./session/session-manager";
@@ -970,6 +971,16 @@ interface RunRootCommandDependencies {
 	forceSetupWizard?: boolean;
 }
 
+function toRuntimeCodexHomeChain(credentials: CodexHomeCredential[]): RuntimeApiKeyChainCredential[] {
+	return credentials.map(credential => ({
+		key: credential.accessToken,
+		label: credential.name ?? credential.path,
+		accountId: credential.accountId,
+		email: credential.email,
+		usageType: "oauth",
+	}));
+}
+
 export async function runRootCommand(
 	parsed: Args,
 	rawArgs: string[],
@@ -984,11 +995,18 @@ export async function runRootCommand(
 
 	const parsedArgs = parsed;
 	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
+	const startupCodexHomeAuth = applyCodexHomeAuthChain({
+		codexHomeFlag: parsedArgs.codexHome,
+		codexHomeChainFlag: parsedArgs.codexHomeChain,
+	});
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
 
 	// Create AuthStorage and ModelRegistry upfront
 	const authStorage = await logger.time("discoverAuthStorage", deps.discoverAuthStorage ?? discoverAuthStorage);
+	if (startupCodexHomeAuth.credentials.length > 0) {
+		authStorage.setRuntimeApiKeyChain("openai-codex", toRuntimeCodexHomeChain(startupCodexHomeAuth.credentials));
+	}
 	const modelRegistry = logger.time("modelRegistry:init", () => new ModelRegistry(authStorage));
 
 	if (parsedArgs.version) {
@@ -1041,6 +1059,14 @@ export async function runRootCommand(
 	let cwd = getProjectDir();
 	const settingsInstance =
 		deps.settings ?? (await logger.time("settings:init", Settings.init, { cwd, configFiles: parsedArgs.config }));
+	const codexHomeAuth = applyCodexHomeAuthChain({
+		codexHomeFlag: parsedArgs.codexHome,
+		codexHomeChainFlag: parsedArgs.codexHomeChain,
+		configuredHomes: settingsInstance.get("providers.codexHomes"),
+	});
+	if (codexHomeAuth.credentials.length > 0) {
+		authStorage.setRuntimeApiKeyChain("openai-codex", toRuntimeCodexHomeChain(codexHomeAuth.credentials));
+	}
 	if (parsedArgs.approvalMode) {
 		// Runtime override (not persisted): every settings.get("tools.approvalMode") downstream
 		// sees this value. The wrapper still honours --auto-approve / --yolo on top of it.
@@ -1459,6 +1485,7 @@ export async function runRootCommand(
 				initialMessage,
 				initialImages,
 				printThoughts: initialArgs.printThoughts,
+
 			});
 			if ($env.PI_TIMING) {
 				logger.printTimings();

--- a/packages/coding-agent/src/session/auth-storage.ts
+++ b/packages/coding-agent/src/session/auth-storage.ts
@@ -17,6 +17,7 @@ export type {
 	ResetCreditAccountStatus,
 	ResetCreditRedeemOutcome,
 	ResetCreditTarget,
+	RuntimeApiKeyChainCredential,
 	SerializedAuthStorage,
 	StoredAuthCredential,
 } from "@oh-my-pi/pi-ai";

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -12,11 +12,13 @@ describe("AuthStorage account rotation", () => {
 	let tempDir: string;
 	let authStorage: AuthStorage;
 	let usageExhausted = false;
+	let exhaustedAccounts: Set<string>;
 
 	const usageProvider: UsageProvider = {
 		id: "openai-codex",
 		async fetchUsage(params) {
 			const accountId = params.credential.accountId ?? "unknown";
+			const exhausted = usageExhausted || exhaustedAccounts.has(accountId);
 			return {
 				provider: "openai-codex",
 				fetchedAt: Date.now(),
@@ -25,8 +27,8 @@ describe("AuthStorage account rotation", () => {
 						id: `requests-${accountId}`,
 						label: "Requests",
 						scope: { provider: "openai-codex", accountId },
-						amount: { unit: "requests", used: usageExhausted ? 100 : 10, limit: 100 },
-						status: usageExhausted ? "exhausted" : "ok",
+						amount: { unit: "requests", used: exhausted ? 100 : 10, limit: 100 },
+						status: exhausted ? "exhausted" : "ok",
 					},
 				],
 			};
@@ -37,6 +39,7 @@ describe("AuthStorage account rotation", () => {
 		tempDir = path.join(os.tmpdir(), `pi-test-auth-rotation-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		usageExhausted = false;
+		exhaustedAccounts = new Set();
 
 		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"), {
 			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
@@ -94,5 +97,23 @@ describe("AuthStorage account rotation", () => {
 
 		const exhaustedFallbackKey = await authStorage.getApiKey("openai-codex", sessionId);
 		expect(exhaustedFallbackKey).toMatch(/^api-acct-/);
+	});
+
+	test("rotates configured runtime Codex credential chains in configured order", async () => {
+		authStorage.setRuntimeApiKeyChain("openai-codex", [
+			{ key: "runtime-token-1", accountId: "acct-1", label: "primary", usageType: "oauth" },
+			{ key: "runtime-token-2", accountId: "acct-2", label: "secondary", usageType: "oauth" },
+		]);
+
+		const sessionId = "runtime-codex-chain-session";
+		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("runtime-token-1");
+		expect(authStorage.getOAuthAccountIdentity("openai-codex", sessionId)?.accountId).toBe("acct-1");
+
+		exhaustedAccounts.add("acct-1");
+		const { switched } = await authStorage.markUsageLimitReached("openai-codex", sessionId);
+		expect(switched).toBe(true);
+
+		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("runtime-token-2");
+		expect(authStorage.getOAuthAccountIdentity("openai-codex", sessionId)?.accountId).toBe("acct-2");
 	});
 });

--- a/packages/coding-agent/test/cli-codex-home-flag.test.ts
+++ b/packages/coding-agent/test/cli-codex-home-flag.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import {
+	applyCodexHomeAuth,
+	applyCodexHomeAuthChain,
+	CODEX_HOME_ENV,
+	OPENAI_CODEX_OAUTH_TOKEN_ENV,
+} from "@oh-my-pi/pi-coding-agent/cli/codex-home";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs) {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+	tempDirs = [];
+});
+
+function createTempDir(): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-codex-home-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function createCodexHome(accessToken: string, accountId = "account-id"): string {
+	const codexHome = createTempDir();
+	fs.writeFileSync(
+		path.join(codexHome, "auth.json"),
+		JSON.stringify({
+			tokens: {
+				access_token: accessToken,
+				refresh_token: "codex-refresh-token",
+				account_id: accountId,
+			},
+		}),
+	);
+	return codexHome;
+}
+
+describe("parseArgs — --codex-home flag", () => {
+	it("parses --codex-home without leaking the value into messages", () => {
+		const result = parseArgs(["--codex-home", "/tmp/codex-home", "--print", "hello"]);
+
+		expect(result.codexHome).toBe("/tmp/codex-home");
+		expect(result.print).toBe(true);
+		expect(result.messages).toEqual(["hello"]);
+	});
+
+	it("parses --codex-home-chain without leaking the value into messages", () => {
+		const result = parseArgs(["--codex-home-chain", "primary=/tmp/one,secondary=/tmp/two", "--print", "hello"]);
+
+		expect(result.codexHomeChain).toBe("primary=/tmp/one,secondary=/tmp/two");
+		expect(result.print).toBe(true);
+		expect(result.messages).toEqual(["hello"]);
+	});
+
+	it("sets OPENAI_CODEX_OAUTH_TOKEN from the selected Codex auth.json without exporting CODEX_HOME", () => {
+		const codexHome = createCodexHome("codex-access-token");
+		const env: NodeJS.ProcessEnv = {};
+
+		const result = applyCodexHomeAuth(codexHome, env);
+
+		expect(result.applied).toBe(true);
+		expect(result.accessToken).toBe("codex-access-token");
+		expect(result.codexHome).toBe(codexHome);
+		expect(env[CODEX_HOME_ENV]).toBeUndefined();
+		expect(env[OPENAI_CODEX_OAUTH_TOKEN_ENV]).toBe("codex-access-token");
+	});
+
+	it("builds an ordered Codex-home credential chain from named homes", () => {
+		const first = createCodexHome("first-token", "acct-first");
+		const second = createCodexHome("second-token", "acct-second");
+		const env: NodeJS.ProcessEnv = {};
+
+		const result = applyCodexHomeAuthChain({ codexHomeChainFlag: `primary=${first},secondary=${second}` }, env);
+
+		expect(result.applied).toBe(true);
+		expect(result.credentials.map(credential => credential.name)).toEqual(["primary", "secondary"]);
+		expect(result.credentials.map(credential => credential.accessToken)).toEqual(["first-token", "second-token"]);
+		expect(result.credentials.map(credential => credential.accountId)).toEqual(["acct-first", "acct-second"]);
+		expect(env[OPENAI_CODEX_OAUTH_TOKEN_ENV]).toBe("first-token");
+	});
+
+	it("installs --codex-home auth as the openai-codex runtime credential", async () => {
+		const codexHome = createCodexHome("codex-runtime-token");
+		const authStorage = await AuthStorage.create(path.join(createTempDir(), "auth.db"));
+		const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+		const parsed = parseArgs(["--codex-home", codexHome, "--model", "openai-codex/gpt-5.5", "--print", "hello"]);
+		parsed.noExtensions = true;
+		parsed.noSkills = true;
+		parsed.noRules = true;
+		parsed.noTools = true;
+		parsed.noLsp = true;
+		parsed.sessionDir = createTempDir();
+
+		try {
+			await runRootCommand(
+				parsed,
+				["--codex-home", codexHome, "--model", "openai-codex/gpt-5.5", "--print", "hello"],
+				{
+					discoverAuthStorage: async () => authStorage,
+					settings,
+					createAgentSession: async () => {
+						expect(await authStorage.getApiKey("openai-codex")).toBe("codex-runtime-token");
+						throw new Error("stop after runtime credential");
+					},
+				},
+			);
+		} catch (error) {
+			if (!(error instanceof Error) || error.message !== "stop after runtime credential") {
+				throw error;
+			}
+		} finally {
+			authStorage.close();
+		}
+	});
+
+	it("installs configured Codex homes as the openai-codex runtime credential chain", async () => {
+		const first = createCodexHome("configured-first-token", "acct-first");
+		const second = createCodexHome("configured-second-token", "acct-second");
+		const authStorage = await AuthStorage.create(path.join(createTempDir(), "auth.db"));
+		const settings = Settings.isolated({
+			"marketplace.autoUpdate": "off",
+			"providers.codexHomes": [
+				{ name: "primary", path: first },
+				{ name: "secondary", path: second },
+			],
+		});
+		const parsed = parseArgs(["--model", "openai-codex/gpt-5.5", "--print", "hello"]);
+		parsed.noExtensions = true;
+		parsed.noSkills = true;
+		parsed.noRules = true;
+		parsed.noTools = true;
+		parsed.noLsp = true;
+		parsed.sessionDir = createTempDir();
+
+		try {
+			await runRootCommand(parsed, ["--model", "openai-codex/gpt-5.5", "--print", "hello"], {
+				discoverAuthStorage: async () => authStorage,
+				settings,
+				createAgentSession: async () => {
+					const sessionId = "configured-codex-homes";
+					expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("configured-first-token");
+					expect(authStorage.getOAuthAccountIdentity("openai-codex", sessionId)?.accountId).toBe("acct-first");
+					throw new Error("stop after configured runtime credential chain");
+				},
+			});
+		} catch (error) {
+			if (!(error instanceof Error) || error.message !== "stop after configured runtime credential chain") {
+				throw error;
+			}
+		} finally {
+			authStorage.close();
+		}
+	});
+
+	it("clears Codex-home auth when the flag is passed empty", () => {
+		const env: NodeJS.ProcessEnv = {
+			[CODEX_HOME_ENV]: "/old/codex-home",
+			[OPENAI_CODEX_OAUTH_TOKEN_ENV]: "old-token",
+		};
+
+		const result = applyCodexHomeAuth("", env);
+
+		expect(result.applied).toBe(false);
+		expect(env[CODEX_HOME_ENV]).toBeUndefined();
+		expect(env[OPENAI_CODEX_OAUTH_TOKEN_ENV]).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Adds configurable Codex-home credential chains for openai-codex runtime auth, including --codex-home CLI loading and process-local account identity rotation for print agents.