### PR TITLE
fix(tui): stop slash Tab completion from reopening file drawer

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slash command Tab completion reopening the file autocomplete drawer after accepting no-argument commands ([#4808](https://github.com/can1357/oh-my-pi/issues/4808)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -437,6 +437,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
 				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
+				if (command && "allowArgs" in command && command.allowArgs === false && argumentText === "") {
+					return null;
+				}
 				if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
 					if (!("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
 						return null; // No argument completion for this command

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -437,7 +437,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
 				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
-				if (command && "allowArgs" in command && command.allowArgs === false && argumentText === "") {
+				if (command && "allowArgs" in command && command.allowArgs === false && !/\S/.test(argumentText)) {
 					return null;
 				}
 				if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -119,6 +119,23 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result?.items.map(item => item.value)).toContain("/tmp/");
 		});
 
+		it("does not treat whitespace-only no-arg slash command arguments as file prefixes", async () => {
+			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-quit-whitespace-"));
+			try {
+				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
+				const provider = new CombinedAutocompleteProvider(
+					[{ name: "quit", description: "Quit", allowArgs: false }],
+					baseDir,
+				);
+				const line = "/quit  ";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result).toBeNull();
+			} finally {
+				fs.rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
+
 		it("treats @ file-reference tokens as literal text inside slash command arguments without completions", async () => {
 			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-rename-args-"));
 			try {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { CURSOR_MARKER } from "@oh-my-pi/pi-tui";
 import { CombinedAutocompleteProvider } from "@oh-my-pi/pi-tui/autocomplete";
@@ -395,6 +398,46 @@ describe("Editor component", () => {
 
 			expect(editor.getText()).toBe("/help ");
 			expect(editor.isShowingAutocomplete()).toBe(false);
+		});
+
+		it("does not open file autocomplete after tab-completing no-arg slash commands", async () => {
+			vi.useFakeTimers();
+			const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "slash-tab-no-arg-"));
+			try {
+				await Bun.write(path.join(baseDir, "visible-file.ts"), "export {};\n");
+				const editor = new Editor(defaultEditorTheme);
+				editor.setAutocompleteProvider(
+					new CombinedAutocompleteProvider([{ name: "quit", description: "Quit", allowArgs: false }], baseDir),
+				);
+
+				let nextUpdate = Promise.withResolvers<void>();
+				editor.onAutocompleteUpdate = () => nextUpdate.resolve();
+				editor.handleInput("/");
+				await nextUpdate.promise;
+
+				nextUpdate = Promise.withResolvers<void>();
+				editor.onAutocompleteUpdate = () => nextUpdate.resolve();
+				editor.handleInput("q");
+				vi.advanceTimersByTime(100);
+				await nextUpdate.promise;
+
+				const chainedUpdates = Promise.withResolvers<void>();
+				let updateCount = 0;
+				editor.onAutocompleteUpdate = () => {
+					updateCount += 1;
+					if (updateCount === 2) {
+						chainedUpdates.resolve();
+					}
+				};
+				editor.handleInput("	");
+				await chainedUpdates.promise;
+
+				expect(editor.getText()).toBe("/quit ");
+				expect(editor.isShowingAutocomplete()).toBe(false);
+			} finally {
+				vi.useRealTimers();
+				await fs.rm(baseDir, { recursive: true, force: true });
+			}
 		});
 	});
 


### PR DESCRIPTION
## Repro
Typing `/q` in the editor with a `quit` slash command (`allowArgs: false`), waiting for slash suggestions, then pressing Tab completes the text to `/quit ` but leaves `editor.isShowingAutocomplete()` true because the chained autocomplete opens file suggestions from the project root.

## Cause
`CombinedAutocompleteProvider.getSuggestions` in `packages/tui/src/autocomplete.ts` let matched no-argument slash commands with an empty argument (`/quit `) fall through to the generic prompt-composer completion paths. `#extractPathPrefix` treats a trailing-space empty token as an empty file prefix, so the chained autocomplete listed the base directory immediately after slash command acceptance.

## Fix
- Return `null` for matched `allowArgs: false` slash commands when the argument text is still empty, preventing the immediate empty-prefix file fallback.
- Preserve existing prompt-composer behavior for no-arg slash-looking text after the user types a real argument token, such as `/settings @`.
- Add an editor regression test that Tab-completes `/q` to `/quit ` with files present and asserts the autocomplete drawer is closed.
- Add the `packages/tui` changelog entry for #4808.

## Verification
Focused tests passed: `bun test packages/tui/test/editor.test.ts` (143 pass, 0 fail) and `bun test packages/tui/test/autocomplete.test.ts` (50 pass, 0 fail). Pre-publish gate also passed via `gh_push_branch` before publishing. Fixes #4808