### PR TITLE
fix(cli): stop exporting launch .env.local into commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash/tool command environments inheriting Bun-autoloaded launch `.env.local` values, so nested apps can load their own dotenv values without parent deployment variables taking precedence. ([#4723](https://github.com/can1357/oh-my-pi/issues/4723))
+
 ## [16.3.10] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/test/non-interactive-env.test.ts
+++ b/packages/coding-agent/test/non-interactive-env.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { buildNonInteractiveEnv } from "@oh-my-pi/pi-coding-agent/exec/non-interactive-env";
 
 describe("buildNonInteractiveEnv", () => {
@@ -44,4 +47,55 @@ describe("buildNonInteractiveEnv", () => {
 		expect(env.LANG).toBeUndefined();
 		expect(env.LC_ALL).toBeUndefined();
 	});
+});
+
+it("keeps launch .env.local values out of child shell config", async () => {
+	const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-env-local-"));
+	try {
+		await Bun.write(
+			path.join(tmp, ".env.local"),
+			"CONVEX_DEPLOYMENT=anonymous:root-local\nCONVEX_URL=http://127.0.0.1:3210\n",
+		);
+		const procmgrPath = path.resolve(import.meta.dir, "../../utils/src/procmgr.ts");
+		const script = [
+			`import { getShellConfig } from ${JSON.stringify(procmgrPath)};`,
+			"const env = getShellConfig().env;",
+			"console.log(JSON.stringify({",
+			"	deployment: env.CONVEX_DEPLOYMENT ?? null,",
+			"	url: env.CONVEX_URL ?? null,",
+			"	inherited: env.OMP_TEST_INHERITED_MARKER ?? null,",
+			"}));",
+		].join("\n");
+		const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
+			cwd: tmp,
+			env: {
+				HOME: process.env.HOME ?? "",
+				OMP_TEST_INHERITED_MARKER: "keep-me",
+				PATH: process.env.PATH ?? "",
+				SHELL: process.env.SHELL ?? "/bin/bash",
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+			proc.exited,
+		]);
+
+		expect(stderr).toBe("");
+		expect(exitCode).toBe(0);
+		const payload: {
+			deployment: string | null;
+			url: string | null;
+			inherited: string | null;
+		} = JSON.parse(stdout);
+		expect(payload).toEqual({
+			deployment: null,
+			url: null,
+			inherited: "keep-me",
+		});
+	} finally {
+		await fs.rm(tmp, { recursive: true, force: true });
+	}
 });

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed child shell environment filtering to drop launch-directory `.env.local` values that Bun auto-loaded before OMP starts command shells. ([#4723](https://github.com/can1357/oh-my-pi/issues/4723))
+
 ## [16.3.10] - 2026-07-06
 
 ### Added

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -53,6 +53,19 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
 	return result;
 }
 
+/** Filters process env for child shells without launch-cwd `.env.local` values. */
+export function filterChildShellEnv(
+	env: Record<string, string | undefined>,
+	cwd: string = process.cwd(),
+): Record<string, string> {
+	const result = filterProcessEnv(env);
+	const launchLocalEnv = parseEnvFile(path.join(cwd, ".env.local"));
+	for (const key in launchLocalEnv) {
+		if (result[key] === launchLocalEnv[key]) delete result[key];
+	}
+	return result;
+}
+
 /**
  * Parses a .env file synchronously and extracts key-value string pairs.
  * Ignores lines that are empty or start with '#'. Trims whitespace.

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { Process, ProcessStatus } from "@oh-my-pi/pi-natives";
 import type { Subprocess } from "bun";
-import { $env, filterProcessEnv } from "./env";
+import { $env, filterChildShellEnv } from "./env";
 import { $which } from "./which";
 
 export interface ShellConfig {
@@ -31,7 +31,7 @@ export function isExecutable(path: string): boolean {
 function buildSpawnEnv(shell: string): Record<string, string> {
 	const noCI = $env.PI_BASH_NO_CI || $env.CLAUDE_BASH_NO_CI;
 	return {
-		...filterProcessEnv(Bun.env),
+		...filterChildShellEnv(Bun.env),
 		SHELL: shell,
 		GIT_EDITOR: "true",
 		GPG_TTY: "not a tty",


### PR DESCRIPTION
## Repro
Starting OMP from a directory containing `.env.local` with `CONVEX_DEPLOYMENT=anonymous:root-local` and `CONVEX_URL=http://127.0.0.1:3210` populated `getShellConfig().env` with those values before nested commands could load their own dotenv files; the focused regression test reproduces this with an isolated Bun process launched from a temp cwd containing `.env.local`.

## Cause
`packages/utils/src/procmgr.ts` built shell session environments from `filterProcessEnv(Bun.env)`. When OMP runs through Bun source entrypoints, Bun auto-loads the launch cwd `.env.local` into `Bun.env`; the bash executor then passes that shell session env into command shells, so dotenv-style CLIs in nested directories see parent values already exported and do not override them.

## Fix
- Added `filterChildShellEnv()` in `packages/utils/src/env.ts` to preserve safe inherited env values while dropping launch-directory `.env.local` entries whose values match Bun's auto-loaded env.
- Updated `getShellConfig()` shell env construction in `packages/utils/src/procmgr.ts` to use the child-shell filter.
- Added a regression test that verifies Convex-style launch `.env.local` keys are absent from child shell config while ordinary inherited env survives.
- Updated the coding-agent and utils changelogs for #4723.

## Verification
Reproduced before the fix with an isolated Bun process importing `packages/utils/src/procmgr.ts` from a cwd containing `.env.local`, which printed `{"convexDeployment":"anonymous:root-local","convexUrl":"http://127.0.0.1:3210"}`. After the fix, the same probe printed `{"convexDeployment":null,"convexUrl":null,"inherited":"keep-me"}`. Ran `bun test packages/coding-agent/test/non-interactive-env.test.ts` twice; final run passed with 6 tests and 21 expectations. `gh_push_branch` also completed the pre-publish gate and pushed commit `4b2924887758`. Fixes #4723