### PR TITLE
fix(config): respect preseeded yaml settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "build:native": "bun --cwd=packages/natives run build",
     "test": "bun scripts/ci-test-ts.ts local",
     "test:ts": "bun scripts/ci-test-ts.ts local-ts",
-    "test:scripts": "bun test scripts/ci-concurrency.test.ts scripts/ci-release-notes.test.ts scripts/fix-dts-extensions.test.ts scripts/link-omp.test.ts",
+    "test:scripts": "bun test scripts/ci-concurrency.test.ts scripts/ci-release-notes.test.ts scripts/fix-dts-extensions.test.ts scripts/install-sh.test.ts scripts/link-omp.test.ts",
     "test:rs": "bun scripts/run-rs-task.ts test:rs",
     "check": "bun run --parallel check:ts check:rs",
     "check:ts": "bun run check:tools && bun run --workspaces --if-present check",

--- a/packages/ai/src/auth-broker/discover.ts
+++ b/packages/ai/src/auth-broker/discover.ts
@@ -1,6 +1,6 @@
 /**
  * Broker-aware auth-storage discovery used by both the coding-agent runtime and
- * the catalog model generator. Keeps the precedence logic (env → config.yml →
+ * the catalog model generator. Keeps the precedence logic (env → config.yml/config.yaml →
  * token file → local SQLite) in one place so build-time tooling sees the same
  * credentials as the TUI.
  */
@@ -12,6 +12,7 @@ import {
 	getConfigRootDir,
 	isEnoent,
 	logger,
+	MAIN_CONFIG_FILENAMES,
 } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { AuthStorage } from "../auth-storage";
@@ -72,21 +73,24 @@ interface ConfigSnapshot {
 }
 
 async function readConfigYaml(agentDir: string): Promise<ConfigSnapshot> {
-	const configPath = path.join(agentDir, "config.yml");
-	try {
-		const raw = await Bun.file(configPath).text();
-		const parsed = YAML.parse(raw);
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-		const record = parsed as Record<string, unknown>;
-		const url = typeof record["auth.broker.url"] === "string" ? (record["auth.broker.url"] as string) : undefined;
-		const token =
-			typeof record["auth.broker.token"] === "string" ? (record["auth.broker.token"] as string) : undefined;
-		return { url, token };
-	} catch (err) {
-		if (isEnoent(err)) return {};
-		logger.warn("auth-broker config.yml unreadable", { error: String(err) });
-		return {};
+	for (const filename of MAIN_CONFIG_FILENAMES) {
+		const configPath = path.join(agentDir, filename);
+		try {
+			const raw = await Bun.file(configPath).text();
+			const parsed = YAML.parse(raw);
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+			const record = parsed as Record<string, unknown>;
+			const url = typeof record["auth.broker.url"] === "string" ? (record["auth.broker.url"] as string) : undefined;
+			const token =
+				typeof record["auth.broker.token"] === "string" ? (record["auth.broker.token"] as string) : undefined;
+			return { url, token };
+		} catch (err) {
+			if (isEnoent(err)) continue;
+			logger.warn("auth-broker config unreadable", { path: configPath, error: String(err) });
+			return {};
+		}
 	}
+	return {};
 }
 
 function resolveSnapshotTtlMs(): number {
@@ -104,7 +108,7 @@ function resolveSnapshotTtlMs(): number {
  * Resolve broker connection configuration using the same precedence as the TUI:
  *
  * 1. `OMP_AUTH_BROKER_URL` / `OMP_AUTH_BROKER_TOKEN` env vars.
- * 2. `auth.broker.url` / `auth.broker.token` in `<agentDir>/config.yml`.
+ * 2. `auth.broker.url` / `auth.broker.token` in `<agentDir>/config.yml` or `<agentDir>/config.yaml`.
  * 3. `<config-root>/auth-broker.token` file (paired with a URL from env/config).
  *
  * Returns `null` when no broker URL is configured — callers should fall back to

--- a/packages/ai/test/auth-broker-config-discovery.test.ts
+++ b/packages/ai/test/auth-broker-config-discovery.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveAuthBrokerConfig } from "@oh-my-pi/pi-ai/auth-broker";
+import { removeWithRetries } from "../../utils/src/temp";
+import { withEnv } from "./helpers";
+
+const SUPPRESS_AUTH_BROKER_ENV = {
+	OMP_AUTH_BROKER_URL: undefined,
+	OMP_AUTH_BROKER_TOKEN: undefined,
+} as const;
+
+describe("resolveAuthBrokerConfig config discovery", () => {
+	let agentDir = "";
+
+	beforeEach(async () => {
+		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-broker-config-"));
+	});
+
+	afterEach(async () => {
+		if (agentDir) {
+			await removeWithRetries(agentDir);
+			agentDir = "";
+		}
+	});
+
+	test("resolves broker URL and token from config.yaml when config.yml is absent", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yaml"),
+			"auth.broker.url: https://yaml-broker.example/v1\nauth.broker.token: yaml-token\n",
+		);
+
+		await withEnv(SUPPRESS_AUTH_BROKER_ENV, async () => {
+			await expect(resolveAuthBrokerConfig({ agentDir })).resolves.toEqual({
+				url: "https://yaml-broker.example/v1",
+				token: "yaml-token",
+			});
+		});
+	});
+
+	test("prefers config.yml over config.yaml when both exist", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yaml"),
+			"auth.broker.url: https://yaml-broker.example/v1\nauth.broker.token: yaml-token\n",
+		);
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			"auth.broker.url: https://yml-broker.example/v1\nauth.broker.token: yml-token\n",
+		);
+
+		await withEnv(SUPPRESS_AUTH_BROKER_ENV, async () => {
+			await expect(resolveAuthBrokerConfig({ agentDir })).resolves.toEqual({
+				url: "https://yml-broker.example/v1",
+				token: "yml-token",
+			});
+		});
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Fixed first-run setup ignoring a pre-seeded `config.yaml`: the settings loader now treats `config.yml` and `config.yaml` as equivalent existing main config files, writes back to the existing extension, and only creates canonical `config.yml` for fresh installs. ([#4914](https://github.com/can1357/oh-my-pi/issues/4914))
+
 - Improved handling of unawaited promises in JS eval cells to prevent process crashes
 - Added warning logs for unhandled rejections originating from finished eval cells
 - Improved advisor robustness by blocking exhausted accounts during consecutive turn failures

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -458,6 +458,7 @@ export class Settings {
 			inMemory: !this.#persist,
 		});
 		cloned.#storage = this.#storage;
+		cloned.#configPath = this.#configPath;
 		cloned.#global = structuredClone(this.#global);
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
 		cloned.#configFiles = [...this.#configFiles];

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -60,7 +60,7 @@ export interface RawSettings {
 export interface SettingsOptions {
 	/** Current working directory for project settings discovery */
 	cwd?: string;
-	/** Agent directory for config.yml storage */
+	/** Agent directory for config.yml/config.yaml storage */
 	agentDir?: string;
 	/** Don't persist to disk (for tests) */
 	inMemory?: boolean;
@@ -234,7 +234,7 @@ export class Settings {
 	#storage: AgentStorage | null = null;
 
 	#configFiles: string[] = [];
-	/** Global settings from config.yml */
+	/** Global settings from config.yml/config.yaml */
 	#global: RawSettings = {};
 	/** Project settings from .claude/settings.yml etc */
 	#project: RawSettings = {};
@@ -676,16 +676,22 @@ export class Settings {
 
 	async #load(): Promise<Settings> {
 		// Project settings load (loadCapability scans cwd) is independent of the
-		// persist chain (storage open → legacy migration → global config.yml read),
-		// so kick it off first and await after the persist chain completes. The
-		// persist steps remain sequential: migration may write config.yml, which
-		// #loadYaml then reads; migration's db fallback needs #storage opened.
+		// persist chain (storage open → legacy migration → global config read), so
+		// kick it off first and await after the persist chain completes. The
+		// persist steps remain sequential: existing config discovery decides
+		// whether migration may write config.yml before the global config is read;
+		// migration's db fallback needs #storage opened.
 		const projectPromise = this.#loadProjectSettings();
 
 		if (this.#persist) {
 			this.#storage = await AgentStorage.open(getAgentDbPath(this.#agentDir));
-			await this.#migrateFromLegacy();
-			this.#global = await this.#loadYaml(this.#configPath!);
+			const existingConfig = await this.#loadExistingMainYaml();
+			if (existingConfig) {
+				this.#global = existingConfig;
+			} else {
+				await this.#migrateFromLegacy();
+				this.#global = await this.#loadYaml(this.#configPath!);
+			}
 			await this.#seedLastChangelogVersionMarker();
 		}
 
@@ -701,8 +707,9 @@ export class Settings {
 	async #loadReadOnly(): Promise<Settings> {
 		const projectPromise = this.#loadProjectSettings();
 
-		if (this.#configPath) {
-			this.#global = await this.#loadYaml(this.#configPath);
+		const existingConfig = await this.#loadExistingMainYaml();
+		if (existingConfig) {
+			this.#global = existingConfig;
 		}
 
 		this.#project = await projectPromise;
@@ -712,18 +719,48 @@ export class Settings {
 	}
 
 	async #loadYaml(filePath: string): Promise<RawSettings> {
+		const loaded = await this.#loadYamlIfPresent(filePath);
+		return loaded ?? {};
+	}
+
+	async #loadYamlIfPresent(filePath: string): Promise<RawSettings | null> {
+		let content: string;
 		try {
-			const content = await Bun.file(filePath).text();
+			content = await Bun.file(filePath).text();
+		} catch (error) {
+			if (isEnoent(error)) return null;
+			logger.warn("Settings: failed to load", { path: filePath, error: String(error) });
+			return {};
+		}
+
+		try {
 			const parsed = YAML.parse(content);
 			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
 				return {};
 			}
 			return this.#migrateRawSettings(parsed as RawSettings);
 		} catch (error) {
-			if (isEnoent(error)) return {};
 			logger.warn("Settings: failed to load", { path: filePath, error: String(error) });
 			return {};
 		}
+	}
+
+	async #loadExistingMainYaml(): Promise<RawSettings | null> {
+		if (!this.#configPath) return null;
+		const ymlPath = path.join(this.#agentDir, "config.yml");
+		const yml = await this.#loadYamlIfPresent(ymlPath);
+		if (yml) {
+			this.#configPath = ymlPath;
+			return yml;
+		}
+		const yamlPath = path.join(this.#agentDir, "config.yaml");
+		const yaml = await this.#loadYamlIfPresent(yamlPath);
+		if (yaml) {
+			this.#configPath = yamlPath;
+			return yaml;
+		}
+		this.#configPath = ymlPath;
+		return null;
 	}
 
 	async #loadProjectSettings(): Promise<RawSettings> {
@@ -780,14 +817,6 @@ export class Settings {
 
 	async #migrateFromLegacy(): Promise<void> {
 		if (!this.#configPath) return;
-
-		// Check if config.yml already exists
-		try {
-			await Bun.file(this.#configPath).text();
-			return; // Already exists, no migration needed
-		} catch (err) {
-			if (!isEnoent(err)) return;
-		}
 
 		let settings: RawSettings = {};
 		let migrated = false;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -22,6 +22,7 @@ import {
 	getProjectDir,
 	isEnoent,
 	logger,
+	MAIN_CONFIG_FILENAMES,
 	procmgr,
 	setWorktreesDir,
 } from "@oh-my-pi/pi-utils";
@@ -264,7 +265,7 @@ export class Settings {
 	private constructor(options: SettingsOptions = {}) {
 		this.#cwd = path.normalize(options.cwd ?? getProjectDir());
 		this.#agentDir = path.normalize(options.agentDir ?? getAgentDir());
-		this.#configPath = options.inMemory ? null : path.join(this.#agentDir, "config.yml");
+		this.#configPath = options.inMemory ? null : path.join(this.#agentDir, MAIN_CONFIG_FILENAMES[0]);
 		this.#configFiles = options.configFiles?.map(file => path.resolve(this.#cwd, expandTilde(file))) ?? [];
 		this.#persist = !options.inMemory && options.readOnly !== true;
 
@@ -748,19 +749,15 @@ export class Settings {
 
 	async #loadExistingMainYaml(): Promise<RawSettings | null> {
 		if (!this.#configPath) return null;
-		const ymlPath = path.join(this.#agentDir, "config.yml");
-		const yml = await this.#loadYamlIfPresent(ymlPath);
-		if (yml) {
-			this.#configPath = ymlPath;
-			return yml;
+		for (const filename of MAIN_CONFIG_FILENAMES) {
+			const configPath = path.join(this.#agentDir, filename);
+			const loaded = await this.#loadYamlIfPresent(configPath);
+			if (loaded) {
+				this.#configPath = configPath;
+				return loaded;
+			}
 		}
-		const yamlPath = path.join(this.#agentDir, "config.yaml");
-		const yaml = await this.#loadYamlIfPresent(yamlPath);
-		if (yaml) {
-			this.#configPath = yamlPath;
-			return yaml;
-		}
-		this.#configPath = ymlPath;
+		this.#configPath = path.join(this.#agentDir, MAIN_CONFIG_FILENAMES[0]);
 		return null;
 	}
 

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -87,6 +87,21 @@ describe("Settings", () => {
 			expect(await Bun.file(getConfigPath()).exists()).toBe(false);
 		});
 
+		it("clones the selected config.yaml path for persisted settings", async () => {
+			const yamlConfigPath = path.join(agentDir, "config.yaml");
+			await Bun.write(yamlConfigPath, YAML.stringify({ setupVersion: 1 }, null, 2));
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			const cloned = await settings.cloneForCwd(tempDir.join("other-project"));
+
+			cloned.set("setupVersion", 2);
+			await cloned.flush();
+
+			const savedSettings = YAML.parse(await Bun.file(yamlConfigPath).text()) as Record<string, unknown>;
+			expect(savedSettings.setupVersion).toBe(2);
+			expect(await Bun.file(getConfigPath()).exists()).toBe(false);
+		});
+
 		it("creates config.yml for new persisted settings when no main config exists", async () => {
 			const yamlConfigPath = path.join(agentDir, "config.yaml");
 

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -70,6 +70,36 @@ describe("Settings", () => {
 		await Bun.sleep(0);
 		await tempDir?.remove();
 	});
+
+	describe("main config file selection", () => {
+		it("loads and updates an existing config.yaml without creating config.yml", async () => {
+			const yamlConfigPath = path.join(agentDir, "config.yaml");
+			await Bun.write(yamlConfigPath, YAML.stringify({ setupVersion: 1 }, null, 2));
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("setupVersion")).toBe(1);
+
+			settings.set("setupVersion", 2);
+			await settings.flush();
+
+			const savedSettings = YAML.parse(await Bun.file(yamlConfigPath).text()) as Record<string, unknown>;
+			expect(savedSettings.setupVersion).toBe(2);
+			expect(await Bun.file(getConfigPath()).exists()).toBe(false);
+		});
+
+		it("creates config.yml for new persisted settings when no main config exists", async () => {
+			const yamlConfigPath = path.join(agentDir, "config.yaml");
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			settings.set("setupVersion", 1);
+			await settings.flush();
+
+			expect(await Bun.file(getConfigPath()).exists()).toBe(true);
+			expect(await Bun.file(yamlConfigPath).exists()).toBe(false);
+			expect((await readSettings()).setupVersion).toBe(1);
+		});
+	});
+
 	describe("defaults", () => {
 		it("keeps eight inline images live by default", async () => {
 			const settings = await Settings.init({ cwd: projectDir, agentDir });

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -22,6 +22,9 @@ export const APP_NAME: string = "omp";
 /** Config directory name (e.g. ".omp") */
 export const CONFIG_DIR_NAME: string = ".omp";
 
+/** Ordered main settings filenames: canonical write target first, legacy-compatible YAML fallback second. */
+export const MAIN_CONFIG_FILENAMES = ["config.yml", "config.yaml"] as const;
+
 /** Version (e.g. "1.0.0") */
 export const VERSION: string = version;
 

--- a/scripts/install-sh.test.ts
+++ b/scripts/install-sh.test.ts
@@ -18,6 +18,34 @@ function writeExecutable(file: string, content: string) {
 	fs.chmodSync(file, 0o755);
 }
 
+function writeFinalMoveFailureShim(shimDir: string) {
+	const realMv = Bun.which("mv");
+	if (!realMv) {
+		throw new Error("mv not found");
+	}
+
+	const quotedMv = `'${realMv.replaceAll("'", "'\\''")}'`;
+
+	writeExecutable(
+		path.join(shimDir, "mv"),
+		`#!/bin/sh
+set -eu
+printf 'mv' >> "$OMP_INSTALL_TEST_LOG"
+for arg do printf ' <%s>' "$arg" >> "$OMP_INSTALL_TEST_LOG"; done
+printf '\n' >> "$OMP_INSTALL_TEST_LOG"
+if [ "\${OMP_INSTALL_TEST_FAIL_FINAL_SOURCE_MOVE_TO:-}" != "" ] && [ "$#" -eq 2 ] && [ "$2" = "$OMP_INSTALL_TEST_FAIL_FINAL_SOURCE_MOVE_TO" ]; then
+  case "$1" in
+    */source|*/source/)
+      echo "simulated final source activation failure" >&2
+      exit 44
+      ;;
+  esac
+fi
+exec ${quotedMv} "$@"
+`,
+	);
+}
+
 function writeFixtureRepo(dir: string) {
 	const packageDir = path.join(dir, "packages", "coding-agent");
 	const nativesDir = path.join(dir, "packages", "natives");
@@ -262,5 +290,54 @@ describe("scripts/install.sh", () => {
 		expect(fs.existsSync(sentinel)).toBe(true);
 		expect(fs.readFileSync(sentinel, "utf8")).toBe("existing checkout");
 		expect(fs.existsSync(path.join(existingSourceDir, replacementMarker))).toBe(false);
+	});
+
+	it("restores the existing source checkout when activating the staged checkout fails", () => {
+		const dir = makeTempDir();
+		const fixtureRepo = path.join(dir, "fixture-repo");
+		const bunInstall = path.join(dir, "bun-install");
+		const commandLog = path.join(dir, "commands.log");
+		const sourceInstallRoot = path.join(dir, "source-installs");
+		const ref = "feature/source-install";
+		const existingSourceDir = path.join(sourceInstallRoot, "feature_source-install");
+		const sentinel = path.join(existingSourceDir, "existing-sentinel.txt");
+		const replacementMarker = "replacement-checkout-marker.txt";
+		const existingLink = path.join(bunInstall, "bin", "omp");
+		writeFixtureRepo(fixtureRepo);
+		fs.writeFileSync(path.join(fixtureRepo, replacementMarker), "new checkout");
+		fs.mkdirSync(existingSourceDir, { recursive: true });
+		fs.writeFileSync(sentinel, "existing checkout");
+		fs.mkdirSync(path.dirname(existingLink), { recursive: true });
+		fs.writeFileSync(existingLink, "#!/bin/sh\necho existing-source-link\n");
+		fs.chmodSync(existingLink, 0o755);
+		const { shimDir, stateDir } = writeShims(dir);
+		writeFinalMoveFailureShim(shimDir);
+
+		const result = Bun.spawnSync(["sh", installScript, "--source", "--ref", ref], {
+			cwd: dir,
+			env: {
+				...process.env,
+				HOME: path.join(dir, "home"),
+				BUN_INSTALL: bunInstall,
+				PI_SOURCE_INSTALL_DIR: sourceInstallRoot,
+				OMP_INSTALL_TEST_FAIL_FINAL_SOURCE_MOVE_TO: existingSourceDir,
+				OMP_INSTALL_TEST_LOG: commandLog,
+				OMP_INSTALL_TEST_REPO_FIXTURE: fixtureRepo,
+				OMP_INSTALL_TEST_STATE: stateDir,
+				PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const stdout = result.stdout.toString();
+		const stderr = result.stderr.toString();
+
+		expect(result.exitCode, `${stdout}\n${stderr}`).toBe(1);
+		expect(stdout).toContain("Failed to activate source install");
+		expect(stderr).toContain("simulated final source activation failure");
+		expect(fs.existsSync(sentinel)).toBe(true);
+		expect(fs.readFileSync(sentinel, "utf8")).toBe("existing checkout");
+		expect(fs.existsSync(path.join(existingSourceDir, replacementMarker))).toBe(false);
+		expect(fs.readFileSync(existingLink, "utf8")).toBe("#!/bin/sh\necho existing-source-link\n");
 	});
 });

--- a/scripts/install-sh.test.ts
+++ b/scripts/install-sh.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const installScript = path.join(repoRoot, "scripts", "install.sh");
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-install-sh-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function writeExecutable(file: string, content: string) {
+	fs.writeFileSync(file, content);
+	fs.chmodSync(file, 0o755);
+}
+
+function writeFixtureRepo(dir: string) {
+	const packageDir = path.join(dir, "packages", "coding-agent");
+	const nativesDir = path.join(dir, "packages", "natives");
+	fs.mkdirSync(packageDir, { recursive: true });
+	fs.mkdirSync(nativesDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, "package.json"),
+		JSON.stringify({ private: true, workspaces: { packages: ["packages/*"] }, catalog: { zod: "4.0.0" } }),
+	);
+	fs.writeFileSync(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({
+			name: "@oh-my-pi/pi-coding-agent",
+			bin: { omp: "src/cli.ts" },
+			dependencies: { zod: "catalog:" },
+		}),
+	);
+	fs.writeFileSync(path.join(nativesDir, "package.json"), JSON.stringify({ name: "@oh-my-pi/pi-natives" }));
+}
+
+function writeShims(dir: string) {
+	const shimDir = path.join(dir, "shim");
+	const stateDir = path.join(dir, "state");
+	fs.mkdirSync(shimDir, { recursive: true });
+	fs.mkdirSync(stateDir, { recursive: true });
+	const gitShim = path.join(shimDir, "git");
+	writeExecutable(
+		gitShim,
+		`#!/bin/sh
+set -eu
+printf 'git' >> "$OMP_INSTALL_TEST_LOG"
+for arg do printf ' <%s>' "$arg" >> "$OMP_INSTALL_TEST_LOG"; done
+printf '\n' >> "$OMP_INSTALL_TEST_LOG"
+if [ "$1" = "clone" ]; then
+  for dest do :; done
+  mkdir -p "$dest"
+  cp -R "$OMP_INSTALL_TEST_REPO_FIXTURE/." "$dest/"
+  exit 0
+fi
+if [ "$1" = "checkout" ]; then exit 0; fi
+if [ "$1" = "lfs" ] && [ "\${2:-}" = "pull" ]; then exit 0; fi
+echo "unexpected git invocation: $*" >&2
+exit 99
+`,
+	);
+	writeExecutable(path.join(shimDir, "git-lfs"), "#!/bin/sh\nexit 0\n");
+
+	const bunShim = path.join(shimDir, "bun");
+	writeExecutable(
+		bunShim,
+		`#!/bin/sh
+set -eu
+if [ "\${1:-}" = "--version" ]; then
+  echo "1.3.14"
+  exit 0
+fi
+printf 'bun' >> "$OMP_INSTALL_TEST_LOG"
+for arg do printf ' <%s>' "$arg" >> "$OMP_INSTALL_TEST_LOG"; done
+printf '\n' >> "$OMP_INSTALL_TEST_LOG"
+
+cwd="$PWD"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cwd=*) cwd="\${1#--cwd=}"; shift ;;
+    --cwd) shift; cwd="$1"; shift ;;
+    *) break ;;
+  esac
+done
+cmd="\${1:-}"
+if [ "$#" -gt 0 ]; then shift; fi
+
+workspace_root() {
+  dir="$1"
+  while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+    if [ -d "$dir/packages/coding-agent" ]; then
+      printf '%s' "$dir"
+      return 0
+    fi
+    dir="\${dir%/*}"
+    if [ -z "$dir" ]; then dir="/"; fi
+  done
+  return 1
+}
+
+is_source_path() {
+  case "$1" in
+    */packages/coding-agent|*/packages/coding-agent/) return 0 ;;
+  esac
+  [ -d "$1/packages/coding-agent" ]
+}
+
+case "$cmd" in
+  install)
+    if [ "\${1:-}" = "-g" ]; then
+      target="\${2:-}"
+      if is_source_path "$target"; then
+        echo "simulated Bun catalog/workspace failure for direct global source install: $target" >&2
+        exit 42
+      fi
+      echo "unexpected global install target: $target" >&2
+      exit 99
+    fi
+    root="$(workspace_root "$cwd")" || {
+      echo "expected workspace install inside cloned repo, got cwd=$cwd" >&2
+      exit 99
+    }
+    printf '%s' "$root" > "$OMP_INSTALL_TEST_STATE/workspace-installed"
+    exit 0
+    ;;
+  run)
+    [ -f "$OMP_INSTALL_TEST_STATE/workspace-installed" ] || {
+      echo "native build attempted before workspace dependencies were installed" >&2
+      exit 99
+    }
+    if [ "$cwd" != "$(workspace_root "$cwd")/packages/natives" ] || [ "\${1:-}" != "build" ]; then
+      echo "unexpected bun run invocation in cwd=$cwd: $*" >&2
+      exit 99
+    fi
+    exit 0
+    ;;
+  link)
+    [ -f "$OMP_INSTALL_TEST_STATE/workspace-installed" ] || {
+      echo "link attempted before workspace dependencies were installed" >&2
+      exit 99
+    }
+    if [ "$#" -eq 0 ]; then
+      target="$cwd"
+    else
+      case "$1" in
+        /*) target="$1" ;;
+        *) target="$cwd/$1" ;;
+      esac
+    fi
+    case "$target" in
+      */packages/coding-agent|*/packages/coding-agent/) ;;
+      *)
+        echo "expected coding-agent package link target, got $target" >&2
+        exit 99
+        ;;
+    esac
+    mkdir -p "$BUN_INSTALL/bin"
+    printf '#!/bin/sh\necho installed-from-source\n' > "$BUN_INSTALL/bin/omp"
+    chmod +x "$BUN_INSTALL/bin/omp"
+    exit 0
+    ;;
+  *)
+    echo "unexpected bun invocation: $cmd $*" >&2
+    exit 99
+    ;;
+esac
+`,
+	);
+
+	return { shimDir, stateDir };
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) fs.rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("scripts/install.sh", () => {
+	it("installs --source --ref from the cloned workspace instead of global-installing the package directory", () => {
+		const dir = makeTempDir();
+		const fixtureRepo = path.join(dir, "fixture-repo");
+		const bunInstall = path.join(dir, "bun-install");
+		const commandLog = path.join(dir, "commands.log");
+		writeFixtureRepo(fixtureRepo);
+		const { shimDir, stateDir } = writeShims(dir);
+
+		const result = Bun.spawnSync(["sh", installScript, "--source", "--ref", "feature/source-install"], {
+			cwd: dir,
+			env: {
+				...process.env,
+				HOME: path.join(dir, "home"),
+				BUN_INSTALL: bunInstall,
+				OMP_INSTALL_TEST_LOG: commandLog,
+				OMP_INSTALL_TEST_REPO_FIXTURE: fixtureRepo,
+				OMP_INSTALL_TEST_STATE: stateDir,
+				PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const stdout = result.stdout.toString();
+		const stderr = result.stderr.toString();
+
+		expect(result.exitCode, `${stdout}\n${stderr}`).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).toContain("✓ Installed omp via bun");
+		expect(fs.existsSync(path.join(bunInstall, "bin", "omp"))).toBe(true);
+	});
+});

--- a/scripts/install-sh.test.ts
+++ b/scripts/install-sh.test.ts
@@ -120,6 +120,14 @@ case "$cmd" in
       echo "unexpected global install target: $target" >&2
       exit 99
     fi
+    if [ "\${OMP_INSTALL_TEST_FAIL_INSTALL:-}" = "1" ]; then
+      if [ "\${1:-}" != "--frozen-lockfile" ]; then
+        echo "expected frozen lockfile install before simulated failure, got: $*" >&2
+        exit 99
+      fi
+      echo "simulated dependency install failure" >&2
+      exit 43
+    fi
     root="$(workspace_root "$cwd")" || {
       echo "expected workspace install inside cloned repo, got cwd=$cwd" >&2
       exit 99
@@ -211,5 +219,48 @@ describe("scripts/install.sh", () => {
 		expect(stderr).toBe("");
 		expect(stdout).toContain("✓ Installed omp via bun");
 		expect(fs.existsSync(path.join(bunInstall, "bin", "omp"))).toBe(true);
+	});
+
+	it("keeps the existing source checkout when reinstall dependency installation fails", () => {
+		const dir = makeTempDir();
+		const fixtureRepo = path.join(dir, "fixture-repo");
+		const bunInstall = path.join(dir, "bun-install");
+		const commandLog = path.join(dir, "commands.log");
+		const sourceInstallRoot = path.join(dir, "source-installs");
+		const ref = "feature/source-install";
+		const existingSourceDir = path.join(sourceInstallRoot, "feature_source-install");
+		const sentinel = path.join(existingSourceDir, "existing-sentinel.txt");
+		const replacementMarker = "replacement-checkout-marker.txt";
+		writeFixtureRepo(fixtureRepo);
+		fs.writeFileSync(path.join(fixtureRepo, replacementMarker), "new checkout");
+		fs.mkdirSync(existingSourceDir, { recursive: true });
+		fs.writeFileSync(sentinel, "existing checkout");
+		const { shimDir, stateDir } = writeShims(dir);
+
+		const result = Bun.spawnSync(["sh", installScript, "--source", "--ref", ref], {
+			cwd: dir,
+			env: {
+				...process.env,
+				HOME: path.join(dir, "home"),
+				BUN_INSTALL: bunInstall,
+				PI_SOURCE_INSTALL_DIR: sourceInstallRoot,
+				OMP_INSTALL_TEST_FAIL_INSTALL: "1",
+				OMP_INSTALL_TEST_LOG: commandLog,
+				OMP_INSTALL_TEST_REPO_FIXTURE: fixtureRepo,
+				OMP_INSTALL_TEST_STATE: stateDir,
+				PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const stdout = result.stdout.toString();
+		const stderr = result.stderr.toString();
+
+		expect(result.exitCode, `${stdout}\n${stderr}`).toBe(1);
+		expect(stdout).toContain("Failed to install source dependencies");
+		expect(stderr).toContain("simulated dependency install failure");
+		expect(fs.existsSync(sentinel)).toBe(true);
+		expect(fs.readFileSync(sentinel, "utf8")).toBe("existing checkout");
+		expect(fs.existsSync(path.join(existingSourceDir, replacementMarker))).toBe(false);
 	});
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -191,7 +191,14 @@ install_via_bun() {
         if [ -d "$SOURCE_DIR" ]; then
             mv "$SOURCE_DIR" "$BACKUP_DIR"
         fi
-        mv "$STAGED_SOURCE_DIR" "$SOURCE_DIR"
+        if ! mv "$STAGED_SOURCE_DIR" "$SOURCE_DIR"; then
+            echo "Failed to activate source install"
+            rm -rf "$SOURCE_DIR"
+            if [ -d "$BACKUP_DIR" ]; then
+                mv "$BACKUP_DIR" "$SOURCE_DIR"
+            fi
+            exit 1
+        fi
         if ! (cd "$SOURCE_DIR/packages/coding-agent" && bun link); then
             echo "Failed to link source install"
             rm -rf "$SOURCE_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -149,27 +149,45 @@ install_via_bun() {
         fi
 
         TMP_DIR="$(mktemp -d)"
+        CLONE_DIR="$TMP_DIR/repo"
         trap 'rm -rf "$TMP_DIR"' EXIT
 
-        if git clone --depth 1 --branch "$REF" "https://github.com/${REPO}.git" "$TMP_DIR" >/dev/null 2>&1; then
+        if git clone --depth 1 --branch "$REF" "https://github.com/${REPO}.git" "$CLONE_DIR" >/dev/null 2>&1; then
             :
         else
-            git clone "https://github.com/${REPO}.git" "$TMP_DIR"
-            (cd "$TMP_DIR" && git checkout "$REF")
+            git clone "https://github.com/${REPO}.git" "$CLONE_DIR"
+            (cd "$CLONE_DIR" && git checkout "$REF")
         fi
 
         # Pull LFS files
         if has_git_lfs; then
-            (cd "$TMP_DIR" && git lfs pull)
+            (cd "$CLONE_DIR" && git lfs pull)
         fi
 
-        if [ ! -d "$TMP_DIR/packages/coding-agent" ]; then
-            echo "Expected package at ${TMP_DIR}/packages/coding-agent"
+        if [ ! -d "$CLONE_DIR/packages/coding-agent" ]; then
+            echo "Expected package at ${CLONE_DIR}/packages/coding-agent"
             exit 1
         fi
 
-        bun install -g "$TMP_DIR/packages/coding-agent" || {
-            echo "Failed to install from source"
+        INSTALL_ROOT="${PI_SOURCE_INSTALL_DIR:-$HOME/.omp/source-installs}"
+        SAFE_REF="$(printf '%s' "$REF" | tr -c 'A-Za-z0-9._-' '_')"
+        SOURCE_DIR="$INSTALL_ROOT/$SAFE_REF"
+        mkdir -p "$INSTALL_ROOT"
+        rm -rf "$SOURCE_DIR"
+        mv "$CLONE_DIR" "$SOURCE_DIR"
+
+        (cd "$SOURCE_DIR" && bun install --frozen-lockfile) || {
+            echo "Failed to install source dependencies"
+            exit 1
+        }
+        if [ -d "$SOURCE_DIR/packages/natives" ]; then
+            (cd "$SOURCE_DIR/packages/natives" && bun run build) || {
+                echo "Failed to build native addon"
+                exit 1
+            }
+        fi
+        (cd "$SOURCE_DIR/packages/coding-agent" && bun link) || {
+            echo "Failed to link source install"
             exit 1
         }
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,23 +173,34 @@ install_via_bun() {
         SAFE_REF="$(printf '%s' "$REF" | tr -c 'A-Za-z0-9._-' '_')"
         SOURCE_DIR="$INSTALL_ROOT/$SAFE_REF"
         mkdir -p "$INSTALL_ROOT"
-        rm -rf "$SOURCE_DIR"
-        mv "$CLONE_DIR" "$SOURCE_DIR"
+        STAGED_SOURCE_DIR="$TMP_DIR/source"
+        mv "$CLONE_DIR" "$STAGED_SOURCE_DIR"
 
-        (cd "$SOURCE_DIR" && bun install --frozen-lockfile) || {
+        (cd "$STAGED_SOURCE_DIR" && bun install --frozen-lockfile) || {
             echo "Failed to install source dependencies"
             exit 1
         }
-        if [ -d "$SOURCE_DIR/packages/natives" ]; then
-            (cd "$SOURCE_DIR/packages/natives" && bun run build) || {
+        if [ -d "$STAGED_SOURCE_DIR/packages/natives" ]; then
+            (cd "$STAGED_SOURCE_DIR/packages/natives" && bun run build) || {
                 echo "Failed to build native addon"
                 exit 1
             }
         fi
-        (cd "$SOURCE_DIR/packages/coding-agent" && bun link) || {
+
+        BACKUP_DIR="$TMP_DIR/previous-source"
+        if [ -d "$SOURCE_DIR" ]; then
+            mv "$SOURCE_DIR" "$BACKUP_DIR"
+        fi
+        mv "$STAGED_SOURCE_DIR" "$SOURCE_DIR"
+        if ! (cd "$SOURCE_DIR/packages/coding-agent" && bun link); then
             echo "Failed to link source install"
+            rm -rf "$SOURCE_DIR"
+            if [ -d "$BACKUP_DIR" ]; then
+                mv "$BACKUP_DIR" "$SOURCE_DIR"
+            fi
             exit 1
-        }
+        fi
+        rm -rf "$BACKUP_DIR"
     else
         bun install -g "$PACKAGE" || {
             echo "Failed to install $PACKAGE"


### PR DESCRIPTION
## Repro
A pre-seeded `~/.omp/agent/config.yaml` containing `setupVersion: 1` is ignored on first settings load, so the startup setup gate sees the schema default `0` and the next setup-version write creates `config.yml`. Reproduced with `bun test repro-config-yaml.test.ts` in a temporary `.wt` harness before the fix: `settings.get("setupVersion")` returned `0` instead of `1`.

## Cause
`packages/coding-agent/src/config/settings.ts` hard-coded the persistent main settings path to `<agentDir>/config.yml` in the `Settings` constructor, then `#migrateFromLegacy()`, `#load()`, `#loadReadOnly()`, and `#saveNow()` all used that path. A populated `config.yaml` was never considered, so setup markers and user settings in that file were invisible and writes targeted a new `config.yml` stub.

## Fix
- Added main config discovery that selects an existing `config.yml` first, falls back to an existing `config.yaml`, and keeps `config.yml` as the canonical path only when neither exists.
- Reused the selected path for subsequent saves, so a pre-existing `config.yaml` is updated in place instead of causing a duplicate `config.yml`.
- Added regression coverage for loading/updating a pre-seeded `config.yaml` and for fresh installs still creating canonical `config.yml`.
- Added an Unreleased changelog entry for the coding-agent package.

## Verification
`bun test packages/coding-agent/test/settings-manager.test.ts -t "main config file selection"` passed: 2 pass, 48 filtered out, 0 fail. `bun test packages/coding-agent/test/settings-manager.test.ts` passed: 50 pass, 0 fail. Pre-publish `gh_push_branch` completed its configured `bun run fix` and `bun check` gate before pushing. Fixes #4914