### PR TITLE
fix(tui): sanitize subagent progress output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed sub-agent progress rendering leaking raw terminal control bytes into the parent TUI. ([#5159](https://github.com/can1357/oh-my-pi/issues/5159))
+
 ## [16.4.3] - 2026-07-11
 
 ### Added

--- a/packages/coding-agent/src/task/render.test.ts
+++ b/packages/coding-agent/src/task/render.test.ts
@@ -184,6 +184,17 @@ describe("task live progress rendering", () => {
 		expect(collapsedText).not.toContain("line 1");
 		expect(collapsedText).not.toContain("raw output:");
 	});
+	it("sanitizes control sequences from expanded subagent recent output", () => {
+		setViewportRows(40);
+		const progress = makeProgress(["safe after \x1b[2Kclear", "raw\rprompt"]);
+
+		const text = renderProgressText(progress, true, uiTheme);
+
+		expect(text).toContain("safe after clear");
+		expect(text).toContain("rawprompt");
+		expect(text).not.toContain("\x1b[2K");
+		expect(text).not.toContain("\r");
+	});
 
 	it("caps collapsed nested task progress at four rows plus an elision line", () => {
 		setViewportRows(40);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Container, Markdown, Text } from "@oh-my-pi/pi-tui";
-import { formatNumber } from "@oh-my-pi/pi-utils";
+import { formatNumber, sanitizeText } from "@oh-my-pi/pi-utils";
 import { settings } from "../config/settings";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { formatContextUsage } from "../modes/components/status-line/context-thresholds";
@@ -249,11 +249,11 @@ function getRenderYieldLabels(type: RenderYieldItem["type"]): string[] {
 function formatYieldPreview(item: RenderYieldItem): string {
 	if (item.useLastTurn === true && item.data === undefined) return "last assistant turn";
 	if (item.data === undefined) return "last assistant turn";
-	if (typeof item.data === "string") return previewLine(replaceTabs(item.data), 70);
+	if (typeof item.data === "string") return previewLine(replaceTabs(sanitizeText(item.data)), 70);
 	try {
-		return previewLine(replaceTabs(JSON.stringify(item.data) ?? "null"), 70);
+		return previewLine(replaceTabs(sanitizeText(JSON.stringify(item.data) ?? "null")), 70);
 	} catch {
-		return previewLine(replaceTabs(String(item.data)), 70);
+		return previewLine(replaceTabs(sanitizeText(String(item.data))), 70);
 	}
 }
 
@@ -281,7 +281,7 @@ function renderTypedYieldSections(value: unknown, continuePrefix: string, expand
 function formatJsonScalar(value: unknown, _theme: Theme): string {
 	if (value === null) return "null";
 	if (typeof value === "string") {
-		const trimmed = truncateToWidth(value, 70);
+		const trimmed = truncateToWidth(sanitizeText(value), 70);
 		return `"${trimmed}"`;
 	}
 	if (typeof value === "number" || typeof value === "boolean") return String(value);
@@ -419,7 +419,7 @@ function renderJsonTreeLines(
 		}
 
 		const label = key ? theme.fg("muted", key) : theme.fg("muted", "value");
-		pushLine(`${prefix}${iconScalar} ${label}: ${theme.fg("dim", String(val))}`);
+		pushLine(`${prefix}${iconScalar} ${label}: ${theme.fg("dim", sanitizeText(String(val)))}`);
 	};
 
 	const renderRoot = (val: unknown) => {
@@ -466,7 +466,7 @@ function stripRecentOutputNoticeLine(text: string): string {
 }
 
 function sanitizeRecentOutput(output: string): string {
-	let text = output.trimEnd();
+	let text = sanitizeText(output).trimEnd();
 	while (text) {
 		const withoutArtifactNotice = stripRawOutputArtifactNotice(text).text;
 		if (withoutArtifactNotice !== text) {
@@ -498,7 +498,8 @@ function renderOutputSection(
 	warning?: string,
 ): string[] {
 	const lines: string[] = [];
-	const trimmedOutput = output.trimEnd();
+	const sanitizedOutput = sanitizeText(output);
+	const trimmedOutput = sanitizedOutput.trimEnd();
 	if (!trimmedOutput && !warning) return lines;
 
 	if (warning) {
@@ -506,7 +507,7 @@ function renderOutputSection(
 		lines.push(
 			`${continuePrefix}  ${theme.fg("warning", theme.status.warning)} ${theme.fg(
 				"dim",
-				truncateToWidth(warning, 80),
+				truncateToWidth(sanitizeText(warning), 80),
 			)}`,
 		);
 
@@ -538,7 +539,7 @@ function renderOutputSection(
 			}
 		}
 
-		const outputLines = output.trimEnd().split("\n");
+		const outputLines = trimmedOutput.split("\n");
 		const previewCount = expanded ? maxExpanded : maxCollapsed;
 		for (const line of outputLines.slice(0, previewCount)) {
 			lines.push(`${continuePrefix}  ${theme.fg("dim", truncateToWidth(replaceTabs(line), 70))}`);
@@ -582,7 +583,7 @@ function renderOutputSection(
 
 	lines.push(`${continuePrefix}${theme.fg("dim", "Output")}`);
 
-	const outputLines = output.trimEnd().split("\n");
+	const outputLines = trimmedOutput.split("\n");
 	const previewCount = expanded ? maxExpanded : maxCollapsed;
 	for (const line of outputLines.slice(0, previewCount)) {
 		lines.push(`${continuePrefix}  ${theme.fg("dim", truncateToWidth(replaceTabs(line), 70))}`);
@@ -603,7 +604,7 @@ function renderTaskSection(
 	maxExpanded = 20,
 ): string[] {
 	const lines: string[] = [];
-	const trimmed = task.trim();
+	const trimmed = sanitizeText(task).trim();
 	if (!expanded || !trimmed) return lines;
 
 	lines.push(`${continuePrefix}${theme.fg("dim", "Task")}`);
@@ -859,7 +860,7 @@ function renderAgentProgress(
 
 	// Main status line: id: description [status] · stats · ⟨agent⟩
 	const trimmedDescription = progress.description?.trim();
-	const description = trimmedDescription ? previewLine(trimmedDescription, 64) : undefined;
+	const description = trimmedDescription ? previewLine(sanitizeText(trimmedDescription), 64) : undefined;
 	const displayId = formatTaskId(progress.id);
 	const titlePart = description ? `${theme.bold(displayId)}: ${description}` : displayId;
 	const indent = prefix ? `${prefix} ` : "";
@@ -900,7 +901,7 @@ function renderAgentProgress(
 	const showBadge = settings.get("task.showResolvedModelBadge");
 	if (progress.status === "running") {
 		if (!description) {
-			const taskPreview = previewLine(progress.assignment ?? progress.task, 40);
+			const taskPreview = previewLine(sanitizeText(progress.assignment ?? progress.task), 40);
 			statusLine += ` ${theme.fg("muted", taskPreview)}`;
 		}
 		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
@@ -918,7 +919,7 @@ function renderAgentProgress(
 			let toolLine = `${continuePrefix}${theme.tree.hook} ${theme.fg("muted", progress.currentTool)}`;
 			const toolDetail = progress.lastIntent ?? progress.currentToolArgs;
 			if (toolDetail) {
-				toolLine += `: ${theme.fg("dim", previewLine(toolDetail, 40))}`;
+				toolLine += `: ${theme.fg("dim", previewLine(sanitizeText(toolDetail), 40))}`;
 			}
 			if (progress.currentToolStartMs) {
 				const elapsed = Date.now() - progress.currentToolStartMs;
@@ -933,7 +934,7 @@ function renderAgentProgress(
 			let toolLine = `${continuePrefix}${theme.tree.hook} ${theme.fg("dim", recent.tool)}`;
 			const toolDetail = progress.lastIntent ?? recent.args;
 			if (toolDetail) {
-				toolLine += `: ${theme.fg("dim", previewLine(toolDetail, 40))}`;
+				toolLine += `: ${theme.fg("dim", previewLine(sanitizeText(toolDetail), 40))}`;
 			}
 			lines.push(toolLine);
 		}
@@ -947,12 +948,12 @@ function renderAgentProgress(
 		const waitLabel = remainingMs > 0 ? `in ${formatDuration(remainingMs)}` : "now";
 		const summary =
 			`retrying ${progress.retryState.attempt}/${progress.retryState.maxAttempts} ${waitLabel}: ` +
-			previewLine(progress.retryState.errorMessage, 60);
+			previewLine(sanitizeText(progress.retryState.errorMessage), 60);
 		lines.push(`${continuePrefix}${theme.tree.hook} ${theme.fg("warning", summary)}`);
 	} else if (progress.retryFailure && progress.status !== "running") {
 		const summary = `auto-retry gave up after ${progress.retryFailure.attempt} attempt${
 			progress.retryFailure.attempt === 1 ? "" : "s"
-		}: ${previewLine(progress.retryFailure.errorMessage, 80)}`;
+		}: ${previewLine(sanitizeText(progress.retryFailure.errorMessage), 80)}`;
 		lines.push(`${continuePrefix}${theme.tree.hook} ${theme.fg("error", summary)}`);
 	}
 
@@ -1346,7 +1347,7 @@ function renderAgentResult(
 		lines.push(
 			`${continuePrefix}${theme.fg("warning", theme.status.warning)} ${theme.fg(
 				"dim",
-				truncateToWidth(missingCompleteWarning, 80),
+				truncateToWidth(sanitizeText(missingCompleteWarning), 80),
 			)}`,
 		);
 	}
@@ -1370,7 +1371,9 @@ function renderAgentResult(
 
 	// Error message
 	if (result.error && (!success || mergeFailed) && (!aborted || result.error !== result.abortReason)) {
-		lines.push(`${continuePrefix}${theme.fg(mergeFailed ? "warning" : "error", previewLine(result.error, 70))}`);
+		lines.push(
+			`${continuePrefix}${theme.fg(mergeFailed ? "warning" : "error", previewLine(sanitizeText(result.error), 70))}`,
+		);
 	}
 
 	return lines;


### PR DESCRIPTION
## Repro
Expanded task sub-agent progress could render child output containing terminal control bytes directly into the parent TUI frame. Reproduced with `bun test packages/coding-agent/src/task/render.test.ts` after adding `sanitizes control sequences from expanded subagent recent output`; before the fix the rendered frame still contained `\r` and `\x1b[2K`.

## Cause
`packages/coding-agent/src/task/render.ts` rendered sub-agent progress/output strings with `replaceTabs()` and width truncation, but did not run `sanitizeText()` on all task-renderer paths. CSI/carriage-return bytes that survived structured task progress could therefore be written by the TUI renderer as terminal controls instead of display text.

## Fix
- Sanitize task sub-agent output previews, fallback output sections, JSON scalar previews, task text, current/recent tool details, retry/error summaries, and yield previews before rendering.
- Added a focused task renderer regression that injects `\r` and CSI clear-line bytes into sub-agent recent output and asserts only sanitized text reaches the rendered frame.
- Added the coding-agent changelog entry for the TUI containment fix.

## Verification
`bun test packages/coding-agent/src/task/render.test.ts` passes: 10 tests, 44 assertions. `bun run fix` completed with no TypeScript formatting changes and Rust checks passing. Attempted `bun test packages/coding-agent/src/task/render.test.ts packages/coding-agent/test/utils/changelog.test.ts`; task render tests passed, but the unrelated PTY changelog smoke expected the harness timeout exit code `124` and received `0` in this environment. Fixes #5159