### PR TITLE
fix(cli): preserve MCP tools when --tools filters built-ins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--tools` filtering in interactive sessions disabling deferred MCP tools; MCP tools discovered from configured servers now stay active when the flag limits only built-in tools. ([#5013](https://github.com/can1357/oh-my-pi/issues/5013))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1763,7 +1763,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 									// Discovery flipped on mid-flight: route the explicit request
 									// through discovery-aware activation so selection persists.
 									await liveSession.activateDiscoveredMCPTools(activation.explicitlyRequestedMCPToolNames);
-								} else if (!discoveryEnabled) {
+								} else if (!discoveryEnabled && !activateAll) {
 									await liveSession.setActiveToolsByName([
 										...liveSession.getActiveToolNames(),
 										...activation.explicitlyRequestedMCPToolNames,
@@ -3055,16 +3055,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					try {
 						await session.refreshMCPTools(
 							tools,
-							deferMCPDiscoveryForUI && !mcpDiscoveryEnabled && options.toolNames === undefined
-								? { activateAll: true }
-								: undefined,
+							deferMCPDiscoveryForUI && !mcpDiscoveryEnabled ? { activateAll: true } : undefined,
 						);
-						if (deferMCPDiscoveryForUI && !mcpDiscoveryEnabled && explicitlyRequestedMCPToolNames.length > 0) {
-							await session.setActiveToolsByName([
-								...session.getActiveToolNames(),
-								...explicitlyRequestedMCPToolNames,
-							]);
-						}
 					} catch (error) {
 						logger.warn("MCP tool refresh failed", {
 							error: error instanceof Error ? error.message : String(error),
@@ -3106,7 +3098,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		startDeferredMCPDiscovery?.(session, {
 			mcpDiscoveryEnabled,
 			explicitlyRequestedMCPToolNames,
-			activateAllMCPTools: !mcpDiscoveryEnabled && options.toolNames === undefined,
+			activateAllMCPTools: !mcpDiscoveryEnabled,
 		});
 
 		return {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6593,8 +6593,8 @@ export class AgentSession {
 	 *
 	 * @param mcpTools The new MCP tools to register.
 	 * @param options.activateAll When true, force-activates every newly registered MCP tool
-	 *   regardless of prior selection state. Used when an ACP client provisions MCP servers
-	 *   for a session where MCP discovery is disabled.
+	 *   regardless of prior selection state. Used when MCP discovery is disabled and tools
+	 *   arrive after initial session activation.
 	 */
 	async refreshMCPTools(mcpTools: CustomTool[], options?: { activateAll?: boolean }): Promise<void> {
 		const previousSelectedMCPToolNames = this.getSelectedMCPToolNames();
@@ -6639,10 +6639,10 @@ export class AgentSession {
 
 		if (options?.activateAll) {
 			// Force-activate every newly registered MCP tool. This path is used
-			// when an ACP client provisions MCP servers for a session where MCP
-			// discovery is disabled — without it, getSelectedMCPToolNames()
-			// returns only already-active tools (circular deadlock: tools can
-			// only become active if they're already active).
+			// when MCP discovery is disabled and tools arrive after initial
+			// activation — without it, getSelectedMCPToolNames() returns only
+			// already-active tools (circular deadlock: tools can only become
+			// active if they're already active).
 			const newMcpNames = mcpTools.map(t => t.name);
 			const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...newMcpNames])];
 			await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });

--- a/packages/coding-agent/test/sdk-mcp-instructions.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-instructions.test.ts
@@ -9,7 +9,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
-import { SERVER_INSTRUCTIONS } from "./fixtures/instructions-mcp";
+import { SERVER_INSTRUCTIONS, TOOL_NAME } from "./fixtures/instructions-mcp";
 
 // Contract: a deferred interactive (`hasUI`) session runs MCP discovery off the
 // first-paint path, so an MCP server's `instructions` are not available when the
@@ -19,6 +19,7 @@ import { SERVER_INSTRUCTIONS } from "./fixtures/instructions-mcp";
 // guard: a prior version gated instruction inclusion on `!deferMCPDiscoveryForUI`,
 // which dropped server instructions permanently for every UI session.
 const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "instructions-mcp.ts");
+const MCP_TOOL_NAME = `mcp__instr_${TOOL_NAME}`;
 
 describe("createAgentSession MCP server instructions (deferred UI)", () => {
 	let registryDir: string;
@@ -109,6 +110,46 @@ describe("createAgentSession MCP server instructions (deferred UI)", () => {
 			expect(prompt).toContain(SERVER_INSTRUCTIONS);
 			// The instructions are framed under the MCP section, not pasted raw.
 			expect(prompt).toContain("MCP Server Instructions");
+		} finally {
+			await session.dispose();
+		}
+	}, 20_000);
+
+	it("keeps MCP tools active after deferred discovery when CLI tool filtering names only built-ins", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({}),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			hasUI: true,
+			toolNames: ["read"],
+		});
+		try {
+			expect(session.getActiveToolNames()).toContain("read");
+
+			// Deferred MCP discovery is fire-and-forget and exposes no promise or
+			// event; fake timers cannot drive the real subprocess handshake, so we
+			// poll the live active-tool state and exit as soon as the fixture tool
+			// appears.
+			const deadline = Date.now() + 12_000;
+			let activeToolNames = session.getActiveToolNames();
+			while (!activeToolNames.includes(MCP_TOOL_NAME) && Date.now() < deadline) {
+				await Bun.sleep(50);
+				activeToolNames = session.getActiveToolNames();
+			}
+
+			expect(activeToolNames).toContain("read");
+			expect(activeToolNames).toContain(MCP_TOOL_NAME);
 		} finally {
 			await session.dispose();
 		}


### PR DESCRIPTION
## Repro
An interactive session with a configured `.mcp.json` server and CLI-style `--tools read` filtering reproduced the issue: after deferred MCP discovery completed, the active tools were only `read`/other built-ins and omitted the fixture MCP tool `mcp__instr_do_thing`. Recorded command: `bun run --cwd packages/coding-agent gen:tool-views && bun .wt/repro-5013-mcp-tools.ts`.

## Cause
`packages/coding-agent/src/sdk.ts` treated any explicit `toolNames` list as a reason not to force-activate MCP tools discovered after first paint. The deferred UI path therefore called `refreshMCPTools` without `activateAll` when `--tools` was present, unlike the blocking startup path where MCP tools are registered as extension tools and included independently of built-in filtering.

## Fix
- Changed deferred MCP refresh activation in `packages/coding-agent/src/sdk.ts` so MCP tools are force-activated whenever MCP discovery mode is disabled, regardless of whether `toolNames` filtered built-ins.
- Removed the now-redundant explicit-MCP reactivation path for deferred refreshes to avoid duplicate active tool entries.
- Updated `AgentSession.refreshMCPTools` comments to describe the broader delayed-tool activation case.
- Added a regression test in `packages/coding-agent/test/sdk-mcp-instructions.test.ts` covering `hasUI: true`, `.mcp.json`, and `toolNames: ["read"]`.

## Verification
Re-ran the recorded repro after the fix: `bun .wt/repro-5013-mcp-tools.ts` exited 0 and reported active tools including `mcp__instr_do_thing`. Ran `bun test packages/coding-agent/test/sdk-mcp-instructions.test.ts`: `2 pass`, `0 fail`, `6 expect() calls`. Pre-publish `gh_push_branch` completed successfully. Fixes #5013