### PR TITLE
fix(agent): reset IRC wake maintenance state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed IRC-woken yielded subagents skipping empty-stop retry because stale yield-termination state carried into the wake turn ([#4658](https://github.com/can1357/oh-my-pi/issues/4658)).
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1824,12 +1824,18 @@ export class AgentSession {
 	 * Sticky across an in-flight prompt run: a successful `yield` makes the run
 	 * terminal for execution purposes, so any trailing empty/aborted assistant
 	 * stop must NOT trigger empty-stop/unexpected-stop/compaction continuations.
-	 * Cleared in `#promptWithMessage` so the next prompt evaluates cleanly.
+	 * Cleared before every new prompt turn so the next turn evaluates cleanly.
 	 */
 	#yieldTerminationPending = false;
 	#providerSessionState = new Map<string, ProviderSessionState>();
 	#hindsightSessionState: HindsightSessionState | undefined = undefined;
 	readonly rawSseDebugBuffer: RawSseDebugBuffer;
+
+	#resetPromptMaintenanceState(): void {
+		this.#emptyStopRetryCount = 0;
+		this.#unexpectedStopRetryCount = 0;
+		this.#yieldTerminationPending = false;
+	}
 
 	#acquirePowerAssertion(): void {
 		if (process.platform !== "darwin") return;
@@ -1949,6 +1955,7 @@ export class AgentSession {
 		if (parkedFollowUps.length > 0) {
 			this.agent.replaceQueues([...this.agent.peekSteeringQueue()], []);
 		}
+		this.#resetPromptMaintenanceState();
 		this.#beginInFlight();
 		void this.agent
 			.prompt(records)
@@ -7566,12 +7573,7 @@ export class AgentSession {
 			this.#todoReminderAwaitingProgress = false;
 			this.#mutationsSinceLastTodoTouch = 0;
 			this.#midRunNudgeCount = 0;
-			this.#emptyStopRetryCount = 0;
-			this.#unexpectedStopRetryCount = 0;
-			// A new prompt cycle starts: drop any sticky yield-termination from the
-			// previous run so empty-stop / unexpected-stop / compaction maintenance
-			// can evaluate this turn normally.
-			this.#yieldTerminationPending = false;
+			this.#resetPromptMaintenanceState();
 
 			await this.#maybeRestoreRetryFallbackPrimary();
 

--- a/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
+++ b/packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts
@@ -14,6 +14,7 @@ import { z } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -129,6 +130,13 @@ function reminderMessages(messages: AgentMessage[]): AgentMessage[] {
 	});
 }
 
+function assistantText(messages: AgentMessage[]): string {
+	return messages
+		.filter((message): message is Extract<AgentMessage, { role: "assistant" }> => message.role === "assistant")
+		.flatMap(message => message.content.flatMap(content => (content.type === "text" ? [content.text] : [])))
+		.join("\n");
+}
+
 afterEach(async () => {
 	for (const harness of activeHarnesses.splice(0)) {
 		await harness.session.dispose();
@@ -193,5 +201,35 @@ describe("AgentSession yield empty-stop suppression", () => {
 		// empty-stop reminder injected on the second run.
 		expect(mock.calls).toHaveLength(5);
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
+	});
+
+	it("treats an idle IRC wake after a yielded run as a fresh turn for empty-stop retry", async () => {
+		const { session, mock } = await createHarness([
+			// Run 1: yield then trailing empty stop. Suppression applies only to this yielded run.
+			yieldCall("first", "call-yield-before-irc"),
+			emptyStop(),
+			// Run 2: an idle IRC wake is a fresh turn, so its empty stop should retry normally.
+			emptyStop(),
+			{ content: ["recovered after IRC retry"], stopReason: "stop" },
+		]);
+
+		await session.prompt("yield first");
+		await session.waitForIdle();
+		expect(mock.calls).toHaveLength(2);
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
+
+		const outcome = await session.deliverIrcMessage({
+			id: "irc-empty-stop-after-yield",
+			from: "peer",
+			to: "me",
+			body: "ping",
+			ts: Date.now(),
+		} as IrcMessage);
+		expect(outcome).toBe("woken");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(4);
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
+		expect(assistantText(session.agent.state.messages)).toContain("recovered after IRC retry");
 	});
 });


### PR DESCRIPTION
## Repro
Added a focused regression in `packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts` that yields, suppresses the immediate trailing empty stop, then delivers an idle IRC message whose wake turn returns an empty stop. Before the fix, `bun test packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts -t "treats an idle IRC wake"` failed because the wake consumed only 3 model calls instead of retrying to 4.

## Cause
`AgentSession.#wakeForIrc` in `packages/coding-agent/src/session/agent-session.ts` called `this.agent.prompt(records)` directly, bypassing `AgentSession.#promptWithMessage`, the only path that cleared `#emptyStopRetryCount`, `#unexpectedStopRetryCount`, and `#yieldTerminationPending`. A prior successful `yield` left `#yieldTerminationPending` sticky, so `#handleAgentEvent` routed the IRC wake's empty `stop` through `post-yield-trailing-stop-suppressed` before `#handleEmptyAssistantStop` could schedule the retry.

## Fix
- Added a shared `AgentSession.#resetPromptMaintenanceState()` helper for the per-turn retry counters and yield-termination flag.
- Called the helper from both user prompt setup and IRC wake setup before starting the wake turn.
- Added regression coverage for an empty-stop retry on an idle IRC wake after a yielded run.
- Added a coding-agent changelog entry for #4658.

## Verification
`bun test packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts -t "treats an idle IRC wake"` passed after the fix. `bun test packages/coding-agent/test/agent-session-yield-empty-stop-suppression.test.ts packages/coding-agent/test/agent-session-empty-stop-guard.test.ts` passed with 12 tests. Pre-publish gate passed in `gh_push_branch`. Fixes #4658