### PR TITLE
fix(tui): refresh context usage after shake

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.test.ts
@@ -16,6 +16,32 @@ function makeSessionWithLastMessage(lastMessage: unknown) {
 	};
 }
 
+function makeMutableContextUsageSession(initialTokens: number) {
+	let tokens = initialTokens;
+	const session = {
+		messages: [
+			{
+				role: "assistant",
+				timestamp: 1,
+				usage: { totalTokens: 10 },
+				content: [],
+			},
+		],
+		model: { contextWindow: 128000 },
+		contextUsageRevision: 0,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		getContextUsage: () => ({ tokens, contextWindow: 128000 }),
+	};
+	return {
+		session,
+		setTokens(nextTokens: number): void {
+			tokens = nextTokens;
+		},
+	};
+}
+
 beforeAll(async () => {
 	await Settings.init({ inMemory: true });
 	const loaded = await getThemeByName("dark");
@@ -40,5 +66,17 @@ describe("StatusLineComponent", () => {
 		);
 
 		expect(statusLine.getCachedContextBreakdown()).toEqual({ usedTokens: 42, contextWindow: 128000 });
+	});
+
+	it("recomputes context tokens after explicit invalidation", () => {
+		const { session, setTokens } = makeMutableContextUsageSession(1000);
+		const statusLine = new StatusLineComponent(session as unknown as AgentSession);
+
+		expect(statusLine.getCachedContextBreakdown()).toEqual({ usedTokens: 1000, contextWindow: 128000 });
+
+		setTokens(250);
+		statusLine.invalidate();
+
+		expect(statusLine.getCachedContextBreakdown()).toEqual({ usedTokens: 250, contextWindow: 128000 });
 	});
 });

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -569,6 +569,7 @@ export class StatusLineComponent implements Component {
 	}
 
 	invalidate(): void {
+		this.#contextUsageCache = undefined;
 		this.#invalidateGitCaches();
 	}
 	#invalidateSessionCaches(): void {


### PR DESCRIPTION
## Repro
Running a focused status-line reproduction showed the stale total: instantiate `StatusLineComponent`, read context tokens at 1000, change `session.getContextUsage()` to 250, call `statusLine.invalidate()`, and the second `getCachedContextBreakdown()` still returned 1000 before the fix.

## Cause
`packages/coding-agent/src/modes/components/status-line/component.ts` memoizes context usage in `StatusLineComponent#getCachedContextBreakdown()`, but `StatusLineComponent.invalidate()` only cleared git caches. `/shake` in `packages/coding-agent/src/modes/controllers/command-controller.ts` and auto-shake in `packages/coding-agent/src/modes/controllers/event-controller.ts` already called `ctx.statusLine.invalidate()`, but the context-usage memo survived when the message-array cache keys stayed stable.

## Fix
- Clear `#contextUsageCache` inside `StatusLineComponent.invalidate()` while leaving the rate-limit usage cache intact.
- Add a regression test covering explicit invalidation after the session context token total changes.

## Verification
- `bun test packages/coding-agent/src/modes/components/status-line/component.test.ts` → 2 pass, 0 fail.
- `gh_push_branch` pre-publish gate completed and pushed the branch.

Fixes #5029