### PR TITLE
fix(mcp): match stdio spawn overload for macOS TCC

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed macOS stdio MCP servers still missing Apple Events TCC prompts by spawning MCP children through the same argv-first `Bun.spawn` overload used by the JS eval kernel. ([#5085](https://github.com/can1357/oh-my-pi/issues/5085))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/mcp/transports/stdio.test.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 import { resolveStdioSpawnCommand, StdioTransport } from "./stdio";
 
@@ -53,6 +53,50 @@ describe("resolveStdioSpawnCommand", () => {
 			cmd: ["server.exe", "--stdio"],
 			detached: true,
 		});
+	});
+});
+
+describe("StdioTransport.connect", () => {
+	it("passes argv as Bun.spawn's first argument and process options as the second", async () => {
+		const cwd = process.cwd();
+		const envValue = "stdio-spawn-shape";
+		const argv = [process.execPath, "-e", "process.exit(0)"];
+		const transport = new StdioTransport({
+			command: argv[0],
+			args: argv.slice(1),
+			cwd,
+			env: {
+				OMP_STDIO_SPAWN_SHAPE: envValue,
+			},
+		});
+		const spawnSpy = spyOn(Bun, "spawn");
+
+		try {
+			await transport.connect();
+
+			expect(spawnSpy).toHaveBeenCalledTimes(1);
+			const call = spawnSpy.mock.calls[0];
+			if (!call) throw new Error("expected StdioTransport.connect() to spawn exactly one subprocess");
+
+			const [spawnArgv, spawnOptions] = call;
+			expect(spawnArgv).toEqual(argv);
+			expect(spawnOptions).toEqual(
+				expect.objectContaining({
+					cwd,
+					detached: !(process.platform === "darwin" || process.platform === "win32"),
+					env: expect.objectContaining({
+						OMP_STDIO_SPAWN_SHAPE: envValue,
+					}),
+					stderr: "pipe",
+					stdin: "pipe",
+					stdout: "pipe",
+					windowsHide: process.platform === "win32" ? expect.any(Boolean) : undefined,
+				}),
+			);
+		} finally {
+			await transport.close();
+			spawnSpy.mockRestore();
+		}
 	});
 });
 

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -8,7 +8,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { getProjectDir, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
-import { type Subprocess, spawn } from "bun";
+import type { Subprocess } from "bun";
 import { hostHasInheritableConsole } from "../../eval/py/spawn-options";
 import type {
 	JsonRpcError,
@@ -376,8 +376,11 @@ export class StdioTransport implements MCPTransport {
 		// macOS stays attached so TCC can prompt for Apple Events automation;
 		// Windows stays attached, and only hides the child when the host has no
 		// console to share. See `StdioSpawnCommand`.
-		this.#process = spawn({
-			cmd: spawnCommand.cmd,
+		// Keep this on Bun's argv-first overload. The eval JS kernel path that
+		// triggers macOS Apple Events TCC prompts uses the same shape; the
+		// one-object `{ cmd }` overload timed out before prompting for `mcpbridge`
+		// even with `detached: false` (#5085).
+		this.#process = Bun.spawn(spawnCommand.cmd, {
 			cwd,
 			env,
 			stdin: "pipe",


### PR DESCRIPTION
## Repro
Reporter reproduced on macOS 26.5.2 with `omp` 16.4.0 and `~/.omp/agent/mcp.json` containing `{"type":"stdio","command":"xcrun","args":["mcpbridge"]}`: `/mcp reload` times out after 30000ms with no Apple Events TCC prompt, while the same process can trigger the prompt and load 21 tools by running `Bun.spawn(["xcrun", "mcpbridge"], { stdin: "pipe", stdout: "pipe", stderr: "pipe" })` from the JS eval kernel.

## Cause
`packages/coding-agent/src/mcp/transports/stdio.ts` resolved the macOS `detached: false` flag correctly, but `StdioTransport.connect()` still invoked Bun through the one-object `{ cmd, ...options }` overload. The working eval path uses Bun's argv-first overload, so stdio MCP children did not match the launch path that macOS TCC accepts for `xcrun mcpbridge`.

## Fix
- Switched `StdioTransport.connect()` to call `Bun.spawn(spawnCommand.cmd, options)` while preserving cwd, env overlay, stdio pipes, `detached`, and `windowsHide` options.
- Added a regression test asserting `StdioTransport.connect()` uses the argv-first `Bun.spawn` overload with process options as the second argument.
- Added an Unreleased changelog entry for the macOS stdio MCP TCC fix.

## Verification
`cd packages/coding-agent && bun test src/mcp/transports/stdio.test.ts` passed: 6 tests, 11 assertions. Pre-publish gate completed during branch push. Fixes #5085