### PR TITLE
fix(Dockerfile): Do bun run gen:tool-views alongside gen:docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,9 +184,11 @@ RUN bun install --frozen-lockfile --ignore-scripts
 # hoisted node_modules that `bun install` just produced.
 COPY . /pi/
 
-# Regenerate the docs index that `--ignore-scripts` skipped above. The root
-# package.json's `prepare` script normally handles this on a vanilla install.
-RUN bun --cwd=packages/coding-agent run gen:docs
+# Regenerate the docs index and tool views that `--ignore-scripts` skipped
+# above. The root package.json's `prepare` script normally handles these on a
+# vanilla install.
+RUN bun --cwd=packages/coding-agent run gen:docs \
+    && bun --cwd=/pi/packages/coding-agent run gen:tool-views
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/omp"]
 CMD ["--help"]


### PR DESCRIPTION
## What

Add `bun --cwd=/pi/packages/coding-agent run gen:tool-views` to the Dockerfile. Dockerfile already runs `bun --cwd=packages/coding-agent run gen:docs` but this is not enough.

## Why

The image built by the Dockerfile will not run without this change. You will see:
```
error: Cannot find module './tool-views.generated.js' from '/pi/packages/coding-agent/src/export/html/index.ts'
```
This change fixes this by generating tool views.

## Testing

Build image: `podman build -t oh-my-pi:dev .`
Run image: `podman run --rm oh-my-pi:dev`