### PR TITLE
fix(coding-agent): refresh expired OAuth discovery credentials

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -689,6 +689,7 @@ export interface OAuthAccessFailure {
  * key usage on it (Gemini CLI / Antigravity).
  */
 export interface OAuthAccountIdentity {
+	credentialId?: number;
 	accountId?: string;
 	email?: string;
 	projectId?: string;
@@ -1953,7 +1954,13 @@ export class AuthStorage {
 		if (typeof preferred.projectId === "string" && preferred.projectId.length > 0) {
 			identity.projectId = preferred.projectId;
 		}
-		if (!identity.accountId && !identity.email && !identity.projectId) return undefined;
+		const credentialEntry = this.#getStoredCredentials(provider).find(entry => entry.credential === preferred);
+		if (credentialEntry) {
+			identity.credentialId = credentialEntry.id;
+		}
+		if (!identity.accountId && !identity.email && !identity.projectId && identity.credentialId === undefined) {
+			return undefined;
+		}
 		return identity;
 	}
 

--- a/packages/ai/test/auth-storage-account-identity.test.ts
+++ b/packages/ai/test/auth-storage-account-identity.test.ts
@@ -48,14 +48,36 @@ describe("AuthStorage.getOAuthAccountIdentity", () => {
 				projectId: "gcp-project-a",
 			},
 		]);
-		expect(authStorage.getOAuthAccountIdentity(PROVIDER)).toEqual({
-			accountId: "acc-a",
-			email: "a@example.com",
-			projectId: "gcp-project-a",
-		});
+		const identity = authStorage.getOAuthAccountIdentity(PROVIDER);
+		// accountId/email/projectId remain the primary identity surface.
+		expect(identity?.accountId).toBe("acc-a");
+		expect(identity?.email).toBe("a@example.com");
+		expect(identity?.projectId).toBe("gcp-project-a");
+		// Stable DB row id is also exposed for cache-key fallbacks.
+		expect(typeof identity?.credentialId).toBe("number");
 	});
 
-	test("drops empty-string fields and returns undefined when no field survives", async () => {
+	test("returns credentialId-only identity when OAuth has no account fields", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		await authStorage.set(PROVIDER, [
+			{
+				type: "oauth",
+				access: "access-a",
+				refresh: "refresh-a",
+				expires: Date.now() + 60 * 60_000,
+			},
+		]);
+		const identity = authStorage.getOAuthAccountIdentity(PROVIDER);
+		// GitLab Duo-style OAuth often lacks accountId/email; the stable row id
+		// must still produce a non-colliding identity for discovery caches.
+		expect(identity).toBeDefined();
+		expect(typeof identity?.credentialId).toBe("number");
+		expect(identity?.accountId).toBeUndefined();
+		expect(identity?.email).toBeUndefined();
+		expect(identity?.projectId).toBeUndefined();
+	});
+
+	test("drops empty-string account fields but keeps credentialId", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 		await authStorage.set(PROVIDER, [
 			{
@@ -67,7 +89,54 @@ describe("AuthStorage.getOAuthAccountIdentity", () => {
 				email: "",
 			},
 		]);
-		expect(authStorage.getOAuthAccountIdentity(PROVIDER)).toBeUndefined();
+		const identity = authStorage.getOAuthAccountIdentity(PROVIDER);
+		expect(identity).toBeDefined();
+		expect(typeof identity?.credentialId).toBe("number");
+		expect(identity?.accountId).toBeUndefined();
+		expect(identity?.email).toBeUndefined();
+	});
+
+	test("distinct identity-less OAuth credentials get distinct credentialIds", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		const storage = authStorage;
+		await storage.set(PROVIDER, [
+			{
+				type: "oauth",
+				access: "access-a",
+				refresh: "refresh-a",
+				expires: Date.now() + 60 * 60_000,
+			},
+			{
+				type: "oauth",
+				access: "access-b",
+				refresh: "refresh-b",
+				expires: Date.now() + 60 * 60_000,
+			},
+		]);
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (provider, credentials) => {
+			const credential = credentials[provider];
+			if (!credential) return null;
+			return { newCredentials: credential, apiKey: credential.access };
+		});
+
+		// Pin each session to a different credential so both identity lookups are live.
+		const sessionA = "session-identity-a";
+		const sessionB = "session-identity-b";
+		const keyA = await storage.getApiKey(PROVIDER, sessionA);
+		// Invalidate the first key so the second session is forced onto the sibling credential.
+		const invalidated = await storage.invalidateCredentialMatching(PROVIDER, keyA ?? "", { sessionId: sessionB });
+		expect(invalidated).toBe(true);
+		const keyB = await storage.getApiKey(PROVIDER, sessionB);
+		expect(keyB).not.toBe(keyA);
+
+		const identityA = storage.getOAuthAccountIdentity(PROVIDER, sessionA);
+		const identityB = storage.getOAuthAccountIdentity(PROVIDER, sessionB);
+		// Cache keys must differ when accountId/email are absent; credentialId is the differentiator.
+		expect(typeof identityA?.credentialId).toBe("number");
+		expect(typeof identityB?.credentialId).toBe("number");
+		expect(identityA?.credentialId).not.toBe(identityB?.credentialId);
+		expect(identityA?.accountId).toBeUndefined();
+		expect(identityB?.accountId).toBeUndefined();
 	});
 
 	test("follows the session-sticky credential across rotation", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- GitLab Duo built-in discovery now keys its per-credential model cache to the OAuth account identity in preference to a configured token (`cacheIdentity ?? configuredApiKey`), matching the discovery fetch bearer precedence so a mixed stored-OAuth-plus-token setup no longer caches one account's namespace models under the other account's cache key.
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/catalog/src/provider-models/descriptor-types.ts
+++ b/packages/catalog/src/provider-models/descriptor-types.ts
@@ -2,7 +2,13 @@ import type { ModelManagerOptions } from "../model-manager";
 import type { Api, FetchImpl } from "../types";
 
 /** Config passed to a provider's runtime model-manager factory. */
-export type ModelManagerConfig = { apiKey?: string; baseUrl?: string; fetch?: FetchImpl };
+export type ModelManagerConfig = {
+	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
+	cacheIdentity?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+};
 
 /** Catalog discovery configuration for providers that support endpoint-based model listing. */
 export interface CatalogDiscoveryConfig {

--- a/packages/catalog/src/provider-models/ollama.ts
+++ b/packages/catalog/src/provider-models/ollama.ts
@@ -8,6 +8,7 @@ import { createBundledReferenceMap, createReferenceResolver } from "./bundled-re
 
 export interface OllamaCloudModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -95,15 +96,16 @@ async function fetchShowMetadata(
 export function ollamaCloudModelManagerOptions(
 	config?: OllamaCloudModelManagerConfig,
 ): ModelManagerOptions<"ollama-chat"> {
-	const apiKey = config?.apiKey;
+	const configuredApiKey = config?.apiKey;
 	const baseUrl = normalizeOllamaCloudBaseUrl(config?.baseUrl);
 	const providerReferences = createBundledReferenceMap<"ollama-chat">("ollama-cloud");
 	const resolveReference = createReferenceResolver(providerReferences);
 	return {
 		providerId: "ollama-cloud",
 		fetchDynamicModels: async () => {
+			const apiKey = (config?.getApiKey ? await config.getApiKey() : undefined) ?? configuredApiKey;
 			if (!apiKey) {
-				return [];
+				return null;
 			}
 			const response = await fetchWithRetry(`${baseUrl}/api/tags`, {
 				method: "GET",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -510,10 +510,19 @@ function isLikelyNanoGptTextModelId(id: string): boolean {
 type SimpleProviderDiscoveryHeaders = Record<string, string> | (() => Record<string, string> | undefined);
 type SimpleProviderConfig = {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 	headers?: SimpleProviderDiscoveryHeaders;
 };
+
+function hasSimpleProviderApiKey(config: SimpleProviderConfig | undefined): boolean {
+	return Boolean(config?.apiKey || config?.getApiKey);
+}
+
+async function resolveSimpleProviderApiKey(config: SimpleProviderConfig | undefined): Promise<string | undefined> {
+	return (config?.getApiKey ? await config.getApiKey() : undefined) ?? config?.apiKey;
+}
 
 function resolveSimpleProviderHeaders(
 	headers: SimpleProviderDiscoveryHeaders | undefined,
@@ -526,14 +535,15 @@ export function createSimpleOpenAICompletionsOptions(
 	defaultBaseUrl: string,
 	config?: SimpleProviderConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? defaultBaseUrl;
 	const references = createBundledReferenceMap<"openai-completions">(providerId);
 	return {
 		providerId,
-		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels({
+		...(hasSimpleProviderApiKey(config) && {
+			fetchDynamicModels: async () => {
+				const apiKey = await resolveSimpleProviderApiKey(config);
+				if (!apiKey) return null;
+				return fetchOpenAICompatibleModels({
 					api: "openai-completions",
 					provider: providerId,
 					baseUrl,
@@ -544,7 +554,8 @@ export function createSimpleOpenAICompletionsOptions(
 						return mapWithBundledReference(entry, defaults, reference);
 					},
 					fetch: config?.fetch,
-				}),
+				});
+			},
 		}),
 	};
 }
@@ -554,14 +565,15 @@ function createSimpleOpenAIResponsesOptions(
 	defaultBaseUrl: string,
 	config?: SimpleProviderConfig,
 ): ModelManagerOptions<"openai-responses"> {
-	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? defaultBaseUrl;
 	const references = createBundledReferenceMap<"openai-responses">(providerId);
 	return {
 		providerId,
-		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels({
+		...(hasSimpleProviderApiKey(config) && {
+			fetchDynamicModels: async () => {
+				const apiKey = await resolveSimpleProviderApiKey(config);
+				if (!apiKey) return null;
+				return fetchOpenAICompatibleModels({
 					api: "openai-responses",
 					provider: providerId,
 					baseUrl,
@@ -572,7 +584,8 @@ function createSimpleOpenAIResponsesOptions(
 						return mapWithBundledReference(entry, defaults, reference);
 					},
 					fetch: config?.fetch,
-				}),
+				});
+			},
 		}),
 	};
 }
@@ -582,15 +595,16 @@ function createSimpleAnthropicProviderOptions(
 	defaultBaseUrlFallback: string,
 	config?: SimpleProviderConfig,
 ): ModelManagerOptions<"anthropic-messages"> {
-	const apiKey = config?.apiKey;
 	const baseUrl = normalizeAnthropicBaseUrl(config?.baseUrl, defaultBaseUrlFallback);
 	const discoveryBaseUrl = toAnthropicDiscoveryBaseUrl(baseUrl);
 	const references = createBundledReferenceMap<"anthropic-messages">(providerId);
 	return {
 		providerId,
-		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels({
+		...(hasSimpleProviderApiKey(config) && {
+			fetchDynamicModels: async () => {
+				const apiKey = await resolveSimpleProviderApiKey(config);
+				if (!apiKey) return null;
+				return fetchOpenAICompatibleModels({
 					api: "anthropic-messages",
 					provider: providerId,
 					baseUrl: discoveryBaseUrl,
@@ -605,7 +619,8 @@ function createSimpleAnthropicProviderOptions(
 						};
 					},
 					fetch: config?.fetch,
-				}),
+				});
+			},
 		}),
 	};
 }
@@ -931,6 +946,7 @@ export function xaiModelManagerOptions(config?: XaiModelManagerConfig): ModelMan
 
 export interface XaiOAuthModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -1181,11 +1197,10 @@ export function xaiOAuthModelManagerOptions(
 		config,
 	);
 	// Static seed handed to the runtime model manager so the picker populates on
-	// a fresh login even before `fetchDynamicModels` fires (it is gated on
-	// `config.apiKey` at construction time, and OAuth tokens resolve later via
-	// AuthStorage). \`generate-models.ts\` calls the same builder so \`models.json\`
-	// carries these entries too — making the synchronous `#loadModels()` boot
-	// path honor `modelRoles.default = "xai-oauth/<id>"` without `await refresh()`.
+	// a fresh login even before `fetchDynamicModels` runs. `generate-models.ts`
+	// calls the same builder so `models.json` carries these entries too — making
+	// the synchronous `#loadModels()` boot path honor
+	// `modelRoles.default = "xai-oauth/<id>"` without `await refresh()`.
 	const staticModels = buildXaiOAuthStaticSeed(resolvedBaseUrl);
 	if (!base.fetchDynamicModels) {
 		return { ...base, staticModels };
@@ -1688,6 +1703,7 @@ export function firepassModelManagerOptions(
 
 export interface WaferModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -1822,21 +1838,25 @@ function mapWaferModel(
 export function waferServerlessModelManagerOptions(
 	config?: WaferModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	const apiKey = config?.apiKey;
+	const configuredApiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? WAFER_DEFAULT_BASE_URL;
 	const providerId = "wafer-serverless" as const;
+	const hasApiKey = Boolean(configuredApiKey || config?.getApiKey);
 	return {
 		providerId,
-		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels({
+		...(hasApiKey && {
+			fetchDynamicModels: async () => {
+				const apiKey = (config?.getApiKey ? await config.getApiKey() : undefined) ?? configuredApiKey;
+				if (!apiKey) return null;
+				return fetchOpenAICompatibleModels({
 					api: "openai-completions",
 					provider: providerId,
 					baseUrl,
 					apiKey,
 					mapModel: (entry, defaults) => mapWaferModel(providerId, baseUrl, entry, defaults),
 					fetch: config?.fetch,
-				}),
+				});
+			},
 		}),
 	};
 }
@@ -2179,23 +2199,25 @@ export function zenmuxModelManagerOptions(config?: ZenMuxModelManagerConfig): Mo
 
 export interface KiloModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
 
 export function kiloModelManagerOptions(config?: KiloModelManagerConfig): ModelManagerOptions<"openai-completions"> {
-	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? "https://api.kilo.ai/api/gateway";
 	return {
 		providerId: "kilo",
-		fetchDynamicModels: () =>
-			fetchOpenAICompatibleModels({
+		fetchDynamicModels: async () => {
+			const apiKey = (config?.getApiKey ? await config.getApiKey() : undefined) ?? config?.apiKey;
+			return fetchOpenAICompatibleModels({
 				api: "openai-completions",
 				provider: "kilo",
 				baseUrl,
 				apiKey,
 				fetch: config?.fetch,
-			}),
+			});
+		},
 	};
 }
 
@@ -2205,6 +2227,7 @@ export function kiloModelManagerOptions(config?: KiloModelManagerConfig): ModelM
 
 export interface AlibabaCodingPlanModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -2212,23 +2235,29 @@ export interface AlibabaCodingPlanModelManagerConfig {
 export function alibabaCodingPlanModelManagerOptions(
 	config?: AlibabaCodingPlanModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	const apiKey = config?.apiKey;
+	const configuredApiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? "https://coding-intl.dashscope.aliyuncs.com/v1";
 	const references = createBundledReferenceMap<"openai-completions">("alibaba-coding-plan");
+	const hasApiKey = Boolean(configuredApiKey || config?.getApiKey);
 	return {
 		providerId: "alibaba-coding-plan",
-		fetchDynamicModels: () =>
-			fetchOpenAICompatibleModels({
-				api: "openai-completions",
-				provider: "alibaba-coding-plan",
-				baseUrl,
-				apiKey,
-				mapModel: (entry, defaults) => {
-					const reference = references.get(defaults.id);
-					return mapWithBundledReference(entry, defaults, reference);
-				},
-				fetch: config?.fetch,
-			}),
+		...(hasApiKey && {
+			fetchDynamicModels: async () => {
+				const apiKey = (config?.getApiKey ? await config.getApiKey() : undefined) ?? configuredApiKey;
+				if (!apiKey) return null;
+				return fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "alibaba-coding-plan",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						return mapWithBundledReference(entry, defaults, reference);
+					},
+					fetch: config?.fetch,
+				});
+			},
+		}),
 	};
 }
 
@@ -2304,6 +2333,7 @@ export function vercelAiGatewayModelManagerOptions(
 
 export interface KimiCodeModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -2311,13 +2341,16 @@ export interface KimiCodeModelManagerConfig {
 export function kimiCodeModelManagerOptions(
 	config?: KimiCodeModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	const apiKey = config?.apiKey;
+	const configuredApiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? "https://api.kimi.com/coding/v1";
+	const hasApiKey = Boolean(configuredApiKey || config?.getApiKey);
 	return {
 		providerId: "kimi-code",
-		...(apiKey && {
-			fetchDynamicModels: () =>
-				fetchOpenAICompatibleModels({
+		...(hasApiKey && {
+			fetchDynamicModels: async () => {
+				const apiKey = (config?.getApiKey ? await config.getApiKey() : undefined) ?? configuredApiKey;
+				if (!apiKey) return null;
+				return fetchOpenAICompatibleModels({
 					api: "openai-completions",
 					provider: "kimi-code",
 					baseUrl,
@@ -2347,7 +2380,8 @@ export function kimiCodeModelManagerOptions(
 						};
 					},
 					fetch: config?.fetch,
-				}),
+				});
+			},
 		}),
 	};
 }
@@ -2883,6 +2917,7 @@ export function sakanaModelManagerOptions(config?: SakanaModelManagerConfig): Mo
 
 export interface QwenPortalModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -3552,6 +3587,7 @@ export function nanoGptModelManagerOptions(
 
 export interface GithubCopilotModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -3708,22 +3744,23 @@ function createCopilotLongContextVariant(
 }
 
 export function githubCopilotModelManagerOptions(config?: GithubCopilotModelManagerConfig): ModelManagerOptions<Api> {
-	const rawApiKey = config?.apiKey;
 	const configuredBaseUrl = config?.baseUrl ?? "https://api.githubcopilot.com";
-	const parsedApiKey = rawApiKey ? parseGitHubCopilotApiKey(rawApiKey) : undefined;
-	const apiKey = parsedApiKey?.accessToken;
-	const baseUrl =
-		parsedApiKey?.apiEndpoint && configuredBaseUrl.includes("githubcopilot.com")
-			? parsedApiKey.apiEndpoint
-			: parsedApiKey?.enterpriseUrl && configuredBaseUrl.includes("githubcopilot.com")
-				? getGitHubCopilotBaseUrl(parsedApiKey.enterpriseUrl)
-				: configuredBaseUrl;
 	const providerRefs = createBundledReferenceMap<Api>("github-copilot");
 	const resolveReference = createReferenceResolver(providerRefs);
 	return {
 		providerId: "github-copilot",
-		...(apiKey && {
+		...((config?.apiKey || config?.getApiKey) && {
 			fetchDynamicModels: async () => {
+				const rawApiKey = (config?.getApiKey ? await config.getApiKey() : undefined) ?? config?.apiKey;
+				if (!rawApiKey) return null;
+				const parsedApiKey = parseGitHubCopilotApiKey(rawApiKey);
+				const apiKey = parsedApiKey.accessToken;
+				const baseUrl =
+					parsedApiKey.apiEndpoint && configuredBaseUrl.includes("githubcopilot.com")
+						? parsedApiKey.apiEndpoint
+						: parsedApiKey.enterpriseUrl && configuredBaseUrl.includes("githubcopilot.com")
+							? getGitHubCopilotBaseUrl(parsedApiKey.enterpriseUrl)
+							: configuredBaseUrl;
 				const longContextVariants: ModelSpec<Api>[] = [];
 				const models = await fetchOpenAICompatibleModels<Api>({
 					api: "openai-completions",
@@ -3874,6 +3911,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 
 export interface AnthropicModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 }
@@ -3881,16 +3919,19 @@ export interface AnthropicModelManagerConfig {
 export function anthropicModelManagerOptions(
 	config?: AnthropicModelManagerConfig,
 ): ModelManagerOptions<"anthropic-messages"> {
-	const apiKey = config?.apiKey;
+	const configuredApiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? ANTHROPIC_BASE_URL;
+	const hasApiKey = Boolean(configuredApiKey || config?.getApiKey);
 	return {
 		providerId: "anthropic",
 		modelsDev: {
 			fetch: () => fetchModelsDevPayload(config?.fetch),
 			map: payload => mapAnthropicModelsDev(payload, baseUrl),
 		},
-		...(apiKey && {
+		...(hasApiKey && {
 			fetchDynamicModels: async () => {
+				const apiKey = (config?.getApiKey ? await config.getApiKey() : undefined) ?? configuredApiKey;
+				if (!apiKey) return null;
 				const modelsDevModels = await fetchModelsDevPayload(config?.fetch)
 					.then(payload => mapAnthropicModelsDev(payload, baseUrl))
 					.catch(() => []);

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -83,7 +83,12 @@ export function gitLabDuoWorkflowModelManagerOptions(
 ): ModelManagerOptions<"gitlab-duo-agent"> {
 	const { apiKey: configuredApiKey, getApiKey, cacheIdentity } = config;
 	const hasApiKey = Boolean(configuredApiKey || getApiKey);
-	const cacheKeyIdentity = configuredApiKey ?? cacheIdentity;
+	// Prefer the OAuth cache identity over a configured token: fetchDynamicModels
+	// resolves the bearer as `getApiKey() ?? configuredApiKey` (OAuth-first), so
+	// the cache key must be OAuth-first too — otherwise a mixed-auth setup (expired
+	// OAuth + env/config token) fetches as the OAuth account but caches under the
+	// token, serving another account's namespace on a later token-only refresh.
+	const cacheKeyIdentity = cacheIdentity ?? configuredApiKey;
 	return {
 		providerId: "gitlab-duo-agent",
 		// GitLab Duo discovery is credential- and namespace-specific
@@ -94,9 +99,10 @@ export function gitLabDuoWorkflowModelManagerOptions(
 		// the exact inputs `fetchGitLabDuoWorkflowModels` resolves the namespace from
 		// (credential/cache identity + base URL + namespace/project config + the same
 		// env vars + the effective workspace cwd whose git remote drives
-		// auto-discovery). Built-in lazy-OAuth discovery passes cacheIdentity when the
-		// token is unavailable without refresh. Falls back to the bare provider id
-		// when no credential identity is present.
+		// auto-discovery). Built-in lazy-OAuth discovery passes the OAuth account's
+		// cacheIdentity, which takes precedence over a configured token so the cache
+		// key matches the OAuth bearer fetchDynamicModels prefers. Falls back to the
+		// bare provider id when no credential identity is present.
 		...(cacheKeyIdentity
 			? { cacheProviderId: gitLabDuoWorkflowModelCacheProviderId(cacheKeyIdentity, config) }
 			: undefined),

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -38,17 +38,21 @@ export function openaiCodexModelManagerOptions(
 
 export interface CursorModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	clientVersion?: string;
 }
 
 export function cursorModelManagerOptions(config: CursorModelManagerConfig = {}): ModelManagerOptions<"cursor-agent"> {
-	const { apiKey, baseUrl, clientVersion } = config;
+	const { apiKey: configuredApiKey, getApiKey, baseUrl, clientVersion } = config;
+	const hasApiKey = Boolean(configuredApiKey || getApiKey);
 	return {
 		providerId: "cursor",
-		...(apiKey
+		...(hasApiKey
 			? {
 					fetchDynamicModels: async () => {
+						const apiKey = (getApiKey ? await getApiKey() : undefined) ?? configuredApiKey;
+						if (!apiKey) return null;
 						const { fetchCursorUsableModels } = await cursorDiscovery();
 						return fetchCursorUsableModels({ apiKey, baseUrl, clientVersion });
 					},
@@ -65,6 +69,8 @@ const cursorDiscovery = once(() => import("../discovery/cursor"));
 
 export interface GitLabDuoWorkflowModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
+	cacheIdentity?: string;
 	baseUrl?: string;
 	fetch?: FetchImpl;
 	namespaceId?: string;
@@ -75,7 +81,9 @@ export interface GitLabDuoWorkflowModelManagerConfig {
 export function gitLabDuoWorkflowModelManagerOptions(
 	config: GitLabDuoWorkflowModelManagerConfig = {},
 ): ModelManagerOptions<"gitlab-duo-agent"> {
-	const apiKey = config.apiKey;
+	const { apiKey: configuredApiKey, getApiKey, cacheIdentity } = config;
+	const hasApiKey = Boolean(configuredApiKey || getApiKey);
+	const cacheKeyIdentity = configuredApiKey ?? cacheIdentity;
 	return {
 		providerId: "gitlab-duo-agent",
 		// GitLab Duo discovery is credential- and namespace-specific
@@ -84,42 +92,48 @@ export function gitLabDuoWorkflowModelManagerOptions(
 		// account/namespace load the first one's authoritative model list at startup
 		// and skip refetching. Partition the cache by a non-reversible fingerprint of
 		// the exact inputs `fetchGitLabDuoWorkflowModels` resolves the namespace from
-		// (credential + base URL + namespace/project config + the same env vars + the
-		// effective workspace cwd whose git remote drives auto-discovery). Built-in
-		// discovery only passes apiKey/baseUrl/fetch, so the cwd/env terms — not the
-		// empty config fields — are what actually separate workspace A from B here.
-		// Falls back to the bare provider id when no credential is present.
-		...(apiKey ? { cacheProviderId: gitLabDuoWorkflowModelCacheProviderId(apiKey, config) } : undefined),
+		// (credential/cache identity + base URL + namespace/project config + the same
+		// env vars + the effective workspace cwd whose git remote drives
+		// auto-discovery). Built-in lazy-OAuth discovery passes cacheIdentity when the
+		// token is unavailable without refresh. Falls back to the bare provider id
+		// when no credential identity is present.
+		...(cacheKeyIdentity
+			? { cacheProviderId: gitLabDuoWorkflowModelCacheProviderId(cacheKeyIdentity, config) }
+			: undefined),
 		dynamicModelsAuthoritative: true,
 		staticModels: [
 			buildGitLabDuoWorkflowFallbackModel("claude_sonnet_4_6_vertex", "Claude Sonnet 4.6 - Vertex", config.baseUrl),
 		],
-		...(apiKey
+		...(hasApiKey
 			? {
-					fetchDynamicModels: async () =>
-						fetchGitLabDuoWorkflowModels({
+					fetchDynamicModels: async () => {
+						const apiKey = (getApiKey ? await getApiKey() : undefined) ?? configuredApiKey;
+						if (!apiKey) return null;
+						return fetchGitLabDuoWorkflowModels({
 							apiKey,
 							baseUrl: config.baseUrl,
 							fetch: config.fetch,
 							namespaceId: config.namespaceId,
 							projectId: config.projectId,
 							cwd: config.cwd,
-						}),
+						});
+					},
 				}
 			: undefined),
 	};
 }
 
-function gitLabDuoWorkflowModelCacheProviderId(apiKey: string, config: GitLabDuoWorkflowModelManagerConfig): string {
+function gitLabDuoWorkflowModelCacheProviderId(identity: string, config: GitLabDuoWorkflowModelManagerConfig): string {
 	// Mirror the exact inputs `discoverGitLabDuoWorkflowNamespace` keys off: explicit
 	// namespace/project config OR the same env vars, then the git remote at the
 	// effective cwd. Built-in discovery leaves the config fields empty, so the env +
-	// resolved cwd terms are what actually distinguish two workspaces sharing a token.
+	// resolved cwd terms are what actually distinguish two workspaces sharing an
+	// OAuth identity or token.
 	const namespaceId = config.namespaceId ?? Bun.env.GITLAB_DUO_NAMESPACE_ID ?? "";
 	const projectId = config.projectId ?? Bun.env.GITLAB_DUO_PROJECT_ID ?? Bun.env.GITLAB_DUO_PROJECT_PATH ?? "";
 	const cwd = config.cwd ?? process.cwd();
 	const scope = [config.baseUrl ?? "", namespaceId, projectId, cwd].join("\u0000");
-	return `gitlab-duo-agent:${Bun.hash(`${apiKey}\u0000${scope}`).toString(36)}`;
+	return `gitlab-duo-agent:${Bun.hash(`${identity}\u0000${scope}`).toString(36)}`;
 }
 
 // Devin (Codeium Cascade)
@@ -127,18 +141,22 @@ function gitLabDuoWorkflowModelCacheProviderId(apiKey: string, config: GitLabDuo
 
 export interface DevinModelManagerConfig {
 	apiKey?: string;
+	getApiKey?: () => Promise<string | undefined>;
 	baseUrl?: string;
 	fetch?: DevinModelDiscoveryOptions["fetch"];
 }
 
 export function devinModelManagerOptions(config: DevinModelManagerConfig = {}): ModelManagerOptions<"devin-agent"> {
-	const { apiKey, baseUrl, fetch } = config;
+	const { apiKey: configuredApiKey, getApiKey, baseUrl, fetch } = config;
+	const hasApiKey = Boolean(configuredApiKey || getApiKey);
 	return {
 		providerId: "devin",
-		...(apiKey ? { dynamicModelsAuthoritative: true } : undefined),
-		...(apiKey
+		...(hasApiKey ? { dynamicModelsAuthoritative: true } : undefined),
+		...(hasApiKey
 			? {
 					fetchDynamicModels: async () => {
+						const apiKey = (getApiKey ? await getApiKey() : undefined) ?? configuredApiKey;
+						if (!apiKey) return null;
 						const { fetchDevinModels } = await devinDiscovery();
 						return fetchDevinModels({ apiKey, baseUrl, fetch });
 					},

--- a/packages/catalog/test/gitlab-duo-cache-identity.test.ts
+++ b/packages/catalog/test/gitlab-duo-cache-identity.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { gitLabDuoWorkflowModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models";
+
+const FIXED_CWD = "/tmp/gitlab-duo-cache-identity-test";
+const FIXED_BASE_URL = "https://gitlab.example.com";
+const FIXED_NAMESPACE_ID = "";
+const FIXED_PROJECT_ID = "";
+
+describe("gitLabDuoWorkflowModelManagerOptions cache identity precedence", () => {
+	it("same cacheIdentity with different apiKeys yields identical cacheProviderId", () => {
+		const a = gitLabDuoWorkflowModelManagerOptions({
+			apiKey: "token-A",
+			cacheIdentity: "cred:5",
+			baseUrl: FIXED_BASE_URL,
+			cwd: FIXED_CWD,
+			namespaceId: FIXED_NAMESPACE_ID,
+			projectId: FIXED_PROJECT_ID,
+		});
+		const b = gitLabDuoWorkflowModelManagerOptions({
+			apiKey: "token-B",
+			cacheIdentity: "cred:5",
+			baseUrl: FIXED_BASE_URL,
+			cwd: FIXED_CWD,
+			namespaceId: FIXED_NAMESPACE_ID,
+			projectId: FIXED_PROJECT_ID,
+		});
+
+		expect(a.cacheProviderId).toBeDefined();
+		expect(a.cacheProviderId).toBe(b.cacheProviderId);
+	});
+
+	it("different cacheIdentity values yield different cacheProviderId", () => {
+		const a = gitLabDuoWorkflowModelManagerOptions({
+			apiKey: "token",
+			cacheIdentity: "cred:5",
+			baseUrl: FIXED_BASE_URL,
+			cwd: FIXED_CWD,
+			namespaceId: FIXED_NAMESPACE_ID,
+			projectId: FIXED_PROJECT_ID,
+		});
+		const b = gitLabDuoWorkflowModelManagerOptions({
+			apiKey: "token",
+			cacheIdentity: "cred:9",
+			baseUrl: FIXED_BASE_URL,
+			cwd: FIXED_CWD,
+			namespaceId: FIXED_NAMESPACE_ID,
+			projectId: FIXED_PROJECT_ID,
+		});
+
+		expect(a.cacheProviderId).not.toBe(b.cacheProviderId);
+	});
+
+	it("falls back to apiKey for cacheProviderId when no cacheIdentity is provided", () => {
+		const options = gitLabDuoWorkflowModelManagerOptions({
+			apiKey: "token",
+			baseUrl: FIXED_BASE_URL,
+			cwd: FIXED_CWD,
+			namespaceId: FIXED_NAMESPACE_ID,
+			projectId: FIXED_PROJECT_ID,
+		});
+
+		expect(options.cacheProviderId).toBeDefined();
+	});
+
+	it("omits cacheProviderId when no credential identity is present", () => {
+		const options = gitLabDuoWorkflowModelManagerOptions({
+			baseUrl: FIXED_BASE_URL,
+			cwd: FIXED_CWD,
+			namespaceId: FIXED_NAMESPACE_ID,
+			projectId: FIXED_PROJECT_ID,
+		});
+
+		expect(options.cacheProviderId).toBeUndefined();
+	});
+});

--- a/packages/catalog/test/ollama-cloud-output-caps.test.ts
+++ b/packages/catalog/test/ollama-cloud-output-caps.test.ts
@@ -82,6 +82,15 @@ test("ollama-cloud discovery always omits max output tokens", async () => {
 	expect(model?.omitMaxOutputTokens).toBe(true);
 });
 
+test("ollama-cloud discovery returns null when no API key resolves", async () => {
+	// null (not []) means "degrade to cache/static" rather than writing an empty
+	// authoritative snapshot that would drop previously cached dynamic models.
+	await expect(ollamaCloudModelManagerOptions({}).fetchDynamicModels?.()).resolves.toBeNull();
+	await expect(
+		ollamaCloudModelManagerOptions({ getApiKey: async () => undefined }).fetchDynamicModels?.(),
+	).resolves.toBeNull();
+});
+
 test("ollama-chat omits num_predict when model opts out of max output tokens", async () => {
 	let requestBody: Record<string, unknown> | undefined;
 	const fetchMock: FetchImpl = vi.fn(async (_input, init) => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Built-in provider model discovery now refreshes expired OAuth tokens instead of silently skipping the provider.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Built-in provider model discovery now refreshes expired OAuth tokens instead of silently skipping the provider, and for providers with multiple stored OAuth accounts it pins the discovery bearer and the per-account model cache to the same account (position 0) so one account's model list can no longer be fetched under one account and served from another account's cache.
+- Built-in provider model discovery now refreshes expired OAuth tokens instead of silently skipping the provider. For GitLab Duo (whose model cache is keyed per credential) the discovery bearer and the cache key are pinned to the same OAuth account, so multiple stored accounts — or a mix of stored OAuth and a configured token — can no longer serve one account's namespace models from another account's cache; other OAuth providers follow the session-active account, preserving account-specific metadata such as GitHub Copilot's enterprise endpoint.
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Built-in provider model discovery now refreshes expired OAuth tokens instead of silently skipping the provider.
+- Built-in provider model discovery now refreshes expired OAuth tokens instead of silently skipping the provider, and for providers with multiple stored OAuth accounts it pins the discovery bearer and the per-account model cache to the same account (position 0) so one account's model list can no longer be fetched under one account and served from another account's cache.
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1560,7 +1560,9 @@ export class ModelRegistry {
 	): Promise<BuiltInDiscoveryResult> {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(p => p.provider));
-		const managerOptions = (await this.#collectBuiltInModelManagerOptions()).filter(opts => {
+		const managerOptions = (
+			await this.#collectBuiltInModelManagerOptions(strategy, configuredDiscoveryProviders, providerFilter)
+		).filter(opts => {
 			if (configuredDiscoveryProviders.has(opts.providerId)) {
 				return false;
 			}
@@ -1583,7 +1585,11 @@ export class ModelRegistry {
 		return { models, authoritativeProviders };
 	}
 
-	async #collectBuiltInModelManagerOptions(): Promise<ModelManagerOptions<Api>[]> {
+	async #collectBuiltInModelManagerOptions(
+		strategy: ModelRefreshStrategy,
+		configuredDiscoveryProviders?: ReadonlySet<string>,
+		providerFilter?: ReadonlySet<string>,
+	): Promise<ModelManagerOptions<Api>[]> {
 		const specialProviderDescriptors: Array<{
 			providerId: string;
 			resolveKey: (value: string | undefined) => string | undefined;
@@ -1622,16 +1628,52 @@ export class ModelRegistry {
 			},
 		];
 		const disabledProviders = getDisabledProviderIdsFromSettings();
-		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId),
-		);
-		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId),
-		);
-		// Use peekApiKey to avoid OAuth token refresh during discovery.
-		// The token is only needed if the dynamic fetch fires (cache miss),
-		// and failures there are handled gracefully.
-		const peekKey = (descriptor: { providerId: string }) => this.#peekApiKeyForProvider(descriptor.providerId);
+		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(descriptor => {
+			if (disabledProviders.has(descriptor.providerId)) {
+				return false;
+			}
+			if (configuredDiscoveryProviders?.has(descriptor.providerId)) {
+				return false;
+			}
+			if (providerFilter && !providerFilter.has(descriptor.providerId)) {
+				return false;
+			}
+			return true;
+		});
+		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(descriptor => {
+			if (disabledProviders.has(descriptor.providerId)) {
+				return false;
+			}
+			if (configuredDiscoveryProviders?.has(descriptor.providerId)) {
+				return false;
+			}
+			if (providerFilter && !providerFilter.has(descriptor.providerId)) {
+				return false;
+			}
+			return true;
+		});
+		// Peek first to avoid OAuth refresh churn during discovery. When peek
+		// fails but a stored OAuth credential exists, the access token has
+		// expired: refresh once through getApiKeyForProvider (persists the
+		// rotated credential), then re-peek so provider-specific peek shapes
+		// (e.g. github-copilot's JSON envelope with enterpriseUrl/apiEndpoint)
+		// are preserved — getApiKey returns the bare token, peek re-wraps it.
+		const peekKey = async (descriptor: { providerId: string }): Promise<string | undefined> => {
+			const peeked = await this.#peekApiKeyForProvider(descriptor.providerId);
+			if (strategy === "offline" || isAuthenticated(peeked) || !this.authStorage.hasOAuth(descriptor.providerId)) {
+				return peeked;
+			}
+			let refreshed: string | undefined;
+			try {
+				refreshed = await this.getApiKeyForProvider(descriptor.providerId);
+			} catch {
+				return peeked;
+			}
+			if (!isAuthenticated(refreshed)) {
+				return peeked;
+			}
+			return this.#peekApiKeyForProvider(descriptor.providerId);
+		};
 		const [standardProviderKeys, specialKeys] = await Promise.all([
 			Promise.all(standardProviderDescriptors.map(peekKey)),
 			Promise.all(enabledSpecialProviderDescriptors.map(peekKey)),

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1555,8 +1555,13 @@ export class ModelRegistry {
 
 	async #resolveBuiltInDiscoveryOAuthAccess(providerId: string): Promise<BuiltInDiscoveryOAuthAccess | undefined> {
 		try {
-			const access = await this.authStorage.getOAuthAccess(providerId);
-			if (!access?.accessToken) {
+			// Pin to account position 0 so the fetched bearer references the SAME
+			// OAuth row that #resolveBuiltInDiscoveryCacheIdentity keys the cache on
+			// (listOAuthAccounts[0]). getOAuthAccess() round-robins across accounts
+			// and could diverge from the cache key on multi-account providers,
+			// caching one account's catalog under another's key.
+			const access = await this.authStorage.getOAuthAccessAt(providerId, 0);
+			if (!access?.ok || !access.accessToken) {
 				return undefined;
 			}
 			return access;
@@ -1567,15 +1572,19 @@ export class ModelRegistry {
 
 	async #resolveBuiltInDiscoveryApiKey(providerId: string): Promise<string | undefined> {
 		try {
-			const access = await this.authStorage.getOAuthAccess(providerId);
-			return this.#formatBuiltInOAuthDiscoveryApiKey(providerId, access);
+			const access = await this.authStorage.getOAuthAccessAt(providerId, 0);
+			return access?.ok ? this.#formatBuiltInOAuthDiscoveryApiKey(providerId, access) : undefined;
 		} catch {
 			return undefined;
 		}
 	}
 
 	#resolveBuiltInDiscoveryCacheIdentity(providerId: string): string | undefined {
-		return formatOAuthCacheIdentity(this.authStorage.getOAuthAccountIdentity(providerId));
+		// Position 0 keeps the cache key aligned with the bearer resolved by
+		// getOAuthAccessAt(providerId, 0); both index the same stable storage
+		// order, so a multi-account provider cannot cache one account's catalog
+		// under another account's key.
+		return formatOAuthCacheIdentity(this.authStorage.listOAuthAccounts(providerId)[0]);
 	}
 
 	#discoveryContext(): DiscoveryContext {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -443,6 +443,7 @@ function formatOAuthCacheIdentity(identity: OAuthAccountIdentity | undefined): s
 	if (identity?.accountId) return `account:${identity.accountId}`;
 	if (identity?.email) return `email:${identity.email}`;
 	if (identity?.projectId) return `project:${identity.projectId}`;
+	if (identity?.credentialId !== undefined) return `cred:${identity.credentialId}`;
 	return undefined;
 }
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -61,7 +61,7 @@ import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oaut
 import { getBundledModelReferenceIndex, resolveModelReference } from "@oh-my-pi/pi-catalog/identity";
 import { isBunTestRuntime, isRecord, logger, wrapFetchForExtraCa } from "@oh-my-pi/pi-utils";
 import { parseModelString, resolveProviderModelReference } from "../config/model-resolver";
-import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
+import type { AuthStorage, OAuthAccountIdentity, OAuthCredential } from "../session/auth-storage";
 import { type ApiKeyResolverModel, type ApiKeyResolverOptions, createApiKeyResolver } from "./api-key-resolver";
 import type { ConfigError, ConfigFile } from "./config-file";
 import {
@@ -238,6 +238,13 @@ function mergeByModelKey<T extends { provider: string; id: string }>(
 interface BuiltInDiscoveryResult {
 	models: Model<Api>[];
 	authoritativeProviders: Set<string>;
+}
+
+interface BuiltInDiscoveryOAuthAccess {
+	accessToken: string;
+	accountId?: string;
+	enterpriseUrl?: string;
+	apiEndpoint?: string;
 }
 
 export type ProviderDiscoveryStatus = "idle" | "ok" | "empty" | "cached" | "unavailable" | "unauthenticated";
@@ -429,6 +436,13 @@ function resolveOAuthAccountIdForAccessToken(
 	if (oauthCredentials.length === 1) {
 		return oauthCredentials[0].accountId;
 	}
+	return undefined;
+}
+
+function formatOAuthCacheIdentity(identity: OAuthAccountIdentity | undefined): string | undefined {
+	if (identity?.accountId) return `account:${identity.accountId}`;
+	if (identity?.email) return `email:${identity.email}`;
+	if (identity?.projectId) return `project:${identity.projectId}`;
 	return undefined;
 }
 
@@ -1521,6 +1535,48 @@ export class ModelRegistry {
 		);
 	}
 
+	#formatBuiltInOAuthDiscoveryApiKey(
+		providerId: string,
+		access: BuiltInDiscoveryOAuthAccess | undefined,
+	): string | undefined {
+		if (!access?.accessToken) {
+			return undefined;
+		}
+		if (providerId === "github-copilot") {
+			return JSON.stringify({
+				token: access.accessToken,
+				enterpriseUrl: access.enterpriseUrl,
+				apiEndpoint: access.apiEndpoint,
+			});
+		}
+		return access.accessToken;
+	}
+
+	async #resolveBuiltInDiscoveryOAuthAccess(providerId: string): Promise<BuiltInDiscoveryOAuthAccess | undefined> {
+		try {
+			const access = await this.authStorage.getOAuthAccess(providerId);
+			if (!access?.accessToken) {
+				return undefined;
+			}
+			return access;
+		} catch {
+			return undefined;
+		}
+	}
+
+	async #resolveBuiltInDiscoveryApiKey(providerId: string): Promise<string | undefined> {
+		try {
+			const access = await this.authStorage.getOAuthAccess(providerId);
+			return this.#formatBuiltInOAuthDiscoveryApiKey(providerId, access);
+		} catch {
+			return undefined;
+		}
+	}
+
+	#resolveBuiltInDiscoveryCacheIdentity(providerId: string): string | undefined {
+		return formatOAuthCacheIdentity(this.authStorage.getOAuthAccountIdentity(providerId));
+	}
+
 	#discoveryContext(): DiscoveryContext {
 		return {
 			fetch: this.#fetch,
@@ -1561,7 +1617,7 @@ export class ModelRegistry {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(p => p.provider));
 		const managerOptions = (
-			await this.#collectBuiltInModelManagerOptions(strategy, configuredDiscoveryProviders, providerFilter)
+			await this.#collectBuiltInModelManagerOptions(configuredDiscoveryProviders, providerFilter)
 		).filter(opts => {
 			if (configuredDiscoveryProviders.has(opts.providerId)) {
 				return false;
@@ -1586,45 +1642,75 @@ export class ModelRegistry {
 	}
 
 	async #collectBuiltInModelManagerOptions(
-		strategy: ModelRefreshStrategy,
 		configuredDiscoveryProviders?: ReadonlySet<string>,
 		providerFilter?: ReadonlySet<string>,
 	): Promise<ModelManagerOptions<Api>[]> {
 		const specialProviderDescriptors: Array<{
 			providerId: string;
 			resolveKey: (value: string | undefined) => string | undefined;
-			createOptions: (key: string) => ModelManagerOptions<Api>;
+			createOptions: (
+				key: string | undefined,
+				getOAuthAccess: (() => Promise<BuiltInDiscoveryOAuthAccess | undefined>) | undefined,
+			) => ModelManagerOptions<Api>;
+			allowStoredOAuthAdmission?: boolean;
 		}> = [
 			{
 				providerId: "google-antigravity",
 				resolveKey: extractGoogleOAuthToken,
-				createOptions: oauthToken =>
-					googleAntigravityModelManagerOptions({
-						oauthToken,
-						endpoint: this.getProviderBaseUrl("google-antigravity"),
-						fetch: this.#fetch,
-					}),
+				allowStoredOAuthAdmission: true,
+				createOptions: (oauthToken, getOAuthAccess) => ({
+					providerId: "google-antigravity",
+					fetchDynamicModels: async () => {
+						const oauthAccess = getOAuthAccess ? await getOAuthAccess() : undefined;
+						const resolvedToken = oauthAccess?.accessToken ?? oauthToken;
+						if (!resolvedToken) return null;
+						const managerOptions = googleAntigravityModelManagerOptions({
+							oauthToken: resolvedToken,
+							endpoint: this.getProviderBaseUrl("google-antigravity"),
+							fetch: this.#fetch,
+						});
+						return managerOptions.fetchDynamicModels?.() ?? null;
+					},
+				}),
 			},
 			{
 				providerId: "google-gemini-cli",
 				resolveKey: extractGoogleOAuthToken,
-				createOptions: oauthToken =>
-					googleGeminiCliModelManagerOptions({
-						oauthToken,
-						endpoint: this.getProviderBaseUrl("google-gemini-cli"),
-						fetch: this.#fetch,
-					}),
+				allowStoredOAuthAdmission: true,
+				createOptions: (oauthToken, getOAuthAccess) => ({
+					providerId: "google-gemini-cli",
+					fetchDynamicModels: async () => {
+						const oauthAccess = getOAuthAccess ? await getOAuthAccess() : undefined;
+						const resolvedToken = oauthAccess?.accessToken ?? oauthToken;
+						if (!resolvedToken) return null;
+						const managerOptions = googleGeminiCliModelManagerOptions({
+							oauthToken: resolvedToken,
+							endpoint: this.getProviderBaseUrl("google-gemini-cli"),
+							fetch: this.#fetch,
+						});
+						return managerOptions.fetchDynamicModels?.() ?? null;
+					},
+				}),
 			},
 			{
 				providerId: "openai-codex",
 				resolveKey: value => value,
-				createOptions: accessToken => {
-					const accountId = resolveOAuthAccountIdForAccessToken(this.authStorage, "openai-codex", accessToken);
-					return openaiCodexModelManagerOptions({
-						accessToken,
-						accountId,
-					});
-				},
+				allowStoredOAuthAdmission: true,
+				createOptions: (accessToken, getOAuthAccess) => ({
+					providerId: "openai-codex",
+					fetchDynamicModels: async () => {
+						const oauthAccess = getOAuthAccess ? await getOAuthAccess() : undefined;
+						const resolvedAccessToken = oauthAccess?.accessToken ?? accessToken;
+						if (!resolvedAccessToken) return null;
+						const managerOptions = openaiCodexModelManagerOptions({
+							accessToken: resolvedAccessToken,
+							accountId:
+								oauthAccess?.accountId ??
+								resolveOAuthAccountIdForAccessToken(this.authStorage, "openai-codex", resolvedAccessToken),
+						});
+						return managerOptions.fetchDynamicModels?.() ?? null;
+					},
+				}),
 			},
 		];
 		const disabledProviders = getDisabledProviderIdsFromSettings();
@@ -1652,28 +1738,11 @@ export class ModelRegistry {
 			}
 			return true;
 		});
-		// Peek first to avoid OAuth refresh churn during discovery. When peek
-		// fails but a stored OAuth credential exists, the access token has
-		// expired: refresh once through getApiKeyForProvider (persists the
-		// rotated credential), then re-peek so provider-specific peek shapes
-		// (e.g. github-copilot's JSON envelope with enterpriseUrl/apiEndpoint)
-		// are preserved — getApiKey returns the bare token, peek re-wraps it.
-		const peekKey = async (descriptor: { providerId: string }): Promise<string | undefined> => {
-			const peeked = await this.#peekApiKeyForProvider(descriptor.providerId);
-			if (strategy === "offline" || isAuthenticated(peeked) || !this.authStorage.hasOAuth(descriptor.providerId)) {
-				return peeked;
-			}
-			let refreshed: string | undefined;
-			try {
-				refreshed = await this.getApiKeyForProvider(descriptor.providerId);
-			} catch {
-				return peeked;
-			}
-			if (!isAuthenticated(refreshed)) {
-				return peeked;
-			}
-			return this.#peekApiKeyForProvider(descriptor.providerId);
-		};
+		// Admission peeks must not refresh OAuth credentials: the model manager only
+		// invokes fetchDynamicModels when it will fetch remote sources, so refresh is
+		// deferred to the lazy resolver passed below.
+		const peekKey = async (descriptor: { providerId: string }): Promise<string | undefined> =>
+			this.#peekApiKeyForProvider(descriptor.providerId);
 		const [standardProviderKeys, specialKeys] = await Promise.all([
 			Promise.all(standardProviderDescriptors.map(peekKey)),
 			Promise.all(enabledSpecialProviderDescriptors.map(peekKey)),
@@ -1682,19 +1751,29 @@ export class ModelRegistry {
 		for (let i = 0; i < standardProviderDescriptors.length; i++) {
 			const descriptor = standardProviderDescriptors[i];
 			const apiKey = standardProviderKeys[i];
+			const hasStoredOAuth = this.authStorage.hasOAuth(descriptor.providerId);
 			const hasExplicitVllmConfig =
 				descriptor.providerId === "vllm" &&
 				(this.#runtimeProviderOverrides.has(descriptor.providerId) ||
 					this.#providerOverrides.has(descriptor.providerId) ||
 					this.#keylessProviders.has(descriptor.providerId));
-			if (isAuthenticated(apiKey) || descriptor.allowUnauthenticated || hasExplicitVllmConfig) {
+			if (isAuthenticated(apiKey) || hasStoredOAuth || descriptor.allowUnauthenticated || hasExplicitVllmConfig) {
 				const discoveryBaseUrl =
 					this.#runtimeProviderOverrides.get(descriptor.providerId)?.baseUrl ??
 					this.#providerOverrides.get(descriptor.providerId)?.baseUrl ??
 					this.getProviderBaseUrl(descriptor.providerId);
+				const discoveryApiKey = isDiscoveryBearerApiKey(apiKey) ? apiKey : undefined;
+				const cacheIdentity =
+					descriptor.providerId === "gitlab-duo-agent" && !discoveryApiKey && hasStoredOAuth
+						? this.#resolveBuiltInDiscoveryCacheIdentity(descriptor.providerId)
+						: undefined;
 				options.push(
 					descriptor.createModelManagerOptions({
-						apiKey: isDiscoveryBearerApiKey(apiKey) ? apiKey : undefined,
+						apiKey: discoveryApiKey,
+						...(hasStoredOAuth && {
+							getApiKey: () => this.#resolveBuiltInDiscoveryApiKey(descriptor.providerId),
+						}),
+						...(cacheIdentity && { cacheIdentity }),
 						baseUrl: discoveryBaseUrl,
 						fetch: this.#fetch,
 					}),
@@ -1705,10 +1784,16 @@ export class ModelRegistry {
 		for (let i = 0; i < enabledSpecialProviderDescriptors.length; i++) {
 			const descriptor = enabledSpecialProviderDescriptors[i];
 			const key = descriptor.resolveKey(specialKeys[i]);
-			if (!isAuthenticated(key)) {
+			const hasStoredOAuth = this.authStorage.hasOAuth(descriptor.providerId);
+			if (!isAuthenticated(key) && !(descriptor.allowStoredOAuthAdmission && hasStoredOAuth)) {
 				continue;
 			}
-			options.push(descriptor.createOptions(key));
+			options.push(
+				descriptor.createOptions(
+					key,
+					hasStoredOAuth ? () => this.#resolveBuiltInDiscoveryOAuthAccess(descriptor.providerId) : undefined,
+				),
+			);
 		}
 		// Append runtime model managers registered by extensions via fetchDynamicModels.
 		for (const { options: managerOpts } of this.#runtimeModelManagers.values()) {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1553,18 +1553,26 @@ export class ModelRegistry {
 		return access.accessToken;
 	}
 
+	// Built-in discovery resolves the OAuth bearer per provider. gitlab-duo-agent
+	// keys its model cache per credential (#resolveBuiltInDiscoveryCacheIdentity
+	// uses listOAuthAccounts[0]), so its bearer MUST come from that same row —
+	// getOAuthAccessAt(0) — to keep the fetched catalog and its cache key aligned
+	// across multiple accounts. Every other provider caches under the bare
+	// provider id (no per-account key) and should follow the session-active
+	// account via getOAuthAccess, which preserves account-specific metadata such
+	// as GitHub Copilot's enterprise apiEndpoint.
+	async #resolveBuiltInDiscoveryAccess(providerId: string): Promise<BuiltInDiscoveryOAuthAccess | undefined> {
+		if (providerId === "gitlab-duo-agent") {
+			const resolution = await this.authStorage.getOAuthAccessAt(providerId, 0);
+			return resolution?.ok ? resolution : undefined;
+		}
+		return this.authStorage.getOAuthAccess(providerId);
+	}
+
 	async #resolveBuiltInDiscoveryOAuthAccess(providerId: string): Promise<BuiltInDiscoveryOAuthAccess | undefined> {
 		try {
-			// Pin to account position 0 so the fetched bearer references the SAME
-			// OAuth row that #resolveBuiltInDiscoveryCacheIdentity keys the cache on
-			// (listOAuthAccounts[0]). getOAuthAccess() round-robins across accounts
-			// and could diverge from the cache key on multi-account providers,
-			// caching one account's catalog under another's key.
-			const access = await this.authStorage.getOAuthAccessAt(providerId, 0);
-			if (!access?.ok || !access.accessToken) {
-				return undefined;
-			}
-			return access;
+			const access = await this.#resolveBuiltInDiscoveryAccess(providerId);
+			return access?.accessToken ? access : undefined;
 		} catch {
 			return undefined;
 		}
@@ -1572,8 +1580,10 @@ export class ModelRegistry {
 
 	async #resolveBuiltInDiscoveryApiKey(providerId: string): Promise<string | undefined> {
 		try {
-			const access = await this.authStorage.getOAuthAccessAt(providerId, 0);
-			return access?.ok ? this.#formatBuiltInOAuthDiscoveryApiKey(providerId, access) : undefined;
+			return this.#formatBuiltInOAuthDiscoveryApiKey(
+				providerId,
+				await this.#resolveBuiltInDiscoveryAccess(providerId),
+			);
 		} catch {
 			return undefined;
 		}
@@ -1774,12 +1784,20 @@ export class ModelRegistry {
 					this.getProviderBaseUrl(descriptor.providerId);
 				const discoveryApiKey = isDiscoveryBearerApiKey(apiKey) ? apiKey : undefined;
 				const cacheIdentity =
-					descriptor.providerId === "gitlab-duo-agent" && !discoveryApiKey && hasStoredOAuth
+					descriptor.providerId === "gitlab-duo-agent" && hasStoredOAuth
 						? this.#resolveBuiltInDiscoveryCacheIdentity(descriptor.providerId)
 						: undefined;
+				// gitlab-duo keys its cache to the OAuth account (cacheIdentity). A
+				// configured/env token passed as apiKey would let fetchDynamicModels
+				// fall back to it when the OAuth refresh fails, caching the token
+				// account's namespace under the OAuth key. When the OAuth cache
+				// identity is in play OAuth is the sole discovery bearer, so drop the
+				// token: a failed refresh then serves cache/static, never a mis-keyed
+				// token catalog.
+				const discoveryApiKeyForOptions = cacheIdentity ? undefined : discoveryApiKey;
 				options.push(
 					descriptor.createModelManagerOptions({
-						apiKey: discoveryApiKey,
+						apiKey: discoveryApiKeyForOptions,
 						...(hasStoredOAuth && {
 							getApiKey: () => this.#resolveBuiltInDiscoveryApiKey(descriptor.providerId),
 						}),

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -1478,6 +1478,277 @@ describe("ModelRegistry", () => {
 			await registry.refreshProvider("github-copilot", "online");
 			expect(requestedUrls).toContain("https://copilot-api.ghe.example.com/models");
 			expect(requestedUrls).not.toContain("https://api.githubcopilot.com/models");
+		});
+	});
+
+	describe("built-in OAuth discovery auto-refresh", () => {
+		test("expired xai-oauth credentials whose refresh rejects does not crash built-in discovery", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "expired-refresh-token",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const registry = new ModelRegistry(authStorage, modelsJsonPath);
+				const spy = spyOn(registry, "getApiKeyForProvider").mockImplementation(() =>
+					Promise.reject(new Error("Mocked refresh failure")),
+				);
+
+				await registry.refreshProvider("xai-oauth", "online");
+				expect(spy).toHaveBeenCalledWith("xai-oauth");
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("built-in discovery refreshes an expired OAuth credential instead of skipping the provider", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "stale-access",
+						refresh: "r",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const captured: { authHeader: string | null } = { authHeader: null };
+				const fetchMock: FetchImpl = async (input, init) => {
+					const url = input instanceof Request ? input.url : String(input);
+					if (url === "https://api.x.ai/v1/models") {
+						captured.authHeader =
+							input instanceof Request
+								? input.headers.get("Authorization")
+								: new Headers(init?.headers).get("Authorization");
+						return new Response(
+							JSON.stringify({
+								data: [{ id: "grok-4.5" }],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async () => {
+					await authStorage.set("xai-oauth", [
+						{
+							type: "oauth",
+							access: "fresh-access",
+							refresh: "r",
+							expires: Date.now() + 3_600_000,
+						},
+					]);
+					return "fresh-access";
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					expect(spy).toHaveBeenCalled();
+					expect(captured.authHeader).toBe("Bearer fresh-access");
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("built-in discovery does not attempt OAuth refresh if no stored credentials exist", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				const fetchMock: FetchImpl = async () => {
+					throw new Error(`Should not fetch because discovery is skipped`);
+				};
+
+				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async () => {
+					return "fresh-access";
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					expect(spy).not.toHaveBeenCalled();
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("refreshProvider for targeted built-in provider does not refresh unrelated expired OAuth credentials", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "stale-xai-access",
+						refresh: "r-xai",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				await authStorage.set("openai-codex", [
+					{
+						type: "oauth",
+						access: "stale-codex-access",
+						refresh: "r-codex",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const captured: { authHeader: string | null } = { authHeader: null };
+				const fetchMock: FetchImpl = async (input, init) => {
+					const url = input instanceof Request ? input.url : String(input);
+					if (url === "https://api.x.ai/v1/models") {
+						captured.authHeader =
+							input instanceof Request
+								? input.headers.get("Authorization")
+								: new Headers(init?.headers).get("Authorization");
+						return new Response(
+							JSON.stringify({
+								data: [{ id: "grok-4.5" }],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const refreshedProviders: string[] = [];
+				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async providerId => {
+					refreshedProviders.push(providerId);
+					if (providerId === "xai-oauth") {
+						await authStorage.set("xai-oauth", [
+							{
+								type: "oauth",
+								access: "fresh-xai-access",
+								refresh: "r-xai",
+								expires: Date.now() + 3_600_000,
+							},
+						]);
+						return "fresh-xai-access";
+					}
+					return undefined;
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					expect(refreshedProviders).toEqual(["xai-oauth"]);
+					expect(captured.authHeader).toBe("Bearer fresh-xai-access");
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		test("refresh('offline') does not refresh expired OAuth credentials and does not hit the network", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "expired-refresh-token",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const fetchMock: FetchImpl = async input => {
+					throw new Error(`Unexpected network call in offline mode: ${String(input)}`);
+				};
+
+				const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+				const spy = spyOn(registry, "getApiKeyForProvider");
+
+				try {
+					await registry.refresh("offline");
+					expect(spy).not.toHaveBeenCalled();
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
 		});
 	});
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1498,13 +1498,26 @@ describe("ModelRegistry", () => {
 					},
 				]);
 
-				const registry = new ModelRegistry(authStorage, modelsJsonPath);
-				const spy = spyOn(registry, "getApiKeyForProvider").mockImplementation(() =>
+				// Lazy discovery resolver calls getOAuthAccess at fetch time; a
+				// rejecting refresh must degrade (serve static / skip remote)
+				// without aborting the discovery batch.
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(() =>
 					Promise.reject(new Error("Mocked refresh failure")),
 				);
 
-				await registry.refreshProvider("xai-oauth", "online");
-				expect(spy).toHaveBeenCalledWith("xai-oauth");
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+						fetch: async input => {
+							throw new Error(`Unexpected network call after refresh failure: ${String(input)}`);
+						},
+					});
+					await expect(registry.refreshProvider("xai-oauth", "online")).resolves.toBeUndefined();
+					expect(spy).toHaveBeenCalledWith("xai-oauth");
+					// Static seed remains available even when the lazy refresh fails.
+					expect(getModelsForProvider(registry, "xai-oauth").length).toBeGreaterThan(0);
+				} finally {
+					spy.mockRestore();
+				}
 			} finally {
 				if (originalXaiOAuthToken === undefined) {
 					delete Bun.env.XAI_OAUTH_TOKEN;
@@ -1553,23 +1566,18 @@ describe("ModelRegistry", () => {
 					throw new Error(`Unexpected URL: ${url}`);
 				};
 
-				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async () => {
-					await authStorage.set("xai-oauth", [
-						{
-							type: "oauth",
-							access: "fresh-access",
-							refresh: "r",
-							expires: Date.now() + 3_600_000,
-						},
-					]);
-					return "fresh-access";
+				// Lazy path: expired peek admits the provider via hasOAuth, then
+				// getOAuthAccess runs once inside fetchDynamicModels.
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async providerId => {
+					expect(providerId).toBe("xai-oauth");
+					return { accessToken: "fresh-access" };
 				});
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
 					await registry.refreshProvider("xai-oauth", "online");
 
-					expect(spy).toHaveBeenCalled();
+					expect(spy).toHaveBeenCalledWith("xai-oauth");
 					expect(captured.authHeader).toBe("Bearer fresh-access");
 				} finally {
 					spy.mockRestore();
@@ -1599,8 +1607,8 @@ describe("ModelRegistry", () => {
 					throw new Error(`Should not fetch because discovery is skipped`);
 				};
 
-				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async () => {
-					return "fresh-access";
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async () => {
+					return { accessToken: "fresh-access" };
 				});
 
 				try {
@@ -1669,18 +1677,10 @@ describe("ModelRegistry", () => {
 				};
 
 				const refreshedProviders: string[] = [];
-				const spy = spyOn(authStorage, "getApiKey").mockImplementation(async providerId => {
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async providerId => {
 					refreshedProviders.push(providerId);
 					if (providerId === "xai-oauth") {
-						await authStorage.set("xai-oauth", [
-							{
-								type: "oauth",
-								access: "fresh-xai-access",
-								refresh: "r-xai",
-								expires: Date.now() + 3_600_000,
-							},
-						]);
-						return "fresh-xai-access";
+						return { accessToken: "fresh-xai-access" };
 					}
 					return undefined;
 				});
@@ -1693,6 +1693,129 @@ describe("ModelRegistry", () => {
 					expect(captured.authHeader).toBe("Bearer fresh-xai-access");
 				} finally {
 					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		// #8 — no OAuth refresh when the manager will not fetch (offline is the
+		// deterministic proxy: strategy "offline" never hits remote sources).
+		test("offline discovery does not call getOAuthAccess for an expired OAuth provider", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "expired-refresh-token",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const fetchMock: FetchImpl = async input => {
+					throw new Error(`Unexpected network call in offline mode: ${String(input)}`);
+				};
+
+				const spy = spyOn(authStorage, "getOAuthAccess");
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await expect(registry.refreshProvider("xai-oauth", "offline")).resolves.toBeUndefined();
+					expect(spy).not.toHaveBeenCalled();
+				} finally {
+					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		// #9 — lazy resolver uses the single getOAuthAccess token as the discovery
+		// bearer; no second peek that could drift to another account.
+		test("lazy discovery Authorization bearer equals the single getOAuthAccess token", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "stale-peek-would-not-return",
+						refresh: "r",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const refreshedToken = "refreshed-account-token-no-drift";
+				const captured: { authHeader: string | null } = { authHeader: null };
+				const fetchMock: FetchImpl = async (input, init) => {
+					const url = input instanceof Request ? input.url : String(input);
+					if (url === "https://api.x.ai/v1/models") {
+						captured.authHeader =
+							input instanceof Request
+								? input.headers.get("Authorization")
+								: new Headers(init?.headers).get("Authorization");
+						return new Response(
+							JSON.stringify({
+								data: [{ id: "grok-4.5" }],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const getOAuthAccessSpy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async () => ({
+					accessToken: refreshedToken,
+				}));
+				const peekApiKeySpy = spyOn(authStorage, "peekApiKey");
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					// Exactly one refresh selection; bearer is that token, not a re-peek.
+					expect(getOAuthAccessSpy).toHaveBeenCalledTimes(1);
+					expect(getOAuthAccessSpy).toHaveBeenCalledWith("xai-oauth");
+					expect(captured.authHeader).toBe(`Bearer ${refreshedToken}`);
+					// peekApiKey may run for admission, but never after the refresh to
+					// re-select the bearer (call count stays at the admission peeks only).
+					const peekCallsAfterRefreshWouldSelectBearer = peekApiKeySpy.mock.calls.filter(
+						([provider]) => provider === "xai-oauth",
+					);
+					// Admission peeks only — if a post-refresh re-peek selected the
+					// bearer, the header would not be forced to the getOAuthAccess token
+					// above. Pin both sides of the contract.
+					expect(peekCallsAfterRefreshWouldSelectBearer.length).toBeGreaterThan(0);
+					expect(captured.authHeader).not.toBe("Bearer stale-peek-would-not-return");
+				} finally {
+					getOAuthAccessSpy.mockRestore();
+					peekApiKeySpy.mockRestore();
 				}
 			} finally {
 				if (originalXaiOAuthToken === undefined) {
@@ -1729,7 +1852,7 @@ describe("ModelRegistry", () => {
 				};
 
 				const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
-				const spy = spyOn(registry, "getApiKeyForProvider");
+				const spy = spyOn(authStorage, "getOAuthAccess");
 
 				try {
 					await registry.refresh("offline");

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1498,13 +1498,12 @@ describe("ModelRegistry", () => {
 					},
 				]);
 
-				// Lazy discovery resolver calls getOAuthAccessAt at fetch time; a
+				// Lazy discovery resolver calls getOAuthAccess at fetch time; a
 				// failed resolution must degrade (serve static / skip remote)
 				// without aborting the discovery batch.
-				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async () => ({
-					ok: false,
-					error: "mock-failure",
-				}));
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async () => {
+					throw new Error("mock-failure");
+				});
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, {
@@ -1513,7 +1512,7 @@ describe("ModelRegistry", () => {
 						},
 					});
 					await expect(registry.refreshProvider("xai-oauth", "online")).resolves.toBeUndefined();
-					expect(spy).toHaveBeenCalledWith("xai-oauth", 0);
+					expect(spy).toHaveBeenCalledWith("xai-oauth");
 					// Static seed remains available even when the lazy refresh fails.
 					expect(getModelsForProvider(registry, "xai-oauth").length).toBeGreaterThan(0);
 				} finally {
@@ -1568,18 +1567,17 @@ describe("ModelRegistry", () => {
 				};
 
 				// Lazy path: expired peek admits the provider via hasOAuth, then
-				// getOAuthAccessAt(0) runs once inside fetchDynamicModels.
-				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async (providerId, position) => {
+				// getOAuthAccess runs once inside fetchDynamicModels.
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async providerId => {
 					expect(providerId).toBe("xai-oauth");
-					expect(position).toBe(0);
-					return { ok: true, accessToken: "fresh-access" };
+					return { accessToken: "fresh-access" };
 				});
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
 					await registry.refreshProvider("xai-oauth", "online");
 
-					expect(spy).toHaveBeenCalledWith("xai-oauth", 0);
+					expect(spy).toHaveBeenCalledWith("xai-oauth");
 					expect(captured.authHeader).toBe("Bearer fresh-access");
 				} finally {
 					spy.mockRestore();
@@ -1609,8 +1607,7 @@ describe("ModelRegistry", () => {
 					throw new Error(`Should not fetch because discovery is skipped`);
 				};
 
-				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async () => ({
-					ok: true,
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async () => ({
 					accessToken: "fresh-access",
 				}));
 
@@ -1680,13 +1677,12 @@ describe("ModelRegistry", () => {
 				};
 
 				const refreshedProviders: string[] = [];
-				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async (providerId, position) => {
+				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async providerId => {
 					refreshedProviders.push(providerId);
 					if (providerId === "xai-oauth") {
-						expect(position).toBe(0);
-						return { ok: true, accessToken: "fresh-xai-access" };
+						return { accessToken: "fresh-xai-access" };
 					}
-					return { ok: false, error: "mock-failure" };
+					throw new Error("mock-failure");
 				});
 
 				try {
@@ -1712,9 +1708,7 @@ describe("ModelRegistry", () => {
 			}
 		});
 
-		// #8 — no OAuth refresh when the manager will not fetch (offline is the
-		// deterministic proxy: strategy "offline" never hits remote sources).
-		test("offline discovery does not call getOAuthAccessAt for an expired OAuth provider", async () => {
+		test("offline discovery does not call getOAuthAccess for an expired OAuth provider", async () => {
 			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
 			const originalXaiApiKey = Bun.env.XAI_API_KEY;
 			delete Bun.env.XAI_OAUTH_TOKEN;
@@ -1734,7 +1728,7 @@ describe("ModelRegistry", () => {
 					throw new Error(`Unexpected network call in offline mode: ${String(input)}`);
 				};
 
-				const spy = spyOn(authStorage, "getOAuthAccessAt");
+				const spy = spyOn(authStorage, "getOAuthAccess");
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
@@ -1757,9 +1751,7 @@ describe("ModelRegistry", () => {
 			}
 		});
 
-		// #9 — lazy resolver uses the single getOAuthAccessAt token as the discovery
-		// bearer; no second peek that could drift to another account.
-		test("lazy discovery Authorization bearer equals the single getOAuthAccessAt token", async () => {
+		test("lazy discovery Authorization bearer equals the single getOAuthAccess token", async () => {
 			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
 			const originalXaiApiKey = Bun.env.XAI_API_KEY;
 			delete Bun.env.XAI_OAUTH_TOKEN;
@@ -1794,22 +1786,18 @@ describe("ModelRegistry", () => {
 					throw new Error(`Unexpected URL: ${url}`);
 				};
 
-				const getOAuthAccessAtSpy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(
-					async (providerId, position) => {
-						expect(providerId).toBe("xai-oauth");
-						expect(position).toBe(0);
-						return { ok: true, accessToken: refreshedToken };
-					},
-				);
+				const getOAuthAccessSpy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async () => ({
+					accessToken: refreshedToken,
+				}));
 				const peekApiKeySpy = spyOn(authStorage, "peekApiKey");
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
 					await registry.refreshProvider("xai-oauth", "online");
 
-					// Exactly one refresh selection at position 0; bearer is that token, not a re-peek.
-					expect(getOAuthAccessAtSpy).toHaveBeenCalledTimes(1);
-					expect(getOAuthAccessAtSpy).toHaveBeenCalledWith("xai-oauth", 0);
+					// Exactly one session-active refresh selection; bearer is that token, not a re-peek.
+					expect(getOAuthAccessSpy).toHaveBeenCalledTimes(1);
+					expect(getOAuthAccessSpy).toHaveBeenCalledWith("xai-oauth");
 					expect(captured.authHeader).toBe(`Bearer ${refreshedToken}`);
 					// peekApiKey may run for admission, but never after the refresh to
 					// re-select the bearer (call count stays at the admission peeks only).
@@ -1817,12 +1805,12 @@ describe("ModelRegistry", () => {
 						([provider]) => provider === "xai-oauth",
 					);
 					// Admission peeks only — if a post-refresh re-peek selected the
-					// bearer, the header would not be forced to the getOAuthAccessAt token
+					// bearer, the header would not be forced to the getOAuthAccess token
 					// above. Pin both sides of the contract.
 					expect(peekCallsAfterRefreshWouldSelectBearer.length).toBeGreaterThan(0);
 					expect(captured.authHeader).not.toBe("Bearer stale-peek-would-not-return");
 				} finally {
-					getOAuthAccessAtSpy.mockRestore();
+					getOAuthAccessSpy.mockRestore();
 					peekApiKeySpy.mockRestore();
 				}
 			} finally {
@@ -1860,7 +1848,7 @@ describe("ModelRegistry", () => {
 				};
 
 				const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
-				const spy = spyOn(authStorage, "getOAuthAccessAt");
+				const spy = spyOn(authStorage, "getOAuthAccess");
 
 				try {
 					await registry.refresh("offline");
@@ -1882,17 +1870,15 @@ describe("ModelRegistry", () => {
 			}
 		});
 
-		// #10 — multi-account provider pins discovery bearer and cache key to the
-		// same OAuth row (position 0), so it cannot fetch under one account and
-		// serve/cache under another.
-		test("multi-account built-in discovery pins bearer to OAuth position 0", async () => {
-			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
-			const originalXaiApiKey = Bun.env.XAI_API_KEY;
-			delete Bun.env.XAI_OAUTH_TOKEN;
-			delete Bun.env.XAI_API_KEY;
+		test("multi-account built-in discovery pins bearer to OAuth position 0 for gitlab-duo-agent", async () => {
+			const originalGitlabToken = Bun.env.GITLAB_TOKEN;
+			const originalGitlabNamespaceId = Bun.env.GITLAB_DUO_NAMESPACE_ID;
+			delete Bun.env.GITLAB_TOKEN;
+			delete Bun.env.GITLAB_DUO_NAMESPACE_ID;
+			Bun.env.GITLAB_DUO_NAMESPACE_ID = "123";
 
 			try {
-				await authStorage.set("xai-oauth", [
+				await authStorage.set("gitlab-duo-agent", [
 					{
 						type: "oauth",
 						access: "stale-account-0",
@@ -1907,17 +1893,27 @@ describe("ModelRegistry", () => {
 					},
 				]);
 
-				const captured: { authHeader: string | null } = { authHeader: null };
+				const captured: { authHeader: string | null; graphqlUrl: string | null } = {
+					authHeader: null,
+					graphqlUrl: null,
+				};
 				const fetchMock: FetchImpl = async (input, init) => {
 					const url = input instanceof Request ? input.url : String(input);
-					if (url === "https://api.x.ai/v1/models") {
+					if (url === "https://gitlab.com/api/graphql") {
+						captured.graphqlUrl = url;
 						captured.authHeader =
 							input instanceof Request
 								? input.headers.get("Authorization")
 								: new Headers(init?.headers).get("Authorization");
 						return new Response(
 							JSON.stringify({
-								data: [{ id: "grok-4.5" }],
+								data: {
+									aiChatAvailableModels: {
+										defaultModel: null,
+										selectableModels: [{ name: "Claude Sonnet 4.6", ref: "claude_sonnet_4_6_vertex" }],
+										pinnedModel: null,
+									},
+								},
 							}),
 							{ status: 200, headers: { "Content-Type": "application/json" } },
 						);
@@ -1940,10 +1936,11 @@ describe("ModelRegistry", () => {
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
-					await registry.refreshProvider("xai-oauth", "online");
+					await registry.refreshProvider("gitlab-duo-agent", "online");
 
+					expect(captured.graphqlUrl).toBe("https://gitlab.com/api/graphql");
 					expect(captured.authHeader).toBe("Bearer tok-account-0");
-					expect(getOAuthAccessAtSpy).toHaveBeenCalledWith("xai-oauth", 0);
+					expect(getOAuthAccessAtSpy).toHaveBeenCalledWith("gitlab-duo-agent", 0);
 					expect(getOAuthAccessAtSpy.mock.calls.some(([, position]) => position === 1)).toBe(false);
 					expect(getOAuthAccessSpy).not.toHaveBeenCalled();
 				} finally {
@@ -1951,20 +1948,157 @@ describe("ModelRegistry", () => {
 					getOAuthAccessSpy.mockRestore();
 				}
 			} finally {
-				if (originalXaiOAuthToken === undefined) {
-					delete Bun.env.XAI_OAUTH_TOKEN;
+				if (originalGitlabToken === undefined) {
+					delete Bun.env.GITLAB_TOKEN;
 				} else {
-					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+					Bun.env.GITLAB_TOKEN = originalGitlabToken;
 				}
-				if (originalXaiApiKey === undefined) {
-					delete Bun.env.XAI_API_KEY;
+				if (originalGitlabNamespaceId === undefined) {
+					delete Bun.env.GITLAB_DUO_NAMESPACE_ID;
 				} else {
-					Bun.env.XAI_API_KEY = originalXaiApiKey;
+					Bun.env.GITLAB_DUO_NAMESPACE_ID = originalGitlabNamespaceId;
+				}
+			}
+		});
+
+		test("gitlab-duo-agent mixed-auth: failed OAuth refresh does not fall back to the configured token", async () => {
+			const originalGitlabToken = Bun.env.GITLAB_TOKEN;
+			const originalGitlabNamespaceId = Bun.env.GITLAB_DUO_NAMESPACE_ID;
+			delete Bun.env.GITLAB_TOKEN;
+			delete Bun.env.GITLAB_DUO_NAMESPACE_ID;
+			Bun.env.GITLAB_TOKEN = "configured-gitlab-token";
+			Bun.env.GITLAB_DUO_NAMESPACE_ID = "123";
+
+			try {
+				await authStorage.set("gitlab-duo-agent", [
+					{
+						type: "oauth",
+						access: "expired-access-token",
+						refresh: "expired-refresh-token",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const requestedUrls: string[] = [];
+				const fetchMock: FetchImpl = async (input, init) => {
+					const url = input instanceof Request ? input.url : String(input);
+					requestedUrls.push(url);
+					if (url === "https://gitlab.com/api/graphql") {
+						return new Response(
+							JSON.stringify({
+								data: {
+									aiChatAvailableModels: {
+										defaultModel: null,
+										selectableModels: [{ name: "Claude Sonnet 4.6", ref: "claude_sonnet_4_6_vertex" }],
+										pinnedModel: null,
+									},
+								},
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const getOAuthAccessAtSpy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async () => {
+					return { ok: false, error: "mock-failure" };
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("gitlab-duo-agent", "online");
+
+					expect(requestedUrls).not.toContain("https://gitlab.com/api/graphql");
+					expect(getOAuthAccessAtSpy).toHaveBeenCalledWith("gitlab-duo-agent", 0);
+				} finally {
+					getOAuthAccessAtSpy.mockRestore();
+				}
+			} finally {
+				if (originalGitlabToken === undefined) {
+					delete Bun.env.GITLAB_TOKEN;
+				} else {
+					Bun.env.GITLAB_TOKEN = originalGitlabToken;
+				}
+				if (originalGitlabNamespaceId === undefined) {
+					delete Bun.env.GITLAB_DUO_NAMESPACE_ID;
+				} else {
+					Bun.env.GITLAB_DUO_NAMESPACE_ID = originalGitlabNamespaceId;
+				}
+			}
+		});
+
+		test("github-copilot built-in discovery uses session-active getOAuthAccess and honors apiEndpoint", async () => {
+			const originalCopilotToken = Bun.env.COPILOT_GITHUB_TOKEN;
+			delete Bun.env.COPILOT_GITHUB_TOKEN;
+
+			try {
+				await authStorage.set("github-copilot", [
+					{
+						type: "oauth",
+						access: "stale-copilot-access",
+						refresh: "r",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const activeAccess = {
+					accessToken: "copilot-token",
+					apiEndpoint: "https://api.business.githubcopilot.com",
+				};
+				const requestedUrls: string[] = [];
+				const fetchMock: FetchImpl = async input => {
+					const url = input instanceof Request ? input.url : String(input);
+					requestedUrls.push(url);
+					if (url === "https://api.business.githubcopilot.com/models") {
+						return new Response(
+							JSON.stringify({
+								data: [
+									{
+										id: "gpt-5.5",
+										name: "GPT 5.5",
+										capabilities: { type: "chat" },
+										context_length: 100_000,
+									},
+								],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					if (url === "https://api.githubcopilot.com/models") {
+						throw new Error(
+							"github-copilot discovery must target the active account apiEndpoint, not the default host",
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const getOAuthAccessSpy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async providerId => {
+					expect(providerId).toBe("github-copilot");
+					return activeAccess;
+				});
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("github-copilot", "online");
+
+					expect(getOAuthAccessSpy).toHaveBeenCalledWith("github-copilot");
+					expect(requestedUrls).toContain("https://api.business.githubcopilot.com/models");
+					expect(requestedUrls).not.toContain("https://api.githubcopilot.com/models");
+					const discovered = getModelsForProvider(registry, "github-copilot").filter(m => m.id === "gpt-5.5");
+					expect(discovered.length).toBeGreaterThan(0);
+					expect(discovered[0]?.baseUrl).toBe("https://api.business.githubcopilot.com");
+				} finally {
+					getOAuthAccessSpy.mockRestore();
+				}
+			} finally {
+				if (originalCopilotToken === undefined) {
+					delete Bun.env.COPILOT_GITHUB_TOKEN;
+				} else {
+					Bun.env.COPILOT_GITHUB_TOKEN = originalCopilotToken;
 				}
 			}
 		});
 	});
-
 	describe("disabled provider filtering", () => {
 		test("getAvailable and getDiscoverableProviders exclude disabled providers from settings", async () => {
 			writeRawModelsJson({

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1498,12 +1498,13 @@ describe("ModelRegistry", () => {
 					},
 				]);
 
-				// Lazy discovery resolver calls getOAuthAccess at fetch time; a
-				// rejecting refresh must degrade (serve static / skip remote)
+				// Lazy discovery resolver calls getOAuthAccessAt at fetch time; a
+				// failed resolution must degrade (serve static / skip remote)
 				// without aborting the discovery batch.
-				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(() =>
-					Promise.reject(new Error("Mocked refresh failure")),
-				);
+				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async () => ({
+					ok: false,
+					error: "mock-failure",
+				}));
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, {
@@ -1512,7 +1513,7 @@ describe("ModelRegistry", () => {
 						},
 					});
 					await expect(registry.refreshProvider("xai-oauth", "online")).resolves.toBeUndefined();
-					expect(spy).toHaveBeenCalledWith("xai-oauth");
+					expect(spy).toHaveBeenCalledWith("xai-oauth", 0);
 					// Static seed remains available even when the lazy refresh fails.
 					expect(getModelsForProvider(registry, "xai-oauth").length).toBeGreaterThan(0);
 				} finally {
@@ -1567,17 +1568,18 @@ describe("ModelRegistry", () => {
 				};
 
 				// Lazy path: expired peek admits the provider via hasOAuth, then
-				// getOAuthAccess runs once inside fetchDynamicModels.
-				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async providerId => {
+				// getOAuthAccessAt(0) runs once inside fetchDynamicModels.
+				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async (providerId, position) => {
 					expect(providerId).toBe("xai-oauth");
-					return { accessToken: "fresh-access" };
+					expect(position).toBe(0);
+					return { ok: true, accessToken: "fresh-access" };
 				});
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
 					await registry.refreshProvider("xai-oauth", "online");
 
-					expect(spy).toHaveBeenCalledWith("xai-oauth");
+					expect(spy).toHaveBeenCalledWith("xai-oauth", 0);
 					expect(captured.authHeader).toBe("Bearer fresh-access");
 				} finally {
 					spy.mockRestore();
@@ -1607,9 +1609,10 @@ describe("ModelRegistry", () => {
 					throw new Error(`Should not fetch because discovery is skipped`);
 				};
 
-				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async () => {
-					return { accessToken: "fresh-access" };
-				});
+				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async () => ({
+					ok: true,
+					accessToken: "fresh-access",
+				}));
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
@@ -1677,12 +1680,13 @@ describe("ModelRegistry", () => {
 				};
 
 				const refreshedProviders: string[] = [];
-				const spy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async providerId => {
+				const spy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(async (providerId, position) => {
 					refreshedProviders.push(providerId);
 					if (providerId === "xai-oauth") {
-						return { accessToken: "fresh-xai-access" };
+						expect(position).toBe(0);
+						return { ok: true, accessToken: "fresh-xai-access" };
 					}
-					return undefined;
+					return { ok: false, error: "mock-failure" };
 				});
 
 				try {
@@ -1710,7 +1714,7 @@ describe("ModelRegistry", () => {
 
 		// #8 — no OAuth refresh when the manager will not fetch (offline is the
 		// deterministic proxy: strategy "offline" never hits remote sources).
-		test("offline discovery does not call getOAuthAccess for an expired OAuth provider", async () => {
+		test("offline discovery does not call getOAuthAccessAt for an expired OAuth provider", async () => {
 			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
 			const originalXaiApiKey = Bun.env.XAI_API_KEY;
 			delete Bun.env.XAI_OAUTH_TOKEN;
@@ -1730,7 +1734,7 @@ describe("ModelRegistry", () => {
 					throw new Error(`Unexpected network call in offline mode: ${String(input)}`);
 				};
 
-				const spy = spyOn(authStorage, "getOAuthAccess");
+				const spy = spyOn(authStorage, "getOAuthAccessAt");
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
@@ -1753,9 +1757,9 @@ describe("ModelRegistry", () => {
 			}
 		});
 
-		// #9 — lazy resolver uses the single getOAuthAccess token as the discovery
+		// #9 — lazy resolver uses the single getOAuthAccessAt token as the discovery
 		// bearer; no second peek that could drift to another account.
-		test("lazy discovery Authorization bearer equals the single getOAuthAccess token", async () => {
+		test("lazy discovery Authorization bearer equals the single getOAuthAccessAt token", async () => {
 			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
 			const originalXaiApiKey = Bun.env.XAI_API_KEY;
 			delete Bun.env.XAI_OAUTH_TOKEN;
@@ -1790,18 +1794,22 @@ describe("ModelRegistry", () => {
 					throw new Error(`Unexpected URL: ${url}`);
 				};
 
-				const getOAuthAccessSpy = spyOn(authStorage, "getOAuthAccess").mockImplementation(async () => ({
-					accessToken: refreshedToken,
-				}));
+				const getOAuthAccessAtSpy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(
+					async (providerId, position) => {
+						expect(providerId).toBe("xai-oauth");
+						expect(position).toBe(0);
+						return { ok: true, accessToken: refreshedToken };
+					},
+				);
 				const peekApiKeySpy = spyOn(authStorage, "peekApiKey");
 
 				try {
 					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
 					await registry.refreshProvider("xai-oauth", "online");
 
-					// Exactly one refresh selection; bearer is that token, not a re-peek.
-					expect(getOAuthAccessSpy).toHaveBeenCalledTimes(1);
-					expect(getOAuthAccessSpy).toHaveBeenCalledWith("xai-oauth");
+					// Exactly one refresh selection at position 0; bearer is that token, not a re-peek.
+					expect(getOAuthAccessAtSpy).toHaveBeenCalledTimes(1);
+					expect(getOAuthAccessAtSpy).toHaveBeenCalledWith("xai-oauth", 0);
 					expect(captured.authHeader).toBe(`Bearer ${refreshedToken}`);
 					// peekApiKey may run for admission, but never after the refresh to
 					// re-select the bearer (call count stays at the admission peeks only).
@@ -1809,12 +1817,12 @@ describe("ModelRegistry", () => {
 						([provider]) => provider === "xai-oauth",
 					);
 					// Admission peeks only — if a post-refresh re-peek selected the
-					// bearer, the header would not be forced to the getOAuthAccess token
+					// bearer, the header would not be forced to the getOAuthAccessAt token
 					// above. Pin both sides of the contract.
 					expect(peekCallsAfterRefreshWouldSelectBearer.length).toBeGreaterThan(0);
 					expect(captured.authHeader).not.toBe("Bearer stale-peek-would-not-return");
 				} finally {
-					getOAuthAccessSpy.mockRestore();
+					getOAuthAccessAtSpy.mockRestore();
 					peekApiKeySpy.mockRestore();
 				}
 			} finally {
@@ -1852,13 +1860,95 @@ describe("ModelRegistry", () => {
 				};
 
 				const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
-				const spy = spyOn(authStorage, "getOAuthAccess");
+				const spy = spyOn(authStorage, "getOAuthAccessAt");
 
 				try {
 					await registry.refresh("offline");
 					expect(spy).not.toHaveBeenCalled();
 				} finally {
 					spy.mockRestore();
+				}
+			} finally {
+				if (originalXaiOAuthToken === undefined) {
+					delete Bun.env.XAI_OAUTH_TOKEN;
+				} else {
+					Bun.env.XAI_OAUTH_TOKEN = originalXaiOAuthToken;
+				}
+				if (originalXaiApiKey === undefined) {
+					delete Bun.env.XAI_API_KEY;
+				} else {
+					Bun.env.XAI_API_KEY = originalXaiApiKey;
+				}
+			}
+		});
+
+		// #10 — multi-account provider pins discovery bearer and cache key to the
+		// same OAuth row (position 0), so it cannot fetch under one account and
+		// serve/cache under another.
+		test("multi-account built-in discovery pins bearer to OAuth position 0", async () => {
+			const originalXaiOAuthToken = Bun.env.XAI_OAUTH_TOKEN;
+			const originalXaiApiKey = Bun.env.XAI_API_KEY;
+			delete Bun.env.XAI_OAUTH_TOKEN;
+			delete Bun.env.XAI_API_KEY;
+
+			try {
+				await authStorage.set("xai-oauth", [
+					{
+						type: "oauth",
+						access: "stale-account-0",
+						refresh: "r0",
+						expires: Date.now() - 60_000,
+					},
+					{
+						type: "oauth",
+						access: "stale-account-1",
+						refresh: "r1",
+						expires: Date.now() - 60_000,
+					},
+				]);
+
+				const captured: { authHeader: string | null } = { authHeader: null };
+				const fetchMock: FetchImpl = async (input, init) => {
+					const url = input instanceof Request ? input.url : String(input);
+					if (url === "https://api.x.ai/v1/models") {
+						captured.authHeader =
+							input instanceof Request
+								? input.headers.get("Authorization")
+								: new Headers(init?.headers).get("Authorization");
+						return new Response(
+							JSON.stringify({
+								data: [{ id: "grok-4.5" }],
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					throw new Error(`Unexpected URL: ${url}`);
+				};
+
+				const getOAuthAccessAtSpy = spyOn(authStorage, "getOAuthAccessAt").mockImplementation(
+					async (_provider, position) => {
+						if (position === 0) {
+							return { ok: true, accessToken: "tok-account-0" };
+						}
+						if (position === 1) {
+							return { ok: true, accessToken: "tok-account-1" };
+						}
+						return { ok: false, error: "mock-failure" };
+					},
+				);
+				const getOAuthAccessSpy = spyOn(authStorage, "getOAuthAccess");
+
+				try {
+					const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+					await registry.refreshProvider("xai-oauth", "online");
+
+					expect(captured.authHeader).toBe("Bearer tok-account-0");
+					expect(getOAuthAccessAtSpy).toHaveBeenCalledWith("xai-oauth", 0);
+					expect(getOAuthAccessAtSpy.mock.calls.some(([, position]) => position === 1)).toBe(false);
+					expect(getOAuthAccessSpy).not.toHaveBeenCalled();
+				} finally {
+					getOAuthAccessAtSpy.mockRestore();
+					getOAuthAccessSpy.mockRestore();
 				}
 			} finally {
 				if (originalXaiOAuthToken === undefined) {


### PR DESCRIPTION
## Summary

Built-in model discovery now recovers when a stored OAuth access token has expired instead of silently skipping that provider. Online discovery refreshes only the providers it is about to discover, while offline discovery remains a cheap peek-only path.

## Details

- Refreshes expired stored OAuth credentials for built-in online discovery before deciding a provider is unauthenticated.
- Re-peeks after refresh so envelope-shaped credentials keep their existing shape.
- Contains refresh rejection so one expired provider does not abort all discovery.
- Applies configured-provider and targeted-provider filters before side-effecting refresh calls.
- Leaves offline discovery peek-only so opening cached model selectors does not rotate or disable OAuth credentials.
- Documents the discovery fix in the coding-agent changelog.

## Validation

- `bun check`
- `cd packages/coding-agent && bun test test/model-registry.test.ts` — `87 pass`, `0 fail`.

Closes #4893
