### PR TITLE
fix(coding-agent): strip thinking markup from session titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed serialization of BigInt values in tool arguments during session compaction
 - Fixed GPT-5.6 over-delegating work by centralizing task fan-out and concurrency policy in the system prompt: default task mode now uses Codex's explicit-request policy, while eager task mode uses its proactive policy. Other models retain the existing delegation strategy; the task tool keeps only model-independent assignment and coordination guidance.
+- Fixed session title generation including leaked thinking markup from OpenAI-compatible endpoints that ignore reasoning disablement. ([#5122](https://github.com/can1357/oh-my-pi/issues/5122))
 
 ## [16.4.1] - 2026-07-10
 

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -35,6 +35,8 @@ const TITLE_MAX_TOKENS = 1024;
 /** Matches the title the model wraps in `<title>...</title>`. */
 const TITLE_MARKER_GLOBAL_RE = /<title>([\s\S]*?)<\/title>/gi;
 const TITLE_VISIBILITY_SENTINEL = "\uE000omp-title-visible\uE000";
+const LEADING_THINKING_TAG_RE = /^\s*<(think|thinking|reasoning)>\s*[\s\S]*?<\/\1>\s*/i;
+const LEADING_THINKING_FENCE_RE = /^\s*```(?:thinking|reasoning)\b[\s\S]*?```\s*/i;
 
 function getTitleModel(registry: ModelRegistry, settings: Settings, currentModel?: Model<Api>): Model<Api> | undefined {
 	const availableModels = registry.getAvailable();
@@ -244,12 +246,12 @@ function extractGeneratedTitle(contentBlocks: AssistantMessage["content"]): stri
 		}
 	}
 	// Stay lenient: prefer the first closed title marker in visible text, then
-	// fall back to a plain sentence after stripping leaked thinking plus any
-	// stray/unclosed title tag fragment (e.g. output truncated before closing).
+	// fall back to a plain sentence after stripping only known leading leaked
+	// thinking envelopes plus any stray/unclosed title tag fragment.
 	const markedTitle = extractVisibleMarkedTitle(textTitle);
 	const cleanedTextTitle =
 		markedTitle ??
-		stripLeakedThinkingMarkup(textTitle)
+		stripLeadingLeakedThinkingMarkup(textTitle)
 			.replace(/<\/?title>/gi, "")
 			.trim();
 	return unwrapJsonTitle(cleanedTextTitle);
@@ -270,6 +272,16 @@ function isVisibleTitleMarker(text: string, markerIndex: number): boolean {
 	return stripLeakedThinkingMarkup(`${text.slice(0, markerIndex)}${TITLE_VISIBILITY_SENTINEL}`).endsWith(
 		TITLE_VISIBILITY_SENTINEL,
 	);
+}
+
+function stripLeadingLeakedThinkingMarkup(text: string): string {
+	let current = text;
+	while (true) {
+		const withoutTag = current.replace(LEADING_THINKING_TAG_RE, "");
+		const withoutFence = withoutTag.replace(LEADING_THINKING_FENCE_RE, "");
+		if (withoutFence === current) return current;
+		current = withoutFence;
+	}
 }
 
 function stripLeakedThinkingMarkup(text: string): string {

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -35,6 +35,8 @@ const TITLE_MAX_TOKENS = 1024;
 /** Matches the title the model wraps in `<title>...</title>`. */
 const TITLE_MARKER_GLOBAL_RE = /<title>([\s\S]*?)<\/title>/gi;
 const TITLE_VISIBILITY_SENTINEL = "\uE000omp-title-visible\uE000";
+const THINKING_TAG_ENVELOPE_RE = /<(think|thinking|reasoning)>\s*[\s\S]*?<\/\1>/gi;
+const THINKING_FENCE_ENVELOPE_RE = /```(?:thinking|reasoning)\b[\s\S]*?```/gi;
 const LEADING_THINKING_TAG_RE = /^\s*<(think|thinking|reasoning)>\s*[\s\S]*?<\/\1>\s*/i;
 const LEADING_THINKING_FENCE_RE = /^\s*```(?:thinking|reasoning)\b[\s\S]*?```\s*/i;
 
@@ -269,9 +271,30 @@ function extractVisibleMarkedTitle(text: string): string | undefined {
 }
 
 function isVisibleTitleMarker(text: string, markerIndex: number): boolean {
+	if (isInsideKnownThinkingEnvelope(text, markerIndex)) return false;
 	return stripLeakedThinkingMarkup(`${text.slice(0, markerIndex)}${TITLE_VISIBILITY_SENTINEL}`).endsWith(
 		TITLE_VISIBILITY_SENTINEL,
 	);
+}
+
+function isInsideKnownThinkingEnvelope(text: string, index: number): boolean {
+	return (
+		isInsideEnvelopeMatchedBy(THINKING_TAG_ENVELOPE_RE, text, index) ||
+		isInsideEnvelopeMatchedBy(THINKING_FENCE_ENVELOPE_RE, text, index)
+	);
+}
+
+function isInsideEnvelopeMatchedBy(pattern: RegExp, text: string, index: number): boolean {
+	pattern.lastIndex = 0;
+	let marker = pattern.exec(text);
+	while (marker !== null) {
+		const start = marker.index;
+		const end = start + marker[0].length;
+		if (index > start && index < end) return true;
+		if (start > index) return false;
+		marker = pattern.exec(text);
+	}
+	return false;
 }
 
 function stripLeadingLeakedThinkingMarkup(text: string): string {

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -4,6 +4,7 @@
 import * as path from "node:path";
 
 import { type Api, type AssistantMessage, completeSimple, type Model } from "@oh-my-pi/pi-ai";
+import { StreamMarkupHealing } from "@oh-my-pi/pi-ai/utils/stream-markup-healing";
 import { isTerminalHeadless, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 
@@ -244,9 +245,15 @@ function extractGeneratedTitle(contentBlocks: AssistantMessage["content"]): stri
 	// Stay lenient: prefer the marker when the model closed it, otherwise
 	// accept a plain sentence after stripping any stray/unclosed tag fragment
 	// (e.g. output truncated before the closing tag).
-	const marker = TITLE_MARKER_RE.exec(textTitle);
-	const candidate = marker ? marker[1].trim() : textTitle.replace(/<\/?title>/gi, "").trim();
+	const cleanedTextTitle = stripLeakedThinkingMarkup(textTitle);
+	const marker = TITLE_MARKER_RE.exec(cleanedTextTitle);
+	const candidate = marker ? marker[1].trim() : cleanedTextTitle.replace(/<\/?title>/gi, "").trim();
 	return unwrapJsonTitle(candidate);
+}
+
+function stripLeakedThinkingMarkup(text: string): string {
+	const healer = new StreamMarkupHealing({ pattern: "thinking" });
+	return healer.feed(text) + healer.flushPending();
 }
 
 /**

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -33,7 +33,8 @@ const TERMINAL_TITLE_CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;
 const TITLE_MAX_TOKENS = 1024;
 
 /** Matches the title the model wraps in `<title>...</title>`. */
-const TITLE_MARKER_RE = /<title>([\s\S]*?)<\/title>/i;
+const TITLE_MARKER_GLOBAL_RE = /<title>([\s\S]*?)<\/title>/gi;
+const TITLE_VISIBILITY_SENTINEL = "\uE000omp-title-visible\uE000";
 
 function getTitleModel(registry: ModelRegistry, settings: Settings, currentModel?: Model<Api>): Model<Api> | undefined {
 	const availableModels = registry.getAvailable();
@@ -242,13 +243,33 @@ function extractGeneratedTitle(contentBlocks: AssistantMessage["content"]): stri
 			textTitle += content.text;
 		}
 	}
-	// Stay lenient: prefer the marker when the model closed it, otherwise
-	// accept a plain sentence after stripping any stray/unclosed tag fragment
-	// (e.g. output truncated before the closing tag).
-	const cleanedTextTitle = stripLeakedThinkingMarkup(textTitle);
-	const marker = TITLE_MARKER_RE.exec(cleanedTextTitle);
-	const candidate = marker ? marker[1].trim() : cleanedTextTitle.replace(/<\/?title>/gi, "").trim();
-	return unwrapJsonTitle(candidate);
+	// Stay lenient: prefer the first closed title marker in visible text, then
+	// fall back to a plain sentence after stripping leaked thinking plus any
+	// stray/unclosed title tag fragment (e.g. output truncated before closing).
+	const markedTitle = extractVisibleMarkedTitle(textTitle);
+	const cleanedTextTitle =
+		markedTitle ??
+		stripLeakedThinkingMarkup(textTitle)
+			.replace(/<\/?title>/gi, "")
+			.trim();
+	return unwrapJsonTitle(cleanedTextTitle);
+}
+
+function extractVisibleMarkedTitle(text: string): string | undefined {
+	TITLE_MARKER_GLOBAL_RE.lastIndex = 0;
+	let marker: RegExpExecArray | null = TITLE_MARKER_GLOBAL_RE.exec(text);
+	while (marker !== null) {
+		const title = marker[1];
+		if (title !== undefined && isVisibleTitleMarker(text, marker.index)) return title.trim();
+		marker = TITLE_MARKER_GLOBAL_RE.exec(text);
+	}
+	return undefined;
+}
+
+function isVisibleTitleMarker(text: string, markerIndex: number): boolean {
+	return stripLeakedThinkingMarkup(`${text.slice(0, markerIndex)}${TITLE_VISIBILITY_SENTINEL}`).endsWith(
+		TITLE_VISIBILITY_SENTINEL,
+	);
 }
 
 function stripLeakedThinkingMarkup(text: string): string {

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -377,6 +377,39 @@ describe("title generator", () => {
 		expect(title).toBe("Fix login button on mobile");
 	});
 
+	it("preserves a markerless title that mentions a <think> tag", async () => {
+		const model = getModelFor("deepseek", "deepseek-v4-pro");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "Fix <think> tag parsing" }],
+		} as never);
+
+		const title = await generateSessionTitle(
+			"fix title generation for <think> tag parsing",
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(title).toBe("Fix <think> tag parsing");
+	});
+
+	it("preserves a markerless title that mentions a ```thinking fence", async () => {
+		const model = getModelFor("deepseek", "deepseek-v4-pro");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "Fix ```thinking fence parsing" }],
+		} as never);
+
+		const title = await generateSessionTitle(
+			"fix title generation for a ```thinking fence",
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(title).toContain("```thinking");
+		expect(title).toContain("fence");
+	});
+
 	it("strips an unclosed <title> tag from a truncated response", async () => {
 		const model = getModelFor("deepseek", "deepseek-v4-pro");
 		vi.spyOn(ai, "completeSimple").mockResolvedValue({

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -70,6 +70,31 @@ describe("title generator", () => {
 		expect(options?.disableReasoning).toBe(true);
 	});
 
+	it.each([
+		[
+			"thinking",
+			"<thinking>Thinking process:\n<title>Wrong internal scratchpad</title>\n</thinking>\n<title>Fix login button</title>",
+		],
+		[
+			"think",
+			"<think>Thinking process:\n<title>Wrong internal scratchpad</title>\n</think>\n<title>Fix login button</title>",
+		],
+	] as const)("ignores leaked <%s> reasoning markup before the visible title", async (_tag, responseText) => {
+		const model = getModelOrThrow("claude-sonnet-4-5");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: responseText }],
+		} as never);
+
+		const title = await generateSessionTitle(
+			"the login button is broken on mobile",
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(title).toBe("Fix login button");
+	});
+
 	it("uses the bundled default prompt when no title prompt file is resolved", async () => {
 		const model = getModelOrThrow("claude-sonnet-4-5");
 		const completeSimpleMock = vi.spyOn(ai, "completeSimple").mockResolvedValue({

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -72,14 +72,22 @@ describe("title generator", () => {
 
 	it.each([
 		[
-			"thinking",
+			"<thinking>",
 			"<thinking>Thinking process:\n<title>Wrong internal scratchpad</title>\n</thinking>\n<title>Fix login button</title>",
 		],
 		[
-			"think",
+			"<think>",
 			"<think>Thinking process:\n<title>Wrong internal scratchpad</title>\n</think>\n<title>Fix login button</title>",
 		],
-	] as const)("ignores leaked <%s> reasoning markup before the visible title", async (_tag, responseText) => {
+		[
+			"<reasoning>",
+			"<reasoning>Thinking process:\n<title>Wrong internal scratchpad</title>\n</reasoning>\n<title>Fix login button</title>",
+		],
+		[
+			"```reasoning",
+			"```reasoning\nThinking process:\n<title>Wrong internal scratchpad</title>\n```\n<title>Fix login button</title>",
+		],
+	] as const)("ignores leaked %s reasoning markup before the visible title", async (_marker, responseText) => {
 		const model = getModelOrThrow("claude-sonnet-4-5");
 		vi.spyOn(ai, "completeSimple").mockResolvedValue({
 			stopReason: "stop",

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -95,6 +95,22 @@ describe("title generator", () => {
 		expect(title).toBe("Fix login button");
 	});
 
+	it("preserves in-band reasoning syntax inside the parsed title", async () => {
+		const model = getModelOrThrow("claude-sonnet-4-5");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: "<title>Fix <think> tag parsing</title>" }],
+		} as never);
+
+		const title = await generateSessionTitle(
+			"fix title generation for <think> tag parsing",
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(title).toBe("Fix <think> tag parsing");
+	});
+
 	it("uses the bundled default prompt when no title prompt file is resolved", async () => {
 		const model = getModelOrThrow("claude-sonnet-4-5");
 		const completeSimpleMock = vi.spyOn(ai, "completeSimple").mockResolvedValue({


### PR DESCRIPTION
## Repro
A mocked online title response that returns leaked thinking before the real title reproduces the bug: `completeSimple` returns `<thinking>Thinking process:\n<title>Wrong internal scratchpad</title>\n</thinking>\n<title>Fix login button</title>`, then `generateSessionTitle('the login button is broken on mobile', ...)` returned `Wrong internal scratchpad` before this fix.

## Cause
`packages/coding-agent/src/utils/title-generator.ts` concatenated visible text blocks and parsed the first `<title>...</title>` match directly in `extractGeneratedTitle()`. OpenAI-compatible backends that ignore `disableReasoning` can leak `<thinking>` / `<think>` envelopes into the visible text channel, so a title marker inside leaked reasoning could be selected before the actual visible title.

## Fix
- Reused `StreamMarkupHealing({ pattern: 'thinking' })` in title extraction before marker parsing so known leaked reasoning envelopes are removed from the visible title text.
- Kept the existing marker, plain-text fallback, and JSON-title unwrapping behavior after cleanup.
- Added regression coverage for both `<thinking>...</thinking>` and `<think>...</think>` envelopes containing an internal wrong title before the visible title.
- Added a `packages/coding-agent` changelog entry for #5122.

## Verification
`bun test packages/coding-agent/test/title-generator.test.ts` passed: 19 pass, 0 fail. `bun check` passed after the source, test, and changelog changes. `gh_push_branch` pre-publish gate also passed and pushed `farm/9d12b947/strip-title-thinking` at `851186f5deb2`. Fixes #5122