### PR TITLE
fix(tui): accept stale mid-prompt skill completions

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed mid-prompt `/skill:` autocomplete Tab acceptance when typed characters outrun the debounced popup refresh ([#4809](https://github.com/can1357/oh-my-pi/issues/4809)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2877,10 +2877,11 @@ export class Editor implements Component, Focusable {
 	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
 	 * - Slash branch re-anchors leading slash popups only against the current
 	 *   leading slash token. It re-anchors a trailing mid-prompt slash token only
-	 *   for `skill:` selections, matching the provider branch that can preserve
-	 *   prompt prose while replacing the live token. Absolute-path completions
-	 *   (`/tmp/fo` via the no-command-match fall-through) share the slash prefix
-	 *   shape but must use the live-suffix path rule so the apply slice stays anchored.
+	 *   for `skill:` selections whose selected item still matches the live token,
+	 *   matching the provider branch that can preserve prompt prose while replacing
+	 *   the live token. Absolute-path completions (`/tmp/fo` via the
+	 *   no-command-match fall-through) share the slash prefix shape but must use
+	 *   the live-suffix path rule so the apply slice stays anchored.
 	 * - `@`-file branch re-anchors via `#extractAtPrefix`; safe when the current text
 	 *   still ends in a whitespace-anchored `@<token>`.
 	 * - Everything else is stale — accepting it would corrupt the buffer (issue #4295).
@@ -2903,7 +2904,19 @@ export class Editor implements Component, Focusable {
 				const currentTrailingStart = findTrailingSlashCommandStart(currentTextBeforeCursor);
 				if (currentTrailingStart !== null) {
 					const token = currentTextBeforeCursor.slice(currentTrailingStart);
-					if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
+					const query = token.slice(1).toLowerCase();
+					if (
+						!token.includes(" ") &&
+						!token.slice(1).includes("/") &&
+						(query.length === 0 ||
+							this.#slashCompletionTextMatchesQuery(query, selected.value) ||
+							this.#slashCompletionTextMatchesQuery(query, selected.label) ||
+							(selected.description
+								? this.#slashCompletionTextMatchesQuery(query, selected.description)
+								: false))
+					) {
+						return true;
+					}
 				}
 			}
 
@@ -2928,6 +2941,17 @@ export class Editor implements Component, Focusable {
 		const selected = this.#autocompleteList?.getSelectedItem();
 		if (!selected) return false;
 		return selected.value.startsWith("/") || selected.value.startsWith('"');
+	}
+
+	#slashCompletionTextMatchesQuery(query: string, text: string): boolean {
+		const target = text.toLowerCase();
+		if (target === query || target.startsWith(query) || target.includes(query)) return true;
+
+		let queryIndex = 0;
+		for (let targetIndex = 0; targetIndex < target.length && queryIndex < query.length; targetIndex += 1) {
+			if (query[queryIndex] === target[targetIndex]) queryIndex += 1;
+		}
+		return queryIndex === query.length;
 	}
 
 	#isSlashCommandNameAutocompleteSelection(): boolean {

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2876,9 +2876,9 @@ export class Editor implements Component, Focusable {
 	 * - Path branch is safe when the prefix is still a live suffix of the text; the
 	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
 	 * - Slash branch re-anchors when both the prefix and the current text carry a
-	 *   leading slash command and the current slash token is clean (no whitespace or
-	 *   inner slash), matching `applyCompletion`'s slash-branch guard. It only
-	 *   engages for command-shaped selections: absolute-path completions (`/tmp/fo`
+	 *   leading or mid-prompt slash command and the current slash token is clean
+	 *   (no whitespace or inner slash), matching `applyCompletion`'s slash guards.
+	 *   It only engages for command-shaped selections: absolute-path completions (`/tmp/fo`
 	 *   via the no-command-match fall-through) share the leading-slash prefix shape
 	 *   but must use the live-suffix path rule so the apply slice stays anchored.
 	 * - `@`-file branch re-anchors via `#extractAtPrefix`; safe when the current text
@@ -2888,10 +2888,15 @@ export class Editor implements Component, Focusable {
 	#autocompletePrefixMatchesCursorText(currentTextBeforeCursor: string): boolean {
 		if (currentTextBeforeCursor === this.#autocompletePrefix) return true;
 
-		if (findLeadingSlashCommandStart(this.#autocompletePrefix) !== null && !this.#selectedCompletionIsPath()) {
-			const currentLeadingStart = findLeadingSlashCommandStart(currentTextBeforeCursor);
-			if (currentLeadingStart !== null) {
-				const token = currentTextBeforeCursor.slice(currentLeadingStart);
+		const prefixHasSlashCommand =
+			findLeadingSlashCommandStart(this.#autocompletePrefix) !== null ||
+			findTrailingSlashCommandStart(this.#autocompletePrefix) !== null;
+		if (prefixHasSlashCommand && !this.#selectedCompletionIsPath()) {
+			const currentSlashStart =
+				findLeadingSlashCommandStart(currentTextBeforeCursor) ??
+				findTrailingSlashCommandStart(currentTextBeforeCursor);
+			if (currentSlashStart !== null) {
+				const token = currentTextBeforeCursor.slice(currentSlashStart);
 				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
 			}
 			return false;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2875,12 +2875,12 @@ export class Editor implements Component, Focusable {
 	 * - Exact match → always safe.
 	 * - Path branch is safe when the prefix is still a live suffix of the text; the
 	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
-	 * - Slash branch re-anchors when both the prefix and the current text carry a
-	 *   leading or mid-prompt slash command and the current slash token is clean
-	 *   (no whitespace or inner slash), matching `applyCompletion`'s slash guards.
-	 *   It only engages for command-shaped selections: absolute-path completions (`/tmp/fo`
-	 *   via the no-command-match fall-through) share the leading-slash prefix shape
-	 *   but must use the live-suffix path rule so the apply slice stays anchored.
+	 * - Slash branch re-anchors leading slash popups only against the current
+	 *   leading slash token. It re-anchors a trailing mid-prompt slash token only
+	 *   for `skill:` selections, matching the provider branch that can preserve
+	 *   prompt prose while replacing the live token. Absolute-path completions
+	 *   (`/tmp/fo` via the no-command-match fall-through) share the slash prefix
+	 *   shape but must use the live-suffix path rule so the apply slice stays anchored.
 	 * - `@`-file branch re-anchors via `#extractAtPrefix`; safe when the current text
 	 *   still ends in a whitespace-anchored `@<token>`.
 	 * - Everything else is stale — accepting it would corrupt the buffer (issue #4295).
@@ -2892,13 +2892,21 @@ export class Editor implements Component, Focusable {
 			findLeadingSlashCommandStart(this.#autocompletePrefix) !== null ||
 			findTrailingSlashCommandStart(this.#autocompletePrefix) !== null;
 		if (prefixHasSlashCommand && !this.#selectedCompletionIsPath()) {
-			const currentSlashStart =
-				findLeadingSlashCommandStart(currentTextBeforeCursor) ??
-				findTrailingSlashCommandStart(currentTextBeforeCursor);
-			if (currentSlashStart !== null) {
-				const token = currentTextBeforeCursor.slice(currentSlashStart);
+			const currentLeadingStart = findLeadingSlashCommandStart(currentTextBeforeCursor);
+			if (currentLeadingStart !== null) {
+				const token = currentTextBeforeCursor.slice(currentLeadingStart);
 				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
 			}
+
+			const selected = this.#autocompleteList?.getSelectedItem();
+			if (selected?.value.startsWith("skill:")) {
+				const currentTrailingStart = findTrailingSlashCommandStart(currentTextBeforeCursor);
+				if (currentTrailingStart !== null) {
+					const token = currentTextBeforeCursor.slice(currentTrailingStart);
+					if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
+				}
+			}
+
 			return false;
 		}
 

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -136,6 +136,27 @@ describe("Editor slash autocomplete acceptance", () => {
 		expect(editor.getText()).toBe("how do I /skill:semantic-compression ");
 	});
 
+	it("cancels a stale mid-prompt skill popup when the live token stops matching the selected skill", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "skill:alpha", description: "Alpha skill" }], "/tmp"),
+		);
+
+		editor.setText("ask ");
+		const opened = onceAutocompleteUpdate(editor);
+		editor.handleInput("/");
+		await opened;
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("t");
+		editor.handleInput("m");
+		editor.handleInput("p");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("ask /tmp");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
 	it("accepts an absolute path completion with Tab when the line has leading whitespace", async () => {
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-absolute-tab-"));
 		try {

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -94,6 +94,26 @@ describe("Editor slash autocomplete acceptance", () => {
 		expect(editor.getText()).toBe("/skills:fix-bug ");
 	});
 
+	it("cancels a stale leading slash popup that moved to a mid-prompt non-skill token", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch model" }], "/tmp"),
+		);
+
+		const opened = onceAutocompleteUpdate(editor);
+		editor.handleInput("/");
+		await opened;
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("\x01"); // Ctrl+A: cursor to line start
+		editor.handleInput("ask ");
+		editor.handleInput("\x06"); // Ctrl+F: cursor after the slash
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("ask /");
+		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
 	it("replaces mid-prompt skill characters typed after the rendered prefix with Tab", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -94,6 +94,28 @@ describe("Editor slash autocomplete acceptance", () => {
 		expect(editor.getText()).toBe("/skills:fix-bug ");
 	});
 
+	it("replaces mid-prompt skill characters typed after the rendered prefix with Tab", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider(
+				[{ name: "skill:semantic-compression", description: "Compress context" }],
+				"/tmp",
+			),
+		);
+
+		editor.setText("how do I ");
+		const opened = onceAutocompleteUpdate(editor);
+		editor.handleInput("/");
+		await opened;
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("s");
+		editor.handleInput("k");
+		editor.handleInput("\t");
+
+		expect(editor.getText()).toBe("how do I /skill:semantic-compression ");
+	});
+
 	it("accepts an absolute path completion with Tab when the line has leading whitespace", async () => {
 		const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "editor-absolute-tab-"));
 		try {


### PR DESCRIPTION
## Repro
A focused TUI regression test opens autocomplete after `how do I /`, types `sk`, then presses Tab before the debounced refresh updates the rendered prefix. Before the fix, `bun test packages/tui/test/skill-tab-race.repro.test.ts` failed because the editor still contained `how do I /sk` instead of inserting `/skill:semantic-compression `.

## Cause
`Editor.#autocompletePrefixMatchesCursorText` in `packages/tui/src/components/editor.ts` only allowed stale slash-command prefixes to re-anchor against leading slash commands. Mid-prompt `/skill:` lookups store the slash token as `#autocompletePrefix`, but their live token is found by `findTrailingSlashCommandStart`, so the accept-time check canceled the popup before `CombinedAutocompleteProvider.applyCompletion` could replace the live token.

## Fix
- Treat both leading and trailing slash-command prefixes as safe command-shaped autocomplete prefixes when the selected completion is not a path.
- Re-anchor Tab acceptance against the current leading or mid-prompt slash token before calling `applyCompletion`.
- Added a regression test in `packages/tui/test/editor-autocomplete-actions.test.ts` for typing `sk` after a mid-prompt `/` and accepting with Tab before debounce catches up.
- Added an Unreleased `packages/tui` changelog entry.

## Verification
`bun test packages/tui/test/editor-autocomplete-actions.test.ts` passed with 21 tests and 47 assertions. `gh_push_branch` completed the pre-publish gate and pushed `3e3ec265dd54`. Fixes #4809