### PR TITLE
feat(lsp): add Astral ty as built-in Python primary LSP server

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Astral `ty` as a built-in Python primary LSP server (`ty server`), ordered behind `pyright`/`basedpyright`/`pylsp` so it becomes the primary Python LSP only when the existing servers are unavailable. `ruff` remains the Python linter and coexists alongside `ty` ([#4617](https://github.com/can1357/oh-my-pi/issues/4617)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/lsp/defaults.json
+++ b/packages/coding-agent/src/lsp/defaults.json
@@ -189,6 +189,12 @@
 		"fileTypes": [".py"],
 		"rootMarkers": ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile"]
 	},
+	"ty": {
+		"command": "ty",
+		"args": ["server"],
+		"fileTypes": [".py", ".pyi"],
+		"rootMarkers": ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile"]
+	},
 	"ruff": {
 		"command": "ruff",
 		"args": ["server"],

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2546,3 +2546,67 @@ describe("expert elixir lsp", () => {
 		expect(names.indexOf("elixirls")).toBeLessThan(names.indexOf("expert"));
 	});
 });
+
+describe("ty python lsp", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("registers ty for .py behind existing Python primaries and before ruff", () => {
+		const config = { servers: DEFAULTS as unknown as Record<string, ServerConfig> };
+		const names = getServersForFile(config, "app.py").map(([name]) => name);
+		expect(names).toContain("ty");
+		expect(names).toContain("ruff");
+		// ty is behind all existing Python primaries
+		expect(names.indexOf("pyright")).toBeLessThan(names.indexOf("ty"));
+		expect(names.indexOf("basedpyright")).toBeLessThan(names.indexOf("ty"));
+		expect(names.indexOf("pylsp")).toBeLessThan(names.indexOf("ty"));
+		// ruff (linter) sorts after all primaries including ty
+		expect(names.indexOf("ty")).toBeLessThan(names.indexOf("ruff"));
+	});
+
+	it("registers ty for .pyi stub files", () => {
+		const config = { servers: DEFAULTS as unknown as Record<string, ServerConfig> };
+		const names = getServersForFile(config, "app.pyi").map(([name]) => name);
+		expect(names).toContain("ty");
+	});
+
+	it("auto-detects ty when its binary and Python root markers are present", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-ty-detect-");
+		const resolvedTy = path.join(tempDir.path(), "bin", "ty");
+		const whichSpy = vi
+			.spyOn(piUtils, "$which")
+			.mockImplementation(command => (command === "ty" ? resolvedTy : null));
+		try {
+			await Bun.write(path.join(tempDir.path(), "pyproject.toml"), '[project]\nname = "demo"\n');
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.ty?.resolvedCommand).toBe(resolvedTy);
+			expect(config.servers.ty?.command).toBe("ty");
+			expect(config.servers.ty?.args).toEqual(["server"]);
+			expect(whichSpy).toHaveBeenCalledWith("ty");
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("coexists with ruff: ty is primary, ruff is linter, both auto-detected", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-ty-ruff-");
+		const resolvedTy = path.join(tempDir.path(), "bin", "ty");
+		const resolvedRuff = path.join(tempDir.path(), "bin", "ruff");
+		vi.spyOn(piUtils, "$which").mockImplementation(command =>
+			command === "ty" ? resolvedTy : command === "ruff" ? resolvedRuff : null,
+		);
+		try {
+			await Bun.write(path.join(tempDir.path(), "pyproject.toml"), '[project]\nname = "demo"\n');
+			const config = loadConfig(tempDir.path());
+			expect(config.servers.ty?.resolvedCommand).toBe(resolvedTy);
+			expect(config.servers.ruff?.resolvedCommand).toBe(resolvedRuff);
+			expect(config.servers.ruff?.isLinter).toBe(true);
+			expect(config.servers.ty?.isLinter).toBeFalsy();
+			const names = getServersForFile(config, path.join(tempDir.path(), "app.py")).map(([name]) => name);
+			expect(names.indexOf("ty")).toBeLessThan(names.indexOf("ruff"));
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds Astral's [`ty`](https://docs.astral.sh/ty/) language server as a built-in Python primary LSP in `omp`, behind the existing Python primaries (`pyright` → `basedpyright` → `pylsp`) in default selection order and ahead of `ruff` (which remains the Python linter).

Closes #4617.

## Changes

### `packages/coding-agent/src/lsp/defaults.json`
- Inserted a `"ty"` entry between `"pylsp"` and `"ruff"`:
  - `command: "ty"`, `args: ["server"]` — per [Astral's editor integration docs](https://docs.astral.sh/ty/editors/#other-editors)
  - `fileTypes: [".py", ".pyi"]` — matches pyright/basedpyright/ruff; `ty` supports stub files
  - `rootMarkers`: the generic Python project marker set (same as `pylsp`)
  - No `isLinter` — `ty` is a primary type/language server, which places it among primaries
  - No `settings`/`initOptions` — the existing `settings` pass-through handles user `settings.ty` configuration without adapter code

### `packages/coding-agent/test/tools/lsp-regressions.test.ts`
- Added `describe("ty python lsp", …)` with 4 tests:
  1. **Selection order for `.py`**: `pyright` → `basedpyright` → `pylsp` → `ty` → `ruff`
  2. **`.pyi` stub files**: `ty` registers for `.pyi`
  3. **Auto-detect**: `loadConfig` detects `ty` when its binary and `pyproject.toml` root marker exist
  4. **Coexistence with ruff**: both detected when both binaries available; `ty` is primary (no `isLinter`), `ruff` is linter (`isLinter: true`), `ty` sorts before `ruff`

### `packages/coding-agent/CHANGELOG.md`
- Added `### Added` entry under `## [Unreleased]` referencing #4617

## Design notes

- **No adapter code** — `ty` uses the generic LSP client path. `settings.ty` pass-through works via the existing `settings` field on `ServerConfig`.
- **Virtualenv bin resolution** — `ty`'s root markers overlap with `PYTHON_ROOT_MARKERS` (which drives `LOCAL_BIN_PATHS`), so `ty` in `.venv/bin` / `venv/bin` / `.env/bin` is resolved automatically by the existing `resolveCommand` logic.
- **Notebook support** — explicitly out of scope per issue comments.

## Verification

- ✅ `bun check` (biome + docs + types) — passed, exit 0
- ✅ `defaults.json` parses as valid JSON; key order confirmed: `pyright → basedpyright → pylsp → ty → ruff`
- ✅ `getServersForFile` contract verified by reading the real implementation (`config.ts:480–512`): iterates `Object.entries` in insertion order, stable-sorts linters last
- ✅ New tests in isolation — `bun test test/tools/lsp-regressions.test.ts -t "ty python lsp"` — **4 pass, 0 fail** (16 expect calls)
- ✅ Full lsp-regressions suite — `bun test test/tools/lsp-regressions.test.ts` — **59 pass, 0 fail** (211 expect calls) — no regressions