### PR TITLE
feat(coding-agent): add opt-in global local memory bank

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in local global memory bank. When `memory.backend=local` and `memory.globalBank` is enabled, the `learn` tool can write cross-project lessons with `scope: "global"`, prompt injection reads the global bank before project memory, and `memory://global` resolves the bank's `learned.md`.
+- Added Nomnoml diagram rendering with a `/settings` mode for SVG images, ASCII fallback, or highlighted fences; when active, Nomnoml replaces the Mermaid prompt/rendering hint.
+- `/guided-goal` now injects project context files (AGENTS.md and the like) as an untrusted `<repository-context>` system block so interview questions and drafted objectives ground in the real repo. Failures and empty projects keep the previous context-free behavior.
+
+### Changed
+
+- Rewrote the `/guided-goal` interviewer rubric around loop-engineering: deterministic success criteria, verification commands, attempt caps, scope boundaries, and stop conditions. Ready objectives must use the five-section structured markdown form.
+
+### Fixed
+
+- Fixed extension `sendUserMessage` throwing `Agent is already processing…` while the agent is streaming: without `deliverAs`, busy messages now queue as a steer. ACP/RPC skill invocations pass `streamingBehavior: "steer"` so they can land mid-turn the same way TUI skill commands do.
+- Fixed autolearn auto-continue firing a capture turn after an aborted stop (Esc/cancel): the controller now skips any `agent_end` whose last assistant message has `stopReason: "aborted"`.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2380,6 +2380,19 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"memory.globalBank": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "memory",
+			group: "General",
+			label: "Global Memory Bank",
+			description:
+				'Keep an additional cross-project bank; learn can target it with scope: "global". Clearing memory remains project-scoped.',
+			condition: "localActive",
+		},
+	},
+
 	// Auto-Learn (experimental): post-stop nudge to capture lessons to memory
 	// and mint/enhance isolated managed skills under ~/.omp/agent/managed-skills.
 	// Master flag is default-off → zero footprint; sub-flags gate behaviour.

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -6,7 +6,7 @@ import { getMnemopiSessionState, type MnemopiScopedMemoryHit, type MnemopiSessio
 import { AgentRegistry } from "../registry/agent-registry";
 import { buildDirectoryResource } from "./filesystem-resource";
 import { validateRelativePath } from "./skill-protocol";
-import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 const DEFAULT_MEMORY_FILE = "memory_summary.md";
 const DEFAULT_GLOBAL_MEMORY_FILE = "learned.md";
@@ -39,6 +39,24 @@ function ensureWithinRoot(targetPath: string, rootPath: string): void {
 function toMemoryValidationError(error: unknown): Error {
 	const message = error instanceof Error ? error.message : String(error);
 	return new Error(message.replace("skill://", "memory://"));
+}
+
+interface SettingsReader {
+	get(key: string): unknown;
+}
+
+function hasSettingsReader(value: unknown): value is SettingsReader {
+	return value !== null && typeof value === "object" && "get" in value && typeof value.get === "function";
+}
+
+function isGlobalMemoryEnabledForContext(context: ResolveContext | undefined): boolean {
+	const settings = context?.settings;
+	if (!hasSettingsReader(settings)) return false;
+	try {
+		return settings.get("memory.backend") === "local" && settings.get("memory.globalBank") === true;
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -212,13 +230,18 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 	readonly scheme = "memory";
 	readonly immutable = true;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
 		const namespace = url.rawHost || url.hostname;
 		if (!namespace) {
 			throw new Error("memory:// URL requires a namespace: memory://root, memory://global, or memory://<memory-id>");
 		}
 
 		if (namespace === GLOBAL_MEMORY_NAMESPACE) {
+			if (!isGlobalMemoryEnabledForContext(context)) {
+				throw new Error(
+					'memory://global requires local memory with memory.globalBank enabled for this session. Set memory.backend to "local" and enable memory.globalBank first.',
+				);
+			}
 			const root = getGlobalMemoryRoot(getAgentDir());
 			try {
 				await fs.stat(root);

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -11,7 +11,7 @@ import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, Ur
 const DEFAULT_MEMORY_FILE = "memory_summary.md";
 const DEFAULT_GLOBAL_MEMORY_FILE = "learned.md";
 const MEMORY_NAMESPACE = "root";
-const GLOBAL_MEMORY_NAMESPACE = "global";
+export const GLOBAL_MEMORY_NAMESPACE = "global";
 
 /**
  * Snapshot of memory roots for every registered session, deduped.
@@ -43,6 +43,7 @@ function toMemoryValidationError(error: unknown): Error {
 
 interface SettingsReader {
 	get(key: string): unknown;
+	getAgentDir?: () => string;
 }
 
 function hasSettingsReader(value: unknown): value is SettingsReader {
@@ -56,6 +57,16 @@ function isGlobalMemoryEnabledForContext(context: ResolveContext | undefined): b
 		return settings.get("memory.backend") === "local" && settings.get("memory.globalBank") === true;
 	} catch {
 		return false;
+	}
+}
+
+function getAgentDirFromContext(context: ResolveContext | undefined): string | undefined {
+	const settings = context?.settings;
+	if (!hasSettingsReader(settings) || typeof settings.getAgentDir !== "function") return undefined;
+	try {
+		return settings.getAgentDir();
+	} catch {
+		return undefined;
 	}
 }
 
@@ -242,7 +253,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 					'memory://global requires local memory with memory.globalBank enabled for this session. Set memory.backend to "local" and enable memory.globalBank first.',
 				);
 			}
-			const root = getGlobalMemoryRoot(getAgentDir());
+			const root = getGlobalMemoryRoot(getAgentDirFromContext(context) ?? getAgentDir());
 			try {
 				await fs.stat(root);
 			} catch (error) {

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getAgentDir, isEnoent } from "@oh-my-pi/pi-utils";
-import { getMemoryRoot } from "../memories";
+import { getGlobalMemoryRoot, getMemoryRoot } from "../memories";
 import { getMnemopiSessionState, type MnemopiScopedMemoryHit, type MnemopiSessionState } from "../mnemopi/state";
 import { AgentRegistry } from "../registry/agent-registry";
 import { buildDirectoryResource } from "./filesystem-resource";
@@ -9,7 +9,9 @@ import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
 
 const DEFAULT_MEMORY_FILE = "memory_summary.md";
+const DEFAULT_GLOBAL_MEMORY_FILE = "learned.md";
 const MEMORY_NAMESPACE = "root";
+const GLOBAL_MEMORY_NAMESPACE = "global";
 
 /**
  * Snapshot of memory roots for every registered session, deduped.
@@ -45,16 +47,21 @@ function toMemoryValidationError(error: unknown): Error {
 export function resolveMemoryUrlToPath(url: InternalUrl, memoryRoot: string): string {
 	const namespace = url.rawHost || url.hostname;
 	if (!namespace) {
-		throw new Error("memory:// URL requires a namespace: memory://root");
+		throw new Error("memory:// URL requires a namespace: memory://root or memory://global");
 	}
-	if (namespace !== MEMORY_NAMESPACE) {
-		throw new Error(`Unknown memory namespace: ${namespace}. Supported: ${MEMORY_NAMESPACE}`);
+	if (namespace !== MEMORY_NAMESPACE && namespace !== GLOBAL_MEMORY_NAMESPACE) {
+		throw new Error(
+			`Unknown memory namespace: ${namespace}. Supported: ${MEMORY_NAMESPACE}, ${GLOBAL_MEMORY_NAMESPACE}`,
+		);
 	}
 
 	const rawPathname = url.rawPathname ?? url.pathname;
 	const hasPath = rawPathname && rawPathname !== "/" && rawPathname !== "";
 	if (!hasPath) {
-		return path.resolve(memoryRoot, DEFAULT_MEMORY_FILE);
+		return path.resolve(
+			memoryRoot,
+			namespace === GLOBAL_MEMORY_NAMESPACE ? DEFAULT_GLOBAL_MEMORY_FILE : DEFAULT_MEMORY_FILE,
+		);
 	}
 	let relativePath: string;
 	try {
@@ -208,19 +215,36 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 	async resolve(url: InternalUrl): Promise<InternalResource> {
 		const namespace = url.rawHost || url.hostname;
 		if (!namespace) {
-			throw new Error("memory:// URL requires a namespace: memory://root or memory://<memory-id>");
+			throw new Error("memory:// URL requires a namespace: memory://root, memory://global, or memory://<memory-id>");
+		}
+
+		if (namespace === GLOBAL_MEMORY_NAMESPACE) {
+			const root = getGlobalMemoryRoot(getAgentDir());
+			try {
+				await fs.stat(root);
+			} catch (error) {
+				if (isEnoent(error)) {
+					throw new Error(
+						'Global memory bank is not available yet. Use learn with scope "global" while memory.globalBank is enabled first.',
+					);
+				}
+				throw error;
+			}
+			const result = await tryResolveInRoot(url, root);
+			if (result) return result;
+			throw new Error(`Memory file not found: ${url.href}`);
 		}
 
 		// Mnemopi rows live in SQLite banks per session, keyed by memory id.
-		// Any host other than the file-backed `root` namespace is treated as a
-		// mnemopi memory id lookup. This is the read counterpart to
+		// Any host other than the file-backed `root`/`global` namespaces is
+		// treated as a mnemopi memory id lookup. This is the read counterpart to
 		// `memory_edit update` and lets agents inspect the full content of a
 		// clipped recall preview before overwriting it (issue #4443).
 		if (namespace !== MEMORY_NAMESPACE) {
 			const mnemopiStates = mnemopiSessionStatesFromRegistry();
 			if (mnemopiStates.length === 0) {
 				throw new Error(
-					`Unknown memory namespace: ${namespace}. Supported: ${MEMORY_NAMESPACE} (file-backed memory summary), or a mnemopi memory id when memory.backend=mnemopi is active.`,
+					`Unknown memory namespace: ${namespace}. Supported: ${MEMORY_NAMESPACE}, ${GLOBAL_MEMORY_NAMESPACE} (file-backed memory), or a mnemopi memory id when memory.backend=mnemopi is active.`,
 				);
 			}
 			const hit = tryResolveMnemopiMemory(namespace);
@@ -263,6 +287,12 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		const completions: UrlCompletion[] = [];
 		if (memoryRootsFromRegistry().length > 0) {
 			completions.push({ value: MEMORY_NAMESPACE, description: "Project memory summary" });
+		}
+		try {
+			await fs.stat(getGlobalMemoryRoot(getAgentDir()));
+			completions.push({ value: GLOBAL_MEMORY_NAMESPACE, description: "Global learned lessons" });
+		} catch (error) {
+			if (!isEnoent(error)) throw error;
 		}
 		if (mnemopiSessionStatesFromRegistry().length > 0) {
 			completions.push({

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -229,7 +229,7 @@ function renderMemoryToolDeveloperInstructionsSnapshot(
 	// large cross-project bank cannot starve project-specific lessons. Clamp to 0:
 	// a truncated summary can exceed its nominal budget once the marker is added.
 	const learnedBudget = Math.max(0, cfg.summaryInjectionTokenLimit - Math.ceil(summaryOut.length / 4));
-	const hasGlobalLearned = snapshot.globalLearned.length > 0;
+	const hasGlobalLearned = isGlobalMemoryBankEnabled(settings) && snapshot.globalLearned.length > 0;
 	const hasProjectLearned = snapshot.learned.length > 0;
 	const projectLearnedBudget = hasGlobalLearned && hasProjectLearned ? Math.ceil(learnedBudget / 2) : learnedBudget;
 	const globalLearnedBudget =

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -224,18 +224,22 @@ function renderMemoryToolDeveloperInstructionsSnapshot(
 		: "";
 	// Lessons share ONE injection budget with the summary so the combined block
 	// stays within `summaryInjectionTokenLimit` (~4 chars/token, matching
-	// truncateByApproxTokens). With no summary, lessons get the whole budget.
-	// Clamp to 0: truncateByApproxTokens appends a marker, so a truncated summary
-	// can exceed `limit * 4` chars and drive the remainder negative — when the
-	// summary already fills the budget, lessons are simply dropped.
+	// truncateByApproxTokens). With no summary, lessons get the whole budget; when
+	// global and project lessons both exist, cap the global baseline at half so a
+	// large cross-project bank cannot starve project-specific lessons. Clamp to 0:
+	// a truncated summary can exceed its nominal budget once the marker is added.
 	const learnedBudget = Math.max(0, cfg.summaryInjectionTokenLimit - Math.ceil(summaryOut.length / 4));
+	const hasGlobalLearned = snapshot.globalLearned.length > 0;
+	const hasProjectLearned = snapshot.learned.length > 0;
+	const projectLearnedBudget = hasGlobalLearned && hasProjectLearned ? Math.ceil(learnedBudget / 2) : learnedBudget;
+	const globalLearnedBudget =
+		hasGlobalLearned && hasProjectLearned ? Math.max(0, learnedBudget - projectLearnedBudget) : learnedBudget;
 	const globalLearnedOut =
-		snapshot.globalLearned && learnedBudget > 0
-			? truncateByApproxTokens(snapshot.globalLearned, learnedBudget).trim()
+		hasGlobalLearned && globalLearnedBudget > 0
+			? truncateByApproxTokens(snapshot.globalLearned, globalLearnedBudget).trim()
 			: "";
-	const projectLearnedBudget = Math.max(0, learnedBudget - Math.ceil(globalLearnedOut.length / 4));
 	const learnedOut =
-		snapshot.learned && projectLearnedBudget > 0
+		hasProjectLearned && projectLearnedBudget > 0
 			? truncateByApproxTokens(snapshot.learned, projectLearnedBudget).trim()
 			: "";
 	if (!summaryOut && !globalLearnedOut && !learnedOut) return undefined;

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -153,6 +153,7 @@ interface MemoryInstructionSession {
 
 interface MemoryToolDeveloperInstructionsSnapshot {
 	summary: string;
+	globalLearned: string;
 	learned: string;
 }
 
@@ -172,6 +173,18 @@ function getMemoryInstructionRoot(agentDir: string, settings: Settings): string 
 	return getMemoryRoot(agentDir, settings.getCwd());
 }
 
+function isGlobalMemoryBankEnabled(settings: Settings): boolean {
+	try {
+		return settings.get("memory.backend") === "local" && settings.get("memory.globalBank") === true;
+	} catch {
+		return false;
+	}
+}
+
+function getMemoryInstructionGlobalRoot(agentDir: string, settings: Settings): string | undefined {
+	return isGlobalMemoryBankEnabled(settings) ? getGlobalMemoryRoot(agentDir) : undefined;
+}
+
 function getMemoryInstructionSessionFile(session: MemoryInstructionSession): string | undefined {
 	return session.sessionManager.getSessionFile() ?? undefined;
 }
@@ -183,6 +196,7 @@ async function readMemoryToolDeveloperInstructionsSnapshot(
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
 	const memoryRoot = getMemoryInstructionRoot(agentDir, settings);
+	const globalRoot = getMemoryInstructionGlobalRoot(agentDir, settings);
 
 	let summary = "";
 	try {
@@ -191,8 +205,9 @@ async function readMemoryToolDeveloperInstructionsSnapshot(
 		// Missing or unreadable summary — injection is best-effort; fall through
 		// so any captured lessons still surface on their own.
 	}
+	const globalLearned = globalRoot ? await readLearnedLessons(globalRoot) : "";
 	const learned = await readLearnedLessons(memoryRoot);
-	return { summary, learned };
+	return { summary, globalLearned, learned };
 }
 
 function renderMemoryToolDeveloperInstructionsSnapshot(
@@ -202,7 +217,7 @@ function renderMemoryToolDeveloperInstructionsSnapshot(
 	if (!snapshot) return undefined;
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
-	if (!snapshot.summary && !snapshot.learned) return undefined;
+	if (!snapshot.summary && !snapshot.globalLearned && !snapshot.learned) return undefined;
 
 	const summaryOut = snapshot.summary
 		? truncateByApproxTokens(snapshot.summary, cfg.summaryInjectionTokenLimit).trim()
@@ -214,12 +229,21 @@ function renderMemoryToolDeveloperInstructionsSnapshot(
 	// can exceed `limit * 4` chars and drive the remainder negative — when the
 	// summary already fills the budget, lessons are simply dropped.
 	const learnedBudget = Math.max(0, cfg.summaryInjectionTokenLimit - Math.ceil(summaryOut.length / 4));
+	const globalLearnedOut =
+		snapshot.globalLearned && learnedBudget > 0
+			? truncateByApproxTokens(snapshot.globalLearned, learnedBudget).trim()
+			: "";
+	const projectLearnedBudget = Math.max(0, learnedBudget - Math.ceil(globalLearnedOut.length / 4));
 	const learnedOut =
-		snapshot.learned && learnedBudget > 0 ? truncateByApproxTokens(snapshot.learned, learnedBudget).trim() : "";
-	if (!summaryOut && !learnedOut) return undefined;
+		snapshot.learned && projectLearnedBudget > 0
+			? truncateByApproxTokens(snapshot.learned, projectLearnedBudget).trim()
+			: "";
+	if (!summaryOut && !globalLearnedOut && !learnedOut) return undefined;
 
 	return prompt.render(readPathTemplate, {
 		memory_summary: summaryOut,
+		global_enabled: isGlobalMemoryBankEnabled(settings),
+		global_learned: globalLearnedOut,
 		learned: learnedOut,
 	});
 }
@@ -262,9 +286,12 @@ export async function refreshMemoryToolDeveloperInstructionsCacheAfterStartup(
 	const current = await readMemoryToolDeveloperInstructionsSnapshot(agentDir, settings);
 	const root = getMemoryInstructionRoot(agentDir, settings);
 	const baseline = memoryToolDeveloperInstructionsByRoot.get(root);
+	const cachedGlobalLearned =
+		cached && cached.sessionFile === sessionFile ? cached.snapshot?.globalLearned : undefined;
 	const cachedLearned = cached && cached.sessionFile === sessionFile ? cached.snapshot?.learned : undefined;
+	const globalLearned = cachedGlobalLearned ?? baseline?.globalLearned ?? "";
 	const learned = cachedLearned ?? baseline?.learned ?? "";
-	const snapshot = current ? { summary: current.summary, learned } : undefined;
+	const snapshot = current ? { summary: current.summary, globalLearned, learned } : undefined;
 	cacheMemoryToolDeveloperInstructions(session, sessionFile, snapshot, settings);
 }
 
@@ -1251,6 +1278,10 @@ export function getMemoryRoot(agentDir: string, cwd: string): string {
 	return path.join(getMemoriesDir(agentDir), encodeProjectPath(cwd));
 }
 
+export function getGlobalMemoryRoot(agentDir: string): string {
+	return path.join(getMemoriesDir(agentDir), "global");
+}
+
 /**
  * Filename of the captured-lessons file under a project's memory root.
  *
@@ -1301,25 +1332,21 @@ function normalizeLearnedText(text: string, maxChars: number): string {
 const learnedWriteChains = new Map<string, Promise<unknown>>();
 
 /**
- * Append one lesson to the project's `learned.md` (newest-first, deduped,
- * capped, secret-redacted, injection-neutralized). The file backs the `learn`
- * tool when `memory.backend` is `local`.
+ * Append one lesson to `root`/learned.md (newest-first, deduped, capped,
+ * secret-redacted, injection-neutralized). The file backs the `learn` tool
+ * when `memory.backend` is `local`.
  */
-export async function saveLearnedLesson(
-	agentDir: string,
-	cwd: string,
-	input: MemoryBackendSaveInput,
-): Promise<MemoryBackendSaveResult> {
+async function saveLearnedLessonAt(root: string, input: MemoryBackendSaveInput): Promise<MemoryBackendSaveResult> {
 	const content = normalizeLearnedText(input.content, MAX_LEARNED_CONTENT_CHARS);
 	if (!content) {
 		return { backend: "local", stored: 0, message: "Empty lesson; nothing stored." };
 	}
 	const context = input.context ? normalizeLearnedText(input.context, MAX_LEARNED_CONTEXT_CHARS) : "";
 	const line = context ? `- ${content} _(context: ${context})_` : `- ${content}`;
-	const filePath = path.join(getMemoryRoot(agentDir, cwd), LEARNED_LESSONS_FILE);
+	const filePath = path.join(root, LEARNED_LESSONS_FILE);
 
 	// Serialize the read-modify-write per file: parallel `learn` calls (sibling
-	// subagents, or two shared tool calls in one turn) share the project memory
+	// subagents, or two shared tool calls in one turn) share the same memory
 	// root, so an unguarded RMW would let the last writer drop the other's lesson.
 	const run = (learnedWriteChains.get(filePath) ?? Promise.resolve()).then(() => appendLearnedLine(filePath, line));
 	const guarded = run.catch(() => {});
@@ -1332,6 +1359,26 @@ export async function saveLearnedLesson(
 		if (learnedWriteChains.get(filePath) === guarded) learnedWriteChains.delete(filePath);
 	}
 	return { backend: "local", stored: 1, message: `Lesson saved to ${LEARNED_LESSONS_FILE}.` };
+}
+
+/**
+ * Append one lesson to the project's `learned.md` (newest-first, deduped,
+ * capped, secret-redacted, injection-neutralized). The file backs the `learn`
+ * tool when `memory.backend` is `local`.
+ */
+export async function saveLearnedLesson(
+	agentDir: string,
+	cwd: string,
+	input: MemoryBackendSaveInput,
+): Promise<MemoryBackendSaveResult> {
+	return saveLearnedLessonAt(getMemoryRoot(agentDir, cwd), input);
+}
+
+export async function saveGlobalLearnedLesson(
+	agentDir: string,
+	input: MemoryBackendSaveInput,
+): Promise<MemoryBackendSaveResult> {
+	return saveLearnedLessonAt(getGlobalMemoryRoot(agentDir), input);
 }
 
 async function appendLearnedLine(filePath: string, line: string): Promise<void> {

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -92,6 +92,13 @@ const CONDITIONS: Record<string, () => boolean> = {
 			return false;
 		}
 	},
+	localActive: () => {
+		try {
+			return Settings.instance.get("memory.backend") === "local";
+		} catch {
+			return false;
+		}
+	},
 	hindsightActive: () => {
 		try {
 			return Settings.instance.get("memory.backend") === "hindsight";

--- a/packages/coding-agent/src/prompts/memories/read-path.md
+++ b/packages/coding-agent/src/prompts/memories/read-path.md
@@ -1,5 +1,8 @@
 # Memory Guidance
 Memory root: memory://root
+{{#if global_enabled}}
+Global memory root: memory://global (`learned.md` only; baseline guidance before project memory)
+{{/if}}
 Operational rules:
 1) Read `memory://root/memory_summary.md` first.
 2) If needed, inspect `memory://root/MEMORY.md` and `memory://root/skills/<name>/SKILL.md`.
@@ -11,7 +14,11 @@ Operational rules:
 Memory summary:
 {{memory_summary}}
 {{/if}}
+{{#if global_learned}}
+Learned lessons (global cross-project baseline; durable but may be stale — verify against the repo before relying on them):
+{{global_learned}}
+{{/if}}
 {{#if learned}}
-Learned lessons (captured via the `learn` tool; durable but may be stale — verify against the repo before relying on them):
+Learned lessons (project-specific; captured via the `learn` tool; durable but may be stale — verify against the repo before relying on them):
 {{learned}}
 {{/if}}

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -28,6 +28,7 @@ export interface InternalUrlExpansionOptions {
 	internalRouter?: InternalUrlResolver;
 	localOptions?: LocalProtocolOptions;
 	ensureLocalParentDirs?: boolean;
+	settings?: unknown;
 }
 
 /**
@@ -175,6 +176,7 @@ async function resolveInternalUrlToPath(
 	internalRouter?: InternalUrlResolver,
 	localOptions?: LocalProtocolOptions,
 	ensureLocalParentDirs?: boolean,
+	settings?: unknown,
 ): Promise<string> {
 	const url = normalizeLocalScheme(rawUrl);
 	const scheme = extractScheme(url);
@@ -208,7 +210,7 @@ async function resolveInternalUrlToPath(
 
 	let resource: InternalResource;
 	try {
-		resource = await internalRouter.resolve(url, { pathOnly: true });
+		resource = await internalRouter.resolve(url, { pathOnly: true, settings });
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new ToolError(`Failed to resolve ${scheme}:// URL in bash command: ${url}\n${message}`);
@@ -268,6 +270,7 @@ export async function expandInternalUrls(command: string, options: InternalUrlEx
 				options.internalRouter,
 				options.localOptions,
 				options.ensureLocalParentDirs,
+				options.settings,
 			);
 		} catch {
 			continue;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -745,6 +745,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				getArtifactsDir: this.session.getArtifactsDir,
 				getSessionId: this.session.getSessionId,
 			},
+			settings: this.session.settings,
 		};
 		command = await expandInternalUrls(command, { ...internalUrlOptions, ensureLocalParentDirs: true });
 		const resolvedEnv = env

--- a/packages/coding-agent/src/tools/learn.ts
+++ b/packages/coding-agent/src/tools/learn.ts
@@ -2,6 +2,7 @@ import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { type } from "arktype";
 import { sanitizeSkillName, writeManagedSkill } from "../autolearn/managed-skills";
 import { isNameClaimedByAuthoredSkill } from "../extensibility/skills";
+import { saveGlobalLearnedLesson } from "../memories";
 import { localBackend } from "../memory-backend/local-backend";
 import learnDescription from "../prompts/tools/learn.md" with { type: "text" };
 import type { ToolSession } from ".";
@@ -9,6 +10,9 @@ import type { ToolSession } from ".";
 const learnSchema = type({
 	memory: type("string").describe("the durable, self-contained lesson to remember (what, when, why)"),
 	"context?": type("string").describe("optional source context for the lesson"),
+	"scope?": type("'project' | 'global'").describe(
+		"where to store the lesson: project (default) or the cross-project global bank (local backend with memory.globalBank enabled; ignored by other backends)",
+	),
 	"skill?": type({
 		action: "'create' | 'update'",
 		name: type("string").describe("kebab-case skill name"),
@@ -79,12 +83,24 @@ export class LearnTool implements AgentTool<typeof learnSchema> {
 				throw new Error("Mnemopi did not store the lesson (no memory id returned).");
 			}
 		} else if (backend === "local") {
-			const result = await localBackend.save?.(
-				{ agentDir: this.session.settings.getAgentDir(), cwd: this.session.settings.getCwd() },
-				{ content: params.memory, context: params.context, source: "coding-agent-learn", importance: 0.8 },
-			);
+			const input = {
+				content: params.memory,
+				context: params.context,
+				source: "coding-agent-learn",
+				importance: 0.8,
+			};
+			const result =
+				params.scope === "global" && this.session.settings.get("memory.globalBank") === true
+					? await saveGlobalLearnedLesson(this.session.settings.getAgentDir(), input)
+					: await localBackend.save?.(
+							{ agentDir: this.session.settings.getAgentDir(), cwd: this.session.settings.getCwd() },
+							input,
+						);
 			if (!result || result.stored === 0) {
 				throw new Error("Lesson was empty after sanitization; nothing stored.");
+			}
+			if (params.scope === "global" && this.session.settings.get("memory.globalBank") !== true) {
+				memoryMessage = "Lesson stored; global bank disabled, stored in project memory";
 			}
 		} else {
 			const state = this.session.getHindsightSessionState?.();

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -7,14 +7,17 @@
  */
 import * as url from "node:url";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
+import { getAgentDir } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../config/settings";
 import {
+	GLOBAL_MEMORY_NAMESPACE,
 	LocalProtocolHandler,
 	memoryRootsFromRegistry,
 	parseInternalUrl,
 	resolveLocalUrlToPath,
 	resolveMemoryUrlToPath,
 } from "../internal-urls";
+import { getGlobalMemoryRoot } from "../memories";
 
 const OSC = "\x1b]";
 const ST = "\x1b\\";
@@ -161,6 +164,11 @@ export function tryResolveInternalUrlSync(input: string): string | undefined {
 		}
 		if (input.startsWith("memory://")) {
 			const url = parseInternalUrl(input);
+			const namespace = url.rawHost || url.hostname;
+			if (namespace === GLOBAL_MEMORY_NAMESPACE) {
+				const agentDir = isSettingsInitialized() ? settings.getAgentDir() : getAgentDir();
+				return resolveMemoryUrlToPath(url, getGlobalMemoryRoot(agentDir));
+			}
 			const roots = memoryRootsFromRegistry();
 			for (const root of roots) {
 				try {

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -5,8 +5,10 @@ import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildMemoryToolDeveloperInstructions,
+	getGlobalMemoryRoot,
 	getMemoryRoot,
 	refreshMemoryToolDeveloperInstructionsCacheAfterStartup,
+	saveGlobalLearnedLesson,
 	saveLearnedLesson,
 } from "@oh-my-pi/pi-coding-agent/memories";
 import { localBackend } from "@oh-my-pi/pi-coding-agent/memory-backend/local-backend";
@@ -234,6 +236,20 @@ describe("learned-lesson read-back", () => {
 		expect(out).toContain("- A captured lesson");
 	});
 
+	it("injects global lessons before project lessons when the global bank is enabled", async () => {
+		const settings = Settings.isolated({ "memory.backend": "local", "memory.globalBank": true });
+		await saveGlobalLearnedLesson(agentDir, { content: "Global baseline lesson" });
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Project-specific lesson" });
+
+		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+
+		expect(out).toContain("memory://global");
+		const globalIndex = out?.indexOf("- Global baseline lesson") ?? -1;
+		const projectIndex = out?.indexOf("- Project-specific lesson") ?? -1;
+		expect(globalIndex).toBeGreaterThanOrEqual(0);
+		expect(projectIndex).toBeGreaterThan(globalIndex);
+	});
+
 	it("returns undefined when the memory backend is off", async () => {
 		const settings = Settings.isolated({ "memory.backend": "local" });
 		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Present but gated" });
@@ -280,19 +296,25 @@ describe("learn tool (local backend)", () => {
 	let agentDir: string;
 	let projCwd: string;
 	let learnedFile: string;
+	let globalLearnedFile: string;
 
 	beforeEach(async () => {
 		tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-learn-local-"));
 		agentDir = path.join(tmp, "agent");
 		projCwd = path.join(tmp, "proj");
 		learnedFile = path.join(getMemoryRoot(agentDir, projCwd), "learned.md");
+		globalLearnedFile = path.join(getGlobalMemoryRoot(agentDir), "learned.md");
 	});
 	afterEach(async () => {
 		await removeWithRetries(tmp);
 	});
 
-	function localSession(): ToolSession {
-		const settings = Settings.isolated({ "autolearn.enabled": true, "memory.backend": "local" });
+	function localSession(overrides: Parameters<typeof Settings.isolated>[0] = {}): ToolSession {
+		const settings = Settings.isolated({
+			"autolearn.enabled": true,
+			"memory.backend": "local",
+			...overrides,
+		});
 		spyOn(settings, "getAgentDir").mockReturnValue(agentDir);
 		spyOn(settings, "getCwd").mockReturnValue(projCwd);
 		return {
@@ -316,6 +338,31 @@ describe("learn tool (local backend)", () => {
 	it("execute writes the lesson to learned.md", async () => {
 		await new LearnTool(localSession()).execute("1", { memory: "A local tool lesson" });
 		expect(await Bun.file(learnedFile).text()).toContain("- A local tool lesson");
+		expect(await Bun.file(globalLearnedFile).exists()).toBe(false);
+	});
+
+	it("execute writes global-scoped lessons to the global bank when enabled", async () => {
+		await new LearnTool(localSession({ "memory.globalBank": true })).execute("global-on", {
+			memory: "A global tool lesson",
+			scope: "global",
+		});
+
+		expect(await Bun.file(globalLearnedFile).text()).toContain("- A global tool lesson");
+		expect(await Bun.file(learnedFile).exists()).toBe(false);
+	});
+
+	it("execute falls back to project memory with a note when global scope is disabled", async () => {
+		const result = await new LearnTool(localSession({ "memory.globalBank": false })).execute("global-off", {
+			memory: "Fallback project lesson",
+			scope: "global",
+		});
+
+		expect(result.content[0]).toEqual({
+			type: "text",
+			text: "Lesson stored; global bank disabled, stored in project memory.",
+		});
+		expect(await Bun.file(learnedFile).text()).toContain("- Fallback project lesson");
+		expect(await Bun.file(globalLearnedFile).exists()).toBe(false);
 	});
 
 	it("execute throws when the lesson is empty after sanitization", async () => {

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -250,6 +250,23 @@ describe("learned-lesson read-back", () => {
 		expect(projectIndex).toBeGreaterThan(globalIndex);
 	});
 
+	it("reserves learned-lesson budget for project lessons when the global bank is large", async () => {
+		const settings = Settings.isolated({
+			"memory.backend": "local",
+			"memory.globalBank": true,
+			"memories.summaryInjectionTokenLimit": 120,
+		});
+		const globalRoot = getGlobalMemoryRoot(agentDir);
+		await fs.mkdir(globalRoot, { recursive: true });
+		await Bun.write(path.join(globalRoot, "learned.md"), `- ${"global baseline ".repeat(500)}\n`);
+		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "PROJECT_MARKER" });
+
+		const out = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+
+		expect(out).toContain("global baseline");
+		expect(out).toContain("PROJECT_MARKER");
+	});
+
 	it("returns undefined when the memory backend is off", async () => {
 		const settings = Settings.isolated({ "memory.backend": "local" });
 		await saveLearnedLesson(agentDir, settings.getCwd(), { content: "Present but gated" });

--- a/packages/coding-agent/test/autolearn-learn-local.test.ts
+++ b/packages/coding-agent/test/autolearn-learn-local.test.ts
@@ -250,6 +250,27 @@ describe("learned-lesson read-back", () => {
 		expect(projectIndex).toBeGreaterThan(globalIndex);
 	});
 
+	it("does not inject cached global lessons after the global bank is disabled", async () => {
+		const enabled = Settings.isolated({ "memory.backend": "local", "memory.globalBank": true });
+		await saveGlobalLearnedLesson(agentDir, { content: "Stale global baseline" });
+		await saveLearnedLesson(agentDir, enabled.getCwd(), { content: "Project lesson stays" });
+
+		const both = await buildMemoryToolDeveloperInstructions(agentDir, enabled);
+		expect(both).toContain("Stale global baseline");
+		expect(both).toContain("Project lesson stays");
+		expect(both).toContain("memory://global");
+
+		const session = sessionWithFile("session-global-disable.jsonl");
+		const disabled = Settings.isolated({ "memory.backend": "local", "memory.globalBank": false });
+		spyOn(disabled, "getCwd").mockReturnValue(enabled.getCwd());
+		await refreshMemoryToolDeveloperInstructionsCacheAfterStartup(session, agentDir, disabled);
+
+		const out = await buildMemoryToolDeveloperInstructions(agentDir, disabled, session);
+		expect(out).toContain("Project lesson stays");
+		expect(out).not.toContain("Stale global baseline");
+		expect(out).not.toContain("memory://global");
+	});
+
 	it("reserves learned-lesson budget for project lessons when the global bank is large", async () => {
 		const settings = Settings.isolated({
 			"memory.backend": "local",

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -92,6 +92,26 @@ describe("MemoryProtocolHandler", () => {
 			expect(resource.content).toBe("- global lesson\n");
 			expect(resource.contentType).toBe("text/markdown");
 			expect(resource.sourcePath).toBe(path.join(globalRoot, "learned.md"));
+		});
+	});
+
+	it("resolves memory://global using the settings-scoped agentDir", async () => {
+		await withMemoryFixture(async ({ agentDir, cleanupRoot }) => {
+			const sessionAgentDir = path.join(cleanupRoot, "session-agent");
+			await fs.mkdir(sessionAgentDir, { recursive: true });
+			const sessionGlobalRoot = getGlobalMemoryRoot(sessionAgentDir);
+			await fs.mkdir(sessionGlobalRoot, { recursive: true });
+			await Bun.write(path.join(sessionGlobalRoot, "learned.md"), "- session global lesson\n");
+
+			const router = InternalUrlRouter.instance();
+			const settings = Settings.isolated({ "memory.backend": "local", "memory.globalBank": true });
+			spyOn(settings, "getAgentDir").mockReturnValue(sessionAgentDir);
+
+			const resource = await router.resolve("memory://global", { settings });
+
+			expect(resource.content).toBe("- session global lesson\n");
+			expect(resource.sourcePath).toBe(path.join(sessionGlobalRoot, "learned.md"));
+			expect(resource.sourcePath).not.toBe(path.join(getGlobalMemoryRoot(agentDir), "learned.md"));
 		});
 	});
 

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { getGlobalMemoryRoot, getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
 import {
@@ -85,11 +86,27 @@ describe("MemoryProtocolHandler", () => {
 			await Bun.write(path.join(globalRoot, "learned.md"), "- global lesson\n");
 
 			const router = InternalUrlRouter.instance();
-			const resource = await router.resolve("memory://global");
+			const settings = Settings.isolated({ "memory.backend": "local", "memory.globalBank": true });
+			const resource = await router.resolve("memory://global", { settings });
 
 			expect(resource.content).toBe("- global lesson\n");
 			expect(resource.contentType).toBe("text/markdown");
 			expect(resource.sourcePath).toBe(path.join(globalRoot, "learned.md"));
+		});
+	});
+
+	it("requires local memory settings with the global bank enabled for memory://global", async () => {
+		await withMemoryFixture(async ({ agentDir }) => {
+			const globalRoot = getGlobalMemoryRoot(agentDir);
+			await fs.mkdir(globalRoot, { recursive: true });
+			await Bun.write(path.join(globalRoot, "learned.md"), "- global lesson\n");
+			const router = InternalUrlRouter.instance();
+			const disabled = Settings.isolated({ "memory.backend": "local", "memory.globalBank": false });
+
+			await expect(router.resolve("memory://global")).rejects.toThrow("memory://global requires local memory");
+			await expect(router.resolve("memory://global", { settings: disabled })).rejects.toThrow(
+				"memory.globalBank enabled",
+			);
 		});
 	});
 

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
-import { getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
+import { getGlobalMemoryRoot, getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
 import {
 	loadMnemopi,
 	loadMnemopiCore,
@@ -78,6 +78,21 @@ describe("MemoryProtocolHandler", () => {
 		});
 	});
 
+	it("resolves memory://global to global learned.md", async () => {
+		await withMemoryFixture(async ({ agentDir }) => {
+			const globalRoot = getGlobalMemoryRoot(agentDir);
+			await fs.mkdir(globalRoot, { recursive: true });
+			await Bun.write(path.join(globalRoot, "learned.md"), "- global lesson\n");
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://global");
+
+			expect(resource.content).toBe("- global lesson\n");
+			expect(resource.contentType).toBe("text/markdown");
+			expect(resource.sourcePath).toBe(path.join(globalRoot, "learned.md"));
+		});
+	});
+
 	it("resolves memory://root/<path> within memory root", async () => {
 		await withMemoryFixture(async ({ memoryRoot }) => {
 			const skillPath = path.join(memoryRoot, "skills", "demo", "SKILL.md");
@@ -96,7 +111,7 @@ describe("MemoryProtocolHandler", () => {
 		await withMemoryFixture(async () => {
 			const router = InternalUrlRouter.instance();
 			await expect(router.resolve("memory://other/memory_summary.md")).rejects.toThrow(
-				/Unknown memory namespace: other\. Supported: root/,
+				/Unknown memory namespace: other\. Supported: root, global/,
 			);
 		});
 	});

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -97,6 +97,23 @@ describe("settings layout", () => {
 		}
 	});
 
+	it("gates the global memory bank setting to the local backend", () => {
+		const def = getSettingsForTab("memory").find(def => def.path === "memory.globalBank");
+
+		expect(def).toMatchObject({
+			path: "memory.globalBank",
+			type: "boolean",
+			tab: "memory",
+			group: "General",
+			label: "Global Memory Bank",
+		});
+		expect(def?.condition?.()).toBe(false);
+
+		Settings.instance.set("memory.backend", "local");
+
+		expect(def?.condition?.()).toBe(true);
+	});
+
 	it("shows provider request limits as a providers services submenu setting", () => {
 		const [def] = getSettingsForTab("providers").filter(item => item.path === "providers.maxInFlightRequests");
 

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -281,6 +281,36 @@ describe("expandInternalUrls", () => {
 		await expect(expandInternalUrls(command, { skills: [], internalRouter: router })).resolves.toBe(command);
 	});
 
+	it("forwards session settings into the internal router resolve context", async () => {
+		const settingsContext = { id: "session-settings" };
+		let receivedSettings: unknown;
+		const internalRouter = {
+			canHandle: (input: string) => input.startsWith("memory://"),
+			resolve: async (input: string, context?: { settings?: unknown }) => {
+				if (context?.settings !== settingsContext) {
+					throw new Error("missing session settings");
+				}
+				receivedSettings = context?.settings;
+				return {
+					url: input,
+					content: "",
+					contentType: "text/plain" as const,
+					sourcePath: "/tmp/memories/global/learned.md",
+					immutable: true,
+				};
+			},
+		};
+
+		await expect(
+			expandInternalUrls("cat memory://global", {
+				skills: [],
+				internalRouter,
+				settings: settingsContext,
+			}),
+		).resolves.toBe(`cat ${shellEscape("/tmp/memories/global/learned.md")}`);
+		expect(receivedSettings).toBe(settingsContext);
+	});
+
 	it("does not match local:/ inside filesystem paths (e.g. /repo/local:/PLAN.md)", async () => {
 		const command = "cat /repo/local:/PLAN.md";
 		await expect(expandInternalUrls(command, { skills: [] })).resolves.toBe(command);

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -1,9 +1,13 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/local-protocol";
+import { getGlobalMemoryRoot, getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import {
 	fileHyperlink,
 	isHyperlinkEnabled,
@@ -13,6 +17,7 @@ import {
 	urlHyperlinkAlways,
 } from "@oh-my-pi/pi-coding-agent/tui/hyperlink";
 import * as terminalCaps from "@oh-my-pi/pi-tui";
+import { getAgentDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 
 // OSC 8 sequence markers
 const OSC = "\x1b]";
@@ -310,5 +315,47 @@ describe("tryResolveInternalUrlSync", () => {
 	it("swallows errors from malformed URLs", () => {
 		// Malformed input should not throw, just return undefined.
 		expect(tryResolveInternalUrlSync("local://%ZZ")).toBeUndefined();
+	});
+
+	it("routes memory://global previews to the global bank root", async () => {
+		const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "hyperlink-memory-global-"));
+		const agentDir = path.join(cleanupRoot, "agent");
+		const projectCwd = path.join(cleanupRoot, "project");
+		await fs.mkdir(agentDir, { recursive: true });
+		await fs.mkdir(projectCwd, { recursive: true });
+
+		const previousAgentDir = getAgentDir();
+		try {
+			setAgentDir(agentDir);
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true, agentDir, cwd: projectCwd });
+
+			AgentRegistry.global().register({
+				id: "test-main",
+				displayName: "test",
+				kind: "main",
+				session: {
+					sessionManager: {
+						getCwd: () => projectCwd,
+						getArtifactsDir: () => null,
+						getSessionId: () => "test",
+					},
+				} as unknown as AgentSession,
+				sessionFile: null,
+			});
+
+			const globalLearned = path.join(getGlobalMemoryRoot(agentDir), "learned.md");
+			const projectLearned = path.join(getMemoryRoot(agentDir, projectCwd), "learned.md");
+			expect(globalLearned).not.toBe(projectLearned);
+			expect(tryResolveInternalUrlSync("memory://global")).toBe(globalLearned);
+			expect(tryResolveInternalUrlSync("memory://global")).not.toBe(projectLearned);
+		} finally {
+			setAgentDir(previousAgentDir);
+			AgentRegistry.resetGlobalForTests();
+			LocalProtocolHandler.resetOverrideForTests();
+			resetSettingsForTest();
+			await Settings.init({ inMemory: true });
+			await removeWithRetries(cleanupRoot);
+		}
 	});
 });


### PR DESCRIPTION
## Summary
Local memory was scoped per project only, so reusable lessons could not be saved into a local cross-project bank.

## Changes
- Add memory.globalBank for local memory mode.
- Add learn scope: "global" and project fallback behavior when the bank is disabled.
- Inject global memories before project memories as baseline context.
- Expose memory://global with the same path safety checks as memory://root.

## Verification
- bun test packages/coding-agent/test/autolearn-learn-local.test.ts packages/coding-agent/test/internal-urls/memory-protocol.test.ts packages/coding-agent/test/modes/components/settings-layout.test.ts — 45 pass, 0 fail
- bun check was also run during publishing and failed on two pre-existing Biome format/organize-import diagnostics in the T1 guided-goal files; targeted unit tests above passed.

Closes #4932
