### PR TITLE
fix(coding-agent): let report_tool_issue cover shipped custom tools

### DIFF
--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -486,6 +486,13 @@ export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
 	goal: s => new GoalTool(s),
 };
 
+/**
+ * First-party tools registered outside BUILTIN_TOOLS / HIDDEN_TOOLS (SDK
+ * injects them as custom tools). Still OMP-shipped, so report_tool_issue must
+ * accept them when AutoQA is on.
+ */
+export const SHIPPED_CUSTOM_TOOL_NAMES = ["generate_image", "tts"] as const;
+
 export type ToolName = BuiltinToolName;
 
 /**
@@ -678,13 +685,16 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// Injected unconditionally into every agent, regardless of requested tool list.
 	const autoQA = isAutoQaEnabled(session.settings);
 	if (autoQA && !tools.some(t => t.name === "report_tool_issue")) {
-		// Build the enum from tools we just constructed via BUILTIN_TOOLS / HIDDEN_TOOLS.
-		// Extension overrides (e.g. a user's custom `bash`) get added later by
-		// other code paths, so they're absent here — exactly what we want; MCP /
-		// extension tools never end up in the report enum.
+		// Build the enum from tools we just constructed via BUILTIN_TOOLS /
+		// HIDDEN_TOOLS, plus OMP-shipped custom tools (generate_image / tts)
+		// that are registered outside this factory but still first-party
+		// (issue #5175). Extension overrides and MCP tools stay excluded.
 		const activeBuiltinNames = tools
 			.map(t => t.name)
 			.filter(name => (name in BUILTIN_TOOLS || name in HIDDEN_TOOLS) && name !== "report_tool_issue");
+		for (const shipped of SHIPPED_CUSTOM_TOOL_NAMES) {
+			if (!activeBuiltinNames.includes(shipped)) activeBuiltinNames.push(shipped);
+		}
 		const qaTool = createReportToolIssueTool(session, activeBuiltinNames);
 		if (qaTool) {
 			tools.push(wrapToolWithMetaNotice(qaTool));

--- a/packages/coding-agent/src/tools/report-tool-issue.ts
+++ b/packages/coding-agent/src/tools/report-tool-issue.ts
@@ -299,6 +299,14 @@ let lastFailureAt = 0;
 export function __resetAutoQaFlushStateForTests(): void {
 	inFlightFlush = null;
 	lastFailureAt = 0;
+	if (cachedDb) {
+		try {
+			cachedDb.close();
+		} catch {
+			// ignore close races in tests
+		}
+		cachedDb = null;
+	}
 }
 
 function envOverrideString(name: string): string | undefined {

--- a/packages/coding-agent/test/tools/report-tool-issue-allowlist.test.ts
+++ b/packages/coding-agent/test/tools/report-tool-issue-allowlist.test.ts
@@ -1,0 +1,90 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import {
+	__resetAutoQaConsentForTests,
+	__resetAutoQaFlushStateForTests,
+	createReportToolIssueTool,
+} from "@oh-my-pi/pi-coding-agent/tools/report-tool-issue";
+import * as piUtils from "@oh-my-pi/pi-utils";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("createReportToolIssueTool allowlist", () => {
+	let tempDir: TempDir;
+	let dbPath: string;
+
+	beforeEach(() => {
+		__resetAutoQaConsentForTests();
+		__resetAutoQaFlushStateForTests();
+		tempDir = TempDir.createSync("@pi-report-tool-issue-allowlist-");
+		dbPath = path.join(tempDir.path(), "autoqa.db");
+		spyOn(piUtils, "getAutoQaDbDir").mockReturnValue(dbPath);
+	});
+
+	afterEach(async () => {
+		__resetAutoQaConsentForTests();
+		__resetAutoQaFlushStateForTests();
+		await tempDir.remove();
+	});
+
+	function createSession(): ToolSession {
+		return {
+			cwd: tempDir.path(),
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			settings: Settings.isolated({
+				"dev.autoqa": true,
+				"dev.autoqa.consent": "granted",
+			}),
+			getActiveModelString: () => "test-model",
+		};
+	}
+
+	function readReports(tool: string): Array<{ tool: string; report: string }> {
+		const db = new Database(dbPath);
+		try {
+			return db
+				.prepare("SELECT tool, report FROM grievances WHERE tool = ? ORDER BY id ASC")
+				.all(tool) as Array<{ tool: string; report: string }>;
+		} finally {
+			db.close();
+		}
+	}
+
+	it("accepts generate_image when it is in the active reportable tool set", async () => {
+		const tool = createReportToolIssueTool(createSession(), ["bash", "generate_image", "read"]);
+		await tool.execute("call-1", {
+			tool: "generate_image",
+			report: "image generation failed before provider call",
+		});
+		expect(readReports("generate_image")).toEqual([
+			{ tool: "generate_image", report: "image generation failed before provider call" },
+		]);
+	});
+
+	it("rejects generate_image when the allowlist is non-empty and omits it", async () => {
+		const tool = createReportToolIssueTool(createSession(), ["bash", "read"]);
+		await tool.execute("call-2", {
+			tool: "generate_image",
+			report: "should not be recorded",
+		});
+		// Silent drop never opens the AutoQA DB, so the file stays absent.
+		expect(await Bun.file(dbPath).exists()).toBe(false);
+	});
+
+	it("includes generate_image and tts in the schema enum when provided", () => {
+		const tool = createReportToolIssueTool(createSession(), ["bash", "generate_image", "tts"]);
+		const schema = tool.parameters as { toJsonSchema?: () => unknown };
+		const json = typeof schema.toJsonSchema === "function" ? (schema.toJsonSchema() as any) : undefined;
+		const toolSchema = json?.properties?.tool;
+		const enumValues: string[] | undefined =
+			toolSchema?.enum ??
+			toolSchema?.anyOf?.flatMap((entry: { const?: string }) => (entry.const ? [entry.const] : []));
+		expect(enumValues).toContain("generate_image");
+		expect(enumValues).toContain("tts");
+		expect(enumValues).toContain("bash");
+	});
+});


### PR DESCRIPTION
## Summary
- AutoQA allowlist now includes OMP-shipped custom tools `generate_image` and `tts`
- `report_tool_issue` schema/runtime can record failures from those tools
- Extension/MCP tools stay excluded

## Root cause
`createTools` built the AutoQA enum only from `BUILTIN_TOOLS` / `HIDDEN_TOOLS`. First-party tools registered as custom tools never entered that set, so validation rejected them before `execute`.

## Test plan
- [x] `bun test packages/coding-agent/test/tools/report-tool-issue-allowlist.test.ts`
- [x] `bun test packages/coding-agent/test/tools/report-tool-issue.test.ts packages/coding-agent/test/tools/report-tool-issue-consent.test.ts`

Closes #5175