### PR TITLE
fix(coding-agent): skip autolearn capture after aborted turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed extension `sendUserMessage` throwing `Agent is already processing…` while the agent is streaming: without `deliverAs`, busy messages now queue as a steer. ACP/RPC skill invocations pass `streamingBehavior: "steer"` so they can land mid-turn the same way TUI skill commands do.
+- Fixed autolearn auto-continue firing a capture turn after an aborted stop (Esc/cancel): the controller now skips any `agent_end` whose last assistant message has `stopReason: "aborted"`.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixed
 
-- Fixed extension `sendUserMessage` throwing `Agent is already processing…` while the agent is streaming: without `deliverAs`, busy messages now queue as a steer. ACP/RPC skill invocations pass `streamingBehavior: "steer"` so they can land mid-turn the same way TUI skill commands do.
 - Fixed autolearn auto-continue firing a capture turn after an aborted stop (Esc/cancel): the controller now skips any `agent_end` whose last assistant message has `stopReason: "aborted"`.
 
 ## [16.3.12] - 2026-07-08

--- a/packages/coding-agent/src/autolearn/controller.ts
+++ b/packages/coding-agent/src/autolearn/controller.ts
@@ -76,11 +76,11 @@ export class AutoLearnController {
 			return;
 		}
 		if (event.type === "agent_end") {
-			this.#onAgentEnd();
+			this.#onAgentEnd(event);
 		}
 	}
 
-	#onAgentEnd(): void {
+	#onAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): void {
 		// Snapshot and reset every turn: the counter describes only the
 		// just-finished turn, so below-threshold, disabled, and plan-mode stops
 		// must not let tool calls accumulate into a later turn.
@@ -94,6 +94,18 @@ export class AutoLearnController {
 		if (this.#suppressNext) {
 			this.#suppressNext = false;
 			return;
+		}
+		// Never nudge a turn that ended in an abort (ESC, cancel, etc.). The
+		// abort flag on the session is unreliable by the time agent_end is
+		// deferred to subscribers; read stopReason from the event messages.
+		for (let i = event.messages.length - 1; i >= 0; i--) {
+			const message = event.messages[i];
+			if (message && typeof message === "object" && "role" in message && message.role === "assistant") {
+				if ("stopReason" in message && message.stopReason === "aborted") {
+					return;
+				}
+				break;
+			}
 		}
 		// Honor a live opt-out: the subscription outlives the setting, so re-check
 		// the current flag rather than trusting install-time state.

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { AutoLearnController, buildAutoLearnInstructions } from "@oh-my-pi/pi-coding-agent/autolearn/controller";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -52,8 +53,8 @@ class FakeSession {
 		this.emit({ type: "agent_start" });
 	}
 
-	agentEnd(): void {
-		this.emit({ type: "agent_end", messages: [] });
+	agentEnd(messages: AgentMessage[] = []): void {
+		this.emit({ type: "agent_end", messages });
 	}
 }
 
@@ -247,6 +248,20 @@ describe("AutoLearnController", () => {
 		session.toolCalls(2);
 		session.agentEnd();
 		expect(session.sent).toHaveLength(1);
+	});
+
+	it("does not nudge when the turn ended with stopReason aborted", () => {
+		const session = new FakeSession();
+		install(session, { "autolearn.autoContinue": true });
+		session.toolCalls(5);
+		session.agentEnd([
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "partial" }],
+				stopReason: "aborted",
+			} as never,
+		]);
+		expect(session.sent).toHaveLength(0);
 	});
 });
 

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { AutoLearnController, buildAutoLearnInstructions } from "@oh-my-pi/pi-coding-agent/autolearn/controller";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { AgentSession, AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -254,13 +255,24 @@ describe("AutoLearnController", () => {
 		const session = new FakeSession();
 		install(session, { "autolearn.autoContinue": true });
 		session.toolCalls(5);
-		session.agentEnd([
-			{
-				role: "assistant",
-				content: [{ type: "text", text: "partial" }],
-				stopReason: "aborted",
-			} as never,
-		]);
+		const abortedMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "partial" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "mock",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			timestamp: Date.now(),
+		};
+		session.agentEnd([abortedMessage]);
 		expect(session.sent).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## Summary
Autolearn listens for agent_end and could nudge after an aborted assistant turn, including ESC/cancel flows where the final assistant message has stopReason: "aborted".

## Changes
- Inspect the agent_end messages payload for the last assistant message.
- Suppress autolearn nudges when that message stopped with stopReason: "aborted".
- Keep existing non-aborted nudge behavior covered by tests.

## Verification
- bun test packages/coding-agent/test/autolearn-controller.test.ts — 17 pass, 0 fail
- bun check was also run during publishing and failed on two pre-existing Biome format/organize-import diagnostics in the T1 guided-goal files; targeted unit tests above passed.

Closes #4925
