### PR TITLE
fix(coding-agent): restore SettingsManager.getGlobalSettings/getProjectSettings in legacy pi shim

### DIFF
--- a/docs/porting-from-pi-mono.md
+++ b/docs/porting-from-pi-mono.md
@@ -363,7 +363,8 @@ Our fork has architectural decisions that differ from upstream. **Do not port th
 | `pkg.pi` manifest field                                          | `pkg.omp` preferred; fallback to `pkg.pi` remains                                                  |
 | `StringEnum` from `pi-ai`                                        | `Type.Enum` from the `pi.typebox` shim (or author the schema with `pi.zod`); `pi-ai` no longer exports `StringEnum` |
 | `formatSize` from `pi-coding-agent`                              | `formatBytes` from `@oh-my-pi/pi-utils`                                                            |
-| `DefaultResourceLoader` / `DefaultPackageManager` / `SettingsManager` / `createEventBus` | Capability-based discovery (`loadCapability(...)`) plus the `Settings` singleton and `EventBus` |
+| `DefaultResourceLoader` / `DefaultPackageManager` / `createEventBus` | Capability-based discovery (`loadCapability(...)`) plus the `Settings` singleton and `EventBus` |
+| `SettingsManager` | The `Settings` singleton, exposed through a legacy shim: `SettingsManager.create(cwd)` returns it synchronously and `Settings` now provides `getGlobalSettings()`/`getProjectSettings()` raw-layer accessors for pi extensions (e.g. `pi-vim`) that read arbitrary namespaced keys |
 
 ### Skip These Upstream Features
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed legacy pi extensions crashing on startup with `s.getGlobalSettings is not a function` (e.g. `pi-vim`): the `SettingsManager` compat shim's `create(cwd)` now returns the initialized `Settings` singleton synchronously instead of a `Promise`, and `Settings` exposes `getGlobalSettings()`/`getProjectSettings()` raw-layer accessors so extensions can read arbitrary namespaced config keys. ([#2166](https://github.com/can1357/oh-my-pi/issues/2166))
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -507,6 +507,16 @@ export class Settings {
 		return this.#cwd;
 	}
 
+	/** Raw global settings layer (config.yml). Legacy pi-compat accessor. */
+	getGlobalSettings(): RawSettings {
+		return structuredClone(this.#global);
+	}
+
+	/** Raw project settings layer (.claude/settings.yml, etc). Legacy pi-compat accessor. */
+	getProjectSettings(): RawSettings {
+		return structuredClone(this.#project);
+	}
+
 	getAgentDir(): string {
 		return this.#agentDir;
 	}

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -19,7 +19,7 @@ import type { TSchema } from "@oh-my-pi/pi-ai";
 import { Text } from "@oh-my-pi/pi-tui";
 import { getAgentDir, getProjectDir, parseFrontmatter as parseOmpFrontmatter } from "@oh-my-pi/pi-utils";
 import type { PromptTemplate } from "../config/prompt-templates";
-import { type SettingPath, Settings } from "../config/settings";
+import { isSettingsInitialized, type SettingPath, Settings } from "../config/settings";
 import { EditTool } from "../edit";
 import type { CreateAgentSessionOptions, CreateAgentSessionResult, LoadExtensionsResult } from "../sdk";
 import {
@@ -646,8 +646,15 @@ export function createReadOnlyTools(cwd: string): ToolDefinition[] {
 }
 
 export const SettingsManager = {
-	create(cwd: string, agentDir?: string): Promise<Settings> {
-		return Settings.init({ cwd, agentDir });
+	/**
+	 * Legacy pi extensions call this synchronously and immediately read
+	 * getGlobalSettings()/getProjectSettings(). Upstream Pi's API is sync, so
+	 * return the initialized global singleton (already scoped to the session
+	 * cwd, which legacy callers pass as ctx.cwd) rather than a Promise. Falls
+	 * back to an isolated instance outside a live session.
+	 */
+	create(_cwd: string, _agentDir?: string): Settings {
+		return isSettingsInitialized() ? Settings.instance : Settings.isolated();
 	},
 
 	inMemory(): Settings {

--- a/packages/coding-agent/test/extensibility/legacy-pi-settings-manager.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-settings-manager.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SettingsManager } from "@oh-my-pi/pi-coding-agent/extensibility/legacy-pi-coding-agent-shim";
+import { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "../helpers/settings-test-state";
+
+// Legacy pi extensions (e.g. pi-vim) call `SettingsManager.create(cwd)`
+// synchronously and immediately read `getGlobalSettings()`/`getProjectSettings()`
+// off the result — upstream Pi's `SettingsManager` is sync and exposes those
+// accessors returning the raw settings layers, including arbitrary
+// extension-namespaced keys (like `piVim`) that the typed `get(path)` API
+// cannot reach. Before this fix the shim returned a `Promise<Settings>` with no
+// such accessors, so `s.getGlobalSettings is not a function` crashed the
+// extension's session_start handler and vim mode never installed. These tests
+// pin the sync-return + raw-layer-accessor contract through the public
+// package specifier.
+
+describe("SettingsManager legacy pi-compat accessors", () => {
+	let settingsState: SettingsTestState | undefined;
+	let tempDir: TempDir;
+	let agentDir: string;
+	let projectDir: string;
+
+	beforeEach(() => {
+		settingsState = beginSettingsTest();
+		tempDir = TempDir.createSync("@pi-settingsmanager-test-");
+		agentDir = tempDir.join("agent");
+		projectDir = tempDir.join("project");
+		fs.mkdirSync(agentDir, { recursive: true });
+		fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+	});
+
+	afterEach(async () => {
+		AgentStorage.resetInstance();
+		restoreSettingsTestState(settingsState);
+		settingsState = undefined;
+		await Bun.sleep(0);
+		await tempDir?.remove();
+	});
+
+	it("create(cwd) returns synchronously with getGlobalSettings/getProjectSettings and reads namespaced keys", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			YAML.stringify({ piVim: { modeColors: { normal: "blue" } } }, null, 2),
+		);
+		await Bun.write(
+			path.join(getProjectAgentDir(projectDir), "settings.json"),
+			JSON.stringify({ piVim: { modeColors: { insert: "green" } } }),
+		);
+
+		await Settings.init({ cwd: projectDir, agentDir });
+
+		// The plugin does `const s = SettingsManager.create(cwd)` and then reads
+		// accessors on the same tick — the result must NOT be a Promise.
+		const manager = SettingsManager.create(projectDir);
+		expect(manager).not.toBeInstanceOf(Promise);
+		expect(typeof manager.getGlobalSettings).toBe("function");
+		expect(typeof manager.getProjectSettings).toBe("function");
+
+		// Arbitrary extension-namespaced keys are visible through the raw layers.
+		expect(manager.getGlobalSettings().piVim).toEqual({ modeColors: { normal: "blue" } });
+		expect(manager.getProjectSettings().piVim).toEqual({ modeColors: { insert: "green" } });
+	});
+
+	it("getGlobalSettings returns a deep clone that cannot mutate internal state", async () => {
+		await Bun.write(
+			path.join(agentDir, "config.yml"),
+			YAML.stringify({ piVim: { modeColors: { normal: "blue" } } }, null, 2),
+		);
+		await Settings.init({ cwd: projectDir, agentDir });
+
+		const manager = SettingsManager.create(projectDir);
+		const layer = manager.getGlobalSettings();
+		const mutated = layer.piVim;
+		if (mutated && typeof mutated === "object" && "modeColors" in mutated) {
+			const modeColors = mutated.modeColors;
+			if (modeColors && typeof modeColors === "object") {
+				(modeColors as Record<string, unknown>).normal = "red";
+			}
+		}
+
+		// A fresh read is unaffected — the accessor handed out a clone.
+		expect(manager.getGlobalSettings().piVim).toEqual({ modeColors: { normal: "blue" } });
+	});
+
+	it("create() works before Settings.init() by returning an isolated instance with the accessors", () => {
+		resetSettingsForTest();
+
+		const manager = SettingsManager.create(projectDir);
+		expect(manager).toBeInstanceOf(Settings);
+		expect(manager).not.toBeInstanceOf(Promise);
+		expect(typeof manager.getGlobalSettings).toBe("function");
+		expect(typeof manager.getProjectSettings).toBe("function");
+		expect(manager.getGlobalSettings()).toEqual({});
+		expect(manager.getProjectSettings()).toEqual({});
+	});
+
+	it("inMemory() returns a usable Settings with the accessors present", () => {
+		const manager = SettingsManager.inMemory();
+		expect(manager).toBeInstanceOf(Settings);
+		expect(typeof manager.getGlobalSettings).toBe("function");
+		expect(typeof manager.getProjectSettings).toBe("function");
+		expect(manager.getGlobalSettings()).toEqual({});
+		expect(manager.getProjectSettings()).toEqual({});
+	});
+});


### PR DESCRIPTION
## Symptom

Legacy Pi extensions crash omp on startup:

```
Extension ".../pi-vim/index.ts" error: s.getGlobalSettings is not a function.
(In 's.getGlobalSettings()', 's.getGlobalSettings' is undefined)
```

`pi-vim/settings.ts` does:

```ts
import { SettingsManager } from "@earendil-works/pi-coding-agent";
const s = SettingsManager.create(cwd),  // omp returned Promise<Settings>
  g = s.getGlobalSettings(),            // Promise has no getGlobalSettings -> throws
  p = s.getProjectSettings();
```

It fires from pi-vim's `session_start` handler *before* it registers its editor component, so vim mode never installs — the plugin is fully non-functional. This breaks any pi extension that uses `SettingsManager`.

## Root cause

1. `src/extensibility/legacy-pi-coding-agent-shim.ts`: the shim's `SettingsManager.create(cwd)` returned `Settings.init({ cwd, agentDir })`, a `Promise<Settings>`. Upstream Pi's `SettingsManager.create(cwd)` is **synchronous** and returns a manager exposing `getGlobalSettings()`/`getProjectSettings()`.
2. `src/config/settings.ts`: the `Settings` class stored raw layers privately (`#global`, `#project`) and exposed only the typed, schema-bound `get(path)`. There was **no** public way to read an arbitrary namespaced key (like `piVim`) or the separate global/project layers, and no `getGlobalSettings`/`getProjectSettings`.

## Fix

- **`Settings`** now exposes `getGlobalSettings()` / `getProjectSettings()` that return `structuredClone`s of the raw global (`config.yml`) and project (`.claude/settings.yml`, etc.) layers, so callers can read arbitrary extension-namespaced keys the typed `get(path)` can't reach, and cannot mutate internal state.
- **`SettingsManager.create()`** is now synchronous: it returns the initialized `Settings` singleton (already scoped to the session cwd, which legacy callers pass as `ctx.cwd`) when a session is live, else an isolated instance. This matches upstream Pi's sync contract. Verified no internal omp code awaits the shim's `create()`; `sdk.ts` already accepts `Settings | Promise<Settings>` for `settingsManager`, so the narrowing is safe.
- `SettingsManager.inMemory()` continues to return an isolated `Settings` (now with the accessors present).

With this, `pi-vim` loads: `create(cwd)` is sync and `getGlobalSettings()` exists, so the `session_start` handler completes and the editor component registers.

## Tests

Added `test/extensibility/legacy-pi-settings-manager.test.ts` (mirrors the existing legacy-pi-compat tests, exercised through the public package specifier):
- `create(cwd)` returns **synchronously** (not a Promise) an object with `getGlobalSettings`/`getProjectSettings` as functions.
- Arbitrary namespaced keys (`piVim`) seeded into the global (`config.yml`) and project (`settings.json`) layers are readable via those accessors.
- The returned layer is a deep clone — mutating it does not affect a subsequent read.
- `create()` before `Settings.init()` returns an isolated instance with the accessors; `inMemory()` returns a usable `Settings` with the accessors.

Deterministic and isolated (temp dirs, no writes to the real `~/.omp`).

### Verification

- `bun install`, `bun check` — clean (no TS errors in touched files).
- `bun test packages/coding-agent/test/extensibility/` — 108 pass / 0 fail.
- `bun test packages/coding-agent/test/settings-manager.test.ts` — full settings suite still green.

## Notes

This is the same class of shim gap fixed reactively for other symbols — restore legacy extension shim exports (#2919), `DefaultResourceLoader` (#4567), `createFindToolDefinition` (#3808), `calculateCost` (#4584) — under the compatibility umbrella #2166. It follows the intentional-divergence policy in `docs/porting-from-pi-mono.md` §15, whose Extensions table row for `SettingsManager` is updated to document the new shimmed accessors.
