### PR TITLE
fix(advisor): use UUIDv7 Codex session IDs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex advisor requests using local `-advisor` session labels as provider session IDs; advisors now use stable UUIDv7 provider identities while keeping labeled transcript names. ([#5040](https://github.com/can1357/oh-my-pi/issues/5040))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/advisor/__tests__/config.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/config.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import {
 	advisorConfigFilePath,
 	discoverAdvisorConfigs,
+	getOrCreateAdvisorProviderSessionId,
 	loadWatchdogConfigFile,
 	resolveAdvisorConfigEditPath,
 	saveWatchdogConfigFile,
@@ -83,6 +84,89 @@ describe("slugifyAdvisorName", () => {
 
 	it("falls back to 'advisor' when nothing alphanumeric survives", () => {
 		expect(slugifyAdvisorName("!!!")).toBe("advisor");
+	});
+});
+
+describe("getOrCreateAdvisorProviderSessionId", () => {
+	const primarySessionA = "018f8f5d-75b0-7cc6-8a6f-2f1c0b8e4c9d";
+	const primarySessionB = "018f8f5d-75b1-7cc6-8a6f-2f1c0b8e4c9d";
+
+	it("returns the generated UUIDv7 instead of a local advisor label", () => {
+		const generated = "0193c8f2-7b1a-7c4d-9e2f-123456789abc";
+
+		const providerSessionId = getOrCreateAdvisorProviderSessionId(
+			new Map<string, string>(),
+			primarySessionA,
+			"security-advisor",
+			() => generated,
+		);
+
+		expect(providerSessionId).toBe(generated);
+		expect(providerSessionId).not.toContain("-advisor");
+	});
+
+	it("reuses the same generated UUIDv7 for repeated calls with the same primary session and slug", () => {
+		const generatedIds = ["0193c8f2-7b1a-7c4d-9e2f-123456789abc", "0193c8f2-7b1b-7c4d-9e2f-123456789abc"];
+		let nextGeneratedIdIndex = 0;
+		const ids = new Map<string, string>();
+
+		const first = getOrCreateAdvisorProviderSessionId(ids, primarySessionA, "architecture", () => {
+			const generated = generatedIds[nextGeneratedIdIndex];
+			if (!generated) throw new Error("unexpected generator call");
+			nextGeneratedIdIndex += 1;
+			return generated;
+		});
+		const second = getOrCreateAdvisorProviderSessionId(ids, primarySessionA, "architecture", () => {
+			const generated = generatedIds[nextGeneratedIdIndex];
+			if (!generated) throw new Error("unexpected generator call");
+			nextGeneratedIdIndex += 1;
+			return generated;
+		});
+
+		expect(first).toBe(generatedIds[0]);
+		expect(second).toBe(generatedIds[0]);
+		expect(nextGeneratedIdIndex).toBe(1);
+	});
+
+	it("creates distinct UUIDv7 values for different advisor slugs or primary sessions", () => {
+		const generatedIds = [
+			"0193c8f2-7b1a-7c4d-9e2f-123456789abc",
+			"0193c8f2-7b1b-7c4d-9e2f-123456789abc",
+			"0193c8f2-7b1c-7c4d-9e2f-123456789abc",
+		];
+		let nextGeneratedIdIndex = 0;
+		const ids = new Map<string, string>();
+		const nextGeneratedId = () => {
+			const generated = generatedIds[nextGeneratedIdIndex];
+			if (!generated) throw new Error("unexpected generator call");
+			nextGeneratedIdIndex += 1;
+			return generated;
+		};
+
+		const architecture = getOrCreateAdvisorProviderSessionId(ids, primarySessionA, "architecture", nextGeneratedId);
+		const security = getOrCreateAdvisorProviderSessionId(ids, primarySessionA, "security", nextGeneratedId);
+		const architectureForOtherSession = getOrCreateAdvisorProviderSessionId(
+			ids,
+			primarySessionB,
+			"architecture",
+			nextGeneratedId,
+		);
+
+		expect(architecture).toBe(generatedIds[0]);
+		expect(security).toBe(generatedIds[1]);
+		expect(architectureForOtherSession).toBe(generatedIds[2]);
+		expect(new Set([architecture, security, architectureForOtherSession]).size).toBe(3);
+	});
+
+	it("rejects generated values that are not UUIDv7", () => {
+		expect(() =>
+			getOrCreateAdvisorProviderSessionId(
+				new Map<string, string>(),
+				primarySessionA,
+				"architecture",
+				() => "550e8400-e29b-41d4-a716-446655440000",
+			),
+		).toThrow("non-UUIDv7");
 	});
 });
 

--- a/packages/coding-agent/src/advisor/config.ts
+++ b/packages/coding-agent/src/advisor/config.ts
@@ -59,6 +59,34 @@ export function slugifyAdvisorName(name: string): string {
 	return slug || "advisor";
 }
 
+const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ADVISOR_PROVIDER_SESSION_KEY_SEPARATOR = "\u0000";
+
+/**
+ * Returns a stable provider-facing UUIDv7 for one advisor within one primary session.
+ *
+ * Codex treats `session_id`/`conversation_id` as a UUID-shaped routing identity,
+ * so advisor labels such as `-advisor` stay local-only.
+ */
+export function getOrCreateAdvisorProviderSessionId(
+	ids: Map<string, string>,
+	primarySessionId: string | undefined,
+	slug: string,
+	randomSessionId: () => string = () => Bun.randomUUIDv7(),
+): string | undefined {
+	if (!primarySessionId) return undefined;
+	const key = `${primarySessionId}${ADVISOR_PROVIDER_SESSION_KEY_SEPARATOR}${slug}`;
+	const existing = ids.get(key);
+	if (existing) return existing;
+
+	const next = randomSessionId();
+	if (!UUID_V7_PATTERN.test(next)) {
+		throw new Error("Advisor provider session id generator returned a non-UUIDv7 value");
+	}
+	ids.set(key, next);
+	return next;
+}
+
 /** Built tool names, for validating an advisor's `tools` list. */
 const KNOWN_TOOL_NAMES = new Set<string>(BUILTIN_TOOL_NAMES);
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -154,6 +154,7 @@ import {
 	AdvisorTranscriptRecorder,
 	advisorTranscriptFilename,
 	formatAdvisorBatchContent,
+	getOrCreateAdvisorProviderSessionId,
 	isAdvisorInterruptImmuneTurnActive,
 	isInterruptingSeverity,
 	resolveAdvisorDeliveryChannel,
@@ -1599,6 +1600,8 @@ export class AgentSession {
 	#advisors: ActiveAdvisor[] = [];
 	/** Configured advisor roster from WATCHDOG.yml; undefined/empty → single legacy advisor. */
 	#advisorConfigs?: AdvisorConfig[];
+	/** Provider-facing UUIDv7 identities keyed by primary provider session and advisor slug. */
+	#advisorProviderSessionIds = new Map<string, string>();
 	/** Aggregate of the most recent stop's recorder closes; awaited by dispose() and
 	 *  used as the open barrier for the next build so two writers never share a file. */
 	#advisorRecorderClosed: Promise<void> = Promise.resolve();
@@ -2477,18 +2480,26 @@ export class AgentSession {
 			const names = config.tools?.length ? new Set(config.tools) : ADVISOR_DEFAULT_TOOL_NAMES;
 			const tools = (this.#advisorTools ?? []).filter(t => names.has(t.name));
 
-			const advisorSessionId = this.#advisorSessionId(slug);
+			const primaryProviderSessionId = this.sessionId;
+			const advisorSessionLabel = slug
+				? `${primaryProviderSessionId}-advisor-${slug}`
+				: `${primaryProviderSessionId}-advisor`;
+			const advisorProviderSessionId = getOrCreateAdvisorProviderSessionId(
+				this.#advisorProviderSessionIds,
+				primaryProviderSessionId,
+				slug,
+			);
 			const appendOnlyContext = new AppendOnlyContextManager();
 
 			// Thread the primary's telemetry into the advisor loop so the advisor
-			// model's GenAI spans + usage/cost hooks fire stamped with the advisor's
-			// own identity. `conversationId` is cleared so the advisor loop falls back
-			// to its own session id; undefined telemetry stays undefined.
+			// model's GenAI spans + usage/cost hooks fire stamped with the local advisor
+			// identity. `conversationId` is cleared so provider telemetry falls back to
+			// the UUIDv7 provider session id, not the local `-advisor` label.
 			const advisorTelemetry = this.agent.telemetry
 				? {
 						...this.agent.telemetry,
 						agent: {
-							id: advisorSessionId,
+							id: advisorSessionLabel,
 							name: slug ? `${MODEL_ROLES.advisor.name}: ${advisorName}` : MODEL_ROLES.advisor.name,
 							description: formatModelString(advisorModel),
 						},
@@ -2500,10 +2511,10 @@ export class AgentSession {
 			// advisor's requests cache, route, and obfuscate like the main turn.
 			// `promptCacheKey` preserves an explicitly pinned provider cache key
 			// unchanged so tan/shared-session advisor calls read the exact shard the
-			// parent turn populated, while keeping only `sessionId` advisor-scoped;
-			// sessions without a pinned key fall back to the advisor session id for
-			// stable advisor-local caching (see can1357/oh-my-pi#3639).
-			const advisorPromptCacheKey = this.agent.promptCacheKey ?? advisorSessionId;
+			// parent turn populated. Otherwise the advisor uses its provider UUIDv7 so
+			// Codex request identity remains UUID-shaped while local labels keep the
+			// `-advisor` suffix.
+			const advisorPromptCacheKey = this.agent.promptCacheKey ?? advisorProviderSessionId;
 			const advisorAgent = new Agent({
 				initialState: {
 					systemPrompt,
@@ -2512,11 +2523,11 @@ export class AgentSession {
 					tools: [adviseTool, ...tools],
 				},
 				appendOnlyContext,
-				sessionId: advisorSessionId,
+				sessionId: advisorProviderSessionId,
 				promptCacheKey: advisorPromptCacheKey,
 				providerSessionState: this.#providerSessionState,
 				preferWebsockets: this.#preferWebsockets,
-				getApiKey: requestModel => this.#modelRegistry.resolver(requestModel, advisorSessionId),
+				getApiKey: requestModel => this.#modelRegistry.resolver(requestModel, advisorProviderSessionId),
 				streamFn: this.#advisorStreamFn,
 				onPayload: this.#onPayload,
 				onResponse: this.#onResponse,
@@ -2575,11 +2586,15 @@ export class AgentSession {
 					// suspect-mark a credential on a transient advisor error).
 					const message = error instanceof Error ? error.message : String(error);
 					if (!isUsageLimitOutcome(extractHttpStatusFromError(error), message)) return;
-					await this.#modelRegistry.authStorage.markUsageLimitReached(advisorModel.provider, advisorSessionId, {
-						retryAfterMs: extractRetryHint(undefined, message),
-						baseUrl: advisorModel.baseUrl,
-						modelId: advisorModel.id,
-					});
+					await this.#modelRegistry.authStorage.markUsageLimitReached(
+						advisorModel.provider,
+						advisorProviderSessionId,
+						{
+							retryAfterMs: extractRetryHint(undefined, message),
+							baseUrl: advisorModel.baseUrl,
+							modelId: advisorModel.id,
+						},
+					);
 				},
 				notifyFailure: error => {
 					const message = error instanceof Error ? error.message : String(error);
@@ -2631,13 +2646,6 @@ export class AgentSession {
 		}
 
 		return this.#advisors.length > 0;
-	}
-
-	/** Provider/session id for an advisor's loop. The slug suffix MUST match the
-	 *  advisor's transcript filename so stats/telemetry attribute the same advisor. */
-	#advisorSessionId(slug: string): string | undefined {
-		if (!this.sessionId) return undefined;
-		return slug ? `${this.sessionId}-advisor-${slug}` : `${this.sessionId}-advisor`;
 	}
 
 	/**
@@ -2845,11 +2853,15 @@ export class AgentSession {
 			// No compaction candidates, fallback to re-prime
 			return true;
 		}
-		const advisorSessionId = this.#advisorSessionId(advisor.slug);
+		const advisorProviderSessionId = getOrCreateAdvisorProviderSessionId(
+			this.#advisorProviderSessionIds,
+			this.sessionId,
+			advisor.slug,
+		);
 		const preparation = prepareCompaction(
 			pathEntries,
 			compactionSettings,
-			await this.#runnableCompactionCandidates(candidates, advisorSessionId),
+			await this.#runnableCompactionCandidates(candidates, advisorProviderSessionId),
 		);
 		if (!preparation) {
 			// Cannot prepare compaction, fallback to re-prime
@@ -2869,17 +2881,17 @@ export class AgentSession {
 		let lastError: unknown;
 		// Instrument the advisor's overflow-compaction one-shot like the primary
 		// compaction path so the advisor model's maintenance call also emits spans.
-		const telemetry = resolveTelemetry(agent.telemetry, advisorSessionId);
+		const telemetry = resolveTelemetry(agent.telemetry, advisorProviderSessionId);
 
 		for (const candidate of candidates) {
-			const apiKey = await this.#modelRegistry.getApiKey(candidate, advisorSessionId);
+			const apiKey = await this.#modelRegistry.getApiKey(candidate, advisorProviderSessionId);
 			if (!apiKey) continue;
 
 			try {
 				compactResult = await compact(
 					preparation,
 					candidate,
-					this.#modelRegistry.resolver(candidate, advisorSessionId),
+					this.#modelRegistry.resolver(candidate, advisorProviderSessionId),
 					undefined,
 					undefined,
 					{
@@ -2887,8 +2899,8 @@ export class AgentSession {
 						convertToLlm: messages => this.#convertToLlmForSideRequest(messages),
 						telemetry,
 						tools: agent.state.tools,
-						sessionId: advisorSessionId,
-						promptCacheKey: advisorSessionId,
+						sessionId: advisorProviderSessionId,
+						promptCacheKey: advisorProviderSessionId,
 					},
 				);
 				break;


### PR DESCRIPTION
## Repro
Advisor Codex requests derived the provider session identity by suffixing the primary UUIDv7 with `-advisor`; a local repro with `Bun.randomUUIDv7()` produced a valid primary UUIDv7 and an invalid 44-character `<uuidv7>-advisor` advisor identity, matching the malformed `conversation_id` / `session_id` reported for `openai-codex/gpt-5.6-luna:xhigh`.

## Cause
`AgentSession.#buildAdvisorRuntime` in `packages/coding-agent/src/session/agent-session.ts` passed the local advisor label from `#advisorSessionId(slug)` into `Agent.sessionId`, prompt-cache fallback, auth stickiness, and advisor compaction, so Codex saw the same `-advisor` suffix that should have been local to transcript/session labels.

## Fix
- Added `getOrCreateAdvisorProviderSessionId` in `packages/coding-agent/src/advisor/config.ts` to allocate one stable UUIDv7 per primary provider session and advisor slug, rejecting non-v7 generator output.
- Updated advisor runtime and advisor compaction in `packages/coding-agent/src/session/agent-session.ts` to use the UUIDv7 provider identity for provider requests, auth stickiness, prompt-cache fallback, and telemetry conversation fallback while preserving local `-advisor` labels for advisor identity/transcript naming.
- Added advisor config regression tests covering stable reuse, per-slug/per-session separation, non-label output, and v7-only validation.
- Added the coding-agent changelog entry for #5040.

## Verification
`bun test src/advisor/__tests__/config.test.ts` passed: 18 tests, 39 assertions. `bun test src/advisor/__tests__/advisor.test.ts src/advisor/__tests__/config.test.ts` passed: 89 tests, 300 assertions. `bun check` passed. Fixes #5040