### PR TITLE
fix(ai): preserve streamed Responses text on empty done items

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses and Codex Responses message finalization preserving streamed text when `output_item.done` arrives with empty content. ([#5146](https://github.com/can1357/oh-my-pi/issues/5146))
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -100,6 +100,7 @@ import {
 	encodeResponsesToolCallId,
 	encodeTextSignatureV1,
 	finalizeCustomToolCallInputDone,
+	finalizeMessageText,
 	finalizePendingResponsesToolCalls,
 	finalizeReasoningThinking,
 	finalizeToolCallArgumentsDone,
@@ -1965,9 +1966,7 @@ class CodexStreamProcessor {
 		}
 
 		if (item.type === "message" && block?.type === "text") {
-			block.text = item.content
-				.map(content => (content.type === "output_text" ? content.text : content.refusal))
-				.join("");
+			block.text = finalizeMessageText(item, block.text);
 			const phase = item.phase === "commentary" || item.phase === "final_answer" ? item.phase : undefined;
 			block.textSignature = encodeTextSignatureV1(item.id, phase);
 			stream.push({

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1971,6 +1971,11 @@ export function appendMessageTextDelta(
 	}
 	stream.push({ type: "text_delta", contentIndex, delta, partial: output });
 }
+/** Chooses final message text while treating non-empty terminal content as authoritative. */
+export function finalizeMessageText(item: ResponseOutputMessage, streamedText: string): string {
+	if (!item.content?.length) return streamedText || "";
+	return item.content.map(part => (part.type === "output_text" ? (part.text ?? "") : (part.refusal ?? ""))).join("");
+}
 
 export function accumulateToolCallArgumentsDelta(
 	block: ResponsesToolCallBlock,
@@ -2448,9 +2453,7 @@ export async function processResponsesStream<TApi extends Api>(
 				closeOpenItem(event.output_index, item.id, entry);
 			} else if (item.type === "message") {
 				const block = entry?.block.type === "text" ? entry.block : undefined;
-				const text = item.content
-					.map(part => (part.type === "output_text" ? (part.text ?? "") : (part.refusal ?? "")))
-					.join("");
+				const text = finalizeMessageText(item, block?.text ?? "");
 				const textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
 				let contentIndex: number;
 				if (block) {

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -473,6 +473,157 @@ describe("openai-codex streaming", () => {
 		expect(capturedText).toEqual({ verbosity: "low" });
 	});
 
+	async function runCodexSseEvents(events: unknown[]) {
+		const token = createCodexTestToken();
+		const context = createCodexTestContext();
+		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };
+		const sse = `${events.map(event => `data: ${JSON.stringify(event)}`).join("\n\n")}\n\n`;
+		const fetchMock: FetchImpl = async () =>
+			new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } });
+		const textEndContents: string[] = [];
+
+		const stream = streamOpenAICodexResponses(model, context, {
+			apiKey: token,
+			fetch: fetchMock,
+		});
+		const readPromise = (async () => {
+			for await (const event of stream) {
+				if (event.type === "text_end") textEndContents.push(event.content);
+			}
+		})();
+		const result = await stream.result();
+		await readPromise;
+
+		return { result, textEndContents };
+	}
+
+	for (const testCase of [
+		{
+			name: "absent terminal content preserves streamed text",
+			deltas: ["Hello", " world"],
+			expectedText: "Hello world",
+		},
+		{
+			name: "empty terminal content preserves streamed text",
+			deltas: ["Hello", " world"],
+			terminalContent: [],
+			expectedText: "Hello world",
+		},
+		{
+			name: "identical terminal text is not appended to streamed text",
+			deltas: ["Same text"],
+			terminalContent: [{ type: "output_text", text: "Same text", annotations: [] }],
+			expectedText: "Same text",
+		},
+		{
+			name: "terminal text replaces streamed text",
+			deltas: ["draft text"],
+			terminalContent: [{ type: "output_text", text: "final text", annotations: [] }],
+			expectedText: "final text",
+		},
+		{
+			name: "explicit empty terminal text clears streamed text",
+			deltas: ["draft text"],
+			terminalContent: [{ type: "output_text", text: "", annotations: [] }],
+			expectedText: "",
+		},
+		{
+			name: "terminal refusal replaces streamed text",
+			deltas: ["draft text"],
+			terminalContent: [{ type: "refusal", refusal: "I cannot help with that." }],
+			expectedText: "I cannot help with that.",
+		},
+	]) {
+		it(`finalizes message text when ${testCase.name}`, async () => {
+			const doneItem =
+				"terminalContent" in testCase
+					? {
+							type: "message",
+							id: "msg_1",
+							role: "assistant",
+							status: "completed",
+							content: testCase.terminalContent,
+						}
+					: { type: "message", id: "msg_1", role: "assistant", status: "completed" };
+			const events = [
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+				},
+				...testCase.deltas.map(delta => ({
+					type: "response.output_text.delta",
+					output_index: 0,
+					item_id: "msg_1",
+					delta,
+				})),
+				{ type: "response.output_item.done", output_index: 0, item: doneItem },
+				{
+					type: "response.completed",
+					response: {
+						id: "resp_1",
+						status: "completed",
+						usage: {
+							input_tokens: 5,
+							output_tokens: 3,
+							total_tokens: 8,
+							input_tokens_details: { cached_tokens: 0 },
+						},
+					},
+				},
+			];
+
+			const { result, textEndContents } = await runCodexSseEvents(events);
+
+			expect(result.content.find(block => block.type === "text")?.text).toBe(testCase.expectedText);
+			expect(textEndContents).toEqual([testCase.expectedText]);
+		});
+	}
+
+	it("keeps separate message output items from concatenating", async () => {
+		const { result, textEndContents } = await runCodexSseEvents([
+			{
+				type: "response.output_item.added",
+				output_index: 0,
+				item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.output_text.delta", output_index: 0, item_id: "msg_1", delta: "First" },
+			{
+				type: "response.output_item.done",
+				output_index: 0,
+				item: { type: "message", id: "msg_1", role: "assistant", status: "completed", content: [] },
+			},
+			{
+				type: "response.output_item.added",
+				output_index: 1,
+				item: { type: "message", id: "msg_2", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.output_text.delta", output_index: 1, item_id: "msg_2", delta: "Second" },
+			{
+				type: "response.output_item.done",
+				output_index: 1,
+				item: { type: "message", id: "msg_2", role: "assistant", status: "completed", content: [] },
+			},
+			{
+				type: "response.completed",
+				response: {
+					id: "resp_1",
+					status: "completed",
+					usage: {
+						input_tokens: 5,
+						output_tokens: 3,
+						total_tokens: 8,
+						input_tokens_details: { cached_tokens: 0 },
+					},
+				},
+			},
+		]);
+
+		const textBlocks = result.content.filter(block => block.type === "text");
+		expect(textBlocks.map(block => block.text)).toEqual(["First", "Second"]);
+		expect(textEndContents).toEqual(["First", "Second"]);
+	});
+
 	it("preserves streamed reasoning when the done item has no summary text", async () => {
 		const token = createCodexTestToken();
 		const model = { ...createCodexTestModel("https://chatgpt.com/backend-api"), preferWebsockets: false };

--- a/packages/ai/test/openai-responses-stream-terminal.test.ts
+++ b/packages/ai/test/openai-responses-stream-terminal.test.ts
@@ -120,6 +120,129 @@ describe("processResponsesStream: terminal events", () => {
 		expect(output.content).toEqual([expect.objectContaining({ type: "text", text: "Hello, trunc" })]);
 	});
 
+	for (const testCase of [
+		{
+			name: "absent terminal content preserves streamed text",
+			deltas: ["Hello", " world"],
+			expectedText: "Hello world",
+		},
+		{
+			name: "empty terminal content preserves streamed text",
+			deltas: ["Hello", " world"],
+			terminalContent: [],
+			expectedText: "Hello world",
+		},
+		{
+			name: "identical terminal text is not appended to streamed text",
+			deltas: ["Same text"],
+			terminalContent: [{ type: "output_text", text: "Same text", annotations: [] }],
+			expectedText: "Same text",
+		},
+		{
+			name: "terminal text replaces streamed text",
+			deltas: ["draft text"],
+			terminalContent: [{ type: "output_text", text: "final text", annotations: [] }],
+			expectedText: "final text",
+		},
+		{
+			name: "explicit empty terminal text clears streamed text",
+			deltas: ["draft text"],
+			terminalContent: [{ type: "output_text", text: "", annotations: [] }],
+			expectedText: "",
+		},
+		{
+			name: "terminal refusal replaces streamed text",
+			deltas: ["draft text"],
+			terminalContent: [{ type: "refusal", refusal: "I cannot help with that." }],
+			expectedText: "I cannot help with that.",
+		},
+	]) {
+		test(`finalizes message text when ${testCase.name}`, async () => {
+			const output = makeOutput();
+			const emitted: EmittedEvent[] = [];
+			const stream = { push: (e: unknown) => emitted.push(e as EmittedEvent), end: () => {} } as never;
+			const doneItem =
+				"terminalContent" in testCase
+					? {
+							type: "message",
+							id: "msg_1",
+							role: "assistant",
+							status: "completed",
+							content: testCase.terminalContent,
+						}
+					: { type: "message", id: "msg_1", role: "assistant", status: "completed" };
+
+			await processResponsesStream(
+				makeStream([
+					{
+						type: "response.output_item.added",
+						output_index: 0,
+						item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+					},
+					...testCase.deltas.map(delta => ({
+						type: "response.output_text.delta",
+						output_index: 0,
+						item_id: "msg_1",
+						delta,
+					})),
+					{ type: "response.output_item.done", output_index: 0, item: doneItem },
+					{ type: "response.completed", response: { id: "resp_done", status: "completed" } },
+				]),
+				output,
+				stream,
+				makeModel(),
+			);
+
+			expect(output.content).toEqual([expect.objectContaining({ type: "text", text: testCase.expectedText })]);
+			const end = emitted.find(e => e.type === "text_end");
+			expect(end?.content).toBe(testCase.expectedText);
+		});
+	}
+
+	test("keeps separate message output items from concatenating", async () => {
+		const output = makeOutput();
+		const emitted: EmittedEvent[] = [];
+		const stream = { push: (e: unknown) => emitted.push(e as EmittedEvent), end: () => {} } as never;
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "message", id: "msg_1", role: "assistant", status: "in_progress", content: [] },
+				},
+				{ type: "response.output_text.delta", output_index: 0, item_id: "msg_1", delta: "First" },
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "message", id: "msg_1", role: "assistant", status: "completed", content: [] },
+				},
+				{
+					type: "response.output_item.added",
+					output_index: 1,
+					item: { type: "message", id: "msg_2", role: "assistant", status: "in_progress", content: [] },
+				},
+				{ type: "response.output_text.delta", output_index: 1, item_id: "msg_2", delta: "Second" },
+				{
+					type: "response.output_item.done",
+					output_index: 1,
+					item: { type: "message", id: "msg_2", role: "assistant", status: "completed", content: [] },
+				},
+				{ type: "response.completed", response: { id: "resp_done", status: "completed" } },
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		const textBlocks = output.content.filter(block => block.type === "text");
+		expect(textBlocks.map(block => block.text)).toEqual(["First", "Second"]);
+		expect(emitted.filter(e => e.type === "text_end").map(e => [e.contentIndex, e.content])).toEqual([
+			[0, "First"],
+			[1, "Second"],
+		]);
+	});
+
 	test("persists final custom tool input on the block and drops the accumulation buffer", async () => {
 		const output = makeOutput();
 		const emitted: EmittedEvent[] = [];


### PR DESCRIPTION
## Repro
A minimal `processResponsesStream` event sequence with `response.output_text.delta` chunks for `Hello world`, followed by `response.output_item.done` for the same `type: "message"` item with `content: []`, reproduced the bug: the final text block and `text_end.content` were both finalized as `""`.

## Cause
`packages/ai/src/providers/openai-shared.ts` and `packages/ai/src/providers/openai-codex-responses.ts` rebuilt message text directly from the final `output_item.done` payload. When OpenAI/Codex sent an empty `content` array even though deltas had already populated the live text block, the finalizer overwrote the streamed block with an empty string.

## Fix
- Added a shared `finalizeMessageText` helper that prefers non-empty done-item text and falls back to the streamed text already present on the block.
- Updated generic Responses message finalization so stored text blocks and `text_end` events use the preserved final text.
- Updated Codex Responses message finalization to use the same fallback path.
- Added generic Responses and Codex SSE regression tests for empty-content message `output_item.done` events.
- Added the `packages/ai` changelog entry for the fix.

## Verification
Reproduced before the fix with a `processResponsesStream` event sequence that finalized `finalText` and `textEndContent` as `""`; after the fix, the same sequence finalized both as `"Hello world"`. Ran `bun test test/openai-responses-stream-terminal.test.ts test/openai-codex-stream.test.ts -t "preserves streamed message text when output_item.done has empty content"` in `packages/ai`: 2 pass, 0 fail. Ran `bun test test/openai-responses-stream-terminal.test.ts test/openai-codex-stream.test.ts` in `packages/ai`: 70 pass, 0 fail. Ran `bun run fix`: completed and formatted one `pi-ai` file. Fixes #5146