### PR TITLE
fix(goals): rearm blocked continuation timer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Rearmed deferred autonomous goal continuations after streaming or post-prompt work instead of dropping the timer tick and potentially leaving an active goal idle indefinitely.
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1240,9 +1240,12 @@ export class InteractiveMode implements InteractiveModeContext {
 			// path that starts a turn while we wait) leaves the agent busy. Firing
 			// the continuation now would route through `submitInteractiveInput` →
 			// `promptCustomMessage` with no `streamingBehavior` and resurface
-			// `AgentBusyError`. Drop this tick; `#handleGoalSessionEvent` reschedules
-			// on the next `agent_end`.
-			if (this.#isAutoSubmitBlocked()) return;
+			// `AgentBusyError`. Rearm the timer because post-prompt work can clear
+			// without another `agent_end`, which would otherwise strand the goal.
+			if (this.#isAutoSubmitBlocked()) {
+				this.#scheduleGoalContinuation();
+				return;
+			}
 			if (this.#pendingSubmittedInput) return;
 			if (this.editor.getText().trim().length > 0) return;
 			if ((this.editor.pendingImages?.length ?? 0) > 0) return;

--- a/packages/coding-agent/test/goals/goal-mode-integration.test.ts
+++ b/packages/coding-agent/test/goals/goal-mode-integration.test.ts
@@ -390,15 +390,15 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(content).not.toContain("Run focused checks");
 	});
 
-	it("drops a goal continuation tick while the agent is streaming", async () => {
+	it("defers a goal continuation tick while the agent is streaming", async () => {
 		// Repro for the race the streaming guard on /goal set X exposed: the
 		// 800ms continuation timer armed by getUserInput() can outlive the idle
 		// window when streaming starts between schedule and fire (e.g. /goal set
 		// taking the streaming branch, or any extension that triggers a turn).
 		// Without the streaming-aware guard the timer fires onInputCallback
 		// with a `goal-continuation` and submitInteractiveInput resurfaces
-		// AgentBusyError via promptCustomMessage. Driven with fake timers so the
-		// 800ms window is exercised deterministically without a real wall-clock wait.
+		// AgentBusyError via promptCustomMessage. The tick must be deferred, not
+		// dropped, or an active goal can wait forever once post-prompt work clears.
 		await harness.mode.handleGoalModeCommand("Ship the release");
 
 		vi.useFakeTimers();
@@ -414,7 +414,10 @@ describe("InteractiveMode goal mode integration", () => {
 		expect(waiter.getResolvedText()).toBeUndefined();
 
 		streaming = false;
-		harness.mode.onInputCallback?.(harness.mode.startPendingSubmission({ text: "cleanup" }));
+		vi.advanceTimersByTime(800);
+		await waitForMicrotasks();
+
+		expect(waiter.getResolvedText()).toContain("Ship the release");
 		await waiter.inputPromise;
 	});
 


### PR DESCRIPTION
## Summary

- rearm the autonomous goal-continuation timer when streaming, compaction, or post-prompt work blocks submission
- preserve the existing scheduler guards for goal state, editor content, images, and pending input
- replace the test that codified a dropped tick with a deterministic deferred-continuation regression

## Why

The timer can fire after the idle window that scheduled it has ended. Returning while blocked assumes another `agent_end` will reschedule the continuation, but post-prompt work can clear without one. That leaves an active goal idle indefinitely at the input prompt.

## Tests

- `bun test ./packages/coding-agent/test/goals/goal-mode-integration.test.ts` (17 pass)
- `bun run check` in `packages/coding-agent`