### PR TITLE
fix(eval): shield Python agent bridge aborts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Python eval `agent()` bridge calls losing in-flight subagent work when the parent cell receives an external abort; the kernel abort is now deferred until already-started bridge calls settle, and new bridge calls are rejected after the abort is pending. ([#5005](https://github.com/can1357/oh-my-pi/issues/5005))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts
@@ -603,21 +603,22 @@ describe("agent() through eval runtimes", () => {
 		});
 		const { session, sessionFile, sessionId } = makeEvalSession(tempDir, "py-agent-interrupt", settings);
 		mockAgents();
-		// Subagents that ignore the abort for far longer than the kernel's SIGINT
-		// escalation window. Each kernel worker thread blocks in a synchronous
-		// `urllib` bridge call, joined by `parallel()`'s ThreadPoolExecutor exit.
-		// The host must respond the instant the cell aborts so the kernel can
-		// unwind via KeyboardInterrupt instead of being hard-killed (which used to
-		// surface "[kernel] Python kernel shutdown" and lose all session state).
+		// Each kernel worker thread blocks in a synchronous `urllib` bridge call,
+		// joined by `parallel()`'s ThreadPoolExecutor exit. The host must keep
+		// those already-started calls attached until they settle, then interrupt
+		// the kernel before `parallel()` launches another wave.
 		let inFlight = 0;
+		let completed = 0;
 		let markSaturated: (() => void) | undefined;
 		const saturated = new Promise<void>(resolve => {
 			markSaturated = resolve;
 		});
-		vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async options => {
+		const releaseAgents = Promise.withResolvers<void>();
+		const runSpy = vi.spyOn(taskExecutor, "runSubprocess").mockImplementation(async options => {
 			// task.maxConcurrency=6 → six bridge calls block at once; signal then.
 			if (++inFlight >= 6) markSaturated?.();
-			await Bun.sleep(9000); // deliberately ignores options.signal
+			await releaseAgents.promise;
+			completed++;
 			return singleResult(options, { output: options.assignment ?? "" });
 		});
 
@@ -640,8 +641,7 @@ describe("agent() through eval runtimes", () => {
 		// bridge calls (condition-driven) instead of waiting a fixed wall second.
 		void saturated.then(() => ac.abort(new Error("external interrupt")));
 
-		const start = Date.now();
-		const result = await executePython(
+		const resultPromise = executePython(
 			"import json\nprint(json.dumps(parallel([lambda n=n: agent(str(n)) for n in range(12)])))",
 			{
 				cwd: tempDir.path(),
@@ -653,13 +653,18 @@ describe("agent() through eval runtimes", () => {
 				signal: ac.signal,
 			},
 		);
-		const elapsed = Date.now() - start;
+		await saturated;
+		await Promise.resolve();
+		expect(completed).toBe(0);
+		releaseAgents.resolve();
+		const result = await resultPromise;
 
-		// Cancelled, but cleanly: no hard-kill, settled well within the kernel's 5s
-		// SIGINT escalation window rather than ~6s after it.
+		// Cancelled, but cleanly: no hard-kill, no orphaned bridge calls, and no
+		// second fan-out wave started after the deferred abort was delivered.
 		expect(result.cancelled).toBe(true);
 		expect(result.output).not.toContain("Python kernel shutdown");
-		expect(elapsed).toBeLessThan(4000);
+		expect(completed).toBe(6);
+		expect(runSpy).toHaveBeenCalledTimes(6);
 
 		// The persistent kernel survived the interrupt: prior state is intact.
 		const after = await executePython("print(PREP_MARKER)", {

--- a/packages/coding-agent/src/eval/__tests__/bridge-timeout.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/bridge-timeout.test.ts
@@ -5,7 +5,9 @@ import {
 	isEvalTimeoutControlEvent,
 	withBridgeTimeoutPause,
 } from "../bridge-timeout";
+import { executeWithKernelBase, type GenericKernel } from "../executor-base";
 import type { JsStatusEvent } from "../js/shared/types";
+import type { KernelDisplayOutput } from "../py/display";
 
 describe("withBridgeTimeoutPause", () => {
 	it("emits one pause before the operation and one resume after it settles", async () => {
@@ -61,4 +63,62 @@ describe("withBridgeTimeoutPause", () => {
 		expect(isEvalTimeoutControlEvent({ op: EVAL_TIMEOUT_RESUME_OP })).toBe(true);
 		expect(isEvalTimeoutControlEvent({ op: "agent", id: "subagent-1" })).toBe(false);
 	});
+});
+
+class TestCancelledError extends Error {
+	readonly timedOut: boolean;
+
+	constructor(timedOut: boolean) {
+		super(timedOut ? "timed out" : "cancelled");
+		this.name = "TestCancelledError";
+		this.timedOut = timedOut;
+	}
+}
+
+it("defers external aborts until an in-flight bridge call resumes", async () => {
+	const abortController = new AbortController();
+	const release = Promise.withResolvers<void>();
+	let completed = false;
+	let kernelSignal: AbortSignal | undefined;
+	const kernel: GenericKernel<Record<string, string | null>> = {
+		async execute(_code, options) {
+			kernelSignal = options.signal;
+			options.onDisplay({
+				type: "status",
+				event: { op: EVAL_TIMEOUT_PAUSE_OP },
+			} satisfies KernelDisplayOutput);
+
+			abortController.abort(new Error("external interrupt"));
+			expect(kernelSignal?.aborted).toBe(false);
+
+			await release.promise;
+			completed = true;
+			options.onDisplay({
+				type: "status",
+				event: { op: EVAL_TIMEOUT_RESUME_OP },
+			} satisfies KernelDisplayOutput);
+			return { status: "ok", cancelled: false, timedOut: false };
+		},
+	};
+
+	const resultPromise = executeWithKernelBase({
+		kernel,
+		code: "agent('slow')",
+		options: { signal: abortController.signal },
+		runIdPrefix: "test",
+		errorLogLabel: "test",
+		cancelledErrorClass: TestCancelledError,
+		buildKernelEnvPatch: () => ({}),
+		formatKernelTimeoutAnnotation: () => "kernel timed out",
+		formatTimeoutAnnotation: () => "timed out",
+	});
+
+	await Promise.resolve();
+	expect(completed).toBe(false);
+
+	release.resolve();
+	const result = await resultPromise;
+	expect(completed).toBe(true);
+	expect(result.cancelled).toBe(true);
+	expect(result.exitCode).toBeUndefined();
 });

--- a/packages/coding-agent/src/eval/executor-base.ts
+++ b/packages/coding-agent/src/eval/executor-base.ts
@@ -3,7 +3,7 @@ import { Settings } from "../config/settings";
 import { OutputSink } from "../session/streaming-output";
 import type { ToolSession } from "../tools";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
-import { isEvalTimeoutControlEvent } from "./bridge-timeout";
+import { EVAL_TIMEOUT_PAUSE_OP, EVAL_TIMEOUT_RESUME_OP, isEvalTimeoutControlEvent } from "./bridge-timeout";
 import type { JsStatusEvent } from "./js/shared/types";
 import type { KernelDisplayOutput } from "./py/display";
 import { registerPyToolBridge } from "./py/tool-bridge";
@@ -158,6 +158,76 @@ export async function waitForPromiseWithCancellation<T>(
 	return await resultPromise;
 }
 
+interface BridgeAbortShield {
+	signal: AbortSignal | undefined;
+	abortRequested: boolean;
+	timedOut: boolean;
+	handleStatus?: (event: JsStatusEvent) => void;
+	dispose?: () => void;
+}
+
+function createBridgeAbortShield(source: AbortSignal | undefined): BridgeAbortShield {
+	const shield: BridgeAbortShield = {
+		signal: undefined,
+		abortRequested: false,
+		timedOut: false,
+	};
+	if (!source) return shield;
+
+	const controller = new AbortController();
+	let pauseDepth = 0;
+	let abortReason: unknown;
+	let removeAbortListener: (() => void) | undefined;
+
+	const requestAbort = (reason: unknown): void => {
+		shield.abortRequested = true;
+		shield.timedOut =
+			shield.timedOut ||
+			(typeof DOMException !== "undefined" && reason instanceof DOMException
+				? reason.name === "TimeoutError"
+				: reason instanceof Error && reason.name === "TimeoutError");
+		abortReason = reason;
+		if (pauseDepth > 0 || controller.signal.aborted) return;
+		controller.abort(reason);
+	};
+
+	const onAbort = (): void => {
+		const reason = source.reason;
+		requestAbort(reason);
+	};
+
+	shield.signal = controller.signal;
+	shield.handleStatus = (event: JsStatusEvent): void => {
+		if (event.op === EVAL_TIMEOUT_PAUSE_OP) {
+			pauseDepth++;
+			return;
+		}
+		if (event.op !== EVAL_TIMEOUT_RESUME_OP || pauseDepth === 0) return;
+		pauseDepth--;
+		if (shield.abortRequested && !controller.signal.aborted) controller.abort(abortReason);
+	};
+	shield.dispose = (): void => {
+		removeAbortListener?.();
+		removeAbortListener = undefined;
+	};
+
+	if (source.aborted) {
+		requestAbort(source.reason);
+	} else {
+		source.addEventListener("abort", onAbort, { once: true });
+		removeAbortListener = () => {
+			source.removeEventListener("abort", onAbort);
+		};
+		if (source.aborted) {
+			source.removeEventListener("abort", onAbort);
+			removeAbortListener = undefined;
+			requestAbort(source.reason);
+		}
+	}
+
+	return shield;
+}
+
 export function createCancelledKernelResult(output: string): KernelExecutionResult {
 	const outputBytes = Buffer.byteLength(output, "utf-8");
 	const outputLines = output.length > 0 ? 1 : 0;
@@ -304,9 +374,11 @@ export async function executeWithKernelBase<
 	const displayOutputs: KernelDisplayOutput[] = [];
 	const deadlineMs = (resolveDeadlineMs ?? getExecutionDeadlineMs)(options);
 	let executionTimeoutMs: number | undefined;
+	const abortShield = createBridgeAbortShield(options?.signal);
 
 	const collectDisplay = (output: KernelDisplayOutput): void => {
 		if (output.type === "status") {
+			abortShield.handleStatus?.(output.event);
 			options?.onStatus?.(output.event);
 			if (!isJulia && isEvalTimeoutControlEvent(output.event)) return;
 		}
@@ -320,8 +392,11 @@ export async function executeWithKernelBase<
 		options?.toolSession && options?.bridgeSessionId
 			? registerPyToolBridge(options.bridgeSessionId, runId, {
 					toolSession: options.toolSession,
-					signal: options.signal,
+					signal: abortShield.signal,
 					emitStatus,
+					abortRequested: () => {
+						return abortShield.abortRequested;
+					},
 				})
 			: null;
 
@@ -338,14 +413,15 @@ export async function executeWithKernelBase<
 			cwd: options?.cwd,
 			env: buildKernelEnvPatch(options ?? ({} as TOptions)),
 			id: runId,
-			signal: options?.signal,
+			signal: abortShield.signal,
 			timeoutMs: executionTimeoutMs,
 			onChunk: text => sink.push(text),
 			onDisplay: output => collectDisplay(output),
 		});
 
-		if (result.cancelled) {
-			const annotation = result.timedOut
+		if (result.cancelled || abortShield.abortRequested) {
+			const timedOut = result.timedOut || abortShield.timedOut;
+			const annotation = timedOut
 				? formatKernelTimeoutAnnotation(executionTimeoutMs ?? options?.idleTimeoutMs, result.kernelKilled ?? false)
 				: undefined;
 			const dumped = await sink.dump(annotation);
@@ -397,8 +473,8 @@ export async function executeWithKernelBase<
 			stdinRequested: false,
 		};
 	} catch (err) {
-		if (isCancellationError(err, cancelledErrorClass) || options?.signal?.aborted) {
-			const timedOut = isTimedOutCancellation(err, cancelledErrorClass, options?.signal);
+		if (isCancellationError(err, cancelledErrorClass) || abortShield.abortRequested || abortShield.signal?.aborted) {
+			const timedOut = abortShield.timedOut || isTimedOutCancellation(err, cancelledErrorClass, abortShield.signal);
 			const dumped = await sink.dump(
 				timedOut ? formatTimeoutAnnotation(executionTimeoutMs ?? options?.idleTimeoutMs) : undefined,
 			);
@@ -421,5 +497,6 @@ export async function executeWithKernelBase<
 		throw error;
 	} finally {
 		unregisterBridge?.();
+		abortShield.dispose?.();
 	}
 }

--- a/packages/coding-agent/src/eval/py/tool-bridge.ts
+++ b/packages/coding-agent/src/eval/py/tool-bridge.ts
@@ -15,6 +15,7 @@ export interface PyToolBridgeEntry {
 	toolSession: ToolSession;
 	signal?: AbortSignal;
 	emitStatus?: (event: JsStatusEvent) => void;
+	abortRequested?: () => boolean;
 }
 
 export interface PyToolBridgeInfo {
@@ -31,23 +32,21 @@ const registrations = new Map<string, PyToolBridgeEntry>();
 let serverPromise: Promise<BridgeServer> | null = null;
 
 /**
- * Forward a bridge call to {@link callSessionTool}, but resolve the HTTP request
- * the instant the cell's signal aborts instead of waiting for the tool/subagent
- * to fully tear down.
+ * Forward a bridge call to {@link callSessionTool} while respecting eval abort
+ * shielding.
  *
- * The kernel invokes this bridge with a *blocking* `urllib` request from a
- * worker thread (each `agent()` / `tool.*` call). When the cell is interrupted,
- * `parallel()`'s `ThreadPoolExecutor.__exit__` joins those worker threads
- * (`shutdown(wait=True)`), so they cannot unwind until their `urllib` call
- * returns — i.e. until this handler responds. A host-side `agent()` teardown
- * (aborting nested LLM streams + tools across a wide fan-out) routinely exceeds
- * the kernel's SIGINT escalation window, so the kernel was hard-killed and its
- * persistent state lost while the subagents were still winding down. Responding
- * immediately on abort lets the kernel raise through the blocked call and settle
- * cleanly (preserving state); the already-signaled call keeps tearing down in
- * the background, its eventual result/rejection swallowed.
+ * Python invokes this bridge with blocking `urllib` requests from worker threads
+ * (each `agent()` / `tool.*` call). The base executor defers the registered
+ * signal while a bridge call is already paused so in-flight subagents can finish
+ * and persist output instead of being orphaned. Once an abort has been requested,
+ * later bridge calls are rejected before starting; once the shielded signal
+ * finally aborts, this handler still resolves the HTTP request promptly so the
+ * kernel can unwind without being hard-killed.
  */
 async function callSessionToolPromptOnAbort(name: string, args: unknown, entry: PyToolBridgeEntry): Promise<unknown> {
+	if (entry.abortRequested?.()) {
+		throw new Error(`bridge call ${JSON.stringify(name)} aborted: eval cell was interrupted`);
+	}
 	const call = callSessionTool(name, args, {
 		session: entry.toolSession,
 		signal: entry.signal,


### PR DESCRIPTION
## Repro
A focused regression test demonstrates the failure: `bun test packages/coding-agent/src/eval/__tests__/bridge-timeout.test.ts -t "defers external aborts"` used to settle the eval result before the mocked in-flight bridge call completed (`Expected: true`, `Received: false` for the subagent completion marker), matching the orphaned `agent()` work described in #5005.

## Cause
`executeWithKernelBase` passed the eval cell's raw `AbortSignal` directly to the Python kernel and `registerPyToolBridge`, while `packages/coding-agent/src/eval/py/tool-bridge.ts` raced every bridge call against that signal. `withBridgeTimeoutPause()` only suspended the idle timeout; it did not shield the kernel or bridge from external session aborts, so a parent abort could interrupt the cell while `runEvalAgent()` subagents were still running.

## Fix
- Added an abort shield in `packages/coding-agent/src/eval/executor-base.ts` that tracks bridge timeout pause/resume status and defers the registered signal until already-started bridge calls settle.
- Rejected new Python bridge calls in `packages/coding-agent/src/eval/py/tool-bridge.ts` once an external abort is pending, preventing `parallel()` from launching another post-abort `agent()` wave.
- Added regression coverage for the generic bridge shield and updated the Python `parallel(agent())` interrupt test to assert no orphaned bridge calls and preserved kernel state.
- Added a `packages/coding-agent/CHANGELOG.md` entry for #5005.

## Verification
Reproduced before the fix with `bun test packages/coding-agent/src/eval/__tests__/bridge-timeout.test.ts -t "defers external aborts"` (1 failing test, subagent completion marker stayed false). After the fix, `bun test packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts packages/coding-agent/src/eval/__tests__/bridge-timeout.test.ts` passed with 44 tests / 156 assertions, and `bun check` passed in `packages/coding-agent`. Fixes #5005