### PR TITLE
fix(auth): refresh expired OAuth tokens for online discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed built-in provider model discovery to refresh only the expired stored OAuth credential needed for an online provider refresh, while leaving unrelated providers and offline discovery untouched ([#4893](https://github.com/can1357/oh-my-pi/issues/4893)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -54,6 +54,7 @@ const LOCAL_PROVIDER_PLACEHOLDERS = new Set<string>(["llama-cpp-local", "lm-stud
  * so a successful fast path does not leave an armed timeout signal for concurrent GC.
  */
 const RUNTIME_DYNAMIC_MODEL_FETCH_TIMEOUT_MS = 15_000;
+const BUILT_IN_DISCOVERY_NON_AUTHORITATIVE_RETRY_MS = 5 * 60 * 1000;
 
 import type { ApiKeyResolver, FetchImpl } from "@oh-my-pi/pi-ai";
 import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
@@ -1560,12 +1561,11 @@ export class ModelRegistry {
 	): Promise<BuiltInDiscoveryResult> {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(p => p.provider));
-		const managerOptions = (await this.#collectBuiltInModelManagerOptions()).filter(opts => {
-			if (configuredDiscoveryProviders.has(opts.providerId)) {
-				return false;
-			}
-			return providerFilter ? providerFilter.has(opts.providerId) : true;
-		});
+		const managerOptions = await this.#collectBuiltInModelManagerOptions(
+			strategy,
+			providerFilter,
+			configuredDiscoveryProviders,
+		);
 		if (managerOptions.length === 0) {
 			return { models: [], authoritativeProviders: new Set() };
 		}
@@ -1583,7 +1583,42 @@ export class ModelRegistry {
 		return { models, authoritativeProviders };
 	}
 
-	async #collectBuiltInModelManagerOptions(): Promise<ModelManagerOptions<Api>[]> {
+	async #resolveBuiltInDiscoveryApiKey(
+		providerId: string,
+		strategy: ModelRefreshStrategy,
+		cacheProviderId: string,
+	): Promise<string | undefined> {
+		const peekedKey = await this.#peekApiKeyForProvider(providerId);
+		if (isAuthenticated(peekedKey) || strategy === "offline") {
+			return peekedKey;
+		}
+		const oauthCredentials = getOAuthCredentialsForProvider(this.authStorage, providerId);
+		if (oauthCredentials.length === 0) {
+			return peekedKey;
+		}
+		if (strategy === "online-if-uncached") {
+			const cache = readModelCache<Api>(cacheProviderId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
+			const cacheAgeMs = cache ? Date.now() - cache.updatedAt : Number.POSITIVE_INFINITY;
+			if (cache?.fresh && (cache.authoritative || cacheAgeMs < BUILT_IN_DISCOVERY_NON_AUTHORITATIVE_RETRY_MS)) {
+				return peekedKey;
+			}
+		}
+		try {
+			return await this.getApiKeyForProvider(providerId);
+		} catch (error) {
+			logger.debug("OAuth refresh failed during model discovery preflight", {
+				provider: providerId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return peekedKey;
+		}
+	}
+
+	async #collectBuiltInModelManagerOptions(
+		strategy: ModelRefreshStrategy,
+		providerFilter: ReadonlySet<string> | undefined,
+		configuredDiscoveryProviders: ReadonlySet<string>,
+	): Promise<ModelManagerOptions<Api>[]> {
 		const specialProviderDescriptors: Array<{
 			providerId: string;
 			resolveKey: (value: string | undefined) => string | undefined;
@@ -1622,20 +1657,32 @@ export class ModelRegistry {
 			},
 		];
 		const disabledProviders = getDisabledProviderIdsFromSettings();
-		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId),
+		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(descriptor => {
+			if (disabledProviders.has(descriptor.providerId)) return false;
+			if (configuredDiscoveryProviders.has(descriptor.providerId)) return false;
+			return providerFilter ? providerFilter.has(descriptor.providerId) : true;
+		});
+		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(descriptor => {
+			if (disabledProviders.has(descriptor.providerId)) return false;
+			return providerFilter ? providerFilter.has(descriptor.providerId) : true;
+		});
+		const standardProviderKeys = await Promise.all(
+			standardProviderDescriptors.map(descriptor => {
+				const discoveryBaseUrl =
+					this.#runtimeProviderOverrides.get(descriptor.providerId)?.baseUrl ??
+					this.#providerOverrides.get(descriptor.providerId)?.baseUrl ??
+					this.getProviderBaseUrl(descriptor.providerId);
+				const cacheProviderId =
+					descriptor.createModelManagerOptions({ baseUrl: discoveryBaseUrl, fetch: this.#fetch })
+						.cacheProviderId ?? descriptor.providerId;
+				return this.#resolveBuiltInDiscoveryApiKey(descriptor.providerId, strategy, cacheProviderId);
+			}),
 		);
-		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(
-			descriptor => !disabledProviders.has(descriptor.providerId),
+		const specialKeys = await Promise.all(
+			enabledSpecialProviderDescriptors.map(descriptor =>
+				this.#resolveBuiltInDiscoveryApiKey(descriptor.providerId, strategy, descriptor.providerId),
+			),
 		);
-		// Use peekApiKey to avoid OAuth token refresh during discovery.
-		// The token is only needed if the dynamic fetch fires (cache miss),
-		// and failures there are handled gracefully.
-		const peekKey = (descriptor: { providerId: string }) => this.#peekApiKeyForProvider(descriptor.providerId);
-		const [standardProviderKeys, specialKeys] = await Promise.all([
-			Promise.all(standardProviderDescriptors.map(peekKey)),
-			Promise.all(enabledSpecialProviderDescriptors.map(peekKey)),
-		]);
 		const options: ModelManagerOptions<Api>[] = [];
 		for (let i = 0; i < standardProviderDescriptors.length; i++) {
 			const descriptor = standardProviderDescriptors[i];
@@ -1670,7 +1717,9 @@ export class ModelRegistry {
 		}
 		// Append runtime model managers registered by extensions via fetchDynamicModels.
 		for (const { options: managerOpts } of this.#runtimeModelManagers.values()) {
-			options.push(managerOpts);
+			if (!providerFilter || providerFilter.has(managerOpts.providerId)) {
+				options.push(managerOpts);
+			}
 		}
 		return options;
 	}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1664,6 +1664,7 @@ export class ModelRegistry {
 		});
 		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(descriptor => {
 			if (disabledProviders.has(descriptor.providerId)) return false;
+			if (configuredDiscoveryProviders.has(descriptor.providerId)) return false;
 			return providerFilter ? providerFilter.has(descriptor.providerId) : true;
 		});
 		const standardProviderKeys = await Promise.all(

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1718,7 +1718,10 @@ export class ModelRegistry {
 		}
 		// Append runtime model managers registered by extensions via fetchDynamicModels.
 		for (const { options: managerOpts } of this.#runtimeModelManagers.values()) {
-			if (!providerFilter || providerFilter.has(managerOpts.providerId)) {
+			if (
+				!configuredDiscoveryProviders.has(managerOpts.providerId) &&
+				(!providerFilter || providerFilter.has(managerOpts.providerId))
+			) {
 				options.push(managerOpts);
 			}
 		}

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Effort, type FetchImpl, type Model } from "@oh-my-pi/pi-ai";
+import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import type { OpenAICompat } from "@oh-my-pi/pi-catalog/types";
@@ -19,15 +20,18 @@ describe("ModelRegistry runtime discovery", () => {
 	let originalOllamaBaseUrl: string | undefined;
 	let originalOllamaHost: string | undefined;
 	let originalOllamaContextLength: string | undefined;
+	let originalAnthropicApiKey: string | undefined;
 
 	beforeEach(async () => {
 		resetSettingsForTest();
 		originalOllamaBaseUrl = Bun.env.OLLAMA_BASE_URL;
 		originalOllamaHost = Bun.env.OLLAMA_HOST;
 		originalOllamaContextLength = Bun.env.OLLAMA_CONTEXT_LENGTH;
+		originalAnthropicApiKey = Bun.env.ANTHROPIC_API_KEY;
 		delete Bun.env.OLLAMA_BASE_URL;
 		delete Bun.env.OLLAMA_HOST;
 		delete Bun.env.OLLAMA_CONTEXT_LENGTH;
+		delete Bun.env.ANTHROPIC_API_KEY;
 		tempDir = path.join(os.tmpdir(), `pi-test-model-registry-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		modelsJsonPath = path.join(tempDir, "models.json");
@@ -54,6 +58,11 @@ describe("ModelRegistry runtime discovery", () => {
 			delete Bun.env.OLLAMA_CONTEXT_LENGTH;
 		} else {
 			Bun.env.OLLAMA_CONTEXT_LENGTH = originalOllamaContextLength;
+		}
+		if (originalAnthropicApiKey === undefined) {
+			delete Bun.env.ANTHROPIC_API_KEY;
+		} else {
+			Bun.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
 		}
 		authStorage.close();
 		if (tempDir && fs.existsSync(tempDir)) {
@@ -114,6 +123,116 @@ describe("ModelRegistry runtime discovery", () => {
 			throw new Error(`Unexpected URL: ${url}`);
 		};
 	}
+
+	async function useAuthStorageWithRefreshTracker() {
+		authStorage.close();
+		const refreshCalls: string[] = [];
+		authStorage = await AuthStorage.create(":memory:", {
+			refreshOAuthCredential: async (provider, _credentialId, credential): Promise<OAuthCredentials> => {
+				refreshCalls.push(provider);
+				return {
+					...credential,
+					access: provider === "anthropic" ? "sk-ant-oat-fresh-anthropic" : `fresh-${provider}`,
+					expires: Date.now() + 3_600_000,
+				};
+			},
+		});
+		return { refreshCalls };
+	}
+
+	type AnthropicDiscoveryCapture = {
+		modelListAuthorization?: string | null;
+		modelListXApiKey?: string | null;
+		modelListCalls: number;
+	};
+
+	function mockAnthropicModelsDiscovery(capture: AnthropicDiscoveryCapture): FetchImpl {
+		const endpointPrefix = "https://api.anthropic.com/";
+		return async (input, init) => {
+			const url = String(input);
+			if (url === "https://models.dev/api.json") {
+				return Response.json({});
+			}
+			if (url.startsWith(endpointPrefix) && url.endsWith("/models")) {
+				const headers = new Headers(init?.headers);
+				capture.modelListAuthorization = headers.get("authorization");
+				capture.modelListXApiKey = headers.get("x-api-key");
+				capture.modelListCalls++;
+				return Response.json({
+					data: [{ id: "claude-regression-4893", display_name: "Claude Regression 4893" }],
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+	}
+
+	test("refreshProvider online refreshes expired anthropic OAuth before model discovery", async () => {
+		const { refreshCalls } = await useAuthStorageWithRefreshTracker();
+		await authStorage.set("anthropic", {
+			type: "oauth",
+			access: "sk-ant-oat-expired-anthropic",
+			refresh: "refresh-anthropic",
+			expires: Date.now() - 60_000,
+		});
+		const capture: AnthropicDiscoveryCapture = { modelListCalls: 0 };
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+			fetch: mockAnthropicModelsDiscovery(capture),
+		});
+
+		await registry.refreshProvider("anthropic", "online");
+
+		expect(refreshCalls).toEqual(["anthropic"]);
+		expect(capture.modelListCalls).toBe(1);
+		expect(capture.modelListAuthorization).toBe("Bearer sk-ant-oat-fresh-anthropic");
+		expect(capture.modelListXApiKey).toBeNull();
+		expect(registry.find("anthropic", "claude-regression-4893")).toBeDefined();
+	});
+
+	test("refreshProvider online does not refresh unrelated expired OAuth credentials", async () => {
+		const { refreshCalls } = await useAuthStorageWithRefreshTracker();
+		await authStorage.set("anthropic", {
+			type: "oauth",
+			access: "sk-ant-oat-expired-anthropic",
+			refresh: "refresh-anthropic",
+			expires: Date.now() - 60_000,
+		});
+		await authStorage.set("openai", {
+			type: "oauth",
+			access: "expired-openai",
+			refresh: "refresh-openai",
+			expires: Date.now() - 60_000,
+		});
+		const capture: AnthropicDiscoveryCapture = { modelListCalls: 0 };
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+			fetch: mockAnthropicModelsDiscovery(capture),
+		});
+
+		await registry.refreshProvider("anthropic", "online");
+
+		expect(refreshCalls).toEqual(["anthropic"]);
+		expect(authStorage.getOAuthCredential("openai")?.access).toBe("expired-openai");
+		expect(capture.modelListCalls).toBe(1);
+	});
+
+	test("refreshProvider offline does not touch expired OAuth credentials", async () => {
+		const { refreshCalls } = await useAuthStorageWithRefreshTracker();
+		await authStorage.set("anthropic", {
+			type: "oauth",
+			access: "sk-ant-oat-expired-anthropic",
+			refresh: "refresh-anthropic",
+			expires: Date.now() - 60_000,
+		});
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, {
+			fetch: async input => {
+				throw new Error(`Offline discovery should not fetch ${String(input)}`);
+			},
+		});
+
+		await registry.refreshProvider("anthropic", "offline");
+
+		expect(refreshCalls).toEqual([]);
+		expect(authStorage.getOAuthCredential("anthropic")?.access).toBe("sk-ant-oat-expired-anthropic");
+	});
 
 	test("auto-discovers ollama models without provider config", async () => {
 		const fetchMock = mockOllamaDiscovery(["phi4-mini"]);

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -234,6 +234,42 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(authStorage.getOAuthCredential("anthropic")?.access).toBe("sk-ant-oat-expired-anthropic");
 	});
 
+	test("configured discovery suppresses built-in special OAuth discovery", async () => {
+		await authStorage.set("google-gemini-cli", {
+			type: "oauth",
+			access: "fresh-google-gemini-cli",
+			refresh: "refresh-google-gemini-cli",
+			expires: Date.now() + 3_600_000,
+		});
+		writeRawModelsJson({
+			"google-gemini-cli": {
+				baseUrl: "http://127.0.0.1:4893",
+				api: "openai-completions",
+				auth: "none",
+				discovery: { type: "openai-models-list" },
+			},
+		});
+		const unexpectedUrls: string[] = [];
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:4893/v1/models") {
+				return Response.json({
+					data: [{ id: "configured-gemini-cli-model", context_length: 65_536 }],
+				});
+			}
+			unexpectedUrls.push(url);
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+
+		await registry.refreshProvider("google-gemini-cli", "online");
+
+		expect(unexpectedUrls).toEqual([]);
+		const configuredModel = registry.find("google-gemini-cli", "configured-gemini-cli-model");
+		expect(configuredModel?.baseUrl).toBe("http://127.0.0.1:4893");
+		expect(configuredModel?.contextWindow).toBe(65_536);
+	});
+
 	test("auto-discovers ollama models without provider config", async () => {
 		const fetchMock = mockOllamaDiscovery(["phi4-mini"]);
 		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -261,6 +261,52 @@ describe("ModelRegistry runtime provider registration", () => {
 		});
 	});
 
+	test("configured discovery suppresses extension fetchDynamicModels for the same provider", async () => {
+		const providerName = "runtime-configured-provider";
+		fs.writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					[providerName]: {
+						baseUrl: "http://127.0.0.1:4893",
+						api: "openai-completions",
+						auth: "none",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+		const configuredFetch: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:4893/v1/models") {
+				return Response.json({
+					data: [{ id: "shared-runtime-model", context_length: 32_768 }],
+				});
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const configuredRegistry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: configuredFetch });
+		let runtimeFetchCalls = 0;
+		configuredRegistry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				fetchDynamicModels: async () => {
+					runtimeFetchCalls++;
+					return [{ ...baseModel, id: "shared-runtime-model", contextWindow: 999_999 }];
+				},
+			},
+			"ext://runtime",
+		);
+
+		await configuredRegistry.refreshProvider(providerName, "online");
+
+		expect(runtimeFetchCalls).toBe(0);
+		expect(configuredRegistry.find(providerName, "shared-runtime-model")?.contextWindow).toBe(32_768);
+	});
+
 	test("refreshRuntimeProviders times out extension fetchDynamicModels that never resolves", async () => {
 		vi.useFakeTimers();
 		const hangingFetch = Promise.withResolvers<readonly NonNullable<ProviderConfigInput["models"]>[number][]>();


### PR DESCRIPTION
## Repro
A focused regression reproduces the failure with `bun test packages/coding-agent/test/model-discovery.test.ts -t "refreshProvider online refreshes expired anthropic OAuth before model discovery"`: the expired stored Anthropic OAuth credential was not refreshed before online built-in discovery, so `refreshCalls` stayed empty and the provider model-list request never received a fresh bearer token.

## Cause
`ModelRegistry.#collectBuiltInModelManagerOptions` in `packages/coding-agent/src/config/model-registry.ts` used `AuthStorage.peekApiKey()` for every built-in provider before constructing model managers. `peekApiKey()` intentionally refuses to refresh OAuth and returns no token for expired OAuth rows, so online discovery skipped providers whose only stored credential was expired. The provider filter was also applied after collection, which would make any future refresh in that collection step touch providers outside `refreshProvider(...)`.

## Fix
- Resolve built-in discovery API keys through a new online-only preflight that refreshes an expired stored OAuth credential only when the selected strategy can hit the network and the selected provider lacks a usable peeked token.
- Apply disabled/configured/provider filters before credential resolution so `refreshProvider("anthropic")` cannot refresh unrelated providers.
- Preserve offline discovery behavior by returning the peeked token without inspecting or refreshing OAuth rows for `offline`.
- Add regression coverage for online refresh, unrelated-provider isolation, and offline no-touch behavior in `packages/coding-agent/test/model-discovery.test.ts`.
- Add the coding-agent changelog entry for #4893.

## Verification
Passed: `bun test packages/coding-agent/test/model-discovery.test.ts` (45 pass, 0 fail). Passed: `bun check`. Fixes #4893