### PR TITLE
fix(tools): allow opaque Codex image keys

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `GenerateImage` rejecting OpenAI Codex-compatible proxy bearer keys when the token does not expose a `chatgpt-account-id`. ([#5174](https://github.com/can1357/oh-my-pi/issues/5174))
+
 ## [16.4.3] - 2026-07-11
 
 ### Added

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -831,11 +831,10 @@ function buildOpenAIImageHeaders(model: Model, apiKey: string, sessionId: string
 
 	if (model.api === "openai-codex-responses" || model.provider === "openai-codex") {
 		const accountId = getCodexAccountId(apiKey);
-		if (!accountId) {
-			throw new Error("Failed to extract accountId from OpenAI Codex token");
-		}
 		headers.delete("x-api-key");
-		headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
+		if (accountId) {
+			headers.set(OPENAI_HEADERS.ACCOUNT_ID, accountId);
+		}
 		headers.set(OPENAI_HEADERS.BETA, OPENAI_HEADER_VALUES.BETA_RESPONSES);
 		headers.set(OPENAI_HEADERS.ORIGINATOR, OPENAI_HEADER_VALUES.ORIGINATOR_CODEX);
 		headers.set("User-Agent", `pi/${packageJson.version} (${os.platform()} ${os.release()}; ${os.arch()})`);

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -133,6 +133,140 @@ describe("imageGenTool", () => {
 		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-webp"));
 	});
 
+	it("sends Codex hosted image requests with opaque proxy bearer keys", async () => {
+		let requestUrl: string | undefined;
+		let requestHeaders: Headers | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			requestUrl = input.toString();
+			requestHeaders = new Headers(init?.headers);
+			return new Response(
+				[
+					"event: response.output_item.done",
+					`data: ${JSON.stringify({
+						type: "response.output_item.done",
+						item: {
+							type: "image_generation_call",
+							result: Buffer.from("fake-codex-webp").toString("base64"),
+							status: "completed",
+						},
+					})}`,
+					"",
+					"event: response.completed",
+					`data: ${JSON.stringify({
+						type: "response.completed",
+						response: { output: [], status: "completed", error: null },
+					})}`,
+					"",
+				].join("\n"),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const model = {
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			id: "gpt-5.5-codex",
+			name: "GPT Codex",
+			baseUrl: "https://example-proxy.invalid/backend-api",
+		} as Model;
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "opaque-proxy-key",
+				getApiKeyForProvider: async () => undefined,
+				authStorage: { rotateSessionCredential: async () => false },
+				resolver: () => async () => "opaque-proxy-key",
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-codex-opaque", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe("https://example-proxy.invalid/backend-api/codex/responses");
+		expect(requestHeaders?.get("authorization")).toBe("Bearer opaque-proxy-key");
+		expect(requestHeaders?.has("chatgpt-account-id")).toBe(false);
+		expect(requestHeaders?.get("OpenAI-Beta")).toBe("responses=experimental");
+		expect(requestHeaders?.get("originator")).toBe("pi");
+		expect(result.details?.provider).toBe("openai-codex");
+		expect(result.details?.imageCount).toBe(1);
+	});
+
+	it("adds Codex account headers when the bearer token exposes an account id", async () => {
+		let requestHeaders: Headers | undefined;
+		const tokenPayload = Buffer.from(
+			JSON.stringify({
+				"https://api.openai.com/auth": { chatgpt_account_id: "acc_test" },
+			}),
+		).toString("base64");
+		const codexJwt = `header.${tokenPayload}.signature`;
+
+		const fetchMock: typeof fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			requestHeaders = new Headers(init?.headers);
+			return new Response(
+				[
+					"event: response.output_item.done",
+					`data: ${JSON.stringify({
+						type: "response.output_item.done",
+						item: {
+							type: "image_generation_call",
+							result: Buffer.from("fake-codex-jwt-webp").toString("base64"),
+							status: "completed",
+						},
+					})}`,
+					"",
+					"event: response.completed",
+					`data: ${JSON.stringify({
+						type: "response.completed",
+						response: { output: [], status: "completed", error: null },
+					})}`,
+					"",
+				].join("\n"),
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const model = {
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			id: "gpt-5.5-codex",
+			name: "GPT Codex",
+			baseUrl: "https://example-proxy.invalid/backend-api",
+		} as Model;
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => codexJwt,
+				getApiKeyForProvider: async () => undefined,
+				authStorage: { rotateSessionCredential: async () => false },
+				resolver: () => async () => codexJwt,
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-codex-jwt", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestHeaders?.get("authorization")).toBe(`Bearer ${codexJwt}`);
+		expect(requestHeaders?.get("chatgpt-account-id")).toBe("acc_test");
+		expect(result.details?.imageCount).toBe(1);
+	});
+
 	it("routes xAI image generation with xAI-only aspect ratios", async () => {
 		setPreferredImageProvider("xai");
 		let requestUrl: string | undefined;


### PR DESCRIPTION
## Repro
A focused `imageGenTool.execute` run with an `openai-codex-responses` model, custom `baseUrl`, and `opaque-proxy-key` throws `Failed to extract accountId from OpenAI Codex token` before the mocked `fetch` is called (`fetchCalled=false`).

## Cause
`packages/coding-agent/src/tools/image-gen.ts` rebuilt Codex image headers in `buildOpenAIImageHeaders()` and treated `getCodexAccountId(apiKey)` as mandatory, unlike the main Codex Responses provider path which only sends `chatgpt-account-id` when the token exposes one.

## Fix
- Changed `buildOpenAIImageHeaders()` to delete stale `x-api-key`, keep the bearer authorization, and set `chatgpt-account-id` only when `getCodexAccountId()` returns a value.
- Added `GenerateImage` regression coverage for opaque Codex-compatible proxy keys to prove the request reaches `fetch` without the account header.
- Added JWT-backed Codex coverage to prove real account IDs still emit `chatgpt-account-id`.
- Added the coding-agent changelog entry for #5174.

## Verification
`bun test packages/coding-agent/test/tools/image-gen.test.ts` passed: 6 tests, 30 assertions. `gh_push_branch` also pushed the branch after its pre-publish gate completed. Fixes #5174