### PR TITLE
fix(tool): resolve bare skill urls to directories

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bare `skill://<name>` path-only resolution for bash, grep, and glob so tools receive the skill directory instead of `SKILL.md`, while `read skill://<name>` still opens the skill instructions. ([#5087](https://github.com/can1357/oh-my-pi/issues/5087))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/internal-urls/skill-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/skill-protocol.ts
@@ -72,7 +72,7 @@ export class SkillProtocolHandler implements ProtocolHandler {
 				throw new Error("Path traversal is not allowed");
 			}
 		} else {
-			targetPath = skill.filePath;
+			targetPath = context?.pathOnly === true ? skill.baseDir : skill.filePath;
 		}
 
 		let stats: fsTypes.Stats;

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -66,7 +66,7 @@ export function resolveSkillUrlToPath(url: string, skills: readonly Skill[]): st
 	const hasRelativePath = rawPath !== "" && rawPath !== "/";
 
 	if (!hasRelativePath) {
-		return path.resolve(skill.filePath);
+		return path.resolve(skill.baseDir);
 	}
 
 	let relativePath: string;

--- a/packages/coding-agent/src/tools/glob.ts
+++ b/packages/coding-agent/src/tools/glob.ts
@@ -184,6 +184,7 @@ export class GlobTool implements AgentTool<typeof findSchema, GlobToolDetails> {
 					signal,
 					localProtocolOptions: this.session.localProtocolOptions,
 					skills: this.session.skills,
+					pathOnly: true,
 				});
 				if (!resource.sourcePath) {
 					throw new ToolError(`Cannot find internal URL without a backing file: ${rawPattern}`);

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -133,11 +133,11 @@ describe("expandSkillUrls", () => {
 		expect(expandSkillUrls(command, skills)).toBe(`python ${shellEscape(expectedPath)}`);
 	});
 
-	it("resolves skill://name with no relative path to SKILL.md", () => {
+	it("resolves skill://name with no relative path to the skill directory", () => {
 		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
-		const command = "cat skill://valid-skill";
+		const command = "printf '%s\n' skill://valid-skill";
 
-		expect(expandSkillUrls(command, skills)).toBe(`cat ${shellEscape(skills[0].filePath)}`);
+		expect(expandSkillUrls(command, skills)).toBe(`printf '%s\n' ${shellEscape(skills[0].baseDir)}`);
 	});
 
 	it("returns command unchanged when no skills are loaded", () => {

--- a/packages/coding-agent/test/tools/grep-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/grep-internal-urls.test.ts
@@ -182,6 +182,24 @@ describe("GrepTool internal URL resolution", () => {
 		expect(getResultText(findResult)).toContain("guide.md");
 	});
 
+	it("walks bare skill:// roots for search and find", async () => {
+		await registerSkillDirectory();
+		const session = createSession({ hasEditTool: true });
+		const searchTool = new GrepTool(session);
+		const findTool = new GlobTool(session);
+
+		const searchResult = await searchTool.execute("test-search", {
+			pattern: "deep needle",
+			path: "skill://demo",
+		});
+		const findResult = await findTool.execute("test-find", {
+			path: "skill://demo",
+		});
+
+		expect(getResultText(searchResult)).toContain("deep needle");
+		expect(getResultText(findResult)).toContain("guide.md");
+	});
+
 	it("resolves artifact:// URL to backing file and greps it", async () => {
 		const content = "line one\nfound the needle here\nline three\n";
 		await Bun.write(path.join(artifactsDir, "5.bash.log"), content);


### PR DESCRIPTION
## Repro
Bare `skill://<name>` resolved to `<skill>/SKILL.md` for filesystem/path-only tool use. `bun test packages/coding-agent/test/tools/bash-skill-urls.test.ts -t "skill directory"` showed bash expansion returning `/tmp/skills/valid-skill/SKILL.md`, and `bun test packages/coding-agent/test/tools/grep-internal-urls.test.ts -t "bare skill"` showed `grep` could not find content under `skill://demo/references/docs/guide.md` when searching `skill://demo`.

## Cause
`packages/coding-agent/src/tools/bash-skill-urls.ts` returned `skill.filePath` for bare `skill://<name>`, and `SkillProtocolHandler.resolve()` in `packages/coding-agent/src/internal-urls/skill-protocol.ts` ignored `ResolveContext.pathOnly`, so path-oriented callers received the instructions file instead of the skill root. `GlobTool` also resolved internal URLs without `pathOnly`, so bare skill roots were treated as a single file.

## Fix
- Changed bash `skill://<name>` expansion to return the absolute skill `baseDir` when no relative path is present.
- Taught `SkillProtocolHandler` to resolve bare skill URLs to `baseDir` only for `pathOnly` callers, preserving `read skill://<name>` as `SKILL.md` content.
- Passed `pathOnly: true` from `GlobTool` internal URL resolution so glob uses the same filesystem root semantics as grep.
- Added regression coverage for bash expansion and bare-root grep/glob traversal.
- Added the coding-agent changelog entry for #5087.

## Verification
`bun test packages/coding-agent/test/tools/bash-skill-urls.test.ts packages/coding-agent/test/tools/grep-internal-urls.test.ts` passed: 62 tests, 106 assertions. `gh_push_branch` pre-publish gate completed and pushed `cf4e510acdfd`. Fixes #5087