### PR TITLE
fix(catalog): price GPT-5.6 and GLM-5.2 for stats

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for GPT-5.6 (Luna, Sol, Terra) model variants
 - Enabled expanded five-tier reasoning effort scale (minimal to xhigh) for GPT-5.6 models
 - Added GPT-5.6 (Terra/Luna/Sol) support for the new `max` reasoning tier: on wire-effort APIs (OpenAI Responses, Codex, Azure, openai-compat/OpenRouter models that advertise reasoning) user efforts shift up one notch — `xhigh` sends `max`, `high` sends `xhigh` — mirroring the Claude Fable/Opus 4.7+ five-tier mapping, and the exposed ladder becomes `minimal..xhigh` with `minimal` reaching the native `low` tier. Devin's per-tier GPT-5.6 sibling rows now collapse into `gpt-5-6-{luna,sol,terra}` logical models with the same shifted routing (`xhigh` → `-max`), plus `-fast` families that keep the direct `low..xhigh` `-priority` scale since Devin serves no `-max-priority` tier.
+
 ### Fixed
 
 - Fixed token pricing for OpenAI Codex GPT-5.6 Luna, Terra, and Sol and direct Z.AI GLM-5.2 so stats can calculate API costs.

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added support for GPT-5.6 (Luna, Sol, Terra) model variants
 - Enabled expanded five-tier reasoning effort scale (minimal to xhigh) for GPT-5.6 models
 - Added GPT-5.6 (Terra/Luna/Sol) support for the new `max` reasoning tier: on wire-effort APIs (OpenAI Responses, Codex, Azure, openai-compat/OpenRouter models that advertise reasoning) user efforts shift up one notch — `xhigh` sends `max`, `high` sends `xhigh` — mirroring the Claude Fable/Opus 4.7+ five-tier mapping, and the exposed ladder becomes `minimal..xhigh` with `minimal` reaching the native `low` tier. Devin's per-tier GPT-5.6 sibling rows now collapse into `gpt-5-6-{luna,sol,terra}` logical models with the same shifted routing (`xhigh` → `-max`), plus `-fast` families that keep the direct `low..xhigh` `-priority` scale since Devin serves no `-max-priority` tier.
+### Fixed
+
+- Fixed token pricing for OpenAI Codex GPT-5.6 Luna, Terra, and Sol and direct Z.AI GLM-5.2 so stats can calculate API costs.
 
 ## [16.3.13] - 2026-07-09
 

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -54,6 +54,12 @@ const CODEX_GPT_5_4_PRIORITY_BY_VARIANT: Partial<Record<OpenAIVariant, number>> 
 	nano: 2,
 };
 
+const CODEX_GPT_5_6_COST_BY_ID: Partial<Record<string, Readonly<ModelSpec<Api>["cost"]>>> = {
+	"gpt-5.6-sol": { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+	"gpt-5.6-terra": { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 3.125 },
+	"gpt-5.6-luna": { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 },
+};
+
 const COPILOT_GENERATED_LIMITS: Record<string, { contextWindow: number; maxTokens: number }> = {
 	"claude-opus-4.6": { contextWindow: 168000, maxTokens: 32000 },
 	"gpt-5.2": { contextWindow: 272000, maxTokens: 128000 },
@@ -218,6 +224,20 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 	if ((model.provider === "zai" || model.provider === "zhipu-coding-plan") && model.id === "glm-5.2") {
 		model.contextWindow = 1_000_000;
 		model.maxTokens = 131_072;
+		if (model.provider === "zai") {
+			model.cost.input = 1.4;
+			model.cost.output = 4.4;
+			model.cost.cacheRead = 0.26;
+			model.cost.cacheWrite = 0;
+		}
+	}
+
+	const codexGpt56Cost = model.provider === "openai-codex" ? CODEX_GPT_5_6_COST_BY_ID[model.id] : undefined;
+	if (codexGpt56Cost) {
+		model.cost.input = codexGpt56Cost.input;
+		model.cost.output = codexGpt56Cost.output;
+		model.cost.cacheRead = codexGpt56Cost.cacheRead;
+		model.cost.cacheWrite = codexGpt56Cost.cacheWrite;
 	}
 	// MiniMax-M3: 512K is the standard pricing tier boundary, not the
 	// model ceiling. Pin every long-context provider that serves the model

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -86009,9 +86009,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -353,4 +353,32 @@ describe("generated model policies", () => {
 		expect(models[2]?.applyPatchToolType).toBeUndefined();
 		expect(models[3]?.applyPatchToolType).toBeUndefined();
 	});
+	it("prices every openai-codex GPT-5.6 size id at its distinct full cost", () => {
+		// The id classifier collapses all three `gpt-5.6-*` ids to the same parsed
+		// variant ("base", version 5.6), so the policy must key off the id suffix
+		// to assign each size its own rate — not a single shared Sol price.
+		const models: ModelSpec<Api>[] = [
+			createSpec({ id: "gpt-5.6-sol", api: "openai-codex-responses", provider: "openai-codex" }),
+			createSpec({ id: "gpt-5.6-terra", api: "openai-codex-responses", provider: "openai-codex" }),
+			createSpec({ id: "gpt-5.6-luna", api: "openai-codex-responses", provider: "openai-codex" }),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.cost).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
+		expect(models[1]?.cost).toEqual({ input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 3.125 });
+		expect(models[2]?.cost).toEqual({ input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 });
+	});
+
+	it("prices direct zai glm-5.2 but leaves zhipu-coding-plan glm-5.2 at zero subscription pricing", () => {
+		const models: ModelSpec<Api>[] = [
+			createSpec({ id: "glm-5.2", api: "anthropic-messages", provider: "zai" }),
+			createSpec({ id: "glm-5.2", api: "openai-completions", provider: "zhipu-coding-plan" }),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.cost).toEqual({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 });
+		expect(models[1]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
 });

--- a/packages/stats/test/db-cost.test.ts
+++ b/packages/stats/test/db-cost.test.ts
@@ -65,12 +65,7 @@ const GLM_WORKED_COST = {
 	total: 0.003652,
 };
 
-function createPricedStats(
-	entryId: string,
-	provider: string,
-	model: string,
-	api: string,
-): MessageStats {
+function createPricedStats(entryId: string, provider: string, model: string, api: string): MessageStats {
 	return {
 		sessionFile: "/tmp/session.jsonl",
 		entryId,

--- a/packages/stats/test/db-cost.test.ts
+++ b/packages/stats/test/db-cost.test.ts
@@ -46,6 +46,105 @@ function expectedCodexGptCost() {
 	};
 }
 
+// Independent worked totals for usage {input:1000, output:500, cacheRead:200,
+// cacheWrite:100}, hand-derived from the per-1M-token rates in the pricing
+// contract — NOT read from the bundled catalog, so a wrong catalog price
+// reddens these assertions instead of echoing through.
+const SOL_WORKED_COST = {
+	input: 0.005, // 1000 * 5 / 1e6
+	output: 0.015, // 500 * 30 / 1e6
+	cacheRead: 0.0001, // 200 * 0.5 / 1e6
+	cacheWrite: 0.000625, // 100 * 6.25 / 1e6
+	total: 0.020725,
+};
+const GLM_WORKED_COST = {
+	input: 0.0014, // 1000 * 1.4 / 1e6
+	output: 0.0022, // 500 * 4.4 / 1e6
+	cacheRead: 0.000052, // 200 * 0.26 / 1e6
+	cacheWrite: 0, // 100 * 0 / 1e6 — zai direct bills no cache-write tokens
+	total: 0.003652,
+};
+
+function createPricedStats(
+	entryId: string,
+	provider: string,
+	model: string,
+	api: string,
+): MessageStats {
+	return {
+		sessionFile: "/tmp/session.jsonl",
+		entryId,
+		folder: "/tmp/project",
+		model,
+		provider,
+		api,
+		timestamp: Date.now(),
+		duration: 1000,
+		ttft: 100,
+		stopReason: "stop",
+		errorMessage: null,
+		usage: {
+			input: 1000,
+			output: 500,
+			cacheRead: 200,
+			cacheWrite: 100,
+			totalTokens: 1800,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		agentType: "main",
+	};
+}
+
+function insertRawZeroCostMessage(
+	database: Database,
+	fields: { entryId: string; model: string; provider: string; api: string },
+): void {
+	database
+		.prepare(`
+			INSERT INTO messages (
+				session_file, entry_id, folder, model, provider, api, timestamp,
+				duration, ttft, stop_reason, error_message,
+				input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens, premium_requests,
+				cost_input, cost_output, cost_cache_read, cost_cache_write, cost_total
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`)
+		.run(
+			"/tmp/session.jsonl",
+			fields.entryId,
+			"/tmp/project",
+			fields.model,
+			fields.provider,
+			fields.api,
+			Date.now(),
+			1000,
+			100,
+			"stop",
+			null,
+			1000,
+			500,
+			200,
+			100,
+			1800,
+			0,
+			0,
+			0,
+			0,
+			0,
+			0,
+		);
+}
+
+function expectCostCloseTo(
+	cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number } | undefined,
+	expected: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number },
+): void {
+	expect(cost?.input).toBeCloseTo(expected.input, 8);
+	expect(cost?.output).toBeCloseTo(expected.output, 8);
+	expect(cost?.cacheRead).toBeCloseTo(expected.cacheRead, 8);
+	expect(cost?.cacheWrite).toBeCloseTo(expected.cacheWrite, 8);
+	expect(cost?.total).toBeCloseTo(expected.total, 8);
+}
+
 describe("stats GPT cost correction", () => {
 	it("stores catalog-derived cost when OpenAI Codex session usage has zero cost", async () => {
 		await initDb();
@@ -105,5 +204,59 @@ describe("stats GPT cost correction", () => {
 
 		const request = getRecentRequests(1)[0];
 		expect(request?.usage.cost.total).toBeCloseTo(expectedCodexGptCost().total, 8);
+	});
+});
+
+describe("stats catalog-derived cost for GPT-5.6 Sol and GLM-5.2", () => {
+	it("stores GPT-5.6 Sol component costs on insert when session usage reports zero cost", async () => {
+		await initDb();
+
+		insertMessageStats([createPricedStats("sol-inserted", "openai-codex", "gpt-5.6-sol", "openai-codex-responses")]);
+
+		expectCostCloseTo(getRecentRequests(1)[0]?.usage.cost, SOL_WORKED_COST);
+	});
+
+	it("backfills historical zero-cost GPT-5.6 Sol rows on database init", async () => {
+		await initDb();
+		closeDb();
+
+		const database = new Database(getStatsDbPath());
+		insertRawZeroCostMessage(database, {
+			entryId: "sol-backfilled",
+			model: "gpt-5.6-sol",
+			provider: "openai-codex",
+			api: "openai-codex-responses",
+		});
+		database.close();
+
+		await initDb();
+
+		expectCostCloseTo(getRecentRequests(1)[0]?.usage.cost, SOL_WORKED_COST);
+	});
+
+	it("stores GLM-5.2 direct zai component costs on insert when session usage reports zero cost", async () => {
+		await initDb();
+
+		insertMessageStats([createPricedStats("glm-inserted", "zai", "glm-5.2", "anthropic-messages")]);
+
+		expectCostCloseTo(getRecentRequests(1)[0]?.usage.cost, GLM_WORKED_COST);
+	});
+
+	it("backfills historical zero-cost GLM-5.2 zai rows on database init", async () => {
+		await initDb();
+		closeDb();
+
+		const database = new Database(getStatsDbPath());
+		insertRawZeroCostMessage(database, {
+			entryId: "glm-backfilled",
+			model: "glm-5.2",
+			provider: "zai",
+			api: "anthropic-messages",
+		});
+		database.close();
+
+		await initDb();
+
+		expectCostCloseTo(getRecentRequests(1)[0]?.usage.cost, GLM_WORKED_COST);
 	});
 });


### PR DESCRIPTION
## What

- Add authoritative generated-catalog pricing policies for OpenAI Codex GPT-5.6 Luna, Terra, and Sol.
- Add direct Z.AI GLM-5.2 token pricing while leaving the Zhipu Coding Plan model unpriced.
- Cover catalog cost calculation plus stats insert and historical zero-cost backfill paths with regression tests.
- Document the user-facing stats correction in the catalog changelog.

| Model | Input | Output | Cache read | Cache write |
| --- | ---: | ---: | ---: | ---: |
| GPT-5.6 Sol | $5.00 | $30.00 | $0.50 | $6.25 |
| GPT-5.6 Terra | $2.50 | $15.00 | $0.25 | $3.125 |
| GPT-5.6 Luna | $1.00 | $6.00 | $0.10 | $1.25 |
| Z.AI GLM-5.2 | $1.40 | $4.40 | $0.26 | $0.00 |

Prices are per million tokens.

## Why

`omp stats` recalculates missing stored costs from the bundled model catalog, but these catalog entries lacked usable pricing metadata. As a result, GPT-5.6 and direct Z.AI GLM-5.2 usage retained exact zero API cost despite nonzero token usage.

Scoping the rates to exact provider/model pairs lets both newly inserted rows and historical zero-cost rows use the existing stats cost/backfill path without treating subscription-based Zhipu Coding Plan usage as token-billed API usage.

## Testing

- `bun --cwd=packages/catalog test test/generated-policies.test.ts` — 14 passed, 0 failed
- `bun --cwd=packages/stats test test/db-cost.test.ts` — 6 passed, 0 failed
- `bun check` — passed

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)