### PR TITLE
fix(session): recover interrupted session turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -67,6 +67,9 @@
 - Fixed native Windows binary compatibility on older Windows 10 CPUs by building the `omp-windows-x64.exe` release asset with a baseline x64 runtime instead of AVX2. (#5172)
 - Fixed `GenerateImage` rejecting OpenAI Codex-compatible proxy bearer keys when the token does not expose a `chatgpt-account-id`. (#5174)
 - Fixed context promotion documentation to accurately reflect the `contextPromotionTarget` runtime behavior and `contextPromotion.enabled` default. (#5163)
+### Fixed
+
+- Fixed resumed sessions retaining an unterminated turn after an abnormal process exit.
 
 ## [16.4.3] - 2026-07-11
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -112,6 +112,7 @@ import {
 import { AgentSession } from "./session/agent-session";
 import { discoverAuthStorage as discoverAuthStorageFromConfig } from "./session/auth-broker-config";
 import type { AuthStorage } from "./session/auth-storage";
+import { createInterruptedTurnAbortMessage } from "./session/exit-diagnostics";
 import {
 	type CustomMessage,
 	convertToLlm,
@@ -1267,11 +1268,19 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	}
 	const secretsEnabled = obfuscator?.hasSecrets() === true;
 
-	// Check if session has existing data to restore
+	// An abnormal process exit after a non-terminal message tail is durable
+	// evidence that the old process can no longer finish that turn. Preserve the
+	// partial transcript and append one terminal aborted assistant record before
+	// rebuilding runtime context. The helper is idempotent once that record exists.
+	let existingBranch = logger.time("getSessionBranch", () => sessionManager.getBranch());
+	const interruptedTurnAbort = createInterruptedTurnAbortMessage(existingBranch);
+	if (interruptedTurnAbort) {
+		sessionManager.appendMessage(interruptedTurnAbort);
+		existingBranch = logger.time("getRecoveredSessionBranch", () => sessionManager.getBranch());
+	}
 	const existingSession = logger.time("loadSessionContext", () =>
 		deobfuscateSessionContext(sessionManager.buildSessionContext(), obfuscator),
 	);
-	const existingBranch = logger.time("getSessionBranch", () => sessionManager.getBranch());
 	const hasExistingSession = existingBranch.length > 0;
 	const hasThinkingEntry = existingBranch.some(entry => entry.type === "thinking_level_change");
 	const hasServiceTierEntry = existingBranch.some(entry => entry.type === "service_tier_change");

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1278,7 +1278,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		sessionManager.appendMessage(interruptedTurnAbort);
 		existingBranch = logger.time("getRecoveredSessionBranch", () => sessionManager.getBranch());
 	}
-	const existingSession = logger.time("loadSessionContext", () =>
+	let existingSession = logger.time("loadSessionContext", () =>
 		deobfuscateSessionContext(sessionManager.buildSessionContext(), obfuscator),
 	);
 	const hasExistingSession = existingBranch.length > 0;
@@ -2167,6 +2167,24 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					autoThinking
 						? resolveProvisionalAutoLevel(refreshedModel)
 						: resolveThinkingLevelForModel(refreshedModel, effectiveThinkingLevel),
+				);
+			}
+		}
+
+		// A first-turn user tail has no assistant metadata to copy. Once startup
+		// has selected its final model, use that model to terminate the
+		// interrupted turn before the live agent consumes the restored context.
+		if (model) {
+			const selectedModelAbort = createInterruptedTurnAbortMessage(existingBranch, {
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+			});
+			if (selectedModelAbort) {
+				sessionManager.appendMessage(selectedModelAbort);
+				existingBranch = logger.time("getRecoveredUserTailBranch", () => sessionManager.getBranch());
+				existingSession = logger.time("loadRecoveredUserTailContext", () =>
+					deobfuscateSessionContext(sessionManager.buildSessionContext(), obfuscator),
 				);
 			}
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -344,6 +344,7 @@ import {
 import { findCompactMode } from "./compact-modes";
 import {
 	collectPendingToolCalls,
+	createInterruptedTurnAbortMessage,
 	SESSION_EXIT_CUSTOM_TYPE,
 	type SessionExitData,
 	summarizeToolArguments,
@@ -15050,7 +15051,7 @@ export class AgentSession {
 			this.#rekeyHindsightMemoryForCurrentSessionId();
 			this.#rekeyMnemopiMemoryForCurrentSessionId();
 
-			const sessionContext = this.buildDisplaySessionContext();
+			let sessionContext = this.buildDisplaySessionContext();
 			const didReloadConversationChange =
 				previousSessionContext !== undefined &&
 				this.#didSessionMessagesChange(previousSessionContext.messages, sessionContext.messages);
@@ -15105,6 +15106,20 @@ export class AgentSession {
 					} else {
 						this.agent.setModel(match);
 					}
+				}
+			}
+
+			const model = this.model;
+			if (model) {
+				const interruptedTurnAbort = createInterruptedTurnAbortMessage(this.sessionManager.getBranch(), {
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+				});
+				if (interruptedTurnAbort) {
+					this.sessionManager.appendMessage(interruptedTurnAbort);
+					sessionContext = this.buildDisplaySessionContext();
+					this.agent.replaceMessages(sessionContext.messages);
 				}
 			}
 

--- a/packages/coding-agent/src/session/exit-diagnostics.ts
+++ b/packages/coding-agent/src/session/exit-diagnostics.ts
@@ -118,6 +118,12 @@ export function createInterruptedTurnAbortMessage(
 		previousAssistant = entry.message;
 		break;
 	}
+	if (
+		tail.role === "toolResult" &&
+		(previousAssistant?.stopReason === "error" || previousAssistant?.stopReason === "aborted")
+	) {
+		return undefined;
+	}
 	const model = previousAssistant ?? fallbackModel;
 	if (!model) return undefined;
 

--- a/packages/coding-agent/src/session/exit-diagnostics.ts
+++ b/packages/coding-agent/src/session/exit-diagnostics.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import type { SessionEntry } from "./session-entries";
 
 export const TOOL_EXECUTION_START_CUSTOM_TYPE = "tool_execution_start";
@@ -56,6 +57,79 @@ interface ToolCallContent {
 function isObject(value: unknown): value is Record<string, unknown> {
 	if (typeof value !== "object") return false;
 	return value !== null;
+}
+
+function readSessionExit(entry: SessionEntry): SessionExitData | undefined {
+	if (entry.type !== "custom" || entry.customType !== SESSION_EXIT_CUSTOM_TYPE || !isObject(entry.data)) {
+		return undefined;
+	}
+	const { reason, kind, recordedAt } = entry.data;
+	if (
+		typeof reason !== "string" ||
+		(kind !== "normal" && kind !== "signal" && kind !== "fatal" && kind !== "process_exit") ||
+		typeof recordedAt !== "string"
+	) {
+		return undefined;
+	}
+	return { reason, kind, recordedAt };
+}
+
+/**
+ * createInterruptedTurnAbortMessage returns a terminal assistant record when
+ * the latest persisted process exit follows a non-terminal conversation tail.
+ */
+export function createInterruptedTurnAbortMessage(entries: readonly SessionEntry[]): AssistantMessage | undefined {
+	let exitIndex = -1;
+	let exit: SessionExitData | undefined;
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const candidate = readSessionExit(entries[index]!);
+		if (!candidate) continue;
+		exitIndex = index;
+		exit = candidate;
+		break;
+	}
+	if (!exit || exit.kind === "normal") return undefined;
+
+	let tailIndex = -1;
+	let tail: AgentMessage | undefined;
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index]!;
+		if (entry.type !== "message") continue;
+		tailIndex = index;
+		tail = entry.message;
+		break;
+	}
+	if (!tail || tailIndex > exitIndex) return undefined;
+	if (tail.role === "assistant" && tail.stopReason !== "toolUse") return undefined;
+
+	let previousAssistant: AssistantMessage | undefined;
+	for (let index = tailIndex; index >= 0; index--) {
+		const entry = entries[index]!;
+		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
+		previousAssistant = entry.message;
+		break;
+	}
+	if (!previousAssistant) return undefined;
+
+	const recordedAt = Date.parse(exit.recordedAt);
+	return {
+		role: "assistant",
+		content: [],
+		api: previousAssistant.api,
+		provider: previousAssistant.provider,
+		model: previousAssistant.model,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "aborted",
+		errorMessage: "Previous OMP process exited before completing the turn.",
+		timestamp: Number.isFinite(recordedAt) ? recordedAt : Date.now(),
+	};
 }
 
 function isToolCallContent(value: unknown): value is ToolCallContent {

--- a/packages/coding-agent/src/session/exit-diagnostics.ts
+++ b/packages/coding-agent/src/session/exit-diagnostics.ts
@@ -54,6 +54,12 @@ interface ToolCallContent {
 	arguments?: unknown;
 }
 
+export interface AssistantModelMetadata {
+	api: AssistantMessage["api"];
+	provider: string;
+	model: string;
+}
+
 function isObject(value: unknown): value is Record<string, unknown> {
 	if (typeof value !== "object") return false;
 	return value !== null;
@@ -78,7 +84,10 @@ function readSessionExit(entry: SessionEntry): SessionExitData | undefined {
  * createInterruptedTurnAbortMessage returns a terminal assistant record when
  * the latest persisted process exit follows a non-terminal conversation tail.
  */
-export function createInterruptedTurnAbortMessage(entries: readonly SessionEntry[]): AssistantMessage | undefined {
+export function createInterruptedTurnAbortMessage(
+	entries: readonly SessionEntry[],
+	fallbackModel?: AssistantModelMetadata,
+): AssistantMessage | undefined {
 	let exitIndex = -1;
 	let exit: SessionExitData | undefined;
 	for (let index = entries.length - 1; index >= 0; index--) {
@@ -100,7 +109,7 @@ export function createInterruptedTurnAbortMessage(entries: readonly SessionEntry
 		break;
 	}
 	if (!tail || tailIndex > exitIndex) return undefined;
-	if (tail.role === "assistant" && tail.stopReason !== "toolUse") return undefined;
+	if (tail.role === "assistant" && !tail.content.some(isToolCallContent)) return undefined;
 
 	let previousAssistant: AssistantMessage | undefined;
 	for (let index = tailIndex; index >= 0; index--) {
@@ -109,15 +118,16 @@ export function createInterruptedTurnAbortMessage(entries: readonly SessionEntry
 		previousAssistant = entry.message;
 		break;
 	}
-	if (!previousAssistant) return undefined;
+	const model = previousAssistant ?? fallbackModel;
+	if (!model) return undefined;
 
 	const recordedAt = Date.parse(exit.recordedAt);
 	return {
 		role: "assistant",
 		content: [],
-		api: previousAssistant.api,
-		provider: previousAssistant.provider,
-		model: previousAssistant.model,
+		api: model.api,
+		provider: model.provider,
+		model: model.model,
 		usage: {
 			input: 0,
 			output: 0,

--- a/packages/coding-agent/src/session/exit-diagnostics.ts
+++ b/packages/coding-agent/src/session/exit-diagnostics.ts
@@ -77,7 +77,12 @@ function readSessionExit(entry: SessionEntry): SessionExitData | undefined {
 	) {
 		return undefined;
 	}
-	return { reason, kind, recordedAt };
+	return {
+		reason,
+		kind,
+		recordedAt,
+		pendingToolCalls: entry.data.pendingToolCalls as PendingToolCallDiagnostic[] | undefined,
+	};
 }
 
 /**
@@ -97,7 +102,7 @@ export function createInterruptedTurnAbortMessage(
 		exit = candidate;
 		break;
 	}
-	if (!exit || exit.kind === "normal") return undefined;
+	if (!exit || (exit.kind === "normal" && !exit.pendingToolCalls?.length)) return undefined;
 
 	let tailIndex = -1;
 	let tail: AgentMessage | undefined;

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -483,6 +483,52 @@ describe("AgentSession model persistence", () => {
 		);
 	});
 
+	it("marks a first user-message process-exit tail aborted with the selected model", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const settings = Settings.isolated();
+		settings.setModelRole("default", modelValue(defaultModel));
+		const sessionManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "interrupted-user"));
+		sessionManager.appendModelChange(modelValue(defaultModel));
+		sessionManager.appendMessage({ role: "user", content: "inspect state", timestamp: Date.now() });
+		sessionManager.appendCustomEntry("session_exit", {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			authStorage: sharedAuthStorage,
+			modelRegistry: sharedModelRegistry,
+			sessionManager,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		session = result.session;
+		expect(result.session.model?.id).toBe(defaultModel.id);
+		expect(
+			result.session.sessionManager
+				.getBranch()
+				.find(entry => entry.type === "message" && entry.message.role === "assistant"),
+		).toMatchObject({
+			type: "message",
+			message: {
+				role: "assistant",
+				api: defaultModel.api,
+				provider: defaultModel.provider,
+				model: defaultModel.id,
+				stopReason: "aborted",
+			},
+		});
+	});
+
 	it("lists restorable temporary model before the default fallback", () => {
 		expect(
 			getRestorableSessionModels(

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { type Api, type AssistantMessage, Effort, type Model } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -423,6 +423,64 @@ describe("AgentSession model persistence", () => {
 
 		expect(result.session.model?.id).toBe(defaultModel.id);
 		expect(result.session.configuredThinkingLevel()).toBe(AUTO_THINKING);
+	});
+
+	it("marks an incomplete process-exit transcript aborted during SDK resume without dropping history", async () => {
+		const sessionManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "interrupted"));
+		const interruptedAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: "call_read", name: "read", arguments: { path: "state.txt" } }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		sessionManager.appendMessage({ role: "user", content: "inspect state", timestamp: Date.now() });
+		sessionManager.appendMessage(interruptedAssistant);
+		sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "call_read",
+			toolName: "read",
+			content: [{ type: "text", text: "preserved partial result" }],
+			isError: false,
+			timestamp: Date.now(),
+		});
+		sessionManager.appendCustomEntry("session_exit", {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+		await sessionManager.flush();
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected interrupted session file");
+
+		const result = await createStartupResumeSession(sessionFile);
+		const messages = result.session.sessionManager.buildSessionContext().messages;
+		expect(messages.at(-1)).toMatchObject({
+			role: "assistant",
+			content: [],
+			stopReason: "aborted",
+			errorMessage: "Previous OMP process exited before completing the turn.",
+		});
+		expect(
+			messages.some(
+				message =>
+					message.role === "toolResult" &&
+					message.content.some(part => part.type === "text" && part.text === "preserved partial result"),
+			),
+		).toBe(true);
+		expect(messages.filter(message => message.role === "assistant" && message.stopReason === "aborted")).toHaveLength(
+			1,
+		);
 	});
 
 	it("lists restorable temporary model before the default fallback", () => {

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -529,6 +529,53 @@ describe("AgentSession model persistence", () => {
 		});
 	});
 
+	it("marks an interrupted first turn aborted when switching sessions", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const created = await createSession({ initialModel: defaultModel, persist: true });
+		const targetFile = path.join(tempDir.path(), "switch-interrupted-user.jsonl");
+		const timestamp = "2026-07-11T02:20:08.800Z";
+		await Bun.write(
+			targetFile,
+			`${[
+				{ type: "session", version: 3, id: "switch-target", timestamp, cwd: tempDir.path() },
+				{
+					type: "model_change",
+					id: "model",
+					parentId: null,
+					timestamp,
+					model: modelValue(defaultModel),
+				},
+				{
+					type: "message",
+					id: "user",
+					parentId: "model",
+					timestamp,
+					message: { role: "user", content: "inspect state", timestamp: Date.parse(timestamp) },
+				},
+				{
+					type: "custom",
+					id: "exit",
+					parentId: "user",
+					timestamp,
+					customType: "session_exit",
+					data: { reason: "exit", kind: "process_exit", recordedAt: timestamp },
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+
+		await expect(created.session.switchSession(targetFile)).resolves.toBe(true);
+
+		expect(created.session.sessionManager.buildSessionContext().messages.at(-1)).toMatchObject({
+			role: "assistant",
+			api: defaultModel.api,
+			provider: defaultModel.provider,
+			model: defaultModel.id,
+			stopReason: "aborted",
+		});
+	});
+
 	it("lists restorable temporary model before the default fallback", () => {
 		expect(
 			getRestorableSessionModels(

--- a/packages/coding-agent/test/session-exit-diagnostics.test.ts
+++ b/packages/coding-agent/test/session-exit-diagnostics.test.ts
@@ -347,6 +347,27 @@ describe("session exit diagnostics", () => {
 		});
 	});
 
+	it("does not reconstruct a failed tool turn already closed by synthetic results", () => {
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		sessionManager.appendMessage({ ...pendingAssistant, stopReason: "error" });
+		sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "toolu_repro",
+			toolName: "bash",
+			content: [{ type: "text", text: "Tool execution stopped after model failure." }],
+			isError: true,
+			timestamp: Date.now(),
+		});
+		sessionManager.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+
+		expect(createInterruptedTurnAbortMessage(sessionManager.getBranch())).toBeUndefined();
+	});
+
 	it("reconstructs a first user-message tail with selected model metadata", () => {
 		const sessionManager = SessionManager.inMemory();
 		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });

--- a/packages/coding-agent/test/session-exit-diagnostics.test.ts
+++ b/packages/coding-agent/test/session-exit-diagnostics.test.ts
@@ -11,6 +11,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import {
 	collectPendingToolCalls,
+	createInterruptedTurnAbortMessage,
 	describePendingToolCalls,
 	SESSION_EXIT_CUSTOM_TYPE,
 	TOOL_EXECUTION_START_CUSTOM_TYPE,
@@ -266,5 +267,105 @@ describe("session exit diagnostics", () => {
 
 		expect(collectPendingToolCalls(sessionManager.getBranch())).toEqual([]);
 		expect(describePendingToolCalls(sessionManager.getBranch())).toBeUndefined();
+	});
+
+	it("reconstructs an abnormal process-exit tail as one terminal aborted assistant message", () => {
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		sessionManager.appendMessage(pendingAssistant);
+		sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "toolu_repro",
+			toolName: "bash",
+			content: [{ type: "text", text: "partial result stays in history" }],
+			isError: false,
+			timestamp: Date.now(),
+		});
+		sessionManager.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+
+		const recovered = createInterruptedTurnAbortMessage(sessionManager.getBranch());
+		expect(recovered).toMatchObject({
+			role: "assistant",
+			content: [],
+			api: pendingAssistant.api,
+			provider: pendingAssistant.provider,
+			model: pendingAssistant.model,
+			stopReason: "aborted",
+		});
+		expect(recovered?.errorMessage).toContain("process exited");
+
+		sessionManager.appendMessage(recovered!);
+		expect(createInterruptedTurnAbortMessage(sessionManager.getBranch())).toBeUndefined();
+		expect(
+			sessionManager
+				.buildSessionContext()
+				.messages.some(
+					message =>
+						message.role === "toolResult" &&
+						message.content.some(part => part.type === "text" && part.text === "partial result stays in history"),
+				),
+		).toBe(true);
+	});
+
+	it("reconstructs an interrupted assistant tool-call tail", () => {
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		sessionManager.appendMessage(pendingAssistant);
+		sessionManager.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+
+		expect(createInterruptedTurnAbortMessage(sessionManager.getBranch())).toMatchObject({
+			role: "assistant",
+			content: [],
+			api: pendingAssistant.api,
+			provider: pendingAssistant.provider,
+			model: pendingAssistant.model,
+			stopReason: "aborted",
+		});
+	});
+
+	it("does not reconstruct clean, completed, or superseded exits", () => {
+		const normalExit = SessionManager.inMemory();
+		normalExit.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		normalExit.appendMessage(pendingAssistant);
+		normalExit.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "dispose",
+			kind: "normal",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+
+		const completedTurn = SessionManager.inMemory();
+		completedTurn.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		completedTurn.appendMessage({
+			...pendingAssistant,
+			content: [{ type: "text", text: "done" }],
+			stopReason: "stop",
+		});
+		completedTurn.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+
+		const supersededExit = SessionManager.inMemory();
+		supersededExit.appendMessage({ role: "user", content: "first turn", timestamp: Date.now() });
+		supersededExit.appendMessage(pendingAssistant);
+		supersededExit.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+		supersededExit.appendMessage({ role: "user", content: "new turn", timestamp: Date.now() });
+
+		expect(createInterruptedTurnAbortMessage(normalExit.getBranch())).toBeUndefined();
+		expect(createInterruptedTurnAbortMessage(completedTurn.getBranch())).toBeUndefined();
+		expect(createInterruptedTurnAbortMessage(supersededExit.getBranch())).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/session-exit-diagnostics.test.ts
+++ b/packages/coding-agent/test/session-exit-diagnostics.test.ts
@@ -331,6 +331,46 @@ describe("session exit diagnostics", () => {
 		});
 	});
 
+	it("reconstructs tool-call content even when stopReason is stop", () => {
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		sessionManager.appendMessage({ ...pendingAssistant, stopReason: "stop" });
+		sessionManager.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+
+		expect(createInterruptedTurnAbortMessage(sessionManager.getBranch())).toMatchObject({
+			role: "assistant",
+			stopReason: "aborted",
+		});
+	});
+
+	it("reconstructs a first user-message tail with selected model metadata", () => {
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		sessionManager.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "exit",
+			kind: "process_exit",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+		});
+
+		expect(
+			createInterruptedTurnAbortMessage(sessionManager.getBranch(), {
+				api: pendingAssistant.api,
+				provider: pendingAssistant.provider,
+				model: pendingAssistant.model,
+			}),
+		).toMatchObject({
+			role: "assistant",
+			api: pendingAssistant.api,
+			provider: pendingAssistant.provider,
+			model: pendingAssistant.model,
+			stopReason: "aborted",
+		});
+	});
+
 	it("does not reconstruct clean, completed, or superseded exits", () => {
 		const normalExit = SessionManager.inMemory();
 		normalExit.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });

--- a/packages/coding-agent/test/session-exit-diagnostics.test.ts
+++ b/packages/coding-agent/test/session-exit-diagnostics.test.ts
@@ -311,6 +311,23 @@ describe("session exit diagnostics", () => {
 		).toBe(true);
 	});
 
+	it("reconstructs a normal exit that reports pending tool calls", () => {
+		const sessionManager = SessionManager.inMemory();
+		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });
+		sessionManager.appendMessage(pendingAssistant);
+		sessionManager.appendCustomEntry(SESSION_EXIT_CUSTOM_TYPE, {
+			reason: "manual exit",
+			kind: "normal",
+			recordedAt: "2026-07-11T02:20:08.800Z",
+			pendingToolCalls: [{ toolCallId: "toolu_repro", toolName: "bash" }],
+		});
+
+		expect(createInterruptedTurnAbortMessage(sessionManager.getBranch())).toMatchObject({
+			role: "assistant",
+			stopReason: "aborted",
+		});
+	});
+
 	it("reconstructs an interrupted assistant tool-call tail", () => {
 		const sessionManager = SessionManager.inMemory();
 		sessionManager.appendMessage({ role: "user", content: "inspect the file", timestamp: Date.now() });


### PR DESCRIPTION
## Repro
If an OMP process exits after persisting a user message or partial assistant tool call, the session exit diagnostic is durable but the transcript tail remains non-terminal. Resuming or switching to that session rebuilds model context from the unterminated turn, leaving the new process to continue from a state the old process can no longer complete.

## Cause
Session-exit diagnostics record process termination separately from ordinary model messages. Session startup and in-app switching restored the persisted branch without consistently interpreting an exit after a non-terminal tail, so no terminal assistant record closed the interrupted turn before context reconstruction.

## Fix
- Recognize a valid process-exit diagnostic at the persisted branch tail.
- Detect pending assistant tool calls from tool-call content, matching the existing pending-tool contract even when `stopReason` is `stop`.
- Recover normal shutdown records when they explicitly report pending tool calls while continuing to ignore clean normal exits.
- Append one synthetic aborted assistant message when the preceding transcript is non-terminal, preserving partial assistant content and tool calls.
- Recover first-turn user-only tails after startup or session switching selects the target model, using that model's API/provider/model metadata.
- Preserve failed or aborted tool turns that were already closed by synthetic tool results instead of appending a second abort.
- Keep recovery idempotent once a terminal record exists, and ignore invalid diagnostics, already-terminal tails, and exits without a preceding message.
- Rebuild resumed or switched session context after appending the recovery record.
- Add unit, startup-resume, and switch-session regressions and record the behavior in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/session-exit-diagnostics.test.ts packages/coding-agent/test/agent-session-model-persistence.test.ts` passed: 33 tests, 68 assertions. `bun check` passed in `packages/coding-agent`, including the root Biome check.