### PR TITLE
fix(tui): replay detected terminal appearance

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed late terminal appearance subscribers missing the already-detected OSC 11 light/dark result, so restored sessions can apply the current terminal theme immediately ([#4731](https://github.com/can1357/oh-my-pi/issues/4731)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -516,6 +516,13 @@ export class ProcessTerminal implements Terminal {
 
 	onAppearanceChange(callback: (appearance: TerminalAppearance) => void): void {
 		this.#appearanceCallbacks.push(callback);
+		if (this.#appearance) {
+			try {
+				callback(this.#appearance);
+			} catch {
+				/* ignore callback errors */
+			}
+		}
 	}
 
 	onPrivateModeReport(callback: (mode: number, supported: boolean) => void): void {

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -144,6 +144,21 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		terminal.stop();
 	});
 
+	it("replays already detected OSC 11 appearance to late subscribers", () => {
+		const { terminal } = setupTerminal();
+
+		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
+		process.stdin.emit("data", "\x1b[?1;2c");
+
+		const appearances: string[] = [];
+		terminal.onAppearanceChange(a => appearances.push(a));
+
+		expect(terminal.appearance).toBe("light");
+		expect(appearances).toEqual(["light"]);
+
+		terminal.stop();
+	});
+
 	it("2-digit hex OSC 11 response is correctly normalized", () => {
 		const { terminal } = setupTerminal();
 


### PR DESCRIPTION
## Repro
Starting `ProcessTerminal`, receiving an OSC 11 light-background response, and only then registering `onAppearanceChange` leaves the terminal state at `light` while the late subscriber receives no event: `{"terminalAppearance":"light","lateSubscriberEvents":[]}`. This matches `omp -c` session restore when Ghostty has already switched to a light auto theme before `InteractiveMode` wires the theme subscriber.

## Cause
`packages/tui/src/terminal.ts` stored the parsed OSC 11 result in `ProcessTerminal.#appearance`, but `ProcessTerminal.onAppearanceChange()` only appended callbacks for future changes. `packages/coding-agent/src/modes/interactive-mode.ts` registers that callback after `ui.start()`, so a fast startup OSC 11 response could be detected before the coding-agent theme bridge existed, leaving `initTheme()`'s pre-probe dark choice active until a later appearance notification.

## Fix
- Replay the cached `ProcessTerminal.#appearance` to newly registered `onAppearanceChange()` subscribers while preserving callback-error isolation.
- Added a regression test covering late subscription after an OSC 11 light response.
- Added an `[Unreleased]` changelog entry for `packages/tui`.

## Verification
`bun test packages/tui/test/terminal-appearance.test.ts` passed: 35 tests, 0 failures. `bun test packages/coding-agent/test/theme-auto-detection.test.ts` passed: 5 tests, 0 failures. A JS repro check now returns `{"terminalAppearance":"light","lateSubscriberEvents":["light"]}`. `gh_push_branch` completed its pre-publish gate before pushing. Fixes #4731