### PR TITLE
fix(utils): keep RPC stdin alive after bad JSONL frames

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1282,7 +1282,17 @@ export async function runRpcMode(
 	// Listen for JSON input using Bun's stdin. Frame dispatch lives in
 	// dispatchRpcInputFrame so it can be exercised directly by tests; see the
 	// helper's docstring for the concurrency contract.
-	for await (const parsed of readJsonl(Bun.stdin.stream())) {
+	//
+	// A single malformed/non-JSON stdin line must not kill the process: report
+	// it with the same parse-error response frame the dispatch catch already
+	// emits, then keep reading subsequent frames (issue #5194).
+	for await (const parsed of readJsonl(Bun.stdin.stream(), undefined, {
+		continueOnError: true,
+		onParseError: e => {
+			const message = e instanceof Error ? e.message : String(e);
+			output(error(undefined, "parse", `Failed to parse command: ${message}`));
+		},
+	})) {
 		try {
 			const awaited = dispatchRpcInputFrame(parsed, dispatchFrameDeps);
 			if (awaited) {

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -47,25 +47,60 @@ export async function* readLines(stream: ReadableStream<Uint8Array>, signal?: Ab
 	}
 }
 
-export async function* readJsonl<T>(stream: ReadableStream<Uint8Array>, signal?: AbortSignal): AsyncGenerator<T> {
+export type ReadJsonlOptions = {
+	/**
+	 * When true, a parse error on one complete JSONL record does not terminate
+	 * the generator. The bad record is skipped and subsequent records continue
+	 * to yield. Callers that need to surface the failure (for example RPC mode)
+	 * can attach `onParseError`.
+	 */
+	continueOnError?: boolean;
+	/** Invoked once per recoverable parse failure when `continueOnError` is set. */
+	onParseError?: (error: unknown) => void;
+};
+
+function skipMalformedJsonlRegion(chunk: Uint8Array, read: number): number {
+	const nl = chunk.indexOf(LF, read);
+	return nl === -1 ? chunk.length : nl + 1;
+}
+
+export async function* readJsonl<T>(
+	stream: ReadableStream<Uint8Array>,
+	signal?: AbortSignal,
+	options?: ReadJsonlOptions,
+): AsyncGenerator<T> {
 	const buffer = new ConcatSink();
 	const source = abortableSource(stream, signal);
+	const continueOnError = options?.continueOnError === true;
+	const onParseError = options?.onParseError;
 	try {
 		for await (const chunk of source) {
-			yield* buffer.pullJSONL<T>(chunk, 0, chunk.length);
+			yield* buffer.pullJSONL<T>(chunk, 0, chunk.length, {
+				continueOnError,
+				onParseError,
+			});
 		}
 		if (!buffer.isEmpty) {
-			const tail = buffer.flush();
-			if (tail) {
-				buffer.clear();
-				const { values, error, done } = parseJsonlChunkCompat(tail, 0, tail.length);
+			let remaining = buffer.flush();
+			buffer.clear();
+			while (remaining && remaining.length > 0) {
+				const { values, error, read, done } = parseJsonlChunkCompat(remaining, 0, remaining.length);
 				if (values.length > 0) {
 					yield* values as T[];
 				}
-				if (error) throw error;
-				if (!done) {
+				if (error) {
+					if (!continueOnError) throw error;
+					onParseError?.(error);
+					const next = skipMalformedJsonlRegion(remaining, read);
+					if (next >= remaining.length) break;
+					remaining = remaining.subarray(next);
+					continue;
+				}
+				if (done) break;
+				if (read === 0) {
 					throw new Error("JSONL stream ended unexpectedly");
 				}
+				remaining = remaining.subarray(read);
 			}
 		}
 	} catch (err) {
@@ -150,15 +185,37 @@ class ConcatSink {
 			}
 		}
 	}
-	*pullJSONL<T>(chunk: Uint8Array, beg: number, end: number) {
+	*pullJSONL<T>(
+		chunk: Uint8Array,
+		beg: number,
+		end: number,
+		options?: { continueOnError?: boolean; onParseError?: (error: unknown) => void },
+	) {
+		const continueOnError = options?.continueOnError === true;
+		const onParseError = options?.onParseError;
+
 		if (this.isEmpty) {
-			const { values, error, read, done } = parseJsonlChunkCompat(chunk, beg, end);
-			if (values.length > 0) {
-				yield* values as T[];
+			let start = beg;
+			while (start < end) {
+				const { values, error, read, done } = parseJsonlChunkCompat(chunk, start, end);
+				if (values.length > 0) {
+					yield* values as T[];
+				}
+				if (error) {
+					if (!continueOnError) throw error;
+					onParseError?.(error);
+					const next = skipMalformedJsonlRegion(chunk, Math.max(read, start));
+					if (next <= start) {
+						// No progress — drop the rest of the chunk rather than loop forever.
+						return;
+					}
+					start = next;
+					continue;
+				}
+				if (done) return;
+				this.reset(chunk.subarray(read, end));
+				return;
 			}
-			if (error) throw error;
-			if (done) return;
-			this.reset(chunk.subarray(read, end));
 			return;
 		}
 
@@ -169,20 +226,35 @@ class ConcatSink {
 		space.set(chunk.subarray(beg, end), offset);
 		this.#length = total;
 
-		const { values, error, read, done } = parseJsonlChunkCompat(space.subarray(0, total), 0, total);
-		if (values.length > 0) {
-			yield* values as T[];
-		}
-		if (error) throw error;
-		if (done) {
-			this.#length = 0;
+		let start = 0;
+		while (true) {
+			const currentLength = this.#length;
+			const { values, error, read, done } = parseJsonlChunkCompat(space.subarray(0, currentLength), start, currentLength);
+			if (values.length > 0) {
+				yield* values as T[];
+			}
+			if (error) {
+				if (!continueOnError) throw error;
+				onParseError?.(error);
+				const next = skipMalformedJsonlRegion(space.subarray(0, currentLength), Math.max(read, start));
+				if (next >= currentLength) {
+					this.#length = 0;
+					return;
+				}
+				start = next;
+				continue;
+			}
+			if (done) {
+				this.#length = 0;
+				return;
+			}
+			const rem = currentLength - read;
+			if (rem < currentLength) {
+				space.copyWithin(0, read, currentLength);
+			}
+			this.#length = rem;
 			return;
 		}
-		const rem = total - read;
-		if (rem < total) {
-			space.copyWithin(0, read, total);
-		}
-		this.#length = rem;
 	}
 }
 

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -144,6 +144,40 @@ describe("readJsonl", () => {
 		const output = await collectAsync(readJsonl(readable));
 		expect(output).toEqual([{ z: 9 }]);
 	});
+
+	it("throws on a malformed line by default", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\nls\n{"b":2}\n'));
+				controller.close();
+			},
+		});
+
+		await expect(collectAsync(readJsonl(readable))).rejects.toThrow();
+	});
+
+	it("continues after a malformed line when continueOnError is set", async () => {
+		const errors: unknown[] = [];
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode('{"a":1}\nls\n{"b":2}\n'));
+				controller.close();
+			},
+		});
+
+		const output = await collectAsync(
+			readJsonl(readable, undefined, {
+				continueOnError: true,
+				onParseError: error => {
+					errors.push(error);
+				},
+			}),
+		);
+		expect(output).toEqual([{ a: 1 }, { b: 2 }]);
+		// Bun.JSONL may surface the bad line both as a trailing error after a
+		// successful value and again when that line is parsed on its own.
+		expect(errors.length).toBeGreaterThanOrEqual(1);
+	});
 });
 
 describe("createSanitizerStream", () => {


### PR DESCRIPTION
## Summary
- `readJsonl` now supports opt-in `continueOnError` + `onParseError` so one bad JSONL record no longer kills the stream
- RPC mode uses that path: malformed/non-JSON stdin lines emit the existing parse-error response frame and keep reading
- Default callers still throw on parse errors

## Root cause
`runRpcMode` only wrapped dispatch in try/catch. Parse errors from `readJsonl` escaped the loop and took the process down.

## Test plan
- [x] `bun test packages/utils/test/stream.test.ts -t readJsonl`
- [x] default path still rejects malformed lines
- [x] `continueOnError` yields later valid records after a bad line

Closes #5194