### PR TITLE
feat(rpc): enable ask tool over plain --mode rpc

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -409,7 +409,12 @@ From `packages/agent/src/agent.ts` defaults:
 
 ## Extension UI Sub-Protocol
 
-Extensions in RPC mode use request/response UI frames.
+Extensions **and the built-in `ask` tool** in RPC mode use request/response UI
+frames. Over plain `--mode rpc` (no `rpc-ui` alias needed), `ask` routes its
+single-select through `select` and its free-text ("Other") answer through
+`editor`; multi-select is driven as repeated `select` frames (each pick toggles;
+the title carries `(N selected)` and a "Done" option). A host that renders these
+frames can answer `ask` prompts directly.
 
 ### Outbound request
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- The interactive `ask` tool now works over plain `--mode rpc`, so UI-capable headless hosts can answer `ask` prompts (single-select via `select`, "Other" free-text via `editor`, multi-select as repeated `select` frames) without launching `--mode rpc-ui`. A new `supportsUserPrompt` session capability — decoupled from `hasUI` — gates `ask` for RPC hosts without flipping UI-only startup paths (MCP discovery deferral, MCP status events, LSP warmup). `--print`/`--json` remain non-interactive; `rpc-ui` is retained as a working alias.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -966,6 +966,7 @@ interface RunRootCommandDependencies {
 	discoverAuthStorage?: typeof discoverAuthStorage;
 	selectSession?: typeof selectSession;
 	runAcpMode?: RunAcpMode;
+	runRpcMode?: RunRpcMode;
 	settings?: Settings;
 	forceSetupWizard?: boolean;
 }
@@ -1055,7 +1056,7 @@ export async function runRootCommand(
 	} else if (parsedArgs.mode === "acp") {
 		applyAcpDefaultSettingOverrides(settingsInstance);
 	}
-	if (parsedArgs.noPty || parsedArgs.mode === "rpc-ui") {
+	if (parsedArgs.noPty || parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {
 		Bun.env.PI_NO_PTY = "1";
 	}
 	if (parsedArgs.noTitle || parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui" || parsedArgs.mode === "acp") {
@@ -1249,6 +1250,7 @@ export async function runRootCommand(
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
 	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
+	sessionOptions.supportsUserPrompt = isInteractive || mode === "rpc" || mode === "rpc-ui";
 	sessionOptions.settings = settingsInstance;
 
 	// OTEL: register the global OTLP trace exporter when an OTLP endpoint is
@@ -1404,9 +1406,9 @@ export async function runRootCommand(
 
 		if (mode === "rpc" || mode === "rpc-ui") {
 			// Branch-only protocol runner: keep RPC host code out of normal interactive startup.
-			const runRpcMode: RunRpcMode = (await import("./modes/rpc/rpc-mode")).runRpcMode;
+			const runRpcMode: RunRpcMode = deps.runRpcMode ?? (await import("./modes/rpc/rpc-mode")).runRpcMode;
 			stopStartupWatchdog();
-			await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined, eventBus);
+			await runRpcMode(session, setToolUIContext, eventBus);
 		} else if (isInteractive) {
 			const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
 			const changelogMarkdown = await logger.time("main:getChangelogForDisplay", getChangelogForDisplay, parsedArgs);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -548,6 +548,11 @@ export interface CreateAgentSessionOptions {
 	/** Whether UI is available (enables interactive tools like ask). Default: false */
 	hasUI?: boolean;
 
+	/** Whether the session can surface an interactive user prompt (enables the `ask` tool).
+	 *  Separate from `hasUI` so RPC hosts get `ask` without also flipping UI-only startup
+	 *  paths (MCP discovery deferral, MCP status events, LSP warmup). Defaults to `hasUI`. */
+	supportsUserPrompt?: boolean;
+
 	/**
 	 * Opt-in OpenTelemetry instrumentation forwarded to the underlying Agent.
 	 * Passing `{}` enables the loop's GenAI-semantic-convention spans. See
@@ -1539,6 +1544,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			isToolActive: name => activeToolNames.has(name),
 			setActiveToolNames,
 			hasUI: options.hasUI ?? false,
+			supportsUserPrompt: options.supportsUserPrompt ?? options.hasUI ?? false,
 			enableLsp,
 			get hasEditTool() {
 				const requestedToolNames = options.toolNames ? normalizeToolNames(options.toolNames) : undefined;

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -712,7 +712,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 	}
 
 	static createIf(session: ToolSession): AskTool | null {
-		return session.hasUI ? new AskTool(session) : null;
+		return (session.supportsUserPrompt ?? session.hasUI) ? new AskTool(session) : null;
 	}
 
 	/** Send terminal notification when ask tool is waiting for input */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -158,6 +158,8 @@ export interface ToolSession {
 	cwd: string;
 	/** Whether UI is available */
 	hasUI: boolean;
+	/** Whether the session can surface an interactive user prompt (gates the `ask` tool). */
+	supportsUserPrompt?: boolean;
 	/**
 	 * Suppress the spawn specialization/coordination advisory appended to `task`
 	 * results. Set by internal/programmatic callers (e.g. the commit agent's

--- a/packages/coding-agent/test/rpc-ask-startup.test.ts
+++ b/packages/coding-agent/test/rpc-ask-startup.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { parseArgs } from "@oh-my-pi/pi-coding-agent/cli/args";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { runRootCommand } from "@oh-my-pi/pi-coding-agent/main";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const STOP = "stop after session options";
+
+/** Snapshot + restore the global PI_NO_PTY env mutation main.ts performs at startup. */
+async function withPreservedNoPty<T>(fn: () => Promise<T>): Promise<T> {
+	const saved = Bun.env.PI_NO_PTY;
+	try {
+		return await fn();
+	} finally {
+		if (saved === undefined) {
+			delete Bun.env.PI_NO_PTY;
+		} else {
+			Bun.env.PI_NO_PTY = saved;
+		}
+	}
+}
+
+/**
+ * Drive runRootCommand far enough to capture the CreateAgentSessionOptions, then
+ * abort by throwing the sentinel inside the injected createAgentSession (mirrors
+ * cli-max-time-flag.test.ts). Returns the options main.ts assembled for the mode.
+ */
+async function captureSessionOptions(argv: string[]): Promise<CreateAgentSessionOptions> {
+	using tempDir = TempDir.createSync("@omp-rpc-ask-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+	const parsed = parseArgs(argv);
+	parsed.noExtensions = true;
+	parsed.noSkills = true;
+	parsed.noRules = true;
+	parsed.noTools = true;
+	parsed.noLsp = true;
+	parsed.sessionDir = tempDir.path();
+
+	let observedOptions: CreateAgentSessionOptions | undefined;
+	try {
+		await runRootCommand(parsed, argv, {
+			discoverAuthStorage: async () => authStorage,
+			settings,
+			createAgentSession: async options => {
+				observedOptions = options;
+				throw new Error(STOP);
+			},
+		});
+	} catch (error) {
+		if (!(error instanceof Error) || error.message !== STOP) {
+			throw error;
+		}
+	} finally {
+		authStorage.close();
+	}
+
+	if (!observedOptions) {
+		throw new Error("createAgentSession was never reached");
+	}
+	return observedOptions;
+}
+
+describe("rpc ask startup wiring", () => {
+	it("marks plain --mode rpc as prompt-capable without flipping hasUI, and forces PI_NO_PTY", async () => {
+		await withPreservedNoPty(async () => {
+			const options = await captureSessionOptions(["--mode", "rpc"]);
+			expect(options.supportsUserPrompt).toBe(true);
+			expect(options.hasUI).toBe(false);
+			expect(Bun.env.PI_NO_PTY).toBe("1");
+		});
+	});
+
+	it("leaves --mode json non-prompt-capable", async () => {
+		await withPreservedNoPty(async () => {
+			const options = await captureSessionOptions(["--mode", "json", "hello"]);
+			expect(options.supportsUserPrompt).toBeFalsy();
+			expect(options.hasUI).toBeFalsy();
+		});
+	});
+
+	it("leaves --print non-prompt-capable", async () => {
+		await withPreservedNoPty(async () => {
+			const options = await captureSessionOptions(["--print", "hello"]);
+			expect(options.supportsUserPrompt).toBeFalsy();
+			expect(options.hasUI).toBeFalsy();
+		});
+	});
+
+	it("passes the real setToolUIContext into runRpcMode for plain --mode rpc", async () => {
+		await withPreservedNoPty(async () => {
+			using tempDir = TempDir.createSync("@omp-rpc-ask-seam-");
+			const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+			const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+			const parsed = parseArgs(["--mode", "rpc"]);
+			parsed.noExtensions = true;
+			parsed.noSkills = true;
+			parsed.noRules = true;
+			parsed.noTools = true;
+			parsed.noLsp = true;
+			parsed.sessionDir = tempDir.path();
+
+			// The exact setter instance createAgentSession hands back; the seam must
+			// forward THIS reference to runRpcMode (proving plain rpc no longer passes
+			// undefined). Only `.model` is read on the path to the rpc branch.
+			const sentinel = (() => {}) as unknown as (uiContext: never, hasUI: boolean) => void;
+			const fakeSession = { model: { provider: "test", id: "test" } };
+
+			let captured: ((uiContext: never, hasUI: boolean) => void) | undefined;
+			try {
+				await runRootCommand(parsed, ["--mode", "rpc"], {
+					discoverAuthStorage: async () => authStorage,
+					settings,
+					createAgentSession: async () =>
+						({
+							session: fakeSession,
+							setToolUIContext: sentinel,
+							modelFallbackMessage: undefined,
+							lspServers: undefined,
+							mcpManager: undefined,
+						}) as unknown as CreateAgentSessionResult,
+					// Capture the forwarded setter, then throw to abort the run. An
+					// always-throwing async body infers Promise<never>, matching the
+					// RunRpcMode signature (a normal return would type as Promise<void>).
+					runRpcMode: async (_session, setToolUIContext) => {
+						captured = setToolUIContext;
+						throw new Error(STOP);
+					},
+				});
+			} catch (error) {
+				if (!(error instanceof Error) || error.message !== STOP) {
+					throw error;
+				}
+			} finally {
+				authStorage.close();
+			}
+
+			expect(captured).toBe(sentinel);
+		});
+	});
+});

--- a/packages/coding-agent/test/tools/ask.test.ts
+++ b/packages/coding-agent/test/tools/ask.test.ts
@@ -1528,3 +1528,29 @@ describe("askToolRenderer malformed call args", () => {
 		expect(text).toContain("Proper");
 	});
 });
+
+describe("AskTool.createIf gating", () => {
+	const base: ToolSession = {
+		cwd: "/tmp/test",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+	};
+
+	it("registers ask when supportsUserPrompt is true", () => {
+		expect(AskTool.createIf({ ...base, supportsUserPrompt: true })).toBeInstanceOf(AskTool);
+	});
+
+	it("does not register ask when supportsUserPrompt is explicitly false even if hasUI is true", () => {
+		expect(AskTool.createIf({ ...base, supportsUserPrompt: false, hasUI: true })).toBeNull();
+	});
+
+	it("falls back to hasUI when supportsUserPrompt is unset (true)", () => {
+		expect(AskTool.createIf({ ...base, hasUI: true })).toBeInstanceOf(AskTool);
+	});
+
+	it("falls back to hasUI when supportsUserPrompt is unset (false)", () => {
+		expect(AskTool.createIf({ ...base, hasUI: false })).toBeNull();
+	});
+});


### PR DESCRIPTION
## What

Register the interactive `ask` tool for plain `—mode rpc` and route its select/editor dialogs through the existing RPC UI bridge, so UI-capable headless hosts (e.g. Paseo) answer `ask` prompts without the local wrapper that rewrote `rpc` -> `rpc-ui`.

- sdk.ts: add `CreateAgentSessionOptions.supportsUserPrompt`; set on `ToolSession` as `supportsUserPrompt ?? hasUI ?? false` (existing hasUI-only callers unchanged).
- tools/index.ts: add `ToolSession.supportsUserPrompt`.
- tools/ask.ts: gate `AskTool.createIf` on `supportsUserPrompt ?? hasUI` (explicit false wins; unset falls back to hasUI). Runtime execute guard unchanged. Multi-select keeps an explicit `Done` option after selection, so RPC hosts can submit without TUI right-arrow callbacks.
- main.ts: set `supportsUserPrompt` for rpc/rpc-ui/interactive (hasUI stays false for rpc); force `PI_NO_PTY=1` for rpc so bash stays on the non-PTY executor once a UI context exists; always pass `setToolUIContext` into `runRpcMode` (was undefined for plain rpc) via a `deps.runRpcMode` seam mirroring the existing `runAcpMode` seam.

`rpc-ui` stays a working alias; rpc-mode.ts is unchanged. `/plan` and `/collab` over RPC are out of scope.

## Why

`ask` was gated off for plain `rpc` at two points, and plain `rpc` never
installed the RPC UI bridge, so hosts needed a wrapper forcing `--mode rpc-ui`. Introduce a narrow `supportsUserPrompt` capability decoupled from `hasUI` so RPC hosts get `ask` without also flipping the UI-only startup paths `hasUI` drives (MCP discovery deferral, MCP status events, LSP warmup) — flipping `hasUI` for rpc would silently change MCP/LSP startup for every RPC host.

## Testing

- ask.test.ts "AskTool.createIf gating":
  - supportsUserPrompt:true -> registers
  - supportsUserPrompt:false + hasUI:true -> null (explicit false wins)
  - hasUI:true, unset supportsUserPrompt -> registers (back-compat)
  - hasUI:false -> null
- ask.test.ts multi-question regression:
  - RPC-like multi-select flow (no onRight callback) can finish via Done
- rpc-ask-startup.test.ts:
  - --mode rpc -> supportsUserPrompt:true, hasUI:false, PI_NO_PTY=1
  - --mode json / --print -> supportsUserPrompt and hasUI falsy
  - seam: plain rpc forwards the real setToolUIContext into runRpcMode
    (captured === injected setter; proves it is no longer undefined)
- Regression guard acp-lazy-startup.test.ts (5 pass): no MCP/LSP startup
  change for rpc.
- bun test: ask.test.ts 46 pass, rpc-ask-startup.test.ts 4 pass.
- bun test: ask.test.ts + rpc-ask-startup.test.ts 50 pass.
- Verified live in Paseo over plain `--mode rpc` (ask without the rpc-ui wrapper).

---

- [x] `bun check` passes (check:ts clean locally; check:rs runs in CI,
  TS-only change)
- [x] Tested locally (unit suites + live Paseo rpc)
- [x] CHANGELOG updated (user-facing; ### Added under [Unreleased])
