### PR TITLE
fix(coding-agent): reject unknown continued session ids

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -67,6 +67,9 @@
 - Fixed native Windows binary compatibility on older Windows 10 CPUs by building the `omp-windows-x64.exe` release asset with a baseline x64 runtime instead of AVX2. (#5172)
 - Fixed `GenerateImage` rejecting OpenAI Codex-compatible proxy bearer keys when the token does not expose a `chatgpt-account-id`. (#5174)
 - Fixed context promotion documentation to accurately reflect the `contextPromotionTarget` runtime behavior and `contextPromotion.enabled` default. (#5163)
+### Fixed
+
+- Fixed `--continue <session-id>` falling back to an unrelated latest session when the requested session does not exist.
 
 ## [16.4.3] - 2026-07-11
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -634,6 +634,14 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 	return undefined;
 }
 
+const SESSION_ID_ARG_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function positionalContinueSessionId(parsed: Args): string | undefined {
+	if (!parsed.continue || parsed.resume || parsed.fork || parsed.messages.length !== 1) return undefined;
+	const message = parsed.messages[0]?.trim();
+	return message && SESSION_ID_ARG_RE.test(message) ? message : undefined;
+}
+
 /** Resolves CLI session flags into an existing, forked, in-memory, or cancelled session manager. */
 export async function createSessionManager(
 	parsed: Args,
@@ -663,6 +671,13 @@ export async function createSessionManager(
 	if (parsed.noSession) {
 		return SessionManager.inMemory();
 	}
+	const continueSessionArg = positionalContinueSessionId(parsed);
+	if (continueSessionArg) {
+		parsed.resume = continueSessionArg;
+		parsed.continue = false;
+		parsed.messages = [];
+	}
+
 	if (typeof parsed.resume === "string") {
 		const sessionArg = parsed.resume;
 		if (sessionArg.includes("/") || sessionArg.includes("\\") || sessionArg.endsWith(".jsonl")) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -637,7 +637,15 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 const SESSION_ID_ARG_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function normalizeContinueSessionArgs(parsed: Args): void {
-	if (!parsed.continue || parsed.resume || parsed.fork || parsed.messages.length !== 1) return;
+	if (
+		!parsed.continue ||
+		parsed.resume ||
+		parsed.fork ||
+		parsed.messages.length !== 1 ||
+		parsed.unrecognizedFlags.length !== 0
+	) {
+		return;
+	}
 	const message = parsed.messages[0]?.trim();
 	if (!message || !SESSION_ID_ARG_RE.test(message)) return;
 	parsed.resume = message;

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -636,10 +636,13 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 
 const SESSION_ID_ARG_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-function positionalContinueSessionId(parsed: Args): string | undefined {
-	if (!parsed.continue || parsed.resume || parsed.fork || parsed.messages.length !== 1) return undefined;
+export function normalizeContinueSessionArgs(parsed: Args): void {
+	if (!parsed.continue || parsed.resume || parsed.fork || parsed.messages.length !== 1) return;
 	const message = parsed.messages[0]?.trim();
-	return message && SESSION_ID_ARG_RE.test(message) ? message : undefined;
+	if (!message || !SESSION_ID_ARG_RE.test(message)) return;
+	parsed.resume = message;
+	parsed.continue = false;
+	parsed.messages = [];
 }
 
 /** Resolves CLI session flags into an existing, forked, in-memory, or cancelled session manager. */
@@ -671,12 +674,7 @@ export async function createSessionManager(
 	if (parsed.noSession) {
 		return SessionManager.inMemory();
 	}
-	const continueSessionArg = positionalContinueSessionId(parsed);
-	if (continueSessionArg) {
-		parsed.resume = continueSessionArg;
-		parsed.continue = false;
-		parsed.messages = [];
-	}
+	normalizeContinueSessionArgs(parsed);
 
 	if (typeof parsed.resume === "string") {
 		const sessionArg = parsed.resume;
@@ -1352,6 +1350,7 @@ export async function runRootCommand(
 			},
 		};
 		const initialArgs = applyExtensionFlags(extensionFlagSink, rawArgs) ?? parsedArgs;
+		normalizeContinueSessionArgs(initialArgs);
 		// Fail fast on stale/typo flags (e.g. `omp --list-models`) now that we
 		// know the real extension flag set. Without this check the unrecognized
 		// token gets silently consumed and any following positional leaks as the

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -636,21 +636,23 @@ async function getChangelogForDisplay(parsed: Args): Promise<string | undefined>
 
 const SESSION_ID_ARG_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export function normalizeContinueSessionArgs(parsed: Args): void {
-	if (
-		!parsed.continue ||
-		parsed.resume ||
-		parsed.fork ||
-		parsed.messages.length !== 1 ||
-		parsed.unrecognizedFlags.length !== 0
-	) {
-		return;
+export function normalizeContinueSessionArgs(parsed: Args, rawArgs?: readonly string[]): void {
+	if (!parsed.continue || parsed.resume || parsed.fork) return;
+
+	let message: string | undefined;
+	if (parsed.unrecognizedFlags.length === 0 && parsed.messages.length === 1) {
+		message = parsed.messages[0]?.trim();
+	} else if (rawArgs) {
+		const continueIndex = rawArgs.findIndex(arg => arg === "--continue" || arg === "-c");
+		message = rawArgs[continueIndex + 1]?.trim();
 	}
-	const message = parsed.messages[0]?.trim();
 	if (!message || !SESSION_ID_ARG_RE.test(message)) return;
+
+	const messageIndex = parsed.messages.indexOf(message);
+	if (messageIndex === -1) return;
 	parsed.resume = message;
 	parsed.continue = false;
-	parsed.messages = [];
+	parsed.messages.splice(messageIndex, 1);
 }
 
 /** Resolves CLI session flags into an existing, forked, in-memory, or cancelled session manager. */
@@ -1162,6 +1164,11 @@ export async function runRootCommand(
 			modelMatchPreferences,
 		);
 	}
+
+	// Resolve an explicit `--continue <id>` before extension flags are loaded.
+	// Reading the token immediately after `--continue` distinguishes the session
+	// id from UUID-shaped values owned by later extension flags.
+	normalizeContinueSessionArgs(parsedArgs, rawArgs);
 
 	// Create session manager based on CLI flags. SessionResolutionError signals a
 	// user-facing failure (unknown --resume/--fork id, non-interactive fork

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -1365,7 +1365,7 @@ export async function runRootCommand(
 			},
 		};
 		const initialArgs = applyExtensionFlags(extensionFlagSink, rawArgs) ?? parsedArgs;
-		normalizeContinueSessionArgs(initialArgs);
+		normalizeContinueSessionArgs(initialArgs, rawArgs);
 		// Fail fast on stale/typo flags (e.g. `omp --list-models`) now that we
 		// know the real extension flag set. Without this check the unrecognized
 		// token gets silently consumed and any following positional leaks as the

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -142,6 +142,18 @@ describe("extension flags vs initial message", () => {
 		expect(extensionArgs.messages).toEqual([]);
 	});
 
+	it("resolves a continued session id before a later extension flag is known", () => {
+		const sessionId = "019ea530-ffff-7000-8000-000000000000";
+		const rawArgs = ["--continue", sessionId, "--spawn-peer", "reviewer"];
+		const startupArgs = parseArgs(rawArgs);
+
+		normalizeContinueSessionArgs(startupArgs, rawArgs);
+
+		expect(startupArgs.continue).toBe(false);
+		expect(startupArgs.resume).toBe(sessionId);
+		expect(startupArgs.messages).toEqual(["reviewer"]);
+	});
+
 	it("documents the pre-fix leak: without the flag map the value becomes the first prompt", () => {
 		// This is exactly the startup parse: extensions have not loaded, so the
 		// flag map is absent. `--spawn-peer` is dropped (it starts with `-`) but

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -118,6 +118,30 @@ describe("extension flags vs initial message", () => {
 		expect(initialMessage).toBeUndefined();
 	});
 
+	it("does not consume a UUID-shaped extension flag value before extension-aware reparse", () => {
+		const sessionId = "019ea530-ffff-7000-8000-000000000000";
+		const rawArgs = ["--continue", "--spawn-peer", sessionId];
+		const startupArgs = parseArgs(rawArgs);
+
+		normalizeContinueSessionArgs(startupArgs);
+		expect(startupArgs.continue).toBe(true);
+		expect(startupArgs.resume).toBeUndefined();
+		expect(startupArgs.messages).toEqual([sessionId]);
+
+		const sink: ExtensionFlagSink = {
+			getFlags: () => extFlags,
+			setFlagValue: () => {},
+		};
+		const extensionArgs = applyExtensionFlags(sink, rawArgs);
+		expect(extensionArgs).not.toBeNull();
+		if (!extensionArgs) return;
+
+		normalizeContinueSessionArgs(extensionArgs);
+		expect(extensionArgs.continue).toBe(true);
+		expect(extensionArgs.resume).toBeUndefined();
+		expect(extensionArgs.messages).toEqual([]);
+	});
+
 	it("documents the pre-fix leak: without the flag map the value becomes the first prompt", () => {
 		// This is exactly the startup parse: extensions have not loaded, so the
 		// flag map is absent. `--spawn-peer` is dropped (it starts with `-`) but

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -4,6 +4,7 @@ import { applyExtensionFlags, type ExtensionFlagSink } from "@oh-my-pi/pi-coding
 import { buildInitialMessage } from "@oh-my-pi/pi-coding-agent/cli/initial-message";
 import { ExtensionRuntime, loadExtensionFromFactory } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { normalizeContinueSessionArgs } from "@oh-my-pi/pi-coding-agent/main";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 
 // Regression coverage for extension-registered flags leaking into the initial
@@ -96,6 +97,25 @@ describe("extension flags vs initial message", () => {
 		const { initialMessage } = buildInitialMessage({ parsed, stdinContent: "diff-context" });
 
 		expect(initialMessage).toBe("diff-context\nreview the diff");
+	});
+
+	it("keeps a continued session id out of the prompt after extension-aware reparse", () => {
+		const sessionId = "019ea530-ffff-7000-8000-000000000000";
+		const sink: ExtensionFlagSink = {
+			getFlags: () => extFlags,
+			setFlagValue: () => {},
+		};
+		const parsed = applyExtensionFlags(sink, ["--continue", sessionId]);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+
+		normalizeContinueSessionArgs(parsed);
+		const { initialMessage } = buildInitialMessage({ parsed });
+
+		expect(parsed.resume).toBe(sessionId);
+		expect(parsed.continue).toBe(false);
+		expect(parsed.messages).toEqual([]);
+		expect(initialMessage).toBeUndefined();
 	});
 
 	it("documents the pre-fix leak: without the flag map the value becomes the first prompt", () => {

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -118,6 +118,23 @@ describe("extension flags vs initial message", () => {
 		expect(initialMessage).toBeUndefined();
 	});
 
+	it("removes a continued session id while preserving a following prompt after extension reparse", () => {
+		const sessionId = "019ea530-ffff-7000-8000-000000000000";
+		const rawArgs = ["--continue", sessionId, "--spawn-peer", "reviewer", "do next"];
+		const sink: ExtensionFlagSink = {
+			getFlags: () => extFlags,
+			setFlagValue: () => {},
+		};
+		const parsed = applyExtensionFlags(sink, rawArgs);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+
+		normalizeContinueSessionArgs(parsed, rawArgs);
+
+		expect(parsed.resume).toBe(sessionId);
+		expect(parsed.messages).toEqual(["do next"]);
+	});
+
 	it("does not consume a UUID-shaped extension flag value before extension-aware reparse", () => {
 		const sessionId = "019ea530-ffff-7000-8000-000000000000";
 		const rawArgs = ["--continue", "--spawn-peer", sessionId];

--- a/packages/coding-agent/test/main-session-resolution-error.test.ts
+++ b/packages/coding-agent/test/main-session-resolution-error.test.ts
@@ -6,15 +6,31 @@
  * `[Uncaught Exception]`.
  */
 import { describe, expect, it, vi } from "bun:test";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { Args } from "@oh-my-pi/pi-coding-agent/cli/args";
 import type { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createSessionManager, SessionResolutionError, writeStartupNotice } from "@oh-my-pi/pi-coding-agent/main";
 import * as sessionListingModule from "@oh-my-pi/pi-coding-agent/session/session-listing";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 
-function buildResumeArgs(resume: string): Args {
+function buildResumeArgs(resume: string, sessionDir?: string): Args {
 	return {
 		resume,
+		sessionDir,
 		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+		unrecognizedFlags: [],
+	};
+}
+
+function buildContinueArgs(message: string, sessionDir?: string): Args {
+	return {
+		continue: true,
+		sessionDir,
+		messages: [message],
 		fileArgs: [],
 		unknownFlags: new Map(),
 		unrecognizedFlags: [],
@@ -104,6 +120,51 @@ describe("createSessionManager — missing session (#2084)", () => {
 			expect(caught).toBeInstanceOf(SessionResolutionError);
 		} finally {
 			vi.restoreAllMocks();
+		}
+	});
+
+	it("rejects --resume with unknown id instead of falling back to latest persisted session", async () => {
+		const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-resume-unknown-id-"));
+		const sessionDir = path.join(cwd, "sessions");
+		const missingId = "019ea530-ffff-7000-8000-000000000000";
+		try {
+			const latest = SessionManager.create(cwd, sessionDir);
+			latest.appendMessage({ role: "user", content: "newer persisted session", timestamp: Date.now() });
+			await latest.rewriteEntries();
+			const latestSessionId = latest.getSessionId();
+			expect(latestSessionId).not.toBe(missingId);
+
+			await expect(
+				createSessionManager(buildResumeArgs(missingId, sessionDir), cwd, stubSettings),
+			).rejects.toMatchObject({
+				name: "SessionResolutionError",
+				message: `Session "${missingId}" not found.`,
+				hint: expect.stringContaining("omp --resume"),
+			});
+		} finally {
+			await fsp.rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects --continue followed by an unknown session id instead of falling back to latest", async () => {
+		const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-continue-unknown-id-"));
+		const sessionDir = path.join(cwd, "sessions");
+		const missingId = "019ea530-ffff-7000-8000-000000000000";
+		try {
+			const latest = SessionManager.create(cwd, sessionDir);
+			latest.appendMessage({ role: "user", content: "latest should not be resumed", timestamp: Date.now() });
+			await latest.rewriteEntries();
+			expect(latest.getSessionId()).not.toBe(missingId);
+
+			await expect(
+				createSessionManager(buildContinueArgs(missingId, sessionDir), cwd, stubSettings),
+			).rejects.toMatchObject({
+				name: "SessionResolutionError",
+				message: `Session "${missingId}" not found.`,
+				hint: expect.stringContaining("omp --resume"),
+			});
+		} finally {
+			await fsp.rm(cwd, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
## Repro
Running `omp --continue <uuid>` with a session id that does not exist can leave `--continue` enabled while treating the UUID as the initial prompt. Session resolution then falls back to the latest persisted session, so the UUID prompt is appended to an unrelated session instead of reporting that the requested session is missing.

## Cause
The CLI supports `--continue` as a flag and parses the following positional token into `messages`. `createSessionManager()` resolves an explicit id only through `--resume`; the `--continue` path otherwise asks for the latest resumable session. Startup parses arguments before extension flags are known, then reparses them after loading extensions, so the session target and initial prompt must agree across both parses without consuming UUID-shaped extension values.

## Fix
- Recognize the UUID token immediately following `--continue`/`-c` as an explicit session target before session resolution.
- Leave UUID-shaped extension flag values untouched.
- Normalize the extension-aware parse from the same raw argv, removing the session id while preserving a following user prompt.
- Resolve the target through the existing `--resume` path so a missing id returns `SessionResolutionError` instead of selecting the latest session.
- Add regressions for missing targets, extension-aware reparse, UUID-shaped extension flag values, mixed extension flags, and following prompts.
- Record the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/main-session-resolution-error.test.ts packages/coding-agent/test/extension-flag-initial-message.test.ts` passed: 39 tests, 93 assertions. `bun check` passed in `packages/coding-agent`, including the root Biome check.