### PR TITLE
fix(tools): clarify background job wakeups

### DIFF
--- a/docs/tools/bash.md
+++ b/docs/tools/bash.md
@@ -42,7 +42,7 @@ The tool returns a single `text` content block plus optional `details`.
   - `details.meta.truncation`: present when output was truncated in memory; includes `artifactId` when full output spilled to an artifact.
   - non-zero exits return a tool result marked `isError` with output plus `Command exited with code <n>`; they are not thrown.
 - Success, background start (`async: true` or auto-background):
-  - `content[0].text`: optional preview tail, timeout notice if any, then `Background job <id> started: <label>` with follow-up instructions.
+  - `content[0].text`: optional preview tail, timeout notice if any, then `Background job <id> started: <label>` with follow-up instructions. The final result is delivered automatically and wakes the agent; the agent does not need to sleep-loop or poll just to wait.
   - `details.async`: `{ state: "running", jobId, type: "bash" }`.
 - Background progress / completion:
   - delivered through `onUpdate` / async job manager, not the initial return.
@@ -90,7 +90,7 @@ Stdout and stderr are merged before the model sees them. Definite non-zero exit 
    - Supports interactive input; `Esc` kills the session from the overlay.
 4. Explicit background job
    - Requires `async: true` and `async.enabled`.
-   - Registers a job with `session.asyncJobManager` and returns `{ state: "running", jobId }` immediately.
+   - Registers a job with `session.asyncJobManager` and returns `{ state: "running", jobId }` immediately. On completion, the async-result delivery wakes the agent automatically.
 5. Auto-backgrounded non-PTY job
    - Requires `bash.autoBackground.enabled`, no PTY, and an async job manager.
    - Starts like a foreground managed job, then backgrounds it when it outlives the wait window.
@@ -115,7 +115,7 @@ Stdout and stderr are merged before the model sees them. Definite non-zero exit 
   - Invalidates `github-cache` rows before execution when the command contains a mutating `gh issue`/`gh pr` subcommand, so later `issue://`/`pr://` reads see post-mutation state (`invalidateGithubCacheForBashCommand`).
 - User-visible prompts / interactive UI
   - PTY mode opens a TUI overlay titled `Console` and forwards input to the PTY.
-  - Background start messages note that the result is delivered automatically when complete and that the `job` tool can poll until then.
+  - Background start messages note that the result is delivered automatically when complete and that the `job` tool is only for deliberate progress inspection, cancellation, or blocking when no other work is possible.
 - Background work / cancellation
   - Async and auto-background jobs continue after the initial tool return.
   - Cancellation aborts the native run; PTY overlay dismissal also kills the PTY.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Clarified that background-job completion automatically wakes the agent, and discouraged sleep loops or repeated `job` polling while work is still running.
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/prompts/tools/async-result.md
+++ b/packages/coding-agent/src/prompts/tools/async-result.md
@@ -1,7 +1,7 @@
 <system-notice>
-{{#if multiple}}{{jobs.length}} background jobs have completed. Resume your work using the results below.
+{{#if multiple}}{{jobs.length}} background jobs have completed. This is the automatic wake-up for those jobs; resume your work using the results below.
 
-{{else}}Background job {{jobs.[0].jobId}} has completed. Resume your work using the result below.
+{{else}}Background job {{jobs.[0].jobId}} has completed. This is the automatic wake-up for that job; resume your work using the result below.
 {{/if}}{{#each jobs}}{{#if @root.multiple}}── Job {{this.jobId}}{{#if this.label}} ({{this.label}}){{/if}} ──
 {{/if}}{{this.result}}{{#unless @last}}
 {{/unless}}{{/each}}

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -33,7 +33,8 @@ Use bash ONLY for: a single binary call, or one short pipeline that COMPUTES a f
 - Internal URIs (`skill://`, `agent://`, …) auto-resolve to FS paths
 {{#if hasEval}}- Need exact pipeline semantics (`cmd | head`, multi-stage filtering) or output truncation? Prefer `eval` and process the stream directly.{{else}}- Need exact pipeline semantics (`cmd | head`, multi-stage filtering) or output truncation? Use a checked-in script, purpose-built tool, or single command that owns the output shape.{{/if}}
 {{#if asyncEnabled}}
-- `async: true` for long-running commands when you don't need immediate output: returns a background job ID; result delivered as a follow-up.
+- `async: true` for long-running commands when you don't need immediate output: returns a background job ID; result delivered as a follow-up that wakes you automatically.
+- After starting an async/background job, do useful independent work or stop naturally. NEVER run `sleep` loops or repeated status checks just to wait; OMP will wake you when the job finishes. Use the `job` tool only to inspect progress, cancel, or block when truly no other work is possible.
 {{/if}}
 </instruction>
 
@@ -60,7 +61,8 @@ Use bash ONLY for: a single binary call, or one short pipeline that COMPUTES a f
 
 ## Auto-background
 
-- A long-running foreground call may convert to a background job; the final result arrives as a follow-up tool call. NOT a failure — don't retry or wait synchronously.
+- A long-running foreground call may convert to a background job; the final result arrives as a follow-up tool call and wakes you automatically. NOT a failure — don't retry or wait synchronously.
+- If this happens, treat the current stop as a scheduling pause. Do not issue sleep/poll loops to wait for it; continue only when the follow-up result arrives or use `job` for deliberate lifecycle control.
 - Need the result inline (e.g. piping into another command)? Raise `timeout` above expected duration{{#if asyncEnabled}}, or set `async: true` up front{{/if}}.
 {{/if}}
 

--- a/packages/coding-agent/src/prompts/tools/job.md
+++ b/packages/coding-agent/src/prompts/tools/job.md
@@ -1,10 +1,10 @@
 Manages async background tasks (e.g. bash scripts, subagents).
 
-Background tasks deliver their results automatically the moment they finish. You NEVER need to poll to retrieve output. Only use this tool if you need to intervene in the lifecycle of a task.
+Background tasks deliver their results automatically the moment they finish and wake the session. You NEVER need to poll to retrieve output. Only use this tool if you need to intervene in the lifecycle of a task.
 
 # Interventions
 
-- **Block and wait:** Pass `poll` with specific job IDs when you are completely blocked and cannot do any other work. The call returns as soon as one watched job finishes, the wait window elapses, or an IRC / steering message interrupts the wait — NOT when all jobs finish; re-issue to keep waiting.
+- **Block and wait:** Pass `poll` with specific job IDs only when you are completely blocked and cannot do any other work. The call returns as soon as one watched job finishes, the wait window elapses, or an IRC / steering message interrupts the wait — NOT when all jobs finish. If it returns `Still Running`, do not immediately poll again; continue other work or stop and let automatic delivery wake you.
   - To watch EVERY running job, issue a call with NO fields at all (no `poll`, no `cancel`, no `list`). NEVER pass an array of every running ID.
   - A finished job's output, or the interrupting message and reason, is included in the next turn.
 - **Stop execution:** Pass `cancel` with job IDs to kill jobs that have hung, stalled, or are no longer needed. A cancel-only call returns immediately.

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -543,9 +543,9 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 			lines.push(...options.notices, "");
 		}
 		lines.push(`Background job ${jobId} started: ${label}`);
-		lines.push("Result will be delivered automatically when complete.");
+		lines.push("Result will be delivered automatically when complete and will wake the session.");
 		lines.push(
-			`You can use \`job\` to poll until complete, but prefer to continue with another task in the meanwhile if it's not blocking.`,
+			`Do not call \`job\` just to wait for output. Continue useful work, end the turn if blocked, or use \`job\` only for lifecycle control such as cancel/list or one deliberate blocking wait.`,
 		);
 		return {
 			content: [{ type: "text", text: lines.join("\n") }],

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -348,6 +348,13 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 			for (const j of running) {
 				lines.push(`- \`${j.id}\` [${j.type}] — ${j.label}`);
 			}
+			lines.push("");
+			lines.push(
+				"No new output is available yet. Background jobs deliver their final result automatically and wake the session when complete.",
+			);
+			lines.push(
+				"Do not call `job` again just to wait; continue useful work, end the turn if blocked, or cancel only if the job is no longer needed.",
+			);
 		}
 
 		const details: JobToolDetails = {

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1443,6 +1443,8 @@ function b() {
 			expect(result.details?.async?.type).toBe("bash");
 			expect(getTextOutput(result)).toContain("Background job");
 			expect(getTextOutput(result)).toContain("start");
+			expect(getTextOutput(result)).toContain("will wake the session");
+			expect(getTextOutput(result)).toContain("Do not call `job` just to wait");
 
 			const jobId = result.details?.async?.jobId;
 			if (!jobId) {
@@ -1637,10 +1639,18 @@ function b() {
 			const pollPromise = jobTool.execute("test-call-useless-poll", { poll: [jobId] }, controller.signal);
 			controller.abort();
 			const polled = await pollPromise;
+			expect(getTextOutput(polled)).toContain(
+				"Background jobs deliver their final result automatically and wake the session",
+			);
+			expect(getTextOutput(polled)).toContain("Do not call `job` again just to wait");
 			expect(polled.useless).toBe(true);
 
 			// A list snapshot showing only running jobs is equally uneventful.
 			const listed = await jobTool.execute("test-call-useless-list", { list: true });
+			expect(getTextOutput(listed)).toContain(
+				"Background jobs deliver their final result automatically and wake the session",
+			);
+			expect(getTextOutput(listed)).toContain("Do not call `job` again just to wait");
 			expect(listed.useless).toBe(true);
 
 			// Once the job settles, the result is informative — flag absent.


### PR DESCRIPTION
## Summary

- state explicitly that background-job completion wakes the agent automatically
- stop background Bash results from encouraging repeated `job` polling
- add actionable guidance to still-running JobTool results and bundled tool prompts
- document the same lifecycle contract in the Bash tool reference

## Why

Agents were repeatedly sleeping and polling background jobs because the Bash result said they could poll until completion, while the automatic completion delivery was not described as a session wakeup. This wastes turns and can look like a stalled harness.

## Tests

- `bun test ./packages/coding-agent/test/tools.test.ts --test-name-pattern "JobTool|auto-background"` (5 pass)
- `bun run check` in `packages/coding-agent`