### PR TITLE
Add ElectronHub DevPass provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added ElectronHub Coding Plan (DevPass) as a `/login electronhub` API-key provider, validating `ek-dev-…` keys against `kimi-k2.6:dev` on `https://api.electronhub.ai/v1`.
+
 ## [16.3.11] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/registry/electronhub.ts
+++ b/packages/ai/src/registry/electronhub.ts
@@ -1,0 +1,27 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://app.electronhub.ai";
+const API_BASE_URL = "https://api.electronhub.ai/v1";
+const VALIDATION_MODEL = "kimi-k2.6:dev";
+
+export const loginElectronHub = createApiKeyLogin({
+	providerLabel: "ElectronHub Coding Plan",
+	authUrl: AUTH_URL,
+	instructions: "Copy your ek-dev- API key from the ElectronHub dashboard Coding Plan tab",
+	promptMessage: "Paste your ElectronHub DevPass API key",
+	placeholder: "ek-dev-...",
+	validation: {
+		kind: "chat-completions",
+		provider: "ElectronHub",
+		baseUrl: API_BASE_URL,
+		model: VALIDATION_MODEL,
+	},
+});
+
+export const electronHubProvider = {
+	id: "electronhub",
+	name: "ElectronHub Coding Plan (DevPass)",
+	login: (cb: OAuthLoginCallbacks) => loginElectronHub(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -11,6 +11,7 @@ import { coreWeaveProvider } from "./coreweave";
 import { cursorProvider } from "./cursor";
 import { deepseekProvider } from "./deepseek";
 import { devinProvider } from "./devin";
+import { electronHubProvider } from "./electronhub";
 import { firepassProvider } from "./firepass";
 import { fireworksProvider } from "./fireworks";
 import { githubCopilotProvider } from "./github-copilot";
@@ -84,6 +85,7 @@ const ALL = [
 	githubCopilotProvider,
 	cursorProvider,
 	devinProvider,
+	electronHubProvider,
 	googleAntigravityProvider,
 	googleGeminiCliProvider,
 	openaiCodexDeviceProvider,

--- a/packages/ai/test/electronhub-login.test.ts
+++ b/packages/ai/test/electronhub-login.test.ts
@@ -1,0 +1,128 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { loginElectronHub } from "@oh-my-pi/pi-ai/registry/electronhub";
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+const originalElectronHubDevKey = Bun.env.ELECTRONHUB_DEV_API_KEY;
+const originalElectronHubKey = Bun.env.ELECTRONHUB_API_KEY;
+
+afterEach(() => {
+	if (originalElectronHubDevKey === undefined) {
+		delete Bun.env.ELECTRONHUB_DEV_API_KEY;
+	} else {
+		Bun.env.ELECTRONHUB_DEV_API_KEY = originalElectronHubDevKey;
+	}
+	if (originalElectronHubKey === undefined) {
+		delete Bun.env.ELECTRONHUB_API_KEY;
+	} else {
+		Bun.env.ELECTRONHUB_API_KEY = originalElectronHubKey;
+	}
+	vi.restoreAllMocks();
+});
+
+describe("electronhub login wiring", () => {
+	test("registers ElectronHub in the /login provider selector", () => {
+		const provider = getOAuthProviders().find(item => item.id === "electronhub");
+		expect(provider).toBeDefined();
+		expect(provider?.name).toBe("ElectronHub Coding Plan (DevPass)");
+		expect(provider?.available).toBe(true);
+	});
+
+	test("resolves ELECTRONHUB_DEV_API_KEY first, then ELECTRONHUB_API_KEY", () => {
+		Bun.env.ELECTRONHUB_DEV_API_KEY = "ek-dev-env";
+		Bun.env.ELECTRONHUB_API_KEY = "ek-fallback";
+		expect(getEnvApiKey("electronhub")).toBe("ek-dev-env");
+
+		delete Bun.env.ELECTRONHUB_DEV_API_KEY;
+		expect(getEnvApiKey("electronhub")).toBe("ek-fallback");
+	});
+
+	test("loginElectronHub trims key and validates against /v1/chat/completions with kimi-k2.6:dev", async () => {
+		const originalFetch = globalThis.fetch;
+		const globalFetchSpy = vi.fn(async () => {
+			throw new Error("unexpected global fetch (live network)");
+		});
+		globalThis.fetch = globalFetchSpy as unknown as typeof globalThis.fetch;
+		try {
+			let validationBody: Record<string, unknown> | undefined;
+			let validationUrl = "";
+			const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				validationUrl =
+					typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+				expect(validationUrl).toBe("https://api.electronhub.ai/v1/chat/completions");
+				expect(init?.method).toBe("POST");
+				const headers = new Headers(init?.headers);
+				expect(headers.get("Content-Type")).toBe("application/json");
+				expect(headers.get("Authorization")).toBe("Bearer ek-dev-test");
+
+				validationBody =
+					typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+				return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+
+			const apiKey = await loginElectronHub({
+				onPrompt: async () => "  ek-dev-test  ",
+				fetch: fetchMock,
+			});
+
+			expect(apiKey).toBe("ek-dev-test");
+			expect(validationBody).toMatchObject({
+				model: "kimi-k2.6:dev",
+				messages: [{ role: "user", content: "ping" }],
+				max_tokens: 1,
+				temperature: 0,
+			});
+			expect(validationUrl).toBe("https://api.electronhub.ai/v1/chat/completions");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(globalFetchSpy).toHaveBeenCalledTimes(0);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("AuthStorage.login('electronhub') validates and stores the trimmed key", async () => {
+		const fetchCalls: Array<{ url: string; init: RequestInit | undefined }> = [];
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url =
+				typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			fetchCalls.push({ url, init });
+			if (url === "https://api.electronhub.ai/v1/chat/completions") {
+				return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const storage = new AuthStorage(store);
+		await storage.reload();
+
+		await storage.login("electronhub", {
+			onAuth: () => {},
+			onPrompt: async () => "  ek-dev-trimmed  ",
+			fetch: fetchMock,
+		});
+
+		expect(await storage.get("electronhub")).toEqual({ type: "api_key", key: "ek-dev-trimmed" });
+
+		expect(fetchCalls.map(call => call.url)).toEqual(["https://api.electronhub.ai/v1/chat/completions"]);
+		const headers = new Headers(fetchCalls[0]?.init?.headers);
+		expect(headers.get("Authorization")).toBe("Bearer ek-dev-trimmed");
+
+		const body =
+			typeof fetchCalls[0]?.init?.body === "string"
+				? (JSON.parse(fetchCalls[0]!.init!.body as string) as Record<string, unknown>)
+				: undefined;
+		expect(body).toMatchObject({ model: "kimi-k2.6:dev" });
+
+		store.close();
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added ElectronHub Coding Plan (DevPass) catalog support with bundled `kimi-k2.6:dev` and `minimax-m2.7:dev` models plus runtime discovery filtered to DevPass-only models.
+
 ## [16.3.11] - 2026-07-06
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -34,6 +34,7 @@ import {
 	buildXaiOAuthStaticSeed,
 	clampFireworksKimiMaxTokens,
 	clampKimiK27CodeMaxTokens,
+	ELECTRONHUB_DEVPASS_STATIC_MODELS,
 	isFireworksKimiK2ModelId,
 	isKimiK27CodeModelId,
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
@@ -343,6 +344,17 @@ function normalizeAntigravityEndpoint(models: readonly ModelSpec[]): ModelSpec[]
 	});
 }
 
+/**
+ * ElectronHub exposes a model-wide `tokens` context field on `/v1/models`, but
+ * not a documented output-token ceiling. Keep `maxTokens` unknown instead of
+ * borrowing caps from same-family models on other providers.
+ */
+function preserveElectronHubUnknownMaxTokens(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model =>
+		model.provider === "electronhub" && model.maxTokens !== null ? { ...model, maxTokens: null } : model,
+	);
+}
+
 const ANTIGRAVITY_ENDPOINT = ANTIGRAVITY_PRIMARY_ENDPOINT;
 
 async function getOAuthAccessFromStorage(provider: OAuthProvider): Promise<OAuthAccess | null> {
@@ -516,6 +528,11 @@ async function generateModels() {
 	if (!authoritativeCatalogProviders.has("gitlab-duo-agent")) {
 		allModels.push(buildGitLabDuoWorkflowFallbackModel());
 	}
+	// Seed ElectronHub DevPass models so `/login electronhub` has a usable
+	// offline catalog even when generation runs without an ElectronHub key.
+	if (!authoritativeCatalogProviders.has("electronhub")) {
+		allModels.push(...ELECTRONHUB_DEVPASS_STATIC_MODELS);
+	}
 	// Seed Fireworks "Fast" serving-path variants (`<id>-fast`). Fast routers are
 	// not enumerated by the serverless control-plane list, so discovery never
 	// surfaces them; the seed projects each base entry into a fast variant.
@@ -592,8 +609,10 @@ async function generateModels() {
 	// previous-snapshot raw members into their logical families.
 	allModels = collapseEffortVariantsAcrossProviders(allModels);
 	// Fill remaining null endpoint limits from each model's canonical-family
-	// reference. Runs last so canonical ids and explicit policy limits are final.
+	// reference, then restore provider-specific unknowns where cross-provider
+	// caps would be misleading.
 	applyCanonicalLimitFallback(allModels);
+	allModels = preserveElectronHubUnknownMaxTokens(allModels);
 
 	for (const model of allModels) {
 		canonicalizeModelCompat(model);

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17456,6 +17456,73 @@
 			"maxTokens": 64000
 		}
 	},
+	"electronhub": {
+		"kimi-k2.6:dev": {
+			"id": "kimi-k2.6:dev",
+			"name": "Kimi K2.6 (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 240000,
+			"maxTokens": null,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"minimax-m2.7:dev": {
+			"id": "minimax-m2.7:dev",
+			"name": "MiniMax M2.7 (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 180000,
+			"maxTokens": null,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
+		}
+	},
 	"firepass": {
 		"kimi-k2.6-turbo": {
 			"id": "kimi-k2.6-turbo",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -17,6 +17,7 @@ import {
 	cloudflareAiGatewayModelManagerOptions,
 	coreWeaveModelManagerOptions,
 	deepseekModelManagerOptions,
+	electronHubModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
 	githubCopilotModelManagerOptions,
@@ -133,6 +134,17 @@ export const CATALOG_PROVIDERS = [
 		createModelManagerOptions: (config: ModelManagerConfig) => devinModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,
 		catalogDiscovery: { label: "Devin", envVars: ["DEVIN_API_KEY"], oauthProvider: "devin" },
+	},
+	{
+		id: "electronhub",
+		defaultModel: "kimi-k2.6:dev",
+		envVars: ["ELECTRONHUB_DEV_API_KEY", "ELECTRONHUB_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => electronHubModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: {
+			label: "ElectronHub Coding Plan",
+			envVars: ["ELECTRONHUB_DEV_API_KEY", "ELECTRONHUB_API_KEY"],
+		},
 	},
 	{
 		id: "firepass",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1683,7 +1683,118 @@ export function firepassModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
-// 7.7 Wafer Serverless
+// 7.7 ElectronHub Coding Plan (DevPass)
+// ---------------------------------------------------------------------------
+
+export interface ElectronHubModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+const ELECTRONHUB_API_BASE_URL = "https://api.electronhub.ai/v1";
+const ELECTRONHUB_OPENAI_COMPAT = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+} as const satisfies ModelSpec<"openai-completions">["compat"];
+
+export const ELECTRONHUB_DEVPASS_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	{
+		id: "kimi-k2.6:dev",
+		name: "Kimi K2.6 (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 240_000,
+		maxTokens: null,
+		compat: ELECTRONHUB_OPENAI_COMPAT,
+	},
+	{
+		id: "minimax-m2.7:dev",
+		name: "MiniMax M2.7 (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 180_000,
+		maxTokens: null,
+		compat: ELECTRONHUB_OPENAI_COMPAT,
+	},
+];
+
+function isElectronHubDevpassModel(entry: OpenAICompatibleModelRecord, id: string): boolean {
+	if (id.endsWith(":dev")) return true;
+	const metadata = isRecord(entry.metadata) ? entry.metadata : undefined;
+	return metadata?.devpass_only === true;
+}
+
+function toElectronHubModelName(name: string): string {
+	const separator = name.indexOf(": ");
+	return separator > 0 ? name.slice(separator + 2) : name;
+}
+
+function mapElectronHubDevpassModel(
+	entry: OpenAICompatibleModelRecord,
+	defaults: ModelSpec<"openai-completions">,
+	reference: ModelSpec<"openai-completions"> | undefined,
+): ModelSpec<"openai-completions"> {
+	const base = mapWithBundledReference(entry, defaults, reference);
+	const metadata = isRecord(entry.metadata) ? entry.metadata : undefined;
+	const pricing = isRecord(entry.pricing) ? entry.pricing : undefined;
+	const input: ("text" | "image")[] =
+		metadata?.vision === true ? ["text", "image"] : metadata?.vision === false ? ["text"] : base.input;
+	return {
+		...base,
+		name: toElectronHubModelName(base.name),
+		reasoning: metadata?.reasoning === true || base.reasoning,
+		input,
+		cost: {
+			input: toNumber(pricing?.input) ?? base.cost.input,
+			output: toNumber(pricing?.output) ?? base.cost.output,
+			cacheRead: toNumber(pricing?.cache_read) ?? base.cost.cacheRead,
+			cacheWrite: toNumber(pricing?.cache_write) ?? base.cost.cacheWrite,
+		},
+		contextWindow: toPositiveNumber(entry.tokens, base.contextWindow),
+		...(metadata?.function_call === false ? { supportsTools: false } : {}),
+		compat: { ...(base.compat ?? {}), ...ELECTRONHUB_OPENAI_COMPAT },
+	};
+}
+
+export function electronHubModelManagerOptions(
+	config?: ElectronHubModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? ELECTRONHUB_API_BASE_URL;
+	return {
+		providerId: "electronhub",
+		dynamicModelsAuthoritative: true,
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "electronhub",
+					baseUrl,
+					apiKey,
+					filterModel: (entry, model) => isElectronHubDevpassModel(entry, model.id),
+					mapModel: (entry, defaults) =>
+						mapElectronHubDevpassModel(
+							entry,
+							defaults,
+							ELECTRONHUB_DEVPASS_STATIC_MODELS.find(model => model.id === defaults.id),
+						),
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// 7.8 Wafer Serverless
 // ---------------------------------------------------------------------------
 
 export interface WaferModelManagerConfig {

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+function getElectronHubOptions(fetch: FetchImpl) {
+	const descriptor = PROVIDER_DESCRIPTORS.find(candidate => candidate.providerId === "electronhub");
+	if (!descriptor) throw new Error("ElectronHub descriptor missing");
+	const options = descriptor.createModelManagerOptions({ apiKey: "ek-dev-test", fetch });
+	expect(options.providerId).toBe("electronhub");
+	return options;
+}
+
+describe("ElectronHub provider catalog", () => {
+	it("bundles DevPass models offline with zero token cost and supportsStore=false", () => {
+		const kimi = getBundledModel<"openai-completions">("electronhub", "kimi-k2.6:dev");
+		const minimax = getBundledModel<"openai-completions">("electronhub", "minimax-m2.7:dev");
+
+		expect(kimi).toBeDefined();
+		expect(minimax).toBeDefined();
+
+		expect(kimi).toMatchObject({
+			provider: "electronhub",
+			api: "openai-completions",
+			baseUrl: "https://api.electronhub.ai/v1",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 240_000,
+			maxTokens: null,
+		});
+		expect(minimax).toMatchObject({
+			provider: "electronhub",
+			api: "openai-completions",
+			baseUrl: "https://api.electronhub.ai/v1",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 180_000,
+			maxTokens: null,
+		});
+
+		// Cost is a flat-rate DevPass plan (zero marginal token cost).
+		expect(kimi.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		expect(minimax.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+
+		// ElectronHub is OpenAI-compatible but does not support the OpenAI `store` flag.
+		expect(kimi.compat.supportsStore).toBe(false);
+		expect(minimax.compat.supportsStore).toBe(false);
+	});
+
+	it("keeps only DevPass models from /v1/models discovery (filters out non-:dev + non-devpass_only)", async () => {
+		const requestedUrls: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			requestedUrls.push(input instanceof Request ? input.url : String(input));
+			return new Response(
+				JSON.stringify({
+					data: [
+						{ id: "kimi-k2.6:dev", name: "ElectronHub: Kimi K2.6 (DevPass)", tokens: 240_000 },
+						{ id: "minimax-m2.7:dev", name: "MiniMax M2.7 (DevPass)", tokens: 180_000 },
+						// Keep via metadata.devpass_only even without :dev suffix
+						{
+							id: "rollout-preview",
+							name: "ElectronHub: Preview",
+							metadata: { devpass_only: true },
+							tokens: 9_999,
+						},
+						// Must be dropped: not a DevPass record
+						{ id: "kimi-k2.6", name: "Kimi K2.6", tokens: 240_000 },
+						// Must be dropped: not a DevPass record
+						{ id: "random-model", name: "Random", metadata: { devpass_only: false }, tokens: 1 },
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		const options = getElectronHubOptions(fetchImpl);
+		const models = await options.fetchDynamicModels?.();
+		expect(models).not.toBeNull();
+
+		// Uses the OpenAI-compatible discovery endpoint.
+		expect(requestedUrls).toEqual(["https://api.electronhub.ai/v1/models"]);
+
+		const ids = (models ?? []).map(model => model.id);
+		expect(ids).toEqual(["kimi-k2.6:dev", "minimax-m2.7:dev", "rollout-preview"]);
+	});
+
+	it("maps ElectronHub discovery metadata into ModelSpec (name cleanup, tokens->contextWindow, function_call=false)", async () => {
+		const fetchImpl: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "thirdparty:dev",
+							name: "ElectronHub: Custom DevPass Name",
+							tokens: 123_456,
+							metadata: {
+								devpass_only: true,
+								reasoning: true,
+								vision: true,
+								function_call: false,
+							},
+							pricing: { input: "0", output: "0", cache_read: "0", cache_write: "0" },
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const options = getElectronHubOptions(fetchImpl);
+		const models = (await options.fetchDynamicModels?.()) as ModelSpec<"openai-completions">[] | null | undefined;
+		const model = models?.find(candidate => candidate.id === "thirdparty:dev");
+
+		expect(model).toBeDefined();
+		expect(model?.name).toBe("Custom DevPass Name");
+		expect(model?.contextWindow).toBe(123_456);
+		expect(model?.reasoning).toBe(true);
+		expect(model?.input).toEqual(["text", "image"]);
+		expect(model?.supportsTools).toBe(false);
+		expect(model?.compat?.supportsStore).toBe(false);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Documented the `ELECTRONHUB_DEV_API_KEY` environment variable in `omp --help` for ElectronHub Coding Plan (DevPass) models.
+
 ### Changed
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -324,6 +324,7 @@ export function getExtraHelpText(): string {
   MISTRAL_API_KEY            - Mistral models
   ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
   UMANS_AI_CODING_PLAN_API_KEY - Umans AI Coding Plan models
+  ELECTRONHUB_DEV_API_KEY    - ElectronHub Coding Plan (DevPass) models
   UMANS_WEBSEARCH_PROVIDER    - Umans gateway web search backend (native or exa)
   MINIMAX_API_KEY            - MiniMax models
   OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models


### PR DESCRIPTION
## Summary
- Add ElectronHub Coding Plan (DevPass) as the `electronhub` login/model provider with `ek-dev-...` key validation against `https://api.electronhub.ai/v1/chat/completions` using `kimi-k2.6:dev`.
- Add ElectronHub catalog wiring, DevPass-only dynamic discovery, and bundled `kimi-k2.6:dev` / `minimax-m2.7:dev` entries with provider-specific handling to keep unknown output-token caps as `null` instead of borrowing caps from other providers.
- Document `ELECTRONHUB_DEV_API_KEY` in CLI help and add focused ElectronHub login/catalog tests.

## Verification
- `bun run check:ts` ✅
- `bun check` ❌ fails after TypeScript checks pass because `cargo` is not installed locally for `check:rs`.
- `bun run test test/electronhub-login.test.ts` (packages/ai) ❌ blocked locally by missing `packages/natives/native/pi_natives.darwin-arm64.node`; `bun --cwd=packages/natives run build` also cannot run because `cargo` is missing.
- `bun run test test/electronhub-provider.test.ts` (packages/catalog) ❌ same missing local native addon / cargo prerequisite.
- Smoke-tested `loginElectronHub` directly with a mocked fetch; it trimmed the key and posted to the expected ElectronHub chat-completions validation endpoint/model.

Note: I intentionally trimmed the generated `models.json` delta back to ElectronHub-only after `bun run gen:models` pulled unrelated upstream catalog churn.