### PR TITLE
fix(ai): normalize Codex transport session IDs

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed
 
 - Fixed concurrent reasoning summaries to ignore legacy streaming events under cutoff contract
+- Normalized arbitrary Codex session IDs to stable version-7-shaped transport UUIDs, preventing GPT-5.6 Luna requests from routing to stale deployments.
 
 ## [16.3.15] - 2026-07-09
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -100,6 +100,7 @@ import {
 	finalizeToolCallArgumentsDone,
 	isOpenAIResponsesProgressEvent,
 	mapOpenAIResponsesStopReason,
+	normalizeCodexTransportSessionId,
 	normalizeOpenAIPromptCacheKey,
 	populateResponsesUsageFromResponse,
 	promoteResponsesToolUseStopReason,
@@ -901,7 +902,7 @@ async function buildCodexRequestContext(
 	const baseUrl = model.baseUrl || CODEX_BASE_URL;
 	const url = resolveCodexResponsesUrl(baseUrl);
 	const promptCacheKey = normalizeOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId);
-	const transportSessionId = normalizeOpenAIPromptCacheKey(options?.sessionId);
+	const transportSessionId = normalizeCodexTransportSessionId(options?.sessionId);
 	const transformedBody = await buildTransformedCodexRequestBody(model, context, options, promptCacheKey);
 
 	const requestHeaders = { ...(model.headers ?? {}), ...(options?.headers ?? {}) };
@@ -2186,8 +2187,7 @@ export async function prewarmOpenAICodexResponses(
 	const accountId = getCodexAccountId(apiKey);
 	const baseUrl = model.baseUrl || CODEX_BASE_URL;
 	const url = resolveCodexResponsesUrl(baseUrl);
-	const transportSessionId = normalizeOpenAIPromptCacheKey(options?.sessionId);
-	const promptCacheKey = transportSessionId;
+	const transportSessionId = normalizeCodexTransportSessionId(options?.sessionId);
 	const providerSessionState = getCodexProviderSessionState(options?.providerSessionState);
 	const responsesLite = resolveCodexResponsesLite(model, options?.responsesLite);
 	const sessionKey = getCodexWebSocketSessionKey(transportSessionId, model, accountId, apiKey, baseUrl, responsesLite);
@@ -2204,7 +2204,7 @@ export async function prewarmOpenAICodexResponses(
 		{ ...(model.headers ?? {}), ...(options?.headers ?? {}) },
 		accountId,
 		apiKey,
-		promptCacheKey,
+		transportSessionId,
 		"websocket",
 		state,
 		responsesLite,
@@ -2330,7 +2330,7 @@ function getCodexWebSocketStateForPublicSession(
 ): CodexWebSocketSessionState | undefined {
 	const baseUrl = options?.baseUrl || model.baseUrl || CODEX_BASE_URL;
 	const providerSessionState = getCodexProviderSessionState(options?.providerSessionState);
-	const normalizedSessionId = normalizeOpenAIPromptCacheKey(options?.sessionId);
+	const normalizedSessionId = normalizeCodexTransportSessionId(options?.sessionId);
 	const publicSessionKey = normalizedSessionId ? `${baseUrl}:${model.id}:${normalizedSessionId}` : undefined;
 	const privateSessionKey = publicSessionKey
 		? providerSessionState?.webSocketPublicToPrivate.get(publicSessionKey)

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1071,6 +1071,25 @@ function normalizeOpenAIStableId(value: string | undefined, maxLength: number, h
 	return `${hashPrefix}${Bun.hash(wellFormed).toString(36)}`;
 }
 
+/** Canonical shape of a UUID already carrying the v7 version nibble and RFC 4122 variant bits. */
+const CODEX_TRANSPORT_SESSION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Stable, version-7-shaped UUID for Codex transport headers. This is not a
+ * time-ordered UUIDv7: hashing preserves affinity for arbitrary client ids
+ * while avoiding Luna's stale-deployment routing for other UUID versions.
+ * Already-valid UUIDv7 values pass through unchanged.
+ */
+export function normalizeCodexTransportSessionId(sessionId: string | undefined): string | undefined {
+	if (!sessionId || sessionId.length === 0) return undefined;
+	const wellFormed = sessionId.toWellFormed();
+	if (CODEX_TRANSPORT_SESSION_ID_PATTERN.test(wellFormed)) return wellFormed;
+	const hex = new Bun.CryptoHasher("sha256").update(wellFormed).digest("hex").slice(0, 32);
+	const variantNibble = (Number.parseInt(hex[16], 16) & 0x3) | 0x8;
+	const stamped = `${hex.slice(0, 12)}7${hex.slice(13, 16)}${variantNibble.toString(16)}${hex.slice(17, 32)}`;
+	return `${stamped.slice(0, 8)}-${stamped.slice(8, 12)}-${stamped.slice(12, 16)}-${stamped.slice(16, 20)}-${stamped.slice(20, 32)}`;
+}
+
 export const OPENAI_RESPONSES_PROGRESS_EVENT_TYPES: ReadonlySet<string> = new Set([
 	"response.created",
 	"response.output_item.added",

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -137,6 +137,13 @@ function encodeWebSocketMessage(value: Record<string, unknown>): Uint8Array {
 	return new TextEncoder().encode(JSON.stringify(value));
 }
 
+/**
+ * Version-7-shaped UUID with an RFC 4122 variant nibble — the shape Codex's
+ * conversation_id/session_id/x-client-request-id headers must carry. Tests
+ * assert only against this shape, never against the derivation algorithm.
+ */
+const CODEX_TRANSPORT_UUID_V7_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 type WsHeaders = Record<string, string>;
 type WsEventType = "open" | "message" | "error" | "close";
 
@@ -1662,52 +1669,13 @@ describe("openai-codex streaming", () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());
 
-		const payload = Buffer.from(
-			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acc_test" } }),
-			"utf8",
-		).toBase64();
-		const token = `aaa.${payload}.bbb`;
-
-		const sse = `${[
-			`data: ${JSON.stringify({
-				type: "response.output_item.added",
-				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
-			})}`,
-			`data: ${JSON.stringify({ type: "response.content_part.added", part: { type: "output_text", text: "" } })}`,
-			`data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
-			`data: ${JSON.stringify({
-				type: "response.output_item.done",
-				item: {
-					type: "message",
-					id: "msg_1",
-					role: "assistant",
-					status: "completed",
-					content: [{ type: "output_text", text: "Hello" }],
-				},
-			})}`,
-			`data: ${JSON.stringify({
-				type: "response.completed",
-				response: {
-					status: "completed",
-					usage: {
-						input_tokens: 5,
-						output_tokens: 3,
-						total_tokens: 8,
-						input_tokens_details: { cached_tokens: 0 },
-					},
-				},
-			})}`,
-		].join("\n\n")}\n\n`;
-
-		const encoder = new TextEncoder();
-		const stream = new ReadableStream({
-			start(controller) {
-				controller.enqueue(encoder.encode(sse));
-				controller.close();
-			},
-		});
-
+		const token = createCodexTestToken();
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
 		const sessionId = "test-session-123";
+
+		const capturedTransportIds: (string | null)[] = [];
+		const capturedCacheKeys: unknown[] = [];
+
 		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
 			const url = typeof input === "string" ? input : input.toString();
 			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
@@ -1717,17 +1685,22 @@ describe("openai-codex streaming", () => {
 				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
 			}
 			if (url === "https://chatgpt.com/backend-api/codex/responses") {
-				const headers = init?.headers instanceof Headers ? init.headers : undefined;
-				// Verify sessionId is set in headers
-				expect(headers?.get("conversation_id")).toBe(sessionId);
-				expect(headers?.get("session_id")).toBe(sessionId);
-				expect(headers?.get("x-client-request-id")).toBe(sessionId);
+				const headers = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+				const conversationId = headers.get("conversation_id");
 
-				// Verify sessionId is set in request body as prompt_cache_key
+				// Codex requires all three transport identifiers to agree and to be
+				// version-7-shaped UUIDs — never the raw, arbitrary client sessionId,
+				// which the real backend routes to a nonexistent Luna deployment.
+				expect(headers.get("session_id")).toBe(conversationId);
+				expect(headers.get("x-client-request-id")).toBe(conversationId);
+				expect(conversationId).toMatch(CODEX_TRANSPORT_UUID_V7_RE);
+				expect(conversationId).not.toBe(sessionId);
+				capturedTransportIds.push(conversationId);
+
 				const body = typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : null;
-				expect(body?.prompt_cache_key).toBe(sessionId);
+				capturedCacheKeys.push(body?.prompt_cache_key);
 
-				return new Response(stream, {
+				return new Response(createCompletedCodexSse("Hello"), {
 					status: 200,
 					headers: { "content-type": "text/event-stream" },
 				});
@@ -1735,30 +1708,62 @@ describe("openai-codex streaming", () => {
 			return new Response("not found", { status: 404 });
 		});
 
-		const model: Model<"openai-codex-responses"> = buildModel({
-			id: "gpt-5.1-codex",
-			name: "GPT-5.1 Codex",
-			api: "openai-codex-responses",
-			provider: "openai-codex",
-			baseUrl: "https://chatgpt.com/backend-api",
-			reasoning: true,
-			input: ["text"],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 400000,
-			maxTokens: 128000,
-		});
-
-		const context: Context = {
-			systemPrompt: ["You are a helpful assistant."],
-			messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
-		};
-
-		const streamResult = streamOpenAICodexResponses(model, context, {
+		await streamOpenAICodexResponses(model, createCodexTestContext(), {
 			apiKey: token,
 			sessionId,
 			fetch: fetchMock as FetchImpl,
+		}).result();
+		await streamOpenAICodexResponses(model, createCodexTestContext(), {
+			apiKey: token,
+			sessionId,
+			fetch: fetchMock as FetchImpl,
+		}).result();
+
+		// Same input sessionId must deterministically derive the identical
+		// transport id every call — not fresh random entropy per request.
+		expect(capturedTransportIds).toHaveLength(2);
+		expect(capturedTransportIds[0]).toBe(capturedTransportIds[1]);
+
+		// The body's prompt_cache_key stays the raw, unhashed sessionId.
+		expect(capturedCacheKeys).toEqual([sessionId, sessionId]);
+	});
+
+	it("passes an already-valid UUIDv7 sessionId through unchanged", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+
+		const token = createCodexTestToken();
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
+		const sessionId = "0190f1e0-1234-7abc-89ab-1234567890ab";
+		let capturedHeaders: Headers | undefined;
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url === "https://api.github.com/repos/openai/codex/releases/latest") {
+				return new Response(JSON.stringify({ tag_name: "rust-v0.0.0" }), { status: 200 });
+			}
+			if (url.startsWith("https://raw.githubusercontent.com/openai/codex/")) {
+				return new Response("PROMPT", { status: 200, headers: { etag: '"etag"' } });
+			}
+			if (url === "https://chatgpt.com/backend-api/codex/responses") {
+				capturedHeaders = init?.headers instanceof Headers ? init.headers : new Headers(init?.headers);
+				return new Response(createCompletedCodexSse("Hello"), {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			}
+			return new Response("not found", { status: 404 });
 		});
-		await streamResult.result();
+
+		await streamOpenAICodexResponses(model, createCodexTestContext(), {
+			apiKey: token,
+			sessionId,
+			fetch: fetchMock as FetchImpl,
+		}).result();
+
+		expect(capturedHeaders?.get("conversation_id")).toBe(sessionId);
+		expect(capturedHeaders?.get("session_id")).toBe(sessionId);
+		expect(capturedHeaders?.get("x-client-request-id")).toBe(sessionId);
 	});
 	it("keeps prompt_cache_key separate from Codex conversation headers", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
@@ -1798,9 +1803,11 @@ describe("openai-codex streaming", () => {
 			promptCacheKey,
 		}).result();
 
-		expect(capturedHeaders?.get("conversation_id")).toBe(sessionId);
-		expect(capturedHeaders?.get("session_id")).toBe(sessionId);
-		expect(capturedHeaders?.get("x-client-request-id")).toBe(sessionId);
+		const conversationId = capturedHeaders?.get("conversation_id");
+		expect(conversationId).toBe(capturedHeaders?.get("session_id"));
+		expect(conversationId).toBe(capturedHeaders?.get("x-client-request-id"));
+		expect(conversationId).toMatch(CODEX_TRANSPORT_UUID_V7_RE);
+		expect(conversationId).not.toBe(sessionId);
 		expect(capturedBody?.prompt_cache_key).toBe(promptCacheKey);
 	});
 


### PR DESCRIPTION
## What

Normalize the Codex transport session ID (the id sent in the `session_id` /
`conversation_id` / `x-client-request-id` transport identity, distinct from
`prompt_cache_key`) to a stable, SHA-256-derived version-7-shaped UUID before
it reaches the Codex Luna backend, across SSE, WebSocket, prewarm, and debug
session paths.

## Why

Codex's `gpt-5.6-luna` backend routes requests to a specific rollout
deployment based on the version nibble of the transport session identity.
pi-ai currently passes through whatever `sessionId` the caller supplies
(including derived, non-UUID values such as an advisor's `<uuid>-advisor`
suffix), which is not a valid UUID at all, let alone a v7 one. When the
transport identity isn't shaped like a v7 UUID, Luna resolves the request to
a stale/wrong deployment and the backend rejects it with a "Model not found"
error for a backend-resolved experiment slug, even though the exact same
session works fine on `terra` and other non-Luna Codex models.

Fixes #5040.

`prompt_cache_key` is untouched by this change — it continues to be derived
from the raw normalized cache identity via `normalizeOpenAIPromptCacheKey`
and is no longer conflated with the transport session id (previously the
prewarm path aliased `promptCacheKey = transportSessionId`).

## Fix

Added `normalizeCodexTransportSessionId` in `openai-shared.ts`:

- Already-valid UUIDv7 values (matching the v7 version nibble + RFC 4122
  variant bits) pass through unchanged.
- Anything else is hashed with SHA-256 and stamped into a version-7-shaped
  UUID (version nibble `7`, correct variant bits) derived deterministically
  from the input, so the same logical session id always maps to the same
  transport UUID.
- This is explicitly **not** a real UUIDv7 — it carries no time-order
  semantics. It exists purely to satisfy Luna's version-nibble-based routing
  check with a stable, collision-resistant identity.

`openai-codex-responses.ts` now calls this normalizer everywhere a transport
session id is derived from `options.sessionId` (request construction,
prewarm, WebSocket session-key resolution) instead of reusing
`normalizeOpenAIPromptCacheKey`, which was never guaranteed to produce a
UUID shape.

## Production evidence

Verified directly against the Codex backend with `gpt-5.6-luna`:

- Non-v7-shaped transport identities (v4, v5, v8 UUIDs) were rejected twice
  in a row with the same backend-resolved "Model not found" experiment-slug
  error described in #5040.
- A random, correctly-shaped v7 UUID was accepted twice in a row.
- The deterministic v7-shaped UUID produced by
  `normalizeCodexTransportSessionId` was accepted.
- Native Codex and Responses-API split-transport paths showed identical
  accept/reject behavior for the same identity shapes.

(No account IDs, credentials, or full generated UUIDs from these runs are
included here.)

## Testing

- `bun run check` (biome + `tsgo --noEmit`) — clean.
- `bun test test/openai-codex-stream.test.ts` — 57 pass / 0 fail / 334
  `expect()` calls, including new coverage for pass-through of valid v7
  ids, deterministic normalization of non-v7 ids, and shared identity
  across SSE/WebSocket/prewarm/debug session paths.
- Full `packages/ai` suite — 2746 pass / 0 fail / 337 environment-gated
  skips (unrelated `E2E env not set` / local-model suites).

---

- [x] `bun run check` passes
- [x] Tested locally (unit tests above) + verified against the live Codex
      backend (production evidence above)
- [x] CHANGELOG updated
