### PR TITLE
fix(mnemopi): drop object-shaped fact coercion

### DIFF
--- a/packages/mnemopi/CHANGELOG.md
+++ b/packages/mnemopi/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed extractor JSON parsing so object-shaped fact, instruction, preference, and timeline items are unwrapped from known text fields or dropped instead of persisting literal `[object Object]` rows. ([#4649](https://github.com/can1357/oh-my-pi/issues/4649))
+
 ## [16.3.7] - 2026-07-05
 
 ### Added

--- a/packages/mnemopi/src/core/extraction.ts
+++ b/packages/mnemopi/src/core/extraction.ts
@@ -86,6 +86,9 @@ const FLAT_FACT_LIMIT = 5;
 const STRUCTURED_CATEGORY_LIMIT = 5;
 const STRING_CATEGORY_KEYS = ["facts", "instructions", "preferences", "timelines"] as const;
 const FACT_TEXT_FIELD_KEYS = ["fact", "text", "content", "value", "statement"] as const;
+const INSTRUCTION_TEXT_FIELD_KEYS = ["instruction", "rule", ...FACT_TEXT_FIELD_KEYS] as const;
+const PREFERENCE_TEXT_FIELD_KEYS = ["preference", ...FACT_TEXT_FIELD_KEYS] as const;
+const TIMELINE_TEXT_FIELD_KEYS = ["description", "event", "timeline", "date", ...FACT_TEXT_FIELD_KEYS] as const;
 
 /** Parsed knowledge-graph edge emitted by the extractor LLM. */
 export interface ExtractedKgTriple {
@@ -113,7 +116,12 @@ function normalizeFact(fact: string): string {
 	return trimmed.replace(/[.!?]+$/, "");
 }
 
-function normalizeFactArray(items: unknown): string[] {
+interface FactArrayOptions {
+	fields: readonly string[];
+	joinFields?: boolean;
+}
+
+function normalizeFactArray(items: unknown, options: FactArrayOptions): string[] {
 	if (!Array.isArray(items)) {
 		return [];
 	}
@@ -123,13 +131,18 @@ function normalizeFactArray(items: unknown): string[] {
 		if (typeof item === "string") {
 			text = item.trim();
 		} else if (isRecord(item)) {
-			for (const key of FACT_TEXT_FIELD_KEYS) {
+			const parts: string[] = [];
+			for (const key of options.fields) {
 				const candidate = item[key];
-				if (typeof candidate === "string" && candidate.trim() !== "") {
-					text = candidate.trim();
-					break;
+				if (typeof candidate === "string") {
+					const trimmed = candidate.trim();
+					if (trimmed !== "") {
+						parts.push(trimmed);
+						if (options.joinFields !== true) break;
+					}
 				}
 			}
+			text = parts.length > 0 ? parts.join(" ") : null;
 		}
 		if (text !== null && text !== "") {
 			const normalized = normalizeFact(text);
@@ -218,10 +231,10 @@ export function parseExtractedFactCategories(rawOutput: string | null | undefine
 			const parsed: unknown = JSON.parse(rawClean);
 			if (isRecord(parsed)) {
 				return {
-					facts: normalizeFactArray(parsed.facts),
-					instructions: normalizeFactArray(parsed.instructions),
-					preferences: normalizeFactArray(parsed.preferences),
-					timelines: normalizeFactArray(parsed.timelines),
+					facts: normalizeFactArray(parsed.facts, { fields: FACT_TEXT_FIELD_KEYS }),
+					instructions: normalizeFactArray(parsed.instructions, { fields: INSTRUCTION_TEXT_FIELD_KEYS }),
+					preferences: normalizeFactArray(parsed.preferences, { fields: PREFERENCE_TEXT_FIELD_KEYS }),
+					timelines: normalizeFactArray(parsed.timelines, { fields: TIMELINE_TEXT_FIELD_KEYS, joinFields: true }),
 					kg: normalizeKgArray(parsed.kg),
 				};
 			}

--- a/packages/mnemopi/src/core/extraction.ts
+++ b/packages/mnemopi/src/core/extraction.ts
@@ -85,6 +85,7 @@ function stripFence(raw: string): string {
 const FLAT_FACT_LIMIT = 5;
 const STRUCTURED_CATEGORY_LIMIT = 5;
 const STRING_CATEGORY_KEYS = ["facts", "instructions", "preferences", "timelines"] as const;
+const FACT_TEXT_FIELD_KEYS = ["fact", "text", "content", "value", "statement"] as const;
 
 /** Parsed knowledge-graph edge emitted by the extractor LLM. */
 export interface ExtractedKgTriple {
@@ -118,8 +119,20 @@ function normalizeFactArray(items: unknown): string[] {
 	}
 	const out: string[] = [];
 	for (const item of items) {
-		if (item !== null && item !== undefined && String(item).trim() !== "") {
-			const normalized = normalizeFact(String(item));
+		let text: string | null = null;
+		if (typeof item === "string") {
+			text = item.trim();
+		} else if (isRecord(item)) {
+			for (const key of FACT_TEXT_FIELD_KEYS) {
+				const candidate = item[key];
+				if (typeof candidate === "string" && candidate.trim() !== "") {
+					text = candidate.trim();
+					break;
+				}
+			}
+		}
+		if (text !== null && text !== "") {
+			const normalized = normalizeFact(text);
 			if (normalized !== "") {
 				out.push(normalized);
 				if (out.length >= STRUCTURED_CATEGORY_LIMIT) break;

--- a/packages/mnemopi/test/extraction.test.ts
+++ b/packages/mnemopi/test/extraction.test.ts
@@ -52,12 +52,15 @@ describe("structured extraction", () => {
 		expect(parseFacts("NO_FACTS")).toEqual([]);
 	});
 
-	it("drops unrecognized object facts instead of stringifying them", () => {
+	it("unwraps category-specific object facts and drops unrecognized objects", () => {
 		const modelJson = JSON.stringify({
 			facts: [{ fact: "The user prefers tabs over spaces" }, { nested: {} }, "The user likes concise replies."],
-			instructions: [{ text: "Always include verification details" }],
-			preferences: [{ value: "Prefers dark mode" }],
-			timelines: [{ subject: "release", predicate: "on", object: "2026-08-01" }],
+			instructions: [{ instruction: "Always include verification details" }],
+			preferences: [{ preference: "Prefers dark mode" }],
+			timelines: [
+				{ date: "2026-08-01", description: "release" },
+				{ subject: "release", predicate: "on", object: "2026-08-01" },
+			],
 		});
 
 		expect(parseFacts(modelJson)).toEqual([
@@ -65,6 +68,7 @@ describe("structured extraction", () => {
 			"The user likes concise replies",
 			"Always include verification details",
 			"Prefers dark mode",
+			"release 2026-08-01",
 		]);
 	});
 

--- a/packages/mnemopi/test/extraction.test.ts
+++ b/packages/mnemopi/test/extraction.test.ts
@@ -52,6 +52,22 @@ describe("structured extraction", () => {
 		expect(parseFacts("NO_FACTS")).toEqual([]);
 	});
 
+	it("drops unrecognized object facts instead of stringifying them", () => {
+		const modelJson = JSON.stringify({
+			facts: [{ fact: "The user prefers tabs over spaces" }, { nested: {} }, "The user likes concise replies."],
+			instructions: [{ text: "Always include verification details" }],
+			preferences: [{ value: "Prefers dark mode" }],
+			timelines: [{ subject: "release", predicate: "on", object: "2026-08-01" }],
+		});
+
+		expect(parseFacts(modelJson)).toEqual([
+			"The user prefers tabs over spaces",
+			"The user likes concise replies",
+			"Always include verification details",
+			"Prefers dark mode",
+		]);
+	});
+
 	it("treats a valid empty structured extraction as no facts", () => {
 		expect(parseFacts('{"facts": [], "instructions": [], "preferences": [], "timelines": [], "kg": []}')).toEqual([]);
 		expect(


### PR DESCRIPTION
## Repro
A focused `parseFacts` regression in `packages/mnemopi` reproduced the issue with `cd packages/mnemopi && bun test test/extraction.test.ts --test-name-pattern "drops unrecognized object facts"`: object-shaped `facts`, `instructions`, `preferences`, and `timelines` entries produced literal `[object Object]` strings before the fix.

## Cause
`packages/mnemopi/src/core/extraction.ts` routed string categories through `normalizeFactArray`, which guarded with `String(item).trim()` and normalized `String(item)`. Arbitrary extractor objects therefore became the non-empty string `[object Object]`, while only `kg` entries used object-aware parsing.

## Fix
- Added known text-field extraction for object-shaped string-category items before normalization.
- Dropped unrecognized object entries and non-string primitives instead of coercing them.
- Added `parseFacts` regression coverage for mixed strings, wrapped objects, and junk timeline objects.
- Added the mnemopi changelog entry for #4649.

## Verification
`cd packages/mnemopi && bun test test/extraction.test.ts` passed with 10 tests and 25 assertions. `cd packages/mnemopi && bun check` passed. Fixes #4649