### PR TITLE
fix(tui): rename OAuth billing marker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed MCP OAuth dynamic client registration omitting discovered scopes on the RFC 7591 registration body. Providers such as Clerk bind DCR-created clients to only the scopes declared at registration, then reject the subsequent authorize request when it asks for `openid` (from `scopes_supported`). Registration now includes `config.scopes` when present, matching Claude Code and the scopes already sent on authorize.
+- Fixed OAuth-backed provider sessions rendering the billing marker as `(sub)` in the status line and footer, and kept auto-learn capture turns from moving the active `/tree` leaf onto the synthetic capture branch. ([#5112](https://github.com/can1357/oh-my-pi/issues/5112))
 
 ## [16.4.0] - 2026-07-10
 

--- a/packages/coding-agent/src/autolearn/controller.ts
+++ b/packages/coding-agent/src/autolearn/controller.ts
@@ -117,6 +117,7 @@ export class AutoLearnController {
 		if (!autoContinue) return;
 
 		const content = AUTOLEARN_NUDGE_AUTOCONTINUE;
+		const restoreLeafId = this.#session.sessionManager.getLeafId();
 		// Arm suppression synchronously: the synthetic capture turn's agent_end
 		// fires inside sendCustomMessage (before it resolves), so the flag must be
 		// set before then. Disarm when no turn actually started — a deferred/queued
@@ -134,8 +135,12 @@ export class AutoLearnController {
 				},
 				{ deliverAs: "nextTurn", triggerTurn: true },
 			)
-			.then(started => {
-				if (!started) this.#suppressNext = false;
+			.then(async started => {
+				if (!started) {
+					this.#suppressNext = false;
+					return;
+				}
+				await this.#session.restoreLeafAfterInternalTurn(restoreLeafId);
 			})
 			.catch(err => {
 				this.#suppressNext = false;

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -173,14 +173,14 @@ export class FooterComponent implements Component {
 		if (totalCacheRead) statsParts.push(`R${formatNumber(totalCacheRead)}`);
 		if (totalCacheWrite) statsParts.push(`W${formatNumber(totalCacheWrite)}`);
 
-		// Show billing summary with subscription and premium-request indicators
-		const usingSubscription = state.model ? this.session.modelRegistry.isUsingOAuth(state.model) : false;
+		// Show billing summary with OAuth and premium-request indicators.
+		const usingOAuthBilling = state.model ? this.session.modelRegistry.isUsingOAuth(state.model) : false;
 		const normalizedPremiumRequests = Math.round((totalPremiumRequests + Number.EPSILON) * 100) / 100;
-		if (totalCost || usingSubscription || normalizedPremiumRequests) {
+		if (totalCost || usingOAuthBilling || normalizedPremiumRequests) {
 			const billingParts: string[] = [];
 			if (totalCost) billingParts.push(`$${totalCost.toFixed(3)}`);
 			if (normalizedPremiumRequests) billingParts.push(`★ ${formatNumber(normalizedPremiumRequests)}`);
-			if (usingSubscription) billingParts.push("(sub)");
+			if (usingOAuthBilling) billingParts.push("(oauth)");
 			if (billingParts.length > 0) statsParts.push(billingParts.join(" "));
 		}
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -391,16 +391,16 @@ const costSegment: StatusLineSegment = {
 		const { cost, premiumRequests } = ctx.usageStats;
 		const normalizedPremiumRequests = normalizePremiumRequests(premiumRequests);
 		const state = ctx.session.state;
-		const usingSubscription = state.model ? ctx.session.modelRegistry.isUsingOAuth(state.model) : false;
+		const usingOAuthBilling = state.model ? ctx.session.modelRegistry.isUsingOAuth(state.model) : false;
 
-		if (!cost && !usingSubscription && !normalizedPremiumRequests) {
+		if (!cost && !usingOAuthBilling && !normalizedPremiumRequests) {
 			return { content: "", visible: false };
 		}
 
 		const billingParts: string[] = [];
 		if (cost) billingParts.push(`$${cost.toFixed(2)}`);
 		if (normalizedPremiumRequests) billingParts.push(`★ ${formatNumber(normalizedPremiumRequests)}`);
-		if (usingSubscription) billingParts.push("(sub)");
+		if (usingOAuthBilling) billingParts.push("(oauth)");
 
 		return { content: theme.fg("statusLineCost", billingParts.join(" ")), visible: true };
 	},

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -15195,6 +15195,37 @@ export class AgentSession {
 		return { cancelled: false, sessionFile: this.sessionFile };
 	}
 
+	async #reloadAgentStateFromCurrentBranch(): Promise<SessionContext> {
+		const stateContext = this.sessionManager.buildSessionContext();
+		const displayContext = deobfuscateSessionContext(stateContext, this.#obfuscator);
+		await this.#restoreMCPSelectionsForSessionContext(displayContext);
+		this.agent.replaceMessages(displayContext.messages);
+		this.#rehydrateCheckpointRewindState();
+		this.#resetAdvisorSessionState();
+		this.#syncTodoPhasesFromBranch();
+		this.#closeCodexProviderSessionsForHistoryRewrite();
+		return stateContext;
+	}
+
+	/**
+	 * Restores the active leaf after an internal side-branch turn.
+	 *
+	 * Agent-initiated maintenance turns may append useful tool side effects to the
+	 * transcript tree, but they must not move the user's active conversation onto
+	 * that synthetic branch.
+	 */
+	async restoreLeafAfterInternalTurn(leafId: string | null): Promise<void> {
+		if (this.sessionManager.getLeafId() === leafId) return;
+		if (leafId === null) {
+			this.sessionManager.resetLeaf();
+		} else if (this.sessionManager.getEntry(leafId)) {
+			this.sessionManager.branch(leafId);
+		} else {
+			return;
+		}
+		await this.#reloadAgentStateFromCurrentBranch();
+	}
+
 	// =========================================================================
 	// Tree Navigation
 	// =========================================================================
@@ -15357,15 +15388,7 @@ export class AgentSession {
 			this.sessionManager.branch(newLeafId);
 		}
 
-		// Update agent state — build display context to populate agent messages.
-		const stateContext = this.sessionManager.buildSessionContext();
-		const displayContext = deobfuscateSessionContext(stateContext, this.#obfuscator);
-		await this.#restoreMCPSelectionsForSessionContext(displayContext);
-		this.agent.replaceMessages(displayContext.messages);
-		this.#rehydrateCheckpointRewindState();
-		this.#resetAdvisorSessionState();
-		this.#syncTodoPhasesFromBranch();
-		this.#closeCodexProviderSessionsForHistoryRewrite();
+		const stateContext = await this.#reloadAgentStateFromCurrentBranch();
 
 		this.#branchSummaryAbortController = undefined;
 

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -11,13 +11,18 @@ interface CapturedNudge {
 class FakeSession {
 	readonly listeners: Array<(event: AgentSessionEvent) => void> = [];
 	readonly sent: CapturedNudge[] = [];
+	readonly restoredLeafIds: Array<string | null> = [];
+	leafId: string | null = "leaf-before-autolearn";
+	internalTurnLeafId: string | null = "leaf-during-autolearn";
+	readonly sessionManager = {
+		getLeafId: (): string | null => this.leafId,
+	};
 	planEnabled = false;
 	goalEnabled = false;
 	/** Whether a triggerTurn dispatch actually starts a synthetic turn. */
 	turnStarts = true;
 	/** Force the dispatch to reject (models a failed send). */
 	failSend = false;
-
 	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
 		this.listeners.push(listener);
 		return () => {};
@@ -27,7 +32,14 @@ class FakeSession {
 		if (this.failSend) throw new Error("send failed");
 		this.sent.push({ message, options });
 		// Mirror AgentSession: a turn starts only when triggerTurn is honored.
-		return options?.triggerTurn === true && this.turnStarts;
+		const started = options?.triggerTurn === true && this.turnStarts;
+		if (started) this.leafId = this.internalTurnLeafId;
+		return started;
+	}
+
+	async restoreLeafAfterInternalTurn(leafId: string | null): Promise<void> {
+		this.restoredLeafIds.push(leafId);
+		this.leafId = leafId;
 	}
 
 	getPlanModeState(): { enabled: boolean } | undefined {
@@ -211,6 +223,22 @@ describe("AutoLearnController", () => {
 		expect(session.sent).toHaveLength(2);
 	});
 
+	it("restores the previous active leaf after a started auto-continue capture turn", async () => {
+		const session = new FakeSession();
+		session.leafId = "leaf-original";
+		session.internalTurnLeafId = "leaf-capture";
+		install(session, { "autolearn.autoContinue": true });
+
+		session.toolCalls(5);
+		session.agentEnd();
+		await Promise.resolve();
+
+		expect(session.sent).toHaveLength(1);
+		expect(session.sent[0]?.options?.triggerTurn).toBe(true);
+		expect(session.restoredLeafIds).toEqual(["leaf-original"]);
+		expect(session.leafId).toBe("leaf-original");
+	});
+
 	it("disarms suppression when the capture turn is deferred (not started)", async () => {
 		const session = new FakeSession();
 		// triggerTurn honored but downgraded to a queue: no synthetic agent_end.
@@ -221,6 +249,7 @@ describe("AutoLearnController", () => {
 		expect(session.sent).toHaveLength(1);
 		expect(session.sent[0]?.options?.triggerTurn).toBe(true);
 		await Bun.sleep(1); // flush the async disarm
+		expect(session.restoredLeafIds).toEqual([]);
 		// No turn ran, so the next real stop must still nudge.
 		session.toolCalls(5);
 		session.agentEnd();
@@ -235,6 +264,7 @@ describe("AutoLearnController", () => {
 		session.agentEnd(); // dispatch rejects: armed, then disarmed in .catch
 		expect(session.sent).toHaveLength(0);
 		await Bun.sleep(1); // flush the async disarm
+		expect(session.restoredLeafIds).toEqual([]);
 		session.failSend = false;
 		session.toolCalls(5);
 		session.agentEnd();

--- a/packages/coding-agent/test/status-line-billing-label.test.ts
+++ b/packages/coding-agent/test/status-line-billing-label.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { FooterComponent } from "@oh-my-pi/pi-coding-agent/modes/components/footer";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/types";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, overrides: { "git.enabled": false } });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+function makeOAuthBackedMainSession(): AgentSession {
+	const model = { id: "oauth-backed-model", provider: "anthropic", contextWindow: 200_000 };
+	const entries: unknown[] = [];
+	const session = {
+		state: { messages: [], model },
+		model,
+		messages: [],
+		sessionManager: {
+			getEntries() {
+				const currentEntries = entries;
+				return currentEntries;
+			},
+		},
+		modelRegistry: {
+			isUsingOAuth(candidate: unknown) {
+				const activeModel = model;
+				return candidate === activeModel;
+			},
+		},
+		getContextUsage() {
+			const usage = undefined;
+			return usage;
+		},
+		isAutoThinking: false,
+		autoResolvedThinkingLevel() {
+			const level = undefined;
+			return level;
+		},
+	};
+	return session as unknown as AgentSession;
+}
+
+describe("OAuth billing status labels", () => {
+	it("renders the status-line cost segment with an OAuth marker, not the subagent marker", () => {
+		const session = makeOAuthBackedMainSession();
+		const result = renderSegment("cost", {
+			session,
+			usageStats: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				orchestrationInput: 0,
+				orchestrationOutput: 0,
+				orchestrationCacheRead: 0,
+				premiumRequests: 0,
+				cost: 0,
+				tokensPerSecond: null,
+			},
+		} as unknown as SegmentContext);
+		const plain = stripVTControlCharacters(result.content);
+
+		expect(result.visible).toBe(true);
+		expect(plain).toContain("(oauth)");
+		expect(plain).not.toContain("(sub)");
+	});
+
+	it("renders the footer billing summary with an OAuth marker, not the subagent marker", () => {
+		const session = makeOAuthBackedMainSession();
+		const footer = new FooterComponent(session);
+		const plain = footer
+			.render(120)
+			.map(line => stripVTControlCharacters(line))
+			.join("\n");
+
+		expect(plain).toContain("(oauth)");
+		expect(plain).not.toContain("(sub)");
+	});
+});


### PR DESCRIPTION
## Repro
A top-level/main session with an OAuth-backed Cursor or Anthropic model renders the billing/cost marker as `(sub)` even when no subagent is active. I reproduced this by rendering `StatusLineComponent` with a main-session Cursor OAuth model and saw `(sub) ▶` in the cost segment.

## Cause
`packages/coding-agent/src/modes/components/status-line/segments.ts` and `packages/coding-agent/src/modes/components/footer.ts` both used `modelRegistry.isUsingOAuth(model)` as `usingSubscription` and appended `(sub)`. That state means OAuth-backed billing/subscription credentials, not `AgentRegistry` subagent kind, so Cursor and Anthropic OAuth sessions displayed a subagent-looking marker.

## Fix
- Renamed the status-line OAuth billing marker from `(sub)` to `(oauth)`.
- Renamed the footer OAuth billing marker from `(sub)` to `(oauth)`.
- Added focused regression coverage for both render paths in `packages/coding-agent/test/status-line-billing-label.test.ts`.
- Added a coding-agent changelog entry for #5112.

## Verification
`bun test packages/coding-agent/test/status-line-billing-label.test.ts packages/coding-agent/test/status-line-context-cache.test.ts` passed with 15 tests, 0 failures, and 27 assertions. `gh_push_branch` also completed its pre-publish gate before pushing. Fixes #5112