### PR TITLE
docs: Grok Build RE dossier for #4945 (DOSSIER_ONLY gate)

### DIFF
--- a/docs/research/grok-build-re/README.md
+++ b/docs/research/grok-build-re/README.md
@@ -4,7 +4,7 @@ Related product request: [can1357/oh-my-pi#4945](https://github.com/can1357/oh-m
 
 **Status: DOSSIER_ONLY.** This document is behavior-evidence for a future separate Build-quota provider. It is **not** a ship of Build chat, Build auth, Build models, or Build usage code. Existing SuperGrok `xai-oauth` (including `xai-oauth/grok-build*`) is unchanged.
 
-Redacted capture fixtures live under [`fixtures/`](fixtures/). Every header and body **value** was redacted before write; only names, lengths, schemas, hosts, methods, and paths are retained.
+Redacted capture fixtures live under [`fixtures/`](fixtures/). Every header and body **value** was redacted before write; retained fields are names, lengths, schemas, hosts, methods, and paths. Public OAuth client identifiers are published only as redacted length metadata, not literal values.
 
 
 ## Executive summary — **DOSSIER_ONLY**
@@ -31,7 +31,7 @@ The official binary is an RE oracle only: `grok 0.2.93 (f00f96316d) [stable]`. W
 - Wave B exercised the official `grok 0.2.93 (f00f96316d) [stable]` binary. Loopback capture used a base-URL override bound only to `127.0.0.1`; every persisted request header/body value was converted to redaction metadata before the fixture was written. The loopback response bodies and statuses are explicitly synthetic and prove request emission only. [Evidence: [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/strace-local-prompt-summary.json`](fixtures/strace-local-prompt-summary.json)]
 - Production transport proof came from redacted `strace` summaries. Authenticated `models` resolved `cli-chat-proxy.grok.com` and connected to its corroborated TLS addresses. The traced `-m grok-build` prompt resolved the same name and connected to one corroborated TLS address, but ended with a redacted non-JSON CLI error. `strace` did not reveal decrypted HTTP, SNI, a status, a response body, or SSE frames. Therefore this is **host DNS/TCP proof only**, not production host/path proof. [Evidence: [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)]
 - The TLS key-log experiment produced an empty temporary file, so it provides no decrypted-wire evidence. [Evidence: [`fixtures/sslkeylog-experiment.json`](fixtures/sslkeylog-experiment.json)]
-- Sensitive fixture data is intentionally limited to field names, types, and redacted lengths. No token, authorization, API-key, email, user identifier, cookie, raw trace line, or raw CLI error is reproduced here. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/api-key-differential.json`](fixtures/api-key-differential.json)]
+- Sensitive fixture data is intentionally limited to field names, types, redacted lengths, and non-secret host metadata. No token, authorization, API-key, email, user identifier, cookie, raw trace line, or raw CLI error is reproduced here. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/api-key-differential.json`](fixtures/api-key-differential.json)]
 - Offline static strings from the same oracle binary remain leads, not contracts. In particular, static auth, billing, streaming, host, and model-like tokens cannot establish a Build request path, authentication rule, model inventory, SSE contract, or usage API.
 
 ## Confirmed request-side facts only
@@ -97,7 +97,7 @@ Static 401/403/429, quota, credit, and access-gate text remains **unverified —
 
 ### 6. Build usage/billing — **partial and the ship blocker**
 
-Normal-turn initialization emitted `GET /v1/user?include=subscription` once and `GET /v1/user` three times under loopback capture. Both requests carried the distinct header subsets shown above. No response was from the production service; the recorder supplied only synthetic errors for non-model paths. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+Normal-turn initialization emitted `GET /v1/user?include=subscription` once and `GET /v1/user` three times under loopback capture. Both requests carried the same header-name subset shown above (`accept`, `accept-encoding`, `authorization`, `host`, `user-agent`, `x-grok-client-version`, `x-xai-token-auth`). No response was from the production service; the recorder supplied only synthetic errors for non-model paths. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
 
 There is no captured durable Build residual, used amount, limit, reset, unit, account scope, or update cadence. Static billing paths and field-like tokens are **unverified — confirm first** and MUST NOT be substituted for Build usage reporting. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
 

--- a/docs/research/grok-build-re/README.md
+++ b/docs/research/grok-build-re/README.md
@@ -1,0 +1,154 @@
+# Grok Build RE Dossier
+
+Related product request: [can1357/oh-my-pi#4945](https://github.com/can1357/oh-my-pi/issues/4945).
+
+**Status: DOSSIER_ONLY.** This document is behavior-evidence for a future separate Build-quota provider. It is **not** a ship of Build chat, Build auth, Build models, or Build usage code. Existing SuperGrok `xai-oauth` (including `xai-oauth/grok-build*`) is unchanged.
+
+Redacted capture fixtures live under [`fixtures/`](fixtures/). Every header and body **value** was redacted before write; only names, lengths, schemas, hosts, methods, and paths are retained.
+
+
+## Executive summary — **DOSSIER_ONLY**
+
+The official binary is an RE oracle only: `grok 0.2.93 (f00f96316d) [stable]`. Wave B confirms selected **request emission** and a production DNS/TCP destination, but it does not confirm production response contracts. In particular, a normal coding turn emitted `GET /v1/user?include=subscription` and `GET /v1/user` under loopback capture, yet no successful response body supplied residual, used, unit, or reset data. Item 6 therefore fails the plan's durable Build-usage gate. Items 1–7 are not all complete, so a Build provider MUST NOT ship. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+**Decision:** publish this evidence dossier only. Do not implement Build auth, Build chat, Build usage, model registration, or error classification from the present evidence. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+### Exit-criteria status matrix
+
+| RE item | Status | Behavior evidence | Gate-relevant missing proof |
+|---|---|---|---|
+| 1. Auth | **partial** | Parseable official auth-store field shape, a usable stored session, authenticated emitted header names, and fake-key-only local failure before network. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/api-key-differential.json`](fixtures/api-key-differential.json)] | Login/device flow, refresh wire, exact accepted/rejected production-auth semantics, and bare-key rejection at a real Build endpoint. |
+| 2. Chat wire | **partial** | Loopback override emitted `POST /v1/responses` schemas; a `-m grok-build` production trace resolved and connected to `cli-chat-proxy.grok.com`. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)] | Successful production HTTP status/body and whether emitted fields are required. |
+| 3. Streaming | **unverified — confirm first** | Only a request-side `stream` boolean was emitted. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)] | Content type, SSE event names/data, terminal done/error behavior, and cancellation. |
+| 4. Models | **partial** | `GET /v1/models` emitted; one authenticated session displayed two account-visible IDs. [Evidence: [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json)] | Successful remote response schema, complete Build inventory, pagination, and an authorized `api.x.ai` comparison if needed. |
+| 5. Quota/errors | **unverified — confirm first** | Available 401s were synthetic loopback responses; the live prompt exposed no HTTP status or response body. [Evidence: [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)] | Distinguishing production quota, auth, and ordinary rate-limit status/body/header signals. |
+| 6. Usage/billing | **partial — ship blocker** | The staged normal turn emitted `GET /v1/user?include=subscription` and `GET /v1/user`; no remote response body was captured. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)] | Durable residual/used/reset fields, units, update cadence, and authenticated response semantics. |
+| 7. Refresh/session | **partial** | The official auth store contains redacted refresh/expiry fields; response requests emitted conversation/session/request IDs and later-turn index. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)] | Refresh endpoint/method/body/rotation and demonstrated multi-turn continuity requirements. |
+| 8. Default-chat adjacent | **partial** | The staged normal turn emitted settings, bundle, subscription/user, and feedback-config requests. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)] | Sidecar response schemas, recap/default toolset identifiers, and required-versus-best-effort behavior. |
+
+## Evidence method and limits
+
+- Wave B exercised the official `grok 0.2.93 (f00f96316d) [stable]` binary. Loopback capture used a base-URL override bound only to `127.0.0.1`; every persisted request header/body value was converted to redaction metadata before the fixture was written. The loopback response bodies and statuses are explicitly synthetic and prove request emission only. [Evidence: [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/strace-local-prompt-summary.json`](fixtures/strace-local-prompt-summary.json)]
+- Production transport proof came from redacted `strace` summaries. Authenticated `models` resolved `cli-chat-proxy.grok.com` and connected to its corroborated TLS addresses. The traced `-m grok-build` prompt resolved the same name and connected to one corroborated TLS address, but ended with a redacted non-JSON CLI error. `strace` did not reveal decrypted HTTP, SNI, a status, a response body, or SSE frames. Therefore this is **host DNS/TCP proof only**, not production host/path proof. [Evidence: [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)]
+- The TLS key-log experiment produced an empty temporary file, so it provides no decrypted-wire evidence. [Evidence: [`fixtures/sslkeylog-experiment.json`](fixtures/sslkeylog-experiment.json)]
+- Sensitive fixture data is intentionally limited to field names, types, and redacted lengths. No token, authorization, API-key, email, user identifier, cookie, raw trace line, or raw CLI error is reproduced here. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/api-key-differential.json`](fixtures/api-key-differential.json)]
+- Offline static strings from the same oracle binary remain leads, not contracts. In particular, static auth, billing, streaming, host, and model-like tokens cannot establish a Build request path, authentication rule, model inventory, SSE contract, or usage API.
+
+## Confirmed request-side facts only
+
+### Destination and override boundary
+
+1. With the captured override set to a loopback `/v1` base, the binary sent its observed preflights and response requests to that loopback recorder before any remote endpoint could be reached. [Evidence: [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/strace-local-prompt-summary.json`](fixtures/strace-local-prompt-summary.json)]
+2. Authenticated production model discovery resolved `cli-chat-proxy.grok.com`; its corroborated IPv4 TLS destinations were `104.18.28.234:443` and `104.18.29.234:443`. The prompt trace also reached `104.18.28.234:443`. A separate observed connection is explicitly not attributed to a Build endpoint. This does **not** prove any production HTTP path. [Evidence: [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)]
+
+### Observed override request paths and per-request header names
+
+The following are emitted request facts under the authenticated **loopback** override. Header sets varied by path; none is asserted to be globally mandatory or sufficient for production auth. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+| Method and path | Count | Observed header names |
+|---|---:|---|
+| `GET /v1/models` | 1 | `accept`, `accept-encoding`, `authorization`, `host`, `user-agent`, `x-email`, `x-grok-client-version`, `x-userid`, `x-xai-token-auth` |
+| `GET /v1/settings` | 4 | `accept`, `accept-encoding`, `authorization`, `host`, `user-agent`, `x-email`, `x-grok-client-identifier`, `x-grok-client-version`, `x-userid`, `x-xai-token-auth` |
+| `GET /v1/bundle/archive` | 2 | `accept`, `accept-encoding`, `authorization`, `host`, `user-agent`, `x-email`, `x-grok-client-version`, `x-userid` |
+| `GET /v1/user?include=subscription` | 1 | `accept`, `accept-encoding`, `authorization`, `host`, `user-agent`, `x-grok-client-version`, `x-xai-token-auth` |
+| `GET /v1/user` | 3 | `accept`, `accept-encoding`, `authorization`, `host`, `user-agent`, `x-grok-client-version`, `x-xai-token-auth` |
+| `GET /v1/feedback/config` | 1 | `accept`, `accept-encoding`, `authorization`, `host`, `traceparent`, `tracestate`, `user-agent`, `x-grok-client-version`, `x-xai-token-auth` |
+| `POST /v1/responses` | 3 | Common: `accept`, `accept-encoding`, `authorization`, `content-length`, `content-type`, `host`, `user-agent`, `x-grok-agent-id`, `x-grok-client-identifier`, `x-grok-client-version`, `x-grok-conv-id`, `x-grok-model-override`, `x-grok-req-id`, `x-grok-session-id`; requests 2–3 additionally emitted `traceparent` and `x-grok-turn-idx`. |
+
+The no-credential control emitted `GET /v1/login-config` to the loopback override without `authorization`, `x-xai-token-auth`, `x-email`, or `x-userid`. This is request emission only, not a device-login contract. [Evidence: [`fixtures/api-key-differential.json`](fixtures/api-key-differential.json)]
+
+### Observed `POST /v1/responses` body schemas
+
+All fields below are top-level request-schema observations from the loopback recorder; values are redacted and no production response contract follows. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+- **Request 1:** `include`, `input`, `max_output_tokens`, `model`, `reasoning`, `store`, `stream`, `temperature`, `tool_choice`, and `tools`. Its `input` was an array of two objects with `content`, `role`, and `type` fields.
+- **Requests 2–3:** `include`, `input`, `model`, `reasoning`, `store`, `stream`, and `tools`. Their `input` was an array of six objects with `content`, `role`, and `type` fields.
+- `content-type` was emitted for all three requests, but the fixture does not prove that any particular request field, header, or media type is required by the production Build service. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+## RE items 1–8
+
+### 1. Build auth — **partial**
+
+The official auth store was parseable and had one entry containing field names for issuer/client metadata, a redacted credential key, redacted refresh token, expiry, and redacted profile/identity metadata. A `grok models` invocation using that official store succeeded and reported a logged-in state. The captured request-side header names are listed above, but their per-endpoint necessity and acceptance rules are not proved. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json), [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+`grok login --device-auth` was not run, and no device authorization, authorization-code, token exchange, or refresh request/response was captured. The static issuer, OAuth vocabulary, and configuration strings are still **unverified — confirm first**. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+### 2. Build chat wire — **partial**
+
+The loopback override emitted `POST /v1/responses` three times with the request-side schemas and header names above. Separately, the live `-m grok-build` trace reached the DNS name `cli-chat-proxy.grok.com` and a corroborated TLS destination. Those two observations establish the override request shape and production host transport independently; they do **not** bind `/v1/responses` to that production host at the HTTP layer. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json), [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json)]
+
+The staged response statuses/bodies were synthetic loopback data. The live prompt had no observable HTTP status or response schema. Production success, field requirements, and error behavior remain **unverified — confirm first**. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)]
+
+### 3. Streaming — **unverified — confirm first**
+
+Only the request-side boolean `stream` was observed. No production media type, SSE event, event-data schema, completion/error signal, or cancellation behavior was captured. Static event-name strings are not streaming evidence. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+### 4. Build model inventory — **partial**
+
+`GET /v1/models` is an emitted loopback request. One authenticated `grok models` session displayed `grok-4.5` and `grok-composer-2.5-fast`; this is account-visible output, not a complete remote model list or a promise that either identifier belongs in an OMP Build provider. [Evidence: [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json)]
+
+The only captured loopback model-list response was deliberately synthetic. A full successful Build response, pagination/cursor behavior, and any authorized comparison to `api.x.ai` remain **unverified — confirm first**. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+### 5. Quota and errors — **unverified — confirm first**
+
+A loopback 401 and staged 401s are synthetic. The production prompt ended in a redacted non-JSON CLI error with no observable HTTP status, response headers, or response body. No captured fact distinguishes Build quota exhaustion from authentication failure, generic rate limiting, capacity, or other errors. [Evidence: [`fixtures/override-models-401.json`](fixtures/override-models-401.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)]
+
+Static 401/403/429, quota, credit, and access-gate text remains **unverified — confirm first** for Build error classification.
+
+### 6. Build usage/billing — **partial and the ship blocker**
+
+Normal-turn initialization emitted `GET /v1/user?include=subscription` once and `GET /v1/user` three times under loopback capture. Both requests carried the distinct header subsets shown above. No response was from the production service; the recorder supplied only synthetic errors for non-model paths. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+There is no captured durable Build residual, used amount, limit, reset, unit, account scope, or update cadence. Static billing paths and field-like tokens are **unverified — confirm first** and MUST NOT be substituted for Build usage reporting. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+This alone blocks Build ship: OMP usage needs response-supported data for `omp usage` and `/usage`, not request costs or a permanent empty implementation.
+
+### 7. Refresh and session continuity — **partial**
+
+The official auth-store field schema includes a redacted refresh-token field and expiry field. `POST /v1/responses` emitted `x-grok-conv-id`, `x-grok-session-id`, `x-grok-req-id`, plus `x-grok-turn-idx` on later observed requests. This proves field/header emission only; it does not prove their values, reuse, precedence, lifetime, or necessity. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+No refresh call, token rotation, re-auth failure, or successful multi-turn production continuity was captured. Refresh/session behavior is therefore **unverified — confirm first** beyond the partial request/store observations. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+### 8. Default-chat adjacent calls — **partial**
+
+The staged normal turn emitted `/v1/settings`, `/v1/bundle/archive`, `/v1/user?include=subscription`, `/v1/user`, and `/v1/feedback/config` before/around response attempts. The fixture does not prove response schemas, that any call is required, a recap mechanism, a default preset/toolset identifier, or a production timing/order guarantee. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json)]
+
+Static Build-named preset and recap tokens remain **unverified — confirm first** rather than evidence of a default coding turn.
+
+## API-key hard-reject differential — bounded result
+
+In a fresh isolated environment with OAuth unset and only a fake seven-character `XAI_API_KEY`, a `-m grok-build` prompt failed locally before any loopback request; the fake key was not echoed or transmitted to the recorder. With neither credential source, the separate control emitted unauthenticated `GET /v1/login-config` requests to the override. [Evidence: [`fixtures/api-key-differential.json`](fixtures/api-key-differential.json)]
+
+This is useful fail-closed evidence for one fake-key input to the official binary. It is **not** a complete production Build-auth rejection contract and does not prove behavior for valid API keys, other credential sources, or real endpoints. [Evidence: [`fixtures/api-key-differential.json`](fixtures/api-key-differential.json)]
+
+## OMP integration map — registration surfaces only
+
+These are conditional implementation surfaces, not authorization to implement and not replacements for missing RE evidence. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+- A future distinct provider identity would be registered through catalog descriptors/model-manager options and the built-in provider/login registry; its OAuth credential would use OMP's provider-scoped store. Existing `xai-oauth` remains a separate SuperGrok/API path and is not evidence of a Build contract.
+- A future usage integration would require a real `UsageProvider`, default usage registration in `AuthStorage`, and the generic `omp usage`/`/usage` path. The current default usage registry has no xAI/xai-oauth usage provider.
+- A future Build path must resolve stored OAuth under its own identity and fail before network on key-only configuration; it must not reuse the current `xai-oauth` API-key fallback. This is an OMP product constraint, not a discovered Build wire contract.
+
+## Remaining capture plan
+
+Use the redacted ingestion rules in [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json) and run only with an explicitly approved, low-cost Build session. Retain host/path/method/status, header names with redacted lengths, and response/SSE schemas; redact every header/body value before persistence. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+1. **Auth and refresh (items 1, 7):** capture an authorized normal request immediately before and after a naturally available refresh; retain refresh host/path/method/status, request header names/redacted lengths, refresh response field schema, and post-refresh header shape. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+2. **Chat, streaming, errors (items 2, 3, 5):** perform one approved minimal coding prompt and one controlled cancellation; capture `POST /v1/responses` status, content type, SSE event names/data schemas, terminal done/error/cancellation behavior, and naturally observed auth/quota/rate-limit signal schemas. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+3. **Models (item 4):** capture a successful remote `GET /v1/models` response including complete returned IDs, response schema, status, and pagination/cursor fields. Compare with `api.x.ai` only if separately authorized and non-billing. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+4. **Usage (item 6):** capture successful `/v1/user?include=subscription`, `/v1/user`, and any normal-turn billing calls; retain all response-field schemas and prove used/residual/reset fields, units, and update cadence. No durable response signal means the Build ship remains blocked. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+5. **Sidecars (item 8):** capture settings, bundle, and feedback responses during a successful normal coding turn; determine default preset/toolset identifiers and whether each sidecar is required or best-effort. [Evidence: [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+## Recommended upstream deliverable shape
+
+Submit one documentation/evidence-only PR that copies this artifact to `docs/research/grok-build-re/` and records the **DOSSIER_ONLY** decision plus the capture plan. Its scope MUST exclude provider code, auth code, model-catalog entries, usage-provider registration, tests that assert invented protocol behavior, API-key fallback changes, and a new issue. The PR can be superseded by a later implementation only after all items 1–7 are behavior-confirmed, including body-level durable Build usage. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+
+## Explicitly unverified — confirm first
+
+- Production HTTP path binding, status codes, response schemas, field requirements, and error semantics for every emitted request. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json)]
+- Device login, OAuth client/scopes/audience, token exchange, refresh request/response, and production auth rejection behavior. [Evidence: [`fixtures/auth-store-shape.json`](fixtures/auth-store-shape.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+- Streaming content type, SSE event/data schema, done/error/cancellation semantics. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+- Complete Build model inventory and remote model-list schema/pagination. [Evidence: [`fixtures/strace-models-summary.json`](fixtures/strace-models-summary.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+- Build quota/auth/rate-limit taxonomy and any status/header/body discriminator. [Evidence: [`fixtures/authenticated-prompt-strace-summary.json`](fixtures/authenticated-prompt-strace-summary.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+- Durable Build usage/billing residual, used, limit, reset, units, account scope, update cadence, and endpoint response semantics. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]
+- Session/recap/default-toolset semantics and which observed sidecars are required. [Evidence: [`fixtures/override-chat-staged.json`](fixtures/override-chat-staged.json), [`fixtures/live-remote-capture-template.json`](fixtures/live-remote-capture-template.json)]

--- a/docs/research/grok-build-re/fixtures/api-key-differential.json
+++ b/docs/research/grok-build-re/fixtures/api-key-differential.json
@@ -10,6 +10,10 @@
     "GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:39489/v1"
   },
   "fake_api_key_case": {
+    "environment_overrides": {
+      "XAI_API_KEY": "<redacted length=7>",
+      "XAI_OAUTH_TOKEN": "unset"
+    },
     "captured_at_models": "2026-07-11T01:34:13.581082Z",
     "models_command": "grok --leader-socket <temporary> --cwd <temporary> models",
     "models_exit_code": 0,

--- a/docs/research/grok-build-re/fixtures/api-key-differential.json
+++ b/docs/research/grok-build-re/fixtures/api-key-differential.json
@@ -1,0 +1,55 @@
+{
+  "capture_kind": "isolated fake-API-key differential",
+  "binary": "grok 0.2.93 (f00f96316d)",
+  "isolation": {
+    "HOME": "<fresh temporary directory>",
+    "GROK_HOME": "<fresh temporary directory>",
+    "XDG_CONFIG_HOME": "<fresh temporary directory>",
+    "XDG_DATA_HOME": "<fresh temporary directory>",
+    "XAI_OAUTH_TOKEN": "unset",
+    "GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:39489/v1"
+  },
+  "fake_api_key_case": {
+    "captured_at_models": "2026-07-11T01:34:13.581082Z",
+    "models_command": "grok --leader-socket <temporary> --cwd <temporary> models",
+    "models_exit_code": 0,
+    "models_stdout_stderr_bytes": 73,
+    "models_recorder_requests": 0,
+    "captured_at_chat": "2026-07-11T01:34:30.408424Z",
+    "chat_command": "grok -p <prompt length=4> -m grok-build --output-format json --cwd <temporary> --leader-socket <temporary> --no-subagents --disable-web-search",
+    "chat_exit_code": 1,
+    "chat_stdout_stderr_bytes": 523,
+    "chat_error_keyword_presence": {"api key": true, "oauth": false, "auth": false, "login": false, "credential": false},
+    "fake_api_key_value_echoed": false,
+    "loopback_recorder_requests": 0,
+    "conclusion": "The fake API-key-only chat attempt failed before any Build-endpoint request, and no fake key was transmitted to the loopback host."
+  },
+  "no_credential_comparison": {
+    "captured_at": "2026-07-11T01:34:55.664645Z",
+    "XAI_API_KEY": "unset",
+    "chat_exit_code": null,
+    "timed_out_after_seconds": 15,
+    "chat_stdout_stderr_bytes": 532,
+    "chat_error_keyword_presence": {"api key": false, "oauth": true, "auth": true, "login": false, "credential": false},
+    "loopback_requests": [
+      {
+        "method": "GET",
+        "path": "/v1/login-config",
+        "count": 2,
+        "header_names_and_redacted_values": {
+          "accept": "<redacted length=3>",
+          "accept-encoding": "<redacted length=17>",
+          "host": "<redacted length=15>",
+          "user-agent": "<redacted length=33>",
+          "x-grok-agent-id": "<redacted length=36>",
+          "x-grok-client-identifier": "<redacted length=10>",
+          "x-grok-client-version": "<redacted length=6>"
+        },
+        "body_schema": {"type": "null"},
+        "synthetic_response": {"status": 401, "body_schema": {"type": "object", "properties": {"error": {"type": "object"}}}}
+      }
+    ],
+    "conclusion": "Without either OAuth or API key, the binary attempted unauthenticated login configuration at the override host. The fake-key case instead failed locally and made no request."
+  },
+  "security": "Only the fake-key length (7) was retained; no API-key value, OAuth value, or authorization-header value was written."
+}

--- a/docs/research/grok-build-re/fixtures/auth-store-shape.json
+++ b/docs/research/grok-build-re/fixtures/auth-store-shape.json
@@ -1,0 +1,36 @@
+{
+  "captured_at": "2026-07-11T01:26:31Z",
+  "source": "~/.grok/auth.json inspected in-process; no values copied",
+  "parseable_json": true,
+  "entry_count": 1,
+  "entry_key_schema": {
+    "issuer_host": "auth.x.ai",
+    "client_id": "b1a00492-073a-47ea-816f-4c329264a828"
+  },
+  "entry_field_schema": {
+    "key": {"type": "string", "redacted": true, "length": 818},
+    "auth_mode": {"type": "string", "redacted": true, "length": 4},
+    "create_time": {"type": "string", "redacted": true, "length": 30},
+    "user_id": {"type": "string", "redacted": true, "length": 36},
+    "email": {"type": "string", "redacted": true, "length": 20},
+    "first_name": {"type": "string", "redacted": true, "length": 2},
+    "last_name": {"type": "string", "redacted": true, "length": 0},
+    "profile_image_asset_id": {"type": "string", "redacted": true, "length": 80},
+    "principal_type": {"type": "string", "redacted": true, "length": 4},
+    "principal_id": {"type": "string", "redacted": true, "length": 36},
+    "team_id": {"type": "string", "redacted": true, "length": 36},
+    "coding_data_retention_opt_out": {"type": "boolean"},
+    "refresh_token": {"type": "string", "redacted": true, "length": 86},
+    "expires_at": {"type": "string", "redacted": true, "length": 30},
+    "oidc_issuer": {"type": "string", "redacted": true, "length": 17},
+    "oidc_client_id": {"type": "string", "redacted": true, "length": 36}
+  },
+  "credential_usability_evidence": {
+    "command": "grok models",
+    "captured_at": "2026-07-11T01:31:17.032482Z",
+    "exit_code": 0,
+    "observed_login_state": "logged in",
+    "transport_trace": "local-only redacted summary in strace-models-summary.json"
+  },
+  "security": "No key, refresh token, identifiers, email, or other values are present in this fixture."
+}

--- a/docs/research/grok-build-re/fixtures/auth-store-shape.json
+++ b/docs/research/grok-build-re/fixtures/auth-store-shape.json
@@ -1,11 +1,11 @@
 {
   "captured_at": "2026-07-11T01:26:31Z",
-  "source": "~/.grok/auth.json inspected in-process; no values copied",
+  "source": "~/.grok/auth.json inspected in-process; credential and user-profile values were not copied",
   "parseable_json": true,
   "entry_count": 1,
   "entry_key_schema": {
     "issuer_host": "auth.x.ai",
-    "client_id": "b1a00492-073a-47ea-816f-4c329264a828"
+    "client_id": {"redacted": true, "length": 36, "note": "public OAuth client identifier shape only; value not published"}
   },
   "entry_field_schema": {
     "key": {"type": "string", "redacted": true, "length": 818},
@@ -32,5 +32,5 @@
     "observed_login_state": "logged in",
     "transport_trace": "local-only redacted summary in strace-models-summary.json"
   },
-  "security": "No key, refresh token, identifiers, email, or other values are present in this fixture."
+  "security": "No access key, refresh token, email, user id, or other credential/profile values are present. Issuer host is intentionally retained as non-secret endpoint metadata; OAuth client_id is retained only as redacted length metadata."
 }

--- a/docs/research/grok-build-re/fixtures/authenticated-prompt-strace-summary.json
+++ b/docs/research/grok-build-re/fixtures/authenticated-prompt-strace-summary.json
@@ -1,0 +1,35 @@
+{
+  "capture_kind": "authenticated production minimal-prompt strace",
+  "captured_at": "2026-07-11T01:53:24.678245Z",
+  "binary": "grok 0.2.93 (f00f96316d)",
+  "command": [
+    "strace", "-ff", "-s", "200", "-e", "trace=network,connect,sendto,recvfrom",
+    "grok", "-p", "<prompt length=4>", "-m", "grok-build",
+    "--output-format", "json", "--max-turns", "1", "--cwd", "<temporary>",
+    "--leader-socket", "<temporary>", "--no-subagents", "--disable-web-search"
+  ],
+  "credential_source": "existing official-binary auth store; not imported or copied",
+  "process_result": {
+    "exit_code": 1,
+    "timed_out": false,
+    "stdout": {
+      "line_count": 1,
+      "byte_count": 143,
+      "schema": {"type": "string", "redacted": true, "classification": "non-JSON CLI error text"},
+      "error_marker_present": true,
+      "error_value_persisted": false
+    }
+  },
+  "host_proof": {
+    "dns_qname_extracted_from_trace": "cli-chat-proxy.grok.com",
+    "corroborated_tls_connection": {"address": "104.18.28.234", "port": 443},
+    "network_syscall_counts": {"connect": 25, "sendto": 16, "recvfrom": 87}
+  },
+  "protocol_boundary": {
+    "http_status_observed": false,
+    "response_body_schema_observed": false,
+    "sse_events_observed": false,
+    "conclusion": "The requested authenticated minimal prompt reached the production Build host transport but returned a redacted non-JSON CLI error. It supplies no status/body/error-classification or streaming contract."
+  },
+  "trace_handling": "Both strace data and CLI output were processed only to metadata. Raw trace lines and raw CLI error text were neither printed nor persisted."
+}

--- a/docs/research/grok-build-re/fixtures/live-remote-capture-template.json
+++ b/docs/research/grok-build-re/fixtures/live-remote-capture-template.json
@@ -1,0 +1,33 @@
+{
+  "purpose": "Redacted fixture template for an explicitly approved, low-cost authenticated remote capture. Do not run automatically: a successful response can consume Build quota.",
+  "redaction_rule": "At ingestion retain only method, URL host/path, status, header names plus value lengths, and JSON/SSE field schemas. Replace every header/body value, including authorization and cookies, before writing.",
+  "captures_needed": [
+    {
+      "re_items": [1, 7],
+      "scenario": "Authorized normal request immediately before and after token refresh, if a naturally expiring session is available.",
+      "required_fields": ["auth/refresh host/path/method/status", "request header names and redacted lengths", "refresh response field schema", "post-refresh request header shape"]
+    },
+    {
+      "re_items": [2, 3, 5],
+      "scenario": "One approved minimal coding prompt and immediate cancellation in a capture environment.",
+      "required_fields": ["POST /v1/responses request schema", "response status", "content-type", "SSE event names and per-event data schema", "done/error/cancellation termination", "quota/auth/rate-limit status and body/header schema when naturally observed"]
+    },
+    {
+      "re_items": [4],
+      "scenario": "Capture successful remote GET /v1/models and compare its returned ids with the same credential against api.x.ai only if separately authorized and non-billing.",
+      "required_fields": ["model-list response schema", "complete returned model-id list", "status", "pagination/cursor fields if present"]
+    },
+    {
+      "re_items": [6],
+      "scenario": "Capture successful /v1/user?include=subscription, /v1/user, and any other normal-turn billing calls.",
+      "required_fields": ["status", "all response-field schemas", "used/residual/reset fields", "units and update cadence"]
+    },
+    {
+      "re_items": [8],
+      "scenario": "Successful normal coding turn from a clean session.",
+      "required_fields": ["settings/bundle/feedback response schemas", "default preset/toolset identifiers", "whether each sidecar is required or best-effort"]
+    }
+  ],
+  "known_request_sidecars_to_observe": ["/v1/models", "/v1/settings", "/v1/bundle/archive", "/v1/user?include=subscription", "/v1/user", "/v1/feedback/config", "/v1/responses", "/v1/login-config"],
+  "current_evidence_boundary": "This template intentionally contains no remote response values because the completed capture used synthetic loopback responses after request emission."
+}

--- a/docs/research/grok-build-re/fixtures/override-chat-staged.json
+++ b/docs/research/grok-build-re/fixtures/override-chat-staged.json
@@ -1,0 +1,77 @@
+{
+  "capture_kind": "authenticated local staged chat-wire proof",
+  "captured_at": "2026-07-11T01:29:06.716416Z",
+  "binary": "grok 0.2.93 (f00f96316d)",
+  "command": [
+    "grok", "-p", "<prompt length=4>", "-m", "grok-build",
+    "--output-format", "json", "--cwd", "<temporary>",
+    "--leader-socket", "<temporary>", "--no-subagents", "--disable-web-search"
+  ],
+  "environment": {
+    "GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:38769/v1",
+    "credential_source": "existing official-binary auth store; not imported or copied"
+  },
+  "synthetic_responses": {
+    "GET /v1/models": {
+      "status": 200,
+      "header_names_and_redacted_values": {"content-type": "<redacted length=16>", "content-length": "<redacted>"},
+      "body_schema": {
+        "type": "object",
+        "properties": {
+          "object": {"type": "string"},
+          "data": {"type": "array", "length": 1, "item_schema": {"type": "object", "properties": {"id": {"type": "string"}, "object": {"type": "string"}, "created": {"type": "number"}, "owned_by": {"type": "string"}}}}
+        }
+      },
+      "note": "This is a deliberately synthetic loopback model list containing one synthetic grok-build entry. It is not a production model response."
+    },
+    "all_other_captured_paths": {
+      "status": 401,
+      "header_names_and_redacted_values": {"content-type": "<redacted length=16>", "content-length": "<redacted>"},
+      "body_schema": {"type": "object", "properties": {"error": {"type": "object", "properties": {"message": {"type": "string"}, "type": {"type": "string"}}}}},
+      "note": "Synthetic local error only; it proves request emission, not remote error semantics."
+    }
+  },
+  "observed_preflight_requests": [
+    {
+      "method": "GET", "path": "/v1/models", "count": 1,
+      "header_names_and_redacted_values": {"accept": "<redacted>", "accept-encoding": "<redacted>", "authorization": "<redacted length=825>", "host": "<redacted>", "user-agent": "<redacted>", "x-email": "<redacted length=20>", "x-grok-client-version": "<redacted length=6>", "x-userid": "<redacted length=36>", "x-xai-token-auth": "<redacted length=12>"},
+      "body_schema": {"type": "null"}
+    },
+    {
+      "method": "GET", "path": "/v1/settings", "count": 4,
+      "header_names_and_redacted_values": {"accept": "<redacted>", "accept-encoding": "<redacted>", "authorization": "<redacted length=825>", "host": "<redacted>", "user-agent": "<redacted>", "x-email": "<redacted length=20>", "x-grok-client-identifier": "<redacted length=10>", "x-grok-client-version": "<redacted length=6>", "x-userid": "<redacted length=36>", "x-xai-token-auth": "<redacted length=12>"},
+      "body_schema": {"type": "null"}
+    },
+    {
+      "method": "GET", "path": "/v1/bundle/archive", "count": 2,
+      "header_names_and_redacted_values": {"accept": "<redacted>", "accept-encoding": "<redacted>", "authorization": "<redacted length=825>", "host": "<redacted>", "user-agent": "<redacted>", "x-email": "<redacted length=20>", "x-grok-client-version": "<redacted length=6>", "x-userid": "<redacted length=36>"},
+      "body_schema": {"type": "null"}
+    },
+    {
+      "method": "GET", "path": "/v1/user?include=subscription", "count": 1,
+      "header_names_and_redacted_values": {"accept": "<redacted>", "accept-encoding": "<redacted>", "authorization": "<redacted length=825>", "host": "<redacted>", "user-agent": "<redacted>", "x-grok-client-version": "<redacted length=6>", "x-xai-token-auth": "<redacted length=12>"},
+      "body_schema": {"type": "null"}
+    },
+    {
+      "method": "GET", "path": "/v1/user", "count": 3,
+      "header_names_and_redacted_values": {"accept": "<redacted>", "accept-encoding": "<redacted>", "authorization": "<redacted length=825>", "host": "<redacted>", "user-agent": "<redacted>", "x-grok-client-version": "<redacted length=6>", "x-xai-token-auth": "<redacted length=12>"},
+      "body_schema": {"type": "null"}
+    },
+    {
+      "method": "GET", "path": "/v1/feedback/config", "count": 1,
+      "header_names_and_redacted_values": {"accept": "<redacted>", "accept-encoding": "<redacted>", "authorization": "<redacted length=825>", "host": "<redacted>", "traceparent": "<redacted length=55>", "tracestate": "<redacted length=0>", "user-agent": "<redacted>", "x-grok-client-version": "<redacted length=6>", "x-xai-token-auth": "<redacted length=12>"},
+      "body_schema": {"type": "null"}
+    }
+  ],
+  "observed_chat_requests": [
+    {
+      "method": "POST", "path": "/v1/responses", "count": 3,
+      "headers_common": {"accept": "<redacted length=17>", "accept-encoding": "<redacted length=17>", "authorization": "<redacted length=825>", "content-length": "<redacted>", "content-type": "<redacted length=16>", "host": "<redacted>", "user-agent": "<redacted length=33>", "x-grok-agent-id": "<redacted>", "x-grok-client-identifier": "<redacted length=10>", "x-grok-client-version": "<redacted length=6>", "x-grok-conv-id": "<redacted>", "x-grok-model-override": "<redacted length=10>", "x-grok-req-id": "<redacted>", "x-grok-session-id": "<redacted>"},
+      "headers_on_requests_2_and_3_only": {"traceparent": "<redacted>", "x-grok-turn-idx": "<redacted>"},
+      "body_schema_request_1": {"type": "object", "properties": {"include": {"type": "array"}, "input": {"type": "array", "length": 2, "item_schema": {"type": "object", "properties": {"content": {"type": "string", "redacted": true}, "role": {"type": "string", "redacted": true}, "type": {"type": "string", "redacted": true}}}}, "max_output_tokens": {"type": "number"}, "model": {"type": "string", "redacted": true}, "reasoning": {"type": "object"}, "store": {"type": "boolean"}, "stream": {"type": "boolean"}, "temperature": {"type": "number"}, "tool_choice": {"type": "object"}, "tools": {"type": "array"}}},
+      "body_schema_requests_2_and_3": {"type": "object", "properties": {"include": {"type": "array"}, "input": {"type": "array", "length": 6, "item_schema": {"type": "object", "properties": {"content": {"type": "string", "redacted": true}, "role": {"type": "string", "redacted": true}, "type": {"type": "string", "redacted": true}}}}, "model": {"type": "string", "redacted": true}, "reasoning": {"type": "object"}, "store": {"type": "boolean"}, "stream": {"type": "boolean"}, "tools": {"type": "array"}}}
+    }
+  ],
+  "probe_result": {"exit_code": null, "timed_out_after_seconds": 35, "request_count": 15, "remote_quota_spent": false},
+  "security": "The loopback server bound only to 127.0.0.1 and converted every header/body value to redaction metadata before any fixture write."
+}

--- a/docs/research/grok-build-re/fixtures/override-models-401.json
+++ b/docs/research/grok-build-re/fixtures/override-models-401.json
@@ -1,0 +1,57 @@
+{
+  "capture_kind": "authenticated local override proof",
+  "captured_at": "2026-07-11T01:27:18.873266Z",
+  "binary": "grok 0.2.93 (f00f96316d)",
+  "command": [
+    "grok", "-p", "<prompt length=4>", "-m", "grok-build",
+    "--output-format", "json", "--cwd", "<temporary>",
+    "--no-subagents", "--disable-web-search"
+  ],
+  "environment": {
+    "GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:45939/v1",
+    "credential_source": "existing official-binary auth store; not imported or copied"
+  },
+  "request": {
+    "method": "GET",
+    "url": "http://127.0.0.1:45939/v1/models",
+    "path": "/v1/models",
+    "header_names_and_redacted_values": {
+      "accept": {"redacted": true, "length": 3},
+      "accept-encoding": {"redacted": true, "length": 17},
+      "authorization": {"redacted": true, "length": 825},
+      "host": {"redacted": true, "length": 15},
+      "user-agent": {"redacted": true, "length": 33},
+      "x-email": {"redacted": true, "length": 20},
+      "x-grok-client-version": {"redacted": true, "length": 6},
+      "x-userid": {"redacted": true, "length": 36},
+      "x-xai-token-auth": {"redacted": true, "length": 12}
+    },
+    "body_schema": {"type": "null"}
+  },
+  "response": {
+    "origin": "synthetic loopback recorder, not a production response",
+    "status": 401,
+    "header_names_and_redacted_values": {
+      "content-type": {"redacted": true, "length": 16},
+      "content-length": {"redacted": true}
+    },
+    "body_schema": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "object",
+          "properties": {
+            "message": {"type": "string"},
+            "type": {"type": "string"}
+          }
+        }
+      }
+    }
+  },
+  "probe_result": {
+    "exit_code": null,
+    "timed_out_after_seconds": 45,
+    "conclusion": "The override was honored before a model/chat request could reach a remote endpoint; the official stored session supplied the observed redacted auth-related headers."
+  },
+  "security": "The recorder replaced every request-header value and every body value with metadata before writing this file."
+}

--- a/docs/research/grok-build-re/fixtures/sslkeylog-experiment.json
+++ b/docs/research/grok-build-re/fixtures/sslkeylog-experiment.json
@@ -1,0 +1,12 @@
+{
+  "capture_kind": "SSLKEYLOGFILE capability probe",
+  "captured_at": "2026-07-11T01:33:27.832284Z",
+  "command": "SSLKEYLOGFILE=<temporary mode-0600 file> grok --leader-socket <temporary> --cwd <temporary> models",
+  "exit_code": 0,
+  "grok_models_stdout_lines": 7,
+  "grok_stderr_bytes": 0,
+  "SSLKEYLOGFILE_bytes_before_deletion": 0,
+  "SSLKEYLOGFILE_nonempty": false,
+  "keylog_file_deleted_without_reading": true,
+  "conclusion": "This invocation did not emit NSS-style TLS key-log material."
+}

--- a/docs/research/grok-build-re/fixtures/strace-local-prompt-summary.json
+++ b/docs/research/grok-build-re/fixtures/strace-local-prompt-summary.json
@@ -1,0 +1,40 @@
+{
+  "capture_kind": "single-prompt strace with loopback override",
+  "captured_at": "2026-07-11T01:32:54.120686Z",
+  "command": [
+    "strace", "-ff", "-s", "200", "-e", "trace=network,connect,sendto,recvfrom",
+    "grok", "-p", "<prompt length=4>", "-m", "grok-build",
+    "--output-format", "json", "--cwd", "<temporary>",
+    "--leader-socket", "<temporary>", "--no-subagents", "--disable-web-search"
+  ],
+  "environment": {
+    "GROK_CLI_CHAT_PROXY_BASE_URL": "http://127.0.0.1:36193/v1",
+    "credential_source": "existing official-binary auth store; not imported or copied"
+  },
+  "process_result": {
+    "timed_out_then_terminated": true,
+    "termination_signal": "SIGKILL",
+    "network_syscall_counts": {"connect": 254, "sendto": 46, "recvfrom": 164},
+    "relevant_connect_destination": "127.0.0.1",
+    "other_connect_destinations": "Observed but not endpoint-attributed because this command initialized unrelated binary services while the loopback recorder was active."
+  },
+  "loopback_request": {
+    "method": "GET",
+    "url": "http://127.0.0.1:36193/v1/models",
+    "path": "/v1/models",
+    "header_names_and_redacted_values": {
+      "accept": "<redacted length=3>",
+      "accept-encoding": "<redacted length=17>",
+      "authorization": "<redacted length=825>",
+      "host": "<redacted length=15>",
+      "user-agent": "<redacted length=33>",
+      "x-email": "<redacted length=20>",
+      "x-grok-client-version": "<redacted length=6>",
+      "x-userid": "<redacted length=36>",
+      "x-xai-token-auth": "<redacted length=12>"
+    },
+    "body_schema": {"type": "null"},
+    "synthetic_response": {"status": 401, "body_schema": {"type": "object", "properties": {"error": {"type": "object"}}}}
+  },
+  "trace_handling": "strace stderr was consumed line-by-line; only syscall counts and connect destinations above were retained. Raw trace content was neither printed nor persisted."
+}

--- a/docs/research/grok-build-re/fixtures/strace-models-summary.json
+++ b/docs/research/grok-build-re/fixtures/strace-models-summary.json
@@ -1,0 +1,37 @@
+{
+  "capture_kind": "authenticated production model-discovery transport trace",
+  "captured_at": "2026-07-11T01:31:17.032482Z",
+  "binary": "grok 0.2.93 (f00f96316d)",
+  "command": [
+    "strace", "-ff", "-s", "200", "-e", "trace=network,connect,sendto,recvfrom",
+    "grok", "--leader-socket", "<temporary>", "--cwd", "<temporary>", "models"
+  ],
+  "exit_code": 0,
+  "grok_models_output": {
+    "login_state": "logged in with grok.com",
+    "default_model": "grok-4.5",
+    "available_model_ids_observed": ["grok-4.5", "grok-composer-2.5-fast"]
+  },
+  "host_proof": {
+    "dns_qname_extracted_from_trace": "cli-chat-proxy.grok.com",
+    "ipv4_connect_destinations": ["104.18.28.234", "104.18.29.234", "35.186.241.51"],
+    "ipv6_connect_destinations": ["2606:4700::6812:1cea", "2606:4700::6812:1dea"],
+    "independent_getent_ahostsv4": {
+      "cli-chat-proxy.grok.com": ["104.18.29.234", "104.18.28.234"]
+    },
+    "redacted_tcp_port_recapture": {
+      "captured_at": "2026-07-11T01:51:19.872695Z",
+      "exit_code": 0,
+      "dns_qname_extracted_from_trace": "cli-chat-proxy.grok.com",
+      "corroborated_ipv4_tls_connections": ["104.18.28.234:443", "104.18.29.234:443"],
+      "raw_trace_persisted": false
+    },
+    "attribution": "The two 104.18.28.234/104.18.29.234 addresses are directly corroborated as cli-chat-proxy.grok.com. The 35.186.241.51 connection was not attributed and is intentionally not treated as a Build endpoint."
+  },
+  "trace_handling": {
+    "raw_trace_bytes_observed": 31246,
+    "raw_trace_persisted": false,
+    "extraction": "Only connect destinations and an allowlisted DNS qname were retained. Raw sendto/recvfrom data was discarded."
+  },
+  "scope_note": "The observed model list is account/session output, not a proof of a globally complete model inventory or an api.x.ai comparison."
+}


### PR DESCRIPTION
## Summary

Grok Build quota work for [#4945](https://github.com/can1357/oh-my-pi/issues/4945) is **blocked on missing usage response evidence**. This PR publishes a redacted reverse-engineering dossier so the gate and remaining capture plan are reviewable without shipping a Build provider.

## Why this is docs-only

The plan requires durable Build residual/used fields before any first-class Build chat provider. Capture of the official `grok 0.2.93` oracle established:

| RE item | Status |
|---|---|
| Auth | partial (store shape + request header names; no device/refresh wire) |
| Chat wire | partial (loopback `POST /v1/responses` request schema; production DNS/TCP to `cli-chat-proxy.grok.com` only) |
| Streaming | unverified |
| Models | partial (request emission + account-visible CLI ids) |
| Quota/errors | unverified |
| **Usage/billing** | **partial — ship blocker** (`GET /v1/user?include=subscription` and `GET /v1/user` emitted; no successful response body) |
| Refresh/session | partial |
| Sidecars | partial |

Hard contingency from the approved plan: **no item-6 durable residual/used → no Build chat ship**. SuperGrok `xai-oauth` (including existing `xai-oauth/grok-build*`) is intentionally untouched.

## What landed

- `docs/research/grok-build-re/README.md` — status matrix, request-side facts, API-key local fail-closed differential, remaining capture plan
- `docs/research/grok-build-re/fixtures/*.json` — redacted request/host fixtures (header **names** and lengths only; no tokens, emails, or authorization values)

## Explicit non-goals (this PR)

- No new provider id / login / catalog entry
- No Build usage provider registration
- No change to `xai-oauth` API-key fallback
- No invented production response, SSE, or billing schemas
- No second tracking issue (stays on #4945)

## Validation

- Secret scan over published tree: no JWT/bearer/email/user-id values
- Every dossier evidence link points at a fixture file in this PR
- No package code or tests changed

## Follow-up required before a Build provider PR

1. Successful remote `/v1/user?include=subscription` (and related) **response** schemas with residual/used/reset units
2. Successful `POST /v1/responses` status/SSE termination/cancellation
3. Production auth accept/reject and refresh wire
4. Complete Build model list body

Until those close items 1–7 with body-level evidence, implementers should treat this tree as the gate record, not an implementation license.
