### PR TITLE
fix(catalog): ignore LiteLLM all-team-models placeholders

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LiteLLM rich discovery to ignore unusable `all-team-models` aggregate placeholders and continue to `/v2/model/info` for real models. ([#4655](https://github.com/can1357/oh-my-pi/issues/4655))
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed LiteLLM rich discovery to ignore unusable `all-team-models` aggregate placeholders and continue to `/v2/model/info` for real models. ([#4655](https://github.com/can1357/oh-my-pi/issues/4655))
+- Fixed LiteLLM rich discovery to ignore unusable sentinel placeholders and continue to `/v2/model/info` for real models. ([#4655](https://github.com/can1357/oh-my-pi/issues/4655))
 
 ## [16.3.7] - 2026-07-05
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3037,6 +3037,7 @@ const LITELLM_RICH_ENDPOINTS = ["/model_group/info", "/v2/model/info", "/model/i
 export const OPENAI_COMPAT_DISCOVERY_DEFAULT_CONTEXT_WINDOW = 128_000;
 export const OPENAI_COMPAT_DISCOVERY_DEFAULT_MAX_TOKENS = 32_768;
 const UNKNOWN_PROXY_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+const LITELLM_ALL_TEAM_MODELS_ID = "all-team-models";
 
 export function normalizeLiteLLMManagementBaseUrl(baseUrl: string): string {
 	const trimmed = baseUrl.trim().replace(/\/+$/g, "");
@@ -3142,11 +3143,56 @@ function getSupportedOpenAIParams(entry: LiteLLMRichModelEntry): string[] | unde
 	return value.flatMap(item => (typeof item === "string" ? [item] : []));
 }
 
+function isLiteLLMUnusableAggregatePlaceholder(entry: LiteLLMRichModelEntry): boolean {
+	const modelGroup = toNonEmptyString(entry.model_group);
+	if (modelGroup !== LITELLM_ALL_TEAM_MODELS_ID) {
+		return false;
+	}
+	const providers = entry.providers;
+	if (providers !== undefined && (!Array.isArray(providers) || providers.length > 0)) {
+		return false;
+	}
+	const modelName = toNonEmptyString(entry.model_name);
+	if (modelName && modelName !== LITELLM_ALL_TEAM_MODELS_ID) {
+		return false;
+	}
+	const id = toNonEmptyString(entry.id);
+	if (id && id !== LITELLM_ALL_TEAM_MODELS_ID) {
+		return false;
+	}
+	const backendModel = toNonEmptyString(getLiteLLMParams(entry)?.model);
+	if (backendModel && backendModel !== LITELLM_ALL_TEAM_MODELS_ID) {
+		return false;
+	}
+	if (
+		toPositiveNumber(getLiteLLMMetadataValue(entry, "max_input_tokens"), null) !== null ||
+		toPositiveNumber(getLiteLLMMetadataValue(entry, "max_output_tokens"), null) !== null
+	) {
+		return false;
+	}
+	if (
+		getLiteLLMMetadataValue(entry, "supports_vision") === true ||
+		getLiteLLMMetadataValue(entry, "supports_reasoning") === true ||
+		getLiteLLMMetadataValue(entry, "supports_function_calling") === true ||
+		getLiteLLMMetadataValue(entry, "supports_tools") === true
+	) {
+		return false;
+	}
+	const supportedOpenAIParams = getSupportedOpenAIParams(entry);
+	if (supportedOpenAIParams && supportedOpenAIParams.length > 0) {
+		return false;
+	}
+	return true;
+}
+
 function mapLiteLLMRichEntry<TApi extends Api>(
 	entry: LiteLLMRichModelEntry,
 	options: FetchLiteLLMRichModelsOptions<TApi>,
 	runtimeBaseUrl: string,
 ): ModelSpec<TApi> | null {
+	if (isLiteLLMUnusableAggregatePlaceholder(entry)) {
+		return null;
+	}
 	const id = getLiteLLMRichModelId(entry);
 	if (!id) {
 		return null;
@@ -3286,11 +3332,11 @@ export function litellmModelManagerOptions(
 	const baseUrl = config?.baseUrl ?? Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1";
 	return {
 		providerId: "litellm",
-		// rich-v2 invalidates rows cached before reseller usage-suffix stripping
-		// (stale display names like `MiniMax-M3 (3x usage)`); bump the version
-		// whenever the mappers below change, or warm authoritative caches keep
-		// serving pre-change rows for the full TTL.
-		cacheProviderId: `litellm:rich-v2:${Bun.hash(baseUrl).toString(36)}`,
+		// rich-v3 invalidates rows cached before reseller usage-suffix stripping
+		// and placeholder-only `all-team-models` filtering; bump the version whenever
+		// the mappers below change, or warm authoritative caches keep serving
+		// pre-change rows for the full TTL.
+		cacheProviderId: `litellm:rich-v3:${Bun.hash(baseUrl).toString(36)}`,
 		// litellm is a local-only proxy and is never bundled in models.json (that
 		// would leak the machine's localhost catalog). Prefer the proxy's richer
 		// management metadata, then fall back to /v1/models and enrich bare ids

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3037,7 +3037,11 @@ const LITELLM_RICH_ENDPOINTS = ["/model_group/info", "/v2/model/info", "/model/i
 export const OPENAI_COMPAT_DISCOVERY_DEFAULT_CONTEXT_WINDOW = 128_000;
 export const OPENAI_COMPAT_DISCOVERY_DEFAULT_MAX_TOKENS = 32_768;
 const UNKNOWN_PROXY_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
-const LITELLM_ALL_TEAM_MODELS_ID = "all-team-models";
+const LITELLM_UNUSABLE_SENTINEL_IDS: Record<string, true> = {
+	"all-team-models": true,
+	"all-proxy-models": true,
+	"no-default-models": true,
+};
 
 export function normalizeLiteLLMManagementBaseUrl(baseUrl: string): string {
 	const trimmed = baseUrl.trim().replace(/\/+$/g, "");
@@ -3143,9 +3147,13 @@ function getSupportedOpenAIParams(entry: LiteLLMRichModelEntry): string[] | unde
 	return value.flatMap(item => (typeof item === "string" ? [item] : []));
 }
 
-function isLiteLLMUnusableAggregatePlaceholder(entry: LiteLLMRichModelEntry): boolean {
+function isLiteLLMUnusableSentinelPlaceholder(entry: LiteLLMRichModelEntry): boolean {
 	const modelGroup = toNonEmptyString(entry.model_group);
-	if (modelGroup !== LITELLM_ALL_TEAM_MODELS_ID) {
+	const id = toNonEmptyString(entry.id);
+	if (
+		(modelGroup === undefined || LITELLM_UNUSABLE_SENTINEL_IDS[modelGroup] !== true) &&
+		(id === undefined || LITELLM_UNUSABLE_SENTINEL_IDS[id] !== true)
+	) {
 		return false;
 	}
 	const providers = entry.providers;
@@ -3153,15 +3161,14 @@ function isLiteLLMUnusableAggregatePlaceholder(entry: LiteLLMRichModelEntry): bo
 		return false;
 	}
 	const modelName = toNonEmptyString(entry.model_name);
-	if (modelName && modelName !== LITELLM_ALL_TEAM_MODELS_ID) {
+	if (modelName && LITELLM_UNUSABLE_SENTINEL_IDS[modelName] !== true) {
 		return false;
 	}
-	const id = toNonEmptyString(entry.id);
-	if (id && id !== LITELLM_ALL_TEAM_MODELS_ID) {
+	if (id && LITELLM_UNUSABLE_SENTINEL_IDS[id] !== true) {
 		return false;
 	}
 	const backendModel = toNonEmptyString(getLiteLLMParams(entry)?.model);
-	if (backendModel && backendModel !== LITELLM_ALL_TEAM_MODELS_ID) {
+	if (backendModel && LITELLM_UNUSABLE_SENTINEL_IDS[backendModel] !== true) {
 		return false;
 	}
 	if (
@@ -3190,7 +3197,7 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 	options: FetchLiteLLMRichModelsOptions<TApi>,
 	runtimeBaseUrl: string,
 ): ModelSpec<TApi> | null {
-	if (isLiteLLMUnusableAggregatePlaceholder(entry)) {
+	if (isLiteLLMUnusableSentinelPlaceholder(entry)) {
 		return null;
 	}
 	const id = getLiteLLMRichModelId(entry);

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -4,6 +4,29 @@ import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
 
 const ORIGINAL_LITELLM_BASE_URL = Bun.env.LITELLM_BASE_URL;
 const MODELS_DEV_URL = "https://models.dev/api.json";
+const ALL_TEAM_MODELS_PLACEHOLDER = {
+	model_group: "all-team-models",
+	model_name: null,
+	providers: [],
+	max_input_tokens: null,
+	max_output_tokens: null,
+	supports_vision: null,
+	supports_reasoning: null,
+	supports_function_calling: null,
+	supported_openai_params: [],
+	litellm_params: {
+		model: null,
+		model_name: null,
+	},
+	model_info: {
+		max_input_tokens: null,
+		max_output_tokens: null,
+		supports_vision: null,
+		supports_reasoning: null,
+		supports_function_calling: null,
+		supported_openai_params: [],
+	},
+} as const;
 
 function restoreLiteLLMBaseUrl(): void {
 	if (ORIGINAL_LITELLM_BASE_URL === undefined) {
@@ -98,7 +121,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v2:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
+			`litellm:rich-v3:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -121,7 +144,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v2:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
+			`litellm:rich-v3:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -236,6 +259,109 @@ describe("LiteLLM provider discovery", () => {
 
 		expect(models?.find(model => model.id === "no-tools")?.supportsTools).toBe(false);
 		expect(models?.find(model => model.id === "params-tools")?.supportsTools).toBe(true);
+	});
+
+	test("falls back from all-team-models placeholder to v2 model info", async () => {
+		const calls: string[] = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			calls.push(url);
+			if (url === MODELS_DEV_URL) {
+				return Response.json({});
+			}
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({ data: [ALL_TEAM_MODELS_PLACEHOLDER] });
+			}
+			if (url === "http://primary:4000/v2/model/info") {
+				return Response.json({
+					data: [
+						{
+							model_name: "example-real-model",
+							model_info: {
+								max_input_tokens: 200_000,
+								max_output_tokens: 12_000,
+								supports_vision: false,
+								supports_reasoning: true,
+							},
+						},
+					],
+				});
+			}
+			if (url === "http://primary:4000/v1/models") {
+				throw new Error("/v1/models should not be called when v2 metadata succeeds");
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as FetchImpl;
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-rich",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(calls).toContain("http://primary:4000/model_group/info");
+		expect(calls).toContain("http://primary:4000/v2/model/info");
+		expect(calls).not.toContain("http://primary:4000/v1/models");
+		expect(models?.map(model => model.id)).toEqual(["example-real-model"]);
+		expect(models?.[0]).toMatchObject({
+			id: "example-real-model",
+			contextWindow: 200_000,
+			maxTokens: 12_000,
+			input: ["text"],
+			reasoning: true,
+		});
+	});
+
+	test("filters all-team-models placeholder from mixed model_group info", async () => {
+		const calls: string[] = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			calls.push(url);
+			if (url === MODELS_DEV_URL) {
+				return Response.json({});
+			}
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({
+					data: [
+						ALL_TEAM_MODELS_PLACEHOLDER,
+						{
+							model_group: "example-real-model",
+							model_name: "Example Real Model",
+							max_input_tokens: 96_000,
+							max_output_tokens: 8_000,
+							supports_function_calling: true,
+						},
+					],
+				});
+			}
+			if (url === "http://primary:4000/v2/model/info") {
+				throw new Error("/v2/model/info should not be called when model_group info has a real model");
+			}
+			if (url === "http://primary:4000/v1/models") {
+				throw new Error("/v1/models should not be called when model_group info has a real model");
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as FetchImpl;
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-rich",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(calls).toContain("http://primary:4000/model_group/info");
+		expect(calls).not.toContain("http://primary:4000/v2/model/info");
+		expect(calls).not.toContain("http://primary:4000/v1/models");
+		expect(models?.map(model => model.id)).toEqual(["example-real-model"]);
+		expect(models?.[0]).toMatchObject({
+			id: "example-real-model",
+			name: "Example Real Model",
+			contextWindow: 96_000,
+			maxTokens: 8_000,
+			supportsTools: true,
+		});
 	});
 
 	test("falls back from missing model_group info to v2 model info", async () => {

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -4,29 +4,33 @@ import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
 
 const ORIGINAL_LITELLM_BASE_URL = Bun.env.LITELLM_BASE_URL;
 const MODELS_DEV_URL = "https://models.dev/api.json";
-const ALL_TEAM_MODELS_PLACEHOLDER = {
-	model_group: "all-team-models",
-	model_name: null,
-	providers: [],
-	max_input_tokens: null,
-	max_output_tokens: null,
-	supports_vision: null,
-	supports_reasoning: null,
-	supports_function_calling: null,
-	supported_openai_params: [],
-	litellm_params: {
-		model: null,
+function makeLiteLLMSentinelPlaceholder(modelGroup: string) {
+	return {
+		model_group: modelGroup,
 		model_name: null,
-	},
-	model_info: {
+		providers: [],
 		max_input_tokens: null,
 		max_output_tokens: null,
 		supports_vision: null,
 		supports_reasoning: null,
 		supports_function_calling: null,
 		supported_openai_params: [],
-	},
-} as const;
+		litellm_params: {
+			model: null,
+			model_name: null,
+		},
+		model_info: {
+			max_input_tokens: null,
+			max_output_tokens: null,
+			supports_vision: null,
+			supports_reasoning: null,
+			supports_function_calling: null,
+			supported_openai_params: [],
+		},
+	} as const;
+}
+
+const ALL_TEAM_MODELS_PLACEHOLDER = makeLiteLLMSentinelPlaceholder("all-team-models");
 
 function restoreLiteLLMBaseUrl(): void {
 	if (ORIGINAL_LITELLM_BASE_URL === undefined) {
@@ -243,7 +247,7 @@ describe("LiteLLM provider discovery", () => {
 			if (url === "http://primary:4000/model_group/info") {
 				return Response.json({
 					data: [
-						{ model_group: "no-tools", supports_function_calling: false },
+						{ model_group: "no-tools", providers: ["openai"], supports_function_calling: false },
 						{ model_group: "params-tools", supported_openai_params: ["tools"] },
 					],
 				});
@@ -261,7 +265,11 @@ describe("LiteLLM provider discovery", () => {
 		expect(models?.find(model => model.id === "params-tools")?.supportsTools).toBe(true);
 	});
 
-	test("falls back from all-team-models placeholder to v2 model info", async () => {
+	test.each([
+		["all-team-models"],
+		["all-proxy-models"],
+		["no-default-models"],
+	])("falls back from %s placeholder to v2 model info", async sentinelModelId => {
 		const calls: string[] = [];
 		const fetchMock = vi.fn(async (input: string | URL | Request) => {
 			const url = inputUrl(input);
@@ -270,7 +278,7 @@ describe("LiteLLM provider discovery", () => {
 				return Response.json({});
 			}
 			if (url === "http://primary:4000/model_group/info") {
-				return Response.json({ data: [ALL_TEAM_MODELS_PLACEHOLDER] });
+				return Response.json({ data: [makeLiteLLMSentinelPlaceholder(sentinelModelId)] });
 			}
 			if (url === "http://primary:4000/v2/model/info") {
 				return Response.json({


### PR DESCRIPTION
## Repro
A mocked LiteLLM rich discovery sequence with `/model_group/info` returning only the observed `all-team-models` aggregate placeholder reproduced the failure: `bun .wt/litellm-placeholder-repro.ts` returned only `litellm/all-team-models` and exited 1 because discovery never called `/v2/model/info`.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` probed `/model_group/info` first, `getLiteLLMRichModelId()` accepted `model_group` as an id, and `fetchLiteLLMRichEndpoint()` treated any mapped row as authoritative. The aggregate placeholder therefore became a valid `ModelSpec` with default limits and stopped the endpoint loop before `/v2/model/info`.

## Fix
- Filter LiteLLM `all-team-models` aggregate placeholders when they have no providers, no concrete backend model id/name, no positive token limits, and no positive capability metadata.
- Preserve mixed `/model_group/info` responses by dropping only the placeholder row and keeping real model groups.
- Bump the LiteLLM rich discovery cache namespace from `rich-v2` to `rich-v3` so cached placeholder-only rows are invalidated.
- Add focused regression coverage for placeholder-only fallback and mixed-response filtering.
- Add an Unreleased catalog changelog entry.

## Verification
`bun .wt/litellm-placeholder-repro.ts` now calls `/model_group/info` then `/v2/model/info` and returns `example-real-model`; `bun test packages/catalog/test/litellm-provider.test.ts` passed with 11 tests and 60 assertions. Fixes #4655