### PR TITLE
test(coding-agent): use current task batch schema

### DIFF
--- a/packages/coding-agent/test/tools/task-async-fallback.test.ts
+++ b/packages/coding-agent/test/tools/task-async-fallback.test.ts
@@ -51,9 +51,8 @@ describe("task.async-fallback", () => {
 		const tool = await TaskTool.create(createSession({ "async.enabled": true }));
 
 		const result = await tool.execute("tool-1", {
-			agent: "task",
-			name: "One",
-			task: "Do the thing.",
+			context: "Shared test context.",
+			tasks: [{ agent: "task", name: "One", task: "Do the thing." }],
 		} as TaskParams);
 
 		const text = getFirstText(result);


### PR DESCRIPTION
## What

Update the task async-fallback regression input to the current `{ context, tasks[] }` batch shape.

## Why

`task.batch` is enabled by default, but this test still used the removed `id`, `description`, and `assignment` fields. Validation therefore returned `Missing tasks` before the test could exercise the synchronous fallback. This changes only the test input; runtime behavior is unchanged.

## Testing

- `bun test packages/coding-agent/test/tools/task-async-fallback.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing; not applicable)
