### PR TITLE
fix(debug): stop native fallback for missing delve

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Go debug launches using native adapters when `dlv` is unavailable; missing Delve and Ruby debug adapters now show install hints, nested Go package directories match module/workspace markers from the launch path, and DAP executable lookup refreshes PATH misses. ([#5037](https://github.com/can1357/oh-my-pi/issues/5037))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { isRecord, logger } from "@oh-my-pi/pi-utils";
+import { isRecord, logger, WhichCachePolicy } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { getConfigDirPaths } from "../config";
 import { getPreloadedPluginRoots } from "../discovery/helpers";
@@ -188,10 +188,21 @@ function resolveAdapterFromConfig(
 	adapterName: string,
 	configs: Record<string, DapAdapterConfig>,
 	cwd: string,
+	lookupCwd: string = cwd,
 ): DapResolvedAdapter | null {
 	const config = configs[adapterName];
 	if (!config) return null;
-	const resolvedCommand = resolveCommand(normalizeCommandForCwd(config.command, cwd), cwd);
+	const commandIsBare =
+		!path.isAbsolute(config.command) && !config.command.includes("/") && !config.command.includes("\\");
+	const normalizedCommand = normalizeCommandForCwd(config.command, cwd);
+	const lookupOptions = {
+		cache: WhichCachePolicy.Fresh,
+		PATH: process.env.PATH,
+	};
+	let resolvedCommand = resolveCommand(normalizedCommand, commandIsBare ? lookupCwd : cwd, lookupOptions);
+	if (!resolvedCommand && commandIsBare && lookupCwd !== cwd) {
+		resolvedCommand = resolveCommand(normalizedCommand, cwd, lookupOptions);
+	}
 	if (!resolvedCommand) return null;
 	return {
 		name: adapterName,
@@ -214,38 +225,89 @@ export function resolveAdapter(adapterName: string, cwd: string): DapResolvedAda
 
 export function getAvailableAdapters(cwd: string): DapResolvedAdapter[] {
 	const configs = getAdapterConfigs(cwd);
-	return Object.keys(configs)
-		.map(name => resolveAdapterFromConfig(name, configs, cwd))
-		.filter((adapter): adapter is DapResolvedAdapter => adapter !== null);
-}
-
-function getMatchingAdapters(program: string, cwd: string): DapResolvedAdapter[] {
-	const extension = path.extname(program).toLowerCase();
-	const available = getAvailableAdapters(cwd);
-	if (!extension) {
-		// For extensionless binaries, only consider native debuggers (gdb, lldb-dap)
-		// or adapters that match by root markers. Don't silently fall back to
-		// unrelated adapters like debugpy for a C binary.
-		const nativeDebuggers: ReadonlySet<string> = new Set(EXTENSIONLESS_DEBUGGER_ORDER);
-		return available.filter(
-			adapter =>
-				nativeDebuggers.has(adapter.name) ||
-				(adapter.rootMarkers.length > 0 && hasRootMarkers(cwd, adapter.rootMarkers)),
-		);
-	}
-	const exactMatches = available.filter(adapter => adapter.fileTypes.includes(extension));
-	if (exactMatches.length > 0) {
-		return exactMatches;
+	const available: DapResolvedAdapter[] = [];
+	for (const name in configs) {
+		const adapter = resolveAdapterFromConfig(name, configs, cwd);
+		if (adapter) available.push(adapter);
 	}
 	return available;
 }
 
-function sortAdaptersForLaunch(program: string, cwd: string, adapters: DapResolvedAdapter[]): DapResolvedAdapter[] {
+function findRootMarkerInLaunchAncestry(
+	program: string,
+	cwd: string,
+	markers: string[],
+	programKind: LaunchProgramKind,
+): string | null {
+	if (markers.length === 0) return null;
+
+	let dir = programKind === "directory" ? path.resolve(cwd, program) : path.dirname(path.resolve(cwd, program));
+	while (true) {
+		if (hasRootMarkers(dir, markers)) return dir;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function getMatchingAdapters(program: string, cwd: string, programKind: LaunchProgramKind): DapResolvedAdapter[] {
+	const extension = path.extname(program).toLowerCase();
+	const configs = getAdapterConfigs(cwd);
+
+	if (extension) {
+		let hasConfiguredExtensionMatch = false;
+		const exactMatches: DapResolvedAdapter[] = [];
+		for (const name in configs) {
+			const config = configs[name];
+			if (!config || !(config.fileTypes ?? []).includes(extension)) continue;
+			hasConfiguredExtensionMatch = true;
+			const rootDir = findRootMarkerInLaunchAncestry(program, cwd, config.rootMarkers ?? [], programKind);
+			const adapter = resolveAdapterFromConfig(name, configs, cwd, rootDir ?? cwd);
+			if (adapter) exactMatches.push(adapter);
+		}
+		if (exactMatches.length > 0) return exactMatches;
+		if (hasConfiguredExtensionMatch) return [];
+	}
+
+	const available: DapResolvedAdapter[] = [];
+	const rootMatchedConfigNames = new Set<string>();
+	const rootMatchDirs = new Map<string, string>();
+	let hasDirectoryRootMatch = false;
+	for (const name in configs) {
+		const config = configs[name];
+		if (!config) continue;
+		const rootDir = findRootMarkerInLaunchAncestry(program, cwd, config.rootMarkers ?? [], programKind);
+		if (rootDir) {
+			rootMatchedConfigNames.add(name);
+			rootMatchDirs.set(name, rootDir);
+			if (config.acceptsDirectoryProgram === true) hasDirectoryRootMatch = true;
+		}
+		if (name === "gdb" || name === "lldb-dap" || rootDir) {
+			const adapter = resolveAdapterFromConfig(name, configs, cwd, rootDir ?? cwd);
+			if (adapter) available.push(adapter);
+		}
+	}
+
+	if (programKind === "directory" && hasDirectoryRootMatch) {
+		return available.filter(adapter => adapter.acceptsDirectoryProgram && rootMatchedConfigNames.has(adapter.name));
+	}
+
+	return available.filter(
+		adapter => adapter.name === "gdb" || adapter.name === "lldb-dap" || rootMatchDirs.has(adapter.name),
+	);
+}
+
+function sortAdaptersForLaunch(
+	program: string,
+	cwd: string,
+	programKind: LaunchProgramKind,
+	adapters: DapResolvedAdapter[],
+): DapResolvedAdapter[] {
 	const extension = path.extname(program).toLowerCase();
 	const rootAware = adapters.map(adapter => ({
 		adapter,
 		hasExtensionMatch: extension.length > 0 && adapter.fileTypes.includes(extension),
-		hasRootMatch: adapter.rootMarkers.length > 0 && hasRootMarkers(cwd, adapter.rootMarkers),
+		hasRootMatch: findRootMarkerInLaunchAncestry(program, cwd, adapter.rootMarkers, programKind) !== null,
 	}));
 	rootAware.sort((left, right) => {
 		if (left.hasExtensionMatch !== right.hasExtensionMatch) {
@@ -270,6 +332,38 @@ function sortAdaptersForLaunch(program: string, cwd: string, adapters: DapResolv
 	return rootAware.map(entry => entry.adapter);
 }
 
+export function getUnavailableLaunchAdapterName(
+	program: string,
+	cwd: string,
+	adapterName: string | undefined,
+	programKind: LaunchProgramKind,
+): string | null {
+	const configs = getAdapterConfigs(cwd);
+	if (adapterName) {
+		if (!configs[adapterName]) return null;
+		return resolveAdapterFromConfig(adapterName, configs, cwd) ? null : adapterName;
+	}
+
+	const extension = path.extname(program).toLowerCase();
+	const candidates: string[] = [];
+	for (const name in configs) {
+		const config = configs[name];
+		if (!config) continue;
+		if (extension) {
+			if ((config.fileTypes ?? []).includes(extension)) candidates.push(name);
+			continue;
+		}
+		if (programKind === "directory" && config.acceptsDirectoryProgram !== true) continue;
+		if (findRootMarkerInLaunchAncestry(program, cwd, config.rootMarkers ?? [], programKind) !== null)
+			candidates.push(name);
+	}
+
+	for (const name of candidates) {
+		if (!resolveAdapterFromConfig(name, configs, cwd)) return name;
+	}
+	return null;
+}
+
 export function selectLaunchAdapter(
 	program: string,
 	cwd: string,
@@ -279,10 +373,10 @@ export function selectLaunchAdapter(
 	if (adapterName) {
 		return resolveAdapter(adapterName, cwd);
 	}
-	const matches = getMatchingAdapters(program, cwd);
+	const matches = getMatchingAdapters(program, cwd, programKind);
 	const candidates =
 		programKind === "directory" ? matches.filter(adapter => adapter.acceptsDirectoryProgram) : matches;
-	const sorted = sortAdaptersForLaunch(program, cwd, candidates.length > 0 ? candidates : matches);
+	const sorted = sortAdaptersForLaunch(program, cwd, programKind, candidates.length > 0 ? candidates : matches);
 	return sorted[0] ?? null;
 }
 

--- a/packages/coding-agent/src/dap/defaults.json
+++ b/packages/coding-agent/src/dap/defaults.json
@@ -64,7 +64,7 @@
 		"connectMode": "socket",
 		"languages": ["go"],
 		"fileTypes": [".go"],
-		"rootMarkers": ["go.mod", "go.sum"],
+		"rootMarkers": ["go.mod", "go.sum", "go.work"],
 		"acceptsDirectoryProgram": true,
 		"launchDefaults": {
 			"request": "launch",

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $which, isRecord, logger, pathIsWithin } from "@oh-my-pi/pi-utils";
+import { $which, isRecord, logger, pathIsWithin, type WhichOptions } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { getConfigDirPaths } from "../config";
 import { type ClaudePluginRoot, getPreloadedPluginRoots } from "../discovery/helpers";
@@ -249,7 +249,7 @@ const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string }> = [
 	{ markers: ["Gemfile", "Gemfile.lock"], binDir: "vendor/bundle/bin" },
 	{ markers: ["Gemfile", "Gemfile.lock"], binDir: "bin" },
 	// Go - check project-local bin
-	{ markers: ["go.mod", "go.sum"], binDir: "bin" },
+	{ markers: ["go.mod", "go.sum", "go.work"], binDir: "bin" },
 ];
 
 const WINDOWS_LOCAL_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const;
@@ -271,11 +271,16 @@ function resolveLocalCommand(basePath: string): string | null {
  * Resolve a command to an executable path.
  * Checks project-local bin directories first, then falls back to $PATH.
  *
- * @param command - The command name (e.g., "typescript-language-server")
+ * @param command - The command name (e.g. "typescript-language-server")
  * @param cwd - Working directory to search from
+ * @param options - Optional PATH lookup controls.
  * @returns Absolute path to the executable, or null if not found
  */
-export function resolveCommand(command: string, cwd: string): string | null {
+export function resolveCommand(
+	command: string,
+	cwd: string,
+	options?: Pick<WhichOptions, "cache" | "PATH">,
+): string | null {
 	// Check local bin directories based on project markers
 	for (const { markers, binDir } of LOCAL_BIN_PATHS) {
 		if (hasRootMarkers(cwd, markers)) {
@@ -288,7 +293,7 @@ export function resolveCommand(command: string, cwd: string): string | null {
 	}
 
 	// Fall back to $PATH
-	return $which(command);
+	return options ? $which(command, options) : $which(command);
 }
 
 interface ConfigSource {

--- a/packages/coding-agent/src/prompts/tools/debug.md
+++ b/packages/coding-agent/src/prompts/tools/debug.md
@@ -11,7 +11,7 @@ Debugger access.
 
 <caution>
 - Only one active debug session at a time.
-- Valid `adapter` values: `gdb`, `lldb-dap`, `python -m debugpy.adapter`, `dlv dap` (must be installed locally).
-- `program` must be an executable file or debug target, not a directory or bare interpreter name.
-- Python debugging requires `debugpy`; `pip install debugpy` if unavailable.
+- Valid `adapter` values include `gdb`, `lldb-dap`, `debugpy`, `dlv`, `rdbg`.
+- Go/Delve accepts `.go` files and package directories. Install Delve with `go install github.com/go-delve/delve/cmd/dlv@latest`.
+- Python debugging requires `debugpy`; install with `pip install debugpy` if unavailable.
 </caution>

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -31,7 +31,9 @@ import {
 	type DapThread,
 	type DapVariable,
 	dapSessionManager,
+	getAdapterConfigs,
 	getAvailableAdapters,
+	getUnavailableLaunchAdapterName,
 	type LaunchProgramKind,
 	resolveLaunchOverrides,
 	selectAttachAdapter,
@@ -497,6 +499,40 @@ function getConfiguredAdapters(cwd: string): string {
 	return adapters.length > 0 ? adapters.join(", ") : "none";
 }
 
+const ADAPTER_UNAVAILABLE_MESSAGES: Record<string, string> = {
+	debugpy: "adapter 'debugpy' is not available: python not found in PATH",
+	dlv: "adapter 'dlv' is not available: install with 'go install github.com/go-delve/delve/cmd/dlv@latest'",
+	rdbg: "adapter 'rdbg' is not available: install with 'gem install debug'",
+};
+
+const ADAPTER_CANONICAL_COMMANDS: Record<string, string> = {
+	debugpy: "python",
+	dlv: "dlv",
+	rdbg: "rdbg",
+};
+
+function formatAdapterUnavailable(adapterName: string, cwd: string): string {
+	const config = getAdapterConfigs(cwd)[adapterName];
+	const canonicalCommand = ADAPTER_CANONICAL_COMMANDS[adapterName] ?? adapterName;
+	if (config && config.command !== canonicalCommand) {
+		return `adapter '${adapterName}' is not available: configured command '${config.command}' did not resolve. Check the DAP adapter config for this workspace.`;
+	}
+	const message = ADAPTER_UNAVAILABLE_MESSAGES[adapterName];
+	if (message) return message;
+	return `adapter '${adapterName}' is not available. Installed adapters: ${getConfiguredAdapters(cwd)}`;
+}
+
+function formatNoLaunchAdapterAvailable(
+	program: string,
+	cwd: string,
+	adapterName: string | undefined,
+	programKind: LaunchProgramKind,
+): string {
+	const unavailableAdapter = getUnavailableLaunchAdapterName(program, cwd, adapterName, programKind);
+	if (unavailableAdapter) return formatAdapterUnavailable(unavailableAdapter, cwd);
+	return `No debugger adapter available. Installed adapters: ${getConfiguredAdapters(cwd)}`;
+}
+
 async function classifyLaunchProgram(program: string): Promise<LaunchProgramKind> {
 	try {
 		return (await fs.stat(program)).isDirectory() ? "directory" : "file";
@@ -515,7 +551,7 @@ function validateLaunchProgram(
 	if (programKind !== "directory" || adapter.acceptsDirectoryProgram) return;
 	const displayPath = formatPathRelativeToCwd(program, cwd, { trailingSlash: true });
 	throw new ToolError(
-		`launch program resolves to a directory: ${displayPath}. Pass an executable file path, or for Python use adapter "debugpy" with program set to the .py file.`,
+		`launch program resolves to a directory: ${displayPath}. Pass an executable file path or choose an adapter that supports package directories.`,
 	);
 }
 
@@ -713,12 +749,7 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 				const programKind = await classifyLaunchProgram(program);
 				const adapter = selectLaunchAdapter(program, commandCwd, params.adapter, programKind);
 				if (!adapter) {
-					if (params.adapter === "debugpy") {
-						throw new ToolError("adapter 'debugpy' is not available: python not found in PATH");
-					}
-					throw new ToolError(
-						`No debugger adapter available. Installed adapters: ${getConfiguredAdapters(commandCwd)}`,
-					);
+					throw new ToolError(formatNoLaunchAdapterAvailable(program, commandCwd, params.adapter, programKind));
 				}
 				validateLaunchProgram(program, commandCwd, programKind, adapter);
 				const extraLaunchArguments = resolveLaunchOverrides(adapter, program, programKind);
@@ -738,8 +769,8 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 				const commandCwd = params.cwd ? resolveToCwd(params.cwd, this.session.cwd) : this.session.cwd;
 				const adapter = selectAttachAdapter(commandCwd, params.adapter, params.port);
 				if (!adapter) {
-					if (params.adapter === "debugpy") {
-						throw new ToolError("adapter 'debugpy' is not available: python not found in PATH");
+					if (params.adapter) {
+						throw new ToolError(formatAdapterUnavailable(params.adapter, commandCwd));
 					}
 					throw new ToolError(
 						`No debugger adapter available. Installed adapters: ${getConfiguredAdapters(commandCwd)}`,

--- a/packages/coding-agent/test/debug/dap-config.test.ts
+++ b/packages/coding-agent/test/debug/dap-config.test.ts
@@ -8,11 +8,18 @@ import { injectPluginDirRoots } from "../../src/discovery/helpers";
 const tempDirs: string[] = [];
 const ORIGINAL_OMP_PLUGIN_DIR = process.env.OMP_PLUGIN_DIR;
 const ORIGINAL_OMP_MARKETPLACE_DIR = process.env.OMP_MARKETPLACE_DIR;
+const ORIGINAL_PATH = process.env.PATH;
 
 async function makeTempDir(prefix: string): Promise<string> {
 	const cwd = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
 	tempDirs.push(cwd);
 	return cwd;
+}
+
+async function writeExecutable(filePath: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\n");
+	await fs.chmod(filePath, 0o755);
 }
 
 afterEach(async () => {
@@ -26,6 +33,11 @@ afterEach(async () => {
 		delete process.env.OMP_MARKETPLACE_DIR;
 	} else {
 		process.env.OMP_MARKETPLACE_DIR = ORIGINAL_OMP_MARKETPLACE_DIR;
+	}
+	if (ORIGINAL_PATH === undefined) {
+		delete process.env.PATH;
+	} else {
+		process.env.PATH = ORIGINAL_PATH;
 	}
 	await injectPluginDirRoots(os.homedir(), []);
 	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
@@ -194,5 +206,101 @@ describe("DAP adapter configuration", () => {
 		const config = getAdapterConfigs(cwd);
 		expect(config["missing-command"]).toBeUndefined();
 		expect(config.valid?.command).toBe("bun");
+	});
+
+	it("does not fall back to native adapters when dlv is the matching Go source adapter but unavailable", async () => {
+		const cwd = await makeTempDir("omp-dap-go-dlv-missing-");
+		const pathDir = path.join(cwd, "empty-path");
+		process.env.PATH = pathDir;
+		await fs.mkdir(pathDir);
+		await fs.writeFile(path.join(cwd, "go.mod"), "module example.com/app\n\ngo 1.22\n");
+		await fs.writeFile(path.join(cwd, "main.go"), "package main\n\nfunc main() {}\n");
+		await writeExecutable(path.join(cwd, "bin", "gdb"));
+		await writeExecutable(path.join(cwd, "bin", "lldb-dap"));
+		await fs.writeFile(
+			path.join(cwd, "dap.json"),
+			JSON.stringify({
+				adapters: {
+					dlv: { command: "./bin/missing-dlv" },
+					gdb: { command: "./bin/gdb" },
+					"lldb-dap": { command: "./bin/lldb-dap" },
+				},
+			}),
+		);
+
+		const selected = selectLaunchAdapter(path.join(cwd, "main.go"), cwd);
+
+		expect(selected).toBeNull();
+	});
+
+	it("resolves default dlv from a nested Go module bin when launched from the repo root", async () => {
+		const cwd = await makeTempDir("omp-dap-go-nested-");
+		const moduleRoot = path.join(cwd, "services", "api");
+		const program = path.join(moduleRoot, "cmd", "api");
+		const pathDir = path.join(cwd, "empty-path");
+		process.env.PATH = pathDir;
+		await fs.mkdir(pathDir);
+		await fs.writeFile(path.join(cwd, "Makefile"), "all:\n\tgo build ./...\n");
+		await fs.mkdir(program, { recursive: true });
+		await fs.writeFile(path.join(moduleRoot, "go.mod"), "module example.com/api\n\ngo 1.22\n");
+		await writeExecutable(path.join(cwd, "bin", "dlv"));
+		await writeExecutable(path.join(moduleRoot, "bin", "dlv"));
+
+		const selected = selectLaunchAdapter(program, cwd, undefined, "directory");
+
+		expect(selected?.name).toBe("dlv");
+		expect(selected?.command).toBe("dlv");
+		expect(selected?.resolvedCommand).toBe(path.join(moduleRoot, "bin", "dlv"));
+	});
+
+	it("falls back to the session cwd bin/dlv when a nested Go module has no local dlv", async () => {
+		const cwd = await makeTempDir("omp-dap-go-nested-cwd-dlv-");
+		const moduleRoot = path.join(cwd, "services", "api");
+		const program = path.join(moduleRoot, "main.go");
+		process.env.PATH = "";
+		await fs.writeFile(path.join(cwd, "go.mod"), "module example.com/repo\n\ngo 1.22\n");
+		await fs.mkdir(moduleRoot, { recursive: true });
+		await fs.writeFile(path.join(moduleRoot, "go.mod"), "module example.com/api\n\ngo 1.22\n");
+		await fs.writeFile(program, "package main\n\nfunc main() {}\n");
+		await writeExecutable(path.join(cwd, "bin", "dlv"));
+
+		const selected = selectLaunchAdapter(program, cwd, undefined, "file");
+
+		expect(selected?.name).toBe("dlv");
+		expect(selected?.command).toBe("dlv");
+		expect(selected?.resolvedCommand).toBe(path.join(cwd, "bin", "dlv"));
+	});
+
+	it("selects dlv for Go workspace directories rooted by go.work", async () => {
+		const cwd = await makeTempDir("omp-dap-go-work-");
+		const program = path.join(cwd, "cmd", "worker");
+		const pathDir = path.join(cwd, "empty-path");
+		process.env.PATH = pathDir;
+		await fs.mkdir(pathDir);
+		await fs.writeFile(path.join(cwd, "go.work"), "go 1.22\n\nuse ./cmd/worker\n");
+		await fs.mkdir(program, { recursive: true });
+		await writeExecutable(path.join(cwd, "bin", "dlv"));
+
+		const selected = selectLaunchAdapter(program, cwd, undefined, "directory");
+
+		expect(selected?.resolvedCommand).toBe(path.join(cwd, "bin", "dlv"));
+	});
+
+	it("re-resolves dlv after an earlier PATH lookup missed it", async () => {
+		const cwd = await makeTempDir("omp-dap-go-dlv-cache-");
+		const pathDir = path.join(cwd, "path-bin");
+		const program = path.join(cwd, "main.go");
+		await fs.mkdir(pathDir);
+		process.env.PATH = pathDir;
+		await fs.writeFile(path.join(cwd, "go.mod"), "module example.com/cache\n\ngo 1.22\n");
+		await fs.writeFile(program, "package main\n\nfunc main() {}\n");
+
+		expect(selectLaunchAdapter(program, cwd)).toBeNull();
+
+		await writeExecutable(path.join(pathDir, "dlv"));
+		const selected = selectLaunchAdapter(program, cwd);
+
+		expect(selected?.name).toBe("dlv");
+		expect(selected?.resolvedCommand).toBe(path.join(pathDir, "dlv"));
 	});
 });

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -16,6 +16,7 @@ import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { DebugTool } from "@oh-my-pi/pi-coding-agent/tools/debug";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
+const ORIGINAL_PATH = process.env.PATH;
 const TEST_ADAPTER: DapResolvedAdapter = {
 	name: "lldb-dap",
 	command: "lldb-dap",
@@ -55,6 +56,12 @@ server = Bun.listen({
 await Bun.sleep(2_000);
 server.stop();
 `;
+
+async function writeExecutable(filePath: string): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), { recursive: true });
+	await fs.writeFile(filePath, process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\n");
+	await fs.chmod(filePath, 0o755);
+}
 
 type DapEventHandler = (body: unknown, event: DapEventMessage) => void | Promise<void>;
 
@@ -162,6 +169,11 @@ class FakeDapClient {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	if (ORIGINAL_PATH === undefined) {
+		delete process.env.PATH;
+	} else {
+		process.env.PATH = ORIGINAL_PATH;
+	}
 });
 
 describe("DAP launch failure handling", () => {
@@ -634,12 +646,20 @@ describe("DebugTool launch validation", () => {
 		}
 	});
 
-	it("throws targeted 'python not found in PATH' when adapter:'debugpy' is unresolvable for launch", async () => {
-		const launchSpy = spyOn(dapModule, "selectLaunchAdapter").mockReturnValue(null);
+	it("throws a Delve install hint instead of launching a native adapter for Go when default dlv is unavailable", async () => {
+		const sessionLaunchSpy = spyOn(dapModule.dapSessionManager, "launch").mockImplementation(async opts => {
+			throw new Error(`unexpected launch with ${opts.adapter.name}`);
+		});
 		try {
-			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-debugpy-"));
+			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-go-dlv-hint-"));
 			try {
-				await fs.writeFile(path.join(cwd, "main.py"), "print('hi')");
+				const pathDir = path.join(cwd, "empty-path");
+				process.env.PATH = pathDir;
+				await fs.mkdir(pathDir);
+				await fs.writeFile(path.join(cwd, "go.mod"), "module example.com/app\n\ngo 1.22\n");
+				await fs.writeFile(path.join(cwd, "main.go"), "package main\n\nfunc main() {}\n");
+				await writeExecutable(path.join(cwd, "bin", "gdb"));
+				await writeExecutable(path.join(cwd, "bin", "lldb-dap"));
 				const session: ToolSession = {
 					cwd,
 					hasUI: false,
@@ -649,22 +669,135 @@ describe("DebugTool launch validation", () => {
 				};
 				const tool = new DebugTool(session);
 
-				await expect(
-					tool.execute("call", { action: "launch", program: "main.py", adapter: "debugpy" }),
-				).rejects.toThrow(/debugpy.*python not found in PATH/);
+				await expect(tool.execute("call", { action: "launch", program: "main.go" })).rejects.toThrow(
+					/go install github\.com\/go-delve\/delve\/cmd\/dlv@latest/,
+				);
+				expect(sessionLaunchSpy).not.toHaveBeenCalled();
 			} finally {
 				await removeWithRetries(cwd);
 			}
 		} finally {
-			launchSpy.mockRestore();
+			sessionLaunchSpy.mockRestore();
 		}
 	});
 
-	it("throws targeted 'python not found in PATH' when adapter:'debugpy' is unresolvable for attach", async () => {
+	it("directs configured missing Delve commands back to the DAP adapter config", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-dlv-config-missing-"));
+		try {
+			const pathDir = path.join(cwd, "empty-path");
+			process.env.PATH = pathDir;
+			await fs.mkdir(pathDir);
+			await fs.writeFile(path.join(cwd, "main.go"), "package main\n\nfunc main() {}\n");
+			await fs.writeFile(
+				path.join(cwd, "dap.json"),
+				JSON.stringify({ adapters: { dlv: { command: "./bin/missing-dlv" } } }),
+			);
+			const session: ToolSession = {
+				cwd,
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+				settings: Settings.isolated({ "debug.enabled": true }),
+			};
+			const tool = new DebugTool(session);
+
+			let message = "";
+			try {
+				await tool.execute("call", { action: "launch", program: "main.go", adapter: "dlv" });
+			} catch (error) {
+				expect(error).toBeInstanceOf(Error);
+				message = (error as Error).message;
+			}
+
+			expect(message).toContain("DAP adapter config");
+			expect(message).toContain("./bin/missing-dlv");
+			expect(message).not.toContain("go install github.com/go-delve/delve/cmd/dlv@latest");
+		} finally {
+			await removeWithRetries(cwd);
+		}
+	});
+
+	it("directs configured missing rdbg commands back to the DAP adapter config", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-rdbg-explicit-"));
+		try {
+			const pathDir = path.join(cwd, "empty-path");
+			process.env.PATH = pathDir;
+			await fs.mkdir(pathDir);
+			await fs.writeFile(path.join(cwd, "app.rb"), "puts 'hi'\n");
+			await fs.writeFile(
+				path.join(cwd, "dap.json"),
+				JSON.stringify({ adapters: { rdbg: { command: "./bin/missing-rdbg" } } }),
+			);
+			const session: ToolSession = {
+				cwd,
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+				settings: Settings.isolated({ "debug.enabled": true }),
+			};
+			const tool = new DebugTool(session);
+
+			let message = "";
+			try {
+				await tool.execute("call", { action: "launch", program: "app.rb", adapter: "rdbg" });
+			} catch (error) {
+				expect(error).toBeInstanceOf(Error);
+				message = (error as Error).message;
+			}
+
+			expect(message).toContain("DAP adapter config");
+			expect(message).toContain("./bin/missing-rdbg");
+			expect(message).not.toContain("gem install debug");
+		} finally {
+			await removeWithRetries(cwd);
+		}
+	});
+
+	it("directs configured missing debugpy commands back to the DAP adapter config for launch", async () => {
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-debugpy-"));
+		try {
+			const pathDir = path.join(cwd, "empty-path");
+			process.env.PATH = pathDir;
+			await fs.mkdir(pathDir);
+			await fs.writeFile(path.join(cwd, "main.py"), "print('hi')");
+			await fs.writeFile(
+				path.join(cwd, "dap.json"),
+				JSON.stringify({ adapters: { debugpy: { command: "./bin/missing-python" } } }),
+			);
+			const session: ToolSession = {
+				cwd,
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+				settings: Settings.isolated({ "debug.enabled": true }),
+			};
+			const tool = new DebugTool(session);
+
+			let message = "";
+			try {
+				await tool.execute("call", { action: "launch", program: "main.py", adapter: "debugpy" });
+			} catch (error) {
+				expect(error).toBeInstanceOf(Error);
+				message = (error as Error).message;
+			}
+
+			expect(message).toContain("DAP adapter config");
+			expect(message).toContain("./bin/missing-python");
+			expect(message).not.toContain("python not found in PATH");
+		} finally {
+			await removeWithRetries(cwd);
+		}
+	});
+
+	it("directs configured missing debugpy commands back to the DAP adapter config for attach", async () => {
 		const attachSpy = spyOn(dapModule, "selectAttachAdapter").mockReturnValue(null);
 		try {
 			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-debugpy-attach-"));
 			try {
+				await fs.writeFile(
+					path.join(cwd, "dap.json"),
+					JSON.stringify({ adapters: { debugpy: { command: "./bin/missing-python" } } }),
+				);
 				const session: ToolSession = {
 					cwd,
 					hasUI: false,
@@ -674,9 +807,17 @@ describe("DebugTool launch validation", () => {
 				};
 				const tool = new DebugTool(session);
 
-				await expect(tool.execute("call", { action: "attach", pid: 1234, adapter: "debugpy" })).rejects.toThrow(
-					/debugpy.*python not found in PATH/,
-				);
+				let message = "";
+				try {
+					await tool.execute("call", { action: "attach", pid: 1234, adapter: "debugpy" });
+				} catch (error) {
+					expect(error).toBeInstanceOf(Error);
+					message = (error as Error).message;
+				}
+
+				expect(message).toContain("DAP adapter config");
+				expect(message).toContain("./bin/missing-python");
+				expect(message).not.toContain("python not found in PATH");
 			} finally {
 				await removeWithRetries(cwd);
 			}


### PR DESCRIPTION
## Repro
In a temporary Go module with `dlv` absent and native adapters available, `selectLaunchAdapter()` picked `gdb` for `main.go`; explicit `adapter:"dlv"` surfaced `No debugger adapter available. Installed adapters: gdb, debugpy`. Recorded repro: `bun /tmp/omp-debug-go-repro.ts` produced `go file without dlv selected: gdb` and the generic missing-adapter error.

## Cause
`packages/coding-agent/src/dap/config.ts` built launch candidates only from resolved adapters, then fell back to all available adapters when a configured extension match such as `dlv` could not resolve. Its extensionless root-marker checks used the debug `cwd` instead of the launch program ancestry, and DAP command resolution reused `$which`'s cached misses. `packages/coding-agent/src/tools/debug.ts` only mapped missing `debugpy` to a targeted error, so missing `dlv`/`rdbg` fell through to the generic adapter list.

## Fix
- Keep `.go` launches on configured Delve selection and return no native fallback when `dlv` is the matching but unavailable adapter.
- Match extensionless/package-directory adapters from the launch program ancestry, add `go.work` to Delve root markers, and refresh PATH command lookups for DAP adapter resolution.
- Add targeted install hints for inferred/explicit `dlv` and explicit `rdbg` unavailability, and remove the Python-only directory-program hint.
- Update `debug.md` to use registry adapter ids and document Delve package-directory launches.
- Add regression tests for missing Delve fallback prevention, nested package directories, `go.work`, stale PATH lookup recovery, and install-hint errors.

## Verification
`bun test packages/coding-agent/test/debug/dap-config.test.ts packages/coding-agent/test/debug/dap-launch-failures.test.ts` passed: 33 tests, 0 failures, 73 expectations. `bun check` passed locally before push, and the pre-publish gate passed during `gh_push_branch`. Fixes #5037