### PR TITLE
fix(coding-agent): detect llama.cpp per-model vision metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed llama.cpp model discovery to honor per-model `architecture.input_modalities` from `/v1/models`, so router presets that advertise image input are no longer treated as text-only ([#4719](https://github.com/can1357/oh-my-pi/issues/4719)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -158,6 +158,7 @@ type LlamaCppDiscoveredModelRuntimeMetadata = {
 
 type LlamaCppModelListEntry = {
 	id: string;
+	input?: ("text" | "image")[];
 	runtimeContextWindow?: number;
 	/**
 	 * `--ctx-size` extracted from the entry's `status.args` (rendered CLI arg
@@ -276,6 +277,20 @@ function extractLlamaCppModelContextWindows(
 	};
 }
 
+function extractLlamaCppModelInputCapabilities(item: Record<string, unknown>): ("text" | "image")[] | undefined {
+	const architecture = item.architecture;
+	if (!isRecord(architecture) || !Array.isArray(architecture.input_modalities)) {
+		return undefined;
+	}
+	const modalities = new Set<string>();
+	for (const modality of architecture.input_modalities) {
+		if (typeof modality === "string") {
+			modalities.add(modality.toLowerCase());
+		}
+	}
+	return modalities.has("image") ? ["text", "image"] : ["text"];
+}
+
 function parseLlamaCppModelList(payload: unknown): LlamaCppModelListEntry[] {
 	if (!isRecord(payload) || !Array.isArray(payload.data)) {
 		return [];
@@ -287,6 +302,7 @@ function parseLlamaCppModelList(payload: unknown): LlamaCppModelListEntry[] {
 		return [
 			{
 				id: item.id,
+				input: extractLlamaCppModelInputCapabilities(item),
 				...extractLlamaCppModelContextWindows(item),
 				configuredContextWindow: extractLlamaCppConfiguredContextWindow(item),
 			},
@@ -545,7 +561,7 @@ export async function discoverLlamaCppModels(
 				provider: providerConfig.provider,
 				baseUrl,
 				reasoning: false,
-				input: serverMetadata?.input ?? ["text"],
+				input: item.input ?? serverMetadata?.input ?? ["text"],
 				imageInputDecoder: "stb",
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow,
@@ -595,7 +611,7 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 			entry.configuredContextWindow ??
 			serverMetadata?.contextWindow ??
 			entry.trainingContextWindow;
-		const input = serverMetadata?.input;
+		const input = entry.input ?? serverMetadata?.input;
 		if (contextWindow === undefined) {
 			return input === undefined ? undefined : { input };
 		}

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -766,6 +766,41 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(llama?.input).toEqual(["text", "image"]);
 	});
 
+	test("llama.cpp discovery marks per-model architecture image modalities as vision-capable", async () => {
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "q51q41_mtp_30tps_120k",
+								architecture: {
+									input_modalities: ["text", "image"],
+									output_modalities: ["text"],
+								},
+								meta: { n_ctx: 123904 },
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(JSON.stringify({ default_generation_settings: { n_ctx: 123904 } }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		const llama = registry.find("llama.cpp", "q51q41_mtp_30tps_120k");
+		expect(llama?.contextWindow).toBe(123904);
+		expect(llama?.input).toEqual(["text", "image"]);
+	});
+
 	test("llama.cpp discovery ignores positive props defaults as per-request limits, not hard caps", async () => {
 		const fetchMock: FetchImpl = async input => {
 			const url = String(input);
@@ -1106,6 +1141,70 @@ describe("ModelRegistry runtime discovery", () => {
 		const refreshed = await registry.refreshSelectedModelMetadata(stale);
 		expect(refreshed.input).toEqual(["text", "image"]);
 		expect(registry.find("llama.cpp", "vision-model")?.input).toEqual(["text", "image"]);
+	});
+
+	test("llama.cpp selected model refresh reads image capability from per-model architecture", async () => {
+		writeModelCache(
+			"llama.cpp",
+			Date.now(),
+			[
+				buildModel({
+					id: "router-vision-model",
+					name: "router-vision-model",
+					provider: "llama.cpp",
+					api: "openai-responses",
+					baseUrl: "http://127.0.0.1:8080",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 32768,
+				}),
+			],
+			true,
+			"",
+			cacheDbPath,
+		);
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "router-vision-model",
+								architecture: {
+									input_modalities: ["text", "image"],
+									output_modalities: ["text"],
+								},
+								meta: { n_ctx: 239104 },
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(
+					JSON.stringify({
+						default_generation_settings: {
+							n_ctx: 239104,
+							params: { max_tokens: -1, n_predict: -1 },
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		const stale = registry.find("llama.cpp", "router-vision-model");
+		if (!stale) throw new Error("cached llama.cpp model missing");
+		expect(stale.input).toEqual(["text"]);
+		const refreshed = await registry.refreshSelectedModelMetadata(stale);
+		expect(refreshed.contextWindow).toBe(239104);
+		expect(refreshed.input).toEqual(["text", "image"]);
+		expect(registry.find("llama.cpp", "router-vision-model")?.input).toEqual(["text", "image"]);
 	});
 
 	test("llama.cpp selected model refresh leaves the cached model untouched when /models no longer lists it", async () => {


### PR DESCRIPTION
## Repro
A llama.cpp `/v1/models` response matching the reporter's payload advertises `architecture.input_modalities: ["text", "image"]` for `q51q41_mtp_30tps_120k`, while `/props` omits `modalities`; before the fix, `bun test packages/coding-agent/test/issue-4719-repro.temp.test.ts` failed because `ModelRegistry` resolved `model.input` as `["text"]` instead of `["text", "image"]`.

## Cause
`packages/coding-agent/src/config/model-discovery.ts` only read llama.cpp image capability from `/props.modalities.vision` in `discoverLlamaCppServerMetadata`; `parseLlamaCppModelList` discarded each `/v1/models` entry's `architecture.input_modalities`, so router presets and loaded models that report capability per model were downgraded to text-only.

## Fix
- Parse `architecture.input_modalities` on llama.cpp `/v1/models` entries and store the resulting per-model input capabilities.
- Prefer per-model input capabilities over `/props` server-level metadata during full discovery and selected-model runtime metadata refresh.
- Add regression coverage for full llama.cpp discovery and cached selected-model refresh using the reporter's per-model architecture shape.
- Add an Unreleased changelog entry for the coding-agent package.

## Verification
`bun test packages/coding-agent/test/model-discovery.test.ts -t llama.cpp` passed with 17 tests; `bun test packages/coding-agent/test/model-discovery.test.ts` passed with 42 tests; `bun check` passed for all packages. Fixes #4719