### PR TITLE
Fix JS eval worker cwd conflict handling

### DIFF
--- a/packages/coding-agent/src/eval/js/worker-core.ts
+++ b/packages/coding-agent/src/eval/js/worker-core.ts
@@ -77,16 +77,16 @@ export class WorkerCore {
 	}
 
 	async #runOne(runId: string, code: string, filename: string, snapshot: SessionSnapshot): Promise<void> {
-		const runtime = this.#ensureRuntime(snapshot);
-		runtime.setCwd(snapshot.cwd);
-		const active: ActiveRun = { runId, pendingTools: new Map() };
-		this.#runs.set(runId, active);
-		const hooks: RuntimeHooks = {
-			onText: chunk => this.#transport.send({ type: "text", runId, chunk }),
-			onDisplay: output => this.#transport.send({ type: "display", runId, output }),
-			callTool: (name, args) => this.#callTool(active, name, args),
-		};
 		try {
+			const runtime = this.#ensureRuntime(snapshot);
+			runtime.setCwd(snapshot.cwd);
+			const active: ActiveRun = { runId, pendingTools: new Map() };
+			this.#runs.set(runId, active);
+			const hooks: RuntimeHooks = {
+				onText: chunk => this.#transport.send({ type: "text", runId, chunk }),
+				onDisplay: output => this.#transport.send({ type: "display", runId, output }),
+				callTool: (name, args) => this.#callTool(active, name, args),
+			};
 			const value = await runtime.run(code, filename, hooks, { runId, cwd: snapshot.cwd });
 			runtime.displayValue(value, hooks);
 			this.#transport.send({ type: "result", runId, ok: true });

--- a/packages/coding-agent/test/eval/worker-core.test.ts
+++ b/packages/coding-agent/test/eval/worker-core.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import { WorkerCore } from "@oh-my-pi/pi-coding-agent/eval/js/worker-core";
+import type {
+	SessionSnapshot,
+	Transport,
+	WorkerInbound,
+	WorkerOutbound,
+} from "@oh-my-pi/pi-coding-agent/eval/js/worker-protocol";
+
+interface WorkerHarness {
+	send(message: WorkerInbound): void;
+	onMessage(handler: (message: WorkerOutbound) => void): () => void;
+}
+
+function createWorkerHarness(): WorkerHarness {
+	const hostListeners = new Set<(message: WorkerOutbound) => void>();
+	const workerListeners = new Set<(message: WorkerInbound) => void>();
+	const transport: Transport = {
+		send: message => {
+			queueMicrotask(() => {
+				for (const listener of hostListeners) listener(message);
+			});
+		},
+		onMessage: handler => {
+			workerListeners.add(handler);
+			return () => workerListeners.delete(handler);
+		},
+		close: () => {},
+	};
+	new WorkerCore(transport);
+	return {
+		send(message) {
+			queueMicrotask(() => {
+				for (const listener of workerListeners) listener(message);
+			});
+		},
+		onMessage(handler) {
+			hostListeners.add(handler);
+			return () => hostListeners.delete(handler);
+		},
+	};
+}
+
+function waitForMessage(
+	harness: WorkerHarness,
+	predicate: (message: WorkerOutbound) => boolean,
+): Promise<WorkerOutbound> {
+	const { promise, resolve } = Promise.withResolvers<WorkerOutbound>();
+	let unsubscribe = (): void => {};
+	unsubscribe = harness.onMessage(message => {
+		if (!predicate(message)) return;
+		unsubscribe();
+		resolve(message);
+	});
+	return promise;
+}
+
+async function initializeWorker(harness: WorkerHarness, snapshot: SessionSnapshot): Promise<void> {
+	const ready = waitForMessage(harness, message => message.type === "ready");
+	harness.send({ type: "init", snapshot });
+	expect((await ready).type).toBe("ready");
+}
+
+describe("WorkerCore", () => {
+	it("reports same-realm cwd conflicts through the worker protocol", async () => {
+		const first = createWorkerHarness();
+		const second = createWorkerHarness();
+		const cwd = process.cwd();
+		await initializeWorker(first, { cwd, sessionId: "same-realm-first", localRoots: {} });
+		await initializeWorker(second, { cwd, sessionId: "same-realm-second", localRoots: {} });
+
+		const gate = Promise.withResolvers<void>();
+		const entered = Promise.withResolvers<void>();
+		(globalThis as { __omp_worker_core_gate?: { entered(): void; wait: Promise<void> } }).__omp_worker_core_gate = {
+			entered: () => entered.resolve(),
+			wait: gate.promise,
+		};
+		try {
+			first.send({
+				type: "run",
+				runId: "hold-first-runtime",
+				code: "globalThis.__omp_worker_core_gate.entered(); await globalThis.__omp_worker_core_gate.wait;",
+				filename: "[same-realm-first].js",
+				snapshot: { cwd, sessionId: "same-realm-first", localRoots: {} },
+			});
+			await entered.promise;
+
+			const result = waitForMessage(
+				second,
+				message => message.type === "result" && message.runId === "overlap-second-runtime",
+			);
+			second.send({
+				type: "run",
+				runId: "overlap-second-runtime",
+				code: "1 + 1;",
+				filename: "[same-realm-second].js",
+				snapshot: { cwd, sessionId: "same-realm-second", localRoots: {} },
+			});
+
+			expect(await result).toMatchObject({
+				type: "result",
+				runId: "overlap-second-runtime",
+				ok: false,
+				error: { message: "Cannot set cwd while another same-realm JS runtime is running" },
+			});
+		} finally {
+			gate.resolve();
+			delete (globalThis as { __omp_worker_core_gate?: { entered(): void; wait: Promise<void> } })
+				.__omp_worker_core_gate;
+			first.send({ type: "close" });
+			second.send({ type: "close" });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- catch `WorkerCore` same-realm `setCwd` failures inside the run result boundary
- return overlapping inline JS eval runtime conflicts through the worker protocol instead of process-level unhandled rejections
- add a regression test for concurrent same-realm worker runs

Fixes #4837

## Validation

- `bun test test/eval/worker-core.test.ts` (observed red before fix: `Cannot set cwd while another same-realm JS runtime is running`)
- `bun test test/eval/worker-core.test.ts test/eval/runtime-global-dispose.test.ts`
- `bun run check:types`