### PR TITLE
feat(agent): add Devin ACU usage reporting

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Fixed stateful OpenAI Responses explicit cache breakpoints being restored onto edited historical messages, ensuring full replays recompute the latest stable cache boundary.
 - Fixed ChatGPT Codex standard and Lite transports rejecting or hiding native computer-use payloads by unrolling the tool definition, forced choice, `computer_call`, and `computer_call_output` into ordinary function-tool forms.
+- Fixed Devin usage polling to resolve stored API-key references before eligibility checks, preserving valid runtime/config fallbacks when stored references are stale or return no data.
+- Fixed Devin usage history to retain one opaque org/principal series across service-key rotation instead of splitting trends by credential secret.
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -316,6 +316,9 @@
 - Fixed the generic lazy-stream idle watchdog aborting healthy `cursor-agent` streams with "Provider stream stalled while waiting for the next event" while a Cursor exec-channel local tool (shell/read/grep/write/MCP/…) legitimately ran longer than the idle budget. Provider streams now advertise consumer-side local work in flight and the watchdog slides its deadline instead of aborting; genuinely silent streams still time out. ([#4593](https://github.com/can1357/oh-my-pi/issues/4593))
 - Fixed OpenAI Codex/Responses reasoning streams so streamed thinking content is preserved when the final `output_item.done` reconstructs to an empty summary ([#4918](https://github.com/can1357/oh-my-pi/issues/4918)).
 - Fixed Anthropic streams hanging forever when generation wedges mid-stream (notably long `write` tool calls on Opus 4.8 high/xhigh) while the server keeps sending `ping` keepalives: pings now extend the idle watchdog only within a bounded window (3x the idle timeout) since the last real stream event, so a stalled tool-call stream times out and recovers instead of hanging with no retry path ([#4900](https://github.com/can1357/oh-my-pi/issues/4900)).
+### Added
+
+- Added Devin service-user API key usage reporting for public v3 ACU consumption and usage metrics.
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/ai/src/auth-broker/wire-schemas.ts
+++ b/packages/ai/src/auth-broker/wire-schemas.ts
@@ -157,7 +157,7 @@ export const healthzResponseSchema = type({
 
 // ─── Usage ─────────────────────────────────────────────────────────────────
 
-const usageUnitSchema = type("'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'unknown'");
+const usageUnitSchema = type("'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'acus' | 'unknown'");
 const usageStatusSchema = type("'ok' | 'warning' | 'exhausted' | 'unknown'");
 
 const usageWindowSchema = type({

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3387,7 +3387,8 @@ export class AuthStorage {
 		if (report.provider === "devin") {
 			const orgId = this.#getUsageReportMetadataValue(report, "orgId");
 			if (orgId) return [`devin:org:${orgId.toLowerCase()}`];
-			return ["devin:enterprise"];
+			const principalId = this.#getUsageReportMetadataValue(report, "principalId");
+			if (principalId) return [`devin:principal:${principalId.toLowerCase()}`];
 		}
 		if (report.provider === "openai-codex") {
 			return identifiers.map(identifier => `${report.provider}:${identifier.toLowerCase()}`);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3321,7 +3321,7 @@ export class AuthStorage {
 
 			const runtimeKey = this.#runtimeOverrides.get(providerId);
 			const envKey = getEnvApiKey(providerId);
-			const apiKey = runtimeKey ?? envKey;
+			const apiKey = runtimeKey ?? this.#configOverrides.get(providerId) ?? envKey;
 			if (!apiKey) continue;
 			const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
 			if (providerImpl.supports && !providerImpl.supports(request)) continue;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -734,6 +734,11 @@ type UsageRequestDescriptor = {
 	baseUrl?: string;
 };
 
+type UsageRequestCollection = {
+	requests: UsageRequestDescriptor[];
+	fallbackRequests: UsageRequestDescriptor[];
+};
+
 type AuthApiKeyOptions = {
 	baseUrl?: string;
 	modelId?: string;
@@ -3077,11 +3082,29 @@ export class AuthStorage {
 	 * supports it). The usage cache is latest-snapshot-only — these rows are
 	 * the only place limit utilization is kept over time.
 	 */
+	#buildUsageHistoryAccountKey(request: UsageRequestDescriptor, report: UsageReport): string {
+		if (request.provider !== "devin") return this.#buildUsageCacheIdentity(request.credential);
+
+		const orgId = this.#getUsageReportMetadataValue(report, "orgId");
+		const principalId = this.#getUsageReportMetadataValue(report, "principalId");
+		const identity = orgId
+			? { kind: "org", value: orgId }
+			: principalId
+				? { kind: "principal", value: principalId }
+				: undefined;
+		if (!identity) return this.#buildUsageCacheIdentity(request.credential);
+
+		const fingerprint = createHash("sha256")
+			.update(`${request.provider}:${identity.kind}:${identity.value}`)
+			.digest("base64url");
+		return `${request.provider}:${identity.kind}:${fingerprint}`;
+	}
+
 	#recordUsageHistory(request: UsageRequestDescriptor, report: UsageReport): void {
 		const record = this.#store.recordUsageSnapshots;
 		if (!record || report.limits.length === 0) return;
 		const recordedAt = Number.isFinite(report.fetchedAt) && report.fetchedAt > 0 ? report.fetchedAt : Date.now();
-		const accountKey = this.#buildUsageCacheIdentity(request.credential);
+		const accountKey = this.#buildUsageHistoryAccountKey(request, report);
 		const metadata = report.metadata ?? {};
 		const metaEmail = typeof metadata.email === "string" ? metadata.email : undefined;
 		const metaAccountId = typeof metadata.accountId === "string" ? metadata.accountId : undefined;
@@ -3259,13 +3282,14 @@ export class AuthStorage {
 		return true;
 	}
 
-	#collectUsageRequests(options?: {
+	async #collectUsageRequests(options?: {
 		baseUrlResolver?: (provider: Provider) => string | undefined;
-	}): UsageRequestDescriptor[] {
+	}): Promise<UsageRequestCollection> {
 		const resolver = this.#usageProviderResolver;
-		if (!resolver) return [];
+		if (!resolver) return { requests: [], fallbackRequests: [] };
 
 		const requests: UsageRequestDescriptor[] = [];
+		const fallbackRequests: UsageRequestDescriptor[] = [];
 		const providers = new Set<string>([
 			...this.#data.keys(),
 			...DEFAULT_USAGE_PROVIDERS.map(provider => provider.id),
@@ -3308,28 +3332,49 @@ export class AuthStorage {
 				continue;
 			}
 
-			const providerRequestStart = requests.length;
+			let hasUsableStoredCredential = false;
 			for (const entry of entries) {
 				const credential = entry.credential;
-				const request =
-					credential.type === "api_key"
-						? this.#buildUsageRequest(provider, { type: "api_key", apiKey: credential.key }, baseUrl)
-						: this.#buildUsageRequestForOauth(provider, credential, baseUrl);
+				let request: UsageRequestDescriptor;
+				if (credential.type === "api_key") {
+					const apiKey = await this.#configValueResolver(credential.key);
+					if (!apiKey) continue;
+					request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
+				} else {
+					request = this.#buildUsageRequestForOauth(provider, credential, baseUrl);
+				}
 				if (providerImpl.supports && !providerImpl.supports(request)) continue;
 				requests.push(request);
+				hasUsableStoredCredential = true;
 			}
-			if (requests.length !== providerRequestStart) continue;
 
 			const runtimeKey = this.#runtimeOverrides.get(providerId);
 			const envKey = getEnvApiKey(providerId);
 			const apiKey = runtimeKey ?? this.#configOverrides.get(providerId) ?? envKey;
 			if (!apiKey) continue;
-			const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
-			if (providerImpl.supports && !providerImpl.supports(request)) continue;
-			requests.push(request);
+			const resolvedApiKey = await this.#configValueResolver(apiKey);
+			if (!resolvedApiKey) continue;
+			const fallbackRequest = this.#buildUsageRequest(
+				provider,
+				{ type: "api_key", apiKey: resolvedApiKey },
+				baseUrl,
+			);
+			if (providerImpl.supports && !providerImpl.supports(fallbackRequest)) continue;
+			if (!hasUsableStoredCredential) {
+				requests.push(fallbackRequest);
+				continue;
+			}
+			if (
+				requests.some(
+					request => this.#buildUsageReportCacheKey(request) === this.#buildUsageReportCacheKey(fallbackRequest),
+				)
+			) {
+				continue;
+			}
+			fallbackRequests.push(fallbackRequest);
 		}
 
-		return requests;
+		return { requests, fallbackRequests };
 	}
 
 	#getUsageReportMetadataValue(report: UsageReport, key: string): string | undefined {
@@ -3793,7 +3838,7 @@ export class AuthStorage {
 		}
 		if (!this.#usageProviderResolver) return null;
 
-		const requests = this.#collectUsageRequests(options);
+		const { requests, fallbackRequests } = await this.#collectUsageRequests(options);
 		if (requests.length === 0) return [];
 
 		this.#usageLogger?.debug("Usage fetch requested", {
@@ -3825,6 +3870,19 @@ export class AuthStorage {
 				requests.map(request => this.#fetchUsageCached(request, this.#usageRequestTimeoutMs)),
 			);
 			const reportPairs = results.flatMap((report, index) => (report ? [{ report, request: requests[index] }] : []));
+			const pendingFallbacks = fallbackRequests.filter(
+				fallback => !reportPairs.some(pair => pair.request.provider === fallback.provider),
+			);
+			if (pendingFallbacks.length > 0) {
+				const fallbackResults = await Promise.all(
+					pendingFallbacks.map(request => this.#fetchUsageCached(request, this.#usageRequestTimeoutMs)),
+				);
+				reportPairs.push(
+					...fallbackResults.flatMap((report, index) =>
+						report ? [{ report, request: pendingFallbacks[index] }] : [],
+					),
+				);
+			}
 			const deduped = this.#dedupeUsageReports(reportPairs.map(pair => pair.report));
 			for (const report of deduped) {
 				const identifiers = new Set(this.#getUsageReportIdentifiers(report));

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3827,7 +3827,12 @@ export class AuthStorage {
 			const reportPairs = results.flatMap((report, index) => (report ? [{ report, request: requests[index] }] : []));
 			const deduped = this.#dedupeUsageReports(reportPairs.map(pair => pair.report));
 			for (const report of deduped) {
-				const pair = reportPairs.find(candidate => candidate.report === report);
+				const identifiers = new Set(this.#getUsageReportIdentifiers(report));
+				const pair = reportPairs.find(
+					candidate =>
+						candidate.report === report ||
+						this.#getUsageReportIdentifiers(candidate.report).some(identifier => identifiers.has(identifier)),
+				);
 				if (pair) this.#recordUsageHistory(pair.request, report);
 			}
 			const resolved = deduped;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3049,7 +3049,6 @@ export class AuthStorage {
 				// fan-out trips 429s every cycle. With ±25% jitter on TTL the refresh
 				// times decorrelate within a few cycles.
 				this.#usageCache.set(cacheKey, { value: report, expiresAt: Date.now() + USAGE_REPORT_TTL_MS + ttlJitter });
-				this.#recordUsageHistory(request, report);
 				this.#reconcileCodexUsageBlock(request, report);
 				return report;
 			}
@@ -3096,6 +3095,8 @@ export class AuthStorage {
 			label: limit.label,
 			windowLabel: limit.window?.label ?? limit.scope.windowId,
 			usedFraction: resolveUsedFraction(limit),
+			used: limit.amount.used,
+			unit: limit.amount.unit,
 			status: limit.status,
 			resetsAt: limit.window?.resetsAt,
 		}));
@@ -3823,9 +3824,12 @@ export class AuthStorage {
 			const results = await Promise.all(
 				requests.map(request => this.#fetchUsageCached(request, this.#usageRequestTimeoutMs)),
 			);
-			const reports = results.filter((report): report is UsageReport => report !== null);
-			const deduped = this.#dedupeUsageReports(reports);
-			// no outer cache write — see comment above.
+			const reportPairs = results.flatMap((report, index) => (report ? [{ report, request: requests[index] }] : []));
+			const deduped = this.#dedupeUsageReports(reportPairs.map(pair => pair.report));
+			for (const report of deduped) {
+				const pair = reportPairs.find(candidate => candidate.report === report);
+				if (pair) this.#recordUsageHistory(pair.request, report);
+			}
 			const resolved = deduped;
 			this.#usageLogger?.debug("Usage fetch resolved", {
 				reports: resolved.map(report => {
@@ -6499,16 +6503,16 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			"DELETE FROM auth_credential_refresh_leases WHERE credential_id = ? AND owner = ?",
 		);
 		this.#insertUsageHistoryStmt = this.#db.prepare(
-			"INSERT INTO usage_history (recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, status, resets_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+			"INSERT INTO usage_history (recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, used_value, unit, status, resets_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 		);
 		this.#lastUsageHistoryStmt = this.#db.prepare(
 			"SELECT id, recorded_at FROM usage_history WHERE provider = ? AND account_key = ? AND limit_id = ? ORDER BY recorded_at DESC LIMIT 1",
 		);
 		this.#updateUsageHistoryStmt = this.#db.prepare(
-			"UPDATE usage_history SET recorded_at = ?, email = ?, account_id = ?, label = ?, window_label = ?, used_fraction = ?, status = ?, resets_at = ? WHERE id = ?",
+			"UPDATE usage_history SET recorded_at = ?, email = ?, account_id = ?, label = ?, window_label = ?, used_fraction = ?, used_value = ?, unit = ?, status = ?, resets_at = ? WHERE id = ?",
 		);
 		this.#listUsageHistoryStmt = this.#db.prepare(
-			"SELECT recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, status, resets_at FROM usage_history WHERE recorded_at >= ? AND (? IS NULL OR provider = ?) ORDER BY recorded_at ASC",
+			"SELECT recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, used_value, unit, status, resets_at FROM usage_history WHERE recorded_at >= ? AND (? IS NULL OR provider = ?) ORDER BY recorded_at ASC",
 		);
 		this.#insertUsageCostStmt = this.#db.prepare(
 			"INSERT INTO usage_cost_history (recorded_at, provider, account_key, cost_usd) VALUES (?, ?, ?, ?)",
@@ -6605,6 +6609,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				label TEXT NOT NULL,
 				window_label TEXT,
 				used_fraction REAL,
+				used_value REAL,
+				unit TEXT,
 				status TEXT,
 				resets_at INTEGER
 			);
@@ -6619,6 +6625,12 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			CREATE INDEX IF NOT EXISTS idx_usage_cost_history_lookup ON usage_cost_history(provider, account_key, recorded_at);
 			CREATE INDEX IF NOT EXISTS idx_usage_history_recorded ON usage_history(recorded_at);
 		`);
+		try {
+			this.#db.run("ALTER TABLE usage_history ADD COLUMN used_value REAL");
+		} catch {}
+		try {
+			this.#db.run("ALTER TABLE usage_history ADD COLUMN unit TEXT");
+		} catch {}
 
 		if (!this.#authCredentialsTableExists()) {
 			this.#createAuthCredentialsTable();
@@ -7301,6 +7313,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 						entry.label,
 						entry.windowLabel ?? null,
 						entry.usedFraction ?? null,
+						entry.used ?? null,
+						entry.unit ?? null,
 						entry.status ?? null,
 						entry.resetsAt ?? null,
 						last.id,
@@ -7317,6 +7331,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 					entry.label,
 					entry.windowLabel ?? null,
 					entry.usedFraction ?? null,
+					entry.used ?? null,
+					entry.unit ?? null,
 					entry.status ?? null,
 					entry.resetsAt ?? null,
 				);
@@ -7339,6 +7355,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				label: string;
 				window_label: string | null;
 				used_fraction: number | null;
+				used_value: number | null;
+				unit: string | null;
 				status: string | null;
 				resets_at: number | null;
 			}>;
@@ -7352,6 +7370,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 				label: row.label,
 				windowLabel: row.window_label ?? undefined,
 				usedFraction: row.used_fraction ?? undefined,
+				used: row.used_value ?? undefined,
+				unit: (row.unit ?? undefined) as UsageHistoryEntry["unit"],
 				status: (row.status ?? undefined) as UsageHistoryEntry["status"],
 				resetsAt: row.resets_at ?? undefined,
 			}));

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3307,17 +3307,7 @@ export class AuthStorage {
 				continue;
 			}
 
-			if (entries.length === 0) {
-				const runtimeKey = this.#runtimeOverrides.get(providerId);
-				const envKey = getEnvApiKey(providerId);
-				const apiKey = runtimeKey ?? envKey;
-				if (!apiKey) continue;
-				const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
-				if (providerImpl.supports && !providerImpl.supports(request)) continue;
-				requests.push(request);
-				continue;
-			}
-
+			const providerRequestStart = requests.length;
 			for (const entry of entries) {
 				const credential = entry.credential;
 				const request =
@@ -3327,6 +3317,15 @@ export class AuthStorage {
 				if (providerImpl.supports && !providerImpl.supports(request)) continue;
 				requests.push(request);
 			}
+			if (requests.length !== providerRequestStart) continue;
+
+			const runtimeKey = this.#runtimeOverrides.get(providerId);
+			const envKey = getEnvApiKey(providerId);
+			const apiKey = runtimeKey ?? envKey;
+			if (!apiKey) continue;
+			const request = this.#buildUsageRequest(provider, { type: "api_key", apiKey }, baseUrl);
+			if (providerImpl.supports && !providerImpl.supports(request)) continue;
+			requests.push(request);
 		}
 
 		return requests;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3387,6 +3387,7 @@ export class AuthStorage {
 		if (report.provider === "devin") {
 			const orgId = this.#getUsageReportMetadataValue(report, "orgId");
 			if (orgId) return [`devin:org:${orgId.toLowerCase()}`];
+			return ["devin:enterprise"];
 		}
 		if (report.provider === "openai-codex") {
 			return identifiers.map(identifier => `${report.provider}:${identifier.toLowerCase()}`);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3732,6 +3732,28 @@ export class AuthStorage {
 		return true;
 	}
 
+	/**
+	 * Check if a credential is supported by the provider's usage provider.
+	 */
+	async isCredentialSupported(provider: Provider, credential?: AuthCredential): Promise<boolean> {
+		const providerImpl = this.usageProviderFor(provider);
+		if (!providerImpl) return false;
+		if (!credential) return true;
+		if (!providerImpl.supports) return true;
+
+		let request: UsageRequestDescriptor;
+		if (credential.type === "api_key") {
+			const resolvedApiKey = await this.#configValueResolver(credential.key);
+			request = this.#buildUsageRequest(
+				provider,
+				{ type: "api_key", apiKey: resolvedApiKey ?? "" },
+			);
+		} else {
+			request = this.#buildUsageRequestForOauth(provider, credential);
+		}
+		return providerImpl.supports(request);
+	}
+
 	async fetchUsageReports(options?: {
 		baseUrlResolver?: (provider: Provider) => string | undefined;
 		/** Caller's cancel signal; only rejects this caller, never the shared upstream fetch. */

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3383,6 +3383,12 @@ export class AuthStorage {
 					identifier => `${report.provider}:org:${orgId.toLowerCase()}|${identifier.toLowerCase()}`,
 				);
 			}
+		}
+		if (report.provider === "devin") {
+			const orgId = this.#getUsageReportMetadataValue(report, "orgId");
+			if (orgId) return [`devin:org:${orgId.toLowerCase()}`];
+		}
+		if (report.provider === "openai-codex") {
 			return identifiers.map(identifier => `${report.provider}:${identifier.toLowerCase()}`);
 		}
 		const projectId =
@@ -3744,10 +3750,7 @@ export class AuthStorage {
 		let request: UsageRequestDescriptor;
 		if (credential.type === "api_key") {
 			const resolvedApiKey = await this.#configValueResolver(credential.key);
-			request = this.#buildUsageRequest(
-				provider,
-				{ type: "api_key", apiKey: resolvedApiKey ?? "" },
-			);
+			request = this.#buildUsageRequest(provider, { type: "api_key", apiKey: resolvedApiKey ?? "" });
 		} else {
 			request = this.#buildUsageRequestForOauth(provider, credential);
 		}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3884,10 +3884,17 @@ export class AuthStorage {
 
 			const baseUrl = options?.baseUrlResolver?.(row.provider as Provider);
 			const cred = row.credential;
-			const initialRequest: UsageRequestDescriptor =
-				cred.type === "api_key"
-					? this.#buildUsageRequest(row.provider as Provider, { type: "api_key", apiKey: cred.key }, baseUrl)
-					: this.#buildUsageRequestForOauth(row.provider as Provider, cred, baseUrl);
+			let initialRequest: UsageRequestDescriptor;
+			if (cred.type === "api_key") {
+				const resolvedApiKey = await this.#configValueResolver(cred.key);
+				initialRequest = this.#buildUsageRequest(
+					row.provider as Provider,
+					{ type: "api_key", apiKey: resolvedApiKey ?? "" },
+					baseUrl,
+				);
+			} else {
+				initialRequest = this.#buildUsageRequestForOauth(row.provider as Provider, cred, baseUrl);
+			}
 
 			const timeoutSignal = AbortSignal.timeout(timeoutMs);
 			const probeSignal = options?.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -46,6 +46,7 @@ import { resolveUsedFraction } from "./usage";
 import { alibabaTokenPlanRankingStrategy, alibabaTokenPlanUsageProvider } from "./usage/alibaba-token-plan";
 import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
 import { cursorUsageProvider } from "./usage/cursor";
+import { devinUsageProvider } from "./usage/devin";
 import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
@@ -597,6 +598,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	ollamaUsageProvider,
 	ollamaCloudUsageProvider,
 	claudeUsageProvider,
+	devinUsageProvider,
 	zaiUsageProvider,
 	opencodeGoUsageProvider,
 	githubCopilotUsageProvider,

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2927,6 +2927,17 @@ export class AuthStorage {
 			signal: timeoutSignal,
 		};
 
+		if (request.credential.type === "api_key") {
+			const configValue = request.credential.apiKey;
+			if (!configValue) return null;
+			const apiKey = await this.#configValueResolver(configValue);
+			if (!apiKey) return null;
+			params = {
+				...params,
+				credential: { ...request.credential, apiKey },
+			};
+		}
+
 		if (
 			request.credential.type === "oauth" &&
 			request.credential.expiresAt !== undefined &&

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -30,6 +30,7 @@ export * from "./types";
 export * from "./usage";
 export * from "./usage/claude";
 export * from "./usage/cursor";
+export * from "./usage/devin";
 export * from "./usage/gemini";
 export * from "./usage/github-copilot";
 export * from "./usage/google-antigravity";

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -155,6 +155,10 @@ export interface UsageHistoryEntry {
 	windowLabel?: string;
 	/** Used fraction (0..1) when resolvable. */
 	usedFraction?: number;
+	/** Absolute used amount for units without a meaningful limit (e.g. ACUs). */
+	used?: number;
+	/** Unit for the recorded amount. */
+	unit?: UsageUnit;
 	status?: UsageStatus;
 	/** Epoch ms the window resets, when known. */
 	resetsAt?: number;

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -6,7 +6,7 @@
  */
 import { type } from "arktype";
 import type { FetchImpl, Provider } from "./types";
-export type UsageUnit = "percent" | "tokens" | "requests" | "usd" | "minutes" | "bytes" | "unknown";
+export type UsageUnit = "percent" | "tokens" | "requests" | "usd" | "minutes" | "bytes" | "acus" | "unknown";
 
 export type UsageStatus = "ok" | "warning" | "exhausted" | "unknown";
 
@@ -187,7 +187,9 @@ export interface UsageCostHistoryQuery {
 
 // ─── Zod schemas (wire-shape validation for the broker `/v1/usage` endpoint) ─
 
-export const usageUnitSchema = type("'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'unknown'");
+export const usageUnitSchema = type(
+	"'percent' | 'tokens' | 'requests' | 'usd' | 'minutes' | 'bytes' | 'acus' | 'unknown'",
+);
 export const usageStatusSchema = type("'ok' | 'warning' | 'exhausted' | 'unknown'");
 
 export const usageWindowSchema = type({

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -379,7 +379,7 @@ function buildAcuLimits(
 		if (acus <= 0) continue;
 		limits.push({
 			id: `devin:acus:product:${product}`,
-			label: `${formatProductName(product)} ACU consumption`,
+			label: `${formatProductName(product)} product ACU consumption`,
 			scope: { ...baseScope, tier: product },
 			amount: { used: acus, unit: "acus" },
 			status: "ok",

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -401,14 +401,13 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	let orgId = readOrgId({
 		orgId: typeof credential.metadata?.orgId === "string" ? credential.metadata.orgId : undefined,
 	});
+	let discoveryError: unknown = null;
 
 	if (!orgId) {
 		try {
 			orgId = await discoverDevinOrgId(apiKey, baseUrl, ctx.fetch, params.signal);
 		} catch (error) {
-			if (isDevinAuthFailure(error)) {
-				throw error;
-			}
+			discoveryError = error;
 			ctx.logger?.debug("Devin org discovery failed", { provider: params.provider, error: String(error) });
 		}
 	}
@@ -443,6 +442,9 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 		}
 		if (isDevinAuthFailure(metricsError)) {
 			throw metricsError;
+		}
+		if (isDevinAuthFailure(discoveryError)) {
+			throw discoveryError;
 		}
 		if (consumptionError) {
 			ctx.logger?.warn("Devin consumption request failed", {

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -515,21 +515,12 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	};
 }
 
-function isDevinApiKeyLike(key: string): boolean {
-	const trimmed = key.trim();
-	if (trimmed.startsWith(DEVIN_API_KEY_PREFIX)) return true;
-	if (trimmed.startsWith("!")) return true;
-	if (/^[A-Z_0-9]+$/.test(trimmed)) return true;
-	return false;
-}
-
 export const devinUsageProvider: UsageProvider = {
 	id: "devin",
 	fetchUsage: fetchDevinUsage,
 	supports: params =>
 		params.provider === "devin" &&
 		params.credential.type === "api_key" &&
-		!!params.credential.apiKey &&
-		isDevinApiKeyLike(params.credential.apiKey),
+		normalizeDevinApiKey(params.credential.apiKey) !== undefined,
 	validatesCredentials: true,
 };

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -91,7 +91,8 @@ function normalizeBaseUrl(baseUrl?: string): string {
 	} catch {
 		return DEFAULT_DEVIN_API_BASE_URL;
 	}
-	return trimmed.replace(/\/+$/, "");
+	const normalized = trimmed.replace(/\/+$/, "");
+	return normalized.replace(/\/v3$/, "");
 }
 
 function normalizeDevinApiKey(apiKey: string | undefined): string | undefined {

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -59,6 +59,11 @@ interface DevinHttpFailure {
 	body: string;
 }
 
+interface DevinIdentity {
+	orgId?: string;
+	principalId?: string;
+}
+
 class DevinUsageRequestError extends Error {
 	readonly url: string;
 	readonly status: number;
@@ -114,12 +119,12 @@ function readOrgId(auth: Pick<DevinUsageAuth, "orgId">): string | undefined {
 	return auth.orgId?.trim() || $env.DEVIN_USAGE_ORG_ID?.trim() || $env.DEVIN_ORG_ID?.trim() || undefined;
 }
 
-async function discoverDevinOrgId(
+async function discoverDevinIdentity(
 	apiKey: string,
 	baseUrl: string | undefined,
 	fetchImpl: FetchImpl,
 	signal?: AbortSignal,
-): Promise<string | undefined> {
+): Promise<DevinIdentity> {
 	const url = `${normalizeBaseUrl(baseUrl)}/v3/self`;
 	let response: Response;
 	try {
@@ -142,20 +147,39 @@ async function discoverDevinOrgId(
 				body: await response.text(),
 			});
 		}
-		return undefined;
+		return {};
 	}
 
 	try {
 		const data = await response.json();
 		if (isRecord(data)) {
-			const discovered =
+			const discoveredOrgId =
 				typeof data.org_id === "string" ? data.org_id : typeof data.orgId === "string" ? data.orgId : undefined;
-			return discovered?.trim() || undefined;
+			const orgId = discoveredOrgId?.trim() || undefined;
+			const principalType = typeof data.principal_type === "string" ? data.principal_type.trim() : undefined;
+			const discoveredPrincipalId =
+				typeof data.service_user_id === "string"
+					? data.service_user_id
+					: typeof data.user_id === "string"
+						? data.user_id
+						: typeof data.devin_id === "string"
+							? data.devin_id
+							: undefined;
+			const rawPrincipalId = discoveredPrincipalId?.trim() || undefined;
+			const principalId = rawPrincipalId
+				? principalType
+					? `${principalType}:${rawPrincipalId}`
+					: rawPrincipalId
+				: undefined;
+			return {
+				...(orgId ? { orgId } : {}),
+				...(principalId ? { principalId } : {}),
+			};
 		}
 	} catch {
-		// Ignore JSON parse errors for discovery and yield no org
+		// Ignore JSON parse errors for discovery and yield no identity.
 	}
-	return undefined;
+	return {};
 }
 function buildConsumptionPaths(orgId: string | undefined): string[] {
 	if (!orgId) return ["/v3/enterprise/consumption/daily"];
@@ -368,6 +392,7 @@ function buildAcuLimits(
 function metadataFromParams(
 	params: UsageFetchParams,
 	orgId: string | undefined,
+	principalId: string | undefined,
 	consumption: DevinConsumptionSummary | null,
 	metrics: DevinUsageMetrics | null,
 ): Record<string, unknown> {
@@ -375,6 +400,7 @@ function metadataFromParams(
 	if (params.credential.accountId) metadata.accountId = params.credential.accountId;
 	if (params.credential.email) metadata.email = params.credential.email;
 	if (orgId) metadata.orgId = orgId;
+	if (principalId) metadata.principalId = principalId;
 	if (consumption) {
 		metadata.totalAcus = consumption.totalAcus;
 		metadata.acusByProduct = consumption.acusByProduct;
@@ -401,11 +427,17 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	let orgId = readOrgId({
 		orgId: typeof credential.metadata?.orgId === "string" ? credential.metadata.orgId : undefined,
 	});
+	let principalId =
+		typeof credential.metadata?.principalId === "string"
+			? credential.metadata.principalId.trim() || undefined
+			: undefined;
 	let discoveryError: unknown = null;
 
 	if (!orgId) {
 		try {
-			orgId = await discoverDevinOrgId(apiKey, baseUrl, ctx.fetch, params.signal);
+			const identity = await discoverDevinIdentity(apiKey, baseUrl, ctx.fetch, params.signal);
+			orgId = identity.orgId;
+			principalId = identity.principalId;
 		} catch (error) {
 			discoveryError = error;
 			ctx.logger?.debug("Devin org discovery failed", { provider: params.provider, error: String(error) });
@@ -475,7 +507,7 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 		...(consumption
 			? undefined
 			: { notes: ["Devin usage metrics were available, but ACU consumption was unavailable."] }),
-		metadata: metadataFromParams(params, orgId, consumption, metrics),
+		metadata: metadataFromParams(params, orgId, principalId, consumption, metrics),
 		raw: {
 			consumption: consumption?.raw,
 			metrics: metrics?.raw,

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -324,13 +324,11 @@ function metadataFromParams(
 	if (params.credential.email) metadata.email = params.credential.email;
 	if (orgId) metadata.orgId = orgId;
 	if (consumption) {
-		metadata.endpoint = consumption.endpoint;
 		metadata.totalAcus = consumption.totalAcus;
 		metadata.acusByProduct = consumption.acusByProduct;
 		metadata.consumptionByDate = consumption.entries;
 	}
 	if (metrics) {
-		metadata.metricsEndpoint = metrics.endpoint;
 		metadata.metrics = {
 			sessionsCount: metrics.sessionsCount,
 			searchesCount: metrics.searchesCount,

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -393,9 +393,6 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 export const devinUsageProvider: UsageProvider = {
 	id: "devin",
 	fetchUsage: fetchDevinUsage,
-	supports: params =>
-		params.provider === "devin" &&
-		params.credential.type === "api_key" &&
-		normalizeDevinApiKey(params.credential.apiKey) !== undefined,
+	supports: params => params.provider === "devin" && params.credential.type === "api_key",
 	validatesCredentials: true,
 };

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -5,7 +5,7 @@ import type { UsageFetchContext, UsageFetchParams, UsageLimit, UsageProvider, Us
 import { toNumber } from "./shared";
 
 const DEFAULT_DEVIN_API_BASE_URL = "https://api.devin.ai";
-const DEVIN_SESSION_TOKEN_PREFIX = "devin-session-token$";
+const DEVIN_API_KEY_PREFIX = "cog_";
 
 export interface DevinUsageQuery {
 	/** Unix seconds, Unix milliseconds, or a Date passed through as `time_after`. */
@@ -16,7 +16,6 @@ export interface DevinUsageQuery {
 
 export interface DevinUsageAuth extends DevinUsageQuery {
 	apiKey?: string;
-	accessToken?: string;
 	baseUrl?: string;
 	orgId?: string;
 	fetch: FetchImpl;
@@ -54,6 +53,28 @@ interface FetchJsonResult {
 	payload: unknown;
 }
 
+interface DevinHttpFailure {
+	url: string;
+	status: number;
+	body: string;
+}
+
+class DevinUsageRequestError extends Error {
+	readonly url: string;
+	readonly status: number;
+
+	constructor(label: string, failure: DevinHttpFailure) {
+		super(`Devin ${label} request failed: ${failure.status} ${failure.body}`.trim());
+		this.name = "DevinUsageRequestError";
+		this.url = failure.url;
+		this.status = failure.status;
+	}
+}
+
+function isDevinAuthFailure(error: unknown): boolean {
+	return error instanceof DevinUsageRequestError && (error.status === 401 || error.status === 403);
+}
+
 function normalizeBaseUrl(baseUrl?: string): string {
 	const trimmed = baseUrl?.trim();
 	if (!trimmed) return DEFAULT_DEVIN_API_BASE_URL;
@@ -68,14 +89,9 @@ function normalizeBaseUrl(baseUrl?: string): string {
 	return trimmed.replace(/\/+$/, "");
 }
 
-function normalizeBearerToken(token: string | undefined): string | undefined {
-	const trimmed = token?.trim();
-	if (!trimmed) return undefined;
-	return trimmed.startsWith(DEVIN_SESSION_TOKEN_PREFIX) ? trimmed.slice(DEVIN_SESSION_TOKEN_PREFIX.length) : trimmed;
-}
-
-function resolveToken(auth: Pick<DevinUsageAuth, "apiKey" | "accessToken">): string | undefined {
-	return normalizeBearerToken(auth.apiKey ?? auth.accessToken);
+function normalizeDevinApiKey(apiKey: string | undefined): string | undefined {
+	const trimmed = apiKey?.trim();
+	return trimmed?.startsWith(DEVIN_API_KEY_PREFIX) ? trimmed : undefined;
 }
 
 function toUnixSeconds(value: number | Date | undefined): number | undefined {
@@ -114,10 +130,10 @@ function buildMetricsPaths(orgId: string | undefined): string[] {
 }
 
 async function fetchFirstJson(auth: DevinUsageAuth, paths: string[], label: string): Promise<FetchJsonResult | null> {
-	const token = resolveToken(auth);
+	const token = normalizeDevinApiKey(auth.apiKey);
 	if (!token) return null;
 	const baseUrl = normalizeBaseUrl(auth.baseUrl);
-	let lastFailure: { url: string; status: number; body: string } | undefined;
+	let lastFailure: DevinHttpFailure | undefined;
 	for (const path of paths) {
 		const url = withUsageQuery(`${baseUrl}${path}`, auth);
 		let response: Response;
@@ -146,7 +162,7 @@ async function fetchFirstJson(auth: DevinUsageAuth, paths: string[], label: stri
 	}
 
 	if (lastFailure) {
-		throw new Error(`Devin ${label} request failed: ${lastFailure.status} ${lastFailure.body}`.trim());
+		throw new DevinUsageRequestError(label, lastFailure);
 	}
 	return null;
 }
@@ -328,9 +344,8 @@ function metadataFromParams(
 async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
 	if (params.provider !== "devin") return null;
 	const { credential } = params;
-	const apiKey = credential.type === "api_key" ? credential.apiKey : undefined;
-	const accessToken = credential.type === "oauth" ? credential.accessToken : undefined;
-	if (!apiKey && !accessToken) return null;
+	const apiKey = credential.type === "api_key" ? normalizeDevinApiKey(credential.apiKey) : undefined;
+	if (!apiKey) return null;
 
 	const baseUrl = params.baseUrl ?? credential.apiEndpoint;
 	const orgId = readOrgId({
@@ -338,7 +353,6 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	});
 	const auth: DevinUsageAuth = {
 		apiKey,
-		accessToken,
 		baseUrl,
 		orgId,
 		fetch: ctx.fetch,
@@ -349,6 +363,7 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	try {
 		consumption = await fetchDevinConsumption(auth);
 	} catch (error) {
+		if (isDevinAuthFailure(error)) throw error;
 		ctx.logger?.warn("Devin consumption request failed", { provider: params.provider, error: String(error) });
 	}
 
@@ -356,6 +371,7 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	try {
 		metrics = await fetchDevinUsageMetrics(auth);
 	} catch (error) {
+		if (isDevinAuthFailure(error)) throw error;
 		ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(error) });
 	}
 
@@ -380,6 +396,8 @@ export const devinUsageProvider: UsageProvider = {
 	id: "devin",
 	fetchUsage: fetchDevinUsage,
 	supports: params =>
-		params.provider === "devin" && (params.credential.type === "api_key" || params.credential.type === "oauth"),
+		params.provider === "devin" &&
+		params.credential.type === "api_key" &&
+		normalizeDevinApiKey(params.credential.apiKey) !== undefined,
 	validatesCredentials: true,
 };

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -114,6 +114,49 @@ function readOrgId(auth: Pick<DevinUsageAuth, "orgId">): string | undefined {
 	return auth.orgId?.trim() || $env.DEVIN_USAGE_ORG_ID?.trim() || $env.DEVIN_ORG_ID?.trim() || undefined;
 }
 
+async function discoverDevinOrgId(
+	apiKey: string,
+	baseUrl: string | undefined,
+	fetchImpl: FetchImpl,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	const url = `${normalizeBaseUrl(baseUrl)}/v3/self`;
+	let response: Response;
+	try {
+		response = await fetchImpl(url, {
+			headers: {
+				Accept: "application/json",
+				Authorization: `Bearer ${apiKey}`,
+			},
+			signal,
+		});
+	} catch {
+		throw new Error("Devin profile request failed before response");
+	}
+
+	if (!response.ok) {
+		if (response.status === 401 || response.status === 403) {
+			throw new DevinUsageRequestError("profile", {
+				url,
+				status: response.status,
+				body: await response.text(),
+			});
+		}
+		return undefined;
+	}
+
+	try {
+		const data = await response.json();
+		if (isRecord(data)) {
+			const discovered =
+				typeof data.org_id === "string" ? data.org_id : typeof data.orgId === "string" ? data.orgId : undefined;
+			return discovered?.trim() || undefined;
+		}
+	} catch {
+		// Ignore JSON parse errors for discovery and yield no org
+	}
+	return undefined;
+}
 function buildConsumptionPaths(orgId: string | undefined): string[] {
 	if (!orgId) return ["/v3/enterprise/consumption/daily"];
 	const encoded = encodeURIComponent(orgId);
@@ -346,9 +389,21 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	if (!apiKey) return null;
 
 	const baseUrl = params.baseUrl ?? credential.apiEndpoint;
-	const orgId = readOrgId({
+	let orgId = readOrgId({
 		orgId: typeof credential.metadata?.orgId === "string" ? credential.metadata.orgId : undefined,
 	});
+
+	if (!orgId) {
+		try {
+			orgId = await discoverDevinOrgId(apiKey, baseUrl, ctx.fetch, params.signal);
+		} catch (error) {
+			if (isDevinAuthFailure(error)) {
+				throw error;
+			}
+			ctx.logger?.debug("Devin org discovery failed", { provider: params.provider, error: String(error) });
+		}
+	}
+
 	const auth: DevinUsageAuth = {
 		apiKey,
 		baseUrl,
@@ -381,7 +436,10 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 			throw metricsError;
 		}
 		if (consumptionError) {
-			ctx.logger?.warn("Devin consumption request failed", { provider: params.provider, error: String(consumptionError) });
+			ctx.logger?.warn("Devin consumption request failed", {
+				provider: params.provider,
+				error: String(consumptionError),
+			});
 		}
 		if (metricsError) {
 			ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(metricsError) });
@@ -390,7 +448,10 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	}
 
 	if (!consumption && consumptionError) {
-		ctx.logger?.warn("Devin consumption request failed", { provider: params.provider, error: String(consumptionError) });
+		ctx.logger?.warn("Devin consumption request failed", {
+			provider: params.provider,
+			error: String(consumptionError),
+		});
 	}
 	if (!metrics && metricsError) {
 		ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(metricsError) });

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -371,7 +371,7 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	try {
 		metrics = await fetchDevinUsageMetrics(auth);
 	} catch (error) {
-		if (isDevinAuthFailure(error)) throw error;
+		if (!consumption && isDevinAuthFailure(error)) throw error;
 		ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(error) });
 	}
 

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -177,6 +177,7 @@ async function fetchFirstJson(auth: DevinUsageAuth, paths: string[], label: stri
 	if (!token) return null;
 	const baseUrl = normalizeBaseUrl(auth.baseUrl);
 	let lastFailure: DevinHttpFailure | undefined;
+	let firstAuthFailure: DevinHttpFailure | undefined;
 	for (const path of paths) {
 		const url = withUsageQuery(`${baseUrl}${path}`, auth);
 		let response: Response;
@@ -193,7 +194,11 @@ async function fetchFirstJson(auth: DevinUsageAuth, paths: string[], label: stri
 		}
 
 		if (!response.ok) {
-			lastFailure = { url, status: response.status, body: await response.text() };
+			const failure = { url, status: response.status, body: await response.text() };
+			if (!firstAuthFailure && (failure.status === 401 || failure.status === 403)) {
+				firstAuthFailure = failure;
+			}
+			lastFailure = failure;
 			continue;
 		}
 
@@ -202,6 +207,10 @@ async function fetchFirstJson(auth: DevinUsageAuth, paths: string[], label: stri
 		} catch {
 			lastFailure = { url, status: response.status, body: "invalid JSON response" };
 		}
+	}
+
+	if (firstAuthFailure) {
+		throw new DevinUsageRequestError(label, firstAuthFailure);
 	}
 
 	if (lastFailure) {

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -1,0 +1,385 @@
+import { $env } from "@oh-my-pi/pi-utils/env";
+import { isRecord } from "@oh-my-pi/pi-utils/type-guards";
+import type { FetchImpl } from "../types";
+import type { UsageFetchContext, UsageFetchParams, UsageLimit, UsageProvider, UsageReport } from "../usage";
+import { toNumber } from "./shared";
+
+const DEFAULT_DEVIN_API_BASE_URL = "https://api.devin.ai";
+const DEVIN_SESSION_TOKEN_PREFIX = "devin-session-token$";
+
+export interface DevinUsageQuery {
+	/** Unix seconds, Unix milliseconds, or a Date passed through as `time_after`. */
+	timeAfter?: number | Date;
+	/** Unix seconds, Unix milliseconds, or a Date passed through as `time_before`. */
+	timeBefore?: number | Date;
+}
+
+export interface DevinUsageAuth extends DevinUsageQuery {
+	apiKey?: string;
+	accessToken?: string;
+	baseUrl?: string;
+	orgId?: string;
+	fetch: FetchImpl;
+	signal?: AbortSignal;
+}
+
+export interface DevinConsumptionEntry {
+	/** Day boundary as returned by Devin, normalized to Unix milliseconds when parseable. */
+	date?: number;
+	/** YYYY-MM-DD rendering of `date`, when parseable. */
+	day?: string;
+	acus: number;
+	acusByProduct: Record<string, number>;
+}
+
+export interface DevinConsumptionSummary {
+	totalAcus: number;
+	entries: DevinConsumptionEntry[];
+	acusByProduct: Record<string, number>;
+	endpoint: string;
+	raw: unknown;
+}
+
+export interface DevinUsageMetrics {
+	sessionsCount?: number;
+	searchesCount?: number;
+	prsCreatedCount?: number;
+	prsMergedCount?: number;
+	endpoint: string;
+	raw: unknown;
+}
+
+interface FetchJsonResult {
+	url: string;
+	payload: unknown;
+}
+
+function normalizeBaseUrl(baseUrl?: string): string {
+	const trimmed = baseUrl?.trim();
+	if (!trimmed) return DEFAULT_DEVIN_API_BASE_URL;
+	try {
+		const parsed = new URL(trimmed);
+		// OMP's Devin chat provider talks to the Codeium/Cascade Connect endpoint;
+		// public usage lives on api.devin.ai.
+		if (parsed.hostname === "server.codeium.com") return DEFAULT_DEVIN_API_BASE_URL;
+	} catch {
+		return DEFAULT_DEVIN_API_BASE_URL;
+	}
+	return trimmed.replace(/\/+$/, "");
+}
+
+function normalizeBearerToken(token: string | undefined): string | undefined {
+	const trimmed = token?.trim();
+	if (!trimmed) return undefined;
+	return trimmed.startsWith(DEVIN_SESSION_TOKEN_PREFIX) ? trimmed.slice(DEVIN_SESSION_TOKEN_PREFIX.length) : trimmed;
+}
+
+function resolveToken(auth: Pick<DevinUsageAuth, "apiKey" | "accessToken">): string | undefined {
+	return normalizeBearerToken(auth.apiKey ?? auth.accessToken);
+}
+
+function toUnixSeconds(value: number | Date | undefined): number | undefined {
+	if (value === undefined) return undefined;
+	const millis = value instanceof Date ? value.getTime() : value > 1_000_000_000_000 ? value : value * 1000;
+	if (!Number.isFinite(millis)) return undefined;
+	return Math.floor(millis / 1000);
+}
+
+function withUsageQuery(url: string, query: DevinUsageQuery): string {
+	const parsed = new URL(url);
+	const timeAfter = toUnixSeconds(query.timeAfter);
+	const timeBefore = toUnixSeconds(query.timeBefore);
+	if (timeAfter !== undefined) parsed.searchParams.set("time_after", String(timeAfter));
+	if (timeBefore !== undefined) parsed.searchParams.set("time_before", String(timeBefore));
+	return parsed.toString();
+}
+
+function readOrgId(auth: Pick<DevinUsageAuth, "orgId">): string | undefined {
+	return auth.orgId?.trim() || $env.DEVIN_USAGE_ORG_ID?.trim() || $env.DEVIN_ORG_ID?.trim() || undefined;
+}
+
+function buildConsumptionPaths(orgId: string | undefined): string[] {
+	if (!orgId) return ["/v3/enterprise/consumption/daily"];
+	const encoded = encodeURIComponent(orgId);
+	return [
+		`/v3/organizations/${encoded}/consumption/daily`,
+		`/v3/enterprise/consumption/daily/organizations/${encoded}`,
+	];
+}
+
+function buildMetricsPaths(orgId: string | undefined): string[] {
+	if (!orgId) return ["/v3/enterprise/metrics/usage"];
+	const encoded = encodeURIComponent(orgId);
+	return [`/v3/organizations/${encoded}/metrics/usage`, `/v3/enterprise/organizations/${encoded}/metrics/usage`];
+}
+
+async function fetchFirstJson(auth: DevinUsageAuth, paths: string[], label: string): Promise<FetchJsonResult | null> {
+	const token = resolveToken(auth);
+	if (!token) return null;
+	const baseUrl = normalizeBaseUrl(auth.baseUrl);
+	let lastFailure: { url: string; status: number; body: string } | undefined;
+	for (const path of paths) {
+		const url = withUsageQuery(`${baseUrl}${path}`, auth);
+		let response: Response;
+		try {
+			response = await auth.fetch(url, {
+				headers: {
+					Accept: "application/json",
+					Authorization: `Bearer ${token}`,
+				},
+				signal: auth.signal,
+			});
+		} catch {
+			throw new Error(`Devin ${label} request failed before response`);
+		}
+
+		if (!response.ok) {
+			lastFailure = { url, status: response.status, body: await response.text() };
+			continue;
+		}
+
+		try {
+			return { url, payload: await response.json() };
+		} catch {
+			lastFailure = { url, status: response.status, body: "invalid JSON response" };
+		}
+	}
+
+	if (lastFailure) {
+		throw new Error(`Devin ${label} request failed: ${lastFailure.status} ${lastFailure.body}`.trim());
+	}
+	return null;
+}
+
+function parseDateMillis(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return value > 1_000_000_000_000 ? value : value * 1000;
+	}
+	if (typeof value === "string" && value.trim()) {
+		const numeric = Number(value);
+		if (Number.isFinite(numeric)) return numeric > 1_000_000_000_000 ? numeric : numeric * 1000;
+		const parsed = Date.parse(value);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return undefined;
+}
+
+function formatDay(dateMs: number | undefined): string | undefined {
+	if (dateMs === undefined || !Number.isFinite(dateMs)) return undefined;
+	return new Date(dateMs).toISOString().slice(0, 10);
+}
+
+function parseAcusByProduct(value: unknown): Record<string, number> {
+	if (!isRecord(value)) return {};
+	const parsed: Record<string, number> = {};
+	for (const [product, raw] of Object.entries(value)) {
+		const acus = toNumber(raw);
+		if (acus === undefined) continue;
+		parsed[product] = acus;
+	}
+	return parsed;
+}
+
+function parseConsumptionEntry(value: unknown): DevinConsumptionEntry | null {
+	if (!isRecord(value)) return null;
+	const acus = toNumber(value.acus);
+	if (acus === undefined) return null;
+	const date = parseDateMillis(value.date);
+	return {
+		...(date !== undefined ? { date, day: formatDay(date) } : {}),
+		acus,
+		acusByProduct: parseAcusByProduct(value.acus_by_product),
+	};
+}
+
+function sumProductTotals(entries: DevinConsumptionEntry[]): Record<string, number> {
+	const totals = new Map<string, number>();
+	for (const entry of entries) {
+		for (const [product, acus] of Object.entries(entry.acusByProduct)) {
+			totals.set(product, (totals.get(product) ?? 0) + acus);
+		}
+	}
+	return Object.fromEntries([...totals.entries()].sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function parseConsumptionPayload(payload: unknown, endpoint: string): DevinConsumptionSummary | null {
+	if (!isRecord(payload)) return null;
+	const entries = Array.isArray(payload.consumption_by_date)
+		? payload.consumption_by_date
+				.map(parseConsumptionEntry)
+				.filter((entry): entry is DevinConsumptionEntry => entry !== null)
+		: [];
+	const totalFromPayload = toNumber(payload.total_acus);
+	if (totalFromPayload === undefined && entries.length === 0) return null;
+	const totalAcus = totalFromPayload ?? entries.reduce((sum, entry) => sum + entry.acus, 0);
+	if (!Number.isFinite(totalAcus)) return null;
+	return {
+		totalAcus,
+		entries,
+		acusByProduct: sumProductTotals(entries),
+		endpoint,
+		raw: payload,
+	};
+}
+
+function parseMetricsPayload(payload: unknown, endpoint: string): DevinUsageMetrics | null {
+	if (!isRecord(payload)) return null;
+	const metrics: DevinUsageMetrics = {
+		sessionsCount: toNumber(payload.sessions_count),
+		searchesCount: toNumber(payload.searches_count),
+		prsCreatedCount: toNumber(payload.prs_created_count),
+		prsMergedCount: toNumber(payload.prs_merged_count),
+		endpoint,
+		raw: payload,
+	};
+	if (
+		metrics.sessionsCount === undefined &&
+		metrics.searchesCount === undefined &&
+		metrics.prsCreatedCount === undefined &&
+		metrics.prsMergedCount === undefined
+	) {
+		return null;
+	}
+	return metrics;
+}
+
+export async function fetchDevinConsumption(auth: DevinUsageAuth): Promise<DevinConsumptionSummary | null> {
+	const result = await fetchFirstJson(auth, buildConsumptionPaths(readOrgId(auth)), "consumption");
+	return result ? parseConsumptionPayload(result.payload, result.url) : null;
+}
+
+export async function fetchDevinUsageMetrics(auth: DevinUsageAuth): Promise<DevinUsageMetrics | null> {
+	const result = await fetchFirstJson(auth, buildMetricsPaths(readOrgId(auth)), "metrics");
+	return result ? parseMetricsPayload(result.payload, result.url) : null;
+}
+
+function formatProductName(product: string): string {
+	return product
+		.split(/[-_]/g)
+		.filter(Boolean)
+		.map(part => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+function buildAcuLimits(
+	params: UsageFetchParams,
+	consumption: DevinConsumptionSummary,
+	orgId: string | undefined,
+): UsageLimit[] {
+	const baseScope: UsageLimit["scope"] = { provider: params.provider };
+	if (params.credential.accountId) {
+		baseScope.accountId = params.credential.accountId;
+	}
+	if (orgId) {
+		baseScope.orgId = orgId;
+	}
+	const limits: UsageLimit[] = [
+		{
+			id: "devin:acus:total",
+			label: "Devin ACU consumption",
+			scope: { ...baseScope, shared: true },
+			amount: { used: consumption.totalAcus, unit: "acus" },
+			status: "ok",
+		},
+	];
+
+	for (const [product, acus] of Object.entries(consumption.acusByProduct)) {
+		if (acus <= 0) continue;
+		limits.push({
+			id: `devin:acus:product:${product}`,
+			label: `${formatProductName(product)} ACU consumption`,
+			scope: { ...baseScope, tier: product },
+			amount: { used: acus, unit: "acus" },
+			status: "ok",
+		});
+	}
+
+	return limits;
+}
+
+function metadataFromParams(
+	params: UsageFetchParams,
+	orgId: string | undefined,
+	consumption: DevinConsumptionSummary | null,
+	metrics: DevinUsageMetrics | null,
+): Record<string, unknown> {
+	const metadata: Record<string, unknown> = {};
+	if (params.credential.accountId) metadata.accountId = params.credential.accountId;
+	if (params.credential.email) metadata.email = params.credential.email;
+	if (orgId) metadata.orgId = orgId;
+	if (consumption) {
+		metadata.endpoint = consumption.endpoint;
+		metadata.totalAcus = consumption.totalAcus;
+		metadata.acusByProduct = consumption.acusByProduct;
+		metadata.consumptionByDate = consumption.entries;
+	}
+	if (metrics) {
+		metadata.metricsEndpoint = metrics.endpoint;
+		metadata.metrics = {
+			sessionsCount: metrics.sessionsCount,
+			searchesCount: metrics.searchesCount,
+			prsCreatedCount: metrics.prsCreatedCount,
+			prsMergedCount: metrics.prsMergedCount,
+		};
+	}
+	return metadata;
+}
+
+async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
+	if (params.provider !== "devin") return null;
+	const { credential } = params;
+	const apiKey = credential.type === "api_key" ? credential.apiKey : undefined;
+	const accessToken = credential.type === "oauth" ? credential.accessToken : undefined;
+	if (!apiKey && !accessToken) return null;
+
+	const baseUrl = params.baseUrl ?? credential.apiEndpoint;
+	const orgId = readOrgId({
+		orgId: typeof credential.metadata?.orgId === "string" ? credential.metadata.orgId : undefined,
+	});
+	const auth: DevinUsageAuth = {
+		apiKey,
+		accessToken,
+		baseUrl,
+		orgId,
+		fetch: ctx.fetch,
+		signal: params.signal,
+	};
+
+	let consumption: DevinConsumptionSummary | null = null;
+	try {
+		consumption = await fetchDevinConsumption(auth);
+	} catch (error) {
+		ctx.logger?.warn("Devin consumption request failed", { provider: params.provider, error: String(error) });
+	}
+
+	let metrics: DevinUsageMetrics | null = null;
+	try {
+		metrics = await fetchDevinUsageMetrics(auth);
+	} catch (error) {
+		ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(error) });
+	}
+
+	if (!consumption && !metrics) return null;
+	const limits = consumption ? buildAcuLimits(params, consumption, orgId) : [];
+	return {
+		provider: params.provider,
+		fetchedAt: Date.now(),
+		limits,
+		...(consumption
+			? undefined
+			: { notes: ["Devin usage metrics were available, but ACU consumption was unavailable."] }),
+		metadata: metadataFromParams(params, orgId, consumption, metrics),
+		raw: {
+			consumption: consumption?.raw,
+			metrics: metrics?.raw,
+		},
+	};
+}
+
+export const devinUsageProvider: UsageProvider = {
+	id: "devin",
+	fetchUsage: fetchDevinUsage,
+	supports: params =>
+		params.provider === "devin" && (params.credential.type === "api_key" || params.credential.type === "oauth"),
+	validatesCredentials: true,
+};

--- a/packages/ai/src/usage/devin.ts
+++ b/packages/ai/src/usage/devin.ts
@@ -358,22 +358,43 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	};
 
 	let consumption: DevinConsumptionSummary | null = null;
+	let consumptionError: unknown = null;
 	try {
 		consumption = await fetchDevinConsumption(auth);
 	} catch (error) {
-		if (isDevinAuthFailure(error)) throw error;
-		ctx.logger?.warn("Devin consumption request failed", { provider: params.provider, error: String(error) });
+		consumptionError = error;
 	}
 
 	let metrics: DevinUsageMetrics | null = null;
+	let metricsError: unknown = null;
 	try {
 		metrics = await fetchDevinUsageMetrics(auth);
 	} catch (error) {
-		if (!consumption && isDevinAuthFailure(error)) throw error;
-		ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(error) });
+		metricsError = error;
 	}
 
-	if (!consumption && !metrics) return null;
+	if (!consumption && !metrics) {
+		if (isDevinAuthFailure(consumptionError)) {
+			throw consumptionError;
+		}
+		if (isDevinAuthFailure(metricsError)) {
+			throw metricsError;
+		}
+		if (consumptionError) {
+			ctx.logger?.warn("Devin consumption request failed", { provider: params.provider, error: String(consumptionError) });
+		}
+		if (metricsError) {
+			ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(metricsError) });
+		}
+		return null;
+	}
+
+	if (!consumption && consumptionError) {
+		ctx.logger?.warn("Devin consumption request failed", { provider: params.provider, error: String(consumptionError) });
+	}
+	if (!metrics && metricsError) {
+		ctx.logger?.debug("Devin metrics request failed", { provider: params.provider, error: String(metricsError) });
+	}
 	const limits = consumption ? buildAcuLimits(params, consumption, orgId) : [];
 	return {
 		provider: params.provider,
@@ -390,9 +411,21 @@ async function fetchDevinUsage(params: UsageFetchParams, ctx: UsageFetchContext)
 	};
 }
 
+function isDevinApiKeyLike(key: string): boolean {
+	const trimmed = key.trim();
+	if (trimmed.startsWith(DEVIN_API_KEY_PREFIX)) return true;
+	if (trimmed.startsWith("!")) return true;
+	if (/^[A-Z_0-9]+$/.test(trimmed)) return true;
+	return false;
+}
+
 export const devinUsageProvider: UsageProvider = {
 	id: "devin",
 	fetchUsage: fetchDevinUsage,
-	supports: params => params.provider === "devin" && params.credential.type === "api_key",
+	supports: params =>
+		params.provider === "devin" &&
+		params.credential.type === "api_key" &&
+		!!params.credential.apiKey &&
+		isDevinApiKeyLike(params.credential.apiKey),
 	validatesCredentials: true,
 };

--- a/packages/ai/test/auth-storage-usage-history.test.ts
+++ b/packages/ai/test/auth-storage-usage-history.test.ts
@@ -137,6 +137,7 @@ describe("AuthStorage usage history recording", () => {
 	afterEach(() => {
 		storage.close();
 		vi.restoreAllMocks();
+		setSystemTime();
 	});
 
 	it("appends one row per limit on a fresh fetch, attributed to the credential", async () => {
@@ -224,6 +225,103 @@ describe("AuthStorage usage history recording", () => {
 		expect(reports).toHaveLength(1);
 		expect(reports?.[0]?.limits).toHaveLength(2);
 		expect(storage.listUsageHistory({ provider: "devin" })).toHaveLength(2);
+	});
+
+	it("keeps Devin org history stable across credential order and key rotation without persisting the org ID", async () => {
+		storage.close();
+		store.close();
+		store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "devin"
+					? ({
+							id: "devin",
+							async fetchUsage(): Promise<UsageReport> {
+								return {
+									provider: "devin",
+									fetchedAt: Date.now(),
+									limits: [
+										{
+											id: "devin:acus:total",
+											label: "ACUs",
+											scope: { provider: "devin", shared: true },
+											amount: { used: 5, unit: "acus" },
+											status: "ok",
+										},
+									],
+									metadata: { orgId: "org-history-shared", principalId: "service-history" },
+								};
+							},
+						} satisfies UsageProvider)
+					: undefined,
+		});
+		await storage.reload();
+
+		setSystemTime(new Date(T0));
+		await storage.set("devin", [
+			{ type: "api_key", key: "cog_second-key" },
+			{ type: "api_key", key: "cog_first-key" },
+		]);
+		await storage.fetchUsageReports();
+
+		setSystemTime(new Date(T0 + HOUR));
+		await storage.set("devin", [
+			{ type: "api_key", key: "cog_first-key" },
+			{ type: "api_key", key: "cog_rotated-key" },
+		]);
+		await storage.fetchUsageReports();
+
+		const history = storage.listUsageHistory({ provider: "devin" });
+		expect(history).toHaveLength(2);
+		const accountKeys = new Set(history.map(entry => entry.accountKey));
+		expect(accountKeys.size).toBe(1);
+		const [accountKey] = [...accountKeys];
+		expect(accountKey).toStartWith("devin:org:");
+		expect(accountKey).not.toContain("org-history-shared");
+	});
+
+	it("keeps distinct per-credential history when a Devin report has no shared identity", async () => {
+		storage.close();
+		store.close();
+		store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "devin"
+					? ({
+							id: "devin",
+							async fetchUsage(): Promise<UsageReport> {
+								return {
+									provider: "devin",
+									fetchedAt: T0,
+									limits: [
+										{
+											id: "devin:acus:total",
+											label: "ACUs",
+											scope: { provider: "devin", shared: true },
+											amount: { used: 5, unit: "acus" },
+											status: "ok",
+										},
+									],
+								};
+							},
+						} satisfies UsageProvider)
+					: undefined,
+		});
+		await storage.reload();
+		await storage.set("devin", [
+			{ type: "api_key", key: "cog_unidentified-one" },
+			{ type: "api_key", key: "cog_unidentified-two" },
+		]);
+
+		await storage.fetchUsageReports();
+
+		const history = storage.listUsageHistory({ provider: "devin" });
+		expect(history).toHaveLength(2);
+		expect(new Set(history.map(entry => entry.accountKey)).size).toBe(2);
+		for (const entry of history) {
+			expect(entry.accountKey).toContain("secret:");
+			expect(entry.accountKey).not.toContain("cog_unidentified");
+		}
 	});
 });
 

--- a/packages/ai/test/auth-storage-usage-history.test.ts
+++ b/packages/ai/test/auth-storage-usage-history.test.ts
@@ -15,7 +15,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, setSystemTime, vi } from "bun:test";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
-import type { UsageHistoryEntry, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import type { UsageHistoryEntry, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
 import * as claudeUsage from "@oh-my-pi/pi-ai/usage/claude";
 import * as opencodeGoUsage from "@oh-my-pi/pi-ai/usage/opencode-go";
 
@@ -185,6 +185,45 @@ describe("AuthStorage usage history recording", () => {
 		const sevenDay = rows.find(row => row.limitId === "anthropic:7d");
 		expect(sevenDay?.usedFraction).toBeCloseTo(0.84);
 		expect(sevenDay?.status).toBe("warning");
+	});
+	it("records history for reports merged across Devin credentials", async () => {
+		storage.close();
+		store.close();
+		store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		storage = new AuthStorage(store, {
+			usageProviderResolver: provider =>
+				provider === "devin"
+					? ({
+							id: "devin",
+							async fetchUsage(params): Promise<UsageReport> {
+								const apiKey = params.credential.type === "api_key" ? params.credential.apiKey : "";
+								return {
+									provider: "devin",
+									fetchedAt: T0,
+									limits: [
+										{
+											id: `devin:${apiKey}`,
+											label: "ACUs",
+											scope: { provider: "devin", accountId: "org-shared" },
+											amount: { used: apiKey === "key-one" ? 3 : 5, unit: "acus" },
+											status: "ok",
+										},
+									],
+									metadata: { orgId: "org-shared", principalId: "service-shared" },
+								};
+							},
+						} satisfies UsageProvider)
+					: undefined,
+		});
+		await storage.reload();
+		await storage.set("devin", [
+			{ type: "api_key", key: "key-one" },
+			{ type: "api_key", key: "key-two" },
+		]);
+		const reports = await storage.fetchUsageReports();
+		expect(reports).toHaveLength(1);
+		expect(reports?.[0]?.limits).toHaveLength(2);
+		expect(storage.listUsageHistory({ provider: "devin" })).toHaveLength(2);
 	});
 });
 

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -905,7 +905,7 @@ describe("devinUsageProvider", () => {
 });
 
 describe("fetchDevinConsumption", () => {
-	it("passes date query parameters to the selected org endpoint", async () => {
+	it("passes date query parameters without duplicating a versioned API root", async () => {
 		const urls: string[] = [];
 		const fetchImpl: FetchImpl = async input => {
 			const url = String(input instanceof Request ? input.url : input);
@@ -918,7 +918,7 @@ describe("fetchDevinConsumption", () => {
 
 		const summary = await fetchDevinConsumption({
 			apiKey: "cog_token",
-			baseUrl: "https://api.example.test/",
+			baseUrl: "https://api.example.test/v3/",
 			orgId: "org-xyz",
 			timeAfter: new Date("2026-01-01T00:00:00.000Z"),
 			timeBefore: 1767312000,

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -230,13 +230,13 @@ describe("devinUsageProvider", () => {
 		}
 	});
 
-	it("deduplicates enterprise-wide usage when service-user keys have no org", async () => {
+	it("deduplicates enterprise-wide usage only when /v3/self identifies the same principal", async () => {
 		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
 		const storage = new AuthStorage(store, {
 			usageFetch: (async input => {
 				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
 				const payload = path.endsWith("/v3/self")
-					? {}
+					? { org_id: null, principal_type: "service_user", service_user_id: "service-shared" }
 					: path.includes("consumption")
 						? { total_acus: 12.5, consumption_by_date: [] }
 						: { sessions_count: 2 };
@@ -257,8 +257,53 @@ describe("devinUsageProvider", () => {
 
 			expect(reports).toHaveLength(1);
 			expect(reports?.[0]?.metadata?.orgId).toBeUndefined();
+			expect(reports?.[0]?.metadata?.principalId).toBe("service_user:service-shared");
 			expect(reports?.[0]?.limits).toHaveLength(1);
 			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 12.5, unit: "acus" });
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("keeps org-less enterprise reports from distinct principals separate", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const storage = new AuthStorage(store, {
+			usageFetch: (async (input, init) => {
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				const authorization = new Headers(init?.headers).get("authorization");
+				const firstPrincipal = authorization === "Bearer cog_enterprise-user-one";
+				const payload = path.endsWith("/v3/self")
+					? {
+							org_id: null,
+							principal_type: "service_user",
+							service_user_id: firstPrincipal ? "service-one" : "service-two",
+						}
+					: path.includes("consumption")
+						? { total_acus: firstPrincipal ? 7 : 9, consumption_by_date: [] }
+						: { sessions_count: 2 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [
+				{ type: "api_key", key: "cog_enterprise-user-one" },
+				{ type: "api_key", key: "cog_enterprise-user-two" },
+			]);
+
+			const reports = (await storage.fetchUsageReports())?.filter(report => report.provider === "devin");
+
+			expect(reports).toHaveLength(2);
+			expect(reports?.map(report => report.metadata?.principalId).sort()).toEqual([
+				"service_user:service-one",
+				"service_user:service-two",
+			]);
+			expect(
+				reports?.map(report => report.limits[0]?.amount.used).sort((left, right) => (left ?? 0) - (right ?? 0)),
+			).toEqual([7, 9]);
 		} finally {
 			storage.close();
 		}

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -301,7 +301,7 @@ describe("devinUsageProvider", () => {
 				{ provider: "devin", credential: { type: "api_key", apiKey: "cog_bad-token" } },
 				{ fetch: fetchImpl },
 			),
-		).rejects.toThrow("Devin profile request failed: 401 unauthorized");
+		).rejects.toThrow("Devin consumption request failed: 401 unauthorized");
 	});
 
 	it("uses org-scoped endpoints and falls back to enterprise org endpoints", async () => {
@@ -582,15 +582,47 @@ describe("devinUsageProvider", () => {
 		]);
 	});
 
-	it("bubbles up /v3/self auth failure and fails validation", async () => {
-		const fetchImpl: FetchImpl = async () => new Response("unauthorized", { status: 401 });
+	it("continues to enterprise usage when /v3/self permission is forbidden", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+			paths.push(path);
+			if (path === "/v3/self") {
+				return new Response("forbidden", { status: 403 });
+			}
+			if (path === "/v3/enterprise/consumption/daily") {
+				return new Response(JSON.stringify({ total_acus: 6, consumption_by_date: [] }), { status: 200 });
+			}
+			return new Response("forbidden", { status: 403 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_usage-only" } },
+			{ fetch: fetchImpl },
+		);
+
+		expect(report?.limits[0]?.amount).toEqual({ used: 6, unit: "acus" });
+		expect(paths).toEqual(["/v3/self", "/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+	});
+
+	it("surfaces /v3/self auth failure when enterprise usage is unavailable", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const fetchImpl: FetchImpl = async input => {
+			const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+			return path === "/v3/self"
+				? new Response("forbidden", { status: 403 })
+				: new Response("not found", { status: 404 });
+		};
 
 		await expect(
 			devinUsageProvider.fetchUsage(
-				{ provider: "devin", credential: { type: "api_key", apiKey: "cog_token" } },
+				{ provider: "devin", credential: { type: "api_key", apiKey: "cog_unavailable" } },
 				{ fetch: fetchImpl },
 			),
-		).rejects.toThrow("Devin profile request failed: 401 unauthorized");
+		).rejects.toThrow("Devin profile request failed: 403 forbidden");
 	});
 });
 

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -40,12 +40,15 @@ const devinModel: Model<"devin-agent"> = buildModel({
 const context: Context = { messages: [{ role: "user", content: "hi", timestamp: 1 }] };
 const ORIGINAL_DEVIN_ORG_ID = Bun.env.DEVIN_ORG_ID;
 const ORIGINAL_DEVIN_USAGE_ORG_ID = Bun.env.DEVIN_USAGE_ORG_ID;
+const ORIGINAL_DEVIN_API_KEY = Bun.env.DEVIN_API_KEY;
 
 afterEach(() => {
 	if (ORIGINAL_DEVIN_ORG_ID === undefined) delete Bun.env.DEVIN_ORG_ID;
 	else Bun.env.DEVIN_ORG_ID = ORIGINAL_DEVIN_ORG_ID;
 	if (ORIGINAL_DEVIN_USAGE_ORG_ID === undefined) delete Bun.env.DEVIN_USAGE_ORG_ID;
 	else Bun.env.DEVIN_USAGE_ORG_ID = ORIGINAL_DEVIN_USAGE_ORG_ID;
+	if (ORIGINAL_DEVIN_API_KEY === undefined) delete Bun.env.DEVIN_API_KEY;
+	else Bun.env.DEVIN_API_KEY = ORIGINAL_DEVIN_API_KEY;
 });
 
 describe("streamDevin usage", () => {
@@ -156,6 +159,48 @@ describe("devinUsageProvider", () => {
 		expect(devinUsageProvider.supports?.(referencedApiKey)).toBe(true);
 		expect(devinUsageProvider.supports?.(unsupportedOauth)).toBe(false);
 		expect(devinUsageProvider.supports?.(wrongProvider)).toBe(false);
+	});
+
+	it("uses DEVIN_API_KEY when a stored Devin OAuth row cannot fetch usage", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		Bun.env.DEVIN_API_KEY = "cog_env-usage";
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const authorization: Array<string | null> = [];
+		const storage = new AuthStorage(store, {
+			usageFetch: (async (input, init) => {
+				authorization.push(new Headers(init?.headers).get("authorization"));
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				const payload = path.endsWith("/v3/self")
+					? { principal_type: "service_user", service_user_id: "service-env", org_id: null }
+					: path.includes("consumption")
+						? { total_acus: 4, consumption_by_date: [] }
+						: { sessions_count: 1 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [
+				{
+					type: "oauth",
+					access: "devin-oauth-access",
+					refresh: "devin-oauth-refresh",
+					expires: Date.now() + 3_600_000,
+				},
+			]);
+
+			const reports = await storage.fetchUsageReports();
+
+			expect(authorization).toEqual(["Bearer cog_env-usage", "Bearer cog_env-usage", "Bearer cog_env-usage"]);
+			expect(reports?.map(report => report.provider)).toEqual(["devin"]);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 4, unit: "acus" });
+		} finally {
+			storage.close();
+		}
 	});
 
 	it("resolves stored API-key config references before fetching usage", async () => {

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -127,11 +127,11 @@ describe("devinUsageProvider", () => {
 			{ path: "/v3/enterprise/metrics/usage", authorization: "Bearer cog_test-token" },
 		]);
 		expect(report.provider).toBe("devin");
-		expect(report.limits.map(limit => [limit.id, limit.amount.used, limit.amount.unit])).toEqual([
-			["devin:acus:total", 12.5, "acus"],
-			["devin:acus:product:cascade", 2.5, "acus"],
-			["devin:acus:product:devin", 8, "acus"],
-			["devin:acus:product:terminal", 2, "acus"],
+		expect(report.limits.map(limit => [limit.id, limit.label, limit.amount.used, limit.amount.unit])).toEqual([
+			["devin:acus:total", "Devin ACU consumption", 12.5, "acus"],
+			["devin:acus:product:cascade", "Cascade product ACU consumption", 2.5, "acus"],
+			["devin:acus:product:devin", "Devin product ACU consumption", 8, "acus"],
+			["devin:acus:product:terminal", "Terminal product ACU consumption", 2, "acus"],
 		]);
 		expect(report.metadata).toMatchObject({
 			totalAcus: 12.5,

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -203,6 +203,45 @@ describe("devinUsageProvider", () => {
 		}
 	});
 
+	it("uses the configured Devin API key when no supported stored credential exists", async () => {
+		delete Bun.env.DEVIN_API_KEY;
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const authorization: Array<string | null> = [];
+		const storage = new AuthStorage(store, {
+			usageFetch: (async (input, init) => {
+				authorization.push(new Headers(init?.headers).get("authorization"));
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				const payload = path.endsWith("/v3/self")
+					? { principal_type: "service_user", service_user_id: "service-config", org_id: null }
+					: path.includes("consumption")
+						? { total_acus: 3, consumption_by_date: [] }
+						: { sessions_count: 1 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			storage.setConfigApiKey("devin", "cog_config-usage");
+
+			const reports = await storage.fetchUsageReports();
+
+			expect(authorization).toEqual([
+				"Bearer cog_config-usage",
+				"Bearer cog_config-usage",
+				"Bearer cog_config-usage",
+			]);
+			expect(reports?.map(report => report.provider)).toEqual(["devin"]);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 3, unit: "acus" });
+		} finally {
+			storage.close();
+		}
+	});
+
 	it("resolves stored API-key config references before fetching usage", async () => {
 		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
 		const authorization: Array<string | null> = [];

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -230,6 +230,40 @@ describe("devinUsageProvider", () => {
 		}
 	});
 
+	it("deduplicates enterprise-wide usage when service-user keys have no org", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const storage = new AuthStorage(store, {
+			usageFetch: (async input => {
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				const payload = path.endsWith("/v3/self")
+					? {}
+					: path.includes("consumption")
+						? { total_acus: 12.5, consumption_by_date: [] }
+						: { sessions_count: 2 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [
+				{ type: "api_key", key: "cog_enterprise-user-one" },
+				{ type: "api_key", key: "cog_enterprise-user-two" },
+			]);
+
+			const reports = (await storage.fetchUsageReports())?.filter(report => report.provider === "devin");
+
+			expect(reports).toHaveLength(1);
+			expect(reports?.[0]?.metadata?.orgId).toBeUndefined();
+			expect(reports?.[0]?.limits).toHaveLength(1);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 12.5, unit: "acus" });
+		} finally {
+			storage.close();
+		}
+	});
+
 	it("resolves stored API-key config references before checking credentials", async () => {
 		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
 		const authorization: Array<string | null> = [];

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -142,10 +142,14 @@ describe("devinUsageProvider", () => {
 		expect(validatedReport).not.toBeInstanceOf(type.errors);
 	});
 
-	it("supports Devin API-key credentials before resolving their values", () => {
-		const referencedApiKey: UsageFetchParams = {
+	it("requires a resolved cog_ Devin API key for usage eligibility", () => {
+		const unresolvedReference: UsageFetchParams = {
 			provider: "devin",
 			credential: { type: "api_key", apiKey: "DEVIN_API_KEY" },
+		};
+		const supportedApiKey: UsageFetchParams = {
+			provider: "devin",
+			credential: { type: "api_key", apiKey: "cog_valid-token" },
 		};
 		const unsupportedOauth: UsageFetchParams = {
 			provider: "devin",
@@ -156,7 +160,8 @@ describe("devinUsageProvider", () => {
 			credential: { type: "api_key", apiKey: "cog_valid-token" },
 		};
 
-		expect(devinUsageProvider.supports?.(referencedApiKey)).toBe(true);
+		expect(devinUsageProvider.supports?.(unresolvedReference)).toBe(false);
+		expect(devinUsageProvider.supports?.(supportedApiKey)).toBe(true);
 		expect(devinUsageProvider.supports?.(unsupportedOauth)).toBe(false);
 		expect(devinUsageProvider.supports?.(wrongProvider)).toBe(false);
 	});
@@ -275,6 +280,116 @@ describe("devinUsageProvider", () => {
 			]);
 			expect(reports?.map(report => report.provider)).toEqual(["devin"]);
 			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 2, unit: "acus" });
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("uses a configured cog_ fallback when a stored Devin reference resolves unsupported", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const authorization: Array<string | null> = [];
+		const storage = new AuthStorage(store, {
+			configValueResolver: async value => value,
+			usageFetch: (async (input, init) => {
+				authorization.push(new Headers(init?.headers).get("authorization"));
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				if (path.endsWith("/v3/self")) return new Response(JSON.stringify({}), { status: 404 });
+				const payload = path.includes("consumption")
+					? { total_acus: 6, consumption_by_date: [] }
+					: { sessions_count: 2 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [{ type: "api_key", key: "DEVIN_STALE_REFERENCE" }]);
+			storage.setConfigApiKey("devin", "cog_config-fallback");
+
+			const reports = await storage.fetchUsageReports();
+
+			expect(authorization).toEqual([
+				"Bearer cog_config-fallback",
+				"Bearer cog_config-fallback",
+				"Bearer cog_config-fallback",
+			]);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 6, unit: "acus" });
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("keeps a resolved stored Devin key ahead of the configured fallback", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const authorization: Array<string | null> = [];
+		const storage = new AuthStorage(store, {
+			configValueResolver: async value => (value === "DEVIN_STORED_REFERENCE" ? "cog_stored-key" : value),
+			usageFetch: (async (input, init) => {
+				authorization.push(new Headers(init?.headers).get("authorization"));
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				if (path.endsWith("/v3/self")) return new Response(JSON.stringify({}), { status: 404 });
+				const payload = path.includes("consumption")
+					? { total_acus: 6, consumption_by_date: [] }
+					: { sessions_count: 2 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [{ type: "api_key", key: "DEVIN_STORED_REFERENCE" }]);
+			storage.setConfigApiKey("devin", "cog_config-fallback");
+
+			const reports = await storage.fetchUsageReports();
+
+			expect(authorization).toEqual(["Bearer cog_stored-key", "Bearer cog_stored-key", "Bearer cog_stored-key"]);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 6, unit: "acus" });
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("uses the configured fallback after all stored Devin credentials return no usage data", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const authorization: Array<string | null> = [];
+		const storage = new AuthStorage(store, {
+			usageFetch: (async (input, init) => {
+				const authorizationValue = new Headers(init?.headers).get("authorization");
+				authorization.push(authorizationValue);
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				if (authorizationValue === "Bearer cog_stored-no-data") {
+					return new Response("not found", { status: 404 });
+				}
+				if (path.endsWith("/v3/self")) return new Response(JSON.stringify({}), { status: 404 });
+				const payload = path.includes("consumption")
+					? { total_acus: 8, consumption_by_date: [] }
+					: { sessions_count: 2 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [{ type: "api_key", key: "cog_stored-no-data" }]);
+			storage.setConfigApiKey("devin", "cog_config-fallback");
+
+			const reports = await storage.fetchUsageReports();
+
+			expect(authorization).toEqual([
+				"Bearer cog_stored-no-data",
+				"Bearer cog_stored-no-data",
+				"Bearer cog_stored-no-data",
+				"Bearer cog_config-fallback",
+				"Bearer cog_config-fallback",
+				"Bearer cog_config-fallback",
+			]);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 8, unit: "acus" });
 		} finally {
 			storage.close();
 		}

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -1,5 +1,7 @@
+import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
 import { create, toBinary } from "@bufbuild/protobuf";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
 import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
 import { type UsageFetchParams, usageReportSchema } from "@oh-my-pi/pi-ai/usage";
@@ -133,23 +135,54 @@ describe("devinUsageProvider", () => {
 		expect(validatedReport).not.toBeInstanceOf(type.errors);
 	});
 
-	it("only supports Devin v3 API key credentials", () => {
-		const supportedApiKey: UsageFetchParams = {
+	it("supports Devin API-key credentials before resolving their values", () => {
+		const referencedApiKey: UsageFetchParams = {
 			provider: "devin",
-			credential: { type: "api_key", apiKey: "cog_valid-token" },
-		};
-		const unsupportedApiKey: UsageFetchParams = {
-			provider: "devin",
-			credential: { type: "api_key", apiKey: "devin-session-token$devin-token" },
+			credential: { type: "api_key", apiKey: "DEVIN_API_KEY" },
 		};
 		const unsupportedOauth: UsageFetchParams = {
 			provider: "devin",
 			credential: { type: "oauth", accessToken: "devin-oauth-token" },
 		};
+		const wrongProvider: UsageFetchParams = {
+			provider: "anthropic",
+			credential: { type: "api_key", apiKey: "cog_valid-token" },
+		};
 
-		expect(devinUsageProvider.supports?.(supportedApiKey)).toBe(true);
-		expect(devinUsageProvider.supports?.(unsupportedApiKey)).toBe(false);
+		expect(devinUsageProvider.supports?.(referencedApiKey)).toBe(true);
 		expect(devinUsageProvider.supports?.(unsupportedOauth)).toBe(false);
+		expect(devinUsageProvider.supports?.(wrongProvider)).toBe(false);
+	});
+
+	it("resolves stored API-key config references before fetching usage", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const authorization: Array<string | null> = [];
+		const storage = new AuthStorage(store, {
+			configValueResolver: async value => (value === "DEVIN_API_KEY" ? "cog_resolved-token" : value),
+			usageFetch: (async (input, init) => {
+				authorization.push(new Headers(init?.headers).get("authorization"));
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				const payload = path.includes("consumption")
+					? { total_acus: 2, consumption_by_date: [] }
+					: { sessions_count: 1 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [{ type: "api_key", key: "DEVIN_API_KEY" }]);
+
+			const reports = await storage.fetchUsageReports();
+
+			expect(authorization).toEqual(["Bearer cog_resolved-token", "Bearer cog_resolved-token"]);
+			expect(reports?.map(report => report.provider)).toEqual(["devin"]);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 2, unit: "acus" });
+		} finally {
+			storage.close();
+		}
 	});
 
 	it("throws definitive auth failures so credential checks fail", async () => {

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -209,6 +209,39 @@ describe("devinUsageProvider", () => {
 			metrics: { sessionsCount: 1 },
 		});
 	});
+
+	it("keeps ACU consumption when metrics permission is forbidden", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const parsed = new URL(String(input instanceof Request ? input.url : input));
+			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
+				return new Response(JSON.stringify({ total_acus: 4.5, consumption_by_date: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (parsed.pathname === "/v3/enterprise/metrics/usage") {
+				return new Response("forbidden", { status: 403 });
+			}
+			return new Response("unexpected Devin URL", { status: 404 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_consumption-only" } },
+			{ fetch: fetchImpl },
+		);
+
+		if (!report) throw new Error("expected Devin usage report");
+		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+		expect(report.limits.map(limit => [limit.id, limit.amount.used, limit.amount.unit])).toEqual([
+			["devin:acus:total", 4.5, "acus"],
+		]);
+		expect(report.metadata).toMatchObject({ totalAcus: 4.5 });
+		expect(report.metadata?.metrics).toBeUndefined();
+	});
 });
 
 describe("fetchDevinConsumption", () => {

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -196,6 +196,40 @@ describe("devinUsageProvider", () => {
 		}
 	});
 
+	it("deduplicates org-wide usage reported by multiple service-user keys", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const storage = new AuthStorage(store, {
+			usageFetch: (async input => {
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				const payload = path.endsWith("/v3/self")
+					? { org_id: "org-shared" }
+					: path.includes("consumption")
+						? { total_acus: 12.5, consumption_by_date: [] }
+						: { sessions_count: 2 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [
+				{ type: "api_key", key: "cog_service-user-one" },
+				{ type: "api_key", key: "cog_service-user-two" },
+			]);
+
+			const reports = (await storage.fetchUsageReports())?.filter(report => report.provider === "devin");
+
+			expect(reports).toHaveLength(1);
+			expect(reports?.[0]?.metadata?.orgId).toBe("org-shared");
+			expect(reports?.[0]?.limits).toHaveLength(1);
+			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 12.5, unit: "acus" });
+		} finally {
+			storage.close();
+		}
+	});
+
 	it("resolves stored API-key config references before checking credentials", async () => {
 		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
 		const authorization: Array<string | null> = [];
@@ -585,6 +619,31 @@ describe("fetchDevinConsumption", () => {
 		expect(summary.totalAcus).toBe(2);
 		expect(urls).toEqual([
 			"https://api.example.test/v3/organizations/org-xyz/consumption/daily?time_after=1767225600&time_before=1767312000",
+		]);
+	});
+
+	it("preserves an org endpoint auth failure when the fallback is missing", async () => {
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+			paths.push(path);
+			if (path === "/v3/organizations/org-xyz/consumption/daily") {
+				return new Response("forbidden", { status: 403 });
+			}
+			return new Response("not found", { status: 404 });
+		};
+
+		await expect(
+			fetchDevinConsumption({
+				apiKey: "cog_token",
+				baseUrl: "https://api.example.test",
+				orgId: "org-xyz",
+				fetch: fetchImpl,
+			}),
+		).rejects.toThrow("Devin consumption request failed: 403 forbidden");
+		expect(paths).toEqual([
+			"/v3/organizations/org-xyz/consumption/daily",
+			"/v3/enterprise/consumption/daily/organizations/org-xyz",
 		]);
 	});
 });

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { create, toBinary } from "@bufbuild/protobuf";
 import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
-import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { usageReportSchema } from "@oh-my-pi/pi-ai/usage";
+import { devinUsageProvider, fetchDevinConsumption } from "@oh-my-pi/pi-ai/usage/devin";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { GetChatMessageResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/api_server_pb/api_server_pb";
 import { GetUserJwtResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/auth_pb/auth_pb";
@@ -9,6 +11,7 @@ import {
 	ModelUsageStatsSchema,
 	StopReason,
 } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/codeium_common_pb/codeium_common_pb";
+import { type } from "arktype";
 
 function frameConnectMessage(payload: Uint8Array): Uint8Array {
 	const out = new Uint8Array(5 + payload.length);
@@ -33,6 +36,15 @@ const devinModel: Model<"devin-agent"> = buildModel({
 });
 
 const context: Context = { messages: [{ role: "user", content: "hi", timestamp: 1 }] };
+const ORIGINAL_DEVIN_ORG_ID = Bun.env.DEVIN_ORG_ID;
+const ORIGINAL_DEVIN_USAGE_ORG_ID = Bun.env.DEVIN_USAGE_ORG_ID;
+
+afterEach(() => {
+	if (ORIGINAL_DEVIN_ORG_ID === undefined) delete Bun.env.DEVIN_ORG_ID;
+	else Bun.env.DEVIN_ORG_ID = ORIGINAL_DEVIN_ORG_ID;
+	if (ORIGINAL_DEVIN_USAGE_ORG_ID === undefined) delete Bun.env.DEVIN_USAGE_ORG_ID;
+	else Bun.env.DEVIN_USAGE_ORG_ID = ORIGINAL_DEVIN_USAGE_ORG_ID;
+});
 
 describe("streamDevin usage", () => {
 	it("includes cached tokens in totalTokens", async () => {
@@ -62,5 +74,138 @@ describe("streamDevin usage", () => {
 			cacheWrite: 13,
 			totalTokens: 131,
 		});
+	});
+});
+
+describe("devinUsageProvider", () => {
+	it("fetches enterprise ACU consumption and usage metrics with bearer auth", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const calls: Array<{ path: string; authorization: string | null }> = [];
+		const fetchImpl: FetchImpl = async (input, init) => {
+			const url = String(input instanceof Request ? input.url : input);
+			const parsed = new URL(url);
+			calls.push({ path: parsed.pathname, authorization: new Headers(init?.headers).get("authorization") });
+			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
+				return new Response(
+					JSON.stringify({
+						total_acus: 12.5,
+						consumption_by_date: [
+							{ date: 1733385600, acus: 7.5, acus_by_product: { devin: 5, cascade: 2.5, terminal: 0 } },
+							{ date: 1733472000, acus: 5, acus_by_product: { devin: 3, terminal: 2 } },
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (parsed.pathname === "/v3/enterprise/metrics/usage") {
+				return new Response(
+					JSON.stringify({ sessions_count: 4, searches_count: 3, prs_created_count: 2, prs_merged_count: 1 }),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response("unexpected Devin URL", { status: 404 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "devin-session-token$devin-token" } },
+			{ fetch: fetchImpl },
+		);
+
+		if (!report) throw new Error("expected Devin usage report");
+		expect(calls).toEqual([
+			{ path: "/v3/enterprise/consumption/daily", authorization: "Bearer devin-token" },
+			{ path: "/v3/enterprise/metrics/usage", authorization: "Bearer devin-token" },
+		]);
+		expect(report.provider).toBe("devin");
+		expect(report.limits.map(limit => [limit.id, limit.amount.used, limit.amount.unit])).toEqual([
+			["devin:acus:total", 12.5, "acus"],
+			["devin:acus:product:cascade", 2.5, "acus"],
+			["devin:acus:product:devin", 8, "acus"],
+			["devin:acus:product:terminal", 2, "acus"],
+		]);
+		expect(report.metadata).toMatchObject({
+			totalAcus: 12.5,
+			acusByProduct: { cascade: 2.5, devin: 8, terminal: 2 },
+			metrics: { sessionsCount: 4, searchesCount: 3, prsCreatedCount: 2, prsMergedCount: 1 },
+		});
+		const validatedReport = usageReportSchema(report);
+		expect(validatedReport).not.toBeInstanceOf(type.errors);
+	});
+
+	it("uses org-scoped endpoints and falls back to enterprise org endpoints", async () => {
+		Bun.env.DEVIN_ORG_ID = "org-abc123";
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const parsed = new URL(String(input instanceof Request ? input.url : input));
+			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/organizations/org-abc123/consumption/daily") {
+				return new Response("org-scope denied", { status: 403 });
+			}
+			if (parsed.pathname === "/v3/enterprise/consumption/daily/organizations/org-abc123") {
+				return new Response(JSON.stringify({ total_acus: 3, consumption_by_date: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			if (parsed.pathname === "/v3/organizations/org-abc123/metrics/usage") {
+				return new Response("org-scope denied", { status: 403 });
+			}
+			if (parsed.pathname === "/v3/enterprise/organizations/org-abc123/metrics/usage") {
+				return new Response(JSON.stringify({ sessions_count: 1 }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			return new Response("unexpected Devin URL", { status: 404 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog-token" } },
+			{ fetch: fetchImpl },
+		);
+
+		if (!report) throw new Error("expected Devin usage report");
+		expect(paths).toEqual([
+			"/v3/organizations/org-abc123/consumption/daily",
+			"/v3/enterprise/consumption/daily/organizations/org-abc123",
+			"/v3/organizations/org-abc123/metrics/usage",
+			"/v3/enterprise/organizations/org-abc123/metrics/usage",
+		]);
+		expect(report.metadata).toMatchObject({
+			orgId: "org-abc123",
+			totalAcus: 3,
+			metrics: { sessionsCount: 1 },
+		});
+	});
+});
+
+describe("fetchDevinConsumption", () => {
+	it("passes date query parameters to the selected org endpoint", async () => {
+		const urls: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const url = String(input instanceof Request ? input.url : input);
+			urls.push(url);
+			return new Response(JSON.stringify({ total_acus: 2, consumption_by_date: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		};
+
+		const summary = await fetchDevinConsumption({
+			apiKey: "cog-token",
+			baseUrl: "https://api.example.test/",
+			orgId: "org-xyz",
+			timeAfter: new Date("2026-01-01T00:00:00.000Z"),
+			timeBefore: 1767312000,
+			fetch: fetchImpl,
+		});
+
+		if (!summary) throw new Error("expected Devin consumption summary");
+		expect(summary.totalAcus).toBe(2);
+		expect(urls).toEqual([
+			"https://api.example.test/v3/organizations/org-xyz/consumption/daily?time_after=1767225600&time_before=1767312000",
+		]);
 	});
 });

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -208,6 +208,8 @@ describe("devinUsageProvider", () => {
 			totalAcus: 3,
 			metrics: { sessionsCount: 1 },
 		});
+		expect(report.metadata?.endpoint).toBeUndefined();
+		expect(report.metadata?.metricsEndpoint).toBeUndefined();
 	});
 
 	it("keeps ACU consumption when metrics permission is forbidden", async () => {

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -235,7 +235,7 @@ describe("devinUsageProvider", () => {
 				type: "api_key",
 				ok: null,
 			});
-			expect(result.reason).toMatch(/returned no data/);
+			expect(result.reason).toMatch(/does not support api_key credentials/);
 		} finally {
 			storage.close();
 		}
@@ -333,6 +333,124 @@ describe("devinUsageProvider", () => {
 		expect(report.metadata).toMatchObject({ totalAcus: 4.5 });
 		expect(report.metadata?.metrics).toBeUndefined();
 	});
+
+	it("keeps metrics when consumption permission is forbidden (metrics-only)", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const parsed = new URL(String(input instanceof Request ? input.url : input));
+			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
+				return new Response("forbidden", { status: 403 });
+			}
+			if (parsed.pathname === "/v3/enterprise/metrics/usage") {
+				return new Response(JSON.stringify({ sessions_count: 10, searches_count: 5 }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			return new Response("unexpected Devin URL", { status: 404 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_metrics-only" } },
+			{ fetch: fetchImpl },
+		);
+
+		if (!report) throw new Error("expected Devin usage report");
+		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+		expect(report.limits).toEqual([]);
+		expect(report.notes).toEqual(["Devin usage metrics were available, but ACU consumption was unavailable."]);
+		expect(report.metadata).toMatchObject({
+			metrics: { sessionsCount: 10, searchesCount: 5 },
+		});
+	});
+
+	it("throws auth failure if both consumption and metrics fail with auth errors", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const parsed = new URL(String(input instanceof Request ? input.url : input));
+			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
+				return new Response("unauthorized", { status: 401 });
+			}
+			if (parsed.pathname === "/v3/enterprise/metrics/usage") {
+				return new Response("forbidden", { status: 403 });
+			}
+			return new Response("unexpected Devin URL", { status: 404 });
+		};
+
+		await expect(
+			devinUsageProvider.fetchUsage(
+				{ provider: "devin", credential: { type: "api_key", apiKey: "cog_bad-token" } },
+				{ fetch: fetchImpl },
+			),
+		).rejects.toThrow("Devin consumption request failed: 401 unauthorized");
+
+		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+	});
+
+	it("does not throw auth failure if both fail with non-auth errors", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const parsed = new URL(String(input instanceof Request ? input.url : input));
+			paths.push(parsed.pathname);
+			return new Response("internal error", { status: 500 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_server-error" } },
+			{ fetch: fetchImpl },
+		);
+
+		expect(report).toBeNull();
+		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+	});
+
+	it("determines credential support correctly (OAuth omission, API key inclusion)", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const storage = new AuthStorage(store, {
+			configValueResolver: async value => (value === "DEVIN_API_KEY" ? "cog_resolved-token" : value),
+		});
+
+		try {
+			// Direct cog_ API key
+			const directSupported = await storage.isCredentialSupported("devin", {
+				type: "api_key",
+				key: "cog_direct-token",
+			});
+			expect(directSupported).toBe(true);
+
+			// Resolved cog_ API key reference
+			const resolvedSupported = await storage.isCredentialSupported("devin", {
+				type: "api_key",
+				key: "DEVIN_API_KEY",
+			});
+			expect(resolvedSupported).toBe(true);
+
+			// Unresolved non-cog API key reference
+			const unresolvedNonCogSupported = await storage.isCredentialSupported("devin", {
+				type: "api_key",
+				key: "invalid-key-no-cog",
+			});
+			expect(unresolvedNonCogSupported).toBe(false);
+
+			// OAuth credential
+			const oauthSupported = await storage.isCredentialSupported("devin", {
+				type: "oauth",
+				access: "some-access-token",
+				refresh: "some-refresh-token",
+			});
+			expect(oauthSupported).toBe(false);
+		} finally {
+			storage.close();
+ 		}
+ 	});
 });
 
 describe("fetchDevinConsumption", () => {

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -88,6 +88,9 @@ describe("devinUsageProvider", () => {
 			const url = String(input instanceof Request ? input.url : input);
 			const parsed = new URL(url);
 			calls.push({ path: parsed.pathname, authorization: new Headers(init?.headers).get("authorization") });
+			if (parsed.pathname === "/v3/self") {
+				return new Response(JSON.stringify({}), { status: 404 });
+			}
 			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
 				return new Response(
 					JSON.stringify({
@@ -116,6 +119,7 @@ describe("devinUsageProvider", () => {
 
 		if (!report) throw new Error("expected Devin usage report");
 		expect(calls).toEqual([
+			{ path: "/v3/self", authorization: "Bearer cog_test-token" },
 			{ path: "/v3/enterprise/consumption/daily", authorization: "Bearer cog_test-token" },
 			{ path: "/v3/enterprise/metrics/usage", authorization: "Bearer cog_test-token" },
 		]);
@@ -162,6 +166,9 @@ describe("devinUsageProvider", () => {
 			usageFetch: (async (input, init) => {
 				authorization.push(new Headers(init?.headers).get("authorization"));
 				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				if (path.endsWith("/v3/self")) {
+					return new Response(JSON.stringify({}), { status: 404 });
+				}
 				const payload = path.includes("consumption")
 					? { total_acus: 2, consumption_by_date: [] }
 					: { sessions_count: 1 };
@@ -177,7 +184,11 @@ describe("devinUsageProvider", () => {
 
 			const reports = await storage.fetchUsageReports();
 
-			expect(authorization).toEqual(["Bearer cog_resolved-token", "Bearer cog_resolved-token"]);
+			expect(authorization).toEqual([
+				"Bearer cog_resolved-token",
+				"Bearer cog_resolved-token",
+				"Bearer cog_resolved-token",
+			]);
 			expect(reports?.map(report => report.provider)).toEqual(["devin"]);
 			expect(reports?.[0]?.limits[0]?.amount).toEqual({ used: 2, unit: "acus" });
 		} finally {
@@ -193,6 +204,9 @@ describe("devinUsageProvider", () => {
 			usageFetch: (async (input, init) => {
 				authorization.push(new Headers(init?.headers).get("authorization"));
 				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				if (path.endsWith("/v3/self")) {
+					return new Response(JSON.stringify({}), { status: 404 });
+				}
 				const payload = path.includes("consumption")
 					? { total_acus: 2, consumption_by_date: [] }
 					: { sessions_count: 1 };
@@ -208,7 +222,11 @@ describe("devinUsageProvider", () => {
 
 			const [result] = await storage.checkCredentials();
 
-			expect(authorization).toEqual(["Bearer cog_resolved-token", "Bearer cog_resolved-token"]);
+			expect(authorization).toEqual([
+				"Bearer cog_resolved-token",
+				"Bearer cog_resolved-token",
+				"Bearer cog_resolved-token",
+			]);
 			expect(result).toMatchObject({
 				provider: "devin",
 				type: "api_key",
@@ -249,7 +267,7 @@ describe("devinUsageProvider", () => {
 				{ provider: "devin", credential: { type: "api_key", apiKey: "cog_bad-token" } },
 				{ fetch: fetchImpl },
 			),
-		).rejects.toThrow("Devin consumption request failed: 401 unauthorized");
+		).rejects.toThrow("Devin profile request failed: 401 unauthorized");
 	});
 
 	it("uses org-scoped endpoints and falls back to enterprise org endpoints", async () => {
@@ -308,6 +326,9 @@ describe("devinUsageProvider", () => {
 		const fetchImpl: FetchImpl = async input => {
 			const parsed = new URL(String(input instanceof Request ? input.url : input));
 			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/self") {
+				return new Response(JSON.stringify({}), { status: 404 });
+			}
 			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
 				return new Response(JSON.stringify({ total_acus: 4.5, consumption_by_date: [] }), {
 					status: 200,
@@ -326,7 +347,7 @@ describe("devinUsageProvider", () => {
 		);
 
 		if (!report) throw new Error("expected Devin usage report");
-		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+		expect(paths).toEqual(["/v3/self", "/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
 		expect(report.limits.map(limit => [limit.id, limit.amount.used, limit.amount.unit])).toEqual([
 			["devin:acus:total", 4.5, "acus"],
 		]);
@@ -341,6 +362,9 @@ describe("devinUsageProvider", () => {
 		const fetchImpl: FetchImpl = async input => {
 			const parsed = new URL(String(input instanceof Request ? input.url : input));
 			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/self") {
+				return new Response(JSON.stringify({}), { status: 404 });
+			}
 			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
 				return new Response("forbidden", { status: 403 });
 			}
@@ -359,7 +383,7 @@ describe("devinUsageProvider", () => {
 		);
 
 		if (!report) throw new Error("expected Devin usage report");
-		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+		expect(paths).toEqual(["/v3/self", "/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
 		expect(report.limits).toEqual([]);
 		expect(report.notes).toEqual(["Devin usage metrics were available, but ACU consumption was unavailable."]);
 		expect(report.metadata).toMatchObject({
@@ -374,6 +398,9 @@ describe("devinUsageProvider", () => {
 		const fetchImpl: FetchImpl = async input => {
 			const parsed = new URL(String(input instanceof Request ? input.url : input));
 			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/self") {
+				return new Response(JSON.stringify({}), { status: 404 });
+			}
 			if (parsed.pathname === "/v3/enterprise/consumption/daily") {
 				return new Response("unauthorized", { status: 401 });
 			}
@@ -390,7 +417,7 @@ describe("devinUsageProvider", () => {
 			),
 		).rejects.toThrow("Devin consumption request failed: 401 unauthorized");
 
-		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+		expect(paths).toEqual(["/v3/self", "/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
 	});
 
 	it("does not throw auth failure if both fail with non-auth errors", async () => {
@@ -400,6 +427,9 @@ describe("devinUsageProvider", () => {
 		const fetchImpl: FetchImpl = async input => {
 			const parsed = new URL(String(input instanceof Request ? input.url : input));
 			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/self") {
+				return new Response(JSON.stringify({}), { status: 404 });
+			}
 			return new Response("internal error", { status: 500 });
 		};
 
@@ -409,7 +439,7 @@ describe("devinUsageProvider", () => {
 		);
 
 		expect(report).toBeNull();
-		expect(paths).toEqual(["/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
+		expect(paths).toEqual(["/v3/self", "/v3/enterprise/consumption/daily", "/v3/enterprise/metrics/usage"]);
 	});
 
 	it("determines credential support correctly (OAuth omission, API key inclusion)", async () => {
@@ -445,12 +475,89 @@ describe("devinUsageProvider", () => {
 				type: "oauth",
 				access: "some-access-token",
 				refresh: "some-refresh-token",
+				expires: 0,
 			});
 			expect(oauthSupported).toBe(false);
 		} finally {
 			storage.close();
- 		}
- 	});
+		}
+	});
+
+	it("discovers org_id from /v3/self and queries organization endpoints", async () => {
+		delete Bun.env.DEVIN_ORG_ID;
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const parsed = new URL(String(input instanceof Request ? input.url : input));
+			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/self") {
+				return new Response(JSON.stringify({ org_id: "org-discovered123" }), { status: 200 });
+			}
+			if (parsed.pathname === "/v3/organizations/org-discovered123/consumption/daily") {
+				return new Response(JSON.stringify({ total_acus: 15.0, consumption_by_date: [] }), { status: 200 });
+			}
+			if (parsed.pathname === "/v3/organizations/org-discovered123/metrics/usage") {
+				return new Response(JSON.stringify({ sessions_count: 5 }), { status: 200 });
+			}
+			return new Response("unexpected", { status: 404 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_token" } },
+			{ fetch: fetchImpl },
+		);
+
+		expect(report).not.toBeNull();
+		expect(paths).toEqual([
+			"/v3/self",
+			"/v3/organizations/org-discovered123/consumption/daily",
+			"/v3/organizations/org-discovered123/metrics/usage",
+		]);
+		expect(report?.metadata).toMatchObject({
+			orgId: "org-discovered123",
+			totalAcus: 15.0,
+			metrics: { sessionsCount: 5 },
+		});
+	});
+
+	it("prioritizes explicit env/config org ID over /v3/self discovery", async () => {
+		Bun.env.DEVIN_ORG_ID = "org-env-priority";
+		delete Bun.env.DEVIN_USAGE_ORG_ID;
+		const paths: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			const parsed = new URL(String(input instanceof Request ? input.url : input));
+			paths.push(parsed.pathname);
+			if (parsed.pathname === "/v3/organizations/org-env-priority/consumption/daily") {
+				return new Response(JSON.stringify({ total_acus: 5.0, consumption_by_date: [] }), { status: 200 });
+			}
+			if (parsed.pathname === "/v3/organizations/org-env-priority/metrics/usage") {
+				return new Response(JSON.stringify({ sessions_count: 2 }), { status: 200 });
+			}
+			return new Response("unexpected", { status: 404 });
+		};
+
+		const report = await devinUsageProvider.fetchUsage(
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_token" } },
+			{ fetch: fetchImpl },
+		);
+
+		expect(report).not.toBeNull();
+		expect(paths).toEqual([
+			"/v3/organizations/org-env-priority/consumption/daily",
+			"/v3/organizations/org-env-priority/metrics/usage",
+		]);
+	});
+
+	it("bubbles up /v3/self auth failure and fails validation", async () => {
+		const fetchImpl: FetchImpl = async () => new Response("unauthorized", { status: 401 });
+
+		await expect(
+			devinUsageProvider.fetchUsage(
+				{ provider: "devin", credential: { type: "api_key", apiKey: "cog_token" } },
+				{ fetch: fetchImpl },
+			),
+		).rejects.toThrow("Devin profile request failed: 401 unauthorized");
+	});
 });
 
 describe("fetchDevinConsumption", () => {

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -185,6 +185,62 @@ describe("devinUsageProvider", () => {
 		}
 	});
 
+	it("resolves stored API-key config references before checking credentials", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const authorization: Array<string | null> = [];
+		const storage = new AuthStorage(store, {
+			configValueResolver: async value => (value === "DEVIN_API_KEY" ? "cog_resolved-token" : value),
+			usageFetch: (async (input, init) => {
+				authorization.push(new Headers(init?.headers).get("authorization"));
+				const path = new URL(String(input instanceof Request ? input.url : input)).pathname;
+				const payload = path.includes("consumption")
+					? { total_acus: 2, consumption_by_date: [] }
+					: { sessions_count: 1 };
+				return new Response(JSON.stringify(payload), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}) as typeof fetch,
+		});
+
+		try {
+			await storage.set("devin", [{ type: "api_key", key: "DEVIN_API_KEY" }]);
+
+			const [result] = await storage.checkCredentials();
+
+			expect(authorization).toEqual(["Bearer cog_resolved-token", "Bearer cog_resolved-token"]);
+			expect(result).toMatchObject({
+				provider: "devin",
+				type: "api_key",
+				ok: true,
+			});
+		} finally {
+			storage.close();
+		}
+	});
+
+	it("rejects non-cog Devin API-key credentials during credential check", async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const storage = new AuthStorage(store, {
+			configValueResolver: async value => value,
+		});
+
+		try {
+			await storage.set("devin", [{ type: "api_key", key: "invalid-key-no-cog" }]);
+
+			const [result] = await storage.checkCredentials();
+
+			expect(result).toMatchObject({
+				provider: "devin",
+				type: "api_key",
+				ok: null,
+			});
+			expect(result.reason).toMatch(/returned no data/);
+		} finally {
+			storage.close();
+		}
+	});
+
 	it("throws definitive auth failures so credential checks fail", async () => {
 		const fetchImpl: FetchImpl = async () => new Response("unauthorized", { status: 401 });
 

--- a/packages/ai/test/devin-usage.test.ts
+++ b/packages/ai/test/devin-usage.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { create, toBinary } from "@bufbuild/protobuf";
 import { streamDevin } from "@oh-my-pi/pi-ai/providers/devin";
 import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
-import { usageReportSchema } from "@oh-my-pi/pi-ai/usage";
+import { type UsageFetchParams, usageReportSchema } from "@oh-my-pi/pi-ai/usage";
 import { devinUsageProvider, fetchDevinConsumption } from "@oh-my-pi/pi-ai/usage/devin";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { GetChatMessageResponseSchema } from "@oh-my-pi/pi-catalog/discovery/devin-gen/exa/api_server_pb/api_server_pb";
@@ -108,14 +108,14 @@ describe("devinUsageProvider", () => {
 		};
 
 		const report = await devinUsageProvider.fetchUsage(
-			{ provider: "devin", credential: { type: "api_key", apiKey: "devin-session-token$devin-token" } },
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_test-token" } },
 			{ fetch: fetchImpl },
 		);
 
 		if (!report) throw new Error("expected Devin usage report");
 		expect(calls).toEqual([
-			{ path: "/v3/enterprise/consumption/daily", authorization: "Bearer devin-token" },
-			{ path: "/v3/enterprise/metrics/usage", authorization: "Bearer devin-token" },
+			{ path: "/v3/enterprise/consumption/daily", authorization: "Bearer cog_test-token" },
+			{ path: "/v3/enterprise/metrics/usage", authorization: "Bearer cog_test-token" },
 		]);
 		expect(report.provider).toBe("devin");
 		expect(report.limits.map(limit => [limit.id, limit.amount.used, limit.amount.unit])).toEqual([
@@ -131,6 +131,36 @@ describe("devinUsageProvider", () => {
 		});
 		const validatedReport = usageReportSchema(report);
 		expect(validatedReport).not.toBeInstanceOf(type.errors);
+	});
+
+	it("only supports Devin v3 API key credentials", () => {
+		const supportedApiKey: UsageFetchParams = {
+			provider: "devin",
+			credential: { type: "api_key", apiKey: "cog_valid-token" },
+		};
+		const unsupportedApiKey: UsageFetchParams = {
+			provider: "devin",
+			credential: { type: "api_key", apiKey: "devin-session-token$devin-token" },
+		};
+		const unsupportedOauth: UsageFetchParams = {
+			provider: "devin",
+			credential: { type: "oauth", accessToken: "devin-oauth-token" },
+		};
+
+		expect(devinUsageProvider.supports?.(supportedApiKey)).toBe(true);
+		expect(devinUsageProvider.supports?.(unsupportedApiKey)).toBe(false);
+		expect(devinUsageProvider.supports?.(unsupportedOauth)).toBe(false);
+	});
+
+	it("throws definitive auth failures so credential checks fail", async () => {
+		const fetchImpl: FetchImpl = async () => new Response("unauthorized", { status: 401 });
+
+		await expect(
+			devinUsageProvider.fetchUsage(
+				{ provider: "devin", credential: { type: "api_key", apiKey: "cog_bad-token" } },
+				{ fetch: fetchImpl },
+			),
+		).rejects.toThrow("Devin consumption request failed: 401 unauthorized");
 	});
 
 	it("uses org-scoped endpoints and falls back to enterprise org endpoints", async () => {
@@ -162,7 +192,7 @@ describe("devinUsageProvider", () => {
 		};
 
 		const report = await devinUsageProvider.fetchUsage(
-			{ provider: "devin", credential: { type: "api_key", apiKey: "cog-token" } },
+			{ provider: "devin", credential: { type: "api_key", apiKey: "cog_token" } },
 			{ fetch: fetchImpl },
 		);
 
@@ -194,7 +224,7 @@ describe("fetchDevinConsumption", () => {
 		};
 
 		const summary = await fetchDevinConsumption({
-			apiKey: "cog-token",
+			apiKey: "cog_token",
 			baseUrl: "https://api.example.test/",
 			orgId: "org-xyz",
 			timeAfter: new Date("2026-01-01T00:00:00.000Z"),

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Fixed spilled tool-output artifact descriptors leaking on error/abort paths. `OutputSink.dump()` was the only path that closed the spill `Bun.FileSink`, but the bash and Python executors re-throw on failure and their `finally` blocks never closed the sink, so a large-output command that errored leaked the artifact descriptor until an unrelated read (e.g. a `SKILL.md` load) hit `EMFILE`. `OutputSink` now exposes an idempotent `dispose()` that closes the sink exactly once, wired into every executor's `finally` ([#6463](https://github.com/can1357/oh-my-pi/issues/6463)).
 - Fixed the first submitted prompt stalling while the local tiny-title worker started: the interactive submit handler now paints the pending user row before starting title generation, and startup prewarms an idle, unref'd worker so the first submit reuses a live subprocess instead of paying spawn latency ahead of the first frame ([#6462](https://github.com/can1357/oh-my-pi/issues/6462)).
 - Fixed legacy Pi extensions failing validation when importing the upstream `keyText` keybinding helper ([#6470](https://github.com/can1357/oh-my-pi/issues/6470)).
+### Fixed
+
+- Fixed `omp usage` and interactive `/usage` to show normalized Devin activity metrics when ACU consumption limits are unavailable.
 
 ## [17.1.0] - 2026-07-24
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -985,6 +985,9 @@
 - Fixed the streamed `write` tool's collapsed pending tail preview leaving stale rows above the first partial-result frame in the TUI; the first result now replays the viewport like the SSH placeholder seam already did ([#4477](https://github.com/can1357/oh-my-pi/issues/4477))
 - Fixed first-run setup ignoring a pre-seeded `config.yaml`: the settings loader now treats `config.yml` and `config.yaml` as equivalent existing main config files, writes back to the existing extension, and only creates canonical `config.yml` for fresh installs. ([#4914](https://github.com/can1357/oh-my-pi/issues/4914))
 - Fixed extension `sendUserMessage()` without `deliverAs` surfacing `AgentBusyError` during active streams; omitted `deliverAs` now queues a steer through the normal prompt flow, and ACP/RPC skill-command prompts queue while streaming (RPC honors the prompt command's `streamingBehavior`, defaulting to steer) ([#4923](https://github.com/can1357/oh-my-pi/issues/4923)).
+### Added
+
+- Added CLI rendering for Devin ACU usage totals.
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -19,6 +19,7 @@ import type { Provider } from "@oh-my-pi/pi-catalog/types";
 import { formatDuration, formatNumber } from "@oh-my-pi/pi-utils/format";
 import { sanitizeText } from "@oh-my-pi/pi-utils/sanitize-text";
 import chalk from "chalk";
+import { getDevinUsageMetrics } from "../usage/devin-metrics";
 
 const BAR_WIDTH = 28;
 
@@ -233,15 +234,6 @@ function describeAmount(limit: UsageLimit): string {
 		parts.push(`${formatUnitValue(amount.used, amount.unit)}${UNIT_SUFFIX[amount.unit]} used`);
 	} else if (absoluteUnit && amount.remaining !== undefined) {
 		parts.push(`${formatUnitValue(amount.remaining, amount.unit)}${UNIT_SUFFIX[amount.unit]} left`);
-	} else if (
-		absoluteUnit &&
-		amount.used !== undefined &&
-		Number.isFinite(amount.used) &&
-		amount.limit === undefined &&
-		amount.remaining === undefined &&
-		fraction === undefined
-	) {
-		parts.push(`${formatUnitValue(amount.used, amount.unit)}${UNIT_SUFFIX[amount.unit]} used`);
 	}
 	if (fraction !== undefined) {
 		parts.push(`${(fraction * 100).toFixed(1)}% used`);
@@ -581,17 +573,23 @@ export function formatUsageBreakdown(
 			lines.push(`  ${formatAccountHeader(report, index, nowMs, redaction)}`);
 			if (report.limits.length === 0) {
 				lines.push(`      ${chalk.dim("no limits reported")}`);
-				return;
-			}
-			const limitsById = new Map<string, UsageLimit>();
-			for (const limit of report.limits) limitsById.set(limit.id, limit);
-			for (const template of providerLimitTemplates) {
-				const limit = limitsById.get(template.id);
-				if (limit) {
-					lines.push(...formatLimitLine(limit, labelWidth, nowMs));
-				} else {
-					lines.push(formatMissingLimitLine(template, labelWidth));
+			} else {
+				const limitsById = new Map<string, UsageLimit>();
+				for (const limit of report.limits) limitsById.set(limit.id, limit);
+				for (const template of providerLimitTemplates) {
+					const limit = limitsById.get(template.id);
+					if (limit) {
+						lines.push(...formatLimitLine(limit, labelWidth, nowMs));
+					} else {
+						lines.push(formatMissingLimitLine(template, labelWidth));
+					}
 				}
+			}
+
+			const metrics = getDevinUsageMetrics(report);
+			if (metrics.length > 0) {
+				const activity = metrics.map(metric => `${formatNumber(metric.value)} ${metric.label}`).join(" · ");
+				lines.push(`      ${chalk.dim(`activity: ${activity}`)}`);
 			}
 		});
 

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -8,7 +8,6 @@
  * always covers the full credential pool.
  */
 import type { AuthCredential, AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
-import type { Provider } from "@oh-my-pi/pi-catalog/types";
 import {
 	resolveUsedFraction,
 	type UsageHistoryEntry,
@@ -16,6 +15,7 @@ import {
 	type UsageReport,
 	type UsageUnit,
 } from "@oh-my-pi/pi-ai/usage";
+import type { Provider } from "@oh-my-pi/pi-catalog/types";
 import { formatDuration, formatNumber } from "@oh-my-pi/pi-utils/format";
 import { sanitizeText } from "@oh-my-pi/pi-utils/sanitize-text";
 import chalk from "chalk";
@@ -148,6 +148,7 @@ function collectIdentityStrings(reports: UsageReport[], accounts: UsageAccountId
 		add(meta.projectId);
 		add(meta.orgId);
 		add(meta.orgName);
+		add(meta.principalId);
 		for (const limit of report.limits) {
 			add(limit.scope.accountId);
 			add(limit.scope.projectId);
@@ -814,7 +815,7 @@ function maskIdentity(redaction: Map<string, string>, value: string | undefined)
 	return value === undefined ? undefined : (redaction.get(value) ?? value);
 }
 
-const IDENTITY_METADATA_KEYS = ["email", "accountId", "projectId", "orgId", "orgName"] as const;
+const IDENTITY_METADATA_KEYS = ["email", "accountId", "projectId", "orgId", "orgName", "principalId"] as const;
 
 /** Mask identity fields in a raw-stripped report for `--redact --json`. */
 function redactReportForJson(

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -732,10 +732,19 @@ export function formatUsageHistory(
 				const latestEntry = series.entries[series.entries.length - 1];
 				const latestFraction = fractions.length > 0 ? fractions[fractions.length - 1] : undefined;
 				const peakFraction = fractions.length > 0 ? Math.max(...fractions) : undefined;
+				const absoluteValues = series.entries
+					.map(entry => entry.used)
+					.filter((used): used is number => used !== undefined);
+				const latestAbsolute = latestEntry?.used;
+				const peakAbsolute = absoluteValues.length > 0 ? Math.max(...absoluteValues) : undefined;
 				const status = historyStatus(latestFraction, latestEntry?.status);
 				const details: string[] = [];
 				if (latestFraction !== undefined) details.push(`latest ${(latestFraction * 100).toFixed(1)}%`);
 				if (peakFraction !== undefined) details.push(`peak ${(peakFraction * 100).toFixed(1)}%`);
+				if (latestFraction === undefined && latestAbsolute !== undefined) {
+					details.push(`latest ${latestAbsolute} ${latestEntry?.unit ?? "units"}`);
+					if (peakAbsolute !== undefined) details.push(`peak ${peakAbsolute} ${latestEntry?.unit ?? "units"}`);
+				}
 				details.push(`${series.entries.length} snapshot${series.entries.length === 1 ? "" : "s"}`);
 				lines.push(
 					`      ${STATUS_COLOR[status]("●")} ${series.title.padEnd(labelWidth)}  ${renderHistorySparkline(series.entries, sinceMs, nowMs)}  ${chalk.dim(details.join(" · "))}`,

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -216,6 +216,10 @@ const UNIT_SUFFIX: Record<UsageUnit, string> = {
 	unknown: "",
 };
 
+function formatHistoryUnitValue(value: number, unit: UsageUnit | undefined): string {
+	return unit ? `${formatUnitValue(value, unit)}${UNIT_SUFFIX[unit]}` : `${formatNumber(value)} units`;
+}
+
 function describeAmount(limit: UsageLimit): string {
 	const amount = limit.amount;
 	const parts: string[] = [];
@@ -742,8 +746,9 @@ export function formatUsageHistory(
 				if (latestFraction !== undefined) details.push(`latest ${(latestFraction * 100).toFixed(1)}%`);
 				if (peakFraction !== undefined) details.push(`peak ${(peakFraction * 100).toFixed(1)}%`);
 				if (latestFraction === undefined && latestAbsolute !== undefined) {
-					details.push(`latest ${latestAbsolute} ${latestEntry?.unit ?? "units"}`);
-					if (peakAbsolute !== undefined) details.push(`peak ${peakAbsolute} ${latestEntry?.unit ?? "units"}`);
+					const unit = latestEntry?.unit;
+					details.push(`latest ${formatHistoryUnitValue(latestAbsolute, unit)}`);
+					if (peakAbsolute !== undefined) details.push(`peak ${formatHistoryUnitValue(peakAbsolute, unit)}`);
 				}
 				details.push(`${series.entries.length} snapshot${series.entries.length === 1 ? "" : "s"}`);
 				lines.push(

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -7,18 +7,17 @@
  * credentials produced no usage report are listed too, so the output
  * always covers the full credential pool.
  */
+import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
 import {
-	type AuthStorage,
 	resolveUsedFraction,
 	type UsageHistoryEntry,
 	type UsageLimit,
 	type UsageReport,
 	type UsageUnit,
-} from "@oh-my-pi/pi-ai";
-import { formatDuration, formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
+} from "@oh-my-pi/pi-ai/usage";
+import { formatDuration, formatNumber } from "@oh-my-pi/pi-utils/format";
+import { sanitizeText } from "@oh-my-pi/pi-utils/sanitize-text";
 import chalk from "chalk";
-import { ModelRegistry } from "../config/model-registry";
-import { discoverAuthStorage } from "../sdk";
 
 const BAR_WIDTH = 28;
 
@@ -31,6 +30,11 @@ export interface UsageCommandArgs {
 	history?: boolean;
 	/** History window in days (with `history`). */
 	days?: number;
+}
+
+export interface UsageCommandDeps {
+	discoverAuthStorage: () => Promise<AuthStorage>;
+	createBaseUrlResolver: (authStorage: AuthStorage) => (provider: string) => string | undefined;
 }
 
 /** Identity slice of a stored credential, for "every account" coverage. */
@@ -199,6 +203,7 @@ const UNIT_SUFFIX: Record<UsageUnit, string> = {
 	requests: " requests",
 	minutes: " min",
 	bytes: " bytes",
+	acus: " ACU",
 	percent: "",
 	usd: "",
 	unknown: "",
@@ -213,6 +218,8 @@ function describeAmount(limit: UsageLimit): string {
 		parts.push(
 			`${formatUnitValue(amount.used, amount.unit)} / ${formatUnitValue(amount.limit, amount.unit)}${UNIT_SUFFIX[amount.unit]}`,
 		);
+	} else if (absoluteUnit && amount.used !== undefined) {
+		parts.push(`${formatUnitValue(amount.used, amount.unit)}${UNIT_SUFFIX[amount.unit]} used`);
 	} else if (absoluteUnit && amount.remaining !== undefined) {
 		parts.push(`${formatUnitValue(amount.remaining, amount.unit)}${UNIT_SUFFIX[amount.unit]} left`);
 	} else if (
@@ -813,8 +820,8 @@ function redactReportForJson(
 	return { ...report, metadata, limits };
 }
 
-export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
-	const authStorage = await discoverAuthStorage();
+export async function runUsageCommand(cmd: UsageCommandArgs, deps: UsageCommandDeps): Promise<void> {
+	const authStorage = await deps.discoverAuthStorage();
 	try {
 		if (cmd.action === "invalidate") {
 			const provider = cmd.provider?.toLowerCase();
@@ -857,10 +864,10 @@ export async function runUsageCommand(cmd: UsageCommandArgs): Promise<void> {
 			process.stdout.write(`${formatUsageHistory(entries, sinceMs, nowMs, redaction)}\n`);
 			return;
 		}
-		const modelRegistry = new ModelRegistry(authStorage);
+		const baseUrlResolver = deps.createBaseUrlResolver(authStorage);
 		const reports =
 			(await authStorage.fetchUsageReports({
-				baseUrlResolver: provider => modelRegistry.getProviderBaseUrl(provider),
+				baseUrlResolver,
 			})) ?? [];
 		const storedAccounts = collectStoredAccounts(authStorage);
 		let accounts = selectReportableAccounts(

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -49,6 +49,10 @@ export interface UsageAccountIdentity {
 	/** Organization/workspace the credential is scoped to (Anthropic multi-subscription). */
 	orgId?: string;
 	orgName?: string;
+}
+
+export interface StoredAccount {
+	identity: UsageAccountIdentity;
 	credential?: AuthCredential;
 }
 
@@ -742,8 +746,8 @@ export function formatUsageHistory(
 	return lines.join("\n");
 }
 
-function collectStoredAccounts(authStorage: AuthStorage): UsageAccountIdentity[] {
-	const accounts: UsageAccountIdentity[] = [];
+function collectStoredAccounts(authStorage: AuthStorage): StoredAccount[] {
+	const accounts: StoredAccount[] = [];
 	const all = authStorage.getAll();
 	for (const provider in all) {
 		const entry = all[provider];
@@ -751,20 +755,24 @@ function collectStoredAccounts(authStorage: AuthStorage): UsageAccountIdentity[]
 		for (const credential of credentials) {
 			if (credential.type === "oauth") {
 				accounts.push({
-					provider,
-					type: "oauth",
-					email: credential.email,
-					accountId: credential.accountId,
-					projectId: credential.projectId,
-					enterpriseUrl: credential.enterpriseUrl,
-					orgId: credential.orgId,
-					orgName: credential.orgName,
+					identity: {
+						provider,
+						type: "oauth",
+						email: credential.email,
+						accountId: credential.accountId,
+						projectId: credential.projectId,
+						enterpriseUrl: credential.enterpriseUrl,
+						orgId: credential.orgId,
+						orgName: credential.orgName,
+					},
 					credential,
 				});
 			} else {
 				accounts.push({
-					provider,
-					type: "api_key",
+					identity: {
+						provider,
+						type: "api_key",
+					},
 					credential,
 				});
 			}
@@ -787,15 +795,15 @@ function collectStoredAccounts(authStorage: AuthStorage): UsageAccountIdentity[]
  * usage endpoint.
  */
 export async function selectReportableAccounts(
-	accounts: UsageAccountIdentity[],
+	accounts: StoredAccount[],
 	isCredentialSupported: (provider: string, credential?: AuthCredential) => Promise<boolean> | boolean,
 	explicitProvider?: string,
 ): Promise<UsageAccountIdentity[]> {
-	if (explicitProvider) return accounts;
+	if (explicitProvider) return accounts.map(a => a.identity);
 	const filtered: UsageAccountIdentity[] = [];
 	for (const account of accounts) {
-		if (await isCredentialSupported(account.provider, account.credential)) {
-			filtered.push(account);
+		if (await isCredentialSupported(account.identity.provider, account.credential)) {
+			filtered.push(account.identity);
 		}
 	}
 	return filtered;

--- a/packages/coding-agent/src/cli/usage-cli.ts
+++ b/packages/coding-agent/src/cli/usage-cli.ts
@@ -7,7 +7,8 @@
  * credentials produced no usage report are listed too, so the output
  * always covers the full credential pool.
  */
-import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import type { AuthCredential, AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
+import type { Provider } from "@oh-my-pi/pi-catalog/types";
 import {
 	resolveUsedFraction,
 	type UsageHistoryEntry,
@@ -48,6 +49,7 @@ export interface UsageAccountIdentity {
 	/** Organization/workspace the credential is scoped to (Anthropic multi-subscription). */
 	orgId?: string;
 	orgName?: string;
+	credential?: AuthCredential;
 }
 
 /**
@@ -757,9 +759,14 @@ function collectStoredAccounts(authStorage: AuthStorage): UsageAccountIdentity[]
 					enterpriseUrl: credential.enterpriseUrl,
 					orgId: credential.orgId,
 					orgName: credential.orgName,
+					credential,
 				});
 			} else {
-				accounts.push({ provider, type: "api_key" });
+				accounts.push({
+					provider,
+					type: "api_key",
+					credential,
+				});
 			}
 		}
 	}
@@ -773,19 +780,25 @@ function collectStoredAccounts(authStorage: AuthStorage): UsageAccountIdentity[]
  * keyless servers, inference providers without a usage API) would only ever
  * render as noise, so they are dropped.
  *
- * `hasUsageProvider` is injected (in practice {@link AuthStorage.usageProviderFor})
- * so custom/broker resolvers stay authoritative — no provider list is duplicated
- * here. An explicit `--provider` request bypasses the cull, so
+ * `isCredentialSupported` checks whether the provider has a usage provider
+ * and whether that usage provider supports the specific credential type/value.
+ * An explicit `--provider` request bypasses the cull, so
  * `omp usage --provider xai` can still confirm the stored credential has no
  * usage endpoint.
  */
-export function selectReportableAccounts(
+export async function selectReportableAccounts(
 	accounts: UsageAccountIdentity[],
-	hasUsageProvider: (provider: string) => boolean,
+	isCredentialSupported: (provider: string, credential?: AuthCredential) => Promise<boolean> | boolean,
 	explicitProvider?: string,
-): UsageAccountIdentity[] {
+): Promise<UsageAccountIdentity[]> {
 	if (explicitProvider) return accounts;
-	return accounts.filter(account => hasUsageProvider(account.provider));
+	const filtered: UsageAccountIdentity[] = [];
+	for (const account of accounts) {
+		if (await isCredentialSupported(account.provider, account.credential)) {
+			filtered.push(account);
+		}
+	}
+	return filtered;
 }
 
 /** Apply a redaction mask to an optional identity field. */
@@ -870,9 +883,9 @@ export async function runUsageCommand(cmd: UsageCommandArgs, deps: UsageCommandD
 				baseUrlResolver,
 			})) ?? [];
 		const storedAccounts = collectStoredAccounts(authStorage);
-		let accounts = selectReportableAccounts(
+		let accounts = await selectReportableAccounts(
 			storedAccounts,
-			provider => authStorage.usageProviderFor(provider) !== undefined,
+			(provider, credential) => authStorage.isCredentialSupported(provider as Provider, credential),
 			cmd.provider,
 		);
 		let filteredReports = reports;

--- a/packages/coding-agent/src/commands/usage.ts
+++ b/packages/coding-agent/src/commands/usage.ts
@@ -3,6 +3,8 @@
  */
 import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
 import { runUsageCommand } from "../cli/usage-cli";
+import { ModelRegistry } from "../config/model-registry";
+import { discoverAuthStorage } from "../sdk";
 
 export default class Usage extends Command {
 	static description = "Show provider usage limits for every authenticated account";
@@ -42,13 +44,22 @@ export default class Usage extends Command {
 
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(Usage);
-		await runUsageCommand({
-			action: args.action,
-			json: flags.json,
-			provider: flags.provider,
-			redact: flags.redact,
-			history: flags.history,
-			days: flags.days,
-		});
+		await runUsageCommand(
+			{
+				action: args.action,
+				json: flags.json,
+				provider: flags.provider,
+				redact: flags.redact,
+				history: flags.history,
+				days: flags.days,
+			},
+			{
+				discoverAuthStorage,
+				createBaseUrlResolver: authStorage => {
+					const modelRegistry = new ModelRegistry(authStorage);
+					return provider => modelRegistry.getProviderBaseUrl(provider);
+				},
+			},
+		);
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -49,6 +49,7 @@ import { formatActiveAccountLabel, limitMatchesActiveAccount } from "../../slash
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
+import { getDevinUsageMetrics } from "../../usage/devin-metrics";
 import {
 	getChangelogPath,
 	parseChangelog,
@@ -1873,6 +1874,17 @@ export function renderUsageReports(
 			);
 		}
 
+		const devinActivityLines = providerReports.flatMap((report, index) => {
+			const metrics = getDevinUsageMetrics(report);
+			if (metrics.length === 0) return [];
+			const activity = metrics.map(metric => `${formatNumber(metric.value)} ${metric.label}`).join(" · ");
+			return [`    ${formatUnlimitedReportLabel(report, index)}: ${activity}`];
+		});
+		if (devinActivityLines.length > 0) {
+			lines.push(`  ${uiTheme.fg("accent", "Devin activity")}`);
+			for (const line of devinActivityLines) lines.push(uiTheme.fg("dim", line));
+		}
+
 		const resetAccountLines: string[] = [];
 		for (const report of providerReports) {
 			const count = report.resetCredits?.availableCount ?? 0;
@@ -1987,7 +1999,9 @@ export function renderUsageReports(
 		}
 
 		// Render accounts with no rate limits (e.g. business/enterprise plans).
-		const unlimitedReports = providerReports.filter(report => report.limits.length === 0);
+		const unlimitedReports = providerReports.filter(
+			report => report.limits.length === 0 && getDevinUsageMetrics(report).length === 0,
+		);
 		for (const report of unlimitedReports) {
 			const label = formatUnlimitedReportLabel(report, 0);
 			const tier = report.metadata?.planType;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1647,6 +1647,16 @@ function formatAggregateAmount(limits: UsageLimit[]): string {
 		return `${formatNumber(remainingPct)}% free`;
 	}
 
+	if (
+		limits.length > 0 &&
+		limits.every(
+			limit => limit.amount.unit === "acus" && limit.amount.used !== undefined && limit.amount.limit === undefined,
+		)
+	) {
+		const totalUsed = limits.reduce((sum, limit) => sum + (limit.amount.used ?? 0), 0);
+		return `${formatNumber(totalUsed)} ACU used`;
+	}
+
 	if (limits.length > 0 && limits.every(isUsedOnlyAbsoluteAmount)) return "";
 
 	// Count unique accounts from limit scopes — not limits.length.

--- a/packages/coding-agent/src/usage/devin-metrics.ts
+++ b/packages/coding-agent/src/usage/devin-metrics.ts
@@ -1,0 +1,30 @@
+import type { UsageReport } from "@oh-my-pi/pi-ai";
+
+export interface DevinUsageMetric {
+	label: string;
+	value: number;
+}
+
+/**
+ * Extract normalized Devin activity metrics without adding provider-specific
+ * fields to the generic usage report schema.
+ */
+export function getDevinUsageMetrics(report: UsageReport): DevinUsageMetric[] {
+	if (report.provider !== "devin") return [];
+	const rawMetrics = report.metadata?.metrics;
+	if (!rawMetrics || typeof rawMetrics !== "object" || Array.isArray(rawMetrics)) return [];
+
+	const metrics = rawMetrics as Record<string, unknown>;
+	const definitions: Array<[key: string, singular: string, plural: string]> = [
+		["sessionsCount", "session", "sessions"],
+		["searchesCount", "search", "searches"],
+		["prsCreatedCount", "PR created", "PRs created"],
+		["prsMergedCount", "PR merged", "PRs merged"],
+	];
+
+	return definitions.flatMap(([key, singular, plural]) => {
+		const value = metrics[key];
+		if (typeof value !== "number" || !Number.isFinite(value)) return [];
+		return [{ value, label: value === 1 ? singular : plural }];
+	});
+}

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -183,6 +183,13 @@ describe("CommandController /usage", () => {
 						amount: { unit: "acus", used: 12.5 },
 						status: "ok",
 					},
+					{
+						id: "devin:acus:product:devin",
+						label: "Devin product ACU consumption",
+						scope: { provider: "devin", accountId: "acct-1", tier: "devin" },
+						amount: { unit: "acus", used: 8 },
+						status: "ok",
+					},
 				],
 				metadata: { email: "devin-a@example.com", accountId: "acct-1" },
 			},
@@ -191,6 +198,8 @@ describe("CommandController /usage", () => {
 		expect(present).toHaveBeenCalledTimes(1);
 		let output = renderPresentedBlocks(present.mock.calls[0]?.[0]);
 		expect(output).toContain("12.5 ACU used");
+		expect(output).toContain("8 ACU used");
+		expect(output).not.toContain("20.5 ACU used");
 		present.mockClear();
 
 		// 2. Multiple Devin accounts plus neighboring fallback case

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -272,4 +272,56 @@ describe("CommandController /usage", () => {
 		// Assert fallback provider falls back to "2 accts" since it has no amount values
 		expect(output).toContain("2 accts");
 	});
+
+	it("renders Devin activity metrics for metrics-only and consumption reports", async () => {
+		const present = vi.fn();
+		const ctx = {
+			session: createUsageSessionDouble(),
+			ui: { terminal: { columns: 100 } },
+			present,
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+		const now = Date.now();
+
+		await controller.handleUsageCommand([
+			{
+				provider: "devin",
+				fetchedAt: now,
+				limits: [],
+				metadata: {
+					metrics: { sessionsCount: 10, searchesCount: 5, prsCreatedCount: 2, prsMergedCount: 1 },
+				},
+			},
+		]);
+
+		let output = renderPresentedBlocks(present.mock.calls[0]?.[0]);
+		expect(output).toContain("Devin activity");
+		expect(output).toContain("10 sessions · 5 searches · 2 PRs created · 1 PR merged");
+		expect(output).not.toContain("-- no limits");
+		present.mockClear();
+
+		await controller.handleUsageCommand([
+			{
+				provider: "devin",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "devin:acus:total",
+						label: "Devin ACU consumption",
+						scope: { provider: "devin", shared: true },
+						amount: { unit: "acus", used: 12.5 },
+						status: "ok",
+					},
+				],
+				metadata: { metrics: { sessionsCount: 3, prsMergedCount: 2 } },
+			},
+		]);
+
+		output = renderPresentedBlocks(present.mock.calls[0]?.[0]);
+		expect(output).toContain("12.5 ACU used");
+		expect(output).toContain("Devin activity");
+		expect(output).toContain("3 sessions · 2 PRs merged");
+	});
 });

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -161,7 +161,7 @@ describe("CommandController /usage", () => {
 	it("renders single and multiple Devin used-only ACUs as summed totals, plus neighboring fallback acct count", async () => {
 		const present = vi.fn();
 		const ctx = {
-			session: {},
+			session: createUsageSessionDouble(),
 			ui: { terminal: { columns: 100 } },
 			present,
 			showWarning: vi.fn(),

--- a/packages/coding-agent/test/modes/controllers/usage-command.test.ts
+++ b/packages/coding-agent/test/modes/controllers/usage-command.test.ts
@@ -157,4 +157,110 @@ describe("CommandController /usage", () => {
 		expect(output).toContain(`(${futureIso.slice(0, 10)})`);
 		expect(output).toContain(`expired (${expiredIso.slice(0, 10)})`);
 	});
+
+	it("renders single and multiple Devin used-only ACUs as summed totals, plus neighboring fallback acct count", async () => {
+		const present = vi.fn();
+		const ctx = {
+			session: {},
+			ui: { terminal: { columns: 100 } },
+			present,
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new CommandController(ctx);
+		const now = Date.now();
+
+		// 1. Single Devin account
+		const reportsSingle: UsageReport[] = [
+			{
+				provider: "devin",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "devin:acus:total",
+						label: "Devin ACU consumption",
+						scope: { provider: "devin", accountId: "acct-1" },
+						amount: { unit: "acus", used: 12.5 },
+						status: "ok",
+					},
+				],
+				metadata: { email: "devin-a@example.com", accountId: "acct-1" },
+			},
+		];
+		await controller.handleUsageCommand(reportsSingle);
+		expect(present).toHaveBeenCalledTimes(1);
+		let output = renderPresentedBlocks(present.mock.calls[0]?.[0]);
+		expect(output).toContain("12.5 ACU used");
+		present.mockClear();
+
+		// 2. Multiple Devin accounts plus neighboring fallback case
+		const reportsMultiple: UsageReport[] = [
+			{
+				provider: "devin",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "devin:acus:total",
+						label: "Devin ACU consumption",
+						scope: { provider: "devin", accountId: "acct-1" },
+						amount: { unit: "acus", used: 12.5 },
+						status: "ok",
+					},
+				],
+				metadata: { email: "devin-a@example.com", accountId: "acct-1" },
+			},
+			{
+				provider: "devin",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "devin:acus:total",
+						label: "Devin ACU consumption",
+						scope: { provider: "devin", accountId: "acct-2" },
+						amount: { unit: "acus", used: 3.0 },
+						status: "ok",
+					},
+				],
+				metadata: { email: "devin-b@example.com", accountId: "acct-2" },
+			},
+			{
+				provider: "mock-fallback",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "mock:fallback:limit",
+						label: "Mock Quota",
+						scope: { provider: "mock-fallback", accountId: "acct-3" },
+						amount: { unit: "requests" },
+						status: "ok",
+					},
+				],
+				metadata: { email: "fallback-a@example.com", accountId: "acct-3" },
+			},
+			{
+				provider: "mock-fallback",
+				fetchedAt: now,
+				limits: [
+					{
+						id: "mock:fallback:limit",
+						label: "Mock Quota",
+						scope: { provider: "mock-fallback", accountId: "acct-4" },
+						amount: { unit: "requests" },
+						status: "ok",
+					},
+				],
+				metadata: { email: "fallback-b@example.com", accountId: "acct-4" },
+			},
+		];
+
+		await controller.handleUsageCommand(reportsMultiple);
+		expect(present).toHaveBeenCalledTimes(1);
+		output = renderPresentedBlocks(present.mock.calls[0]?.[0]);
+
+		// Assert Devin total sum is formatted as "15.5 ACU used" instead of falling back to "2 accts"
+		expect(output).toContain("15.5 ACU used");
+
+		// Assert fallback provider falls back to "2 accts" since it has no amount values
+		expect(output).toContain("2 accts");
+	});
 });

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { UsageReport } from "@oh-my-pi/pi-ai";
+import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
 import {
 	buildRedactionMap,
 	collectUnreportedAccounts,
@@ -8,11 +9,10 @@ import {
 	formatUsageBreakdown,
 	formatUsageHistory,
 	runUsageCommand,
-	selectReportableAccounts,
 	type StoredAccount,
+	selectReportableAccounts,
 	type UsageAccountIdentity,
 } from "@oh-my-pi/pi-coding-agent/cli/usage-cli";
-import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
 
 const HOUR = 3_600_000;
 const FIVE_HOURS = 5 * HOUR;
@@ -622,7 +622,14 @@ describe("runUsageCommand", () => {
 
 		const mockAuthStorage = {
 			getAll: () => mockCredentials,
-			fetchUsageReports: async () => [],
+			fetchUsageReports: async (): Promise<UsageReport[]> => [
+				{
+					provider: "devin",
+					fetchedAt: Date.now(),
+					limits: [],
+					metadata: { principalId: "service_user:service-secret" },
+				},
+			],
 			isCredentialSupported: () => true,
 			close: () => {},
 		} as unknown as AuthStorage;
@@ -654,7 +661,10 @@ describe("runUsageCommand", () => {
 			access?: unknown;
 		}
 
-		const parsed = JSON.parse(output) as { accountsWithoutUsage: RedactedAccountIdentityOutput[] };
+		const parsed = JSON.parse(output) as {
+			reports: Array<{ metadata?: { principalId?: string } }>;
+			accountsWithoutUsage: RedactedAccountIdentityOutput[];
+		};
 		expect(parsed).toHaveProperty("accountsWithoutUsage");
 
 		// Ensure identities are masked
@@ -664,11 +674,15 @@ describe("runUsageCommand", () => {
 		expect(openaiAcc!.email).toContain("*");
 		expect(openaiAcc!.orgId).not.toBe("org-discovered-123");
 		expect(openaiAcc!.orgId).toContain("*");
+		const principalId = parsed.reports[0]?.metadata?.principalId;
+		expect(principalId).not.toBe("service_user:service-secret");
+		expect(principalId).toContain("*");
 
 		// Ensure credential info is absent
 		expect(openaiAcc!.credential).toBeUndefined();
 		expect(openaiAcc!.access).toBeUndefined();
 		expect(output).not.toContain("cog_secretkey123");
 		expect(output).not.toContain("access_token_secret");
+		expect(output).not.toContain("service_user:service-secret");
 	});
 });

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -377,6 +377,41 @@ describe("formatUsageBreakdown", () => {
 		expect(text).toContain("12.5 ACU used");
 	});
 
+	it("renders Devin activity metrics with and without ACU consumption", () => {
+		const now = Date.parse("2026-01-01T00:00:00.000Z");
+		const metricsOnly: UsageReport = {
+			provider: "devin",
+			fetchedAt: now,
+			limits: [],
+			metadata: {
+				metrics: { sessionsCount: 10, searchesCount: 5, prsCreatedCount: 2, prsMergedCount: 1 },
+			},
+		};
+		const consumptionAndMetrics: UsageReport = {
+			provider: "devin",
+			fetchedAt: now,
+			limits: [
+				{
+					id: "devin:acus:total",
+					label: "Devin ACU consumption",
+					scope: { provider: "devin", shared: true },
+					amount: { unit: "acus", used: 12.5 },
+					status: "ok",
+				},
+			],
+			metadata: { metrics: { sessionsCount: 3, prsMergedCount: 2 } },
+		};
+
+		const metricsOnlyText = stripVTControlCharacters(formatUsageBreakdown([metricsOnly], [], now));
+		expect(metricsOnlyText).toContain("activity: 10 sessions · 5 searches · 2 PRs created · 1 PR merged");
+
+		const consumptionAndMetricsText = stripVTControlCharacters(
+			formatUsageBreakdown([consumptionAndMetrics], [], now),
+		);
+		expect(consumptionAndMetricsText).toContain("12.5 ACU used");
+		expect(consumptionAndMetricsText).toContain("activity: 3 sessions · 2 PRs merged");
+	});
+
 	it("renders Cursor request quotas in the usage breakdown", () => {
 		const now = Date.parse("2026-01-01T00:00:00.000Z");
 		const reports: UsageReport[] = [

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -503,6 +503,30 @@ describe("formatUsageHistory", () => {
 		expect(text).toContain("3 snapshots");
 	});
 
+	it("renders absolute ACU history with normalized units", () => {
+		const absoluteEntries = [
+			historyEntry(SINCE + HOUR, undefined, {
+				provider: "devin",
+				limitId: "devin:acus:total",
+				label: "Devin ACU consumption",
+				used: 12.5,
+				unit: "acus",
+			}),
+			historyEntry(NOW - HOUR, undefined, {
+				provider: "devin",
+				limitId: "devin:acus:total",
+				label: "Devin ACU consumption",
+				used: 15,
+				unit: "acus",
+			}),
+		];
+
+		const text = stripVTControlCharacters(formatUsageHistory(absoluteEntries, SINCE, NOW));
+		expect(text).toContain("latest 15 ACU");
+		expect(text).toContain("peak 15 ACU");
+		expect(text).not.toContain("latest 15 acus");
+	});
+
 	it("redacts account labels through the provided map", () => {
 		const redaction = buildRedactionMap(["dummy.primary@example.test"]);
 		const text = stripVTControlCharacters(formatUsageHistory(entries, SINCE, NOW, redaction));

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -7,6 +7,7 @@ import {
 	computeProviderWindowStats,
 	formatUsageBreakdown,
 	formatUsageHistory,
+	selectReportableAccounts,
 	type UsageAccountIdentity,
 } from "@oh-my-pi/pi-coding-agent/cli/usage-cli";
 
@@ -504,5 +505,27 @@ describe("formatUsageHistory", () => {
 		const text = stripVTControlCharacters(formatUsageHistory(entries, SINCE, NOW, redaction));
 		expect(text).not.toContain("dummy.primary@example.test");
 		expect(text).toContain("du*");
+	});
+});
+
+describe("selectReportableAccounts", () => {
+	it("filters out unsupported credentials based on the isCredentialSupported callback", async () => {
+		const accounts: UsageAccountIdentity[] = [
+			{ provider: "devin", type: "api_key", credential: { type: "api_key", key: "cog_test" } },
+			{ provider: "devin", type: "oauth", credential: { type: "oauth", access: "token", refresh: "refresh", expires: 0 } },
+			{ provider: "openai-codex", type: "api_key", credential: { type: "api_key", key: "sk-test" } },
+		];
+
+		const filtered = await selectReportableAccounts(
+			accounts,
+			(provider, cred) => {
+				if (provider === "devin" && cred?.type === "oauth") return false;
+				return true;
+			}
+		);
+
+		expect(filtered).toHaveLength(2);
+		expect(filtered[0]).toMatchObject({ provider: "devin", type: "api_key" });
+		expect(filtered[1]).toMatchObject({ provider: "openai-codex", type: "api_key" });
 	});
 });

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -348,6 +348,31 @@ describe("formatUsageBreakdown", () => {
 		expect(text).toContain("0.40× quota left");
 	});
 
+	it("renders Devin ACU consumption without requiring a quota limit", () => {
+		const now = Date.parse("2026-01-01T00:00:00.000Z");
+		const reports: UsageReport[] = [
+			{
+				provider: "devin",
+				fetchedAt: now,
+				metadata: { orgId: "org-abc123" },
+				limits: [
+					{
+						id: "devin:acus:total",
+						label: "Devin ACU consumption",
+						scope: { provider: "devin", orgId: "org-abc123", shared: true },
+						amount: { unit: "acus", used: 12.5 },
+						status: "ok",
+					},
+				],
+			},
+		];
+
+		const text = stripVTControlCharacters(formatUsageBreakdown(reports, [], now));
+		expect(text).toContain("Devin");
+		expect(text).toContain("Devin ACU consumption");
+		expect(text).toContain("12.5 ACU used");
+	});
+
 	it("renders Cursor request quotas in the usage breakdown", () => {
 		const now = Date.parse("2026-01-01T00:00:00.000Z");
 		const reports: UsageReport[] = [

--- a/packages/coding-agent/test/usage-cli.test.ts
+++ b/packages/coding-agent/test/usage-cli.test.ts
@@ -7,9 +7,12 @@ import {
 	computeProviderWindowStats,
 	formatUsageBreakdown,
 	formatUsageHistory,
+	runUsageCommand,
 	selectReportableAccounts,
+	type StoredAccount,
 	type UsageAccountIdentity,
 } from "@oh-my-pi/pi-coding-agent/cli/usage-cli";
+import type { AuthStorage } from "@oh-my-pi/pi-ai/auth-storage";
 
 const HOUR = 3_600_000;
 const FIVE_HOURS = 5 * HOUR;
@@ -510,22 +513,162 @@ describe("formatUsageHistory", () => {
 
 describe("selectReportableAccounts", () => {
 	it("filters out unsupported credentials based on the isCredentialSupported callback", async () => {
-		const accounts: UsageAccountIdentity[] = [
-			{ provider: "devin", type: "api_key", credential: { type: "api_key", key: "cog_test" } },
-			{ provider: "devin", type: "oauth", credential: { type: "oauth", access: "token", refresh: "refresh", expires: 0 } },
-			{ provider: "openai-codex", type: "api_key", credential: { type: "api_key", key: "sk-test" } },
+		const accounts: StoredAccount[] = [
+			{ identity: { provider: "devin", type: "api_key" }, credential: { type: "api_key", key: "cog_test" } },
+			{
+				identity: { provider: "devin", type: "oauth" },
+				credential: { type: "oauth", access: "token", refresh: "refresh", expires: 0 },
+			},
+			{ identity: { provider: "openai-codex", type: "api_key" }, credential: { type: "api_key", key: "sk-test" } },
 		];
 
-		const filtered = await selectReportableAccounts(
-			accounts,
-			(provider, cred) => {
-				if (provider === "devin" && cred?.type === "oauth") return false;
-				return true;
-			}
-		);
+		const filtered = await selectReportableAccounts(accounts, (provider, cred) => {
+			if (provider === "devin" && cred?.type === "oauth") return false;
+			return true;
+		});
 
 		expect(filtered).toHaveLength(2);
 		expect(filtered[0]).toMatchObject({ provider: "devin", type: "api_key" });
 		expect(filtered[1]).toMatchObject({ provider: "openai-codex", type: "api_key" });
+	});
+});
+
+describe("runUsageCommand", () => {
+	it("removes all raw api_key and oauth credentials from accountsWithoutUsage in JSON output", async () => {
+		const mockCredentials = {
+			devin: { type: "api_key", key: "cog_secretkey123" },
+			openai: {
+				type: "oauth",
+				access: "access_token_secret",
+				refresh: "refresh_token_secret",
+				email: "user@example.test",
+				expires: 0,
+			},
+		};
+
+		const mockAuthStorage = {
+			getAll: () => mockCredentials,
+			fetchUsageReports: async () => [],
+			isCredentialSupported: () => true,
+			close: () => {},
+		} as unknown as AuthStorage;
+
+		const deps = {
+			discoverAuthStorage: async () => mockAuthStorage,
+			createBaseUrlResolver: () => () => undefined,
+		};
+
+		const originalWrite = process.stdout.write;
+		let output = "";
+		process.stdout.write = (chunk: string | Uint8Array) => {
+			output += String(chunk);
+			return true;
+		};
+
+		try {
+			await runUsageCommand({ action: "view", json: true }, deps);
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+
+		interface AccountIdentityOutput {
+			provider: string;
+			type: string;
+			email?: string;
+			orgId?: string;
+			credential?: unknown;
+			key?: unknown;
+			access?: unknown;
+			refresh?: unknown;
+		}
+
+		const parsed = JSON.parse(output) as { accountsWithoutUsage: AccountIdentityOutput[] };
+		expect(parsed).toHaveProperty("accountsWithoutUsage");
+		expect(parsed.accountsWithoutUsage).toHaveLength(2);
+
+		// Ensure identities are correct but credential info is not present
+		const devinAcc = parsed.accountsWithoutUsage.find(a => a.provider === "devin");
+		expect(devinAcc).toBeDefined();
+		expect(devinAcc!.type).toBe("api_key");
+		expect(devinAcc!.credential).toBeUndefined();
+		expect(devinAcc!.key).toBeUndefined();
+
+		const openaiAcc = parsed.accountsWithoutUsage.find(a => a.provider === "openai");
+		expect(openaiAcc).toBeDefined();
+		expect(openaiAcc!.type).toBe("oauth");
+		expect(openaiAcc!.email).toBe("user@example.test");
+		expect(openaiAcc!.credential).toBeUndefined();
+		expect(openaiAcc!.access).toBeUndefined();
+		expect(openaiAcc!.refresh).toBeUndefined();
+
+		// Ensure no secrets exist anywhere in the JSON output string
+		expect(output).not.toContain("cog_secretkey123");
+		expect(output).not.toContain("access_token_secret");
+		expect(output).not.toContain("refresh_token_secret");
+	});
+
+	it("removes all raw credentials and applies masking to identities with --redact", async () => {
+		const mockCredentials = {
+			devin: { type: "api_key", key: "cog_secretkey123" },
+			openai: {
+				type: "oauth",
+				access: "access_token_secret",
+				refresh: "refresh_token_secret",
+				email: "user@example.test",
+				expires: 0,
+				orgId: "org-discovered-123",
+			},
+		};
+
+		const mockAuthStorage = {
+			getAll: () => mockCredentials,
+			fetchUsageReports: async () => [],
+			isCredentialSupported: () => true,
+			close: () => {},
+		} as unknown as AuthStorage;
+
+		const deps = {
+			discoverAuthStorage: async () => mockAuthStorage,
+			createBaseUrlResolver: () => () => undefined,
+		};
+
+		const originalWrite = process.stdout.write;
+		let output = "";
+		process.stdout.write = (chunk: string | Uint8Array) => {
+			output += String(chunk);
+			return true;
+		};
+
+		try {
+			await runUsageCommand({ action: "view", json: true, redact: true }, deps);
+		} finally {
+			process.stdout.write = originalWrite;
+		}
+
+		interface RedactedAccountIdentityOutput {
+			provider: string;
+			type: string;
+			email?: string;
+			orgId?: string;
+			credential?: unknown;
+			access?: unknown;
+		}
+
+		const parsed = JSON.parse(output) as { accountsWithoutUsage: RedactedAccountIdentityOutput[] };
+		expect(parsed).toHaveProperty("accountsWithoutUsage");
+
+		// Ensure identities are masked
+		const openaiAcc = parsed.accountsWithoutUsage.find(a => a.provider === "openai");
+		expect(openaiAcc).toBeDefined();
+		expect(openaiAcc!.email).not.toBe("user@example.test");
+		expect(openaiAcc!.email).toContain("*");
+		expect(openaiAcc!.orgId).not.toBe("org-discovered-123");
+		expect(openaiAcc!.orgId).toContain("*");
+
+		// Ensure credential info is absent
+		expect(openaiAcc!.credential).toBeUndefined();
+		expect(openaiAcc!.access).toBeUndefined();
+		expect(output).not.toContain("cog_secretkey123");
+		expect(output).not.toContain("access_token_secret");
 	});
 });


### PR DESCRIPTION
## Summary
- Add a Devin usage provider that fetches public API ACU consumption and usage metrics for service-user/PAT API keys.
- Register Devin in the default usage provider set and expose it through package exports.
- Render normalized Devin metrics in both `omp usage` and interactive `/usage`, with the `ACU` unit across schemas and history.
- Keep history stable across API-key rotation with a privacy-safe organization/principal identity, while resolving stored credential references before env/config fallback.

## Screenshots
No visual change.

## Testing

Latest-head verification after rebasing onto `main@22a2ea169`:

- `bun test packages/ai/test/devin-usage.test.ts packages/ai/test/auth-storage-usage-history.test.ts packages/coding-agent/test/usage-cli.test.ts packages/coding-agent/test/modes/controllers/usage-command.test.ts` — 70 passed, 0 failed, 261 assertions.
- `bun run check:ts`

## Risk
- Live Devin API was not exercised because no Devin credential env var was present.
- Org-scoped endpoint paths are based on the public Devin endpoint set and covered with fallback tests.
- Devin usage intentionally supports only v3 API credentials with the `cog_` prefix; OAuth `/login` credentials are not sent to these endpoints.

## Notes
- Supports Devin API-key credentials only.
- Definitive Devin 401/403 usage responses are surfaced as credential failures for health checks.

## AI Review Report

Independent review passes covered endpoint fallback, credential precedence, deduplication, history identity, human CLI/TUI rendering, schema units, and current-main compatibility. Remediation made metrics-only reports visible, stabilized history across credential rotation, prevented stale stored references from suppressing valid `cog_` fallback credentials, and normalized docs-style `/v3` API roots without duplicating the version path. The latest review surface has no unresolved thread.

## Security Audit
No new persistent secrets. Tokens are only used as bearer headers. History identity uses a SHA-256 organization/principal marker rather than storing raw credentials; raw provider payloads remain in usage metadata/raw report paths consistent with existing usage providers.
