### PR TITLE
fix(coding-agent): supervise GPT-5.6 delegation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -118,6 +118,9 @@
 ### Removed
 
 - Removed the bundled plan subagent from available task agents.
+### Fixed
+
+- Added configured concurrency-cap guidance to GPT-5.6 eager delegation prompts and reserved active supervision guidance for top-level agents ([#5132](https://github.com/can1357/oh-my-pi/pull/5132) by [@lyc-aon](https://github.com/lyc-aon)).
 
 ## [16.4.2] - 2026-07-10
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fixed the Model Hub role-assignment strip hiding the selected chip once the row overflowed; the strip now scrolls horizontally, truncating passed chips behind a leading ellipsis so the selection (plus one chip of lookahead) stays visible.
 - Fixed mouse hover and clicks in the /models Roles view landing one row above the pointer (the row mapping subtracted the status row twice).
 - Fixed model search keeping the most-recently-used model on top of the results: match quality now ranks first (an exact `gpt-5.5` beats the active `gpt-5.6-sol`), with MRU order only breaking ties between equally good matches.
+- Added configured concurrency-cap guidance to GPT-5.6 delegation prompts and reserved active supervision guidance for top-level agents ([#5132](https://github.com/can1357/oh-my-pi/pull/5132) by [@lyc-aon](https://github.com/lyc-aon)).
 
 ## [16.4.5] - 2026-07-11
 
@@ -118,9 +119,6 @@
 ### Removed
 
 - Removed the bundled plan subagent from available task agents.
-### Fixed
-
-- Added configured concurrency-cap guidance to GPT-5.6 eager delegation prompts and reserved active supervision guidance for top-level agents ([#5132](https://github.com/can1357/oh-my-pi/pull/5132) by [@lyc-aon](https://github.com/lyc-aon)).
 
 ## [16.4.2] - 2026-07-10
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added configured concurrency-cap guidance to GPT-5.6 delegation prompts and reserved active supervision guidance for top-level agents ([#5132](https://github.com/can1357/oh-my-pi/pull/5132) by [@lyc-aon](https://github.com/lyc-aon)).
 
 ## [16.4.6] - 2026-07-12
 
@@ -30,7 +33,6 @@
 - Fixed the Model Hub role-assignment strip hiding the selected chip once the row overflowed; the strip now scrolls horizontally, truncating passed chips behind a leading ellipsis so the selection (plus one chip of lookahead) stays visible.
 - Fixed mouse hover and clicks in the /models Roles view landing one row above the pointer (the row mapping subtracted the status row twice).
 - Fixed model search keeping the most-recently-used model on top of the results: match quality now ranks first (an exact `gpt-5.5` beats the active `gpt-5.6-sol`), with MRU order only breaking ties between equally good matches.
-- Added configured concurrency-cap guidance to GPT-5.6 delegation prompts and reserved active supervision guidance for top-level agents ([#5132](https://github.com/can1357/oh-my-pi/pull/5132) by [@lyc-aon](https://github.com/lyc-aon)).
 
 ## [16.4.5] - 2026-07-11
 

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -146,6 +146,12 @@ You SHOULD use syntax-aware tools before text hacks:
 {{#if useCodexTaskPrompt}}
 {{#if eagerTasks}}
 Proactive multi-agent delegation is active. Any earlier instruction requiring an explicit user request before spawning sub-agents no longer applies. Use sub-agents when parallel work would materially improve speed or quality. This mode remains active until a later multi-agent mode developer message changes it.
+{{#unless isSubagent}}
+- Keep ownership of the overall task. Monitor sub-agents for stalls, repeated tool errors, scope drift, or disproportionate effort; intervene when needed and verify their results before relying on them.
+{{/unless}}
+{{#when MAX_CONCURRENCY ">" 0}}
+- **Concurrency cap:** At most {{pluralize MAX_CONCURRENCY "subagent" "subagents"}} run at once in this session. Keep each fan-out at or under that cap; excess tasks only queue.
+{{/when}}
 {{else}}
 Do not spawn sub-agents unless the user or applicable AGENTS.md/skill instructions explicitly ask for sub-agents, delegation, or parallel agent work.
 {{/if}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -149,9 +149,6 @@ Proactive multi-agent delegation is active. Any earlier instruction requiring an
 {{#unless isSubagent}}
 - Keep ownership of the overall task. Monitor sub-agents for stalls, repeated tool errors, scope drift, or disproportionate effort; intervene when needed and verify their results before relying on them.
 {{/unless}}
-{{#when MAX_CONCURRENCY ">" 0}}
-- **Concurrency cap:** At most {{pluralize MAX_CONCURRENCY "subagent" "subagents"}} run at once in this session. Keep each fan-out at or under that cap; excess tasks only queue.
-{{/when}}
 {{else}}
 Do not spawn sub-agents unless the user or applicable AGENTS.md/skill instructions explicitly ask for sub-agents, delegation, or parallel agent work.
 {{/if}}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2445,6 +2445,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				mcpDiscoveryServerSummaries: discoverableToolSummary.servers.map(formatDiscoverableToolServerSummary),
 				eagerTasks,
 				eagerTasksAlways,
+				isSubagent: agentKind === "sub",
 				taskBatch: settings.get("task.batch"),
 				taskMaxConcurrency: settings.get("task.maxConcurrency"),
 				taskIrcEnabled: isIrcEnabled(settings, options.taskDepth ?? 0),

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -13757,6 +13757,7 @@ export class AgentSession {
 		currentSelector: string,
 		options?: { pinFallback?: boolean },
 	): Promise<void> {
+		const previousEditMode = this.#resolveActiveEditMode();
 		const resolved = resolveModelOverride([selector.raw], this.#modelRegistry, this.settings);
 		const candidate = resolved.model ?? this.#modelRegistry.find(selector.provider, selector.id);
 		if (!candidate) {
@@ -13776,6 +13777,7 @@ export class AgentSession {
 		this.sessionManager.appendModelChange(candidateSelector, EPHEMERAL_MODEL_CHANGE_ROLE);
 		this.settings.getStorage()?.recordModelUsage(candidateSelector);
 		this.setThinkingLevel(nextThinkingLevel);
+		await this.#syncAfterModelChange(previousEditMode);
 		if (!this.#activeRetryFallback) {
 			this.#activeRetryFallback = {
 				role,
@@ -13909,10 +13911,12 @@ export class AgentSession {
 		const thinkingToApply =
 			currentThinkingLevel === lastAppliedFallbackThinkingLevel ? originalThinkingLevel : currentThinkingLevel;
 		const primarySelector = formatModelStringWithRouting(primaryModel);
+		const previousEditMode = this.#resolveActiveEditMode();
 		this.#setModelWithProviderSessionReset(primaryModel);
 		this.sessionManager.appendModelChange(primarySelector, EPHEMERAL_MODEL_CHANGE_ROLE);
 		this.settings.getStorage()?.recordModelUsage(primarySelector);
 		this.setThinkingLevel(thinkingToApply);
+		await this.#syncAfterModelChange(previousEditMode);
 		this.#clearActiveRetryFallback();
 	}
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -483,6 +483,8 @@ export interface BuildSystemPromptOptions {
 	eagerTasks?: boolean;
 	/** When true, the Eager Tasks section uses the hard MUST/ONLY wording (`task.eager: always`) rather than the softer `preferred` nudge. */
 	eagerTasksAlways?: boolean;
+	/** Whether this prompt belongs to a spawned task agent rather than the top-level agent. */
+	isSubagent?: boolean;
 	/** Whether `task.batch` is enabled; selects the centralized delegation guidance's call shape. */
 	taskBatch?: boolean;
 	/** Effective task concurrency limit displayed in centralized delegation guidance. Zero means unlimited. */
@@ -543,6 +545,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryServerSummaries = [],
 		eagerTasks = false,
 		eagerTasksAlways = false,
+		isSubagent = false,
 		taskBatch = true,
 		taskMaxConcurrency = 0,
 		taskIrcEnabled = false,
@@ -791,6 +794,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryServerSummaries,
 		eagerTasks,
 		eagerTasksAlways,
+		isSubagent,
 		taskBatch,
 		MAX_CONCURRENCY: normalizeConcurrencyLimit(taskMaxConcurrency),
 		taskIrcEnabled,

--- a/packages/coding-agent/test/agent-session-retry-fallback.test.ts
+++ b/packages/coding-agent/test/agent-session-retry-fallback.test.ts
@@ -14,6 +14,7 @@ import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/ex
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 type AutoRetryStartEvent = Extract<AgentSessionEvent, { type: "auto_retry_start" }>;
@@ -44,14 +45,14 @@ function getLastAssistantMessage(session: AgentSession): AssistantMessage {
 	return lastMessage;
 }
 
-function createFallbackAgent(primaryModel: Model, requestedModels: string[]): Agent {
+function createFallbackAgent(primaryModel: Model, requestedModels: string[], systemPrompt = ["Test"]): Agent {
 	const mock = createMockModel();
 	let primaryAttempts = 0;
 	return new Agent({
 		getApiKey: model => `${model.provider}-test-key`,
 		initialState: {
 			model: primaryModel,
-			systemPrompt: ["Test"],
+			systemPrompt,
 			tools: [],
 			messages: [],
 		},
@@ -84,6 +85,7 @@ describe("AgentSession retry fallback", () => {
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
 		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
 		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+		authStorage.setRuntimeApiKey("openai-codex", "openai-codex-test-key");
 		authStorage.setRuntimeApiKey("google", "google-test-key");
 		authStorage.setRuntimeApiKey("google-vertex", "google-vertex-test-key");
 		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
@@ -323,11 +325,36 @@ describe("AgentSession retry fallback", () => {
 	});
 
 	it("falls back to the chain when credential rotation exhausts the retry budget", async () => {
-		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const primaryModel = getBundledModel("openai-codex", "gpt-5.6-luna");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
 		if (!primaryModel || !fallbackModel) {
 			throw new Error("Expected bundled test models to exist");
 		}
+		const renderPrompt = async (model: Model): Promise<string[]> => {
+			const { systemPrompt } = await buildSystemPrompt({
+				cwd: tempDir.path(),
+				contextFiles: [],
+				skills: [],
+				rules: [],
+				toolNames: ["task"],
+				workspaceTree: {
+					rootPath: tempDir.path(),
+					rendered: "",
+					truncated: false,
+					totalLines: 0,
+					agentsMdFiles: [],
+				},
+				activeRepoContext: null,
+				model: `${model.provider}/${model.id}`,
+				includeModelInPrompt: false,
+				eagerTasks: true,
+				taskBatch: true,
+				taskMaxConcurrency: 12,
+			});
+			return systemPrompt;
+		};
+		const initialSystemPrompt = await renderPrompt(primaryModel);
+		expect(initialSystemPrompt.join("\n\n")).toContain("Proactive multi-agent delegation is active");
 
 		const requestedModels: string[] = [];
 		const mock = createMockModel();
@@ -335,7 +362,7 @@ describe("AgentSession retry fallback", () => {
 			getApiKey: model => `${model.provider}-test-key`,
 			initialState: {
 				model: primaryModel,
-				systemPrompt: ["Test"],
+				systemPrompt: initialSystemPrompt,
 				tools: [],
 				messages: [],
 			},
@@ -369,6 +396,7 @@ describe("AgentSession retry fallback", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings,
 			modelRegistry,
+			rebuildSystemPrompt: async () => ({ systemPrompt: await renderPrompt(session?.model ?? primaryModel) }),
 		});
 		const { retryStartEvents, retryEndEvents } = trackRetryEvents(session);
 
@@ -389,6 +417,10 @@ describe("AgentSession retry fallback", () => {
 		expect(retryStartEvents.map(event => event.attempt)).toEqual([1, 2, 1]);
 		expect(retryEndEvents).toHaveLength(1);
 		expect(retryEndEvents[0]).toMatchObject({ success: true });
+		const fallbackPrompt = session.agent.state.systemPrompt.join("\n\n");
+		expect(fallbackPrompt).toContain("Delegation is preferred here.");
+		expect(fallbackPrompt).not.toContain("Proactive multi-agent delegation is active");
+		expect(fallbackPrompt).not.toContain("Keep ownership of the overall task");
 	});
 
 	it("applies a provider-wildcard chain to any model of that provider", async () => {
@@ -1632,14 +1664,39 @@ describe("AgentSession retry fallback", () => {
 		expect(session.model?.id).toBe(fallbackModel.id);
 	});
 	it("suppresses cooled selectors and lazily reverts to the role primary after cooldown expiry", async () => {
-		const primaryModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		const primaryModel = getBundledModel("openai-codex", "gpt-5.6-luna");
 		const fallbackModel = getBundledModel("openai", "gpt-4o-mini");
 		if (!primaryModel || !fallbackModel) {
 			throw new Error("Expected bundled test models to exist");
 		}
+		const renderPrompt = async (model: Model): Promise<string[]> => {
+			const { systemPrompt } = await buildSystemPrompt({
+				cwd: tempDir.path(),
+				contextFiles: [],
+				skills: [],
+				rules: [],
+				toolNames: ["task"],
+				workspaceTree: {
+					rootPath: tempDir.path(),
+					rendered: "",
+					truncated: false,
+					totalLines: 0,
+					agentsMdFiles: [],
+				},
+				activeRepoContext: null,
+				model: `${model.provider}/${model.id}`,
+				includeModelInPrompt: false,
+				eagerTasks: true,
+				taskBatch: true,
+				taskMaxConcurrency: 12,
+			});
+			return systemPrompt;
+		};
+		const initialSystemPrompt = await renderPrompt(primaryModel);
+		expect(initialSystemPrompt.join("\n\n")).toContain("Proactive multi-agent delegation is active");
 
 		const requestedModels: string[] = [];
-		const agent = createFallbackAgent(primaryModel, requestedModels);
+		const agent = createFallbackAgent(primaryModel, requestedModels, initialSystemPrompt);
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -1656,6 +1713,7 @@ describe("AgentSession retry fallback", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings,
 			modelRegistry,
+			rebuildSystemPrompt: async () => ({ systemPrompt: await renderPrompt(session?.model ?? primaryModel) }),
 		});
 		let now = Date.now();
 		vi.spyOn(Date, "now").mockImplementation(() => now);
@@ -1678,6 +1736,9 @@ describe("AgentSession retry fallback", () => {
 		]);
 		expect(session.model?.provider).toBe(fallbackModel.provider);
 		expect(session.model?.id).toBe(fallbackModel.id);
+		const fallbackPrompt = session.agent.state.systemPrompt.join("\n\n");
+		expect(fallbackPrompt).toContain("Delegation is preferred here.");
+		expect(fallbackPrompt).not.toContain("Proactive multi-agent delegation is active");
 
 		now += 240;
 		await session.prompt("Third prompt should lazily revert to primary");
@@ -1690,6 +1751,9 @@ describe("AgentSession retry fallback", () => {
 		]);
 		expect(session.model?.provider).toBe(primaryModel.provider);
 		expect(session.model?.id).toBe(primaryModel.id);
+		const restoredPrompt = session.agent.state.systemPrompt.join("\n\n");
+		expect(restoredPrompt).toContain("Proactive multi-agent delegation is active");
+		expect(restoredPrompt).toContain("Keep ownership of the overall task");
 	});
 
 	it("restores routed fallback primaries after cooldown expiry", async () => {

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -165,7 +165,7 @@ describe("GPT-5.6 delegation prompt policy", () => {
 		expect(rendered).toContain("Do not spawn sub-agents unless");
 		expect(rendered).not.toContain("Proactive multi-agent delegation is active");
 		expect(rendered).not.toContain("Maximize parallelism");
-		expect(rendered).not.toContain("At most 12 subagents");
+		expect(rendered).toContain("At most 12 subagents");
 	});
 
 	it("gives eager GPT-5.6 sessions bounded, supervised delegation guidance", async () => {

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -159,33 +159,26 @@ describe("GPT-5.6 delegation prompt policy", () => {
 		return systemPrompt.join("\n\n");
 	}
 
-	it("keeps default GPT-5.6 sessions non-delegating", async () => {
-		const rendered = await renderDelegationPrompt(false);
+	it("keeps the canonical concurrency cap regardless of eager delegation", async () => {
+		const [defaultRendered, eagerRendered] = await Promise.all([
+			renderDelegationPrompt(false),
+			renderDelegationPrompt(true),
+		]);
 
-		expect(rendered).toContain("Do not spawn sub-agents unless");
-		expect(rendered).not.toContain("Proactive multi-agent delegation is active");
-		expect(rendered).not.toContain("Maximize parallelism");
-		expect(rendered).toContain("At most 12 subagents");
+		expect(defaultRendered).toContain("At most 12 subagents");
+		expect(eagerRendered).toContain("At most 12 subagents");
 	});
 
-	it("gives eager GPT-5.6 sessions bounded, supervised delegation guidance", async () => {
-		const rendered = await renderDelegationPrompt(true);
+	it("reserves eager delegation supervision for the top-level GPT-5.6 agent", async () => {
+		const [rootRendered, descendantRendered] = await Promise.all([
+			renderDelegationPrompt(true),
+			renderDelegationPrompt(true, true),
+		]);
 
-		expect(rendered).toContain("Proactive multi-agent delegation is active");
-		expect(rendered).toContain("Keep ownership of the overall task");
-		expect(rendered).toContain("Monitor sub-agents for stalls");
-		expect(rendered).toContain("At most 12 subagents");
-		expect(rendered).not.toContain("Do not spawn sub-agents unless");
-		expect(rendered).not.toContain("Maximize parallelism");
-	});
-
-	it("reserves active delegation supervision for the top-level GPT-5.6 agent", async () => {
-		const rendered = await renderDelegationPrompt(true, true);
-
-		expect(rendered).toContain("Proactive multi-agent delegation is active");
-		expect(rendered).toContain("At most 12 subagents");
-		expect(rendered).not.toContain("Keep ownership of the overall task");
-		expect(rendered).not.toContain("Monitor sub-agents for stalls");
+		expect(rootRendered).toContain("Keep ownership of the overall task");
+		expect(rootRendered).toContain("Monitor sub-agents for stalls");
+		expect(descendantRendered).not.toContain("Keep ownership of the overall task");
+		expect(descendantRendered).not.toContain("Monitor sub-agents for stalls");
 	});
 });
 

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -138,6 +138,57 @@ describe("system prompt model identifier", () => {
 	});
 });
 
+describe("GPT-5.6 delegation prompt policy", () => {
+	async function renderDelegationPrompt(eagerTasks: boolean, isSubagent = false): Promise<string> {
+		const cwd = process.cwd();
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["task"],
+			workspaceTree: { ...EMPTY_TREE, rootPath: cwd },
+			activeRepoContext: null,
+			model: "openai/gpt-5.6-luna",
+			includeModelInPrompt: false,
+			eagerTasks,
+			isSubagent,
+			taskBatch: true,
+			taskMaxConcurrency: 12,
+		});
+		return systemPrompt.join("\n\n");
+	}
+
+	it("keeps default GPT-5.6 sessions non-delegating", async () => {
+		const rendered = await renderDelegationPrompt(false);
+
+		expect(rendered).toContain("Do not spawn sub-agents unless");
+		expect(rendered).not.toContain("Proactive multi-agent delegation is active");
+		expect(rendered).not.toContain("Maximize parallelism");
+		expect(rendered).not.toContain("At most 12 subagents");
+	});
+
+	it("gives eager GPT-5.6 sessions bounded, supervised delegation guidance", async () => {
+		const rendered = await renderDelegationPrompt(true);
+
+		expect(rendered).toContain("Proactive multi-agent delegation is active");
+		expect(rendered).toContain("Keep ownership of the overall task");
+		expect(rendered).toContain("Monitor sub-agents for stalls");
+		expect(rendered).toContain("At most 12 subagents");
+		expect(rendered).not.toContain("Do not spawn sub-agents unless");
+		expect(rendered).not.toContain("Maximize parallelism");
+	});
+
+	it("reserves active delegation supervision for the top-level GPT-5.6 agent", async () => {
+		const rendered = await renderDelegationPrompt(true, true);
+
+		expect(rendered).toContain("Proactive multi-agent delegation is active");
+		expect(rendered).toContain("At most 12 subagents");
+		expect(rendered).not.toContain("Keep ownership of the overall task");
+		expect(rendered).not.toContain("Monitor sub-agents for stalls");
+	});
+});
+
 describe("AgentSession model-change prompt refresh", () => {
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;


### PR DESCRIPTION
## What

- Keep eager top-level GPT-5.6 agents responsible for monitoring delegated work.
- Show the effective task concurrency cap in GPT-5.6 delegation guidance.
- Keep overall-task manager language out of descendant prompts.

## Why

GPT-5.6 has a dedicated task policy. Its eager branch enabled delegation but omitted the configured cap and any instruction for the main agent to catch stalls, repeated tool errors, scope drift, or disproportionate effort.

## Testing

- `bun test packages/coding-agent/test/system-prompt-model.test.ts` (9 pass)
- `bun check`
- `HOME=<clean> bun scripts/ci-test-ts.ts coding-agent-heavy --only-failures` (95/95 chunks)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

## Grug summary

GPT-5.6 can delegate, but the main agent still watches the herd and stays inside the fence.
