### PR TITLE
fix(tui): stop slash Tab completion from opening files

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slash-command Tab completion opening file suggestions after completing a no-arg command such as `/settings` ([#4767](https://github.com/can1357/oh-my-pi/issues/4767)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -437,7 +437,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
 				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
-				if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
+				const commandAllowsArgs = command && (!("allowArgs" in command) || command.allowArgs !== false);
+				if (command && !commandAllowsArgs && argumentText.length === 0) {
+					return null;
+				}
+				if (commandAllowsArgs) {
 					if (!("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
 						return null; // No argument completion for this command
 					}

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -136,6 +136,23 @@ describe("CombinedAutocompleteProvider", () => {
 			}
 		});
 
+		it("does not fall through to file suggestions after a matched no-arg slash command with empty arguments", async () => {
+			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-settings-empty-args-"));
+			try {
+				fs.mkdirSync(path.join(baseDir, "alpha"));
+				const provider = new CombinedAutocompleteProvider(
+					[{ name: "settings", description: "Open settings", allowArgs: false }],
+					baseDir,
+				);
+				const line = "/settings ";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result).toBeNull();
+			} finally {
+				fs.rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
+
 		it("returns @ file-reference completions for matched slash commands that reject arguments", async () => {
 			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-settings-args-"));
 			try {


### PR DESCRIPTION
## Repro
Typing `/se` in the editor, waiting for slash-command autocomplete, and pressing Tab completed `/settings ` but then left autocomplete open with file-system directory suggestions. Reproduced with `bun test tmp/repro-4767.test.ts`, which failed because `editor.isShowingAutocomplete()` was `true` after the chained update.

## Cause
`Editor` chains a follow-up autocomplete refresh after accepting a slash-command name with Tab. `CombinedAutocompleteProvider.getSuggestions` in `packages/tui/src/autocomplete.ts` treated `/settings ` as a matched no-arg command with ordinary prompt text, fell through to file-path completion, and the empty trailing token listed the working directory.

## Fix
- Return `null` for matched `allowArgs: false` slash commands when the argument text is empty, preventing the post-accept refresh from becoming a root file completion.
- Preserve existing prompt-composer completions for explicit text after no-arg commands, including `/settings @` file-reference suggestions.
- Add regression coverage in `packages/tui/test/autocomplete.test.ts` for the empty-argument no-arg slash-command boundary.
- Add a `packages/tui` changelog entry.

## Verification
`bun test packages/tui/test/autocomplete.test.ts packages/tui/test/editor-autocomplete-actions.test.ts` passed: 71 tests, 149 assertions. `gh_push_branch` pre-publish gate also passed before pushing. Fixes #4767