### PR TITLE
fix(rpc): include context usage in session stats

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `get_session_stats` RPC responses to include context-window usage so RPC clients can render context meters.
+
 ## [16.3.9] - 2026-07-06
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -933,6 +933,7 @@ export interface SessionStats {
 	};
 	premiumRequests: number;
 	cost: number;
+	contextUsage?: ContextUsage;
 }
 
 /** Advisor statistics for /advisor status command. */
@@ -15212,6 +15213,7 @@ export class AgentSession {
 			},
 			cost: totalCost,
 			premiumRequests: totalPremiumRequests,
+			contextUsage: this.getContextUsage(),
 		};
 	}
 

--- a/packages/coding-agent/test/agent-session-stats.test.ts
+++ b/packages/coding-agent/test/agent-session-stats.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, UserMessage } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("AgentSession session stats", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+
+	beforeAll(async () => {
+		tempDir = TempDir.createSync("@pi-session-stats-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(() => {
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		session = undefined;
+	});
+
+	it("includes context usage available from the active session", () => {
+		const model = modelRegistry.getAll().find(candidate => candidate.contextWindow && candidate.contextWindow > 0);
+		if (!model?.contextWindow) {
+			throw new Error("Expected bundled model with a context window");
+		}
+
+		const userMessage: UserMessage = {
+			role: "user",
+			content: "Hello",
+			timestamp: Date.now(),
+		};
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "ok" }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 10,
+				output: 2,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 12,
+				cost: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					total: 0,
+				},
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [userMessage, assistantMessage],
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+		});
+
+		const directUsage = session.getContextUsage();
+		const stats = session.getSessionStats();
+
+		expect(directUsage).toEqual({
+			tokens: 10,
+			contextWindow: model.contextWindow,
+			percent: (10 / model.contextWindow) * 100,
+		});
+		expect(stats.contextUsage).toEqual(directUsage);
+	});
+});


### PR DESCRIPTION
## Repro
A focused `AgentSession` repro creates a session with an active model context window and one assistant turn, then compares `session.getContextUsage()` with `session.getSessionStats()`. Before the fix, `getContextUsage()` returned `{ tokens: 10, contextWindow: 1000, percent: 1 }` while `getSessionStats()` had no `contextUsage` own property, so the `get_session_stats` RPC response could not expose the context-window data.

## Cause
`packages/coding-agent/src/session/agent-session.ts` defined `SessionStats` without `contextUsage`, and `AgentSession.getSessionStats()` returned token totals, cost, and premium request counts without calling the existing `AgentSession.getContextUsage()` path that `get_state` already uses.

## Fix
- Added optional `contextUsage` to `SessionStats`.
- Returned `this.getContextUsage()` from `AgentSession.getSessionStats()` so `get_session_stats` includes the same context-window usage data available internally.
- Added a regression test covering `getSessionStats().contextUsage` against the direct `getContextUsage()` result.
- Added a coding-agent changelog entry.

## Verification
Ran `bun test packages/coding-agent/test/agent-session-stats.test.ts` (1 pass) and `bun run check` in `packages/coding-agent` (passed). `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #4668