### PR TITLE
feat: scheduler extension — session-quota-aware prompt queue (packages/scheduler-extension)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -180,6 +180,16 @@
         "@types/bun": "catalog:",
       },
     },
+    "packages/scheduler-extension": {
+      "name": "@oh-my-pi/scheduler-extension",
+      "version": "16.3.11",
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+      },
+      "peerDependencies": {
+        "@oh-my-pi/pi-coding-agent": "^16",
+      },
+    },
     "packages/snapcompact": {
       "name": "@oh-my-pi/snapcompact",
       "version": "16.3.11",
@@ -756,6 +766,8 @@
     "@oh-my-pi/pi-utils": ["@oh-my-pi/pi-utils@workspace:packages/utils"],
 
     "@oh-my-pi/pi-wire": ["@oh-my-pi/pi-wire@workspace:packages/wire"],
+
+    "@oh-my-pi/scheduler-extension": ["@oh-my-pi/scheduler-extension@workspace:packages/scheduler-extension"],
 
     "@oh-my-pi/snapcompact": ["@oh-my-pi/snapcompact@workspace:packages/snapcompact"],
 

--- a/packages/scheduler-extension/CHANGELOG.md
+++ b/packages/scheduler-extension/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Initial release: session-quota-aware prompt queue (`/scheduler`) — queue prompts and drain them unattended across Claude 5-hour session windows, with provider rate-limit holds (429 retry-after), network-outage backoff probing, a self-healing watchdog, pause-on-user-abort, resume-not-skip semantics, crash recovery, and `/scheduler export`.

--- a/packages/scheduler-extension/README.md
+++ b/packages/scheduler-extension/README.md
@@ -1,0 +1,296 @@
+# scheduler — session-quota-aware prompt queue for oh-my-pi
+
+Queue up prompts before bed. `scheduler` drains them unattended: it dispatches
+the next task whenever the agent goes idle, tracks Claude's **5-hour session
+windows** (max **4 per rolling 24 h**) when the active model runs on Claude
+subscription auth, dispatches ungated for every other provider, waits for the
+next window when a gated quota is exhausted — and when a task dies mid-flight
+(rate limit, error, abort, crash) it **resumes that task instead of skipping
+it**.
+
+It is a single-file [oh-my-pi](https://github.com/oh-my-pi) (omp) extension:
+no daemon, no external process, no RPC client. It runs inside your omp
+session and adds one slash command: `/scheduler`.
+
+## Why
+
+Claude subscriptions meter usage in 5-hour session windows, with a cap on how
+many windows you can open per rolling 24 hours. If you only use omp at your
+desk, most of those windows expire unused. `scheduler` lets you bank real
+work for the hours you are asleep:
+
+1. Queue tasks with `/scheduler add ...`.
+2. `/scheduler start` and go to bed.
+3. The extension sends the next prompt each time the agent goes idle,
+   opens session windows only when the quota allows it, sleeps until the next
+   window when it doesn't, and retries interrupted tasks with a
+   "continue where you left off" preamble.
+4. Wake up, read `/scheduler log`.
+
+## Install
+
+> **Requires**: [oh-my-pi](https://github.com/oh-my-pi) with the extension
+> runtime (`~/.omp/agent/extensions/` support) and Bun (omp ships with it).
+
+**Option A — copy/symlink into the user extensions directory** (loaded on
+every omp launch; see omp's `extension-loading` docs — a one-level
+subdirectory with a `package.json` manifest or `index.ts` is discovered
+automatically):
+
+```bash
+# macOS/Linux
+git clone https://github.com/YOU/scheduler ~/.omp/agent/extensions/scheduler
+
+# Windows (PowerShell) — copy…
+git clone https://github.com/YOU/scheduler "$env:USERPROFILE\.omp\agent\extensions\scheduler"
+# …or symlink a working checkout (needs Developer Mode or admin):
+New-Item -ItemType SymbolicLink `
+  -Path "$env:USERPROFILE\.omp\agent\extensions\scheduler" `
+  -Target "D:\Projects\scheduler"
+```
+
+**Option B — reference it from settings** (`~/.omp/agent/config.yml`):
+
+```yaml
+extensions:
+  - D:/Projects/scheduler
+```
+
+**Option C — load once via CLI flag:**
+
+```bash
+omp --extension D:/Projects/scheduler
+```
+
+Restart omp. `/scheduler` (with no arguments) prints usage.
+
+## ⚠️ Prerequisite: approval mode must be `yolo`
+
+Overnight runs are unattended. If omp asks "Allow tool: bash?" at 3 AM,
+nobody answers and the whole night is wasted. Before starting the scheduler,
+make sure every tool call is auto-approved:
+
+```bash
+omp --yolo                                  # per launch, or:
+omp config set tools.approvalMode yolo      # persistent
+```
+
+`/scheduler start` checks the persisted `tools.approvalMode` in your omp
+config files and shows a confirmation warning when it is set to something
+other than `yolo`. It **cannot** see runtime flags (they are in-memory only),
+so if you launched with `--yolo` you can safely confirm through the warning.
+
+Also disable OS sleep for the machine — the queue runs inside the omp
+process; a sleeping laptop dispatches nothing.
+
+## Usage
+
+```text
+/scheduler add <prompt>        queue a task
+/scheduler add-file <path>     queue a task whose prompt is the file's content
+/scheduler list                show queue, current task, session-window state
+/scheduler status              alias of list
+/scheduler start               begin draining the queue when the agent is idle
+/scheduler pause               finish the current task, then hold
+/scheduler stop                abort the current task (kept as resumable) and hold
+/scheduler remove <id>         remove one queued task
+/scheduler clear               remove all pending tasks
+/scheduler log [n]             show the last n JSONL log entries (default 10)
+/scheduler config              show the config file path and current values
+```
+
+Examples:
+
+```text
+/scheduler add Refactor src/parser.ts to a recursive-descent parser; keep tests green
+/scheduler add-file prompts/nightly-refactor.md
+/scheduler start
+/scheduler status
+```
+
+`status` output looks like:
+
+```text
+scheduler: running
+model: anthropic/claude-fable-5 — quota: 5h×4 (anthropic)
+windows: 2/4 used in last 24h; active window ends in 3h12m
+current: t3 (attempt 2) — Migrate the database layer to Drizzle…
+queue:
+  t4  queued      Write integration tests for the auth flow
+  t5  interrupted Port CI to GitHub Actions (attempt 1, rate limited)
+finished: 3 done, 0 failed (/scheduler log for details)
+context: 45% of 200k tokens
+```
+
+## How it works
+
+```mermaid
+flowchart TD
+    A[/scheduler start/] --> B{agent idle?}
+    B -- no --> W1[wait for agent_end] --> B
+    B -- yes --> P{quota profile\ngated?}
+    P -- "no (openai, local, …)" --> D[dispatch next task\nwith unattended preamble]
+    P -- "yes (anthropic/claude)" --> C{session window\navailable?}
+    C -- "no (4/4 in 24h)" --> T[arm timer for\nnext window] --> C
+    C -- yes --> D
+    D --> E{turn outcome}
+    E -- success --> F[mark done] --> B
+    E -- "error / rate limit / abort / crash" --> G[mark interrupted]
+    G --> H[re-dispatch same task\nwith RESUME preamble] --> E
+```
+
+- **Dispatch loop** — the extension listens to omp's `agent_start` /
+  `agent_end` session events. While running, each `agent_end` (plus an idle
+  check) triggers the next dispatch via omp's user-prompt flow
+  (`sendUserMessage`), exactly as if you had typed the prompt.
+- **Quota tracking** — applies only when the active model matches a *gated*
+  quota profile (by default: anthropic/claude — see
+  [Model awareness](#model-awareness)). Every agent turn that begins outside
+  an active window records a new window start in `state.json`, tagged with
+  the profile it was tracked under (manual prompts count too). A dispatch is
+  only allowed when a window is active or fewer than the profile's
+  `maxSessionsPer24h` windows started in the rolling 24 h. When blocked, a
+  timer fires at the moment the oldest window ages out (+ configurable
+  slack) and dispatching resumes automatically. Ungated models record no
+  windows and dispatch whenever the agent is idle.
+- **Resume, not skip** — a task whose turn ends in an error/abort (or whose
+  provider retries are exhausted — `auto_retry_end`) is marked
+  `interrupted`. It keeps its place at the head of the queue and is re-sent
+  with a resume preamble ("Continue exactly where you left off; do not
+  repeat completed work"). After `maxAttempts` total attempts it is marked
+  `failed` and the queue moves on. Tasks left `running` by a crashed or
+  closed omp process are recovered as `interrupted` on the next launch.
+- **Prompt wrapper** — every dispatched prompt is prefixed with a
+  token-efficiency/autonomy preamble (no summaries, no progress narration,
+  never ask questions — decide autonomously and note assumptions in a final
+  line). Both preambles live in `config.json`; edit them to taste.
+
+## Model awareness
+
+Only **Anthropic Claude subscription auth** meters usage in 5-hour session
+windows (max 4 per rolling 24 h). API-key billing and every other provider
+(OpenAI, Google, local models, …) have no such windows — gating them would
+just waste idle hours. The scheduler therefore resolves the active
+provider/model at dispatch time (and at every turn start) and matches it
+against the ordered `quotaProfiles` list in `config.json`; the first match
+wins:
+
+```json
+"quotaProfiles": [
+	{ "match": "anthropic|claude", "sessionHours": 5, "maxSessionsPer24h": 4 },
+	{ "match": ".*", "sessionHours": null, "maxSessionsPer24h": null }
+]
+```
+
+- `match` is a case-insensitive regex tested against the provider id, the
+  model id, and `provider/modelId` of the active model.
+- `sessionHours`/`maxSessionsPer24h` set the window policy; `null` (either
+  field) means **unlimited**: no windows are recorded and dispatch is never
+  quota-blocked for that model.
+- A model that matches no profile — or a provider/model the extension cannot
+  detect at all — runs **unlimited**, and a `notice` line is written to the
+  task log so the decision is visible.
+- Each window record in `state.json` stores the profile it was tracked
+  under, so switching models mid-day (e.g. `/model` from Claude to GPT and
+  back) never corrupts the Claude window counts.
+- `/scheduler status` shows the detected model and the applied profile:
+  `model: anthropic/claude-fable-5 — quota: 5h×4 (anthropic)` vs
+  `model: openai/gpt-5 — quota: none (openai)`.
+
+> **Note:** the extension cannot see *how* you authenticate. If you use
+> Anthropic models via API-key billing (no session windows), replace the
+> first profile's limits with `null`/`null` to run ungated.
+
+Legacy configs (`windowHours`/`maxWindowsPer24h`) are migrated automatically:
+their values become the gated anthropic profile's limits.
+
+## Configuration
+
+`/scheduler config` prints the file path. Default location:
+`~/.omp/agent/scheduler/config.json` (respects `PI_CODING_AGENT_DIR`).
+The file is created with defaults on first load and re-read on every
+`/scheduler start` and session start.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `quotaProfiles` | anthropic/claude → 5h×4, `.*` → unlimited | Ordered provider/model → window-policy map; see [Model awareness](#model-awareness). |
+| `maxAttempts` | `3` | Total attempts (first + resumes) before a task is marked `failed`. |
+| `dispatchDelayMs` | `4000` | Idle settle delay before dispatching the next task. |
+| `windowSlackMs` | `60000` | Extra wait added to the next-window resume timer. |
+| `promptPreamble` | see file | Prepended to **every** dispatched prompt. |
+| `resumePreamble` | see file | Additionally prepended when resuming an interrupted task. |
+
+## State files
+
+Everything lives under `~/.omp/agent/scheduler/`
+(or `$PI_CODING_AGENT_DIR/scheduler/`):
+
+| File | Contents |
+|---|---|
+| `state.json` | Queue, task statuses/attempts, run mode, observed session-window start times (each tagged with its quota profile), in-flight task id. Written atomically on every change; survives restarts. |
+| `config.json` | User-editable configuration (table above). |
+| `task-log.jsonl` | Append-only log: one JSON object per event — `start`, `pause`, `stop`, `dispatch`, `end` (with status, error, duration), `blocked` (with resume time), `resume_timer`, `window_start`, `recovered`, `retry_failed`, `notice` (e.g. undetectable provider → ungated). `/scheduler log [n]` pretty-prints the tail. |
+
+Deleting `state.json` resets the queue and window history; deleting
+`config.json` restores defaults on next load.
+
+## Limitations
+
+Honest list — these follow from what omp's documented extension API can and
+cannot express:
+
+1. **Window accounting is a local approximation.** A window is recorded when
+   *this* omp process observes an agent turn start outside an active window
+   (gated profiles only; ungated models record nothing). Usage from other
+   machines, the Claude apps, or other omp instances is invisible;
+   Anthropic's server is the source of truth. If you burned windows
+   elsewhere, the scheduler may dispatch into a rate limit — that turn is
+   then marked `interrupted` and retried in the next window, so work is
+   still not lost. The auth mode is equally invisible: profiles match on
+   provider/model id, not on subscription-vs-API-key, so API-key Anthropic
+   users should edit `quotaProfiles` (see
+   [Model awareness](#model-awareness)).
+2. **Turn-failure detection is best-effort.** omp documents `agent_end` as a
+   notification-only lifecycle event and does not specify a typed error
+   payload for extensions. The extension inspects the final assistant
+   message defensively (`stopReason` of `error`/`aborted`, `errorMessage`)
+   and listens to `auto_retry_end` for exhausted provider retries. An
+   unrecognizable payload is treated as success. Crash/shutdown recovery is
+   independent of this and always resumes tasks that never finished.
+3. **The `--yolo` runtime flag cannot be verified.** omp keeps runtime flag
+   overrides in memory only, so the pre-start check reads the persisted
+   config files. A non-`yolo` result is a *warning with a confirm dialog*,
+   not a hard block.
+4. **No OS-level scheduling.** This is an in-process extension, not a
+   daemon: the omp session must stay open and the machine awake. Disable
+   sleep/hibernation for overnight runs.
+5. **Shared session context.** Queued tasks run sequentially in the current
+   omp session, so later tasks see earlier tasks' conversation (usually a
+   feature; occasionally not). Long nights may trigger omp's automatic
+   compaction — that is normal and handled by omp itself.
+6. **Manual use while running.** The dispatcher fires after *any* agent turn
+   ends. If you interact manually while the scheduler is running, your turn
+   ending can trigger the next queued task. `/scheduler pause` first.
+
+## Development
+
+```bash
+bun run check     # syntax/transpile check (bun build --no-bundle)
+bun run smoke     # behavioral smoke test against a mocked ExtensionAPI
+```
+
+The smoke test (`test/smoke.ts`) uses a throwaway `PI_CODING_AGENT_DIR`, so
+it never touches your real queue or config.
+
+## Contributing
+
+Issues and PRs welcome. Keep it a single-file extension (`index.ts`), cite
+the omp doc section for every runtime API you use (see the existing code
+comments), run `bun run check` and `bun run smoke` before submitting, and
+update the config/state tables in this README when you change the schema.
+Interested in getting this into omp itself? See
+[CONTRIBUTING-UPSTREAM.md](./CONTRIBUTING-UPSTREAM.md).
+
+## License
+
+[MIT](./LICENSE)

--- a/packages/scheduler-extension/package.json
+++ b/packages/scheduler-extension/package.json
@@ -1,0 +1,51 @@
+{
+	"type": "module",
+	"name": "@oh-my-pi/scheduler-extension",
+	"version": "16.3.11",
+	"description": "Session-quota-aware prompt queue extension for omp",
+	"homepage": "https://omp.sh",
+	"author": "Naren Krithick",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/can1357/oh-my-pi.git",
+		"directory": "packages/scheduler-extension"
+	},
+	"bugs": {
+		"url": "https://github.com/can1357/oh-my-pi/issues"
+	},
+	"keywords": [
+		"scheduler",
+		"queue",
+		"quota",
+		"agent",
+		"extension"
+	],
+	"scripts": {
+		"check": "biome check . && bun run check:types",
+		"check:types": "tsgo -p tsconfig.json --noEmit",
+		"test": "bun test/smoke.ts",
+		"lint": "biome lint .",
+		"fix": "biome check --write --unsafe .",
+		"fmt": "biome format --write ."
+	},
+	"devDependencies": {
+		"@types/bun": "^1.3.14"
+	},
+	"peerDependencies": {
+		"@oh-my-pi/pi-coding-agent": "^16"
+	},
+	"engines": {
+		"bun": ">=1.3.14"
+	},
+	"omp": {
+		"extensions": [
+			"./src/extension.ts"
+		]
+	},
+	"files": [
+		"src",
+		"README.md",
+		"CHANGELOG.md"
+	]
+}

--- a/packages/scheduler-extension/src/extension.ts
+++ b/packages/scheduler-extension/src/extension.ts
@@ -1,0 +1,1449 @@
+/**
+ * scheduler — session-quota-aware prompt queue for oh-my-pi (omp).
+ *
+ * Queue prompts, then let the scheduler drain them unattended (e.g. overnight):
+ * it dispatches the next task whenever the agent goes idle, tracks Claude's
+ * 5-hour session windows (max N per rolling 24h) when — and only when — the
+ * active model matches a gated quota profile (Anthropic Claude subscription
+ * auth), dispatches ungated for every other provider, waits for the next
+ * window when a gated quota is exhausted, and RESUMES interrupted tasks
+ * instead of skipping them.
+ *
+ * Extension shape per omp docs (extensions.md § "What an extension is"):
+ * a TS module exporting a default factory that receives ExtensionAPI.
+ * Ships as @oh-my-pi/scheduler-extension (packages/scheduler-extension);
+ * also installable standalone by copying into ~/.omp/agent/extensions/scheduler
+ * (skills/authoring-extensions.md § "Discovery paths").
+ *
+ * Every runtime API used below is cited against the omp docs:
+ *   - extensions.md            (runtime reference; "§" quotes its headings)
+ *   - authoring-extensions.md  (the authoring skill)
+ *   - settings.md              (config file locations / precedence)
+ *   - approval-mode.md         (tools.approvalMode semantics)
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Lifecycle of one queued prompt. */
+export type TaskStatus =
+	| "queued" // waiting for dispatch
+	| "running" // dispatched, turn in progress
+	| "interrupted" // turn ended in error/rate-limit/abort — will be re-sent with resume preamble
+	| "done" // turn completed normally
+	| "failed"; // exceeded maxAttempts; will not be retried
+
+/** One queued prompt. */
+export interface SchedulerTask {
+	id: string;
+	prompt: string;
+	/** Set when the prompt was loaded via `add-file`. */
+	sourceFile?: string;
+	status: TaskStatus;
+	addedAt: string;
+	dispatchedAt?: string;
+	endedAt?: string;
+	attempts: number;
+	lastError?: string;
+}
+
+/** Scheduler run mode set by start/pause/stop. */
+export type RunMode = "stopped" | "running" | "paused";
+
+/** One locally observed provider session window (state.json). */
+export interface WindowRecord {
+	/** ISO timestamp of the window start. */
+	startedAt: string;
+	/** `match` pattern of the quota profile the window was recorded under. */
+	profile: string;
+}
+
+/** Persisted state (state.json in the data dir). */
+export interface SchedulerState {
+	version: 2;
+	run: RunMode;
+	tasks: SchedulerTask[];
+	/**
+	 * Provider session windows observed locally, tagged with the quota
+	 * profile they were recorded under so counts survive model switches
+	 * (v1 stored plain ISO strings; migrated on load).
+	 */
+	windows: WindowRecord[];
+	/** Task currently in flight, if any (survives crashes for resume-not-skip). */
+	currentTaskId: string | null;
+	/**
+	 * Provider-declared rate-limit hold (ISO): no dispatch until this time.
+	 * Set from the 429 retry-after when provider retries are exhausted;
+	 * cleared on expiry or by any turn that ends without a rate limit.
+	 */
+	rateLimitedUntil?: string | null;
+	nextTaskSeq: number;
+}
+
+/**
+ * One quota profile: which models it applies to and its window policy.
+ * Only Anthropic Claude *subscription* auth meters usage in session windows;
+ * API-key billing and other providers have no such windows.
+ */
+export interface QuotaProfile {
+	/**
+	 * Case-insensitive regex tested against the provider id, the model id,
+	 * and "provider/modelId" of the active model. First match wins.
+	 */
+	match: string;
+	/** Length of one session window, in hours. null = unlimited (no windows). */
+	sessionHours: number | null;
+	/** Maximum session windows per rolling 24 hours. null = unlimited. */
+	maxSessionsPer24h: number | null;
+}
+
+/** User-editable configuration (config.json in the data dir). */
+export interface SchedulerConfig {
+	/**
+	 * Ordered quota profiles; the first whose `match` hits the active
+	 * provider/model applies. No match (or undetectable model) = unlimited.
+	 */
+	quotaProfiles: QuotaProfile[];
+	/** Attempts (initial + resumes) before a task is marked failed. */
+	maxAttempts: number;
+	/** Idle settle delay before dispatching the next task, in ms. */
+	dispatchDelayMs: number;
+	/** Extra slack added when arming the next-window resume timer, in ms. */
+	windowSlackMs: number;
+	/** Prepended to every dispatched prompt (token-efficiency / autonomy rules). */
+	promptPreamble: string;
+	/** Additionally prepended when re-dispatching an interrupted task. */
+	resumePreamble: string;
+	/** First retry delay after a network/outage interruption, in ms (doubles each consecutive outage). */
+	outageBackoffBaseMs: number;
+	/** Ceiling for the outage retry delay, in ms. */
+	outageBackoffMaxMs: number;
+	/** Watchdog tick interval, in ms; self-heals lost timers and stalled dispatches. */
+	watchdogIntervalMs: number;
+	/** How long a dispatched task may sit with an idle agent before the watchdog re-queues it, in ms. */
+	stallTimeoutMs: number;
+}
+
+/** One JSONL log record (task-log.jsonl in the data dir). */
+export interface SchedulerLogEntry {
+	ts: string;
+	event:
+		| "start"
+		| "pause"
+		| "stop"
+		| "dispatch"
+		| "end"
+		| "blocked"
+		| "resume_timer"
+		| "window_start"
+		| "recovered"
+		| "retry_failed"
+		| "notice";
+	taskId?: string;
+	status?: TaskStatus;
+	attempt?: number;
+	resumed?: boolean;
+	error?: string;
+	durationMs?: number;
+	resumeAt?: string;
+	detail?: string;
+}
+
+/**
+ * Structural subset of the handler context this extension uses.
+ * All members are documented in extensions.md § "2) Handler context
+ * (ExtensionContext)" and § "UI integration points"; commands additionally
+ * receive ExtensionCommandContext (§ "3) Command context") which is a
+ * superset, so this shape fits both.
+ */
+interface CtxLike {
+	ui: {
+		notify(message: string, level?: "info" | "warning" | "error"): void;
+		confirm(title: string, message: string): Promise<boolean>;
+		setStatus(key: string, text: string): void;
+	};
+	hasUI: boolean;
+	cwd: string;
+	/** extensions.md § "2) Handler context": `model`, `models` (read-only model query). */
+	model?: unknown;
+	models?: { current?(): unknown };
+	isIdle(): boolean;
+	hasPendingMessages(): boolean;
+	abort(): void | Promise<void>;
+	getContextUsage(): { tokens: number; contextWindow: number; percent: number } | undefined;
+}
+
+/**
+ * Opaque handle returned by setTimeout (number under DOM typings, Timeout
+ * object under Node/Bun); only ever passed back to clearTimeout.
+ */
+type TimerHandle = number;
+
+/** Opaque handle returned by setInterval; only ever passed back to clearInterval. */
+type IntervalHandle = number;
+
+// ---------------------------------------------------------------------------
+// Data dir + defaults
+// ---------------------------------------------------------------------------
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * settings.md § "Where settings live": PI_CODING_AGENT_DIR relocates the
+ * ~/.omp/agent base directory; honor it so scheduler data moves with it.
+ */
+function agentDir(): string {
+	return process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".omp", "agent");
+}
+
+function dataDir(): string {
+	return path.join(agentDir(), "scheduler");
+}
+function stateFile(): string {
+	return path.join(dataDir(), "state.json");
+}
+function configFile(): string {
+	return path.join(dataDir(), "config.json");
+}
+function logFile(): string {
+	return path.join(dataDir(), "task-log.jsonl");
+}
+
+const DEFAULT_PROMPT_PREAMBLE = [
+	"[scheduler] Unattended queued task — no human is watching this session.",
+	"Rules for this task:",
+	"- Never ask questions or wait for confirmation; make every decision autonomously.",
+	"- Do not narrate progress. Do not produce summaries unless the task explicitly asks for one.",
+	"- Keep all output terse: results, file paths, and errors only.",
+	"- End with a single final line noting any assumptions you made.",
+].join("\n");
+
+const DEFAULT_RESUME_PREAMBLE = [
+	"[scheduler] RESUME: this task was interrupted before completion (error, rate limit, or abort).",
+	"Continue exactly where you left off; do not repeat completed work.",
+	"Inspect the current state of files/artifacts to verify what is already done, then finish only the remainder.",
+].join("\n");
+
+/**
+ * Default quota profiles: Anthropic Claude subscription auth is metered in
+ * 5-hour session windows (max 4 per rolling 24h); every other provider —
+ * OpenAI, Google, local models, API-key billing — has no such windows and
+ * dispatches ungated. First match wins; edit config.json to adjust.
+ */
+const DEFAULT_QUOTA_PROFILES: QuotaProfile[] = [
+	{ match: "anthropic|claude", sessionHours: 5, maxSessionsPer24h: 4 },
+	{ match: ".*", sessionHours: null, maxSessionsPer24h: null },
+];
+
+const DEFAULT_CONFIG: SchedulerConfig = {
+	quotaProfiles: DEFAULT_QUOTA_PROFILES,
+	maxAttempts: 3,
+	dispatchDelayMs: 4000,
+	windowSlackMs: 60_000,
+	promptPreamble: DEFAULT_PROMPT_PREAMBLE,
+	resumePreamble: DEFAULT_RESUME_PREAMBLE,
+	outageBackoffBaseMs: 30_000,
+	outageBackoffMaxMs: 15 * 60_000,
+	watchdogIntervalMs: 60_000,
+	stallTimeoutMs: 10 * 60_000,
+};
+
+const EMPTY_STATE: SchedulerState = {
+	version: 2,
+	run: "stopped",
+	tasks: [],
+	windows: [],
+	currentTaskId: null,
+	rateLimitedUntil: null,
+	nextTaskSeq: 1,
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function ensureDataDir(): void {
+	fs.mkdirSync(dataDir(), { recursive: true });
+}
+
+/** Atomic-ish JSON write: temp file then rename. */
+function writeJson(file: string, value: unknown): void {
+	ensureDataDir();
+	const tmp = `${file}.tmp`;
+	fs.writeFileSync(tmp, `${JSON.stringify(value, null, "\t")}\n`, "utf8");
+	fs.renameSync(tmp, file);
+}
+
+function readJson<T>(file: string): T | null {
+	try {
+		return JSON.parse(fs.readFileSync(file, "utf8")) as T;
+	} catch {
+		return null;
+	}
+}
+
+/** Limits of a gated quota profile (both bounds present and positive). */
+interface GatedLimits {
+	sessionHours: number;
+	maxSessionsPer24h: number;
+}
+
+/** The quota situation of the active provider/model, resolved at use time. */
+interface ActiveQuota {
+	/** Profile `match` pattern; also the key window records are tagged with. */
+	key: string;
+	provider: string;
+	modelId: string;
+	/** False when the extension API exposed no readable model. */
+	detected: boolean;
+	/** null = unlimited: no window tracking, no dispatch gating. */
+	limits: GatedLimits | null;
+}
+
+/**
+ * Active provider/model, read defensively from the handler context.
+ * extensions.md § "Model selection (ctx.models)": "current() — the live
+ * session model (read lazily, so it reflects /model switches)", with
+ * ctx.model (§ "2) Handler context") as fallback. Model strings are
+ * documented as "provider/id", so only those two fields are relied on;
+ * anything unreadable resolves to null (= unknown).
+ */
+function detectModel(ctx: CtxLike | null): { provider: string; modelId: string } | null {
+	if (!ctx) return null;
+	let m: unknown;
+	try {
+		m = ctx.models?.current?.();
+	} catch {
+		m = undefined;
+	}
+	if (!m) m = ctx.model;
+	const rec = m as { provider?: unknown; id?: unknown } | null | undefined;
+	const provider = typeof rec?.provider === "string" ? rec.provider : "";
+	const modelId = typeof rec?.id === "string" ? rec.id : "";
+	return provider || modelId ? { provider, modelId } : null;
+}
+
+/** First matching quota profile for the active model; no match/unknown = unlimited. */
+function resolveQuota(ctx: CtxLike | null, cfg: SchedulerConfig): ActiveQuota {
+	const detected = detectModel(ctx);
+	if (!detected) return { key: "unknown", provider: "", modelId: "", detected: false, limits: null };
+	const { provider, modelId } = detected;
+	for (const p of cfg.quotaProfiles) {
+		let re: RegExp;
+		try {
+			re = new RegExp(p.match, "i");
+		} catch {
+			continue; // invalid user pattern — skip; later profiles still apply
+		}
+		if (!(re.test(provider) || re.test(modelId) || re.test(`${provider}/${modelId}`))) continue;
+		if (
+			typeof p.sessionHours === "number" &&
+			p.sessionHours > 0 &&
+			typeof p.maxSessionsPer24h === "number" &&
+			p.maxSessionsPer24h > 0
+		) {
+			return {
+				key: p.match,
+				provider,
+				modelId,
+				detected: true,
+				limits: { sessionHours: p.sessionHours, maxSessionsPer24h: p.maxSessionsPer24h },
+			};
+		}
+		return { key: p.match, provider, modelId, detected: true, limits: null };
+	}
+	return { key: "unmatched", provider, modelId, detected: true, limits: null };
+}
+
+/** Start (epoch ms) of the profile's session window covering `now`, or null. */
+function activeWindowStart(state: SchedulerState, key: string, sessionHours: number, now: number): number | null {
+	const len = sessionHours * HOUR_MS;
+	for (const w of state.windows) {
+		if (w.profile !== key) continue;
+		const t = Date.parse(w.startedAt);
+		if (Number.isFinite(t) && now >= t && now < t + len) return t;
+	}
+	return null;
+}
+
+/** The profile's window starts (epoch ms, ascending) within the last rolling 24h. */
+function windowStartsInLast24h(state: SchedulerState, key: string, now: number): number[] {
+	return state.windows
+		.filter(w => w.profile === key)
+		.map(w => Date.parse(w.startedAt))
+		.filter(t => Number.isFinite(t) && now - t < DAY_MS && t <= now)
+		.sort((a, b) => a - b);
+}
+
+/** Drop window records too old to matter for the rolling 24h math. */
+function pruneWindows(state: SchedulerState, now: number): void {
+	state.windows = state.windows.filter(w => {
+		const t = Date.parse(w.startedAt);
+		return Number.isFinite(t) && now - t < 2 * DAY_MS;
+	});
+}
+
+/**
+ * Migrate persisted state to the current shape. v1 stored windows as plain
+ * ISO strings under the then-global (Claude-only) quota; they are re-tagged
+ * with the first gated profile so a mid-upgrade day keeps counting them.
+ */
+function migrateState(raw: unknown, cfg: SchedulerConfig): SchedulerState | null {
+	if (!raw || typeof raw !== "object") return null;
+	const st = raw as SchedulerState & { windows?: unknown[] };
+	const legacyKey =
+		cfg.quotaProfiles.find(p => typeof p.sessionHours === "number" && typeof p.maxSessionsPer24h === "number")
+			?.match ?? DEFAULT_QUOTA_PROFILES[0].match;
+	st.windows = (Array.isArray(st.windows) ? st.windows : []).map(w =>
+		typeof w === "string" ? { startedAt: w, profile: legacyKey } : (w as WindowRecord),
+	);
+	st.rateLimitedUntil ??= null;
+	st.version = 2;
+	return st;
+}
+
+interface QuotaVerdict {
+	ok: boolean;
+	/** When blocked: epoch ms at which the oldest counted window falls out of the 24h horizon. */
+	nextAt?: number;
+	reason?: string;
+}
+
+/** Can a prompt be dispatched now without exceeding the gated profile's quota? */
+function quotaCheck(state: SchedulerState, key: string, limits: GatedLimits, now: number): QuotaVerdict {
+	if (activeWindowStart(state, key, limits.sessionHours, now) !== null) return { ok: true };
+	const used = windowStartsInLast24h(state, key, now);
+	if (used.length < limits.maxSessionsPer24h) return { ok: true };
+	return {
+		ok: false,
+		nextAt: used[0] + DAY_MS,
+		reason: `all ${limits.maxSessionsPer24h} session windows used in the last 24h (profile "${key}")`,
+	};
+}
+
+function nextPendingTask(state: SchedulerState): SchedulerTask | undefined {
+	// Resume-not-skip: an interrupted task keeps its queue position and is
+	// simply the first pending task again on the next dispatch.
+	return state.tasks.find(t => t.status === "queued" || t.status === "interrupted");
+}
+
+function truncate(text: string, max: number): string {
+	const one = text.replace(/\s+/g, " ").trim();
+	return one.length <= max ? one : `${one.slice(0, max - 1)}…`;
+}
+
+function fmtDuration(ms: number): string {
+	if (ms < 0) ms = 0;
+	const totalMin = Math.round(ms / 60_000);
+	const h = Math.floor(totalMin / 60);
+	const m = totalMin % 60;
+	return h > 0 ? `${h}h${String(m).padStart(2, "0")}m` : `${m}m`;
+}
+
+function fmtClock(epochMs: number): string {
+	const d = new Date(epochMs);
+	return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+/**
+ * Best-effort effective `tools.approvalMode` from persisted settings.
+ *
+ * settings.md § "Where settings live" / § "Precedence": project
+ * `<cwd>/.omp/config.yml` (and legacy `settings.json`) overrides global
+ * `~/.omp/agent/config.yml` (and legacy `settings.json`). Runtime flags
+ * (`--yolo`, `--approval-mode`) are in-memory only and CANNOT be detected
+ * here — callers must treat a non-yolo result as a warning, not a hard fact.
+ * Returns null when no layer sets the key (schema default is `yolo`,
+ * approval-mode.md § "Modes").
+ */
+function detectApprovalMode(cwd: string): string | null {
+	const candidates = [
+		path.join(cwd, ".omp", "config.yml"),
+		path.join(cwd, ".omp", "settings.json"),
+		path.join(agentDir(), "config.yml"),
+		path.join(agentDir(), "settings.json"),
+	];
+	for (const file of candidates) {
+		const mode = readApprovalModeFrom(file);
+		if (mode) return mode;
+	}
+	return null;
+}
+
+function readApprovalModeFrom(file: string): string | null {
+	let text: string;
+	try {
+		text = fs.readFileSync(file, "utf8");
+	} catch {
+		return null;
+	}
+	if (file.endsWith(".json")) {
+		try {
+			const parsed = JSON.parse(text) as { tools?: { approvalMode?: unknown } };
+			const mode = parsed?.tools?.approvalMode;
+			return typeof mode === "string" ? mode : null;
+		} catch {
+			return null;
+		}
+	}
+	// Narrow YAML scan: in the settings schema `approvalMode` only exists under
+	// `tools:` (settings.md § "Tools and approvals"), so a single-key match is
+	// unambiguous without a YAML parser.
+	const match = /^\s*approvalMode:\s*["']?([A-Za-z-]+)["']?\s*(?:#.*)?$/m.exec(text);
+	return match ? match[1] : null;
+}
+
+/**
+ * Best-effort error/abort detection from an `agent_end` payload.
+ *
+ * extensions.md § "Prompt and turn lifecycle" documents `agent_end` as a
+ * notification-only lifecycle event; rpc.md shows it carrying `messages`.
+ * The message internals are not part of the documented extension contract,
+ * so this inspects them defensively and returns null (= assume success)
+ * when nothing recognizable is present. Rate-limit/retry failures are
+ * caught separately via `auto_retry_end` (extensions.md § "Reliability/
+ * runtime signals").
+ */
+function detectTurnError(event: unknown): string | null {
+	const ev = event as { messages?: unknown } | null | undefined;
+	const messages = Array.isArray(ev?.messages) ? (ev.messages as Record<string, unknown>[]) : [];
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (!msg || typeof msg !== "object") continue;
+		if (msg.role !== "assistant") continue;
+		const stop = typeof msg.stopReason === "string" ? msg.stopReason : "";
+		if (stop === "error" || stop === "aborted") {
+			const errText = typeof msg.errorMessage === "string" && msg.errorMessage ? `: ${msg.errorMessage}` : "";
+			return `turn ${stop}${errText}`;
+		}
+		return null; // last assistant message looks normal
+	}
+	return null;
+}
+
+/**
+ * Provider-requested wait extracted from a retry/rate-limit error string,
+ * in ms (clamped to 1s..24h), or null when the error names no wait.
+ * Recognized shapes (surfaced through auto_retry_end on provider 429s):
+ *   "retry-after-ms=13448000", "Provider requested 13448000ms wait",
+ *   "retry-after: 3600" (seconds).
+ */
+function parseRetryAfterMs(error: string): number | null {
+	let ms: number | null = null;
+	const msMatch = /retry-after-ms=(\d+)/i.exec(error) ?? /requested (\d+)\s*ms wait/i.exec(error);
+	if (msMatch) {
+		ms = Number.parseInt(msMatch[1], 10);
+	} else {
+		const secMatch = /retry[- ]after["':\s]+(\d+)/i.exec(error);
+		if (secMatch) ms = Number.parseInt(secMatch[1], 10) * 1000;
+	}
+	if (ms === null || !Number.isFinite(ms)) return null;
+	return Math.min(Math.max(ms, 1000), DAY_MS);
+}
+
+/**
+ * True when the error smells like a connectivity/provider outage rather
+ * than a task fault: transport failures, DNS, timeouts, and 5xx/overload.
+ * Such interruptions must never burn task attempts — the task did nothing
+ * wrong — and are retried on a capped exponential backoff instead.
+ */
+function isTransientNetworkError(error: string): boolean {
+	return /fetch failed|network|socket|connection (?:refused|reset|closed|error)|ECONN\w+|ENOTFOUND|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|ENETUNREACH|EPIPE|offline|dns|timed? ?out|overloaded|\b5\d{2}\b/i.test(
+		error,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Extension factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Default factory export — extensions.md § "What an extension is".
+ * Registration happens here; runtime actions (sendUserMessage, abort, …)
+ * only run from event/command handlers, per extensions.md § "Constraints
+ * and pitfalls" ("Runtime actions are unavailable during extension load").
+ */
+export default function schedulerExtension(pi: ExtensionAPI) {
+	// extensions.md § "1) Registration and actions": setLabel
+	pi.setLabel("Scheduler");
+
+	// ---- in-memory runtime -------------------------------------------------
+	let state: SchedulerState | null = null;
+	let cfg: SchedulerConfig = structuredClone(DEFAULT_CONFIG);
+	let liveCtx: CtxLike | null = null;
+	let agentActive = false;
+	/** Set by auto_retry_end when retries were exhausted during the current turn. */
+	let retryFailure: string | null = null;
+	let dispatchTimer: TimerHandle | null = null;
+	let resumeTimer: TimerHandle | null = null;
+	let emptyQueueNotified = false;
+	/** Consecutive outage interruptions; sets the backoff step, reset on any healthy turn. */
+	let outageStreak = 0;
+	/** Watchdog interval handle (unref'd — never holds the host process open). */
+	let watchdogTimer: IntervalHandle | null = null;
+	/** One-shot guard for the unknown-provider notice (reset per process). */
+	let unknownModelNoticed = false;
+
+	function startTimer(ms: number, fn: () => void): TimerHandle {
+		return setTimeout(fn, ms) as unknown as TimerHandle;
+	}
+	function stopTimer(handle: TimerHandle | null): null {
+		clearTimeout(handle as TimerHandle); // spec no-op for null/stale handles
+		return null;
+	}
+	function clearTimers(): void {
+		dispatchTimer = stopTimer(dispatchTimer);
+		resumeTimer = stopTimer(resumeTimer);
+	}
+
+	// ---- watchdog ------------------------------------------------------------
+	/**
+	 * Last line of defense so "running" can never silently stall for hours.
+	 * Heals two failure shapes one-shot timers cannot survive:
+	 *   1) a dispatched task whose turn never materialized (prompt swallowed
+	 *      or agent_end lost) — re-queued without burning an attempt;
+	 *   2) pending work with no armed timer (a timer died with an exception).
+	 * Long-running turns are untouched: recovery requires an *idle* agent.
+	 */
+	function watchdogTick(): void {
+		const st = getState();
+		if (st.run !== "running") return;
+		if (st.currentTaskId !== null) {
+			const task = st.tasks.find(t => t.id === st.currentTaskId);
+			const dispatchedAt = task?.dispatchedAt ? Date.parse(task.dispatchedAt) : Number.NaN;
+			const stale = !Number.isFinite(dispatchedAt) || Date.now() - dispatchedAt > cfg.stallTimeoutMs;
+			if (stale && liveCtx?.isIdle() === true) {
+				const id = st.currentTaskId;
+				logEvent({ event: "recovered", taskId: id, detail: "watchdog: task in flight but agent idle" });
+				notify(
+					null,
+					`scheduler: watchdog — ${id} stalled with an idle agent; re-queued (attempt not counted).`,
+					"warning",
+				);
+				settleCurrentTask("stalled: agent idle with task in flight", true);
+				scheduleDispatch(cfg.dispatchDelayMs);
+			}
+			return;
+		}
+		if (dispatchTimer === null && resumeTimer === null && !agentActive && nextPendingTask(st)) {
+			logEvent({ event: "notice", detail: "watchdog: pending work with no armed timer — re-arming dispatch" });
+			scheduleDispatch(cfg.dispatchDelayMs);
+		}
+	}
+	function startWatchdog(): void {
+		if (watchdogTimer !== null) return;
+		const handle = setInterval(watchdogTick, cfg.watchdogIntervalMs);
+		handle.unref?.(); // Node/Bun: don't keep the host process alive for the watchdog
+		watchdogTimer = handle as unknown as IntervalHandle; // same opaque-handle convention as TimerHandle
+	}
+	function stopWatchdog(): void {
+		if (watchdogTimer !== null) {
+			clearInterval(watchdogTimer as IntervalHandle);
+			watchdogTimer = null;
+		}
+	}
+
+	// ---- persistence -------------------------------------------------------
+	function getState(): SchedulerState {
+		if (state === null) {
+			state = migrateState(readJson<unknown>(stateFile()), cfg) ?? structuredClone(EMPTY_STATE);
+		}
+		return state;
+	}
+	function saveState(): void {
+		if (state !== null) writeJson(stateFile(), state);
+	}
+	function loadConfig(): void {
+		const onDisk = readJson<Partial<SchedulerConfig> & { windowHours?: unknown; maxWindowsPer24h?: unknown }>(
+			configFile(),
+		);
+		if (onDisk === null) {
+			cfg = structuredClone(DEFAULT_CONFIG);
+			writeJson(configFile(), cfg); // seed an editable config file
+			return;
+		}
+		cfg = { ...structuredClone(DEFAULT_CONFIG), ...onDisk } as SchedulerConfig;
+		const legacy = !Array.isArray(onDisk.quotaProfiles) || onDisk.quotaProfiles.length === 0;
+		if (legacy) {
+			// Pre-quotaProfiles config: windowHours/maxWindowsPer24h were global
+			// and only ever described Claude subscription windows — carry them
+			// into the gated anthropic profile, then persist the migrated shape.
+			cfg.quotaProfiles = structuredClone(DEFAULT_QUOTA_PROFILES);
+			if (typeof onDisk.windowHours === "number") cfg.quotaProfiles[0].sessionHours = onDisk.windowHours;
+			if (typeof onDisk.maxWindowsPer24h === "number")
+				cfg.quotaProfiles[0].maxSessionsPer24h = onDisk.maxWindowsPer24h;
+		}
+		delete (cfg as unknown as Record<string, unknown>).windowHours;
+		delete (cfg as unknown as Record<string, unknown>).maxWindowsPer24h;
+		if (legacy) writeJson(configFile(), cfg);
+	}
+	function logEvent(entry: Omit<SchedulerLogEntry, "ts">): void {
+		try {
+			ensureDataDir();
+			fs.appendFileSync(logFile(), `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`, "utf8");
+		} catch (err) {
+			// pi.logger — extensions.md § "1) Registration and actions" ("Also exposed: pi.logger")
+			pi.logger?.warn?.(`scheduler: failed to append log: ${String(err)}`);
+		}
+	}
+	function readLogTail(n: number): SchedulerLogEntry[] {
+		try {
+			const lines = fs.readFileSync(logFile(), "utf8").split("\n").filter(Boolean);
+			return lines.slice(-n).flatMap(line => {
+				try {
+					return [JSON.parse(line) as SchedulerLogEntry];
+				} catch {
+					return [];
+				}
+			});
+		} catch {
+			return [];
+		}
+	}
+
+	// ---- UI helpers ----------------------------------------------------------
+	function notify(ctx: CtxLike | null, message: string, level: "info" | "warning" | "error" = "info"): void {
+		// ctx.ui.notify — authoring-extensions.md § "Minimum viable extension";
+		// no-op safe when headless (extensions.md § "Print/headless/subagent paths").
+		try {
+			(ctx ?? liveCtx)?.ui.notify(message, level);
+		} catch {
+			/* headless */
+		}
+	}
+	function updateStatus(): void {
+		const ctx = liveCtx;
+		if (!ctx?.hasUI) return;
+		const st = getState();
+		const pending = st.tasks.filter(t => t.status === "queued" || t.status === "interrupted").length;
+		try {
+			// ctx.ui.setStatus — authoring-extensions.md § "Subscribing to events" example.
+			ctx.ui.setStatus("scheduler", st.run === "stopped" && pending === 0 ? "" : `sched:${st.run} q:${pending}`);
+		} catch {
+			/* mode without status support */
+		}
+	}
+
+	/**
+	 * Resolve the active model's quota profile; when the model cannot be
+	 * detected, gate nothing (contract: unknown provider = unlimited) but
+	 * log a one-shot notice so the choice is visible in the task log.
+	 */
+	function currentQuota(ctx: CtxLike | null): ActiveQuota {
+		const quota = resolveQuota(ctx ?? liveCtx, cfg);
+		if (!quota.detected && !unknownModelNoticed) {
+			unknownModelNoticed = true;
+			logEvent({
+				event: "notice",
+				detail: "active provider/model not detectable — treating as unlimited (no session-window gating)",
+			});
+			notify(null, "scheduler: provider/model unknown — dispatching without session-window gating.", "warning");
+		}
+		return quota;
+	}
+
+	// ---- dispatch loop -------------------------------------------------------
+	function scheduleDispatch(delayMs: number): void {
+		dispatchTimer = stopTimer(dispatchTimer);
+		dispatchTimer = startTimer(delayMs, () => {
+			dispatchTimer = null;
+			tryDispatch();
+		});
+	}
+
+	function armResumeTimer(atMs: number): void {
+		resumeTimer = stopTimer(resumeTimer);
+		const delay = Math.max(1000, atMs - Date.now());
+		resumeTimer = startTimer(delay, () => {
+			resumeTimer = null;
+			logEvent({ event: "resume_timer" });
+			tryDispatch();
+		});
+	}
+
+	function tryDispatch(): void {
+		const st = getState();
+		if (st.run !== "running") return;
+		if (st.currentTaskId !== null) return; // a task is already in flight
+		if (agentActive) return; // manual/other turn in progress
+		// extensions.md § "2) Handler context": isIdle(), hasPendingMessages().
+		// Defer to user-queued messages; re-check after the next agent_end.
+		if (liveCtx && (!liveCtx.isIdle() || liveCtx.hasPendingMessages())) {
+			scheduleDispatch(cfg.dispatchDelayMs);
+			return;
+		}
+		const task = nextPendingTask(st);
+		if (!task) {
+			if (!emptyQueueNotified) {
+				emptyQueueNotified = true;
+				notify(null, "scheduler: queue drained — still running; new tasks dispatch automatically.");
+			}
+			updateStatus();
+			return;
+		}
+		const now = Date.now();
+		// A provider-declared hold wins over local window math: the provider
+		// named its own reset clock, so wait it out before dispatching anything.
+		const holdUntil = st.rateLimitedUntil ? Date.parse(st.rateLimitedUntil) : Number.NaN;
+		if (Number.isFinite(holdUntil) && holdUntil > now) {
+			armResumeTimer(holdUntil);
+			return;
+		}
+		if (st.rateLimitedUntil) {
+			st.rateLimitedUntil = null;
+			saveState();
+		}
+		// Provider-aware gating: only a gated profile (Anthropic Claude
+		// subscription windows) can block dispatch; unlimited profiles skip
+		// window bookkeeping entirely.
+		const quota = currentQuota(null);
+		if (quota.limits !== null) {
+			const verdict = quotaCheck(st, quota.key, quota.limits, now);
+			if (!verdict.ok) {
+				const resumeAt = (verdict.nextAt ?? now + HOUR_MS) + cfg.windowSlackMs;
+				logEvent({ event: "blocked", detail: verdict.reason, resumeAt: new Date(resumeAt).toISOString() });
+				notify(null, `scheduler: ${verdict.reason}; auto-resuming at ${fmtClock(resumeAt)}.`, "warning");
+				armResumeTimer(resumeAt);
+				return;
+			}
+		}
+
+		const resuming = task.status === "interrupted";
+		task.status = "running";
+		task.attempts += 1;
+		task.dispatchedAt = new Date(now).toISOString();
+		st.currentTaskId = task.id;
+		emptyQueueNotified = false;
+		saveState();
+		logEvent({ event: "dispatch", taskId: task.id, attempt: task.attempts, resumed: resuming });
+
+		const parts = [cfg.promptPreamble.trim()];
+		if (resuming) parts.push(cfg.resumePreamble.trim());
+		parts.push(task.prompt);
+		try {
+			// extensions.md § "Message delivery semantics":
+			// "pi.sendUserMessage(content, { deliverAs }) always goes through
+			// prompt flow" — when the agent is idle this starts a turn.
+			pi.sendUserMessage(parts.filter(Boolean).join("\n\n"));
+			notify(null, `scheduler: dispatched ${task.id}${resuming ? " (resume)" : ""} — ${truncate(task.prompt, 60)}`);
+		} catch (err) {
+			task.status = "interrupted";
+			task.lastError = `dispatch failed: ${String(err)}`;
+			st.currentTaskId = null;
+			saveState();
+			logEvent({ event: "end", taskId: task.id, status: "interrupted", error: task.lastError });
+			scheduleDispatch(30_000);
+		}
+		updateStatus();
+	}
+
+	function settleCurrentTask(error: string | null, refundAttempt = false): void {
+		const st = getState();
+		if (st.currentTaskId === null) return;
+		const task = st.tasks.find(t => t.id === st.currentTaskId);
+		st.currentTaskId = null;
+		if (task) {
+			task.endedAt = new Date().toISOString();
+			const durationMs = task.dispatchedAt ? Date.now() - Date.parse(task.dispatchedAt) : undefined;
+			if (error) {
+				task.lastError = error;
+				if (refundAttempt) {
+					// Rate limits and outages are not the task's fault: refund
+					// the attempt so they can never exhaust maxAttempts.
+					task.attempts = Math.max(0, task.attempts - 1);
+					task.status = "interrupted";
+				} else {
+					task.status = task.attempts >= cfg.maxAttempts ? "failed" : "interrupted";
+					notify(
+						null,
+						task.status === "failed"
+							? `scheduler: ${task.id} FAILED after ${task.attempts} attempts (${truncate(error, 80)}) — /scheduler retry ${task.id} to re-queue.`
+							: `scheduler: ${task.id} interrupted (${truncate(error, 80)}) — will resume, attempt ${task.attempts}/${cfg.maxAttempts}.`,
+						"warning",
+					);
+				}
+			} else {
+				task.status = "done";
+				notify(null, `scheduler: ${task.id} done — ${truncate(task.prompt, 60)}`);
+			}
+			logEvent({ event: "end", taskId: task.id, status: task.status, error: error ?? undefined, durationMs });
+		}
+		saveState();
+	}
+
+	// ---- events ----------------------------------------------------------------
+	// Event names below are from extensions.md § "Event surface".
+
+	pi.on("session_start", async (_event, ctx) => {
+		liveCtx = ctx as unknown as CtxLike;
+		ensureDataDir();
+		loadConfig();
+		const st = getState();
+		// Crash/restart recovery: a task left "running" by a previous process
+		// was interrupted mid-flight — resume it, don't skip it.
+		if (st.currentTaskId !== null) {
+			const task = st.tasks.find(t => t.id === st.currentTaskId);
+			if (task && task.status === "running") {
+				task.status = "interrupted";
+				task.lastError = "process restarted mid-task";
+				task.endedAt = new Date().toISOString();
+				logEvent({ event: "recovered", taskId: task.id, status: "interrupted" });
+			}
+			st.currentTaskId = null;
+			saveState();
+		}
+		startWatchdog();
+		if (st.run === "running") {
+			const pending = st.tasks.filter(t => t.status === "queued" || t.status === "interrupted").length;
+			notify(ctx as unknown as CtxLike, `scheduler: active — ${pending} task(s) pending. /scheduler stop to halt.`);
+			scheduleDispatch(cfg.dispatchDelayMs);
+		}
+		updateStatus();
+	});
+
+	pi.on("agent_start", async (_event, ctx) => {
+		liveCtx = ctx as unknown as CtxLike;
+		agentActive = true;
+		// Window accounting: ANY agent turn (scheduled or typed manually)
+		// consumes the provider session window, so a new local window record
+		// starts whenever a turn begins outside an active one — but only for
+		// gated profiles; unlimited providers record no windows at all.
+		const quota = currentQuota(liveCtx);
+		if (quota.limits === null) return;
+		const st = getState();
+		const now = Date.now();
+		if (activeWindowStart(st, quota.key, quota.limits.sessionHours, now) === null) {
+			st.windows.push({ startedAt: new Date(now).toISOString(), profile: quota.key });
+			pruneWindows(st, now);
+			saveState();
+			logEvent({
+				event: "window_start",
+				detail: `${windowStartsInLast24h(st, quota.key, now).length}/${quota.limits.maxSessionsPer24h} in last 24h (profile "${quota.key}")`,
+			});
+		}
+	});
+
+	pi.on("agent_end", async (event, ctx) => {
+		liveCtx = ctx as unknown as CtxLike;
+		agentActive = false;
+		const fromRetryExhaustion = retryFailure !== null;
+		const error = retryFailure ?? detectTurnError(event);
+		retryFailure = null;
+		const waitMs = error === null ? null : parseRetryAfterMs(error);
+		const rateLimited =
+			error !== null && (waitMs !== null || (fromRetryExhaustion && /rate.?limit|\b429\b|quota/i.test(error)));
+		const outage = !rateLimited && error !== null && fromRetryExhaustion && isTransientNetworkError(error);
+		// A user abort of a *scheduled* turn means the human wants the seat:
+		// pause the queue instead of fighting them for the next turn.
+		const userAbort =
+			!rateLimited && !outage && error !== null && /\baborted\b/i.test(error) && getState().currentTaskId !== null;
+		settleCurrentTask(error, rateLimited || outage || userAbort);
+		const st = getState();
+		if (rateLimited) {
+			// Trust the provider's own reset clock over local window math and
+			// hold ALL dispatch until then — immediate retries only burn attempts.
+			outageStreak = 0;
+			const resumeAt = Date.now() + (waitMs ?? HOUR_MS) + cfg.windowSlackMs;
+			st.rateLimitedUntil = new Date(resumeAt).toISOString();
+			saveState();
+			logEvent({ event: "blocked", detail: "provider rate limit", resumeAt: st.rateLimitedUntil });
+			notify(
+				null,
+				`scheduler: provider rate-limited — holding dispatch until ${fmtClock(resumeAt)} (${fmtDuration(resumeAt - Date.now())}).`,
+				"warning",
+			);
+			if (st.run === "running") armResumeTimer(resumeAt);
+		} else if (outage) {
+			// Connectivity is down; back off exponentially and probe forever —
+			// an overnight outage must resume work, not fail the queue.
+			outageStreak += 1;
+			const backoff = Math.min(cfg.outageBackoffBaseMs * 2 ** (outageStreak - 1), cfg.outageBackoffMaxMs);
+			const resumeAt = Date.now() + backoff;
+			logEvent({
+				event: "blocked",
+				detail: `network/provider outage #${outageStreak}`,
+				resumeAt: new Date(resumeAt).toISOString(),
+			});
+			notify(
+				null,
+				`scheduler: provider unreachable — retrying in ${fmtDuration(backoff)} (outage #${outageStreak}, attempt not counted).`,
+				"warning",
+			);
+			if (st.run === "running") armResumeTimer(resumeAt);
+		} else if (userAbort) {
+			st.run = "paused";
+			saveState();
+			clearTimers();
+			logEvent({ event: "pause", detail: "user aborted the in-flight scheduled task" });
+			notify(
+				null,
+				"scheduler: turn aborted by user — queue paused, task kept as interrupted (attempt not counted). /scheduler start to resume.",
+				"warning",
+			);
+		} else {
+			outageStreak = 0;
+			if (st.rateLimitedUntil) {
+				// A turn ended without a rate limit: the provider is healthy again.
+				st.rateLimitedUntil = null;
+				saveState();
+			}
+			if (st.run === "running") scheduleDispatch(cfg.dispatchDelayMs);
+		}
+		updateStatus();
+	});
+
+	// extensions.md § "Reliability/runtime signals": auto_retry_start / auto_retry_end.
+	// Payload shape is not part of the documented contract → defensive reads only.
+	pi.on("auto_retry_end", async event => {
+		const ev = event as unknown as Record<string, unknown> | null | undefined;
+		if (ev && ev.success === false) {
+			retryFailure =
+				typeof ev.error === "string" && ev.error ? ev.error : "provider retries exhausted (rate limit or outage)";
+			logEvent({ event: "retry_failed", taskId: getState().currentTaskId ?? undefined, error: retryFailure });
+		}
+	});
+
+	pi.on("session_shutdown", async () => {
+		// Persist in-flight work as interrupted so the next launch resumes it.
+		const st = getState();
+		if (st.currentTaskId !== null) {
+			const task = st.tasks.find(t => t.id === st.currentTaskId);
+			if (task && task.status === "running") {
+				task.status = "interrupted";
+				task.lastError = "session shutdown mid-task";
+				task.endedAt = new Date().toISOString();
+				logEvent({ event: "recovered", taskId: task.id, status: "interrupted", detail: "session_shutdown" });
+			}
+			st.currentTaskId = null;
+			saveState();
+		}
+		clearTimers();
+		stopWatchdog();
+	});
+
+	// ---- command -----------------------------------------------------------
+	// pi.registerCommand — authoring-extensions.md § "Registering commands".
+	pi.registerCommand("scheduler", {
+		description:
+			"Quota-aware prompt queue: add|add-file|list|status|start|pause|stop|remove|retry|clear|export|log|config",
+		handler: async (args, ctx) => {
+			const cctx = ctx as unknown as CtxLike;
+			liveCtx = cctx;
+			loadConfig();
+			const trimmed = (args ?? "").trim();
+			const space = trimmed.search(/\s/);
+			const sub = (space === -1 ? trimmed : trimmed.slice(0, space)).toLowerCase();
+			const rest = space === -1 ? "" : trimmed.slice(space + 1).trim();
+
+			switch (sub) {
+				case "add":
+					return cmdAdd(cctx, rest, undefined);
+				case "add-file":
+					return cmdAddFile(cctx, rest);
+				case "list":
+				case "status":
+					return cmdStatus(cctx);
+				case "start":
+					return cmdStart(cctx);
+				case "pause":
+					return cmdPause(cctx);
+				case "stop":
+					return cmdStop(cctx);
+				case "remove":
+					return cmdRemove(cctx, rest);
+				case "retry":
+					return cmdRetry(cctx, rest);
+				case "clear":
+					return cmdClear(cctx);
+				case "export":
+					return cmdExport(cctx, rest);
+				case "log":
+					return cmdLog(cctx, rest);
+				case "config":
+					return cmdConfig(cctx);
+				default:
+					notify(
+						cctx,
+						[
+							"scheduler — session-quota-aware prompt queue",
+							"  /scheduler add <prompt>      queue a task",
+							"  /scheduler add-file <path>   queue a task from a file",
+							"  /scheduler list | status     queue + session-window state",
+							"  /scheduler start             begin draining the queue when idle",
+							"  /scheduler pause             finish current task, then hold",
+							"  /scheduler stop              abort current task and hold",
+							"  /scheduler remove <id>       remove one task",
+							"  /scheduler retry [id]        re-queue failed task(s) with a fresh attempt budget",
+							"  /scheduler clear             remove all pending tasks",
+							"  /scheduler export [path]     write the queue to a markdown file (default scheduler-queue.md)",
+							"  /scheduler log [n]           show last n log entries (default 10)",
+							"  /scheduler config            show config file path + values",
+						].join("\n"),
+					);
+			}
+		},
+	});
+
+	// ---- subcommand implementations -----------------------------------------
+
+	function cmdAdd(ctx: CtxLike, prompt: string, sourceFile: string | undefined): void {
+		if (!prompt) {
+			notify(ctx, "scheduler: usage — /scheduler add <prompt>", "warning");
+			return;
+		}
+		const st = getState();
+		const task: SchedulerTask = {
+			id: `t${st.nextTaskSeq++}`,
+			prompt,
+			sourceFile,
+			status: "queued",
+			addedAt: new Date().toISOString(),
+			attempts: 0,
+		};
+		st.tasks.push(task);
+		emptyQueueNotified = false;
+		saveState();
+		notify(
+			ctx,
+			`scheduler: queued ${task.id} — ${truncate(prompt, 60)}${st.run === "stopped" ? " (scheduler stopped; /scheduler start to begin)" : ""}`,
+		);
+		if (st.run === "running") scheduleDispatch(cfg.dispatchDelayMs);
+		updateStatus();
+	}
+
+	function cmdAddFile(ctx: CtxLike, fileArg: string): void {
+		if (!fileArg) {
+			notify(ctx, "scheduler: usage — /scheduler add-file <path>", "warning");
+			return;
+		}
+		// ctx.cwd — extensions.md § "2) Handler context".
+		const resolved = path.isAbsolute(fileArg) ? fileArg : path.join(ctx.cwd, fileArg);
+		let content: string;
+		try {
+			content = fs.readFileSync(resolved, "utf8").trim();
+		} catch (err) {
+			notify(ctx, `scheduler: cannot read ${resolved}: ${String(err)}`, "error");
+			return;
+		}
+		if (!content) {
+			notify(ctx, `scheduler: ${resolved} is empty`, "warning");
+			return;
+		}
+		cmdAdd(ctx, content, resolved);
+	}
+
+	function cmdStatus(ctx: CtxLike): void {
+		const st = getState();
+		const now = Date.now();
+		const lines: string[] = [];
+		lines.push(`scheduler: ${st.run}`);
+
+		// Detected model + applied quota profile, e.g.
+		// "model: anthropic/claude-fable-5 — quota: 5h×4 (anthropic)".
+		const quota = currentQuota(ctx);
+		const modelName = quota.detected
+			? quota.provider && quota.modelId
+				? `${quota.provider}/${quota.modelId}`
+				: quota.provider || quota.modelId
+			: "unknown";
+		const providerLabel = quota.detected ? quota.provider || quota.modelId : "unknown provider";
+		lines.push(
+			quota.limits
+				? `model: ${modelName} — quota: ${quota.limits.sessionHours}h×${quota.limits.maxSessionsPer24h} (${providerLabel})`
+				: `model: ${modelName} — quota: none (${providerLabel})`,
+		);
+
+		if (quota.limits === null) {
+			lines.push("windows: not tracked (unlimited profile)");
+		} else {
+			const used = windowStartsInLast24h(st, quota.key, now);
+			const active = activeWindowStart(st, quota.key, quota.limits.sessionHours, now);
+			let windowLine = `windows: ${used.length}/${quota.limits.maxSessionsPer24h} used in last 24h`;
+			if (active !== null) {
+				windowLine += `; active window ends in ${fmtDuration(active + quota.limits.sessionHours * HOUR_MS - now)}`;
+			} else if (used.length >= quota.limits.maxSessionsPer24h) {
+				windowLine += `; next window at ${fmtClock(used[0] + DAY_MS)}`;
+			} else {
+				windowLine += "; a new window starts with the next prompt";
+			}
+			lines.push(windowLine);
+		}
+
+		const holdUntil = st.rateLimitedUntil ? Date.parse(st.rateLimitedUntil) : Number.NaN;
+		if (Number.isFinite(holdUntil) && holdUntil > now) {
+			lines.push(`hold: provider rate-limited until ${fmtClock(holdUntil)} (${fmtDuration(holdUntil - now)})`);
+		}
+
+		const current = st.currentTaskId ? st.tasks.find(t => t.id === st.currentTaskId) : undefined;
+		lines.push(
+			current
+				? `current: ${current.id} (attempt ${current.attempts}) — ${truncate(current.prompt, 60)}`
+				: "current: none",
+		);
+
+		const pending = st.tasks.filter(t => t.status === "queued" || t.status === "interrupted");
+		if (pending.length === 0) {
+			lines.push("queue: empty");
+		} else {
+			lines.push("queue:");
+			for (const t of pending) {
+				const extra =
+					t.status === "interrupted"
+						? ` (attempt ${t.attempts}, ${truncate(t.lastError ?? "interrupted", 40)})`
+						: "";
+				lines.push(`  ${t.id}  ${t.status.padEnd(11)} ${truncate(t.prompt, 56)}${extra}`);
+			}
+		}
+		const done = st.tasks.filter(t => t.status === "done").length;
+		const failed = st.tasks.filter(t => t.status === "failed").length;
+		if (done + failed > 0) lines.push(`finished: ${done} done, ${failed} failed (/scheduler log for details)`);
+
+		// ctx.getContextUsage() — extensions.md § "2) Handler context"; payload
+		// mirrors rpc.md § "get_state" contextUsage {tokens, contextWindow, percent}.
+		const usage = ctx.getContextUsage?.();
+		if (usage)
+			lines.push(`context: ${Math.round(usage.percent)}% of ${Math.round(usage.contextWindow / 1000)}k tokens`);
+
+		notify(ctx, lines.join("\n"));
+	}
+
+	async function cmdStart(ctx: CtxLike): Promise<void> {
+		const st = getState();
+		if (st.run === "running") {
+			notify(ctx, "scheduler: already running");
+			return;
+		}
+		// Permissions upfront: unattended tasks must never block on approval
+		// prompts. approval-mode.md § "Modes": only `yolo` auto-approves all
+		// tiers; `--yolo`/`--auto-approve` force it per session.
+		const mode = detectApprovalMode(ctx.cwd);
+		if (mode && mode !== "yolo") {
+			const warning =
+				`tools.approvalMode is "${mode}" (not "yolo"): overnight tasks WILL stall on approval prompts. ` +
+				`Fix: relaunch with --yolo, or run: omp config set tools.approvalMode yolo. ` +
+				`(If you launched with --yolo just now, this check cannot see runtime flags.)`;
+			if (ctx.hasUI) {
+				let proceed = false;
+				try {
+					// ctx.ui.confirm — extensions.md § "UI integration points" (dialogs).
+					proceed = await ctx.ui.confirm("scheduler: approval mode warning", `${warning}\n\nStart anyway?`);
+				} catch {
+					notify(ctx, `scheduler WARNING: ${warning}`, "warning");
+					proceed = true; // dialog unsupported in this mode — warn and continue
+				}
+				if (!proceed) {
+					notify(ctx, "scheduler: start cancelled");
+					return;
+				}
+			} else {
+				notify(ctx, `scheduler WARNING: ${warning}`, "warning");
+			}
+		}
+		st.run = "running";
+		emptyQueueNotified = false;
+		saveState();
+		logEvent({ event: "start" });
+		const pending = st.tasks.filter(t => t.status === "queued" || t.status === "interrupted").length;
+		notify(ctx, `scheduler: running — ${pending} task(s) pending; dispatching when idle.`);
+		scheduleDispatch(500);
+		updateStatus();
+	}
+
+	function cmdPause(ctx: CtxLike): void {
+		const st = getState();
+		if (st.run !== "running") {
+			notify(ctx, `scheduler: not running (state: ${st.run})`);
+			return;
+		}
+		st.run = "paused";
+		saveState();
+		clearTimers();
+		logEvent({ event: "pause" });
+		notify(ctx, st.currentTaskId ? "scheduler: paused — current task will finish, then hold." : "scheduler: paused.");
+		updateStatus();
+	}
+
+	async function cmdStop(ctx: CtxLike): Promise<void> {
+		const st = getState();
+		clearTimers();
+		const hadCurrent = st.currentTaskId !== null;
+		if (hadCurrent) {
+			const task = st.tasks.find(t => t.id === st.currentTaskId);
+			if (task) {
+				// Stop aborts the in-flight task but keeps it resumable
+				// (resume-not-skip): it stays at the head of the queue as
+				// "interrupted" for the next /scheduler start.
+				task.status = "interrupted";
+				task.lastError = "stopped by user";
+				task.endedAt = new Date().toISOString();
+				logEvent({ event: "end", taskId: task.id, status: "interrupted", error: task.lastError });
+			}
+			st.currentTaskId = null;
+		}
+		st.run = "stopped";
+		saveState();
+		logEvent({ event: "stop" });
+		if (hadCurrent) {
+			try {
+				// ctx.abort() — extensions.md § "2) Handler context".
+				await ctx.abort();
+			} catch {
+				/* nothing streaming */
+			}
+		}
+		notify(
+			ctx,
+			hadCurrent ? "scheduler: stopped — current task aborted (kept as interrupted)." : "scheduler: stopped.",
+		);
+		updateStatus();
+	}
+
+	function cmdRemove(ctx: CtxLike, id: string): void {
+		if (!id) {
+			notify(ctx, "scheduler: usage — /scheduler remove <id>", "warning");
+			return;
+		}
+		const st = getState();
+		const idx = st.tasks.findIndex(t => t.id === id);
+		if (idx === -1) {
+			notify(ctx, `scheduler: no task ${id}`, "warning");
+			return;
+		}
+		if (st.currentTaskId === id) {
+			notify(ctx, `scheduler: ${id} is in flight — /scheduler stop first`, "warning");
+			return;
+		}
+		st.tasks.splice(idx, 1);
+		saveState();
+		notify(ctx, `scheduler: removed ${id}`);
+		updateStatus();
+	}
+
+	function cmdRetry(ctx: CtxLike, id: string): void {
+		const st = getState();
+		const targets = st.tasks.filter(t => t.status === "failed" && (!id || t.id === id));
+		if (targets.length === 0) {
+			notify(ctx, id ? `scheduler: no failed task ${id}` : "scheduler: no failed tasks to retry", "warning");
+			return;
+		}
+		for (const t of targets) {
+			// Back to "interrupted", not "queued": the task already ran
+			// partially, so the resume preamble applies on re-dispatch.
+			t.status = "interrupted";
+			t.attempts = 0;
+			logEvent({ event: "notice", taskId: t.id, detail: "failed task re-queued via /scheduler retry" });
+		}
+		emptyQueueNotified = false;
+		saveState();
+		notify(
+			ctx,
+			`scheduler: re-queued ${targets.map(t => t.id).join(", ")}${st.run === "running" ? "" : " (scheduler stopped; /scheduler start to begin)"}`,
+		);
+		if (st.run === "running") scheduleDispatch(cfg.dispatchDelayMs);
+		updateStatus();
+	}
+
+	function cmdClear(ctx: CtxLike): void {
+		const st = getState();
+		const before = st.tasks.length;
+		st.tasks = st.tasks.filter(t => t.id === st.currentTaskId);
+		saveState();
+		notify(
+			ctx,
+			`scheduler: cleared ${before - st.tasks.length} task(s)${st.currentTaskId ? " (in-flight task kept; /scheduler stop to abort it)" : ""}`,
+		);
+		updateStatus();
+	}
+
+	function cmdLog(ctx: CtxLike, arg: string): void {
+		const n = Math.max(1, Math.min(100, Number.parseInt(arg, 10) || 10));
+		const entries = readLogTail(n);
+		if (entries.length === 0) {
+			notify(ctx, `scheduler: log empty (${logFile()})`);
+			return;
+		}
+		const lines = entries.map(e => {
+			const bits = [e.ts.replace("T", " ").slice(0, 19), e.event];
+			if (e.taskId) bits.push(e.taskId);
+			if (e.status) bits.push(e.status);
+			if (e.attempt !== undefined) bits.push(`attempt=${e.attempt}`);
+			if (e.durationMs !== undefined) bits.push(`took=${fmtDuration(e.durationMs)}`);
+			if (e.resumeAt) bits.push(`resumeAt=${e.resumeAt}`);
+			if (e.error) bits.push(`error=${truncate(e.error, 60)}`);
+			if (e.detail) bits.push(e.detail);
+			return `  ${bits.join("  ")}`;
+		});
+		notify(ctx, [`scheduler: last ${entries.length} log entries (${logFile()}):`, ...lines].join("\n"));
+	}
+
+	/**
+	 * Human-workable escape hatch: dump every task (any status) to markdown so
+	 * the queue survives outside the harness — the user can re-run prompts by
+	 * hand, edit them, or re-import via /scheduler add-file.
+	 */
+	function cmdExport(ctx: CtxLike, fileArg: string): void {
+		const st = getState();
+		const resolved = fileArg
+			? path.isAbsolute(fileArg)
+				? fileArg
+				: path.join(ctx.cwd, fileArg)
+			: path.join(ctx.cwd, "scheduler-queue.md");
+		const lines: string[] = [
+			"# scheduler queue export",
+			"",
+			`- exported: ${new Date().toISOString()}`,
+			`- state file: ${stateFile()}`,
+			`- run mode: ${st.run}`,
+			"",
+		];
+		if (st.tasks.length === 0) lines.push("_queue empty_", "");
+		for (const t of st.tasks) {
+			lines.push(`## ${t.id} — ${t.status}`, "");
+			lines.push(`- added: ${t.addedAt}  attempts: ${t.attempts}${t.sourceFile ? `  source: ${t.sourceFile}` : ""}`);
+			if (t.lastError) lines.push(`- last error: ${truncate(t.lastError, 200)}`);
+			lines.push("", "```text", t.prompt, "```", "");
+		}
+		try {
+			fs.writeFileSync(resolved, `${lines.join("\n")}\n`, "utf8");
+		} catch (err) {
+			notify(ctx, `scheduler: export failed: ${String(err)}`, "error");
+			return;
+		}
+		logEvent({ event: "notice", detail: `queue exported to ${resolved}` });
+		notify(ctx, `scheduler: exported ${st.tasks.length} task(s) → ${resolved}`);
+	}
+
+	function cmdConfig(ctx: CtxLike): void {
+		loadConfig();
+		const profiles = cfg.quotaProfiles.map(p => {
+			const policy =
+				typeof p.sessionHours === "number" && typeof p.maxSessionsPer24h === "number"
+					? `${p.sessionHours}h×${p.maxSessionsPer24h}`
+					: "unlimited";
+			return `    ${p.match} → ${policy}`;
+		});
+		notify(
+			ctx,
+			[
+				`scheduler: config file — ${configFile()}`,
+				"  quotaProfiles (first match on provider/model wins):",
+				...profiles,
+				`  maxAttempts: ${cfg.maxAttempts}`,
+				`  dispatchDelayMs: ${cfg.dispatchDelayMs}`,
+				`  outageBackoff: ${fmtDuration(cfg.outageBackoffBaseMs)} … ${fmtDuration(cfg.outageBackoffMaxMs)} (doubling)`,
+				`  watchdog: every ${fmtDuration(cfg.watchdogIntervalMs)}, stall timeout ${fmtDuration(cfg.stallTimeoutMs)}`,
+				`  windowSlackMs: ${cfg.windowSlackMs}`,
+				`  promptPreamble: ${truncate(cfg.promptPreamble, 70)}`,
+				`  resumePreamble: ${truncate(cfg.resumePreamble, 70)}`,
+				"edit the file, then re-run /scheduler start (config reloads on start and session start)",
+			].join("\n"),
+		);
+	}
+}

--- a/packages/scheduler-extension/test/smoke.ts
+++ b/packages/scheduler-extension/test/smoke.ts
@@ -1,0 +1,711 @@
+/**
+ * Behavioral smoke test for the scheduler extension.
+ *
+ * Run with: bun test/smoke.ts
+ *
+ * Drives the extension through a mocked ExtensionAPI: queue → start →
+ * dispatch → success, interruption → resume preamble, window-quota blocking,
+ * stop, crash recovery via a second extension instance, and model awareness
+ * (anthropic gated, other providers ungated, unknown provider ungated with a
+ * notice). Uses a throwaway PI_CODING_AGENT_DIR so no real user data is
+ * touched.
+ */
+
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent";
+import type { SchedulerConfig, SchedulerState } from "../src/extension";
+import schedulerExtension from "../src/extension";
+
+/** Model exposed through the mocked ctx (shape per extensions.md "provider/id"). */
+interface MockModel {
+	provider: string;
+	id: string;
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+type EventHandler = (event: unknown, ctx: unknown) => Promise<unknown> | unknown;
+type CommandHandler = (args: string, ctx: unknown) => Promise<void> | void;
+
+interface MockPi {
+	api: ExtensionAPI;
+	emit(event: string, payload: unknown, ctx: unknown): Promise<void>;
+	command(args: string, ctx: unknown): Promise<void>;
+	sentPrompts: string[];
+}
+
+function makeMockPi(): MockPi {
+	const handlers = new Map<string, EventHandler[]>();
+	let commandHandler: CommandHandler | null = null;
+	const sentPrompts: string[] = [];
+	const raw = {
+		setLabel(_label: string) {},
+		logger: { warn(_msg: string) {}, info(_msg: string) {} },
+		on(event: string, handler: EventHandler) {
+			const list = handlers.get(event) ?? [];
+			list.push(handler);
+			handlers.set(event, list);
+		},
+		registerCommand(_name: string, def: { description: string; handler: CommandHandler }) {
+			commandHandler = def.handler;
+		},
+		sendUserMessage(content: string) {
+			sentPrompts.push(content);
+		},
+	};
+	return {
+		api: raw as unknown as ExtensionAPI,
+		async emit(event, payload, ctx) {
+			for (const handler of handlers.get(event) ?? []) await handler(payload, ctx);
+		},
+		async command(args, ctx) {
+			assert.ok(commandHandler, "command not registered");
+			await commandHandler(args, ctx);
+		},
+		sentPrompts,
+	};
+}
+
+interface MockCtx {
+	ui: {
+		notify(message: string, level?: string): void;
+		confirm(title: string, message: string): Promise<boolean>;
+		setStatus(key: string, text: string): void;
+	};
+	hasUI: boolean;
+	cwd: string;
+	models: { current(): MockModel | undefined };
+	isIdle(): boolean;
+	hasPendingMessages(): boolean;
+	abort(): void;
+	getContextUsage(): undefined;
+	notifications: string[];
+	confirmCalls: number;
+}
+
+/**
+ * `model` is what ctx.models.current() returns: default is a Claude
+ * subscription model (gated by the default quota profile); pass another
+ * provider to exercise ungated dispatch, or null for an undetectable model.
+ */
+function makeCtx(cwd: string, model: MockModel | null = { provider: "anthropic", id: "claude-fable-5" }): MockCtx {
+	const ctx: MockCtx = {
+		notifications: [],
+		confirmCalls: 0,
+		ui: {
+			notify(message) {
+				ctx.notifications.push(message);
+			},
+			async confirm() {
+				ctx.confirmCalls += 1;
+				return true;
+			},
+			setStatus() {},
+		},
+		hasUI: true,
+		cwd,
+		models: { current: () => model ?? undefined },
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		abort() {},
+		getContextUsage: () => undefined,
+	};
+	return ctx;
+}
+
+function sleep(ms: number): Promise<void> {
+	const { promise, resolve } = Promise.withResolvers<void>();
+	setTimeout(resolve, ms);
+	return promise;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario
+// ---------------------------------------------------------------------------
+
+const tmpAgentDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-scheduler-smoke-"));
+process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
+const tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), "omp-scheduler-cwd-"));
+const stateFile = path.join(tmpAgentDir, "scheduler", "state.json");
+const configFile = path.join(tmpAgentDir, "scheduler", "config.json");
+const logFile = path.join(tmpAgentDir, "scheduler", "task-log.jsonl");
+
+function readState(): SchedulerState {
+	return JSON.parse(fs.readFileSync(stateFile, "utf8")) as SchedulerState;
+}
+function task(state: SchedulerState, id: string) {
+	const found = state.tasks.find(t => t.id === id);
+	assert.ok(found, `task ${id} missing`);
+	return found;
+}
+
+const a = makeMockPi();
+const ctx = makeCtx(tmpCwd);
+schedulerExtension(a.api);
+
+// 1. session_start seeds config.json with defaults
+await a.emit("session_start", {}, ctx);
+assert.ok(fs.existsSync(configFile), "config.json seeded on session_start");
+
+// default config gates anthropic/claude at 5h×4; status shows model + profile
+await a.command("status", ctx);
+assert.match(
+	ctx.notifications.at(-1) ?? "",
+	/model: anthropic\/claude-fable-5 — quota: 5h×4 \(anthropic\)/,
+	"status shows the detected model and the gated default profile",
+);
+
+// speed the loop up and shrink windows so quota logic is exercisable:
+// sessionHours 1e-5 h = 36ms, 3 windows per rolling 24h for anthropic/claude.
+const cfg = JSON.parse(fs.readFileSync(configFile, "utf8")) as SchedulerConfig;
+cfg.dispatchDelayMs = 30;
+cfg.quotaProfiles = [
+	{ match: "anthropic|claude", sessionHours: 0.00001, maxSessionsPer24h: 3 },
+	{ match: ".*", sessionHours: null, maxSessionsPer24h: null },
+];
+fs.writeFileSync(configFile, JSON.stringify(cfg));
+
+// 2. add + status
+await a.command("add Write the CHANGELOG", ctx);
+assert.match(ctx.notifications.at(-1) ?? "", /queued t1/);
+await a.command("status", ctx);
+assert.match(ctx.notifications.at(-1) ?? "", /t1 {2}queued/);
+assert.match(ctx.notifications.at(-1) ?? "", /windows: 0\/3/);
+
+// 3. start warns (via confirm) when approvalMode is persisted non-yolo
+fs.writeFileSync(path.join(tmpAgentDir, "config.yml"), "tools:\n  approvalMode: write\n");
+await a.command("start", ctx);
+assert.equal(ctx.confirmCalls, 1, "non-yolo approval mode should trigger a confirm dialog");
+await sleep(600); // cmdStart arms a 500ms initial dispatch
+
+// 4. dispatch wraps prompt with the unattended preamble
+assert.equal(a.sentPrompts.length, 1, "one prompt dispatched");
+assert.match(a.sentPrompts[0], /no human is watching/);
+assert.match(a.sentPrompts[0], /Write the CHANGELOG/);
+assert.doesNotMatch(a.sentPrompts[0], /RESUME/);
+
+// 5. successful turn settles the task as done and records one session window
+await a.emit("agent_start", {}, ctx);
+await a.emit("agent_end", { messages: [{ role: "assistant", content: [], stopReason: "stop" }] }, ctx);
+{
+	const st = readState();
+	assert.equal(task(st, "t1").status, "done");
+	assert.equal(st.currentTaskId, null);
+	assert.equal(st.windows.length, 1, "agent_start recorded a session window");
+	assert.equal(st.windows[0].profile, "anthropic|claude", "window tagged with the profile it was tracked under");
+}
+
+// 6. failed turn marks the task interrupted, then re-dispatches with RESUME
+await a.command("add Migrate the database", ctx);
+await sleep(80);
+assert.equal(a.sentPrompts.length, 2, "t2 dispatched");
+await a.emit("agent_start", {}, ctx);
+await a.emit(
+	"agent_end",
+	{ messages: [{ role: "assistant", content: [], stopReason: "error", errorMessage: "rate limited" }] },
+	ctx,
+);
+{
+	const st = readState();
+	assert.equal(task(st, "t2").status, "interrupted");
+	assert.match(task(st, "t2").lastError ?? "", /rate limited/);
+}
+await sleep(80); // agent_end scheduled the next dispatch (30ms)
+assert.equal(a.sentPrompts.length, 3, "t2 re-dispatched");
+assert.match(a.sentPrompts[2], /RESUME/);
+assert.match(a.sentPrompts[2], /do not repeat completed work/);
+assert.match(a.sentPrompts[2], /Migrate the database/);
+await a.emit("agent_start", {}, ctx);
+await a.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctx);
+{
+	const st = readState();
+	assert.equal(task(st, "t2").status, "done");
+	assert.equal(task(st, "t2").attempts, 2);
+}
+
+// 7. quota exhausted for the gated anthropic profile (3 windows used, none
+// active) blocks dispatch + arms resume timer
+await sleep(50); // let the 36ms window expire
+await a.command("add Third task", ctx);
+await sleep(80);
+assert.equal(a.sentPrompts.length, 3, "t3 must NOT dispatch while quota is exhausted");
+assert.ok(
+	ctx.notifications.some(n => n.includes("auto-resuming at")),
+	"blocked notification announces auto-resume time",
+);
+{
+	const st = readState();
+	assert.equal(task(st, "t3").status, "queued");
+}
+
+// 8. stop clears timers and holds
+await a.command("stop", ctx);
+{
+	const st = readState();
+	assert.equal(st.run, "stopped");
+}
+
+// 9. log shows JSONL entries; remove/clear manage the queue
+await a.command("log 20", ctx);
+assert.match(ctx.notifications.at(-1) ?? "", /log entries/);
+assert.match(ctx.notifications.at(-1) ?? "", /dispatch/);
+assert.match(ctx.notifications.at(-1) ?? "", /blocked/);
+for (const line of fs.readFileSync(logFile, "utf8").split("\n").filter(Boolean)) {
+	JSON.parse(line); // every log line is valid JSON
+}
+await a.command("remove t3", ctx);
+assert.equal(
+	readState().tasks.some(t => t.id === "t3"),
+	false,
+);
+await a.command("clear", ctx);
+
+// 10. crash recovery: a fresh instance finds a task left "running" by a dead
+// process, marks it interrupted, and (run=running) resumes it with the preamble.
+{
+	const st = readState();
+	st.run = "running";
+	st.currentTaskId = "t9";
+	st.windows = []; // fresh quota for the new "day"
+	st.tasks = [
+		{
+			id: "t9",
+			prompt: "Port the parser to Rust",
+			status: "running",
+			addedAt: new Date().toISOString(),
+			dispatchedAt: new Date().toISOString(),
+			attempts: 1,
+		},
+	];
+	st.nextTaskSeq = 10;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const b = makeMockPi();
+const ctxB = makeCtx(tmpCwd);
+schedulerExtension(b.api);
+await b.emit("session_start", {}, ctxB);
+{
+	const st = readState();
+	assert.equal(task(st, "t9").status, "interrupted", "in-flight task recovered as interrupted");
+	assert.equal(st.currentTaskId, null);
+}
+assert.ok(
+	ctxB.notifications.some(n => n.includes("active") && n.includes("1 task(s) pending")),
+	"restart announces the active scheduler",
+);
+await sleep(80); // session_start scheduled dispatch (dispatchDelayMs=30)
+assert.equal(b.sentPrompts.length, 1, "recovered task re-dispatched after restart");
+assert.match(b.sentPrompts[0], /RESUME/);
+assert.match(b.sentPrompts[0], /Port the parser to Rust/);
+await b.emit("agent_start", {}, ctxB);
+await b.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctxB);
+assert.equal(task(readState(), "t9").status, "done");
+await sleep(50);
+await b.command("stop", ctxB); // clear timers so the process can exit
+
+// 11. model awareness: a non-matching provider dispatches ungated even when
+// the anthropic quota is exhausted, and records no windows of its own.
+{
+	const st = readState();
+	st.run = "running";
+	st.currentTaskId = null;
+	st.tasks = [
+		{
+			id: "t20",
+			prompt: "Summarize the release notes",
+			status: "queued",
+			addedAt: new Date().toISOString(),
+			attempts: 0,
+		},
+	];
+	st.windows = [
+		// anthropic quota fully used within the rolling 24h (windows expired 36ms after start)
+		{ startedAt: new Date(Date.now() - 60_000).toISOString(), profile: "anthropic|claude" },
+		{ startedAt: new Date(Date.now() - 40_000).toISOString(), profile: "anthropic|claude" },
+		{ startedAt: new Date(Date.now() - 20_000).toISOString(), profile: "anthropic|claude" },
+	];
+	st.nextTaskSeq = 21;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const c = makeMockPi();
+const ctxC = makeCtx(tmpCwd, { provider: "openai", id: "gpt-5" });
+schedulerExtension(c.api);
+await c.emit("session_start", {}, ctxC);
+await sleep(80);
+assert.equal(c.sentPrompts.length, 1, "openai model dispatches despite exhausted anthropic quota");
+assert.match(c.sentPrompts[0], /Summarize the release notes/);
+await c.command("status", ctxC);
+{
+	const statusOut = ctxC.notifications.at(-1) ?? "";
+	assert.match(statusOut, /model: openai\/gpt-5 — quota: none \(openai\)/, "status shows the ungated provider");
+	assert.match(statusOut, /windows: not tracked \(unlimited profile\)/);
+}
+await c.emit("agent_start", {}, ctxC);
+{
+	const st = readState();
+	assert.equal(st.windows.length, 3, "unlimited profile records no session windows");
+	assert.ok(
+		st.windows.every(w => w.profile === "anthropic|claude"),
+		"anthropic window records untouched",
+	);
+}
+await c.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctxC);
+assert.equal(task(readState(), "t20").status, "done");
+await sleep(50);
+await c.command("stop", ctxC);
+
+// 12. unknown provider: no detectable model → ungated dispatch + notice log
+{
+	const st = readState();
+	st.run = "running";
+	st.tasks = [
+		{
+			id: "t30",
+			prompt: "Rebuild the search index",
+			status: "queued",
+			addedAt: new Date().toISOString(),
+			attempts: 0,
+		},
+	];
+	st.nextTaskSeq = 31;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const d = makeMockPi();
+const ctxD = makeCtx(tmpCwd, null); // ctx exposes no readable model at all
+schedulerExtension(d.api);
+await d.emit("session_start", {}, ctxD);
+await sleep(80);
+assert.equal(d.sentPrompts.length, 1, "unknown provider dispatches ungated");
+assert.match(d.sentPrompts[0], /Rebuild the search index/);
+assert.ok(
+	ctxD.notifications.some(n => n.includes("provider/model unknown")),
+	"unknown provider announces ungated dispatch",
+);
+assert.ok(
+	fs
+		.readFileSync(logFile, "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map(line => JSON.parse(line) as { event: string; detail?: string })
+		.some(e => e.event === "notice" && (e.detail ?? "").includes("not detectable")),
+	"a notice line is logged for the undetectable provider/model",
+);
+await d.command("status", ctxD);
+assert.match(ctxD.notifications.at(-1) ?? "", /model: unknown — quota: none \(unknown provider\)/);
+await d.emit("agent_start", {}, ctxD);
+assert.equal(readState().windows.length, 3, "no window recorded for an unknown provider");
+await d.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctxD);
+assert.equal(task(readState(), "t30").status, "done");
+await sleep(50);
+await d.command("stop", ctxD);
+
+// 13. v1 state migration: legacy string windows are re-tagged to the first
+// gated profile so a mid-upgrade day keeps counting them.
+{
+	const st = readState() as unknown as { version: number; windows: unknown[] };
+	st.version = 1;
+	st.windows = [new Date(Date.now() - 60_000).toISOString()];
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const e = makeMockPi();
+const ctxE = makeCtx(tmpCwd);
+schedulerExtension(e.api);
+await e.emit("session_start", {}, ctxE);
+await e.command("status", ctxE);
+assert.match(
+	ctxE.notifications.at(-1) ?? "",
+	/windows: 1\/3 used in last 24h/,
+	"legacy v1 window string counts against the gated anthropic profile",
+);
+
+// 14. provider rate limit: retries exhausted with a retry-after → task kept
+// "interrupted" with the attempt refunded, and ALL dispatch held until the
+// provider-declared reset time (no immediate retry burn-down).
+{
+	const st = readState();
+	st.run = "running";
+	st.currentTaskId = null;
+	st.rateLimitedUntil = null;
+	st.windows = [];
+	st.tasks = [
+		{
+			id: "t40",
+			prompt: "Push the fork and raise the PR",
+			status: "queued",
+			addedAt: new Date().toISOString(),
+			attempts: 0,
+		},
+	];
+	st.nextTaskSeq = 41;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const f = makeMockPi();
+const ctxF = makeCtx(tmpCwd);
+schedulerExtension(f.api);
+await f.emit("session_start", {}, ctxF);
+await sleep(80);
+assert.equal(f.sentPrompts.length, 1, "t40 dispatched");
+await f.emit("agent_start", {}, ctxF);
+await f.emit(
+	"auto_retry_end",
+	{
+		success: false,
+		error: 'Retry failed after 1 attempts: Provider requested 120000ms wait, exceeds retry.maxDelayMs (300000ms). Original error: 429 {"type":"rate_limit_error"} retry-after-ms=120000',
+	},
+	ctxF,
+);
+await f.emit("agent_end", { messages: [{ role: "assistant", content: [], stopReason: "stop" }] }, ctxF);
+{
+	const st = readState();
+	const t40 = task(st, "t40");
+	assert.equal(t40.status, "interrupted", "rate-limited task stays interrupted, never failed");
+	assert.equal(t40.attempts, 0, "rate-limited attempt is refunded");
+	const hold = Date.parse(st.rateLimitedUntil ?? "");
+	assert.ok(Number.isFinite(hold) && hold > Date.now() + 100_000, "hold recorded from the provider retry-after");
+	assert.ok(
+		ctxF.notifications.some(n => n.includes("rate-limited — holding dispatch until")),
+		"rate-limit hold is announced",
+	);
+}
+await sleep(120);
+assert.equal(f.sentPrompts.length, 1, "no re-dispatch while the provider hold is active");
+await f.command("status", ctxF);
+assert.match(ctxF.notifications.at(-1) ?? "", /hold: provider rate-limited until/);
+await f.command("stop", ctxF); // clears the armed resume timer
+
+// 15. /scheduler retry revives a failed task (fresh attempt budget, resume
+// preamble), and an expired provider hold is cleared on the next dispatch.
+{
+	const st = readState();
+	st.run = "running";
+	st.currentTaskId = null;
+	st.rateLimitedUntil = new Date(Date.now() - 1000).toISOString(); // expired hold
+	st.windows = [];
+	st.tasks = [
+		{
+			id: "t50",
+			prompt: "Fix the merge conflicts",
+			status: "failed",
+			addedAt: new Date().toISOString(),
+			attempts: 3,
+			lastError: "provider retries exhausted (rate limit or outage)",
+		},
+	];
+	st.nextTaskSeq = 51;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const g = makeMockPi();
+const ctxG = makeCtx(tmpCwd);
+schedulerExtension(g.api);
+await g.emit("session_start", {}, ctxG);
+await sleep(80);
+assert.equal(g.sentPrompts.length, 0, "failed task is not auto-dispatched");
+await g.command("retry t50", ctxG);
+assert.match(ctxG.notifications.at(-1) ?? "", /re-queued t50/);
+{
+	const t50 = task(readState(), "t50");
+	assert.equal(t50.status, "interrupted", "retry re-queues as interrupted (resume path)");
+	assert.equal(t50.attempts, 0, "retry resets the attempt budget");
+}
+await sleep(80);
+assert.equal(g.sentPrompts.length, 1, "retried task dispatched");
+assert.match(g.sentPrompts[0], /RESUME/);
+assert.match(g.sentPrompts[0], /Fix the merge conflicts/);
+assert.equal(readState().rateLimitedUntil ?? null, null, "expired provider hold cleared on dispatch");
+await g.emit("agent_start", {}, ctxG);
+await g.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctxG);
+assert.equal(task(readState(), "t50").status, "done");
+await g.command("retry", ctxG);
+assert.match(ctxG.notifications.at(-1) ?? "", /no failed tasks to retry/);
+await sleep(50);
+await g.command("stop", ctxG);
+
+// 16. network outage: provider unreachable → attempt refunded, exponential
+// backoff armed, and the task auto-resumes once the "internet" is back.
+{
+	const c16 = JSON.parse(fs.readFileSync(configFile, "utf8")) as SchedulerConfig;
+	c16.outageBackoffBaseMs = 40; // armResumeTimer clamps to 1s minimum
+	c16.outageBackoffMaxMs = 200;
+	fs.writeFileSync(configFile, JSON.stringify(c16));
+	const st = readState();
+	st.run = "running";
+	st.currentTaskId = null;
+	st.rateLimitedUntil = null;
+	st.windows = [];
+	st.tasks = [
+		{
+			id: "t60",
+			prompt: "Count to 200, print every second",
+			status: "queued",
+			addedAt: new Date().toISOString(),
+			attempts: 0,
+		},
+	];
+	st.nextTaskSeq = 61;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const h = makeMockPi();
+const ctxH = makeCtx(tmpCwd);
+schedulerExtension(h.api);
+await h.emit("session_start", {}, ctxH);
+await sleep(80);
+assert.equal(h.sentPrompts.length, 1, "t60 dispatched");
+// internet cut: harness retries exhaust with a transport error
+await h.emit("agent_start", {}, ctxH);
+await h.emit(
+	"auto_retry_end",
+	{
+		success: false,
+		error: "Retry failed after 8 attempts: fetch failed: connect ECONNREFUSED api.anthropic.com:443",
+	},
+	ctxH,
+);
+await h.emit("agent_end", { messages: [{ role: "assistant", content: [], stopReason: "stop" }] }, ctxH);
+{
+	const st = readState();
+	const t60 = task(st, "t60");
+	assert.equal(t60.status, "interrupted", "outage keeps the task interrupted, never failed");
+	assert.equal(t60.attempts, 0, "outage attempt is refunded");
+	assert.equal(st.rateLimitedUntil ?? null, null, "outage does not record a rate-limit hold");
+	assert.ok(
+		ctxH.notifications.some(n => n.includes("provider unreachable — retrying in") && n.includes("outage #1")),
+		"outage backoff is announced",
+	);
+}
+assert.equal(h.sentPrompts.length, 1, "no instant re-dispatch after an outage");
+// internet restored: the armed backoff timer (1s clamp) re-dispatches with RESUME
+await sleep(1300);
+assert.equal(h.sentPrompts.length, 2, "task auto-resumes after the outage backoff");
+assert.match(h.sentPrompts[1], /RESUME/);
+assert.match(h.sentPrompts[1], /Count to 200/);
+// second consecutive outage doubles the streak, still refunding the attempt
+await h.emit("agent_start", {}, ctxH);
+await h.emit(
+	"auto_retry_end",
+	{ success: false, error: "fetch failed: getaddrinfo ENOTFOUND api.anthropic.com" },
+	ctxH,
+);
+await h.emit("agent_end", { messages: [{ role: "assistant", content: [], stopReason: "stop" }] }, ctxH);
+assert.equal(task(readState(), "t60").attempts, 0, "second outage attempt also refunded");
+assert.ok(
+	ctxH.notifications.some(n => n.includes("outage #2")),
+	"consecutive outages escalate the streak",
+);
+await sleep(1300);
+assert.equal(h.sentPrompts.length, 3, "resumes again after the second backoff");
+await h.emit("agent_start", {}, ctxH);
+await h.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctxH);
+assert.equal(task(readState(), "t60").status, "done", "task completes once connectivity is back");
+await sleep(50);
+await h.command("stop", ctxH);
+
+// 17. user abort of a scheduled turn pauses the queue (never re-dispatches
+// over the human) and keeps the task interrupted with the attempt refunded.
+{
+	const st = readState();
+	st.run = "running";
+	st.currentTaskId = null;
+	st.rateLimitedUntil = null;
+	st.windows = [];
+	st.tasks = [
+		{ id: "t70", prompt: "Long refactor", status: "queued", addedAt: new Date().toISOString(), attempts: 0 },
+	];
+	st.nextTaskSeq = 71;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const m = makeMockPi();
+const ctxM = makeCtx(tmpCwd);
+schedulerExtension(m.api);
+await m.emit("session_start", {}, ctxM);
+await sleep(80);
+assert.equal(m.sentPrompts.length, 1, "t70 dispatched");
+await m.emit("agent_start", {}, ctxM);
+await m.emit("agent_end", { messages: [{ role: "assistant", content: [], stopReason: "aborted" }] }, ctxM);
+{
+	const st = readState();
+	assert.equal(st.run, "paused", "user abort pauses the queue");
+	const t70 = task(st, "t70");
+	assert.equal(t70.status, "interrupted", "aborted task kept resumable");
+	assert.equal(t70.attempts, 0, "user abort refunds the attempt");
+	assert.ok(
+		ctxM.notifications.some(n => n.includes("queue paused")),
+		"abort pause is announced",
+	);
+}
+await sleep(120);
+assert.equal(m.sentPrompts.length, 1, "paused queue never re-dispatches over the user");
+await m.command("start", ctxM);
+await sleep(700); // cmdStart arms a 500ms initial dispatch
+assert.equal(m.sentPrompts.length, 2, "start resumes the aborted task");
+assert.match(m.sentPrompts[1], /RESUME/);
+await m.emit("agent_start", {}, ctxM);
+await m.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctxM);
+assert.equal(task(readState(), "t70").status, "done");
+await sleep(50);
+await m.command("stop", ctxM);
+
+// 18. watchdog: a dispatched prompt whose turn never materializes (swallowed
+// message / lost agent_end) is re-queued with the attempt refunded and
+// re-dispatched automatically — "running" can never silently stall.
+{
+	const c18 = JSON.parse(fs.readFileSync(configFile, "utf8")) as SchedulerConfig;
+	c18.watchdogIntervalMs = 40;
+	c18.stallTimeoutMs = 60;
+	fs.writeFileSync(configFile, JSON.stringify(c18));
+	const st = readState();
+	st.run = "running";
+	st.currentTaskId = null;
+	st.rateLimitedUntil = null;
+	st.windows = [];
+	st.tasks = [
+		{ id: "t80", prompt: "Swallowed dispatch", status: "queued", addedAt: new Date().toISOString(), attempts: 0 },
+	];
+	st.nextTaskSeq = 81;
+	fs.writeFileSync(stateFile, JSON.stringify(st));
+}
+const w = makeMockPi();
+const ctxW = makeCtx(tmpCwd);
+schedulerExtension(w.api);
+await w.emit("session_start", {}, ctxW);
+await sleep(80);
+assert.equal(w.sentPrompts.length, 1, "t80 dispatched");
+// no agent_start/agent_end ever arrives; the watchdog notices the idle agent
+// past stallTimeoutMs and re-queues + re-dispatches.
+await sleep(300);
+assert.ok(w.sentPrompts.length >= 2, "watchdog re-dispatched the stalled task");
+assert.ok(
+	ctxW.notifications.some(n => n.includes("watchdog")),
+	"watchdog recovery is announced",
+);
+assert.match(w.sentPrompts.at(-1) ?? "", /RESUME/);
+// catch the task in flight, then pin isIdle=false so the watchdog cannot
+// steal the turn we are about to simulate (mock isIdle is constant-true).
+for (let k = 0; k < 100 && readState().currentTaskId === null; k++) await sleep(20);
+assert.equal(readState().currentTaskId, "t80", "t80 back in flight");
+ctxW.isIdle = () => false;
+await w.emit("agent_start", {}, ctxW);
+await w.emit("agent_end", { messages: [{ role: "assistant", content: [] }] }, ctxW);
+assert.equal(task(readState(), "t80").status, "done", "recovered task completes");
+await sleep(50);
+await w.command("stop", ctxW);
+
+// 19. export: the whole queue lands in a human-workable markdown file.
+await w.command("export", ctxW);
+const defaultExport = path.join(tmpCwd, "scheduler-queue.md");
+assert.ok(fs.existsSync(defaultExport), "default export file created");
+{
+	const md = fs.readFileSync(defaultExport, "utf8");
+	assert.match(md, /## t80 — done/);
+	assert.match(md, /Swallowed dispatch/);
+	assert.match(md, /```text/);
+}
+await w.command("export custom-dump.md", ctxW);
+assert.ok(fs.existsSync(path.join(tmpCwd, "custom-dump.md")), "explicit export path honored");
+
+console.log("smoke: all assertions passed");
+console.log(`smoke: data dir was ${tmpAgentDir}`);

--- a/packages/scheduler-extension/tsconfig.json
+++ b/packages/scheduler-extension/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../tsconfig.workspace.json",
+	"include": [
+		"src",
+		"test"
+	]
+}


### PR DESCRIPTION
## What

A new user-facing package, `@oh-my-pi/scheduler-extension`, following the `packages/swarm-extension` pattern (single extension entry + `omp.extensions` manifest key). It adds a `/scheduler` command that queues prompts and drains them unattended — e.g. overnight — dispatching the next task whenever the agent goes idle.

## Why

A common complaint with Claude subscription auth: the 5-hour session windows expire while you sleep, and idle quota is simply lost. This extension lets you bank work instead — queue tasks, walk away, and let the agent spend every window productively. It solves that without touching provider code, using only documented extension surfaces.

## Design

- **Quota-aware dispatch**: tracks provider session windows locally (started-at + rolling 24h count) *only* when the active model matches a gated quota profile (Anthropic subscription auth by default); every other provider dispatches ungated. When a gated quota is exhausted it arms a resume timer for the next window instead of burning attempts.
- **Provider rate limits are ground truth**: on a 429 with retries exhausted, the `retry-after` is parsed from the error, all dispatch is held until the provider-declared reset (persisted across restarts), and the task's attempt is refunded — an outage can never burn a task to `failed`.
- **Network outages are transient**: transport/DNS/timeout/5xx errors trigger exponential backoff probing (30s doubling to a 15min ceiling, forever), so a task stranded by a 10-hour outage auto-resumes when connectivity returns. The 15min ceiling doubles as a quota-reset prober.
- **Self-healing watchdog**: a periodic tick re-arms lost timers and re-queues dispatches whose turn never materialized (idle agent past a stall timeout). A `running` scheduler cannot silently stall.
- **The human always wins the seat**: a user abort (Esc) of a scheduled turn pauses the queue and refunds the attempt instead of re-dispatching over the user.
- **Resume, not skip**: interrupted tasks are re-sent with a resume preamble ("inspect current state, finish only the remainder"); crash recovery via atomic (temp+rename) `state.json` re-queues the in-flight task on the next `session_start`.
- **Workable queue file**: `/scheduler export [path]` writes the whole queue (status, attempts, errors, full prompts) as markdown.

## Extension API surface

Uses only documented APIs: `registerCommand`, `sendUserMessage`, `agent_start`/`agent_end`/`auto_retry_end`/`session_start`/`session_shutdown`, `ctx.isIdle()`/`ctx.hasPendingMessages()`, `ctx.ui.*`, `ctx.abort()`, `ctx.getContextUsage()`, and the `PI_CODING_AGENT_DIR` data-dir convention. In that sense it's both a feature and a stress test of the extension API.

Three places work around documented gaps (marked with "best-effort" comments in the source), which could become first-class core APIs later: a typed turn outcome on `agent_end`, read access to effective settings, and a blessed per-extension data-dir helper.

## Structure

```
packages/scheduler-extension/
├── package.json      # mirrors swarm-extension; omp.extensions -> src/extension.ts
├── src/extension.ts  # the whole extension (~1400 lines incl. doc comments)
├── test/smoke.ts     # 19-section behavioral smoke test against a mocked ExtensionAPI
├── README.md         # user guide
└── CHANGELOG.md
```

Zero new dependencies (node builtins + type-only import of `@oh-my-pi/pi-coding-agent`).

## Verification

- `bun run check` in the package: biome + `tsgo --noEmit` clean.
- `bun test/smoke.ts`: 19 scenario sections covering queue lifecycle, quota gating and window arithmetic, resume-not-skip, crash recovery, rate-limit hold + attempt refund, `/scheduler retry`, network-outage backoff and auto-resume, abort-pause, watchdog stall recovery, and export.
- Lockfile delta is scoped to registering the new workspace member.
