### PR TITLE
fix(coding-agent): inherit default keybindings in named profiles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed named profiles dropping default user keybindings from `~/.omp/agent/keybindings.*`; profile keybindings now inherit those defaults and override only the keys they define ([#4867](https://github.com/can1357/oh-my-pi/issues/4867)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -9,7 +9,7 @@ import {
 	TUI_KEYBINDINGS,
 	KeybindingsManager as TuiKeybindingsManager,
 } from "@oh-my-pi/pi-tui";
-import { getAgentDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
+import { getActiveProfile, getAgentDir, getProfileRootDir, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import { JSONC, YAML } from "bun";
 
 /**
@@ -375,6 +375,12 @@ interface KeybindingsConfigPaths {
 	writeBackPath: string;
 }
 
+/** Controls inherited keybinding lookup when creating a manager for a named profile. */
+export interface KeybindingsCreateOptions {
+	/** Default-profile agent directory whose keybindings are merged before profile-specific bindings. */
+	inheritedAgentDir?: string;
+}
+
 /**
  * Load raw config from a file synchronously.
  * Returns parsed JSON/YAML or null if file doesn't exist or is invalid.
@@ -426,6 +432,45 @@ function resolveKeybindingsConfigPaths(agentDir: string): KeybindingsConfigPaths
 	}
 
 	return { readPath: ymlPath, writeBackPath: ymlPath };
+}
+
+function mergeKeybindingsConfig(
+	inheritedConfig: KeybindingsConfig,
+	profileConfig: KeybindingsConfig,
+): KeybindingsConfig {
+	return { ...inheritedConfig, ...profileConfig };
+}
+
+function resolveInheritedAgentDir(agentDir: string, options: KeybindingsCreateOptions): string | undefined {
+	const inheritedAgentDir =
+		options.inheritedAgentDir ?? (getActiveProfile() ? path.join(getProfileRootDir(undefined), "agent") : undefined);
+	if (!inheritedAgentDir) return undefined;
+	if (path.resolve(inheritedAgentDir) === path.resolve(agentDir)) return undefined;
+	return inheritedAgentDir;
+}
+
+function loadMergedKeybindingsConfig(
+	agentDir: string,
+	options: KeybindingsCreateOptions,
+): {
+	config: KeybindingsConfig;
+	profilePath: string;
+	inheritedPath: string | undefined;
+} {
+	const profilePaths = resolveKeybindingsConfigPaths(agentDir);
+	const profile = loadKeybindingsConfig(profilePaths.readPath, profilePaths.writeBackPath);
+	const inheritedAgentDir = resolveInheritedAgentDir(agentDir, options);
+	if (!inheritedAgentDir) {
+		return { config: profile.config, profilePath: profile.persistedPath, inheritedPath: undefined };
+	}
+
+	const inheritedPaths = resolveKeybindingsConfigPaths(inheritedAgentDir);
+	const inherited = loadKeybindingsConfig(inheritedPaths.readPath, inheritedPaths.writeBackPath);
+	return {
+		config: mergeKeybindingsConfig(inherited.config, profile.config),
+		profilePath: profile.persistedPath,
+		inheritedPath: inherited.persistedPath,
+	};
 }
 
 /**
@@ -499,22 +544,23 @@ function keyConfigValue(keys: KeyId[]): KeyId | KeyId[] {
  */
 export class KeybindingsManager extends TuiKeybindingsManager {
 	#configPath: string | undefined;
+	#inheritedConfigPath: string | undefined;
 	#userBindings: KeybindingsConfig;
 
-	constructor(userBindings: KeybindingsConfig = {}, configPath?: string) {
+	constructor(userBindings: KeybindingsConfig = {}, configPath?: string, inheritedConfigPath?: string) {
 		super(KEYBINDINGS, userBindings);
 		this.#configPath = configPath;
+		this.#inheritedConfigPath = inheritedConfigPath;
 		this.#userBindings = userBindings;
 	}
 
 	/**
-	 * Create from config file at agentDir/keybindings.yml.
+	 * Create from config files at agentDir/keybindings.yml and the default profile.
 	 * Legacy keybindings.json is migrated to keybindings.yml on load.
 	 */
-	static create(agentDir: string = getAgentDir()): KeybindingsManager {
-		const { readPath, writeBackPath } = resolveKeybindingsConfigPaths(agentDir);
-		const { config: userBindings, persistedPath } = KeybindingsManager.#loadFromFile(readPath, writeBackPath);
-		const manager = new KeybindingsManager(userBindings, persistedPath);
+	static create(agentDir: string = getAgentDir(), options: KeybindingsCreateOptions = {}): KeybindingsManager {
+		const { config: userBindings, profilePath, inheritedPath } = loadMergedKeybindingsConfig(agentDir, options);
+		const manager = new KeybindingsManager(userBindings, profilePath, inheritedPath);
 		// Set globally so getKeybindings() returns this manager
 		setKeybindings(manager);
 		return manager;
@@ -528,12 +574,15 @@ export class KeybindingsManager extends TuiKeybindingsManager {
 	}
 
 	/**
-	 * Reload keybindings from the config file.
+	 * Reload keybindings from the config files.
 	 */
 	reload(): void {
 		if (!this.#configPath) return;
-		const { config } = KeybindingsManager.#loadFromFile(this.#configPath);
-		this.setUserBindings(config);
+		const { config: inheritedConfig } = this.#inheritedConfigPath
+			? KeybindingsManager.#loadFromFile(this.#inheritedConfigPath)
+			: { config: {} };
+		const { config: profileConfig } = KeybindingsManager.#loadFromFile(this.#configPath);
+		this.setUserBindings(mergeKeybindingsConfig(inheritedConfig, profileConfig));
 	}
 
 	setUserBindings(userBindings: KeybindingsConfig): void {

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/keybindings-migration.test.ts
+++ b/packages/coding-agent/test/keybindings-migration.test.ts
@@ -4,12 +4,31 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { matchesAppFollowUp } from "@oh-my-pi/pi-coding-agent/modes/utils/keybinding-matchers";
-import { setKeybindings } from "@oh-my-pi/pi-tui";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { type KeybindingsConfig, setKeybindings } from "@oh-my-pi/pi-tui";
+import {
+	__resetDirsFromEnvForTests,
+	getAgentDir,
+	getProfileRootDir,
+	removeWithRetries,
+	setProfile,
+} from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 
 function ctrl(key: string): string {
 	return String.fromCharCode(key.toLowerCase().charCodeAt(0) & 31);
+}
+
+async function writeKeybindingsYaml(agentDir: string, config: KeybindingsConfig): Promise<void> {
+	await fs.mkdir(agentDir, { recursive: true });
+	await Bun.write(path.join(agentDir, "keybindings.yml"), YAML.stringify(config, null, 2));
+}
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = value;
+	}
 }
 describe("KeybindingsManager.create", () => {
 	beforeEach(() => {
@@ -146,6 +165,94 @@ describe("KeybindingsManager.create", () => {
 			expect(await Bun.file(canonicalPath).exists()).toBe(false);
 		} finally {
 			await removeWithRetries(agentDir);
+		}
+	});
+
+	it("inherits default user keybindings for a named profile without a profile keybindings file (#4867)", async () => {
+		const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-keybindings-profile-"));
+		const defaultAgentDir = path.join(rootDir, "default", "agent");
+		const profileAgentDir = path.join(rootDir, "profiles", "work", "agent");
+
+		await writeKeybindingsYaml(defaultAgentDir, {
+			"app.session.fork": "ctrl+f",
+			"app.session.new": "ctrl+n",
+		});
+
+		try {
+			const manager = KeybindingsManager.create(profileAgentDir, { inheritedAgentDir: defaultAgentDir });
+
+			expect(manager.getKeys("app.session.fork")).toEqual(["ctrl+f"]);
+			expect(manager.getKeys("app.session.new")).toEqual(["ctrl+n"]);
+		} finally {
+			await removeWithRetries(rootDir);
+		}
+	});
+
+	it("merges default user keybindings with profile overrides for a named profile (#4867)", async () => {
+		const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-keybindings-profile-"));
+		const defaultAgentDir = path.join(rootDir, "default", "agent");
+		const profileAgentDir = path.join(rootDir, "profiles", "work", "agent");
+
+		await writeKeybindingsYaml(defaultAgentDir, {
+			"app.session.fork": "ctrl+f",
+			"app.session.new": "ctrl+n",
+		});
+		await writeKeybindingsYaml(profileAgentDir, {
+			"app.session.fork": "alt+f",
+			"app.clipboard.copyLine": "alt+l",
+		});
+
+		try {
+			const manager = KeybindingsManager.create(profileAgentDir, { inheritedAgentDir: defaultAgentDir });
+
+			expect(manager.getKeys("app.session.new")).toEqual(["ctrl+n"]);
+			expect(manager.getKeys("app.session.fork")).toEqual(["alt+f"]);
+			expect(manager.getKeys("app.clipboard.copyLine")).toEqual(["alt+l"]);
+		} finally {
+			await removeWithRetries(rootDir);
+		}
+	});
+
+	it("merges default user keybindings when create uses the active profile with no arguments (#4867)", async () => {
+		const originalConfigDir = process.env.PI_CONFIG_DIR;
+		const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+		const originalOmpProfile = process.env.OMP_PROFILE;
+		const originalPiProfile = process.env.PI_PROFILE;
+		const configRootDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-keybindings-active-profile-"));
+
+		try {
+			process.env.PI_CONFIG_DIR = path.relative(os.homedir(), configRootDir);
+			restoreEnvValue("PI_CODING_AGENT_DIR", originalAgentDirEnv);
+			restoreEnvValue("OMP_PROFILE", originalOmpProfile);
+			restoreEnvValue("PI_PROFILE", originalPiProfile);
+			__resetDirsFromEnvForTests();
+
+			const defaultAgentDir = path.join(getProfileRootDir(undefined), "agent");
+			const profileAgentDir = path.join(getProfileRootDir("work"), "agent");
+			await writeKeybindingsYaml(defaultAgentDir, {
+				"app.session.fork": "ctrl+f",
+				"app.session.new": "ctrl+n",
+			});
+			await writeKeybindingsYaml(profileAgentDir, {
+				"app.session.fork": "alt+f",
+				"app.clipboard.copyLine": "alt+l",
+			});
+
+			setProfile("work");
+
+			expect(getAgentDir()).toBe(profileAgentDir);
+			const manager = KeybindingsManager.create();
+
+			expect(manager.getKeys("app.session.new")).toEqual(["ctrl+n"]);
+			expect(manager.getKeys("app.session.fork")).toEqual(["alt+f"]);
+			expect(manager.getKeys("app.clipboard.copyLine")).toEqual(["alt+l"]);
+		} finally {
+			restoreEnvValue("PI_CONFIG_DIR", originalConfigDir);
+			restoreEnvValue("PI_CODING_AGENT_DIR", originalAgentDirEnv);
+			restoreEnvValue("OMP_PROFILE", originalOmpProfile);
+			restoreEnvValue("PI_PROFILE", originalPiProfile);
+			__resetDirsFromEnvForTests();
+			await removeWithRetries(configRootDir);
 		}
 	});
 


### PR DESCRIPTION
## Repro
A minimal loader repro created a default `agent/keybindings.yml` with `tui.editor.deleteCharBackward: [backspace, ctrl+h, ctrl+?]`, then created an empty named-profile agent dir and ran `bun .wt/repro-keybindings.ts`; before the fix it printed `["backspace"]` and exited 1 with `missing inherited default user binding ctrl+?`, matching the reporter's named-profile Backspace loss.

## Cause
`packages/coding-agent/src/config/keybindings.ts` loaded exactly one keybinding source in `KeybindingsManager.create(agentDir = getAgentDir())`: `resolveKeybindingsConfigPaths(agentDir)` followed by `#loadFromFile(...)`. Under `--profile`, `getAgentDir()` points at `~/.omp/profiles/<name>/agent`, so the manager never read the default-profile `~/.omp/agent/keybindings.*` file.

## Fix
- Added default-profile keybinding inheritance for active named profiles, with profile keybindings merged last so profile files override only the bindings they define.
- Preserved legacy `keybindings.json` migration for both inherited and profile-specific sources.
- Added regression tests for explicit inherited dirs and the production no-argument active-profile `KeybindingsManager.create()` path.
- Added a coding-agent changelog entry for the profile keybinding inheritance fix.

## Verification
`bun test packages/coding-agent/test/keybindings-migration.test.ts` passed with 14 tests and 41 assertions. `PI_CONFIG_DIR=../../data/workspaces/can1357__oh-my-pi__4867/.omp-tmp/omp-profile-auto-o4Sx6s OMP_PROFILE=work PI_PROFILE=work bun .wt/repro-keybindings-auto.ts` printed inherited `deleteKeys` including `ctrl+?` and profile override `profileKeys:["alt+f"]`. `bun check` passed. Fixes #4867