### PR TITLE
fix(auth): decouple login success from model refresh

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed interactive OAuth login success messages waiting on model discovery; `/login xai-oauth` now reports saved credentials immediately while model metadata refreshes in the background. ([#4989](https://github.com/can1357/oh-my-pi/issues/4989))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1179,7 +1179,7 @@ export class SelectorController {
 				},
 				onManualCodeInput: useManualInput ? () => manualInput.waitForInput(providerId) : undefined,
 			});
-			await this.ctx.session.modelRegistry.refresh();
+			this.ctx.session.modelRegistry.refreshInBackground();
 			const block = new TranscriptBlock();
 			block.addChild(
 				new Text(theme.fg("success", `${theme.status.success} Successfully logged in to ${providerId}`), 1, 0),

--- a/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
@@ -1,0 +1,65 @@
+import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+
+interface RenderableBlock {
+	render(width: number): string[];
+}
+
+function renderPresented(blocks: unknown[]): string {
+	return blocks
+		.flatMap(block => {
+			const maybeRenderable = block as Partial<RenderableBlock>;
+			return maybeRenderable.render ? maybeRenderable.render(120) : [String(block)];
+		})
+		.join("\n");
+}
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("SelectorController login", () => {
+	it("presents OAuth success as soon as credentials are saved", async () => {
+		const loginSaved = Promise.withResolvers<void>();
+		const presentedBlocks: unknown[] = [];
+		const authStorage = {
+			login: vi.fn(async () => {
+				loginSaved.resolve();
+			}),
+		} as unknown as AuthStorage;
+		const refresh = vi.fn(() => new Promise<void>(() => {}));
+		const refreshInBackground = vi.fn();
+		const ctx = {
+			oauthManualInput: {
+				waitForInput: vi.fn(),
+				clear: vi.fn(),
+			},
+			session: {
+				modelRegistry: {
+					authStorage,
+					refresh,
+					refreshInBackground,
+				},
+			},
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			present: vi.fn((block: unknown) => {
+				presentedBlocks.push(block);
+			}),
+			openInBrowser: vi.fn(),
+		} as unknown as InteractiveModeContext;
+		const controller = new SelectorController(ctx);
+
+		void controller.showOAuthSelector("login", "xai-oauth");
+		await loginSaved.promise;
+		await Promise.resolve();
+
+		expect(renderPresented(presentedBlocks)).toContain("Successfully logged in to xai-oauth");
+		expect(refreshInBackground).toHaveBeenCalledTimes(1);
+		expect(refresh).not.toHaveBeenCalled();
+		expect(ctx.showError).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Repro
Interactive `/login xai-oauth` could finish saving credentials but keep the terminal at `OAuth callback received; completing login…` because the success transcript was emitted only after a whole-registry model refresh. I reproduced it with `cd packages/coding-agent && bun run gen:tool-views && bun test test/modes/controllers/selector-controller-login.test.ts`; the pre-fix test kept `modelRegistry.refresh()` pending after `authStorage.login(...)` resolved and observed an empty success transcript.

## Cause
`SelectorController.#handleOAuthLogin` in `packages/coding-agent/src/modes/controllers/selector-controller.ts` awaited `this.ctx.session.modelRegistry.refresh()` before presenting `Successfully logged in to ${providerId}` and the credential path, coupling visible login completion to network-bound model discovery.

## Fix
- Switched the interactive OAuth login path to call `modelRegistry.refreshInBackground()` immediately after credentials are saved.
- Kept the success transcript emission synchronous with the completed credential save.
- Added `packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts` to assert success is presented while a foreground refresh would remain pending.
- Added the coding-agent changelog entry for issue #4989.

## Verification
`cd packages/coding-agent && bun test test/modes/controllers/selector-controller-login.test.ts test/modes/controllers/selector-controller-logout.test.ts` passed: 2 tests, 9 assertions. The pre-publish `gh_push_branch` gate completed and pushed the branch, which means `bun run fix` and `bun check` passed before remote publication. Fixes #4989