### PR TITLE
feat(agent): per-prompt temperature override in prompt options

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -318,6 +318,10 @@ export interface AgentOptions {
 
 export interface AgentPromptOptions {
 	toolChoice?: ToolChoice;
+	/** Sampling-temperature override for this prompt run only. Absent = the agent's
+	 *  configured `temperature`; a number (including a literal 0) overrides it for this
+	 *  run, leaving the agent's persistent temperature untouched. */
+	temperature?: number;
 }
 
 /** Buffered Cursor exec-channel tool result waiting to be emitted after the assistant message. */
@@ -1120,7 +1124,7 @@ export class Agent {
 			model,
 			reasoning,
 			disableReasoning: this.#state.disableReasoning,
-			temperature: this.#temperature,
+			temperature: options?.temperature ?? this.#temperature,
 			topP: this.#topP,
 			topK: this.#topK,
 			minP: this.#minP,

--- a/packages/agent/test/per-prompt-temperature.test.ts
+++ b/packages/agent/test/per-prompt-temperature.test.ts
@@ -1,0 +1,57 @@
+// Per-prompt temperature override: a `temperature` on a single prompt run reaches the
+// provider request for that run only; absent leaves exact current behavior, and the
+// agent's persistent temperature is never mutated.
+import { describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+
+/** Wrap a mock stream so we record the `temperature` of each provider request, then delegate. */
+function capturingMock(responses: { content: string[] }[]) {
+	const mock = createMockModel({ responses });
+	const captured: (number | undefined)[] = [];
+	const streamFn = ((...args: unknown[]) => {
+		for (const arg of args) {
+			if (arg && typeof arg === "object" && "temperature" in arg) {
+				const t = (arg as { temperature?: unknown }).temperature;
+				if (typeof t === "number" || t === undefined) {
+					captured.push(t as number | undefined);
+					break;
+				}
+			}
+		}
+		return (mock.stream as (...a: unknown[]) => unknown)(...args);
+	}) as typeof mock.stream;
+	return { model: mock.model, streamFn, captured };
+}
+
+function newAgent(temperature: number, m: ReturnType<typeof capturingMock>): Agent {
+	return new Agent({
+		initialState: { model: m.model, systemPrompt: ["t"], tools: [], messages: [] },
+		temperature,
+		streamFn: m.streamFn,
+	});
+}
+
+describe("per-prompt temperature override", () => {
+	it("a temperature override reaches the provider request for that prompt only", async () => {
+		const m = capturingMock([{ content: ["ok"] }, { content: ["ok"] }]);
+		const agent = newAgent(0.2, m);
+
+		await agent.prompt("with override", { temperature: 0.9 });
+		expect(m.captured.at(-1)).toBe(0.9);
+		// the agent's persistent temperature is untouched by the per-run override
+		expect(agent.temperature).toBe(0.2);
+
+		// a subsequent prompt with NO override falls back to the agent temperature
+		await agent.prompt("no override");
+		expect(m.captured.at(-1)).toBe(0.2);
+	});
+
+	it("a literal 0 override is honored (not coalesced away to the agent temperature)", async () => {
+		const m = capturingMock([{ content: ["ok"] }]);
+		const agent = newAgent(0.7, m);
+		await agent.prompt("deterministic", { temperature: 0 });
+		expect(m.captured.at(-1)).toBe(0);
+		expect(agent.temperature).toBe(0.7);
+	});
+});

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -849,6 +849,9 @@ export interface PromptOptions {
 	attribution?: MessageAttribution;
 	/** Skip pre-send compaction checks for this prompt (internal use for maintenance flows). */
 	skipCompactionCheck?: boolean;
+	/** Sampling-temperature override for this single prompt, overriding the session
+	 *  temperature for one call only (a literal 0 is honored). Absent = session temperature. */
+	temperature?: number;
 }
 
 /** Options for AgentSession.followUp() */
@@ -7556,7 +7559,7 @@ export class AgentSession {
 	async #promptWithMessage(
 		message: AgentMessage,
 		expandedText: string,
-		options?: Pick<PromptOptions, "toolChoice" | "images" | "skipCompactionCheck"> & {
+		options?: Pick<PromptOptions, "toolChoice" | "images" | "skipCompactionCheck" | "temperature"> & {
 			prependMessages?: AgentMessage[];
 			skipPostPromptRecoveryWait?: boolean;
 		},
@@ -7715,7 +7718,10 @@ export class AgentSession {
 				return;
 			}
 
-			const agentPromptOptions = options?.toolChoice ? { toolChoice: options.toolChoice } : undefined;
+			const agentPromptOptions =
+				options?.toolChoice !== undefined || options?.temperature !== undefined
+					? { toolChoice: options?.toolChoice, temperature: options?.temperature }
+					: undefined;
 			const nonMessageTokens = computeNonMessageTokens(this);
 			const contextWindow = this.model?.contextWindow ?? 0;
 			const breakdown = this.getContextBreakdown({ contextWindow, pendingMessages: messages });
@@ -13753,7 +13759,10 @@ export class AgentSession {
 		this.#resolveRetry();
 	}
 
-	async #promptAgentWithIdleRetry(messages: AgentMessage[], options?: { toolChoice?: ToolChoice }): Promise<void> {
+	async #promptAgentWithIdleRetry(
+		messages: AgentMessage[],
+		options?: { toolChoice?: ToolChoice; temperature?: number },
+	): Promise<void> {
 		const deadline = Date.now() + 30_000;
 		for (;;) {
 			try {


### PR DESCRIPTION
## What

Adds an optional `temperature?: number` to `AgentPromptOptions` (packages/agent) and `PromptOptions` (packages/coding-agent), threaded through `prompt()` to the provider request for that single prompt run.

- **Absent ⇒ exact current behavior** — the agent's configured temperature is used, byte-identical request.
- A number — **including a literal `0`** — overrides sampling for that run only (`options?.temperature ?? this.#temperature`, so `0` is honored, not coalesced away).
- The agent's **persistent temperature is never mutated** by a per-run override.

## Why

Programmatic recovery and retry-with-diversity flows want to vary sampling for exactly one call — e.g. re-sampling a stuck/looping run at a raised temperature, or forcing a deterministic (`0`) re-issue — without touching session state. Today temperature is fixed at agent construction, so a single re-sample can't diverge. The prompt-options interface already carries per-call knobs (`toolChoice`, `userInitiated`), and this extends the same pattern with one optional field.

## Testing

- `packages/agent/test/per-prompt-temperature.test.ts` (new): asserts the override reaches the provider request for that run only, the very next un-overridden prompt falls back to the configured temperature, a literal `0` is honored, and the persistent temperature is untouched.
- `bun run check` exit 0; the new test 2/2 green on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)