### PR TITLE
fix(catalog): restore LiteLLM bundled metadata fallback

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LiteLLM discovery to fall back to bundled catalog metadata when `models.dev` lacks a model reference, preserving reasoning and thinking support for models such as `glm-5.2`. ([#4695](https://github.com/can1357/oh-my-pi/issues/4695))
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3346,11 +3346,11 @@ export function litellmModelManagerOptions(
 		cacheProviderId: `litellm:rich-v3:${Bun.hash(baseUrl).toString(36)}`,
 		// litellm is a local-only proxy and is never bundled in models.json (that
 		// would leak the machine's localhost catalog). Prefer the proxy's richer
-		// management metadata, then fall back to /v1/models and enrich bare ids
-		// against models.dev like the gateway providers (fireworks et al.) do.
+		// management metadata, then enrich ids against models.dev with the bundled
+		// catalog as a fallback before using /v1/models.
 		fetchDynamicModels: async () => {
 			const modelsDevReferences = await loadModelsDevReferences<"openai-completions">(config?.fetch);
-			const resolveReference = (id: string) => modelsDevReferences.get(id);
+			const resolveReference = createReferenceResolver(modelsDevReferences);
 			const richModels = await fetchLiteLLMRichModels({
 				api: "openai-completions",
 				provider: "litellm",

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -238,6 +238,54 @@ describe("LiteLLM provider discovery", () => {
 		});
 	});
 
+	test("enriches LiteLLM rich models missing from models.dev with bundled reasoning metadata", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			if (url === MODELS_DEV_URL) {
+				return Response.json({});
+			}
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({
+					data: [
+						{
+							model_group: "glm-5.2",
+							model_name: "GLM-5.2",
+						},
+					],
+				});
+			}
+			if (url === "http://primary:4000/v1/models") {
+				throw new Error("/v1/models should not be called when model_group info has a real model");
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as FetchImpl;
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-rich",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models).toHaveLength(1);
+		expect(models?.[0]).toMatchObject({
+			id: "glm-5.2",
+			name: "GLM-5.2",
+			api: "openai-completions",
+			provider: "litellm",
+			baseUrl: "http://primary:4000/v1",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: ["minimal", "low", "medium", "high", "xhigh"],
+				effortMap: {
+					minimal: "none",
+					xhigh: "max",
+				},
+			},
+		});
+	});
+
 	test("uses LiteLLM tool support metadata when rich endpoints succeed", async () => {
 		const fetchMock = vi.fn(async (input: string | URL | Request) => {
 			const url = inputUrl(input);
@@ -545,6 +593,55 @@ describe("LiteLLM provider discovery", () => {
 			name: "MiniMax M3",
 			contextWindow: 262_144,
 			maxTokens: 8_192,
+		});
+	});
+
+	test("enriches LiteLLM /v1/models fallback entries missing from models.dev with bundled reasoning metadata", async () => {
+		const calls: string[] = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			calls.push(url);
+			if (url === MODELS_DEV_URL) {
+				return Response.json({});
+			}
+			if (
+				url === "http://primary:4000/model_group/info" ||
+				url === "http://primary:4000/v2/model/info" ||
+				url === "http://primary:4000/model/info" ||
+				url === "http://primary:4000/v1/model/info"
+			) {
+				return new Response("{}", { status: 404 });
+			}
+			if (url === "http://primary:4000/v1/models") {
+				return Response.json({ data: [{ id: "glm-5.2" }] });
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as FetchImpl;
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-fallback",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(calls).toContain("http://primary:4000/v1/models");
+		expect(models).toHaveLength(1);
+		expect(models?.[0]).toMatchObject({
+			id: "glm-5.2",
+			name: "GLM-5.2",
+			api: "openai-completions",
+			provider: "litellm",
+			baseUrl: "http://primary:4000/v1",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: ["minimal", "low", "medium", "high", "xhigh"],
+				effortMap: {
+					minimal: "none",
+					xhigh: "max",
+				},
+			},
 		});
 	});
 });


### PR DESCRIPTION
## Repro
With `models.dev` mocked as empty and LiteLLM `/model_group/info` returning `glm-5.2`, `litellmModelManagerOptions({ baseUrl, fetch }).fetchDynamicModels()` returned a LiteLLM model with `reasoning: false` and no `thinking` block. The recorded repro used the catalog module directly with a mocked fetch implementation matching `omp models refresh litellm --json` enrichment inputs.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` loaded `models.dev` references in `litellmModelManagerOptions` and used `modelsDevReferences.get(id)` as the only reference resolver. When `models.dev` lacked `glm-5.2`, both `mapLiteLLMRichEntry` and `mapLiteLLMOpenAICompatibleModel` received `undefined` and fell back to default non-reasoning metadata instead of the bundled catalog entry.

## Fix
- Changed LiteLLM dynamic discovery to build its resolver with `createReferenceResolver(modelsDevReferences)`, preserving `models.dev` precedence while adding bundled catalog fallback metadata.
- Added a rich `/model_group/info` regression for `glm-5.2` proving LiteLLM transport fields remain while bundled reasoning/thinking metadata is inherited.
- Added a `/v1/models` fallback regression for the same bundled metadata path.
- Added the catalog changelog entry for #4695.

## Verification
`bun test packages/catalog/test/litellm-provider.test.ts -t "enriches LiteLLM rich models missing from models.dev with bundled reasoning metadata"` passed; `bun test packages/catalog/test/litellm-provider.test.ts -t "enriches LiteLLM /v1/models fallback entries missing from models.dev with bundled reasoning metadata"` passed; `bun test packages/catalog/test/litellm-provider.test.ts` passed with 15 tests; `bun --cwd packages/catalog check` passed. `gh_push_branch` also completed its pre-publish gate before pushing. Fixes #4695