### PR TITLE
Fix browser launch on Microsoft Edge installs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed the browser tool failing to launch Microsoft Edge-only Windows installs with Puppeteer's empty `Code: 0` launch error by keeping Edge's required `--enable-automation` default while preserving Chrome/Chromium stealth launch defaults.
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -29,15 +29,20 @@ export const DEFAULT_VIEWPORT = { width: 1365, height: 768, deviceScaleFactor: 1
  * connection dropped, etc.).
  */
 export const BROWSER_PROTOCOL_TIMEOUT_MS = 60_000;
+const ENABLE_AUTOMATION_FLAG = "--enable-automation";
 // Automation-tell launch flags that puppeteer-core adds by default. We suppress
 // them via `ignoreDefaultArgs` (the supported escape hatch) to mirror xxxx's
-// chromiumSwitches patch. `--enable-automation` is the loudest: it sets
+// chromiumSwitches patch. `--enable-automation` is the loudest: it normally sets
 // navigator.webdriver=true and shows the "controlled by automated software" infobar.
+// Edge is the launch-stability exception: it can exit before CDP opens when this
+// default flag is stripped, so Edge keeps Puppeteer's flag while our explicit
+// `--disable-blink-features=AutomationControlled` launch arg still handles
+// navigator.webdriver.
 // `ignoreDefaultArgs` does exact-string matching, so each entry must be a flag that
 // puppeteer emits verbatim. The default `--disable-features=...` string can't be
 // matched this way; it is neutralized in the puppeteer-core patch (ChromeLauncher).
 const STEALTH_IGNORE_DEFAULT_ARGS = [
-	"--enable-automation",
+	ENABLE_AUTOMATION_FLAG,
 	"--disable-extensions",
 	"--disable-default-apps",
 	"--disable-component-extensions-with-background-pages",
@@ -47,6 +52,23 @@ const STEALTH_IGNORE_DEFAULT_ARGS = [
 	"--disable-ipc-flooding-protection",
 	"--metrics-recording-only",
 ];
+
+function isMicrosoftEdgeExecutable(executablePath: string | undefined): boolean {
+	if (!executablePath) return false;
+	const normalizedPath = executablePath.replaceAll("\\", "/").toLowerCase();
+	const executableName = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1);
+	return (
+		executableName === "msedge.exe" ||
+		executableName === "microsoft edge" ||
+		executableName.startsWith("microsoft-edge")
+	);
+}
+
+function stealthIgnoreDefaultArgs(executablePath: string | undefined): string[] {
+	if (!isMicrosoftEdgeExecutable(executablePath)) return [...STEALTH_IGNORE_DEFAULT_ARGS];
+	return STEALTH_IGNORE_DEFAULT_ARGS.filter(arg => arg !== ENABLE_AUTOMATION_FLAG);
+}
+
 const STEALTH_ACCEPT_LANGUAGE = "en-US,en";
 
 const USER_AGENT_TARGET_TIMEOUT_MS = 5_000;
@@ -282,12 +304,13 @@ export async function launchHeadlessBrowser(opts: LaunchHeadlessOptions): Promis
 	if (ignoreCert === "true" || ignoreCert === "1" || ignoreCert === "yes" || ignoreCert === "on") {
 		launchArgs.push("--ignore-certificate-errors");
 	}
+	const executablePath = await ensureChromiumExecutable();
 	return await puppeteer.launch({
 		headless: opts.headless,
 		defaultViewport: opts.headless ? initialViewport : null,
-		executablePath: await ensureChromiumExecutable(),
+		executablePath,
 		args: launchArgs,
-		ignoreDefaultArgs: [...STEALTH_IGNORE_DEFAULT_ARGS],
+		ignoreDefaultArgs: stealthIgnoreDefaultArgs(executablePath),
 		protocolTimeout: BROWSER_PROTOCOL_TIMEOUT_MS,
 	});
 }
@@ -735,6 +758,10 @@ export async function applyStealthPatches(
 	await configureUserAgentTargets(browser, targetState);
 	state.browserSession = targetState.browserSession;
 	await injectStealthScripts(page);
+}
+
+export function stealthIgnoreDefaultArgsForTest(executablePath: string | undefined): string[] {
+	return stealthIgnoreDefaultArgs(executablePath);
 }
 
 export function targetSupportsUserAgentOverrideForTest(target: Target): boolean {

--- a/packages/coding-agent/test/tools/browser-launch.test.ts
+++ b/packages/coding-agent/test/tools/browser-launch.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { stealthIgnoreDefaultArgsForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
+
+const AUTOMATION_FLAG = "--enable-automation";
+
+const EDGE_EXECUTABLE_PATHS = [
+	"C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+	"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+	"/usr/bin/microsoft-edge-stable",
+] as const;
+
+const CHROME_EXECUTABLE_PATHS = [
+	"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+	"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+	"/usr/bin/chromium",
+] as const;
+
+describe("browser launch stealth defaults", () => {
+	it("keeps Puppeteer's automation default for Microsoft Edge executables", () => {
+		for (const executablePath of EDGE_EXECUTABLE_PATHS) {
+			const ignoreDefaultArgs = stealthIgnoreDefaultArgsForTest(executablePath);
+
+			expect(ignoreDefaultArgs).not.toContain(AUTOMATION_FLAG);
+			expect(ignoreDefaultArgs).toContain("--disable-extensions");
+		}
+	});
+
+	it("continues filtering Puppeteer's automation default for Chrome and Chromium executables", () => {
+		for (const executablePath of CHROME_EXECUTABLE_PATHS) {
+			const ignoreDefaultArgs = stealthIgnoreDefaultArgsForTest(executablePath);
+
+			expect(ignoreDefaultArgs).toContain(AUTOMATION_FLAG);
+		}
+	});
+});


### PR DESCRIPTION
## What

Fix the browser tool's default headless launch on Microsoft Edge installs by keeping Puppeteer's `--enable-automation` default for Edge executables while preserving the existing Chrome/Chromium stealth `ignoreDefaultArgs` behavior.

## Why

On Windows machines with Edge but no Chrome, the browser tool resolves Edge correctly, but Edge can exit before CDP opens with Puppeteer's empty `Code: 0` launch error when the full stealth default-arg filter strips `--enable-automation`. Keeping that flag for Edge restores launch stability; the existing `--disable-blink-features=AutomationControlled` launch arg still keeps `navigator.webdriver === false`.

## Testing

- `bun run fix:tools`
- `bun check` from `packages/coding-agent/`
- `bun run lint` from `packages/coding-agent/`
- `bun test packages/coding-agent/test/tools/browser-launch.test.ts`
- Patched-source visible Edge smoke to `https://www.google.com/`
- Root `bun check` was attempted; it fails on this Windows checkout in unrelated Rust code with `pi-uutils-ctx` reporting field `stdin_fd` is never read under `-D warnings`.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)