### PR TITLE
fix(providers): use Grok 4.5 for xAI web search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed xAI `web_search` requests to use Grok 4.5 for search-backed answers instead of Grok 4.3. ([#4891](https://github.com/can1357/oh-my-pi/issues/4891))
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -8,7 +8,7 @@ import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
-const XAI_WEB_SEARCH_MODEL = "grok-4.3";
+const XAI_WEB_SEARCH_MODEL = "grok-4.5";
 const DEFAULT_NUM_RESULTS = 10;
 const MAX_NUM_RESULTS = 30;
 

--- a/packages/coding-agent/test/tools/web-search-xai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-xai.test.ts
@@ -124,7 +124,7 @@ describe("xAI web search provider", () => {
 	});
 
 	it("POSTs the Responses API with bearer auth and xAI web_search tool payload", async () => {
-		const capture = captureFetch({ id: "resp_request", model: "grok-4.3", output_text: "xAI answer" });
+		const capture = captureFetch({ id: "resp_request", model: "grok-4.5", output_text: "xAI answer" });
 
 		await searchXAI({
 			...makeParams(capture.fetchMock),
@@ -140,7 +140,7 @@ describe("xAI web search provider", () => {
 			Authorization: "Bearer test-xai-key",
 		});
 		expect(capture.capturedRequest?.body).toMatchObject({
-			model: "grok-4.3",
+			model: "grok-4.5",
 			input: [
 				{ role: "system", content: "Use web search for current xAI facts." },
 				{ role: "user", content: "latest xAI web search" },


### PR DESCRIPTION
## Repro
Updating the xAI web search request contract to expect Grok 4.5 reproduces the issue: `bun test packages/coding-agent/test/tools/web-search-xai.test.ts -t "POSTs the Responses API"` failed because the captured Responses API body still contained `model: "grok-4.3"`.

## Cause
`packages/coding-agent/src/web/search/providers/xai.ts` defines `XAI_WEB_SEARCH_MODEL` as `grok-4.3`, and `buildRequestBody` serializes that constant into every xAI Responses API `web_search` payload.

## Fix
- Changed the xAI web search model constant from `grok-4.3` to `grok-4.5`.
- Updated the xAI web search provider test to assert the outbound Responses API payload requests Grok 4.5.
- Added an Unreleased changelog entry for the provider fix.

## Verification
`bun test packages/coding-agent/test/tools/web-search-xai.test.ts -t "POSTs the Responses API"` now passes with 1 test; `bun test packages/coding-agent/test/tools/web-search-xai.test.ts` passes with 24 tests; `bun run check` from `packages/coding-agent` passed. Pre-publish gate also ran during branch push. Fixes #4891