### PR TITLE
fix(tool): allow grep selectors on directories

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `grep` explicit line selectors on directory searches so they filter each matched file by line number instead of aborting with a single-file-only error ([#4898](https://github.com/can1357/oh-my-pi/issues/4898)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/prompts/tools/grep.md
+++ b/packages/coding-agent/src/prompts/tools/grep.md
@@ -2,7 +2,8 @@ Greps files using regex.
 
 <instruction>
 - Rust regex (RE2-style): alternation is `foo|bar`, not GNU BRE-style `foo\|bar`; Rust word boundaries like `\bword\b` are supported. Use line anchors or post-filters instead of lookaround/backreferences.
-- `path`: SHOULD scope to a known path (e.g. `src`); pass several as a delimited list (`src; tests`). Literal colon filename + line range? Use `selector` (e.g. `{"path":"test:1-2","selector":"1-2"}`), not recursive `path:"test:1-2:1-2"`.
+- `path`: SHOULD scope to a known path (e.g. `src`); pass several as a delimited list (`src; tests`). Use `selector` only for line-number filtering, never path/root selection (`"/"` belongs in `path`).
+- Literal colon filename + line range? Use `selector` (e.g. `{"path":"test:1-2","selector":"1-2"}`), not recursive `path:"test:1-2:1-2"`.
 - Cross-line patterns detected from literal `\n` or `\\n` in `pattern`.
 </instruction>
 

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -410,6 +410,18 @@ function lineAllowed(lineNumber: number, ranges: readonly LineRange[] | undefine
 	return !ranges || isLineInRanges(lineNumber, ranges);
 }
 
+function lineRangeFetchEnd(pathSpecs: readonly GrepPathSpec[]): number | undefined {
+	let maxEnd = 0;
+	for (const spec of pathSpecs) {
+		if (!spec.ranges) continue;
+		for (const range of spec.ranges) {
+			if (range.endLine === undefined) return undefined;
+			maxEnd = Math.max(maxEnd, range.endLine);
+		}
+	}
+	return maxEnd;
+}
+
 /** Binary search for the index of the line containing byte `offset`. */
 function findLineIndex(starts: readonly number[], offset: number): number {
 	if (starts.length === 0) return -1;
@@ -1107,6 +1119,14 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 					Boolean(multiTargets) ||
 					(virtualResources.length > 0 && (virtualResources.length > 1 || searchablePaths.length > 0));
 				const perFileMatchCap = isMultiScope ? MULTI_FILE_PER_FILE_MATCHES : SINGLE_FILE_MATCHES;
+				const hasLineRangeFilters = pathSpecs.some(spec => spec.ranges);
+				const lineRangeMatchFetchEnd = hasLineRangeFilters ? lineRangeFetchEnd(pathSpecs) : undefined;
+				const nativeMaxCount = hasLineRangeFilters ? undefined : INTERNAL_TOTAL_CAP;
+				const nativeMaxCountPerFile = hasLineRangeFilters
+					? lineRangeMatchFetchEnd === undefined
+						? undefined
+						: Math.max(perFileMatchCap + 1, lineRangeMatchFetchEnd)
+					: perFileMatchCap + 1;
 
 				// Run grep
 				let result: GrepResult = {
@@ -1141,12 +1161,12 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 										multiline: effectiveMultiline,
 										hidden: true,
 										gitignore: useGitignore,
-										maxCount: INTERNAL_TOTAL_CAP,
+										maxCount: nativeMaxCount,
 										contextBefore: normalizedContextBefore,
 										contextAfter: normalizedContextAfter,
 										maxColumns: DEFAULT_MAX_COLUMN,
 										mode: effectiveOutputMode,
-										maxCountPerFile: perFileMatchCap + 1,
+										maxCountPerFile: nativeMaxCountPerFile,
 										signal,
 										timeoutMs: SEARCH_GREP_TIMEOUT_MS,
 									},
@@ -1188,12 +1208,12 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 									multiline: effectiveMultiline,
 									hidden: true,
 									gitignore: useGitignore,
-									maxCount: INTERNAL_TOTAL_CAP,
+									maxCount: nativeMaxCount,
 									contextBefore: normalizedContextBefore,
 									contextAfter: normalizedContextAfter,
 									maxColumns: DEFAULT_MAX_COLUMN,
 									mode: effectiveOutputMode,
-									maxCountPerFile: perFileMatchCap + 1,
+									maxCountPerFile: nativeMaxCountPerFile,
 									signal,
 									timeoutMs: SEARCH_GREP_TIMEOUT_MS,
 								},

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -80,7 +80,7 @@ const searchSchema = type({
 		'file, directory, glob, internal URL, or "<file>:<lines>" selector to search; pass several as a semicolon-delimited list ("src; tests"). Omitted -> searches the workspace root (".")',
 	),
 	"selector?": type("string").describe(
-		'line selector without a leading colon (e.g. "50-100", "50+10", "50-100,200-300"); keeps `path` literal when filenames contain colons',
+		'line selector applied to every searched file (e.g. "50-100", "50+10", "50-100,200-300"); never a path like "/"',
 	),
 	"case?": type("boolean").describe("case-sensitive search"),
 	"gitignore?": type("boolean").describe("respect gitignore"),
@@ -126,6 +126,7 @@ interface GrepPathSpec {
 	clean: string;
 	literalFilesystemMatch?: boolean;
 	ranges?: [LineRange, ...LineRange[]];
+	rangeSource?: "explicit" | "path";
 }
 
 /**
@@ -182,6 +183,7 @@ async function parsePathSpecs(
 				clean: literalMatch && !rawPathHasScheme ? resolveReadPath(entry, cwd) : entry,
 				literalFilesystemMatch: literalMatch,
 				ranges: explicitRanges,
+				rangeSource: "explicit",
 			});
 			continue;
 		}
@@ -210,6 +212,7 @@ async function parsePathSpecs(
 		const literalFilesystemMatch = strictSplit.sel !== undefined && split.sel === undefined;
 		let clean = literalFilesystemMatch ? resolveReadPath(entry, cwd) : entry;
 		let ranges: [LineRange, ...LineRange[]] | undefined;
+		let rangeSource: "path" | undefined;
 		if (!literalFilesystemMatch && split.sel) {
 			const parsed = parseLineRanges(split.sel);
 			if (!parsed) {
@@ -222,8 +225,15 @@ async function parsePathSpecs(
 			}
 			clean = split.path;
 			ranges = parsed;
+			rangeSource = "path";
 		}
-		specs.push({ original: entry, clean, literalFilesystemMatch, ranges });
+		specs.push({
+			original: entry,
+			clean,
+			literalFilesystemMatch,
+			ranges,
+			rangeSource: ranges ? rangeSource : undefined,
+		});
 	}
 	return specs;
 }
@@ -971,6 +981,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 				const searchablePaths = internalResolution.paths;
 				const { virtualResources, virtualPathSet, virtualInputIndexes } = internalResolution;
 				const rangesByAbsPath = new Map<string, LineRange[]>();
+				const globalRanges = pathSpecs.find(spec => spec.rangeSource === "explicit")?.ranges;
 
 				if (
 					archiveUnreadable.length > 0 &&
@@ -1030,6 +1041,7 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 					for (let idx = 0; idx < pathSpecs.length; idx++) {
 						const spec = pathSpecs[idx];
 						if (!spec.ranges) continue;
+						if (spec.rangeSource === "explicit") continue;
 						if (virtualInputIndexes.has(idx)) continue;
 						const resolved = internalResolution.resolvedPathsByInput[idx];
 						if (!resolved) continue;
@@ -1223,11 +1235,11 @@ export class GrepTool implements AgentTool<typeof searchSchema, GrepToolDetails>
 					throw err;
 				}
 				result = mergeGrepResults(result, virtualResult, INTERNAL_TOTAL_CAP);
-				if (rangesByAbsPath.size > 0) {
+				if (rangesByAbsPath.size > 0 || globalRanges) {
 					const filteredMatches: GrepMatch[] = [];
 					for (const match of result.matches) {
 						const abs = matchAbsolutePath(match.path, searchPath);
-						const ranges = rangesByAbsPath.get(abs);
+						const ranges = rangesByAbsPath.get(abs) ?? globalRanges;
 						if (!ranges) {
 							// Path has no line-range constraint (e.g. a peer entry without `:N-M`).
 							filteredMatches.push(match);

--- a/packages/coding-agent/test/tools/grep-directory-selector.test.ts
+++ b/packages/coding-agent/test/tools/grep-directory-selector.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { GrepTool } from "@oh-my-pi/pi-coding-agent/tools/grep";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter(entry => entry.type === "text")
+		.map(entry => entry.text ?? "")
+		.join("\n");
+}
+
+describe("grep explicit line selector on directory searches", () => {
+	let testDir: string;
+
+	beforeEach(async () => {
+		testDir = await fs.mkdtemp(path.join(os.tmpdir(), "grep-directory-selector-"));
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(testDir);
+	});
+
+	function createSession(): ToolSession {
+		return {
+			cwd: testDir,
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated({ "grep.contextBefore": 0, "grep.contextAfter": 0 }),
+		};
+	}
+
+	it("filters matches by per-file line number instead of rejecting the directory", async () => {
+		const appDir = path.join(testDir, "scripts", "app");
+		await fs.mkdir(appDir, { recursive: true });
+		await Bun.write(path.join(appDir, "one.ts"), "outside one\ninside one\noutside one again\n");
+		await Bun.write(path.join(appDir, "two.ts"), "outside two\ninside two\noutside two again\n");
+
+		const result = await new GrepTool(createSession()).execute("grep-directory-selector", {
+			pattern: "inside|outside",
+			path: "scripts/app",
+			selector: "2-2",
+		});
+
+		const text = resultText(result);
+		expect(text).toContain("inside one");
+		expect(text).toContain("inside two");
+		expect(text).not.toContain("outside one");
+		expect(text).not.toContain("outside two");
+		expect(text).not.toContain("Line-range selector requires a single file");
+	});
+});

--- a/packages/coding-agent/test/tools/grep-directory-selector.test.ts
+++ b/packages/coding-agent/test/tools/grep-directory-selector.test.ts
@@ -54,4 +54,25 @@ describe("grep explicit line selector on directory searches", () => {
 		expect(text).not.toContain("outside two");
 		expect(text).not.toContain("Line-range selector requires a single file");
 	});
+
+	it("fetches enough directory matches before applying an explicit later line selector", async () => {
+		const appDir = path.join(testDir, "scripts", "hot");
+		await fs.mkdir(appDir, { recursive: true });
+		const content = `${Array.from(
+			{ length: 30 },
+			(_, index) => `cap-needle line ${String(index + 1).padStart(2, "0")}`,
+		).join("\n")}\n`;
+		await Bun.write(path.join(appDir, "many.ts"), content);
+
+		const result = await new GrepTool(createSession()).execute("grep-directory-selector-cap", {
+			pattern: "cap-needle",
+			path: "scripts/hot",
+			selector: "25-25",
+		});
+
+		const text = resultText(result);
+		expect(text).toContain("cap-needle line 25");
+		expect(text).not.toContain("cap-needle line 24");
+		expect(text).not.toContain("cap-needle line 26");
+	});
 });


### PR DESCRIPTION
## Repro
A `grep` tool call against a directory with an explicit line selector reproduced the report: `GrepTool.execute(..., { pattern: "https?://", path: "scripts/app", selector: "1-20" })` threw `Line-range selector requires a single file: scripts/app is a directory`; the same call with `selector: "/"` threw the invalid selector error.

## Cause
`packages/coding-agent/src/tools/grep.ts` treated every parsed line range as a per-path constraint, then prevalidated the resolved target as a regular file before grep ran. That was correct for embedded selectors like `file.ts:1-20`, but wrong for the explicit `selector` parameter because it applies to the search result line numbers and can be meaningful for every file found under a directory or glob.

## Fix
- Track whether a grep line range came from the explicit `selector` parameter or from an embedded path selector.
- Apply explicit selectors as a global per-file match filter after grep returns, so directory searches filter each matched file by line number instead of aborting before search.
- Keep embedded path selectors file-only and keep invalid selector values rejected.
- Clarify the grep tool prompt/schema language and add a regression test for directory searches.

## Verification
`bun test packages/coding-agent/test/tools/grep-directory-selector.test.ts packages/coding-agent/test/tools/path-literal-colon-selector.test.ts` passed: 23 pass, 0 fail. `gh_push_branch` also completed the pre-publish gate (`bun run fix` and `bun check`) before pushing. Fixes #4898