### PR TITLE
feat(coding-agent): support per-task task agents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added per-task agent overrides for `task` tool batch items, defaulting omitted item agents to the top-level agent.
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -4,6 +4,8 @@ Execution blocks your turn: the call only returns once the work is completely fi
 
 # Delegation Strategy
 - **Maximize parallelism:** Break work into the widest possible {{#if batchEnabled}}array of `tasks[]`{{else}}set of parallel `task` calls{{/if}}. NEVER serialize work that can run concurrently. Tasks touching different files or independent refactors should run in parallel; agents resolve their own file collisions live.
+{{#if batchEnabled}}- **One shared context, one batch:** Keep work sharing the same context/contract in one `tasks[]` batch, even when items use different `agent` overrides. Split calls only for different context/contracts, not merely different agents.
+{{/if}}
 {{#when MAX_CONCURRENCY ">" 0}}
 - **Concurrency cap:** At most {{pluralize MAX_CONCURRENCY "subagent" "subagents"}} run at once in this session — anything beyond that just queues, so a {{#if batchEnabled}}`tasks[]` batch{{else}}set of parallel `task` calls{{/if}} larger than {{MAX_CONCURRENCY}} only delays results. Keep the fan-out at or under the cap.
 {{/when}}
@@ -18,6 +20,7 @@ Execution blocks your turn: the call only returns once the work is completely fi
 {{#if batchEnabled}}
 - `context`: Shared project state, constraints, and contracts. Applies to the entire batch; do not duplicate this background into individual tasks.
 - `tasks[]`: Array of subagents to spawn.
+  - `agent`: Optional agent override for this item; defaults to the top-level `agent`.
   - `assignment`: Complete, self-contained instructions. One-liners or missing acceptance criteria are PROHIBITED.
   - `id`: A stable CamelCase identifier (≤32 chars). Generated automatically if omitted.
   - `description`: A UI label only; the subagent NEVER sees it.

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -317,7 +317,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
  * item's `isolated` (batch form) wins over the top-level flag (flat form).
  */
 function spawnParamsFor(params: TaskParams, item: TaskItem): TaskParams {
-	const spawn: TaskParams = { agent: params.agent };
+	const spawn: TaskParams = { agent: item.agent ?? params.agent };
 	if (item.id !== undefined) spawn.id = item.id;
 	if (item.description !== undefined) spawn.description = item.description;
 	if (item.role !== undefined) spawn.role = item.role;
@@ -329,6 +329,83 @@ function spawnParamsFor(params: TaskParams, item: TaskItem): TaskParams {
 		spawn.isolated = params.isolated;
 	}
 	return spawn;
+}
+
+interface ResolvedSpawnItem {
+	item: TaskItem;
+	index: number;
+	agentName: string;
+	agent: AgentDefinition;
+}
+
+type SpawnItemAgentResolution = { ok: true; resolved: ResolvedSpawnItem[] } | { ok: false; error: string };
+
+function spawnItemTarget(item: TaskItem, index: number): string {
+	const id = item.id?.trim();
+	return id ? `task id \`${id}\`` : `index ${index + 1}`;
+}
+
+function resolveSpawnItemAgents(args: {
+	params: TaskParams;
+	items: TaskItem[];
+	agents: AgentDefinition[];
+	disabledAgents: string[];
+	blockedAgent?: string;
+	parentSpawns: string | boolean | null | undefined;
+}): SpawnItemAgentResolution {
+	const available = args.agents.map(agent => agent.name).join(", ") || "none";
+	const enabled = args.agents.filter(agent => !args.disabledAgents.includes(agent.name)).map(agent => agent.name);
+	const spawnPolicy = resolveSpawnPolicy(args.parentSpawns);
+	const resolved: ResolvedSpawnItem[] = [];
+
+	for (let index = 0; index < args.items.length; index++) {
+		const item = args.items[index];
+		const agentName = item.agent ?? args.params.agent ?? "";
+		const target = spawnItemTarget(item, index);
+		const agent = getAgent(args.agents, agentName);
+		if (!agent) {
+			return { ok: false, error: `Unknown agent "${agentName}" for ${target}. Available: ${available}` };
+		}
+		if (args.disabledAgents.length > 0 && args.disabledAgents.includes(agentName)) {
+			const enabledSuffix = enabled.length > 0 ? ` Enabled agents: ${enabled.join(", ")}` : "";
+			const message =
+				`Agent "${agentName}" for ${target} is disabled in settings. ` +
+				`Enable it via /agents, or use a different agent type.${enabledSuffix}`;
+			return { ok: false, error: message };
+		}
+		if (args.blockedAgent && agentName === args.blockedAgent) {
+			const message =
+				`Cannot spawn ${args.blockedAgent} agent for ${target} from within itself ` +
+				"(recursion prevention). Use a different agent type.";
+			return { ok: false, error: message };
+		}
+		const spawnAllowed =
+			spawnPolicy.enabled && (spawnPolicy.allowedAgents === null || spawnPolicy.allowedAgents.includes(agentName));
+		if (!spawnAllowed) {
+			return {
+				ok: false,
+				error: `Cannot spawn '${agentName}' for ${target}. Allowed: ${spawnPolicy.allowedErrorText}`,
+			};
+		}
+		resolved.push({ item, index, agentName, agent });
+	}
+
+	return { ok: true, resolved };
+}
+
+function summarizeResolvedAgents(spawns: readonly ResolvedSpawnItem[]): string {
+	const counts = new Map<string, number>();
+	for (const spawn of spawns) {
+		counts.set(spawn.agentName, (counts.get(spawn.agentName) ?? 0) + 1);
+	}
+	if (counts.size === 0) return "task";
+	if (counts.size === 1) return counts.keys().next().value ?? "task";
+	return `mixed (${Array.from(counts, ([agent, count]) => `${agent}×${count}`).join(", ")})`;
+}
+
+function commonResolvedAgentName(spawns: readonly ResolvedSpawnItem[]): string | undefined {
+	const first = spawns[0]?.agentName;
+	return first && spawns.every(spawn => spawn.agentName === first) ? first : undefined;
 }
 
 /** Generic worker agents whose output sharpens with a tailored `role` rather than the bare type. */
@@ -453,9 +530,48 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	readonly name = "task";
 	readonly approval = "exec" as const;
 	readonly formatApprovalDetails = (args: unknown): string[] => {
-		const params = args as Partial<TaskParams>;
+		const params = args && typeof args === "object" ? (args as Partial<TaskParams>) : {};
 		const lines: string[] = [];
-		if (typeof params.agent === "string") {
+		const tasks = Array.isArray(params.tasks) ? params.tasks : [];
+		const hasBatchTasks = tasks.length > 0;
+		const effectiveAgentFor = (task: unknown): string | undefined => {
+			const item = task && typeof task === "object" ? (task as Partial<TaskItem>) : {};
+			const effectiveAgent = (item.agent as unknown) ?? params.agent;
+			return typeof effectiveAgent === "string" ? effectiveAgent : undefined;
+		};
+		const hasAgentOverride = (task: unknown): boolean => {
+			const item = task && typeof task === "object" ? (task as Partial<TaskItem>) : {};
+			return typeof item.agent === "string";
+		};
+		const countEffectiveAgents = (items: readonly unknown[]): Map<string, number> => {
+			const counts = new Map<string, number>();
+			for (const item of items) {
+				const agent = effectiveAgentFor(item);
+				if (agent === undefined) continue;
+				counts.set(agent, (counts.get(agent) ?? 0) + 1);
+			}
+			return counts;
+		};
+		const formatAgentCounts = (counts: ReadonlyMap<string, number>): string =>
+			Array.from(counts, ([agent, count]) => `${truncateForPrompt(agent)}×${count}`).join(", ");
+		const formatHiddenAgentSummary = (counts: ReadonlyMap<string, number>): string | undefined => {
+			if (counts.size === 0) return undefined;
+			if (counts.size === 1) {
+				const first = counts.entries().next();
+				if (first.done) return undefined;
+				const [agent, count] = first.value;
+				return count === 1 ? `agent: ${truncateForPrompt(agent)}` : `agent: ${truncateForPrompt(agent)}×${count}`;
+			}
+			return `agents: ${formatAgentCounts(counts)}`;
+		};
+		const agentCounts = hasBatchTasks ? countEffectiveAgents(tasks) : new Map<string, number>();
+		const agentsMixed = agentCounts.size > 1;
+		if (hasBatchTasks && agentsMixed) {
+			lines.push(`Agents: mixed (${formatAgentCounts(agentCounts)})`);
+		} else if (hasBatchTasks && agentCounts.size === 1) {
+			const first = agentCounts.keys().next();
+			if (!first.done) lines.push(`Agent: ${truncateForPrompt(first.value)}`);
+		} else if (typeof params.agent === "string") {
 			lines.push(`Agent: ${truncateForPrompt(params.agent)}`);
 		}
 		if (typeof params.role === "string" && params.role.trim()) {
@@ -470,20 +586,37 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		if (typeof params.context === "string" && params.context.trim()) {
 			lines.push(`Context:\n${truncateForPrompt(params.context)}`);
 		}
-		const tasks = Array.isArray(params.tasks) ? params.tasks : [];
 		const firstTask = tasks[0];
 		if (firstTask) {
-			if (typeof firstTask.id === "string" && firstTask.id.trim()) {
-				lines.push(`Task: ${truncateForPrompt(firstTask.id)}`);
+			const firstTaskParams = firstTask && typeof firstTask === "object" ? (firstTask as Partial<TaskItem>) : {};
+			const firstEffectiveAgent = effectiveAgentFor(firstTask);
+			const firstAgentSuffix =
+				(agentsMixed || hasAgentOverride(firstTask)) && firstEffectiveAgent !== undefined
+					? ` (agent: ${truncateForPrompt(firstEffectiveAgent)})`
+					: "";
+			if (typeof firstTaskParams.id === "string" && firstTaskParams.id.trim()) {
+				lines.push(`Task: ${truncateForPrompt(firstTaskParams.id)}${firstAgentSuffix}`);
+			} else if (firstAgentSuffix) {
+				lines.push(`Task:${firstAgentSuffix}`);
 			}
-			if (typeof firstTask.role === "string" && firstTask.role.trim()) {
-				lines.push(`Role: ${truncateForPrompt(firstTask.role)}`);
+			if (typeof firstTaskParams.role === "string" && firstTaskParams.role.trim()) {
+				lines.push(`Role: ${truncateForPrompt(firstTaskParams.role)}`);
 			}
-			if (typeof firstTask.assignment === "string") {
-				lines.push(`Assignment:\n${truncateForPrompt(firstTask.assignment)}`);
+			if (typeof firstTaskParams.assignment === "string") {
+				lines.push(`Assignment:\n${truncateForPrompt(firstTaskParams.assignment)}`);
 			}
 			if (tasks.length > 1) {
-				lines.push(`+${tasks.length - 1} more task${tasks.length === 2 ? "" : "s"}`);
+				const hiddenTasks = tasks.slice(1);
+				const hiddenAgentCounts = countEffectiveAgents(hiddenTasks);
+				const hiddenAgentSummary =
+					agentsMixed || hiddenTasks.some(hasAgentOverride) || hiddenAgentCounts.size > 1
+						? formatHiddenAgentSummary(hiddenAgentCounts)
+						: undefined;
+				lines.push(
+					`+${tasks.length - 1} more task${tasks.length === 2 ? "" : "s"}${
+						hiddenAgentSummary ? ` (${hiddenAgentSummary})` : ""
+					}`,
+				);
 			}
 		}
 		return lines;
@@ -590,7 +723,25 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		const spawnItems = resolveSpawnItems(params);
-		const selectedAgent = this.#discoveredAgents.find(agent => agent.name === params.agent);
+		const { agents: freshAgents, projectAgentsDir } = await discoverAgents(this.session.cwd);
+		const preflight = resolveSpawnItemAgents({
+			params,
+			items: spawnItems,
+			agents: freshAgents,
+			disabledAgents: this.session.settings.get("task.disabledAgents") as string[],
+			blockedAgent: this.#blockedAgent,
+			parentSpawns: this.session.getSessionSpawns(),
+		});
+		if (!preflight.ok) {
+			return {
+				content: [{ type: "text", text: preflight.error }],
+				details: { projectAgentsDir, results: [], totalDurationMs: 0 },
+			};
+		}
+		const resolvedSpawns = preflight.resolved;
+		const hasBlockingAgent = resolvedSpawns.some(spawn => spawn.agent.blocking === true);
+		const commonAgentName = commonResolvedAgentName(resolvedSpawns);
+		const agentSummary = summarizeResolvedAgents(resolvedSpawns);
 		const asyncEnabled = this.session.settings.get("async.enabled");
 		const manager = asyncEnabled ? this.session.asyncJobManager : undefined;
 		const depthCapacity = canSpawnAtDepth(
@@ -601,11 +752,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// Coordination only makes sense when the siblings keep running after this
 		// call returns (async). In the sync fallback they have already completed,
 		// so a "coordinate while they run" hint would misfire.
-		const willRunAsync = !!manager && selectedAgent?.blocking !== true;
+		const willRunAsync = !!manager && !hasBlockingAgent;
 		const advisory = this.session.suppressSpawnAdvisory
 			? undefined
 			: composeSpawnAdvisory({
-					agentName: params.agent,
+					agentName: commonAgentName,
 					items: spawnItems,
 					depthCapacity,
 					ircEnabled,
@@ -627,7 +778,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			if (!appended) content.push({ type: "text", text: advisory });
 			return { ...result, content };
 		};
-		if (!asyncEnabled || !manager || selectedAgent?.blocking === true) {
+		if (!asyncEnabled || !manager || hasBlockingAgent) {
 			// Sync fallback: async execution disabled, orphaned host that never
 			// wired a job manager, or an agent definition that declares
 			// `blocking: true`. The session-scoped semaphore still bounds fan-out
@@ -641,21 +792,20 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// Resolve agent ids up front so the immediate result can name them.
 		const outputManager =
 			this.session.agentOutputManager ?? new AgentOutputManager(this.session.getArtifactsDir ?? (() => null));
-		const agentLabel = params.agent ?? "task";
-		const agentSource = selectedAgent?.source ?? "bundled";
-		const spawns: Array<{ agentId: string; item: TaskItem; progress: AgentProgress }> = [];
-		for (let index = 0; index < spawnItems.length; index++) {
-			const item = spawnItems[index];
+		const spawns: Array<{ agentId: string; item: TaskItem; agentName: string; progress: AgentProgress }> = [];
+		for (const resolved of resolvedSpawns) {
+			const { item, index, agentName, agent } = resolved;
 			const agentId = await outputManager.allocate(item.id?.trim() || generateTaskName());
 			const assignment = (item.assignment ?? "").trim();
 			spawns.push({
 				agentId,
 				item,
+				agentName,
 				progress: {
 					index,
 					id: agentId,
-					agent: agentLabel,
-					agentSource,
+					agent: agentName,
+					agentSource: agent.source,
 					status: "pending",
 					task: renderSubagentUserPrompt(assignment),
 					assignment,
@@ -691,7 +841,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			},
 		});
 
-		const started: Array<{ agentId: string; jobId: string; description?: string }> = [];
+		const started: Array<{ agentId: string; jobId: string; agentName: string; description?: string }> = [];
 		const failedSchedules: string[] = [];
 		for (const spawn of spawns) {
 			try {
@@ -710,10 +860,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					},
 				});
 				if (started.length === 0) primaryJobId = jobId;
-				started.push({ agentId: spawn.agentId, jobId, description: spawn.item.description });
+				started.push({
+					agentId: spawn.agentId,
+					jobId,
+					agentName: spawn.agentName,
+					description: spawn.item.description,
+				});
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				failedSchedules.push(`${spawn.agentId}: ${message}`);
+				failedSchedules.push(`${spawn.agentId} (${spawn.agentName}): ${message}`);
 				spawn.progress.status = "failed";
 				settledCount += 1;
 				failedCount += 1;
@@ -733,20 +888,20 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		if (single) {
-			const { agentId, jobId, description } = started[0];
+			const { agentId, jobId, agentName, description } = started[0];
 			const coordinationHint = ircEnabled
 				? `DM \`${agentId}\` via \`irc\` to coordinate while it runs; use \`job\` only to inspect (\`list\`), wait (\`poll\`), or cancel a stuck task.`
 				: `Use \`job\` to inspect (\`list\`), wait (\`poll\`), or cancel a stuck task.`;
 			const descriptionSuffix = description ? ` — ${description}` : "";
 			onUpdate?.({
-				content: [{ type: "text", text: `Spawned agent \`${agentId}\`...` }],
+				content: [{ type: "text", text: `Spawned agent \`${agentId}\` using \`${agentName}\`...` }],
 				details: buildAsyncDetails("running", jobId),
 			});
 			return withAdvisory({
 				content: [
 					{
 						type: "text",
-						text: `Spawned agent \`${agentId}\` (job \`${jobId}\`)${descriptionSuffix}. The result will be delivered when it yields. ${coordinationHint}`,
+						text: `Spawned agent \`${agentId}\` using \`${agentName}\` (job \`${jobId}\`)${descriptionSuffix}. The result will be delivered when it yields. ${coordinationHint}`,
 					},
 				],
 				details: buildAsyncDetails("running", jobId),
@@ -761,8 +916,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				? ` Failed to schedule ${failedSchedules.length} spawn${failedSchedules.length === 1 ? "" : "s"}: ${failedSchedules.join("; ")}.`
 				: "";
 		const startedListing = started
-			.map(({ agentId, jobId, description }) => {
-				const prefix = `- \`${agentId}\` (job \`${jobId}\`)`;
+			.map(({ agentId, jobId, agentName, description }) => {
+				const prefix = `- \`${agentId}\` using \`${agentName}\` (job \`${jobId}\`)`;
 				return description ? `${prefix} — ${description}` : prefix;
 			})
 			.join("\n");
@@ -774,7 +929,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			content: [
 				{
 					type: "text",
-					text: `Spawned ${started.length} background agents using ${agentLabel}.${scheduleFailureSummary} Each result will be delivered when that agent yields.\n${startedListing}\n${coordinationHint}`,
+					text: `Spawned ${started.length} background agents using ${agentSummary}.${scheduleFailureSummary} Each result will be delivered when that agent yields.\n${startedListing}\n${coordinationHint}`,
 				},
 			],
 			details: buildAsyncDetails("running", primaryJobId),

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -37,7 +37,15 @@ import {
 import { framedBlock, renderStatusLine } from "../tui";
 import { repairDoubleEncodedJsonString } from "./repair-args";
 import { subprocessToolRegistry } from "./subprocess-tool-registry";
-import type { AgentProgress, SingleResult, TaskItem, TaskParams, TaskToolDetails, YieldItem } from "./types";
+import {
+	type AgentProgress,
+	oneLineLabel,
+	type SingleResult,
+	type TaskItem,
+	type TaskParams,
+	type TaskToolDetails,
+	type YieldItem,
+} from "./types";
 import { assembleYieldResult } from "./yield-assembly";
 
 /** Render context threaded in from `ToolExecutionComponent.#buildRenderContext`. */
@@ -677,6 +685,74 @@ function formatOutputInline(data: unknown, theme: Theme, maxWidth = 80): string 
 	return `Output: ${pairs.join(", ")}`;
 }
 
+const AGENT_LABEL_MAX_WIDTH = 24;
+const AGENT_HEADER_MAX_WIDTH = 56;
+const MIXED_AGENT_LABEL_LIMIT = 3;
+
+type AgentInputTask = Partial<TaskItem> & { agent?: unknown };
+
+function formatAgentLabel(value: unknown, maxWidth = AGENT_LABEL_MAX_WIDTH): string {
+	if (typeof value !== "string") return "";
+	const label = oneLineLabel(value, maxWidth);
+	return label ? truncateToWidth(replaceTabs(label), maxWidth) : "";
+}
+
+function appendAgentStatusLabel(line: string, agent: unknown, theme: Theme): string {
+	const label = formatAgentLabel(agent);
+	return label ? `${line}${theme.sep.dot}${theme.fg("dim", label)}` : line;
+}
+
+function summarizeAgentLabels(labels: readonly string[]): string {
+	const counts = new Map<string, number>();
+	for (const label of labels) {
+		if (!label) continue;
+		counts.set(label, (counts.get(label) ?? 0) + 1);
+	}
+	if (counts.size === 0) return "";
+	if (counts.size === 1) return counts.keys().next().value ?? "";
+
+	const parts = Array.from(counts)
+		.slice(0, MIXED_AGENT_LABEL_LIMIT)
+		.map(([label, count]) => `${label}×${count}`);
+	if (counts.size > MIXED_AGENT_LABEL_LIMIT) parts.push("…");
+	return truncateToWidth(`mixed (${parts.join(", ")})`, AGENT_HEADER_MAX_WIDTH);
+}
+
+function formatArgsAgentHeaderDescription(args: Partial<TaskParams> | undefined): string {
+	const defaultAgent = (args as { agent?: unknown } | undefined)?.agent;
+	const tasks = Array.isArray(args?.tasks) ? args.tasks : [];
+	if (tasks.length === 0) return summarizeAgentLabels([formatAgentLabel(defaultAgent)]);
+
+	const labels: string[] = [];
+	for (const task of tasks) {
+		const itemAgent = (task as AgentInputTask | undefined)?.agent;
+		const label = formatAgentLabel(itemAgent ?? defaultAgent);
+		if (label) labels.push(label);
+	}
+	return summarizeAgentLabels(labels);
+}
+
+function formatDetailsAgentHeaderDescription(details: TaskToolDetails | undefined): string {
+	if (!details) return "";
+	const items: Array<{ agent?: unknown }> =
+		details.progress && details.progress.length > 0 ? details.progress : details.results;
+	return summarizeAgentLabels(items.map(item => formatAgentLabel(item.agent)).filter(Boolean));
+}
+
+function shouldRenderTaskAgentLabels(tasks: TaskItem[] | undefined, defaultAgent: unknown): boolean {
+	if (!Array.isArray(tasks) || tasks.length === 0) return false;
+	const defaultLabel = formatAgentLabel(defaultAgent);
+	const labels = new Set<string>();
+	let hasOverride = false;
+	for (const task of tasks) {
+		const itemAgent = (task as AgentInputTask | undefined)?.agent;
+		if (itemAgent != null) hasOverride = true;
+		const label = formatAgentLabel(itemAgent ?? defaultAgent);
+		if (label) labels.add(label);
+	}
+	return hasOverride || !defaultLabel || labels.size > 1;
+}
+
 /**
  * Render the call preview lines for the single spawned agent. The
  * args stream in token by token, so every field access is defensive.
@@ -685,6 +761,7 @@ function renderTaskCallLines(args: Partial<TaskParams> | undefined, theme: Theme
 	if (!args) return [];
 	const bullet = theme.fg("dim", "•");
 	const lines: string[] = [];
+	const defaultAgent = (args as { agent?: unknown } | undefined)?.agent;
 
 	const rawId = typeof args.id === "string" ? args.id.trim() : "";
 	const idLabel = rawId ? formatTaskId(rawId) : "";
@@ -696,7 +773,7 @@ function renderTaskCallLines(args: Partial<TaskParams> | undefined, theme: Theme
 		}
 		lines.push(line);
 	}
-	lines.push(...renderTaskItemLines(args.tasks, theme));
+	lines.push(...renderTaskItemLines(args.tasks, defaultAgent, theme));
 	return lines;
 }
 
@@ -712,11 +789,12 @@ const COLLAPSED_AGENT_LIMIT = 4;
  * over time and trailing entries may be partially parsed — every field access
  * is defensive.
  */
-function renderTaskItemLines(tasks: TaskItem[] | undefined, theme: Theme): string[] {
+function renderTaskItemLines(tasks: TaskItem[] | undefined, defaultAgent: unknown, theme: Theme): string[] {
 	if (!Array.isArray(tasks) || tasks.length === 0) return [];
 
 	const bullet = theme.fg("dim", "•");
 	const cap = Math.min(tasks.length, COLLAPSED_AGENT_LIMIT);
+	const showAgentLabels = shouldRenderTaskAgentLabels(tasks, defaultAgent);
 	const lines: string[] = [];
 	for (let i = 0; i < cap; i++) {
 		const task = tasks[i] as Partial<TaskItem> | undefined;
@@ -726,6 +804,10 @@ function renderTaskItemLines(tasks: TaskItem[] | undefined, theme: Theme): strin
 		const desc = typeof task?.description === "string" ? task.description.trim() : "";
 		if (desc) {
 			line += `: ${theme.fg("muted", previewLine(desc, 64))}`;
+		}
+		if (showAgentLabels) {
+			const agentLabel = formatAgentLabel((task as AgentInputTask | undefined)?.agent ?? defaultAgent);
+			if (agentLabel) line += theme.fg("dim", ` [${agentLabel}]`);
 		}
 		if (task?.isolated === true) {
 			line += theme.fg("dim", " [isolated]");
@@ -794,8 +876,9 @@ export function renderCall(args: TaskParams, options: TaskRenderOptions, theme: 
 	// Dispatch glyph from the first frame: spawning is non-blocking, so a
 	// pending/hourglass icon would misread the call as something the turn
 	// waits on.
+	const agentLabel = formatArgsAgentHeaderDescription(args);
 	const header = renderStatusLine(
-		{ iconOverride: theme.styledSymbol("tool.task", "accent"), title: "Task", description: args.agent },
+		{ iconOverride: theme.styledSymbol("tool.task", "accent"), title: "Task", description: agentLabel || undefined },
 		theme,
 	);
 	const assignmentSection = createAssignmentSectionRenderer(args, theme);
@@ -907,6 +990,7 @@ function renderAgentProgress(
 	} else if (progress.status === "completed") {
 		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
 	}
+	statusLine = appendAgentStatusLabel(statusLine, progress.agent, theme);
 
 	lines.push(statusLine);
 
@@ -1235,6 +1319,7 @@ function renderAgentResult(
 	if (result.truncated) {
 		statusLine += ` ${theme.fg("warning", "[truncated]")}`;
 	}
+	statusLine = appendAgentStatusLabel(statusLine, result.agent, theme);
 
 	lines.push(statusLine);
 
@@ -1460,7 +1545,7 @@ export function renderResult(
 ): Component {
 	const fallbackText = result.content.find(c => c.type === "text")?.text ?? "";
 	const details = result.details;
-	const agentLabel = args?.agent?.trim() || undefined;
+	const agentLabel = formatDetailsAgentHeaderDescription(details) || formatArgsAgentHeaderDescription(args);
 	const assignmentSection = createAssignmentSectionRenderer(args, theme);
 	const contextSection = createContextSectionRenderer(args, theme);
 
@@ -1468,12 +1553,12 @@ export function renderResult(
 		const text = result.content.find(c => c.type === "text")?.text || "";
 		const errored = result.isError === true;
 		const header = errored
-			? renderStatusLine({ icon: "error", title: "Task", description: agentLabel }, theme)
+			? renderStatusLine({ icon: "error", title: "Task", description: agentLabel || undefined }, theme)
 			: renderStatusLine(
 					{
 						iconOverride: theme.styledSymbol("status.done", "accent"),
 						title: "Task",
-						description: agentLabel,
+						description: agentLabel || undefined,
 					},
 					theme,
 				);

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -82,6 +82,7 @@ const ROLE_INPUT_SCHEMA = `string <= ${ROLE_INPUT_MAX}` as const;
 
 export const taskItemSchema = type({
 	"id?": "string",
+	"agent?": "string",
 	"description?": "string",
 	"role?": ROLE_INPUT_SCHEMA,
 	assignment: "string",
@@ -89,6 +90,7 @@ export const taskItemSchema = type({
 });
 const taskItemSchemaIsolated = type({
 	"id?": "string",
+	"agent?": "string",
 	"description?": "string",
 	"role?": ROLE_INPUT_SCHEMA,
 	assignment: "string",
@@ -100,6 +102,8 @@ const taskItemSchemaIsolated = type({
 export interface TaskItem {
 	/** Stable agent id; default = generated AdjectiveNoun. */
 	id?: string;
+	/** Agent type override for this item; default = top-level `agent`. */
+	agent?: string;
 	/** UI label, not seen by the subagent. */
 	description?: string;
 	/** Specialist role/expertise this subagent embodies; shapes its system-prompt identity and display name. */

--- a/packages/coding-agent/test/task/render-call.test.ts
+++ b/packages/coding-agent/test/task/render-call.test.ts
@@ -25,6 +25,12 @@ describe("task renderer: streaming call preview", () => {
 		return Bun.stripANSI(component.render(160).join("\n"));
 	}
 
+	function findRenderedLine(out: string, needle: string): string {
+		const line = out.split("\n").find(renderedLine => renderedLine.includes(needle));
+		expect(line).toBeDefined();
+		return line!;
+	}
+
 	// The preview must surface the agent id + ui description so the user can
 	// see what is being dispatched while args stream in.
 	it("shows the agent id, description, and assignment preview", () => {
@@ -112,6 +118,35 @@ describe("task renderer: streaming call preview", () => {
 		expect(contextAt).toBeGreaterThanOrEqual(0);
 		expect(firstAgentAt).toBeGreaterThan(contextAt);
 		expect(out.indexOf("Fix02Setup")).toBeGreaterThan(firstAgentAt);
+	});
+
+	it("previews streamed item agents without rendering an undefined top-level agent", () => {
+		const args = {
+			context: "# Goal\nCatalog the library backlog.",
+			tasks: [{ id: "CatalogBooks", agent: "librarian", description: "Catalog rare books" }],
+		} as unknown as TaskParams;
+		const out = render(args);
+		const lines = out.split("\n");
+
+		expect(out).not.toContain("undefined");
+		expect(lines[0]).toContain("librarian");
+		expect(findRenderedLine(out, "CatalogBooks")).toContain("librarian");
+	});
+
+	it("summarizes mixed item agents in the header and labels each row", () => {
+		const args = {
+			agent: "task",
+			context: "# Goal\nSplit code and research work.",
+			tasks: [
+				{ id: "InspectCode", description: "Inspect code paths" },
+				{ id: "CatalogBooks", agent: "librarian", description: "Catalog rare books" },
+			],
+		} as unknown as TaskParams;
+		const out = render(args);
+
+		expect(out).toContain("mixed (task×1, librarian×1)");
+		expect(findRenderedLine(out, "InspectCode")).toContain("task");
+		expect(findRenderedLine(out, "CatalogBooks")).toContain("librarian");
 	});
 
 	// Early in the stream only `context` has parsed; the (empty) agent-list

--- a/packages/coding-agent/test/task/task-batch.test.ts
+++ b/packages/coding-agent/test/task/task-batch.test.ts
@@ -33,23 +33,51 @@ const taskAgent: AgentDefinition = {
 	source: "bundled",
 };
 
+const librarianAgent: AgentDefinition = {
+	name: "librarian",
+	description: "Research librarian agent",
+	systemPrompt: "You are a librarian.",
+	source: "project",
+	blocking: true,
+};
+
 function createSession(
-	options: { manager?: AsyncJobManager; settings?: Record<string, unknown>; agentId?: string } = {},
+	options: {
+		manager?: AsyncJobManager;
+		settings?: Record<string, unknown>;
+		agentId?: string;
+		spawns?: string | null;
+	} = {},
 ): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
 		settings: Settings.isolated(options.settings ?? {}),
 		getSessionFile: () => null,
-		getSessionSpawns: () => "*",
+		getSessionSpawns: () => options.spawns ?? "*",
 		getAgentId: () => options.agentId ?? null,
 		asyncJobManager: options.manager,
 	} as unknown as ToolSession;
 }
 
 function getSchemaProperties(tool: TaskTool): Record<string, unknown> {
-	const wire = toolWireSchema(tool) as { properties?: Record<string, unknown> };
-	return wire.properties ?? {};
+	const wire = toolWireSchema(tool);
+	if (!isRecord(wire)) return {};
+	const properties = wire.properties;
+	return isRecord(properties) ? properties : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function getTaskItemProperties(properties: Record<string, unknown>): Record<string, unknown> | undefined {
+	const tasks = properties.tasks;
+	if (!isRecord(tasks)) return undefined;
+	const items = tasks.items;
+	if (!isRecord(items)) return undefined;
+	const itemProperties = items.properties;
+	return isRecord(itemProperties) ? itemProperties : undefined;
 }
 
 function getFirstText(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -76,9 +104,9 @@ function makeResult(id: string, overrides: Partial<SingleResult> = {}): SingleRe
 	};
 }
 
-function mockDiscovery(): void {
+function mockDiscovery(agents: AgentDefinition[] = [taskAgent]): void {
 	vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
-		agents: [taskAgent],
+		agents,
 		projectAgentsDir: null,
 	});
 }
@@ -107,9 +135,18 @@ describe("task.batch schema gating", () => {
 		expect(onProperties.assignment).toBeUndefined();
 		expect(onProperties.id).toBeUndefined();
 		expect(onProperties.description).toBeUndefined();
-		const items = (onProperties.tasks as { items?: { properties?: Record<string, unknown> } }).items;
-		expect(items?.properties?.assignment).toBeDefined();
-		expect(items?.properties?.id).toBeDefined();
+		const itemProperties = getTaskItemProperties(onProperties);
+		expect(itemProperties?.assignment).toBeDefined();
+		expect(itemProperties?.id).toBeDefined();
+	});
+
+	it("exposes per-item agent in the batch wire shape", async () => {
+		mockDiscovery([taskAgent, librarianAgent]);
+
+		const tool = await TaskTool.create(createSession({ settings: { "task.batch": true } }));
+		const itemProperties = getTaskItemProperties(getSchemaProperties(tool));
+
+		expect(itemProperties?.agent).toBeDefined();
 	});
 
 	it("places isolated per item in the batch shape when isolation is enabled", async () => {
@@ -118,10 +155,8 @@ describe("task.batch schema gating", () => {
 		const tool = await TaskTool.create(
 			createSession({ settings: { "task.batch": true, "task.isolation.mode": "auto" } }),
 		);
-		const properties = getSchemaProperties(tool);
-		expect(properties.isolated).toBeUndefined();
-		const items = (properties.tasks as { items?: { properties?: Record<string, unknown> } }).items;
-		expect(items?.properties?.isolated).toBeDefined();
+		const itemProperties = getTaskItemProperties(getSchemaProperties(tool));
+		expect(itemProperties?.isolated).toBeDefined();
 	});
 
 	it("never exposes a per-call schema input", async () => {
@@ -201,6 +236,30 @@ describe("task.batch validation", () => {
 			{ "task.batch": true },
 		);
 		expect(text).toContain("Duplicate task id");
+	});
+});
+
+describe("task.batch approval details", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("surfaces mixed effective agents in batch approval details", async () => {
+		mockDiscovery([taskAgent, librarianAgent]);
+		const tool = await TaskTool.create(createSession({ settings: { "task.batch": true } }));
+
+		const details = tool.formatApprovalDetails({
+			agent: "task",
+			context: "# Goal\nRoute each task to the right specialist.",
+			tasks: [
+				{ id: "Scout", assignment: "Inspect the implementation." },
+				{ id: "Archivist", agent: "librarian", assignment: "Find the reference material." },
+			],
+		} as TaskParams);
+
+		expect(details).toContain("Agents: mixed (task×1, librarian×1)");
+		expect(details).toContain("Task: Scout (agent: task)");
+		expect(details).toContain("+1 more task (agent: librarian)");
 	});
 });
 
@@ -363,6 +422,131 @@ describe("task.batch spawning", () => {
 			"# Goal\nShared synchronous context.",
 			"# Goal\nShared synchronous context.",
 		]);
+	});
+
+	it("falls back to sync fanout when any resolved item agent is blocking", async () => {
+		mockDiscovery([taskAgent, librarianAgent]);
+		const seen: Array<{ id?: string; agent: string; context?: string }> = [];
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			seen.push({ id: options.id, agent: options.agent.name, context: options.context });
+			return makeResult(options.id ?? "?", { agent: options.agent.name, agentSource: options.agent.source });
+		});
+
+		const manager = createManager();
+		const tool = await TaskTool.create(
+			createSession({ manager, settings: { "async.enabled": true, "task.batch": true } }),
+		);
+
+		const result = await tool.execute("tc-mixed-blocking-batch", {
+			agent: "task",
+			context: "# Goal\nRoute each item to its effective agent.",
+			tasks: [
+				{ id: "Code", assignment: "Inspect the code paths." },
+				{ id: "Books", agent: "librarian", assignment: "Catalogue the references." },
+			],
+		} as unknown as TaskParams);
+
+		expect(result.details?.async).toBeUndefined();
+		expect(manager.getAllJobs()).toHaveLength(0);
+		expect(seen).toHaveLength(2);
+		expect(seen.map(spawn => spawn.context)).toEqual([
+			"# Goal\nRoute each item to its effective agent.",
+			"# Goal\nRoute each item to its effective agent.",
+		]);
+		expect(
+			seen.map(({ id, agent }) => ({ id, agent })).sort((a, b) => (a.id ?? "").localeCompare(b.id ?? "")),
+		).toEqual([
+			{ id: "Books", agent: "librarian" },
+			{ id: "Code", agent: "task" },
+		]);
+		expect(
+			result.details?.results.map(({ id, agent }) => ({ id, agent })).sort((a, b) => a.id.localeCompare(b.id)),
+		).toEqual([
+			{ id: "Books", agent: "librarian" },
+			{ id: "Code", agent: "task" },
+		]);
+	});
+
+	it("rejects invalid per-item agents before dispatching any batch job", async () => {
+		const batchWithOverride = (agent: string) => ({
+			agent: "task",
+			context: "# Goal\nValidate every effective agent before dispatch.",
+			tasks: [
+				{ id: "Default", assignment: "Use the inherited agent." },
+				{ id: "Override", agent, assignment: "Use the item override." },
+			],
+		});
+		const scenarios: Array<{
+			name: string;
+			params: unknown;
+			settings?: Record<string, unknown>;
+			spawns?: string;
+			blockedAgent?: string;
+			expected: string;
+		}> = [
+			{
+				name: "unknown item agent",
+				params: batchWithOverride("ghost"),
+				expected: 'Unknown agent "ghost"',
+			},
+			{
+				name: "disabled item agent",
+				params: batchWithOverride("librarian"),
+				settings: { "task.disabledAgents": ["librarian"] },
+				expected: 'Agent "librarian" for task id `Override` is disabled',
+			},
+			{
+				name: "self-recursive item agent",
+				params: batchWithOverride("librarian"),
+				blockedAgent: "librarian",
+				expected: "Cannot spawn librarian agent for task id `Override` from within itself",
+			},
+			{
+				name: "parent-spawn-disallowed item agent",
+				params: batchWithOverride("librarian"),
+				spawns: "task",
+				expected: "Cannot spawn 'librarian'",
+			},
+		];
+
+		for (const scenario of scenarios) {
+			const previousBlockedAgent = Bun.env.PI_BLOCKED_AGENT;
+			try {
+				if (scenario.blockedAgent) {
+					Bun.env.PI_BLOCKED_AGENT = scenario.blockedAgent;
+				} else {
+					delete Bun.env.PI_BLOCKED_AGENT;
+				}
+				mockDiscovery([taskAgent, librarianAgent]);
+				const runSubprocess = vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+					return makeResult(options.id ?? "?", { agent: options.agent.name, agentSource: options.agent.source });
+				});
+				const manager = createManager();
+				const tool = await TaskTool.create(
+					createSession({
+						manager,
+						spawns: scenario.spawns,
+						settings: { "async.enabled": true, "task.batch": true, ...scenario.settings },
+					}),
+				);
+
+				const result = await tool.execute(
+					`tc-preflight-${scenario.name}`,
+					scenario.params as unknown as TaskParams,
+				);
+
+				expect(getFirstText(result)).toContain(scenario.expected);
+				expect(runSubprocess).not.toHaveBeenCalled();
+				expect(manager.getAllJobs()).toHaveLength(0);
+			} finally {
+				if (previousBlockedAgent === undefined) {
+					delete Bun.env.PI_BLOCKED_AGENT;
+				} else {
+					Bun.env.PI_BLOCKED_AGENT = previousBlockedAgent;
+				}
+				vi.restoreAllMocks();
+			}
+		}
 	});
 
 	it("settles the batch async aggregate when a queued spawn is cancelled mid-flight", async () => {

--- a/packages/coding-agent/test/task/task-progress-render.test.ts
+++ b/packages/coding-agent/test/task/task-progress-render.test.ts
@@ -180,6 +180,54 @@ describe("task progress rendering", () => {
 		expect(row).not.toContain(theme.fg("accent", titlePart));
 	});
 
+	it("renders resolved agent labels on mixed progress and result rows", async () => {
+		const theme = (await getThemeByName("dark"))!;
+		const progressOptions: RenderResultOptions = { expanded: false, isPartial: true, spinnerFrame: 0 };
+		const progressDetails: TaskToolDetails = {
+			projectAgentsDir: null,
+			results: [],
+			totalDurationMs: 0,
+			progress: [
+				runningProgress({ index: 0, id: "InspectCode", agent: "task", description: "Inspect code paths" }),
+				runningProgress({
+					index: 1,
+					id: "CatalogBooks",
+					agent: "librarian",
+					description: "Catalog rare books",
+				}),
+			],
+		};
+
+		const progressComponent = taskToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "" }], details: progressDetails },
+			progressOptions,
+			theme,
+		);
+		expect(Bun.stripANSI(findRow(progressComponent, "InspectCode"))).toContain("task");
+		expect(Bun.stripANSI(findRow(progressComponent, "CatalogBooks"))).toContain("librarian");
+
+		const resultDetails: TaskToolDetails = {
+			projectAgentsDir: null,
+			results: [
+				finishedResult({ index: 0, id: "InspectCode", agent: "task", description: "Inspect code paths" }),
+				finishedResult({
+					index: 1,
+					id: "CatalogBooks",
+					agent: "librarian",
+					description: "Catalog rare books",
+				}),
+			],
+			totalDurationMs: 5,
+		};
+		const resultComponent = taskToolRenderer.renderResult(
+			{ content: [{ type: "text", text: "" }], details: resultDetails },
+			{ expanded: false, isPartial: false },
+			theme,
+		);
+		expect(Bun.stripANSI(findRow(resultComponent, "InspectCode"))).toContain("task");
+		expect(Bun.stripANSI(findRow(resultComponent, "CatalogBooks"))).toContain("librarian");
+	});
+
 	it("shows the dispatch glyph in the header while agents run, not a spinner", async () => {
 		const theme = (await getThemeByName("dark"))!;
 		const options: RenderResultOptions = { expanded: false, isPartial: true, spinnerFrame: 0 };


### PR DESCRIPTION
## Summary
- Add optional `tasks[].agent` overrides to the `task` tool batch shape, with the top-level `agent` kept as the default.
- Preflight every effective agent (`tasks[].agent ?? agent`) before dispatch so unknown, disabled, self-recursive, or spawn-disallowed item agents fail the whole batch before any subagent launches.
- Route each item through its resolved agent config, force sync fanout when any resolved agent is blocking, and surface effective agents in task previews, progress/results, approval details, and the tool prompt.

<img width="851" height="473" alt="file-58a2e6effe04a72a0ebd3433dd6aeab3" src="https://github.com/user-attachments/assets/37557266-faf0-41f2-a5e1-8cc371bbd0b8" />


Closes #1403.
Supersedes / revives #1455.

## Verification
- `bun --cwd=packages/coding-agent check`
- `bun --cwd=packages/coding-agent test test/task/task-batch.test.ts test/task/render-call.test.ts test/task/task-progress-render.test.ts`
- `packages/coding-agent/dist/omp --smoke-test`

## Notes
- Local manual smoke confirmed a single mixed batch rendered `mixed (explore×1, librarian×1)` with row-level `explore` and `librarian` labels. Screenshot to be added after PR creation.