### PR TITLE
fix(coding-agent): resolve agent:// for nested subagent output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed `agent://<id>` (and the `output()` eval helper) failing with `Not found` for a subagent spawned by another subagent (any spawn chain 2+ levels deep). `artifactsDirsFromRegistry` scanned only each ref's adopted (root-wide) `ArtifactManager` dir, but a subagent's own children are written one level deeper under its `sessionFile`-derived dir — so a live, addressable nested peer's output was unresolvable. The resolver now collects both candidate dirs per registered agent. ([#4650](https://github.com/can1357/oh-my-pi/issues/4650))
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/internal-urls/__tests__/agent-protocol-nested.test.ts
+++ b/packages/coding-agent/src/internal-urls/__tests__/agent-protocol-nested.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, afterEach, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { AgentRegistry } from "../../registry/agent-registry";
+import type { AgentSession } from "../../session/agent-session";
+import { ArtifactManager } from "../../session/artifacts";
+import { AgentProtocolHandler } from "../agent-protocol";
+import { resetRegisteredArtifactDirsForTests } from "../registry-helpers";
+
+const tempDir = TempDir.createSync("omp-nested-agent-repro-");
+afterEach(() => {
+	AgentRegistry.resetGlobalForTests();
+	resetRegisteredArtifactDirsForTests();
+});
+afterAll(() => {
+	tempDir.removeSync();
+});
+
+it("agent:// resolves a depth-2 subagent's .md output while its session is live and artifact-manager-adopted", async () => {
+	const root = tempDir.path();
+	const rootSessionFile = path.join(root, "session.jsonl");
+	const rootArtifactsDir = rootSessionFile.slice(0, -6);
+	await fs.mkdir(rootArtifactsDir, { recursive: true });
+	// Every subagent adopts the root ArtifactManager and reports its dir.
+	const sharedArtifactManager = new ArtifactManager(rootArtifactsDir);
+
+	// A depth-1 subagent's OWN children are written under its own
+	// sessionFile.slice(0, -6) (task/index.ts), i.e. one level deeper.
+	const midSessionFile = path.join(rootArtifactsDir, "CodexDeepDive.jsonl");
+	const midOwnArtifactsDir = midSessionFile.slice(0, -6);
+	await fs.mkdir(midOwnArtifactsDir, { recursive: true });
+
+	const grandchildId = "CodexDeepDive.GraphStore";
+	const grandchildSessionFile = path.join(midOwnArtifactsDir, `${grandchildId}.jsonl`);
+	await fs.writeFile(path.join(midOwnArtifactsDir, `${grandchildId}.md`), "full report content");
+
+	const fakeSession = {
+		sessionManager: { getArtifactsDir: () => sharedArtifactManager.dir },
+	} as unknown as AgentSession;
+	const registry = AgentRegistry.global();
+	registry.register({
+		id: "Main",
+		displayName: "main",
+		kind: "main",
+		session: fakeSession,
+		sessionFile: rootSessionFile,
+	});
+	registry.register({
+		id: "CodexDeepDive",
+		displayName: "sub",
+		kind: "sub",
+		parentId: "Main",
+		session: fakeSession,
+		sessionFile: midSessionFile,
+	});
+	registry.register({
+		id: grandchildId,
+		displayName: "sub",
+		kind: "sub",
+		parentId: "CodexDeepDive",
+		session: fakeSession,
+		sessionFile: grandchildSessionFile,
+	});
+
+	const resource = await new AgentProtocolHandler().resolve(new URL(`agent://${grandchildId}`) as never);
+	expect(resource.content).toBe("full report content");
+});

--- a/packages/coding-agent/src/internal-urls/registry-helpers.ts
+++ b/packages/coding-agent/src/internal-urls/registry-helpers.ts
@@ -20,11 +20,13 @@ export function resetRegisteredArtifactDirsForTests(): void {
 /**
  * Snapshot of artifacts dirs for every registered session, deduped.
  *
- * Prefers `sessionManager.getArtifactsDir()` because subagents adopt their
- * parent's `ArtifactManager` and report the parent's dir there; dedup then
- * collapses parent + N subagents (the whole agent tree) to one entry. Falls
- * back to the raw session file (with the `.jsonl` suffix stripped) when no
- * live session reference is attached.
+ * Collects TWO candidate dirs per ref, because a subagent reads from its
+ * adopted (root-wide) `ArtifactManager.dir` but its own children are written
+ * one level deeper, under `sessionFile.slice(0, -6)` (`task/index.ts`). A
+ * depth-2+ subagent's output therefore lives in the write-time dir, not the
+ * adopted one, so `agent://` must scan both or it 404s a live nested peer.
+ * `addDir` dedup collapses the depth-0 case (both formulas agree) back to a
+ * single entry.
  */
 export function artifactsDirsFromRegistry(): string[] {
 	const dirs: string[] = [];
@@ -33,7 +35,8 @@ export function artifactsDirsFromRegistry(): string[] {
 		if (!dirs.includes(dir)) dirs.push(dir);
 	};
 	for (const ref of AgentRegistry.global().list()) {
-		addDir(ref.session?.sessionManager.getArtifactsDir() ?? (ref.sessionFile ? ref.sessionFile.slice(0, -6) : null));
+		addDir(ref.session?.sessionManager.getArtifactsDir());
+		if (ref.sessionFile) addDir(ref.sessionFile.slice(0, -6));
 	}
 	for (const dir of extraArtifactsDirs) addDir(dir);
 	return dirs;


### PR DESCRIPTION
Fixes #4650

## What

`agent://<id>` (and the `output()` eval helper, which resolves through the same registry) now finds a subagent's output regardless of spawn depth. `artifactsDirsFromRegistry` collects **two** candidate dirs per registered agent — the adopted (root-wide) `ArtifactManager.dir` **and** the ref's own `sessionFile`-derived dir — instead of treating them as mutually-exclusive fallbacks.

## Why

Two different formulas compute a subagent's artifacts directory:
- `task/index.ts` derives the dir a subagent's **own children** are written into from that subagent's **own** `sessionFile.slice(0, -6)` — nesting one level deeper per hop.
- `internal-urls/registry-helpers.ts` (`artifactsDirsFromRegistry`, what `agent://` scans) preferred each ref's live **adopted** `ArtifactManager.dir` via `sessionManager.getArtifactsDir()`, which every subagent inherits flat from the root.

So for any spawn chain 2+ levels deep, the grandchild's output lives in the write-time dir but the resolver only scanned the adopted dir → `Not found: <id>` / `Available: none`, even though the file exists and the id is a live, addressable peer. The old `getArtifactsDir() ?? sessionFile` `??` made the two mutually exclusive; collecting both (with the existing `addDir` dedup collapsing the depth-0 case) fixes it without changing the flat case.

## Testing

- New regression test `packages/coding-agent/src/internal-urls/__tests__/agent-protocol-nested.test.ts` drives the exact write-vs-read seam (depth-2 subagent, faked adopted `ArtifactManager`): **fails on clean `main`** (`Not found`), **passes with the fix**.
- `bun test src/eval/__tests__/agent-bridge.test.ts src/internal-urls/__tests__/agent-protocol-nested.test.ts` — 40 pass / 0 fail (39 existing agent-bridge cases unaffected, incl. the depth-0 "registers temp artifact dirs" case).
- `bun run check:types` clean.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
