### PR TITLE
fix(tui): guard selector cursor symbol

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed selector rendering when a legacy theme omits symbol settings by falling back to an ASCII cursor instead of crashing ([#4745](https://github.com/can1357/oh-my-pi/issues/4745)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -12,6 +12,8 @@ const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
 const PRIMARY_COLUMN_GAP = 2;
 const MIN_DESCRIPTION_WIDTH = 10;
 
+const DEFAULT_CURSOR_SYMBOL = ">";
+
 function sanitizeSingleLine(text: string): string {
 	return replaceTabs(text)
 		.replace(/[\r\n]+/g, " ")
@@ -372,9 +374,8 @@ export class SelectList implements Component, MouseRoutable {
 		width: number,
 		primaryColumnWidth: number,
 	): SelectItemLayout {
-		const prefix = isSelected
-			? `${this.theme.symbols.cursor} `
-			: padding(visibleWidth(this.theme.symbols.cursor) + 1);
+		const cursor = this.theme.symbols?.cursor ?? DEFAULT_CURSOR_SYMBOL;
+		const prefix = isSelected ? `${cursor} ` : padding(visibleWidth(cursor) + 1);
 		const prefixWidth = visibleWidth(prefix);
 		const descriptionSingleLine = item.description ? sanitizeSingleLine(item.description) : undefined;
 

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { SelectList } from "@oh-my-pi/pi-tui/components/select-list";
+import { SelectList, type SelectListTheme } from "@oh-my-pi/pi-tui/components/select-list";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "@oh-my-pi/pi-tui/keybindings";
 import type { SgrMouseEvent } from "@oh-my-pi/pi-tui/mouse";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
@@ -76,6 +76,14 @@ describe("SelectList", () => {
 		expect(rendered.length).toBeGreaterThanOrEqual(1);
 		expect(rendered[0]).not.toContain("\n");
 		expect(rendered[0]).toContain("Line one Line two Line three");
+	});
+
+	it("falls back to an ASCII cursor when a legacy theme omits symbols", () => {
+		const legacyTheme: SelectListTheme = { ...testTheme };
+		Reflect.deleteProperty(legacyTheme, "symbols");
+		const list = new SelectList([{ value: "run", label: "run" }], 1, legacyTheme);
+
+		expect(list.render(40)).toEqual(["> run"]);
 	});
 
 	it("keeps descriptions aligned when the primary text is truncated", () => {


### PR DESCRIPTION
## Repro
Rendering a selector with a runtime legacy `SelectListTheme` that omits `symbols` crashes before the list can paint: JS eval imported `packages/tui/src/components/select-list.ts`, constructed `new SelectList([{ value: "one", label: "One" }], 1, themeWithoutSymbols)`, and called `render(40)`, which reproduced `TypeError: undefined is not an object (evaluating 'this.theme.symbols.cursor')`.

## Cause
`packages/tui/src/components/select-list.ts` assumed every selector theme includes the newer `symbols` map and dereferenced `this.theme.symbols.cursor` in `SelectList.#computeItemLayout`; runtime legacy/cross-version selector theme objects can still reach selector render paths without that map, so the first render of a picker crashes.

## Fix
- Added a local ASCII cursor fallback in `SelectList` when `theme.symbols?.cursor` is missing.
- Added a regression test that deletes `symbols` from a runtime selector theme and verifies render output instead of a crash.
- Added the `packages/tui` changelog entry for #4745.

## Verification
`bun test packages/tui/test/select-list.test.ts` passed with 22 tests and 59 assertions. Manual JS eval of the original missing-symbol selector scenario now renders `> One`. `gh_push_branch` pre-publish gate pushed the branch successfully. Fixes #4745