### PR TITLE
fix(tui): highlighted streamed diff scrollback rows

### DIFF
--- a/packages/coding-agent/test/theme-highlight-diff-parity.test.ts
+++ b/packages/coding-agent/test/theme-highlight-diff-parity.test.ts
@@ -1,0 +1,52 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { getThemeByName, highlightCode, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+const unifiedDiffChunks = [
+	[
+		"diff --git a/src/example.ts b/src/example.ts",
+		"index 1234567..89abcde 100644",
+		"--- a/src/example.ts",
+		"+++ b/src/example.ts",
+		"@@ -1,4 +1,5 @@",
+		' import { run } from "./run";',
+		"-const enabled = false;",
+		"+const enabled = true;",
+		"+run(enabled);",
+	],
+	[
+		"@@ -8,4 +9,4 @@ export function start() {",
+		" context();",
+		'-return "old";',
+		'+return "new";',
+		"\\ No newline at end of file",
+	],
+].map(lines => lines.join("\n"));
+
+const unifiedDiff = unifiedDiffChunks.join("\n");
+const diffLanguages: Array<"diff" | "patch"> = ["diff", "patch"];
+
+beforeAll(async () => {
+	const darkTheme = await getThemeByName("dark");
+	if (!darkTheme) throw new Error("Expected dark theme to exist");
+	setThemeInstance(darkTheme);
+});
+
+describe("diff highlighter chunk parity", () => {
+	for (const lang of diffLanguages) {
+		it(`highlights newline-complete ${lang} chunks with whole-block visual styles`, () => {
+			const completeDiff = `${unifiedDiff}\n`;
+			const wholeBlock = highlightCode(completeDiff, lang);
+			const chunkedLines = unifiedDiffChunks.flatMap(chunk => {
+				const highlighted = highlightCode(`${chunk}\n`, lang);
+				return highlighted.slice(0, -1);
+			});
+			chunkedLines.push("");
+
+			expect(Bun.stripANSI(wholeBlock.join("\n"))).toBe(completeDiff);
+			expect(wholeBlock.join("\n")).not.toBe(completeDiff);
+			expect(chunkedLines.map(line => line.replace(/^\x1b\[39m/u, ""))).toEqual(
+				wholeBlock.map(line => line.replace(/^\x1b\[39m/u, "")),
+			);
+		});
+	}
+});

--- a/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
+++ b/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
@@ -148,4 +148,46 @@ describe("transcript streaming commit (assistant text)", () => {
 			await term.flush();
 		}
 	});
+
+	it("keeps the final closed diff row highlighted while following prose streams", async () => {
+		if (process.platform === "win32") return;
+		const rows = 6;
+		const term = new VirtualTerminal(52, rows);
+		Object.defineProperty(term, "isNativeViewportAtBottom", { configurable: true, value: () => undefined });
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const chat = new TranscriptContainer();
+		const block = new StreamingMarkdownBlock();
+		const diffLines = Array.from({ length: 18 }, (_value, index) => {
+			const sign = index % 2 === 0 ? "-" : "+";
+			return `${sign}closed-${String(index).padStart(2, "0")}`;
+		});
+		const finalDiffLine = "+closed-tail-no-extra-newline";
+		const codeBlockSource = [...diffLines, finalDiffLine].join("\n");
+		const streamingProse = Array.from(
+			{ length: 12 },
+			(_value, index) => `still streaming prose line ${String(index).padStart(2, "0")}`,
+		).join("\n");
+		const closedFenceWithLiveTail = `\`\`\`diff\n${codeBlockSource}\n\`\`\`\n${streamingProse}`;
+		chat.addChild(block);
+		tui.addChild(chat);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+
+			block.setStreamingText(closedFenceWithLiveTail);
+			tui.requestRender();
+			await scheduler.drain(term);
+
+			const streamedRows = term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+			const finalDiffRow = streamedRows.findIndex(row => row.includes(finalDiffLine));
+			expect(finalDiffRow).toBeGreaterThanOrEqual(0);
+			expect(finalDiffRow).toBeLessThan(term.getBufferPosition().baseY);
+			expect(foregroundColumnsForBufferRow(term, finalDiffRow).length).toBeGreaterThan(0);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
 });

--- a/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
+++ b/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
-import type { Component } from "@oh-my-pi/pi-tui";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { Markdown, type MarkdownTheme } from "@oh-my-pi/pi-tui/components/markdown";
+import { StressRenderScheduler } from "../../tui/test/render-stress-scheduler";
+import { defaultMarkdownTheme } from "../../tui/test/test-themes.js";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
 
 class MutableLiveBlock implements Component {
 	#lines: string[];
@@ -24,6 +28,63 @@ class MutableLiveBlock implements Component {
 	}
 }
 
+const diffMarkdownTheme: MarkdownTheme = {
+	...defaultMarkdownTheme,
+	codeBlock: text => text,
+	codeBlockBorder: text => text,
+	highlightCode: (source, lang) => {
+		const normalizedLang = lang?.trim().toLowerCase();
+		const highlighted: string[] = [];
+		for (const line of source.split("\n")) {
+			if (normalizedLang === "diff" && line.startsWith("+")) highlighted.push(`\x1b[32m${line}\x1b[39m`);
+			else if (normalizedLang === "diff" && line.startsWith("-")) highlighted.push(`\x1b[31m${line}\x1b[39m`);
+			else highlighted.push(line);
+		}
+		return highlighted;
+	},
+};
+
+class StreamingMarkdownBlock implements Component {
+	#finalized = false;
+	#markdown = new Markdown("", 0, 0, diffMarkdownTheme);
+
+	setStreamingText(text: string): void {
+		this.#finalized = false;
+		this.#markdown.transientRenderCache = true;
+		this.#markdown.setText(text);
+	}
+
+	finalize(text: string): void {
+		this.#finalized = true;
+		this.#markdown.transientRenderCache = false;
+		this.#markdown.setText(text);
+	}
+
+	render(width: number): readonly string[] {
+		const lines = this.#markdown.render(width);
+		return lines;
+	}
+
+	isTranscriptBlockFinalized(): boolean {
+		const finalized = this.#finalized;
+		return finalized;
+	}
+
+	getTranscriptBlockSettledRows(): number {
+		const rows = this.#markdown.getLastRenderSettledRows();
+		return rows;
+	}
+}
+
+function foregroundColumnsForBufferRow(term: VirtualTerminal, bufferRow: number): number[] {
+	const before = term.getBufferPosition();
+	term.scrollLines(bufferRow - before.viewportY);
+	const columns = term.getViewportRowForegroundColumns(0);
+	const after = term.getBufferPosition();
+	term.scrollLines(before.viewportY - after.viewportY);
+	return columns;
+}
+
 describe("transcript streaming commit (assistant text)", () => {
 	it("commits only the declared settled head while the trailing line grows", () => {
 		const chat = new TranscriptContainer();
@@ -40,5 +101,51 @@ describe("transcript streaming commit (assistant text)", () => {
 		chat.render(80);
 
 		expect(chat.getNativeScrollbackLiveRegionStart()).toBe(2);
+	});
+
+	it("keeps diff foreground on rows committed while a streamed fence is still open", async () => {
+		if (process.platform === "win32") return;
+		const rows = 6;
+		const term = new VirtualTerminal(48, rows);
+		Object.defineProperty(term, "isNativeViewportAtBottom", { configurable: true, value: () => undefined });
+		const scheduler = new StressRenderScheduler();
+		const tui = new TUI(term, undefined, { renderScheduler: scheduler });
+		const chat = new TranscriptContainer();
+		const block = new StreamingMarkdownBlock();
+		const diffLines = Array.from({ length: 18 }, (_value, index) => {
+			const sign = index % 2 === 0 ? "+" : "-";
+			return `${sign}changed-${String(index).padStart(2, "0")}`;
+		});
+		const openFence = `\`\`\`diff\n${diffLines.join("\n")}\n`;
+		const closedFence = `${openFence}\`\`\``;
+		chat.addChild(block);
+		tui.addChild(chat);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+
+			block.setStreamingText(openFence);
+			tui.requestRender();
+			await scheduler.drain(term);
+
+			const streamedRows = term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+			const streamedRow = streamedRows.findIndex(row => row.includes("+changed-00"));
+			expect(streamedRow).toBeGreaterThanOrEqual(0);
+			expect(streamedRow).toBeLessThan(term.getBufferPosition().baseY);
+
+			block.finalize(closedFence);
+			tui.requestRender();
+			await scheduler.drain(term);
+
+			const finalRows = term.getScrollBuffer().map(row => Bun.stripANSI(row).trimEnd());
+			const finalRow = finalRows.findIndex(row => row.includes("+changed-00"));
+			expect(finalRow).toBe(streamedRow);
+			expect(finalRow).toBeLessThan(term.getBufferPosition().baseY);
+			expect(foregroundColumnsForBufferRow(term, finalRow).length).toBeGreaterThan(0);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
 	});
 });

--- a/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
+++ b/packages/coding-agent/test/transcript-streaming-commit-repro.test.ts
@@ -190,4 +190,33 @@ describe("transcript streaming commit (assistant text)", () => {
 			await term.flush();
 		}
 	});
+
+	it("renders a leading completed blank row in an open streamed diff body", () => {
+		const block = new StreamingMarkdownBlock();
+		block.setStreamingText("```diff\n\n+next");
+
+		const rows = block.render(40).map(row => Bun.stripANSI(row).trimEnd());
+		const fenceRow = rows.indexOf("```diff");
+
+		expect(fenceRow).toBeGreaterThanOrEqual(0);
+		expect(rows.slice(fenceRow, fenceRow + 4)).toEqual(["```diff", "", "  +next", "```"]);
+	});
+
+	it("appends a completed blank row when the streamed diff line cache grows", () => {
+		const block = new StreamingMarkdownBlock();
+
+		block.setStreamingText("```diff\n+a\n+streaming");
+		const initialRows = block.render(40).map(row => Bun.stripANSI(row).trimEnd());
+		const initialCodeRow = initialRows.indexOf("  +a");
+		expect(initialCodeRow).toBeGreaterThanOrEqual(0);
+		expect(initialRows.slice(initialCodeRow, initialCodeRow + 2)).toEqual(["  +a", "  +streaming"]);
+
+		block.setStreamingText("```diff\n+a\n\n+streaming");
+
+		const rows = block.render(40).map(row => Bun.stripANSI(row).trimEnd());
+		const codeRow = rows.indexOf("  +a");
+
+		expect(codeRow).toBeGreaterThanOrEqual(0);
+		expect(rows.slice(codeRow, codeRow + 3)).toEqual(["  +a", "", "  +streaming"]);
+	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed streamed diff code fences retaining unhighlighted rows in native scrollback when long transient blocks leave the viewport before finalization ([#5126](https://github.com/can1357/oh-my-pi/issues/5126)).
+
 ## [16.4.1] - 2026-07-10
 
 ### Added

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1421,16 +1421,19 @@ export class Markdown implements Component {
 		}
 
 		if (canStreamDiff) {
+			const closedFence = this.#codeTokenHasClosingFence(token);
 			const lineEnd = tokenText.lastIndexOf("\n");
-			if (lineEnd >= 0) {
-				const completedText = tokenText.slice(0, lineEnd);
-				if (completedText.length > 0) {
+			if (closedFence || lineEnd >= 0) {
+				const completedText = closedFence ? tokenText : tokenText.slice(0, lineEnd);
+				if (closedFence || completedText.length > 0) {
 					for (const hlLine of this.#highlightStreamingDiffLines(completedText, lang)) {
 						bodyLines.push(`${codeIndent}${hlLine}`);
 					}
 				}
-				for (const codeLine of tokenText.slice(lineEnd + 1).split("\n")) {
-					bodyLines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+				if (!closedFence) {
+					for (const codeLine of tokenText.slice(lineEnd + 1).split("\n")) {
+						bodyLines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+					}
 				}
 				return bodyLines;
 			}
@@ -1440,6 +1443,37 @@ export class Markdown implements Component {
 			bodyLines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
 		}
 		return bodyLines;
+	}
+
+	#codeTokenHasClosingFence(token: Token): boolean {
+		const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+		const firstLineEnd = raw.indexOf("\n");
+		if (firstLineEnd < 0) return false;
+		const openingLine = raw.slice(0, firstLineEnd);
+		const openingTrimmed = openingLine.trimStart();
+		const openingIndent = openingLine.length - openingTrimmed.length;
+		if (openingIndent > 3) return false;
+		const fenceChar = openingTrimmed.charAt(0);
+		if (fenceChar !== "`" && fenceChar !== "~") return false;
+		let fenceLength = 0;
+		while (openingTrimmed.charAt(fenceLength) === fenceChar) fenceLength++;
+		if (fenceLength < 3) return false;
+
+		let lineStart = firstLineEnd + 1;
+		while (lineStart <= raw.length) {
+			const lineEnd = raw.indexOf("\n", lineStart);
+			const line = lineEnd >= 0 ? raw.slice(lineStart, lineEnd) : raw.slice(lineStart);
+			const trimmed = line.trimStart();
+			const indent = line.length - trimmed.length;
+			let closingLength = 0;
+			while (trimmed.charAt(closingLength) === fenceChar) closingLength++;
+			if (indent <= 3 && closingLength >= fenceLength && trimmed.slice(closingLength).trim().length === 0) {
+				return true;
+			}
+			if (lineEnd < 0) break;
+			lineStart = lineEnd + 1;
+		}
+		return false;
 	}
 
 	#highlightStreamingDiffLines(completedText: string, lang: string | undefined): readonly string[] {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -937,6 +937,11 @@ interface StreamPrefixLineCache extends RenderSignature {
 	tokenCount: number;
 	lines: readonly string[];
 }
+interface StreamingDiffLineCache extends RenderSignature {
+	lang: string | undefined;
+	text: string;
+	lines: readonly string[];
+}
 
 export class Markdown implements Component {
 	#text: string;
@@ -979,8 +984,12 @@ export class Markdown implements Component {
 	// True while #renderStreamingContentLines renders the frozen token range:
 	// frozen code blocks highlight even in transient mode so their bytes match
 	// the finalized render (they render once into the prefix line cache, so
-	// the FFI cost is amortized); the volatile tail stays unhighlighted.
+	// the FFI cost is amortized). The volatile tail normally stays
+	// unhighlighted; streaming diff fences line-highlight completed rows so
+	// semantic colors reach native scrollback before rows leave the viewport.
 	#renderingFrozenPrefix = false;
+	#streamingDiffLineCache?: StreamingDiffLineCache;
+	#activeRenderSignature?: RenderSignature;
 
 	#ignoreTight = false;
 
@@ -1190,9 +1199,15 @@ export class Markdown implements Component {
 
 		// Parse markdown to HTML-like tokens
 		const tokens = this.#lexTokens(normalizedText);
-		const contentLines = this.transientRenderCache
-			? this.#renderStreamingContentLines(tokens, normalizedText, signature, contentWidth)
-			: this.#renderContentLines(tokens, 0, tokens.length, contentWidth, signature);
+		let contentLines: string[];
+		this.#activeRenderSignature = signature;
+		try {
+			contentLines = this.transientRenderCache
+				? this.#renderStreamingContentLines(tokens, normalizedText, signature, contentWidth)
+				: this.#renderContentLines(tokens, 0, tokens.length, contentWidth, signature);
+		} finally {
+			this.#activeRenderSignature = undefined;
+		}
 		const emptyLines = this.#renderEmptyPaddingLines(signature);
 
 		// Combine top padding, content, and bottom padding
@@ -1386,6 +1401,92 @@ export class Markdown implements Component {
 		return contentLines;
 	}
 
+	#renderCodeBodyLines(token: Token, codeIndent: string): string[] {
+		const bodyLines: string[] = [];
+		const tokenText = "text" in token && typeof token.text === "string" ? token.text : "";
+		const lang = "lang" in token && typeof token.lang === "string" ? token.lang : undefined;
+		const normalizedLang = lang?.toLowerCase();
+		const canStreamDiff =
+			this.transientRenderCache &&
+			!this.#renderingFrozenPrefix &&
+			this.#theme.highlightCode &&
+			(normalizedLang === "diff" || normalizedLang === "patch" || normalizedLang === "udiff");
+
+		if (this.#theme.highlightCode && (!this.transientRenderCache || this.#renderingFrozenPrefix)) {
+			const highlightedLines = this.#theme.highlightCode(tokenText, lang);
+			for (const hlLine of highlightedLines) {
+				bodyLines.push(`${codeIndent}${hlLine}`);
+			}
+			return bodyLines;
+		}
+
+		if (canStreamDiff) {
+			const lineEnd = tokenText.lastIndexOf("\n");
+			if (lineEnd >= 0) {
+				const completedText = tokenText.slice(0, lineEnd);
+				if (completedText.length > 0) {
+					for (const hlLine of this.#highlightStreamingDiffLines(completedText, lang)) {
+						bodyLines.push(`${codeIndent}${hlLine}`);
+					}
+				}
+				for (const codeLine of tokenText.slice(lineEnd + 1).split("\n")) {
+					bodyLines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+				}
+				return bodyLines;
+			}
+		}
+
+		for (const codeLine of tokenText.split("\n")) {
+			bodyLines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
+		}
+		return bodyLines;
+	}
+
+	#highlightStreamingDiffLines(completedText: string, lang: string | undefined): readonly string[] {
+		const highlightCode = this.#theme.highlightCode;
+		if (!highlightCode) return [];
+		const signature = this.#activeRenderSignature;
+		const cache = this.#streamingDiffLineCache;
+		if (
+			signature &&
+			cache &&
+			completedText.startsWith(cache.text) &&
+			(cache.text.length === completedText.length || completedText.charCodeAt(cache.text.length) === 0x0a) &&
+			cache.lang === lang &&
+			cache.width === signature.width &&
+			cache.paddingX === signature.paddingX &&
+			cache.paddingY === signature.paddingY &&
+			cache.codeBlockIndent === signature.codeBlockIndent &&
+			cache.themeId === signature.themeId &&
+			cache.defaultTextStyleId === signature.defaultTextStyleId &&
+			cache.imageProtocol === signature.imageProtocol &&
+			cache.hyperlinks === signature.hyperlinks &&
+			cache.textSizing === signature.textSizing &&
+			cache.bgColorProbe === signature.bgColorProbe &&
+			cache.headingProbe === signature.headingProbe
+		) {
+			if (completedText.length === cache.text.length) return cache.lines;
+			const lines = cache.lines.slice();
+			const addedText = completedText.slice(cache.text.length === 0 ? 0 : cache.text.length + 1);
+			if (addedText.length > 0) {
+				for (const codeLine of addedText.split("\n")) {
+					lines.push(...highlightCode(codeLine, lang));
+				}
+			}
+			this.#streamingDiffLineCache = { ...signature, lang, text: completedText, lines };
+			return lines;
+		}
+
+		const lines: string[] = [];
+		for (const codeLine of completedText.split("\n")) {
+			lines.push(...highlightCode(codeLine, lang));
+		}
+		if (signature) {
+			this.#streamingDiffLineCache = { ...signature, lang, text: completedText, lines };
+		}
+		return lines;
+	}
+
 	#renderEmptyPaddingLines(signature: RenderSignature): string[] {
 		const emptyLine = padding(signature.width);
 		const emptyLines: string[] = [];
@@ -1563,17 +1664,8 @@ export class Markdown implements Component {
 
 				const codeIndent = padding(this.#codeBlockIndent);
 				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
-				if (this.#theme.highlightCode && (!this.transientRenderCache || this.#renderingFrozenPrefix)) {
-					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
-					for (const hlLine of highlightedLines) {
-						lines.push(`${codeIndent}${hlLine}`);
-					}
-				} else {
-					// Split code by newlines and style each line
-					const codeLines = token.text.split("\n");
-					for (const codeLine of codeLines) {
-						lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
-					}
+				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
+					lines.push(bodyLine);
 				}
 				lines.push(this.#theme.codeBlockBorder("```"));
 				if (nextTokenType && nextTokenType !== "space") {
@@ -1953,16 +2045,8 @@ export class Markdown implements Component {
 				// Code block in list item
 				const codeIndent = padding(this.#codeBlockIndent);
 				lines.push({ text: this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`), nested: false });
-				if (this.#theme.highlightCode && (!this.transientRenderCache || this.#renderingFrozenPrefix)) {
-					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
-					for (const hlLine of highlightedLines) {
-						lines.push({ text: `${codeIndent}${hlLine}`, nested: false });
-					}
-				} else {
-					const codeLines = token.text.split("\n");
-					for (const codeLine of codeLines) {
-						lines.push({ text: `${codeIndent}${this.#theme.codeBlock(codeLine)}`, nested: false });
-					}
+				for (const bodyLine of this.#renderCodeBodyLines(token, codeIndent)) {
+					lines.push({ text: bodyLine, nested: false });
 				}
 				lines.push({ text: this.#theme.codeBlockBorder("```"), nested: false });
 			} else if (isMathToken(token)) {

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1425,10 +1425,8 @@ export class Markdown implements Component {
 			const lineEnd = tokenText.lastIndexOf("\n");
 			if (closedFence || lineEnd >= 0) {
 				const completedText = closedFence ? tokenText : tokenText.slice(0, lineEnd);
-				if (closedFence || completedText.length > 0) {
-					for (const hlLine of this.#highlightStreamingDiffLines(completedText, lang)) {
-						bodyLines.push(`${codeIndent}${hlLine}`);
-					}
+				for (const hlLine of this.#highlightStreamingDiffLines(completedText, lang)) {
+					bodyLines.push(`${codeIndent}${hlLine}`);
 				}
 				if (!closedFence) {
 					for (const codeLine of tokenText.slice(lineEnd + 1).split("\n")) {
@@ -1502,10 +1500,8 @@ export class Markdown implements Component {
 			if (completedText.length === cache.text.length) return cache.lines;
 			const lines = cache.lines.slice();
 			const addedText = completedText.slice(cache.text.length === 0 ? 0 : cache.text.length + 1);
-			if (addedText.length > 0) {
-				for (const codeLine of addedText.split("\n")) {
-					lines.push(...highlightCode(codeLine, lang));
-				}
+			for (const codeLine of addedText.split("\n")) {
+				lines.push(...highlightCode(codeLine, lang));
 			}
 			this.#streamingDiffLineCache = { ...signature, lang, text: completedText, lines };
 			return lines;


### PR DESCRIPTION
## Repro
A headless repro streamed one still-open fenced `diff` block taller than a 6-row terminal through the production TUI scrollback path, then finalized the fence. Before the fix, `bun .wt/repro-5126.ts` left the early committed row `-old line 1` in native scrollback with `foregroundColumns=0`, proving it had kept the generic gray/default foreground while later viewport rows finalized with diff colors.

## Cause
`packages/tui/src/components/markdown.ts` skipped `highlightCode` for the active transient fenced-code token, so an open long `diff` fence rendered completed rows with `theme.codeBlock` until the fence finalized. `TranscriptContainer` and `TUI` correctly committed scrolled live rows as immutable visual snapshots; once those gray rows crossed into native scrollback, finalization could repaint only the live viewport, and `rowsEquivalent()` intentionally treated SGR-only changes as equivalent.

## Fix
- Added an instance-local streaming diff line cache in `Markdown` that detects transient `diff`/`patch`/`udiff` code tokens and highlights only newline-complete rows while leaving the current incomplete row provisional.
- Reused the same code-body renderer for top-level and nested-list fenced code blocks, preserving the existing full-highlight path for frozen/final code blocks and non-diff transient fallback for other languages.
- Added a production-style TUI/TranscriptContainer regression that asserts an early streamed diff row committed to Ghostty-backed native scrollback keeps non-default foreground after finalization.
- Added a focused diff highlighter chunk-parity regression for `diff` and `patch` aliases, and documented the user-visible fix in `packages/tui/CHANGELOG.md`.

## Verification
`bun .wt/repro-5126.ts` now reports `foregroundColumns=11` for the early committed diff row. `bun test packages/coding-agent/test/transcript-streaming-commit-repro.test.ts packages/coding-agent/test/theme-highlight-diff-parity.test.ts packages/tui/test/markdown.test.ts packages/tui/test/markdown-stream-prefix-cache.test.ts` passed with 119 tests and 383 assertions. `bun check` passed. Fixes #5126