### PR TITLE
fix(coding-agent): include exact MCP resource read hints

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fixed subagent yield tool calls being discarded when a soft request budget aborts the assistant turn before the yield event completes.
 - Fixed --tools filtering in interactive sessions incorrectly disabling deferred MCP tools from configured servers.
 - Fixed kept-alive task subagents entering infinite provider-call loops after an IRC wake and terminal yield.
+- Fixed MCP resource notifications showing an unusable generic `mcp://<uri>` hint when a resource URI contains its own scheme; notifications now include the exact `read(path=...)` target.
 
 ## [16.3.15] - 2026-07-09
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -301,9 +301,10 @@ function buildMcpNotificationBatchMessage(entries: McpNotificationEntry[]): Agen
 	if (resources.length === 0) return null;
 	const lines = [`[MCP notification] ${resources.length} resource(s) updated:`];
 	for (const resource of resources) {
-		lines.push(`- server="${resource.serverName}" uri=${resource.uri}`);
+		const readPath = `mcp://${resource.uri}`;
+		lines.push(`- server="${resource.serverName}" uri=${resource.uri} read(path=${JSON.stringify(readPath)})`);
 	}
-	lines.push('Use read(path="mcp://<uri>") to inspect if relevant.');
+	lines.push("Use the listed read(path=...) target to inspect if relevant.");
 	return {
 		role: "user",
 		content: [{ type: "text", text: lines.join("\n") }],

--- a/packages/coding-agent/test/sdk-mcp-notification-uri.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-notification-uri.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("MCP notification resource read hints", () => {
+	const tempDirs: string[] = [];
+
+	afterAll(() => {
+		for (const tempDir of tempDirs.splice(0)) {
+			removeSyncWithRetries(tempDir);
+		}
+	});
+
+	it("emits an exact read path for resource URIs that embed their own scheme", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-mcp-notification-uri-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwd = path.join(tempDir, "project");
+		const agentDir = path.join(tempDir, "agent");
+		fs.mkdirSync(cwd, { recursive: true });
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		const { session } = await createAgentSession({
+			cwd,
+			agentDir,
+			settings: Settings.isolated({ "mcp.notifications": true }),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			modelRegistry,
+		});
+
+		try {
+			session.yieldQueue.enqueue("mcp-notification", { serverName: "dingtalk", uri: "dingtalk://messages" });
+			const [buildMessage] = session.yieldQueue.drainLazy();
+			const message = buildMessage?.();
+			expect(message).toBeDefined();
+			expect(message?.role).toBe("user");
+			const firstContent = message?.role === "user" ? message.content[0] : undefined;
+			const text =
+				typeof firstContent === "string" ? firstContent : firstContent?.type === "text" ? firstContent.text : "";
+
+			expect(text).toContain('read(path="mcp://dingtalk://messages")');
+			expect(text).not.toContain("mcp://dingtalk/messages");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+});


### PR DESCRIPTION
## What

Include the exact read(path=...) target for every MCP resource update notification, including resource URIs that contain their own scheme.

## Why

The generic mcp://<uri> hint is not directly usable for values such as dingtalk://messages. The MCP internal URL handler already supports nested-scheme paths such as mcp://test://notes, so notifications should provide the exact resolvable path.

## Testing

- bun test packages/coding-agent/test/sdk-mcp-notification-uri.test.ts (1 pass)
- bun run --cwd packages/coding-agent check
- bun check

---

- [x] bun check passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)