### PR TITLE
fix(coding-agent): queue extension sendUserMessage as steer while streaming

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed extension `sendUserMessage` throwing `Agent is already processing…` while the agent is streaming: without `deliverAs`, busy messages now queue as a steer. ACP/RPC skill invocations pass `streamingBehavior: "steer"` so they can land mid-turn the same way TUI skill commands do.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1107,7 +1107,10 @@ export interface ExtensionAPI {
 		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
 	): void;
 
-	/** Send a user message to the agent, or queue it when deliverAs is set. */
+	/**
+	 * Send a user message to the agent, or queue it when deliverAs is set.
+	 * When the agent is busy and deliverAs is omitted, the message is queued as a steer.
+	 */
 	sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
 		options?: { deliverAs?: "steer" | "followUp" },

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -843,13 +843,16 @@ export class AcpAgent implements Agent {
 			return false;
 		}
 		const built = await buildSkillPromptMessage(skill, parsed.args, "user");
-		await record.session.promptCustomMessage({
-			customType: SKILL_PROMPT_MESSAGE_TYPE,
-			content: built.message,
-			display: true,
-			details: built.details,
-			attribution: "user",
-		});
+		await record.session.promptCustomMessage(
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: built.message,
+				display: true,
+				details: built.details,
+				attribution: "user",
+			},
+			{ streamingBehavior: "steer" },
+		);
 		return true;
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -95,13 +95,16 @@ export async function tryRunRpcSkillCommand(
 	const skill = session.skills.find(candidate => candidate.name === parsed.name);
 	if (!skill) return false;
 	const built = await buildSkillPromptMessage(skill, parsed.args, "user");
-	await session.promptCustomMessage({
-		customType: SKILL_PROMPT_MESSAGE_TYPE,
-		content: built.message,
-		display: true,
-		details: built.details,
-		attribution: "user",
-	});
+	await session.promptCustomMessage(
+		{
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: built.message,
+			display: true,
+			details: built.details,
+			attribution: "user",
+		},
+		{ streamingBehavior: "steer" },
+	);
 	return { agentInvoked: true };
 }
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -88,6 +88,7 @@ export type RpcSkillCommandResult = { agentInvoked: true };
 export async function tryRunRpcSkillCommand(
 	session: RpcSkillCommandSession,
 	text: string,
+	streamingBehavior: "steer" | "followUp" = "steer",
 ): Promise<RpcSkillCommandResult | false> {
 	if (!session.skillsSettings?.enableSkillCommands) return false;
 	const parsed = parseSkillInvocation(text);
@@ -103,7 +104,7 @@ export async function tryRunRpcSkillCommand(
 			details: built.details,
 			attribution: "user",
 		},
-		{ streamingBehavior: "steer" },
+		{ streamingBehavior },
 	);
 	return { agentInvoked: true };
 }
@@ -845,7 +846,7 @@ export async function runRpcMode(
 			// =================================================================
 
 			case "prompt": {
-				const skillResult = await tryRunRpcSkillCommand(session, command.message);
+				const skillResult = await tryRunRpcSkillCommand(session, command.message, command.streamingBehavior);
 				if (skillResult) {
 					return success(id, "prompt", skillResult);
 				}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8311,6 +8311,8 @@ export class AgentSession {
 	/**
 	 * Send a user message to the agent.
 	 * When deliverAs is set, queue the message instead of starting a new turn.
+	 * When the agent is already streaming and no deliverAs is given, the message
+	 * is queued as a steer instead of rejecting with AgentBusyError.
 	 *
 	 * @param content User message content (string or content array)
 	 * @param options.deliverAs Delivery mode: "steer" or "followUp"
@@ -8344,6 +8346,14 @@ export class AgentSession {
 			return;
 		}
 		if (options?.deliverAs === "steer") {
+			await this.#queueUserMessage(text, images, "steer");
+			return;
+		}
+
+		// Extension callers often omit deliverAs. When the agent is already busy,
+		// queue as a steer instead of throwing AgentBusyError ("Agent is already
+		// processing…") which surfaces as an extension toast.
+		if (this.isStreaming) {
 			await this.#queueUserMessage(text, images, "steer");
 			return;
 		}

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -176,6 +176,36 @@ describe("AgentSession concurrent prompt guard", () => {
 		await firstPrompt.catch(() => {});
 	});
 
+	it("queues sendUserMessage as steer while streaming without AgentBusyError", async () => {
+		await createSession();
+
+		const firstPrompt = session.prompt("First message");
+		await waitFor(() => session.isStreaming);
+
+		// The first agent loop may dequeue a steer before the assertion runs, so
+		// observe agent.steer itself rather than the residual queue length.
+		const steered: AgentMessage[] = [];
+		const originalSteer = session.agent.steer.bind(session.agent);
+		session.agent.steer = (message: AgentMessage) => {
+			steered.push(message);
+			originalSteer(message);
+		};
+
+		// Extension path: no deliverAs while busy must queue, not throw.
+		await expect(session.sendUserMessage("hello from extension")).resolves.toBeUndefined();
+		expect(steered).toHaveLength(1);
+		const queued = steered[0];
+		expect(queued?.role).toBe("user");
+		if (queued?.role === "user") {
+			expect(queued.content).toEqual([{ type: "text", text: "hello from extension" }]);
+			expect(queued.steering).toBe(true);
+		}
+
+		session.agent.clearAllQueues();
+		await session.abort();
+		await firstPrompt.catch(() => {});
+	});
+
 	it("delivers hidden nextTurn stop reactions through the next LLM call without exposing them in the visible queue", async () => {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
 		let firstStream: AssistantMessageEventStream | undefined;

--- a/packages/coding-agent/test/rpc-skill-command.test.ts
+++ b/packages/coding-agent/test/rpc-skill-command.test.ts
@@ -16,6 +16,7 @@ describe("tryRunRpcSkillCommand", () => {
 		);
 
 		let message: Pick<CustomMessage, "attribution" | "content" | "customType" | "details" | "display"> | undefined;
+		let options: { streamingBehavior?: "steer" | "followUp" } | undefined;
 
 		const handled = await tryRunRpcSkillCommand(
 			{
@@ -23,8 +24,9 @@ describe("tryRunRpcSkillCommand", () => {
 				skills: [
 					{ name: "reviewer", description: "Review code", filePath: skillPath, baseDir: dir, source: "project" },
 				],
-				async promptCustomMessage(nextMessage: typeof message) {
+				async promptCustomMessage(nextMessage, nextOptions) {
 					message = nextMessage;
+					options = nextOptions;
 				},
 			},
 			"/skill:reviewer focus on risks",
@@ -39,8 +41,41 @@ describe("tryRunRpcSkillCommand", () => {
 		expect(message?.content).toContain("User: focus on risks");
 		expect(message?.display).toBe(true);
 		expect(message?.attribution).toBe("user");
+		expect(options?.streamingBehavior).toBe("steer");
 
 		await removeWithRetries(dir);
+	});
+
+	test("honors the RPC prompt streaming behavior for registered /skill commands", async () => {
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-rpc-skill-${Snowflake.next()}-`));
+		const skillPath = path.join(dir, "SKILL.md");
+		await Bun.write(
+			skillPath,
+			"---\nname: reviewer\ndescription: Review code\n---\n\nReview the supplied code carefully.\n",
+		);
+
+		let options: { streamingBehavior?: "steer" | "followUp" } | undefined;
+		try {
+			const handled = await tryRunRpcSkillCommand(
+				{
+					skillsSettings: { enableSkillCommands: true },
+					skills: [
+						{ name: "reviewer", description: "Review code", filePath: skillPath, baseDir: dir, source: "project" },
+					],
+					async promptCustomMessage(nextMessage, nextOptions) {
+						expect(nextMessage.customType).toBe(SKILL_PROMPT_MESSAGE_TYPE);
+						options = nextOptions;
+					},
+				},
+				"/skill:reviewer wait for the current turn",
+				"followUp",
+			);
+
+			expect(handled).toEqual({ agentInvoked: true });
+			expect(options?.streamingBehavior).toBe("followUp");
+		} finally {
+			await removeWithRetries(dir);
+		}
 	});
 
 	test("ignores unknown skill commands so normal prompt handling can continue", async () => {


### PR DESCRIPTION
## Summary
Extension sendUserMessage currently falls through to prompt() when no deliverAs option is provided. During an active stream that path throws AgentBusyError and surfaces as “Extension sendUserMessage failed”.

## Changes
- Queue extension sendUserMessage calls as steer while the session is streaming when deliverAs is omitted.
- Document the extension-facing behavior.
- Pass streamingBehavior: "steer" for ACP/RPC skill-command prompts.

## Verification
- bun test packages/coding-agent/test/agent-session-concurrent.test.ts — 29 pass, 0 fail
- bun check was also run during publishing and failed on two pre-existing Biome format/organize-import diagnostics in the T1 guided-goal files; targeted unit tests above passed.

Closes #4923
