### PR TITLE
feat(coding-agent): allow thinking renderers to replace blocks

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -468,7 +468,18 @@ pi.registerAssistantThinkingRenderer((context, theme) => {
 });
 ```
 
-Used by interactive rendering to add display-only supplemental UI below each visible assistant thinking block. The renderer receives the already-visible thinking text, content/thinking indexes, theme, and a `requestRender()` callback for async renderers. All registered renderers that return a component are appended in registration order. Renderers must not mutate messages; the original thinking block remains the provider/session source of truth.
+Used by interactive rendering to customize each visible assistant thinking block. The renderer receives parent assistant message metadata, provider thinking content metadata, the current full trimmed thinking text snapshot, content/thinking indexes, theme, and a `requestRender()` callback for async renderers. `requestRender()` repaints already-mounted renderer output; if the renderer returned `undefined`, it re-runs this thinking block's renderers and schedules a repaint so async work can later mount `{ type: "append" }` or `{ type: "replace" }` output. Renderers must not mutate messages; the thinking block remains the provider/session source of truth.
+
+`context.message.timestamp` is stable across streaming partials and is the recommended anchor for renderer-local async state keys. `context.message.responseId` may be absent or appear only after provider finalization; do not key streaming state on `responseId` alone. `context.content.itemId` and `context.content.thinkingSignature` identify provider-native reasoning items when available; fall back to `contentIndex` and `thinkingIndex` otherwise.
+
+Renderer results:
+
+- `Component`: legacy shorthand for appending supplemental UI below the original thinking Markdown.
+- `{ type: "append", component: Component }`: explicit append behavior, equivalent to returning a bare component.
+- `{ type: "replace", component: Component }`: suppresses the default thinking Markdown and renders the replacement component instead.
+- `undefined`: renders nothing extra and leaves the default thinking Markdown visible.
+
+If multiple renderers return `{ type: "replace", component }`, the first replacement wins and later replacements are ignored with a warning. Append renderers still run after a replacement, in registration order.
 
 ## Tool call/result renderer
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added explicit assistant thinking renderer result arms for extensions: `{ type: "append", component: Component }` keeps the existing supplemental rendering behavior, while `{ type: "replace", component: Component }` suppresses the default thinking Markdown so extensions can render the block themselves. Bare `Component` returns remain the legacy append shorthand. Thinking render contexts now include parent assistant message metadata and provider thinking content metadata for async renderer state.
+
 ## [17.2.15] - 2026-08-12
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -22,6 +22,7 @@ import type {
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type {
 	Api,
+	AssistantMessage,
 	AssistantMessageEvent,
 	AssistantMessageEventStream,
 	Context,
@@ -35,6 +36,7 @@ import type {
 	SimpleStreamOptions,
 	Static,
 	TextContent,
+	ThinkingContent,
 	TSchema,
 } from "@oh-my-pi/pi-ai";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oauth/types";
@@ -1109,16 +1111,37 @@ export type MessageRenderer<T = unknown> = (
 ) => Component | undefined;
 
 export interface AssistantThinkingRenderContext {
+	/**
+	 * Parent assistant message metadata. `timestamp` is stable across streaming partials
+	 * and is the recommended anchor for renderer-local async state keys. `responseId`
+	 * may be absent or appear only after provider finalization; do not key streaming
+	 * state on `responseId` alone.
+	 */
+	message: Readonly<Pick<AssistantMessage, "timestamp" | "responseId" | "api" | "provider" | "model">>;
+	/**
+	 * Provider thinking content item currently being rendered. `itemId` and
+	 * `thinkingSignature` identify provider-native reasoning items when available;
+	 * fall back to `contentIndex` and `thinkingIndex` otherwise.
+	 */
+	content: Readonly<Pick<ThinkingContent, "itemId" | "thinkingSignature">>;
 	contentIndex: number;
 	thinkingIndex: number;
+	/** Current full trimmed thinking snapshot. */
 	text: string;
+	/** Repaint mounted output, or re-run this thinking block's renderers when no component was mounted yet. */
 	requestRender(): void;
 }
+
+export type AssistantThinkingRenderResult =
+	| Component
+	| { type: "append"; component: Component }
+	| { type: "replace"; component: Component }
+	| undefined;
 
 export type AssistantThinkingRenderer = (
 	context: AssistantThinkingRenderContext,
 	theme: Theme,
-) => Component | undefined;
+) => AssistantThinkingRenderResult;
 
 // ============================================================================
 // Command Registration
@@ -1284,7 +1307,7 @@ export interface ExtensionAPI {
 	/** Register a custom renderer for CustomMessageEntry. */
 	registerMessageRenderer<T = unknown>(customType: string, renderer: MessageRenderer<T>): void;
 
-	/** Register a renderer for assistant thinking blocks. Rendered after the original thinking text. */
+	/** Register a renderer for assistant thinking blocks. Legacy Component returns append after the original thinking text. */
 	registerAssistantThinkingRenderer(renderer: AssistantThinkingRenderer): void;
 
 	// =========================================================================

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -194,6 +194,10 @@ function isStructuredThinkingResult(
 	return candidate.type === "append" || candidate.type === "replace";
 }
 
+interface ThinkingRendererCache {
+	text: string;
+	entries: Array<{ result: AssistantThinkingRenderResult; dirty: boolean } | undefined>;
+}
 /**
  * Component that renders a complete assistant message
  */
@@ -283,6 +287,8 @@ export class AssistantMessageComponent extends Container {
 	#thinkingRateLive = false;
 	#visibleThinkingUsesRenderers = false;
 	#thinkingRenderRefreshQueued = false;
+	#thinkingRendererCache = new Map<string, ThinkingRendererCache>();
+	#thinkingRendererCacheTimestamp: number | undefined;
 
 	#textColorTransform?: (text: string) => string;
 
@@ -336,6 +342,7 @@ export class AssistantMessageComponent extends Container {
 		// updateContent() directly and keep the fast path.
 		this.#fastPathKey = undefined;
 		this.#fastPathItems = undefined;
+		this.#thinkingRendererCache.clear();
 		if (this.#lastMessage) {
 			this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
 		}
@@ -732,65 +739,85 @@ export class AssistantMessageComponent extends Container {
 		thinkingIndex: number,
 		text: string,
 	): ThinkingExtensionComponents {
+		const key = `${contentIndex}:${thinkingIndex}`;
+		let cache = this.#thinkingRendererCache.get(key);
+		if (!cache || cache.text !== text) {
+			cache = { text, entries: [] };
+			this.#thinkingRendererCache.set(key, cache);
+		}
+
 		const append: Component[] = [];
 		let replacement: Component | undefined;
-		for (const renderer of this.thinkingRenderers) {
-			let rerunRenderersOnRequest = true;
-			try {
-				const result: AssistantThinkingRenderResult = renderer(
-					{
-						message: {
-							timestamp: message.timestamp,
-							responseId: message.responseId,
-							api: message.api,
-							provider: message.provider,
-							model: message.model,
+		for (let rendererIndex = 0; rendererIndex < this.thinkingRenderers.length; rendererIndex++) {
+			const renderer = this.thinkingRenderers[rendererIndex]!;
+			let entry = cache.entries[rendererIndex];
+			if (!entry || entry.dirty) {
+				entry = { result: undefined, dirty: false };
+				cache.entries[rendererIndex] = entry;
+				let rerunRendererOnRequest = true;
+				try {
+					entry.result = renderer(
+						{
+							message: {
+								timestamp: message.timestamp,
+								responseId: message.responseId,
+								api: message.api,
+								provider: message.provider,
+								model: message.model,
+							},
+							content: {
+								itemId: content.itemId,
+								thinkingSignature: content.thinkingSignature,
+							},
+							contentIndex,
+							thinkingIndex,
+							text,
+							requestRender: () => {
+								if (rerunRendererOnRequest) entry!.dirty = true;
+								this.#requestThinkingRender(rerunRendererOnRequest);
+							},
 						},
-						content: {
-							itemId: content.itemId,
-							thinkingSignature: content.thinkingSignature,
-						},
+						theme,
+					);
+					if (entry.result && (isComponent(entry.result) || isStructuredThinkingResult(entry.result))) {
+						rerunRendererOnRequest = false;
+						entry.dirty = false;
+					}
+					if (!entry.result) entry.dirty = true;
+				} catch (error) {
+					logger.warn("Assistant thinking renderer failed", {
 						contentIndex,
 						thinkingIndex,
-						text,
-						requestRender: () => this.#requestThinkingRender(rerunRenderersOnRequest),
-					},
-					theme,
-				);
-				if (!result) continue;
-				if (isComponent(result)) {
-					rerunRenderersOnRequest = false;
-					append.push(result);
-					continue;
+						error: error instanceof Error ? error.message : String(error),
+					});
 				}
-				if (!isStructuredThinkingResult(result)) {
-					logger.warn("Assistant thinking renderer returned an invalid result", {
+			}
+
+			const result = entry.result;
+			if (!result) continue;
+			if (isComponent(result)) {
+				append.push(result);
+				continue;
+			}
+			if (!isStructuredThinkingResult(result)) {
+				logger.warn("Assistant thinking renderer returned an invalid result", {
+					contentIndex,
+					thinkingIndex,
+				});
+				continue;
+			}
+			if (result.type === "replace") {
+				if (replacement) {
+					logger.warn("Assistant thinking replacement renderer ignored because one is already active", {
 						contentIndex,
 						thinkingIndex,
 					});
 					continue;
 				}
-				if (result.type === "replace") {
-					if (replacement) {
-						logger.warn("Assistant thinking replacement renderer ignored because one is already active", {
-							contentIndex,
-							thinkingIndex,
-						});
-						continue;
-					}
-					rerunRenderersOnRequest = false;
-					replacement = result.component;
-					continue;
-				}
-				rerunRenderersOnRequest = false;
-				append.push(result.component);
-			} catch (error) {
-				logger.warn("Assistant thinking renderer failed", {
-					contentIndex,
-					thinkingIndex,
-					error: error instanceof Error ? error.message : String(error),
-				});
+				replacement = result.component;
+				continue;
 			}
+			append.push(result.component);
 		}
 		return { append, replace: replacement };
 	}
@@ -806,9 +833,6 @@ export class AssistantMessageComponent extends Container {
 				else if (this.hideThinkingBlock) parts.push("KH");
 				else parts.push("KV");
 			} else {
-				// Non-rendered blocks (toolCall, redactedThinking, …) still occupy a
-				// content index. Encode their position so an inserted/removed one shifts
-				// the key and forces the teardown path instead of mis-indexing children.
 				parts.push(`O:${content.type}`);
 			}
 		}
@@ -828,9 +852,20 @@ export class AssistantMessageComponent extends Container {
 		) {
 			return false;
 		}
-		// Thinking renderers are arbitrary extension code: their output can change
-		// even when the message shape and text are identical.
-		if (this.thinkingRenderers.length > 0) return false;
+		if (this.thinkingRenderers.length > 0 && this.#fastPathItems) {
+			let thinkingIndex = 0;
+			for (let contentIndex = 0; contentIndex < message.content.length; contentIndex++) {
+				const content = message.content[contentIndex]!;
+				if (content.type !== "thinking") continue;
+				const display = resolveThinkingDisplay(content, this.proseOnlyThinking);
+				if (display.visible && !this.hideThinkingBlock) {
+					const cache = this.#thinkingRendererCache.get(`${contentIndex}:${thinkingIndex}`);
+					if (!cache || cache.text !== display.text) return false;
+					if (cache.entries.some(entry => entry?.dirty)) return false;
+				}
+				thinkingIndex++;
+			}
+		}
 		return true;
 	}
 
@@ -892,6 +927,10 @@ export class AssistantMessageComponent extends Container {
 	updateContent(message: AssistantMessage, opts?: { transient?: boolean }): void {
 		this.#blockVersion++;
 		this.#lastMessage = message;
+		if (this.#thinkingRendererCacheTimestamp !== message.timestamp) {
+			this.#thinkingRendererCache.clear();
+			this.#thinkingRendererCacheTimestamp = message.timestamp;
+		}
 		this.#lastUpdateTransient = opts?.transient === true;
 
 		// Streaming-speed gauge: only a live, in-flight render of the single

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -925,7 +925,6 @@ export class AssistantMessageComponent extends Container {
 				this.#fastPathItems = undefined;
 				return false;
 			}
-			item.md.transientRenderCache = transient;
 			if (newText !== item.lastText) {
 				// Only the last (actively streaming) block may mutate in place: a
 				// delta into an earlier block would invalidate rows the settled

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -197,6 +197,9 @@ function isStructuredThinkingResult(
 interface ThinkingRendererCache {
 	text: string;
 	responseId: string | undefined;
+	api: AssistantMessage["api"];
+	provider: AssistantMessage["provider"];
+	model: string;
 	itemId: string | undefined;
 	thinkingSignature: string | undefined;
 	entries: Array<{ result: AssistantThinkingRenderResult; dirty: boolean } | undefined>;
@@ -291,6 +294,7 @@ export class AssistantMessageComponent extends Container {
 	#visibleThinkingUsesRenderers = false;
 	#thinkingRenderRefreshQueued = false;
 	#thinkingRendererCache = new Map<string, ThinkingRendererCache>();
+	#disposed = false;
 	#thinkingRendererCacheTimestamp: number | undefined;
 
 	#textColorTransform?: (text: string) => string;
@@ -365,6 +369,9 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	override dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#thinkingRendererCache.clear();
 		this.#stopThinkingAnimation();
 		super.dispose();
 	}
@@ -709,6 +716,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#requestThinkingRender(rerunRenderers: boolean): void {
+		if (this.#disposed) return;
 		if (!rerunRenderers) {
 			this.onImageUpdate?.();
 			return;
@@ -716,6 +724,10 @@ export class AssistantMessageComponent extends Container {
 		if (this.#thinkingRenderRefreshQueued) return;
 		this.#thinkingRenderRefreshQueued = true;
 		queueMicrotask(() => {
+			if (this.#disposed) {
+				this.#thinkingRenderRefreshQueued = false;
+				return;
+			}
 			try {
 				if (this.#lastMessage) {
 					this.#fastPathKey = undefined;
@@ -748,12 +760,18 @@ export class AssistantMessageComponent extends Container {
 			!cache ||
 			cache.text !== text ||
 			cache.responseId !== message.responseId ||
+			cache.api !== message.api ||
+			cache.provider !== message.provider ||
+			cache.model !== message.model ||
 			cache.itemId !== content.itemId ||
 			cache.thinkingSignature !== content.thinkingSignature
 		) {
 			cache = {
 				text,
 				responseId: message.responseId,
+				api: message.api,
+				provider: message.provider,
+				model: message.model,
 				itemId: content.itemId,
 				thinkingSignature: content.thinkingSignature,
 				entries: [],
@@ -879,6 +897,9 @@ export class AssistantMessageComponent extends Container {
 						!cache ||
 						cache.text !== display.text ||
 						cache.responseId !== message.responseId ||
+						cache.api !== message.api ||
+						cache.provider !== message.provider ||
+						cache.model !== message.model ||
 						cache.itemId !== content.itemId ||
 						cache.thinkingSignature !== content.thinkingSignature
 					) {

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -1,5 +1,6 @@
-import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ImageContent, ThinkingContent } from "@oh-my-pi/pi-ai";
 import {
+	type Component,
 	Container,
 	Image,
 	type ImageBudget,
@@ -10,9 +11,9 @@ import {
 	TERMINAL,
 	Text,
 } from "@oh-my-pi/pi-tui";
-import { formatNumber } from "@oh-my-pi/pi-utils";
+import { formatNumber, logger } from "@oh-my-pi/pi-utils";
 import chalk from "@oh-my-pi/pi-utils/chalk";
-import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
+import type { AssistantThinkingRenderer, AssistantThinkingRenderResult } from "../../extensibility/extensions/types";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { expandKeyHint, getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { convertImageToPng } from "../../utils/image-loading";
@@ -175,6 +176,24 @@ function lerpHex(from: string, to: string, t: number): string {
 	return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
 }
 
+interface ThinkingExtensionComponents {
+	append: Component[];
+	replace?: Component;
+}
+
+function isComponent(result: AssistantThinkingRenderResult): result is Component {
+	return typeof result === "object" && result !== null && typeof (result as Component).render === "function";
+}
+
+function isStructuredThinkingResult(
+	result: AssistantThinkingRenderResult,
+): result is { type: "append" | "replace"; component: Component } {
+	if (typeof result !== "object" || result === null || isComponent(result)) return false;
+	const candidate = result as { type?: unknown; component?: unknown };
+	if (!isComponent(candidate.component as AssistantThinkingRenderResult)) return false;
+	return candidate.type === "append" || candidate.type === "replace";
+}
+
 /**
  * Component that renders a complete assistant message
  */
@@ -262,6 +281,8 @@ export class AssistantMessageComponent extends Container {
 	 *  session-wide {@link sharedSpeedTracker} can't surface a previous turn's rate
 	 *  on a fresh block that has no live token throughput of its own. */
 	#thinkingRateLive = false;
+	#visibleThinkingUsesRenderers = false;
+	#thinkingRenderRefreshQueued = false;
 
 	#textColorTransform?: (text: string) => string;
 
@@ -501,6 +522,17 @@ export class AssistantMessageComponent extends Container {
 		return this.#blockVersion;
 	}
 
+	/**
+	 * Default assistant text/thinking streams are append-only while visible rows
+	 * keep prior content and grow at the bottom. Once a visible thinking block is
+	 * handed to extension renderers, any renderer can later switch from `undefined`
+	 * to `{ type: "replace" }` via `requestRender()`, so keep those rows in the
+	 * repaintable live region instead of marking them safe for native scrollback.
+	 */
+	isTranscriptBlockAppendOnly(): boolean {
+		return !this.#visibleThinkingUsesRenderers;
+	}
+
 	markTranscriptBlockFinalized(): void {
 		this.#transcriptBlockFinalized = true;
 		this.#stopThinkingAnimation();
@@ -666,25 +698,101 @@ export class AssistantMessageComponent extends Container {
 		this.#renderImageEntries(entries, true);
 	}
 
-	#appendThinkingExtensions(contentIndex: number, thinkingIndex: number, text: string): void {
-		for (const renderer of this.thinkingRenderers) {
+	#requestThinkingRender(rerunRenderers: boolean): void {
+		if (!rerunRenderers) {
+			this.onImageUpdate?.();
+			return;
+		}
+		if (this.#thinkingRenderRefreshQueued) return;
+		this.#thinkingRenderRefreshQueued = true;
+		queueMicrotask(() => {
 			try {
-				const component = renderer(
+				if (this.#lastMessage) {
+					this.#fastPathKey = undefined;
+					this.#fastPathItems = undefined;
+					this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
+				} else {
+					super.invalidate();
+				}
+				this.onImageUpdate?.();
+			} catch (error) {
+				logger.warn("Assistant thinking renderer refresh failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			} finally {
+				this.#thinkingRenderRefreshQueued = false;
+			}
+		});
+	}
+
+	#renderThinkingExtensions(
+		message: AssistantMessage,
+		content: ThinkingContent,
+		contentIndex: number,
+		thinkingIndex: number,
+		text: string,
+	): ThinkingExtensionComponents {
+		const append: Component[] = [];
+		let replacement: Component | undefined;
+		for (const renderer of this.thinkingRenderers) {
+			let rerunRenderersOnRequest = true;
+			try {
+				const result: AssistantThinkingRenderResult = renderer(
 					{
+						message: {
+							timestamp: message.timestamp,
+							responseId: message.responseId,
+							api: message.api,
+							provider: message.provider,
+							model: message.model,
+						},
+						content: {
+							itemId: content.itemId,
+							thinkingSignature: content.thinkingSignature,
+						},
 						contentIndex,
 						thinkingIndex,
 						text,
-						requestRender: () => this.onImageUpdate?.(),
+						requestRender: () => this.#requestThinkingRender(rerunRenderersOnRequest),
 					},
 					theme,
 				);
-				if (component) {
-					this.#contentContainer.addChild(component);
+				if (!result) continue;
+				if (isComponent(result)) {
+					rerunRenderersOnRequest = false;
+					append.push(result);
+					continue;
 				}
-			} catch {
-				// Ignore extension renderer failures and keep the original thinking block visible.
+				if (!isStructuredThinkingResult(result)) {
+					logger.warn("Assistant thinking renderer returned an invalid result", {
+						contentIndex,
+						thinkingIndex,
+					});
+					continue;
+				}
+				if (result.type === "replace") {
+					if (replacement) {
+						logger.warn("Assistant thinking replacement renderer ignored because one is already active", {
+							contentIndex,
+							thinkingIndex,
+						});
+						continue;
+					}
+					rerunRenderersOnRequest = false;
+					replacement = result.component;
+					continue;
+				}
+				rerunRenderersOnRequest = false;
+				append.push(result.component);
+			} catch (error) {
+				logger.warn("Assistant thinking renderer failed", {
+					contentIndex,
+					thinkingIndex,
+					error: error instanceof Error ? error.message : String(error),
+				});
 			}
 		}
+		return { append, replace: replacement };
 	}
 
 	#computeShapeKey(message: AssistantMessage): string {
@@ -720,19 +828,9 @@ export class AssistantMessageComponent extends Container {
 		) {
 			return false;
 		}
-		// Extension stability: if thinking renderers exist and any tracked thinking
-		// block's text changed, extensions may produce a different child count.
-		if (this.thinkingRenderers.length > 0 && this.#fastPathItems) {
-			for (const item of this.#fastPathItems) {
-				if (item.blockType === "thinking") {
-					const content = message.content[item.contentIndex];
-					if (content?.type === "thinking") {
-						const display = resolveThinkingDisplay(content, this.proseOnlyThinking);
-						if (display.text !== item.lastText) return false;
-					}
-				}
-			}
-		}
+		// Thinking renderers are arbitrary extension code: their output can change
+		// even when the message shape and text are identical.
+		if (this.thinkingRenderers.length > 0) return false;
 		return true;
 	}
 
@@ -769,6 +867,7 @@ export class AssistantMessageComponent extends Container {
 				this.#fastPathItems = undefined;
 				return false;
 			}
+			item.md.transientRenderCache = transient;
 			if (newText !== item.lastText) {
 				// Only the last (actively streaming) block may mutate in place: a
 				// delta into an earlier block would invalidate rows the settled
@@ -848,6 +947,7 @@ export class AssistantMessageComponent extends Container {
 		// Fast path: reuse Markdown children when shape is stable during streaming
 		if (this.#tryFastPathUpdate(message, opts)) return;
 
+		this.#visibleThinkingUsesRenderers = false;
 		// Clear content container
 		this.#contentContainer.clear();
 		this.#thinkingDots = undefined;
@@ -898,16 +998,25 @@ export class AssistantMessageComponent extends Container {
 							(c.type === "thinking" && resolveThinkingDisplay(c, this.proseOnlyThinking).visible),
 					);
 
-				// Thinking traces in thinkingText color, italic
-				const md = new Markdown(thinkingText, 1, 0, getMarkdownTheme(), {
-					color: (text: string) => theme.fg("thinkingText", text),
-					italic: true,
-				});
-				md.transientRenderCache = this.#lastUpdateTransient;
-				this.#contentContainer.addChild(md);
-				captureItems?.push({ md, contentIndex: i, blockType: "thinking", lastText: thinkingText });
-				this.#appendThinkingExtensions(i, thinkingIndex, thinkingText);
-				hasRenderedContent = true;
+				if (this.thinkingRenderers.length > 0) {
+					this.#visibleThinkingUsesRenderers = true;
+				}
+				const thinkingComponents = this.#renderThinkingExtensions(message, content, i, thinkingIndex, thinkingText);
+				if (thinkingComponents.replace) {
+					this.#contentContainer.addChild(thinkingComponents.replace);
+				} else {
+					// Thinking traces in thinkingText color, italic
+					const md = new Markdown(thinkingText, 1, 0, getMarkdownTheme(), {
+						color: (text: string) => theme.fg("thinkingText", text),
+						italic: true,
+					});
+					md.transientRenderCache = this.#lastUpdateTransient;
+					this.#contentContainer.addChild(md);
+					captureItems?.push({ md, contentIndex: i, blockType: "thinking", lastText: thinkingText });
+				}
+				for (const component of thinkingComponents.append) {
+					this.#contentContainer.addChild(component);
+				}
 				thinkingIndex += 1;
 				if (hasVisibleContentAfter) {
 					this.#contentContainer.addChild(new Spacer(1));

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -196,6 +196,9 @@ function isStructuredThinkingResult(
 
 interface ThinkingRendererCache {
 	text: string;
+	responseId: string | undefined;
+	itemId: string | undefined;
+	thinkingSignature: string | undefined;
 	entries: Array<{ result: AssistantThinkingRenderResult; dirty: boolean } | undefined>;
 }
 /**
@@ -741,8 +744,20 @@ export class AssistantMessageComponent extends Container {
 	): ThinkingExtensionComponents {
 		const key = `${contentIndex}:${thinkingIndex}`;
 		let cache = this.#thinkingRendererCache.get(key);
-		if (!cache || cache.text !== text) {
-			cache = { text, entries: [] };
+		if (
+			!cache ||
+			cache.text !== text ||
+			cache.responseId !== message.responseId ||
+			cache.itemId !== content.itemId ||
+			cache.thinkingSignature !== content.thinkingSignature
+		) {
+			cache = {
+				text,
+				responseId: message.responseId,
+				itemId: content.itemId,
+				thinkingSignature: content.thinkingSignature,
+				entries: [],
+			};
 			this.#thinkingRendererCache.set(key, cache);
 		}
 
@@ -860,7 +875,15 @@ export class AssistantMessageComponent extends Container {
 				const display = resolveThinkingDisplay(content, this.proseOnlyThinking);
 				if (display.visible && !this.hideThinkingBlock) {
 					const cache = this.#thinkingRendererCache.get(`${contentIndex}:${thinkingIndex}`);
-					if (!cache || cache.text !== display.text) return false;
+					if (
+						!cache ||
+						cache.text !== display.text ||
+						cache.responseId !== message.responseId ||
+						cache.itemId !== content.itemId ||
+						cache.thinkingSignature !== content.thinkingSignature
+					) {
+						return false;
+					}
 					if (cache.entries.some(entry => entry?.dirty)) return false;
 				}
 				thinkingIndex++;

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -433,8 +433,6 @@ export class TranscriptContainer
 			const previous = previousSegments[i];
 			const finalized = isBlockFinalized(child);
 			const commitAllowed = canCommitLiveBlock(child);
-			const inLiveRegion = i >= liveStartIndex;
-			const liveBoundary = !finalized || !commitAllowed;
 			const version = getBlockVersion(child);
 			const committedReusable =
 				previous !== undefined &&

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -389,9 +389,9 @@ export class TranscriptContainer
 				liveStartIndex = i;
 				hasLiveBlock = true;
 				this.#nativeScrollbackLiveRegionPinned =
-					(
-						this.children[i] as Component & Partial<NativeScrollbackLiveRegion>
-					).isNativeScrollbackLiveRegionPinned?.() === true;
+					!canCommitLiveBlock(child) ||
+					(child as Component & Partial<NativeScrollbackLiveRegion>).isNativeScrollbackLiveRegionPinned?.() ===
+						true;
 				break;
 			}
 		}

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -17,6 +17,13 @@ import { isToolActivityComponent } from "./tool-activity";
 interface FinalizableBlock {
 	isTranscriptBlockFinalized?(): boolean;
 	/**
+	 * Blocks may opt out of native scrollback commit promotion even when their
+	 * current frame is otherwise eligible. Replacement thinking renderers own
+	 * previously rendered rows and can re-layout them after async state changes,
+	 * so those rows must stay in the repaintable live region.
+	 */
+	isTranscriptBlockAppendOnly?(): boolean;
+	/**
 	 * Monotonic content version for blocks that can still mutate *after*
 	 * reporting finalized (e.g. `AssistantMessageComponent`: the inline error
 	 * restored at the next turn's `agent_start`, late tool-result images). The
@@ -63,6 +70,13 @@ function isBlockFinalized(child: Component): boolean {
 function getBlockVersion(child: Component): number | undefined {
 	const fn = (child as Component & FinalizableBlock).getTranscriptBlockVersion;
 	return fn ? fn.call(child) : undefined;
+}
+function canCommitLiveBlock(child: Component): boolean {
+	const fn = (child as Component & FinalizableBlock).isTranscriptBlockAppendOnly;
+	return fn ? fn.call(child) : true;
+}
+function isLiveRegionBoundary(child: Component): boolean {
+	return !isBlockFinalized(child) || !canCommitLiveBlock(child);
 }
 
 /** Clamped read of a block's declared settled rows (see {@link FinalizableBlock}). */
@@ -282,12 +296,13 @@ export class TranscriptContainer
 		const index = children.indexOf(component);
 		if (index < 0) return false;
 		for (let i = 0; i <= index; i++) {
-			if (!isBlockFinalized(children[i]!)) return true;
+			if (isLiveRegionBoundary(children[i]!)) return true;
 		}
-		// Every block at/before `index` finalized: the live region starts at the
-		// first unfinalized block below it, or at the last child when none exists.
+		// Every block at/before `index` finalized and can commit: the live region
+		// starts at the first live/non-committable block below it, or at the last
+		// child when none exists.
 		for (let i = index + 1; i < children.length; i++) {
-			if (!isBlockFinalized(children[i]!)) return false;
+			if (isLiveRegionBoundary(children[i]!)) return false;
 		}
 		return index === children.length - 1;
 	}
@@ -358,16 +373,19 @@ export class TranscriptContainer
 			sealCommittedSnapshot(previous.component);
 		}
 
-		// The commit boundary stops at the earliest still-mutating block. A
-		// block that has not finalized must gate it: out-of-band inserts
-		// (TTSR/todo cards) can append a finalized block *below* a tool that is
-		// still awaiting its result, and committing rows there would strand the
-		// tool's history rows on a mid-stream preview the late result never
-		// reaches.
+		// The commit boundary stops at the earliest still-mutating or explicitly
+		// non-committable block. A block that has not finalized must gate it:
+		// out-of-band inserts (TTSR/todo cards) can append a finalized block
+		// *below* a tool that is still awaiting its result, and committing rows
+		// there would strand the tool's history rows on a mid-stream preview the
+		// late result never reaches. A finalized block may also opt out when it can
+		// still repaint prior rows through async renderer state, e.g. replacement-
+		// capable assistant thinking.
 		let liveStartIndex = -1;
 		let hasLiveBlock = false;
 		for (let i = 0; i < count; i++) {
-			if (!isBlockFinalized(this.children[i]!)) {
+			const child = this.children[i]!;
+			if (isLiveRegionBoundary(child)) {
 				liveStartIndex = i;
 				hasLiveBlock = true;
 				this.#nativeScrollbackLiveRegionPinned =
@@ -414,6 +432,9 @@ export class TranscriptContainer
 			// post-finalize re-layouts, and expand toggles remain visible.
 			const previous = previousSegments[i];
 			const finalized = isBlockFinalized(child);
+			const commitAllowed = canCommitLiveBlock(child);
+			const inLiveRegion = i >= liveStartIndex;
+			const liveBoundary = !finalized || !commitAllowed;
 			const version = getBlockVersion(child);
 			const committedReusable =
 				previous !== undefined &&
@@ -480,17 +501,20 @@ export class TranscriptContainer
 			const sep = row > 0 && !isPlainBlank(lines[row - 1]!) ? 1 : 0;
 
 			// The separator before the first live block stays in the committed
-			// prefix (it is deterministic once the prior block's body is
-			// settled); the boundary then extends through the live block's
-			// declared settled rows, mapped from its raw render into the
-			// stripped contribution.
+			// prefix (it is deterministic once the prior block's body is settled).
+			// Append-only live blocks may extend the exactness boundary through
+			// declared settled rows, mapped from raw render into stripped
+			// contribution; non-committable blocks keep the boundary at their first
+			// content row so replacement-capable renderers stay in the live region.
 			if (hasLiveBlock && i === liveStartIndex) {
 				let settled = 0;
-				const settledRaw = getBlockSettledRows(child);
-				if (settledRaw > 0) {
-					let lead = 0;
-					while (lead < raw.length && isPlainBlank(raw[lead]!)) lead++;
-					settled = Math.max(0, Math.min(contribution.length, settledRaw - lead));
+				if (commitAllowed) {
+					const settledRaw = getBlockSettledRows(child);
+					if (settledRaw > 0) {
+						let lead = 0;
+						while (lead < raw.length && isPlainBlank(raw[lead]!)) lead++;
+						settled = Math.max(0, Math.min(contribution.length, settledRaw - lead));
+					}
 				}
 				this.#nativeScrollbackLiveRegionStart = row + sep + settled;
 			}

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -331,6 +331,41 @@ describe("AssistantMessageComponent thinking renderers", () => {
 		expect(rendered).not.toContain("translation loading");
 	});
 
+	it("preserves mounted renderer components while later answer text streams", () => {
+		let rendererCalls = 0;
+		let mountedNote: Text | undefined;
+		const component = new AssistantMessageComponent(
+			{
+				...createAssistantMessage(""),
+				content: [{ type: "thinking", thinking: "Stable thinking." }],
+			},
+			false,
+			undefined,
+			[
+				() => {
+					rendererCalls += 1;
+					const note = new Text("translation loading", 1, 0);
+					mountedNote ??= note;
+					return note;
+				},
+			],
+		);
+
+		mountedNote?.setText("translation ready");
+		component.updateContent({
+			...createAssistantMessage("Answer"),
+			content: [
+				{ type: "thinking", thinking: "Stable thinking." },
+				{ type: "text", text: "Answer" },
+			],
+		});
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendererCalls).toBe(1);
+		expect(rendered).toContain("translation ready");
+		expect(rendered).not.toContain("translation loading");
+	});
+
 	it("mounts a replacement when an async renderer becomes ready after streaming stops", async () => {
 		let ready = false;
 		let renderRequests = 0;

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -150,7 +150,64 @@ describe("AssistantMessageComponent settled-row commit boundary", () => {
 
 describe("AssistantMessageComponent thinking renderers", () => {
 	it("renders all extension outputs below visible thinking blocks in registration order", () => {
-		const contexts: Array<{ contentIndex: number; thinkingIndex: number; text: string }> = [];
+		const contexts: Array<{
+			message: { timestamp: number; responseId?: string; api: string; provider: string; model: string };
+			content: { itemId?: string; thinkingSignature?: string };
+			contentIndex: number;
+			thinkingIndex: number;
+			text: string;
+		}> = [];
+		const message = {
+			...createAssistantMessage(""),
+			responseId: "resp-1",
+			content: [
+				{
+					type: "thinking" as const,
+					thinking: "I should inspect the input.",
+					itemId: "item-1",
+					thinkingSignature: "sig-1",
+				},
+			],
+		};
+		const component = new AssistantMessageComponent(message, false, undefined, [
+			context => {
+				contexts.push({
+					message: context.message,
+					content: context.content,
+					contentIndex: context.contentIndex,
+					thinkingIndex: context.thinkingIndex,
+					text: context.text,
+				});
+				return new Text("first note", 1, 0);
+			},
+			() => new Text("second note", 1, 0),
+		]);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).toContain("I should inspect the input.");
+		expect(rendered.indexOf("I should inspect the input.")).toBeLessThan(rendered.indexOf("first note"));
+		expect(rendered.indexOf("first note")).toBeLessThan(rendered.indexOf("second note"));
+		expect(contexts).toEqual([
+			{
+				message: {
+					timestamp: message.timestamp,
+					responseId: "resp-1",
+					api: "anthropic-messages",
+					provider: "anthropic",
+					model: "claude-sonnet-4-5",
+				},
+				content: {
+					itemId: "item-1",
+					thinkingSignature: "sig-1",
+				},
+				contentIndex: 0,
+				thinkingIndex: 0,
+				text: "I should inspect the input.",
+			},
+		]);
+	});
+
+	it("preserves legacy component returns that define structured result fields", () => {
 		const component = new AssistantMessageComponent(
 			{
 				...createAssistantMessage(""),
@@ -159,23 +216,62 @@ describe("AssistantMessageComponent thinking renderers", () => {
 			false,
 			undefined,
 			[
-				context => {
-					contexts.push({
-						contentIndex: context.contentIndex,
-						thinkingIndex: context.thinkingIndex,
-						text: context.text,
-					});
-					return new Text("first note", 1, 0);
-				},
-				() => new Text("second note", 1, 0),
+				() =>
+					Object.assign(new Text("legacy component with structured fields", 1, 0), {
+						type: "replace",
+						component: new Text("wrong structured replacement", 1, 0),
+					}),
 			],
 		);
 
 		const rendered = Bun.stripANSI(component.render(120).join("\n"));
 		expect(rendered).toContain("I should inspect the input.");
-		expect(rendered.indexOf("I should inspect the input.")).toBeLessThan(rendered.indexOf("first note"));
-		expect(rendered.indexOf("first note")).toBeLessThan(rendered.indexOf("second note"));
-		expect(contexts).toEqual([{ contentIndex: 0, thinkingIndex: 0, text: "I should inspect the input." }]);
+		expect(rendered).toContain("legacy component with structured fields");
+		expect(rendered).not.toContain("wrong structured replacement");
+	});
+
+	it("lets extension renderers replace the default thinking block while preserving appenders", () => {
+		const component = new AssistantMessageComponent(
+			{
+				...createAssistantMessage(""),
+				content: [{ type: "thinking", thinking: "Sensitive chain of thought." }],
+			},
+			false,
+			undefined,
+			[
+				() => ({ type: "append", component: new Text("early audit note", 1, 0) }),
+				() => ({ type: "replace", component: new Text("redacted outline", 1, 0) }),
+				() => new Text("legacy appended note", 1, 0),
+			],
+		);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).not.toContain("Sensitive chain of thought.");
+		expect(rendered).toContain("redacted outline");
+		expect(rendered).toContain("early audit note");
+		expect(rendered).toContain("legacy appended note");
+		expect(rendered.indexOf("redacted outline")).toBeLessThan(rendered.indexOf("early audit note"));
+		expect(rendered.indexOf("early audit note")).toBeLessThan(rendered.indexOf("legacy appended note"));
+	});
+
+	it("uses the first replacement renderer when multiple extensions try to replace thinking", () => {
+		const component = new AssistantMessageComponent(
+			{
+				...createAssistantMessage(""),
+				content: [{ type: "thinking", thinking: "Original thinking." }],
+			},
+			false,
+			undefined,
+			[
+				() => ({ type: "replace", component: new Text("first replacement", 1, 0) }),
+				() => ({ type: "replace", component: new Text("second replacement", 1, 0) }),
+			],
+		);
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(rendered).not.toContain("Original thinking.");
+		expect(rendered).toContain("first replacement");
+		expect(rendered).not.toContain("second replacement");
 	});
 
 	it("keeps original thinking visible when an extension renderer throws", () => {
@@ -198,7 +294,7 @@ describe("AssistantMessageComponent thinking renderers", () => {
 		expect(rendered).not.toContain("renderer failed");
 	});
 
-	it("keeps async renderer components mounted when they request a render", () => {
+	it("keeps async renderer components mounted when they request a render", async () => {
 		let renderRequests = 0;
 		let rendererCalls = 0;
 		let mountedNote: Text | undefined;
@@ -226,12 +322,51 @@ describe("AssistantMessageComponent thinking renderers", () => {
 		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("translation loading");
 		mountedNote?.setText("translation ready");
 		requestRender?.();
+		await Promise.resolve();
 
 		const rendered = Bun.stripANSI(component.render(120).join("\n"));
 		expect(renderRequests).toBe(1);
 		expect(rendererCalls).toBe(1);
 		expect(rendered).toContain("translation ready");
 		expect(rendered).not.toContain("translation loading");
+	});
+
+	it("mounts a replacement when an async renderer becomes ready after streaming stops", async () => {
+		let ready = false;
+		let renderRequests = 0;
+		let rendererCalls = 0;
+		let requestRender: (() => void) | undefined;
+		const component = new AssistantMessageComponent(
+			{
+				...createAssistantMessage(""),
+				content: [{ type: "thinking", thinking: "Sensitive async thinking." }],
+			},
+			false,
+			() => {
+				renderRequests += 1;
+			},
+			[
+				context => {
+					rendererCalls += 1;
+					requestRender = context.requestRender;
+					if (!ready) return undefined;
+					return { type: "replace", component: new Text(`redacted ${context.text.length}`, 1, 0) };
+				},
+			],
+		);
+
+		expect(Bun.stripANSI(component.render(120).join("\n"))).toContain("Sensitive async thinking.");
+		expect(rendererCalls).toBe(1);
+
+		ready = true;
+		requestRender?.();
+		await Promise.resolve();
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(renderRequests).toBe(1);
+		expect(rendererCalls).toBe(2);
+		expect(rendered).toContain("redacted 25");
+		expect(rendered).not.toContain("Sensitive async thinking.");
 	});
 
 	it("does not invoke extension renderers when thinking is hidden", () => {

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -334,26 +334,24 @@ describe("AssistantMessageComponent thinking renderers", () => {
 	it("preserves mounted renderer components while later answer text streams", () => {
 		let rendererCalls = 0;
 		let mountedNote: Text | undefined;
-		const component = new AssistantMessageComponent(
-			{
-				...createAssistantMessage(""),
-				content: [{ type: "thinking", thinking: "Stable thinking." }],
+		const componentMessage: AssistantMessage = {
+			...createAssistantMessage(""),
+			content: [{ type: "thinking", thinking: "Stable thinking." }],
+		};
+		const component = new AssistantMessageComponent(componentMessage, false, undefined, [
+			() => {
+				rendererCalls += 1;
+				const note = new Text("translation loading", 1, 0);
+				mountedNote ??= note;
+				return note;
 			},
-			false,
-			undefined,
-			[
-				() => {
-					rendererCalls += 1;
-					const note = new Text("translation loading", 1, 0);
-					mountedNote ??= note;
-					return note;
-				},
-			],
-		);
+		]);
 
 		mountedNote?.setText("translation ready");
+		const nextMessage = createAssistantMessage("Answer");
 		component.updateContent({
-			...createAssistantMessage("Answer"),
+			...nextMessage,
+			timestamp: componentMessage.timestamp,
 			content: [
 				{ type: "thinking", thinking: "Stable thinking." },
 				{ type: "text", text: "Answer" },

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -366,6 +366,42 @@ describe("AssistantMessageComponent thinking renderers", () => {
 		expect(rendered).not.toContain("translation loading");
 	});
 
+	it("reruns renderers when provider metadata arrives without a text change", () => {
+		const signatures: Array<string | undefined> = [];
+		const component = new AssistantMessageComponent(
+			{
+				...createAssistantMessage(""),
+				content: [{ type: "thinking", thinking: "Stable thinking." }],
+			},
+			false,
+			undefined,
+			[
+				context => {
+					signatures.push(context.content.thinkingSignature);
+					return new Text(context.content.thinkingSignature ?? "pending signature", 1, 0);
+				},
+			],
+		);
+
+		component.updateContent({
+			...createAssistantMessage(""),
+			responseId: "response-final",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Stable thinking.",
+					itemId: "reasoning-item",
+					thinkingSignature: "signature-final",
+				},
+			],
+		});
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(signatures).toEqual([undefined, "signature-final"]);
+		expect(rendered).toContain("signature-final");
+		expect(rendered).not.toContain("pending signature");
+	});
+
 	it("mounts a replacement when an async renderer becomes ready after streaming stops", async () => {
 		let ready = false;
 		let renderRequests = 0;

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -400,9 +400,33 @@ describe("AssistantMessageComponent thinking renderers", () => {
 		expect(rendered).not.toContain("pending signature");
 	});
 
+	it("reruns renderers when the effective provider model changes", () => {
+		const models: string[] = [];
+		const componentMessage: AssistantMessage = {
+			...createAssistantMessage(""),
+			content: [{ type: "thinking", thinking: "Stable thinking." }],
+		};
+		const component = new AssistantMessageComponent(componentMessage, false, undefined, [
+			context => {
+				models.push(context.message.model);
+				return new Text(context.message.model, 1, 0);
+			},
+		]);
+
+		component.updateContent({
+			...componentMessage,
+			model: "claude-opus-4-8",
+		});
+
+		const rendered = Bun.stripANSI(component.render(120).join("\n"));
+		expect(models).toEqual(["claude-sonnet-4-5", "claude-opus-4-8"]);
+		expect(rendered).toContain("claude-opus-4-8");
+		expect(rendered).not.toContain("claude-sonnet-4-5");
+	});
 	it("mounts a replacement when an async renderer becomes ready after streaming stops", async () => {
 		let ready = false;
 		let renderRequests = 0;
+
 		let rendererCalls = 0;
 		let requestRender: (() => void) | undefined;
 		const component = new AssistantMessageComponent(
@@ -436,6 +460,31 @@ describe("AssistantMessageComponent thinking renderers", () => {
 		expect(rendererCalls).toBe(2);
 		expect(rendered).toContain("redacted 25");
 		expect(rendered).not.toContain("Sensitive async thinking.");
+	});
+	it("ignores late renderer refreshes after disposal", async () => {
+		let rendererCalls = 0;
+		let requestRender: (() => void) | undefined;
+		const component = new AssistantMessageComponent(
+			{
+				...createAssistantMessage(""),
+				content: [{ type: "thinking", thinking: "Pending thinking." }],
+			},
+			false,
+			undefined,
+			[
+				context => {
+					rendererCalls += 1;
+					requestRender = context.requestRender;
+					return undefined;
+				},
+			],
+		);
+
+		component.dispose();
+		requestRender?.();
+		await Promise.resolve();
+
+		expect(rendererCalls).toBe(1);
 	});
 
 	it("does not invoke extension renderers when thinking is hidden", () => {

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -326,6 +326,23 @@ describe("TranscriptContainer", () => {
 		expect(replacementContainer.getNativeScrollbackLiveRegionStart()).toBe(0);
 	});
 
+	it("pins finalized replacement-capable thinking above the viewport", () => {
+		const container = new TranscriptContainer();
+		const assistant = new AssistantMessageComponent(undefined, false, undefined, [() => undefined]);
+		assistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "raw final thinking" }],
+			}),
+		);
+		assistant.markTranscriptBlockFinalized();
+		container.addChild(assistant);
+
+		container.render(80);
+
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(0);
+		expect(container.isNativeScrollbackLiveRegionPinned()).toBe(true);
+	});
+
 	it("keeps finalized replacement-capable assistant thinking in the live region above later finalized blocks", () => {
 		const container = new TranscriptContainer();
 		const assistant = new AssistantMessageComponent(undefined, false, undefined, [() => undefined]);

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -125,6 +125,28 @@ class VersionedFinalizedBlock implements Component {
 	}
 }
 
+class NonCommittableFinalizedBlock implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = lines;
+	}
+
+	isTranscriptBlockFinalized(): boolean {
+		return true;
+	}
+
+	isTranscriptBlockAppendOnly(): boolean {
+		return false;
+	}
+
+	invalidate(): void {}
+
+	render(_width: number): string[] {
+		return [...this.#lines];
+	}
+}
+
 beforeAll(() => {
 	initTheme();
 });
@@ -204,6 +226,143 @@ describe("TranscriptContainer", () => {
 		b.set(["b1", "b2"]);
 		expect(container.render(40)).toEqual(["a1", "a2", "", "b1", "b2"]);
 		expect(container.getNativeScrollbackLiveRegionStart()).toBeUndefined();
+	});
+
+	it("keeps replacement-rendered assistant thinking in the live region", () => {
+		const defaultContainer = new TranscriptContainer();
+		const defaultAssistant = new AssistantMessageComponent();
+		defaultAssistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "Final append-only thinking." }],
+			}),
+		);
+		defaultAssistant.markTranscriptBlockFinalized();
+		defaultContainer.addChild(defaultAssistant);
+		defaultContainer.render(80);
+		expect(defaultContainer.getNativeScrollbackLiveRegionStart()).toBeUndefined();
+
+		const replacementContainer = new TranscriptContainer();
+		const replacementAssistant = new AssistantMessageComponent(undefined, false, undefined, [
+			({ text }) => ({ type: "replace", component: new Text(`redacted${".".repeat(text.length)}`, 1, 0) }),
+		]);
+		replacementAssistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "x" }],
+			}),
+		);
+		replacementContainer.addChild(replacementAssistant);
+		replacementContainer.render(80);
+		replacementAssistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "xx" }],
+			}),
+		);
+
+		const rendered = plain(replacementContainer.render(80));
+		expect(rendered).toContain("redacted..");
+		expect(rendered).not.toContain("xx");
+		expect(replacementContainer.getNativeScrollbackLiveRegionStart()).toBe(0);
+	});
+
+	it("keeps pending replacement-capable assistant thinking in the live region", () => {
+		let ready = false;
+		const container = new TranscriptContainer();
+		const assistant = new AssistantMessageComponent(undefined, false, undefined, [
+			({ text }) => (ready ? { type: "replace", component: new Text(`redacted ${text.length}`, 1, 0) } : undefined),
+		]);
+		assistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "raw" }],
+			}),
+		);
+		container.addChild(assistant);
+		container.render(80);
+		assistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "raw grows" }],
+			}),
+		);
+
+		expect(plain(container.render(80))).toContain("raw grows");
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(0);
+
+		ready = true;
+		assistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "raw grows" }],
+			}),
+		);
+
+		const rendered = plain(container.render(80));
+		expect(rendered).toContain("redacted 9");
+		expect(rendered).not.toContain("raw grows");
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(0);
+	});
+	it("keeps finalized replacement-capable assistant thinking in the live region", () => {
+		const defaultContainer = new TranscriptContainer();
+		const defaultAssistant = new AssistantMessageComponent();
+		defaultAssistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "Final append-only thinking." }],
+			}),
+		);
+		defaultAssistant.markTranscriptBlockFinalized();
+		defaultContainer.addChild(defaultAssistant);
+		defaultContainer.render(80);
+		expect(defaultContainer.getNativeScrollbackLiveRegionStart()).toBeUndefined();
+
+		const replacementContainer = new TranscriptContainer();
+		const replacementAssistant = new AssistantMessageComponent(undefined, false, undefined, [() => undefined]);
+		replacementAssistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "raw final thinking" }],
+			}),
+		);
+		replacementAssistant.markTranscriptBlockFinalized();
+		replacementContainer.addChild(replacementAssistant);
+
+		const rendered = plain(replacementContainer.render(80));
+		expect(rendered).toContain("raw final thinking");
+		expect(replacementContainer.getNativeScrollbackLiveRegionStart()).toBe(0);
+	});
+
+	it("keeps finalized replacement-capable assistant thinking in the live region above later finalized blocks", () => {
+		const container = new TranscriptContainer();
+		const assistant = new AssistantMessageComponent(undefined, false, undefined, [() => undefined]);
+		assistant.updateContent(
+			makeAssistantMessage({
+				content: [{ type: "thinking", thinking: "raw final thinking" }],
+			}),
+		);
+		assistant.markTranscriptBlockFinalized();
+		container.addChild(assistant);
+		container.addChild(new MutableBlock(["next finalized block"]));
+
+		const rendered = plain(container.render(80));
+		expect(rendered).toContain("raw final thinking");
+		expect(rendered).toContain("next finalized block");
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(0);
+	});
+
+	it("treats blocks below finalized non-committable blocks as live", () => {
+		const container = new TranscriptContainer();
+		const volatile = new NonCommittableFinalizedBlock(["volatile"]);
+		const card = new MutableBlock(["notification"]);
+		container.addChild(volatile);
+		container.addChild(card);
+
+		expect(container.render(40)).toEqual(["volatile", "", "notification"]);
+		expect(container.isBlockInLiveRegion(card)).toBe(true);
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(0);
+	});
+
+	it("pins the live region at empty finalized non-committable blocks", () => {
+		const container = new TranscriptContainer();
+		container.addChild(new NonCommittableFinalizedBlock([]));
+		container.addChild(new MutableBlock(["later finalized block"]));
+
+		expect(container.render(40)).toEqual(["later finalized block"]);
+		expect(container.getNativeScrollbackLiveRegionStart()).toBe(0);
 	});
 
 	it("keeps an unfinalized block below the seam when a finalized block is appended below it", () => {


### PR DESCRIPTION
## Summary

Rerolls the assistant thinking renderer replacement API for #1728 against current `main`.

Thinking renderers now support:

- `Component`: legacy append behavior below the default thinking Markdown.
- `{ type: "append", component }`: explicit append behavior.
- `{ type: "replace", component }`: suppresses the default thinking Markdown for that thinking block and renders the replacement component instead.

## Details

- Passes parent assistant metadata and provider thinking content metadata to renderers so async/stateful renderers can build stable keys without colliding across transcript history.
- Keeps legacy component returns compatible by detecting TUI components before structured result objects.
- Uses first-replacement-wins when multiple renderers try to replace the same thinking block, while preserving append renderers after replacements.
- Preserves `requestRender()` semantics for both mounted async components and late `undefined` -> append/replace renderer output.
- Keeps replacement-capable visible thinking blocks in the repaintable live region so late async replacement cannot leave stale raw thinking rows in native scrollback.
- Updates extension docs and the coding-agent changelog.

## Verification

```sh
bun test packages/coding-agent/test/modes/components/transcript-container.test.ts packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
bun --cwd=packages/coding-agent run check:types
bun --cwd=packages/coding-agent run check:docs
```

Results:

- `60 pass`, `0 fail`, `182 expect() calls`
- `check:types` passed
- `check:docs` passed (`Docs index fresh for 121 docs`)

Closes #1728.

Previous stale PR: #2340.