### PR TITLE
feat(coding-agent): defer MCP connections until tools are needed

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an opt-in local global memory bank. When `memory.backend=local` and `memory.globalBank` is enabled, the `learn` tool can write cross-project lessons with `scope: "global"`, prompt injection reads the global bank before project memory, and `memory://global` resolves the bank's `learned.md`.
+- Added Nomnoml diagram rendering with a `/settings` mode for SVG images, ASCII fallback, or highlighted fences; when active, Nomnoml replaces the Mermaid prompt/rendering hint.
+- Added opt-in lazy MCP discovery (`mcp.lazyDiscovery`) so configured MCP servers can be advertised from config and cached schemas without connecting at startup; matching or calling a lazy tool connects only the selected server on demand.
+- `/guided-goal` now injects project context files (AGENTS.md and the like) as an untrusted `<repository-context>` system block so interview questions and drafted objectives ground in the real repo. Failures and empty projects keep the previous context-free behavior.
+
+### Changed
+
+- Rewrote the `/guided-goal` interviewer rubric around loop-engineering: deterministic success criteria, verification commands, attempt caps, scope boundaries, and stop conditions. Ready objectives must use the five-section structured markdown form.
+
+### Fixed
+
+- Fixed extension `sendUserMessage` throwing `Agent is already processing…` while the agent is streaming: without `deliverAs`, busy messages now queue as a steer. ACP/RPC skill invocations pass `streamingBehavior: "steer"` so they can land mid-turn the same way TUI skill commands do.
+- Fixed autolearn auto-continue firing a capture turn after an aborted stop (Esc/cancel): the controller now skips any `agent_end` whose last assistant message has `stopReason: "aborted"`.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -15,6 +15,8 @@ export interface MCPServer {
 	name: string;
 	/** Whether this server is enabled (default: true) */
 	enabled?: boolean;
+	/** Human-readable server description for lazy discovery summaries */
+	description?: string;
 	/** Connection timeout in milliseconds */
 	timeout?: number;
 	/** Command to run (for stdio transport) */
@@ -61,6 +63,8 @@ export const mcpCapability = defineCapability<MCPServer>({
 	toExtensionId: server => `mcp:${server.name}`,
 	validate: server => {
 		if (!server.name) return "Missing server name";
+		if (server.description !== undefined && typeof server.description !== "string")
+			return "description must be a string";
 		if (!server.command && !server.url) return "Must have command or url";
 
 		// Validate transport-endpoint pairing

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -113,6 +113,10 @@
           "type": "boolean",
           "description": "Whether OMP should try to connect this server."
         },
+        "description": {
+          "type": "string",
+          "description": "Human-readable server description shown in lazy discovery summaries."
+        },
         "timeout": {
           "type": "number",
           "minimum": 0,

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -145,6 +145,10 @@
               "enum": ["stdio"],
               "description": "Default transport when omitted."
             },
+            "description": {
+              "type": "string",
+              "description": "Human-readable server description shown in lazy discovery summaries."
+            },
             "command": {
               "type": "string",
               "minLength": 1,
@@ -187,6 +191,10 @@
               "enum": ["http"],
               "description": "Streamable HTTP transport."
             },
+            "description": {
+              "type": "string",
+              "description": "Human-readable server description shown in lazy discovery summaries."
+            },
             "url": {
               "type": "string",
               "minLength": 1,
@@ -217,6 +225,10 @@
               "type": "string",
               "enum": ["sse"],
               "description": "Legacy SSE transport kept for compatibility. Prefer http for new configs."
+            },
+            "description": {
+              "type": "string",
+              "description": "Human-readable server description shown in lazy discovery summaries."
             },
             "url": {
               "type": "string",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3830,6 +3830,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"mcp.lazyDiscovery": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "Lazy MCP Discovery",
+			description:
+				"Defer MCP server connections until their tools are first needed; the prompt lists servers from config and cached schemas",
+		},
+	},
+
 	"mcp.discoveryDefaultServers": {
 		type: "array",
 		default: [] as string[],

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -157,6 +157,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			result.push({
 				name: serverName,
 				enabled,
+				description: serverConfig.description as string | undefined,
 				timeout,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -25,6 +25,7 @@ interface MCPConfigFile {
 		string,
 		{
 			enabled?: boolean;
+			description?: string;
 			timeout?: number;
 			command?: string;
 			args?: string[];
@@ -86,6 +87,7 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 			const server: MCPServer = {
 				name,
 				enabled,
+				description: typeof serverConfig.description === "string" ? serverConfig.description : undefined,
 				timeout,
 				command: serverConfig.command,
 				args: serverConfig.args,

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -40,6 +40,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 	const transport = server.transport ?? (server.command ? "stdio" : server.url ? "http" : "stdio");
 	const shared = {
 		enabled: server.enabled,
+		description: server.description,
 		timeout: server.timeout,
 		auth: server.auth,
 		oauth: server.oauth,

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -36,7 +36,7 @@ import {
 import { type MCPStoredOAuthCredential, refreshMCPOAuthToken } from "./oauth-flow";
 import type { McpConnectionStatusEvent } from "./startup-events";
 import type { MCPToolDetails } from "./tool-bridge";
-import { createMCPServerToolName, DeferredMCPTool, MCPTool } from "./tool-bridge";
+import { createMCPServerToolName, DeferredMCPTool, MCPTool, sanitizeMCPServerName } from "./tool-bridge";
 import type { MCPToolCache } from "./tool-cache";
 import type {
 	MCPGetPromptResult,
@@ -111,6 +111,25 @@ function trackPromise<T>(promise: Promise<T>): TrackedPromise<T> {
 
 function delay(ms: number): Promise<void> {
 	return Bun.sleep(ms);
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+	if (signal?.aborted) throw abortReason(signal);
+}
+
+function waitForAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+	if (!signal) return promise;
+	throwIfAborted(signal);
+	const aborted = Promise.withResolvers<never>();
+	const onAbort = (): void => aborted.reject(abortReason(signal));
+	signal.addEventListener("abort", onAbort, { once: true });
+	return Promise.race([promise, aborted.promise]).finally(() => {
+		signal.removeEventListener("abort", onAbort);
+	});
 }
 
 /**
@@ -422,44 +441,8 @@ export class MCPManager {
 		};
 	}
 
-	async connectServerOnDemand(name: string): Promise<void> {
-		if (this.#connections.has(name)) return;
-		const pending = this.#pendingOnDemandConnections.get(name);
-		if (pending) return pending;
-		const pendingConnection = this.#pendingConnections.get(name);
-		if (pendingConnection) {
-			const pendingReady = this.#pendingToolLoads.get(name) ?? pendingConnection;
-			const attempt = pendingReady
-				.then(
-					() => {
-						this.#serverErrors.delete(name);
-					},
-					error => {
-						const message = error instanceof Error ? error.message : String(error);
-						this.#serverErrors.set(name, message);
-						throw error;
-					},
-				)
-				.finally(() => {
-					this.#pendingOnDemandConnections.delete(name);
-				});
-			this.#pendingOnDemandConnections.set(name, attempt);
-			return attempt;
-		}
-		const config = this.#serverConfigs.get(name);
-		if (!config) throw new Error(`MCP server not configured: ${name}`);
-		const validationErrors = validateServerConfig(name, config);
-		if (validationErrors.length > 0) {
-			const message = validationErrors.join("; ");
-			this.#serverErrors.set(name, message);
-			throw new Error(message);
-		}
-
-		const source = this.#sources.get(name);
-		const connectEpoch = this.#epoch;
-		const connectionPromise = this.#connectAndWireServer(name, config, source, connectEpoch);
-		this.#pendingConnections.set(name, connectionPromise);
-		const attempt = connectionPromise
+	#trackOnDemandReady(name: string, ready: Promise<unknown>): Promise<void> {
+		const attempt = ready
 			.then(
 				() => {
 					this.#serverErrors.delete(name);
@@ -471,11 +454,43 @@ export class MCPManager {
 				},
 			)
 			.finally(() => {
-				if (this.#pendingConnections.get(name) === connectionPromise) this.#pendingConnections.delete(name);
 				this.#pendingOnDemandConnections.delete(name);
 			});
 		this.#pendingOnDemandConnections.set(name, attempt);
 		return attempt;
+	}
+
+	async connectServerOnDemand(name: string, signal?: AbortSignal): Promise<void> {
+		throwIfAborted(signal);
+		const pending = this.#pendingOnDemandConnections.get(name);
+		if (pending) return waitForAbort(pending, signal);
+		const pendingToolLoad = this.#pendingToolLoads.get(name);
+		if (pendingToolLoad) return waitForAbort(this.#trackOnDemandReady(name, pendingToolLoad), signal);
+		if (this.#connections.has(name)) return;
+		const pendingConnection = this.#pendingConnections.get(name);
+		if (pendingConnection) {
+			const pendingReady = this.#pendingToolLoads.get(name) ?? pendingConnection;
+			return waitForAbort(this.#trackOnDemandReady(name, pendingReady), signal);
+		}
+		const config = this.#serverConfigs.get(name);
+		if (!config) throw new Error(`MCP server not configured: ${name}`);
+		const validationErrors = validateServerConfig(name, config);
+		if (validationErrors.length > 0) {
+			const message = validationErrors.join("; ");
+			this.#serverErrors.set(name, message);
+			throw new Error(message);
+		}
+		const source = this.#sources.get(name);
+		const connectEpoch = this.#epoch;
+		const connectionPromise = this.#connectAndWireServer(name, config, source, connectEpoch);
+		this.#pendingConnections.set(name, connectionPromise);
+		const attempt = this.#trackOnDemandReady(name, connectionPromise);
+		return waitForAbort(
+			attempt.finally(() => {
+				if (this.#pendingConnections.get(name) === connectionPromise) this.#pendingConnections.delete(name);
+			}),
+			signal,
+		);
 	}
 
 	getDeferredDiscoverableTools(): DiscoverableTool[] {
@@ -648,8 +663,17 @@ export class MCPManager {
 			this.#pendingConnections.set(name, connectionPromise);
 
 			const toolsPromise = connectionPromise.then(async connection => {
-				const serverTools = await listTools(connection);
-				return { connection, serverTools };
+				try {
+					const serverTools = await listTools(connection);
+					return { connection, serverTools };
+				} catch (error) {
+					if (this.#connections.get(name) === connection) {
+						connection.transport.onClose = undefined;
+						await connection.transport.close().catch(() => {});
+						if (this.#connections.get(name) === connection) this.#connections.delete(name);
+					}
+					throw error;
+				}
 			});
 			this.#pendingToolLoads.set(name, toolsPromise);
 
@@ -865,6 +889,23 @@ export class MCPManager {
 	 */
 	getSource(name: string): SourceMeta | undefined {
 		return this.#sources.get(name) ?? this.#connections.get(name)?._source;
+	}
+
+	/** Resolve a normalized MCP tool name to the raw configured server name. */
+	resolveServerNameFromToolName(toolName: string): string | undefined {
+		if (!toolName.startsWith("mcp__")) return undefined;
+		const rest = toolName.slice("mcp__".length);
+		let bestName: string | undefined;
+		let bestLength = -1;
+		const candidateNames = new Set([...this.#serverConfigs.keys(), ...this.#connections.keys()]);
+		for (const name of candidateNames) {
+			const sanitized = sanitizeMCPServerName(name);
+			if (rest !== sanitized && !rest.startsWith(`${sanitized}_`)) continue;
+			if (sanitized.length <= bestLength) continue;
+			bestName = name;
+			bestLength = sanitized.length;
+		}
+		return bestName;
 	}
 
 	/**

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -471,6 +471,14 @@ export class MCPManager {
 		throwIfAborted(signal);
 		const pending = this.#pendingOnDemandConnections.get(name);
 		if (pending) return waitForAbort(pending, signal);
+		const pendingReconnect = this.#pendingReconnections.get(name);
+		if (pendingReconnect) {
+			const reconnectReady = pendingReconnect.then(connection => {
+				if (connection) return;
+				throw new Error(this.#serverErrors.get(name) ?? `MCP server failed to reconnect: ${name}`);
+			});
+			return waitForAbort(this.#trackOnDemandReady(name, reconnectReady), signal);
+		}
 		const pendingToolLoad = this.#pendingToolLoads.get(name);
 		if (pendingToolLoad) return waitForAbort(this.#trackOnDemandReady(name, pendingToolLoad), signal);
 		if (this.#connections.has(name)) return;
@@ -1181,6 +1189,7 @@ export class MCPManager {
 			}
 			try {
 				const connection = await this.#connectAndWireServer(name, config, source, reconnectEpoch);
+				this.#serverErrors.delete(name);
 				logger.debug("MCP reconnected", { path: `mcp:${name}`, tools: connection.tools?.length ?? 0 });
 				return connection;
 			} catch (error) {
@@ -1202,6 +1211,7 @@ export class MCPManager {
 					});
 					await Bun.sleep(delays[attempt]);
 				} else {
+					this.#serverErrors.set(name, msg);
 					logger.error("MCP reconnect failed after retries", { path: `mcp:${name}`, error: msg });
 					// Don't remove stale tools — keep them in the registry so they
 					// remain selected. Calls will fail with MCP errors, which

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -426,7 +426,26 @@ export class MCPManager {
 		if (this.#connections.has(name)) return;
 		const pending = this.#pendingOnDemandConnections.get(name);
 		if (pending) return pending;
-
+		const pendingConnection = this.#pendingConnections.get(name);
+		if (pendingConnection) {
+			const pendingReady = this.#pendingToolLoads.get(name) ?? pendingConnection;
+			const attempt = pendingReady
+				.then(
+					() => {
+						this.#serverErrors.delete(name);
+					},
+					error => {
+						const message = error instanceof Error ? error.message : String(error);
+						this.#serverErrors.set(name, message);
+						throw error;
+					},
+				)
+				.finally(() => {
+					this.#pendingOnDemandConnections.delete(name);
+				});
+			this.#pendingOnDemandConnections.set(name, attempt);
+			return attempt;
+		}
 		const config = this.#serverConfigs.get(name);
 		if (!config) throw new Error(`MCP server not configured: ${name}`);
 		const validationErrors = validateServerConfig(name, config);
@@ -872,6 +891,11 @@ export class MCPManager {
 		if (reconnecting) {
 			const result = await reconnecting;
 			if (result) return result;
+		}
+		if (this.#serverConfigs.has(name)) {
+			await this.connectServerOnDemand(name);
+			const connected = this.#connections.get(name);
+			if (connected) return connected;
 		}
 		throw new Error(`MCP server not connected: ${name}`);
 	}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -442,19 +442,26 @@ export class MCPManager {
 	}
 
 	#trackOnDemandReady(name: string, ready: Promise<unknown>): Promise<void> {
-		const attempt = ready
+		let attempt: Promise<void>;
+		attempt = ready
 			.then(
 				() => {
-					this.#serverErrors.delete(name);
+					if (this.#pendingOnDemandConnections.get(name) === attempt) {
+						this.#serverErrors.delete(name);
+					}
 				},
 				error => {
-					const message = error instanceof Error ? error.message : String(error);
-					this.#serverErrors.set(name, message);
+					if (this.#pendingOnDemandConnections.get(name) === attempt) {
+						const message = error instanceof Error ? error.message : String(error);
+						this.#serverErrors.set(name, message);
+					}
 					throw error;
 				},
 			)
 			.finally(() => {
-				this.#pendingOnDemandConnections.delete(name);
+				if (this.#pendingOnDemandConnections.get(name) === attempt) {
+					this.#pendingOnDemandConnections.delete(name);
+				}
 			});
 		this.#pendingOnDemandConnections.set(name, attempt);
 		return attempt;
@@ -495,8 +502,14 @@ export class MCPManager {
 
 	getDeferredDiscoverableTools(): DiscoverableTool[] {
 		const tools: DiscoverableTool[] = [];
-		for (const [name, cachedCount] of this.#deferredServerToolCounts) {
-			if (cachedCount !== null || this.#connections.has(name) || this.#pendingConnections.has(name)) continue;
+		for (const [name, toolCount] of this.#deferredServerToolCounts) {
+			// The sentinel tracks readiness, not connection presence: `null` marks a
+			// cache-miss server whose tools have not finished loading, so keep its
+			// pseudo-entry discoverable while the shared connect/`listTools()` is
+			// still pending (a cancelled search can retry and rejoin it). Any non-null
+			// count — cached, or loaded live including a ready zero-tool server —
+			// means readiness completed, so the entry is hidden.
+			if (toolCount !== null) continue;
 			const config = this.#serverConfigs.get(name);
 			const description = config?.description?.slice(0, 200);
 			tools.push({
@@ -788,6 +801,12 @@ export class MCPManager {
 		// Stable sort by name so reconnect order does not perturb the array.
 		// See `sortMCPToolsByName` for the cache-stability rationale.
 		sortMCPToolsByName(this.#tools);
+		// Mark a deferred server ready once its live tools land. The pseudo-entry
+		// gate in getDeferredDiscoverableTools keys off this sentinel, so recording
+		// the loaded count (including 0) hides it only after readiness completes.
+		if (this.#deferredServerToolCounts.has(name)) {
+			this.#deferredServerToolCounts.set(name, tools.length);
+		}
 	}
 
 	#triggerNotificationRefresh(serverName: string, kind: "tools" | "resources" | "prompts"): void {
@@ -891,16 +910,37 @@ export class MCPManager {
 		return this.#sources.get(name) ?? this.#connections.get(name)?._source;
 	}
 
-	/** Resolve a normalized MCP tool name to the raw configured server name. */
+	/**
+	 * Resolve a normalized MCP tool name to the raw configured server name.
+	 *
+	 * Cached/live tool metadata is authoritative. AgentSession registers tools
+	 * into its name-keyed Map in array order, so the last exact entry is callable;
+	 * resolve collisions to that same owner. The sanitized
+	 * namespace is otherwise ambiguous — a tool `bar_baz` on server `foo`
+	 * normalizes to `mcp__foo_bar_baz`, which a server literally named `foo_bar`
+	 * would appear to own by prefix.
+	 *
+	 * For uncached names (no live tool yet) fall back to the longest configured
+	 * sanitized `<server>_` prefix. A bare `rest === sanitized` is NOT a tool
+	 * match: server-level pseudo-entries use the `mcp__server__<server>` shape, so
+	 * only a real `<server>_<tool>` prefix qualifies. This keeps the existing
+	 * uncached `github` / `github-mcp` longest-match resolution intact.
+	 */
 	resolveServerNameFromToolName(toolName: string): string | undefined {
 		if (!toolName.startsWith("mcp__")) return undefined;
+		for (let index = this.#tools.length - 1; index >= 0; index--) {
+			const tool = this.#tools[index];
+			if (tool?.name !== toolName) continue;
+			const owner = tool.mcpServerName;
+			if (typeof owner === "string" && owner.length > 0) return owner;
+		}
 		const rest = toolName.slice("mcp__".length);
 		let bestName: string | undefined;
 		let bestLength = -1;
 		const candidateNames = new Set([...this.#serverConfigs.keys(), ...this.#connections.keys()]);
 		for (const name of candidateNames) {
 			const sanitized = sanitizeMCPServerName(name);
-			if (rest !== sanitized && !rest.startsWith(`${sanitized}_`)) continue;
+			if (!rest.startsWith(`${sanitized}_`)) continue;
 			if (sanitized.length <= bestLength) continue;
 			bestName = name;
 			bestLength = sanitized.length;
@@ -1193,9 +1233,9 @@ export class MCPManager {
 		connection.config = config;
 		if (source) connection._source = source;
 
-		// Bail out if the server was disconnected or the manager was reset
-		// while we were connecting (e.g. /mcp reload called disconnectAll).
-		if (!this.#serverConfigs.has(name) || this.#epoch !== reconnectEpoch) {
+		// Bail out if disconnect/reload or a same-name replacement superseded
+		// this attempt while its transport was connecting.
+		if (this.#serverConfigs.get(name) !== config || this.#epoch !== reconnectEpoch) {
 			await connection.transport.close().catch(() => {});
 			throw new Error(`Server "${name}" was disconnected during reconnection`);
 		}
@@ -1219,9 +1259,27 @@ export class MCPManager {
 		};
 		try {
 			const serverTools = await listTools(connection);
+			// listTools can outlive disconnect/reload or a same-name replacement.
+			// Publish only if this exact attempt still owns the current config and
+			// connection in the epoch it captured.
+			if (
+				this.#epoch !== reconnectEpoch ||
+				this.#serverConfigs.get(name) !== config ||
+				this.#connections.get(name) !== connection
+			) {
+				throw new Error(`Server "${name}" was disconnected during tool loading`);
+			}
 			const reconnect = () => this.reconnectServer(name);
 			const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
-			void this.toolCache?.set(name, config, serverTools);
+			void this.toolCache?.set(
+				name,
+				config,
+				serverTools,
+				() =>
+					this.#epoch === reconnectEpoch &&
+					this.#serverConfigs.get(name) === config &&
+					this.#connections.get(name) === connection,
+			);
 			this.#replaceServerTools(name, customTools);
 			this.#onToolsChanged?.(this.#tools);
 			void this.#loadServerResourcesAndPrompts(name, connection);
@@ -1230,7 +1288,7 @@ export class MCPManager {
 			// Clean up the connection to avoid zombie transports
 			connection.transport.onClose = undefined;
 			await connection.transport.close().catch(() => {});
-			this.#connections.delete(name);
+			if (this.#connections.get(name) === connection) this.#connections.delete(name);
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -12,6 +12,7 @@ import type { SourceMeta } from "../capability/types";
 import { resolveConfigValue } from "../config/resolve-config-value";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import type { AuthStorage } from "../session/auth-storage";
+import type { DiscoverableTool, DiscoverableToolServerSummary } from "../tool-discovery/tool-index";
 import {
 	connectToServer,
 	disconnectServer,
@@ -35,7 +36,7 @@ import {
 import { type MCPStoredOAuthCredential, refreshMCPOAuthToken } from "./oauth-flow";
 import type { McpConnectionStatusEvent } from "./startup-events";
 import type { MCPToolDetails } from "./tool-bridge";
-import { DeferredMCPTool, MCPTool } from "./tool-bridge";
+import { createMCPServerToolName, DeferredMCPTool, MCPTool } from "./tool-bridge";
 import type { MCPToolCache } from "./tool-cache";
 import type {
 	MCPGetPromptResult,
@@ -156,6 +157,8 @@ export interface MCPDiscoverOptions {
 	filterExa?: boolean;
 	/** Whether to filter out browser MCP servers when builtin browser tool is enabled (default: false) */
 	filterBrowser?: boolean;
+	/** Server names that must connect eagerly even in lazy discovery mode. */
+	discoveryDefaultServers?: readonly string[];
 	/** Called when MCP server connection state changes. */
 	onStatus?: (event: McpConnectionStatusEvent) => void;
 }
@@ -198,6 +201,9 @@ export class MCPManager {
 	#subscribedResources = new Map<string, Set<string>>();
 	#pendingResourceRefresh = new Map<string, { connection: MCPServerConnection; promise: Promise<void> }>();
 	#pendingReconnections = new Map<string, Promise<MCPServerConnection | null>>();
+	#pendingOnDemandConnections = new Map<string, Promise<void>>();
+	#deferredServerToolCounts = new Map<string, number | null>();
+	#serverErrors = new Map<string, string>();
 	/** Preserved configs for reconnection after connection loss. */
 	#serverConfigs = new Map<string, MCPServerConfig>();
 	/**
@@ -333,6 +339,167 @@ export class MCPManager {
 		const result = await this.connectServers(configs, sources, options?.onStatus);
 		result.exaApiKeys = exaApiKeys;
 		return result;
+	}
+
+	/**
+	 * Discover configured MCP servers without connecting to them, except servers
+	 * explicitly listed as discovery defaults. Cached schemas are exposed as
+	 * deferred tools whose first call connects the server on demand; cache misses
+	 * are represented by server-level discoverable pseudo-entries.
+	 */
+	async discoverDeferred(options?: MCPDiscoverOptions): Promise<MCPLoadResult> {
+		let loadedConfigs: LoadMCPConfigsResult;
+		try {
+			loadedConfigs = await loadAllMCPConfigs(this.cwd, {
+				enableProjectConfig: options?.enableProjectConfig,
+				filterExa: options?.filterExa,
+				filterBrowser: options?.filterBrowser,
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			options?.onStatus?.({ type: "failed", serverName: ".mcp.json", error: message });
+			throw error;
+		}
+
+		const { configs, exaApiKeys, sources } = loadedConfigs;
+		const eagerServers = new Set((options?.discoveryDefaultServers ?? []).map(name => name.trim()).filter(Boolean));
+		const eagerConfigs: Record<string, MCPServerConfig> = {};
+		const eagerSources: Record<string, SourceMeta> = {};
+		const deferredTools: CustomTool<TSchema, MCPToolDetails>[] = [];
+		const errors = new Map<string, string>();
+
+		this.#deferredServerToolCounts.clear();
+		this.#serverErrors.clear();
+
+		for (const [name, config] of Object.entries(configs)) {
+			if (sources[name]) this.#sources.set(name, sources[name]);
+			this.#serverConfigs.set(name, config);
+			if (eagerServers.has(name)) {
+				eagerConfigs[name] = config;
+				if (sources[name]) eagerSources[name] = sources[name];
+				continue;
+			}
+
+			const validationErrors = validateServerConfig(name, config);
+			if (validationErrors.length > 0) {
+				const message = validationErrors.join("; ");
+				errors.set(name, message);
+				this.#serverErrors.set(name, message);
+				this.#deferredServerToolCounts.set(name, null);
+				continue;
+			}
+
+			const cached = await this.toolCache?.get(name, config);
+			if (cached && cached.length > 0) {
+				this.#deferredServerToolCounts.set(name, cached.length);
+				const source = this.#sources.get(name);
+				const reconnect = () => this.reconnectServer(name);
+				const getConnection = async () => {
+					await this.connectServerOnDemand(name);
+					return this.waitForConnection(name);
+				};
+				deferredTools.push(...DeferredMCPTool.fromTools(name, cached, getConnection, source, reconnect));
+			} else {
+				this.#deferredServerToolCounts.set(name, null);
+			}
+		}
+
+		let eagerResult: MCPLoadResult | undefined;
+		if (Object.keys(eagerConfigs).length > 0) {
+			eagerResult = await this.connectServers(eagerConfigs, eagerSources, options?.onStatus);
+			for (const [name, message] of eagerResult.errors) errors.set(name, message);
+		}
+
+		const tools = [...(eagerResult?.tools ?? []), ...deferredTools];
+		sortMCPToolsByName(tools);
+		this.#tools = tools;
+
+		return {
+			tools,
+			errors,
+			connectedServers: eagerResult?.connectedServers ?? [],
+			exaApiKeys,
+		};
+	}
+
+	async connectServerOnDemand(name: string): Promise<void> {
+		if (this.#connections.has(name)) return;
+		const pending = this.#pendingOnDemandConnections.get(name);
+		if (pending) return pending;
+
+		const config = this.#serverConfigs.get(name);
+		if (!config) throw new Error(`MCP server not configured: ${name}`);
+		const validationErrors = validateServerConfig(name, config);
+		if (validationErrors.length > 0) {
+			const message = validationErrors.join("; ");
+			this.#serverErrors.set(name, message);
+			throw new Error(message);
+		}
+
+		const source = this.#sources.get(name);
+		const connectEpoch = this.#epoch;
+		const connectionPromise = this.#connectAndWireServer(name, config, source, connectEpoch);
+		this.#pendingConnections.set(name, connectionPromise);
+		const attempt = connectionPromise
+			.then(
+				() => {
+					this.#serverErrors.delete(name);
+				},
+				error => {
+					const message = error instanceof Error ? error.message : String(error);
+					this.#serverErrors.set(name, message);
+					throw error;
+				},
+			)
+			.finally(() => {
+				if (this.#pendingConnections.get(name) === connectionPromise) this.#pendingConnections.delete(name);
+				this.#pendingOnDemandConnections.delete(name);
+			});
+		this.#pendingOnDemandConnections.set(name, attempt);
+		return attempt;
+	}
+
+	getDeferredDiscoverableTools(): DiscoverableTool[] {
+		const tools: DiscoverableTool[] = [];
+		for (const [name, cachedCount] of this.#deferredServerToolCounts) {
+			if (cachedCount !== null || this.#connections.has(name) || this.#pendingConnections.has(name)) continue;
+			const config = this.#serverConfigs.get(name);
+			const description = config?.description?.slice(0, 200);
+			tools.push({
+				name: createMCPServerToolName(name),
+				label: name,
+				summary: description ?? `MCP server "${name}" — tools not yet loaded; searching or calling loads them`,
+				source: "mcp",
+				serverName: name,
+				deferredServer: true,
+				schemaKeys: [],
+			});
+		}
+		return tools;
+	}
+
+	getDiscoverableServerSummaries(): DiscoverableToolServerSummary[] {
+		const summaries: DiscoverableToolServerSummary[] = [];
+		for (const [name, config] of this.#serverConfigs) {
+			const liveToolCount = this.#tools.filter(tool => tool.mcpServerName === name).length;
+			const cachedCount = this.#deferredServerToolCounts.get(name);
+			summaries.push({
+				name,
+				toolCount: liveToolCount || cachedCount || 0,
+				cached: !this.#connections.has(name) && cachedCount !== undefined && cachedCount !== null,
+				deferred: !this.#connections.has(name) && (cachedCount === undefined || cachedCount === null),
+				description: config.description?.slice(0, 200),
+			});
+		}
+		return summaries.sort((left, right) => left.name.localeCompare(right.name));
+	}
+
+	getServerError(name: string): string | undefined {
+		return this.#serverErrors.get(name);
+	}
+
+	isServerDeferred(name: string): boolean {
+		return this.#serverConfigs.has(name) && !this.#connections.has(name) && !this.#pendingConnections.has(name);
 	}
 
 	/**
@@ -741,6 +908,9 @@ export class MCPManager {
 		this.#pendingConnections.delete(name);
 		this.#pendingToolLoads.delete(name);
 		this.#pendingReconnections.delete(name);
+		this.#pendingOnDemandConnections.delete(name);
+		this.#deferredServerToolCounts.delete(name);
+		this.#serverErrors.delete(name);
 		this.#sources.delete(name);
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
@@ -787,9 +957,12 @@ export class MCPManager {
 		this.#pendingConnections.clear();
 		this.#pendingToolLoads.clear();
 		this.#pendingReconnections.clear();
+		this.#pendingOnDemandConnections.clear();
 		this.#pendingResourceRefresh.clear();
 		this.#sources.clear();
 		this.#serverConfigs.clear();
+		this.#deferredServerToolCounts.clear();
+		this.#serverErrors.clear();
 		this.#connections.clear();
 		this.#tools = [];
 		this.#subscribedResources.clear();

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -232,8 +232,12 @@ function sanitizeMCPToolNamePart(value: string, fallback: string): string {
 	return sanitized.length > 0 ? sanitized : fallback;
 }
 
+export function sanitizeMCPServerName(serverName: string): string {
+	return sanitizeMCPToolNamePart(serverName, "server");
+}
+
 export function createMCPToolName(serverName: string, toolName: string): string {
-	const sanitizedServerName = sanitizeMCPToolNamePart(serverName, "server");
+	const sanitizedServerName = sanitizeMCPServerName(serverName);
 	const sanitizedToolName = sanitizeMCPToolNamePart(toolName, "tool");
 
 	// Strip redundant server name prefix from tool name if present
@@ -248,7 +252,7 @@ export function createMCPToolName(serverName: string, toolName: string): string 
 }
 
 export function createMCPServerToolName(serverName: string): string {
-	return `mcp__${sanitizeMCPToolNamePart(serverName, "server")}`;
+	return `mcp__server__${sanitizeMCPServerName(serverName)}`;
 }
 
 /**

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -247,6 +247,10 @@ export function createMCPToolName(serverName: string, toolName: string): string 
 	return `mcp__${sanitizedServerName}_${normalizedToolName}`;
 }
 
+export function createMCPServerToolName(serverName: string): string {
+	return `mcp__${sanitizeMCPToolNamePart(serverName, "server")}`;
+}
+
 /**
  * Parse an MCP tool name back to server and tool components.
  *

--- a/packages/coding-agent/src/mcp/tool-cache.ts
+++ b/packages/coding-agent/src/mcp/tool-cache.ts
@@ -88,7 +88,12 @@ export class MCPToolCache {
 		return parsed.tools as MCPToolDefinition[];
 	}
 
-	async set(serverName: string, config: MCPServerConfig, tools: MCPToolDefinition[]): Promise<void> {
+	async set(
+		serverName: string,
+		config: MCPServerConfig,
+		tools: MCPToolDefinition[],
+		shouldCommit?: () => boolean,
+	): Promise<void> {
 		let configHash: string;
 		try {
 			configHash = await hashConfig(config);
@@ -96,6 +101,7 @@ export class MCPToolCache {
 			logger.warn("MCP tool cache hash failed", { serverName, error: String(error) });
 			return;
 		}
+		if (shouldCommit && !shouldCommit()) return;
 
 		const payload: MCPToolCachePayload = {
 			version: CACHE_VERSION,
@@ -112,6 +118,7 @@ export class MCPToolCache {
 		}
 
 		const expiresAtSec = Math.floor((Date.now() + CACHE_TTL_MS) / 1000);
+		if (shouldCommit && !shouldCommit()) return;
 		this.storage.setCache(cacheKey(serverName), serialized, expiresAtSec);
 	}
 }

--- a/packages/coding-agent/src/mcp/tool-cache.ts
+++ b/packages/coding-agent/src/mcp/tool-cache.ts
@@ -44,8 +44,13 @@ function toHex(buffer: ArrayBuffer): string {
 	return output;
 }
 
+function cacheRelevantConfig(config: MCPServerConfig): Omit<MCPServerConfig, "description"> {
+	const { description: _description, ...cacheRelevant } = config;
+	return cacheRelevant;
+}
+
 async function hashConfig(config: MCPServerConfig): Promise<string> {
-	const stable = stableStringify(config);
+	const stable = stableStringify(cacheRelevantConfig(config));
 	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(stable));
 	return toHex(digest);
 }

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -63,6 +63,8 @@ export interface MCPAuthConfig {
 interface MCPServerConfigBase {
 	/** Whether this server is enabled (default: true) */
 	enabled?: boolean;
+	/** Human-readable server description for discovery summaries */
+	description?: string;
 	/** MCP request timeout in milliseconds (default: 30000, 0 to disable) */
 	timeout?: number;
 	/** Authentication configuration (optional) */

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1154,7 +1154,7 @@ export class MCPCommandController {
 			await addMCPServer(filePath, name, config);
 
 			// Reload MCP manager
-			await this.#reloadMCP();
+			await this.#reloadMCP(config.enabled === false ? undefined : name);
 			const state =
 				config.enabled === false
 					? "disconnected"
@@ -1778,7 +1778,7 @@ export class MCPCommandController {
 				});
 				await updateMCPServer(found.filePath, name, updated);
 			}
-			await this.#reloadMCP();
+			await this.#reloadMCP(name);
 			const state = await this.#waitForServerConnectionWithAnimation(name);
 
 			const lines = [
@@ -1897,17 +1897,32 @@ export class MCPCommandController {
 	/**
 	 * Reload MCP manager with new configs
 	 */
-	async #reloadMCP(): Promise<void> {
+	async #reloadMCP(targetServer?: string): Promise<void> {
 		if (!this.ctx.mcpManager) {
 			return;
 		}
+		const manager = this.ctx.mcpManager;
 
 		// Disconnect all existing servers
-		await this.ctx.mcpManager.disconnectAll();
+		await manager.disconnectAll();
 
-		// Rediscover and connect
-		const result = await this.ctx.mcpManager.discoverAndConnect();
-		await this.ctx.session.refreshMCPTools(this.ctx.mcpManager.getTools());
+		// Honor mcp.lazyDiscovery: a reload must not eagerly spawn every
+		// configured server. discoverDeferred re-reads config and re-exposes
+		// cached schemas + server pseudo-entries without connecting. A command
+		// that needs one server live (add/reauth) passes targetServer so only
+		// that server connects on demand; its failure folds into the same error
+		// map discoverAndConnect would have surfaced. Plain reload/remove/unauth
+		// pass no target, so lazy policy reconnects nothing they don't need.
+		const lazyDiscovery = this.ctx.settings.get("mcp.lazyDiscovery") === true;
+		const result = lazyDiscovery ? await manager.discoverDeferred() : await manager.discoverAndConnect();
+		if (lazyDiscovery && targetServer && manager.getServerConfig(targetServer)) {
+			try {
+				await manager.connectServerOnDemand(targetServer);
+			} catch (error) {
+				result.errors.set(targetServer, error instanceof Error ? error.message : String(error));
+			}
+		}
+		await this.ctx.session.refreshMCPTools(manager.getTools());
 
 		this.#showMCPConnectionErrors(result.errors);
 	}

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1908,14 +1908,25 @@ export class MCPCommandController {
 
 		// Honor mcp.lazyDiscovery: a reload must not eagerly spawn every
 		// configured server. discoverDeferred re-reads config and re-exposes
-		// cached schemas + server pseudo-entries without connecting. A command
-		// that needs one server live (add/reauth) passes targetServer so only
-		// that server connects on demand; its failure folds into the same error
-		// map discoverAndConnect would have surfaced. Plain reload/remove/unauth
-		// pass no target, so lazy policy reconnects nothing they don't need.
+		// cached schemas + server pseudo-entries while eagerly connecting only
+		// configured discovery defaults. A command that needs one non-default
+		// server live (add/reauth) passes targetServer so only that server connects
+		// on demand; its failure folds into the same error map discoverAndConnect
+		// would have surfaced. Plain reload/remove/unauth pass no target beyond the
+		// configured defaults.
 		const lazyDiscovery = this.ctx.settings.get("mcp.lazyDiscovery") === true;
-		const result = lazyDiscovery ? await manager.discoverDeferred() : await manager.discoverAndConnect();
-		if (lazyDiscovery && targetServer && manager.getServerConfig(targetServer)) {
+		const discoveryDefaultServers = (this.ctx.settings.get("mcp.discoveryDefaultServers") ?? [])
+			.map(name => name.trim())
+			.filter(Boolean);
+		const result = lazyDiscovery
+			? await manager.discoverDeferred({ discoveryDefaultServers })
+			: await manager.discoverAndConnect();
+		if (
+			lazyDiscovery &&
+			targetServer &&
+			!discoveryDefaultServers.includes(targetServer) &&
+			manager.getServerConfig(targetServer)
+		) {
 			try {
 				await manager.connectServerOnDemand(targetServer);
 			} catch (error) {

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1303,7 +1303,9 @@ export class MCPCommandController {
 					const state =
 						config.enabled === false
 							? "inactive"
-							: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
+							: this.ctx.mcpManager?.isServerDeferred(name)
+								? "deferred"
+								: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
 					const status =
 						state === "inactive"
 							? theme.fg("warning", " ◌ inactive")
@@ -1311,7 +1313,9 @@ export class MCPCommandController {
 								? theme.fg("success", " ● connected")
 								: state === "connecting"
 									? theme.fg("muted", " ◌ connecting")
-									: theme.fg("muted", " ○ not connected");
+									: state === "deferred"
+										? theme.fg("muted", " ◌ deferred")
+										: theme.fg("muted", " ○ not connected");
 					lines.push(`  ${theme.fg("accent", name)}${status} ${theme.fg("dim", `[${type}]`)}`);
 				}
 				lines.push("");
@@ -1326,7 +1330,9 @@ export class MCPCommandController {
 					const state =
 						config.enabled === false
 							? "inactive"
-							: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
+							: this.ctx.mcpManager?.isServerDeferred(name)
+								? "deferred"
+								: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
 					const status =
 						state === "inactive"
 							? theme.fg("warning", " ◌ inactive")
@@ -1334,7 +1340,9 @@ export class MCPCommandController {
 								? theme.fg("success", " ● connected")
 								: state === "connecting"
 									? theme.fg("muted", " ◌ connecting")
-									: theme.fg("muted", " ○ not connected");
+									: state === "deferred"
+										? theme.fg("muted", " ◌ deferred")
+										: theme.fg("muted", " ○ not connected");
 					lines.push(`  ${theme.fg("accent", name)}${status} ${theme.fg("dim", `[${type}]`)}`);
 				}
 				lines.push("");
@@ -1343,15 +1351,19 @@ export class MCPCommandController {
 			// Show discovered servers (from .claude.json, .cursor/mcp.json, .vscode/mcp.json, etc.)
 			if (discoveredServers.length > 0) {
 				for (const { providerName, shortPath, items: entries } of groupBySource(discoveredServers, e => e.source)) {
+					const manager = this.ctx.mcpManager;
+					if (!manager) continue;
 					lines.push(theme.fg("accent", providerName) + theme.fg("muted", ` (${shortPath}):`));
 					for (const { name } of entries) {
-						const state = this.ctx.mcpManager!.getConnectionStatus(name);
+						const state = manager.isServerDeferred(name) ? "deferred" : manager.getConnectionStatus(name);
 						const status =
 							state === "connected"
 								? theme.fg("success", " ● connected")
 								: state === "connecting"
 									? theme.fg("muted", " ◌ connecting")
-									: theme.fg("muted", " ○ not connected");
+									: state === "deferred"
+										? theme.fg("muted", " ◌ deferred")
+										: theme.fg("muted", " ○ not connected");
 						lines.push(`  ${theme.fg("accent", name)}${status}`);
 					}
 					lines.push("");

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -366,6 +366,37 @@ function collectPendingMCPToolNames(
 	return [...names];
 }
 
+function collectMCPServerNames(toolNames: readonly string[]): string[] {
+	const serverNames = new Set<string>();
+	for (const name of toolNames) {
+		const parsed = parseMCPToolName(name);
+		if (parsed?.serverName) serverNames.add(parsed.serverName);
+	}
+	return [...serverNames];
+}
+
+function startLazyMCPConnectionsForToolNames(
+	mcpManager: MCPManager,
+	session: AgentSession,
+	toolNames: readonly string[],
+): void {
+	for (const serverName of collectMCPServerNames(toolNames)) {
+		if (mcpManager.getConnection(serverName) || !mcpManager.getServerConfig(serverName)) continue;
+		void mcpManager
+			.connectServerOnDemand(serverName)
+			.then(async () => {
+				if (session.isDisposed) return;
+				await session.refreshMCPTools(mcpManager.getTools());
+			})
+			.catch(error => {
+				logger.warn("Lazy MCP connection failed", {
+					path: `mcp:${serverName}`,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+	}
+}
+
 function logMCPLoadErrors(errors: MCPLoadResult["errors"]): void {
 	for (const [serverName, error] of errors) {
 		logger.error("MCP tool load failed", { path: `mcp:${serverName}`, error });
@@ -3151,6 +3182,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					}, debounceMs),
 				);
 			});
+		}
+		if (mcpManager && lazyMCPDiscovery) {
+			const requestedOrRestoredMCPToolNames = collectPendingMCPToolNames(
+				options.toolNames,
+				existingSession.selectedMCPToolNames,
+			);
+			if (requestedOrRestoredMCPToolNames.length > 0) {
+				startLazyMCPConnectionsForToolNames(mcpManager, session, requestedOrRestoredMCPToolNames);
+			}
 		}
 
 		startDeferredMCPDiscovery?.(session, {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -366,11 +366,11 @@ function collectPendingMCPToolNames(
 	return [...names];
 }
 
-function collectMCPServerNames(toolNames: readonly string[]): string[] {
+function collectMCPServerNames(mcpManager: MCPManager, toolNames: readonly string[]): string[] {
 	const serverNames = new Set<string>();
 	for (const name of toolNames) {
-		const parsed = parseMCPToolName(name);
-		if (parsed?.serverName) serverNames.add(parsed.serverName);
+		const serverName = mcpManager.resolveServerNameFromToolName(name);
+		if (serverName) serverNames.add(serverName);
 	}
 	return [...serverNames];
 }
@@ -379,15 +379,25 @@ function startLazyMCPConnectionsForToolNames(
 	mcpManager: MCPManager,
 	session: AgentSession,
 	toolNames: readonly string[],
+	enqueueMCPUpdate: (update: () => Promise<void>) => Promise<void>,
 ): void {
-	for (const serverName of collectMCPServerNames(toolNames)) {
-		if (mcpManager.getConnection(serverName) || !mcpManager.getServerConfig(serverName)) continue;
+	for (const serverName of collectMCPServerNames(mcpManager, toolNames)) {
+		if (!mcpManager.getServerConfig(serverName)) continue;
+		const requestedToolNamesForServer = toolNames.filter(
+			name => mcpManager.resolveServerNameFromToolName(name) === serverName,
+		);
 		void mcpManager
 			.connectServerOnDemand(serverName)
-			.then(async () => {
-				if (session.isDisposed) return;
-				await session.refreshMCPTools(mcpManager.getTools());
-			})
+			.then(() =>
+				enqueueMCPUpdate(async () => {
+					if (session.isDisposed) return;
+					await session.refreshMCPTools(mcpManager.getTools());
+					if (session.isDisposed) return;
+					if (requestedToolNamesForServer.length > 0) {
+						await session.activateDiscoveredMCPTools(requestedToolNamesForServer);
+					}
+				}),
+			)
 			.catch(error => {
 				logger.warn("Lazy MCP connection failed", {
 					path: `mcp:${serverName}`,
@@ -1746,12 +1756,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 				if (lazyMCPDiscovery) {
 					const lazyManager = mcpManager;
-					const mcpResult = await logger.time("discoverDeferredMCPTools", () =>
-						lazyManager.discoverDeferred(mcpDiscoverOptions),
-					);
-					applyMCPEnvironment(mcpResult);
-					logMCPLoadErrors(mcpResult.errors);
-					customTools.push(...mcpResult.tools);
+					try {
+						const mcpResult = await logger.time("discoverDeferredMCPTools", () =>
+							lazyManager.discoverDeferred(mcpDiscoverOptions),
+						);
+						applyMCPEnvironment(mcpResult);
+						logMCPLoadErrors(mcpResult.errors);
+						customTools.push(...mcpResult.tools);
+					} catch (error) {
+						logger.error("MCP tool load failed", {
+							path: ".mcp.json",
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
 				} else {
 					const deferredMCPManager = mcpManager;
 					startDeferredMCPDiscovery = (liveSession, activation) => {
@@ -1840,12 +1857,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						mcpManager.setNotificationsEnabled(true);
 					}
 					const lazyManager = mcpManager;
-					const mcpResult = await logger.time("discoverDeferredMCPTools", () =>
-						lazyManager.discoverDeferred(mcpDiscoverOptions),
-					);
-					applyMCPEnvironment(mcpResult);
-					logMCPLoadErrors(mcpResult.errors);
-					customTools.push(...mcpResult.tools);
+					try {
+						const mcpResult = await logger.time("discoverDeferredMCPTools", () =>
+							lazyManager.discoverDeferred(mcpDiscoverOptions),
+						);
+						applyMCPEnvironment(mcpResult);
+						logMCPLoadErrors(mcpResult.errors);
+						customTools.push(...mcpResult.tools);
+					} catch (error) {
+						logger.error("MCP tool load failed", {
+							path: ".mcp.json",
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
 				} else {
 					const mcpResult = await logger.time("discoverAndLoadMCPTools", discoverAndLoadMCPTools, cwd, {
 						...mcpDiscoverOptions,
@@ -3130,28 +3154,34 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 		// Wire MCP manager callbacks to session for reactive tool updates.
 		// Skip when reusing a parent's manager — the parent owns the callbacks.
+		let mcpToolUpdateTail: Promise<void> = Promise.resolve();
+		const enqueueMCPUpdate = (update: () => Promise<void>): Promise<void> => {
+			const queued = mcpToolUpdateTail.then(update);
+			mcpToolUpdateTail = queued.catch(() => {});
+			return queued;
+		};
 		if (mcpManager && !options.mcpManager) {
 			mcpManager.setOnToolsChanged(tools => {
-				void (async () => {
-					try {
-						await session.refreshMCPTools(
-							tools,
-							deferMCPDiscoveryForUI && !mcpDiscoveryEnabled && options.toolNames === undefined
-								? { activateAll: true }
-								: undefined,
-						);
-						if (deferMCPDiscoveryForUI && !mcpDiscoveryEnabled && explicitlyRequestedMCPToolNames.length > 0) {
-							await session.setActiveToolsByName([
-								...session.getActiveToolNames(),
-								...explicitlyRequestedMCPToolNames,
-							]);
-						}
-					} catch (error) {
-						logger.warn("MCP tool refresh failed", {
-							error: error instanceof Error ? error.message : String(error),
-						});
+				void enqueueMCPUpdate(async () => {
+					if (session.isDisposed) return;
+					await session.refreshMCPTools(
+						tools,
+						deferMCPDiscoveryForUI && !mcpDiscoveryEnabled && options.toolNames === undefined
+							? { activateAll: true }
+							: undefined,
+					);
+					if (session.isDisposed) return;
+					if (deferMCPDiscoveryForUI && !mcpDiscoveryEnabled && explicitlyRequestedMCPToolNames.length > 0) {
+						await session.setActiveToolsByName([
+							...session.getActiveToolNames(),
+							...explicitlyRequestedMCPToolNames,
+						]);
 					}
-				})();
+				}).catch(error => {
+					logger.warn("MCP tool refresh failed", {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
 			});
 			// Wire prompt refresh → rebuild MCP prompt slash commands
 			mcpManager.setOnPromptsChanged(serverName => {
@@ -3189,7 +3219,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				existingSession.selectedMCPToolNames,
 			);
 			if (requestedOrRestoredMCPToolNames.length > 0) {
-				startLazyMCPConnectionsForToolNames(mcpManager, session, requestedOrRestoredMCPToolNames);
+				startLazyMCPConnectionsForToolNames(mcpManager, session, requestedOrRestoredMCPToolNames, enqueueMCPUpdate);
 			}
 		}
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1592,6 +1592,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			isMCPDiscoveryEnabled: () => session.isMCPDiscoveryEnabled(),
 			getSelectedMCPToolNames: () => session.getSelectedMCPToolNames(),
 			activateDiscoveredMCPTools: toolNames => session.activateDiscoveredMCPTools(toolNames),
+			refreshMCPTools: tools => session.refreshMCPTools(tools),
 			// Generic tool discovery (unified — covers built-in + MCP + extension)
 			isToolDiscoveryEnabled: () => session.isToolDiscoveryEnabled(),
 			getDiscoverableTools: filter => session.getDiscoverableTools(filter),
@@ -1680,6 +1681,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		toolSession.mcpManager = mcpManager;
 		const enableMCP = options.enableMCP ?? true;
 		const deferMCPDiscoveryForUI = enableMCP && !mcpManager && options.hasUI === true;
+		const lazyMCPDiscovery = settings.get("mcp.lazyDiscovery") === true;
+		const lazyMCPDiscoveryDefaultServers = settings.get("mcp.discoveryDefaultServers") ?? [];
 		const customTools: CustomTool[] = [];
 		let startDeferredMCPDiscovery:
 			| ((liveSession: AgentSession, activation: DeferredMCPActivation) => void)
@@ -1697,6 +1700,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			filterExa: true,
 			// Filter browser MCP servers when builtin browser tool is active
 			filterBrowser: settings.get("browser.enabled") ?? false,
+			discoveryDefaultServers: lazyMCPDiscoveryDefaultServers,
 		};
 		if (enableMCP && !mcpManager) {
 			if (deferMCPDiscoveryForUI) {
@@ -1709,97 +1713,131 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					mcpManager.setNotificationsEnabled(true);
 				}
 
-				const deferredMCPManager = mcpManager;
-				startDeferredMCPDiscovery = (liveSession, activation) => {
-					void (async () => {
-						try {
-							const mcpResult = await logger.time("discoverAndLoadMCPTools", () =>
-								deferredMCPManager.discoverAndConnect(mcpDiscoverOptions),
-							);
-							// The session can be torn down while servers are still connecting.
-							// Don't resurrect tools on a disposed session, and don't leak the
-							// transports/subprocesses the connect just spawned.
-							if (liveSession.isDisposed) {
-								await deferredMCPManager.disconnectAll();
-								return;
-							}
-							applyMCPEnvironment(mcpResult);
-							logMCPLoadErrors(mcpResult.errors);
-							// `tools.discoveryMode: "auto"` was resolved against a registry that
-							// held only built-ins plus persisted placeholder names. Recompute with
-							// the real MCP tool count: a large toolset must flip discovery on
-							// BEFORE the refresh, or activateAll would dump every MCP tool into
-							// the active set with no search_tool_bm25 registered.
-							let discoveryEnabled = activation.mcpDiscoveryEnabled;
-							let activateAll = activation.activateAllMCPTools;
-							if (!discoveryEnabled) {
-								const nonMCPToolNames = [...toolRegistry.keys()].filter(name => !isMCPToolName(name));
-								const projectedMode = resolveEffectiveToolDiscoveryMode(
-									settings,
-									countToolsForAutoDiscovery([...nonMCPToolNames, ...mcpResult.tools.map(tool => tool.name)]),
+				if (lazyMCPDiscovery) {
+					const lazyManager = mcpManager;
+					const mcpResult = await logger.time("discoverDeferredMCPTools", () =>
+						lazyManager.discoverDeferred(mcpDiscoverOptions),
+					);
+					applyMCPEnvironment(mcpResult);
+					logMCPLoadErrors(mcpResult.errors);
+					customTools.push(...mcpResult.tools);
+				} else {
+					const deferredMCPManager = mcpManager;
+					startDeferredMCPDiscovery = (liveSession, activation) => {
+						void (async () => {
+							try {
+								const mcpResult = await logger.time("discoverAndLoadMCPTools", () =>
+									deferredMCPManager.discoverAndConnect(mcpDiscoverOptions),
 								);
-								if (projectedMode !== "off") {
-									effectiveDiscoveryMode = projectedMode;
-									mcpDiscoveryEnabled = true;
-									discoveryEnabled = true;
-									activateAll = false;
-									liveSession.enableMCPDiscovery();
-									if (!toolRegistry.has("search_tool_bm25")) {
-										const searchTool: Tool = new SearchToolBm25Tool(toolSession);
-										toolRegistry.set(
-											searchTool.name,
-											new ExtensionToolWrapper(wrapToolWithMetaNotice(searchTool), extensionRunner) as Tool,
-										);
+								// The session can be torn down while servers are still connecting.
+								// Don't resurrect tools on a disposed session, and don't leak the
+								// transports/subprocesses the connect just spawned.
+								if (liveSession.isDisposed) {
+									await deferredMCPManager.disconnectAll();
+									return;
+								}
+								applyMCPEnvironment(mcpResult);
+								logMCPLoadErrors(mcpResult.errors);
+								// `tools.discoveryMode: "auto"` was resolved against a registry that
+								// held only built-ins plus persisted placeholder names. Recompute with
+								// the real MCP tool count: a large toolset must flip discovery on
+								// BEFORE the refresh, or activateAll would dump every MCP tool into
+								// the active set with no search_tool_bm25 registered.
+								let discoveryEnabled = activation.mcpDiscoveryEnabled;
+								let activateAll = activation.activateAllMCPTools;
+								if (!discoveryEnabled) {
+									const nonMCPToolNames = [...toolRegistry.keys()].filter(name => !isMCPToolName(name));
+									const projectedMode = resolveEffectiveToolDiscoveryMode(
+										settings,
+										countToolsForAutoDiscovery([
+											...nonMCPToolNames,
+											...mcpResult.tools.map(tool => tool.name),
+										]),
+									);
+									if (projectedMode !== "off") {
+										effectiveDiscoveryMode = projectedMode;
+										mcpDiscoveryEnabled = true;
+										discoveryEnabled = true;
+										activateAll = false;
+										liveSession.enableMCPDiscovery();
+										if (!toolRegistry.has("search_tool_bm25")) {
+											const searchTool: Tool = new SearchToolBm25Tool(toolSession);
+											toolRegistry.set(
+												searchTool.name,
+												new ExtensionToolWrapper(
+													wrapToolWithMetaNotice(searchTool),
+													extensionRunner,
+												) as Tool,
+											);
+										}
+										await liveSession.setActiveToolsByName([
+											...liveSession.getActiveToolNames(),
+											"search_tool_bm25",
+										]);
 									}
-									await liveSession.setActiveToolsByName([
-										...liveSession.getActiveToolNames(),
-										"search_tool_bm25",
-									]);
 								}
-							}
-							await liveSession.refreshMCPTools(mcpResult.tools, { activateAll });
-							if (activation.explicitlyRequestedMCPToolNames.length > 0) {
-								if (discoveryEnabled && !activation.mcpDiscoveryEnabled) {
-									// Discovery flipped on mid-flight: route the explicit request
-									// through discovery-aware activation so selection persists.
-									await liveSession.activateDiscoveredMCPTools(activation.explicitlyRequestedMCPToolNames);
-								} else if (!discoveryEnabled) {
-									await liveSession.setActiveToolsByName([
-										...liveSession.getActiveToolNames(),
-										...activation.explicitlyRequestedMCPToolNames,
-									]);
+								await liveSession.refreshMCPTools(mcpResult.tools, { activateAll });
+								if (activation.explicitlyRequestedMCPToolNames.length > 0) {
+									if (discoveryEnabled && !activation.mcpDiscoveryEnabled) {
+										// Discovery flipped on mid-flight: route the explicit request
+										// through discovery-aware activation so selection persists.
+										await liveSession.activateDiscoveredMCPTools(activation.explicitlyRequestedMCPToolNames);
+									} else if (!discoveryEnabled) {
+										await liveSession.setActiveToolsByName([
+											...liveSession.getActiveToolNames(),
+											...activation.explicitlyRequestedMCPToolNames,
+										]);
+									}
 								}
+							} catch (error) {
+								logger.error("MCP tool load failed", {
+									path: ".mcp.json",
+									error: error instanceof Error ? error.message : String(error),
+								});
 							}
-						} catch (error) {
-							logger.error("MCP tool load failed", {
-								path: ".mcp.json",
-								error: error instanceof Error ? error.message : String(error),
-							});
-						}
-					})();
-				};
+						})();
+					};
+				}
 			} else {
-				const mcpResult = await logger.time("discoverAndLoadMCPTools", discoverAndLoadMCPTools, cwd, {
-					...mcpDiscoverOptions,
-					cacheStorage: settings.getStorage(),
-					authStorage,
-				});
-				mcpManager = mcpResult.manager;
-				toolSession.mcpManager = mcpManager;
+				if (lazyMCPDiscovery) {
+					const cacheStorage = settings.getStorage();
+					mcpManager = new MCPManager(cwd, cacheStorage ? new MCPToolCache(cacheStorage) : null);
+					mcpManager.setAuthStorage(authStorage);
+					toolSession.mcpManager = mcpManager;
 
-				if (settings.get("mcp.notifications")) {
-					mcpManager.setNotificationsEnabled(true);
-				}
-				applyMCPEnvironment(mcpResult);
+					if (settings.get("mcp.notifications")) {
+						mcpManager.setNotificationsEnabled(true);
+					}
+					const lazyManager = mcpManager;
+					const mcpResult = await logger.time("discoverDeferredMCPTools", () =>
+						lazyManager.discoverDeferred(mcpDiscoverOptions),
+					);
+					applyMCPEnvironment(mcpResult);
+					logMCPLoadErrors(mcpResult.errors);
+					customTools.push(...mcpResult.tools);
+				} else {
+					const mcpResult = await logger.time("discoverAndLoadMCPTools", discoverAndLoadMCPTools, cwd, {
+						...mcpDiscoverOptions,
+						cacheStorage: settings.getStorage(),
+						authStorage,
+					});
+					mcpManager = mcpResult.manager;
+					toolSession.mcpManager = mcpManager;
 
-				// Log MCP errors
-				for (const { path, error } of mcpResult.errors) {
-					logger.error("MCP tool load failed", { path, error });
-				}
+					if (settings.get("mcp.notifications")) {
+						mcpManager.setNotificationsEnabled(true);
+					}
+					applyMCPEnvironment(mcpResult);
 
-				if (mcpResult.tools.length > 0) {
-					// MCP tools are LoadedCustomTool, extract the tool property
-					customTools.push(...mcpResult.tools.map(loaded => loaded.tool));
+					// Log MCP errors
+					for (const { path, error } of mcpResult.errors) {
+						logger.error("MCP tool load failed", { path, error });
+					}
+
+					if (mcpResult.tools.length > 0) {
+						// MCP tools are LoadedCustomTool, extract the tool property
+						customTools.push(...mcpResult.tools.map(loaded => loaded.tool));
+					}
 				}
 			}
 		}
@@ -2330,7 +2368,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		): Promise<BuildSystemPromptResult> => {
 			toolContextStore.setToolNames(toolNames);
 			const discoverableMCPTools: DiscoverableTool[] = mcpDiscoveryEnabled
-				? filterBySource(collectDiscoverableTools(tools.values()), "mcp")
+				? [
+						...filterBySource(collectDiscoverableTools(tools.values()), "mcp"),
+						...(mcpManager?.getDeferredDiscoverableTools() ?? []),
+					]
 				: [];
 			const activeToolNames = new Set(toolNames);
 			const discoverableBuiltinTools: DiscoverableTool[] =
@@ -2344,10 +2385,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					: [];
 			const discoverableToolsForDesc: DiscoverableTool[] = [...discoverableBuiltinTools, ...discoverableMCPTools];
 			const discoverableToolSummary = summarizeDiscoverableTools(discoverableToolsForDesc);
+			const lazyMcpServerSummaries = lazyMCPDiscovery
+				? (mcpManager?.getDiscoverableServerSummaries() ?? [])
+				: undefined;
+			const promptMcpServerSummaries = lazyMcpServerSummaries ?? discoverableToolSummary.servers;
 			const hasDiscoverableTools =
-				mcpDiscoveryEnabled && toolNames.includes("search_tool_bm25") && discoverableToolsForDesc.length > 0;
+				mcpDiscoveryEnabled &&
+				toolNames.includes("search_tool_bm25") &&
+				(discoverableToolsForDesc.length > 0 || promptMcpServerSummaries.length > 0);
 			const promptTools = buildSystemPromptToolMetadata(tools, {
-				search_tool_bm25: { description: renderSearchToolBm25Description(discoverableToolsForDesc) },
+				search_tool_bm25: {
+					description: renderSearchToolBm25Description(discoverableToolsForDesc, promptMcpServerSummaries),
+				},
 			});
 			const memoryBackend = await resolveMemoryBackend(settings);
 			const memoryInstructions = await memoryBackend.buildDeveloperInstructions(agentDir, settings, session);
@@ -2411,7 +2460,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				nativeTools,
 				intentField,
 				mcpDiscoveryMode: hasDiscoverableTools,
-				mcpDiscoveryServerSummaries: discoverableToolSummary.servers.map(formatDiscoverableToolServerSummary),
+				mcpDiscoveryServerSummaries: promptMcpServerSummaries.map(formatDiscoverableToolServerSummary),
 				eagerTasks,
 				eagerTasksAlways,
 				taskBatch: settings.get("task.batch"),
@@ -2480,7 +2529,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			? requestedActiveToolNames.filter(name => name.startsWith("mcp__"))
 			: [];
 		const discoveryDefaultServers = new Set(
-			(settings.get("mcp.discoveryDefaultServers") ?? []).map(serverName => serverName.trim()).filter(Boolean),
+			lazyMCPDiscoveryDefaultServers.map(serverName => serverName.trim()).filter(Boolean),
 		);
 		const discoveryDefaultServerToolNames = mcpDiscoveryEnabled
 			? selectDiscoverableToolNamesByServer(
@@ -2877,6 +2926,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						return out;
 					}
 				: undefined,
+			getDeferredDiscoverableMCPTools: mcpManager ? () => mcpManager.getDeferredDiscoverableTools() : undefined,
 			disconnectOwnedMcpManager: ownedMcpManager ? () => ownedMcpManager.disconnectAll() : undefined,
 			mcpDiscoveryEnabled,
 			initialSelectedMCPToolNames,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -747,6 +747,8 @@ export interface AgentSessionConfig {
 	 * signature comparison and silently keep a stale prompt cached.
 	 */
 	getMcpServerInstructions?: () => Map<string, string> | undefined;
+	/** Lazy MCP server pseudo-entries for configured servers whose tools are not loaded yet. */
+	getDeferredDiscoverableMCPTools?: () => DiscoverableTool[];
 	/** Enable hidden-by-default MCP tool discovery for this session. */
 	mcpDiscoveryEnabled?: boolean;
 	/** MCP tool names to activate for the current session when discovery mode is enabled. */
@@ -1733,6 +1735,7 @@ export class AgentSession {
 		| undefined;
 	#getLocalCalendarDate: () => string;
 	#getMcpServerInstructions: (() => Map<string, string> | undefined) | undefined;
+	#getDeferredDiscoverableMCPTools: (() => DiscoverableTool[]) | undefined;
 	#reloadSshTool: (() => Promise<AgentTool | null>) | undefined;
 	#setActiveToolNames: ((names: Iterable<string>) => void) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
@@ -2180,6 +2183,7 @@ export class AgentSession {
 		this.#rebuildSystemPrompt = config.rebuildSystemPrompt;
 		this.#getLocalCalendarDate = config.getLocalCalendarDate ?? formatLocalCalendarDate;
 		this.#getMcpServerInstructions = config.getMcpServerInstructions;
+		this.#getDeferredDiscoverableMCPTools = config.getDeferredDiscoverableMCPTools;
 		this.#reloadSshTool = config.reloadSshTool;
 		this.#setActiveToolNames = config.setActiveToolNames;
 		this.#disconnectOwnedMcpManager = config.disconnectOwnedMcpManager;
@@ -5935,7 +5939,8 @@ export class AgentSession {
 
 	#collectDiscoverableMCPToolsFromRegistry(): Map<string, DiscoverableTool> {
 		const mcpTools = filterBySource(collectDiscoverableTools(this.#toolRegistry.values()), "mcp");
-		return new Map(mcpTools.map(tool => [tool.name, tool] as const));
+		const deferredTools = this.#getDeferredDiscoverableMCPTools?.() ?? [];
+		return new Map([...mcpTools, ...deferredTools].map(tool => [tool.name, tool] as const));
 	}
 
 	#setDiscoverableMCPTools(discoverableMCPTools: Map<string, DiscoverableTool>): void {

--- a/packages/coding-agent/src/tool-discovery/mode.ts
+++ b/packages/coding-agent/src/tool-discovery/mode.ts
@@ -19,6 +19,7 @@ export function resolveEffectiveToolDiscoveryMode(settings: Settings, toolCount:
 	const configuredMode = settings.get("tools.discoveryMode");
 	if (configuredMode === "all" || configuredMode === "mcp-only") return configuredMode;
 	if (settings.get("mcp.discoveryMode")) return "mcp-only";
+	if (settings.get("mcp.lazyDiscovery")) return "mcp-only";
 	if (configuredMode === "auto" && toolCount > TOOL_DISCOVERY_AUTO_THRESHOLD) return "mcp-only";
 	return "off";
 }

--- a/packages/coding-agent/src/tool-discovery/tool-index.ts
+++ b/packages/coding-agent/src/tool-discovery/tool-index.ts
@@ -16,12 +16,19 @@ export interface DiscoverableTool {
 	serverName?: string;
 	/** MCP only */
 	mcpToolName?: string;
+	/** MCP lazy-discovery pseudo-entry for a server whose tools are not loaded yet. */
+	deferredServer?: boolean;
 	schemaKeys: string[];
 }
 
 export interface DiscoverableToolServerSummary {
 	name: string;
 	toolCount: number;
+	/** True when schemas came from the MCP tool cache without a live connection. */
+	cached?: boolean;
+	/** True when the server is configured but no cached tool schema is available yet. */
+	deferred?: boolean;
+	description?: string;
 }
 
 export interface DiscoverableToolSummary {
@@ -188,8 +195,14 @@ export function filterBySource(tools: DiscoverableTool[], source: DiscoverableTo
 }
 
 export function formatDiscoverableToolServerSummary(server: DiscoverableToolServerSummary): string {
+	const suffix = server.description ? ` — ${server.description.slice(0, 200)}` : "";
+	if (server.deferred) return `${server.name} (deferred)${suffix}`;
+	if (server.cached) {
+		const toolLabel = server.toolCount === 1 ? "tool" : "tools";
+		return `${server.name} (${server.toolCount} ${toolLabel} cached)${suffix}`;
+	}
 	const toolLabel = server.toolCount === 1 ? "tool" : "tools";
-	return `${server.name} (${server.toolCount} ${toolLabel})`;
+	return `${server.name} (${server.toolCount} ${toolLabel})${suffix}`;
 }
 
 export function selectDiscoverableToolNamesByServer(

--- a/packages/coding-agent/src/tool-discovery/tool-index.ts
+++ b/packages/coding-agent/src/tool-discovery/tool-index.ts
@@ -18,6 +18,13 @@ export interface DiscoverableTool {
 	mcpToolName?: string;
 	/** MCP lazy-discovery pseudo-entry for a server whose tools are not loaded yet. */
 	deferredServer?: boolean;
+	/**
+	 * Configured MCP server description, carried as BM25 corpus-only metadata so a
+	 * live tool loaded from a cache-miss server that matched only by its server
+	 * description still ranks on the original query terms. Never surfaced as the
+	 * tool's own description/output.
+	 */
+	serverDescription?: string;
 	schemaKeys: string[];
 }
 
@@ -64,6 +71,10 @@ const FIELD_WEIGHTS = {
 	serverName: 2,
 	mcpToolName: 4,
 	summary: 2,
+	// Same weight as `summary`: the configured server description carries the
+	// identical descriptive signal that previously lived on the pseudo-entry, so
+	// moving it into the live corpus must neither amplify nor suppress ranking.
+	serverDescription: 2,
 	schemaKey: 1,
 } as const;
 
@@ -121,6 +132,7 @@ function buildSearchDocument(tool: DiscoverableTool): DiscoverableToolSearchDocu
 	addWeightedTokens(termFrequencies, tool.serverName, FIELD_WEIGHTS.serverName);
 	addWeightedTokens(termFrequencies, tool.mcpToolName, FIELD_WEIGHTS.mcpToolName);
 	addWeightedTokens(termFrequencies, tool.summary, FIELD_WEIGHTS.summary);
+	addWeightedTokens(termFrequencies, tool.serverDescription, FIELD_WEIGHTS.serverDescription);
 	for (const schemaKey of tool.schemaKeys) {
 		addWeightedTokens(termFrequencies, schemaKey, FIELD_WEIGHTS.schemaKey);
 	}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -11,6 +11,7 @@ import { checkJuliaKernelAvailability } from "../eval/jl/kernel";
 import { checkPythonKernelAvailability } from "../eval/py/kernel";
 import { checkRubyKernelAvailability } from "../eval/rb/kernel";
 import type { ToolPathWithSource } from "../extensibility/custom-tools";
+import type { CustomTool } from "../extensibility/custom-tools/types";
 import type { Skill } from "../extensibility/skills";
 import type { GoalModeState, GoalRuntime } from "../goals";
 import { GoalTool } from "../goals/tools/goal-tool";
@@ -299,6 +300,8 @@ export interface ToolSession {
 	getSelectedMCPToolNames?: () => string[];
 	/** Merge MCP tool selections into the active session tool set. */
 	activateDiscoveredMCPTools?: (toolNames: string[]) => Promise<string[]>;
+	/** Refresh the session's MCP tool registry after an on-demand MCP connection. */
+	refreshMCPTools?: (tools: CustomTool[]) => Promise<void>;
 	// ── Generic tool discovery (unified — covers built-in + MCP + extension) ──
 	/** Whether any form of tool discovery is active (tools.discoveryMode !== "off" or mcp.discoveryMode). */
 	isToolDiscoveryEnabled?: () => boolean;

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -149,7 +149,8 @@ function isDiscoveryEnabled(session: ToolSession): boolean {
 
 function getLazyMCPServerName(session: ToolSession, tool: DiscoverableTool): string | undefined {
 	if (tool.source !== "mcp" || !tool.serverName || !session.mcpManager) return undefined;
-	if (session.mcpManager.getConnection(tool.serverName)) return undefined;
+	// Always route configured ranked MCP servers through readiness-aware
+	// connectServerOnDemand: a stored connection may still be waiting on listTools.
 	if (!session.mcpManager.getServerConfig(tool.serverName)) return undefined;
 	return tool.serverName;
 }
@@ -157,6 +158,7 @@ function getLazyMCPServerName(session: ToolSession, tool: DiscoverableTool): str
 async function connectLazyMCPMatches(
 	session: ToolSession,
 	ranked: Array<{ tool: DiscoverableTool; score: number }>,
+	signal?: AbortSignal,
 ): Promise<{ attempted: boolean; unavailable: string[]; unavailableServerNames: Set<string> }> {
 	if (!session.mcpManager) return { attempted: false, unavailable: [], unavailableServerNames: new Set() };
 	const serverNames = [
@@ -170,10 +172,12 @@ async function connectLazyMCPMatches(
 	const unavailableServerNames = new Set<string>();
 	let connected = false;
 	for (const serverName of serverNames) {
+		if (signal?.aborted) throw signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
 		try {
-			await session.mcpManager.connectServerOnDemand(serverName);
+			await session.mcpManager.connectServerOnDemand(serverName, signal);
 			connected = true;
 		} catch (error) {
+			if (signal?.aborted) throw signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
 			const message = error instanceof Error ? error.message : String(error);
 			unavailable.push(`server "${serverName}" unavailable: ${message}`);
 			unavailableServerNames.add(serverName);
@@ -274,7 +278,7 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 	async execute(
 		_toolCallId: string,
 		params: SearchToolBm25Params,
-		_signal?: AbortSignal,
+		signal?: AbortSignal,
 		_onUpdate?: AgentToolUpdateCallback<SearchToolBm25Details>,
 		_context?: AgentToolContext,
 	): Promise<AgentToolResult<SearchToolBm25Details>> {
@@ -310,7 +314,7 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			throw error;
 		}
 
-		const lazyConnections = await connectLazyMCPMatches(this.session, ranked);
+		const lazyConnections = await connectLazyMCPMatches(this.session, ranked, signal);
 		const unavailableServers = lazyConnections.unavailable;
 		const unavailableServerNames = lazyConnections.unavailableServerNames;
 		if (lazyConnections.attempted) {

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -11,6 +11,7 @@ import {
 	buildDiscoverableToolSearchIndex,
 	type DiscoverableTool,
 	type DiscoverableToolSearchIndex,
+	type DiscoverableToolServerSummary,
 	filterBySource,
 	formatDiscoverableToolServerSummary,
 	searchDiscoverableTools,
@@ -51,6 +52,7 @@ export interface SearchToolBm25Details {
 	activated_tools: string[];
 	active_selected_tools: string[];
 	tools: SearchToolBm25Match[];
+	unavailable_servers?: string[];
 }
 
 function formatMatch(tool: DiscoverableTool, score: number): SearchToolBm25Match {
@@ -66,12 +68,16 @@ function formatMatch(tool: DiscoverableTool, score: number): SearchToolBm25Match
 }
 
 function buildSearchToolBm25Content(details: SearchToolBm25Details): string {
-	return JSON.stringify({
+	const payload: Record<string, unknown> = {
 		query: details.query,
 		activated_tools: details.activated_tools,
 		match_count: details.tools.length,
 		total_tools: details.total_tools,
-	});
+	};
+	if (details.unavailable_servers && details.unavailable_servers.length > 0) {
+		payload.unavailable_servers = details.unavailable_servers;
+	}
+	return JSON.stringify(payload);
 }
 
 /** Get discoverable tools for description rendering. Falls back to empty array on error. */
@@ -141,15 +147,54 @@ function isDiscoveryEnabled(session: ToolSession): boolean {
 	return session.isMCPDiscoveryEnabled?.() ?? false;
 }
 
-export function renderSearchToolBm25Description(discoverableTools: DiscoverableTool[] = []): string {
+function getLazyMCPServerName(session: ToolSession, tool: DiscoverableTool): string | undefined {
+	if (tool.source !== "mcp" || !tool.serverName || !session.mcpManager) return undefined;
+	if (session.mcpManager.getConnection(tool.serverName)) return undefined;
+	if (!session.mcpManager.getServerConfig(tool.serverName)) return undefined;
+	return tool.serverName;
+}
+
+async function connectLazyMCPMatches(
+	session: ToolSession,
+	ranked: Array<{ tool: DiscoverableTool; score: number }>,
+): Promise<{ attempted: boolean; unavailable: string[] }> {
+	if (!session.mcpManager) return { attempted: false, unavailable: [] };
+	const serverNames = [
+		...new Set(
+			ranked
+				.map(result => getLazyMCPServerName(session, result.tool))
+				.filter((serverName): serverName is string => typeof serverName === "string"),
+		),
+	];
+	const unavailable: string[] = [];
+	let connected = false;
+	for (const serverName of serverNames) {
+		try {
+			await session.mcpManager.connectServerOnDemand(serverName);
+			connected = true;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			unavailable.push(`server "${serverName}" unavailable: ${message}`);
+		}
+	}
+	if (connected) {
+		await session.refreshMCPTools?.(session.mcpManager.getTools());
+	}
+	return { attempted: serverNames.length > 0, unavailable };
+}
+
+export function renderSearchToolBm25Description(
+	discoverableTools: DiscoverableTool[] = [],
+	serverSummaries?: DiscoverableToolServerSummary[],
+): string {
 	const summary = summarizeDiscoverableTools(discoverableTools);
 	const builtinToolNames = filterBySource(discoverableTools, "builtin")
 		.map(t => t.name)
 		.sort();
 	return prompt.render(searchToolBm25Description, {
 		discoverableToolCount: summary.toolCount,
-		discoverableMCPServerSummaries: summary.servers.map(formatDiscoverableToolServerSummary),
-		hasDiscoverableMCPServers: summary.servers.length > 0,
+		discoverableMCPServerSummaries: (serverSummaries ?? summary.servers).map(formatDiscoverableToolServerSummary),
+		hasDiscoverableMCPServers: (serverSummaries ?? summary.servers).length > 0,
 		discoverableBuiltinToolNames: builtinToolNames,
 		hasDiscoverableBuiltinTools: builtinToolNames.length > 0,
 	});
@@ -249,8 +294,8 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			throw new ToolError("Limit must be a positive integer.");
 		}
 
-		const searchIndex = getDiscoverableToolSearchIndexForExecution(this.session);
-		const selectedToolNames = new Set(getSelectedToolNames(this.session));
+		let searchIndex = getDiscoverableToolSearchIndexForExecution(this.session);
+		let selectedToolNames = new Set(getSelectedToolNames(this.session));
 		let ranked: Array<{ tool: DiscoverableTool; score: number }> = [];
 		try {
 			ranked = searchDiscoverableTools(searchIndex, query, searchIndex.documents.length)
@@ -262,11 +307,21 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			}
 			throw error;
 		}
+
+		const lazyConnections = await connectLazyMCPMatches(this.session, ranked);
+		const unavailableServers = lazyConnections.unavailable;
+		if (lazyConnections.attempted) {
+			searchIndex = buildDiscoverableToolSearchIndex(getDiscoverableToolsForDescription(this.session));
+			selectedToolNames = new Set(getSelectedToolNames(this.session));
+			ranked = searchDiscoverableTools(searchIndex, query, searchIndex.documents.length)
+				.filter(result => !selectedToolNames.has(result.tool.name))
+				.slice(0, limit);
+		}
 		const activated =
 			ranked.length > 0
 				? await activateTools(
 						this.session,
-						ranked.map(result => result.tool.name),
+						ranked.filter(result => !result.tool.deferredServer).map(result => result.tool.name),
 					)
 				: [];
 
@@ -277,6 +332,7 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			activated_tools: activated,
 			active_selected_tools: getSelectedToolNames(this.session),
 			tools: ranked.map(result => formatMatch(result.tool, result.score)),
+			unavailable_servers: unavailableServers.length > 0 ? unavailableServers : undefined,
 		};
 
 		return {

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -102,22 +102,31 @@ function getDiscoverableToolsForDescription(session: ToolSession): DiscoverableT
 function withServerDescriptions(session: ToolSession, tools: DiscoverableTool[]): DiscoverableTool[] {
 	const manager = session.mcpManager;
 	if (!manager) return tools;
-	return tools.map(tool => {
+	let changed = false;
+	const enriched = tools.map(tool => {
 		if (tool.source !== "mcp" || tool.deferredServer || typeof tool.serverName !== "string") {
 			return tool;
 		}
 		const description = manager.getServerConfig(tool.serverName)?.description?.slice(0, 200);
 		if (!description || description.trim().length === 0) return tool;
+		changed = true;
 		return { ...tool, serverDescription: description };
 	});
+	return changed ? enriched : tools;
 }
 
 function getDiscoverableToolSearchIndexForExecution(session: ToolSession): DiscoverableToolSearchIndex {
 	try {
 		const cached = session.getDiscoverableToolSearchIndex?.();
-		if (cached) return cached;
+		if (cached) {
+			const tools = cached.documents.map(document => document.tool);
+			const enriched = withServerDescriptions(session, tools);
+			return enriched === tools ? cached : buildDiscoverableToolSearchIndex(enriched);
+		}
 	} catch {}
-	return buildDiscoverableToolSearchIndex(getDiscoverableToolsForDescription(session));
+	return buildDiscoverableToolSearchIndex(
+		withServerDescriptions(session, getDiscoverableToolsForDescription(session)),
+	);
 }
 
 /** Resolve the effective selected tool names (generic or legacy MCP). */

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -89,6 +89,29 @@ function getDiscoverableToolsForDescription(session: ToolSession): DiscoverableT
 	}
 }
 
+/**
+ * Enrich live MCP descriptors with their configured server description as
+ * BM25 corpus-only ranking metadata. Once a cache-miss server connects its
+ * pseudo-entry (which carried the server description in its summary) is hidden,
+ * so without this a generic live tool like `search` loses the description
+ * signal that let the server match the query. `getServerConfig` is concrete
+ * like the discovery accessor above, so no extra try/catch is needed; skip
+ * tools with no resolvable, non-blank description and clone only where the
+ * signal exists.
+ */
+function withServerDescriptions(session: ToolSession, tools: DiscoverableTool[]): DiscoverableTool[] {
+	const manager = session.mcpManager;
+	if (!manager) return tools;
+	return tools.map(tool => {
+		if (tool.source !== "mcp" || tool.deferredServer || typeof tool.serverName !== "string") {
+			return tool;
+		}
+		const description = manager.getServerConfig(tool.serverName)?.description?.slice(0, 200);
+		if (!description || description.trim().length === 0) return tool;
+		return { ...tool, serverDescription: description };
+	});
+}
+
 function getDiscoverableToolSearchIndexForExecution(session: ToolSession): DiscoverableToolSearchIndex {
 	try {
 		const cached = session.getDiscoverableToolSearchIndex?.();
@@ -318,7 +341,9 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 		const unavailableServers = lazyConnections.unavailable;
 		const unavailableServerNames = lazyConnections.unavailableServerNames;
 		if (lazyConnections.attempted) {
-			searchIndex = buildDiscoverableToolSearchIndex(getDiscoverableToolsForDescription(this.session));
+			searchIndex = buildDiscoverableToolSearchIndex(
+				withServerDescriptions(this.session, getDiscoverableToolsForDescription(this.session)),
+			);
 			selectedToolNames = new Set(getSelectedToolNames(this.session));
 			ranked = searchDiscoverableTools(searchIndex, query, searchIndex.documents.length)
 				.filter(result => !selectedToolNames.has(result.tool.name))

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -157,8 +157,8 @@ function getLazyMCPServerName(session: ToolSession, tool: DiscoverableTool): str
 async function connectLazyMCPMatches(
 	session: ToolSession,
 	ranked: Array<{ tool: DiscoverableTool; score: number }>,
-): Promise<{ attempted: boolean; unavailable: string[] }> {
-	if (!session.mcpManager) return { attempted: false, unavailable: [] };
+): Promise<{ attempted: boolean; unavailable: string[]; unavailableServerNames: Set<string> }> {
+	if (!session.mcpManager) return { attempted: false, unavailable: [], unavailableServerNames: new Set() };
 	const serverNames = [
 		...new Set(
 			ranked
@@ -167,6 +167,7 @@ async function connectLazyMCPMatches(
 		),
 	];
 	const unavailable: string[] = [];
+	const unavailableServerNames = new Set<string>();
 	let connected = false;
 	for (const serverName of serverNames) {
 		try {
@@ -175,12 +176,13 @@ async function connectLazyMCPMatches(
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			unavailable.push(`server "${serverName}" unavailable: ${message}`);
+			unavailableServerNames.add(serverName);
 		}
 	}
 	if (connected) {
 		await session.refreshMCPTools?.(session.mcpManager.getTools());
 	}
-	return { attempted: serverNames.length > 0, unavailable };
+	return { attempted: serverNames.length > 0, unavailable, unavailableServerNames };
 }
 
 export function renderSearchToolBm25Description(
@@ -310,6 +312,7 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 
 		const lazyConnections = await connectLazyMCPMatches(this.session, ranked);
 		const unavailableServers = lazyConnections.unavailable;
+		const unavailableServerNames = lazyConnections.unavailableServerNames;
 		if (lazyConnections.attempted) {
 			searchIndex = buildDiscoverableToolSearchIndex(getDiscoverableToolsForDescription(this.session));
 			selectedToolNames = new Set(getSelectedToolNames(this.session));
@@ -321,7 +324,17 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			ranked.length > 0
 				? await activateTools(
 						this.session,
-						ranked.filter(result => !result.tool.deferredServer).map(result => result.tool.name),
+						ranked
+							.filter(
+								result =>
+									!result.tool.deferredServer &&
+									!(
+										result.tool.source === "mcp" &&
+										typeof result.tool.serverName === "string" &&
+										unavailableServerNames.has(result.tool.serverName)
+									),
+							)
+							.map(result => result.tool.name),
 					)
 				: [];
 

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
 import * as oauthFlow from "@oh-my-pi/pi-coding-agent/mcp/oauth-flow";
 import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
@@ -41,7 +42,29 @@ function restoreEnvValue(name: string, value: string | undefined): void {
 	Bun.env[name] = value;
 	process.env[name] = value;
 }
-function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<string, unknown> = {}) {
+
+type Renderable = { render(width: number): readonly string[] };
+
+function isRenderable(value: unknown): value is Renderable {
+	return typeof value === "object" && value !== null && "render" in value && typeof value.render === "function";
+}
+
+function renderPresented(calls: readonly (readonly unknown[])[]): string {
+	const lines: string[] = [];
+	for (const [content] of calls) {
+		const components = Array.isArray(content) ? content : [content];
+		for (const component of components) {
+			if (isRenderable(component)) lines.push(...component.render(120));
+		}
+	}
+	return Bun.stripANSI(lines.join("\n"));
+}
+
+function createController(
+	authStorage: AuthStorage,
+	mcpManagerOverrides: Record<string, unknown> = {},
+	settings: Settings = Settings.isolated(),
+) {
 	const showError = vi.fn();
 	const showStatus = vi.fn();
 	const present = vi.fn();
@@ -51,6 +74,9 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 		prepareConfig,
 		disconnectAll: vi.fn(async () => {}),
 		discoverAndConnect: vi.fn(async () => ({ errors: new Map<string, string>() })),
+		discoverDeferred: vi.fn(async () => ({ errors: new Map<string, string>() })),
+		connectServerOnDemand: vi.fn(async (_name: string) => {}),
+		getServerConfig: vi.fn(() => undefined as MCPServerConfig | undefined),
 		getTools: vi.fn(() => []),
 		waitForConnection: vi.fn(async () => {}),
 		getConnectionStatus: vi.fn(() => "connected"),
@@ -72,6 +98,7 @@ function createController(authStorage: AuthStorage, mcpManagerOverrides: Record<
 			refreshMCPTools: vi.fn(),
 			modelRegistry: { authStorage },
 		},
+		settings,
 		mcpManager,
 	} as never);
 
@@ -175,6 +202,83 @@ describe("/mcp auth commands", () => {
 		const savedUrl = savedServer?.type === "http" || savedServer?.type === "sse" ? savedServer.url : undefined;
 		expect(savedUrl).toBe(RAW_SERVER_URL);
 		expect(savedServer?.auth).toBeUndefined();
+	});
+
+	test("lazy reauth rediscovers deferred and connects only the target server", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(AUTH_ERROR);
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockResolvedValue({
+			access: "fresh-access",
+			refresh: "fresh-refresh",
+			expires: Date.now() + 3_600_000,
+		});
+		const discoverDeferred = vi.fn(async () => ({
+			errors: new Map<string, string>(),
+			connectedServers: [] as string[],
+			tools: [],
+			exaApiKeys: [] as string[],
+		}));
+		const connectServerOnDemand = vi.fn(async (_name: string) => {});
+		const discoverAndConnect = vi.fn(async () => ({ errors: new Map<string, string>() }));
+		const { controller, showError } = createController(
+			authStorage,
+			{
+				discoverDeferred,
+				connectServerOnDemand,
+				discoverAndConnect,
+				// The just-reauthed server is configured after deferred rediscovery, so
+				// the targeted on-demand connect path is eligible.
+				getServerConfig: vi.fn((name: string) =>
+					name === "envserver" ? { type: "http", url: EXPANDED_SERVER_URL } : undefined,
+				),
+			},
+			Settings.isolated({ "mcp.lazyDiscovery": true }),
+		);
+
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		// Lazy policy: rediscover deferred (no eager fan-out), then connect only
+		// the reauthed target on demand.
+		expect(discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(discoverAndConnect).not.toHaveBeenCalled();
+		expect(connectServerOnDemand).toHaveBeenCalledTimes(1);
+		expect(connectServerOnDemand.mock.calls[0]?.[0]).toBe("envserver");
+	});
+
+	test("lazy reauth surfaces a targeted connection rejection", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(AUTH_ERROR);
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockResolvedValue({
+			access: "fresh-access",
+			refresh: "fresh-refresh",
+			expires: Date.now() + 3_600_000,
+		});
+		const connectError = new Error("targeted reauth connection failed");
+		const connectServerOnDemand = vi.fn(async () => {
+			throw connectError;
+		});
+		const { controller, present, mcpManager } = createController(
+			authStorage,
+			{
+				connectServerOnDemand,
+				getServerConfig: vi.fn((name: string) =>
+					name === "envserver" ? { type: "http", url: EXPANDED_SERVER_URL } : undefined,
+				),
+			},
+			Settings.isolated({ "mcp.lazyDiscovery": true }),
+		);
+
+		await controller.handle("/mcp reauth envserver");
+
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		expect(connectServerOnDemand).toHaveBeenCalledWith("envserver");
+		const output = renderPresented(present.mock.calls);
+		expect(output).toContain("Some servers failed to connect:");
+		expect(output).toContain("envserver: targeted reauth connection failed");
 	});
 
 	test("reuses embedded DCR client secret during reauth token exchange", async () => {
@@ -354,6 +458,34 @@ describe("/mcp auth commands", () => {
 		expect(savedServer?.auth).toBeUndefined();
 	});
 
+	test("lazy unauth rediscovers deferred without reconnecting any server", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		await authStorage.set(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL), {
+			type: "oauth",
+			access: "expanded-access",
+			refresh: "expanded-refresh",
+			expires: Date.now() + 3_600_000,
+		});
+		const { controller, mcpManager } = createController(
+			authStorage,
+			{
+				// If unauth accidentally passed a target, this config would make the
+				// targeted connection observable.
+				getServerConfig: vi.fn(() => ({ type: "http", url: EXPANDED_SERVER_URL })),
+			},
+			Settings.isolated({ "mcp.lazyDiscovery": true }),
+		);
+
+		await controller.handle("/mcp unauth envserver");
+
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
+		expect(authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL))).toBeUndefined();
+	});
+
 	test("clears url-keyed auth for discovered definition-only servers", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();
@@ -363,14 +495,22 @@ describe("/mcp auth commands", () => {
 			refresh: "discovered-refresh",
 			expires: Date.now() + 3_600_000,
 		});
-		const { controller, showError } = createController(authStorage, {
-			getServerConfig: vi.fn(() => ({ type: "http", url: EXPANDED_SERVER_URL })),
-			getSource: vi.fn(() => ({ provider: "test", path: "/tmp/discovered.json" })),
-		});
+		const { controller, showError, mcpManager } = createController(
+			authStorage,
+			{
+				getServerConfig: vi.fn(() => ({ type: "http", url: EXPANDED_SERVER_URL })),
+				getSource: vi.fn(() => ({ provider: "test", path: "/tmp/discovered.json" })),
+			},
+			Settings.isolated({ "mcp.lazyDiscovery": true }),
+		);
 
 		await controller.handle("/mcp unauth discovered");
 
 		expect(showError).not.toHaveBeenCalled();
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
 		expect(authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL))).toBeUndefined();
 		const userConfigPath = getMCPConfigPath("user", projectDir);
 		const userConfig = JSON.parse(

--- a/packages/coding-agent/test/mcp-command-toggle.test.ts
+++ b/packages/coding-agent/test/mcp-command-toggle.test.ts
@@ -220,6 +220,26 @@ describe("/mcp reload and add honor mcp.lazyDiscovery", () => {
 		expect(refreshMCPTools).toHaveBeenCalledTimes(1);
 	});
 
+	test("lazy /mcp reload connects configured defaults while leaving non-defaults deferred", async () => {
+		await writeProjectConfig(projectDir, {
+			defaulted: { type: "stdio", command: "default-server" },
+			deferred: { type: "stdio", command: "deferred-server" },
+		});
+		const { controller, mcpManager } = createController({
+			settings: Settings.isolated({
+				"mcp.lazyDiscovery": true,
+				"mcp.discoveryDefaultServers": ["  defaulted  ", "", "   "],
+			}),
+		});
+
+		await controller.handle("/mcp reload");
+
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledWith({
+			discoveryDefaultServers: ["defaulted"],
+		});
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
+	});
+
 	test("eager /mcp reload still uses discoverAndConnect", async () => {
 		await writeProjectConfig(projectDir, {
 			mcp1: { type: "stdio", command: "mcp-one" },
@@ -260,6 +280,34 @@ describe("/mcp reload and add honor mcp.lazyDiscovery", () => {
 			mcpServers?: Record<string, MCPServerConfig>;
 		};
 		expect(saved.mcpServers?.newsrv).toMatchObject({ type: "stdio", command: "new-server" });
+	});
+
+	test("lazy /mcp add does not reconnect a target already handled as a discovery default", async () => {
+		const addedConfig: MCPServerConfig = { type: "stdio", command: "new-server" };
+		const defaultError = "default target connection failed";
+		const { controller, mcpManager, present } = createController({
+			settings: Settings.isolated({
+				"mcp.lazyDiscovery": true,
+				"mcp.discoveryDefaultServers": ["  newsrv  "],
+			}),
+			mcpManagerExtra: {
+				discoverDeferred: vi.fn(async () => ({
+					...emptyLoadResult(),
+					errors: new Map([["newsrv", defaultError]]),
+				})),
+				getServerConfig: vi.fn((name: string) => (name === "newsrv" ? addedConfig : undefined)),
+			},
+		});
+
+		await controller.handle("/mcp add newsrv -- new-server");
+
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledWith({
+			discoveryDefaultServers: ["newsrv"],
+		});
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
+		const output = renderPresented(present.mock.calls);
+		expect(output).toContain("Some servers failed to connect:");
+		expect(output).toContain(`newsrv: ${defaultError}`);
 	});
 
 	test("lazy /mcp add surfaces a targeted connection rejection", async () => {

--- a/packages/coding-agent/test/mcp-command-toggle.test.ts
+++ b/packages/coding-agent/test/mcp-command-toggle.test.ts
@@ -3,6 +3,9 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { SourceMeta } from "@oh-my-pi/pi-coding-agent/capability/types";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as mcpConfigWriter from "@oh-my-pi/pi-coding-agent/mcp/config-writer";
+import type { MCPLoadResult } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { MCPCommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/mcp-command-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -31,11 +34,35 @@ function restoreAgentDir(): void {
 	delete Bun.env.PI_CODING_AGENT_DIR;
 }
 
-function createController() {
+function emptyLoadResult(): MCPLoadResult {
+	return { errors: new Map<string, string>(), connectedServers: [], tools: [], exaApiKeys: [] };
+}
+
+type Renderable = { render(width: number): readonly string[] };
+
+function isRenderable(value: unknown): value is Renderable {
+	return typeof value === "object" && value !== null && "render" in value && typeof value.render === "function";
+}
+
+function renderPresented(calls: readonly (readonly unknown[])[]): string {
+	const lines: string[] = [];
+	for (const [content] of calls) {
+		const components = Array.isArray(content) ? content : [content];
+		for (const component of components) {
+			if (isRenderable(component)) lines.push(...component.render(120));
+		}
+	}
+	return Bun.stripANSI(lines.join("\n"));
+}
+
+function createController(options: { settings?: Settings; mcpManagerExtra?: Record<string, unknown> } = {}) {
 	const refreshMCPTools = vi.fn(async () => {});
+	const present = vi.fn();
 	const mcpManager = {
 		disconnectAll: vi.fn(async () => {}),
-		discoverAndConnect: vi.fn(async () => ({ errors: new Map<string, string>() })),
+		discoverAndConnect: vi.fn(async () => emptyLoadResult()),
+		discoverDeferred: vi.fn(async () => emptyLoadResult()),
+		connectServerOnDemand: vi.fn(async (_name: string) => {}),
 		disconnectServer: vi.fn(async () => {}),
 		connectServers: vi.fn(
 			async (_configs: Record<string, MCPServerConfig>, _sources: Record<string, SourceMeta>) => ({
@@ -46,13 +73,17 @@ function createController() {
 			}),
 		),
 		getTools: vi.fn(() => []),
+		getServerConfig: vi.fn(() => undefined as MCPServerConfig | undefined),
+		getConnection: vi.fn(() => undefined),
+		getConnectedServers: vi.fn(() => [] as string[]),
 		waitForConnection: vi.fn(async () => ({})),
 		getConnectionStatus: vi.fn(() => "connected"),
 		getSource: vi.fn(() => undefined),
+		...options.mcpManagerExtra,
 	};
 	const controller = new MCPCommandController({
 		chatContainer: { addChild: vi.fn() },
-		present: vi.fn(),
+		present,
 		ui: { requestRender: vi.fn() },
 		editor: {},
 		showError: vi.fn(),
@@ -65,11 +96,15 @@ function createController() {
 		session: {
 			refreshMCPTools,
 			modelRegistry: { authStorage: undefined },
+			getActiveToolNames: vi.fn(() => [] as string[]),
+			getToolByName: vi.fn(() => undefined),
+			setActiveToolsByName: vi.fn(async () => {}),
 		},
+		settings: options.settings ?? Settings.isolated(),
 		mcpManager,
 	} as never);
 
-	return { controller, mcpManager, refreshMCPTools };
+	return { controller, mcpManager, refreshMCPTools, present };
 }
 
 async function writeProjectConfig(projectDir: string, servers: Record<string, MCPServerConfig>): Promise<void> {
@@ -139,5 +174,167 @@ describe("/mcp enable and disable", () => {
 		const [configs] = mcpManager.connectServers.mock.calls[0]!;
 		expect(Object.keys(configs)).toEqual(["mcp1"]);
 		expect(configs.mcp1).toEqual({ type: "stdio", command: "mcp-one", enabled: true });
+	});
+});
+
+describe("/mcp reload and add honor mcp.lazyDiscovery", () => {
+	let projectDir = "";
+	let agentDir = "";
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-lazyreload-project-"));
+		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-lazyreload-agent-"));
+		setProjectDir(projectDir);
+		setAgentDir(agentDir);
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		setProjectDir(originalProjectDir);
+		restoreAgentDir();
+		await removeWithRetries(projectDir);
+		await removeWithRetries(agentDir);
+	});
+
+	test("lazy /mcp reload rediscovers deferred without eager or targeted connects", async () => {
+		await writeProjectConfig(projectDir, {
+			mcp1: { type: "stdio", command: "mcp-one" },
+			mcp2: { type: "stdio", command: "mcp-two" },
+		});
+		const { controller, mcpManager, refreshMCPTools } = createController({
+			settings: Settings.isolated({ "mcp.lazyDiscovery": true }),
+		});
+
+		await controller.handle("/mcp reload");
+
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		// Zero eager connects: neither the eager discovery path nor any on-demand
+		// connect may fire for a plain reload under lazy discovery.
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
+		expect(refreshMCPTools).toHaveBeenCalledTimes(1);
+	});
+
+	test("eager /mcp reload still uses discoverAndConnect", async () => {
+		await writeProjectConfig(projectDir, {
+			mcp1: { type: "stdio", command: "mcp-one" },
+		});
+		const { controller, mcpManager } = createController({
+			settings: Settings.isolated({ "mcp.lazyDiscovery": false }),
+		});
+
+		await controller.handle("/mcp reload");
+
+		expect(mcpManager.discoverAndConnect).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverDeferred).not.toHaveBeenCalled();
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
+	});
+
+	test("lazy /mcp add connects only the added target after deferred rediscovery", async () => {
+		const addedConfig: MCPServerConfig = { type: "stdio", command: "new-server" };
+		const { controller, mcpManager } = createController({
+			settings: Settings.isolated({ "mcp.lazyDiscovery": true }),
+			// After rediscovery the added server is configured, so the targeted
+			// connect path is eligible; getConnectionStatus stays "connected" so
+			// the status animation resolves without a live transport.
+			mcpManagerExtra: {
+				getServerConfig: vi.fn((name: string) => (name === "newsrv" ? addedConfig : undefined)),
+			},
+		});
+
+		await controller.handle("/mcp add newsrv -- new-server");
+
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		// Only the just-added server connects on demand — no eager fan-out.
+		expect(mcpManager.connectServerOnDemand).toHaveBeenCalledTimes(1);
+		expect(mcpManager.connectServerOnDemand.mock.calls[0]?.[0]).toBe("newsrv");
+
+		const saved = JSON.parse(await Bun.file(getMCPConfigPath("project", projectDir)).text()) as {
+			mcpServers?: Record<string, MCPServerConfig>;
+		};
+		expect(saved.mcpServers?.newsrv).toMatchObject({ type: "stdio", command: "new-server" });
+	});
+
+	test("lazy /mcp add surfaces a targeted connection rejection", async () => {
+		const addedConfig: MCPServerConfig = { type: "stdio", command: "new-server" };
+		const connectError = new Error("targeted add connection failed");
+		const { controller, mcpManager, present } = createController({
+			settings: Settings.isolated({ "mcp.lazyDiscovery": true }),
+			mcpManagerExtra: {
+				getServerConfig: vi.fn((name: string) => (name === "newsrv" ? addedConfig : undefined)),
+				connectServerOnDemand: vi.fn(async () => {
+					throw connectError;
+				}),
+				getConnectionStatus: vi.fn(() => "connecting"),
+			},
+		});
+
+		await controller.handle("/mcp add newsrv -- new-server");
+
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		expect(mcpManager.connectServerOnDemand).toHaveBeenCalledWith("newsrv");
+		const output = renderPresented(present.mock.calls);
+		expect(output).toContain("Some servers failed to connect:");
+		expect(output).toContain("newsrv: targeted add connection failed");
+	});
+
+	test("lazy /mcp add leaves a disabled server deferred without connecting it", async () => {
+		const addMCPServer = mcpConfigWriter.addMCPServer;
+		vi.spyOn(mcpConfigWriter, "addMCPServer").mockImplementation(async (filePath, name, config) => {
+			// Exercise #handleWizardComplete's real disabled-config branch: the writer
+			// receives the same config object that chooses the subsequent reload target.
+			config.enabled = false;
+			await addMCPServer(filePath, name, config);
+		});
+		const { controller, mcpManager } = createController({
+			settings: Settings.isolated({ "mcp.lazyDiscovery": true }),
+			mcpManagerExtra: {
+				// Keep the target resolvable so mutating the caller to always pass `name`
+				// would perform a targeted connect and fail this regression.
+				getServerConfig: vi.fn(() => ({ type: "stdio", command: "should-not-connect" })),
+				getConnectionStatus: vi.fn(() => "connecting"),
+			},
+		});
+
+		await controller.handle("/mcp add disabledsrv -- disabled-server");
+
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
+		const saved = JSON.parse(await Bun.file(getMCPConfigPath("project", projectDir)).text()) as {
+			mcpServers?: Record<string, MCPServerConfig>;
+		};
+		expect(saved.mcpServers?.disabledsrv?.enabled).toBe(false);
+	});
+
+	test("lazy /mcp remove rediscovers deferred without reconnecting any server", async () => {
+		await writeProjectConfig(projectDir, {
+			removed: { type: "stdio", command: "removed-server" },
+			remaining: { type: "stdio", command: "remaining-server" },
+		});
+		const { controller, mcpManager } = createController({
+			settings: Settings.isolated({ "mcp.lazyDiscovery": true }),
+			// If remove accidentally passed a target, this live config would make the
+			// targeted connection observable.
+			mcpManagerExtra: {
+				getServerConfig: vi.fn(() => ({ type: "stdio", command: "should-not-connect" })),
+			},
+		});
+
+		await controller.handle("/mcp remove removed");
+
+		expect(mcpManager.disconnectAll).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverDeferred).toHaveBeenCalledTimes(1);
+		expect(mcpManager.discoverAndConnect).not.toHaveBeenCalled();
+		expect(mcpManager.connectServerOnDemand).not.toHaveBeenCalled();
 	});
 });

--- a/packages/coding-agent/test/mcp-lazy-discovery.test.ts
+++ b/packages/coding-agent/test/mcp-lazy-discovery.test.ts
@@ -1183,6 +1183,120 @@ describe("lazy MCP discovery (T6)", () => {
 		}
 	});
 
+	it("search and on-demand waiters join one reconnect with isolated aborts and tool readiness", async () => {
+		writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const connectionReady = Promise.withResolvers<void>();
+		const listToolsStarted = Promise.withResolvers<void>();
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => {
+				await connectionReady.promise;
+				return mockConnectionFor(name, config);
+			});
+			listToolsSpy.mockImplementation(() => {
+				listToolsStarted.resolve();
+				return toolLoad.promise;
+			});
+
+			const reconnect = manager.reconnectServer(DEFERRED_SERVER);
+			await Promise.resolve();
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+
+			const controller = new AbortController();
+			const aborted = manager.connectServerOnDemand(DEFERRED_SERVER, controller.signal).then(
+				() => undefined,
+				error => error,
+			);
+			const session = createBm25Session(manager, {
+				discoverableTools: manager
+					.getDeferredDiscoverableTools()
+					.filter(tool => tool.serverName === DEFERRED_SERVER),
+			});
+			const search = new SearchToolBm25Tool(session).execute("join-reconnect", {
+				query: "Deferred wiki server",
+				limit: 5,
+			});
+			await Promise.resolve();
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+
+			controller.abort();
+			expect(await aborted).toMatchObject({ name: "AbortError" });
+			connectionReady.resolve();
+			await listToolsStarted.promise;
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+			let searchSettled = false;
+			void search.finally(() => {
+				searchSettled = true;
+			});
+			await Promise.resolve();
+			expect(searchSettled).toBe(false);
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			const [reconnected, result] = await Promise.all([reconnect, search]);
+			expect(reconnected).toBeDefined();
+			expect(result.details?.activated_tools).toContain(`mcp__${DEFERRED_SERVER}_lookup_docs`);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			connectionReady.resolve();
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("a joined reconnect failure is observable and a later on-demand retry connects once", async () => {
+		writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const rejectReconnect = Promise.withResolvers<void>();
+		const retryConnectionReady = Promise.withResolvers<void>();
+		const reconnectError = new Error("reconnect transport failed");
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementationOnce(async () => {
+				await rejectReconnect.promise;
+				throw reconnectError;
+			});
+			listToolsSpy.mockResolvedValue([LIVE_TOOL_DEF]);
+
+			const reconnect = manager.reconnectServer(DEFERRED_SERVER);
+			await Promise.resolve();
+			const joined = manager.connectServerOnDemand(DEFERRED_SERVER).then(
+				() => undefined,
+				error => error,
+			);
+			// Invalidate the configuration epoch while the transport attempt is latched.
+			// Its rejection then terminates the shared reconnect without wall-clock backoff.
+			await manager.disconnectAll();
+			rejectReconnect.resolve();
+
+			expect(await reconnect).toBeNull();
+			expect(await joined).toMatchObject({ message: `MCP server failed to reconnect: ${DEFERRED_SERVER}` });
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(manager.getConnection(DEFERRED_SERVER)).toBeUndefined();
+
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => {
+				await retryConnectionReady.promise;
+				return mockConnectionFor(name, config);
+			});
+			const firstRetry = manager.connectServerOnDemand(DEFERRED_SERVER);
+			const secondRetry = manager.connectServerOnDemand(DEFERRED_SERVER);
+			await Promise.resolve();
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+			retryConnectionReady.resolve();
+			await Promise.all([firstRetry, secondRetry]);
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+			expect(manager.getTools().map(tool => tool.name)).toContain(`mcp__${DEFERRED_SERVER}_lookup_docs`);
+		} finally {
+			rejectReconnect.resolve();
+			retryConnectionReady.resolve();
+			await manager.disconnectAll();
+		}
+	});
+
 	it("MCP schema allows description on every concrete transport", () => {
 		for (const serverName of ["stdioServer", "httpServer", "sseServer"] as const) {
 			const transportSchema = mcpSchema.$defs[serverName].allOf.find(isClosedTransportSchema);
@@ -1714,6 +1828,78 @@ describe("lazy MCP discovery (T6)", () => {
 			expect(result.details?.activated_tools).toContain(liveToolName);
 			expect(result.details?.tools.map(match => match.name)).toContain(liveToolName);
 			expect(session.getSelectedMCPToolNames()).toContain(liveToolName);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("native user and project descriptions reach deferred prompts and BM25 without changing precedence", async () => {
+		const userAgentDir = getAgentDir();
+		const projectConfigDir = path.join(workDir, ".omp");
+		fs.mkdirSync(userAgentDir, { recursive: true });
+		fs.mkdirSync(projectConfigDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(userAgentDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					user_native: { command: "echo", description: "Celestial payroll records" },
+					shared_native: { command: "echo", description: "User shared description" },
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(projectConfigDir, "mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					project_native: { command: "echo", description: "Quantum issue tracker" },
+					shared_native: { command: "echo", description: "Project shared description" },
+					plain_native: { command: "echo" },
+				},
+			}),
+		);
+		clearFsCache();
+
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		try {
+			await manager.discoverDeferred();
+			const summaries = manager.getDiscoverableServerSummaries();
+			expect(summaries).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "user_native", description: "Celestial payroll records" }),
+					expect.objectContaining({ name: "project_native", description: "Quantum issue tracker" }),
+					expect.objectContaining({ name: "shared_native", description: "Project shared description" }),
+					expect.objectContaining({ name: "plain_native", description: undefined }),
+				]),
+			);
+			expect(manager.getServerConfig("shared_native")?.description).toBe("Project shared description");
+
+			const pseudo = manager.getDeferredDiscoverableTools();
+			const plainPseudo = pseudo.find(tool => tool.serverName === "plain_native");
+			expect(plainPseudo?.summary).toBe(
+				'MCP server "plain_native" — tools not yet loaded; searching or calling loads them',
+			);
+			const promptDescription = renderSearchToolBm25Description(pseudo, summaries);
+			expect(promptDescription).toContain("user_native (deferred) — Celestial payroll records");
+			expect(promptDescription).toContain("project_native (deferred) — Quantum issue tracker");
+			expect(promptDescription).toContain("plain_native (deferred)");
+			expect(promptDescription).not.toContain("undefined");
+
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockResolvedValue([
+				{ name: "search", description: "Run a query", inputSchema: { type: "object", properties: {} } },
+			]);
+			const session = createBm25Session(manager, { discoverableTools: pseudo });
+			const result = await new SearchToolBm25Tool(session).execute("native-description", {
+				query: "celestial payroll records",
+				limit: 5,
+			});
+
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(connectSpy.mock.calls[0]?.[0]).toBe("user_native");
+			expect(result.details?.activated_tools).toContain("mcp__user_native_search");
+			expect(result.details?.tools.map(match => match.name)).toContain("mcp__user_native_search");
 		} finally {
 			await manager.disconnectAll();
 		}

--- a/packages/coding-agent/test/mcp-lazy-discovery.test.ts
+++ b/packages/coding-agent/test/mcp-lazy-discovery.test.ts
@@ -8,7 +8,7 @@
  * 4. A failing on-demand connect surfaces `server "<name>" unavailable: …`.
  * 5. Eager `discoverAndConnect` still connects at discovery time.
  */
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, type Mock, mock, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -152,9 +152,9 @@ describe("lazy MCP discovery (T6)", () => {
 	let isolatedHome: string;
 	let originalAgentDir: string;
 	let storage: AgentStorage;
-	let connectSpy: ReturnType<typeof spyOn>;
-	let listToolsSpy: ReturnType<typeof spyOn>;
-	let homedirSpy: ReturnType<typeof spyOn>;
+	let connectSpy: Mock<typeof mcpClient.connectToServer>;
+	let listToolsSpy: Mock<typeof mcpClient.listTools>;
+	let homedirSpy: Mock<typeof os.homedir>;
 
 	beforeEach(async () => {
 		workDir = path.join(os.tmpdir(), `omp-mcp-lazy-${Snowflake.next()}`);
@@ -389,6 +389,62 @@ describe("lazy MCP discovery (T6)", () => {
 				.join("\n");
 			const payload = JSON.parse(contentText) as { unavailable_servers?: string[] };
 			expect(payload.unavailable_servers).toEqual([unavailable]);
+			expect(result.details?.activated_tools).toEqual([]);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("connectServerOnDemand reuses an existing pending connection", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const connectionReady = Promise.withResolvers<MCPServerConnection>();
+		try {
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => {
+				expect(name).toBe(CACHED_SERVER);
+				return connectionReady.promise.then(() => mockConnectionFor(name, config));
+			});
+			listToolsSpy.mockResolvedValue([LIVE_TOOL_DEF]);
+
+			const startupConnect = manager.connectServers({ [CACHED_SERVER]: cached }, {}, undefined);
+			await Promise.resolve();
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+
+			const onDemandConnect = manager.connectServerOnDemand(CACHED_SERVER);
+			await Promise.resolve();
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+
+			connectionReady.resolve(mockConnectionFor(CACHED_SERVER, cached));
+			await onDemandConnect;
+			await startupConnect;
+
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+			expect(manager.getConnection(CACHED_SERVER)).toBeDefined();
+			expect(manager.getTools().map(tool => tool.name)).toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("waitForConnection starts on-demand connect for deferred cached tools", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set(CACHED_SERVER, cached, [CACHED_TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, toolCache);
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockResolvedValue([LIVE_TOOL_DEF]);
+
+			const connection = await manager.waitForConnection(CACHED_SERVER);
+
+			expect(connection.name).toBe(CACHED_SERVER);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+			expect(manager.getTools().map(tool => tool.name)).toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
 		} finally {
 			await manager.disconnectAll();
 		}

--- a/packages/coding-agent/test/mcp-lazy-discovery.test.ts
+++ b/packages/coding-agent/test/mcp-lazy-discovery.test.ts
@@ -18,14 +18,17 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, mock, spyOn } f
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
 import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import { createMCPServerToolName } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import { MCPToolCache } from "@oh-my-pi/pi-coding-agent/mcp/tool-cache";
 import type { MCPServerConfig, MCPServerConnection, MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -167,6 +170,37 @@ async function waitFor(predicate: () => boolean, message: string, timeoutMs = 1_
 	}
 }
 
+async function getCallableMCPToolOwner(cwd: string, tools: CustomTool[], toolName: string) {
+	const authStorage = await AuthStorage.create(path.join(cwd, `collision-owner-${Snowflake.next()}.db`));
+	const modelRegistry = new ModelRegistry(authStorage, path.join(cwd, `collision-owner-${Snowflake.next()}.yml`));
+	try {
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir: path.join(cwd, "agent"),
+			authStorage,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			enableMCP: false,
+			hasUI: false,
+		});
+		try {
+			await session.refreshMCPTools(tools);
+			return (session.getToolByName(toolName) as { mcpServerName?: string } | undefined)?.mcpServerName;
+		} finally {
+			await session.dispose();
+		}
+	} finally {
+		authStorage.close();
+	}
+}
+
 type ClosedTransportSchema = {
 	additionalProperties: false;
 	properties: Record<string, unknown>;
@@ -271,6 +305,17 @@ describe("lazy MCP discovery (T6)", () => {
 		} finally {
 			await manager.disconnectAll();
 		}
+	});
+
+	it("validates guarded cache ownership after hashing and at the persistent write boundary", async () => {
+		const config = serverConfig(CACHED_SERVER, "Cached docs server");
+		const toolCache = new MCPToolCache(storage);
+		const shouldCommit = mock(() => true);
+
+		await toolCache.set(CACHED_SERVER, config, [CACHED_TOOL_DEF], shouldCommit);
+
+		expect(shouldCommit).toHaveBeenCalledTimes(2);
+		expect(await toolCache.get(CACHED_SERVER, config)).toEqual([CACHED_TOOL_DEF]);
 	});
 
 	it("resolves lazy MCP tool names against the longest configured sanitized server name", async () => {
@@ -440,7 +485,7 @@ describe("lazy MCP discovery (T6)", () => {
 		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
 		const authStorage = await AuthStorage.create(path.join(workDir, `stored-loading-${Snowflake.next()}.db`));
 		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "stored-loading-models.yml"));
-		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		let session: AgentSession | undefined;
 		try {
 			await manager.discoverDeferred();
 			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
@@ -499,7 +544,7 @@ describe("lazy MCP discovery (T6)", () => {
 		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "serialized-refresh-models.yml"));
 		const firstRefreshStarted = Promise.withResolvers<void>();
 		const releaseFirstRefresh = Promise.withResolvers<void>();
-		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		let session: AgentSession | undefined;
 		let manager: MCPManager | undefined;
 		try {
 			({ session, mcpManager: manager } = await createAgentSession({
@@ -564,7 +609,7 @@ describe("lazy MCP discovery (T6)", () => {
 		const authStorage = await AuthStorage.create(path.join(workDir, `queue-recovery-${Snowflake.next()}.db`));
 		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "queue-recovery-models.yml"));
 		const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
-		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		let session: AgentSession | undefined;
 		let manager: MCPManager | undefined;
 		try {
 			({ session, mcpManager: manager } = await createAgentSession({
@@ -619,7 +664,7 @@ describe("lazy MCP discovery (T6)", () => {
 		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
 		const authStorage = await AuthStorage.create(path.join(workDir, `dispose-refresh-${Snowflake.next()}.db`));
 		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "dispose-refresh-models.yml"));
-		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		let session: AgentSession | undefined;
 		let refreshCompleted = false;
 		try {
 			await manager.discoverDeferred();
@@ -1168,6 +1213,557 @@ describe("lazy MCP discovery (T6)", () => {
 			expect(manager.getConnection(DEFERRED_SERVER)).toBeDefined();
 			expect(manager.isServerDeferred(CACHED_SERVER)).toBe(false);
 			expect(manager.isServerDeferred(DEFERRED_SERVER)).toBe(false);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("resolves lazy tool names by owning-server metadata and non-stealing prefix fallback", async () => {
+		// Ambiguous namespace: server `foo` (tools `bar`, `bar_baz`) and server
+		// `foo_bar` (tool `baz`) all normalize under `mcp__foo_...`. Pseudo-entries
+		// use `mcp__server__<server>`, so a bare `mcp__foo_bar` is a real
+		// `<server>_<tool>` (server `foo`, tool `bar`), NOT a name-equality match
+		// for configured server `foo_bar`.
+		fs.writeFileSync(
+			path.join(workDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					foo: serverConfig("foo", "Foo server"),
+					foo_bar: serverConfig("foo_bar", "Foo bar server"),
+				},
+			}),
+		);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockResolvedValue([
+				{ name: "bar", description: "Foo bar tool", inputSchema: { type: "object", properties: {} } },
+				{ name: "bar_baz", description: "Foo bar_baz tool", inputSchema: { type: "object", properties: {} } },
+			]);
+
+			// Uncached fallback: configured `foo_bar` must NOT steal a bare
+			// `mcp__foo_bar` via name-equality; only a real `<server>_<tool>` prefix
+			// qualifies, so it resolves to server `foo` (tool `bar`).
+			expect(manager.resolveServerNameFromToolName("mcp__foo_bar")).toBe("foo");
+			// Longest configured sanitized prefix still wins where no live tool exists.
+			expect(manager.resolveServerNameFromToolName("mcp__foo_bar_baz")).toBe("foo_bar");
+
+			// Load `foo`'s live tools (`bar` → mcp__foo_bar, `bar_baz` →
+			// mcp__foo_bar_baz, both mcpServerName `foo`).
+			await manager.connectServerOnDemand("foo");
+			expect(manager.getTools().map(tool => tool.name)).toEqual(
+				expect.arrayContaining(["mcp__foo_bar", "mcp__foo_bar_baz"]),
+			);
+
+			// Exact live-metadata now wins: `mcp__foo_bar_baz` resolves to its true
+			// owner `foo`, overriding the longer prefix-colliding config `foo_bar`.
+			expect(manager.resolveServerNameFromToolName("mcp__foo_bar_baz")).toBe("foo");
+			expect(manager.resolveServerNameFromToolName("mcp__foo_bar")).toBe("foo");
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("keeps a cache-miss pseudo-entry discoverable through pending readiness and hides it once ready", async () => {
+		writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		try {
+			await manager.discoverDeferred();
+			// Cache-miss server starts discoverable.
+			expect(manager.getDeferredDiscoverableTools().map(tool => tool.name)).toContain(
+				createMCPServerToolName(DEFERRED_SERVER),
+			);
+
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => toolLoad.promise);
+
+			const connect = manager.connectServerOnDemand(DEFERRED_SERVER);
+			// Connection stored but listTools() still pending: the pseudo-entry must
+			// remain discoverable so a cancelled search can retry and join it.
+			await waitFor(
+				() => manager.getConnection(DEFERRED_SERVER) !== undefined,
+				"Timed out waiting for pending deferred connection",
+			);
+			expect(manager.getDeferredDiscoverableTools().map(tool => tool.name)).toContain(
+				createMCPServerToolName(DEFERRED_SERVER),
+			);
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await connect;
+			// Readiness completed with tools → pseudo-entry hidden.
+			expect(manager.getDeferredDiscoverableTools().map(tool => tool.name)).not.toContain(
+				createMCPServerToolName(DEFERRED_SERVER),
+			);
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("hides a cache-miss pseudo-entry for a ready server that exposes zero tools", async () => {
+		writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		try {
+			await manager.discoverDeferred();
+			expect(manager.getDeferredDiscoverableTools().map(tool => tool.name)).toContain(
+				createMCPServerToolName(DEFERRED_SERVER),
+			);
+
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			// A ready server that legitimately exposes no tools still completes
+			// readiness, so its pseudo-entry must be hidden, not left dangling.
+			listToolsSpy.mockResolvedValue([]);
+
+			await manager.connectServerOnDemand(DEFERRED_SERVER);
+
+			expect(manager.getConnection(DEFERRED_SERVER)).toBeDefined();
+			expect(manager.getTools().filter(tool => tool.mcpServerName === DEFERRED_SERVER)).toEqual([]);
+			expect(manager.getDeferredDiscoverableTools().map(tool => tool.name)).not.toContain(
+				createMCPServerToolName(DEFERRED_SERVER),
+			);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	for (const disconnect of ["disconnectServer", "disconnectAll"] as const) {
+		it(`does not publish pending tool readiness after ${disconnect}`, async () => {
+			writeProjectMcpConfig(workDir);
+			const manager = new MCPManager(workDir, new MCPToolCache(storage));
+			const listStarted = Promise.withResolvers<void>();
+			const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+			const onToolsChanged = mock(() => {});
+			manager.setOnToolsChanged(onToolsChanged);
+			try {
+				await manager.discoverDeferred();
+				connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+					mockConnectionFor(name, config),
+				);
+				listToolsSpy.mockImplementation(() => {
+					listStarted.resolve();
+					return toolLoad.promise;
+				});
+
+				const readinessResult = manager.connectServerOnDemand(DEFERRED_SERVER).then(
+					() => undefined,
+					error => error,
+				);
+				await listStarted.promise;
+				expect(manager.getConnection(DEFERRED_SERVER)).toBeDefined();
+
+				if (disconnect === "disconnectServer") {
+					await manager.disconnectServer(DEFERRED_SERVER);
+				} else {
+					await manager.disconnectAll();
+				}
+				toolLoad.resolve([LIVE_TOOL_DEF]);
+
+				const readinessError = await readinessResult;
+				expect(readinessError).toBeInstanceOf(Error);
+				expect(manager.getConnection(DEFERRED_SERVER)).toBeUndefined();
+				expect(manager.getTools().filter(tool => tool.mcpServerName === DEFERRED_SERVER)).toEqual([]);
+				expect(manager.getDiscoverableServerSummaries().some(summary => summary.name === DEFERRED_SERVER)).toBe(
+					false,
+				);
+				expect(onToolsChanged).not.toHaveBeenCalled();
+			} finally {
+				toolLoad.resolve([LIVE_TOOL_DEF]);
+				await manager.disconnectAll();
+			}
+		});
+	}
+
+	it("does not let a stale on-demand readiness attempt poison a same-name replacement", async () => {
+		writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const listLoads: Array<{
+			promise: Promise<MCPToolDefinition[]>;
+			resolve: (value: MCPToolDefinition[]) => void;
+		}> = [];
+		const oldListStarted = Promise.withResolvers<void>();
+		const replacementListStarted = Promise.withResolvers<void>();
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => {
+				const latch = Promise.withResolvers<MCPToolDefinition[]>();
+				listLoads.push(latch);
+				if (listLoads.length === 1) oldListStarted.resolve();
+				if (listLoads.length === 2) replacementListStarted.resolve();
+				return latch.promise;
+			});
+
+			const oldReady = manager.connectServerOnDemand(DEFERRED_SERVER).then(
+				() => undefined,
+				error => error,
+			);
+			await oldListStarted.promise;
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+
+			await manager.disconnectServer(DEFERRED_SERVER);
+			await manager.discoverDeferred();
+
+			const replacementReady = manager.connectServerOnDemand(DEFERRED_SERVER);
+			await replacementListStarted.promise;
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+			expect(manager.getConnection(DEFERRED_SERVER)).toBeDefined();
+			expect(manager.getServerError(DEFERRED_SERVER)).toBeUndefined();
+
+			listLoads[0]?.resolve([LIVE_TOOL_DEF]);
+			const oldOutcome = await oldReady;
+			expect(oldOutcome).toBeInstanceOf(Error);
+			expect(manager.getServerError(DEFERRED_SERVER)).toBeUndefined();
+			let thirdSettled = false;
+			const thirdReady = manager.connectServerOnDemand(DEFERRED_SERVER).finally(() => {
+				thirdSettled = true;
+			});
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+
+			await Promise.resolve();
+			expect(thirdSettled).toBe(false);
+
+			listLoads[1]?.resolve([LIVE_TOOL_DEF]);
+			await Promise.all([replacementReady, thirdReady]);
+			expect(thirdSettled).toBe(true);
+
+			expect(manager.getConnection(DEFERRED_SERVER)).toBeDefined();
+			expect(manager.getTools().filter(tool => tool.mcpServerName === DEFERRED_SERVER)).toHaveLength(1);
+			expect(manager.getServerError(DEFERRED_SERVER)).toBeUndefined();
+		} finally {
+			for (const latch of listLoads) latch.resolve([LIVE_TOOL_DEF]);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("does not let an obsolete connection overwrite its same-name replacement's cache after hashing", async () => {
+		const oldConfig = serverConfig(DEFERRED_SERVER, "Old deferred wiki server");
+		if (oldConfig.type !== "stdio") throw new Error("Expected stdio test config");
+		oldConfig.args = [DEFERRED_SERVER, "old"];
+		fs.writeFileSync(
+			path.join(workDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { [DEFERRED_SERVER]: oldConfig } }),
+		);
+		const toolCache = new MCPToolCache(storage);
+		const manager = new MCPManager(workDir, toolCache);
+		const oldTool: MCPToolDefinition = {
+			...LIVE_TOOL_DEF,
+			name: "old_lookup",
+			description: "Obsolete tool schema",
+		};
+		const replacementTool: MCPToolDefinition = {
+			...LIVE_TOOL_DEF,
+			name: "replacement_lookup",
+			description: "Replacement tool schema",
+		};
+		const connections: MCPServerConnection[] = [];
+		const cacheWrites: Promise<void>[] = [];
+		const originalCacheSet = toolCache.set.bind(toolCache);
+		spyOn(toolCache, "set").mockImplementation((...args) => {
+			const write = originalCacheSet(...args);
+			cacheWrites.push(write);
+			return write;
+		});
+		const setCacheSpy = spyOn(storage, "setCache");
+
+		const blockedDigest = Promise.withResolvers<ArrayBuffer>();
+		const oldDigestStarted = Promise.withResolvers<void>();
+		const originalDigest = crypto.subtle.digest.bind(crypto.subtle);
+		let blockedFirstDigest = false;
+		let releaseOldDigest = async (): Promise<void> => {};
+		spyOn(crypto.subtle, "digest").mockImplementation((algorithm, data) => {
+			if (!blockedFirstDigest) {
+				blockedFirstDigest = true;
+				let released = false;
+				releaseOldDigest = async () => {
+					if (released) return;
+					released = true;
+					blockedDigest.resolve(await originalDigest(algorithm, data));
+				};
+				oldDigestStarted.resolve();
+				return blockedDigest.promise;
+			}
+			return originalDigest(algorithm, data);
+		});
+
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => {
+				const connection = mockConnectionFor(name, config);
+				connections.push(connection);
+				return connection;
+			});
+			listToolsSpy.mockImplementation(async connection =>
+				connection === connections[0] ? [oldTool] : [replacementTool],
+			);
+
+			const oldReady = manager.connectServerOnDemand(DEFERRED_SERVER);
+			await oldDigestStarted.promise;
+			await oldReady;
+			const oldOwnedConfig = manager.getServerConfig(DEFERRED_SERVER);
+			if (!oldOwnedConfig) throw new Error("Expected the old manager-owned config");
+			const oldOwnedConfigSnapshot = structuredClone(oldOwnedConfig);
+			const oldCacheWrite = cacheWrites[0];
+			if (!oldCacheWrite) throw new Error("Expected the old cache write to be pending");
+
+			await manager.disconnectServer(DEFERRED_SERVER);
+			const replacementConfig = serverConfig(DEFERRED_SERVER, "Replacement deferred wiki server");
+			if (replacementConfig.type !== "stdio") throw new Error("Expected stdio test config");
+			replacementConfig.args = [DEFERRED_SERVER, "replacement"];
+			fs.writeFileSync(
+				path.join(workDir, ".mcp.json"),
+				JSON.stringify({ mcpServers: { [DEFERRED_SERVER]: replacementConfig } }),
+			);
+			clearFsCache();
+			await manager.discoverDeferred();
+			await manager.connectServerOnDemand(DEFERRED_SERVER);
+			const replacementOwnedConfig = manager.getServerConfig(DEFERRED_SERVER);
+			if (!replacementOwnedConfig) throw new Error("Expected the replacement manager-owned config");
+			expect(replacementOwnedConfig).not.toEqual(oldOwnedConfigSnapshot);
+			const replacementCacheWrite = cacheWrites[1];
+			if (!replacementCacheWrite) throw new Error("Expected the replacement cache write");
+			await replacementCacheWrite;
+			expect(setCacheSpy).toHaveBeenCalledTimes(1);
+
+			await releaseOldDigest();
+			await oldCacheWrite;
+			expect(setCacheSpy).toHaveBeenCalledTimes(1);
+
+			const freshCache = new MCPToolCache(storage);
+			expect(await freshCache.get(DEFERRED_SERVER, replacementOwnedConfig)).toEqual([replacementTool]);
+			expect(await freshCache.get(DEFERRED_SERVER, oldOwnedConfigSnapshot)).toBeNull();
+		} finally {
+			await releaseOldDigest();
+			await Promise.all(cacheWrites);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("search_tool_bm25 connects and activates a generic live tool matched only by server description", async () => {
+		// Cache-miss server whose only query signal is its configured description;
+		// its live tool name (`search`) does not contain the query terms.
+		fs.writeFileSync(
+			path.join(workDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					[DEFERRED_SERVER]: serverConfig(DEFERRED_SERVER, "Product documentation knowledge base"),
+				},
+			}),
+		);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		try {
+			await manager.discoverDeferred();
+			expect(connectSpy).not.toHaveBeenCalled();
+
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => {
+				expect(name).toBe(DEFERRED_SERVER);
+				return mockConnectionFor(name, config);
+			});
+			listToolsSpy.mockResolvedValue([
+				{ name: "search", description: "Run a query", inputSchema: { type: "object", properties: {} } },
+			]);
+
+			// The pseudo-entry carries the server description in its summary so the
+			// query matches before connect.
+			const pseudo = manager.getDeferredDiscoverableTools();
+			const session = createBm25Session(manager, { discoverableTools: pseudo });
+			const tool = new SearchToolBm25Tool(session);
+
+			const result = await tool.execute("call-desc-only", { query: "documentation knowledge base", limit: 5 });
+
+			// Right server connected once, and the generic live tool ranked/activated
+			// via the preserved description signal — both sinks, not just reconnect.
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(connectSpy.mock.calls[0]?.[0]).toBe(DEFERRED_SERVER);
+			const liveToolName = `mcp__${DEFERRED_SERVER}_search`;
+			expect(result.details?.activated_tools).toContain(liveToolName);
+			expect(result.details?.tools.map(match => match.name)).toContain(liveToolName);
+			expect(session.getSelectedMCPToolNames()).toContain(liveToolName);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("search_tool_bm25 retry after abort joins pending cache-miss readiness and activates", async () => {
+		// Cache-miss server matched only by its configured description; its live
+		// tool name (`search`) does not carry the query terms.
+		fs.writeFileSync(
+			path.join(workDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					[DEFERRED_SERVER]: serverConfig(DEFERRED_SERVER, "Product documentation knowledge base"),
+				},
+			}),
+		);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const listStarted = Promise.withResolvers<void>();
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		const liveToolDef: MCPToolDefinition = {
+			name: "search",
+			description: "Run a query",
+			inputSchema: { type: "object", properties: {} },
+		};
+		const liveToolName = `mcp__${DEFERRED_SERVER}_search`;
+		const query = "documentation knowledge base";
+		const secondReachedManager = Promise.withResolvers<void>();
+		let onDemandCalls = 0;
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => {
+				listStarted.resolve();
+				return toolLoad.promise;
+			});
+
+			// Deterministic join probe: wrap the public connectServerOnDemand so we
+			// can count how many searches actually reached the manager. This
+			// distinguishes "second search joined pending readiness" from "retry has
+			// not reached the connect path yet" — microtask draining alone cannot.
+			const originalConnectServerOnDemand = manager.connectServerOnDemand.bind(manager);
+			spyOn(manager, "connectServerOnDemand").mockImplementation((name, signal) => {
+				onDemandCalls++;
+				if (onDemandCalls === 2) secondReachedManager.resolve();
+				return originalConnectServerOnDemand(name, signal);
+			});
+
+			// ONE session/tool, sourced from the cache-miss pseudo-entry.
+			const session = createBm25Session(manager, {
+				discoverableTools: manager.getDeferredDiscoverableTools(),
+			});
+			const tool = new SearchToolBm25Tool(session);
+
+			// First search: connect resolves, listTools latches, then the caller aborts.
+			const controller = new AbortController();
+			const firstSearch = tool.execute("call-abort", { query, limit: 5 }, controller.signal);
+			await listStarted.promise;
+			expect(onDemandCalls).toBe(1);
+			controller.abort(new DOMException("cancelled", "AbortError"));
+			await expect(firstSearch).rejects.toMatchObject({ name: "AbortError" });
+
+			// Readiness is still pending (listTools latched), so the manager keeps the
+			// pseudo-entry discoverable — proving the cancelled search can retry from it.
+			expect(manager.getConnection(DEFERRED_SERVER)).toBeDefined();
+			expect(manager.getDeferredDiscoverableTools().map(entry => entry.name)).toContain(
+				createMCPServerToolName(DEFERRED_SERVER),
+			);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+
+			// Second search on the SAME session. Await the wrapper's 2nd invocation
+			// (a real causal signal, not a timer) to prove the retry reached the
+			// manager, then assert it joined the shared readiness: the transport
+			// connect/list stay at 1 and the search stays pending.
+			let secondSettled = false;
+			const secondSearch = tool.execute("call-retry", { query, limit: 5 }).then(result => {
+				secondSettled = true;
+				return result;
+			});
+			await secondReachedManager.promise;
+			expect(onDemandCalls).toBe(2);
+			expect(secondSettled).toBe(false);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+
+			// Release the joined readiness: tools load once and the retry ranks +
+			// activates the now-live generic tool via the preserved description signal.
+			toolLoad.resolve([liveToolDef]);
+			const result = await secondSearch;
+			expect(secondSettled).toBe(true);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+			expect(result.details?.activated_tools).toContain(liveToolName);
+			expect(result.details?.tools.map(match => match.name)).toContain(liveToolName);
+			expect(session.getSelectedMCPToolNames()).toContain(liveToolName);
+			expect(manager.getDeferredDiscoverableTools().map(entry => entry.name)).not.toContain(
+				createMCPServerToolName(DEFERRED_SERVER),
+			);
+		} finally {
+			toolLoad.resolve([liveToolDef]);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("resolves both-live normalized-name collisions to the callable registry owner", async () => {
+		// Ambiguous namespace: server `foo` tool `bar_baz` and server `foo_bar`
+		// tool `baz` both normalize to `mcp__foo_bar_baz`. AgentSession registers
+		// manager tools into a Map in array order, so the last exact entry is callable.
+		const fooConfig = serverConfig("foo", "Foo server");
+		const fooBarConfig = serverConfig("foo_bar", "Foo bar server");
+		fs.writeFileSync(
+			path.join(workDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { foo: fooConfig, foo_bar: fooBarConfig } }),
+		);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const collisionName = "mcp__foo_bar_baz";
+		try {
+			await manager.discoverDeferred();
+			// Preserve uncached fallback: the longest configured server prefix wins
+			// before any exact tool metadata exists.
+			expect(manager.resolveServerNameFromToolName("mcp__foo_bar")).toBe("foo");
+			expect(manager.resolveServerNameFromToolName(collisionName)).toBe("foo_bar");
+
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(async (connection: MCPServerConnection) =>
+				connection.name === "foo"
+					? [{ name: "bar_baz", description: "Foo collision", inputSchema: { type: "object", properties: {} } }]
+					: [{ name: "baz", description: "Foo bar collision", inputSchema: { type: "object", properties: {} } }],
+			);
+			await manager.discoverAndConnect();
+
+			const exactOwners = manager
+				.getTools()
+				.filter(tool => tool.name === collisionName)
+				.map(tool => tool.mcpServerName);
+			expect(exactOwners).toEqual(["foo", "foo_bar"]);
+			const callableOwner = await getCallableMCPToolOwner(workDir, manager.getTools(), collisionName);
+			expect(callableOwner).toBe("foo_bar");
+			expect(manager.resolveServerNameFromToolName(collisionName)).toBe(callableOwner);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("resolves both-cached normalized-name collisions to the callable registry owner", async () => {
+		const fooConfig = serverConfig("foo", "Foo server");
+		const fooBarConfig = serverConfig("foo_bar", "Foo bar server");
+		fs.writeFileSync(
+			path.join(workDir, ".mcp.json"),
+			JSON.stringify({ mcpServers: { foo: fooConfig, foo_bar: fooBarConfig } }),
+		);
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set("foo", fooConfig, [
+			{ name: "bar_baz", description: "Cached foo collision", inputSchema: { type: "object", properties: {} } },
+		]);
+		await toolCache.set("foo_bar", fooBarConfig, [
+			{ name: "baz", description: "Cached foo bar collision", inputSchema: { type: "object", properties: {} } },
+		]);
+		const manager = new MCPManager(workDir, toolCache);
+		const collisionName = "mcp__foo_bar_baz";
+		try {
+			await manager.discoverDeferred();
+
+			const exactOwners = manager
+				.getTools()
+				.filter(tool => tool.name === collisionName)
+				.map(tool => tool.mcpServerName);
+			expect(exactOwners).toEqual(["foo", "foo_bar"]);
+			const callableOwner = await getCallableMCPToolOwner(workDir, manager.getTools(), collisionName);
+			expect(callableOwner).toBe("foo_bar");
+			expect(manager.resolveServerNameFromToolName(collisionName)).toBe(callableOwner);
+			expect(connectSpy).not.toHaveBeenCalled();
 		} finally {
 			await manager.disconnectAll();
 		}

--- a/packages/coding-agent/test/mcp-lazy-discovery.test.ts
+++ b/packages/coding-agent/test/mcp-lazy-discovery.test.ts
@@ -33,6 +33,7 @@ import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import {
+	buildDiscoverableToolSearchIndex,
 	type DiscoverableTool,
 	formatDiscoverableToolServerSummary,
 } from "@oh-my-pi/pi-coding-agent/tool-discovery/tool-index";
@@ -126,6 +127,7 @@ function createBm25Session(
 ): LazyDiscoverySession {
 	const activated = options.activated ?? [];
 	let discoverableTools = options.discoverableTools;
+	const initialSearchIndex = buildDiscoverableToolSearchIndex(discoverableTools);
 	return {
 		cwd: "/tmp/lazy-mcp",
 		hasUI: false,
@@ -134,6 +136,7 @@ function createBm25Session(
 		settings: Settings.isolated({ "mcp.lazyDiscovery": true, "mcp.discoveryMode": true }),
 		isMCPDiscoveryEnabled: () => true,
 		getDiscoverableTools: () => discoverableTools,
+		getDiscoverableToolSearchIndex: () => initialSearchIndex,
 		getSelectedMCPToolNames: () => [...activated],
 		activateDiscoveredMCPTools: async (toolNames: string[]) => {
 			for (const name of toolNames) {
@@ -305,6 +308,44 @@ describe("lazy MCP discovery (T6)", () => {
 		} finally {
 			await manager.disconnectAll();
 		}
+	});
+
+	it("ignores description-only edits in cache identity but invalidates transport edits", async () => {
+		const toolCache = new MCPToolCache(storage);
+		const storedConfig: MCPServerConfig = {
+			type: "stdio",
+			command: "cached-server",
+			args: ["--mode", "docs"],
+			env: { TENANT: "alpha" },
+			auth: { type: "apikey", credentialId: "credential-a" },
+			description: "Original display description",
+		};
+		await toolCache.set(CACHED_SERVER, storedConfig, [CACHED_TOOL_DEF]);
+
+		expect(
+			await toolCache.get(CACHED_SERVER, {
+				...storedConfig,
+				description: "Updated display description",
+			}),
+		).toEqual([CACHED_TOOL_DEF]);
+		expect(
+			await toolCache.get(CACHED_SERVER, {
+				...storedConfig,
+				env: { TENANT: "beta" },
+			}),
+		).toBeNull();
+		expect(
+			await toolCache.get(CACHED_SERVER, {
+				...storedConfig,
+				auth: { type: "apikey", credentialId: "credential-b" },
+			}),
+		).toBeNull();
+		expect(
+			await toolCache.get(CACHED_SERVER, {
+				...storedConfig,
+				command: "replacement-server",
+			}),
+		).toBeNull();
 	});
 
 	it("validates guarded cache ownership after hashing and at the persistent write boundary", async () => {
@@ -1544,6 +1585,91 @@ describe("lazy MCP discovery (T6)", () => {
 		} finally {
 			await releaseOldDigest();
 			await Promise.all(cacheWrites);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("search_tool_bm25 initially ranks a cached generic tool by server description without a pseudo-entry", async () => {
+		const config = serverConfig(CACHED_SERVER, "Celestial archive knowledge");
+		fs.writeFileSync(path.join(workDir, ".mcp.json"), JSON.stringify({ mcpServers: { [CACHED_SERVER]: config } }));
+		const genericTool: MCPToolDefinition = {
+			name: "search",
+			description: "Run a query",
+			inputSchema: { type: "object", properties: {} },
+		};
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set(CACHED_SERVER, config, [genericTool]);
+		const manager = new MCPManager(workDir, toolCache);
+		try {
+			const discovered = await manager.discoverDeferred();
+			expect(manager.getDeferredDiscoverableTools()).toEqual([]);
+			connectSpy.mockImplementation(async (name: string, liveConfig: MCPServerConfig) =>
+				mockConnectionFor(name, liveConfig),
+			);
+			listToolsSpy.mockResolvedValue([genericTool]);
+			const initialTool: DiscoverableTool = {
+				name: `mcp__${CACHED_SERVER}_search`,
+				label: `${CACHED_SERVER}/search`,
+				summary: genericTool.description ?? "search",
+				source: "mcp",
+				serverName: CACHED_SERVER,
+				mcpToolName: "search",
+				schemaKeys: [],
+			};
+			expect(discovered.tools.map(tool => tool.name)).toEqual([initialTool.name]);
+			const session = createBm25Session(manager, { discoverableTools: [initialTool] });
+
+			const result = await new SearchToolBm25Tool(session).execute("cached-desc", {
+				query: "celestial archive knowledge",
+				limit: 5,
+			});
+
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(result.details?.activated_tools).toEqual([initialTool.name]);
+			expect(result.details?.tools.map(match => match.name)).toContain(initialTool.name);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("search_tool_bm25 initially ranks an already-connected generic tool by server description", async () => {
+		const config = serverConfig(CACHED_SERVER, "Celestial archive knowledge");
+		fs.writeFileSync(path.join(workDir, ".mcp.json"), JSON.stringify({ mcpServers: { [CACHED_SERVER]: config } }));
+		const genericTool: MCPToolDefinition = {
+			name: "search",
+			description: "Run a query",
+			inputSchema: { type: "object", properties: {} },
+		};
+		connectSpy.mockImplementation(async (name: string, liveConfig: MCPServerConfig) =>
+			mockConnectionFor(name, liveConfig),
+		);
+		listToolsSpy.mockResolvedValue([genericTool]);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		try {
+			const discovered = await manager.discoverDeferred({ discoveryDefaultServers: [CACHED_SERVER] });
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(manager.getDeferredDiscoverableTools()).toEqual([]);
+			const initialTool: DiscoverableTool = {
+				name: `mcp__${CACHED_SERVER}_search`,
+				label: `${CACHED_SERVER}/search`,
+				summary: genericTool.description ?? "search",
+				source: "mcp",
+				serverName: CACHED_SERVER,
+				mcpToolName: "search",
+				schemaKeys: [],
+			};
+			expect(discovered.tools.map(tool => tool.name)).toEqual([initialTool.name]);
+			const session = createBm25Session(manager, { discoverableTools: [initialTool] });
+
+			const result = await new SearchToolBm25Tool(session).execute("connected-desc", {
+				query: "celestial archive knowledge",
+				limit: 5,
+			});
+
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(result.details?.activated_tools).toEqual([initialTool.name]);
+			expect(result.details?.tools.map(match => match.name)).toContain(initialTool.name);
+		} finally {
 			await manager.disconnectAll();
 		}
 	});

--- a/packages/coding-agent/test/mcp-lazy-discovery.test.ts
+++ b/packages/coding-agent/test/mcp-lazy-discovery.test.ts
@@ -1,30 +1,42 @@
 /**
  * Contracts for T6 lazy MCP discovery (`mcp.lazyDiscovery`):
  *
- * 1. `discoverDeferred` loads cached schemas without calling `connectToServer`.
+ * 1. Deferred discovery uses cached schemas, distinct pseudo-names, and longest
+ *    configured server-name matching without connecting eagerly.
  * 2. Server summaries mark cached vs deferred (cache-miss) servers for prompts.
- * 3. `search_tool_bm25` matching a cached lazy tool connects that server once
- *    and activates the real tool after refresh.
- * 4. A failing on-demand connect surfaces `server "<name>" unavailable: …`.
- * 5. Eager `discoverAndConnect` still connects at discovery time.
+ * 3. Explicit headless selections reactivate after on-demand refresh.
+ * 4. Malformed lazy config remains non-fatal and logs its parse failure.
+ * 5. Search cancellation aborts on-demand waits instead of reporting unavailable.
+ * 6. Stored connections are ready only after successful tool loading; failed
+ *    loads are discarded and can retry.
+ * 7. MCP refresh updates serialize and recover after a rejected update.
+ * 8. Per-caller aborts do not cancel or poison shared connection readiness.
+ * 9. Concrete transport schemas accept descriptions without opening the schema.
+ * 10. Eager `discoverAndConnect` still connects at discovery time.
  */
 import { afterEach, beforeEach, describe, expect, it, type Mock, mock, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { createMCPServerToolName } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import { MCPToolCache } from "@oh-my-pi/pi-coding-agent/mcp/tool-cache";
 import type { MCPServerConfig, MCPServerConnection, MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import {
 	type DiscoverableTool,
 	formatDiscoverableToolServerSummary,
 } from "@oh-my-pi/pi-coding-agent/tool-discovery/tool-index";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { renderSearchToolBm25Description, SearchToolBm25Tool } from "@oh-my-pi/pi-coding-agent/tools/search-tool-bm25";
-import { getAgentDir, removeSyncWithRetries, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
+import { getAgentDir, logger, removeSyncWithRetries, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
+import mcpSchema from "../src/config/mcp-schema.json" with { type: "json" };
 import { createMockConnection, createMockTransport } from "./mcp-test-utils";
 
 const CACHED_SERVER = "cached_docs";
@@ -147,6 +159,31 @@ function createBm25Session(
 	};
 }
 
+async function waitFor(predicate: () => boolean, message: string, timeoutMs = 1_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error(message);
+		await Bun.sleep(1);
+	}
+}
+
+type ClosedTransportSchema = {
+	additionalProperties: false;
+	properties: Record<string, unknown>;
+};
+
+function isClosedTransportSchema(value: unknown): value is ClosedTransportSchema {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"additionalProperties" in value &&
+		value.additionalProperties === false &&
+		"properties" in value &&
+		typeof value.properties === "object" &&
+		value.properties !== null
+	);
+}
+
 describe("lazy MCP discovery (T6)", () => {
 	let workDir: string;
 	let isolatedHome: string;
@@ -226,7 +263,7 @@ describe("lazy MCP discovery (T6)", () => {
 
 			const deferredPseudo = manager.getDeferredDiscoverableTools();
 			const deferredNames = deferredPseudo.map(tool => tool.name);
-			expect(deferredNames).toContain(`mcp__${DEFERRED_SERVER}`);
+			expect(deferredNames).toContain(createMCPServerToolName(DEFERRED_SERVER));
 			expect(deferredNames).not.toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
 			const deferredEntry = deferredPseudo.find(tool => tool.serverName === DEFERRED_SERVER);
 			expect(deferredEntry?.deferredServer).toBe(true);
@@ -234,6 +271,53 @@ describe("lazy MCP discovery (T6)", () => {
 		} finally {
 			await manager.disconnectAll();
 		}
+	});
+
+	it("resolves lazy MCP tool names against the longest configured sanitized server name", async () => {
+		fs.writeFileSync(
+			path.join(workDir, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					github: serverConfig("github", "GitHub"),
+					"github-mcp": serverConfig("github-mcp", "GitHub MCP"),
+				},
+			}),
+		);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		try {
+			await manager.discoverDeferred();
+
+			expect(manager.resolveServerNameFromToolName("mcp__github_mcp_search")).toBe("github-mcp");
+			expect(manager.resolveServerNameFromToolName("mcp__github_search")).toBe("github");
+			expect(manager.resolveServerNameFromToolName("mcp__missing_search")).toBeUndefined();
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("deferred server pseudo-entry does not overwrite a real MCP tool name", () => {
+		const realTool: DiscoverableTool = {
+			name: "mcp__foo_bar",
+			label: "foo/bar",
+			summary: "Real foo tool",
+			source: "mcp",
+			serverName: "foo",
+			mcpToolName: "bar",
+			schemaKeys: [],
+		};
+		const deferredServer: DiscoverableTool = {
+			name: createMCPServerToolName("foo_bar"),
+			label: "foo_bar",
+			summary: "Deferred foo_bar server",
+			source: "mcp",
+			serverName: "foo_bar",
+			deferredServer: true,
+			schemaKeys: [],
+		};
+		const discoverableByName = new Map([realTool, deferredServer].map(tool => [tool.name, tool]));
+
+		expect([...discoverableByName.keys()]).toEqual(expect.arrayContaining(["mcp__foo_bar", "mcp__server__foo_bar"]));
+		expect(discoverableByName.get("mcp__foo_bar")?.deferredServer).not.toBe(true);
 	});
 
 	it("prompt summaries advertise cached and deferred servers", () => {
@@ -249,7 +333,7 @@ describe("lazy MCP discovery (T6)", () => {
 					schemaKeys: ["query"],
 				},
 				{
-					name: `mcp__${DEFERRED_SERVER}`,
+					name: createMCPServerToolName(DEFERRED_SERVER),
 					label: DEFERRED_SERVER,
 					summary: `MCP server "${DEFERRED_SERVER}" — tools not yet loaded; searching or calling loads them`,
 					source: "mcp",
@@ -295,6 +379,337 @@ describe("lazy MCP discovery (T6)", () => {
 		expect(rendered).toContain(`${CACHED_SERVER} (1 tool cached)`);
 		expect(rendered).toContain(`${DEFERRED_SERVER} (deferred)`);
 	});
+
+	it("reactivates explicitly requested lazy MCP tools after on-demand refresh", async () => {
+		writeProjectMcpConfig(workDir);
+		const toolName = `mcp__${CACHED_SERVER}_lookup_docs`;
+		// Intentionally uncached: FIX B must activate after live connect/list/refresh,
+		// not via a pre-seeded MCPToolCache schema that already looks selected.
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		await manager.discoverDeferred();
+		connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => mockConnectionFor(name, config));
+		listToolsSpy.mockImplementation(() => toolLoad.promise);
+		const authStorage = await AuthStorage.create(path.join(workDir, `lazy-reactivation-${Snowflake.next()}.db`));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "lazy-reactivation-models.yml"));
+		try {
+			const { session } = await createAgentSession({
+				cwd: workDir,
+				agentDir: path.join(workDir, "agent"),
+				authStorage,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "mcp.lazyDiscovery": true, "mcp.discoveryMode": true }),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableLsp: false,
+				hasUI: false,
+				mcpManager: manager,
+				toolNames: [toolName],
+			});
+			try {
+				// Explicit requested name starts absent until connect/list/refresh/activation.
+				expect(session.getSelectedMCPToolNames()).not.toContain(toolName);
+				expect(session.getActiveToolNames()).not.toContain(toolName);
+
+				toolLoad.resolve([LIVE_TOOL_DEF]);
+				await waitFor(
+					() => session.getActiveToolNames().includes(toolName),
+					"Timed out waiting for requested lazy MCP tool activation",
+				);
+				expect(session.getSelectedMCPToolNames()).toContain(toolName);
+				expect(session.getActiveToolNames()).toContain(toolName);
+			} finally {
+				toolLoad.resolve([LIVE_TOOL_DEF]);
+				await session.dispose();
+			}
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			authStorage.close();
+			await manager.disconnectAll();
+		}
+	});
+
+	it("waits for a stored connection's tool load before activating a requested tool", async () => {
+		writeProjectMcpConfig(workDir);
+		const toolName = `mcp__${CACHED_SERVER}_lookup_docs`;
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		const authStorage = await AuthStorage.create(path.join(workDir, `stored-loading-${Snowflake.next()}.db`));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "stored-loading-models.yml"));
+		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => toolLoad.promise);
+			const startupConnect = manager.connectServerOnDemand(CACHED_SERVER);
+			await waitFor(
+				() => manager.getConnection(CACHED_SERVER) !== undefined,
+				"Timed out waiting for stored MCP connection",
+			);
+
+			({ session } = await createAgentSession({
+				cwd: workDir,
+				agentDir: path.join(workDir, "agent"),
+				authStorage,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "mcp.lazyDiscovery": true, "mcp.discoveryMode": true }),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableLsp: false,
+				hasUI: false,
+				mcpManager: manager,
+				toolNames: [toolName],
+			}));
+			expect(session.getSelectedMCPToolNames()).not.toContain(toolName);
+			expect(session.getActiveToolNames()).not.toContain(toolName);
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await startupConnect;
+			await waitFor(
+				() => session?.getActiveToolNames().includes(toolName) === true,
+				"Timed out waiting for stored MCP tool activation after readiness",
+			);
+			expect(session.getSelectedMCPToolNames()).toContain(toolName);
+			expect(session.getActiveToolNames()).toContain(toolName);
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await session?.dispose();
+			authStorage.close();
+			await manager.disconnectAll();
+		}
+	});
+
+	it("serializes owned-manager tool refresh before requested-tool activation", async () => {
+		writeProjectMcpConfig(workDir);
+		const toolName = `mcp__${CACHED_SERVER}_lookup_docs`;
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => mockConnectionFor(name, config));
+		listToolsSpy.mockImplementation(() => toolLoad.promise);
+		const authStorage = await AuthStorage.create(path.join(workDir, `serialized-refresh-${Snowflake.next()}.db`));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "serialized-refresh-models.yml"));
+		const firstRefreshStarted = Promise.withResolvers<void>();
+		const releaseFirstRefresh = Promise.withResolvers<void>();
+		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		let manager: MCPManager | undefined;
+		try {
+			({ session, mcpManager: manager } = await createAgentSession({
+				cwd: workDir,
+				agentDir: path.join(workDir, "agent"),
+				authStorage,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "mcp.lazyDiscovery": true, "mcp.discoveryMode": true }),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableLsp: false,
+				hasUI: false,
+				toolNames: [toolName],
+			}));
+			const originalRefresh = session.refreshMCPTools.bind(session);
+			const activeSession = session;
+			let refreshCalls = 0;
+			spyOn(session, "refreshMCPTools").mockImplementation(async (tools, options) => {
+				refreshCalls++;
+				if (refreshCalls === 1) {
+					firstRefreshStarted.resolve();
+					await releaseFirstRefresh.promise;
+				}
+				await originalRefresh(tools, options);
+				if (refreshCalls === 1) activeSession.agent.setSystemPrompt(["stale-pre-activation-prompt"]);
+			});
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await firstRefreshStarted.promise;
+			await Bun.sleep(0);
+			expect(refreshCalls).toBe(1);
+			expect(session.getActiveToolNames()).not.toContain(toolName);
+
+			releaseFirstRefresh.resolve();
+			await waitFor(
+				() =>
+					session?.getActiveToolNames().includes(toolName) === true &&
+					session.systemPrompt[0] !== "stale-pre-activation-prompt",
+				"Timed out waiting for serialized MCP activation and prompt application",
+			);
+			expect(refreshCalls).toBe(2);
+			expect(session.getSelectedMCPToolNames()).toContain(toolName);
+			expect(session.systemPrompt).not.toEqual(["stale-pre-activation-prompt"]);
+		} finally {
+			releaseFirstRefresh.resolve();
+			await session?.dispose();
+			authStorage.close();
+			await manager?.disconnectAll();
+		}
+	});
+
+	it("recovers the MCP update queue after a refresh rejects", async () => {
+		writeProjectMcpConfig(workDir);
+		const toolName = `mcp__${CACHED_SERVER}_lookup_docs`;
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => mockConnectionFor(name, config));
+		listToolsSpy.mockImplementation(() => toolLoad.promise);
+		const authStorage = await AuthStorage.create(path.join(workDir, `queue-recovery-${Snowflake.next()}.db`));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "queue-recovery-models.yml"));
+		const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		let manager: MCPManager | undefined;
+		try {
+			({ session, mcpManager: manager } = await createAgentSession({
+				cwd: workDir,
+				agentDir: path.join(workDir, "agent"),
+				authStorage,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "mcp.lazyDiscovery": true, "mcp.discoveryMode": true }),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableLsp: false,
+				hasUI: false,
+				toolNames: [toolName],
+			}));
+			const originalRefresh = session.refreshMCPTools.bind(session);
+			let refreshCalls = 0;
+			spyOn(session, "refreshMCPTools").mockImplementation(async (tools, options) => {
+				refreshCalls++;
+				if (refreshCalls === 1) throw new Error("first queued refresh rejected");
+				await originalRefresh(tools, options);
+			});
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await waitFor(
+				() => session?.getActiveToolNames().includes(toolName) === true,
+				"Timed out waiting for MCP update queue recovery",
+			);
+
+			expect(refreshCalls).toBe(2);
+			expect(warnSpy).toHaveBeenCalledWith("MCP tool refresh failed", {
+				error: "first queued refresh rejected",
+			});
+			expect(session.getSelectedMCPToolNames()).toContain(toolName);
+			expect(session.getActiveToolNames()).toContain(toolName);
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			warnSpy.mockRestore();
+			await session?.dispose();
+			authStorage.close();
+			await manager?.disconnectAll();
+		}
+	});
+
+	it("does not activate requested MCP tools when disposal starts during refresh", async () => {
+		writeProjectMcpConfig(workDir);
+		const toolName = `mcp__${CACHED_SERVER}_lookup_docs`;
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		const authStorage = await AuthStorage.create(path.join(workDir, `dispose-refresh-${Snowflake.next()}.db`));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, "dispose-refresh-models.yml"));
+		let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
+		let refreshCompleted = false;
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => toolLoad.promise);
+			const startupConnect = manager.connectServerOnDemand(CACHED_SERVER);
+			await waitFor(
+				() => manager.getConnection(CACHED_SERVER) !== undefined,
+				"Timed out waiting for stored MCP connection",
+			);
+			({ session } = await createAgentSession({
+				cwd: workDir,
+				agentDir: path.join(workDir, "agent"),
+				authStorage,
+				modelRegistry,
+				sessionManager: SessionManager.inMemory(),
+				settings: Settings.isolated({ "mcp.lazyDiscovery": true, "mcp.discoveryMode": true }),
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableLsp: false,
+				hasUI: false,
+				mcpManager: manager,
+				toolNames: [toolName],
+			}));
+			const originalRefresh = session.refreshMCPTools.bind(session);
+			spyOn(session, "refreshMCPTools").mockImplementation(async (tools, options) => {
+				await originalRefresh(tools, options);
+				await session?.dispose();
+				refreshCompleted = true;
+			});
+			const activateSpy = spyOn(session, "activateDiscoveredMCPTools");
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await startupConnect;
+			await waitFor(() => refreshCompleted, "Timed out waiting for MCP refresh disposal");
+			await Bun.sleep(0);
+			expect(session.isDisposed).toBe(true);
+			expect(activateSpy).not.toHaveBeenCalled();
+			expect(session.getSelectedMCPToolNames()).not.toContain(toolName);
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await session?.dispose();
+			authStorage.close();
+			await manager.disconnectAll();
+		}
+	});
+
+	for (const hasUI of [false, true]) {
+		it(`malformed lazy MCP config is non-fatal with hasUI=${hasUI}`, async () => {
+			fs.mkdirSync(getAgentDir(), { recursive: true });
+			fs.writeFileSync(path.join(getAgentDir(), "mcp.json"), '{"mcpServers":');
+			const authStorage = await AuthStorage.create(path.join(workDir, `malformed-${hasUI}-${Snowflake.next()}.db`));
+			const modelRegistry = new ModelRegistry(authStorage, path.join(workDir, `malformed-${hasUI}-models.yml`));
+			const errorSpy = spyOn(logger, "error").mockImplementation(() => {});
+			try {
+				const { session } = await createAgentSession({
+					cwd: workDir,
+					agentDir: path.join(workDir, "agent"),
+					authStorage,
+					modelRegistry,
+					sessionManager: SessionManager.inMemory(),
+					settings: Settings.isolated({ "mcp.lazyDiscovery": true }),
+					disableExtensionDiscovery: true,
+					skills: [],
+					contextFiles: [],
+					promptTemplates: [],
+					slashCommands: [],
+					enableLsp: false,
+					hasUI,
+				});
+				try {
+					expect(session.getAllToolNames().filter(name => name.startsWith("mcp__"))).toEqual([]);
+					expect(errorSpy).toHaveBeenCalledWith("MCP tool load failed", {
+						path: ".mcp.json",
+						error: expect.stringContaining("JSON Parse error: Unexpected EOF"),
+					});
+				} finally {
+					await session.dispose();
+				}
+			} finally {
+				errorSpy.mockRestore();
+				authStorage.close();
+			}
+		});
+	}
 
 	it("search_tool_bm25 matching a cached lazy tool connects once and activates it", async () => {
 		const { cached } = writeProjectMcpConfig(workDir);
@@ -350,6 +765,173 @@ describe("lazy MCP discovery (T6)", () => {
 		}
 	});
 
+	it("search_tool_bm25 aborts while waiting for lazy MCP on-demand connect", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set(CACHED_SERVER, cached, [CACHED_TOOL_DEF]);
+		const manager = new MCPManager(workDir, toolCache);
+		const connectionReady = Promise.withResolvers<void>();
+		try {
+			await manager.discoverDeferred();
+			const connectStarted = Promise.withResolvers<void>();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => {
+				connectStarted.resolve();
+				await connectionReady.promise;
+				return mockConnectionFor(name, config);
+			});
+			listToolsSpy.mockResolvedValue([LIVE_TOOL_DEF]);
+			const originalConnectServerOnDemand = manager.connectServerOnDemand.bind(manager);
+			let observedSignal: AbortSignal | undefined;
+			spyOn(manager, "connectServerOnDemand").mockImplementation((name, signal) => {
+				observedSignal = signal;
+				return originalConnectServerOnDemand(name, signal);
+			});
+			const discoverableTools: DiscoverableTool[] = [
+				{
+					name: `mcp__${CACHED_SERVER}_lookup_docs`,
+					label: `${CACHED_SERVER}/lookup_docs`,
+					summary: CACHED_TOOL_DEF.description ?? "docs",
+					source: "mcp",
+					serverName: CACHED_SERVER,
+					mcpToolName: "lookup_docs",
+					schemaKeys: ["query"],
+				},
+			];
+			const tool = new SearchToolBm25Tool(createBm25Session(manager, { discoverableTools }));
+			const controller = new AbortController();
+			const execution = tool.execute("call-abort", { query: "documentation lookup", limit: 1 }, controller.signal);
+			await connectStarted.promise;
+			controller.abort(new DOMException("cancelled", "AbortError"));
+
+			const promptRejection = Promise.race([
+				execution,
+				Bun.sleep(250).then(() => {
+					throw new Error("Timed out waiting for lazy MCP search cancellation");
+				}),
+			]);
+			await expect(promptRejection).rejects.toMatchObject({ name: "AbortError" });
+			expect(observedSignal).toBe(controller.signal);
+		} finally {
+			connectionReady.resolve();
+			await manager.connectServerOnDemand(CACHED_SERVER).catch(() => undefined);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("isolates one caller's abort from a shared on-demand attempt", async () => {
+		writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const listStarted = Promise.withResolvers<void>();
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => {
+				listStarted.resolve();
+				return toolLoad.promise;
+			});
+			const controller = new AbortController();
+			const first = manager.connectServerOnDemand(CACHED_SERVER, controller.signal);
+			await listStarted.promise;
+			let secondSettled = false;
+			const secondResult = manager.connectServerOnDemand(CACHED_SERVER).then(
+				() => {
+					secondSettled = true;
+					return undefined;
+				},
+				error => {
+					secondSettled = true;
+					return error;
+				},
+			);
+
+			controller.abort(new DOMException("cancel first waiter", "AbortError"));
+			await expect(first).rejects.toMatchObject({ name: "AbortError", message: "cancel first waiter" });
+			await Promise.resolve();
+			expect(secondSettled).toBe(false);
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			expect(await secondResult).toBeUndefined();
+			expect(secondSettled).toBe(true);
+			expect(manager.getTools().map(tool => tool.name)).toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("search_tool_bm25 waits for stored connection tool load before refresh", async () => {
+		writeProjectMcpConfig(workDir);
+		const toolName = `mcp__${CACHED_SERVER}_lookup_docs`;
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		const originalConnectServerOnDemand = manager.connectServerOnDemand.bind(manager);
+		let readinessSpy: { mockRestore: () => void } | undefined;
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => toolLoad.promise);
+
+			// Store the connection before listTools finishes so a getConnection()
+			// presence check would incorrectly skip readiness-aware connect.
+			const startupConnect = manager.connectServerOnDemand(CACHED_SERVER);
+			await waitFor(
+				() => manager.getConnection(CACHED_SERVER) !== undefined,
+				"Timed out waiting for stored MCP connection",
+			);
+
+			let readinessEntered = false;
+			readinessSpy = spyOn(manager, "connectServerOnDemand").mockImplementation((name, signal) => {
+				if (name === CACHED_SERVER) readinessEntered = true;
+				return originalConnectServerOnDemand(name, signal);
+			});
+
+			const discoverableTools: DiscoverableTool[] = [
+				{
+					name: toolName,
+					label: `${CACHED_SERVER}/lookup_docs`,
+					summary: CACHED_TOOL_DEF.description ?? "docs",
+					source: "mcp",
+					serverName: CACHED_SERVER,
+					mcpToolName: "lookup_docs",
+					schemaKeys: ["query"],
+				},
+			];
+			const session = createBm25Session(manager, { discoverableTools });
+			const tool = new SearchToolBm25Tool(session);
+			let searchSettled = false;
+			const search = tool
+				.execute("call-stored-loading", { query: "documentation lookup", limit: 1 })
+				.then(result => {
+					searchSettled = true;
+					return result;
+				});
+
+			// If getConnection() early-return is restored, search never joins readiness.
+			await waitFor(() => readinessEntered, "Timed out waiting for search to enter connectServerOnDemand readiness");
+			expect(searchSettled).toBe(false);
+			expect(session.getSelectedMCPToolNames()).not.toContain(toolName);
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await startupConnect;
+			const result = await search;
+			expect(searchSettled).toBe(true);
+			expect(result.details?.activated_tools).toEqual([toolName]);
+			expect(session.getSelectedMCPToolNames()).toContain(toolName);
+			expect(manager.getTools().map(entry => entry.name)).toContain(toolName);
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			readinessSpy?.mockRestore();
+			await manager.disconnectAll();
+		}
+	});
+
 	it("search_tool_bm25 reports unavailable when on-demand connect fails", async () => {
 		const { cached } = writeProjectMcpConfig(workDir);
 		const toolCache = new MCPToolCache(storage);
@@ -395,6 +977,95 @@ describe("lazy MCP discovery (T6)", () => {
 		}
 	});
 
+	it("connectServerOnDemand waits for tool loading after connection is stored", async () => {
+		writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const toolLoad = Promise.withResolvers<MCPToolDefinition[]>();
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(() => toolLoad.promise);
+
+			const first = manager.connectServerOnDemand(CACHED_SERVER);
+			await waitFor(
+				() => manager.getConnection(CACHED_SERVER) !== undefined,
+				"Timed out waiting for MCP connection storage",
+			);
+			let secondResolved = false;
+			const second = manager.connectServerOnDemand(CACHED_SERVER).then(() => {
+				secondResolved = true;
+			});
+			await Promise.resolve();
+
+			expect(secondResolved).toBe(false);
+			expect(manager.getTools().map(tool => tool.name)).not.toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
+
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await Promise.all([first, second]);
+			expect(manager.getTools().map(tool => tool.name)).toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
+		} finally {
+			toolLoad.resolve([LIVE_TOOL_DEF]);
+			await manager.disconnectAll();
+		}
+	});
+
+	it("retries after a stored connection's tool load rejects", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const manager = new MCPManager(workDir, new MCPToolCache(storage));
+		const firstConnection = mockConnectionFor(CACHED_SERVER, cached);
+		const closeStarted = Promise.withResolvers<void>();
+		const releaseClose = Promise.withResolvers<void>();
+		const toolLoadError = new Error("tools/list rejected");
+		let firstConnectionCloseCalls = 0;
+		firstConnection.transport.close = async () => {
+			firstConnectionCloseCalls++;
+			closeStarted.resolve();
+			await releaseClose.promise;
+		};
+		connectSpy
+			.mockResolvedValueOnce(firstConnection)
+			.mockImplementation(async (name: string, config: MCPServerConfig) => mockConnectionFor(name, config));
+		listToolsSpy.mockRejectedValueOnce(toolLoadError).mockResolvedValueOnce([LIVE_TOOL_DEF]);
+		try {
+			const initialLoad = manager.connectServers({ [CACHED_SERVER]: cached }, {});
+			await closeStarted.promise;
+			expect(manager.getConnection(CACHED_SERVER)).toBe(firstConnection);
+
+			let readinessSettled = false;
+			const readinessResult = manager.connectServerOnDemand(CACHED_SERVER).then(
+				() => {
+					readinessSettled = true;
+					return undefined;
+				},
+				error => {
+					readinessSettled = true;
+					return error;
+				},
+			);
+			await Promise.resolve();
+			expect(readinessSettled).toBe(false);
+
+			releaseClose.resolve();
+			const initial = await initialLoad;
+			expect(initial.errors.get(CACHED_SERVER)).toBe("tools/list rejected");
+			expect(await readinessResult).toBe(toolLoadError);
+			expect(manager.getConnection(CACHED_SERVER)).toBeUndefined();
+
+			await manager.connectServerOnDemand(CACHED_SERVER);
+
+			expect(firstConnectionCloseCalls).toBe(1);
+			expect(connectSpy).toHaveBeenCalledTimes(2);
+			expect(listToolsSpy).toHaveBeenCalledTimes(2);
+			expect(manager.getConnection(CACHED_SERVER)).not.toBe(firstConnection);
+			expect(manager.getTools().map(tool => tool.name)).toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
+		} finally {
+			releaseClose.resolve();
+			await manager.disconnectAll();
+		}
+	});
+
 	it("connectServerOnDemand reuses an existing pending connection", async () => {
 		const { cached } = writeProjectMcpConfig(workDir);
 		const manager = new MCPManager(workDir, new MCPToolCache(storage));
@@ -423,6 +1094,21 @@ describe("lazy MCP discovery (T6)", () => {
 			expect(manager.getTools().map(tool => tool.name)).toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
 		} finally {
 			await manager.disconnectAll();
+		}
+	});
+
+	it("MCP schema allows description on every concrete transport", () => {
+		for (const serverName of ["stdioServer", "httpServer", "sseServer"] as const) {
+			const transportSchema = mcpSchema.$defs[serverName].allOf.find(isClosedTransportSchema);
+			expect(transportSchema).toBeDefined();
+			if (!transportSchema?.properties) {
+				throw new Error(`Expected ${serverName} closed transport schema to define properties`);
+			}
+			expect(transportSchema.additionalProperties).toBe(false);
+			expect(transportSchema.properties.description).toEqual({
+				type: "string",
+				description: "Human-readable server description shown in lazy discovery summaries.",
+			});
 		}
 	});
 

--- a/packages/coding-agent/test/mcp-lazy-discovery.test.ts
+++ b/packages/coding-agent/test/mcp-lazy-discovery.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Contracts for T6 lazy MCP discovery (`mcp.lazyDiscovery`):
+ *
+ * 1. `discoverDeferred` loads cached schemas without calling `connectToServer`.
+ * 2. Server summaries mark cached vs deferred (cache-miss) servers for prompts.
+ * 3. `search_tool_bm25` matching a cached lazy tool connects that server once
+ *    and activates the real tool after refresh.
+ * 4. A failing on-demand connect surfaces `server "<name>" unavailable: …`.
+ * 5. Eager `discoverAndConnect` still connects at discovery time.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as mcpClient from "@oh-my-pi/pi-coding-agent/mcp/client";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { MCPToolCache } from "@oh-my-pi/pi-coding-agent/mcp/tool-cache";
+import type { MCPServerConfig, MCPServerConnection, MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import {
+	type DiscoverableTool,
+	formatDiscoverableToolServerSummary,
+} from "@oh-my-pi/pi-coding-agent/tool-discovery/tool-index";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { renderSearchToolBm25Description, SearchToolBm25Tool } from "@oh-my-pi/pi-coding-agent/tools/search-tool-bm25";
+import { getAgentDir, removeSyncWithRetries, Snowflake, setAgentDir } from "@oh-my-pi/pi-utils";
+import { createMockConnection, createMockTransport } from "./mcp-test-utils";
+
+const CACHED_SERVER = "cached_docs";
+const DEFERRED_SERVER = "deferred_wiki";
+const CACHED_TOOL_DEF: MCPToolDefinition = {
+	name: "lookup_docs",
+	description: "Look up product documentation by keyword",
+	inputSchema: {
+		type: "object",
+		properties: { query: { type: "string" } },
+		required: ["query"],
+	},
+};
+const LIVE_TOOL_DEF: MCPToolDefinition = {
+	name: "lookup_docs",
+	description: "Live documentation lookup after connect",
+	inputSchema: {
+		type: "object",
+		properties: { query: { type: "string" } },
+		required: ["query"],
+	},
+};
+
+function serverConfig(name: string, description: string): MCPServerConfig {
+	return {
+		type: "stdio",
+		command: "echo",
+		args: [name],
+		description,
+	};
+}
+
+function writeProjectMcpConfig(cwd: string): {
+	cached: MCPServerConfig;
+	deferred: MCPServerConfig;
+} {
+	const cached = serverConfig(CACHED_SERVER, "Cached docs server");
+	const deferred = serverConfig(DEFERRED_SERVER, "Deferred wiki server");
+	fs.writeFileSync(
+		path.join(cwd, ".mcp.json"),
+		JSON.stringify({
+			mcpServers: {
+				[CACHED_SERVER]: cached,
+				[DEFERRED_SERVER]: deferred,
+			},
+		}),
+	);
+	return { cached, deferred };
+}
+
+function mockConnectionFor(name: string, config: MCPServerConfig): MCPServerConnection {
+	const connection = createMockConnection({ tools: {} }, createMockTransport(new Map()));
+	connection.name = name;
+	connection.config = config;
+	return connection;
+}
+
+type LazyDiscoverySession = ToolSession & {
+	isMCPDiscoveryEnabled: () => boolean;
+	getDiscoverableTools: (filter?: { source?: DiscoverableTool["source"] }) => DiscoverableTool[];
+	getSelectedMCPToolNames: () => string[];
+	activateDiscoveredMCPTools: (toolNames: string[]) => Promise<string[]>;
+	refreshMCPTools?: (tools: unknown[]) => Promise<void>;
+	mcpManager?: MCPManager;
+};
+
+type RefreshedMCPTool = {
+	name: string;
+	description?: string;
+	mcpServerName?: string;
+	mcpToolName?: string;
+};
+
+function isRefreshedMCPTool(tool: unknown): tool is RefreshedMCPTool {
+	return typeof tool === "object" && tool !== null && "name" in tool && typeof tool.name === "string";
+}
+
+function createBm25Session(
+	manager: MCPManager,
+	options: {
+		discoverableTools: DiscoverableTool[];
+		activated?: string[];
+	},
+): LazyDiscoverySession {
+	const activated = options.activated ?? [];
+	let discoverableTools = options.discoverableTools;
+	return {
+		cwd: "/tmp/lazy-mcp",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated({ "mcp.lazyDiscovery": true, "mcp.discoveryMode": true }),
+		isMCPDiscoveryEnabled: () => true,
+		getDiscoverableTools: () => discoverableTools,
+		getSelectedMCPToolNames: () => [...activated],
+		activateDiscoveredMCPTools: async (toolNames: string[]) => {
+			for (const name of toolNames) {
+				if (!activated.includes(name)) activated.push(name);
+			}
+			return toolNames;
+		},
+		refreshMCPTools: async tools => {
+			// After on-demand connect, re-expose live tool names so BM25 can activate them.
+			const refreshed: DiscoverableTool[] = [];
+			for (const tool of tools) {
+				if (!isRefreshedMCPTool(tool)) continue;
+				refreshed.push({
+					name: tool.name,
+					label: tool.name,
+					summary: tool.description ?? tool.name,
+					source: "mcp" as const,
+					serverName: tool.mcpServerName,
+					mcpToolName: tool.mcpToolName,
+					schemaKeys: [],
+				});
+			}
+			discoverableTools = refreshed;
+		},
+		mcpManager: manager,
+	};
+}
+
+describe("lazy MCP discovery (T6)", () => {
+	let workDir: string;
+	let isolatedHome: string;
+	let originalAgentDir: string;
+	let storage: AgentStorage;
+	let connectSpy: ReturnType<typeof spyOn>;
+	let listToolsSpy: ReturnType<typeof spyOn>;
+	let homedirSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(async () => {
+		workDir = path.join(os.tmpdir(), `omp-mcp-lazy-${Snowflake.next()}`);
+		isolatedHome = path.join(os.tmpdir(), `omp-mcp-lazy-home-${Snowflake.next()}`);
+		fs.mkdirSync(workDir, { recursive: true });
+		fs.mkdirSync(isolatedHome, { recursive: true });
+		// Capability discovery also walks user-level MCP configs under getAgentDir()
+		// and os.homedir()-scoped sources (Claude/Cursor/etc). Redirect both so the
+		// suite only sees the two project servers under test.
+		originalAgentDir = getAgentDir();
+		setAgentDir(path.join(workDir, "agent"));
+		homedirSpy = spyOn(os, "homedir").mockReturnValue(isolatedHome);
+		storage = await AgentStorage.open(path.join(workDir, "agent.db"));
+		connectSpy = spyOn(mcpClient, "connectToServer");
+		listToolsSpy = spyOn(mcpClient, "listTools");
+	});
+
+	afterEach(async () => {
+		connectSpy.mockRestore();
+		listToolsSpy.mockRestore();
+		homedirSpy.mockRestore();
+		setAgentDir(originalAgentDir);
+		mock.restore();
+		AgentStorage.resetInstance();
+		for (const dir of [workDir, isolatedHome]) {
+			if (dir && fs.existsSync(dir)) {
+				removeSyncWithRetries(dir);
+			}
+		}
+	});
+
+	it("discoverDeferred loads cached tools without connecting", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set(CACHED_SERVER, cached, [CACHED_TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, toolCache);
+		try {
+			const result = await manager.discoverDeferred();
+
+			expect(connectSpy).not.toHaveBeenCalled();
+			expect(listToolsSpy).not.toHaveBeenCalled();
+			expect(result.connectedServers).toEqual([]);
+			expect(result.tools.map(tool => tool.name)).toEqual([`mcp__${CACHED_SERVER}_lookup_docs`]);
+			expect(manager.getConnection(CACHED_SERVER)).toBeUndefined();
+			expect(manager.getConnection(DEFERRED_SERVER)).toBeUndefined();
+			expect(manager.isServerDeferred(CACHED_SERVER)).toBe(true);
+			expect(manager.isServerDeferred(DEFERRED_SERVER)).toBe(true);
+
+			const summaries = manager.getDiscoverableServerSummaries();
+			expect(summaries).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						name: CACHED_SERVER,
+						toolCount: 1,
+						cached: true,
+						deferred: false,
+						description: "Cached docs server",
+					}),
+					expect.objectContaining({
+						name: DEFERRED_SERVER,
+						toolCount: 0,
+						cached: false,
+						deferred: true,
+						description: "Deferred wiki server",
+					}),
+				]),
+			);
+
+			const deferredPseudo = manager.getDeferredDiscoverableTools();
+			const deferredNames = deferredPseudo.map(tool => tool.name);
+			expect(deferredNames).toContain(`mcp__${DEFERRED_SERVER}`);
+			expect(deferredNames).not.toContain(`mcp__${CACHED_SERVER}_lookup_docs`);
+			const deferredEntry = deferredPseudo.find(tool => tool.serverName === DEFERRED_SERVER);
+			expect(deferredEntry?.deferredServer).toBe(true);
+			expect(deferredEntry?.summary).toBe("Deferred wiki server");
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("prompt summaries advertise cached and deferred servers", () => {
+		const rendered = renderSearchToolBm25Description(
+			[
+				{
+					name: `mcp__${CACHED_SERVER}_lookup_docs`,
+					label: `${CACHED_SERVER}/lookup_docs`,
+					summary: CACHED_TOOL_DEF.description ?? "docs",
+					source: "mcp",
+					serverName: CACHED_SERVER,
+					mcpToolName: "lookup_docs",
+					schemaKeys: ["query"],
+				},
+				{
+					name: `mcp__${DEFERRED_SERVER}`,
+					label: DEFERRED_SERVER,
+					summary: `MCP server "${DEFERRED_SERVER}" — tools not yet loaded; searching or calling loads them`,
+					source: "mcp",
+					serverName: DEFERRED_SERVER,
+					deferredServer: true,
+					schemaKeys: [],
+				},
+			],
+			[
+				{
+					name: CACHED_SERVER,
+					toolCount: 1,
+					cached: true,
+					deferred: false,
+					description: "Cached docs server",
+				},
+				{
+					name: DEFERRED_SERVER,
+					toolCount: 0,
+					cached: false,
+					deferred: true,
+					description: "Deferred wiki server",
+				},
+			],
+		);
+
+		expect(rendered).toContain(
+			formatDiscoverableToolServerSummary({
+				name: CACHED_SERVER,
+				toolCount: 1,
+				cached: true,
+				description: "Cached docs server",
+			}),
+		);
+		expect(rendered).toContain(
+			formatDiscoverableToolServerSummary({
+				name: DEFERRED_SERVER,
+				toolCount: 0,
+				deferred: true,
+				description: "Deferred wiki server",
+			}),
+		);
+		expect(rendered).toContain(`${CACHED_SERVER} (1 tool cached)`);
+		expect(rendered).toContain(`${DEFERRED_SERVER} (deferred)`);
+	});
+
+	it("search_tool_bm25 matching a cached lazy tool connects once and activates it", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set(CACHED_SERVER, cached, [CACHED_TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, toolCache);
+		try {
+			await manager.discoverDeferred();
+			expect(connectSpy).not.toHaveBeenCalled();
+
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) => {
+				expect(name).toBe(CACHED_SERVER);
+				return mockConnectionFor(name, config);
+			});
+			// #connectAndWireServer always listTools after connect.
+			listToolsSpy.mockResolvedValue([LIVE_TOOL_DEF]);
+
+			const discoverableTools: DiscoverableTool[] = [
+				{
+					name: `mcp__${CACHED_SERVER}_lookup_docs`,
+					label: `${CACHED_SERVER}/lookup_docs`,
+					summary: CACHED_TOOL_DEF.description ?? "docs",
+					source: "mcp",
+					serverName: CACHED_SERVER,
+					mcpToolName: "lookup_docs",
+					schemaKeys: ["query"],
+				},
+			];
+			const session = createBm25Session(manager, { discoverableTools });
+			const tool = new SearchToolBm25Tool(session);
+
+			const result = await tool.execute("call-lazy-activate", { query: "documentation lookup", limit: 1 });
+
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(connectSpy.mock.calls[0]?.[0]).toBe(CACHED_SERVER);
+			expect(listToolsSpy).toHaveBeenCalledTimes(1);
+			expect(manager.getConnection(CACHED_SERVER)).toBeDefined();
+			expect(manager.isServerDeferred(CACHED_SERVER)).toBe(false);
+			expect(result.details?.activated_tools).toEqual([`mcp__${CACHED_SERVER}_lookup_docs`]);
+			expect(result.details?.unavailable_servers).toBeUndefined();
+			expect(result.content[0]).toMatchObject({
+				type: "text",
+				text: expect.stringContaining(`mcp__${CACHED_SERVER}_lookup_docs`),
+			});
+
+			// A second search for the same already-selected match must not reconnect.
+			const second = await tool.execute("call-lazy-again", { query: "documentation lookup", limit: 1 });
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(second.details?.activated_tools).toEqual([]);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("search_tool_bm25 reports unavailable when on-demand connect fails", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set(CACHED_SERVER, cached, [CACHED_TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, toolCache);
+		try {
+			await manager.discoverDeferred();
+			connectSpy.mockRejectedValue(new Error("spawn EACCES"));
+
+			const discoverableTools: DiscoverableTool[] = [
+				{
+					name: `mcp__${CACHED_SERVER}_lookup_docs`,
+					label: `${CACHED_SERVER}/lookup_docs`,
+					summary: CACHED_TOOL_DEF.description ?? "docs",
+					source: "mcp",
+					serverName: CACHED_SERVER,
+					mcpToolName: "lookup_docs",
+					schemaKeys: ["query"],
+				},
+			];
+			const session = createBm25Session(manager, { discoverableTools });
+			const tool = new SearchToolBm25Tool(session);
+
+			const result = await tool.execute("call-lazy-fail", { query: "documentation lookup", limit: 1 });
+
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(manager.getConnection(CACHED_SERVER)).toBeUndefined();
+			const unavailable = `server "${CACHED_SERVER}" unavailable: spawn EACCES`;
+			expect(result.details?.unavailable_servers).toEqual([unavailable]);
+			// Content is a JSON payload; quotes are escaped, so parse then assert.
+			const contentText = result.content
+				.filter(
+					(part): part is { type: "text"; text: string } => part.type === "text" && typeof part.text === "string",
+				)
+				.map(part => part.text)
+				.join("\n");
+			const payload = JSON.parse(contentText) as { unavailable_servers?: string[] };
+			expect(payload.unavailable_servers).toEqual([unavailable]);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+
+	it("eager discoverAndConnect still connects at discovery time", async () => {
+		const { cached } = writeProjectMcpConfig(workDir);
+		const toolCache = new MCPToolCache(storage);
+		await toolCache.set(CACHED_SERVER, cached, [CACHED_TOOL_DEF]);
+
+		const manager = new MCPManager(workDir, toolCache);
+		try {
+			connectSpy.mockImplementation(async (name: string, config: MCPServerConfig) =>
+				mockConnectionFor(name, config),
+			);
+			listToolsSpy.mockImplementation(async (connection: MCPServerConnection) => {
+				if (connection.name === CACHED_SERVER) return [LIVE_TOOL_DEF];
+				return [
+					{
+						name: "search_wiki",
+						description: "Search the deferred wiki",
+						inputSchema: { type: "object", properties: {} },
+					},
+				];
+			});
+
+			const result = await manager.discoverAndConnect();
+
+			expect(connectSpy).toHaveBeenCalled();
+			const connectedNames = new Set(connectSpy.mock.calls.map((call: unknown[]) => String(call[0])));
+			expect(connectedNames.has(CACHED_SERVER)).toBe(true);
+			expect(connectedNames.has(DEFERRED_SERVER)).toBe(true);
+			expect(result.connectedServers).toEqual(expect.arrayContaining([CACHED_SERVER, DEFERRED_SERVER]));
+			expect(manager.getConnection(CACHED_SERVER)).toBeDefined();
+			expect(manager.getConnection(DEFERRED_SERVER)).toBeDefined();
+			expect(manager.isServerDeferred(CACHED_SERVER)).toBe(false);
+			expect(manager.isServerDeferred(DEFERRED_SERVER)).toBe(false);
+		} finally {
+			await manager.disconnectAll();
+		}
+	});
+});


### PR DESCRIPTION
## Summary
MCP startup connected and listed tools for every configured server even when tool discovery mode should keep MCP tools deferred.

## Changes
- Add mcp.lazyDiscovery to defer server connections until search or tool use.
- Build prompt server summaries from config and cache without connecting.
- Connect servers on demand with single-flight behavior and cache refresh.
- Teach search_tool_bm25 to activate deferred cached tools or surface unavailable servers without breaking the session.

## Verification
- bun test packages/coding-agent/test/mcp-lazy-discovery.test.ts — 12 pass, 0 fail
- bun check was also run during publishing and failed on two pre-existing Biome format/organize-import diagnostics in the T1 guided-goal files; targeted unit tests above passed.

Closes #4934
