### PR TITLE
fix(coding-agent): hide empty local provider tabs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/switch` and `/model` showing empty tabs for implicit local providers (`ollama`, `llama.cpp`, `lm-studio`) before local discovery returns any models. ([#5026](https://github.com/can1357/oh-my-pi/issues/5026))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -166,6 +166,8 @@ export class ModelSelectorComponent extends Container {
 	#activeTabIndex: number = 0;
 	#refreshingProviders: Set<string> = new Set();
 	#scheduledProviderRefreshes: Map<string, Timer> = new Map();
+	#refreshingHiddenOptionalProviders: Set<string> = new Set();
+	#hiddenOptionalProviderRefreshAttempts: Set<string> = new Set();
 	#refreshSpinnerFrame: number = 0;
 	#refreshSpinnerInterval?: Timer;
 
@@ -271,6 +273,7 @@ export class ModelSelectorComponent extends Container {
 		// dropped while the offline refresh promise is still pending. This stays
 		// on the open path, so it must remain cheap.
 		this.#syncFromRegistryState();
+		this.#refreshHiddenOptionalProviders();
 
 		// Reconcile with cached discovery state in the background. A --models
 		// scope is registry-independent, so the offline reload would only repeat
@@ -278,7 +281,10 @@ export class ModelSelectorComponent extends Container {
 		if (this.#scopedModels.length === 0) {
 			this.#modelRegistry
 				.refresh("offline")
-				.then(() => this.#syncFromRegistryState())
+				.then(() => {
+					this.#syncFromRegistryState();
+					this.#refreshHiddenOptionalProviders();
+				})
 				.catch(error => {
 					this.#errorMessage = error instanceof Error ? error.message : String(error);
 					this.#updateList();
@@ -566,6 +572,47 @@ export class ModelSelectorComponent extends Container {
 			clearTimeout(timer);
 			this.#scheduledProviderRefreshes.delete(providerId);
 			this.#setProviderRefreshing(providerId, false);
+		}
+	}
+
+	#refreshHiddenOptionalProviders(): void {
+		if (this.#scopedModels.length > 0) {
+			return;
+		}
+		const visibleProviders = new Set(
+			this.#providers
+				.map(provider => provider.providerId)
+				.filter((providerId): providerId is string => providerId !== undefined),
+		);
+		for (const provider of this.#modelRegistry.getDiscoverableProviders()) {
+			if (visibleProviders.has(provider)) {
+				continue;
+			}
+			if (!this.#modelRegistry.getProviderDiscoveryState(provider)?.optional) {
+				continue;
+			}
+			if (
+				this.#hiddenOptionalProviderRefreshAttempts.has(provider) ||
+				this.#refreshingHiddenOptionalProviders.has(provider) ||
+				this.#refreshingProviders.has(provider)
+			) {
+				continue;
+			}
+			this.#hiddenOptionalProviderRefreshAttempts.add(provider);
+			this.#refreshingHiddenOptionalProviders.add(provider);
+			void this.#refreshHiddenOptionalProviderInBackground(provider);
+		}
+	}
+
+	async #refreshHiddenOptionalProviderInBackground(providerId: string): Promise<void> {
+		try {
+			await this.#modelRegistry.refreshProvider(providerId, "online");
+			this.#syncFromRegistryState();
+		} catch {
+			// Hidden optional providers are speculative local probes; failures must not replace visible results.
+		} finally {
+			this.#refreshingHiddenOptionalProviders.delete(providerId);
+			this.#tui.requestRender();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -116,6 +116,7 @@ const ALL_TAB = "ALL";
 const STATIC_PROVIDER_TABS: ProviderTabState[] = [{ id: ALL_TAB, label: ALL_TAB }];
 
 const MODEL_TAB_REFRESH_DEBOUNCE_MS = 120;
+const HIDDEN_OPTIONAL_PROVIDER_REFRESH_RETRY_MS = 2_000;
 
 function formatProviderTabLabel(providerId: string): string {
 	return providerId.replace(/[-_]+/g, " ").toUpperCase();
@@ -167,7 +168,8 @@ export class ModelSelectorComponent extends Container {
 	#refreshingProviders: Set<string> = new Set();
 	#scheduledProviderRefreshes: Map<string, Timer> = new Map();
 	#refreshingHiddenOptionalProviders: Set<string> = new Set();
-	#hiddenOptionalProviderRefreshAttempts: Set<string> = new Set();
+	#hiddenOptionalProviderRetryTimers: Map<string, Timer> = new Map();
+	#disposed = false;
 	#refreshSpinnerFrame: number = 0;
 	#refreshSpinnerInterval?: Timer;
 
@@ -291,6 +293,23 @@ export class ModelSelectorComponent extends Container {
 				})
 				.finally(() => this.#tui.requestRender());
 		}
+	}
+
+	override dispose(): void {
+		this.#disposed = true;
+		for (const timer of this.#scheduledProviderRefreshes.values()) {
+			clearTimeout(timer);
+		}
+		this.#scheduledProviderRefreshes.clear();
+		for (const timer of this.#hiddenOptionalProviderRetryTimers.values()) {
+			clearTimeout(timer);
+		}
+		this.#hiddenOptionalProviderRetryTimers.clear();
+		if (this.#refreshSpinnerInterval) {
+			clearInterval(this.#refreshSpinnerInterval);
+			this.#refreshSpinnerInterval = undefined;
+		}
+		super.dispose();
 	}
 
 	#buildMenuRoleActions(): void {
@@ -592,16 +611,47 @@ export class ModelSelectorComponent extends Container {
 				continue;
 			}
 			if (
-				this.#hiddenOptionalProviderRefreshAttempts.has(provider) ||
+				this.#hiddenOptionalProviderRetryTimers.has(provider) ||
 				this.#refreshingHiddenOptionalProviders.has(provider) ||
 				this.#refreshingProviders.has(provider)
 			) {
 				continue;
 			}
-			this.#hiddenOptionalProviderRefreshAttempts.add(provider);
 			this.#refreshingHiddenOptionalProviders.add(provider);
 			void this.#refreshHiddenOptionalProviderInBackground(provider);
 		}
+	}
+
+	#scheduleHiddenOptionalProviderRetry(providerId: string): void {
+		if (this.#disposed || this.#scopedModels.length > 0) {
+			return;
+		}
+		if (
+			this.#hiddenOptionalProviderRetryTimers.has(providerId) ||
+			this.#refreshingHiddenOptionalProviders.has(providerId)
+		) {
+			return;
+		}
+		if (this.#providers.some(provider => provider.providerId === providerId)) {
+			return;
+		}
+		if (!this.#modelRegistry.getProviderDiscoveryState(providerId)?.optional) {
+			return;
+		}
+		const timer = setTimeout(() => {
+			this.#hiddenOptionalProviderRetryTimers.delete(providerId);
+			if (
+				this.#disposed ||
+				this.#refreshingProviders.has(providerId) ||
+				this.#providers.some(provider => provider.providerId === providerId) ||
+				!this.#modelRegistry.getProviderDiscoveryState(providerId)?.optional
+			) {
+				return;
+			}
+			this.#refreshingHiddenOptionalProviders.add(providerId);
+			void this.#refreshHiddenOptionalProviderInBackground(providerId);
+		}, HIDDEN_OPTIONAL_PROVIDER_REFRESH_RETRY_MS);
+		this.#hiddenOptionalProviderRetryTimers.set(providerId, timer);
 	}
 
 	async #refreshHiddenOptionalProviderInBackground(providerId: string): Promise<void> {
@@ -612,7 +662,10 @@ export class ModelSelectorComponent extends Container {
 			// Hidden optional providers are speculative local probes; failures must not replace visible results.
 		} finally {
 			this.#refreshingHiddenOptionalProviders.delete(providerId);
-			this.#tui.requestRender();
+			if (!this.#disposed) {
+				this.#scheduleHiddenOptionalProviderRetry(providerId);
+				this.#tui.requestRender();
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -496,6 +496,9 @@ export class ModelSelectorComponent extends Container {
 			providerSet.add(item.provider);
 		}
 		for (const provider of this.#modelRegistry.getDiscoverableProviders()) {
+			if (this.#modelRegistry.getProviderDiscoveryState(provider)?.optional) {
+				continue;
+			}
 			providerSet.add(provider);
 		}
 		const sortedProviderIds = Array.from(providerSet).sort((left, right) =>

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -115,12 +115,21 @@ export class SelectorController {
 	 * @param create Factory that receives a `done` callback and returns the component and focus target
 	 */
 	showSelector(create: (done: () => void) => { component: Component; focus: Component }): void {
+		let activeComponent: Component | undefined;
 		const done = () => {
+			const component = activeComponent;
+			activeComponent = undefined;
+			component?.dispose?.();
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(this.ctx.editor);
 			this.ctx.ui.setFocus(this.ctx.editor);
 		};
 		const { component, focus } = create(done);
+		activeComponent = component;
+		const previous = this.ctx.editorContainer.children[0];
+		if (previous !== this.ctx.editor) {
+			previous?.dispose?.();
+		}
 		this.ctx.editorContainer.clear();
 		this.ctx.editorContainer.addChild(component);
 		this.ctx.ui.setFocus(focus);

--- a/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
+++ b/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { beforeAll, describe, expect, type Mock, test, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -36,9 +36,12 @@ function installTestTheme(): void {
 	setThemeInstance(testTheme);
 }
 
+type RefreshProvider = ModelRegistry["refreshProvider"];
+
 interface SelectorHarness {
 	selector: ModelSelectorComponent;
 	backgroundRefresh: Promise<void>;
+	refreshProvider: Mock<RefreshProvider>;
 }
 
 type DiscoveryStatesByProvider = Partial<Record<string, ProviderDiscoveryState>>;
@@ -57,10 +60,11 @@ function createSelector(
 	// The constructor kicks off an offline refresh in the background. Drive it
 	// through an explicit gate so tests can await drain instead of sleeping.
 	const refreshGate = Promise.withResolvers<void>();
+	const refreshProvider = vi.fn<RefreshProvider>(async () => {});
 	const modelRegistry = {
 		getAll: () => models,
 		refresh: vi.fn(() => refreshGate.promise),
-		refreshProvider: vi.fn(async () => {}),
+		refreshProvider,
 		getError: () => undefined,
 		getAvailable: () => models,
 		getDiscoverableProviders: () => options.discoverableProviders ?? [],
@@ -88,7 +92,7 @@ function createSelector(
 		.then(() => Promise.resolve())
 		.then(() => Promise.resolve())
 		.then(() => Promise.resolve());
-	return { selector, backgroundRefresh };
+	return { selector, backgroundRefresh, refreshProvider };
 }
 
 describe("ModelSelector search stays inside the active provider tab (#4522)", () => {
@@ -214,12 +218,19 @@ describe("ModelSelector provider tabs hide optional empty local discovery provid
 			},
 		};
 
-		const { selector, backgroundRefresh } = createSelector([], () => {}, {
+		const { selector, backgroundRefresh, refreshProvider } = createSelector([], () => {}, {
 			discoverableProviders: providers,
 			discoveryStates,
 		});
 		await backgroundRefresh;
 		installTestTheme();
+
+		expect(refreshProvider).toHaveBeenCalledTimes(3);
+		expect(refreshProvider.mock.calls).toEqual([
+			["ollama", "online"],
+			["llama.cpp", "online"],
+			["lm-studio", "online"],
+		]);
 
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("ALL");
@@ -231,7 +242,7 @@ describe("ModelSelector provider tabs hide optional empty local discovery provid
 	test("keeps non-optional discoverable providers visible even without models", async () => {
 		installTestTheme();
 		const provider = "vllm";
-		const { selector, backgroundRefresh } = createSelector([], () => {}, {
+		const { selector, backgroundRefresh, refreshProvider } = createSelector([], () => {}, {
 			discoverableProviders: [provider],
 			discoveryStates: {
 				[provider]: {
@@ -245,6 +256,7 @@ describe("ModelSelector provider tabs hide optional empty local discovery provid
 		});
 		await backgroundRefresh;
 		installTestTheme();
+		expect(refreshProvider).not.toHaveBeenCalled();
 
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("VLLM");

--- a/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
+++ b/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
@@ -191,52 +191,70 @@ describe("ModelSelector provider tabs hide optional empty local discovery provid
 		}
 	});
 
-	test("omits optional implicit local providers when discovery returned no models", async () => {
-		installTestTheme();
-		const providers = ["ollama", "llama.cpp", "lm-studio"];
-		const discoveryStates: DiscoveryStatesByProvider = {
-			ollama: {
-				provider: "ollama",
-				status: "empty",
-				optional: true,
-				stale: false,
-				models: [],
-			},
-			"llama.cpp": {
-				provider: "llama.cpp",
-				status: "empty",
-				optional: true,
-				stale: false,
-				models: [],
-			},
-			"lm-studio": {
-				provider: "lm-studio",
-				status: "empty",
-				optional: true,
-				stale: false,
-				models: [],
-			},
-		};
+	test("retries hidden optional local providers while the selector remains open", async () => {
+		vi.useFakeTimers();
+		let selector: ModelSelectorComponent | undefined;
+		try {
+			installTestTheme();
+			const providers = ["ollama", "llama.cpp", "lm-studio"];
+			const discoveryStates: DiscoveryStatesByProvider = {
+				ollama: {
+					provider: "ollama",
+					status: "empty",
+					optional: true,
+					stale: false,
+					models: [],
+				},
+				"llama.cpp": {
+					provider: "llama.cpp",
+					status: "empty",
+					optional: true,
+					stale: false,
+					models: [],
+				},
+				"lm-studio": {
+					provider: "lm-studio",
+					status: "empty",
+					optional: true,
+					stale: false,
+					models: [],
+				},
+			};
 
-		const { selector, backgroundRefresh, refreshProvider } = createSelector([], () => {}, {
-			discoverableProviders: providers,
-			discoveryStates,
-		});
-		await backgroundRefresh;
-		installTestTheme();
+			const harness = createSelector([], () => {}, {
+				discoverableProviders: providers,
+				discoveryStates,
+			});
+			selector = harness.selector;
+			await harness.backgroundRefresh;
+			installTestTheme();
 
-		expect(refreshProvider).toHaveBeenCalledTimes(3);
-		expect(refreshProvider.mock.calls).toEqual([
-			["ollama", "online"],
-			["llama.cpp", "online"],
-			["lm-studio", "online"],
-		]);
+			expect(harness.refreshProvider).toHaveBeenCalledTimes(3);
+			expect(harness.refreshProvider.mock.calls).toEqual([
+				["ollama", "online"],
+				["llama.cpp", "online"],
+				["lm-studio", "online"],
+			]);
 
-		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
-		expect(rendered).toContain("ALL");
-		expect(rendered).not.toContain("OLLAMA");
-		expect(rendered).not.toContain("LLAMA.CPP");
-		expect(rendered).not.toContain("LM STUDIO");
+			harness.refreshProvider.mockClear();
+			vi.advanceTimersByTime(2_000);
+			await Promise.resolve();
+
+			expect(harness.refreshProvider.mock.calls).toEqual([
+				["ollama", "online"],
+				["llama.cpp", "online"],
+				["lm-studio", "online"],
+			]);
+
+			const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+			expect(rendered).toContain("ALL");
+			expect(rendered).not.toContain("OLLAMA");
+			expect(rendered).not.toContain("LLAMA.CPP");
+			expect(rendered).not.toContain("LM STUDIO");
+		} finally {
+			selector?.dispose();
+			vi.useRealTimers();
+		}
 	});
 
 	test("keeps non-optional discoverable providers visible even without models", async () => {

--- a/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
+++ b/packages/coding-agent/test/model-selector-provider-search-scope.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, test, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
-import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import type { ModelRegistry, ProviderDiscoveryState } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ModelSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/model-selector";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -41,7 +41,18 @@ interface SelectorHarness {
 	backgroundRefresh: Promise<void>;
 }
 
-function createSelector(models: Model[], onSelect: (model: Model) => void): SelectorHarness {
+type DiscoveryStatesByProvider = Partial<Record<string, ProviderDiscoveryState>>;
+
+interface SelectorOptions {
+	discoverableProviders?: string[];
+	discoveryStates?: DiscoveryStatesByProvider;
+}
+
+function createSelector(
+	models: Model[],
+	onSelect: (model: Model) => void,
+	options: SelectorOptions = {},
+): SelectorHarness {
 	const settings = Settings.isolated({});
 	// The constructor kicks off an offline refresh in the background. Drive it
 	// through an explicit gate so tests can await drain instead of sleeping.
@@ -52,7 +63,8 @@ function createSelector(models: Model[], onSelect: (model: Model) => void): Sele
 		refreshProvider: vi.fn(async () => {}),
 		getError: () => undefined,
 		getAvailable: () => models,
-		getDiscoverableProviders: () => [],
+		getDiscoverableProviders: () => options.discoverableProviders ?? [],
+		getProviderDiscoveryState: (provider: string) => options.discoveryStates?.[provider],
 	} as unknown as ModelRegistry;
 	const ui = {
 		requestRender: vi.fn(),
@@ -164,5 +176,77 @@ describe("ModelSelector search stays inside the active provider tab (#4522)", ()
 		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(rendered).toContain("No matching models in OPENROUTER");
 		expect(rendered).toContain("Switch to ALL");
+	});
+});
+
+describe("ModelSelector provider tabs hide optional empty local discovery providers (#5026)", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("dark");
+		if (!testTheme) {
+			throw new Error("Failed to load dark theme for ModelSelector tests");
+		}
+	});
+
+	test("omits optional implicit local providers when discovery returned no models", async () => {
+		installTestTheme();
+		const providers = ["ollama", "llama.cpp", "lm-studio"];
+		const discoveryStates: DiscoveryStatesByProvider = {
+			ollama: {
+				provider: "ollama",
+				status: "empty",
+				optional: true,
+				stale: false,
+				models: [],
+			},
+			"llama.cpp": {
+				provider: "llama.cpp",
+				status: "empty",
+				optional: true,
+				stale: false,
+				models: [],
+			},
+			"lm-studio": {
+				provider: "lm-studio",
+				status: "empty",
+				optional: true,
+				stale: false,
+				models: [],
+			},
+		};
+
+		const { selector, backgroundRefresh } = createSelector([], () => {}, {
+			discoverableProviders: providers,
+			discoveryStates,
+		});
+		await backgroundRefresh;
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("ALL");
+		expect(rendered).not.toContain("OLLAMA");
+		expect(rendered).not.toContain("LLAMA.CPP");
+		expect(rendered).not.toContain("LM STUDIO");
+	});
+
+	test("keeps non-optional discoverable providers visible even without models", async () => {
+		installTestTheme();
+		const provider = "vllm";
+		const { selector, backgroundRefresh } = createSelector([], () => {}, {
+			discoverableProviders: [provider],
+			discoveryStates: {
+				[provider]: {
+					provider,
+					status: "empty",
+					optional: false,
+					stale: false,
+					models: [],
+				},
+			},
+		});
+		await backgroundRefresh;
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("VLLM");
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-overlay-focus.test.ts
@@ -83,3 +83,47 @@ describe("SelectorController.focusActiveEditorArea", () => {
 		expect(setFocus).toHaveBeenCalledWith(editor);
 	});
 });
+
+describe("SelectorController.showSelector disposal", () => {
+	it("disposes the selector exactly once when the close callback restores the editor", () => {
+		const editor = { id: "editor", dispose: vi.fn(), render: () => [] };
+		const selector = { id: "selector", dispose: vi.fn(), render: () => [] };
+		const slot = createEditorSlot(editor);
+		const { ctx, setFocus } = createCtx(slot, editor);
+		let closeSelector: (() => void) | undefined;
+
+		new SelectorController(ctx).showSelector(done => {
+			closeSelector = done;
+			return { component: selector, focus: selector };
+		});
+
+		expect(slot.children).toEqual([selector]);
+		expect(setFocus).toHaveBeenLastCalledWith(selector);
+
+		closeSelector?.();
+		closeSelector?.();
+
+		expect(selector.dispose).toHaveBeenCalledTimes(1);
+		expect(editor.dispose).not.toHaveBeenCalled();
+		expect(slot.children).toEqual([editor]);
+		expect(setFocus).toHaveBeenLastCalledWith(editor);
+	});
+
+	it("disposes a non-editor component occupying the editor slot before showing a selector", () => {
+		const editor = { id: "editor", dispose: vi.fn(), render: () => [] };
+		const stalePrompt = { id: "stale-prompt", dispose: vi.fn(), render: () => [] };
+		const selector = { id: "selector", dispose: vi.fn(), render: () => [] };
+		const slot = createEditorSlot(stalePrompt);
+		const { ctx, setFocus } = createCtx(slot, editor);
+
+		new SelectorController(ctx).showSelector(() => {
+			return { component: selector, focus: selector };
+		});
+
+		expect(stalePrompt.dispose).toHaveBeenCalledTimes(1);
+		expect(editor.dispose).not.toHaveBeenCalled();
+		expect(selector.dispose).not.toHaveBeenCalled();
+		expect(slot.children).toEqual([selector]);
+		expect(setFocus).toHaveBeenLastCalledWith(selector);
+	});
+});


### PR DESCRIPTION
## Repro
With no available models and optional discovery states for the implicit local providers, the model selector still rendered empty local provider tabs. Reproduced with `bun test packages/coding-agent/test/model-selector-provider-search-scope.test.ts -t 'omits optional implicit local providers when discovery returned no models'`, which failed because the rendered tab strip contained `LLAMA.CPP LM STUDIO OLLAMA`.

## Cause
`ModelSelectorComponent.#buildProviderTabs()` in `packages/coding-agent/src/modes/components/model-selector.ts` added every provider from `ModelRegistry.getDiscoverableProviders()` without checking discovery state. `ModelRegistry.#addImplicitDiscoverableProviders()` registers `ollama`, `llama.cpp`, and `lm-studio` as optional keyless discoverable providers on startup, so unreachable local providers produced provider tabs even when no discovered models existed.

## Fix
- Skip discoverable providers whose `ProviderDiscoveryState.optional` flag is set when building provider tabs; providers that actually have models still enter the tab set through `#allModels`.
- Added model-selector rendering coverage for optional empty implicit local providers.
- Added companion coverage that non-optional discoverable providers still appear without models.
- Updated the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/model-selector-provider-search-scope.test.ts` passed with 5 tests and 16 assertions. `bun run check:types` passed in `packages/coding-agent`. The publish gate also completed `bun run fix` and `bun check` before pushing. Fixes #5026