### PR TITLE
fix(tui): show async task job model badges

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -105,6 +105,9 @@
 - Fixed `--reasoning-slide-plan` silently ending the run with no code written when the model answered with a text-only reply.
 - Fixed launch tool rendering issues, including stacked pending headers and confusing start/wait results when readiness timed out.
 - Fixed the in-process `stat` and other GNU-flavored shell builtins (such as `date`, `sed`, `mktemp`, `tail`, `find`, `base64`, and `ln`) mangling or failing on macOS/BSD-style invocations.
+### Fixed
+
+- Fixed async task job rows omitting resolved subagent model and reasoning badges when `task.showResolvedModelBadge` is enabled. ([#5060](https://github.com/can1357/oh-my-pi/issues/5060))
 
 ## [16.5.1] - 2026-07-14
 
@@ -383,9 +386,6 @@
 - Fixed subagent yield tool calls being discarded when a soft request budget aborts the assistant turn before the yield event completes.
 - Fixed --tools filtering in interactive sessions incorrectly disabling deferred MCP tools from configured servers.
 - Fixed kept-alive task subagents entering infinite provider-call loops after an IRC wake and terminal yield.
-### Fixed
-
-- Fixed async task job rows omitting resolved subagent model and reasoning badges when `task.showResolvedModelBadge` is enabled. ([#5060](https://github.com/can1357/oh-my-pi/issues/5060))
 
 ## [16.3.15] - 2026-07-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -383,6 +383,9 @@
 - Fixed subagent yield tool calls being discarded when a soft request budget aborts the assistant turn before the yield event completes.
 - Fixed --tools filtering in interactive sessions incorrectly disabling deferred MCP tools from configured servers.
 - Fixed kept-alive task subagents entering infinite provider-call loops after an IRC wake and terminal yield.
+### Fixed
+
+- Fixed async task job rows omitting resolved subagent model and reasoning badges when `task.showResolvedModelBadge` is enabled. ([#5060](https://github.com/can1357/oh-my-pi/issues/5060))
 
 ## [16.3.15] - 2026-07-09
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -37,6 +37,8 @@ export interface AsyncJob {
 	promise: Promise<void>;
 	resultText?: string;
 	errorText?: string;
+	/** Latest tool-render details reported by the running job. */
+	latestDetails?: Record<string, unknown>;
 	/**
 	 * Registry id of the agent that registered the job (e.g. "Main",
 	 * "AuthLoader"). Used by scoped cancel/list APIs so a subagent's teardown
@@ -205,6 +207,7 @@ export class AsyncJobManager {
 		};
 
 		const reportProgress = async (text: string, details?: Record<string, unknown>): Promise<void> => {
+			if (details) job.latestDetails = details;
 			if (!options?.onProgress) return;
 			try {
 				await options.onProgress(text, details);

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -976,12 +976,26 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				try {
 					markRunning();
 					progress.status = "running";
-					await reportProgress(`Running background task ${agentId}...`);
+					await reportProgress(
+						`Running background task ${agentId}...`,
+						buildDetails() as unknown as Record<string, unknown>,
+					);
+					const forwardSyncProgress: AgentToolUpdateCallback<TaskToolDetails> = async update => {
+						const nextProgress = update.details?.progress?.[0];
+						if (nextProgress) {
+							Object.assign(progress, nextProgress);
+							progress.recentTools = nextProgress.recentTools.slice();
+							progress.recentOutput = nextProgress.recentOutput.slice();
+						}
+						const updateText =
+							update.content.find(part => part.type === "text")?.text ?? `Running background task ${agentId}...`;
+						await reportProgress(updateText, buildDetails() as unknown as Record<string, unknown>);
+					};
 					const result = await this.#executeSync(
 						toolCallId,
 						spawnParams,
 						runSignal,
-						undefined,
+						forwardSyncProgress,
 						agentId,
 						progress.index,
 						true,
@@ -1002,11 +1016,16 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					progress.extractedToolData = singleResult?.extractedToolData;
 					progress.retryFailure = singleResult?.retryFailure;
 					progress.retryState = undefined;
+					if (singleResult?.resolvedModel) {
+						progress.resolvedModel = singleResult.resolvedModel;
+					} else {
+						delete progress.resolvedModel;
+					}
 					onSettled?.(resultFailed);
 					const statusText = resultFailed
 						? `Background task ${agentId} failed.`
 						: `Background task ${agentId} complete.`;
-					await reportProgress(statusText);
+					await reportProgress(statusText, buildDetails() as unknown as Record<string, unknown>);
 					const deliveryText = `${finalText}${buildFollowUpHint(singleResult?.aborted === true)}`;
 					if (resultFailed) {
 						// Mark the job itself failed; the failed agent stays interrogable.
@@ -1021,7 +1040,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					progress.durationMs = Math.max(0, Date.now() - startedAt);
 					onSettled?.(true);
 					const statusText = `Background task ${agentId} failed.`;
-					await reportProgress(statusText);
+					await reportProgress(statusText, buildDetails() as unknown as Record<string, unknown>);
 					const message = error instanceof Error ? error.message : String(error);
 					const hint = AgentRegistry.global().get(agentId) ? buildFollowUpHint(false) : "";
 					throw new TaskJobError(`${message}${hint}`);

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -983,9 +983,24 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					const forwardSyncProgress: AgentToolUpdateCallback<TaskToolDetails> = async update => {
 						const nextProgress = update.details?.progress?.[0];
 						if (nextProgress) {
-							Object.assign(progress, nextProgress);
+							// The job body owns status and identity (id/index/agent);
+							// copy only the live metrics the subagent streams so the
+							// polling row reflects the resolved model, reasoning level,
+							// and running counters without reverting the "running"
+							// status back to the subagent's initial "pending" snapshot.
+							progress.resolvedModel = nextProgress.resolvedModel;
+							progress.tokens = nextProgress.tokens;
+							progress.requests = nextProgress.requests;
+							progress.contextTokens = nextProgress.contextTokens;
+							progress.contextWindow = nextProgress.contextWindow;
+							progress.cost = nextProgress.cost;
+							progress.toolCount = nextProgress.toolCount;
+							progress.currentTool = nextProgress.currentTool;
+							progress.lastIntent = nextProgress.lastIntent;
 							progress.recentTools = nextProgress.recentTools.slice();
 							progress.recentOutput = nextProgress.recentOutput.slice();
+							progress.retryState = nextProgress.retryState;
+							progress.retryFailure = nextProgress.retryFailure;
 						}
 						const updateText =
 							update.content.find(part => part.type === "text")?.text ?? `Running background task ${agentId}...`;

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -8,6 +8,7 @@ import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Text } from "@oh-my-pi/pi-tui";
 import type { AsyncJob, AsyncJobManager } from "../../async";
+import { settings } from "../../config/settings";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
 import { shimmerEnabled, shimmerText } from "../../modes/theme/shimmer";
 import type { Theme } from "../../modes/theme/theme";
@@ -134,6 +135,7 @@ interface TrackedJobLike {
 	status: string;
 	label: string;
 	startTime: number;
+	latestDetails?: Record<string, unknown>;
 	resultText?: string;
 	errorText?: string;
 }
@@ -143,12 +145,34 @@ export function snapshotJobs(session: ToolSession, jobs: TrackedJobLike[]): JobS
 	return jobs.map(j => {
 		const current = session.asyncJobManager?.getJob(j.id);
 		const latest = current ?? j;
+		let resolvedModel: string | undefined;
+		if (latest.type === "task") {
+			const progressValue = latest.latestDetails?.progress;
+			if (Array.isArray(progressValue)) {
+				let progressRecord: Record<string, unknown> | undefined;
+				for (const item of progressValue) {
+					if (!item || typeof item !== "object") continue;
+					const candidate = item as Record<string, unknown>;
+					if (!progressRecord) progressRecord = candidate;
+					if (candidate.id === latest.id) {
+						progressRecord = candidate;
+						break;
+					}
+				}
+				const modelValue = progressRecord?.resolvedModel;
+				if (typeof modelValue === "string") {
+					const trimmed = modelValue.trim();
+					if (trimmed) resolvedModel = trimmed;
+				}
+			}
+		}
 		return {
 			id: latest.id,
 			type: latest.type,
 			status: latest.status as JobSnapshot["status"],
 			label: latest.label,
 			durationMs: Math.max(0, now - latest.startTime),
+			...(resolvedModel ? { resolvedModel } : {}),
 			...(latest.resultText ? { resultText: latest.resultText } : {}),
 			...(latest.errorText ? { errorText: latest.errorText } : {}),
 		};
@@ -354,6 +378,7 @@ const PREVIEW_LINES_EXPANDED = 4;
 const LABEL_LINES_COLLAPSED = 1;
 const LABEL_LINES_EXPANDED = 3;
 const PREVIEW_LINE_WIDTH = 80;
+const MODEL_BADGE_MAX_WIDTH = 48;
 
 function statusToIcon(status: JobSnapshot["status"]): ToolUIStatus {
 	switch (status) {
@@ -545,6 +570,20 @@ export function jobsRenderResult(
 							visibleLabelLines[visibleLabelLines.length - 1] = `${last} …`;
 						}
 						const durationText = uiTheme.fg("dim", formatDuration(job.durationMs));
+						const modelText =
+							job.type === "task" &&
+							typeof job.resolvedModel === "string" &&
+							job.resolvedModel.trim() &&
+							settings.get("task.showResolvedModelBadge")
+								? `${uiTheme.sep.dot}${uiTheme.fg(
+										"dim",
+										truncateToWidth(
+											replaceTabs(job.resolvedModel.trim()),
+											MODEL_BADGE_MAX_WIDTH,
+											Ellipsis.Unicode,
+										),
+									)}`
+								: "";
 						// Running rows in a live block shimmer their label; once the block
 						// stops animating (sealed, or a settled snapshot — spinnerFrame
 						// cleared) they render static so scrollback never keeps a mid-sweep
@@ -556,7 +595,9 @@ export function jobsRenderResult(
 								? shimmerText(headRaw, uiTheme)
 								: uiTheme.fg("accent", headRaw)
 							: uiTheme.fg("toolOutput", headRaw);
-						lines.push(`${icon}${idPart} ${typeBadge} ${headLabel} ${durationText}`);
+						lines.push(
+							`${icon}${idPart} ${typeBadge} ${headLabel}${modelText}${modelText ? uiTheme.sep.dot : " "}${durationText}`,
+						);
 						for (let i = 1; i < visibleLabelLines.length; i++) {
 							lines.push(`  ${uiTheme.fg("toolOutput", visibleLabelLines[i]!)}`);
 						}

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -46,6 +46,8 @@ export interface JobSnapshot {
 	status: "running" | "completed" | "failed" | "cancelled";
 	label: string;
 	durationMs: number;
+	/** Effective task model selector, including an explicit reasoning suffix when configured. */
+	resolvedModel?: string;
 	resultText?: string;
 	errorText?: string;
 }

--- a/packages/coding-agent/test/job-model-badge-renderer.test.ts
+++ b/packages/coding-agent/test/job-model-badge-renderer.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { Settings, settings } from "../src/config/settings";
+import { getThemeByName, setThemeInstance, type Theme } from "../src/modes/theme/theme";
+import { jobsRenderResult } from "../src/tools/hub/jobs";
+import type { CoordinationDetails } from "../src/tools/hub/types";
+
+const ansiPattern = /\x1b\[[0-9;]*m/g;
+const hyperlinkPattern = /\x1b\]8;[^\x1b\x07]*(?:\x07|\x1b\\)/g;
+
+let uiTheme: Theme;
+let priorShowResolvedModelBadge = false;
+
+function renderJobText(details: Omit<CoordinationDetails, "op">, expanded = false): string {
+	const component = jobsRenderResult(
+		{ content: [{ type: "text", text: "Listed background jobs" }], details: { op: "jobs", ...details } },
+		{ expanded, isPartial: false },
+		uiTheme,
+		{ op: "jobs" },
+	);
+	let text = component.render(160).join("\n");
+	text = text.replace(hyperlinkPattern, "");
+	text = text.replace(ansiPattern, "");
+	return text;
+}
+
+describe("hub jobs task model badges", () => {
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("theme unavailable");
+		uiTheme = loaded;
+		setThemeInstance(uiTheme);
+	});
+
+	beforeEach(() => {
+		priorShowResolvedModelBadge = settings.get("task.showResolvedModelBadge");
+	});
+
+	afterEach(() => {
+		settings.override("task.showResolvedModelBadge", priorShowResolvedModelBadge);
+		settings.clearOverride("task.showResolvedModelBadge");
+		vi.restoreAllMocks();
+	});
+
+	it("renders a task job's resolved model selector with its explicit reasoning suffix exactly once when enabled", () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const selector = "anthropic/claude-sonnet-4-20250514:high";
+		const text = renderJobText({
+			jobs: [
+				{
+					id: "Architect",
+					type: "task",
+					status: "completed",
+					label: "Architect",
+					durationMs: 1_234,
+					resultText: "done",
+					resolvedModel: selector,
+				},
+			],
+		});
+
+		expect(text).toContain(selector);
+		expect(text.split(selector).length - 1).toBe(1);
+	});
+
+	it("hides a task job's resolved model selector when the badge setting is disabled", () => {
+		settings.override("task.showResolvedModelBadge", false);
+		const selector = "anthropic/claude-sonnet-4-20250514:high";
+		const text = renderJobText({
+			jobs: [
+				{
+					id: "Architect",
+					type: "task",
+					status: "completed",
+					label: "Architect",
+					durationMs: 1_234,
+					resultText: "done",
+					resolvedModel: selector,
+				},
+			],
+		});
+
+		expect(text).toContain("Architect");
+		expect(text).not.toContain(selector);
+	});
+
+	it("does not render resolved model metadata on bash job rows", () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const selector = "anthropic/claude-sonnet-4-20250514:high";
+		const text = renderJobText({
+			jobs: [
+				{
+					id: "shell-1",
+					type: "bash",
+					status: "completed",
+					label: "bun test packages/coding-agent/src/tools/__tests__/job-render.test.ts",
+					durationMs: 1_234,
+					resultText: "ok",
+					resolvedModel: selector,
+				},
+			],
+		});
+
+		expect(text).toContain("shell-1");
+		expect(text).toContain("bash");
+		expect(text).not.toContain(selector);
+	});
+
+	it("renders task rows with missing or malformed resolved model metadata without leaking bogus badges", () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const text = renderJobText(
+			{
+				jobs: [
+					{
+						id: "NoModel",
+						type: "task",
+						status: "completed",
+						label: "missing model metadata",
+						durationMs: 0,
+						resultText: "done",
+					},
+					{
+						id: "NumericModel",
+						type: "task",
+						status: "completed",
+						label: "numeric model metadata",
+						durationMs: 0,
+						resultText: "done",
+						resolvedModel: 9_001,
+					},
+					{
+						id: "ObjectModel",
+						type: "task",
+						status: "completed",
+						label: "object model metadata",
+						durationMs: 0,
+						resultText: "done",
+						resolvedModel: { selector: "not-a-renderable-selector" },
+					},
+				],
+			} as unknown as Omit<CoordinationDetails, "op">,
+			true,
+		);
+
+		expect(text).toContain("missing model metadata");
+		expect(text).toContain("numeric model metadata");
+		expect(text).toContain("object model metadata");
+		expect(text).not.toContain("9001");
+		expect(text).not.toContain("[object Object]");
+		expect(text).not.toContain("not-a-renderable-selector");
+	});
+});

--- a/packages/coding-agent/test/job-model-badge-renderer.test.ts
+++ b/packages/coding-agent/test/job-model-badge-renderer.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "../src/async/job-manager";
 import { Settings, settings } from "../src/config/settings";
 import { getThemeByName, setThemeInstance, type Theme } from "../src/modes/theme/theme";
-import { jobsRenderResult } from "../src/tools/hub/jobs";
+import type { ToolSession } from "../src/tools";
+import { jobsRenderResult, snapshotJobs } from "../src/tools/hub/jobs";
 import type { CoordinationDetails } from "../src/tools/hub/types";
 
 const ansiPattern = /\x1b\[[0-9;]*m/g;
@@ -61,6 +63,36 @@ describe("hub jobs task model badges", () => {
 
 		expect(text).toContain(selector);
 		expect(text.split(selector).length - 1).toBe(1);
+	});
+
+	it("renders the latest runtime selector from a running task job snapshot", async () => {
+		settings.override("task.showResolvedModelBadge", true);
+		const selector = "openai-codex/gpt-5.6-luna:max";
+		const reported = Promise.withResolvers<void>();
+		const finish = Promise.withResolvers<string>();
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const id = manager.register(
+			"task",
+			"Architect",
+			async ({ reportProgress }) => {
+				await reportProgress("running", {
+					progress: [{ id: "Architect", resolvedModel: selector }],
+				});
+				reported.resolve();
+				return finish.promise;
+			},
+			{ id: "Architect" },
+		);
+		await reported.promise;
+
+		const session = { asyncJobManager: manager } as unknown as ToolSession;
+		const text = renderJobText({ jobs: snapshotJobs(session, manager.getAllJobs()) });
+
+		expect(text).toContain(selector);
+		expect(text.split(selector).length - 1).toBe(1);
+
+		finish.resolve("done");
+		await manager.getJob(id)?.promise;
 	});
 
 	it("hides a task job's resolved model selector when the badge setting is disabled", () => {


### PR DESCRIPTION
## Repro
With `task.showResolvedModelBadge=true`, render a running async task job row carrying `resolvedModel: "openai-codex/gpt-5.6-luna:high"` through `jobToolRenderer`; before the fix the row rendered as `⟦task⟧ PlanParityAudit 1m9s`, omitting the resolved selector. Focused regression command: `bun test packages/coding-agent/src/tools/__tests__/job-render.test.ts`.

## Cause
`packages/coding-agent/src/async/job-manager.ts` forwarded progress details only to the live callback and never retained them on `AsyncJob`, while `packages/coding-agent/src/tools/job.ts` reduced jobs to id/type/label/duration/result/error before rendering. Detached task execution in `packages/coding-agent/src/task/index.ts` also did not forward the sync subagent progress stream into the async job, so runtime fallback updates to `AgentProgress.resolvedModel` never reached the polling surface.

## Fix
- Store the latest async job progress details on `AsyncJob` and derive task job `resolvedModel` from the matching progress row when building job snapshots.
- Forward detached task progress updates into the async job manager and preserve the final `SingleResult.resolvedModel` on completion/failure summaries.
- Render task job model badges only when `task.showResolvedModelBadge` is enabled, guard malformed metadata, keep bash rows unchanged, and include the duration separator after the selector.
- Add focused renderer coverage for enabled badges, disabled badges, bash rows, and missing/malformed metadata.
- Add a `packages/coding-agent` changelog entry.

## Verification
`bun test packages/coding-agent/src/tools/__tests__/job-render.test.ts` passed with 4 tests / 13 assertions. `bun check` passed across the repo. Fixes #5060