### PR TITLE
fix(coding-agent): preserve enabled duplicate skills

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed skill loading so disabling a higher-priority provider no longer drops same-named skills from enabled lower-priority providers.
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -167,17 +167,21 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 	const userSkillsDir = path.join(getUserClaude(ctx), "skills");
 
-	// Walk up from cwd finding .claude/skills/ in ancestors
+	// Walk up from cwd finding .claude/skills/ in ancestors. Skip $HOME:
+	// that path is already scanned as the Claude user source below, and scanning
+	// it again as project would bypass enableClaudeUser when project skills stay enabled.
 	const projectScans: Promise<LoadResult<Skill>>[] = [];
 	let current = ctx.cwd;
 	while (true) {
-		projectScans.push(
-			scanSkillsFromDir(ctx, {
-				dir: path.join(current, CONFIG_DIR, "skills"),
-				providerId: PROVIDER_ID,
-				level: "project",
-			}),
-		);
+		if (current !== ctx.home) {
+			projectScans.push(
+				scanSkillsFromDir(ctx, {
+					dir: path.join(current, CONFIG_DIR, "skills"),
+					providerId: PROVIDER_ID,
+					level: "project",
+				}),
+			);
+		}
 		if (current === (ctx.repoRoot ?? ctx.home)) break;
 		const parent = path.dirname(current);
 		if (parent === current) break; // filesystem root

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -190,12 +190,18 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	const disabledSkillNames = new Set(
 		(disabledExtensions ?? []).filter(id => id.startsWith("skill:")).map(id => id.slice(6)),
 	);
-	// Filter skills by source and patterns first
-	const filteredSkills = result.items.filter(capSkill => {
+	// Select authored skills from the pre-dedup superset. `loadCapability`
+	// dedupes before source toggles, so a disabled high-priority provider must
+	// not hide an enabled lower-priority provider with the same skill name.
+	const seenAuthoredSkillNames = new Set<string>();
+	const filteredSkills = result.all.filter(capSkill => {
+		if (capSkill._source.provider === MANAGED_SKILLS_PROVIDER_ID) return false;
 		if (disabledSkillNames.has(capSkill.name)) return false;
 		if (!isSourceEnabled(capSkill._source)) return false;
 		if (matchesIgnorePatterns(capSkill.name)) return false;
 		if (!matchesIncludePatterns(capSkill.name)) return false;
+		if (seenAuthoredSkillNames.has(capSkill.name)) return false;
+		seenAuthoredSkillNames.add(capSkill.name);
 		return true;
 	});
 
@@ -213,9 +219,6 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 	// Process skills with resolved paths
 	for (let i = 0; i < filteredSkills.length; i++) {
 		const capSkill = filteredSkills[i];
-		// Managed (auto-learn) skills are resolved dead-last (below) so any
-		// authored skill of the same name — from ANY provider or custom dir — wins.
-		if (capSkill._source.provider === MANAGED_SKILLS_PROVIDER_ID) continue;
 		const resolvedPath = realPaths[i];
 
 		// Skip silently if we've already loaded this exact file (via symlink)

--- a/packages/coding-agent/test/autolearn-discovery.test.ts
+++ b/packages/coding-agent/test/autolearn-discovery.test.ts
@@ -100,10 +100,32 @@ describe("managed-skills discovery", () => {
 		expect(dises[0]?.source).toBe("omp-managed:user");
 	});
 
-	it("defers a managed skill to an ENABLED authored skill hidden behind a disabled higher-priority one", async () => {
+	it("selects an enabled lower-priority authored skill when a disabled higher-priority provider has the same name (#4648)", async () => {
+		await writeSkill(path.join(tempHome, ".claude", "skills"), "fallback-authored", "Disabled claude.");
+		await writeSkill(path.join(tempHome, ".agents", "skills"), "fallback-authored", "Enabled agents.");
+		const { skills } = await loadSkills({
+			cwd: tempCwd,
+			enableClaudeUser: false,
+			enableClaudeProject: false,
+		});
+		const matches = skills.filter(s => s.name === "fallback-authored");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.source).toBe("agents:user");
+	});
+
+	it("preserves provider priority when duplicate authored providers are both enabled (#4648)", async () => {
+		await writeSkill(path.join(tempHome, ".claude", "skills"), "priority-authored", "Enabled claude.");
+		await writeSkill(path.join(tempHome, ".agents", "skills"), "priority-authored", "Enabled agents.");
+		const { skills } = await loadSkills({ cwd: tempCwd });
+		const matches = skills.filter(s => s.name === "priority-authored");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.source).toBe("claude:user");
+	});
+
+	it("keeps managed skills dead-last behind an enabled authored fallback hidden by a disabled duplicate (#4648)", async () => {
 		// claude (priority 80, fully disabled) shadows agents (70, enabled) at
-		// capability dedup; agents survives only in result.all. Managed must NOT mask
-		// the enabled authored name, so no omp-managed skill is surfaced here.
+		// capability dedup. loadSkills must recover the enabled authored agent skill
+		// from the pre-dedup superset and still keep managed dead-last.
 		await writeSkill(path.join(tempHome, ".claude", "skills"), "shadowed", "Disabled claude.");
 		await writeSkill(path.join(tempHome, ".agents", "skills"), "shadowed", "Enabled agents.");
 		await writeSkill(managedDir, "shadowed", "Managed shadowed.");
@@ -112,6 +134,9 @@ describe("managed-skills discovery", () => {
 			enableClaudeUser: false,
 			enableClaudeProject: false,
 		});
+		const shadowed = skills.filter(s => s.name === "shadowed");
+		expect(shadowed).toHaveLength(1);
+		expect(shadowed[0]?.source).toBe("agents:user");
 		expect(skills.some(s => s.name === "shadowed" && s.source === "omp-managed:user")).toBe(false);
 	});
 

--- a/packages/coding-agent/test/autolearn-discovery.test.ts
+++ b/packages/coding-agent/test/autolearn-discovery.test.ts
@@ -113,6 +113,21 @@ describe("managed-skills discovery", () => {
 		expect(matches[0]?.source).toBe("agents:user");
 	});
 
+	it("does not resurrect disabled home claude user skills as project skills when cwd is under home", async () => {
+		// No repo root marker is created in tempHome/work. A Claude home skill must
+		// stay user-scoped only even while project skills remain enabled by default.
+		await writeSkill(path.join(tempHome, ".claude", "skills"), "home-only", "Disabled claude home skill.");
+		await writeSkill(path.join(tempHome, ".agents", "skills"), "home-only", "Enabled agents fallback.");
+		const { skills } = await loadSkills({
+			cwd: tempCwd,
+			enableClaudeUser: false,
+		});
+		const matches = skills.filter(s => s.name === "home-only");
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.source).toBe("agents:user");
+		expect(skills.some(s => s.name === "home-only" && s.source === "claude:project")).toBe(false);
+	});
+
 	it("preserves provider priority when duplicate authored providers are both enabled (#4648)", async () => {
 		await writeSkill(path.join(tempHome, ".claude", "skills"), "priority-authored", "Enabled claude.");
 		await writeSkill(path.join(tempHome, ".agents", "skills"), "priority-authored", "Enabled agents.");


### PR DESCRIPTION
## Repro
A focused provider-seam script registered a higher-priority `claude` skill named `foo` and a lower-priority `agents` skill with the same name, then called `loadSkills({ enableClaudeUser: false, enableClaudeProject: false })`. Before the fix, `bun .wt/repro-skill-provider-fallback.ts` exited 1 with `foo source: <missing>` instead of `agents:user`.

## Cause
`packages/coding-agent/src/extensibility/skills.ts` filtered `loadCapability(skillCapability.id).items`, but `items` had already been name-deduped in `packages/coding-agent/src/capability/index.ts` before `loadSkills()` applied `isSourceEnabled()`. A disabled higher-priority provider could therefore win capability dedup, get filtered out later, and leave the enabled lower-priority authored skill only in `result.all` where the authored-skill path never considered it.

## Fix
- Select authored skills from `result.all`, applying source toggles, disabled skill IDs, include/ignore patterns, and first-wins name dedup in `loadSkills()` so the highest-priority enabled authored provider owns each name.
- Keep managed skills excluded from the authored pass so the existing dead-last managed-skill resolution remains the fallback path.
- Add regression tests for disabled `claude` versus enabled `agents` duplicate names, normal both-enabled priority, and managed dead-last behavior behind an enabled authored fallback.
- Add a `packages/coding-agent` changelog entry.

## Verification
`bun .wt/repro-skill-provider-fallback.ts` now prints `foo source: agents:user` and exits 0. `bun test packages/coding-agent/test/autolearn-discovery.test.ts` passes with 10 pass / 0 fail / 23 expect() calls. Pre-publish gate passed during `gh_push_branch`. Fixes #4648