### PR TITLE
feat(coding-agent): add You.com (ydc) web search provider

### DIFF
--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -62,6 +62,7 @@ import { xiaomiProvider } from "./xiaomi";
 import { xiaomiTokenPlanAmsProvider } from "./xiaomi-token-plan-ams";
 import { xiaomiTokenPlanCnProvider } from "./xiaomi-token-plan-cn";
 import { xiaomiTokenPlanSgpProvider } from "./xiaomi-token-plan-sgp";
+import { ydcProvider } from "./ydc";
 import { zaiProvider } from "./zai";
 import { zenmuxProvider } from "./zenmux";
 import { zhipuCodingPlanProvider } from "./zhipu-coding-plan";
@@ -126,6 +127,7 @@ const ALL = [
 	tavilyProvider,
 	kagiProvider,
 	parallelProvider,
+	ydcProvider,
 	ollamaProvider,
 	ollamaCloudProvider,
 	lmStudioProvider,

--- a/packages/ai/src/registry/ydc.ts
+++ b/packages/ai/src/registry/ydc.ts
@@ -1,0 +1,46 @@
+import * as AIError from "../error";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://you.com/platform";
+
+/**
+ * Login to You.com.
+ *
+ * Opens browser to the You.com platform dashboard and prompts the user to
+ * paste their API key. Returns the API key directly (not OAuthCredentials -
+ * this isn't OAuth).
+ */
+export async function loginYou(options: OAuthLoginCallbacks): Promise<string> {
+	if (!options.onPrompt) {
+		throw new AIError.OnPromptRequiredError("You.com");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your You.com API key from the You.com platform dashboard.",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your You.com API key",
+		placeholder: "ydc-sk-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new AIError.LoginCancelledError();
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new AIError.ApiKeyRequiredError();
+	}
+
+	return trimmed;
+}
+
+export const ydcProvider = {
+	id: "ydc",
+	name: "You.com",
+	envKeys: "YDC_API_KEY",
+	login: (cb: OAuthLoginCallbacks) => loginYou(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added You.com (`ydc`) as a supported web search provider with `YDC_API_KEY` credential discovery, `/login` paste-key support, and provider fallback support
+
 ### Fixed
 
 - Improved reliability of edits when file snapshots share identical 16-bit hash tags

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -342,6 +342,7 @@ export function getExtraHelpText(): string {
   PERPLEXITY_API_KEY         - Perplexity web search API key (optional; anonymous fallback)
   PERPLEXITY_COOKIES         - Perplexity web search (session cookie)
   TAVILY_API_KEY             - Tavily web search
+  YDC_API_KEY                - You.com web search
   TINYFISH_API_KEY           - TinyFish web search
   FIRECRAWL_API_KEY          - Firecrawl web search
   ANTHROPIC_SEARCH_API_KEY   - Anthropic web search (override; isolates search from main ANTHROPIC_API_KEY)

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-bundled-keys.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-bundled-keys.ts
@@ -989,6 +989,7 @@ export const BUNDLED_PI_REGISTRY_KEYS: ReadonlySet<string> = new Set([
 	"@oh-my-pi/pi-coding-agent/web/search/providers/tinyfish",
 	"@oh-my-pi/pi-coding-agent/web/search/providers/utils",
 	"@oh-my-pi/pi-coding-agent/web/search/providers/xai",
+	"@oh-my-pi/pi-coding-agent/web/search/providers/ydc",
 	"@oh-my-pi/pi-coding-agent/web/search/providers/zai",
 	"@oh-my-pi/pi-natives",
 	"@oh-my-pi/pi-tui",

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-bundled-registry.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-bundled-registry.ts
@@ -991,6 +991,7 @@ import * as bundledPiCodingAgentWebSearchProvidersTavily from "@oh-my-pi/pi-codi
 import * as bundledPiCodingAgentWebSearchProvidersTinyfish from "@oh-my-pi/pi-coding-agent/web/search/providers/tinyfish";
 import * as bundledPiCodingAgentWebSearchProvidersUtils from "@oh-my-pi/pi-coding-agent/web/search/providers/utils";
 import * as bundledPiCodingAgentWebSearchProvidersXai from "@oh-my-pi/pi-coding-agent/web/search/providers/xai";
+import * as bundledPiCodingAgentWebSearchProvidersYdc from "@oh-my-pi/pi-coding-agent/web/search/providers/ydc";
 import * as bundledPiCodingAgentWebSearchProvidersZai from "@oh-my-pi/pi-coding-agent/web/search/providers/zai";
 import * as bundledPiCodingAgentWebSearchRender from "@oh-my-pi/pi-coding-agent/web/search/render";
 import * as bundledPiCodingAgentWebSearchTypes from "@oh-my-pi/pi-coding-agent/web/search/types";
@@ -3395,6 +3396,8 @@ export const BUNDLED_PI_REGISTRY: Readonly<Record<string, Readonly<Record<string
 		bundledPiCodingAgentWebSearchProvidersUtils as unknown as Readonly<Record<string, unknown>>,
 	"@oh-my-pi/pi-coding-agent/web/search/providers/xai":
 		bundledPiCodingAgentWebSearchProvidersXai as unknown as Readonly<Record<string, unknown>>,
+	"@oh-my-pi/pi-coding-agent/web/search/providers/ydc":
+		bundledPiCodingAgentWebSearchProvidersYdc as unknown as Readonly<Record<string, unknown>>,
 	"@oh-my-pi/pi-coding-agent/web/search/providers/zai":
 		bundledPiCodingAgentWebSearchProvidersZai as unknown as Readonly<Record<string, unknown>>,
 	"@oh-my-pi/pi-natives": bundledPiNatives as unknown as Readonly<Record<string, unknown>>,

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -79,6 +79,11 @@ const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
 		label: SEARCH_PROVIDER_LABELS.tavily,
 		load: async () => new (await import("./providers/tavily")).TavilyProvider(),
 	},
+	ydc: {
+		id: "ydc",
+		label: SEARCH_PROVIDER_LABELS.ydc,
+		load: async () => new (await import("./providers/ydc")).YouProvider(),
+	},
 	firecrawl: {
 		id: "firecrawl",
 		label: SEARCH_PROVIDER_LABELS.firecrawl,

--- a/packages/coding-agent/src/web/search/providers/ydc.ts
+++ b/packages/coding-agent/src/web/search/providers/ydc.ts
@@ -1,0 +1,197 @@
+/**
+ * You.com Web Search Provider
+ *
+ * Uses You.com's agent-focused search API to return structured web and news
+ * results.
+ */
+import { type ApiKey, type AuthStorage, type FetchImpl, getEnvApiKey, withAuth } from "@oh-my-pi/pi-ai";
+import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { clampNumResults, dateToAgeSeconds } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+import { classifyProviderHttpError, withHardTimeout } from "./utils";
+
+const YDC_SEARCH_URL = "https://api.you.com/v1/agents/search";
+const DEFAULT_NUM_RESULTS = 5;
+const MAX_NUM_RESULTS = 20;
+
+export interface YouSearchParams {
+	query: string;
+	num_results?: number;
+	recency?: "day" | "week" | "month" | "year";
+	signal?: AbortSignal;
+	fetch?: FetchImpl;
+}
+
+interface YouWebResult {
+	url?: string | null;
+	title?: string | null;
+	description?: string | null;
+	snippets?: string[] | null;
+	page_age?: string | null;
+	authors?: string[] | null;
+}
+
+interface YouNewsResult {
+	url?: string | null;
+	title?: string | null;
+	description?: string | null;
+	page_age?: string | null;
+}
+
+interface YouSearchResponse {
+	results?: {
+		web?: YouWebResult[] | null;
+		news?: YouNewsResult[] | null;
+	} | null;
+	metadata?: {
+		search_uuid?: string | null;
+		query?: string | null;
+	} | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	if (typeof value !== "object" || value === null) return null;
+	return value as Record<string, unknown>;
+}
+
+function getErrorMessage(value: unknown): string | null {
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : null;
+	}
+
+	const record = asRecord(value);
+	if (!record) return null;
+
+	for (const key of ["detail", "error", "message"]) {
+		const message = getErrorMessage(record[key]);
+		if (message) return message;
+	}
+
+	return null;
+}
+
+/** Exported for testing. Builds the You.com request body from unified params. */
+export function buildRequestBody(params: YouSearchParams): Record<string, unknown> {
+	const numResults = clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+	// `count` is You.com's per-section (web/news) result cap. Recency maps to the
+	// orthogonal `freshness` temporal filter and is only sent when requested,
+	// keeping the default corpus intact for technical queries.
+	const body: Record<string, unknown> = {
+		query: params.query,
+		count: numResults,
+	};
+	if (params.recency) {
+		body.freshness = params.recency;
+	}
+	return body;
+}
+
+async function callYouSearch(apiKey: string, params: YouSearchParams): Promise<YouSearchResponse> {
+	const response = await (params.fetch ?? fetch)(YDC_SEARCH_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			// You.com's public API endpoint trips Bun's response decompression;
+			// request an uncompressed body to keep parsing reliable.
+			"Accept-Encoding": "identity",
+			"X-API-Key": apiKey,
+		},
+		body: JSON.stringify(buildRequestBody(params)),
+		signal: withHardTimeout(params.signal),
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		const classified = classifyProviderHttpError("ydc", response.status, errorText);
+		if (classified) throw classified;
+		let message = errorText.trim();
+		if (message.length === 0) {
+			message = response.statusText;
+		} else {
+			try {
+				message = getErrorMessage(JSON.parse(errorText)) ?? message;
+			} catch {
+				// Keep raw text fallback.
+			}
+		}
+		throw new SearchProviderError("ydc", `You.com API error (${response.status}): ${message}`, response.status);
+	}
+
+	return (await response.json()) as YouSearchResponse;
+}
+
+function toSearchResponse(response: YouSearchResponse, numResults: number): SearchResponse {
+	const sources: SearchSource[] = [];
+
+	for (const result of response.results?.web ?? []) {
+		if (!result.url) continue;
+		const snippetParts: string[] = [];
+		if (result.description) snippetParts.push(result.description);
+		if (result.snippets?.length) snippetParts.push(...result.snippets);
+		sources.push({
+			title: result.title ?? result.url,
+			url: result.url,
+			snippet: snippetParts.length > 0 ? snippetParts.join("\n") : undefined,
+			publishedDate: result.page_age ?? undefined,
+			ageSeconds: dateToAgeSeconds(result.page_age ?? undefined),
+			author: result.authors?.[0] ?? undefined,
+		});
+	}
+
+	for (const result of response.results?.news ?? []) {
+		if (!result.url) continue;
+		sources.push({
+			title: result.title ?? result.url,
+			url: result.url,
+			snippet: result.description ?? undefined,
+			publishedDate: result.page_age ?? undefined,
+			ageSeconds: dateToAgeSeconds(result.page_age ?? undefined),
+		});
+	}
+
+	return {
+		provider: "ydc",
+		sources: sources.slice(0, numResults),
+		requestId: response.metadata?.search_uuid ?? undefined,
+		authMode: "api_key",
+	};
+}
+
+/** Execute You.com web search. */
+export async function searchYou(params: SearchParams): Promise<SearchResponse> {
+	const youParams: YouSearchParams = {
+		query: params.query,
+		num_results: params.numSearchResults ?? params.limit,
+		recency: params.recency,
+		signal: params.signal,
+		fetch: params.fetch,
+	};
+	const keyOrResolver: ApiKey = params.authStorage.resolver("ydc", {
+		sessionId: params.sessionId,
+	});
+
+	const numResults = clampNumResults(youParams.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+	const response = await withAuth(keyOrResolver, key => callYouSearch(key, youParams), {
+		signal: params.signal,
+		missingKeyMessage: 'You.com credentials not found. Set YDC_API_KEY or configure an API key for provider "ydc".',
+	});
+
+	return toSearchResponse(response, numResults);
+}
+
+/** Search provider for You.com web search. */
+export class YouProvider extends SearchProvider {
+	readonly id = "ydc";
+	readonly label = "You.com";
+
+	isAvailable(authStorage: AuthStorage): boolean {
+		return authStorage.hasAuth("ydc") || !!getEnvApiKey("ydc");
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchYou(params);
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -37,6 +37,7 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "jina", label: "Jina", description: "Requires JINA_API_KEY" },
 	{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY and Kagi Search API beta access" },
 	{ value: "tavily", label: "Tavily", description: "Requires TAVILY_API_KEY" },
+	{ value: "ydc", label: "You.com", description: "Requires YDC_API_KEY" },
 	{ value: "firecrawl", label: "Firecrawl", description: "Requires FIRECRAWL_API_KEY" },
 	{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },
 	{ value: "kimi", label: "Kimi", description: "Requires MOONSHOT_SEARCH_API_KEY or MOONSHOT_API_KEY" },

--- a/packages/coding-agent/test/tools/web-search-ydc.test.ts
+++ b/packages/coding-agent/test/tools/web-search-ydc.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { searchYou } from "@oh-my-pi/pi-coding-agent/web/search/providers/ydc";
+import type { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
+
+describe("You.com web search provider", () => {
+	beforeEach(() => {
+		process.env.YDC_API_KEY = "test-ydc-key";
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.YDC_API_KEY;
+	});
+
+	const fakeAuthStorage = {
+		async getApiKey() {
+			return process.env.YDC_API_KEY ?? undefined;
+		},
+		hasAuth() {
+			return Boolean(process.env.YDC_API_KEY);
+		},
+		resolver(_provider: string) {
+			return async () => process.env.YDC_API_KEY ?? undefined;
+		},
+		async rotateSessionCredential() {
+			return false;
+		},
+	} as unknown as AuthStorage;
+
+	function makeParams(query: string) {
+		return {
+			query,
+			authStorage: fakeAuthStorage,
+			systemPrompt: "You.com test prompt",
+		} as const;
+	}
+
+	it("maps web and news results into a unified SearchResponse", async () => {
+		const fetchMock = async (): Promise<Response> =>
+			new Response(
+				JSON.stringify({
+					results: {
+						web: [
+							{
+								title: "Result One",
+								url: "https://example.com/one",
+								description: "First description",
+								snippets: ["snippet a", "snippet b"],
+								page_age: "2026-03-01T00:00:00Z",
+								authors: ["Jane Doe"],
+							},
+							{ url: "https://example.com/two", description: "Second description" },
+							{ title: "No URL", description: "dropped" },
+						],
+						news: [
+							{
+								title: "News One",
+								url: "https://news.example.com/n1",
+								description: "News description",
+								page_age: "2026-05-01T00:00:00Z",
+							},
+						],
+					},
+					metadata: { search_uuid: "req-ydc-123", query: "latest ai" },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const response = await searchYou({
+			...makeParams("latest ai"),
+			numSearchResults: 5,
+			fetch: fetchMock,
+		});
+
+		expect(response.provider).toBe("ydc");
+		expect(response.authMode).toBe("api_key");
+		expect(response.requestId).toBe("req-ydc-123");
+		// URL-less result is dropped; web results precede news results.
+		expect(response.sources).toMatchObject([
+			{
+				title: "Result One",
+				url: "https://example.com/one",
+				snippet: "First description\nsnippet a\nsnippet b",
+				publishedDate: "2026-03-01T00:00:00Z",
+				author: "Jane Doe",
+			},
+			{
+				title: "https://example.com/two",
+				url: "https://example.com/two",
+				snippet: "Second description",
+			},
+			{
+				title: "News One",
+				url: "https://news.example.com/n1",
+				snippet: "News description",
+				publishedDate: "2026-05-01T00:00:00Z",
+			},
+		]);
+		expect(response.sources[0]?.ageSeconds).toBeTypeOf("number");
+	});
+
+	it("slices combined web and news results to numSearchResults", async () => {
+		const fetchMock = async (): Promise<Response> =>
+			new Response(
+				JSON.stringify({
+					results: {
+						web: [
+							{ title: "W1", url: "https://example.com/w1" },
+							{ title: "W2", url: "https://example.com/w2" },
+						],
+						news: [{ title: "N1", url: "https://news.example.com/n1" }],
+					},
+					metadata: {},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const response = await searchYou({
+			...makeParams("bounded"),
+			numSearchResults: 2,
+			fetch: fetchMock,
+		});
+
+		expect(response.sources.map(s => s.url)).toEqual(["https://example.com/w1", "https://example.com/w2"]);
+	});
+
+	it("surfaces structured API errors", async () => {
+		const fetchMock = (): Promise<Response> =>
+			Promise.resolve(
+				new Response(JSON.stringify({ error: "invalid api key" }), {
+					status: 403,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+
+		await expect(searchYou({ ...makeParams("bad auth"), fetch: fetchMock })).rejects.toEqual(
+			expect.objectContaining({
+				provider: "ydc",
+				status: 403,
+				message: "ydc: 403 forbidden",
+			}) satisfies Partial<SearchProviderError>,
+		);
+	});
+
+	it("throws a clear error when You.com credentials are missing", async () => {
+		delete process.env.YDC_API_KEY;
+		await expect(searchYou(makeParams("missing creds"))).rejects.toThrow(
+			'You.com credentials not found. Set YDC_API_KEY or configure an API key for provider "ydc".',
+		);
+	});
+});

--- a/packages/coding-agent/test/web/search/ydc.test.ts
+++ b/packages/coding-agent/test/web/search/ydc.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { buildRequestBody, searchYou, type YouSearchParams } from "@oh-my-pi/pi-coding-agent/web/search/providers/ydc";
+
+describe("You.com buildRequestBody", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("always includes query and count", () => {
+		const body = buildRequestBody({ query: "Bun 1.3 release notes", num_results: 7 });
+		expect(body.query).toBe("Bun 1.3 release notes");
+		expect(body.count).toBe(7);
+	});
+
+	it("defaults count to 5 when num_results is unset", () => {
+		const body = buildRequestBody({ query: "q" });
+		expect(body.count).toBe(5);
+	});
+
+	it("omits freshness when recency is unset", () => {
+		const body = buildRequestBody({ query: "q" });
+		expect(body).not.toHaveProperty("freshness");
+	});
+
+	it.each(["day", "week", "month", "year"] as const)("passes %s through as freshness verbatim", recency => {
+		const body = buildRequestBody({ query: "q", recency });
+		expect(body.freshness).toBe(recency);
+	});
+});
+
+describe("You.com searchYou request shape (integration)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.YDC_API_KEY;
+	});
+
+	const fakeAuthStorage = {
+		async getApiKey() {
+			return process.env.YDC_API_KEY ?? undefined;
+		},
+		resolver: vi.fn(() => async () => process.env.YDC_API_KEY ?? undefined),
+		hasAuth() {
+			return Boolean(process.env.YDC_API_KEY);
+		},
+	} as unknown as AuthStorage;
+
+	function makeParams(query: string, extras: Partial<YouSearchParams> = {}) {
+		return {
+			query,
+			authStorage: fakeAuthStorage,
+			systemPrompt: "You.com integration test prompt",
+			...extras,
+		};
+	}
+
+	it("posts query, count, and freshness with the X-API-Key header", async () => {
+		process.env.YDC_API_KEY = "test-ydc-key";
+
+		let capturedUrl: string | undefined;
+		let capturedBody: Record<string, unknown> | undefined;
+		let capturedApiKey: string | undefined;
+		const fetchMock: FetchImpl = async (input, init) => {
+			capturedUrl =
+				typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			capturedBody = JSON.parse(init?.body as string);
+			capturedApiKey = new Headers(init?.headers).get("X-API-Key") ?? undefined;
+			return new Response(JSON.stringify({ results: { web: [] }, metadata: { search_uuid: "req-0" } }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		await searchYou({
+			...makeParams("Bun runtime latest release notes", { recency: "week" }),
+			numSearchResults: 3,
+			fetch: fetchMock,
+		});
+
+		expect(capturedUrl).toBe("https://api.you.com/v1/agents/search");
+		expect(capturedApiKey).toBe("test-ydc-key");
+		expect(capturedBody).toMatchObject({
+			query: "Bun runtime latest release notes",
+			count: 3,
+			freshness: "week",
+		});
+	});
+
+	it("omits freshness entirely when recency is not provided", async () => {
+		process.env.YDC_API_KEY = "test-ydc-key";
+
+		let capturedBody: Record<string, unknown> | undefined;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			capturedBody = JSON.parse(init?.body as string);
+			return new Response(JSON.stringify({ results: {}, metadata: {} }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		await searchYou({ ...makeParams("bun sqlite"), fetch: fetchMock });
+
+		expect(capturedBody).toBeDefined();
+		expect(capturedBody).not.toHaveProperty("freshness");
+	});
+});


### PR DESCRIPTION
Hi! 👋

I'm Eugene, and I work at You.com (YDC). First — thank you for building oh-my-pi. It's a fantastic project, and we'd love for people to be able to reach You.com search from within it. This is my first PR here, so please let me know if anything doesn't match how you'd like contributions done — I'm very happy to adjust.

## What this adds

This adds **You.com** as a provider for the `web_search` tool. With a `YDC_API_KEY` set, the agent can search the web through You.com just like any of the other supported providers — it slots into the existing search chain and settings. You can also authenticate interactively: `omp login` offers You.com and prompts you to paste your API key.

## How it works

- A new provider definition teaches the auth layer about You.com — where to find the key (`YDC_API_KEY`), how to log in, and how to rotate credentials on auth failures.
- The provider calls `https://api.you.com/v1/agents/search` with your key, translates the tool's parameters into You.com's request (result count, and a time filter when you ask for recent results), and folds the web and news results back into the shared result shape the agent already understands. Network and auth errors flow through the same handling every other provider uses.
- You.com is registered in the provider list, shows up in settings and the setup dropdown, and `YDC_API_KEY` is documented in the CLI's environment-variable help.

## A couple of small choices

- You.com's search endpoint doesn't return a synthesized answer, so results come back as a clean list of sources without a summary blurb.
- A recency filter maps to You.com's time filter and is only sent when you actually ask for it, so ordinary queries keep the full index.

## Testing

Unit tests cover the request shape, the web + news result mapping, result limiting, error handling, and the missing-key message. Type checks and formatting are clean, and the wider search and AI test suites still pass.

I also ran it live against the real API:
- A recent-Bun-release query returned five well-formed sources — titles, URLs, publish dates, and snippets — with the recency filter correctly applied.
- Running the same path the agent uses ("OpenAI news today") produced the properly formatted, freshness-aware output the model would see.

Would you be open to accepting this? I'd be glad to iterate on any review feedback, tweak the approach, or split things up differently if that's easier to review. Thanks so much for your time and consideration!

— Eugene, You.com