### PR TITLE
feat(status-line): add path.basenameOnly segment option (#4700)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added `statusLine.segmentOptions.path.basenameOnly` to render only the final directory/project name in the custom status-line `path` segment, ignoring parent-path transforms (`stripWorkPrefix`, `abbreviate`). `maxLength` still clamps the basename. Defaults to `false` ([#4700](https://github.com/can1357/oh-my-pi/issues/4700)).
+
 
 ## [16.3.10] - 2026-07-06
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -228,6 +228,16 @@ const pathSegment: StatusLineSegment = {
 	render(ctx) {
 		const opts = ctx.options.path ?? {};
 		const stripPrefix = opts.stripWorkPrefix !== false;
+		// basenameOnly: render just the final directory/project name, ignoring
+		// parent-path transforms (stripWorkPrefix, abbreviate, repo suffix).
+		// maxLength still clamps the basename itself.
+		if (opts.basenameOnly) {
+			const base = ctx.worktree ? ctx.worktree.projectName : path.basename(ctx.activeRepo?.cwd ?? getProjectDir());
+			const pwd = clampPathLength(base, opts.maxLength ?? 40);
+			const icon = ctx.worktree ? theme.icon.worktree : theme.icon.folder;
+			const content = withIcon(icon, pwd);
+			return { content: theme.fg("statusLinePath", content), visible: true };
+		}
 
 		// Linked git worktree: the on-disk path nests the worktree base, the
 		// project, and a worktree dir that usually duplicates the branch (already

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -15,7 +15,7 @@ export interface CollabStatus {
 
 export interface StatusLineSegmentOptions {
 	model?: { showThinkingLevel?: boolean };
-	path?: { abbreviate?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
+	path?: { abbreviate?: boolean; basenameOnly?: boolean; maxLength?: number; stripWorkPrefix?: boolean };
 	git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
 	time?: { format?: "12h" | "24h"; showSeconds?: boolean };
 }

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -239,17 +239,17 @@ describe("status line path segment", () => {
 	});
 });
 
-describe("status line path segment in a linked worktree", () => {
-	function worktreeContext(
-		worktree: { projectName: string; worktreeName: string } | null,
-		branch: string | null,
-	): SegmentContext {
-		const ctx = createPathContext();
-		ctx.worktree = worktree;
-		ctx.git = { branch, status: null, pr: null };
-		return ctx;
-	}
+function worktreeContext(
+	worktree: { projectName: string; worktreeName: string } | null,
+	branch: string | null,
+): SegmentContext {
+	const ctx = createPathContext();
+	ctx.worktree = worktree;
+	ctx.git = { branch, status: null, pr: null };
+	return ctx;
+}
 
+describe("status line path segment in a linked worktree", () => {
 	it("collapses to the project name and drops the worktree dir when it equals the branch", () => {
 		const rendered = renderSegment("path", worktreeContext({ projectName: "pi", worktreeName: "xx" }, "xx"));
 		const content = Bun.stripANSI(rendered.content);
@@ -293,5 +293,119 @@ describe("status line path segment in a linked worktree", () => {
 		expect(label.length).toBeLessThanOrEqual(10);
 		expect(label.startsWith("…")).toBe(true);
 		expect(label.endsWith("feature")).toBe(true);
+	});
+});
+
+describe("status line path segment with basenameOnly", () => {
+	it("renders only the basename, ignoring parent path and transforms", () => {
+		// Nest under a scratch root so the existing scratch logic would render
+		// the trailing relative path (parent/basename), not just the basename.
+		// Only the basenameOnly short-circuit produces just the final name.
+		const scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-bn-"));
+		const nestedDir = path.join(scratchRoot, "nested-project");
+		fs.mkdirSync(nestedDir);
+		try {
+			setProjectDir(nestedDir);
+			const ctx = createPathContext();
+			ctx.options.path = { basenameOnly: true, abbreviate: false, maxLength: 120, stripWorkPrefix: true };
+			const rendered = renderSegment("path", ctx);
+			const content = Bun.stripANSI(rendered.content);
+			expect(rendered.visible).toBe(true);
+			expect(content).toBe(`${theme.icon.folder} nested-project`);
+			// The scratch-root parent folder must not leak (it would without basenameOnly).
+			expect(content).not.toContain(path.basename(scratchRoot));
+			expect(content).not.toContain(theme.icon.scratchFolder);
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(scratchRoot);
+		}
+	});
+
+	it("ignores stripWorkPrefix: false (basenameOnly wins)", () => {
+		const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-bn-noprefix-"));
+		try {
+			setProjectDir(parentDir);
+			const ctx = createPathContext();
+			ctx.options.path = { basenameOnly: true, stripWorkPrefix: false };
+			const content = Bun.stripANSI(renderSegment("path", ctx).content);
+			expect(content).toBe(`${theme.icon.folder} ${path.basename(parentDir)}`);
+			expect(content).not.toContain(os.tmpdir());
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(parentDir);
+		}
+	});
+
+	it("ignores abbreviate: true (no home prefix from shortenPath)", () => {
+		// Under a fake home but outside ~/Projects, the existing logic would
+		// render ~/code/nested-project when abbreviate is enabled. basenameOnly
+		// must drop the home prefix entirely and show just the final name.
+		const { home } = createFakeHome();
+		const nestedDir = path.join(home, "code", "nested-project");
+		fs.mkdirSync(nestedDir, { recursive: true });
+		try {
+			setProjectDir(nestedDir);
+			const ctx = createPathContext();
+			ctx.options.path = { basenameOnly: true, abbreviate: true };
+			const content = Bun.stripANSI(renderSegment("path", ctx).content);
+			expect(content).toBe(`${theme.icon.folder} nested-project`);
+			expect(content).not.toContain("~");
+			expect(content).not.toContain("code");
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(home);
+		}
+	});
+
+	it("clamps a long basename to maxLength", () => {
+		const longName = "a".repeat(50);
+		const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), `omp-status-line-bn-long-${longName}-`));
+		try {
+			setProjectDir(parentDir);
+			const ctx = createPathContext();
+			ctx.options.path = { basenameOnly: true, maxLength: 10 };
+			const rendered = renderSegment("path", ctx);
+			const content = Bun.stripANSI(rendered.content);
+			const label = content.slice(theme.icon.folder.length + 1);
+			expect(label.length).toBeLessThanOrEqual(10);
+			expect(label.startsWith("…")).toBe(true);
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(parentDir);
+		}
+	});
+
+	it("drops the repo suffix when basenameOnly is enabled", () => {
+		const parentDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-bn-repo-"));
+		const repoDir = path.join(parentDir, "pr-workspace");
+		fs.mkdirSync(repoDir);
+		try {
+			setProjectDir(parentDir);
+			const ctx = createPathContext();
+			ctx.activeRepo = {
+				cwd: parentDir,
+				repoRoot: repoDir,
+				relativeRepoRoot: "pr-workspace",
+				source: "single-direct-child-repo",
+			};
+			ctx.options.path = { basenameOnly: true };
+			const content = Bun.stripANSI(renderSegment("path", ctx).content);
+			expect(content).toBe(`${theme.icon.folder} ${path.basename(parentDir)}`);
+			expect(content).not.toContain("↳");
+			expect(content).not.toContain("pr-workspace");
+		} finally {
+			setProjectDir(originalProjectDir);
+			removeSyncWithRetries(parentDir);
+		}
+	});
+
+	it("uses projectName and worktree icon in a linked worktree", () => {
+		const ctx = worktreeContext({ projectName: "pi", worktreeName: "wt-icon" }, "icon");
+		ctx.options.path = { basenameOnly: true };
+		const content = Bun.stripANSI(renderSegment("path", ctx).content);
+		expect(content).toBe(`${theme.icon.worktree} pi`);
+		// Worktree dir is dropped; worktree icon is kept.
+		expect(content).not.toContain("wt-icon");
+		expect(content).not.toContain(theme.icon.folder);
 	});
 });


### PR DESCRIPTION
## Summary

Adds an additive `basenameOnly` option to the custom status-line `path` segment (`statusLine.segmentOptions.path.basenameOnly`). When enabled, the segment renders only the final directory/project name (e.g. `pinch`) instead of a shortened full path (e.g. `…/Desktop/desktop/opensource/pinch`).

Closes #4700.

## Behavior

- **Default `false`** — existing status lines are unaffected.
- **Precedence**: `basenameOnly: true` wins over `stripWorkPrefix` and `abbreviate` (parent-path transforms are skipped entirely). `maxLength` still clamps the basename itself.
- **Worktree**: uses `ctx.worktree.projectName` (the shared project name) and keeps the worktree icon — consistent with the existing worktree collapse, avoids showing the worktree dir name.
- **Repo suffix**: dropped (`↳ <repo>` is not appended — basename-only means just the name).

## Changes

| File | Change |
|---|---|
| `packages/coding-agent/src/modes/components/status-line/types.ts` | Add `basenameOnly?: boolean` to `StatusLineSegmentOptions.path` |
| `packages/coding-agent/src/modes/components/status-line/segments.ts` | Insert `basenameOnly` short-circuit at the top of `pathSegment.render`, before the worktree branch |
| `packages/coding-agent/test/status-line-path.test.ts` | 6 new contract tests; hoisted `worktreeContext` helper to module scope |
| `packages/coding-agent/CHANGELOG.md` | `### Added` entry under `[Unreleased]` |

## Tests

6 new tests covering:
1. Renders only the basename (nested under a scratch root so the existing logic would *not* produce just the basename without the new short-circuit).
2. Ignores `stripWorkPrefix: false` (basenameOnly wins).
3. Ignores `abbreviate: true` (no home prefix from `shortenPath`).
4. `maxLength` clamps a long basename.
5. Drops the repo suffix (`↳`).
6. Worktree uses `projectName` + worktree icon, drops worktree dir.

## Verification

- `bun check` (repo root) — clean: `check:ts` (biome + tsgo across all workspaces) and `check:rs` (cargo check) both exit 0.
- `bun test test/status-line-path.test.ts` — 18/18 pass (12 existing + 6 new).
- `bun test test/status-line-path.test.ts test/status-line-overflow.test.ts test/status-line-settings-cache.test.ts` — 38/38 pass, no regressions.

## Changelog note

The changelog entry was hand-authored under `## [Unreleased]` → `### Added`, per the repo's documented convention (`AGENTS.md`). There is no changeset/release-please automation — `bun run release` only promotes `[Unreleased]` → `[version]` at release time; `fix-changelogs` normalizes formatting but does not generate content.