### PR TITLE
feat: add Ultra reasoning mode

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -23,8 +23,8 @@
 - Added visual warnings and detailed recovery instructions to the session timeline when compaction fails to free sufficient space.
 ### Added
 
-- Added the agent-local `Ultra` thinking selector, mapping it to Max while preserving provider effort levels and applying Max lowering for compaction paths.
-- Added atomic steering/follow-up queue transforms and companion batching so hidden context is delivered with its queued root without overwriting concurrent enqueues.
+- Added the agent-local `Ultra` thinking selector, mapping it to Max while preserving provider effort levels and applying Max lowering for compaction paths ([#5117](https://github.com/can1357/oh-my-pi/pull/5117) by [@jeffscottward](https://github.com/jeffscottward)).
+- Added atomic steering/follow-up queue transforms and companion batching so hidden context is delivered with its queued root without overwriting concurrent enqueues ([#5117](https://github.com/can1357/oh-my-pi/pull/5117) by [@jeffscottward](https://github.com/jeffscottward)).
 
 ## [16.4.5] - 2026-07-11
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 - Added an automated image-dropping rescue tier to compaction dead-end recovery.
 - Added visual warnings and detailed recovery instructions to the session timeline when compaction fails to free sufficient space.
+### Added
+
+- Added the agent-local `Ultra` thinking selector, mapping it to Max while preserving provider effort levels and applying Max lowering for compaction paths.
+- Added atomic steering/follow-up queue transforms and companion batching so hidden context is delivered with its queued root without overwriting concurrent enqueues.
 
 ## [16.4.5] - 2026-07-11
 
@@ -39,9 +43,6 @@
 ### Fixed
 
 - Fixed serialization of BigInt tool arguments to prevent data loss during remote compaction.
-### Added
-
-- Added the agent-local `Ultra` thinking selector, mapping it to Max while preserving provider effort levels and applying Max lowering for compaction paths.
 
 ## [16.4.1] - 2026-07-10
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -39,6 +39,9 @@
 ### Fixed
 
 - Fixed serialization of BigInt tool arguments to prevent data loss during remote compaction.
+### Added
+
+- Added the agent-local `Ultra` thinking selector, mapping it to Max while preserving provider effort levels and applying Max lowering for compaction paths.
 
 ## [16.4.1] - 2026-07-10
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -346,6 +346,7 @@ export class Agent {
 	#transformProviderContext?: (context: Context, model: Model) => Context | Promise<Context>;
 	#steeringQueue: AgentMessage[] = [];
 	#followUpQueue: AgentMessage[] = [];
+	#queueCompanions = new WeakSet<object>();
 	#steeringMode: "all" | "one-at-a-time";
 	#followUpMode: "all" | "one-at-a-time";
 	#interruptMode: "immediate" | "wait";
@@ -844,6 +845,37 @@ export class Agent {
 		this.#followUpQueue = followUp.slice();
 	}
 
+	/**
+	 * Atomically transform the live steering and follow-up queues.
+	 *
+	 * The callback must be synchronous and side-effect free. Messages listed as
+	 * companions are delivered with the next ordinary message when the queue is
+	 * configured for one-at-a-time delivery.
+	 */
+	transformQueues(
+		transform: (queues: {
+			readonly steering: readonly AgentMessage[];
+			readonly followUp: readonly AgentMessage[];
+		}) => {
+			readonly steering: readonly AgentMessage[];
+			readonly followUp: readonly AgentMessage[];
+			readonly companions?: Iterable<AgentMessage>;
+		},
+	): void {
+		const next = transform({
+			steering: this.#steeringQueue.slice(),
+			followUp: this.#followUpQueue.slice(),
+		});
+		if (isPromise(next)) {
+			throw new TypeError("Agent queue transforms must be synchronous");
+		}
+		this.#steeringQueue = Array.from(next.steering);
+		this.#followUpQueue = Array.from(next.followUp);
+		for (const message of next.companions ?? []) {
+			this.#queueCompanions.add(message as object);
+		}
+	}
+
 	appendMessage(m: AgentMessage) {
 		this.#state.messages.push(m);
 	}
@@ -907,14 +939,20 @@ export class Agent {
 		return this.#abortController?.signal.aborted === true && this.#state.isStreaming;
 	}
 
+	#dequeueOneWithCompanions(queue: AgentMessage[]): [messages: AgentMessage[], remaining: AgentMessage[]] {
+		let end = 0;
+		while (end < queue.length && this.#queueCompanions.has(queue[end] as object)) {
+			end++;
+		}
+		if (end < queue.length) end++;
+		return [queue.slice(0, end), queue.slice(end)];
+	}
+
 	#dequeueSteeringMessages(): AgentMessage[] {
 		if (this.#steeringMode === "one-at-a-time") {
-			if (this.#steeringQueue.length > 0) {
-				const first = this.#steeringQueue[0];
-				this.#steeringQueue = this.#steeringQueue.slice(1);
-				return [first];
-			}
-			return [];
+			const [messages, remaining] = this.#dequeueOneWithCompanions(this.#steeringQueue);
+			this.#steeringQueue = remaining;
+			return messages;
 		}
 		const steering = this.#steeringQueue.slice();
 		this.#steeringQueue = [];
@@ -923,12 +961,9 @@ export class Agent {
 
 	#dequeueFollowUpMessages(): AgentMessage[] {
 		if (this.#followUpMode === "one-at-a-time") {
-			if (this.#followUpQueue.length > 0) {
-				const first = this.#followUpQueue[0];
-				this.#followUpQueue = this.#followUpQueue.slice(1);
-				return [first];
-			}
-			return [];
+			const [messages, remaining] = this.#dequeueOneWithCompanions(this.#followUpQueue);
+			this.#followUpQueue = remaining;
+			return messages;
 		}
 		const followUp = this.#followUpQueue.slice();
 		this.#followUpQueue = [];

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -659,6 +659,8 @@ function effortFromThinkingLevel(level: ThinkingLevel): Effort {
 			return Effort.High;
 		case ThinkingLevel.XHigh:
 			return Effort.XHigh;
+		case ThinkingLevel.Ultra:
+			return Effort.Max;
 		case ThinkingLevel.Max:
 			return Effort.Max;
 		case ThinkingLevel.Off:

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -660,7 +660,6 @@ function effortFromThinkingLevel(level: ThinkingLevel): Effort {
 		case ThinkingLevel.XHigh:
 			return Effort.XHigh;
 		case ThinkingLevel.Ultra:
-			return Effort.Max;
 		case ThinkingLevel.Max:
 			return Effort.Max;
 		case ThinkingLevel.Off:

--- a/packages/agent/src/thinking.ts
+++ b/packages/agent/src/thinking.ts
@@ -14,6 +14,7 @@ export const ThinkingLevel = {
 	High: Effort.High,
 	XHigh: Effort.XHigh,
 	Max: Effort.Max,
+	Ultra: "ultra",
 } as const;
 
 export type ThinkingLevel = (typeof ThinkingLevel)[keyof typeof ThinkingLevel];

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -80,6 +80,55 @@ describe("Agent", () => {
 		expect(mock.calls.length).toBe(2);
 	});
 
+	for (const queueKind of ["steering", "follow-up"] as const) {
+		it(`delivers queue companions with the next ${queueKind} message in one-at-a-time mode`, async () => {
+			const mock = createMockModel({
+				responses: [{ content: ["Processed 1"] }, { content: ["Processed 2"] }],
+			});
+			const agent = new Agent({ streamFn: mock.stream });
+			agent.replaceMessages([
+				{
+					role: "user",
+					content: [{ type: "text", text: "Initial" }],
+					timestamp: Date.now() - 10,
+				},
+				createAssistantMessage([{ type: "text", text: "Initial response" }]),
+			]);
+
+			const contextMessage = {
+				role: "user" as const,
+				content: [{ type: "text" as const, text: "Companion context" }],
+				timestamp: Date.now(),
+			};
+			const firstMessage = {
+				role: "user" as const,
+				content: [{ type: "text" as const, text: "Queued 1" }],
+				timestamp: Date.now() + 1,
+			};
+			const secondMessage = {
+				role: "user" as const,
+				content: [{ type: "text" as const, text: "Queued 2" }],
+				timestamp: Date.now() + 2,
+			};
+			const enqueue = queueKind === "steering" ? agent.steer.bind(agent) : agent.followUp.bind(agent);
+			enqueue(firstMessage);
+			enqueue(secondMessage);
+			agent.transformQueues(queues => ({
+				steering: queueKind === "steering" ? [contextMessage, ...queues.steering] : queues.steering,
+				followUp: queueKind === "follow-up" ? [contextMessage, ...queues.followUp] : queues.followUp,
+				companions: [contextMessage],
+			}));
+
+			await expect(agent.continue()).resolves.toBeUndefined();
+
+			expect(mock.calls).toHaveLength(2);
+			const firstCall = JSON.stringify(mock.calls[0]?.context.messages);
+			expect(firstCall).toContain("Companion context");
+			expect(firstCall).toContain("Queued 1");
+			expect(firstCall).not.toContain("Queued 2");
+		});
+	}
+
 	it("delivers a steer that lands at the yield boundary instead of stranding it", async () => {
 		// Regression: a steering message queued after the stop-boundary dequeue
 		// (e.g. while onBeforeYield runs) was silently stranded in the queue until

--- a/packages/agent/test/compaction-thinking-level.test.ts
+++ b/packages/agent/test/compaction-thinking-level.test.ts
@@ -10,6 +10,7 @@ import {
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core/thinking";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 
 // Pins fix #1 of the compaction effort-override bug. Before this fix,
@@ -62,6 +63,25 @@ function getGrokBuildModel(): Model {
 	const model = getBundledModel("xai-oauth", "grok-build");
 	if (!model) throw new Error("Expected built-in xai-oauth/grok-build to exist");
 	return model;
+}
+
+function getMaxCapableModel(): Model {
+	return buildModel({
+		id: "mock-max-capable",
+		name: "Mock Max Capable",
+		api: "openai-responses",
+		provider: "mock",
+		baseUrl: "https://example.com",
+		reasoning: true,
+		thinking: {
+			mode: "effort",
+			efforts: [ai.Effort.Low, ai.Effort.Medium, ai.Effort.High, ai.Effort.XHigh, ai.Effort.Max],
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 4096,
+	});
 }
 
 const messages: AgentMessage[] = [
@@ -147,6 +167,20 @@ describe("compaction thinking-level resolution (regression)", () => {
 		const call = spy.mock.calls[0];
 		if (!call) throw new Error("expected completeSimple call");
 		expect(call[2]?.reasoning).toBe(ai.Effort.High);
+	});
+
+	test("ThinkingLevel.Ultra on max-capable models → reasoning=max", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "handoff" }]));
+		await generateHandoff(messages, getMaxCapableModel(), "test-key", {
+			systemPrompt: ["sp"],
+			tools: [],
+			thinkingLevel: ThinkingLevel.Ultra,
+		});
+		const call = spy.mock.calls[0];
+		if (!call) throw new Error("expected completeSimple call");
+		expect(call[2]?.reasoning).toBe(ai.Effort.Max);
 	});
 });
 
@@ -249,6 +283,21 @@ describe("compact() propagates thinkingLevel to all three summarizers (regressio
 			// trip requireSupportedEffort. The fix + the wire-side strip in
 			// fix #2 keep this clean.
 			expect(opts?.reasoning).toBeUndefined();
+		}
+	});
+
+	test("ThinkingLevel.Ultra → every fan-out call gets reasoning=max", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "summary" }]));
+
+		await compact(makePreparation(), getMaxCapableModel(), "test-key", undefined, undefined, {
+			thinkingLevel: ThinkingLevel.Ultra,
+		});
+
+		expect(spy).toHaveBeenCalledTimes(3);
+		for (const [, , opts] of spy.mock.calls) {
+			expect(opts?.reasoning).toBe(ai.Effort.Max);
 		}
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -180,6 +180,9 @@
 
 - Fixed PageUp/PageDown in the model browser wrapping past the list edges instead of clamping
 - Fixed the hover highlight sticking to the last hovered model row when the pointer moved into the provider sidebar
+### Added
+
+- Added model-gated Ultra thinking across CLI, TUI, config, suffix, ACP, and RPC surfaces, with root-only proactive delegation through the existing task runtime, atomic queued-context delivery, explicit tool exclusions, and vibe-mode precedence.
 
 ## [16.4.6] - 2026-07-12
 
@@ -305,7 +308,6 @@
 - Fixed an issue where BigInt values in tool arguments failed to serialize during session compaction.
 - Resolved an issue where GPT-5.6 over-delegated tasks by refining task fan-out and concurrency policies in the system prompt.
 - Fixed a race condition in concurrent MCP OAuth token refreshes across processes, ensuring rotating refresh tokens are only refreshed once and preventing stale token errors from clearing valid credentials.
-- Added model-gated Ultra thinking across CLI, TUI, config, suffix, ACP, and RPC surfaces, with root-only proactive delegation through the existing task runtime when enabled and not explicitly excluded.
 
 ## [16.4.1] - 2026-07-10
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -182,7 +182,7 @@
 - Fixed the hover highlight sticking to the last hovered model row when the pointer moved into the provider sidebar
 ### Added
 
-- Added model-gated Ultra thinking across CLI, TUI, config, suffix, ACP, and RPC surfaces, with root-only proactive delegation through the existing task runtime, atomic queued-context delivery, explicit tool exclusions, and vibe-mode precedence.
+- Added model-gated Ultra thinking across CLI, TUI, config, suffix, ACP, and RPC surfaces, with root-only proactive delegation through the existing task runtime, atomic queued-context delivery, explicit tool exclusions, and vibe-mode precedence ([#5117](https://github.com/can1357/oh-my-pi/pull/5117) by [@jeffscottward](https://github.com/jeffscottward)).
 
 ## [16.4.6] - 2026-07-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -305,6 +305,7 @@
 - Fixed an issue where BigInt values in tool arguments failed to serialize during session compaction.
 - Resolved an issue where GPT-5.6 over-delegated tasks by refining task fan-out and concurrency policies in the system prompt.
 - Fixed a race condition in concurrent MCP OAuth token refreshes across processes, ensuring rotating refresh tokens are only refreshed once and preventing stale token errors from clearing valid credentials.
+- Added model-gated Ultra thinking across CLI, TUI, config, suffix, ACP, and RPC surfaces, with root-only proactive delegation through the existing task runtime when enabled and not explicitly excluded.
 
 ## [16.4.1] - 2026-07-10
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -691,6 +691,7 @@ function normalizeSuppressedSelector(
 	if (!trimmed) return trimmed;
 	const parsed = parseModelString(trimmed, {
 		allowMaxSuffix: true,
+		allowUltraSuffix: true,
 		allowAutoAlias: true,
 		isLiteralModelId: (provider, id) => hasLiveModel?.(provider, id) === true,
 	});

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -16,12 +16,11 @@
  */
 
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import type { Api, Effort, KnownProvider, Model, ModelSpec } from "@oh-my-pi/pi-ai";
+import type { Api, KnownProvider, Model, ModelSpec } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { modelMatchesHost } from "@oh-my-pi/pi-catalog/hosts";
 import { buildModelProviderPriorityRank } from "@oh-my-pi/pi-catalog/identity";
 import { stripThinkingVariantToken } from "@oh-my-pi/pi-catalog/identity/family";
-import { clampThinkingLevelForModel } from "@oh-my-pi/pi-catalog/model-thinking";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
 import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
 import { resolveBareVariantAlias, resolveVariantAlias } from "@oh-my-pi/pi-catalog/variant-collapse";
@@ -87,22 +86,28 @@ export interface ScopedModel {
 
 interface ThinkingSuffixOptions {
 	allowMaxSuffix?: boolean;
+	allowUltraSuffix?: boolean;
 	allowAutoAlias?: boolean;
 }
 
 interface ModelStringParseOptions extends ThinkingSuffixOptions {
 	isLiteralModelId?: (provider: string, id: string) => boolean;
 }
-// Suffix recognition for the model-pattern parser: `:max` is a real thinking
-// level and `:auto` maps to the auto sentinel. Both are gated behind flags
-// (and the literal-id / exact-match guards on the callers) because real model
-// ids end in `:max` (e.g. `glm-4.7:max`) — an ungated split would silently
-// reinterpret them as a thinking suffix.
-const MAX_THINKING_SUFFIX_OPTIONS: ThinkingSuffixOptions = { allowMaxSuffix: true, allowAutoAlias: true };
+// Suffix recognition for the model-pattern parser: `:max` and `:ultra` are real
+// thinking levels and `:auto` maps to the auto sentinel. They are gated behind
+// flags (and the literal-id / exact-match guards on the callers) because real
+// model ids can end in these tokens (e.g. `glm-4.7:max`) — an ungated split
+// would silently reinterpret them as thinking suffixes.
+const GUARDED_THINKING_SUFFIX_OPTIONS: ThinkingSuffixOptions = {
+	allowMaxSuffix: true,
+	allowUltraSuffix: true,
+	allowAutoAlias: true,
+};
 
 function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): ConfiguredThinkingLevel | undefined {
 	const level = parseThinkingLevel(value);
 	if (level === ThinkingLevel.Max) return options?.allowMaxSuffix === true ? level : undefined;
+	if (level === ThinkingLevel.Ultra) return options?.allowUltraSuffix === true ? level : undefined;
 	if (level !== undefined) return level;
 	if (options?.allowAutoAlias === true && value === AUTO_THINKING) return AUTO_THINKING;
 	return undefined;
@@ -112,9 +117,9 @@ function parseThinkingSuffix(value: string, options?: ThinkingSuffixOptions): Co
  * Split a trailing `:<level>` thinking selector off a model pattern.
  *
  * `level` is set when the suffix parses as a concrete thinking level (or, when
- * the caller opts in via `allowMaxSuffix`/`allowAutoAlias`, the guarded `:max`
- * level / `:auto` sentinel); `base` then has the suffix stripped. Otherwise
- * `base` is the input.
+ * the caller opts in via `allowMaxSuffix`/`allowUltraSuffix`/`allowAutoAlias`,
+ * the guarded `:max` / `:ultra` level or `:auto` sentinel); `base` then has the
+ * suffix stripped. Otherwise `base` is the input.
  * `minColonIndex` requires the colon to appear strictly after that index —
  * role-alias callers pass the matched alias prefix length.
  */
@@ -155,15 +160,15 @@ function resolveGlobScopePattern(
 		};
 	}
 
-	const maxSuffix = splitThinkingSuffix(pattern, -1, MAX_THINKING_SUFFIX_OPTIONS);
-	if (maxSuffix.level !== undefined) {
+	const guardedSuffix = splitThinkingSuffix(pattern, -1, GUARDED_THINKING_SUFFIX_OPTIONS);
+	if (guardedSuffix.level !== undefined) {
 		const literalMatches = matchingGlobModels(pattern, availableModels);
 		if (literalMatches.length > 0) {
 			return { models: literalMatches, thinkingLevel: undefined, explicitThinkingLevel: false };
 		}
-		const thinkingLevel = concreteThinkingLevel(maxSuffix.level);
+		const thinkingLevel = concreteThinkingLevel(guardedSuffix.level);
 		return {
-			models: matchingGlobModels(maxSuffix.base, availableModels),
+			models: matchingGlobModels(guardedSuffix.base, availableModels),
 			thinkingLevel,
 			explicitThinkingLevel: thinkingLevel !== undefined,
 		};
@@ -191,13 +196,14 @@ export function parseModelString(
 	// Strip strict thinking level suffixes first (e.g. "claude-sonnet-4-6:high" -> id "claude-sonnet-4-6", thinkingLevel "high").
 	const strict = splitThinkingSuffix(id);
 	if (strict.level) return { provider, id: strict.base, thinkingLevel: strict.level };
-	// `max` is a real thinking level, but real model IDs can also end in
-	// `:max`. Context-aware callers pass a literal lookup so those models win.
-	const maxAlias = splitThinkingSuffix(id, -1, options);
-	if (maxAlias.level) {
+	// `max` and `ultra` are real thinking selectors, but real model IDs can also
+	// end in those tokens. Context-aware callers pass a literal lookup so those
+	// models win.
+	const guardedAlias = splitThinkingSuffix(id, -1, options);
+	if (guardedAlias.level) {
 		return options?.isLiteralModelId?.(provider, id) === true
 			? { provider, id }
-			: { provider, id: maxAlias.base, thinkingLevel: maxAlias.level };
+			: { provider, id: guardedAlias.base, thinkingLevel: guardedAlias.level };
 	}
 	return { provider, id };
 }
@@ -240,6 +246,22 @@ export function formatModelSelectorValue(selector: string, thinkingLevel: Config
 	return thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit ? `${selector}:${thinkingLevel}` : selector;
 }
 
+function resolveExplicitThinkingLevelForModel(
+	model: Model<Api>,
+	thinkingLevel: ThinkingLevel | undefined,
+): ThinkingLevel | undefined {
+	const resolved = resolveThinkingLevelForModel(model, thinkingLevel);
+	return thinkingLevel === ThinkingLevel.Ultra ? resolved : (resolved ?? thinkingLevel);
+}
+
+function resolveConfiguredThinkingLevelForModel(
+	model: Model<Api>,
+	thinkingLevel: ConfiguredThinkingLevel | undefined,
+): ConfiguredThinkingLevel | undefined {
+	if (thinkingLevel === AUTO_THINKING) return AUTO_THINKING;
+	return resolveExplicitThinkingLevelForModel(model, thinkingLevel);
+}
+
 function getOpenRouterRouteSuffix(modelId: string): { baseId: string; suffix: string } | undefined {
 	const colonIdx = modelId.lastIndexOf(":");
 	if (colonIdx === -1) {
@@ -247,10 +269,10 @@ function getOpenRouterRouteSuffix(modelId: string): { baseId: string; suffix: st
 	}
 
 	const suffix = modelId.slice(colonIdx + 1).trim();
-	// `max` is a thinking-level suffix, never an OpenRouter route suffix, so
-	// `openrouter/<id>:max` falls through to the max-aware selector split instead of
-	// being cloned into a literal `<id>:max` model id with the reasoning level lost.
-	if (!suffix || parseThinkingSuffix(suffix, MAX_THINKING_SUFFIX_OPTIONS)) {
+	// Guarded thinking-level suffixes are never OpenRouter route suffixes, so
+	// `openrouter/<id>:ultra` falls through to selector splitting instead of being
+	// cloned into a literal `<id>:ultra` model id with the reasoning level lost.
+	if (!suffix || parseThinkingSuffix(suffix, GUARDED_THINKING_SUFFIX_OPTIONS)) {
 		return undefined;
 	}
 
@@ -772,10 +794,10 @@ function parseModelPatternWithContext(
 		return { model: exactMatch, thinkingLevel: undefined, warning: undefined, explicitThinkingLevel: false };
 	}
 
-	// No match - try stripping a valid thinking suffix and recursing.
-	// `max` is accepted only after the full pattern failed, so literal model IDs
-	// ending in `:max` keep winning over the thinking suffix.
-	const { base, level } = splitThinkingSuffix(pattern, -1, MAX_THINKING_SUFFIX_OPTIONS);
+	// No match - try stripping a valid thinking suffix and recursing. Guarded
+	// suffixes are accepted only after the full pattern failed, so literal model
+	// IDs ending in `:max` / `:ultra` keep winning over the thinking suffix.
+	const { base, level } = splitThinkingSuffix(pattern, -1, GUARDED_THINKING_SUFFIX_OPTIONS);
 	if (level) {
 		const result = parseModelPatternWithContext(base, availableModels, context, options);
 		if (result.model) {
@@ -941,7 +963,7 @@ function resolveDefaultInheritedPatterns(
 		const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(
 			pattern,
 			modelRoleAliasPrefixLength(pattern) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
-			MAX_THINKING_SUFFIX_OPTIONS,
+			GUARDED_THINKING_SUFFIX_OPTIONS,
 		);
 		const aliasRole = getModelRoleAlias(aliasCandidate, settings);
 		if (aliasRole === role) {
@@ -978,7 +1000,7 @@ function resolveConfiguredRolePattern(
 	const { base: aliasCandidate, level: thinkingLevel } = splitThinkingSuffix(
 		normalized,
 		modelRoleAliasPrefixLength(normalized) ?? LEGACY_MODEL_ROLE_ALIAS_PREFIX.length,
-		MAX_THINKING_SUFFIX_OPTIONS,
+		GUARDED_THINKING_SUFFIX_OPTIONS,
 	);
 	const role = getModelRoleAlias(aliasCandidate, settings);
 	if (!role) return [normalized];
@@ -1097,9 +1119,7 @@ export function resolveModelRoleValue(
 			return {
 				model: resolved.model,
 				thinkingLevel: resolved.explicitThinkingLevel
-					? resolved.thinkingLevel === AUTO_THINKING
-						? AUTO_THINKING
-						: (resolveThinkingLevelForModel(resolved.model, resolved.thinkingLevel) ?? resolved.thinkingLevel)
+					? resolveConfiguredThinkingLevelForModel(resolved.model, resolved.thinkingLevel)
 					: resolved.thinkingLevel,
 				explicitThinkingLevel: resolved.explicitThinkingLevel,
 				warning: resolved.warning,
@@ -1140,12 +1160,12 @@ export function extractExplicitThinkingSelector(
 		if (strictSelector) {
 			return strictSelector;
 		}
-		const maxSelector = splitThinkingSuffix(current, rolePrefixLength, MAX_THINKING_SUFFIX_OPTIONS).level;
+		const guardedSelector = splitThinkingSuffix(current, rolePrefixLength, GUARDED_THINKING_SUFFIX_OPTIONS).level;
 		if (
-			maxSelector &&
+			guardedSelector &&
 			(modelRoleAliasPrefixLength(current) !== undefined || !isLiteralModelSelector(current, options))
 		) {
-			return maxSelector;
+			return guardedSelector;
 		}
 		const expanded = expandRoleAlias(current, settings).trim();
 		if (!expanded || expanded === current) break;
@@ -1167,7 +1187,7 @@ export function resolveModelFromString(
 	const exact = available.find(model => `${model.provider}/${model.id}` === value);
 	if (exact) return exact;
 	const parsed = parseModelString(value, {
-		...MAX_THINKING_SUFFIX_OPTIONS,
+		...GUARDED_THINKING_SUFFIX_OPTIONS,
 		isLiteralModelId: (provider, id) => available.some(model => model.provider === provider && model.id === id),
 	});
 	if (parsed) {
@@ -1360,9 +1380,7 @@ export async function resolveModelScope(
 		if (scopedModels.some(sm => modelsAreEqual(sm.model, model))) return;
 		scopedModels.push({
 			model,
-			thinkingLevel: explicit
-				? (resolveThinkingLevelForModel(model, thinkingLevel) ?? thinkingLevel)
-				: thinkingLevel,
+			thinkingLevel: explicit ? resolveExplicitThinkingLevelForModel(model, thinkingLevel) : thinkingLevel,
 			explicitThinkingLevel: explicit,
 		});
 	};
@@ -1661,10 +1679,11 @@ export function resolveCliModel(options: {
 		selector = `${selector}@${upstream}`;
 	}
 
+	const resolvedThinkingLevel = resolveConfiguredThinkingLevelForModel(model, thinkingLevel);
 	return {
 		model,
 		selector,
-		thinkingLevel,
+		thinkingLevel: resolvedThinkingLevel,
 		warning,
 		error: undefined,
 	};
@@ -1691,7 +1710,7 @@ export async function findInitialModel(options: {
 	isContinuing: boolean;
 	defaultProvider?: string;
 	defaultModelId?: string;
-	defaultThinkingSelector?: Effort;
+	defaultThinkingSelector?: ThinkingLevel;
 	modelRegistry: InitialModelRegistry;
 }): Promise<InitialModelResult> {
 	const {
@@ -1706,7 +1725,7 @@ export async function findInitialModel(options: {
 	} = options;
 
 	let model: Model<Api> | undefined;
-	let thinkingLevel: Effort | undefined;
+	let thinkingLevel: ThinkingLevel | undefined;
 
 	// 1. CLI args take priority
 	if (cliProvider && cliModel) {
@@ -1727,10 +1746,7 @@ export async function findInitialModel(options: {
 				: (scoped.thinkingLevel ?? defaultThinkingSelector);
 		return {
 			model: scoped.model,
-			thinkingLevel:
-				scopedThinkingSelector === ThinkingLevel.Off
-					? ThinkingLevel.Off
-					: clampThinkingLevelForModel(scoped.model, scopedThinkingSelector),
+			thinkingLevel: resolveThinkingLevelForModel(scoped.model, scopedThinkingSelector),
 			fallbackMessage: undefined,
 		};
 	}
@@ -1740,7 +1756,7 @@ export async function findInitialModel(options: {
 		const found = modelRegistry.find(defaultProvider, defaultModelId);
 		if (found) {
 			model = found;
-			thinkingLevel = clampThinkingLevelForModel(found, defaultThinkingSelector);
+			thinkingLevel = resolveThinkingLevelForModel(found, defaultThinkingSelector);
 			return { model, thinkingLevel, fallbackMessage: undefined };
 		}
 	}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -636,6 +636,24 @@ function findExactModelReferenceMatch(modelReference: string, availableModels: M
 	}
 	return undefined;
 }
+
+function matchExactModel(
+	modelPattern: string,
+	availableModels: Model<Api>[],
+	context: ModelPreferenceContext,
+): Model<Api> | undefined {
+	const exactRefMatch = findExactModelReferenceMatch(modelPattern, availableModels);
+	if (exactRefMatch) {
+		return exactRefMatch;
+	}
+
+	const lowerPattern = modelPattern.toLowerCase();
+	const exactMatches = availableModels.filter(model => model.id.toLowerCase() === lowerPattern);
+	if (exactMatches.length > 0) {
+		return pickPreferredModel(exactMatches, context);
+	}
+	return resolveBedrockInferenceProfileModelId(modelPattern, availableModels);
+}
 /**
  * The single model-matching engine. Tries, in order:
  * 1. exact `provider/id` reference (variant-alias and OpenRouter routed/date
@@ -651,25 +669,11 @@ function matchModel(
 	availableModels: Model<Api>[],
 	context: ModelPreferenceContext,
 ): Model<Api> | undefined {
-	const exactRefMatch = findExactModelReferenceMatch(modelPattern, availableModels);
-	if (exactRefMatch) {
-		return exactRefMatch;
+	const exactMatch = matchExactModel(modelPattern, availableModels, context);
+	if (exactMatch) {
+		return exactMatch;
 	}
-
-	// Exact ID match (case-insensitive) — this must happen before provider-scoped
-	// fuzzy matching so raw IDs that contain slashes (for example OpenRouter model
-	// IDs like "openai/gpt-4o:extended") still resolve as IDs instead of being
-	// misread as a provider-qualified selector.
 	const lowerPattern = modelPattern.toLowerCase();
-	const exactMatches = availableModels.filter(m => m.id.toLowerCase() === lowerPattern);
-	if (exactMatches.length > 0) {
-		return pickPreferredModel(exactMatches, context);
-	}
-
-	const bedrockInferenceProfile = resolveBedrockInferenceProfileModelId(modelPattern, availableModels);
-	if (bedrockInferenceProfile) {
-		return bedrockInferenceProfile;
-	}
 
 	// Retired effort-tier variant ids (bare, no provider prefix) resolve to
 	// their collapsed logical model; models from the providers whose table
@@ -788,15 +792,15 @@ function parseModelPatternWithContext(
 	context: ModelPreferenceContext,
 	options?: { allowInvalidThinkingSelectorFallback?: boolean },
 ): ParsedModelResult {
-	// Try exact match first
-	const exactMatch = matchModel(pattern, availableModels, context);
+	// Literal references win over selector parsing, but fuzzy matches must not:
+	// `base:ultra` still means model `base` at Ultra even when an unrelated
+	// `base-preview:ultra` model happens to satisfy the fuzzy matcher.
+	const exactMatch = matchExactModel(pattern, availableModels, context);
 	if (exactMatch) {
 		return { model: exactMatch, thinkingLevel: undefined, warning: undefined, explicitThinkingLevel: false };
 	}
 
-	// No match - try stripping a valid thinking suffix and recursing. Guarded
-	// suffixes are accepted only after the full pattern failed, so literal model
-	// IDs ending in `:max` / `:ultra` keep winning over the thinking suffix.
+	// No literal match - try stripping a valid thinking suffix and recursing.
 	const { base, level } = splitThinkingSuffix(pattern, -1, GUARDED_THINKING_SUFFIX_OPTIONS);
 	if (level) {
 		const result = parseModelPatternWithContext(base, availableModels, context, options);
@@ -811,6 +815,13 @@ function parseModelPatternWithContext(
 			};
 		}
 		return result;
+	}
+
+	// No thinking suffix matched, so the normal fuzzy/alias engine may resolve
+	// the complete pattern.
+	const fuzzyMatch = matchModel(pattern, availableModels, context);
+	if (fuzzyMatch) {
+		return { model: fuzzyMatch, thinkingLevel: undefined, warning: undefined, explicitThinkingLevel: false };
 	}
 
 	const lastColonIndex = pattern.lastIndexOf(":");

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1,3 +1,4 @@
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { DEFAULT_SHARE_URL } from "@oh-my-pi/pi-wire";
 import { SHAPE_VARIANT_NAMES } from "@oh-my-pi/snapcompact";
@@ -989,7 +990,7 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: [...THINKING_EFFORTS, AUTO_THINKING],
+		values: [...THINKING_EFFORTS, ThinkingLevel.Ultra, AUTO_THINKING],
 		default: "high",
 		ui: {
 			tab: "model",
@@ -999,6 +1000,7 @@ export const SETTINGS_SCHEMA = {
 			options: [
 				getConfiguredThinkingLevelMetadata(AUTO_THINKING),
 				...THINKING_EFFORTS.map(getThinkingLevelMetadata),
+				getThinkingLevelMetadata(ThinkingLevel.Ultra),
 			],
 		},
 	},

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1604,6 +1604,9 @@ export class AcpAgent implements Agent {
 		if (!thinkingLevel) {
 			throw new Error(`Unknown ACP thinking level: ${value}`);
 		}
+		if (!this.#buildThinkingOptions(session).some(option => option.value === thinkingLevel)) {
+			throw new Error(`ACP thinking level unavailable for current model: ${value}`);
+		}
 		session.setThinkingLevel(thinkingLevel);
 	}
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2289,7 +2289,7 @@ export class AcpAgent implements Agent {
 				},
 				getActiveTools: () => record.session.getActiveToolNames(),
 				getAllTools: () => record.session.getAllToolNames(),
-				setActiveTools: toolNames => record.session.setActiveToolsByName(toolNames),
+				setActiveTools: toolNames => record.session.setActiveToolsByName(toolNames, { explicit: true }),
 				getCommands: () => getSessionSlashCommands(record.session),
 				setModel: async model => {
 					const apiKey = await record.session.modelRegistry.getApiKey(model);

--- a/packages/coding-agent/src/modes/components/model-browser.ts
+++ b/packages/coding-agent/src/modes/components/model-browser.ts
@@ -26,7 +26,12 @@ import { getModelMatchPreferences, resolveModelRoleValue } from "../../config/mo
 import { getKnownRoleIds, getRoleInfo, MODEL_ROLE_IDS } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
 import type { ModelPerfStats } from "../../session/agent-storage";
-import { AUTO_THINKING, type ConfiguredThinkingLevel, parseConfiguredThinkingLevel } from "../../thinking";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	parseConfiguredThinkingLevel,
+	resolveThinkingLevelForModel,
+} from "../../thinking";
 import { type ThemeColor, theme } from "../theme/theme";
 import {
 	matchesSelectCancel,
@@ -70,15 +75,19 @@ export function resolveRoleAssignments(
 ): RoleAssignments {
 	const resolvedThinkingLevel = (
 		role: string,
+		model: Model,
 		resolved: { explicitThinkingLevel: boolean; thinkingLevel?: ConfiguredThinkingLevel },
 	): ConfiguredThinkingLevel => {
-		if (resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined) {
-			return resolved.thinkingLevel;
+		const configured =
+			resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
+				? resolved.thinkingLevel
+				: role === "default"
+					? (parseConfiguredThinkingLevel(settings.get("defaultThinkingLevel")) ?? ThinkingLevel.Inherit)
+					: ThinkingLevel.Inherit;
+		if (configured === ThinkingLevel.Ultra) {
+			return resolveThinkingLevelForModel(model, configured) ?? ThinkingLevel.Inherit;
 		}
-		if (role === "default") {
-			return parseConfiguredThinkingLevel(settings.get("defaultThinkingLevel")) ?? ThinkingLevel.Inherit;
-		}
-		return ThinkingLevel.Inherit;
+		return configured;
 	};
 
 	const roles: RoleAssignments = {};
@@ -95,7 +104,7 @@ export function resolveRoleAssignments(
 		if (resolved.model) {
 			roles[role] = {
 				model: resolved.model,
-				thinkingLevel: resolvedThinkingLevel(role, resolved),
+				thinkingLevel: resolvedThinkingLevel(role, resolved.model, resolved),
 				autoSelected: false,
 			};
 		}
@@ -109,7 +118,7 @@ export function resolveRoleAssignments(
 			if (!resolved.model) continue;
 			roles[role] = {
 				model: resolved.model,
-				thinkingLevel: resolvedThinkingLevel(role, resolved),
+				thinkingLevel: resolvedThinkingLevel(role, resolved.model, resolved),
 				autoSelected: true,
 			};
 		}
@@ -247,6 +256,8 @@ export function thinkingLevelGlyph(level: ConfiguredThinkingLevel): string {
 		case ThinkingLevel.XHigh:
 			return glyphOf(theme.thinking.xhigh);
 		case ThinkingLevel.Max:
+			return glyphOf(theme.thinking.max);
+		case ThinkingLevel.Ultra:
 			return glyphOf(theme.thinking.max);
 		case ThinkingLevel.Inherit:
 			return "";

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -12,7 +12,6 @@
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Model } from "@oh-my-pi/pi-ai";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
-import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getCatalogProviderEntry } from "@oh-my-pi/pi-catalog/provider-models";
 import {
 	type Component,
@@ -30,7 +29,12 @@ import {
 import type { ModelRegistry } from "../../config/model-registry";
 import { getKnownRoleIds, getRoleInfo } from "../../config/model-roles";
 import type { Settings } from "../../config/settings";
-import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	getAvailableThinkingLevelsForModel,
+	getConfiguredThinkingLevelMetadata,
+} from "../../thinking";
 import { theme } from "../theme/theme";
 import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import {
@@ -766,7 +770,7 @@ export class ModelHubComponent implements Component {
 	}
 
 	#thinkingOptionsFor(model: Model): ConfiguredThinkingLevel[] {
-		return [ThinkingLevel.Inherit, ThinkingLevel.Off, AUTO_THINKING, ...getSupportedEfforts(model)];
+		return [ThinkingLevel.Inherit, ThinkingLevel.Off, AUTO_THINKING, ...getAvailableThinkingLevelsForModel(model)];
 	}
 
 	#openRoleStrip(item: ModelBrowserItem): void {

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -1,5 +1,4 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import type { Effort } from "@oh-my-pi/pi-ai";
 import {
 	type Component,
 	Container,
@@ -362,7 +361,7 @@ function getSettingsTabs(): Tab[] {
  */
 export interface SettingsRuntimeContext {
 	/** Available thinking levels (from session) */
-	availableThinkingLevels: Effort[];
+	availableThinkingLevels: ThinkingLevel[];
 	/** Current thinking level (from session) */
 	thinkingLevel: ThinkingLevel | undefined;
 	/** Available themes */

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -150,7 +150,7 @@ export class ExtensionUiController {
 			},
 			getActiveTools: () => this.ctx.session.getActiveToolNames(),
 			getAllTools: () => this.ctx.session.getAllToolNames(),
-			setActiveTools: toolNames => this.ctx.session.setActiveToolsByName(toolNames),
+			setActiveTools: toolNames => this.ctx.session.setActiveToolsByName(toolNames, { explicit: true }),
 			setModel: async model => {
 				const key = await this.ctx.session.modelRegistry.getApiKey(model);
 				if (!key) return false;
@@ -370,7 +370,7 @@ export class ExtensionUiController {
 			},
 			getActiveTools: () => this.ctx.session.getActiveToolNames(),
 			getAllTools: () => this.ctx.session.getAllToolNames(),
-			setActiveTools: toolNames => this.ctx.session.setActiveToolsByName(toolNames),
+			setActiveTools: toolNames => this.ctx.session.setActiveToolsByName(toolNames, { explicit: true }),
 			setModel: async model => {
 				const key = await this.ctx.session.modelRegistry.getApiKey(model);
 				if (!key) return false;

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1181,7 +1181,9 @@ export class MCPCommandController {
 					const currentActive = this.ctx.session.getActiveToolNames();
 					const toActivate = serverTools.map(t => t.name).filter(n => this.ctx.session.getToolByName(n));
 					if (toActivate.length > 0) {
-						await this.ctx.session.setActiveToolsByName([...new Set([...currentActive, ...toActivate])]);
+						await this.ctx.session.setActiveToolsByName([...new Set([...currentActive, ...toActivate])], {
+							explicit: false,
+						});
 					}
 				}
 			}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2099,7 +2099,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	async #clearTransientModeState(): Promise<void> {
 		if (this.planModeEnabled || this.planModePaused) {
 			if (this.#planModePreviousTools !== undefined) {
-				await this.session.setActiveToolsByName(this.#planModePreviousTools);
+				await this.session.setActiveToolsByName(this.#planModePreviousTools, { explicit: false });
 			}
 			this.session.setStandingResolveHandler?.(null);
 			this.session.setPlanModeState(undefined);
@@ -2115,7 +2115,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		if (this.goalModeEnabled || this.goalModePaused) {
 			if (this.#goalModePreviousTools !== undefined) {
-				await this.session.setActiveToolsByName(this.#goalModePreviousTools);
+				await this.session.setActiveToolsByName(this.#goalModePreviousTools, { explicit: false });
 			}
 			this.session.setGoalModeState(undefined);
 			this.goalModeEnabled = false;
@@ -2172,7 +2172,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			if (restored?.goal) {
 				const previousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
 				this.#goalModePreviousTools = previousTools;
-				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])], { explicit: false });
 			}
 			this.#updateGoalModeStatus();
 			return;
@@ -2240,7 +2240,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// prompt, which predictably invalidates the cache.
 		this.lastAssistantUsage = undefined;
 
-		await this.session.setActiveToolsByName(uniquePlanTools);
+		await this.session.setActiveToolsByName(uniquePlanTools, { explicit: false });
 		this.session.setPlanModeState({
 			enabled: true,
 			planFilePath,
@@ -2330,7 +2330,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		const previousTools = this.#planModePreviousTools;
 		if (previousTools && previousTools.length > 0) {
-			await this.session.setActiveToolsByName(previousTools);
+			await this.session.setActiveToolsByName(previousTools, { explicit: false });
 		}
 		if (this.#planModePreviousModelState) {
 			if (!options?.deferModelRestore) {
@@ -2390,7 +2390,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		const state = options.resume
 			? await this.session.goalRuntime.resumeGoal()
 			: await this.session.goalRuntime.createGoal({ objective: options.objective ?? "" });
-		await this.session.setActiveToolsByName(goalTools);
+		await this.session.setActiveToolsByName(goalTools, { explicit: false });
 		this.session.setGoalModeState(state);
 		this.goalModeEnabled = true;
 		this.#resetGoalContinuationSuppression();
@@ -2410,7 +2410,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}): Promise<void> {
 		const previousTools = this.#goalModePreviousTools;
 		if (this.goalModeEnabled && previousTools) {
-			await this.session.setActiveToolsByName(previousTools);
+			await this.session.setActiveToolsByName(previousTools, { explicit: false });
 		}
 		const currentState = this.session.getGoalModeState();
 		if (options?.reason === "completed") {
@@ -2819,7 +2819,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		// Restore the execution tool set, but force-enable `read`: approved-plan
 		// prompts now require loading the durable local:// plan file before work.
 		const executionTools = previousTools.includes("read") ? previousTools : [...previousTools, "read"];
-		await this.session.setActiveToolsByName(executionTools);
+		await this.session.setActiveToolsByName(executionTools, { explicit: false });
 		this.session.setPlanReferencePath(options.planFilePath);
 
 		// Resolve the deferred plan-approval model transition. On the compact path

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -6,7 +6,7 @@
  */
 import type { AgentMessage, AgentToolResult, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
-import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
+import type { ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
 import type { ContextUsage } from "../../extensibility/extensions/types";
 import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
@@ -240,7 +240,7 @@ export type RpcResponse =
 			type: "response";
 			command: "cycle_thinking_level";
 			success: true;
-			data: { level: Effort } | null;
+			data: { level: ThinkingLevel } | null;
 	  }
 
 	// Queue modes

--- a/packages/coding-agent/src/modes/runtime-init.ts
+++ b/packages/coding-agent/src/modes/runtime-init.ts
@@ -85,7 +85,7 @@ export async function initializeExtensions(session: AgentSession, options: Initi
 			},
 			getActiveTools: () => session.getActiveToolNames(),
 			getAllTools: () => session.getAllToolNames(),
-			setActiveTools: (toolNames: string[]) => session.setActiveToolsByName(toolNames),
+			setActiveTools: (toolNames: string[]) => session.setActiveToolsByName(toolNames, { explicit: true }),
 			getCommands: () => getSessionSlashCommands(session),
 			setModel: model => runExtensionSetModel(session, model),
 			getThinkingLevel: () => session.thinkingLevel,

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -1877,6 +1877,7 @@ export class Theme {
 			high: this.#symbols["thinking.high"],
 			xhigh: this.#symbols["thinking.xhigh"],
 			max: this.#symbols["thinking.max"],
+			ultra: this.#symbols["thinking.max"],
 			autoPending: this.#symbols["thinking.autoPending"],
 		};
 	}

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -1685,6 +1685,7 @@ export class Theme {
 				return (str: string) => this.fg("thinkingHigh", str);
 			case "xhigh":
 				return (str: string) => this.fg("thinkingXhigh", str);
+			case "ultra":
 			case "max":
 				// thinkingMax is optional; themes without it resolve to the xhigh color.
 				return (str: string) => this.fg(this.#fgColors.thinkingMax ? "thinkingMax" : "thinkingXhigh", str);

--- a/packages/coding-agent/src/prompts/system/ultra-mode-context.md
+++ b/packages/coding-agent/src/prompts/system/ultra-mode-context.md
@@ -1,0 +1,7 @@
+<system-reminder>
+A high-intensity root-session delegation mode is active.
+
+When delegation meaningfully improves speed or quality for independent investigation, implementation, review, or verification, proactively use `{{toolRefs.task}}` for those independent slices.{{#if taskBatch}} Batch independent slices together when that is clearer than serial delegation.{{/if}}
+
+Keep work inline when it is small, sequential, or clearer without delegation. Do not delegate merely to satisfy this reminder, and do not amplify nested subagent fan-out.
+</system-reminder>

--- a/packages/coding-agent/src/prompts/system/ultra-mode-reset.md
+++ b/packages/coding-agent/src/prompts/system/ultra-mode-reset.md
@@ -1,0 +1,5 @@
+<system-reminder>
+The prior high-intensity proactive delegation instruction no longer applies.
+
+Return to the current standing task guidance from the system prompt, active tools, and settings. Do not carry over any extra proactive-delegation bias from the previous high-intensity mode.
+</system-reminder>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1327,6 +1327,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const sessionModelStr = sessionModelStrings[i];
 				const parsedModel = parseModelString(sessionModelStr, {
 					allowMaxSuffix: true,
+					allowUltraSuffix: true,
 					allowAutoAlias: true,
 					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
 				});
@@ -1782,10 +1783,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 									// through discovery-aware activation so selection persists.
 									await liveSession.activateDiscoveredMCPTools(activation.explicitlyRequestedMCPToolNames);
 								} else if (!discoveryEnabled && !activateAll) {
-									await liveSession.setActiveToolsByName([
-										...liveSession.getActiveToolNames(),
-										...activation.explicitlyRequestedMCPToolNames,
-									]);
+									await liveSession.setActiveToolsByName(
+										[...liveSession.getActiveToolNames(), ...activation.explicitlyRequestedMCPToolNames],
+										{ explicit: false },
+									);
 								}
 							}
 						} catch (error) {
@@ -1968,16 +1969,21 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Retry session-model candidates now that extension providers are
 		// registered. The initial restore runs before extensions load, so a role
 		// model supplied by an extension would have either fallen back to the
-		// saved default (`restoredSessionModelIndex > 0`) or failed entirely
+		// saved default (`restoredSessionModelIndex > 0`), failed entirely
 		// (`restoredSessionModelIndex === -1`, with the settings default or
-		// downstream fallback filling `model`). Reclaim it here so resume
-		// honors the last active role in either case.
-		const sessionRetryLimit = restoredSessionModelIndex >= 0 ? restoredSessionModelIndex : sessionModelStrings.length;
+		// downstream fallback filling `model`), or matched an ambiguous guarded
+		// suffix as a base model before a literal extension id was registered.
+		// Reclaim through the selected index inclusively so resume honors the
+		// last active role in all cases.
+		const priorRestoredSessionModelIndex = restoredSessionModelIndex;
+		const sessionRetryLimit =
+			restoredSessionModelIndex >= 0 ? restoredSessionModelIndex + 1 : sessionModelStrings.length;
 		if (!hasExplicitModel && sessionRetryLimit > 0) {
 			for (let i = 0; i < sessionRetryLimit; i++) {
 				const sessionModelStr = sessionModelStrings[i];
 				const parsedModel = parseModelString(sessionModelStr, {
 					allowMaxSuffix: true,
+					allowUltraSuffix: true,
 					allowAutoAlias: true,
 					isLiteralModelId: (provider, id) => modelRegistry.find(provider, id) !== undefined,
 				});
@@ -1985,7 +1991,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
 				if (restoredModel && hasModelAuth(restoredModel)) {
 					model = restoredModel;
-					modelFallbackMessage = undefined;
+					if (priorRestoredSessionModelIndex < 0 || i < priorRestoredSessionModelIndex) {
+						modelFallbackMessage = undefined;
+					}
 					restoredSessionModelIndex = i;
 					restoredSessionThinkingLevel = parsedModel.thinkingLevel;
 					// Recompute thinking-level from scratch against the reclaimed
@@ -2364,7 +2372,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				);
 			}
 			if (!liveSession.getActiveToolNames().includes("search_tool_bm25")) {
-				await liveSession.setActiveToolsByName([...liveSession.getActiveToolNames(), "search_tool_bm25"]);
+				await liveSession.setActiveToolsByName([...liveSession.getActiveToolNames(), "search_tool_bm25"], {
+					explicit: false,
+				});
 			}
 			return true;
 		}
@@ -2620,7 +2630,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				agentKind === "main" && !explicitTaskEager && effectiveThinkingLevel === ThinkingLevel.Ultra;
 			if (
 				((explicitTaskEager && settings.get("task.eager") !== "default") || implicitRootUltraTask) &&
-				toolRegistry.has("task")
+				toolRegistry.has("task") &&
+				builtInRegistryToolNames.has("task")
 			) {
 				forceActive.add("task");
 			}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -6,7 +6,7 @@ import {
 	type AgentTool,
 	AppendOnlyContextManager,
 	filterProviderReplayMessages,
-	type ThinkingLevel,
+	ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
 import type { Context, CredentialDisabledEvent, Message, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
 import type { Dialect } from "@oh-my-pi/pi-ai/dialect";
@@ -2606,15 +2606,22 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (effectiveDiscoveryMode === "all") {
 			// Tools a forced tool_choice will target must stay active, or the named
 			// choice references a tool absent from the request (provider 400). Eager
-			// todos force a named `todo` choice on the first turn. `task` is also kept
-			// active under discovery-all when `task.eager` is not `default`, so eager delegation is
-			// possible and the Eager Tasks prompt section renders, even though nothing
-			// forces a `task` tool_choice.
+			// todos force a named `todo` choice on the first turn. `task` is kept
+			// active when explicitly configured eager delegation needs it, and for
+			// implicit root Ultra so discovery-all does not hide the only delegation
+			// tool the Ultra session policy can use. Explicit `task.eager=default`
+			// remains authoritative and suppresses this Ultra activation.
 			const forceActive = new Set<string>();
 			if (settings.get("todo.eager") !== "default" && settings.get("todo.enabled") && toolRegistry.has("todo")) {
 				forceActive.add("todo");
 			}
-			if (settings.get("task.eager") !== "default" && toolRegistry.has("task")) {
+			const explicitTaskEager = settings.isConfigured("task.eager");
+			const implicitRootUltraTask =
+				agentKind === "main" && !explicitTaskEager && effectiveThinkingLevel === ThinkingLevel.Ultra;
+			if (
+				((explicitTaskEager && settings.get("task.eager") !== "default") || implicitRootUltraTask) &&
+				toolRegistry.has("task")
+			) {
 				forceActive.add("task");
 			}
 			initialToolNames = filterInitialToolsForDiscoveryAll(initialToolNames, {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -286,6 +286,8 @@ import thinkingLoopRedirectTemplate from "../prompts/system/thinking-loop-redire
 import toolCallLoopRedirectTemplate from "../prompts/system/tool-call-loop-redirect.md" with { type: "text" };
 import ttsrInterruptTemplate from "../prompts/system/ttsr-interrupt.md" with { type: "text" };
 import ttsrToolReminderTemplate from "../prompts/system/ttsr-tool-reminder.md" with { type: "text" };
+import ultraModeContextPrompt from "../prompts/system/ultra-mode-context.md" with { type: "text" };
+import ultraModeResetPrompt from "../prompts/system/ultra-mode-reset.md" with { type: "text" };
 import unexpectedStopRetryTemplate from "../prompts/system/unexpected-stop-retry.md" with { type: "text" };
 import vibeModeActivePrompt from "../prompts/system/vibe-mode-active.md" with { type: "text" };
 import { AgentRegistry } from "../registry/agent-registry";
@@ -303,6 +305,7 @@ import {
 	type ConfiguredThinkingLevel,
 	clampAutoThinkingEffort,
 	concreteThinkingLevel,
+	getAvailableThinkingLevelsForModel,
 	parseConfiguredThinkingLevel,
 	resolveProvisionalAutoLevel,
 	resolveThinkingLevelForModel,
@@ -511,6 +514,23 @@ const GEMINI_TOOL_REMINDER_TYPE = "gemini-tool-call-reminder";
  *  thinking/response loop. Steers the model off the repeated content; never displayed. */
 const THINKING_LOOP_REDIRECT_TYPE = "thinking-loop-redirect";
 const TOOL_CALL_LOOP_REDIRECT_TYPE = "tool-call-loop-redirect";
+
+const ULTRA_MODE_CONTEXT_TYPE = "ultra-mode-context";
+const ULTRA_MODE_RESET_TYPE = "ultra-mode-reset";
+
+type UltraModeInactiveReason = "selector-inactive" | "subagent" | "task-eager-configured" | "task-unavailable";
+
+type UltraModeDecision = { active: true; taskToolName: string } | { active: false; reason: UltraModeInactiveReason };
+
+type UltraModeContextStatus = "active" | "reset";
+
+interface UltraModeContextDetails {
+	selector: "ultra";
+	status: UltraModeContextStatus;
+	reason: string;
+	taskTool?: string;
+	providerThinkingLevel?: Effort;
+}
 
 function customMessageContentText(content: string | (TextContent | ImageContent)[]): string {
 	if (typeof content === "string") return content;
@@ -1662,7 +1682,8 @@ type AgentContinueSkipReason =
 	| PostPromptSkipReason
 	| "session-unavailable"
 	| "should-continue-false"
-	| "post-restore-unavailable";
+	| "post-restore-unavailable"
+	| "post-ultra-reconcile-unavailable";
 
 type ScheduledAgentContinueOptions = {
 	delayMs?: number;
@@ -1739,7 +1760,7 @@ export class AgentSession {
 	readonly configWarnings: string[] = [];
 
 	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
-	/** Effective, metadata-clamped thinking level applied to the agent (never `auto`). */
+	/** Model-clamped local selector (never `auto`); Ultra lowers to Max when applied to the agent. */
 	#thinkingLevel: ThinkingLevel | undefined;
 	/** True when the user configured `auto`; the effective level is resolved per turn. */
 	#autoThinking: boolean = false;
@@ -2507,7 +2528,7 @@ export class AgentSession {
 			this.#autoThinking = true;
 			this.#thinkingLevel = resolveProvisionalAutoLevel(this.model);
 		} else {
-			this.#thinkingLevel = config.thinkingLevel;
+			this.#thinkingLevel = resolveThinkingLevelForModel(this.model, config.thinkingLevel);
 		}
 		if (config.prewalk) {
 			this.#prewalk = config.prewalk;
@@ -2603,6 +2624,7 @@ export class AgentSession {
 				}
 			}
 			await this.#maintainContextMidRun(messages, signal, context);
+			await this.#reconcileQueuedUltraModeContext();
 		});
 		this.yieldQueue = new YieldQueue({
 			isStreaming: () => this.isStreaming,
@@ -4772,6 +4794,13 @@ export class AgentSession {
 						this.#skipAgentContinue("post-restore-unavailable", options);
 						return;
 					}
+					if (this.agent.hasQueuedMessages()) {
+						await this.#reconcileQueuedUltraModeContext();
+						if (signal.aborted || this.#isDisposed) {
+							this.#skipAgentContinue("post-ultra-reconcile-unavailable", options);
+							return;
+						}
+					}
 					await this.agent.continue();
 				} catch (error) {
 					logger.warn("agent.continue failed after scheduling", {
@@ -4793,11 +4822,12 @@ export class AgentSession {
 
 	#scheduleAutoContinuePrompt(generation: number): void {
 		const continuePrompt = async () => {
-			// Compaction summarizes away the first-message eager preludes, so re-assert the
-			// delegate-via-tasks / phased-todo reminders on this auto-resumed turn. This runs
-			// at invocation (past the abort check below), so an aborted continuation queues
-			// nothing; scoped to this request via prependMessages, never the shared queue.
-			const eagerNudges = this.#buildPostCompactionEagerNudges();
+			// Compaction can summarize away hidden mode/task preludes, so re-assert any
+			// currently-applicable root-session context on this auto-resumed turn. This
+			// runs at invocation (past the abort check below), so an aborted continuation
+			// queues nothing; scoped to this request via prependMessages, never the shared
+			// queue.
+			const eagerNudges = await this.#buildPostCompactionEagerNudges();
 			await this.#promptWithMessage(
 				{
 					role: "developer",
@@ -8179,8 +8209,9 @@ export class AgentSession {
 			if (!options?.streamingBehavior) {
 				throw new AgentBusyError();
 			}
-			// Steer/follow-up the keyword notices BEFORE the queued user message so the
-			// model reads the steering notice ahead of the prompt it modifies.
+			// Steer/follow-up hidden keyword context BEFORE the queued user message so the
+			// model reads turn-local guidance ahead of the prompt it modifies. Standing
+			// Ultra mode context is re-derived when the queued turn actually executes.
 			for (const notice of keywordNotices) {
 				await this.sendCustomMessage(notice, { deliverAs: options.streamingBehavior });
 			}
@@ -8383,6 +8414,12 @@ export class AgentSession {
 			const vibeModeMessage = this.#buildVibeModeMessage();
 			if (vibeModeMessage) {
 				messages.push(vibeModeMessage);
+			}
+			const hasExplicitUltraModeMessage = options?.prependMessages?.some(message =>
+				this.#isUltraModeCustomMessage(message),
+			);
+			if (!hasExplicitUltraModeMessage) {
+				messages.push(...(await this.#buildRootTurnUltraModeMessages(message, { activateTask: true })));
 			}
 			if (options?.prependMessages) {
 				messages.push(...options.prependMessages);
@@ -9882,7 +9919,15 @@ export class AgentSession {
 	 * preferred default or the current effective level.
 	 */
 	#reapplyThinkingLevel(preferredDefault?: ThinkingLevel): void {
-		this.setThinkingLevel(this.#autoThinking ? AUTO_THINKING : (preferredDefault ?? this.#thinkingLevel));
+		if (this.#autoThinking) {
+			this.setThinkingLevel(AUTO_THINKING);
+			return;
+		}
+		const requestedLevel =
+			this.configuredThinkingLevel() === ThinkingLevel.Ultra
+				? ThinkingLevel.Ultra
+				: (preferredDefault ?? this.#thinkingLevel);
+		this.setThinkingLevel(requestedLevel);
 	}
 
 	/**
@@ -10067,9 +10112,9 @@ export class AgentSession {
 	/**
 	 * Get available thinking levels for current model.
 	 */
-	getAvailableThinkingLevels(): ReadonlyArray<Effort> {
+	getAvailableThinkingLevels(): readonly ThinkingLevel[] {
 		if (!this.model) return [];
-		return getSupportedEfforts(this.model);
+		return getAvailableThinkingLevelsForModel(this.model);
 	}
 
 	// =========================================================================
@@ -11984,6 +12029,169 @@ export class AgentSession {
 		};
 	}
 
+	#stripQueuedUltraModeMessages(messages: readonly AgentMessage[]): AgentMessage[] {
+		return messages.filter(message => !this.#isUltraModeCustomMessage(message));
+	}
+
+	async #reconcileQueuedUltraModeContext(): Promise<void> {
+		if (!this.agent.hasQueuedMessages()) return;
+
+		const originalSteering = [...this.agent.peekSteeringQueue()];
+		const originalFollowUp = [...this.agent.peekFollowUpQueue()];
+		const steering = this.#stripQueuedUltraModeMessages(originalSteering);
+		const followUp = this.#stripQueuedUltraModeMessages(originalFollowUp);
+		const firstQueuedRootMessage = steering[0] ?? followUp[0];
+		if (!firstQueuedRootMessage) {
+			if (steering.length !== originalSteering.length || followUp.length !== originalFollowUp.length) {
+				this.agent.replaceQueues(steering, followUp);
+			}
+			return;
+		}
+
+		const ultraModeMessages = await this.#buildUltraModeContextMessages({
+			activateTask: true,
+			suppressActiveReassertion: true,
+		});
+		if (steering.length > 0) {
+			this.agent.replaceQueues([...ultraModeMessages, ...steering], followUp);
+			return;
+		}
+		this.agent.replaceQueues(steering, [...ultraModeMessages, ...followUp]);
+	}
+
+	#implicitUltraTaskAllowed(): boolean {
+		return this.#requestedToolNames === undefined || this.#requestedToolNames.has("task");
+	}
+
+	#resolveImplicitUltraModeDecision(): UltraModeDecision {
+		if (this.configuredThinkingLevel() !== ThinkingLevel.Ultra) {
+			return { active: false, reason: "selector-inactive" };
+		}
+		if (this.#agentKind === "sub") {
+			return { active: false, reason: "subagent" };
+		}
+		if (this.settings.isConfigured("task.eager")) {
+			return { active: false, reason: "task-eager-configured" };
+		}
+		if (!this.#implicitUltraTaskAllowed()) {
+			return { active: false, reason: "task-unavailable" };
+		}
+		const activeToolNames = this.getActiveToolNames();
+		const taskIsAvailable = activeToolNames.includes("task") || this.#toolRegistry.has("task");
+		if (!taskIsAvailable) {
+			return { active: false, reason: "task-unavailable" };
+		}
+		return { active: true, taskToolName: this.#buildEagerPreludeContext().toolRefs.task };
+	}
+
+	async #ensureImplicitUltraTaskActive(): Promise<void> {
+		if (!this.#implicitUltraTaskAllowed()) return;
+		const activeToolNames = this.getActiveToolNames();
+		if (activeToolNames.includes("task")) return;
+		if (!this.#toolRegistry.has("task")) return;
+		await this.#applyActiveToolsByName([...activeToolNames, "task"], { persistMCPSelection: false });
+	}
+
+	#isUltraModeCustomMessage(message: AgentMessage): message is CustomMessage<UltraModeContextDetails> {
+		return (
+			message.role === "custom" &&
+			(message.customType === ULTRA_MODE_CONTEXT_TYPE || message.customType === ULTRA_MODE_RESET_TYPE)
+		);
+	}
+
+	#isAgentOnlyRootTurnMessage(message: AgentMessage): boolean {
+		if (message.role === "user") return false;
+		if ("attribution" in message && message.attribution === "user") return false;
+		return true;
+	}
+
+	#lastUltraModeContextStatusFromBranch(): UltraModeContextStatus | undefined {
+		const branch = this.sessionManager.getBranch();
+		for (let index = branch.length - 1; index >= 0; index--) {
+			const entry = branch[index];
+			if (entry?.type !== "custom_message") continue;
+			if (entry.customType === ULTRA_MODE_CONTEXT_TYPE) return "active";
+			if (entry.customType === ULTRA_MODE_RESET_TYPE) return "reset";
+			const details = entry.details;
+			if (!details || typeof details !== "object" || Array.isArray(details)) continue;
+			if ((details as Partial<UltraModeContextDetails>).selector !== "ultra") continue;
+			const status = (details as Partial<UltraModeContextDetails>).status;
+			if (status === "active" || status === "reset") return status;
+		}
+		return undefined;
+	}
+
+	#createUltraModeContextMessage(taskToolName: string): CustomMessage<UltraModeContextDetails> {
+		const context = this.#buildEagerPreludeContext();
+		const details: UltraModeContextDetails = {
+			selector: "ultra",
+			status: "active",
+			reason: "implicit-root",
+			taskTool: taskToolName,
+			providerThinkingLevel: Effort.Max,
+		};
+		return {
+			role: "custom",
+			customType: ULTRA_MODE_CONTEXT_TYPE,
+			content: prompt.render(ultraModeContextPrompt, context),
+			display: false,
+			details,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+	}
+
+	#createUltraModeResetMessage(reason: UltraModeInactiveReason): CustomMessage<UltraModeContextDetails> {
+		const details: UltraModeContextDetails = {
+			selector: "ultra",
+			status: "reset",
+			reason,
+		};
+		return {
+			role: "custom",
+			customType: ULTRA_MODE_RESET_TYPE,
+			content: prompt.render(ultraModeResetPrompt, {}),
+			display: false,
+			details,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+	}
+
+	async #buildUltraModeContextMessages(options: {
+		activateTask: boolean;
+		suppressActiveReassertion?: boolean;
+	}): Promise<CustomMessage[]> {
+		const lastStatus = this.#lastUltraModeContextStatusFromBranch();
+		const decision = this.#resolveImplicitUltraModeDecision();
+		if (decision.active) {
+			if (options.activateTask) {
+				await this.#ensureImplicitUltraTaskActive();
+			}
+			if (!this.getActiveToolNames().includes("task")) {
+				return [];
+			}
+			if (options.suppressActiveReassertion && lastStatus === "active") {
+				return [];
+			}
+			return [this.#createUltraModeContextMessage(decision.taskToolName)];
+		}
+		if (lastStatus !== "active") {
+			return [];
+		}
+		return [this.#createUltraModeResetMessage(decision.reason)];
+	}
+
+	async #buildRootTurnUltraModeMessages(
+		message: AgentMessage,
+		options: { activateTask: boolean },
+	): Promise<CustomMessage[]> {
+		if (this.#isUltraModeCustomMessage(message)) return [];
+		return this.#buildUltraModeContextMessages({
+			activateTask: options.activateTask,
+			suppressActiveReassertion: this.#isAgentOnlyRootTurnMessage(message),
+		});
+	}
 	#createEagerTodoPrelude(
 		promptText: string | undefined,
 	): { message: AgentMessage; toolChoice?: ToolChoice } | undefined {
@@ -12085,16 +12293,15 @@ export class AgentSession {
 	}
 
 	/**
-	 * Build the eager task/todo reminders to re-inject on the auto-continuation turn that
-	 * follows a compaction. The first-message preludes are the oldest messages, so
-	 * compaction summarizes them away and the agent silently loses the delegate-via-tasks
-	 * and phased-todo guidance mid-work; this re-asserts them, reminder-only (the todo
-	 * builder drops its forced tool_choice when `promptText` is undefined). Each builder
-	 * still applies its own mode / agent-kind / plan-mode / tool-active / surviving-todo
-	 * gates, so an empty array means nothing currently warrants a nudge.
+	 * Build the hidden mode/task reminders to re-inject on the auto-continuation turn
+	 * that follows a compaction. Compaction can summarize away the earliest hidden
+	 * custom messages, so this re-asserts only currently applicable guidance. Each
+	 * builder still applies its own mode / agent-kind / plan-mode / tool-active gates,
+	 * so an empty array means nothing currently warrants a nudge.
 	 */
-	#buildPostCompactionEagerNudges(): AgentMessage[] {
+	async #buildPostCompactionEagerNudges(): Promise<AgentMessage[]> {
 		const nudges: AgentMessage[] = [];
+		nudges.push(...(await this.#buildUltraModeContextMessages({ activateTask: true })));
 		const todo = this.#createEagerTodoPrelude(undefined);
 		if (todo) nudges.push(todo.message);
 		const task = this.#createEagerTaskPrelude(undefined);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -16018,7 +16018,7 @@ export class AgentSession {
 		// blowing the heap before the new session even loads (issue #3846). The
 		// error-recovery path rebuilds the context on demand from the restored
 		// state instead.
-		let previousSessionContext = switchingToDifferentSession ? undefined : this.buildDisplaySessionContext();
+		let previousSessionContext: SessionContext | undefined;
 		// switchSession replaces these arrays wholesale during load/rollback, so retaining
 		// the existing message objects is sufficient and avoids structured-clone failures for
 		// extension/custom metadata that is valid to persist but not cloneable.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1965,8 +1965,14 @@ export class AgentSession {
 	#setActiveToolNames: ((names: Iterable<string>) => void) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#requestedToolNames: ReadonlySet<string> | undefined;
-	/** Logical sessions where a public active-tool update explicitly removed `task`. */
-	#runtimeTaskExclusionSessionIds = new Set<string>();
+	/** Current logical session whose explicit active-tool update removed `task`. */
+	#runtimeTaskExclusionSessionId: string | undefined;
+	/** Monotonic logical-session generation; never restored across rollback. */
+	#runtimeTaskExclusionEpoch = 0;
+	/** Last logical session synchronized into the agent. */
+	#runtimeTaskExclusionLogicalSessionId: string | undefined;
+	/** Serializes explicit tool intent with session switches. */
+	#runtimeTaskExclusionGate: Promise<void> = Promise.resolve();
 	#baseSystemPrompt: string[];
 	#baseSystemPromptBeforeMemoryPromotion: string[] | undefined;
 	/**
@@ -2420,7 +2426,7 @@ export class AgentSession {
 		const previousTools = this.getActiveToolNames();
 		const augmentations = ["resolve"];
 		if (this.hasBuiltInTool("write")) augmentations.push("write");
-		await this.setActiveToolsByName([...new Set([...previousTools, ...augmentations])]);
+		await this.setActiveToolsByName([...new Set([...previousTools, ...augmentations])], { explicit: false });
 		this.#planYoloPreviousTools = previousTools;
 		this.setPlanModeState({
 			enabled: true,
@@ -2456,7 +2462,7 @@ export class AgentSession {
 				});
 				const previousTools = this.#planYoloPreviousTools;
 				if (previousTools) {
-					await this.setActiveToolsByName(previousTools);
+					await this.setActiveToolsByName(previousTools, { explicit: false });
 				}
 				this.setStandingResolveHandler(null);
 				this.setPlanModeState(undefined);
@@ -6197,6 +6203,15 @@ export class AgentSession {
 	 * needing to re-call `#syncAgentSessionId()` on every such event.
 	 */
 	#syncAgentSessionId(sessionId?: string): void {
+		const logicalSessionId = sessionId ?? this.sessionManager.getSessionId();
+		if (
+			this.#runtimeTaskExclusionLogicalSessionId !== undefined &&
+			this.#runtimeTaskExclusionLogicalSessionId !== logicalSessionId
+		) {
+			this.#runtimeTaskExclusionEpoch++;
+			this.#runtimeTaskExclusionSessionId = undefined;
+		}
+		this.#runtimeTaskExclusionLogicalSessionId = logicalSessionId;
 		const sid = this.#activeProviderSessionId(sessionId);
 		this.agent.sessionId = sid;
 		this.agent.setMetadataResolver((provider: string) =>
@@ -7087,22 +7102,49 @@ export class AgentSession {
 	}
 
 	/**
+	 * Serialize explicit active-tool intent with session switches and reloads.
+	 * Internal reconciliation bypasses this gate with `explicit: false`.
+	 */
+	async #acquireRuntimeTaskExclusionGate(): Promise<() => void> {
+		const previous = this.#runtimeTaskExclusionGate;
+		let releaseGate!: () => void;
+		this.#runtimeTaskExclusionGate = new Promise<void>(resolve => {
+			releaseGate = resolve;
+		});
+		await previous;
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			releaseGate();
+		};
+	}
+
+	/**
 	 * Set active tools by name.
 	 * Only tools in the registry can be enabled. Unknown tool names are ignored.
 	 * Also rebuilds the system prompt to reflect the new tool set.
 	 * Changes take effect before the next model call.
-	 * Additive internal reconciliation can pass `explicit: false` to preserve that intent.
+	 * Public calls are explicit by default. Internal reconciliation must opt out
+	 * with `explicit: false` so it cannot create or clear user task-exclusion intent.
 	 */
 	async setActiveToolsByName(toolNames: string[], options?: { explicit?: boolean }): Promise<void> {
 		const normalizedToolNames = normalizeToolNames(toolNames);
-		const explicitSessionId = options?.explicit === false ? undefined : this.sessionManager.getSessionId();
-		await this.#applyActiveToolsByName(normalizedToolNames);
-		if (explicitSessionId !== undefined) {
-			if (normalizedToolNames.includes("task")) {
-				this.#runtimeTaskExclusionSessionIds.delete(explicitSessionId);
-			} else {
-				this.#runtimeTaskExclusionSessionIds.add(explicitSessionId);
+		const explicit = options?.explicit !== false;
+		const releaseGate = explicit ? await this.#acquireRuntimeTaskExclusionGate() : undefined;
+		try {
+			const explicitSessionId = explicit ? this.sessionManager.getSessionId() : undefined;
+			const explicitEpoch = this.#runtimeTaskExclusionEpoch;
+			await this.#applyActiveToolsByName(normalizedToolNames);
+			if (
+				explicitSessionId !== undefined &&
+				explicitSessionId === this.sessionManager.getSessionId() &&
+				explicitEpoch === this.#runtimeTaskExclusionEpoch
+			) {
+				this.#runtimeTaskExclusionSessionId = normalizedToolNames.includes("task") ? undefined : explicitSessionId;
 			}
+		} finally {
+			releaseGate?.();
 		}
 	}
 
@@ -12110,9 +12152,13 @@ export class AgentSession {
 		});
 	}
 
+	#hasRuntimeTaskExclusion(): boolean {
+		return this.#runtimeTaskExclusionSessionId === this.sessionManager.getSessionId();
+	}
+
 	#implicitUltraTaskAllowed(): boolean {
 		if (this.#requestedToolNames !== undefined && !this.#requestedToolNames.has("task")) return false;
-		return !this.#runtimeTaskExclusionSessionIds.has(this.sessionManager.getSessionId());
+		return !this.#hasRuntimeTaskExclusion();
 	}
 
 	#resolveImplicitUltraModeDecision(): UltraModeDecision {
@@ -12220,7 +12266,7 @@ export class AgentSession {
 		suppressActiveReassertion?: boolean;
 	}): Promise<CustomMessage[]> {
 		const lastStatus = this.#lastUltraModeContextStatusFromBranch();
-		if (this.#runtimeTaskExclusionSessionIds.has(this.sessionManager.getSessionId())) {
+		if (this.#hasRuntimeTaskExclusion()) {
 			const activeToolNames = this.getActiveToolNames();
 			if (activeToolNames.includes("task")) {
 				await this.#applyActiveToolsByName(
@@ -15956,13 +16002,14 @@ export class AgentSession {
 				return false;
 			}
 		}
+		let releaseRuntimeTaskExclusionGate: (() => void) | undefined;
 
 		this.#disconnectFromAgent();
 		await this.abort({ goalReason: "internal" });
 
 		// Flush pending writes before switching so restore snapshots reflect committed state.
 		await this.sessionManager.flush();
-		const previousSessionState = this.sessionManager.captureState();
+		let previousSessionState = this.sessionManager.captureState();
 		// Only same-session reloads compare against the prior context to detect
 		// rollback edits (`#didSessionMessagesChange` below). Building it for a
 		// different-session switch is a pure waste — and on huge pre-fix sessions
@@ -15971,7 +16018,7 @@ export class AgentSession {
 		// blowing the heap before the new session even loads (issue #3846). The
 		// error-recovery path rebuilds the context on demand from the restored
 		// state instead.
-		const previousSessionContext = switchingToDifferentSession ? undefined : this.buildDisplaySessionContext();
+		let previousSessionContext = switchingToDifferentSession ? undefined : this.buildDisplaySessionContext();
 		// switchSession replaces these arrays wholesale during load/rollback, so retaining
 		// the existing message objects is sufficient and avoids structured-clone failures for
 		// extension/custom metadata that is valid to persist but not cloneable.
@@ -15985,14 +16032,15 @@ export class AgentSession {
 		const previousAutoThinking = this.#autoThinking;
 		const previousAutoResolvedLevel = this.#autoResolvedLevel;
 		const previousServiceTierByFamily = this.#serviceTierByFamily;
-		const previousSelectedMCPToolNames = new Set(this.#selectedMCPToolNames);
-		const previousTools = [...this.agent.state.tools];
-		const previousBaseSystemPrompt = this.#baseSystemPrompt;
-		const previousSystemPrompt = this.agent.state.systemPrompt;
-		const previousBaseSystemPromptBeforeMemoryPromotion = this.#baseSystemPromptBeforeMemoryPromotion;
+		let previousSelectedMCPToolNames = new Set(this.#selectedMCPToolNames);
+		let previousTools = [...this.agent.state.tools];
+		let previousBaseSystemPrompt = this.#baseSystemPrompt;
+		let previousSystemPrompt = this.agent.state.systemPrompt;
+		let previousBaseSystemPromptBeforeMemoryPromotion = this.#baseSystemPromptBeforeMemoryPromotion;
 		const previousFreshProviderSessionId = this.#freshProviderSessionId;
-		const previousInheritedProviderPromptCacheKey = this.#inheritedProviderPromptCacheKey;
-		const previousFallbackSelectedMCPToolNames = previousSessionFile
+		let previousInheritedProviderPromptCacheKey = this.#inheritedProviderPromptCacheKey;
+		let previousRuntimeTaskExclusionSessionId = this.#runtimeTaskExclusionSessionId;
+		let previousFallbackSelectedMCPToolNames = previousSessionFile
 			? this.#getSessionDefaultSelectedMCPToolNames(previousSessionFile)
 			: undefined;
 
@@ -16010,6 +16058,21 @@ export class AgentSession {
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 
 		try {
+			releaseRuntimeTaskExclusionGate = await this.#acquireRuntimeTaskExclusionGate();
+			// Explicit updates may have completed while abort/flush ran. Refresh every
+			// tool-related rollback snapshot only after the gate has drained them.
+			previousSessionState = this.sessionManager.captureState();
+			previousSessionContext = switchingToDifferentSession ? undefined : this.buildDisplaySessionContext();
+			previousSelectedMCPToolNames = new Set(this.#selectedMCPToolNames);
+			previousTools = [...this.agent.state.tools];
+			previousBaseSystemPrompt = this.#baseSystemPrompt;
+			previousSystemPrompt = this.agent.state.systemPrompt;
+			previousBaseSystemPromptBeforeMemoryPromotion = this.#baseSystemPromptBeforeMemoryPromotion;
+			previousInheritedProviderPromptCacheKey = this.#inheritedProviderPromptCacheKey;
+			previousRuntimeTaskExclusionSessionId = this.#runtimeTaskExclusionSessionId;
+			previousFallbackSelectedMCPToolNames = previousSessionFile
+				? this.#getSessionDefaultSelectedMCPToolNames(previousSessionFile)
+				: undefined;
 			await this.sessionManager.setSessionFile(sessionPath);
 			if (switchingToDifferentSession) {
 				this.#freshProviderSessionId = undefined;
@@ -16028,13 +16091,21 @@ export class AgentSession {
 			await this.#restoreMCPSelectionsForSessionContext(sessionContext, { fallbackSelectedMCPToolNames });
 			this.#rehydrateCheckpointRewindState();
 
-			// Emit session_switch event to hooks
-			if (this.#extensionRunner) {
-				await this.#extensionRunner.emit({
-					type: "session_switch",
-					reason: "resume",
-					previousSessionFile,
-				});
+			// Session-switch hooks may make explicit active-tool updates. Temporarily
+			// release the gate after target adoption, then drain those updates before
+			// continuing so rollback can still restore the source atomically.
+			releaseRuntimeTaskExclusionGate?.();
+			releaseRuntimeTaskExclusionGate = undefined;
+			try {
+				if (this.#extensionRunner) {
+					await this.#extensionRunner.emit({
+						type: "session_switch",
+						reason: "resume",
+						previousSessionFile,
+					});
+				}
+			} finally {
+				releaseRuntimeTaskExclusionGate = await this.#acquireRuntimeTaskExclusionGate();
 			}
 
 			this.agent.replaceMessages(sessionContext.messages);
@@ -16151,6 +16222,7 @@ export class AgentSession {
 			this.sessionManager.restoreState(previousSessionState);
 			this.#freshProviderSessionId = previousFreshProviderSessionId;
 			this.#syncAgentSessionId(previousSessionState.sessionId);
+			this.#runtimeTaskExclusionSessionId = previousRuntimeTaskExclusionSessionId;
 			this.#rekeyHindsightMemoryForCurrentSessionId();
 			this.#rekeyMnemopiMemoryForCurrentSessionId();
 			let restoreMcpError: unknown;
@@ -16202,6 +16274,8 @@ export class AgentSession {
 				throw restoreMcpError;
 			}
 			throw error;
+		} finally {
+			releaseRuntimeTaskExclusionGate?.();
 		}
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -518,7 +518,12 @@ const TOOL_CALL_LOOP_REDIRECT_TYPE = "tool-call-loop-redirect";
 const ULTRA_MODE_CONTEXT_TYPE = "ultra-mode-context";
 const ULTRA_MODE_RESET_TYPE = "ultra-mode-reset";
 
-type UltraModeInactiveReason = "selector-inactive" | "subagent" | "task-eager-configured" | "task-unavailable";
+type UltraModeInactiveReason =
+	| "selector-inactive"
+	| "subagent"
+	| "vibe-mode"
+	| "task-eager-configured"
+	| "task-unavailable";
 
 type UltraModeDecision = { active: true; taskToolName: string } | { active: false; reason: UltraModeInactiveReason };
 
@@ -1232,6 +1237,7 @@ function parseRetryFallbackSelector(
 	if (!trimmed) return undefined;
 	const parsed = parseModelString(trimmed, {
 		allowMaxSuffix: true,
+		allowUltraSuffix: true,
 		allowAutoAlias: true,
 		isLiteralModelId: (provider, id) => modelLookup?.find(provider, id) !== undefined,
 	});
@@ -1959,6 +1965,8 @@ export class AgentSession {
 	#setActiveToolNames: ((names: Iterable<string>) => void) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#requestedToolNames: ReadonlySet<string> | undefined;
+	/** Logical sessions where a public active-tool update explicitly removed `task`. */
+	#runtimeTaskExclusionSessionIds = new Set<string>();
 	#baseSystemPrompt: string[];
 	#baseSystemPromptBeforeMemoryPromotion: string[] | undefined;
 	/**
@@ -6751,7 +6759,7 @@ export class AgentSession {
 			...this.#getActiveNonMCPToolNames(),
 			...this.#filterSelectableMCPToolNames(nextSelectedMCPToolNames),
 		];
-		await this.setActiveToolsByName(nextActive);
+		await this.#applyActiveToolsByName(nextActive);
 		return [...new Set(activated)];
 	}
 
@@ -6846,7 +6854,7 @@ export class AgentSession {
 			}
 			if (newlyAdded.length > 0) {
 				const nextActive = [...this.getActiveToolNames(), ...newlyAdded];
-				await this.setActiveToolsByName(nextActive);
+				await this.#applyActiveToolsByName(nextActive);
 				this.#invalidateDiscoverableToolSearchIndex();
 			}
 		}
@@ -7083,9 +7091,19 @@ export class AgentSession {
 	 * Only tools in the registry can be enabled. Unknown tool names are ignored.
 	 * Also rebuilds the system prompt to reflect the new tool set.
 	 * Changes take effect before the next model call.
+	 * Additive internal reconciliation can pass `explicit: false` to preserve that intent.
 	 */
-	async setActiveToolsByName(toolNames: string[]): Promise<void> {
-		await this.#applyActiveToolsByName(toolNames);
+	async setActiveToolsByName(toolNames: string[], options?: { explicit?: boolean }): Promise<void> {
+		const normalizedToolNames = normalizeToolNames(toolNames);
+		const explicitSessionId = options?.explicit === false ? undefined : this.sessionManager.getSessionId();
+		await this.#applyActiveToolsByName(normalizedToolNames);
+		if (explicitSessionId !== undefined) {
+			if (normalizedToolNames.includes("task")) {
+				this.#runtimeTaskExclusionSessionIds.delete(explicitSessionId);
+			} else {
+				this.#runtimeTaskExclusionSessionIds.add(explicitSessionId);
+			}
+		}
 	}
 
 	async #restoreMCPSelectionsForSessionContext(
@@ -9115,9 +9133,10 @@ export class AgentSession {
 	}
 
 	/** Clear queued messages and return the user-restorable ones (text plus any attached images).
-	 *  Only user-authored messages (plain user turns, `attribution:"user"` custom like `/skill`) are
-	 *  returned for editor restore. Other queued messages stay in the agent-core queues so a continuing
-	 *  stream still delivers them — EXCEPT on `forInterrupt` (Esc+abort), where only advisor cards are
+	 *  User-authored messages (plain user turns, `attribution:"user"` custom like `/skill`) are
+	 *  returned for editor restore; known hidden user companions and queued Ultra context leave with
+	 *  a removed root, while Ultra remains beside a retained vibe root. Other agent-authored messages
+	 *  stay queued — EXCEPT on `forInterrupt` (Esc+abort), where only advisor cards are
 	 *  kept (abort()'s #extractQueuedAdvisorCards preserves them as visible advice) and every other
 	 *  non-user steer (hidden goal/plan/budget, IRC/extension asides) is dropped, so abort()'s
 	 *  #drainStrandedQueuedMessages can't auto-resume the run the user just interrupted (the drain only
@@ -9130,10 +9149,17 @@ export class AgentSession {
 		const followUpAll = this.agent.peekFollowUpQueue();
 		const steering = steeringAll.filter(isUserQueuedMessage).map(toRestoredQueuedMessage);
 		const followUp = followUpAll.filter(isUserQueuedMessage).map(toRestoredQueuedMessage);
-		const keep: (m: AgentMessage) => boolean = options?.forInterrupt
-			? isAdvisorCard
-			: m => !isUserQueuedMessage(m) && !isHiddenUserCompanion(m);
-		this.agent.replaceQueues(steeringAll.filter(keep), followUpAll.filter(keep));
+		const keepAfterRestore = (queue: readonly AgentMessage[]): AgentMessage[] =>
+			queue.filter((message, index) => {
+				if (isUserQueuedMessage(message) || isHiddenUserCompanion(message)) return false;
+				if (!this.#isUltraModeCustomMessage(message)) return true;
+				const root = queue[index + 1];
+				return root?.role === "custom" && root.customType === "vibe-mode-context";
+			});
+		this.agent.replaceQueues(
+			options?.forInterrupt ? steeringAll.filter(isAdvisorCard) : keepAfterRestore(steeringAll),
+			options?.forInterrupt ? followUpAll.filter(isAdvisorCard) : keepAfterRestore(followUpAll),
+		);
 		return { steering, followUp };
 	}
 
@@ -9169,12 +9195,16 @@ export class AgentSession {
 			}
 			return -1;
 		};
-		// Notices queue immediately before their user message, so dropping the popped
-		// prompt means also dropping the contiguous hidden-user companions right before
-		// it — companions of other queued prompts stay put.
+		// Known hidden notices and a queued Ultra context sit immediately before
+		// their user message. Remove that contiguous group with the restored prompt;
+		// agent-authored entries such as advisor cards remain independently queued.
 		const removeWithCompanions = (queue: readonly AgentMessage[], userIndex: number): AgentMessage[] => {
 			let start = userIndex;
-			while (start > 0 && isHiddenUserCompanion(queue[start - 1])) start--;
+			while (start > 0) {
+				const previous = queue[start - 1];
+				if (!isHiddenUserCompanion(previous) && !this.#isUltraModeCustomMessage(previous)) break;
+				start--;
+			}
 			const next = queue.slice();
 			next.splice(start, userIndex - start + 1);
 			return next;
@@ -12033,18 +12063,22 @@ export class AgentSession {
 		return messages.filter(message => !this.#isUltraModeCustomMessage(message));
 	}
 
+	#isQueuedUltraRootMessage(message: AgentMessage): boolean {
+		if (message.role === "custom" && message.customType === "vibe-mode-context") return true;
+		return !this.#isAgentOnlyRootTurnMessage(message) && !isHiddenUserCompanion(message);
+	}
+
 	async #reconcileQueuedUltraModeContext(): Promise<void> {
 		if (!this.agent.hasQueuedMessages()) return;
 
-		const originalSteering = [...this.agent.peekSteeringQueue()];
-		const originalFollowUp = [...this.agent.peekFollowUpQueue()];
-		const steering = this.#stripQueuedUltraModeMessages(originalSteering);
-		const followUp = this.#stripQueuedUltraModeMessages(originalFollowUp);
-		const firstQueuedRootMessage = steering[0] ?? followUp[0];
-		if (!firstQueuedRootMessage) {
-			if (steering.length !== originalSteering.length || followUp.length !== originalFollowUp.length) {
-				this.agent.replaceQueues(steering, followUp);
-			}
+		const hasQueuedRootMessage = [...this.agent.peekSteeringQueue(), ...this.agent.peekFollowUpQueue()].some(
+			message => this.#isQueuedUltraRootMessage(message),
+		);
+		if (!hasQueuedRootMessage) {
+			this.agent.transformQueues(queues => ({
+				steering: this.#stripQueuedUltraModeMessages(queues.steering),
+				followUp: this.#stripQueuedUltraModeMessages(queues.followUp),
+			}));
 			return;
 		}
 
@@ -12052,15 +12086,33 @@ export class AgentSession {
 			activateTask: true,
 			suppressActiveReassertion: true,
 		});
-		if (steering.length > 0) {
-			this.agent.replaceQueues([...ultraModeMessages, ...steering], followUp);
-			return;
-		}
-		this.agent.replaceQueues(steering, [...ultraModeMessages, ...followUp]);
+		this.agent.transformQueues(queues => {
+			const steering = this.#stripQueuedUltraModeMessages(queues.steering);
+			const followUp = this.#stripQueuedUltraModeMessages(queues.followUp);
+			const steeringRootIndex = steering.findIndex(message => this.#isQueuedUltraRootMessage(message));
+			const followUpRootIndex = followUp.findIndex(message => this.#isQueuedUltraRootMessage(message));
+			const target = steeringRootIndex >= 0 ? "steering" : followUpRootIndex >= 0 ? "followUp" : undefined;
+			if (!target || ultraModeMessages.length === 0) return { steering, followUp };
+
+			const queued = target === "steering" ? steering : followUp;
+			const rootIndex = target === "steering" ? steeringRootIndex : followUpRootIndex;
+			let insertionIndex = rootIndex;
+			while (insertionIndex > 0 && isHiddenUserCompanion(queued[insertionIndex - 1])) {
+				insertionIndex--;
+			}
+			const hiddenCompanions = queued.slice(insertionIndex, rootIndex);
+			const reconciled = [...queued.slice(0, insertionIndex), ...ultraModeMessages, ...queued.slice(insertionIndex)];
+			return {
+				steering: target === "steering" ? reconciled : steering,
+				followUp: target === "followUp" ? reconciled : followUp,
+				companions: [...ultraModeMessages, ...hiddenCompanions],
+			};
+		});
 	}
 
 	#implicitUltraTaskAllowed(): boolean {
-		return this.#requestedToolNames === undefined || this.#requestedToolNames.has("task");
+		if (this.#requestedToolNames !== undefined && !this.#requestedToolNames.has("task")) return false;
+		return !this.#runtimeTaskExclusionSessionIds.has(this.sessionManager.getSessionId());
 	}
 
 	#resolveImplicitUltraModeDecision(): UltraModeDecision {
@@ -12070,6 +12122,9 @@ export class AgentSession {
 		if (this.#agentKind === "sub") {
 			return { active: false, reason: "subagent" };
 		}
+		if (this.#vibeModeState?.enabled) {
+			return { active: false, reason: "vibe-mode" };
+		}
 		if (this.settings.isConfigured("task.eager")) {
 			return { active: false, reason: "task-eager-configured" };
 		}
@@ -12077,7 +12132,8 @@ export class AgentSession {
 			return { active: false, reason: "task-unavailable" };
 		}
 		const activeToolNames = this.getActiveToolNames();
-		const taskIsAvailable = activeToolNames.includes("task") || this.#toolRegistry.has("task");
+		const taskIsAvailable =
+			this.#builtInToolNames.has("task") && (activeToolNames.includes("task") || this.#toolRegistry.has("task"));
 		if (!taskIsAvailable) {
 			return { active: false, reason: "task-unavailable" };
 		}
@@ -12086,6 +12142,7 @@ export class AgentSession {
 
 	async #ensureImplicitUltraTaskActive(): Promise<void> {
 		if (!this.#implicitUltraTaskAllowed()) return;
+		if (!this.#builtInToolNames.has("task")) return;
 		const activeToolNames = this.getActiveToolNames();
 		if (activeToolNames.includes("task")) return;
 		if (!this.#toolRegistry.has("task")) return;
@@ -12163,6 +12220,15 @@ export class AgentSession {
 		suppressActiveReassertion?: boolean;
 	}): Promise<CustomMessage[]> {
 		const lastStatus = this.#lastUltraModeContextStatusFromBranch();
+		if (this.#runtimeTaskExclusionSessionIds.has(this.sessionManager.getSessionId())) {
+			const activeToolNames = this.getActiveToolNames();
+			if (activeToolNames.includes("task")) {
+				await this.#applyActiveToolsByName(
+					activeToolNames.filter(name => name !== "task"),
+					{ persistMCPSelection: false },
+				);
+			}
+		}
 		const decision = this.#resolveImplicitUltraModeDecision();
 		if (decision.active) {
 			if (options.activateTask) {
@@ -12868,6 +12934,7 @@ export class AgentSession {
 
 		const parsed = parseModelString(trimmedTarget, {
 			allowMaxSuffix: true,
+			allowUltraSuffix: true,
 			allowAutoAlias: true,
 			isLiteralModelId: (provider, id) =>
 				availableModels.some(model => model.provider === provider && model.id === id),

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2547,7 +2547,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			const parentOwnedToolNames = new Set(["todo"]);
 			const filteredSubagentTools = subagentToolNames.filter(name => !parentOwnedToolNames.has(name));
 			if (filteredSubagentTools.length !== subagentToolNames.length) {
-				await awaitAbortable(session.setActiveToolsByName(filteredSubagentTools));
+				await awaitAbortable(session.setActiveToolsByName(filteredSubagentTools, { explicit: false }));
 			}
 
 			session.sessionManager.appendSessionInit({
@@ -2603,7 +2603,12 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						getActiveTools: () => session.getActiveToolNames(),
 						getAllTools: () => session.getAllToolNames(),
 						setActiveTools: (toolNames: string[]) =>
-							session.setActiveToolsByName(toolNames.filter(name => !parentOwnedToolNames.has(name))),
+							session.setActiveToolsByName(
+								toolNames.filter(name => !parentOwnedToolNames.has(name)),
+								{
+									explicit: true,
+								},
+							),
 						getCommands: () => getSessionSlashCommands(session),
 						setModel: model => runExtensionSetModel(session, model),
 						getThinkingLevel: () => session.thinkingLevel,

--- a/packages/coding-agent/src/task/persisted-revive.ts
+++ b/packages/coding-agent/src/task/persisted-revive.ts
@@ -113,7 +113,7 @@ export function createPersistedSubagentReviverFactory(
 			// Clamp the active set to the persisted list: createAgentSession's
 			// `alwaysInclude` can re-add non-defaultInactive extension/custom tools
 			// the original run didn't carry. Unknown/missing names are ignored.
-			await session.setActiveToolsByName(init.tools);
+			await session.setActiveToolsByName(init.tools, { explicit: false });
 			// Cold revives must drive registry status themselves — createAgentSession
 			// doesn't wire this generically (the live path does it in the executor).
 			// Without it the idle-TTL timer never clears on a turn and the lifecycle

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -40,6 +40,11 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 		label: "max",
 		description: "Maximum reasoning the model supports",
 	},
+	[ThinkingLevel.Ultra]: {
+		value: ThinkingLevel.Ultra,
+		label: "ultra",
+		description: "Ultra reasoning (uses max provider effort)",
+	},
 };
 
 const EFFORT_BY_SELECTOR: Readonly<Record<string, Effort>> = {
@@ -59,6 +64,7 @@ const THINKING_LEVEL_BY_SELECTOR: Readonly<Record<string, ThinkingLevel>> = {
 	[ThinkingLevel.High]: ThinkingLevel.High,
 	[ThinkingLevel.XHigh]: ThinkingLevel.XHigh,
 	[ThinkingLevel.Max]: ThinkingLevel.Max,
+	[ThinkingLevel.Ultra]: ThinkingLevel.Ultra,
 };
 
 function getOwnSelector<T>(selectors: Readonly<Record<string, T>>, value: string | null | undefined): T | undefined {
@@ -100,6 +106,9 @@ export function toReasoningEffort(level: ThinkingLevel | undefined): Effort | un
 	if (level === undefined || level === ThinkingLevel.Off || level === ThinkingLevel.Inherit) {
 		return undefined;
 	}
+	if (level === ThinkingLevel.Ultra) {
+		return Effort.Max;
+	}
 	return level;
 }
 
@@ -123,7 +132,26 @@ export function resolveThinkingLevelForModel(
 	if (level === ThinkingLevel.Off) {
 		return ThinkingLevel.Off;
 	}
-	return clampThinkingLevelForModel(model, level);
+	if (level === ThinkingLevel.Ultra) {
+		const resolved = clampThinkingLevelForModel(model, Effort.Max);
+		return model && resolved === Effort.Max && getSupportedEfforts(model).includes(Effort.Max)
+			? ThinkingLevel.Ultra
+			: resolved;
+	}
+	return clampThinkingLevelForModel(model, toReasoningEffort(level));
+}
+
+/**
+ * Returns model-aware concrete thinking selectors. Ultra is agent-local and is
+ * available only when the model advertises the provider Max effort.
+ */
+export function getAvailableThinkingLevelsForModel(model: Model): readonly ThinkingLevel[] {
+	const supported = getSupportedEfforts(model);
+	const levels: ThinkingLevel[] = [...supported];
+	if (supported.includes(Effort.Max)) {
+		levels.push(ThinkingLevel.Ultra);
+	}
+	return levels;
 }
 
 /**
@@ -176,7 +204,12 @@ export function getConfiguredThinkingLevelMetadata(level: ConfiguredThinkingLeve
  * for the flag's `options` list, shell completions, and the "invalid level"
  * warning so all three stay in sync.
  */
-export const CLI_THINKING_LEVELS: readonly string[] = [ThinkingLevel.Off, ...THINKING_EFFORTS, AUTO_THINKING];
+export const CLI_THINKING_LEVELS: readonly string[] = [
+	ThinkingLevel.Off,
+	...THINKING_EFFORTS,
+	ThinkingLevel.Ultra,
+	AUTO_THINKING,
+];
 
 /**
  * Parses a `--thinking` CLI value. Accepts every {@link parseConfiguredThinkingLevel}

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -8,6 +8,7 @@ import type {
 	CreateElicitationRequest,
 	CreateElicitationResponse,
 	PromptRequest,
+	SessionConfigOption,
 	SessionNotification,
 } from "@agentclientprotocol/sdk";
 import {
@@ -17,7 +18,8 @@ import {
 	zPromptResponse,
 	zSessionNotification,
 } from "@agentclientprotocol/sdk/dist/schema/zod.gen.js";
-import type { Model } from "@oh-my-pi/pi-ai";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
@@ -60,6 +62,7 @@ const TEST_MODELS: Model[] = [
 		provider: "anthropic",
 		baseUrl: "https://example.invalid",
 		reasoning: true,
+		thinking: { mode: "effort", efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] },
 		input: ["text", "image"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 200_000,
@@ -72,12 +75,18 @@ const TEST_MODELS: Model[] = [
 		provider: "openai",
 		baseUrl: "https://example.invalid",
 		reasoning: true,
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+		},
 		input: ["text", "image"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 200_000,
 		maxTokens: 8_192,
 	}),
 ];
+
+const ULTRA_THINKING_LEVEL = ThinkingLevel.Ultra;
 
 function makeAssistantMessage(text: string, thinking?: string) {
 	const content: Array<{ type: "text"; text: string } | { type: "thinking"; thinking: string }> = [
@@ -108,9 +117,10 @@ function makeAssistantMessage(text: string, thinking?: string) {
 class FakeAgentSession {
 	sessionManager: SessionManager;
 	sessionId: string;
-	agent: { sessionId: string; waitForIdle: () => Promise<void> };
+	agent: { sessionId: string; waitForIdle: () => Promise<void>; state: { thinkingLevel: string | undefined } };
 	model: Model | undefined;
 	thinkingLevel: string | undefined;
+	configuredThinkingSelector: string | undefined;
 	customCommands: [] = [];
 	extensionRunner = undefined;
 	isStreaming = false;
@@ -141,6 +151,7 @@ class FakeAgentSession {
 		this.sessionId = this.sessionManager.getSessionId();
 		this.agent = {
 			sessionId: this.sessionId,
+			state: { thinkingLevel: undefined },
 			waitForIdle: async () => {
 				await this.waitForIdle();
 			},
@@ -163,17 +174,26 @@ class FakeAgentSession {
 	}
 
 	getAvailableThinkingLevels(): ReadonlyArray<string> {
-		return ["low", "medium", "high"];
+		const efforts = this.model?.thinking?.efforts.map(effort => String(effort)) ?? [];
+		return efforts.includes(Effort.Max) ? [...efforts, ULTRA_THINKING_LEVEL] : efforts;
+	}
+
+	configuredThinkingLevel(): string | undefined {
+		return this.configuredThinkingSelector;
 	}
 
 	setThinkingLevel(level: string | undefined): void {
-		const isChanging = this.thinkingLevel !== level;
+		const providerLevel = level === ULTRA_THINKING_LEVEL ? Effort.Max : level;
+		const isChanging = this.thinkingLevel !== level || this.agent.state.thinkingLevel !== providerLevel;
+		this.configuredThinkingSelector = level;
 		this.thinkingLevel = level;
+		this.agent.state.thinkingLevel = providerLevel;
 		if (isChanging) {
 			for (const listener of this.#listeners) {
 				listener({
 					type: "thinking_level_changed",
 					thinkingLevel: level,
+					configured: undefined,
 				} as AgentSessionEvent);
 			}
 		}
@@ -422,6 +442,29 @@ function expectAcpNotifications(updates: SessionNotification[]): void {
 	}
 }
 
+type AcpSelectConfigOption = Extract<SessionConfigOption, { type: "select" }>;
+
+function getSelectConfigOption(
+	configOptions: readonly SessionConfigOption[] | null | undefined,
+	id: string,
+): AcpSelectConfigOption {
+	const option = configOptions?.find(candidate => candidate.id === id);
+	if (option?.type !== "select") {
+		throw new Error(`Missing ACP select config option: ${id}`);
+	}
+	return option;
+}
+
+function getSelectOptionValues(option: AcpSelectConfigOption): string[] {
+	const values: string[] = [];
+	for (const entry of option.options) {
+		if ("value" in entry && typeof entry.value === "string") {
+			values.push(entry.value);
+		}
+	}
+	return values;
+}
+
 const cleanupRoots: string[] = [];
 const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
 const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
@@ -568,6 +611,46 @@ describe("ACP agent", () => {
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("advertises and accepts Ultra only for max-capable ACP models", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		const initialThinking = getSelectConfigOption(created.configOptions, "thinking");
+		expect(getSelectOptionValues(initialThinking)).not.toContain(ULTRA_THINKING_LEVEL);
+		await expect(
+			harness.agent.setSessionConfigOption({
+				sessionId: created.sessionId,
+				configId: "thinking",
+				value: ULTRA_THINKING_LEVEL,
+			}),
+		).rejects.toThrow(/thinking level/i);
+		expect(session.thinkingLevel).toBeUndefined();
+
+		const modelResponse = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "model",
+			value: `${TEST_MODELS[1]!.provider}/${TEST_MODELS[1]!.id}`,
+		});
+		const maxModelThinking = getSelectConfigOption(modelResponse.configOptions, "thinking");
+		expect(TEST_MODELS[1]!.thinking?.efforts).toContain(Effort.Max);
+		expect(TEST_MODELS[1]!.thinking?.efforts.map(effort => String(effort))).not.toContain(ULTRA_THINKING_LEVEL);
+		expect(getSelectOptionValues(maxModelThinking)).toContain(ULTRA_THINKING_LEVEL);
+
+		const ultraResponse = await harness.agent.setSessionConfigOption({
+			sessionId: created.sessionId,
+			configId: "thinking",
+			value: ULTRA_THINKING_LEVEL,
+		});
+		const ultraThinking = getSelectConfigOption(ultraResponse.configOptions, "thinking");
+		expect(ultraThinking.currentValue).toBe(ULTRA_THINKING_LEVEL);
+		expect(session.configuredThinkingLevel()).toBe(ULTRA_THINKING_LEVEL);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.Max);
+
+		harness.abortController.abort();
 	});
 
 	it("advertises plan mode and emits schema-valid mode updates", async () => {

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Agent, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type AssistantMessage, Effort, type Model, type ProviderSessionState } from "@oh-my-pi/pi-ai";
 import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
@@ -1934,6 +1934,105 @@ describe("AgentSession retry fallback", () => {
 			(session.model?.compat as { openRouterRouting?: { only?: string[] } } | undefined)?.openRouterRouting?.only,
 		).toEqual(["cerebras"]);
 	});
+
+	it("applies explicit Ultra fallback selectors without treating them as literal ids", async () => {
+		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!primaryModel) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+		const provider = "ultra-fallback";
+		const fallbackId = "max-fallback";
+		modelRegistry.registerProvider(
+			provider,
+			{
+				baseUrl: "https://ultra-fallback.example.com/v1",
+				apiKey: "ultra-fallback-key",
+				api: "openai-responses",
+				models: [
+					{
+						id: fallbackId,
+						name: "Max Fallback",
+						reasoning: true,
+						thinking: {
+							mode: "effort",
+							efforts: [Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+						},
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 8192,
+					},
+				],
+			},
+			"test://ultra-fallback",
+		);
+		const fallbackModel = modelRegistry.find(provider, fallbackId);
+		if (!fallbackModel) {
+			throw new Error("Expected runtime fallback model to be registered");
+		}
+
+		const requested: Array<{ selector: string; reasoning?: Effort }> = [];
+		const mock = createMockModel();
+		let primaryAttempts = 0;
+		const agent = new Agent({
+			getApiKey: model => `${model.provider}-test-key`,
+			initialState: { model: primaryModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: (requestedModel, context, options) => {
+				if (!options) throw new Error("Expected stream options");
+				requested.push({
+					selector: `${requestedModel.provider}/${requestedModel.id}`,
+					reasoning: options.reasoning,
+				});
+				if (requestedModel.provider === primaryModel.provider && requestedModel.id === primaryModel.id) {
+					primaryAttempts += 1;
+					mock.push({ throw: "rate limit exceeded retry-after-ms=200" });
+				} else {
+					mock.push({ content: [`ok:${requestedModel.provider}/${requestedModel.id}`] });
+				}
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 5,
+			"retry.maxRetries": 1,
+			"retry.fallbackChains": {
+				default: [`${provider}/${fallbackId}:ultra`],
+			},
+		});
+		settings.setModelRole("default", `${primaryModel.provider}/${primaryModel.id}`);
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") fallbackAppliedEvents.push(event);
+		});
+
+		expect(session.configWarnings).not.toContain(
+			`Fallback chain for role 'default' references unknown model: ${provider}/${fallbackId}:ultra`,
+		);
+
+		await session.prompt("First prompt triggers Ultra fallback");
+		await session.waitForIdle();
+
+		expect(primaryAttempts).toBe(1);
+		expect(requested.map(call => call.selector)).toEqual([
+			`${primaryModel.provider}/${primaryModel.id}`,
+			`${fallbackModel.provider}/${fallbackModel.id}`,
+		]);
+		expect(fallbackAppliedEvents[0]?.to).toBe(`${provider}/${fallbackId}:ultra`);
+		expect(session.model?.provider).toBe(fallbackModel.provider);
+		expect(session.model?.id).toBe(fallbackModel.id);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(session.configuredThinkingLevel()).toBe(ThinkingLevel.Ultra);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.Max);
+		expect(requested[1]?.reasoning).toBe(Effort.Max);
+	});
 	it("preserves thinking on bare fallback selectors and does not overwrite user thinking on restore", async () => {
 		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
@@ -2076,11 +2175,19 @@ describe("AgentSession retry fallback", () => {
 		// to distinct selectors...
 		expect(parseModelString("openai/gpt-4o:max", { allowMaxSuffix: true })?.thinkingLevel).toBe(Effort.Max);
 		expect(parseModelString("openai/gpt-4o:xhigh")?.thinkingLevel).toBe(Effort.XHigh);
+		expect(parseModelString("openai/gpt-4o:ultra", { allowUltraSuffix: true })?.thinkingLevel).toBe(
+			ThinkingLevel.Ultra,
+		);
 		// ...but suppression normalizes every thinking suffix to the base selector,
 		// so suppressing either still covers both.
 		modelRegistry.suppressSelector("openai/gpt-4o:max", future);
 		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o:xhigh")).toBe(true);
 		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o:max")).toBe(true);
+		modelRegistry.clearSuppressedSelectors();
+		modelRegistry.suppressSelector("openai/gpt-4o:ultra", future);
+		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o")).toBe(true);
+		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o:xhigh")).toBe(true);
+		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o:ultra")).toBe(true);
 
 		await modelRegistry.refresh("offline");
 		expect(modelRegistry.isSelectorSuppressed("openai/gpt-4o")).toBe(false);

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Agent, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import * as autoThinkingClassifier from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
@@ -304,7 +304,7 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe(Effort.Minimal);
 	});
 
-	it("cycles through max as the final tier on a max-capable model", async () => {
+	it("cycles through ultra after max on a max-capable model", async () => {
 		const model = getAnthropicModelOrThrow("claude-opus-4-7");
 		const agent = new Agent({
 			initialState: {
@@ -329,12 +329,16 @@ describe("AgentSession role model thinking behavior", () => {
 		});
 
 		const available = session.getAvailableThinkingLevels();
-		expect(available.at(-1)).toBe(Effort.Max);
+		expect(available.at(-2)).toBe(Effort.Max);
+		expect(available.at(-1)).toBe(ThinkingLevel.Ultra);
 
 		session.setThinkingLevel(Effort.XHigh);
 		expect(session.cycleThinkingLevel()).toBe(Effort.Max);
 		expect(session.thinkingLevel).toBe(Effort.Max);
-		// max is the last tier: the wheel wraps back to off.
+		expect(session.cycleThinkingLevel()).toBe(ThinkingLevel.Ultra);
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.Max);
+		// ultra is the last local selector: the wheel wraps back to off.
 		expect(session.cycleThinkingLevel()).toBe("off");
 	});
 

--- a/packages/coding-agent/test/agent-session-ultra-mode.test.ts
+++ b/packages/coding-agent/test/agent-session-ultra-mode.test.ts
@@ -7,6 +7,7 @@ import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream"
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
@@ -35,6 +36,9 @@ type Harness = {
 	releaseFirstResponse?: () => void;
 	waitForTaskActivation?: () => Promise<void>;
 	releaseTaskActivation?: () => void;
+	holdNextTaskRemoval?: () => void;
+	waitForTaskRemoval?: () => Promise<void>;
+	releaseTaskRemoval?: () => void;
 };
 
 function isTextContentBlock(value: unknown): value is TextContent {
@@ -175,11 +179,15 @@ describe("AgentSession Ultra mode orchestration", () => {
 			holdTaskActivation?: boolean;
 			requestedToolNames?: ReadonlySet<string>;
 			taskBuiltIn?: boolean;
+			extensionRunner?: ExtensionRunner;
 		} = {},
 	): Promise<Harness> {
 		let releaseFirstResponse: (() => void) | undefined;
 		const taskActivationStarted = Promise.withResolvers<void>();
 		const taskActivationRelease = Promise.withResolvers<void>();
+		let holdNextTaskRemoval = false;
+		const taskRemovalStarted = Promise.withResolvers<void>();
+		const taskRemovalRelease = Promise.withResolvers<void>();
 		const observedCalls: ObservedPromptCall[] = [];
 		const waiters: Array<{
 			predicate: (call: ObservedPromptCall) => boolean;
@@ -264,10 +272,16 @@ describe("AgentSession Ultra mode orchestration", () => {
 			],
 			thinkingLevel: options.thinkingLevel,
 			agentKind: options.agentKind,
+			extensionRunner: options.extensionRunner,
 			rebuildSystemPrompt: async toolNames => {
 				if (options.holdTaskActivation && toolNames.includes("task")) {
 					taskActivationStarted.resolve();
 					await taskActivationRelease.promise;
+				}
+				if (holdNextTaskRemoval && !toolNames.includes("task")) {
+					holdNextTaskRemoval = false;
+					taskRemovalStarted.resolve();
+					await taskRemovalRelease.promise;
 				}
 				return { systemPrompt: [`tools:${toolNames.join(",")}`] };
 			},
@@ -291,6 +305,11 @@ describe("AgentSession Ultra mode orchestration", () => {
 			releaseFirstResponse: () => releaseFirstResponse?.(),
 			waitForTaskActivation: () => taskActivationStarted.promise,
 			releaseTaskActivation: () => taskActivationRelease.resolve(),
+			holdNextTaskRemoval: () => {
+				holdNextTaskRemoval = true;
+			},
+			waitForTaskRemoval: () => taskRemovalStarted.promise,
+			releaseTaskRemoval: () => taskRemovalRelease.resolve(),
 		};
 		harnesses.push(harness);
 		return harness;
@@ -758,7 +777,7 @@ describe("AgentSession Ultra mode orchestration", () => {
 			thinkingLevel: ThinkingLevel.Ultra,
 		});
 
-		await session.setActiveToolsByName(["read"]);
+		await session.setActiveToolsByName(["read"], { explicit: true });
 		await session.prompt("continue without delegation");
 
 		expect(observedCalls[0]?.toolNames).not.toContain("task");
@@ -769,7 +788,23 @@ describe("AgentSession Ultra mode orchestration", () => {
 		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(0);
 	});
 
-	it("does not treat internal active-tool reconciliation as an explicit task exclusion", async () => {
+	it("treats direct active-tool updates as explicit by default", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+		});
+
+		await session.setActiveToolsByName(["read"]);
+		await session.prompt("honor the public task exclusion");
+
+		expect(observedCalls[0]?.toolNames).not.toContain("task");
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			false,
+		);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(0);
+	});
+
+	it("does not treat an explicitly internal active-tool update as a task exclusion", async () => {
 		const { session, observedCalls } = await createHarness({
 			thinkingLevel: ThinkingLevel.Ultra,
 		});
@@ -790,7 +825,7 @@ describe("AgentSession Ultra mode orchestration", () => {
 			thinkingLevel: ThinkingLevel.Ultra,
 		});
 
-		await session.setActiveToolsByName(["read"]);
+		await session.setActiveToolsByName(["read"], { explicit: true });
 		await session.setActiveToolsByName(["read", "task"], { explicit: false });
 		expect(session.getActiveToolNames()).toContain("task");
 
@@ -802,14 +837,14 @@ describe("AgentSession Ultra mode orchestration", () => {
 		);
 	});
 
-	it("preserves explicit runtime task exclusions across logical session round trips", async () => {
+	it("does not resurrect explicit runtime task exclusions after a new-session round trip", async () => {
 		const { session, observedCalls } = await createHarness({
 			thinkingLevel: Effort.High,
 			persisted: true,
 		});
 		session.setThinkingLevel(ThinkingLevel.Ultra);
 
-		await session.setActiveToolsByName(["read"]);
+		await session.setActiveToolsByName(["read"], { explicit: true });
 		await session.prompt("work in session A without delegation");
 		const sessionAFile = session.sessionFile;
 		expect(sessionAFile).toBeDefined();
@@ -817,19 +852,354 @@ describe("AgentSession Ultra mode orchestration", () => {
 
 		await session.newSession();
 		session.setThinkingLevel(ThinkingLevel.Ultra);
-		await session.setActiveToolsByName(["read", "task"]);
+		await session.setActiveToolsByName(["read", "task"], { explicit: false });
 		await session.prompt("allow delegation in session B");
 		expect(observedCalls.at(-1)?.toolNames).toContain("task");
 
 		expect(await session.switchSession(sessionAFile!)).toBe(true);
 		expect(session.configuredThinkingLevel()).toBe(ThinkingLevel.Ultra);
-		await session.prompt("return to session A without delegation");
+		await session.prompt("return to session A with delegation available");
 
 		const returnedCall = observedCalls.at(-1);
-		expect(returnedCall?.toolNames).not.toContain("task");
+		expect(returnedCall?.toolNames).toContain("task");
 		expect(returnedCall?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
-			false,
+			true,
 		);
+	});
+
+	it("ignores an in-flight exclusion after a successful A-B-A session round trip", async () => {
+		const { session, observedCalls, holdNextTaskRemoval, waitForTaskRemoval, releaseTaskRemoval } =
+			await createHarness({
+				thinkingLevel: ThinkingLevel.Ultra,
+				persisted: true,
+				activeTask: true,
+			});
+		const sessionAFile = session.sessionFile;
+		expect(sessionAFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		expect(await session.newSession()).toBe(true);
+		const sessionBFile = session.sessionFile;
+		expect(sessionBFile).toBeDefined();
+		await session.sessionManager.flush();
+		expect(await session.switchSession(sessionAFile!)).toBe(true);
+
+		holdNextTaskRemoval?.();
+		const staleExclusion = session.setActiveToolsByName(["read"], { explicit: true });
+		await waitForTaskRemoval?.();
+
+		const setSessionFile = session.sessionManager.setSessionFile.bind(session.sessionManager);
+		let switchStarted = false;
+		const switchSpy = vi.spyOn(session.sessionManager, "setSessionFile").mockImplementation(async sessionPath => {
+			switchStarted = true;
+			await setSessionFile(sessionPath);
+		});
+		try {
+			const switchToB = session.switchSession(sessionBFile!);
+			const switchStartedBeforeRelease = switchStarted;
+			releaseTaskRemoval?.();
+			await staleExclusion;
+			const switchedToB = await switchToB;
+			const switchedBackToA = await session.switchSession(sessionAFile!);
+
+			expect(switchStartedBeforeRelease).toBe(false);
+			expect(switchedToB).toBe(true);
+			expect(switchedBackToA).toBe(true);
+		} finally {
+			releaseTaskRemoval?.();
+			switchSpy.mockRestore();
+		}
+
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.prompt("allow delegation after the round trip");
+		expect(observedCalls.at(-1)?.toolNames).toContain("task");
+	});
+
+	it("drops an exclusion that finishes after newSession advances the logical-session epoch", async () => {
+		const { session, observedCalls, holdNextTaskRemoval, waitForTaskRemoval, releaseTaskRemoval } =
+			await createHarness({
+				thinkingLevel: ThinkingLevel.Ultra,
+				persisted: true,
+				activeTask: true,
+			});
+		const sessionAFile = session.sessionFile;
+		const sessionAId = session.sessionId;
+		expect(sessionAFile).toBeDefined();
+		expect(sessionAId).toBeDefined();
+		await session.sessionManager.flush();
+
+		holdNextTaskRemoval?.();
+		const staleExclusion = session.setActiveToolsByName(["read"], { explicit: true });
+		await waitForTaskRemoval?.();
+		try {
+			expect(await session.newSession()).toBe(true);
+			expect(session.sessionId).not.toBe(sessionAId);
+			const switchBackToA = session.switchSession(sessionAFile!);
+
+			releaseTaskRemoval?.();
+			await staleExclusion;
+			expect(await switchBackToA).toBe(true);
+		} finally {
+			releaseTaskRemoval?.();
+		}
+
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.prompt("allow delegation after returning to the reused session id");
+		expect(observedCalls.at(-1)?.toolNames).toContain("task");
+	});
+
+	it("lets a session_switch hook make an explicit active-tool update", async () => {
+		let hookedSession: AgentSession | undefined;
+		let hookCalls = 0;
+		const extensionRunner = {
+			hasHandlers: vi.fn(() => false),
+			emit: vi.fn(async (event: { type: string }) => {
+				if (event.type === "session_switch") {
+					hookCalls++;
+					await hookedSession?.setActiveToolsByName(["read"], { explicit: true });
+				}
+				return undefined;
+			}),
+		} as unknown as ExtensionRunner;
+		const source = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+			activeTask: true,
+			extensionRunner,
+		});
+		hookedSession = source.session;
+		const target = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+			activeTask: true,
+		});
+		const targetFile = target.session.sessionFile;
+		expect(targetFile).toBeDefined();
+		await source.sessionManager.flush();
+		await target.sessionManager.flush();
+
+		expect(await source.session.switchSession(targetFile!)).toBe(true);
+		expect(hookCalls).toBe(1);
+		expect(source.session.getActiveToolNames()).not.toContain("task");
+	});
+
+	it("clears an explicit runtime task exclusion when starting a new session", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+		});
+
+		await session.setActiveToolsByName(["read"], { explicit: true });
+		expect(await session.newSession()).toBe(true);
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.prompt("allow delegation in the new session");
+
+		expect(observedCalls.at(-1)?.toolNames).toContain("task");
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+	});
+
+	it("does not resurrect explicit runtime task exclusions after switching away and back", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: Effort.High,
+			persisted: true,
+		});
+		const sessionAFile = session.sessionFile;
+		expect(sessionAFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		expect(await session.newSession()).toBe(true);
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.setActiveToolsByName(["read"], { explicit: true });
+		await session.prompt("work in session B without delegation");
+		const sessionBFile = session.sessionFile;
+		expect(sessionBFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		expect(await session.switchSession(sessionAFile!)).toBe(true);
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.prompt("allow delegation in session A");
+		expect(observedCalls.at(-1)?.toolNames).toContain("task");
+
+		expect(await session.switchSession(sessionBFile!)).toBe(true);
+		await session.prompt("return to session B with delegation available");
+		expect(observedCalls.at(-1)?.toolNames).toContain("task");
+	});
+
+	it("preserves the current exclusion when a different-session switch rolls back", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: Effort.High,
+			persisted: true,
+		});
+		const sessionAFile = session.sessionFile;
+		expect(sessionAFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		expect(await session.newSession()).toBe(true);
+		const sessionBFile = session.sessionFile;
+		expect(sessionBFile).toBeDefined();
+		await session.sessionManager.flush();
+		expect(await session.switchSession(sessionAFile!)).toBe(true);
+
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.setActiveToolsByName(["read"], { explicit: true });
+		const setSessionFile = session.sessionManager.setSessionFile.bind(session.sessionManager);
+		const failedSwitch = vi.spyOn(session.sessionManager, "setSessionFile").mockImplementation(async sessionPath => {
+			await setSessionFile(sessionPath);
+			throw new Error("simulated switch failure");
+		});
+		try {
+			await expect(session.switchSession(sessionBFile!)).rejects.toThrow("simulated switch failure");
+		} finally {
+			failedSwitch.mockRestore();
+		}
+
+		expect(session.sessionFile).toBe(sessionAFile);
+		await session.prompt("continue without delegation after rollback");
+		expect(observedCalls.at(-1)?.toolNames).not.toContain("task");
+	});
+
+	it("does not leak the tool-intent gate when a switch fails before target loading", async () => {
+		const source = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+			activeTask: true,
+		});
+		const target = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+			activeTask: true,
+		});
+		const targetFile = target.session.sessionFile;
+		expect(targetFile).toBeDefined();
+		await source.sessionManager.flush();
+		await target.sessionManager.flush();
+
+		const flushFailure = vi
+			.spyOn(source.sessionManager, "flush")
+			.mockRejectedValueOnce(new Error("simulated pre-load flush failure"));
+		try {
+			await expect(source.session.switchSession(targetFile!)).rejects.toThrow("simulated pre-load flush failure");
+		} finally {
+			flushFailure.mockRestore();
+		}
+
+		await source.session.setActiveToolsByName(["read"], { explicit: true });
+		expect(source.session.getActiveToolNames()).not.toContain("task");
+	});
+
+	it("applies an explicit update after a failed switch rolls back", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: Effort.High,
+			persisted: true,
+			activeTask: true,
+		});
+		const sessionAFile = session.sessionFile;
+		expect(sessionAFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		expect(await session.newSession()).toBe(true);
+		const sessionBFile = session.sessionFile;
+		expect(sessionBFile).toBeDefined();
+		await session.sessionManager.flush();
+		expect(await session.switchSession(sessionAFile!)).toBe(true);
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+
+		const switchStarted = Promise.withResolvers<void>();
+		const releaseSwitch = Promise.withResolvers<void>();
+		const setSessionFile = session.sessionManager.setSessionFile.bind(session.sessionManager);
+		const failedSwitch = vi.spyOn(session.sessionManager, "setSessionFile").mockImplementation(async sessionPath => {
+			switchStarted.resolve();
+			await releaseSwitch.promise;
+			await setSessionFile(sessionPath);
+			throw new Error("simulated delayed switch failure");
+		});
+		try {
+			const switching = session.switchSession(sessionBFile!);
+			await switchStarted.promise;
+
+			const explicitUpdate = session.setActiveToolsByName(["read"], { explicit: true });
+			const updateAppliedBeforeRollback = !session.getActiveToolNames().includes("task");
+			releaseSwitch.resolve();
+
+			await expect(switching).rejects.toThrow("simulated delayed switch failure");
+			await explicitUpdate;
+			expect(updateAppliedBeforeRollback).toBe(false);
+		} finally {
+			failedSwitch.mockRestore();
+		}
+
+		expect(session.sessionFile).toBe(sessionAFile);
+		await session.prompt("honor the update after rollback");
+		expect(observedCalls.at(-1)?.toolNames).not.toContain("task");
+	});
+
+	it("serializes an explicit update with a failing same-session reload", async () => {
+		const { session } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+			activeTask: true,
+		});
+		const sessionFile = session.sessionFile;
+		expect(sessionFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		const reloadStarted = Promise.withResolvers<void>();
+		const releaseReload = Promise.withResolvers<void>();
+		const setSessionFile = session.sessionManager.setSessionFile.bind(session.sessionManager);
+		const failedReload = vi.spyOn(session.sessionManager, "setSessionFile").mockImplementation(async sessionPath => {
+			reloadStarted.resolve();
+			await releaseReload.promise;
+			await setSessionFile(sessionPath);
+			throw new Error("simulated delayed reload failure");
+		});
+		try {
+			const reloading = session.reload();
+			await reloadStarted.promise;
+			const explicitUpdate = session.setActiveToolsByName(["read"], { explicit: true });
+			for (let i = 0; i < 4; i++) await Promise.resolve();
+			const updateAppliedBeforeRollback = !session.getActiveToolNames().includes("task");
+			releaseReload.resolve();
+
+			await expect(reloading).rejects.toThrow("simulated delayed reload failure");
+			await explicitUpdate;
+			expect(updateAppliedBeforeRollback).toBe(false);
+		} finally {
+			releaseReload.resolve();
+			failedReload.mockRestore();
+		}
+
+		expect(session.sessionFile).toBe(sessionFile);
+		expect(session.getActiveToolNames()).not.toContain("task");
+	});
+
+	it("preserves an explicit runtime task exclusion across same-session reloads", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+		});
+
+		await session.setActiveToolsByName(["read"], { explicit: true });
+		await session.reload();
+		await session.prompt("continue without delegation after reload");
+
+		expect(observedCalls.at(-1)?.toolNames).not.toContain("task");
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
+	});
+
+	it("preserves an explicit runtime task exclusion across fresh provider sessions", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			persisted: true,
+		});
+		const sessionFile = session.sessionFile;
+
+		await session.setActiveToolsByName(["read"], { explicit: true });
+		expect(session.freshSession()).toBeDefined();
+		expect(session.sessionFile).toBe(sessionFile);
+		await session.prompt("continue without delegation in a fresh provider session");
+
+		expect(observedCalls.at(-1)?.toolNames).not.toContain("task");
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
 	});
 
 	it("preserves an explicit runtime task exclusion until task is re-enabled", async () => {
@@ -841,7 +1211,7 @@ describe("AgentSession Ultra mode orchestration", () => {
 		await session.prompt("start with proactive delegation");
 		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
 
-		await session.setActiveToolsByName(["read"]);
+		await session.setActiveToolsByName(["read"], { explicit: true });
 		await session.prompt("continue without delegation");
 
 		expect(observedCalls[1]?.toolNames).not.toContain("task");
@@ -849,7 +1219,7 @@ describe("AgentSession Ultra mode orchestration", () => {
 		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
 		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(1);
 
-		await session.setActiveToolsByName(["read", "task"]);
+		await session.setActiveToolsByName(["read", "task"], { explicit: true });
 		await session.prompt("resume proactive delegation");
 
 		expect(observedCalls[2]?.toolNames).toContain("task");

--- a/packages/coding-agent/test/agent-session-ultra-mode.test.ts
+++ b/packages/coding-agent/test/agent-session-ultra-mode.test.ts
@@ -1,0 +1,554 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage, type AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import { Effort, type Model, type TextContent } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+const ULTRA_CONTEXT_TYPE = "ultra-mode-context";
+const ULTRA_RESET_TYPE = "ultra-mode-reset";
+const CONTINUE_MARKER = "Resume work on the user's most recent intent";
+
+type ObservedPromptCall = {
+	toolChoice: string | undefined;
+	toolNames: string[];
+	messageRoles: AgentMessage["role"][];
+	messageTexts: string[];
+	agentThinkingLevel: Effort | undefined;
+};
+
+type Harness = {
+	session: AgentSession;
+	sessionManager: SessionManager;
+	observedCalls: ObservedPromptCall[];
+	authStorage: AuthStorage;
+	waitForCall: (predicate: (call: ObservedPromptCall) => boolean) => Promise<ObservedPromptCall>;
+	releaseFirstResponse?: () => void;
+};
+
+function isTextContentBlock(value: unknown): value is TextContent {
+	return Boolean(value && typeof value === "object" && (value as TextContent).type === "text");
+}
+
+function getToolChoiceName(choice: unknown): string | undefined {
+	if (!choice) return undefined;
+	if (typeof choice === "string") return choice;
+	if (typeof choice !== "object" || !("type" in choice)) return undefined;
+	const toolChoice = choice as { type?: string; name?: string; function?: { name?: string } };
+	if (toolChoice.type === "tool") return toolChoice.name;
+	if (toolChoice.type === "function") return toolChoice.name ?? toolChoice.function?.name;
+	return undefined;
+}
+
+function getMessageText(message: AgentMessage): string {
+	if (!("content" in message)) return "";
+	if (typeof message.content === "string") return message.content;
+	if (!Array.isArray(message.content)) return "";
+	return message.content
+		.filter(isTextContentBlock)
+		.map(content => content.text)
+		.join("\n");
+}
+
+function createAssistantResponse(text: string) {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic" as const,
+		model: "claude-opus-4-7",
+		stopReason: "stop" as const,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: Date.now(),
+	};
+}
+
+function modelOrThrow(id: string): Model {
+	const model = getBundledModel("anthropic", id);
+	if (!model) throw new Error(`Expected anthropic model ${id} to exist`);
+	return model;
+}
+function toProviderEffort(level: ThinkingLevel | undefined): Effort | undefined {
+	switch (level) {
+		case undefined:
+		case ThinkingLevel.Inherit:
+		case ThinkingLevel.Off:
+			return undefined;
+		case ThinkingLevel.Ultra:
+			return Effort.Max;
+		case Effort.Minimal:
+		case Effort.Low:
+		case Effort.Medium:
+		case Effort.High:
+		case Effort.XHigh:
+		case Effort.Max:
+			return level;
+	}
+}
+
+function createTool(name: string, label: string, customWireName?: string): AgentTool {
+	return {
+		name,
+		label,
+		description: `${label} tool`,
+		parameters: type({}),
+		loadMode: name === "task" ? "discoverable" : "essential",
+		execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		...(customWireName ? { customWireName } : {}),
+	} as AgentTool;
+}
+
+function stubCompaction(): void {
+	vi.spyOn(compactionModule, "compact").mockImplementation(async preparation => ({
+		summary: "compacted summary",
+		shortSummary: "compacted",
+		firstKeptEntryId: preparation.firstKeptEntryId,
+		tokensBefore: preparation.tokensBefore,
+	}));
+}
+
+function emitHighUsageTurn(session: AgentSession): void {
+	const assistantMsg = {
+		...createAssistantResponse("Done."),
+		usage: {
+			input: 190_000,
+			output: 1_000,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 191_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	};
+	session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+	session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+}
+
+describe("AgentSession Ultra mode orchestration", () => {
+	let tempDir: TempDir;
+	const harnesses: Harness[] = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-agent-session-ultra-mode-");
+		harnesses.length = 0;
+	});
+
+	afterEach(async () => {
+		for (const harness of harnesses) {
+			await harness.session.dispose();
+			harness.authStorage.close();
+		}
+		harnesses.length = 0;
+		tempDir.removeSync();
+		vi.restoreAllMocks();
+	});
+
+	async function createHarness(
+		options: {
+			model?: Model;
+			thinkingLevel?: ThinkingLevel;
+			settingsOverride?: Record<string, unknown>;
+			activeTask?: boolean;
+			registerTask?: boolean;
+			agentKind?: "main" | "sub";
+			persisted?: boolean;
+			sessionManager?: SessionManager;
+			taskWireName?: string;
+			holdFirstResponse?: boolean;
+			requestedToolNames?: ReadonlySet<string>;
+		} = {},
+	): Promise<Harness> {
+		let releaseFirstResponse: (() => void) | undefined;
+		const observedCalls: ObservedPromptCall[] = [];
+		const waiters: Array<{
+			predicate: (call: ObservedPromptCall) => boolean;
+			resolve: (call: ObservedPromptCall) => void;
+		}> = [];
+		const selectedModel = options.model ?? modelOrThrow("claude-opus-4-7");
+		const model = { ...selectedModel, contextWindow: 200_000, maxTokens: 64_000 };
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${harnesses.length}.db`));
+		authStorage.setRuntimeApiKey(model.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${harnesses.length}.yml`));
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"todo.enabled": false,
+			"todo.eager": "default",
+			...options.settingsOverride,
+		});
+		const sessionManager =
+			options.sessionManager ??
+			(options.persisted
+				? SessionManager.create(tempDir.path(), tempDir.path())
+				: SessionManager.inMemory(tempDir.path()));
+		const readTool = createTool("read", "Read");
+		const taskTool = createTool("task", "Task", options.taskWireName);
+		const tools = options.activeTask === true ? [readTool, taskTool] : [readTool];
+		const toolRegistry = new Map<string, AgentTool>([[readTool.name, readTool]]);
+		if (options.registerTask !== false) toolRegistry.set(taskTool.name, taskTool);
+
+		let session: AgentSession;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools,
+				messages: [],
+				thinkingLevel: toProviderEffort(options.thinkingLevel),
+			},
+			convertToLlm,
+			getToolChoice: () => session?.nextToolChoiceDirective(),
+			streamFn: (_model, context, streamOptions) => {
+				const call: ObservedPromptCall = {
+					toolChoice: getToolChoiceName(streamOptions?.toolChoice),
+					toolNames: (context.tools ?? []).map(tool => tool.name),
+					messageRoles: context.messages.map(message => message.role),
+					messageTexts: context.messages.map(message => getMessageText(message)),
+					agentThinkingLevel: agent.state.thinkingLevel,
+				};
+				observedCalls.push(call);
+				for (let i = waiters.length - 1; i >= 0; i--) {
+					const waiter = waiters[i];
+					if (waiter?.predicate(call)) {
+						waiter.resolve(call);
+						waiters.splice(i, 1);
+					}
+				}
+				const response = createAssistantResponse("done");
+				const stream = new AssistantMessageEventStream();
+				if (options.holdFirstResponse && observedCalls.length === 1) {
+					queueMicrotask(() => stream.push({ type: "start", partial: response }));
+					releaseFirstResponse = () => {
+						stream.push({ type: "done", reason: "stop", message: response });
+					};
+					return stream;
+				}
+				queueMicrotask(() => {
+					stream.push({ type: "start", partial: response });
+					stream.push({ type: "done", reason: "stop", message: response });
+				});
+				return stream;
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			toolRegistry,
+			thinkingLevel: options.thinkingLevel,
+			agentKind: options.agentKind,
+			rebuildSystemPrompt: async toolNames => ({ systemPrompt: [`tools:${toolNames.join(",")}`] }),
+			requestedToolNames: options.requestedToolNames,
+		});
+
+		const waitForCall = (predicate: (call: ObservedPromptCall) => boolean) => {
+			const existing = observedCalls.find(predicate);
+			if (existing) return Promise.resolve(existing);
+			const { promise, resolve } = Promise.withResolvers<ObservedPromptCall>();
+			waiters.push({ predicate, resolve });
+			return promise;
+		};
+
+		const harness = {
+			session,
+			sessionManager,
+			observedCalls,
+			authStorage,
+			waitForCall,
+			releaseFirstResponse: () => releaseFirstResponse?.(),
+		};
+		harnesses.push(harness);
+		return harness;
+	}
+
+	function customEntries(session: AgentSession, customType: string) {
+		return session.sessionManager
+			.getBranch()
+			.filter(entry => entry.type === "custom_message" && entry.customType === customType);
+	}
+
+	it("keeps the Ultra selector in session state while lowering provider-facing state to max", async () => {
+		const { session, observedCalls } = await createHarness({ thinkingLevel: ThinkingLevel.Ultra });
+
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(session.configuredThinkingLevel()).toBe(ThinkingLevel.Ultra);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.Max);
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls).toHaveLength(1);
+		const call = observedCalls[0];
+		expect(call?.agentThinkingLevel).toBe(Effort.Max);
+		expect(call?.toolChoice).toBeUndefined();
+		expect(call?.toolNames).toContain("task");
+		const modeText = call?.messageTexts.find(text => text.includes("meaningfully improves speed or quality")) ?? "";
+		expect(modeText).toContain("proactively use `task`");
+		expect(modeText).toContain("Keep work inline");
+		expect(modeText).not.toMatch(/must fan|subagents are the default/i);
+		expect(call?.messageTexts.join("\n")).not.toMatch(/\bultra\b/i);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)[0]).toMatchObject({
+			display: false,
+			attribution: "agent",
+			details: expect.objectContaining({ status: "active", selector: "ultra" }),
+		});
+	});
+
+	it("persists Ultra identity across a cold resume without leaking a provider Ultra effort", async () => {
+		const first = await createHarness({ thinkingLevel: Effort.High, activeTask: true, persisted: true });
+		first.session.setThinkingLevel(ThinkingLevel.Ultra);
+		await first.session.prompt("map the project seams");
+		const sessionFile = first.session.sessionFile;
+		expect(sessionFile).toBeDefined();
+		await first.session.sessionManager.flush();
+		await first.session.dispose();
+
+		const resumedSessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		const resumed = await createHarness({
+			thinkingLevel: Effort.Low,
+			activeTask: true,
+			persisted: true,
+			sessionManager: resumedSessionManager,
+		});
+
+		expect(await resumed.session.switchSession(sessionFile!)).toBe(true);
+		expect(resumed.session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(resumed.session.configuredThinkingLevel()).toBe(ThinkingLevel.Ultra);
+		expect(resumed.session.agent.state.thinkingLevel).toBe(Effort.Max);
+
+		await resumed.session.prompt("continue after resume");
+		const call = resumed.observedCalls.at(-1);
+		expect(call?.agentThinkingLevel).toBe(Effort.Max);
+		expect(call?.messageTexts.join("\n")).not.toMatch(/\bultra\b/i);
+		expect(call?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(true);
+	});
+
+	it("degrades Ultra on a model without max and emits exactly one standing-policy reset", async () => {
+		const { session, observedCalls } = await createHarness({ thinkingLevel: ThinkingLevel.Ultra, activeTask: true });
+		await session.prompt("parallelize the first pass");
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+
+		await session.setModel(modelOrThrow("claude-sonnet-4-5"));
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+		expect(session.configuredThinkingLevel()).toBe(Effort.XHigh);
+		expect(session.agent.state.thinkingLevel).toBe(Effort.XHigh);
+
+		observedCalls.length = 0;
+		await session.prompt("continue on the downgraded model");
+
+		const resetEntries = customEntries(session, ULTRA_RESET_TYPE);
+		expect(resetEntries).toHaveLength(1);
+		expect(resetEntries[0]).toMatchObject({
+			display: false,
+			attribution: "agent",
+			details: expect.objectContaining({ status: "reset", reason: "selector-inactive" }),
+		});
+		const resetText = observedCalls[0]?.messageTexts.find(text => text.includes("no longer applies")) ?? "";
+		expect(resetText).toContain("standing task guidance");
+		expect(resetText).not.toMatch(/explicit[- ]request[- ]only|\bultra\b/i);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+
+		observedCalls.length = 0;
+		await session.prompt("one more downgraded turn");
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(1);
+	});
+
+	it("does not inject implicit mode context for max, subagents, missing task, or explicit task.eager", async () => {
+		const cases: Array<Parameters<typeof createHarness>[0]> = [
+			{ thinkingLevel: Effort.Max },
+			{ thinkingLevel: ThinkingLevel.Ultra, agentKind: "sub", activeTask: true },
+			{ thinkingLevel: ThinkingLevel.Ultra, registerTask: false },
+			{ thinkingLevel: ThinkingLevel.Ultra, settingsOverride: { "task.eager": "default" } },
+		];
+
+		for (const options of cases) {
+			const { session, observedCalls } = await createHarness(options);
+			await session.prompt("refactor the parser across modules");
+			const call = observedCalls[0];
+			expect(call?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(false);
+			expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
+			expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(0);
+		}
+	});
+
+	it("re-injects the conditional mode context after compaction without forcing task", async () => {
+		const { session, waitForCall } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			activeTask: true,
+			settingsOverride: {
+				"compaction.enabled": true,
+				"compaction.autoContinue": true,
+				"compaction.strategy": "context-full",
+			},
+		});
+		stubCompaction();
+
+		await session.prompt("refactor the parser across modules");
+		emitHighUsageTurn(session);
+		const continuation = await waitForCall(call => call.messageTexts.some(text => text.includes(CONTINUE_MARKER)));
+
+		expect(continuation.toolChoice).toBeUndefined();
+		expect(continuation.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			true,
+		);
+		expect(continuation.messageTexts.join("\n")).not.toMatch(/\bultra\b/i);
+	});
+
+	it("queues the mode context with a streaming follow-up when task is already active", async () => {
+		const { session, waitForCall, releaseFirstResponse } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			activeTask: true,
+			holdFirstResponse: true,
+		});
+
+		const first = session.prompt("start a long root turn");
+		await waitForCall(call => call.messageTexts.includes("start a long root turn"));
+		await session.prompt("queue more parallel work", { streamingBehavior: "followUp" });
+		releaseFirstResponse?.();
+		await first;
+
+		const followUp = await waitForCall(call => call.messageTexts.includes("queue more parallel work"));
+		expect(followUp.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(true);
+		expect(followUp.toolChoice).toBeUndefined();
+	});
+
+	it("routes Ultra transitions through synthetic and custom root turns", async () => {
+		const { session, observedCalls } = await createHarness({ thinkingLevel: ThinkingLevel.Ultra, activeTask: true });
+
+		await session.promptCustomMessage({
+			customType: "rpc-root",
+			content: "custom root work",
+			display: false,
+			attribution: "user",
+		});
+
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			true,
+		);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+
+		observedCalls.length = 0;
+		await session.prompt("agent-only maintenance", { synthetic: true });
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+
+		await session.setModel(modelOrThrow("claude-sonnet-4-5"));
+		observedCalls.length = 0;
+		await session.prompt("synthetic user continuation", { synthetic: true, attribution: "user" });
+
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(1);
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("no longer applies"))).toBe(true);
+	});
+
+	it("re-resolves Ultra mode for queued streaming turns before execution", async () => {
+		const activated = await createHarness({ thinkingLevel: Effort.Max, holdFirstResponse: true });
+		const firstActivationTurn = activated.session.prompt("start without ultra");
+		await activated.waitForCall(call => call.messageTexts.includes("start without ultra"));
+		activated.session.setThinkingLevel(ThinkingLevel.Ultra);
+		await activated.session.prompt("queued after ultra activation", { streamingBehavior: "followUp" });
+		activated.releaseFirstResponse?.();
+		await firstActivationTurn;
+
+		const activatedFollowUp = await activated.waitForCall(call =>
+			call.messageTexts.includes("queued after ultra activation"),
+		);
+		expect(activatedFollowUp.toolNames).toContain("task");
+		expect(activatedFollowUp.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			true,
+		);
+		expect(customEntries(activated.session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+
+		const downgraded = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			activeTask: true,
+			holdFirstResponse: true,
+		});
+		const firstDowngradedTurn = downgraded.session.prompt("start ultra turn");
+		await downgraded.waitForCall(call => call.messageTexts.includes("start ultra turn"));
+		await downgraded.session.prompt("queued after downgrade", { streamingBehavior: "followUp" });
+		downgraded.session.setThinkingLevel(Effort.Max);
+		downgraded.releaseFirstResponse?.();
+		await firstDowngradedTurn;
+
+		await downgraded.waitForCall(call => call.messageTexts.some(text => text.includes("no longer applies")));
+		await downgraded.waitForCall(call => call.messageTexts.includes("queued after downgrade"));
+		expect(customEntries(downgraded.session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+		expect(customEntries(downgraded.session, ULTRA_RESET_TYPE)).toHaveLength(1);
+
+		const explicitEager = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			activeTask: true,
+			holdFirstResponse: true,
+		});
+		const firstExplicitEagerTurn = explicitEager.session.prompt("start ultra before explicit eager");
+		await explicitEager.waitForCall(call => call.messageTexts.includes("start ultra before explicit eager"));
+		await explicitEager.session.prompt("queued after explicit eager", { streamingBehavior: "followUp" });
+		explicitEager.session.settings.set("task.eager", "default");
+		explicitEager.releaseFirstResponse?.();
+		await firstExplicitEagerTurn;
+
+		await explicitEager.waitForCall(call => call.messageTexts.some(text => text.includes("no longer applies")));
+		await explicitEager.waitForCall(call => call.messageTexts.includes("queued after explicit eager"));
+		expect(customEntries(explicitEager.session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+		expect(customEntries(explicitEager.session, ULTRA_RESET_TYPE)).toHaveLength(1);
+	});
+
+	it("does not force Ultra task activation when requested tools exclude task", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			requestedToolNames: new Set(["read"]),
+		});
+
+		await session.prompt("refactor the parser across modules");
+
+		expect(observedCalls[0]?.toolNames).not.toContain("task");
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			false,
+		);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(0);
+	});
+
+	it("ignores unrelated custom status details when deriving Ultra reset state", async () => {
+		const unrelatedActive = await createHarness({ thinkingLevel: Effort.Max, activeTask: true });
+		await unrelatedActive.session.sendCustomMessage({
+			customType: "other-mode",
+			content: "not Ultra",
+			display: false,
+			details: { status: "active" },
+			attribution: "agent",
+		});
+		await unrelatedActive.session.prompt("ordinary max turn");
+		expect(customEntries(unrelatedActive.session, ULTRA_RESET_TYPE)).toHaveLength(0);
+
+		const unrelatedReset = await createHarness({ thinkingLevel: ThinkingLevel.Ultra, activeTask: true });
+		await unrelatedReset.session.prompt("parallelize the first pass");
+		await unrelatedReset.session.sendCustomMessage({
+			customType: "other-mode",
+			content: "not Ultra",
+			display: false,
+			details: { status: "reset" },
+			attribution: "agent",
+		});
+		await unrelatedReset.session.setModel(modelOrThrow("claude-sonnet-4-5"));
+		await unrelatedReset.session.prompt("continue after downgrade");
+
+		expect(customEntries(unrelatedReset.session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+		expect(customEntries(unrelatedReset.session, ULTRA_RESET_TYPE)).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/agent-session-ultra-mode.test.ts
+++ b/packages/coding-agent/test/agent-session-ultra-mode.test.ts
@@ -33,6 +33,8 @@ type Harness = {
 	authStorage: AuthStorage;
 	waitForCall: (predicate: (call: ObservedPromptCall) => boolean) => Promise<ObservedPromptCall>;
 	releaseFirstResponse?: () => void;
+	waitForTaskActivation?: () => Promise<void>;
+	releaseTaskActivation?: () => void;
 };
 
 function isTextContentBlock(value: unknown): value is TextContent {
@@ -170,10 +172,14 @@ describe("AgentSession Ultra mode orchestration", () => {
 			sessionManager?: SessionManager;
 			taskWireName?: string;
 			holdFirstResponse?: boolean;
+			holdTaskActivation?: boolean;
 			requestedToolNames?: ReadonlySet<string>;
+			taskBuiltIn?: boolean;
 		} = {},
 	): Promise<Harness> {
 		let releaseFirstResponse: (() => void) | undefined;
+		const taskActivationStarted = Promise.withResolvers<void>();
+		const taskActivationRelease = Promise.withResolvers<void>();
 		const observedCalls: ObservedPromptCall[] = [];
 		const waiters: Array<{
 			predicate: (call: ObservedPromptCall) => boolean;
@@ -252,9 +258,19 @@ describe("AgentSession Ultra mode orchestration", () => {
 			settings,
 			modelRegistry,
 			toolRegistry,
+			builtInToolNames: [
+				"read",
+				...(options.taskBuiltIn === false || options.registerTask === false ? [] : ["task"]),
+			],
 			thinkingLevel: options.thinkingLevel,
 			agentKind: options.agentKind,
-			rebuildSystemPrompt: async toolNames => ({ systemPrompt: [`tools:${toolNames.join(",")}`] }),
+			rebuildSystemPrompt: async toolNames => {
+				if (options.holdTaskActivation && toolNames.includes("task")) {
+					taskActivationStarted.resolve();
+					await taskActivationRelease.promise;
+				}
+				return { systemPrompt: [`tools:${toolNames.join(",")}`] };
+			},
 			requestedToolNames: options.requestedToolNames,
 		});
 
@@ -273,6 +289,8 @@ describe("AgentSession Ultra mode orchestration", () => {
 			authStorage,
 			waitForCall,
 			releaseFirstResponse: () => releaseFirstResponse?.(),
+			waitForTaskActivation: () => taskActivationStarted.promise,
+			releaseTaskActivation: () => taskActivationRelease.resolve(),
 		};
 		harnesses.push(harness);
 		return harness;
@@ -387,6 +405,47 @@ describe("AgentSession Ultra mode orchestration", () => {
 		}
 	});
 
+	it("does not activate a task-named extension when built-in task provenance is shadowed", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			taskBuiltIn: false,
+		});
+
+		expect(session.hasBuiltInTool("task")).toBe(false);
+		await session.prompt("do not activate a shadow task");
+
+		expect(session.getActiveToolNames()).not.toContain("task");
+		expect(observedCalls[0]?.toolNames).not.toContain("task");
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			false,
+		);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
+	});
+
+	it("yields proactive task orchestration to vibe mode and resumes after exit", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			activeTask: true,
+		});
+
+		await session.prompt("start with proactive delegation");
+		session.setVibeModeState({ enabled: true });
+		await session.setActiveToolsByName(["read"], { explicit: false });
+		await session.prompt("direct vibe workers instead");
+
+		expect(observedCalls[1]?.toolNames).not.toContain("task");
+		expect(observedCalls[1]?.messageTexts.some(text => text.includes("Vibe mode is ON"))).toBe(true);
+		expect(customEntries(session, ULTRA_RESET_TYPE).at(-1)).toMatchObject({
+			details: expect.objectContaining({ status: "reset", reason: "vibe-mode" }),
+		});
+
+		session.setVibeModeState(undefined);
+		await session.prompt("resume proactive delegation");
+
+		expect(observedCalls[2]?.toolNames).toContain("task");
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(2);
+	});
+
 	it("re-injects the conditional mode context after compaction without forcing task", async () => {
 		const { session, waitForCall } = await createHarness({
 			thinkingLevel: ThinkingLevel.Ultra,
@@ -467,6 +526,7 @@ describe("AgentSession Ultra mode orchestration", () => {
 		const activatedFollowUp = await activated.waitForCall(call =>
 			call.messageTexts.includes("queued after ultra activation"),
 		);
+		expect(activated.observedCalls).toHaveLength(2);
 		expect(activatedFollowUp.toolNames).toContain("task");
 		expect(activatedFollowUp.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
 			true,
@@ -485,8 +545,11 @@ describe("AgentSession Ultra mode orchestration", () => {
 		downgraded.releaseFirstResponse?.();
 		await firstDowngradedTurn;
 
-		await downgraded.waitForCall(call => call.messageTexts.some(text => text.includes("no longer applies")));
-		await downgraded.waitForCall(call => call.messageTexts.includes("queued after downgrade"));
+		const downgradedFollowUp = await downgraded.waitForCall(call =>
+			call.messageTexts.includes("queued after downgrade"),
+		);
+		expect(downgraded.observedCalls).toHaveLength(2);
+		expect(downgradedFollowUp.messageTexts.some(text => text.includes("no longer applies"))).toBe(true);
 		expect(customEntries(downgraded.session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
 		expect(customEntries(downgraded.session, ULTRA_RESET_TYPE)).toHaveLength(1);
 
@@ -502,10 +565,176 @@ describe("AgentSession Ultra mode orchestration", () => {
 		explicitEager.releaseFirstResponse?.();
 		await firstExplicitEagerTurn;
 
-		await explicitEager.waitForCall(call => call.messageTexts.some(text => text.includes("no longer applies")));
-		await explicitEager.waitForCall(call => call.messageTexts.includes("queued after explicit eager"));
+		const explicitEagerFollowUp = await explicitEager.waitForCall(call =>
+			call.messageTexts.includes("queued after explicit eager"),
+		);
+		expect(explicitEager.observedCalls).toHaveLength(2);
+		expect(explicitEagerFollowUp.messageTexts.some(text => text.includes("no longer applies"))).toBe(true);
 		expect(customEntries(explicitEager.session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
 		expect(customEntries(explicitEager.session, ULTRA_RESET_TYPE)).toHaveLength(1);
+	});
+
+	it("preserves follow-ups enqueued while queued Ultra context is building", async () => {
+		const {
+			session,
+			observedCalls,
+			waitForCall,
+			releaseFirstResponse,
+			waitForTaskActivation,
+			releaseTaskActivation,
+		} = await createHarness({
+			thinkingLevel: Effort.Max,
+			holdFirstResponse: true,
+			holdTaskActivation: true,
+		});
+		const first = session.prompt("start before Ultra");
+		await waitForCall(call => call.messageTexts.includes("start before Ultra"));
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.prompt("queued before context build", { streamingBehavior: "followUp" });
+		releaseFirstResponse?.();
+		await waitForTaskActivation?.();
+
+		await session.prompt("queued during context build", { streamingBehavior: "followUp" });
+		releaseTaskActivation?.();
+		await first;
+
+		expect(observedCalls).toHaveLength(3);
+		expect(observedCalls[1]?.messageTexts).toContain("queued before context build");
+		expect(observedCalls[1]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			true,
+		);
+		expect(observedCalls[2]?.messageTexts).toContain("queued during context build");
+	});
+
+	it("injects queued Ultra context only into the higher-priority steering queue", async () => {
+		const { session, observedCalls, waitForCall, releaseFirstResponse } = await createHarness({
+			thinkingLevel: Effort.Max,
+			holdFirstResponse: true,
+		});
+		const first = session.prompt("start before queued transition");
+		await waitForCall(call => call.messageTexts.includes("start before queued transition"));
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.prompt("queued steering root", { streamingBehavior: "steer" });
+		await session.prompt("queued follow-up root", { streamingBehavior: "followUp" });
+		releaseFirstResponse?.();
+		await first;
+
+		expect(observedCalls).toHaveLength(3);
+		expect(observedCalls[1]?.messageTexts).toContain("queued steering root");
+		expect(observedCalls[2]?.messageTexts).toContain("queued follow-up root");
+		const contextCount = observedCalls[2]?.messageTexts.filter(text =>
+			text.includes("meaningfully improves speed or quality"),
+		).length;
+		expect(contextCount).toBe(1);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+	});
+
+	it("keeps hidden keyword context with its queued user root and Ultra companion", async () => {
+		const { session, observedCalls, waitForCall, releaseFirstResponse } = await createHarness({
+			thinkingLevel: Effort.Max,
+			holdFirstResponse: true,
+		});
+		const first = session.prompt("start before hidden companion");
+		await waitForCall(call => call.messageTexts.includes("start before hidden companion"));
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		session.agent.followUp({
+			role: "custom",
+			customType: "ultrathink-notice",
+			content: "hidden keyword context",
+			display: false,
+			attribution: "user",
+			timestamp: Date.now(),
+		});
+		session.agent.followUp({
+			role: "user",
+			content: [{ type: "text", text: "queued user root" }],
+			timestamp: Date.now() + 1,
+		});
+		releaseFirstResponse?.();
+		await first;
+
+		expect(observedCalls).toHaveLength(2);
+		expect(observedCalls[1]?.messageTexts).toContain("hidden keyword context");
+		expect(observedCalls[1]?.messageTexts).toContain("queued user root");
+		expect(observedCalls[1]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			true,
+		);
+	});
+
+	it("delivers an Ultra reset with queued vibe context instead of a standalone model turn", async () => {
+		const { session, observedCalls, waitForCall, releaseFirstResponse } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			activeTask: true,
+			holdFirstResponse: true,
+		});
+		const first = session.prompt("start before vibe");
+		await waitForCall(call => call.messageTexts.includes("start before vibe"));
+		session.setVibeModeState({ enabled: true });
+		await session.setActiveToolsByName(["read"], { explicit: false });
+		await session.sendVibeModeContext({ deliverAs: "followUp" });
+		await session.prompt("queued vibe work", { streamingBehavior: "followUp" });
+		releaseFirstResponse?.();
+		await first;
+
+		expect(observedCalls).toHaveLength(3);
+		expect(observedCalls[1]?.messageTexts.some(text => text.includes("You are the DIRECTOR"))).toBe(true);
+		expect(observedCalls[1]?.messageTexts.some(text => text.includes("no longer applies"))).toBe(true);
+		expect(observedCalls[1]?.toolNames).not.toContain("task");
+		expect(observedCalls[2]?.messageTexts).toContain("queued vibe work");
+	});
+
+	it("removes a queued Ultra companion with a restored user prompt while preserving advisor context", async () => {
+		const { session } = await createHarness();
+		const advisor: AgentMessage = {
+			role: "custom",
+			customType: "advisor-card",
+			content: "independent advisor context",
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now(),
+		};
+		const ultraContext: AgentMessage = {
+			role: "custom",
+			customType: ULTRA_CONTEXT_TYPE,
+			content: "queued Ultra context",
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now() + 1,
+		};
+		const hiddenNotice: AgentMessage = {
+			role: "custom",
+			customType: "ultrathink-notice",
+			content: "hidden keyword context",
+			display: false,
+			attribution: "user",
+			timestamp: Date.now() + 2,
+		};
+		const userPrompt: AgentMessage = {
+			role: "user",
+			content: [{ type: "text", text: "restore me" }],
+			timestamp: Date.now() + 3,
+		};
+		const vibeContext: AgentMessage = {
+			role: "custom",
+			customType: "vibe-mode-context",
+			content: "queued vibe context",
+			display: false,
+			attribution: "agent",
+			timestamp: Date.now() + 4,
+		};
+		const queuedGroup = [advisor, ultraContext, hiddenNotice, userPrompt];
+		session.agent.replaceQueues(queuedGroup, []);
+
+		expect(session.popLastQueuedMessage()?.text).toBe("restore me");
+		expect(session.agent.peekSteeringQueue()).toEqual([advisor]);
+
+		session.agent.replaceQueues(queuedGroup, []);
+		expect(session.clearQueue().steering.map(message => message.text)).toEqual(["restore me"]);
+		expect(session.agent.peekSteeringQueue()).toEqual([advisor]);
+
+		session.agent.replaceQueues([ultraContext, vibeContext, userPrompt], []);
+		expect(session.clearQueue().steering.map(message => message.text)).toEqual(["restore me"]);
+		expect(session.agent.peekSteeringQueue()).toEqual([ultraContext, vibeContext]);
 	});
 
 	it("does not force Ultra task activation when requested tools exclude task", async () => {
@@ -522,6 +751,113 @@ describe("AgentSession Ultra mode orchestration", () => {
 		);
 		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
 		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(0);
+	});
+
+	it("honors an explicit runtime task exclusion before the first Ultra turn", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+		});
+
+		await session.setActiveToolsByName(["read"]);
+		await session.prompt("continue without delegation");
+
+		expect(observedCalls[0]?.toolNames).not.toContain("task");
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			false,
+		);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(0);
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(0);
+	});
+
+	it("does not treat internal active-tool reconciliation as an explicit task exclusion", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+		});
+
+		await session.setActiveToolsByName(["read"], { explicit: false });
+		await session.prompt("allow proactive delegation");
+
+		expect(observedCalls[0]?.toolNames).toContain("task");
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			true,
+		);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(0);
+	});
+
+	it("does not let internal active-tool reconciliation clear an explicit task exclusion", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+		});
+
+		await session.setActiveToolsByName(["read"]);
+		await session.setActiveToolsByName(["read", "task"], { explicit: false });
+		expect(session.getActiveToolNames()).toContain("task");
+
+		await session.prompt("continue without delegation");
+
+		expect(observedCalls[0]?.toolNames).not.toContain("task");
+		expect(observedCalls[0]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			false,
+		);
+	});
+
+	it("preserves explicit runtime task exclusions across logical session round trips", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: Effort.High,
+			persisted: true,
+		});
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+
+		await session.setActiveToolsByName(["read"]);
+		await session.prompt("work in session A without delegation");
+		const sessionAFile = session.sessionFile;
+		expect(sessionAFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		await session.newSession();
+		session.setThinkingLevel(ThinkingLevel.Ultra);
+		await session.setActiveToolsByName(["read", "task"]);
+		await session.prompt("allow delegation in session B");
+		expect(observedCalls.at(-1)?.toolNames).toContain("task");
+
+		expect(await session.switchSession(sessionAFile!)).toBe(true);
+		expect(session.configuredThinkingLevel()).toBe(ThinkingLevel.Ultra);
+		await session.prompt("return to session A without delegation");
+
+		const returnedCall = observedCalls.at(-1);
+		expect(returnedCall?.toolNames).not.toContain("task");
+		expect(returnedCall?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			false,
+		);
+	});
+
+	it("preserves an explicit runtime task exclusion until task is re-enabled", async () => {
+		const { session, observedCalls } = await createHarness({
+			thinkingLevel: ThinkingLevel.Ultra,
+			activeTask: true,
+		});
+
+		await session.prompt("start with proactive delegation");
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+
+		await session.setActiveToolsByName(["read"]);
+		await session.prompt("continue without delegation");
+
+		expect(observedCalls[1]?.toolNames).not.toContain("task");
+		expect(observedCalls[1]?.messageTexts.some(text => text.includes("no longer applies"))).toBe(true);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(1);
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(1);
+
+		await session.setActiveToolsByName(["read", "task"]);
+		await session.prompt("resume proactive delegation");
+
+		expect(observedCalls[2]?.toolNames).toContain("task");
+		expect(observedCalls[2]?.messageTexts.some(text => text.includes("meaningfully improves speed or quality"))).toBe(
+			true,
+		);
+		expect(customEntries(session, ULTRA_CONTEXT_TYPE)).toHaveLength(2);
+		expect(customEntries(session, ULTRA_RESET_TYPE)).toHaveLength(1);
 	});
 
 	it("ignores unrelated custom status details when deriving Ultra reset state", async () => {

--- a/packages/coding-agent/test/auto-thinking-classifier.test.ts
+++ b/packages/coding-agent/test/auto-thinking-classifier.test.ts
@@ -15,12 +15,17 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
 	AUTO_THINKING,
+	CLI_THINKING_LEVELS,
 	clampAutoThinkingEffort,
+	getAvailableThinkingLevelsForModel,
+	getConfiguredThinkingLevelMetadata,
 	parseCliThinkingLevel,
 	parseConfiguredThinkingLevel,
 	parseEffort,
 	parseThinkingLevel,
 	resolveProvisionalAutoLevel,
+	resolveThinkingLevelForModel,
+	toReasoningEffort,
 } from "@oh-my-pi/pi-coding-agent/thinking";
 import type { TinyMemoryLocalModelKey } from "@oh-my-pi/pi-coding-agent/tiny/models";
 import { tinyModelClient } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
@@ -75,6 +80,19 @@ describe("auto thinking classifier helpers", () => {
 		expect(parseCliThinkingLevel("max")).toBe(ThinkingLevel.Max);
 		expect(parseCliThinkingLevel(ThinkingLevel.Inherit)).toBeUndefined();
 		expect(parseCliThinkingLevel("bogus")).toBeUndefined();
+	});
+
+	it("parses and displays ultra without widening provider-facing efforts", () => {
+		expect(parseEffort("ultra")).toBeUndefined();
+		expect(parseThinkingLevel("ultra")).toBe(ThinkingLevel.Ultra);
+		expect(parseConfiguredThinkingLevel("ultra")).toBe(ThinkingLevel.Ultra);
+		expect(parseCliThinkingLevel("ultra")).toBe(ThinkingLevel.Ultra);
+		expect(CLI_THINKING_LEVELS).toContain("ultra");
+		expect(getConfiguredThinkingLevelMetadata(ThinkingLevel.Ultra)).toMatchObject({
+			value: ThinkingLevel.Ultra,
+			label: "ultra",
+		});
+		expect(toReasoningEffort(ThinkingLevel.Ultra)).toBe(Effort.Max);
 	});
 
 	it("maps online 4-way classifier labels to effort levels", () => {
@@ -249,6 +267,65 @@ describe("auto thinking classifier helpers", () => {
 		expect(clampAutoThinkingEffort(devinModel, Effort.XHigh)).toBeUndefined();
 		expect(clampAutoThinkingEffort(devinModel, Effort.Max)).toBeUndefined();
 		expect(resolveProvisionalAutoLevel(devinModel)).toBeUndefined();
+	});
+
+	it("exposes and preserves ultra only for models that advertise max", () => {
+		const maxCapableModel = buildModel({
+			id: "mock-max-capable",
+			name: "Mock Max Capable",
+			api: "openai-completions",
+			provider: "mock",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			thinking: { mode: "effort", efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max] },
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 4096,
+		});
+		const xhighCeilingModel = buildModel({
+			id: "mock-xhigh-ceiling",
+			name: "Mock XHigh Ceiling",
+			api: "openai-completions",
+			provider: "mock",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			thinking: { mode: "effort", efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh] },
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 4096,
+		});
+		const noEffortModel = {
+			id: "no-effort",
+			name: "No Effort",
+			api: "openai-completions",
+			provider: "mock",
+			baseUrl: "https://example.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 4096,
+		} as Model;
+
+		expect(getAvailableThinkingLevelsForModel(maxCapableModel)).toEqual([
+			Effort.Low,
+			Effort.Medium,
+			Effort.High,
+			Effort.XHigh,
+			Effort.Max,
+			ThinkingLevel.Ultra,
+		]);
+		expect(getAvailableThinkingLevelsForModel(xhighCeilingModel)).toEqual([
+			Effort.Low,
+			Effort.Medium,
+			Effort.High,
+			Effort.XHigh,
+		]);
+		expect(resolveThinkingLevelForModel(maxCapableModel, ThinkingLevel.Ultra)).toBe(ThinkingLevel.Ultra);
+		expect(resolveThinkingLevelForModel(xhighCeilingModel, ThinkingLevel.Ultra)).toBe(Effort.XHigh);
+		expect(resolveThinkingLevelForModel(noEffortModel, ThinkingLevel.Ultra)).toBeUndefined();
 	});
 
 	it("parses max as a real thinking level", () => {

--- a/packages/coding-agent/test/cli/completions.test.ts
+++ b/packages/coding-agent/test/cli/completions.test.ts
@@ -211,7 +211,7 @@ describe("omp completions (integration / drift)", () => {
 		}
 		expect(stdout).toContain("{-r,--resume}");
 		// Real enum option sets flow through unchanged.
-		expect(stdout).toContain(":value:(off minimal low medium high xhigh max auto)");
+		expect(stdout).toContain(":value:(off minimal low medium high xhigh max ultra auto)");
 		expect(stdout).toContain(":value:(always-ask write yolo)");
 		// Real subcommands present; dynamic callbacks wired.
 		expect(stdout).toContain("_omp_cmd_commit");

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
-import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -27,6 +27,7 @@ function makeTool(name: string): AgentTool {
 interface HarnessOptions {
 	extraRegistryTools?: readonly AgentTool[];
 	builtInToolNames?: Iterable<string>;
+	modelId?: string;
 }
 
 describe("InteractiveMode plan.defaultOnStartup", () => {
@@ -74,7 +75,7 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 	 *  entries still have built-in provenance after extension shadowing. */
 	function createHarness(settings: Settings, options: HarnessOptions = {}): InteractiveMode {
 		const registry = new ModelRegistry(authStorage, path.join(tempDir.path(), `models-${Bun.nanoseconds()}.yml`));
-		const initialModel = modelOrThrow(registry, "claude-sonnet-4-5");
+		const initialModel = modelOrThrow(registry, options.modelId ?? "claude-sonnet-4-5");
 		const readTool = makeTool("read");
 		const resolveTool = makeTool("resolve");
 		// AgentSession requires a Map-typed tool registry; the harness needs both
@@ -116,6 +117,28 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		expect(created.planModeEnabled).toBe(true);
 		expect(session?.getPlanModeState()).toMatchObject({ enabled: true, planFilePath: "local://PLAN.md" });
 		expect(session?.getActiveToolNames()).toContain("resolve");
+	});
+
+	it("does not turn temporary plan tool reconciliation into an Ultra task exclusion", async () => {
+		const taskTool = makeTool("task");
+		const created = createHarness(Settings.isolated({ "compaction.enabled": false }), {
+			extraRegistryTools: [taskTool],
+			builtInToolNames: ["read", "resolve", "task"],
+			modelId: "claude-opus-4-7",
+		});
+		session?.setThinkingLevel(Effort.Max);
+
+		expect(session?.getActiveToolNames()).not.toContain("task");
+		await created.handlePlanModeCommand();
+		await created.handlePlanModeCommand();
+		await created.handlePlanModeCommand();
+
+		session?.setThinkingLevel(ThinkingLevel.Ultra);
+		const promptSpy = vi.spyOn(session!.agent, "prompt").mockResolvedValue(undefined);
+		await session?.prompt("delegate after leaving plan mode");
+
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		expect(session?.getActiveToolNames()).toContain("task");
 	});
 
 	it("activates write when entering plan mode even if it was hidden by discoveryMode (issue #3165)", async () => {

--- a/packages/coding-agent/test/model-hub.test.ts
+++ b/packages/coding-agent/test/model-hub.test.ts
@@ -6,6 +6,7 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { thinkingLevelGlyph } from "@oh-my-pi/pi-coding-agent/modes/components/model-browser";
 import {
 	type ModelHubCallbacks,
 	ModelHubComponent,
@@ -171,6 +172,11 @@ describe("ModelHub", () => {
 			expect(rendered).toContain("●smol");
 		});
 
+		test("defines a compact glyph for ultra thinking", () => {
+			installTestTheme();
+			expect(thinkingLevelGlyph(ThinkingLevel.Ultra)).toBeTruthy();
+		});
+
 		test("list rows carry no role chips; only the selected model's detail line is tagged", () => {
 			const settings = Settings.isolated({});
 			const haiku = makeModel("test", "claude-haiku-4.5");
@@ -207,6 +213,30 @@ describe("ModelHub", () => {
 			expect(defaultRow).toContain("auto");
 			expect(defaultRow).not.toContain("inherit");
 			expect(smolRow).toContain("auto");
+		});
+
+		test("roles view resolves default ultra to the selected model ceiling", () => {
+			const model = getBundledModel("openai", "gpt-5.5");
+			if (!model) throw new Error("Expected bundled model openai/gpt-5.5");
+			const settings = Settings.isolated({
+				cycleOrder: ["default", "slow"],
+				defaultThinkingLevel: ThinkingLevel.Ultra,
+				modelRoles: {
+					default: `${model.provider}/${model.id}`,
+					slow: `${model.provider}/${model.id}:ultra`,
+				},
+			});
+			const { hub } = createHub({ models: [model], scoped: true, settings });
+			installTestTheme();
+
+			hub.handleInput(UP); // All models → Roles (since Recent is removed)
+			const lines = hub.render(220).map(line => stripVTControlCharacters(line));
+			const defaultRow = lines.find(line => line.includes("DEFAULT"));
+			const slowRow = lines.find(line => line.includes("SLOW"));
+			expect(defaultRow).toContain("xhigh");
+			expect(defaultRow).not.toContain("ultra");
+			expect(slowRow).toContain("xhigh");
+			expect(slowRow).not.toContain("ultra");
 		});
 
 		test("x clears a configured role back to auto-selection", () => {
@@ -358,6 +388,7 @@ describe("ModelHub", () => {
 			expect(thinking).toContain("inherit");
 			expect(thinking).toContain("xhigh");
 			expect(thinking).not.toContain("max");
+			expect(thinking).not.toContain("ultra");
 		});
 
 		test("renders max as a real final tier on max-capable models (gpt-5.6)", () => {
@@ -371,6 +402,7 @@ describe("ModelHub", () => {
 			const thinking = footerLine(hub.render(220));
 			expect(thinking).toContain("xhigh");
 			expect(thinking).toContain("max");
+			expect(thinking).toContain("ultra");
 		});
 
 		test("Enter on a chip already holding this model unassigns it", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -495,6 +495,18 @@ describe("parseModelPattern", () => {
 			expect(result.warning).toBeUndefined();
 		});
 
+		test("max suffix parsing is not captured by a fuzzy literal max model", () => {
+			const fuzzyLiteralMax = {
+				...mockMaxSuffixModels[1],
+				id: "coding-router-preview:max",
+				name: "NanoGPT Coding Router Preview Max",
+			};
+			const result = parseModelPattern("nanogpt/coding-router:max", [mockMaxSuffixModels[0], fuzzyLiteralMax]);
+			expect(result.model?.id).toBe("coding-router");
+			expect(result.thinkingLevel).toBe(Effort.Max);
+			expect(result.explicitThinkingLevel).toBe(true);
+		});
+
 		test("literal model ids ending in auto win over the auto sentinel alias", () => {
 			const result = parseModelPattern("example/runtime:auto", mockAutoSuffixModels);
 			expect(result.model?.id).toBe("runtime:auto");
@@ -517,6 +529,38 @@ describe("parseModelPattern", () => {
 			expect(result.thinkingLevel).toBeUndefined();
 			expect(result.explicitThinkingLevel).toBe(false);
 			expect(result.warning).toBeUndefined();
+		});
+
+		test("ultra suffix parsing is not captured by a fuzzy literal ultra model", () => {
+			const fuzzyLiteralUltra = {
+				...mockUltraSuffixModels[1],
+				id: "coding-router-preview:ultra",
+				name: "NanoGPT Coding Router Preview Ultra",
+			};
+			const result = parseModelPattern("nanogpt/coding-router:ultra", [mockUltraSuffixModels[0], fuzzyLiteralUltra]);
+			expect(result.model?.id).toBe("coding-router");
+			expect(result.thinkingLevel).toBe(ThinkingLevel.Ultra);
+			expect(result.explicitThinkingLevel).toBe(true);
+		});
+
+		test("stacked selectors resolve their exact inner literal before fuzzy suffix models", () => {
+			const fuzzyUltra = {
+				...mockUltraSuffixModels[1],
+				id: "coding-router-max-preview:ultra",
+			};
+			const ultraResult = parseModelPattern("nanogpt/coding-router:max:ultra", [mockMaxSuffixModels[1], fuzzyUltra]);
+			expect(ultraResult.model?.id).toBe("coding-router:max");
+			expect(ultraResult.thinkingLevel).toBe(ThinkingLevel.Ultra);
+			expect(ultraResult.explicitThinkingLevel).toBe(true);
+
+			const fuzzyMax = {
+				...mockMaxSuffixModels[1],
+				id: "coding-router-ultra-preview:max",
+			};
+			const maxResult = parseModelPattern("nanogpt/coding-router:ultra:max", [mockUltraSuffixModels[1], fuzzyMax]);
+			expect(maxResult.model?.id).toBe("coding-router:ultra");
+			expect(maxResult.thinkingLevel).toBe(Effort.Max);
+			expect(maxResult.explicitThinkingLevel).toBe(true);
 		});
 	});
 
@@ -1140,6 +1184,12 @@ describe("resolveCliModel", () => {
 				getAll: () => [defaultBedrockModel],
 			},
 		});
+		const bareMaxLiteralResult = resolveCliModel({
+			cliModel: `${profileArn}:max`,
+			modelRegistry: {
+				getAll: () => [defaultBedrockModel],
+			},
+		});
 
 		expect(baseResult.error).toBeUndefined();
 		expect(baseResult.model?.provider).toBe("amazon-bedrock");
@@ -1154,6 +1204,9 @@ describe("resolveCliModel", () => {
 		expect(offResult.error).toBeUndefined();
 		expect(offResult.model?.id).toBe(profileArn);
 		expect(offResult.thinkingLevel).toBe("off");
+		expect(bareMaxLiteralResult.error).toBeUndefined();
+		expect(bareMaxLiteralResult.model?.id).toBe(`${profileArn}:max`);
+		expect(bareMaxLiteralResult.thinkingLevel).toBeUndefined();
 	});
 
 	test("returns a clear error when there are no models", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { DEFAULT_MODEL_PER_PROVIDER } from "@oh-my-pi/pi-catalog/provider-models";
@@ -6,6 +7,7 @@ import {
 	expandRoleAlias,
 	extractExplicitThinkingSelector,
 	filterAvailableModelsByEnabledPatterns,
+	findInitialModel,
 	parseModelPattern,
 	parseModelString,
 	pickDefaultAvailableModel,
@@ -132,6 +134,37 @@ const mockMaxSuffixModels: Model<Api>[] = [
 	buildModel({
 		id: "coding-router:max",
 		name: "NanoGPT Coding Router Max",
+		api: "openai-completions",
+		provider: "nanogpt",
+		baseUrl: "https://nano-gpt.com/api/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	}),
+];
+
+const mockUltraSuffixModels: Model<Api>[] = [
+	buildModel({
+		id: "coding-router",
+		name: "NanoGPT Coding Router",
+		api: "openai-completions",
+		provider: "nanogpt",
+		baseUrl: "https://nano-gpt.com/api/v1",
+		reasoning: true,
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+		},
+		input: ["text"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 8192,
+	}),
+	buildModel({
+		id: "coding-router:ultra",
+		name: "NanoGPT Coding Router Ultra",
 		api: "openai-completions",
 		provider: "nanogpt",
 		baseUrl: "https://nano-gpt.com/api/v1",
@@ -469,6 +502,22 @@ describe("parseModelPattern", () => {
 			expect(result.explicitThinkingLevel).toBe(false);
 			expect(result.warning).toBeUndefined();
 		});
+
+		test("ultra parses as a guarded thinking suffix after the literal pattern misses", () => {
+			const result = parseModelPattern("nanogpt/coding-router:ultra", [mockUltraSuffixModels[0]]);
+			expect(result.model?.id).toBe("coding-router");
+			expect(result.thinkingLevel).toBe(ThinkingLevel.Ultra);
+			expect(result.explicitThinkingLevel).toBe(true);
+			expect(result.warning).toBeUndefined();
+		});
+
+		test("literal model ids ending in ultra win over the thinking suffix", () => {
+			const result = parseModelPattern("nanogpt/coding-router:ultra", mockUltraSuffixModels);
+			expect(result.model?.id).toBe("coding-router:ultra");
+			expect(result.thinkingLevel).toBeUndefined();
+			expect(result.explicitThinkingLevel).toBe(false);
+			expect(result.warning).toBeUndefined();
+		});
 	});
 
 	describe("patterns with invalid thinking levels", () => {
@@ -714,6 +763,24 @@ describe("resolveModelRoleValue", () => {
 		expect(result.model?.provider).toBe("anthropic");
 		expect(result.model?.id).toBe("claude-opus-4-7");
 		expect(result.thinkingLevel).toBe(Effort.Max);
+		expect(result.explicitThinkingLevel).toBe(true);
+	});
+
+	test("preserves ultra when the resolved model advertises max", () => {
+		const result = resolveModelRoleValue("anthropic/claude-opus-4-7:ultra", mockMaxCapableModels);
+
+		expect(result.model?.provider).toBe("anthropic");
+		expect(result.model?.id).toBe("claude-opus-4-7");
+		expect(result.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(result.explicitThinkingLevel).toBe(true);
+	});
+
+	test("degrades ultra to the model ceiling when max is not advertised", () => {
+		const result = resolveModelRoleValue("nanogpt/coding-router:ultra", [mockMaxSuffixModels[0]]);
+
+		expect(result.model?.provider).toBe("nanogpt");
+		expect(result.model?.id).toBe("coding-router");
+		expect(result.thinkingLevel).toBe(Effort.XHigh);
 		expect(result.explicitThinkingLevel).toBe(true);
 	});
 
@@ -1163,6 +1230,60 @@ describe("resolveCliModel", () => {
 	});
 });
 
+describe("findInitialModel", () => {
+	test("keeps existing default-selector clamping for models without controllable efforts", async () => {
+		const noEffortModel = {
+			id: "glm-5-2",
+			name: "GLM-5.2",
+			api: "devin-agent",
+			provider: "devin",
+			baseUrl: "https://server.codeium.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 4096,
+		} as Model<Api>;
+		const registry = {
+			find: (provider: string, id: string) =>
+				provider === noEffortModel.provider && id === noEffortModel.id ? noEffortModel : undefined,
+			getAvailable: () => [noEffortModel],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: noEffortModel.provider,
+			defaultModelId: noEffortModel.id,
+			defaultThinkingSelector: Effort.High,
+			modelRegistry: registry,
+		});
+
+		expect(result.model?.id).toBe(noEffortModel.id);
+		expect(result.thinkingLevel).toBeUndefined();
+	});
+
+	test("degrades initial ultra defaults through the existing max clamp", async () => {
+		const [model] = mockMaxSuffixModels;
+		const registry = {
+			find: (provider: string, id: string) => (provider === model.provider && id === model.id ? model : undefined),
+			getAvailable: () => [model],
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRegistry"];
+
+		const result = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: model.provider,
+			defaultModelId: model.id,
+			defaultThinkingSelector: ThinkingLevel.Ultra,
+			modelRegistry: registry,
+		});
+
+		expect(result.model?.id).toBe("coding-router");
+		expect(result.thinkingLevel).toBe(Effort.XHigh);
+	});
+});
+
 describe("resolveModelScope", () => {
 	test("does not coalesce explicit provider/id patterns to Codex (regression for enabledModels)", async () => {
 		const scoped = await resolveModelScope(["openai/gpt-5.5"], {
@@ -1317,6 +1438,24 @@ describe("parseModelString", () => {
 			expect(result).toEqual({ provider: "example", id: "runtime:auto" });
 		});
 
+		test("extracts ultra when explicitly enabled for provider id selectors", () => {
+			const result = parseModelString("deepseek/deepseek-v4-pro:ultra", { allowUltraSuffix: true });
+			expect(result).toEqual({ provider: "deepseek", id: "deepseek-v4-pro", thinkingLevel: ThinkingLevel.Ultra });
+		});
+
+		test("preserves literal ultra model ids when the caller can prove they exist", () => {
+			const result = parseModelString("nanogpt/coding-router:ultra", {
+				allowUltraSuffix: true,
+				isLiteralModelId: (provider, id) => provider === "nanogpt" && id === "coding-router:ultra",
+			});
+			expect(result).toEqual({ provider: "nanogpt", id: "coding-router:ultra" });
+		});
+
+		test("leaves :ultra attached to the model id unless the caller opts in via allowUltraSuffix", () => {
+			const result = parseModelString("anthropic/claude-sonnet-4-5:ultra");
+			expect(result).toEqual({ provider: "anthropic", id: "claude-sonnet-4-5:ultra" });
+		});
+
 		test("does not strip inherited object keys as thinking suffixes", () => {
 			const result = parseModelString("anthropic/claude-sonnet-4-5:constructor");
 			expect(result).toEqual({ provider: "anthropic", id: "claude-sonnet-4-5:constructor" });
@@ -1352,6 +1491,18 @@ describe("resolveModelFromString", () => {
 		const result = resolveModelFromString("example/runtime:auto", mockAutoSuffixModels);
 		expect(result?.provider).toBe("example");
 		expect(result?.id).toBe("runtime:auto");
+	});
+
+	test("applies ultra as a provider model selector alias after literal lookup misses", () => {
+		const result = resolveModelFromString("nanogpt/coding-router:ultra", [mockUltraSuffixModels[0]]);
+		expect(result?.provider).toBe("nanogpt");
+		expect(result?.id).toBe("coding-router");
+	});
+
+	test("preserves literal ultra provider model ids before alias parsing", () => {
+		const result = resolveModelFromString("nanogpt/coding-router:ultra", mockUltraSuffixModels);
+		expect(result?.provider).toBe("nanogpt");
+		expect(result?.id).toBe("coding-router:ultra");
 	});
 });
 
@@ -1407,6 +1558,20 @@ describe("extractExplicitThinkingSelector", () => {
 			isLiteralModelId: () => false,
 		});
 		expect(result).toBe("auto");
+	});
+
+	test("does not carry ultra from literal role model ids", () => {
+		const result = extractExplicitThinkingSelector("nanogpt/coding-router:ultra", undefined, {
+			isLiteralModelId: (provider, id) => provider === "nanogpt" && id === "coding-router:ultra",
+		});
+		expect(result).toBeUndefined();
+	});
+
+	test("treats ultra as an explicit selector when the model id is not literal", () => {
+		const result = extractExplicitThinkingSelector("nanogpt/coding-router:ultra", undefined, {
+			isLiteralModelId: () => false,
+		});
+		expect(result).toBe(ThinkingLevel.Ultra);
 	});
 });
 

--- a/packages/coding-agent/test/modes/components/settings-selector-memory-refresh.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-selector-memory-refresh.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { SettingsSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/settings-selector";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -39,7 +40,10 @@ function stubStdoutGeometry(cols: number): { restore(): void } {
 	};
 }
 
-function createSelector(onCancel: () => void = () => {}): SettingsSelectorComponent {
+function createSelector(
+	onCancel: () => void = () => {},
+	contextOverrides: Partial<ConstructorParameters<typeof SettingsSelectorComponent>[0]> = {},
+): SettingsSelectorComponent {
 	return new SettingsSelectorComponent(
 		{
 			availableThinkingLevels: [],
@@ -47,6 +51,7 @@ function createSelector(onCancel: () => void = () => {}): SettingsSelectorCompon
 			availableThemes: ["dark"],
 			providers: [],
 			cwd: process.cwd(),
+			...contextOverrides,
 		},
 		{
 			onChange: () => {},
@@ -62,6 +67,22 @@ function focusMemoryTab(comp: SettingsSelectorComponent): void {
 	}
 }
 
+describe("SettingsSelectorComponent model tab", () => {
+	it("includes agent-local ultra in the runtime thinking submenu", () => {
+		const comp = createSelector(() => {}, {
+			availableThinkingLevels: [ThinkingLevel.Max, ThinkingLevel.Ultra],
+		});
+
+		comp.handleInput("\x1b[C");
+		const modelTab = comp.render(120).join("\n");
+		expect(modelTab).toContain("Thinking Level");
+
+		comp.handleInput("\n");
+		const submenu = comp.render(120).join("\n");
+		expect(submenu).toContain("max");
+		expect(submenu).toContain("ultra");
+	});
+});
 describe("SettingsSelectorComponent memory tab", () => {
 	it("reveals condition-gated Hindsight rows the moment memory.backend changes via the submenu", () => {
 		settings.set("memory.backend", "off");

--- a/packages/coding-agent/test/rpc.test.ts
+++ b/packages/coding-agent/test/rpc.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AgentEvent, AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { type AgentEvent, type AgentMessage, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type AssistantMessage, Effort, type TextContent } from "@oh-my-pi/pi-ai";
 import {
 	type CompactionEntry,
@@ -11,6 +11,12 @@ import {
 	type SessionMessageEntry,
 } from "@oh-my-pi/pi-coding-agent";
 import { RpcClient } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-client";
+import {
+	dispatchRpcInputFrame,
+	type PendingExtensionRequest,
+	type RpcInputFrameDeps,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import type { RpcCommand, RpcResponse } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-types";
 import type { BashExecutionMessage } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { e2eApiKey } from "./utilities";
@@ -24,6 +30,76 @@ const isAssistantMessage = (message: AgentMessage): message is AssistantMessage 
 const isSessionMessageEntry = (entry: FileEntry): entry is SessionMessageEntry => entry.type === "message";
 
 const isCompactionEntry = (entry: FileEntry): entry is CompactionEntry => entry.type === "compaction";
+
+const ULTRA_THINKING_LEVEL = ThinkingLevel.Ultra;
+
+function createRpcDispatchDeps(
+	handleCommand: (command: RpcCommand) => Promise<RpcResponse>,
+	outputs: object[],
+): RpcInputFrameDeps {
+	return {
+		handleCommand,
+		output: obj => {
+			outputs.push(obj);
+		},
+		errorResponse: (id, command, message) => ({
+			id,
+			type: "response",
+			command,
+			success: false,
+			error: message,
+		}),
+		pendingExtensionRequests: new Map<string, PendingExtensionRequest>(),
+		onHostToolResult: () => {},
+		onHostToolUpdate: () => {},
+		onHostUriResult: () => {},
+	};
+}
+
+test("RPC dispatch preserves Ultra set_thinking_level selector strings", async () => {
+	const outputs: object[] = [];
+	const handled: RpcCommand[] = [];
+	const command = { id: "set-ultra", type: "set_thinking_level", level: ULTRA_THINKING_LEVEL } satisfies RpcCommand;
+	const deps = createRpcDispatchDeps(async frame => {
+		handled.push(frame);
+		if (frame.type !== command.type) {
+			return {
+				id: frame.id,
+				type: "response",
+				command: frame.type,
+				success: false,
+				error: `Unexpected command: ${frame.type}`,
+			};
+		}
+		return { id: frame.id, type: "response", command: frame.type, success: true };
+	}, outputs);
+
+	const dispatched = dispatchRpcInputFrame(command, deps);
+	expect(dispatched).toBeInstanceOf(Promise);
+	await dispatched;
+
+	expect(handled).toEqual([command]);
+	expect(outputs).toEqual([{ id: "set-ultra", type: "response", command: "set_thinking_level", success: true }]);
+});
+
+test("RPC dispatch round-trips Ultra cycle_thinking_level responses", async () => {
+	const outputs: object[] = [];
+	const response = {
+		id: "cycle-ultra",
+		type: "response",
+		command: "cycle_thinking_level",
+		success: true,
+		data: { level: ULTRA_THINKING_LEVEL },
+	} satisfies RpcResponse;
+	const deps = createRpcDispatchDeps(async command => {
+		expect(command.type).toBe("cycle_thinking_level");
+		return response;
+	}, outputs);
+
+	await dispatchRpcInputFrame({ id: "cycle-ultra", type: "cycle_thinking_level" } satisfies RpcCommand, deps);
+
+	expect(outputs).toEqual([response]);
+});
 
 /**
  * RPC mode tests.

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -45,6 +45,26 @@ function createReasoningModel(): Model<"openai-responses"> {
 	});
 }
 
+function createMaxReasoningModel(): Model<"openai-responses"> {
+	return buildModel({
+		id: "mock-max-reasoning",
+		name: "mock-max-reasoning",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: true,
+		thinking: {
+			mode: "effort",
+			efforts: [Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+			defaultLevel: Effort.High,
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	});
+}
+
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
 
 describe("createAgentSession MCP discovery prompt gating", () => {
@@ -197,6 +217,103 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 			enableLsp: false,
 		});
 
+		expect(session.getActiveToolNames()).not.toContain("task");
+		await session.dispose();
+	});
+
+	it("force-activates task for implicit root Ultra under tools.discoveryMode all", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all" }),
+			model: createMaxReasoningModel(),
+			thinkingLevel: ThinkingLevel.Ultra,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		const prompt = session.systemPrompt.join("\n");
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(session.getActiveToolNames()).toContain("task");
+		expect(prompt).not.toContain("Delegation is preferred here");
+		expect(prompt).not.toContain("Delegation is the default here");
+		await session.dispose();
+	});
+
+	it("keeps ordinary Max discoverable under tools.discoveryMode all when task.eager is defaulted", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all" }),
+			model: createMaxReasoningModel(),
+			thinkingLevel: ThinkingLevel.Max,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Max);
+		expect(session.getActiveToolNames()).not.toContain("task");
+		await session.dispose();
+	});
+
+	it("keeps task discoverable when explicit task.eager default suppresses implicit Ultra activation", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all", "task.eager": "default" }),
+			model: createMaxReasoningModel(),
+			thinkingLevel: ThinkingLevel.Ultra,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(session.getActiveToolNames()).not.toContain("task");
+		await session.dispose();
+	});
+
+	it("keeps subagent Ultra task discoverable under tools.discoveryMode all", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all" }),
+			model: createMaxReasoningModel(),
+			thinkingLevel: ThinkingLevel.Ultra,
+			taskDepth: 1,
+			parentTaskPrefix: "SubAgent",
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
 		expect(session.getActiveToolNames()).not.toContain("task");
 		await session.dispose();
 	});

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -9,7 +9,7 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TOOL_DISCOVERY_AUTO_THRESHOLD } from "@oh-my-pi/pi-coding-agent/tool-discovery/mode";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
@@ -64,6 +64,19 @@ function createMaxReasoningModel(): Model<"openai-responses"> {
 		maxTokens: 2048,
 	});
 }
+
+const shadowTaskExtension: ExtensionFactory = pi => {
+	pi.registerTool({
+		name: "task",
+		label: "Shadow Task",
+		description: "A non-built-in task-shaped extension tool",
+		parameters: type({}),
+		defaultInactive: true,
+		async execute() {
+			return { content: [{ type: "text", text: "shadow task" }] };
+		},
+	});
+};
 
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
 
@@ -244,6 +257,31 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		expect(session.getActiveToolNames()).toContain("task");
 		expect(prompt).not.toContain("Delegation is preferred here");
 		expect(prompt).not.toContain("Delegation is the default here");
+		await session.dispose();
+	});
+
+	it("does not force-activate a task-named extension for implicit root Ultra", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all" }),
+			model: createMaxReasoningModel(),
+			thinkingLevel: ThinkingLevel.Ultra,
+			disableExtensionDiscovery: true,
+			extensions: [shadowTaskExtension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+		expect(session.hasBuiltInTool("task")).toBe(false);
+		expect(session.getActiveToolNames()).not.toContain("task");
 		await session.dispose();
 	});
 

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Effort, type FetchImpl } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
@@ -60,6 +61,26 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			],
 		});
 	};
+
+	function createMaxReasoningModel() {
+		return buildModel({
+			id: "runtime-max-reasoning-model",
+			name: "Runtime Max Reasoning Model",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://runtime.example.com/v1",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Medium, Effort.High, Effort.XHigh, Effort.Max],
+				defaultLevel: Effort.High,
+			},
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		});
+	}
 
 	const dynamicOnlyProviderConfig: ProviderConfigInput = {
 		baseUrl: "https://runtime.example.com/v1",
@@ -290,6 +311,40 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		// The extension model has no explicit ladder; the inferred fallback tops
 		// out at xhigh, so the real max level clamps down.
 		expect(session.thinkingLevel).toBe(Effort.XHigh);
+	});
+
+	test("preserves initial Ultra selector on session while Agent starts with max effort", async () => {
+		const authStorage = await AuthStorage.create(path.join(tempDir, "ultra-auth.db"));
+		authStoragesToClose.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "ultra-models.yml"));
+		const sessionManager = SessionManager.inMemory();
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated(),
+			model: createMaxReasoningModel(),
+			thinkingLevel: ThinkingLevel.Ultra,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		try {
+			expect(session.thinkingLevel).toBe(ThinkingLevel.Ultra);
+			expect(session.agent.state.thinkingLevel).toBe(Effort.Max);
+			expect(session.agent.state.thinkingLevel).not.toBe(ThinkingLevel.Ultra);
+			expect(sessionManager.buildSessionContext().thinkingLevel).toBe(ThinkingLevel.Ultra);
+		} finally {
+			await session.dispose();
+		}
 	});
 
 	test("selects the settings default model without synchronously validating auth", async () => {

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -537,6 +537,75 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		}
 	});
 
+	test("preserves restore warning when post-extension retry reselects the default fallback", async () => {
+		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) {
+			throw new Error("Expected bundled anthropic default model");
+		}
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "resume-warning-auth.db"));
+		authStorage.setRuntimeApiKey(defaultModel.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "resume-warning-models.yml"));
+
+		const missingRoleModel = "runtime-provider/missing-model";
+		const targetSessionFile = path.join(tempDir, "resume-warning.jsonl");
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "resume-warning", timestamp, cwd: tempDir },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: `${defaultModel.provider}/${defaultModel.id}`,
+					role: "default",
+				},
+				{
+					type: "model_change",
+					id: "smol-model",
+					parentId: "default-model",
+					timestamp,
+					model: missingRoleModel,
+					role: "smol",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		const sessionManager = await SessionManager.open(
+			targetSessionFile,
+			path.join(tempDir, "resume-warning-sessions"),
+		);
+
+		const { session, modelFallbackMessage } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe(defaultModel.provider);
+			expect(session.model?.id).toBe(defaultModel.id);
+			expect(modelFallbackMessage).toContain(`Could not restore model ${missingRoleModel}`);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
 	test("prefers the provider default over catalog order in the startup fallback", async () => {
 		// Regression: with an Anthropic key but no configured `default` role and no
 		// session/CLI model, the step-4 startup fallback used to pick the first
@@ -681,6 +750,78 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			expect(session.model?.provider).toBe("runtime-provider");
 			expect(session.model?.id).toBe("runtime-reasoning-model");
 			expect(session.thinkingLevel).toBe(Effort.XHigh);
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
+
+	test("rechecks a restored Ultra-suffixed literal model after extension registration", async () => {
+		const authStorage = await AuthStorage.create(path.join(tempDir, "resume-literal-ultra-auth.db"));
+		authStorage.setRuntimeApiKey("openai", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "literal-ultra-models.yml"));
+
+		const targetSessionFile = path.join(tempDir, "resume-literal-ultra.jsonl");
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "resume-literal-ultra", timestamp, cwd: tempDir },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: "openai/gpt-4o:ultra",
+					role: "default",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir, "literal-ultra-sessions"));
+		const literalUltraProvider: ExtensionFactory = pi => {
+			pi.registerProvider("openai", {
+				baseUrl: "https://runtime-openai.example.com/v1",
+				apiKey: "test-key",
+				api: "openai-completions",
+				models: [
+					{
+						id: "gpt-4o:ultra",
+						name: "Literal Ultra Model",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 8192,
+					},
+				],
+			});
+		};
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			extensions: [literalUltraProvider],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("openai");
+			expect(session.model?.id).toBe("gpt-4o:ultra");
+			expect(session.thinkingLevel).not.toBe(ThinkingLevel.Ultra);
+			expect(session.agent.state.thinkingLevel).toBeUndefined();
 		} finally {
 			await session.dispose();
 			authStorage.close();

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { Effort } from "@oh-my-pi/pi-ai";
+import { Effort, THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { clearCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import { createMockModel, registerMockApi } from "@oh-my-pi/pi-ai/providers/mock";
 import { __providerInFlightForTesting, streamSimple } from "@oh-my-pi/pi-ai/stream";
@@ -137,6 +137,16 @@ describe("Settings", () => {
 			const settings = Settings.isolated();
 			expect(settings.get("providers.maxInFlightRequests")).toEqual({});
 			expect(getDefault("providers.maxInFlightRequests")).toEqual({});
+		});
+
+		it("accepts ultra in config without adding it to provider effort metadata", () => {
+			const values = getEnumValues("defaultThinkingLevel");
+			expect(values).toContain("ultra");
+			expect(values).toContain(Effort.Max);
+			expect(THINKING_EFFORTS).not.toContain("ultra");
+
+			const settings = Settings.isolated({ defaultThinkingLevel: "ultra" });
+			expect(settings.get("defaultThinkingLevel")).toBe("ultra");
 		});
 
 		it("exposes all tool calling mode options", () => {

--- a/packages/coding-agent/test/status-line-model.test.ts
+++ b/packages/coding-agent/test/status-line-model.test.ts
@@ -69,13 +69,16 @@ describe("status line model segment advisor badge", () => {
 });
 
 describe("status line model segment compact thinking level", () => {
-	function createThinkingContext(compactThinkingLevel: boolean): SegmentContext {
+	function createThinkingContext(
+		compactThinkingLevel: boolean,
+		level: ThinkingLevel = ThinkingLevel.High,
+	): SegmentContext {
 		return {
 			...createModelContext(false),
 			session: {
 				state: {
 					model: { id: "test-model", name: "Test Model", thinking: true },
-					thinkingLevel: ThinkingLevel.High,
+					thinkingLevel: level,
 				},
 				isFastModeActive: () => false,
 				isAutoThinking: false,
@@ -90,6 +93,13 @@ describe("status line model segment compact thinking level", () => {
 		const display = theme.thinking.high;
 		const modelPrefix = theme.icon.model ? `${theme.icon.model} ` : "";
 		const rendered = renderSegment("model", createThinkingContext(false));
+		expect(Bun.stripANSI(rendered.content)).toBe(`${modelPrefix}Test Model${theme.sep.dot}${display}`);
+	});
+
+	it("renders Ultra with Max's thinking suffix when compact mode is off", () => {
+		const display = theme.thinking.max;
+		const modelPrefix = theme.icon.model ? `${theme.icon.model} ` : "";
+		const rendered = renderSegment("model", createThinkingContext(false, ThinkingLevel.Ultra));
 		expect(Bun.stripANSI(rendered.content)).toBe(`${modelPrefix}Test Model${theme.sep.dot}${display}`);
 	});
 

--- a/packages/coding-agent/test/theme-islight.test.ts
+++ b/packages/coding-agent/test/theme-islight.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { generateThemeVars } from "@oh-my-pi/pi-coding-agent/export/html";
 import { defaultThemes } from "@oh-my-pi/pi-coding-agent/modes/theme/defaults";
 import { getResolvedThemeColors, getThemeByName, isLightTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -15,6 +16,14 @@ describe("Theme.isLight", () => {
 		expect((await getThemeByName("porcelain"))?.isLight).toBe(true);
 		expect((await getThemeByName("light-catppuccin"))?.isLight).toBe(true);
 		expect((await getThemeByName("dark-catppuccin"))?.isLight).toBe(false);
+	});
+
+	it("renders ultra with max's thinking border treatment", async () => {
+		const theme = await getThemeByName("dark");
+		if (!theme) throw new Error("Expected built-in dark theme");
+		expect(theme.getThinkingBorderColor(ThinkingLevel.Ultra)("sample")).toBe(
+			theme.getThinkingBorderColor(ThinkingLevel.Max)("sample"),
+		);
 	});
 
 	it("exposes the status-line surface luminance for accent sizing", async () => {


### PR DESCRIPTION
## Summary

Adds an agent-local `Ultra` thinking selector to OMP, compatible with the current OpenAI Codex behavior while keeping OMP's provider contracts unchanged.

- Exposes Ultra across CLI/config, current ModelHub/ModelBrowser UI, model suffixes, ACP, RPC, SDK, themes, and session persistence.
- Offers Ultra only when the selected model advertises real `max`; unsupported models use the existing model-aware clamp.
- Lowers Ultra to provider-facing `reasoning.effort=max`, including compaction/handoff calls. No provider or catalog `Effort.Ultra` value is introduced.
- Enables conditional, root-session proactive delegation through OMP's existing `task` runtime.
- Preserves explicit `task.eager` settings and startup/runtime tool exclusions, including exclusions made before the first turn and across logical A→B→A session switches.
- Keeps internal discovery, MCP, and temporary plan/goal tool reconciliation neutral rather than treating it as user intent.
- Yields to upstream vibe mode's exclusive worker runtime instead of re-adding `task`, then resumes Ultra orchestration after vibe exits.
- Reconciles Ultra guidance atomically across ordinary, synthetic/custom, queued streaming, resume/session-switch, retry, and post-compaction turns.
- Delivers hidden queued Ultra context with its intended one-at-a-time root without dropping concurrent enqueues, duplicating across steering/follow-up, or leaving context orphaned after queue restore.
- Keeps literal model IDs ending in `:ultra` authoritative before treating the token as a thinking suffix.

Related discussion: #4976. This PR also proposes a separate opt-in Ultra orchestration workflow; it does not close or claim acceptance of that enhancement request.

## Design notes

Ultra is deliberately represented as `ThinkingLevel.Ultra` in the agent/session layer, not as a provider effort. `AgentSession` retains that identity for UI, persistence, and orchestration, while the core `Agent` receives `Effort.Max`. This keeps existing provider fallback behavior intact, including OpenAI's max-to-xhigh retry handling when a backend rejects `max`.

The orchestration prompt is a clean-room OMP implementation. It activates only for a root session with a Max-capable model, an available/requested `task` tool, and no explicit `task.eager` override. Leaving that state emits a hidden reset that returns control to OMP's standing task policy rather than forcing an explicit-only policy.

Queued transitions use a synchronous agent-owned live-queue transform after asynchronous context preparation. Generic queue companions travel with the next ordinary message under one-at-a-time delivery; steering retains priority over follow-up, hidden keyword/image notices remain attached to their user root, and queued vibe context receives the Ultra reset in the same model turn.

The branch is rebased onto current `main`. Upstream replaced the legacy ModelSelector while this PR was open, so Ultra behavior is ported into the current ModelHub/ModelBrowser architecture; the deleted selector and its legacy test suite remain deleted.

## Verification

Post-rebase verification on current `main` (base `79faf94f2`, head `c5d08d61c`):

- `bun run check` — pass (workspace formatting, lint, TypeScript, Rust check gate, and generated-doc index)
- All 18 focused Ultra test files — 516 pass, 13 intentional skips, 0 fail
- Cross-subsystem Ultra/ModelHub/vibe/mode/discovery/SDK matrix — 169 pass, 0 fail across 17 files
- `bun run ci:test:smoke` — pass
- `bun run --cwd packages/coding-agent build` — pass
- `git diff --check origin/main...HEAD` — pass

## Compatibility

- Existing Max behavior and transport fallback remain unchanged.
- `:max`, `:auto`, OpenRouter routing suffixes, role aliases, exact/literal model IDs, and non-reasoning models have dedicated regression coverage.
- Current upstream plan/goal/vibe behavior is preserved; Ultra yields while vibe mode owns orchestration, and post-compaction prepends retain duplicate suppression.
- Changelog entries are included for both `pi-agent-core` and `pi-coding-agent`.
