### PR TITLE
fix(coding-agent): keep required plugin modules synchronous

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed plugin validation and loading rejecting extensions that synchronously load relative CommonJS helpers with `createRequire()`.
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -176,6 +176,7 @@ const realpathCache = new Map<string, Promise<string>>();
 const nativeAddonResolutionCache = new Map<string, Promise<string | null>>();
 const nativeAddonRequireScanCache = new Map<string, Promise<boolean>>();
 const nativeAddonLoaderModulePaths = new Set<string>();
+const synchronousRequireModulePaths = new Set<string>();
 
 function clearLegacyPiResolutionCaches(): void {
 	resolvedSpecifierFallbacks.clear();
@@ -187,6 +188,7 @@ function clearLegacyPiResolutionCaches(): void {
 	nativeAddonResolutionCache.clear();
 	nativeAddonRequireScanCache.clear();
 	nativeAddonLoaderModulePaths.clear();
+	synchronousRequireModulePaths.clear();
 	realpathCache.clear();
 }
 
@@ -1089,12 +1091,11 @@ function escapeRegExp(value: string): string {
 }
 
 // Match source modules in an extension graph: relative imports, package
-// `imports` aliases such as `#src/*`, and extension-local bare dependency
-// entries. Bare imports inside node_modules dependencies remain native Bun
-// resolutions; once an ESM dependency entry is hooked, its relative children
-// are still collected and rewritten with the reload mtime tag. Synchronous
-// `require()` children stay on Bun's native loader: routing them through our
-// async onLoad hook makes createRequire() fail before the module can execute.
+// `imports` aliases such as `#src/*`, extension-local bare dependencies, and
+// literal CommonJS requires. Required children are still traversed so nested
+// napi-rs loaders can receive the native-addon rewrite, but ordinary required
+// modules stay on Bun's synchronous native loader instead of being claimed by
+// the async ESM hook.
 const EXTENSION_GRAPH_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])([^"'()\s]+)(["'])/g;
 
 // Extension source realpaths already covered by an installed load-time hook for
@@ -1170,8 +1171,15 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 		modules.set(file, source);
 		const dir = path.dirname(file);
 		const specifiers = new Set<string>();
+		const requireSpecifiers = new Set<string>();
 		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
 			if (match[2]) specifiers.add(match[2]);
+		}
+		for (const match of source.matchAll(NATIVE_ADDON_REQUIRE_SPECIFIER_REGEX)) {
+			if (match[2]) {
+				specifiers.add(match[2]);
+				requireSpecifiers.add(match[2]);
+			}
 		}
 		for (const specifier of specifiers) {
 			try {
@@ -1211,6 +1219,12 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 					}
 					nextFollowsBareDependencies = false;
 				}
+				if (resolved && requireSpecifiers.has(specifier)) {
+					synchronousRequireModulePaths.add(resolved);
+					if (await moduleRequiresNativeAddon(resolved)) {
+						nativeAddonLoaderModulePaths.add(resolved);
+					}
+				}
 				if (resolved && !modules.has(resolved)) {
 					const queuedFollowsBareDependencies = queuedFollowBareDependencies.get(resolved) ?? false;
 					const mergedFollowsBareDependencies = queuedFollowsBareDependencies || nextFollowsBareDependencies;
@@ -1218,7 +1232,7 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 					queue.push({ file: resolved, followBareDependencies: mergedFollowsBareDependencies });
 				}
 			} catch {
-				// Unresolvable import (e.g. a type-only path); skip it.
+				// Unresolvable specifier (e.g. a type-only path); skip it.
 			}
 		}
 	}
@@ -1227,9 +1241,10 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 
 /**
  * Install exact-path load hooks for the current extension graph. ESM/TS source
- * retains the async rewrite path. Native-addon CJS loaders use a synchronous
- * hook with source pre-rewritten during graph collection; Bun rejects a CJS
- * `require()` whose onLoad callback returns a promise.
+ * retains the async rewrite path. Modules reached through synchronous
+ * `require()` stay on Bun's native loader, except native-addon CJS loaders:
+ * those use a synchronous hook with source pre-rewritten during graph
+ * collection. Bun rejects any `require()` whose onLoad callback returns a promise.
  */
 function installExtensionGraphHook(
 	entryRealPath: string,
@@ -1238,8 +1253,11 @@ function installExtensionGraphHook(
 	const asyncModules = new Map<string, string>();
 	const syncCommonJsModules = new Map<string, string>();
 	for (const [modulePath, source] of modules) {
-		const destination = nativeAddonLoaderModulePaths.has(modulePath) ? syncCommonJsModules : asyncModules;
-		destination.set(modulePath, source);
+		if (nativeAddonLoaderModulePaths.has(modulePath)) {
+			syncCommonJsModules.set(modulePath, source);
+		} else if (!synchronousRequireModulePaths.has(modulePath)) {
+			asyncModules.set(modulePath, source);
+		}
 	}
 
 	if (asyncModules.size > 0) {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1091,10 +1091,10 @@ function escapeRegExp(value: string): string {
 // Match source modules in an extension graph: relative imports, package
 // `imports` aliases such as `#src/*`, and extension-local bare dependency
 // entries. Bare imports inside node_modules dependencies remain native Bun
-// resolutions; once the dependency entry is hooked, its relative children are
-// still collected and rewritten with the reload mtime tag. `require()` calls
-// are scanned too so CJS entries and napi-rs loaders reached without an
-// import statement still join the graph.
+// resolutions; once an ESM dependency entry is hooked, its relative children
+// are still collected and rewritten with the reload mtime tag. Synchronous
+// `require()` children stay on Bun's native loader: routing them through our
+// async onLoad hook makes createRequire() fail before the module can execute.
 const EXTENSION_GRAPH_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])([^"'()\s]+)(["'])/g;
 
 // Extension source realpaths already covered by an installed load-time hook for
@@ -1171,9 +1171,6 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 		const dir = path.dirname(file);
 		const specifiers = new Set<string>();
 		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
-			if (match[2]) specifiers.add(match[2]);
-		}
-		for (const match of source.matchAll(NATIVE_ADDON_REQUIRE_SPECIFIER_REGEX)) {
 			if (match[2]) specifiers.add(match[2]);
 		}
 		for (const specifier of specifiers) {

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -350,6 +350,30 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(mod.hasZod).toBe(true);
 	});
 
+	it("loads relative CommonJS helpers through createRequire without async hooks", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "create-require-ext", version: "1.0.0", type: "module" }),
+			"hooks/config.js": [
+				'const nested = require("./nested.js");',
+				'module.exports = { mode: "full", nested };',
+			].join("\n"),
+			"hooks/nested.js": 'module.exports = "native-cjs";',
+			"index.js": [
+				'import { createRequire } from "node:module";',
+				"const require = createRequire(import.meta.url);",
+				'const config = require("./hooks/config.js");',
+				"export { config };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.js"))) as {
+			config: { mode: string; nested: string };
+		};
+
+		expect(mod.config).toEqual({ mode: "full", nested: "native-cjs" });
+	});
+
 	it("exposes legacy root tool factories used by pi-lean-ctx", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "legacy-tool-factory-ext", version: "1.0.0" }),


### PR DESCRIPTION
## What

   Track extension modules reached through synchronous CommonJS `require()` calls separately from modules reached through ESM imports.

   Ordinary required modules now remain on Bun’s native synchronous loader instead of being routed through OMP’s asynchronous compatibility `onLoad` hook. Required modules are still
 traversed so nested native-addon loaders remain discoverable, and CommonJS loaders that require native `.node` addons retain their existing synchronous pre-rewritten hook.

   Add an end-to-end regression test covering an ESM extension entrypoint that uses `createRequire()` to load a relative CommonJS helper with a nested `require()`.

   ## Why

   Plugins such as Ponytail use an ESM extension entrypoint with synchronous CommonJS helpers:

   ```js
   import { createRequire } from "node:module";

   const require = createRequire(import.meta.url);
   const config = require("../hooks/ponytail-config.js");
   ```

   OMP previously added the relative CommonJS helper to its asynchronous extension module graph. Bun cannot satisfy a synchronous `require()` through an async `onLoad` hook, causing
 plugin validation and installation to fail with:

   ```text
   require() async module ".../hooks/ponytail-config.js" is unsupported. use "await import()" instead.
   ```

   The loader must retain whether a module was reached through ESM import or synchronous CommonJS require. Synchronous loading takes precedence because `require()` cannot consume an
 asynchronous loader result.

   ## Testing

   Verified the focused extension loader suite:

   ```text
   bun test packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts

   18 pass
   0 fail
   56 expect() calls
   ```

   Verified related plugin validation and discovery suites:

   ```text
   bun test \
     packages/coding-agent/test/plugin-install-validation.test.ts \
     packages/coding-agent/test/plugin-extensions-discovery.test.ts \
     packages/coding-agent/test/issue-973-legacy-pi-plugin.test.ts

   22 pass
   0 fail
   84 expect() calls
   ```

   Verified the actual upstream Ponytail plugin using the fixed local OMP source and an isolated home directory:

   ```text
   bun packages/coding-agent/src/cli.ts plugin install git:github.com/DietrichGebert/ponytail

   ✔ Installed @dietrichgebert/ponytail@4.8.4
   ```

   Focused Biome checks pass, and LSP diagnostics are clean for both touched TypeScript files.

   Repository-wide `bun check` was run but remains blocked by unrelated existing type errors in `packages/ai/src/providers/cursor.ts` and dependent package checks. No reported
 diagnostic referenced the files changed by this PR.

   ---

   - [ ] `bun check` passes - no but unrelated to my changes
   - [x] Tested locally
   - [x] CHANGELOG updated (if user-facing)
