### PR TITLE
fix(catalog): classify Z.ai GLM-5.2 anthropic-messages endpoint as budget-effort with high/max

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Z.ai GLM-5.2 on the `anthropic-messages` coding endpoint deriving `mode: "budget"` with five synthetic effort tiers instead of the wire-exact `anthropic-budget-effort` with `[high, max]`. The catalog now matches Z.ai's Anthropic proxy to the same two-tier reasoning scale as Umans, so `output_config.effort` is emitted on the wire.
+
 ## [16.4.1] - 2026-07-10
 
 ### Added

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -318,7 +318,7 @@ function getModelDefinedEfforts<TApi extends Api>(
 		}
 		if (
 			isZaiThinkingFormat(compat) ||
-			isUmansGlm52ReasoningEffortModel(spec) ||
+			isAnthropicMessagesGlm52ReasoningEffortModel(spec) ||
 			isOllamaCloudGlm52ReasoningEffortModel(spec) ||
 			spec.provider === "baseten"
 		) {
@@ -394,8 +394,12 @@ function isOllamaCloudGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpe
 	return spec.api === "ollama-chat" && spec.provider === "ollama-cloud" && isGlm52ReasoningEffortModelId(spec.id);
 }
 
-function isUmansGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
-	return spec.api === "anthropic-messages" && spec.provider === "umans" && isGlm52ReasoningEffortModelId(spec.id);
+function isAnthropicMessagesGlm52ReasoningEffortModel<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
+	return (
+		spec.api === "anthropic-messages" &&
+		(spec.provider === "umans" || spec.provider === "zai") &&
+		isGlm52ReasoningEffortModelId(spec.id)
+	);
 }
 
 function isMinimaxReasoningModelOnAnthropicEndpoint<TApi extends Api>(spec: ModelSpec<TApi>): boolean {
@@ -617,7 +621,7 @@ function inferThinkingControlMode<TApi extends Api>(
 			if (isMinimaxReasoningModelOnAnthropicEndpoint(spec)) {
 				return "anthropic-adaptive";
 			}
-			if (isUmansGlm52ReasoningEffortModel(spec)) {
+			if (isAnthropicMessagesGlm52ReasoningEffortModel(spec)) {
 				return "anthropic-budget-effort";
 			}
 			if (parsedModel.family === "anthropic") {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -88426,13 +88426,10 @@
 			"contextWindow": 1000000,
 			"maxTokens": 131072,
 			"thinking": {
-				"mode": "budget",
+				"mode": "anthropic-budget-effort",
 				"efforts": [
-					"minimal",
-					"low",
-					"medium",
 					"high",
-					"xhigh"
+					"max"
 				]
 			}
 		},

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -650,6 +650,23 @@ describe("model thinking derivation", () => {
 		expect(devin.thinking?.effortMap).toBeUndefined();
 		expect(devin.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.XHigh, Effort.Max]);
 	});
+	it("classifies Z.ai GLM-5.2 on the anthropic-messages coding endpoint as budget-effort with high/max", () => {
+		// Z.ai's anthropic-messages proxy (api.z.ai/api/anthropic) serves
+		// GLM-5.2 with the same two-tier high/max reasoning scale as Umans.
+		// The catalog must derive mode:"anthropic-budget-effort" (not plain
+		// "budget" with five synthetic tiers) so the wire encoder emits
+		// output_config.effort instead of only thinking.budget_tokens.
+		const model = createModel({
+			id: "glm-5.2",
+			api: "anthropic-messages",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/api/anthropic",
+		});
+
+		expect(model.thinking?.mode).toBe("anthropic-budget-effort");
+		expect(getSupportedEfforts(model)).toEqual([Effort.High, Effort.Max]);
+		expect(model.thinking?.effortMap).toBeUndefined();
+	});
 });
 
 describe("model thinking runtime helpers", () => {


### PR DESCRIPTION
## Problem

Z.ai GLM-5.2 on the `anthropic-messages` coding endpoint (`api.z.ai/api/anthropic`) was deriving `mode: "budget"` with five synthetic effort tiers (`minimal`→`xhigh`). The Z.ai docs confirm GLM-5.2 only supports `high` and `max` for `reasoning_effort`, and the existing Umans provider already implements this same two-tier scale. Because the catalog classified Z.ai as plain `budget` mode, `output_config.effort` was never emitted on the wire — only `thinking.budget_tokens`.

## Root Cause

`isUmansGlm52ReasoningEffortModel()` — the predicate that routes GLM-5.2 on `anthropic-messages` to the correct `[high, max]` effort list and `anthropic-budget-effort` mode — only matched `provider === "umans"`, not `provider === "zai"`.

## Fix

Generalized `isUmansGlm52ReasoningEffortModel` → `isAnthropicMessagesGlm52ReasoningEffortModel`, matching both `provider === "umans"` and `provider === "zai"`. Both call sites updated:
- `getModelDefinedEfforts` → now returns `[high, max]` for Z.ai GLM-5.2
- `inferThinkingControlMode` → now returns `"anthropic-budget-effort"` for Z.ai GLM-5.2

Regenerated `models.json` from the updated policy. The bundled `zai/glm-5.2` entry now has:
```json
"thinking": { "mode": "anthropic-budget-effort", "efforts": ["high", "max"] }
```
instead of the previous:
```json
"thinking": { "mode": "budget", "efforts": ["minimal", "low", "medium", "high", "xhigh"] }
```

## Verification

- `bun check` — passes (exit code 0)
- `bun test packages/catalog/test/model-thinking.test.ts` — 30 pass, 0 fail (includes new regression test)
- `bun test packages/catalog/test/umans-provider.test.ts packages/catalog/test/generated-policies.test.ts` — 21 pass, 0 fail
- `bun test packages/ai/test/anthropic-alignment.test.ts` — 84 pass, 0 fail

## Files Changed

- `packages/catalog/src/model-thinking.ts` — generalized predicate + both call sites
- `packages/catalog/src/models.json` — regenerated (zai/glm-5.2 thinking metadata)
- `packages/catalog/test/model-thinking.test.ts` — regression test for Z.ai GLM-5.2 on anthropic-messages
- `packages/catalog/CHANGELOG.md` — `[Unreleased] > Fixed` entry