### PR TITLE
fix(ai): apply codex reset to selected account

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 
 - Fixed concurrent reasoning summaries to ignore legacy streaming events under cutoff contract
+- Fixed Codex saved-reset redemption to include the selected account in the consume request body, so `/usage reset` applies to the chosen OpenAI account in multi-account setups. ([#5054](https://github.com/can1357/oh-my-pi/issues/5054))
 
 ## [16.3.15] - 2026-07-09
 

--- a/packages/ai/src/usage/openai-codex-reset.ts
+++ b/packages/ai/src/usage/openai-codex-reset.ts
@@ -8,7 +8,7 @@
  *
  *   GET  /wham/rate-limit-reset-credits           → list redeemable credits
  *   POST /wham/rate-limit-reset-credits/consume   → spend one credit
- *        body: { credit_id, redeem_request_id }
+ *        body: { credit_id, redeem_request_id, account_id? }
  *
  * `redeem_request_id` is a client-generated idempotency key (UUID). The consume
  * response carries a `code`: `"reset"` on success, otherwise a business reason
@@ -159,7 +159,11 @@ export async function consumeCodexResetCredit(
 	const response = await auth.fetch(url, {
 		method: "POST",
 		headers: buildHeaders(auth, true),
-		body: JSON.stringify({ credit_id: auth.creditId, redeem_request_id: redeemRequestId }),
+		body: JSON.stringify({
+			credit_id: auth.creditId,
+			redeem_request_id: redeemRequestId,
+			account_id: auth.accountId,
+		}),
 		signal: auth.signal,
 	});
 	let body: unknown;

--- a/packages/ai/test/openai-codex-reset.test.ts
+++ b/packages/ai/test/openai-codex-reset.test.ts
@@ -5,7 +5,7 @@
  * drift (and so we never need to spend a real credit to verify it):
  *
  *   GET  /wham/rate-limit-reset-credits
- *   POST /wham/rate-limit-reset-credits/consume  { credit_id, redeem_request_id }
+ *   POST /wham/rate-limit-reset-credits/consume  { credit_id, redeem_request_id, account_id? }
  */
 import { describe, expect, it } from "bun:test";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
@@ -93,7 +93,11 @@ describe("consumeCodexResetCredit", () => {
 		expect(result.code).toBe("reset");
 		expect(calls[0]?.method).toBe("POST");
 		expect(calls[0]?.url).toBe("https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume");
-		expect(calls[0]?.body).toEqual({ credit_id: "RateLimitResetCredit_abc", redeem_request_id: "req-123" });
+		expect(calls[0]?.body).toEqual({
+			credit_id: "RateLimitResetCredit_abc",
+			redeem_request_id: "req-123",
+			account_id: "acct-1",
+		});
 		expect(calls[0]?.headers["Content-Type"]).toBe("application/json");
 	});
 


### PR DESCRIPTION
## Repro
Calling `consumeCodexResetCredit({ accountId: "acct-2" })` for `/usage reset` produced a consume request with `ChatGPT-Account-Id: acct-2`, but the JSON body was only `{ credit_id, redeem_request_id }`; the selected account was absent from the payload, matching the reporter's multi-account case where the reset was spent on one account regardless of selector choice.

## Cause
`packages/ai/src/usage/openai-codex-reset.ts` scoped reset-credit listing with `ChatGPT-Account-Id`, but `consumeCodexResetCredit` did not include the selected account id in the `/wham/rate-limit-reset-credits/consume` JSON body. `AuthStorage.redeemResetCredit` already passed `match.accountId`, so the loss happened at the wire-shaping boundary.

## Fix
- Include `account_id` in the Codex reset consume body when `accountId` is supplied.
- Update the OpenAI Codex reset wire-contract test to assert the selected account is present in the POST body.
- Add an Unreleased changelog entry for the multi-account `/usage reset` fix.

## Verification
`bun test packages/ai/test/openai-codex-reset.test.ts` passed: 7 tests, 22 assertions. `bun run check` in `packages/ai` passed. Fixes #5054