### PR TITLE
docs(coding-agent): correct context promotion target docs

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -513,12 +513,11 @@ When a turn fails with a context overflow error (e.g. `context_length_exceeded`)
 
 ### Target selection
 
-Selection is model-driven, not role-driven:
+Selection is explicit and model-driven:
 
 1. `currentModel.contextPromotionTarget` (if configured)
-2. smallest larger-context model on the same provider + API
 
-Candidates are ignored unless credentials resolve (`ModelRegistry.getApiKey(...)`).
+Only the configured target is considered; context promotion does not automatically choose a larger same-provider/API sibling. Configured targets are ignored unless credentials resolve (`ModelRegistry.getApiKey(...)`).
 
 ### OpenAI Codex websocket handoff
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -504,7 +504,7 @@ read:
 
 ```yaml
 contextPromotion:
-  enabled: true
+  enabled: false
 
 compaction:
   enabled: true
@@ -520,7 +520,7 @@ memory:
 
 | Key | Type | Default | Notes |
 |---|---|---|---|
-| `contextPromotion.enabled` | boolean | `true` | Promote relevant earlier context. |
+| `contextPromotion.enabled` | boolean | `false` | Promote to the active model's explicit `contextPromotionTarget` on context overflow. |
 | `compaction.enabled` | boolean | `true` | Automatic conversation compaction. |
 | `compaction.midTurnEnabled` | boolean | `true` | Check thresholds at safe mid-turn tool-loop boundaries before the next provider request. |
 | `compaction.strategy` | enum | `snapcompact` | `context-full`, `handoff`, `shake`, `snapcompact`, `off`. |

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed context promotion docs to match the explicit `contextPromotionTarget` runtime behavior and `contextPromotion.enabled` default. ([#5163](https://github.com/can1357/oh-my-pi/issues/5163))
+
 ## [16.4.3] - 2026-07-11
 
 ### Added


### PR DESCRIPTION
## Repro
`docs/models.md` advertised context promotion target selection as `currentModel.contextPromotionTarget` followed by automatic smallest larger-context same-provider/API sibling selection, while `docs/settings.md` listed `contextPromotion.enabled` as default `true`. Reading the runtime showed `AgentSession.#resolveContextPromotionTarget()` only accepts an explicit configured target, and `settings-schema.ts` defaults the setting to `false`.

## Cause
`docs/models.md` and `docs/settings.md` drifted from the explicit-target context promotion behavior in `packages/coding-agent/src/session/agent-session.ts` and the default in `packages/coding-agent/src/config/settings-schema.ts`; the runtime had already been limited to explicit `contextPromotionTarget` values.

## Fix
- Updated `docs/models.md` to state that context promotion only considers `currentModel.contextPromotionTarget` and does not auto-select a larger sibling.
- Updated `docs/settings.md` to show `contextPromotion.enabled: false` and describe explicit-target promotion.
- Added an Unreleased `packages/coding-agent/CHANGELOG.md` entry for the docs correction.

## Verification
`bun test packages/coding-agent/test/agent-session-context-promotion.test.ts` passed: 11 tests, 34 assertions. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #5163