### PR TITLE
fix(ai): retry empty Ollama completions

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ollama/Ollama Cloud EOS-only completions to retry empty stops with a single output token before the agent loop can halt silently. ([#4659](https://github.com/can1357/oh-my-pi/issues/4659))
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { clearStreamingPartialJson, kStreamingPartialJson } from "../utils/block-symbols";
+import { withEmptyCompletionRetry } from "../utils/empty-completion-retry";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { CapturedHttpErrorResponse, RawHttpRequestDump } from "../utils/http-inspector";
 import {
@@ -449,10 +450,10 @@ function hasVisibleAssistantContent(output: AssistantMessage): boolean {
 
 const OLLAMA_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
 
-export const streamOllama: StreamFunction<"ollama-chat"> = (
+const streamOllamaOnce = (
 	model: Model<"ollama-chat">,
 	context: Context,
-	options: OllamaChatOptions,
+	options: OllamaChatOptions = {},
 ): AssistantMessageEventStream => {
 	const stream = new AssistantMessageEventStream();
 	void (async () => {
@@ -771,3 +772,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 	})();
 	return stream;
 };
+
+/** Retry EOS-only Ollama completions before the agent loop sees an empty stop. */
+export const streamOllama: StreamFunction<"ollama-chat"> = (model, context, options) =>
+	withEmptyCompletionRetry(model, context, options, streamOllamaOnce);

--- a/packages/ai/src/utils/empty-completion-retry.ts
+++ b/packages/ai/src/utils/empty-completion-retry.ts
@@ -109,17 +109,16 @@ export function withEmptyCompletionRetry<M, O extends EmptyCompletionRetryOption
 			}
 
 			// Retry only a genuinely degenerate completion: a normal stop that
-			// produced no visible content AND billed no output tokens (the flaky
-			// gateway signature — charged nothing, returned nothing). A stop that
-			// reports output tokens spent its budget somewhere (e.g. thinking) and
-			// is left alone.
+			// produced no visible content and reported no generated content tokens.
+			// Some providers count the terminal EOS as one output token, so a
+			// one-token invisible stop is still the same empty-completion failure.
 			const message = terminal?.type === "done" ? terminal.message : undefined;
 			const isRetryableEmpty =
 				!committed &&
 				message !== undefined &&
 				message.stopReason === "stop" &&
 				!message.errorMessage &&
-				(message.usage?.output ?? 0) <= 0 &&
+				(message.usage?.output ?? 0) <= 1 &&
 				!hasVisibleAssistantContent(message);
 
 			if (isRetryableEmpty && emptyAttempt < MAX_EMPTY_COMPLETION_RETRIES && !signal?.aborted) {

--- a/packages/ai/test/empty-completion-retry.test.ts
+++ b/packages/ai/test/empty-completion-retry.test.ts
@@ -51,6 +51,17 @@ function emptyAttempt(): AssistantMessageEventStream {
 	] as unknown as AssistantMessageEvent[]);
 }
 
+/** start + stop with no visible content and a single EOS output token. */
+function eosOnlyAttempt(): AssistantMessageEventStream {
+	const message = assistant();
+	message.usage.output = 1;
+	message.usage.totalTokens = 1;
+	return streamFromEvents([
+		{ type: "start", partial: message },
+		{ type: "done", reason: "stop", message },
+	] as unknown as AssistantMessageEvent[]);
+}
+
 function contentAttempt(): AssistantMessageEventStream {
 	const message = assistant(["hello"]);
 	return streamFromEvents([
@@ -86,6 +97,23 @@ describe("withEmptyCompletionRetry", () => {
 		expect(events.filter(e => e.type === "start")).toHaveLength(1);
 		expect(events.some(e => e.type === "text_delta")).toBe(true);
 		expect(events.at(-1)?.type).toBe("done");
+		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	it("retries an EOS-only empty stop that reports one output token", async () => {
+		let attempts = 0;
+		const waits: number[] = [];
+		const stream = withEmptyCompletionRetry({}, CTX, { providerRetryWait: async ms => void waits.push(ms) }, () => {
+			attempts++;
+			return attempts === 1 ? eosOnlyAttempt() : contentAttempt();
+		});
+
+		const events = await drain(stream);
+		const result = await stream.result();
+
+		expect(attempts).toBe(2);
+		expect(waits).toEqual([500]);
+		expect(events.filter(e => e.type === "start")).toHaveLength(1);
 		expect(result.content).toEqual([{ type: "text", text: "hello" }]);
 	});
 

--- a/packages/ai/test/ollama-thinking-disable.test.ts
+++ b/packages/ai/test/ollama-thinking-disable.test.ts
@@ -81,6 +81,35 @@ describe("Ollama chat thinking controls", () => {
 		expect(payload?.think).toBe(false);
 	});
 
+	it("retries EOS-only empty completions before surfacing Ollama output", async () => {
+		let attempts = 0;
+		const fetchMock = async (): Promise<Response> => {
+			attempts++;
+			if (attempts === 1) {
+				return new Response(
+					'{"message":{"content":""},"done":true,"done_reason":"stop","prompt_eval_count":98563,"eval_count":1}\n',
+					{ status: 200 },
+				);
+			}
+			return new Response(
+				'{"message":{"content":"recovered"},"done":true,"done_reason":"stop","prompt_eval_count":98563,"eval_count":3}\n',
+				{ status: 200 },
+			);
+		};
+		const context: Context = {
+			messages: [{ role: "user", content: "Continue the task.", timestamp: 0 }],
+		};
+
+		const result = await streamOllama(createReasoningOllamaModel(), context, {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			providerRetryWait: async () => {},
+		}).result();
+
+		expect(attempts).toBe(2);
+		expect(result.content).toEqual([{ type: "text", text: "recovered" }]);
+	});
+
 	it("normalizes tool schemas for Ollama's Go parser", async () => {
 		let payload: OllamaChatRequestPayload | undefined;
 		const fetchMock = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {


### PR DESCRIPTION
## Repro
A mocked Ollama `/api/chat` stream that returns a terminal EOS-only chunk (`message.content: ""`, `done_reason: "stop"`, `prompt_eval_count: 98563`, `eval_count: 1`) reproduced the silent halt path with `bun .wt/repro-ollama-empty-completion.ts`: before the fix it made one provider attempt and surfaced `content: []`, `stopReason: "stop"`, `usage.output: 1`.

## Cause
`packages/ai/src/providers/ollama.ts` exported `streamOllama` as the single-attempt streamer directly, so Ollama/Ollama Cloud bypassed the shared retry wrapper used by OpenAI and Anthropic providers. `packages/ai/src/utils/empty-completion-retry.ts` also only retried invisible stops with `usage.output <= 0`, so an Ollama EOS-only stop counted as one output token was not retryable.

## Fix
- Split Ollama streaming into `streamOllamaOnce` and wrap the public `streamOllama` with `withEmptyCompletionRetry`.
- Treat invisible `stop` completions with zero or one output token as retryable, covering providers that count the EOS token.
- Added retry utility and Ollama provider regressions for one-token empty stops.
- Added an `@oh-my-pi/pi-ai` changelog entry.

## Verification
`bun test packages/ai/test/empty-completion-retry.test.ts packages/ai/test/ollama-thinking-disable.test.ts` passed with 16 tests. `bun .wt/repro-ollama-empty-completion.ts` now makes two attempts and returns `[{ type: "text", text: "recovered" }]`. `bun check` passed locally, and `gh_push_branch` completed its pre-publish gate before pushing. Fixes #4659