### PR TITLE
fix(agent): surface empty stop retry failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed empty local-model `stop` responses exhausting their retry cap without surfacing a user-visible retry failure. ([#5128](https://github.com/can1357/oh-my-pi/issues/5128))
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10874,21 +10874,21 @@ export class AgentSession {
 
 		this.#emptyStopRetryCount++;
 		if (this.#emptyStopRetryCount > EMPTY_STOP_MAX_RETRIES) {
-			logger.warn("Assistant returned empty stop after retry cap", {
-				attempts: this.#emptyStopRetryCount - 1,
+			const attempts = this.#emptyStopRetryCount - 1;
+			const finalError = "Assistant returned empty stop after retry cap";
+			logger.warn(finalError, {
+				attempts,
 				model: assistantMessage.model,
 				provider: assistantMessage.provider,
 			});
-			if (this.#retryAttempt > 0) {
-				await this.#emitSessionEvent({
-					type: "auto_retry_end",
-					success: false,
-					attempt: this.#retryAttempt,
-					finalError: "Assistant returned empty stop after retry cap",
-				});
-				this.#clearPendingRecoveredRetryErrors();
-				this.#retryAttempt = 0;
-			}
+			await this.#emitSessionEvent({
+				type: "auto_retry_end",
+				success: false,
+				attempt: this.#retryAttempt > 0 ? this.#retryAttempt : attempts,
+				finalError,
+			});
+			this.#clearPendingRecoveredRetryErrors();
+			this.#retryAttempt = 0;
 			this.#resolveRetry();
 			// Tool-use orphans corrupt Anthropic message history (tool_result without
 			// matching tool_use). Always remove them even when the retry cap is hit.

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -270,6 +270,28 @@ describe("AgentSession empty stop guard", () => {
 		expect(emptyAssistantStops(activeBranchMessages)).toHaveLength(1);
 	});
 
+	it("emits failed auto-retry end when repeated empty stops exhaust the retry cap", async () => {
+		const { session, mock } = await createHarness([emptyStop(), emptyStop(), emptyStop(), emptyStop()]);
+		const retryEndEvents: Array<Extract<AgentSessionEvent, { type: "auto_retry_end" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") {
+				retryEndEvents.push(event);
+			}
+		});
+
+		await expectPromptCompletes(session.prompt("answer without tools"));
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(4);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({
+			type: "auto_retry_end",
+			success: false,
+			attempt: 3,
+		});
+		expect(retryEndEvents[0]?.finalError).toContain("empty stop");
+	});
+
 	it("ends auto-retry state when empty stop retries hit the cap", async () => {
 		vi.spyOn(scheduler, "wait").mockResolvedValue(undefined);
 		const { session, mock } = await createHarness(


### PR DESCRIPTION
## Repro
A focused `AgentSession` harness returns four consecutive assistant messages with `stopReason: "stop"` and no actionable text or tool calls. Before the fix, `bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts` failed because the empty-stop retry cap was reached with zero failed `auto_retry_end` events, leaving the TUI without a visible error to render.

## Cause
`packages/coding-agent/src/session/agent-session.ts` handled capped empty assistant stops in `AgentSession.#handleEmptyAssistantStop()`, but only emitted a failed `auto_retry_end` event when the normal provider-error retry state (`#retryAttempt`) was already active. Empty-stop self-continuations use `#emptyStopRetryCount`, so local-model empty `stop` loops exhausted their cap and fell through maintenance without a user-visible retry failure.

## Fix
- Emit a failed `auto_retry_end` event whenever the empty-stop retry cap is exhausted, using the normal retry attempt when present and otherwise the empty-stop retry count.
- Clear any pending retry recovery state and reset `#retryAttempt` on that terminal empty-stop path.
- Add regression coverage for the no-prior-retry empty-stop cap path in `agent-session-empty-stop-guard.test.ts`.
- Add an Unreleased changelog entry for the coding-agent package.

## Verification
`bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts` passes with 9 tests and 58 assertions. `gh_push_branch` completed the pre-publish gate and pushed the branch after `bun check` passed. Fixes #5128