### PR TITLE
fix(web): cover compiled header fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,7 +30,7 @@
 ### Fixed
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
-- Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178), [#5208](https://github.com/can1357/oh-my-pi/issues/5208))
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/test/tools/web-search-browser-headers.test.ts
+++ b/packages/coding-agent/test/tools/web-search-browser-headers.test.ts
@@ -74,21 +74,42 @@ describe("browser navigation headers", () => {
 		expect(headers["Sec-Ch-Ua-Platform"]).toBe('"macOS"');
 	});
 
-	it("returns stable fallback headers when header-generator data files are unavailable", async () => {
+	it("returns stable fallback headers in compiled binaries when header-generator data files are unavailable", async () => {
 		const dataFilesDir = path.join(headerGeneratorRoot, "data_files");
 		const unavailableDataFilesDir = path.join(
 			headerGeneratorRoot,
 			`.data_files-unavailable-${process.pid}-${Date.now()}`,
 		);
+		const tempRoot = path.join(packageRoot, ".wt");
+		await fs.mkdir(tempRoot, { recursive: true });
+		const tempDir = await fs.mkdtemp(path.join(tempRoot, "browser-headers-"));
+		const entrypoint = path.join(tempDir, "entry.ts");
+		const outfile = path.join(tempDir, "browser-headers");
 
-		await fs.rename(dataFilesDir, unavailableDataFilesDir);
-		try {
-			const script = [
+		await Bun.write(
+			entrypoint,
+			[
 				'import { buildBrowserNavigationHeaders } from "@oh-my-pi/pi-coding-agent/web/search/providers/browser-headers";',
 				"const headers = buildBrowserNavigationHeaders();",
 				"process.stdout.write(JSON.stringify(headers));",
-			].join("\n");
-			const proc = Bun.spawn([process.execPath, "--no-install", "--eval", script], {
+			].join("\n"),
+		);
+
+		const build = await Bun.build({
+			entrypoints: [entrypoint],
+			root: packageRoot,
+			compile: {
+				outfile,
+			},
+			throw: false,
+		});
+		if (!build.success) {
+			throw new Error(`browser header compile failed:\n${build.logs.map(log => log.message).join("\n")}`);
+		}
+
+		await fs.rename(dataFilesDir, unavailableDataFilesDir);
+		try {
+			const proc = Bun.spawn([outfile], {
 				cwd: packageRoot,
 				stdout: "pipe",
 				stderr: "pipe",
@@ -101,12 +122,13 @@ describe("browser navigation headers", () => {
 			]);
 
 			if (exitCode !== 0) {
-				throw new Error(`browser header import failed with exit ${exitCode}:\n${stderr}`);
+				throw new Error(`compiled browser header probe failed with exit ${exitCode}:\n${stderr}`);
 			}
 
 			expect(JSON.parse(stdout)).toEqual(CHROME_FALLBACK_HEADERS);
 		} finally {
 			await fs.rename(unavailableDataFilesDir, dataFilesDir);
+			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
 


### PR DESCRIPTION
## Repro
Compiled a tiny Bun entrypoint that instantiates `header-generator`, moved `node_modules/header-generator/data_files` aside to simulate the released binary running without its build-time `node_modules`, and ran the executable. It exited with `ENOENT: no such file or directory, open '.../node_modules/header-generator/data_files/headers-order.json'`, matching the `web_search` failure reported for `providers.webSearch: perplexity`.

## Cause
`header-generator` reads `data_files/headers-order.json` through `__dirname` inside its constructor. In bundled executables that path points at the build machine's `node_modules`, so `packages/coding-agent/src/web/search/providers/browser-headers.ts` must treat generator construction as optional and fall back to the static Chrome profile when the data files are missing.

## Fix
- Replaced the source-process-only browser header fallback test with a compiled executable regression probe in `packages/coding-agent/test/tools/web-search-browser-headers.test.ts`.
- The probe compiles an entrypoint that calls `buildBrowserNavigationHeaders()`, hides `header-generator/data_files`, runs the compiled executable, and asserts the stable fallback headers are returned instead of surfacing `ENOENT`.
- Updated the coding-agent changelog entry to link the regression to #5208.

## Verification
`bun test test/tools/web-search-browser-headers.test.ts` in `packages/coding-agent`: 4 pass, 0 fail. Fixes #5208