### PR TITLE
fix(session): skip snapcompact frames in collapsed transcripts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed collapsed compacted session transcript rebuilds reattaching snapcompact archive image frames to the live TUI, avoiding large retained JSC heaps on resume and transcript refresh. ([#4979](https://github.com/can1357/oh-my-pi/issues/4979))
+
 ## [16.3.14] - 2026-07-09
 
 ### Fixed

--- a/packages/coding-agent/src/session/session-context.test.ts
+++ b/packages/coding-agent/src/session/session-context.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import * as snapcompact from "@oh-my-pi/snapcompact";
+import type { CompactionSummaryMessage } from "./messages";
+import { buildSessionContext } from "./session-context";
+import type { SessionEntry } from "./session-entries";
+
+const timestamp = "2026-07-09T00:00:00.000Z";
+
+const compactedEntries = [
+	{
+		type: "message",
+		id: "m1",
+		parentId: null,
+		timestamp,
+		message: { role: "user", content: [{ type: "text", text: "before compaction" }], timestamp: 1 },
+	},
+	{
+		type: "compaction",
+		id: "c1",
+		parentId: "m1",
+		timestamp,
+		summary: "summary",
+		firstKeptEntryId: "m1",
+		tokensBefore: 123,
+		preserveData: {
+			[snapcompact.PRESERVE_KEY]: {
+				frames: [{ data: "base64-frame", mimeType: "image/png", cols: 10, rows: 10, chars: 100 }],
+				totalChars: 100,
+				truncatedChars: 0,
+				textHead: "head",
+				textTail: "tail",
+			},
+		},
+	},
+	{
+		type: "message",
+		id: "m2",
+		parentId: "c1",
+		timestamp,
+		message: { role: "user", content: [{ type: "text", text: "after compaction" }], timestamp: 2 },
+	},
+] satisfies SessionEntry[];
+
+function compactionSummary(messages: AgentMessage[]): CompactionSummaryMessage {
+	const summary = messages.find(
+		(message): message is CompactionSummaryMessage => message.role === "compactionSummary",
+	);
+	if (!summary) throw new Error("Expected a compaction summary message");
+	return summary;
+}
+
+describe("buildSessionContext snapcompact archives", () => {
+	it("omits snapcompact archive blocks from collapsed transcript summaries", () => {
+		const context = buildSessionContext(compactedEntries, undefined, undefined, {
+			transcript: true,
+			collapseCompactedHistory: true,
+		});
+
+		const summary = compactionSummary(context.messages);
+
+		expect(summary.images).toBeUndefined();
+		expect(summary.blocks).toBeUndefined();
+	});
+
+	it("keeps snapcompact archive blocks in full transcript summaries", () => {
+		const context = buildSessionContext(compactedEntries, undefined, undefined, { transcript: true });
+
+		const summary = compactionSummary(context.messages);
+
+		expect(summary.images?.map(image => image.data)).toEqual(["base64-frame"]);
+		expect(summary.blocks?.map(block => block.type)).toEqual(["text", "image", "text"]);
+	});
+
+	it("keeps snapcompact archive blocks in provider context summaries", () => {
+		const context = buildSessionContext(compactedEntries);
+
+		const summary = compactionSummary(context.messages);
+
+		expect(summary.images?.map(image => image.data)).toEqual(["base64-frame"]);
+		expect(summary.blocks?.map(block => block.type)).toEqual(["text", "image", "text"]);
+	});
+});

--- a/packages/coding-agent/src/session/session-context.ts
+++ b/packages/coding-agent/src/session/session-context.ts
@@ -132,6 +132,7 @@ function snapcompactHistoryBlocksForContext(
 	options: BuildSessionContextOptions | undefined,
 ) {
 	if (!archive) return undefined;
+	if (options?.transcript && options.collapseCompactedHistory) return undefined;
 	return snapcompact.historyBlocks(archive, snapcompactHistoryBlockOptions(archive, options));
 }
 


### PR DESCRIPTION
## Repro
A focused repro built a compacted session with `preserveData.snapcompact` containing one image frame, then called `buildSessionContext(entries, undefined, undefined, { transcript: true, collapseCompactedHistory: true })`; before the fix, the returned `compactionSummary` still carried `images: ["base64-frame"]`. Command: `bun test ./collapsed-snapcompact-repro.test.ts`.

## Cause
`packages/coding-agent/src/session/session-context.ts` routed collapsed live transcript rebuilds through `snapcompactHistoryBlocksForContext(...)` with `options.transcript === true`, so `snapcompact.historyBlocks(...)` rebuilt full archive blocks and `createCompactionSummaryMessage(...)` retained image frames on the TUI-visible summary message.

## Fix
- Return no snapcompact history blocks when building collapsed transcript contexts.
- Preserve snapcompact archive block reattachment for provider context and full transcript exports/replays.
- Add `packages/coding-agent/src/session/session-context.test.ts` coverage for collapsed transcript, full transcript, and provider context behavior.
- Add the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/src/session/session-context.test.ts` → 3 pass, 0 fail. `gh_push_branch` completed the repository pre-publish gate and pushed `farm/4c645aa5/skip-collapsed-snapcompact-frames` at `f21d2385e452`. Fixes #4979