### PR TITLE
fix(coding-agent): suppress todo reminders for interactive questions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed todo reminders auto-continuing over interactive skill questions; text-only assistant questions now yield to the user without firing the incomplete-todo reminder loop. ([#5089](https://github.com/can1357/oh-my-pi/issues/5089))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -407,7 +407,13 @@ const MID_RUN_TODO_NUDGE_MUTATING_TOOLS: Record<string, true> = {
 	write: true,
 	ast_edit: true,
 };
-const USER_RESPONSE_CUE_RE = /\b(?:confirm|reply|answer|choose|pick|decide|advise|let\s+me\s+know|tell\s+me)\b/i;
+const MARKDOWN_PROMPT_PREFIX_RE = /^(?:>\s*)?(?:(?:[-*+]|\d+[.)])\s+)*/;
+const PROMPT_LABEL_RE = /^(?:q(?:uestion)?|ask)\s*\d*\s*[:.)-]\s*/i;
+const QUESTION_PROMPT_RE =
+	/^(?:what|which|when|where|why|how|who|whom|whose|do|does|did|can|could|would|will|should|is|are|am|may|shall)\b/i;
+const USER_DIRECTED_PROMPT_RE = /\b(?:you|your|we|our)\b/i;
+const USER_RESPONSE_CUE_RE =
+	/^(?:please\s+)?(?:confirm|reply|choose|pick|decide|advise)\b|^(?:please\s+)?answer\b|^(?:please\s+)?(?:let\s+me\s+know|tell\s+me)\b/i;
 
 function assistantText(message: AssistantMessage): string {
 	return message.content
@@ -417,16 +423,47 @@ function assistantText(message: AssistantMessage): string {
 		.trim();
 }
 
+interface PromptLine {
+	text: string;
+	hadPromptLabel: boolean;
+}
+
+function promptLine(line: string): PromptLine {
+	const withoutMarkdownPrefix = line.trim().replace(MARKDOWN_PROMPT_PREFIX_RE, "").trim();
+	const withoutPromptLabel = withoutMarkdownPrefix.replace(PROMPT_LABEL_RE, "").trim();
+	return {
+		text: withoutPromptLabel,
+		hadPromptLabel: withoutPromptLabel !== withoutMarkdownPrefix,
+	};
+}
+
+function isQuestionPromptLine(line: string): boolean {
+	const candidate = promptLine(line);
+	if (!/[?？]\s*$/.test(candidate.text)) return false;
+	return (
+		candidate.hadPromptLabel ||
+		QUESTION_PROMPT_RE.test(candidate.text) ||
+		USER_DIRECTED_PROMPT_RE.test(candidate.text)
+	);
+}
+
+function isResponseCueLine(line: string): boolean {
+	const candidate = promptLine(line)
+		.text.replace(/[.!?。！？]+$/, "")
+		.trim();
+	return USER_RESPONSE_CUE_RE.test(candidate);
+}
+
 function isAwaitingUserAnswer(message: AssistantMessage): boolean {
 	const text = assistantText(message);
 	if (!text) return false;
-	const tail = text
+	const tailLines = text
 		.split(/\r?\n/)
 		.map(line => line.trim())
 		.filter(Boolean)
-		.slice(-6)
-		.join("\n");
-	return /[?？]/.test(tail) || USER_RESPONSE_CUE_RE.test(tail);
+		.slice(-6);
+	const lastLine = tailLines.at(-1);
+	return tailLines.some(isQuestionPromptLine) || (lastLine !== undefined && isResponseCueLine(lastLine));
 }
 /** `customType` for the hidden mid-run todo nudge; `display: false`, so it reaches
  *  the model but never renders in the TUI or transcript. */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -407,6 +407,27 @@ const MID_RUN_TODO_NUDGE_MUTATING_TOOLS: Record<string, true> = {
 	write: true,
 	ast_edit: true,
 };
+const USER_RESPONSE_CUE_RE = /\b(?:confirm|reply|answer|choose|pick|decide|advise|let\s+me\s+know|tell\s+me)\b/i;
+
+function assistantText(message: AssistantMessage): string {
+	return message.content
+		.filter((content): content is TextContent => content.type === "text")
+		.map(content => content.text)
+		.join("\n")
+		.trim();
+}
+
+function isAwaitingUserAnswer(message: AssistantMessage): boolean {
+	const text = assistantText(message);
+	if (!text) return false;
+	const tail = text
+		.split(/\r?\n/)
+		.map(line => line.trim())
+		.filter(Boolean)
+		.slice(-6)
+		.join("\n");
+	return /[?？]/.test(tail) || USER_RESPONSE_CUE_RE.test(tail);
+}
 /** `customType` for the hidden mid-run todo nudge; `display: false`, so it reaches
  *  the model but never renders in the TUI or transcript. */
 const MID_RUN_TODO_NUDGE_MESSAGE_TYPE = "mid-run-todo-nudge";
@@ -4146,7 +4167,7 @@ export class AgentSession {
 					await emitAgentEndNotification();
 					return;
 				}
-				const todoContinuationScheduled = await this.#checkTodoCompletion();
+				const todoContinuationScheduled = await this.#checkTodoCompletion(msg);
 				if (todoContinuationScheduled) {
 					await emitAgentEndNotification();
 					return;
@@ -11419,7 +11440,7 @@ export class AgentSession {
 	/**
 	 * Check if agent stopped with incomplete todos and prompt to continue.
 	 */
-	async #checkTodoCompletion(): Promise<boolean> {
+	async #checkTodoCompletion(message: AssistantMessage): Promise<boolean> {
 		// Skip todo reminders when the most recent turn was driven by an explicit user force —
 		// the user wanted exactly that tool, not a follow-up nag about incomplete todos.
 		const lastServedLabel = this.#toolChoiceQueue.consumeLastServedLabel();
@@ -11481,6 +11502,13 @@ export class AgentSession {
 		if (incomplete.length === 0) {
 			this.#todoReminderCount = 0;
 			this.#todoReminderAwaitingProgress = false;
+			return false;
+		}
+
+		if (isAwaitingUserAnswer(message)) {
+			logger.debug("Todo completion: assistant is waiting for user input; skipping reminder", {
+				incomplete: incomplete.length,
+			});
 			return false;
 		}
 

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -186,6 +186,30 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
+	it("still reminds and continues when ordinary prose contains answer", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("Final answer: I summarized the work completed so far, but the todo items remain open.");
+		await withTimeout(firstReminderPromise, 1000, "todo_reminder never fired");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([1]);
+		expect(todoReminderTranscriptEntry()).toBeDefined();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("still reminds and continues when TypeScript optional syntax appears in the assistant tail", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("Tail note: the interface includes foo?: string, but the todo items remain open.");
+		await withTimeout(firstReminderPromise, 1000, "todo_reminder never fired");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([1]);
+		expect(todoReminderTranscriptEntry()).toBeDefined();
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("fires exactly one reminder per user pause when the agent only acknowledges", async () => {
 		// Each call to continue() mirrors what the bug-reported model did: emit another
 		// text-only stop ("paused at your instruction"), no tool calls in between.

--- a/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts
@@ -31,10 +31,10 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 	let firstReminderPromise: Promise<void>;
 	let resolveFirstReminder: () => void;
 
-	function textOnlyAssistantMessage(): AssistantMessage {
+	function textOnlyAssistantMessage(text = "paused at your instruction"): AssistantMessage {
 		return {
 			role: "assistant",
-			content: [{ type: "text", text: "paused at your instruction" }],
+			content: [{ type: "text", text }],
 			api: "anthropic-messages",
 			provider: "anthropic",
 			model: "claude-sonnet-4-5",
@@ -51,8 +51,8 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		};
 	}
 
-	function emitTextOnlyStop(): void {
-		const msg = textOnlyAssistantMessage();
+	function emitTextOnlyStop(text?: string): void {
+		const msg = textOnlyAssistantMessage(text);
 		session.agent.emitExternalEvent({ type: "message_end", message: msg });
 		session.agent.emitExternalEvent({ type: "agent_end", messages: [msg] });
 	}
@@ -90,6 +90,18 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 				details,
 				timestamp: Date.now(),
 			},
+		});
+	}
+
+	function todoReminderTranscriptEntry() {
+		return sessionManager.getBranch().find(entry => {
+			if (entry.type !== "message" || entry.message.role !== "developer") return false;
+			const { content } = entry.message;
+			if (!Array.isArray(content)) return false;
+			return content.some(
+				(item): item is TextContent =>
+					item.type === "text" && item.text.includes("You stopped with 2 incomplete todo item(s):"),
+			);
 		});
 	}
 
@@ -159,16 +171,19 @@ describe("AgentSession todo reminder self-continuation suppression", () => {
 		await withTimeout(firstReminderPromise, 1000, "todo_reminder never fired");
 		expect(reminderAttempts).toEqual([1]);
 
-		const reminderEntry = sessionManager.getBranch().find(entry => {
-			if (entry.type !== "message" || entry.message.role !== "developer") return false;
-			const { content } = entry.message;
-			if (!Array.isArray(content)) return false;
-			return content.some(
-				(item): item is TextContent =>
-					item.type === "text" && item.text.includes("You stopped with 2 incomplete todo item(s):"),
-			);
-		});
+		const reminderEntry = todoReminderTranscriptEntry();
 		expect(reminderEntry?.type).toBe("message");
+	});
+
+	it("does not remind or continue when the assistant yields with a user-facing question", async () => {
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+
+		emitTextOnlyStop("I need your feedback before continuing. Which trade-off should I optimize for?");
+		await session.waitForIdle();
+
+		expect(reminderAttempts).toEqual([]);
+		expect(todoReminderTranscriptEntry()).toBeUndefined();
+		expect(continueSpy).not.toHaveBeenCalled();
 	});
 
 	it("fires exactly one reminder per user pause when the agent only acknowledges", async () => {


### PR DESCRIPTION
## Repro
A focused `AgentSession` regression reproduces the reported `/skill:grilling` shape: the assistant has incomplete todos, stops with a text-only user-facing question (`Which trade-off should I optimize for?`), and the session still emits `todo_reminder` attempt 1/3. Command: `bun test packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts --test-name-pattern question` failed before the fix with `expected []` but received `[1]`.

## Cause
`packages/coding-agent/src/session/agent-session.ts` ran `#checkTodoCompletion()` for every text-only final stop with incomplete todos. That path did not distinguish an abandoned task from a deliberate user-yielding question, so interactive skill prompts that ask one question at a time were auto-continued by the incomplete-todo reminder loop.

## Fix
- Added a stop-time check that recognizes assistant text yielding to the user via a question or explicit response cue and skips the todo reminder continuation.
- Passed the final assistant message into `#checkTodoCompletion()` so the reminder decision uses the exact stop being settled.
- Added regression coverage proving user-facing questions emit no `todo_reminder`, append no hidden reminder, and do not call `agent.continue()` while preserving the existing baseline reminder behavior.
- Added a coding-agent changelog entry for the issue.

## Verification
`bun run gen:tool-views` generated the missing local test prerequisite. `bun test packages/coding-agent/test/agent-session-todo-reminder-loop.test.ts` passed: 4 pass, 0 fail, 7 expect calls. `gh_push_branch` pre-publish gate completed and pushed the branch. Fixes #5089