### PR TITLE
fix(coding-agent): refresh llama vision input metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed llama.cpp selected-model refresh keeping cached local vision models text-only after `/props` reports `modalities.vision: true`, so configuring a local model as the default and vision role now lets image inspection resolve it as image-capable. ([#4654](https://github.com/can1357/oh-my-pi/issues/4654))
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -151,8 +151,9 @@ type LlamaCppDiscoveredServerMetadata = {
 };
 
 type LlamaCppDiscoveredModelRuntimeMetadata = {
-	contextWindow: number;
-	maxTokens: number;
+	contextWindow?: number;
+	maxTokens?: number;
+	input?: ("text" | "image")[];
 };
 
 type LlamaCppModelListEntry = {
@@ -594,12 +595,14 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 			entry.configuredContextWindow ??
 			serverMetadata?.contextWindow ??
 			entry.trainingContextWindow;
+		const input = serverMetadata?.input;
 		if (contextWindow === undefined) {
-			return undefined;
+			return input === undefined ? undefined : { input };
 		}
 		return {
 			contextWindow,
 			maxTokens: resolveLlamaCppMaxTokens(contextWindow, serverMetadata?.maxTokens),
+			...(input !== undefined ? { input } : {}),
 		};
 	};
 	try {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -866,12 +866,13 @@ export class ModelRegistry {
 		if (runtimeMetadata === undefined) {
 			return this.find(model.provider, model.id) ?? model;
 		}
-		const { contextWindow, maxTokens } = runtimeMetadata;
+		const { contextWindow, maxTokens, input } = runtimeMetadata;
 		const current = this.find(model.provider, model.id) ?? model;
 		const override = this.#resolveLiveModelOverride(current);
 		const customModel = this.#resolveLiveCustomModelOverlay(current);
 		const patch: ModelPatch = {};
 		if (
+			contextWindow !== undefined &&
 			override?.contextWindow === undefined &&
 			customModel?.contextWindow === undefined &&
 			current.contextWindow !== contextWindow
@@ -884,15 +885,25 @@ export class ModelRegistry {
 			patch.contextWindow ??
 			current.contextWindow ??
 			contextWindow;
-		const effectiveMaxTokens = Math.min(maxTokens, effectiveContextWindow);
-		if (
-			override?.maxTokens === undefined &&
-			customModel?.maxTokens === undefined &&
-			current.maxTokens !== effectiveMaxTokens
-		) {
-			patch.maxTokens = effectiveMaxTokens;
+		if (maxTokens !== undefined && effectiveContextWindow !== undefined) {
+			const effectiveMaxTokens = Math.min(maxTokens, effectiveContextWindow);
+			if (
+				override?.maxTokens === undefined &&
+				customModel?.maxTokens === undefined &&
+				current.maxTokens !== effectiveMaxTokens
+			) {
+				patch.maxTokens = effectiveMaxTokens;
+			}
 		}
-		if (patch.contextWindow === undefined && patch.maxTokens === undefined) {
+		if (
+			input !== undefined &&
+			override?.input === undefined &&
+			customModel?.input === undefined &&
+			(current.input.length !== input.length || current.input.some((value, index) => value !== input[index]))
+		) {
+			patch.input = input;
+		}
+		if (patch.contextWindow === undefined && patch.maxTokens === undefined && patch.input === undefined) {
 			return current;
 		}
 		const patched = applyModelPatch(current, patch, "merge");

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -1052,6 +1052,62 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(registry.find("llama.cpp", "sleeping-model")?.contextWindow).toBe(239104);
 	});
 
+	test("llama.cpp selected model refresh marks cached text-only models image-capable from /props vision modality", async () => {
+		writeModelCache(
+			"llama.cpp",
+			Date.now(),
+			[
+				buildModel({
+					id: "vision-model",
+					name: "vision-model",
+					provider: "llama.cpp",
+					api: "openai-responses",
+					baseUrl: "http://127.0.0.1:8080",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 32768,
+				}),
+			],
+			true,
+			"",
+			cacheDbPath,
+		);
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(JSON.stringify({ data: [{ id: "vision-model", meta: { n_ctx: 239104 } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(
+					JSON.stringify({
+						default_generation_settings: {
+							n_ctx: 239104,
+							params: { max_tokens: -1, n_predict: -1 },
+						},
+						modalities: { vision: true, audio: false, video: false },
+					}),
+					{
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					},
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		const stale = registry.find("llama.cpp", "vision-model");
+		if (!stale) throw new Error("cached llama.cpp model missing");
+		expect(stale.input).toEqual(["text"]);
+		const refreshed = await registry.refreshSelectedModelMetadata(stale);
+		expect(refreshed.input).toEqual(["text", "image"]);
+		expect(registry.find("llama.cpp", "vision-model")?.input).toEqual(["text", "image"]);
+	});
+
 	test("llama.cpp selected model refresh leaves the cached model untouched when /models no longer lists it", async () => {
 		writeModelCache(
 			"llama.cpp",


### PR DESCRIPTION
## Repro
A cached llama.cpp model can remain recorded as `input: ["text"]` even after the local server loads a vision-capable model. The focused regression command `bun test packages/coding-agent/test/model-discovery.test.ts -t 'llama.cpp selected model refresh marks cached text-only models image-capable from /props vision modality'` failed before the fix because `refreshSelectedModelMetadata()` kept the refreshed model text-only while `/props` returned `modalities: { vision: true }`.

## Cause
`packages/coding-agent/src/config/model-discovery.ts` already parsed `/props.modalities.vision` during provider discovery, but `discoverLlamaCppModelRuntimeMetadata()` only returned runtime `contextWindow` and `maxTokens` for selected-model refresh. `packages/coding-agent/src/config/model-registry.ts` therefore patched llama.cpp context metadata after lazy load while dropping the refreshed `input` capability, so `modelRoles.vision` could still resolve to a cached text-only model.

## Fix
- Propagate llama.cpp runtime `input` metadata from `/props` through `discoverLlamaCppModelRuntimeMetadata()`.
- Patch selected llama.cpp models' `input` field during runtime refresh when no explicit model override/custom model input is configured.
- Add a regression test covering a cached text-only llama.cpp model becoming `input: ["text", "image"]` after `/props.modalities.vision === true`.
- Add the coding-agent changelog entry for the local vision detection fix.

## Verification
`bun test packages/coding-agent/test/model-discovery.test.ts -t 'llama.cpp selected model refresh marks cached text-only models image-capable from /props vision modality'` passed (1 pass). `bun test packages/coding-agent/test/model-discovery.test.ts` passed (40 pass, 147 expects). `bun check` passed. `gh_push_branch` pre-publish gate passed and pushed `farm/91f334f7/detect-local-vision-model`. Fixes #4654