### PR TITLE
fix(tui): hide empty Codex thought separators

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex reasoning summary display so empty HTML comment separator lines are omitted from visible thinking blocks instead of rendering as `<!-- -->` markers ([#4936](https://github.com/can1357/oh-my-pi/issues/4936)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -41,8 +41,9 @@ export function canonicalizeMessage(text: string | null | undefined): string {
 }
 
 export function formatThinkingForDisplay(text: string, proseOnly: boolean): string {
+	if (!proseOnly || !text) return text;
 	const cleanedText = stripEmptyHtmlCommentSeparators(text);
-	if (!proseOnly || !cleanedText) return cleanedText;
+	if (!cleanedText) return cleanedText;
 	if (text === formatCacheKey) return formatCacheValue;
 
 	const lines = cleanedText.split("\n");

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -1,12 +1,30 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 
+const EMPTY_HTML_COMMENT_SEPARATOR = /^\s*<!--[\s-]*-->\s*$/;
+
+function stripEmptyHtmlCommentSeparators(text: string): string {
+	if (!text.includes("<!--")) return text;
+	const lines = text.split("\n");
+	const resultLines: string[] = [];
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i]!;
+		if (!EMPTY_HTML_COMMENT_SEPARATOR.test(line)) {
+			resultLines.push(line);
+			continue;
+		}
+		const prevBlank = resultLines.length > 0 && resultLines[resultLines.length - 1]!.trim() === "";
+		const nextBlank = i + 1 < lines.length && lines[i + 1]!.trim() === "";
+		if ((prevBlank || resultLines.length === 0) && nextBlank) i += 1;
+	}
+	return resultLines.join("\n");
+}
+
 // Single-entry memo for the proseOnly formatting path. During a streaming tick
 // the same growing thinking text is formatted up to three times (reveal count,
 // reveal slice, component render); this collapses them to one computation. The
-// `proseOnly === false` branch is a passthrough and never consults the cache, so
-// the key can be the text alone. A single entry is enough for the common case of
-// one active thinking block and never regresses (a miss recomputes exactly as
-// before).
+// non-prose branch skips code-fence elision and never consults the cache. A
+// single entry is enough for the common case of one active thinking block and
+// never regresses (a miss recomputes exactly as before).
 let formatCacheKey = "";
 let formatCacheValue = "";
 
@@ -23,10 +41,11 @@ export function canonicalizeMessage(text: string | null | undefined): string {
 }
 
 export function formatThinkingForDisplay(text: string, proseOnly: boolean): string {
-	if (!proseOnly || !text) return text;
+	const cleanedText = stripEmptyHtmlCommentSeparators(text);
+	if (!proseOnly || !cleanedText) return cleanedText;
 	if (text === formatCacheKey) return formatCacheValue;
 
-	const lines = text.split("\n");
+	const lines = cleanedText.split("\n");
 	const resultLines: string[] = [];
 	let inFence = false;
 	let fenceChar = "";
@@ -101,7 +120,7 @@ export function hasDisplayableThinking(
 ): boolean {
 	if (!text) return false;
 	if (!formattedText) return false;
-	return formattedText.length > 0 && canonicalizeMessage(text).length > 0;
+	return formattedText.length > 0 && canonicalizeMessage(stripEmptyHtmlCommentSeparators(text)).length > 0;
 }
 
 /** Whether an assistant message contains thinking content the TUI can reveal. */

--- a/packages/coding-agent/test/modes/components/prose-only-thinking.test.ts
+++ b/packages/coding-agent/test/modes/components/prose-only-thinking.test.ts
@@ -7,6 +7,11 @@ describe("formatThinkingForDisplay", () => {
 		expect(formatThinkingForDisplay(text, false)).toBe(text);
 	});
 
+	it("preserves fenced code verbatim in raw thinking display", () => {
+		const text = "```html\n<!-- -->\n<div></div>\n```";
+		expect(formatThinkingForDisplay(text, false)).toBe(text);
+	});
+
 	it("should replace fully enclosed code blocks with an ellipsis", () => {
 		const text = "Let me rewrite readString:\n```go\nfunc foo() {}\n```\nAnd then test it.";
 		expect(formatThinkingForDisplay(text, true)).toBe("Let me rewrite readString:...\nAnd then test it.");

--- a/packages/coding-agent/test/modes/components/prose-only-thinking.test.ts
+++ b/packages/coding-agent/test/modes/components/prose-only-thinking.test.ts
@@ -39,4 +39,18 @@ describe("formatThinkingForDisplay", () => {
 		expect(formatted).toBe("...");
 		expect(hasDisplayableThinking(text, formatted)).toBe(true);
 	});
+
+	it("drops empty Codex reasoning comment separators", () => {
+		const text =
+			"Investigating disappearing buttons issue\n\n<!--  -->\n\nAnalyzing missing LoadCompleteRequest causing deadlock\n\n<!---- --->\n\nPlanning timestamp evaluation";
+		expect(formatThinkingForDisplay(text, true)).toBe(
+			"Investigating disappearing buttons issue\n\nAnalyzing missing LoadCompleteRequest causing deadlock\n\nPlanning timestamp evaluation",
+		);
+	});
+
+	it("treats comment-only reasoning separators as non-displayable", () => {
+		const formatted = formatThinkingForDisplay("<!--  -->", true);
+		expect(formatted).toBe("");
+		expect(hasDisplayableThinking("<!--  -->", formatted)).toBe(false);
+	});
 });


### PR DESCRIPTION
## Repro
A displayed-thinking block containing Codex's empty reasoning separator `<!--  -->` currently keeps that line in `formatThinkingForDisplay`, so `bun test repro-thought-comment.test.ts` failed with the marker still present between thought summary lines.

## Cause
`packages/coding-agent/src/utils/thinking-display.ts` only elided fenced code blocks for prose-only thinking. Empty HTML comment separators emitted in Codex reasoning summaries were treated as ordinary prose, so `AssistantMessageComponent` rendered them through Markdown as visible `<!-- -->` lines even when thinking blocks were otherwise visible.

## Fix
- Strip empty/hyphen-only HTML comment separator lines before thinking display formatting and displayability checks.
- Preserve one blank paragraph break around removed separators so adjacent thought summary lines keep readable spacing.
- Add regression coverage in `packages/coding-agent/test/modes/components/prose-only-thinking.test.ts` for Codex separators and comment-only thinking blocks.
- Ran the coding-agent formatter; it normalized the workflow prompt example typography.

## Verification
`bun test packages/coding-agent/test/modes/components/prose-only-thinking.test.ts` passes: 9 tests, 13 assertions. `bun run --cwd packages/coding-agent check:types` passes. `gh_push_branch` completed the pre-publish gate and pushed `farm/3625fd46/fix-thought-comment-marker`. Fixes #4936