### PR TITLE
fix(ai): accept null assistant chat content

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Chat Completions request parsing to accept assistant tool-call replay messages with `content: null` as absent content. ([#5121](https://github.com/can1357/oh-my-pi/issues/5121))
+
 ## [16.4.1] - 2026-07-10
 
 ### Changed

--- a/packages/ai/src/providers/openai-chat-server-schema.ts
+++ b/packages/ai/src/providers/openai-chat-server-schema.ts
@@ -114,6 +114,7 @@ export const toolChoiceSchema = type("'auto' | 'none' | 'required'")
 // ─── Messages ───────────────────────────────────────────────────────────────
 
 const baseContent = type("string").or(userContentPartSchema.array());
+const assistantContent = baseContent.or("null");
 
 export const systemMessageSchema = type({
 	role: "'system'",
@@ -132,7 +133,7 @@ export const userMessageSchema = type({
 
 export const assistantMessageSchema = type({
 	role: "'assistant'",
-	"content?": baseContent,
+	"content?": assistantContent,
 	"tool_calls?": toolCallSchema.array(),
 	// DeepSeek-style reasoning channel. The gateway emits it on the way out
 	// (encodeResponse/encodeStream); accept it back so thinking-mode

--- a/packages/ai/test/auth-gateway-openai-chat.test.ts
+++ b/packages/ai/test/auth-gateway-openai-chat.test.ts
@@ -153,6 +153,36 @@ describe("auth-gateway openai-chat: parseRequest", () => {
 		expect(parsed.stream).toBe(false);
 	});
 
+	it("accepts assistant null content when replaying tool calls", () => {
+		const parsed = parseRequest({
+			model: "m",
+			messages: [
+				{ role: "user", content: "weather?" },
+				{
+					role: "assistant",
+					content: null,
+					tool_calls: [{ id: "call_1", type: "function", function: { name: "get_weather", arguments: "{}" } }],
+				},
+				{ role: "tool", tool_call_id: "call_1", content: "sunny" },
+			],
+		});
+
+		const assistant = parsed.context.messages.find(m => m.role === "assistant");
+		if (assistant?.role !== "assistant") throw new Error("expected assistant");
+		expect(assistant.content).toHaveLength(1);
+		const call = assistant.content[0];
+		if (call?.type !== "toolCall") throw new Error("expected toolCall");
+		expect(call.id).toBe("call_1");
+		expect(call.name).toBe("get_weather");
+		expect(call.arguments).toEqual({});
+
+		const tool = parsed.context.messages.find(m => m.role === "toolResult");
+		if (tool?.role !== "toolResult") throw new Error("expected toolResult");
+		expect(tool.toolCallId).toBe("call_1");
+		expect(tool.toolName).toBe("get_weather");
+		expect(tool.content).toEqual([{ type: "text", text: "sunny" }]);
+	});
+
 	it("honours an explicit wire `name` on a tool message over back-resolution", () => {
 		const parsed = parseRequest({
 			model: "m",


### PR DESCRIPTION
## Repro
Calling `parseRequest` from `packages/ai/src/providers/openai-chat-server.ts` with an OpenAI Chat replay containing `{ role: "assistant", content: null, tool_calls: [...] }` followed by a `role: "tool"` result failed before translation with `openai-chat: messages[1].content must be a string or an object (was null)`.

## Cause
`packages/ai/src/providers/openai-chat-server-schema.ts` reused `baseContent` for assistant `content`, and `baseContent` only admitted `string | content-part[]`; `parseRequest` in `packages/ai/src/providers/openai-chat-server.ts` already normalized `m.content ?? undefined`, but the ArkType schema rejected `null` before that walker ran.

## Fix
- Added an assistant-only content schema that extends the shared Chat content shape with `null`.
- Kept system, developer, user, and tool message content validation unchanged.
- Added a regression test proving null assistant content replays as a canonical assistant tool call and back-resolved tool result.
- Added the `packages/ai` changelog entry for issue #5121.

## Verification
`bun test packages/ai/test/auth-gateway-openai-chat.test.ts` passed with 12 tests and 82 assertions. `gh_push_branch` completed its pre-publish gate and pushed `farm/e65c94ce/allow-assistant-null-content` at `38af95646ccb`. Fixes #5121