### PR TITLE
fix(ai): preserve Codex SSE watchdog reasons

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Fixed xai-oauth/grok-4.5 Responses requests to omit the unsupported reasoning.summary field while preserving the reasoning.effort payload.
 - Fixed Codex OAuth credential selection to re-check blocked accounts during ranking and clear stale usage-limit blocks once live usage indicates recovery.
 - Fixed sequential-cutoff reasoning summaries duplicating section headers across Codex reasoning items by tracking the cumulative summary response-globally, so replayed sections and replay-only items no longer re-emit text earlier thinking blocks already streamed.
+### Fixed
+
+- Fixed OpenAI Codex SSE idle and first-event watchdogs surfacing a generic `Request was aborted` message by preserving the specific timeout reason through transport cancellation and error finalization.
 
 ## [16.3.15] - 2026-07-09
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -50,6 +50,7 @@ import {
 	sanitizeOpenAIResponsesAssistantFallbackItemsForReplay,
 	sanitizeOpenAIResponsesAssistantHistoryItemsForReplay,
 } from "../utils";
+import { type AbortSourceTracker, createAbortSourceTracker } from "../utils/abort";
 import { clearStreamingPartialJson, kStreamingLastParseLen, kStreamingPartialJson } from "../utils/block-symbols";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import type { RawHttpRequestDump } from "../utils/http-inspector";
@@ -643,6 +644,7 @@ interface CodexRequestContext {
 }
 
 interface CodexRequestSetup {
+	abortTracker: AbortSourceTracker;
 	requestSignal: AbortSignal;
 	wrapCodexSseStream: (source: AsyncGenerator<Record<string, unknown>>) => AsyncGenerator<Record<string, unknown>>;
 	requestAbortController: AbortController;
@@ -884,6 +886,7 @@ interface CodexStreamFailureContext {
 	model: Model<"openai-codex-responses">;
 	output: AssistantMessage;
 	options: OpenAICodexResponsesOptions | undefined;
+	requestSetup: CodexRequestSetup;
 	requestContext: CodexRequestContext;
 	startTime: number;
 	firstTokenTime?: number;
@@ -1153,28 +1156,33 @@ function resetOutputState(output: AssistantMessage): void {
 }
 
 function createRequestSetup(options: OpenAICodexResponsesOptions | undefined): CodexRequestSetup {
-	const requestAbortController = new AbortController();
-	const requestSignal = options?.signal
-		? AbortSignal.any([options.signal, requestAbortController.signal])
-		: requestAbortController.signal;
+	const abortTracker = createAbortSourceTracker(options?.signal);
+	const { requestAbortController, requestSignal } = abortTracker;
 	const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 	const websocketIdleTimeoutMs = options?.streamIdleTimeoutMs ?? CODEX_WEBSOCKET_IDLE_TIMEOUT_MS;
 	const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
 	const websocketFirstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? CODEX_WEBSOCKET_FIRST_EVENT_TIMEOUT_MS;
+	const firstEventTimeoutAbortError = new AIError.StreamTimeoutError(
+		"OpenAI Codex SSE stream timed out while waiting for the first event",
+	);
+	const idleTimeoutAbortError = new AIError.StreamTimeoutError(
+		"OpenAI Codex SSE stream stalled while waiting for the next event",
+	);
 	const wrapCodexSseStream = (
 		source: AsyncGenerator<Record<string, unknown>>,
 	): AsyncGenerator<Record<string, unknown>> =>
 		iterateWithIdleTimeout(source, {
 			idleTimeoutMs,
 			firstItemTimeoutMs: firstEventTimeoutMs,
-			firstItemErrorMessage: "OpenAI Codex SSE stream timed out while waiting for the first event",
-			errorMessage: "OpenAI Codex SSE stream stalled while waiting for the next event",
-			onIdle: () => requestAbortController.abort(),
-			onFirstItemTimeout: () => requestAbortController.abort(),
+			firstItemErrorMessage: firstEventTimeoutAbortError.message,
+			errorMessage: idleTimeoutAbortError.message,
+			onIdle: () => abortTracker.abortLocally(idleTimeoutAbortError),
+			onFirstItemTimeout: () => abortTracker.abortLocally(firstEventTimeoutAbortError),
 			abortSignal: options?.signal,
 			isProgressItem: isCodexStreamProgressEvent,
 		});
 	return {
+		abortTracker,
 		requestAbortController,
 		requestSignal,
 		wrapCodexSseStream,
@@ -1632,7 +1640,7 @@ async function handleCodexStreamFailure(context: CodexStreamFailureContext, erro
 	}
 	const result = await AIError.finalize(error, {
 		api: context.model.api,
-		signal: context.options?.signal,
+		abortTracker: context.requestSetup.abortTracker,
 		rawRequestDump: context.requestContext.rawRequestDump,
 	});
 	output.stopReason = result.stopReason;
@@ -2490,6 +2498,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 					model,
 					output,
 					options,
+					requestSetup,
 					requestContext: requestContext ?? {
 						apiKey: "",
 						accountId: "",

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -978,6 +978,34 @@ describe("openai-codex streaming", () => {
 		expect(byName.get("older")?.arguments).toEqual({});
 	});
 
+	it("surfaces SSE idle watchdog aborts with the timeout reason", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const context = createCodexTestContext();
+		let transportSignal: AbortSignal | undefined;
+		const fetchMock: FetchImpl = (input: string | URL | Request, init?: RequestInit) => {
+			transportSignal = getRequestSignal(input, init);
+			return Promise.resolve(createNoProgressCodexSse(transportSignal));
+		};
+
+		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };
+		const result = await streamOpenAICodexResponses(model, context, {
+			fetch: fetchMock as FetchImpl,
+			apiKey: token,
+			streamIdleTimeoutMs: 20,
+			streamFirstEventTimeoutMs: 1_000,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("OpenAI Codex SSE stream stalled while waiting for the next event");
+		await Bun.sleep(0);
+		expect(transportSignal?.reason).toBeInstanceOf(Error);
+		if (!(transportSignal?.reason instanceof Error))
+			throw new Error("Expected the request signal to carry an Error reason");
+		expect(transportSignal.reason.message).toBe("OpenAI Codex SSE stream stalled while waiting for the next event");
+	});
+
 	it("waits for caller abort when SSE streams only no-progress status events", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-stream-");
 		setAgentDir(tempDir.path());


### PR DESCRIPTION
## What

Preserve the specific first-event and idle timeout reasons when Codex SSE watchdogs abort the transport.

## Why

The watchdog currently calls a bare AbortController.abort(), so transport cancellation can replace the actionable StreamTimeoutError with the generic Request was aborted message. This is the Codex SSE variant of the timeout-reason flattening described in #591.

## Testing

- bun test packages/ai/test/openai-codex-stream.test.ts (58 pass)
- bun run --cwd packages/ai check
- bun check

---

- [x] bun check passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)