### PR TITLE
feat(catalog): add grok-4.5 to xAI and SuperGrok catalogs

### DIFF
--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -21,8 +21,17 @@ const oauthTokens = await Promise.all([
 	resolveApiKey("google-gemini-cli"),
 	resolveApiKey("google-antigravity"),
 	resolveApiKey("openai-codex"),
+	resolveApiKey("xai-oauth"),
 ]);
-const [anthropicOAuthToken, githubCopilotToken, geminiCliToken, antigravityToken, openaiCodexToken] = oauthTokens;
+const [
+	anthropicOAuthToken,
+	githubCopilotToken,
+	geminiCliToken,
+	antigravityToken,
+	openaiCodexToken,
+	xaiOauthFromTestauth,
+] = oauthTokens;
+const xaiOauthToken = e2eApiKey("XAI_OAUTH_TOKEN") ?? xaiOauthFromTestauth;
 
 function hasBedrockCredentials(): boolean {
 	const region = e2eApiKey("AWS_REGION") ?? e2eApiKey("AWS_DEFAULT_REGION");
@@ -1075,6 +1084,123 @@ describe("Generate E2E Tests", () => {
 			{ retry: 3 },
 		);
 	});
+
+	describe.skipIf(!e2eApiKey("XAI_API_KEY") || !getBundledModel("xai", "grok-4.5"))(
+		"xAI Provider (grok-4.5 via OpenAI Completions)",
+		() => {
+			const llm = getBundledModel("xai", "grok-4.5")!;
+			const efforts = llm.thinking?.mode === "effort" ? llm.thinking.efforts : [];
+
+			it(
+				"should complete basic text generation",
+				async () => {
+					await basicTextGeneration(llm);
+				},
+				{ retry: 3 },
+			);
+
+			it(
+				"should handle tool calling",
+				async () => {
+					await handleToolCall(llm);
+				},
+				{ retry: 3 },
+			);
+
+			it(
+				"should handle streaming",
+				async () => {
+					await handleStreaming(llm);
+				},
+				{ retry: 3 },
+			);
+
+			for (const effort of efforts) {
+				it(
+					`should handle thinking mode (effort=${effort})`,
+					async () => {
+						await handleThinking(llm, { reasoning: effort });
+					},
+					{ retry: 2 },
+				);
+			}
+
+			it(
+				"should handle multi-turn with thinking and tools",
+				async () => {
+					await multiTurn(llm, { reasoning: Effort.Medium });
+				},
+				{ retry: 3 },
+			);
+
+			it(
+				"should handle image input",
+				async () => {
+					await handleImage(llm);
+				},
+				{ retry: 3 },
+			);
+		},
+	);
+
+	describe.skipIf(!xaiOauthToken || !getBundledModel("xai-oauth", "grok-4.5"))(
+		"xAI OAuth Provider (grok-4.5 via OpenAI Responses)",
+		() => {
+			const llm = getBundledModel("xai-oauth", "grok-4.5") as Model<"openai-responses">;
+			const efforts = llm.thinking?.mode === "effort" ? llm.thinking.efforts : [];
+			const opts = { apiKey: xaiOauthToken! };
+
+			it(
+				"should complete basic text generation",
+				async () => {
+					await basicTextGeneration(llm, opts);
+				},
+				{ retry: 3 },
+			);
+
+			it(
+				"should handle tool calling",
+				async () => {
+					await handleToolCall(llm, opts);
+				},
+				{ retry: 3 },
+			);
+
+			it(
+				"should handle streaming",
+				async () => {
+					await handleStreaming(llm, opts);
+				},
+				{ retry: 3 },
+			);
+
+			for (const effort of efforts) {
+				it(
+					`should handle thinking mode (effort=${effort})`,
+					async () => {
+						await handleThinking(llm, { ...opts, reasoning: effort });
+					},
+					{ retry: 2 },
+				);
+			}
+
+			it(
+				"should handle multi-turn with thinking and tools",
+				async () => {
+					await multiTurn(llm, { ...opts, reasoning: Effort.High });
+				},
+				{ retry: 3 },
+			);
+
+			it(
+				"should handle image input",
+				async () => {
+					await handleImage(llm, opts);
+				},
+				{ retry: 3 },
+			);
+		},
+	);
 
 	describe.skipIf(!e2eApiKey("GROQ_API_KEY"))("Groq Provider (gpt-oss-20b via OpenAI Completions)", () => {
 		const llm = getBundledModel("groq", "openai/gpt-oss-20b");

--- a/packages/ai/test/xai-oauth-effort-strip.test.ts
+++ b/packages/ai/test/xai-oauth-effort-strip.test.ts
@@ -28,6 +28,14 @@ describe("effort-dial-less reasoner encoding (regression)", () => {
 		expect(getSupportedEfforts(grok43).length).toBeGreaterThan(0);
 	});
 
+	test("xai-oauth/grok-4.5 keeps its effort dial", () => {
+		const grok45 = getBundledModel("xai-oauth", "grok-4.5");
+		if (!grok45) throw new Error("xai-oauth/grok-4.5 must be in bundled models.json");
+		expect(grok45.reasoning).toBe(true);
+		expect(grok45.thinking).toBeDefined();
+		expect(getSupportedEfforts(grok45).length).toBeGreaterThan(0);
+	});
+
 	test("xai-oauth/grok-4.20-0309-reasoning reasons but carries no thinking config", () => {
 		const grokR = getBundledModel("xai-oauth", "grok-4.20-0309-reasoning");
 		if (!grokR) throw new Error("xai-oauth/grok-4.20-0309-reasoning must be in bundled models.json");

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `grok-4.5` to the xAI Grok OAuth (SuperGrok) curated catalog: reasoning + vision, 500K context (xAI docs + models.dev), with the reasoning-effort dial enabled via `isGrokReasoningEffortCapable`. Paid `xai` and SuperGrok defaults now point at `grok-4.5`. ([#4859](https://github.com/can1357/oh-my-pi/issues/4859))
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -78,7 +78,7 @@ export const isMimoModelIdOrName = memo((value: string): boolean => {
 	return value.toLowerCase().includes("mimo");
 });
 
-const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3"] as const;
+const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3", "grok-4.5"] as const;
 
 /**
  * Grok SKUs that expose the wire `reasoning.effort` dial. Other Grok reasoners

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -83094,6 +83094,35 @@
 				]
 			}
 		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"grok-beta": {
 			"id": "grok-beta",
 			"name": "Grok Beta",
@@ -83308,6 +83337,47 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			}
+		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-responses",
+			"provider": "xai-oauth",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -408,13 +408,13 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "xai",
-		defaultModel: "grok-4-fast-non-reasoning",
+		defaultModel: "grok-4.5",
 		envVars: ["XAI_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => xaiModelManagerOptions(config),
 	},
 	{
 		id: "xai-oauth",
-		defaultModel: "grok-4.3",
+		defaultModel: "grok-4.5",
 		envVars: ["XAI_OAUTH_TOKEN", "XAI_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => xaiOAuthModelManagerOptions(config),
 		catalogDiscovery: {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -960,14 +960,24 @@ interface XAICuratedModel {
 
 // Source of truth for the xai-oauth chat picker. Top of list = headline.
 // Context windows from hermes-agent/agent/model_metadata.py:205-220
-// ("Values sourced from models.dev (2026-04)"). grok-build is xAI's
-// coding-fine-tuned chat model; 512K context per user spec (2026-05-17).
+// ("Values sourced from models.dev (2026-04)"), plus xAI docs for newer
+// SKUs (e.g. grok-4.5 @ 500k — docs.x.ai/developers/models/grok-4.5).
+// grok-build is xAI's coding-fine-tuned chat model; 512K context per user
+// spec (2026-05-17).
 //
 // supportsReasoningEffort=false entries reason natively but reject the wire
 // `reasoning.effort` param (api.x.ai returns HTTP 400). The corresponding
 // omit/include/history replay defaults live in catalog compat so every
 // OpenAI-family endpoint consumes the same constraint.
 export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
+	// Flagship (2026-06): reasoning + vision, 500k context (xAI docs + models.dev).
+	// On the effort-capable allowlist so the picker exposes reasoning levels.
+	{
+		id: "grok-4.5",
+		contextWindow: 500_000,
+		name: "Grok 4.5",
+		input: ["text", "image"],
+	},
 	{
 		id: "grok-build",
 		contextWindow: 512_000,

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -262,9 +262,11 @@ describe("modelFamilyToken", () => {
 describe("isGrokReasoningEffortCapable", () => {
 	test("matches effort-capable Grok SKUs across namespaces", () => {
 		expect(isGrokReasoningEffortCapable("grok-4.3")).toBe(true);
+		expect(isGrokReasoningEffortCapable("grok-4.5")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-3-mini")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-4.20-multi-agent")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.3")).toBe(true);
+		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.5")).toBe(true);
 		expect(isGrokReasoningEffortCapable("openrouter/xai/grok-3-mini")).toBe(true);
 	});
 

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -41,10 +41,24 @@ describe("xai-oauth bundled catalog (regression)", () => {
 		});
 	}
 
-	// Absolute contract for the user-specified SuperGrok addition. The parity
-	// loop above can't catch a value typo (e.g. 2_000_000) or a flipped
-	// reasoning flag — both sides regenerate from the same seed together — so
-	// pin the literal attributes here.
+	// Absolute contract for flagship SuperGrok SKUs. The parity loop above
+	// can't catch a value typo (e.g. 2_000_000) or a flipped reasoning flag —
+	// both sides regenerate from the same seed together — so pin the literal
+	// attributes here.
+	it("exposes grok-4.5 as a reasoning 500K vision model with effort dial", () => {
+		const flagship = seed.find(model => model.id === "grok-4.5");
+		expect(flagship, "grok-4.5 must be in the SuperGrok curated seed").toBeDefined();
+		expect(flagship!.reasoning).toBe(true);
+		expect(flagship!.contextWindow).toBe(500_000);
+		expect(flagship!.maxTokens).toBe(500_000);
+		expect(flagship!.input).toEqual(["text", "image"]);
+		// Effort-capable allowlist (identity/family.ts) + curated merge must
+		// surface the dial — issue #4859 explicitly needs reasoning levels.
+		expect(flagship!.compat?.supportsReasoningEffort).not.toBe(false);
+		expect(flagship!.compat?.omitReasoningEffort).toBe(false);
+		expect(bundled["grok-4.5"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
+
 	it("exposes grok-composer-2.5-fast as a non-reasoning 200K text model", () => {
 		const composer = seed.find(model => model.id === "grok-composer-2.5-fast");
 		expect(composer, "grok-composer-2.5-fast must be in the SuperGrok curated seed").toBeDefined();


### PR DESCRIPTION
Closes #4859

## What

Adds `grok-4.5` for paid `xai` and SuperGrok `xai-oauth` with the metadata the picker and boot path need (context, vision, reasoning-effort dial) — not just the model id.

## Why

Without curation, dynamic `/v1/models` still lacks context/reasoning/modality fields, so a new SKU lands with wrong limits and no effort dial. Grok 4.5 is the current flagship per xAI docs / models.dev.

## Changes

- SuperGrok curated entry: `grok-4.5` (500k, vision, reasoning) at the top of `XAI_OAUTH_CURATED_MODELS`
- Effort allowlist: `grok-4.5` in `isGrokReasoningEffortCapable`
- Defaults: `xai` and `xai-oauth` → `grok-4.5`
- Generator-identical `models.json` entries for those two providers only
- Regression pins (`xai-oauth-bundle`, `identity-family`, `xai-oauth-effort-strip`) + catalog CHANGELOG

## `models.json`

Same approach as #2173: edit the curated source, run `bun run gen:models`, commit **only** the generator-produced `xai` / `xai-oauth` blocks onto upstream `main`. A full regen also refreshes whatever else is logged into the local agent.db (Cursor, OpenRouter, …) — that noise was left out so this stays a surgical catalog PR, not a `chore: bump models`.

Net catalog delta: **+70 lines** (`grok-4.5` under each provider).

## Metadata

| Field | Value | Source |
|---|---|---|
| id | `grok-4.5` | [xAI docs](https://docs.x.ai/developers/models/grok-4.5), models.dev |
| context | 500k | same |
| input | text + image | same |
| effort dial | yes | same treatment as `grok-4.3` |
| paid cost | $2 / $6 / $0.50 cache per 1M | xAI docs |
| SuperGrok cost | zero | existing oauth contract |

## Verification

```sh
bun --cwd=packages/catalog test test/xai-oauth-bundle.test.ts test/identity-family.test.ts
bun --cwd=packages/ai test test/xai-oauth-effort-strip.test.ts

bun --cwd=packages/coding-agent src/cli.ts -p --no-session --no-tools \
  --model xai-oauth/grok-4.5 --thinking medium \
  'Reply with exactly one line: Grok45-OK'
```

> Implemented against live SuperGrok `xai-oauth/grok-4.5`.

## Out of scope

- Hard-coded `web_search` model (`grok-4.3`)
- `x_search` (#3341)
- Dynamic discovery redesign