### PR TITLE
fix(plan): carry local artifacts into approve execute

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed plan mode to document `local://` artifacts as writable session-local planning files and to carry every pre-approval `local://` artifact into the fresh session created by Approve and Execute.
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2602,6 +2602,49 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
+	#resolveLocalRoot(): string {
+		return resolveLocalUrlToPath("local://", {
+			getArtifactsDir: () => this.sessionManager.getArtifactsDir(),
+			getSessionId: () => this.sessionManager.getSessionId(),
+		});
+	}
+
+	async #copyLocalArtifactsForFreshSession(sourceRoot: string, destinationRoot: string): Promise<void> {
+		if (sourceRoot === destinationRoot) return;
+
+		let sourceRootStat: { isDirectory(): boolean };
+		try {
+			sourceRootStat = await fs.lstat(sourceRoot);
+		} catch (error) {
+			if (isEnoent(error)) return;
+			throw error;
+		}
+
+		if (!sourceRootStat.isDirectory()) return;
+
+		await fs.mkdir(destinationRoot, { recursive: true });
+		await this.#copyLocalArtifactEntries(sourceRoot, destinationRoot);
+	}
+
+	async #copyLocalArtifactEntries(sourceDir: string, destinationDir: string): Promise<void> {
+		const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+		for (const entry of entries) {
+			const sourcePath = path.join(sourceDir, entry.name);
+			const destinationPath = path.join(destinationDir, entry.name);
+
+			if (entry.isDirectory()) {
+				await fs.mkdir(destinationPath, { recursive: true });
+				await this.#copyLocalArtifactEntries(sourcePath, destinationPath);
+				continue;
+			}
+
+			if (entry.isFile()) {
+				await fs.mkdir(path.dirname(destinationPath), { recursive: true });
+				await fs.copyFile(sourcePath, destinationPath);
+			}
+		}
+	}
+
 	async #approvePlan(
 		planContent: string,
 		options: {
@@ -2632,14 +2675,16 @@ export class InteractiveMode implements InteractiveModeContext {
 			});
 
 			if (!options.preserveContext) {
+				const oldLocalRoot = this.#resolveLocalRoot();
 				await this.handleClearCommand();
-				// The new session has a fresh local:// root — persist the approved plan there
-				// so `local://<slug>-plan.md` resolves correctly in the execution session.
+				const newLocalRoot = this.#resolveLocalRoot();
+				await this.#copyLocalArtifactsForFreshSession(oldLocalRoot, newLocalRoot);
 				const newLocalPath = resolveLocalUrlToPath(options.planFilePath, {
 					getArtifactsDir: () => this.sessionManager.getArtifactsDir(),
 					getSessionId: () => this.sessionManager.getSessionId(),
 				});
-				await Bun.write(newLocalPath, planContent);
+				await fs.mkdir(path.dirname(newLocalPath), { recursive: true });
+				await fs.writeFile(newLocalPath, planContent);
 			} else if (options.compactBeforeExecute) {
 				// Distill the plan-mode transcript before the execution turn is queued so
 				// the plan-approved synthetic prompt lands as a fresh cache anchor.

--- a/packages/coding-agent/src/prompts/system/plan-mode-active.md
+++ b/packages/coding-agent/src/prompts/system/plan-mode-active.md
@@ -1,7 +1,10 @@
 <critical>
-Plan mode is active. You MUST perform READ-ONLY work only:
-- You NEVER create, edit, or delete files — except the single plan file named below.
+Plan mode is active. You MUST preserve read-only working-tree and system semantics:
+- You NEVER create, edit, delete, or rename working-tree files.
 - You NEVER run state-changing commands (`git commit`, `npm install`, migrations) or make any other system change.
+- `local://` artifacts are session-local planning artifacts. You MAY create or update them when explicitly requested or needed for the plan.
+- You NEVER delete or rename `local://` artifacts.
+- You MUST write the canonical plan to `local://<slug>-plan.md`.
 
 To leave plan mode and implement: call `resolve` with `action: "apply"`, a `reason`, and `extra: { title: "<slug>" }`, where `<slug>` matches your `local://<slug>-plan.md`. The user then picks an execution option and full write access is restored. `<slug>` may contain only letters, numbers, underscores, and hyphens.
 

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -415,6 +415,61 @@ describe("InteractiveMode plan review rendering", () => {
 		expect(await Bun.file(resolvedPlanPath).text()).toContain("edited body");
 	});
 
+	it("carries pre-approval local artifacts into the fresh approve-and-execute session", async () => {
+		const planFilePath = "local://handoff-plan.md";
+		const localOptions = {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		};
+		const oldLocalRoot = resolveLocalUrlToPath("local://", localOptions);
+		const oldPlanPath = resolveLocalUrlToPath(planFilePath, localOptions);
+		const oldArtifactPath = resolveLocalUrlToPath("local://handoff/nested/context.txt", localOptions);
+		await fs.mkdir(path.dirname(oldArtifactPath), { recursive: true });
+		await Bun.write(oldArtifactPath, "pre-approval handoff");
+		await Bun.write(oldPlanPath, "# Plan\n\noriginal body\n");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		const planContent = "# Plan\n\nfinal approved body\n";
+		vi.spyOn(mode, "showPlanReview").mockImplementation(async (_plan, _title, _options, dialogOptions) => {
+			dialogOptions?.onPlanEdited?.(planContent);
+			return "Approve and execute";
+		});
+		vi.spyOn(mode, "handleClearCommand").mockImplementation(async () => {
+			await session.sessionManager.newSession();
+		});
+		let artifactAtPrompt = "";
+		let planAtPrompt = "";
+		const prompt = vi.spyOn(session, "prompt").mockImplementation(async () => {
+			const promptArtifactPath = resolveLocalUrlToPath("local://handoff/nested/context.txt", localOptions);
+			const promptPlanPath = resolveLocalUrlToPath(planFilePath, localOptions);
+			artifactAtPrompt = (await Bun.file(promptArtifactPath).exists())
+				? await Bun.file(promptArtifactPath).text()
+				: "<missing>";
+			planAtPrompt = (await Bun.file(promptPlanPath).exists()) ? await Bun.file(promptPlanPath).text() : "<missing>";
+			return undefined as never;
+		});
+
+		expect(await Bun.file(oldArtifactPath).text()).toBe("pre-approval handoff");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "HANDOFF",
+		});
+
+		const newLocalRoot = resolveLocalUrlToPath("local://", localOptions);
+		const newArtifactPath = resolveLocalUrlToPath("local://handoff/nested/context.txt", localOptions);
+		const newPlanPath = resolveLocalUrlToPath(planFilePath, localOptions);
+		expect(newLocalRoot).not.toBe(oldLocalRoot);
+		expect(await Bun.file(newArtifactPath).text()).toBe("pre-approval handoff");
+		expect(await Bun.file(newPlanPath).text()).toBe(planContent);
+		expect(artifactAtPrompt).toBe("pre-approval handoff");
+		expect(planAtPrompt).toBe(planContent);
+		expect(await Bun.file(oldArtifactPath).text()).toBe("pre-approval handoff");
+		expect(prompt).toHaveBeenCalledWith(expect.any(String), { synthetic: true });
+	});
+
 	it("offers approve-and-keep-context as a distinct plan approval path", async () => {
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {


### PR DESCRIPTION
## Summary
- Clarify plan-mode guardrails so `local://` artifacts are documented as session-local planning artifacts that may be created or updated while working-tree writes remain forbidden.
- Copy all regular files under the old session `local://` root into the fresh session during Approve & Execute, then write the approved plan content last.
- Add regression coverage for nested pre-approval `local://` artifacts surviving fresh Approve & Execute.

## Verification
- `bun test test/interactive-mode-plan-review.test.ts test/tools/plan-mode-guard-local.test.ts test/plan-mode/approved-plan.test.ts`
- `bun build src/modes/interactive-mode.ts --no-bundle --external '*' --outfile /tmp/omp-interactive-mode.js`

## Note
- `bun check` was attempted in the dedicated worktree and failed before useful package validation because the worktree cannot resolve shared workspace prerequisites/types (`cargo metadata` workspace error and TS2688 missing `bun`/React type definitions).