### PR TITLE
Allow resume by session name in omp --resume

### DIFF
--- a/docs/session-switching-and-recent-listing.md
+++ b/docs/session-switching-and-recent-listing.md
@@ -84,8 +84,8 @@ Breadcrumb writes are best-effort and non-fatal.
 
 2. Resume key value
    - `resolveResumableSession(...)` searches local sessions first, then all sessions when `sessionDir` is not forced
-   - matching is case-insensitive and accepts `id` prefix, full JSONL filename prefix, or the session-id suffix after the timestamp
-   - first match in modified-descending order is used (no ambiguity prompt)
+   - matching is case-insensitive and accepts `id` prefix, full JSONL filename prefix, the session-id suffix after the timestamp, or the session title
+   - first match in modified-descending order is used (no ambiguity prompt); id/filename matches beat title matches
 
 Cross-project match behavior:
 
@@ -244,6 +244,6 @@ Switch/open can still throw on true I/O failures (permission errors, rewrite fai
 
 ### ID prefix matching caveats
 
-- Matching uses `startsWith` on the lowercased session id, lowercased JSONL filename, and lowercased id suffix after the filename timestamp.
+- Matching uses `startsWith` on the lowercased session id, lowercased JSONL filename, and lowercased id suffix after the filename timestamp, plus exact-then-substring matching on the lowercased session title.
 - First match in modified-descending order wins; there is no ambiguity UI if multiple sessions share a prefix.
 - Prefix-listing metadata is intentionally lightweight, so search text may not include messages outside the first 4KB of the session file.

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -76,7 +76,7 @@ export default class Index extends Command {
 		}),
 		resume: Flags.string({
 			char: "r",
-			description: "Resume a session (by ID prefix, path, or picker if omitted)",
+			description: "Resume a session (by ID prefix, name/title, path, or picker if omitted)",
 		}),
 		"session-dir": Flags.string({
 			description: "Directory for session storage and lookup",

--- a/packages/coding-agent/src/session/session-listing.ts
+++ b/packages/coding-agent/src/session/session-listing.ts
@@ -611,6 +611,31 @@ function sessionMatchesResumeArg(session: SessionInfo, sessionArg: string): bool
 	const fileSessionId = fileName.slice(separator + 1);
 	return fileSessionId.startsWith(normalizedArg);
 }
+/**
+ * Find the best resume match in a modified-descending session list.
+ *
+ * Match tiers, checked across the whole list so a title can never shadow an
+ * id/filename prefix:
+ * 1. id / filename / filename-id-suffix prefix (see {@link sessionMatchesResumeArg})
+ * 2. exact title match (case-insensitive)
+ * 3. title substring match (case-insensitive)
+ *
+ * Within a tier, the first (most recently modified) session wins.
+ */
+function findResumeMatch(sessions: SessionInfo[], sessionArg: string): SessionInfo | undefined {
+	const normalizedArg = sessionArg.toLowerCase();
+	let titleExact: SessionInfo | undefined;
+	let titlePartial: SessionInfo | undefined;
+	for (const session of sessions) {
+		if (sessionMatchesResumeArg(session, sessionArg)) return session;
+		if (titleExact) continue;
+		const title = session.title?.toLowerCase();
+		if (!title) continue;
+		if (title === normalizedArg) titleExact = session;
+		else if (!titlePartial && title.includes(normalizedArg)) titlePartial = session;
+	}
+	return titleExact ?? titlePartial;
+}
 
 /** Controls cross-directory fallback for resumable session lookup. */
 export interface ResolveResumableSessionOptions {
@@ -633,7 +658,7 @@ export async function resolveResumableSession(
 	const resolvedOptions = isSessionStorage(storageOrOptions) ? options : storageOrOptions;
 	const localSessionDir = sessionDir ?? computeDefaultSessionDir(cwd, storage);
 	const localSessions = await listSessions(localSessionDir, storage);
-	const localMatch = localSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
+	const localMatch = findResumeMatch(localSessions, sessionArg);
 	if (localMatch) {
 		return { session: localMatch, scope: "local" };
 	}
@@ -643,7 +668,7 @@ export async function resolveResumableSession(
 	}
 
 	const globalSessions = await listAllSessions(storage);
-	const globalMatch = globalSessions.find(session => sessionMatchesResumeArg(session, sessionArg));
+	const globalMatch = findResumeMatch(globalSessions, sessionArg);
 	if (!globalMatch) {
 		return undefined;
 	}

--- a/packages/coding-agent/test/session-manager/file-operations.test.ts
+++ b/packages/coding-agent/test/session-manager/file-operations.test.ts
@@ -102,12 +102,12 @@ describe("resolveResumableSession", () => {
 		removeSyncWithRetries(tempDir);
 	});
 
-	function writeSession(fileName: string, headerCwd: string, id: string = Snowflake.next()): string {
+	function writeSession(fileName: string, headerCwd: string, id: string = Snowflake.next(), title?: string): string {
 		const filePath = path.join(sessionDir, fileName);
 		fs.writeFileSync(
 			filePath,
 			`${[
-				JSON.stringify({ type: "session", id, timestamp: "2025-01-01T00:00:00Z", cwd: headerCwd }),
+				JSON.stringify({ type: "session", id, timestamp: "2025-01-01T00:00:00Z", cwd: headerCwd, title }),
 				JSON.stringify({
 					type: "message",
 					id: "msg-1",
@@ -154,6 +154,42 @@ describe("resolveResumableSession", () => {
 
 		expect(match?.scope).toBe("local");
 		expect(match?.session.path).toBe(path.join(sessionDir, "2025-01-01_moved.jsonl"));
+	});
+	it("matches by exact title, case-insensitively", async () => {
+		writeSession("2025-01-01_titled.jsonl", "/tmp/project", "titled1234", "Fast GPT");
+
+		const match = await resolveResumableSession("fast gpt", "/tmp/project", sessionDir);
+
+		expect(match?.scope).toBe("local");
+		expect(match?.session.id).toBe("titled1234");
+	});
+
+	it("matches by title substring when no exact title matches", async () => {
+		writeSession("2025-01-01_titled.jsonl", "/tmp/project", "titled1234", "Fast GPT experiments");
+
+		const match = await resolveResumableSession("gpt exper", "/tmp/project", sessionDir);
+
+		expect(match?.session.id).toBe("titled1234");
+	});
+
+	it("prefers id prefix over a more recent title match", async () => {
+		writeSession("2025-01-01_by-id.jsonl", "/tmp/project", "abc123def");
+		await new Promise(r => setTimeout(r, 10));
+		writeSession("2025-01-02_by-title.jsonl", "/tmp/project", "zzz999zzz", "abc123def notes");
+
+		const match = await resolveResumableSession("abc123", "/tmp/project", sessionDir);
+
+		expect(match?.session.id).toBe("abc123def");
+	});
+
+	it("prefers an exact title over a more recent substring title match", async () => {
+		writeSession("2025-01-01_exact.jsonl", "/tmp/project", "exact12345", "fast gpt");
+		await new Promise(r => setTimeout(r, 10));
+		writeSession("2025-01-02_partial.jsonl", "/tmp/project", "partial123", "fast gpt extras");
+
+		const match = await resolveResumableSession("fast gpt", "/tmp/project", sessionDir);
+
+		expect(match?.session.id).toBe("exact12345");
 	});
 });
 


### PR DESCRIPTION
## What
Add ability to resume a session using omp -r <title>
<!-- Brief description of the change -->
Add a check for session name at the bottom of the matching waterfall for omp -r.
## Why
Currently there's no way to resume an omp session by name.  This is a useful feature to have, and is prevalent in most other agents.
<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing

Tests were written and test suites were re-reun. No tests were broken due to this change.

