### PR TITLE
fix(tui): honor /move overlay width

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed the `/move` directory picker drawing a 68-column frame inside wider full-width overlays. ([#5067](https://github.com/can1357/oh-my-pi/issues/5067))
 - Fixed Go debug launches falling back to native debuggers when Delve is unavailable; nested modules and `go.work` workspaces now resolve local Delve adapters before PATH, newly installed adapters are detected without restart, and missing adapter errors include install or configuration guidance. ([#5037](https://github.com/can1357/oh-my-pi/issues/5037))
 - Fixed a memory leak (large retained JavaScriptCore heaps) in the TUI during session transcript rebuilds and refreshes by properly handling snapcompact archive image frames.
 - Fixed a crash in interactive TUI sessions (Cannot set cwd while another same-realm JS runtime is running) when the JS evaluation worker falls back to the in-process inline path.

--- a/packages/coding-agent/src/modes/components/__tests__/move-overlay.test.ts
+++ b/packages/coding-agent/src/modes/components/__tests__/move-overlay.test.ts
@@ -3,12 +3,14 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { visibleWidth } from "@oh-my-pi/pi-tui";
 import { Settings } from "../../../config/settings";
 import { getThemeByName, setThemeInstance, type Theme } from "../../theme/theme";
 import { MoveOverlay, type MoveOverlayResult, resolveExistingDirectory, resolveMovePath } from "../move-overlay";
 
 // Strip SGR colors so assertions see visible text only.
-const strip = (lines: readonly string[]): string => lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
+const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, "");
+const strip = (lines: readonly string[]): string => lines.map(stripAnsi).join("\n");
 
 describe("resolveMovePath", () => {
 	it("expands ~ to homedir", () => {
@@ -80,6 +82,19 @@ describe("MoveOverlay", () => {
 		const text = strip(overlay.render(80));
 		expect(text).toContain("Move to directory");
 		expect(text).toContain("Path:");
+	});
+
+	it("renders every frame row at the assigned overlay width", () => {
+		const overlay = new MoveOverlay(cwd, () => {});
+		const lines = overlay.render(72);
+		const plainLines = lines.map(stripAnsi);
+
+		expect(lines.map(line => visibleWidth(line))).toEqual(Array(lines.length).fill(72));
+		expect(plainLines[0]!.endsWith(uiTheme.boxRound.topRight)).toBe(true);
+		expect(plainLines.at(-1)!.endsWith(uiTheme.boxRound.bottomRight)).toBe(true);
+		for (const line of plainLines.slice(1, -1)) {
+			expect(line.endsWith(uiTheme.boxRound.vertical)).toBe(true);
+		}
 	});
 
 	it("lists child directories (excluding hidden and files) on empty input", () => {

--- a/packages/coding-agent/src/modes/components/move-overlay.ts
+++ b/packages/coding-agent/src/modes/components/move-overlay.ts
@@ -25,7 +25,6 @@ interface DirEntry {
 }
 
 const MAX_RESULTS = 15;
-const OVERLAY_WIDTH = 68;
 
 /** TTL for the directory listing cache (ms). */
 const DIR_CACHE_TTL = 500;
@@ -230,8 +229,8 @@ export class MoveOverlay implements Component, Focusable {
 		}
 	}
 
-	render(_width: number): readonly string[] {
-		const w = OVERLAY_WIDTH;
+	render(width: number): readonly string[] {
+		const w = width;
 		const lines: string[] = [];
 
 		lines.push(topBorder(w, "Move to directory"));


### PR DESCRIPTION
## Repro
A minimal script rendered `MoveOverlay.render(72)` and measured each returned row with `visibleWidth`; before the fix, `bun .wt/repro-move-overlay-width.ts` failed with `renderedWidths:[68,68,68,68,68,68,68]`, demonstrating the 4-column right-border gap in a 72-column overlay.

## Cause
`packages/coding-agent/src/modes/components/move-overlay.ts` ignored the `Component.render(width)` contract by discarding the supplied width and using the fixed `OVERLAY_WIDTH` value of 68. The `/move` command mounts this component through `showHookCustom(..., { overlay: true })`, and `packages/coding-agent/src/modes/controllers/extension-ui-controller.ts` asks TUI for `width: "100%"`, so the compositor reserved the full terminal width while the component drew a shorter frame.

## Fix
- Removed the fixed 68-column `/move` overlay width and passed the render width through to the shared overlay-box frame helpers.
- Added a regression test that renders `MoveOverlay` at 72 columns, checks every row's visible width, and verifies the top, bottom, and content right borders terminate at the assigned width.
- Added a `packages/coding-agent` changelog entry for the TUI rendering fix.

## Verification
`bun .wt/repro-move-overlay-width.ts` now prints `renderedWidths:[72,72,72,72,72,72,72]`; `bun test packages/coding-agent/src/modes/components/__tests__/move-overlay.test.ts` passed 19 tests; `gh_push_branch` completed the pre-publish `bun run fix` and `bun check` gate before pushing. Fixes #5067