### PR TITLE
RPC v2: add native plan and goal mode controls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added RPC protocol v2 native plan and goal mode controls, including capability negotiation, typed mode state, and safe session-switch restoration for non-interactive clients.
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -10,9 +10,12 @@
  * - Events: AgentSessionEvent objects streamed as they occur
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { isZodSchema, zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
-import { $env, isRecord, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, isEnoent, isRecord, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
@@ -24,31 +27,35 @@ import {
 } from "../../extensibility/extensions";
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
+import { resolveLocalUrlToPath } from "../../internal-urls";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands } from "../../slash-commands/available-commands";
+import { normalizeLocalScheme } from "../../tools/path-utils";
 import type { EventBus } from "../../utils/event-bus";
 import { initializeExtensions } from "../runtime-init";
 import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./host-tools";
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
+import { RpcNativeModeController } from "./rpc-native-mode-controller";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
-import type {
-	RpcCommand,
-	RpcExtensionUIRequest,
-	RpcExtensionUIResponse,
-	RpcHostToolCallRequest,
-	RpcHostToolCancelRequest,
-	RpcHostToolDefinition,
-	RpcHostToolResult,
-	RpcHostToolUpdate,
-	RpcHostUriCancelRequest,
-	RpcHostUriRequest,
-	RpcHostUriResult,
-	RpcResponse,
-	RpcSessionState,
-	RpcSubagentSubscriptionLevel,
+import {
+	RPC_NATIVE_MODE_PROTOCOL,
+	type RpcCommand,
+	type RpcExtensionUIRequest,
+	type RpcExtensionUIResponse,
+	type RpcHostToolCallRequest,
+	type RpcHostToolCancelRequest,
+	type RpcHostToolDefinition,
+	type RpcHostToolResult,
+	type RpcHostToolUpdate,
+	type RpcHostUriCancelRequest,
+	type RpcHostUriRequest,
+	type RpcHostUriResult,
+	type RpcResponse,
+	type RpcSessionState,
+	type RpcSubagentSubscriptionLevel,
 } from "./rpc-types";
 
 // Re-export types for consumers
@@ -69,6 +76,8 @@ type RpcOutput = (
 		| RpcHostUriCancelRequest
 		| object,
 ) => void;
+
+const RPC_PLAN_APPROVAL_TIMEOUT_MS = 600_000;
 
 export type RpcSessionChangeCommand = Extract<
 	RpcCommand,
@@ -426,6 +435,44 @@ function normalizeHostToolDefinitions(tools: RpcHostToolDefinition[]): RpcHostTo
 	});
 }
 
+function resolveRpcNativePlanFilePath(session: AgentSession, planFilePath: string): string {
+	if (planFilePath.startsWith("local:")) {
+		const normalized = normalizeLocalScheme(planFilePath);
+		return resolveLocalUrlToPath(normalized, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+	}
+	return path.resolve(session.sessionManager.getCwd(), planFilePath);
+}
+
+async function readRpcNativePlanFile(session: AgentSession, planFilePath: string): Promise<string | null> {
+	try {
+		return await Bun.file(resolveRpcNativePlanFilePath(session, planFilePath)).text();
+	} catch (error) {
+		if (isEnoent(error)) return null;
+		throw error;
+	}
+}
+
+async function listRpcNativePlanFiles(session: AgentSession): Promise<string[]> {
+	const localRoot = resolveRpcNativePlanFilePath(session, "local://");
+	try {
+		const entries = await fs.readdir(localRoot, { withFileTypes: true });
+		const plans = await Promise.all(
+			entries
+				.filter(entry => entry.isFile() && /plan\.md$/i.test(entry.name))
+				.map(async entry => {
+					const stat = await fs.stat(path.join(localRoot, entry.name)).catch(() => null);
+					return { url: `local://${entry.name}`, mtime: stat?.mtimeMs ?? 0 };
+				}),
+		);
+		return plans.sort((a, b) => b.mtime - a.mtime).map(plan => plan.url);
+	} catch {
+		return [];
+	}
+}
+
 function parseValueDialogResponse(
 	response: RpcExtensionUIResponse,
 	dialogOptions: ExtensionUIDialogOptions | undefined,
@@ -521,14 +568,12 @@ export async function runRpcMode(
 	setToolUIContext?: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
 	eventBus?: EventBus,
 ): Promise<never> {
-	// Signal to RPC clients that the server is ready to accept commands
 	// Suppress terminal notifications: they write \x07 (BEL) or OSC sequences directly to
 	// process.stdout with no newline, which the reader merges with the next JSON line and
 	// breaks JSON.parse. In RPC mode stdout is the JSON protocol channel — nothing else
 	// may write there.
 	process.env.PI_NOTIFICATIONS = "off";
 
-	process.stdout.write(`${JSON.stringify({ type: "ready" })}\n`);
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
 		process.stdout.write(`${JSON.stringify(obj)}\n`);
 	};
@@ -588,6 +633,12 @@ export async function runRpcMode(
 			};
 
 			const onAbort = () => {
+				this.output({
+					type: "extension_ui_request",
+					id: Snowflake.next() as string,
+					method: "cancel",
+					targetId: id,
+				} as RpcExtensionUIRequest);
 				cleanup();
 				resolve(defaultValue);
 			};
@@ -800,7 +851,71 @@ export async function runRpcMode(
 	const rpcUiContext = new RpcExtensionUIContext(pendingExtensionRequests, output);
 	setToolUIContext?.(rpcUiContext, true);
 
-	// Set up extensions with RPC-based UI context
+	const nativeModeController = new RpcNativeModeController({
+		isStreaming: () => session.isStreaming,
+		isCompacting: () => session.isCompacting,
+		hasPostPromptWork: () => session.hasPostPromptWork,
+		isPlanModeEnabled: () => session.settings.get("plan.enabled"),
+		isGoalModeEnabled: () => session.settings.get("goal.enabled"),
+		getGoalContinuationModes: () => session.settings.get("goal.continuationModes"),
+		getActiveToolNames: () => session.getActiveToolNames(),
+		hasBuiltInTool: name => session.hasBuiltInTool(name),
+		setActiveToolsByName: names => session.setActiveToolsByName(names),
+		captureModelState: () => {
+			const model = session.model;
+			return model ? { model, thinkingLevel: session.configuredThinkingLevel() } : undefined;
+		},
+		resolvePlanRoleModel: () => session.resolveRoleModelWithThinking("plan"),
+		applyTemporaryModel: (model, thinkingLevel) => session.setModelTemporary(model, thinkingLevel),
+		setThinkingLevel: thinkingLevel => session.setThinkingLevel(thinkingLevel),
+		getPlanModeState: () => session.getPlanModeState(),
+		setPlanModeState: state => session.setPlanModeState(state),
+		getPlanReferencePath: () => session.getPlanReferencePath(),
+		setPlanReferencePath: planFilePath => session.setPlanReferencePath(planFilePath),
+		setStandingResolveHandler: handler => session.setStandingResolveHandler(handler),
+		getGoalModeState: () => session.getGoalModeState(),
+		setGoalModeState: state => session.setGoalModeState(state),
+		goalRuntime: session.goalRuntime,
+		getPersistedMode: () => {
+			const context = session.sessionManager.buildSessionContext();
+			return { mode: context.mode, modeData: context.modeData };
+		},
+		appendModeChange: (mode, data) => {
+			session.sessionManager.appendModeChange(mode, data);
+		},
+		readPlan: planFilePath => readRpcNativePlanFile(session, planFilePath),
+		listPlanFiles: () => listRpcNativePlanFiles(session),
+		confirmPlan: (title, message, options) =>
+			rpcUiContext.confirm(title, message, { timeout: RPC_PLAN_APPROVAL_TIMEOUT_MS, signal: options?.signal }),
+		submitPrompt: (description, options) => session.prompt(description, options),
+		submitGoalContinuation: prompt =>
+			session.promptCustomMessage({
+				customType: "goal-continuation",
+				content: prompt,
+				display: false,
+				attribution: "agent",
+			}),
+		reportBackgroundError: backgroundError => {
+			output(
+				error(
+					undefined,
+					"native_mode",
+					backgroundError instanceof Error ? backgroundError.message : String(backgroundError),
+				),
+			);
+		},
+	});
+	let sessionSwitchReconciled = false;
+	session.setSessionSwitchReconciler(async () => {
+		await nativeModeController.reconcileAfterSessionChange();
+		sessionSwitchReconciled = true;
+	});
+
+	// Reconcile persisted native state before clients can issue mode commands.
+	await nativeModeController.reconcile();
+	process.stdout.write(`${JSON.stringify({ type: "ready", protocol: RPC_NATIVE_MODE_PROTOCOL })}\n`);
+
+	// Set up extensions with RPC-based UI context.
 	await initializeExtensions(session, {
 		reportSendError: (action, err) => {
 			output(error(undefined, action, err.message));
@@ -817,8 +932,16 @@ export async function runRpcMode(
 		uiContext: rpcUiContext,
 	});
 
-	// Output all agent events as JSON
 	session.subscribe(event => {
+		void nativeModeController.handleSessionEvent(event).catch(backgroundError => {
+			output(
+				error(
+					undefined,
+					"native_mode",
+					backgroundError instanceof Error ? backgroundError.message : String(backgroundError),
+				),
+			);
+		});
 		output(event);
 	});
 
@@ -926,9 +1049,17 @@ export async function runRpcMode(
 			case "new_session":
 			case "switch_session":
 			case "branch": {
-				const result = await handleRpcSessionChange(session, command, subagentRegistry);
-				if (!result.data.cancelled) await emitAvailableCommandsUpdate();
-				return success(id, result.type, result.data);
+				sessionSwitchReconciled = false;
+				await nativeModeController.prepareForSessionChange();
+				try {
+					const result = await handleRpcSessionChange(session, command, subagentRegistry);
+					if (!sessionSwitchReconciled) await nativeModeController.reconcile();
+					if (!result.data.cancelled) await emitAvailableCommandsUpdate();
+					return success(id, result.type, result.data);
+				} catch (commandError) {
+					await nativeModeController.reconcile();
+					throw commandError;
+				}
 			}
 
 			// =================================================================
@@ -959,8 +1090,41 @@ export async function runRpcMode(
 						examples: tool.examples,
 					})),
 					contextUsage: session.getContextUsage(),
+					mode: nativeModeController.getMode(),
 				};
 				return success(id, "get_state", state);
+			}
+
+			case "set_plan_mode": {
+				try {
+					return success(
+						id,
+						"set_plan_mode",
+						await nativeModeController.setPlanMode({ action: command.action, description: command.description }),
+					);
+				} catch (commandError) {
+					return error(
+						id,
+						"set_plan_mode",
+						commandError instanceof Error ? commandError.message : String(commandError),
+					);
+				}
+			}
+
+			case "set_goal_mode": {
+				try {
+					return success(
+						id,
+						"set_goal_mode",
+						await nativeModeController.setGoalMode({ action: command.action, description: command.description }),
+					);
+				} catch (commandError) {
+					return error(
+						id,
+						"set_goal_mode",
+						commandError instanceof Error ? commandError.message : String(commandError),
+					);
+				}
 			}
 
 			case "get_available_commands": {

--- a/packages/coding-agent/src/modes/rpc/rpc-native-mode-controller.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-native-mode-controller.ts
@@ -1,0 +1,838 @@
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
+import type { Goal, GoalModeState, GoalStatus } from "../../goals/state";
+import { type PlanApprovalDetails, resolveApprovedPlan } from "../../plan-mode/approved-plan";
+import type { PlanModeState } from "../../plan-mode/state";
+import type { ConfiguredThinkingLevel } from "../../thinking";
+import { type ResolveToolDetails, runResolveInvocation } from "../../tools/resolve-invocation";
+import { ToolError } from "../../tools/tool-errors";
+import type {
+	RpcGoalModeStatus,
+	RpcNativeModeAction,
+	RpcNativeModeResult,
+	RpcNativeModeState,
+	RpcPlanModeStatus,
+} from "./rpc-types";
+
+export const DEFAULT_RPC_PLAN_FILE_PATH = "local://PLAN.md";
+export const RPC_GOAL_CONTINUATION_DELAY_MS = 800;
+
+export type RpcPersistedNativeMode = "plan" | "plan_paused" | "goal" | "goal_paused" | "none";
+
+export interface RpcPersistedMode {
+	mode: string;
+	modeData?: Record<string, unknown>;
+}
+
+export interface RpcGoalRuntime {
+	clearAccounting(): void;
+	onThreadResumed(options?: { preserveActiveGoal?: boolean }): Promise<GoalModeState | undefined>;
+	createGoal(input: { objective: string; tokenBudget?: number }): Promise<GoalModeState>;
+	resumeGoal(): Promise<GoalModeState>;
+	pauseGoal(): Promise<GoalModeState | undefined>;
+	dropGoal(): Promise<Goal | undefined>;
+	buildContinuationPrompt(): string | undefined;
+}
+
+export type RpcPlanResolveHandler = (input: unknown) => Promise<AgentToolResult<ResolveToolDetails>>;
+
+export interface RpcNativeModeModelState {
+	model: Model;
+	thinkingLevel?: ConfiguredThinkingLevel;
+}
+
+export interface RpcPlanRoleModel {
+	model: Model | undefined;
+	thinkingLevel?: ConfiguredThinkingLevel;
+	explicitThinkingLevel: boolean;
+}
+
+type PendingPlanApproval = {
+	generation: number;
+	state: PlanModeState;
+	planFilePath: string;
+	abortController: AbortController;
+};
+
+/**
+ * The small host boundary keeps native RPC mode transitions independent from the
+ * terminal UI and makes the controller directly unit-testable.
+ */
+export interface RpcNativeModeHost {
+	isStreaming(): boolean;
+	isCompacting(): boolean;
+	hasPostPromptWork(): boolean;
+
+	isPlanModeEnabled(): boolean;
+	isGoalModeEnabled(): boolean;
+	getGoalContinuationModes(): readonly string[];
+
+	getActiveToolNames(): string[];
+	hasBuiltInTool(name: string): boolean;
+	setActiveToolsByName(names: string[]): Promise<void>;
+
+	getPlanModeState(): PlanModeState | undefined;
+	setPlanModeState(state: PlanModeState | undefined): void;
+	getPlanReferencePath(): string;
+	setPlanReferencePath(path: string): void;
+	setStandingResolveHandler(handler: RpcPlanResolveHandler | null): void;
+
+	captureModelState(): RpcNativeModeModelState | undefined;
+	resolvePlanRoleModel(): RpcPlanRoleModel;
+	applyTemporaryModel(model: Model, thinkingLevel?: ConfiguredThinkingLevel): Promise<void>;
+	setThinkingLevel(thinkingLevel?: ConfiguredThinkingLevel): void;
+
+	getGoalModeState(): GoalModeState | undefined;
+	setGoalModeState(state: GoalModeState | undefined): void;
+	goalRuntime: RpcGoalRuntime;
+
+	getPersistedMode(): RpcPersistedMode;
+	appendModeChange(mode: RpcPersistedNativeMode, data?: Record<string, unknown>): void;
+
+	readPlan(path: string): Promise<string | null>;
+	listPlanFiles(): Promise<string[]>;
+	confirmPlan(title: string, message: string, options?: { signal?: AbortSignal }): Promise<boolean>;
+
+	/** Starts a normal user prompt without making the mode response await its turn. */
+	submitPrompt(description: string, options: { expandPromptTemplates: false }): void | Promise<unknown>;
+	/** Starts a hidden goal continuation without making the scheduler await its turn. */
+	submitGoalContinuation(prompt: string): void | Promise<unknown>;
+	/** Optional reporting hook for fire-and-forget prompt failures. */
+	reportBackgroundError?(error: unknown): void;
+}
+
+export type RpcNativeModeSessionEvent =
+	| { type: "agent_start" }
+	| { type: "agent_end" }
+	| { type: "tool_execution_start" }
+	| { type: "message_start"; message: { role: string; synthetic?: boolean } }
+	| { type: "goal_updated"; goal: Goal | null; state?: GoalModeState };
+
+export function isRpcNativeModeAction(value: unknown): value is RpcNativeModeAction {
+	return value === "on" || value === "off" || value === "toggle";
+}
+
+/** Converts absent and whitespace-only descriptions to `undefined`. */
+export function normalizeRpcNativeModeDescription(value: unknown): string | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value !== "string") throw new Error("description must be a string");
+	const description = value.trim();
+	return description || undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isGoalStatus(value: unknown): value is GoalStatus {
+	return (
+		value === "active" ||
+		value === "paused" ||
+		value === "budget-limited" ||
+		value === "complete" ||
+		value === "dropped"
+	);
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/** Reads only complete, non-terminal persisted goals. Invalid persisted data is stale. */
+export function goalFromRpcPersistedModeData(modeData: unknown): Goal | undefined {
+	if (!isRecord(modeData) || !isRecord(modeData.goal)) return undefined;
+	const value = modeData.goal;
+	if (
+		typeof value.id !== "string" ||
+		!value.id.trim() ||
+		typeof value.objective !== "string" ||
+		!value.objective.trim() ||
+		!isGoalStatus(value.status) ||
+		value.status === "complete" ||
+		value.status === "dropped" ||
+		!isNonNegativeFiniteNumber(value.tokensUsed) ||
+		!isNonNegativeFiniteNumber(value.timeUsedSeconds) ||
+		!isNonNegativeFiniteNumber(value.createdAt) ||
+		!isNonNegativeFiniteNumber(value.updatedAt)
+	) {
+		return undefined;
+	}
+	const tokenBudget = value.tokenBudget;
+	if (tokenBudget !== undefined) {
+		if (
+			typeof tokenBudget !== "number" ||
+			!Number.isFinite(tokenBudget) ||
+			!Number.isInteger(tokenBudget) ||
+			tokenBudget <= 0
+		) {
+			return undefined;
+		}
+	}
+	return {
+		id: value.id,
+		objective: value.objective,
+		status: value.status,
+		...(tokenBudget === undefined ? {} : { tokenBudget }),
+		tokensUsed: value.tokensUsed,
+		timeUsedSeconds: value.timeUsedSeconds,
+		createdAt: value.createdAt,
+		updatedAt: value.updatedAt,
+	};
+}
+
+export function planModeStatus(planFilePath: string | undefined, active: boolean, paused: boolean): RpcPlanModeStatus {
+	if (!active && !paused) return { status: "off" };
+	return {
+		status: active ? "active" : "paused",
+		...(planFilePath ? { planFilePath } : {}),
+	};
+}
+
+export function goalModeStatus(state: GoalModeState | undefined, continuationConfigured: boolean): RpcGoalModeStatus {
+	if (!state || state.goal.status === "complete" || state.goal.status === "dropped") {
+		return { status: "off", continuationEnabled: false };
+	}
+	const active = state.enabled === true;
+	const goal = state.goal;
+	return {
+		status: active ? "active" : "paused",
+		objective: goal.objective,
+		goalId: goal.id,
+		...(goal.tokenBudget === undefined ? {} : { tokenBudget: goal.tokenBudget }),
+		tokensUsed: goal.tokensUsed,
+		continuationEnabled: active && goal.status === "active" && continuationConfigured,
+	};
+}
+
+export interface RpcNativeModeRequest {
+	action: RpcNativeModeAction;
+	description?: string;
+}
+
+export class RpcNativeModeController {
+	readonly #host: RpcNativeModeHost;
+	#plan: RpcPlanModeStatus = { status: "off" };
+	#planPreviousTools: string[] | undefined;
+	#planPreviousModelState: RpcNativeModeModelState | undefined;
+	#planGeneration = 0;
+	#pendingPlanApproval: PendingPlanApproval | undefined;
+	#goalPreviousTools: string[] | undefined;
+	#goalContinuationTimer: ReturnType<typeof setTimeout> | undefined;
+	#goalContinuationTurnInFlight = false;
+	#goalSuppressNextContinuation = false;
+	#goalTurnHadToolCalls = false;
+
+	constructor(host: RpcNativeModeHost) {
+		this.#host = host;
+	}
+
+	getMode(): RpcNativeModeState {
+		const livePlan = this.#host.getPlanModeState();
+		const plan = livePlan?.enabled ? planModeStatus(livePlan.planFilePath, true, false) : { ...this.#plan };
+		const goal = goalModeStatus(this.#host.getGoalModeState(), this.#isGoalContinuationConfigured());
+		return { plan, goal };
+	}
+
+	/** Rehydrates the current session's persisted mode after startup or session navigation. */
+	async reconcile(): Promise<RpcNativeModeState> {
+		await this.prepareForSessionChange();
+		return this.#reconcilePersistedMode();
+	}
+
+	/** Rehydrates after AgentSession has already restored the target session state. */
+	async reconcileAfterSessionChange(): Promise<RpcNativeModeState> {
+		await this.prepareForSessionChange({ restoreTools: false, restoreModel: false });
+		return this.#reconcilePersistedMode(true);
+	}
+
+	async #reconcilePersistedMode(preserveActiveGoal = false): Promise<RpcNativeModeState> {
+		const persisted = this.#host.getPersistedMode();
+
+		if (persisted.mode === "plan" || persisted.mode === "plan_paused") {
+			await this.#reconcilePlan(persisted.mode, persisted.modeData);
+			return this.getMode();
+		}
+		if (persisted.mode === "goal" || persisted.mode === "goal_paused") {
+			await this.#reconcileGoal(persisted.mode, persisted.modeData, preserveActiveGoal);
+			return this.getMode();
+		}
+
+		this.#host.goalRuntime.clearAccounting();
+		if (persisted.mode !== "none") this.#host.appendModeChange("none");
+		return this.getMode();
+	}
+	/**
+	 * Restores transient tools and model state before a session branch/new/switch operation. This
+	 * intentionally does not append a mode entry: the outgoing session must retain
+	 * its durable mode while the target session is loaded.
+	 */
+	async prepareForSessionChange(options?: { restoreTools?: boolean; restoreModel?: boolean }): Promise<void> {
+		this.#invalidatePlanApprovals();
+		this.#cancelGoalContinuation();
+		this.#goalContinuationTurnInFlight = false;
+		this.#goalSuppressNextContinuation = false;
+		this.#goalTurnHadToolCalls = false;
+		if (options?.restoreTools !== false) {
+			await this.#restorePlanTools();
+			await this.#restoreGoalTools();
+		} else {
+			this.#planPreviousTools = undefined;
+			this.#goalPreviousTools = undefined;
+		}
+		if (options?.restoreModel !== false) {
+			await this.#restorePlanModel();
+		} else {
+			this.#planPreviousModelState = undefined;
+		}
+		this.#host.setStandingResolveHandler(null);
+		this.#host.setPlanModeState(undefined);
+		this.#host.setGoalModeState(undefined);
+		this.#host.goalRuntime.clearAccounting();
+		this.#plan = { status: "off" };
+	}
+
+	async setPlanMode(input: RpcNativeModeRequest): Promise<RpcNativeModeResult> {
+		this.#assertCanMutate("plan");
+		const action = this.#validatedAction(input.action);
+		const description = normalizeRpcNativeModeDescription(input.description);
+		const current = this.getMode().plan.status;
+
+		if (action === "off") {
+			if (current !== "off") await this.#exitPlan({ paused: false });
+			return { mode: this.getMode(), agentInvoked: false };
+		}
+		if (action === "toggle") {
+			if (current === "active") {
+				await this.#exitPlan({ paused: true });
+				return { mode: this.getMode(), agentInvoked: false };
+			}
+			if (current === "paused") {
+				await this.#exitPlan({ paused: false });
+				return { mode: this.getMode(), agentInvoked: false };
+			}
+			this.#requireDescription(description, "A description is required to enable plan mode.");
+			await this.#enterPlan();
+			this.#submitDescription(description);
+			return { mode: this.getMode(), agentInvoked: true };
+		}
+
+		if (current === "active") {
+			if (description) this.#submitDescription(description);
+			return { mode: this.getMode(), agentInvoked: description !== undefined };
+		}
+		this.#requireDescription(description, "A description is required to enable plan mode.");
+		await this.#enterPlan();
+		this.#submitDescription(description);
+		return { mode: this.getMode(), agentInvoked: true };
+	}
+
+	async setGoalMode(input: RpcNativeModeRequest): Promise<RpcNativeModeResult> {
+		this.#assertCanMutate("goal");
+		const action = this.#validatedAction(input.action);
+		const description = normalizeRpcNativeModeDescription(input.description);
+		const current = this.getMode().goal.status;
+
+		if (action === "off") {
+			if (current !== "off") await this.#dropGoal();
+			return { mode: this.getMode(), agentInvoked: false };
+		}
+		if (action === "toggle") {
+			if (current === "active") {
+				await this.#pauseGoal();
+				return { mode: this.getMode(), agentInvoked: false };
+			}
+			if (current === "paused") {
+				await this.#dropGoal();
+				return { mode: this.getMode(), agentInvoked: false };
+			}
+			this.#requireDescription(description, "An objective is required to enable goal mode.");
+			await this.#createGoal(description);
+			this.#submitDescription(description);
+			return { mode: this.getMode(), agentInvoked: true };
+		}
+
+		if (current === "active") {
+			if (description) this.#submitDescription(description);
+			return { mode: this.getMode(), agentInvoked: description !== undefined };
+		}
+		if (current === "paused") {
+			if (description) {
+				throw new Error("A paused goal can only be resumed without a replacement objective.");
+			}
+			await this.#resumeGoal();
+			return { mode: this.getMode(), agentInvoked: false };
+		}
+		this.#requireDescription(description, "An objective is required to enable goal mode.");
+		await this.#createGoal(description);
+		this.#submitDescription(description);
+		return { mode: this.getMode(), agentInvoked: true };
+	}
+
+	/** Receives structural AgentSession events without coupling tests to AgentSession. */
+	async handleSessionEvent(event: unknown): Promise<void> {
+		if (!isRecord(event) || typeof event.type !== "string") return;
+		if (event.type === "agent_start") {
+			this.#goalTurnHadToolCalls = false;
+			this.#cancelGoalContinuation();
+			return;
+		}
+		if (event.type === "tool_execution_start") {
+			this.#goalTurnHadToolCalls = true;
+			if (!this.#goalContinuationTurnInFlight) this.#goalSuppressNextContinuation = false;
+			return;
+		}
+		if (event.type === "message_start" && this.#isUserMessageStart(event.message)) {
+			this.#goalSuppressNextContinuation = false;
+			this.#cancelGoalContinuation();
+			return;
+		}
+		if (event.type === "goal_updated") {
+			await this.#handleGoalUpdated(event);
+			return;
+		}
+		if (event.type !== "agent_end") return;
+
+		if (this.#goalContinuationTurnInFlight) {
+			this.#goalSuppressNextContinuation = !this.#goalTurnHadToolCalls;
+			this.#goalContinuationTurnInFlight = false;
+		}
+		const state = this.#host.getGoalModeState();
+		if (state?.mode === "exiting" || state?.goal.status === "complete") {
+			await this.#finishCompletedGoal();
+			return;
+		}
+		this.#scheduleGoalContinuation();
+	}
+
+	#validatedAction(action: unknown): RpcNativeModeAction {
+		if (isRpcNativeModeAction(action)) return action;
+		throw new Error(`Invalid native mode action: ${String(action)}`);
+	}
+
+	#assertCanMutate(mode: "plan" | "goal"): void {
+		if (this.#host.isStreaming()) {
+			throw new Error(`Cannot change ${mode} mode while a response is in progress.`);
+		}
+	}
+
+	#requireDescription(description: string | undefined, message: string): asserts description is string {
+		if (!description) throw new Error(message);
+	}
+
+	#planPath(): string {
+		const live = this.#host.getPlanModeState()?.planFilePath;
+		const plan = this.#plan;
+		const remembered = plan.status === "off" ? undefined : plan.planFilePath;
+		const reference = this.#host.getPlanReferencePath().trim();
+		return live || remembered || reference || DEFAULT_RPC_PLAN_FILE_PATH;
+	}
+
+	#assertPlanCanEnter(): void {
+		if (!this.#host.isPlanModeEnabled()) {
+			throw new Error("Plan mode is disabled by settings.");
+		}
+		const goalStatus = this.getMode().goal.status;
+		if (goalStatus !== "off") {
+			throw new Error("Cannot enable plan mode while goal mode is active or paused.");
+		}
+	}
+
+	#assertGoalCanEnter(): void {
+		if (!this.#host.isGoalModeEnabled()) {
+			throw new Error("Goal mode is disabled by settings.");
+		}
+		const planStatus = this.getMode().plan.status;
+		if (planStatus !== "off") {
+			throw new Error("Cannot enable goal mode while plan mode is active or paused.");
+		}
+	}
+
+	async #enterPlan(options?: { planFilePath?: string; reentry?: boolean; persist?: boolean }): Promise<void> {
+		this.#assertPlanCanEnter();
+		this.#cancelGoalContinuation();
+		const previousTools = this.#host.getActiveToolNames();
+		const planTools = [...previousTools, "resolve"];
+		if (this.#host.hasBuiltInTool("write")) planTools.push("write");
+		const planFilePath = options?.planFilePath ?? this.#planPath();
+		await this.#host.setActiveToolsByName([...new Set(planTools)]);
+		this.#planPreviousTools = previousTools;
+		this.#plan = planModeStatus(planFilePath, true, false);
+		this.#host.setPlanModeState({
+			enabled: true,
+			planFilePath,
+			workflow: "parallel",
+			reentry: options?.reentry === true,
+		});
+		try {
+			await this.#applyPlanModel();
+		} catch (error) {
+			await this.#rollbackPlanEntry(error);
+		}
+		this.#host.setStandingResolveHandler(input => this.#runPlanApprovalResolve(input));
+		if (options?.persist !== false) this.#host.appendModeChange("plan", { planFilePath });
+	}
+
+	async #rollbackPlanEntry(error: unknown): Promise<never> {
+		const rollbackFailures: unknown[] = [];
+		try {
+			await this.#restorePlanTools();
+		} catch (rollbackError) {
+			rollbackFailures.push(rollbackError);
+		}
+		try {
+			await this.#restorePlanModel();
+		} catch (rollbackError) {
+			rollbackFailures.push(rollbackError);
+		}
+		this.#planPreviousTools = undefined;
+		this.#planPreviousModelState = undefined;
+		this.#host.setStandingResolveHandler(null);
+		this.#host.setPlanModeState(undefined);
+		this.#plan = { status: "off" };
+		if (rollbackFailures.length > 0) {
+			throw new AggregateError(
+				[error, ...rollbackFailures],
+				"Failed to activate the plan model and restore the prior session state.",
+			);
+		}
+		throw error;
+	}
+
+	async #exitPlan(options: { paused: boolean }): Promise<void> {
+		this.#invalidatePlanApprovals();
+		const current = this.getMode().plan;
+		if (current.status === "off") return;
+		const planFilePath = current.planFilePath ?? this.#planPath();
+		await this.#restorePlanTools();
+		await this.#restorePlanModel();
+		this.#host.setStandingResolveHandler(null);
+		this.#host.setPlanModeState(undefined);
+		if (options.paused) {
+			this.#plan = planModeStatus(planFilePath, false, true);
+			this.#host.appendModeChange("plan_paused", { planFilePath });
+			return;
+		}
+		this.#plan = { status: "off" };
+		this.#host.appendModeChange("none");
+	}
+
+	async #restorePlanTools(): Promise<void> {
+		const previousTools = this.#planPreviousTools;
+		this.#planPreviousTools = undefined;
+		if (previousTools !== undefined) await this.#host.setActiveToolsByName(previousTools);
+	}
+
+	async #applyPlanModel(): Promise<void> {
+		const planRole = this.#host.resolvePlanRoleModel();
+		if (!planRole.model) return;
+
+		const previous = this.#host.captureModelState();
+		this.#planPreviousModelState = previous;
+		const planThinkingLevel = planRole.explicitThinkingLevel ? planRole.thinkingLevel : undefined;
+		if (!previous || !modelsAreEqual(previous.model, planRole.model)) {
+			await this.#host.applyTemporaryModel(planRole.model, planThinkingLevel);
+			return;
+		}
+		if (planRole.explicitThinkingLevel) this.#host.setThinkingLevel(planThinkingLevel);
+	}
+
+	async #restorePlanModel(): Promise<void> {
+		const previous = this.#planPreviousModelState;
+		if (!previous) return;
+
+		const current = this.#host.captureModelState();
+		if (current && modelsAreEqual(current.model, previous.model)) {
+			this.#host.setThinkingLevel(previous.thinkingLevel);
+		} else {
+			await this.#host.applyTemporaryModel(previous.model, previous.thinkingLevel);
+		}
+		this.#planPreviousModelState = undefined;
+	}
+
+	#invalidatePlanApprovals(): void {
+		this.#planGeneration += 1;
+		this.#cancelPendingPlanApproval();
+	}
+
+	#cancelPendingPlanApproval(): void {
+		const pending = this.#pendingPlanApproval;
+		this.#pendingPlanApproval = undefined;
+		pending?.abortController.abort();
+	}
+
+	#isSameActivePlan(generation: number, state: PlanModeState, planFilePath: string): boolean {
+		const activeState = this.#host.getPlanModeState();
+		if (!activeState?.enabled) return false;
+		return this.#planGeneration === generation && activeState === state && activeState.planFilePath === planFilePath;
+	}
+
+	#beginPlanApproval(generation: number, state: PlanModeState, planFilePath: string): PendingPlanApproval | undefined {
+		if (!this.#isSameActivePlan(generation, state, planFilePath)) return undefined;
+		this.#cancelPendingPlanApproval();
+		const pending: PendingPlanApproval = {
+			generation,
+			state,
+			planFilePath,
+			abortController: new AbortController(),
+		};
+		this.#pendingPlanApproval = pending;
+		return pending;
+	}
+
+	#isCurrentPlanApproval(pending: PendingPlanApproval): boolean {
+		return (
+			this.#pendingPlanApproval === pending &&
+			!pending.abortController.signal.aborted &&
+			this.#isSameActivePlan(pending.generation, pending.state, pending.planFilePath)
+		);
+	}
+
+	#finishPlanApproval(pending: PendingPlanApproval): void {
+		if (this.#pendingPlanApproval === pending) this.#pendingPlanApproval = undefined;
+	}
+
+	#cancelledPlanApprovalResult(details: PlanApprovalDetails): AgentToolResult<PlanApprovalDetails> {
+		return {
+			content: [{ type: "text" as const, text: "Plan approval was cancelled." }],
+			details,
+		};
+	}
+
+	#runPlanApprovalResolve(input: unknown): Promise<AgentToolResult<ResolveToolDetails>> {
+		return runResolveInvocation(input as Parameters<typeof runResolveInvocation>[0], {
+			sourceToolName: "plan_approval",
+			label: "Plan ready for approval",
+			apply: async (_reason, extra) => {
+				const state = this.#host.getPlanModeState();
+				if (!state?.enabled) throw new ToolError("Plan mode is not active.");
+				const generation = this.#planGeneration;
+				const activePlanFilePath = state.planFilePath;
+				const { planFilePath, planContent, title } = await resolveApprovedPlan({
+					suppliedTitle: extra?.title,
+					statePlanFilePath: activePlanFilePath,
+					readPlan: path => this.#host.readPlan(path),
+					listPlanFiles: () => this.#host.listPlanFiles(),
+				});
+				const details: PlanApprovalDetails = { planFilePath, title, planExists: true };
+				const approval = this.#beginPlanApproval(generation, state, activePlanFilePath);
+				if (!approval) return this.#cancelledPlanApprovalResult(details);
+
+				try {
+					const approved = await this.#host.confirmPlan(
+						`Approve plan: ${title}`,
+						`Approve and execute the plan at ${planFilePath}?\n\n${planContent}`,
+						{ signal: approval.abortController.signal },
+					);
+					if (!this.#isCurrentPlanApproval(approval)) return this.#cancelledPlanApprovalResult(details);
+					if (!approved) {
+						return {
+							content: [
+								{
+									type: "text" as const,
+									text: "Plan refinement requested. Update the plan file, then request approval again when ready.",
+								},
+							],
+							details,
+						};
+					}
+					this.#host.setPlanReferencePath(planFilePath);
+					await this.#exitPlan({ paused: false });
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Plan approved at ${planFilePath}. Plan mode exited; proceed with the implementation.`,
+							},
+						],
+						details,
+					};
+				} finally {
+					this.#finishPlanApproval(approval);
+				}
+			},
+		});
+	}
+
+	async #createGoal(objective: string): Promise<void> {
+		this.#assertGoalCanEnter();
+		const previousTools = this.#host.getActiveToolNames();
+		await this.#host.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+		try {
+			await this.#host.goalRuntime.createGoal({ objective });
+			this.#goalPreviousTools = previousTools;
+		} catch (error) {
+			await this.#host.setActiveToolsByName(previousTools);
+			throw error;
+		}
+	}
+
+	async #resumeGoal(): Promise<void> {
+		this.#assertGoalCanEnter();
+		const previousTools = this.#host.getActiveToolNames();
+		await this.#host.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+		try {
+			await this.#host.goalRuntime.resumeGoal();
+			this.#goalPreviousTools = previousTools;
+			this.#goalSuppressNextContinuation = false;
+		} catch (error) {
+			await this.#host.setActiveToolsByName(previousTools);
+			throw error;
+		}
+	}
+
+	async #pauseGoal(): Promise<void> {
+		this.#cancelGoalContinuation();
+		await this.#host.goalRuntime.pauseGoal();
+		await this.#restoreGoalTools();
+	}
+
+	async #dropGoal(): Promise<void> {
+		this.#cancelGoalContinuation();
+		await this.#host.goalRuntime.dropGoal();
+		await this.#restoreGoalTools();
+		this.#goalContinuationTurnInFlight = false;
+		this.#goalSuppressNextContinuation = false;
+	}
+
+	async #restoreGoalTools(): Promise<void> {
+		const previousTools = this.#goalPreviousTools;
+		this.#goalPreviousTools = undefined;
+		if (previousTools !== undefined) await this.#host.setActiveToolsByName(previousTools);
+	}
+
+	async #handleGoalUpdated(event: Record<string, unknown>): Promise<void> {
+		const state = event.state as GoalModeState | undefined;
+		if (state?.goal?.status === "dropped") {
+			this.#cancelGoalContinuation();
+			await this.#restoreGoalTools();
+			this.#goalContinuationTurnInFlight = false;
+			this.#goalSuppressNextContinuation = false;
+			return;
+		}
+		if (!state?.enabled) {
+			this.#cancelGoalContinuation();
+			await this.#restoreGoalTools();
+		}
+	}
+
+	async #finishCompletedGoal(): Promise<void> {
+		this.#cancelGoalContinuation();
+		await this.#restoreGoalTools();
+		this.#host.setGoalModeState(undefined);
+		this.#host.appendModeChange("none");
+		this.#goalContinuationTurnInFlight = false;
+		this.#goalSuppressNextContinuation = false;
+	}
+
+	#isGoalContinuationConfigured(): boolean {
+		return this.#host.getGoalContinuationModes().includes("rpc");
+	}
+
+	#scheduleGoalContinuation(): void {
+		this.#cancelGoalContinuation();
+		if (!this.#isGoalContinuationConfigured() || this.#goalSuppressNextContinuation) return;
+		if (this.getMode().plan.status !== "off") return;
+		const state = this.#host.getGoalModeState();
+		if (!state?.enabled || state.goal.status !== "active") return;
+		const prompt = this.#host.goalRuntime.buildContinuationPrompt();
+		if (!prompt) return;
+		this.#goalContinuationTimer = setTimeout(() => {
+			this.#goalContinuationTimer = undefined;
+			if (!this.#isGoalContinuationConfigured() || this.#goalSuppressNextContinuation) return;
+			if (this.#host.isStreaming() || this.#host.isCompacting() || this.#host.hasPostPromptWork()) return;
+			if (this.getMode().plan.status !== "off") return;
+			const latest = this.#host.getGoalModeState();
+			if (!latest?.enabled || latest.goal.status !== "active") return;
+			this.#goalContinuationTurnInFlight = true;
+			this.#runBackground(
+				() => this.#host.submitGoalContinuation(prompt),
+				() => {
+					this.#goalContinuationTurnInFlight = false;
+				},
+			);
+		}, RPC_GOAL_CONTINUATION_DELAY_MS);
+	}
+
+	#cancelGoalContinuation(): void {
+		if (this.#goalContinuationTimer !== undefined) {
+			clearTimeout(this.#goalContinuationTimer);
+			this.#goalContinuationTimer = undefined;
+		}
+	}
+
+	#isUserMessageStart(value: unknown): boolean {
+		return isRecord(value) && value.role === "user" && value.synthetic !== true;
+	}
+
+	#submitDescription(description: string): void {
+		this.#runBackground(() => this.#host.submitPrompt(description, { expandPromptTemplates: false }));
+	}
+
+	#runBackground(start: () => void | Promise<unknown>, onError?: () => void): void {
+		try {
+			void Promise.resolve(start()).catch(error => {
+				onError?.();
+				this.#host.reportBackgroundError?.(error);
+			});
+		} catch (error) {
+			onError?.();
+			this.#host.reportBackgroundError?.(error);
+		}
+	}
+
+	async #reconcilePlan(mode: "plan" | "plan_paused", modeData: Record<string, unknown> | undefined): Promise<void> {
+		this.#host.goalRuntime.clearAccounting();
+		if (!this.#host.isPlanModeEnabled()) {
+			this.#host.appendModeChange("none");
+			return;
+		}
+		const planFilePath =
+			typeof modeData?.planFilePath === "string" && modeData.planFilePath.trim()
+				? modeData.planFilePath.trim()
+				: this.#planPath();
+		if (mode === "plan_paused") {
+			this.#plan = planModeStatus(planFilePath, false, true);
+			return;
+		}
+		await this.#enterPlan({ planFilePath, reentry: true, persist: false });
+	}
+
+	async #reconcileGoal(
+		mode: "goal" | "goal_paused",
+		modeData: Record<string, unknown> | undefined,
+		preserveActiveGoal: boolean,
+	): Promise<void> {
+		if (!this.#host.isGoalModeEnabled()) {
+			this.#host.goalRuntime.clearAccounting();
+			this.#host.appendModeChange("none");
+			return;
+		}
+		const goal = goalFromRpcPersistedModeData(modeData);
+		if (!goal) {
+			this.#host.goalRuntime.clearAccounting();
+			this.#host.appendModeChange("none");
+			return;
+		}
+		const restoredGoal =
+			mode === "goal_paused" && goal.status !== "paused" ? { ...goal, status: "paused" as const } : goal;
+		this.#host.setGoalModeState({
+			enabled: mode === "goal",
+			mode: "active",
+			goal: restoredGoal,
+		});
+		const restored = await this.#host.goalRuntime.onThreadResumed(
+			preserveActiveGoal ? { preserveActiveGoal: true } : undefined,
+		);
+		if (!restored || restored.goal.status === "complete" || restored.goal.status === "dropped") {
+			this.#host.setGoalModeState(undefined);
+			this.#host.goalRuntime.clearAccounting();
+			this.#host.appendModeChange("none");
+			return;
+		}
+		if (!restored.enabled) return;
+		const previousTools = this.#host.getActiveToolNames();
+		await this.#host.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+		this.#goalPreviousTools = previousTools;
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -21,6 +21,52 @@ import type {
 import type { TodoPhase } from "../../tools/todo";
 
 // ============================================================================
+// RPC Protocol Capabilities
+// ============================================================================
+
+export interface RpcProtocolInfo {
+	version: 2;
+	capabilities: { nativeModeControl: 1 };
+}
+
+/** Advertised in the ready frame once native plan/goal control is available. */
+export const RPC_NATIVE_MODE_PROTOCOL: RpcProtocolInfo = {
+	version: 2,
+	capabilities: { nativeModeControl: 1 },
+};
+
+export interface RpcReadyFrame {
+	type: "ready";
+	protocol: RpcProtocolInfo;
+}
+
+export type RpcNativeModeAction = "on" | "off" | "toggle";
+
+export type RpcPlanModeStatus = { status: "off" } | { status: "active" | "paused"; planFilePath?: string };
+
+export type RpcGoalModeStatus =
+	| { status: "off"; continuationEnabled: false }
+	| {
+			status: "active" | "paused";
+			objective?: string;
+			goalId?: string;
+			tokenBudget?: number;
+			tokensUsed?: number;
+			continuationEnabled: boolean;
+	  };
+
+/** Native mode snapshot shared by get_state and mode-mutation responses. */
+export interface RpcNativeModeState {
+	plan: RpcPlanModeStatus;
+	goal: RpcGoalModeStatus;
+}
+
+export interface RpcNativeModeResult {
+	mode: RpcNativeModeState;
+	agentInvoked: boolean;
+}
+
+// ============================================================================
 // RPC Commands (stdin)
 // ============================================================================
 
@@ -35,6 +81,8 @@ export type RpcCommand =
 
 	// State
 	| { id?: string; type: "get_state" }
+	| { id?: string; type: "set_plan_mode"; action: RpcNativeModeAction; description?: string }
+	| { id?: string; type: "set_goal_mode"; action: RpcNativeModeAction; description?: string }
 	| { id?: string; type: "get_available_commands" }
 	| { id?: string; type: "set_todos"; phases: TodoPhase[] }
 	| { id?: string; type: "set_host_tools"; tools: RpcHostToolDefinition[] }
@@ -110,6 +158,8 @@ export interface RpcSessionState {
 	dumpTools?: Array<{ name: string; description: string; parameters: unknown; examples?: readonly ToolExample[] }>;
 	/** Current context window usage. */
 	contextUsage?: ContextUsage;
+	/** Native plan and goal status. `status` is the only state discriminator. */
+	mode: RpcNativeModeState;
 }
 
 export interface RpcAvailableSlashCommand {
@@ -178,6 +228,8 @@ export type RpcResponse =
 
 	// State
 	| { id?: string; type: "response"; command: "get_state"; success: true; data: RpcSessionState }
+	| { id?: string; type: "response"; command: "set_plan_mode"; success: true; data: RpcNativeModeResult }
+	| { id?: string; type: "response"; command: "set_goal_mode"; success: true; data: RpcNativeModeResult }
 	| {
 			id?: string;
 			type: "response";

--- a/packages/coding-agent/src/tools/resolve-invocation.ts
+++ b/packages/coding-agent/src/tools/resolve-invocation.ts
@@ -1,0 +1,84 @@
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { ToolError } from "./tool-errors";
+
+/** The resolve tool's stable result payload, shared by queued and standing handlers. */
+export interface ResolveToolDetails {
+	action: "apply" | "discard";
+	reason: string;
+	extra?: Record<string, unknown>;
+	sourceToolName?: string;
+	label?: string;
+	sourceResultDetails?: unknown;
+}
+
+/** Runtime-safe structural form of the resolve tool input. */
+export interface ResolveInvocationParams {
+	action: "apply" | "discard";
+	reason: string;
+	extra?: Record<string, unknown>;
+}
+
+export interface ResolveInvocationOptions {
+	sourceToolName: string;
+	label: string;
+	apply(reason: string, extra?: Record<string, unknown>): Promise<AgentToolResult<unknown>>;
+	reject?(reason: string, extra?: Record<string, unknown>): Promise<AgentToolResult<unknown> | undefined>;
+	/** Invoked synchronously when `apply()` throws, before the error is rethrown. */
+	onApplyError?(error: unknown): void;
+}
+
+/**
+ * Shared invocation runner used by queued and standing resolve handlers. This
+ * module deliberately has no rendering or TUI dependency so headless mode
+ * controllers can use the real resolve protocol without loading the renderer.
+ */
+export async function runResolveInvocation(
+	params: ResolveInvocationParams,
+	options: ResolveInvocationOptions,
+): Promise<AgentToolResult<ResolveToolDetails>> {
+	const baseDetails: ResolveToolDetails = {
+		action: params.action,
+		reason: params.reason,
+		sourceToolName: options.sourceToolName,
+		label: options.label,
+		...(params.extra != null ? { extra: params.extra } : {}),
+	};
+	if (params.action === "apply") {
+		let result: AgentToolResult<unknown>;
+		try {
+			result = await options.apply(params.reason, params.extra);
+		} catch (error) {
+			try {
+				options.onApplyError?.(error);
+			} catch {
+				// Requeue hooks must not mask the original apply failure.
+			}
+			if (error instanceof ToolError) throw error;
+			const message = error instanceof Error ? error.message : String(error);
+			throw new ToolError(`Apply failed: ${message}`);
+		}
+		return {
+			...result,
+			details: {
+				...baseDetails,
+				...(result.details != null ? { sourceResultDetails: result.details } : {}),
+			},
+		};
+	}
+	if (params.action === "discard" && options.reject != null) {
+		const result = await options.reject(params.reason, params.extra);
+		if (result != null) {
+			return {
+				...result,
+				details: {
+					...baseDetails,
+					...(result.details != null ? { sourceResultDetails: result.details } : {}),
+				},
+			};
+		}
+	}
+	return {
+		content: [{ type: "text" as const, text: `Discarded: ${options.label}. Reason: ${params.reason}` }],
+		details: baseDetails,
+	};
+}

--- a/packages/coding-agent/src/tools/resolve.ts
+++ b/packages/coding-agent/src/tools/resolve.ts
@@ -15,6 +15,10 @@ import resolveDescription from "../prompts/tools/resolve.md" with { type: "text"
 import { Ellipsis, padToWidth, renderStatusLine, truncateToWidth } from "../tui";
 import type { ToolSession } from ".";
 import { replaceTabs } from "./render-utils";
+import { type ResolveToolDetails, runResolveInvocation } from "./resolve-invocation";
+
+export { type ResolveToolDetails, runResolveInvocation } from "./resolve-invocation";
+
 import { ToolError } from "./tool-errors";
 
 const resolveSchema = type({
@@ -24,15 +28,6 @@ const resolveSchema = type({
 });
 
 type ResolveParams = typeof resolveSchema.infer;
-
-export interface ResolveToolDetails {
-	action: "apply" | "discard";
-	reason: string;
-	extra?: Record<string, unknown>;
-	sourceToolName?: string;
-	label?: string;
-	sourceResultDetails?: unknown;
-}
 
 /** Monotonic suffix making each staged preview's pending-invoker id UNIQUE, so
  *  stacked previews never clobber one another by label. */
@@ -109,74 +104,6 @@ export function buildResolveReminderMessage(sourceToolName: string): CustomMessa
 		details: { toolName: sourceToolName },
 		attribution: "agent",
 		timestamp: Date.now(),
-	};
-}
-
-/**
- * Shared invocation runner used by both queued (in-flight) handlers and
- * standing handlers (e.g. plan-mode approval). Discriminates on action,
- * routes through the caller's apply/reject, and wraps the resulting tool
- * payload with `ResolveToolDetails` so the renderer and event-controller
- * see a consistent shape.
- */
-export async function runResolveInvocation(
-	params: ResolveParams,
-	options: {
-		sourceToolName: string;
-		label: string;
-		apply(reason: string, extra?: Record<string, unknown>): Promise<AgentToolResult<unknown>>;
-		reject?(reason: string, extra?: Record<string, unknown>): Promise<AgentToolResult<unknown> | undefined>;
-		/** Invoked synchronously when `apply()` throws, before the error is rethrown.
-		 *  The queued caller uses this to re-push the resolve directive so the
-		 *  pending preview survives a failed apply (e.g. overlapping ast_edit
-		 *  replacements) and the model can `discard` or fix-and-retry. */
-		onApplyError?(error: unknown): void;
-	},
-): Promise<AgentToolResult<ResolveToolDetails>> {
-	const baseDetails: ResolveToolDetails = {
-		action: params.action,
-		reason: params.reason,
-		sourceToolName: options.sourceToolName,
-		label: options.label,
-		...(params.extra != null ? { extra: params.extra } : {}),
-	};
-	if (params.action === "apply") {
-		let result: AgentToolResult<unknown>;
-		try {
-			result = await options.apply(params.reason, params.extra);
-		} catch (error) {
-			try {
-				options.onApplyError?.(error);
-			} catch {
-				// Requeue hook must not mask the original apply failure.
-			}
-			if (error instanceof ToolError) throw error;
-			const message = error instanceof Error ? error.message : String(error);
-			throw new ToolError(`Apply failed: ${message}`);
-		}
-		return {
-			...result,
-			details: {
-				...baseDetails,
-				...(result.details != null ? { sourceResultDetails: result.details } : {}),
-			},
-		};
-	}
-	if (params.action === "discard" && options.reject != null) {
-		const result = await options.reject(params.reason, params.extra);
-		if (result != null) {
-			return {
-				...result,
-				details: {
-					...baseDetails,
-					...(result.details != null ? { sourceResultDetails: result.details } : {}),
-				},
-			};
-		}
-	}
-	return {
-		content: [{ type: "text" as const, text: `Discarded: ${options.label}. Reason: ${params.reason}` }],
-		details: baseDetails,
 	};
 }
 

--- a/packages/coding-agent/test/rpc-native-modes.test.ts
+++ b/packages/coding-agent/test/rpc-native-modes.test.ts
@@ -1,0 +1,869 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai";
+import type { Goal, GoalModeState } from "@oh-my-pi/pi-coding-agent/goals/state";
+import {
+	DEFAULT_RPC_PLAN_FILE_PATH,
+	RPC_GOAL_CONTINUATION_DELAY_MS,
+	type RpcGoalRuntime,
+	RpcNativeModeController,
+	type RpcNativeModeHost,
+	type RpcPersistedMode,
+	type RpcPersistedNativeMode,
+	type RpcPlanResolveHandler,
+	type RpcPlanRoleModel,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-native-mode-controller";
+import {
+	RPC_NATIVE_MODE_PROTOCOL,
+	type RpcNativeModeState,
+	type RpcReadyFrame,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
+import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
+import type { ConfiguredThinkingLevel } from "@oh-my-pi/pi-coding-agent/thinking";
+
+interface ModelState {
+	model: Model;
+	thinkingLevel?: ConfiguredThinkingLevel;
+}
+
+interface NativeModeHostOptions {
+	planModeEnabled?: boolean;
+	goalModeEnabled?: boolean;
+	continuationModes?: readonly string[];
+	activeTools?: string[];
+	builtInTools?: string[];
+	modelState?: ModelState;
+	planRoleModel?: RpcPlanRoleModel;
+	persisted?: RpcPersistedMode;
+}
+
+interface GoalTransitionHost {
+	getGoalModeState(): GoalModeState | undefined;
+	setGoalModeState(state: GoalModeState | undefined): void;
+	appendModeChange(mode: RpcPersistedNativeMode, data?: Record<string, unknown>): void;
+}
+
+/** A deterministic implementation of the controller's production GoalRuntime boundary. */
+class TransitionGoalRuntime implements RpcGoalRuntime {
+	#nextGoalId = 1;
+	readonly calls: string[] = [];
+	readonly #host: GoalTransitionHost;
+
+	constructor(host: GoalTransitionHost) {
+		this.#host = host;
+	}
+
+	clearAccounting(): void {
+		this.calls.push("clearAccounting");
+	}
+
+	async onThreadResumed(options?: { preserveActiveGoal?: boolean }): Promise<GoalModeState | undefined> {
+		this.calls.push("threadResumed");
+		const state = this.#host.getGoalModeState();
+		if (!state || (options?.preserveActiveGoal && state.enabled && state.goal.status === "active")) return state;
+		if (state.goal.status !== "active") return state;
+		return await this.pauseGoal();
+	}
+
+	async createGoal(input: { objective: string; tokenBudget?: number }): Promise<GoalModeState> {
+		this.calls.push("create");
+		const existing = this.#host.getGoalModeState();
+		if (existing?.goal && existing.goal.status !== "complete" && existing.goal.status !== "dropped") {
+			throw new Error("cannot create a new goal because this session already has a goal");
+		}
+		const id = this.#nextGoalId++;
+		const state: GoalModeState = {
+			enabled: true,
+			mode: "active",
+			goal: {
+				id: `goal-${id}`,
+				objective: input.objective,
+				status: "active",
+				...(input.tokenBudget === undefined ? {} : { tokenBudget: input.tokenBudget }),
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				createdAt: id,
+				updatedAt: id,
+			},
+		};
+		this.#host.setGoalModeState(state);
+		this.#host.appendModeChange("goal", { goal: { ...state.goal } });
+		return state;
+	}
+
+	async resumeGoal(): Promise<GoalModeState> {
+		this.calls.push("resume");
+		const state = this.#host.getGoalModeState();
+		if (!state) throw new Error("No paused goal.");
+		const resumed: GoalModeState = {
+			...state,
+			enabled: true,
+			mode: "active",
+			reason: undefined,
+			goal: { ...state.goal, status: "active", updatedAt: state.goal.updatedAt + 1 },
+		};
+		this.#host.setGoalModeState(resumed);
+		this.#host.appendModeChange("goal", { goal: { ...resumed.goal } });
+		return resumed;
+	}
+
+	async pauseGoal(): Promise<GoalModeState | undefined> {
+		this.calls.push("pause");
+		const state = this.#host.getGoalModeState();
+		if (!state) return undefined;
+		const status =
+			state.goal.status === "active" || state.goal.status === "budget-limited" ? "paused" : state.goal.status;
+		const paused: GoalModeState = {
+			...state,
+			enabled: false,
+			mode: "active",
+			reason: undefined,
+			goal: { ...state.goal, status, updatedAt: state.goal.updatedAt + 1 },
+		};
+		this.#host.setGoalModeState(paused);
+		this.#host.appendModeChange("goal_paused", { goal: { ...paused.goal } });
+		return paused;
+	}
+
+	async dropGoal(): Promise<Goal | undefined> {
+		this.calls.push("drop");
+		const state = this.#host.getGoalModeState();
+		if (!state) return undefined;
+		const dropped: Goal = { ...state.goal, status: "dropped", updatedAt: state.goal.updatedAt + 1 };
+		this.#host.setGoalModeState(undefined);
+		this.#host.appendModeChange("none");
+		return dropped;
+	}
+
+	buildContinuationPrompt(): string | undefined {
+		const state = this.#host.getGoalModeState();
+		return state?.enabled && state.goal.status === "active" ? `Continue goal: ${state.goal.objective}` : undefined;
+	}
+}
+
+class NativeModeHost implements RpcNativeModeHost {
+	streaming = false;
+	compacting = false;
+	postPromptWork = false;
+	planModeEnabled: boolean;
+	goalModeEnabled: boolean;
+	continuationModes: readonly string[];
+	activeTools: string[];
+	readonly builtInTools: Set<string>;
+	planState: PlanModeState | undefined;
+	planReferencePath = "";
+	goalState: GoalModeState | undefined;
+	persisted: RpcPersistedMode;
+	resolveHandler: RpcPlanResolveHandler | null = null;
+	modelState: ModelState | undefined;
+	temporaryModelFailure: Error | undefined;
+	planRoleModel: RpcPlanRoleModel;
+	readonly planFiles = new Map<string, string>();
+	readonly confirmations: boolean[] = [];
+	readonly confirmCalls: Array<{ title: string; message: string }> = [];
+	readonly prompts: string[] = [];
+	readonly promptOptions: Array<{ expandPromptTemplates: false } | undefined> = [];
+	confirmationResult: Promise<boolean> | undefined;
+	readonly confirmationSignals: AbortSignal[] = [];
+	readonly cancelledConfirmations: AbortSignal[] = [];
+	readonly promptSnapshots: Array<{ planActive: boolean; goalActive: boolean }> = [];
+	readonly continuations: string[] = [];
+	readonly backgroundErrors: unknown[] = [];
+	readonly modeChanges: Array<{ mode: RpcPersistedNativeMode; data?: Record<string, unknown> }> = [];
+	readonly activeToolSnapshots: string[][] = [];
+	promptResult: void | Promise<unknown> = undefined;
+	readonly goalRuntime: TransitionGoalRuntime;
+
+	constructor(options: NativeModeHostOptions = {}) {
+		this.planModeEnabled = options.planModeEnabled ?? true;
+		this.goalModeEnabled = options.goalModeEnabled ?? true;
+		this.continuationModes = options.continuationModes ?? [];
+		this.activeTools = [...(options.activeTools ?? ["read"])];
+		this.builtInTools = new Set(options.builtInTools ?? ["write", "resolve", "goal"]);
+		this.persisted = options.persisted ?? { mode: "none" };
+		this.modelState = options.modelState ? { ...options.modelState } : undefined;
+		this.planRoleModel = options.planRoleModel ?? { model: undefined, explicitThinkingLevel: false };
+		this.goalRuntime = new TransitionGoalRuntime(this);
+	}
+
+	isStreaming(): boolean {
+		return this.streaming;
+	}
+
+	isCompacting(): boolean {
+		return this.compacting;
+	}
+
+	hasPostPromptWork(): boolean {
+		return this.postPromptWork;
+	}
+
+	isPlanModeEnabled(): boolean {
+		return this.planModeEnabled;
+	}
+
+	isGoalModeEnabled(): boolean {
+		return this.goalModeEnabled;
+	}
+
+	getGoalContinuationModes(): readonly string[] {
+		return this.continuationModes;
+	}
+
+	getActiveToolNames(): string[] {
+		return [...this.activeTools];
+	}
+
+	hasBuiltInTool(name: string): boolean {
+		return this.builtInTools.has(name);
+	}
+
+	async setActiveToolsByName(names: string[]): Promise<void> {
+		this.activeTools = [...names];
+		this.activeToolSnapshots.push([...names]);
+	}
+
+	captureModelState(): ModelState | undefined {
+		return this.modelState ? { ...this.modelState } : undefined;
+	}
+
+	resolvePlanRoleModel(): RpcPlanRoleModel {
+		return { ...this.planRoleModel };
+	}
+
+	async applyTemporaryModel(model: Model, thinkingLevel?: ConfiguredThinkingLevel): Promise<void> {
+		const failure = this.temporaryModelFailure;
+		this.temporaryModelFailure = undefined;
+		this.modelState = { model, thinkingLevel };
+		if (failure) throw failure;
+	}
+
+	setThinkingLevel(thinkingLevel?: ConfiguredThinkingLevel): void {
+		if (!this.modelState) return;
+		this.modelState = { ...this.modelState, thinkingLevel };
+	}
+
+	getPlanModeState(): PlanModeState | undefined {
+		return this.planState;
+	}
+
+	setPlanModeState(state: PlanModeState | undefined): void {
+		this.planState = state ? { ...state } : undefined;
+	}
+
+	getPlanReferencePath(): string {
+		return this.planReferencePath;
+	}
+
+	setPlanReferencePath(path: string): void {
+		this.planReferencePath = path;
+	}
+
+	setStandingResolveHandler(handler: RpcPlanResolveHandler | null): void {
+		this.resolveHandler = handler;
+	}
+
+	getGoalModeState(): GoalModeState | undefined {
+		return this.goalState;
+	}
+
+	setGoalModeState(state: GoalModeState | undefined): void {
+		this.goalState = state;
+	}
+
+	getPersistedMode(): RpcPersistedMode {
+		return this.persisted;
+	}
+
+	appendModeChange(mode: RpcPersistedNativeMode, data?: Record<string, unknown>): void {
+		const entry = data ? { mode, data: { ...data } } : { mode };
+		this.modeChanges.push(entry);
+		this.persisted = { mode, ...(data ? { modeData: { ...data } } : {}) };
+	}
+
+	async readPlan(path: string): Promise<string | null> {
+		return this.planFiles.get(path) ?? null;
+	}
+
+	async listPlanFiles(): Promise<string[]> {
+		return [...this.planFiles.keys()];
+	}
+
+	async confirmPlan(title: string, message: string, options?: { signal?: AbortSignal }): Promise<boolean> {
+		this.confirmCalls.push({ title, message });
+		const signal = options?.signal;
+		if (signal) {
+			this.confirmationSignals.push(signal);
+			if (signal.aborted) this.cancelledConfirmations.push(signal);
+			else signal.addEventListener("abort", () => this.cancelledConfirmations.push(signal), { once: true });
+		}
+		return this.confirmationResult ?? this.confirmations.shift() ?? false;
+	}
+
+	submitPrompt(description: string, options?: { expandPromptTemplates: false }): void | Promise<unknown> {
+		this.prompts.push(description);
+		this.promptOptions.push(options);
+		this.promptSnapshots.push({
+			planActive: this.planState?.enabled === true,
+			goalActive: this.goalState?.enabled === true,
+		});
+		return this.promptResult;
+	}
+
+	submitGoalContinuation(prompt: string): void | Promise<unknown> {
+		this.continuations.push(prompt);
+	}
+
+	reportBackgroundError(error: unknown): void {
+		this.backgroundErrors.push(error);
+	}
+}
+
+function createHarness(options?: NativeModeHostOptions): {
+	host: NativeModeHost;
+	controller: RpcNativeModeController;
+} {
+	const host = new NativeModeHost(options);
+	return { host, controller: new RpcNativeModeController(host) };
+}
+
+function persistedGoal(overrides: Partial<Goal> = {}): Goal {
+	return {
+		id: "goal-1",
+		objective: "Ship the release",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 1,
+		updatedAt: 1,
+		...overrides,
+	};
+}
+
+async function scheduleActiveGoalContinuation(controller: RpcNativeModeController): Promise<void> {
+	await controller.handleSessionEvent({ type: "agent_end" });
+}
+
+const executionModel = { provider: "test", id: "execution" } as Model;
+const planModel = { provider: "test", id: "plan" } as Model;
+const executionThinking = "low" as ConfiguredThinkingLevel;
+const planThinking = "high" as ConfiguredThinkingLevel;
+
+function createPlanRoleHarness(): { host: NativeModeHost; controller: RpcNativeModeController } {
+	return createHarness({
+		modelState: { model: executionModel, thinkingLevel: executionThinking },
+		planRoleModel: { model: planModel, thinkingLevel: planThinking, explicitThinkingLevel: true },
+	});
+}
+
+function expectModelState(host: NativeModeHost, state: ModelState): void {
+	expect(host.modelState?.model).toBe(state.model);
+	expect(host.modelState?.thinkingLevel).toBe(state.thinkingLevel);
+}
+async function flushMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("RPC native mode controller", () => {
+	it("advertises the exact v2 native mode capability in ready frames", () => {
+		const ready: RpcReadyFrame = { type: "ready", protocol: RPC_NATIVE_MODE_PROTOCOL };
+
+		expect(ready).toEqual({
+			type: "ready",
+			protocol: { version: 2, capabilities: { nativeModeControl: 1 } },
+		});
+	});
+
+	it("reports an honest discriminated off-mode state before any transition", () => {
+		const { controller } = createHarness({ continuationModes: ["rpc"] });
+		const mode: RpcNativeModeState = controller.getMode();
+
+		expect(mode).toEqual({
+			plan: { status: "off" },
+			goal: { status: "off", continuationEnabled: false },
+		});
+	});
+
+	it("rejects native mutations when their settings are disabled", async () => {
+		const { host, controller } = createHarness();
+		host.planModeEnabled = false;
+
+		await expect(controller.setPlanMode({ action: "on", description: "Draft a plan" })).rejects.toThrow(
+			"Plan mode is disabled by settings.",
+		);
+
+		host.goalModeEnabled = false;
+		await expect(controller.setGoalMode({ action: "on", description: "Ship a release" })).rejects.toThrow(
+			"Goal mode is disabled by settings.",
+		);
+		expect(host.activeTools).toEqual(["read"]);
+		expect(host.prompts).toEqual([]);
+	});
+
+	it("requires a real description to activate an inactive native mode", async () => {
+		const { controller } = createHarness();
+
+		await expect(controller.setPlanMode({ action: "on", description: " \t " })).rejects.toThrow(
+			"A description is required to enable plan mode.",
+		);
+		await expect(controller.setGoalMode({ action: "toggle" })).rejects.toThrow(
+			"An objective is required to enable goal mode.",
+		);
+	});
+
+	it("changes plan mode before submitting a trimmed normal prompt without waiting for its turn", async () => {
+		const { promise, resolve } = Promise.withResolvers<void>();
+		const { host, controller } = createHarness();
+		host.promptResult = promise;
+
+		const result = await controller.setPlanMode({ action: "on", description: "  Design the rollout  " });
+
+		expect(result).toMatchObject({
+			agentInvoked: true,
+			mode: { plan: { status: "active", planFilePath: DEFAULT_RPC_PLAN_FILE_PATH } },
+		});
+		expect(host.prompts).toEqual(["Design the rollout"]);
+		expect(host.promptSnapshots).toEqual([{ planActive: true, goalActive: false }]);
+		expect(host.prompts[0]).not.toMatch(/^\//);
+		resolve();
+	});
+
+	it("augments and restores tools across plan on, toggle pause, toggle off, and explicit off", async () => {
+		const { host, controller } = createHarness({ activeTools: ["read", "todo"] });
+
+		await controller.setPlanMode({ action: "on", description: "Draft the migration plan" });
+		expect(controller.getMode().plan).toEqual({ status: "active", planFilePath: DEFAULT_RPC_PLAN_FILE_PATH });
+		expect(host.activeTools).toEqual(["read", "todo", "resolve", "write"]);
+
+		await controller.setPlanMode({ action: "toggle" });
+		expect(controller.getMode().plan).toEqual({ status: "paused", planFilePath: DEFAULT_RPC_PLAN_FILE_PATH });
+		expect(host.activeTools).toEqual(["read", "todo"]);
+		expect(host.modeChanges.at(-1)).toEqual({
+			mode: "plan_paused",
+			data: { planFilePath: DEFAULT_RPC_PLAN_FILE_PATH },
+		});
+
+		await expect(controller.setPlanMode({ action: "on" })).rejects.toThrow(
+			"A description is required to enable plan mode.",
+		);
+
+		await controller.setPlanMode({ action: "toggle" });
+		expect(controller.getMode().plan).toEqual({ status: "off" });
+		expect(host.modeChanges.at(-1)).toEqual({ mode: "none" });
+
+		await controller.setPlanMode({ action: "on", description: "Draft the recovery plan" });
+		expect(host.activeTools).toEqual(["read", "todo", "resolve", "write"]);
+		await controller.setPlanMode({ action: "off" });
+		expect(controller.getMode().plan).toEqual({ status: "off" });
+		expect(host.activeTools).toEqual(["read", "todo"]);
+		expect(host.modeChanges.map(change => change.mode)).toEqual(["plan", "plan_paused", "none", "plan", "none"]);
+	});
+
+	it("keeps plan and goal modes mutually exclusive", async () => {
+		const { controller } = createHarness();
+
+		await controller.setPlanMode({ action: "on", description: "Plan the release" });
+		await expect(controller.setGoalMode({ action: "on", description: "Ship the release" })).rejects.toThrow(
+			"Cannot enable goal mode while plan mode is active or paused.",
+		);
+
+		await controller.setPlanMode({ action: "off" });
+		await controller.setGoalMode({ action: "on", description: "Ship the release" });
+		await expect(controller.setPlanMode({ action: "on", description: "Plan the release" })).rejects.toThrow(
+			"Cannot enable plan mode while goal mode is active or paused.",
+		);
+	});
+
+	it("rehydrates paused modes and persists their explicit off transitions", async () => {
+		const pausedPlan = createHarness({
+			persisted: { mode: "plan_paused", modeData: { planFilePath: "local://paused-plan.md" } },
+		});
+
+		await pausedPlan.controller.reconcile();
+		expect(pausedPlan.controller.getMode().plan).toEqual({
+			status: "paused",
+			planFilePath: "local://paused-plan.md",
+		});
+		expect(pausedPlan.host.activeTools).toEqual(["read"]);
+		await pausedPlan.controller.setPlanMode({ action: "off" });
+		expect(pausedPlan.controller.getMode().plan).toEqual({ status: "off" });
+		expect(pausedPlan.host.modeChanges.at(-1)).toEqual({ mode: "none" });
+
+		const pausedGoal = createHarness({
+			persisted: { mode: "goal", modeData: { goal: persistedGoal() } },
+		});
+		await pausedGoal.controller.reconcile();
+		expect(pausedGoal.controller.getMode().goal).toMatchObject({
+			status: "paused",
+			objective: "Ship the release",
+			continuationEnabled: false,
+		});
+		expect(pausedGoal.host.modeChanges.at(-1)?.mode).toBe("goal_paused");
+
+		const resumed = await pausedGoal.controller.setGoalMode({ action: "on" });
+		expect(resumed.agentInvoked).toBe(false);
+		expect(resumed.mode.goal).toMatchObject({ status: "active", objective: "Ship the release" });
+		expect(pausedGoal.host.activeTools).toEqual(["read", "goal"]);
+	});
+
+	it("preserves an active persisted goal through reconcileAfterSessionChange without overwriting it as paused", async () => {
+		vi.useFakeTimers();
+		const goal = persistedGoal();
+		const { host, controller } = createHarness({
+			continuationModes: ["rpc"],
+			persisted: { mode: "goal", modeData: { goal } },
+		});
+
+		const mode = await controller.reconcileAfterSessionChange();
+
+		expect(mode.goal).toMatchObject({
+			status: "active",
+			objective: "Ship the release",
+			continuationEnabled: true,
+		});
+		expect(host.goalState).toMatchObject({ enabled: true, goal: { status: "active" } });
+		expect(host.activeTools).toEqual(["read", "goal"]);
+		expect(host.modeChanges).toEqual([]);
+		expect(host.persisted).toEqual({ mode: "goal", modeData: { goal } });
+
+		await scheduleActiveGoalContinuation(controller);
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(host.continuations).toEqual(["Continue goal: Ship the release"]);
+	});
+
+	it("keeps a real plan active on denial or timeout and exits only after affirmative approval", async () => {
+		const { host, controller } = createHarness();
+		await controller.setPlanMode({ action: "on", description: "Draft the migration" });
+		const handler = host.resolveHandler;
+		if (!handler) throw new Error("Expected plan mode to install a standing resolve handler");
+
+		await expect(handler({ action: "apply", reason: "Plan is ready", extra: { title: "my-plan" } })).rejects.toThrow(
+			"Plan file not found",
+		);
+
+		host.planFiles.set("local://my-plan.md", "# Migration\n\n1. Migrate safely.\n");
+		host.confirmations.push(false, false, true);
+		const denied = await handler({ action: "apply", reason: "Plan is ready", extra: { title: "my-plan" } });
+		expect(denied.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("Plan refinement requested"),
+		});
+		expect(controller.getMode().plan).toMatchObject({ status: "active" });
+		expect(host.resolveHandler).toBe(handler);
+		expect(host.activeTools).toEqual(["read", "resolve", "write"]);
+
+		const timedOut = await handler({ action: "apply", reason: "Plan is ready", extra: { title: "my-plan" } });
+		expect(timedOut.content[0]).toMatchObject({
+			type: "text",
+			text: expect.stringContaining("Plan refinement requested"),
+		});
+		expect(controller.getMode().plan).toMatchObject({ status: "active" });
+
+		const approved = await handler({ action: "apply", reason: "Plan is ready", extra: { title: "my-plan" } });
+		expect(approved.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("Plan approved") });
+		expect(host.confirmCalls).toHaveLength(3);
+		expect(host.confirmCalls[0]).toMatchObject({
+			title: "Approve plan: my-plan",
+			message: expect.stringContaining("local://my-plan.md"),
+		});
+		expect(host.planReferencePath).toBe("local://my-plan.md");
+		expect(controller.getMode().plan).toEqual({ status: "off" });
+		expect(host.resolveHandler).toBeNull();
+		expect(host.activeTools).toEqual(["read"]);
+		expect(host.modeChanges.at(-1)).toEqual({ mode: "none" });
+	});
+
+	it("cancels a pending approval when a new session generation replaces its plan", async () => {
+		const pendingConfirmation = Promise.withResolvers<boolean>();
+		const { host, controller } = createHarness();
+		host.confirmationResult = pendingConfirmation.promise;
+
+		await controller.setPlanMode({ action: "on", description: "Draft the outgoing plan" });
+		host.planFiles.set(DEFAULT_RPC_PLAN_FILE_PATH, "# Outgoing plan\n");
+		const staleHandler = host.resolveHandler;
+		if (!staleHandler) throw new Error("Expected an outgoing plan approval handler");
+		const staleApproval = staleHandler({
+			action: "apply",
+			reason: "Plan is ready",
+			extra: { title: "PLAN" },
+		});
+		await flushMicrotasks();
+		expect(host.confirmationSignals).toHaveLength(1);
+
+		await controller.prepareForSessionChange();
+		host.planReferencePath = "local://new-session-plan.md";
+		await controller.setPlanMode({ action: "on", description: "Draft the incoming plan" });
+		const newSessionHandler = host.resolveHandler;
+		if (!newSessionHandler) throw new Error("Expected an incoming plan approval handler");
+		expect(host.confirmationSignals[0]?.aborted).toBe(true);
+
+		pendingConfirmation.resolve(true);
+		await staleApproval.catch(() => undefined);
+
+		expect(host.cancelledConfirmations).toEqual([host.confirmationSignals[0]]);
+		expect(host.planReferencePath).toBe("local://new-session-plan.md");
+		expect(controller.getMode().plan).toEqual({ status: "active", planFilePath: "local://new-session-plan.md" });
+		expect(host.resolveHandler).toBe(newSessionHandler);
+	});
+
+	it("submits a slash-prefixed plan description as literal prompt content", async () => {
+		const { host, controller } = createHarness();
+
+		await controller.setPlanMode({ action: "on", description: "/drop keep this plan request literal" });
+
+		expect(host.prompts).toEqual(["/drop keep this plan request literal"]);
+		expect(host.promptOptions).toEqual([{ expandPromptTemplates: false }]);
+	});
+
+	it("applies the configured plan model and explicit thinking on entry", async () => {
+		const { host, controller } = createPlanRoleHarness();
+
+		await controller.setPlanMode({ action: "on", description: "Draft the model-aware plan" });
+
+		expectModelState(host, { model: planModel, thinkingLevel: planThinking });
+	});
+
+	it("rolls back a rejected plan-role model activation so a retry can enter cleanly", async () => {
+		const { host, controller } = createPlanRoleHarness();
+		host.temporaryModelFailure = new Error("plan model is unavailable");
+
+		await expect(controller.setPlanMode({ action: "on", description: "Draft the failed plan" })).rejects.toThrow(
+			"plan model is unavailable",
+		);
+
+		expect(controller.getMode().plan).toEqual({ status: "off" });
+		expect(host.getPlanModeState()).toBeUndefined();
+		expect(host.activeTools).toEqual(["read"]);
+		expectModelState(host, { model: executionModel, thinkingLevel: executionThinking });
+		expect(host.resolveHandler).toBeNull();
+		expect(host.modeChanges).toEqual([]);
+
+		const retry = await controller.setPlanMode({ action: "on", description: "Draft the recovered plan" });
+		expect(retry).toMatchObject({
+			agentInvoked: true,
+			mode: { plan: { status: "active", planFilePath: DEFAULT_RPC_PLAN_FILE_PATH } },
+		});
+		expect(host.getPlanModeState()).toMatchObject({ enabled: true, planFilePath: DEFAULT_RPC_PLAN_FILE_PATH });
+		expect(host.activeTools).toEqual(["read", "resolve", "write"]);
+		expectModelState(host, { model: planModel, thinkingLevel: planThinking });
+		expect(host.resolveHandler).not.toBeNull();
+	});
+
+	it("restores the exact pre-plan model and thinking when plan mode pauses", async () => {
+		const { host, controller } = createPlanRoleHarness();
+		await controller.setPlanMode({ action: "on", description: "Draft the paused plan" });
+		expectModelState(host, { model: planModel, thinkingLevel: planThinking });
+
+		await controller.setPlanMode({ action: "toggle" });
+
+		expectModelState(host, { model: executionModel, thinkingLevel: executionThinking });
+	});
+
+	it("restores the exact pre-plan model and thinking when plan mode is turned off", async () => {
+		const { host, controller } = createPlanRoleHarness();
+		await controller.setPlanMode({ action: "on", description: "Draft the disposable plan" });
+		expectModelState(host, { model: planModel, thinkingLevel: planThinking });
+
+		await controller.setPlanMode({ action: "off" });
+
+		expectModelState(host, { model: executionModel, thinkingLevel: executionThinking });
+	});
+
+	it("keeps the plan model after denial and restores it after approval", async () => {
+		const denied = createPlanRoleHarness();
+		await denied.controller.setPlanMode({ action: "on", description: "Draft the review plan" });
+		expectModelState(denied.host, { model: planModel, thinkingLevel: planThinking });
+		denied.host.planFiles.set(DEFAULT_RPC_PLAN_FILE_PATH, "# Review plan\n");
+		const deniedHandler = denied.host.resolveHandler;
+		if (!deniedHandler) throw new Error("Expected a plan approval handler");
+		denied.host.confirmations.push(false);
+
+		await deniedHandler({ action: "apply", reason: "Plan is ready", extra: { title: "PLAN" } });
+
+		expectModelState(denied.host, { model: planModel, thinkingLevel: planThinking });
+		expect(denied.controller.getMode().plan).toMatchObject({ status: "active" });
+
+		const approved = createPlanRoleHarness();
+		await approved.controller.setPlanMode({ action: "on", description: "Draft the approved plan" });
+		expectModelState(approved.host, { model: planModel, thinkingLevel: planThinking });
+		approved.host.planFiles.set(DEFAULT_RPC_PLAN_FILE_PATH, "# Approved plan\n");
+		const approvedHandler = approved.host.resolveHandler;
+		if (!approvedHandler) throw new Error("Expected a plan approval handler");
+		approved.host.confirmations.push(true);
+
+		await approvedHandler({ action: "apply", reason: "Plan is ready", extra: { title: "PLAN" } });
+
+		expectModelState(approved.host, { model: executionModel, thinkingLevel: executionThinking });
+	});
+
+	it("restores the exact pre-plan model and thinking during session preparation", async () => {
+		const { host, controller } = createPlanRoleHarness();
+		await controller.setPlanMode({ action: "on", description: "Draft the switching plan" });
+		expectModelState(host, { model: planModel, thinkingLevel: planThinking });
+
+		await controller.prepareForSessionChange();
+
+		expectModelState(host, { model: executionModel, thinkingLevel: executionThinking });
+	});
+	it("routes goal create, pause, resume, and drop through the GoalRuntime transition contract", async () => {
+		const { host, controller } = createHarness();
+
+		const created = await controller.setGoalMode({ action: "on", description: "  Ship the release  " });
+		expect(created).toMatchObject({
+			agentInvoked: true,
+			mode: {
+				goal: {
+					status: "active",
+					objective: "Ship the release",
+					continuationEnabled: false,
+				},
+			},
+		});
+		expect(host.goalState?.enabled).toBe(true);
+		expect(host.goalState?.goal.status).toBe("active");
+		expect(host.activeTools).toEqual(["read", "goal"]);
+		expect(host.modeChanges.at(-1)?.mode).toBe("goal");
+		expect(host.prompts).toEqual(["Ship the release"]);
+		expect(host.prompts[0]).not.toMatch(/^\//);
+
+		await controller.setGoalMode({ action: "toggle" });
+		expect(controller.getMode().goal).toMatchObject({ status: "paused", objective: "Ship the release" });
+		expect(host.goalState?.enabled).toBe(false);
+		expect(host.goalState?.goal.status).toBe("paused");
+		expect(host.activeTools).toEqual(["read"]);
+		expect(host.modeChanges.at(-1)?.mode).toBe("goal_paused");
+
+		await expect(controller.setGoalMode({ action: "on", description: "Replace it" })).rejects.toThrow(
+			"A paused goal can only be resumed without a replacement objective.",
+		);
+		const resumed = await controller.setGoalMode({ action: "on" });
+		expect(resumed.agentInvoked).toBe(false);
+		expect(host.goalState?.enabled).toBe(true);
+		expect(host.goalState?.goal.status).toBe("active");
+		expect(host.activeTools).toEqual(["read", "goal"]);
+		expect(host.modeChanges.at(-1)?.mode).toBe("goal");
+
+		await controller.setGoalMode({ action: "off" });
+		expect(controller.getMode().goal).toEqual({ status: "off", continuationEnabled: false });
+		expect(host.goalState).toBeUndefined();
+		expect(host.activeTools).toEqual(["read"]);
+		expect(host.modeChanges.at(-1)?.mode).toBe("none");
+		expect(host.goalRuntime.calls).toEqual(["create", "pause", "resume", "drop"]);
+	});
+
+	it("rejects both native mode mutations while a response is streaming", async () => {
+		const { host, controller } = createHarness();
+		host.streaming = true;
+
+		await expect(controller.setPlanMode({ action: "on", description: "Draft the plan" })).rejects.toThrow(
+			"Cannot change plan mode while a response is in progress.",
+		);
+		await expect(controller.setGoalMode({ action: "on", description: "Ship the release" })).rejects.toThrow(
+			"Cannot change goal mode while a response is in progress.",
+		);
+		expect(controller.getMode()).toEqual({
+			plan: { status: "off" },
+			goal: { status: "off", continuationEnabled: false },
+		});
+	});
+
+	it("reports disabled continuation honestly and dispatches one continuation only after an active idle end", async () => {
+		vi.useFakeTimers();
+		const disabled = createHarness();
+		await disabled.controller.setGoalMode({ action: "on", description: "Ship the release" });
+		expect(disabled.controller.getMode().goal).toMatchObject({ status: "active", continuationEnabled: false });
+		await scheduleActiveGoalContinuation(disabled.controller);
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(disabled.host.continuations).toEqual([]);
+
+		const enabled = createHarness({ continuationModes: ["rpc"] });
+		await enabled.controller.setGoalMode({ action: "on", description: "Ship the release" });
+		expect(enabled.controller.getMode().goal).toMatchObject({ status: "active", continuationEnabled: true });
+		await scheduleActiveGoalContinuation(enabled.controller);
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS - 1);
+		await flushMicrotasks();
+		expect(enabled.host.continuations).toEqual([]);
+		enabled.host.postPromptWork = true;
+		vi.advanceTimersByTime(1);
+		await flushMicrotasks();
+		expect(enabled.host.continuations).toEqual([]);
+
+		enabled.host.postPromptWork = false;
+		await scheduleActiveGoalContinuation(enabled.controller);
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(enabled.host.continuations).toHaveLength(1);
+		expect(enabled.host.continuations[0]).toContain("goal");
+	});
+
+	it("cancels scheduled RPC goal continuation when user work or a mode transition supersedes it", async () => {
+		vi.useFakeTimers();
+
+		const userStart = createHarness({ continuationModes: ["rpc"] });
+		await userStart.controller.setGoalMode({ action: "on", description: "Ship the release" });
+		await scheduleActiveGoalContinuation(userStart.controller);
+		await userStart.controller.handleSessionEvent({ type: "message_start", message: { role: "user" } });
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(userStart.host.continuations).toEqual([]);
+
+		const agentStart = createHarness({ continuationModes: ["rpc"] });
+		await agentStart.controller.setGoalMode({ action: "on", description: "Ship the release" });
+		await scheduleActiveGoalContinuation(agentStart.controller);
+		await agentStart.controller.handleSessionEvent({ type: "agent_start" });
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(agentStart.host.continuations).toEqual([]);
+
+		const paused = createHarness({ continuationModes: ["rpc"] });
+		await paused.controller.setGoalMode({ action: "on", description: "Ship the release" });
+		await scheduleActiveGoalContinuation(paused.controller);
+		await paused.controller.setGoalMode({ action: "toggle" });
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(paused.host.continuations).toEqual([]);
+
+		const dropped = createHarness({ continuationModes: ["rpc"] });
+		await dropped.controller.setGoalMode({ action: "on", description: "Ship the release" });
+		await scheduleActiveGoalContinuation(dropped.controller);
+		await dropped.controller.setGoalMode({ action: "off" });
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(dropped.host.continuations).toEqual([]);
+
+		const planResume = createHarness({ continuationModes: ["rpc"] });
+		await planResume.controller.setGoalMode({ action: "on", description: "Ship the release" });
+		await scheduleActiveGoalContinuation(planResume.controller);
+		planResume.host.persisted = { mode: "plan", modeData: { planFilePath: "local://resume-plan.md" } };
+		await planResume.controller.reconcile();
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(planResume.host.continuations).toEqual([]);
+		expect(planResume.controller.getMode().plan).toEqual({
+			status: "active",
+			planFilePath: "local://resume-plan.md",
+		});
+	});
+
+	it("suppresses the next RPC continuation after a continuation turn ends without tool execution", async () => {
+		vi.useFakeTimers();
+		const { host, controller } = createHarness({ continuationModes: ["rpc"] });
+		await controller.setGoalMode({ action: "on", description: "Ship the release" });
+
+		await scheduleActiveGoalContinuation(controller);
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(host.continuations).toHaveLength(1);
+
+		await controller.handleSessionEvent({ type: "agent_end" });
+		vi.advanceTimersByTime(RPC_GOAL_CONTINUATION_DELAY_MS);
+		await flushMicrotasks();
+		expect(host.continuations).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/rpc-native-wire.test.ts
+++ b/packages/coding-agent/test/rpc-native-wire.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runRpcMode } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import { createTestSession } from "./utilities";
+
+const RPC_WIRE_RUNNER_ARG = "--rpc-native-wire-runner";
+
+const offMode = {
+	plan: { status: "off" },
+	goal: { status: "off", continuationEnabled: false },
+} as const;
+
+class ControlledProcessExit extends Error {
+	constructor(readonly code: number | undefined) {
+		super(`Controlled process exit: ${code ?? 0}`);
+	}
+}
+
+async function runRpcWireRunner(): Promise<void> {
+	const { cleanup, session } = await createTestSession({
+		inMemory: true,
+		settingsOverrides: {
+			"plan.enabled": false,
+			"goal.enabled": false,
+		},
+	});
+	const originalExit = process.exit;
+
+	// The exercised commands must acknowledge their no-op without starting an
+	// agent turn. Throwing here makes a regression fail before any model call.
+	Object.defineProperties(session, {
+		prompt: {
+			configurable: true,
+			value: async () => {
+				throw new Error("set_*_mode off must not invoke session.prompt");
+			},
+		},
+		promptCustomMessage: {
+			configurable: true,
+			value: async () => {
+				throw new Error("set_*_mode off must not invoke session.promptCustomMessage");
+			},
+		},
+	});
+	process.exit = ((code?: number): never => {
+		throw new ControlledProcessExit(code);
+	}) as typeof process.exit;
+
+	try {
+		await runRpcMode(session);
+	} catch (error) {
+		if (error instanceof ControlledProcessExit) {
+			process.exitCode = error.code ?? 0;
+			return;
+		}
+		process.exitCode = 1;
+		process.stderr.write(`${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`);
+	} finally {
+		process.exit = originalExit;
+		await cleanup();
+	}
+}
+
+if (process.argv.includes(RPC_WIRE_RUNNER_ARG)) {
+	await runRpcWireRunner();
+} else {
+	describe("RPC native mode wire frames", () => {
+		test("advertises v2 control and acknowledges off-mode commands without an agent turn", async () => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-rpc-native-wire-"));
+			const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+			const runnerPath = path.join(import.meta.dir, "rpc-native-wire.test.ts");
+			const proc = Bun.spawn([process.execPath, runnerPath, RPC_WIRE_RUNNER_ARG], {
+				cwd: repoRoot,
+				stdin: "pipe",
+				stdout: "pipe",
+				stderr: "pipe",
+				env: {
+					...process.env,
+					XDG_CONFIG_HOME: root,
+					XDG_DATA_HOME: root,
+					PI_CODING_AGENT_DIR: path.join(root, "agent"),
+					PI_NO_TITLE: "1",
+					NO_COLOR: "1",
+				},
+			});
+
+			try {
+				const requests = [
+					{ id: "state", type: "get_state" },
+					{ id: "plan-off", type: "set_plan_mode", action: "off" },
+					{ id: "goal-off", type: "set_goal_mode", action: "off" },
+				];
+				proc.stdin.write(
+					new TextEncoder().encode(`${requests.map(request => JSON.stringify(request)).join("\n")}\n`),
+				);
+				proc.stdin.flush();
+				proc.stdin.end();
+
+				const [stdout, stderr, exitCode] = await Promise.all([
+					new Response(proc.stdout).text(),
+					new Response(proc.stderr).text(),
+					proc.exited,
+				]);
+				expect(exitCode).toBe(0);
+				expect(stderr).toBe("");
+
+				const frames = stdout
+					.split("\n")
+					.filter(Boolean)
+					.map(line => JSON.parse(line) as Record<string, unknown>);
+
+				expect(frames[0]).toEqual({
+					type: "ready",
+					protocol: { version: 2, capabilities: { nativeModeControl: 1 } },
+				});
+				expect(frames.find(frame => frame.id === "state")).toEqual({
+					id: "state",
+					type: "response",
+					command: "get_state",
+					success: true,
+					data: expect.objectContaining({ mode: offMode }),
+				});
+				expect(frames.find(frame => frame.id === "plan-off")).toEqual({
+					id: "plan-off",
+					type: "response",
+					command: "set_plan_mode",
+					success: true,
+					data: { mode: offMode, agentInvoked: false },
+				});
+				expect(frames.find(frame => frame.id === "goal-off")).toEqual({
+					id: "goal-off",
+					type: "response",
+					command: "set_goal_mode",
+					success: true,
+					data: { mode: offMode, agentInvoked: false },
+				});
+			} finally {
+				await fs.rm(root, { recursive: true, force: true });
+			}
+		}, 30000);
+	});
+}


### PR DESCRIPTION
## What

- Advertise RPC protocol v2 with `nativeModeControl: 1` capability negotiation.
- Add typed `set_plan_mode` and `set_goal_mode` commands plus native plan/goal state in `get_state`.
- Reuse the real plan and goal runtimes, including tool/model restoration, plan approval, goal accounting/continuation, and session-switch reconciliation.
- Keep prompt-template expansion disabled for native mode descriptions so slash-prefixed text remains literal.
- Extract the shared resolve invocation path so RPC plan approval uses the same validation and result contract as the built-in tool.
- Add controller lifecycle regressions and an end-to-end RPC wire-frame test.

## Why

Non-interactive RPC clients currently cannot enter or inspect OMP's real plan and goal modes. Sending `/plan` or `/goal` as prompt text is not equivalent: it does not provide a typed acknowledgement or a reliable native-state contract for external clients. This adds a capability-negotiated API without coupling the core to any specific transport or UI.

## Testing

- `bun test packages/coding-agent/test/rpc-native-modes.test.ts packages/coding-agent/test/rpc-native-wire.test.ts` — 24 pass, 0 fail
- `bun run check` in `packages/coding-agent` — passed
- `bun check` at repository root — passed
- Compiled `dist/omp` RPC smoke: protocol v2, `nativeModeControl: 1`, valid `get_state.data.mode`, successful no-op plan/goal acknowledgements, clean exit

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)