### PR TITLE
fix(ai): omit Codex optional response defaults

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Changed the xAI Grok OAuth (`xai-oauth`) provider to use manual code-paste login by default. `/login` now accepts a pasted authorization code or full `http://127.0.0.1:56121/callback?code=...` redirect URL without starting a local callback listener ([#3277](https://github.com/can1357/oh-my-pi/pull/3277) by [@Jaaneek](https://github.com/Jaaneek)).
 - Renamed the xAI Grok OAuth provider in login and credential prompts to "xAI Grok OAuth (SuperGrok or X Premium+)" ([#3277](https://github.com/can1357/oh-my-pi/pull/3277) by [@Jaaneek](https://github.com/Jaaneek)).
 
+### Fixed
+
+- Fixed OpenAI Codex GPT-5.x requests sending optional `reasoning.summary`, `reasoning.context`, and `text.verbosity` controls by default, reducing Codex `server_error` disconnects from unsupported request shapes. ([#4949](https://github.com/can1357/oh-my-pi/issues/4949))
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -107,7 +107,7 @@ import { transformMessages } from "./transform-messages";
 export interface OpenAICodexResponsesOptions extends StreamOptions {
 	reasoning?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 	reasoningSummary?: "auto" | "concise" | "detailed" | null;
-	/** `reasoning.context` replay scope; defaults to `all_turns` when unset. The `all_turns` value is gated to gpt-5.4+ Codex models — older ids reject it, so it is suppressed and `context` omitted. */
+	/** Explicit `reasoning.context` replay scope. Omitted by default so Codex applies its native request policy. */
 	reasoningContext?: CodexReasoningContext;
 	textVerbosity?: "low" | "medium" | "high";
 	include?: string[];
@@ -983,7 +983,7 @@ export async function buildTransformedCodexRequestBody(
 	}
 	const codexOptions: CodexRequestOptions = {
 		reasoningEffort: options?.reasoning,
-		reasoningSummary: options?.reasoningSummary === undefined ? "auto" : options.reasoningSummary,
+		reasoningSummary: options?.reasoningSummary,
 		reasoningContext: options?.reasoningContext,
 		textVerbosity: options?.textVerbosity,
 		include: options?.include,

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -15,7 +15,7 @@ export interface ReasoningConfig {
 export interface CodexRequestOptions {
 	reasoningEffort?: ReasoningConfig["effort"];
 	reasoningSummary?: ReasoningConfig["summary"] | null;
-	/** Explicit `reasoning.context` override; defaults to `all_turns` when unset. The `all_turns` value is gated to gpt-5.4+ Codex models — older ids reject it, so it is suppressed and `context` omitted. */
+	/** Explicit `reasoning.context` override. Omitted by default so Codex applies its native request policy. */
 	reasoningContext?: CodexReasoningContext;
 	textVerbosity?: "low" | "medium" | "high";
 	include?: string[];
@@ -85,13 +85,12 @@ function getReasoningConfig(model: Model<Api>, options: CodexRequestOptions): Re
 		effort:
 			options.reasoningEffort === "none" ? "none" : requireSupportedEffort(model, options.reasoningEffort as Effort),
 	};
-	// `reasoning.summary` is accepted only from gpt-5.4 onward; earlier Codex ids
-	// (gpt-5.1-codex, gpt-5.3-codex, gpt-5.3-codex-spark) reject it with
-	// "Unsupported parameter: 'reasoning.summary' is not supported with this model".
-	// Mirrors the all_turns gate: an explicit summary is suppressed on unsupported
-	// ids, letting the server skip the human-readable summary stream.
-	if (options.reasoningSummary !== null && supportsCodexReasoningSummary(model.id)) {
-		config.summary = options.reasoningSummary ?? "detailed";
+	if (
+		options.reasoningSummary !== undefined &&
+		options.reasoningSummary !== null &&
+		supportsCodexReasoningSummary(model.id)
+	) {
+		config.summary = options.reasoningSummary;
 	}
 	return config;
 }
@@ -305,29 +304,24 @@ export async function transformRequestBody(
 			...body.reasoning,
 			...reasoningConfig,
 		};
-		// Default reasoning replay to `all_turns`, mirroring codex-rs; an
-		// explicit `reasoningContext` overrides the default. The `all_turns`
-		// value is only accepted from gpt-5.4 onward — earlier Codex ids
-		// (gpt-5.1-codex, gpt-5.3-codex, gpt-5.3-codex-spark) reject it with
-		// "Unsupported value: 'all_turns' is not supported with this model".
-		// For those, drop `context` so the server applies its `current_turn`
-		// default. The version gate is authoritative: even an explicit
-		// `all_turns` override is suppressed on unsupported models, while
-		// `current_turn`/`auto` (universally supported) always pass through.
-		const context = options.reasoningContext ?? "all_turns";
-		if (context === "all_turns" && !supportsAllTurnsReasoningContext(model.id)) {
-			delete body.reasoning.context;
-		} else {
-			body.reasoning.context = context;
+		if (options.reasoningContext !== undefined) {
+			const context = options.reasoningContext;
+			if (context === "all_turns" && !supportsAllTurnsReasoningContext(model.id)) {
+				delete body.reasoning.context;
+			} else {
+				body.reasoning.context = context;
+			}
 		}
 	} else {
 		delete body.reasoning;
 	}
 
-	body.text = {
-		...body.text,
-		verbosity: options.textVerbosity || "high",
-	};
+	if (options.textVerbosity !== undefined) {
+		body.text = {
+			...body.text,
+			verbosity: options.textVerbosity,
+		};
+	}
 
 	const include = Array.isArray(options.include) ? [...options.include] : [];
 	include.push("reasoning.encrypted_content");

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1632,7 +1632,7 @@ function mapOptionsForApi<TApi extends Api>(
 				toolChoice: mapOpenAiToolChoice(options?.toolChoice),
 				serviceTier: options?.serviceTier,
 				preferWebsockets: options?.preferWebsockets,
-				reasoningSummary: options?.hideThinkingSummary ? null : "detailed",
+				reasoningSummary: options?.hideThinkingSummary ? null : undefined,
 				textVerbosity: options?.textVerbosity,
 			});
 

--- a/packages/ai/test/openai-codex-responses-lite.test.ts
+++ b/packages/ai/test/openai-codex-responses-lite.test.ts
@@ -83,35 +83,39 @@ function createCodexFetchMock(sse: string, onRequest: (captured: CapturedCodexRe
 	}) as FetchImpl;
 }
 
-describe("openai-codex reasoning.context", () => {
-	it("defaults to all_turns on gpt-5.4+ models and forwards explicit overrides", async () => {
-		const model = createCodexModel("gpt-5.4");
+describe("openai-codex optional response controls", () => {
+	it("sends reasoning effort without optional Codex response controls unless explicitly requested", async () => {
+		const model = createCodexModel("gpt-5.5");
 
 		const defaulted = await transformRequestBody({ model: model.id }, model, { reasoningEffort: "medium" });
-		expect(defaulted.reasoning?.context).toBe("all_turns");
+		expect(defaulted.reasoning).toEqual({ effort: "medium" });
+		expect("summary" in (defaulted.reasoning ?? {})).toBe(false);
+		expect("context" in (defaulted.reasoning ?? {})).toBe(false);
+		expect("text" in defaulted).toBe(false);
 
 		const explicit = await transformRequestBody({ model: model.id }, model, {
 			reasoningEffort: "medium",
-			reasoningContext: "current_turn",
+			reasoningSummary: "concise",
+			reasoningContext: "all_turns",
+			textVerbosity: "low",
 		});
-		expect(explicit.reasoning?.context).toBe("current_turn");
+		expect(explicit.reasoning).toEqual({
+			effort: "medium",
+			summary: "concise",
+			context: "all_turns",
+		});
+		expect(explicit.text).toEqual({ verbosity: "low" });
 	});
 
-	it("keeps the all_turns default for the lite transport on supported models", async () => {
+	it("omits reasoning.summary when explicitly suppressed", async () => {
 		const model = createCodexModel("gpt-5.5");
 
-		const lite = await transformRequestBody({ model: model.id }, model, {
+		const suppressed = await transformRequestBody({ model: model.id }, model, {
 			reasoningEffort: "medium",
-			responsesLite: true,
+			reasoningSummary: null,
 		});
-		expect(lite.reasoning?.context).toBe("all_turns");
-
-		const overridden = await transformRequestBody({ model: model.id }, model, {
-			reasoningEffort: "medium",
-			responsesLite: true,
-			reasoningContext: "auto",
-		});
-		expect(overridden.reasoning?.context).toBe("auto");
+		expect(suppressed.reasoning).toEqual({ effort: "medium" });
+		expect("summary" in (suppressed.reasoning ?? {})).toBe(false);
 	});
 
 	// gpt-5.1-codex / gpt-5.3-codex / gpt-5.3-codex-spark reject `all_turns`
@@ -120,13 +124,15 @@ describe("openai-codex reasoning.context", () => {
 		"gpt-5.1-codex",
 		"gpt-5.3-codex",
 		"gpt-5.3-codex-spark",
-	])("omits the all_turns default for pre-5.4 model %s", async modelId => {
+	])("omits unsupported all_turns context for pre-5.4 model %s", async modelId => {
 		const model = createCodexModel(modelId);
 
-		const defaulted = await transformRequestBody({ model: model.id }, model, { reasoningEffort: "medium" });
-		expect(defaulted.reasoning).toBeDefined();
-		expect(defaulted.reasoning?.context).toBeUndefined();
-		expect("context" in (defaulted.reasoning ?? {})).toBe(false);
+		const forced = await transformRequestBody({ model: model.id }, model, {
+			reasoningEffort: "medium",
+			reasoningContext: "all_turns",
+		});
+		expect(forced.reasoning).toEqual({ effort: "medium" });
+		expect("context" in (forced.reasoning ?? {})).toBe(false);
 
 		// A supported override (current_turn/auto) is still honored.
 		const overridden = await transformRequestBody({ model: model.id }, model, {
@@ -134,38 +140,6 @@ describe("openai-codex reasoning.context", () => {
 			reasoningContext: "current_turn",
 		});
 		expect(overridden.reasoning?.context).toBe("current_turn");
-	});
-
-	it("suppresses an explicit all_turns override on a pre-5.4 model", async () => {
-		const model = createCodexModel("gpt-5.3-codex-spark");
-
-		const forced = await transformRequestBody({ model: model.id }, model, {
-			reasoningEffort: "medium",
-			reasoningContext: "all_turns",
-		});
-		expect(forced.reasoning).toBeDefined();
-		expect(forced.reasoning?.context).toBeUndefined();
-	});
-});
-
-describe("openai-codex reasoning.summary", () => {
-	it("sends summary on gpt-5.4+ models and honors explicit levels", async () => {
-		const model = createCodexModel("gpt-5.4");
-
-		const defaulted = await transformRequestBody({ model: model.id }, model, { reasoningEffort: "medium" });
-		expect(defaulted.reasoning?.summary).toBe("detailed");
-
-		const explicit = await transformRequestBody({ model: model.id }, model, {
-			reasoningEffort: "medium",
-			reasoningSummary: "concise",
-		});
-		expect(explicit.reasoning?.summary).toBe("concise");
-
-		const suppressed = await transformRequestBody({ model: model.id }, model, {
-			reasoningEffort: "medium",
-			reasoningSummary: null,
-		});
-		expect("summary" in (suppressed.reasoning ?? {})).toBe(false);
 	});
 
 	// gpt-5.1-codex / gpt-5.3-codex / gpt-5.3-codex-spark reject `reasoning.summary`
@@ -178,7 +152,7 @@ describe("openai-codex reasoning.summary", () => {
 		const model = createCodexModel(modelId);
 
 		const defaulted = await transformRequestBody({ model: model.id }, model, { reasoningEffort: "medium" });
-		expect(defaulted.reasoning).toBeDefined();
+		expect(defaulted.reasoning).toEqual({ effort: "medium" });
 		expect("summary" in (defaulted.reasoning ?? {})).toBe(false);
 
 		// Even an explicit summary level is suppressed on unsupported ids.
@@ -186,6 +160,7 @@ describe("openai-codex reasoning.summary", () => {
 			reasoningEffort: "medium",
 			reasoningSummary: "detailed",
 		});
+		expect(forced.reasoning).toEqual({ effort: "medium" });
 		expect("summary" in (forced.reasoning ?? {})).toBe(false);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the default `textVerbosity` setting being forwarded to OpenAI Codex requests unless the user explicitly configures it, preserving Codex's native response-control defaults. ([#4949](https://github.com/can1357/oh-my-pi/issues/4949))
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -34,9 +34,13 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 			openrouterRoutingPreset && openrouterRoutingPreset !== "default" ? openrouterRoutingPreset : undefined;
 		const antigravityEndpointMode = settings.get("providers.antigravityEndpoint");
 		const textVerbosity =
-			model.api === "openai-codex-responses" || model.api === "openai-responses"
-				? settings.get("textVerbosity")
-				: undefined;
+			model.api === "openai-codex-responses"
+				? settings.isConfigured("textVerbosity")
+					? settings.get("textVerbosity")
+					: undefined
+				: model.api === "openai-responses"
+					? settings.get("textVerbosity")
+					: undefined;
 		const streamFirstEventTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamFirstEventTimeoutSeconds"));
 		const streamIdleTimeoutMs = timeoutSecondsToMs(settings.get("providers.streamIdleTimeoutSeconds"));
 		// Server-side fallback (opt-in): when the user enables it AND the

--- a/packages/coding-agent/test/settings-stream-fn.test.ts
+++ b/packages/coding-agent/test/settings-stream-fn.test.ts
@@ -81,7 +81,17 @@ describe("createSettingsAwareStreamFn", () => {
 		expect(calls[0]?.options?.hideThinkingSummary).toBe(true);
 	});
 
-	it("applies Responses-family text verbosity from settings while preserving caller overrides", () => {
+	it("applies Codex text verbosity only when settings or caller options configure it", () => {
+		const unconfiguredSettings = Settings.isolated({});
+		const { fn: unconfiguredBase, calls: unconfiguredCalls } = captureBase();
+		const unconfiguredWrapped = createSettingsAwareStreamFn(unconfiguredSettings, unconfiguredBase);
+
+		unconfiguredWrapped(stubCodexModel, stubContext, undefined);
+		unconfiguredWrapped(stubCodexModel, stubContext, { textVerbosity: "medium" });
+
+		expect(unconfiguredCalls[0]?.options?.textVerbosity).toBeUndefined();
+		expect(unconfiguredCalls[1]?.options?.textVerbosity).toBe("medium");
+
 		const settings = Settings.isolated({ textVerbosity: "low" });
 		const { fn: base, calls } = captureBase();
 		const wrapped = createSettingsAwareStreamFn(settings, base);


### PR DESCRIPTION
## Repro
A local request-shape repro for GPT-5.5 showed the default Codex transform sending optional controls that the reporter identified as correlated with intermittent Codex `server_error` disconnects: `reasoning.summary: "detailed"`, `reasoning.context: "all_turns"`, and `text.verbosity: "high"`. Recorded command: `cd .wt/repro && bun test codex-request-params.test.ts`.

## Cause
`packages/ai/src/providers/openai-codex/request-transformer.ts` defaulted Codex response controls whenever reasoning or text options were absent; `packages/ai/src/stream.ts` forced `reasoningSummary: "detailed"` for Codex unless summaries were hidden; and `packages/coding-agent/src/session/settings-stream-fn.ts` forwarded the schema default `textVerbosity` to Codex even when the user had not configured it.

## Fix
- Omit Codex `reasoning.summary`, `reasoning.context`, and `text.verbosity` by default while preserving explicit supported overrides.
- Stop `streamSimple` from forcing a Codex reasoning summary when summaries are not hidden.
- Forward the coding-agent `textVerbosity` setting to Codex only when the user explicitly configures it; caller-provided stream options still win.
- Add regression coverage for Codex request transforms and settings-aware stream option merging.

## Verification
`bun test packages/ai/test/openai-codex-responses-lite.test.ts packages/ai/test/openai-codex-stream.test.ts packages/coding-agent/test/settings-stream-fn.test.ts` passed: 85 tests, 0 failures, 403 assertions. `gh_push_branch` also completed the pre-publish gate before pushing. Fixes #4949.