### PR TITLE
docs(commands): strengthen fix issue analysis

### DIFF
--- a/.omp/commands/fix-issues.md
+++ b/.omp/commands/fix-issues.md
@@ -38,12 +38,13 @@ Each subagent **MUST** follow this exact workflow:
 1. Read `issue://<N>` (or `issue://<owner>/<repo>/<N>` for cross-repo) — fetches the issue body plus comments; comments often carry the real repro and fix hints. Append `?comments=0` only if you explicitly want to skip them.
 2. `gh search prs` for the issue number to see if a fix is already in flight.
    - If a PR exists and looks reasonable → switch tracks: review that PR per `.omp/commands/review-prs.md` instead, and report back as `existing-pr`. Do **not** open a competing fix.
+3. Search open and closed issues for closely related reports using subsystem, symptom, and suspected root-cause terms—not only `#<N>`. Record reports that plausibly share the invariant, but do not treat them as confirmed until source-level investigation and reproduction support the link.
 
 #### b. Diagnose & try to reproduce — **in the current cwd, on `main`**
 
 Reproduce **here first**, before touching any worktree. The point is to confirm the bug is real on current main before investing in a fix branch.
 
-1. Read the relevant source paths in this checkout. Form a concrete hypothesis (one or two sentences) about the failure.
+1. Read the relevant source paths in this checkout. Trace the reported entry point through shared helpers, sibling call paths, and downstream consumers; inspect relevant state, concurrency, and lifecycle boundaries. For bugs involving persistence, path resolution, shared mutable state, cache, concurrency, lifecycle, retries, or cross-process/project boundaries, map the causal chain and responsible identity, ownership, or namespace key. Form a concrete hypothesis (one or two sentences) about the failure and its invariant. Do not guess when that boundary is ambiguous.
 2. Write a focused test file under the package the bug lives in. Naming: `repro-issue-<N>-<slug>.test.ts` (or `.rs`, etc.) — unique, greppable, deletable.
 3. Run **only that test file**, not the suite. Confirm it fails for the reason in the issue.
 
@@ -90,9 +91,9 @@ Use absolute paths — the worktree lives outside the main checkout.
 
 1. Move (don't copy) the failing test file from the main checkout into the same path inside the worktree. Delete it from main so the original cwd is left clean.
 2. Confirm it still fails inside the worktree on the current branch.
-3. Implement the fix in source. Match existing patterns (see `AGENTS.md`); fix at the source, not at the symptom; no stubs, no mocks added to product code.
+3. Implement the source-level root-cause fix. Match existing patterns (see `AGENTS.md`); do not fix only a symptom or add stubs, mocks, or placeholders to product code.
 4. Re-run the repro test until it passes.
-5. Add or adjust adjacent unit/contract tests where the fix changes a real contract — not just plumbing. Run **only** the affected test files; no full-suite runs from subagents.
+5. For every proven directly affected boundary that shares the invariant, add and run the smallest regression test that demonstrates the effect. For those stateful or boundary-crossing bugs, include the smallest negative regression test proving the unwanted side effect does not recur; when a shared resource can cross independent contexts or agents, include paired-context/isolation coverage. Also add or adjust adjacent unit/contract tests where the fix changes a real contract — not just plumbing. Run **only** the affected test files; no full-suite runs from subagents.
 6. Run `bun fmt` over the union of files edited.
 
 #### f. Commit
@@ -122,11 +123,13 @@ Worktree:  ~/.omp/wt/.../fix-issue-<N>            (if created)
 Branch:    fix/issue-<N>                          (if created)
 Commits:   <shas + one-liners>                    (if any)
 Notes:     <root cause in one sentence; or what info is missing>
+Coverage:  <related reports/manifestations investigated; proven boundaries tested; explicit exclusions>
 ```
 
 ### 3. Aggregate
 
 After all subagents finish, print a single summary table:
+Carry each subagent's bounded coverage into its `Branch / Notes` cell.
 
 ```
 | # | Title | Status | Branch / Notes |
@@ -135,6 +138,14 @@ After all subagents finish, print a single summary table:
 
 Group worktree paths by status (`fixed` first), so the user can `cd` and push the ready ones in one pass.
 
+## Engineering constraints
+
+- Verify issue claims, review findings, and related-report links against source and focused reproduction before relying on them.
+- Treat every demonstrably same-invariant path as in scope; explicitly bound unrelated cleanup, speculative hardening, and refactors outside it.
+- Tests enforce verified behavior.
+- Make clean, maintained source-level root-cause fixes; do not ship stubs, mocks-as-product-code, or placeholders.
+- Do not push, open PRs, or comment on issues; the human handles delivery.
+
 ## Rules
 
 - **MUST** reproduce on `main` in the current cwd **before** creating any worktree. No worktree until repro is confirmed.
@@ -142,7 +153,5 @@ Group worktree paths by status (`fixed` first), so the user can `cd` and push th
 - **MUST** check for an existing PR first; if one exists and is reasonable, divert to `review-prs` flow instead of duplicating work.
 - **MUST** symlink `target`, `node_modules`, and the native `*.node` binaries before any build/test runs in the worktree. **MUST NOT** symlink the whole `packages/natives/native/` directory that would shadow tracked source files.
 - **MUST** use conventional commits with `Fixes #<N>` in the body.
-- **MUST NOT** push, open PRs, or comment on issues. Human handles delivery.
-- **MUST NOT** ship stubs, mocks-as-product-code, or "TODO: implement" placeholders as a fix.
-- **MUST NOT** expand scope: fix the reported bug, not adjacent code smells.
+- For bugs involving persistence, path resolution, shared mutable state, cache, concurrency, lifecycle, retries, or cross-process/project boundaries, **MUST** identify the causal chain and responsible identity, ownership, or namespace key; **MUST** add the smallest negative regression proving the unwanted side effect does not recur; and **MUST** add paired-context/isolation coverage when a shared resource can cross independent contexts or agents.
 - If repro fails, delete the temporary test file from cwd before yielding — leave the original checkout clean.


### PR DESCRIPTION
## Summary

Enhances `/fix-issues` without changing its resolve → reproduce → worktree → fix → commit → aggregate workflow.

- Finds closely related reports by subsystem, symptom, and suspected root cause.
- Traces shared helpers, consumers, and relevant state/concurrency/lifecycle boundaries.
- Requires evidence-backed same-invariant fixes and focused regressions for direct side effects.
- Adds conditional ownership/namespace and paired-context isolation checks for stateful or cross-context bugs.

## Validation

- `git diff --check`
- Prompt contract check confirming the existing workflow and no-push guard remain present.