### PR TITLE
fix(compaction): fall back to LLM compaction on text-only models

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9799,23 +9799,27 @@ export class AgentSession {
 			// Strategy honored on manual /compact too. Custom instructions (public
 			// user focus OR internal plan-mode guidance) imply a directed LLM
 			// summary; a text-only model cannot read snapcompact frames. When
-			// snapcompact itself was requested, fail locally instead of silently
-			// converting the "no LLM call" path into a provider-backed summary.
+			// snapcompact itself was requested, fall back to LLM-backed
+			// context-full compaction instead of failing — mirrors the
+			// auto-compaction behavior, which already falls back gracefully.
+			// The active text-only model handles LLM summarization (text→text)
+			// fine; the compaction candidate chain also includes any configured
+			// vision model as a fallback.
 			const wantsSnapcompact =
 				compactionPrep.kind !== "fromHook" &&
 				effectiveSettings.strategy === "snapcompact" &&
 				!customInstructions &&
 				!options?.internalGuidance;
-			const snapcompactReady = wantsSnapcompact;
+			let snapcompactReady = wantsSnapcompact;
 			const snapcompactShapeSetting = this.settings.get("snapcompact.shape");
 			let snapcompactShape: snapcompact.Shape | undefined;
 			if (wantsSnapcompact && !this.model.input.includes("image")) {
 				this.emitNotice(
 					"warning",
-					`snapcompact needs a vision-capable model (${this.model.id} is text-only)`,
+					`snapcompact needs a vision-capable model (${this.model.id} is text-only); falling back to LLM compaction`,
 					"compaction",
 				);
-				throw new Error(`snapcompact cannot run locally: ${this.model.id} is text-only.`);
+				snapcompactReady = false;
 			} else if (snapcompactReady) {
 				const text = snapcompact.serializeConversation(
 					convertToLlm(preparation.messagesToSummarize.concat(preparation.turnPrefixMessages)),

--- a/packages/coding-agent/test/agent-session-snapcompact-manual-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-snapcompact-manual-fallback.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression test for manual `/compact` with a text-only active model.
+ *
+ * The snapcompact strategy renders conversation history as image frames that
+ * the active model reads back on subsequent turns. A text-only model cannot
+ * read those frames. Previously, manual `/compact` hard-failed with:
+ *   "snapcompact cannot run locally: <model> is text-only."
+ *
+ * The fix mirrors the auto-compaction behavior: fall back to LLM-backed
+ * context-full compaction (text→text summarization) instead of throwing.
+ * The active text-only model handles LLM summarization fine; the compaction
+ * candidate chain also includes any configured vision model as a fallback.
+ */
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import type { Message } from "@oh-my-pi/pi-ai";
+import { type GeneratedProvider, getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+interface ManualHarness {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	notices: string[];
+}
+
+interface ManualHarnessOptions {
+	activeModel: { provider: GeneratedProvider; id: string };
+	seedMessages?: Message[];
+}
+
+async function createManualHarness(
+	tempDir: TempDir,
+	authStorage: AuthStorage,
+	options: ManualHarnessOptions,
+): Promise<ManualHarness> {
+	const activeModel = getBundledModel(options.activeModel.provider, options.activeModel.id);
+	if (!activeModel) {
+		throw new Error(`Missing bundled model ${options.activeModel.provider}/${options.activeModel.id}`);
+	}
+	authStorage.setRuntimeApiKey(options.activeModel.provider, "test-key");
+
+	const modelRegistry = new ModelRegistry(authStorage);
+	const agent = new Agent({
+		initialState: { model: activeModel, systemPrompt: ["Test"], tools: [], messages: [] },
+	});
+	const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+	const seed = options.seedMessages ?? [{ role: "user", content: "hello", timestamp: Date.now() }];
+	for (const message of seed) sessionManager.appendMessage(message);
+
+	const settings = Settings.isolated({
+		"compaction.strategy": "snapcompact",
+		// Force a tiny kept-recent window so prepareCompaction splits the branch
+		// into discard+summarize vs kept-recent, leaving non-empty work for compact().
+		"compaction.keepRecentTokens": 1,
+		modelRoles: { vision: "aimlapi/claude-sonnet-4-5-20250929" },
+	});
+	const session = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+
+	vi.spyOn(compactionModule, "compact").mockResolvedValue({
+		summary: "compacted",
+		shortSummary: undefined,
+		firstKeptEntryId: sessionManager.getBranch()[0]?.id ?? "",
+		tokensBefore: 123,
+		details: {},
+	});
+
+	const notices: string[] = [];
+	session.subscribe(event => {
+		if (event.type === "notice" && event.source === "compaction") notices.push(event.message);
+	});
+
+	return { session, sessionManager, notices };
+}
+
+describe("AgentSession manual /compact snapcompact text-only fallback", () => {
+	let session: AgentSession | undefined;
+	let authStorage: AuthStorage | undefined;
+	let tempDir: TempDir | undefined;
+
+	afterEach(async () => {
+		try {
+			await session?.dispose();
+		} finally {
+			authStorage?.close();
+			await tempDir?.remove();
+			vi.restoreAllMocks();
+			session = undefined;
+			authStorage = undefined;
+			tempDir = undefined;
+		}
+	});
+
+	it("falls back to LLM compaction when the active model is text-only", async () => {
+		tempDir = TempDir.createSync("@pi-snapcompact-manual-text-only-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+
+		// Seed enough turn-pairs for prepareCompaction to split into
+		// discard+summarize vs kept-recent (keepRecentTokens=1 forces a split).
+		const filler = "the quick brown fox jumps over the lazy dog. ".repeat(64);
+		const seedMessages: Message[] = [];
+		for (let i = 0; i < 32; i++) {
+			seedMessages.push({
+				role: "user",
+				content: [{ type: "text", text: `turn ${i}: ${filler}` }],
+				timestamp: Date.now() - (32 - i) * 1000,
+			});
+			seedMessages.push({
+				role: "assistant",
+				content: [{ type: "text", text: `reply ${i}: ${filler}` }],
+				timestamp: Date.now() - (32 - i) * 1000 + 100,
+			});
+		}
+
+		const harness = await createManualHarness(tempDir, authStorage, {
+			// qwen3-coder-480b is text-only — cannot read snapcompact frames.
+			activeModel: { provider: "aimlapi", id: "alibaba/qwen3-coder-480b-a35b-instruct" },
+			seedMessages,
+		});
+		session = harness.session;
+
+		// Manual /compact must not throw; it must fall through to LLM summarization.
+		const result = await session.compact();
+
+		expect(result.summary).toBe("compacted");
+		expect(compactionModule.compact).toHaveBeenCalled();
+		expect(harness.notices).toContain(
+			"snapcompact needs a vision-capable model (alibaba/qwen3-coder-480b-a35b-instruct is text-only); falling back to LLM compaction",
+		);
+		expect(harness.sessionManager.getBranch().find(entry => entry.type === "compaction")).toMatchObject({
+			type: "compaction",
+			summary: "compacted",
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Manual `/compact` with the snapcompact strategy hard-failed when the active model was text-only:

```
Warning: compaction: snapcompact needs a vision-capable model (umans-glm-5.2 is text-only)
Error: Compaction failed: snapcompact cannot run locally: umans-glm-5.2 is text-only.
```

## Root cause

Snapcompact renders conversation history as image frames that the active model reads back on subsequent turns — a text-only model cannot see those frames, so snapcompact cannot run. The manual `/compact` path (line ~9812) chose to **hard-fail** instead of falling back:

```ts
if (wantsSnapcompact && !this.model.input.includes("image")) {
    throw new Error(`snapcompact cannot run locally: ${this.model.id} is text-only.`);
}
```

Meanwhile, the **auto-compaction** path (line ~12381) already handles this gracefully — it emits a warning and falls back to LLM-backed context-full compaction.

## Fix

Mirror the auto-compaction behavior: when the active model is text-only, emit a warning and clear `snapcompactReady` so the flow falls through to `#compactWithFallbackModel` — the LLM summarization path.

The active text-only model handles text→text LLM summarization fine (snapcompact is the only path that needs image input — it renders frames). The compaction candidate chain (`#resolveCompactionModelCandidates`) also includes all configured model roles (including `vision`) as fallback candidates, so a configured vision model is tried if the active model fails.

### Context window consideration

The vision model may have a smaller context window than the default model (e.g. 262K vs 405K). This is not a concern because:
- The active text-only model is tried **first** in the candidate chain and handles LLM summarization (text→text, no images needed)
- `prepareCompaction` sizes the summary input using `keepRecentTokens` (default 20K), not the model's full context window
- The vision model is only tried if the active model has an auth failure

## Testing

- Added `agent-session-snapcompact-manual-fallback.test.ts` — verifies manual `/compact` with a text-only model falls back to LLM compaction instead of throwing
- Existing `agent-session-snapcompact-auto-fallback.test.ts` still passes (3/3 tests)
