### PR TITLE
fix(tui): reduce idle loader render work

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed the mid-prompt `/` autocomplete popup lingering until Esc on tokens that are neither a path nor skill-shaped. Skill suggestions previously stayed alive through fuzzy subsequence matches against long skill descriptions, so nearly any prose token kept the popup hovering; matching is now gated to the `skill:` namespace (bare `/`, `s`, `sk`, …), explicit `skill:` queries (fuzzy search retained), and bare skill-name prefixes (`/hum` → `skill:humanizer`). Everything else falls through to path completion or dismisses the popup, and the Tab/Enter staleness guard shares the same gate so a stale popup can no longer rewrite tokens like `/scan` into `/skill:…`.
+- Fixed idle Loader animation driving the full TUI render pipeline on every spinner tick by directly rewriting the Loader's visible rows when geometry is unchanged, reducing idle render work while preserving fallback repaint paths ([#5192](https://github.com/can1357/oh-my-pi/issues/5192)).
 
 ## [16.4.1] - 2026-07-10
 

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -93,11 +93,10 @@ export class Loader extends Text {
 		const frame = this.#frames[this.#currentFrame];
 		const text = `${this.spinnerColorFn(frame)} ${this.messageColorFn(this.message)}`;
 		if (this.setText(text) && this.#ui) {
-			// Component-scoped: a spinner tick changes only this component, so
-			// the TUI may reuse every other root subtree instead of re-walking
-			// the whole tree (full repaints at 12.5 Hz made huge transcripts
-			// lag as soon as the loader appeared).
-			this.#ui.requestComponentRender(this);
+			// Direct write: a loader tick changes only this component, so the TUI
+			// can update the already-positioned rows without driving the full
+			// compose/prepare/diff pipeline. Unsafe states fall back inside TUI.
+			this.#ui.requestDirectWrite(this);
 		}
 	}
 }

--- a/packages/tui/src/components/loader.ts
+++ b/packages/tui/src/components/loader.ts
@@ -95,8 +95,13 @@ export class Loader extends Text {
 		if (this.setText(text) && this.#ui) {
 			// Direct write: a loader tick changes only this component, so the TUI
 			// can update the already-positioned rows without driving the full
-			// compose/prepare/diff pipeline. Unsafe states fall back inside TUI.
-			this.#ui.requestDirectWrite(this);
+			// compose/prepare/diff pipeline. Lightweight test stubs may not carry
+			// the newer API; keep their legacy component-scoped path working.
+			if (typeof this.#ui.requestDirectWrite === "function") {
+				this.#ui.requestDirectWrite(this);
+			} else {
+				this.#ui.requestComponentRender(this);
+			}
 		}
 	}
 }

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1835,6 +1835,155 @@ export class TUI extends Container {
 		this.#requestOrdinaryRender();
 	}
 
+	/**
+	 * Rewrite a quiet, visible component segment directly.
+	 *
+	 * Loader-style animation changes one already-positioned segment at a fixed
+	 * size. When the current frame geometry is still valid, rewrite just those
+	 * rows and update the diff baseline instead of scheduling a full render
+	 * cycle. Unsafe states fall back to `requestComponentRender()`, preserving
+	 * the ordinary renderer as the correctness path.
+	 */
+	requestDirectWrite(component: Component): void {
+		if (this.#stopped) return;
+		if (
+			this.#renderRequested ||
+			this.#postFullPaintSettleTimer !== undefined ||
+			this.#postFullPaintSettleUntilMs > 0
+		) {
+			this.requestComponentRender(component);
+			return;
+		}
+
+		const width = this.terminal.columns;
+		const height = this.terminal.rows;
+		if (!this.#hasEverRendered || this.#resizeEventPending) {
+			this.requestComponentRender(component);
+			return;
+		}
+		if (width !== this.#previousWidth || height !== this.#previousHeight || width !== this.#composeWidth) {
+			this.requestComponentRender(component);
+			return;
+		}
+		if (this.#clearScrollbackOnNextRender || this.#forceViewportRepaintOnNextRender) {
+			this.requestComponentRender(component);
+			return;
+		}
+		if (this.overlayStack.length > 0 || this.#altActive || !this.#imageBudget.quiescent) {
+			this.requestComponentRender(component);
+			return;
+		}
+
+		const children = this.children;
+		const segments = this.#frameSegments;
+		if (segments.length !== children.length) {
+			this.requestComponentRender(component);
+			return;
+		}
+		for (let i = 0; i < children.length; i++) {
+			if (segments[i]!.component !== children[i]) {
+				this.requestComponentRender(component);
+				return;
+			}
+		}
+
+		const root = this.#resolveComponentRoot(component);
+		if (root === null) {
+			this.requestComponentRender(component);
+			return;
+		}
+		const segmentIndex = segments.findIndex(segment => segment.component === root);
+		if (segmentIndex === -1) {
+			this.requestComponentRender(component);
+			return;
+		}
+		const segment = segments[segmentIndex]!;
+		if (segment.liveLocalStart !== undefined || segment.start < this.#committedRows) {
+			this.requestComponentRender(component);
+			return;
+		}
+
+		const windowTop = Math.max(this.#committedRows, this.#composedFrame.length - height, 0);
+		if (windowTop !== this.#windowTopRow) {
+			this.requestComponentRender(component);
+			return;
+		}
+		const screenStart = segment.start - windowTop;
+		if (screenStart < 0 || screenStart + segment.rowCount > height) {
+			this.requestComponentRender(component);
+			return;
+		}
+
+		const nextLines = root.render(width);
+		if (nextLines.length !== segment.rowCount) {
+			this.requestComponentRender(component);
+			return;
+		}
+		for (const line of nextLines) {
+			if (line.includes(CURSOR_MARKER)) {
+				this.requestComponentRender(component);
+				return;
+			}
+		}
+
+		let firstChanged = -1;
+		let lastChanged = -1;
+		const previousWindow = this.#previousWindow;
+		for (let i = 0; i < nextLines.length; i++) {
+			const frameRow = segment.start + i;
+			const raw = nextLines[i]!;
+			const prepared = this.#prepareLine(raw, width);
+			this.#composedFrame[frameRow] = raw;
+			this.#preparedMeta[frameRow] = prepared;
+			this.#preparedFrame[frameRow] = prepared.line;
+			if (previousWindow[screenStart + i] === prepared.line) continue;
+			previousWindow[screenStart + i] = prepared.line;
+			if (firstChanged === -1) firstChanged = i;
+			lastChanged = i;
+		}
+		segments[segmentIndex] = { ...segment, lines: nextLines };
+		this.#preparedValidRows = Math.max(this.#preparedValidRows, segment.start + nextLines.length);
+		this.#renderStablePrefixRows = Math.min(this.#renderStablePrefixRows, segment.start);
+
+		let cursorPos: { row: number; col: number } | null = null;
+		for (let i = this.#frameCursorMarkers.length - 1; i >= 0; i--) {
+			const marker = this.#frameCursorMarkers[i]!;
+			if (marker.row >= windowTop) {
+				cursorPos = marker;
+				break;
+			}
+		}
+
+		if (firstChanged === -1) {
+			this.#writeCursorPosition(cursorPos, this.#composedFrame.length);
+			this.#previousWidth = width;
+			this.#previousHeight = height;
+			return;
+		}
+
+		const currentScreenRow = Math.max(0, Math.min(height - 1, this.#hardwareCursorRow - windowTop));
+		const targetScreenRow = screenStart + firstChanged;
+		const rowDelta = targetScreenRow - currentScreenRow;
+		let buffer = this.#paintBeginSequence;
+		if (rowDelta > 0) buffer += `\x1b[${rowDelta}B`;
+		else if (rowDelta < 0) buffer += `\x1b[${-rowDelta}A`;
+		buffer += "\r";
+		for (let i = firstChanged; i <= lastChanged; i++) {
+			if (i > firstChanged) buffer += "\r\n";
+			buffer += this.#lineRewriteSequence(this.#preparedFrame[segment.start + i] ?? "", width);
+		}
+		const cursorControl = this.#cursorControlSequence(
+			cursorPos,
+			this.#composedFrame.length,
+			segment.start + lastChanged,
+		);
+		buffer += cursorControl.seq;
+		buffer += this.#paintEndSequence;
+		this.terminal.write(buffer);
+		this.#windowTopRow = windowTop;
+		this.#commit(this.#composedFrame, previousWindow, width, height, cursorControl);
+	}
+
 	/** Ordinary (non-forced) scheduling shared by full and component-scoped requests. */
 	#requestOrdinaryRender(): void {
 		// Coalesce non-forced renders inside the post-full-paint ConPTY settle

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1898,7 +1898,11 @@ export class TUI extends Container {
 			return;
 		}
 		const segment = segments[segmentIndex]!;
-		if (segment.liveLocalStart !== undefined || segment.start < this.#committedRows) {
+		const fullyLiveUncommittedSegment = segment.liveLocalStart === 0 && segment.start >= this.#committedRows;
+		if (
+			(segment.liveLocalStart !== undefined && !fullyLiveUncommittedSegment) ||
+			segment.start < this.#committedRows
+		) {
 			this.requestComponentRender(component);
 			return;
 		}

--- a/packages/tui/test/component-render.test.ts
+++ b/packages/tui/test/component-render.test.ts
@@ -53,6 +53,15 @@ function visible(term: VirtualTerminal): string[] {
 	return strip(term.getViewport()).filter(row => row.length > 0);
 }
 
+class RenderCountingTUI extends TUI {
+	renders = 0;
+
+	override render(width: number): readonly string[] {
+		this.renders++;
+		return super.render(width);
+	}
+}
+
 describe("TUI.requestComponentRender", () => {
 	it("re-renders only the requesting subtree on a quiet frame", async () => {
 		const term = new VirtualTerminal(40, 8, 1_000);
@@ -242,6 +251,73 @@ describe("TUI.requestComponentRender", () => {
 			expect(duplicated).toEqual([]);
 			const observed = Array.from(buffer.matchAll(/ROW-\d{3}/g), match => match[0]);
 			expect(observed).toEqual(markers);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+});
+
+describe("TUI.requestDirectWrite", () => {
+	it("directly rewrites a visible unchanged-size root segment without a full render", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new RenderCountingTUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0", "msg-1"]);
+		const spinner = new CountingLines(["spin-0"]);
+		const footer = new CountingLines(["footer"]);
+		tui.addChild(transcript);
+		tui.addChild(spinner);
+		tui.addChild(footer);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			expect(visible(term)).toEqual(["msg-0", "msg-1", "spin-0", "footer"]);
+			const tuiRenders = tui.renders;
+			const transcriptRenders = transcript.renders;
+			const footerRenders = footer.renders;
+
+			spinner.set(["spin-1"]);
+			tui.requestDirectWrite(spinner);
+			await scheduler.drain(term);
+
+			expect(visible(term)).toEqual(["msg-0", "msg-1", "spin-1", "footer"]);
+			expect(tui.renders).toBe(tuiRenders);
+			expect(transcript.renders).toBe(transcriptRenders);
+			expect(footer.renders).toBe(footerRenders);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
+	it("falls back to a full render while a visible overlay is up", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new RenderCountingTUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0"]);
+		const spinner = new CountingLines(["spin-0"]);
+		const footer = new CountingLines(["footer"]);
+		tui.addChild(transcript);
+		tui.addChild(spinner);
+		tui.addChild(footer);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			tui.showOverlay(new CountingLines(["modal"]), { width: 5, anchor: "top-left" });
+			await scheduler.drain(term);
+			expect(visible(term)).toEqual(["modal", "spin-0", "footer"]);
+			const tuiRenders = tui.renders;
+			const transcriptRenders = transcript.renders;
+
+			spinner.set(["spin-1"]);
+			tui.requestDirectWrite(spinner);
+			await scheduler.drain(term);
+			expect(visible(term)).toEqual(["modal", "spin-1", "footer"]);
+			expect(tui.renders).toBeGreaterThan(tuiRenders);
+			expect(transcript.renders).toBeGreaterThan(transcriptRenders);
 		} finally {
 			tui.stop();
 			await term.flush();

--- a/packages/tui/test/component-render.test.ts
+++ b/packages/tui/test/component-render.test.ts
@@ -45,6 +45,13 @@ class LiveHead extends CountingLines implements NativeScrollbackLiveRegion {
 	}
 }
 
+class AnchoredStatusContainer extends Container implements NativeScrollbackLiveRegion {
+	getNativeScrollbackLiveRegionStart(): number | undefined {
+		const hasAnchoredRows = this.children.length > 0;
+		return hasAnchoredRows ? 0 : undefined;
+	}
+}
+
 function strip(rows: string[]): string[] {
 	return rows.map(row => Bun.stripANSI(row).trimEnd());
 }
@@ -286,6 +293,37 @@ describe("TUI.requestDirectWrite", () => {
 			expect(tui.renders).toBe(tuiRenders);
 			expect(transcript.renders).toBe(transcriptRenders);
 			expect(footer.renders).toBe(footerRenders);
+		} finally {
+			tui.stop();
+			await term.flush();
+		}
+	});
+
+	it("directly rewrites fully live anchored status segments", async () => {
+		const term = new VirtualTerminal(40, 8, 1_000);
+		const scheduler = new StressRenderScheduler();
+		const tui = new RenderCountingTUI(term, undefined, { renderScheduler: scheduler });
+		const transcript = new CountingLines(["msg-0", "msg-1"]);
+		const status = new AnchoredStatusContainer();
+		const spinner = new CountingLines(["spin-0"]);
+		status.addChild(spinner);
+		tui.addChild(transcript);
+		tui.addChild(status);
+
+		try {
+			tui.start();
+			await scheduler.drain(term);
+			expect(visible(term)).toEqual(["msg-0", "msg-1", "spin-0"]);
+			const tuiRenders = tui.renders;
+			const transcriptRenders = transcript.renders;
+
+			spinner.set(["spin-1"]);
+			tui.requestDirectWrite(spinner);
+			await scheduler.drain(term);
+
+			expect(visible(term)).toEqual(["msg-0", "msg-1", "spin-1"]);
+			expect(tui.renders).toBe(tuiRenders);
+			expect(transcript.renders).toBe(transcriptRenders);
 		} finally {
 			tui.stop();
 			await term.flush();

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -49,6 +49,26 @@ describe("Loader component", () => {
 		loader.stop();
 	});
 
+	it("falls back to component-scoped renders for lightweight TUI stubs", () => {
+		vi.useFakeTimers();
+		const ui = { requestComponentRender: vi.fn() };
+		const loader = new Loader(
+			ui as unknown as TUI,
+			text => text,
+			text => text,
+			"Checking",
+			["0"],
+		);
+
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+
+		loader.setMessage("Still checking");
+		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		expect(loader.render(30).join("\n")).toContain("0 Still checking");
+
+		loader.stop();
+	});
+
 	it("skips animated render requests when composed text is unchanged before the spinner advances", () => {
 		vi.useFakeTimers();
 		const ui = { requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };

--- a/packages/tui/test/loader.test.ts
+++ b/packages/tui/test/loader.test.ts
@@ -36,71 +36,79 @@ describe("Loader component", () => {
 
 	it("keeps spinner cadence when animated messages repaint at 30fps", () => {
 		vi.useFakeTimers();
-		const ui = { requestComponentRender: vi.fn() } as unknown as TUI;
+		const ui = { requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
 		const colorMessage = ((text: string) => text) as LoaderMessageColorFn & { animated: true };
 		colorMessage.animated = true;
-		const loader = new Loader(ui, text => text, colorMessage, "Checking", ["0", "1", "2", "3"]);
+		const loader = new Loader(ui as unknown as TUI, text => text, colorMessage, "Checking", ["0", "1", "2", "3"]);
 
 		vi.advanceTimersByTime(170);
 
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(3);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 		expect(loader.render(20).join("\n")).toContain("2 Checking");
 		loader.stop();
 	});
 
 	it("skips animated render requests when composed text is unchanged before the spinner advances", () => {
 		vi.useFakeTimers();
-		const ui = { requestComponentRender: vi.fn() } as unknown as TUI;
+		const ui = { requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
 		const colorMessage = ((text: string) => text) as LoaderMessageColorFn & { animated: true };
 		colorMessage.animated = true;
-		const loader = new Loader(ui, text => text, colorMessage, "Checking", ["0", "1"]);
+		const loader = new Loader(ui as unknown as TUI, text => text, colorMessage, "Checking", ["0", "1"]);
 
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 
 		vi.advanceTimersByTime(34);
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
 
 		vi.advanceTimersByTime(67);
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 		expect(loader.render(20).join("\n")).toContain("1 Checking");
 
 		loader.stop();
 	});
 
-	it("requests render for message changes but not repeated identical messages", () => {
+	it("requests direct writes for message changes but not repeated identical messages", () => {
 		vi.useFakeTimers();
-		const ui = { requestComponentRender: vi.fn() } as unknown as TUI;
+		const ui = { requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
 		const loader = new Loader(
-			ui,
+			ui as unknown as TUI,
 			text => text,
 			text => text,
 			"Checking",
 			["0"],
 		);
 
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 
 		loader.setMessage("Still checking");
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
 		expect(loader.render(30).join("\n")).toContain("0 Still checking");
 
 		loader.setMessage("Still checking");
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 
 		loader.stop();
 	});
 
-	it("requests render when animated message bytes change between spinner frames", () => {
+	it("requests direct writes when animated message bytes change between spinner frames", () => {
 		vi.useFakeTimers();
 		setSystemTime(new Date(1_000));
-		const ui = { synchronizedOutput: true, requestComponentRender: vi.fn() } as unknown as TUI;
+		const ui = { synchronizedOutput: true, requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
 		const colorMessage = ((text: string) => `${text}-${Date.now()}`) as LoaderMessageColorFn & { animated: true };
 		colorMessage.animated = true;
-		const loader = new Loader(ui, text => text, colorMessage, "Checking", ["0"]);
+		const loader = new Loader(ui as unknown as TUI, text => text, colorMessage, "Checking", ["0"]);
 
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 
 		vi.advanceTimersByTime(34);
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 		expect(loader.render(40).join("\n")).toContain("0 Checking-");
 
 		loader.stop();
@@ -109,18 +117,20 @@ describe("Loader component", () => {
 	it("holds animated message-only frames when synchronized output is unavailable", () => {
 		vi.useFakeTimers();
 		setSystemTime(new Date(1_000));
-		const ui = { synchronizedOutput: false, requestComponentRender: vi.fn() } as unknown as TUI;
+		const ui = { synchronizedOutput: false, requestDirectWrite: vi.fn(), requestComponentRender: vi.fn() };
 		const colorMessage = ((text: string) => `${text}-${Date.now()}`) as LoaderMessageColorFn & { animated: true };
 		colorMessage.animated = true;
-		const loader = new Loader(ui, text => text, colorMessage, "Checking", ["0", "1"]);
+		const loader = new Loader(ui as unknown as TUI, text => text, colorMessage, "Checking", ["0", "1"]);
 
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 
 		vi.advanceTimersByTime(34);
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(1);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(1);
 
 		vi.advanceTimersByTime(67);
-		expect(ui.requestComponentRender).toHaveBeenCalledTimes(2);
+		expect(ui.requestDirectWrite).toHaveBeenCalledTimes(2);
+		expect(ui.requestComponentRender).not.toHaveBeenCalled();
 		expect(loader.render(40).join("\n")).toContain("1 Checking-");
 
 		loader.stop();
@@ -136,7 +146,7 @@ describe("Loader component", () => {
 			"Checking",
 			["a", "b", "c"],
 		);
-		const spy = spyOn(tui, "requestComponentRender");
+		const spy = spyOn(tui, "requestDirectWrite");
 		loader.dispose();
 		const after = spy.mock.calls.length;
 		await Bun.sleep(40); // longer than the spinner interval
@@ -149,7 +159,7 @@ describe("Loader component", () => {
 		vi.useFakeTimers();
 		const term = new VirtualTerminal(20, 4);
 		const tui = new TUI(term);
-		const spy = spyOn(tui, "requestComponentRender");
+		const spy = spyOn(tui, "requestDirectWrite");
 		const container = new Container();
 		const loader = new Loader(
 			tui,


### PR DESCRIPTION
## Repro
A focused TUI harness reproduced the idle spinner hot path with `bun local://idle-render-repro.ts`: five spinner-only `requestComponentRender` ticks after initial paint still invoked `TUI.render()` five times while the transcript subtree stayed reused (`{"spinnerTicks":5,"tuiRenderCallsAfterInitialPaint":5,"transcriptRenderCallsAfterInitialPaint":0}`).

## Cause
`Loader.#updateDisplay()` in `packages/tui/src/components/loader.ts` used `TUI.requestComponentRender()`, which scoped compose to the Loader root but still entered `TUI.#doRender()` in `packages/tui/src/tui.ts`; that path prepares the frame, slices/diffs the viewport, and writes cursor state for every animation tick even when only the Loader rows changed.

## Fix
- Added `TUI.requestDirectWrite(component)` for quiet, visible, unchanged-size segments; it re-renders only the resolved root segment, prepares those rows, rewrites the changed terminal rows, and updates `#previousWindow`/render accounting so the next full diff stays consistent.
- Guarded the direct-write path with the same unsafe-state checks as component-scoped rendering: first paint, resize/geometry drift, overlays, alt-screen, forced repaint, changed root structure, non-quiescent image budget, committed/live-seam segments, off-screen segments, row-count changes, and cursor-marker rows all fall back to `requestComponentRender()`.
- Switched `Loader.#updateDisplay()` to request direct writes while preserving the spinner cadence and equality guards.
- Added regression coverage for the direct-write fast path, overlay fallback, and Loader scheduling semantics.
- Added a `packages/tui/CHANGELOG.md` entry for #5192.

## Verification
`bun test packages/tui/test/component-render.test.ts packages/tui/test/loader.test.ts` passed with 16 tests and 57 assertions. `bun check` passed. `bun local://idle-render-fixed.ts` showed five direct-write spinner ticks after initial paint invoked `TUI.render()` zero times (`{"spinnerTicks":5,"tuiRenderCallsAfterInitialPaint":0,"transcriptRenderCallsAfterInitialPaint":0}`). Fixes #5192