### PR TITLE
fix(agent): surface pending irc replies to wait

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `irc wait` skipping replies that arrived between wait calls by draining pending IRC asides before honoring queued-interrupt aborts ([#4657](https://github.com/can1357/oh-my-pi/issues/4657)).
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -14120,15 +14120,15 @@ export class AgentSession {
 	// =========================================================================
 
 	/**
-	 * Surfaces (and consumes) pending IRC incoming records before the next model
+	 * Surfaces and consumes pending IRC incoming records before the next model
 	 * step can inject them automatically.
 	 *
-	 * The inbox tool injects the formatted body into the tool result, so the
-	 * model sees it once via the result. Leaving the record in either pending
-	 * IRC queue would deliver it a second time at the next step boundary —
-	 * including on `peek`, which is why peek also drains here.
+	 * Tool results already expose the formatted body to the model. Leaving the
+	 * same record in either pending IRC queue would deliver it a second time at
+	 * the next step boundary — including on `peek`, which is why inbox peeks
+	 * also drain here.
 	 */
-	drainPendingIrcInboxMessages(agentId: string): IrcMessage[] {
+	drainPendingIrcInboxMessages(agentId: string, opts?: { from?: string; limit?: number }): IrcMessage[] {
 		const messages: IrcMessage[] = [];
 		const remainingInterrupts: CustomMessage[] = [];
 		const remainingAsides: CustomMessage[] = [];
@@ -14152,6 +14152,14 @@ export class AgentSession {
 				const body = Reflect.get(details, "message");
 				const replyTo = Reflect.get(details, "replyTo");
 				if (typeof id !== "string" || typeof from !== "string" || typeof body !== "string") {
+					queue.remaining.push(record);
+					continue;
+				}
+				if (opts?.from !== undefined && from !== opts.from) {
+					queue.remaining.push(record);
+					continue;
+				}
+				if (opts?.limit !== undefined && messages.length >= opts.limit) {
 					queue.remaining.push(record);
 					continue;
 				}

--- a/packages/coding-agent/src/tools/irc.ts
+++ b/packages/coding-agent/src/tools/irc.ts
@@ -171,7 +171,7 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 			case "send":
 				return this.#executeSend(registry, senderId, params, signal);
 			case "wait":
-				return this.#executeWait(senderId, params, signal);
+				return this.#executeWait(registry, senderId, params, signal);
 			case "inbox":
 				return this.#executeInbox(registry, senderId, params);
 			default:
@@ -367,8 +367,24 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 		}
 	}
 
-	async #executeWait(senderId: string, params: IrcParams, signal?: AbortSignal): Promise<AgentToolResult<IrcDetails>> {
+	async #executeWait(
+		registry: AgentRegistry,
+		senderId: string,
+		params: IrcParams,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<IrcDetails>> {
 		const from = params.from?.trim() || undefined;
+		const session = registry.get(senderId)?.session;
+		const pending =
+			typeof session?.drainPendingIrcInboxMessages === "function"
+				? session.drainPendingIrcInboxMessages(senderId, { from, limit: 1 })[0]
+				: undefined;
+		if (pending) {
+			return {
+				content: [{ type: "text", text: formatIncoming(pending) }],
+				details: { op: "wait", from: senderId, waited: pending },
+			};
+		}
 		const timeoutMs = this.#resolveTimeoutMs(params);
 		const waited = await IrcBus.global().wait(senderId, { from }, timeoutMs, signal);
 		if (!waited) {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -611,6 +611,41 @@ describe("IRC", () => {
 			expect(text).toContain("No message");
 		});
 
+		it("op=wait consumes a pending IRC aside before honoring a queued interrupt abort", async () => {
+			const { session } = createRealSession();
+			sessions.push(session);
+			Object.defineProperty(session, "isStreaming", { value: true, configurable: true });
+			registry.register({ id: "0-Running", displayName: "task", kind: "sub", session });
+
+			const delivery = await session.deliverIrcMessage({
+				id: "msg-wait-pending",
+				from: "0-Main",
+				to: "0-Running",
+				body: "queued interrupt note",
+				ts: Date.now(),
+			});
+			expect(delivery).toBe("injected");
+
+			const tool = new IrcTool(makeToolSession(registry, "0-Running"));
+			const controller = new AbortController();
+			controller.abort(new Error("queued IRC interrupt"));
+
+			const result = await tool.execute("call-1", { op: "wait", timeoutMs: 30_000 }, controller.signal);
+
+			expect(result.isError).toBeFalsy();
+			expect(result.details?.waited).toMatchObject({
+				id: "msg-wait-pending",
+				from: "0-Main",
+				to: "0-Running",
+				body: "queued interrupt note",
+			});
+			const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+			expect(text).toContain("queued interrupt note");
+
+			const empty = await tool.execute("call-2", { op: "inbox" });
+			expect(empty.details?.inbox).toEqual([]);
+		});
+
 		it("op=inbox drains IRC asides that arrived while the caller was running", async () => {
 			const { session } = createRealSession();
 			sessions.push(session);


### PR DESCRIPTION
## Repro
A streaming `AgentSession` receives an IRC reply with no parked waiter, then the next `IrcTool` `op=wait` is invoked with the queued-IRC abort signal already aborted. Before the fix, the wait honored the abort first and surfaced the queued-message skip instead of the pending reply; the focused harness produced `error: "mock queued user message"`. Reproduced with an in-process Bun harness that created a streaming session, called `session.deliverIrcMessage(...)`, then executed `IrcTool` `op=wait` under an aborted signal.

## Cause
`packages/coding-agent/src/tools/irc.ts` sent `op=wait` directly to `IrcBus.wait()`, while `packages/coding-agent/src/session/agent-session.ts` stored mid-turn IRC deliveries in `#pendingIrcInterrupts`. That queue is what trips the agent loop's interrupt signal, so `wait` could observe the abort before consuming the pending IRC record. `op=inbox` had a session-pending drain path, but `op=wait` did not.

## Fix
- Extended `AgentSession.drainPendingIrcInboxMessages()` with optional `from` and `limit` filters so callers can consume only the pending IRC records they can surface.
- Changed `IrcTool` `op=wait` to consume one matching pending IRC record before parking on `IrcBus.wait()` or honoring the queued-interrupt abort signal.
- Added a regression test covering a real streaming session, an already-aborted queued-IRC signal, and a follow-up empty inbox to prove no duplicate delivery remains.
- Added the coding-agent changelog entry.

## Verification
- `bun test packages/coding-agent/test/tools/irc.test.ts` → 40 pass, 0 fail.
- `bun check` in `packages/coding-agent` → passed.
- `gh_push_branch` pre-publish gate completed and pushed commit `06f6762103ef`. Fixes #4657