### PR TITLE
fix(ai): clear stale OAuth session stickies after credential changes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provider credential changes leaving persisted session-sticky OAuth credential mappings active, so existing sessions reselect accounts after login/logout instead of reusing stale `session:sticky:<provider>:<sessionId>` rows. ([#4982](https://github.com/can1357/oh-my-pi/issues/4982))
+
 ## [16.3.15] - 2026-07-09
 
 ### Breaking Changes

--- a/packages/ai/src/auth-broker/remote-store.ts
+++ b/packages/ai/src/auth-broker/remote-store.ts
@@ -732,6 +732,13 @@ export class RemoteAuthCredentialStore implements AuthCredentialStore {
 		this.#cache.set(key, { value, expiresAtSec });
 	}
 
+	/** Drop all cache rows whose keys start with the supplied prefix. */
+	deleteCachePrefix(prefix: string): void {
+		for (const key of this.#cache.keys()) {
+			if (key.startsWith(prefix)) this.#cache.delete(key);
+		}
+	}
+
 	cleanExpiredCache(): void {
 		const nowSec = Math.floor(Date.now() / 1000);
 		for (const [key, entry] of this.#cache) {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -58,6 +58,7 @@ import { opencodeGoUsageProvider } from "./usage/opencode-go";
 import { zaiUsageProvider } from "./usage/zai";
 
 const USAGE_RANKING_METRIC_EPSILON = 1e-9;
+const SESSION_STICKY_CACHE_PREFIX = "session:sticky:";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Credential Types
@@ -317,6 +318,8 @@ export interface AuthCredentialStore {
 	deleteAuthCredentialsForProvider(provider: string, disabledCause: string): void;
 	getCache(key: string, options?: { includeExpired?: boolean }): string | null;
 	setCache(key: string, value: string, expiresAtSec: number): void;
+	/** Drop all cache rows whose keys start with the supplied prefix. */
+	deleteCachePrefix?(prefix: string): void;
 	cleanExpiredCache(): void;
 	/** Non-expired block for one (credential, providerKey, scope) key, or undefined. */
 	getCredentialBlock?(credentialId: number, providerKey: string, blockScope: string): number | undefined;
@@ -1534,7 +1537,7 @@ export class AuthStorage {
 		try {
 			const credentialId = this.#getStoredCredentials(provider)[index]?.id;
 			if (credentialId !== undefined) {
-				const cacheKey = `session:sticky:${provider}:${sessionId}`;
+				const cacheKey = `${SESSION_STICKY_CACHE_PREFIX}${provider}:${sessionId}`;
 				const cacheValue = JSON.stringify({ type, index, credentialId });
 				// Expires in 30 days
 				const expiresAtSec = Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
@@ -1556,7 +1559,7 @@ export class AuthStorage {
 			return sessionMap.get(sessionId);
 		}
 		try {
-			const cacheKey = `session:sticky:${provider}:${sessionId}`;
+			const cacheKey = `${SESSION_STICKY_CACHE_PREFIX}${provider}:${sessionId}`;
 			const raw = this.#store.getCache(cacheKey);
 			if (raw) {
 				const val = JSON.parse(raw) as { type: AuthCredential["type"]; index: number; credentialId?: number };
@@ -1600,7 +1603,7 @@ export class AuthStorage {
 			}
 		}
 		try {
-			const cacheKey = `session:sticky:${provider}:${sessionId}`;
+			const cacheKey = `${SESSION_STICKY_CACHE_PREFIX}${provider}:${sessionId}`;
 			this.#store.setCache(cacheKey, "", 0);
 		} catch (err) {
 			logger.debug("Failed to clear session sticky credential from persistent store cache", { err });
@@ -1642,6 +1645,14 @@ export class AuthStorage {
 		return fallback;
 	}
 
+	#clearProviderSessionCredentialCache(provider: string): void {
+		try {
+			this.#store.deleteCachePrefix?.(`${SESSION_STICKY_CACHE_PREFIX}${provider}:`);
+		} catch (err) {
+			logger.debug("Failed to clear provider session sticky credentials from persistent store cache", { err });
+		}
+	}
+
 	/**
 	 * Clears round-robin and session assignment state for a provider.
 	 * Called when credentials are added/removed to prevent stale index references.
@@ -1653,6 +1664,7 @@ export class AuthStorage {
 			}
 		}
 		this.#sessionLastCredential.delete(provider);
+		this.#clearProviderSessionCredentialCache(provider);
 		for (const key of this.#credentialBackoff.keys()) {
 			if (key.startsWith(`${provider}:`)) {
 				this.#credentialBackoff.delete(key);
@@ -5172,6 +5184,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#getCacheStmt: Statement;
 	#getCacheIncludingExpiredStmt: Statement;
 	#upsertCacheStmt: Statement;
+	#deleteCachePrefixStmt: Statement;
 	#deleteExpiredCacheStmt: Statement;
 	#getCredentialBlockStmt: Statement;
 	#listCredentialBlocksByCredentialStmt: Statement;
@@ -5222,6 +5235,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#upsertCacheStmt = this.#db.prepare(
 			"INSERT INTO cache (key, value, expires_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at",
 		);
+		this.#deleteCachePrefixStmt = this.#db.prepare("DELETE FROM cache WHERE substr(key, 1, ?) = ?");
 		this.#deleteExpiredCacheStmt = this.#db.prepare(`DELETE FROM cache WHERE expires_at <= ${SQLITE_NOW_EPOCH}`);
 		this.#getCredentialBlockStmt = this.#db.prepare(
 			"SELECT blocked_until_ms FROM auth_credential_blocks WHERE credential_id = ? AND provider_key = ? AND block_scope = ? AND blocked_until_ms > ?",
@@ -5826,6 +5840,15 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			this.#upsertCacheStmt.run(key, value, expiresAtSec);
 		} catch {
 			// Ignore cache set failures
+		}
+	}
+
+	/** Drop all cache rows whose keys start with the supplied prefix. */
+	deleteCachePrefix(prefix: string): void {
+		try {
+			this.#deleteCachePrefixStmt.run(prefix.length, prefix);
+		} catch {
+			// Ignore cache delete failures
 		}
 	}
 

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -843,7 +843,7 @@ describe("AuthStorage persistent session stickiness", () => {
 		}
 	});
 
-	it("re-resolves a persisted sticky to the same account by id after a lower-index credential is removed", async () => {
+	it("drops persisted session stickiness after a lower-index credential is removed", async () => {
 		const provider = "unit-sticky-invalidation";
 		const mk = (suffix: string): OAuthCredential => ({
 			type: "oauth",
@@ -853,50 +853,53 @@ describe("AuthStorage persistent session stickiness", () => {
 			projectId: `project-${suffix}`,
 			email: `user-${suffix}@example.com`,
 		});
+		const initialCredentials = [mk("a"), mk("b"), mk("c"), mk("d")];
+		const remainingCredentials = initialCredentials.slice(1);
 
 		let authStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(dbPath)));
-		// Four accounts so a one-slot index shift still lands on a *different* valid index.
-		await authStorage.set(provider, [mk("a"), mk("b"), mk("c"), mk("d")]);
+		await authStorage.set(provider, initialCredentials);
 		let rows = authStorage.listStoredCredentials(provider);
 
-		// Stick a session to an account whose index is >= 1 (so removing index 0
-		// shifts it) and <= len-2 (so the old recorded index still maps to a
-		// different live account — the resurrection-prone shape the review flagged).
+		const control = new AuthStorage(
+			new SqliteAuthCredentialStore(new Database(path.join(tempDir, "sticky-control.db"))),
+		);
+		await control.set(provider, remainingCredentials);
 		let session: string | undefined;
 		let stuckId = -1;
 		let stuckIndex = -1;
 		let stuckToken: string | undefined;
-		for (let i = 0; i < 256 && session === undefined; i++) {
-			const candidate = `sticky-probe-${i}`;
-			const token = await authStorage.getApiKey(provider, candidate);
-			const index = rows.findIndex(row => (row.credential as OAuthCredential).access === token);
-			if (index >= 1 && index <= rows.length - 2) {
-				session = candidate;
-				stuckIndex = index;
-				stuckId = rows[index].id;
-				stuckToken = token;
+		let freshToken: string | undefined;
+		try {
+			for (let i = 0; i < 256 && session === undefined; i++) {
+				const candidate = `sticky-probe-${i}`;
+				const token = await authStorage.getApiKey(provider, candidate);
+				const expectedFreshToken = await control.getApiKey(provider, candidate);
+				const index = rows.findIndex(row => (row.credential as OAuthCredential).access === token);
+				if (index >= 1 && index <= rows.length - 2 && token !== expectedFreshToken) {
+					session = candidate;
+					stuckIndex = index;
+					stuckId = rows[index].id;
+					stuckToken = token;
+					freshToken = expectedFreshToken;
+				}
 			}
+		} finally {
+			control.close();
 		}
 		expect(session).toBeDefined();
-		// The account that will slide into the OLD recorded index after the removal.
-		const shiftedToken = (rows[stuckIndex + 1].credential as OAuthCredential).access;
-		expect(shiftedToken).not.toBe(stuckToken);
+		expect(freshToken).toBeDefined();
 
-		// Remove the index-0 account (a different account) -> indices shift down by one.
 		expect(await authStorage.removeCredential(provider, rows[0].id)).toBe(true);
 		authStorage.close();
 
-		// Restart from the same DB.
 		authStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(dbPath)));
 		await authStorage.reload();
 		rows = authStorage.listStoredCredentials(provider);
 		expect(rows.findIndex(row => row.id === stuckId)).toBe(stuckIndex - 1);
 
-		// The persisted sticky must follow the credential id, not the stale index:
-		// route back to the same account, never the one now occupying the old index.
 		const resolved = await authStorage.getApiKey(provider, session);
 		authStorage.close();
-		expect(resolved).toBe(stuckToken);
-		expect(resolved).not.toBe(shiftedToken);
+		expect(resolved).toBe(freshToken);
+		expect(resolved).not.toBe(stuckToken);
 	});
 });

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { UsageProvider } from "@oh-my-pi/pi-ai";
+import type { OAuthCredential, UsageProvider } from "@oh-my-pi/pi-ai";
 import * as oauth from "@oh-my-pi/pi-ai/oauth";
-import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
+import type { OAuthCredentials, OAuthProviderId } from "@oh-my-pi/pi-ai/oauth/types";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
@@ -13,6 +13,37 @@ describe("AuthStorage account rotation", () => {
 	let authStorage: AuthStorage;
 	let usageExhausted = false;
 
+	const stickyInvalidationSource = "auth-storage-rotation-issue-4982";
+	const targetProvider = "issue-4982-target" as OAuthProviderId;
+	const unrelatedProvider = "issue-4982-unrelated" as OAuthProviderId;
+	let nextLoginCredential: OAuthCredentials | undefined;
+
+	const findSessionWhereFreshSelectionChanges = async (
+		provider: string,
+		initialCredentials: OAuthCredential[],
+		finalCredentials: OAuthCredential[],
+	): Promise<{ sessionId: string; stickyKey: string; freshKey: string }> => {
+		const control = await AuthStorage.create(path.join(tempDir, `issue-4982-control-${Snowflake.next()}.db`), {
+			usageProviderResolver: () => undefined,
+		});
+		try {
+			await control.set(provider, finalCredentials);
+			await authStorage.set(provider, initialCredentials);
+
+			for (let attempt = 0; attempt < 128; attempt += 1) {
+				const sessionId = `issue-4982-session-${attempt}`;
+				const stickyKey = await authStorage.getApiKey(provider, sessionId);
+				const freshKey = await control.getApiKey(provider, sessionId);
+				if (stickyKey && freshKey && stickyKey !== freshKey) {
+					return { sessionId, stickyKey, freshKey };
+				}
+			}
+		} finally {
+			control.close();
+		}
+
+		throw new Error("expected at least one session whose fresh credential selection changes after login");
+	};
 	const usageProvider: UsageProvider = {
 		id: "openai-codex",
 		async fetchUsage(params) {
@@ -37,6 +68,20 @@ describe("AuthStorage account rotation", () => {
 		tempDir = path.join(os.tmpdir(), `pi-test-auth-rotation-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		usageExhausted = false;
+		nextLoginCredential = undefined;
+		for (const provider of [targetProvider, unrelatedProvider]) {
+			oauth.registerOAuthProvider({
+				id: provider,
+				name: provider,
+				sourceId: stickyInvalidationSource,
+				async login() {
+					if (!nextLoginCredential) {
+						throw new Error(`missing queued OAuth credential for ${provider}`);
+					}
+					return nextLoginCredential;
+				},
+			});
+		}
 
 		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"), {
 			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
@@ -60,6 +105,7 @@ describe("AuthStorage account rotation", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		oauth.unregisterOAuthProviders(stickyInvalidationSource);
 		authStorage.close();
 		if (tempDir && fs.existsSync(tempDir)) {
 			removeSyncWithRetries(tempDir);
@@ -144,5 +190,81 @@ describe("AuthStorage account rotation", () => {
 		const result = await authStorage.markUsageLimitReached("openai-codex", sessionId, { apiKey: failedKey });
 		expect(result.switched).toBe(true);
 		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe(stickyKey);
+	});
+
+	test("provider login invalidates only that provider's persisted session stickiness", async () => {
+		const targetInitialCredentials: OAuthCredential[] = [
+			{
+				type: "oauth",
+				access: "target-access-a",
+				refresh: "target-refresh-a",
+				expires: Date.now() + 3600_000,
+				accountId: "target-acct-a",
+				email: "target-a@example.com",
+			},
+			{
+				type: "oauth",
+				access: "target-access-b",
+				refresh: "target-refresh-b",
+				expires: Date.now() + 3600_000,
+				accountId: "target-acct-b",
+				email: "target-b@example.com",
+			},
+		];
+		const targetAddedCredential: OAuthCredential = {
+			type: "oauth",
+			access: "target-access-c",
+			refresh: "target-refresh-c",
+			expires: Date.now() + 3600_000,
+			accountId: "target-acct-c",
+			email: "target-c@example.com",
+		};
+		const targetFinalCredentials = [...targetInitialCredentials, targetAddedCredential];
+		const { sessionId, stickyKey, freshKey } = await findSessionWhereFreshSelectionChanges(
+			targetProvider,
+			targetInitialCredentials,
+			targetFinalCredentials,
+		);
+
+		await authStorage.set(unrelatedProvider, [
+			{
+				type: "oauth",
+				access: "unrelated-access-a",
+				refresh: "unrelated-refresh-a",
+				expires: Date.now() + 3600_000,
+				accountId: "unrelated-acct-a",
+				email: "unrelated-a@example.com",
+			},
+			{
+				type: "oauth",
+				access: "unrelated-access-b",
+				refresh: "unrelated-refresh-b",
+				expires: Date.now() + 3600_000,
+				accountId: "unrelated-acct-b",
+				email: "unrelated-b@example.com",
+			},
+		]);
+		const unrelatedSessionId = "issue-4982-unrelated-session";
+		const unrelatedStickyKey = await authStorage.getApiKey(unrelatedProvider, unrelatedSessionId);
+		expect(unrelatedStickyKey).toMatch(/^unrelated-access-/);
+
+		const { type: _type, ...loginCredential } = targetAddedCredential;
+		nextLoginCredential = loginCredential;
+		await authStorage.login(targetProvider, {
+			onAuth: () => {},
+			onPrompt: async () => "",
+		});
+		nextLoginCredential = undefined;
+
+		authStorage.close();
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"), {
+			usageProviderResolver: provider => (provider === "openai-codex" ? usageProvider : undefined),
+		});
+		await authStorage.reload();
+
+		const reloadedTargetKey = await authStorage.getApiKey(targetProvider, sessionId);
+		expect(reloadedTargetKey).toBe(freshKey);
+		expect(reloadedTargetKey).not.toBe(stickyKey);
+		expect(await authStorage.getApiKey(unrelatedProvider, unrelatedSessionId)).toBe(unrelatedStickyKey);
 	});
 });


### PR DESCRIPTION
## Repro
A focused AuthStorage repro persisted `session:sticky:unit-issue-4982:session-1` for OAuth account A, changed the provider credentials to include account B, reopened the same SQLite store, then still resolved `access-a` instead of the current policy's `access-b`. Command: `bun test packages/ai/test/issue-4982-repro.test.ts` failed before the fix with `Expected: "access-b"`, `Received: "access-a"`.

## Cause
`AuthStorage.#resetProviderAssignments(provider)` in `packages/ai/src/auth-storage.ts` cleared only in-memory `#sessionLastCredential` state. Persisted cache rows written by `#recordSessionCredential()` under `session:sticky:<provider>:<sessionId>` remained in the SQLite cache, so a fresh `AuthStorage` instance could rehydrate an old credential id and route the session back to the previous OAuth account after login/logout/upsert.

## Fix
- Added provider-prefix cache deletion to the `AuthCredentialStore` contract, with SQLite and auth-broker remote-store implementations.
- Cleared `session:sticky:<provider>:` persistent cache rows whenever provider credential assignments reset.
- Updated stale-removal stickiness coverage to match the new invalidation contract.
- Added a regression test for OAuth login/upsert invalidation and unrelated-provider sticky preservation.
- Added an `@oh-my-pi/pi-ai` changelog entry for #4982.

## Verification
`bun test packages/coding-agent/test/auth-storage-rotation.test.ts packages/ai/test/auth-storage-email-dedupe.test.ts` passed: 28 pass, 0 fail, 80 expect() calls. `gh_push_branch` completed the repo pre-publish gate before pushing. Fixes #4982