### PR TITLE
fix(ai): include Responses incomplete details

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses server non-streaming envelopes to always include the required `incomplete_details` field, using `null` for completed responses. ([#5120](https://github.com/can1357/oh-my-pi/issues/5120))
+
 ## [16.4.1] - 2026-07-10
 
 ### Changed

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -568,6 +568,10 @@ function responseStatusForStopReason(message: AssistantMessage): ResponseStatus 
 	return "completed";
 }
 
+function incompleteDetailsForStatus(status: ResponseStatus): { reason: "max_output_tokens" } | null {
+	return status === "incomplete" ? { reason: "max_output_tokens" } : null;
+}
+
 function buildReasoningItem(part: ThinkingContent): ReasoningOutputItem {
 	const baseId = part.itemId ?? makeReasoningId();
 	if (part.thinkingSignature) {
@@ -718,7 +722,7 @@ function buildResponseEnvelope(
 		model: requestedModelId,
 		output: items,
 		usage,
-		...(status === "incomplete" ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
+		incomplete_details: incompleteDetailsForStatus(status),
 		...(status === "failed" ? { error: { message: message.errorMessage ?? "response failed" } } : {}),
 	};
 }
@@ -812,6 +816,7 @@ export function encodeStream(
 				model: requestedModelId,
 				output,
 				usage: null,
+				incomplete_details: incompleteDetailsForStatus(status),
 			});
 
 			const openMessage = (signature?: MessageSignature): OpenMessage => {
@@ -1242,7 +1247,7 @@ export function encodeStream(
 								model: requestedModelId,
 								output: items,
 								usage,
-								...(status === "incomplete" ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
+								incomplete_details: incompleteDetailsForStatus(status),
 								...(status === "failed"
 									? { error: { message: message?.errorMessage ?? "response failed" } }
 									: {}),
@@ -1267,6 +1272,7 @@ export function encodeStream(
 									model: requestedModelId,
 									output: [],
 									error: { message: err instanceof Error ? err.message : String(err) },
+									incomplete_details: null,
 								},
 							}),
 						),

--- a/packages/ai/test/auth-gateway-openai-responses.test.ts
+++ b/packages/ai/test/auth-gateway-openai-responses.test.ts
@@ -276,6 +276,8 @@ describe("openai-responses encodeResponse", () => {
 
 		expect(body.object).toBe("response");
 		expect(body.status).toBe("completed");
+		expect(Object.hasOwn(body, "incomplete_details")).toBe(true);
+		expect(body.incomplete_details).toBeNull();
 		expect(body.model).toBe("gpt-5-requested");
 		expect(body.created_at).toBe(1_700_000_000);
 		expect(typeof body.id).toBe("string");


### PR DESCRIPTION
## Repro
Completed non-streaming OpenAI Responses envelopes produced by `encodeResponse()` were missing the schema-required `incomplete_details` field. Reproduced by adding the reporter's assertion and running `bun test packages/ai/test/auth-gateway-openai-responses.test.ts -t "encodes reasoning"`, which failed with `Expected: true` / `Received: false` for `Object.hasOwn(body, "incomplete_details")`.

## Cause
`packages/ai/src/providers/openai-responses-server.ts` built response envelopes with a conditional spread that only emitted `incomplete_details` when `status === "incomplete"`; completed and failed response objects omitted the required field entirely.

## Fix
- Added a single `incompleteDetailsForStatus()` helper that returns `{ reason: "max_output_tokens" }` for incomplete responses and `null` for all other statuses.
- Used that helper for non-streaming response envelopes and streaming response snapshots/terminal envelopes so server-produced Responses objects carry the field consistently.
- Added regression coverage in `packages/ai/test/auth-gateway-openai-responses.test.ts` for completed non-streaming responses having an own `incomplete_details: null` property.
- Added an Unreleased changelog entry for `@oh-my-pi/pi-ai`.

## Verification
`bun test packages/ai/test/auth-gateway-openai-responses.test.ts` passed with 11 tests and 108 expectations. `gh_push_branch` also completed the pre-publish gate before pushing. Fixes #5120