### PR TITLE
fix(agent): finalize failed partial streams

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Finalized partial assistant output as an error turn when provider event iteration fails, preserving completed content while dropping unfinished tool calls.
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1375,6 +1375,39 @@ async function streamAssistantResponse(
 			const completedToolCallIds = new Set<string>();
 
 			const responseIterator = response[Symbol.asyncIterator]();
+			const finishFailedStream = async (error: unknown): Promise<AssistantMessage> => {
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				const failed: AssistantMessage = partialMessage
+					? { ...partialMessage, stopReason: "error", errorMessage }
+					: {
+							role: "assistant",
+							content: [],
+							api: model.api,
+							provider: model.provider,
+							model: model.id,
+							usage: {
+								input: 0,
+								output: 0,
+								cacheRead: 0,
+								cacheWrite: 0,
+								totalTokens: 0,
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+							},
+							stopReason: "error",
+							errorMessage,
+							timestamp: Date.now(),
+						};
+				const finalMessage = snapshotAssistantMessage(retainCompletedToolCalls(failed, completedToolCallIds));
+				if (addedPartial) {
+					context.messages[context.messages.length - 1] = finalMessage;
+				} else {
+					context.messages.push(finalMessage);
+					stream.push({ type: "message_start", message: snapshotAssistantMessage(finalMessage) });
+				}
+				stream.push({ type: "message_end", message: snapshotAssistantMessage(finalMessage) });
+				await finishChat(finalMessage);
+				return finalMessage;
+			};
 			const finishAbortedStream = async (): Promise<AssistantMessage> => {
 				try {
 					const cleanup = responseIterator.return?.();
@@ -1415,13 +1448,23 @@ async function streamAssistantResponse(
 				while (true) {
 					let next: IteratorResult<AssistantMessageEvent>;
 					if (abortRacePromise) {
-						const result = await Promise.race([responseIterator.next(), abortRacePromise]);
+						const result = await Promise.race([
+							responseIterator.next().catch(error => ({ error })),
+							abortRacePromise,
+						]);
 						if (result === ABORTED) {
 							return await finishAbortedStream();
 						}
+						if ("error" in result) {
+							return await finishFailedStream(result.error);
+						}
 						next = result;
 					} else {
-						next = await responseIterator.next();
+						try {
+							next = await responseIterator.next();
+						} catch (error) {
+							return await finishFailedStream(error);
+						}
 					}
 					if (next.done) break;
 
@@ -1532,7 +1575,12 @@ async function streamAssistantResponse(
 				detachAbortListener?.();
 			}
 
-			let trailing = await response.result();
+			let trailing: AssistantMessage;
+			try {
+				trailing = await response.result();
+			} catch (error) {
+				return await finishFailedStream(error);
+			}
 			if (harmonyMitigationEnabled) {
 				const detection = detectHarmonyLeakInAssistantMessage(trailing);
 				if (detection) {

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -7,6 +7,7 @@ import type {
 	AgentMessage,
 	AgentTool,
 	AgentToolContext,
+	StreamFn,
 	ToolCallContext,
 } from "@oh-my-pi/pi-agent-core/types";
 import type { AssistantMessage, AssistantMessageEvent, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
@@ -1000,6 +1001,56 @@ describe("agentLoop with AgentMessage", () => {
 		// The exclusive call waited for every shared call to finish.
 		expect(startTimes.exclusive).toBeGreaterThan(finishTimes.slow);
 		expect(startTimes.exclusive).toBeGreaterThan(finishTimes.fast);
+	});
+
+	it("finalizes partial output when provider event iteration fails", async () => {
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [] };
+		const errorMessage = "provider stream disconnected before toolcall_end";
+		const streamFn: StreamFn = () => {
+			const stream = new AssistantMessageEventStream();
+			const partial: AssistantMessage = {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Useful partial analysis." },
+					{ type: "toolCall", id: "tool-1", name: "bash", arguments: {} },
+				],
+				api: "openai-completions",
+				provider: "test-provider",
+				model: "test-model",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			};
+			queueMicrotask(() => {
+				stream.push({ type: "start", partial });
+				stream.push({ type: "text_start", contentIndex: 0, partial });
+				stream.push({ type: "text_delta", contentIndex: 0, delta: "Useful partial analysis.", partial });
+				stream.push({ type: "text_end", contentIndex: 0, content: "Useful partial analysis.", partial });
+				stream.push({ type: "toolcall_start", contentIndex: 1, partial });
+				stream.push({ type: "toolcall_delta", contentIndex: 1, delta: '{"command":"', partial });
+				stream.fail(new Error(errorMessage));
+			});
+			return stream;
+		};
+		const config: AgentLoopConfig = {
+			model: createMockModel({ responses: [] }).model,
+			convertToLlm: identityConverter,
+		};
+
+		const messages = await agentLoop([createUserMessage("continue")], context, config, undefined, streamFn).result();
+
+		expect(messages.map(message => message.role)).toEqual(["user", "assistant"]);
+		const failedTurn = messages[1] as AssistantMessage;
+		expect(failedTurn.stopReason).toBe("error");
+		expect(failedTurn.errorMessage).toBe(errorMessage);
+		expect(failedTurn.content).toEqual([{ type: "text", text: "Useful partial analysis." }]);
 	});
 
 	it("drops incomplete tool calls when assistant aborts before toolcall_end", async () => {


### PR DESCRIPTION
## Summary

- convert rejected provider event iteration into a terminal assistant error turn
- preserve completed partial text and completed tool calls
- discard tool calls that never reached `toolcall_end`
- handle rejected trailing `response.result()` through the same finalization path

## Why

A provider stream can fail after emitting useful assistant content or partial tool arguments. The iterator rejection currently escapes the agent loop, so the partial turn never receives `message_end` and the run cannot settle through its normal error path.

This change is provider-agnostic and intentionally does not add retry policy or watchdog thresholds.

## Tests

- `bun test ./packages/agent/test/agent-loop.test.ts` (57 pass)
- `bun run check` in `packages/agent`