### PR TITLE
fix(ai): self-heal stale Codex usage-limit blocks

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex load balancing: clear stale persisted and in-memory usage-limit blocks for an `openai-codex` account when a fresh live usage report shows it is allowed and below all limits, including broker-backed gateway snapshots, so traffic returns to recovered accounts instead of funneling to one sibling.
+
 ## [16.3.11] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -61,6 +61,41 @@ function toCredentialBlockSnapshot(block: StoredCredentialBlock): CredentialBloc
 	};
 }
 
+function credentialBlockSnapshotsEqual(
+	left: readonly CredentialBlockSnapshot[] | undefined,
+	right: readonly CredentialBlockSnapshot[] | undefined,
+): boolean {
+	const leftBlocks = left ?? [];
+	const rightBlocks = right ?? [];
+	if (leftBlocks.length !== rightBlocks.length) return false;
+	for (let index = 0; index < leftBlocks.length; index += 1) {
+		const leftBlock = leftBlocks[index]!;
+		const rightBlock = rightBlocks[index]!;
+		if (
+			leftBlock.providerKey !== rightBlock.providerKey ||
+			leftBlock.blockScope !== rightBlock.blockScope ||
+			leftBlock.blockedUntilMs !== rightBlock.blockedUntilMs
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function snapshotBlocksChanged(previous: readonly SnapshotEntry[], next: readonly SnapshotEntry[]): boolean {
+	const previousBlocksById = new Map<number, readonly CredentialBlockSnapshot[] | undefined>();
+	for (const entry of previous) previousBlocksById.set(entry.id, entry.blocks);
+	for (const entry of next) {
+		const previousBlocks = previousBlocksById.get(entry.id);
+		if (!credentialBlockSnapshotsEqual(previousBlocks, entry.blocks)) return true;
+		previousBlocksById.delete(entry.id);
+	}
+	for (const previousBlocks of previousBlocksById.values()) {
+		if (previousBlocks && previousBlocks.length > 0) return true;
+	}
+	return false;
+}
+
 function credentialEntryWithBlocks(
 	entry: AuthCredentialSnapshotEntry,
 	blocks: readonly CredentialBlockSnapshot[] | undefined,
@@ -173,6 +208,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	#cache: Map<string, CacheEntry> = new Map();
 	#usageCache?: UsageCacheEntry;
 	#usageInflight?: Promise<UsageReport[] | null>;
+	#usageCacheEpoch = 0;
 	#closed = false;
 	/**
 	 * `true` once the SSE consumer received its first frame and hasn't dropped
@@ -202,10 +238,9 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 
 	#applySnapshot(snapshot: SnapshotResponse, generation: number): void {
 		const nowMs = Date.now();
-		this.#snapshot = {
-			...snapshot,
-			credentials: snapshot.credentials.map(entry => this.#normalizeSnapshotEntryBlocks(entry, nowMs)),
-		};
+		const credentials = snapshot.credentials.map(entry => this.#normalizeSnapshotEntryBlocks(entry, nowMs));
+		if (snapshotBlocksChanged(this.#snapshot.credentials, credentials)) this.#invalidateUsageCache();
+		this.#snapshot = { ...snapshot, credentials };
 		this.#generation = generation;
 		this.#snapshotReceivedAt = nowMs;
 		const onSnapshot = this.#onSnapshot;
@@ -304,6 +339,8 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	): void {
 		const incoming = this.#normalizeSnapshotEntryBlocks(entry, Date.now());
 		const index = this.#snapshot.credentials.findIndex(candidate => candidate.id === incoming.id);
+		const previousBlocks = index === -1 ? undefined : this.#snapshot.credentials[index]?.blocks;
+		if (!credentialBlockSnapshotsEqual(previousBlocks, incoming.blocks)) this.#invalidateUsageCache();
 		const credentials =
 			index === -1
 				? [...this.#snapshot.credentials, incoming]
@@ -314,6 +351,8 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 	}
 
 	#removeStreamCredential(id: number, refresher: RefresherSchedule, generation: number, serverNowMs: number): void {
+		const removed = this.#snapshot.credentials.find(entry => entry.id === id);
+		if (removed?.blocks && removed.blocks.length > 0) this.#invalidateUsageCache();
 		const credentials = this.#snapshot.credentials.filter(entry => entry.id !== id);
 		this.#snapshot = { ...this.#snapshot, generation, serverNowMs, refresher, credentials };
 		this.#generation = generation;
@@ -376,6 +415,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 
 	upsertCredentialBlock(block: StoredCredentialBlock): void {
 		this.#upsertSnapshotBlock(block);
+		this.#invalidateUsageCache();
 		const body = toCredentialBlockSnapshot(block);
 		void this.#client
 			.upsertCredentialBlock(block.credentialId, body)
@@ -394,6 +434,7 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 
 	deleteCredentialBlocks(credentialId: number): void {
 		this.#deleteSnapshotBlocks(credentialId);
+		this.#invalidateUsageCache();
 		void this.#client
 			.deleteCredentialBlocks(credentialId)
 			.then(() => {
@@ -698,6 +739,12 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		}
 	}
 
+	#invalidateUsageCache(): void {
+		this.#usageCache = undefined;
+		this.#usageInflight = undefined;
+		this.#usageCacheEpoch += 1;
+	}
+
 	/**
 	 * Store-level hook consumed by `AuthStorage` — routes refresh through the
 	 * broker so the actual refresh token never leaves the broker host. Returns
@@ -834,9 +881,11 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 			return Promise.resolve(cached.reports);
 		}
 		if (this.#usageInflight) return this.#usageInflight;
+		const epoch = this.#usageCacheEpoch;
 		const inflight = this.#client
 			.fetchUsage()
 			.then(body => {
+				if (epoch !== this.#usageCacheEpoch) return this.#loadUsageReports();
 				this.#usageCache = { reports: body.reports, fetchedAt: Date.now() };
 				return body.reports;
 			})
@@ -845,11 +894,12 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 				// Documented 15s TTL fallback: cache the null so sequential callers
 				// don't re-hit the broker while it's still down. See
 				// docs/auth-broker-gateway.md § "Client-side single-flight".
+				if (epoch !== this.#usageCacheEpoch) return this.#loadUsageReports();
 				this.#usageCache = { reports: null, fetchedAt: Date.now() };
 				return null;
 			})
 			.finally(() => {
-				this.#usageInflight = undefined;
+				if (this.#usageInflight === inflight) this.#usageInflight = undefined;
 			});
 		this.#usageInflight = inflight;
 		return inflight;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -967,6 +967,7 @@ export class AuthStorage {
 	#usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	#rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
 	#usageCache: UsageCache;
+	#usageCacheEpoch = 0;
 	#usageRequestInFlight: Map<string, Promise<UsageReport | null>> = new Map();
 	#usageHeaderIngestAt: Map<string, number> = new Map();
 	#usageReportsInFlight: Map<string, Promise<UsageReport[] | null>> = new Map();
@@ -1433,6 +1434,7 @@ export class AuthStorage {
 		const nextBlockedUntil = Math.max(existing, blockedUntilMs);
 		backoffMap.set(credentialIndex, nextBlockedUntil);
 		this.#credentialBackoff.set(backoffKey, backoffMap);
+		this.#invalidateUsageReportCache(provider);
 
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
@@ -2336,8 +2338,10 @@ export class AuthStorage {
 		const inFlight = this.#usageRequestInFlight.get(cacheKey);
 		if (inFlight) return inFlight;
 
+		const usageCacheEpoch = this.#usageCacheEpoch;
 		const promise = (async () => {
 			const report = await this.#fetchUsageUncached(request, timeoutMs);
+			if (usageCacheEpoch !== this.#usageCacheEpoch) return report;
 			const ttlJitter = USAGE_REPORT_TTL_MS * (Math.random() * 0.5 - 0.25);
 			if (report !== null) {
 				// Success: stagger per-credential cache expiry so all accounts don't
@@ -2347,6 +2351,7 @@ export class AuthStorage {
 				// times decorrelate within a few cycles.
 				this.#usageCache.set(cacheKey, { value: report, expiresAt: Date.now() + USAGE_REPORT_TTL_MS + ttlJitter });
 				this.#recordUsageHistory(request, report);
+				this.#reconcileCodexUsageBlock(request, report);
 				return report;
 			}
 			// Failure: apply a short jittered cool-down so the credential doesn't
@@ -2761,7 +2766,14 @@ export class AuthStorage {
 		// whole point of routing through it.
 		const storeHook = this.#store.getUsageReport?.bind(this.#store);
 		if (storeHook) {
-			return storeHook(provider, credential, options?.signal);
+			const report = await storeHook(provider, credential, options?.signal);
+			if (report) {
+				this.#reconcileCodexUsageBlock(
+					this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
+					report,
+				);
+			}
+			return report;
 		}
 		return this.#fetchUsageCached(
 			this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
@@ -2789,7 +2801,10 @@ export class AuthStorage {
 		// `RemoteAuthCredentialStore` implements the store hook so a gateway
 		// backed by a broker automatically routes usage to the broker without
 		// needing the caller to wire it explicitly.
-		const override = this.#fetchUsageReportsOverride ?? this.#store.fetchUsageReports?.bind(this.#store);
+		const storeOverride = this.#store.fetchUsageReports?.bind(this.#store);
+		const override = this.#fetchUsageReportsOverride ?? storeOverride;
+		const shouldReconcileStoreHookReports =
+			this.#fetchUsageReportsOverride === undefined && storeOverride !== undefined;
 		if (override) {
 			// Reuse the in-flight map so concurrent callers (widget poll + format
 			// dispatch + credential selection) coalesce into one upstream call.
@@ -2805,7 +2820,9 @@ export class AuthStorage {
 				});
 				this.#usageReportsInFlight.set(OVERRIDE_KEY, shared);
 			}
-			return raceUsageWithSignal(shared, options?.signal);
+			const reports = await raceUsageWithSignal(shared, options?.signal);
+			if (shouldReconcileStoreHookReports && reports) this.#reconcileCodexUsageBlocksFromReports(reports);
+			return reports;
 		}
 		if (!this.#usageProviderResolver) return null;
 
@@ -4255,6 +4272,7 @@ export class AuthStorage {
 	 * `/usage` reflects a freshly-redeemed reset instead of stale numbers.
 	 */
 	#invalidateUsageReportCache(provider: string, baseUrl?: string): void {
+		this.#usageCacheEpoch += 1;
 		const expired = Date.now() - 1;
 		for (const entry of this.#getStoredCredentials(provider)) {
 			if (entry.credential.type !== "oauth") continue;
@@ -4266,6 +4284,12 @@ export class AuthStorage {
 		}
 	}
 
+	#invalidateUsageReportCacheForProviderKey(providerKey: string): void {
+		const oauthSuffix = ":oauth";
+		if (!providerKey.endsWith(oauthSuffix)) return;
+		this.#invalidateUsageReportCache(providerKey.slice(0, -oauthSuffix.length));
+	}
+
 	/**
 	 * Lift any temporary backoff blocks on one credential (across the bare
 	 * `provider:oauth` key and its scoped `\0`-suffixed derivatives). Called
@@ -4274,13 +4298,10 @@ export class AuthStorage {
 	 * that `markUsageLimitReached` set for the now-obsolete reset time.
 	 */
 	#clearCredentialBlocks(provider: string, credentialId: number): void {
-		const deleteCredentialBlocks = this.#store.deleteCredentialBlocks?.bind(this.#store);
-		if (deleteCredentialBlocks) {
-			try {
-				deleteCredentialBlocks(credentialId);
-			} catch (err) {
-				logger.debug("Failed to clear persisted credential blocks", { err, provider, credentialId });
-			}
+		try {
+			this.deleteCredentialBlocks(credentialId);
+		} catch (err) {
+			logger.debug("Failed to clear persisted credential blocks", { err, provider, credentialId });
 		}
 
 		const index = this.#getStoredCredentials(provider).findIndex(entry => entry.id === credentialId);
@@ -4291,6 +4312,78 @@ export class AuthStorage {
 			if (key !== providerKey && !key.startsWith(scopedPrefix)) continue;
 			backoffMap.delete(index);
 			if (backoffMap.size === 0) this.#credentialBackoff.delete(key);
+		}
+	}
+
+	/**
+	 * Self-heal a stale Codex usage-limit block: when a fresh live usage report
+	 * shows the account is allowed and below every limit, drop the persisted and
+	 * in-memory `openai-codex:oauth` block so the balancer re-includes it. Only
+	 * Codex — its blocks are unscoped (`codexRankingStrategy` defines no
+	 * `blockScope`), so clearing all blocks for the credential id is exact. A
+	 * future scoped Codex block would require revisiting this.
+	 */
+	#isHealthyCodexUsageReport(report: UsageReport): boolean {
+		const metadata = report.metadata;
+		return (
+			report.provider === "openai-codex" &&
+			metadata?.allowed === true &&
+			metadata.limitReached === false &&
+			!this.#isUsageLimitReached(report.limits)
+		);
+	}
+
+	#reconcileCodexUsageBlockForCredential(provider: Provider, credentialId: number, report: UsageReport): void {
+		if (!this.#isHealthyCodexUsageReport(report)) return;
+		const providerKey = this.#getProviderTypeKey(provider, "oauth");
+		const credentialIndex = this.#getStoredCredentials(provider).findIndex(entry => entry.id === credentialId);
+		if (credentialIndex < 0) return;
+		const blockedUntilMs = this.#getCredentialBlockedUntil(provider, providerKey, credentialIndex);
+		if (blockedUntilMs === undefined) return;
+		this.#clearCredentialBlocks(provider, credentialId);
+		logger.info("Cleared stale Codex usage-limit block after healthy live usage report", {
+			credentialId,
+			provider,
+			clearedBlockedUntilMs: blockedUntilMs,
+		});
+	}
+
+	#reconcileCodexUsageBlock(request: UsageRequestDescriptor, report: UsageReport): void {
+		if (request.provider !== "openai-codex") return;
+		const credentialId = this.#findStoredCredentialIdForUsageCredential(request.provider, request.credential);
+		if (credentialId === undefined) return;
+		this.#reconcileCodexUsageBlockForCredential(request.provider, credentialId, report);
+	}
+
+	#findStoredCredentialIdsForUsageReport(report: UsageReport): number[] {
+		if (report.provider !== "openai-codex") return [];
+		const email = this.#getUsageReportMetadataValue(report, "email")?.toLowerCase();
+		const accountId = (
+			this.#getUsageReportMetadataValue(report, "accountId") ?? this.#getUsageReportScopeAccountId(report)
+		)?.toLowerCase();
+		if (!email && !accountId) return [];
+		const matches: number[] = [];
+		for (const entry of this.#getStoredCredentials(report.provider)) {
+			const credential = entry.credential;
+			if (credential.type !== "oauth") continue;
+			const credentialEmail = credential.email?.trim().toLowerCase();
+			const credentialAccountId = credential.accountId?.trim().toLowerCase();
+			if ((email && credentialEmail === email) || (accountId && credentialAccountId === accountId)) {
+				matches.push(entry.id);
+			}
+		}
+		return matches;
+	}
+
+	#reconcileCodexUsageBlocksFromReports(reports: UsageReport[]): void {
+		const reconciled = new Set<number>();
+		for (const report of reports) {
+			if (!this.#isHealthyCodexUsageReport(report)) continue;
+			for (const credentialId of this.#findStoredCredentialIdsForUsageReport(report)) {
+				if (reconciled.has(credentialId)) continue;
+				reconciled.add(credentialId);
+				this.#reconcileCodexUsageBlockForCredential(report.provider, credentialId, report);
+			}
 		}
 	}
 
@@ -4654,6 +4747,7 @@ export class AuthStorage {
 		const upsertCredentialBlock = this.#store.upsertCredentialBlock?.bind(this.#store);
 		if (!upsertCredentialBlock) return;
 		upsertCredentialBlock(block);
+		this.#invalidateUsageReportCacheForProviderKey(block.providerKey);
 		this.#bumpGeneration("credential-block");
 	}
 

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { AuthBrokerClient, RemoteAuthCredentialStore, startAuthBroker } from "@oh-my-pi/pi-ai/auth-broker";
 import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
@@ -22,6 +23,14 @@ type UsageWindowConfig = {
 	windowId: string;
 	windowLabel: string;
 	durationMs: number;
+};
+
+type CodexUsageMetadata = {
+	accountId?: string;
+	allowed?: boolean;
+	limitReached?: boolean;
+	planType?: string;
+	email?: string;
 };
 
 function createLimit(args: {
@@ -66,6 +75,7 @@ function createCodexUsageReport(args: {
 	secondary: UsageWindowSpec;
 	primaryWindow?: UsageWindowConfig;
 	secondaryWindow?: UsageWindowConfig;
+	metadata?: CodexUsageMetadata;
 }): UsageReport {
 	const primaryWindow = args.primaryWindow ?? { windowId: "1h", windowLabel: "1 Hour", durationMs: HOUR_MS };
 	const secondaryWindow = args.secondaryWindow ?? { windowId: "7d", windowLabel: "7 Day", durationMs: WEEK_MS };
@@ -90,7 +100,7 @@ function createCodexUsageReport(args: {
 				resetInMs: args.secondary.resetInMs,
 			}),
 		],
-		metadata: { accountId: args.accountId },
+		metadata: { accountId: args.accountId, ...args.metadata },
 	};
 }
 
@@ -319,6 +329,352 @@ describe("AuthStorage codex oauth ranking", () => {
 			.filter((accountId): accountId is string => accountId !== undefined)
 			.sort();
 		expect(activeAccounts).toEqual(["acct-A", "acct-B"]);
+	});
+
+	test("a healthy live Codex usage report clears a stale persisted block so the account is balanced again", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-blocked", "blocked@example.com") },
+			{ type: "oauth", ...createCredential("acct-healthy", "healthy@example.com") },
+		]);
+
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		store.upsertCredentialBlock({
+			credentialId: blockedRow.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + 6 * 24 * HOUR_MS,
+		});
+
+		usageByAccount.set(
+			"acct-blocked",
+			createCodexUsageReport({
+				accountId: "acct-blocked",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+				metadata: {
+					allowed: true,
+					limitReached: false,
+					planType: "pro",
+					email: "blocked@example.com",
+					accountId: "acct-blocked",
+				},
+			}),
+		);
+		usageByAccount.set(
+			"acct-healthy",
+			createCodexUsageReport({
+				accountId: "acct-healthy",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+				metadata: {
+					allowed: true,
+					limitReached: false,
+					planType: "pro",
+					email: "healthy@example.com",
+					accountId: "acct-healthy",
+				},
+			}),
+		);
+
+		const blockedSelectionCounts = await countApiKeySelections(
+			authStorage,
+			"openai-codex",
+			"stale-codex-block-before-fetch",
+			40,
+		);
+		expect(countFor(blockedSelectionCounts, "api-acct-blocked")).toBe(0);
+		expect(countFor(blockedSelectionCounts, "api-acct-healthy")).toBeGreaterThan(0);
+
+		const generationBeforeFetch = authStorage.getGeneration();
+
+		await authStorage.fetchUsageReports();
+
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeUndefined();
+		expect(authStorage.getGeneration()).toBeGreaterThan(generationBeforeFetch);
+
+		const reconciledSelectionCounts = await countApiKeySelections(
+			authStorage,
+			"openai-codex",
+			"stale-codex-block-after-fetch",
+			150,
+		);
+		expect(countFor(reconciledSelectionCounts, "api-acct-blocked")).toBeGreaterThan(0);
+		expect(countFor(reconciledSelectionCounts, "api-acct-healthy")).toBeGreaterThan(0);
+	});
+
+	test("an older in-flight healthy Codex usage report does not clear a newer usage-limit block", async () => {
+		if (!authStorage || !store?.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-race-blocked", "race-blocked@example.com") },
+			{ type: "oauth", ...createCredential("acct-race-healthy", "race-healthy@example.com") },
+		]);
+
+		const blockedReport = createCodexUsageReport({
+			accountId: "acct-race-blocked",
+			primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+			secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+			metadata: {
+				allowed: true,
+				limitReached: false,
+				planType: "pro",
+				email: "race-blocked@example.com",
+				accountId: "acct-race-blocked",
+			},
+		});
+		usageByAccount.set("acct-race-blocked", blockedReport);
+		usageByAccount.set(
+			"acct-race-healthy",
+			createCodexUsageReport({
+				accountId: "acct-race-healthy",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+				metadata: {
+					allowed: true,
+					limitReached: false,
+					planType: "pro",
+					email: "race-healthy@example.com",
+					accountId: "acct-race-healthy",
+				},
+			}),
+		);
+
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-race-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		let blockedSessionId: string | undefined;
+		for (let index = 0; index < 100; index += 1) {
+			const sessionId = `codex-inflight-race-selected-${index}`;
+			if ((await authStorage.getApiKey("openai-codex", sessionId)) === "api-acct-race-blocked") {
+				blockedSessionId = sessionId;
+				break;
+			}
+		}
+		if (!blockedSessionId) throw new Error("expected a session selecting the race-blocked account");
+
+		const inFlightBaseUrl = "https://codex-inflight-race.example";
+		const inFlightStarted = Promise.withResolvers<void>();
+		const inFlightUsage = Promise.withResolvers<UsageReport | null>();
+		vi.spyOn(usageProvider, "fetchUsage").mockImplementation(async params => {
+			const accountId = params.credential.accountId;
+			if (params.baseUrl === inFlightBaseUrl && accountId === "acct-race-blocked") {
+				inFlightStarted.resolve();
+				return inFlightUsage.promise;
+			}
+			if (!accountId) return null;
+			return usageByAccount.get(accountId) ?? null;
+		});
+
+		const inFlightReports = authStorage.fetchUsageReports({
+			baseUrlResolver: provider => (provider === "openai-codex" ? inFlightBaseUrl : undefined),
+		});
+		await inFlightStarted.promise;
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeUndefined();
+
+		const markResult = await authStorage.markUsageLimitReached("openai-codex", blockedSessionId, {
+			retryAfterMs: 6 * 24 * HOUR_MS,
+		});
+
+		expect(markResult.switched).toBe(true);
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeDefined();
+
+		inFlightUsage.resolve(blockedReport);
+		await inFlightReports;
+
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeDefined();
+		const selectionCounts = await countApiKeySelections(
+			authStorage,
+			"openai-codex",
+			"codex-inflight-race-after-resolve",
+			40,
+		);
+		expect(countFor(selectionCounts, "api-acct-race-blocked")).toBe(0);
+		expect(countFor(selectionCounts, "api-acct-race-healthy")).toBeGreaterThan(0);
+	});
+
+	test("broker-sourced healthy Codex usage clears remote gateway backoff", async () => {
+		if (!authStorage || !store?.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-broker-blocked", "broker-blocked@example.com") },
+			{ type: "oauth", ...createCredential("acct-broker-healthy", "broker-healthy@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-broker-blocked",
+			createCodexUsageReport({
+				accountId: "acct-broker-blocked",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+				metadata: {
+					allowed: true,
+					limitReached: false,
+					planType: "pro",
+					email: "broker-blocked@example.com",
+					accountId: "acct-broker-blocked",
+				},
+			}),
+		);
+		usageByAccount.set(
+			"acct-broker-healthy",
+			createCodexUsageReport({
+				accountId: "acct-broker-healthy",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+				metadata: {
+					allowed: true,
+					limitReached: false,
+					planType: "pro",
+					email: "broker-healthy@example.com",
+					accountId: "acct-broker-healthy",
+				},
+			}),
+		);
+
+		const token = "codex-broker-reconcile";
+		const handle = startAuthBroker({
+			storage: authStorage,
+			bind: "127.0.0.1:0",
+			bearerTokens: [token],
+			disableRefresher: true,
+		});
+		try {
+			const brokerClient = new AuthBrokerClient({ url: handle.url, token });
+			const originalUpsertCredentialBlock = brokerClient.upsertCredentialBlock.bind(brokerClient);
+			const blockPersisted = Promise.withResolvers<void>();
+			vi.spyOn(brokerClient, "upsertCredentialBlock").mockImplementation(async (id, block, signal) => {
+				try {
+					const response = await originalUpsertCredentialBlock(id, block, signal);
+					blockPersisted.resolve();
+					return response;
+				} catch (error) {
+					blockPersisted.reject(error);
+					throw error;
+				}
+			});
+			const initialResult = await brokerClient.fetchSnapshot();
+			if (initialResult.status !== 200) throw new Error("expected broker snapshot");
+			const blockedRow = initialResult.snapshot.credentials.find(entry => {
+				const credential = entry.credential;
+				return credential.type === "oauth" && credential.accountId === "acct-broker-blocked";
+			});
+			if (!blockedRow) throw new Error("expected blocked credential row");
+			const remoteStore = new RemoteAuthCredentialStore({
+				client: brokerClient,
+				initialSnapshot: initialResult.snapshot,
+				streamSnapshots: false,
+			});
+			const clientStorage = new AuthStorage(remoteStore);
+			await clientStorage.reload();
+			try {
+				let blockedSessionId: string | undefined;
+				for (let index = 0; index < 100; index += 1) {
+					const sessionId = `broker-codex-local-block-${index}`;
+					const apiKey = await clientStorage.getApiKey("openai-codex", sessionId);
+					if (apiKey === "api-acct-broker-blocked") {
+						blockedSessionId = sessionId;
+						break;
+					}
+				}
+				if (!blockedSessionId) throw new Error("expected a session selecting the blocked account");
+
+				const markResult = await clientStorage.markUsageLimitReached("openai-codex", blockedSessionId, {
+					retryAfterMs: 6 * 24 * HOUR_MS,
+				});
+
+				expect(markResult.switched).toBe(true);
+				expect(remoteStore.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeDefined();
+				await blockPersisted.promise;
+				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeDefined();
+
+				await clientStorage.fetchUsageReports();
+
+				expect(remoteStore.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeUndefined();
+				expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBeUndefined();
+				expect(await clientStorage.getApiKey("openai-codex", blockedSessionId)).toBe("api-acct-broker-blocked");
+			} finally {
+				clientStorage.close();
+				remoteStore.close();
+			}
+		} finally {
+			await handle.close();
+		}
+	});
+
+	test("an unhealthy live Codex usage report leaves a stale persisted block in place", async () => {
+		if (!authStorage || !store?.upsertCredentialBlock || !store.getCredentialBlock) {
+			throw new Error("test setup failed");
+		}
+
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-blocked", "blocked@example.com") },
+			{ type: "oauth", ...createCredential("acct-healthy", "healthy@example.com") },
+		]);
+
+		const blockedRow = store.listAuthCredentials("openai-codex").find(row => {
+			const credential = row.credential;
+			return credential.type === "oauth" && credential.accountId === "acct-blocked";
+		});
+		if (!blockedRow) throw new Error("expected blocked credential row");
+
+		const blockedUntilMs = Date.now() + 6 * 24 * HOUR_MS;
+		store.upsertCredentialBlock({
+			credentialId: blockedRow.id,
+			providerKey: "openai-codex:oauth",
+			blockScope: "",
+			blockedUntilMs,
+		});
+
+		usageByAccount.set(
+			"acct-blocked",
+			createCodexUsageReport({
+				accountId: "acct-blocked",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+				metadata: {
+					allowed: true,
+					limitReached: true,
+					planType: "pro",
+					email: "blocked@example.com",
+					accountId: "acct-blocked",
+				},
+			}),
+		);
+		usageByAccount.set(
+			"acct-healthy",
+			createCodexUsageReport({
+				accountId: "acct-healthy",
+				primary: { usedFraction: 0.2, resetInMs: HOUR_MS },
+				secondary: { usedFraction: 0.3, resetInMs: WEEK_MS },
+				metadata: {
+					allowed: true,
+					limitReached: false,
+					planType: "pro",
+					email: "healthy@example.com",
+					accountId: "acct-healthy",
+				},
+			}),
+		);
+
+		await authStorage.fetchUsageReports();
+
+		expect(store.getCredentialBlock(blockedRow.id, "openai-codex:oauth", "")).toBe(blockedUntilMs);
 	});
 
 	test("falls back to earliest-unblocking account when all exhausted", async () => {

--- a/packages/ai/test/remote-auth-store.test.ts
+++ b/packages/ai/test/remote-auth-store.test.ts
@@ -9,6 +9,7 @@ import {
 	type CredentialBlockResponse,
 	type FetchSnapshotResult,
 	RemoteAuthCredentialStore,
+	type SnapshotResponse,
 	startAuthBroker,
 } from "@oh-my-pi/pi-ai/auth-broker";
 import { snapshotResponseSchema } from "@oh-my-pi/pi-ai/auth-broker/wire-schemas";
@@ -219,6 +220,112 @@ describe("RemoteAuthCredentialStore + AuthStorage integration", () => {
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 
 		remoteStore.close();
+	});
+
+	test("broker block snapshots invalidate cached usage before the next fetchUsageReports", async () => {
+		const brokerClient = new AuthBrokerClient({ url: "http://127.0.0.1:9", token: "unused" });
+		const now = Date.now();
+		const blockedUntilMs = now + 60_000;
+		const credentialEntry = {
+			id: 7,
+			provider: "anthropic" as const,
+			credential: {
+				type: "oauth" as const,
+				access: "remote-access",
+				refresh: REMOTE_REFRESH_SENTINEL,
+				expires: now + 120_000,
+				accountId: "remote-account",
+				email: "remote@example.com",
+			},
+			identityKey: "email:remote@example.com",
+			rotatesInMs: null,
+		};
+		const initialSnapshot: SnapshotResponse = {
+			generation: 1,
+			generatedAt: now,
+			serverNowMs: now,
+			refresher: { enabled: false, intervalMs: 0, skewMs: 0, nextSweepInMs: Number.MAX_SAFE_INTEGER },
+			credentials: [credentialEntry],
+		};
+		const blockedSnapshot: SnapshotResponse = {
+			...initialSnapshot,
+			generation: 2,
+			generatedAt: now + 1,
+			serverNowMs: now + 1,
+			credentials: [
+				{
+					...credentialEntry,
+					blocks: [{ providerKey: "anthropic:oauth", blockScope: "tier:fable", blockedUntilMs }],
+				},
+			],
+		};
+		const healthyReport: UsageReport = {
+			provider: "anthropic",
+			fetchedAt: now,
+			limits: [
+				{
+					id: "anthropic:7d:fable",
+					label: "Claude 7 Day (Fable)",
+					scope: { provider: "anthropic", windowId: "7d", tier: "fable" },
+					window: { id: "7d", label: "7 Day" },
+					amount: { used: 10, limit: 100, usedFraction: 0.1, unit: "percent" },
+					status: "ok",
+				},
+			],
+			metadata: { accountId: "remote-account", email: "remote@example.com", brokerFetch: "before-block" },
+		};
+		const blockedReport: UsageReport = {
+			provider: "anthropic",
+			fetchedAt: now + 1,
+			limits: [
+				{
+					id: "anthropic:7d:fable",
+					label: "Claude 7 Day (Fable)",
+					scope: { provider: "anthropic", windowId: "7d", tier: "fable" },
+					window: { id: "7d", label: "7 Day" },
+					amount: { used: 100, limit: 100, usedFraction: 1, unit: "percent" },
+					status: "exhausted",
+				},
+			],
+			metadata: { accountId: "remote-account", email: "remote@example.com", brokerFetch: "after-block" },
+		};
+		const fetchUsageSpy = vi
+			.spyOn(brokerClient, "fetchUsage")
+			.mockResolvedValueOnce({ generatedAt: now, reports: [healthyReport] })
+			.mockResolvedValueOnce({ generatedAt: now + 1, reports: [blockedReport] });
+		const backgroundSnapshotFetch = Promise.withResolvers<FetchSnapshotResult>();
+		vi.spyOn(brokerClient, "fetchSnapshot")
+			.mockReturnValueOnce(backgroundSnapshotFetch.promise)
+			.mockResolvedValueOnce({
+				status: 200,
+				generation: blockedSnapshot.generation,
+				snapshot: blockedSnapshot,
+			});
+		const remoteStore = new RemoteAuthCredentialStore({
+			client: brokerClient,
+			streamSnapshots: false,
+			initialSnapshot,
+		});
+		try {
+			const first = await remoteStore.fetchUsageReports();
+			expect(fetchUsageSpy).toHaveBeenCalledTimes(1);
+			expect(first).not.toBeNull();
+			expect(first?.[0]?.metadata?.brokerFetch).toBe("before-block");
+			expect(requireLimit(first![0]!, "anthropic:7d:fable").status).toBe("ok");
+
+			await remoteStore.refreshSnapshot();
+			expect(remoteStore.getCredentialBlock(7, "anthropic:oauth", "tier:fable")).toBe(blockedUntilMs);
+
+			const second = await remoteStore.fetchUsageReports();
+			expect(fetchUsageSpy).toHaveBeenCalledTimes(2);
+			expect(second).not.toBeNull();
+			expect(second?.[0]?.metadata?.brokerFetch).toBe("after-block");
+			const afterBlockLimit = requireLimit(second![0]!, "anthropic:7d:fable");
+			expect(afterBlockLimit.status).toBe("exhausted");
+			expect(afterBlockLimit.amount.usedFraction).toBe(1);
+		} finally {
+			remoteStore.close();
+		}
 	});
 
 	test("getUsageReport caches broker fetch failure for USAGE_CACHE_TTL_MS", async () => {


### PR DESCRIPTION
## Summary
- Clear a stale persisted/in-memory `openai-codex:oauth` credential block when a fresh live Codex usage report says the account is allowed and below all limits.
- Keep reconciliation Codex-scoped and limited to the successful live `#fetchUsageCached` path, avoiding cache hits, last-good fallback, and unhealthy reports.
- Add regression coverage for healthy stale-block clearing, pre-clear selection exclusion, post-clear selection inclusion, and unhealthy retention.

## Verification
- `bun test packages/ai/test/auth-storage-codex-selection.test.ts`
- `bun check`
- `git diff --check`

## Review
- Reviewed source/test/changelog diff locally.
- Reviewer subagent approved the change with no findings.
