### PR TITLE
feat(coding-agent): render nomnoml diagrams as SVG or ASCII

### DIFF
--- a/.outline/sdd/task-38-report.md
+++ b/.outline/sdd/task-38-report.md
@@ -1,0 +1,23 @@
+# Task 38 report
+
+## Implemented
+
+- Restored keyed Kitty image ownership after budget demotion. Restoration keeps render-pass accounting, retransmission, release, and purge on one graphics ID; a concurrent key reacquisition is adopted without leaving an orphan mapping.
+- Made top-level Nomnoml extraction list-aware with an indentation stack. Unordered, ordered, continuation-indented, and nested-list fences remain Markdown; a later top-level fence is still extracted.
+- Made `setToolResultImages()` terminal after component disposal. Pending conversion continuations clear their in-flight key before dropping disposed results.
+- Added direct component and real `EventController` late-result regressions.
+
+## Verification
+
+- `bun test packages/tui/test/image-budget.test.ts packages/tui/test/image-render.test.ts packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts packages/coding-agent/test/selector-settings-side-effects.test.ts packages/coding-agent/test/issue-3656-shake-during-stream.test.ts`: 96 passed, 0 failed.
+- `bun run check:types` in `packages/tui`: passed.
+- `bun run check:types` in `packages/coding-agent`: passed.
+- Targeted Biome check/write over all five changed TypeScript files: passed.
+
+## Mutation proofs
+
+- Removing the restored-image ownership rebind made `restores keyed image ownership so release purges the retransmitted id exactly once` fail.
+- Removing the list-nesting fence guard made the ordered-list two-space continuation regression fail.
+- Removing the disposed entry guard made `ignores tool-result images delivered by an owner after disposal` fail.
+
+Each mutation was restored before the final verification run.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1028,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "faccess"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fluent"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,12 +1232,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
 name = "fontdue"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.21.1",
 ]
 
 [[package]]
@@ -1894,6 +1944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2162,18 @@ checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.13.0",
  "libc",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
 ]
 
 [[package]]
@@ -2996,6 +3064,7 @@ dependencies = [
  "portable-pty",
  "rayon",
  "regex",
+ "resvg",
  "serde",
  "serde_json",
  "similar 3.1.1",
@@ -3090,6 +3159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3187,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -3437,6 +3521,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3452,6 +3553,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3532,6 +3648,24 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser 0.25.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "safe_arch"
@@ -3687,6 +3821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3697,6 +3840,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -3745,6 +3897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,6 +3951,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
 ]
 
 [[package]]
@@ -3962,6 +4133,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,6 +4168,21 @@ dependencies = [
  "serde_core",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -4705,6 +4917,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4738,16 +4959,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -4766,6 +5023,34 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser 0.25.1",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf16_iter"
@@ -5724,6 +6009,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,7 @@ image = { version = "0.25", default-features = false, features = [
    "webp",
 ] }
 png = "0.18"
+resvg = "0.47"
 inferno = { version = "0.12", default-features = false }
 syntect = { version = "5.3", default-features = false, features = [
    "default-syntaxes",

--- a/bun.lock
+++ b/bun.lock
@@ -292,6 +292,7 @@
       "dependencies": {
         "@oh-my-pi/pi-natives": "catalog:",
         "handlebars": "catalog:",
+        "nomnoml": "1.7.0",
         "winston": "catalog:",
         "winston-daily-rotate-file": "catalog:",
       },
@@ -1117,6 +1118,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "graphre": ["graphre@0.1.3", "", {}, "sha512-F4OO/+BQj3R2UB3PQOGLgdAUy+SQuwy2A5cVGELAQDJlloSyyHqRe60ESFouRf8W0K+sm6gtWKotOwZoX3BL8w=="],
+
     "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
@@ -1246,6 +1249,8 @@
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "node-releases": ["node-releases@2.0.50", "", {}, "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg=="],
+
+    "nomnoml": ["nomnoml@1.7.0", "", { "dependencies": { "graphre": "^0.1.3" }, "bin": { "nomnoml": "dist/nomnoml-cli.js" } }, "sha512-l4eP+/2oSLT+zybLhvaWAQhPluiVbJuD3YUsLM0ggPbQMKH5ni2Vfc0YQPQRsolRHSt5H9SXtzng9MBVCbd+Ag=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 

--- a/crates/pi-natives/Cargo.toml
+++ b/crates/pi-natives/Cargo.toml
@@ -47,6 +47,7 @@ serde.workspace = true
 serde_json.workspace = true
 similar.workspace = true
 smallvec.workspace = true
+resvg.workspace = true
 syntect.workspace = true
 tiktoken-rs.workspace = true
 tokio.workspace = true

--- a/crates/pi-natives/src/lib.rs
+++ b/crates/pi-natives/src/lib.rs
@@ -47,6 +47,7 @@ pub mod ps;
 pub mod pty;
 pub mod shell;
 pub mod summary;
+pub mod svg;
 pub mod task;
 #[cfg(test)]
 pub(crate) mod testing;

--- a/crates/pi-natives/src/svg.rs
+++ b/crates/pi-natives/src/svg.rs
@@ -1,0 +1,70 @@
+//! SVG rasterization helpers.
+//!
+//! Converts trusted, already-generated SVG strings to PNG bytes for terminal
+//! image protocols. Parsing and rendering are offloaded through the shared
+//! blocking task wrapper so the N-API event loop stays responsive.
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use resvg::{tiny_skia, usvg};
+
+use crate::task;
+
+const MAX_ZOOM: f32 = 8.0;
+const MAX_PIXELS: u64 = 64_000_000;
+
+#[napi]
+pub fn render_svg_to_png(svg: String, zoom: f64) -> task::Promise<Uint8Array> {
+	task::blocking("render_svg_to_png", (), move |_| render_svg_to_png_sync(&svg, zoom))
+}
+
+fn render_svg_to_png_sync(svg: &str, zoom: f64) -> Result<Uint8Array> {
+	if svg.trim().is_empty() {
+		return Err(Error::from_reason("SVG input is empty"));
+	}
+	if !zoom.is_finite() || zoom <= 0.0 || zoom > f64::from(MAX_ZOOM) {
+		return Err(Error::from_reason(format!(
+			"Invalid SVG zoom {zoom}: expected 0 < zoom <= {MAX_ZOOM}"
+		)));
+	}
+	let zoom = zoom as f32;
+	let mut options = usvg::Options::default();
+	options.fontdb_mut().load_system_fonts();
+	let tree =
+		usvg::Tree::from_str(svg, &options).map_err(|err| Error::from_reason(err.to_string()))?;
+	let size = tree
+		.size()
+		.scale_by(zoom)
+		.ok_or_else(|| Error::from_reason("Scaled SVG size is invalid"))?
+		.to_int_size();
+	let width = size.width();
+	let height = size.height();
+	if u64::from(width) * u64::from(height) > MAX_PIXELS {
+		return Err(Error::from_reason(format!(
+			"Scaled SVG is too large: {width}x{height} exceeds {MAX_PIXELS} pixels"
+		)));
+	}
+	let mut pixmap = tiny_skia::Pixmap::new(width, height).ok_or_else(|| {
+		Error::from_reason(format!("Failed to allocate SVG pixmap {width}x{height}"))
+	})?;
+	resvg::render(&tree, tiny_skia::Transform::from_scale(zoom, zoom), &mut pixmap.as_mut());
+	let png = pixmap
+		.encode_png()
+		.map_err(|err| Error::from_reason(err.to_string()))?;
+	Ok(Uint8Array::from(png))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn renders_svg_to_png_bytes() {
+		let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="4" height="3"><rect width="4" height="3" fill="red"/></svg>"#;
+		let png = render_svg_to_png_sync(svg, 2.0).expect("svg renders");
+		let bytes = png.to_vec();
+		assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+		assert_eq!(u32::from_be_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]), 8);
+		assert_eq!(u32::from_be_bytes([bytes[20], bytes[21], bytes[22], bytes[23]]), 6);
+	}
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Nomnoml diagram rendering with a `/settings` mode for SVG images, ASCII fallback, or highlighted fences; when active, Nomnoml replaces the Mermaid prompt/rendering hint.
+- `/guided-goal` now injects project context files (AGENTS.md and the like) as an untrusted `<repository-context>` system block so interview questions and drafted objectives ground in the real repo. Failures and empty projects keep the previous context-free behavior.
+
+### Changed
+
+- Rewrote the `/guided-goal` interviewer rubric around loop-engineering: deterministic success criteria, verification commands, attempt caps, scope boundaries, and stop conditions. Ready objectives must use the five-section structured markdown form.
+
+### Fixed
+
+- Fixed extension `sendUserMessage` throwing `Agent is already processing…` while the agent is streaming: without `deliverAs`, busy messages now queue as a steer. ACP/RPC skill invocations pass `streamingBehavior: "steer"` so they can land mid-turn the same way TUI skill commands do.
+- Fixed autolearn auto-continue firing a capture turn after an aborted stop (Esc/cancel): the controller now skips any `agent_end` whose last assistant message has `stopReason: "aborted"`.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -845,6 +845,27 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"tui.renderNomnoml": {
+		type: "enum",
+		values: ["off", "svg", "ascii"] as const,
+		default: "svg",
+		ui: {
+			tab: "appearance",
+			group: "Display",
+			label: "Render Nomnoml Diagrams",
+			description: "Render nomnoml fenced code blocks as diagrams (replaces the Mermaid hint while active)",
+			options: [
+				{ value: "off", label: "Off", description: "Highlight nomnoml fences as plain code" },
+				{
+					value: "svg",
+					label: "SVG image",
+					description: "Rasterize to an inline terminal image; falls back to ASCII without image support",
+				},
+				{ value: "ascii", label: "ASCII", description: "Render as ASCII diagrams inline in markdown" },
+			],
+		},
+	},
+
 	"tui.hyperlinks": {
 		type: "enum",
 		values: ["off", "auto", "always"] as const,

--- a/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
+++ b/packages/coding-agent/src/modes/components/agent-transcript-viewer.ts
@@ -166,6 +166,7 @@ export class AgentTranscriptViewer implements Component {
 			hideThinkingBlock: deps.hideThinkingBlock,
 			proseOnlyThinking: deps.proseOnlyThinking,
 			requestRender: deps.requestRender,
+			showImages: false,
 		});
 		this.#scrollView = new ScrollView([], {
 			height: 10,

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -151,7 +151,7 @@ function findTopLevelNomnomlBlocks(text: string): TopLevelNomnomlBlock[] {
 	return blocks;
 }
 
-function splitNomnomlImages(
+export function splitNomnomlImages(
 	text: string,
 	pngByKey: ReadonlyMap<string, string>,
 	placementScope: string,
@@ -164,8 +164,10 @@ function splitNomnomlImages(
 		if (!block) continue;
 		const data = pngByKey.get(block.rasterKey);
 		if (!data) continue;
-		const before = text.slice(lastIndex, block.start).trim();
-		if (before) segments.push({ type: "markdown", text: before });
+		// Keep emptiness guards, but push the original slice so indented code /
+		// hard-break trailing spaces adjacent to the fence stay intact.
+		const before = text.slice(lastIndex, block.start);
+		if (before.trim()) segments.push({ type: "markdown", text: before });
 		segments.push({
 			type: "image",
 			key: nomnomlImageKey(block.rasterKey, placementScope, occurrence, block.start),
@@ -175,9 +177,9 @@ function splitNomnomlImages(
 		});
 		lastIndex = block.end;
 	}
-	const after = text.slice(lastIndex).trim();
-	if (after) segments.push({ type: "markdown", text: after });
-	return segments.length === 0 ? [{ type: "markdown", text: text.trim() }] : segments;
+	const after = text.slice(lastIndex);
+	if (after.trim()) segments.push({ type: "markdown", text: after });
+	return segments.length === 0 ? [{ type: "markdown", text }] : segments;
 }
 
 /**

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -277,8 +277,10 @@ export class AssistantMessageComponent extends Container {
 	#nomnomlPngByKey = new Map<string, string>();
 	#nomnomlPngInFlight = new Set<string>();
 	#nomnomlPlacementKeys = new Set<string>();
+	#toolImagePlacementKeys = new Set<string>();
 	readonly #instanceId = ++assistantMessageComponentInstanceSeq;
 	readonly #showImages: () => boolean;
+	#disposed = false;
 	#transcriptBlockFinalized: boolean;
 	/**
 	 * True while any rendered item carries a ` ```mermaid ` fence. Mermaid's
@@ -382,6 +384,12 @@ export class AssistantMessageComponent extends Container {
 
 	/** Re-read the live image setting and rebuild this turn immediately. */
 	refreshImagePolicy(): void {
+		if (this.#disposed) return;
+		if (this.#showImages()) {
+			for (const [toolCallId, images] of this.#toolImagesByCallId) {
+				this.#convertToolImagesForKitty(toolCallId, images);
+			}
+		}
 		if (this.#lastMessage) {
 			this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
 		} else {
@@ -413,9 +421,12 @@ export class AssistantMessageComponent extends Container {
 	setProseOnlyThinking(proseOnly: boolean): void {
 		this.proseOnlyThinking = proseOnly;
 	}
-
 	override dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
 		this.#stopThinkingAnimation();
+		this.#replaceNomnomlPlacements(new Set());
+		this.#replaceToolImagePlacements(new Set());
 		super.dispose();
 	}
 
@@ -615,13 +626,14 @@ export class AssistantMessageComponent extends Container {
 	setToolResultImages(toolCallId: string, images: ImageContent[]): void {
 		if (!toolCallId) return;
 		const validImages = images.filter(img => img.type === "image" && img.data && img.mimeType);
+		const keyPrefix = this.#toolImageKeyPrefix(toolCallId);
 		for (const key of Array.from(this.#convertedKittyImages.keys())) {
-			if (key.startsWith(`${toolCallId}:`)) {
+			if (key.startsWith(keyPrefix)) {
 				this.#convertedKittyImages.delete(key);
 			}
 		}
 		for (const key of Array.from(this.#kittyConversionsInFlight)) {
-			if (key.startsWith(`${toolCallId}:`)) {
+			if (key.startsWith(keyPrefix)) {
 				this.#kittyConversionsInFlight.delete(key);
 			}
 		}
@@ -636,18 +648,27 @@ export class AssistantMessageComponent extends Container {
 		}
 	}
 
+	#toolImageKeyPrefix(toolCallId: string): string {
+		return `assistant-tool:am${this.#instanceId}:${toolCallId}:`;
+	}
+
+	#toolImageKey(toolCallId: string, index: number): string {
+		return `${this.#toolImageKeyPrefix(toolCallId)}${index}`;
+	}
+
 	#convertToolImagesForKitty(toolCallId: string, images: ImageContent[]): void {
-		if (TERMINAL.imageProtocol !== ImageProtocol.Kitty) return;
+		if (!this.#showImages() || TERMINAL.imageProtocol !== ImageProtocol.Kitty) return;
 		for (let index = 0; index < images.length; index++) {
 			const image = images[index];
 			if (!image || image.mimeType === "image/png") continue;
-			const key = `${toolCallId}:${index}`;
+			const key = this.#toolImageKey(toolCallId, index);
 			if (this.#convertedKittyImages.has(key) || this.#kittyConversionsInFlight.has(key)) continue;
 			this.#kittyConversionsInFlight.add(key);
 			new Bun.Image(Buffer.from(image.data, "base64"))
 				.png()
 				.toBase64()
 				.then(data => {
+					if (this.#disposed) return;
 					this.#kittyConversionsInFlight.delete(key);
 					this.#convertedKittyImages.set(key, {
 						type: "image",
@@ -666,11 +687,18 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#renderToolImages(): void {
+		if (!this.#showImages()) {
+			this.#replaceToolImagePlacements(new Set());
+			return;
+		}
 		const imageEntries = Array.from(this.#toolImagesByCallId.entries()).flatMap(([toolCallId, images]) =>
-			images.map((image, index) => ({ image, key: `${toolCallId}:${index}` })),
+			images.map((image, index) => ({ image, key: this.#toolImageKey(toolCallId, index) })),
 		);
-		if (imageEntries.length === 0) return;
-
+		if (imageEntries.length === 0) {
+			this.#replaceToolImagePlacements(new Set());
+			return;
+		}
+		const placementKeys = new Set<string>();
 		this.#contentContainer.addChild(new Spacer(1));
 		for (const { image, key } of imageEntries) {
 			const displayImage =
@@ -678,6 +706,7 @@ export class AssistantMessageComponent extends Container {
 					? this.#convertedKittyImages.get(key)
 					: image;
 			if (TERMINAL.imageProtocol && displayImage) {
+				placementKeys.add(key);
 				this.#contentContainer.addChild(
 					new Image(
 						displayImage.data,
@@ -690,6 +719,14 @@ export class AssistantMessageComponent extends Container {
 			}
 			this.#contentContainer.addChild(new Text(theme.fg("toolOutput", `[Image: ${image.mimeType}]`), 1, 0));
 		}
+		this.#replaceToolImagePlacements(placementKeys);
+	}
+
+	#replaceToolImagePlacements(nextKeys: Set<string>): void {
+		for (const key of this.#toolImagePlacementKeys) {
+			if (!nextKeys.has(key)) this.imageBudget?.release(key);
+		}
+		this.#toolImagePlacementKeys = nextKeys;
 	}
 
 	#appendThinkingExtensions(contentIndex: number, thinkingIndex: number, text: string): void {
@@ -831,6 +868,7 @@ export class AssistantMessageComponent extends Container {
 				this.#nomnomlPngInFlight.add(block.rasterKey);
 				resolveNomnomlPng(block.source)
 					.then(data => {
+						if (this.#disposed) return;
 						this.#nomnomlPngInFlight.delete(block.rasterKey);
 						if (!data) return;
 						this.#nomnomlPngByKey.set(block.rasterKey, data);
@@ -903,6 +941,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	updateContent(message: AssistantMessage, opts?: { transient?: boolean }): void {
+		if (this.#disposed) return;
 		this.#blockVersion++;
 		this.#lastMessage = message;
 		this.#lastUpdateTransient = opts?.transient === true;

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -1,9 +1,9 @@
 import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import { Container, Image, type ImageBudget, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@oh-my-pi/pi-tui";
-import { formatNumber } from "@oh-my-pi/pi-utils";
+import { formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
-import { getMarkdownNomnomlRendering, resolveNomnomlPng } from "../../modes/theme/nomnoml-cache";
+import { getMarkdownNomnomlRendering, resolveNomnomlAscii, resolveNomnomlPng } from "../../modes/theme/nomnoml-cache";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { canonicalizeMessage, formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
@@ -81,7 +81,7 @@ type TopLevelNomnomlBlock = {
 
 type TextNomnomlSegment =
 	| { type: "markdown"; text: string }
-	| { type: "image"; key: string; data: string; mimeType: "image/png" };
+	| { type: "image"; key: string; data: string; mimeType: "image/png"; source: string };
 
 function nomnomlRasterKey(source: string): string {
 	return `nomnoml:${Bun.hash(source)}`;
@@ -157,6 +157,7 @@ function splitNomnomlImages(
 			key: nomnomlImageKey(block.rasterKey, placementScope, occurrence, block.start),
 			data,
 			mimeType: "image/png",
+			source: block.source,
 		});
 		lastIndex = block.end;
 	}
@@ -275,8 +276,9 @@ export class AssistantMessageComponent extends Container {
 	#kittyConversionsInFlight = new Set<string>();
 	#nomnomlPngByKey = new Map<string, string>();
 	#nomnomlPngInFlight = new Set<string>();
+	#nomnomlPlacementKeys = new Set<string>();
 	readonly #instanceId = ++assistantMessageComponentInstanceSeq;
-	#showImages = true;
+	readonly #showImages: () => boolean;
 	#transcriptBlockFinalized: boolean;
 	/**
 	 * True while any rendered item carries a ` ```mermaid ` fence. Mermaid's
@@ -344,10 +346,10 @@ export class AssistantMessageComponent extends Container {
 		private readonly thinkingRenderers: readonly AssistantThinkingRenderer[] = [],
 		private readonly imageBudget?: ImageBudget,
 		private proseOnlyThinking = true,
-		showImages = true,
+		showImages: boolean | (() => boolean) = true,
 	) {
 		super();
-		this.#showImages = showImages;
+		this.#showImages = typeof showImages === "function" ? showImages : () => showImages;
 		this.#transcriptBlockFinalized = message !== undefined;
 
 		// Slim cache-invalidation divider, populated above the content when this
@@ -378,12 +380,20 @@ export class AssistantMessageComponent extends Container {
 		this.#blockVersion++;
 	}
 
+	/** Re-read the live image setting and rebuild this turn immediately. */
+	refreshImagePolicy(): void {
+		if (this.#lastMessage) {
+			this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
+		} else {
+			this.invalidate();
+		}
+	}
+
 	override invalidate(): void {
 		super.invalidate();
-		// Theme/symbol changes arrive via invalidate(). Fast-path children captured
-		// getMarkdownTheme() at construction, so drop them and force the teardown
-		// path to rebuild with the current theme. Streaming updates call
-		// updateContent() directly and keep the fast path.
+		// Theme/symbol changes arrive via invalidate(). A captured Markdown child
+		// would otherwise retain the old theme, and an image-policy change could
+		// retain an SVG or ASCII child built under the previous setting.
 		this.#fastPathKey = undefined;
 		this.#fastPathItems = undefined;
 		if (this.#lastMessage) {
@@ -704,7 +714,9 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#computeShapeKey(message: AssistantMessage): string {
-		const parts: string[] = [`htb:${this.hideThinkingBlock ? 1 : 0}|pot:${this.proseOnlyThinking ? 1 : 0}`];
+		const parts: string[] = [
+			`htb:${this.hideThinkingBlock ? 1 : 0}|pot:${this.proseOnlyThinking ? 1 : 0}|img:${this.#showImages() ? 1 : 0}`,
+		];
 		for (const content of message.content) {
 			if (content.type === "text") {
 				parts.push(canonicalizeMessage(content.text) ? "T1" : "T0");
@@ -803,9 +815,9 @@ export class AssistantMessageComponent extends Container {
 		return true;
 	}
 
-	#queueNomnomlPngs(message: AssistantMessage): void {
+	#queueNomnomlPngs(message: AssistantMessage, showImages: boolean): void {
 		if (
-			!this.#showImages ||
+			!showImages ||
 			this.#lastUpdateTransient ||
 			!TERMINAL.imageProtocol ||
 			getMarkdownNomnomlRendering() !== "svg"
@@ -840,9 +852,43 @@ export class AssistantMessageComponent extends Container {
 				segment.data,
 				segment.mimeType,
 				{ fallbackColor: (text: string) => theme.fg("toolOutput", text) },
-				{ ...resolveImageOptions(), budget: this.imageBudget, imageKey: segment.key },
+				{
+					...resolveImageOptions(),
+					budget: this.imageBudget,
+					imageKey: segment.key,
+					fallback: width => {
+						const source = sanitizeText(segment.source);
+						const ascii = resolveNomnomlAscii(source, width);
+						if (ascii === null) return [theme.fg("toolOutput", "[Nomnoml diagram]")];
+						return ascii.split("\n").map(line => theme.fg("toolOutput", line));
+					},
+				},
 			),
 		);
+	}
+
+	#nomnomlKeysFor(message: AssistantMessage, renderImages: boolean): Set<string> {
+		const keys = new Set<string>();
+		if (!renderImages) return keys;
+		for (let i = 0; i < message.content.length; i++) {
+			const content = message.content[i];
+			if (content?.type !== "text" || !canonicalizeMessage(content.text)) continue;
+			for (const segment of splitNomnomlImages(
+				content.text.trim(),
+				this.#nomnomlPngByKey,
+				`am${this.#instanceId}:${i}`,
+			)) {
+				if (segment.type === "image") keys.add(segment.key);
+			}
+		}
+		return keys;
+	}
+
+	#replaceNomnomlPlacements(nextKeys: Set<string>): void {
+		for (const key of this.#nomnomlPlacementKeys) {
+			if (!nextKeys.has(key)) this.imageBudget?.release(key);
+		}
+		this.#nomnomlPlacementKeys = nextKeys;
 	}
 
 	#appendMarkdownText(
@@ -860,6 +906,7 @@ export class AssistantMessageComponent extends Container {
 		this.#blockVersion++;
 		this.#lastMessage = message;
 		this.#lastUpdateTransient = opts?.transient === true;
+		const showImages = this.#showImages();
 
 		// Streaming-speed gauge: only a live, in-flight render of the single
 		// animating hidden-thinking block feeds the shared session tracker. The
@@ -911,7 +958,13 @@ export class AssistantMessageComponent extends Container {
 			return false;
 		});
 
-		this.#queueNomnomlPngs(message);
+		const renderNomnomlImages =
+			showImages &&
+			!this.#lastUpdateTransient &&
+			!!TERMINAL.imageProtocol &&
+			getMarkdownNomnomlRendering() === "svg";
+		this.#replaceNomnomlPlacements(this.#nomnomlKeysFor(message, renderNomnomlImages));
+		this.#queueNomnomlPngs(message, showImages);
 
 		// Fast path: reuse Markdown children when shape is stable during streaming
 		if (this.#tryFastPathUpdate(message, opts)) return;
@@ -936,11 +989,6 @@ export class AssistantMessageComponent extends Container {
 
 		// Render content in order
 		let thinkingIndex = 0;
-		const renderNomnomlImages =
-			this.#showImages &&
-			!this.#lastUpdateTransient &&
-			!!TERMINAL.imageProtocol &&
-			getMarkdownNomnomlRendering() === "svg";
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && canonicalizeMessage(content.text)) {

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -77,7 +77,6 @@ type TopLevelNomnomlBlock = {
 	start: number;
 	end: number;
 	rasterKey: string;
-	imageKey: string;
 };
 
 type TextNomnomlSegment =
@@ -88,8 +87,8 @@ function nomnomlRasterKey(source: string): string {
 	return `nomnoml:${Bun.hash(source)}`;
 }
 
-function nomnomlImageKey(rasterKey: string, occurrence: number, start: number): string {
-	return `${rasterKey}:${occurrence}:${start}`;
+function nomnomlImageKey(rasterKey: string, placementScope: string, occurrence: number, start: number): string {
+	return `${rasterKey}:${placementScope}:${occurrence}:${start}`;
 }
 
 function findTopLevelNomnomlBlocks(text: string): TopLevelNomnomlBlock[] {
@@ -116,7 +115,6 @@ function findTopLevelNomnomlBlocks(text: string): TopLevelNomnomlBlock[] {
 								start: fence.start,
 								end: offset,
 								rasterKey,
-								imageKey: nomnomlImageKey(rasterKey, blocks.length, fence.start),
 							});
 						}
 					}
@@ -139,15 +137,27 @@ function findTopLevelNomnomlBlocks(text: string): TopLevelNomnomlBlock[] {
 	return blocks;
 }
 
-function splitNomnomlImages(text: string, pngByKey: ReadonlyMap<string, string>): TextNomnomlSegment[] {
+function splitNomnomlImages(
+	text: string,
+	pngByKey: ReadonlyMap<string, string>,
+	placementScope: string,
+): TextNomnomlSegment[] {
 	const segments: TextNomnomlSegment[] = [];
 	let lastIndex = 0;
-	for (const block of findTopLevelNomnomlBlocks(text)) {
+	const blocks = findTopLevelNomnomlBlocks(text);
+	for (let occurrence = 0; occurrence < blocks.length; occurrence++) {
+		const block = blocks[occurrence];
+		if (!block) continue;
 		const data = pngByKey.get(block.rasterKey);
 		if (!data) continue;
 		const before = text.slice(lastIndex, block.start).trim();
 		if (before) segments.push({ type: "markdown", text: before });
-		segments.push({ type: "image", key: block.imageKey, data, mimeType: "image/png" });
+		segments.push({
+			type: "image",
+			key: nomnomlImageKey(block.rasterKey, placementScope, occurrence, block.start),
+			data,
+			mimeType: "image/png",
+		});
 		lastIndex = block.end;
 	}
 	const after = text.slice(lastIndex).trim();
@@ -252,6 +262,10 @@ function lerpHex(from: string, to: string, t: number): string {
 /**
  * Component that renders a complete assistant message
  */
+// Stable per-instance prefix so assistant nomnoml image placements do not collide
+// across assistant turns that share one terminal ImageBudget.
+let assistantMessageComponentInstanceSeq = 0;
+
 export class AssistantMessageComponent extends Container {
 	#contentContainer: Container;
 	#markerSlot: Container;
@@ -261,6 +275,8 @@ export class AssistantMessageComponent extends Container {
 	#kittyConversionsInFlight = new Set<string>();
 	#nomnomlPngByKey = new Map<string, string>();
 	#nomnomlPngInFlight = new Set<string>();
+	readonly #instanceId = ++assistantMessageComponentInstanceSeq;
+	#showImages = true;
 	#transcriptBlockFinalized: boolean;
 	/**
 	 * True while any rendered item carries a ` ```mermaid ` fence. Mermaid's
@@ -328,8 +344,10 @@ export class AssistantMessageComponent extends Container {
 		private readonly thinkingRenderers: readonly AssistantThinkingRenderer[] = [],
 		private readonly imageBudget?: ImageBudget,
 		private proseOnlyThinking = true,
+		showImages = true,
 	) {
 		super();
+		this.#showImages = showImages;
 		this.#transcriptBlockFinalized = message !== undefined;
 
 		// Slim cache-invalidation divider, populated above the content when this
@@ -786,7 +804,12 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#queueNomnomlPngs(message: AssistantMessage): void {
-		if (this.#lastUpdateTransient || !TERMINAL.imageProtocol || getMarkdownNomnomlRendering() !== "svg") {
+		if (
+			!this.#showImages ||
+			this.#lastUpdateTransient ||
+			!TERMINAL.imageProtocol ||
+			getMarkdownNomnomlRendering() !== "svg"
+		) {
 			return;
 		}
 		for (const content of message.content) {
@@ -914,14 +937,17 @@ export class AssistantMessageComponent extends Container {
 		// Render content in order
 		let thinkingIndex = 0;
 		const renderNomnomlImages =
-			!this.#lastUpdateTransient && !!TERMINAL.imageProtocol && getMarkdownNomnomlRendering() === "svg";
+			this.#showImages &&
+			!this.#lastUpdateTransient &&
+			!!TERMINAL.imageProtocol &&
+			getMarkdownNomnomlRendering() === "svg";
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && canonicalizeMessage(content.text)) {
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				const trimmed = content.text.trim();
 				const segments: TextNomnomlSegment[] = renderNomnomlImages
-					? splitNomnomlImages(trimmed, this.#nomnomlPngByKey)
+					? splitNomnomlImages(trimmed, this.#nomnomlPngByKey, `am${this.#instanceId}:${i}`)
 					: [{ type: "markdown", text: trimmed }];
 				for (const segment of segments) {
 					if (segment.type === "markdown") {

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -94,6 +94,7 @@ function nomnomlImageKey(rasterKey: string, placementScope: string, occurrence: 
 function findTopLevelNomnomlBlocks(text: string): TopLevelNomnomlBlock[] {
 	const blocks: TopLevelNomnomlBlock[] = [];
 	let fence: { marker: string; start: number; contentStart: number; nomnoml: boolean } | undefined;
+	const listIndents: number[] = [];
 	let offset = 0;
 	for (const rawLine of text.split(/(?<=\n)/)) {
 		if (rawLine.length === 0) continue;
@@ -123,7 +124,20 @@ function findTopLevelNomnomlBlocks(text: string): TopLevelNomnomlBlock[] {
 			}
 			continue;
 		}
-		if (fenceMatch) {
+
+		const listItem = /^( *)(?:[-+*]|\d{1,9}[.)])([ \t]+)/.exec(line);
+		if (listItem) {
+			const markerIndent = listItem[1]?.length ?? 0;
+			while (listIndents.length > 0 && (listIndents.at(-1) ?? 0) >= markerIndent) listIndents.pop();
+			listIndents.push(markerIndent);
+			continue;
+		}
+		const indent = /^ */.exec(line)?.[0].length ?? 0;
+		if (line.trim() !== "") {
+			while (listIndents.length > 0 && (listIndents.at(-1) ?? 0) >= indent) listIndents.pop();
+		}
+		const nestedInList = listIndents.length > 0;
+		if (fenceMatch && !nestedInList) {
 			const marker = fenceMatch[1] ?? "";
 			const info = fenceMatch[2] ?? "";
 			fence = {
@@ -624,7 +638,7 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	setToolResultImages(toolCallId: string, images: ImageContent[]): void {
-		if (!toolCallId) return;
+		if (this.#disposed || !toolCallId) return;
 		const validImages = images.filter(img => img.type === "image" && img.data && img.mimeType);
 		const keyPrefix = this.#toolImageKeyPrefix(toolCallId);
 		for (const key of Array.from(this.#convertedKittyImages.keys())) {
@@ -668,8 +682,8 @@ export class AssistantMessageComponent extends Container {
 				.png()
 				.toBase64()
 				.then(data => {
-					if (this.#disposed) return;
 					this.#kittyConversionsInFlight.delete(key);
+					if (this.#disposed) return;
 					this.#convertedKittyImages.set(key, {
 						type: "image",
 						data,

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -72,28 +72,83 @@ function containsMermaidFence(text: string): boolean {
 	return false;
 }
 
-const NOMNOML_BLOCK = /```nomnoml[^\n]*\n([\s\S]*?)```/g;
+type TopLevelNomnomlBlock = {
+	source: string;
+	start: number;
+	end: number;
+	rasterKey: string;
+	imageKey: string;
+};
 
 type TextNomnomlSegment =
 	| { type: "markdown"; text: string }
 	| { type: "image"; key: string; data: string; mimeType: "image/png" };
 
-function nomnomlImageKey(source: string): string {
+function nomnomlRasterKey(source: string): string {
 	return `nomnoml:${Bun.hash(source)}`;
+}
+
+function nomnomlImageKey(rasterKey: string, occurrence: number, start: number): string {
+	return `${rasterKey}:${occurrence}:${start}`;
+}
+
+function findTopLevelNomnomlBlocks(text: string): TopLevelNomnomlBlock[] {
+	const blocks: TopLevelNomnomlBlock[] = [];
+	let fence: { marker: string; start: number; contentStart: number; nomnoml: boolean } | undefined;
+	let offset = 0;
+	for (const rawLine of text.split(/(?<=\n)/)) {
+		if (rawLine.length === 0) continue;
+		const lineStart = offset;
+		const line = rawLine.endsWith("\n") ? rawLine.slice(0, -1) : rawLine;
+		offset += rawLine.length;
+		const fenceMatch = CODE_FENCE_LINE.exec(line);
+		if (fence) {
+			if (fenceMatch) {
+				const marker = fenceMatch[1] ?? "";
+				const info = fenceMatch[2] ?? "";
+				if (info.trim() === "" && marker[0] === fence.marker[0] && marker.length >= fence.marker.length) {
+					if (fence.nomnoml) {
+						const source = text.slice(fence.contentStart, lineStart).trim();
+						if (source) {
+							const rasterKey = nomnomlRasterKey(source);
+							blocks.push({
+								source,
+								start: fence.start,
+								end: offset,
+								rasterKey,
+								imageKey: nomnomlImageKey(rasterKey, blocks.length, fence.start),
+							});
+						}
+					}
+					fence = undefined;
+				}
+			}
+			continue;
+		}
+		if (fenceMatch) {
+			const marker = fenceMatch[1] ?? "";
+			const info = fenceMatch[2] ?? "";
+			fence = {
+				marker,
+				start: lineStart,
+				contentStart: offset,
+				nomnoml: /^nomnoml\b/.test(info.trim()),
+			};
+		}
+	}
+	return blocks;
 }
 
 function splitNomnomlImages(text: string, pngByKey: ReadonlyMap<string, string>): TextNomnomlSegment[] {
 	const segments: TextNomnomlSegment[] = [];
 	let lastIndex = 0;
-	for (let match = NOMNOML_BLOCK.exec(text); match !== null; match = NOMNOML_BLOCK.exec(text)) {
-		const source = match[1]?.trim() ?? "";
-		const key = nomnomlImageKey(source);
-		const data = pngByKey.get(key);
+	for (const block of findTopLevelNomnomlBlocks(text)) {
+		const data = pngByKey.get(block.rasterKey);
 		if (!data) continue;
-		const before = text.slice(lastIndex, match.index).trim();
+		const before = text.slice(lastIndex, block.start).trim();
 		if (before) segments.push({ type: "markdown", text: before });
-		segments.push({ type: "image", key, data, mimeType: "image/png" });
-		lastIndex = NOMNOML_BLOCK.lastIndex;
+		segments.push({ type: "image", key: block.imageKey, data, mimeType: "image/png" });
+		lastIndex = block.end;
 	}
 	const after = text.slice(lastIndex).trim();
 	if (after) segments.push({ type: "markdown", text: after });
@@ -731,34 +786,26 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#queueNomnomlPngs(message: AssistantMessage): void {
-		if (
-			this.#lastUpdateTransient ||
-			TERMINAL.imageProtocol === undefined ||
-			getMarkdownNomnomlRendering() !== "svg"
-		) {
+		if (this.#lastUpdateTransient || !TERMINAL.imageProtocol || getMarkdownNomnomlRendering() !== "svg") {
 			return;
 		}
 		for (const content of message.content) {
 			if (content.type !== "text") continue;
-			NOMNOML_BLOCK.lastIndex = 0;
-			for (let match = NOMNOML_BLOCK.exec(content.text); match !== null; match = NOMNOML_BLOCK.exec(content.text)) {
-				const source = match[1]?.trim() ?? "";
-				if (!source) continue;
-				const key = nomnomlImageKey(source);
-				if (this.#nomnomlPngByKey.has(key) || this.#nomnomlPngInFlight.has(key)) continue;
-				this.#nomnomlPngInFlight.add(key);
-				resolveNomnomlPng(source)
+			for (const block of findTopLevelNomnomlBlocks(content.text)) {
+				if (this.#nomnomlPngByKey.has(block.rasterKey) || this.#nomnomlPngInFlight.has(block.rasterKey)) continue;
+				this.#nomnomlPngInFlight.add(block.rasterKey);
+				resolveNomnomlPng(block.source)
 					.then(data => {
-						this.#nomnomlPngInFlight.delete(key);
+						this.#nomnomlPngInFlight.delete(block.rasterKey);
 						if (!data) return;
-						this.#nomnomlPngByKey.set(key, data);
+						this.#nomnomlPngByKey.set(block.rasterKey, data);
 						if (this.#lastMessage) {
 							this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
 						}
 						this.onImageUpdate?.();
 					})
 					.catch(() => {
-						this.#nomnomlPngInFlight.delete(key);
+						this.#nomnomlPngInFlight.delete(block.rasterKey);
 					});
 			}
 		}
@@ -867,7 +914,7 @@ export class AssistantMessageComponent extends Container {
 		// Render content in order
 		let thinkingIndex = 0;
 		const renderNomnomlImages =
-			!this.#lastUpdateTransient && TERMINAL.imageProtocol !== undefined && getMarkdownNomnomlRendering() === "svg";
+			!this.#lastUpdateTransient && !!TERMINAL.imageProtocol && getMarkdownNomnomlRendering() === "svg";
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && canonicalizeMessage(content.text)) {

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -3,6 +3,7 @@ import { Container, Image, type ImageBudget, ImageProtocol, Markdown, Spacer, TE
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import type { AssistantThinkingRenderer } from "../../extensibility/extensions/types";
+import { getMarkdownNomnomlRendering, resolveNomnomlPng } from "../../modes/theme/nomnoml-cache";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { getPreviewLines, resolveImageOptions, TRUNCATE_LENGTHS } from "../../tools/render-utils";
 import { canonicalizeMessage, formatThinkingForDisplay, hasDisplayableThinking } from "../../utils/thinking-display";
@@ -39,12 +40,12 @@ function resolveThinkingDisplay(block: ThinkingContentBlock, proseOnly: boolean)
 }
 
 /**
- * Whether `text` contains a ` ```mermaid ` fence (open or closed) outside
- * ordinary code fences. Mermaid defers native-scrollback settling wholesale
- * (see {@link AssistantMessageComponent.getTranscriptBlockSettledRows}): its
- * ASCII rendering resolves asynchronously, so even a completed fence can
- * re-layout rows that already looked settled. Fence-aware so a mermaid
- * example inside a regular code block never triggers the deferral.
+ * Whether `text` contains a ` ```mermaid ` or ` ```nomnoml ` fence (open or
+ * closed) outside ordinary code fences. Diagram renderers defer native-scrollback
+ * settling wholesale (see {@link AssistantMessageComponent.getTranscriptBlockSettledRows}):
+ * their rendering can resolve asynchronously, so even a completed fence can
+ * re-layout rows that already looked settled. Fence-aware so examples inside a
+ * regular code block never trigger the deferral.
  */
 function containsMermaidFence(text: string): boolean {
 	let fence: string | null = null;
@@ -52,22 +53,51 @@ function containsMermaidFence(text: string): boolean {
 		const fenceMatch = CODE_FENCE_LINE.exec(line);
 		if (fence !== null) {
 			// Inside a code block: only a bare matching closing fence ends it.
-			if (
-				fenceMatch &&
-				fenceMatch[2]!.trim() === "" &&
-				fenceMatch[1]![0] === fence[0] &&
-				fenceMatch[1]!.length >= fence.length
-			) {
-				fence = null;
+			if (fenceMatch) {
+				const marker = fenceMatch[1] ?? "";
+				const info = fenceMatch[2] ?? "";
+				if (info.trim() === "" && marker[0] === fence[0] && marker.length >= fence.length) {
+					fence = null;
+				}
 			}
 			continue;
 		}
 		if (fenceMatch) {
-			if (/^mermaid\b/.test(fenceMatch[2]!.trim())) return true;
-			fence = fenceMatch[1]!;
+			const marker = fenceMatch[1] ?? "";
+			const info = fenceMatch[2] ?? "";
+			if (/^(?:mermaid|nomnoml)\b/.test(info.trim())) return true;
+			fence = marker;
 		}
 	}
 	return false;
+}
+
+const NOMNOML_BLOCK = /```nomnoml[^\n]*\n([\s\S]*?)```/g;
+
+type TextNomnomlSegment =
+	| { type: "markdown"; text: string }
+	| { type: "image"; key: string; data: string; mimeType: "image/png" };
+
+function nomnomlImageKey(source: string): string {
+	return `nomnoml:${Bun.hash(source)}`;
+}
+
+function splitNomnomlImages(text: string, pngByKey: ReadonlyMap<string, string>): TextNomnomlSegment[] {
+	const segments: TextNomnomlSegment[] = [];
+	let lastIndex = 0;
+	for (let match = NOMNOML_BLOCK.exec(text); match !== null; match = NOMNOML_BLOCK.exec(text)) {
+		const source = match[1]?.trim() ?? "";
+		const key = nomnomlImageKey(source);
+		const data = pngByKey.get(key);
+		if (!data) continue;
+		const before = text.slice(lastIndex, match.index).trim();
+		if (before) segments.push({ type: "markdown", text: before });
+		segments.push({ type: "image", key, data, mimeType: "image/png" });
+		lastIndex = NOMNOML_BLOCK.lastIndex;
+	}
+	const after = text.slice(lastIndex).trim();
+	if (after) segments.push({ type: "markdown", text: after });
+	return segments.length === 0 ? [{ type: "markdown", text: text.trim() }] : segments;
 }
 
 /**
@@ -174,6 +204,8 @@ export class AssistantMessageComponent extends Container {
 	#toolImagesByCallId = new Map<string, ImageContent[]>();
 	#convertedKittyImages = new Map<string, ImageContent>();
 	#kittyConversionsInFlight = new Set<string>();
+	#nomnomlPngByKey = new Map<string, string>();
+	#nomnomlPngInFlight = new Set<string>();
 	#transcriptBlockFinalized: boolean;
 	/**
 	 * True while any rendered item carries a ` ```mermaid ` fence. Mermaid's
@@ -622,7 +654,7 @@ export class AssistantMessageComponent extends Container {
 		for (const content of message.content) {
 			if (content.type === "toolCall") return false;
 		}
-		if (this.#toolImagesByCallId.size > 0) return false;
+		if (this.#toolImagesByCallId.size > 0 || this.#nomnomlPngByKey.size > 0) return false;
 		const errorPresentation = resolveAssistantErrorPresentation(message);
 		if (errorPresentation.kind === "compact-recovered") return false;
 		if (errorPresentation.kind === "full" && !(message.stopReason === "error" && this.#errorPinned)) {
@@ -698,6 +730,62 @@ export class AssistantMessageComponent extends Container {
 		return true;
 	}
 
+	#queueNomnomlPngs(message: AssistantMessage): void {
+		if (
+			this.#lastUpdateTransient ||
+			TERMINAL.imageProtocol === undefined ||
+			getMarkdownNomnomlRendering() !== "svg"
+		) {
+			return;
+		}
+		for (const content of message.content) {
+			if (content.type !== "text") continue;
+			NOMNOML_BLOCK.lastIndex = 0;
+			for (let match = NOMNOML_BLOCK.exec(content.text); match !== null; match = NOMNOML_BLOCK.exec(content.text)) {
+				const source = match[1]?.trim() ?? "";
+				if (!source) continue;
+				const key = nomnomlImageKey(source);
+				if (this.#nomnomlPngByKey.has(key) || this.#nomnomlPngInFlight.has(key)) continue;
+				this.#nomnomlPngInFlight.add(key);
+				resolveNomnomlPng(source)
+					.then(data => {
+						this.#nomnomlPngInFlight.delete(key);
+						if (!data) return;
+						this.#nomnomlPngByKey.set(key, data);
+						if (this.#lastMessage) {
+							this.updateContent(this.#lastMessage, { transient: this.#lastUpdateTransient });
+						}
+						this.onImageUpdate?.();
+					})
+					.catch(() => {
+						this.#nomnomlPngInFlight.delete(key);
+					});
+			}
+		}
+	}
+
+	#appendNomnomlImage(segment: Extract<TextNomnomlSegment, { type: "image" }>): void {
+		this.#contentContainer.addChild(
+			new Image(
+				segment.data,
+				segment.mimeType,
+				{ fallbackColor: (text: string) => theme.fg("toolOutput", text) },
+				{ ...resolveImageOptions(), budget: this.imageBudget, imageKey: segment.key },
+			),
+		);
+	}
+
+	#appendMarkdownText(
+		text: string,
+		contentIndex: number,
+		captureItems?: Array<{ md: Markdown; contentIndex: number; blockType: "text" | "thinking"; lastText: string }>,
+	): void {
+		const md = new Markdown(text, 1, 0, getMarkdownTheme());
+		md.transientRenderCache = this.#lastUpdateTransient;
+		this.#contentContainer.addChild(md);
+		captureItems?.push({ md, contentIndex, blockType: "text", lastText: text });
+	}
+
 	updateContent(message: AssistantMessage, opts?: { transient?: boolean }): void {
 		this.#blockVersion++;
 		this.#lastMessage = message;
@@ -753,6 +841,8 @@ export class AssistantMessageComponent extends Container {
 			return false;
 		});
 
+		this.#queueNomnomlPngs(message);
+
 		// Fast path: reuse Markdown children when shape is stable during streaming
 		if (this.#tryFastPathUpdate(message, opts)) return;
 
@@ -776,15 +866,23 @@ export class AssistantMessageComponent extends Container {
 
 		// Render content in order
 		let thinkingIndex = 0;
+		const renderNomnomlImages =
+			!this.#lastUpdateTransient && TERMINAL.imageProtocol !== undefined && getMarkdownNomnomlRendering() === "svg";
 		for (let i = 0; i < message.content.length; i++) {
 			const content = message.content[i];
 			if (content.type === "text" && canonicalizeMessage(content.text)) {
 				// Set paddingY=0 to avoid extra spacing before tool executions
 				const trimmed = content.text.trim();
-				const md = new Markdown(trimmed, 1, 0, getMarkdownTheme());
-				md.transientRenderCache = this.#lastUpdateTransient;
-				this.#contentContainer.addChild(md);
-				captureItems?.push({ md, contentIndex: i, blockType: "text", lastText: trimmed });
+				const segments: TextNomnomlSegment[] = renderNomnomlImages
+					? splitNomnomlImages(trimmed, this.#nomnomlPngByKey)
+					: [{ type: "markdown", text: trimmed }];
+				for (const segment of segments) {
+					if (segment.type === "markdown") {
+						this.#appendMarkdownText(segment.text, i, captureItems);
+					} else {
+						this.#appendNomnomlImage(segment);
+					}
+				}
 			} else if (content.type === "thinking" && resolveThinkingDisplay(content, this.proseOnlyThinking).visible) {
 				const thinkingText = resolveThinkingDisplay(content, this.proseOnlyThinking).text;
 				if (this.hideThinkingBlock) {

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -65,6 +65,7 @@ export interface ChatTranscriptBuilderDeps {
 	hideThinkingBlock?: () => boolean;
 	proseOnlyThinking?: () => boolean;
 	requestRender: () => void;
+	showImages?: boolean;
 }
 
 /** Extracts the plain-text content of a user message (string or text blocks). */
@@ -280,6 +281,7 @@ export class ChatTranscriptBuilder {
 			this.deps.getMessageRenderer ? undefined : [], // placeholder for thinkingRenderers
 			undefined, // placeholder for imageBudget
 			proseOnlyThinking,
+			this.deps.showImages ?? false,
 		);
 		this.container.addChild(assistantComponent);
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -30,6 +30,7 @@ import {
 	previewTheme,
 	setColorBlindMode,
 	setMarkdownMermaidRendering,
+	setMarkdownNomnomlRendering,
 	setSymbolPreset,
 	setTheme,
 	theme,
@@ -460,6 +461,14 @@ export class SelectorController {
 				setMarkdownMermaidRendering(value as boolean);
 				this.ctx.session.refreshBaseSystemPrompt().catch(err => {
 					this.ctx.showError(`Failed to apply Mermaid rendering setting: ${err}`);
+				});
+				this.ctx.rebuildChatFromMessages();
+				this.ctx.ui.resetDisplay();
+				break;
+			case "tui.renderNomnoml":
+				setMarkdownNomnomlRendering(value as "off" | "svg" | "ascii");
+				this.ctx.session.refreshBaseSystemPrompt().catch(err => {
+					this.ctx.showError(`Failed to apply Nomnoml rendering setting: ${err}`);
 				});
 				this.ctx.rebuildChatFromMessages();
 				this.ctx.ui.resetDisplay();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -414,11 +414,17 @@ export class SelectorController {
 
 			// Settings with UI side effects
 			case "showImages":
+			case "terminal.showImages":
 				for (const child of this.ctx.chatContainer.children) {
 					if (child instanceof ToolExecutionComponent) {
 						child.setShowImages(value as boolean);
+					} else if (child instanceof AssistantMessageComponent) {
+						child.refreshImagePolicy();
 					}
 				}
+				// Image placements and their text replacements may already be frozen
+				// in native scrollback. Retire those snapshots and replay the transcript.
+				this.ctx.ui.resetDisplay();
 				break;
 			case "hideThinkingBlock":
 				this.ctx.hideThinkingBlock = value as boolean;

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -123,7 +123,7 @@ import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
 import { messageHasDisplayableThinking } from "../utils/thinking-display";
 import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
-import type { AssistantMessageComponent } from "./components/assistant-message";
+import { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import { ChatBlock, type ChatBlockHost } from "./components/chat-block";
 import { CustomEditor } from "./components/custom-editor";
@@ -1553,9 +1553,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		// clear+replay, then re-append them in their original chat-container order
 		// and restore the `pendingTools` map so streaming routes back into them.
 		const liveComponents: Component[] = [];
+		const liveSet = new Set<Component>();
 		const livePendingTools = new Map<string, ToolExecutionHandle>();
 		if (this.viewSession?.isStreaming) {
-			const liveSet = new Set<Component>();
 			if (this.streamingComponent) liveSet.add(this.streamingComponent);
 			for (const [id, component] of this.pendingTools) {
 				livePendingTools.set(id, component);
@@ -1566,6 +1566,9 @@ export class InteractiveMode implements InteractiveModeContext {
 					if (liveSet.has(child)) liveComponents.push(child);
 				}
 			}
+		}
+		for (const child of this.chatContainer.children) {
+			if (child instanceof AssistantMessageComponent && !liveSet.has(child)) child.dispose();
 		}
 		this.chatContainer.clear();
 		// Live display uses the compacted transcript tail; export/resume callers

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -179,6 +179,7 @@ import {
 	onTerminalAppearanceChange,
 	onThemeChange,
 	setMarkdownMermaidRendering,
+	setMarkdownNomnomlRendering,
 	theme,
 } from "./theme/theme";
 import type {
@@ -650,6 +651,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		setTuiTight(settings.get("tui.tight"));
 		setMarkdownMermaidRendering(settings.get("tui.renderMermaid"));
+		setMarkdownNomnomlRendering(settings.get("tui.renderNomnoml"));
 		this.ui = new TUI(new ProcessTerminal(), settings.get("showHardwareCursor"));
 		this.ui.setMaxInlineImages(settings.get("tui.maxInlineImages"));
 		// OSC 66 text-sizing is Kitty-only; resolve the setting against the terminal's

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { Settings } from "../../config/settings";
 import { buildSystemPrompt } from "../../system-prompt";
-import { AssistantMessageComponent } from "../components/assistant-message";
+import { AssistantMessageComponent, splitNomnomlImages } from "../components/assistant-message";
 import { type AssistantMessageContext, createAssistantMessageComponent } from "../utils/interactive-context-helpers";
 import * as nomnomlCache from "./nomnoml-cache";
 import {
@@ -735,5 +735,43 @@ describe("AssistantMessageComponent async disposal", () => {
 		expect(toBase64Spy).not.toHaveBeenCalled();
 		expect(requestRender).not.toHaveBeenCalled();
 		expect(budget.keys).toEqual([]);
+	});
+});
+
+describe("splitNomnomlImages whitespace", () => {
+	it("preserves four-space-indented code blocks after nomnoml fence replacement", () => {
+		const source = "[A] -> [B]";
+		const rasterKey = `nomnoml:${Bun.hash(source)}`;
+		const text = "```nomnoml\n[A] -> [B]\n```\n    const kept = true;\n";
+		const segments = splitNomnomlImages(text, new Map([[rasterKey, TINY_PNG]]), "test");
+		expect(segments).toHaveLength(2);
+		expect(segments[0]).toMatchObject({ type: "image", source });
+		expect(segments[1]).toEqual({ type: "markdown", text: "    const kept = true;\n" });
+	});
+
+	it("preserves hard-break trailing spaces before a replaced fence", () => {
+		const source = "[A] -> [B]";
+		const rasterKey = `nomnoml:${Bun.hash(source)}`;
+		const text = "line with hard break  \n```nomnoml\n[A] -> [B]\n```\n";
+		const segments = splitNomnomlImages(text, new Map([[rasterKey, TINY_PNG]]), "test");
+		expect(segments[0]).toEqual({ type: "markdown", text: "line with hard break  \n" });
+		expect(segments[1]).toMatchObject({ type: "image", source });
+	});
+});
+
+describe("Nomnoml source size bound", () => {
+	it("rejects oversized sources before SVG generation", async () => {
+		nomnomlCache.clearNomnomlCache();
+		const huge = `[${"A".repeat(70_000)}]`;
+		const result = await nomnomlCache.resolveNomnomlPng(huge);
+		expect(result).toBeNull();
+		// Cache the rejection so a second call stays a sync cache hit (no generation).
+		expect(await nomnomlCache.resolveNomnomlPng(huge)).toBeNull();
+	});
+
+	it("rejects oversized sources on the ASCII path", () => {
+		nomnomlCache.clearNomnomlCache();
+		const huge = `[${"A".repeat(70_000)}]`;
+		expect(nomnomlCache.resolveNomnomlAscii(huge, 120)).toBeNull();
 	});
 });

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -4,6 +4,8 @@ import { ImageBudget, ImageProtocol, Markdown, setTerminalImageProtocol, TERMINA
 import { Settings } from "../../config/settings";
 import { buildSystemPrompt } from "../../system-prompt";
 import { AssistantMessageComponent } from "../components/assistant-message";
+import type { InteractiveModeContext } from "../types";
+import { createAssistantMessageComponent } from "../utils/interactive-context-helpers";
 import * as nomnomlCache from "./nomnoml-cache";
 import {
 	getMarkdownTheme,
@@ -130,6 +132,29 @@ describe("Mermaid rendering setting", () => {
 		expect(mermaid).toContain("```mermaid");
 		expect(mermaid).toContain("graph TD");
 	});
+
+	for (const [style, source] of [
+		["built-in", "[<hidden> secret]"],
+		["custom", "#.ghost: visual=hidden\n[<ghost> secret]"],
+	] as const) {
+		it(`replaces all-hidden ${style} nomnoml fences without leaking source`, () => {
+			setMarkdownNomnomlRendering("ascii");
+
+			const theme = getMarkdownTheme();
+			const ascii = theme.resolveNomnomlAscii?.(source, 80);
+			expect(ascii).toBe("");
+			expect(ascii).not.toBeNull();
+
+			const rendered = stripAnsi(
+				new Markdown(`\`\`\`nomnoml\n${source}\n\`\`\``, 0, 0, theme).render(80).join("\n"),
+			);
+			expect(rendered).not.toContain("secret");
+			expect(rendered).not.toContain("```nomnoml");
+			expect(rendered).not.toContain("```");
+			expect(rendered).not.toContain("[<hidden>");
+			expect(rendered).not.toContain("visual=hidden");
+		});
+	}
 });
 
 describe("Nomnoml SVG assistant rendering", () => {
@@ -236,6 +261,36 @@ describe("Nomnoml SVG assistant rendering", () => {
 		await Promise.resolve();
 		const rendered = stripAnsi(component.render(120).join("\n"));
 		expect(rasterSpy).not.toHaveBeenCalled();
+		expect(budget.keys).toHaveLength(0);
+		expect(rendered).toContain("A");
+		expect(rendered).toContain("B");
+		expect(rendered).not.toContain("[Image:");
+	});
+
+	it("propagates terminal.showImages through the live assistant helper", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterResult = Promise.withResolvers<string>();
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockReturnValue(rasterResult.promise);
+		const budget = new RecordingImageBudget(10);
+		const requestRender = vi.fn();
+		const ctx = {
+			effectiveHideThinkingBlock: false,
+			proseOnlyThinking: true,
+			settings: Settings.isolated({ "terminal.showImages": false }),
+			ui: { imageBudget: budget, requestRender },
+			viewSession: { extensionRunner: undefined },
+		} as unknown as InteractiveModeContext;
+		const fence = "```nomnoml\n[A] -> [B]\n```";
+		const component = createAssistantMessageComponent(ctx, createAssistantMessage(fence));
+
+		rasterResult.resolve(TINY_PNG);
+		await rasterResult.promise;
+		await Promise.resolve();
+		const rendered = stripAnsi(component.render(120).join("\n"));
+
+		expect(rasterSpy).not.toHaveBeenCalled();
+		expect(requestRender).not.toHaveBeenCalled();
 		expect(budget.keys).toHaveLength(0);
 		expect(rendered).toContain("A");
 		expect(rendered).toContain("B");

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, beforeAll, describe, expect, it } from "bun:test";
-import { Markdown } from "@oh-my-pi/pi-tui";
+import { afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { ImageBudget, ImageProtocol, Markdown, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
 import { Settings } from "../../config/settings";
 import { buildSystemPrompt } from "../../system-prompt";
+import { AssistantMessageComponent } from "../components/assistant-message";
+import * as nomnomlCache from "./nomnoml-cache";
 import {
 	getMarkdownTheme,
 	getThemeByName,
@@ -22,6 +25,38 @@ function stripAnsi(text: string): string {
 	return text.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
+const originalImageProtocol = TERMINAL.imageProtocol;
+const TINY_PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function createAssistantMessage(markdown: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: markdown }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+class RecordingImageBudget extends ImageBudget {
+	readonly keys: Array<string | undefined> = [];
+
+	override acquireId(key?: string): number {
+		this.keys.push(key);
+		return super.acquireId(key);
+	}
+}
+
 beforeAll(async () => {
 	await Settings.init({ inMemory: true });
 	const theme = await getThemeByName("dark");
@@ -32,6 +67,8 @@ beforeAll(async () => {
 afterEach(() => {
 	setMarkdownMermaidRendering(true);
 	setMarkdownNomnomlRendering("off");
+	setTerminalImageProtocol(originalImageProtocol);
+	vi.restoreAllMocks();
 });
 
 describe("Mermaid rendering setting", () => {
@@ -92,5 +129,57 @@ describe("Mermaid rendering setting", () => {
 		);
 		expect(mermaid).toContain("```mermaid");
 		expect(mermaid).toContain("graph TD");
+	});
+});
+
+describe("Nomnoml SVG assistant rendering", () => {
+	it("keeps ASCII fallback when the terminal has no image protocol", () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(null);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+
+		const component = new AssistantMessageComponent(createAssistantMessage("```nomnoml\n[A] -> [B]\n```"));
+		const rendered = stripAnsi(component.render(120).join("\n"));
+
+		expect(rasterSpy).not.toHaveBeenCalled();
+		expect(rendered).toContain("A");
+		expect(rendered).toContain("B");
+		expect(rendered).not.toContain("[Image:");
+	});
+
+	it("does not rasterize nomnoml fences nested inside an outer code fence", () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+
+		const component = new AssistantMessageComponent(
+			createAssistantMessage("````markdown\n```nomnoml\n[A] -> [B]\n```\n````"),
+		);
+		const rendered = stripAnsi(component.render(120).join("\n"));
+
+		expect(rasterSpy).not.toHaveBeenCalled();
+		expect(rendered).toContain("```nomnoml");
+	});
+
+	it("uses unique image placement keys for repeated nomnoml sources", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const imageUpdated = Promise.withResolvers<void>();
+		const budget = new RecordingImageBudget(10);
+
+		new AssistantMessageComponent(
+			createAssistantMessage("```nomnoml\n[A] -> [B]\n```\n\n```nomnoml\n[A] -> [B]\n```"),
+			false,
+			imageUpdated.resolve,
+			[],
+			budget,
+		);
+		await imageUpdated.promise;
+
+		expect(rasterSpy).toHaveBeenCalledTimes(1);
+		expect(budget.keys).toHaveLength(2);
+		expect(new Set(budget.keys).size).toBe(2);
+		expect(budget.keys.every(key => key?.startsWith("nomnoml:"))).toBe(true);
 	});
 });

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
-import { ImageBudget, ImageProtocol, Markdown, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
+import {
+	Container,
+	Image,
+	ImageBudget,
+	ImageProtocol,
+	Markdown,
+	setTerminalImageProtocol,
+	TERMINAL,
+} from "@oh-my-pi/pi-tui";
 import { Settings } from "../../config/settings";
 import { buildSystemPrompt } from "../../system-prompt";
 import { AssistantMessageComponent } from "../components/assistant-message";
-import type { InteractiveModeContext } from "../types";
-import { createAssistantMessageComponent } from "../utils/interactive-context-helpers";
+import { type AssistantMessageContext, createAssistantMessageComponent } from "../utils/interactive-context-helpers";
 import * as nomnomlCache from "./nomnoml-cache";
 import {
 	getMarkdownTheme,
@@ -57,6 +64,20 @@ class RecordingImageBudget extends ImageBudget {
 		this.keys.push(key);
 		return super.acquireId(key);
 	}
+}
+
+function createLiveContext(
+	showImages: boolean,
+	budget: ImageBudget,
+	requestRender: () => void,
+): AssistantMessageContext & { settings: Settings } {
+	return {
+		effectiveHideThinkingBlock: false,
+		proseOnlyThinking: true,
+		settings: Settings.isolated({ "terminal.showImages": showImages }),
+		ui: { imageBudget: budget, requestRender },
+		viewSession: { extensionRunner: undefined },
+	};
 }
 
 beforeAll(async () => {
@@ -274,13 +295,7 @@ describe("Nomnoml SVG assistant rendering", () => {
 		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockReturnValue(rasterResult.promise);
 		const budget = new RecordingImageBudget(10);
 		const requestRender = vi.fn();
-		const ctx = {
-			effectiveHideThinkingBlock: false,
-			proseOnlyThinking: true,
-			settings: Settings.isolated({ "terminal.showImages": false }),
-			ui: { imageBudget: budget, requestRender },
-			viewSession: { extensionRunner: undefined },
-		} as unknown as InteractiveModeContext;
+		const ctx = createLiveContext(false, budget, requestRender);
 		const fence = "```nomnoml\n[A] -> [B]\n```";
 		const component = createAssistantMessageComponent(ctx, createAssistantMessage(fence));
 
@@ -295,5 +310,209 @@ describe("Nomnoml SVG assistant rendering", () => {
 		expect(rendered).toContain("A");
 		expect(rendered).toContain("B");
 		expect(rendered).not.toContain("[Image:");
+	});
+
+	it("turns images on for an existing live component after invalidation", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const budget = new RecordingImageBudget(10);
+		const imageUpdated = Promise.withResolvers<void>();
+		const ctx = createLiveContext(false, budget, imageUpdated.resolve);
+		const message = createAssistantMessage("```nomnoml\n[A] -> [B]\n```");
+		const component = createAssistantMessageComponent(ctx, message);
+
+		ctx.settings.override("terminal.showImages", true);
+		component.invalidate();
+		await imageUpdated.promise;
+		await Promise.resolve();
+		budget.beginPass();
+		const rendered = component.render(120).join("\n");
+		budget.endPass();
+
+		expect(rasterSpy).toHaveBeenCalledTimes(1);
+		expect(budget.keys).toHaveLength(1);
+		expect(rendered).toContain("\x1b_G");
+	});
+
+	it("turns images off for an existing live component on update", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const budget = new RecordingImageBudget(10);
+		const imageUpdated = Promise.withResolvers<void>();
+		const ctx = createLiveContext(true, budget, imageUpdated.resolve);
+		const message = createAssistantMessage("```nomnoml\n[A] -> [B]\n```");
+		const component = createAssistantMessageComponent(ctx, message);
+		await imageUpdated.promise;
+		await Promise.resolve();
+
+		budget.beginPass();
+		const initial = component.render(120).join("\n");
+		budget.endPass();
+		const placementKey = budget.keys.at(-1);
+		if (!placementKey) throw new Error("Expected a Nomnoml placement key");
+		const initialId = budget.acquireId(placementKey);
+		expect(initial).toContain("\x1b_G");
+		expect(budget.takeTransmits()).toHaveLength(1);
+		const genericId = budget.acquireId("generic-tool-image");
+		budget.enqueueTransmit(genericId, "generic-transmit");
+		expect(budget.takeTransmits()).toEqual(["generic-transmit"]);
+
+		ctx.settings.override("terminal.showImages", false);
+		component.refreshImagePolicy();
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(budget.takePurgeIds()).toEqual([initialId]);
+		expect(budget.acquireId("generic-tool-image")).toBe(genericId);
+		expect(budget.shouldTransmit(genericId)).toBe(false);
+		expect(rendered).toContain("A");
+		expect(rendered).toContain("B");
+		expect(rendered).not.toContain("\x1b_G");
+		expect(rendered).not.toContain("[Image:");
+		const imageChildren = component.children.flatMap(child =>
+			child instanceof Container ? child.children.filter(grandchild => grandchild instanceof Image) : [],
+		);
+		expect(imageChildren).toEqual([]);
+
+		component.refreshImagePolicy();
+		expect(budget.takePurgeIds()).toEqual([]);
+
+		ctx.settings.override("terminal.showImages", true);
+		component.refreshImagePolicy();
+		budget.beginPass();
+		const restored = component.render(120).join("\n");
+		budget.endPass();
+		const restoredId = budget.acquireId(placementKey);
+		expect(restored).toContain("\x1b_G");
+		expect(restoredId).not.toBe(initialId);
+		expect(budget.takeTransmits()).toHaveLength(1);
+	});
+
+	it("resolves budget fallbacks at the effective image width", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const asciiSpy = spyOn(nomnomlCache, "resolveNomnomlAscii");
+		const budget = new RecordingImageBudget(1);
+		let updates = 0;
+		const loaded = Promise.withResolvers<void>();
+		const onUpdate = () => {
+			updates += 1;
+			if (updates === 2) loaded.resolve();
+		};
+		const source = "[Alpha] -> [Beta]";
+		const older = new AssistantMessageComponent(
+			createAssistantMessage(`\`\`\`nomnoml\n${source}\n\`\`\``),
+			false,
+			onUpdate,
+			[],
+			budget,
+		);
+		const newer = new AssistantMessageComponent(
+			createAssistantMessage("```nomnoml\n[New] -> [Diagram]\n```"),
+			false,
+			onUpdate,
+			[],
+			budget,
+		);
+		await loaded.promise;
+		await Promise.resolve();
+
+		let narrow = "";
+		for (let pass = 0; pass < 2; pass++) {
+			budget.beginPass();
+			narrow = stripAnsi(older.render(10).join("\n"));
+			newer.render(10);
+			budget.endPass();
+		}
+		expect(asciiSpy).toHaveBeenCalledWith(source, 8);
+		expect(narrow).toContain("Alpha");
+		expect(narrow).toContain("Beta");
+		expect(narrow).not.toContain(source);
+		expect(narrow).not.toContain("```nomnoml");
+		expect(narrow.split("\n").every(line => Bun.stringWidth(line) <= 8)).toBe(true);
+
+		budget.beginPass();
+		const tooNarrow = stripAnsi(older.render(6).join("\n"));
+		newer.render(6);
+		budget.endPass();
+		expect(asciiSpy).toHaveBeenCalledWith(source, 4);
+		expect(tooNarrow).not.toContain("Alpha");
+		expect(tooNarrow).not.toContain("Beta");
+		expect(tooNarrow).not.toContain(source);
+		expect(tooNarrow).not.toContain("┌");
+		expect(tooNarrow.replace(/\s/g, "")).toContain("[Nomnomldiagram]");
+	});
+	it("renders budget-demoted hidden-label diagrams without leaking source at narrow width", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const budget = new RecordingImageBudget(1);
+		let updates = 0;
+		const loaded = Promise.withResolvers<void>();
+		const onUpdate = () => {
+			updates += 1;
+			if (updates === 2) loaded.resolve();
+		};
+		const source =
+			"[Public] -> [<hidden> built-in-secret]\n[Public] -> [<ghost> custom-secret]\n#.ghost: visual=hidden";
+		const older = new AssistantMessageComponent(
+			createAssistantMessage(`\`\`\`nomnoml\n${source}\n\`\`\``),
+			false,
+			onUpdate,
+			[],
+			budget,
+		);
+		const newer = new AssistantMessageComponent(
+			createAssistantMessage("```nomnoml\n[Other] -> [Diagram]\n```"),
+			false,
+			onUpdate,
+			[],
+			budget,
+		);
+		await loaded.promise;
+		await Promise.resolve();
+
+		let rendered = "";
+		for (let pass = 0; pass < 2; pass++) {
+			budget.beginPass();
+			rendered = stripAnsi(older.render(20).join("\n"));
+			newer.render(20);
+			budget.endPass();
+		}
+
+		expect(rendered).toContain("Public");
+		expect(rendered).not.toContain("built-in-secret");
+		expect(rendered).not.toContain("custom-secret");
+		expect(rendered).not.toContain("secret");
+		expect(rendered).not.toContain("visual=hidden");
+		expect(rendered).not.toContain("[<hidden>");
+		expect(rendered).not.toContain("[Image:");
+		expect(rendered).not.toContain("```");
+		expect(rendered.split("\n").every(line => Bun.stringWidth(line) <= 18)).toBe(true);
+	});
+
+	it("falls back to a neutral label when ASCII cannot render after protocol loss", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const imageUpdated = Promise.withResolvers<void>();
+		const source = "[broken\x1b[31m";
+		const component = new AssistantMessageComponent(
+			createAssistantMessage(`\`\`\`nomnoml\n${source}\n\`\`\``),
+			false,
+			imageUpdated.resolve,
+		);
+		await imageUpdated.promise;
+		await Promise.resolve();
+
+		setTerminalImageProtocol(null);
+		const rendered = stripAnsi(component.render(12).join("\n"));
+		expect(rendered).not.toContain("[broken");
+		expect(rendered).not.toContain("[Image:");
+		expect(rendered).not.toContain("\x1b");
+		expect(rendered).toContain("Nomnoml");
+		expect(rendered).toContain("diagram");
+		expect(rendered.split("\n").every(line => Bun.stringWidth(line) <= 10)).toBe(true);
 	});
 });

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -335,6 +335,43 @@ describe("Nomnoml SVG assistant rendering", () => {
 		expect(rendered).toContain("\x1b_G");
 	});
 
+	it("preserves non-PNG read images without converting or rendering them while images are off", async () => {
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const budget = new RecordingImageBudget(10);
+		const imageUpdated = Promise.withResolvers<void>();
+		const onImageUpdate = vi.fn(() => imageUpdated.resolve());
+		let showImages = false;
+		const component = new AssistantMessageComponent(
+			createAssistantMessage("Read image"),
+			false,
+			onImageUpdate,
+			[],
+			budget,
+			true,
+			() => showImages,
+		);
+		component.setToolResultImages("read-jpeg", [{ type: "image", data: TINY_PNG, mimeType: "image/jpeg" }]);
+		await new Bun.Image(Buffer.from(TINY_PNG, "base64")).png().toBase64();
+		await Promise.resolve();
+		expect(onImageUpdate).not.toHaveBeenCalled();
+
+		const hidden = stripAnsi(component.render(120).join("\n"));
+		expect(hidden).toContain("Read image");
+		expect(hidden).not.toContain("[Image:");
+		expect(budget.keys).toEqual([]);
+
+		showImages = true;
+		component.refreshImagePolicy();
+		await imageUpdated.promise;
+		expect(onImageUpdate).toHaveBeenCalledTimes(1);
+		await Promise.resolve();
+		budget.beginPass();
+		const restored = component.render(120).join("\n");
+		budget.endPass();
+		expect(restored).toContain("\x1b_G");
+		expect(budget.keys.at(-1)).toMatch(/^assistant-tool:am\d+:read-jpeg:0$/);
+	});
+
 	it("turns images off for an existing live component on update", async () => {
 		setMarkdownNomnomlRendering("svg");
 		setTerminalImageProtocol(ImageProtocol.Kitty);
@@ -514,5 +551,123 @@ describe("Nomnoml SVG assistant rendering", () => {
 		expect(rendered).toContain("Nomnoml");
 		expect(rendered).toContain("diagram");
 		expect(rendered.split("\n").every(line => Bun.stringWidth(line) <= 10)).toBe(true);
+	});
+});
+
+describe("AssistantMessageComponent async disposal", () => {
+	it("does not resurrect a Nomnoml image after dispose while raster is pending", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+
+		const raster = Promise.withResolvers<string>();
+		spyOn(nomnomlCache, "resolveNomnomlPng").mockReturnValue(raster.promise);
+
+		const budget = new RecordingImageBudget(10);
+		const requestRender = vi.fn();
+		const ctx = createLiveContext(true, budget, requestRender);
+		const message = createAssistantMessage("```nomnoml\n[A] -> [B]\n```");
+		const component = createAssistantMessageComponent(ctx, message);
+
+		component.dispose();
+		const contentContainer = component.children[1];
+		if (!(contentContainer instanceof Container)) throw new Error("Expected content container");
+		const childrenAfterDispose = contentContainer.children.slice();
+		raster.resolve(TINY_PNG);
+		await raster.promise;
+		await Promise.resolve();
+
+		expect(requestRender).not.toHaveBeenCalled();
+		expect(budget.keys).toEqual([]);
+		expect(contentContainer.children).toHaveLength(childrenAfterDispose.length);
+		expect(contentContainer.children.every((child, index) => child === childrenAfterDispose[index])).toBe(true);
+		expect(contentContainer.children.some(child => child instanceof Image)).toBe(false);
+	});
+
+	it("does not resurrect a Kitty tool image after dispose while conversion is pending", async () => {
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+
+		const conversion = Promise.withResolvers<string>();
+		spyOn(Bun.Image.prototype, "toBase64").mockReturnValue(conversion.promise);
+
+		const budget = new RecordingImageBudget(10);
+		const requestRender = vi.fn();
+		const ctx = createLiveContext(true, budget, requestRender);
+		const message = createAssistantMessage("tool image");
+		const component = createAssistantMessageComponent(ctx, message);
+		component.setToolResultImages("read-1", [{ type: "image", data: TINY_PNG, mimeType: "image/jpeg" }]);
+
+		component.dispose();
+		const contentContainer = component.children[1];
+		if (!(contentContainer instanceof Container)) throw new Error("Expected content container");
+		const childrenAfterDispose = contentContainer.children.slice();
+		conversion.resolve(TINY_PNG);
+		await conversion.promise;
+		await Promise.resolve();
+
+		expect(requestRender).not.toHaveBeenCalled();
+		expect(budget.keys).toEqual([]);
+		expect(contentContainer.children).toHaveLength(childrenAfterDispose.length);
+		expect(contentContainer.children.every((child, index) => child === childrenAfterDispose[index])).toBe(true);
+		expect(contentContainer.children.some(child => child instanceof Image)).toBe(false);
+	});
+
+	it("ignores updateContent after dispose", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+
+		const raster = Promise.withResolvers<string>();
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockReturnValue(raster.promise);
+
+		const budget = new RecordingImageBudget(10);
+		const requestRender = vi.fn();
+		const ctx = createLiveContext(true, budget, requestRender);
+		const firstMessage = createAssistantMessage("```nomnoml\n[Old] -> [Old]\n```");
+		const component = createAssistantMessageComponent(ctx, firstMessage);
+
+		expect(rasterSpy).toHaveBeenCalledTimes(1);
+
+		component.dispose();
+		const contentContainer = component.children[1];
+		if (!(contentContainer instanceof Container)) throw new Error("Expected content container");
+		const childrenAfterDispose = contentContainer.children.slice();
+
+		const secondMessage = createAssistantMessage("```nomnoml\n[New] -> [New]\n```");
+		component.updateContent(secondMessage);
+
+		expect(rasterSpy).toHaveBeenCalledTimes(1);
+		expect(budget.keys).toEqual([]);
+		expect(contentContainer.children).toHaveLength(childrenAfterDispose.length);
+		expect(contentContainer.children.every((child, index) => child === childrenAfterDispose[index])).toBe(true);
+
+		raster.resolve(TINY_PNG);
+		await raster.promise;
+		await Promise.resolve();
+
+		expect(requestRender).not.toHaveBeenCalled();
+		expect(budget.keys).toEqual([]);
+	});
+
+	it("ignores refreshImagePolicy after dispose", async () => {
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+
+		const conversion = Promise.withResolvers<string>();
+		const toBase64Spy = spyOn(Bun.Image.prototype, "toBase64").mockReturnValue(conversion.promise);
+
+		const budget = new RecordingImageBudget(10);
+		const requestRender = vi.fn();
+		const ctx = createLiveContext(false, budget, requestRender);
+		const message = createAssistantMessage("tool image");
+		const component = createAssistantMessageComponent(ctx, message);
+		component.setToolResultImages("read-fresh", [{ type: "image", data: TINY_PNG, mimeType: "image/jpeg" }]);
+
+		expect(toBase64Spy).not.toHaveBeenCalled();
+
+		component.dispose();
+		ctx.settings.override("terminal.showImages", true);
+		component.refreshImagePolicy();
+
+		expect(toBase64Spy).not.toHaveBeenCalled();
+		expect(requestRender).not.toHaveBeenCalled();
+		expect(budget.keys).toEqual([]);
 	});
 });

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -182,4 +182,63 @@ describe("Nomnoml SVG assistant rendering", () => {
 		expect(new Set(budget.keys).size).toBe(2);
 		expect(budget.keys.every(key => key?.startsWith("nomnoml:"))).toBe(true);
 	});
+
+	it("uses unique image placement keys for nomnoml sources in separate content blocks", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const imageUpdated = Promise.withResolvers<void>();
+		const budget = new RecordingImageBudget(10);
+		const fence = "```nomnoml\n[A] -> [B]\n```";
+		const message = createAssistantMessage(fence);
+		message.content = [
+			{ type: "text", text: fence },
+			{ type: "text", text: fence },
+		];
+		new AssistantMessageComponent(message, false, imageUpdated.resolve, [], budget);
+		await imageUpdated.promise;
+		expect(rasterSpy).toHaveBeenCalledTimes(1);
+		expect(budget.keys).toHaveLength(2);
+		expect(new Set(budget.keys).size).toBe(2);
+	});
+
+	it("uses unique image placement keys for identical nomnoml sources across assistant turns", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const firstUpdated = Promise.withResolvers<void>();
+		const secondUpdated = Promise.withResolvers<void>();
+		const budget = new RecordingImageBudget(10);
+		const fence = "```nomnoml\n[A] -> [B]\n```";
+		new AssistantMessageComponent(createAssistantMessage(fence), false, firstUpdated.resolve, [], budget);
+		new AssistantMessageComponent(createAssistantMessage(fence), false, secondUpdated.resolve, [], budget);
+		await Promise.all([firstUpdated.promise, secondUpdated.promise]);
+		expect(budget.keys).toHaveLength(2);
+		expect(new Set(budget.keys).size).toBe(2);
+	});
+
+	it("suppresses nomnoml images when showImages is false", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const budget = new RecordingImageBudget(10);
+		const fence = "```nomnoml\n[A] -> [B]\n```";
+		const component = new AssistantMessageComponent(
+			createAssistantMessage(fence),
+			false,
+			undefined,
+			[],
+			budget,
+			true,
+			false,
+		);
+		// Give any accidental async queue a turn to fire before asserting.
+		await Promise.resolve();
+		const rendered = stripAnsi(component.render(120).join("\n"));
+		expect(rasterSpy).not.toHaveBeenCalled();
+		expect(budget.keys).toHaveLength(0);
+		expect(rendered).toContain("A");
+		expect(rendered).toContain("B");
+		expect(rendered).not.toContain("[Image:");
+	});
 });

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -207,6 +207,51 @@ describe("Nomnoml SVG assistant rendering", () => {
 		expect(rendered).toContain("```nomnoml");
 	});
 
+	for (const [kind, marker] of [
+		["unordered", "- item"],
+		["ordered", "10. item"],
+	] as const) {
+		for (const indent of [2, 4] as const) {
+			it(`keeps ${indent}-space nomnoml fences inside ${kind} list items`, () => {
+				setMarkdownNomnomlRendering("svg");
+				setTerminalImageProtocol(ImageProtocol.Kitty);
+				const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+				const padding = " ".repeat(indent);
+				const markdown = `${marker}\n${padding}\`\`\`nomnoml\n${padding}[A] -> [B]\n${padding}\`\`\`\n${padding}continuation\n- following item`;
+
+				const component = new AssistantMessageComponent(createAssistantMessage(markdown));
+				const rendered = stripAnsi(component.render(120).join("\n"));
+
+				expect(rasterSpy).not.toHaveBeenCalled();
+				expect(rendered).toContain("continuation");
+				expect(rendered).toContain("following item");
+			});
+		}
+	}
+
+	it("keeps a fence in its parent list item after a nested child item", () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+		const markdown = "- parent\n  - child\n  ```nomnoml\n  [A] -> [B]\n  ```\n  parent continuation";
+
+		const component = new AssistantMessageComponent(createAssistantMessage(markdown));
+		const rendered = stripAnsi(component.render(120).join("\n"));
+
+		expect(rasterSpy).not.toHaveBeenCalled();
+		expect(rendered).toContain("parent continuation");
+	});
+
+	it("still rasterizes a top-level nomnoml fence after a list", () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const rasterSpy = spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(TINY_PNG);
+
+		new AssistantMessageComponent(createAssistantMessage("- item\n\n```nomnoml\n[A] -> [B]\n```"));
+
+		expect(rasterSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("uses unique image placement keys for repeated nomnoml sources", async () => {
 		setMarkdownNomnomlRendering("svg");
 		setTerminalImageProtocol(ImageProtocol.Kitty);
@@ -555,6 +600,27 @@ describe("Nomnoml SVG assistant rendering", () => {
 });
 
 describe("AssistantMessageComponent async disposal", () => {
+	it("ignores tool-result images delivered by an owner after disposal", async () => {
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const toBase64Spy = spyOn(Bun.Image.prototype, "toBase64");
+		const budget = new RecordingImageBudget(10);
+		const requestRender = vi.fn();
+		const ctx = createLiveContext(true, budget, requestRender);
+		const component = createAssistantMessageComponent(ctx, createAssistantMessage("done"));
+		component.dispose();
+		const contentContainer = component.children[1];
+		if (!(contentContainer instanceof Container)) throw new Error("Expected content container");
+		const childrenAfterDispose = contentContainer.children.slice();
+
+		component.setToolResultImages("late-read", [{ type: "image", data: TINY_PNG, mimeType: "image/jpeg" }]);
+		await Promise.resolve();
+
+		expect(toBase64Spy).not.toHaveBeenCalled();
+		expect(budget.keys).toEqual([]);
+		expect(requestRender).not.toHaveBeenCalled();
+		expect(contentContainer.children).toEqual(childrenAfterDispose);
+	});
+
 	it("does not resurrect a Nomnoml image after dispose while raster is pending", async () => {
 		setMarkdownNomnomlRendering("svg");
 		setTerminalImageProtocol(ImageProtocol.Kitty);

--- a/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-rendering.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { Markdown } from "@oh-my-pi/pi-tui";
 import { Settings } from "../../config/settings";
 import { buildSystemPrompt } from "../../system-prompt";
-import { getMarkdownTheme, getThemeByName, setMarkdownMermaidRendering, setThemeInstance } from "./theme";
+import {
+	getMarkdownTheme,
+	getThemeByName,
+	setMarkdownMermaidRendering,
+	setMarkdownNomnomlRendering,
+	setThemeInstance,
+} from "./theme";
 
 const workspaceTree = {
 	rootPath: "/tmp/project",
@@ -25,6 +31,7 @@ beforeAll(async () => {
 
 afterEach(() => {
 	setMarkdownMermaidRendering(true);
+	setMarkdownNomnomlRendering("off");
 });
 
 describe("Mermaid rendering setting", () => {
@@ -49,5 +56,41 @@ describe("Mermaid rendering setting", () => {
 		expect(lines).toContain("```mermaid");
 		expect(lines).toContain("graph TD");
 		expect(lines).toContain("-->");
+	});
+
+	it("uses the Nomnoml prompt hint instead of Mermaid when Nomnoml rendering is enabled", async () => {
+		const { systemPrompt } = await buildSystemPrompt({
+			renderMermaid: true,
+			renderNomnoml: true,
+			contextFiles: [],
+			skills: [],
+			toolNames: [],
+			workspaceTree,
+		});
+		const prompt = systemPrompt.join("\n");
+
+		expect(prompt).toContain("```nomnoml");
+		expect(prompt).not.toContain("```mermaid");
+	});
+
+	it("exposes Nomnoml ASCII fallback in SVG mode and renders Mermaid as code", () => {
+		setMarkdownMermaidRendering(true);
+		setMarkdownNomnomlRendering("svg");
+
+		const theme = getMarkdownTheme();
+		const ascii = theme.resolveNomnomlAscii?.("[A] -> [B]", 80);
+		expect(ascii).toContain("A");
+		expect(ascii).toContain("B");
+
+		const nomnoml = stripAnsi(new Markdown("```nomnoml\n[A] -> [B]\n```", 0, 0, theme).render(80).join("\n"));
+		expect(nomnoml).not.toContain("```nomnoml");
+		expect(nomnoml).toContain("A");
+		expect(nomnoml).toContain("B");
+
+		const mermaid = stripAnsi(
+			new Markdown("```mermaid\ngraph TD\n  A --> B\n```", 0, 0, theme).render(80).join("\n"),
+		);
+		expect(mermaid).toContain("```mermaid");
+		expect(mermaid).toContain("graph TD");
 	});
 });

--- a/packages/coding-agent/src/modes/theme/nomnoml-cache.test.ts
+++ b/packages/coding-agent/src/modes/theme/nomnoml-cache.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as natives from "@oh-my-pi/pi-natives";
+import * as utils from "@oh-my-pi/pi-utils";
+import { clearNomnomlCache, resolveNomnomlAscii, resolveNomnomlPng } from "./nomnoml-cache";
+
+const ASCII_CACHE_MAX_ENTRIES = 256;
+const PNG_CACHE_MAX_ENTRIES = 64;
+
+describe("nomnoml cache bounds", () => {
+	beforeEach(() => {
+		clearNomnomlCache();
+	});
+
+	afterEach(() => {
+		clearNomnomlCache();
+	});
+
+	it("evicts the oldest ascii entry once the cap is reached and keeps the newest", () => {
+		const render = spyOn(utils, "renderNomnomlAsciiSafe").mockImplementation(source => source);
+		for (let i = 0; i < ASCII_CACHE_MAX_ENTRIES; i++) resolveNomnomlAscii(`[N${i}]`);
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES);
+
+		// A full-but-not-over cache still serves both ends.
+		resolveNomnomlAscii("[N0]");
+		resolveNomnomlAscii(`[N${ASCII_CACHE_MAX_ENTRIES - 1}]`);
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES);
+
+		resolveNomnomlAscii("[overflow]");
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES + 1);
+
+		// The oldest key is gone, the newest two survive.
+		resolveNomnomlAscii("[N0]");
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES + 2);
+		resolveNomnomlAscii("[overflow]");
+		resolveNomnomlAscii(`[N${ASCII_CACHE_MAX_ENTRIES - 1}]`);
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES + 2);
+
+		render.mockRestore();
+	});
+
+	it("keys ascii entries per width so one source at many widths still respects the cap", () => {
+		const render = spyOn(utils, "renderNomnomlAsciiSafe").mockImplementation(source => source);
+		for (let width = 1; width <= ASCII_CACHE_MAX_ENTRIES; width++) resolveNomnomlAscii("[A]", width);
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES);
+
+		resolveNomnomlAscii("[A]", ASCII_CACHE_MAX_ENTRIES + 1);
+		// Width 1 was evicted by the overflow insert; the newest width is still cached.
+		resolveNomnomlAscii("[A]", ASCII_CACHE_MAX_ENTRIES + 1);
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES + 1);
+		resolveNomnomlAscii("[A]", 1);
+		expect(render).toHaveBeenCalledTimes(ASCII_CACHE_MAX_ENTRIES + 2);
+
+		render.mockRestore();
+	});
+
+	it("evicts the oldest png entry once the cap is reached and keeps the newest", async () => {
+		const render = spyOn(utils, "renderNomnomlSvg").mockReturnValue(null);
+		for (let i = 0; i < PNG_CACHE_MAX_ENTRIES; i++) await resolveNomnomlPng(`[P${i}]`);
+		expect(render).toHaveBeenCalledTimes(PNG_CACHE_MAX_ENTRIES);
+
+		await resolveNomnomlPng("[overflow]");
+		expect(render).toHaveBeenCalledTimes(PNG_CACHE_MAX_ENTRIES + 1);
+
+		await resolveNomnomlPng("[overflow]");
+		await resolveNomnomlPng(`[P${PNG_CACHE_MAX_ENTRIES - 1}]`);
+		expect(render).toHaveBeenCalledTimes(PNG_CACHE_MAX_ENTRIES + 1);
+
+		await resolveNomnomlPng("[P0]");
+		expect(render).toHaveBeenCalledTimes(PNG_CACHE_MAX_ENTRIES + 2);
+
+		render.mockRestore();
+	});
+
+	it("never evicts an in-flight png render that another caller is awaiting", async () => {
+		// Only the deferred source rasterizes; the filler sources settle as null.
+		const render = spyOn(utils, "renderNomnomlSvg").mockImplementation(source =>
+			source === "[slow]" ? "<svg/>" : null,
+		);
+		const { promise, resolve } = Promise.withResolvers<Uint8Array>();
+		const raster = spyOn(natives, "renderSvgToPng").mockReturnValue(promise);
+
+		const inFlight = resolveNomnomlPng("[slow]");
+		for (let i = 0; i < PNG_CACHE_MAX_ENTRIES + 8; i++) await resolveNomnomlPng(`[F${i}]`);
+
+		// The pending entry survived the eviction sweep, so this dedupes onto it.
+		const joined = resolveNomnomlPng("[slow]");
+		expect(raster).toHaveBeenCalledTimes(1);
+
+		resolve(new Uint8Array([1, 2, 3]));
+		expect(await inFlight).toBe(await joined);
+		expect(await inFlight).toBe(Buffer.from([1, 2, 3]).toString("base64"));
+
+		raster.mockRestore();
+		render.mockRestore();
+	});
+});

--- a/packages/coding-agent/src/modes/theme/nomnoml-cache.ts
+++ b/packages/coding-agent/src/modes/theme/nomnoml-cache.ts
@@ -7,6 +7,40 @@ let markdownNomnomlRendering: MarkdownNomnomlRendering = "svg";
 const asciiCache = new Map<string, string | null>();
 const pngCache = new Map<string, Promise<string | null> | string | null>();
 
+// Both caches live for the whole session and only clear on an explicit theme
+// change, so they need their own ceiling: one diagram re-rendered at N terminal
+// widths stores N ASCII entries, and each PNG entry holds a full base64 payload.
+// Eviction is insertion-order (Map iterates oldest key first), not LRU — a cap
+// is what bounds memory; recency ranking would not earn its complexity here.
+const ASCII_CACHE_MAX_ENTRIES = 256;
+const PNG_CACHE_MAX_ENTRIES = 64;
+
+function cacheAscii(key: string, ascii: string | null): void {
+	asciiCache.set(key, ascii);
+	if (asciiCache.size <= ASCII_CACHE_MAX_ENTRIES) return;
+	const oldest = asciiCache.keys().next();
+	if (!oldest.done) asciiCache.delete(oldest.value);
+}
+
+/** Drop the oldest settled entry. Returns false when every slot is in flight. */
+function evictSettledPng(): boolean {
+	for (const [candidate, cached] of pngCache) {
+		// Never drop an in-flight render: concurrent callers dedupe on that exact
+		// promise, and deleting it would make the next caller re-rasterize.
+		if (cached instanceof Promise) continue;
+		pngCache.delete(candidate);
+		return true;
+	}
+	return false;
+}
+
+function cachePng(key: string, png: Promise<string | null> | string | null): void {
+	// Hard cap: with every slot in flight there is no evictable victim, so the new
+	// render goes uncached rather than growing the map past the ceiling.
+	if (!pngCache.has(key) && pngCache.size >= PNG_CACHE_MAX_ENTRIES && !evictSettledPng()) return;
+	pngCache.set(key, png);
+}
+
 // Native MAX_PIXELS (64_000_000) only rejects after SVG generation. Bound the
 // source cheaply first so pathological fences never reach sync parse/layout.
 // No existing char-budget neighbor fits; style matches MAX_PIXELS / MAX_CANVAS_CELLS.
@@ -50,7 +84,7 @@ export function resolveNomnomlAscii(source: string, maxWidth?: number): string |
 	const cached = asciiCache.get(key);
 	if (cached !== undefined) return cached;
 	const ascii = renderNomnomlAsciiSafe(normalized, maxWidth ?? 120);
-	asciiCache.set(key, ascii);
+	cacheAscii(key, ascii);
 	return ascii;
 }
 
@@ -73,8 +107,10 @@ export async function resolveNomnomlPng(source: string): Promise<string | null> 
 			return null;
 		}
 	})();
-	pngCache.set(normalized, pending);
+	cachePng(normalized, pending);
 	const result = await pending;
-	pngCache.set(normalized, result);
+	// Claim the slot only if it is still ours: a clearNomnomlCache() (or a slot we
+	// never got) during flight must not resurrect an entry behind the caller's back.
+	if (pngCache.get(normalized) === pending) cachePng(normalized, result);
 	return result;
 }

--- a/packages/coding-agent/src/modes/theme/nomnoml-cache.ts
+++ b/packages/coding-agent/src/modes/theme/nomnoml-cache.ts
@@ -7,6 +7,11 @@ let markdownNomnomlRendering: MarkdownNomnomlRendering = "svg";
 const asciiCache = new Map<string, string | null>();
 const pngCache = new Map<string, Promise<string | null> | string | null>();
 
+// Native MAX_PIXELS (64_000_000) only rejects after SVG generation. Bound the
+// source cheaply first so pathological fences never reach sync parse/layout.
+// No existing char-budget neighbor fits; style matches MAX_PIXELS / MAX_CANVAS_CELLS.
+const MAX_SOURCE_CHARS = 64_000;
+
 export function setMarkdownNomnomlRendering(mode: MarkdownNomnomlRendering): void {
 	if (markdownNomnomlRendering === mode) return;
 	markdownNomnomlRendering = mode;
@@ -26,9 +31,21 @@ function normalizedSource(source: string): string | null {
 	return normalized.length === 0 ? null : normalized;
 }
 
+function rejectOversizedSource(normalized: string): boolean {
+	if (normalized.length <= MAX_SOURCE_CHARS) return false;
+	logger.debug("Nomnoml source exceeds size budget", {
+		length: normalized.length,
+		maxSourceChars: MAX_SOURCE_CHARS,
+	});
+	return true;
+}
+
 export function resolveNomnomlAscii(source: string, maxWidth?: number): string | null {
 	const normalized = normalizedSource(source);
 	if (normalized === null) return null;
+	// renderNomnomlAsciiSafe only rejects oversized canvases after parse/layout,
+	// so the same pre-generation source bound applies here.
+	if (rejectOversizedSource(normalized)) return null;
 	const key = `${maxWidth ?? ""}\x00${normalized}`;
 	const cached = asciiCache.get(key);
 	if (cached !== undefined) return cached;
@@ -40,6 +57,7 @@ export function resolveNomnomlAscii(source: string, maxWidth?: number): string |
 export async function resolveNomnomlPng(source: string): Promise<string | null> {
 	const normalized = normalizedSource(source);
 	if (normalized === null) return null;
+	if (rejectOversizedSource(normalized)) return null;
 	const cached = pngCache.get(normalized);
 	if (typeof cached === "string" || cached === null) return cached;
 	if (cached !== undefined) return cached;

--- a/packages/coding-agent/src/modes/theme/nomnoml-cache.ts
+++ b/packages/coding-agent/src/modes/theme/nomnoml-cache.ts
@@ -1,0 +1,62 @@
+import { renderSvgToPng } from "@oh-my-pi/pi-natives";
+import { logger, renderNomnomlAsciiSafe, renderNomnomlSvg } from "@oh-my-pi/pi-utils";
+
+export type MarkdownNomnomlRendering = "off" | "svg" | "ascii";
+
+let markdownNomnomlRendering: MarkdownNomnomlRendering = "svg";
+const asciiCache = new Map<string, string | null>();
+const pngCache = new Map<string, Promise<string | null> | string | null>();
+
+export function setMarkdownNomnomlRendering(mode: MarkdownNomnomlRendering): void {
+	if (markdownNomnomlRendering === mode) return;
+	markdownNomnomlRendering = mode;
+}
+
+export function getMarkdownNomnomlRendering(): MarkdownNomnomlRendering {
+	return markdownNomnomlRendering;
+}
+
+export function clearNomnomlCache(): void {
+	asciiCache.clear();
+	pngCache.clear();
+}
+
+function normalizedSource(source: string): string | null {
+	const normalized = source.replace(/\r\n?/g, "\n").trim();
+	return normalized.length === 0 ? null : normalized;
+}
+
+export function resolveNomnomlAscii(source: string, maxWidth?: number): string | null {
+	const normalized = normalizedSource(source);
+	if (normalized === null) return null;
+	const key = `${maxWidth ?? ""}\x00${normalized}`;
+	const cached = asciiCache.get(key);
+	if (cached !== undefined) return cached;
+	const ascii = renderNomnomlAsciiSafe(normalized, maxWidth ?? 120);
+	asciiCache.set(key, ascii);
+	return ascii;
+}
+
+export async function resolveNomnomlPng(source: string): Promise<string | null> {
+	const normalized = normalizedSource(source);
+	if (normalized === null) return null;
+	const cached = pngCache.get(normalized);
+	if (typeof cached === "string" || cached === null) return cached;
+	if (cached !== undefined) return cached;
+
+	const pending = (async () => {
+		try {
+			const svg = renderNomnomlSvg(normalized);
+			if (svg === null) return null;
+			const bytes = await renderSvgToPng(svg, 2);
+			return Buffer.from(bytes).toString("base64");
+		} catch (err) {
+			logger.debug("Nomnoml SVG rasterization failed", { error: String(err) });
+			return null;
+		}
+	})();
+	pngCache.set(normalized, pending);
+	const result = await pending;
+	pngCache.set(normalized, result);
+	return result;
+}

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -19,6 +19,12 @@ import darkThemeJson from "./dark.json" with { type: "json" };
 import { defaultThemes } from "./defaults";
 import lightThemeJson from "./light.json" with { type: "json" };
 import { resolveMermaidAscii } from "./mermaid-cache";
+import {
+	getMarkdownNomnomlRendering,
+	type MarkdownNomnomlRendering,
+	resolveNomnomlAscii,
+	setMarkdownNomnomlRendering as setNomnomlCacheRendering,
+} from "./nomnoml-cache";
 
 export { getLanguageFromPath } from "../../utils/lang-from-path";
 
@@ -2867,28 +2873,36 @@ export function setMarkdownMermaidRendering(enabled: boolean): void {
 	cachedMarkdownTheme = undefined;
 }
 
+export function setMarkdownNomnomlRendering(mode: MarkdownNomnomlRendering): void {
+	if (getMarkdownNomnomlRendering() === mode) return;
+	setNomnomlCacheRendering(mode);
+	cachedMarkdownTheme = undefined;
+}
+
 export function getMarkdownTheme(): MarkdownTheme {
 	if (cachedMarkdownTheme !== undefined && cachedMarkdownThemeRef === theme) {
 		return cachedMarkdownTheme;
 	}
-	const mermaid = markdownMermaidRendering
-		? (() => {
-				// Mermaid ASCII diagrams render with the active palette so they read as
-				// content rather than raw monochrome. Roles mirror the SVG renderer's
-				// mapping; `text`/`muted`/`border`/`borderMuted`/`accent` exist in every theme.
-				const mermaidColorMode =
-					theme.getColorMode() === "truecolor" ? ("truecolor" as const) : ("ansi256" as const);
-				const mermaidTheme = {
-					fg: theme.getColorHex("text"),
-					border: theme.getColorHex("border"),
-					line: theme.getColorHex("muted"),
-					arrow: theme.getColorHex("accent"),
-					corner: theme.getColorHex("muted"),
-					junction: theme.getColorHex("borderMuted"),
-				};
-				return { mermaidColorMode, mermaidTheme };
-			})()
-		: undefined;
+	const nomnomlRendering = getMarkdownNomnomlRendering();
+	const mermaid =
+		markdownMermaidRendering && nomnomlRendering === "off"
+			? (() => {
+					// Mermaid ASCII diagrams render with the active palette so they read as
+					// content rather than raw monochrome. Roles mirror the SVG renderer's
+					// mapping; `text`/`muted`/`border`/`borderMuted`/`accent` exist in every theme.
+					const mermaidColorMode =
+						theme.getColorMode() === "truecolor" ? ("truecolor" as const) : ("ansi256" as const);
+					const mermaidTheme = {
+						fg: theme.getColorHex("text"),
+						border: theme.getColorHex("border"),
+						line: theme.getColorHex("muted"),
+						arrow: theme.getColorHex("accent"),
+						corner: theme.getColorHex("muted"),
+						junction: theme.getColorHex("borderMuted"),
+					};
+					return { mermaidColorMode, mermaidTheme };
+				})()
+			: undefined;
 	const markdownTheme: MarkdownTheme = {
 		heading: (text: string) => theme.fg("mdHeading", text),
 		link: (text: string) => theme.fg("mdLink", text),
@@ -2913,6 +2927,8 @@ export function getMarkdownTheme(): MarkdownTheme {
 						colorMode: mermaid.mermaidColorMode,
 					})
 			: undefined,
+		resolveNomnomlAscii:
+			nomnomlRendering !== "off" ? (source, maxWidth) => resolveNomnomlAscii(source, maxWidth) : undefined,
 		highlightCode: (code: string, lang?: string): string[] => {
 			const validLang = lang && nativeSupportsLanguage(lang) ? lang : undefined;
 			const highlighted = highlightCached(code, validLang, theme);

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -7,13 +7,24 @@ import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { AssistantMessageComponent } from "../components/assistant-message";
 import type { InteractiveModeContext } from "../types";
 
+export type AssistantMessageContext = Pick<
+	InteractiveModeContext,
+	"effectiveHideThinkingBlock" | "proseOnlyThinking"
+> & {
+	settings: Pick<InteractiveModeContext["settings"], "get">;
+	ui: Pick<InteractiveModeContext["ui"], "imageBudget" | "requestRender">;
+	viewSession: {
+		extensionRunner: InteractiveModeContext["viewSession"]["extensionRunner"];
+	};
+};
+
 /**
  * Construct an {@link AssistantMessageComponent} wired to the live context's
  * thinking/image settings. `message` is omitted for the streaming placeholder
  * component and supplied when rendering a persisted turn.
  */
 export function createAssistantMessageComponent(
-	ctx: InteractiveModeContext,
+	ctx: AssistantMessageContext,
 	message?: AssistantMessage,
 ): AssistantMessageComponent {
 	return new AssistantMessageComponent(
@@ -23,6 +34,6 @@ export function createAssistantMessageComponent(
 		ctx.viewSession.extensionRunner?.getAssistantThinkingRenderers(),
 		ctx.ui.imageBudget,
 		ctx.proseOnlyThinking,
-		ctx.settings.get("terminal.showImages"),
+		() => ctx.settings.get("terminal.showImages"),
 	);
 }

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -23,5 +23,6 @@ export function createAssistantMessageComponent(
 		ctx.viewSession.extensionRunner?.getAssistantThinkingRenderers(),
 		ctx.ui.imageBudget,
 		ctx.proseOnlyThinking,
+		ctx.settings.get("terminal.showImages"),
 	);
 }

--- a/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/interactive-context-helpers.ts
@@ -34,6 +34,6 @@ export function createAssistantMessageComponent(
 		ctx.viewSession.extensionRunner?.getAssistantThinkingRenderers(),
 		ctx.ui.imageBudget,
 		ctx.proseOnlyThinking,
-		() => ctx.settings.get("terminal.showImages"),
+		() => ctx.settings.get("terminal.showImages") !== false,
 	);
 }

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -16,6 +16,9 @@ You are a helpful assistant the team trusts with load-bearing changes, operating
 - Consider what code compiles to. NEVER allocate avoidably; no needless copies or computation.
 - You are not alone in this repo. Treat unexpected changes as the user's work and adapt.
 - In terminal prose and final chat, you MAY use LaTeX math (`$`, `$$`, `\text`, `\times`) and color (`\textcolor`, `\colorbox`, `\fcolorbox`).
+{{#if renderNomnoml}}
+- To show a diagram, you MAY emit a ` ```nomnoml ` block — the terminal renders it as a diagram. Prefer nomnoml over Mermaid; use simple syntax like `[A] -> [B]` and `#direction: right` when useful.
+{{/if}}
 {{#if renderMermaid}}
 - To show a diagram, you MAY emit a ` ```mermaid ` block — the terminal renders it as ASCII. Use it for genuine structure or flow, not trivia.
 {{/if}}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2422,6 +2422,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				model: settings.get("includeModelInPrompt") ? getActiveModelString() : undefined,
 				personality: agentKind === "sub" ? "none" : settings.get("personality"),
 				renderMermaid: settings.get("tui.renderMermaid"),
+				renderNomnoml: settings.get("tui.renderNomnoml") !== "off",
 				activeRepoContext,
 			});
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -499,6 +499,8 @@ export interface BuildSystemPromptOptions {
 	includeWorkspaceTree?: boolean;
 	/** Whether Mermaid fenced blocks render as terminal ASCII diagrams. Default: true */
 	renderMermaid?: boolean;
+	/** Whether nomnoml fenced blocks render as diagrams and replace the Mermaid prompt hint. Default: false */
+	renderNomnoml?: boolean;
 	/** Pre-resolved nested active repo context. Undefined resolves from cwd. */
 	activeRepoContext?: ActiveRepoContext | null;
 }
@@ -543,6 +545,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		personality = "default",
 		includeWorkspaceTree = false,
 		renderMermaid = true,
+		renderNomnoml = false,
 		activeRepoContext: providedActiveRepoContext,
 	} = options;
 	const inlineToolDescriptors = providedInlineToolDescriptors ?? false;
@@ -784,7 +787,8 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		hasMemoryRoot: memoryRootEnabled,
 		hasObsidian: hasObsidian(),
 		includeWorkspaceTree,
-		renderMermaid,
+		renderMermaid: renderMermaid && !renderNomnoml,
+		renderNomnoml,
 	};
 	const rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);
 	const systemPrompt = [rendered];

--- a/packages/coding-agent/test/issue-3656-shake-during-stream.test.ts
+++ b/packages/coding-agent/test/issue-3656-shake-during-stream.test.ts
@@ -7,12 +7,14 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
-import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as nomnomlCache from "@oh-my-pi/pi-coding-agent/modes/theme/nomnoml-cache";
+import { initTheme, setMarkdownNomnomlRendering } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 /**
@@ -37,6 +39,22 @@ const usage = {
 	totalTokens: 0,
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
+
+const originalImageProtocol = TERMINAL.imageProtocol;
+const tinyPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function assistantWithNomnoml(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "```nomnoml\n[Old] -> [New]\n```" }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		stopReason: "stop",
+		usage,
+		timestamp: Date.now(),
+	};
+}
 
 function assistantWithBash(command: string): AssistantMessage {
 	return {
@@ -90,6 +108,8 @@ describe("issue #3656 /shake mid-stream preserves the in-flight assistant turn",
 
 	afterEach(async () => {
 		mode?.stop();
+		setMarkdownNomnomlRendering("off");
+		setTerminalImageProtocol(originalImageProtocol);
 		HistoryStorage.resetInstance();
 		vi.restoreAllMocks();
 		await session?.dispose();
@@ -183,6 +203,77 @@ describe("issue #3656 /shake mid-stream preserves the in-flight assistant turn",
 		expect(mode.chatContainer.children).toContain(streamingComponent);
 		expect(mode.chatContainer.children).toContain(pendingTool);
 		expect(mode.pendingTools.get("call-1")).toBe(pendingTool);
+	});
+
+	it("disposes rebuilt Nomnoml placements exactly once and gives the replacement a fresh Kitty ID", async () => {
+		setMarkdownNomnomlRendering("svg");
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		vi.spyOn(nomnomlCache, "resolveNomnomlPng").mockResolvedValue(tinyPng);
+		Settings.instance.override("terminal.showImages", true);
+		const message = assistantWithNomnoml();
+		session.sessionManager.appendMessage(message);
+		const budget = mode.ui.imageBudget;
+		const acquireSpy = vi.spyOn(budget, "acquireId");
+		const releaseSpy = vi.spyOn(budget, "release");
+		const genericId = budget.acquireId("generic-tool-image");
+		const imageUpdated = Promise.withResolvers<void>();
+		mode.ui.requestRender = vi.fn(() => imageUpdated.resolve());
+
+		mode.rebuildChatFromMessages();
+		await imageUpdated.promise;
+		const oldComponent = mode.chatContainer.children.find(child => child instanceof AssistantMessageComponent) as
+			| AssistantMessageComponent
+			| undefined;
+		if (!oldComponent) throw new Error("Expected rebuilt historical assistant component");
+		budget.beginPass();
+		const oldRender = oldComponent.render(120).join("\n");
+		budget.endPass();
+		const oldAcquireIndex = acquireSpy.mock.calls.findIndex(
+			([key]) => typeof key === "string" && /^nomnoml:[^:]+:am\d+:0:/.test(key),
+		);
+		const oldKey = acquireSpy.mock.calls[oldAcquireIndex]?.[0];
+		const oldId = acquireSpy.mock.results[oldAcquireIndex]?.value as number | undefined;
+		if (typeof oldKey !== "string" || oldId === undefined) throw new Error("Expected old Nomnoml placement");
+		expect(oldRender).toContain("\x1b_G");
+		expect(oldKey).toMatch(/^nomnoml:[^:]+:am\d+:0:/);
+		expect(oldId).toBeGreaterThan(0);
+		expect(budget.takeTransmits()).toHaveLength(1);
+		releaseSpy.mockClear();
+		acquireSpy.mockClear();
+
+		const replacementUpdated = Promise.withResolvers<void>();
+		mode.ui.requestRender = vi.fn(() => replacementUpdated.resolve());
+
+		mode.rebuildChatFromMessages();
+		await replacementUpdated.promise;
+		const replacement = mode.chatContainer.children.find(child => child instanceof AssistantMessageComponent) as
+			| AssistantMessageComponent
+			| undefined;
+		if (!replacement) throw new Error("Expected replacement historical assistant component");
+		expect(replacement).not.toBe(oldComponent);
+		expect(releaseSpy.mock.calls).toEqual([[oldKey]]);
+		expect(budget.takePurgeIds()).toEqual([oldId]);
+		expect(budget.acquireId("generic-tool-image")).toBe(genericId);
+
+		budget.beginPass();
+		const replacementRender = replacement.render(120).join("\n");
+		budget.endPass();
+		const replacementAcquireIndex = acquireSpy.mock.calls.findIndex(
+			([key]) => typeof key === "string" && /^nomnoml:[^:]+:am\d+:0:/.test(key),
+		);
+		const replacementKey = acquireSpy.mock.calls[replacementAcquireIndex]?.[0];
+		const replacementId = acquireSpy.mock.results[replacementAcquireIndex]?.value as number | undefined;
+		if (typeof replacementKey !== "string" || replacementId === undefined) {
+			throw new Error("Expected replacement Nomnoml placement");
+		}
+		expect(replacementRender).toContain("\x1b_G");
+		expect(replacementKey).not.toBe(oldKey);
+		expect(replacementId).toBeGreaterThan(0);
+		expect(replacementId).not.toBe(oldId);
+
+		oldComponent.dispose();
+		oldComponent.dispose();
+		expect(releaseSpy.mock.calls).toEqual([[oldKey]]);
 	});
 
 	it("does not preserve in-flight tracking when the session is idle (post-stream rebuilds reset cleanly)", () => {

--- a/packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts
@@ -15,12 +15,13 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { ReadToolGroupComponent } from "@oh-my-pi/pi-coding-agent/modes/components/read-tool-group";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import { Container } from "@oh-my-pi/pi-tui";
+import { Container, ImageBudget, ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
 
 beforeAll(async () => {
 	await initTheme(false, undefined, undefined, "dark", "light");
@@ -66,15 +67,16 @@ function assistantMessage(content: Block[]): AssistantMessage {
 	};
 }
 
-function createFixture() {
+function createFixture(imageBudget?: ImageBudget) {
 	const chatContainer = new Container();
+	const requestRender = vi.fn();
 	const sessionMock = { getToolByName: () => undefined, extensionRunner: undefined };
 	const ctx = {
 		isInitialized: true,
 		init: vi.fn(async () => {}),
 		statusLine: { invalidate: vi.fn() },
 		updateEditorTopBorder: vi.fn(),
-		ui: { requestRender: vi.fn(), imageBudget: undefined },
+		ui: { requestRender, imageBudget },
 		chatContainer,
 		pendingTools: new Map(),
 		noteDisplayableThinkingContent: vi.fn(() => false),
@@ -86,7 +88,7 @@ function createFixture() {
 		session: sessionMock,
 		viewSession: sessionMock,
 	} as unknown as InteractiveModeContext;
-	return { controller: new EventController(ctx), chatContainer };
+	return { controller: new EventController(ctx), chatContainer, ctx, requestRender };
 }
 
 /** Drive one assistant completion: message_start then a single full message_update. */
@@ -154,5 +156,36 @@ describe("EventController read-group accretion", () => {
 		// A visible-reasoning completion breaks the run and finalizes the prior group.
 		await streamCompletion(controller, [thinking("done exploring"), read("b.ts:1-50")]);
 		expect(group!.isTranscriptBlockFinalized()).toBe(true);
+	});
+
+	it("drops a late read image result after its assistant owner is disposed", async () => {
+		const originalProtocol = TERMINAL.imageProtocol;
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		Settings.instance.override("terminal.showImages", true);
+		const budget = new ImageBudget(10, vi.fn());
+		const acquireSpy = vi.spyOn(budget, "acquireId");
+		const toBase64Spy = vi.spyOn(Bun.Image.prototype, "toBase64");
+		const { controller, ctx } = createFixture(budget);
+
+		try {
+			await streamCompletion(controller, [read("late.webp")]);
+			const owner = ctx.streamingComponent;
+			if (!(owner instanceof AssistantMessageComponent)) throw new Error("Expected assistant image owner");
+			owner.dispose();
+
+			await controller.handleEvent({
+				type: "tool_execution_end",
+				toolCallId: "read-late.webp",
+				toolName: "read",
+				isError: false,
+				result: { content: [{ type: "image", data: "not-decoded", mimeType: "image/webp" }] },
+			} as AgentSessionEvent);
+			await Promise.resolve();
+
+			expect(toBase64Spy).not.toHaveBeenCalled();
+			expect(acquireSpy).not.toHaveBeenCalled();
+		} finally {
+			setTerminalImageProtocol(originalProtocol);
+		}
 	});
 });

--- a/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
+++ b/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
@@ -145,7 +145,7 @@ function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContex
 		updateEditorTopBorder: vi.fn(),
 		ui: { requestRender: vi.fn(), imageBudget: undefined },
 		resetTranscript: () => chatContainer.clear(),
-		settings: { get: () => false },
+		settings: Settings.instance,
 		toolOutputExpanded: false,
 		hideThinkingBlock: false,
 		focusedAgentId: undefined,

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
@@ -53,6 +55,24 @@ describe("selector setting side effects", () => {
 
 		expect(invalidate).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
+	});
+
+	it("applies the terminal.showImages schema path to existing transcript components", () => {
+		const setShowImages = vi.fn();
+		const refreshImagePolicy = vi.fn();
+		const resetDisplay = vi.fn();
+		const tool = Object.assign(Object.create(ToolExecutionComponent.prototype), { setShowImages });
+		const assistant = Object.assign(Object.create(AssistantMessageComponent.prototype), { refreshImagePolicy });
+		const controller = new SelectorController({
+			chatContainer: { children: [tool, assistant] },
+			ui: { resetDisplay },
+		} as unknown as ConstructorParameters<typeof SelectorController>[0]);
+
+		controller.handleSettingChange("terminal.showImages", false);
+
+		expect(setShowImages).toHaveBeenCalledWith(false);
+		expect(refreshImagePolicy).toHaveBeenCalledTimes(1);
+		expect(resetDisplay).toHaveBeenCalledTimes(1);
 	});
 
 	it("replaces malformed default retry fallback chains from the model selector action", async () => {

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -1,21 +1,49 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
-import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { ImageBudget, ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
 
 let settingsState: SettingsTestState | undefined;
+const originalImageProtocol = TERMINAL.imageProtocol;
+const tinyPng = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function assistantMessage(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "Read image" }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
 
 beforeEach(async () => {
 	settingsState = beginSettingsTest();
 	await Settings.init({ inMemory: true });
+	const testTheme = await getThemeByName("dark");
+	if (!testTheme) throw new Error("Failed to load dark theme for selector test");
+	setThemeInstance(testTheme);
 });
 
 afterEach(() => {
+	setTerminalImageProtocol(originalImageProtocol);
+	vi.restoreAllMocks();
 	restoreSettingsTestState(settingsState);
 	settingsState = undefined;
 });
@@ -57,22 +85,48 @@ describe("selector setting side effects", () => {
 		expect(requestRender).toHaveBeenCalledTimes(1);
 	});
 
-	it("applies the terminal.showImages schema path to existing transcript components", () => {
-		const setShowImages = vi.fn();
-		const refreshImagePolicy = vi.fn();
+	it("applies terminal.showImages to stored assistant read images through the real selector path", () => {
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		Settings.instance.override("terminal.showImages", true);
+		const budget = new ImageBudget(10);
+		const assistant = new AssistantMessageComponent(assistantMessage(), false, undefined, [], budget, true, () =>
+			Settings.instance.get("terminal.showImages"),
+		);
+		assistant.setToolResultImages("read-image", [{ type: "image", data: tinyPng, mimeType: "image/png" }]);
 		const resetDisplay = vi.fn();
-		const tool = Object.assign(Object.create(ToolExecutionComponent.prototype), { setShowImages });
-		const assistant = Object.assign(Object.create(AssistantMessageComponent.prototype), { refreshImagePolicy });
 		const controller = new SelectorController({
-			chatContainer: { children: [tool, assistant] },
+			chatContainer: { children: [assistant] },
 			ui: { resetDisplay },
 		} as unknown as ConstructorParameters<typeof SelectorController>[0]);
 
-		controller.handleSettingChange("terminal.showImages", false);
+		budget.beginPass();
+		const initial = assistant.render(100).join("\n");
+		budget.endPass();
+		const [initialTransmit] = budget.takeTransmits();
+		expect(initial).toContain("\x1b_G");
+		expect(initialTransmit).toContain("\x1b_G");
+		const transmittedId = Number(initialTransmit?.match(/i=(\d+)/)?.[1]);
+		expect(transmittedId).toBeGreaterThan(0);
 
-		expect(setShowImages).toHaveBeenCalledWith(false);
-		expect(refreshImagePolicy).toHaveBeenCalledTimes(1);
-		expect(resetDisplay).toHaveBeenCalledTimes(1);
+		Settings.instance.override("terminal.showImages", false);
+		controller.handleSettingChange("terminal.showImages", false);
+		const hidden = stripVTControlCharacters(assistant.render(100).join("\n"));
+		expect(hidden).toContain("Read image");
+		expect(hidden).not.toContain("[Image:");
+		expect(budget.takeTransmits()).toEqual([]);
+		expect(budget.takePurgeIds()).toEqual([transmittedId]);
+
+		Settings.instance.override("terminal.showImages", true);
+		controller.handleSettingChange("terminal.showImages", true);
+		budget.beginPass();
+		const restored = assistant.render(100).join("\n");
+		budget.endPass();
+		const [restoredTransmit] = budget.takeTransmits();
+		const restoredId = Number(restoredTransmit?.match(/i=(\d+)/)?.[1]);
+		expect(restored).toContain("\x1b_G");
+		expect(restoredId).toBeGreaterThan(0);
+		expect(restoredId).not.toBe(transmittedId);
+		expect(resetDisplay).toHaveBeenCalledTimes(2);
 	});
 
 	it("replaces malformed default retry fallback chains from the model selector action", async () => {

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added native SVG-to-PNG rasterization for inline terminal image rendering.
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -1335,6 +1335,8 @@ export declare function readImageFromClipboard(): Promise<ClipboardImage | undef
  */
 export declare function renderSnapcompactPng(text: string, options: SnapcompactRenderOptions): Promise<string>
 
+export declare function renderSvgToPng(svg: string, zoom: number): Promise<Uint8Array>
+
 /**
  * Search content for a pattern (one-shot, compiles pattern each time).
  * For repeated searches with the same pattern, use [`grep`] with file filters.

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -61,6 +61,7 @@ export const parseKey = nativeBindings.parseKey;
 export const parseKittySequence = nativeBindings.parseKittySequence;
 export const readImageFromClipboard = nativeBindings.readImageFromClipboard;
 export const renderSnapcompactPng = nativeBindings.renderSnapcompactPng;
+export const renderSvgToPng = nativeBindings.renderSvgToPng;
 export const search = nativeBindings.search;
 export const setHangulCompatJamoWidthOverride = nativeBindings.setHangulCompatJamoWidthOverride;
 export const sliceWithWidth = nativeBindings.sliceWithWidth;

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Markdown theme support for rendering `nomnoml` fenced code blocks as inline ASCII diagrams.
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -146,6 +146,26 @@ export class ImageBudget {
 		return id;
 	}
 
+	/** Rebind a demoted keyed image to its retained id without stealing another owner's key. */
+	restoreOwnership(key: string, id: number): number {
+		const ownedId = this.#keyToId.get(key);
+		let restoredId: number;
+		if (ownedId !== undefined) {
+			restoredId = ownedId;
+		} else if (this.#idToKey.has(id)) {
+			restoredId = this.acquireId(key);
+		} else {
+			this.#keyToId.set(key, id);
+			this.#idToKey.set(id, key);
+			restoredId = id;
+		}
+		const lastIndex = this.#passIds.length - 1;
+		if (!this.#stablePass && lastIndex >= 0 && this.#passIds[lastIndex] === id) {
+			this.#passIds[lastIndex] = restoredId;
+		}
+		return restoredId;
+	}
+
 	/**
 	 * Release one stable logical image key. The key is forgotten immediately so
 	 * a later component gets a fresh graphics id. If that id was transmitted,
@@ -403,6 +423,15 @@ export class Image implements Component {
 		// toward (and are demoted by) the budget; without a protocol every image is
 		// already text.
 		const suppressed = hasProtocol && this.#budget !== undefined ? this.#budget.observe(this.#imageId ?? 0) : false;
+		if (
+			!suppressed &&
+			this.#cachedSuppressed &&
+			this.#budget !== undefined &&
+			this.#imageId !== undefined &&
+			this.#options.imageKey
+		) {
+			this.#imageId = this.#budget.restoreOwnership(this.#options.imageKey, this.#imageId);
+		}
 
 		if (
 			this.#cachedLines &&

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -8,6 +8,7 @@ import {
 	TERMINAL,
 } from "../terminal-capabilities";
 import type { Component } from "../tui";
+import { wrapTextWithAnsi } from "../utils";
 
 export interface ImageTheme {
 	fallbackColor: (str: string) => string;
@@ -17,6 +18,8 @@ export interface ImageOptions {
 	maxWidthCells?: number;
 	maxHeightCells?: number;
 	filename?: string;
+	/** Width-aware text used when graphics are unavailable or budget-suppressed. */
+	fallback?: (width: number) => string | readonly string[];
 	/** Shared budget that caps how many inline images render as live graphics. */
 	budget?: ImageBudget;
 	/**
@@ -84,8 +87,10 @@ export class ImageBudget {
 	#purgeIds: number[] = [];
 	/** Image ids whose data is believed to be loaded in the terminal's store. */
 	#transmitted = new Set<number>();
+	/** Image ids already queued for this frame but not yet emitted. */
+	#pendingTransmitIds = new Set<number>();
 	/** Transmit sequences (full base64) to write once, before this frame's placements. */
-	#pendingTransmits: string[] = [];
+	#pendingTransmits: Array<{ id: number; sequence: string }> = [];
 	// True while the in-flight pass is a partial/throwaway pass (the
 	// non-multiplexer resize viewport fast path) that walks only the visible
 	// tail, bottom-up. Such a pass cannot derive display order from observe()
@@ -142,6 +147,26 @@ export class ImageBudget {
 	}
 
 	/**
+	 * Release one stable logical image key. The key is forgotten immediately so
+	 * a later component gets a fresh graphics id. If that id was transmitted,
+	 * queue its terminal-store deletion and request the repaint that emits it.
+	 * Returns whether a terminal purge was scheduled.
+	 */
+	release(key: string): boolean {
+		const id = this.#keyToId.get(key);
+		if (id === undefined) return false;
+
+		this.#keyToId.delete(key);
+		this.#idToKey.delete(id);
+		this.#pendingTransmitIds.delete(id);
+		this.#pendingTransmits = this.#pendingTransmits.filter(transmit => transmit.id !== id);
+		if (!this.#transmitted.delete(id)) return false;
+		if (!this.#purgeIds.includes(id)) this.#purgeIds.push(id);
+		this.#requestRender();
+		return true;
+	}
+
+	/**
 	 * Begin a render pass. Called by the renderer before composing the frame.
 	 * Pass `stable: true` for a partial/throwaway pass that does not walk the
 	 * whole tree in display order (the resize viewport fast path): {@link observe}
@@ -188,9 +213,8 @@ export class ImageBudget {
 		if (this.#applyingReset) {
 			for (let i = this.#onTerminal; i < this.#planned && i < total; i++) {
 				const id = this.#passIds[i];
-				this.#purgeIds.push(id);
-				// d=I frees the data too, so the image must re-transmit if it returns.
-				this.#transmitted.delete(id);
+				// d=I is valid only for Kitty ids whose data reached the terminal store.
+				if (this.#transmitted.delete(id) && !this.#purgeIds.includes(id)) this.#purgeIds.push(id);
 				this.#forgetKeyForId(id);
 			}
 			this.#onTerminal = this.#planned;
@@ -214,12 +238,21 @@ export class ImageBudget {
 		return ids;
 	}
 
-	/** All image ids believed to be loaded in the terminal store; clears tracking. */
+	/** All image ids believed to be loaded in the terminal store, plus any queued for purge; clears tracking. */
 	takeAllTransmittedIds(): readonly number[] {
-		if (this.#transmitted.size === 0) return EMPTY_IDS;
-		const ids = [...this.#transmitted];
+		let ids: readonly number[];
+		if (this.#transmitted.size === 0 && this.#purgeIds.length === 0) {
+			ids = EMPTY_IDS;
+		} else if (this.#purgeIds.length === 0) {
+			ids = [...this.#transmitted];
+		} else if (this.#transmitted.size === 0) {
+			ids = this.#purgeIds;
+		} else {
+			ids = [...new Set([...this.#transmitted, ...this.#purgeIds])];
+		}
 		this.#transmitted.clear();
 		this.#purgeIds = [];
+		this.#pendingTransmitIds.clear();
 		this.#pendingTransmits = [];
 		this.#keyToId.clear();
 		this.#idToKey.clear();
@@ -228,7 +261,7 @@ export class ImageBudget {
 
 	/** Whether `imageId`'s data still needs to be transmitted to the terminal. */
 	shouldTransmit(imageId: number): boolean {
-		return !this.#transmitted.has(imageId);
+		return !this.#transmitted.has(imageId) && !this.#pendingTransmitIds.has(imageId);
 	}
 
 	/**
@@ -236,9 +269,9 @@ export class ImageBudget {
 	 * repeated call (e.g. a width-change re-render) never re-sends the data.
 	 */
 	enqueueTransmit(imageId: number, sequence: string): void {
-		if (this.#transmitted.has(imageId)) return;
-		this.#transmitted.add(imageId);
-		this.#pendingTransmits.push(sequence);
+		if (this.#transmitted.has(imageId) || this.#pendingTransmitIds.has(imageId)) return;
+		this.#pendingTransmitIds.add(imageId);
+		this.#pendingTransmits.push({ id: imageId, sequence });
 	}
 
 	/** Whether a frame has image data queued but not yet written to the terminal. */
@@ -264,7 +297,10 @@ export class ImageBudget {
 	/** Transmit sequences to write before this frame's placements; clears the queue. */
 	takeTransmits(): readonly string[] {
 		if (this.#pendingTransmits.length === 0) return EMPTY_TRANSMITS;
-		const sequences = this.#pendingTransmits;
+		const pending = this.#pendingTransmits;
+		for (const transmit of pending) this.#transmitted.add(transmit.id);
+		const sequences = pending.map(transmit => transmit.sequence);
+		this.#pendingTransmitIds.clear();
 		this.#pendingTransmits = [];
 		return sequences;
 	}
@@ -280,6 +316,7 @@ export class ImageBudget {
 	forgetTransmitted(): void {
 		if (this.#transmitted.size === 0 && this.#pendingTransmits.length === 0) return;
 		this.#transmitted.clear();
+		this.#pendingTransmitIds.clear();
 		this.#pendingTransmits = [];
 	}
 
@@ -419,11 +456,11 @@ export class Image implements Component {
 				const placement = moveUp + (result.sequence ?? "");
 				lines.push(cursorRows > 0 ? SAVE_CURSOR + placement + RESTORE_CURSOR : placement);
 			} else {
-				lines = this.#fallbackLines();
+				lines = this.#fallbackLines(maxWidth);
 			}
 			this.#renderedGraphicRows = Math.max(this.#renderedGraphicRows, lines.length);
 		} else {
-			lines = this.#fallbackLines();
+			lines = this.#fallbackLines(maxWidth);
 		}
 
 		this.#cachedLines = lines;
@@ -445,16 +482,16 @@ export class Image implements Component {
 	 * (stale band + recommit). Reserved rows stay non-plain so blank-edge
 	 * trimming cannot collapse the block either.
 	 */
-	#fallbackLines(): string[] {
-		const fallback = this.#theme.fallbackColor(
-			imageFallback(this.#mimeType, this.#dimensions, this.#options.filename),
-		);
-		if (this.#renderedGraphicRows <= 1) return [fallback];
-		const lines: string[] = [];
-		for (let i = 0; i < this.#renderedGraphicRows - 1; i++) {
-			lines.push(RESERVED_IMAGE_ROW);
-		}
-		lines.push(fallback);
-		return lines;
+	#fallbackLines(width: number): string[] {
+		const custom = this.#options.fallback?.(Math.max(1, width));
+		const fallbackLines =
+			custom === undefined
+				? [this.#theme.fallbackColor(imageFallback(this.#mimeType, this.#dimensions, this.#options.filename))]
+				: (typeof custom === "string" ? custom.split("\n") : [...custom]).flatMap(line =>
+						wrapTextWithAnsi(line, Math.max(1, width)),
+					);
+		if (fallbackLines.length === 0) fallbackLines.push("");
+		const reservedRows = Math.max(0, this.#renderedGraphicRows - fallbackLines.length);
+		return [...Array.from({ length: reservedRows }, () => RESERVED_IMAGE_ROW), ...fallbackLines];
 	}
 }

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -674,6 +674,11 @@ export interface MarkdownTheme {
 	 * Return null to fall back to fenced code rendering.
 	 */
 	resolveMermaidAscii?: (source: string, maxWidth?: number) => string | null;
+	/**
+	 * Resolve a nomnoml ASCII rendering by fenced block source text.
+	 * Return null to fall back to fenced code rendering.
+	 */
+	resolveNomnomlAscii?: (source: string, maxWidth?: number) => string | null;
 	symbols: SymbolTheme;
 }
 
@@ -1548,6 +1553,21 @@ export class Markdown implements Component {
 				// resolver already re-fits over-wide horizontal graphs top-down.
 				if (token.lang === "mermaid" && this.#theme.resolveMermaidAscii) {
 					const ascii = this.#theme.resolveMermaidAscii(token.text, width);
+					if (ascii) {
+						for (const asciiLine of ascii.split("\n")) {
+							lines.push(
+								visibleWidth(asciiLine) > width ? truncateToWidth(asciiLine, width, Ellipsis.Omit) : asciiLine,
+							);
+						}
+						if (nextTokenType && nextTokenType !== "space") {
+							lines.push("");
+						}
+						break;
+					}
+				}
+
+				if (token.lang === "nomnoml" && this.#theme.resolveNomnomlAscii) {
+					const ascii = this.#theme.resolveNomnomlAscii(token.text, width);
 					if (ascii) {
 						for (const asciiLine of ascii.split("\n")) {
 							lines.push(

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1568,7 +1568,8 @@ export class Markdown implements Component {
 
 				if (token.lang === "nomnoml" && this.#theme.resolveNomnomlAscii) {
 					const ascii = this.#theme.resolveNomnomlAscii(token.text, width);
-					if (ascii) {
+					// Empty string is a successful all-hidden/blank render; only null falls back.
+					if (ascii !== null) {
 						for (const asciiLine of ascii.split("\n")) {
 							lines.push(
 								visibleWidth(asciiLine) > width ? truncateToWidth(asciiLine, width, Ellipsis.Omit) : asciiLine,

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1673,6 +1673,7 @@ export class TUI extends Container {
 	}
 
 	stop(): void {
+		if (this.#stopped) return;
 		// Leave the alt buffer first so the teardown cursor math below runs against
 		// the restored normal screen (which #previousLines still describes).
 		if (this.#resizeAltActive) {
@@ -1685,10 +1686,8 @@ export class TUI extends Container {
 			this.#altActive = false;
 			this.#altPreviousLines = [];
 		}
-		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
-			for (const id of this.#imageBudget.takeAllTransmittedIds()) {
-				this.terminal.write(encodeKittyDeleteImage(id));
-			}
+		for (const id of this.#imageBudget.takeAllTransmittedIds()) {
+			this.terminal.write(encodeKittyDeleteImage(id));
 		}
 		this.#clearSixelProbeState();
 		this.#stopped = true;
@@ -2786,8 +2785,6 @@ export class TUI extends Container {
 		let purgeSequence = "";
 		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
 			for (const id of this.#imageBudget.takePurgeIds()) purgeSequence += encodeKittyDeleteImage(id);
-		} else {
-			this.#imageBudget.takePurgeIds();
 		}
 
 		// 6. Emit.

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -371,6 +371,51 @@ describe("Image budget integration", () => {
 		expect([...budget.takeTransmits()]).toEqual([]);
 	});
 
+	it("restores keyed image ownership so release purges the retransmitted id exactly once", () => {
+		const requestRender = vi.fn();
+		const budget = new ImageBudget(2, requestRender);
+		const makeImage = (key: string) =>
+			new Image(
+				BASE64_ONE_PIXEL_PNG,
+				"image/png",
+				{ fallbackColor: text => text },
+				{ maxWidthCells: 4, maxHeightCells: 4, budget, imageKey: key },
+			);
+		const oldest = makeImage("oldest");
+		const middle = makeImage("middle");
+		const newest = makeImage("newest");
+		const renderPass = (images: Image[]) => {
+			budget.beginPass();
+			for (const image of images) image.render(20);
+			return budget.endPass();
+		};
+
+		renderPass([oldest, middle]);
+		const initialId = budget.acquireId("oldest");
+		expect(budget.takeTransmits()).toHaveLength(2);
+
+		renderPass([oldest, middle, newest]);
+		expect(renderPass([oldest, middle, newest])).toBe(true);
+		expect(budget.takePurgeIds()).toEqual([initialId]);
+		expect(budget.takeTransmits()).toHaveLength(1);
+		const competingId = budget.acquireId("oldest");
+		expect(competingId).not.toBe(initialId);
+
+		renderPass([oldest, middle]);
+		renderPass([oldest, middle]);
+		const restoredId = budget.acquireId("oldest");
+		expect(restoredId).toBe(competingId);
+		const restoredTransmits = budget.takeTransmits();
+		expect(restoredTransmits).toHaveLength(1);
+		expect(restoredTransmits[0]).toContain(`i=${restoredId}`);
+
+		expect(budget.release("oldest")).toBe(true);
+		expect(budget.release("oldest")).toBe(false);
+		expect(budget.takePurgeIds()).toEqual([restoredId]);
+		expect(budget.takePurgeIds()).toEqual([]);
+		expect(budget.acquireId("oldest")).not.toBe(restoredId);
+	});
+
 	it("moves back up before multi-row direct Kitty placements and restores the cursor below them", () => {
 		const budget = new ImageBudget(3, () => {});
 		const id = budget.acquireId("k");

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -58,6 +58,8 @@ describe("ImageBudget", () => {
 		const budget = new ImageBudget(2, () => {
 			renders += 1;
 		});
+		budget.enqueueTransmit(1, "TX1");
+		expect(budget.takeTransmits()).toEqual(["TX1"]);
 
 		// At cap: nothing demoted.
 		expect(pass(budget, 2).suppressed).toEqual([false, false]);
@@ -130,6 +132,31 @@ describe("ImageBudget", () => {
 		expect(budget.acquireId()).not.toBe(budget.acquireId());
 	});
 
+	it("releases only loaded stable images and reacquires them with fresh ids", () => {
+		const requestRender = vi.fn();
+		const budget = new ImageBudget(3, requestRender);
+		const releasedId = budget.acquireId("nomnoml:removed");
+		const survivingId = budget.acquireId("nomnoml:surviving");
+
+		budget.enqueueTransmit(releasedId, "removed-transmit");
+		budget.enqueueTransmit(survivingId, "surviving-transmit");
+		expect(budget.release("nomnoml:removed")).toBe(false);
+		expect(budget.takeTransmits()).toEqual(["surviving-transmit"]);
+		expect(budget.takePurgeIds()).toEqual([]);
+		expect(requestRender).not.toHaveBeenCalled();
+
+		const loadedId = budget.acquireId("nomnoml:removed");
+		budget.enqueueTransmit(loadedId, "loaded-transmit");
+		expect(budget.takeTransmits()).toEqual(["loaded-transmit"]);
+		expect(budget.release("nomnoml:removed")).toBe(true);
+		expect(budget.release("nomnoml:removed")).toBe(false);
+		expect(budget.takePurgeIds()).toEqual([loadedId]);
+		expect(budget.takePurgeIds()).toEqual([]);
+		expect(requestRender).toHaveBeenCalledTimes(1);
+		expect(budget.acquireId("nomnoml:removed")).not.toBe(loadedId);
+		expect(budget.acquireId("nomnoml:surviving")).toBe(survivingId);
+	});
+
 	it("initializes separate budgets with different starting IDs", () => {
 		const budget1 = new ImageBudget();
 		const budget2 = new ImageBudget();
@@ -195,7 +222,7 @@ describe("ImageBudget", () => {
 		budget.observe(id2);
 		budget.observe(id3);
 		expect(budget.endPass()).toBe(true);
-		expect([...budget.takePurgeIds()]).toEqual([oldId]);
+		expect([...budget.takePurgeIds()]).toEqual([]);
 
 		const suppressedId = budget.acquireId("keyA");
 		expect(suppressedId).not.toBe(oldId);
@@ -426,6 +453,95 @@ describe("Image budget integration", () => {
 		expect(olderLines.join("")).toContain("[Image:");
 		expect(olderLines.join("")).not.toContain("\x1b_G");
 		expect(newerLines.at(-1) ?? "").toContain("\x1b_G");
+	});
+
+	it("uses a width-aware custom fallback when the image protocol is unavailable", () => {
+		terminal.imageProtocol = null;
+		const receivedWidths: number[] = [];
+		const image = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: t => t },
+			{
+				fallback: width => {
+					receivedWidths.push(width);
+					return "diagram source remains readable";
+				},
+			},
+		);
+
+		const lines = image.render(12);
+		expect(receivedWidths).toEqual([10]);
+		expect(lines.join(" ")).toContain("diagram");
+		expect(lines.join(" ")).not.toContain("[Image:");
+		expect(lines.every(line => Bun.stringWidth(Bun.stripANSI(line)) <= 10)).toBe(true);
+	});
+
+	it("keeps generic fallback behavior when no custom fallback is supplied", () => {
+		terminal.imageProtocol = null;
+		const image = new Image(BASE64_ONE_PIXEL_PNG, "image/png", { fallbackColor: t => t });
+		const rendered = image.render(20).join("\n");
+		expect(rendered).toContain("[Image:");
+		expect(rendered).toContain("image/png");
+	});
+
+	it("uses the custom fallback on budget demotion without shrinking prior graphic height", () => {
+		const budget = new ImageBudget(1, () => {});
+		const older = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: t => t },
+			{ maxWidthCells: 4, maxHeightCells: 4, budget, imageKey: "diagram", fallback: () => "ASCII diagram" },
+			{ widthPx: 40, heightPx: 40 },
+		);
+		const newer = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: t => t },
+			{ maxWidthCells: 4, maxHeightCells: 4, budget, imageKey: "new" },
+		);
+		let initialHeight = 0;
+		let demoted: readonly string[] = [];
+		for (let pass = 0; pass < 2; pass++) {
+			budget.beginPass();
+			const olderLines = older.render(20);
+			if (pass === 0) initialHeight = olderLines.length;
+			demoted = olderLines;
+			newer.render(20);
+			budget.endPass();
+		}
+
+		expect(demoted.join("")).toContain("ASCIIdiagram");
+		expect(demoted.join("\n")).not.toContain("[Image:");
+		expect(demoted).toHaveLength(initialHeight);
+	});
+
+	it("keeps Sixel demotions out of the Kitty purge queue", () => {
+		terminal.imageProtocol = ImageProtocol.Sixel;
+		const budget = new ImageBudget(1, () => {});
+		const older = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 4, maxHeightCells: 4, budget, imageKey: "sixel-old" },
+		);
+		const newer = new Image(
+			BASE64_ONE_PIXEL_PNG,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 4, maxHeightCells: 4, budget, imageKey: "sixel-new" },
+		);
+
+		for (let passIndex = 0; passIndex < 2; passIndex++) {
+			budget.beginPass();
+			older.render(20);
+			newer.render(20);
+			budget.endPass();
+			expect(budget.takeTransmits()).toEqual([]);
+		}
+
+		expect(budget.takePurgeIds()).toEqual([]);
+		expect(budget.takeAllTransmittedIds()).toEqual([]);
 	});
 });
 
@@ -663,6 +779,43 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("retains a released Kitty purge through protocol loss and flushes it once on stop", async () => {
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		const tui = new TUI(term);
+		const imageId = tui.imageBudget.acquireId("released-after-kitty");
+		tui.addChild(makeImage(tui.imageBudget, "released-after-kitty"));
+
+		try {
+			tui.start();
+			await settle(term);
+			expect(writes.join("")).toContain("\x1b_Ga=t");
+			writes.length = 0;
+
+			expect(tui.imageBudget.release("released-after-kitty")).toBe(true);
+			terminal.imageProtocol = null;
+			await settle(term);
+
+			const deletion = encodeKittyDeleteImage(imageId);
+			expect(writes.join("")).not.toContain(deletion);
+
+			tui.stop();
+			const writesAfterFirstStop = writes.join("");
+			expect(writesAfterFirstStop.split(deletion).length - 1).toBe(1);
+
+			tui.stop();
+			expect(writes.join("")).toBe(writesAfterFirstStop);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("holds the first Ghostty image paint until the startup settle window passes", () => {
 		const originalId = terminal.id;
 		const originalGraphics = { ...getKittyGraphics() };
@@ -748,6 +901,7 @@ describe("ImageBudget transmit tracking", () => {
 		const budget = new ImageBudget(3, () => {});
 		budget.enqueueTransmit(1, "TX1");
 		budget.enqueueTransmit(2, "TX2");
+		expect([...budget.takeTransmits()]).toEqual(["TX1", "TX2"]);
 		expect(budget.shouldTransmit(1)).toBe(false);
 
 		expect([...budget.takeAllTransmittedIds()]).toEqual([1, 2]);
@@ -759,6 +913,7 @@ describe("ImageBudget transmit tracking", () => {
 	it("re-transmits an image after a purge frees its data", () => {
 		const budget = new ImageBudget(2, () => {});
 		budget.enqueueTransmit(1, "TX1");
+		expect([...budget.takeTransmits()]).toEqual(["TX1"]);
 		expect(budget.shouldTransmit(1)).toBe(false);
 
 		// Push past the cap so the oldest image (id 1) is demoted and purged.
@@ -768,5 +923,38 @@ describe("ImageBudget transmit tracking", () => {
 
 		// d=I freed the data, so the image must transmit again if it returns.
 		expect(budget.shouldTransmit(1)).toBe(true);
+	});
+
+	it("includes released ids queued for purge before they are drained", () => {
+		const budget = new ImageBudget(3, () => {});
+		const id = budget.acquireId("released");
+
+		budget.enqueueTransmit(id, "TX");
+		expect([...budget.takeTransmits()]).toEqual(["TX"]);
+		expect(budget.release("released")).toBe(true);
+
+		// The purge id has not been drained yet; shutdown cleanup must still delete it.
+		expect([...budget.takeAllTransmittedIds()]).toEqual([id]);
+		expect([...budget.takeAllTransmittedIds()]).toEqual([]);
+		expect(budget.shouldTransmit(id)).toBe(true);
+		expect(budget.acquireId("released")).not.toBe(id);
+	});
+
+	it("deduplicates ids that appear in both transmitted and purge sets", () => {
+		const budget = new ImageBudget(3, () => {});
+		const id = budget.acquireId("overlap");
+
+		budget.enqueueTransmit(id, "TX1");
+		expect([...budget.takeTransmits()]).toEqual(["TX1"]);
+		expect(budget.release("overlap")).toBe(true);
+
+		// Re-enqueue the same numeric id before the purge is drained: the id is now
+		// queued for purge and pending for re-transmission.
+		budget.enqueueTransmit(id, "TX2");
+		expect([...budget.takeTransmits()]).toEqual(["TX2"]);
+
+		expect([...budget.takeAllTransmittedIds()]).toEqual([id]);
+		expect([...budget.takeAllTransmittedIds()]).toEqual([]);
+		expect(budget.acquireId("overlap")).not.toBe(id);
 	});
 });

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -719,6 +719,47 @@ more text`,
 		});
 	});
 
+	describe("Nomnoml fenced blocks", () => {
+		const renderNomnomlLines = (text: string, resolveNomnomlAscii: (source: string) => string | null) => {
+			const markdown = new Markdown(text, 0, 0, { ...defaultMarkdownTheme, resolveNomnomlAscii });
+
+			return markdown.render(80).map(line => stripVTControlCharacters(line).trimEnd());
+		};
+
+		it("treats empty-string resolver output as success and does not leak the fence or source", () => {
+			const fencedNomnoml = "```nomnoml\n[<hidden> secret]\n```";
+			const nomnomlSource = "[<hidden> secret]";
+			const seenSources: string[] = [];
+
+			const plainLines = renderNomnomlLines(fencedNomnoml, source => {
+				seenSources.push(source);
+				return source === nomnomlSource ? "" : null;
+			});
+
+			expect(seenSources).toEqual([nomnomlSource]);
+			// Empty successful render may leave a blank line; never the fence or source.
+			expect(plainLines.some(line => line.includes("```nomnoml"))).toBeFalsy();
+			expect(plainLines.some(line => line.includes("```"))).toBeFalsy();
+			expect(plainLines.some(line => line.includes("secret"))).toBeFalsy();
+			expect(plainLines.some(line => line.includes("[<hidden>"))).toBeFalsy();
+			expect(plainLines.every(line => line.trim() === "")).toBeTruthy();
+		});
+
+		it("falls back to the original fenced code block when nomnoml resolution returns null", () => {
+			const invalidNomnoml = "```nomnoml\n[A\n```";
+			const invalidSource = "[A";
+			const seenSources: string[] = [];
+
+			const plainLines = renderNomnomlLines(invalidNomnoml, source => {
+				seenSources.push(source);
+				return null;
+			});
+
+			expect(seenSources).toEqual([invalidSource]);
+			expect(plainLines).toEqual(["```nomnoml", "  [A", "```"]);
+		});
+	});
+
 	describe("Spacing after dividers", () => {
 		it("should have only one blank line between divider and following paragraph", () => {
 			const markdown = new Markdown(

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Nomnoml SVG and ASCII rendering helpers for terminal diagram output.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@oh-my-pi/pi-natives": "catalog:",
     "handlebars": "catalog:",
+    "nomnoml": "1.7.0",
     "winston": "catalog:",
     "winston-daily-rotate-file": "catalog:"
   },

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -15,6 +15,7 @@ export * as logger from "./logger";
 export * from "./loop-phase";
 export * from "./mermaid-ascii";
 export * from "./mime";
+export * from "./nomnoml";
 export * from "./path";
 export * from "./path-tree";
 export * from "./peek-file";

--- a/packages/utils/src/nomnoml-ascii.ts
+++ b/packages/utils/src/nomnoml-ascii.ts
@@ -1,4 +1,5 @@
 import nomnoml from "nomnoml";
+import { sanitizeText } from "./sanitize-text";
 
 type Point = { x: number; y: number };
 type Label = { text?: string; x?: number; y?: number; width?: number; height?: number };
@@ -169,9 +170,38 @@ function compactConfig(config: NomnomlConfig, direction?: "TB" | "LR"): NomnomlC
 	};
 }
 
+/** Strip controls via {@link sanitizeText}, then collapse tabs to spaces for the fixed-width grid. */
+function sanitizeDiagramText(text: string): string {
+	return sanitizeText(text).replaceAll("\t", " ");
+}
+
+function sanitizeAssociationLabels(assoc: Association): void {
+	if (assoc.startLabel?.text !== undefined) {
+		assoc.startLabel.text = sanitizeDiagramText(assoc.startLabel.text);
+	}
+	if (assoc.endLabel?.text !== undefined) {
+		assoc.endLabel.text = sanitizeDiagramText(assoc.endLabel.text);
+	}
+}
+
+/** Sanitize every user-facing string on the parse tree before measure/draw so both see the same text. */
+function sanitizeLayoutPart(part: LayoutPart): void {
+	if (part.lines) part.lines = part.lines.map(sanitizeDiagramText);
+	for (const node of part.nodes ?? []) sanitizeLayoutNode(node);
+	for (const assoc of part.assocs ?? []) sanitizeAssociationLabels(assoc);
+}
+
+function sanitizeLayoutNode(node: LayoutNode): void {
+	if (typeof node.id === "string") node.id = sanitizeDiagramText(node.id);
+	sanitizeLayoutPart(node);
+	for (const part of node.parts ?? []) sanitizeLayoutPart(part);
+}
+
 function layout(source: string, direction?: "TB" | "LR"): ParsedNomnoml | null {
 	const parsed = nomnomlRuntime.parse(source);
 	parsed.config = compactConfig(parsed.config, direction);
+	// Narrowest entry: scrub labels/lines once before nomnoml measures and we draw.
+	sanitizeLayoutPart(parsed.root);
 	const measurer: Measurer = {
 		setFont: () => {},
 		textWidth: (text: string) => Math.max(1, Bun.stringWidth(text)),

--- a/packages/utils/src/nomnoml-ascii.ts
+++ b/packages/utils/src/nomnoml-ascii.ts
@@ -11,6 +11,8 @@ type LayoutPart = {
 	height?: number;
 	x?: number;
 	y?: number;
+	/** Compartment-local origin nomnoml applies before drawing nested content. */
+	offset?: Point;
 };
 type LayoutNode = LayoutPart & {
 	id?: string;
@@ -215,24 +217,17 @@ function isHidden(node: LayoutNode, config: NomnomlConfig): boolean {
 	return config.styles?.[node.type ?? "class"]?.visual === "hidden";
 }
 
-function collectNodeRows(node: LayoutNode, config: NomnomlConfig, depth = 0): NodeRow[] {
+/** Text rows a classifier draws inside its own border: its compartment lines, divider-separated. */
+function collectNodeRows(node: LayoutNode): NodeRow[] {
 	const rows: NodeRow[] = [];
 	const parts = node.parts ?? [];
 	for (const part of parts) {
-		const partRows: NodeRow[] = [];
-		for (const line of part.lines ?? []) partRows.push(line);
-		for (const child of part.nodes ?? []) {
-			if (!isHidden(child, config)) partRows.push(...collectNodeRows(child, config, depth + 1));
-		}
-		for (const row of partRows) {
-			if (row === COMPARTMENT_DIVIDER) {
-				rows.push(row);
-				continue;
-			}
-			const trimmed = row.trim();
+		// Child classifiers are drawn as their own boxes by drawNode, not inlined here.
+		for (const line of part.lines ?? []) {
+			const trimmed = line.trim();
 			if (trimmed) rows.push(trimmed);
 		}
-		if (depth === 0 && rows.length > 0 && part !== parts[parts.length - 1]) rows.push(COMPARTMENT_DIVIDER);
+		if (rows.length > 0 && part !== parts[parts.length - 1]) rows.push(COMPARTMENT_DIVIDER);
 	}
 	if (rows.length === 0 && node.id) rows.push(node.id);
 	return rows;
@@ -246,13 +241,39 @@ function nodeWidth(rows: NodeRow[]): number {
 	return width;
 }
 
-function drawNode(grid: CharGrid, node: LayoutNode, config: NomnomlConfig): void {
-	const rows = collectNodeRows(node, config);
-	const contentWidth = nodeWidth(rows);
-	const width = Math.max(3, Math.ceil(node.width ?? contentWidth + 2));
+/** Cell geometry of a classifier's border box, in the coordinate frame of its compartment. */
+type NodeBox = { rows: NodeRow[]; width: number; height: number; left: number; top: number };
+
+function nodeBox(node: LayoutNode, offsetX: number, offsetY: number): NodeBox {
+	const rows = collectNodeRows(node);
+	const width = Math.max(3, Math.ceil(node.width ?? nodeWidth(rows) + 2));
 	const height = Math.max(3, Math.ceil(node.height ?? rows.length + 2));
-	const left = Math.round((node.x ?? 0) - width / 2);
-	const top = Math.round((node.y ?? 0) - height / 2);
+	return {
+		rows,
+		width,
+		height,
+		left: offsetX + (node.x ?? 0) - width / 2,
+		top: offsetY + (node.y ?? 0) - height / 2,
+	};
+}
+
+/**
+ * Origin nomnoml uses for a compartment's own nodes and associations: the
+ * owning node's top-left, then `part.x/y`, then `part.offset`, then the gutter.
+ */
+function compartmentOrigin(box: NodeBox, part: LayoutPart, config: NomnomlConfig): Point {
+	const gutter = config.gutter ?? 0;
+	return {
+		x: box.left + (part.x ?? 0) + (part.offset?.x ?? 0) + gutter,
+		y: box.top + (part.y ?? 0) + (part.offset?.y ?? 0) + gutter,
+	};
+}
+
+function drawNode(grid: CharGrid, node: LayoutNode, config: NomnomlConfig, offsetX = 0, offsetY = 0): void {
+	const box = nodeBox(node, offsetX, offsetY);
+	const { rows, width, height } = box;
+	const left = Math.round(box.left);
+	const top = Math.round(box.top);
 	const right = left + width - 1;
 	const bottom = top + height - 1;
 
@@ -280,6 +301,76 @@ function drawNode(grid: CharGrid, node: LayoutNode, config: NomnomlConfig): void
 		const x = left + 1 + Math.max(0, Math.floor((width - 2 - rowWidth) / 2));
 		grid.text(x, top + 1 + i, row);
 	}
+
+	// Nested classifiers are laid out as real boxes inside their compartment, so
+	// draw them there instead of flattening them into the parent's text rows.
+	for (const part of node.parts ?? []) {
+		const origin = compartmentOrigin(box, part, config);
+		for (const child of part.nodes ?? []) {
+			if (!isHidden(child, config)) drawNode(grid, child, config, origin.x, origin.y);
+		}
+	}
+}
+
+/**
+ * Shift an association's geometry into root coordinates.
+ *
+ * nomnoml lays out nested content relative to the enclosing compartment, so an
+ * association inside `node.parts[*]` carries part-local points. Root-level
+ * associations already sit in absolute coordinates and are returned untouched.
+ */
+function translateAssoc(assoc: Association, dx: number, dy: number): Association {
+	if (dx === 0 && dy === 0) return assoc;
+	const shiftPoints = (points: Point[] | undefined): Point[] | undefined =>
+		points?.map(point => ({ x: point.x + dx, y: point.y + dy }));
+	const shiftLabel = (label: Label | undefined): Label | undefined =>
+		label === undefined
+			? undefined
+			: {
+					...label,
+					x: label.x === undefined ? undefined : label.x + dx,
+					y: label.y === undefined ? undefined : label.y + dy,
+				};
+	return {
+		...assoc,
+		path: shiftPoints(assoc.path),
+		points: shiftPoints(assoc.points),
+		startLabel: shiftLabel(assoc.startLabel),
+		endLabel: shiftLabel(assoc.endLabel),
+	};
+}
+
+/**
+ * Gather every association in the tree, root-first, in root coordinates.
+ *
+ * Mirrors {@link drawNode}'s recursion — same `node.parts[*]` descent, same
+ * {@link compartmentOrigin}, same hidden-node skip — so edges and boxes always
+ * agree on what exists and where it sits. The root compartment's own
+ * offset/gutter is skipped because top-level nodes are drawn without it too,
+ * and a uniform shift is trimmed away by {@link CharGrid.lines}.
+ */
+function collectAllAssocs(
+	part: LayoutPart,
+	config: NomnomlConfig,
+	offsetX = 0,
+	offsetY = 0,
+	out: Association[] = [],
+	seen: Set<Association> = new Set(),
+): Association[] {
+	for (const assoc of part.assocs ?? []) {
+		if (seen.has(assoc)) continue;
+		seen.add(assoc);
+		out.push(translateAssoc(assoc, offsetX, offsetY));
+	}
+	for (const node of part.nodes ?? []) {
+		if (isHidden(node, config)) continue;
+		const box = nodeBox(node, offsetX, offsetY);
+		for (const child of node.parts ?? []) {
+			const origin = compartmentOrigin(box, child, config);
+			collectAllAssocs(child, config, origin.x, origin.y, out, seen);
+		}
+	}
+	return out;
 }
 
 function drawAssociationLines(grid: CharGrid, assoc: Association): void {
@@ -369,11 +460,12 @@ function renderLayout(root: LayoutPart, config: NomnomlConfig): string | null {
 	const height = Math.max(1, Math.ceil(root.height ?? 0) + 2);
 	if (width > MAX_DIMENSION || height > MAX_DIMENSION || width * height > MAX_CANVAS_CELLS) return null;
 	const grid = new CharGrid(width, height);
-	for (const assoc of root.assocs ?? []) drawAssociationLines(grid, assoc);
+	const assocs = collectAllAssocs(root, config);
+	for (const assoc of assocs) drawAssociationLines(grid, assoc);
 	for (const node of root.nodes ?? []) {
 		if (!isHidden(node, config)) drawNode(grid, node, config);
 	}
-	for (const assoc of root.assocs ?? []) drawAssociationDecorations(grid, assoc);
+	for (const assoc of assocs) drawAssociationDecorations(grid, assoc);
 	const lines = grid.lines();
 	// Empty string = valid layout with nothing visible (e.g. all-hidden nodes).
 	// null is reserved for parse/layout/oversized failure so Markdown can fall back.

--- a/packages/utils/src/nomnoml-ascii.ts
+++ b/packages/utils/src/nomnoml-ascii.ts
@@ -282,9 +282,9 @@ function asciiDisplayWidth(ascii: string): number {
 }
 
 function renderLayout(root: LayoutPart): string | null {
-	const width = Math.min(MAX_DIMENSION, Math.max(1, Math.ceil(root.width ?? 0) + 2));
-	const height = Math.min(MAX_DIMENSION, Math.max(1, Math.ceil(root.height ?? 0) + 2));
-	if (width * height > MAX_CANVAS_CELLS) return null;
+	const width = Math.max(1, Math.ceil(root.width ?? 0) + 2);
+	const height = Math.max(1, Math.ceil(root.height ?? 0) + 2);
+	if (width > MAX_DIMENSION || height > MAX_DIMENSION || width * height > MAX_CANVAS_CELLS) return null;
 	const grid = new CharGrid(width, height);
 	for (const assoc of root.assocs ?? []) drawAssociationLines(grid, assoc);
 	for (const node of root.nodes ?? []) drawNode(grid, node);
@@ -303,8 +303,7 @@ export function renderNomnomlAsciiSafe(source: string, maxWidth = 120): string |
 		const normalizedSource = source.replace(/\r\n?/g, "\n").trim();
 		if (!normalizedSource) return null;
 		const base = renderVariant(normalizedSource);
-		if (base === null) return null;
-		let best: string | null = asciiDisplayWidth(base) <= maxWidth ? base : null;
+		let best: string | null = base !== null && asciiDisplayWidth(base) <= maxWidth ? base : null;
 		let bestWidth = best === null ? Number.POSITIVE_INFINITY : asciiDisplayWidth(best);
 		for (const direction of ["TB", "LR"] as const) {
 			const variant = renderVariant(normalizedSource, direction);

--- a/packages/utils/src/nomnoml-ascii.ts
+++ b/packages/utils/src/nomnoml-ascii.ts
@@ -1,0 +1,322 @@
+import nomnoml from "nomnoml";
+
+type Point = { x: number; y: number };
+type Label = { text?: string; x?: number; y?: number; width?: number; height?: number };
+type LayoutPart = {
+	lines?: string[];
+	nodes?: LayoutNode[];
+	assocs?: Association[];
+	width?: number;
+	height?: number;
+	x?: number;
+	y?: number;
+};
+type LayoutNode = LayoutPart & {
+	id?: string;
+	parts?: LayoutPart[];
+	dividers?: number[];
+};
+type Association = {
+	type?: string;
+	path?: Point[];
+	points?: Point[];
+	startLabel?: Label;
+	endLabel?: Label;
+};
+type NomnomlConfig = {
+	direction?: string;
+	padding?: number;
+	spacing?: number;
+	gutter?: number;
+	edgeMargin?: number;
+	arrowSize?: number;
+	bendSize?: number;
+};
+type ParsedNomnoml = { root: LayoutPart; config: NomnomlConfig };
+type Measurer = {
+	setFont: (font: string, size: number, weight: string, style: string) => void;
+	textWidth: (text: string) => number;
+	textHeight: () => number;
+};
+type NomnomlRuntime = typeof nomnoml & {
+	parse: (source: string) => ParsedNomnoml;
+	layout: (measurer: Measurer, config: NomnomlConfig, root: LayoutPart) => void;
+};
+
+// nomnoml 1.7.0 ships incomplete .d.ts declarations: parse/layout are exported
+// at runtime but absent from the type file. Keep the escape hatch local.
+const nomnomlRuntime = nomnoml as NomnomlRuntime;
+
+const MAX_CANVAS_CELLS = 40_000;
+const MAX_DIMENSION = 400;
+
+class CharGrid {
+	#cells: string[][];
+
+	constructor(
+		readonly width: number,
+		readonly height: number,
+	) {
+		this.#cells = Array.from({ length: height }, () => Array.from({ length: width }, () => " "));
+	}
+
+	set(x: number, y: number, char: string): void {
+		if (x < 0 || y < 0 || x >= this.width || y >= this.height) return;
+		const row = this.#cells[y];
+		if (!row) return;
+		const current = row[x] ?? " ";
+		row[x] = mergeChars(current, char);
+	}
+
+	text(x: number, y: number, text: string): void {
+		let cursor = x;
+		for (const char of text) {
+			this.set(cursor, y, char);
+			cursor += Bun.stringWidth(char) || 1;
+		}
+	}
+
+	lines(): string[] {
+		let top = 0;
+		let bottom = this.#cells.length - 1;
+		while (top <= bottom && rowEmpty(this.#cells[top])) top++;
+		while (bottom >= top && rowEmpty(this.#cells[bottom])) bottom--;
+		if (top > bottom) return [];
+
+		let left = this.width;
+		let right = 0;
+		for (let y = top; y <= bottom; y++) {
+			const row = this.#cells[y];
+			if (!row) continue;
+			for (let x = 0; x < row.length; x++) {
+				if ((row[x] ?? " ") !== " ") {
+					left = Math.min(left, x);
+					right = Math.max(right, x);
+				}
+			}
+		}
+		if (left > right) return [];
+
+		const result: string[] = [];
+		for (let y = top; y <= bottom; y++) {
+			const row = this.#cells[y];
+			if (!row) continue;
+			result.push(
+				row
+					.slice(left, right + 1)
+					.join("")
+					.trimEnd(),
+			);
+		}
+		return result;
+	}
+}
+
+function rowEmpty(row: string[] | undefined): boolean {
+	return row === undefined || row.every(char => char === " ");
+}
+
+function isHorizontal(char: string): boolean {
+	return char === "─" || char === "-" || char === "┼" || char === "+";
+}
+
+function isVertical(char: string): boolean {
+	return char === "│" || char === "|" || char === "┼" || char === "+";
+}
+
+function mergeChars(current: string, next: string): string {
+	if (current === " " || current === next) return next;
+	if (next === " ") return current;
+	if ((isHorizontal(current) && isVertical(next)) || (isVertical(current) && isHorizontal(next))) return "┼";
+	if (current === "┼" && (isHorizontal(next) || isVertical(next))) return current;
+	if (next === "┼" && (isHorizontal(current) || isVertical(current))) return next;
+	if ("<>^v".includes(next)) return next;
+	if ("┌┐└┘│─".includes(current) && "│─".includes(next)) return current;
+	return next;
+}
+
+function compactConfig(config: NomnomlConfig, direction?: "TB" | "LR"): NomnomlConfig {
+	return {
+		...config,
+		direction: direction ?? config.direction,
+		padding: 1,
+		spacing: 4,
+		gutter: 2,
+		edgeMargin: 0,
+		arrowSize: 1,
+		bendSize: 0.3,
+	};
+}
+
+function layout(source: string, direction?: "TB" | "LR"): LayoutPart | null {
+	const parsed = nomnomlRuntime.parse(source);
+	parsed.config = compactConfig(parsed.config, direction);
+	const measurer: Measurer = {
+		setFont: () => {},
+		textWidth: (text: string) => Math.max(1, Bun.stringWidth(text)),
+		textHeight: () => 1,
+	};
+	nomnomlRuntime.layout(measurer, parsed.config, parsed.root);
+	return parsed.root;
+}
+
+function collectNodeRows(node: LayoutNode, depth = 0): string[] {
+	const rows: string[] = [];
+	const parts = node.parts ?? [];
+	for (const part of parts) {
+		for (const line of part.lines ?? []) rows.push(line);
+		const children = part.nodes ?? [];
+		if (children.length > 0) {
+			for (const child of children) rows.push(...collectNodeRows(child, depth + 1));
+		}
+		if (depth === 0 && rows.length > 0 && part !== parts[parts.length - 1])
+			rows.push("─".repeat(Math.max(1, nodeWidth(rows))));
+	}
+	if (rows.length === 0 && node.id) rows.push(node.id);
+	return rows.map(row => row.trim()).filter(row => row.length > 0);
+}
+
+function nodeWidth(rows: string[]): number {
+	let width = 1;
+	for (const row of rows) width = Math.max(width, Bun.stringWidth(row));
+	return width;
+}
+
+function drawNode(grid: CharGrid, node: LayoutNode): void {
+	const rows = collectNodeRows(node);
+	const contentWidth = nodeWidth(rows);
+	const width = Math.max(3, Math.ceil(node.width ?? contentWidth + 2));
+	const height = Math.max(3, Math.ceil(node.height ?? rows.length + 2));
+	const left = Math.round((node.x ?? 0) - width / 2);
+	const top = Math.round((node.y ?? 0) - height / 2);
+	const right = left + width - 1;
+	const bottom = top + height - 1;
+
+	grid.set(left, top, "┌");
+	grid.set(right, top, "┐");
+	grid.set(left, bottom, "└");
+	grid.set(right, bottom, "┘");
+	for (let x = left + 1; x < right; x++) {
+		grid.set(x, top, "─");
+		grid.set(x, bottom, "─");
+	}
+	for (let y = top + 1; y < bottom; y++) {
+		grid.set(left, y, "│");
+		grid.set(right, y, "│");
+	}
+
+	const availableRows = Math.max(1, height - 2);
+	for (let i = 0; i < Math.min(rows.length, availableRows); i++) {
+		const row = rows[i] ?? "";
+		const rowWidth = Bun.stringWidth(row);
+		const x = left + 1 + Math.max(0, Math.floor((width - 2 - rowWidth) / 2));
+		grid.text(x, top + 1 + i, row);
+	}
+}
+
+function drawAssociationLines(grid: CharGrid, assoc: Association): void {
+	const points = assoc.path ?? assoc.points ?? [];
+	if (points.length < 2) return;
+	for (let i = 1; i < points.length; i++) {
+		const previous = points[i - 1];
+		const current = points[i];
+		if (!previous || !current) continue;
+		drawSegment(grid, roundPoint(previous), roundPoint(current));
+	}
+}
+
+function drawAssociationDecorations(grid: CharGrid, assoc: Association): void {
+	const points = assoc.path ?? assoc.points ?? [];
+	if (points.length < 2) return;
+	const type = assoc.type ?? "";
+	if (type.includes(">")) drawArrow(grid, points, false);
+	if (type.includes("<")) drawArrow(grid, points, true);
+	drawLabel(grid, assoc.startLabel);
+	drawLabel(grid, assoc.endLabel);
+}
+
+function roundPoint(point: Point): Point {
+	return { x: Math.round(point.x), y: Math.round(point.y) };
+}
+
+function drawSegment(grid: CharGrid, start: Point, end: Point): void {
+	if (start.x !== end.x && start.y !== end.y) {
+		drawSegment(grid, start, { x: end.x, y: start.y });
+		drawSegment(grid, { x: end.x, y: start.y }, end);
+		return;
+	}
+	if (start.x === end.x) {
+		const min = Math.min(start.y, end.y);
+		const max = Math.max(start.y, end.y);
+		for (let y = min; y <= max; y++) grid.set(start.x, y, "│");
+		return;
+	}
+	const min = Math.min(start.x, end.x);
+	const max = Math.max(start.x, end.x);
+	for (let x = min; x <= max; x++) grid.set(x, start.y, "─");
+}
+
+function drawArrow(grid: CharGrid, points: Point[], atStart: boolean): void {
+	const arrowPoint = atStart ? points[1] : points[points.length - 2];
+	const towardPoint = atStart ? points[0] : points[points.length - 1];
+	if (!arrowPoint || !towardPoint) return;
+	const dx = towardPoint.x - arrowPoint.x;
+	const dy = towardPoint.y - arrowPoint.y;
+	const char = Math.abs(dx) >= Math.abs(dy) ? (dx >= 0 ? ">" : "<") : dy >= 0 ? "v" : "^";
+	const point = roundPoint(arrowPoint);
+	grid.set(point.x, point.y, char);
+}
+
+function drawLabel(grid: CharGrid, label: Label | undefined): void {
+	const text = label?.text?.trim();
+	if (!text || label?.x === undefined || label.y === undefined) return;
+	const x = Math.round(label.x - Bun.stringWidth(text) / 2);
+	const y = Math.round(label.y);
+	grid.text(x, y, text);
+}
+
+function asciiDisplayWidth(ascii: string): number {
+	let max = 0;
+	for (const line of ascii.split("\n")) max = Math.max(max, Bun.stringWidth(line));
+	return max;
+}
+
+function renderLayout(root: LayoutPart): string | null {
+	const width = Math.min(MAX_DIMENSION, Math.max(1, Math.ceil(root.width ?? 0) + 2));
+	const height = Math.min(MAX_DIMENSION, Math.max(1, Math.ceil(root.height ?? 0) + 2));
+	if (width * height > MAX_CANVAS_CELLS) return null;
+	const grid = new CharGrid(width, height);
+	for (const assoc of root.assocs ?? []) drawAssociationLines(grid, assoc);
+	for (const node of root.nodes ?? []) drawNode(grid, node);
+	for (const assoc of root.assocs ?? []) drawAssociationDecorations(grid, assoc);
+	const lines = grid.lines();
+	return lines.length === 0 ? null : lines.join("\n");
+}
+
+function renderVariant(source: string, direction?: "TB" | "LR"): string | null {
+	const root = layout(source, direction);
+	return root ? renderLayout(root) : null;
+}
+
+export function renderNomnomlAsciiSafe(source: string, maxWidth = 120): string | null {
+	try {
+		const normalizedSource = source.replace(/\r\n?/g, "\n").trim();
+		if (!normalizedSource) return null;
+		const base = renderVariant(normalizedSource);
+		if (base === null) return null;
+		let best: string | null = asciiDisplayWidth(base) <= maxWidth ? base : null;
+		let bestWidth = best === null ? Number.POSITIVE_INFINITY : asciiDisplayWidth(best);
+		for (const direction of ["TB", "LR"] as const) {
+			const variant = renderVariant(normalizedSource, direction);
+			if (variant === null) continue;
+			const width = asciiDisplayWidth(variant);
+			if (width <= maxWidth && width < bestWidth) {
+				best = variant;
+				bestWidth = width;
+			}
+		}
+		return best;
+	} catch {
+		return null;
+	}
+}

--- a/packages/utils/src/nomnoml-ascii.ts
+++ b/packages/utils/src/nomnoml-ascii.ts
@@ -13,6 +13,7 @@ type LayoutPart = {
 };
 type LayoutNode = LayoutPart & {
 	id?: string;
+	type?: string;
 	parts?: LayoutPart[];
 	dividers?: number[];
 };
@@ -31,6 +32,7 @@ type NomnomlConfig = {
 	edgeMargin?: number;
 	arrowSize?: number;
 	bendSize?: number;
+	styles?: Record<string, { visual?: string }>;
 };
 type ParsedNomnoml = { root: LayoutPart; config: NomnomlConfig };
 type Measurer = {
@@ -50,6 +52,7 @@ const nomnomlRuntime = nomnoml as NomnomlRuntime;
 const MAX_CANVAS_CELLS = 40_000;
 const MAX_DIMENSION = 400;
 const WIDE_CONTINUATION_CELL = "\0";
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 class CharGrid {
 	#cells: string[][];
@@ -84,9 +87,9 @@ class CharGrid {
 
 	text(x: number, y: number, text: string): void {
 		let cursor = x;
-		for (const char of text) {
-			this.set(cursor, y, char);
-			cursor += Bun.stringWidth(char) || 1;
+		for (const { segment } of graphemeSegmenter.segment(text)) {
+			this.set(cursor, y, segment);
+			cursor += Bun.stringWidth(segment) || 1;
 		}
 	}
 
@@ -164,7 +167,7 @@ function compactConfig(config: NomnomlConfig, direction?: "TB" | "LR"): NomnomlC
 	};
 }
 
-function layout(source: string, direction?: "TB" | "LR"): LayoutPart | null {
+function layout(source: string, direction?: "TB" | "LR"): ParsedNomnoml | null {
 	const parsed = nomnomlRuntime.parse(source);
 	parsed.config = compactConfig(parsed.config, direction);
 	const measurer: Measurer = {
@@ -173,17 +176,23 @@ function layout(source: string, direction?: "TB" | "LR"): LayoutPart | null {
 		textHeight: () => 1,
 	};
 	nomnomlRuntime.layout(measurer, parsed.config, parsed.root);
-	return parsed.root;
+	return parsed;
 }
 
-function collectNodeRows(node: LayoutNode, depth = 0): string[] {
+function isHidden(node: LayoutNode, config: NomnomlConfig): boolean {
+	return config.styles?.[node.type ?? "class"]?.visual === "hidden";
+}
+
+function collectNodeRows(node: LayoutNode, config: NomnomlConfig, depth = 0): string[] {
 	const rows: string[] = [];
 	const parts = node.parts ?? [];
 	for (const part of parts) {
 		for (const line of part.lines ?? []) rows.push(line);
 		const children = part.nodes ?? [];
 		if (children.length > 0) {
-			for (const child of children) rows.push(...collectNodeRows(child, depth + 1));
+			for (const child of children) {
+				if (!isHidden(child, config)) rows.push(...collectNodeRows(child, config, depth + 1));
+			}
 		}
 		if (depth === 0 && rows.length > 0 && part !== parts[parts.length - 1])
 			rows.push("─".repeat(Math.max(1, nodeWidth(rows))));
@@ -198,8 +207,8 @@ function nodeWidth(rows: string[]): number {
 	return width;
 }
 
-function drawNode(grid: CharGrid, node: LayoutNode): void {
-	const rows = collectNodeRows(node);
+function drawNode(grid: CharGrid, node: LayoutNode, config: NomnomlConfig): void {
+	const rows = collectNodeRows(node, config);
 	const contentWidth = nodeWidth(rows);
 	const width = Math.max(3, Math.ceil(node.width ?? contentWidth + 2));
 	const height = Math.max(3, Math.ceil(node.height ?? rows.length + 2));
@@ -275,6 +284,7 @@ function drawSegment(grid: CharGrid, start: Point, end: Point): void {
 }
 
 function drawArrow(grid: CharGrid, points: Point[], atStart: boolean): void {
+	// path = [sourceNode, ...edge.points, targetNode]; marker at path[1]/path[length-2]
 	const arrowPoint = atStart ? points[1] : points[points.length - 2];
 	const towardPoint = atStart ? points[0] : points[points.length - 1];
 	if (!arrowPoint || !towardPoint) return;
@@ -299,21 +309,25 @@ function asciiDisplayWidth(ascii: string): number {
 	return max;
 }
 
-function renderLayout(root: LayoutPart): string | null {
+function renderLayout(root: LayoutPart, config: NomnomlConfig): string | null {
 	const width = Math.max(1, Math.ceil(root.width ?? 0) + 2);
 	const height = Math.max(1, Math.ceil(root.height ?? 0) + 2);
 	if (width > MAX_DIMENSION || height > MAX_DIMENSION || width * height > MAX_CANVAS_CELLS) return null;
 	const grid = new CharGrid(width, height);
 	for (const assoc of root.assocs ?? []) drawAssociationLines(grid, assoc);
-	for (const node of root.nodes ?? []) drawNode(grid, node);
+	for (const node of root.nodes ?? []) {
+		if (!isHidden(node, config)) drawNode(grid, node, config);
+	}
 	for (const assoc of root.assocs ?? []) drawAssociationDecorations(grid, assoc);
 	const lines = grid.lines();
-	return lines.length === 0 ? null : lines.join("\n");
+	// Empty string = valid layout with nothing visible (e.g. all-hidden nodes).
+	// null is reserved for parse/layout/oversized failure so Markdown can fall back.
+	return lines.join("\n");
 }
 
 function renderVariant(source: string, direction?: "TB" | "LR"): string | null {
-	const root = layout(source, direction);
-	return root ? renderLayout(root) : null;
+	const parsed = layout(source, direction);
+	return parsed ? renderLayout(parsed.root, parsed.config) : null;
 }
 
 export function renderNomnomlAsciiSafe(source: string, maxWidth = 120): string | null {

--- a/packages/utils/src/nomnoml-ascii.ts
+++ b/packages/utils/src/nomnoml-ascii.ts
@@ -49,6 +49,7 @@ const nomnomlRuntime = nomnoml as NomnomlRuntime;
 
 const MAX_CANVAS_CELLS = 40_000;
 const MAX_DIMENSION = 400;
+const WIDE_CONTINUATION_CELL = "\0";
 
 class CharGrid {
 	#cells: string[][];
@@ -64,8 +65,21 @@ class CharGrid {
 		if (x < 0 || y < 0 || x >= this.width || y >= this.height) return;
 		const row = this.#cells[y];
 		if (!row) return;
-		const current = row[x] ?? " ";
-		row[x] = mergeChars(current, char);
+		const previous = row[x];
+		const current = previous === WIDE_CONTINUATION_CELL ? " " : (previous ?? " ");
+		const next = mergeChars(current, char);
+		row[x] = next;
+		const width = Bun.stringWidth(next);
+		// If a narrower glyph replaced a wider one at this leading cell, clear the
+		// now-orphaned continuation sentinels it used to own.
+		const previousWidth = previous && previous !== WIDE_CONTINUATION_CELL ? Bun.stringWidth(previous) : 1;
+		for (let dx = Math.max(1, width); dx < previousWidth && x + dx < this.width; dx++) {
+			if (row[x + dx] === WIDE_CONTINUATION_CELL) row[x + dx] = " ";
+		}
+		if (width <= 1) return;
+		for (let dx = 1; dx < width && x + dx < this.width; dx++) {
+			row[x + dx] = WIDE_CONTINUATION_CELL;
+		}
 	}
 
 	text(x: number, y: number, text: string): void {
@@ -89,7 +103,8 @@ class CharGrid {
 			const row = this.#cells[y];
 			if (!row) continue;
 			for (let x = 0; x < row.length; x++) {
-				if ((row[x] ?? " ") !== " ") {
+				const cell = row[x] ?? " ";
+				if (cell !== " " && cell !== WIDE_CONTINUATION_CELL) {
 					left = Math.min(left, x);
 					right = Math.max(right, x);
 				}
@@ -104,6 +119,7 @@ class CharGrid {
 			result.push(
 				row
 					.slice(left, right + 1)
+					.filter(cell => cell !== WIDE_CONTINUATION_CELL)
 					.join("")
 					.trimEnd(),
 			);
@@ -113,7 +129,7 @@ class CharGrid {
 }
 
 function rowEmpty(row: string[] | undefined): boolean {
-	return row === undefined || row.every(char => char === " ");
+	return row === undefined || row.every(char => char === " " || char === WIDE_CONTINUATION_CELL);
 }
 
 function isHorizontal(char: string): boolean {
@@ -215,6 +231,7 @@ function drawNode(grid: CharGrid, node: LayoutNode): void {
 }
 
 function drawAssociationLines(grid: CharGrid, assoc: Association): void {
+	if (assoc.type === "-/-") return;
 	const points = assoc.path ?? assoc.points ?? [];
 	if (points.length < 2) return;
 	for (let i = 1; i < points.length; i++) {
@@ -226,6 +243,7 @@ function drawAssociationLines(grid: CharGrid, assoc: Association): void {
 }
 
 function drawAssociationDecorations(grid: CharGrid, assoc: Association): void {
+	if (assoc.type === "-/-") return;
 	const points = assoc.path ?? assoc.points ?? [];
 	if (points.length < 2) return;
 	const type = assoc.type ?? "";

--- a/packages/utils/src/nomnoml-ascii.ts
+++ b/packages/utils/src/nomnoml-ascii.ts
@@ -52,6 +52,8 @@ const nomnomlRuntime = nomnoml as NomnomlRuntime;
 const MAX_CANVAS_CELLS = 40_000;
 const MAX_DIMENSION = 400;
 const WIDE_CONTINUATION_CELL = "\0";
+const COMPARTMENT_DIVIDER = Symbol("compartment-divider");
+type NodeRow = string | typeof COMPARTMENT_DIVIDER;
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 class CharGrid {
@@ -183,27 +185,34 @@ function isHidden(node: LayoutNode, config: NomnomlConfig): boolean {
 	return config.styles?.[node.type ?? "class"]?.visual === "hidden";
 }
 
-function collectNodeRows(node: LayoutNode, config: NomnomlConfig, depth = 0): string[] {
-	const rows: string[] = [];
+function collectNodeRows(node: LayoutNode, config: NomnomlConfig, depth = 0): NodeRow[] {
+	const rows: NodeRow[] = [];
 	const parts = node.parts ?? [];
 	for (const part of parts) {
-		for (const line of part.lines ?? []) rows.push(line);
-		const children = part.nodes ?? [];
-		if (children.length > 0) {
-			for (const child of children) {
-				if (!isHidden(child, config)) rows.push(...collectNodeRows(child, config, depth + 1));
-			}
+		const partRows: NodeRow[] = [];
+		for (const line of part.lines ?? []) partRows.push(line);
+		for (const child of part.nodes ?? []) {
+			if (!isHidden(child, config)) partRows.push(...collectNodeRows(child, config, depth + 1));
 		}
-		if (depth === 0 && rows.length > 0 && part !== parts[parts.length - 1])
-			rows.push("─".repeat(Math.max(1, nodeWidth(rows))));
+		for (const row of partRows) {
+			if (row === COMPARTMENT_DIVIDER) {
+				rows.push(row);
+				continue;
+			}
+			const trimmed = row.trim();
+			if (trimmed) rows.push(trimmed);
+		}
+		if (depth === 0 && rows.length > 0 && part !== parts[parts.length - 1]) rows.push(COMPARTMENT_DIVIDER);
 	}
 	if (rows.length === 0 && node.id) rows.push(node.id);
-	return rows.map(row => row.trim()).filter(row => row.length > 0);
+	return rows;
 }
 
-function nodeWidth(rows: string[]): number {
+function nodeWidth(rows: NodeRow[]): number {
 	let width = 1;
-	for (const row of rows) width = Math.max(width, Bun.stringWidth(row));
+	for (const row of rows) {
+		if (row !== COMPARTMENT_DIVIDER) width = Math.max(width, Bun.stringWidth(row));
+	}
 	return width;
 }
 
@@ -233,6 +242,10 @@ function drawNode(grid: CharGrid, node: LayoutNode, config: NomnomlConfig): void
 	const availableRows = Math.max(1, height - 2);
 	for (let i = 0; i < Math.min(rows.length, availableRows); i++) {
 		const row = rows[i] ?? "";
+		if (row === COMPARTMENT_DIVIDER) {
+			for (let x = left + 1; x < right; x++) grid.set(x, top + 1 + i, "─");
+			continue;
+		}
 		const rowWidth = Bun.stringWidth(row);
 		const x = left + 1 + Math.max(0, Math.floor((width - 2 - rowWidth) / 2));
 		grid.text(x, top + 1 + i, row);
@@ -255,11 +268,35 @@ function drawAssociationDecorations(grid: CharGrid, assoc: Association): void {
 	if (assoc.type === "-/-") return;
 	const points = assoc.path ?? assoc.points ?? [];
 	if (points.length < 2) return;
-	const type = assoc.type ?? "";
-	if (type.includes(">")) drawArrow(grid, points, false);
-	if (type.includes("<")) drawArrow(grid, points, true);
+	const tokens = (assoc.type ?? "").split(/[-_]/);
+	drawTerminator(grid, points, true, tokens[0] ?? "");
+	drawTerminator(grid, points, false, tokens[tokens.length - 1] ?? "");
 	drawLabel(grid, assoc.startLabel);
 	drawLabel(grid, assoc.endLabel);
+}
+
+function drawTerminator(grid: CharGrid, points: Point[], atStart: boolean, terminator: string): void {
+	if (!terminator) return;
+	// path = [sourceNode, ...edge.points, targetNode]; marker at path[1]/path[length-2]
+	const markerPoint = atStart ? points[1] : points[points.length - 2];
+	const nodePoint = atStart ? points[0] : points[points.length - 1];
+	if (!markerPoint || !nodePoint) return;
+	const dx = nodePoint.x - markerPoint.x;
+	const dy = nodePoint.y - markerPoint.y;
+	const direction = Math.abs(dx) >= Math.abs(dy) ? (dx >= 0 ? "right" : "left") : dy >= 0 ? "down" : "up";
+	const directional = (right: string, left: string, down: string, up: string): string =>
+		direction === "right" ? right : direction === "left" ? left : direction === "down" ? down : up;
+	let glyph: string;
+	if (terminator === ">" || terminator === "<") glyph = directional(">", "<", "v", "^");
+	else if (terminator === ":>" || terminator === "<:") glyph = directional("▷", "◁", "▽", "△");
+	else if (terminator === "+") glyph = "♦";
+	else if (terminator === "o") glyph = "◇";
+	else if (terminator === "(" || terminator === ")") glyph = directional(")", "(", "⌣", "⌢");
+	else if (terminator === "(o" || terminator === "o)") glyph = "⊙";
+	else if (terminator === ">o" || terminator === "o<") glyph = "⊚";
+	else return;
+	const point = roundPoint(markerPoint);
+	grid.set(point.x, point.y, glyph);
 }
 
 function roundPoint(point: Point): Point {
@@ -281,18 +318,6 @@ function drawSegment(grid: CharGrid, start: Point, end: Point): void {
 	const min = Math.min(start.x, end.x);
 	const max = Math.max(start.x, end.x);
 	for (let x = min; x <= max; x++) grid.set(x, start.y, "─");
-}
-
-function drawArrow(grid: CharGrid, points: Point[], atStart: boolean): void {
-	// path = [sourceNode, ...edge.points, targetNode]; marker at path[1]/path[length-2]
-	const arrowPoint = atStart ? points[1] : points[points.length - 2];
-	const towardPoint = atStart ? points[0] : points[points.length - 1];
-	if (!arrowPoint || !towardPoint) return;
-	const dx = towardPoint.x - arrowPoint.x;
-	const dy = towardPoint.y - arrowPoint.y;
-	const char = Math.abs(dx) >= Math.abs(dy) ? (dx >= 0 ? ">" : "<") : dy >= 0 ? "v" : "^";
-	const point = roundPoint(arrowPoint);
-	grid.set(point.x, point.y, char);
 }
 
 function drawLabel(grid: CharGrid, label: Label | undefined): void {

--- a/packages/utils/src/nomnoml.ts
+++ b/packages/utils/src/nomnoml.ts
@@ -1,0 +1,22 @@
+import nomnoml from "nomnoml";
+
+import { renderNomnomlAsciiSafe } from "./nomnoml-ascii";
+
+type NomnomlRuntime = typeof nomnoml & {
+	renderSvg: (source: string) => string;
+};
+
+// nomnoml 1.7.0's .d.ts omits runtime exports used by the package itself.
+const nomnomlRuntime = nomnoml as NomnomlRuntime;
+
+export { renderNomnomlAsciiSafe };
+
+export function renderNomnomlSvg(source: string): string | null {
+	try {
+		const normalizedSource = source.replace(/\r\n?/g, "\n").trim();
+		if (!normalizedSource) return null;
+		return nomnomlRuntime.renderSvg(normalizedSource);
+	} catch {
+		return null;
+	}
+}

--- a/packages/utils/test/nomnoml-ascii.test.ts
+++ b/packages/utils/test/nomnoml-ascii.test.ts
@@ -86,6 +86,39 @@ describe("renderNomnomlAsciiSafe", () => {
 		});
 	}
 
+	it("draws associations declared inside a nested container", () => {
+		// Walking only root.assocs renders both nested nodes and silently drops the edge.
+		const rendered = stripDiagram(renderNomnomlAsciiSafe("[Container|\n  [A] -> [B]\n]", 80));
+		const rows = rendered.split("\n");
+
+		expect(rendered).toContain("Container");
+		// Container plus both nested classifiers, each with its own border box.
+		expect(rendered.match(/┌/g)).toHaveLength(3);
+
+		const arrowRow = rows.findIndex(row => row.includes("v"));
+		const arrowColumn = rows[arrowRow]?.indexOf("v") ?? -1;
+		const sourceRow = rows.findIndex(row => row.includes("A"));
+		const targetRow = rows.findIndex(row => row.includes("B"));
+
+		expect(arrowColumn).toBeGreaterThan(0);
+		// The edge runs down from below A and lands on B's box, not in dead space.
+		expect(arrowRow).toBeGreaterThan(sourceRow);
+		expect(arrowRow).toBeLessThan(targetRow);
+		const connectorRows = rows.filter(row => row[arrowColumn] === "│").length;
+		expect(connectorRows).toBeGreaterThan(1);
+	});
+
+	it("accumulates compartment offsets for doubly nested associations", () => {
+		const rendered = stripDiagram(renderNomnomlAsciiSafe("[Outer|\n [Inner|\n  [A] -> [B]\n ]\n]", 80));
+		const rows = rendered.split("\n");
+
+		// Outer, Inner, and both leaf classifiers.
+		expect(rendered.match(/┌/g)).toHaveLength(4);
+		expect(rows.some(row => row.includes("v"))).toBe(true);
+		// A mistranslated edge escapes the outer box; its border column must survive.
+		expect(rows.every(row => "┌│└".includes(row[0] ?? ""))).toBe(true);
+	});
+
 	it("places direct association markers on connector-facing edge points", () => {
 		// nomnoml path for [A]->[B] is [source center, top edge, mid, bottom edge, target center].
 		// Marker must land on path[length-2] (x=2,y=7,v), not node-center (2,9) or mid-route (2,5).

--- a/packages/utils/test/nomnoml-ascii.test.ts
+++ b/packages/utils/test/nomnoml-ascii.test.ts
@@ -217,4 +217,13 @@ describe("renderNomnomlAsciiSafe", () => {
 			expect(String(rendered)).not.toContain("```");
 		});
 	}
+
+	it("strips control characters and turns tabs into spaces in node labels", () => {
+		// BEL is stripped by sanitizeText; tab becomes a single space for the grid.
+		// Avoid ESC-[ CSI sequences: the '[' would break nomnoml's bracket DSL.
+		const rendered = stripDiagram(renderNomnomlAsciiSafe("[A\x07B\tC]", 80));
+		expect(rendered).not.toContain("\x07");
+		expect(rendered).not.toContain("\t");
+		expect(rendered).toContain("AB C");
+	});
 });

--- a/packages/utils/test/nomnoml-ascii.test.ts
+++ b/packages/utils/test/nomnoml-ascii.test.ts
@@ -38,6 +38,97 @@ describe("renderNomnomlAsciiSafe", () => {
 		expect(new Set(widths).size).toBe(1);
 	});
 
+	it("places grapheme clusters without overwriting the closing border", () => {
+		for (const label of ["e\u0301", "👩‍💻"]) {
+			const rendered = stripDiagram(renderNomnomlAsciiSafe(`[${label}]`, 80));
+			const rows = rendered.split("\n");
+
+			expect(rendered).toContain(`│${label}│`);
+			expect(new Set(rows.map(row => Bun.stringWidth(row))).size).toBe(1);
+		}
+	});
+
+	for (const [style, source] of [
+		["built-in", "[A] -/- [<hidden> secret] -/- [B]"],
+		["custom", "#.ghost: visual=hidden\n[A] -/- [<ghost> secret] -/- [B]"],
+	] as const) {
+		it(`omits ${style} hidden node visuals while retaining their layout gap`, () => {
+			const direct = stripDiagram(renderNomnomlAsciiSafe("[A] -/- [B]", 80));
+			const directRows = direct.split("\n");
+			const directGap =
+				directRows.findIndex(row => row.includes("B")) - directRows.findIndex(row => row.includes("A"));
+			const rendered = stripDiagram(renderNomnomlAsciiSafe(source, 80));
+			const rows = rendered.split("\n");
+			const hiddenGap = rows.findIndex(row => row.includes("B")) - rows.findIndex(row => row.includes("A"));
+
+			expect(rendered).not.toContain("secret");
+			expect(rendered.match(/┌/g)).toHaveLength(2);
+			expect(hiddenGap).toBeGreaterThan(directGap);
+		});
+	}
+	for (const [style, source, expectedLines, expectedWidth] of [
+		["built-in", "[<package> Pkg|\n  [A]\n  [B]\n  [<hidden> secret]\n]", 24, 9],
+		["custom", "#.ghost: visual=hidden\n[<package> Pkg|\n  [A]\n  [B]\n  [<ghost> secret]\n]", 24, 9],
+	] as const) {
+		it(`hides nested ${style} package child while preserving the computed container layout`, () => {
+			const rendered = stripDiagram(renderNomnomlAsciiSafe(source, 80));
+			const rows = rendered.split("\n");
+			const widths = rows.map(line => Bun.stringWidth(line));
+
+			expect(rendered).not.toContain("secret");
+			expect(rendered).toContain("Pkg");
+			expect(rendered).toContain("A");
+			expect(rendered).toContain("B");
+			expect(rendered).toMatch(/│\s*─{2,}\s*│/);
+			expect(rows.length).toBe(expectedLines);
+			expect(new Set(widths).size).toBe(1);
+			expect(widths[0]).toBe(expectedWidth);
+		});
+	}
+
+	it("places direct association markers on connector-facing edge points", () => {
+		// nomnoml path for [A]->[B] is [source center, top edge, mid, bottom edge, target center].
+		// Marker must land on path[length-2] (x=2,y=7,v), not node-center (2,9) or mid-route (2,5).
+		const endRows = stripDiagram(renderNomnomlAsciiSafe("[A] -> [B]", 80)).split("\n");
+		expect(endRows[7]?.[2]).toBe("v");
+		expect(endRows[9]?.[2]).not.toBe("v");
+		expect(endRows[5]?.[2]).not.toBe("v");
+
+		// Reverse arrow uses path[1] with direction toward the source center.
+		const startRows = stripDiagram(renderNomnomlAsciiSafe("[A] <- [B]", 80)).split("\n");
+		expect(startRows[3]?.[2]).toBe("^");
+		expect(startRows[1]?.[2]).not.toBe("^");
+
+		const bothRows = stripDiagram(renderNomnomlAsciiSafe("[A] <-> [B]", 80)).split("\n");
+		expect(bothRows[3]?.[2]).toBe("^");
+		expect(bothRows[7]?.[2]).toBe("v");
+	});
+
+	it("places bent multi-point association markers on the final connector edge points", () => {
+		// Three associations: two short routes (5 pts) plus a deliberate bend Start->End (7 pts).
+		// End markers sit at path[length-2]: Mid top (3,7,v), End left (4,14,v), End right (7,14,v).
+		// Node-center placement would put End markers on (6,16); wrong penultimate uses (9,12).
+		const source = "[Start] -> [Mid]\n[Mid] -> [End]\n[Start] -> [End]";
+		const rows = stripDiagram(renderNomnomlAsciiSafe(source, 80)).split("\n");
+
+		expect(rows[7]?.[3]).toBe("v");
+		expect(rows[14]?.[4]).toBe("v");
+		expect(rows[14]?.[7]).toBe("v");
+
+		// Node-center placement for the bent Start->End edge.
+		expect(rows[16]?.[6]).not.toBe("v");
+		// Wrong penultimate (path[length-3]) for the bent route.
+		expect(rows[12]?.[9]).not.toBe("v");
+
+		const markerCells = rows.flatMap((row, y) =>
+			[...row].flatMap((ch, x) => ("<>^v".includes(ch) ? [{ x, y, ch }] : [])),
+		);
+		expect(markerCells).toEqual([
+			{ x: 3, y: 7, ch: "v" },
+			{ x: 4, y: 14, ch: "v" },
+			{ x: 7, y: 14, ch: "v" },
+		]);
+	});
 	it("does not draw layout-only hidden association connectors", () => {
 		const rendered = stripDiagram(renderNomnomlAsciiSafe("#direction: right\n[A] -/- [B]", 80));
 		expect(rendered).toContain("A");
@@ -54,4 +145,19 @@ describe("renderNomnomlAsciiSafe", () => {
 		expect(gap.length).toBeGreaterThan(0);
 		expect(gap.every(line => line.trim() === "")).toBe(true);
 	});
+
+	for (const [style, source] of [
+		["built-in", "[<hidden> secret]"],
+		["custom", "#.ghost: visual=hidden\n[<ghost> secret]"],
+	] as const) {
+		it(`returns empty string for all-hidden ${style} diagrams without falling back to null`, () => {
+			const rendered = renderNomnomlAsciiSafe(source, 80);
+			// Empty string = successful blank layout; null would make Markdown leak source.
+			expect(rendered).toBe("");
+			expect(rendered).not.toBeNull();
+			expect(String(rendered)).not.toContain("secret");
+			expect(String(rendered)).not.toContain("hidden");
+			expect(String(rendered)).not.toContain("```");
+		});
+	}
 });

--- a/packages/utils/test/nomnoml-ascii.test.ts
+++ b/packages/utils/test/nomnoml-ascii.test.ts
@@ -30,4 +30,28 @@ describe("renderNomnomlAsciiSafe", () => {
 
 		expect(renderNomnomlAsciiSafe(source, 1000)).toBeNull();
 	});
+
+	it("keeps rows aligned when labels contain wide glyphs", () => {
+		const rendered = stripDiagram(renderNomnomlAsciiSafe("[漢字😀]", 80));
+		const widths = rendered.split("\n").map(line => Bun.stringWidth(line));
+		expect(rendered).toContain("漢字😀");
+		expect(new Set(widths).size).toBe(1);
+	});
+
+	it("does not draw layout-only hidden association connectors", () => {
+		const rendered = stripDiagram(renderNomnomlAsciiSafe("#direction: right\n[A] -/- [B]", 80));
+		expect(rendered).toContain("A");
+		expect(rendered).toContain("B");
+		// This layout stacks A above B. The hidden edge must leave the inter-box
+		// gap blank (no vertical │/horizontal ─/arrowhead); unguarded ASCII path
+		// previously painted a vertical connector there.
+		const lines = rendered.split("\n");
+		const firstBottom = lines.findIndex(line => line.includes("└"));
+		const secondTop = lines.findIndex((line, index) => index > firstBottom && line.includes("┌"));
+		expect(firstBottom).toBeGreaterThanOrEqual(0);
+		expect(secondTop).toBeGreaterThan(firstBottom);
+		const gap = lines.slice(firstBottom + 1, secondTop);
+		expect(gap.length).toBeGreaterThan(0);
+		expect(gap.every(line => line.trim() === "")).toBe(true);
+	});
 });

--- a/packages/utils/test/nomnoml-ascii.test.ts
+++ b/packages/utils/test/nomnoml-ascii.test.ts
@@ -24,4 +24,10 @@ describe("renderNomnomlAsciiSafe", () => {
 
 		expect(renderNomnomlAsciiSafe(source, 8)).toBeNull();
 	});
+
+	it("returns null instead of clipping layouts past the canvas dimension limit", () => {
+		const source = `[${"A".repeat(450)}]`;
+
+		expect(renderNomnomlAsciiSafe(source, 1000)).toBeNull();
+	});
 });

--- a/packages/utils/test/nomnoml-ascii.test.ts
+++ b/packages/utils/test/nomnoml-ascii.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { renderNomnomlAsciiSafe } from "../src/nomnoml";
+
+function stripDiagram(ascii: string | null): string {
+	return ascii ?? "";
+}
+
+describe("renderNomnomlAsciiSafe", () => {
+	it("renders labeled boxes and a directed connector", () => {
+		const rendered = stripDiagram(renderNomnomlAsciiSafe("#direction: right\n[A] -> [B]", 80));
+
+		expect(rendered).toContain("A");
+		expect(rendered).toContain("B");
+		expect(rendered).toContain("┌");
+		expect(/[>v<^]/.test(rendered)).toBe(true);
+	});
+
+	it("returns null for invalid nomnoml", () => {
+		expect(renderNomnomlAsciiSafe("[A", 80)).toBeNull();
+	});
+
+	it("returns null when the diagram cannot fit after direction retry", () => {
+		const source = "[This label is much wider than the viewport] -> [B]";
+
+		expect(renderNomnomlAsciiSafe(source, 8)).toBeNull();
+	});
+});

--- a/packages/utils/test/nomnoml-ascii.test.ts
+++ b/packages/utils/test/nomnoml-ascii.test.ts
@@ -129,6 +129,63 @@ describe("renderNomnomlAsciiSafe", () => {
 			{ x: 7, y: 14, ch: "v" },
 		]);
 	});
+
+	for (const [source, decorator] of [
+		["[A] +-> [B]", "♦"],
+		["[A] o-> [B]", "◇"],
+		["[A] <:- [B]", "△"],
+	] as const) {
+		it(`renders the ${decorator} endpoint decorator on a direct connector`, () => {
+			const rendered = stripDiagram(renderNomnomlAsciiSafe(source, 80));
+			expect(rendered).toContain(decorator);
+			expect(rendered).toContain("A");
+			expect(rendered).toContain("B");
+		});
+	}
+
+	it("retains distinct endpoint decorators on bent connectors", () => {
+		const rendered = stripDiagram(renderNomnomlAsciiSafe("[Start] +-> [Mid]\n[Mid] -> [End]\n[Start] o-> [End]", 80));
+		expect(rendered).toContain("♦");
+		expect(rendered).toContain("◇");
+		expect(rendered.match(/[>v<^]/g)?.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it("renders supported socket decorators without exposing their literal source", () => {
+		for (const [source, decorator] of [
+			["[A] (- [B]", "⌢"],
+			["[A] (o- [B]", "⊙"],
+			["[A] o<- [B]", "⊚"],
+		] as const) {
+			const rendered = stripDiagram(renderNomnomlAsciiSafe(source, 80));
+			expect(rendered).toContain(decorator);
+			expect(rendered).not.toContain(source);
+		}
+	});
+
+	it("does not leak hidden classifier source while rendering its visible connector decorator", () => {
+		const source = "[<hidden> secret] +-> [Visible]";
+		const rendered = stripDiagram(renderNomnomlAsciiSafe(source, 80));
+		expect(rendered).toContain("♦");
+		expect(rendered).toContain("Visible");
+		expect(rendered).not.toContain("secret");
+		expect(rendered).not.toContain("hidden");
+		expect(rendered).not.toContain(source);
+	});
+
+	for (const [description, source] of [
+		["later wider compartment", "[User|veryLongFieldName]"],
+		["earlier wider compartment", "[veryLongClassName|x]"],
+		["nested later content", "[Outer|[Inner|veryLongNestedField]]"],
+	] as const) {
+		it(`spans the final interior width for ${description}`, () => {
+			const rows = stripDiagram(renderNomnomlAsciiSafe(source, 80)).split("\n");
+			const topBorder = rows.find(row => /^┌─+┐$/.test(row));
+			const divider = rows.find(row => /^│─+│$/.test(row));
+			expect(topBorder).toBeDefined();
+			expect(divider).toBeDefined();
+			expect(Bun.stringWidth(divider ?? "")).toBe(Bun.stringWidth(topBorder ?? ""));
+		});
+	}
 	it("does not draw layout-only hidden association connectors", () => {
 		const rendered = stripDiagram(renderNomnomlAsciiSafe("#direction: right\n[A] -/- [B]", 80));
 		expect(rendered).toContain("A");


### PR DESCRIPTION
## Summary
The TUI only had Mermaid ASCII rendering, while nomnoml diagrams are often easier for agents to emit correctly and for users to read.

## Changes
- Add tui.renderNomnoml with off/svg/ascii modes and SVG as the default.
- Add nomnoml SVG rendering plus a resvg-backed PNG raster path in pi-natives.
- Add an ASCII fallback painter for nomnoml fences.
- Wire assistant-message image rendering, markdown fallback behavior, settings, and prompt hints so active nomnoml replaces Mermaid.

## Verification
- bun test packages/utils/test/nomnoml-ascii.test.ts — 3 pass, 0 fail
- cargo test -p pi-natives — 153 passed
- bun check was also run during publishing and failed on two pre-existing Biome format/organize-import diagnostics in the T1 guided-goal files; targeted unit tests above passed.

Closes #4930
