### PR TITLE
fix(coding-agent): bound startup changelog rendering

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed first-run interactive startup rendering the full packaged changelog when the last-seen marker is missing, malformed, or unreadable. Startup upgrade notes now show at most three unseen releases and cap Markdown source at 64 KiB; `/changelog full` remains the explicit full-history path. ([#5135](https://github.com/can1357/oh-my-pi/issues/5135))
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -78,9 +78,10 @@ import { concreteThinkingLevel, parseConfiguredThinkingLevel } from "./thinking"
 import type { LspStartupServerInfo } from "./tools";
 import {
 	getChangelogPath,
-	getNewEntries,
 	parseChangelog,
+	parseChangelogVersion,
 	readLastChangelogVersion,
+	selectStartupChangelog,
 	writeLastChangelogVersion,
 } from "./utils/changelog";
 import { EventBus } from "./utils/event-bus";
@@ -610,6 +611,11 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 	}
 
 	const lastVersion = await readLastChangelogVersion();
+	const parsedLastVersion = parseChangelogVersion(lastVersion);
+	if (!parsedLastVersion) {
+		await writeLastChangelogVersion(VERSION);
+		return undefined;
+	}
 	if (lastVersion === VERSION) {
 		// Steady state: user already saw the current version's changelog. Skip the file read + parse.
 		return undefined;
@@ -617,18 +623,12 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 
 	const changelogPath = getChangelogPath();
 	const entries = await parseChangelog(changelogPath);
-
-	if (!lastVersion) {
-		if (entries.length > 0) {
-			await writeLastChangelogVersion(VERSION);
-			return entries.map(e => e.content).join("\n\n");
-		}
-	} else {
-		const newEntries = getNewEntries(entries, lastVersion);
-		if (newEntries.length > 0) {
-			await writeLastChangelogVersion(VERSION);
-			return newEntries.map(e => e.content).join("\n\n");
-		}
+	const startupChangelog = selectStartupChangelog(entries, lastVersion, VERSION);
+	if (startupChangelog.persistCurrentVersion) {
+		await writeLastChangelogVersion(VERSION);
+	}
+	if (startupChangelog.markdown) {
+		return startupChangelog.markdown;
 	}
 
 	return undefined;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -47,7 +47,12 @@ import { limitMatchesActiveAccount } from "../../slash-commands/helpers/active-o
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
-import { getChangelogPath, parseChangelog } from "../../utils/changelog";
+import {
+	getChangelogPath,
+	parseChangelog,
+	RECENT_CHANGELOG_ENTRY_LIMIT,
+	renderChangelogEntries,
+} from "../../utils/changelog";
 import { copyToClipboard } from "../../utils/clipboard";
 import { openPath } from "../../utils/open";
 import { setSessionTerminalTitle } from "../../utils/title-generator";
@@ -487,16 +492,9 @@ export class CommandController {
 	async handleChangelogCommand(showFull = false): Promise<void> {
 		const changelogPath = getChangelogPath();
 		const allEntries = await parseChangelog(changelogPath);
-		// Default to showing only the latest 3 versions unless --full is specified
-		// allEntries comes from parseChangelog with newest first, reverse to show oldest->newest
-		const entriesToShow = showFull ? allEntries : allEntries.slice(0, 3);
+		const entriesToShow = showFull ? allEntries : allEntries.slice(0, RECENT_CHANGELOG_ENTRY_LIMIT);
 		const changelogMarkdown =
-			entriesToShow.length > 0
-				? [...entriesToShow]
-						.reverse()
-						.map(e => e.content)
-						.join("\n\n")
-				: "No changelog entries found.";
+			entriesToShow.length > 0 ? renderChangelogEntries(entriesToShow).markdown : "No changelog entries found.";
 		const title = showFull ? "Full Changelog" : "Recent Changes";
 		const hint = showFull
 			? ""

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -34,7 +34,12 @@ import { resolveResumableSession } from "../session/session-listing";
 import { formatShakeSummary, type ShakeMode } from "../session/shake-types";
 import { expandTilde, resolveToCwd } from "../tools/path-utils";
 import { urlHyperlinkAlways } from "../tui";
-import { getChangelogPath, parseChangelog } from "../utils/changelog";
+import {
+	getChangelogPath,
+	parseChangelog,
+	RECENT_CHANGELOG_ENTRY_LIMIT,
+	renderChangelogEntries,
+} from "../utils/changelog";
 import { copyToClipboard } from "../utils/clipboard";
 import { CollabQrCodeComponent } from "./helpers/collab-qrcode";
 import { buildContextReportText } from "./helpers/context-report";
@@ -1082,17 +1087,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			const changelogPath = getChangelogPath();
 			const allEntries = await parseChangelog(changelogPath);
 			const showFull = command.args.trim().toLowerCase() === "full";
-			const entriesToShow = showFull ? allEntries : allEntries.slice(0, 3);
+			const entriesToShow = showFull ? allEntries : allEntries.slice(0, RECENT_CHANGELOG_ENTRY_LIMIT);
 			if (entriesToShow.length === 0) {
 				await runtime.output("No changelog entries found.");
 				return commandConsumed();
 			}
-			await runtime.output(
-				[...entriesToShow]
-					.reverse()
-					.map(entry => entry.content)
-					.join("\n\n"),
-			);
+			await runtime.output(renderChangelogEntries(entriesToShow).markdown);
 			return commandConsumed();
 		},
 		handleTui: async (command, runtime) => {

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -137,16 +137,14 @@ export function getNewEntries(entries: ChangelogEntry[], lastVersion: string): C
 }
 
 /**
- * Render changelog entries newest-last and optionally cap the Markdown source size.
+ * Render changelog entries oldest-first by default and optionally cap the Markdown source size.
  */
 export function renderChangelogEntries(
 	entries: ChangelogEntry[],
-	options: { maxBytes?: number; truncationHint?: string } = {},
+	options: { maxBytes?: number; truncationHint?: string; oldestFirst?: boolean } = {},
 ): RenderedChangelog {
-	const markdown = [...entries]
-		.reverse()
-		.map(entry => entry.content)
-		.join("\n\n");
+	const orderedEntries = options.oldestFirst === false ? entries : [...entries].reverse();
+	const markdown = orderedEntries.map(entry => entry.content).join("\n\n");
 	if (options.maxBytes === undefined || Buffer.byteLength(markdown) <= options.maxBytes) {
 		return { markdown, truncated: false };
 	}
@@ -191,6 +189,7 @@ export function selectStartupChangelog(
 	const rendered = renderChangelogEntries(newEntries, {
 		maxBytes: STARTUP_CHANGELOG_MAX_BYTES,
 		truncationHint: STARTUP_CHANGELOG_FULL_HINT,
+		oldestFirst: false,
 	});
 	return {
 		markdown: rendered.markdown,

--- a/packages/coding-agent/src/utils/changelog.ts
+++ b/packages/coding-agent/src/utils/changelog.ts
@@ -7,6 +7,27 @@ export interface ChangelogEntry {
 	content: string;
 }
 
+/** Number of changelog releases shown by automatic and default recent views. */
+export const RECENT_CHANGELOG_ENTRY_LIMIT = 3;
+/** Maximum Markdown source bytes allowed in automatic startup release notes. */
+export const STARTUP_CHANGELOG_MAX_BYTES = 64 * 1024;
+/** Hint appended when automatic startup release notes are truncated. */
+export const STARTUP_CHANGELOG_FULL_HINT = "Use `/changelog full` to view the complete changelog.";
+
+/** Markdown generated from selected changelog entries and whether it hit a size cap. */
+export interface RenderedChangelog {
+	markdown: string;
+	truncated: boolean;
+}
+
+/** Automatic startup changelog decision, including whether the marker should advance. */
+export interface StartupChangelogSelection {
+	markdown: string | undefined;
+	persistCurrentVersion: boolean;
+	truncated: boolean;
+	selectedEntries: number;
+}
+
 /**
  * Parse changelog entries from the file at `changelogPath`. Scans for `## [x.y.z]`
  * headings and collects each block until the next heading or EOF.
@@ -87,19 +108,96 @@ export function compareVersions(v1: ChangelogEntry, v2: ChangelogEntry): number 
 }
 
 /**
- * Get entries newer than lastVersion
+ * Parse an omp changelog marker version into comparable parts.
  */
-export function getNewEntries(entries: ChangelogEntry[], lastVersion: string): ChangelogEntry[] {
-	// Parse lastVersion
-	const parts = lastVersion.split(".").map(Number);
-	const last: ChangelogEntry = {
-		major: parts[0] || 0,
-		minor: parts[1] || 0,
-		patch: parts[2] || 0,
+export function parseChangelogVersion(version: string | undefined): ChangelogEntry | undefined {
+	const match = version?.match(/^(\d+)\.(\d+)\.(\d+)$/);
+	if (!match) {
+		return undefined;
+	}
+
+	return {
+		major: Number.parseInt(match[1], 10),
+		minor: Number.parseInt(match[2], 10),
+		patch: Number.parseInt(match[3], 10),
 		content: "",
 	};
+}
 
-	return entries.filter(entry => compareVersions(entry, last) > 0);
+/**
+ * Get entries newer than lastVersion.
+ */
+export function getNewEntries(entries: ChangelogEntry[], lastVersion: string): ChangelogEntry[] {
+	const parsedLastVersion = parseChangelogVersion(lastVersion);
+	if (!parsedLastVersion) {
+		return [];
+	}
+
+	return entries.filter(entry => compareVersions(entry, parsedLastVersion) > 0);
+}
+
+/**
+ * Render changelog entries newest-last and optionally cap the Markdown source size.
+ */
+export function renderChangelogEntries(
+	entries: ChangelogEntry[],
+	options: { maxBytes?: number; truncationHint?: string } = {},
+): RenderedChangelog {
+	const markdown = [...entries]
+		.reverse()
+		.map(entry => entry.content)
+		.join("\n\n");
+	if (options.maxBytes === undefined || Buffer.byteLength(markdown) <= options.maxBytes) {
+		return { markdown, truncated: false };
+	}
+
+	const suffix = `\n\n…\n\n${options.truncationHint ?? STARTUP_CHANGELOG_FULL_HINT}`;
+	let low = 0;
+	let high = markdown.length;
+	while (low < high) {
+		const middle = Math.floor((low + high + 1) / 2);
+		if (Buffer.byteLength(markdown.slice(0, middle) + suffix) <= options.maxBytes) {
+			low = middle;
+		} else {
+			high = middle - 1;
+		}
+	}
+
+	return { markdown: markdown.slice(0, low) + suffix, truncated: true };
+}
+
+/**
+ * Select bounded release notes for interactive startup.
+ */
+export function selectStartupChangelog(
+	entries: ChangelogEntry[],
+	lastVersion: string | undefined,
+	currentVersion: string,
+): StartupChangelogSelection {
+	const parsedLastVersion = parseChangelogVersion(lastVersion);
+	if (!parsedLastVersion) {
+		return { markdown: undefined, persistCurrentVersion: true, truncated: false, selectedEntries: 0 };
+	}
+	const markerVersion = lastVersion ?? "";
+	if (markerVersion === currentVersion) {
+		return { markdown: undefined, persistCurrentVersion: false, truncated: false, selectedEntries: 0 };
+	}
+
+	const newEntries = getNewEntries(entries, markerVersion).slice(0, RECENT_CHANGELOG_ENTRY_LIMIT);
+	if (newEntries.length === 0) {
+		return { markdown: undefined, persistCurrentVersion: false, truncated: false, selectedEntries: 0 };
+	}
+
+	const rendered = renderChangelogEntries(newEntries, {
+		maxBytes: STARTUP_CHANGELOG_MAX_BYTES,
+		truncationHint: STARTUP_CHANGELOG_FULL_HINT,
+	});
+	return {
+		markdown: rendered.markdown,
+		persistCurrentVersion: true,
+		truncated: rendered.truncated,
+		selectedEntries: newEntries.length,
+	};
 }
 
 // Re-export getChangelogPath from paths.ts for convenience

--- a/packages/coding-agent/test/utils/changelog.test.ts
+++ b/packages/coding-agent/test/utils/changelog.test.ts
@@ -104,6 +104,7 @@ describe("selectStartupChangelog", () => {
 		expect(selection.persistCurrentVersion).toBe(true);
 		expect(selection.truncated).toBe(false);
 		expect(selection.selectedEntries).toBe(RECENT_CHANGELOG_ENTRY_LIMIT);
+		expect(selection.markdown?.match(/## \[(\d+\.\d+\.\d+)\]/)?.[1]).toBe("1.0.5");
 		expect(selection.markdown).toContain("## [1.0.5]");
 		expect(selection.markdown).toContain("## [1.0.4]");
 		expect(selection.markdown).toContain("## [1.0.3]");
@@ -143,8 +144,9 @@ describe("selectStartupChangelog", () => {
 		expect(selection.persistCurrentVersion).toBe(true);
 		expect(selection.selectedEntries).toBe(RECENT_CHANGELOG_ENTRY_LIMIT);
 		expect(selection.truncated).toBe(true);
+		expect(selection.markdown?.match(/## \[(\d+\.\d+\.\d+)\]/)?.[1]).toBe("1.0.4");
 		expect(selection.markdown).toContain(STARTUP_CHANGELOG_FULL_HINT);
-		expect(selection.markdown).not.toContain("TAIL-FOUR");
+		expect(selection.markdown).not.toContain("TAIL-THREE");
 		expect(Buffer.byteLength(selection.markdown ?? "")).toBeLessThanOrEqual(STARTUP_CHANGELOG_MAX_BYTES);
 	});
 });
@@ -158,6 +160,7 @@ describe("renderChangelogEntries", () => {
 			release(1, 0, 0, `### Added\n\n- First ${largeBody}\nEND-FIRST`),
 		]);
 
+		expect(rendered.markdown.match(/## \[(\d+\.\d+\.\d+)\]/)?.[1]).toBe("1.0.0");
 		expect(rendered.truncated).toBe(false);
 		expect(rendered.markdown).toContain("END-FIRST");
 		expect(rendered.markdown).toContain("END-SECOND");

--- a/packages/coding-agent/test/utils/changelog.test.ts
+++ b/packages/coding-agent/test/utils/changelog.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Startup changelog contracts:
+ *
+ * - First-run/untrusted marker states persist the current version without
+ *   replaying historical markdown.
+ * - Returning users only see a bounded startup slice (latest unseen releases,
+ *   capped by source bytes), while explicit full changelog rendering remains
+ *   unbounded.
+ * - The last-seen marker is a plain file in the agent dir.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { removeWithRetries, VERSION } from "@oh-my-pi/pi-utils";
+import {
+	type ChangelogEntry,
+	RECENT_CHANGELOG_ENTRY_LIMIT,
+	readLastChangelogVersion,
+	renderChangelogEntries,
+	STARTUP_CHANGELOG_FULL_HINT,
+	STARTUP_CHANGELOG_MAX_BYTES,
+	selectStartupChangelog,
+	writeLastChangelogVersion,
+} from "../../src/utils/changelog";
+
+const CURRENT_VERSION = "2.0.0";
+const repoRoot = path.resolve(import.meta.dir, "..", "..", "..", "..");
+const cliEntry = path.join(repoRoot, "packages", "coding-agent", "src", "cli.ts");
+const packageDir = path.join(repoRoot, "packages", "coding-agent");
+const hasPtyHarness =
+	process.platform === "linux" &&
+	(await Bun.file("/usr/bin/script").exists()) &&
+	(await Bun.file("/usr/bin/timeout").exists());
+const PTY_STARTUP_OUTPUT_CEILING = 512 * 1024;
+
+function release(major: number, minor: number, patch: number, body: string): ChangelogEntry {
+	const heading = `## [${major}.${minor}.${patch}] - 2026-07-11`;
+	const content = `${heading}\n\n${body.trimEnd()}`;
+	return { major, minor, patch, content };
+}
+
+async function withTempAgentDir<T>(callback: (agentDir: string) => Promise<T>): Promise<T> {
+	const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-changelog-marker-"));
+	try {
+		const result = await callback(agentDir);
+		return result;
+	} finally {
+		await removeWithRetries(agentDir);
+	}
+}
+
+describe("selectStartupChangelog", () => {
+	const currentVersion = CURRENT_VERSION;
+	const history = [
+		release(2, 0, 0, "### Added\n\n- Current release."),
+		release(1, 9, 0, "### Added\n\n- Previous release."),
+		release(1, 8, 0, "### Added\n\n- Older release."),
+	];
+
+	test("treats missing, empty, malformed, and unreadable-equivalent markers as first run", () => {
+		const invalidMarkers: Array<{ name: string; value: string | undefined }> = [
+			{ name: "missing or unreadable marker", value: undefined },
+			{ name: "empty marker", value: "" },
+			{ name: "malformed marker", value: "not-a-semver" },
+			{ name: "incomplete marker", value: "1.9" },
+			{ name: "whitespace-padded marker", value: " 1.9.0 " },
+		];
+
+		for (const marker of invalidMarkers) {
+			const selection = selectStartupChangelog(history, marker.value, currentVersion);
+			expect(selection.markdown).toBeUndefined();
+			expect(selection.persistCurrentVersion).toBe(true);
+			expect(selection.truncated).toBe(false);
+			expect(selection.selectedEntries).toBe(0);
+		}
+	});
+
+	test("does not render or rewrite when the marker already matches the current version", () => {
+		const selection = selectStartupChangelog(history, currentVersion, currentVersion);
+
+		expect(selection.markdown).toBeUndefined();
+		expect(selection.persistCurrentVersion).toBe(false);
+		expect(selection.truncated).toBe(false);
+		expect(selection.selectedEntries).toBe(0);
+	});
+
+	test("selects at most the three newest unseen releases for an older marker", () => {
+		const selection = selectStartupChangelog(
+			[
+				release(1, 0, 5, "### Added\n\n- Unseen five."),
+				release(1, 0, 4, "### Added\n\n- Unseen four."),
+				release(1, 0, 3, "### Added\n\n- Unseen three."),
+				release(1, 0, 2, "### Added\n\n- Unseen two."),
+				release(1, 0, 1, "### Added\n\n- Unseen one."),
+				release(1, 0, 0, "### Added\n\n- Already seen."),
+			],
+			"1.0.0",
+			"1.0.5",
+		);
+
+		expect(selection.persistCurrentVersion).toBe(true);
+		expect(selection.truncated).toBe(false);
+		expect(selection.selectedEntries).toBe(RECENT_CHANGELOG_ENTRY_LIMIT);
+		expect(selection.markdown).toContain("## [1.0.5]");
+		expect(selection.markdown).toContain("## [1.0.4]");
+		expect(selection.markdown).toContain("## [1.0.3]");
+		expect(selection.markdown).not.toContain("## [1.0.2]");
+		expect(selection.markdown).not.toContain("## [1.0.1]");
+		expect(selection.markdown).not.toContain("## [1.0.0]");
+	});
+
+	test("caps one oversized startup release and appends the full-changelog hint", () => {
+		const selection = selectStartupChangelog(
+			[release(2, 0, 0, `### Added\n\n- ${"x".repeat(STARTUP_CHANGELOG_MAX_BYTES * 2)}\nTAIL-ONE-RELEASE`)],
+			"1.0.0",
+			"2.0.0",
+		);
+
+		expect(selection.persistCurrentVersion).toBe(true);
+		expect(selection.selectedEntries).toBe(1);
+		expect(selection.truncated).toBe(true);
+		expect(selection.markdown).toContain(STARTUP_CHANGELOG_FULL_HINT);
+		expect(selection.markdown).not.toContain("TAIL-ONE-RELEASE");
+		expect(Buffer.byteLength(selection.markdown ?? "")).toBeLessThanOrEqual(STARTUP_CHANGELOG_MAX_BYTES);
+	});
+
+	test("caps aggregate startup releases that exceed the byte budget and appends the full-changelog hint", () => {
+		const halfBudgetBody = "x".repeat(Math.ceil(STARTUP_CHANGELOG_MAX_BYTES / 2));
+		const selection = selectStartupChangelog(
+			[
+				release(1, 0, 4, `### Added\n\n- Four ${halfBudgetBody}\nTAIL-FOUR`),
+				release(1, 0, 3, `### Added\n\n- Three ${halfBudgetBody}\nTAIL-THREE`),
+				release(1, 0, 2, `### Added\n\n- Two ${halfBudgetBody}\nTAIL-TWO`),
+				release(1, 0, 1, "### Added\n\n- Already seen."),
+			],
+			"1.0.1",
+			"1.0.4",
+		);
+
+		expect(selection.persistCurrentVersion).toBe(true);
+		expect(selection.selectedEntries).toBe(RECENT_CHANGELOG_ENTRY_LIMIT);
+		expect(selection.truncated).toBe(true);
+		expect(selection.markdown).toContain(STARTUP_CHANGELOG_FULL_HINT);
+		expect(selection.markdown).not.toContain("TAIL-FOUR");
+		expect(Buffer.byteLength(selection.markdown ?? "")).toBeLessThanOrEqual(STARTUP_CHANGELOG_MAX_BYTES);
+	});
+});
+
+describe("renderChangelogEntries", () => {
+	test("renders complete history when no maxBytes cap is passed", () => {
+		const largeBody = "y".repeat(STARTUP_CHANGELOG_MAX_BYTES);
+		const rendered = renderChangelogEntries([
+			release(3, 0, 0, `### Added\n\n- Third ${largeBody}\nEND-THIRD`),
+			release(2, 0, 0, `### Added\n\n- Second ${largeBody}\nEND-SECOND`),
+			release(1, 0, 0, `### Added\n\n- First ${largeBody}\nEND-FIRST`),
+		]);
+
+		expect(rendered.truncated).toBe(false);
+		expect(rendered.markdown).toContain("END-FIRST");
+		expect(rendered.markdown).toContain("END-SECOND");
+		expect(rendered.markdown).toContain("END-THIRD");
+		expect(rendered.markdown).not.toContain(STARTUP_CHANGELOG_FULL_HINT);
+		expect(Buffer.byteLength(rendered.markdown)).toBeGreaterThan(STARTUP_CHANGELOG_MAX_BYTES);
+	});
+});
+
+describe("last changelog marker", () => {
+	test("reads a missing marker as undefined and writes the current version in the supplied agent dir", async () => {
+		await withTempAgentDir(async agentDir => {
+			expect(await readLastChangelogVersion(agentDir)).toBeUndefined();
+
+			await writeLastChangelogVersion(CURRENT_VERSION, agentDir);
+
+			expect(await readLastChangelogVersion(agentDir)).toBe(CURRENT_VERSION);
+			expect(await Bun.file(path.join(agentDir, "last-changelog-version")).text()).toBe(CURRENT_VERSION);
+		});
+	});
+});
+
+describe.skipIf(!hasPtyHarness)("interactive startup changelog PTY smoke", () => {
+	test("does not dump packaged changelog history on first install with uncollapsed notes", async () => {
+		await withTempAgentDir(async agentDir => {
+			const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-changelog-pty-"));
+			try {
+				await fs.mkdir(path.join(root, "xdg-config"), { recursive: true });
+				await fs.mkdir(path.join(root, "xdg-state"), { recursive: true });
+				await fs.mkdir(path.join(root, "xdg-data"), { recursive: true });
+				await Bun.write(path.join(agentDir, "config.yml"), "setupVersion: 1\ncollapseChangelog: false\n");
+
+				const proc = Bun.spawn(
+					["timeout", "6s", "script", "-q", "-c", `bun ${JSON.stringify(cliEntry)}`, "/dev/null"],
+					{
+						cwd: repoRoot,
+						stdout: "pipe",
+						stderr: "pipe",
+						env: {
+							...process.env,
+							HOME: root,
+							XDG_CONFIG_HOME: path.join(root, "xdg-config"),
+							XDG_STATE_HOME: path.join(root, "xdg-state"),
+							XDG_DATA_HOME: path.join(root, "xdg-data"),
+							PI_CODING_AGENT_DIR: agentDir,
+							PI_PACKAGE_DIR: packageDir,
+							PI_NO_TITLE: "1",
+							NO_COLOR: "1",
+							TERM: "xterm-256color",
+						},
+					},
+				);
+
+				const [stdout, stderr, exitCode] = await Promise.all([
+					new Response(proc.stdout).arrayBuffer(),
+					new Response(proc.stderr).text(),
+					proc.exited,
+				]);
+				const output = Buffer.from(stdout).toString("utf8");
+
+				expect(exitCode).toBe(124);
+				expect(Buffer.byteLength(output)).toBeLessThan(PTY_STARTUP_OUTPUT_CEILING);
+				expect(output).not.toContain("## [");
+				expect(output).not.toContain(STARTUP_CHANGELOG_FULL_HINT);
+				expect(stderr).not.toContain("Cannot find module");
+				expect(await readLastChangelogVersion(agentDir)).toBe(VERSION);
+			} finally {
+				await removeWithRetries(root);
+			}
+		});
+	}, 15_000);
+});


### PR DESCRIPTION
## Repro
A fresh interactive startup with `collapseChangelog: false`, no `last-changelog-version` marker, and the packaged `packages/coding-agent/CHANGELOG.md` available selected the full parsed changelog before the TUI rendered. I reproduced the selector path selecting 632 entries and 1,420,147 bytes of changelog content, and a PTY startup stayed active at the 6s timeout after emitting 73,241 bytes before the fix.

## Cause
`getChangelogForDisplay()` in `packages/coding-agent/src/main.ts` treated an absent marker as an upgrade from version zero and returned `entries.map(e => e.content).join("\n\n")`, while `parseChangelog()` in `packages/coding-agent/src/utils/changelog.ts` intentionally parses every release. `InteractiveMode` then rendered that unbounded Markdown when `collapseChangelog` was false, unlike `/changelog`, which already used a recent-only slice.

## Fix
- Treat missing, empty, malformed, or unreadable changelog markers as first-install state: persist the current version and render no historical startup notes.
- Add shared changelog rendering helpers that keep default recent views to three entries and cap automatic startup Markdown at 64 KiB with a `/changelog full` hint when truncated.
- Update startup, TUI `/changelog`, and ACP `/changelog` paths to use the shared bounded selection/rendering behavior while leaving `/changelog full` unbounded.
- Add regression coverage for marker states, current/older markers, single-release and aggregate truncation, full-history rendering, marker persistence, and a PTY startup smoke.
- Record the fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/utils/changelog.test.ts` passed with 8 tests and 60 assertions. `bun check` passed in `packages/coding-agent`. `gh_push_branch` pre-publish checks passed before pushing `farm/2867b062/bound-startup-changelog`. Fixes #5135