### PR TITLE
fix(plugins): skip invalid custom tool entries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Fixed
 
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed plugin custom tool loading to skip and report invalid feature entries instead of crashing startup when a plugin dependency tree leaves one feature unresolved. ([#5189](https://github.com/can1357/oh-my-pi/issues/5189))
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -21,6 +21,34 @@ import * as typebox from "../typebox";
 import { createNoOpUIContext, resolvePath, withExitGuard } from "../utils";
 import type { CustomToolAPI, CustomToolFactory, LoadedCustomTool, ToolLoadError } from "./types";
 
+interface LoadToolResult {
+	tools: LoadedCustomTool[];
+	errors: ToolLoadError[];
+}
+
+function isLoadableCustomTool(value: unknown): value is LoadedCustomTool["tool"] {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"name" in value &&
+		typeof value.name === "string" &&
+		value.name.length > 0 &&
+		"description" in value &&
+		typeof value.description === "string" &&
+		"parameters" in value &&
+		"execute" in value &&
+		typeof value.execute === "function"
+	);
+}
+
+function invalidToolError(path: string, index: number, source: ToolLoadError["source"]): ToolLoadError {
+	return {
+		path,
+		error: `Tool factory returned invalid tool at index ${index}: expected object with string name, string description, parameters, and execute function`,
+		source,
+	};
+}
+
 /**
  * Load a single tool module using native Bun import.
  */
@@ -29,18 +57,20 @@ async function loadTool(
 	cwd: string,
 	sharedApi: CustomToolAPI,
 	source?: { provider: string; providerName: string; level: "user" | "project" },
-): Promise<{ tools: LoadedCustomTool[] | null; error: ToolLoadError | null }> {
+): Promise<LoadToolResult> {
 	const resolvedPath = resolvePath(toolPath, cwd);
 
 	// Skip declarative tool files (.md, .json) - these are metadata only, not executable modules
 	if (resolvedPath.endsWith(".md") || resolvedPath.endsWith(".json")) {
 		return {
-			tools: null,
-			error: {
-				path: toolPath,
-				error: "Declarative tool files (.md, .json) cannot be loaded as executable modules",
-				source,
-			},
+			tools: [],
+			errors: [
+				{
+					path: toolPath,
+					error: "Declarative tool files (.md, .json) cannot be loaded as executable modules",
+					source,
+				},
+			],
 		};
 	}
 
@@ -49,23 +79,32 @@ async function loadTool(
 		const factory = (module.default ?? module) as CustomToolFactory;
 
 		if (typeof factory !== "function") {
-			return { tools: null, error: { path: toolPath, error: "Tool must export a default function", source } };
+			return { tools: [], errors: [{ path: toolPath, error: "Tool must export a default function", source }] };
 		}
 
-		const toolResult = await withExitGuard(async () => factory(sharedApi));
+		const toolResult: unknown = await withExitGuard(async () => factory(sharedApi));
 		const toolsArray = Array.isArray(toolResult) ? toolResult : [toolResult];
 
-		const loadedTools: LoadedCustomTool[] = toolsArray.map(tool => ({
-			path: toolPath,
-			resolvedPath,
-			tool,
-			source,
-		}));
+		const loadedTools: LoadedCustomTool[] = [];
+		const errors: ToolLoadError[] = [];
+		for (const [index, tool] of toolsArray.entries()) {
+			if (!isLoadableCustomTool(tool)) {
+				errors.push(invalidToolError(toolPath, index, source));
+				continue;
+			}
 
-		return { tools: loadedTools, error: null };
+			loadedTools.push({
+				path: toolPath,
+				resolvedPath,
+				tool,
+				source,
+			});
+		}
+
+		return { tools: loadedTools, errors };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		return { tools: null, error: { path: toolPath, error: `Failed to load tool: ${message}`, source } };
+		return { tools: [], errors: [{ path: toolPath, error: `Failed to load tool: ${message}`, source }] };
 	}
 }
 
@@ -129,28 +168,22 @@ export class CustomToolLoader {
 
 	async load(pathsWithSources: ToolPathWithSource[]): Promise<void> {
 		for (const { path: toolPath, source } of pathsWithSources) {
-			const { tools: loadedTools, error } = await loadTool(toolPath, this.#sharedApi.cwd, this.#sharedApi, source);
+			const { tools: loadedTools, errors } = await loadTool(toolPath, this.#sharedApi.cwd, this.#sharedApi, source);
+			this.errors.push(...errors);
 
-			if (error) {
-				this.errors.push(error);
-				continue;
-			}
-
-			if (loadedTools) {
-				for (const loadedTool of loadedTools) {
-					// Check for name conflicts
-					if (this.#seenNames.has(loadedTool.tool.name)) {
-						this.errors.push({
-							path: toolPath,
-							error: `Tool name "${loadedTool.tool.name}" conflicts with existing tool`,
-							source,
-						});
-						continue;
-					}
-
-					this.#seenNames.add(loadedTool.tool.name);
-					this.tools.push(loadedTool);
+			for (const loadedTool of loadedTools) {
+				// Check for name conflicts
+				if (this.#seenNames.has(loadedTool.tool.name)) {
+					this.errors.push({
+						path: toolPath,
+						error: `Tool name "${loadedTool.tool.name}" conflicts with existing tool`,
+						source,
+					});
+					continue;
 				}
+
+				this.#seenNames.add(loadedTool.tool.name);
+				this.tools.push(loadedTool);
 			}
 		}
 	}

--- a/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadCustomTools } from "../../src/extensibility/custom-tools/loader";
+import { loadCustomTools, type ToolPathWithSource } from "../../src/extensibility/custom-tools/loader";
 
 let tempRoot: string | undefined;
 
@@ -30,6 +30,39 @@ const VALID_TOOL_SOURCE = [
 	'\tname: "safe_custom_tool",',
 	'\tlabel: "Safe Custom Tool",',
 	'\tdescription: "Returns a fixed response",',
+	"\tparameters: api.zod.object({}),",
+	"\tasync execute() {",
+	'\t\treturn { content: [{ type: "text", text: "ok" }] };',
+	"\t},",
+	"});",
+].join("\n");
+
+const TEST_SOURCE: NonNullable<ToolPathWithSource["source"]> = {
+	provider: "plugin",
+	providerName: "Regression Plugin",
+	level: "user",
+};
+
+const ARRAY_WITH_NULL_SOURCE = ["export default () => [null];"].join("\n");
+
+const MIXED_ARRAY_SOURCE = [
+	"export default api => [",
+	"\t{",
+	'\t\tname: "mixed_valid_tool",',
+	'\t\tlabel: "Mixed Valid Tool",',
+	'\t\tdescription: "Returns a fixed response from a mixed tool factory result",',
+	"\t\tparameters: api.zod.object({}),",
+	"\t\tasync execute() {",
+	'\t\t\treturn { content: [{ type: "text", text: "ok" }] };',
+	"\t\t},",
+	"\t},",
+	"\tnull,",
+	"];",
+].join("\n");
+
+const MISSING_NAME_SOURCE = [
+	"export default api => ({",
+	'\tdescription: "Missing name but otherwise loadable shape",',
 	"\tparameters: api.zod.object({}),",
 	"\tasync execute() {",
 	'\t\treturn { content: [{ type: "text", text: "ok" }] };',
@@ -78,5 +111,65 @@ describe("custom tool loader", () => {
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0]?.path).toBe(factoryExitTool);
 		expect(result.errors[0]?.error).toContain("process.exit(3)");
+	});
+
+	it("reports a null array entry instead of throwing", async () => {
+		const nullArrayTool = await writeTool("null-array.js", ARRAY_WITH_NULL_SOURCE);
+
+		const result = await loadCustomTools([{ path: nullArrayTool, source: TEST_SOURCE }], requireTempRoot(), []);
+
+		expect(result.tools).toEqual([]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toMatchObject({
+			path: nullArrayTool,
+			source: TEST_SOURCE,
+		});
+		expect(result.errors[0]?.error.toLowerCase()).toContain("invalid");
+		expect(result.errors[0]?.error).toContain("index 0");
+	});
+
+	it("reports a tool entry missing a name instead of throwing", async () => {
+		const missingNameTool = await writeTool("missing-name.js", MISSING_NAME_SOURCE);
+
+		const loadResult = loadCustomTools([{ path: missingNameTool, source: TEST_SOURCE }], requireTempRoot(), []);
+		await expect(loadResult).resolves.toMatchObject({
+			tools: [],
+			errors: [
+				{
+					path: missingNameTool,
+					source: TEST_SOURCE,
+				},
+			],
+		});
+		const result = await loadResult;
+
+		expect(result.tools).toEqual([]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toMatchObject({
+			path: missingNameTool,
+			source: TEST_SOURCE,
+		});
+		expect(result.errors[0]?.error.toLowerCase()).toContain("invalid");
+		expect(result.errors[0]?.error).toContain("index 0");
+		expect(result.errors[0]?.error).toContain("string name");
+	});
+
+	it("keeps valid tools from a mixed array and reports the null entry", async () => {
+		const mixedArrayTool = await writeTool("mixed-array.js", MIXED_ARRAY_SOURCE);
+
+		const result = await loadCustomTools([{ path: mixedArrayTool, source: TEST_SOURCE }], requireTempRoot(), []);
+
+		expect(result.tools.map(tool => tool.tool.name)).toEqual(["mixed_valid_tool"]);
+		expect(result.tools[0]).toMatchObject({
+			path: mixedArrayTool,
+			source: TEST_SOURCE,
+		});
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toMatchObject({
+			path: mixedArrayTool,
+			source: TEST_SOURCE,
+		});
+		expect(result.errors[0]?.error.toLowerCase()).toContain("invalid");
+		expect(result.errors[0]?.error).toContain("index 1");
 	});
 });

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -389,8 +389,7 @@ function buildMidPromptSkillCompletions(commands: CommandEntry[], lowerPrefix: s
 		commands.filter(cmd => {
 			const name = getCommandName(cmd);
 			return (
-				name !== undefined &&
-				name.startsWith(SKILL_NAMESPACE) &&
+				name?.startsWith(SKILL_NAMESPACE) &&
 				midPromptSkillTokenMatches(lowerPrefix, name, getStaticCommandDescription(cmd))
 			);
 		}),


### PR DESCRIPTION
## Repro
With a plugin custom tool factory returning a failed feature placeholder (`[null]`), `bun .wt/repro-null-tool.ts` reproduced the startup failure path: `loadCustomTools()` dereferenced `loadedTool.tool.name` and exited with `TypeError: null is not an object`.

## Cause
`packages/coding-agent/src/extensibility/custom-tools/loader.ts` trusted every factory array entry as a `LoadedCustomTool`; when one plugin feature failed to construct and surfaced as `null`, `CustomToolLoader.load()` still reached the duplicate-name check and read `.tool.name` without validating the entry.

## Fix
- Validate each custom tool factory result before registering it.
- Convert invalid entries into `ToolLoadError` records that keep the original path and source metadata.
- Continue loading valid entries from the same factory result instead of dropping the whole plugin module.
- Added focused regression coverage for all-null and mixed valid/null factory arrays.
- Added an Unreleased changelog entry for the crash fix.

## Verification
`bun test test/extensibility/custom-tool-loader.test.ts` in `packages/coding-agent`: 4 pass, 0 fail, 19 assertions. `bun run check` in `packages/coding-agent`: passed. Fixes #5189