### PR TITLE
fix(tui): display Cursor final answers after tool output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor-provider turns whose assistant message contains intro text, tool calls, and trailing final text rendering the final answer above the tool output instead of at the transcript tail ([#4871](https://github.com/can1357/oh-my-pi/issues/4871)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -35,6 +35,7 @@ import {
 	buildIrcMessageCard,
 	normalizeToolArgs,
 	resolveAssistantErrorPresentation,
+	splitAssistantMessageToolTimeline,
 } from "../utils/transcript-render-helpers";
 import { createAdvisorMessageCard } from "./advisor-message";
 import { AssistantMessageComponent } from "./assistant-message";
@@ -273,8 +274,9 @@ export class ChatTranscriptBuilder {
 	#appendAssistantMessage(message: Extract<AgentMessage, { role: "assistant" }>): void {
 		const hideThinkingBlock = this.deps.hideThinkingBlock?.() ?? false;
 		const proseOnlyThinking = this.deps.proseOnlyThinking ? this.deps.proseOnlyThinking() : true;
+		const timeline = splitAssistantMessageToolTimeline(message);
 		const assistantComponent = new AssistantMessageComponent(
-			message,
+			timeline.beforeTools,
 			hideThinkingBlock,
 			() => this.deps.requestRender(),
 			this.deps.getMessageRenderer ? undefined : [], // placeholder for thinkingRenderers
@@ -355,6 +357,17 @@ export class ChatTranscriptBuilder {
 			} else {
 				this.#pendingTools.set(content.id, component);
 			}
+		}
+		if (timeline.afterTools && assistantHasVisibleContent(timeline.afterTools)) {
+			const afterToolsComponent = new AssistantMessageComponent(
+				timeline.afterTools,
+				hideThinkingBlock,
+				() => this.deps.requestRender(),
+				this.deps.getMessageRenderer ? undefined : [],
+				undefined,
+				proseOnlyThinking,
+			);
+			this.container.addChild(afterToolsComponent);
 		}
 
 		this.#pendingUsage =

--- a/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
+++ b/packages/coding-agent/src/modes/components/chat-transcript-builder.ts
@@ -303,11 +303,24 @@ export class ChatTranscriptBuilder {
 		const errorPresentation = resolveAssistantErrorPresentation(message);
 		const hasErrorStop = errorPresentation.kind === "full";
 		const errorMessage = hasErrorStop ? errorPresentation.text : null;
+		const appendAssistantSegment = (segment: Extract<AgentMessage, { role: "assistant" }> | undefined) => {
+			if (!segment || !assistantHasVisibleContent(segment)) return;
+			const component = new AssistantMessageComponent(
+				segment,
+				hideThinkingBlock,
+				() => this.deps.requestRender(),
+				this.deps.getMessageRenderer ? undefined : [],
+				undefined,
+				proseOnlyThinking,
+			);
+			this.container.addChild(component);
+		};
 
 		for (const content of message.content) {
 			if (content.type !== "toolCall") continue;
 			this.#resolveWaitingPoll(content.name);
 
+			const afterToolSegment = timeline.afterToolCalls.get(content.id);
 			if (
 				content.name === "read" &&
 				readArgsHaveTarget(content.arguments) &&
@@ -321,10 +334,15 @@ export class ChatTranscriptBuilder {
 						false,
 						content.id,
 					);
+				} else if (afterToolSegment) {
+					const group = this.#ensureReadGroup();
+					group.updateArgs(content.arguments, content.id);
+					this.#pendingTools.set(content.id, group);
 				} else {
 					const normalizedArgs = normalizeToolArgs(content.arguments);
 					this.#readArgs.set(content.id, normalizedArgs);
 				}
+				appendAssistantSegment(afterToolSegment);
 				continue;
 			}
 
@@ -357,17 +375,7 @@ export class ChatTranscriptBuilder {
 			} else {
 				this.#pendingTools.set(content.id, component);
 			}
-		}
-		if (timeline.afterTools && assistantHasVisibleContent(timeline.afterTools)) {
-			const afterToolsComponent = new AssistantMessageComponent(
-				timeline.afterTools,
-				hideThinkingBlock,
-				() => this.deps.requestRender(),
-				this.deps.getMessageRenderer ? undefined : [],
-				undefined,
-				proseOnlyThinking,
-			);
-			this.container.addChild(afterToolsComponent);
+			appendAssistantSegment(afterToolSegment);
 		}
 
 		this.#pendingUsage =

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -83,6 +83,7 @@ export class EventController {
 	#backgroundToolCallIds = new Set<string>();
 	#readToolCallArgs = new Map<string, Record<string, unknown>>();
 	#readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
+	#toolTimelineComponents = new Map<string, Component>();
 	#lastAssistantComponent: AssistantMessageComponent | undefined = undefined;
 	// Assistant component whose turn-ending error is currently mirrored in the
 	// pinned banner. Its inline `Error: …` line is suppressed while pinned and
@@ -258,6 +259,28 @@ export class EventController {
 		assistantComponent.setToolResultImages(toolCallId, images);
 		return true;
 	}
+
+	#insertAfterTranscriptComponent(anchor: Component | undefined, component: Component): void {
+		const children = this.ctx.chatContainer.children;
+		const anchorIndex = anchor ? children.indexOf(anchor) : -1;
+		this.ctx.chatContainer.addChild(component);
+		if (anchorIndex < 0) return;
+		children.splice(children.length - 1, 1);
+		children.splice(anchorIndex + 1, 0, component);
+	}
+
+	#appendPostToolAssistantSegment(
+		toolCallId: string,
+		segment: AssistantMessage | undefined,
+	): AssistantMessageComponent | undefined {
+		if (!segment || !assistantHasVisibleContent(segment)) return undefined;
+		const component = createAssistantMessageComponent(this.ctx);
+		component.updateContent(segment);
+		component.markTranscriptBlockFinalized();
+		this.#insertAfterTranscriptComponent(this.#toolTimelineComponents.get(toolCallId), component);
+		return component;
+	}
+
 	#updateWorkingMessageFromIntent(intent: unknown): void {
 		if (this.ctx.session.isAborting) return;
 		// Streamed JSON can deliver non-string `i` (object, number, boolean) before
@@ -285,6 +308,7 @@ export class EventController {
 		this.#lastVisibleBlockCount = 0;
 		this.#renderedCustomMessages.clear();
 		this.#lastIntent = undefined;
+		this.#toolTimelineComponents.clear();
 		this.#backgroundToolCallIds.clear();
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
@@ -369,6 +393,7 @@ export class EventController {
 	}
 
 	async #handleAgentStart(_event: Extract<AgentSessionEvent, { type: "agent_start" }>): Promise<void> {
+		this.#toolTimelineComponents.clear();
 		this.#lastIntent = undefined;
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
@@ -699,6 +724,7 @@ export class EventController {
 							const group = this.#getReadGroup();
 							group.updateArgs(content.arguments, content.id);
 							this.ctx.pendingTools.set(content.id, group);
+							this.#toolTimelineComponents.set(content.id, group);
 						}
 						continue;
 					}
@@ -745,6 +771,7 @@ export class EventController {
 					component.setExpanded(this.ctx.toolOutputExpanded);
 					this.ctx.chatContainer.addChild(component);
 					this.ctx.pendingTools.set(content.id, component);
+					this.#toolTimelineComponents.set(content.id, component);
 					this.#toolArgsReveal.bind(content.id, component);
 				} else {
 					const component = this.ctx.pendingTools.get(content.id);
@@ -860,14 +887,12 @@ export class EventController {
 				this.ctx.lastAssistantUsage = usage;
 			}
 			this.ctx.streamingComponent.markTranscriptBlockFinalized();
-			let postToolAssistantComponent: AssistantMessageComponent | undefined;
-			if (displayTimeline.afterTools && assistantHasVisibleContent(displayTimeline.afterTools)) {
-				postToolAssistantComponent = createAssistantMessageComponent(this.ctx);
-				postToolAssistantComponent.updateContent(displayTimeline.afterTools);
-				postToolAssistantComponent.markTranscriptBlockFinalized();
-				this.ctx.chatContainer.addChild(postToolAssistantComponent);
+			let lastPostToolAssistantComponent: AssistantMessageComponent | undefined;
+			for (const [toolCallId, segment] of displayTimeline.afterToolCalls) {
+				const component = this.#appendPostToolAssistantSegment(toolCallId, segment);
+				if (component) lastPostToolAssistantComponent = component;
 			}
-			this.#lastAssistantComponent = postToolAssistantComponent ?? this.ctx.streamingComponent;
+			this.#lastAssistantComponent = lastPostToolAssistantComponent ?? this.ctx.streamingComponent;
 			if (settings.get("display.showTokenUsage") && assistantUsageIsBilled(event.message.usage)) {
 				this.ctx.chatContainer.addChild(
 					createUsageRowBlock(event.message.usage, event.message.duration, event.message.ttft),
@@ -904,6 +929,7 @@ export class EventController {
 					const group = this.#getReadGroup();
 					group.updateArgs(event.args, event.toolCallId);
 					this.ctx.pendingTools.set(event.toolCallId, group);
+					this.#toolTimelineComponents.set(event.toolCallId, group);
 				}
 				this.ctx.ui.requestRender();
 				return;
@@ -929,6 +955,7 @@ export class EventController {
 			component.setExpanded(this.ctx.toolOutputExpanded);
 			this.ctx.chatContainer.addChild(component);
 			this.ctx.pendingTools.set(event.toolCallId, component);
+			this.#toolTimelineComponents.set(event.toolCallId, component);
 			this.ctx.ui.requestRender();
 		} else {
 			// The tool is about to run, so its arguments are final and validated.
@@ -1129,6 +1156,7 @@ export class EventController {
 		);
 		this.#readToolCallArgs.clear();
 		this.#readToolCallAssistantComponents.clear();
+		this.#toolTimelineComponents.clear();
 		this.#resetReadGroup();
 		// The turn is over: nothing else lands this turn, so the waiting poll is
 		// final history — seal it instead of letting its spinner tick while idle.

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -1,4 +1,4 @@
-import type { ImageContent } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { getStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { type Component, Loader, TERMINAL } from "@oh-my-pi/pi-tui";
@@ -32,7 +32,11 @@ import { vocalizer } from "../../tts/vocalizer";
 import { canonicalizeMessage } from "../../utils/thinking-display";
 import { interruptHint } from "../shared";
 import { createAssistantMessageComponent } from "../utils/interactive-context-helpers";
-import { assistantUsageIsBilled } from "../utils/transcript-render-helpers";
+import {
+	assistantHasVisibleContent,
+	assistantUsageIsBilled,
+	splitAssistantMessageToolTimeline,
+} from "../utils/transcript-render-helpers";
 import { StreamingRevealController } from "./streaming-reveal";
 import { streamingStringKeysForTool, ToolArgsRevealController } from "./tool-args-reveal";
 
@@ -463,7 +467,10 @@ export class EventController {
 			this.ctx.streamingComponent = createAssistantMessageComponent(this.ctx);
 			this.ctx.streamingMessage = event.message;
 			this.ctx.chatContainer.addChild(this.ctx.streamingComponent);
-			this.#streamingReveal.begin(this.ctx.streamingComponent, this.ctx.streamingMessage);
+			this.#streamingReveal.begin(
+				this.ctx.streamingComponent,
+				splitAssistantMessageToolTimeline(this.ctx.streamingMessage).beforeTools,
+			);
 			this.ctx.ui.requestRender();
 		}
 	}
@@ -648,7 +655,8 @@ export class EventController {
 				this.#streamingReveal.resyncVisibility();
 			}
 			this.ctx.streamingMessage = event.message;
-			this.#streamingReveal.setTarget(this.ctx.streamingMessage);
+			const timeline = splitAssistantMessageToolTimeline(this.ctx.streamingMessage);
+			this.#streamingReveal.setTarget(timeline.beforeTools);
 
 			const visibleBlockCount = this.ctx.streamingMessage.content.filter(
 				content =>
@@ -810,15 +818,18 @@ export class EventController {
 				errorMessage = resolveAbortLabel(this.ctx.streamingMessage, this.ctx.viewSession.retryAttempt);
 				this.ctx.streamingMessage.errorMessage = errorMessage;
 			}
-			if (silentlyAborted || ttsrSilenced) {
-				// Silence the streaming render by downgrading stopReason to "stop" for
-				// display only — does NOT mutate the persisted message's stopReason
-				// (the marker on errorMessage drives replay-side suppression).
-				const msgWithoutAbort = { ...this.ctx.streamingMessage, stopReason: "stop" as const };
-				this.ctx.streamingComponent.updateContent(msgWithoutAbort);
-			} else {
-				this.ctx.streamingComponent.updateContent(this.ctx.streamingMessage);
-			}
+			const displayMessage: AssistantMessage =
+				silentlyAborted || ttsrSilenced
+					? {
+							// Silence the streaming render by downgrading stopReason to "stop" for
+							// display only — does NOT mutate the persisted message's stopReason
+							// (the marker on errorMessage drives replay-side suppression).
+							...this.ctx.streamingMessage,
+							stopReason: "stop",
+						}
+					: this.ctx.streamingMessage;
+			const displayTimeline = splitAssistantMessageToolTimeline(displayMessage);
+			this.ctx.streamingComponent.updateContent(displayTimeline.beforeTools);
 
 			if (this.ctx.streamingMessage.stopReason !== "aborted" && this.ctx.streamingMessage.stopReason !== "error") {
 				for (const [toolCallId, component] of this.ctx.pendingTools.entries()) {
@@ -848,8 +859,15 @@ export class EventController {
 				}
 				this.ctx.lastAssistantUsage = usage;
 			}
-			this.#lastAssistantComponent = this.ctx.streamingComponent;
-			this.#lastAssistantComponent.markTranscriptBlockFinalized();
+			this.ctx.streamingComponent.markTranscriptBlockFinalized();
+			let postToolAssistantComponent: AssistantMessageComponent | undefined;
+			if (displayTimeline.afterTools && assistantHasVisibleContent(displayTimeline.afterTools)) {
+				postToolAssistantComponent = createAssistantMessageComponent(this.ctx);
+				postToolAssistantComponent.updateContent(displayTimeline.afterTools);
+				postToolAssistantComponent.markTranscriptBlockFinalized();
+				this.ctx.chatContainer.addChild(postToolAssistantComponent);
+			}
+			this.#lastAssistantComponent = postToolAssistantComponent ?? this.ctx.streamingComponent;
 			if (settings.get("display.showTokenUsage") && assistantUsageIsBilled(event.message.usage)) {
 				this.ctx.chatContainer.addChild(
 					createUsageRowBlock(event.message.usage, event.message.duration, event.message.ttft),

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -137,6 +137,59 @@ export function assistantHasVisibleContent(message: AssistantAgentMessage): bool
 }
 
 /**
+ * Split mixed assistant turns into the visible text before tool execution and
+ * the visible text that must render after the tool timeline. Cursor can return
+ * intro text, tool calls, and the final answer in one assistant message; keeping
+ * the post-tool text in the leading assistant block buries the answer above tool
+ * results in the transcript.
+ */
+export function splitAssistantMessageToolTimeline(message: AssistantAgentMessage): {
+	beforeTools: AssistantAgentMessage;
+	afterTools: AssistantAgentMessage | undefined;
+	hasToolCalls: boolean;
+} {
+	const beforeTools: AssistantAgentMessage["content"] = [];
+	const afterTools: AssistantAgentMessage["content"] = [];
+	let sawToolCall = false;
+
+	for (const content of message.content) {
+		if (content.type === "toolCall") {
+			sawToolCall = true;
+			continue;
+		}
+		if (sawToolCall) {
+			afterTools.push(content);
+		} else {
+			beforeTools.push(content);
+		}
+	}
+
+	if (!sawToolCall) {
+		return { beforeTools: message, afterTools: undefined, hasToolCalls: false };
+	}
+
+	const beforeMessage: AssistantAgentMessage = {
+		...message,
+		content: beforeTools,
+		stopReason: "stop",
+		errorMessage: undefined,
+		retryRecovery: undefined,
+	};
+	const afterMessage: AssistantAgentMessage | undefined =
+		afterTools.length === 0
+			? undefined
+			: {
+					...message,
+					content: afterTools,
+					stopReason: "stop",
+					errorMessage: undefined,
+					retryRecovery: undefined,
+				};
+
+	return { beforeTools: beforeMessage, afterTools: afterMessage, hasToolCalls: true };
+}
+
+/**
  * Normalize raw tool-call arguments to a plain record, collapsing non-object or
  * array values to an empty object.
  */

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -137,56 +137,57 @@ export function assistantHasVisibleContent(message: AssistantAgentMessage): bool
 }
 
 /**
- * Split mixed assistant turns into the visible text before tool execution and
- * the visible text that must render after the tool timeline. Cursor can return
- * intro text, tool calls, and the final answer in one assistant message; keeping
- * the post-tool text in the leading assistant block buries the answer above tool
- * results in the transcript.
+ * Split mixed assistant turns into visible text before tool execution and
+ * visible text segments that must render immediately after the preceding tool.
+ * Cursor can return intro text, tool calls, progress text, and the final answer
+ * in one assistant message; keeping every text block in the leading assistant
+ * block buries post-tool text above tool results in the transcript.
  */
 export function splitAssistantMessageToolTimeline(message: AssistantAgentMessage): {
 	beforeTools: AssistantAgentMessage;
-	afterTools: AssistantAgentMessage | undefined;
+	afterToolCalls: ReadonlyMap<string, AssistantAgentMessage>;
 	hasToolCalls: boolean;
 } {
 	const beforeTools: AssistantAgentMessage["content"] = [];
-	const afterTools: AssistantAgentMessage["content"] = [];
+	const afterToolCalls = new Map<string, AssistantAgentMessage>();
+	let pendingAfterTool: AssistantAgentMessage["content"] = [];
+	let lastToolCallId: string | undefined;
 	let sawToolCall = false;
+
+	const displaySegment = (content: AssistantAgentMessage["content"]): AssistantAgentMessage => ({
+		...message,
+		content,
+		stopReason: "stop",
+		errorMessage: undefined,
+		retryRecovery: undefined,
+	});
+
+	const flushPendingAfterTool = () => {
+		if (!lastToolCallId || pendingAfterTool.length === 0) return;
+		afterToolCalls.set(lastToolCallId, displaySegment(pendingAfterTool));
+		pendingAfterTool = [];
+	};
 
 	for (const content of message.content) {
 		if (content.type === "toolCall") {
+			flushPendingAfterTool();
 			sawToolCall = true;
+			lastToolCallId = content.id;
 			continue;
 		}
 		if (sawToolCall) {
-			afterTools.push(content);
+			pendingAfterTool.push(content);
 		} else {
 			beforeTools.push(content);
 		}
 	}
+	flushPendingAfterTool();
 
 	if (!sawToolCall) {
-		return { beforeTools: message, afterTools: undefined, hasToolCalls: false };
+		return { beforeTools: message, afterToolCalls, hasToolCalls: false };
 	}
 
-	const beforeMessage: AssistantAgentMessage = {
-		...message,
-		content: beforeTools,
-		stopReason: "stop",
-		errorMessage: undefined,
-		retryRecovery: undefined,
-	};
-	const afterMessage: AssistantAgentMessage | undefined =
-		afterTools.length === 0
-			? undefined
-			: {
-					...message,
-					content: afterTools,
-					stopReason: "stop",
-					errorMessage: undefined,
-					retryRecovery: undefined,
-				};
-
-	return { beforeTools: beforeMessage, afterTools: afterMessage, hasToolCalls: true };
+	return { beforeTools: displaySegment(beforeTools), afterToolCalls, hasToolCalls: true };
 }
 
 /**

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -387,6 +387,11 @@ export class UiHelpers {
 				const errorPresentation = resolveAssistantErrorPresentation(message, this.ctx.viewSession.retryAttempt);
 				const hasErrorStop = errorPresentation.kind === "full";
 				const errorMessage = hasErrorStop ? errorPresentation.text : null;
+				const appendAssistantSegment = (segment: AssistantMessage | undefined) => {
+					if (!segment || !assistantHasVisibleContent(segment)) return;
+					const component = createAssistantMessageComponent(this.ctx, segment);
+					this.ctx.chatContainer.addChild(component);
+				};
 
 				// Render tool call components
 				for (const content of message.content) {
@@ -394,6 +399,7 @@ export class UiHelpers {
 						continue;
 					}
 					resolveWaitingPoll(content.name);
+					const afterToolSegment = timeline.afterToolCalls.get(content.id);
 
 					if (
 						content.name === "read" &&
@@ -414,6 +420,19 @@ export class UiHelpers {
 								false,
 								content.id,
 							);
+						} else if (afterToolSegment) {
+							if (!readGroup) {
+								readGroup = new ReadToolGroupComponent({
+									showContentPreview: this.ctx.settings.get("read.toolResultPreview"),
+								});
+								readGroup.setExpanded(this.ctx.toolOutputExpanded);
+								this.ctx.chatContainer.addChild(readGroup);
+							}
+							readGroup.updateArgs(content.arguments, content.id);
+							this.ctx.pendingTools.set(content.id, readGroup);
+							if (assistantComponent) {
+								readToolCallAssistantComponents.set(content.id, assistantComponent);
+							}
 						} else {
 							const normalizedArgs = normalizeToolArgs(content.arguments);
 							readToolCallArgs.set(content.id, normalizedArgs);
@@ -421,6 +440,7 @@ export class UiHelpers {
 								readToolCallAssistantComponents.set(content.id, assistantComponent);
 							}
 						}
+						appendAssistantSegment(afterToolSegment);
 						continue;
 					}
 
@@ -468,10 +488,7 @@ export class UiHelpers {
 					} else {
 						this.ctx.pendingTools.set(content.id, component);
 					}
-				}
-				if (timeline.afterTools && assistantHasVisibleContent(timeline.afterTools)) {
-					const afterToolsComponent = createAssistantMessageComponent(this.ctx, timeline.afterTools);
-					this.ctx.chatContainer.addChild(afterToolsComponent);
+					appendAssistantSegment(afterToolSegment);
 				}
 				pendingUsage =
 					this.ctx.settings.get("display.showTokenUsage") && assistantUsageIsBilled(message.usage)

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -56,6 +56,7 @@ import {
 	buildIrcMessageCard,
 	normalizeToolArgs,
 	resolveAssistantErrorPresentation,
+	splitAssistantMessageToolTimeline,
 } from "./transcript-render-helpers";
 
 type TextBlock = { type: "text"; text: string };
@@ -250,7 +251,10 @@ export class UiHelpers {
 				break;
 			}
 			case "assistant": {
-				const assistantComponent = createAssistantMessageComponent(this.ctx, message);
+				const assistantComponent = createAssistantMessageComponent(
+					this.ctx,
+					splitAssistantMessageToolTimeline(message).beforeTools,
+				);
 				this.ctx.chatContainer.addChild(assistantComponent);
 				break;
 			}
@@ -356,6 +360,7 @@ export class UiHelpers {
 			if (message.role !== "toolResult") flushPendingUsage();
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
+				const timeline = splitAssistantMessageToolTimeline(message);
 				this.ctx.addMessageToChat(message);
 				const lastChild = this.ctx.chatContainer.children[this.ctx.chatContainer.children.length - 1];
 				const assistantComponent = lastChild instanceof AssistantMessageComponent ? lastChild : undefined;
@@ -463,6 +468,10 @@ export class UiHelpers {
 					} else {
 						this.ctx.pendingTools.set(content.id, component);
 					}
+				}
+				if (timeline.afterTools && assistantHasVisibleContent(timeline.afterTools)) {
+					const afterToolsComponent = createAssistantMessageComponent(this.ctx, timeline.afterTools);
+					this.ctx.chatContainer.addChild(afterToolsComponent);
 				}
 				pendingUsage =
 					this.ctx.settings.get("display.showTokenUsage") && assistantUsageIsBilled(message.usage)

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/event-controller-mixed-assistant-render.test.ts
+++ b/packages/coding-agent/test/event-controller-mixed-assistant-render.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage, ToolCall, Usage } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
+import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+const TOOL_CALL_ID = "toolu_mixed_text_order";
+const INTRO_MARKER = "INTRO TEXT BEFORE TOOL";
+const TOOL_RESULT_MARKER = "TOOL RESULT BETWEEN TEXT BLOCKS";
+const FINAL_MARKER = "FINAL ANSWER AFTER TOOL";
+
+function zeroUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function assistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "cursor",
+		provider: "cursor",
+		model: "cursor-model",
+		stopReason: "stop",
+		usage: zeroUsage(),
+		timestamp: 1,
+	};
+}
+
+function lineContaining(lines: string[], marker: string): number {
+	const index = lines.findIndex(line => line.includes(marker));
+	if (index === -1) {
+		throw new Error(`Rendered transcript did not contain ${marker}:\n${lines.join("\n")}`);
+	}
+	return index;
+}
+
+function createFixture() {
+	const chatContainer = new TranscriptContainer();
+	const pendingTools = new Map();
+	const ui = {
+		requestRender: vi.fn(),
+		requestComponentRender: vi.fn(),
+		imageBudget: undefined,
+	} as unknown as TUI;
+	const viewSession = {
+		getToolByName: () => undefined,
+		extensionRunner: undefined,
+		isTtsrAbortPending: false,
+		retryAttempt: 0,
+	};
+	let hasDisplayableThinkingContent = false;
+	const ctx = {
+		isInitialized: true,
+		init: vi.fn(async () => {}),
+		ui,
+		settings,
+		chatContainer,
+		pendingTools,
+		toolOutputExpanded: false,
+		effectiveHideThinkingBlock: false,
+		proseOnlyThinking: true,
+		statusLine: { invalidate: vi.fn() },
+		updateEditorTopBorder: vi.fn(),
+		noteDisplayableThinkingContent: vi.fn((message: AssistantMessage) => {
+			const hasThinking = message.content.some(
+				content => content.type === "thinking" && content.thinking.trim() !== "",
+			);
+			if (!hasThinking || hasDisplayableThinkingContent) return false;
+			hasDisplayableThinkingContent = true;
+			return true;
+		}),
+		session: viewSession,
+		viewSession,
+		sessionManager: { getCwd: () => process.cwd() },
+		showWarning: vi.fn(),
+		showPinnedError: vi.fn(),
+		clearTransientSessionUi: vi.fn(),
+		lastAssistantUsage: zeroUsage(),
+	} as unknown as InteractiveModeContext;
+
+	return { controller: new EventController(ctx), chatContainer };
+}
+
+describe("EventController mixed assistant text/tool rendering", () => {
+	beforeAll(async () => {
+		await initTheme(false);
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, overrides: { "display.smoothStreaming": false } });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	it("renders trailing assistant text after the tool result for one text-toolCall-text message", async () => {
+		const { controller, chatContainer } = createFixture();
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: TOOL_CALL_ID,
+			name: "contract_probe",
+			arguments: { value: 1 },
+		};
+		const started = assistantMessage([]);
+		const withToolCall = assistantMessage([{ type: "text", text: INTRO_MARKER }, toolCall]);
+		const completed = assistantMessage([
+			{ type: "text", text: INTRO_MARKER },
+			toolCall,
+			{ type: "text", text: FINAL_MARKER },
+		]);
+
+		await controller.handleEvent({ type: "message_start", message: started } as Extract<
+			AgentSessionEvent,
+			{ type: "message_start" }
+		>);
+		await controller.handleEvent({
+			type: "message_update",
+			message: withToolCall,
+			assistantMessageEvent: { type: "toolcall_end", contentIndex: 1, toolCall, partial: withToolCall },
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		await controller.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: TOOL_CALL_ID,
+			toolName: "contract_probe",
+			args: { value: 1 },
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		await controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: TOOL_CALL_ID,
+			toolName: "contract_probe",
+			result: { content: [{ type: "text", text: TOOL_RESULT_MARKER }] },
+			isError: false,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+		await controller.handleEvent({ type: "message_end", message: completed } as Extract<
+			AgentSessionEvent,
+			{ type: "message_end" }
+		>);
+
+		const lines = chatContainer.render(120).map(line => Bun.stripANSI(line));
+		const introLine = lineContaining(lines, INTRO_MARKER);
+		const toolResultLine = lineContaining(lines, TOOL_RESULT_MARKER);
+		const finalLine = lineContaining(lines, FINAL_MARKER);
+
+		expect(introLine).toBeLessThan(toolResultLine);
+		expect(finalLine).toBeGreaterThan(toolResultLine);
+	});
+});

--- a/packages/coding-agent/test/event-controller-mixed-assistant-render.test.ts
+++ b/packages/coding-agent/test/event-controller-mixed-assistant-render.test.ts
@@ -8,10 +8,13 @@ import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/typ
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type { TUI } from "@oh-my-pi/pi-tui";
 
-const TOOL_CALL_ID = "toolu_mixed_text_order";
-const INTRO_MARKER = "INTRO TEXT BEFORE TOOL";
-const TOOL_RESULT_MARKER = "TOOL RESULT BETWEEN TEXT BLOCKS";
-const FINAL_MARKER = "FINAL ANSWER AFTER TOOL";
+const TOOL_CALL_A_ID = "toolu_mixed_text_order_a";
+const TOOL_CALL_B_ID = "toolu_mixed_text_order_b";
+const INTRO_MARKER = "INTRO TEXT BEFORE FIRST TOOL";
+const TOOL_RESULT_A_MARKER = "TOOL RESULT FROM FIRST TOOL";
+const MIDDLE_MARKER = "MIDDLE TEXT BETWEEN TOOL CALLS";
+const TOOL_RESULT_B_MARKER = "TOOL RESULT FROM SECOND TOOL";
+const FINAL_MARKER = "FINAL ANSWER AFTER SECOND TOOL";
 
 function zeroUsage(): Usage {
 	return {
@@ -107,19 +110,33 @@ describe("EventController mixed assistant text/tool rendering", () => {
 		resetSettingsForTest();
 	});
 
-	it("renders trailing assistant text after the tool result for one text-toolCall-text message", async () => {
+	it("renders assistant text segments in order around two tool results from one mixed message", async () => {
 		const { controller, chatContainer } = createFixture();
-		const toolCall: ToolCall = {
+		const toolCallA: ToolCall = {
 			type: "toolCall",
-			id: TOOL_CALL_ID,
-			name: "contract_probe",
-			arguments: { value: 1 },
+			id: TOOL_CALL_A_ID,
+			name: "contract_probe_a",
+			arguments: { value: "a" },
+		};
+		const toolCallB: ToolCall = {
+			type: "toolCall",
+			id: TOOL_CALL_B_ID,
+			name: "contract_probe_b",
+			arguments: { value: "b" },
 		};
 		const started = assistantMessage([]);
-		const withToolCall = assistantMessage([{ type: "text", text: INTRO_MARKER }, toolCall]);
+		const withFirstToolCall = assistantMessage([{ type: "text", text: INTRO_MARKER }, toolCallA]);
+		const withSecondToolCall = assistantMessage([
+			{ type: "text", text: INTRO_MARKER },
+			toolCallA,
+			{ type: "text", text: MIDDLE_MARKER },
+			toolCallB,
+		]);
 		const completed = assistantMessage([
 			{ type: "text", text: INTRO_MARKER },
-			toolCall,
+			toolCallA,
+			{ type: "text", text: MIDDLE_MARKER },
+			toolCallB,
 			{ type: "text", text: FINAL_MARKER },
 		]);
 
@@ -129,20 +146,48 @@ describe("EventController mixed assistant text/tool rendering", () => {
 		>);
 		await controller.handleEvent({
 			type: "message_update",
-			message: withToolCall,
-			assistantMessageEvent: { type: "toolcall_end", contentIndex: 1, toolCall, partial: withToolCall },
+			message: withFirstToolCall,
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall: toolCallA,
+				partial: withFirstToolCall,
+			},
+		} as Extract<AgentSessionEvent, { type: "message_update" }>);
+		await controller.handleEvent({
+			type: "message_update",
+			message: withSecondToolCall,
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 3,
+				toolCall: toolCallB,
+				partial: withSecondToolCall,
+			},
 		} as Extract<AgentSessionEvent, { type: "message_update" }>);
 		await controller.handleEvent({
 			type: "tool_execution_start",
-			toolCallId: TOOL_CALL_ID,
-			toolName: "contract_probe",
-			args: { value: 1 },
+			toolCallId: TOOL_CALL_A_ID,
+			toolName: "contract_probe_a",
+			args: { value: "a" },
 		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
 		await controller.handleEvent({
 			type: "tool_execution_end",
-			toolCallId: TOOL_CALL_ID,
-			toolName: "contract_probe",
-			result: { content: [{ type: "text", text: TOOL_RESULT_MARKER }] },
+			toolCallId: TOOL_CALL_A_ID,
+			toolName: "contract_probe_a",
+			result: { content: [{ type: "text", text: TOOL_RESULT_A_MARKER }] },
+			isError: false,
+		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
+		await controller.handleEvent({
+			type: "tool_execution_start",
+			toolCallId: TOOL_CALL_B_ID,
+			toolName: "contract_probe_b",
+			args: { value: "b" },
+		} as Extract<AgentSessionEvent, { type: "tool_execution_start" }>);
+		await controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: TOOL_CALL_B_ID,
+			toolName: "contract_probe_b",
+			result: { content: [{ type: "text", text: TOOL_RESULT_B_MARKER }] },
 			isError: false,
 		} as Extract<AgentSessionEvent, { type: "tool_execution_end" }>);
 		await controller.handleEvent({ type: "message_end", message: completed } as Extract<
@@ -152,10 +197,14 @@ describe("EventController mixed assistant text/tool rendering", () => {
 
 		const lines = chatContainer.render(120).map(line => Bun.stripANSI(line));
 		const introLine = lineContaining(lines, INTRO_MARKER);
-		const toolResultLine = lineContaining(lines, TOOL_RESULT_MARKER);
+		const toolResultALine = lineContaining(lines, TOOL_RESULT_A_MARKER);
+		const middleLine = lineContaining(lines, MIDDLE_MARKER);
+		const toolResultBLine = lineContaining(lines, TOOL_RESULT_B_MARKER);
 		const finalLine = lineContaining(lines, FINAL_MARKER);
 
-		expect(introLine).toBeLessThan(toolResultLine);
-		expect(finalLine).toBeGreaterThan(toolResultLine);
+		expect(introLine).toBeLessThan(toolResultALine);
+		expect(toolResultALine).toBeLessThan(middleLine);
+		expect(middleLine).toBeLessThan(toolResultBLine);
+		expect(toolResultBLine).toBeLessThan(finalLine);
 	});
 });


### PR DESCRIPTION
## Repro
A mixed Cursor-shaped assistant turn with content ordered `text -> toolCall -> text` rendered the trailing final answer in the leading assistant block above the tool output. I reproduced the ordering failure with `bun /tmp/omp-4871-repro.ts`, which printed `finalIndex` before `toolIndex` for the final answer and tool-result rows.

## Cause
`packages/coding-agent/src/modes/controllers/event-controller.ts`, `packages/coding-agent/src/modes/utils/ui-helpers.ts`, and `packages/coding-agent/src/modes/components/chat-transcript-builder.ts` passed the entire mixed assistant message into one `AssistantMessageComponent`. Tool calls render as separate transcript components below that assistant component, so any text block after a tool call was still painted above the tool execution/result timeline.

## Fix
- Added `splitAssistantMessageToolTimeline` in `packages/coding-agent/src/modes/utils/transcript-render-helpers.ts` to separate visible pre-tool assistant text from post-tool assistant text while suppressing duplicate turn-ending error decorations on split fragments.
- Applied the split to live streaming in `EventController`, including message start/update reveal targets and message-end post-tool answer insertion.
- Applied the same split to live transcript rebuilds in `UiHelpers` and file-backed transcript rendering in `ChatTranscriptBuilder` so resumed/transcript views match live TUI ordering.
- Added `packages/coding-agent/test/event-controller-mixed-assistant-render.test.ts` covering a single `text -> toolCall -> text` assistant message and asserting the final answer renders after the tool result.
- Updated `packages/coding-agent/CHANGELOG.md`.

## Verification
- `bun /tmp/omp-4871-repro.ts` reproduced the pre-fix ordering failure in the minimal transcript composition.
- `cd packages/coding-agent && bun run gen:tool-views && bun test test/event-controller-mixed-assistant-render.test.ts` passed: 1 test, 2 assertions.
- `cd packages/coding-agent && bun check` passed.
- `gh_push_branch` pre-publish gate completed and pushed the branch. Fixes #4871