### PR TITLE
fix(collab-web): deduplicate tool cards and hide thinking shimmer during tool execution

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed duplicate tool cards and stale "thinking…" shimmer during tool execution in the live collab view.
+
 ## [16.3.7] - 2026-07-05
 
 ### Fixed

--- a/packages/collab-web/src/components/transcript/Transcript.tsx
+++ b/packages/collab-web/src/components/transcript/Transcript.tsx
@@ -263,16 +263,39 @@ export function Transcript(props: TranscriptProps): ReactNode {
 		if (el !== null && lockRef.current) el.scrollTop = el.scrollHeight;
 	}, [entries, stream, activeTools, working]);
 
-	// Active tools not already represented as toolCall blocks in the stream ghost.
+	// Active tools not already represented as toolCall blocks in the stream ghost
+	// or in finalized entries (prevents duplicate tool cards when the entry frame
+	// arrives before tool_execution_start).
 	const streamIds = new Set<string>();
 	if (stream !== null) {
 		for (const block of stream.content) {
 			if (block.type === "toolCall") streamIds.add(block.id);
 		}
 	}
+	const entryIds = new Set<string>();
+	for (const entry of entries) {
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			const blocks = entry.message.content;
+			if (Array.isArray(blocks)) {
+				for (const block of blocks) {
+					if (
+						block &&
+						typeof block === "object" &&
+						"type" in block &&
+						block.type === "toolCall" &&
+						"id" in block
+					) {
+						if (typeof block.id === "string") {
+							entryIds.add(block.id);
+						}
+					}
+				}
+			}
+		}
+	}
 	const tailTools: ActiveTool[] = [];
 	for (const tool of activeTools.values()) {
-		if (!streamIds.has(tool.toolCallId)) tailTools.push(tool);
+		if (!streamIds.has(tool.toolCallId) && !entryIds.has(tool.toolCallId)) tailTools.push(tool);
 	}
 
 	return (
@@ -317,7 +340,7 @@ export function Transcript(props: TranscriptProps): ReactNode {
 					))}
 				</Row>
 			)}
-			{working && stream === null && (
+			{working && stream === null && activeTools.size === 0 && (
 				<Row kind="assistant" gutter="agent">
 					<div className="tr-shimmer">thinking…</div>
 				</Row>


### PR DESCRIPTION
## What

   Fix two rendering bugs in collab-web's `Transcript.tsx` when a tool is executing:

   1. **Duplicate tool execution boxes** — `tailTools` dedup only checked `streamIds`. When the stream is null (entry committed), every running tool leaked into a
 separate `tailTools` row, producing an identical ToolCard alongside the one rendered from the committed entry's content.

   2. **Stale "thinking…" shimmer during tool execution** — The shimmer condition `working && stream === null` stayed true for the entire tool execution phase because
 `isStreaming` isn't set to `false` until `agent_end`. The shimmer persisted while tools were already running.

   ## Why

   1. The `tailTools` computation was missing an `entryIds` pass that collects toolCall IDs from committed assistant-message entries. Without it, a tool already shown in
 the entry row was also rendered in `tailTools`.

   2. The shimmer condition had no check for active tools. `working` stays `true` during tool execution until `agent_end` fires after all tools finish.

   ## Testing

   - Tested with a real omp collab session executing `bash sleep 10`: single tool card, no duplicate, no thinking shimmer during execution.
   - `bun test packages/collab-web/test/` — 59 tests pass.

   ---

   - [x] `bun check` passes
   - [x] Tested locally
   - [x] CHANGELOG updated (user-facing) 