### PR TITLE
fix(coding-agent): keep batch context from expanding child scope

### DIFF
--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -28,16 +28,16 @@
 
 The wire schema is shape-swapped by `task.batch` (default on). One unit of work is the task item `{ name?, agent?, task, isolated? }` (`isolated` only when `task.isolation.mode` is not `none`):
 
-- **Batch shape** (`task.batch` on): `{ context, tasks: item[] }` — one subagent per item, all run under the same fan-out rules; there is no top-level agent field. `context` is **required** shared background rendered into every spawned subagent's system prompt (`CONTEXT` section); `agent` and `isolated` are per item, so one call may mix agent types.
+- **Batch shape** (`task.batch` on): `{ context, tasks: item[] }` — one subagent per item, all run under the same fan-out rules; there is no top-level agent field. `context` is **required** shared background and cross-cutting constraints rendered into every spawned subagent's system prompt (`SHARED CONTEXT` section); it may constrain a child's task but cannot expand its executable scope. `agent` and `isolated` are per item, so one call may mix agent types.
 - **Flat shape** (`task.batch` off): `{ ...item }` — exactly one spawn per call. Shared background goes into a `local://` file (e.g. `local://ctx.md`) that each spawn's `task` references; subagents share the parent's `local://` root.
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `context` | `string` | Yes (batch) | Shared background prepended to every spawn of the call via the subagent system prompt. Rejected when `task.batch` is off. |
+| `context` | `string` | Yes (batch) | Shared background and cross-cutting constraints prepended to every spawn via the subagent system prompt. Parent orchestration here is not child work unless that child's `task` explicitly includes it. Rejected when `task.batch` is off. |
 | `tasks` | `array` | Yes (batch) | One task item per subagent. Provided names must be unique within the call (case-insensitive). Rejected when `task.batch` is off. |
 | `name` | `string` | No | Stable agent name — becomes the registry/IRC id. Defaults to a generated AdjectiveNoun name. Uniquified per session by `AgentOutputManager`. Item field in batch shape, top-level in flat shape. |
 | `agent` | `string` | No | Agent type to run this item (e.g. `scout`). Defaults to the spawn policy's default agent (usually `task`); items in one batch call may use different agent types. Item field in batch shape, top-level in flat shape. |
-| `task` | `string` | Yes | The work — complete, self-contained instructions. Empty-after-trim is rejected. Item field in batch shape, top-level in flat shape. |
+| `task` | `string` | Yes | The executable assignment — complete, self-contained instructions. Shared `context` may constrain this task, but cannot add work to it. Empty-after-trim is rejected. Item field in batch shape, top-level in flat shape. |
 | `isolated` | `boolean` | No | Run in an isolated workspace and return patches. Exists only when `task.isolation.mode` is not `none`; per item in batch shape, top-level in flat shape. Isolated agents are torn down at completion — not revivable. |
 
 There is no wire label field: the one-line UI label shown in the TUI/registry is generated automatically from the `task` text by the tiny/title model (fire-and-forget), so callers never provide it.
@@ -89,7 +89,7 @@ Artifacts and side channels:
 9. If `isolated`, it requires a git repo (`getRepoRoot(...)` / `captureBaseline(...)`), maps `task.isolation.mode` to a backend-kind hint (`parseIsolationMode`), and materializes the workspace via the natives PAL (`ensureIsolation` → `isoResolve`/`isoStart`), walking the candidate list when a backend is unavailable.
 10. Artifacts dir comes from the parent session file when available, otherwise a temp dir. When the session is executing an approved plan, the plan reference is handed to the subagent.
 11. Non-isolated spawns call `runSubprocess(...)` directly with parent cwd; isolated spawns run inside the isolation workspace, then commit to a branch (`mergeMode === "branch"`) or capture a patch, and always clean up the workspace.
-12. `runSubprocess(...)` creates a child agent session with an isolated settings snapshot (forcing `async.enabled = false` and `bash.autoBackground.enabled = false` — subagents are internally synchronous), child `agentId` equal to the allocated id, child internal URL router/`AgentOutputManager`, output schema, the shared `context` (batch calls) in the system prompt's `CONTEXT` section, and the IRC peer roster in the system prompt.
+12. `runSubprocess(...)` creates a child agent session with an isolated settings snapshot (forcing `async.enabled = false` and `bash.autoBackground.enabled = false` — subagents are internally synchronous), child `agentId` equal to the allocated id, child internal URL router/`AgentOutputManager`, output schema, the shared `context` (batch calls) in the system prompt's `SHARED CONTEXT` section, the per-spawn `role` (when given, via `resolveSubagentDisplayName`) as the subagent's system-prompt persona and registry/roster display name, and the IRC peer roster in the system prompt.
 13. Child tool availability: explicit `agent.tools` if provided; auto-add `task` when the agent has `spawns` and depth allows; strip `task` at `task.maxRecursionDepth`; ensure `irc` is present in explicit tool lists; expand `exec` to `eval` + `bash`; strip parent-owned `todo`.
 14. The child must finish through the hidden `yield` tool; up to 3 reminder prompts, the last forcing `toolChoice = yield` when supported. `finalizeSubprocessOutput(...)` reconciles raw text, `yield` payloads, structured schemas, `report_finding` data, and abort states.
 15. End-of-run lifecycle (keep-alive, in `runSubprocess`'s finalizer):
@@ -156,7 +156,7 @@ Artifacts and side channels:
 
 ## Notes
 - Parallelism is parallel `task` calls in one assistant message — or, with `task.batch`, a `tasks[]` batch in one call; either way the session-scoped semaphore bounds the fan-out. With `async.enabled=true`, each spawn is an independent background job.
-- Shared background convention without batch mode: write it once to a `local://` file and reference that path in each spawn's `task` — subagents share the parent's `local://` root. With `task.batch`, the required `context` parameter carries the shared background directly into each spawn's system prompt.
+- Shared background convention without batch mode: write it once to a `local://` file and reference that path in each spawn's `task` — subagents share the parent's `local://` root. With `task.batch`, the required `context` parameter carries shared background and cross-cutting constraints into each spawn's system prompt; executable work remains in each item's `task`.
 - Prefer messaging an existing agent (`irc`) over a fresh spawn for follow-up work: it already holds the relevant context. `irc` op:"list" shows idle/parked candidates; messaging a parked agent revives it. `history://<id>` shows what an agent has done.
 - `irc` availability is derived, not configured (`isIrcEnabled` in `packages/coding-agent/src/tools/irc.ts`): it exists exactly when there is someone to message — the session can spawn subagents, or it is a subagent itself. Messaging is the only follow-up path to a finished subagent, so task without irc would strand idle agents.
 - Subagents are internally synchronous: the executor forces `async.enabled = false` and `bash.autoBackground.enabled = false` in the child settings snapshot, so there are no fire-and-forget grandchildren.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed mouse hover and clicks in the /models Roles view landing one row above the pointer (the row mapping subtracted the status row twice).
 - Fixed model search keeping the most-recently-used model on top of the results: match quality now ranks first (an exact `gpt-5.5` beats the active `gpt-5.6-sol`), with MRU order only breaking ties between equally good matches.
 
+- Prevented shared batch context from expanding a subagent's executable assignment with parent-only orchestration work ([#5134](https://github.com/can1357/oh-my-pi/pull/5134) by [@lyc-aon](https://github.com/lyc-aon)).
 ## [16.4.5] - 2026-07-11
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Prevented shared batch context from expanding a subagent's executable assignment with parent-only orchestration work ([#5134](https://github.com/can1357/oh-my-pi/pull/5134) by [@lyc-aon](https://github.com/lyc-aon)).
 
 ## [16.4.6] - 2026-07-12
 
@@ -31,7 +34,6 @@
 - Fixed mouse hover and clicks in the /models Roles view landing one row above the pointer (the row mapping subtracted the status row twice).
 - Fixed model search keeping the most-recently-used model on top of the results: match quality now ranks first (an exact `gpt-5.5` beats the active `gpt-5.6-sol`), with MRU order only breaking ties between equally good matches.
 
-- Prevented shared batch context from expanding a subagent's executable assignment with parent-only orchestration work ([#5134](https://github.com/can1357/oh-my-pi/pull/5134) by [@lyc-aon](https://github.com/lyc-aon)).
 ## [16.4.5] - 2026-07-11
 
 ### Breaking Changes

--- a/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
@@ -4,10 +4,14 @@ ROLE
 {{agent}}
 
 {{#if context}}
-CONTEXT
+SHARED CONTEXT
 ===================================
 
+This block provides background and cross-cutting constraints. It may constrain how you perform the assignment below, but it does not expand your executable scope.
+
 {{context}}
+
+ASSIGNMENT BOUNDARY: Parent orchestration in shared context—such as instructions to spawn, wait for, poll, monitor, or verify other agents—is not your work unless the per-child assignment explicitly includes it. Execute only the assignment delivered separately.
 {{/if}}
 
 {{#if planReference}}

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -10,7 +10,7 @@ Execution blocks your turn: the call only returns once the work is completely fi
 
 # Inputs
 {{#if batchEnabled}}
-- `context`: Shared project state, constraints, and contracts. Applies to the entire batch; do not duplicate this background into individual tasks.
+- `context`: Shared project state, cross-cutting constraints, and contracts. Applies to the entire batch; do not duplicate this background into individual tasks. It may constrain how children work, but it never adds executable work. Parent workflow actions belong in a child's `task` only when that child must perform them.
 - `tasks[]`: Array of subagents to spawn.
   - `name`: A stable CamelCase identifier (≤32 chars), used to address the agent (IRC, job ids). Generated automatically if omitted.
   - `agent`: The agent type running this item (e.g. `scout`, `reviewer`). Omitting it gives you the general-purpose worker (`{{defaultAgent}}`) — NEVER pass that name explicitly. Only omit it after checking the agent list below and finding no specialist that fits.{{#if allowedAgentsText}} Current spawn policy allows: {{allowedAgentsText}}.{{/if}}
@@ -39,9 +39,11 @@ Subagents start blank. They have no access to your conversation history.
 # Format Contracts
 {{#if batchEnabled}}
 The `context` field MUST follow this format:
-# Goal         ← what the batch accomplishes
-# Constraints  ← rules and session decisions
-# Contract     ← shared interfaces
+# Background                ← project state and why the batch exists
+# Cross-Cutting Constraints ← rules, non-goals, and session decisions
+# Shared Interfaces         ← contracts every child must preserve
+
+Each child's `task` defines its executable scope. Shared `context` may constrain that scope, but cannot expand it.
 {{/if}}
 
 The `task` field MUST follow this format:

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -240,6 +240,49 @@ describe("runSubprocess yield reminders", () => {
 		expect(userPrompt).not.toMatch(/CONTEXT\n=+/);
 	});
 
+	it("keeps shared context from expanding a child's executable scope", async () => {
+		let userPrompt = "";
+		const leafAssignment = "Run one command locally. Do not delegate.";
+		const leakedParentWorkflow = "Spawn a task agent, wait for it, and verify its work.";
+		const session = createMockSession(({ text, emit }) => {
+			userPrompt = text;
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-context-authority",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const createAgentSessionSpy = mockCreateAgentSession(session);
+
+		await runSubprocess({
+			...baseOptions,
+			id: "subagent-context-authority",
+			task: `Complete the assignment below, thoroughly:\n\n${leafAssignment}`,
+			context: leakedParentWorkflow,
+			assignment: leafAssignment,
+		});
+
+		const systemPromptBuilder = createAgentSessionSpy.mock.calls[0]?.[0]?.systemPrompt;
+		expect(systemPromptBuilder).toBeFunction();
+		if (typeof systemPromptBuilder !== "function") throw new Error("Expected system prompt builder");
+		const builtPrompt = systemPromptBuilder(["system", "project", "now"]);
+		const systemPrompt = Array.isArray(builtPrompt) ? builtPrompt : [builtPrompt];
+		const childContract = systemPrompt.find(section => section.includes("SHARED CONTEXT")) ?? "";
+
+		expect(childContract).toContain("does not expand your executable scope");
+		expect(childContract).toContain(leakedParentWorkflow);
+		expect(childContract).toContain("ASSIGNMENT BOUNDARY");
+		expect(childContract).toContain("is not your work unless the per-child assignment explicitly includes it");
+		expect(childContract.indexOf("ASSIGNMENT BOUNDARY")).toBeGreaterThan(childContract.indexOf(leakedParentWorkflow));
+		expect(userPrompt).toContain(leafAssignment);
+		expect(userPrompt).not.toContain(leakedParentWorkflow);
+	});
+
 	it("sends reminder prompt when subagent stops without yield", async () => {
 		const prompts: string[] = [];
 		const promptOptions: Array<PromptOptions | undefined> = [];


### PR DESCRIPTION
## What

- Mark batch context as shared background and constraints.
- Make each child assignment the only source of executable scope.
- Document and test that parent orchestration in context does not become child work.

## Why

Batch context is inserted at system level. Rapid-delegating models could treat parent instructions such as spawn, wait, or monitor as the child's own work despite a leaf assignment.

## Testing

- `bun test packages/coding-agent/test/task/executor-subagent-reminders.test.ts` (20 pass)
- `bun check`
- `HOME=<clean> bun scripts/ci-test-ts.ts coding-agent-heavy --only-failures` (95/95 chunks)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

## Grug summary

Context tells child the terrain. Assignment tells child what to do.
