### PR TITLE
fix(coding-agent): report empty job list

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -42,6 +42,9 @@
 ### Removed
 
 - Removed the bundled plan subagent from available task agents.
+### Fixed
+
+- Fixed empty background-job lists returning blank tool output instead of an explicit no-jobs status ([#5143](https://github.com/can1357/oh-my-pi/pull/5143) by [@lyc-aon](https://github.com/lyc-aon)).
 
 ## [16.4.2] - 2026-07-10
 

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -355,7 +355,7 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 			...(cancelOutcomes.length ? { cancelled: cancelOutcomes.map(({ id, status }) => ({ id, status })) } : {}),
 		};
 		return {
-			content: [{ type: "text", text: lines.join("\n").trimEnd() }],
+			content: [{ type: "text", text: lines.length > 0 ? lines.join("\n").trimEnd() : "No background jobs found." }],
 			details,
 			// A poll where everything is still running carries no new information
 			// once a later poll exists — same predicate the TUI uses to displace

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1595,6 +1595,21 @@ function b() {
 	});
 
 	describe("JobTool", () => {
+		it("returns an explicit empty state when listing before any jobs exist", async () => {
+			const manager = new AsyncJobManager({
+				onJobComplete: async () => {},
+			});
+			const session = createTestToolSession(testDir, Settings.isolated({ "bash.autoBackground.enabled": true }), {
+				asyncJobManager: manager,
+			});
+			const jobTool = new JobTool(session);
+
+			const result = await jobTool.execute("test-call-empty-list", { list: true });
+
+			expect(getTextOutput(result)).toContain("No background jobs");
+			expect(result.details).toEqual({ jobs: [] });
+		});
+
 		it("should wait for jobs and acknowledge deliveries to prevent race conditions", async () => {
 			const manager = new AsyncJobManager({
 				onJobComplete: async () => {},


### PR DESCRIPTION
## What changed

- Return an explicit no-jobs status when `job {list:true}` has no jobs.
- Cover the model-visible text and structured empty details.

## Why

The result builder joined an empty line array, so the model received a blank tool result. The TUI fallback hid the problem.

## Tests

- `bun --cwd packages/coding-agent check`
- `bun test packages/coding-agent/test/tools.test.ts --test-name-pattern JobTool` (3 pass)
- Clean-home `bun run ci:test:coding-agent:native` (50/50 chunks)

## Grug summary

Empty job list now says it is empty. No mystery blank.
