### PR TITLE
fix(coding-agent): flush throttled output tails

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed throttled live command output holding a quiet final chunk until the command exited.
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -735,6 +735,7 @@ export class OutputSink {
 	#truncated = false;
 	#lastChunkTime = 0;
 	#pendingChunk = "";
+	#pendingChunkTimer: Timer | undefined;
 
 	// Per-line column cap streaming state (persists across `push` calls so a
 	// long line split across chunks still trips the same trigger).
@@ -806,20 +807,18 @@ export class OutputSink {
 	push(chunk: string): void {
 		chunk = sanitizeWithOptionalSixelPassthrough(chunk, sanitizeText);
 
-		// Throttled onChunk: coalesce chunks arriving inside the throttle window
-		// and flush the buffered concatenation on the next eligible tick (plus a
-		// final flush in dump()) so the preview never has silent gaps.
+		// Throttled onChunk: coalesce chunks arriving inside the throttle window.
+		// A timer flushes quiet tails at the throttle boundary; dump() catches a
+		// final pending chunk when the process exits before that timer fires.
 		// Live preview gets the raw (pre-cap) chunk so the TUI never lags behind
 		// what reached the sink — the column cap is for the persisted LLM view.
 		if (this.#onChunk) {
 			const now = Date.now();
 			if (now - this.#lastChunkTime >= this.#chunkThrottleMs) {
-				this.#lastChunkTime = now;
-				const merged = this.#pendingChunk + chunk;
-				this.#pendingChunk = "";
-				this.#onChunk(merged);
+				this.#emitPendingChunkWith(chunk, now);
 			} else {
 				this.#pendingChunk += chunk;
+				this.#schedulePendingChunkFlush();
 			}
 		}
 
@@ -1121,6 +1120,7 @@ export class OutputSink {
 	 * branch in `dump()` against stale totals.
 	 */
 	replace(text: string): void {
+		this.#clearPendingChunkTimer();
 		this.#buffer = text;
 		this.#bufferBytes = Buffer.byteLength(text, "utf-8");
 		this.#head = "";
@@ -1136,6 +1136,38 @@ export class OutputSink {
 		this.#columnDroppedBytes = 0;
 		this.#columnTruncatedLines = 0;
 		this.#pendingChunk = "";
+	}
+
+	#clearPendingChunkTimer(): void {
+		if (!this.#pendingChunkTimer) return;
+		clearTimeout(this.#pendingChunkTimer);
+		this.#pendingChunkTimer = undefined;
+	}
+
+	#emitPendingChunkWith(chunk: string, now: number): void {
+		this.#clearPendingChunkTimer();
+		this.#lastChunkTime = now;
+		const merged = this.#pendingChunk + chunk;
+		this.#pendingChunk = "";
+		this.#onChunk?.(merged);
+	}
+
+	#flushPendingChunk(): void {
+		if (this.#pendingChunk.length === 0) {
+			this.#clearPendingChunkTimer();
+			return;
+		}
+		this.#emitPendingChunkWith("", Date.now());
+	}
+
+	#schedulePendingChunkFlush(): void {
+		if (this.#chunkThrottleMs <= 0 || this.#pendingChunkTimer) return;
+		const elapsed = Date.now() - this.#lastChunkTime;
+		const delay = Math.max(0, this.#chunkThrottleMs - elapsed);
+		this.#pendingChunkTimer = setTimeout(() => {
+			this.#pendingChunkTimer = undefined;
+			this.#flushPendingChunk();
+		}, delay);
 	}
 
 	/**
@@ -1179,11 +1211,7 @@ export class OutputSink {
 
 		// Flush any chunk still held back by the throttle so the live preview
 		// ends with the complete stream.
-		if (this.#onChunk && this.#pendingChunk.length > 0) {
-			const pending = this.#pendingChunk;
-			this.#pendingChunk = "";
-			this.#onChunk(pending);
-		}
+		this.#flushPendingChunk();
 		const totalLines = this.#sawData ? this.#totalLines + 1 : 0;
 
 		if (this.#file) {

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -32,6 +32,7 @@ function byteLength(text: string): number {
 }
 
 afterEach(async () => {
+	vi.useRealTimers();
 	for (const dir of createdTempDirs.splice(0)) {
 		await removeWithRetries(dir);
 	}
@@ -315,6 +316,48 @@ describe("OutputSink", () => {
 		// First push fires immediately; dump flushes the coalesced remainder.
 		expect(chunks).toEqual(["a", "bc"]);
 		expect(dumped.output).toBe("abc");
+	});
+
+	test("throttled onChunk emits a quiet tail at the throttle boundary", () => {
+		vi.useFakeTimers();
+		const chunks: string[] = [];
+		const sink = new OutputSink({ onChunk: chunk => chunks.push(chunk), chunkThrottleMs: 20 });
+
+		sink.push("a");
+		sink.push("b");
+		expect(chunks).toEqual(["a"]);
+
+		vi.advanceTimersByTime(20);
+
+		expect(chunks).toEqual(["a", "b"]);
+	});
+
+	test("dump flushes a throttled tail once and cancels its timer", async () => {
+		vi.useFakeTimers();
+		const chunks: string[] = [];
+		const sink = new OutputSink({ onChunk: chunk => chunks.push(chunk), chunkThrottleMs: 20 });
+
+		sink.push("a");
+		sink.push("b");
+		expect((await sink.dump()).output).toBe("ab");
+		expect(chunks).toEqual(["a", "b"]);
+
+		vi.advanceTimersByTime(20);
+
+		expect(chunks).toEqual(["a", "b"]);
+	});
+
+	test("replace cancels a throttled tail and discards its pending preview", () => {
+		vi.useFakeTimers();
+		const chunks: string[] = [];
+		const sink = new OutputSink({ onChunk: chunk => chunks.push(chunk), chunkThrottleMs: 20 });
+
+		sink.push("a");
+		sink.push("superseded");
+		sink.replace("replacement");
+		vi.advanceTimersByTime(20);
+
+		expect(chunks).toEqual(["a"]);
 	});
 
 	test("caps artifact-on-disk size: head + notice + tail when stream exceeds cap", async () => {


### PR DESCRIPTION
## What

Flush buffered live command output when its throttle boundary arrives, even if no later chunk is received. Cancel the scheduled flush when output is replaced or synchronously dumped.

## Why

A chunk arriving inside the throttle window remained hidden until another chunk arrived or the command completed. Long-running commands that became quiet could therefore show stale live output indefinitely.

This is downstream preview scheduling only; it does not change native shell buffering or backpressure.

## Before/after evidence

The normal live bash path configures a 50 ms output throttle.

The exact new deterministic tests were run against the parent `7aa1d581c` by applying only the current test file over that revision:

| Contract | Parent | PR `71aaad50e` |
|---|---:|---:|
| Quiet tail appears at its configured boundary | Fail: callbacks remained `["a"]` | Pass: callbacks became `["a", "b"]` |
| `dump()` flushes once and cancels the timer | Pass | Pass |
| `replace()` discards superseded pending preview | Pass | Pass |

A bounded real-clock check ran 10 samples per revision with a 50 ms throttle: push `"a"`, immediately push `"b"`, observe for 75 ms, then call `dump()`.

| Revision | Tail delivered before `dump()` | Observed tail latency | Callback count after `dump()` |
|---|---:|---:|---:|
| Parent `7aa1d581c` | 0/10 | Not delivered within 75 ms | 2 |
| PR `71aaad50e` | 10/10 | 50.56–53.07 ms; mean 51.26 ms | 2 |

On the parent, the tail first appeared when `dump()` ran after the observation window. On the PR it appeared at the configured boundary, and `dump()` did not emit it again.

This proves live-preview delivery timing and timer lifecycle. It does not claim faster command execution or higher throughput; persisted output was already complete when the command ended.

## Testing

- `bun test packages/coding-agent/test/streaming-output.test.ts` — 55 passed, 155 assertions
- Contracts cover boundary delivery, dump single-delivery, and replace cancellation
- `bun check`
- `git diff --check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)