### PR TITLE
fix(tools): accept empty read and grep selectors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `read` and `grep` treating empty optional `selector` fields emitted by models as invalid selectors instead of behaving like omitted selectors. ([#4879](https://github.com/can1357/oh-my-pi/issues/4879))
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -158,11 +158,11 @@ async function parsePathSpecs(
 	cwd: string,
 	explicitSelector?: string,
 ): Promise<GrepPathSpec[]> {
-	const explicitRanges =
-		explicitSelector === undefined || explicitSelector.length === 0 ? undefined : parseLineRanges(explicitSelector);
-	if (explicitSelector !== undefined && !explicitRanges) {
+	const normalizedSelector = explicitSelector?.trim() || undefined;
+	const explicitRanges = normalizedSelector === undefined ? undefined : parseLineRanges(normalizedSelector);
+	if (normalizedSelector !== undefined && !explicitRanges) {
 		throw new ToolError(
-			`selector "${explicitSelector}" is invalid — use line ranges like "50-100", "50+10", or "50-100,200-300" without a leading colon`,
+			`selector "${normalizedSelector}" is invalid — use line ranges like "50-100", "50+10", or "50-100,200-300" without a leading colon`,
 		);
 	}
 	const specs: GrepPathSpec[] = [];

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2118,13 +2118,10 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		_toolContext?: AgentToolContext,
 	): Promise<AgentToolResult<ReadToolDetails>> {
 		let { path: readPath } = params;
-		let explicitSelector = params.selector?.trim();
+		let explicitSelector = params.selector?.trim() || undefined;
 		let explicitParsedSelector = explicitSelector === undefined ? undefined : parseSel(explicitSelector);
-		if (
-			params.selector !== undefined &&
-			(explicitSelector === undefined || explicitSelector.length === 0 || explicitParsedSelector?.kind === "none")
-		) {
-			throw invalidSelector(params.selector);
+		if (explicitSelector !== undefined && explicitParsedSelector?.kind === "none") {
+			throw invalidSelector(explicitSelector);
 		}
 		if (readPath.startsWith("file://")) {
 			readPath = expandPath(readPath);

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -330,6 +330,34 @@ describe("Coding Agent Tools", () => {
 			expect(result.details?.truncation).toBeUndefined();
 		});
 
+		it("treats empty optional selector as omitted for read", async () => {
+			const testFile = path.join(testDir, "read-empty-selector.txt");
+			const content = "alpha\nselector target\nomega";
+			fs.writeFileSync(testFile, content);
+
+			const omitted = getTextOutput(await readTool.execute("test-read-empty-selector-omitted", { path: testFile }));
+			expect(omitted).toContain("alpha");
+			expect(omitted).toContain("selector target");
+			expect(omitted).toContain("omega");
+
+			for (const { name, selector } of [
+				{ name: "empty", selector: "" },
+				{ name: "whitespace", selector: " \t\n " },
+			]) {
+				const withOptionalSelector = getTextOutput(
+					await readTool.execute(`test-read-empty-selector-${name}`, {
+						path: testFile,
+						selector,
+					}),
+				);
+				expect(withOptionalSelector).toBe(omitted);
+			}
+
+			await expect(
+				readTool.execute("test-read-empty-selector-malformed", { path: testFile, selector: "-100" }),
+			).rejects.toThrow(/Invalid selector/);
+		});
+
 		it("truncates lines wider than the read column cap, leaving narrow lines untouched", async () => {
 			const wideLine = "x".repeat(1500);
 			const testFile = path.join(testDir, "wide.txt");
@@ -1647,6 +1675,42 @@ function b() {
 			expect(output).not.toContain("# example.txt");
 			// PI_EDIT_VARIANT=replace in beforeEach disables hashlines; expect line-number mode
 			expect(output).toMatch(/\*2\|match line/);
+		});
+
+		it("treats empty optional selector as omitted for search", async () => {
+			const testFile = path.join(testDir, "grep-empty-selector.txt");
+			fs.writeFileSync(testFile, "before\nneedle empty selector\nbetween\nneedle whitespace selector\nafter");
+
+			const omitted = getTextOutput(
+				await searchTool.execute("test-search-empty-selector-omitted", {
+					pattern: "needle",
+					path: testFile,
+				}),
+			);
+			expect(omitted).toMatch(/\*2\|needle empty selector/);
+			expect(omitted).toMatch(/\*4\|needle whitespace selector/);
+
+			for (const { name, selector } of [
+				{ name: "empty", selector: "" },
+				{ name: "whitespace", selector: " \t\n " },
+			]) {
+				const withOptionalSelector = getTextOutput(
+					await searchTool.execute(`test-search-empty-selector-${name}`, {
+						pattern: "needle",
+						path: testFile,
+						selector,
+					}),
+				);
+				expect(withOptionalSelector).toBe(omitted);
+			}
+
+			await expect(
+				searchTool.execute("test-search-empty-selector-malformed", {
+					pattern: "needle",
+					path: testFile,
+					selector: "not-a-range",
+				}),
+			).rejects.toThrow(/selector "not-a-range" is invalid/);
 		});
 
 		it("flags a zero-match search as contextually useless", async () => {


### PR DESCRIPTION
## Repro
`bun test packages/coding-agent/test/tools.test.ts --test-name-pattern "empty optional selector"` reproduced the regression before the fix: `read` failed with `Invalid selector ':'` and `grep` failed with `selector "" is invalid` when the optional `selector` field was present as an empty string.

## Cause
`packages/coding-agent/src/tools/read.ts` trimmed `params.selector` but still treated any present empty string as invalid, while `packages/coding-agent/src/tools/grep.ts` parsed an empty explicit selector to no ranges and then rejected it because the field was present. Whitespace-only selectors followed the same path after trimming.

## Fix
- Normalize empty and whitespace-only `read` selector parameters to omitted before read selector validation.
- Normalize empty and whitespace-only `grep` selector parameters to omitted before line-range parsing.
- Add focused read/grep regression tests that compare empty and whitespace-only selectors against omitted selectors while preserving malformed non-empty selector rejection.
- Add the coding-agent changelog entry for #4879.

## Verification
`bun test packages/coding-agent/test/tools.test.ts --test-name-pattern "empty optional selector"` passed with 2 tests, 11 assertions. `bun test packages/coding-agent/test/tools.test.ts` passed with 107 tests, 1 skip, 340 assertions. `bun check` passed before publishing, and the publish gate also ran successfully. Fixes #4879