### PR TITLE
perf(coding-agent): fast-path version output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `omp --version` and `omp -v` to return before loading the full command registry.
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -3,48 +3,57 @@
  *
  * Lives in its own module (importable without side effects) so that tests can
  * inspect the registered subcommands without triggering the side-effectful
- * top-level await in `cli.ts`. Adding a new subcommand here is enough to make
- * `runCli` route to it instead of forwarding the argv as a prompt to
- * `launch` — see #1496 for the original "args silently leak to the LLM"
- * regression that motivated the split.
+ * top-level await in `cli.ts`. New subcommands need a static name entry in
+ * `cli/subcommands.ts` and a matching loader here. The typed loader map keeps
+ * those two pieces in sync — see #1496 for the original "args silently leak
+ * to the LLM" regression that motivated the split.
  */
 import type { CommandEntry } from "@oh-my-pi/pi-utils/cli";
 import { flagConsumesValue } from "./cli/flag-tables";
+import { isSubcommand, SUBCOMMANDS, type SubcommandName } from "./cli/subcommands";
 
-export const commands: CommandEntry[] = [
-	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
-	{ name: "acp", load: () => import("./commands/acp").then(m => m.default) },
-	{ name: "auth-broker", load: () => import("./commands/auth-broker").then(m => m.default) },
-	{ name: "auth-gateway", load: () => import("./commands/auth-gateway").then(m => m.default) },
-	{ name: "agents", load: () => import("./commands/agents").then(m => m.default) },
-	{ name: "bench", load: () => import("./commands/bench").then(m => m.default) },
-	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
-	{ name: "completions", load: () => import("./commands/completions").then(m => m.default) },
-	{ name: "__complete", load: () => import("./commands/complete").then(m => m.default) },
-	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
-	{ name: "dry-balance", load: () => import("./commands/dry-balance").then(m => m.default) },
-	{ name: "gc", load: () => import("./commands/gc").then(m => m.default) },
-	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
-	{ name: "gallery", load: () => import("./commands/gallery").then(m => m.default) },
-	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
-	{ name: "install", load: () => import("./commands/install").then(m => m.default) },
-	{ name: "join", load: () => import("./commands/join").then(m => m.default) },
-	{ name: "models", load: () => import("./commands/models").then(m => m.default) },
-	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
-	{ name: "say", load: () => import("./commands/say").then(m => m.default) },
-	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
-	{ name: "shell", load: () => import("./commands/shell").then(m => m.default) },
-	{ name: "read", load: () => import("./commands/read").then(m => m.default) },
-	{ name: "ssh", load: () => import("./commands/ssh").then(m => m.default) },
-	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
-	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
-	{ name: "usage", load: () => import("./commands/usage").then(m => m.default) },
-	{ name: "tiny-models", load: () => import("./commands/tiny-models").then(m => m.default) },
-	{ name: "token", load: () => import("./commands/token").then(m => m.default) },
-	{ name: "ttsr", load: () => import("./commands/ttsr").then(m => m.default) },
-	{ name: "worktree", load: () => import("./commands/worktree").then(m => m.default), aliases: ["wt"] },
-	{ name: "search", load: () => import("./commands/web-search").then(m => m.default), aliases: ["q"] },
-];
+export { isSubcommand } from "./cli/subcommands";
+
+const commandLoaders = {
+	launch: () => import("./commands/launch").then(m => m.default),
+	acp: () => import("./commands/acp").then(m => m.default),
+	"auth-broker": () => import("./commands/auth-broker").then(m => m.default),
+	"auth-gateway": () => import("./commands/auth-gateway").then(m => m.default),
+	agents: () => import("./commands/agents").then(m => m.default),
+	bench: () => import("./commands/bench").then(m => m.default),
+	commit: () => import("./commands/commit").then(m => m.default),
+	completions: () => import("./commands/completions").then(m => m.default),
+	__complete: () => import("./commands/complete").then(m => m.default),
+	config: () => import("./commands/config").then(m => m.default),
+	"dry-balance": () => import("./commands/dry-balance").then(m => m.default),
+	gc: () => import("./commands/gc").then(m => m.default),
+	grep: () => import("./commands/grep").then(m => m.default),
+	gallery: () => import("./commands/gallery").then(m => m.default),
+	grievances: () => import("./commands/grievances").then(m => m.default),
+	install: () => import("./commands/install").then(m => m.default),
+	join: () => import("./commands/join").then(m => m.default),
+	models: () => import("./commands/models").then(m => m.default),
+	plugin: () => import("./commands/plugin").then(m => m.default),
+	say: () => import("./commands/say").then(m => m.default),
+	setup: () => import("./commands/setup").then(m => m.default),
+	shell: () => import("./commands/shell").then(m => m.default),
+	read: () => import("./commands/read").then(m => m.default),
+	ssh: () => import("./commands/ssh").then(m => m.default),
+	stats: () => import("./commands/stats").then(m => m.default),
+	update: () => import("./commands/update").then(m => m.default),
+	usage: () => import("./commands/usage").then(m => m.default),
+	"tiny-models": () => import("./commands/tiny-models").then(m => m.default),
+	token: () => import("./commands/token").then(m => m.default),
+	ttsr: () => import("./commands/ttsr").then(m => m.default),
+	worktree: () => import("./commands/worktree").then(m => m.default),
+	search: () => import("./commands/web-search").then(m => m.default),
+} satisfies Record<SubcommandName, CommandEntry["load"]>;
+
+export const commands: CommandEntry[] = SUBCOMMANDS.map(command => ({
+	name: command.name,
+	load: commandLoaders[command.name],
+	...("aliases" in command ? { aliases: [...command.aliases] } : {}),
+}));
 
 // Documented-looking plugin-management verbs that are NOT registered top-level
 // commands. Without a guard `resolveCliArgv` rewrites e.g. `omp list` to
@@ -79,11 +88,6 @@ export function reservedTopLevelWordMessage(first: string | undefined, argc = 1)
  * Flags (`-…`) and `@file` arguments are never subcommands; for those the CLI
  * runner skips ahead to the default `launch` command.
  */
-export function isSubcommand(first: string | undefined): boolean {
-	if (!first || first.startsWith("-") || first.startsWith("@")) return false;
-	return commands.some(entry => entry.name === first || entry.aliases?.includes(first));
-}
-
 export type ResolvedCliArgv = { argv: string[] } | { error: string };
 
 /**

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -317,6 +317,10 @@ export async function runCli(argv: string[]): Promise<void> {
 		await runSmokeTest();
 		return;
 	}
+	if (resolvedArgv[0] === "--version" || resolvedArgv[0] === "-v") {
+		process.stdout.write(`${APP_NAME}/${VERSION}\n`);
+		return;
+	}
 	const [{ run }, { commands, resolveCliArgv }] = await Promise.all([
 		import("@oh-my-pi/pi-utils/cli"),
 		import("./cli-commands"),

--- a/packages/coding-agent/src/cli/profile-bootstrap.ts
+++ b/packages/coding-agent/src/cli/profile-bootstrap.ts
@@ -33,7 +33,6 @@
  * them also activates (`omp --print --profile work`).
  */
 
-import { isSubcommand } from "../cli-commands";
 import {
 	EXTENSION_SHADOWABLE_STRING_FLAGS,
 	isUnknownLongValueCandidate,
@@ -42,6 +41,7 @@ import {
 	PROFILE_BOOTSTRAP_BOUNDARY_ARG,
 	STRING_VALUE_FLAGS,
 } from "./flag-tables";
+import { isSubcommand } from "./subcommands";
 
 function isProfileBootstrapSubcommand(arg: string): boolean {
 	return arg === "launch" || arg === "acp";

--- a/packages/coding-agent/src/cli/subcommands.ts
+++ b/packages/coding-agent/src/cli/subcommands.ts
@@ -1,0 +1,51 @@
+/**
+ * Top-level command names and aliases needed during profile bootstrap.
+ *
+ * Keep this module limited to static data: profile selection runs before the
+ * full command registry may be loaded.
+ */
+export const SUBCOMMANDS = [
+	{ name: "launch" },
+	{ name: "acp" },
+	{ name: "auth-broker" },
+	{ name: "auth-gateway" },
+	{ name: "agents" },
+	{ name: "bench" },
+	{ name: "commit" },
+	{ name: "completions" },
+	{ name: "__complete" },
+	{ name: "config" },
+	{ name: "dry-balance" },
+	{ name: "gc" },
+	{ name: "grep" },
+	{ name: "gallery" },
+	{ name: "grievances" },
+	{ name: "install" },
+	{ name: "join" },
+	{ name: "models" },
+	{ name: "plugin" },
+	{ name: "say" },
+	{ name: "setup" },
+	{ name: "shell" },
+	{ name: "read" },
+	{ name: "ssh" },
+	{ name: "stats" },
+	{ name: "update" },
+	{ name: "usage" },
+	{ name: "tiny-models" },
+	{ name: "token" },
+	{ name: "ttsr" },
+	{ name: "worktree", aliases: ["wt"] },
+	{ name: "search", aliases: ["q"] },
+] as const;
+
+export type SubcommandName = (typeof SUBCOMMANDS)[number]["name"];
+
+const SUBCOMMAND_LOOKUP = new Set<string>(
+	SUBCOMMANDS.flatMap(command => [command.name, ...("aliases" in command ? command.aliases : [])]),
+);
+
+export function isSubcommand(first: string | undefined): boolean {
+	if (!first || first.startsWith("-") || first.startsWith("@")) return false;
+	return SUBCOMMAND_LOOKUP.has(first);
+}

--- a/packages/coding-agent/test/profile-cli.test.ts
+++ b/packages/coding-agent/test/profile-cli.test.ts
@@ -99,7 +99,7 @@ describe("global --profile flag", () => {
 		await runCli(["--profile=work", "--version"]);
 
 		expect(process.exitCode).toBe(0);
-		expect(writeSpy).toHaveBeenCalled();
+		expect(writeSpy).toHaveBeenCalledWith(`${APP_NAME}/${VERSION}\n`);
 		expect(getActiveProfile()).toBe("work");
 		expect(getAgentDir()).toBe(path.join(os.homedir(), configDir, "profiles", "work", "agent"));
 	});
@@ -113,18 +113,69 @@ describe("global --profile flag", () => {
 		await runCli(["--version"]);
 
 		expect(process.exitCode).toBe(0);
-		expect(writeSpy).toHaveBeenCalled();
+		expect(writeSpy).toHaveBeenCalledWith(`${APP_NAME}/${VERSION}\n`);
 		expect(getActiveProfile()).toBe("work");
 		expect(getAgentDir()).toBe(path.join(os.homedir(), configDir, "profiles", "work", "agent"));
 		expect(getAgentDbPath()).toBe(path.join(os.homedir(), configDir, "profiles", "work", "agent", "agent.db"));
 	});
 
+	it("prints --version and -v without loading the command registry", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-version-fast-path-"));
+		try {
+			const preloadPath = path.join(root, "block-cli-commands.ts");
+			await Bun.write(
+				preloadPath,
+				[
+					"Bun.plugin({",
+					'  name: "block-cli-commands",',
+					"  setup(build) {",
+					"    build.onResolve({ filter: /^\\.\\/cli-commands$/ }, () => ({",
+					'      path: "cli-commands-blocked",',
+					'      namespace: "cli-commands-blocked",',
+					"    }));",
+					'    build.onLoad({ filter: /.*/, namespace: "cli-commands-blocked" }, () => ({',
+					'      contents: "throw new Error(\\"cli-commands import blocked\\"); export {}; ",',
+					'      loader: "ts",',
+					"    }));",
+					"  },",
+					"});",
+				].join("\n"),
+			);
+
+			for (const flag of ["--version", "-v"]) {
+				const proc = Bun.spawn([process.execPath, "--preload", preloadPath, cliEntry, flag], {
+					cwd: repoRoot,
+					stdout: "pipe",
+					stderr: "pipe",
+					env: {
+						...process.env,
+						PI_CONFIG_DIR: `.omp-version-fast-path-${flag.replaceAll("-", "")}`,
+						PI_NO_TITLE: "1",
+						NO_COLOR: "1",
+					},
+				});
+				const [stdout, stderr, exitCode] = await Promise.all([
+					readStream(proc.stdout as ReadableStream<Uint8Array>),
+					readStream(proc.stderr as ReadableStream<Uint8Array>),
+					proc.exited,
+				]);
+
+				expect(exitCode, stderr).toBe(0);
+				expect(stdout).toBe(`${APP_NAME}/${VERSION}\n`);
+				expect(stderr).not.toContain("cli-commands import blocked");
+			}
+		} finally {
+			await removeWithRetries(root);
+		}
+	});
+
 	it("accepts the profile flag after other root flags", async () => {
-		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
 		await runCli(["--version", "--profile", "office"]);
 
 		expect(process.exitCode).toBe(0);
+		expect(writeSpy).toHaveBeenCalledWith(`${APP_NAME}/${VERSION}\n`);
 		expect(getActiveProfile()).toBe("office");
 		expect(getAgentDir()).toBe(path.join(os.homedir(), configDir, "profiles", "office", "agent"));
 	});


### PR DESCRIPTION
## What

Return `omp --version` and `omp -v` before loading the full CLI command registry while preserving profile, worker, and smoke-test bootstrap behavior.

## Why

Version checks only need the application name and version. Loading command routing metadata added avoidable startup work, including when update tooling invokes the version command.

## Before/after benchmark

Compared commit `ef4992f8a` with its exact parent `7aa1d581c` from separate clean worktrees using Bun 1.3.14 and the same dependency tree on an Apple M4 Pro running macOS 26.2.

These are source-run timings, not compiled-binary timings. Hyperfine 1.20.0 used 10 warmups and 100 measured executions per command, split across two 50-run passes in opposite order to reduce order and thermal drift.

| Command | Parent mean ± σ | PR mean ± σ | Parent median | PR median | Median improvement | Parent range | PR range |
|---|---:|---:|---:|---:|---:|---:|---:|
| `--version` | 31.855 ± 4.454 ms | 26.362 ± 4.145 ms | 31.362 ms | 25.948 ms | **5.414 ms / 17.26%** | 27.574–57.388 ms | 22.241–56.470 ms |
| `-v` | 34.286 ± 9.144 ms | 29.395 ± 7.141 ms | 31.981 ms | 27.494 ms | **4.487 ms / 14.03%** | 27.828–90.620 ms | 23.308–61.363 ms |

Mean improvements were 5.493 ms / 17.24% for `--version` and 4.891 ms / 14.26% for `-v`.

Benchmark shape:

```sh
hyperfine --warmup 10 --runs 50 \
  --command-name 'parent --version' 'cd <parent-worktree> && bun packages/coding-agent/src/cli.ts --version' \
  --command-name 'PR --version' 'cd <pr-worktree> && bun packages/coding-agent/src/cli.ts --version'
# Repeated in reverse order; the same procedure was used for -v.
```

## Testing

- `bun test packages/coding-agent/test/profile-cli.test.ts packages/coding-agent/test/profile-bootstrap.test.ts packages/coding-agent/test/cli-argv-routing.test.ts` — 45 passed
- Subprocess coverage proves both flags succeed when command-registry loading is made fatal
- `bun check`
- `git diff --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)