### PR TITLE
feat(catalog): add Grok 4.5 to xAI catalogs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Changed the xAI Grok OAuth (`xai-oauth`) provider to use manual code-paste login by default. `/login` now accepts a pasted authorization code or full `http://127.0.0.1:56121/callback?code=...` redirect URL without starting a local callback listener ([#3277](https://github.com/can1357/oh-my-pi/pull/3277) by [@Jaaneek](https://github.com/Jaaneek)).
 - Renamed the xAI Grok OAuth provider in login and credential prompts to "xAI Grok OAuth (SuperGrok or X Premium+)" ([#3277](https://github.com/can1357/oh-my-pi/pull/3277) by [@Jaaneek](https://github.com/Jaaneek)).
+### Fixed
+
+- Dropped `presence_penalty`, `frequency_penalty`, and `stop` on xAI Grok reasoning models (chat-completions and Responses) so a configured presencePenalty no longer 400s the default grok-4.5 request (xAI rejects those params on reasoning models).
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1,5 +1,6 @@
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
-import { isKimiModelId } from "@oh-my-pi/pi-catalog/identity";
+import { modelMatchesHost } from "@oh-my-pi/pi-catalog/hosts";
+import { isGrokReasoningEffortCapable, isKimiModelId } from "@oh-my-pi/pi-catalog/identity";
 import { resolveWireModelId } from "@oh-my-pi/pi-catalog/model-thinking";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import type { ResolvedOpenAICompat } from "@oh-my-pi/pi-catalog/types";
@@ -1446,17 +1447,25 @@ function buildParams(
 	if (options?.minP !== undefined) {
 		params.min_p = options.minP;
 	}
-	if (options?.presencePenalty !== undefined) {
+	// xAI reasoning models reject presence_penalty / frequency_penalty / stop
+	// (docs.x.ai/developers/model-capabilities/text/reasoning). Drop them for
+	// Grok effort-capable SKUs on an xAI host so a configured presencePenalty
+	// (or stopSequences) does not 400 the default grok-4.5 request.
+	const dropXaiReasoningSampling =
+		isGrokReasoningEffortCapable(model.id) &&
+		(modelMatchesHost({ provider: model.provider, baseUrl: model.baseUrl ?? "" }, "xai") ||
+			model.provider === "xai-oauth");
+	if (options?.presencePenalty !== undefined && !dropXaiReasoningSampling) {
 		params.presence_penalty = options.presencePenalty;
 	}
 	if (options?.repetitionPenalty !== undefined) {
 		params.repetition_penalty = options.repetitionPenalty;
 	}
-	if (options?.stopSequences?.length) {
+	if (options?.stopSequences?.length && !dropXaiReasoningSampling) {
 		const seqs = options.stopSequences;
 		params.stop = seqs.length === 1 ? seqs[0] : seqs.slice(0, 4);
 	}
-	if (options?.frequencyPenalty !== undefined) {
+	if (options?.frequencyPenalty !== undefined && !dropXaiReasoningSampling) {
 		params.frequency_penalty = options.frequencyPenalty;
 	}
 	applyOpenAIServiceTier(params, options?.serviceTier, model);

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1,6 +1,7 @@
 import type { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { toFirepassWireModelId, toFireworksWireModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
-import { isGlm52ReasoningEffortModelId } from "@oh-my-pi/pi-catalog/identity";
+import { modelMatchesHost } from "@oh-my-pi/pi-catalog/hosts";
+import { isGlm52ReasoningEffortModelId, isGrokReasoningEffortCapable } from "@oh-my-pi/pi-catalog/identity";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { calculateCost } from "@oh-my-pi/pi-catalog/models";
 import type {
@@ -2491,11 +2492,17 @@ type CommonSamplingOptions = Pick<
  * proxies (notably Ollama) that forward to upstream APIs with an unknown output-token cap
  * can let the upstream apply its own default instead of 400-ing on `maxTokens` values that
  * reflect the model's context window rather than the upstream output limit.
+ *
+ * xAI reasoning models reject `presence_penalty` / `frequency_penalty` / `stop`
+ * (docs.x.ai/developers/model-capabilities/text/reasoning). This path has no
+ * frequency/stop fields; presence is dropped when the model is a Grok
+ * effort-capable reasoner on an xAI host so a configured presencePenalty does
+ * not 400 the default grok-4.5 request.
  */
 export function applyCommonResponsesSamplingParams<P extends CommonResponsesParams>(
 	params: P,
 	options: CommonSamplingOptions | undefined,
-	model: Pick<Model, "provider" | "api" | "id" | "omitMaxOutputTokens" | "maxTokens">,
+	model: Pick<Model, "provider" | "api" | "id" | "baseUrl" | "omitMaxOutputTokens" | "maxTokens">,
 ): void {
 	if (options?.maxTokens && !model.omitMaxOutputTokens) {
 		params.max_output_tokens = Math.min(
@@ -2508,7 +2515,13 @@ export function applyCommonResponsesSamplingParams<P extends CommonResponsesPara
 	if (options?.topP !== undefined) params.top_p = options.topP;
 	if (options?.topK !== undefined) params.top_k = options.topK;
 	if (options?.minP !== undefined) params.min_p = options.minP;
-	if (options?.presencePenalty !== undefined) params.presence_penalty = options.presencePenalty;
+	const dropXaiReasoningSampling =
+		isGrokReasoningEffortCapable(model.id) &&
+		(modelMatchesHost({ provider: model.provider, baseUrl: model.baseUrl ?? "" }, "xai") ||
+			model.provider === "xai-oauth");
+	if (options?.presencePenalty !== undefined && !dropXaiReasoningSampling) {
+		params.presence_penalty = options.presencePenalty;
+	}
 	if (options?.repetitionPenalty !== undefined) params.repetition_penalty = options.repetitionPenalty;
 	applyOpenAIServiceTier(params, options?.serviceTier, model);
 }

--- a/packages/ai/test/xai-reasoning-sampling-strip.test.ts
+++ b/packages/ai/test/xai-reasoning-sampling-strip.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { applyCommonResponsesSamplingParams } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+/**
+ * xAI reasoning models reject presence_penalty / frequency_penalty / stop
+ * (docs.x.ai/developers/model-capabilities/text/reasoning). With grok-4.5 as
+ * the xai-oauth default (and reasoning mandatory), a configured presencePenalty
+ * must not reach the wire or the default model 400s.
+ */
+function grok45Completions(): Model<"openai-completions"> {
+	return buildModel({
+		id: "grok-4.5",
+		name: "Grok 4.5",
+		api: "openai-completions",
+		provider: "xai",
+		baseUrl: "https://api.x.ai/v1",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 500_000,
+		maxTokens: 500_000,
+	});
+}
+
+function openaiGpt(): Model<"openai-completions"> {
+	return buildModel({
+		id: "gpt-4o-mini",
+		name: "GPT-4o mini",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	});
+}
+
+function createAbortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function baseContext(): Context {
+	return {
+		messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+	};
+}
+
+describe("xAI reasoning sampling-param strip", () => {
+	test("applyCommonResponsesSamplingParams drops presence_penalty for xAI Grok 4.5", () => {
+		const model = buildModel({
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			api: "openai-responses",
+			provider: "xai-oauth",
+			baseUrl: "https://api.x.ai/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 500_000,
+			maxTokens: 500_000,
+		});
+		const params: Record<string, unknown> = {};
+		applyCommonResponsesSamplingParams(params as never, { presencePenalty: 0.5, temperature: 0.7, topP: 0.9 }, model);
+		expect(params.presence_penalty).toBeUndefined();
+		// Non-rejected sampling still flows.
+		expect(params.temperature).toBe(0.7);
+		expect(params.top_p).toBe(0.9);
+	});
+
+	test("applyCommonResponsesSamplingParams still sends presence_penalty for non-xAI models", () => {
+		const model = buildModel({
+			id: "gpt-5",
+			name: "GPT-5",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 100_000,
+		});
+		const params: Record<string, unknown> = {};
+		applyCommonResponsesSamplingParams(params as never, { presencePenalty: 0.5 }, model);
+		expect(params.presence_penalty).toBe(0.5);
+	});
+
+	test("openai-completions drops presence/frequency/stop for xAI Grok 4.5", async () => {
+		const model = grok45Completions();
+		const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+		const fetchMock: FetchImpl = async () =>
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			signal: createAbortedSignal(),
+			presencePenalty: 0.5,
+			frequencyPenalty: 0.25,
+			stopSequences: ["STOP"],
+			onPayload: payload => resolve(payload as Record<string, unknown>),
+		});
+		const payload = await promise;
+		expect(payload.presence_penalty).toBeUndefined();
+		expect(payload.frequency_penalty).toBeUndefined();
+		expect(payload.stop).toBeUndefined();
+	});
+
+	test("openai-completions still sends presence/frequency/stop for non-xAI models", async () => {
+		const model = openaiGpt();
+		const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+		const fetchMock: FetchImpl = async () =>
+			new Response("data: [DONE]\n\n", {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+			signal: createAbortedSignal(),
+			presencePenalty: 0.5,
+			frequencyPenalty: 0.25,
+			stopSequences: ["STOP"],
+			onPayload: payload => resolve(payload as Record<string, unknown>),
+		});
+		const payload = await promise;
+		expect(payload.presence_penalty).toBe(0.5);
+		expect(payload.frequency_penalty).toBe(0.25);
+		expect(payload.stop).toBe("STOP");
+	});
+});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Grok 4.5 to the xai and xai-oauth (SuperGrok) catalogs; grok-4.5 is now the xai-oauth default model.
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added Grok 4.5 to the xai and xai-oauth (SuperGrok) catalogs; grok-4.5 is now the xai-oauth default model. Its reasoning effort is constrained to xAI's supported low/medium/high tiers and marked mandatory, so a thinking-off request clamps to low instead of omitting reasoning (which xAI's grok-4.5 rejects, since reasoning cannot be disabled).
+- Added Grok 4.5 to the xai and xai-oauth (SuperGrok) catalogs; grok-4.5 is now the xai-oauth default model. Its reasoning effort is constrained to xAI's supported low/medium/high tiers and marked mandatory, so a thinking-off request clamps to low instead of omitting reasoning (which xAI's grok-4.5 rejects, since reasoning cannot be disabled). The effort cap keys on the xAI host (provider `xai` or base URL `api.x.ai`), so a custom OpenAI-compatible config pointed at xAI gets the same ladder; the documented `grok-build-latest` alias inherits the Grok 4.5 effort/mandatory-reasoning contract (distinct from the separate `grok-build` / `grok-build-0.1` SKUs that reject `reasoning.effort`).
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added Grok 4.5 to the xai and xai-oauth (SuperGrok) catalogs; grok-4.5 is now the xai-oauth default model.
+- Added Grok 4.5 to the xai and xai-oauth (SuperGrok) catalogs; grok-4.5 is now the xai-oauth default model. Its reasoning effort is constrained to xAI's supported low/medium/high tiers and marked mandatory, so a thinking-off request clamps to low instead of omitting reasoning (which xAI's grok-4.5 rejects, since reasoning cannot be disabled).
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -14,6 +14,7 @@ import {
 	isClaudeModelId,
 	isDeepseekModelIdOrName,
 	isGlm52ReasoningEffortModelId,
+	isGrok45ReasoningModelId,
 	isGrokReasoningEffortCapable,
 	isKimiK26ModelId,
 	isKimiModelId,
@@ -426,7 +427,10 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// OpenAI's reasoning-API surface.
 		supportsDeveloperRole: isOpenAIHost || isAzureHost,
 		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
-		supportsReasoningEffort: !isGrok && !isXiaomiMimo && (!(isZai || isZhipu) || supportsZaiReasoningEffort),
+		supportsReasoningEffort:
+			(!isGrok || isGrok45ReasoningModelId(spec.id)) &&
+			!isXiaomiMimo &&
+			(!(isZai || isZhipu) || supportsZaiReasoningEffort),
 		// GitHub Copilot's chat-completions endpoint rejects reasoning params wholesale.
 		supportsReasoningParams: provider !== "github-copilot",
 		reasoningEffortMap: isMimoReasoningEffortModel ? MIMO_REASONING_EFFORT_MAP : {},

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -78,7 +78,7 @@ export const isMimoModelIdOrName = memo((value: string): boolean => {
 	return value.toLowerCase().includes("mimo");
 });
 
-const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3"] as const;
+const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3", "grok-4.5"] as const;
 
 /**
  * Grok SKUs that expose the wire `reasoning.effort` dial. Other Grok reasoners

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -92,6 +92,19 @@ export const isGrokReasoningEffortCapable = memo((modelId: string): boolean => {
 });
 
 /**
+ * grok-4.5 and its `grok-4.5-latest` alias accept only reasoning.effort
+ * low/medium/high — there is no `minimal` or `xhigh` tier
+ * (docs.x.ai/developers/model-capabilities/text/reasoning; defaults high,
+ * reasoning cannot be disabled). Distinct from `grok-4.20-multi-agent`, whose
+ * `xhigh` selects agent count. Used to pin the effort dial on xAI surfaces.
+ */
+export const isGrok45ReasoningModelId = memo((modelId: string): boolean => {
+	const bare = bareModelId(modelId).trim().toLowerCase();
+	if (!bare) return false;
+	return bare.startsWith("grok-4.5");
+});
+
+/**
  * MiniMax M2-generation family (M2, M2.1, M2.5, M2.7, including `-highspeed`/
  * `-lightning`/`-her`/`-turbo` variants, dotless aliases like `minimax-m21`,
  * and short `minimax/m2-…` ids on aggregator hosts). Underlying model accepts

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -79,6 +79,8 @@ export const isMimoModelIdOrName = memo((value: string): boolean => {
 });
 
 const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3", "grok-4.5"] as const;
+/** Documented grok-4.5 aliases that do not share the `grok-4.5` prefix (docs.x.ai/developers/models/grok-4.5). */
+const GROK_45_ALIAS_IDS = new Set(["grok-build-latest"]);
 
 /**
  * Grok SKUs that expose the wire `reasoning.effort` dial. Other Grok reasoners
@@ -88,20 +90,23 @@ const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "g
 export const isGrokReasoningEffortCapable = memo((modelId: string): boolean => {
 	const bare = bareModelId(modelId).trim().toLowerCase();
 	if (!bare) return false;
+	if (GROK_45_ALIAS_IDS.has(bare)) return true;
 	return GROK_EFFORT_CAPABLE_PREFIXES.some(prefix => bare.startsWith(prefix));
 });
 
 /**
- * grok-4.5 and its `grok-4.5-latest` alias accept only reasoning.effort
- * low/medium/high — there is no `minimal` or `xhigh` tier
- * (docs.x.ai/developers/model-capabilities/text/reasoning; defaults high,
- * reasoning cannot be disabled). Distinct from `grok-4.20-multi-agent`, whose
- * `xhigh` selects agent count. Used to pin the effort dial on xAI surfaces.
+ * grok-4.5 and its documented aliases (`grok-4.5-latest`, `grok-build-latest`)
+ * accept only reasoning.effort low/medium/high — there is no `minimal` or
+ * `xhigh` tier (docs.x.ai/developers/model-capabilities/text/reasoning; defaults
+ * high, reasoning cannot be disabled). Distinct from the separate `grok-build`
+ * / `grok-build-0.1` SKUs (which reject the effort param) and from
+ * `grok-4.20-multi-agent` (whose `xhigh` selects agent count). Used to pin the
+ * effort dial on xAI surfaces.
  */
 export const isGrok45ReasoningModelId = memo((modelId: string): boolean => {
 	const bare = bareModelId(modelId).trim().toLowerCase();
 	if (!bare) return false;
-	return bare.startsWith("grok-4.5");
+	return bare.startsWith("grok-4.5") || GROK_45_ALIAS_IDS.has(bare);
 });
 
 /**

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -504,6 +504,10 @@ const OPENAI_O_SERIES_RE = /^o[134](?:$|[-:.])/i;
  * - Gemini 3.x exposes levels only; Gemini 2.5 Pro floors thinkingBudget at
  *   128 and rejects 0 (2.5 Flash/Flash-Lite keep the off switch).
  * - OpenAI o-series and MiniMax M2 are reasoning-first architectures.
+ * - Grok 4.5 (xai / xai-oauth) documents reasoning as non-disableable
+ *   (docs.x.ai/developers/model-capabilities/text/reasoning): an omitted
+ *   effort defaults to high, so thinking-off must clamp to the lowest
+ *   supported effort rather than silently run at the default high.
  * - Thinking-variant SKUs (`*-thinking`, `*-reasoner`, `*-reasoning`) ARE the
  *   thinking checkpoint; live bare twins pair-collapse away
  *   (variant-collapse) and the collapsed entry owns off — this floor protects
@@ -515,6 +519,9 @@ function impliesMandatoryReasoning(parsed: ParsedModel, modelId: string): boolea
 		if (parsed.kind === "pro" && semverGte(parsed.version, "2.5")) return true;
 	}
 	if (isMinimaxM2FamilyModelId(modelId)) return true;
+	// grok-4.5 reasoning cannot be disabled (see doc comment); clamp thinking-off
+	// to the lowest supported effort instead of omitting reasoning.
+	if (isGrok45ReasoningModelId(modelId)) return true;
 	if (OPENAI_O_SERIES_RE.test(bareModelId(modelId))) return true;
 	return findThinkingVariantToken(modelId) !== undefined;
 }

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -314,11 +314,14 @@ function getModelDefinedEfforts<TApi extends Api>(
 	if (isSakanaFuguReasoningModel(spec)) {
 		return FUGU_REASONING_EFFORTS;
 	}
-	// grok-4.5 (xai / xai-oauth) accepts only reasoning.effort low/medium/high
-	// (docs.x.ai/developers/model-capabilities/text/reasoning). The Responses
-	// and completions default ladders would expose `xhigh` and send it verbatim,
-	// which xAI 400s. Pin the xAI-native surfaces to low/medium/high.
-	if ((spec.provider === "xai" || spec.provider === "xai-oauth") && isGrok45ReasoningModelId(spec.id)) {
+	// grok-4.5 on any xAI host accepts only reasoning.effort low/medium/high
+	// (docs.x.ai/developers/model-capabilities/text/reasoning). Key on the xAI
+	// host (provider xai / baseUrl api.x.ai), not just the built-in provider
+	// ids: a custom OpenAI-compatible config pointed at api.x.ai already gets
+	// supportsReasoningEffort via host detection, and without this cap would
+	// expose/send unsupported values like `xhigh` (xAI 400s). xai-oauth is
+	// included by provider id (its baseUrl is also api.x.ai).
+	if ((modelMatchesHost(spec, "xai") || spec.provider === "xai-oauth") && isGrok45ReasoningModelId(spec.id)) {
 		return LOW_MEDIUM_HIGH_REASONING_EFFORTS;
 	}
 	return isOpenAICompatReasoningApi(spec.api) &&

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -24,6 +24,7 @@ import {
 	findThinkingVariantToken,
 	isDeepseekModelIdOrName,
 	isGlm52ReasoningEffortModelId,
+	isGrok45ReasoningModelId,
 	isMimoModelIdOrName,
 	isMinimaxM2FamilyModelId,
 	isMinimaxM3FamilyModelId,
@@ -312,6 +313,13 @@ function getModelDefinedEfforts<TApi extends Api>(
 	}
 	if (isSakanaFuguReasoningModel(spec)) {
 		return FUGU_REASONING_EFFORTS;
+	}
+	// grok-4.5 (xai / xai-oauth) accepts only reasoning.effort low/medium/high
+	// (docs.x.ai/developers/model-capabilities/text/reasoning). The Responses
+	// and completions default ladders would expose `xhigh` and send it verbatim,
+	// which xAI 400s. Pin the xAI-native surfaces to low/medium/high.
+	if ((spec.provider === "xai" || spec.provider === "xai-oauth") && isGrok45ReasoningModelId(spec.id)) {
+		return LOW_MEDIUM_HIGH_REASONING_EFFORTS;
 	}
 	return isOpenAICompatReasoningApi(spec.api) &&
 		(isMinimaxM2FamilyModelId(spec.id) ||

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -4972,7 +4972,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -14269,7 +14269,7 @@
 			"cost": {
 				"input": 0.55,
 				"output": 1.65,
-				"cacheRead": 0,
+				"cacheRead": 0.55,
 				"cacheWrite": 0
 			},
 			"contextWindow": 161000,
@@ -14286,13 +14286,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.07,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 384000,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14322,13 +14322,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.74,
+				"output": 3.48,
+				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 393216,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14349,7 +14349,7 @@
 		},
 		"google/gemma-4-31B-it": {
 			"id": "google/gemma-4-31B-it",
-			"name": "Gemma 4 31B Instruct",
+			"name": "Gemma 4 31B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14359,13 +14359,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.12,
+				"output": 0.35,
+				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14388,9 +14388,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.05,
+				"output": 0.1,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14398,7 +14398,7 @@
 		},
 		"JetBrains/Mellum2-12B-A2.5B-Instruct": {
 			"id": "JetBrains/Mellum2-12B-A2.5B-Instruct",
-			"name": "JetBrains/Mellum2-12B-A2.5B-Instruct",
+			"name": "Mellum2 12B A2.5B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14407,13 +14407,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.05,
+				"output": 0.1,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"meta-llama/Llama-3.1-70B-Instruct": {
 			"id": "meta-llama/Llama-3.1-70B-Instruct",
@@ -14428,7 +14428,7 @@
 			"cost": {
 				"input": 0.8,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.8,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14436,7 +14436,7 @@
 		},
 		"meta-llama/Llama-3.1-8B-Instruct": {
 			"id": "meta-llama/Llama-3.1-8B-Instruct",
-			"name": "Meta-Llama-3.1-8B-Instruct",
+			"name": "Llama 3.1 8B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14447,7 +14447,7 @@
 			"cost": {
 				"input": 0.22,
 				"output": 0.22,
-				"cacheRead": 0,
+				"cacheRead": 0.22,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14455,7 +14455,7 @@
 		},
 		"meta-llama/Llama-3.3-70B-Instruct": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct",
-			"name": "Llama-3.3-70B-Instruct",
+			"name": "Llama 3.3 70B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14466,7 +14466,7 @@
 			"cost": {
 				"input": 0.71,
 				"output": 0.71,
-				"cacheRead": 0,
+				"cacheRead": 0.71,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14494,7 +14494,7 @@
 		},
 		"microsoft/Phi-4-mini-instruct": {
 			"id": "microsoft/Phi-4-mini-instruct",
-			"name": "Phi-4-mini-instruct",
+			"name": "Phi 4 Mini 3.8B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14505,7 +14505,7 @@
 			"cost": {
 				"input": 0.08,
 				"output": 0.35,
-				"cacheRead": 0,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14524,7 +14524,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1.2,
-				"cacheRead": 0,
+				"cacheRead": 0.3,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -14551,9 +14551,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 2.85,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 3,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14571,7 +14571,7 @@
 		},
 		"moonshotai/Kimi-K2.6": {
 			"id": "moonshotai/Kimi-K2.6",
-			"name": "Kimi-K2.6",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14581,9 +14581,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14611,9 +14611,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.94,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14631,7 +14631,7 @@
 		},
 		"nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-			"name": "NVIDIA Nemotron 3 Super 120B",
+			"name": "Nemotron 3 Super",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14642,7 +14642,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.8,
-				"cacheRead": 0,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14660,22 +14660,32 @@
 		},
 		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
-			"name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+			"name": "Nemotron 3 Ultra",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 2.75,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -14688,9 +14698,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
-				"cacheRead": 0,
+				"input": 0.04,
+				"output": 0.14,
+				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14715,9 +14725,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.2,
-				"cacheRead": 0,
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14733,7 +14743,7 @@
 		},
 		"OpenPipe/Qwen3-14B-Instruct": {
 			"id": "OpenPipe/Qwen3-14B-Instruct",
-			"name": "OpenPipe Qwen3 14B Instruct",
+			"name": "Qwen3 14B Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14744,7 +14754,7 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.22,
-				"cacheRead": 0,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
@@ -14752,7 +14762,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B Instruct 2507",
+			"name": "Qwen3 235B A22B-2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14763,7 +14773,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14771,7 +14781,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3-235B-A22B-Thinking-2507",
+			"name": "Qwen3 235B A22B Thinking-2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14782,7 +14792,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14811,7 +14821,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.3,
-				"cacheRead": 0,
+				"cacheRead": 0.1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14819,7 +14829,7 @@
 		},
 		"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
 			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-			"name": "Qwen3-Coder-480B-A35B-Instruct",
+			"name": "Qwen3 Coder 480B A35B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14830,7 +14840,7 @@
 			"cost": {
 				"input": 1,
 				"output": 1.5,
-				"cacheRead": 0,
+				"cacheRead": 1,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14838,7 +14848,7 @@
 		},
 		"Qwen/Qwen3.5-27B": {
 			"id": "Qwen/Qwen3.5-27B",
-			"name": "Qwen3.5 27B",
+			"name": "Qwen3.5-27B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14848,13 +14858,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.39,
+				"output": 3.12,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14867,7 +14877,7 @@
 		},
 		"Qwen/Qwen3.5-35B-A3B": {
 			"id": "Qwen/Qwen3.5-35B-A3B",
-			"name": "Qwen3.5 35B-A3B",
+			"name": "Qwen3.5-35B-A3B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14877,13 +14887,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 1.25,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14906,13 +14916,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 3.6,
+				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14925,7 +14935,7 @@
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
-			"name": "Qwen3.6 35B-A3B",
+			"name": "Qwen3.6 35B A3B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14935,13 +14945,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 1.25,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14973,7 +14983,7 @@
 		},
 		"zai-org/GLM-5.1": {
 			"id": "zai-org/GLM-5.1",
-			"name": "GLM-5.1",
+			"name": "GLM 5.1",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14987,8 +14997,8 @@
 				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
-			"maxTokens": 131072,
+			"contextWindow": 202752,
+			"maxTokens": 202752,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -15002,7 +15012,7 @@
 		},
 		"zai-org/GLM-5.2": {
 			"id": "zai-org/GLM-5.2",
-			"name": "GLM-5.2",
+			"name": "GLM 5.2",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -15011,13 +15021,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.39,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 164000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -16764,26 +16774,6 @@
 			},
 			"requestModelId": "MODEL_GOOGLE_GEMINI_3_0_FLASH_MINIMAL"
 		},
-		"glm-5-1": {
-			"id": "glm-5-1",
-			"name": "GLM-5.1",
-			"api": "devin-agent",
-			"provider": "devin",
-			"baseUrl": "https://server.codeium.com",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"supportsTools": true,
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
 		"glm-5-2": {
 			"id": "glm-5-2",
 			"name": "GLM-5.2 High",
@@ -17453,6 +17443,46 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"swe-1-7": {
+			"id": "swe-1-7",
+			"name": "SWE-1.7",
+			"api": "devin-agent",
+			"provider": "devin",
+			"baseUrl": "https://server.codeium.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"supportsTools": true,
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262000,
+			"maxTokens": 64000
+		},
+		"swe-1-7-lightning": {
+			"id": "swe-1-7-lightning",
+			"name": "SWE-1.7 Lightning",
+			"api": "devin-agent",
+			"provider": "devin",
+			"baseUrl": "https://server.codeium.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"supportsTools": true,
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
 			"maxTokens": 64000
 		}
 	},
@@ -23447,6 +23477,33 @@
 				]
 			}
 		},
+		"openai/gpt-oss-20b": {
+			"id": "openai/gpt-oss-20b",
+			"name": "GPT OSS 20B",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"Qwen/Qwen3-235B-A22B": {
 			"id": "Qwen/Qwen3-235B-A22B",
 			"name": "Qwen3 235B-A22B",
@@ -24526,6 +24583,44 @@
 		"aion-labs/aion-2.0": {
 			"id": "aion-labs/aion-2.0",
 			"name": "Aion-2.0",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"aion-labs/aion-3.0": {
+			"id": "aion-labs/aion-3.0",
+			"name": "Aion-3.0",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
+		"aion-labs/aion-3.0-mini": {
+			"id": "aion-labs/aion-3.0-mini",
+			"name": "Aion-3.0-Mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28532,7 +28627,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28542,13 +28637,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
-			"maxTokens": 128000,
+			"contextWindow": 1048576,
+			"maxTokens": 512000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -29470,6 +29565,25 @@
 			"contextWindow": 131072,
 			"maxTokens": 163840
 		},
+		"nex-agi/nex-n2-mini": {
+			"id": "nex-agi/nex-n2-mini",
+			"name": "Nex-N2-Mini",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144
+		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
 			"name": "Nex-N2-Pro",
@@ -29486,8 +29600,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -29505,8 +29619,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
@@ -33859,6 +33973,25 @@
 			"contextWindow": null,
 			"maxTokens": null
 		},
+		"tencent/hy3": {
+			"id": "tencent/hy3",
+			"name": "Hy3",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": null
+		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
 			"name": "Hy3 Preview",
@@ -33906,6 +34039,25 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 64000
+		},
+		"tencent/hy3:free": {
+			"id": "tencent/hy3:free",
+			"name": "Hy3 (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": null
 		},
 		"thedrummer/cydonia-24b-v4.1": {
 			"id": "thedrummer/cydonia-24b-v4.1",
@@ -46633,8 +46785,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 262144,
+			"maxTokens": 262144
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -48807,7 +48959,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B Instruct 2507",
+			"name": "Qwen3 235B A22B-2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -48864,7 +49016,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3-235B-A22B-Thinking-2507",
+			"name": "Qwen3 235B A22B Thinking-2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49250,7 +49402,7 @@
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
-			"name": "Qwen3.6 35B-A3B",
+			"name": "Qwen3.6 35B A3B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -62311,6 +62463,36 @@
 			},
 			"contextPromotionTarget": "opencode-zen/gpt-5.4"
 		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"grok-build-0.1": {
 			"id": "grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -62330,6 +62512,35 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"hy3-free": {
+			"id": "hy3-free",
+			"name": "Hy3 Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63214,7 +63425,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.66,
+				"input": 0.65,
 				"output": 3.41,
 				"cacheRead": 0.14,
 				"cacheWrite": 0
@@ -63289,6 +63500,35 @@
 				]
 			}
 		},
+		"~x-ai/grok-latest": {
+			"id": "~x-ai/grok-latest",
+			"name": "Grok Latest",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"ai21/jamba-large-1.7": {
 			"id": "ai21/jamba-large-1.7",
 			"name": "Jamba Large 1.7",
@@ -63307,6 +63547,90 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 4096
+		},
+		"aion-labs/aion-2.0": {
+			"id": "aion-labs/aion-2.0",
+			"name": "Aion-2.0",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7999999999999999,
+				"output": 1.5999999999999999,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"aion-labs/aion-3.0": {
+			"id": "aion-labs/aion-3.0",
+			"name": "Aion-3.0",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 3,
+				"output": 6,
+				"cacheRead": 0.75,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"aion-labs/aion-3.0-mini": {
+			"id": "aion-labs/aion-3.0-mini",
+			"name": "Aion-3.0-Mini",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.7,
+				"output": 1.4,
+				"cacheRead": 0.18,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"alibaba/tongyi-deepresearch-30b-a3b": {
 			"id": "alibaba/tongyi-deepresearch-30b-a3b",
@@ -64846,7 +65170,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -66224,7 +66548,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -66875,7 +67199,7 @@
 			"cost": {
 				"input": 0.375,
 				"output": 2.025,
-				"cacheRead": 0.09,
+				"cacheRead": 0.203,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -66902,7 +67226,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.66,
+				"input": 0.65,
 				"output": 3.41,
 				"cacheRead": 0.14,
 				"cacheWrite": 0
@@ -66995,6 +67319,64 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 163840
+		},
+		"nex-agi/nex-n2-mini": {
+			"id": "nex-agi/nex-n2-mini",
+			"name": "Nex-N2-Mini",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.024999999999999998,
+				"output": 0.09999999999999999,
+				"cacheRead": 0.0025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"nex-agi/nex-n2-pro": {
+			"id": "nex-agi/nex-n2-pro",
+			"name": "Nex-N2-Pro",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1,
+				"cacheRead": 0.024999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -70301,7 +70683,7 @@
 			"cost": {
 				"input": 0.385,
 				"output": 2.4499999999999997,
-				"cacheRead": 0.195,
+				"cacheRead": 0.111,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -70938,6 +71320,34 @@
 				"supportsToolChoice": false
 			}
 		},
+		"tencent/hy3": {
+			"id": "tencent/hy3",
+			"name": "Hy3",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0.035,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
 			"name": "Hy3 Preview",
@@ -70969,6 +71379,34 @@
 		"tencent/hy3-preview:free": {
 			"id": "tencent/hy3-preview:free",
 			"name": "Hy3 preview (free)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
+		"tencent/hy3:free": {
+			"id": "tencent/hy3:free",
+			"name": "Hy3 (free)",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -71418,6 +71856,35 @@
 				]
 			}
 		},
+		"x-ai/grok-4.5": {
+			"id": "x-ai/grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -71571,7 +72038,7 @@
 			"cost": {
 				"input": 0.105,
 				"output": 0.28,
-				"cacheRead": 0.0028,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -71971,9 +72438,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.9086,
-				"output": 2.8556,
-				"cacheRead": 0.16874,
+				"input": 0.84,
+				"output": 2.64,
+				"cacheRead": 0.156,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -73401,38 +73868,6 @@
 				"escapeBuiltinToolNames": true
 			}
 		},
-		"umans-glm-5.2-nvfp4": {
-			"id": "umans-glm-5.2-nvfp4",
-			"name": "Umans GLM 5.2 NVFP4 (experimental, short test from Jun 29)",
-			"api": "anthropic-messages",
-			"provider": "umans",
-			"baseUrl": "https://api.code.umans.ai",
-			"reasoning": true,
-			"thinking": {
-				"mode": "anthropic-budget-effort",
-				"efforts": [
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"xhigh": "max"
-				}
-			},
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 405504,
-			"maxTokens": 131071,
-			"compat": {
-				"escapeBuiltinToolNames": true
-			}
-		},
 		"umans-kimi-k2.7": {
 			"id": "umans-kimi-k2.7",
 			"name": "Umans Kimi K2.7 Code",
@@ -73522,6 +73957,64 @@
 			"maxTokens": null,
 			"compat": {
 				"supportsUsageInStreaming": false
+			}
+		},
+		"aion-labs-aion-3-0": {
+			"id": "aion-labs-aion-3-0",
+			"name": "Aion 3.0",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 3.75,
+				"output": 7.5,
+				"cacheRead": 0.9375,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"aion-labs-aion-3-0-mini": {
+			"id": "aion-labs-aion-3-0-mini",
+			"name": "Aion 3.0 Mini",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.875,
+				"output": 1.75,
+				"cacheRead": 0.225,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"aion-labs.aion-2-0": {
@@ -74080,6 +74573,28 @@
 				}
 			}
 		},
+		"e2ee-deepseek-v4-flash": {
+			"id": "e2ee-deepseek-v4-flash",
+			"name": "e2ee-deepseek-v4-flash",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1048576,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-gemma-3-27b-p": {
 			"id": "e2ee-gemma-3-27b-p",
 			"name": "e2ee-gemma-3-27b-p",
@@ -74362,6 +74877,28 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": null,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-qwen3-6-27b": {
+			"id": "e2ee-qwen3-6-27b",
+			"name": "e2ee-qwen3-6-27b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 65536,
 			"compat": {
 				"supportsUsageInStreaming": false
 			}
@@ -74833,6 +75370,36 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"grok-4-5": {
+			"id": "grok-4-5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.27,
+				"output": 6.8,
+				"cacheRead": 0.57,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
 			"maxTokens": 32000,
 			"thinking": {
 				"mode": "effort",
@@ -79099,7 +79666,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax-M3",
+			"name": "MiniMax M3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -81557,6 +82124,36 @@
 				]
 			}
 		},
+		"xai/grok-4.5": {
+			"id": "xai/grok-4.5",
+			"name": "Grok 4.5",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"xai/grok-build-0.1": {
 			"id": "xai/grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -83094,6 +83691,35 @@
 				]
 			}
 		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"grok-beta": {
 			"id": "grok-beta",
 			"name": "Grok Beta",
@@ -83308,6 +83934,47 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			}
+		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-responses",
+			"provider": "xai-oauth",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -86308,6 +86975,25 @@
 				]
 			}
 		},
+		"kuaishou/kat-coder-air-v2.5": {
+			"id": "kuaishou/kat-coder-air-v2.5",
+			"name": "KAT-Coder-Air-V2.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.135,
+				"output": 0.54,
+				"cacheRead": 0.027,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": null
+		},
 		"kuaishou/kat-coder-pro-v1": {
 			"id": "kuaishou/kat-coder-pro-v1",
 			"name": "KAT-Coder-Pro-V1",
@@ -86364,6 +87050,25 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000
+		},
+		"kuaishou/kat-coder-pro-v2.5": {
+			"id": "kuaishou/kat-coder-pro-v2.5",
+			"name": "KAT-Coder-Pro-V2.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.444,
+				"output": 1.776,
+				"cacheRead": 0.09,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": null
 		},
 		"meituan/longcat-2.0": {
 			"id": "meituan/longcat-2.0",
@@ -88482,9 +89187,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.134561595,
-				"output": 0.539161765,
-				"cacheRead": 0.033869245,
+				"input": 0.1323,
+				"output": 0.5301,
+				"cacheRead": 0.0333,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -88927,6 +89632,66 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"x-ai/grok-4.5": {
+			"id": "x-ai/grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"x-ai/grok-4.5-free": {
+			"id": "x-ai/grok-4.5-free",
+			"name": "Grok 4.5 (Free)",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -83119,7 +83119,8 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"requiresEffort": true
 			}
 		},
 		"grok-beta": {
@@ -83383,7 +83384,8 @@
 					"low",
 					"medium",
 					"high"
-				]
+				],
+				"requiresEffort": true
 			},
 			"compat": {
 				"reasoningEffortMap": {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -4972,7 +4972,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "aimlapi",
 			"baseUrl": "https://api.aimlapi.com/v1",
@@ -14269,7 +14269,7 @@
 			"cost": {
 				"input": 0.55,
 				"output": 1.65,
-				"cacheRead": 0.55,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 161000,
@@ -14286,13 +14286,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.07,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14322,13 +14322,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.74,
-				"output": 3.48,
-				"cacheRead": 0.14,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
+			"maxTokens": 393216,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14349,7 +14349,7 @@
 		},
 		"google/gemma-4-31B-it": {
 			"id": "google/gemma-4-31B-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14359,13 +14359,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.12,
-				"output": 0.35,
-				"cacheRead": 0.09,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14388,9 +14388,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.1,
-				"cacheRead": 0.05,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14398,7 +14398,7 @@
 		},
 		"JetBrains/Mellum2-12B-A2.5B-Instruct": {
 			"id": "JetBrains/Mellum2-12B-A2.5B-Instruct",
-			"name": "Mellum2 12B A2.5B",
+			"name": "JetBrains/Mellum2-12B-A2.5B-Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14407,13 +14407,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.05,
-				"output": 0.1,
-				"cacheRead": 0.05,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 131072
+			"contextWindow": null,
+			"maxTokens": null
 		},
 		"meta-llama/Llama-3.1-70B-Instruct": {
 			"id": "meta-llama/Llama-3.1-70B-Instruct",
@@ -14428,7 +14428,7 @@
 			"cost": {
 				"input": 0.8,
 				"output": 0.8,
-				"cacheRead": 0.8,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14436,7 +14436,7 @@
 		},
 		"meta-llama/Llama-3.1-8B-Instruct": {
 			"id": "meta-llama/Llama-3.1-8B-Instruct",
-			"name": "Llama 3.1 8B",
+			"name": "Meta-Llama-3.1-8B-Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14447,7 +14447,7 @@
 			"cost": {
 				"input": 0.22,
 				"output": 0.22,
-				"cacheRead": 0.22,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14455,7 +14455,7 @@
 		},
 		"meta-llama/Llama-3.3-70B-Instruct": {
 			"id": "meta-llama/Llama-3.3-70B-Instruct",
-			"name": "Llama 3.3 70B",
+			"name": "Llama-3.3-70B-Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14466,7 +14466,7 @@
 			"cost": {
 				"input": 0.71,
 				"output": 0.71,
-				"cacheRead": 0.71,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14494,7 +14494,7 @@
 		},
 		"microsoft/Phi-4-mini-instruct": {
 			"id": "microsoft/Phi-4-mini-instruct",
-			"name": "Phi 4 Mini 3.8B",
+			"name": "Phi-4-mini-instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14505,7 +14505,7 @@
 			"cost": {
 				"input": 0.08,
 				"output": 0.35,
-				"cacheRead": 0.08,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -14524,7 +14524,7 @@
 			"cost": {
 				"input": 0.3,
 				"output": 1.2,
-				"cacheRead": 0.3,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
@@ -14551,9 +14551,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3,
-				"cacheRead": 0.1,
+				"input": 0.5,
+				"output": 2.85,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14571,7 +14571,7 @@
 		},
 		"moonshotai/Kimi-K2.6": {
 			"id": "moonshotai/Kimi-K2.6",
-			"name": "Kimi K2.6",
+			"name": "Kimi-K2.6",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14581,9 +14581,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.95,
-				"output": 4,
-				"cacheRead": 0.16,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14611,9 +14611,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.94,
-				"output": 4,
-				"cacheRead": 0.19,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14631,7 +14631,7 @@
 		},
 		"nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-			"name": "Nemotron 3 Super",
+			"name": "NVIDIA Nemotron 3 Super 120B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14642,7 +14642,7 @@
 			"cost": {
 				"input": 0.2,
 				"output": 0.8,
-				"cacheRead": 0.2,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14660,32 +14660,22 @@
 		},
 		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
-			"name": "Nemotron 3 Ultra",
+			"name": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 2.75,
-				"cacheRead": 0.15,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
+			"contextWindow": null,
+			"maxTokens": null
 		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
@@ -14698,9 +14688,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.04,
-				"output": 0.14,
-				"cacheRead": 0.04,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14725,9 +14715,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.03,
-				"output": 0.13,
-				"cacheRead": 0.03,
+				"input": 0.05,
+				"output": 0.2,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -14743,7 +14733,7 @@
 		},
 		"OpenPipe/Qwen3-14B-Instruct": {
 			"id": "OpenPipe/Qwen3-14B-Instruct",
-			"name": "Qwen3 14B Instruct",
+			"name": "OpenPipe Qwen3 14B Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14754,7 +14744,7 @@
 			"cost": {
 				"input": 0.05,
 				"output": 0.22,
-				"cacheRead": 0.05,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 32768,
@@ -14762,7 +14752,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B-2507",
+			"name": "Qwen3 235B A22B Instruct 2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14773,7 +14763,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0.1,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14781,7 +14771,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3 235B A22B Thinking-2507",
+			"name": "Qwen3-235B-A22B-Thinking-2507",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14792,7 +14782,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.1,
-				"cacheRead": 0.1,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14821,7 +14811,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.3,
-				"cacheRead": 0.1,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14829,7 +14819,7 @@
 		},
 		"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
 			"id": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-			"name": "Qwen3 Coder 480B A35B",
+			"name": "Qwen3-Coder-480B-A35B-Instruct",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14840,7 +14830,7 @@
 			"cost": {
 				"input": 1,
 				"output": 1.5,
-				"cacheRead": 1,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -14848,7 +14838,7 @@
 		},
 		"Qwen/Qwen3.5-27B": {
 			"id": "Qwen/Qwen3.5-27B",
-			"name": "Qwen3.5-27B",
+			"name": "Qwen3.5 27B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14858,13 +14848,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 3.12,
-				"cacheRead": 0.08,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14877,7 +14867,7 @@
 		},
 		"Qwen/Qwen3.5-35B-A3B": {
 			"id": "Qwen/Qwen3.5-35B-A3B",
-			"name": "Qwen3.5-35B-A3B",
+			"name": "Qwen3.5 35B-A3B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14887,13 +14877,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.25,
-				"cacheRead": 0.25,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14916,13 +14906,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 3.6,
-				"cacheRead": 0.12,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14935,7 +14925,7 @@
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
-			"name": "Qwen3.6 35B A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14945,13 +14935,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.25,
-				"cacheRead": 0.25,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -14983,7 +14973,7 @@
 		},
 		"zai-org/GLM-5.1": {
 			"id": "zai-org/GLM-5.1",
-			"name": "GLM 5.1",
+			"name": "GLM-5.1",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -14997,8 +14987,8 @@
 				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
-			"contextWindow": 202752,
-			"maxTokens": 202752,
+			"contextWindow": 200000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -15012,7 +15002,7 @@
 		},
 		"zai-org/GLM-5.2": {
 			"id": "zai-org/GLM-5.2",
-			"name": "GLM 5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "coreweave",
 			"baseUrl": "https://api.inference.wandb.ai/v1",
@@ -15021,13 +15011,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.39,
-				"output": 4.4,
-				"cacheRead": 0.26,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 164000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -16774,6 +16764,26 @@
 			},
 			"requestModelId": "MODEL_GOOGLE_GEMINI_3_0_FLASH_MINIMAL"
 		},
+		"glm-5-1": {
+			"id": "glm-5-1",
+			"name": "GLM-5.1",
+			"api": "devin-agent",
+			"provider": "devin",
+			"baseUrl": "https://server.codeium.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"supportsTools": true,
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
 		"glm-5-2": {
 			"id": "glm-5-2",
 			"name": "GLM-5.2 High",
@@ -17443,46 +17453,6 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
-		},
-		"swe-1-7": {
-			"id": "swe-1-7",
-			"name": "SWE-1.7",
-			"api": "devin-agent",
-			"provider": "devin",
-			"baseUrl": "https://server.codeium.com",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"supportsTools": true,
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262000,
-			"maxTokens": 64000
-		},
-		"swe-1-7-lightning": {
-			"id": "swe-1-7-lightning",
-			"name": "SWE-1.7 Lightning",
-			"api": "devin-agent",
-			"provider": "devin",
-			"baseUrl": "https://server.codeium.com",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"supportsTools": true,
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 202752,
 			"maxTokens": 64000
 		}
 	},
@@ -23477,33 +23447,6 @@
 				]
 			}
 		},
-		"openai/gpt-oss-20b": {
-			"id": "openai/gpt-oss-20b",
-			"name": "GPT OSS 20B",
-			"api": "openai-completions",
-			"provider": "huggingface",
-			"baseUrl": "https://router.huggingface.co/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.1,
-				"output": 0.5,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
 		"Qwen/Qwen3-235B-A22B": {
 			"id": "Qwen/Qwen3-235B-A22B",
 			"name": "Qwen3 235B-A22B",
@@ -24583,44 +24526,6 @@
 		"aion-labs/aion-2.0": {
 			"id": "aion-labs/aion-2.0",
 			"name": "Aion-2.0",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": null,
-			"maxTokens": null
-		},
-		"aion-labs/aion-3.0": {
-			"id": "aion-labs/aion-3.0",
-			"name": "Aion-3.0",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": null,
-			"maxTokens": null
-		},
-		"aion-labs/aion-3.0-mini": {
-			"id": "aion-labs/aion-3.0-mini",
-			"name": "Aion-3.0-Mini",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28627,7 +28532,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28637,13 +28542,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 1.2,
-				"cacheRead": 0.06,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 512000,
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -29565,25 +29470,6 @@
 			"contextWindow": 131072,
 			"maxTokens": 163840
 		},
-		"nex-agi/nex-n2-mini": {
-			"id": "nex-agi/nex-n2-mini",
-			"name": "Nex-N2-Mini",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
-		},
 		"nex-agi/nex-n2-pro": {
 			"id": "nex-agi/nex-n2-pro",
 			"name": "Nex-N2-Pro",
@@ -29600,8 +29486,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": null,
+			"maxTokens": null
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -29619,8 +29505,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": null,
+			"maxTokens": null
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
@@ -33973,25 +33859,6 @@
 			"contextWindow": null,
 			"maxTokens": null
 		},
-		"tencent/hy3": {
-			"id": "tencent/hy3",
-			"name": "Hy3",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": null
-		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
 			"name": "Hy3 Preview",
@@ -34039,25 +33906,6 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 64000
-		},
-		"tencent/hy3:free": {
-			"id": "tencent/hy3:free",
-			"name": "Hy3 (free)",
-			"api": "openai-completions",
-			"provider": "kilo",
-			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": null
 		},
 		"thedrummer/cydonia-24b-v4.1": {
 			"id": "thedrummer/cydonia-24b-v4.1",
@@ -46785,8 +46633,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": null,
+			"maxTokens": null
 		},
 		"nothingiisreal/L3.1-70B-Celeste-V0.1-BF16": {
 			"id": "nothingiisreal/L3.1-70B-Celeste-V0.1-BF16",
@@ -48959,7 +48807,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Instruct-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-			"name": "Qwen3 235B A22B-2507",
+			"name": "Qwen3 235B A22B Instruct 2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49016,7 +48864,7 @@
 		},
 		"Qwen/Qwen3-235B-A22B-Thinking-2507": {
 			"id": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-			"name": "Qwen3 235B A22B Thinking-2507",
+			"name": "Qwen3-235B-A22B-Thinking-2507",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -49402,7 +49250,7 @@
 		},
 		"Qwen/Qwen3.6-35B-A3B": {
 			"id": "Qwen/Qwen3.6-35B-A3B",
-			"name": "Qwen3.6 35B A3B",
+			"name": "Qwen3.6 35B-A3B",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -62463,36 +62311,6 @@
 			},
 			"contextPromotionTarget": "opencode-zen/gpt-5.4"
 		},
-		"grok-4.5": {
-			"id": "grok-4.5",
-			"name": "Grok 4.5",
-			"api": "openai-completions",
-			"provider": "opencode-zen",
-			"baseUrl": "https://opencode.ai/zen/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
-		},
 		"grok-build-0.1": {
 			"id": "grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -62512,35 +62330,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
-		},
-		"hy3-free": {
-			"id": "hy3-free",
-			"name": "Hy3 Free",
-			"api": "openai-completions",
-			"provider": "opencode-zen",
-			"baseUrl": "https://opencode.ai/zen/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -63425,7 +63214,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.65,
+				"input": 0.66,
 				"output": 3.41,
 				"cacheRead": 0.14,
 				"cacheWrite": 0
@@ -63500,35 +63289,6 @@
 				]
 			}
 		},
-		"~x-ai/grok-latest": {
-			"id": "~x-ai/grok-latest",
-			"name": "Grok Latest",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": null,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
 		"ai21/jamba-large-1.7": {
 			"id": "ai21/jamba-large-1.7",
 			"name": "Jamba Large 1.7",
@@ -63547,90 +63307,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 4096
-		},
-		"aion-labs/aion-2.0": {
-			"id": "aion-labs/aion-2.0",
-			"name": "Aion-2.0",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.7999999999999999,
-				"output": 1.5999999999999999,
-				"cacheRead": 0.19999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
-		"aion-labs/aion-3.0": {
-			"id": "aion-labs/aion-3.0",
-			"name": "Aion-3.0",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 3,
-				"output": 6,
-				"cacheRead": 0.75,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
-		"aion-labs/aion-3.0-mini": {
-			"id": "aion-labs/aion-3.0-mini",
-			"name": "Aion-3.0-Mini",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.7,
-				"output": 1.4,
-				"cacheRead": 0.18,
-				"cacheWrite": 0
-			},
-			"contextWindow": 131072,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
 		},
 		"alibaba/tongyi-deepresearch-30b-a3b": {
 			"id": "alibaba/tongyi-deepresearch-30b-a3b",
@@ -65170,7 +64846,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65536,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -66548,7 +66224,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -67199,7 +66875,7 @@
 			"cost": {
 				"input": 0.375,
 				"output": 2.025,
-				"cacheRead": 0.203,
+				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -67226,7 +66902,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.65,
+				"input": 0.66,
 				"output": 3.41,
 				"cacheRead": 0.14,
 				"cacheWrite": 0
@@ -67319,64 +66995,6 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 163840
-		},
-		"nex-agi/nex-n2-mini": {
-			"id": "nex-agi/nex-n2-mini",
-			"name": "Nex-N2-Mini",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.024999999999999998,
-				"output": 0.09999999999999999,
-				"cacheRead": 0.0025,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
-		"nex-agi/nex-n2-pro": {
-			"id": "nex-agi/nex-n2-pro",
-			"name": "Nex-N2-Pro",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.25,
-				"output": 1,
-				"cacheRead": 0.024999999999999998,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
 		},
 		"nex-agi/nex-n2-pro:free": {
 			"id": "nex-agi/nex-n2-pro:free",
@@ -70683,7 +70301,7 @@
 			"cost": {
 				"input": 0.385,
 				"output": 2.4499999999999997,
-				"cacheRead": 0.111,
+				"cacheRead": 0.195,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -71320,34 +70938,6 @@
 				"supportsToolChoice": false
 			}
 		},
-		"tencent/hy3": {
-			"id": "tencent/hy3",
-			"name": "Hy3",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.14,
-				"output": 0.58,
-				"cacheRead": 0.035,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": null,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
 		"tencent/hy3-preview": {
 			"id": "tencent/hy3-preview",
 			"name": "Hy3 Preview",
@@ -71379,34 +70969,6 @@
 		"tencent/hy3-preview:free": {
 			"id": "tencent/hy3-preview:free",
 			"name": "Hy3 preview (free)",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
-		"tencent/hy3:free": {
-			"id": "tencent/hy3:free",
-			"name": "Hy3 (free)",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -71856,35 +71418,6 @@
 				]
 			}
 		},
-		"x-ai/grok-4.5": {
-			"id": "x-ai/grok-4.5",
-			"name": "Grok 4.5",
-			"api": "openrouter",
-			"provider": "openrouter",
-			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
-			}
-		},
 		"x-ai/grok-build-0.1": {
 			"id": "x-ai/grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -72038,7 +71571,7 @@
 			"cost": {
 				"input": 0.105,
 				"output": 0.28,
-				"cacheRead": 0.028,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -72438,9 +71971,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.84,
-				"output": 2.64,
-				"cacheRead": 0.156,
+				"input": 0.9086,
+				"output": 2.8556,
+				"cacheRead": 0.16874,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -73868,6 +73401,38 @@
 				"escapeBuiltinToolNames": true
 			}
 		},
+		"umans-glm-5.2-nvfp4": {
+			"id": "umans-glm-5.2-nvfp4",
+			"name": "Umans GLM 5.2 NVFP4 (experimental, short test from Jun 29)",
+			"api": "anthropic-messages",
+			"provider": "umans",
+			"baseUrl": "https://api.code.umans.ai",
+			"reasoning": true,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"efforts": [
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"xhigh": "max"
+				}
+			},
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 405504,
+			"maxTokens": 131071,
+			"compat": {
+				"escapeBuiltinToolNames": true
+			}
+		},
 		"umans-kimi-k2.7": {
 			"id": "umans-kimi-k2.7",
 			"name": "Umans Kimi K2.7 Code",
@@ -73957,64 +73522,6 @@
 			"maxTokens": null,
 			"compat": {
 				"supportsUsageInStreaming": false
-			}
-		},
-		"aion-labs-aion-3-0": {
-			"id": "aion-labs-aion-3-0",
-			"name": "Aion 3.0",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 3.75,
-				"output": 7.5,
-				"cacheRead": 0.9375,
-				"cacheWrite": 0
-			},
-			"contextWindow": 128000,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
-		},
-		"aion-labs-aion-3-0-mini": {
-			"id": "aion-labs-aion-3-0-mini",
-			"name": "Aion 3.0 Mini",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.875,
-				"output": 1.75,
-				"cacheRead": 0.225,
-				"cacheWrite": 0
-			},
-			"contextWindow": 128000,
-			"maxTokens": 32768,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
 			}
 		},
 		"aion-labs.aion-2-0": {
@@ -74573,28 +74080,6 @@
 				}
 			}
 		},
-		"e2ee-deepseek-v4-flash": {
-			"id": "e2ee-deepseek-v4-flash",
-			"name": "e2ee-deepseek-v4-flash",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1000000,
-			"maxTokens": 1048576,
-			"compat": {
-				"supportsUsageInStreaming": false
-			}
-		},
 		"e2ee-gemma-3-27b-p": {
 			"id": "e2ee-gemma-3-27b-p",
 			"name": "e2ee-gemma-3-27b-p",
@@ -74877,28 +74362,6 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": null,
-			"compat": {
-				"supportsUsageInStreaming": false
-			}
-		},
-		"e2ee-qwen3-6-27b": {
-			"id": "e2ee-qwen3-6-27b",
-			"name": "e2ee-qwen3-6-27b",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": 65536,
 			"compat": {
 				"supportsUsageInStreaming": false
 			}
@@ -75370,36 +74833,6 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 32000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
-		},
-		"grok-4-5": {
-			"id": "grok-4-5",
-			"name": "Grok 4.5",
-			"api": "openai-completions",
-			"provider": "venice",
-			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2.27,
-				"output": 6.8,
-				"cacheRead": 0.57,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
 			"maxTokens": 32000,
 			"thinking": {
 				"mode": "effort",
@@ -79666,7 +79099,7 @@
 		},
 		"minimax/minimax-m3": {
 			"id": "minimax/minimax-m3",
-			"name": "MiniMax M3",
+			"name": "MiniMax-M3",
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
@@ -82124,36 +81557,6 @@
 				]
 			}
 		},
-		"xai/grok-4.5": {
-			"id": "xai/grok-4.5",
-			"name": "Grok 4.5",
-			"api": "anthropic-messages",
-			"provider": "vercel-ai-gateway",
-			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"thinking": {
-				"mode": "budget",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
-		},
 		"xai/grok-build-0.1": {
 			"id": "xai/grok-build-0.1",
 			"name": "Grok Build 0.1",
@@ -83713,7 +83116,6 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
 					"high"
@@ -83978,15 +83380,10 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
 					"low",
 					"medium",
-					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "low"
-				}
+					"high"
+				]
 			},
 			"compat": {
 				"reasoningEffortMap": {
@@ -86975,25 +86372,6 @@
 				]
 			}
 		},
-		"kuaishou/kat-coder-air-v2.5": {
-			"id": "kuaishou/kat-coder-air-v2.5",
-			"name": "KAT-Coder-Air-V2.5",
-			"api": "openai-completions",
-			"provider": "zenmux",
-			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.135,
-				"output": 0.54,
-				"cacheRead": 0.027,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": null
-		},
 		"kuaishou/kat-coder-pro-v1": {
 			"id": "kuaishou/kat-coder-pro-v1",
 			"name": "KAT-Coder-Pro-V1",
@@ -87050,25 +86428,6 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 80000
-		},
-		"kuaishou/kat-coder-pro-v2.5": {
-			"id": "kuaishou/kat-coder-pro-v2.5",
-			"name": "KAT-Coder-Pro-V2.5",
-			"api": "openai-completions",
-			"provider": "zenmux",
-			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0.444,
-				"output": 1.776,
-				"cacheRead": 0.09,
-				"cacheWrite": 0
-			},
-			"contextWindow": 256000,
-			"maxTokens": null
 		},
 		"meituan/longcat-2.0": {
 			"id": "meituan/longcat-2.0",
@@ -89187,9 +88546,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.1323,
-				"output": 0.5301,
-				"cacheRead": 0.0333,
+				"input": 0.134561595,
+				"output": 0.539161765,
+				"cacheRead": 0.033869245,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -89632,66 +88991,6 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
-		},
-		"x-ai/grok-4.5": {
-			"id": "x-ai/grok-4.5",
-			"name": "Grok 4.5",
-			"api": "openai-completions",
-			"provider": "zenmux",
-			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 2,
-				"output": 6,
-				"cacheRead": 0.5,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			}
-		},
-		"x-ai/grok-4.5-free": {
-			"id": "x-ai/grok-4.5-free",
-			"name": "Grok 4.5 (Free)",
-			"api": "openai-completions",
-			"provider": "zenmux",
-			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 500000,
-			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -414,7 +414,7 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "xai-oauth",
-		defaultModel: "grok-4.3",
+		defaultModel: "grok-4.5",
 		envVars: ["XAI_OAUTH_TOKEN", "XAI_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => xaiOAuthModelManagerOptions(config),
 		catalogDiscovery: {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -968,6 +968,11 @@ interface XAICuratedModel {
 // omit/include/history replay defaults live in catalog compat so every
 // OpenAI-family endpoint consumes the same constraint.
 export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
+	// xAI's flagship (docs.x.ai/developers/models/grok-4.5): 500K context,
+	// text+image, reasoning with the wire effort dial (low/medium/high;
+	// rejects "none", unlike grok-4.3 — verified live 2026-07-08, matches
+	// models.dev). Aliases: grok-4.5-latest, grok-build-latest.
+	{ id: "grok-4.5", contextWindow: 500_000, name: "Grok 4.5", input: ["text", "image"] },
 	{
 		id: "grok-build",
 		contextWindow: 512_000,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -926,7 +926,21 @@ export interface XaiModelManagerConfig {
 }
 
 export function xaiModelManagerOptions(config?: XaiModelManagerConfig): ModelManagerOptions<"openai-completions"> {
-	return createSimpleOpenAICompletionsOptions("xai", "https://api.x.ai/v1", config);
+	const options = createSimpleOpenAICompletionsOptions("xai", "https://api.x.ai/v1", config);
+	const fetchDynamic = options.fetchDynamicModels;
+	if (!fetchDynamic) {
+		return options;
+	}
+	// Direct xAI /v1/models may return the grok-4.5 aliases (grok-4.5-latest /
+	// grok-build-latest); drop them so the bundled `xai/grok-4.5` entry owns the
+	// reasoning/vision/limit metadata instead of an alias with discovery defaults.
+	return {
+		...options,
+		fetchDynamicModels: async () => {
+			const models = await fetchDynamic();
+			return models === null ? null : models.filter(model => !Object.hasOwn(XAI_CANONICALIZED_ALIAS_IDS, model.id));
+		},
+	};
 }
 
 export interface XaiOAuthModelManagerConfig {
@@ -1022,11 +1036,12 @@ export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
 const XAI_NON_CHAT_PREFIXES = ["grok-imagine-", "grok-stt-", "grok-voice-"] as const;
 
 // Documented grok-4.5 aliases (docs.x.ai/developers/models/grok-4.5). xAI's
-// /v1/models may surface these instead of the canonical `grok-4.5`; they resolve
-// to the same model. Drop them so the curated/injected `grok-4.5` entry owns the
-// metadata rather than an alias falling through to discovery defaults
-// (reasoning:false, text-only, null limits).
-const XAI_OAUTH_CANONICALIZED_ALIAS_IDS: Record<string, true> = {
+// /v1/models may surface these instead of the canonical `grok-4.5` on both the
+// direct `xai` and `xai-oauth` surfaces; they resolve to the same model. Drop
+// them so the curated/bundled `grok-4.5` entry owns the metadata rather than an
+// alias falling through to discovery defaults (reasoning:false, text-only,
+// null limits).
+const XAI_CANONICALIZED_ALIAS_IDS: Record<string, true> = {
 	"grok-4.5-latest": true,
 	"grok-build-latest": true,
 };
@@ -1115,9 +1130,7 @@ export function applyXAIOAuthCuration(
 	dynamic: readonly ModelSpec<"openai-responses">[],
 ): ModelSpec<"openai-responses">[] {
 	const filtered = dynamic.filter(
-		e =>
-			!XAI_NON_CHAT_PREFIXES.some(p => e.id.startsWith(p)) &&
-			!Object.hasOwn(XAI_OAUTH_CANONICALIZED_ALIAS_IDS, e.id),
+		e => !XAI_NON_CHAT_PREFIXES.some(p => e.id.startsWith(p)) && !Object.hasOwn(XAI_CANONICALIZED_ALIAS_IDS, e.id),
 	);
 
 	const byId = new Map<string, ModelSpec<"openai-responses">>(filtered.map(e => [e.id, e]));

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1021,6 +1021,16 @@ export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
 // strings; the chat picker MUST exclude these prefixes or selecting them 400s.
 const XAI_NON_CHAT_PREFIXES = ["grok-imagine-", "grok-stt-", "grok-voice-"] as const;
 
+// Documented grok-4.5 aliases (docs.x.ai/developers/models/grok-4.5). xAI's
+// /v1/models may surface these instead of the canonical `grok-4.5`; they resolve
+// to the same model. Drop them so the curated/injected `grok-4.5` entry owns the
+// metadata rather than an alias falling through to discovery defaults
+// (reasoning:false, text-only, null limits).
+const XAI_OAUTH_CANONICALIZED_ALIAS_IDS: Record<string, true> = {
+	"grok-4.5-latest": true,
+	"grok-build-latest": true,
+};
+
 function withXaiOAuthCompatDefaults(model: ModelSpec<"openai-responses">): ModelSpec<"openai-responses"> {
 	const compat = {
 		...(model.compat ?? {}),
@@ -1101,8 +1111,14 @@ function mergeCuratedIntoModel(
  * Order: curated models first in declaration order; then dynamic remainder
  * in original order.
  */
-function applyXAIOAuthCuration(dynamic: readonly ModelSpec<"openai-responses">[]): ModelSpec<"openai-responses">[] {
-	const filtered = dynamic.filter(e => !XAI_NON_CHAT_PREFIXES.some(p => e.id.startsWith(p)));
+export function applyXAIOAuthCuration(
+	dynamic: readonly ModelSpec<"openai-responses">[],
+): ModelSpec<"openai-responses">[] {
+	const filtered = dynamic.filter(
+		e =>
+			!XAI_NON_CHAT_PREFIXES.some(p => e.id.startsWith(p)) &&
+			!Object.hasOwn(XAI_OAUTH_CANONICALIZED_ALIAS_IDS, e.id),
+	);
 
 	const byId = new Map<string, ModelSpec<"openai-responses">>(filtered.map(e => [e.id, e]));
 	for (const curated of XAI_OAUTH_CURATED_MODELS) {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1145,10 +1145,19 @@ export function applyXAIOAuthCuration(
 	if (template) {
 		for (const curated of XAI_OAUTH_CURATED_MODELS) {
 			if (!byId.has(curated.id)) {
-				// Reset id/name on the template before merging so the helper's
-				// `curated.name ?? base.name` clause falls back to curated.id
-				// (the inject contract), not to the unrelated template's label.
-				const base: ModelSpec<"openai-responses"> = { ...template, id: curated.id, name: curated.id };
+				// Reset id/name AND compat on the template before merging: the template
+				// is a structural donor (api/provider/baseUrl/cost) only. Its `compat`
+				// belongs to an unrelated model (e.g. grok-build's
+				// `omitReasoningEffort: true`) and must not leak into the injected
+				// curated entry — `mergeCuratedIntoModel` recomputes compat (including
+				// `omitReasoningEffort`) from the curated id, and `curated.name ??
+				// base.name` falls back to curated.id (the inject contract).
+				const base: ModelSpec<"openai-responses"> = {
+					...template,
+					id: curated.id,
+					name: curated.id,
+					compat: undefined,
+				};
 				byId.set(curated.id, mergeCuratedIntoModel(base, curated));
 			}
 		}

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -171,6 +171,10 @@ describe("xAI-OAuth Responses reasoning-effort suppression", () => {
 		expect(buildOpenAIResponsesCompat(grokResponsesSpec("grok-4.3")).supportsReasoningEffort).toBe(true);
 	});
 
+	it("keeps the effort dial for a custom grok-4.5 spec (on the allowlist)", () => {
+		expect(buildOpenAIResponsesCompat(grokResponsesSpec("grok-4.5")).supportsReasoningEffort).toBe(true);
+	});
+
 	it("lets an explicit compat.supportsReasoningEffort override the allowlist default", () => {
 		const compat = buildOpenAIResponsesCompat({
 			...grokResponsesSpec("grok-build"),

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -264,7 +264,10 @@ describe("isGrokReasoningEffortCapable", () => {
 		expect(isGrokReasoningEffortCapable("grok-4.3")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-3-mini")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-4.20-multi-agent")).toBe(true);
+		expect(isGrokReasoningEffortCapable("grok-4.5")).toBe(true);
+		expect(isGrokReasoningEffortCapable("grok-4.5-latest")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.3")).toBe(true);
+		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.5")).toBe(true);
 		expect(isGrokReasoningEffortCapable("openrouter/xai/grok-3-mini")).toBe(true);
 	});
 

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -267,6 +267,7 @@ describe("isGrokReasoningEffortCapable", () => {
 		expect(isGrokReasoningEffortCapable("grok-4.20-multi-agent")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-4.5")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-4.5-latest")).toBe(true);
+		expect(isGrokReasoningEffortCapable("grok-build-latest")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.3")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.5")).toBe(true);
 		expect(isGrokReasoningEffortCapable("openrouter/xai/grok-3-mini")).toBe(true);
@@ -274,6 +275,7 @@ describe("isGrokReasoningEffortCapable", () => {
 
 	test("rejects effort-dial-less Grok SKUs and non-Grok ids", () => {
 		expect(isGrokReasoningEffortCapable("grok-build")).toBe(false);
+		expect(isGrokReasoningEffortCapable("grok-build-0.1")).toBe(false);
 		expect(isGrokReasoningEffortCapable("grok-4.20-0309-reasoning")).toBe(false);
 		expect(isGrokReasoningEffortCapable("gpt-5")).toBe(false);
 		expect(isGrokReasoningEffortCapable("")).toBe(false);
@@ -284,6 +286,7 @@ describe("isGrok45ReasoningModelId", () => {
 	test("matches grok-4.5 ids across namespaces and aliases", () => {
 		expect(isGrok45ReasoningModelId("grok-4.5")).toBe(true);
 		expect(isGrok45ReasoningModelId("grok-4.5-latest")).toBe(true);
+		expect(isGrok45ReasoningModelId("grok-build-latest")).toBe(true);
 		expect(isGrok45ReasoningModelId("xai-oauth/grok-4.5")).toBe(true);
 		expect(isGrok45ReasoningModelId("openrouter/xai/grok-4.5")).toBe(true);
 	});
@@ -294,6 +297,7 @@ describe("isGrok45ReasoningModelId", () => {
 		expect(isGrok45ReasoningModelId("grok-4")).toBe(false);
 		expect(isGrok45ReasoningModelId("grok-3-mini")).toBe(false);
 		expect(isGrok45ReasoningModelId("grok-build")).toBe(false);
+		expect(isGrok45ReasoningModelId("grok-build-0.1")).toBe(false);
 		expect(isGrok45ReasoningModelId("")).toBe(false);
 	});
 });

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -3,6 +3,7 @@ import {
 	hasOpus47ApiRestrictions,
 	isClaudeModelId,
 	isGlmVisionModelId,
+	isGrok45ReasoningModelId,
 	isGrokReasoningEffortCapable,
 	isKimiK26ModelId,
 	isKimiModelId,
@@ -276,5 +277,23 @@ describe("isGrokReasoningEffortCapable", () => {
 		expect(isGrokReasoningEffortCapable("grok-4.20-0309-reasoning")).toBe(false);
 		expect(isGrokReasoningEffortCapable("gpt-5")).toBe(false);
 		expect(isGrokReasoningEffortCapable("")).toBe(false);
+	});
+});
+
+describe("isGrok45ReasoningModelId", () => {
+	test("matches grok-4.5 ids across namespaces and aliases", () => {
+		expect(isGrok45ReasoningModelId("grok-4.5")).toBe(true);
+		expect(isGrok45ReasoningModelId("grok-4.5-latest")).toBe(true);
+		expect(isGrok45ReasoningModelId("xai-oauth/grok-4.5")).toBe(true);
+		expect(isGrok45ReasoningModelId("openrouter/xai/grok-4.5")).toBe(true);
+	});
+
+	test("rejects non-4.5 Grok SKUs and empty ids", () => {
+		expect(isGrok45ReasoningModelId("grok-4.3")).toBe(false);
+		expect(isGrok45ReasoningModelId("grok-4.20-multi-agent")).toBe(false);
+		expect(isGrok45ReasoningModelId("grok-4")).toBe(false);
+		expect(isGrok45ReasoningModelId("grok-3-mini")).toBe(false);
+		expect(isGrok45ReasoningModelId("grok-build")).toBe(false);
+		expect(isGrok45ReasoningModelId("")).toBe(false);
 	});
 });

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -581,18 +581,41 @@ describe("model thinking derivation", () => {
 			provider: "xai",
 			reasoning: true,
 		});
+		// custom OpenAI-compatible config pointed at api.x.ai must get the same
+		// low/medium/high cap — host detection already enables reasoning_effort,
+		// so without this the default ladder would expose xhigh (xAI 400s).
+		const customXai = createModel({
+			id: "grok-4.5",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://api.x.ai/v1",
+			reasoning: true,
+		});
+		// Documented alias (docs.x.ai/developers/models/grok-4.5) must inherit
+		// the Grok 4.5 effort/mandatory-reasoning contract, not discovery defaults.
+		const buildLatest = createModel({
+			id: "grok-build-latest",
+			api: "openai-completions",
+			provider: "xai",
+			reasoning: true,
+		});
 
 		const expected = [Effort.Low, Effort.Medium, Effort.High];
 		expect(getSupportedEfforts(oauth)).toEqual(expected);
 		expect(getSupportedEfforts(direct)).toEqual(expected);
+		expect(getSupportedEfforts(customXai)).toEqual(expected);
+		expect(getSupportedEfforts(buildLatest)).toEqual(expected);
 		expect(getSupportedEfforts(oauth)).not.toContain(Effort.XHigh);
 		expect(getSupportedEfforts(oauth)).not.toContain(Effort.Minimal);
 		expect(getSupportedEfforts(direct)).not.toContain(Effort.XHigh);
 		expect(getSupportedEfforts(direct)).not.toContain(Effort.Minimal);
+		expect(getSupportedEfforts(customXai)).not.toContain(Effort.XHigh);
 		// grok-4.5 reasoning cannot be disabled: mandatory-reasoning flag is set and
 		// a thinking-off request clamps to the lowest supported effort (low), not omit.
 		expect(oauth.thinking?.requiresEffort).toBe(true);
 		expect(direct.thinking?.requiresEffort).toBe(true);
+		expect(customXai.thinking?.requiresEffort).toBe(true);
+		expect(buildLatest.thinking?.requiresEffort).toBe(true);
 		expect(minimumSupportedEffort(oauth)).toBe(Effort.Low);
 		expect(minimumSupportedEffort(direct)).toBe(Effort.Low);
 		// Direct xAI chat-completions must actually send reasoning_effort for
@@ -602,6 +625,8 @@ describe("model thinking derivation", () => {
 		expect(oauth.compat.supportsReasoningEffort).toBe(true);
 		expect(direct.compat.supportsReasoningEffort).toBe(true);
 		expect(direct.compat.omitReasoningEffort).toBe(false);
+		expect(buildLatest.compat.supportsReasoningEffort).toBe(true);
+		expect(buildLatest.compat.omitReasoningEffort).toBe(false);
 	});
 
 	it("keeps reasoning effort disabled for other direct xAI Grok models", () => {

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -567,6 +567,29 @@ describe("model thinking derivation", () => {
 		expect(getSupportedEfforts(model)).toEqual([]);
 		expect(clampThinkingLevelForModel(model, Effort.High)).toBeUndefined();
 	});
+
+	it("caps grok-4.5 efforts to low/medium/high on xai and xai-oauth", () => {
+		const oauth = createModel({
+			id: "grok-4.5",
+			api: "openai-responses",
+			provider: "xai-oauth",
+			reasoning: true,
+		});
+		const direct = createModel({
+			id: "grok-4.5",
+			api: "openai-completions",
+			provider: "xai",
+			reasoning: true,
+		});
+
+		const expected = [Effort.Low, Effort.Medium, Effort.High];
+		expect(getSupportedEfforts(oauth)).toEqual(expected);
+		expect(getSupportedEfforts(direct)).toEqual(expected);
+		expect(getSupportedEfforts(oauth)).not.toContain(Effort.XHigh);
+		expect(getSupportedEfforts(oauth)).not.toContain(Effort.Minimal);
+		expect(getSupportedEfforts(direct)).not.toContain(Effort.XHigh);
+		expect(getSupportedEfforts(direct)).not.toContain(Effort.Minimal);
+	});
 });
 
 describe("model thinking runtime helpers", () => {

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -568,7 +568,7 @@ describe("model thinking derivation", () => {
 		expect(clampThinkingLevelForModel(model, Effort.High)).toBeUndefined();
 	});
 
-	it("caps grok-4.5 efforts to low/medium/high on xai and xai-oauth", () => {
+	it("caps grok-4.5 efforts and marks reasoning mandatory on xai and xai-oauth", () => {
 		const oauth = createModel({
 			id: "grok-4.5",
 			api: "openai-responses",
@@ -589,6 +589,12 @@ describe("model thinking derivation", () => {
 		expect(getSupportedEfforts(oauth)).not.toContain(Effort.Minimal);
 		expect(getSupportedEfforts(direct)).not.toContain(Effort.XHigh);
 		expect(getSupportedEfforts(direct)).not.toContain(Effort.Minimal);
+		// grok-4.5 reasoning cannot be disabled: mandatory-reasoning flag is set and
+		// a thinking-off request clamps to the lowest supported effort (low), not omit.
+		expect(oauth.thinking?.requiresEffort).toBe(true);
+		expect(direct.thinking?.requiresEffort).toBe(true);
+		expect(minimumSupportedEffort(oauth)).toBe(Effort.Low);
+		expect(minimumSupportedEffort(direct)).toBe(Effort.Low);
 	});
 });
 

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -595,6 +595,26 @@ describe("model thinking derivation", () => {
 		expect(direct.thinking?.requiresEffort).toBe(true);
 		expect(minimumSupportedEffort(oauth)).toBe(Effort.Low);
 		expect(minimumSupportedEffort(direct)).toBe(Effort.Low);
+		// Direct xAI chat-completions must actually send reasoning_effort for
+		// grok-4.5 (docs.x.ai); the family-wide !isGrok gate is overridden for
+		// grok-4.5 so the mandatory-reasoning clamp reaches the wire instead of
+		// being silently omitted (which would run xAI's default high effort).
+		expect(oauth.compat.supportsReasoningEffort).toBe(true);
+		expect(direct.compat.supportsReasoningEffort).toBe(true);
+		expect(direct.compat.omitReasoningEffort).toBe(false);
+	});
+
+	it("keeps reasoning effort disabled for other direct xAI Grok models", () => {
+		// The direct-xAI reasoning-effort override is scoped to grok-4.5; the
+		// family-wide !isGrok gate still disables reasoning_effort for older Grok
+		// chat-completions models, so this stays false.
+		const grok43 = createModel({
+			id: "grok-4.3",
+			api: "openai-completions",
+			provider: "xai",
+			reasoning: true,
+		});
+		expect(grok43.compat.supportsReasoningEffort).toBe(false);
 	});
 });
 

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -63,6 +63,15 @@ describe("xai-oauth bundled catalog (regression)", () => {
 		expect(bundled["grok-composer-2.5-fast"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 	});
 
+	it("exposes grok-4.5 as a reasoning 500K text+image model", () => {
+		const grok45 = seed.find(model => model.id === "grok-4.5");
+		expect(grok45, "grok-4.5 must be in the SuperGrok curated seed").toBeDefined();
+		expect(grok45!.reasoning).toBe(true);
+		expect(grok45!.contextWindow).toBe(500_000);
+		expect(grok45!.input).toEqual(["text", "image"]);
+		expect(bundled["grok-4.5"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
+
 	// The OAuth surface's /v1/models reports no per-request output limit, so the
 	// curated catalog owns maxTokens — set to mirror each model's contextWindow
 	// (the openai-responses wire still clamps the actual request to

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import MODELS_JSON from "@oh-my-pi/pi-catalog/models.json" with { type: "json" };
-import { buildXaiOAuthStaticSeed } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import { applyXAIOAuthCuration, buildXaiOAuthStaticSeed } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 // Pins the invariant: bundled `models.json` carries every entry the runtime
@@ -83,5 +83,77 @@ describe("xai-oauth bundled catalog (regression)", () => {
 			expect(model.maxTokens, `seed ${model.id} maxTokens`).toBe(model.contextWindow);
 			expect(bundled[model.id]?.maxTokens, `bundled ${model.id} maxTokens`).toBe(model.contextWindow);
 		}
+	});
+
+	// Documented grok-4.5 aliases (docs.x.ai/developers/models/grok-4.5) may
+	// appear in /v1/models; dropping them keeps the curated grok-4.5 entry as
+	// the sole owner of vision/reasoning/context metadata.
+	it("drops grok-4.5-latest and grok-build-latest aliases during curation", () => {
+		const dynamic: ModelSpec<"openai-responses">[] = [
+			{
+				id: "grok-4.5-latest",
+				name: "Grok 4.5 Latest",
+				api: "openai-responses",
+				provider: "xai-oauth",
+				baseUrl: "https://api.x.ai/v1",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 128_000,
+			},
+			{
+				id: "grok-build-latest",
+				name: "Grok Build Latest",
+				api: "openai-responses",
+				provider: "xai-oauth",
+				baseUrl: "https://api.x.ai/v1",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 128_000,
+			},
+			{
+				id: "grok-4.5",
+				name: "Grok 4.5 (raw)",
+				api: "openai-responses",
+				provider: "xai-oauth",
+				baseUrl: "https://api.x.ai/v1",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 128_000,
+			},
+			{
+				id: "grok-4.3",
+				name: "Grok 4.3 (raw)",
+				api: "openai-responses",
+				provider: "xai-oauth",
+				baseUrl: "https://api.x.ai/v1",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 128_000,
+			},
+		];
+
+		const curated = applyXAIOAuthCuration(dynamic);
+		const ids = curated.map(model => model.id);
+		expect(ids).not.toContain("grok-4.5-latest");
+		expect(ids).not.toContain("grok-build-latest");
+		expect(ids).toContain("grok-4.5");
+		expect(ids).toContain("grok-4.3");
+
+		const grok45 = curated.find(model => model.id === "grok-4.5");
+		expect(grok45).toBeDefined();
+		if (!grok45) {
+			return;
+		}
+		expect(grok45.reasoning).toBe(true);
+		expect(grok45.input).toContain("image");
+		expect(grok45.contextWindow).toBe(500_000);
 	});
 });

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -156,4 +156,51 @@ describe("xai-oauth bundled catalog (regression)", () => {
 		expect(grok45.input).toContain("image");
 		expect(grok45.contextWindow).toBe(500_000);
 	});
+
+	// Inject path must not leak the structural template's compat into the
+	// curated entry. When /v1/models returns only a non-effort model
+	// (grok-build with omitReasoningEffort:true) and omits grok-4.5, the
+	// inject pass clones that entry as a template — without resetting
+	// compat, grok-4.5 inherits omitReasoningEffort:true and silently
+	// drops the user's low/medium effort dial.
+	it("resets template compat when injecting missing curated models", () => {
+		const dynamic: ModelSpec<"openai-responses">[] = [
+			{
+				id: "grok-build",
+				name: "Grok Build (raw)",
+				api: "openai-responses",
+				provider: "xai-oauth",
+				baseUrl: "https://api.x.ai/v1",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128_000,
+				maxTokens: 128_000,
+				compat: { omitReasoningEffort: true },
+			},
+		];
+
+		const curated = applyXAIOAuthCuration(dynamic);
+
+		const grok45 = curated.find(model => model.id === "grok-4.5");
+		expect(grok45).toBeDefined();
+		if (!grok45) {
+			return;
+		}
+		// Injected effort-capable model must recompute omitReasoningEffort
+		// from its own id, not inherit the template's true.
+		expect(grok45.compat?.omitReasoningEffort).toBe(false);
+		expect(grok45.reasoning).toBe(true);
+		expect(grok45.contextWindow).toBe(500_000);
+		expect(grok45.input).toContain("image");
+
+		// Overlay path still preserves the non-effort contract for the
+		// template model itself (curated supportsReasoningEffort:false).
+		const grokBuild = curated.find(model => model.id === "grok-build");
+		expect(grokBuild).toBeDefined();
+		if (!grokBuild) {
+			return;
+		}
+		expect(grokBuild.compat?.omitReasoningEffort).toBe(true);
+	});
 });

--- a/packages/catalog/test/xai-provider.test.ts
+++ b/packages/catalog/test/xai-provider.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, vi } from "bun:test";
+import { xaiModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+describe("xAI provider discovery", () => {
+	// Documented grok-4.5 aliases (docs.x.ai/developers/models/grok-4.5) may
+	// surface from /v1/models; drop them so the bundled xai/grok-4.5 entry owns
+	// reasoning/vision/limit metadata instead of an alias with discovery defaults.
+	test("drops grok-4.5-latest and grok-build-latest aliases from dynamic discovery", async () => {
+		const fetchMock: FetchImpl = vi.fn(async (input, init) => {
+			const url = String(input);
+			expect(url).toBe("https://api.x.ai/v1/models");
+			expect(new Headers(init?.headers).get("authorization")).toBe("Bearer xai-test-key");
+			return new Response(
+				JSON.stringify({
+					object: "list",
+					data: [
+						{ id: "grok-4.5", object: "model" },
+						{ id: "grok-4.5-latest", object: "model" },
+						{ id: "grok-build-latest", object: "model" },
+						{ id: "grok-4-fast", object: "model" },
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		});
+
+		const options = xaiModelManagerOptions({ apiKey: "xai-test-key", fetch: fetchMock });
+		const models = await options.fetchDynamicModels?.();
+		const ids = models?.map(model => model.id) ?? [];
+
+		expect(ids).toContain("grok-4.5");
+		expect(ids).toContain("grok-4-fast");
+		expect(ids).not.toContain("grok-4.5-latest");
+		expect(ids).not.toContain("grok-build-latest");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

Grok 4.5 is now available through the bundled xAI catalog, including the SuperGrok-backed `xai-oauth` provider. The OAuth catalog now treats Grok 4.5 as the headline/default model, while the plain xAI source default remains unchanged.

## Details

- Adds `grok-4.5` to the Grok reasoning-effort allowlist so the effort dial applies to `grok-4.5` and `grok-4.5-latest`.
- Adds the curated `xai-oauth/grok-4.5` entry with 500K context, text+image input, reasoning defaults, and zero OAuth cost.
- Regenerates `models.json`, including the paid `xai/grok-4.5` entry from upstream catalog data and normal generated provider drift.
- Pins the catalog-facing invariants in focused tests.

## Validation

- `bun check`
- `cd packages/catalog && bun test test/identity-family.test.ts test/build.test.ts test/xai-oauth-bundle.test.ts test/model-thinking.test.ts test/canonical-limit-fallback.test.ts` — `96 pass`, `0 fail`.

Closes #4889
