### PR TITLE
feat(auth-broker): import Codex access-token-only credentials

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed access-token-only OAuth credentials attempting token refresh with an empty refresh token after expiry.
+
+## [16.3.11-zen.1] - 2026-07-07
+
+### Added
+
+- Added `anysearch` registry provider definition and interactive credentials login support.
+
+### Fixed
+
+- Fixed plain-text 5xx provider status messages (including relay `520` HTML pages) being left as non-retryable numeric statuses instead of transient retryable errors.
+- Fixed relay `insufficient_user_*` quota errors being classified as generic 403 auth failures instead of retryable usage-limit errors.
+
 ## [16.3.11] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3377,6 +3377,21 @@ export class AuthStorage {
 			.filter((entry): entry is { credential: OAuthCredential; index: number } => entry.credential.type === "oauth");
 
 		if (credentials.length === 0) return undefined;
+		if (
+			credentials.every(
+				entry =>
+					entry.credential.refresh.trim().length === 0 &&
+					Date.now() + OAUTH_REFRESH_SKEW_MS >= entry.credential.expires,
+			)
+		) {
+			throw new AIError.OAuthError(
+				`${provider} credential is access-token-only and expired; import a fresh CPA JSON`,
+				{
+					kind: "validation",
+					provider,
+				},
+			);
+		}
 
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
 		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
@@ -3548,6 +3563,15 @@ export class AuthStorage {
 			if (existing) return raceCredentialRefreshWithSignal(existing, signal);
 		}
 		if (Date.now() + OAUTH_REFRESH_SKEW_MS < credential.expires) return credential;
+		if (credential.refresh.trim().length === 0) {
+			throw new AIError.OAuthError(
+				`${provider} credential is access-token-only and expired; import a fresh CPA JSON`,
+				{
+					kind: "validation",
+					provider,
+				},
+			);
+		}
 		if (credentialId === undefined) {
 			return this.#refreshOAuthCredentialUnshared(provider, credential, undefined, signal);
 		}
@@ -3812,9 +3836,10 @@ export class AuthStorage {
 			return { apiKey: result.apiKey, credential: updated };
 		} catch (error) {
 			const errorMsg = String(error);
+			const isAccessTokenOnlyExpired = errorMsg.includes("credential is access-token-only and expired");
 			// Only remove credentials for definitive auth failures
 			// Keep credentials for transient errors (network, 5xx) and block temporarily
-			const isDefinitiveFailure = AIError.isDefinitiveOAuthFailure(errorMsg);
+			const isDefinitiveFailure = !isAccessTokenOnlyExpired && AIError.isDefinitiveOAuthFailure(errorMsg);
 
 			logger.warn("OAuth token refresh failed", {
 				provider,

--- a/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
+++ b/packages/ai/test/auth-storage-force-refresh-rotate.test.ts
@@ -100,6 +100,45 @@ describe("AuthStorage forceRefresh + rotateSessionCredential", () => {
 		expect(after).toBe("minted-access");
 	});
 
+	test("access-token-only OAuth works until the refresh window, then skips refresh", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const refreshes: string[] = [];
+		registerOAuthProvider({
+			id: PROVIDER,
+			name: "Rotate Unit",
+			sourceId: SOURCE,
+			async login() {
+				return { access: "login", refresh: "login", expires: farExpiry() };
+			},
+			async refreshToken(credentials) {
+				refreshes.push(credentials.refresh);
+				return { ...credentials, access: "minted", refresh: "minted", expires: farExpiry() };
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+		await authStorage.set(PROVIDER, [
+			{ type: "oauth", access: "token-only-fresh", refresh: "", expires: farExpiry() },
+		]);
+
+		expect(await authStorage.getApiKey(PROVIDER, "fresh")).toBe("token-only-fresh");
+		expect(refreshes).toEqual([]);
+
+		await authStorage.set(PROVIDER, [
+			{ type: "oauth", access: "token-only-expired", refresh: "", expires: Date.now() - 1_000 },
+			{ type: "oauth", access: "sibling", refresh: "sibling-refresh", expires: farExpiry() },
+		]);
+		expect(await authStorage.getApiKey(PROVIDER, "sibling")).toBe("sibling");
+		expect(refreshes).toEqual([]);
+
+		await authStorage.set(PROVIDER, [
+			{ type: "oauth", access: "token-only-expired", refresh: "", expires: Date.now() - 1_000 },
+		]);
+		await expect(authStorage.getApiKey(PROVIDER, "expired")).rejects.toThrow("access-token-only and expired");
+		expect(refreshes).toEqual([]);
+	});
+
 	test("rotateSessionCredential(401) blocks + clears the sticky and rotates to a sibling", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 		registerProvider();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Changed
+### Added
+
+- Added `omp auth-broker import` support for CPA Codex access-token-only JSON credentials.
+
+## [16.3.11-zen.1] - 2026-07-07
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 

--- a/packages/coding-agent/src/cli/auth-broker-cli.ts
+++ b/packages/coding-agent/src/cli/auth-broker-cli.ts
@@ -454,6 +454,8 @@ interface ImportPlanEntry {
 	accountId: string | null;
 	expiresAt: number;
 	disabled: boolean;
+	refreshable: boolean;
+	accessTokenOnly: boolean;
 	credential: OAuthCredential;
 }
 
@@ -523,8 +525,17 @@ async function loadImportPlan(
 			});
 			continue;
 		}
-		if (!json.access_token || !json.refresh_token) {
-			skipped.push({ file, reason: "missing access_token or refresh_token" });
+		if (!json.access_token) {
+			skipped.push({ file, reason: "missing access_token" });
+			continue;
+		}
+		const refreshToken = typeof json.refresh_token === "string" ? json.refresh_token : "";
+		const accessTokenOnly = refreshToken.trim().length === 0;
+		if (accessTokenOnly && provider !== "openai-codex") {
+			skipped.push({
+				file,
+				reason: "missing refresh_token; access-token-only import is currently supported only for openai-codex",
+			});
 			continue;
 		}
 		const expiresAt = parseCliProxyExpiry(json.expired);
@@ -537,7 +548,7 @@ async function loadImportPlan(
 		const credential: OAuthCredential = {
 			type: "oauth",
 			access: json.access_token,
-			refresh: json.refresh_token,
+			refresh: refreshToken,
 			expires: expiresAt,
 			...(email !== null ? { email } : {}),
 			...(accountId !== null ? { accountId } : {}),
@@ -549,6 +560,8 @@ async function loadImportPlan(
 			accountId,
 			expiresAt,
 			disabled: json.disabled === true,
+			refreshable: !accessTokenOnly,
+			accessTokenOnly,
 			credential,
 		});
 	}
@@ -557,9 +570,10 @@ async function loadImportPlan(
 
 function describeImportEntry(entry: ImportPlanEntry): string {
 	const ident = entry.email ?? entry.accountId ?? "(no identity)";
+	const mode = entry.accessTokenOnly ? " [access-token-only]" : "";
 	const stale = entry.expiresAt < Date.now() ? " [expired]" : "";
 	const disabled = entry.disabled ? " [disabled]" : "";
-	return `${entry.provider}: ${ident}${stale}${disabled} from ${entry.sourceFile}`;
+	return `${entry.provider}: ${ident}${mode}${stale}${disabled} from ${entry.sourceFile}`;
 }
 
 async function runImport(flags: AuthBrokerCommandArgs["flags"]): Promise<void> {
@@ -583,6 +597,8 @@ async function runImport(flags: AuthBrokerCommandArgs["flags"]): Promise<void> {
 					accountId: e.accountId,
 					expiresAt: e.expiresAt,
 					disabled: e.disabled,
+					refreshable: e.refreshable,
+					accessTokenOnly: e.accessTokenOnly,
 					file: e.sourceFile,
 				})),
 				skipped,

--- a/packages/coding-agent/test/auth-broker-import.test.ts
+++ b/packages/coding-agent/test/auth-broker-import.test.ts
@@ -136,6 +136,90 @@ describe("auth-broker import (CLIProxyAPI)", () => {
 		expect(parsed.plan[0].provider).toBe("anthropic");
 	});
 
+	test("imports Codex access-token-only CPA JSON without persisting session_token", async () => {
+		await writeCliProxyJson("codex-token-only.json", {
+			type: "codex",
+			email: "user@example.com",
+			expired: "2099-12-31 23:59:59 +0000",
+			account_id: "00000000-0000-4000-8000-000000000001",
+			access_token: "codex-access-only",
+			session_token: "ignored-session-token",
+			refresh_token: "",
+		});
+		await writeCliProxyJson("codex-missing-refresh.json", {
+			type: "codex",
+			email: "missing-refresh@example.com",
+			expired: "2099-12-31T23:59:59Z",
+			access_token: "codex-missing-refresh",
+		});
+
+		let restore = silenceStdout();
+		await runAuthBrokerCommand({
+			action: "import",
+			flags: { source: cliproxyDir, dryRun: true, json: true },
+		});
+		const dryRun = JSON.parse(restore().trim().split("\n").pop() ?? "{}");
+		expect(dryRun.plan).toHaveLength(2);
+		expect(dryRun.plan.map((entry: { email: string }) => entry.email).sort()).toEqual([
+			"missing-refresh@example.com",
+			"user@example.com",
+		]);
+		for (const entry of dryRun.plan) {
+			expect(entry).toMatchObject({
+				provider: "openai-codex",
+				refreshable: false,
+				accessTokenOnly: true,
+			});
+		}
+
+		restore = silenceStdout();
+		await runAuthBrokerCommand({
+			action: "import",
+			flags: { source: cliproxyDir },
+		});
+		const text = restore();
+		expect(text).toContain("[access-token-only]");
+
+		const store = await SqliteAuthCredentialStore.open(getAgentDbPath());
+		try {
+			const rows = store.listAuthCredentials("openai-codex");
+			expect(rows).toHaveLength(2);
+			const row = rows.find(
+				entry => entry.credential.type === "oauth" && entry.credential.email === "user@example.com",
+			);
+			if (!row) throw new Error("missing imported Codex token-only credential");
+			expect(row.credential.type).toBe("oauth");
+			if (row.credential.type === "oauth") {
+				expect(row.credential.access).toBe("codex-access-only");
+				expect(row.credential.refresh).toBe("");
+				expect(row.credential.accountId).toBe("00000000-0000-4000-8000-000000000001");
+				expect("session_token" in row.credential).toBe(false);
+			}
+		} finally {
+			store.close();
+		}
+	});
+
+	test("skips access-token-only JSON for non-Codex providers", async () => {
+		await writeCliProxyJson("claude-token-only.json", {
+			type: "claude",
+			access_token: "claude-access-only",
+			expired: "2099-12-31T23:59:59Z",
+			refresh_token: "",
+		});
+
+		const restore = silenceStdout();
+		await runAuthBrokerCommand({
+			action: "import",
+			flags: { source: cliproxyDir, dryRun: true, json: true },
+		});
+		const parsed = JSON.parse(restore().trim().split("\n").pop() ?? "{}");
+		expect(parsed.plan).toHaveLength(0);
+		expect(parsed.skipped[0].reason).toContain(
+			"access-token-only import is currently supported only for openai-codex",
+		);
+	});
+
 	test("--provider override forces a provider id when the JSON type is unrecognized", async () => {
 		await writeCliProxyJson("weird.json", {
 			type: "some-future-type",


### PR DESCRIPTION
## Summary
- allow `omp auth-broker import` to accept CPA Codex JSON with an access token and no refresh token
- mark token-only imports in dry-run output and keep `session_token` ignored/unpersisted
- prevent expired token-only OAuth credentials from attempting refresh with an empty refresh token

## Verification
- `bun test packages/coding-agent/test/auth-broker-import.test.ts packages/ai/test/auth-storage-force-refresh-rotate.test.ts`
- `bun check`