### PR TITLE
fix(tui): cancel streaming prompts on first escape

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Escape during an active TUI prompt requiring a second press before canceling; the first Escape now aborts the streaming turn immediately. ([#4921](https://github.com/can1357/oh-my-pi/issues/4921))
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -154,7 +154,6 @@ const TINY_TITLE_PROGRESS_REVEAL_DELAY_MS = 1_000;
 // deliberate human double-tap is always tens of milliseconds apart.
 const LEFT_DOUBLE_TAP_MIN_GAP_MS = 40;
 const LEFT_DOUBLE_TAP_MAX_GAP_MS = 500;
-const STREAMING_ESCAPE_CANCEL_WINDOW_MS = 2_000;
 
 export class InputController {
 	constructor(
@@ -179,16 +178,6 @@ export class InputController {
 	// (>= LEFT_DOUBLE_TAP_MAX_GAP_MS) starts a fresh sequence. See
 	// #detectLeftDoubleTap.
 	#leftTapCount = 0;
-	// Streaming turns use a two-step Esc: first press arms this token, second press
-	// within the window aborts the same live assistant turn. The token is a per-turn
-	// sentinel minted lazily on demand and reset on every `agent_start`/`agent_end`
-	// (see setupKeyHandlers), so it survives `message_start`/`message_update`
-	// transitions inside a single turn but cannot leak across turn boundaries.
-	#streamingEscapeTurnSentinel: object | undefined;
-	#streamingEscapeArmedToken: object | undefined;
-	#streamingEscapeArmedUntil = 0;
-	#streamingEscapeTimer: NodeJS.Timeout | undefined;
-	#streamingEscapeSessionSubscribed = false;
 	// Sequential index for `local://attachment-N` references created by large-paste and
 	// pasted-file attachments. Seeded from 0 and bumped past existing attachment files.
 	#attachmentCounter = 0;
@@ -238,50 +227,12 @@ export class InputController {
 		const unsubscribe = tinyTitleClient.onProgress(update);
 	}
 
-	#clearStreamingEscapeArm(): void {
-		this.#streamingEscapeArmedToken = undefined;
-		this.#streamingEscapeArmedUntil = 0;
-		if (this.#streamingEscapeTimer) {
-			clearTimeout(this.#streamingEscapeTimer);
-			this.#streamingEscapeTimer = undefined;
-		}
-	}
-
-	#handleStreamingEscape(): void {
-		if (!this.#streamingEscapeTurnSentinel) {
-			this.#streamingEscapeTurnSentinel = {};
-		}
-		const token = this.#streamingEscapeTurnSentinel;
-		const now = Date.now();
-		if (this.#streamingEscapeArmedToken === token && now <= this.#streamingEscapeArmedUntil) {
-			this.#clearStreamingEscapeArm();
-			void this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
-			return;
-		}
-
-		this.#clearStreamingEscapeArm();
-		this.#streamingEscapeArmedToken = token;
-		this.#streamingEscapeArmedUntil = now + STREAMING_ESCAPE_CANCEL_WINDOW_MS;
-		this.#streamingEscapeTimer = setTimeout(() => {
-			if (this.#streamingEscapeArmedToken === token && Date.now() >= this.#streamingEscapeArmedUntil) {
-				this.#clearStreamingEscapeArm();
-			}
-		}, STREAMING_ESCAPE_CANCEL_WINDOW_MS);
-		this.#streamingEscapeTimer.unref?.();
-		this.ctx.showStatus("Press Esc again within 2s to cancel streaming.");
+	#abortStreamingTurn(): void {
+		void this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
 	}
 
 	setupKeyHandlers(): void {
 		this.ctx.editor.setActionKeys("app.interrupt", this.ctx.keybindings.getKeys("app.interrupt"));
-		if (!this.#streamingEscapeSessionSubscribed && typeof this.ctx.session.subscribe === "function") {
-			this.#streamingEscapeSessionSubscribed = true;
-			this.ctx.session.subscribe(event => {
-				if (event.type === "agent_start" || event.type === "agent_end") {
-					this.#streamingEscapeTurnSentinel = undefined;
-					this.#clearStreamingEscapeArm();
-				}
-			});
-		}
 		if (!this.#focusedLeftTapListenerInstalled) {
 			this.#focusedLeftTapListenerInstalled = true;
 			this.ctx.ui.addInputListener(data => {
@@ -351,7 +302,7 @@ export class InputController {
 			if (this.ctx.loopModeEnabled) {
 				this.ctx.pauseLoop();
 				if (this.ctx.session.isStreaming) {
-					this.#handleStreamingEscape();
+					this.#abortStreamingTurn();
 				} else {
 					this.ctx.cancelPendingSubmission();
 				}
@@ -402,11 +353,10 @@ export class InputController {
 				this.ctx.isPythonMode = false;
 				this.ctx.updateEditorBorderColor();
 			} else if (this.ctx.session.isStreaming) {
-				this.#handleStreamingEscape();
+				this.#abortStreamingTurn();
 			} else if (this.ctx.editor.getText().trim()) {
-				// Esc must not destroy an in-progress draft; it only disarms a previous empty-editor Esc.
+				// Esc must not destroy an in-progress draft.
 				this.ctx.lastEscapeTime = 0;
-				this.#clearStreamingEscapeArm();
 			} else if (vocalizer.isSpeaking()) {
 				// TTS buffers seconds of PCM past the streaming abort, so an Esc
 				// arriving after the model stopped would otherwise fall through to

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -269,6 +269,16 @@ function abortViewSession(ctx: InteractiveModeContext): AbortViewSession {
 	// so property access is explicit.
 	return ctx.viewSession as unknown as AbortViewSession;
 }
+
+type MutableSessionState = InteractiveModeContext["session"] & {
+	isStreaming: boolean;
+};
+
+function mutableSessionState(ctx: InteractiveModeContext): MutableSessionState {
+	// Test harness installs a mutable fake AgentSession; keep the unchecked cast named
+	// so state mutations are explicit.
+	return ctx.session as MutableSessionState;
+}
 beforeEach(async () => {
 	await Settings.init({ inMemory: true });
 });
@@ -438,111 +448,37 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
-	it("requires a second Esc within two seconds to abort streaming", () => {
-		const now = vi.spyOn(Date, "now");
-		now.mockReturnValue(1_000);
+	it("aborts an active streaming turn on the first Esc without asking for confirmation", () => {
 		const { ctx, editor, spies } = createContext();
-		(ctx.session as { isStreaming: boolean }).isStreaming = true;
+		mutableSessionState(ctx).isStreaming = true;
 		const controller = new InputController(ctx);
 
 		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.abort).toHaveBeenCalledTimes(1);
+		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
+		expect(spies.showStatus).not.toHaveBeenCalledWith("Press Esc again within 2s to cancel streaming.");
+	});
+
+	it("aborts the submitted turn on the first Esc once the main session starts streaming", async () => {
+		const { ctx, editor, spies } = createContext();
+		const submission = createSubmission({ text: "fix issue #4921" });
+		spies.startPendingSubmission.mockReturnValue(submission);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		controller.setupEditorSubmitHandler();
+		await editor.onSubmit?.("fix issue #4921");
+		mutableSessionState(ctx).isStreaming = true;
+		ctx.loadingAnimation = undefined;
+
 		editor.onEscape?.();
 
 		expect(spies.cancelPendingSubmission).not.toHaveBeenCalled();
-		expect(spies.clearQueue).not.toHaveBeenCalled();
-		expect(spies.abort).not.toHaveBeenCalled();
-		expect(spies.showStatus).toHaveBeenCalledWith("Press Esc again within 2s to cancel streaming.");
-
-		now.mockReturnValue(2_500);
-		editor.onEscape?.();
-
 		expect(spies.abort).toHaveBeenCalledTimes(1);
 		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
-	});
-
-	it("expires the streaming Esc arm instead of aborting on a late second press", () => {
-		const now = vi.spyOn(Date, "now");
-		now.mockReturnValue(1_000);
-		const { ctx, editor, spies } = createContext();
-		(ctx.session as { isStreaming: boolean }).isStreaming = true;
-		const controller = new InputController(ctx);
-
-		controller.setupKeyHandlers();
-		editor.onEscape?.();
-		now.mockReturnValue(3_001);
-		editor.onEscape?.();
-
-		expect(spies.abort).not.toHaveBeenCalled();
-		expect(spies.showStatus).toHaveBeenCalledTimes(2);
-	});
-
-	it("preserves the streaming Esc arm when streamingComponent appears between presses", () => {
-		// Pre-`message_start`: first Esc arms on the per-turn sentinel. `message_start`
-		// then publishes `ctx.streamingComponent`; the second Esc must still abort the
-		// same live turn instead of re-arming on the new component reference.
-		const now = vi.spyOn(Date, "now");
-		now.mockReturnValue(1_000);
-		const { ctx, editor, spies } = createContext();
-		(ctx.session as { isStreaming: boolean }).isStreaming = true;
-		const controller = new InputController(ctx);
-
-		controller.setupKeyHandlers();
-		editor.onEscape?.();
-		(ctx as unknown as { streamingComponent: object }).streamingComponent = {};
-		now.mockReturnValue(1_500);
-		editor.onEscape?.();
-
-		expect(spies.abort).toHaveBeenCalledTimes(1);
-		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
-	});
-
-	it("aborts on the second Esc even when ctx.streamingMessage was replaced by a delta in between", () => {
-		// `EventController` replaces `ctx.streamingMessage` with a fresh immutable
-		// snapshot on every `message_update`; the per-turn sentinel is unaffected so
-		// swapping the message must not invalidate the armed token.
-		const now = vi.spyOn(Date, "now");
-		now.mockReturnValue(1_000);
-		const { ctx, editor, spies } = createContext();
-		(ctx.session as { isStreaming: boolean }).isStreaming = true;
-		(ctx as unknown as { streamingComponent: object }).streamingComponent = {};
-		(ctx as unknown as { streamingMessage: object }).streamingMessage = { content: [] };
-		const controller = new InputController(ctx);
-
-		controller.setupKeyHandlers();
-		editor.onEscape?.();
-		(ctx as unknown as { streamingMessage: object }).streamingMessage = { content: ["delta"] };
-		now.mockReturnValue(1_500);
-		editor.onEscape?.();
-
-		expect(spies.abort).toHaveBeenCalledTimes(1);
-		expect(spies.abort).toHaveBeenCalledWith({ reason: USER_INTERRUPT_LABEL });
-	});
-
-	it("clears the streaming Esc arm when the current turn ends", () => {
-		const now = vi.spyOn(Date, "now");
-		now.mockReturnValue(1_000);
-		const { ctx, editor, spies, sessionListeners } = createContext();
-		(ctx.session as { isStreaming: boolean }).isStreaming = true;
-		const controller = new InputController(ctx);
-
-		controller.setupKeyHandlers();
-		// Fallback arm (no streamingMessage/streamingComponent yet — pre-message_start).
-		editor.onEscape?.();
-		expect(sessionListeners).toHaveLength(1);
-
-		// Turn 1 ends; a new turn starts. session.subscribe receives both transitions,
-		// either of which must invalidate the still-armed fallback token so it cannot
-		// fast-abort the new turn's first Esc.
-		for (const listener of sessionListeners) {
-			listener({ type: "agent_end" });
-			listener({ type: "agent_start" });
-		}
-
-		now.mockReturnValue(1_500);
-		editor.onEscape?.();
-
-		expect(spies.abort).not.toHaveBeenCalled();
-		expect(spies.showStatus).toHaveBeenCalledTimes(2);
+		expect(spies.showStatus).not.toHaveBeenCalledWith("Press Esc again within 2s to cancel streaming.");
 	});
 
 	it("returns focused subagent view to main on Esc instead of aborting", () => {


### PR DESCRIPTION
## Repro
Against the pre-fix `InputController`, the focused regression command `bun test packages/coding-agent/test/input-controller-escape.test.ts` failed because first Esc during a streaming turn invoked `session.abort` 0 times; the old handler only armed a second-Esc confirmation window.

## Cause
`packages/coding-agent/src/modes/controllers/input-controller.ts` routed streaming Esc through `#handleStreamingEscape`, which intentionally stored a per-turn sentinel and required a second Esc within two seconds before calling `session.abort({ reason: USER_INTERRUPT_LABEL })`. That made the first Esc after prompt submission appear ignored once the session had entered streaming state.

## Fix
- Replace the two-step streaming Esc arm with a direct `#abortStreamingTurn()` call that aborts the active session with `USER_INTERRUPT_LABEL` on the first press.
- Remove obsolete streaming-Esc sentinel, timeout, and turn-transition cleanup state.
- Update `packages/coding-agent/test/input-controller-escape.test.ts` to cover first-Esc cancellation during an active stream and the post-submit streaming window.
- Add the coding-agent changelog entry for #4921.

## Verification
`bun test packages/coding-agent/test/input-controller-escape.test.ts` passed with 29 tests and 92 assertions. `gh_push_branch` completed the pre-publish gate (`bun run fix` and `bun check`) and pushed the branch. Fixes #4921