### PR TITLE
fix(cli): route npm self-updates through npm

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp update` on npm-managed Windows installs so npm `.cmd`/`.ps1`/`.bat` launchers update through npm instead of being overwritten by downloaded release binaries. ([#5053](https://github.com/can1357/oh-my-pi/issues/5053))
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -109,6 +109,19 @@ async function getBunGlobalBinDir(): Promise<string | undefined> {
 	}
 }
 
+async function getNpmGlobalBinDir(): Promise<string | undefined> {
+	if (!$which("npm")) return undefined;
+	try {
+		const result = await $`npm prefix -g`.quiet().nothrow();
+		if (result.exitCode !== 0) return undefined;
+		const prefix = result.text().trim();
+		if (prefix.length === 0) return undefined;
+		return process.platform === "win32" ? prefix : path.join(prefix, "bin");
+	} catch {
+		return undefined;
+	}
+}
+
 async function getHomebrewFormulaPrefix(): Promise<string | undefined> {
 	if (!$which("brew")) return undefined;
 	for (const formula of [HOMEBREW_FORMULA, APP_NAME]) {
@@ -189,26 +202,36 @@ function isPathInDirectory(filePath: string, directoryPath: string): boolean {
 	return isPathInDirectoryLexical(resolvedFile, dirReal);
 }
 
-type UpdateMethod = "brew" | "mise" | "bun" | "binary";
+type UpdateMethod = "brew" | "mise" | "bun" | "npm" | "binary";
 
 interface UpdateMethodResolutionOptions {
 	homebrewPrefix?: string;
 	miseBinDirs?: readonly string[];
 	miseDataDir?: string;
+	npmBinDir?: string;
 }
 
-type UpdateTarget = { method: "brew" } | { method: "mise" } | { method: "bun" } | { method: "binary"; path: string };
+type UpdateTarget =
+	| { method: "brew" }
+	| { method: "mise" }
+	| { method: "bun" }
+	| { method: "npm" }
+	| { method: "binary"; path: string };
 
 function resolveUpdateMethod(
 	ompPath: string,
 	bunBinDir: string | undefined,
 	options: UpdateMethodResolutionOptions = {},
 ): UpdateMethod {
-	const { homebrewPrefix, miseBinDirs = [], miseDataDir } = options;
+	const { homebrewPrefix, miseBinDirs = [], miseDataDir, npmBinDir } = options;
+	const launcherExtension = path.extname(ompPath).toLowerCase();
+	const isWindowsScriptLauncher =
+		launcherExtension === ".cmd" || launcherExtension === ".ps1" || launcherExtension === ".bat";
 	if (homebrewPrefix && isPathInDirectory(ompPath, path.join(homebrewPrefix, "bin"))) return "brew";
 	if (miseBinDirs.some(dir => isPathInDirectory(ompPath, dir))) return "mise";
 	if (miseDataDir && isPathInDirectory(ompPath, path.join(miseDataDir, "shims"))) return "mise";
 	if (bunBinDir && isPathInDirectory(ompPath, bunBinDir)) return "bun";
+	if ((npmBinDir && isPathInDirectory(ompPath, npmBinDir)) || isWindowsScriptLauncher) return "npm";
 	return "binary";
 }
 
@@ -221,6 +244,7 @@ export function resolveUpdateMethodForTest(
 }
 async function resolveUpdateTarget(): Promise<UpdateTarget> {
 	const bunBinDir = await getBunGlobalBinDir();
+	const npmBinDir = await getNpmGlobalBinDir();
 	const homebrewPrefix = await getHomebrewFormulaPrefix();
 	const miseAvailable = $which("mise") !== undefined;
 	const miseBinDirs = miseAvailable ? await getMiseBinDirs() : [];
@@ -228,7 +252,7 @@ async function resolveUpdateTarget(): Promise<UpdateTarget> {
 	const ompPath = resolveOmpPath();
 
 	if (ompPath) {
-		const method = resolveUpdateMethod(ompPath, bunBinDir, { homebrewPrefix, miseBinDirs, miseDataDir });
+		const method = resolveUpdateMethod(ompPath, bunBinDir, { homebrewPrefix, miseBinDirs, miseDataDir, npmBinDir });
 		if (method === "binary") return { method, path: ompPath };
 		return { method };
 	}
@@ -715,6 +739,14 @@ export async function replaceBinaryForUpdate(options: BinaryReplacementOptions):
 	}
 }
 
+function buildVersionedPackageInstallArgs(expectedVersion: string, nativeTag: string): string[] {
+	const args = [`${PACKAGE}@${expectedVersion}`, `${NATIVES_PACKAGE}@${expectedVersion}`];
+	if (SUPPORTED_NATIVE_TAGS.has(nativeTag)) {
+		args.push(`${NATIVES_PACKAGE}-${nativeTag}@${expectedVersion}`);
+	}
+	return args;
+}
+
 /**
  * Build the bun argv used to globally install a specific omp version.
  *
@@ -746,17 +778,23 @@ export async function replaceBinaryForUpdate(options: BinaryReplacementOptions):
  * See #1824.
  */
 export function buildBunInstallArgs(expectedVersion: string, nativeTag: string = currentNativeTag()): string[] {
-	const args = [
+	return [
 		"install",
 		"-g",
 		"--no-cache",
 		`--registry=${NPM_REGISTRY}`,
-		`${PACKAGE}@${expectedVersion}`,
-		`${NATIVES_PACKAGE}@${expectedVersion}`,
+		...buildVersionedPackageInstallArgs(expectedVersion, nativeTag),
 	];
-	if (SUPPORTED_NATIVE_TAGS.has(nativeTag)) {
-		args.push(`${NATIVES_PACKAGE}-${nativeTag}@${expectedVersion}`);
-	}
+}
+
+/** Build the npm argv used to update npm-managed global installs. */
+export function buildNpmInstallArgs(expectedVersion: string, nativeTag: string = currentNativeTag()): string[] {
+	const args = [
+		"install",
+		"-g",
+		`--registry=${NPM_REGISTRY}`,
+		...buildVersionedPackageInstallArgs(expectedVersion, nativeTag),
+	];
 	return args;
 }
 
@@ -773,7 +811,7 @@ export function buildMiseForceInstallArgs(expectedVersion: string): string[] {
 }
 
 /**
- * Update via bun package manager.
+ * Update via package manager.
  */
 async function updateViaBun(expectedVersion: string): Promise<void> {
 	console.log(chalk.dim("Updating via bun..."));
@@ -792,6 +830,17 @@ async function updateViaBun(expectedVersion: string): Promise<void> {
 	} catch (err) {
 		console.log(chalk.yellow(`Warning: could not prune stale Bun cache entries: ${err}`));
 	}
+}
+
+async function updateViaNpm(expectedVersion: string): Promise<void> {
+	console.log(chalk.dim("Updating via npm..."));
+	const args = buildNpmInstallArgs(expectedVersion);
+	const result = await $`npm ${args}`.nothrow();
+	if (result.exitCode !== 0) {
+		throw new Error(`npm install failed with exit code ${result.exitCode}`);
+	}
+
+	await printVerification(expectedVersion);
 }
 
 async function updateViaHomebrew(expectedVersion: string, force: boolean): Promise<void> {
@@ -920,6 +969,8 @@ export async function runUpdateCommand(opts: { force: boolean; check: boolean })
 			await updateViaMise(release.version, opts.force);
 		} else if (target.method === "bun") {
 			await updateViaBun(release.version);
+		} else if (target.method === "npm") {
+			await updateViaNpm(release.version);
 		} else {
 			await updateViaBinaryAt(target.path, release.version);
 		}

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -10,6 +10,7 @@ import {
 	buildHomebrewUpdateArgs,
 	buildMiseForceInstallArgs,
 	buildMiseUpgradeArgs,
+	buildNpmInstallArgs,
 	parseUpdateArgs,
 	pruneBunInstallCache,
 	replaceBinaryForUpdate,
@@ -75,6 +76,20 @@ describe("update-cli install target detection", () => {
 		expect(method).toBe("bun");
 	});
 
+	it("uses npm update when prioritized omp is inside an npm global bin", () => {
+		const method = resolveUpdateMethodForTest("/Users/test/.npm-global/bin/omp", undefined, {
+			npmBinDir: "/Users/test/.npm-global/bin",
+		});
+
+		expect(method).toBe("npm");
+	});
+
+	it("uses npm update for Windows npm command shims even when no package-manager bin dirs were detected", () => {
+		const method = resolveUpdateMethodForTest("C:\\Users\\test\\AppData\\Roaming\\npm\\omp.cmd", undefined);
+
+		expect(method).toBe("npm");
+	});
+
 	it("uses binary update when prioritized omp is outside bun global bin", () => {
 		const method = resolveUpdateMethodForTest("/Users/test/.local/bin/omp", "/Users/test/.bun/bin");
 
@@ -133,6 +148,16 @@ describe("update-cli package manager commands", () => {
 	it("targets the mise GitHub backend tool and force-reinstalls the checked version when requested", () => {
 		expect(buildMiseUpgradeArgs()).toEqual(["upgrade", "github:can1357/oh-my-pi", "--bump"]);
 		expect(buildMiseForceInstallArgs("15.10.5")).toEqual(["install", "--force", "github:can1357/oh-my-pi@15.10.5"]);
+	});
+
+	it("pins npm package installs to the official registry and the checked native package versions", () => {
+		const args = buildNpmInstallArgs("16.3.15", "win32-x64");
+
+		expect(args.slice(0, 2)).toEqual(["install", "-g"]);
+		expect(args).toContain("--registry=https://registry.npmjs.org/");
+		expect(args).toContain("@oh-my-pi/pi-coding-agent@16.3.15");
+		expect(args).toContain("@oh-my-pi/pi-natives@16.3.15");
+		expect(args).toContain("@oh-my-pi/pi-natives-win32-x64@16.3.15");
 	});
 });
 


### PR DESCRIPTION
## Repro
A focused resolver repro failed before the fix: `bun test packages/coding-agent/test/repro-5053-npm-shim.test.ts` showed `resolveUpdateMethodForTest("C:\\Users\\tosoyn\\AppData\\Roaming\\npm\\omp.cmd", undefined)` returning `"binary"`, which would make `omp update` replace npm's `.cmd` launcher with a downloaded Windows PE binary.

## Cause
`packages/coding-agent/src/cli/update-cli.ts` only recognized Homebrew, mise, Bun global-bin paths, and standalone binary installs in `resolveUpdateMethod`; npm global shims were not detected, so a PATH-resolved `%APPDATA%\\npm\\omp.cmd` fell through to the `binary` target used by `updateViaBinaryAt`.

## Fix
- Added npm global-bin discovery via `npm prefix -g` and an `npm` update target in the self-update resolver.
- Treated Windows script launchers (`.cmd`, `.ps1`, `.bat`) as npm-managed update targets instead of binary replacement targets.
- Added `buildNpmInstallArgs`/`updateViaNpm` so npm-managed installs run `npm install -g` against the same pinned registry and versioned native packages as the version check.
- Added regression coverage for npm global-bin detection, Windows npm `.cmd` shim detection, and npm install argv construction.

## Verification
`bun test packages/coding-agent/test/update-cli.test.ts packages/coding-agent/src/cli/update-cli.test.ts` passed with 26 tests and 74 assertions. `bun check` passed in `packages/coding-agent`. `gh_push_branch` pre-publish checks passed before pushing `farm/96ac2ac8/windows-npm-update-shim`. Fixes #5053