### PR TITLE
fix(tui): correct skill card header spacing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed skill card headers to render a single space between the `skill` tag and skill name ([#4662](https://github.com/can1357/oh-my-pi/issues/4662)).
+
 ## [16.3.9] - 2026-07-06
 
 ### Added

--- a/packages/coding-agent/src/modes/components/__tests__/skill-message.test.ts
+++ b/packages/coding-agent/src/modes/components/__tests__/skill-message.test.ts
@@ -42,6 +42,8 @@ describe("SkillMessageComponent", () => {
 		// New look: an icon-tagged "skill" header with the name and a single meta line.
 		expect(text).toContain("skill");
 		expect(text).toContain("atomic-commit");
+		expect(text).toContain("skill atomic-commit");
+		expect(text).not.toContain("skill  atomic-commit");
 		expect(text).toContain("88 lines");
 
 		// The card is drawn with an outline.

--- a/packages/coding-agent/src/modes/components/skill-message.ts
+++ b/packages/coding-agent/src/modes/components/skill-message.ts
@@ -50,7 +50,7 @@ export class SkillMessageComponent extends Container {
 
 		// Header: icon-tag + skill name, with the invocation args trailing dimmed.
 		const tag = theme.fg("customMessageLabel", theme.bold(`${theme.icon.extensionSkill} skill`));
-		let header = `${tag}  ${theme.fg("customMessageText", theme.bold(name))}`;
+		let header = `${tag} ${theme.fg("customMessageText", theme.bold(name))}`;
 		if (args) {
 			header += ` ${theme.fg("dim", args)}`;
 		}


### PR DESCRIPTION
## Repro
A focused repro test for the skill card header rendered a collapsed `SkillMessageComponent` and asserted the visible header contains `skill atomic-commit`. Before the fix, `bun test /tmp/omp-skill-spacing-repro.test.ts` failed because the rendered card contained `✦ skill  atomic-commit`.

## Cause
`packages/coding-agent/src/modes/components/skill-message.ts` built the skill header with two literal spaces between the already-formatted `tag` and the themed skill name in `SkillMessageComponent.#rebuild`, so the visible header emitted `skill  <name>`.

## Fix
- Changed the skill header formatter to insert one separator space between `tag` and the skill name.
- Added a regression assertion in `packages/coding-agent/src/modes/components/__tests__/skill-message.test.ts` that accepts `skill atomic-commit` and rejects `skill  atomic-commit`.
- Added the fix to `packages/coding-agent/CHANGELOG.md` under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/src/modes/components/__tests__/skill-message.test.ts` passed with 4 tests. `bun test /tmp/omp-skill-spacing-repro.test.ts` passed with 1 test after the fix. Fixes #4662