### PR TITLE
fix(natives): guard shell timeout process-group cleanup

### DIFF
--- a/crates/pi-shell/src/process.rs
+++ b/crates/pi-shell/src/process.rs
@@ -1561,9 +1561,10 @@ impl TerminationTargets {
 		Self::default()
 	}
 
-	/// Record a process group id. Duplicates are ignored.
+	/// Record a process group id. Duplicates and the host process group are
+	/// ignored.
 	pub fn add_pgid(&mut self, pgid: i32) {
-		if pgid > 0 && !self.pgids.contains(&pgid) {
+		if pgid > 0 && !is_self_process_group(pgid) && !self.pgids.contains(&pgid) {
 			self.pgids.push(pgid);
 		}
 	}
@@ -1973,6 +1974,24 @@ mod tests {
 		targets.add_process(pinned);
 		targets.add_pid(self_pid);
 		assert_eq!(targets.processes.len(), 1, "duplicate pids must be deduped");
+	}
+
+	/// A cancellation wave must never signal the harness' own process group.
+	/// If a child reports that pgid (for example when process-group isolation
+	/// failed under WSL), per-process signalling still reaches the child while
+	/// the group target is discarded.
+	#[cfg(unix)]
+	#[test]
+	fn add_pgid_ignores_own_process_group() {
+		// SAFETY: `getpgid(0)` queries the calling process and does not access
+		// caller-owned memory.
+		let own_pgid = unsafe { libc::getpgid(0) };
+		assert!(own_pgid > 0, "test process must have an observable pgid");
+
+		let mut targets = TerminationTargets::new();
+		targets.add_pgid(own_pgid);
+
+		assert!(targets.pgids.is_empty(), "own pgid must not enter the kill set");
 	}
 
 	/// Regression test for the review on PR #4606: a long-running shell

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed shell timeout cleanup on POSIX hosts so a child process that reports OMP's own process group cannot cause cancellation to signal and terminate the OMP process itself ([#4866](https://github.com/can1357/oh-my-pi/issues/4866)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed


### PR DESCRIPTION
## Repro
A timed-out bash command enters native shell cancellation cleanup. Before the fix, `TerminationTargets::add_pgid` accepted any positive process group id; if a WSL/POSIX child reported OMP's own pgid, cleanup would enqueue that pgid and later call `kill(-pgid, SIGTERM)`, terminating OMP itself. Repro regression command: `cargo test -p pi-shell add_pgid_ignores_own_process_group`.

## Cause
`crates/pi-shell/src/process.rs` built timeout/cancellation `TerminationTargets` from spawned process ids and reported pgids, but `TerminationTargets::add_pgid` only filtered non-positive and duplicate pgids. It did not reject the host process group, so a failed process-group isolation path could turn bash timeout cleanup into a signal against OMP's own process group.

## Fix
- Added a host-process-group guard to `TerminationTargets::add_pgid` so OMP's own pgid is never enqueued for group signaling.
- Added `add_pgid_ignores_own_process_group`, a regression test that exercises the dangerous kill-set state without sending any signal.
- Added a `packages/natives` changelog entry for the timeout cleanup crash fix.

## Verification
- `cargo test -p pi-shell add_pgid_ignores_own_process_group` — passed.
- `cargo test -p pi-shell timeout` — passed.
- `cargo test -p pi-shell` — passed, 829 tests.
- `bun test packages/coding-agent/test/bash-executor.test.ts --timeout 10000` — passed, 38 tests.
- `cargo check -p pi-shell` — passed.
- Pre-publish gate passed via `gh_push_branch` before pushing. Fixes #4866.