### PR TITLE
fix(cli): show progress for print mode prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp -p` looking hung while a text-mode prompt is in flight by writing a one-shot working indicator to stderr before awaiting the model response. ([#4901](https://github.com/can1357/oh-my-pi/issues/4901))
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -62,13 +62,22 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		}
 	});
 
+	let wroteTextWorkingIndicator = false;
+	const writeTextWorkingIndicator = (): void => {
+		if (mode !== "text" || wroteTextWorkingIndicator) return;
+		process.stderr.write("Working...\n");
+		wroteTextWorkingIndicator = true;
+	};
+
 	// Send initial message with attachments
 	if (initialMessage !== undefined) {
+		writeTextWorkingIndicator();
 		await logger.time("print:prompt:initial", () => session.prompt(initialMessage, { images: initialImages }));
 	}
 
 	// Send remaining messages
 	for (const message of messages) {
+		writeTextWorkingIndicator();
 		await logger.time("print:prompt:next", () => session.prompt(message));
 	}
 

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/print-mode-working-indicator.test.ts
+++ b/packages/coding-agent/test/print-mode-working-indicator.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { runPrintMode } from "@oh-my-pi/pi-coding-agent/modes/print-mode";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+function makeAssistantMessage(text: string): AssistantMessage {
+	const timestamp = Date.now();
+	const usage = {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage,
+		timestamp,
+	};
+}
+
+interface DelayedSession {
+	session: AgentSession;
+	promptStarted: Promise<void>;
+	resolvePrompt: () => void;
+}
+
+function createDelayedSession(finalMessage: AssistantMessage): DelayedSession {
+	const messages: AssistantMessage[] = [];
+	const { promise: promptStarted, resolve: markPromptStarted } = Promise.withResolvers<void>();
+	const { promise: promptReleased, resolve: resolvePrompt } = Promise.withResolvers<void>();
+
+	const session = {
+		state: { messages },
+		sessionManager: {
+			getHeader: () => undefined,
+		},
+		extensionRunner: undefined,
+		subscribe: () => () => {},
+		prompt: async () => {
+			markPromptStarted();
+			await promptReleased;
+			messages.push(finalMessage);
+			return true;
+		},
+		dispose: async () => {},
+	} as unknown as AgentSession;
+
+	return { session, promptStarted, resolvePrompt };
+}
+
+describe("print mode working indicator", () => {
+	let stderrOutput: string[];
+	let stdoutOutput: string[];
+
+	beforeEach(() => {
+		stderrOutput = [];
+		stdoutOutput = [];
+		vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+			stderrOutput.push(String(chunk));
+			return true;
+		});
+		vi.spyOn(process.stdout, "write").mockImplementation((...args: unknown[]) => {
+			const chunk = args[0];
+			if (typeof chunk === "string") stdoutOutput.push(chunk);
+			const last = args[args.length - 1];
+			if (typeof last === "function") last();
+			return true;
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("writes a text-mode working indicator before the prompt resolves and prints the final answer afterward", async () => {
+		const delayed = createDelayedSession(makeAssistantMessage("final answer"));
+		const run = runPrintMode(delayed.session, { mode: "text", initialMessage: "hello" });
+
+		await delayed.promptStarted;
+		try {
+			expect(stderrOutput.join("")).toContain("Working");
+			expect(stdoutOutput.join("")).toBe("");
+		} finally {
+			delayed.resolvePrompt();
+			await run;
+		}
+
+		expect(stdoutOutput.join("")).toBe("final answer\n");
+	});
+
+	it("does not write the text-mode working indicator in JSON mode while the prompt is pending", async () => {
+		const delayed = createDelayedSession(makeAssistantMessage("json answer"));
+		const run = runPrintMode(delayed.session, { mode: "json", initialMessage: "hello" });
+
+		await delayed.promptStarted;
+		try {
+			expect(stderrOutput.join("")).toBe("");
+		} finally {
+			delayed.resolvePrompt();
+			await run;
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A delayed `runPrintMode(..., { mode: "text" })` harness reproduced the issue with `bun run gen:tool-views && bun test repro-print-mode.test.ts`: while `session.prompt()` was unresolved, stdout was empty and stderr was also empty (`Expected to contain: "working"; Received: ""`), so `omp -p` had no visible liveness signal until the final assistant text printed after completion.

## Cause
`packages/coding-agent/src/modes/print-mode.ts` subscribed to session events only for JSON output and, in text mode, awaited each `session.prompt()` before reading the final assistant message from `session.state.messages` and writing it to stdout. That path intentionally kept stdout clean but left no text-mode stderr status during the in-flight model request.

## Fix
- Added a one-shot text-mode stderr indicator before the first prompt is awaited in `runPrintMode`, guarded so follow-up messages in the same print-mode invocation do not duplicate it.
- Left JSON mode unchanged so machine-readable event output does not gain the human text-mode indicator.
- Added focused print-mode tests covering pending text-mode liveness, delayed final stdout output, and the JSON-mode non-indicator case.
- Added the coding-agent changelog entry for #4901.

## Verification
Reproduced before the fix with `bun run gen:tool-views && bun test repro-print-mode.test.ts` (failed because stderr stayed empty while the delayed prompt was pending). Verified after the fix with `bun test packages/coding-agent/test/print-mode-working-indicator.test.ts` (2 pass), `bun test packages/coding-agent/test/silent-abort-print-mode.test.ts packages/coding-agent/test/cli-print-thoughts-flag.test.ts packages/coding-agent/test/print-mode-working-indicator.test.ts` (8 pass), and the pre-publish gate from `gh_push_branch` (`bun run fix` plus `bun check`) passed. Fixes #4901