### PR TITLE
fix(theme): replay detected terminal appearance

### DIFF
--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2111,6 +2111,19 @@ var terminalReportedAppearance: "dark" | "light" | undefined;
 /** Appearance reported by the macOS fallback observer, or undefined if not yet available. */
 var macOSReportedAppearance: "dark" | "light" | undefined;
 
+function writeThemeDebug(event: string, details: Record<string, unknown> = {}): void {
+	if (Bun.env.OMP_THEME_DEBUG !== "1") return;
+	const suffix = Object.keys(details).length > 0 ? ` ${JSON.stringify(details)}` : "";
+	const line = `[omp-theme-debug] theme ${event}${suffix}\n`;
+	process.stderr.write(line);
+	if (!Bun.env.OMP_THEME_DEBUG_LOG) return;
+	try {
+		fs.appendFileSync(Bun.env.OMP_THEME_DEBUG_LOG, line);
+	} catch {
+		// Debug logging must not break startup.
+	}
+}
+
 function shouldUseMacOSAppearanceFallback(): boolean {
 	// Zellij currently breaks OSC 11 passthrough on macOS, so terminal-derived
 	// appearance cannot be trusted there. Fall back to host macOS appearance
@@ -2121,6 +2134,7 @@ function shouldUseMacOSAppearanceFallback(): boolean {
 function detectTerminalBackground(): "dark" | "light" {
 	// Tier 1: terminal-reported appearance from OSC 11 luminance.
 	if (!shouldUseMacOSAppearanceFallback() && terminalReportedAppearance) {
+		writeThemeDebug("selected-signal", { source: "osc11", appearance: terminalReportedAppearance });
 		return terminalReportedAppearance;
 	}
 
@@ -2130,22 +2144,43 @@ function detectTerminalBackground(): "dark" | "light" {
 		const parts = colorfgbg.split(";");
 		if (parts.length >= 2) {
 			const bg = parseInt(parts[1], 10);
-			if (!Number.isNaN(bg)) return bg < 8 ? "dark" : "light";
+			if (!Number.isNaN(bg)) {
+				const appearance = bg < 8 ? "dark" : "light";
+				writeThemeDebug("selected-signal", { source: "colorfgbg", colorfgbg, backgroundIndex: bg, appearance });
+				return appearance;
+			}
 		}
+		writeThemeDebug("ignored-signal", { source: "colorfgbg", colorfgbg, reason: "unparseable" });
 	}
 
 	// Tier 3: host macOS appearance for known-broken terminal paths only.
 	if (shouldUseMacOSAppearanceFallback()) {
 		const macAppearance = macOSReportedAppearance ?? detectMacOSAppearance();
-		if (macAppearance) return macAppearance;
+		if (macAppearance) {
+			writeThemeDebug("selected-signal", { source: "macos-zellij", appearance: macAppearance });
+			return macAppearance;
+		}
 	}
 
+	writeThemeDebug("selected-signal", {
+		source: "fallback-dark",
+		terminalReportedAppearance,
+		colorfgbg: colorfgbg || undefined,
+		macosFallback: shouldUseMacOSAppearanceFallback(),
+	});
 	return "dark";
 }
 
 function getDefaultTheme(): string {
 	const bg = detectTerminalBackground();
-	return bg === "light" ? autoLightTheme : autoDarkTheme;
+	const name = bg === "light" ? autoLightTheme : autoDarkTheme;
+	writeThemeDebug("selected-theme", {
+		appearance: bg,
+		theme: name,
+		darkTheme: autoDarkTheme,
+		lightTheme: autoLightTheme,
+	});
+	return name;
 }
 
 // ============================================================================
@@ -2301,7 +2336,11 @@ export function setAutoThemeMapping(mode: "dark" | "light", themeName: string): 
  * Mode 2031 notifications trigger re-queries rather than providing the value directly.
  */
 export function onTerminalAppearanceChange(mode: "dark" | "light"): void {
-	if (terminalReportedAppearance === mode) return;
+	if (terminalReportedAppearance === mode) {
+		writeThemeDebug("terminal-appearance-unchanged", { appearance: mode });
+		return;
+	}
+	writeThemeDebug("terminal-appearance", { previousAppearance: terminalReportedAppearance, appearance: mode });
 	terminalReportedAppearance = mode;
 	reevaluateAutoTheme("terminal appearance");
 }

--- a/packages/coding-agent/test/theme-auto-detection.test.ts
+++ b/packages/coding-agent/test/theme-auto-detection.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import * as nativesModule from "@oh-my-pi/pi-natives";
 import { MacOSAppearance } from "@oh-my-pi/pi-natives";
@@ -6,11 +9,14 @@ import { MacOSAppearance } from "@oh-my-pi/pi-natives";
 const originalPlatform = process.platform;
 const originalColorfgbg = Bun.env.COLORFGBG;
 const originalZellij = Bun.env.ZELLIJ;
-
+const originalThemeDebug = Bun.env.OMP_THEME_DEBUG;
+const originalThemeDebugLog = Bun.env.OMP_THEME_DEBUG_LOG;
 type ThemeTestGlobals = {
 	platform?: NodeJS.Platform;
 	colorfgbg?: string;
 	zellij?: string;
+	themeDebug?: string;
+	themeDebugLog?: string;
 };
 
 const withThemeTestGlobals = (globals: ThemeTestGlobals = {}) => {
@@ -26,6 +32,12 @@ const withThemeTestGlobals = (globals: ThemeTestGlobals = {}) => {
 	if (globals.zellij === undefined) delete Bun.env.ZELLIJ;
 	else Bun.env.ZELLIJ = globals.zellij;
 
+	if (globals.themeDebug === undefined) delete Bun.env.OMP_THEME_DEBUG;
+	else Bun.env.OMP_THEME_DEBUG = globals.themeDebug;
+
+	if (globals.themeDebugLog === undefined) delete Bun.env.OMP_THEME_DEBUG_LOG;
+	else Bun.env.OMP_THEME_DEBUG_LOG = globals.themeDebugLog;
+
 	return {
 		[Symbol.dispose]() {
 			themeModule.stopThemeWatcher();
@@ -38,10 +50,23 @@ const withThemeTestGlobals = (globals: ThemeTestGlobals = {}) => {
 			else Bun.env.COLORFGBG = originalColorfgbg;
 			if (originalZellij === undefined) delete Bun.env.ZELLIJ;
 			else Bun.env.ZELLIJ = originalZellij;
+			if (originalThemeDebug === undefined) delete Bun.env.OMP_THEME_DEBUG;
+			else Bun.env.OMP_THEME_DEBUG = originalThemeDebug;
+			if (originalThemeDebugLog === undefined) delete Bun.env.OMP_THEME_DEBUG_LOG;
+			else Bun.env.OMP_THEME_DEBUG_LOG = originalThemeDebugLog;
 			vi.restoreAllMocks();
 		},
 	};
 };
+
+function themeDebugPayloads(stderr: string[], event: string): Record<string, unknown>[] {
+	const prefix = `[omp-theme-debug] theme ${event} `;
+	return stderr
+		.join("")
+		.split("\n")
+		.filter(line => line.startsWith(prefix))
+		.map(line => JSON.parse(line.slice(prefix.length)) as Record<string, unknown>);
+}
 
 describe("theme auto-detection", () => {
 	beforeEach(async () => {
@@ -127,5 +152,41 @@ describe("theme auto-detection", () => {
 
 		expect(themeModule.getCurrentThemeName()).toBe("light");
 		expect(detectSpy).not.toHaveBeenCalled();
+	});
+
+	it("persists OSC 11 source and selected light theme in debug log", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-theme-debug-"));
+		const logPath = path.join(tempDir, "theme.log");
+
+		try {
+			using _globals = withThemeTestGlobals({ colorfgbg: "15;0", themeDebug: "1", themeDebugLog: logPath });
+			const stderr: string[] = [];
+			vi.spyOn(process.stderr, "write").mockImplementation(chunk => {
+				stderr.push(typeof chunk === "string" ? chunk : chunk.toString());
+				return true;
+			});
+			const detectSpy = vi.spyOn(nativesModule, "detectMacOSAppearance").mockReturnValue(MacOSAppearance.Dark);
+
+			themeModule.onTerminalAppearanceChange("light");
+			await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+
+			expect(themeModule.getCurrentThemeName()).toBe("light");
+			expect(detectSpy).not.toHaveBeenCalled();
+			expect(themeDebugPayloads(stderr, "selected-signal")).toContainEqual(
+				expect.objectContaining({ source: "osc11", appearance: "light" }),
+			);
+			expect(themeDebugPayloads(stderr, "selected-theme")).toContainEqual(
+				expect.objectContaining({ appearance: "light", theme: "light" }),
+			);
+
+			const log = fs.readFileSync(logPath, "utf8");
+			expect(log).toContain("[omp-theme-debug] theme selected-signal");
+			expect(log).toContain('"source":"osc11"');
+			expect(log).toContain('"appearance":"light"');
+			expect(log).toContain("[omp-theme-debug] theme selected-theme");
+			expect(log).toContain('"theme":"light"');
+		} finally {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -40,6 +40,27 @@ function shouldEnableModifyOtherKeysFallback(env: NodeJS.ProcessEnv = Bun.env): 
 	return TERMINAL.id !== "base" && TERMINAL.id !== "trueColor";
 }
 
+function formatControlSequenceForDebug(sequence: string): string {
+	return sequence
+		.replace(/\x1b\\/g, "<ST>")
+		.replace(/\x1b/g, "<ESC>")
+		.replace(/\x07/g, "<BEL>");
+}
+
+function writeThemeDebug(event: string, details: Record<string, unknown> = {}): void {
+	if ($env.OMP_THEME_DEBUG !== "1" && $env.PI_TUI_APPEARANCE_DEBUG !== "1") return;
+	const suffix = Object.keys(details).length > 0 ? ` ${JSON.stringify(details)}` : "";
+	const line = `[omp-theme-debug] terminal ${event}${suffix}\n`;
+	process.stderr.write(line);
+	const logPath = $env.OMP_THEME_DEBUG_LOG || $env.PI_TUI_APPEARANCE_DEBUG_LOG || "";
+	if (!logPath) return;
+	try {
+		fs.appendFileSync(logPath, line);
+	} catch {
+		// Debug logging must not break terminal startup.
+	}
+}
+
 /**
  * Maximum encoded UTF-8 bytes per `process.stdout.write` call on Windows.
  *
@@ -516,6 +537,12 @@ export class ProcessTerminal implements Terminal {
 
 	onAppearanceChange(callback: (appearance: TerminalAppearance) => void): void {
 		this.#appearanceCallbacks.push(callback);
+		if (!this.#appearance) return;
+		try {
+			callback(this.#appearance);
+		} catch {
+			/* ignore callback errors */
+		}
 	}
 
 	onPrivateModeReport(callback: (mode: number, supported: boolean) => void): void {
@@ -834,6 +861,7 @@ export class ProcessTerminal implements Terminal {
 					case "osc11": {
 						if (this.#osc11Pending) {
 							// DA1 arrived before the OSC 11 reply: terminal does not support OSC 11.
+							writeThemeDebug("osc11-unsupported-da1", { queued: this.#osc11QueryQueued });
 							this.#osc11Pending = false;
 							this.#osc11ResponseBuffer = "";
 						}
@@ -922,10 +950,11 @@ export class ProcessTerminal implements Terminal {
 					this.#osc11ResponseBuffer += sequence;
 					const osc11Match = this.#osc11ResponseBuffer.match(osc11ResponsePattern);
 					if (!osc11Match) return;
+					const rawSequence = this.#osc11ResponseBuffer;
 					const [, rHex, gHex, bHex] = osc11Match;
 					this.#osc11Pending = false;
 					this.#osc11ResponseBuffer = "";
-					this.#handleOsc11Response(rHex!, gHex!, bHex!);
+					this.#handleOsc11Response(rHex!, gHex!, bHex!, rawSequence);
 					return;
 				}
 			}
@@ -948,6 +977,7 @@ export class ProcessTerminal implements Terminal {
 			// (Neovim convention — coalesces rapid notifications during transitions)
 			const appearanceMatch = sequence.match(appearanceDsrPattern);
 			if (appearanceMatch) {
+				writeThemeDebug("mode2031-notification", { appearanceCode: appearanceMatch[1] });
 				if (this.#mode2031DebounceTimer) clearTimeout(this.#mode2031DebounceTimer);
 				this.#mode2031DebounceTimer = setTimeout(() => {
 					this.#mode2031DebounceTimer = undefined;
@@ -986,6 +1016,10 @@ export class ProcessTerminal implements Terminal {
 		// prematurely clear the new query's pending state.
 		if (this.#osc11Pending || this.#da1SentinelOwners.some(o => o.kind === "osc11")) {
 			this.#osc11QueryQueued = true;
+			writeThemeDebug("osc11-query-queued", {
+				pending: this.#osc11Pending,
+				outstandingSentinel: this.#da1SentinelOwners.some(o => o.kind === "osc11"),
+			});
 			return;
 		}
 		this.#startOsc11Query();
@@ -997,6 +1031,7 @@ export class ProcessTerminal implements Terminal {
 		this.#da1SentinelOwners.push({ kind: "osc11" });
 		this.#safeWrite("\x1b]11;?\x07"); // OSC 11 query (BEL terminated)
 		this.#safeWrite("\x1b[c"); // DA1 sentinel
+		writeThemeDebug("osc11-query-sent", { query: formatControlSequenceForDebug("\x1b]11;?\x07") });
 	}
 
 	#shouldQueryOsc99Support(): boolean {
@@ -1049,15 +1084,30 @@ export class ProcessTerminal implements Terminal {
 	 * Parse an OSC 11 background color response and compute BT.601 luminance.
 	 * Handles 1-, 2-, 3-, and 4-digit XParseColor hex components.
 	 */
-	#handleOsc11Response(rHex: string, gHex: string, bHex: string): void {
+	#handleOsc11Response(rHex: string, gHex: string, bHex: string, rawSequence?: string): void {
 		const normalize = (hex: string): number => {
 			const value = parseInt(hex, 16);
 			if (Number.isNaN(value)) return 0;
 			const max = 16 ** hex.length - 1;
 			return max > 0 ? value / max : 0;
 		};
-		const luminance = 0.299 * normalize(rHex) + 0.587 * normalize(gHex) + 0.114 * normalize(bHex);
+		const red = normalize(rHex);
+		const green = normalize(gHex);
+		const blue = normalize(bHex);
+		const luminance = 0.299 * red + 0.587 * green + 0.114 * blue;
 		const mode: TerminalAppearance = luminance < 0.5 ? "dark" : "light";
+		writeThemeDebug("osc11-response", {
+			raw: rawSequence ? formatControlSequenceForDebug(rawSequence) : undefined,
+			rHex,
+			gHex,
+			bHex,
+			red,
+			green,
+			blue,
+			luminance,
+			appearance: mode,
+			previousAppearance: this.#appearance,
+		});
 		if (mode === this.#appearance) return;
 		this.#appearance = mode;
 		for (const cb of this.#appearanceCallbacks) {
@@ -1127,6 +1177,7 @@ export class ProcessTerminal implements Terminal {
 	#resolvePrivateMode(mode: number, supported: boolean): void {
 		if (this.#privateModeSupport.has(mode)) return;
 		this.#privateModeSupport.set(mode, supported);
+		if (mode === 2031) writeThemeDebug("mode2031-support", { supported });
 		for (const cb of this.#privateModeCallbacks) {
 			try {
 				cb(mode, supported);

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { extractPrintableText } from "@oh-my-pi/pi-tui/keys";
 import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
 import {
@@ -17,7 +20,8 @@ const stdoutRowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "ro
 const stdinSetRawModeDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "setRawMode");
 const originalWslDistroName = Bun.env.WSL_DISTRO_NAME;
 const originalWslInterop = Bun.env.WSL_INTEROP;
-
+const originalThemeDebug = Bun.env.OMP_THEME_DEBUG;
+const originalThemeDebugLog = Bun.env.OMP_THEME_DEBUG_LOG;
 // These suites drive the real ProcessTerminal start()/probe pipeline, so they
 // opt out of the test-default headless suppression and restore it per case.
 let previousHeadless = false;
@@ -38,6 +42,15 @@ function restoreEnv(key: string, original: string | undefined): void {
 	Bun.env[key] = original;
 }
 
+function terminalDebugPayloads(stderr: string[], event: string): Record<string, unknown>[] {
+	const prefix = `[omp-theme-debug] terminal ${event} `;
+	return stderr
+		.join("")
+		.split("\n")
+		.filter(line => line.startsWith(prefix))
+		.map(line => JSON.parse(line.slice(prefix.length)) as Record<string, unknown>);
+}
+
 describe("ProcessTerminal OSC 11 appearance detection", () => {
 	beforeEach(() => {
 		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
@@ -56,6 +69,8 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		restoreProperty(process, "platform", processPlatformDescriptor);
 		restoreEnv("WSL_INTEROP", originalWslInterop);
 		restoreEnv("WSL_DISTRO_NAME", originalWslDistroName);
+		restoreEnv("OMP_THEME_DEBUG", originalThemeDebug);
+		restoreEnv("OMP_THEME_DEBUG_LOG", originalThemeDebugLog);
 	});
 
 	function setupTerminal() {
@@ -142,6 +157,70 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		expect(appearances).toEqual(["dark"]);
 
 		terminal.stop();
+	});
+
+	it("replays startup OSC 11 appearance to callbacks registered after the response", () => {
+		vi.useFakeTimers();
+		const { terminal } = setupTerminal();
+
+		process.stdin.emit("data", "\x1b]11;rgb:fafa/fafa/fafa\x07");
+		// Startup also has the kitty keyboard DA1 sentinel ahead of OSC 11 in the FIFO.
+		process.stdin.emit("data", "\x1b[?1;2c");
+		process.stdin.emit("data", "\x1b[?1;2c");
+
+		const appearances: string[] = [];
+		terminal.onAppearanceChange(a => appearances.push(a));
+
+		expect(terminal.appearance).toBe("light");
+		expect(appearances).toEqual(["light"]);
+
+		process.stdin.emit("data", "\x1b[?997;2n");
+		vi.advanceTimersByTime(100);
+		process.stdin.emit("data", "\x1b]11;rgb:fafa/fafa/fafa\x07");
+		process.stdin.emit("data", "\x1b[?1;2c");
+
+		expect(appearances).toEqual(["light"]);
+
+		terminal.stop();
+	});
+
+	it("persists sanitized OSC 11 response and light appearance in debug log", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-terminal-debug-"));
+		const logPath = path.join(tempDir, "terminal.log");
+		let terminal: ProcessTerminal | undefined;
+
+		try {
+			Bun.env.OMP_THEME_DEBUG = "1";
+			Bun.env.OMP_THEME_DEBUG_LOG = logPath;
+			const stderr: string[] = [];
+			vi.spyOn(process.stderr, "write").mockImplementation(chunk => {
+				stderr.push(typeof chunk === "string" ? chunk : chunk.toString());
+				return true;
+			});
+			({ terminal } = setupTerminal());
+
+			process.stdin.emit("data", "\x1b]11;rgb:fafa/fafa/fafa\x07");
+			process.stdin.emit("data", "\x1b[?1;2c");
+
+			expect(terminal.appearance).toBe("light");
+			expect(terminalDebugPayloads(stderr, "osc11-response")).toContainEqual(
+				expect.objectContaining({
+					raw: "<ESC>]11;rgb:fafa/fafa/fafa<BEL>",
+					rHex: "fafa",
+					gHex: "fafa",
+					bHex: "fafa",
+					appearance: "light",
+				}),
+			);
+
+			const log = fs.readFileSync(logPath, "utf8");
+			expect(log).toContain("[omp-theme-debug] terminal osc11-response");
+			expect(log).toContain('"raw":"<ESC>]11;rgb:fafa/fafa/fafa<BEL>"');
+			expect(log).toContain('"appearance":"light"');
+		} finally {
+			terminal?.stop();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("2-digit hex OSC 11 response is correctly normalized", () => {


### PR DESCRIPTION
## Summary

- replay an already-detected terminal appearance to late `onAppearanceChange` subscribers
- add theme/terminal debug output gated by `OMP_THEME_DEBUG=1`, with optional persistent logging via `OMP_THEME_DEBUG_LOG`
- cover JetBrains-style OSC 11 `rgb:fafa/fafa/fafa` detection, debug log persistence, and late subscriber replay

## Why

`ProcessTerminal.start()` can receive and parse the startup OSC 11 response before `InteractiveMode.init()` registers its `onAppearanceChange` callback. Previously, late subscribers only received future changes, so theme auto-selection could remain on the fallback dark slot even after the terminal had already detected a light background.

## Verification

```text
bunx biome check packages/tui/src/terminal.ts packages/tui/test/terminal-appearance.test.ts packages/coding-agent/src/modes/theme/theme.ts packages/coding-agent/test/theme-auto-detection.test.ts run-omp-theme-debug.ps1
OK
```

```text
bun test packages/tui/test/terminal-appearance.test.ts packages/coding-agent/test/theme-auto-detection.test.ts
42 pass
0 fail
138 expect() calls
```

Note: `run-omp-theme-debug.ps1` was local-only and is not included in this PR.