### PR TITLE
fix(auth): serialize MCP OAuth refreshes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed shared SQLite OAuth refreshes to use durable credential-row ownership plus compare-and-set persistence, preventing stale refresh failures from deleting or overwriting a peer's rotated credential. ([#5081](https://github.com/can1357/oh-my-pi/issues/5081))
+
 ## [16.4.0] - 2026-07-10
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -314,6 +314,7 @@ export interface AuthCredentialStore {
 	updateAuthCredential(id: number, credential: AuthCredential): void;
 	deleteAuthCredential(id: number, disabledCause: string): void;
 	tryDisableAuthCredentialIfMatches(id: number, expectedData: string, disabledCause: string): boolean;
+	tryUpdateAuthCredentialIfMatches?(id: number, expectedData: string, credential: AuthCredential): boolean;
 	replaceAuthCredentialsForProvider(provider: string, credentials: AuthCredential[]): StoredAuthCredential[];
 	upsertAuthCredentialForProvider(provider: string, credential: AuthCredential): StoredAuthCredential[];
 	deleteAuthCredentialsForProvider(provider: string, disabledCause: string): void;
@@ -332,6 +333,9 @@ export interface AuthCredentialStore {
 	cleanExpiredCredentialBlocks?(nowMs: number): void;
 	/** List non-expired blocks for broker snapshots. */
 	listCredentialBlocks?(credentialIds: readonly number[]): StoredCredentialBlock[];
+	tryAcquireCredentialRefreshLease?(credentialId: number, owner: string, expiresAtMs: number): boolean;
+	getCredentialRefreshLeaseExpiresAt?(credentialId: number): number | undefined;
+	releaseCredentialRefreshLease?(credentialId: number, owner: string): void;
 	/**
 	 * Append usage-limit snapshots for trend history. Optional: stores without
 	 * durable storage (e.g. the broker remote store) omit it and recording is
@@ -593,6 +597,8 @@ const DEFAULT_OAUTH_REFRESH_TIMEOUT_MS = 10_000;
  * the rotation cadence by <4%.
  */
 const OAUTH_REFRESH_SKEW_MS = 60_000;
+const OAUTH_REFRESH_LEASE_TTL_MS = 15_000;
+const OAUTH_REFRESH_LEASE_POLL_MS = 50;
 /**
  * Cap on the buffered credential_disabled backlog held while no handler is attached.
  * In practice the backlog is 0–N where N ≈ active providers (≤ ~20). The cap exists so
@@ -716,6 +722,29 @@ export interface OAuthAccountSummary {
 export interface InvalidateCredentialMatchingOptions {
 	signal?: AbortSignal;
 	sessionId?: string;
+}
+
+/** Options for refreshing one stored OAuth row through durable ownership. */
+export interface StoredOAuthRefreshOptions<T extends OAuthCredential = OAuthCredential> {
+	observedCredential?: T;
+	credentialFromRow: (credential: OAuthCredential) => T | undefined;
+	forceRefresh?: boolean;
+	canRefresh?: (credential: T) => boolean;
+	refreshSkewMs?: number;
+	signal?: AbortSignal;
+	keepCredentialOnRefreshFailure?: boolean | ((error: unknown) => boolean);
+	onRefreshFailure?: (error: unknown) => void;
+	refresh: (credential: T) => Promise<OAuthCredentials>;
+	mergeRefreshedCredential?: (credential: T, refreshed: OAuthCredentials) => T;
+	isDefinitiveFailure?: (error: unknown) => boolean;
+	disabledCause?: (error: unknown) => string;
+}
+
+/** Result of a stored OAuth refresh attempt. */
+export interface StoredOAuthRefreshResult<T extends OAuthCredential = OAuthCredential> {
+	credential: T | undefined;
+	refreshed: boolean;
+	removed: boolean;
 }
 
 /**
@@ -1831,6 +1860,162 @@ export class AuthStorage {
 			}
 		}
 		return rows;
+	}
+
+	/**
+	 * Refresh one stored OAuth credential under durable row ownership.
+	 */
+	async refreshStoredOAuthCredential<T extends OAuthCredential = OAuthCredential>(
+		provider: string,
+		options: StoredOAuthRefreshOptions<T>,
+	): Promise<StoredOAuthRefreshResult<T>> {
+		const refreshSkewMs = options.refreshSkewMs ?? OAUTH_REFRESH_SKEW_MS;
+		const hasDurableLease =
+			!!this.#store.tryAcquireCredentialRefreshLease &&
+			!!this.#store.getCredentialRefreshLeaseExpiresAt &&
+			!!this.#store.releaseCredentialRefreshLease;
+		const owner = crypto.randomUUID();
+		let leasedCredentialId: number | undefined;
+
+		while (hasDurableLease) {
+			if (options.signal?.aborted) throw new AIError.AbortError("OAuth refresh ownership aborted by caller");
+			const rows = this.#store.listAuthCredentials(provider);
+			this.#setStoredCredentials(
+				provider,
+				rows.map(row => ({ id: row.id, credential: row.credential })),
+			);
+			const row = rows.find(entry => entry.credential.type === "oauth");
+			if (row?.credential.type !== "oauth") {
+				return { credential: undefined, refreshed: false, removed: false };
+			}
+			const current = options.credentialFromRow(row.credential);
+			if (!current) {
+				return { credential: undefined, refreshed: false, removed: false };
+			}
+			if (options.observedCredential && !authCredentialEquals(current, options.observedCredential)) {
+				return { credential: current, refreshed: false, removed: false };
+			}
+			if (!options.forceRefresh && Date.now() + refreshSkewMs < current.expires) {
+				return { credential: current, refreshed: false, removed: false };
+			}
+			if (options.canRefresh && !options.canRefresh(current)) {
+				return { credential: current, refreshed: false, removed: false };
+			}
+			if (this.#store.tryAcquireCredentialRefreshLease?.(row.id, owner, Date.now() + OAUTH_REFRESH_LEASE_TTL_MS)) {
+				leasedCredentialId = row.id;
+				break;
+			}
+			const leaseExpiresAt = this.#store.getCredentialRefreshLeaseExpiresAt?.(row.id);
+			const waitMs =
+				leaseExpiresAt === undefined
+					? OAUTH_REFRESH_LEASE_POLL_MS
+					: Math.min(Math.max(leaseExpiresAt - Date.now(), OAUTH_REFRESH_LEASE_POLL_MS), 250);
+			await raceCredentialRefreshWithSignal(
+				Bun.sleep(waitMs),
+				options.signal,
+				"OAuth refresh ownership wait aborted by caller",
+			);
+		}
+
+		try {
+			const rows = this.#store.listAuthCredentials(provider);
+			this.#setStoredCredentials(
+				provider,
+				rows.map(row => ({ id: row.id, credential: row.credential })),
+			);
+			const row = rows.find(entry => entry.credential.type === "oauth");
+			if (row?.credential.type !== "oauth") {
+				return { credential: undefined, refreshed: false, removed: false };
+			}
+			const current = options.credentialFromRow(row.credential);
+			if (!current) {
+				return { credential: undefined, refreshed: false, removed: false };
+			}
+			if (options.observedCredential && !authCredentialEquals(current, options.observedCredential)) {
+				return { credential: current, refreshed: false, removed: false };
+			}
+			if (!options.forceRefresh && Date.now() + refreshSkewMs < current.expires) {
+				return { credential: current, refreshed: false, removed: false };
+			}
+			if (options.canRefresh && !options.canRefresh(current)) {
+				return { credential: current, refreshed: false, removed: false };
+			}
+			const serialized = serializeCredential(provider, current);
+			if (!serialized) return { credential: current, refreshed: false, removed: false };
+
+			let refreshed: OAuthCredentials;
+			try {
+				refreshed = await options.refresh(current);
+			} catch (error) {
+				if (options.isDefinitiveFailure?.(error)) {
+					const disabledCause = options.disabledCause?.(error) ?? `oauth refresh failed: ${String(error)}`;
+					const disabled = this.#store.tryDisableAuthCredentialIfMatches(row.id, serialized.data, disabledCause);
+					if (disabled) {
+						this.#setStoredCredentials(
+							provider,
+							rows
+								.filter(entry => entry.id !== row.id)
+								.map(entry => ({ id: entry.id, credential: entry.credential })),
+						);
+						this.#resetProviderAssignments(provider);
+						this.#emitCredentialDisabled({ provider, disabledCause });
+						return { credential: undefined, refreshed: false, removed: true };
+					}
+					await this.reload();
+					const latest = this.get(provider);
+					return {
+						credential: latest?.type === "oauth" ? options.credentialFromRow(latest) : undefined,
+						refreshed: false,
+						removed: false,
+					};
+				}
+				options.onRefreshFailure?.(error);
+				const keepCredential =
+					typeof options.keepCredentialOnRefreshFailure === "function"
+						? options.keepCredentialOnRefreshFailure(error)
+						: options.keepCredentialOnRefreshFailure === true;
+				if (keepCredential) {
+					return { credential: current, refreshed: false, removed: false };
+				}
+				throw error;
+			}
+
+			const merged: T = options.mergeRefreshedCredential
+				? options.mergeRefreshedCredential(current, refreshed)
+				: {
+						...current,
+						access: refreshed.access,
+						refresh: refreshed.refresh,
+						expires: refreshed.expires,
+						accountId: refreshed.accountId ?? current.accountId,
+						email: refreshed.email ?? current.email,
+						projectId: refreshed.projectId ?? current.projectId,
+						enterpriseUrl: refreshed.enterpriseUrl ?? current.enterpriseUrl,
+						apiEndpoint: refreshed.apiEndpoint ?? current.apiEndpoint,
+					};
+			if (this.#store.tryUpdateAuthCredentialIfMatches) {
+				if (!this.#store.tryUpdateAuthCredentialIfMatches(row.id, serialized.data, merged)) {
+					await this.reload();
+					const latest = this.get(provider);
+					return {
+						credential: latest?.type === "oauth" ? options.credentialFromRow(latest) : undefined,
+						refreshed: false,
+						removed: false,
+					};
+				}
+			} else {
+				this.#store.updateAuthCredential(row.id, merged);
+			}
+			this.#setStoredCredentials(
+				provider,
+				rows.map(entry => ({ id: entry.id, credential: entry.id === row.id ? merged : entry.credential })),
+			);
+			return { credential: merged, refreshed: true, removed: false };
+		} finally {
+			if (leasedCredentialId !== undefined) {
+				this.#store.releaseCredentialRefreshLease?.(leasedCredentialId, owner);
+			}
+		}
 	}
 
 	async #upsertOAuthCredential(provider: string, credential: OAuthCredential): Promise<void> {
@@ -5018,7 +5203,7 @@ type SerializedCredentialRecord = {
 	identityKey: string | null;
 };
 
-const AUTH_SCHEMA_VERSION = 5;
+const AUTH_SCHEMA_VERSION = 6;
 const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
 
 /**
@@ -5214,6 +5399,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#updateStmt: Statement;
 	#deleteStmt: Statement;
 	#deleteIfMatchesStmt: Statement;
+	#updateIfMatchesStmt: Statement;
 	#deleteByProviderStmt: Statement;
 	#hardDeleteStmt: Statement;
 	#getCacheStmt: Statement;
@@ -5225,6 +5411,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#upsertCredentialBlockStmt: Statement;
 	#deleteCredentialBlocksStmt: Statement;
 	#deleteExpiredCredentialBlocksStmt: Statement;
+	#acquireCredentialRefreshLeaseStmt: Statement;
+	#getCredentialRefreshLeaseStmt: Statement;
+	#releaseCredentialRefreshLeaseStmt: Statement;
 	#credentialBlockReconcileAfter: Map<string, number> = new Map();
 	#insertUsageHistoryStmt: Statement;
 	#insertUsageCostStmt: Statement;
@@ -5252,6 +5441,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		);
 		this.#updateStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET credential_type = ?, data = ?, identity_key = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ?`,
+		);
+		this.#updateIfMatchesStmt = this.#db.prepare(
+			`UPDATE auth_credentials SET credential_type = ?, data = ?, identity_key = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ? AND data = ? AND disabled_cause IS NULL`,
 		);
 		this.#deleteStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET disabled_cause = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ?`,
@@ -5287,6 +5479,21 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#deleteCredentialBlocksStmt = this.#db.prepare("DELETE FROM auth_credential_blocks WHERE credential_id = ?");
 		this.#deleteExpiredCredentialBlocksStmt = this.#db.prepare(
 			"DELETE FROM auth_credential_blocks WHERE blocked_until_ms <= ?",
+		);
+		this.#acquireCredentialRefreshLeaseStmt = this.#db.prepare(
+			`INSERT INTO auth_credential_refresh_leases (credential_id, owner, expires_at_ms, updated_at)
+			VALUES (?, ?, ?, ${SQLITE_NOW_EPOCH})
+			ON CONFLICT(credential_id) DO UPDATE SET
+				owner = excluded.owner,
+				expires_at_ms = excluded.expires_at_ms,
+				updated_at = excluded.updated_at
+			WHERE auth_credential_refresh_leases.expires_at_ms <= ?`,
+		);
+		this.#getCredentialRefreshLeaseStmt = this.#db.prepare(
+			"SELECT expires_at_ms FROM auth_credential_refresh_leases WHERE credential_id = ?",
+		);
+		this.#releaseCredentialRefreshLeaseStmt = this.#db.prepare(
+			"DELETE FROM auth_credential_refresh_leases WHERE credential_id = ? AND owner = ?",
 		);
 		this.#insertUsageHistoryStmt = this.#db.prepare(
 			"INSERT INTO usage_history (recorded_at, provider, account_key, email, account_id, limit_id, label, window_label, used_fraction, status, resets_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -5400,6 +5607,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		if (!this.#authCredentialsTableExists()) {
 			this.#createAuthCredentialsTable();
 			this.#createAuthCredentialBlocksTable();
+			this.#createAuthCredentialRefreshLeasesTable();
 			this.#writeAuthSchemaVersion(AUTH_SCHEMA_VERSION);
 			return;
 		}
@@ -5417,6 +5625,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 
 		this.#createAuthCredentialIndexes();
 		this.#createAuthCredentialBlocksTable();
+		this.#createAuthCredentialRefreshLeasesTable();
 		this.#backfillCredentialIdentityKeys();
 		// Rewriting an already-current version row is a no-op write transaction
 		// on every boot; only persist when the recorded version actually changes.
@@ -5514,6 +5723,18 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		`);
 	}
 
+	#createAuthCredentialRefreshLeasesTable(): void {
+		this.#db.run(`
+			CREATE TABLE IF NOT EXISTS auth_credential_refresh_leases (
+				credential_id INTEGER PRIMARY KEY,
+				owner TEXT NOT NULL,
+				expires_at_ms INTEGER NOT NULL,
+				updated_at INTEGER NOT NULL
+			);
+			CREATE INDEX IF NOT EXISTS idx_auth_credential_refresh_leases_expires ON auth_credential_refresh_leases(expires_at_ms);
+		`);
+	}
+
 	#migrateAuthSchema(fromVersion: number): void {
 		if (fromVersion < 1) {
 			this.#migrateAuthSchemaV0ToV1();
@@ -5526,6 +5747,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		}
 		if (fromVersion < 5) {
 			this.#migrateAuthSchemaV4ToV5();
+		}
+		if (fromVersion < 6) {
+			this.#migrateAuthSchemaV5ToV6();
 		}
 	}
 
@@ -5616,6 +5840,13 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#migrateAuthSchemaV4ToV5(): void {
 		const migrate = this.#db.transaction(() => {
 			this.#createAuthCredentialBlocksTable();
+		});
+		migrate();
+	}
+
+	#migrateAuthSchemaV5ToV6(): void {
+		const migrate = this.#db.transaction(() => {
+			this.#createAuthCredentialRefreshLeasesTable();
 		});
 		migrate();
 	}
@@ -5826,6 +6057,35 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		}
 	}
 
+	tryUpdateAuthCredentialIfMatches(id: number, expectedData: string, credential: AuthCredential): boolean {
+		try {
+			const providerStmt = this.#db.prepare("SELECT provider FROM auth_credentials WHERE id = ?");
+			let providerRow: { provider?: string } | undefined;
+			try {
+				providerRow = providerStmt.get(id) as { provider?: string } | undefined;
+			} finally {
+				providerStmt.finalize();
+			}
+			const provider = providerRow?.provider ?? "";
+			const serialized = serializeCredential(provider, credential);
+			if (!serialized) return false;
+			const result = this.#updateIfMatchesStmt.run(
+				serialized.credentialType,
+				serialized.data,
+				serialized.identityKey,
+				id,
+				expectedData,
+			) as { changes: number };
+			if (result.changes !== 1) return false;
+			if (provider) {
+				this.#purgeSupersededDisabledRows(provider, this.listAuthCredentials(provider));
+			}
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
 	deleteAuthCredential(id: number, disabledCause: string): void {
 		try {
 			this.#deleteStmt.run(normalizeDisabledCause(disabledCause), id);
@@ -5957,6 +6217,28 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 			}
 		}
 		return blocks;
+	}
+
+	tryAcquireCredentialRefreshLease(credentialId: number, owner: string, expiresAtMs: number): boolean {
+		const result = this.#acquireCredentialRefreshLeaseStmt.run(credentialId, owner, expiresAtMs, Date.now()) as {
+			changes: number;
+		};
+		return result.changes === 1;
+	}
+
+	getCredentialRefreshLeaseExpiresAt(credentialId: number): number | undefined {
+		const row = this.#getCredentialRefreshLeaseStmt.get(credentialId) as { expires_at_ms?: number } | undefined;
+		if (typeof row?.expires_at_ms !== "number") return undefined;
+		if (row.expires_at_ms <= Date.now()) return undefined;
+		return row.expires_at_ms;
+	}
+
+	releaseCredentialRefreshLease(credentialId: number, owner: string): void {
+		try {
+			this.#releaseCredentialRefreshLeaseStmt.run(credentialId, owner);
+		} catch {
+			// Ignore lease release failures; expired leases are stealable.
+		}
 	}
 
 	recordUsageSnapshots(entries: UsageHistoryEntry[]): void {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -336,6 +336,7 @@ export interface AuthCredentialStore {
 	tryAcquireCredentialRefreshLease?(credentialId: number, owner: string, expiresAtMs: number): boolean;
 	getCredentialRefreshLeaseExpiresAt?(credentialId: number): number | undefined;
 	releaseCredentialRefreshLease?(credentialId: number, owner: string): void;
+	renewCredentialRefreshLease?(credentialId: number, owner: string, expiresAtMs: number): boolean;
 	/**
 	 * Append usage-limit snapshots for trend history. Optional: stores without
 	 * durable storage (e.g. the broker remote store) omit it and recording is
@@ -599,6 +600,7 @@ const DEFAULT_OAUTH_REFRESH_TIMEOUT_MS = 10_000;
 const OAUTH_REFRESH_SKEW_MS = 60_000;
 const OAUTH_REFRESH_LEASE_TTL_MS = 15_000;
 const OAUTH_REFRESH_LEASE_POLL_MS = 50;
+const OAUTH_REFRESH_LEASE_RENEW_MS = 5_000;
 /**
  * Cap on the buffered credential_disabled backlog held while no handler is attached.
  * In practice the backlog is 0–N where N ≈ active providers (≤ ~20). The cap exists so
@@ -1873,7 +1875,8 @@ export class AuthStorage {
 		const hasDurableLease =
 			!!this.#store.tryAcquireCredentialRefreshLease &&
 			!!this.#store.getCredentialRefreshLeaseExpiresAt &&
-			!!this.#store.releaseCredentialRefreshLease;
+			!!this.#store.releaseCredentialRefreshLease &&
+			!!this.#store.renewCredentialRefreshLease;
 		const owner = crypto.randomUUID();
 		let leasedCredentialId: number | undefined;
 
@@ -1943,42 +1946,76 @@ export class AuthStorage {
 			const serialized = serializeCredential(provider, current);
 			if (!serialized) return { credential: current, refreshed: false, removed: false };
 
+			let stopLeaseRenewal = false;
+			let leaseRenewalError: unknown;
+			const leaseRenewalStopped = Promise.withResolvers<void>();
+			const leaseRenewal =
+				leasedCredentialId !== undefined
+					? (async () => {
+							while (!stopLeaseRenewal) {
+								await Promise.race([Bun.sleep(OAUTH_REFRESH_LEASE_RENEW_MS), leaseRenewalStopped.promise]);
+								if (stopLeaseRenewal) return;
+								const renewed = this.#store.renewCredentialRefreshLease?.(
+									leasedCredentialId,
+									owner,
+									Date.now() + OAUTH_REFRESH_LEASE_TTL_MS,
+								);
+								if (!renewed) {
+									throw new AIError.ConfigurationError("OAuth refresh ownership was lost before persistence");
+								}
+							}
+						})().catch(error => {
+							leaseRenewalError = error;
+						})
+					: undefined;
+
 			let refreshed: OAuthCredentials;
 			try {
-				refreshed = await options.refresh(current);
-			} catch (error) {
-				if (options.isDefinitiveFailure?.(error)) {
-					const disabledCause = options.disabledCause?.(error) ?? `oauth refresh failed: ${String(error)}`;
-					const disabled = this.#store.tryDisableAuthCredentialIfMatches(row.id, serialized.data, disabledCause);
-					if (disabled) {
-						this.#setStoredCredentials(
-							provider,
-							rows
-								.filter(entry => entry.id !== row.id)
-								.map(entry => ({ id: entry.id, credential: entry.credential })),
+				try {
+					refreshed = await options.refresh(current);
+				} catch (error) {
+					if (options.isDefinitiveFailure?.(error)) {
+						const disabledCause = options.disabledCause?.(error) ?? `oauth refresh failed: ${String(error)}`;
+						const disabled = this.#store.tryDisableAuthCredentialIfMatches(
+							row.id,
+							serialized.data,
+							disabledCause,
 						);
-						this.#resetProviderAssignments(provider);
-						this.#emitCredentialDisabled({ provider, disabledCause });
-						return { credential: undefined, refreshed: false, removed: true };
+						if (disabled) {
+							this.#setStoredCredentials(
+								provider,
+								rows
+									.filter(entry => entry.id !== row.id)
+									.map(entry => ({ id: entry.id, credential: entry.credential })),
+							);
+							this.#resetProviderAssignments(provider);
+							this.#emitCredentialDisabled({ provider, disabledCause });
+							return { credential: undefined, refreshed: false, removed: true };
+						}
+						await this.reload();
+						const latest = this.get(provider);
+						return {
+							credential: latest?.type === "oauth" ? options.credentialFromRow(latest) : undefined,
+							refreshed: false,
+							removed: false,
+						};
 					}
-					await this.reload();
-					const latest = this.get(provider);
-					return {
-						credential: latest?.type === "oauth" ? options.credentialFromRow(latest) : undefined,
-						refreshed: false,
-						removed: false,
-					};
+					options.onRefreshFailure?.(error);
+					const keepCredential =
+						typeof options.keepCredentialOnRefreshFailure === "function"
+							? options.keepCredentialOnRefreshFailure(error)
+							: options.keepCredentialOnRefreshFailure === true;
+					if (keepCredential) {
+						return { credential: current, refreshed: false, removed: false };
+					}
+					throw error;
 				}
-				options.onRefreshFailure?.(error);
-				const keepCredential =
-					typeof options.keepCredentialOnRefreshFailure === "function"
-						? options.keepCredentialOnRefreshFailure(error)
-						: options.keepCredentialOnRefreshFailure === true;
-				if (keepCredential) {
-					return { credential: current, refreshed: false, removed: false };
-				}
-				throw error;
+			} finally {
+				stopLeaseRenewal = true;
+				leaseRenewalStopped.resolve();
+				await leaseRenewal;
 			}
+			if (leaseRenewalError) throw leaseRenewalError;
 
 			const merged: T = options.mergeRefreshedCredential
 				? options.mergeRefreshedCredential(current, refreshed)
@@ -5413,6 +5450,7 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#deleteExpiredCredentialBlocksStmt: Statement;
 	#acquireCredentialRefreshLeaseStmt: Statement;
 	#getCredentialRefreshLeaseStmt: Statement;
+	#renewCredentialRefreshLeaseStmt: Statement;
 	#releaseCredentialRefreshLeaseStmt: Statement;
 	#credentialBlockReconcileAfter: Map<string, number> = new Map();
 	#insertUsageHistoryStmt: Statement;
@@ -5491,6 +5529,9 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		);
 		this.#getCredentialRefreshLeaseStmt = this.#db.prepare(
 			"SELECT expires_at_ms FROM auth_credential_refresh_leases WHERE credential_id = ?",
+		);
+		this.#renewCredentialRefreshLeaseStmt = this.#db.prepare(
+			`UPDATE auth_credential_refresh_leases SET expires_at_ms = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE credential_id = ? AND owner = ?`,
 		);
 		this.#releaseCredentialRefreshLeaseStmt = this.#db.prepare(
 			"DELETE FROM auth_credential_refresh_leases WHERE credential_id = ? AND owner = ?",
@@ -6058,32 +6099,28 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	}
 
 	tryUpdateAuthCredentialIfMatches(id: number, expectedData: string, credential: AuthCredential): boolean {
+		const providerStmt = this.#db.prepare("SELECT provider FROM auth_credentials WHERE id = ?");
+		let providerRow: { provider?: string } | undefined;
 		try {
-			const providerStmt = this.#db.prepare("SELECT provider FROM auth_credentials WHERE id = ?");
-			let providerRow: { provider?: string } | undefined;
-			try {
-				providerRow = providerStmt.get(id) as { provider?: string } | undefined;
-			} finally {
-				providerStmt.finalize();
-			}
-			const provider = providerRow?.provider ?? "";
-			const serialized = serializeCredential(provider, credential);
-			if (!serialized) return false;
-			const result = this.#updateIfMatchesStmt.run(
-				serialized.credentialType,
-				serialized.data,
-				serialized.identityKey,
-				id,
-				expectedData,
-			) as { changes: number };
-			if (result.changes !== 1) return false;
-			if (provider) {
-				this.#purgeSupersededDisabledRows(provider, this.listAuthCredentials(provider));
-			}
-			return true;
-		} catch {
-			return false;
+			providerRow = providerStmt.get(id) as { provider?: string } | undefined;
+		} finally {
+			providerStmt.finalize();
 		}
+		const provider = providerRow?.provider ?? "";
+		const serialized = serializeCredential(provider, credential);
+		if (!serialized) return false;
+		const result = this.#updateIfMatchesStmt.run(
+			serialized.credentialType,
+			serialized.data,
+			serialized.identityKey,
+			id,
+			expectedData,
+		) as { changes: number };
+		if (result.changes !== 1) return false;
+		if (provider) {
+			this.#purgeSupersededDisabledRows(provider, this.listAuthCredentials(provider));
+		}
+		return true;
 	}
 
 	deleteAuthCredential(id: number, disabledCause: string): void {
@@ -6101,16 +6138,11 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	 * row between our pre-check and the disable.
 	 */
 	tryDisableAuthCredentialIfMatches(id: number, expectedData: string, disabledCause: string): boolean {
-		try {
-			const result = this.#deleteIfMatchesStmt.run(normalizeDisabledCause(disabledCause), id, expectedData) as {
-				changes: number;
-			};
-			return result.changes === 1;
-		} catch {
-			return false;
-		}
+		const result = this.#deleteIfMatchesStmt.run(normalizeDisabledCause(disabledCause), id, expectedData) as {
+			changes: number;
+		};
+		return result.changes === 1;
 	}
-
 	deleteAuthCredentialsForProvider(provider: string, disabledCause: string): void {
 		try {
 			this.#deleteByProviderStmt.run(normalizeDisabledCause(disabledCause), provider);
@@ -6231,6 +6263,13 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		if (typeof row?.expires_at_ms !== "number") return undefined;
 		if (row.expires_at_ms <= Date.now()) return undefined;
 		return row.expires_at_ms;
+	}
+
+	renewCredentialRefreshLease(credentialId: number, owner: string, expiresAtMs: number): boolean {
+		const result = this.#renewCredentialRefreshLeaseStmt.run(expiresAtMs, credentialId, owner) as {
+			changes: number;
+		};
+		return result.changes === 1;
 	}
 
 	releaseCredentialRefreshLease(credentialId: number, owner: string): void {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -308,13 +308,28 @@ export interface AuthCredentialSnapshot {
  *   a remote broker; mutating methods (`replace*`, `upsert*`, `delete*ForProvider`)
  *   throw because login flows route through the broker, not the client.
  */
+export interface CredentialRefreshLeaseFence {
+	owner: string;
+	nowMs: number;
+}
+
 export interface AuthCredentialStore {
 	close(): void;
 	listAuthCredentials(provider?: string): StoredAuthCredential[];
 	updateAuthCredential(id: number, credential: AuthCredential): void;
 	deleteAuthCredential(id: number, disabledCause: string): void;
-	tryDisableAuthCredentialIfMatches(id: number, expectedData: string, disabledCause: string): boolean;
-	tryUpdateAuthCredentialIfMatches?(id: number, expectedData: string, credential: AuthCredential): boolean;
+	tryDisableAuthCredentialIfMatches(
+		id: number,
+		expectedData: string,
+		disabledCause: string,
+		lease?: CredentialRefreshLeaseFence,
+	): boolean;
+	tryUpdateAuthCredentialIfMatches?(
+		id: number,
+		expectedData: string,
+		credential: AuthCredential,
+		lease?: CredentialRefreshLeaseFence,
+	): boolean;
 	replaceAuthCredentialsForProvider(provider: string, credentials: AuthCredential[]): StoredAuthCredential[];
 	upsertAuthCredentialForProvider(provider: string, credential: AuthCredential): StoredAuthCredential[];
 	deleteAuthCredentialsForProvider(provider: string, disabledCause: string): void;
@@ -601,6 +616,7 @@ const OAUTH_REFRESH_SKEW_MS = 60_000;
 const OAUTH_REFRESH_LEASE_TTL_MS = 15_000;
 const OAUTH_REFRESH_LEASE_POLL_MS = 50;
 const OAUTH_REFRESH_LEASE_RENEW_MS = 5_000;
+const OAUTH_REFRESH_OPERATION_TIMEOUT_MS = 10_000;
 /**
  * Cap on the buffered credential_disabled backlog held while no handler is attached.
  * In practice the backlog is 0–N where N ≈ active providers (≤ ~20). The cap exists so
@@ -736,7 +752,8 @@ export interface StoredOAuthRefreshOptions<T extends OAuthCredential = OAuthCred
 	signal?: AbortSignal;
 	keepCredentialOnRefreshFailure?: boolean | ((error: unknown) => boolean);
 	onRefreshFailure?: (error: unknown) => void;
-	refresh: (credential: T) => Promise<OAuthCredentials>;
+	refreshTimeoutMs?: number;
+	refresh: (credential: T, signal?: AbortSignal) => Promise<OAuthCredentials>;
 	mergeRefreshedCredential?: (credential: T, refreshed: OAuthCredentials) => T;
 	isDefinitiveFailure?: (error: unknown) => boolean;
 	disabledCause?: (error: unknown) => string;
@@ -1968,11 +1985,20 @@ export class AuthStorage {
 							leaseRenewalError = error;
 						})
 					: undefined;
+			const refreshAbort = new AbortController();
+			const refreshTimeout = setTimeout(() => {
+				refreshAbort.abort(
+					new AIError.OAuthError(`OAuth token refresh timed out for provider: ${provider}`, {
+						kind: "timeout",
+						provider,
+					}),
+				);
+			}, options.refreshTimeoutMs ?? OAUTH_REFRESH_OPERATION_TIMEOUT_MS);
 
 			let refreshed: OAuthCredentials;
 			try {
 				try {
-					refreshed = await options.refresh(current);
+					refreshed = await options.refresh(current, refreshAbort.signal);
 				} catch (error) {
 					if (options.isDefinitiveFailure?.(error)) {
 						const disabledCause = options.disabledCause?.(error) ?? `oauth refresh failed: ${String(error)}`;
@@ -1980,6 +2006,7 @@ export class AuthStorage {
 							row.id,
 							serialized.data,
 							disabledCause,
+							leasedCredentialId !== undefined ? { owner, nowMs: Date.now() } : undefined,
 						);
 						if (disabled) {
 							this.#setStoredCredentials(
@@ -2014,6 +2041,7 @@ export class AuthStorage {
 				stopLeaseRenewal = true;
 				leaseRenewalStopped.resolve();
 				await leaseRenewal;
+				clearTimeout(refreshTimeout);
 			}
 			if (leaseRenewalError) throw leaseRenewalError;
 
@@ -2031,7 +2059,14 @@ export class AuthStorage {
 						apiEndpoint: refreshed.apiEndpoint ?? current.apiEndpoint,
 					};
 			if (this.#store.tryUpdateAuthCredentialIfMatches) {
-				if (!this.#store.tryUpdateAuthCredentialIfMatches(row.id, serialized.data, merged)) {
+				if (
+					!this.#store.tryUpdateAuthCredentialIfMatches(
+						row.id,
+						serialized.data,
+						merged,
+						leasedCredentialId !== undefined ? { owner, nowMs: Date.now() } : undefined,
+					)
+				) {
 					await this.reload();
 					const latest = this.get(provider);
 					return {
@@ -5443,6 +5478,8 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	#getCacheIncludingExpiredStmt: Statement;
 	#upsertCacheStmt: Statement;
 	#deleteExpiredCacheStmt: Statement;
+	#updateIfMatchesWithLeaseStmt: Statement;
+	#deleteIfMatchesWithLeaseStmt: Statement;
 	#getCredentialBlockStmt: Statement;
 	#listCredentialBlocksByCredentialStmt: Statement;
 	#upsertCredentialBlockStmt: Statement;
@@ -5483,11 +5520,29 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		this.#updateIfMatchesStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET credential_type = ?, data = ?, identity_key = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ? AND data = ? AND disabled_cause IS NULL`,
 		);
+		this.#updateIfMatchesWithLeaseStmt = this.#db.prepare(
+			`UPDATE auth_credentials
+			SET credential_type = ?, data = ?, identity_key = ?, updated_at = ${SQLITE_NOW_EPOCH}
+			WHERE id = ? AND data = ? AND disabled_cause IS NULL
+				AND EXISTS (
+					SELECT 1 FROM auth_credential_refresh_leases
+					WHERE credential_id = ? AND owner = ? AND expires_at_ms > ?
+				)`,
+		);
 		this.#deleteStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET disabled_cause = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ?`,
 		);
 		this.#deleteIfMatchesStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET disabled_cause = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE id = ? AND data = ? AND disabled_cause IS NULL`,
+		);
+		this.#deleteIfMatchesWithLeaseStmt = this.#db.prepare(
+			`UPDATE auth_credentials
+			SET disabled_cause = ?, updated_at = ${SQLITE_NOW_EPOCH}
+			WHERE id = ? AND data = ? AND disabled_cause IS NULL
+				AND EXISTS (
+					SELECT 1 FROM auth_credential_refresh_leases
+					WHERE credential_id = ? AND owner = ? AND expires_at_ms > ?
+				)`,
 		);
 		this.#deleteByProviderStmt = this.#db.prepare(
 			`UPDATE auth_credentials SET disabled_cause = ?, updated_at = ${SQLITE_NOW_EPOCH} WHERE provider = ? AND disabled_cause IS NULL`,
@@ -6098,7 +6153,12 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		}
 	}
 
-	tryUpdateAuthCredentialIfMatches(id: number, expectedData: string, credential: AuthCredential): boolean {
+	tryUpdateAuthCredentialIfMatches(
+		id: number,
+		expectedData: string,
+		credential: AuthCredential,
+		lease?: CredentialRefreshLeaseFence,
+	): boolean {
 		const providerStmt = this.#db.prepare("SELECT provider FROM auth_credentials WHERE id = ?");
 		let providerRow: { provider?: string } | undefined;
 		try {
@@ -6109,13 +6169,24 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 		const provider = providerRow?.provider ?? "";
 		const serialized = serializeCredential(provider, credential);
 		if (!serialized) return false;
-		const result = this.#updateIfMatchesStmt.run(
-			serialized.credentialType,
-			serialized.data,
-			serialized.identityKey,
-			id,
-			expectedData,
-		) as { changes: number };
+		const result = lease
+			? (this.#updateIfMatchesWithLeaseStmt.run(
+					serialized.credentialType,
+					serialized.data,
+					serialized.identityKey,
+					id,
+					expectedData,
+					id,
+					lease.owner,
+					lease.nowMs,
+				) as { changes: number })
+			: (this.#updateIfMatchesStmt.run(
+					serialized.credentialType,
+					serialized.data,
+					serialized.identityKey,
+					id,
+					expectedData,
+				) as { changes: number });
 		if (result.changes !== 1) return false;
 		if (provider) {
 			this.#purgeSupersededDisabledRows(provider, this.listAuthCredentials(provider));
@@ -6137,10 +6208,24 @@ export class SqliteAuthCredentialStore implements AuthCredentialStore {
 	 * the OAuth refresh-failure path to avoid clobbering a peer that rotated the
 	 * row between our pre-check and the disable.
 	 */
-	tryDisableAuthCredentialIfMatches(id: number, expectedData: string, disabledCause: string): boolean {
-		const result = this.#deleteIfMatchesStmt.run(normalizeDisabledCause(disabledCause), id, expectedData) as {
-			changes: number;
-		};
+	tryDisableAuthCredentialIfMatches(
+		id: number,
+		expectedData: string,
+		disabledCause: string,
+		lease?: CredentialRefreshLeaseFence,
+	): boolean {
+		const result = lease
+			? (this.#deleteIfMatchesWithLeaseStmt.run(
+					normalizeDisabledCause(disabledCause),
+					id,
+					expectedData,
+					id,
+					lease.owner,
+					lease.nowMs,
+				) as { changes: number })
+			: (this.#deleteIfMatchesStmt.run(normalizeDisabledCause(disabledCause), id, expectedData) as {
+					changes: number;
+				});
 		return result.changes === 1;
 	}
 	deleteAuthCredentialsForProvider(provider: string, disabledCause: string): void {

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -432,4 +432,82 @@ describe("AuthStorage OAuth refresh race", () => {
 		expect(cRow?.credential.type).toBe("oauth");
 		if (cRow?.credential.type === "oauth") expect(cRow.credential.refresh).toBe("c-ref");
 	});
+
+	test("propagates CAS update storage errors instead of treating them as peer refresh wins", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		await authStorage.set("unit-oauth-cas-update-error", [
+			{
+				type: "oauth",
+				access: "access-old",
+				refresh: "refresh-old",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		const failure = new Error("sqlite update failed");
+		vi.spyOn(store, "tryUpdateAuthCredentialIfMatches").mockImplementation(() => {
+			throw failure;
+		});
+
+		await expect(
+			authStorage.refreshStoredOAuthCredential("unit-oauth-cas-update-error", {
+				credentialFromRow: row => row,
+				forceRefresh: true,
+				refresh: async credential => ({
+					...credential,
+					access: "access-fresh",
+					refresh: "refresh-fresh",
+					expires: Date.now() + 60 * 60_000,
+				}),
+			}),
+		).rejects.toThrow("sqlite update failed");
+
+		const stored = store.listAuthCredentials("unit-oauth-cas-update-error");
+		expect(stored).toHaveLength(1);
+		expect(stored[0]?.credential).toMatchObject({
+			type: "oauth",
+			access: "access-old",
+			refresh: "refresh-old",
+		});
+	});
+
+	test("propagates CAS disable storage errors instead of treating them as peer rotations", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		await authStorage.set("unit-oauth-cas-disable-error", [
+			{
+				type: "oauth",
+				access: "access-old",
+				refresh: "refresh-old",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		const failure = new Error("sqlite disable failed");
+		vi.spyOn(store, "tryDisableAuthCredentialIfMatches").mockImplementation(() => {
+			throw failure;
+		});
+
+		await expect(
+			authStorage.refreshStoredOAuthCredential("unit-oauth-cas-disable-error", {
+				credentialFromRow: row => row,
+				forceRefresh: true,
+				refresh: async () => {
+					throw new Error('HTTP 400 invalid_grant {"error":"invalid_grant"}');
+				},
+				isDefinitiveFailure: error => error instanceof Error && error.message.includes("invalid_grant"),
+				disabledCause: error => `oauth refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+			}),
+		).rejects.toThrow("sqlite disable failed");
+
+		expect(events).toHaveLength(0);
+		const stored = store.listAuthCredentials("unit-oauth-cas-disable-error");
+		expect(stored).toHaveLength(1);
+		expect(stored[0]?.credential).toMatchObject({
+			type: "oauth",
+			access: "access-old",
+			refresh: "refresh-old",
+		});
+	});
 });

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, setSystemTime, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -36,6 +36,7 @@ describe("AuthStorage OAuth refresh race", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+		setSystemTime();
 		oauthUtils.unregisterOAuthProviders("auth-storage-oauth-refresh-race-test");
 		store?.close();
 		store = null;
@@ -504,6 +505,112 @@ describe("AuthStorage OAuth refresh race", () => {
 		expect(events).toHaveLength(0);
 		const stored = store.listAuthCredentials("unit-oauth-cas-disable-error");
 		expect(stored).toHaveLength(1);
+		expect(stored[0]?.credential).toMatchObject({
+			type: "oauth",
+			access: "access-old",
+			refresh: "refresh-old",
+		});
+	});
+
+	test("does not persist a refresh when durable lease ownership is lost before CAS update", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		const now = Date.parse("2026-07-10T12:00:00.000Z");
+		setSystemTime(new Date(now));
+		await authStorage.set("unit-oauth-lease-update", [
+			{
+				type: "oauth",
+				access: "access-old",
+				refresh: "refresh-old",
+				expires: now - 60_000,
+			},
+		]);
+		const storedBefore = store.listAuthCredentials("unit-oauth-lease-update");
+		expect(storedBefore).toHaveLength(1);
+		const credentialId = storedBefore[0]!.id;
+		const stealLease = store.tryAcquireCredentialRefreshLease?.bind(store);
+		if (!stealLease) throw new Error("test store does not support refresh leases");
+		const updateSpy = vi.spyOn(store, "tryUpdateAuthCredentialIfMatches");
+
+		const result = await authStorage.refreshStoredOAuthCredential("unit-oauth-lease-update", {
+			credentialFromRow: row => row,
+			forceRefresh: true,
+			refresh: async credential => {
+				// Keep the credential row bytes unchanged while expiring owner A's
+				// lease. A non-lease-fenced final CAS would still persist this token.
+				setSystemTime(new Date(now + 16_000));
+				expect(stealLease(credentialId, "peer-owner", now + 31_000)).toBe(true);
+				return {
+					...credential,
+					access: "access-from-lost-owner",
+					refresh: "refresh-from-lost-owner",
+					expires: now + 60 * 60_000,
+				};
+			},
+		});
+
+		expect(updateSpy).toHaveBeenCalled();
+		expect(result).toMatchObject({ refreshed: false, removed: false });
+		expect(result.credential).toMatchObject({
+			type: "oauth",
+			access: "access-old",
+			refresh: "refresh-old",
+		});
+		const stored = store.listAuthCredentials("unit-oauth-lease-update");
+		expect(stored).toHaveLength(1);
+		expect(stored[0]?.id).toBe(credentialId);
+		expect(stored[0]?.credential).toMatchObject({
+			type: "oauth",
+			access: "access-old",
+			refresh: "refresh-old",
+		});
+	});
+
+	test("does not terminal-disable a credential when durable lease ownership is lost before CAS disable", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		const now = Date.parse("2026-07-10T12:30:00.000Z");
+		setSystemTime(new Date(now));
+		await authStorage.set("unit-oauth-lease-disable", [
+			{
+				type: "oauth",
+				access: "access-old",
+				refresh: "refresh-old",
+				expires: now - 60_000,
+			},
+		]);
+		const storedBefore = store.listAuthCredentials("unit-oauth-lease-disable");
+		expect(storedBefore).toHaveLength(1);
+		const credentialId = storedBefore[0]!.id;
+		const stealLease = store.tryAcquireCredentialRefreshLease?.bind(store);
+		if (!stealLease) throw new Error("test store does not support refresh leases");
+		const disableSpy = vi.spyOn(store, "tryDisableAuthCredentialIfMatches");
+
+		const result = await authStorage.refreshStoredOAuthCredential("unit-oauth-lease-disable", {
+			credentialFromRow: row => row,
+			forceRefresh: true,
+			refresh: async () => {
+				// The row still contains the same stale refresh token. Only the lease
+				// fence distinguishes stale owner A from the current row owner.
+				setSystemTime(new Date(now + 16_000));
+				expect(stealLease(credentialId, "peer-owner", now + 31_000)).toBe(true);
+				throw new Error('HTTP 400 invalid_grant {"error":"invalid_grant"}');
+			},
+			isDefinitiveFailure: error => error instanceof Error && error.message.includes("invalid_grant"),
+			disabledCause: error => `oauth refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+		});
+
+		expect(disableSpy).toHaveBeenCalled();
+		expect(result).toMatchObject({ refreshed: false, removed: false });
+		expect(result.credential).toMatchObject({
+			type: "oauth",
+			access: "access-old",
+			refresh: "refresh-old",
+		});
+		expect(events).toHaveLength(0);
+		const stored = store.listAuthCredentials("unit-oauth-lease-disable");
+		expect(stored).toHaveLength(1);
+		expect(stored[0]?.id).toBe(credentialId);
 		expect(stored[0]?.credential).toMatchObject({
 			type: "oauth",
 			access: "access-old",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed concurrent MCP OAuth refreshes across OMP processes so rotating refresh tokens are refreshed once, waiters reuse the canonical credential, and stale `invalid_grant` losers cannot clear the winner. ([#5081](https://github.com/can1357/oh-my-pi/issues/5081))
+
 ## [16.4.0] - 2026-07-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -11,7 +11,7 @@ import { logger } from "@oh-my-pi/pi-utils";
 import type { SourceMeta } from "../capability/types";
 import { resolveConfigValue } from "../config/resolve-config-value";
 import type { CustomTool } from "../extensibility/custom-tools/types";
-import type { AuthStorage } from "../session/auth-storage";
+import { type AuthStorage, REMOTE_REFRESH_SENTINEL } from "../session/auth-storage";
 import {
 	connectToServer,
 	disconnectServer,
@@ -1226,76 +1226,78 @@ export class MCPManager {
 			const { credentialId } = lookup;
 			try {
 				let credential: MCPStoredOAuthCredential | undefined = lookup.credential;
-				// Refresh material comes from ONE source: the credential's embedded
-				// fields (written atomically with the tokens they minted — tokenUrl
-				// always present) or, for legacy rows that predate embedding, the
-				// config auth block. Never mix the two: a shared file's auth block
-				// can belong to another profile, whose client the grant is NOT
-				// bound to.
-				const material = selectMcpOAuthRefreshMaterial(credential, auth);
-				const tokenUrl = material?.tokenUrl;
-				const clientId = material?.clientId;
-				const clientSecret = material?.clientSecret;
-				// `authorizationUrl` only lives on the embedded credential form;
-				// legacy `MCPAuthConfig` rows never carried it. Required to filter
-				// same-origin resource indicators on refresh when the authorize and
-				// token endpoints sit on different origins (issue #3502 review
-				// follow-up).
-				const authorizationUrl = material && "authorizationUrl" in material ? material.authorizationUrl : undefined;
-				const resourceIsFallback =
-					!material?.resource && (config.type === "http" || config.type === "sse") && Boolean(config.url);
-				const resource = material?.resource ?? (resourceIsFallback ? config.url : undefined);
-				// Proactive refresh: 5-minute buffer before expiry
-				// Force refresh: on 401/403 auth errors (revoked tokens, clock skew, missing expires)
 				const REFRESH_BUFFER_MS = 5 * 60_000;
-				const shouldRefresh =
-					opts?.forceRefresh || (credential.expires && Date.now() >= credential.expires - REFRESH_BUFFER_MS);
-				if (shouldRefresh && credential.refresh && tokenUrl) {
-					try {
-						const refreshed = await refreshMCPOAuthToken(
-							tokenUrl,
-							credential.refresh,
-							clientId,
-							clientSecret,
-							resource,
-							{ authorizationUrl, stripSameOriginResource: resourceIsFallback },
-						);
-						// Spread the old credential first so embedded refresh material survives rotation.
-						const refreshedCredential: MCPStoredOAuthCredential = {
-							...credential,
-							...refreshed,
-							tokenUrl,
-							clientId,
-							clientSecret,
-							resource: resourceIsFallback ? undefined : resource,
-							authorizationUrl,
-						};
-						await this.#authStorage.set(credentialId, refreshedCredential);
-						credential = refreshedCredential;
-					} catch (refreshError) {
-						const errorMsg = refreshError instanceof Error ? refreshError.message : String(refreshError);
-						if (isDefinitiveOAuthFailure(errorMsg)) {
-							// `invalid_grant` / `invalid_token` / 401 from the token endpoint means
-							// the server has retired this credential — keeping the stale access
-							// token would just re-fail with 401 on every MCP request and leave a
-							// poisoned row in agent.db that survives restarts. Drop it now so the
-							// next connect attempt surfaces a clean "needs reauth" failure and
-							// the user can recover with `/mcp reauth <server>` (or `/mcp unauth`
-							// to forget the server entirely).
-							logger.warn("MCP OAuth refresh failed definitively; cleared credential", {
-								credentialId,
-								error: errorMsg,
+				const refreshResult = await this.#authStorage.refreshStoredOAuthCredential<MCPStoredOAuthCredential>(
+					credentialId,
+					{
+						observedCredential: credential,
+						credentialFromRow: row => row,
+						forceRefresh: opts?.forceRefresh,
+						refreshSkewMs: REFRESH_BUFFER_MS,
+						canRefresh: current => {
+							const material = selectMcpOAuthRefreshMaterial(current, auth);
+							return Boolean(current.refresh && material?.tokenUrl);
+						},
+						refresh: current => {
+							if (current.refresh === REMOTE_REFRESH_SENTINEL) {
+								throw new Error("MCP OAuth refresh token is broker-redacted; local refresh is unavailable");
+							}
+							const material = selectMcpOAuthRefreshMaterial(current, auth);
+							const tokenUrl = material?.tokenUrl;
+							if (!current.refresh || !tokenUrl) {
+								throw new Error("MCP OAuth credential is missing refresh material");
+							}
+							const clientId = material?.clientId;
+							const clientSecret = material?.clientSecret;
+							const authorizationUrl =
+								material && "authorizationUrl" in material ? material.authorizationUrl : undefined;
+							const resourceIsFallback =
+								!material?.resource && (config.type === "http" || config.type === "sse") && Boolean(config.url);
+							const resource = material?.resource ?? (resourceIsFallback ? config.url : undefined);
+							return refreshMCPOAuthToken(tokenUrl, current.refresh, clientId, clientSecret, resource, {
+								authorizationUrl,
+								stripSameOriginResource: resourceIsFallback,
 							});
-							await this.#authStorage.remove(credentialId);
-							credential = undefined;
-						} else {
+						},
+						mergeRefreshedCredential: (current, refreshed) => {
+							const material = selectMcpOAuthRefreshMaterial(current, auth);
+							const tokenUrl = material?.tokenUrl;
+							const clientId = material?.clientId;
+							const clientSecret = material?.clientSecret;
+							const authorizationUrl =
+								material && "authorizationUrl" in material ? material.authorizationUrl : undefined;
+							const resourceIsFallback =
+								!material?.resource && (config.type === "http" || config.type === "sse") && Boolean(config.url);
+							const resource = material?.resource ?? (resourceIsFallback ? config.url : undefined);
+							return {
+								...current,
+								...refreshed,
+								tokenUrl,
+								clientId,
+								clientSecret,
+								resource: resourceIsFallback ? undefined : resource,
+								authorizationUrl,
+							};
+						},
+						isDefinitiveFailure: error =>
+							isDefinitiveOAuthFailure(error instanceof Error ? error.message : String(error)),
+						disabledCause: error =>
+							`oauth refresh failed: ${error instanceof Error ? error.message : String(error)}`,
+						keepCredentialOnRefreshFailure: error =>
+							!(error instanceof Error && error.message.includes("broker-redacted")),
+						onRefreshFailure: refreshError => {
+							if (refreshError instanceof Error && refreshError.message.includes("broker-redacted")) return;
 							logger.warn("MCP OAuth refresh failed, using existing token", {
 								credentialId,
 								error: refreshError,
 							});
-						}
-					}
+						},
+					},
+				);
+				if (refreshResult.removed) {
+					logger.warn("MCP OAuth refresh failed definitively; cleared credential", { credentialId });
 				}
+				credential = refreshResult.credential;
 
 				if (credential) {
 					if (resolved.type === "http" || resolved.type === "sse") {

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -1238,7 +1238,7 @@ export class MCPManager {
 							const material = selectMcpOAuthRefreshMaterial(current, auth);
 							return Boolean(current.refresh && material?.tokenUrl);
 						},
-						refresh: current => {
+						refresh: (current, signal) => {
 							if (current.refresh === REMOTE_REFRESH_SENTINEL) {
 								throw new Error("MCP OAuth refresh token is broker-redacted; local refresh is unavailable");
 							}
@@ -1257,6 +1257,7 @@ export class MCPManager {
 							return refreshMCPOAuthToken(tokenUrl, current.refresh, clientId, clientSecret, resource, {
 								authorizationUrl,
 								stripSameOriginResource: resourceIsFallback,
+								signal,
 							});
 						},
 						mergeRefreshedCredential: (current, refreshed) => {

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -715,6 +715,7 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
  */
 export interface RefreshMCPOAuthTokenOptions {
 	fetch?: FetchImpl;
+	signal?: AbortSignal;
 	/**
 	 * Authorization-server URL the original grant was minted against. Used to
 	 * filter same-origin resource indicators on refresh. Defaults to `tokenUrl`'s
@@ -766,6 +767,7 @@ export async function refreshMCPOAuthToken(
 		method: "POST",
 		headers: { "Content-Type": "application/x-www-form-urlencoded" },
 		body: params.toString(),
+		signal: optsFromTrailing?.signal,
 	});
 
 	if (!response.ok) {

--- a/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
@@ -10,7 +10,7 @@
  * Bearer injection, so the next request surfaces a clean auth error instead.
  */
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, setSystemTime, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -35,6 +35,54 @@ const SHARED_FRESH_REFRESH = "refresh-1";
 function getAuthorizationHeader(config: MCPServerConfig): string | undefined {
 	if (config.type !== "http" && config.type !== "sse") return undefined;
 	return config.headers?.Authorization;
+}
+
+type ControlledSleep = {
+	ms: number;
+	resolved: boolean;
+	resolve: () => void;
+};
+
+function installControlledBunSleep(): ControlledSleep[] {
+	const calls: ControlledSleep[] = [];
+	vi.spyOn(Bun, "sleep").mockImplementation((ms: number | Date) => {
+		const { promise, resolve } = Promise.withResolvers<void>();
+		let call: ControlledSleep;
+		const delayMs = typeof ms === "number" ? ms : Math.max(0, ms.getTime() - Date.now());
+		call = {
+			ms: delayMs,
+			resolved: false,
+			resolve: () => {
+				if (call.resolved) return;
+				call.resolved = true;
+				resolve();
+			},
+		};
+		calls.push(call);
+		return promise;
+	});
+	return calls;
+}
+
+async function drainMicrotasks(count = 10): Promise<void> {
+	for (let attempt = 0; attempt < count; attempt++) {
+		await Promise.resolve();
+	}
+}
+
+async function waitForControlledSleep(calls: ControlledSleep[], ms: number): Promise<ControlledSleep> {
+	for (let attempt = 0; attempt < 20; attempt++) {
+		const call = calls.find(candidate => !candidate.resolved && candidate.ms === ms);
+		if (call) return call;
+		await Promise.resolve();
+	}
+	throw new Error(`Timed out waiting for Bun.sleep(${ms})`);
+}
+
+function resolvePendingControlledSleeps(calls: ControlledSleep[]): void {
+	for (const call of calls) {
+		if (!call.resolved) call.resolve();
+	}
 }
 
 async function withSharedSQLiteAuth<T>(
@@ -176,6 +224,98 @@ describe("MCPManager OAuth refresh failure", () => {
 });
 
 describe("MCPManager shared SQLite OAuth refresh", () => {
+	afterEach(() => {
+		setSystemTime();
+		vi.restoreAllMocks();
+	});
+
+	test("renews refresh ownership while the token endpoint is blocked", async () => {
+		await withSharedSQLiteAuth(async ({ authA, authB, storeA }) => {
+			const startMs = Date.parse("2026-07-10T12:00:00.000Z");
+			setSystemTime(new Date(startMs));
+			const sleeps = installControlledBunSleep();
+			const renewSpy = vi.spyOn(storeA, "renewCredentialRefreshLease");
+
+			await authA.set(SHARED_CREDENTIAL_ID, {
+				type: "oauth",
+				access: SHARED_STALE_ACCESS,
+				refresh: SHARED_STALE_REFRESH,
+				expires: startMs - 60_000,
+			});
+			await authB.reload();
+
+			const refreshStarted = Promise.withResolvers<void>();
+			const allowRefreshResponse = Promise.withResolvers<void>();
+			const refreshTokens: string[] = [];
+			let refreshRequests = 0;
+			const tokenServer = Bun.serve({
+				hostname: "127.0.0.1",
+				port: 0,
+				async fetch(req) {
+					if (req.method !== "POST" || new URL(req.url).pathname !== "/token") {
+						return new Response("not found", { status: 404 });
+					}
+					refreshRequests += 1;
+					const body = new URLSearchParams(await req.text());
+					refreshTokens.push(body.get("refresh_token") ?? "");
+					if (refreshRequests === 1) {
+						refreshStarted.resolve();
+						await allowRefreshResponse.promise;
+						return Response.json({
+							access_token: SHARED_FRESH_ACCESS,
+							refresh_token: SHARED_FRESH_REFRESH,
+							expires_in: 3600,
+						});
+					}
+					return Response.json({ error: "invalid_grant" }, { status: 400 });
+				},
+			});
+			try {
+				const managerA = new MCPManager(process.cwd());
+				managerA.setAuthStorage(authA);
+				const managerB = new MCPManager(process.cwd());
+				managerB.setAuthStorage(authB);
+				const config: MCPServerConfig = {
+					type: "http",
+					url: "https://logfire.example.com/mcp",
+					auth: {
+						type: "oauth",
+						credentialId: SHARED_CREDENTIAL_ID,
+						tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
+					},
+				};
+
+				const preparedA = managerA.prepareConfig(config);
+				await refreshStarted.promise;
+				const renewalSleep = await waitForControlledSleep(sleeps, 5_000);
+
+				setSystemTime(new Date(startMs + 5_000));
+				renewalSleep.resolve();
+				await drainMicrotasks();
+				expect(renewSpy).toHaveBeenCalledTimes(1);
+
+				setSystemTime(new Date(startMs + 16_000));
+				const preparedB = managerB.prepareConfig(config);
+				const peerLeaseWait = await waitForControlledSleep(sleeps, 250);
+
+				expect(refreshRequests).toBe(1);
+				expect(refreshTokens).toEqual([SHARED_STALE_REFRESH]);
+
+				allowRefreshResponse.resolve();
+				const resolvedA = await preparedA;
+				peerLeaseWait.resolve();
+				const resolvedB = await preparedB;
+
+				expect(getAuthorizationHeader(resolvedA)).toBe(`Bearer ${SHARED_FRESH_ACCESS}`);
+				expect(getAuthorizationHeader(resolvedB)).toBe(`Bearer ${SHARED_FRESH_ACCESS}`);
+				expect(refreshRequests).toBe(1);
+				expect(refreshTokens).toEqual([SHARED_STALE_REFRESH]);
+			} finally {
+				resolvePendingControlledSleeps(sleeps);
+				tokenServer.stop(true);
+			}
+		});
+	});
 	test("shares refresh ownership so peer managers do not replay a rotating refresh token", async () => {
 		await withSharedSQLiteAuth(async ({ authA, authB }) => {
 			await authA.set(SHARED_CREDENTIAL_ID, {

--- a/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
@@ -11,20 +11,57 @@
  */
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
 import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import * as oauthFlow from "@oh-my-pi/pi-coding-agent/mcp/oauth-flow";
 import type { MCPServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const CREDENTIAL_ID = "mcp_oauth_test_1908";
 const TOKEN_URL = "https://example.com/oauth/token";
 const STALE_ACCESS = "stale-access-token";
 const STALE_REFRESH = "stale-refresh-token";
 
+const SHARED_CREDENTIAL_ID = "mcp_oauth_test_5081";
+const SHARED_STALE_ACCESS = "access-0";
+const SHARED_STALE_REFRESH = "refresh-0";
+const SHARED_FRESH_ACCESS = "access-1";
+const SHARED_FRESH_REFRESH = "refresh-1";
+
 /** Build a `Headers` snapshot from a prepared MCP config. */
 function getAuthorizationHeader(config: MCPServerConfig): string | undefined {
 	if (config.type !== "http" && config.type !== "sse") return undefined;
 	return config.headers?.Authorization;
+}
+
+async function withSharedSQLiteAuth<T>(
+	fn: (context: {
+		authA: AuthStorage;
+		authB: AuthStorage;
+		storeA: SqliteAuthCredentialStore;
+		storeB: SqliteAuthCredentialStore;
+	}) => Promise<T>,
+): Promise<T> {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-oauth-shared-refresh-"));
+	let authA: AuthStorage | undefined;
+	let authB: AuthStorage | undefined;
+	try {
+		const dbPath = path.join(tempDir, "agent.db");
+		const storeA = await SqliteAuthCredentialStore.open(dbPath);
+		const storeB = await SqliteAuthCredentialStore.open(dbPath);
+		authA = new AuthStorage(storeA);
+		authB = new AuthStorage(storeB);
+		await authA.reload();
+		await authB.reload();
+		return await fn({ authA, authB, storeA, storeB });
+	} finally {
+		authA?.close();
+		authB?.close();
+		await removeWithRetries(tempDir);
+	}
 }
 
 describe("MCPManager OAuth refresh failure", () => {
@@ -135,5 +172,158 @@ describe("MCPManager OAuth refresh failure", () => {
 		expect(getAuthorizationHeader(prepared)).toBe("Bearer fresh-access");
 		const remaining = authStorage.get(CREDENTIAL_ID);
 		expect(remaining).toMatchObject({ type: "oauth", access: "fresh-access", refresh: "fresh-refresh" });
+	});
+});
+
+describe("MCPManager shared SQLite OAuth refresh", () => {
+	test("shares refresh ownership so peer managers do not replay a rotating refresh token", async () => {
+		await withSharedSQLiteAuth(async ({ authA, authB }) => {
+			await authA.set(SHARED_CREDENTIAL_ID, {
+				type: "oauth",
+				access: SHARED_STALE_ACCESS,
+				refresh: SHARED_STALE_REFRESH,
+				expires: Date.now() - 60_000,
+			});
+			await authB.reload();
+
+			const refreshStarted = Promise.withResolvers<void>();
+			const allowRefreshResponse = Promise.withResolvers<void>();
+			const refreshTokens: string[] = [];
+			let refreshRequests = 0;
+			const tokenServer = Bun.serve({
+				hostname: "127.0.0.1",
+				port: 0,
+				async fetch(req) {
+					if (req.method !== "POST" || new URL(req.url).pathname !== "/token") {
+						return new Response("not found", { status: 404 });
+					}
+					refreshRequests += 1;
+					const body = new URLSearchParams(await req.text());
+					refreshTokens.push(body.get("refresh_token") ?? "");
+					if (refreshRequests === 1) {
+						refreshStarted.resolve();
+						await allowRefreshResponse.promise;
+						return Response.json({
+							access_token: SHARED_FRESH_ACCESS,
+							refresh_token: SHARED_FRESH_REFRESH,
+							expires_in: 3600,
+						});
+					}
+					return Response.json({ error: "invalid_grant" }, { status: 400 });
+				},
+			});
+			try {
+				const managerA = new MCPManager(process.cwd());
+				managerA.setAuthStorage(authA);
+				const managerB = new MCPManager(process.cwd());
+				managerB.setAuthStorage(authB);
+				const config: MCPServerConfig = {
+					type: "http",
+					url: "https://logfire.example.com/mcp",
+					auth: {
+						type: "oauth",
+						credentialId: SHARED_CREDENTIAL_ID,
+						tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
+					},
+				};
+
+				const preparedA = managerA.prepareConfig(config);
+				await refreshStarted.promise;
+				const preparedB = managerB.prepareConfig(config);
+				allowRefreshResponse.resolve();
+
+				const [resolvedA, resolvedB] = await Promise.all([preparedA, preparedB]);
+
+				expect(refreshRequests).toBe(1);
+				expect(refreshTokens).toEqual([SHARED_STALE_REFRESH]);
+				expect(getAuthorizationHeader(resolvedA)).toBe(`Bearer ${SHARED_FRESH_ACCESS}`);
+				expect(getAuthorizationHeader(resolvedB)).toBe(`Bearer ${SHARED_FRESH_ACCESS}`);
+
+				await authA.reload();
+				const canonical = authA.get(SHARED_CREDENTIAL_ID);
+				expect(canonical).toMatchObject({
+					type: "oauth",
+					access: SHARED_FRESH_ACCESS,
+					refresh: SHARED_FRESH_REFRESH,
+				});
+			} finally {
+				tokenServer.stop(true);
+			}
+		});
+	});
+
+	test("keeps the peer-rotated credential when a stale refresh attempt returns invalid_grant", async () => {
+		await withSharedSQLiteAuth(async ({ authA, authB, storeB }) => {
+			await authA.set(SHARED_CREDENTIAL_ID, {
+				type: "oauth",
+				access: SHARED_STALE_ACCESS,
+				refresh: SHARED_STALE_REFRESH,
+				expires: Date.now() - 60_000,
+			});
+			await authB.reload();
+			const storedBefore = storeB.listAuthCredentials(SHARED_CREDENTIAL_ID);
+			expect(storedBefore).toHaveLength(1);
+			const rowId = storedBefore[0]!.id;
+
+			const refreshStarted = Promise.withResolvers<void>();
+			const allowInvalidGrant = Promise.withResolvers<void>();
+			const refreshTokens: string[] = [];
+			let refreshRequests = 0;
+			const tokenServer = Bun.serve({
+				hostname: "127.0.0.1",
+				port: 0,
+				async fetch(req) {
+					if (req.method !== "POST" || new URL(req.url).pathname !== "/token") {
+						return new Response("not found", { status: 404 });
+					}
+					refreshRequests += 1;
+					const body = new URLSearchParams(await req.text());
+					refreshTokens.push(body.get("refresh_token") ?? "");
+					refreshStarted.resolve();
+					await allowInvalidGrant.promise;
+					return Response.json({ error: "invalid_grant" }, { status: 400 });
+				},
+			});
+			try {
+				const managerA = new MCPManager(process.cwd());
+				managerA.setAuthStorage(authA);
+				const config: MCPServerConfig = {
+					type: "http",
+					url: "https://logfire.example.com/mcp",
+					auth: {
+						type: "oauth",
+						credentialId: SHARED_CREDENTIAL_ID,
+						tokenUrl: `http://127.0.0.1:${tokenServer.port}/token`,
+					},
+				};
+
+				const prepared = managerA.prepareConfig(config);
+				await refreshStarted.promise;
+				storeB.updateAuthCredential(rowId, {
+					type: "oauth",
+					access: SHARED_FRESH_ACCESS,
+					refresh: SHARED_FRESH_REFRESH,
+					expires: Date.now() + 60 * 60_000,
+				});
+				allowInvalidGrant.resolve();
+
+				const resolved = await prepared;
+
+				expect(refreshRequests).toBe(1);
+				expect(refreshTokens).toEqual([SHARED_STALE_REFRESH]);
+				expect(getAuthorizationHeader(resolved)).toBe(`Bearer ${SHARED_FRESH_ACCESS}`);
+
+				await authA.reload();
+				const canonical = authA.get(SHARED_CREDENTIAL_ID);
+				expect(canonical).toMatchObject({
+					type: "oauth",
+					access: SHARED_FRESH_ACCESS,
+					refresh: SHARED_FRESH_REFRESH,
+				});
+				expect(storeB.listAuthCredentials(SHARED_CREDENTIAL_ID)).toHaveLength(1);
+			} finally {
+				tokenServer.stop(true);
+			}
+		});
 	});
 });

--- a/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
@@ -115,10 +115,11 @@ async function withSharedSQLiteAuth<T>(
 describe("MCPManager OAuth refresh failure", () => {
 	let manager: MCPManager;
 	let authStorage: AuthStorage;
+	let store: SqliteAuthCredentialStore;
 	let serverConfig: MCPServerConfig;
 
 	beforeEach(async () => {
-		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		store = new SqliteAuthCredentialStore(new Database(":memory:"));
 		authStorage = new AuthStorage(store);
 		await authStorage.reload();
 
@@ -147,6 +148,7 @@ describe("MCPManager OAuth refresh failure", () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		authStorage.close();
 		vi.restoreAllMocks();
 	});
@@ -169,7 +171,7 @@ describe("MCPManager OAuth refresh failure", () => {
 			undefined,
 			undefined,
 			"https://logfire.example.com/mcp",
-			{ authorizationUrl: undefined, stripSameOriginResource: true },
+			{ authorizationUrl: undefined, stripSameOriginResource: true, signal: expect.any(AbortSignal) },
 		);
 		// The poisoned Bearer must not be re-injected — that is the loop the user
 		// reported (#1908).
@@ -220,6 +222,60 @@ describe("MCPManager OAuth refresh failure", () => {
 		expect(getAuthorizationHeader(prepared)).toBe("Bearer fresh-access");
 		const remaining = authStorage.get(CREDENTIAL_ID);
 		expect(remaining).toMatchObject({ type: "oauth", access: "fresh-access", refresh: "fresh-refresh" });
+	});
+
+	test("aborts a timed-out token fetch and waits for it before releasing refresh ownership", async () => {
+		vi.useFakeTimers();
+		const fetchCalled = Promise.withResolvers<void>();
+		const abortObserved = Promise.withResolvers<void>();
+		const allowFetchReject = Promise.withResolvers<void>();
+		let capturedSignal: AbortSignal | undefined;
+		let preparedSettled = false;
+		const releaseSpy = vi.spyOn(store, "releaseCredentialRefreshLease");
+		const fetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+				capturedSignal = init?.signal ?? undefined;
+				if (!capturedSignal) throw new Error("token refresh fetch did not receive an AbortSignal");
+				fetchCalled.resolve();
+				capturedSignal.addEventListener(
+					"abort",
+					() => {
+						abortObserved.resolve();
+					},
+					{ once: true },
+				);
+				await allowFetchReject.promise;
+				throw capturedSignal.reason ?? new Error("fetch aborted");
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchImpl);
+
+		const prepared = manager.prepareConfig(serverConfig).finally(() => {
+			preparedSettled = true;
+		});
+		await fetchCalled.promise;
+		expect(capturedSignal).toBeDefined();
+
+		vi.advanceTimersByTime(9_999);
+		await drainMicrotasks();
+		expect(capturedSignal!.aborted).toBe(false);
+		expect(preparedSettled).toBe(false);
+		expect(releaseSpy).not.toHaveBeenCalled();
+
+		vi.advanceTimersByTime(1);
+		await abortObserved.promise;
+		expect(capturedSignal!.aborted).toBe(true);
+		await drainMicrotasks();
+		expect(preparedSettled).toBe(false);
+		expect(releaseSpy).not.toHaveBeenCalled();
+
+		allowFetchReject.resolve();
+		const preparedConfig = await prepared;
+
+		expect(preparedSettled).toBe(true);
+		expect(releaseSpy).toHaveBeenCalledTimes(1);
+		expect(getAuthorizationHeader(preparedConfig)).toBe(`Bearer ${STALE_ACCESS}`);
 	});
 });
 


### PR DESCRIPTION
## Repro
A temporary shared `agent.db` and local rotating token endpoint reproduced the stale-loser delete with `bun .wt/repro-mcp-oauth-race.ts`: two independent credential stores read `refresh-0`; the winner persisted `refresh-1`; the stale `invalid_grant` loser removed the row, leaving the final credential missing.

## Cause
`packages/coding-agent/src/mcp/manager.ts` refreshed MCP OAuth credentials directly inside `MCPManager.#resolveAuthConfig()` and then wrote or removed the credential through provider-key `AuthStorage.set()` / `AuthStorage.remove()`. That bypassed the row-id refresh protections in `packages/ai/src/auth-storage.ts`, so separate OMP processes had no durable owner around read → token endpoint → persist/delete, and terminal failures were not compare-and-set against the exact credential revision that failed.

## Fix
- Added durable SQLite refresh leases and compare-and-set update support for stored OAuth rows in `packages/ai/src/auth-storage.ts`.
- Added `AuthStorage.refreshStoredOAuthCredential()` to acquire ownership, re-read canonical storage, skip stale waiters, persist rotated credentials conditionally, and CAS-disable only the exact failed revision.
- Routed MCP proactive refresh and forced 401/403 refresh through that shared owner in `packages/coding-agent/src/mcp/manager.ts`, including an explicit broker-redacted refresh-token failure path.
- Added MCP regression coverage for shared SQLite refresh ownership and stale `invalid_grant` losers.

## Verification
`bun .wt/repro-mcp-oauth-race.ts` reproduced the pre-fix stale-loser delete and was recorded on the issue. `bun test packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts` passed with 6 tests / 21 assertions. `bun check` passed locally, and the pre-publish gate passed during `gh_push_branch`. Fixes #5081