### PR TITLE
fix(catalog): preserve static limits on cache fingerprint mismatch

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed stale cached model limits overriding updated static catalog limits after a static catalog fingerprint mismatch. ([#4956](https://github.com/can1357/oh-my-pi/issues/4956))
+
 ## [16.3.12] - 2026-07-08
 
 ### Fixed

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -152,8 +152,9 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const dynamicFetchSucceeded = fetchedDynamicModels !== null;
 	const cacheModels = dynamicFetchSucceeded
 		? []
-		: dropCachedModelIdsOnStaticMismatch(
+		: prepareCacheModelsForStaticMismatch(
 				normalizeModelList<TApi>(cache?.models ?? []),
+				staticModels,
 				cacheFingerprintMatches,
 				options.dropCachedModelIdsOnStaticMismatch,
 			);
@@ -188,8 +189,9 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				collapseBuiltModelVariants(
 					mergeDynamicModels(
 						mergeModelSources(staticModels, modelsDevModels),
-						dropCachedModelIdsOnStaticMismatch(
+						prepareCacheModelsForStaticMismatch(
 							normalizeModelList<TApi>(latestCache?.models ?? cache?.models ?? []),
+							staticModels,
 							cacheFingerprintMatches,
 							options.dropCachedModelIdsOnStaticMismatch,
 						),
@@ -260,16 +262,29 @@ function shouldFetchRemoteSources(
 	return false;
 }
 
-function dropCachedModelIdsOnStaticMismatch<TApi extends Api>(
+function prepareCacheModelsForStaticMismatch<TApi extends Api>(
 	models: readonly Model<TApi>[],
+	staticModels: readonly Model<TApi>[],
 	cacheFingerprintMatches: boolean,
 	ids: readonly string[] | undefined,
 ): Model<TApi>[] {
-	if (cacheFingerprintMatches || ids === undefined || ids.length === 0 || models.length === 0) {
-		return models.length === 0 ? [] : [...models];
+	if (models.length === 0) {
+		return [];
 	}
-	const droppedIds = new Set(ids);
-	return models.filter(model => !droppedIds.has(model.id));
+	if (cacheFingerprintMatches) {
+		return [...models];
+	}
+
+	const droppedIds = ids && ids.length > 0 ? new Set(ids) : undefined;
+	const staticIds = staticModels.length > 0 ? new Set(staticModels.map(model => model.id)) : undefined;
+	const sanitizedModels: Model<TApi>[] = [];
+	for (const model of models) {
+		if (droppedIds?.has(model.id)) {
+			continue;
+		}
+		sanitizedModels.push(staticIds?.has(model.id) ? { ...model, contextWindow: null, maxTokens: null } : model);
+	}
+	return sanitizedModels;
 }
 
 function mergeModelSources<TApi extends Api>(...sources: readonly (readonly Model<TApi>[])[]): Model<TApi>[] {

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -478,6 +478,66 @@ describe("model cache spec round trip", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+
+	it("uses current static limits for same-id cache rows when the static fingerprint changed", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-static-fingerprint-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const staleSameId = buildModel(
+			completionsSpec({
+				id: "catalog-updated-model",
+				name: "Catalog Updated Model (cached)",
+				provider: "spec-cache-test",
+				contextWindow: 64_000,
+				maxTokens: 4_000,
+			}),
+		);
+		const cachedOnly = buildModel(
+			completionsSpec({
+				id: "cache-only-model",
+				name: "Cache Only Model",
+				provider: "spec-cache-test",
+				contextWindow: 96_000,
+				maxTokens: 6_000,
+			}),
+		);
+		const updatedStatic = completionsSpec({
+			id: staleSameId.id,
+			name: "Catalog Updated Model",
+			provider: "spec-cache-test",
+			contextWindow: 256_000,
+			maxTokens: 32_000,
+		});
+
+		try {
+			writeModelCache(
+				"spec-cache-test",
+				Date.now(),
+				[staleSameId, cachedOnly],
+				true,
+				"merge-v3:stale-static-catalog",
+				dbPath,
+			);
+
+			const offline = await resolveProviderModels<"openai-completions">(
+				{
+					providerId: "spec-cache-test",
+					staticModels: [updatedStatic],
+					cacheDbPath: dbPath,
+				},
+				"offline",
+			);
+
+			const sameId = offline.models.find(candidate => candidate.id === updatedStatic.id);
+			expect(sameId?.contextWindow).toBe(256_000);
+			expect(sameId?.maxTokens).toBe(32_000);
+
+			const cacheOnly = offline.models.find(candidate => candidate.id === cachedOnly.id);
+			expect(cacheOnly?.contextWindow).toBe(96_000);
+			expect(cacheOnly?.maxTokens).toBe(6_000);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("isOfficialAnthropicApiUrl", () => {

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 


### PR DESCRIPTION
## Repro
A cache row written with an older `staticFingerprint` and a same-id model carrying `contextWindow: 64000` was resolved offline against an updated static model carrying `contextWindow: 256000`. Running `bun run .wt/repro-cached-limits.ts` before the fix returned `{"contextWindow":64000,"maxTokens":16384,"stale":false}`, proving the stale cached context window overrode the updated static catalog value.

## Cause
`resolveProviderModels` in `packages/catalog/src/model-manager.ts` merged cached models into the static catalog even when `cacheFingerprintMatches` was false. The merge path fed stale cached limits into `mergeDynamicModel`, whose `preferDiscoveryLimit` treats finite cached limits as authoritative discovery values, so same-id cache rows could override corrected static `contextWindow` and `maxTokens` values after a release updated `models.json`.

## Fix
- Sanitize cached models on static fingerprint mismatch before merging them with the current static catalog.
- Null only `contextWindow` and `maxTokens` for cached models whose ids exist in the current static catalog, forcing `preferDiscoveryLimit` to fall back to the updated static values.
- Preserve cached-only models and the existing `dropCachedModelIdsOnStaticMismatch` behavior.
- Add regression coverage for offline resolution with a mismatched cache fingerprint, a same-id static model, and a cached-only model.

## Verification
`bun test packages/catalog/test/build.test.ts -t "uses current static limits"` passed: 1 pass, 26 filtered out. `bun test packages/catalog/test/build.test.ts` passed: 27 pass, 0 fail. `gh_push_branch` also completed its pre-publish `bun run fix` and `bun check` gate before pushing. Fixes #4956