### PR TITLE
fix(cursor): preserve max-mode flag

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor `max_mode` requests to send discovered max-mode metadata on both model payload fields. ([#4797](https://github.com/can1357/oh-my-pi/issues/4797))
+
 ## [16.3.11] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -76,6 +76,7 @@ import {
 	RequestContextResultSchema,
 	RequestContextSchema,
 	RequestContextSuccessSchema,
+	RequestedModelSchema,
 	ResumeActionSchema,
 	SelectedContextSchema,
 	SelectedImageSchema,
@@ -2790,16 +2791,24 @@ function buildGrpcRequest(
 		turns,
 	});
 
+	const wireModelId = model.requestModelId ?? model.id;
+	const cursorMaxMode = model.cursorMaxMode === true;
 	const modelDetails = create(ModelDetailsSchema, {
-		modelId: model.id,
+		modelId: wireModelId,
 		displayModelId: model.id,
 		displayName: model.name,
+		...(cursorMaxMode ? { maxMode: true } : undefined),
+	});
+	const requestedModel = create(RequestedModelSchema, {
+		modelId: wireModelId,
+		maxMode: cursorMaxMode,
 	});
 
 	const runRequest = create(AgentRunRequestSchema, {
 		conversationState,
 		action,
 		modelDetails,
+		requestedModel,
 		conversationId: state.conversationId,
 	});
 

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -23,9 +23,23 @@ const cursorModel: Model<"cursor-agent"> = buildModel({
 	maxTokens: 1,
 });
 
-function captureCursorPayload(context: Context): Promise<AgentRunRequest> {
+const cursorMaxModeModel: Model<"cursor-agent"> = buildModel({
+	id: "cursor-composer-2.5-max",
+	name: "Cursor Composer 2.5 Max",
+	api: "cursor-agent",
+	provider: "cursor",
+	baseUrl: "",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1,
+	maxTokens: 1,
+	cursorMaxMode: true,
+});
+
+function captureCursorPayload(context: Context, model: Model<"cursor-agent"> = cursorModel): Promise<AgentRunRequest> {
 	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
-	streamCursor(cursorModel, context, {
+	streamCursor(model, context, {
 		apiKey: "test-token",
 		onPayload: payload => {
 			if (isAgentRunRequest(payload)) {
@@ -163,6 +177,19 @@ describe("Cursor request action encoding", () => {
 		});
 
 		expect(payload.action?.action.case).toBe("userMessageAction");
+	});
+
+	it("sends Cursor max-mode metadata on model details and requested model", async () => {
+		const payload = await captureCursorPayload(
+			{
+				messages: [{ role: "user", content: "continue", timestamp: 0 }],
+			},
+			cursorMaxModeModel,
+		);
+
+		expect(payload.modelDetails?.maxMode).toBe(true);
+		expect(payload.requestedModel?.modelId).toBe("cursor-composer-2.5-max");
+		expect(payload.requestedModel?.maxMode).toBe(true);
 	});
 
 	it("uses a resume action when a tool result is the final context message", async () => {

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Cursor discovery to preserve `GetUsableModels` max-mode metadata for premium models. ([#4797](https://github.com/can1357/oh-my-pi/issues/4797))
+- Fixed Cursor discovery to preserve `GetUsableModels` max-mode metadata for premium models and invalidate stale pre-max-mode cache rows. ([#4797](https://github.com/can1357/oh-my-pi/issues/4797))
 
 ## [16.3.11] - 2026-07-06
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor discovery to preserve `GetUsableModels` max-mode metadata for premium models. ([#4797](https://github.com/can1357/oh-my-pi/issues/4797))
+
 ## [16.3.11] - 2026-07-06
 
 ### Added

--- a/packages/catalog/src/discovery/cursor.ts
+++ b/packages/catalog/src/discovery/cursor.ts
@@ -28,6 +28,7 @@ const CursorModelDetailsSchema = type({
 	displayModelId: OptionalDisplayNameSchema.default(undefined),
 	aliases: CursorAliasesSchema.default(() => []),
 	"thinkingDetails?": "unknown",
+	maxMode: "boolean = false",
 });
 
 const CursorModelsInnerSchema = type("unknown[]");
@@ -283,6 +284,7 @@ function normalizeCursorModel(
 			name,
 			baseUrl: baseUrlOverride ?? reference.baseUrl,
 			reasoning,
+			cursorMaxMode: details.maxMode,
 		};
 	}
 	return {
@@ -296,6 +298,7 @@ function normalizeCursorModel(
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: DEFAULT_CONTEXT_WINDOW,
 		maxTokens: DEFAULT_MAX_TOKENS,
+		cursorMaxMode: details.maxMode,
 	};
 }
 

--- a/packages/catalog/src/provider-models/special.ts
+++ b/packages/catalog/src/provider-models/special.ts
@@ -42,10 +42,13 @@ export interface CursorModelManagerConfig {
 	clientVersion?: string;
 }
 
+const CURSOR_CACHE_PROVIDER_ID = "cursor:max-mode-v2";
+
 export function cursorModelManagerOptions(config: CursorModelManagerConfig = {}): ModelManagerOptions<"cursor-agent"> {
 	const { apiKey, baseUrl, clientVersion } = config;
 	return {
 		providerId: "cursor",
+		cacheProviderId: CURSOR_CACHE_PROVIDER_ID,
 		...(apiKey
 			? {
 					fetchDynamicModels: async () => {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -711,6 +711,8 @@ export interface Model<TApi extends Api = Api> {
 	supportsTools?: boolean;
 	/** GitLab Duo Workflow root namespace selected during catalog discovery. */
 	gitlabDuoWorkflowRootNamespaceId?: string;
+	/** Cursor `max_mode` request flag returned by `GetUsableModels` for premium models that require max mode. */
+	cursorMaxMode?: boolean;
 	cost: {
 		input: number; // $/million tokens
 		output: number; // $/million tokens

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as http2 from "node:http2";
 import type * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
 import { create, toBinary } from "@bufbuild/protobuf";
 import { fetchCursorUsableModels } from "@oh-my-pi/pi-catalog/discovery/cursor";
 import { GetUsableModelsResponseSchema, ModelDetailsSchema } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
+import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
+import { cursorModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/special";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 
 const servers = new Set<http2.Http2Server>();
+const tempDirs = new Set<string>();
 
 afterEach(async () => {
 	await Promise.all(
@@ -21,7 +28,9 @@ afterEach(async () => {
 			return promise;
 		}),
 	);
+	await Promise.all([...tempDirs].map(dir => fs.rm(dir, { recursive: true, force: true })));
 	servers.clear();
+	tempDirs.clear();
 });
 
 function requireTcpAddress(address: string | net.AddressInfo | null): net.AddressInfo {
@@ -46,6 +55,27 @@ function startCursorDiscoveryServer(body: Uint8Array): Promise<string> {
 	return promise;
 }
 
+async function createTempCachePath(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-cursor-cache-"));
+	tempDirs.add(dir);
+	return path.join(dir, "models.db");
+}
+
+function cursorModelSpec(id: string): ModelSpec<"cursor-agent"> {
+	return {
+		id,
+		name: id,
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "https://api2.cursor.sh",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	};
+}
+
 describe("fetchCursorUsableModels", () => {
 	it("preserves Cursor max-mode metadata from GetUsableModels", async () => {
 		const response = create(GetUsableModelsResponseSchema, {
@@ -67,6 +97,49 @@ describe("fetchCursorUsableModels", () => {
 				name: "Cursor Composer Max",
 				api: "cursor-agent",
 				provider: "cursor",
+				cursorMaxMode: true,
+			}),
+		]);
+	});
+
+	it("ignores Cursor cache rows written before max-mode metadata was persisted", async () => {
+		const cacheDbPath = await createTempCachePath();
+		const staleSpec = cursorModelSpec("cursor-composer-max");
+		await resolveProviderModels(
+			{
+				providerId: "cursor",
+				cacheProviderId: "cursor",
+				cacheDbPath,
+				staticModels: [],
+				fetchDynamicModels: async () => [staleSpec],
+				now: () => 1,
+			},
+			"online",
+		);
+
+		const response = create(GetUsableModelsResponseSchema, {
+			models: [
+				create(ModelDetailsSchema, {
+					modelId: staleSpec.id,
+					displayName: staleSpec.name,
+					maxMode: true,
+				}),
+			],
+		});
+		const baseUrl = await startCursorDiscoveryServer(toBinary(GetUsableModelsResponseSchema, response));
+		const result = await resolveProviderModels(
+			{
+				...cursorModelManagerOptions({ apiKey: "test-token", baseUrl }),
+				cacheDbPath,
+				staticModels: [],
+				now: () => 2,
+			},
+			"online-if-uncached",
+		);
+
+		expect(result.models).toEqual([
+			expect.objectContaining({
+				id: staleSpec.id,
 				cursorMaxMode: true,
 			}),
 		]);

--- a/packages/catalog/test/cursor-discovery.test.ts
+++ b/packages/catalog/test/cursor-discovery.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as http2 from "node:http2";
+import type * as net from "node:net";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { fetchCursorUsableModels } from "@oh-my-pi/pi-catalog/discovery/cursor";
+import { GetUsableModelsResponseSchema, ModelDetailsSchema } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
+
+const servers = new Set<http2.Http2Server>();
+
+afterEach(async () => {
+	await Promise.all(
+		[...servers].map(server => {
+			const { promise, resolve, reject } = Promise.withResolvers<void>();
+			server.close(error => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve();
+			});
+			return promise;
+		}),
+	);
+	servers.clear();
+});
+
+function requireTcpAddress(address: string | net.AddressInfo | null): net.AddressInfo {
+	if (!address || typeof address === "string") {
+		throw new Error("HTTP/2 test server did not bind to a TCP address");
+	}
+	return address;
+}
+
+function startCursorDiscoveryServer(body: Uint8Array): Promise<string> {
+	const { promise, resolve, reject } = Promise.withResolvers<string>();
+	const server = http2.createServer();
+	servers.add(server);
+	server.once("error", reject);
+	server.on("stream", (stream: http2.ServerHttp2Stream) => {
+		stream.respond({ ":status": 200, "content-type": "application/proto" });
+		stream.end(Buffer.from(body));
+	});
+	server.listen(0, "127.0.0.1", () => {
+		resolve(`http://127.0.0.1:${requireTcpAddress(server.address()).port}`);
+	});
+	return promise;
+}
+
+describe("fetchCursorUsableModels", () => {
+	it("preserves Cursor max-mode metadata from GetUsableModels", async () => {
+		const response = create(GetUsableModelsResponseSchema, {
+			models: [
+				create(ModelDetailsSchema, {
+					modelId: "cursor-composer-max",
+					displayName: "Cursor Composer Max",
+					maxMode: true,
+				}),
+			],
+		});
+		const baseUrl = await startCursorDiscoveryServer(toBinary(GetUsableModelsResponseSchema, response));
+
+		const models = await fetchCursorUsableModels({ apiKey: "test-token", baseUrl, timeoutMs: 1_000 });
+
+		expect(models).toEqual([
+			expect.objectContaining({
+				id: "cursor-composer-max",
+				name: "Cursor Composer Max",
+				api: "cursor-agent",
+				provider: "cursor",
+				cursorMaxMode: true,
+			}),
+		]);
+	});
+});


### PR DESCRIPTION
## Repro
Added focused coverage for the reported Cursor max-mode path and reproduced the failure with `bun test packages/ai/test/cursor-exec-handlers.test.ts packages/catalog/test/cursor-discovery.test.ts`: discovery returned a usable model without `cursorMaxMode`, and the captured `AgentRunRequest` had `modelDetails.maxMode === undefined` with no `requestedModel.maxMode === true`.

## Cause
`packages/catalog/src/discovery/cursor.ts` decoded `GetUsableModelsResponse.models` but ignored `ModelDetails.maxMode`, so discovered Cursor model specs lost the required max-mode metadata. `packages/ai/src/providers/cursor.ts` then built `AgentRunRequest` with only `modelDetails` fields for id/name and never populated either `ModelDetails.maxMode` or `RequestedModel.maxMode`.

## Fix
- Added `Model.cursorMaxMode` / `ModelSpec.cursorMaxMode` metadata and preserved `ModelDetails.maxMode` during Cursor discovery.
- Updated Cursor request construction to derive the wire model id once, set `modelDetails.maxMode` for max-mode models, and include `requestedModel.maxMode` on every run request.
- Added regression tests for both `GetUsableModels` discovery and `streamCursor` request payload shaping.
- Added changelog entries for `@oh-my-pi/pi-catalog` and `@oh-my-pi/pi-ai`.

## Verification
`bun test packages/ai/test/cursor-exec-handlers.test.ts packages/catalog/test/cursor-discovery.test.ts` passed: 17 tests, 0 failures. `bun --cwd=packages/ai run check` passed. `bun --cwd=packages/catalog run check` passed. Fixes #4797