### PR TITLE
Perf/memoize non message tokens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/modes/utils/context-usage.ts
+++ b/packages/coding-agent/src/modes/utils/context-usage.ts
@@ -43,6 +43,7 @@ export interface ContextBreakdown {
 
 const EMPTY_STRING_PARTS: readonly string[] = [];
 const EMPTY_TOOLS: ReadonlyArray<Pick<Tool, "name" | "description" | "parameters">> = [];
+const EMPTY_SKILLS: readonly Skill[] = [];
 
 export function estimateSkillsTokens(skills: readonly Skill[]): number {
 	const fragments: string[] = [];
@@ -86,10 +87,58 @@ export function estimateToolSchemaTokens(
  * cadence — non-message recomputed only when the inputs identity changes,
  * messages walked incrementally as new entries append.
  */
+// Non-message inputs (system prompt, tools, skills) change rarely — at most
+// once per turn via setSystemPrompt/setTools — but the per-turn compaction and
+// threshold paths call these helpers several times: getContextBreakdown calls
+// both, and #estimateStoredContextTokens adds a third. Memoize on the identity
+// of the three input arrays so the expensive parts (system-prompt tokenization
+// and the per-tool JSON.stringify(toolWireSchema) inside estimateToolSchemaTokens)
+// run at most once per input change rather than per call. The identity keys are
+// the same stable references the StatusLineComponent cache already trusts
+// (setSystemPrompt/setTools replace the array reference rather than mutating it).
+interface NonMessageTokenCache {
+	systemPromptRef: readonly string[];
+	toolsRef: ReadonlyArray<Pick<Tool, "name" | "description" | "parameters">>;
+	skillsRef: readonly Skill[];
+	tokens: number | undefined;
+	breakdown:
+		| {
+				skillsTokens: number;
+				toolsTokens: number;
+				systemContextTokens: number;
+				systemPromptTokens: number;
+		  }
+		| undefined;
+}
+
+const nonMessageTokenCache = new WeakMap<AgentSession, NonMessageTokenCache>();
+
+function nonMessageTokenCacheEntry(session: AgentSession): NonMessageTokenCache {
+	const systemPromptRef = session.systemPrompt ?? EMPTY_STRING_PARTS;
+	const toolsRef = session.agent?.state?.tools ?? EMPTY_TOOLS;
+	const skillsRef = session.skills ?? EMPTY_SKILLS;
+	let entry = nonMessageTokenCache.get(session);
+	if (
+		entry &&
+		entry.systemPromptRef === systemPromptRef &&
+		entry.toolsRef === toolsRef &&
+		entry.skillsRef === skillsRef
+	) {
+		return entry;
+	}
+	entry = { systemPromptRef, toolsRef, skillsRef, tokens: undefined, breakdown: undefined };
+	nonMessageTokenCache.set(session, entry);
+	return entry;
+}
+
 export function computeNonMessageTokens(session: AgentSession): number {
+	const entry = nonMessageTokenCacheEntry(session);
+	if (entry.tokens !== undefined) return entry.tokens;
 	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
 	const tools = session.agent?.state?.tools ?? EMPTY_TOOLS;
-	return countTokens(systemPromptParts) + estimateToolSchemaTokens(tools);
+	const tokens = countTokens(systemPromptParts) + estimateToolSchemaTokens(tools);
+	entry.tokens = tokens;
+	return tokens;
 }
 
 /**
@@ -104,12 +153,16 @@ export function computeNonMessageBreakdown(session: AgentSession): {
 	systemContextTokens: number;
 	systemPromptTokens: number;
 } {
-	const skillsTokens = estimateSkillsTokens(session.skills ?? []);
-	const toolsTokens = estimateToolSchemaTokens(session.agent?.state?.tools ?? []);
-	const systemPromptParts = session.systemPrompt ?? [];
+	const entry = nonMessageTokenCacheEntry(session);
+	if (entry.breakdown) return entry.breakdown;
+	const skillsTokens = estimateSkillsTokens(session.skills ?? EMPTY_SKILLS);
+	const toolsTokens = estimateToolSchemaTokens(session.agent?.state?.tools ?? EMPTY_TOOLS);
+	const systemPromptParts = session.systemPrompt ?? EMPTY_STRING_PARTS;
 	const systemContextTokens = countTokens(systemPromptParts.slice(1));
 	const systemPromptTokens = Math.max(0, countTokens(systemPromptParts[0] ?? "") - skillsTokens);
-	return { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
+	const breakdown = { skillsTokens, toolsTokens, systemContextTokens, systemPromptTokens };
+	entry.breakdown = breakdown;
+	return breakdown;
 }
 
 /**

--- a/packages/coding-agent/test/modes/context-usage.test.ts
+++ b/packages/coding-agent/test/modes/context-usage.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, it } from "bun:test";
 import { arkToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import {
 	type ContextBreakdown,
+	computeNonMessageBreakdown,
+	computeNonMessageTokens,
 	estimateToolSchemaTokens,
 	renderContextUsage,
 } from "@oh-my-pi/pi-coding-agent/modes/utils/context-usage";
@@ -84,5 +86,54 @@ describe("renderContextUsage snapcompact section", () => {
 	it("omits the section entirely when no snapcompact setting is on", () => {
 		const output = renderContextUsage(breakdownWith(undefined), themeStub);
 		expect(output).not.toContain("Snapcompact");
+	});
+});
+
+/**
+ * Contract: the non-message token totals reflect the CURRENT system prompt,
+ * tools, and skills — including after they change via reference replacement
+ * (the setSystemPrompt/setTools pattern), and stay stable while those inputs
+ * hold the same identity. The memo must never serve a stale value for changed
+ * inputs.
+ */
+describe("computeNonMessageTokens / computeNonMessageBreakdown memoization", () => {
+	function makeSession(systemPrompt: string[], tools: unknown[] = [], skills: unknown[] = []) {
+		return { systemPrompt, agent: { state: { tools } }, skills };
+	}
+
+	it("recomputes when the system prompt reference changes and caches otherwise", () => {
+		const session = makeSession(["system prompt alpha"]);
+		const first = computeNonMessageTokens(session as never);
+		// Same inputs (identical refs) → cached, identical value.
+		expect(computeNonMessageTokens(session as never)).toBe(first);
+		// Replace the system prompt reference (mirrors setSystemPrompt).
+		session.systemPrompt = ["system prompt beta with more tokens than alpha"];
+		const afterChange = computeNonMessageTokens(session as never);
+		expect(afterChange).toBeGreaterThan(first);
+		// Cached on the new inputs.
+		expect(computeNonMessageTokens(session as never)).toBe(afterChange);
+	});
+
+	it("recomputes the breakdown when the tools reference changes", () => {
+		const session = makeSession(["base"], []);
+		const before = computeNonMessageBreakdown(session as never);
+		expect(before.toolsTokens).toBe(0);
+		// New tools array reference (mirrors setTools).
+		session.agent.state.tools = [{ name: "search", description: "search the web", parameters: {} }];
+		const after = computeNonMessageBreakdown(session as never);
+		expect(after.toolsTokens).toBeGreaterThan(0);
+		// Cached on the new tools.
+		expect(computeNonMessageBreakdown(session as never).toolsTokens).toBe(after.toolsTokens);
+	});
+
+	it("shares one cache entry so tokens and breakdown invalidate together", () => {
+		const session = makeSession(["shared prompt"]);
+		const tokens = computeNonMessageTokens(session as never);
+		const breakdown = computeNonMessageBreakdown(session as never);
+		// Changing the system prompt ref must invalidate BOTH fields, not just
+		// the one most recently touched.
+		session.systemPrompt = ["shared prompt but longer now to shift the count"];
+		expect(computeNonMessageTokens(session as never)).not.toBe(tokens);
+		expect(computeNonMessageBreakdown(session as never).systemPromptTokens).not.toBe(breakdown.systemPromptTokens);
 	});
 });

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the native build script failing to locate the `@napi-rs/cli` `napi` binary on Windows because the `PATH` lookup joined entries with a Unix `:` separator instead of the platform delimiter (`path.delimiter`).
+
 ## [16.3.6] - 2026-07-04
 
 ### Changed

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -382,7 +382,11 @@ napiArgs[10] = buildOutputDir;
 // Resolve napi bin directly: `bunx @napi-rs/cli` can pick up the wrong bin on
 // systems where `cli` exists on PATH (e.g. Mono's /usr/bin/cli on Ubuntu).
 const napiBin = Bun.which("napi", {
-	PATH: `${path.join(import.meta.dir, "..", "node_modules", ".bin")}:${path.join(repoRoot, "node_modules", ".bin")}:${process.env.PATH ?? ""}`,
+	PATH: [
+		path.join(import.meta.dir, "..", "node_modules", ".bin"),
+		path.join(repoRoot, "node_modules", ".bin"),
+		process.env.PATH ?? "",
+	].join(path.delimiter),
 });
 if (!napiBin) {
 	throw new Error("Could not locate @napi-rs/cli `napi` binary in node_modules/.bin");


### PR DESCRIPTION
## What

- perf(coding-agent) — Memoize computeNonMessageTokens / computeNonMessageBreakdown on the identity of (systemPrompt, tools, skills). Same WeakMap-keyed-on-stable-refs pattern the StatusLineComponent cache already uses; the two helpers keep their independent (diverging-in-an-edge-case) decompositions and share one cache entry whose fields
invalidate together.

- fix(natives) — Build-script napi PATH lookup now joins with path.delimiter instead of :. The Unix separator meant Bun.which couldn't locate napi.exe on Windows, blocking native builds and every test that imports countTokens (its import chain eager-loads the .node). Needed to verify the perf change on Windows.

## Why


getContextBreakdown is called twice per user turn (pre-prompt compaction check + the context snapshot), each calling both non-message helpers, and #estimateStoredContextTokens adds a third — ~5 non-message token computations/turn. The expensive parts are system-prompt tokenization and estimateToolSchemaTokens
(JSON.stringify(toolWireSchema(...)) per tool), recomputed over inputs that change at most once per turn via setSystemPrompt/setTools (which replace the array reference, never mutate in place). Memoizing collapses ~5 → ~2 per input change. The status-line /context% segment and the /context panel benefit too.

The build-script fix is incidental to the perf work but was the blocker to running any test on Windows.

## Testing

- check:types (tsgo) passes for coding-agent and natives; biome clean on all changed files.
- 3 new contract tests in context-usage.test.ts defending the cache's no-staleness contract: recomputes when the system-prompt ref changes; recomputes the breakdown when the tools ref changes; the shared entry invalidates both tokens and breakdown together.
- agent-session-snapcompact-budget.test.ts (real AgentSession → computeNonMessageTokens) + 6 context/compaction integration files (status-line-context-cache, compaction, agent-session-compaction, agent-session-eager-compaction, context-consolidation, status-line-cache-hit) — 79 pass / 0 fail.
- Native build now succeeds on Windows after the path.delimiter fix.

---

- [ x] `bun check` passes
- [ x] Tested locally
- [x ] CHANGELOG updated (if user-facing)
