### PR TITLE
fix(ai): preserve active Anthropic tool streams

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Changed the xAI Grok OAuth (`xai-oauth`) provider to use manual code-paste login by default. `/login` now accepts a pasted authorization code or full `http://127.0.0.1:56121/callback?code=...` redirect URL without starting a local callback listener ([#3277](https://github.com/can1357/oh-my-pi/pull/3277) by [@Jaaneek](https://github.com/Jaaneek)).
 - Renamed the xAI Grok OAuth provider in login and credential prompts to "xAI Grok OAuth (SuperGrok or X Premium+)" ([#3277](https://github.com/can1357/oh-my-pi/pull/3277) by [@Jaaneek](https://github.com/Jaaneek)).
 
+### Fixed
+
+- Fixed Anthropic active tool-call streams (notably long `write` calls from Opus 4.8 high/xhigh reasoning) being cut off by the first-event SDK timeout after the stream had already connected, which could trigger repeated timeout retries instead of letting the tool call finish. ([#4900](https://github.com/can1357/oh-my-pi/issues/4900))
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -60,7 +60,6 @@ import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTi
 import { notifyProviderResponse } from "../utils/provider-response";
 import { COMBINATOR_KEYS, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { spillToDescription } from "../utils/schema/spill";
-import { createSdkStreamRequestOptions } from "../utils/sdk-stream-timeout";
 import { notifyRawSseEvent } from "../utils/sse-debug";
 import {
 	AnthropicApiError,
@@ -1952,7 +1951,11 @@ const streamAnthropicOnce = (
 				// pins it alongside a timeout; a client retry budget of 5 would otherwise
 				// multiply with PROVIDER_MAX_RETRIES into up to 66 wire attempts).
 				const requestOptions = {
-					...createSdkStreamRequestOptions(requestSignal, requestTimeoutMs),
+					signal: requestSignal,
+					// The provider loop owns retries and the clearable pre-response timer
+					// above owns time-to-first-event. Do not pass the first-event budget to
+					// the Anthropic SDK `timeout`: Stainless treats it as an absolute stream
+					// deadline, so active long tool-call streams can be aborted mid-body.
 					maxRetries: 0,
 					...(umansGatewayWebSearchHeader ? { headers: umansGatewayWebSearchHeader } : {}),
 				};

--- a/packages/ai/test/anthropic-stream-timeout.test.ts
+++ b/packages/ai/test/anthropic-stream-timeout.test.ts
@@ -234,7 +234,7 @@ describe("anthropic first-event timeout retries", () => {
 		}
 		expect(retryDelayMs).toBeGreaterThanOrEqual(375);
 		expect(retryDelayMs).toBeLessThanOrEqual(500);
-		expect(requestTimeouts).toEqual([1, 1]);
+		expect(requestTimeouts).toEqual([undefined, undefined]);
 		expect(requestMaxRetries).toEqual([0, 0]);
 		expect(result.stopReason).toBe("stop");
 		expect(JSON.parse(JSON.stringify(result.content))).toEqual([{ type: "text", text: "retry recovered" }]);
@@ -289,7 +289,7 @@ describe("anthropic first-event timeout retries", () => {
 		expect(JSON.parse(JSON.stringify(result.content))).toEqual([{ type: "text", text: "retry recovered" }]);
 	});
 
-	it("does not arm the Anthropic first-event watchdog before the stream connects", async () => {
+	it("does not pass the first-event budget to the SDK when the stream connects in time", async () => {
 		let seenRequestTimeout: number | undefined;
 		let seenRequestMaxRetries: number | undefined;
 		const create = ((
@@ -312,12 +312,116 @@ describe("anthropic first-event timeout retries", () => {
 		}).result();
 
 		expect(result.stopReason).toBe("stop");
-		expect(seenRequestTimeout).toBe(20);
+		expect(seenRequestTimeout).toBeUndefined();
 		expect(seenRequestMaxRetries).toBe(0);
 		expect(JSON.parse(JSON.stringify(result.content))).toEqual([{ type: "text", text: "delayed connect" }]);
 	});
 
-	it("times out before the Anthropic stream connects and forwards the budget to the SDK request", async () => {
+	it("does not let the SDK request timeout kill an active tool-call stream after response start", async () => {
+		let attempt = 0;
+		let seenRequestTimeout: number | undefined;
+		let seenRequestMaxRetries: number | undefined;
+		const create = ((
+			_body: unknown,
+			requestOptions?: { signal?: AbortSignal; timeout?: number; maxRetries?: number },
+		) => {
+			seenRequestTimeout = requestOptions?.timeout;
+			seenRequestMaxRetries = requestOptions?.maxRetries;
+			attempt += 1;
+			const response = new Response(null, {
+				status: 200,
+				headers: { "request-id": "req_active_write" },
+			});
+			const stream: MockAnthropicStream = {
+				async *[Symbol.asyncIterator]() {
+					const events: MockAnthropicEvent[] = [
+						{
+							type: "message_start",
+							message: {
+								id: "msg_active_write",
+								usage: {
+									input_tokens: 12,
+									output_tokens: 0,
+									cache_read_input_tokens: 0,
+									cache_creation_input_tokens: 0,
+								},
+							},
+						},
+						{
+							type: "content_block_start",
+							index: 0,
+							content_block: {
+								type: "tool_use",
+								id: "toolu_active_write",
+								name: "write",
+								input: {},
+							},
+						},
+						{
+							type: "content_block_delta",
+							index: 0,
+							delta: {
+								type: "input_json_delta",
+								partial_json: '{"path":"notes.md","content":"hello"}',
+							},
+						},
+						{ type: "content_block_stop", index: 0 },
+						{
+							type: "message_delta",
+							delta: { stop_reason: "tool_use" },
+							usage: {
+								input_tokens: 12,
+								output_tokens: 6,
+								cache_read_input_tokens: 0,
+								cache_creation_input_tokens: 0,
+							},
+						},
+						{ type: "message_stop" },
+					];
+					for (const event of events) {
+						yield event;
+						if (event.type === "content_block_delta" && requestOptions?.timeout !== undefined) {
+							throw new Error("SDK stream timeout fired after response start");
+						}
+					}
+				},
+			};
+			return {
+				async withResponse() {
+					return {
+						data: stream,
+						response,
+						request_id: response.headers.get("request-id"),
+					};
+				},
+			} as never;
+		}) as unknown as AnthropicMessagesClientLike["messages"]["create"];
+		const client = { messages: { create } } as AnthropicMessagesClientLike;
+		const providerRetryWait = vi.fn(async () => {});
+
+		const result = await streamAnthropic(model, context, {
+			client,
+			streamFirstEventTimeoutMs: 1,
+			providerRetryWait,
+		}).result();
+
+		expect(attempt).toBe(1);
+		expect(providerRetryWait).not.toHaveBeenCalled();
+		expect(seenRequestTimeout).toBeUndefined();
+		expect(seenRequestMaxRetries).toBe(0);
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.errorMessage).toBeUndefined();
+		expect(JSON.parse(JSON.stringify(result.content))).toEqual([
+			{
+				type: "toolCall",
+				id: "toolu_active_write",
+				name: "write",
+				arguments: { path: "notes.md", content: "hello" },
+			},
+		]);
+	});
+
+	it("times out before the Anthropic stream connects without arming the SDK stream timeout", async () => {
 		let attempt = 0;
 		const requestTimeouts: Array<number | undefined> = [];
 		const requestMaxRetries: Array<number | undefined> = [];
@@ -345,7 +449,7 @@ describe("anthropic first-event timeout retries", () => {
 
 		expect(attempt).toBe(11);
 		expect(providerRetryWait).toHaveBeenCalledTimes(10);
-		expect(requestTimeouts).toEqual(new Array(11).fill(1));
+		expect(requestTimeouts).toEqual(new Array(11).fill(undefined));
 		expect(requestMaxRetries).toEqual(new Array(11).fill(0));
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("Anthropic stream timed out while waiting for the first event");

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 


### PR DESCRIPTION
## Repro
A focused Anthropic stream regression reproduces the reporter shape with an active `write` tool call: run `bun test packages/ai/test/anthropic-stream-timeout.test.ts -t "does not let the SDK request timeout kill an active tool-call stream after response start"` against the pre-fix implementation plus the regression test. The old code passes `requestOptions.timeout: 1` to the Anthropic SDK after response start, so the test fails before the tool call can complete.

## Cause
`packages/ai/src/providers/anthropic.ts` reused `createSdkStreamRequestOptions(requestSignal, requestTimeoutMs)` for Anthropic streaming requests. That maps the first-event timeout into the SDK `timeout` option; the local clearable timer only guards connection/first-event, but Stainless treats `timeout` as an absolute request/stream deadline, so long active tool-call bodies can be aborted after streaming progress has already begun.

## Fix
- Keep Anthropic SDK retries pinned with `maxRetries: 0`, but stop passing the first-event timeout into the SDK `timeout` option.
- Leave the provider-owned clearable pre-response/first-event watchdog and iterator idle timeout in place, so no-event hangs still retry/fail on the existing bounded path.
- Add a regression covering a write-like Anthropic `tool_use` stream with `input_json_delta` progress; it asserts no SDK timeout is present after response start and the completed `write` tool call is preserved.
- Add the `packages/ai` changelog entry for #4900.

## Verification
`bun test packages/ai/test/anthropic-stream-timeout.test.ts` passed: 11 tests, 55 assertions. `bun check` passed across the monorepo. `bun run fix` reported no fixes for the touched TypeScript/Markdown files before commit. Fixes #4900