### PR TITLE
fix(tui): restore Read selector previews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Read tool previews dropping explicit `selector` arguments, so line ranges and `raw` modifiers render in terminal read call titles again ([#4899](https://github.com/can1357/oh-my-pi/issues/4899)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -345,7 +345,9 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	updateArgs(args: ReadRenderArgs, toolCallId?: string): void {
 		if (!toolCallId) return;
 		const basePath = args.file_path || args.path || "";
-		const selector = (args.selector ?? args.sel)?.trim().replace(/^:+/, "");
+		const rawSelector =
+			typeof args.selector === "string" ? args.selector : typeof args.sel === "string" ? args.sel : undefined;
+		const selector = rawSelector?.trim().replace(/^:+/, "");
 		const rawPath = selector && selector.length > 0 ? `${basePath}:${selector}` : basePath;
 		const entry: ReadEntry = this.#entries.get(toolCallId) ?? {
 			toolCallId,

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -37,6 +37,7 @@ export function readArgsTargetInternalUrl(args: unknown): boolean {
 type ReadRenderArgs = {
 	path?: string;
 	file_path?: string;
+	selector?: string;
 	// Legacy field from the old schema; tolerated for rebuilt transcripts.
 	sel?: string;
 };
@@ -344,7 +345,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	updateArgs(args: ReadRenderArgs, toolCallId?: string): void {
 		if (!toolCallId) return;
 		const basePath = args.file_path || args.path || "";
-		const rawPath = args.sel ? `${basePath}:${args.sel}` : basePath;
+		const selector = (args.selector ?? args.sel)?.trim().replace(/^:+/, "");
+		const rawPath = selector && selector.length > 0 ? `${basePath}:${selector}` : basePath;
 		const entry: ReadEntry = this.#entries.get(toolCallId) ?? {
 			toolCallId,
 			path: rawPath,

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -3314,6 +3314,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 interface ReadRenderArgs {
 	path?: unknown;
 	file_path?: unknown;
+	selector?: unknown;
 	sel?: string;
 	// Legacy fields from old schema — tolerated for in-flight tool calls during transition
 	offset?: number;
@@ -3378,10 +3379,20 @@ function formatReadPathLink(
 
 export const readToolRenderer = {
 	renderCall(args: ReadRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
-		const rawPath =
+		const baseRawPath =
 			typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : "";
-		if (isReadableUrlPath(rawPath)) {
-			return renderReadUrlCall({ path: rawPath, raw: args.raw }, _options, uiTheme);
+		const explicitSelector =
+			typeof args.selector === "string"
+				? args.selector.trim().replace(/^:+/, "")
+				: args.sel?.trim().replace(/^:+/, "");
+		const rawPath =
+			explicitSelector && explicitSelector.length > 0 ? `${baseRawPath}:${explicitSelector}` : baseRawPath;
+		if (isReadableUrlPath(baseRawPath)) {
+			return renderReadUrlCall(
+				{ path: rawPath, raw: args.raw || explicitSelector?.toLowerCase() === "raw" },
+				_options,
+				uiTheme,
+			);
 		}
 
 		const offset = args.offset;
@@ -3405,9 +3416,9 @@ export const readToolRenderer = {
 		args?: ReadRenderArgs,
 	): Component {
 		const urlDetails = result.details as ReadUrlToolDetails | undefined;
-		const rawPathForKind =
+		const baseRawPathForKind =
 			typeof args?.file_path === "string" ? args.file_path : typeof args?.path === "string" ? args.path : "";
-		if (urlDetails?.kind === "url" || isReadableUrlPath(rawPathForKind)) {
+		if (urlDetails?.kind === "url" || isReadableUrlPath(baseRawPathForKind)) {
 			return renderReadUrlResult(
 				result as {
 					content: Array<{ type: string; text?: string }>;
@@ -3422,8 +3433,14 @@ export const readToolRenderer = {
 		if (result.isError) {
 			const rawErrorText = result.content?.find(c => c.type === "text")?.text ?? "";
 			const errorText = (rawErrorText || "Unknown error").replace(/^Error:\s*/, "");
-			const rawPath =
+			const baseRawPath =
 				typeof args?.file_path === "string" ? args.file_path : typeof args?.path === "string" ? args.path : "";
+			const explicitSelector =
+				typeof args?.selector === "string"
+					? args.selector.trim().replace(/^:+/, "")
+					: args?.sel?.trim().replace(/^:+/, "");
+			const rawPath =
+				explicitSelector && explicitSelector.length > 0 ? `${baseRawPath}:${explicitSelector}` : baseRawPath;
 			const filePath =
 				formatReadPathLink(rawPath, { offset: args?.offset, sourcePath: readSourceFsPath(result.details) }) ||
 				shortenPath(rawPath);
@@ -3450,8 +3467,14 @@ export const readToolRenderer = {
 		// echo next to the styled warning line below.
 		const contentText = details?.displayContent?.text ?? stripOutputNotice(rawText, details?.meta);
 		const imageContent = result.content?.find(c => c.type === "image");
-		const rawPath =
+		const baseRawPath =
 			typeof args?.file_path === "string" ? args.file_path : typeof args?.path === "string" ? args.path : "";
+		const explicitSelector =
+			typeof args?.selector === "string"
+				? args.selector.trim().replace(/^:+/, "")
+				: args?.sel?.trim().replace(/^:+/, "");
+		const rawPath =
+			explicitSelector && explicitSelector.length > 0 ? `${baseRawPath}:${explicitSelector}` : baseRawPath;
 		const renderPath = splitReadRenderPath(rawPath);
 		const lang = getLanguageFromPath(renderPath.path);
 

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -274,6 +274,21 @@ describe("ReadToolGroupComponent", () => {
 		expect(extractLinkTexts(rendered)).not.toContain("src/grouped.ts:2-3");
 	});
 
+	it("ignores non-string selectors from malformed runtime args", () => {
+		const component = new ReadToolGroupComponent();
+		const malformedArgs = { path: "src/example.ts", selector: 10 } as unknown as {
+			path: string;
+			selector: string;
+		};
+
+		expect(() => component.updateArgs(malformedArgs, "read-malformed-selector")).not.toThrow();
+
+		const plain = Bun.stripANSI(component.render(120).join("\n"));
+
+		expect(plain).toContain("Read src/example.ts");
+		expect(plain).not.toContain("src/example.ts:10");
+	});
+
 	it("links inline preview titles when the summary row is suppressed", () => {
 		settings.override("tui.hyperlinks", "always");
 		const component = new ReadToolGroupComponent({ showContentPreview: true });

--- a/packages/coding-agent/test/read-tool-group.test.ts
+++ b/packages/coding-agent/test/read-tool-group.test.ts
@@ -250,6 +250,30 @@ describe("ReadToolGroupComponent", () => {
 		expect(extractLinkTexts(rendered)).not.toContain("src/example.ts:7-9");
 	});
 
+	it("renders separate selector grouped summary paths while linking only the base path", () => {
+		settings.override("tui.hyperlinks", "always");
+		const component = new ReadToolGroupComponent();
+		const resolvedPath = path.resolve("/workspace/src/grouped.ts");
+		component.updateArgs({ path: "src/grouped.ts", selector: "2-3" }, "read-split-selector");
+		component.updateResult(
+			{
+				content: [{ type: "text", text: "line 2" }],
+				details: { meta: { source: { type: "path", value: resolvedPath } } },
+			},
+			false,
+			"read-split-selector",
+		);
+
+		const rendered = component.render(120).join("\n");
+
+		const groupedUri = new URL(url.pathToFileURL(path.resolve(resolvedPath)).href);
+		groupedUri.searchParams.set("line", "2");
+		expect(Bun.stripANSI(rendered)).toContain("Read src/grouped.ts:2-3");
+		expect(extractLinkUris(rendered)).toContain(groupedUri.href);
+		expect(extractLinkTexts(rendered)).toContain("src/grouped.ts");
+		expect(extractLinkTexts(rendered)).not.toContain("src/grouped.ts:2-3");
+	});
+
 	it("links inline preview titles when the summary row is suppressed", () => {
 		settings.override("tui.hyperlinks", "always");
 		const component = new ReadToolGroupComponent({ showContentPreview: true });

--- a/packages/coding-agent/test/tools/read-renderer.test.ts
+++ b/packages/coding-agent/test/tools/read-renderer.test.ts
@@ -83,6 +83,46 @@ describe("readToolRenderer hyperlinks", () => {
 		expect(extractLinkTexts(rendered)).not.toContain(`${examplePath}:10-12`);
 	});
 
+	it("renders separate selector read call paths while linking only the base path", async () => {
+		settings.override("tui.hyperlinks", "always");
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const examplePath = path.resolve("/tmp/omp-read/separate-selector.ts");
+		const component = readToolRenderer.renderCall(
+			{ path: examplePath, selector: "10-12" },
+			{ expanded: false, isPartial: false },
+			theme!,
+		);
+
+		const rendered = component.render(200).join("\n");
+		expect(Bun.stripANSI(rendered)).toContain(`${examplePath}:10-12`);
+		const exampleUri = new URL(url.pathToFileURL(path.resolve(examplePath)).href);
+		exampleUri.searchParams.set("line", "10");
+		expect(extractLinkUris(rendered)).toContain(exampleUri.href);
+		expect(extractLinkTexts(rendered)).toContain(examplePath);
+		expect(extractLinkTexts(rendered)).not.toContain(`${examplePath}:10-12`);
+	});
+
+	it("renders separate raw read selectors while linking only the base path", async () => {
+		settings.override("tui.hyperlinks", "always");
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+
+		const examplePath = path.resolve("/tmp/omp-read/raw-selector.ts");
+		const component = readToolRenderer.renderCall(
+			{ path: examplePath, selector: "raw" },
+			{ expanded: false, isPartial: false },
+			theme!,
+		);
+
+		const rendered = component.render(200).join("\n");
+		expect(Bun.stripANSI(rendered)).toContain(`${examplePath}:raw`);
+		expect(extractLinkUris(rendered)).toContain(url.pathToFileURL(path.resolve(examplePath)).href);
+		expect(extractLinkTexts(rendered)).toContain(examplePath);
+		expect(extractLinkTexts(rendered)).not.toContain(`${examplePath}:raw`);
+	});
+
 	it("links HTTP read result headers to the final URL", async () => {
 		settings.override("tui.hyperlinks", "always");
 		const theme = await getThemeByName("dark");


### PR DESCRIPTION
## Repro
A renderer-level repro for issue #4899 called `readToolRenderer.renderCall({ path: "/tmp/omp-read/example.ts", selector: "10-12" })` and expected the visible title to include `/tmp/omp-read/example.ts:10-12`. Before the fix, `bun test ./repro-read-selector.test.ts` failed with the rendered output `⏳ Read: /tmp/omp-read/example.ts`, proving the split `selector` field was dropped from the terminal preview.

## Cause
`packages/coding-agent/src/tools/read.ts` and `packages/coding-agent/src/modes/components/read-tool-group.ts` still rendered only inline selectors (`path:2-3`) and legacy `sel` args. After the Read schema added the separate `selector` field, regular tool execution and grouped read rendering built titles from `path` alone, so line ranges and `raw` modifiers were executed by the tool but omitted from the TUI display.

## Fix
- Threaded explicit `selector` arguments into `readToolRenderer.renderCall`, `renderResult`, image/error titles, and grouped read summaries by composing the display target as `path:selector` while keeping hyperlink targets on the base path.
- Preserved legacy inline selector and `sel` behavior for rebuilt transcripts and older sessions.
- Added renderer and grouped read regression tests for split line-range selectors and split `raw` selectors.
- Added the coding-agent changelog entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/tools/read-renderer.test.ts packages/coding-agent/test/read-tool-group.test.ts` passed: 35 tests, 105 expects. `bun --cwd=packages/coding-agent run check:types` passed. `gh_push_branch` also ran the pre-publish gate before pushing. Fixes #4899