### PR TITLE
fix(catalog): parse version-first Claude ids

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed SAP AI Core Claude ids in version-first order (`anthropic--claude-4.8-opus`) parsing as unknown, restoring Anthropic adaptive thinking metadata and capability gates. ([#5069](https://github.com/can1357/oh-my-pi/issues/5069))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/catalog/src/identity/classify.ts
+++ b/packages/catalog/src/identity/classify.ts
@@ -106,15 +106,20 @@ export const parseGeminiModel = parser((modelId): GeminiModel | null => {
 });
 
 export const parseAnthropicModel = parser((modelId): AnthropicModel | null => {
-	const match = /claude-(opus|sonnet|fable|mythos)-(\d{1,2}(?:[.-]\d{1,2}){0,2})\b/.exec(modelId);
-	if (!match) {
+	const kindFirst = /claude-(opus|sonnet|fable|mythos)-(\d{1,2}(?:[.-]\d{1,2}){0,2})\b/.exec(modelId);
+	const versionFirst = kindFirst
+		? null
+		: /claude-(\d{1,2}(?:[.-]\d{1,2}){0,2})-(opus|sonnet|fable|mythos)\b/.exec(modelId);
+	const kind = kindFirst?.[1] ?? versionFirst?.[2];
+	const versionInput = kindFirst?.[2] ?? versionFirst?.[1];
+	if (!kind || !versionInput) {
 		return null;
 	}
-	const version = parseSemVer(match[2]);
+	const version = parseSemVer(versionInput);
 	if (!version) {
 		return null;
 	}
-	return { family: "anthropic", kind: match[1] as AnthropicKind, version };
+	return { family: "anthropic", kind: kind as AnthropicKind, version };
 });
 
 export const parseOpenAIModel = parser((modelId): OpenAIModel | null => {

--- a/packages/catalog/test/identity-family.test.ts
+++ b/packages/catalog/test/identity-family.test.ts
@@ -12,6 +12,7 @@ import {
 	isOpenAIModelId,
 	isReasoningGlmModelId,
 	modelFamilyToken,
+	parseAnthropicModel,
 	supportsAdaptiveThinkingDisplay,
 	supportsMidConversationSystemMessages,
 } from "@oh-my-pi/pi-catalog/identity";
@@ -61,6 +62,22 @@ describe("isClaudeModelId", () => {
 	});
 });
 
+describe("parseAnthropicModel", () => {
+	test("parses SAP hai-proxy version-first Claude ids without accepting Haiku", () => {
+		expect(parseAnthropicModel("anthropic--claude-4.8-opus")).toEqual({
+			family: "anthropic",
+			kind: "opus",
+			version: { major: 4, minor: 8, patch: 0 },
+		});
+		expect(parseAnthropicModel("anthropic--claude-4.6-opus")).toEqual({
+			family: "anthropic",
+			kind: "opus",
+			version: { major: 4, minor: 6, patch: 0 },
+		});
+		expect(parseAnthropicModel("anthropic--claude-4.8-haiku")).toBeNull();
+	});
+});
+
 describe("supportsAdaptiveThinkingDisplay", () => {
 	test("allows Claude Fable 5, Opus 4.7 or newer, and Sonnet 5 or newer only", () => {
 		expect(supportsAdaptiveThinkingDisplay("claude-fable-5")).toBe(true);
@@ -71,6 +88,8 @@ describe("supportsAdaptiveThinkingDisplay", () => {
 		// Dotted and dashed version separators are equivalent.
 		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.7")).toBe(true);
 		expect(supportsAdaptiveThinkingDisplay("anthropic/claude-opus-4.8")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("anthropic--claude-4.8-opus")).toBe(true);
+		expect(supportsAdaptiveThinkingDisplay("anthropic--claude-4.6-opus")).toBe(false);
 		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-6")).toBe(false);
 		expect(supportsAdaptiveThinkingDisplay("claude-opus-4.6")).toBe(false);
 		expect(supportsAdaptiveThinkingDisplay("claude-opus-4-20250514")).toBe(false);
@@ -83,6 +102,7 @@ describe("hasOpus47ApiRestrictions", () => {
 		expect(hasOpus47ApiRestrictions("claude-fable-5")).toBe(true);
 		expect(hasOpus47ApiRestrictions("claude-opus-4-7")).toBe(true);
 		expect(hasOpus47ApiRestrictions("claude-opus-4.8")).toBe(true);
+		expect(hasOpus47ApiRestrictions("anthropic--claude-4.7-opus")).toBe(true);
 		expect(hasOpus47ApiRestrictions("claude-sonnet-5")).toBe(true);
 		expect(hasOpus47ApiRestrictions("us.anthropic.claude-sonnet-5")).toBe(true);
 		expect(hasOpus47ApiRestrictions("claude-opus-4-6")).toBe(false);
@@ -97,6 +117,8 @@ describe("supportsMidConversationSystemMessages", () => {
 		expect(supportsMidConversationSystemMessages("claude-opus-4-8")).toBe(true);
 		expect(supportsMidConversationSystemMessages("claude-sonnet-5")).toBe(true);
 		expect(supportsMidConversationSystemMessages("us.anthropic.claude-sonnet-5")).toBe(true);
+		expect(supportsMidConversationSystemMessages("anthropic--claude-4.8-opus")).toBe(true);
+		expect(supportsMidConversationSystemMessages("anthropic--claude-4.7-opus")).toBe(false);
 		expect(supportsMidConversationSystemMessages("claude-opus-4-7")).toBe(false);
 		expect(supportsMidConversationSystemMessages("claude-sonnet-4-6")).toBe(false);
 	});

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -228,6 +228,30 @@ describe("model thinking derivation", () => {
 		expect(openRouterAnthropic.thinking?.effortMap).toBeUndefined();
 	});
 
+	it("derives Anthropic adaptive thinking for SAP hai-proxy version-first Claude ids", () => {
+		const opus48 = createModel({
+			id: "anthropic--claude-4.8-opus",
+			api: "anthropic-messages",
+			provider: "custom",
+		});
+		const opus46 = createModel({
+			id: "anthropic--claude-4.6-opus",
+			api: "anthropic-messages",
+			provider: "custom",
+		});
+
+		expect(opus48.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+			supportsDisplay: true,
+		});
+		expect(getSupportedEfforts(opus48)).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max]);
+		expect(opus46.thinking).toEqual({
+			mode: "anthropic-adaptive",
+			efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.Max],
+		});
+	});
+
 	it("maps GLM-5.2 reasoning effort per host dialect", () => {
 		const zai = createModel({
 			id: "glm-5.2",


### PR DESCRIPTION
## Repro
The parser repro imports `parseAnthropicModel` from `packages/catalog/src/identity/classify.ts` and compares `claude-opus-4-8` with `anthropic--claude-4.8-opus`; before the fix, the canonical id parsed as Anthropic Opus 4.8 while the SAP hai-proxy id returned `null`, causing downstream thinking inference to fall back to the budget path.

## Cause
`parseAnthropicModel` in `packages/catalog/src/identity/classify.ts` only matched `claude-<kind>-<version>` ids, so `bareModelId` left `anthropic--claude-4.8-opus` intact and the classifier never recognized its `claude-<version>-<kind>` segment. `parseKnownModel`, `supportsAdaptiveThinkingDisplay`, `supportsMidConversationSystemMessages`, and Anthropic thinking derivation therefore saw the model as unknown instead of Anthropic Opus 4.8.

## Fix
- Added version-first Claude parsing to `parseAnthropicModel` while preserving the existing kind-first format and unsupported Haiku behavior.
- Added identity regression coverage for SAP hai-proxy ids across parser and capability predicates.
- Added model-thinking regression coverage proving SAP-shaped Opus 4.8 and 4.6 derive `anthropic-adaptive` mode with the expected effort ladders.
- Added the catalog changelog entry for #5069.

## Verification
`bun test packages/catalog/test/identity-family.test.ts packages/catalog/test/model-thinking.test.ts` passed: 56 tests, 301 expectations. `bun run check` in `packages/catalog` passed. `gh_push_branch` pre-publish gate passed and pushed the branch. Fixes #5069