### PR TITLE
feat(catalog): add xAI Grok 4.5

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `grok-4.5` to the bundled xAI catalog (`xai` + SuperGrok `xai-oauth`): reasoning, vision-capable, 500K context; OAuth seed also keeps the effort dial on the allowlist.
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/catalog/src/identity/family.ts
+++ b/packages/catalog/src/identity/family.ts
@@ -78,7 +78,7 @@ export const isMimoModelIdOrName = memo((value: string): boolean => {
 	return value.toLowerCase().includes("mimo");
 });
 
-const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3"] as const;
+const GROK_EFFORT_CAPABLE_PREFIXES = ["grok-3-mini", "grok-4.20-multi-agent", "grok-4.3", "grok-4.5"] as const;
 
 /**
  * Grok SKUs that expose the wire `reasoning.effort` dial. Other Grok reasoners

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -83094,6 +83094,35 @@
 				]
 			}
 		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			}
+		},
 		"grok-beta": {
 			"id": "grok-beta",
 			"name": "Grok Beta",
@@ -83308,6 +83337,47 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
+			},
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			}
+		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-responses",
+			"provider": "xai-oauth",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -982,6 +982,7 @@ export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
 		supportsReasoningEffort: false,
 		input: ["text", "image"],
 	},
+	{ id: "grok-4.5", contextWindow: 500_000, name: "Grok 4.5", input: ["text", "image"] },
 	{ id: "grok-4.3", contextWindow: 1_000_000, name: "Grok 4.3", input: ["text", "image"] },
 	// grok-4.20-multi-agent-0309 is text-only per the bundled catalog; omit `input` for the default.
 	{ id: "grok-4.20-multi-agent-0309", contextWindow: 2_000_000, name: "Grok 4.20 (Multi-Agent)" },

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -171,6 +171,10 @@ describe("xAI-OAuth Responses reasoning-effort suppression", () => {
 		expect(buildOpenAIResponsesCompat(grokResponsesSpec("grok-4.3")).supportsReasoningEffort).toBe(true);
 	});
 
+	it("keeps the effort dial for custom grok-4.5 specs (official reasoning model)", () => {
+		expect(buildOpenAIResponsesCompat(grokResponsesSpec("grok-4.5")).supportsReasoningEffort).toBe(true);
+	});
+
 	it("lets an explicit compat.supportsReasoningEffort override the allowlist default", () => {
 		const compat = buildOpenAIResponsesCompat({
 			...grokResponsesSpec("grok-build"),

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -262,6 +262,7 @@ describe("modelFamilyToken", () => {
 describe("isGrokReasoningEffortCapable", () => {
 	test("matches effort-capable Grok SKUs across namespaces", () => {
 		expect(isGrokReasoningEffortCapable("grok-4.3")).toBe(true);
+		expect(isGrokReasoningEffortCapable("grok-4.5")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-3-mini")).toBe(true);
 		expect(isGrokReasoningEffortCapable("grok-4.20-multi-agent")).toBe(true);
 		expect(isGrokReasoningEffortCapable("xai-oauth/grok-4.3")).toBe(true);

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -63,6 +63,16 @@ describe("xai-oauth bundled catalog (regression)", () => {
 		expect(bundled["grok-composer-2.5-fast"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 	});
 
+	it("exposes grok-4.5 as a reasoning 500K vision model", () => {
+		const grok45 = seed.find(model => model.id === "grok-4.5");
+		expect(grok45, "grok-4.5 must be in the SuperGrok curated seed").toBeDefined();
+		expect(grok45!.reasoning).toBe(true);
+		expect(grok45!.contextWindow).toBe(500_000);
+		expect(grok45!.input).toEqual(["text", "image"]);
+		expect(grok45!.compat?.supportsReasoningEffort).toBeUndefined();
+		expect(bundled["grok-4.5"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
+
 	// The OAuth surface's /v1/models reports no per-request output limit, so the
 	// curated catalog owns maxTokens — set to mirror each model's contextWindow
 	// (the openai-responses wire still clamps the actual request to


### PR DESCRIPTION
## Summary
- Add official `grok-4.5` to the SuperGrok (`xai-oauth`) curated seed: reasoning + vision, 500K context.
- Allowlist `grok-4.5` for `reasoning.effort` so Responses requests keep the effort dial instead of omitting it.
- Bundle matching `xai/grok-4.5` and `xai-oauth/grok-4.5` entries in `models.json` so boot-time model resolution sees the GA model offline.

## How model lists are edited
- Never hand-edit `packages/catalog/src/models.json` as source of truth.
- For SuperGrok/OAuth: edit `XAI_OAUTH_CURATED_MODELS` in `packages/catalog/src/provider-models/openai-compat.ts`.
- For effort-capable Grok SKUs: update `GROK_EFFORT_CAPABLE_PREFIXES` in `packages/catalog/src/identity/family.ts`.
- Regenerate with `bun run gen:models` and commit the resulting `models.json`.

## Test plan
- [x] `bun test packages/catalog/test/xai-oauth-bundle.test.ts packages/catalog/test/identity-family.test.ts packages/catalog/test/build.test.ts`
- [x] `bun --cwd packages/catalog check`
- [x] Confirmed bundled entries: `xai/grok-4.5` (paid API pricing) and `xai-oauth/grok-4.5` (zero-cost SuperGrok seed)