### PR TITLE
fix(agent): isolate memory root resolution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `memory://root` resolution leaking between live agents with different working directories by resolving file-backed memory roots from the calling session cwd before falling back to the global session registry. ([#5079](https://github.com/can1357/oh-my-pi/issues/5079))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -6,7 +6,7 @@ import { getMnemopiSessionState, type MnemopiScopedMemoryHit, type MnemopiSessio
 import { AgentRegistry } from "../registry/agent-registry";
 import { buildDirectoryResource } from "./filesystem-resource";
 import { validateRelativePath } from "./skill-protocol";
-import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 const DEFAULT_MEMORY_FILE = "memory_summary.md";
 const MEMORY_NAMESPACE = "root";
@@ -26,6 +26,11 @@ export function memoryRootsFromRegistry(): string[] {
 		if (root && !roots.includes(root)) roots.push(root);
 	}
 	return roots;
+}
+
+function memoryRootsForContext(context?: ResolveContext): string[] {
+	if (context?.cwd) return [getMemoryRoot(getAgentDir(), context.cwd)];
+	return memoryRootsFromRegistry();
 }
 
 function ensureWithinRoot(targetPath: string, rootPath: string): void {
@@ -196,16 +201,15 @@ function renderMnemopiMemory(url: InternalUrl, hit: MnemopiScopedMemoryHit): Int
 
 /**
  * Protocol handler for memory:// URLs.
- *
- * Walks every active session's memory root. Worktree-based subagents have
- * their own root; first one containing the file wins. Parent and subagent
- * sharing a cwd see the same file regardless of order.
+ * Resolves file-backed roots against the calling session cwd when provided.
+ * Contextless callers fall back to the live-session registry for legacy
+ * cross-session lookups.
  */
 export class MemoryProtocolHandler implements ProtocolHandler {
 	readonly scheme = "memory";
 	readonly immutable = true;
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
 		const namespace = url.rawHost || url.hostname;
 		if (!namespace) {
 			throw new Error("memory:// URL requires a namespace: memory://root or memory://<memory-id>");
@@ -230,7 +234,7 @@ export class MemoryProtocolHandler implements ProtocolHandler {
 			);
 		}
 
-		const roots = memoryRootsFromRegistry();
+		const roots = memoryRootsForContext(context);
 		if (roots.length === 0) {
 			throw new Error(
 				"Memory artifacts are not available for this project yet. Run a session with memories enabled first.",

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -27,6 +27,7 @@ export interface InternalUrlExpansionOptions {
 	noEscape?: boolean;
 	internalRouter?: InternalUrlResolver;
 	localOptions?: LocalProtocolOptions;
+	cwd?: string;
 	ensureLocalParentDirs?: boolean;
 }
 
@@ -175,6 +176,7 @@ async function resolveInternalUrlToPath(
 	internalRouter?: InternalUrlResolver,
 	localOptions?: LocalProtocolOptions,
 	ensureLocalParentDirs?: boolean,
+	cwd?: string,
 ): Promise<string> {
 	const url = normalizeLocalScheme(rawUrl);
 	const scheme = extractScheme(url);
@@ -208,7 +210,7 @@ async function resolveInternalUrlToPath(
 
 	let resource: InternalResource;
 	try {
-		resource = await internalRouter.resolve(url, { pathOnly: true });
+		resource = await internalRouter.resolve(url, { cwd, pathOnly: true });
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new ToolError(`Failed to resolve ${scheme}:// URL in bash command: ${url}\n${message}`);
@@ -268,6 +270,7 @@ export async function expandInternalUrls(command: string, options: InternalUrlEx
 				options.internalRouter,
 				options.localOptions,
 				options.ensureLocalParentDirs,
+				options.cwd,
 			);
 		} catch {
 			continue;

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -741,6 +741,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		const internalUrlOptions: InternalUrlExpansionOptions = {
 			skills: this.session.skills ?? [],
 			internalRouter: InternalUrlRouter.instance(),
+			cwd: this.session.cwd,
 			localOptions: {
 				getArtifactsDir: this.session.getArtifactsDir,
 				getSessionId: this.session.getSessionId,

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -78,6 +78,66 @@ describe("MemoryProtocolHandler", () => {
 		});
 	});
 
+	it("resolves memory://root against the caller cwd when multiple sessions are live", async () => {
+		const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-protocol-isolation-"));
+		const previousAgentDir = getAgentDir();
+		try {
+			const agentDir = path.join(cleanupRoot, "agent");
+			setAgentDir(agentDir);
+
+			const firstCwd = path.join(cleanupRoot, "first-project");
+			const secondCwd = path.join(cleanupRoot, "second-project");
+			await fs.mkdir(firstCwd, { recursive: true });
+			await fs.mkdir(secondCwd, { recursive: true });
+
+			const firstMemoryRoot = getMemoryRoot(agentDir, firstCwd);
+			const secondMemoryRoot = getMemoryRoot(agentDir, secondCwd);
+			await fs.mkdir(firstMemoryRoot, { recursive: true });
+			await fs.mkdir(secondMemoryRoot, { recursive: true });
+
+			const firstSummary = "first registered session summary";
+			const secondSummary = "second session cwd summary";
+			await Bun.write(path.join(firstMemoryRoot, "memory_summary.md"), firstSummary);
+			await Bun.write(path.join(secondMemoryRoot, "memory_summary.md"), secondSummary);
+
+			AgentRegistry.global().register({
+				id: "first-session",
+				displayName: "first-session",
+				kind: "main",
+				session: {
+					sessionManager: {
+						getCwd: () => firstCwd,
+						getArtifactsDir: () => null,
+						getSessionId: () => "first-session",
+					},
+				} as unknown as AgentSession,
+				sessionFile: null,
+			});
+			AgentRegistry.global().register({
+				id: "second-session",
+				displayName: "second-session",
+				kind: "main",
+				session: {
+					sessionManager: {
+						getCwd: () => secondCwd,
+						getArtifactsDir: () => null,
+						getSessionId: () => "second-session",
+					},
+				} as unknown as AgentSession,
+				sessionFile: null,
+			});
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root", { cwd: secondCwd });
+
+			expect(resource.content).toBe(secondSummary);
+			expect(resource.content).not.toBe(firstSummary);
+		} finally {
+			setAgentDir(previousAgentDir);
+			await removeWithRetries(cleanupRoot);
+		}
+	});
+
 	it("resolves memory://root/<path> within memory root", async () => {
 		await withMemoryFixture(async ({ memoryRoot }) => {
 			const skillPath = path.join(memoryRoot, "skills", "demo", "SKILL.md");

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
-import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { type ResolveContext, resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { expandInternalUrls, expandSkillUrls } from "@oh-my-pi/pi-coding-agent/tools/bash-skill-urls";
 import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 
@@ -24,6 +24,7 @@ function createInternalRouter(resources: Record<string, { sourcePath?: string; e
 	canHandle: (input: string) => boolean;
 	resolve: (
 		input: string,
+		context?: ResolveContext,
 	) => Promise<{ url: string; content: string; contentType: "text/plain"; sourcePath?: string; immutable: boolean }>;
 } {
 	return {
@@ -167,6 +168,33 @@ describe("expandInternalUrls", () => {
 		await expect(expandInternalUrls(command, { skills, internalRouter: router })).resolves.toBe(
 			`cat ${shellEscape("/tmp/session/reviewer_0.md")} ${shellEscape("/tmp/artifacts/12.bash.log")} ${shellEscape("/tmp/memories/memory_summary.md")} ${shellEscape("/tmp/rules/rs-no-unwrap.md")} ${shellEscape(expectedSkillPath)}`,
 		);
+	});
+
+	it("passes caller cwd to the router when expanding memory URLs", async () => {
+		const cwd = "/tmp/session-b";
+		const sourcePath = "/tmp/session-b-memory/memory_summary.md";
+		let observedCwd: string | undefined;
+		let observedPathOnly: boolean | undefined;
+		const router = {
+			canHandle: (input: string) => input === "memory://root/memory_summary.md",
+			resolve: async (input: string, context?: ResolveContext) => {
+				observedCwd = context?.cwd;
+				observedPathOnly = context?.pathOnly;
+				return {
+					url: input,
+					content: "",
+					contentType: "text/plain" as const,
+					sourcePath,
+					immutable: true,
+				};
+			},
+		};
+
+		await expect(
+			expandInternalUrls("cat memory://root/memory_summary.md", { skills: [], internalRouter: router, cwd }),
+		).resolves.toBe(`cat ${shellEscape(sourcePath)}`);
+		expect(observedCwd).toBe(cwd);
+		expect(observedPathOnly).toBe(true);
 	});
 
 	it("expands quoted non-skill URLs and shell-escapes quotes in paths", async () => {


### PR DESCRIPTION
## Repro
A minimal two-session repro registered two live agents with different cwd-backed memory roots, wrote different `memory_summary.md` contents in each root, then resolved `memory://root` through the cwd-less bash URL expansion shape used before this fix. `bun .wt/repro-5079-memory-isolation.ts` exited 1 after expanding to the first registered agent's `memory_summary.md` instead of the second agent's expected memory root.

## Cause
`packages/coding-agent/src/internal-urls/memory-protocol.ts` resolved file-backed `memory://root` by walking every live session from `AgentRegistry.global()` and returning the first matching file, ignoring `ResolveContext.cwd`. `packages/coding-agent/src/tools/bash-skill-urls.ts` also resolved internal URLs with only `{ pathOnly: true }`, so bash expansion had no caller cwd and used that global first-root fallback.

## Fix
- Resolve file-backed memory roots from the caller's `ResolveContext.cwd` before falling back to the registry for contextless callers.
- Pass the session cwd into bash internal-URL expansion so `memory://root` path expansion stays pinned to the invoking agent.
- Add regression coverage for two registered memory roots and for bash expansion forwarding caller cwd to the router.
- Add the coding-agent changelog entry for issue #5079.

## Verification
`bun test packages/coding-agent/test/internal-urls/memory-protocol.test.ts packages/coding-agent/test/tools/bash-skill-urls.test.ts` passed with 44 tests. `bun check` passed. `gh_push_branch` pre-publish checks passed before pushing `farm/c75c3acc/isolate-agent-memory-summary`. Fixes #5079