### PR TITLE
feat(bedrock): add providers.awsAuthRefresh to auto-refresh AWS SSO

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -162,6 +162,8 @@ When `CLAUDE_CODE_USE_FOUNDRY` is enabled, Anthropic requests switch to Foundry 
 
 Region fallback in provider code: `options.region` → `AWS_REGION` → `AWS_DEFAULT_REGION` → `us-east-1`.
 
+To auto-refresh an expired AWS SSO session instead of erroring, set the `providers.awsAuthRefresh` setting (see [Settings](./settings.md)) to a command such as `aws sso login --profile my-profile`. It runs when the SSO token is missing/expired or a request returns 401/403, refreshes credentials on disk, and the request is retried; its stdout is shown (for the SSO device URL/code), not parsed. For programmatic credentials emitted to stdout, use a profile `credential_process` instead.
+
 ### Azure OpenAI Responses
 
 | Variable                           | Default / behavior                                                          |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -633,6 +633,7 @@ searxng:
 | `providers.openaiWebsockets` | enum | `auto` | `auto`, `off`, `on`. |
 | `providers.openrouterVariant` | enum | `default` | `default`, `nitro`, `floor`, `online`, `exacto`. |
 | `providers.kimiApiFormat` | enum | `anthropic` | `openai`, `anthropic`. |
+| `providers.awsAuthRefresh` | string | _(unset)_ | Shell command run to refresh AWS credentials for Amazon Bedrock when the SSO token is missing/expired or a request returns 401/403 (e.g. `aws sso login --profile my-profile`). Refreshes creds on disk; stdout is shown, not parsed. See [Providers](./providers.md). |
 | `provider.appendOnlyContext` | enum | `auto` | `auto`, `on`, `off`. |
 | `exa.enabled` | boolean | `true` | Enable Exa integration. |
 | `exa.enableSearch` | boolean | `true` | Exa search. |

--- a/packages/ai/src/error/aws.ts
+++ b/packages/ai/src/error/aws.ts
@@ -9,7 +9,9 @@ export type AwsCredentialsErrorKind =
 	/** SSO `GetRoleCredentials` call failed or returned no role. */
 	| "sso-role"
 	/** External `credential_process` failed, timed out, or emitted bad output. */
-	| "credential-process";
+	| "credential-process"
+	/** The configured `awsAuthRefresh` command failed, timed out, or was empty. */
+	| "auth-refresh";
 
 /** A failure resolving AWS credentials for the Bedrock provider. */
 export class AwsCredentialsError extends Error {

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -52,6 +52,12 @@ export interface BedrockOptions extends StreamOptions {
 	profile?: string;
 	/** Amazon Bedrock API key sent as `Authorization: Bearer`, ahead of SigV4 credential resolution. */
 	bearerToken?: string;
+	/**
+	 * Shell command run to refresh AWS credentials on disk when the SSO token is
+	 * missing/expired or a request returns 401/403 (e.g. `aws sso login`). Ignored
+	 * on the bearer-token and `AWS_BEDROCK_SKIP_AUTH` paths.
+	 */
+	awsAuthRefresh?: string;
 	toolChoice?: "auto" | "any" | "none" | { type: "tool"; name: string };
 	/* See https://docs.aws.amazon.com/bedrock/latest/userguide/inference-reasoning.html for supported models. */
 	reasoning?: Effort;
@@ -356,12 +362,15 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 			};
 
 			const bearerToken = resolveBearerToken(options);
-			let requestHeaders: Record<string, string>;
-			if (bearerToken) {
-				requestHeaders = { ...baseHeaders, Authorization: `Bearer ${bearerToken}` };
-			} else {
+			const skipAuth = $flag("AWS_BEDROCK_SKIP_AUTH");
+
+			// Resolve credentials and sign for this attempt. `forceRefresh` runs the
+			// configured `awsAuthRefresh` command before re-resolving; it only
+			// applies to the SigV4 credential path (bearer/skip-auth carry no creds).
+			const buildRequestHeaders = async (forceRefresh: boolean): Promise<Record<string, string>> => {
+				if (bearerToken) return { ...baseHeaders, Authorization: `Bearer ${bearerToken}` };
 				let credentials: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
-				if ($flag("AWS_BEDROCK_SKIP_AUTH")) {
+				if (skipAuth) {
 					credentials = { accessKeyId: "dummy-access-key", secretAccessKey: "dummy-secret-key" };
 				} else {
 					credentials = await resolveAwsCredentials({
@@ -369,6 +378,8 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 						region,
 						signal: options.signal,
 						fetch: options.fetch,
+						authRefresh: options.awsAuthRefresh,
+						forceRefresh,
 					});
 				}
 				const signed = await signRequest({
@@ -381,40 +392,48 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 					credentials,
 					headers: baseHeaders,
 				});
-				requestHeaders = { ...baseHeaders, ...signed };
-			}
+				return { ...baseHeaders, ...signed };
+			};
 
-			// Bun's native fetch ceiling is disabled below (`timeout: false`) so
-			// configurable watchdogs govern slow-prefill streams (issue #2422).
-			// Direct callers that bypass `register-builtins` (which installs the
-			// iterator-level first-event watchdog) still need a pre-response
-			// timer, otherwise a Bedrock/proxy that accepts the POST and never
-			// sends headers would hang forever.
-			const firstEventTimeoutMs = options.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs();
-			// Clear the pre-response timer the instant headers arrive (below): an
-			// absolute `AbortSignal.timeout` would keep aborting the actively
-			// streaming body, not just a stalled time-to-first-byte (issue #2422).
-			const watchdog = armPreResponseTimeout(options.signal, firstEventTimeoutMs);
-			let response: Response;
-			try {
-				response = await fetchWithRetry(url, {
-					method: "POST",
-					headers: requestHeaders,
-					body,
-					signal: watchdog.signal,
-					fetch: options.fetch,
-					timeout: false,
-				});
-			} finally {
-				watchdog.clear();
+			const sendOnce = async (forceRefresh: boolean): Promise<Response> => {
+				const requestHeaders = await buildRequestHeaders(forceRefresh);
+				// Bun's native fetch ceiling is disabled below (`timeout: false`) so
+				// configurable watchdogs govern slow-prefill streams (issue #2422).
+				// Direct callers that bypass `register-builtins` (which installs the
+				// iterator-level first-event watchdog) still need a pre-response
+				// timer, otherwise a Bedrock/proxy that accepts the POST and never
+				// sends headers would hang forever.
+				const firstEventTimeoutMs = options.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs();
+				// Clear the pre-response timer the instant headers arrive (below): an
+				// absolute `AbortSignal.timeout` would keep aborting the actively
+				// streaming body, not just a stalled time-to-first-byte (issue #2422).
+				const watchdog = armPreResponseTimeout(options.signal, firstEventTimeoutMs);
+				try {
+					return await fetchWithRetry(url, {
+						method: "POST",
+						headers: requestHeaders,
+						body,
+						signal: watchdog.signal,
+						fetch: options.fetch,
+						timeout: false,
+					});
+				} finally {
+					watchdog.clear();
+				}
+			};
+
+			// A 401/403 on the credential path means the signed creds were rejected.
+			// Drop the cache so the retry re-resolves; when `awsAuthRefresh` is set,
+			// re-run it first (forceRefresh) to repair on-disk SSO state, then retry
+			// the request once.
+			const canReauth = !bearerToken && !skipAuth;
+			let response = await sendOnce(false);
+			if (!response.ok && canReauth && (response.status === 401 || response.status === 403)) {
+				invalidateAwsCredentialCache({ profile: options.profile, region });
+				if (options.awsAuthRefresh) response = await sendOnce(true);
 			}
 
 			if (!response.ok) {
-				if (!bearerToken && (response.status === 401 || response.status === 403)) {
-					// Stale cached credentials (e.g. rotated session keys in ~/.aws/credentials) —
-					// drop the cache entry so the next attempt re-resolves from scratch.
-					invalidateAwsCredentialCache({ profile: options.profile, region });
-				}
 				const errBody = await response.text().catch(() => "");
 				throw new AIError.BedrockApiError(
 					`Bedrock HTTP ${response.status}: ${errBody.slice(0, 1000)}`,

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -40,6 +40,18 @@ export interface CredentialResolveOptions {
 	region?: string;
 	signal?: AbortSignal;
 	fetch?: FetchImpl;
+	/**
+	 * Shell command run to refresh credentials on disk (e.g. `aws sso login`) when
+	 * the SSO cache token is missing/expired. Its stdout/stderr is logged, not
+	 * parsed; credentials are re-read from the AWS chain after it exits 0.
+	 */
+	authRefresh?: string;
+	/**
+	 * Run {@link authRefresh} before resolving even when the cached token still
+	 * looks valid. Set by the Bedrock provider after a 401/403, where the cached
+	 * credentials were accepted locally but rejected by the service.
+	 */
+	forceRefresh?: boolean;
 }
 
 const REFRESH_SKEW_MS = 60_000;
@@ -68,20 +80,25 @@ export async function resolveAwsCredentials(opts: CredentialResolveOptions = {})
 	const region = opts.region || $env.AWS_REGION || $env.AWS_DEFAULT_REGION || "us-east-1";
 	const cacheKey = `${profile}\x00${region}`;
 
-	const hit = cache.get(cacheKey);
-	if (hit && hit.expiresAt - REFRESH_SKEW_MS > Date.now()) return hit.creds;
+	// forceRefresh (a 401/403 backstop) must not be served the cached creds the
+	// service just rejected, and must not join an in-flight resolution started
+	// without the refresh command.
+	if (!opts.forceRefresh) {
+		const hit = cache.get(cacheKey);
+		if (hit && hit.expiresAt - REFRESH_SKEW_MS > Date.now()) return hit.creds;
 
-	// Single-flight: N concurrent cold calls must not each spawn credential_process/SSO/IMDS fetches.
-	// The shared resolution is deliberately detached from any caller's signal — aborting one
-	// request must not fail every waiter — and bounded by its own timeout instead; each caller
-	// races its own signal against the shared promise.
-	const existing = inflight.get(cacheKey);
-	if (existing) return raceWithSignal(existing, opts.signal);
+		// Single-flight: N concurrent cold calls must not each spawn credential_process/SSO/IMDS fetches.
+		// The shared resolution is deliberately detached from any caller's signal — aborting one
+		// request must not fail every waiter — and bounded by its own timeout instead; each caller
+		// races its own signal against the shared promise.
+		const existing = inflight.get(cacheKey);
+		if (existing) return raceWithSignal(existing, opts.signal);
+	}
 
 	const fetchImpl = opts.fetch ?? (globalThis.fetch as FetchImpl);
 	const promise = (async () => {
 		try {
-			const creds = await resolveFresh(profile, region, AbortSignal.timeout(SHARED_RESOLVE_TIMEOUT_MS), fetchImpl);
+			const creds = await resolveFreshWithRefresh(profile, region, fetchImpl, opts.authRefresh, opts.forceRefresh);
 			cache.set(cacheKey, { creds, expiresAt: creds.expiresAt ?? Number.POSITIVE_INFINITY });
 			return creds;
 		} finally {
@@ -90,6 +107,42 @@ export async function resolveAwsCredentials(opts: CredentialResolveOptions = {})
 	})();
 	inflight.set(cacheKey, promise);
 	return raceWithSignal(promise, opts.signal);
+}
+
+/**
+ * Resolve credentials, running the optional `awsAuthRefresh` command to repair
+ * on-disk SSO state when needed. The command runs proactively when
+ * `forceRefresh` is set (post-401/403), and reactively when the first
+ * resolution reports a missing/expired SSO token; either way credentials are
+ * re-resolved from the AWS chain afterward. Without a command, this is a plain
+ * pass-through to {@link resolveFresh}.
+ */
+async function resolveFreshWithRefresh(
+	profile: string,
+	region: string,
+	fetchImpl: FetchImpl,
+	authRefresh: string | undefined,
+	forceRefresh: boolean | undefined,
+): Promise<ResolvedCredentials> {
+	const newSignal = () => AbortSignal.timeout(SHARED_RESOLVE_TIMEOUT_MS);
+
+	if (authRefresh && forceRefresh) {
+		await runAuthRefresh(authRefresh, newSignal());
+	}
+
+	try {
+		return await resolveFresh(profile, region, newSignal(), fetchImpl);
+	} catch (err) {
+		const isSsoTokenStale =
+			err instanceof AIError.AwsCredentialsError &&
+			(err.kind === "sso-token-expired" || err.kind === "sso-token-missing");
+		// Only the proactive (non-forced) path retries here; a forced refresh
+		// already ran above, so a still-stale token means the command didn't fix
+		// it and re-running would just loop.
+		if (!authRefresh || forceRefresh || !isSsoTokenStale) throw err;
+		await runAuthRefresh(authRefresh, newSignal());
+		return await resolveFresh(profile, region, newSignal(), fetchImpl);
+	}
 }
 
 async function resolveFresh(
@@ -513,6 +566,84 @@ export function tokenizeCredentialProcessCommand(cmd: string): string[] {
 	}
 	if (hasToken) tokens.push(current);
 	return tokens;
+}
+
+// ---------- awsAuthRefresh ----------
+
+/**
+ * Wall-clock bound for the refresh command. SSO device-code flows wait on a
+ * human completing the browser step, so this is generous relative to other
+ * credential timeouts.
+ */
+const AUTH_REFRESH_TIMEOUT_MS = 3 * 60_000;
+/**
+ * Minimum spacing between refresh runs for one command. A refresh that succeeds
+ * but leaves the token still-rejected (misconfigured command, wrong profile)
+ * would otherwise re-run on every retry; this debounces the storm while a
+ * genuinely-expired token an hour later still refreshes.
+ */
+const AUTH_REFRESH_DEBOUNCE_MS = 10_000;
+
+/** In-flight refresh per command, so concurrent resolutions share one login. */
+const authRefreshInflight: Map<string, Promise<void>> = new Map();
+/** Last completion timestamp per command, for {@link AUTH_REFRESH_DEBOUNCE_MS}. */
+const authRefreshLastRun: Map<string, number> = new Map();
+
+/**
+ * Run the user's `awsAuthRefresh` command to refresh credentials on disk (e.g.
+ * `aws sso login`). Modeled on Claude Code's setting of the same name: the
+ * command's job is to rewrite `~/.aws` state, not to emit credentials, so its
+ * stdout/stderr is logged rather than parsed and the caller re-reads the AWS
+ * chain afterward. Single-flighted and debounced per command; a non-zero exit
+ * throws so the caller can surface the failure instead of looping.
+ */
+async function runAuthRefresh(command: string, signal: AbortSignal | undefined): Promise<void> {
+	const trimmed = command.trim();
+	if (!trimmed) return;
+
+	const inflight = authRefreshInflight.get(trimmed);
+	if (inflight) return inflight;
+
+	const lastRun = authRefreshLastRun.get(trimmed);
+	if (lastRun !== undefined && Date.now() - lastRun < AUTH_REFRESH_DEBOUNCE_MS) return;
+
+	const promise = (async () => {
+		const argv = buildCredentialProcessArgv("awsAuthRefresh", trimmed);
+		logger.info("aws-credentials: running awsAuthRefresh", { command: trimmed });
+		const timeout = AbortSignal.timeout(AUTH_REFRESH_TIMEOUT_MS);
+		const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
+		const child = Bun.spawn(argv, {
+			stdin: "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+			windowsHide: true,
+			signal: combined,
+		});
+		const [stdout, stderr, exitCode] = await Promise.all([
+			new Response(child.stdout).text(),
+			new Response(child.stderr).text(),
+			child.exited,
+		]);
+		// Unlike credential_process, stdout is informational (e.g. the SSO device
+		// URL/code); surface it so the user can complete the browser flow.
+		const combinedOutput = [stdout.trim(), stderr.trim()].filter(Boolean).join("\n");
+		if (exitCode !== 0) {
+			throw new AIError.AwsCredentialsError(
+				`awsAuthRefresh command exited ${exitCode}: ${combinedOutput.slice(-512) || "(no output)"}`,
+				"auth-refresh",
+			);
+		}
+		if (combinedOutput)
+			logger.info("aws-credentials: awsAuthRefresh output", { output: combinedOutput.slice(-1024) });
+	})();
+
+	authRefreshInflight.set(trimmed, promise);
+	try {
+		await promise;
+	} finally {
+		authRefreshInflight.delete(trimmed);
+		authRefreshLastRun.set(trimmed, Date.now());
+	}
 }
 
 // ---------- IMDSv2 ----------

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -574,6 +574,14 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	/** Antigravity endpoint routing mode: "auto" (default with failover), "production", "sandbox". */
 	antigravityEndpointMode?: "auto" | "production" | "sandbox";
 	/**
+	 * Shell command run to refresh AWS credentials for Amazon Bedrock when the SSO
+	 * token is missing/expired or a request returns 401/403. The command refreshes
+	 * credentials on disk (e.g. `aws sso login`); its stdout is not parsed and
+	 * credentials are re-read from the AWS chain afterward. Ignored by non-Bedrock
+	 * providers.
+	 */
+	awsAuthRefresh?: string;
+	/**
 	 * Anthropic `server-side-fallback-2026-06-01` fallback chain (top-level
 	 * `fallbacks` request field). Opt-in ONLY — leaving this undefined is
 	 * the default and preserves the pre-fallback behavior on every

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -177,3 +177,101 @@ describe("resolveAwsCredentials credential_process", () => {
 		await expect(promise).rejects.toBeDefined();
 	});
 });
+
+// `awsAuthRefresh` coverage. The SSO cache lives under `os.homedir()` (which
+// can't be redirected mid-process), so these drive the reactive path through
+// the file seam instead: an SSO profile with no cached token first throws
+// `sso-token-missing`, and the refresh command writes static keys into the
+// shared credentials file that the retry's profile resolution then returns
+// (static keys are checked ahead of the SSO branch). No homedir or fetch mocks.
+describe("resolveAwsCredentials awsAuthRefresh", () => {
+	let tmp: string;
+	const saved = new Map<string, string | undefined>();
+
+	const START_URL = "https://example.awsapps.com/start";
+	const SSO_REGION = "us-east-1";
+	let credentialsPath: string;
+
+	beforeEach(async () => {
+		for (const k of ENV_KEYS) {
+			saved.set(k, Bun.env[k]);
+			delete Bun.env[k];
+		}
+		Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+		tmp = await fs.mkdtemp(path.join(os.tmpdir(), "aws-authrefresh-"));
+		credentialsPath = path.join(tmp, "credentials");
+		clearAwsCredentialCache();
+	});
+
+	afterEach(async () => {
+		for (const [k, v] of saved) {
+			if (v === undefined) delete Bun.env[k];
+			else Bun.env[k] = v;
+		}
+		saved.clear();
+		await removeWithRetries(tmp);
+		clearAwsCredentialCache();
+	});
+
+	async function writeFixtureFile(name: string, body: string): Promise<string> {
+		const p = path.join(tmp, name);
+		await Bun.write(p, body);
+		return p;
+	}
+
+	/** SSO profile with no cached token, so the first resolution throws sso-token-missing. */
+	async function writeSsoConfig(profile: string): Promise<void> {
+		const cfg = path.join(tmp, "config");
+		await Bun.write(
+			cfg,
+			`[profile ${profile}]\n` +
+				`sso_start_url = ${START_URL}\n` +
+				`sso_region = ${SSO_REGION}\n` +
+				`sso_account_id = 111122223333\n` +
+				`sso_role_name = TestRole\n`,
+		);
+		Bun.env.AWS_CONFIG_FILE = cfg;
+		await Bun.write(credentialsPath, "");
+		Bun.env.AWS_SHARED_CREDENTIALS_FILE = credentialsPath;
+	}
+
+	test("missing SSO token surfaces an actionable error without a refresh command", async () => {
+		await writeSsoConfig("bare");
+		await expect(resolveAwsCredentials({ profile: "bare", region: SSO_REGION })).rejects.toThrow(/aws sso login/i);
+	});
+
+	test("runs awsAuthRefresh on a stale token, then re-resolves the repaired creds", async () => {
+		await writeSsoConfig("refreshable");
+
+		// The refresh command stands in for `aws sso login`: it repairs on-disk
+		// state so the retry resolves. Writing static keys for the profile is the
+		// simplest repair to observe (the retry returns them ahead of the SSO
+		// branch); a marker file proves the command actually ran.
+		const marker = path.join(tmp, "ran.txt");
+		const written = `[refreshable]\naws_access_key_id = AKIAFRESH\naws_secret_access_key = fresh-secret\n`;
+		const refreshScript = await writeFixtureFile(
+			"refresh.js",
+			`const fs=require("node:fs");
+			 fs.writeFileSync(${JSON.stringify(credentialsPath)}, ${JSON.stringify(written)});
+			 fs.writeFileSync(${JSON.stringify(marker)}, "1");`,
+		);
+		const authRefresh = `${quoteForConfig(process.execPath)} ${quoteForConfig(refreshScript)}`;
+
+		const creds = await resolveAwsCredentials({ profile: "refreshable", region: SSO_REGION, authRefresh });
+		expect(creds.accessKeyId).toBe("AKIAFRESH");
+		expect(creds.secretAccessKey).toBe("fresh-secret");
+		expect(await Bun.file(marker).exists()).toBe(true);
+	});
+
+	test("surfaces the refresh command's non-zero exit", async () => {
+		await writeSsoConfig("broken-refresh");
+		const failScript = await writeFixtureFile(
+			"fail-refresh.js",
+			`process.stderr.write("login failed");process.exit(3);`,
+		);
+		const authRefresh = `${quoteForConfig(process.execPath)} ${quoteForConfig(failScript)}`;
+		await expect(
+			resolveAwsCredentials({ profile: "broken-refresh", region: SSO_REGION, authRefresh }),
+		).rejects.toThrow(/awsAuthRefresh command exited 3.*login failed/);
+	});
+});

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4350,6 +4350,17 @@ export const SETTINGS_SCHEMA = {
 			description: "Model ID for Gemini Google Search grounding. Defaults to gemini-2.5-flash.",
 		},
 	},
+	"providers.awsAuthRefresh": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "providers",
+			group: "Services",
+			label: "AWS Auth Refresh Command",
+			description:
+				"Shell command run to refresh AWS credentials for Amazon Bedrock when the SSO token is missing/expired or a request returns 401/403 (for example `aws sso login --profile my-profile`). The command refreshes credentials on disk; its stdout is shown, not parsed, and credentials are re-read from the AWS chain afterward.",
+		},
+	},
 	"providers.antigravityEndpoint": {
 		type: "enum",
 		values: ["auto", "production", "sandbox"] as const,

--- a/packages/coding-agent/src/session/settings-stream-fn.ts
+++ b/packages/coding-agent/src/session/settings-stream-fn.ts
@@ -33,6 +33,8 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 		const openrouterVariant =
 			openrouterRoutingPreset && openrouterRoutingPreset !== "default" ? openrouterRoutingPreset : undefined;
 		const antigravityEndpointMode = settings.get("providers.antigravityEndpoint");
+		const awsAuthRefresh =
+			model.api === "bedrock-converse-stream" ? settings.get("providers.awsAuthRefresh") : undefined;
 		const textVerbosity =
 			model.api === "openai-codex-responses" || model.api === "openai-responses"
 				? settings.get("textVerbosity")
@@ -55,6 +57,7 @@ export function createSettingsAwareStreamFn(settings: Settings, base: StreamFn =
 			...streamOptions,
 			openrouterVariant: streamOptions?.openrouterVariant ?? openrouterVariant,
 			antigravityEndpointMode: streamOptions?.antigravityEndpointMode ?? antigravityEndpointMode,
+			awsAuthRefresh: streamOptions?.awsAuthRefresh ?? awsAuthRefresh,
 			textVerbosity: streamOptions?.textVerbosity ?? textVerbosity,
 			streamFirstEventTimeoutMs: streamOptions?.streamFirstEventTimeoutMs ?? streamFirstEventTimeoutMs,
 			streamIdleTimeoutMs: streamOptions?.streamIdleTimeoutMs ?? streamIdleTimeoutMs,


### PR DESCRIPTION
## What

Adds a `providers.awsAuthRefresh` setting that lets omp refresh an expired AWS SSO session on its own for the Amazon Bedrock provider, instead of erroring out. It is a port of [Claude Code's `awsAuthRefresh` setting](https://code.claude.com/docs/en/amazon-bedrock.md): a shell command (e.g. `aws sso login --profile my-profile`) that omp runs to refresh credentials on disk, after which it re-resolves from the AWS chain and retries.

## Why

Today, when the AWS SSO token expires, `resolveAwsCredentials` throws `sso-token-expired` / `sso-token-missing` ("Run 'aws sso login'"), and `AuthFailed` is not in `RETRIABLE_KINDS`, so the request just fails. In an interactive session this bites the background maintenance calls (title generation, commit-message generation) as well as the main turn, so the session effectively breaks until the user re-logs in out of band. One-shot `omp -p` prompts often appear to work because they skip those background calls.

Claude Code handles this by running a user-configured refresh command and retrying; this brings the same ergonomics to omp.

## Behavior (matches Claude Code's semantics)

- **Proactive:** the credential resolver runs the command when it reports a missing/expired SSO token, then re-resolves. This is the pre-request choke point, so it covers the main turn *and* every background task in one place.
- **Reactive:** on a `401`/`403` the Bedrock provider drops the credential cache and, when the command is set, re-runs it (`forceRefresh`) and retries the request once.
- The command's job is to refresh on-disk state; its stdout/stderr is **logged** (so the SSO device URL/code is visible), **not parsed**. For programmatic stdout-JSON credentials, a profile `credential_process` remains the right tool - this is deliberately the fire-and-forget variant.
- Ignored on the bearer-token and `AWS_BEDROCK_SKIP_AUTH` paths, which carry no AWS credentials.

The command spawn reuses the existing `credential_process` tokenizer, is single-flighted and debounced per command (so a still-stale token can't loop), and is bounded by a generous timeout to allow for the browser step.

## Wiring

`providers.awsAuthRefresh` (string setting) -> `BedrockOptions.awsAuthRefresh` (attached in `createSettingsAwareStreamFn`, gated on `model.api === "bedrock-converse-stream"`) -> `resolveAwsCredentials({ authRefresh, forceRefresh })`.

## Open question

I named the setting `providers.awsAuthRefresh` to match omp's existing namespaced provider settings (`providers.openrouterVariant`, `providers.kimiApiFormat`). Claude Code uses a flat `awsAuthRefresh`. Happy to rename to the flat form if you'd prefer byte-for-byte parity for migrating users - it's a one-liner.

## Testing

- `bun test test/aws-credentials.test.ts` - 16 pass (added 3: missing-token error without a command, refresh-then-resolve, and non-zero-exit surfacing).
- `bun test test/bedrock-inference-profile.test.ts` - 8 pass.
- `check:types` clean for `packages/ai` and `packages/coding-agent`; biome clean; docs index fresh.

Docs updated: `docs/settings.md`, `docs/environment-variables.md`.