### PR TITLE
fix(agent): stop malformed subagent yield loops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed the streamed `write` tool's collapsed pending tail preview leaving stale rows above the first partial-result frame in the TUI; the first result now replays the viewport like the SSH placeholder seam already did ([#4477](https://github.com/can1357/oh-my-pi/issues/4477))
 - Fixed first-run setup ignoring a pre-seeded `config.yaml`: the settings loader now treats `config.yml` and `config.yaml` as equivalent existing main config files, writes back to the existing extension, and only creates canonical `config.yml` for fresh installs. ([#4914](https://github.com/can1357/oh-my-pi/issues/4914))
 - Fixed extension `sendUserMessage()` without `deliverAs` surfacing `AgentBusyError` during active streams; omitted `deliverAs` now queues a steer through the normal prompt flow, and ACP/RPC skill-command prompts queue while streaming (RPC honors the prompt command's `streamingBehavior`, defaulting to steer) ([#4923](https://github.com/can1357/oh-my-pi/issues/4923)).
+- Fixed subagents that repeatedly submit malformed `yield` results from leaving the parent waiting forever; malformed submissions now repeat the required response format, and repeated invalid submissions fail the child with a clear error. ([#4957](https://github.com/can1357/oh-my-pi/issues/4957))
 
 ## [16.3.12] - 2026-07-08
 

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -798,6 +798,8 @@ export function createSubagentSettings(
 
 type AbortReason = "signal" | "terminate" | "timeout" | "budget";
 
+const MAX_YIELD_TOOL_ERRORS = 6;
+
 /** Inputs for the run monitor driving one subagent assignment. */
 interface RunMonitorArgs {
 	index: number;
@@ -834,11 +836,13 @@ interface SubagentRunMonitor {
 	hasUsage(): boolean;
 	yieldCalled(): boolean;
 	runtimeLimitExceeded(): boolean;
+	terminalError(): string | undefined;
 	/** True when the abort carries a precise external reason (signal / wall-clock / budget). */
 	hasExplicitAbortReason(): boolean;
 	/** Whether the (attempted) abort counts as a cancelled run rather than an internal failure. */
 	isAbortedRun(): boolean;
 	requestAbort(reason: AbortReason): void;
+	failWithError(message: string): void;
 	abortActiveSession(): Promise<void>;
 	waitForActiveSessionAbort(): Promise<void>;
 	resolveSignalAbortReason(): string;
@@ -922,6 +926,8 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 	let hasUsage = false;
 	let budgetSteerSent = false;
 	let budgetLimitExceeded = false;
+	let terminalError: string | undefined;
+	let consecutiveYieldToolErrors = 0;
 	let lastAssistantSalvageText: string | undefined;
 	let activeSessionAbortPromise: Promise<void> | undefined;
 
@@ -958,6 +964,11 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		abortReason = reason;
 		abortController.abort();
 		void abortActiveSession();
+	};
+
+	const failWithError = (message: string) => {
+		terminalError ??= message;
+		requestAbort("terminate");
 	};
 
 	// Handle abort signal
@@ -1187,6 +1198,38 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 				// renderer doesn't double-count it against the final entry.
 				if (event.toolName === "task") {
 					progress.inflightTaskDetails = undefined;
+				}
+
+				if (event.toolName === "yield") {
+					if (event.isError) {
+						consecutiveYieldToolErrors++;
+						let yieldErrorText = "";
+						const resultContent = event.result?.content;
+						if (Array.isArray(resultContent)) {
+							const textParts: string[] = [];
+							for (const block of resultContent) {
+								if (
+									block &&
+									typeof block === "object" &&
+									"type" in block &&
+									block.type === "text" &&
+									"text" in block &&
+									typeof block.text === "string"
+								) {
+									textParts.push(block.text);
+								}
+							}
+							yieldErrorText = textParts.join("\n").trim();
+						}
+						if (consecutiveYieldToolErrors >= MAX_YIELD_TOOL_ERRORS) {
+							const suffix = yieldErrorText ? ` Last yield error: ${yieldErrorText}` : "";
+							failWithError(
+								`Subagent submitted invalid yield results ${consecutiveYieldToolErrors} times; stopping to avoid an infinite submit loop.${suffix}`,
+							);
+						}
+					} else {
+						consecutiveYieldToolErrors = 0;
+					}
 				}
 
 				// Check for registered subagent tool handler
@@ -1454,10 +1497,12 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 		hasUsage: () => hasUsage,
 		yieldCalled: () => yieldCalled,
 		runtimeLimitExceeded: () => runtimeLimitExceeded,
+		terminalError: () => terminalError,
 		hasExplicitAbortReason: () => abortReason === "signal" || runtimeLimitExceeded || budgetLimitExceeded,
 		isAbortedRun: () =>
 			abortReason === "signal" || runtimeLimitExceeded || budgetLimitExceeded || abortReason === undefined,
 		requestAbort,
+		failWithError,
 		abortActiveSession,
 		waitForActiveSessionAbort,
 		resolveSignalAbortReason,
@@ -1615,6 +1660,7 @@ async function driveSessionToYield(
 			error = err instanceof Error ? err.stack || err.message : String(err);
 		}
 	} finally {
+		error ??= monitor.terminalError();
 		if (abortSignal.aborted) {
 			aborted = monitor.isAbortedRun();
 			if (aborted) {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1200,38 +1200,6 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 					progress.inflightTaskDetails = undefined;
 				}
 
-				if (event.toolName === "yield") {
-					if (event.isError) {
-						consecutiveYieldToolErrors++;
-						let yieldErrorText = "";
-						const resultContent = event.result?.content;
-						if (Array.isArray(resultContent)) {
-							const textParts: string[] = [];
-							for (const block of resultContent) {
-								if (
-									block &&
-									typeof block === "object" &&
-									"type" in block &&
-									block.type === "text" &&
-									"text" in block &&
-									typeof block.text === "string"
-								) {
-									textParts.push(block.text);
-								}
-							}
-							yieldErrorText = textParts.join("\n").trim();
-						}
-						if (consecutiveYieldToolErrors >= MAX_YIELD_TOOL_ERRORS) {
-							const suffix = yieldErrorText ? ` Last yield error: ${yieldErrorText}` : "";
-							failWithError(
-								`Subagent submitted invalid yield results ${consecutiveYieldToolErrors} times; stopping to avoid an infinite submit loop.${suffix}`,
-							);
-						}
-					} else {
-						consecutiveYieldToolErrors = 0;
-					}
-				}
-
 				// Check for registered subagent tool handler
 				const handler = subprocessToolRegistry.getHandler(event.toolName);
 				const eventArgs = (event as { args?: Record<string, unknown> }).args ?? {};
@@ -1277,6 +1245,37 @@ function createSubagentRunMonitor(args: RunMonitorArgs): SubagentRunMonitor {
 						})
 					) {
 						requestAbort("terminate");
+					}
+				}
+				if (event.toolName === "yield") {
+					if (event.isError && !yieldCalled && !abortSent) {
+						consecutiveYieldToolErrors++;
+						let yieldErrorText = "";
+						const resultContent = event.result?.content;
+						if (Array.isArray(resultContent)) {
+							const textParts: string[] = [];
+							for (const block of resultContent) {
+								if (
+									block &&
+									typeof block === "object" &&
+									"type" in block &&
+									block.type === "text" &&
+									"text" in block &&
+									typeof block.text === "string"
+								) {
+									textParts.push(block.text);
+								}
+							}
+							yieldErrorText = textParts.join("\n").trim();
+						}
+						if (consecutiveYieldToolErrors >= MAX_YIELD_TOOL_ERRORS) {
+							const suffix = yieldErrorText ? ` Last yield error: ${yieldErrorText}` : "";
+							failWithError(
+								`Subagent submitted invalid yield results ${consecutiveYieldToolErrors} times; stopping to avoid an infinite submit loop.${suffix}`,
+							);
+						}
+					} else if (!event.isError) {
+						consecutiveYieldToolErrors = 0;
 					}
 				}
 				flushProgress = true;

--- a/packages/coding-agent/src/tools/yield.ts
+++ b/packages/coding-agent/src/tools/yield.ts
@@ -16,6 +16,9 @@ import { subprocessToolRegistry } from "../task/subprocess-tool-registry";
 import type { ToolSession } from ".";
 import { buildOutputValidator, formatAllValidationIssues } from "./output-schema-validator";
 
+const YIELD_RESULT_FORMAT_HINT =
+	'Submit success as {"result":{"data":<your output>}} or failure as {"result":{"error":"message"}}.';
+
 export interface YieldDetails {
 	/** Successful result payload, or omitted when `useLastTurn` requests last-turn extraction. */
 	data?: unknown;
@@ -305,7 +308,7 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 		const raw = params as Record<string, unknown>;
 		const rawResult = raw.result;
 		if (!rawResult || typeof rawResult !== "object" || Array.isArray(rawResult)) {
-			throw new Error("result must be an object containing either data or error");
+			throw new Error(`result must be an object containing either data or error. ${YIELD_RESULT_FORMAT_HINT}`);
 		}
 		const resultRecord = rawResult as Record<string, unknown>;
 		const errorMessage = typeof resultRecord.error === "string" ? resultRecord.error : undefined;
@@ -322,9 +325,7 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 			throw new Error("result cannot contain both data and error");
 		}
 		if (errorMessage === undefined && data === undefined && yieldType === undefined) {
-			throw new Error(
-				'result must contain either `data` or `error`. Use `{result: {data: <your output>}}` for success or `{result: {error: "message"}}` for failure.',
-			);
+			throw new Error(`result must contain either \`data\` or \`error\`. ${YIELD_RESULT_FORMAT_HINT}`);
 		}
 
 		const status = errorMessage !== undefined ? "aborted" : "success";

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -341,6 +341,48 @@ describe("runSubprocess yield reminders", () => {
 		expect(result.output).toContain('"ok": true');
 	});
 
+	it("fails instead of waiting forever when yield submit errors repeat", async () => {
+		const promptReleased = Promise.withResolvers<void>();
+		let yieldAttempts = 0;
+		let abortCalls = 0;
+		const session = createMockSession(async ({ emit, state }) => {
+			for (let attempt = 1; attempt <= 6; attempt++) {
+				const assistant = createAssistantStopMessage(`malformed yield attempt ${attempt}`);
+				state.messages.push(assistant);
+				emit({ type: "message_end", message: assistant });
+				emit({
+					type: "tool_execution_end",
+					toolCallId: `tool-malformed-${attempt}`,
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "result must be an object containing either data or error" }],
+						details: { status: "error", error: "result must be an object containing either data or error" },
+					},
+					isError: true,
+				});
+				yieldAttempts = attempt;
+			}
+			await promptReleased.promise;
+		});
+		const abortableSession = session as unknown as { abort: () => Promise<void> };
+		abortableSession.abort = async () => {
+			abortCalls += 1;
+			promptReleased.resolve();
+		};
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-repeated-malformed-yield" });
+		expect(result.exitCode).toBe(1);
+		expect(result.aborted).toBe(false);
+		expect(result.stderr).toContain("Subagent submitted invalid yield results 6 times");
+		expect(result.stderr).toContain("stopping to avoid an infinite submit loop");
+		expect(result.stderr).toContain("result must be an object containing either data or error");
+		expect(result.error).toBe(result.stderr);
+		expect(yieldAttempts).toBe(6);
+		expect(abortCalls).toBe(1);
+	});
+
 	it("waits for yield-triggered abort cleanup before resolving the subagent", async () => {
 		const promptCleanup = Promise.withResolvers<void>();
 		const abortCleanup = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -383,6 +383,51 @@ describe("runSubprocess yield reminders", () => {
 		expect(abortCalls).toBe(1);
 	});
 
+	it("ignores malformed yield siblings after a valid yield", async () => {
+		const promptReleased = Promise.withResolvers<void>();
+		let abortCalls = 0;
+		const session = createMockSession(async ({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-valid",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+			for (let attempt = 1; attempt <= 6; attempt++) {
+				emit({
+					type: "tool_execution_end",
+					toolCallId: `tool-malformed-sibling-${attempt}`,
+					toolName: "yield",
+					result: {
+						content: [{ type: "text", text: "result must be an object containing either data or error" }],
+						details: { status: "error", error: "result must be an object containing either data or error" },
+					},
+					isError: true,
+				});
+			}
+			await promptReleased.promise;
+		});
+		const abortableSession = session as unknown as { abort: () => Promise<void> };
+		abortableSession.abort = async () => {
+			abortCalls += 1;
+			promptReleased.resolve();
+		};
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({ ...baseOptions, id: "subagent-valid-yield-with-bad-siblings" });
+		expect(result.exitCode).toBe(0);
+		expect(result.aborted).toBe(false);
+		expect(result.output).toContain('"ok": true');
+		expect(result.stderr).toBe("");
+		expect(result.error).toBeUndefined();
+		expect(abortCalls).toBe(1);
+	});
+
 	it("waits for yield-triggered abort cleanup before resolving the subagent", async () => {
 		const promptCleanup = Promise.withResolvers<void>();
 		const abortCleanup = Promise.withResolvers<void>();

--- a/packages/coding-agent/test/tools/yield.test.ts
+++ b/packages/coding-agent/test/tools/yield.test.ts
@@ -1129,7 +1129,7 @@ describe("YieldTool", () => {
 	it("rejects submissions without a result object", async () => {
 		const tool = new YieldTool(createSession());
 		await expect(tool.execute("call-3", {} as never)).rejects.toThrow(
-			"result must be an object containing either data or error",
+			'Submit success as {"result":{"data":<your output>}} or failure as {"result":{"error":"message"}}.',
 		);
 	});
 	it("sets lenientArgValidation so agent-loop bypasses validation errors", () => {


### PR DESCRIPTION
## Repro
A focused regression in `packages/coding-agent/test/task/executor-subagent-reminders.test.ts` simulates a subagent emitting repeated malformed `yield` tool errors (`result must be an object containing either data or error`) and then parking. On a pre-fix worktree, `timeout 5s bun test packages/coding-agent/test/task/executor-subagent-reminders.test.ts -t "fails instead of waiting forever"` exited 124 because the parent never settled.

## Cause
`packages/coding-agent/src/task/executor.ts` only treated successful or aborted `yield` details as terminal subprocess output. Malformed `yield` tool errors were surfaced back to the subagent but were not counted by the subprocess monitor, so a weak model could keep retrying invalid submissions inside the same prompt while `runSubprocess` continued waiting for a valid yield or idle completion.

## Fix
- Added a finite repeated-`yield` error guard in the subagent run monitor that aborts the child session with a clear failure after six invalid yield submissions.
- Propagated that monitor terminal error into the final `SingleResult` as a failed, non-aborted subagent result.
- Added regression coverage for repeated malformed submit attempts while preserving the existing one-error-then-success recovery path.
- Added the coding-agent changelog entry for #4957.

## Verification
`bun test packages/coding-agent/test/task/executor-subagent-reminders.test.ts -t "fails instead of waiting forever"` passed (1 test). `bun test packages/coding-agent/test/task/executor-subagent-reminders.test.ts` passed (20 tests). Pre-publish gate in `gh_push_branch` completed successfully (`bun run fix` and `bun check`). Fixes #4957