### PR TITLE
feat(coding-agent): add usage-aware ordered model role candidates

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -306,6 +306,19 @@ enabledModels:
   - claude-sonnet-4-5
 ```
 
+For ordered fallback selection, you can also declare candidate lists for specific roles:
+
+```yaml
+modelRoles:
+  task:
+    strategy: ordered
+    candidates:
+      - model: anthropic/claude-sonnet-4-5
+      - model: openai-codex/gpt-5.6-sol
+```
+
+In this mode, only TaskTool launches whose winning selector is one exact `pi/<role>` use ordered health filtering; skip only known-depleted OAuth candidates; unknown/no usage data and explicit provider API-key overrides remain selectable; all-depleted candidates retain candidate 0 best-effort; scalar/comma/list roles and eval/dashboard behavior stay unchanged; each candidate is one direct selector and nested roles are invalid.
+
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `modelRoles` | record | `{}` | Map of role name -> model id. Built-in roles: `default`, `smol`, `slow`, `vision`, `plan`, `designer`, `commit`, `tiny`, `task`, `advisor`. The `tiny` role overrides the online model for lightweight background tasks (titles, memory, auto-thinking, unexpected-stop), else `pi/smol`. Per-role env/flags exist only for `--model`/`--smol`/`--slow`/`--plan`; configure the advisor with `modelRoles.advisor`. |

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a typed, model-scoped OAuth usage-health query with per-account quota-window summaries ([#5017](https://github.com/can1357/oh-my-pi/issues/5017), [#5018](https://github.com/can1357/oh-my-pi/issues/5018)).
+
 ## [16.4.0] - 2026-07-10
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -39,6 +39,7 @@ import type {
 	UsageLogger,
 	UsageProvider,
 	UsageReport,
+	UsageStatus,
 } from "./usage";
 import { resolveUsedFraction } from "./usage";
 import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
@@ -256,6 +257,36 @@ export interface CheckCredentialsOptions {
 	completionProbe?: CompletionProbe;
 	/** Per-credential completion probe timeout (ms). Defaults to `timeoutMs`. */
 	completionTimeoutMs?: number;
+}
+
+export type ModelUsageHealthState = "eligible" | "unknown" | "depleted";
+
+export interface ModelUsageWindowHealth {
+	readonly id: string;
+	readonly label: string;
+	readonly status?: UsageStatus;
+	readonly usedFraction?: number;
+	readonly resetsAt?: number;
+	readonly durationMs?: number;
+}
+
+export interface UsageAccountHealth {
+	readonly credentialId: number;
+	readonly state: ModelUsageHealthState;
+	readonly fetchedAt?: number;
+	readonly primary?: ModelUsageWindowHealth;
+	readonly secondary?: ModelUsageWindowHealth;
+}
+
+export interface ModelUsageHealth {
+	readonly state: ModelUsageHealthState;
+	readonly accounts: readonly UsageAccountHealth[];
+}
+
+export interface ModelUsageHealthOptions {
+	modelId: string;
+	baseUrl?: string;
+	signal?: AbortSignal;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1005,6 +1036,65 @@ type RankedOAuthCandidate = OAuthCandidate & {
 	primaryDrainRate: number;
 	orderPos: number;
 };
+
+function safeResolveUsedFraction(limit: UsageLimit): number | undefined {
+	const amount = limit.amount;
+	if (amount.usedFraction !== undefined) {
+		return Number.isFinite(amount.usedFraction) ? amount.usedFraction : undefined;
+	}
+	if (amount.used !== undefined && amount.limit !== undefined) {
+		if (!Number.isFinite(amount.used) || !Number.isFinite(amount.limit) || amount.limit <= 0) {
+			return undefined;
+		}
+		const fraction = amount.used / amount.limit;
+		return Number.isFinite(fraction) ? fraction : undefined;
+	}
+	if (amount.unit === "percent" && amount.used !== undefined) {
+		return Number.isFinite(amount.used) ? amount.used / 100 : undefined;
+	}
+	if (amount.remainingFraction !== undefined) {
+		if (!Number.isFinite(amount.remainingFraction)) {
+			return undefined;
+		}
+		const fraction = 1 - amount.remainingFraction;
+		return Number.isFinite(fraction) ? Math.max(0, fraction) : undefined;
+	}
+	return undefined;
+}
+
+function buildWindowSummary(limit: UsageLimit | undefined): ModelUsageWindowHealth | undefined {
+	if (!limit) return undefined;
+	const usedFraction = safeResolveUsedFraction(limit);
+	const resetsAt = limit.window?.resetsAt;
+	const durationMs = limit.window?.durationMs;
+
+	return {
+		id: limit.id,
+		label: limit.label,
+		...(limit.status !== undefined ? { status: limit.status } : {}),
+		...(usedFraction !== undefined && Number.isFinite(usedFraction) ? { usedFraction } : {}),
+		...(resetsAt !== undefined && Number.isFinite(resetsAt) ? { resetsAt } : {}),
+		...(durationMs !== undefined && Number.isFinite(durationMs) && durationMs > 0 ? { durationMs } : {}),
+	};
+}
+
+function buildModelUsageHealth(accounts: UsageAccountHealth[]): ModelUsageHealth {
+	let state: ModelUsageHealthState = "unknown";
+	if (accounts.length > 0) {
+		const states = accounts.map(a => a.state);
+		if (states.includes("eligible")) {
+			state = "eligible";
+		} else if (states.includes("unknown")) {
+			state = "unknown";
+		} else if (states.every(s => s === "depleted")) {
+			state = "depleted";
+		}
+	}
+	return {
+		state,
+		accounts,
+	};
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // AuthStorage Class
@@ -2797,11 +2887,25 @@ export class AuthStorage {
 	#isUsageLimitExhausted(limit: UsageLimit): boolean {
 		if (limit.status === "exhausted") return true;
 		const amount = limit.amount;
-		if (amount.usedFraction !== undefined && amount.usedFraction >= 1) return true;
-		if (amount.remainingFraction !== undefined && amount.remainingFraction <= 0) return true;
-		if (amount.used !== undefined && amount.limit !== undefined && amount.used >= amount.limit) return true;
-		if (amount.remaining !== undefined && amount.remaining <= 0) return true;
-		if (amount.unit === "percent" && amount.used !== undefined && amount.used >= 100) return true;
+		if (amount.usedFraction !== undefined && Number.isFinite(amount.usedFraction) && amount.usedFraction >= 1)
+			return true;
+		if (
+			amount.remainingFraction !== undefined &&
+			Number.isFinite(amount.remainingFraction) &&
+			amount.remainingFraction <= 0
+		)
+			return true;
+		if (
+			amount.used !== undefined &&
+			Number.isFinite(amount.used) &&
+			amount.limit !== undefined &&
+			Number.isFinite(amount.limit) &&
+			amount.used >= amount.limit
+		)
+			return true;
+		if (amount.remaining !== undefined && Number.isFinite(amount.remaining) && amount.remaining <= 0) return true;
+		if (amount.unit === "percent" && amount.used !== undefined && Number.isFinite(amount.used) && amount.used >= 100)
+			return true;
 		return false;
 	}
 
@@ -4260,6 +4364,298 @@ export class AuthStorage {
 			projectId: selection.credential.projectId,
 			enterpriseUrl: selection.credential.enterpriseUrl,
 		}));
+	}
+
+	/**
+	 * Returns the usage health state and account statuses for the specified provider and model.
+	 */
+	async getModelUsageHealth(provider: Provider, options: ModelUsageHealthOptions): Promise<ModelUsageHealth> {
+		if (options.signal?.aborted) {
+			return Promise.reject(options.signal.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+		}
+		if (this.#runtimeOverrides.has(provider) || this.#configOverrides.has(provider)) {
+			return { state: "unknown", accounts: [] };
+		}
+		const selections = this.#getStoredOAuthSelections(provider);
+		if (selections.length === 0) {
+			return { state: "unknown", accounts: [] };
+		}
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		if (!strategy) {
+			return { state: "unknown", accounts: [] };
+		}
+
+		const context: CredentialRankingContext = { modelId: options.modelId };
+		const blockScope = strategy.blockScope?.(context);
+		const providerKey = this.#getProviderTypeKey(provider, "oauth");
+
+		// Snapshot active OAuth blocks before concurrent probes.
+		const snapshotBlocks = selections.map(selection => {
+			const blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, selection.index, blockScope);
+			return {
+				credentialId: selection.credentialId,
+				isBlockedInitially: blockedUntil !== undefined,
+				blockedUntilInitially: blockedUntil,
+			};
+		});
+
+		// Create Promise.withResolvers to manage the overall result, abort, and aggregate timeout.
+		const {
+			promise: overallPromise,
+			resolve: resolveOverall,
+			reject: rejectOverall,
+		} = Promise.withResolvers<ModelUsageHealth>();
+
+		// Handle caller AbortSignal
+		let abortListener: (() => void) | undefined;
+		if (options.signal) {
+			if (options.signal.aborted) {
+				return Promise.reject(
+					options.signal.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+				);
+			}
+			abortListener = () => {
+				rejectFinal(options.signal!.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+			};
+			options.signal.addEventListener("abort", abortListener);
+		}
+
+		// Set up aggregate timeout
+		const aggregateTimeoutMs = Math.max(5000, this.#usageRequestTimeoutMs * 1.5);
+		const timeoutTimer = setTimeout(() => {
+			resolveWithCurrentProgress();
+		}, aggregateTimeoutMs);
+
+		// unref the timer if supported (Bun/Node)
+		if (typeof timeoutTimer.unref === "function") {
+			timeoutTimer.unref();
+		}
+
+		const cleanup = () => {
+			if (timeoutTimer) {
+				clearTimeout(timeoutTimer);
+			}
+			if (options.signal && abortListener) {
+				options.signal.removeEventListener("abort", abortListener);
+			}
+		};
+
+		let completed = false;
+		const resolveFinal = (result: ModelUsageHealth) => {
+			if (completed) return;
+			completed = true;
+			cleanup();
+			resolveOverall(result);
+		};
+
+		const rejectFinal = (err: unknown) => {
+			if (completed) return;
+			completed = true;
+			cleanup();
+			rejectOverall(err);
+		};
+
+		const probeResults: Array<UsageAccountHealth | undefined> = new Array(selections.length).fill(undefined);
+
+		const resolveWithCurrentProgress = () => {
+			const finalAccounts: UsageAccountHealth[] = selections.map((selection, index) => {
+				if (probeResults[index] !== undefined) {
+					return probeResults[index]!;
+				}
+				// It is in flight, so it timed out. Check block status.
+				const currentIdx = this.#getStoredCredentials(provider).findIndex(
+					entry => entry.id === selection.credentialId,
+				);
+				if (currentIdx === -1) {
+					return {
+						credentialId: selection.credentialId,
+						state: "unknown",
+					};
+				}
+				const blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, currentIdx, blockScope);
+				const isBlockedCurrently = blockedUntil !== undefined;
+				const snap = snapshotBlocks[index];
+				const remainsBlocked =
+					isBlockedCurrently ||
+					(!isBlockedCurrently &&
+						snap.blockedUntilInitially !== undefined &&
+						snap.blockedUntilInitially > Date.now() &&
+						provider !== "openai-codex");
+
+				return {
+					credentialId: selection.credentialId,
+					state: remainsBlocked ? "depleted" : "unknown",
+				};
+			});
+
+			resolveFinal(buildModelUsageHealth(finalAccounts));
+		};
+
+		const resolveWithResults = () => {
+			const finalAccounts = probeResults.map((r, index) => {
+				if (r !== undefined) return r;
+				return {
+					credentialId: selections[index].credentialId,
+					state: "unknown" as const,
+				};
+			});
+			resolveFinal(buildModelUsageHealth(finalAccounts));
+		};
+
+		// Query every snapshot in parallel.
+		const probePromises = selections.map(async (selection, index) => {
+			let report: UsageReport | null = null;
+			let fetchFailed = false;
+
+			const snap = snapshotBlocks[index];
+			const shouldFetch = !snap.isBlockedInitially || provider === "openai-codex";
+
+			if (shouldFetch) {
+				try {
+					if (options.signal?.aborted) {
+						throw options.signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+					}
+					report = await this.#getUsageReport(provider, selection.credential, {
+						baseUrl: options.baseUrl,
+						timeoutMs: this.#usageRequestTimeoutMs,
+						signal: options.signal,
+					});
+				} catch (error) {
+					if (options.signal?.aborted) {
+						throw error;
+					}
+					fetchFailed = true;
+				}
+			}
+
+			const currentIdx = this.#getStoredCredentials(provider).findIndex(
+				entry => entry.id === selection.credentialId,
+			);
+			if (currentIdx === -1) {
+				return {
+					credentialId: selection.credentialId,
+					state: "unknown" as const,
+				};
+			}
+
+			const blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, currentIdx, blockScope);
+			const isBlockedCurrently = blockedUntil !== undefined;
+
+			if (report === null || fetchFailed) {
+				const remainsBlocked =
+					isBlockedCurrently ||
+					(!isBlockedCurrently &&
+						snap.blockedUntilInitially !== undefined &&
+						snap.blockedUntilInitially > Date.now() &&
+						provider !== "openai-codex");
+				return {
+					credentialId: selection.credentialId,
+					state: remainsBlocked ? ("depleted" as const) : ("unknown" as const),
+				};
+			}
+
+			// For non-null report
+			const scopedLimits = this.#getScopedUsageLimits(strategy, report, context);
+			const exhaustedScopedLimits = scopedLimits.filter(limit => this.#isUsageLimitReached([limit]));
+			const now = Date.now();
+			const allExhaustedScopedStale =
+				exhaustedScopedLimits.length > 0 &&
+				exhaustedScopedLimits.every(limit => {
+					const resetsAt = limit.window?.resetsAt;
+					if (resetsAt !== undefined && Number.isFinite(resetsAt) && resetsAt <= now) {
+						const fetchedAt = report.fetchedAt;
+						const hasFreshFetch = fetchedAt !== undefined && Number.isFinite(fetchedAt) && fetchedAt >= resetsAt;
+						return !hasFreshFetch;
+					}
+					return false;
+				});
+
+			const windows = strategy.findWindowLimits(report, context);
+			const primary = windows.primary;
+			const secondary = windows.secondary;
+
+			const primarySummary = buildWindowSummary(primary);
+			const secondarySummary = buildWindowSummary(secondary);
+
+			const isDepleted = isBlockedCurrently || (exhaustedScopedLimits.length > 0 && !allExhaustedScopedStale);
+
+			let accountState: ModelUsageHealthState;
+			if (isDepleted) {
+				accountState = "depleted";
+			} else {
+				const isPrimaryExhausted = primary ? this.#isUsageLimitReached([primary]) : false;
+				const isSecondaryExhausted = secondary ? this.#isUsageLimitReached([secondary]) : false;
+				const isPrimaryInScope = primary ? scopedLimits.some(limit => limit.id === primary.id) : false;
+				const isSecondaryInScope = secondary ? scopedLimits.some(limit => limit.id === secondary.id) : false;
+				const hasUnconfirmedExhaustion =
+					(isPrimaryExhausted && !isPrimaryInScope) || (isSecondaryExhausted && !isSecondaryInScope);
+
+				const hasStaleExhaustion = exhaustedScopedLimits.length > 0 && allExhaustedScopedStale;
+
+				if (hasUnconfirmedExhaustion || hasStaleExhaustion) {
+					accountState = "unknown";
+				} else {
+					accountState = "eligible";
+				}
+			}
+
+			const accountHealth: UsageAccountHealth = {
+				credentialId: selection.credentialId,
+				state: accountState,
+				...(report.fetchedAt !== undefined && Number.isFinite(report.fetchedAt)
+					? { fetchedAt: report.fetchedAt }
+					: {}),
+				...(primarySummary ? { primary: primarySummary } : {}),
+				...(secondarySummary ? { secondary: secondarySummary } : {}),
+			};
+
+			return accountHealth;
+		});
+
+		selections.forEach((selection, index) => {
+			probePromises[index].then(
+				result => {
+					probeResults[index] = result;
+					if (probeResults.every(r => r !== undefined)) {
+						resolveWithResults();
+					}
+				},
+				_error => {
+					if (options.signal?.aborted) {
+						return;
+					}
+					const currentIdx = this.#getStoredCredentials(provider).findIndex(
+						entry => entry.id === selection.credentialId,
+					);
+					if (currentIdx === -1) {
+						probeResults[index] = {
+							credentialId: selection.credentialId,
+							state: "unknown",
+						};
+					} else {
+						const blockedUntil = this.#getCredentialBlockedUntil(provider, providerKey, currentIdx, blockScope);
+						const isBlockedCurrently = blockedUntil !== undefined;
+						const snap = snapshotBlocks[index];
+						const remainsBlocked =
+							isBlockedCurrently ||
+							(!isBlockedCurrently &&
+								snap.blockedUntilInitially !== undefined &&
+								snap.blockedUntilInitially > Date.now() &&
+								provider !== "openai-codex");
+
+						probeResults[index] = {
+							credentialId: selection.credentialId,
+							state: remainsBlocked ? "depleted" : "unknown",
+						};
+					}
+					if (probeResults.every(r => r !== undefined)) {
+						resolveWithResults();
+					}
+				},
+			);
+		});
+
+		return overallPromise;
 	}
 
 	/**

--- a/packages/ai/test/auth-storage-model-usage-health.test.ts
+++ b/packages/ai/test/auth-storage-model-usage-health.test.ts
@@ -1,0 +1,1042 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
+import type { UsageLimit, UsageProvider, UsageReport, UsageStatus } from "../src/usage";
+
+async function drainMicrotasks(count: number): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		await Promise.resolve();
+	}
+}
+
+describe("AuthStorage getModelUsageHealth", () => {
+	let db: Database;
+	let store: SqliteAuthCredentialStore;
+	let authStorage: AuthStorage;
+	let usageProvider: UsageProvider;
+	let codexUsageProvider: UsageProvider;
+	const usageReports = new Map<string, UsageReport | null>();
+	const codexReports = new Map<string, UsageReport | null>();
+
+	function makeLimit(args: {
+		id: string;
+		windowId: "5h" | "7d";
+		usedFraction: number;
+		tier?: "fable" | "mythos";
+		resetsAt?: number;
+		durationMs?: number;
+		status?: UsageStatus;
+	}): UsageLimit {
+		const used = args.usedFraction * 100;
+		return {
+			id: args.id,
+			label: args.tier ? `Claude 7 Day (${args.tier})` : `Claude ${args.windowId === "5h" ? "5 Hour" : "7 Day"}`,
+			scope: {
+				provider: "anthropic",
+				windowId: args.windowId,
+				...(args.tier ? { tier: args.tier } : { shared: true }),
+			},
+			window: {
+				id: args.windowId,
+				label: args.windowId === "5h" ? "5 Hour" : "7 Day",
+				...(args.resetsAt !== undefined ? { resetsAt: args.resetsAt } : {}),
+				...(args.durationMs !== undefined ? { durationMs: args.durationMs } : {}),
+			},
+			amount: {
+				used,
+				limit: 100,
+				remaining: 100 - used,
+				usedFraction: args.usedFraction,
+				remainingFraction: 1 - args.usedFraction,
+				unit: "percent",
+			},
+			status: args.status ?? (args.usedFraction >= 1 ? "exhausted" : "ok"),
+		};
+	}
+
+	beforeEach(async () => {
+		db = new Database(":memory:");
+		store = new SqliteAuthCredentialStore(db);
+		usageProvider = {
+			id: "anthropic",
+			async fetchUsage(params) {
+				const email = params.credential.email;
+				if (!email) return null;
+				return usageReports.get(email) ?? null;
+			},
+		};
+		codexUsageProvider = {
+			id: "openai-codex",
+			async fetchUsage(params) {
+				const email = params.credential.email;
+				if (!email) return null;
+				return codexReports.get(email) ?? null;
+			},
+		};
+		authStorage = new AuthStorage(store, {
+			usageProviderResolver: provider => {
+				if (provider === "anthropic") return usageProvider;
+				if (provider === "openai-codex") return codexUsageProvider;
+				return undefined;
+			},
+			usageRequestTimeoutMs: 100,
+		});
+		await authStorage.reload();
+		usageReports.clear();
+		codexReports.clear();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		authStorage.close();
+		db.close();
+	});
+
+	it("depletes account when 5-hour limit is exhausted", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 1.0 }),
+				makeLimit({ id: "anthropic:7d", windowId: "7d", usedFraction: 0.2 }),
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.state).toBe("depleted");
+		expect(health.accounts[0].state).toBe("depleted");
+	});
+
+	it("depletes account when weekly limit is exhausted", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1 }),
+				makeLimit({ id: "anthropic:7d", windowId: "7d", usedFraction: 1.0 }),
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.state).toBe("depleted");
+		expect(health.accounts[0].state).toBe("depleted");
+	});
+
+	it("keeps account eligible when both limits are healthy", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1 }),
+				makeLimit({ id: "anthropic:7d", windowId: "7d", usedFraction: 0.2 }),
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.state).toBe("eligible");
+		expect(health.accounts[0].state).toBe("eligible");
+	});
+
+	it("verifies window summaries, labels, status, account fetchedAt, and usedFraction > 1", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		const fetchedAtTime = 123456789;
+		const resetsAtTime = 123457890;
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: fetchedAtTime,
+			limits: [
+				makeLimit({
+					id: "anthropic:5h",
+					windowId: "5h",
+					usedFraction: 1.5, // usedFraction > 1 preserved
+					resetsAt: resetsAtTime,
+					durationMs: 5 * 3600 * 1000,
+					status: "exhausted",
+				}),
+				makeLimit({
+					id: "anthropic:7d",
+					windowId: "7d",
+					usedFraction: Number.NaN, // non-finite omitted
+					resetsAt: Number.POSITIVE_INFINITY, // non-finite omitted
+					durationMs: Number.NEGATIVE_INFINITY, // non-finite omitted
+					status: "ok",
+				}),
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		const acc = health.accounts[0];
+
+		// Check primary summary
+		expect(acc.primary).toBeDefined();
+		expect(acc.primary?.id).toBe("anthropic:5h");
+		expect(acc.primary?.label).toBe("Claude 5 Hour");
+		expect(acc.primary?.status).toBe("exhausted");
+		expect(acc.primary?.usedFraction).toBe(1.5);
+		expect(acc.primary?.resetsAt).toBe(resetsAtTime);
+		expect(acc.primary?.durationMs).toBe(5 * 3600 * 1000);
+
+		// Check secondary summary (non-finite fields omitted)
+		expect(acc.secondary).toBeDefined();
+		expect(acc.secondary?.id).toBe("anthropic:7d");
+		expect(acc.secondary?.label).toBe("Claude 7 Day");
+		expect(acc.secondary?.status).toBe("ok");
+		expect(acc.secondary?.usedFraction).toBeUndefined();
+		expect(acc.secondary?.resetsAt).toBeUndefined();
+		expect(acc.secondary?.durationMs).toBeUndefined();
+
+		// Check fetchedAt
+		expect(acc.fetchedAt).toBe(fetchedAtTime);
+	});
+
+	it("omits fetchedAt from account when report fetchedAt is non-finite", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Number.NaN, // non-finite
+			limits: [makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1 })],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.accounts[0].fetchedAt).toBeUndefined();
+	});
+
+	it("aggregates states correctly when there is an eligible sibling", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+			{
+				type: "oauth",
+				access: "access-token-2",
+				refresh: "refresh-token-2",
+				expires: Date.now() + 3600000,
+				accountId: "account-2",
+				email: "two@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 1.0 })],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+
+		usageReports.set("two@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1 })],
+			metadata: { email: "two@example.com", accountId: "account-2" },
+		});
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.state).toBe("eligible");
+		expect(health.accounts[0].state).toBe("depleted");
+		expect(health.accounts[1].state).toBe("eligible");
+	});
+
+	for (const limitSpec of [
+		{ name: "5-hour", id: "anthropic:5h", windowId: "5h" as const },
+		{ name: "weekly", id: "anthropic:7d", windowId: "7d" as const },
+	]) {
+		it(`resolves stale elapsed-reset reports as unknown for ${limitSpec.name} limit`, async () => {
+			await authStorage.set("anthropic", [
+				{
+					type: "oauth",
+					access: "access-token-1",
+					refresh: "refresh-token-1",
+					expires: Date.now() + 3600000,
+					accountId: "account-1",
+					email: "one@example.com",
+				},
+			]);
+
+			const now = Date.now();
+			const resetsAt = now - 5000;
+
+			usageReports.set("one@example.com", {
+				provider: "anthropic",
+				fetchedAt: resetsAt - 1000,
+				limits: [makeLimit({ id: limitSpec.id, windowId: limitSpec.windowId, usedFraction: 1.0, resetsAt })],
+				metadata: { email: "one@example.com", accountId: "account-1" },
+			});
+
+			const health = await authStorage.getModelUsageHealth("anthropic", {
+				modelId: "claude-sonnet-4-5",
+			});
+			expect(health.accounts[0].state).toBe("unknown");
+		});
+
+		it(`resolves post-reset exhausted reports as depleted for ${limitSpec.name} limit`, async () => {
+			await authStorage.set("anthropic", [
+				{
+					type: "oauth",
+					access: "access-token-1",
+					refresh: "refresh-token-1",
+					expires: Date.now() + 3600000,
+					accountId: "account-1",
+					email: "one@example.com",
+				},
+			]);
+
+			const now = Date.now();
+			const resetsAt = now - 5000;
+
+			usageReports.set("one@example.com", {
+				provider: "anthropic",
+				fetchedAt: resetsAt + 1000,
+				limits: [makeLimit({ id: limitSpec.id, windowId: limitSpec.windowId, usedFraction: 1.0, resetsAt })],
+				metadata: { email: "one@example.com", accountId: "account-1" },
+			});
+
+			const health = await authStorage.getModelUsageHealth("anthropic", {
+				modelId: "claude-sonnet-4-5",
+			});
+			expect(health.accounts[0].state).toBe("depleted");
+		});
+	}
+
+	it("handles Fable future-reset weekly depletion without leaking to Sonnet", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		const futureReset = Date.now() + 600000;
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1 }),
+				makeLimit({
+					id: "anthropic:7d:fable",
+					windowId: "7d",
+					usedFraction: 1.0,
+					tier: "fable",
+					resetsAt: futureReset,
+				}),
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+
+		// Query Fable kind
+		const fableHealth = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5",
+		});
+		expect(fableHealth.accounts[0].state).toBe("depleted");
+		expect(fableHealth.accounts[0].secondary).toBeDefined();
+		expect(fableHealth.accounts[0].secondary?.id).toBe("anthropic:7d:fable");
+
+		// Query Sonnet kind (must not leak)
+		const sonnetHealth = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(sonnetHealth.accounts[0].state).toBe("eligible");
+		expect(sonnetHealth.accounts[0].secondary).toBeUndefined();
+	});
+
+	it("marks Fable weekly exhaustion with missing resets as unknown", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1 }),
+				makeLimit({
+					id: "anthropic:7d:fable",
+					windowId: "7d",
+					usedFraction: 1.0,
+					tier: "fable",
+					resetsAt: undefined,
+				}),
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5",
+		});
+		expect(health.accounts[0].state).toBe("unknown");
+	});
+
+	it("marks Fable weekly exhaustion with elapsed resets as unknown", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		const pastReset = Date.now() - 5000;
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 0.1 }),
+				makeLimit({
+					id: "anthropic:7d:fable",
+					windowId: "7d",
+					usedFraction: 1.0,
+					tier: "fable",
+					resetsAt: pastReset,
+				}),
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-fable-5",
+		});
+		expect(health.accounts[0].state).toBe("unknown");
+	});
+
+	it("aggregates to depleted when all accounts are depleted", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+			{
+				type: "oauth",
+				access: "access-token-2",
+				refresh: "refresh-token-2",
+				expires: Date.now() + 3600000,
+				accountId: "account-2",
+				email: "two@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 1.0 })],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+		usageReports.set("two@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 1.0 })],
+			metadata: { email: "two@example.com", accountId: "account-2" },
+		});
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.state).toBe("depleted");
+	});
+
+	it("aggregates to unknown when one is depleted and another is null", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+			{
+				type: "oauth",
+				access: "access-token-2",
+				refresh: "refresh-token-2",
+				expires: Date.now() + 3600000,
+				accountId: "account-2",
+				email: "two@example.com",
+			},
+		]);
+
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [makeLimit({ id: "anthropic:5h", windowId: "5h", usedFraction: 1.0 })],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+		usageReports.set("two@example.com", null);
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.state).toBe("unknown");
+	});
+
+	it("keeps blocked Codex depleted when refresh returns null", async () => {
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "access-token-codex",
+				refresh: "refresh-token-codex",
+				expires: Date.now() + 3600000,
+				accountId: "account-codex",
+				email: "codex@example.com",
+			},
+		]);
+
+		const summary = authStorage.listOAuthAccounts("openai-codex")[0];
+		authStorage.upsertCredentialBlock({
+			credentialId: summary.credentialId,
+			providerKey: "openai-codex:oauth",
+			blockScope: "shared",
+			blockedUntilMs: Date.now() + 3600000,
+		});
+
+		codexReports.set("codex@example.com", null);
+
+		const health = await authStorage.getModelUsageHealth("openai-codex", { modelId: "gpt-5" });
+		expect(health.accounts[0].state).toBe("depleted");
+	});
+
+	it("resolves as unknown when the fetch hangs past the aggregate timeout bound", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		const { promise: hangPromise } = Promise.withResolvers<UsageReport | null>();
+		vi.spyOn(usageProvider, "fetchUsage").mockReturnValue(hangPromise);
+
+		vi.useFakeTimers();
+		const healthPromise = authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+
+		// Small timeout (100ms) leads to Math.max(5000, 100 * 1.5) = 5000ms aggregate timeout
+		vi.advanceTimersByTime(5000);
+		await drainMicrotasks(10);
+
+		const health = await healthPromise;
+		expect(health.accounts[0].state).toBe("unknown");
+		vi.useRealTimers();
+	});
+
+	it("survives active block for Codex when refresh/fetch returns null", async () => {
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "access-token-codex",
+				refresh: "refresh-token-codex",
+				expires: Date.now() + 3600000,
+				accountId: "account-codex",
+				email: "codex@example.com",
+			},
+		]);
+
+		const summary = authStorage.listOAuthAccounts("openai-codex")[0];
+		authStorage.upsertCredentialBlock({
+			credentialId: summary.credentialId,
+			providerKey: "openai-codex:oauth",
+			blockScope: "shared",
+			blockedUntilMs: Date.now() + 3600000,
+		});
+
+		const spy = vi.spyOn(codexUsageProvider, "fetchUsage").mockResolvedValue(null);
+
+		const health = await authStorage.getModelUsageHealth("openai-codex", { modelId: "gpt-5" });
+		expect(health.accounts[0].state).toBe("depleted");
+		expect(spy).toHaveBeenCalled();
+	});
+
+	it("survives active block for Codex when refresh/fetch rejects", async () => {
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "access-token-codex",
+				refresh: "refresh-token-codex",
+				expires: Date.now() + 3600000,
+				accountId: "account-codex",
+				email: "codex@example.com",
+			},
+		]);
+
+		const summary = authStorage.listOAuthAccounts("openai-codex")[0];
+		authStorage.upsertCredentialBlock({
+			credentialId: summary.credentialId,
+			providerKey: "openai-codex:oauth",
+			blockScope: "shared",
+			blockedUntilMs: Date.now() + 3600000,
+		});
+
+		const spy = vi.spyOn(codexUsageProvider, "fetchUsage").mockRejectedValue(new Error("network failure"));
+
+		const health = await authStorage.getModelUsageHealth("openai-codex", { modelId: "gpt-5" });
+		expect(health.accounts[0].state).toBe("depleted");
+		expect(spy).toHaveBeenCalled();
+	});
+
+	it("survives active block for Codex when refresh/fetch times out", async () => {
+		await authStorage.set("openai-codex", [
+			{
+				type: "oauth",
+				access: "access-token-codex",
+				refresh: "refresh-token-codex",
+				expires: Date.now() + 3600000,
+				accountId: "account-codex",
+				email: "codex@example.com",
+			},
+		]);
+
+		const summary = authStorage.listOAuthAccounts("openai-codex")[0];
+		authStorage.upsertCredentialBlock({
+			credentialId: summary.credentialId,
+			providerKey: "openai-codex:oauth",
+			blockScope: "shared",
+			blockedUntilMs: Date.now() + 3600000,
+		});
+
+		const { promise: hangPromise } = Promise.withResolvers<UsageReport | null>();
+		const spy = vi.spyOn(codexUsageProvider, "fetchUsage").mockReturnValue(hangPromise);
+
+		vi.useFakeTimers();
+		const healthPromise = authStorage.getModelUsageHealth("openai-codex", { modelId: "gpt-5" });
+		vi.advanceTimersByTime(5000);
+		await drainMicrotasks(10);
+
+		const health = await healthPromise;
+		expect(health.accounts[0].state).toBe("depleted");
+		expect(spy).toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+
+	it("does not fetch usage for pre-blocked Anthropic account", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		const summary = authStorage.listOAuthAccounts("anthropic")[0];
+		authStorage.upsertCredentialBlock({
+			credentialId: summary.credentialId,
+			providerKey: "anthropic:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + 3600000,
+		});
+
+		const spy = vi.spyOn(usageProvider, "fetchUsage");
+
+		const health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.accounts[0].state).toBe("depleted");
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("rejects immediately if already aborted, or later during probe", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		// Scenario A: already aborted
+		const controller1 = new AbortController();
+		controller1.abort();
+		await expect(
+			authStorage.getModelUsageHealth("anthropic", {
+				modelId: "claude-sonnet-4-5",
+				signal: controller1.signal,
+			}),
+		).rejects.toThrow("aborted");
+
+		// Scenario B: aborted later in flight
+		const controller2 = new AbortController();
+		const { promise: hangPromise } = Promise.withResolvers<UsageReport | null>();
+		vi.spyOn(usageProvider, "fetchUsage").mockReturnValue(hangPromise);
+
+		const promise = authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+			signal: controller2.signal,
+		});
+
+		await drainMicrotasks(5);
+		controller2.abort();
+
+		await expect(promise).rejects.toThrow("aborted");
+	});
+
+	it("never attributes another row block when stable credential ID is removed/disabled during probe", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+			{
+				type: "oauth",
+				access: "access-token-2",
+				refresh: "refresh-token-2",
+				expires: Date.now() + 3600000,
+				accountId: "account-2",
+				email: "two@example.com",
+			},
+		]);
+
+		const summaries = authStorage.listOAuthAccounts("anthropic");
+		const id1 = summaries[0].credentialId;
+		const id2 = summaries[1].credentialId;
+
+		// Add block to credential 2. Initially at index 1.
+		authStorage.upsertCredentialBlock({
+			credentialId: id2,
+			providerKey: "anthropic:oauth",
+			blockScope: "",
+			blockedUntilMs: Date.now() + 3600000,
+		});
+
+		// Hook fetchUsage to disable credential 1 during its fetch
+		const { promise: fetchPromise, resolve: resolveFetch } = Promise.withResolvers<UsageReport | null>();
+		vi.spyOn(usageProvider, "fetchUsage").mockImplementation(async params => {
+			if (params.credential.email === "one@example.com") {
+				// While in flight, disable credential 1
+				authStorage.disableCredentialById(id1, "disabled in test");
+				return fetchPromise;
+			}
+			return null;
+		});
+
+		const healthPromise = authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+
+		await drainMicrotasks(10);
+		resolveFetch(null);
+
+		const health = await healthPromise;
+		// Since credential 1 (id1) was deleted/disabled, it should report unknown (not depleted from credential 2's block)
+		const targetAcc = health.accounts.find(a => a.credentialId === id1);
+		expect(targetAcc).toBeDefined();
+		expect(targetAcc?.state).toBe("unknown");
+	});
+	it("resolves expired snapshot block with no current block as unknown", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		const summary = authStorage.listOAuthAccounts("anthropic")[0];
+		const spy = vi.spyOn(usageProvider, "fetchUsage");
+
+		let currentTime = 1000000;
+		const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => currentTime);
+		const originalGet = store.getCredentialBlock.bind(store);
+		const storeSpy = vi
+			.spyOn(store, "getCredentialBlock")
+			.mockImplementation((credentialId, providerKey, blockScope) => {
+				const res = originalGet(credentialId, providerKey, blockScope);
+				currentTime = 1002000;
+				return res;
+			});
+
+		try {
+			const blockTime = 1001000; // Expired by evaluation (1002000)
+			authStorage.upsertCredentialBlock({
+				credentialId: summary.credentialId,
+				providerKey: "anthropic:oauth",
+				blockScope: "",
+				blockedUntilMs: blockTime,
+			});
+
+			const health = await authStorage.getModelUsageHealth("anthropic", {
+				modelId: "claude-sonnet-4-5",
+			});
+
+			expect(health.accounts[0].state).toBe("unknown");
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			dateSpy.mockRestore();
+			storeSpy.mockRestore();
+		}
+	});
+
+	it("resolves still-active snapshot block as depleted", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		const summary = authStorage.listOAuthAccounts("anthropic")[0];
+		const spy = vi.spyOn(usageProvider, "fetchUsage");
+
+		let currentTime = 1000000;
+		const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => currentTime);
+		const originalGet = store.getCredentialBlock.bind(store);
+		const storeSpy = vi
+			.spyOn(store, "getCredentialBlock")
+			.mockImplementation((credentialId, providerKey, blockScope) => {
+				const res = originalGet(credentialId, providerKey, blockScope);
+				currentTime = 1002000;
+				return res;
+			});
+
+		try {
+			const blockTime = 1100000; // Still active during evaluation (1100000 > 1002000)
+			authStorage.upsertCredentialBlock({
+				credentialId: summary.credentialId,
+				providerKey: "anthropic:oauth",
+				blockScope: "",
+				blockedUntilMs: blockTime,
+			});
+
+			const health = await authStorage.getModelUsageHealth("anthropic", {
+				modelId: "claude-sonnet-4-5",
+			});
+
+			expect(health.accounts[0].state).toBe("depleted");
+			expect(spy).not.toHaveBeenCalled();
+		} finally {
+			dateSpy.mockRestore();
+			storeSpy.mockRestore();
+		}
+	});
+	it("rejects with abort error on already-aborted signal even with no credentials or overrides", async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			authStorage.getModelUsageHealth("anthropic", {
+				modelId: "claude-sonnet-4-5",
+				signal: controller.signal,
+			}),
+		).rejects.toThrow("aborted");
+	});
+	it("handles non-finite limits (usedFraction=Infinity, remainingFraction=Infinity, limit=Infinity) without depleting or resolving to usedFraction 0", async () => {
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-1",
+				refresh: "refresh-token-1",
+				expires: Date.now() + 3600000,
+				accountId: "account-1",
+				email: "one@example.com",
+			},
+		]);
+
+		// Scenario A: status='ok' usedFraction=Infinity must not cause depletion, and usedFraction is omitted
+		usageReports.set("one@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "anthropic:5h",
+					label: "Claude 5 Hour",
+					scope: { provider: "anthropic", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour" },
+					amount: {
+						used: 10,
+						limit: 100,
+						usedFraction: Number.POSITIVE_INFINITY,
+						remainingFraction: -Number.POSITIVE_INFINITY,
+						unit: "percent",
+					},
+					status: "ok",
+				},
+			],
+			metadata: { email: "one@example.com", accountId: "account-1" },
+		});
+
+		let health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.state).toBe("eligible");
+		expect(health.accounts[0].state).toBe("eligible");
+		expect(health.accounts[0].primary?.usedFraction).toBeUndefined();
+
+		// Scenario B: remainingFraction=Infinity must not become summary usedFraction 0 (should be omitted)
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-2",
+				refresh: "refresh-token-2",
+				expires: Date.now() + 3600000,
+				accountId: "account-2",
+				email: "two@example.com",
+			},
+		]);
+		usageReports.set("two@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "anthropic:5h",
+					label: "Claude 5 Hour",
+					scope: { provider: "anthropic", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour" },
+					amount: {
+						remainingFraction: Number.POSITIVE_INFINITY,
+						unit: "percent",
+					},
+					status: "ok",
+				},
+			],
+			metadata: { email: "two@example.com", accountId: "account-2" },
+		});
+
+		health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.accounts[0].primary?.usedFraction).toBeUndefined();
+
+		// Scenario C: finite-used/infinite-limit must not become summary usedFraction 0 (should be omitted)
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "access-token-3",
+				refresh: "refresh-token-3",
+				expires: Date.now() + 3600000,
+				accountId: "account-3",
+				email: "three@example.com",
+			},
+		]);
+		usageReports.set("three@example.com", {
+			provider: "anthropic",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "anthropic:5h",
+					label: "Claude 5 Hour",
+					scope: { provider: "anthropic", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour" },
+					amount: {
+						used: 10,
+						limit: Number.POSITIVE_INFINITY,
+						unit: "percent",
+					},
+					status: "ok",
+				},
+			],
+			metadata: { email: "three@example.com", accountId: "account-3" },
+		});
+
+		health = await authStorage.getModelUsageHealth("anthropic", {
+			modelId: "claude-sonnet-4-5",
+		});
+		expect(health.accounts[0].primary?.usedFraction).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added usage-aware ordered model role candidates with account- and model-scoped quota health checks ([#5017](https://github.com/can1357/oh-my-pi/issues/5017), [#5018](https://github.com/can1357/oh-my-pi/issues/5018)).
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1927,9 +1927,7 @@ export class ModelRegistry {
 		return model => {
 			let available = byProvider.get(model.provider);
 			if (available === undefined) {
-				available =
-					!disabledProviders.has(model.provider) &&
-					(this.#keylessProviders.has(model.provider) || this.authStorage.hasAuth(model.provider));
+				available = !disabledProviders.has(model.provider) && this.hasConfiguredAuth(model);
 				byProvider.set(model.provider, available);
 			}
 			return available;
@@ -1967,6 +1965,10 @@ export class ModelRegistry {
 			this.#keylessProviders.has(model.provider) ||
 			this.authStorage.hasAuth(model.provider)
 		);
+	}
+
+	hasExplicitProviderApiKey(provider: string): boolean {
+		return this.#customProviderApiKeys.has(provider);
 	}
 
 	getDiscoverableProviders(): string[] {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1003,24 +1003,98 @@ export interface AgentModelPatternResolutionOptions {
 	fallbackModelPattern?: string;
 }
 
+export interface AgentModelRequest {
+	patterns: string[];
+	candidateRole?: ModelRole;
+}
+
+export function resolveAgentModelRequest(options: AgentModelPatternResolutionOptions): AgentModelRequest {
+	return resolveAgentModelRequestInternal(options, true);
+}
+
 export function resolveAgentModelPatterns(options: AgentModelPatternResolutionOptions): string[] {
+	return resolveAgentModelRequestInternal(options, false).patterns;
+}
+
+function tryResolveCandidatePolicy(pattern: string, settings: Settings | undefined): AgentModelRequest | undefined {
+	const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(
+		pattern,
+		PREFIX_MODEL_ROLE.length,
+		MAX_THINKING_SUFFIX_OPTIONS,
+	);
+	const role = getModelRoleAlias(aliasCandidate);
+	if (role && role !== "default") {
+		const candidatesSettings = settings?.getModelRoleCandidates(role);
+		if (candidatesSettings) {
+			const candidatePatterns: string[] = [];
+			let expansionFailed = false;
+
+			for (const c of candidatesSettings.candidates) {
+				const expanded = resolveConfiguredModelPatterns(c.model, settings);
+				if (expanded.length !== 1) {
+					expansionFailed = true;
+					break;
+				}
+				const expandedPattern = expanded[0];
+				const { base: candidateBase } = splitThinkingSuffix(expandedPattern, -1, MAX_THINKING_SUFFIX_OPTIONS);
+				const patternWithSuffix = thinkingLevel ? `${candidateBase}:${thinkingLevel}` : expandedPattern;
+				candidatePatterns.push(patternWithSuffix);
+			}
+
+			if (!expansionFailed && candidatePatterns.length > 0) {
+				return {
+					patterns: candidatePatterns,
+					candidateRole: role,
+				};
+			}
+		}
+	}
+	return undefined;
+}
+
+function resolveAgentModelRequestInternal(
+	options: AgentModelPatternResolutionOptions,
+	includeCandidatePolicy: boolean,
+): AgentModelRequest {
 	const { settingsOverride, agentModel, settings, activeModelPattern, fallbackModelPattern } = options;
 
-	const overridePatterns = resolveConfiguredModelPatterns(settingsOverride, settings);
-	if (overridePatterns.length > 0) return overridePatterns;
+	const normalizedOverridePatterns = normalizeModelPatternList(settingsOverride);
+	if (normalizedOverridePatterns.length > 0) {
+		if (includeCandidatePolicy && normalizedOverridePatterns.length === 1) {
+			const resolved = tryResolveCandidatePolicy(normalizedOverridePatterns[0], settings);
+			if (resolved) return resolved;
+		}
+		const overridePatterns = resolveConfiguredModelPatterns(settingsOverride, settings);
+		if (overridePatterns.length > 0) {
+			return { patterns: overridePatterns, candidateRole: undefined };
+		}
+	}
 
 	const normalizedAgentPatterns = normalizeModelPatternList(agentModel);
 	const configuredAgentPatterns = resolveConfiguredModelPatterns(agentModel, settings);
 	const singleAgentPattern = normalizedAgentPatterns.length === 1 ? normalizedAgentPatterns[0] : undefined;
 	const agentInheritsSessionModel = singleAgentPattern ? isSessionInheritedAgentPattern(singleAgentPattern) : false;
+
+	if (includeCandidatePolicy && singleAgentPattern) {
+		const resolved = tryResolveCandidatePolicy(singleAgentPattern, settings);
+		if (resolved) return resolved;
+	}
+
 	if (configuredAgentPatterns.length > 0) {
-		if (!agentInheritsSessionModel) return configuredAgentPatterns;
-		if (singleAgentPattern === "pi/task") return configuredAgentPatterns;
+		if (!agentInheritsSessionModel) {
+			return { patterns: configuredAgentPatterns, candidateRole: undefined };
+		}
+		if (singleAgentPattern === "pi/task") {
+			return { patterns: configuredAgentPatterns, candidateRole: undefined };
+		}
 	}
 
 	const fallback =
 		activeModelPattern?.trim() || fallbackModelPattern?.trim() || settings?.getModelRole("default")?.trim() || "";
-	return resolveConfiguredModelPatterns(fallback, settings);
+	return {
+		patterns: resolveConfiguredModelPatterns(fallback, settings),
+		candidateRole: undefined,
+	};
 }
 
 /**

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -279,14 +279,28 @@ export interface ModelTagsSettings {
 	[key: string]: ModelTagDef;
 }
 
+export type ModelRoleCandidateStrategy = "ordered";
+
+export interface ModelRoleCandidateSettings {
+	model: string;
+}
+
+export interface ModelRoleCandidatesSettings {
+	strategy: ModelRoleCandidateStrategy;
+	candidates: ModelRoleCandidateSettings[];
+}
+
+export type ModelRoleSetting = string | string[] | ModelRoleCandidatesSettings;
+export type ModelRolesSettings = Record<string, ModelRoleSetting>;
+
 // Typed defaults for array/record settings — named constants avoid `as` casts
 // under `as const` while still letting SettingValue infer the correct element type.
 const EMPTY_STRING_ARRAY: string[] = [];
-const EMPTY_STRING_RECORD: Record<string, string> = {};
 const EMPTY_NUMBER_RECORD: Record<string, number> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const DEFAULT_TOOL_CALL_LOOP_EXEMPT_TOOLS: string[] = ["job", "irc"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
+const EMPTY_MODEL_ROLES_RECORD: ModelRolesSettings = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	{
@@ -479,7 +493,7 @@ export const SETTINGS_SCHEMA = {
 
 	disabledExtensions: { type: "array", default: EMPTY_STRING_ARRAY },
 
-	modelRoles: { type: "record", default: EMPTY_STRING_RECORD },
+	modelRoles: { type: "record", default: EMPTY_MODEL_ROLES_RECORD },
 
 	modelTags: { type: "record", default: EMPTY_MODEL_TAGS_RECORD },
 
@@ -5242,7 +5256,7 @@ export interface GroupTypeMap {
 	statusLine: StatusLineSettings;
 	thinkingBudgets: ThinkingBudgetsSettings;
 	stt: SttSettings;
-	modelRoles: Record<string, string>;
+	modelRoles: ModelRolesSettings;
 	modelTags: ModelTagsSettings;
 	cycleOrder: string[];
 	shellMinimizer: ShellMinimizerSettings;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -28,18 +28,22 @@ import {
 } from "@oh-my-pi/pi-utils";
 import { JSONC, YAML } from "bun";
 import { type Settings as SettingsCapabilityItem, settingsCapability } from "../capability/settings";
-import type { ModelRole } from "../config/model-roles";
 import { loadCapability } from "../discovery";
 import { isLightTheme, setAutoThemeMapping, setColorBlindMode, setSymbolPreset } from "../modes/theme/theme";
 import { AgentStorage } from "../session/agent-storage";
+import { AUTO_THINKING, parseThinkingLevel } from "../thinking";
 import { normalizeToolName } from "../tools/builtin-names";
 import { type EditMode, normalizeEditMode } from "../utils/edit-mode";
 import { withFileLock } from "./file-lock";
+import { MODEL_ROLE_IDS, type ModelRole } from "./model-roles";
 import {
 	type BashInterceptorRule,
 	type GroupPrefix,
 	type GroupTypeMap,
 	getDefault,
+	type ModelRoleCandidateSettings,
+	type ModelRoleCandidatesSettings,
+	type ModelRolesSettings,
 	SETTINGS_SCHEMA,
 	type SettingPath,
 	type SettingValue,
@@ -588,19 +592,55 @@ export class Settings {
 		return this.get("bashInterceptor.patterns");
 	}
 
-	#modelRolesFromLayer(layer: RawSettings): Record<string, string> {
+	#modelRolesFromLayer(layer: RawSettings): ModelRolesSettings {
 		const value = getByPath(layer, ["modelRoles"]);
 		if (!isRecord(value)) return {};
+		return { ...value } as ModelRolesSettings;
+	}
 
-		const roles: Record<string, string> = {};
-		for (const role in value) {
-			if (!Object.hasOwn(value, role)) continue;
-			const modelId = modelRoleValueFromUnknown(value[role]);
-			if (modelId !== undefined) {
-				roles[role] = modelId;
+	/**
+	 * Get model role candidates (helper for modelRoles record with ordered object policy).
+	 */
+	getModelRoleCandidates(role: string): ModelRoleCandidatesSettings | undefined {
+		const roles: unknown = this.get("modelRoles");
+		if (!isRecord(roles)) return undefined;
+
+		const val = roles[role];
+		if (!isRecord(val)) return undefined;
+
+		if (val.strategy !== "ordered") return undefined;
+		if (!Array.isArray(val.candidates) || val.candidates.length === 0) return undefined;
+
+		const validCandidates: ModelRoleCandidateSettings[] = [];
+
+		for (const c of val.candidates) {
+			if (!c || typeof c !== "object" || Array.isArray(c)) return undefined;
+			if (!("model" in c) || typeof c.model !== "string") return undefined;
+			const trimmed = c.model.trim();
+			if (trimmed === "") return undefined;
+			if (trimmed.includes(",")) return undefined;
+
+			// Check for default / pi/<known role> with or without trailing thinking suffix
+			const lastColon = trimmed.lastIndexOf(":");
+			let base = trimmed;
+			if (lastColon !== -1) {
+				const suffix = trimmed.slice(lastColon + 1);
+				if (suffix === AUTO_THINKING || parseThinkingLevel(suffix) !== undefined) {
+					base = trimmed.slice(0, lastColon);
+				}
 			}
+
+			if (base === "default" || (base.startsWith("pi/") && MODEL_ROLE_IDS.includes(base.slice(3) as ModelRole))) {
+				return undefined;
+			}
+
+			validCandidates.push({ model: trimmed });
 		}
-		return roles;
+
+		return {
+			strategy: "ordered",
+			candidates: validCandidates,
+		};
 	}
 
 	/**
@@ -631,6 +671,10 @@ export class Settings {
 	getModelRole(role: ModelRole | string): string | undefined {
 		const roles: unknown = this.get("modelRoles");
 		if (!isRecord(roles)) return undefined;
+		const candidates = this.getModelRoleCandidates(role as string);
+		if (candidates) {
+			return candidates.candidates[0].model;
+		}
 		return modelRoleValueFromUnknown(roles[role]);
 	}
 
@@ -644,9 +688,14 @@ export class Settings {
 		const normalized: Record<string, string> = {};
 		for (const role in roles) {
 			if (!Object.hasOwn(roles, role)) continue;
-			const modelId = modelRoleValueFromUnknown(roles[role]);
-			if (modelId !== undefined) {
-				normalized[role] = modelId;
+			const candidates = this.getModelRoleCandidates(role);
+			if (candidates) {
+				normalized[role] = candidates.candidates[0].model;
+			} else {
+				const modelId = modelRoleValueFromUnknown(roles[role]);
+				if (modelId !== undefined) {
+					normalized[role] = modelId;
+				}
 			}
 		}
 		return normalized;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -47,6 +47,7 @@ import {
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
 import { buildServiceTierByFamily } from "./config/service-tier";
 import { Settings, type SkillsSettings } from "./config/settings";
+import type { ModelRolesSettings } from "./config/settings-schema";
 import { CursorExecHandlers } from "./cursor";
 import "./discovery";
 import { initializeWithSettings } from "./discovery";
@@ -2034,14 +2035,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 						fallbackSelectors.push(fallbackSelector);
 					}
 					if (fallbackSelectors.length > 0) {
-						const modelRoles: Record<string, string> = {};
-						const existingRoles = settings.getModelRoles();
-						for (const role in existingRoles) {
-							const selector = existingRoles[role];
-							if (selector) {
-								modelRoles[role] = selector;
-							}
-						}
+						const rawModelRoles = settings.get("modelRoles");
+						const modelRoles: ModelRolesSettings =
+							typeof rawModelRoles === "object" && rawModelRoles !== null && !Array.isArray(rawModelRoles)
+								? { ...rawModelRoles }
+								: {};
 						modelRoles[options.modelPatternFallbackRole] = primarySelector;
 						settings.override("modelRoles", modelRoles);
 						const fallbackChains: Record<string, string[]> = {

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -17,10 +17,11 @@ import {
 	resolveModelOverride,
 	resolveModelOverrideWithAuthFallback,
 } from "../config/model-resolver";
+import type { ModelRole } from "../config/model-roles";
 import type { PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily, resolveSubagentServiceTier } from "../config/service-tier";
 import { Settings } from "../config/settings";
-import { SETTINGS_SCHEMA, type SettingPath } from "../config/settings-schema";
+import { type ModelRolesSettings, SETTINGS_SCHEMA, type SettingPath } from "../config/settings-schema";
 import type { ToolPathWithSource } from "../extensibility/custom-tools";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
@@ -177,14 +178,11 @@ function installSubagentRetryFallbackChain(args: {
 	if (fallbackSelectors.length === 0) return undefined;
 
 	const role = `${SUBAGENT_RETRY_FALLBACK_ROLE_PREFIX}${id}`;
-	const modelRoles: Record<string, string> = {};
-	const existingRoles = settings.getModelRoles();
-	for (const existingRole in existingRoles) {
-		const selector = existingRoles[existingRole];
-		if (selector) {
-			modelRoles[existingRole] = selector;
-		}
-	}
+	const rawModelRoles = settings.get("modelRoles");
+	const modelRoles: ModelRolesSettings =
+		typeof rawModelRoles === "object" && rawModelRoles !== null && !Array.isArray(rawModelRoles)
+			? { ...rawModelRoles }
+			: {};
 	modelRoles[role] = candidates[selectedIndex].selector;
 	settings.override("modelRoles", modelRoles);
 	const fallbackChains: Record<string, string[]> = {
@@ -301,6 +299,7 @@ export interface ExecutorOptions {
 	 */
 	detached?: boolean;
 	modelOverride?: string | string[];
+	modelCandidateRole?: ModelRole;
 	/**
 	 * Active model selector of the parent session, used as an auth-aware fallback
 	 * if the resolved subagent model has no working credentials. See #985.
@@ -2105,6 +2104,43 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 			checkAbort();
 
+			let effectiveModelPatterns = modelPatterns;
+			if (options.modelCandidateRole) {
+				const resolvedPatterns = modelPatterns.map(pattern => {
+					const resolved = resolveModelOverride([pattern], modelRegistry, settings);
+					return { pattern, resolved };
+				});
+				const staticResolved = resolvedPatterns.filter(item => item.resolved.model !== undefined);
+
+				if (staticResolved.length > 0) {
+					let selectedIndex = -1;
+					for (let i = 0; i < staticResolved.length; i++) {
+						const item = staticResolved[i];
+						const model = item.resolved.model!;
+						if (modelRegistry.hasExplicitProviderApiKey(model.provider)) {
+							selectedIndex = i;
+							break;
+						}
+						const health = await awaitAbortable(
+							modelRegistry.authStorage.getModelUsageHealth(model.provider, {
+								modelId: model.id,
+								baseUrl: model.baseUrl,
+								signal: abortSignal,
+							}),
+						);
+						if (health.state !== "depleted") {
+							selectedIndex = i;
+							break;
+						}
+					}
+					if (selectedIndex !== -1) {
+						effectiveModelPatterns = staticResolved.slice(selectedIndex).map(item => item.pattern);
+					} else {
+						effectiveModelPatterns = staticResolved.map(item => item.pattern);
+					}
+				}
+			}
+
 			const {
 				model,
 				thinkingLevel: resolvedThinkingLevel,
@@ -2112,7 +2148,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				authFallbackUsed,
 			} = await awaitAbortable(
 				resolveModelOverrideWithAuthFallback(
-					modelPatterns,
+					effectiveModelPatterns,
 					options.parentActiveModelPattern,
 					modelRegistry,
 					settings,
@@ -2129,7 +2165,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const retryFallbackRole = installSubagentRetryFallbackChain({
 				settings: subagentSettings,
 				id,
-				candidates: resolveSubagentRetryFallbackCandidates(modelPatterns, modelRegistry, settings),
+				candidates: resolveSubagentRetryFallbackCandidates(effectiveModelPatterns, modelRegistry, settings),
 				model,
 				authFallbackUsed,
 			});
@@ -2213,7 +2249,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				modelRegistry,
 				settings: subagentSettings,
 				model,
-				modelPattern: model || modelOverride === undefined ? undefined : modelPatterns,
+				modelPattern: model || modelOverride === undefined ? undefined : effectiveModelPatterns,
 				modelPatternAuthFallback:
 					model || modelOverride === undefined ? undefined : options.parentActiveModelPattern,
 				modelPatternFallbackRole:

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -20,7 +20,7 @@ import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my
 import type { Usage } from "@oh-my-pi/pi-ai";
 import { $env, logger, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import type { ToolSession } from "..";
-import { resolveAgentModelPatterns } from "../config/model-resolver";
+import { resolveAgentModelRequest } from "../config/model-resolver";
 import { MCPManager } from "../mcp/manager";
 import type { Theme } from "../modes/theme/theme";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
@@ -1139,13 +1139,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		const agentModelOverrides = this.session.settings.get("task.agentModelOverrides");
 		const settingsModelOverride = agentModelOverrides[agentName];
 		const parentActiveModelPattern = this.session.getActiveModelString?.();
-		const modelOverride = resolveAgentModelPatterns({
+		const modelRequest = resolveAgentModelRequest({
 			settingsOverride: settingsModelOverride,
 			agentModel: effectiveAgent.model,
 			settings: this.session.settings,
 			activeModelPattern: parentActiveModelPattern,
 			fallbackModelPattern: this.session.getModelString?.(),
 		});
+		const modelOverride = modelRequest.patterns;
+		const modelCandidateRole = modelRequest.candidateRole;
 		const thinkingLevelOverride = effectiveAgent.thinkingLevel;
 
 		// Output schema priority: agent frontmatter > inherited parent session.
@@ -1301,6 +1303,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				invokedAt: launchTiming?.invokedAt,
 				acquiredAt: launchTiming?.acquiredAt,
 				modelOverride,
+				modelCandidateRole,
 				parentActiveModelPattern,
 				thinkingLevel: thinkingLevelOverride,
 				outputSchema: effectiveOutputSchema,

--- a/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
+++ b/packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts
@@ -1,11 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as sdkModule from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { runSubprocess } from "@oh-my-pi/pi-coding-agent/task/executor";
 import type { AgentDefinition } from "@oh-my-pi/pi-coding-agent/task/types";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
 function model(provider: string, id: string): Model<Api> {
 	return buildModel({
@@ -43,6 +49,38 @@ function createYieldingSession(): AgentSession {
 					to: "fallback/working-model",
 					role: "subagent:issue-2750",
 				});
+				listener({
+					type: "tool_execution_end",
+					toolCallId: "tool-yield",
+					toolName: "yield",
+					result: { content: [{ type: "text", text: "Result submitted." }], details: { status: "success" } },
+					isError: false,
+				});
+			}
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => undefined,
+		abort: async () => {},
+		dispose: async () => {},
+	};
+	return session as unknown as AgentSession;
+}
+
+function createSimpleYieldingSession(): AgentSession {
+	const listeners: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+	const session = {
+		agent: { state: { systemPrompt: ["test"] } },
+		state: { messages: [] },
+		extensionRunner: undefined,
+		sessionManager: { appendSessionInit: () => {} },
+		getActiveToolNames: () => ["yield"],
+		setActiveToolsByName: async () => {},
+		subscribe: (listener: (event: { type: string; [key: string]: unknown }) => void) => {
+			listeners.push(listener);
+			return () => {};
+		},
+		prompt: async () => {
+			for (const listener of listeners) {
 				listener({
 					type: "tool_execution_end",
 					toolCallId: "tool-yield",
@@ -186,5 +224,345 @@ describe("subagent runtime model resolution", () => {
 		expect(childModelPattern).toEqual(["openai-codex/gpt-5.5:auto"]);
 		expect(childModelPatternAuthFallback).toBe("openai-codex/gpt-5.5");
 		expect(childModelPatternFallbackRole).toBe("subagent:issue-4421");
+	});
+
+	it("runSubprocess candidate health selection: depleted candidate 0 selects candidate 1 with preserved thinking", async () => {
+		const primary = model("primary", "bad-runtime-model");
+		const fallback = model("fallback", "working-model");
+		const tail = model("tail", "tail-model");
+		let childModel: Model | undefined;
+		let childFallbackChains: Record<string, string[]> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childModel = options.model;
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			return {
+				session: createSimpleYieldingSession(),
+				extensionsResult: {},
+				setToolUIContext: () => {},
+			} as unknown as sdkModule.CreateAgentSessionResult;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated();
+
+		const getModelUsageHealthSpy = vi.fn().mockImplementation(async (provider: string) => {
+			if (provider === "primary") return { state: "depleted" };
+			return { state: "eligible" };
+		});
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "depleted-test",
+			modelOverride: ["primary/bad-runtime-model:high", "fallback/working-model:low", "tail/tail-model:medium"],
+			modelCandidateRole: "task",
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback, tail],
+				getApiKey: async () => "test-key",
+				hasExplicitProviderApiKey: () => false,
+				authStorage: {
+					getModelUsageHealth: getModelUsageHealthSpy,
+				},
+			} as unknown as ModelRegistry,
+			enableLsp: false,
+		});
+
+		// Depleted candidate 0 is skipped. Preserved thinking for candidate 1 is ":low".
+		expect(childModel).toBe(fallback);
+		expect(result.resolvedModel).toBe("fallback/working-model:low");
+		expect(getModelUsageHealthSpy).toHaveBeenCalledTimes(2); // primary + fallback checked
+
+		// Skipped candidate 0 never re-enters the retry/session tail, but candidate 2 is retained.
+		expect(childFallbackChains?.["subagent:depleted-test"]).toEqual(["tail/tail-model:medium"]);
+	});
+
+	it("runSubprocess candidate health selection: unknown stays candidate 0", async () => {
+		const primary = model("primary", "bad-runtime-model");
+		const fallback = model("fallback", "working-model");
+		let childModel: Model | undefined;
+		let childFallbackChains: Record<string, string[]> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childModel = options.model;
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			return {
+				session: createSimpleYieldingSession(),
+				extensionsResult: {},
+				setToolUIContext: () => {},
+			} as unknown as sdkModule.CreateAgentSessionResult;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated();
+
+		const getModelUsageHealthSpy = vi.fn().mockImplementation(async (provider: string) => {
+			if (provider === "primary") return { state: "unknown" };
+			return { state: "eligible" };
+		});
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "unknown-test",
+			modelOverride: ["primary/bad-runtime-model:high", "fallback/working-model:low"],
+			modelCandidateRole: "task",
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback],
+				getApiKey: async () => "test-key",
+				hasExplicitProviderApiKey: () => false,
+				authStorage: {
+					getModelUsageHealth: getModelUsageHealthSpy,
+				},
+			} as unknown as ModelRegistry,
+			enableLsp: false,
+		});
+
+		expect(childModel).toBe(primary);
+		expect(result.resolvedModel).toBe("primary/bad-runtime-model:high");
+		expect(getModelUsageHealthSpy).toHaveBeenCalledTimes(1); // breaks on first non-depleted (unknown)
+		expect(childFallbackChains?.["subagent:unknown-test"]).toEqual(["fallback/working-model:low"]);
+	});
+
+	it("runSubprocess candidate health selection: all depleted retains candidate 0", async () => {
+		const primary = model("primary", "bad-runtime-model");
+		const fallback = model("fallback", "working-model");
+		let childModel: Model | undefined;
+		let childFallbackChains: Record<string, string[]> | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childModel = options.model;
+			childFallbackChains = options.settings?.get("retry.fallbackChains") as Record<string, string[]> | undefined;
+			return {
+				session: createSimpleYieldingSession(),
+				extensionsResult: {},
+				setToolUIContext: () => {},
+			} as unknown as sdkModule.CreateAgentSessionResult;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated();
+
+		const getModelUsageHealthSpy = vi.fn().mockImplementation(async () => {
+			return { state: "depleted" };
+		});
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "all-depleted-test",
+			modelOverride: ["primary/bad-runtime-model:high", "fallback/working-model:low"],
+			modelCandidateRole: "task",
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback],
+				getApiKey: async () => "test-key",
+				hasExplicitProviderApiKey: () => false,
+				authStorage: {
+					getModelUsageHealth: getModelUsageHealthSpy,
+				},
+			} as unknown as ModelRegistry,
+			enableLsp: false,
+		});
+
+		// retains both candidates
+		expect(childModel).toBe(primary);
+		expect(result.resolvedModel).toBe("primary/bad-runtime-model:high");
+		expect(getModelUsageHealthSpy).toHaveBeenCalledTimes(2);
+		expect(childFallbackChains?.["subagent:all-depleted-test"]).toEqual(["fallback/working-model:low"]);
+	});
+
+	it("runSubprocess candidate health selection: explicit provider API key bypasses OAuth health", async () => {
+		const primary = model("primary", "bad-runtime-model");
+		const fallback = model("fallback", "working-model");
+		let childModel: Model | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childModel = options.model;
+			return {
+				session: createSimpleYieldingSession(),
+				extensionsResult: {},
+				setToolUIContext: () => {},
+			} as unknown as sdkModule.CreateAgentSessionResult;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated();
+
+		const getModelUsageHealthSpy = vi.fn();
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "bypass-test",
+			modelOverride: ["primary/bad-runtime-model:high", "fallback/working-model:low"],
+			modelCandidateRole: "task",
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback],
+				getApiKey: async () => "test-key",
+				hasExplicitProviderApiKey: (provider: string) => provider === "primary",
+				authStorage: {
+					getModelUsageHealth: getModelUsageHealthSpy,
+				},
+			} as unknown as ModelRegistry,
+			enableLsp: false,
+		});
+
+		expect(childModel).toBe(primary);
+		expect(getModelUsageHealthSpy).not.toHaveBeenCalled();
+	});
+
+	it("runSubprocess subagent retry fallback injection preserves unrelated modelRoles entries, including malformed objects", async () => {
+		const primary = model("primary", "bad-runtime-model");
+		const fallback = model("fallback", "working-model");
+		let childSettings: Settings | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childSettings = options.settings;
+			return {
+				session: createSimpleYieldingSession(),
+				extensionsResult: {},
+				setToolUIContext: () => {},
+			} as unknown as sdkModule.CreateAgentSessionResult;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated({
+			modelRoles: {
+				unrelatedRole: "primary/bad-runtime-model",
+				malformedRole: { strategy: "invalid-strategy", candidates: [] } as unknown,
+			},
+		});
+
+		await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "retry-injection-test",
+			modelOverride: ["primary/bad-runtime-model", "fallback/working-model"],
+			settings,
+			modelRegistry: {
+				refresh: async () => {},
+				getAvailable: () => [primary, fallback],
+				getApiKey: async () => "test-key",
+			} as unknown as ModelRegistry,
+			enableLsp: false,
+		});
+
+		expect(childSettings).toBeDefined();
+		const finalModelRoles = childSettings!.get("modelRoles") as Record<string, unknown>;
+		expect(finalModelRoles.unrelatedRole).toBe("primary/bad-runtime-model");
+		expect(finalModelRoles.malformedRole).toEqual({ strategy: "invalid-strategy", candidates: [] });
+		expect(finalModelRoles["subagent:retry-injection-test"]).toBe("primary/bad-runtime-model");
+	});
+
+	it("runSubprocess candidate health selection: unresolved command config with no OAuth stays candidate 0 during health check and falls back on eventual auth", async () => {
+		const tempDir = path.join(os.tmpdir(), `pi-test-unresolved-cmd-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		const modelsPath = path.join(tempDir, "models.json");
+		const counterFile = path.join(tempDir, "counter.txt");
+		fs.writeFileSync(counterFile, "0");
+
+		// Command fails (exit 1) to simulate unresolved status.
+		const trackingCommand = `node -e "const fs=require('fs'); fs.writeFileSync('${counterFile.replace(/\\/g, "/")}', String(Number(fs.readFileSync('${counterFile.replace(/\\/g, "/")}', 'utf8')) + 1)); process.exit(1);"`;
+
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					primary: {
+						baseUrl: "https://primary.example.com/v1",
+						api: "openai-completions",
+						apiKey: `!${trackingCommand}`,
+						models: [{ id: "bad-runtime-model", name: "Bad Runtime Model" }],
+					},
+					fallback: {
+						baseUrl: "https://fallback.example.com/v1",
+						api: "openai-completions",
+						apiKey: "fallback-auth-key",
+						models: [{ id: "working-model", name: "Working Model" }],
+					},
+				},
+			}),
+		);
+
+		const authStorage = await AuthStorage.create(":memory:");
+		const registry = new ModelRegistry(authStorage, modelsPath);
+
+		const primary = registry.find("primary", "bad-runtime-model")!;
+		const fallback = registry.find("fallback", "working-model")!;
+		expect(primary).toBeDefined();
+		expect(fallback).toBeDefined();
+
+		// 1. Availability check must include it and NOT execute the command again (only once on eagerness).
+		const available = registry.getAvailable();
+		expect(available.some(m => m.provider === "primary" && m.id === "bad-runtime-model")).toBe(true);
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+
+		let childModel: Model | undefined;
+		vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async options => {
+			if (!options) throw new Error("Expected createAgentSession options");
+			childModel = options.model;
+			return {
+				session: createSimpleYieldingSession(),
+				extensionsResult: {},
+				setToolUIContext: () => {},
+			} as unknown as sdkModule.CreateAgentSessionResult;
+		});
+
+		const agent: AgentDefinition = { name: "task", description: "test", systemPrompt: "test", source: "bundled" };
+		const settings = Settings.isolated();
+		const getModelUsageHealthSpy = vi.fn();
+		const originalGetModelUsageHealth = authStorage.getModelUsageHealth.bind(authStorage);
+		vi.spyOn(authStorage, "getModelUsageHealth").mockImplementation(async (provider, opts) => {
+			getModelUsageHealthSpy(provider, opts);
+			return originalGetModelUsageHealth(provider, opts);
+		});
+
+		const result = await runSubprocess({
+			cwd: "/tmp",
+			agent,
+			task: "work",
+			index: 0,
+			id: "unresolved-command-test",
+			modelOverride: ["primary/bad-runtime-model", "fallback/working-model"],
+			modelCandidateRole: "task",
+			parentActiveModelPattern: "fallback/working-model",
+			settings,
+			modelRegistry: registry,
+			enableLsp: false,
+		});
+
+		// 2. Health is NOT probed (bypassed via hasExplicitProviderApiKey).
+		expect(getModelUsageHealthSpy).not.toHaveBeenCalled();
+
+		// 3. Command has still run only once during the selection process.
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+
+		// 4. Eventual auth fallback redirects it to the parent session's working model.
+		expect(childModel).toBeDefined();
+		expect(childModel!.id).toBe("working-model");
+		expect(result.resolvedModel).toBe("fallback/working-model");
+
+		authStorage.close();
+		try {
+			removeSyncWithRetries(tempDir);
+		} catch {}
 	});
 });

--- a/packages/coding-agent/test/model-registry-command-values.test.ts
+++ b/packages/coding-agent/test/model-registry-command-values.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Api, Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
@@ -22,6 +23,8 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 		fs.mkdirSync(tempDir, { recursive: true });
 		modelsPath = path.join(tempDir, "models.json");
 		authStorage = await AuthStorage.create(":memory:");
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true });
 	});
 
 	afterEach(() => {
@@ -131,5 +134,120 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 
 		// The command should have only run once.
 		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+	});
+
+	test("hasExplicitProviderApiKey returns true for literal and unresolved command provider keys without executing the command during check", async () => {
+		const counterFile = path.join(tempDir, "bypass_counter.txt");
+		fs.writeFileSync(counterFile, "0");
+		// Command increments a counter and then fails (exit 1) to simulate unresolved status.
+		const trackingCommand = `node -e "const fs=require('fs'); fs.writeFileSync('${counterFile.replace(/\\/g, "/")}', String(Number(fs.readFileSync('${counterFile.replace(/\\/g, "/")}', 'utf8')) + 1)); process.exit(1);"`;
+
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"literal-provider": {
+						baseUrl: "https://literal.example.com",
+						apiKey: "literal-key",
+					},
+					"command-provider": {
+						baseUrl: "https://command.example.com",
+						apiKey: `!${trackingCommand}`,
+					},
+				},
+			}),
+		);
+
+		// Eager load executes the command once on initialization.
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+
+		// Querying hasExplicitProviderApiKey must be synchronous and NOT execute the command.
+		expect(registry.hasExplicitProviderApiKey("literal-provider")).toBe(true);
+		expect(registry.hasExplicitProviderApiKey("command-provider")).toBe(true);
+		expect(registry.hasExplicitProviderApiKey("non-existent-provider")).toBe(false);
+
+		// The command execution count remains 1.
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+	});
+
+	test("unresolved command key model is available in getAvailable without re-execution, and disabledProvider excludes it", async () => {
+		const counterFile = path.join(tempDir, "regression_counter.txt");
+		fs.writeFileSync(counterFile, "0");
+		// Command fails (exit 1) to simulate unresolved status.
+		const trackingCommand = `node -e "const fs=require('fs'); fs.writeFileSync('${counterFile.replace(/\\/g, "/")}', String(Number(fs.readFileSync('${counterFile.replace(/\\/g, "/")}', 'utf8')) + 1)); process.exit(1);"`;
+
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"command-provider": {
+						baseUrl: "https://command.example.com",
+						api: "openai-completions",
+						apiKey: `!${trackingCommand}`,
+						models: [{ id: "bad-model", name: "Bad Model" }],
+					},
+				},
+			}),
+		);
+
+		// Eager load executes the command once on initialization.
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+
+		// 1. Model is available in getAvailable, and checking it did NOT re-execute the command.
+		const availableBefore = registry.getAvailable();
+		expect(availableBefore.some(m => m.provider === "command-provider" && m.id === "bad-model")).toBe(true);
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+
+		// 2. Disabled provider still excludes it.
+		const originalDisabled = settings.get("disabledProviders");
+		try {
+			settings.override("disabledProviders", ["command-provider"]);
+			const availableAfter = registry.getAvailable();
+			expect(availableAfter.some(m => m.provider === "command-provider" && m.id === "bad-model")).toBe(false);
+		} finally {
+			// Restore settings
+			settings.override("disabledProviders", originalDisabled);
+		}
+
+		// Check count remains 1 at the end.
+		expect(fs.readFileSync(counterFile, "utf8")).toBe("1");
+	});
+
+	test("getAvailable memoizes configured-auth lookup once per provider when multiple models share a provider", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"shared-provider": {
+						baseUrl: "https://shared.example.com",
+						api: "openai-completions",
+						apiKey: "dummy-key",
+						models: [
+							{ id: "model-1", name: "Model 1" },
+							{ id: "model-2", name: "Model 2" },
+							{ id: "model-3", name: "Model 3" },
+						],
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const hasAuthSpy = vi.spyOn(authStorage, "hasAuth").mockReturnValue(true);
+
+		const available = registry.getAvailable();
+
+		// Assert availability of all three models under the shared provider
+		const sharedModels = available.filter(m => m.provider === "shared-provider");
+		expect(sharedModels.length).toBe(3);
+		expect(sharedModels.map(m => m.id).sort()).toEqual(["model-1", "model-2", "model-3"]);
+
+		// Assert hasAuth was called exactly ONCE for "shared-provider" due to provider-level memoization
+		const callsForShared = hasAuthSpy.mock.calls.filter(args => args[0] === "shared-provider");
+		expect(callsForShared.length).toBe(1);
+
+		hasAuthSpy.mockRestore();
 	});
 });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -10,6 +10,7 @@ import {
 	parseModelString,
 	pickDefaultAvailableModel,
 	resolveAgentModelPatterns,
+	resolveAgentModelRequest,
 	resolveAllowedModels,
 	resolveCliModel,
 	resolveModelFromString,
@@ -839,6 +840,319 @@ describe("resolveAgentModelPatterns", () => {
 		const dashed = resolveModelOverride(patterns, dashedRegistry, settings);
 		expect(dashed.model?.provider).toBe("anthropic");
 		expect(dashed.model?.id).toBe("claude-opus-4-8");
+	});
+});
+
+describe("resolveAgentModelRequest and ordered candidates", () => {
+	test("returns all candidates and candidateRole with resolveAgentModelRequest", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+			},
+		});
+
+		const result = resolveAgentModelRequest({
+			agentModel: "pi/task",
+			settings,
+		});
+
+		expect(result.patterns).toEqual(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]);
+		expect(result.candidateRole).toBe("task");
+	});
+
+	test("legacy resolveAgentModelPatterns returns candidate 0 only for the same settings", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+			},
+		});
+
+		const result = resolveAgentModelPatterns({
+			agentModel: "pi/task",
+			settings,
+		});
+
+		expect(result).toEqual(["anthropic/claude-sonnet-4-5"]);
+	});
+
+	test("resolves candidate 0 only for default, pi/default, or undefined without returning candidateRole", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+			},
+		});
+
+		// Case 1: pi/default
+		const reqPiDefault = resolveAgentModelRequest({
+			agentModel: "pi/default",
+			settings,
+		});
+		expect(reqPiDefault.patterns).toEqual(["anthropic/claude-sonnet-4-5"]);
+		expect(reqPiDefault.candidateRole).toBeUndefined();
+
+		const patPiDefault = resolveAgentModelPatterns({
+			agentModel: "pi/default",
+			settings,
+		});
+		expect(patPiDefault).toEqual(["anthropic/claude-sonnet-4-5"]);
+
+		// Case 2: default
+		const reqDefault = resolveAgentModelRequest({
+			agentModel: "default",
+			settings,
+		});
+		expect(reqDefault.patterns).toEqual(["anthropic/claude-sonnet-4-5"]);
+		expect(reqDefault.candidateRole).toBeUndefined();
+
+		const patDefault = resolveAgentModelPatterns({
+			agentModel: "default",
+			settings,
+		});
+		expect(patDefault).toEqual(["anthropic/claude-sonnet-4-5"]);
+
+		// Case 3: undefined (falls back to default model role)
+		const reqUndefined = resolveAgentModelRequest({
+			settings,
+		});
+		expect(reqUndefined.patterns).toEqual(["anthropic/claude-sonnet-4-5"]);
+		expect(reqUndefined.candidateRole).toBeUndefined();
+
+		const patUndefined = resolveAgentModelPatterns({
+			settings,
+		});
+		expect(patUndefined).toEqual(["anthropic/claude-sonnet-4-5"]);
+	});
+
+	test("bypasses candidate list policy when settingsOverride is passed", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+			},
+		});
+
+		const result = resolveAgentModelRequest({
+			agentModel: "pi/task",
+			settingsOverride: "openai/gpt-4o:high",
+			settings,
+		});
+
+		expect(result.patterns).toEqual(["openai/gpt-4o:high"]);
+		expect(result.candidateRole).toBeUndefined();
+	});
+
+	test("settingsOverride with single role pattern resolves candidates and candidateRole", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				slow: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+				default: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+			},
+		});
+
+		// settingsOverride='pi/slow:high' returns full candidates + candidateRole and applies :high
+		const result = resolveAgentModelRequest({
+			settingsOverride: "pi/slow:high",
+			settings,
+		});
+		expect(result.patterns).toEqual(["anthropic/claude-sonnet-4-5:high", "openai/gpt-4o:high"]);
+		expect(result.candidateRole).toBe("slow");
+
+		// legacy resolveAgentModelPatterns returns candidate0 with thinking suffix
+		const patternsResult = resolveAgentModelPatterns({
+			settingsOverride: "pi/slow:high",
+			settings,
+		});
+		expect(patternsResult).toEqual(["anthropic/claude-sonnet-4-5:high"]);
+
+		// pi/default remains no marker (candidateRole is undefined)
+		const resultDefault = resolveAgentModelRequest({
+			settingsOverride: "pi/default:high",
+			settings,
+		});
+		expect(resultDefault.patterns).toEqual(["anthropic/claude-sonnet-4-5:high"]);
+		expect(resultDefault.candidateRole).toBeUndefined();
+	});
+
+	test("regression: settingsOverride with empty role expansion falls through to agent model or fallback", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				task: ",", // expands to empty because resolved.length is 0 and task has no roleDefaults
+				default: "local/fallback-model",
+			},
+		});
+
+		const result = resolveAgentModelRequest({
+			settingsOverride: "pi/task",
+			fallbackModelPattern: "openai/gpt-4o",
+			settings,
+		});
+
+		// Should fall through to fallbackModelPattern (openai/gpt-4o) since pi/task has empty expansion
+		expect(result.patterns).toEqual(["openai/gpt-4o"]);
+		expect(result.candidateRole).toBeUndefined();
+	});
+
+	test("appends and strips thinking level suffixes correctly", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5:low" }, { model: "openai/gpt-4o" }],
+				},
+			},
+		});
+
+		// If outer pattern specifies :high, strip :low from candidate 0 and apply :high to all.
+		const resultHigh = resolveAgentModelRequest({
+			agentModel: "pi/task:high",
+			settings,
+		});
+		expect(resultHigh.patterns).toEqual(["anthropic/claude-sonnet-4-5:high", "openai/gpt-4o:high"]);
+		expect(resultHigh.candidateRole).toBe("task");
+
+		// If outer pattern has no suffix, preserve candidate's own suffix if present.
+		const resultNone = resolveAgentModelRequest({
+			agentModel: "pi/task",
+			settings,
+		});
+		expect(resultNone.patterns).toEqual(["anthropic/claude-sonnet-4-5:low", "openai/gpt-4o"]);
+		expect(resultNone.candidateRole).toBe("task");
+	});
+
+	test("falls back to default/built-in resolution if expansion of a candidate fails", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "local/fallback-model",
+				task: {
+					strategy: "ordered",
+					candidates: [
+						{ model: "" }, // empty is invalid -> candidate resolution fails
+						{ model: "openai/gpt-4o" },
+					],
+				},
+			},
+		});
+
+		const result = resolveAgentModelRequest({
+			agentModel: "pi/task",
+			settings,
+		});
+
+		// When candidates parsing fails, it falls back to the default or built-in priorities
+		expect(result.patterns).toEqual(["local/fallback-model"]);
+		expect(result.candidateRole).toBeUndefined();
+	});
+
+	test("retains legacy scalar, comma, and string-array formats behavior and returns candidateRole undefined", () => {
+		const settingsScalar = Settings.isolated({
+			modelRoles: { task: "anthropic/claude-sonnet-4-5" },
+		});
+		const resScalar = resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsScalar });
+		expect(resScalar.patterns).toEqual(["anthropic/claude-sonnet-4-5"]);
+		expect(resScalar.candidateRole).toBeUndefined();
+
+		const settingsComma = Settings.isolated({
+			modelRoles: { task: "anthropic/claude-sonnet-4-5,openai/gpt-4o" },
+		});
+		const resComma = resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsComma });
+		expect(resComma.patterns).toEqual(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]);
+		expect(resComma.candidateRole).toBeUndefined();
+
+		const settingsArray = Settings.isolated({
+			modelRoles: { task: ["anthropic/claude-sonnet-4-5", "openai/gpt-4o"] },
+		});
+		const resArray = resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsArray });
+		expect(resArray.patterns).toEqual(["anthropic/claude-sonnet-4-5", "openai/gpt-4o"]);
+		expect(resArray.candidateRole).toBeUndefined();
+	});
+
+	test("ignores invalid candidates with comma lists or default/nested roles and treats policy as absent", () => {
+		// Candidate with comma list
+		const settingsCommaCand = Settings.isolated({
+			modelRoles: {
+				default: "local/fallback-model",
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet,openai/gpt-4o" }],
+				},
+			},
+		});
+		expect(resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsCommaCand }).patterns).toEqual([
+			"local/fallback-model",
+		]);
+
+		// Candidate with "default" role
+		const settingsDefaultCand = Settings.isolated({
+			modelRoles: {
+				default: "local/fallback-model",
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "default" }],
+				},
+			},
+		});
+		expect(resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsDefaultCand }).patterns).toEqual([
+			"local/fallback-model",
+		]);
+
+		// Candidate with nested "pi/slow" role
+		const settingsSlowCand = Settings.isolated({
+			modelRoles: {
+				default: "local/fallback-model",
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "pi/slow" }],
+				},
+			},
+		});
+		expect(resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsSlowCand }).patterns).toEqual([
+			"local/fallback-model",
+		]);
+
+		// Candidate with nested "pi/slow:high" role (with thinking suffix)
+		const settingsSlowSuffixCand = Settings.isolated({
+			modelRoles: {
+				default: "local/fallback-model",
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "pi/slow:high" }],
+				},
+			},
+		});
+		expect(resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsSlowSuffixCand }).patterns).toEqual([
+			"local/fallback-model",
+		]);
+
+		// Non-ordered strategy
+		const settingsUnordered = Settings.isolated({
+			modelRoles: {
+				default: "local/fallback-model",
+				task: {
+					strategy: "unordered",
+					candidates: [{ model: "openai/gpt-4o" }],
+				},
+			},
+		});
+		expect(resolveAgentModelRequest({ agentModel: "pi/task", settings: settingsUnordered }).patterns).toEqual([
+			"local/fallback-model",
+		]);
 	});
 });
 

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -244,6 +244,33 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("deferred subagent fallback injection preserves unrelated modelRoles entries, including malformed objects", async () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				unrelatedRole: "runtime-provider/runtime-model",
+				malformedRole: { strategy: "invalid-strategy", candidates: [] } as unknown,
+			},
+		});
+
+		const { session } = await createAgentSession({
+			...(await buildSessionOptions(["runtime-provider/runtime-model", "runtime-provider/runtime-reasoning-model"])),
+			modelPatternFallbackRole: "subagent:deferred",
+			settings,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("runtime-provider");
+			expect(session.model?.id).toBe("runtime-model");
+
+			const finalModelRoles = session.settings.get("modelRoles") as Record<string, unknown>;
+			expect(finalModelRoles.unrelatedRole).toBe("runtime-provider/runtime-model");
+			expect(finalModelRoles.malformedRole).toEqual({ strategy: "invalid-strategy", candidates: [] });
+			expect(finalModelRoles["subagent:deferred"]).toBe("runtime-provider/runtime-model");
+		} finally {
+			await session.dispose();
+		}
+	});
+
 	test("splits deferred comma-delimited modelPattern and installs fallback chain", async () => {
 		const { session } = await createAgentSession({
 			...(await buildSessionOptions("runtime-provider/runtime-model,runtime-provider/runtime-reasoning-model")),

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -18,6 +18,7 @@ import {
 import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
 import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
+import type { ModelRolesSettings } from "../src/config/settings-schema";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
 
 function context(): Context {
@@ -450,6 +451,92 @@ describe("Settings", () => {
 			settings.clearOverride("modelRoles");
 
 			expect(settings.getModelRole("default")).toBe("anthropic/claude-opus-4-5");
+		});
+
+		it("projects candidate 0 for valid ordered object modelRoles configurations", () => {
+			const settings = Settings.isolated({
+				modelRoles: {
+					task: {
+						strategy: "ordered",
+						candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+					},
+					default: "local/fallback",
+				},
+			});
+
+			expect(settings.getModelRole("task")).toBe("anthropic/claude-sonnet-4-5");
+			expect(settings.getModelRoles().task).toBe("anthropic/claude-sonnet-4-5");
+			expect(settings.getModelRole("default")).toBe("local/fallback");
+		});
+
+		it("preserves unrelated raw values including malformed and valid objects during setModelRole", () => {
+			const rawModelRoles: Record<string, unknown> = {
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+				malformed: {
+					strategy: "unordered",
+					candidates: [],
+				},
+				scalar: "openai/gpt-4o",
+			};
+
+			const settings = Settings.isolated({
+				modelRoles: rawModelRoles as unknown as ModelRolesSettings,
+			});
+
+			settings.setModelRole("smol", "local/llama");
+
+			const currentRoles = settings.get("modelRoles");
+			expect(currentRoles).toBeDefined();
+			expect(currentRoles).toEqual({
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+				malformed: {
+					strategy: "unordered",
+					candidates: [],
+				},
+				scalar: "openai/gpt-4o",
+				smol: "local/llama",
+			} as unknown as ModelRolesSettings);
+		});
+
+		it("preserves unrelated raw values including malformed and valid objects during overrideModelRoles", () => {
+			const rawModelRoles: Record<string, unknown> = {
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+				malformed: {
+					strategy: "unordered",
+					candidates: [],
+				},
+				scalar: "openai/gpt-4o",
+			};
+
+			const settings = Settings.isolated({
+				modelRoles: rawModelRoles as unknown as ModelRolesSettings,
+			});
+
+			settings.overrideModelRoles({ smol: "local/llama" });
+
+			const currentRoles = settings.get("modelRoles");
+			expect(currentRoles).toBeDefined();
+			expect(currentRoles).toEqual({
+				task: {
+					strategy: "ordered",
+					candidates: [{ model: "anthropic/claude-sonnet-4-5" }, { model: "openai/gpt-4o" }],
+				},
+				malformed: {
+					strategy: "unordered",
+					candidates: [],
+				},
+				scalar: "openai/gpt-4o",
+				smol: "local/llama",
+			} as unknown as ModelRolesSettings);
 		});
 	});
 

--- a/packages/coding-agent/test/task/task-spawn.test.ts
+++ b/packages/coding-agent/test/task/task-spawn.test.ts
@@ -466,4 +466,89 @@ describe("task spawn routing", () => {
 			expect(unboundedTool.description).not.toContain("Concurrency cap");
 		}
 	});
+
+	it("transports full ordered patterns plus modelCandidateRole for exact role policy after semaphore acquisition", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [{ ...taskAgent, model: ["pi/task"] }],
+			projectAgentsDir: null,
+		});
+
+		let capturedOptions: unknown;
+		const runSpy = vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			capturedOptions = options;
+			return makeResult(options.id ?? "?");
+		});
+
+		const manager = createManager();
+		const settings = {
+			modelRoles: {
+				task: {
+					strategy: "ordered" as const,
+					candidates: [{ model: "primary-candidate" }, { model: "fallback-candidate" }],
+				},
+			},
+		};
+		const tool = await TaskTool.create(createSession({ manager, settings }));
+
+		const result = await tool.execute("tc-exact-role", {
+			agent: "task",
+			id: "ExactRoleAgent",
+			description: "role policy task",
+			assignment: "Do the thing.",
+		} as TaskParams);
+
+		const jobId = result.details?.async?.jobId;
+		expect(jobId).toBeTruthy();
+		const job = manager.getJob(jobId!);
+		await job!.promise;
+
+		expect(runSpy).toHaveBeenCalledTimes(1);
+		expect(capturedOptions).toBeDefined();
+		const opts = capturedOptions as Record<string, unknown>;
+		expect(opts.modelOverride).toEqual(["primary-candidate", "fallback-candidate"]);
+		expect(opts.modelCandidateRole).toBe("task");
+	});
+
+	it("transports concrete override patterns without modelCandidateRole", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [{ ...taskAgent, model: ["pi/task"] }],
+			projectAgentsDir: null,
+		});
+
+		let capturedOptions: unknown;
+		const runSpy = vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			capturedOptions = options;
+			return makeResult(options.id ?? "?");
+		});
+
+		const manager = createManager();
+		const settings = {
+			modelRoles: {
+				task: {
+					strategy: "ordered" as const,
+					candidates: [{ model: "primary-candidate" }, { model: "fallback-candidate" }],
+				},
+			},
+			"task.agentModelOverrides.task": "concrete-override",
+		};
+		const tool = await TaskTool.create(createSession({ manager, settings }));
+
+		const result = await tool.execute("tc-concrete-override", {
+			agent: "task",
+			id: "ConcreteOverrideAgent",
+			description: "concrete override task",
+			assignment: "Do the thing.",
+		} as TaskParams);
+
+		const jobId = result.details?.async?.jobId;
+		expect(jobId).toBeTruthy();
+		const job = manager.getJob(jobId!);
+		await job!.promise;
+
+		expect(runSpy).toHaveBeenCalledTimes(1);
+		expect(capturedOptions).toBeDefined();
+		const opts = capturedOptions as Record<string, unknown>;
+		expect(opts.modelOverride).toEqual(["concrete-override"]);
+		expect(opts.modelCandidateRole).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## What

- Add a typed, model-scoped OAuth usage-health query with per-account quota-window summaries.
- Allow `modelRoles.<role>` to declare opt-in ordered candidates for TaskTool subagents.
- Skip only candidates known depleted while preserving explicit provider-key, auth, and retry precedence.

## Why

Relates to #5017.
Relates to #5018.

This is the narrow shared substrate requested by maintainers; weighted and extra strategies, reserve confirmation, eval support, new retry behavior, and expanded UI remain follow-ups.

## Testing

- `bun test packages/ai/test/auth-storage-model-usage-health.test.ts`
- `bun test packages/coding-agent/test/model-resolver.test.ts packages/coding-agent/test/settings-manager.test.ts packages/coding-agent/test/model-registry-command-values.test.ts packages/coding-agent/test/issue-2750-subagent-runtime-fallback.test.ts packages/coding-agent/test/sdk-model-selection.test.ts packages/coding-agent/test/task/task-spawn.test.ts packages/coding-agent/test/bundled-agent-parsing.test.ts`
- `bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)