### PR TITLE
fix(coding-agent): prevent memory URL writes from leaking to cwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `write` treating read-only internal URLs like `memory://root/memory_summary.md` as project-relative filesystem paths, prevented leaks such as `{cwd}/memory:/root/memory_summary.md`, and made `memory://root` prefer the calling session's cwd-specific memory root when multiple agents are live. ([#5075](https://github.com/can1357/oh-my-pi/issues/5075))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -6,7 +6,7 @@ import { getMnemopiSessionState, type MnemopiScopedMemoryHit, type MnemopiSessio
 import { AgentRegistry } from "../registry/agent-registry";
 import { buildDirectoryResource } from "./filesystem-resource";
 import { validateRelativePath } from "./skill-protocol";
-import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 const DEFAULT_MEMORY_FILE = "memory_summary.md";
 const MEMORY_NAMESPACE = "root";
@@ -26,6 +26,13 @@ export function memoryRootsFromRegistry(): string[] {
 		if (root && !roots.includes(root)) roots.push(root);
 	}
 	return roots;
+}
+
+function memoryRootsForContext(context?: ResolveContext): string[] {
+	const roots = memoryRootsFromRegistry();
+	if (!context?.cwd) return roots;
+	const callerRoot = getMemoryRoot(getAgentDir(), context.cwd);
+	return [callerRoot, ...roots.filter(root => root !== callerRoot)];
 }
 
 function ensureWithinRoot(targetPath: string, rootPath: string): void {
@@ -197,15 +204,15 @@ function renderMnemopiMemory(url: InternalUrl, hit: MnemopiScopedMemoryHit): Int
 /**
  * Protocol handler for memory:// URLs.
  *
- * Walks every active session's memory root. Worktree-based subagents have
- * their own root; first one containing the file wins. Parent and subagent
- * sharing a cwd see the same file regardless of order.
+ * Resolves the caller cwd's memory root first, then walks other active
+ * sessions' roots. Parent and subagent sharing a cwd see the same file
+ * regardless of registry order.
  */
 export class MemoryProtocolHandler implements ProtocolHandler {
 	readonly scheme = "memory";
 	readonly immutable = true;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
 		const namespace = url.rawHost || url.hostname;
 		if (!namespace) {
 			throw new Error("memory:// URL requires a namespace: memory://root or memory://<memory-id>");
@@ -230,7 +237,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 			);
 		}
 
-		const roots = memoryRootsFromRegistry();
+		const roots = memoryRootsForContext(context);
 		if (roots.length === 0) {
 			throw new Error(
 				"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",
@@ -259,9 +266,9 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 		throw new Error(`Memory file not found: ${url.href}`);
 	}
 
-	async complete(): Promise<UrlCompletion[]> {
+	async complete(_query?: string, context?: ResolveContext): Promise<UrlCompletion[]> {
 		const completions: UrlCompletion[] = [];
-		if (memoryRootsFromRegistry().length > 0) {
+		if (memoryRootsForContext(context).length > 0) {
 			completions.push({ value: MEMORY_NAMESPACE, description: "Project memory summary" });
 		}
 		if (mnemopiSessionStatesFromRegistry().length > 0) {

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -830,9 +830,13 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 					}
 					return { content: [{ type: "text", text: resultText }], details: {} };
 				}
-				// Schemes without a `write` hook fall through to existing logic
-				// (local:// resolves to a backing file via plan-mode-guard) or are
-				// rejected downstream when no backing file exists.
+				if (scheme !== "local") {
+					throw new ToolError(
+						`${scheme}:// URLs are read-only for write; use the protocol-specific tool for mutations.`,
+					);
+				}
+				// local:// is backed by the session-local artifact sandbox and is
+				// resolved by resolvePlanPath below so write/read share the same root.
 			}
 
 			const conflictUri = parseConflictUri(path);

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -92,6 +92,67 @@ describe("MemoryProtocolHandler", () => {
 		});
 	});
 
+	it("prefers the caller cwd memory root over earlier registered sessions", async () => {
+		const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-protocol-"));
+		const previousAgentDir = getAgentDir();
+		try {
+			const agentDir = path.join(cleanupRoot, "agent");
+			await fs.mkdir(agentDir, { recursive: true });
+			setAgentDir(agentDir);
+
+			const firstCwd = path.join(cleanupRoot, "project-a");
+			const secondCwd = path.join(cleanupRoot, "project-b");
+			await fs.mkdir(firstCwd, { recursive: true });
+			await fs.mkdir(secondCwd, { recursive: true });
+
+			const firstMemoryRoot = getMemoryRoot(agentDir, firstCwd);
+			const secondMemoryRoot = getMemoryRoot(agentDir, secondCwd);
+			await fs.mkdir(firstMemoryRoot, { recursive: true });
+			await fs.mkdir(secondMemoryRoot, { recursive: true });
+
+			await Bun.write(path.join(firstMemoryRoot, "memory_summary.md"), "first session summary");
+			const secondSummaryPath = path.join(secondMemoryRoot, "memory_summary.md");
+			await Bun.write(secondSummaryPath, "second session summary");
+
+			AgentRegistry.global().register({
+				id: "test-first",
+				displayName: "test first",
+				kind: "main",
+				session: {
+					sessionManager: {
+						getCwd: () => firstCwd,
+						getArtifactsDir: () => null,
+						getSessionId: () => "test-first",
+					},
+				} as unknown as AgentSession,
+				sessionFile: null,
+			});
+			AgentRegistry.global().register({
+				id: "test-second",
+				displayName: "test second",
+				kind: "main",
+				session: {
+					sessionManager: {
+						getCwd: () => secondCwd,
+						getArtifactsDir: () => null,
+						getSessionId: () => "test-second",
+					},
+				} as unknown as AgentSession,
+				sessionFile: null,
+			});
+
+			const resource = await InternalUrlRouter.instance().resolve("memory://root/memory_summary.md", {
+				cwd: secondCwd,
+			});
+
+			expect(resource.content).toBe("second session summary");
+			expect(resource.sourcePath).toBe(await fs.realpath(secondSummaryPath));
+		} finally {
+			setAgentDir(previousAgentDir);
+			await removeWithRetries(cleanupRoot);
+		}
+	});
+
 	it("throws for unknown memory namespace when no mnemopi backend is active", async () => {
 		await withMemoryFixture(async () => {
 			const router = InternalUrlRouter.instance();

--- a/packages/coding-agent/test/write-acp-fs.test.ts
+++ b/packages/coding-agent/test/write-acp-fs.test.ts
@@ -164,4 +164,22 @@ describe("write tool ACP fs routing", () => {
 			).text(),
 		).toBe(scratchContent);
 	});
+
+	it("rejects read-only internal URLs without creating scheme-looking paths on disk", async () => {
+		const targetPath = "memory://root/memory_summary.md";
+		const leakedPath = path.join(tmpDir, "memory:/root/memory_summary.md");
+		const session = createSession(tmpDir);
+		const tool = new WriteTool(session);
+
+		let rejection: unknown;
+		try {
+			await tool.execute("call-memory", { path: targetPath, content: "memory summary\n" });
+		} catch (error) {
+			rejection = error;
+		}
+
+		expect(await Bun.file(leakedPath).exists()).toBe(false);
+		if (!(rejection instanceof Error)) throw new Error("Expected memory:// write to reject");
+		expect(rejection.message).toContain("memory:// URLs are read-only for write");
+	});
 });


### PR DESCRIPTION
## Repro
Writing through the coding-agent `write` tool with `path: "memory://root/memory_summary.md"` reproduced the leak: before the fix, `WriteTool.execute` reported success and created `{cwd}/memory:/root/memory_summary.md` containing the supplied content.

## Cause
`packages/coding-agent/src/tools/write.ts` only dispatched internal URL writes when a protocol handler exposed `write()`. Registered schemes without a write hook then fell through to the normal filesystem path resolver, and `resolvePlanPath()` treated `memory://root/memory_summary.md` as a cwd-relative path after URL normalization.

## Fix
- Reject registered read-only internal URL schemes in `WriteTool.execute` before archive/sqlite/filesystem fallback.
- Keep `local://` on the existing session-artifact filesystem path because `resolvePlanPath()` intentionally backs it with the local sandbox.
- Add a regression test proving `memory://root/memory_summary.md` rejects and does not create `{cwd}/memory:/root/memory_summary.md`.
- Add the coding-agent changelog entry for #5075.

## Verification
Reproduced before the fix with a direct `WriteTool.execute` harness: result text showed `Successfully wrote 15 bytes to memory:/root/memory_summary.md`, and `{cwd}/memory:/root/memory_summary.md` existed with the supplied content. After the fix, the same harness rejects with `memory:// URLs are read-only for write` and the leaked path does not exist. Ran `bun test packages/coding-agent/test/write-acp-fs.test.ts`: 5 pass, 0 fail, 13 expect() calls. Fixes #5075