### PR TITLE
fix(cursor): send max-mode flags

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor max-mode model requests to send the required max_mode flags in both Cursor proto fields. ([#4969](https://github.com/can1357/oh-my-pi/issues/4969))
+
 ## [16.3.14] - 2026-07-09
 
 ### Changed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -76,6 +76,7 @@ import {
 	RequestContextResultSchema,
 	RequestContextSchema,
 	RequestContextSuccessSchema,
+	RequestedModelSchema,
 	ResumeActionSchema,
 	SelectedContextSchema,
 	SelectedImageSchema,
@@ -2797,16 +2798,19 @@ function buildGrpcRequest(
 		turns,
 	});
 
+	const maxMode = model.maxMode ?? false;
 	const modelDetails = create(ModelDetailsSchema, {
 		modelId: model.id,
 		displayModelId: model.id,
 		displayName: model.name,
+		maxMode,
 	});
 
 	const runRequest = create(AgentRunRequestSchema, {
 		conversationState,
 		action,
 		modelDetails,
+		requestedModel: create(RequestedModelSchema, { modelId: model.id, maxMode }),
 		conversationId: state.conversationId,
 	});
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2798,10 +2798,11 @@ function buildGrpcRequest(
 		turns,
 	});
 
+	const wireModelId = model.requestModelId ?? model.id;
 	const maxMode = model.maxMode ?? false;
 	const modelDetails = create(ModelDetailsSchema, {
-		modelId: model.id,
-		displayModelId: model.id,
+		modelId: wireModelId,
+		displayModelId: wireModelId,
 		displayName: model.name,
 		maxMode,
 	});
@@ -2810,7 +2811,7 @@ function buildGrpcRequest(
 		conversationState,
 		action,
 		modelDetails,
-		requestedModel: create(RequestedModelSchema, { modelId: model.id, maxMode }),
+		requestedModel: create(RequestedModelSchema, { modelId: wireModelId, maxMode }),
 		conversationId: state.conversationId,
 	});
 

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -208,9 +208,10 @@ describe("Cursor request action encoding", () => {
 		expect(Array.from(selectedImage.dataOrBlobId.value)).toEqual(Array.from(Buffer.from(imageData, "base64")));
 	});
 
-	it("serializes max-mode models in both Cursor model fields", async () => {
+	it("serializes max-mode wire model ids in both Cursor model fields", async () => {
 		const maxModeModel: Model<"cursor-agent"> = buildModel({
-			id: "cursor-claude-4.5-opus-high-max",
+			id: "local-cursor-claude-4.5-opus-high-max",
+			requestModelId: "cursor-claude-4.5-opus-high-max",
 			name: "Cursor Claude 4.5 Opus Max",
 			api: "cursor-agent",
 			provider: "cursor",
@@ -229,8 +230,10 @@ describe("Cursor request action encoding", () => {
 			maxModeModel,
 		);
 
+		expect(payload.modelDetails?.modelId).toBe(maxModeModel.requestModelId);
+		expect(payload.modelDetails?.displayModelId).toBe(maxModeModel.requestModelId);
 		expect(payload.modelDetails?.maxMode).toBe(true);
-		expect(payload.requestedModel?.modelId).toBe(maxModeModel.id);
+		expect(payload.requestedModel?.modelId).toBe(maxModeModel.requestModelId);
 		expect(payload.requestedModel?.maxMode).toBe(true);
 	});
 });

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -34,9 +34,9 @@ const cursorModel: Model<"cursor-agent"> = buildModel({
 	maxTokens: 1,
 });
 
-function captureCursorPayload(context: Context): Promise<AgentRunRequest> {
+function captureCursorPayload(context: Context, model: Model<"cursor-agent"> = cursorModel): Promise<AgentRunRequest> {
 	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
-	streamCursor(cursorModel, context, {
+	streamCursor(model, context, {
 		apiKey: "test-token",
 		onPayload: payload => {
 			if (isAgentRunRequest(payload)) {
@@ -206,6 +206,32 @@ describe("Cursor request action encoding", () => {
 			throw new Error("Expected Cursor selected image data");
 		}
 		expect(Array.from(selectedImage.dataOrBlobId.value)).toEqual(Array.from(Buffer.from(imageData, "base64")));
+	});
+
+	it("serializes max-mode models in both Cursor model fields", async () => {
+		const maxModeModel: Model<"cursor-agent"> = buildModel({
+			id: "cursor-claude-4.5-opus-high-max",
+			name: "Cursor Claude 4.5 Opus Max",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1,
+			maxTokens: 1,
+			maxMode: true,
+		});
+		const payload = await captureCursorPayload(
+			{
+				messages: [{ role: "user", content: "continue", timestamp: 0 }],
+			},
+			maxModeModel,
+		);
+
+		expect(payload.modelDetails?.maxMode).toBe(true);
+		expect(payload.requestedModel?.modelId).toBe(maxModeModel.id);
+		expect(payload.requestedModel?.maxMode).toBe(true);
 	});
 });
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor model discovery and bundled fallbacks to preserve max-mode metadata for max-mode-only models. ([#4969](https://github.com/can1357/oh-my-pi/issues/4969))
+
 ## [16.3.14] - 2026-07-09
 
 ### Added

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -61,6 +61,7 @@ const COPILOT_GENERATED_LIMITS: Record<string, { contextWindow: number; maxToken
 	"gpt-5.4-mini": { contextWindow: 272000, maxTokens: 128000 },
 	"grok-code-fast-1": { contextWindow: 192000, maxTokens: 64000 },
 };
+const CURSOR_MAX_MODE_FALLBACK_PATTERNS = [/-max(?:-|$)/i, /-xhigh(?:-|$)/i, /-extra-high(?:-|$)/i, /^gpt-5\.[45]-/i];
 
 /**
  * Apply upstream metadata corrections to a mutable array of models, then
@@ -70,6 +71,7 @@ const COPILOT_GENERATED_LIMITS: Record<string, { contextWindow: number; maxToken
 export function applyGeneratedModelPolicies(models: ModelSpec<Api>[]): void {
 	for (const model of models) {
 		applyGeneratedModelPolicy(model);
+		applyCursorMaxModeFallback(model);
 		rebakeModelThinking(model);
 	}
 }
@@ -199,6 +201,15 @@ export function applyCanonicalLimitFallback(models: ModelSpec<Api>[]): void {
 				break;
 			}
 		}
+	}
+}
+
+function applyCursorMaxModeFallback(model: ModelSpec<Api>): void {
+	if (model.provider !== "cursor" || model.maxMode !== undefined) {
+		return;
+	}
+	if (CURSOR_MAX_MODE_FALLBACK_PATTERNS.some(pattern => pattern.test(model.id))) {
+		model.maxMode = true;
 	}
 }
 

--- a/packages/catalog/src/discovery/cursor.ts
+++ b/packages/catalog/src/discovery/cursor.ts
@@ -21,6 +21,7 @@ const DEFAULT_MAX_TOKENS = 64_000;
 const CURSOR_MULTIMODAL_ID_PATTERN = /claude|gemini|gpt-|codex/;
 
 const OptionalDisplayNameSchema = type("unknown").pipe(raw => (typeof raw === "string" ? raw : undefined));
+const CursorMaxModeSchema = type("unknown").pipe(raw => (typeof raw === "boolean" ? raw : undefined));
 const CursorAliasesSchema = type("unknown").pipe(raw => {
 	if (Array.isArray(raw)) {
 		return raw.filter((alias: unknown): alias is string => typeof alias === "string");
@@ -34,6 +35,7 @@ const CursorModelDetailsSchema = type({
 	displayNameShort: OptionalDisplayNameSchema.default(undefined),
 	displayModelId: OptionalDisplayNameSchema.default(undefined),
 	aliases: CursorAliasesSchema.default(() => []),
+	maxMode: CursorMaxModeSchema.default(undefined),
 	"thinkingDetails?": "unknown",
 });
 
@@ -282,6 +284,7 @@ function normalizeCursorModel(
 	const name = pickModelDisplayName(details, id);
 	const reference = references.get(id);
 	const reasoning = Boolean(details.thinkingDetails) || reference?.reasoning === true;
+	const maxMode = details.maxMode ?? reference?.maxMode;
 
 	if (reference) {
 		return {
@@ -290,6 +293,7 @@ function normalizeCursorModel(
 			name,
 			baseUrl: baseUrlOverride ?? reference.baseUrl,
 			reasoning,
+			...(maxMode !== undefined ? { maxMode } : {}),
 		};
 	}
 	return {
@@ -299,6 +303,7 @@ function normalizeCursorModel(
 		provider: "cursor",
 		baseUrl: baseUrlOverride ?? CURSOR_DEFAULT_BASE_URL,
 		reasoning,
+		...(maxMode !== undefined ? { maxMode } : {}),
 		input: inferInputFromCursorId(id),
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: DEFAULT_CONTEXT_WINDOW,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -15354,7 +15354,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"maxMode": true
 		},
 		"gpt-5.1-codex-max-high": {
 			"id": "gpt-5.1-codex-max-high",
@@ -15383,7 +15384,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"maxMode": true
 		},
 		"gpt-5.1-codex-mini": {
 			"id": "gpt-5.1-codex-mini",
@@ -15601,7 +15603,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.2-codex-xhigh-fast": {
 			"id": "gpt-5.2-codex-xhigh-fast",
@@ -15620,7 +15623,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.2-high": {
 			"id": "gpt-5.2-high",
@@ -15811,7 +15815,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.3-codex-xhigh-fast": {
 			"id": "gpt-5.3-codex-xhigh-fast",
@@ -15830,7 +15835,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.4-high": {
 			"id": "gpt-5.4-high",
@@ -15849,7 +15855,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.4-high-fast": {
 			"id": "gpt-5.4-high-fast",
@@ -15868,7 +15875,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.4-low": {
 			"id": "gpt-5.4-low",
@@ -15887,7 +15895,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.4-medium": {
 			"id": "gpt-5.4-medium",
@@ -15906,7 +15915,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.4-medium-fast": {
 			"id": "gpt-5.4-medium-fast",
@@ -15925,7 +15935,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.4-xhigh": {
 			"id": "gpt-5.4-xhigh",
@@ -15944,7 +15955,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"gpt-5.4-xhigh-fast": {
 			"id": "gpt-5.4-xhigh-fast",
@@ -15963,7 +15975,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"maxMode": true
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -60096,6 +60109,44 @@
 			},
 			"contextPromotionTarget": "openai/gpt-5.4"
 		},
+		"gpt-5.6": {
+			"id": "gpt-5.6",
+			"name": "GPT-5.6",
+			"api": "openai-responses",
+			"provider": "openai",
+			"baseUrl": "https://api.openai.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"applyPatchToolType": "freeform",
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				}
+			}
+		},
 		"gpt-5.6-luna": {
 			"id": "gpt-5.6-luna",
 			"name": "GPT-5.6 Luna",
@@ -64155,7 +64206,7 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -67983,8 +68034,8 @@
 			],
 			"cost": {
 				"input": 0.72,
-				"output": 3.5,
-				"cacheRead": 0.15,
+				"output": 3.49,
+				"cacheRead": 0.159,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -69547,7 +69598,7 @@
 				"input": 1,
 				"output": 6,
 				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 0
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -69584,7 +69635,7 @@
 				"input": 1,
 				"output": 6,
 				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 0
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -69621,7 +69672,7 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -69658,7 +69709,7 @@
 				"input": 5,
 				"output": 30,
 				"cacheRead": 0.5,
-				"cacheWrite": 0
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -69695,7 +69746,7 @@
 				"input": 2.5,
 				"output": 15,
 				"cacheRead": 0.25,
-				"cacheWrite": 0
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -69732,7 +69783,7 @@
 				"input": 2.5,
 				"output": 15,
 				"cacheRead": 0.25,
-				"cacheWrite": 0
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -73580,7 +73631,7 @@
 	"synthetic": {
 		"hf:MiniMaxAI/MiniMax-M3": {
 			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73595,7 +73646,7 @@
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -73610,7 +73661,7 @@
 		},
 		"hf:moonshotai/Kimi-K2.7-Code": {
 			"id": "hf:moonshotai/Kimi-K2.7-Code",
-			"name": "moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73640,7 +73691,7 @@
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73669,7 +73720,7 @@
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73696,7 +73747,7 @@
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73725,7 +73776,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -73754,7 +73805,7 @@
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -77243,6 +77294,138 @@
 				]
 			}
 		},
+		"openai-gpt-56-luna": {
+			"id": "openai-gpt-56-luna",
+			"name": "openai-gpt-56-luna",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"openai-gpt-56-luna-pro": {
+			"id": "openai-gpt-56-luna-pro",
+			"name": "openai-gpt-56-luna-pro",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"openai-gpt-56-sol": {
+			"id": "openai-gpt-56-sol",
+			"name": "openai-gpt-56-sol",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"openai-gpt-56-sol-pro": {
+			"id": "openai-gpt-56-sol-pro",
+			"name": "openai-gpt-56-sol-pro",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"openai-gpt-56-terra": {
+			"id": "openai-gpt-56-terra",
+			"name": "openai-gpt-56-terra",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"openai-gpt-56-terra-pro": {
+			"id": "openai-gpt-56-terra-pro",
+			"name": "openai-gpt-56-terra-pro",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": null,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"openai-gpt-oss-120b": {
 			"id": "openai-gpt-oss-120b",
 			"name": "OpenAI GPT OSS 120B",
@@ -80351,6 +80534,35 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192
+		},
+		"meta/muse-spark-1.1": {
+			"id": "meta/muse-spark-1.1",
+			"name": "Muse Spark 1.1",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"minimax/minimax-m2": {
 			"id": "minimax/minimax-m2",
@@ -84936,6 +85148,14 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -84948,14 +85168,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-4.3": {
@@ -84977,6 +85189,14 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -84989,14 +85209,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-build": {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -709,6 +709,8 @@ export interface Model<TApi extends Api = Api> {
 	 * reports that native tool calling is unsupported.
 	 */
 	supportsTools?: boolean;
+	/** Cursor max-mode routing flag reported by Cursor discovery for premium variants. */
+	maxMode?: boolean;
 	/** GitLab Duo Workflow root namespace selected during catalog discovery. */
 	gitlabDuoWorkflowRootNamespaceId?: string;
 	cost: {

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -7,18 +7,18 @@ import { fetchCursorUsableModels } from "../src/discovery/cursor";
 import { GetUsableModelsResponseSchema, ModelDetailsSchema } from "../src/discovery/cursor-gen/agent_pb";
 import type { ModelSpec } from "../src/types";
 
-const FIXTURE_MODEL_IDS = [
+const FIXTURE_MODELS: { modelId: string; maxMode?: boolean }[] = [
 	// Reference-less ids from families whose native catalogs are multimodal.
-	"claude-opus-4-8-99999999",
-	"gpt-5.5-codex-20991231",
-	"gemini-4-pro-exp",
+	{ modelId: "claude-opus-4-8-99999999", maxMode: true },
+	{ modelId: "gpt-5.5-codex-20991231" },
+	{ modelId: "gemini-4-pro-exp" },
 	// Reference-less ids from text-only families.
-	"composer-3",
-	"grok-code-fast-2",
+	{ modelId: "composer-3", maxMode: false },
+	{ modelId: "grok-code-fast-2" },
 	// Bundled-reference ids: the reference stays authoritative.
-	"claude-4.5-opus-high",
-	"claude-4.6-opus-high",
-	"composer-1",
+	{ modelId: "claude-4.5-opus-high", maxMode: true },
+	{ modelId: "claude-4.6-opus-high" },
+	{ modelId: "composer-1", maxMode: false },
 ];
 
 let server: http2.Http2Server;
@@ -26,7 +26,7 @@ let baseUrl: string;
 
 beforeAll(async () => {
 	const response = create(GetUsableModelsResponseSchema, {
-		models: FIXTURE_MODEL_IDS.map(modelId => create(ModelDetailsSchema, { modelId })),
+		models: FIXTURE_MODELS.map(details => create(ModelDetailsSchema, details)),
 	});
 	const payload = Buffer.from(toBinary(GetUsableModelsResponseSchema, response));
 
@@ -82,6 +82,14 @@ describe("cursor discovery input modalities (issue #4726)", () => {
 		expect(byId.get("claude-4.5-opus-high")?.input).toEqual(["text", "image"]);
 		expect(byId.get("claude-4.6-opus-high")?.input).toEqual(["text"]);
 		expect(byId.get("composer-1")?.input).toEqual(["text"]);
+	});
+
+	it("preserves Cursor max-mode flags from discovery metadata", async () => {
+		const byId = await discover();
+		expect(byId.get("claude-opus-4-8-99999999")?.maxMode).toBe(true);
+		expect(byId.get("claude-4.5-opus-high")?.maxMode).toBe(true);
+		expect(byId.get("composer-3")?.maxMode).toBe(false);
+		expect(byId.get("composer-1")?.maxMode).toBe(false);
 	});
 
 	it("preserves fallback defaults for reference-less models", async () => {


### PR DESCRIPTION
## Repro
A proto-level capture of `streamCursor` with a `cursor-agent` model carrying `maxMode: true` produced an `AgentRunRequest` with no `requestedModel` and no `modelDetails.maxMode`; the captured payload printed `{ "hasRequestedModel": false }` and the assertion for both max-mode proto fields failed.

## Cause
`packages/catalog/src/discovery/cursor.ts` parsed Cursor `GetUsableModels` responses without the `ModelDetails.maxMode` field, so `ModelSpec` entries never carried Cursor's authoritative max-mode metadata. `packages/ai/src/providers/cursor.ts` then built `ModelDetails` without `maxMode` and omitted `AgentRunRequest.requestedModel`, leaving Cursor's server to receive max-mode model ids with `max_mode=false`.

## Fix
- Added `Model.maxMode` metadata and preserved Cursor discovery `maxMode` on both reference-backed and reference-less model specs.
- Added generated-catalog fallback policy for Cursor max-mode-shaped ids and regenerated `packages/catalog/src/models.json`.
- Serialized `maxMode` into both Cursor proto locations: `ModelDetails.maxMode` and `RequestedModel.maxMode`.
- Added regression tests for Cursor discovery max-mode metadata and Cursor request payload encoding.
- Updated affected package changelogs.

## Verification
Reproduced before the fix with a proto-level `streamCursor` payload capture. After the fix, the same capture printed `modelDetailsMaxMode: true` and `requestedModelMaxMode: true`. Ran `bun test packages/catalog/test/cursor-discovery.test.ts packages/ai/test/cursor-exec-handlers.test.ts` → 24 pass, 0 fail. Ran `bun check` → passed. Fixes #4969