### PR TITLE
fix(coding-agent): guard browser header generation in binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+
 ## [16.4.4] - 2026-07-11
 
 ### Changed

--- a/packages/coding-agent/src/web/search/providers/browser-headers.ts
+++ b/packages/coding-agent/src/web/search/providers/browser-headers.ts
@@ -1,22 +1,35 @@
 import { HeaderGenerator } from "header-generator";
 
-// Instantiate the singleton header generator.
-// This matches modern browsers from real-world query statistics
-// and randomizes between Chrome, Firefox, Safari, and Edge.
-const generator = new HeaderGenerator({
-	browserListQuery: "last 3 versions",
-	devices: ["desktop"],
-	operatingSystems: ["windows", "macos", "linux"],
-	locales: ["en-US", "en"],
-	httpVersion: "2",
-	strict: false,
-});
+// Lazily instantiate the singleton header generator. Bun single-file binaries do not
+// bundle header-generator's fs-loaded data_files, so construction may throw when the
+// original build-time node_modules path is absent.
+let generator: HeaderGenerator | undefined;
+let generatorUnavailable = false;
+
+function getHeaderGenerator(): HeaderGenerator | undefined {
+	if (generatorUnavailable) return undefined;
+	try {
+		generator ??= new HeaderGenerator({
+			browserListQuery: "last 3 versions",
+			devices: ["desktop"],
+			operatingSystems: ["windows", "macos", "linux"],
+			locales: ["en-US", "en"],
+			httpVersion: "2",
+			strict: false,
+		});
+		return generator;
+	} catch {
+		generatorUnavailable = true;
+		return undefined;
+	}
+}
 
 // A fallback desktop Mac Chrome navigation fingerprint matching
 // the previous static default setup for deterministic or non-randomized calls.
 const CHROME_FALLBACK_HEADERS: Record<string, string> = {
 	Accept:
 		"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+	"Accept-Encoding": "gzip, deflate, br, zstd",
 	"Accept-Language": "en-US,en;q=0.9",
 	"Cache-Control": "max-age=0",
 	Priority: "u=0, i",
@@ -81,10 +94,14 @@ export function buildBrowserNavigationHeaders(options?: { randomized?: boolean }
 		return { ...CHROME_FALLBACK_HEADERS };
 	}
 
+	const generator = getHeaderGenerator();
+	if (!generator) {
+		return { ...CHROME_FALLBACK_HEADERS };
+	}
+
 	try {
 		// Generate realistic, consistent headers with the Bayesian generator
-		const generated = generator.getHeaders();
-		return canonicalizeHeaderNames(generated);
+		return canonicalizeHeaderNames(generator.getHeaders());
 	} catch {
 		// Gracefully recover to the robust default profile on unexpected generator errors
 		return { ...CHROME_FALLBACK_HEADERS };

--- a/packages/coding-agent/test/tools/web-search-browser-headers.test.ts
+++ b/packages/coding-agent/test/tools/web-search-browser-headers.test.ts
@@ -1,10 +1,35 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildBrowserNavigationHeaders } from "@oh-my-pi/pi-coding-agent/web/search/providers/browser-headers";
 import { browserFetch } from "@oh-my-pi/pi-coding-agent/web/search/providers/browser-page";
 
 afterEach(() => {
 	vi.restoreAllMocks();
 });
+
+const CHROME_FALLBACK_HEADERS: Record<string, string> = {
+	Accept:
+		"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+	"Accept-Encoding": "gzip, deflate, br, zstd",
+	"Accept-Language": "en-US,en;q=0.9",
+	"Cache-Control": "max-age=0",
+	Priority: "u=0, i",
+	"Sec-Ch-Ua": '"Google Chrome";v="149", "Chromium";v="149", ";Not A Brand";v="99"',
+	"Sec-Ch-Ua-Mobile": "?0",
+	"Sec-Ch-Ua-Platform": '"macOS"',
+	"Sec-Fetch-Dest": "document",
+	"Sec-Fetch-Mode": "navigate",
+	"Sec-Fetch-Site": "none",
+	"Sec-Fetch-User": "?1",
+	"Upgrade-Insecure-Requests": "1",
+	"User-Agent":
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
+};
+
+const packageRoot = path.join(import.meta.dir, "../..");
+const headerGeneratorRoot = path.dirname(fileURLToPath(import.meta.resolve("header-generator")));
 
 describe("browser navigation headers", () => {
 	it("builds a randomized, internally consistent browser profile", () => {
@@ -47,6 +72,42 @@ describe("browser navigation headers", () => {
 		expect(headers["User-Agent"]).toContain("Macintosh; Intel Mac OS X 10_15_7");
 		expect(headers["Sec-Ch-Ua"]).toContain('v="149"');
 		expect(headers["Sec-Ch-Ua-Platform"]).toBe('"macOS"');
+	});
+
+	it("returns stable fallback headers when header-generator data files are unavailable", async () => {
+		const dataFilesDir = path.join(headerGeneratorRoot, "data_files");
+		const unavailableDataFilesDir = path.join(
+			headerGeneratorRoot,
+			`.data_files-unavailable-${process.pid}-${Date.now()}`,
+		);
+
+		await fs.rename(dataFilesDir, unavailableDataFilesDir);
+		try {
+			const script = [
+				'import { buildBrowserNavigationHeaders } from "@oh-my-pi/pi-coding-agent/web/search/providers/browser-headers";',
+				"const headers = buildBrowserNavigationHeaders();",
+				"process.stdout.write(JSON.stringify(headers));",
+			].join("\n");
+			const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
+				cwd: packageRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+
+			if (exitCode !== 0) {
+				throw new Error(`browser header import failed with exit ${exitCode}:\n${stderr}`);
+			}
+
+			expect(JSON.parse(stdout)).toEqual(CHROME_FALLBACK_HEADERS);
+		} finally {
+			await fs.rename(unavailableDataFilesDir, dataFilesDir);
+		}
 	});
 
 	it("uses ordinary fetch before considering the browser fallback", async () => {


### PR DESCRIPTION
## Repro
With `header-generator/data_files` unavailable, `bun .wt/repro-5178-header-data-missing.ts` reproduced the reported failure: importing `packages/coding-agent/src/web/search/providers/browser-headers.ts` constructed `HeaderGenerator` at module load and threw `ENOENT` for `headers-order.json`, matching the compiled binary’s build-time `node_modules/header-generator/data_files` path failure during extension loading.

## Cause
`packages/coding-agent/src/web/search/providers/browser-headers.ts` eagerly instantiated `HeaderGenerator` at module scope. The `header-generator` constructor reads JSON and ZIP files via `fs.readFileSync(`${__dirname}/data_files/...`)`, so Bun standalone binaries that do not have the build-time `node_modules/header-generator/data_files` path available failed during package/extension import before `buildBrowserNavigationHeaders()` could use its existing fallback profile.

## Fix
- Lazy-initialize the `HeaderGenerator` singleton inside `buildBrowserNavigationHeaders()` and cache the unavailable state after constructor failure.
- Return the bundled Chrome fallback header profile when `header-generator` cannot be constructed or when generated headers fail.
- Include `Accept-Encoding` in the fallback profile so it satisfies the same core navigation-header contract as randomized profiles.
- Add a regression test that temporarily hides `node_modules/header-generator/data_files`, runs a fresh Bun subprocess, and verifies fallback headers are returned instead of an import-time crash.
- Add an Unreleased changelog entry for the compiled Linux binary extension-loading regression.

## Verification
`bun test packages/coding-agent/test/tools/web-search-browser-headers.test.ts` passed: 4 pass, 0 fail, 11 expect() calls. `bun --cwd=packages/coding-agent run check` passed. `gh_push_branch` completed its pre-publish gate and pushed `farm/41fa4cf3/fix-extension-header-data` at `d7a71642c8e9`. Fixes #5178