### PR TITLE
feat(coding-agent): add timestamp to per-turn token-usage row

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the turn's local timestamp (`YYYY-MM-DD HH:mm:ss`, down to the second) to the per-turn token-usage row shown under assistant messages when `display.showTokenUsage` is enabled.
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -84,6 +84,7 @@ export class ChatTranscriptBuilder {
 	#pendingUsage: Usage | undefined;
 	#pendingUsageDuration: number | undefined;
 	#pendingUsageTtft: number | undefined;
+	#pendingUsageTimestamp: number | undefined;
 	#lastAssistantUsage: Usage | undefined;
 	#waitingPoll: ToolExecutionComponent | null = null;
 	#todoSnapshot: ToolExecutionComponent | null = null;
@@ -132,6 +133,7 @@ export class ChatTranscriptBuilder {
 		this.#pendingUsage = undefined;
 		this.#pendingUsageDuration = undefined;
 		this.#pendingUsageTtft = undefined;
+		this.#pendingUsageTimestamp = undefined;
 		this.#lastAssistantUsage = undefined;
 		this.#waitingPoll = null;
 		this.#todoSnapshot = null;
@@ -200,11 +202,17 @@ export class ChatTranscriptBuilder {
 		this.#readGroup?.seal();
 		this.#readGroup = null;
 		this.container.addChild(
-			createUsageRowBlock(this.#pendingUsage, this.#pendingUsageDuration, this.#pendingUsageTtft),
+			createUsageRowBlock(
+				this.#pendingUsage,
+				this.#pendingUsageDuration,
+				this.#pendingUsageTtft,
+				this.#pendingUsageTimestamp,
+			),
 		);
 		this.#pendingUsage = undefined;
 		this.#pendingUsageDuration = undefined;
 		this.#pendingUsageTtft = undefined;
+		this.#pendingUsageTimestamp = undefined;
 	}
 
 	#appendChatMessage(message: AgentMessage): void {
@@ -361,6 +369,7 @@ export class ChatTranscriptBuilder {
 			settings.get("display.showTokenUsage") && assistantUsageIsBilled(message.usage) ? message.usage : undefined;
 		this.#pendingUsageDuration = message.duration;
 		this.#pendingUsageTtft = message.ttft;
+		this.#pendingUsageTimestamp = message.timestamp;
 	}
 
 	#appendToolResult(message: Extract<AgentMessage, { role: "toolResult" }>): void {

--- a/packages/coding-agent/src/modes/components/usage-row.ts
+++ b/packages/coding-agent/src/modes/components/usage-row.ts
@@ -6,9 +6,25 @@ import { theme } from "../../modes/theme/theme";
 /** Below this the rate is nonsense (cached/instant responses yield absurd tok/s). */
 const MIN_DURATION_MS = 100;
 
-export function createUsageRowBlock(usage: Usage, durationMs?: number, ttftMs?: number): Container {
+/** Local `YYYY-MM-DD HH:mm:ss` stamp for the per-turn usage row. */
+function formatUsageTimestamp(ms: number): string {
+	const d = new Date(ms);
+	const pad = (n: number): string => String(n).padStart(2, "0");
+	const date = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+	const time = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+	return `${date} ${time}`;
+}
+
+// `timestamp` is optional and trails the throughput args to preserve the existing
+// (usage, durationMs, ttftMs) call contract — this function is part of the package's
+// public export surface (./modes/components/*).
+export function createUsageRowBlock(usage: Usage, durationMs?: number, ttftMs?: number, timestamp?: number): Container {
 	const totalInput = usage.input + usage.cacheWrite;
 	const parts: string[] = [];
+	// Lead with the turn's local wall-clock time (down to the second), log-line style.
+	if (timestamp !== undefined && Number.isFinite(timestamp) && timestamp > 0) {
+		parts.push(formatUsageTimestamp(timestamp));
+	}
 	parts.push(`${theme.icon.input} ${formatNumber(totalInput)}`);
 	parts.push(`${theme.icon.output} ${formatNumber(usage.output)}`);
 	if (usage.cacheRead > 0) {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -852,7 +852,12 @@ export class EventController {
 			this.#lastAssistantComponent.markTranscriptBlockFinalized();
 			if (settings.get("display.showTokenUsage") && assistantUsageIsBilled(event.message.usage)) {
 				this.ctx.chatContainer.addChild(
-					createUsageRowBlock(event.message.usage, event.message.duration, event.message.ttft),
+					createUsageRowBlock(
+						event.message.usage,
+						event.message.duration,
+						event.message.ttft,
+						event.message.timestamp,
+					),
 				);
 			}
 			this.ctx.streamingComponent = undefined;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -300,14 +300,18 @@ export class UiHelpers {
 		let pendingUsage: Usage | undefined;
 		let pendingUsageDuration: number | undefined;
 		let pendingUsageTtft: number | undefined;
+		let pendingUsageTimestamp: number | undefined;
 		const flushPendingUsage = () => {
 			if (!pendingUsage) return;
 			readGroup?.seal();
 			readGroup = null;
-			this.ctx.chatContainer.addChild(createUsageRowBlock(pendingUsage, pendingUsageDuration, pendingUsageTtft));
+			this.ctx.chatContainer.addChild(
+				createUsageRowBlock(pendingUsage, pendingUsageDuration, pendingUsageTtft, pendingUsageTimestamp),
+			);
 			pendingUsage = undefined;
 			pendingUsageDuration = undefined;
 			pendingUsageTtft = undefined;
+			pendingUsageTimestamp = undefined;
 		};
 		// Rebuild-time mirror of the event controller's displaceable-poll
 		// bookkeeping: a `job` poll that found every watched job still running is
@@ -470,6 +474,7 @@ export class UiHelpers {
 						: undefined;
 				pendingUsageDuration = message.duration;
 				pendingUsageTtft = message.ttft;
+				pendingUsageTimestamp = message.timestamp;
 			} else if (message.role === "toolResult") {
 				const pendingReadComponent = this.ctx.pendingTools.get(message.toolCallId);
 				const isReadGroupResult =

--- a/packages/coding-agent/test/modes/controllers/event-controller-toolcall-finalize.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-toolcall-finalize.test.ts
@@ -120,4 +120,31 @@ describe("EventController finalizes assistant block when tool-call args stream",
 		const finalized = await dispatchUpdate(message);
 		expect(finalized).toHaveBeenCalled();
 	});
+
+	it("emits the per-turn usage row with the turn's local timestamp at message_end", async () => {
+		await Settings.init({ inMemory: true, cwd: process.cwd() });
+		settings.set("display.showTokenUsage", true);
+		// Fixed local wall-clock time; single-digit fields exercise zero-padding.
+		const timestamp = new Date(2026, 0, 2, 3, 4, 5).getTime();
+		const message: AssistantMessage = {
+			...makeStreamingMessage([{ type: "text", text: "done" }]),
+			usage: {
+				input: 1234,
+				output: 7,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1241,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp,
+		};
+		const { controller } = createFixture(message);
+		await controller.handleEvent({ type: "message_end", message } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+		const row = mountedComponents.at(-1) as unknown as { render(width: number): string[] } | undefined;
+		expect(row).toBeDefined();
+		expect(row?.render(120).join("\n")).toContain("2026-01-02 03:04:05");
+	});
 });

--- a/packages/coding-agent/test/usage-row-placement.test.ts
+++ b/packages/coding-agent/test/usage-row-placement.test.ts
@@ -6,19 +6,25 @@
  * row above the read group, diverging from the live path. The fix defers the row and
  * flushes it after the turn's tools are placed.
  */
-import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ChatTranscriptBuilder } from "@oh-my-pi/pi-coding-agent/modes/components/chat-transcript-builder";
 import { ReadToolGroupComponent } from "@oh-my-pi/pi-coding-agent/modes/components/read-tool-group";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
 import type { SessionContext } from "@oh-my-pi/pi-coding-agent/session/session-context";
-import { Container } from "@oh-my-pi/pi-tui";
+import { Container, type TUI } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
 
 // 4242 → "4.2K": distinctive enough not to collide with a read group's render.
 const USAGE_INPUT = 4242;
 const USAGE_LABEL = formatNumber(USAGE_INPUT);
+// Fixed local wall-clock time so the rendered stamp is deterministic across time zones.
+// Single-digit month/day/hour/minute/second exercise the formatter's zero-padding.
+const USAGE_TS = new Date(2026, 0, 2, 3, 4, 5).getTime();
+const USAGE_TS_LABEL = "2026-01-02 03:04:05";
 
 function readTurn(): AgentMessage[] {
 	const assistant = {
@@ -36,7 +42,7 @@ function readTurn(): AgentMessage[] {
 			totalTokens: USAGE_INPUT + 7,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
-		timestamp: Date.now(),
+		timestamp: USAGE_TS,
 	} as unknown as AgentMessage;
 	const toolResult = {
 		role: "toolResult",
@@ -90,6 +96,8 @@ describe("UiHelpers.renderSessionContext token-usage row placement", () => {
 		// The usage row is the trailing block and renders the turn's input tokens.
 		const last = children[children.length - 1]!;
 		expect(last.render(120).join("\n")).toContain(USAGE_LABEL);
+		// The row also carries the message's local timestamp down to the second.
+		expect(last.render(120).join("\n")).toContain(USAGE_TS_LABEL);
 		// And it sits strictly below the read group (the bug placed it above).
 		expect(children.length - 1).toBeGreaterThan(readIdx);
 		// Exactly one usage row — no duplication.
@@ -104,5 +112,46 @@ describe("UiHelpers.renderSessionContext token-usage row placement", () => {
 		expect(children.some(c => c.render(120).join("\n").includes(USAGE_LABEL))).toBe(false);
 		// Last block is the read group, not a usage row.
 		expect(children[children.length - 1]).toBeInstanceOf(ReadToolGroupComponent);
+	});
+});
+
+describe("ChatTranscriptBuilder token-usage row timestamp", () => {
+	beforeEach(async () => {
+		await Settings.init({ inMemory: true, cwd: process.cwd() });
+		settings.set("display.showTokenUsage", true);
+	});
+	afterEach(() => {
+		resetSettingsForTest();
+	});
+
+	it("renders the turn's local timestamp on the rebuilt usage row", () => {
+		const builder = new ChatTranscriptBuilder({
+			ui: { requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI,
+			cwd: process.cwd(),
+			requestRender: () => {},
+		});
+		const message = {
+			role: "assistant",
+			content: [{ type: "text", text: "done" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: USAGE_INPUT,
+				output: 7,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: USAGE_INPUT + 7,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: USAGE_TS,
+		} as unknown as AgentMessage;
+		builder.rebuild([{ type: "message", id: "m1", parentId: null, timestamp: new Date(0).toISOString(), message }]);
+		const children = builder.container.children;
+		const last = children[children.length - 1]!;
+		const rendered = last.render(120).join("\n");
+		expect(rendered).toContain(USAGE_TS_LABEL);
+		expect(rendered).toContain(USAGE_LABEL);
 	});
 });


### PR DESCRIPTION
## What

When **Show Token Usage** (`display.showTokenUsage`) is enabled, the per-turn stats row under each assistant message now leads with the turn's local wall-clock time, down to the second (`YYYY-MM-DD HH:mm:ss`):

```
2026-07-10 14:23:45   5.3K   2.4K   731K   2.8s   82.2/s
```

## Why

With the row enabled there was no way to tell *when* each turn happened. The stamp is sourced from the assistant message's persisted `timestamp`, so live streaming, interactive transcript rebuilds, and restored sessions all show the **turn** time rather than the view time.

Design notes:
- `createUsageRowBlock` takes `timestamp` as an **optional trailing** argument, preserving its existing `(usage, durationMs, ttftMs)` call contract — this function is on the package's public `./modes/components/*` export surface, so reordering would have been a silent breaking change (all args are `number`).
- Threaded through all three render paths that emit the row: live `EventController.#handleMessageEnd`, `UiHelpers.renderSessionContext` rebuild, and `ChatTranscriptBuilder.rebuild`.
- No new theme icon; plain fixed-width local stamp (avoids reusing the TTFT clock icon and avoids expanding every symbol preset).

## Testing

- `check:ts` across all TS workspaces (coding-agent: biome + docs-index + `tsgo --noEmit`) — passes.
- 142 blast-radius tests pass (`event-controller*`, `transcript*`, `tool-execution*`, `read-grouping`, `usage-row`), including 3 contract tests that assert the exact rendered stamp on the UiHelpers rebuild, EventController live (`message_end`), and `ChatTranscriptBuilder.rebuild` paths.

> Note: root `bun check` exits nonzero **only** on a pre-existing `check:rs` (rustfmt) discrepancy that fails identically on clean `main`; this PR touches no `.rs` files. The full `coding-agent-heavy` suite was not run.

---

- [ ] `bun check` passes — `check:ts` (all TS workspaces) passes; root `bun check` fails solely on the pre-existing Rust-formatting `check:rs` issue described above.
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)