### PR TITLE
fix(ai): preserve vLLM cached token usage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-compatible chat-completions streams preserving vLLM-style trailing cached-token usage chunks so `cacheRead` and billable `input` session stats are accurate ([#5022](https://github.com/can1357/oh-my-pi/issues/5022)).
+
 ## [16.3.15] - 2026-07-09
 
 ### Breaking Changes

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -156,16 +156,16 @@ function firstPositiveNumber(...values: unknown[]): number {
 	return 0;
 }
 
-function hasCacheReadTokenField(rawUsage: object): boolean {
+function hasPositiveCacheReadTokenField(rawUsage: object): boolean {
 	const usageLike = rawUsage as OpenAICompletionsUsageLike;
-	if (typeof usageLike.cached_tokens === "number") return true;
-	if (typeof usageLike.prompt_cache_hit_tokens === "number") return true;
+	if (typeof usageLike.cached_tokens === "number" && usageLike.cached_tokens > 0) return true;
+	if (typeof usageLike.prompt_cache_hit_tokens === "number" && usageLike.prompt_cache_hit_tokens > 0) return true;
 
 	const rawPromptTokenDetails = usageLike.prompt_tokens_details;
 	if (typeof rawPromptTokenDetails !== "object" || rawPromptTokenDetails === null) return false;
 
 	const promptTokenDetails = rawPromptTokenDetails as OpenAICompletionsPromptTokenDetails;
-	return typeof promptTokenDetails.cached_tokens === "number";
+	return typeof promptTokenDetails.cached_tokens === "number" && promptTokenDetails.cached_tokens > 0;
 }
 
 /**
@@ -1012,7 +1012,7 @@ const streamOpenAICompletionsOnce = (
 			const applyUsagePayload = (rawUsage: object): void => {
 				output.usage = parseChunkUsage(rawUsage, model, premiumRequestsTotal);
 				sawUsagePayload = true;
-				awaitTrailingUsageDetails = !hasCacheReadTokenField(rawUsage);
+				awaitTrailingUsageDetails = !hasPositiveCacheReadTokenField(rawUsage);
 			};
 			const timedOpenaiStream = iterateWithIdleTimeout(openaiStream, {
 				idleTimeoutMs,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -156,6 +156,18 @@ function firstPositiveNumber(...values: unknown[]): number {
 	return 0;
 }
 
+function hasCacheReadTokenField(rawUsage: object): boolean {
+	const usageLike = rawUsage as OpenAICompletionsUsageLike;
+	if (typeof usageLike.cached_tokens === "number") return true;
+	if (typeof usageLike.prompt_cache_hit_tokens === "number") return true;
+
+	const rawPromptTokenDetails = usageLike.prompt_tokens_details;
+	if (typeof rawPromptTokenDetails !== "object" || rawPromptTokenDetails === null) return false;
+
+	const promptTokenDetails = rawPromptTokenDetails as OpenAICompletionsPromptTokenDetails;
+	return typeof promptTokenDetails.cached_tokens === "number";
+}
+
 /**
  * Normalize tool call ID for Mistral.
  * Mistral requires tool IDs to be exactly 9 alphanumeric characters (a-z, A-Z, 0-9).
@@ -990,9 +1002,18 @@ const streamOpenAICompletionsOnce = (
 
 			// Terminal-chunk bookkeeping for the post-finish grace window below.
 			// `streamFinishedAt` flips when a chunk carries `finish_reason`;
-			// `sawUsagePayload` flips when a usage payload was parsed.
+			// `sawUsagePayload` flips when a usage payload was parsed. Some
+			// OpenAI-compatible servers send basic usage with `finish_reason` and
+			// cache-read details in a trailing usage-only chunk, so only the
+			// no-choice terminal path may break while those details are pending.
 			let streamFinishedAt: number | undefined;
 			let sawUsagePayload = false;
+			let awaitTrailingUsageDetails = false;
+			const applyUsagePayload = (rawUsage: object): void => {
+				output.usage = parseChunkUsage(rawUsage, model, premiumRequestsTotal);
+				sawUsagePayload = true;
+				awaitTrailingUsageDetails = !hasCacheReadTokenField(rawUsage);
+			};
 			const timedOpenaiStream = iterateWithIdleTimeout(openaiStream, {
 				idleTimeoutMs,
 				firstItemTimeoutMs: firstEventTimeoutMs,
@@ -1030,8 +1051,7 @@ const streamOpenAICompletionsOnce = (
 				}
 
 				if (chunk.usage) {
-					output.usage = parseChunkUsage(chunk.usage, model, premiumRequestsTotal);
-					sawUsagePayload = true;
+					applyUsagePayload(chunk.usage);
 				}
 
 				const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
@@ -1046,8 +1066,7 @@ const streamOpenAICompletionsOnce = (
 				if (!chunk.usage) {
 					const choiceUsage = (choice as OpenAICompletionsChoiceUsage).usage;
 					if (typeof choiceUsage === "object" && choiceUsage !== null) {
-						output.usage = parseChunkUsage(choiceUsage, model, premiumRequestsTotal);
-						sawUsagePayload = true;
+						applyUsagePayload(choiceUsage);
 					}
 				}
 
@@ -1239,11 +1258,10 @@ const streamOpenAICompletionsOnce = (
 					}
 				}
 
-				// `finish_reason` + usage both observed: the chat-completions
-				// contract has nothing left to deliver. Break instead of waiting
-				// for `[DONE]`/connection close so hosts that hold the socket open
-				// can't park the turn until the idle watchdog errors it out.
-				if (streamFinishedAt !== undefined && sawUsagePayload) break;
+				// If usage arrived on the finish chunk without cache-read fields,
+				// keep draining through the grace window for vLLM-style trailing
+				// usage details instead of finalizing the incomplete accounting.
+				if (streamFinishedAt !== undefined && sawUsagePayload && !awaitTrailingUsageDetails) break;
 			}
 
 			if (streamMarkupHealing) {

--- a/packages/ai/test/openai-stream-terminal-close.test.ts
+++ b/packages/ai/test/openai-stream-terminal-close.test.ts
@@ -88,6 +88,38 @@ describe("terminal frame without connection close", () => {
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
 	}, 10_000);
 
+	it("openai-completions: keeps reading usage-only cache details after finish usage", async () => {
+		const fetchMock = createNeverClosingFetch([
+			completionChunk({
+				choices: [{ index: 0, delta: { role: "assistant", content: "Hello" }, finish_reason: "stop" }],
+				usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+			}),
+			completionChunk({
+				choices: [],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+					prompt_tokens_details: { cached_tokens: 4 },
+				},
+			}),
+		]);
+
+		const startedAt = Date.now();
+		const result = await streamOpenAICompletions(completionsModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+		expect(result.content).toEqual([{ type: "text", text: "Hello" }]);
+		expect(result.usage.input).toBe(6);
+		expect(result.usage.cacheRead).toBe(4);
+		expect(result.usage.output).toBe(5);
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+	}, 10_000);
+
 	it("openai-completions: ends cleanly via the grace window when no usage chunk ever arrives", async () => {
 		const fetchMock = createNeverClosingFetch([
 			completionChunk({ choices: [{ index: 0, delta: { role: "assistant", content: "Hello" } }] }),

--- a/packages/ai/test/openai-stream-terminal-close.test.ts
+++ b/packages/ai/test/openai-stream-terminal-close.test.ts
@@ -88,11 +88,16 @@ describe("terminal frame without connection close", () => {
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
 	}, 10_000);
 
-	it("openai-completions: keeps reading usage-only cache details after finish usage", async () => {
+	it("openai-completions: ignores zero cache placeholder until trailing positive cache details arrive", async () => {
 		const fetchMock = createNeverClosingFetch([
 			completionChunk({
 				choices: [{ index: 0, delta: { role: "assistant", content: "Hello" }, finish_reason: "stop" }],
-				usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+					prompt_tokens_details: { cached_tokens: 0 },
+				},
 			}),
 			completionChunk({
 				choices: [],


### PR DESCRIPTION
## Repro
A synthetic OpenAI-compatible SSE stream matching the reported vLLM sequence reproduces the bug: the `finish_reason: "stop"` chunk carries basic `usage`, then a following usage-only chunk carries `prompt_tokens_details.cached_tokens`. Before the fix, `streamOpenAICompletions` returned `{"input":35227,"cacheRead":0}` instead of subtracting the trailing cached tokens.

## Cause
`packages/ai/src/providers/openai-completions.ts` broke out of the streaming loop as soon as `streamFinishedAt` and `sawUsagePayload` were both set. When vLLM sent basic usage on the same chunk as `finish_reason`, that early break finalized incomplete accounting before the later usage-only chunk with `prompt_tokens_details.cached_tokens` could be read.

## Fix
- Added cache-read-field detection for OpenAI-compatible usage payloads.
- Kept draining through the existing post-finish grace window when the finish chunk has usage but no cache-read fields.
- Preserved the immediate terminal break after a post-finish usage-only chunk is processed.
- Added regression coverage for vLLM-style two-stage streaming usage accounting.

## Verification
`bun test packages/ai/test/openai-stream-terminal-close.test.ts` passed: 4 tests, 22 assertions. `gh_push_branch` completed the pre-publish gate before pushing. Fixes #5022