### PR TITLE
Fix broker-backed MCP OAuth refresh

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -4565,6 +4565,7 @@ export class AuthStorage {
 				throw error;
 			}
 			const updated: OAuthCredential = {
+				...attempted,
 				type: "oauth",
 				access: refreshed.access,
 				refresh: refreshed.refresh,

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -11,7 +11,7 @@ import { logger } from "@oh-my-pi/pi-utils";
 import type { SourceMeta } from "../capability/types";
 import { resolveConfigValue } from "../config/resolve-config-value";
 import type { CustomTool } from "../extensibility/custom-tools/types";
-import type { AuthStorage } from "../session/auth-storage";
+import { type AuthStorage, REMOTE_REFRESH_SENTINEL } from "../session/auth-storage";
 import {
 	connectToServer,
 	disconnectServer,
@@ -1252,26 +1252,45 @@ export class MCPManager {
 					opts?.forceRefresh || (credential.expires && Date.now() >= credential.expires - REFRESH_BUFFER_MS);
 				if (shouldRefresh && credential.refresh && tokenUrl) {
 					try {
-						const refreshed = await refreshMCPOAuthToken(
-							tokenUrl,
-							credential.refresh,
-							clientId,
-							clientSecret,
-							resource,
-							{ authorizationUrl, stripSameOriginResource: resourceIsFallback },
-						);
-						// Spread the old credential first so embedded refresh material survives rotation.
-						const refreshedCredential: MCPStoredOAuthCredential = {
-							...credential,
-							...refreshed,
-							tokenUrl,
-							clientId,
-							clientSecret,
-							resource: resourceIsFallback ? undefined : resource,
-							authorizationUrl,
-						};
-						await this.#authStorage.set(credentialId, refreshedCredential);
-						credential = refreshedCredential;
+						if (credential.refresh === REMOTE_REFRESH_SENTINEL) {
+							if (lookup.rowId === undefined) {
+								throw new Error(`Broker-backed MCP OAuth credential '${credentialId}' has no stored row id`);
+							}
+							const refreshedEntry = await this.#authStorage.forceRefreshCredentialById(lookup.rowId);
+							if (refreshedEntry.credential.type !== "oauth") {
+								throw new Error(`Broker refresh returned non-OAuth credential for '${credentialId}'`);
+							}
+							credential = {
+								...credential,
+								...refreshedEntry.credential,
+								tokenUrl,
+								clientId,
+								clientSecret,
+								resource: resourceIsFallback ? undefined : resource,
+								authorizationUrl,
+							};
+						} else {
+							const refreshed = await refreshMCPOAuthToken(
+								tokenUrl,
+								credential.refresh,
+								clientId,
+								clientSecret,
+								resource,
+								{ authorizationUrl, stripSameOriginResource: resourceIsFallback },
+							);
+							// Spread the old credential first so embedded refresh material survives rotation.
+							const refreshedCredential: MCPStoredOAuthCredential = {
+								...credential,
+								...refreshed,
+								tokenUrl,
+								clientId,
+								clientSecret,
+								resource: resourceIsFallback ? undefined : resource,
+								authorizationUrl,
+							};
+							await this.#authStorage.set(credentialId, refreshedCredential);
+							credential = refreshedCredential;
+						}
 					} catch (refreshError) {
 						const errorMsg = refreshError instanceof Error ? refreshError.message : String(refreshError);
 						if (isDefinitiveOAuthFailure(errorMsg)) {

--- a/packages/coding-agent/src/mcp/oauth-credentials.ts
+++ b/packages/coding-agent/src/mcp/oauth-credentials.ts
@@ -11,6 +11,7 @@ import type { MCPAuthConfig, MCPServerConfig } from "./types";
 
 export interface MCPOAuthCredentialLookup {
 	credentialId: string;
+	rowId?: number;
 	credential: MCPStoredOAuthCredential;
 }
 
@@ -46,14 +47,18 @@ export function lookupMcpOAuthCredentialForServer(
 	) {
 		const credential = authStorage.get(auth.credentialId);
 		if (credential?.type === "oauth") {
-			return { credentialId: auth.credentialId, credential };
+			const rowId = authStorage
+				.listStoredCredentials(auth.credentialId)
+				.find(row => row.credential.type === "oauth")?.id;
+			return { credentialId: auth.credentialId, rowId, credential };
 		}
 	}
 	if (options.allowUrlKeyedFallback === false) return undefined;
 	for (const credentialId of urlKeyedCredentialIds) {
 		const credential = authStorage.get(credentialId);
 		if (credential?.type === "oauth") {
-			return { credentialId, credential };
+			const rowId = authStorage.listStoredCredentials(credentialId).find(row => row.credential.type === "oauth")?.id;
+			return { credentialId, rowId, credential };
 		}
 	}
 	return undefined;

--- a/packages/coding-agent/test/mcp-broker-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/mcp-broker-oauth-refresh.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression test for broker-backed MCP OAuth refresh.
+ *
+ * Broker snapshots redact refresh tokens as `__remote__`. When an expired MCP
+ * credential carries that sentinel, `prepareConfig` must ask the auth broker to
+ * refresh the row by id instead of sending the sentinel to the MCP token
+ * endpoint. The config should use the broker's fresh access token while the
+ * stored MCP refresh metadata remains available for future refreshes.
+ */
+import { expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { type MCPStoredOAuthCredential, mcpOAuthCredentialId } from "@oh-my-pi/pi-coding-agent/mcp/oauth-flow";
+import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { AuthStorage, REMOTE_REFRESH_SENTINEL } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+
+const SERVER_URL = "https://mcp-broker-refresh.example.com/mcp";
+const TOKEN_URL = "https://auth.example.com/oauth/token";
+const CLIENT_ID = "broker-mcp-client";
+const AUTHORIZATION_URL = "https://auth.example.com/oauth/authorize";
+const RESOURCE = "https://api.example.com/mcp-resource";
+
+function authorizationHeader(config: MCPServerConfig): string | undefined {
+	if (config.type !== "http" && config.type !== "sse") return undefined;
+	return config.headers?.Authorization;
+}
+
+test("broker-backed MCP OAuth refresh uses the broker row id instead of POSTing the sentinel", async () => {
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-mcp-broker-refresh-"));
+	let authStorage: AuthStorage | undefined;
+	const credentialId = mcpOAuthCredentialId(SERVER_URL);
+	const refreshCalls: Array<{ provider: string; id: number }> = [];
+	let rowId = -1;
+	try {
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"), {
+			refreshOAuthCredential: async (provider, id, credential) => {
+				expect(provider).toBe(credentialId);
+				expect(id).toBe(rowId);
+				refreshCalls.push({ provider, id });
+				expect(credential).toMatchObject({
+					type: "oauth",
+					access: "expired-access",
+					refresh: REMOTE_REFRESH_SENTINEL,
+					tokenUrl: TOKEN_URL,
+					clientId: CLIENT_ID,
+					authorizationUrl: AUTHORIZATION_URL,
+					resource: RESOURCE,
+				});
+				return {
+					access: "broker-access",
+					refresh: REMOTE_REFRESH_SENTINEL,
+					expires: Date.now() + 3_600_000,
+				};
+			},
+		});
+		await authStorage.set(credentialId, {
+			type: "oauth",
+			access: "expired-access",
+			refresh: REMOTE_REFRESH_SENTINEL,
+			expires: Date.now() - 60_000,
+			tokenUrl: TOKEN_URL,
+			clientId: CLIENT_ID,
+			authorizationUrl: AUTHORIZATION_URL,
+			resource: RESOURCE,
+		} as MCPStoredOAuthCredential);
+
+		const storedBefore = authStorage.listStoredCredentials(credentialId);
+		expect(storedBefore).toHaveLength(1);
+		rowId = storedBefore[0]!.id;
+
+		const fetchMock: typeof globalThis.fetch = Object.assign(
+			async (input: string | URL | Request): Promise<Response> => {
+				throw new Error(`unexpected direct token endpoint fetch: ${String(input)}`);
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+
+		const manager = new MCPManager(tempDir);
+		manager.setAuthStorage(authStorage);
+
+		const prepared = await manager.prepareConfig({ type: "http", url: SERVER_URL });
+
+		expect(refreshCalls).toEqual([{ provider: credentialId, id: rowId }]);
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(authorizationHeader(prepared)).toBe("Bearer broker-access");
+
+		const storedAfter = authStorage.listStoredCredentials(credentialId);
+		expect(storedAfter).toHaveLength(1);
+		expect(storedAfter[0]!.id).toBe(rowId);
+		expect(storedAfter[0]!.credential).toMatchObject({
+			type: "oauth",
+			refresh: REMOTE_REFRESH_SENTINEL,
+			tokenUrl: TOKEN_URL,
+			clientId: CLIENT_ID,
+			authorizationUrl: AUTHORIZATION_URL,
+			resource: RESOURCE,
+		});
+	} finally {
+		authStorage?.close();
+		vi.restoreAllMocks();
+		await Bun.sleep(0);
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## What

Fix broker-backed MCP OAuth refresh for MCP servers such as Linear.

When an MCP OAuth credential is broker-backed, its refresh token is redacted as `__remote__`. The MCP manager now detects that sentinel and refreshes through `AuthStorage.forceRefreshCredentialById(rowId)` instead of sending the sentinel to the MCP token endpoint.

The patch also preserves embedded MCP OAuth metadata during row-id refresh so future refreshes still have `tokenUrl`, `clientId`, `authorizationUrl`, and `resource`.

## Why

Linear MCP auth works immediately after `/mcp reauth linear`, then later/fresh sessions lose Linear again.

Root cause: broker snapshots redact refresh tokens to `__remote__`, but `MCPManager` sent that sentinel directly to Linear’s token endpoint. Linear rejects it with:

```json
{"error":"invalid_grant","error_description":"Invalid token format"}
```

OMP then classified the refresh as definitive and cleared the credential, causing Linear to disappear from `/mcp list`.

This keeps the existing direct refresh path for local credentials with real refresh tokens, and routes only broker-redacted credentials through the broker refresh path.

## Testing

```sh
bun test packages/coding-agent/test/mcp-broker-oauth-refresh.test.ts
```

```text
1 pass
0 fail
10 expect() calls
Ran 1 test across 1 file.
```

```sh
bun run --cwd packages/coding-agent check:types
```

```text
tsgo -p tsconfig.json --noEmit
```

```sh
bunx biome check packages/coding-agent/src/mcp/manager.ts \
  packages/coding-agent/src/mcp/oauth-credentials.ts \
  packages/ai/src/auth-storage.ts \
  packages/coding-agent/test/mcp-broker-oauth-refresh.test.ts
```

```text
OK
```

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
