### PR TITLE
fix(auth): rotate Codex credentials before provider fallback

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed access-token-only OAuth credentials attempting token refresh with an empty refresh token after expiry.
 - Fixed gateway usage-limit retries falling through to cross-provider model fallback before trying a sibling credential from the same provider.
+- Fixed Codex usage-limit rotation treating Plus and K-12 accounts as separate quota groups for shared 5-hour/7-day windows.
 
 ## [16.3.11-zen.1] - 2026-07-07
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed access-token-only OAuth credentials attempting token refresh with an empty refresh token after expiry.
+- Fixed gateway usage-limit retries falling through to cross-provider model fallback before trying a sibling credential from the same provider.
+
+## [16.3.11-zen.1] - 2026-07-07
+
+### Added
+
+- Added `anysearch` registry provider definition and interactive credentials login support.
+
+### Fixed
+
+- Fixed plain-text 5xx provider status messages (including relay `520` HTML pages) being left as non-retryable numeric statuses instead of transient retryable errors.
+- Fixed relay `insufficient_user_*` quota errors being classified as generic 403 auth failures instead of retryable usage-limit errors.
+
 ## [16.3.11] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -233,6 +233,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 			retryAfterMs,
 			baseUrl: model.baseUrl,
 			modelId: model.id,
+			apiKey: oldKey,
 			signal,
 		});
 		logger.debug("auth-gateway retrying provider request after usage-limit block", {

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -1,6 +1,7 @@
 import type { OAuthAccess } from "./auth-storage";
 import * as AIError from "./error";
 import { isAuthRetryableError } from "./error/auth-classify";
+import { isUsageLimit } from "./error/flags";
 
 /**
  * Context passed to an {@link ApiKeyResolver} on each resolution attempt.
@@ -92,7 +93,8 @@ export async function resolveRetryKey(
 	previousKey?: string,
 ): Promise<string | undefined> {
 	try {
-		return (await resolver({ lastChance, error, signal, previousKey })) || undefined;
+		const rotateSibling = lastChance || (!lastChance && isUsageLimit(error));
+		return (await resolver({ lastChance: rotateSibling, error, signal, previousKey })) || undefined;
 	} catch {
 		return undefined;
 	}

--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -23,6 +23,8 @@ export interface ApiKeyResolveContext {
 	lastChance: boolean;
 	/** The auth error that triggered this re-resolution, or `undefined` on the initial resolve. */
 	error: unknown;
+	/** Bearer used by the failed attempt, when the caller can expose it. */
+	previousKey?: string;
 	/** Caller cancel signal, threaded into any credential refresh / rotation work. */
 	signal?: AbortSignal;
 }
@@ -87,9 +89,10 @@ export async function resolveRetryKey(
 	lastChance: boolean,
 	error: unknown,
 	signal?: AbortSignal,
+	previousKey?: string,
 ): Promise<string | undefined> {
 	try {
-		return (await resolver({ lastChance, error, signal })) || undefined;
+		return (await resolver({ lastChance, error, signal, previousKey })) || undefined;
 	} catch {
 		return undefined;
 	}
@@ -136,7 +139,7 @@ export async function withAuth<T>(
 	}
 
 	for (let i = 0; i < AUTH_RETRY_STEPS.length; i++) {
-		const nextKey = await resolveRetryKey(resolver, AUTH_RETRY_STEPS[i]!, lastError, signal);
+		const nextKey = await resolveRetryKey(resolver, AUTH_RETRY_STEPS[i]!, lastError, signal, lastKey);
 		if (nextKey === undefined || nextKey === lastKey) continue;
 		lastKey = nextKey;
 		try {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3398,12 +3398,21 @@ export class AuthStorage {
 		const checkUsage = strategy !== undefined && (credentials.length > 1 || requiresProModel);
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		const sessionPreferredIndex = sessionCredential?.type === "oauth" ? sessionCredential.index : undefined;
+		const sessionPreferredCredential =
+			sessionPreferredIndex !== undefined
+				? credentials.find(entry => entry.index === sessionPreferredIndex)?.credential
+				: undefined;
+		const sessionPreferredCanRefreshOrUse =
+			sessionPreferredCredential !== undefined &&
+			(sessionPreferredCredential.refresh.trim().length > 0 ||
+				Date.now() + OAUTH_REFRESH_SKEW_MS < sessionPreferredCredential.expires);
 		// Skip ranking only when the session already has a working preferred credential — re-ranking
 		// mid-session causes account switches that cold-start the server-side prompt cache. New sessions
 		// (no preference) and sessions whose preferred is blocked still rank, so we pick the account
 		// with the most headroom proactively and fall back intelligently when rate-limited.
 		const sessionPreferredIsAvailable =
 			sessionPreferredIndex !== undefined &&
+			sessionPreferredCanRefreshOrUse &&
 			!this.#isCredentialBlocked(provider, providerKey, sessionPreferredIndex, blockScope);
 		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || requiresProModel);
 		const rankingOrder = shouldRank && sessionId ? credentials.map((_credential, index) => index) : order;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3057,9 +3057,19 @@ export class AuthStorage {
 	async markUsageLimitReached(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { retryAfterMs?: number; baseUrl?: string; modelId?: string; signal?: AbortSignal },
+		options?: { retryAfterMs?: number; baseUrl?: string; modelId?: string; apiKey?: string; signal?: AbortSignal },
 	): Promise<UsageLimitMarkResult> {
-		const sessionCredential = this.#getSessionCredential(provider, sessionId);
+		let sessionCredential = this.#getSessionCredential(provider, sessionId);
+		if (!sessionCredential && options?.apiKey) {
+			const stored = this.#getStoredCredentials(provider);
+			for (let index = 0; index < stored.length; index++) {
+				const entry = stored[index];
+				if (entry && (await this.#credentialMatchesApiKey(entry.credential, options.apiKey))) {
+					sessionCredential = { type: entry.credential.type, index };
+					break;
+				}
+			}
+		}
 		if (!sessionCredential) return { switched: false };
 
 		const providerKey = this.#getProviderTypeKey(provider, sessionCredential.type);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1390,12 +1390,14 @@ export class AuthStorage {
 
 		const credentialId = this.#getStoredCredentials(provider)[credentialIndex]?.id;
 		if (credentialId === undefined) return blockedUntil;
-		const persistedGlobalBlockedUntil = this.#readPersistedCredentialBlock(credentialId, providerKey, "");
-		if (
-			persistedGlobalBlockedUntil !== undefined &&
-			(blockedUntil === undefined || persistedGlobalBlockedUntil > blockedUntil)
-		) {
-			blockedUntil = persistedGlobalBlockedUntil;
+		if (!blockScope || provider !== "openai-codex") {
+			const persistedGlobalBlockedUntil = this.#readPersistedCredentialBlock(credentialId, providerKey, "");
+			if (
+				persistedGlobalBlockedUntil !== undefined &&
+				(blockedUntil === undefined || persistedGlobalBlockedUntil > blockedUntil)
+			) {
+				blockedUntil = persistedGlobalBlockedUntil;
+			}
 		}
 		if (blockScope) {
 			const persistedScopedBlockedUntil = this.#readPersistedCredentialBlock(credentialId, providerKey, blockScope);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3059,8 +3059,8 @@ export class AuthStorage {
 		sessionId: string | undefined,
 		options?: { retryAfterMs?: number; baseUrl?: string; modelId?: string; apiKey?: string; signal?: AbortSignal },
 	): Promise<UsageLimitMarkResult> {
-		let sessionCredential = this.#getSessionCredential(provider, sessionId);
-		if (!sessionCredential && options?.apiKey) {
+		let sessionCredential: { type: AuthCredential["type"]; index: number } | undefined;
+		if (options?.apiKey) {
 			const stored = this.#getStoredCredentials(provider);
 			for (let index = 0; index < stored.length; index++) {
 				const entry = stored[index];
@@ -3070,6 +3070,7 @@ export class AuthStorage {
 				}
 			}
 		}
+		sessionCredential ??= this.#getSessionCredential(provider, sessionId);
 		if (!sessionCredential) return { switched: false };
 
 		const providerKey = this.#getProviderTypeKey(provider, sessionCredential.type);
@@ -4391,7 +4392,7 @@ export class AuthStorage {
 	async rotateSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { error?: unknown; modelId?: string; signal?: AbortSignal },
+		options?: { error?: unknown; modelId?: string; apiKey?: string; signal?: AbortSignal },
 	): Promise<boolean> {
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		if (!sessionCredential) return false;
@@ -4403,6 +4404,7 @@ export class AuthStorage {
 			return (
 				await this.markUsageLimitReached(provider, sessionId, {
 					modelId: options?.modelId,
+					apiKey: options?.apiKey,
 					signal: options?.signal,
 				})
 			).switched;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1106,7 +1106,13 @@ export function streamSimple<TApi extends Api>(
 				// Caller aborted between attempts: don't mint a fresh token or fire
 				// another doomed request — emit the captured failure instead.
 				if (signal?.aborted) break;
-				const nextKey = await resolveRetryKey(apiKeyResolver, AUTH_RETRY_STEPS[step]!, failure.error, signal);
+				const nextKey = await resolveRetryKey(
+					apiKeyResolver,
+					AUTH_RETRY_STEPS[step]!,
+					failure.error,
+					signal,
+					lastKey,
+				);
 				if (nextKey === undefined || nextKey === lastKey) continue;
 				lastKey = nextKey;
 				const isLastStep = step === AUTH_RETRY_STEPS.length - 1;

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -285,8 +285,6 @@ function buildUsageLimit(args: {
 		label: usageWindow.label,
 		scope: {
 			provider: "openai-codex",
-			accountId: args.accountId,
-			tier: args.planType,
 			windowId: usageWindow.id,
 			shared: true,
 		},

--- a/packages/ai/src/usage/openai-codex.ts
+++ b/packages/ai/src/usage/openai-codex.ts
@@ -505,6 +505,9 @@ export const openaiCodexUsageProvider: UsageProvider = {
 const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
 
 export const codexRankingStrategy: CredentialRankingStrategy = {
+	blockScope() {
+		return "shared";
+	},
 	findWindowLimits(report) {
 		const findLimit = (key: "primary" | "secondary"): UsageLimit | undefined => {
 			const direct = report.limits.find(l => l.id === `openai-codex:${key}`);

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -99,6 +99,28 @@ describe("withAuth", () => {
 		]);
 	});
 
+	it("switches accounts before refreshing the same account on usage limits", async () => {
+		const keys: string[] = [];
+		const contexts: ApiKeyResolveContext[] = [];
+		const result = await withAuth(
+			ctx => {
+				contexts.push(ctx);
+				return ctx.error === undefined ? "k0" : ctx.lastChance ? "k2" : "k1";
+			},
+			async key => {
+				keys.push(key);
+				if (key === "k2") return "success";
+				throw usageLimitError();
+			},
+		);
+		expect(result).toBe("success");
+		expect(keys).toEqual(["k0", "k2"]);
+		expect(contexts.map(ctx => ({ lastChance: ctx.lastChance, hasError: ctx.error !== undefined }))).toEqual([
+			{ lastChance: false, hasError: false },
+			{ lastChance: true, hasError: true },
+		]);
+	});
+
 	it("stops retrying when the resolver returns undefined", async () => {
 		const keys: string[] = [];
 		const original = authError();

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -98,7 +98,7 @@ function createCredential(accountId: string, email: string): OAuthCredentials {
 	return {
 		access: `access-${accountId}`,
 		refresh: `refresh-${accountId}`,
-		expires: Date.now() + HOUR_MS,
+		expires: Date.now() + WEEK_MS,
 		accountId,
 		email,
 	};
@@ -594,6 +594,54 @@ describe("AuthStorage codex oauth ranking", () => {
 		// refreshes never overlap (peak in-flight stays 1). A wall-clock bound here was
 		// flaky on loaded CI runners, so maxConcurrent is the authoritative signal.
 		expect(maxConcurrent).toBe(3);
+	});
+
+	test("skips expired access-token-only sticky credential and selects fresh sibling", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const sessionId = "sticky-token-only-session";
+		await authStorage.set("openai-codex", [{ type: "oauth", ...createCredential("acct-k12", "k12@example.com") }]);
+		usageByAccount.set(
+			"acct-k12",
+			createCodexUsageReport({
+				accountId: "acct-k12",
+				primary: { usedFraction: 0.3, resetInMs: 20 * 60 * 1000 },
+				secondary: { usedFraction: 0.2, resetInMs: 5 * 24 * 60 * 60 * 1000 },
+			}),
+		);
+		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("api-acct-k12");
+		usageByAccount.set(
+			"acct-k12",
+			createCodexUsageReport({
+				accountId: "acct-k12",
+				primary: { usedFraction: 1, resetInMs: FIVE_HOUR_MS },
+				secondary: { usedFraction: 0.17, resetInMs: WEEK_MS },
+			}),
+		);
+		usageByAccount.set(
+			"acct-plus",
+			createCodexUsageReport({
+				accountId: "acct-plus",
+				primary: { usedFraction: 0.2, resetInMs: FIVE_HOUR_MS },
+				secondary: { usedFraction: 0.74, resetInMs: WEEK_MS },
+			}),
+		);
+
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "access-acct-k12",
+				refresh: "",
+				expires: Date.now() - 1_000,
+				accountId: "acct-k12",
+				email: "k12@example.com",
+			},
+			{
+				type: "oauth",
+				...createCredential("acct-plus", "plus@example.com"),
+			},
+		]);
+
+		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("api-acct-plus");
 	});
 });
 

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -643,6 +643,52 @@ describe("AuthStorage codex oauth ranking", () => {
 
 		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("api-acct-plus");
 	});
+
+	test("ignores legacy global Codex blocks when a scoped quota window has fresh siblings", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-k12", "k12@example.com") },
+			{ type: "oauth", ...createCredential("acct-plus", "plus@example.com") },
+		]);
+		usageByAccount.set(
+			"acct-k12",
+			createCodexUsageReport({
+				accountId: "acct-k12",
+				primary: { usedFraction: 1, resetInMs: FIVE_HOUR_MS },
+				secondary: { usedFraction: 1, resetInMs: WEEK_MS },
+			}),
+		);
+		usageByAccount.set(
+			"acct-plus",
+			createCodexUsageReport({
+				accountId: "acct-plus",
+				primary: { usedFraction: 0.2, resetInMs: FIVE_HOUR_MS },
+				secondary: { usedFraction: 0.74, resetInMs: WEEK_MS },
+			}),
+		);
+		const plus = store
+			.listAuthCredentials("openai-codex")
+			.find(row => row.credential.type === "oauth" && row.credential.accountId === "acct-plus");
+		if (!plus || !store.upsertCredentialBlock) throw new Error("missing plus credential row");
+		store.upsertCredentialBlock({
+			credentialId: plus.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + WEEK_MS,
+		});
+		const k12 = store
+			.listAuthCredentials("openai-codex")
+			.find(row => row.credential.type === "oauth" && row.credential.accountId === "acct-k12");
+		if (!k12 || !store.upsertCredentialBlock) throw new Error("missing k12 credential row");
+		store.upsertCredentialBlock({
+			credentialId: k12.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "shared",
+			blockedUntilMs: Date.now() + HOUR_MS,
+		});
+
+		expect(await authStorage.getApiKey("openai-codex", "session-with-legacy-global-block")).toBe("api-acct-plus");
+	});
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/ai/test/openai-codex-usage.test.ts
+++ b/packages/ai/test/openai-codex-usage.test.ts
@@ -63,7 +63,7 @@ describe("openai-codex usage parser", () => {
 		expect(report).not.toBeNull();
 		const main = report?.limits.filter(l => l.id === "openai-codex:primary" || l.id === "openai-codex:secondary");
 		expect(main?.map(l => l.id)).toEqual(["openai-codex:primary", "openai-codex:secondary"]);
-		expect(main?.[0].scope.tier).toBe("pro");
+		expect(main?.[0].scope).toEqual({ provider: "openai-codex", windowId: "5h", shared: true });
 		expect(main?.[0].amount.usedFraction).toBeCloseTo(0.04, 5);
 	});
 

--- a/packages/ai/test/stream-auth-retry.test.ts
+++ b/packages/ai/test/stream-auth-retry.test.ts
@@ -405,7 +405,7 @@ describe("streamSimple resolver auth retry", () => {
 			expect((await stream.result()).content).toEqual([{ type: "text", text: "ok" }]);
 			expect(keys).toEqual(["credential-A", "credential-B"]);
 			expect(eventTypes).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
-			expect(retryContexts.map(ctx => ctx.lastChance)).toEqual([false, true]);
+			expect(retryContexts.map(ctx => ctx.lastChance)).toEqual([true]);
 		}
 	});
 
@@ -501,10 +501,9 @@ describe("streamSimple resolver auth retry", () => {
 		expect((await stream.result()).content).toEqual([{ type: "text", text: "ok" }]);
 		expect(keys).toEqual(["old-key", "next-key"]);
 		expect(retryContexts.map(ctx => ({ lastChance: ctx.lastChance, hasError: ctx.error !== undefined }))).toEqual([
-			{ lastChance: false, hasError: true },
 			{ lastChance: true, hasError: true },
 		]);
-		expect((retryContexts[1]?.error as Error).message).toContain("Resource exhausted");
+		expect((retryContexts[0]?.error as Error).message).toContain("Resource exhausted");
 	});
 
 	it("surfaces the original error when the resolver declines every retry", async () => {

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -49,7 +49,7 @@ export function createApiKeyResolver(
 	options: ApiKeyResolverOptions = {},
 ): ApiKeyResolver {
 	const { sessionId, baseUrl, modelId } = options;
-	return async ({ lastChance, error, signal }) => {
+	return async ({ lastChance, error, signal, previousKey }) => {
 		if (error === undefined) {
 			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
 		}
@@ -59,7 +59,12 @@ export function createApiKeyResolver(
 			// sibling exists we switch immediately; the precise no-sibling backoff
 			// is owned by `markUsageLimitReached` (default + server usage-report
 			// reset) and the outer whole-turn retry layer.
-			await registry.authStorage.rotateSessionCredential(provider, sessionId, { error, modelId, signal });
+			await registry.authStorage.rotateSessionCredential(provider, sessionId, {
+				error,
+				modelId,
+				signal,
+				apiKey: previousKey,
+			});
 			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
 		}
 		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });

--- a/packages/coding-agent/test/agent-session-retry-cap.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-cap.test.ts
@@ -282,6 +282,79 @@ describe("AgentSession retry delay cap", () => {
 		expect(last.content).toContainEqual({ type: "text", text: "recovered after credential switch" });
 	});
 
+	it("switches same-provider credentials before model fallback on ChatGPT usage limits", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const fallbackModel = getBundledModel("openai", "gpt-5.5");
+		if (!primaryModel || !fallbackModel) {
+			throw new Error("Expected bundled primary and fallback test models to exist");
+		}
+
+		authStorage.removeRuntimeApiKey("anthropic");
+		authStorage.setRuntimeApiKey("openai", "openai-fallback-key");
+		await authStorage.set("anthropic", [
+			{ type: "api_key", key: "anthropic-key-1" },
+			{ type: "api_key", key: "anthropic-key-2" },
+		]);
+
+		const usageLimitError = "Error: You have hit your ChatGPT usage limit (k12 plan). Try again in ~231 min.";
+		const mock = createMockModel();
+		const requestedModels: string[] = [];
+		const requestedKeys: string[] = [];
+		let agent!: Agent;
+		agent = new Agent({
+			getApiKey: model => modelRegistry.resolver(model, agent.sessionId),
+			initialState: {
+				model: primaryModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				requestedModels.push(`${requestedModel.provider}/${requestedModel.id}`);
+				const apiKey = resolveInitialApiKey(options?.apiKey);
+				requestedKeys.push(apiKey);
+				if (requestedKeys.length === 1) {
+					mock.push({ throw: usageLimitError });
+				} else {
+					mock.push({ content: ["recovered after sibling account"] });
+				}
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxDelayMs": 100,
+			"retry.maxRetries": 1,
+			"retry.modelFallback": true,
+			"retry.fallbackChains": {
+				default: [`${fallbackModel.provider}/${fallbackModel.id}`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
+		await session.prompt("Trigger k12 usage limit");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${primaryModel.provider}/${primaryModel.id}`,
+		]);
+		expect([...requestedKeys].sort()).toEqual(["anthropic-key-1", "anthropic-key-2"]);
+		const last = lastAssistant(session);
+		expect(last.stopReason).toBe("stop");
+		expect(last.content).toContainEqual({ type: "text", text: "recovered after sibling account" });
+	});
+
 	it("waits for the earliest sibling unblock instead of failing the delay cap", async () => {
 		// Regression: with every sibling credential momentarily blocked (e.g. a
 		// short post-401 or usage-probe block), a usage-limit 429 with a

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -119,4 +119,30 @@ describe("AuthStorage account rotation", () => {
 		expect(result.switched).toBe(true);
 		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("api-acct-2");
 	});
+
+	test("usage-limit rotation trusts the failed bearer over stale session stickiness", async () => {
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "plus-access",
+				refresh: "plus-refresh",
+				expires: Date.now() + 60_000,
+				accountId: "plus-acct",
+			},
+			{
+				type: "oauth",
+				access: "k12-access",
+				refresh: "k12-refresh",
+				expires: Date.now() + 60_000,
+				accountId: "k12-acct",
+			},
+		]);
+
+		const sessionId = "stale-sticky-session";
+		const stickyKey = await authStorage.getApiKey("openai-codex", sessionId);
+		const failedKey = stickyKey === "api-plus-acct" ? "k12-access" : "plus-access";
+		const result = await authStorage.markUsageLimitReached("openai-codex", sessionId, { apiKey: failedKey });
+		expect(result.switched).toBe(true);
+		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe(stickyKey);
+	});
 });

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -95,4 +95,28 @@ describe("AuthStorage account rotation", () => {
 		const exhaustedFallbackKey = await authStorage.getApiKey("openai-codex", sessionId);
 		expect(exhaustedFallbackKey).toMatch(/^api-acct-/);
 	});
+
+	test("usage-limit rotation can match the failed bearer when session stickiness is missing", async () => {
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "access-1",
+				refresh: "refresh-1",
+				expires: Date.now() + 60_000,
+				accountId: "acct-1",
+			},
+			{
+				type: "oauth",
+				access: "access-2",
+				refresh: "refresh-2",
+				expires: Date.now() + 60_000,
+				accountId: "acct-2",
+			},
+		]);
+
+		const sessionId = "missing-sticky-session";
+		const result = await authStorage.markUsageLimitReached("openai-codex", sessionId, { apiKey: "access-1" });
+		expect(result.switched).toBe(true);
+		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe("api-acct-2");
+	});
 });


### PR DESCRIPTION
## Summary
- rotate to same-provider Codex sibling credentials before falling back to another provider/model on usage-limit errors
- avoid force-refreshing access-token-only Codex credentials when quota is exhausted
- scope Codex quota blocks so stale legacy global blocks do not hide otherwise usable sibling accounts

## Tests
- `bun test packages/ai/test/auth-storage-codex-selection.test.ts packages/ai/test/auth-storage-block-persistence.test.ts packages/ai/test/auth-retry.test.ts packages/ai/test/openai-codex-usage.test.ts packages/coding-agent/test/auth-storage-rotation.test.ts packages/coding-agent/test/agent-session-retry-cap.test.ts`
- `bun check`