### PR TITLE
fix(ai): mirror Codex instruction-only plan input

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `openai-codex-responses` fresh plan execution requests that contained only system/developer guidance by mirroring the final instruction as user input so Codex accepts the first turn. ([#4714](https://github.com/can1357/oh-my-pi/issues/4714))
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -230,16 +230,61 @@ export async function transformRequestBody(
 		}
 	}
 
-	if (prompt?.developerMessages && prompt.developerMessages.length > 0 && Array.isArray(body.input)) {
-		const developerMessages = prompt.developerMessages.map(
-			text =>
-				({
+	if (prompt?.developerMessages && prompt.developerMessages.length > 0) {
+		const developerMessages: InputItem[] = prompt.developerMessages.map(text => ({
+			type: "message",
+			role: "developer",
+			content: [{ type: "input_text", text }],
+		}));
+		const input = Array.isArray(body.input) ? body.input : [];
+		body.input = [...developerMessages, ...input];
+	}
+
+	let finalInstruction = prompt?.developerMessages.findLast(text => text.trim().length > 0);
+	if (finalInstruction === undefined && Array.isArray(body.input)) {
+		for (let itemIndex = body.input.length - 1; itemIndex >= 0; itemIndex -= 1) {
+			const item = body.input[itemIndex];
+			if (item.role !== "developer" || !Array.isArray(item.content)) continue;
+			for (let partIndex = item.content.length - 1; partIndex >= 0; partIndex -= 1) {
+				const part = item.content[partIndex];
+				if (
+					part &&
+					typeof part === "object" &&
+					"type" in part &&
+					part.type === "input_text" &&
+					"text" in part &&
+					typeof part.text === "string" &&
+					part.text.trim().length > 0
+				) {
+					finalInstruction = part.text;
+					break;
+				}
+			}
+			if (finalInstruction !== undefined) break;
+		}
+	}
+	if (finalInstruction === undefined && typeof body.instructions === "string" && body.instructions.trim().length > 0) {
+		finalInstruction = body.instructions;
+	}
+	if (finalInstruction !== undefined) {
+		const input = Array.isArray(body.input) ? body.input : [];
+		let hasVisibleInput = false;
+		for (const item of input) {
+			if (item.role !== "developer") {
+				hasVisibleInput = true;
+				break;
+			}
+		}
+		if (!hasVisibleInput) {
+			body.input = [
+				...input,
+				{
 					type: "message",
-					role: "developer",
-					content: [{ type: "input_text", text }],
-				}) as InputItem,
-		);
-		body.input = [...developerMessages, ...body.input];
+					role: "user",
+					content: [{ type: "input_text", text: finalInstruction }],
+				},
+			];
+		}
 	}
 
 	const responsesLite = shouldUseCodexResponsesLite(body, options.responsesLite);

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -5,6 +5,7 @@ import {
 	transformRequestBody,
 } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
 import {
+	buildTransformedCodexRequestBody,
 	convertCodexResponsesMessages,
 	streamOpenAICodexResponses,
 } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
@@ -266,6 +267,58 @@ describe("openai-codex Responses Lite input shaping", () => {
 
 		const noTools = await transformRequestBody({ model: model.id }, model, { responsesLite: true });
 		expect(noTools.parallel_tool_calls).toBeUndefined();
+	});
+});
+
+describe("openai-codex fresh execution input shaping", () => {
+	it("adds a user continuation when only instructions would be sent", async () => {
+		const model = createCodexModel("gpt-5.1-codex");
+		const body = await buildTransformedCodexRequestBody(
+			model,
+			{
+				systemPrompt: ["You are a helpful assistant.", "Read local://approved-plan.md and execute it."],
+				messages: [],
+			},
+			undefined,
+		);
+
+		expect(body.instructions).toBe("You are a helpful assistant.");
+		expect(body.input).toEqual([
+			{
+				type: "message",
+				role: "developer",
+				content: [{ type: "input_text", text: "Read local://approved-plan.md and execute it." }],
+			},
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: "Read local://approved-plan.md and execute it." }],
+			},
+		]);
+	});
+
+	it("does not add a continuation when user input is present", async () => {
+		const model = createCodexModel("gpt-5.1-codex");
+		const body = await buildTransformedCodexRequestBody(
+			model,
+			{
+				systemPrompt: ["You are a helpful assistant.", "Read local://approved-plan.md and execute it."],
+				messages: [{ role: "user", content: "Start execution", timestamp: Date.now() }],
+			},
+			undefined,
+		);
+
+		expect(body.input).toEqual([
+			{
+				type: "message",
+				role: "developer",
+				content: [{ type: "input_text", text: "Read local://approved-plan.md and execute it." }],
+			},
+			{
+				role: "user",
+				content: [{ type: "input_text", text: "Start execution" }],
+			},
+		]);
 	});
 });
 


### PR DESCRIPTION
## Repro
A fresh Codex plan-execution context with only system/developer guidance builds a Responses request whose `input` has the developer plan instruction but no user item. Reproduced with `bun test packages/ai/test/openai-codex-responses-lite.test.ts -t "adds a user continuation"`, which failed because the expected user continuation was absent.

## Cause
`packages/ai/src/providers/openai-codex/request-transformer.ts` preserved `instructions` and prepended developer messages, but it did not add any visible `user` input when the converted conversation was empty. Codex treats instruction-only `response.create` payloads as missing actionable input and rejects them before the agent can read the approved `local://<slug>-plan.md` plan.

## Fix
- Preserve developer guidance when transforming Codex request bodies, including bodies that did not already carry an `input` array.
- Detect instruction-only Codex request bodies and append a non-empty `role: "user"` message mirroring the final instruction text.
- Add regression coverage for fresh execution request shaping and for the existing-user guard that must not duplicate real user input.
- Add an `packages/ai` changelog entry for #4714.

## Verification
`bun test packages/ai/test/openai-codex-responses-lite.test.ts` passed with 21 tests. `bun run --cwd packages/ai check:types` passed. Pre-publish `gh_push_branch` completed its `bun run fix` and `bun check` gate before pushing. Fixes #4714