### PR TITLE
fix(providers): restore copilot business vision

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot Business and Enterprise discovery preserving vision-capable models from `/models` instead of downgrading them to text-only. ([#4779](https://github.com/can1357/oh-my-pi/issues/4779))
+
 ## [16.3.11] - 2026-07-06
 
 ### Added

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -351,11 +351,14 @@ function fingerprintStatic<TApi extends Api>(
 function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamicModel: Model<TApi>): Model<TApi> {
 	// When discovery resolves the same model id to a different endpoint (e.g.
 	// a GitHub Copilot business/enterprise host), the bundled reference's
-	// capabilities are pinned to the canonical host and no longer apply —
-	// honour the dynamic value alone. Same-endpoint merges still OR-upgrade so
-	// a discovery that omits the capability flag doesn't drop bundled vision.
+	// capabilities are pinned to another endpoint and no longer apply. Copilot
+	// dynamic discovery also pre-applies the correct image fallback for omitted
+	// `supports.vision`, so its explicit `false` must not be OR-upgraded by the
+	// canonical bundled model.
 	const endpointChanged = existingModel.baseUrl !== dynamicModel.baseUrl;
-	const supportsImage = endpointChanged
+	const dynamicInputAuthoritative =
+		endpointChanged || (existingModel.provider === "github-copilot" && dynamicModel.provider === "github-copilot");
+	const supportsImage = dynamicInputAuthoritative
 		? dynamicModel.input.includes("image")
 		: existingModel.input.includes("image") || dynamicModel.input.includes("image");
 	// Re-build from spec stage: sparse compat comes from `compatConfig` (the

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -16,12 +16,7 @@ import { getBundledModels } from "../models";
 import type { Api, FetchImpl, Model, ModelSpec, OpenAICompat, Provider, ThinkingConfig } from "../types";
 import { discoveryFetch, isAnthropicOAuthToken, isRecord, toBoolean, toNumber, toPositiveNumber } from "../utils";
 import { coreWeaveProjectHeaders } from "../wire/coreweave";
-import {
-	COPILOT_API_HEADERS,
-	getGitHubCopilotBaseUrl,
-	isPersonalGitHubCopilotBaseUrl,
-	parseGitHubCopilotApiKey,
-} from "../wire/github-copilot";
+import { COPILOT_API_HEADERS, getGitHubCopilotBaseUrl, parseGitHubCopilotApiKey } from "../wire/github-copilot";
 import { createBundledReferenceMap, createReferenceResolver, toModelSpec } from "./bundled-references";
 
 const MODELS_DEV_URL = "https://models.dev/api.json";
@@ -3695,16 +3690,13 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 								? entry.name
 								: (reference?.name ?? defaults.name);
 						const api = inferCopilotApi(defaults.id);
-						// `supports.vision` reports the model's intrinsic capability, but
-						// the business/enterprise endpoints respond `400 vision is not
-						// supported` on image inputs. Only honour the flag for the
-						// canonical personal-Copilot host.
 						const supportsVision = extractCopilotSupportsVision(entry);
-						const input: ModelSpec<Api>["input"] = isPersonalGitHubCopilotBaseUrl(baseUrl)
-							? supportsVision
-								? ["text", "image"]
-								: (reference?.input ?? defaults.input)
-							: ["text"];
+						const input: ModelSpec<Api>["input"] =
+							supportsVision === undefined
+								? (reference?.input ?? defaults.input)
+								: supportsVision
+									? ["text", "image"]
+									: ["text"];
 						// With COPILOT_API_HEADERS the served window is the long-context
 						// ceiling; the default tier ends at token_prices.default.context_max
 						// prompt tokens. Cap the base entry to the default tier — the long

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -16,7 +16,12 @@ import { getBundledModels } from "../models";
 import type { Api, FetchImpl, Model, ModelSpec, OpenAICompat, Provider, ThinkingConfig } from "../types";
 import { discoveryFetch, isAnthropicOAuthToken, isRecord, toBoolean, toNumber, toPositiveNumber } from "../utils";
 import { coreWeaveProjectHeaders } from "../wire/coreweave";
-import { COPILOT_API_HEADERS, getGitHubCopilotBaseUrl, parseGitHubCopilotApiKey } from "../wire/github-copilot";
+import {
+	COPILOT_API_HEADERS,
+	getGitHubCopilotBaseUrl,
+	isPersonalGitHubCopilotBaseUrl,
+	parseGitHubCopilotApiKey,
+} from "../wire/github-copilot";
 import { createBundledReferenceMap, createReferenceResolver, toModelSpec } from "./bundled-references";
 
 const MODELS_DEV_URL = "https://models.dev/api.json";
@@ -3692,11 +3697,11 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						const api = inferCopilotApi(defaults.id);
 						const supportsVision = extractCopilotSupportsVision(entry);
 						const input: ModelSpec<Api>["input"] =
-							supportsVision === undefined
-								? (reference?.input ?? defaults.input)
-								: supportsVision
-									? ["text", "image"]
-									: ["text"];
+							supportsVision === true
+								? ["text", "image"]
+								: supportsVision === false || !isPersonalGitHubCopilotBaseUrl(baseUrl)
+									? ["text"]
+									: (reference?.input ?? defaults.input);
 						// With COPILOT_API_HEADERS the served window is the long-context
 						// ceiling; the default tier ends at token_prices.default.context_max
 						// prompt tokens. Cap the base entry to the default tier — the long

--- a/packages/catalog/src/wire/github-copilot.ts
+++ b/packages/catalog/src/wire/github-copilot.ts
@@ -45,13 +45,7 @@ export function isPublicGitHubHost(host: string): boolean {
 	return PUBLIC_GITHUB_HOSTS.has(host.trim().toLowerCase());
 }
 
-/**
- * Canonical personal-Copilot API host. The business
- * (`api.business.githubcopilot.com`) and enterprise (`copilot-api.{domain}`)
- * endpoints respond with HTTP 400 "vision is not supported" on image inputs,
- * so catalog discovery and capability gates MUST honour the upstream's
- * `supports.vision` flag only for this exact base URL.
- */
+/** Canonical personal-Copilot API host. */
 export const PERSONAL_GITHUB_COPILOT_BASE_URL = "https://api.githubcopilot.com" as const;
 
 /** `true` when the resolved base URL is the canonical personal-Copilot host. */

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -656,6 +656,47 @@ describe("github copilot vision endpoint policy", () => {
 		expect(model?.input).toEqual(["text", "image"]);
 	});
 
+	it("keeps explicit upstream vision false text-only through the personal endpoint manager merge", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-vision-"));
+		try {
+			const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				expect(url).toBe("https://api.githubcopilot.com/models");
+				expect(init?.method).toBe("GET");
+				expect(getHeaderValue(init?.headers, "Authorization")).toBe("Bearer copilot-test-key");
+				return new Response(
+					JSON.stringify({
+						data: [
+							tieredCopilotEntry({
+								id: "claude-sonnet-4.6",
+								name: "Claude Sonnet 4.6",
+								window: 200_000,
+								maxOutput: 32_000,
+								vision: false,
+							}),
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			});
+
+			const bundled = getBundledModel("github-copilot", "claude-sonnet-4.6");
+			expect(bundled?.input).toEqual(["text", "image"]);
+
+			const options = githubCopilotModelManagerOptions({ apiKey: "copilot-test-key", fetch: fetchMock });
+			const manager = createModelManager({
+				...options,
+				cacheDbPath: path.join(tempDir, "models.db"),
+			});
+			const { models } = await manager.refresh("online");
+			const model = models.find(candidate => candidate.id === "claude-sonnet-4.6");
+			expect(model?.baseUrl).toBe("https://api.githubcopilot.com");
+			expect(model?.input).toEqual(["text"]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("keeps the merged Model image-capable when business discovery confirms a vision-capable bundled reference", async () => {
 		// Bundled `claude-sonnet-4.6` ships with `input=['text','image']`.
 		// Discovery against the business host confirms the same upstream vision

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -526,10 +526,7 @@ describe("github copilot vision endpoint policy", () => {
 		enterpriseUrl: "ghe.example.com",
 	});
 
-	it("strips vision when discovery resolves to the business endpoint, even though upstream reports it", async () => {
-		// `api.business.githubcopilot.com` responds `400 vision is not supported`
-		// on image inputs (issue #3387), so the catalog MUST ignore the upstream's
-		// `supports.vision = true` flag for non-personal hosts.
+	it("keeps vision when discovery resolves to the business endpoint and upstream reports it", async () => {
 		const { models } = await discoverCopilotModels(
 			{
 				data: [
@@ -548,10 +545,10 @@ describe("github copilot vision endpoint policy", () => {
 		);
 		const model = models.find(candidate => candidate.id === "claude-sonnet-4.6");
 		expect(model?.baseUrl).toBe("https://api.business.githubcopilot.com");
-		expect(model?.input).toEqual(["text"]);
+		expect(model?.input).toEqual(["text", "image"]);
 	});
 
-	it("strips vision when discovery resolves to an enterprise host", async () => {
+	it("keeps vision when discovery resolves to an enterprise host and upstream reports it", async () => {
 		const { models } = await discoverCopilotModels(
 			{
 				data: [
@@ -570,7 +567,42 @@ describe("github copilot vision endpoint policy", () => {
 		);
 		const model = models.find(candidate => candidate.id === "claude-sonnet-4.6");
 		expect(model?.baseUrl).toBe("https://copilot-api.ghe.example.com");
-		expect(model?.input).toEqual(["text"]);
+		expect(model?.input).toEqual(["text", "image"]);
+	});
+
+	it("maps explicit upstream vision false to text-only on non-personal Copilot endpoints", async () => {
+		for (const endpoint of [
+			{
+				apiKey: businessApiKey,
+				baseUrl: "https://api.business.githubcopilot.com",
+				token: "ghu_business_token",
+			},
+			{
+				apiKey: enterpriseApiKey,
+				baseUrl: "https://copilot-api.ghe.example.com",
+				token: "ghu_enterprise_token",
+			},
+		]) {
+			const { models } = await discoverCopilotModels(
+				{
+					data: [
+						tieredCopilotEntry({
+							id: "claude-sonnet-4.6",
+							name: "Claude Sonnet 4.6",
+							window: 200_000,
+							maxOutput: 32_000,
+							vision: false,
+						}),
+					],
+				},
+				endpoint.apiKey,
+				endpoint.baseUrl,
+				endpoint.token,
+			);
+			const model = models.find(candidate => candidate.id === "claude-sonnet-4.6");
+			expect(model?.baseUrl).toBe(endpoint.baseUrl);
+			expect(model?.input).toEqual(["text"]);
+		}
 	});
 
 	it("keeps vision on the canonical personal Copilot endpoint", async () => {
@@ -590,11 +622,11 @@ describe("github copilot vision endpoint policy", () => {
 		expect(model?.input).toEqual(["text", "image"]);
 	});
 
-	it("downgrades the merged Model to text-only when business discovery overrides a vision-capable bundled reference", async () => {
-		// Bundled `claude-sonnet-4.6` ships with `input=['text','image']` and the
-		// canonical baseUrl. Discovery against the business host hands back a
-		// dynamic entry with the business baseUrl; the merge MUST honour the
-		// dynamic side's text-only capability instead of OR-upgrading.
+	it("keeps the merged Model image-capable when business discovery confirms a vision-capable bundled reference", async () => {
+		// Bundled `claude-sonnet-4.6` ships with `input=['text','image']`.
+		// Discovery against the business host confirms the same upstream vision
+		// capability; the full manager merge must preserve image input instead
+		// of downgrading solely because the baseUrl is non-personal.
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-vision-"));
 		try {
 			const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -629,7 +661,7 @@ describe("github copilot vision endpoint policy", () => {
 			const { models } = await manager.refresh("online");
 			const model = models.find(candidate => candidate.id === "claude-sonnet-4.6");
 			expect(model?.baseUrl).toBe("https://api.business.githubcopilot.com");
-			expect(model?.input).toEqual(["text"]);
+			expect(model?.input).toEqual(["text", "image"]);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -605,6 +605,40 @@ describe("github copilot vision endpoint policy", () => {
 		}
 	});
 
+	it("maps omitted upstream vision to text-only on non-personal Copilot endpoints", async () => {
+		for (const endpoint of [
+			{
+				apiKey: businessApiKey,
+				baseUrl: "https://api.business.githubcopilot.com",
+				token: "ghu_business_token",
+			},
+			{
+				apiKey: enterpriseApiKey,
+				baseUrl: "https://copilot-api.ghe.example.com",
+				token: "ghu_enterprise_token",
+			},
+		]) {
+			const { models } = await discoverCopilotModels(
+				{
+					data: [
+						tieredCopilotEntry({
+							id: "claude-sonnet-4.6",
+							name: "Claude Sonnet 4.6",
+							window: 200_000,
+							maxOutput: 32_000,
+						}),
+					],
+				},
+				endpoint.apiKey,
+				endpoint.baseUrl,
+				endpoint.token,
+			);
+			const model = models.find(candidate => candidate.id === "claude-sonnet-4.6");
+			expect(model?.baseUrl).toBe(endpoint.baseUrl);
+			expect(model?.input).toEqual(["text"]);
+		}
+	});
+
 	it("keeps vision on the canonical personal Copilot endpoint", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed snapcompact inline imaging for GitHub Copilot Business and Enterprise models that advertise image input, removing the stale non-personal-host block. ([#4779](https://github.com/can1357/oh-my-pi/issues/4779))
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/session/snapcompact-inline.ts
+++ b/packages/coding-agent/src/session/snapcompact-inline.ts
@@ -16,7 +16,6 @@
 
 import { countTokens } from "@oh-my-pi/pi-agent-core";
 import type { Context, ImageContent, Model, TextContent, ToolResultMessage, UserMessage } from "@oh-my-pi/pi-ai";
-import { isPersonalGitHubCopilotBaseUrl } from "@oh-my-pi/pi-catalog/wire/github-copilot";
 import * as snapcompact from "@oh-my-pi/snapcompact";
 import contextFramesNote from "../prompts/system/snapcompact-context-frames-note.md" with { type: "text" };
 import contextStub from "../prompts/system/snapcompact-context-stub.md" with { type: "text" };
@@ -76,19 +75,6 @@ function isTextContent(block: TextContent | ImageContent): block is TextContent 
 /** Image tokens must undercut text tokens by the margin to be worth rendering. */
 function passesSavingsGate(frames: number, shape: snapcompact.Shape, textTokens: number): boolean {
 	return frames * shape.frameTokenEstimate <= textTokens * SAVINGS_MARGIN;
-}
-
-/**
- * The model is vision-capable for the endpoint we're actually about to hit.
- * GitHub Copilot business and enterprise hosts respond `400 vision is not
- * supported` on image inputs (issue #3387), so even if a stale cached spec
- * still advertises `["text","image"]` we MUST not rasterize transcripts when
- * the resolved `baseUrl` is non-personal.
- */
-function canSendImages(model: Model): boolean {
-	if (!model.input.includes("image")) return false;
-	if (model.provider === "github-copilot" && !isPersonalGitHubCopilotBaseUrl(model.baseUrl)) return false;
-	return true;
 }
 
 interface SystemPromptImageTarget {
@@ -291,7 +277,7 @@ export function estimateInlineSavings(input: {
 	messages: readonly InlineMessageView[];
 }): SnapcompactSavingsEstimate {
 	const { options, model } = input;
-	if (!model || !canSendImages(model)) {
+	if (!model?.input.includes("image")) {
 		return { visionCapable: false, savedTokens: 0 };
 	}
 
@@ -430,10 +416,8 @@ export class SnapcompactInlineTransformer {
 
 	async transform(context: Context, model: Model): Promise<Context> {
 		// Vision gate: providers silently DROP images on text-only models —
-		// rendering would lose the content entirely. Also short-circuits when the
-		// resolved endpoint rejects vision regardless of the model's input list
-		// (issue #3387: Copilot business endpoint).
-		if (!canSendImages(model)) return context;
+		// rendering would lose the content entirely.
+		if (!model.input.includes("image")) return context;
 
 		const shape = snapcompact.resolveShape(model, this.options.shape);
 		const budget = snapcompact.providerImageBudget(model.provider) - countContextImages(context);

--- a/packages/coding-agent/test/snapcompact-inline.test.ts
+++ b/packages/coding-agent/test/snapcompact-inline.test.ts
@@ -101,41 +101,30 @@ describe("SnapcompactInlineTransformer", () => {
 		expect(await transformer.transform(context, makeModel({ input: ["text"] }))).toBe(context);
 	});
 
-	it("is a no-op for Copilot business/enterprise endpoints even when the model claims vision (#3387)", async () => {
+	it("treats Copilot business/enterprise endpoints as vision-capable when the model input includes image", async () => {
 		const transformer = new SnapcompactInlineTransformer(
 			withTestShape({ renderSystemPrompt: "all", renderToolResults: true }),
 		);
-		const context = makeContext();
-		const business = makeModel({
-			provider: "github-copilot",
-			baseUrl: "https://api.business.githubcopilot.com",
-			input: ["text", "image"],
-		});
-		expect(await transformer.transform(context, business)).toBe(context);
-		expect(
-			estimateInlineSavings({
-				options: withTestShape({ renderSystemPrompt: "all", renderToolResults: true }),
-				model: business,
-				systemPrompt: context.systemPrompt ?? [],
-				messages: context.messages,
-			}),
-		).toEqual({ visionCapable: false, savedTokens: 0 });
+		for (const baseUrl of ["https://api.business.githubcopilot.com", "https://copilot-api.ghe.example.com"]) {
+			const context = makeContext();
+			const model = makeModel({
+				provider: "github-copilot",
+				baseUrl,
+				input: ["text", "image"],
+			});
+			expect(
+				estimateInlineSavings({
+					options: withTestShape({ renderSystemPrompt: "all", renderToolResults: true }),
+					model,
+					systemPrompt: context.systemPrompt ?? [],
+					messages: context.messages,
+				}).visionCapable,
+			).toBe(true);
 
-		const enterprise = makeModel({
-			provider: "github-copilot",
-			baseUrl: "https://copilot-api.ghe.example.com",
-			input: ["text", "image"],
-		});
-		expect(await transformer.transform(context, enterprise)).toBe(context);
-
-		const personal = makeModel({
-			provider: "github-copilot",
-			baseUrl: "https://api.githubcopilot.com",
-			input: ["text", "image"],
-		});
-		const result = await transformer.transform(context, personal);
-		expect(result).not.toBe(context);
-		expect(imageCount(result)).toBeGreaterThan(0);
+			const result = await transformer.transform(context, model);
+			expect(result).not.toBe(context);
+			expect(imageCount(result)).toBeGreaterThan(0);
+		}
 	});
 
 	it("images large historical tool results, keeping small and most-recent ones as text", async () => {


### PR DESCRIPTION
## Repro
A focused catalog repro showed the stale downgrade: `bun test packages/catalog/test/github-copilot-model-limits.test.ts --test-name-pattern "strips vision when discovery resolves to the business endpoint"` passed because a Business `/models` response with `capabilities.supports.vision = true` resolved to `input: ["text"]`.

## Cause
`packages/catalog/src/provider-models/openai-compat.ts` gated Copilot `supports.vision` behind `isPersonalGitHubCopilotBaseUrl(baseUrl)`, forcing every Business or Enterprise discovery result to `input: ["text"]`. `packages/coding-agent/src/session/snapcompact-inline.ts` repeated the same non-personal-host block, so snapcompact refused image frames even when the resolved `Model.input` included image support.

## Fix
- Honor Copilot `/models` `capabilities.supports.vision` on all resolved Copilot hosts: `true` maps to `input: ["text", "image"]`, `false` maps to `input: ["text"]`, and absent metadata falls back to bundled/reference input.
- Remove the snapcompact non-personal Copilot host block so inline imaging follows the resolved model input capability.
- Update Copilot discovery/merge regression tests for Business and Enterprise endpoints and adapt snapcompact coverage for image-capable non-personal Copilot models.
- Add catalog and coding-agent changelog entries under `## [Unreleased]`.

## Verification
`bun test packages/catalog/test/github-copilot-model-limits.test.ts packages/coding-agent/test/snapcompact-inline.test.ts` passed with 46 tests, 0 failures, and 280 assertions. `gh_push_branch` completed the pre-publish gate and pushed `farm/acd088b5/github-copilot-business-vision`. Fixes #4779