### PR TITLE
fix(auth): rotate all Codex OAuth siblings after quota exhaustion

### DIFF
--- a/packages/ai/src/auth-retry.ts
+++ b/packages/ai/src/auth-retry.ts
@@ -6,27 +6,23 @@ import { isUsageLimit } from "./error/flags";
 /**
  * Context passed to an {@link ApiKeyResolver} on each resolution attempt.
  *
- * The `error`/`lastChance` pair drives the central a/b/c retry policy shared by
- * the streaming ({@link streamSimple}) and non-streaming ({@link withAuth})
- * drivers:
- * - `error === undefined` → **initial resolve** (no force-refresh; cheap, may
- *   return a locally-cached not-yet-expired token).
- * - `error !== undefined && !lastChance` → **step (b): refresh the SAME
- *   account** (force a token re-mint / await an in-flight broker refresh).
- * - `error !== undefined && lastChance` → **step (c): switch account**
- *   (invalidate/usage-limit the current credential and rotate to a sibling).
+ * The `error`/`lastChance` pair drives shared authentication recovery:
+ * - `error === undefined` → initial resolve (no force-refresh).
+ * - `error !== undefined && !lastChance` → refresh the same credential.
+ * - `error !== undefined && lastChance` → rotate to a sibling credential.
  *
- * The resolver returns the bearer to send, or `undefined` to stop retrying and
- * surface the last error to the caller.
+ * Normal authentication errors follow the bounded a/b/c sequence. Usage-limit
+ * errors call the sibling step repeatedly until the resolver exhausts or
+ * repeats its credential pool.
  */
 export interface ApiKeyResolveContext {
-	/** True on the final retry step — the resolver should rotate to a sibling credential. */
+	/** True when resolving a sibling credential after an authentication failure. */
 	lastChance: boolean;
-	/** The auth error that triggered this re-resolution, or `undefined` on the initial resolve. */
+	/** The error that triggered re-resolution, or `undefined` on initial resolve. */
 	error: unknown;
 	/** Bearer used by the failed attempt, when the caller can expose it. */
 	previousKey?: string;
-	/** Caller cancel signal, threaded into any credential refresh / rotation work. */
+	/** Caller cancel signal, threaded into credential refresh and rotation. */
 	signal?: AbortSignal;
 }
 
@@ -77,10 +73,10 @@ export function seedApiKeyResolver(seed: string | undefined, resolver: ApiKeyRes
 export { isAuthRetryableError };
 
 /**
- * The ordered `lastChance` values for the retry steps after the initial
- * attempt fails: `false` → step (b) refresh-same, `true` → step (c) switch.
- * Shared by {@link withAuth} and the streaming retry driver so both run the
- * same policy.
+ * The ordered normal-auth retry steps after the initial attempt fails:
+ * `false` → refresh same credential, `true` → switch once to a sibling.
+ * Usage-limit recovery is intentionally separate because it walks every
+ * distinct available sibling.
  */
 export const AUTH_RETRY_STEPS: readonly boolean[] = [false, true];
 
@@ -100,19 +96,64 @@ export async function resolveRetryKey(
 	}
 }
 
+type UsageLimitRotationState<TCredential, TFailure> = {
+	credential: TCredential;
+	failure: TFailure;
+};
+
+type UsageLimitRotationAttempt<TFailure, TResult> =
+	| { type: "failure"; failure: TFailure }
+	| { type: "success"; value: TResult };
+
+type UsageLimitRotationResult<TCredential, TFailure, TResult> =
+	| { type: "exhausted"; state: UsageLimitRotationState<TCredential, TFailure> }
+	| { type: "non_usage"; state: UsageLimitRotationState<TCredential, TFailure> }
+	| { type: "success"; value: TResult };
+
 /**
- * Runs an auth-protected operation through the central a/b/c retry policy.
+ * Replays a quota-limited request with distinct sibling credentials.
  *
- * - A static string key (or any non-resolver) → a single `attempt` with no
- *   retry (identical to the legacy static-key path).
- * - A resolver → initial `attempt`, then on a retryable auth error up to two
- *   more attempts (refresh-same, then switch). A step is skipped when the
- *   resolver returns the same key it just tried or `undefined`; non-auth errors
- *   propagate immediately.
+ * Credential pools can be larger than the normal a/b/c retry ladder. Stop
+ * when selection is exhausted, cycles, or caller aborts.
+ */
+export async function rotateUsageLimitedSiblings<TCredential, TIdentity, TFailure, TResult>(
+	initial: UsageLimitRotationState<TCredential, TFailure>,
+	options: {
+		credentialIdentity: (credential: TCredential) => TIdentity;
+		failureError: (failure: TFailure) => unknown;
+		resolveSibling: (state: UsageLimitRotationState<TCredential, TFailure>) => Promise<TCredential | undefined>;
+		attempt: (credential: TCredential) => Promise<UsageLimitRotationAttempt<TFailure, TResult>>;
+		signal?: AbortSignal;
+	},
+): Promise<UsageLimitRotationResult<TCredential, TFailure, TResult>> {
+	let state = initial;
+	const attemptedCredentials = new Set<TIdentity>([options.credentialIdentity(state.credential)]);
+	while (true) {
+		options.signal?.throwIfAborted();
+		const sibling = await options.resolveSibling(state);
+		if (sibling === undefined) return { type: "exhausted", state };
+		const identity = options.credentialIdentity(sibling);
+		if (attemptedCredentials.has(identity)) return { type: "exhausted", state };
+		attemptedCredentials.add(identity);
+
+		options.signal?.throwIfAborted();
+		const outcome = await options.attempt(sibling);
+		if (outcome.type === "success") return outcome;
+		state = { credential: sibling, failure: outcome.failure };
+		if (!isUsageLimit(options.failureError(state.failure))) return { type: "non_usage", state };
+	}
+}
+
+/**
+ * Runs an auth-protected operation through shared credential recovery.
  *
- * Used by non-streaming consumers (image generation, web search, completion
- * helpers). The streaming driver in `stream.ts` implements the same policy with
- * its replay-safe buffering machinery.
+ * - A static string key (or any non-resolver) → one `attempt`, no retry.
+ * - A resolver → initial `attempt`; normal authentication errors use a bounded
+ *   refresh-same then switch-sibling ladder. Usage-limit errors skip refreshing
+ *   the exhausted credential and walk distinct siblings until selection ends.
+ *
+ * Used by non-streaming consumers. The streaming driver in `stream.ts` uses
+ * the same sibling-rotation primitive with replay-safe buffering.
  */
 export async function withAuth<T>(
 	key: ApiKey | undefined,
@@ -140,8 +181,32 @@ export async function withAuth<T>(
 		lastError = error;
 	}
 
-	for (let i = 0; i < AUTH_RETRY_STEPS.length; i++) {
-		const nextKey = await resolveRetryKey(resolver, AUTH_RETRY_STEPS[i]!, lastError, signal, lastKey);
+	if (isUsageLimit(lastError)) {
+		const rotation = await rotateUsageLimitedSiblings(
+			{ credential: lastKey, failure: lastError },
+			{
+				credentialIdentity: credential => credential,
+				failureError: failure => failure,
+				resolveSibling: state => resolveRetryKey(resolver, true, state.failure, signal, state.credential),
+				attempt: async credential => {
+					try {
+						return { type: "success", value: await attempt(credential) };
+					} catch (error) {
+						if (!isAuthError(error)) throw error;
+						return { type: "failure", failure: error };
+					}
+				},
+				signal,
+			},
+		);
+		if (rotation.type === "success") return rotation.value;
+		lastKey = rotation.state.credential;
+		lastError = rotation.state.failure;
+		if (rotation.type === "exhausted") throw lastError;
+	}
+
+	for (const lastChance of AUTH_RETRY_STEPS) {
+		const nextKey = await resolveRetryKey(resolver, lastChance, lastError, signal, lastKey);
 		if (nextKey === undefined || nextKey === lastKey) continue;
 		lastKey = nextKey;
 		try {
@@ -189,20 +254,12 @@ export interface WithOAuthAccessOptions {
 }
 
 /**
- * {@link withAuth} for OAuth-access consumers: runs an auth-protected
- * operation through the central a/b/c retry policy, handing the attempt the
- * full {@link OAuthAccess} (bearer + identity metadata: `accountId`,
- * `projectId`, `enterpriseUrl`) instead of bare API-key bytes.
+ * {@link withAuth} for consumers that require OAuth identity metadata.
  *
- * - initial → `getOAuthAccess` (or `opts.seed`).
- * - step (b) → `getOAuthAccess` with `forceRefresh: true` (re-mint the SAME
- *   account; picks up peer/broker rotations).
- * - step (c) → `rotateSessionCredential` then re-resolve (switch to a sibling).
- *
- * A step is skipped when it yields no access or the same `accessToken` that
- * just failed; non-auth errors propagate immediately. Use this instead of
- * hand-rolled `getOAuthAccess` + fetch flows so 401s and usage-limits rotate
- * credentials instead of failing the call.
+ * Normal authentication failures refresh the same credential once, then select
+ * a sibling. Usage-limit failures select each distinct available sibling until
+ * exhausted; `credentialId` provides stable sibling identity across token
+ * refreshes, with the bearer as a compatibility fallback.
  */
 export async function withOAuthAccess<T>(
 	storage: OAuthAccessSource,
@@ -223,8 +280,10 @@ export async function withOAuthAccess<T>(
 
 	const resolveStep = async (lastChance: boolean, error: unknown): Promise<OAuthAccess | undefined> => {
 		try {
-			if (!lastChance) return await storage.getOAuthAccess(provider, sessionId, { forceRefresh: true, signal });
-			await storage.rotateSessionCredential(provider, sessionId, { error, signal });
+			const rotateSibling = lastChance || isUsageLimit(error);
+			if (!rotateSibling) return await storage.getOAuthAccess(provider, sessionId, { forceRefresh: true, signal });
+			const rotated = await storage.rotateSessionCredential(provider, sessionId, { error, signal });
+			if (!rotated) return undefined;
 			return await storage.getOAuthAccess(provider, sessionId, { signal });
 		} catch {
 			return undefined;
@@ -237,6 +296,30 @@ export async function withOAuthAccess<T>(
 	} catch (error) {
 		if (!isAuthError(error)) throw error;
 		lastError = error;
+	}
+
+	if (isUsageLimit(lastError)) {
+		const rotation = await rotateUsageLimitedSiblings(
+			{ credential: lastAccess, failure: lastError },
+			{
+				credentialIdentity: credential => credential.credentialId ?? credential.accessToken,
+				failureError: failure => failure,
+				resolveSibling: state => resolveStep(true, state.failure),
+				attempt: async credential => {
+					try {
+						return { type: "success", value: await attempt(credential) };
+					} catch (error) {
+						if (!isAuthError(error)) throw error;
+						return { type: "failure", failure: error };
+					}
+				},
+				signal,
+			},
+		);
+		if (rotation.type === "success") return rotation.value;
+		lastAccess = rotation.state.credential;
+		lastError = rotation.state.failure;
+		if (rotation.type === "exhausted") throw lastError;
 	}
 
 	for (const lastChance of AUTH_RETRY_STEPS) {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -17,9 +17,10 @@ import { CATALOG_PROVIDERS, type ProviderCatalogEntry } from "@oh-my-pi/pi-catal
 import { CODEX_BASE_URL } from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, $pickenv, getConfigRootDir, isEnoent, logger, withExtraCaFetch } from "@oh-my-pi/pi-utils";
 import { getCustomApi } from "./api-registry";
-import { AUTH_RETRY_STEPS, isApiKeyResolver, resolveRetryKey } from "./auth-retry";
+import { AUTH_RETRY_STEPS, isApiKeyResolver, resolveRetryKey, rotateUsageLimitedSiblings } from "./auth-retry";
 import * as AIError from "./error";
 import { ProviderHttpError } from "./error";
+import { isUsageLimit } from "./error/flags";
 import { isUsageLimitOutcome } from "./error/rate-limit";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
@@ -1098,13 +1099,38 @@ export function streamSimple<TApi extends Api>(
 			}
 			let failure = await runAttempt(lastKey, true);
 			if (!failure) return;
-			// a/b/c policy: refresh the same account (lastChance=false), then
-			// switch to a sibling (lastChance=true). A step is skipped when the
-			// resolver yields the same key it just tried or `undefined`; the
-			// final step's attempt clears the capture flag so it emits directly.
+			// Usage limits cannot be fixed by refreshing the same bearer. Walk
+			// distinct siblings through the shared retry primitive; a fixed a/b/c
+			// ladder can strand a fourth or later account after earlier quota hits.
+			if (isUsageLimit(failure.error)) {
+				const rotation = await rotateUsageLimitedSiblings(
+					{ credential: lastKey, failure },
+					{
+						credentialIdentity: credential => credential,
+						failureError: failed => failed.error,
+						resolveSibling: state =>
+							resolveRetryKey(apiKeyResolver, true, state.failure.error, signal, state.credential),
+						attempt: async credential => {
+							const next = await runAttempt(credential, true);
+							return next === undefined
+								? { type: "success", value: undefined }
+								: { type: "failure", failure: next };
+						},
+						signal,
+					},
+				);
+				if (rotation.type === "success") return;
+				lastKey = rotation.state.credential;
+				failure = rotation.state.failure;
+				if (rotation.type === "exhausted") {
+					emitFailure(failure);
+					return;
+				}
+			}
+
+			// Non-quota authentication failures retain the a/b/c policy:
+			// refresh the same account, then switch once.
 			for (let step = 0; step < AUTH_RETRY_STEPS.length; step++) {
-				// Caller aborted between attempts: don't mint a fresh token or fire
-				// another doomed request — emit the captured failure instead.
 				if (signal?.aborted) break;
 				const nextKey = await resolveRetryKey(
 					apiKeyResolver,

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import type { ApiKeyResolveContext, OAuthAccess, OAuthAccessSource } from "@oh-my-pi/pi-ai";
-import { isApiKeyResolver, isAuthRetryableError, resolveApiKeyOnce, withAuth, withOAuthAccess } from "@oh-my-pi/pi-ai";
+import {
+	isApiKeyResolver,
+	isAuthRetryableError,
+	resolveApiKeyOnce,
+	rotateUsageLimitedSiblings,
+	withAuth,
+	withOAuthAccess,
+} from "@oh-my-pi/pi-ai";
 
 function authError(status = 401): Error & { status: number } {
 	return Object.assign(new Error(`${status} authentication_error`), { status });
@@ -71,6 +78,30 @@ describe("isAuthRetryableError", () => {
 	});
 });
 
+describe("rotateUsageLimitedSiblings", () => {
+	it("propagates an abort without resolving another credential", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		let resolveCalls = 0;
+		await expect(
+			rotateUsageLimitedSiblings(
+				{ credential: "initial", failure: usageLimitError() },
+				{
+					credentialIdentity: credential => credential,
+					failureError: failure => failure,
+					resolveSibling: async () => {
+						resolveCalls += 1;
+						return "sibling";
+					},
+					attempt: async () => ({ type: "success", value: "unexpected" }),
+					signal: controller.signal,
+				},
+			),
+		).rejects.toHaveProperty("name", "AbortError");
+		expect(resolveCalls).toBe(0);
+	});
+});
+
 describe("withAuth", () => {
 	it("runs a single attempt for a static string key (no retry)", async () => {
 		const keys: Array<string | undefined> = [];
@@ -131,6 +162,40 @@ describe("withAuth", () => {
 			{ lastChance: false, hasError: false },
 			{ lastChance: true, hasError: true },
 		]);
+	});
+
+	it("surfaces the final usage limit when no unseen sibling remains", async () => {
+		const keys: string[] = [];
+		const exhausted = usageLimitError();
+		await expect(
+			withAuth(
+				ctx => (ctx.error === undefined ? "k0" : "k0"),
+				async key => {
+					keys.push(key);
+					throw exhausted;
+				},
+			),
+		).rejects.toBe(exhausted);
+		expect(keys).toEqual(["k0"]);
+	});
+
+	it("falls back to the normal authentication policy after a sibling returns 401", async () => {
+		const keys: string[] = [];
+		const result = await withAuth(
+			ctx => {
+				if (ctx.error === undefined) return "quota-limited";
+				if (ctx.lastChance) return "sibling";
+				return "refreshed-sibling";
+			},
+			async key => {
+				keys.push(key);
+				if (key === "refreshed-sibling") return "success";
+				throw key === "quota-limited" ? usageLimitError() : authError();
+			},
+		);
+
+		expect(result).toBe("success");
+		expect(keys).toEqual(["quota-limited", "sibling", "refreshed-sibling"]);
 	});
 
 	it("stops retrying when the resolver returns undefined", async () => {
@@ -276,6 +341,66 @@ describe("withOAuthAccess", () => {
 			"rotate",
 			{ forceRefresh: undefined },
 		]);
+	});
+
+	it("walks later OAuth siblings after consecutive usage limits", async () => {
+		const accounts = [access("t0"), access("t1"), access("t2"), access("t3")];
+		let index = 0;
+		const calls: Array<{ forceRefresh: boolean | undefined } | "rotate"> = [];
+		const storage: OAuthAccessSource = {
+			async getOAuthAccess(_provider, _sessionId, options) {
+				calls.push({ forceRefresh: options?.forceRefresh });
+				return accounts[index];
+			},
+			async rotateSessionCredential() {
+				calls.push("rotate");
+				index += 1;
+				return accounts[index] !== undefined;
+			},
+		};
+		const attempts: string[] = [];
+		const result = await withOAuthAccess(storage, "prov", async current => {
+			attempts.push(current.accessToken);
+			if (current.accessToken === "t3") return "success";
+			throw usageLimitError();
+		});
+
+		expect(result).toBe("success");
+		expect(attempts).toEqual(["t0", "t1", "t2", "t3"]);
+		expect(calls).toEqual([
+			{ forceRefresh: undefined },
+			"rotate",
+			{ forceRefresh: undefined },
+			"rotate",
+			{ forceRefresh: undefined },
+			"rotate",
+			{ forceRefresh: undefined },
+		]);
+	});
+
+	it("does not retry a refreshed token when no OAuth sibling was selected", async () => {
+		const exhausted = usageLimitError();
+		const calls: string[] = [];
+		const storage: OAuthAccessSource = {
+			async getOAuthAccess() {
+				calls.push("resolve");
+				return access("fresh-token", { credentialId: 1 });
+			},
+			async rotateSessionCredential() {
+				calls.push("rotate");
+				return false;
+			},
+		};
+		const attempts: string[] = [];
+		await expect(
+			withOAuthAccess(storage, "prov", async current => {
+				attempts.push(current.accessToken);
+				throw exhausted;
+			}),
+		).rejects.toBe(exhausted);
+
+		expect(attempts).toEqual(["fresh-token"]);
+		expect(calls).toEqual(["resolve", "rotate"]);
 	});
 
 	it("propagates non-auth errors immediately and surfaces the last auth error when exhausted", async () => {

--- a/packages/ai/test/stream-auth-retry.test.ts
+++ b/packages/ai/test/stream-auth-retry.test.ts
@@ -410,6 +410,82 @@ describe("streamSimple resolver auth retry", () => {
 		}
 	});
 
+	it("walks later distinct credentials after consecutive usage-limit events", async () => {
+		const keys: unknown[] = [];
+		const accounts = ["credential-0", "credential-1", "credential-2", "credential-3"];
+		let siblingIndex = 0;
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				pushKey(keys, options);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					if (options?.apiKey === "credential-3") {
+						ok(stream);
+						return;
+					}
+					stream.push({ type: "start", partial: assistant() });
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: assistantError("You have hit your ChatGPT usage limit (pro plan). Try again later.", 429),
+					});
+				});
+				return stream;
+			},
+			SOURCE_ID,
+		);
+
+		const retryContexts: ApiKeyResolveContext[] = [];
+		const stream = streamSimple(model(), context, {
+			apiKey: async ctx => {
+				if (ctx.error === undefined) return accounts[0]!;
+				retryContexts.push(ctx);
+				siblingIndex += 1;
+				return accounts[siblingIndex];
+			},
+		});
+		for await (const _event of stream) {
+			// drain
+		}
+
+		expect((await stream.result()).content).toEqual([{ type: "text", text: "ok" }]);
+		expect(keys).toEqual(accounts);
+		expect(retryContexts.map(ctx => ctx.lastChance)).toEqual([true, true, true]);
+	});
+
+	it("surfaces the usage-limit event when rotation repeats a credential", async () => {
+		const keys: unknown[] = [];
+		registerCustomApi(
+			API,
+			(_model: Model<Api>, _context: Context, options?: SimpleStreamOptions) => {
+				pushKey(keys, options);
+				const stream = new AssistantMessageEventStream();
+				queueMicrotask(() => {
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: assistantError("You have hit your ChatGPT usage limit (pro plan). Try again later.", 429),
+					});
+				});
+				return stream;
+			},
+			SOURCE_ID,
+		);
+
+		const stream = streamSimple(model(), context, {
+			apiKey: async () => "credential-0",
+		});
+		for await (const _event of stream) {
+			// drain
+		}
+
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toMatch(/usage limit/i);
+		expect(keys).toEqual(["credential-0"]);
+	});
+
 	it("does not rotate or refresh on informative transient 429 bodies", async () => {
 		const transient429Bodies = [
 			"Cloud Code Assist API error (429): Too many requests",

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -59,12 +59,13 @@ export function createApiKeyResolver(
 			// sibling exists we switch immediately; the precise no-sibling backoff
 			// is owned by `markUsageLimitReached` (default + server usage-report
 			// reset) and the outer whole-turn retry layer.
-			await registry.authStorage.rotateSessionCredential(provider, sessionId, {
+			const rotated = await registry.authStorage.rotateSessionCredential(provider, sessionId, {
 				error,
 				modelId,
 				signal,
 				apiKey: previousKey,
 			});
+			if (!rotated) return undefined;
 			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
 		}
 		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });

--- a/packages/coding-agent/test/auth-storage-rotation.test.ts
+++ b/packages/coding-agent/test/auth-storage-rotation.test.ts
@@ -2,11 +2,14 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { UsageProvider } from "@oh-my-pi/pi-ai";
+import { type UsageProvider, withAuth } from "@oh-my-pi/pi-ai";
 import * as oauth from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { createApiKeyResolver } from "../src/config/api-key-resolver";
+
+const TEST_CREDENTIAL_TTL_MS = 60 * 60 * 1_000;
 
 describe("AuthStorage account rotation", () => {
 	let tempDir: string;
@@ -144,5 +147,40 @@ describe("AuthStorage account rotation", () => {
 		const result = await authStorage.markUsageLimitReached("openai-codex", sessionId, { apiKey: failedKey });
 		expect(result.switched).toBe(true);
 		expect(await authStorage.getApiKey("openai-codex", sessionId)).toBe(stickyKey);
+	});
+
+	test("resolver reaches a fourth Codex account after three quota blocks", async () => {
+		await authStorage.set(
+			"openai-codex",
+			["acct-1", "acct-2", "acct-3", "acct-4"].map(accountId => ({
+				type: "oauth" as const,
+				access: `access-${accountId}`,
+				refresh: `refresh-${accountId}`,
+				expires: Date.now() + TEST_CREDENTIAL_TTL_MS,
+				accountId,
+			})),
+		);
+
+		const sessionId = "four-account-quota-session";
+		const resolver = createApiKeyResolver(
+			{
+				getApiKeyForProvider: (provider, requestedSessionId, options) =>
+					authStorage.getApiKey(provider, requestedSessionId, options),
+				authStorage,
+			},
+			"openai-codex",
+			{ sessionId },
+		);
+		const quotaError = Object.assign(new Error("usage_limit_reached"), { status: 429 });
+		const attempted: string[] = [];
+		const result = await withAuth(resolver, async key => {
+			attempted.push(key);
+			if (attempted.length === 4) return "recovered";
+			throw quotaError;
+		});
+
+		expect(result).toBe("recovered");
+		expect(new Set(attempted).size).toBe(4);
+		expect(attempted).toHaveLength(4);
 	});
 });


### PR DESCRIPTION
## What

Walk every distinct OAuth credential after an account-level usage-limit response. Shared retry primitive now drives streaming, API-key, and OAuth-access paths. Resolver no longer reuses a refreshed bearer when no sibling was selected.

## Why

Fixes #4853. The existing a/b/c ladder could only rotate through two siblings; a four-account pool with first three quota-limited never reached its fourth available account.

## Testing

- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
- Focused runtime tests were prepared but not run after local native artifacts were removed at user request. CI should execute them.

---

- [x] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (internal retry bugfix; no user-facing release note added)