### PR TITLE
fix(ai): accept response.done terminal event

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses streams that end with `response.done` being misclassified as premature stream closures.
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -668,7 +668,7 @@ const streamOpenAIResponsesOnce = (
 			}
 
 			// Detect premature stream closure: the HTTP stream ended without the
-			// provider sending `response.completed` or `response.incomplete`.
+			// provider sending a recognized terminal response event.
 			// Custom/proxy providers may drop the connection mid-stream; without
 			// this guard the incomplete output is silently surfaced as a successful
 			// "stop".

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -80,6 +80,7 @@ import {
 import type { ChatCompletionCreateParamsStreaming } from "./openai-chat-wire";
 import type { InputItem } from "./openai-codex/request-transformer";
 import type {
+	Response as OpenAIResponse,
 	ResponseContentPartAddedEvent,
 	ResponseCreateParamsStreaming,
 	ResponseCustomToolCall,
@@ -1798,13 +1799,25 @@ export function finalizeCustomToolCallInputDone(block: ResponsesToolCallBlock, i
 	block.arguments = { input };
 }
 
+type OpenAIResponsesTerminalStreamEvent =
+	| Extract<ResponseStreamEvent, { type: "response.completed" | "response.incomplete" }>
+	| { type: "response.done"; response?: Partial<OpenAIResponse> };
+
+function getOpenAIResponsesTerminalEvent(event: ResponseStreamEvent): OpenAIResponsesTerminalStreamEvent | undefined {
+	const type = (event as { type?: unknown }).type;
+	return type === "response.completed" || type === "response.incomplete" || type === "response.done"
+		? (event as OpenAIResponsesTerminalStreamEvent)
+		: undefined;
+}
+
 export interface ProcessResponsesStreamOptions {
 	onFirstToken?: () => void;
 	onOutputItemDone?: (item: ResponseOutputItem) => void;
 	/**
-	 * Called when a terminal `response.completed` or `response.incomplete` event
-	 * is successfully processed. Only invoked on the successful-completion path;
-	 * thrown failure (`response.failed`) and cancellation paths never call this.
+	 * Called when a terminal `response.completed`, `response.incomplete`, or
+	 * `response.done` event is successfully processed. Only invoked on the
+	 * successful-completion path; thrown failure (`response.failed`) and
+	 * cancellation paths never call this.
 	 * Used by callers to detect premature stream closure (i.e. the stream ended
 	 * without a recognized terminal event).
 	 */
@@ -2039,6 +2052,7 @@ export async function processResponsesStream<TApi extends Api>(
 	let sawFirstToken = false;
 
 	for await (const event of openaiStream) {
+		const terminalEvent = getOpenAIResponsesTerminalEvent(event);
 		if (event.type === "response.created") {
 			output.responseId = event.response.id;
 		} else if (event.type === "response.output_item.added") {
@@ -2297,8 +2311,8 @@ export async function processResponsesStream<TApi extends Api>(
 				closeOpenItem(event.output_index, item.id, entry, item.call_id, prefixedFunctionCallItemKey(item.call_id));
 				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
 			}
-		} else if (event.type === "response.completed" || event.type === "response.incomplete") {
-			const response = event.response;
+		} else if (terminalEvent) {
+			const response = terminalEvent.response;
 			finalizePendingResponsesToolCalls(output);
 			if (response?.id) {
 				output.responseId = response.id;
@@ -2336,7 +2350,7 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 			promoteResponsesToolUseStopReason(output, (response as { end_turn?: boolean } | undefined)?.end_turn);
 			options?.onCompleted?.();
-			// `response.completed`/`response.incomplete` is the last event of a
+			// `response.completed`/`response.incomplete`/`response.done` is the last event of a
 			// Responses stream. Stop pulling instead of waiting for the server to
 			// close the connection: misbehaving providers keep the socket open
 			// after the terminal event, which would park this loop until the idle

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -705,6 +705,53 @@ describe("OpenAI-family first-event timeouts", () => {
 		]);
 	});
 
+	it("accepts response.done with a completed response as an OpenAI responses terminal event", async () => {
+		const completedResponse = createSseResponse([
+			{ type: "response.created", response: { id: "resp_done" } },
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_done", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Hello done" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_done",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello done" }],
+				},
+			},
+			{
+				type: "response.done",
+				response: {
+					id: "resp_done",
+					status: "completed",
+					usage: {
+						input_tokens: 3,
+						output_tokens: 2,
+						total_tokens: 5,
+					},
+				},
+			},
+		]);
+		const fetch: FetchImpl = () => Promise.resolve(completedResponse);
+		const result = await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+			apiKey: "test-key",
+			fetch,
+		}).result();
+
+		expect(result.errorMessage).toBeUndefined();
+		expect(result.stopReason).toBe("stop");
+		expect(result.content as unknown[]).toContainEqual({
+			type: "text",
+			text: "Hello done",
+			textSignature: '{"v":1,"id":"msg_done"}',
+		});
+	});
+
 	it("errors when Azure OpenAI responses stream closes without a terminal response event", async () => {
 		const incompleteResponse = createSseResponse([
 			{ type: "response.created", response: { id: "resp_incomplete_azure" } },


### PR DESCRIPTION
## Summary
- Treat `response.done` as a terminal OpenAI Responses stream event alongside `response.completed` / `response.incomplete`
- Keep premature stream-closure detection for streams without a recognized terminal event
- Add regression coverage for completed streams ending in `response.done`

## Validation
- `bun test packages/ai/test/openai-first-event-timeout.test.ts -t "accepts response.done with a completed response as an OpenAI responses terminal event"`
- `bun test packages/ai/test/openai-first-event-timeout.test.ts`
- `bun run check` in `packages/ai`