### PR TITLE
fix(agent): abort repeated empty yield results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MiniMax-M3 task subagents retrying empty `yield` results forever; repeated untyped `result: {}` submissions now abort the child with guidance instead of leaving the parent blocked. ([#5095](https://github.com/can1357/oh-my-pi/issues/5095))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/yield.ts
+++ b/packages/coding-agent/src/tools/yield.ts
@@ -198,6 +198,14 @@ function wrapYieldParameters(dataSchema: Record<string, unknown>): Record<string
  */
 const MAX_SCHEMA_RETRIES = 3;
 
+/**
+ * Max consecutive untyped empty-result submissions before the yield tool fails
+ * the child explicitly. Some weak tool callers can acknowledge the required
+ * wrapper in prose while repeatedly sending `{ result: {} }`; without a hard
+ * stop the parent waits forever.
+ */
+const MAX_EMPTY_RESULT_RETRIES = 3;
+
 export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 	readonly name = "yield";
 	readonly approval = "read" as const;
@@ -217,6 +225,7 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 	#knownSectionLabels: readonly string[] = [];
 	#isKnownSection?: (label: string) => boolean;
 	#schemaValidationFailures = 0;
+	#emptyResultFailures = 0;
 
 	constructor(session: ToolSession) {
 		let validate: ((value: unknown) => JsonSchemaValidationResult) | undefined;
@@ -322,8 +331,26 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 			throw new Error("result cannot contain both data and error");
 		}
 		if (errorMessage === undefined && data === undefined && yieldType === undefined) {
+			this.#emptyResultFailures++;
+			if (this.#emptyResultFailures > MAX_EMPTY_RESULT_RETRIES) {
+				const attemptCount = this.#emptyResultFailures;
+				this.#emptyResultFailures = 0;
+				const error =
+					`yield result stayed empty after ${attemptCount} consecutive attempt(s); aborting child instead of retrying forever. ` +
+					'Submit success as `{ "result": { "data": <your output> } }` or failure as `{ "result": { "error": "message" } }`.';
+				return {
+					content: [{ type: "text", text: `Task aborted: ${error}` }],
+					details: {
+						data: undefined,
+						status: "aborted",
+						error,
+						type: yieldType,
+					},
+				};
+			}
+			const remaining = MAX_EMPTY_RESULT_RETRIES - this.#emptyResultFailures;
 			throw new Error(
-				'result must contain either `data` or `error`. Use `{result: {data: <your output>}}` for success or `{result: {error: "message"}}` for failure.',
+				`result must contain either \`data\` or \`error\`. Use \`{result: {data: <your output>}}\` for success or \`{result: {error: "message"}}\` for failure. Empty untyped result retries remaining before abort: ${remaining}.`,
 			);
 		}
 
@@ -370,6 +397,7 @@ export class YieldTool implements AgentTool<TSchema, YieldDetails> {
 			}
 		}
 
+		this.#emptyResultFailures = 0;
 		const responseText =
 			status === "aborted"
 				? `Task aborted: ${errorMessage}`

--- a/packages/coding-agent/test/tools/yield.test.ts
+++ b/packages/coding-agent/test/tools/yield.test.ts
@@ -526,6 +526,57 @@ describe("YieldTool", () => {
 		).rejects.toThrow("data is required when yield indicates success");
 	});
 
+	it("aborts instead of throwing forever after repeated untyped empty results", async () => {
+		const tool = new YieldTool(createSession());
+		const expectedGuidance =
+			'result must contain either `data` or `error`. Use `{result: {data: <your output>}}` for success or `{result: {error: "message"}}` for failure.';
+
+		for (let attempt = 1; attempt <= 3; attempt++) {
+			await expect(tool.execute(`call-empty-retry-${attempt}`, { result: {} } as never)).rejects.toThrow(
+				expectedGuidance,
+			);
+		}
+
+		const abortResult = await tool.execute("call-empty-abort", { result: {} } as never);
+		const details = abortResult.details;
+		expect(details).toBeDefined();
+		if (!details) throw new Error("missing abort details");
+		expect(details.status).toBe("aborted");
+		expect(details.data).toBeUndefined();
+		expect(String(details.error)).toContain("retrying forever");
+		expect(abortResult.content).toEqual([{ type: "text", text: expect.stringContaining("Task aborted") }]);
+	});
+
+	it("resets the untyped empty-result retry budget after a valid yield", async () => {
+		const tool = new YieldTool(createSession());
+		const expectedGuidance =
+			'result must contain either `data` or `error`. Use `{result: {data: <your output>}}` for success or `{result: {error: "message"}}` for failure.';
+
+		for (let attempt = 1; attempt <= 2; attempt++) {
+			await expect(tool.execute(`call-empty-before-valid-${attempt}`, { result: {} } as never)).rejects.toThrow(
+				expectedGuidance,
+			);
+		}
+
+		const validResult = await tool.execute("call-valid-reset", { result: { data: { ok: true } } } as never);
+		expect(validResult.details).toEqual({ data: { ok: true }, status: "success", error: undefined });
+
+		for (let attempt = 1; attempt <= 3; attempt++) {
+			await expect(tool.execute(`call-empty-after-valid-${attempt}`, { result: {} } as never)).rejects.toThrow(
+				expectedGuidance,
+			);
+		}
+
+		const abortResult = await tool.execute("call-empty-after-reset-abort", { result: {} } as never);
+		const details = abortResult.details;
+		expect(details).toBeDefined();
+		if (!details) throw new Error("missing abort details");
+		expect(details.status).toBe("aborted");
+		expect(details.data).toBeUndefined();
+		expect(String(details.error)).toContain("retrying forever");
+		expect(abortResult.content).toEqual([{ type: "text", text: expect.stringContaining("Task aborted") }]);
+	});
+
 	it("exposes typed last-turn mode in the argument schema", () => {
 		const tool = new YieldTool(createSession());
 		const parameters = tool.parameters as unknown as Record<string, unknown>;


### PR DESCRIPTION
## Repro
Reproduced with a direct yield-tool harness that calls `YieldTool.execute()` five times with `yield({ result: {} })`: before the fix, `bun .wt/repro-yield-empty.ts` printed the same `result must contain either data or error` rejection for all five attempts and never returned a terminal result.

## Cause
`packages/coding-agent/src/tools/yield.ts` rejected untyped empty `result: {}` submissions as structural validation errors every time. Because thrown tool errors are not terminal yield results, `subprocessToolRegistry` never recorded a final `yield` item and `packages/coding-agent/src/task/executor.ts` had no `abortedViaYield` signal to unblock the parent.

## Fix
- Added a consecutive empty-result retry cap in `YieldTool.execute()` with a concrete success/failure payload example in the retry guidance.
- After the cap, synthesize a non-error aborted yield result so the existing yield termination and subprocess finalization paths mark the child aborted instead of letting it retry forever.
- Reset the empty-result retry budget after a valid yield, and added regression coverage for both the abort path and reset behavior.
- Added the coding-agent changelog entry for #5095.

## Verification
`bun .wt/repro-yield-empty.ts` now rejects the first three empty untyped yields, returns `details.status === "aborted"` on the fourth, and resets the budget afterward. `bun test packages/coding-agent/test/tools/yield.test.ts` passed: 42 tests, 151 expectations. `bun check` passed locally, and the pre-publish gate passed while pushing this branch. Fixes #5095