### PR TITLE
fix(ai): adapt xai responses replay shapes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed xAI OAuth Responses continuations replaying OpenAI-only `custom_tool_call`/`custom_tool_call_output` history and `input_image.detail: "original"` frames; replay now downgrades those to xAI-compatible function calls and `detail: "auto"`. ([#5002](https://github.com/can1357/oh-my-pi/issues/5002))
+
 ## [16.3.15] - 2026-07-09
 
 ### Breaking Changes

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1529,6 +1529,7 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 				customCallIds,
 				options.preserveAssistantMessageIds,
 				supportsCustomToolCalls,
+				options.context.tools,
 			);
 			const outputItems = suppressHiddenEmptyFallback
 				? sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(convertedOutputItems)
@@ -1578,6 +1579,7 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 	customCallIds?: Set<string>,
 	preserveMessageIds = false,
 	supportsCustomToolCalls = true,
+	tools?: readonly Tool[],
 ): ResponseInput {
 	const outputItems: ResponseInput = [];
 	let unsignedTextBlocks = 0;
@@ -1661,11 +1663,15 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 			} as ResponseInput[number]);
 			continue;
 		}
+		const functionName =
+			block.customWireName && !supportsCustomToolCalls
+				? resolveReplayCustomToolName(block.customWireName, tools)
+				: block.name;
 		outputItems.push({
 			type: "function_call",
 			...(itemId ? { id: itemId } : {}),
 			call_id: normalized.callId,
-			name: block.name,
+			name: functionName,
 			arguments: JSON.stringify(block.arguments),
 		});
 	}

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1355,6 +1355,52 @@ export function convertResponsesInputContent(
 	return normalizedContent.length > 0 ? normalizedContent : undefined;
 }
 
+interface ResponsesReplayCompatibilityOptions {
+	supportsCustomToolCalls: boolean;
+	tools: readonly Tool[] | undefined;
+}
+
+function resolveReplayCustomToolName(wireName: string, tools: readonly Tool[] | undefined): string {
+	if (tools) {
+		for (const tool of tools) {
+			if (tool.customWireName === wireName) return tool.name;
+		}
+	}
+	if (wireName === "apply_patch") return "edit";
+	return wireName;
+}
+
+function adaptResponsesReplayItemsForModel(
+	input: ResponseInput,
+	options: ResponsesReplayCompatibilityOptions,
+): ResponseInput {
+	let changed = false;
+	const adapted: ResponseInput = [];
+	for (const item of input) {
+		let next = item;
+		if (!options.supportsCustomToolCalls && item.type === "custom_tool_call") {
+			changed = true;
+			next = {
+				type: "function_call",
+				...(item.id ? { id: item.id } : {}),
+				call_id: item.call_id,
+				name: resolveReplayCustomToolName(item.name, options.tools),
+				arguments: JSON.stringify({ input: item.input }),
+				...(item.namespace ? { namespace: item.namespace } : {}),
+			};
+		} else if (!options.supportsCustomToolCalls && item.type === "custom_tool_call_output") {
+			changed = true;
+			next = {
+				type: "function_call_output",
+				call_id: item.call_id,
+				output: item.output,
+			};
+		}
+		adapted.push(next);
+	}
+	return changed ? adapted : input;
+}
+
 export interface BuildResponsesInputOptions<TApi extends Api> {
 	model: Model<TApi>;
 	context: Context;
@@ -1379,6 +1425,13 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 		messages.push({ role: options.systemRole as "system" | "developer", content: systemPrompt });
 	}
 
+	const supportsImageDetailOriginal =
+		options.model.provider === "xai-oauth" ? false : options.supportsImageDetailOriginal;
+	const supportsCustomToolCalls = options.model.applyPatchToolType === "freeform";
+	const replayCompatibility: ResponsesReplayCompatibilityOptions = {
+		supportsCustomToolCalls,
+		tools: options.context.tools,
+	};
 	let knownCallIds = new Set<string>();
 	const customCallIds = new Set<string>();
 	const transformedMessages = transformMessages(
@@ -1406,7 +1459,10 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 				}) ??
 					false);
 			if (historyItems && shouldReplayPayloadItems) {
-				messages.push(...sanitizeOpenAIResponsesHistoryItemsForReplay(filterReasoning(historyItems)));
+				const sanitizedItems = sanitizeOpenAIResponsesHistoryItemsForReplay(filterReasoning(historyItems), {
+					supportsImageDetailOriginal,
+				});
+				messages.push(...adaptResponsesReplayItemsForModel(sanitizedItems, replayCompatibility));
 				knownCallIds = collectKnownCallIds(messages);
 				for (const id of collectCustomCallIds(messages)) customCallIds.add(id);
 				msgIndex++;
@@ -1415,7 +1471,7 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 			const content = convertResponsesInputContent(
 				msg.content,
 				options.model.input.includes("image"),
-				options.supportsImageDetailOriginal,
+				supportsImageDetailOriginal,
 			);
 			if (!content) continue;
 			messages.push({
@@ -1443,9 +1499,13 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 			const historyItems = providerPayload?.items;
 			let suppressHiddenEmptyFallback = false;
 			if (historyItems) {
-				const sanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
+				const rawSanitizedHistoryItems = sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
 					filterReasoning(historyItems),
+					{ supportsImageDetailOriginal },
 				);
+				const sanitizedHistoryItems = rawSanitizedHistoryItems
+					? adaptResponsesReplayItemsForModel(rawSanitizedHistoryItems, replayCompatibility)
+					: undefined;
 				if (nativeReplayEnabled && sanitizedHistoryItems) {
 					if (providerPayload?.dt) {
 						messages.push(...sanitizedHistoryItems);
@@ -1468,6 +1528,7 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 				suppressHiddenEmptyFallback ? false : includeThinkingSignatures,
 				customCallIds,
 				options.preserveAssistantMessageIds,
+				supportsCustomToolCalls,
 			);
 			const outputItems = suppressHiddenEmptyFallback
 				? sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(convertedOutputItems)
@@ -1480,9 +1541,10 @@ export function buildResponsesInput<TApi extends Api>(options: BuildResponsesInp
 				msg,
 				options.model,
 				options.strictResponsesPairing,
-				options.supportsImageDetailOriginal,
+				supportsImageDetailOriginal,
 				knownCallIds,
 				customCallIds,
+				supportsCustomToolCalls,
 			);
 		}
 		msgIndex++;
@@ -1515,6 +1577,7 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 	includeThinkingSignatures = true,
 	customCallIds?: Set<string>,
 	preserveMessageIds = false,
+	supportsCustomToolCalls = true,
 ): ResponseInput {
 	const outputItems: ResponseInput = [];
 	let unsignedTextBlocks = 0;
@@ -1586,7 +1649,7 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 			itemId = undefined;
 		}
 		knownCallIds.add(normalized.callId);
-		if (block.customWireName) {
+		if (block.customWireName && supportsCustomToolCalls) {
 			const rawInput = typeof block.arguments?.input === "string" ? block.arguments.input : "";
 			customCallIds?.add(normalized.callId);
 			outputItems.push({
@@ -1618,6 +1681,7 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 	supportsImageDetailOriginal: boolean,
 	knownCallIds: ReadonlySet<string>,
 	customCallIds?: ReadonlySet<string>,
+	supportsCustomToolCalls = true,
 ): void {
 	const supportsImages = model.input.includes("image");
 	const textResult = toolResult.content
@@ -1647,7 +1711,7 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 		} as ResponseInput[number]);
 		return;
 	}
-	if (customCallIds?.has(normalized.callId)) {
+	if (supportsCustomToolCalls && customCallIds?.has(normalized.callId)) {
 		messages.push({
 			type: "custom_tool_call_output",
 			call_id: normalized.callId,

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -65,10 +65,50 @@ export function truncateResponseItemId(id: string, prefix: string): string {
 	return `${prefix}_${Bun.hash(id).toString(36)}`;
 }
 
-export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record<string, unknown>>): ResponseInput {
+interface OpenAIResponsesReplaySanitizeOptions {
+	supportsImageDetailOriginal?: boolean;
+}
+
+function isReplayRecord(value: unknown): value is Record<string, unknown> {
+	if (!value || typeof value !== "object") return false;
+	return !Array.isArray(value);
+}
+
+function sanitizeReplayValueForCompatibility(value: unknown, options: OpenAIResponsesReplaySanitizeOptions): unknown {
+	if (options.supportsImageDetailOriginal !== false) return value;
+	if (Array.isArray(value)) {
+		let changed = false;
+		const sanitized = value.map(item => {
+			const next = sanitizeReplayValueForCompatibility(item, options);
+			if (next !== item) changed = true;
+			return next;
+		});
+		return changed ? sanitized : value;
+	}
+	if (!isReplayRecord(value)) return value;
+
+	let changed = false;
+	const sanitized: Record<string, unknown> = {};
+	for (const key in value) {
+		const child = value[key];
+		const next = sanitizeReplayValueForCompatibility(child, options);
+		if (next !== child) changed = true;
+		sanitized[key] = next;
+	}
+	if (value.type === "input_image" && value.detail === "original") {
+		sanitized.detail = "auto";
+		changed = true;
+	}
+	return changed ? sanitized : value;
+}
+
+export function sanitizeOpenAIResponsesHistoryItemsForReplay(
+	items: Array<Record<string, unknown>>,
+	options: OpenAIResponsesReplaySanitizeOptions = {},
+): ResponseInput {
 	const normalizedCallIds = new Map<string, string>();
 	return items.flatMap(item => {
-		const sanitized = sanitizeOpenAIResponsesHistoryItemForReplay(item, normalizedCallIds);
+		const sanitized = sanitizeOpenAIResponsesHistoryItemForReplay(item, normalizedCallIds, options);
 		return sanitized ? [sanitized] : [];
 	});
 }
@@ -82,8 +122,9 @@ export function sanitizeOpenAIResponsesHistoryItemsForReplay(items: Array<Record
  */
 export function sanitizeOpenAIResponsesAssistantHistoryItemsForReplay(
 	items: Array<Record<string, unknown>>,
+	options: OpenAIResponsesReplaySanitizeOptions = {},
 ): ResponseInput | undefined {
-	const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay(items);
+	const sanitized = sanitizeOpenAIResponsesHistoryItemsForReplay(items, options);
 	let hasReplayableAssistantOutput = false;
 
 	for (const item of sanitized) {
@@ -153,6 +194,7 @@ export function sanitizeOpenAIResponsesAssistantFallbackItemsForReplay(items: Re
 function sanitizeOpenAIResponsesHistoryItemForReplay(
 	item: Record<string, unknown>,
 	normalizedCallIds: Map<string, string>,
+	options: OpenAIResponsesReplaySanitizeOptions,
 ): OpenAIResponsesReplayItem | undefined {
 	if (item.type === "item_reference") return undefined;
 	if (item.type === "image_generation_call") return sanitizeOpenAIResponsesImageGenerationCallForReplay(item);
@@ -164,7 +206,8 @@ function sanitizeOpenAIResponsesHistoryItemForReplay(
 		sanitizedItem.call_id = normalizeReplayedResponsesHistoryCallId(item.call_id, normalizedCallIds);
 	}
 
-	return sanitizedItem as unknown as OpenAIResponsesReplayItem;
+	const compatibleItem = sanitizeReplayValueForCompatibility(sanitizedItem, options);
+	return compatibleItem as unknown as OpenAIResponsesReplayItem;
 }
 
 function sanitizeOpenAIResponsesReasoningItemForReplay(item: Record<string, unknown>): OpenAIResponsesReplayItem {

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -5,10 +5,11 @@ import {
 } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { type OpenAIResponsesOptions, streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import { buildResponsesInput } from "@oh-my-pi/pi-ai/providers/openai-shared";
-import type { Context, Model, ModelSpec, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
+import type { Context, Model, ModelSpec, ProviderSessionState, Tool } from "@oh-my-pi/pi-ai/types";
 import { createOpenAIResponsesHistoryPayload, truncateResponseItemId } from "@oh-my-pi/pi-ai/utils";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { type } from "arktype";
 
 function createAbortedSignal(): AbortSignal {
 	const controller = new AbortController();
@@ -51,6 +52,13 @@ const issue5002ZeroUsage = {
 	cacheWrite: 0,
 	totalTokens: 0,
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+const issue5002EditTool: Tool = {
+	name: "edit",
+	customWireName: "apply_patch",
+	description: "Apply a hashline patch",
+	parameters: type({ input: "string" }),
+	customFormat: { syntax: "lark", definition: 'start: "*** Begin Patch" LF\nLF: /\\n/' },
 };
 
 const preservedHistoryItems = [
@@ -431,7 +439,7 @@ describe("OpenAI responses history payload", () => {
 						{
 							type: "toolCall",
 							id: "call_apply",
-							name: "edit",
+							name: "apply_patch",
 							arguments: { input: ISSUE_5002_PATCH },
 							customWireName: "apply_patch",
 						},
@@ -452,6 +460,7 @@ describe("OpenAI responses history payload", () => {
 					timestamp: Date.now(),
 				},
 			],
+			tools: [issue5002EditTool],
 		};
 
 		const xaiInput = buildResponsesInput({

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -8,7 +8,7 @@ import { buildResponsesInput } from "@oh-my-pi/pi-ai/providers/openai-shared";
 import type { Context, Model, ModelSpec, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { createOpenAIResponsesHistoryPayload, truncateResponseItemId } from "@oh-my-pi/pi-ai/utils";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 function createAbortedSignal(): AbortSignal {
 	const controller = new AbortController();
@@ -24,12 +24,34 @@ function createCodexToken(accountId: string): string {
 	return `${header}.${payload}.signature`;
 }
 
-function getOpenAIReasoningModel(
-	provider: Parameters<typeof getBundledModel>[0],
-	id: string,
-): Model<"openai-responses"> {
-	return getBundledModel(provider, id) as Model<"openai-responses">;
+function getOpenAIReasoningModel(provider: GeneratedProvider, id: string): Model<"openai-responses"> {
+	const model = getBundledModel<"openai-responses">(provider, id);
+	return model;
 }
+
+const ISSUE_5002_PATCH = "*** Begin Patch\n*** End Patch\n";
+const ISSUE_5002_TOOL_OUTPUT = "patch applied";
+const issue5002XaiOAuthModel = buildModel({
+	id: "grok-build",
+	name: "Grok Build",
+	api: "openai-responses",
+	provider: "xai-oauth",
+	baseUrl: "https://api.x.ai/v1",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 256000,
+	maxTokens: 64000,
+} satisfies ModelSpec<"openai-responses">);
+
+const issue5002ZeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
 
 const preservedHistoryItems = [
 	{ type: "message", role: "user", content: [{ type: "input_text", text: "Preserved user" }] },
@@ -287,6 +309,38 @@ function findResponsesInputItem(input: unknown[] | undefined, type: string): Rec
 	}) as Record<string, unknown> | undefined;
 }
 
+function isIssue5002Record(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+	return true;
+}
+
+function findResponsesInputItemByCallId(
+	input: unknown[],
+	type: string,
+	callId: string,
+): Record<string, unknown> | undefined {
+	for (const item of input) {
+		if (!isIssue5002Record(item)) continue;
+		if (item.type === type && item.call_id === callId) return item;
+	}
+	return undefined;
+}
+
+function collectResponsesInputImageDetails(input: unknown): string[] {
+	const details: string[] = [];
+	const visit = (node: unknown): void => {
+		if (Array.isArray(node)) {
+			for (const child of node) visit(child);
+			return;
+		}
+		if (!isIssue5002Record(node)) return;
+		if (node.type === "input_image" && typeof node.detail === "string") details.push(node.detail);
+		for (const key in node) visit(node[key]);
+	};
+	visit(input);
+	return details;
+}
+
 function containsUserInputText(input: unknown[] | undefined, text: string): boolean {
 	return (input ?? []).some(item => {
 		if (!item || typeof item !== "object") return false;
@@ -355,9 +409,185 @@ describe("OpenAI responses history payload", () => {
 		});
 		assertWireOrder(openaiItems);
 
-		const codexModel = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
+		const codexModel = getBundledModel<"openai-codex-responses">("openai-codex", "gpt-5.2-codex");
 		const codexItems = convertCodexResponsesMessages(codexModel, makeContext("openai-codex"));
 		assertWireOrder(codexItems);
+	});
+
+	it("adapts reconstructed apply_patch replay for xai-oauth while preserving OpenAI custom replay", () => {
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "previous frame" },
+						{ type: "image", mimeType: "image/png", data: "ZmFrZQ==", detail: "original" },
+					],
+					timestamp: Date.now(),
+				},
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "toolCall",
+							id: "call_apply",
+							name: "edit",
+							arguments: { input: ISSUE_5002_PATCH },
+							customWireName: "apply_patch",
+						},
+					],
+					api: "openai-responses",
+					provider: "openai",
+					model: "gpt-5-mini",
+					usage: issue5002ZeroUsage,
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call_apply",
+					toolName: "edit",
+					content: [{ type: "text", text: ISSUE_5002_TOOL_OUTPUT }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const xaiInput = buildResponsesInput({
+			model: issue5002XaiOAuthModel,
+			context,
+			strictResponsesPairing: false,
+			supportsImageDetailOriginal: issue5002XaiOAuthModel.compat.supportsImageDetailOriginal,
+			nativeHistory: { replay: true, filterReasoning: issue5002XaiOAuthModel.compat.filterReasoningHistory },
+		});
+		expect(findResponsesInputItemByCallId(xaiInput, "function_call", "call_apply")).toEqual({
+			type: "function_call",
+			call_id: "call_apply",
+			name: "edit",
+			arguments: JSON.stringify({ input: ISSUE_5002_PATCH }),
+		});
+		expect(findResponsesInputItemByCallId(xaiInput, "function_call_output", "call_apply")).toEqual({
+			type: "function_call_output",
+			call_id: "call_apply",
+			output: ISSUE_5002_TOOL_OUTPUT,
+		});
+		expect(JSON.stringify(xaiInput)).not.toContain("custom_tool_call");
+		expect(collectResponsesInputImageDetails(xaiInput)).toEqual(["auto"]);
+
+		const openaiModel = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const openaiInput = buildResponsesInput({
+			model: openaiModel,
+			context,
+			strictResponsesPairing: false,
+			supportsImageDetailOriginal: openaiModel.compat.supportsImageDetailOriginal,
+			nativeHistory: { replay: true, filterReasoning: openaiModel.compat.filterReasoningHistory },
+		});
+		expect(findResponsesInputItemByCallId(openaiInput, "custom_tool_call", "call_apply")).toEqual({
+			type: "custom_tool_call",
+			call_id: "call_apply",
+			name: "apply_patch",
+			input: ISSUE_5002_PATCH,
+		});
+		expect(findResponsesInputItemByCallId(openaiInput, "custom_tool_call_output", "call_apply")).toEqual({
+			type: "custom_tool_call_output",
+			call_id: "call_apply",
+			output: ISSUE_5002_TOOL_OUTPUT,
+		});
+		expect(collectResponsesInputImageDetails(openaiInput)).toEqual(["original"]);
+	});
+
+	it("adapts persisted native apply_patch Responses items for xai-oauth continuations", () => {
+		const nativeHistoryItems = [
+			{
+				type: "message",
+				role: "user",
+				content: [
+					{ type: "input_text", text: "previous native frame" },
+					{ type: "input_image", detail: "original", image_url: "data:image/png;base64,ZmFrZQ==" },
+				],
+			},
+			{ type: "custom_tool_call", call_id: "call_native_apply", name: "apply_patch", input: ISSUE_5002_PATCH },
+			{
+				type: "custom_tool_call_output",
+				call_id: "call_native_apply",
+				output: ISSUE_5002_TOOL_OUTPUT,
+			},
+		];
+		const xaiContext: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "fallback should not be replayed" }],
+					api: "openai-responses",
+					provider: "xai-oauth",
+					model: issue5002XaiOAuthModel.id,
+					usage: issue5002ZeroUsage,
+					stopReason: "stop",
+					providerPayload: createOpenAIResponsesHistoryPayload("xai-oauth", nativeHistoryItems),
+					timestamp: Date.now(),
+				},
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		};
+
+		const xaiInput = buildResponsesInput({
+			model: issue5002XaiOAuthModel,
+			context: xaiContext,
+			strictResponsesPairing: false,
+			supportsImageDetailOriginal: issue5002XaiOAuthModel.compat.supportsImageDetailOriginal,
+			nativeHistory: { replay: true, filterReasoning: issue5002XaiOAuthModel.compat.filterReasoningHistory },
+		});
+		expect(findResponsesInputItemByCallId(xaiInput, "function_call", "call_native_apply")).toEqual({
+			type: "function_call",
+			call_id: "call_native_apply",
+			name: "edit",
+			arguments: JSON.stringify({ input: ISSUE_5002_PATCH }),
+		});
+		expect(findResponsesInputItemByCallId(xaiInput, "function_call_output", "call_native_apply")).toEqual({
+			type: "function_call_output",
+			call_id: "call_native_apply",
+			output: ISSUE_5002_TOOL_OUTPUT,
+		});
+		expect(JSON.stringify(xaiInput)).not.toContain("custom_tool_call");
+		expect(collectResponsesInputImageDetails(xaiInput)).toEqual(["auto"]);
+
+		const openaiModel = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const openaiContext: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "fallback should not be replayed" }],
+					api: "openai-responses",
+					provider: "openai",
+					model: openaiModel.id,
+					usage: issue5002ZeroUsage,
+					stopReason: "stop",
+					providerPayload: createOpenAIResponsesHistoryPayload("openai", nativeHistoryItems),
+					timestamp: Date.now(),
+				},
+				{ role: "user", content: "continue", timestamp: Date.now() },
+			],
+		};
+		const openaiInput = buildResponsesInput({
+			model: openaiModel,
+			context: openaiContext,
+			strictResponsesPairing: false,
+			supportsImageDetailOriginal: openaiModel.compat.supportsImageDetailOriginal,
+			nativeHistory: { replay: true, filterReasoning: openaiModel.compat.filterReasoningHistory },
+		});
+		expect(findResponsesInputItemByCallId(openaiInput, "custom_tool_call", "call_native_apply")).toEqual({
+			type: "custom_tool_call",
+			call_id: "call_native_apply",
+			name: "apply_patch",
+			input: ISSUE_5002_PATCH,
+		});
+		expect(findResponsesInputItemByCallId(openaiInput, "custom_tool_call_output", "call_native_apply")).toEqual({
+			type: "custom_tool_call_output",
+			call_id: "call_native_apply",
+			output: ISSUE_5002_TOOL_OUTPUT,
+		});
+		expect(collectResponsesInputImageDetails(openaiInput)).toEqual(["original"]);
 	});
 
 	it("prepends multiple OpenAI developer instructions in order without changing prompt cache key routing", async () => {
@@ -1052,7 +1282,7 @@ describe("OpenAI responses history payload", () => {
 				{ role: "user", content: "Resume", timestamp: Date.now() },
 			],
 		};
-		const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
+		const model = getBundledModel<"openai-codex-responses">("openai-codex", "gpt-5.2-codex");
 		const payload = (await captureCodexPayload(model, context)) as { input?: unknown[] };
 		const functionCallItem = findResponsesInputItem(payload.input, "function_call");
 		const functionCallOutputItem = findResponsesInputItem(payload.input, "function_call_output");

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -26266,6 +26266,25 @@
 			"contextWindow": null,
 			"maxTokens": null
 		},
+		"cognitivecomputations/dolphin-mistral-24b-venice-edition": {
+			"id": "cognitivecomputations/dolphin-mistral-24b-venice-edition",
+			"name": "Uncensored",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": null,
+			"maxTokens": null
+		},
 		"cohere/command-a": {
 			"id": "cohere/command-a",
 			"name": "Command A",
@@ -61445,8 +61464,6 @@
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 3,
-			"requestModelId": "gpt-5.6-luna",
-			"reasoningMode": "pro",
 			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
@@ -61464,7 +61481,9 @@
 					"high": "xhigh",
 					"xhigh": "max"
 				}
-			}
+			},
+			"requestModelId": "gpt-5.6-luna",
+			"reasoningMode": "pro"
 		},
 		"gpt-5.6-sol": {
 			"id": "gpt-5.6-sol",
@@ -61537,8 +61556,6 @@
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 1,
-			"requestModelId": "gpt-5.6-sol",
-			"reasoningMode": "pro",
 			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
@@ -61556,7 +61573,9 @@
 					"high": "xhigh",
 					"xhigh": "max"
 				}
-			}
+			},
+			"requestModelId": "gpt-5.6-sol",
+			"reasoningMode": "pro"
 		},
 		"gpt-5.6-terra": {
 			"id": "gpt-5.6-terra",
@@ -61629,8 +61648,6 @@
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"priority": 2,
-			"requestModelId": "gpt-5.6-terra",
-			"reasoningMode": "pro",
 			"applyPatchToolType": "freeform",
 			"thinking": {
 				"mode": "effort",
@@ -61648,7 +61665,9 @@
 					"high": "xhigh",
 					"xhigh": "max"
 				}
-			}
+			},
+			"requestModelId": "gpt-5.6-terra",
+			"reasoningMode": "pro"
 		}
 	},
 	"opencode": {
@@ -64649,7 +64668,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.65,
+				"input": 0.66,
 				"output": 3.41,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
@@ -68450,7 +68469,7 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.65,
+				"input": 0.66,
 				"output": 3.41,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
@@ -73884,13 +73903,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.54,
-				"output": 1.76,
-				"cacheRead": 0.09999999999999999,
+				"input": 0.49,
+				"output": 1.54,
+				"cacheRead": 0.091,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 101376,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -74106,7 +74125,7 @@
 	"synthetic": {
 		"hf:MiniMaxAI/MiniMax-M3": {
 			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -74121,7 +74140,7 @@
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -74136,7 +74155,7 @@
 		},
 		"hf:moonshotai/Kimi-K2.7-Code": {
 			"id": "hf:moonshotai/Kimi-K2.7-Code",
-			"name": "moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -74166,7 +74185,7 @@
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -74195,7 +74214,7 @@
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -74222,7 +74241,7 @@
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -74251,7 +74270,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -74280,7 +74299,7 @@
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -77771,134 +77790,182 @@
 		},
 		"openai-gpt-56-luna": {
 			"id": "openai-gpt-56-luna",
-			"name": "openai-gpt-56-luna",
+			"name": "GPT-5.6 Luna",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 7.5,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"openai-gpt-56-luna-pro": {
 			"id": "openai-gpt-56-luna-pro",
-			"name": "openai-gpt-56-luna-pro",
+			"name": "GPT-5.6 Luna Pro",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 7.5,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"openai-gpt-56-sol": {
 			"id": "openai-gpt-56-sol",
-			"name": "openai-gpt-56-sol",
+			"name": "GPT-5.6 Sol",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 6.25,
+				"output": 37.5,
+				"cacheRead": 0.625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"openai-gpt-56-sol-pro": {
 			"id": "openai-gpt-56-sol-pro",
-			"name": "openai-gpt-56-sol-pro",
+			"name": "GPT-5.6 Sol Pro",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 6.25,
+				"output": 37.5,
+				"cacheRead": 0.625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"openai-gpt-56-terra": {
 			"id": "openai-gpt-56-terra",
-			"name": "openai-gpt-56-terra",
+			"name": "GPT-5.6 Terra",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3.125,
+				"output": 18.75,
+				"cacheRead": 0.3125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"openai-gpt-56-terra-pro": {
 			"id": "openai-gpt-56-terra-pro",
-			"name": "openai-gpt-56-terra-pro",
+			"name": "GPT-5.6 Terra Pro",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 3.125,
+				"output": 18.75,
+				"cacheRead": 0.3125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
-			"compat": {
-				"supportsUsageInStreaming": false
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
 			}
 		},
 		"openai-gpt-oss-120b": {
@@ -80221,7 +80288,7 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0.0028,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -81018,7 +81085,8 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 1.25,
@@ -85573,6 +85641,7 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true
 			}
 		},
@@ -85601,6 +85670,7 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
 				"supportsReasoningEffort": false
 			}
@@ -85623,6 +85693,15 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -85635,14 +85714,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-4.3": {
@@ -85664,6 +85735,15 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -85676,14 +85756,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false
 			}
 		},
 		"grok-4.5": {
@@ -85711,7 +85783,21 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
-				"omitReasoningEffort": true
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low"
+				}
 			}
 		},
 		"grok-build": {
@@ -85739,6 +85825,7 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
 				"supportsReasoningEffort": false
 			}
@@ -85768,6 +85855,7 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
 				"supportsReasoningEffort": false
 			}
@@ -85796,6 +85884,7 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true
 			}
 		}
@@ -90069,6 +90158,43 @@
 				]
 			},
 			"contextPromotionTarget": "zenmux/openai/gpt-5.4"
+		},
+		"openai/gpt-5.6-luna": {
+			"id": "openai/gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "low",
+					"low": "medium",
+					"medium": "high",
+					"high": "xhigh",
+					"xhigh": "max"
+				}
+			}
 		},
 		"openai/gpt-image-1.5": {
 			"id": "openai/gpt-image-1.5",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1078,6 +1078,7 @@ function withXaiOAuthCompatDefaults(model: ModelSpec<"openai-responses">): Model
 		...(model.compat ?? {}),
 		includeEncryptedReasoning: model.compat?.includeEncryptedReasoning ?? false,
 		filterReasoningHistory: model.compat?.filterReasoningHistory ?? true,
+		supportsImageDetailOriginal: model.compat?.supportsImageDetailOriginal ?? false,
 		omitReasoningEffort: model.compat?.omitReasoningEffort ?? !isGrokReasoningEffortCapable(model.id),
 	};
 	return { ...model, compat };

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1118,6 +1118,7 @@ function mergeCuratedIntoModel(
 		reasoningEffortMap: { ...XAI_REASONING_EFFORT_MAP, ...(base.compat?.reasoningEffortMap ?? {}) },
 		includeEncryptedReasoning: base.compat?.includeEncryptedReasoning ?? false,
 		filterReasoningHistory: base.compat?.filterReasoningHistory ?? true,
+		supportsImageDetailOriginal: base.compat?.supportsImageDetailOriginal ?? false,
 		omitReasoningEffort: base.compat?.omitReasoningEffort ?? !isGrokReasoningEffortCapable(base.id),
 		...(effort === undefined ? {} : { supportsReasoningEffort: effort }),
 	};


### PR DESCRIPTION
## Repro
Continuing a session on `xai-oauth/grok-4.5` after prior OpenAI Responses freeform `apply_patch` and native-resolution image history can serialize `custom_tool_call`, `custom_tool_call_output`, and `input_image.detail: "original"` into the xAI Responses request. I reproduced this with `bun test packages/ai/test/repro-5002.test.ts` before the fix; the request input still contained the OpenAI-only custom tool shapes and `detail: "original"`.

## Cause
`buildResponsesInput()` in `packages/ai/src/providers/openai-shared.ts` replayed `ToolCall.customWireName` and persisted OpenAI Responses provider payload items without checking whether the target model supports OpenAI custom/freeform tools. Image detail clamping only used the model compat flag, and `packages/catalog/src/provider-models/openai-compat.ts` inherited `supportsImageDetailOriginal: true` for the xAI host even though xAI OAuth rejects that replay value.

## Fix
- Convert historical custom/freeform `apply_patch` replay to `function_call` / `function_call_output` when the target Responses model does not advertise `applyPatchToolType: "freeform"`.
- Downgrade `input_image.detail: "original"` to `"auto"` for xAI OAuth, including recursively sanitized native `providerPayload` history.
- Mark xAI OAuth catalog compat as not supporting `detail: "original"` and add issue #5002 regression coverage for reconstructed and persisted native history replay.

## Verification
`bun test packages/ai/test/openai-responses-history-payload.test.ts packages/ai/test/apply-patch-freeform.test.ts packages/ai/test/github-copilot-long-context-wire.test.ts` passed with 67 tests and 193 assertions. `bun run check:types` in `packages/ai` passed. Pre-publish `gh_push_branch` completed its `bun run fix` + `bun check` gate and pushed the branch. Fixes #5002