### PR TITLE
fix(prompting): allow magic keywords beside punctuation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ultrathink`, `orchestrate`, and `workflowz` magic keywords not triggering when adjacent to sentence punctuation or quotes while still ignoring inflections and path/file-extension occurrences. ([#4965](https://github.com/can1357/oh-my-pi/issues/4965))
+
 ## [16.3.13] - 2026-07-09
 
 ### Fixed

--- a/packages/coding-agent/src/modes/magic-keyword-boundary.ts
+++ b/packages/coding-agent/src/modes/magic-keyword-boundary.ts
@@ -1,0 +1,22 @@
+/** Characters that bind a magic keyword into an identifier or path segment. */
+const LEFT_BOUNDARY = String.raw`(?<![\p{L}\p{N}_./\\-])`;
+
+/** Characters that cannot immediately follow a standalone magic keyword. */
+const RIGHT_BOUNDARY = String.raw`(?![\p{L}\p{N}_/\\-])(?!\.[\p{L}\p{N}_-])`;
+
+/** Escape a literal string for safe insertion into a RegExp source. */
+function escapeRegExp(value: string): string {
+	return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
+/**
+ * Build a case-sensitive magic-keyword matcher for prose punctuation boundaries.
+ *
+ * Sentence punctuation and quotes may touch the keyword, but letters, digits,
+ * underscores, slashes, backslashes, hyphens, and file-extension dots keep the
+ * occurrence embedded in another token or path.
+ */
+export function magicKeywordRegex(keyword: string, flags = ""): RegExp {
+	const normalizedFlags = flags.includes("u") ? flags : `${flags}u`;
+	return new RegExp(`${LEFT_BOUNDARY}${escapeRegExp(keyword)}${RIGHT_BOUNDARY}`, normalizedFlags);
+}

--- a/packages/coding-agent/src/modes/orchestrate.ts
+++ b/packages/coding-agent/src/modes/orchestrate.ts
@@ -1,5 +1,6 @@
 import orchestrateNotice from "../prompts/system/orchestrate-notice.md" with { type: "text" };
 import { createGradientHighlighter, type KeywordHighlighter } from "./gradient-highlight";
+import { magicKeywordRegex } from "./magic-keyword-boundary";
 import { keywordInProse } from "./markdown-prose";
 
 /**
@@ -8,21 +9,21 @@ import { keywordInProse } from "./markdown-prose";
  * Typing the standalone word in the input editor paints it with a cool
  * teal→violet gradient ({@link highlightOrchestrate}); submitting a message that
  * mentions it appends a hidden {@link ORCHESTRATE_NOTICE} that switches the model
- * into multi-agent orchestration mode. Matching is whitespace-delimited and
+ * into multi-agent orchestration mode. Matching is prose-delimited and
  * case-sensitive (lowercase only), so "orchestrated", "Orchestrate", or a path
  * like "orchestrate.ts" never trigger either behavior. Replaces the former
  * `/orchestrate` slash command.
  */
 
-// Detection: lowercase keyword flanked by whitespace or a string edge. Non-global so `.test` stays stateless.
-const ORCHESTRATE_WORD = /(?<!\S)orchestrate(?!\S)/;
+// Detection: lowercase keyword flanked by prose punctuation, whitespace, or a string edge.
+const ORCHESTRATE_WORD = magicKeywordRegex("orchestrate");
 
 /** Hidden system notice appended after a user message that mentions "orchestrate". */
 export const ORCHESTRATE_NOTICE: string = orchestrateNotice.trim();
 
 /**
  * Whether `text` contains the standalone keyword "orchestrate" (lowercase,
- * whitespace-delimited) in prose — never inside a code block, inline code span,
+ * prose-delimited) in prose — never inside a code block, inline code span,
  * or XML/HTML section.
  */
 export function containsOrchestrate(text: string): boolean {
@@ -36,7 +37,7 @@ export function containsOrchestrate(text: string): boolean {
  */
 export const highlightOrchestrate: KeywordHighlighter = createGradientHighlighter({
 	probe: /orchestrate/,
-	highlight: /(?<!\S)orchestrate(?!\S)/g,
+	highlight: magicKeywordRegex("orchestrate", "g"),
 	stops: 14,
 	hue: t => 150 + t * 130,
 });

--- a/packages/coding-agent/src/modes/ultrathink.ts
+++ b/packages/coding-agent/src/modes/ultrathink.ts
@@ -1,5 +1,6 @@
 import ultrathinkNotice from "../prompts/system/ultrathink-notice.md" with { type: "text" };
 import { createGradientHighlighter, type KeywordHighlighter } from "./gradient-highlight";
+import { magicKeywordRegex } from "./magic-keyword-boundary";
 import { keywordInProse } from "./markdown-prose";
 
 /**
@@ -13,15 +14,15 @@ import { keywordInProse } from "./markdown-prose";
  * trigger either behavior.
  */
 
-// Detection: lowercase keyword flanked by whitespace or a string edge. Non-global so `.test` stays stateless.
-const ULTRATHINK_WORD = /(?<!\S)ultrathink(?!\S)/;
+// Detection: lowercase keyword flanked by prose punctuation, whitespace, or a string edge.
+const ULTRATHINK_WORD = magicKeywordRegex("ultrathink");
 
 /** Hidden system notice appended after a user message that mentions "ultrathink". */
 export const ULTRATHINK_NOTICE: string = ultrathinkNotice.trim();
 
 /**
  * Whether `text` contains the standalone keyword "ultrathink" (lowercase,
- * whitespace-delimited) in prose — never inside a code block, inline code span,
+ * prose-delimited) in prose — never inside a code block, inline code span,
  * or XML/HTML section.
  */
 export function containsUltrathink(text: string): boolean {
@@ -35,7 +36,7 @@ export function containsUltrathink(text: string): boolean {
  */
 export const highlightUltrathink: KeywordHighlighter = createGradientHighlighter({
 	probe: /ultrathink/,
-	highlight: /(?<!\S)ultrathink(?!\S)/g,
+	highlight: magicKeywordRegex("ultrathink", "g"),
 	stops: 14,
 	hue: t => t * 330,
 });

--- a/packages/coding-agent/src/modes/workflow.ts
+++ b/packages/coding-agent/src/modes/workflow.ts
@@ -1,6 +1,7 @@
 import { prompt } from "@oh-my-pi/pi-utils";
 import workflowNoticeTemplate from "../prompts/system/workflow-notice.md" with { type: "text" };
 import { createGradientHighlighter, type KeywordHighlighter } from "./gradient-highlight";
+import { magicKeywordRegex } from "./magic-keyword-boundary";
 import { keywordInProse } from "./markdown-prose";
 
 /**
@@ -10,13 +11,13 @@ import { keywordInProse } from "./markdown-prose";
  * amber→green gradient ({@link highlightWorkflow}); submitting a message that
  * mentions it appends a hidden workflow notice that steers the model to author
  * a deterministic multi-subagent workflow through the active task schema.
- * Matching is whitespace-delimited and case-sensitive (lowercase only) —
+ * Matching is prose-delimited and case-sensitive (lowercase only) —
  * "workflowz" triggers, but "workflowzed", "Workflowz", and "workflowz.ts"
  * never do.
  */
 
-// Detection: lowercase keyword flanked by whitespace or a string edge. Non-global so `.test` stays stateless.
-const WORKFLOW_WORD = /(?<!\S)workflowz(?!\S)/;
+// Detection: lowercase keyword flanked by prose punctuation, whitespace, or a string edge.
+const WORKFLOW_WORD = magicKeywordRegex("workflowz");
 
 /** WORKFLOW_NOTICE is the default hidden notice for sessions with batched task calls enabled. */
 export const WORKFLOW_NOTICE: string = renderWorkflowNotice({ taskBatch: true });
@@ -28,7 +29,7 @@ export function renderWorkflowNotice({ taskBatch }: { taskBatch: boolean }): str
 
 /**
  * Whether `text` contains the standalone keyword "workflowz"
- * (lowercase, whitespace-delimited) in prose — never inside a code block, inline
+ * (lowercase, prose-delimited) in prose — never inside a code block, inline
  * code span, or XML/HTML section.
  */
 export function containsWorkflow(text: string): boolean {
@@ -42,7 +43,7 @@ export function containsWorkflow(text: string): boolean {
  */
 export const highlightWorkflow: KeywordHighlighter = createGradientHighlighter({
 	probe: /workflowz/,
-	highlight: /(?<!\S)workflowz(?!\S)/g,
+	highlight: magicKeywordRegex("workflowz", "g"),
 	stops: 14,
 	hue: t => 30 + t * 120,
 });

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/modes/magic-keywords.test.ts
+++ b/packages/coding-agent/test/modes/magic-keywords.test.ts
@@ -22,6 +22,16 @@ describe("highlightMagicKeywords", () => {
 		}
 	});
 
+	it("paints punctuation-adjacent prose keywords without changing visible text", () => {
+		const input = 'first "ultrathink," then orchestrate. Finally workflowz!';
+		const decorated = highlightMagicKeywords(input);
+		expect(decorated).not.toBe(input);
+		expect(Bun.stripANSI(decorated)).toBe(input);
+		for (const keyword of ["ultrathink", "orchestrate", "workflowz"]) {
+			expect(decorated).not.toContain(keyword);
+		}
+	});
+
 	it("never paints keywords inside code spans, fenced blocks, or XML sections", () => {
 		const input = "`ultrathink`\n```\norchestrate\n```\n<x>workflowz</x>";
 		expect(highlightMagicKeywords(input)).toBe(input);
@@ -71,10 +81,22 @@ describe("hasMagicKeyword", () => {
 		expect(hasMagicKeyword("just workflowz the steps")).toBe(true);
 	});
 
-	it("rejects keywords embedded in longer words or paths", () => {
+	it("detects standalone keywords beside prose punctuation and quotes", () => {
+		for (const text of ["please ultrathink.", 'say "orchestrate" now', "then workflowz, please"]) {
+			expect(hasMagicKeyword(text)).toBe(true);
+		}
+	});
+
+	it("rejects casing, inflections, old workflow names, and paths", () => {
+		expect(hasMagicKeyword("Ultrathink")).toBe(false);
+		expect(hasMagicKeyword("ORCHESTRATE")).toBe(false);
+		expect(hasMagicKeyword("workflow")).toBe(false);
+		expect(hasMagicKeyword("workflows")).toBe(false);
 		expect(hasMagicKeyword("ultrathinking is fun")).toBe(false);
-		expect(hasMagicKeyword("orchestrate.ts is a file")).toBe(false);
 		expect(hasMagicKeyword("workflowzed already")).toBe(false);
+		expect(hasMagicKeyword("src/modes/ultrathink.ts")).toBe(false);
+		expect(hasMagicKeyword("orchestrate.ts is a file")).toBe(false);
+		expect(hasMagicKeyword("packages/coding-agent/test/modes/workflowz.test.ts")).toBe(false);
 	});
 
 	it("rejects keywords inside code spans, fences, and xml sections", () => {

--- a/packages/coding-agent/test/modes/orchestrate.test.ts
+++ b/packages/coding-agent/test/modes/orchestrate.test.ts
@@ -22,7 +22,13 @@ describe("orchestrate keyword detection", () => {
 		expect(containsOrchestrate("do it now\norchestrate")).toBe(true);
 	});
 
-	it("ignores casing, inflections, punctuation-adjacent, and path-embedded forms", () => {
+	it("matches the lowercase word beside prose punctuation and quotes", () => {
+		for (const text of ["do it. orchestrate.", "please orchestrate, then report", 'say "orchestrate" now']) {
+			expect(containsOrchestrate(text)).toBe(true);
+		}
+	});
+
+	it("ignores casing, inflections, and path-embedded forms", () => {
 		expect(containsOrchestrate("Orchestrate")).toBe(false);
 		expect(containsOrchestrate("ORCHESTRATE")).toBe(false);
 		expect(containsOrchestrate("orchestrated the build")).toBe(false);
@@ -30,9 +36,8 @@ describe("orchestrate keyword detection", () => {
 		expect(containsOrchestrate("a clean orchestration")).toBe(false);
 		expect(containsOrchestrate("it orchestrates well")).toBe(false);
 		expect(containsOrchestrate("reorchestrate everything")).toBe(false);
-		// The reported bug: a path/extension is not whitespace, so the word never triggers.
+		// A path/extension must not trigger even though sentence punctuation does.
 		expect(containsOrchestrate("packages/coding-agent/src/modes/orchestrate.ts")).toBe(false);
-		expect(containsOrchestrate("do it. orchestrate.")).toBe(false);
 		expect(containsOrchestrate("nothing to see here")).toBe(false);
 	});
 
@@ -53,9 +58,16 @@ describe("orchestrate keyword highlighting", () => {
 		expect(Bun.stripANSI(decorated)).toBe("please orchestrate this");
 	});
 
+	it("decorates punctuation-adjacent prose while preserving visible text", () => {
+		const input = 'please "orchestrate," then continue';
+		const decorated = highlightOrchestrate(input);
+		expect(decorated).not.toBe(input);
+		expect(Bun.stripANSI(decorated)).toBe(input);
+	});
+
 	it("leaves text without the standalone keyword untouched", () => {
 		expect(highlightOrchestrate("nothing here")).toBe("nothing here");
-		// Probe hits the substring but the whitespace boundary fails — no decoration.
+		// Probe hits the substring but token/path boundaries fail — no decoration.
 		expect(highlightOrchestrate("orchestrated builds")).toBe("orchestrated builds");
 		expect(highlightOrchestrate("Orchestrate this")).toBe("Orchestrate this");
 		// The reported bug: a filename must not be painted.

--- a/packages/coding-agent/test/modes/workflow.test.ts
+++ b/packages/coding-agent/test/modes/workflow.test.ts
@@ -13,23 +13,28 @@ beforeAll(() => {
 });
 
 describe("workflow keyword detection", () => {
-	it("matches the lowercase trigger word delimited by whitespace", () => {
+	it("matches the lowercase trigger word delimited by whitespace or a string edge", () => {
 		expect(containsWorkflow("workflowz")).toBe(true);
 		expect(containsWorkflow("please workflowz this rollout")).toBe(true);
 		expect(containsWorkflow("design the workflowz")).toBe(true);
 		expect(containsWorkflow("run these workflowz")).toBe(true);
 	});
 
-	it("ignores old triggers, casing, inflections, punctuation-adjacent, and path-embedded forms", () => {
+	it("matches the lowercase trigger word beside prose punctuation and quotes", () => {
+		for (const text of ["do it. workflowz.", "please workflowz, then report", 'say "workflowz" now']) {
+			expect(containsWorkflow(text)).toBe(true);
+		}
+	});
+
+	it("ignores old triggers, casing, inflections, and path-embedded forms", () => {
 		expect(containsWorkflow("workflow")).toBe(false);
 		expect(containsWorkflow("workflows")).toBe(false);
 		expect(containsWorkflow("Workflowz")).toBe(false);
 		expect(containsWorkflow("WORKFLOWZ")).toBe(false);
 		expect(containsWorkflow("workflowzed the build")).toBe(false);
 		expect(containsWorkflow("reworkflowz everything")).toBe(false);
-		// A path/extension is not whitespace, so the word never triggers.
+		// A path/extension must not trigger even though sentence punctuation does.
 		expect(containsWorkflow("packages/coding-agent/test/modes/workflowz.test.ts")).toBe(false);
-		expect(containsWorkflow("do it. workflowz.")).toBe(false);
 		expect(containsWorkflow("nothing to see here")).toBe(false);
 	});
 });
@@ -43,8 +48,15 @@ describe("workflow keyword highlighting", () => {
 		expect(Bun.stripANSI(decorated)).toBe(input);
 	});
 
+	it("decorates punctuation-adjacent prose while preserving visible text", () => {
+		const input = 'please "workflowz," then continue';
+		const decorated = highlightWorkflow(input);
+		expect(decorated).not.toBe(input);
+		expect(Bun.stripANSI(decorated)).toBe(input);
+	});
+
 	it("leaves text without the standalone keyword untouched", () => {
-		// Probe hits the substring but the whitespace boundary fails — no decoration.
+		// Probe hits the substring but token/path boundaries fail — no decoration.
 		expect(highlightWorkflow("workflowzed builds")).toBe("workflowzed builds");
 		expect(highlightWorkflow("Workflowz this")).toBe("Workflowz this");
 		const filePath = "packages/coding-agent/test/modes/workflowz.test.ts";


### PR DESCRIPTION
## Repro
Imported `packages/coding-agent/src/modes/{ultrathink,orchestrate,workflow}.ts` and called the exported `contains*` helpers. Before the fix, `containsUltrathink("please ultrathink")` returned `true`, while `containsUltrathink("please ultrathink.")`, `containsUltrathink("\"ultrathink\"")`, `containsOrchestrate("please orchestrate,")`, and `containsWorkflow("please workflowz.")` all returned `false`.

## Cause
`packages/coding-agent/src/modes/ultrathink.ts`, `orchestrate.ts`, and `workflow.ts` all used `(?<!\S)<keyword>(?!\S)` for both detection and highlighting. That made whitespace or string edges the only valid boundaries, so normal prose punctuation and quotes adjacent to the keyword caused `keywordInProse` and the gradient highlighters to miss the standalone occurrence.

## Fix
- Added `packages/coding-agent/src/modes/magic-keyword-boundary.ts` to centralize the case-sensitive prose-boundary regex used by all three keyword families.
- Switched `ultrathink`, `orchestrate`, and `workflowz` detection/highlighting to accept punctuation and quotes while rejecting letters, digits, inflections, path separators, hyphens, and file-extension dots such as `ultrathink.ts`.
- Updated keyword detection/highlighting regression tests and the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/orchestrate.test.ts packages/coding-agent/test/modes/workflow.test.ts packages/coding-agent/test/modes/magic-keywords.test.ts` passed: 30 tests, 115 assertions. Manual JS eval after the fix returned `true` for `please ultrathink.`, `"ultrathink"`, `please orchestrate,`, and `please workflowz.`, and `false` for `ultrathinking`, `Ultrathink`, and `ultrathink.ts`. I also tried `bun test packages/coding-agent/test/agent-session-magic-keywords.test.ts`; it failed before tests started because `packages/coding-agent/src/export/html/index.ts` could not resolve generated `./tool-views.generated.js`. `gh_push_branch` completed the pre-publish gate (`bun run fix` and `bun check`) before pushing. Fixes #4965