### PR TITLE
fix(lsp): handle go.work workspace diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LSP workspace diagnostics for Go workspaces so roots with `go.work` are recognized and every `go.work use` module is included in the `go build` package patterns. ([#5038](https://github.com/can1357/oh-my-pi/issues/5038))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -573,8 +573,79 @@ interface ProjectType {
 	description: string;
 }
 
+/** Convert a `go.work` use directory into the package pattern `go build` needs. */
+function goWorkspaceBuildPattern(diskPath: string): string | null {
+	const trimmed = diskPath.trim();
+	if (!trimmed) return null;
+
+	const isAbsolute = path.isAbsolute(trimmed) || path.win32.isAbsolute(trimmed);
+	const normalized = trimmed.replaceAll("\\", "/").replace(/\/+$/, "");
+	const dir = normalized || ".";
+	if (dir === ".") return "./...";
+	if (dir.endsWith("/...")) return dir;
+	if (isAbsolute || dir.startsWith("./") || dir.startsWith("../")) return `${dir}/...`;
+	return `./${dir}/...`;
+}
+
+/** Parse `go work edit -json` output into per-module package patterns. */
+function parseGoWorkspaceBuildPatterns(output: string): string[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(output);
+	} catch {
+		return [];
+	}
+
+	if (!parsed || typeof parsed !== "object" || !("Use" in parsed) || !Array.isArray(parsed.Use)) return [];
+
+	const patterns = new Set<string>();
+	for (const entry of parsed.Use) {
+		if (!entry || typeof entry !== "object" || !("DiskPath" in entry) || typeof entry.DiskPath !== "string") {
+			continue;
+		}
+		const pattern = goWorkspaceBuildPattern(entry.DiskPath);
+		if (pattern) patterns.add(pattern);
+	}
+	return [...patterns];
+}
+
+/** Resolve the `go build` command for a `go.work` workspace. */
+async function resolveGoWorkspaceDiagnosticsCommand(cwd: string, signal?: AbortSignal): Promise<string[]> {
+	const fallback = ["go", "build", "./..."];
+	try {
+		const proc = Bun.spawn(["go", "work", "edit", "-json"], {
+			cwd,
+			stdout: "pipe",
+			stderr: "pipe",
+			windowsHide: true,
+		});
+		const abortHandler = () => {
+			proc.kill();
+		};
+		if (signal) {
+			signal.addEventListener("abort", abortHandler, { once: true });
+		}
+
+		try {
+			const [stdout] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+			const exitCode = await proc.exited;
+			throwIfAborted(signal);
+			if (exitCode !== 0) return fallback;
+			const patterns = parseGoWorkspaceBuildPatterns(stdout);
+			return patterns.length > 0 ? ["go", "build", ...patterns] : fallback;
+		} finally {
+			signal?.removeEventListener("abort", abortHandler);
+		}
+	} catch {
+		if (signal?.aborted) {
+			throw new ToolAbortError();
+		}
+		return fallback;
+	}
+}
+
 /** Detect project type from root markers */
-function detectProjectType(cwd: string): ProjectType {
+async function detectProjectType(cwd: string, signal?: AbortSignal): Promise<ProjectType> {
 	// Check for Rust (Cargo.toml)
 	if (fs.existsSync(path.join(cwd, "Cargo.toml"))) {
 		return { type: "rust", command: ["cargo", "check", "--message-format=short"], description: "Rust (cargo check)" };
@@ -583,6 +654,15 @@ function detectProjectType(cwd: string): ProjectType {
 	// Check for TypeScript (tsconfig.json)
 	if (fs.existsSync(path.join(cwd, "tsconfig.json"))) {
 		return { type: "typescript", command: ["npx", "tsc", "--noEmit"], description: "TypeScript (tsc --noEmit)" };
+	}
+
+	// Check for Go workspaces before single-module Go projects.
+	if (fs.existsSync(path.join(cwd, "go.work"))) {
+		return {
+			type: "go",
+			command: await resolveGoWorkspaceDiagnosticsCommand(cwd, signal),
+			description: "Go workspace (go build)",
+		};
 	}
 
 	// Check for Go (go.mod)
@@ -604,47 +684,52 @@ async function runWorkspaceDiagnostics(
 	signal?: AbortSignal,
 ): Promise<{ output: string; projectType: ProjectType }> {
 	throwIfAborted(signal);
-	const projectType = detectProjectType(cwd);
+	const projectType = await detectProjectType(cwd, signal);
 	if (!projectType.command) {
 		return {
-			output: `Cannot detect project type. Supported: Rust (Cargo.toml), TypeScript (tsconfig.json), Go (go.mod), Python (pyproject.toml)`,
+			output: `Cannot detect project type. Supported: Rust (Cargo.toml), TypeScript (tsconfig.json), Go (go.work/go.mod), Python (pyproject.toml)`,
 			projectType,
 		};
 	}
-	const proc = Bun.spawn(projectType.command, {
-		cwd,
-		stdout: "pipe",
-		stderr: "pipe",
-		windowsHide: true,
-	});
-	const abortHandler = () => {
-		proc.kill();
-	};
-	if (signal) {
-		signal.addEventListener("abort", abortHandler, { once: true });
-	}
-
 	try {
-		const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
-		await proc.exited;
-		throwIfAborted(signal);
-		const combined = (stdout + stderr).trim();
-		if (!combined) {
-			return { output: "No issues found", projectType };
+		const proc = Bun.spawn(projectType.command, {
+			cwd,
+			stdout: "pipe",
+			stderr: "pipe",
+			windowsHide: true,
+		});
+		const abortHandler = () => {
+			proc.kill();
+		};
+		if (signal) {
+			signal.addEventListener("abort", abortHandler, { once: true });
 		}
-		// Limit output length
-		const lines = combined.split("\n");
-		if (lines.length > 50) {
-			return { output: `${lines.slice(0, 50).join("\n")}\n[…${lines.length - 50}ln elided…]`, projectType };
+
+		try {
+			const [stdout, stderr] = await Promise.all([
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+			await proc.exited;
+			throwIfAborted(signal);
+			const combined = (stdout + stderr).trim();
+			if (!combined) {
+				return { output: "No issues found", projectType };
+			}
+			// Limit output length
+			const lines = combined.split("\n");
+			if (lines.length > 50) {
+				return { output: `${lines.slice(0, 50).join("\n")}\n[…${lines.length - 50}ln elided…]`, projectType };
+			}
+			return { output: combined, projectType };
+		} finally {
+			signal?.removeEventListener("abort", abortHandler);
 		}
-		return { output: combined, projectType };
 	} catch (e) {
 		if (signal?.aborted) {
 			throw new ToolAbortError();
 		}
 		return { output: `Failed to run ${projectType.command.join(" ")}: ${e}`, projectType };
-	} finally {
-		signal?.removeEventListener("abort", abortHandler);
 	}
 }
 

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { RenderResultOptions } from "@oh-my-pi/pi-agent-core";
+import type { AgentToolResult, RenderResultOptions } from "@oh-my-pi/pi-agent-core";
 import { preloadPluginRoots } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { LspTool } from "@oh-my-pi/pi-coding-agent/lsp";
 import * as lspClient from "@oh-my-pi/pi-coding-agent/lsp/client";
@@ -20,6 +20,7 @@ import type {
 	DeleteFile,
 	Diagnostic,
 	LspClient,
+	LspToolDetails,
 	RenameFile,
 	ServerConfig,
 	SymbolInformation,
@@ -43,6 +44,7 @@ import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { clampTimeout } from "@oh-my-pi/pi-coding-agent/tools/tool-timeouts";
 import * as piUtils from "@oh-my-pi/pi-utils";
 import { sanitizeText, TempDir } from "@oh-my-pi/pi-utils";
+import type { Subprocess } from "bun";
 import DEFAULTS from "../../src/lsp/defaults.json" with { type: "json" };
 import { getLanguageFromPath } from "../../src/utils/lang-from-path";
 
@@ -187,6 +189,57 @@ function installFakeLsp(handler: FakeLspHandler): FakeLspServer {
 
 	vi.spyOn(piUtils.ptree, "spawn").mockReturnValue(proc);
 	return server;
+}
+
+type BunSpawnOptions = Bun.SpawnOptions.SpawnOptions<
+	Bun.SpawnOptions.Writable,
+	Bun.SpawnOptions.Readable,
+	Bun.SpawnOptions.Readable
+>;
+
+interface BunSpawnCall {
+	cmd: string[];
+	options?: BunSpawnOptions;
+}
+
+interface BunSpawnOutput {
+	stdout?: string;
+	stderr?: string;
+	exitCode?: number;
+}
+
+function textStream(text: string): ReadableStream<Uint8Array> {
+	const body = new Response(text).body;
+	if (!body) {
+		throw new Error("Failed to create text stream");
+	}
+	return body;
+}
+
+function completedProcess(stdout = "", stderr = "", exitCode = 0): Subprocess {
+	return {
+		pid: 12_345,
+		stdout: textStream(stdout),
+		stderr: textStream(stderr),
+		exited: Promise.resolve(exitCode),
+		kill: () => {},
+	} as Subprocess;
+}
+
+function recordBunSpawn(calls: BunSpawnCall[], outputForCommand: (cmd: string[]) => BunSpawnOutput = () => ({})): void {
+	vi.spyOn(Bun, "spawn").mockImplementation(((cmd: string[], options?: BunSpawnOptions) => {
+		const recordedCmd = [...cmd];
+		calls.push({ cmd: recordedCmd, options });
+		const output = outputForCommand(recordedCmd);
+		return completedProcess(output.stdout, output.stderr, output.exitCode);
+	}) as typeof Bun.spawn);
+}
+
+function textResult(result: AgentToolResult<LspToolDetails>): string {
+	return result.content
+		.filter(block => block.type === "text")
+		.map(block => block.text)
+		.join("\n");
 }
 
 describe("lsp regressions", () => {
@@ -1053,6 +1106,86 @@ describe("lsp regressions", () => {
 			expect(output).toBe("OK");
 		} finally {
 			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
+	it("treats a go.work-only root as a Go workspace for workspace diagnostics", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-go-work-only-");
+		const spawnCalls: BunSpawnCall[] = [];
+		recordBunSpawn(spawnCalls, cmd => {
+			if (cmd.join("\0") === "go\0work\0edit\0-json") {
+				return { stdout: JSON.stringify({ Use: [{ DiskPath: "./service" }] }) };
+			}
+			return {};
+		});
+
+		try {
+			const serviceDir = path.join(tempDir.path(), "service");
+			await fs.promises.mkdir(serviceDir, { recursive: true });
+			await Bun.write(path.join(tempDir.path(), "go.work"), ["go 1.22", "", "use ./service", ""].join("\n"));
+			await Bun.write(path.join(serviceDir, "go.mod"), "module example.com/service\n\ngo 1.22\n");
+
+			const tool = new LspTool({ cwd: tempDir.path() } as ToolSession);
+			const result = await tool.execute("go-work-only-diagnostics", {
+				action: "diagnostics",
+				file: "*",
+			});
+
+			const buildCalls = spawnCalls.filter(call => call.cmd[0] === "go" && call.cmd[1] === "build");
+			expect(buildCalls).toHaveLength(1);
+			expect(buildCalls[0]?.cmd).toEqual(["go", "build", "./service/..."]);
+			expect(buildCalls[0]?.options?.cwd).toBe(tempDir.path());
+			const output = textResult(result);
+			expect(output).toContain("Workspace diagnostics (");
+			expect(output).toContain("go build");
+			expect(output).toContain("No issues found");
+			expect(output).not.toContain("Cannot detect project type");
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("builds every go.work use module when go.work and go.mod coexist", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-go-work-before-mod-");
+		const spawnCalls: BunSpawnCall[] = [];
+		recordBunSpawn(spawnCalls, cmd => {
+			if (cmd.join("\0") === "go\0work\0edit\0-json") {
+				return {
+					stdout: JSON.stringify({
+						Use: [{ DiskPath: "." }, { DiskPath: "./service" }, { DiskPath: "./tools/helper" }],
+					}),
+				};
+			}
+			return {};
+		});
+
+		try {
+			const serviceDir = path.join(tempDir.path(), "service");
+			const helperDir = path.join(tempDir.path(), "tools", "helper");
+			await fs.promises.mkdir(serviceDir, { recursive: true });
+			await fs.promises.mkdir(helperDir, { recursive: true });
+			await Bun.write(path.join(tempDir.path(), "go.mod"), "module example.com/root\n\ngo 1.22\n");
+			await Bun.write(path.join(serviceDir, "go.mod"), "module example.com/service\n\ngo 1.22\n");
+			await Bun.write(path.join(helperDir, "go.mod"), "module example.com/helper\n\ngo 1.22\n");
+			await Bun.write(
+				path.join(tempDir.path(), "go.work"),
+				["go 1.22", "", "use (", "\t.", "\t./service", "\t./tools/helper", ")", ""].join("\n"),
+			);
+
+			const tool = new LspTool({ cwd: tempDir.path() } as ToolSession);
+			const result = await tool.execute("go-work-module-patterns", {
+				action: "diagnostics",
+				file: "*",
+			});
+
+			const buildCalls = spawnCalls.filter(call => call.cmd[0] === "go" && call.cmd[1] === "build");
+			expect(buildCalls).toHaveLength(1);
+			expect(buildCalls[0]?.cmd.slice(0, 2)).toEqual(["go", "build"]);
+			expect(buildCalls[0]?.cmd.slice(2).sort()).toEqual(["./...", "./service/...", "./tools/helper/..."]);
+			expect(textResult(result)).toContain("Workspace diagnostics (");
+			expect(textResult(result)).toContain("go build");
+		} finally {
 			tempDir.removeSync();
 		}
 	});


### PR DESCRIPTION
## Repro
A `go.work`-only workspace running `lsp` diagnostics with `file:"*"` reproduced the failure with `bun .wt/repro-go-work-diagnostics.ts`: before the fix the tool returned `Workspace diagnostics (Unknown project type): Cannot detect project type...` instead of treating the root as Go.

## Cause
`packages/coding-agent/src/lsp/index.ts` detected workspace diagnostics project types by checking `go.mod` only for Go, so `go.work`-only roots fell through to `unknown`; when `go.work` and `go.mod` coexisted, the `go.mod` branch ran `go build ./...`, which covers only the root module in Go workspace mode.

## Fix
- Detect `go.work` before `go.mod` in `detectProjectType`.
- Resolve `go.work` diagnostics commands with `go work edit -json` and expand each `use` directory into a `go build <dir>/...` package pattern, with `go build ./...` as the fallback when enumeration fails.
- Keep workspace diagnostic spawn failures contained in the tool result so missing Go binaries report as failed diagnostics commands rather than uncaught exceptions.
- Add LSP regression tests for `go.work`-only roots and mixed `go.work`/`go.mod` workspaces.
- Add the coding-agent changelog entry.

## Verification
Ran `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts -t go.work` (3 pass, 54 filtered out, 0 fail, 15 expect() calls), `bun check` (passed), and `bun .wt/repro-go-work-diagnostics.ts` after the fix to verify `go.work` is recognized as `Go workspace (go build)` even without a local Go binary. Fixes #5038