### PR TITLE
feat: add Grok 4.5 xAI support and OAuth refresh

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Grok 4.5 to the xai and xai-oauth (SuperGrok) catalogs; grok-4.5 is now the xai-oauth default model.
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -78,7 +78,7 @@ export const isMimoModelIdOrName = memo((value: string): boolean => {
 	return value.toLowerCase().includes("mimo");
 });
 
-const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3"] as const;
+const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3", "grok-4.5"] as const;
 
 /**
  * Grok SKUs that expose the wire `reasoning.effort` dial. Other Grok reasoners

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -4972,7 +4972,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -14269,7 +14269,7 @@
 			"cost": {
 				"input": 0.55,
 				"output": 1.65,
-				"cacheRead": 0,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 161000,
@@ -14286,13 +14286,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14322,13 +14322,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.74,
+				"output": 3.48,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 393216,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14349,7 +14349,7 @@
 		},
 		"google/gemma-4-31B-it": {
 			"id": "google/gemma-4-31B-it",
-			"name": "Gemma 4 31B Instruct",
+			"name": "Gemma 4 31B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14359,13 +14359,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.12,
+				"output": 0.35,
+				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14388,9 +14388,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.05,
+				"output": 0.1,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14398,7 +14398,7 @@
 		},
 		"JetBrains/Mellum2-12B-A2.5B-Instruct": {
 			"id": "JetBrains/Mellum2-12B-A2.5B-Instruct",
-			"name": "JetBrains/Mellum2-12B-A2.5B-Instruct",
+			"name": "Mellum2 12B A2.5B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14407,13 +14407,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.05,
+				"output": 0.1,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"meta-llama/Llama-3.1-70B-Instruct": {
 			"id": "meta-llama/Llama-3.1-70B-Instruct",
@@ -14428,7 +14428,7 @@
 			"cost": {
 				"input": 0.8,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.8,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14436,7 +14436,7 @@
 		},
 		"meta-llama/Llama-3.1-8B-Instruct": {
 			"id": "meta-llama/Llama-3.1-8B-Instruct",
-			"name": "Meta-Llama-3.1-8B-Instruct",
+			"name": "Llama 3.1 8B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14447,7 +14447,7 @@
 			"cost": {
 				"input": 0.22,
 				"output": 0.22,
-				"cacheRead": 0,
+				"cacheRead": 0.22,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14455,7 +14455,7 @@
 		},
 		"meta-llama/Llama-3.3-70B-Instruct": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct",
-			"name": "Llama-3.3-70B-Instruct",
+			"name": "Llama 3.3 70B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14466,7 +14466,7 @@
 			"cost": {
 				"input": 0.71,
 				"output": 0.71,
-				"cacheRead": 0,
+				"cacheRead": 0.71,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14494,7 +14494,7 @@
 		},
 		"microsoft/Phi-4-mini-instruct": {
 			"id": "microsoft/Phi-4-mini-instruct",
-			"name": "Phi-4-mini-instruct",
+			"name": "Phi 4 Mini 3.8B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14505,7 +14505,7 @@
 			"cost": {
 				"input": 0.08,
 				"output": 0.35,
-				"cacheRead": 0,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14524,7 +14524,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1.2,
-				"cacheRead": 0,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -14551,9 +14551,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 2.85,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 3,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14571,7 +14571,7 @@
 		},
 		"moonshotai/Kimi-K2.6": {
 			"id": "moonshotai/Kimi-K2.6",
-			"name": "Kimi-K2.6",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14581,9 +14581,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14611,9 +14611,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.94,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14631,7 +14631,7 @@
 		},
 		"nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-			"name": "NVIDIA Nemotron 3 Super 120B",
+			"name": "Nemotron 3 Super",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14642,7 +14642,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14660,22 +14660,32 @@
 		},
 		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
-			"name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+			"name": "Nemotron 3 Ultra",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 2.75,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -14688,9 +14698,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
-				"cacheRead": 0,
+				"input": 0.04,
+				"output": 0.14,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14715,9 +14725,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.2,
-				"cacheRead": 0,
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14733,7 +14743,7 @@
 		},
 		"OpenPipe/Qwen3-14B-Instruct": {
 			"id": "OpenPipe/Qwen3-14B-Instruct",
-			"name": "OpenPipe Qwen3 14B Instruct",
+			"name": "Qwen3 14B Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14744,7 +14754,7 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.22,
-				"cacheRead": 0,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
@@ -14752,7 +14762,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B Instruct 2507",
+			"name": "Qwen3 235B A22B-2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14763,7 +14773,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14771,7 +14781,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3-235B-A22B-Thinking-2507",
+			"name": "Qwen3 235B A22B Thinking-2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14782,7 +14792,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14811,7 +14821,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.3,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14819,7 +14829,7 @@
 		},
 		"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
 			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-			"name": "Qwen3-Coder-480B-A35B-Instruct",
+			"name": "Qwen3 Coder 480B A35B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14830,7 +14840,7 @@
 			"cost": {
 				"input": 1,
 				"output": 1.5,
-				"cacheRead": 0,
+				"cacheRead": 1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14838,7 +14848,7 @@
 		},
 		"Qwen/Qwen3.5-27B": {
 			"id": "Qwen/Qwen3.5-27B",
-			"name": "Qwen3.5 27B",
+			"name": "Qwen3.5-27B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14848,13 +14858,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.39,
+				"output": 3.12,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14867,7 +14877,7 @@
 		},
 		"Qwen/Qwen3.5-35B-A3B": {
 			"id": "Qwen/Qwen3.5-35B-A3B",
-			"name": "Qwen3.5 35B-A3B",
+			"name": "Qwen3.5-35B-A3B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14877,13 +14887,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 1.25,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14906,13 +14916,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 3.6,
+				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14925,7 +14935,7 @@
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
-			"name": "Qwen3.6 35B-A3B",
+			"name": "Qwen3.6 35B A3B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14935,13 +14945,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 1.25,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14973,7 +14983,7 @@
 		},
 		"zai-org/GLM-5.1": {
 			"id": "zai-org/GLM-5.1",
-			"name": "GLM-5.1",
+			"name": "GLM 5.1",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14987,8 +14997,8 @@
 				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
-			"maxTokens": 131072,
+			"contextWindow": 202752,
+			"maxTokens": 202752,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -15002,7 +15012,7 @@
 		},
 		"zai-org/GLM-5.2": {
 			"id": "zai-org/GLM-5.2",
-			"name": "GLM-5.2",
+			"name": "GLM 5.2",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -15011,13 +15021,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.39,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 164000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -16764,26 +16774,6 @@
 			},
 			"requestModelId": "MODEL_GOOGLE_GEMINI_3_0_FLASH_MINIMAL"
 		},
-		"glm-5-1": {
-			"id": "glm-5-1",
-			"name": "GLM-5.1",
-			"api": "devin-agent",
-			"provider": "devin",
-			"baseUrl": "https://server.codeium.com",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"supportsTools": true,
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
 		"glm-5-2": {
 			"id": "glm-5-2",
 			"name": "GLM-5.2 High",
@@ -17453,6 +17443,46 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"swe-1-7": {
+			"id": "swe-1-7",
+			"name": "SWE-1.7",
+			"api": "devin-agent",
+			"provider": "devin",
+			"baseUrl": "https://server.codeium.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"supportsTools": true,
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262000,
+			"maxTokens": 64000
+		},
+		"swe-1-7-lightning": {
+			"id": "swe-1-7-lightning",
+			"name": "SWE-1.7 Lightning",
+			"api": "devin-agent",
+			"provider": "devin",
+			"baseUrl": "https://server.codeium.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"supportsTools": true,
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
 			"maxTokens": 64000
 		}
 	},
@@ -23447,6 +23477,33 @@
 				]
 			}
 		},
+		"openai/gpt-oss-20b": {
+			"id": "openai/gpt-oss-20b",
+			"name": "GPT OSS 20B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"Qwen/Qwen3-235B-A22B": {
 			"id": "Qwen/Qwen3-235B-A22B",
 			"name": "Qwen3 235B-A22B",
@@ -24526,6 +24583,44 @@
 		"aion-labs/aion-2.0": {
 			"id": "aion-labs/aion-2.0",
 			"name": "Aion-2.0",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"aion-labs/aion-3.0": {
+			"id": "aion-labs/aion-3.0",
+			"name": "Aion-3.0",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"aion-labs/aion-3.0-mini": {
+			"id": "aion-labs/aion-3.0-mini",
+			"name": "Aion-3.0-Mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28532,7 +28627,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28542,13 +28637,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
-			"maxTokens": 128000,
+			"contextWindow": 1048576,
+			"maxTokens": 512000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -29470,6 +29565,25 @@
 			"contextWindow": 131072,
 			"maxTokens": 163840
 		},
+		"nex-agi/nex-n2-mini": {
+			"id": "nex-agi/nex-n2-mini",
+			"name": "Nex-N2-Mini",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144
+		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
 			"name": "Nex-N2-Pro",
@@ -29486,8 +29600,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -29505,8 +29619,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
@@ -33859,6 +33973,25 @@
 			"contextWindow": null,
 			"maxTokens": null
 		},
+		"tencent/hy3": {
+			"id": "tencent/hy3",
+			"name": "Hy3",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": null
+		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
 			"name": "Hy3 Preview",
@@ -33906,6 +34039,25 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 64000
+		},
+		"tencent/hy3:free": {
+			"id": "tencent/hy3:free",
+			"name": "Hy3 (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": null
 		},
 		"thedrummer/cydonia-24b-v4.1": {
 			"id": "thedrummer/cydonia-24b-v4.1",
@@ -46633,8 +46785,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -48807,7 +48959,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B Instruct 2507",
+			"name": "Qwen3 235B A22B-2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -48864,7 +49016,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3-235B-A22B-Thinking-2507",
+			"name": "Qwen3 235B A22B Thinking-2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49250,7 +49402,7 @@
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
-			"name": "Qwen3.6 35B-A3B",
+			"name": "Qwen3.6 35B A3B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -62311,6 +62463,36 @@
 			},
 			"contextPromotionTarget": "opencode-zen/gpt-5.4"
 		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"grok-build-0.1": {
 			"id": "grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -62330,6 +62512,35 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"hy3-free": {
+			"id": "hy3-free",
+			"name": "Hy3 Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63214,7 +63425,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.66,
+				"input": 0.65,
 				"output": 3.41,
 				"cacheRead": 0.14,
 				"cacheWrite": 0
@@ -63289,6 +63500,35 @@
 				]
 			}
 		},
+		"~x-ai/grok-latest": {
+			"id": "~x-ai/grok-latest",
+			"name": "Grok Latest",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"ai21/jamba-large-1.7": {
 			"id": "ai21/jamba-large-1.7",
 			"name": "Jamba Large 1.7",
@@ -63307,6 +63547,90 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 4096
+		},
+		"aion-labs/aion-2.0": {
+			"id": "aion-labs/aion-2.0",
+			"name": "Aion-2.0",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7999999999999999,
+				"output": 1.5999999999999999,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"aion-labs/aion-3.0": {
+			"id": "aion-labs/aion-3.0",
+			"name": "Aion-3.0",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 3,
+				"output": 6,
+				"cacheRead": 0.75,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"aion-labs/aion-3.0-mini": {
+			"id": "aion-labs/aion-3.0-mini",
+			"name": "Aion-3.0-Mini",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7,
+				"output": 1.4,
+				"cacheRead": 0.18,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"alibaba/tongyi-deepresearch-30b-a3b": {
 			"id": "alibaba/tongyi-deepresearch-30b-a3b",
@@ -64846,7 +65170,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -66224,7 +66548,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -66875,7 +67199,7 @@
 			"cost": {
 				"input": 0.375,
 				"output": 2.025,
-				"cacheRead": 0.09,
+				"cacheRead": 0.203,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -66902,7 +67226,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.66,
+				"input": 0.65,
 				"output": 3.41,
 				"cacheRead": 0.14,
 				"cacheWrite": 0
@@ -66995,6 +67319,64 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 163840
+		},
+		"nex-agi/nex-n2-mini": {
+			"id": "nex-agi/nex-n2-mini",
+			"name": "Nex-N2-Mini",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.024999999999999998,
+				"output": 0.09999999999999999,
+				"cacheRead": 0.0025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"nex-agi/nex-n2-pro": {
+			"id": "nex-agi/nex-n2-pro",
+			"name": "Nex-N2-Pro",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.024999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -70301,7 +70683,7 @@
 			"cost": {
 				"input": 0.385,
 				"output": 2.4499999999999997,
-				"cacheRead": 0.195,
+				"cacheRead": 0.111,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -70938,6 +71320,34 @@
 				"supportsToolChoice": false
 			}
 		},
+		"tencent/hy3": {
+			"id": "tencent/hy3",
+			"name": "Hy3",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0.035,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
 			"name": "Hy3 Preview",
@@ -70969,6 +71379,34 @@
 		"tencent/hy3-preview:free": {
 			"id": "tencent/hy3-preview:free",
 			"name": "Hy3 preview (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"tencent/hy3:free": {
+			"id": "tencent/hy3:free",
+			"name": "Hy3 (free)",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -71418,6 +71856,35 @@
 				]
 			}
 		},
+		"x-ai/grok-4.5": {
+			"id": "x-ai/grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -71571,7 +72038,7 @@
 			"cost": {
 				"input": 0.105,
 				"output": 0.28,
-				"cacheRead": 0.0028,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -71971,9 +72438,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.9086,
-				"output": 2.8556,
-				"cacheRead": 0.16874,
+				"input": 0.84,
+				"output": 2.64,
+				"cacheRead": 0.156,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -73401,38 +73868,6 @@
 				"escapeBuiltinToolNames": true
 			}
 		},
-		"umans-glm-5.2-nvfp4": {
-			"id": "umans-glm-5.2-nvfp4",
-			"name": "Umans GLM 5.2 NVFP4 (experimental, short test from Jun 29)",
-			"api": "anthropic-messages",
-			"provider": "umans",
-			"baseUrl": "https://api.code.umans.ai",
-			"reasoning": true,
-			"thinking": {
-				"mode": "anthropic-budget-effort",
-				"efforts": [
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"xhigh": "max"
-				}
-			},
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 405504,
-			"maxTokens": 131071,
-			"compat": {
-				"escapeBuiltinToolNames": true
-			}
-		},
 		"umans-kimi-k2.7": {
 			"id": "umans-kimi-k2.7",
 			"name": "Umans Kimi K2.7 Code",
@@ -73522,6 +73957,64 @@
 			"maxTokens": null,
 			"compat": {
 				"supportsUsageInStreaming": false
+			}
+		},
+		"aion-labs-aion-3-0": {
+			"id": "aion-labs-aion-3-0",
+			"name": "Aion 3.0",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 3.75,
+				"output": 7.5,
+				"cacheRead": 0.9375,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"aion-labs-aion-3-0-mini": {
+			"id": "aion-labs-aion-3-0-mini",
+			"name": "Aion 3.0 Mini",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.875,
+				"output": 1.75,
+				"cacheRead": 0.225,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"aion-labs.aion-2-0": {
@@ -74080,6 +74573,28 @@
 				}
 			}
 		},
+		"e2ee-deepseek-v4-flash": {
+			"id": "e2ee-deepseek-v4-flash",
+			"name": "e2ee-deepseek-v4-flash",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1048576,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-gemma-3-27b-p": {
 			"id": "e2ee-gemma-3-27b-p",
 			"name": "e2ee-gemma-3-27b-p",
@@ -74362,6 +74877,28 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": null,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-qwen3-6-27b": {
+			"id": "e2ee-qwen3-6-27b",
+			"name": "e2ee-qwen3-6-27b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 65536,
 			"compat": {
 				"supportsUsageInStreaming": false
 			}
@@ -74833,6 +75370,36 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"grok-4-5": {
+			"id": "grok-4-5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.27,
+				"output": 6.8,
+				"cacheRead": 0.57,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
 			"maxTokens": 32000,
 			"thinking": {
 				"mode": "effort",
@@ -79099,7 +79666,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -81557,6 +82124,36 @@
 				]
 			}
 		},
+		"xai/grok-4.5": {
+			"id": "xai/grok-4.5",
+			"name": "Grok 4.5",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"xai/grok-build-0.1": {
 			"id": "xai/grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -83094,6 +83691,35 @@
 				]
 			}
 		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"grok-beta": {
 			"id": "grok-beta",
 			"name": "Grok Beta",
@@ -83308,6 +83934,47 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			}
+		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-responses",
+			"provider": "xai-oauth",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86308,6 +86975,25 @@
 				]
 			}
 		},
+		"kuaishou/kat-coder-air-v2.5": {
+			"id": "kuaishou/kat-coder-air-v2.5",
+			"name": "KAT-Coder-Air-V2.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.135,
+				"output": 0.54,
+				"cacheRead": 0.027,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": null
+		},
 		"kuaishou/kat-coder-pro-v1": {
 			"id": "kuaishou/kat-coder-pro-v1",
 			"name": "KAT-Coder-Pro-V1",
@@ -86364,6 +87050,25 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000
+		},
+		"kuaishou/kat-coder-pro-v2.5": {
+			"id": "kuaishou/kat-coder-pro-v2.5",
+			"name": "KAT-Coder-Pro-V2.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.444,
+				"output": 1.776,
+				"cacheRead": 0.09,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": null
 		},
 		"meituan/longcat-2.0": {
 			"id": "meituan/longcat-2.0",
@@ -88482,9 +89187,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.134561595,
-				"output": 0.539161765,
-				"cacheRead": 0.033869245,
+				"input": 0.1323,
+				"output": 0.5301,
+				"cacheRead": 0.0333,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -88927,6 +89632,66 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"x-ai/grok-4.5": {
+			"id": "x-ai/grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"x-ai/grok-4.5-free": {
+			"id": "x-ai/grok-4.5-free",
+			"name": "Grok 4.5 (Free)",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -414,7 +414,7 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "xai-oauth",
-		defaultModel: "grok-4.3",
+		defaultModel: "grok-4.5",
 		envVars: ["XAI_OAUTH_TOKEN", "XAI_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => xaiOAuthModelManagerOptions(config),
 		catalogDiscovery: {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -968,6 +968,11 @@ interface XAICuratedModel {
 // omit/include/history replay defaults live in catalog compat so every
 // OpenAI-family endpoint consumes the same constraint.
 export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
+	// xAI's flagship (docs.x.ai/developers/models/grok-4.5): 500K context,
+	// text+image, reasoning with the wire effort dial (low/medium/high;
+	// rejects "none", unlike grok-4.3 — verified live 2026-07-08, matches
+	// models.dev). Aliases: grok-4.5-latest, grok-build-latest.
+	{ id: "grok-4.5", contextWindow: 500_000, name: "Grok 4.5", input: ["text", "image"] },
 	{
 		id: "grok-build",
 		contextWindow: 512_000,

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -171,6 +171,10 @@ describe("xAI-OAuth Responses reasoning-effort suppression", () => {
 		expect(buildOpenAIResponsesCompat(grokResponsesSpec("grok-4.3")).supportsReasoningEffort).toBe(true);
 	});
 
+	it("keeps the effort dial for a custom grok-4.5 spec (on the allowlist)", () => {
+		expect(buildOpenAIResponsesCompat(grokResponsesSpec("grok-4.5")).supportsReasoningEffort).toBe(true);
+	});
+
 	it("lets an explicit compat.supportsReasoningEffort override the allowlist default", () => {
 		const compat = buildOpenAIResponsesCompat({
 			...grokResponsesSpec("grok-build"),

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -264,7 +264,10 @@ describe("isGrokReasoningEffortCapable", () => {
 		expect(isGrokReasoningEffortCapable("grok-4.3")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-3-mini")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-4.20-multi-agent")).toBe(true);
+		expect(isGrokReasoningEffortCapable("grok-4.5")).toBe(true);
+		expect(isGrokReasoningEffortCapable("grok-4.5-latest")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.3")).toBe(true);
+		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.5")).toBe(true);
 		expect(isGrokReasoningEffortCapable("openrouter/xai/grok-3-mini")).toBe(true);
 	});
 

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -63,6 +63,15 @@ describe("xai-oauth bundled catalog (regression)", () => {
 		expect(bundled["grok-composer-2.5-fast"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 	});
 
+	it("exposes grok-4.5 as a reasoning 500K text+image model", () => {
+		const grok45 = seed.find(model => model.id === "grok-4.5");
+		expect(grok45, "grok-4.5 must be in the SuperGrok curated seed").toBeDefined();
+		expect(grok45!.reasoning).toBe(true);
+		expect(grok45!.contextWindow).toBe(500_000);
+		expect(grok45!.input).toEqual(["text", "image"]);
+		expect(bundled["grok-4.5"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
+
 	// The OAuth surface's /v1/models reports no per-request output limit, so the
 	// curated catalog owns maxTokens — set to mirror each model's contextWindow
 	// (the openai-responses wire still clamps the actual request to

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- xAI web search now uses `grok-4.5` instead of `grok-4.3`.
+
+### Fixed
+
+- Built-in provider model discovery now refreshes expired OAuth tokens instead of silently skipping the provider.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1560,7 +1560,9 @@ export class ModelRegistry {
 	): Promise<BuiltInDiscoveryResult> {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(p => p.provider));
-		const managerOptions = (await this.#collectBuiltInModelManagerOptions()).filter(opts => {
+		const managerOptions = (
+			await this.#collectBuiltInModelManagerOptions(strategy, configuredDiscoveryProviders, providerFilter)
+		).filter(opts => {
 			if (configuredDiscoveryProviders.has(opts.providerId)) {
 				return false;
 			}
@@ -1583,7 +1585,11 @@ export class ModelRegistry {
 		return { models, authoritativeProviders };
 	}
 
-	async #collectBuiltInModelManagerOptions(): Promise<ModelManagerOptions<Api>[]> {
+	async #collectBuiltInModelManagerOptions(
+		strategy: ModelRefreshStrategy,
+		configuredDiscoveryProviders?: ReadonlySet<string>,
+		providerFilter?: ReadonlySet<string>,
+	): Promise<ModelManagerOptions<Api>[]> {
 		const specialProviderDescriptors: Array<{
 			providerId: string;
 			resolveKey: (value: string | undefined) => string | undefined;
@@ -1622,16 +1628,52 @@ export class ModelRegistry {
 			},
 		];
 		const disabledProviders = getDisabledProviderIdsFromSettings();
-		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId),
-		);
-		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId),
-		);
-		// Use peekApiKey to avoid OAuth token refresh during discovery.
-		// The token is only needed if the dynamic fetch fires (cache miss),
-		// and failures there are handled gracefully.
-		const peekKey = (descriptor: { providerId: string }) => this.#peekApiKeyForProvider(descriptor.providerId);
+		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(descriptor => {
+			if (disabledProviders.has(descriptor.providerId)) {
+				return false;
+			}
+			if (configuredDiscoveryProviders?.has(descriptor.providerId)) {
+				return false;
+			}
+			if (providerFilter && !providerFilter.has(descriptor.providerId)) {
+				return false;
+			}
+			return true;
+		});
+		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(descriptor => {
+			if (disabledProviders.has(descriptor.providerId)) {
+				return false;
+			}
+			if (configuredDiscoveryProviders?.has(descriptor.providerId)) {
+				return false;
+			}
+			if (providerFilter && !providerFilter.has(descriptor.providerId)) {
+				return false;
+			}
+			return true;
+		});
+		// Peek first to avoid OAuth refresh churn during discovery. When peek
+		// fails but a stored OAuth credential exists, the access token has
+		// expired: refresh once through getApiKeyForProvider (persists the
+		// rotated credential), then re-peek so provider-specific peek shapes
+		// (e.g. github-copilot's JSON envelope with enterpriseUrl/apiEndpoint)
+		// are preserved — getApiKey returns the bare token, peek re-wraps it.
+		const peekKey = async (descriptor: { providerId: string }): Promise<string | undefined> => {
+			const peeked = await this.#peekApiKeyForProvider(descriptor.providerId);
+			if (strategy === "offline" || isAuthenticated(peeked) || !this.authStorage.hasOAuth(descriptor.providerId)) {
+				return peeked;
+			}
+			let refreshed: string | undefined;
+			try {
+				refreshed = await this.getApiKeyForProvider(descriptor.providerId);
+			} catch {
+				return peeked;
+			}
+			if (!isAuthenticated(refreshed)) {
+				return peeked;
+			}
+			return this.#peekApiKeyForProvider(descriptor.providerId);
+		};
 		const [standardProviderKeys, specialKeys] = await Promise.all([
 			Promise.all(standardProviderDescriptors.map(peekKey)),
 			Promise.all(enabledSpecialProviderDescriptors.map(peekKey)),

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -8,7 +8,7 @@ import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
-const XAI_WEB_SEARCH_MODEL = "grok-4.3";
+const XAI_WEB_SEARCH_MODEL = "grok-4.5";
 const DEFAULT_NUM_RESULTS = 10;
 const MAX_NUM_RESULTS = 30;
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -1478,6 +1478,277 @@ describe("ModelRegistry", () => {
 			await registry.refreshProvider("github-copilot", "online");
 			expect(requestedUrls).toContain("https://copilot-api.ghe.example.com/models");
 			expect(requestedUrls).not.toContain("https://api.githubcopilot.com/models");
+		});
+	});
+
+	describe("built-in OAuth discovery auto-refresh", () => {
+		test("expired xai-oauth credentials whose refresh rejects does not crash built-in discovery", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "expired-refresh-token",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				const spy = spyOn(registry, "getApiKeyForProvider").mockImplementation(() =>
+					Promise.reject(new Error("Mocked refresh failure")),
+				);
+
+				await registry.refreshProvider("xai-oauth", "online");
+				expect(spy).toHaveBeenCalledWith("xai-oauth");
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("built-in discovery refreshes an expired OAuth credential instead of skipping the provider", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "stale-access",
+						refresh: "r",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const captured: { authHeader: string | null } = { authHeader: null };
+				const fetchMock: FetchImpl = async (input, init) => {
+					const url = input instanceof Request ? input.url : String(input);
+					if (url === "https://api.x.ai/v1/models") {
+						captured.authHeader =
+							input instanceof Request
+								? input.headers.get("Authorization")
+								: new Headers(init?.headers).get("Authorization");
+						return new Response(
+							JSON.stringify({
+								data: [{ id: "grok-4.5" }],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async () => {
+					await authStorage.set("xai-oauth", [
+						{
+							type: "oauth",
+							access: "fresh-access",
+							refresh: "r",
+							expires: Date.now() + 3_600_000,
+						},
+					]);
+					return "fresh-access";
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					expect(spy).toHaveBeenCalled();
+					expect(captured.authHeader).toBe("Bearer fresh-access");
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("built-in discovery does not attempt OAuth refresh if no stored credentials exist", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				const fetchMock: FetchImpl = async () => {
+					throw new Error(`Should not fetch because discovery is skipped`);
+				};
+
+				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async () => {
+					return "fresh-access";
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					expect(spy).not.toHaveBeenCalled();
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("refreshProvider for targeted built-in provider does not refresh unrelated expired OAuth credentials", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "stale-xai-access",
+						refresh: "r-xai",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				await authStorage.set("openai-codex", [
+					{
+						type: "oauth",
+						access: "stale-codex-access",
+						refresh: "r-codex",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const captured: { authHeader: string | null } = { authHeader: null };
+				const fetchMock: FetchImpl = async (input, init) => {
+					const url = input instanceof Request ? input.url : String(input);
+					if (url === "https://api.x.ai/v1/models") {
+						captured.authHeader =
+							input instanceof Request
+								? input.headers.get("Authorization")
+								: new Headers(init?.headers).get("Authorization");
+						return new Response(
+							JSON.stringify({
+								data: [{ id: "grok-4.5" }],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const refreshedProviders: string[] = [];
+				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async providerId => {
+					refreshedProviders.push(providerId);
+					if (providerId === "xai-oauth") {
+						await authStorage.set("xai-oauth", [
+							{
+								type: "oauth",
+								access: "fresh-xai-access",
+								refresh: "r-xai",
+								expires: Date.now() + 3_600_000,
+							},
+						]);
+						return "fresh-xai-access";
+					}
+					return undefined;
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					expect(refreshedProviders).toEqual(["xai-oauth"]);
+					expect(captured.authHeader).toBe("Bearer fresh-xai-access");
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("refresh('offline') does not refresh expired OAuth credentials and does not hit the network", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "expired-refresh-token",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const fetchMock: FetchImpl = async input => {
+					throw new Error(`Unexpected network call in offline mode: ${String(input)}`);
+				};
+
+				const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+				const spy = spyOn(registry, "getApiKeyForProvider");
+
+				try {
+					await registry.refresh("offline");
+					expect(spy).not.toHaveBeenCalled();
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
 		});
 	});
 

--- a/packages/coding-agent/test/tools/web-search-xai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-xai.test.ts
@@ -140,7 +140,7 @@ describe("xAI web search provider", () => {
 			Authorization: "Bearer test-xai-key",
 		});
 		expect(capture.capturedRequest?.body).toMatchObject({
-			model: "grok-4.3",
+			model: "grok-4.5",
 			input: [
 				{ role: "system", content: "Use web search for current xAI facts." },
 				{ role: "user", content: "latest xAI web search" },


### PR DESCRIPTION
## Summary

Grok 4.5 is now available in the xAI catalogs, and SuperGrok-backed discovery no longer disappears just because the stored OAuth access token has expired. The xAI OAuth catalog defaults to Grok 4.5, xAI web search uses the same flagship model, and built-in discovery refreshes expired OAuth credentials only when online discovery actually needs them.

## What changed

| Area | Change |
| --- | --- |
| xAI catalog | Added Grok 4.5 to the xAI OAuth curated list, regenerated the bundled xAI/xAI OAuth entries, and kept the plain xAI source default unchanged. |
| Defaults | Switched the xAI OAuth provider default to `grok-4.5` and updated xAI web search requests from `grok-4.3` to `grok-4.5`. |
| OAuth discovery | Built-in provider discovery now refreshes expired stored OAuth credentials, re-peeks after refresh to preserve provider-specific credential shapes, skips unrelated providers during targeted refreshes, and stays peek-only in offline mode. |
| Tests and docs | Added focused regressions for Grok 4.5 catalog metadata, web-search request shape, OAuth refresh success/failure/no-op paths, targeted refresh scoping, offline no-refresh behavior, and Unreleased changelog entries. |

## Design notes

- The xAI OAuth curated entry is the single source feeding the static seed, dynamic overlay, and inject-when-missing paths, so Grok 4.5 remains present even if the OAuth `/v1/models` listing omits it.
- The refresh path deliberately refreshes through `getApiKeyForProvider`, then calls `peekApiKey` again. That keeps providers such as GitHub Copilot returning their existing JSON envelope shape instead of accidentally passing around a raw token.
- Offline discovery preserves the old cheap cached-reconciliation behavior: expired OAuth credentials are not refreshed when `strategy === "offline"`.
- The generated `models.json` update includes normal upstream provider drift from the model generator alongside the required xAI and xAI OAuth Grok 4.5 entries.

## Commits

| Commit | Purpose |
| --- | --- |
| `26de42f` | Add Grok 4.5 catalog support, xAI OAuth default, generated model entries, and catalog-side tests. |
| `66b634d` | Refresh expired OAuth credentials during built-in discovery, update xAI web search, and add coding-agent regressions/changelog coverage. |

## Validation

- `bun check`
- `cd packages/catalog && bun run gen:models`
- Parsed `packages/catalog/src/models.json` to verify `xai/grok-4.5` and `xai-oauth/grok-4.5` metadata:
  - `xai/grok-4.5`: 500K context, cost `2 / 6 / 0.5`.
  - `xai-oauth/grok-4.5`: zero cost, 500K context/max tokens, reasoning enabled, text+image input, no explicit `compat.supportsReasoningEffort` override.
- `cd packages/catalog && bun test test/identity-family.test.ts test/build.test.ts test/xai-oauth-bundle.test.ts test/model-thinking.test.ts test/canonical-limit-fallback.test.ts` — `96 pass`, `0 fail`.
- `cd packages/coding-agent && bun test test/model-registry.test.ts test/tools/web-search-xai.test.ts` — `111 pass`, `0 fail`.

Manual SuperGrok UI smoke was not run because it requires a real SuperGrok login; the local coverage exercises the catalog, request, and discovery contracts directly.
