### PR TITLE
fix(tui): hide Codex thinking comment separators

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex 5.6 Sol thinking summaries rendering standalone `<!-- -->` separator comments as visible thinking text. ([#4958](https://github.com/can1357/oh-my-pi/issues/4958))
+
 ## [16.3.13] - 2026-07-09
 
 ### Fixed

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -33,6 +33,17 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 	let fenceLen = 0;
 
 	const FENCE = /^( {0,3})([`~]{3,})/;
+	const EMPTY_HTML_COMMENT = /^\s*<!--\s*-->\s*$/;
+	const hasRenderableLineAfter = (index: number): boolean => {
+		for (let j = index + 1; j < lines.length; j++) {
+			const next = lines[j]!;
+			if (next.trim() === "" || EMPTY_HTML_COMMENT.test(next)) continue;
+			return true;
+		}
+		return false;
+	};
+
+	let suppressBlankAfterComment = false;
 	const appendEllipsis = () => {
 		let lastLineIdx = resultLines.length - 1;
 		while (lastLineIdx >= 0 && resultLines[lastLineIdx]!.trim() === "") {
@@ -70,8 +81,17 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 				fenceChar = "";
 				fenceLen = 0;
 			}
+			suppressBlankAfterComment = false;
 			// We skip all internal lines of a code fence.
+		} else if (EMPTY_HTML_COMMENT.test(line)) {
+			if (hasRenderableLineAfter(i)) {
+				const last = resultLines[resultLines.length - 1];
+				if (last !== undefined && last.trim() !== "") resultLines.push("");
+			}
+			suppressBlankAfterComment = true;
+		} else if (suppressBlankAfterComment && line.trim() === "") {
 		} else if (open) {
+			suppressBlankAfterComment = false;
 			const marker = open[2]!;
 			const ch = marker[0]!;
 			// A backtick fence's info string may not contain a backtick.
@@ -84,6 +104,7 @@ export function formatThinkingForDisplay(text: string, proseOnly: boolean): stri
 				resultLines.push(line);
 			}
 		} else {
+			suppressBlankAfterComment = false;
 			resultLines.push(line);
 		}
 	}
@@ -101,7 +122,7 @@ export function hasDisplayableThinking(
 ): boolean {
 	if (!text) return false;
 	if (!formattedText) return false;
-	return formattedText.length > 0 && canonicalizeMessage(text).length > 0;
+	return canonicalizeMessage(formattedText).length > 0 && canonicalizeMessage(text).length > 0;
 }
 
 /** Whether an assistant message contains thinking content the TUI can reveal. */

--- a/packages/coding-agent/src/utils/thinking-display.ts
+++ b/packages/coding-agent/src/utils/thinking-display.ts
@@ -122,7 +122,7 @@ export function hasDisplayableThinking(
 ): boolean {
 	if (!text) return false;
 	if (!formattedText) return false;
-	return canonicalizeMessage(formattedText).length > 0 && canonicalizeMessage(text).length > 0;
+	return formattedText.trim().length > 0 && canonicalizeMessage(text).length > 0;
 }
 
 /** Whether an assistant message contains thinking content the TUI can reveal. */

--- a/packages/coding-agent/test/session/thinking-display.test.ts
+++ b/packages/coding-agent/test/session/thinking-display.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { canonicalizeMessage } from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
+import {
+	canonicalizeMessage,
+	formatThinkingForDisplay,
+	hasDisplayableThinking,
+} from "@oh-my-pi/pi-coding-agent/utils/thinking-display";
 
 describe("canonicalizeMessage", () => {
 	it("returns empty string for undefined, empty, or whitespace-only", () => {
@@ -22,5 +26,58 @@ describe("canonicalizeMessage", () => {
 		expect(canonicalizeMessage("hello.")).toBe("hello.");
 		expect(canonicalizeMessage(". hello .")).toBe(". hello .");
 		expect(canonicalizeMessage("a")).toBe("a");
+	});
+});
+
+describe("formatThinkingForDisplay", () => {
+	it("removes standalone empty HTML comment separators while preserving prose sections", () => {
+		const formatted = formatThinkingForDisplay(
+			[
+				"I checked the request.",
+				"<!-- -->",
+				"The implementation path is straightforward.",
+				"  <!-- -->  ",
+				"I will update the tests first.",
+			].join("\n"),
+			true,
+		);
+
+		expect(formatted).toBe(
+			[
+				"I checked the request.",
+				"",
+				"The implementation path is straightforward.",
+				"",
+				"I will update the tests first.",
+			].join("\n"),
+		);
+	});
+
+	it("keeps non-empty HTML-like prose instead of dropping every angle-bracket line", () => {
+		const formatted = formatThinkingForDisplay(
+			[
+				"These notes mention <thinking> as prose.",
+				"<!-- keep this explanation visible -->",
+				"Continue with the observable contract.",
+			].join("\n"),
+			true,
+		);
+
+		expect(formatted).toBe(
+			[
+				"These notes mention <thinking> as prose.",
+				"<!-- keep this explanation visible -->",
+				"Continue with the observable contract.",
+			].join("\n"),
+		);
+	});
+});
+
+describe("hasDisplayableThinking", () => {
+	it("treats comment-only separators as non-displayable after prose-only formatting", () => {
+		const rawThinking = ["  <!-- -->  ", "", "\t", "<!-- -->"].join("\n");
+		const formatted = formatThinkingForDisplay(rawThinking, true);
+
+		expect(hasDisplayableThinking(rawThinking, formatted)).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
Codex 5.6 Sol thinking summaries can contain standalone empty HTML comment separators such as `<!-- -->`; reproducing the display path with `formatThinkingForDisplay('Analyzing...\n\n<!-- -->\n\nPlanning...', true)` showed the formatted thinking text still contained the comment, matching the reporter's screenshot where `<!-- -->` rendered inside thinking blocks.

## Cause
`packages/coding-agent/src/utils/thinking-display.ts` treated prose-only thinking as ordinary Markdown text after only eliding fenced code blocks, so OpenAI/Codex's empty HTML comment separator lines survived formatting and `AssistantMessageComponent` rendered them through the thinking Markdown block.

## Fix
- Added prose-only thinking formatting for standalone empty HTML comments so they become paragraph separators instead of visible text.
- Changed displayability to consider the formatted thinking text, preventing comment-only placeholder blocks from rendering.
- Added focused regression tests for separator removal, non-empty HTML-like prose preservation, and comment-only non-displayability.
- Added a `packages/coding-agent` changelog entry for #4958.

## Verification
Ran `bun test packages/coding-agent/test/session/thinking-display.test.ts`: 6 pass, 0 fail, 16 assertions. `gh_push_branch` completed the pre-publish gate and pushed `farm/47ac35fd/fix-sol-thinking-block`. Fixes #4958