### PR TITLE
fix(edit): reject nested apply_patch envelopes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Rejected nested `*** Begin Patch` and premature `*** End Patch` markers instead of treating them as update content and applying a malformed multi-envelope patch.
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/edit/apply-patch/parser.ts
+++ b/packages/coding-agent/src/edit/apply-patch/parser.ts
@@ -74,6 +74,9 @@ function parseApplyPatchWithOptions(patchText: string, options: ParseApplyPatchO
 	if (!hasEndMarker && !streaming) {
 		throw new ParseError("The last line of the patch must be '*** End Patch'");
 	}
+	if (!streaming) {
+		validateCompleteEnvelopeMarkers(lines);
+	}
 
 	const hunks: PatchInput[] = [];
 	let remaining = hasEndMarker ? lines.slice(1, lines.length - 1) : lines.slice(1);
@@ -171,4 +174,17 @@ function parseApplyPatchWithOptions(patchText: string, options: ParseApplyPatchO
 	}
 
 	return hunks;
+}
+
+function validateCompleteEnvelopeMarkers(lines: string[]): void {
+	for (let index = 0; index < lines.length; index++) {
+		const marker = lines[index].trim();
+		const lineNumber = index + 1;
+		if (marker === BEGIN_PATCH_MARKER && index !== 0) {
+			throw new ParseError("Nested '*** Begin Patch' markers are not allowed", lineNumber);
+		}
+		if (marker === END_PATCH_MARKER && index !== lines.length - 1) {
+			throw new ParseError("Nested '*** End Patch' markers are not allowed", lineNumber);
+		}
+	}
 }

--- a/packages/coding-agent/test/core/apply-patch.test.ts
+++ b/packages/coding-agent/test/core/apply-patch.test.ts
@@ -639,6 +639,33 @@ describe("parseApplyPatch (production)", () => {
 		const result = parseApplyPatch(wrap("*** Update File: a.py\n@@\n-x\n+y\n*** End of File"));
 		expect(result[0].diff).toContain("*** End of File");
 	});
+
+	test("rejects an end marker before another file operation", () => {
+		const patch = `*** Begin Patch
+*** Update File: scripts/example.py
+@@
++N_TRAIN = 512
+*** End Patch
+*** Update File: scripts/example.py
+@@
++BATCH = 512
+*** End Patch`;
+
+		expect(() => parseApplyPatch(patch)).toThrow(ParseError);
+		expect(() => parseApplyPatch(patch)).toThrow("Nested '*** End Patch' markers are not allowed");
+	});
+
+	test("rejects a nested begin marker", () => {
+		const patch = `*** Begin Patch
+*** Update File: scripts/example.py
+@@
++N_TRAIN = 512
+*** Begin Patch
+*** End Patch`;
+
+		expect(() => parseApplyPatch(patch)).toThrow(ParseError);
+		expect(() => parseApplyPatch(patch)).toThrow("Nested '*** Begin Patch' markers are not allowed");
+	});
 });
 
 describe("applyCodexPatch (production)", () => {


### PR DESCRIPTION
## Summary

- reject nested `*** Begin Patch` markers in complete apply_patch envelopes
- reject premature `*** End Patch` markers instead of treating them as update diff content
- keep streaming preview parsing lenient for incomplete in-progress envelopes

## Why

A malformed payload containing an inner `*** End Patch` followed by another file operation was accepted as one patch. The inner marker became update diff content, allowing unintended duplicate insertions instead of failing the malformed envelope.

## Tests

- `bun test ./packages/coding-agent/test/core/apply-patch.test.ts` (80 pass)
- `bun run check` in `packages/coding-agent`