### PR TITLE
fix(mcp): keep macOS stdio servers attached

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed macOS stdio MCP servers launching in a detached session, so `xcrun mcpbridge` can trigger the TCC Apple Events permission prompt and complete startup. ([#4987](https://github.com/can1357/oh-my-pi/issues/4987))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.test.ts
@@ -31,6 +31,18 @@ describe("resolveStdioSpawnCommand", () => {
 		});
 	});
 
+	it("keeps Darwin stdio MCP servers attached so TCC Apple Events prompts can resolve", async () => {
+		await expect(
+			resolveStdioSpawnCommand(
+				{ command: "xcrun", args: ["mcpbridge"] },
+				{ cwd: process.cwd(), env: {}, platform: "darwin" },
+			),
+		).resolves.toEqual({
+			cmd: ["xcrun", "mcpbridge"],
+			detached: false,
+		});
+	});
+
 	it("detaches off-Windows MCP servers so terminal job-control signals cannot stop them", async () => {
 		await expect(
 			resolveStdioSpawnCommand(

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -37,12 +37,17 @@ export interface StdioSpawnCommand {
 	 */
 	windowsHide?: boolean;
 	/**
-	 * Run the subprocess in its own session.
+	 * Run the subprocess in its own session when the platform can safely do so.
 	 *
-	 * POSIX: `true`. Detach → `setsid`, so the MCP process tree has no
-	 * controlling terminal and terminal job-control signals (Ctrl+Z SIGTSTP,
+	 * Linux/other POSIX: `true`. Detach → `setsid`, so the MCP process tree has
+	 * no controlling terminal and terminal job-control signals (Ctrl+Z SIGTSTP,
 	 * background-read SIGTTIN) cannot stop stdio servers such as
 	 * `chrome-devtools-mcp` and leave our read loop blocked on silent pipes.
+	 *
+	 * macOS: `false`. LaunchServices/TCC attributes Apple Events automation to
+	 * the responsible terminal process only while the child stays in the
+	 * inherited session; detaching via `setsid` prevents the permission prompt
+	 * for servers such as `xcrun mcpbridge` (#4987).
 	 *
 	 * Windows: `false`. There is no SIGTSTP/SIGTTIN to escape, and Windows
 	 * wrapper chains must stay in the OMP console session so nested console
@@ -247,7 +252,7 @@ export async function resolveStdioSpawnCommand(
 	options: ResolveStdioSpawnOptions,
 ): Promise<StdioSpawnCommand> {
 	const args = config.args ?? [];
-	if (options.platform !== "win32") return { cmd: [config.command, ...args], detached: true };
+	if (options.platform !== "win32") return { cmd: [config.command, ...args], detached: options.platform !== "darwin" };
 
 	const windowsHide = options.hostHasInheritableConsole === undefined ? true : !options.hostHasInheritableConsole;
 	const resolved = await resolveWindowsCommandPath(config.command, options.cwd, options.env);
@@ -366,10 +371,11 @@ export class StdioTransport implements MCPTransport {
 		});
 
 		// Platform-derived session and console-window handling come from
-		// `resolveStdioSpawnCommand`: POSIX detaches into its own session to
-		// escape terminal job-control signals (SIGTSTP, SIGTTIN); Windows stays
-		// attached, and only hides the child when the host has no console to
-		// share. See `StdioSpawnCommand`.
+		// `resolveStdioSpawnCommand`: Linux/other POSIX detach into their own
+		// session to escape terminal job-control signals (SIGTSTP, SIGTTIN);
+		// macOS stays attached so TCC can prompt for Apple Events automation;
+		// Windows stays attached, and only hides the child when the host has no
+		// console to share. See `StdioSpawnCommand`.
 		this.#process = spawn({
 			cmd: spawnCommand.cmd,
 			cwd,

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -1024,10 +1024,10 @@ export class InputController {
 			// leaves wrappers and pipeline peers running and the terminal
 			// hung — exactly the failure shape we're fixing. Stopping the whole
 			// group keeps the shell's job-control view consistent. Long-lived
-			// children that must survive the suspend (MCP stdio servers via
-			// the `detached: true` spawn in `mcp/transports/stdio.ts`, every
-			// brush external command via brush's per-child `setsid` in
-			// `crates/vendor/brush-core/src/commands.rs`) are already in
+			// children that must survive the suspend (Linux/other POSIX MCP stdio
+			// servers via the platform-specific `detached: true` spawn in
+			// `mcp/transports/stdio.ts`, every brush external command via brush's
+			// per-child `setsid` in `crates/vendor/brush-core/src/commands.rs`) are
 			// their own sessions, so pgid=0 does not reach them.
 			process.kill(0, "SIGSTOP");
 		} catch (err) {


### PR DESCRIPTION
## Repro
Resolving the `xcrun mcpbridge` stdio server through `packages/coding-agent/src/mcp/transports/stdio.ts` with `platform: "darwin"` returned `{ "cmd": ["xcrun", "mcpbridge"], "detached": true }`, so MCP stdio startup used a detached POSIX session on macOS; that matches the reporter's failing TCC Apple Events path where `xcrun mcpbridge` never prompts and the MCP initialize/tools handshake times out.

## Cause
`resolveStdioSpawnCommand` treated every non-Windows host as safe to detach (`detached: true`). On macOS, that `setsid` behavior breaks the responsible-process/session path that TCC uses to prompt or inherit Apple Events permission for Xcode automation, so `StdioTransport.connect()` spawned `xcrun mcpbridge` in the same problematic mode documented by the native shell path.

## Fix
- Keep Darwin stdio MCP server launches attached while preserving Linux/other POSIX detachment and Windows console handling.
- Update the signal-handling comments in `stdio.ts` and `input-controller.ts` so the platform split is explicit.
- Add resolver regression coverage for `xcrun mcpbridge` on Darwin returning `detached: false`.
- Add a coding-agent changelog entry for the macOS stdio MCP fix.

## Verification
`bun test src/mcp/transports/stdio.test.ts` in `packages/coding-agent` passed: 5 pass, 0 fail, 8 expect() calls. A direct resolver smoke check returned Darwin `{ "cmd": ["xcrun", "mcpbridge"], "detached": false }` and Linux `{ "cmd": ["server", "--stdio"], "detached": true }`. `gh_push_branch` completed the pre-publish gate before pushing. Fixes #4987