### PR TITLE
fix(coding-agent): restore ask tool timeout fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the ask tool timeout so it auto-selects the recommended option even when the UI selector does not settle on its own. ([#4995](https://github.com/can1357/oh-my-pi/issues/4995))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -180,6 +180,8 @@ export type AutocompleteProviderFactory = (current: AutocompleteProvider) => Aut
 // and may be invoked from event handlers that have already taken the agent
 // loop's lock — hooks intentionally cannot.
 export interface ExtensionUIContext {
+	/** True when selector timeouts start only after the dialog is presented. */
+	timeoutStartsOnPresentation?: boolean;
 	/** Show a selector and return the selected label, even when an option also includes a description. */
 	select(
 		title: string,

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -125,6 +125,8 @@ export interface ExtensionUIDialogOptions {
 	timeout?: number;
 	/** Invoked when the UI times out while waiting for a selection/input */
 	onTimeout?: () => void;
+	/** Invoked when the UI-managed timeout countdown starts */
+	onTimeoutStart?: () => void;
 	/** Invoked when user input resets a UI-managed timeout countdown */
 	onTimeoutReset?: () => void;
 	/** Initial cursor position for select dialogs (0-indexed) */

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -125,6 +125,8 @@ export interface ExtensionUIDialogOptions {
 	timeout?: number;
 	/** Invoked when the UI times out while waiting for a selection/input */
 	onTimeout?: () => void;
+	/** Invoked when user input resets a UI-managed timeout countdown */
+	onTimeoutReset?: () => void;
 	/** Initial cursor position for select dialogs (0-indexed) */
 	initialIndex?: number;
 	/** Render an outlined list for select dialogs */

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -61,6 +61,7 @@ export interface HookSelectorOptions {
 	tui?: TUI;
 	timeout?: number;
 	onTimeout?: () => void;
+	onTimeoutReset?: () => void;
 	initialIndex?: number;
 	outline?: boolean;
 	maxVisible?: number;
@@ -178,6 +179,7 @@ export class HookSelectorComponent extends Container {
 	#onLeftCallback: (() => void) | undefined;
 	#onRightCallback: (() => void) | undefined;
 	#onExternalEditorCallback: (() => void) | undefined;
+	#onTimeoutResetCallback: (() => void) | undefined;
 	#slider: HookSelectorSlider | undefined;
 	#sliderIndex: number = 0;
 	#sliderComponent: Text | undefined;
@@ -213,6 +215,7 @@ export class HookSelectorComponent extends Container {
 		this.#onLeftCallback = opts?.onLeft;
 		this.#onRightCallback = opts?.onRight;
 		this.#onExternalEditorCallback = opts?.onExternalEditor;
+		this.#onTimeoutResetCallback = opts?.onTimeoutReset;
 		if (opts?.slider && opts.slider.segments.length > 0) {
 			this.#slider = opts.slider;
 			this.#sliderIndex = Math.max(0, Math.min(opts.slider.index, opts.slider.segments.length - 1));
@@ -633,8 +636,10 @@ export class HookSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
-		// Reset countdown on any interaction
-		this.#countdown?.reset();
+		if (this.#countdown) {
+			this.#countdown.reset();
+			this.#onTimeoutResetCallback?.();
+		}
 
 		if (matchesSelectCancel(keyData)) {
 			this.#onCancelCallback();

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -61,6 +61,7 @@ export interface HookSelectorOptions {
 	tui?: TUI;
 	timeout?: number;
 	onTimeout?: () => void;
+	onTimeoutStart?: () => void;
 	onTimeoutReset?: () => void;
 	initialIndex?: number;
 	outline?: boolean;
@@ -235,6 +236,7 @@ export class HookSelectorComponent extends Container {
 		}
 
 		if (opts?.timeout && opts.timeout > 0 && opts.tui) {
+			opts.onTimeoutStart?.();
 			this.#countdown = new CountdownTimer(
 				opts.timeout,
 				opts.tui,

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -61,6 +61,7 @@ export class ExtensionUiController {
 	async initHooksAndCustomTools(): Promise<void> {
 		// Create and set hook & tool UI context
 		const uiContext: ExtensionUIContext = {
+			timeoutStartsOnPresentation: true,
 			select: (title, options, dialogOptions) => this.showCollabAwareSelector(title, options, dialogOptions),
 			confirm: (title, message, _dialogOptions) => this.showHookConfirm(title, message),
 			input: (title, placeholder, dialogOptions) => this.showHookInput(title, placeholder, dialogOptions),

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -624,6 +624,7 @@ export class ExtensionUiController {
 					initialIndex: dialogOptions?.initialIndex,
 					timeout: dialogOptions?.timeout,
 					onTimeout: dialogOptions?.onTimeout,
+					onTimeoutStart: dialogOptions?.onTimeoutStart,
 					onTimeoutReset: dialogOptions?.onTimeoutReset,
 					tui: this.ctx.ui,
 					outline: dialogOptions?.outline,

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -624,6 +624,7 @@ export class ExtensionUiController {
 					initialIndex: dialogOptions?.initialIndex,
 					timeout: dialogOptions?.timeout,
 					onTimeout: dialogOptions?.onTimeout,
+					onTimeoutReset: dialogOptions?.onTimeoutReset,
 					tui: this.ctx.ui,
 					outline: dialogOptions?.outline,
 					disabledIndices: dialogOptions?.disabledIndices,

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -380,6 +380,7 @@ interface AskSingleQuestionOptions {
 }
 
 interface UIContext {
+	timeoutStartsOnPresentation?: boolean;
 	select(
 		prompt: string,
 		options: ExtensionUISelectItem[],
@@ -474,9 +475,14 @@ async function askSingleQuestion(
 				: undefined,
 		};
 		try {
-			const choice = dialogSignal
-				? await untilAborted(dialogSignal, () => ui.select(prompt, optionsToShow, dialogOptions))
-				: await ui.select(prompt, optionsToShow, dialogOptions);
+			const runSelect = () => {
+				const selection = ui.select(prompt, optionsToShow, dialogOptions);
+				if (timeoutMs !== undefined && !ui.timeoutStartsOnPresentation) {
+					armFallbackTimeout(timeoutMs);
+				}
+				return selection;
+			};
+			const choice = dialogSignal ? await untilAborted(dialogSignal, runSelect) : await runSelect();
 			if (!timeoutTriggered && choice === undefined && typeof timeout === "number") {
 				// Fallback for UI surfaces that enforce `timeout` without invoking
 				// `onTimeout`: their auto-cancel resolves right at the deadline. A
@@ -774,6 +780,7 @@ export class AskTool implements AgentTool<typeof askSchema, AskToolDetails> {
 
 		const extensionUi = context.ui;
 		const ui: UIContext = {
+			timeoutStartsOnPresentation: extensionUi.timeoutStartsOnPresentation,
 			select: (prompt, options, dialogOptions) => extensionUi.select(prompt, options, dialogOptions),
 			editor: (title, prefill, dialogOptions, editorOptions) =>
 				extensionUi.editor(title, prefill, dialogOptions, editorOptions),

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -432,10 +432,16 @@ async function askSingleQuestion(
 		const helpText = navigation
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
 			: "up/down navigate  enter select  esc cancel";
+		const timeoutController = typeof timeout === "number" && timeout > 0 ? new AbortController() : undefined;
+		const dialogSignal =
+			signal && timeoutController
+				? AbortSignal.any([signal, timeoutController.signal])
+				: (timeoutController?.signal ?? signal);
+		let timeoutId: NodeJS.Timeout | undefined;
 		const dialogOptions = {
 			initialIndex,
 			timeout,
-			signal,
+			signal: dialogSignal,
 			outline: true,
 			onTimeout,
 			helpText,
@@ -454,18 +460,33 @@ async function askSingleQuestion(
 				: undefined,
 		};
 		const startMs = Date.now();
-		const choice = signal
-			? await untilAborted(signal, () => ui.select(prompt, optionsToShow, dialogOptions))
-			: await ui.select(prompt, optionsToShow, dialogOptions);
-		if (!timeoutTriggered && choice === undefined && typeof timeout === "number") {
-			// Fallback for UI surfaces that enforce `timeout` without invoking
-			// `onTimeout`: their auto-cancel resolves right at the deadline. A
-			// cancel arriving well past the deadline is a deliberate user Esc on
-			// a surface that kept the dialog open — keep treating it as a cancel.
-			const elapsed = Date.now() - startMs;
-			timeoutTriggered = elapsed >= timeout && elapsed <= timeout + TIMEOUT_DETECTION_TOLERANCE_MS;
+		if (timeoutController && typeof timeout === "number") {
+			timeoutId = setTimeout(() => {
+				timeoutTriggered = true;
+				timeoutController.abort();
+			}, timeout);
 		}
-		return { choice, timedOut: timeoutTriggered, navigation: navigationAction };
+		try {
+			const choice = dialogSignal
+				? await untilAborted(dialogSignal, () => ui.select(prompt, optionsToShow, dialogOptions))
+				: await ui.select(prompt, optionsToShow, dialogOptions);
+			if (!timeoutTriggered && choice === undefined && typeof timeout === "number") {
+				// Fallback for UI surfaces that enforce `timeout` without invoking
+				// `onTimeout`: their auto-cancel resolves right at the deadline. A
+				// cancel arriving well past the deadline is a deliberate user Esc on
+				// a surface that kept the dialog open — keep treating it as a cancel.
+				const elapsed = Date.now() - startMs;
+				timeoutTriggered = elapsed >= timeout && elapsed <= timeout + TIMEOUT_DETECTION_TOLERANCE_MS;
+			}
+			return { choice, timedOut: timeoutTriggered, navigation: navigationAction };
+		} catch (error) {
+			if (timeoutTriggered && error instanceof Error && error.name === "AbortError") {
+				return { choice: undefined, timedOut: true, navigation: navigationAction };
+			}
+			throw error;
+		} finally {
+			clearTimeout(timeoutId);
+		}
 	};
 
 	const promptForCustomInput = async (

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -642,6 +642,9 @@ async function askSingleQuestion(
 			customInput = undefined;
 			break;
 		}
+		if (timedOut && selectedOptions.length === 0 && customInput === undefined) {
+			selectedOptions = getAutoSelectionOnTimeout(questionOptions, recommended);
+		}
 		if (navigation?.allowForward) {
 			return { selectedOptions, customInput, timedOut, navigation: "forward" };
 		}

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -389,6 +389,7 @@ interface UIContext {
 			signal?: AbortSignal;
 			outline?: boolean;
 			onTimeout?: () => void;
+			onTimeoutStart?: () => void;
 			onTimeoutReset?: () => void;
 			onLeft?: () => void;
 			onRight?: () => void;
@@ -455,6 +456,7 @@ async function askSingleQuestion(
 			signal: dialogSignal,
 			outline: true,
 			onTimeout,
+			onTimeoutStart: timeoutMs === undefined ? undefined : () => armFallbackTimeout(timeoutMs),
 			onTimeoutReset: timeoutMs === undefined ? undefined : () => armFallbackTimeout(timeoutMs),
 			helpText,
 			selectionMarker: marker?.selectionMarker,
@@ -471,9 +473,6 @@ async function askSingleQuestion(
 					}
 				: undefined,
 		};
-		if (timeoutMs !== undefined) {
-			armFallbackTimeout(timeoutMs);
-		}
 		try {
 			const choice = dialogSignal
 				? await untilAborted(dialogSignal, () => ui.select(prompt, optionsToShow, dialogOptions))

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -389,6 +389,7 @@ interface UIContext {
 			signal?: AbortSignal;
 			outline?: boolean;
 			onTimeout?: () => void;
+			onTimeoutReset?: () => void;
 			onLeft?: () => void;
 			onRight?: () => void;
 			helpText?: string;
@@ -432,18 +433,29 @@ async function askSingleQuestion(
 		const helpText = navigation
 			? "up/down navigate  enter select  ←/→ question  esc cancel"
 			: "up/down navigate  enter select  esc cancel";
-		const timeoutController = typeof timeout === "number" && timeout > 0 ? new AbortController() : undefined;
+		const timeoutMs = typeof timeout === "number" && timeout > 0 ? timeout : undefined;
+		const timeoutController = timeoutMs === undefined ? undefined : new AbortController();
 		const dialogSignal =
 			signal && timeoutController
 				? AbortSignal.any([signal, timeoutController.signal])
 				: (timeoutController?.signal ?? signal);
 		let timeoutId: NodeJS.Timeout | undefined;
+		let timeoutStartedMs = Date.now();
+		const armFallbackTimeout = (durationMs: number) => {
+			clearTimeout(timeoutId);
+			timeoutStartedMs = Date.now();
+			timeoutId = setTimeout(() => {
+				timeoutTriggered = true;
+				timeoutController?.abort();
+			}, durationMs);
+		};
 		const dialogOptions = {
 			initialIndex,
 			timeout,
 			signal: dialogSignal,
 			outline: true,
 			onTimeout,
+			onTimeoutReset: timeoutMs === undefined ? undefined : () => armFallbackTimeout(timeoutMs),
 			helpText,
 			selectionMarker: marker?.selectionMarker,
 			checkedIndices: marker?.checkedIndices,
@@ -459,12 +471,8 @@ async function askSingleQuestion(
 					}
 				: undefined,
 		};
-		const startMs = Date.now();
-		if (timeoutController && typeof timeout === "number") {
-			timeoutId = setTimeout(() => {
-				timeoutTriggered = true;
-				timeoutController.abort();
-			}, timeout);
+		if (timeoutMs !== undefined) {
+			armFallbackTimeout(timeoutMs);
 		}
 		try {
 			const choice = dialogSignal
@@ -475,7 +483,7 @@ async function askSingleQuestion(
 				// `onTimeout`: their auto-cancel resolves right at the deadline. A
 				// cancel arriving well past the deadline is a deliberate user Esc on
 				// a surface that kept the dialog open — keep treating it as a cancel.
-				const elapsed = Date.now() - startMs;
+				const elapsed = Date.now() - timeoutStartedMs;
 				timeoutTriggered = elapsed >= timeout && elapsed <= timeout + TIMEOUT_DETECTION_TOLERANCE_MS;
 			}
 			return { choice, timedOut: timeoutTriggered, navigation: navigationAction };

--- a/packages/coding-agent/test/ask-timeout.test.ts
+++ b/packages/coding-agent/test/ask-timeout.test.ts
@@ -48,10 +48,7 @@ describe("AskTool timeout", () => {
 
 	it("auto-selects the recommended option when the selector does not settle", async () => {
 		vi.useFakeTimers();
-		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
-			dialogOptions?.onTimeoutStart?.();
-			return Promise.withResolvers<string | undefined>().promise;
-		});
+		const select = vi.fn<AskSelect>(() => Promise.withResolvers<string | undefined>().promise);
 		const abort = vi.fn();
 		const context = {
 			hasUI: true,
@@ -176,6 +173,7 @@ describe("AskTool timeout", () => {
 		const context = {
 			hasUI: true,
 			ui: {
+				timeoutStartsOnPresentation: true,
 				select,
 				editor: vi.fn(),
 			},

--- a/packages/coding-agent/test/ask-timeout.test.ts
+++ b/packages/coding-agent/test/ask-timeout.test.ts
@@ -50,7 +50,7 @@ describe("AskTool timeout", () => {
 		vi.useFakeTimers();
 		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
 			dialogOptions?.onTimeoutStart?.();
-			return new Promise<string | undefined>(() => {});
+			return Promise.withResolvers<string | undefined>().promise;
 		});
 		const abort = vi.fn();
 		const context = {
@@ -106,7 +106,7 @@ describe("AskTool timeout", () => {
 		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
 			dialogOptions?.onTimeoutStart?.();
 			resetTimeout = dialogOptions?.onTimeoutReset;
-			return new Promise<string | undefined>(() => {});
+			return Promise.withResolvers<string | undefined>().promise;
 		});
 		const abort = vi.fn();
 		const context = {
@@ -170,7 +170,7 @@ describe("AskTool timeout", () => {
 		let startTimeout: (() => void) | undefined;
 		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
 			startTimeout = dialogOptions?.onTimeoutStart;
-			return new Promise<string | undefined>(() => {});
+			return Promise.withResolvers<string | undefined>().promise;
 		});
 		const abort = vi.fn();
 		const context = {
@@ -225,6 +225,75 @@ describe("AskTool timeout", () => {
 		expect(rejection).toBeUndefined();
 		expect(result?.details?.selectedOptions).toEqual(["Postgres"]);
 		expect(result?.details?.timedOut).toBe(true);
+		expect(abort).not.toHaveBeenCalled();
+	});
+
+	it("auto-selects timed-out single-choice questions before advancing multi-question asks", async () => {
+		vi.useFakeTimers();
+		let callCount = 0;
+		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
+			callCount += 1;
+			if (callCount === 1) {
+				dialogOptions?.onTimeoutStart?.();
+				return Promise.withResolvers<string | undefined>().promise;
+			}
+			return Promise.resolve("OAuth");
+		});
+		const abort = vi.fn();
+		const context = {
+			hasUI: true,
+			ui: {
+				select,
+				editor: vi.fn(),
+			},
+			abort,
+		} as unknown as AgentToolContext;
+		let result: AskExecutionResult | undefined;
+		let rejection: unknown;
+
+		void createAskTool()
+			.execute(
+				"ask-timeout",
+				{
+					questions: [
+						{
+							id: "db",
+							question: "Which database?",
+							options: [{ label: "SQLite" }, { label: "Postgres" }],
+							recommended: 1,
+						},
+						{
+							id: "auth",
+							question: "Which auth?",
+							options: [{ label: "JWT" }, { label: "OAuth" }],
+							recommended: 0,
+						},
+					],
+				},
+				undefined,
+				undefined,
+				context,
+			)
+			.then(
+				value => {
+					result = value;
+				},
+				error => {
+					rejection = error;
+				},
+			);
+
+		await drainMicrotasks();
+		vi.advanceTimersByTime(10);
+		await drainMicrotasks();
+		await drainMicrotasks();
+
+		expect(rejection).toBeUndefined();
+		expect(select).toHaveBeenCalledTimes(2);
+		expect(result?.details?.results?.[0]?.selectedOptions).toEqual(["Postgres"]);
+		expect(result?.details?.results?.[0]?.timedOut).toBe(true);
+		expect(result?.details?.results?.[1]?.selectedOptions).toEqual(["OAuth"]);
+		expect(result?.details?.results?.[1]?.timedOut).toBeUndefined();
 		expect(abort).not.toHaveBeenCalled();
 	});
 

--- a/packages/coding-agent/test/ask-timeout.test.ts
+++ b/packages/coding-agent/test/ask-timeout.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import type { AgentToolContext, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import type { TUI } from "@oh-my-pi/pi-tui";
+import type { ExtensionUIDialogOptions, ExtensionUISelectItem } from "../src/extensibility/extensions";
+import { HookSelectorComponent } from "../src/modes/components/hook-selector";
 import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
 import type { ToolSession } from "../src/tools";
 import { AskTool, type AskToolDetails } from "../src/tools/ask";
 
 type AskExecutionResult = AgentToolResult<AskToolDetails>;
+type AskSelect = (
+	title: string,
+	options: ExtensionUISelectItem[],
+	dialogOptions?: ExtensionUIDialogOptions,
+) => Promise<string | undefined>;
 
 async function drainMicrotasks(): Promise<void> {
 	await Promise.resolve();
@@ -40,7 +48,7 @@ describe("AskTool timeout", () => {
 
 	it("auto-selects the recommended option when the selector does not settle", async () => {
 		vi.useFakeTimers();
-		const select = vi.fn(() => new Promise<string | undefined>(() => {}));
+		const select = vi.fn<AskSelect>(() => new Promise<string | undefined>(() => {}));
 		const abort = vi.fn();
 		const context = {
 			hasUI: true,
@@ -87,5 +95,84 @@ describe("AskTool timeout", () => {
 		expect(result?.details?.selectedOptions).toEqual(["Postgres"]);
 		expect(result?.details?.timedOut).toBe(true);
 		expect(abort).not.toHaveBeenCalled();
+	});
+
+	it("honors selector timeout resets before using the fallback timeout", async () => {
+		vi.useFakeTimers();
+		let resetTimeout: (() => void) | undefined;
+		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
+			resetTimeout = dialogOptions?.onTimeoutReset;
+			return new Promise<string | undefined>(() => {});
+		});
+		const abort = vi.fn();
+		const context = {
+			hasUI: true,
+			ui: {
+				select,
+				editor: vi.fn(),
+			},
+			abort,
+		} as unknown as AgentToolContext;
+		let result: AskExecutionResult | undefined;
+		let rejection: unknown;
+
+		void createAskTool()
+			.execute(
+				"ask-timeout",
+				{
+					questions: [
+						{
+							id: "db",
+							question: "Which database?",
+							options: [{ label: "SQLite" }, { label: "Postgres" }],
+							recommended: 1,
+						},
+					],
+				},
+				undefined,
+				undefined,
+				context,
+			)
+			.then(
+				value => {
+					result = value;
+				},
+				error => {
+					rejection = error;
+				},
+			);
+
+		await drainMicrotasks();
+		expect(resetTimeout).toBeDefined();
+
+		vi.advanceTimersByTime(9);
+		resetTimeout?.();
+		vi.advanceTimersByTime(9);
+		await drainMicrotasks();
+
+		expect(result).toBeUndefined();
+
+		vi.advanceTimersByTime(1);
+		await drainMicrotasks();
+
+		expect(rejection).toBeUndefined();
+		expect(result?.details?.selectedOptions).toEqual(["Postgres"]);
+		expect(result?.details?.timedOut).toBe(true);
+		expect(abort).not.toHaveBeenCalled();
+	});
+
+	it("notifies callers when selector input resets the UI countdown", () => {
+		vi.useFakeTimers();
+		const onTimeoutReset = vi.fn();
+		const selector = new HookSelectorComponent("Pick one", ["SQLite", "Postgres"], vi.fn(), vi.fn(), {
+			timeout: 10,
+			tui: { requestRender: vi.fn() } as unknown as TUI,
+			onTimeoutReset,
+		});
+
+		selector.handleInput("j");
+
+		expect(onTimeoutReset).toHaveBeenCalledTimes(1);
+		selector.dispose();
 	});
 });

--- a/packages/coding-agent/test/ask-timeout.test.ts
+++ b/packages/coding-agent/test/ask-timeout.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { AgentToolContext, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { getThemeByName, setThemeInstance } from "../src/modes/theme/theme";
+import type { ToolSession } from "../src/tools";
+import { AskTool, type AskToolDetails } from "../src/tools/ask";
+
+type AskExecutionResult = AgentToolResult<AskToolDetails>;
+
+async function drainMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+function createAskTool(): AskTool {
+	return new AskTool({
+		hasUI: true,
+		settings: {
+			get(key: string): unknown {
+				if (key === "ask.timeout") return 0.01;
+				if (key === "ask.notify") return "off";
+				if (key === "speech.enabled") return false;
+				return undefined;
+			},
+		},
+		getPlanModeState: () => ({ enabled: false }),
+	} as unknown as ToolSession);
+}
+
+describe("AskTool timeout", () => {
+	beforeAll(async () => {
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("theme unavailable");
+		setThemeInstance(loaded);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("auto-selects the recommended option when the selector does not settle", async () => {
+		vi.useFakeTimers();
+		const select = vi.fn(() => new Promise<string | undefined>(() => {}));
+		const abort = vi.fn();
+		const context = {
+			hasUI: true,
+			ui: {
+				select,
+				editor: vi.fn(),
+			},
+			abort,
+		} as unknown as AgentToolContext;
+		let result: AskExecutionResult | undefined;
+		let rejection: unknown;
+
+		void createAskTool()
+			.execute(
+				"ask-timeout",
+				{
+					questions: [
+						{
+							id: "db",
+							question: "Which database?",
+							options: [{ label: "SQLite" }, { label: "Postgres" }],
+							recommended: 1,
+						},
+					],
+				},
+				undefined,
+				undefined,
+				context,
+			)
+			.then(
+				value => {
+					result = value;
+				},
+				error => {
+					rejection = error;
+				},
+			);
+
+		await drainMicrotasks();
+		vi.advanceTimersByTime(10);
+		await drainMicrotasks();
+
+		expect(rejection).toBeUndefined();
+		expect(result?.details?.selectedOptions).toEqual(["Postgres"]);
+		expect(result?.details?.timedOut).toBe(true);
+		expect(abort).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/ask-timeout.test.ts
+++ b/packages/coding-agent/test/ask-timeout.test.ts
@@ -48,7 +48,10 @@ describe("AskTool timeout", () => {
 
 	it("auto-selects the recommended option when the selector does not settle", async () => {
 		vi.useFakeTimers();
-		const select = vi.fn<AskSelect>(() => new Promise<string | undefined>(() => {}));
+		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
+			dialogOptions?.onTimeoutStart?.();
+			return new Promise<string | undefined>(() => {});
+		});
 		const abort = vi.fn();
 		const context = {
 			hasUI: true,
@@ -101,6 +104,7 @@ describe("AskTool timeout", () => {
 		vi.useFakeTimers();
 		let resetTimeout: (() => void) | undefined;
 		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
+			dialogOptions?.onTimeoutStart?.();
 			resetTimeout = dialogOptions?.onTimeoutReset;
 			return new Promise<string | undefined>(() => {});
 		});
@@ -161,17 +165,83 @@ describe("AskTool timeout", () => {
 		expect(abort).not.toHaveBeenCalled();
 	});
 
-	it("notifies callers when selector input resets the UI countdown", () => {
+	it("does not run the fallback timeout while the selector is queued", async () => {
 		vi.useFakeTimers();
+		let startTimeout: (() => void) | undefined;
+		const select = vi.fn<AskSelect>((_title, _options, dialogOptions) => {
+			startTimeout = dialogOptions?.onTimeoutStart;
+			return new Promise<string | undefined>(() => {});
+		});
+		const abort = vi.fn();
+		const context = {
+			hasUI: true,
+			ui: {
+				select,
+				editor: vi.fn(),
+			},
+			abort,
+		} as unknown as AgentToolContext;
+		let result: AskExecutionResult | undefined;
+		let rejection: unknown;
+
+		void createAskTool()
+			.execute(
+				"ask-timeout",
+				{
+					questions: [
+						{
+							id: "db",
+							question: "Which database?",
+							options: [{ label: "SQLite" }, { label: "Postgres" }],
+							recommended: 1,
+						},
+					],
+				},
+				undefined,
+				undefined,
+				context,
+			)
+			.then(
+				value => {
+					result = value;
+				},
+				error => {
+					rejection = error;
+				},
+			);
+
+		await drainMicrotasks();
+		expect(startTimeout).toBeDefined();
+
+		vi.advanceTimersByTime(10);
+		await drainMicrotasks();
+
+		expect(result).toBeUndefined();
+
+		startTimeout?.();
+		vi.advanceTimersByTime(10);
+		await drainMicrotasks();
+
+		expect(rejection).toBeUndefined();
+		expect(result?.details?.selectedOptions).toEqual(["Postgres"]);
+		expect(result?.details?.timedOut).toBe(true);
+		expect(abort).not.toHaveBeenCalled();
+	});
+
+	it("notifies callers when the selector countdown starts and resets", () => {
+		vi.useFakeTimers();
+		const onTimeoutStart = vi.fn();
 		const onTimeoutReset = vi.fn();
 		const selector = new HookSelectorComponent("Pick one", ["SQLite", "Postgres"], vi.fn(), vi.fn(), {
 			timeout: 10,
 			tui: { requestRender: vi.fn() } as unknown as TUI,
+			onTimeoutStart,
 			onTimeoutReset,
 		});
 
 		selector.handleInput("j");
 
+		expect(onTimeoutStart).toHaveBeenCalledTimes(1);
 		expect(onTimeoutReset).toHaveBeenCalledTimes(1);
 		selector.dispose();
 	});


### PR DESCRIPTION
## Repro
A minimal `AskTool` harness with `ask.timeout=0.01` and a UI `select` promise that never settles reproduced the hang: before the fix, `bun test ./tmp-repro-4995.test.ts` left `details.selectedOptions` undefined instead of returning the recommended `Postgres` option with `timedOut: true`.

## Cause
`packages/coding-agent/src/tools/ask.ts` delegated timeout enforcement entirely to the UI selector by passing `dialogOptions.timeout`. If that UI surface failed to resolve or call `onTimeout`, `askSingleQuestion()` stayed parked in `ui.select(...)`, so the fallback that auto-selects the recommended option never ran.

## Fix
- Added an `AbortController`-backed timeout guard inside the ask tool selector path, sharing the signal with the UI dialog so stalled selectors are closed at the configured deadline.
- Preserved existing UI timeout behavior and elapsed-time fallback while converting the tool-owned timeout abort into `timedOut: true` instead of a user cancellation.
- Added `packages/coding-agent/test/ask-timeout.test.ts` covering a selector that never settles and asserting the recommended option is returned without aborting the turn.
- Added an unreleased changelog entry for the coding-agent package.

## Verification
`bun test ./packages/coding-agent/test/ask-timeout.test.ts` passed with 1 test and 4 assertions. `bun --cwd=packages/coding-agent run check` passed. `gh_push_branch` completed the pre-publish gate and pushed `farm/dbddd1ee/fix-question-tool-timeouts`. Fixes #4995