### PR TITLE
fix(coding-agent): preserve literal bash internal URLs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash internal-URL expansion so unresolved literal `memory://` / `skill://` text stays verbatim instead of aborting command execution ([#4737](https://github.com/can1357/oh-my-pi/issues/4737)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -140,6 +140,30 @@ function unquoteToken(token: string): string {
 	return token;
 }
 
+function isInsideShellQuote(command: string, index: number): boolean {
+	let quote: "'" | '"' | undefined;
+	for (let i = 0; i < index; i++) {
+		const char = command[i];
+		if (char === "\\" && quote !== "'") {
+			i++;
+			continue;
+		}
+		if (char === "'" && quote !== '"') {
+			quote = quote === "'" ? undefined : "'";
+			continue;
+		}
+		if (char === '"' && quote !== "'") {
+			quote = quote === '"' ? undefined : '"';
+		}
+	}
+	return quote !== undefined;
+}
+
+function isEmbeddedInQuotedText(command: string, token: string, index: number): boolean {
+	if (token.startsWith("'") || token.startsWith('"')) return false;
+	return isInsideShellQuote(command, index);
+}
+
 /** Shell-escape a path using single quotes. */
 function shellEscape(p: string): string {
 	return `'${p.replace(/'/g, "'\\''")}'`;
@@ -216,6 +240,7 @@ export function expandSkillUrls(command: string, skills: readonly Skill[]): stri
 
 /**
  * Expand supported internal URLs in a bash command string to shell-escaped absolute paths.
+ * Unresolvable URLs and literal mentions inside larger quoted text are left unchanged.
  * Supported schemes: skill://, agent://, artifact://, memory://, rule://, local://
  */
 export async function expandInternalUrls(command: string, options: InternalUrlExpansionOptions): Promise<string> {
@@ -231,15 +256,22 @@ export async function expandInternalUrls(command: string, options: InternalUrlEx
 		const index = match.index;
 		if (index === undefined) continue;
 
+		if (isEmbeddedInQuotedText(command, token, index)) continue;
+
 		const rawUrl = unquoteToken(token);
 		const url = normalizeLocalScheme(rawUrl);
-		const resolvedPath = await resolveInternalUrlToPath(
-			url,
-			options.skills,
-			options.internalRouter,
-			options.localOptions,
-			options.ensureLocalParentDirs,
-		);
+		let resolvedPath: string;
+		try {
+			resolvedPath = await resolveInternalUrlToPath(
+				url,
+				options.skills,
+				options.internalRouter,
+				options.localOptions,
+				options.ensureLocalParentDirs,
+			);
+		} catch {
+			continue;
+		}
 		const replacement = options.noEscape ? resolvedPath : shellEscape(resolvedPath);
 		expanded = `${expanded.slice(0, index)}${replacement}${expanded.slice(index + token.length)}`;
 	}

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -178,6 +178,22 @@ describe("expandInternalUrls", () => {
 		);
 	});
 
+	it("leaves literal internal URLs embedded in quoted text unchanged", async () => {
+		const router = createInternalRouter({
+			"memory://root/summary.md": { sourcePath: "/tmp/memories/summary.md" },
+		});
+		const command = `printf '%s\\n' 'the literal memory://root/summary.md string'`;
+
+		await expect(expandInternalUrls(command, { skills: [], internalRouter: router })).resolves.toBe(command);
+	});
+
+	it("leaves unresolved quoted literal URLs unchanged", async () => {
+		const router = createInternalRouter({});
+		const command = "grep 'memory://xyz-quoted' file.txt";
+
+		await expect(expandInternalUrls(command, { skills: [], internalRouter: router })).resolves.toBe(command);
+	});
+
 	it("expands agent:// URLs when router is available", async () => {
 		const router = createInternalRouter({
 			"agent://abc": { sourcePath: "/tmp/session/abc.md" },
@@ -239,34 +255,30 @@ describe("expandInternalUrls", () => {
 		);
 	});
 
-	it("throws when local:// URL is used without local protocol options", async () => {
-		await expect(expandInternalUrls("mv foo local://bar", { skills: [] })).rejects.toThrow(
-			"Cannot resolve local:// URL in bash command: local protocol options are unavailable for this session.",
-		);
+	it("leaves local:// URLs unchanged without local protocol options", async () => {
+		const command = "mv foo local://bar";
+		await expect(expandInternalUrls(command, { skills: [] })).resolves.toBe(command);
 	});
 
-	it("throws when non-skill URL is used without an internal router", async () => {
-		await expect(expandInternalUrls("cat artifact://1", { skills: [] })).rejects.toThrow(
-			"Cannot resolve artifact:// URL in bash command",
-		);
+	it("leaves non-skill URLs unchanged without an internal router", async () => {
+		const command = "cat artifact://1";
+		await expect(expandInternalUrls(command, { skills: [] })).resolves.toBe(command);
 	});
 
-	it("throws when internal router resolves URL without sourcePath", async () => {
+	it("leaves internal URLs unchanged when they resolve without sourcePath", async () => {
 		const router = createInternalRouter({
 			"rule://my-rule": {},
 		});
-		await expect(expandInternalUrls("cat rule://my-rule", { skills: [], internalRouter: router })).rejects.toThrow(
-			"rule:// URL resolved without a filesystem path",
-		);
+		const command = "cat rule://my-rule";
+		await expect(expandInternalUrls(command, { skills: [], internalRouter: router })).resolves.toBe(command);
 	});
 
-	it("surfaces resolver errors with actionable context", async () => {
+	it("leaves internal URLs unchanged when the resolver fails", async () => {
 		const router = createInternalRouter({
 			"memory://root/missing.md": { error: "Memory file not found" },
 		});
-		await expect(
-			expandInternalUrls("cat memory://root/missing.md", { skills: [], internalRouter: router }),
-		).rejects.toThrow("Failed to resolve memory:// URL in bash command");
+		const command = "cat memory://root/missing.md";
+		await expect(expandInternalUrls(command, { skills: [], internalRouter: router })).resolves.toBe(command);
 	});
 
 	it("does not match local:/ inside filesystem paths (e.g. /repo/local:/PLAN.md)", async () => {


### PR DESCRIPTION
## Repro
Calling `expandInternalUrls` for `printf '%s\n' 'the literal memory://xyz-quoted string'` with a router that recognizes `memory://` but fails to resolve `memory://xyz-quoted` reproduced the issue: expansion threw `ToolError: Failed to resolve memory:// URL in bash command: memory://xyz-quoted` before the command could execute.

## Cause
`packages/coding-agent/src/tools/bash-skill-urls.ts` scanned the entire bash command with `INTERNAL_URL_PATTERN_INCLUDING_NORMALIZED_LOCAL`, including URL-looking text inside larger quoted shell literals, and `expandInternalUrls` let every `resolveInternalUrlToPath` failure propagate. That made literal mentions behave like path arguments and aborted the bash tool on resolver misses.

## Fix
- Added shell-quote context detection so bare internal-URL matches embedded inside larger quoted text are left unchanged.
- Changed `expandInternalUrls` to leave unresolvable internal URLs verbatim instead of throwing before bash can run.
- Updated `bash-skill-urls` tests for quoted literal mentions, unresolved quoted URL tokens, and unresolved router/local/source-path cases.
- Added the coding-agent changelog entry for the fix.

## Verification
`bun test test/tools/bash-skill-urls.test.ts` from `packages/coding-agent`: 31 pass, 0 fail. `bun check`: passed for all packages. Manual JS repro after the fix returned the original `printf '%s\n' 'the literal memory://xyz-quoted string'` command instead of throwing. Fixes #4737