### PR TITLE
Fix legacy plugin JSON import validation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy plugin validation for extension graphs that import JSON with `with { type: "json" }`, leaving JSON files on Bun's native loader instead of parsing them as JavaScript ([#4687](https://github.com/can1357/oh-my-pi/issues/4687)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1059,7 +1059,8 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 				let resolved: string | null = null;
 				let nextFollowsBareDependencies = followBareDependencies;
 				if (specifier.startsWith(".")) {
-					resolved = await realpathOrSelf(Bun.resolveSync(specifier, dir));
+					const candidate = Bun.resolveSync(specifier, dir);
+					resolved = hasSourceModuleExtension(candidate) ? await realpathOrSelf(candidate) : null;
 				} else if (specifier.startsWith("#")) {
 					resolved = await resolvePackageImportSpecifier(specifier, file);
 				} else if (
@@ -1078,7 +1079,10 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 						dependencyExtension === ".cjs" ||
 						dependencyExtension === ".cts" ||
 						((dependencyExtension === ".js" || dependencyExtension === ".jsx") && manifest?.type !== "module");
-					resolved = dependencyEntry && !isCommonJsEntry ? await realpathOrSelf(dependencyEntry) : null;
+					resolved =
+						dependencyEntry && hasSourceModuleExtension(dependencyEntry) && !isCommonJsEntry
+							? await realpathOrSelf(dependencyEntry)
+							: null;
 					nextFollowsBareDependencies = false;
 				}
 				if (resolved && !modules.has(resolved)) {

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -308,6 +308,22 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(mod.css).toBe(".x{color:red}");
 	});
 
+	it("leaves JSON import-attribute targets on Bun's native loader", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "json-import-ext", version: "1.0.0" }),
+			"prices.json": JSON.stringify({ input: 0.15 }),
+			"index.ts": [
+				'import prices from "./prices.json" with { type: "json" };',
+				"export const inputPrice = prices.input;",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { inputPrice: number };
+
+		expect(mod.inputPrice).toBe(0.15);
+	});
+
 	it("loads the extension's own node_modules deps natively while remapping legacy pi imports", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "dep-ext", version: "1.0.0" }),


### PR DESCRIPTION
## Repro
A minimal legacy plugin entry that imports `./data.json` with `with { type: "json" }` reproduced the failure through `loadLegacyPiModule()` with `bun /tmp/omp-json-import-repro.ts`: before the fix, Bun raised `BuildMessage: Expected ";" but found ":"` because the compat graph hook served the JSON file as JavaScript.

## Cause
`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` collected every relative `Bun.resolveSync()` target into the extension rewrite graph. That included `.json` files, so `installExtensionGraphHook()` intercepted the JSON module and `getLoader()` fell back to `"js"`, forcing Bun's per-module parser to parse raw JSON instead of using the native JSON loader.

## Fix
- Filter relative extension graph targets through `hasSourceModuleExtension()` before registering them with the rewrite hook.
- Apply the same source-module filter to extension-local bare dependency entries so non-source assets stay on Bun's native loaders.
- Add a `loadLegacyPiModule()` regression test for a temp extension importing JSON with `with { type: "json" }`.
- Add a coding-agent changelog entry for the plugin validation fix.

## Verification
`bun /tmp/omp-json-import-repro.ts` now prints `{ "value": true }`; `bun test packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts -t 'leaves JSON import-attribute targets on Bun'` passed with 1 test; `bun check` passed; `bun run fix` reported no fixes needed before commit. Fixes #4687