### PR TITLE
fix(agent): honor context abort before provider dispatch

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -73,6 +73,11 @@ import { yieldIfDue } from "./utils/yield";
 
 /** Stop-details marker for a provider error after assistant content/tool args already streamed. */
 export const STREAM_INTERRUPTED_AFTER_CONTENT_STOP_DETAIL = "stream_interrupted_after_content";
+/**
+ * Capability version for the guard that prevents provider dispatch after an
+ * asynchronous context transform aborts the current request.
+ */
+export const POST_TRANSFORM_ABORT_GUARD_VERSION = 1;
 
 /** Sentinel returned by the abort race in `streamAssistantResponse`. */
 const ABORTED: unique symbol = Symbol("agent-loop-aborted");
@@ -1221,6 +1226,12 @@ async function streamAssistantResponse(
 	let messages = context.messages;
 	if (config.transformContext) {
 		messages = await config.transformContext(messages, signal);
+	}
+
+	// A context extension may abort while transforming messages. Honor that
+	// cancellation before conversion, credential resolution, or provider dispatch.
+	if (signal?.aborted) {
+		return emitAbortedAssistantMessage(null, false, new Set(), context, config, stream, signal);
 	}
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -86,6 +86,38 @@ describe("agentLoop with AgentMessage", () => {
 		expect(events.map(event => event.type)).toContain("agent_end");
 	});
 
+	it("does not dispatch the provider after a context transform aborts", async () => {
+		const context: AgentContext = {
+			systemPrompt: ["You are helpful."],
+			messages: [],
+			tools: [],
+		};
+		const controller = new AbortController();
+		const mock = createMockModel({ responses: [{ content: ["Provider must not run"] }] });
+		let providerCalls = 0;
+		const provider = (...args: Parameters<typeof mock.stream>) => {
+			providerCalls++;
+			return mock.stream(...args);
+		};
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			transformContext: async messages => {
+				controller.abort("Context transform aborted this request");
+				return messages;
+			},
+		};
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, controller.signal, provider);
+		const messages = await stream.result();
+
+		expect(providerCalls).toBe(0);
+		const final = messages.at(-1);
+		expect(final?.role).toBe("assistant");
+		if (final?.role !== "assistant") throw new Error("expected aborted assistant message");
+		expect(final.stopReason).toBe("aborted");
+	});
+
 	it("returns detailed telemetry when awaiting detailed() directly", async () => {
 		const context: AgentContext = {
 			systemPrompt: ["You are helpful."],

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -7,6 +7,7 @@ export { Container, Markdown, Spacer, Text } from "@oh-my-pi/pi-tui";
 // Logging
 export { getAgentDir, logger, VERSION } from "@oh-my-pi/pi-utils";
 export * as zod from "zod/v4";
+export { countTokens, POST_TRANSFORM_ABORT_GUARD_VERSION } from "@oh-my-pi/pi-agent-core";
 export { z } from "zod/v4";
 export * from "./config/keybindings";
 export * from "./config/model-registry";


### PR DESCRIPTION
Adds POST_TRANSFORM_ABORT_GUARD_VERSION, returns the existing aborted assistant boundary immediately after an awaited context transform aborts, and re-exports the capability plus countTokens from the coding-agent package root. Includes a regression proving the provider stream function is not called.