### PR TITLE
fix(discovery): load rules from marketplace plugins

### DIFF
--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -15,7 +15,7 @@ In the TUI, `/marketplace` with no arguments opens the interactive plugin browse
 
 A **marketplace** is a Git repository (or local directory) containing a catalog file at `.omp-plugin/marketplace.json` (preferred) or `.claude-plugin/marketplace.json` (Claude Code-compatible fallback). The catalog lists available plugins with their sources, descriptions, and metadata.
 
-A **plugin** is a directory containing Claude/OMP plugin content such as skills, commands, agents, hooks, tools, MCP servers, or LSP servers. Extension modules (`package.json` `omp.extensions` entry points) are not loaded from marketplace installs — they only load for npm-installed or `omp plugin link`ed plugins. Plugins are identified by `name@marketplace` (e.g. `code-review@claude-plugins-official`).
+A **plugin** is a directory containing Claude/OMP plugin content such as skills, commands, agents, hooks, tools, MCP servers, LSP servers, or rules (conventional `rules/*.md` and `rules/*.mdc` files). Extension modules (`package.json` `omp.extensions` entry points) are not loaded from marketplace installs — they only load for npm-installed or `omp plugin link`ed plugins. Plugins are identified by `name@marketplace` (e.g. `code-review@claude-plugins-official`).
 
 **Scopes**: marketplace plugins can be installed at two scopes:
 

--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -16,6 +16,7 @@ It reflects the current implementation, including partial semantics and metadata
 - [`packages/coding-agent/src/discovery/helpers.ts`](../packages/coding-agent/src/discovery/helpers.ts)
 - [`packages/coding-agent/src/discovery/builtin.ts`](../packages/coding-agent/src/discovery/builtin.ts)
 - [`packages/coding-agent/src/discovery/omp-plugins.ts`](../packages/coding-agent/src/discovery/omp-plugins.ts)
+- [`packages/coding-agent/src/discovery/claude-plugins.ts`](../packages/coding-agent/src/discovery/claude-plugins.ts)
 - [`packages/coding-agent/src/discovery/builtin-defaults.ts`](../packages/coding-agent/src/discovery/builtin-defaults.ts)
 - [`packages/coding-agent/src/discovery/agents.ts`](../packages/coding-agent/src/discovery/agents.ts)
 - [`packages/coding-agent/src/discovery/cursor.ts`](../packages/coding-agent/src/discovery/cursor.ts)
@@ -56,6 +57,7 @@ Consequence: precedence and deduplication are **name-based only**. Two different
 
 - `native` (priority `100`)
 - `omp-plugins` (priority `90`) — `rules/*.{md,mdc}` inside configured extension package roots, normalized via the shared `buildRuleFromMarkdown` path
+- `claude-plugins` (priority `70`) — `rules/*.{md,mdc}` inside resolved marketplace plugin roots (Claude Code plugin cache plus OMP user/project plugin registries, via `listClaudePluginRoots`), normalized via the shared `buildRuleFromMarkdown` path; each rule's `_source` level is the plugin's `root.scope` (`user` or `project`)
 - `agents` (priority `70`)
 - `cursor` (priority `50`)
 - `windsurf` (priority `50`)
@@ -155,18 +157,20 @@ Ambiguity consequences:
 ### Precedence model
 
 - Providers are ordered by priority descending.
-- Equal priority keeps registration order (`cursor` before `windsurf` from `discovery/index.ts`).
+- Equal priority keeps registration order (`cursor` before `windsurf`, and `claude-plugins` before `agents`, per import order in `discovery/index.ts`).
+- `native` (priority `100`) is the highest-priority rules source, so project/user `.omp/rules` and `RULES.md` rules always take precedence over same-named marketplace (`claude-plugins`), extension-package (`omp-plugins`), and other rules.
 - Dedup is first-wins: first encountered rule name is kept; later same-name items are marked `_shadowed` in `all` and excluded from `items`.
 
 Effective rule provider order is currently:
 
 1. `native` (100)
 2. `omp-plugins` (90)
-3. `agents` (70)
-4. `cursor` (50)
-5. `windsurf` (50)
-6. `cline` (40)
-7. `builtin-defaults` (1)
+3. `claude-plugins` (70)
+4. `agents` (70)
+5. `cursor` (50)
+6. `windsurf` (50)
+7. `cline` (40)
+8. `builtin-defaults` (1)
 
 ### Intra-provider ordering caveat
 
@@ -176,6 +180,7 @@ Notable source-order differences:
 
 - `native` appends project `.omp/rules`, user `~/.omp/agent/rules`, user `RULES.md`, then nearest project `RULES.md`.
 - `omp-plugins` appends `rules/` results per configured extension package root.
+- `claude-plugins` appends `rules/` results per resolved marketplace plugin root, in `listClaudePluginRoots` order (injected `--plugin-dir` roots and project-scope roots before user-scope roots), so a project-scope marketplace plugin's rule wins a same-named user-scope plugin's rule within this provider.
 - `agents` appends project-walk `.agent`/`.agents` rule dirs before user home dirs.
 - `cursor` appends user then project results.
 - `windsurf` appends user `global_rules` first, then project rules.
@@ -261,7 +266,7 @@ Implications:
 
 ## 9. Known partial / non-enforced semantics
 
-1. The rule providers currently loaded for `rules` are `native`, `omp-plugins`, `agents`, `cursor`, `windsurf`, `cline`, and embedded `builtin-defaults`; provider files for other tools may parse other config formats but do not register rule loaders.
+1. The rule providers currently loaded for `rules` are `native`, `omp-plugins`, `claude-plugins`, `agents`, `cursor`, `windsurf`, `cline`, and embedded `builtin-defaults`; provider files for other tools may parse other config formats but do not register rule loaders.
 2. `globs` metadata is surfaced to prompt/UI and is used as a global path gate for TTSR matching, but it is not used to automatically select rulebook rules for `rule://`.
 3. Rule selection for `rule://` includes rulebook, always-apply, and registered TTSR rules (so a triggered TTSR rule can be re-read), but not rules that registered no condition and carry neither a description nor `alwaysApply`.
 4. Discovery warnings (`loadCapability("rules").warnings`) are produced but `createAgentSession` does not currently surface/log them in this path.

--- a/docs/skills/authoring-marketplaces.md
+++ b/docs/skills/authoring-marketplaces.md
@@ -201,6 +201,7 @@ my-plugin/
   agents/*.md              ← subagent definitions
   hooks/pre/, hooks/post/  ← hooks
   tools/                   ← custom tools
+  rules/*.md, rules/*.mdc  ← rules (loaded via the marketplace/claude-plugins provider, priority 70)
   .mcp.json                ← MCP server definitions
   package.json             ← optional; its version is a fallback when the catalog entry has no version
   README.md                ← recommended: description + usage

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `rules/*.md` and `rules/*.mdc` discovery for installed marketplace plugins, including OMP user/project scope and existing rule precedence.
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -11,11 +11,13 @@ import { registerProvider } from "../capability";
 import { readFile } from "../capability/fs";
 import { type Hook, hookCapability } from "../capability/hook";
 import { type MCPServer, mcpCapability } from "../capability/mcp";
+import { type Rule, ruleCapability } from "../capability/rule";
 import { type Skill, skillCapability } from "../capability/skill";
 import { type SlashCommand, slashCommandCapability } from "../capability/slash-command";
 import { type CustomTool, toolCapability } from "../capability/tool";
 import type { LoadContext, LoadResult } from "../capability/types";
 import {
+	buildRuleFromMarkdown,
 	type ClaudePluginRoot,
 	createSourceMeta,
 	expandEnvVarsDeep,
@@ -335,6 +337,35 @@ async function loadHooks(ctx: LoadContext): Promise<LoadResult<Hook>> {
 }
 
 // =============================================================================
+// Rules
+// =============================================================================
+
+async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
+	const items: Rule[] = [];
+	const warnings: string[] = [];
+
+	const { roots, warnings: rootWarnings } = await listClaudePluginRoots(ctx.home, ctx.cwd);
+	warnings.push(...rootWarnings);
+
+	const results = await Promise.all(
+		roots.map(async root =>
+			loadFilesFromDir<Rule>(ctx, path.join(root.path, "rules"), PROVIDER_ID, root.scope, {
+				extensions: ["md", "mdc"],
+				transform: (name, content, filePath, source) =>
+					buildRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
+			}),
+		),
+	);
+
+	for (const result of results) {
+		items.push(...result.items);
+		if (result.warnings) warnings.push(...result.warnings);
+	}
+
+	return { items, warnings };
+}
+
+// =============================================================================
 // Custom Tools
 // =============================================================================
 
@@ -489,6 +520,14 @@ registerProvider<Hook>(hookCapability.id, {
 	description: "Load hooks from Claude Code marketplace plugins",
 	priority: PRIORITY,
 	load: loadHooks,
+});
+
+registerProvider<Rule>(ruleCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: "Load rules from Claude Code marketplace plugins",
+	priority: PRIORITY,
+	load: loadRules,
 });
 
 registerProvider<CustomTool>(toolCapability.id, {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -1044,7 +1044,10 @@ describe("marketplace plugin rules", () => {
 				},
 			}),
 		);
-		await fs.writeFile(path.join(pluginPath, "rules", "alpha.md"), "---\ndescription: Alpha rule\n---\nAlpha body.\n");
+		await fs.writeFile(
+			path.join(pluginPath, "rules", "alpha.md"),
+			"---\ndescription: Alpha rule\n---\nAlpha body.\n",
+		);
 		await fs.writeFile(path.join(pluginPath, "rules", "beta.mdc"), "---\ndescription: Beta rule\n---\nBeta body.\n");
 
 		const result = await loadCapability<Rule>(ruleCapability.id, { cwd: tempDir, providers: ["claude-plugins"] });

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -11,9 +11,10 @@ import {
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { loadSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/slash-commands";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
-import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { getAgentDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import { type Rule, ruleCapability } from "@oh-my-pi/pi-coding-agent/capability/rule";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import type { SlashCommand } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
 
@@ -992,6 +993,332 @@ describe("listClaudePluginRoots", () => {
 		expect(result.warnings).toEqual([]);
 		expect(result.all.find(c => c.name === "manifest-commands-replace:admin")).toBeDefined();
 		expect(result.all.find(c => c.name === "manifest-commands-replace:default")).toBeUndefined();
+	});
+});
+
+describe("marketplace plugin rules", () => {
+	let tempDir: string;
+	let originalHome: string | undefined;
+
+	beforeEach(async () => {
+		clearClaudePluginRootsCache();
+		clearFsCache();
+		originalHome = process.env.HOME;
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-rules-test-"));
+		process.env.HOME = tempDir;
+		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
+	});
+
+	afterEach(async () => {
+		clearClaudePluginRootsCache();
+		clearFsCache();
+		vi.restoreAllMocks();
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		await removeWithRetries(tempDir);
+	});
+
+	test("loads rules/*.md and rules/*.mdc from a user-scoped OMP plugin registry", async () => {
+		const ompPluginsDir = path.join(tempDir, ".omp", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "rule-pack");
+		await fs.mkdir(ompPluginsDir, { recursive: true });
+		await fs.mkdir(path.join(pluginPath, "rules"), { recursive: true });
+
+		await fs.writeFile(
+			path.join(ompPluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"rule-pack@market": [
+						{
+							scope: "user",
+							installPath: pluginPath,
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(path.join(pluginPath, "rules", "alpha.md"), "---\ndescription: Alpha rule\n---\nAlpha body.\n");
+		await fs.writeFile(path.join(pluginPath, "rules", "beta.mdc"), "---\ndescription: Beta rule\n---\nBeta body.\n");
+
+		const result = await loadCapability<Rule>(ruleCapability.id, { cwd: tempDir, providers: ["claude-plugins"] });
+		expect(result.warnings).toEqual([]);
+
+		const alpha = result.items.find(rule => rule.name === "alpha");
+		const beta = result.items.find(rule => rule.name === "beta");
+
+		expect(alpha).toBeDefined();
+		expect(beta).toBeDefined();
+		expect(alpha?._source.provider).toBe("claude-plugins");
+		expect(alpha?._source.level).toBe("user");
+		expect(beta?._source.level).toBe("user");
+	});
+
+	test("preserves canonical frontmatter metadata and strips body/name from marketplace rule files", async () => {
+		const ompPluginsDir = path.join(tempDir, ".omp", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "style-pack");
+		await fs.mkdir(ompPluginsDir, { recursive: true });
+		await fs.mkdir(path.join(pluginPath, "rules"), { recursive: true });
+
+		await fs.writeFile(
+			path.join(ompPluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"style-pack@market": [
+						{
+							scope: "user",
+							installPath: pluginPath,
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		const ruleFile = path.join(pluginPath, "rules", "commit-style.md");
+		await fs.writeFile(
+			ruleFile,
+			[
+				"---",
+				"description: Enforce conventional commit subjects",
+				"alwaysApply: true",
+				"globs:",
+				'  - "**/*.md"',
+				"---",
+				"",
+				"Use conventional commit subjects.",
+				"Keep the body under 72 columns.",
+				"",
+			].join("\n"),
+		);
+
+		const result = await loadCapability<Rule>(ruleCapability.id, { cwd: tempDir, providers: ["claude-plugins"] });
+		const rule = result.items.find(item => item.name === "commit-style");
+
+		expect(rule).toBeDefined();
+		expect(rule?.description).toBe("Enforce conventional commit subjects");
+		expect(rule?.alwaysApply).toBe(true);
+		expect(rule?.globs).toEqual(["**/*.md"]);
+		expect(rule?.content).toBe("Use conventional commit subjects.\nKeep the body under 72 columns.");
+		expect(rule?.path).toBe(ruleFile);
+	});
+
+	test("project-scoped OMP plugin shadows a same-ID user-scoped plugin and reports project-level rules", async () => {
+		const userPluginsDir = path.join(tempDir, ".omp", "plugins");
+		const userPluginPath = path.join(tempDir, "plugins", "user-shared");
+		const projectDir = path.join(tempDir, "project");
+		const projectPluginsDir = path.join(projectDir, ".omp", "plugins");
+		const projectPluginPath = path.join(tempDir, "plugins", "project-shared");
+
+		await fs.mkdir(userPluginsDir, { recursive: true });
+		await fs.mkdir(path.join(userPluginPath, "rules"), { recursive: true });
+		await fs.mkdir(projectPluginsDir, { recursive: true });
+		await fs.mkdir(path.join(projectPluginPath, "rules"), { recursive: true });
+
+		await fs.writeFile(
+			path.join(userPluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"shared-plugin@market": [
+						{
+							scope: "user",
+							installPath: userPluginPath,
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(
+			path.join(projectPluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"shared-plugin@market": [
+						{
+							scope: "project",
+							installPath: projectPluginPath,
+							version: "2.0.0",
+							installedAt: "2025-01-02T00:00:00Z",
+							lastUpdated: "2025-01-02T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(path.join(userPluginPath, "rules", "shared.md"), "User scope rule body.\n");
+		await fs.writeFile(path.join(projectPluginPath, "rules", "shared.md"), "Project scope rule body.\n");
+
+		const result = await loadCapability<Rule>(ruleCapability.id, { cwd: projectDir, providers: ["claude-plugins"] });
+		const shared = result.items.filter(item => item.name === "shared");
+
+		expect(shared).toHaveLength(1);
+		expect(shared[0].content).toBe("Project scope rule body.\n");
+		expect(shared[0]._source.level).toBe("project");
+		expect(shared[0]._source.path).toContain(projectPluginPath);
+		expect(result.all.filter(item => item.name === "shared")).toHaveLength(1);
+	});
+
+	test("disabled marketplace plugin entries contribute no rules while enabled siblings still load", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const disabledPluginPath = path.join(tempDir, "plugins", "disabled-pack");
+		const enabledPluginPath = path.join(tempDir, "plugins", "enabled-pack");
+		await fs.mkdir(pluginsDir, { recursive: true });
+		await fs.mkdir(path.join(disabledPluginPath, "rules"), { recursive: true });
+		await fs.mkdir(path.join(enabledPluginPath, "rules"), { recursive: true });
+
+		await fs.writeFile(
+			path.join(pluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"disabled-pack@market": [
+						{
+							scope: "user",
+							installPath: disabledPluginPath,
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+							enabled: false,
+						},
+					],
+					"enabled-pack@market": [
+						{
+							scope: "user",
+							installPath: enabledPluginPath,
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+							enabled: true,
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(path.join(disabledPluginPath, "rules", "note.md"), "Should never load.\n");
+		await fs.writeFile(path.join(enabledPluginPath, "rules", "sentinel.md"), "Should load.\n");
+
+		const result = await loadCapability<Rule>(ruleCapability.id, { cwd: tempDir, providers: ["claude-plugins"] });
+
+		expect(result.warnings).toEqual([]);
+		expect(result.items.find(item => item.name === "sentinel")).toBeDefined();
+		expect(result.items.find(item => item.name === "note")).toBeUndefined();
+		expect(result.all.filter(item => item.name === "note")).toHaveLength(0);
+	});
+
+	test("native same-name rule wins capability dedup over the priority-70 marketplace rule", async () => {
+		const originalAgentDir = getAgentDir();
+		const nativeAgentDir = path.join(tempDir, "agent");
+		try {
+			setAgentDir(nativeAgentDir);
+			await fs.mkdir(path.join(nativeAgentDir, "rules"), { recursive: true });
+			await fs.writeFile(path.join(nativeAgentDir, "rules", "shared-rule.md"), "Native version.\n");
+
+			const ompPluginsDir = path.join(tempDir, ".omp", "plugins");
+			const pluginPath = path.join(tempDir, "plugins", "conflicting-pack");
+			await fs.mkdir(ompPluginsDir, { recursive: true });
+			await fs.mkdir(path.join(pluginPath, "rules"), { recursive: true });
+			await fs.writeFile(
+				path.join(ompPluginsDir, "installed_plugins.json"),
+				JSON.stringify({
+					version: 2,
+					plugins: {
+						"conflicting-pack@market": [
+							{
+								scope: "user",
+								installPath: pluginPath,
+								version: "1.0.0",
+								installedAt: "2025-01-01T00:00:00Z",
+								lastUpdated: "2025-01-01T00:00:00Z",
+							},
+						],
+					},
+				}),
+			);
+			await fs.writeFile(path.join(pluginPath, "rules", "shared-rule.md"), "Marketplace version.\n");
+
+			const result = await loadCapability<Rule>(ruleCapability.id, {
+				cwd: tempDir,
+				providers: ["native", "claude-plugins"],
+			});
+			const winners = result.items.filter(item => item.name === "shared-rule");
+			const all = result.all.filter(item => item.name === "shared-rule");
+
+			expect(winners).toHaveLength(1);
+			expect(winners[0].content).toBe("Native version.\n");
+			expect(winners[0]._source.provider).toBe("native");
+			expect(all).toHaveLength(2);
+			expect(all.find(item => item._source.provider === "claude-plugins")?._shadowed).toBe(true);
+		} finally {
+			setAgentDir(originalAgentDir);
+		}
+	});
+
+	test("plugin visible in both the Claude and OMP registries under the same ID does not duplicate its rules", async () => {
+		const claudePluginsDir = path.join(tempDir, ".claude", "plugins");
+		const ompPluginsDir = path.join(tempDir, ".omp", "plugins");
+		const claudePluginPath = path.join(tempDir, "plugins", "claude-copy");
+		const ompPluginPath = path.join(tempDir, "plugins", "omp-copy");
+
+		await fs.mkdir(claudePluginsDir, { recursive: true });
+		await fs.mkdir(ompPluginsDir, { recursive: true });
+		await fs.mkdir(path.join(claudePluginPath, "rules"), { recursive: true });
+		await fs.mkdir(path.join(ompPluginPath, "rules"), { recursive: true });
+
+		await fs.writeFile(
+			path.join(claudePluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"dup-plugin@market": [
+						{
+							scope: "user",
+							installPath: claudePluginPath,
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(
+			path.join(ompPluginsDir, "installed_plugins.json"),
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"dup-plugin@market": [
+						{
+							scope: "user",
+							installPath: ompPluginPath,
+							version: "1.1.0",
+							installedAt: "2025-01-02T00:00:00Z",
+							lastUpdated: "2025-01-02T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+		await fs.writeFile(path.join(claudePluginPath, "rules", "dup.md"), "Claude registry copy.\n");
+		await fs.writeFile(path.join(ompPluginPath, "rules", "dup.md"), "OMP registry copy.\n");
+
+		const result = await loadCapability<Rule>(ruleCapability.id, { cwd: tempDir, providers: ["claude-plugins"] });
+		const dup = result.all.filter(item => item.name === "dup");
+
+		expect(dup).toHaveLength(1);
+		expect(dup[0].content).toBe("OMP registry copy.\n");
+		expect(dup[0]._source.path).toContain(ompPluginPath);
 	});
 });
 


### PR DESCRIPTION
## Summary

- register `ruleCapability` in the marketplace (`claude-plugins`) provider
- discover conventional `rules/*.md` and `rules/*.mdc` files through `buildRuleFromMarkdown`
- preserve user/project scope, existing provider precedence, project shadowing, and OMP-over-Claude registry authority
- document marketplace rule packaging and rulebook precedence

## Context

`omp-plugins` already loads rules from configured/npm/link extension packages, but marketplace roots are intentionally excluded from that provider and handled by `claude-plugins`. That provider loaded skills, commands, hooks, tools, and MCP servers but not rules, so installed marketplace rule packs were silently inert.

This reimplements the closed #519 / #530 change against the current provider split and registry behavior.

## Verification

- `nix shell nixpkgs#bun -c bun test packages/coding-agent/test/discovery/claude-plugins.test.ts` — 36 pass, 0 fail, 107 assertions
- `nix shell nixpkgs#bun -c ./node_modules/.bin/biome check packages/coding-agent/src/discovery/claude-plugins.ts packages/coding-agent/test/discovery/claude-plugins.test.ts` — clean
- mutation check: removing the new rule-provider registration makes all six added cases fail