### PR TITLE
fix: remove extra space between skill tag and name in header

### DIFF
--- a/packages/coding-agent/src/modes/components/skill-message.ts
+++ b/packages/coding-agent/src/modes/components/skill-message.ts
@@ -50,7 +50,7 @@ export class SkillMessageComponent extends Container {
 
 		// Header: icon-tag + skill name, with the invocation args trailing dimmed.
 		const tag = theme.fg("customMessageLabel", theme.bold(`${theme.icon.extensionSkill} skill`));
-		let header = `${tag}  ${theme.fg("customMessageText", theme.bold(name))}`;
+	let header = `${tag} ${theme.fg("customMessageText", theme.bold(name))}`;
 		if (args) {
 			header += ` ${theme.fg("dim", args)}`;
 		}


### PR DESCRIPTION
The skill card header rendered `skill  <name>` with a double space between the tag and the skill name. Changed to single space.

**Before:** ` skill  rc-fixing-naming-smells`
**After:** ` skill rc-fixing-naming-smells`

---
`packages/coding-agent/src/modes/components/skill-message.ts:53` — `${tag}  ${...}` → `${tag} ${...}`