### PR TITLE
feat(eval-rb): add lifecycle tests mirroring python executor suite

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `AssistantMessage.stopSequence` and surfaced the matched stop sequence through the Anthropic Messages server (`stop_reason: "stop_sequence"` + `stop_sequence`) for both non-streaming and streaming responses.
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic-messages-server.ts
+++ b/packages/ai/src/providers/anthropic-messages-server.ts
@@ -8,7 +8,6 @@ import type {
 	AssistantMessageEventStream,
 	Message,
 	RedactedThinkingContent,
-	StopReason,
 	TextContent,
 	ThinkingContent,
 	Tool,
@@ -430,8 +429,9 @@ function randomFallback(): string {
 	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-function mapStopReasonOut(reason: StopReason): "end_turn" | "max_tokens" | "tool_use" {
-	switch (reason) {
+function mapStopReasonOut(message: AssistantMessage): "end_turn" | "max_tokens" | "tool_use" | "stop_sequence" {
+	if (message.stopSequence != null) return "stop_sequence";
+	switch (message.stopReason) {
 		case "length":
 			return "max_tokens";
 		case "toolUse":
@@ -490,11 +490,8 @@ export function encodeResponse(message: AssistantMessage, requestedModelId: stri
 		role: "assistant",
 		model: requestedModelId,
 		content: encodeContentBlocks(message),
-		stop_reason: mapStopReasonOut(message.stopReason),
-		// TODO: surface the matched stop sequence once pi-ai's
-		// `AssistantMessage.stopReason` carries the matched string. Intentionally
-		// `null` for now (Anthropic schema allows it).
-		stop_sequence: null,
+		stop_reason: mapStopReasonOut(message),
+		stop_sequence: message.stopSequence ?? null,
 		usage: encodeUsage(message),
 	};
 }
@@ -566,8 +563,6 @@ export function encodeStream(
 							model: requestedModelId,
 							content: [],
 							stop_reason: null,
-							// TODO: same as encodeResponse — surface matched stop sequence
-							// once pi-ai propagates it.
 							stop_sequence: null,
 							usage: partial ? encodeUsage(partial) : ZERO_WIRE_USAGE,
 						},
@@ -696,15 +691,16 @@ export function encodeStream(
 							break;
 						case "done": {
 							for (const idx of [...open.keys()]) closeBlock(idx);
-							controller.enqueue(
-								sseFrame("message_delta", {
-									type: "message_delta",
-									// TODO: surface matched stop sequence once pi-ai
-									// propagates it on the `done` event.
-									delta: { stop_reason: mapStopReasonOut(ev.reason), stop_sequence: null },
-									usage: encodeUsage(ev.message),
-								}),
-							);
+								controller.enqueue(
+									sseFrame("message_delta", {
+										type: "message_delta",
+										delta: {
+											stop_reason: mapStopReasonOut(ev.message),
+											stop_sequence: ev.message.stopSequence ?? null,
+										},
+										usage: encodeUsage(ev.message),
+									}),
+								);
 							controller.enqueue(sseFrame("message_stop", { type: "message_stop" }));
 							controller.close();
 							return;
@@ -727,7 +723,10 @@ export function encodeStream(
 				controller.enqueue(
 					sseFrame("message_delta", {
 						type: "message_delta",
-						delta: { stop_reason: "end_turn", stop_sequence: null },
+						delta: {
+							stop_reason: lastPartial ? mapStopReasonOut(lastPartial) : "end_turn",
+							stop_sequence: lastPartial?.stopSequence ?? null,
+						},
 						usage: lastPartial ? encodeUsage(lastPartial) : ZERO_WIRE_USAGE,
 					}),
 				);

--- a/packages/ai/src/providers/anthropic-messages-server.ts
+++ b/packages/ai/src/providers/anthropic-messages-server.ts
@@ -598,6 +598,7 @@ export function encodeStream(
 					if (cancelled) return;
 					switch (ev.type) {
 						case "start":
+							lastPartial = ev.partial;
 							ensureStart(ev.partial);
 							break;
 						case "text_start": {
@@ -691,16 +692,16 @@ export function encodeStream(
 							break;
 						case "done": {
 							for (const idx of [...open.keys()]) closeBlock(idx);
-								controller.enqueue(
-									sseFrame("message_delta", {
-										type: "message_delta",
-										delta: {
-											stop_reason: mapStopReasonOut(ev.message),
-											stop_sequence: ev.message.stopSequence ?? null,
-										},
-										usage: encodeUsage(ev.message),
-									}),
-								);
+							controller.enqueue(
+								sseFrame("message_delta", {
+									type: "message_delta",
+									delta: {
+										stop_reason: mapStopReasonOut(ev.message),
+										stop_sequence: ev.message.stopSequence ?? null,
+									},
+									usage: encodeUsage(ev.message),
+								}),
+							);
 							controller.enqueue(sseFrame("message_stop", { type: "message_stop" }));
 							controller.close();
 							return;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2330,6 +2330,9 @@ const streamAnthropicOnce = (
 								output.stopReason = mapStopReason(rawStopReason);
 								sawTerminalEnvelope = true;
 							}
+							if (delta?.stop_sequence != null) {
+								output.stopSequence = delta.stop_sequence;
+							}
 							if (output.stopReason === "error") {
 								const stopDetails = delta?.stop_details;
 								output.stopDetails = stopDetails ?? (rawStopReason ? { type: rawStopReason } : null);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2445,6 +2445,7 @@ const streamAnthropicOnce = (
 						output.providerPayload = undefined;
 						output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
 						output.stopReason = "stop";
+						output.stopSequence = undefined;
 						firstTokenTime = undefined;
 						continue;
 					}
@@ -2478,6 +2479,7 @@ const streamAnthropicOnce = (
 						output.providerPayload = undefined;
 						output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
 						output.stopReason = "stop";
+						output.stopSequence = undefined;
 						firstTokenTime = undefined;
 						continue;
 					}
@@ -2505,6 +2507,7 @@ const streamAnthropicOnce = (
 						output.providerPayload = undefined;
 						output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
 						output.stopReason = "stop";
+						output.stopSequence = undefined;
 						firstTokenTime = undefined;
 						continue;
 					}
@@ -2549,6 +2552,7 @@ const streamAnthropicOnce = (
 					output.providerPayload = undefined;
 					output.usage = createEmptyUsage(copilotDynamicHeaders?.premiumRequests);
 					output.stopReason = "stop";
+					output.stopSequence = undefined;
 					firstTokenTime = undefined;
 				}
 			}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -740,6 +740,13 @@ export interface AssistantMessage {
 	usage: Usage;
 	stopReason: StopReason;
 	stopDetails?: StopDetails | null;
+	/**
+	 * The stop sequence string the model matched to end the turn, when the
+	 * provider reports one (e.g. Anthropic `stop_reason: "stop_sequence"` with
+	 * a `message_delta.delta.stop_sequence`). `undefined`/`null` when the turn
+	 * ended for any other reason (natural stop, length, tool use, error).
+	 */
+	stopSequence?: string | null;
 	errorMessage?: string;
 	/** Per-tool abort messages used when an aborted assistant turn needs different placeholder results per tool call. */
 	toolCallAbortMessages?: Record<string, string>;

--- a/packages/ai/test/anthropic-messages-server-stop-sequence-roundtrip.test.ts
+++ b/packages/ai/test/anthropic-messages-server-stop-sequence-roundtrip.test.ts
@@ -88,8 +88,9 @@ describe("anthropic provider stop sequence (parser round-trip)", () => {
 		// error enters the generic retry path (the provider will NOT retry once
 		// it has replayed text to the consumer). The second attempt succeeds
 		// cleanly; the final message must NOT retain the stale stop_sequence.
-		const broken =
-			frame("message_start", {
+		const broken = sseResponse([
+			{
+				type: "message_start",
 				message: {
 					id: "msg_1",
 					type: "message",
@@ -100,10 +101,17 @@ describe("anthropic provider stop sequence (parser round-trip)", () => {
 					stop_sequence: null,
 					usage: { input_tokens: 5, output_tokens: 0 },
 				},
-			}) +
-			frame("message_delta", messageDelta("stop_sequence", "STALE")) +
-			// Truncated JSON → transient stream-parse error → retry.
-			'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"stop_sequence"';
+			},
+			messageDelta("stop_sequence", "STALE"),
+			// A real, retryable Anthropic error SSE frame: the parser throws this
+			// outward (anthropic.ts:1368) as an overloaded_error, which the retry
+			// classifier treats as retryable. With no content streamed yet, the
+			// generic provider-retry path fires a second fetch.
+			{
+				type: "error",
+				error: { type: "overloaded_error", message: "Overloaded" },
+			},
+		]);
 
 		const clean = sseResponse([
 			{
@@ -126,10 +134,7 @@ describe("anthropic provider stop sequence (parser round-trip)", () => {
 			{ type: "message_stop" },
 		]);
 
-		const { fetch, calls } = makeFetchMock([
-			() => new Response(broken, { status: 200, headers: { "content-type": "text/event-stream" } }),
-			() => clean,
-		]);
+		const { fetch, calls } = makeFetchMock([() => broken, () => clean]);
 
 		const stream = streamAnthropic(makeModel(), makeContext(), { fetch, providerRetryWait: async () => {} });
 		const message = await stream.result();

--- a/packages/ai/test/anthropic-messages-server-stop-sequence-roundtrip.test.ts
+++ b/packages/ai/test/anthropic-messages-server-stop-sequence-roundtrip.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import type { Context, FetchImpl, Model } from "@oh-my-pi/pi-ai";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+
+function makeModel() {
+	return {
+		id: "claude-sonnet-4-5",
+		name: "claude-sonnet-4-5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	} as unknown as Model<"anthropic-messages">;
+}
+
+function makeContext(): Context {
+	return { messages: [{ role: "user", content: "hi" }] as Context["messages"] };
+}
+
+function frame(type: string, data: unknown): string {
+	return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function sseResponse(events: Array<Record<string, unknown>>): Response {
+	const body = events.map(e => frame(e.type as string, e)).join("");
+	return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+function messageDelta(
+	stopReason: string,
+	stopSequence: string | null,
+	usage = { input_tokens: 5, output_tokens: 3 },
+): Record<string, unknown> {
+	return { type: "message_delta", delta: { stop_reason: stopReason, stop_sequence: stopSequence, usage } };
+}
+
+function makeFetchMock(responses: Array<() => Response>): { fetch: FetchImpl } {
+	let i = 0;
+	const fetchImpl = (async (_input: unknown, _init?: unknown) => {
+		const handler = responses[Math.min(i, responses.length - 1)];
+		i++;
+		return handler();
+	}) as unknown as FetchImpl;
+	return { fetch: fetchImpl };
+}
+
+describe("anthropic provider stop sequence (parser round-trip)", () => {
+	it("captures stop_sequence from the raw message_delta SSE frame", async () => {
+		const { fetch } = makeFetchMock([
+			() =>
+				sseResponse([
+					{
+						type: "message_start",
+						message: {
+							id: "msg_1",
+							type: "message",
+							role: "assistant",
+							model: "claude-sonnet-4-5",
+							content: [],
+							stop_reason: null,
+							stop_sequence: null,
+							usage: { input_tokens: 5, output_tokens: 3 },
+						},
+					},
+					{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+					{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hi" } },
+					{ type: "content_block_stop", index: 0 },
+					messageDelta("stop_sequence", "STOP_HERE"),
+					{ type: "message_stop" },
+				]),
+		]);
+
+		const stream = streamAnthropic(makeModel(), makeContext(), { fetch });
+		const message = await stream.result();
+
+		expect(message.stopSequence).toBe("STOP_HERE");
+		expect(message.stopReason).toBe("stop");
+	});
+
+	it("clears a stale stop_sequence from a prior attempt on retry", async () => {
+		// First attempt streams a stop_sequence but then fails with a malformed
+		// trailing frame (transient stream-parse error) → the provider retries.
+		// The second attempt succeeds cleanly; the final message must NOT retain
+		// the stale stop_sequence.
+		const broken =
+			frame("message_start", {
+				message: {
+					id: "msg_1",
+					type: "message",
+					role: "assistant",
+					model: "claude-sonnet-4-5",
+					content: [],
+					stop_reason: null,
+					stop_sequence: null,
+					usage: { input_tokens: 5, output_tokens: 0 },
+				},
+			}) +
+			frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }) +
+			frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "hi" } }) +
+			frame("content_block_stop", { index: 0 }) +
+			frame("message_delta", messageDelta("stop_sequence", "STALE")) +
+			// Malformed trailing frame (missing closing braces) → transient parse error → retry.
+			'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"STALE","usage":{"input_tokens":5,"output_tokens":3}}\n\n';
+
+		const clean = sseResponse([
+			{
+				type: "message_start",
+				message: {
+					id: "msg_2",
+					type: "message",
+					role: "assistant",
+					model: "claude-sonnet-4-5",
+					content: [],
+					stop_reason: null,
+					stop_sequence: null,
+					usage: { input_tokens: 5, output_tokens: 3 },
+				},
+			},
+			{ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+			{ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+			{ type: "content_block_stop", index: 0 },
+			messageDelta("end_turn", null),
+			{ type: "message_stop" },
+		]);
+
+		const { fetch } = makeFetchMock([
+			() => new Response(broken, { status: 200, headers: { "content-type": "text/event-stream" } }),
+			() => clean,
+		]);
+
+		const stream = streamAnthropic(makeModel(), makeContext(), { fetch });
+		const message = await stream.result();
+
+		expect(message.stopSequence).toBeUndefined();
+		expect(message.stopReason).toBe("stop");
+	});
+});

--- a/packages/ai/test/anthropic-messages-server-stop-sequence-roundtrip.test.ts
+++ b/packages/ai/test/anthropic-messages-server-stop-sequence-roundtrip.test.ts
@@ -35,17 +35,17 @@ function messageDelta(
 	stopSequence: string | null,
 	usage = { input_tokens: 5, output_tokens: 3 },
 ): Record<string, unknown> {
-	return { type: "message_delta", delta: { stop_reason: stopReason, stop_sequence: stopSequence, usage } };
+	return { type: "message_delta", delta: { stop_reason: stopReason, stop_sequence: stopSequence }, usage };
 }
 
-function makeFetchMock(responses: Array<() => Response>): { fetch: FetchImpl } {
+function makeFetchMock(responses: Array<() => Response>): { fetch: FetchImpl; calls: () => number } {
 	let i = 0;
 	const fetchImpl = (async (_input: unknown, _init?: unknown) => {
 		const handler = responses[Math.min(i, responses.length - 1)];
 		i++;
 		return handler();
 	}) as unknown as FetchImpl;
-	return { fetch: fetchImpl };
+	return { fetch: fetchImpl, calls: () => i };
 }
 
 describe("anthropic provider stop sequence (parser round-trip)", () => {
@@ -82,10 +82,12 @@ describe("anthropic provider stop sequence (parser round-trip)", () => {
 	});
 
 	it("clears a stale stop_sequence from a prior attempt on retry", async () => {
-		// First attempt streams a stop_sequence but then fails with a malformed
-		// trailing frame (transient stream-parse error) → the provider retries.
-		// The second attempt succeeds cleanly; the final message must NOT retain
-		// the stale stop_sequence.
+		// First attempt sets a stop_sequence but then fails with a malformed
+		// trailing frame (transient stream-parse error). No content blocks are
+		// streamed, so streamedReplayUnsafeContent stays false and the parse
+		// error enters the generic retry path (the provider will NOT retry once
+		// it has replayed text to the consumer). The second attempt succeeds
+		// cleanly; the final message must NOT retain the stale stop_sequence.
 		const broken =
 			frame("message_start", {
 				message: {
@@ -99,12 +101,9 @@ describe("anthropic provider stop sequence (parser round-trip)", () => {
 					usage: { input_tokens: 5, output_tokens: 0 },
 				},
 			}) +
-			frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }) +
-			frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "hi" } }) +
-			frame("content_block_stop", { index: 0 }) +
 			frame("message_delta", messageDelta("stop_sequence", "STALE")) +
-			// Malformed trailing frame (missing closing braces) → transient parse error → retry.
-			'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"STALE","usage":{"input_tokens":5,"output_tokens":3}}\n\n';
+			// Truncated JSON → transient stream-parse error → retry.
+			'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"stop_sequence"';
 
 		const clean = sseResponse([
 			{
@@ -127,15 +126,18 @@ describe("anthropic provider stop sequence (parser round-trip)", () => {
 			{ type: "message_stop" },
 		]);
 
-		const { fetch } = makeFetchMock([
+		const { fetch, calls } = makeFetchMock([
 			() => new Response(broken, { status: 200, headers: { "content-type": "text/event-stream" } }),
 			() => clean,
 		]);
 
-		const stream = streamAnthropic(makeModel(), makeContext(), { fetch });
+		const stream = streamAnthropic(makeModel(), makeContext(), { fetch, providerRetryWait: async () => {} });
 		const message = await stream.result();
 
 		expect(message.stopSequence).toBeUndefined();
 		expect(message.stopReason).toBe("stop");
+		// Proves a retry actually happened (broken → clean), so the stale
+		// stop_sequence was reset by the retry path rather than never set.
+		expect(calls()).toBe(2);
 	});
 });

--- a/packages/ai/test/anthropic-messages-server-stop-sequence-server.test.ts
+++ b/packages/ai/test/anthropic-messages-server-stop-sequence-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { encodeResponse, encodeStream } from "@oh-my-pi/pi-ai/providers/anthropic-messages-server";
-import type { AssistantMessage, AssistantMessageEventStream } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "../src/utils/event-stream";
 
 function makeMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
 	return {
@@ -8,8 +9,16 @@ function makeMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessag
 		content: [],
 		api: "anthropic-messages" as AssistantMessage["api"],
 		provider: "anthropic",
-		model: "claude-sonnet-4-0",
-		usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		timestamp: 0,
 		stopReason: "stop",
 		...overrides,
 	};
@@ -34,38 +43,66 @@ function collectSse(stream: ReadableStream<Uint8Array>): Promise<Record<string, 
 	})();
 }
 
-function lastStopSequence(frames: Record<string, unknown>[]): { stop_reason: unknown; stop_sequence: unknown } | undefined {
-	const deltas = frames.filter((f) => f.event === "message_delta");
+function lastStopSequence(
+	frames: Record<string, unknown>[],
+): { stop_reason: unknown; stop_sequence: unknown } | undefined {
+	const deltas = frames.filter(f => f.event === "message_delta");
 	const last = deltas[deltas.length - 1] as { delta?: { stop_reason?: unknown; stop_sequence?: unknown } } | undefined;
 	return last?.delta ? { stop_reason: last.delta.stop_reason, stop_sequence: last.delta.stop_sequence } : undefined;
 }
 
-describe("anthropic-messages-server stop sequence", () => {
+describe("anthropic-messages-server stop sequence (encoder)", () => {
 	it("encodes a matched stop sequence in the non-streaming response", () => {
-		const res = encodeResponse(makeMessage({ stopSequence: "DONE" }), "claude-sonnet-4-0") as Record<string, unknown>;
+		const res = encodeResponse(makeMessage({ stopSequence: "DONE" }), "claude-sonnet-4-5") as Record<string, unknown>;
 		expect(res.stop_reason).toBe("stop_sequence");
 		expect(res.stop_sequence).toBe("DONE");
 	});
 
 	it("emits end_turn with null stop_sequence when none matched", () => {
-		const res = encodeResponse(makeMessage(), "claude-sonnet-4-0") as Record<string, unknown>;
+		const res = encodeResponse(makeMessage(), "claude-sonnet-4-5") as Record<string, unknown>;
 		expect(res.stop_reason).toBe("end_turn");
 		expect(res.stop_sequence).toBeNull();
 	});
 
 	it("keeps tool_use mapping when no stop sequence matched", () => {
-		const res = encodeResponse(makeMessage({ stopReason: "toolUse" }), "claude-sonnet-4-0") as Record<string, unknown>;
+		const res = encodeResponse(makeMessage({ stopReason: "toolUse" }), "claude-sonnet-4-5") as Record<
+			string,
+			unknown
+		>;
 		expect(res.stop_reason).toBe("tool_use");
 		expect(res.stop_sequence).toBeNull();
 	});
+});
 
+describe("anthropic-messages-server stop sequence (streaming)", () => {
 	it("surfaces the matched stop sequence on the streaming message_delta", async () => {
 		const message = makeMessage({ stopSequence: "STOP_HERE" });
 		const events = new AssistantMessageEventStream() as AssistantMessageEventStream;
 		events.push({ type: "start", partial: message });
 		events.push({ type: "done", reason: "stop", message });
 
-		const frames = await collectSse(encodeStream(events, "claude-sonnet-4-0"));
+		const frames = await collectSse(encodeStream(events, "claude-sonnet-4-5"));
+		const delta = lastStopSequence(frames);
+		expect(delta?.stop_reason).toBe("stop_sequence");
+		expect(delta?.stop_sequence).toBe("STOP_HERE");
+	});
+
+	it("falls back to the last partial when the stream ends without an explicit done", async () => {
+		const message = makeMessage();
+		const events = new AssistantMessageEventStream() as AssistantMessageEventStream;
+		events.push({ type: "start", partial: message });
+		message.stopSequence = "STOP_HERE";
+		message.usage = {
+			input: 5,
+			output: 3,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 8,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		};
+		events.end(message);
+
+		const frames = await collectSse(encodeStream(events, "claude-sonnet-4-5"));
 		const delta = lastStopSequence(frames);
 		expect(delta?.stop_reason).toBe("stop_sequence");
 		expect(delta?.stop_sequence).toBe("STOP_HERE");

--- a/packages/ai/test/anthropic-messages-server-stop-sequence.test.ts
+++ b/packages/ai/test/anthropic-messages-server-stop-sequence.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { encodeResponse, encodeStream } from "@oh-my-pi/pi-ai/providers/anthropic-messages-server";
+import type { AssistantMessage, AssistantMessageEventStream } from "@oh-my-pi/pi-ai";
+
+function makeMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages" as AssistantMessage["api"],
+		provider: "anthropic",
+		model: "claude-sonnet-4-0",
+		usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+		stopReason: "stop",
+		...overrides,
+	};
+}
+
+function collectSse(stream: ReadableStream<Uint8Array>): Promise<Record<string, unknown>[]> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	const frames: Record<string, unknown>[] = [];
+	return (async () => {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			const text = decoder.decode(value, { stream: true });
+			for (const block of text.split("\n\n")) {
+				const event = block.match(/event: (\S+)/)?.[1];
+				const data = block.match(/data: (\{.*\})/s)?.[1];
+				if (event && data) frames.push({ event, ...JSON.parse(data) });
+			}
+		}
+		return frames;
+	})();
+}
+
+function lastStopSequence(frames: Record<string, unknown>[]): { stop_reason: unknown; stop_sequence: unknown } | undefined {
+	const deltas = frames.filter((f) => f.event === "message_delta");
+	const last = deltas[deltas.length - 1] as { delta?: { stop_reason?: unknown; stop_sequence?: unknown } } | undefined;
+	return last?.delta ? { stop_reason: last.delta.stop_reason, stop_sequence: last.delta.stop_sequence } : undefined;
+}
+
+describe("anthropic-messages-server stop sequence", () => {
+	it("encodes a matched stop sequence in the non-streaming response", () => {
+		const res = encodeResponse(makeMessage({ stopSequence: "DONE" }), "claude-sonnet-4-0") as Record<string, unknown>;
+		expect(res.stop_reason).toBe("stop_sequence");
+		expect(res.stop_sequence).toBe("DONE");
+	});
+
+	it("emits end_turn with null stop_sequence when none matched", () => {
+		const res = encodeResponse(makeMessage(), "claude-sonnet-4-0") as Record<string, unknown>;
+		expect(res.stop_reason).toBe("end_turn");
+		expect(res.stop_sequence).toBeNull();
+	});
+
+	it("keeps tool_use mapping when no stop sequence matched", () => {
+		const res = encodeResponse(makeMessage({ stopReason: "toolUse" }), "claude-sonnet-4-0") as Record<string, unknown>;
+		expect(res.stop_reason).toBe("tool_use");
+		expect(res.stop_sequence).toBeNull();
+	});
+
+	it("surfaces the matched stop sequence on the streaming message_delta", async () => {
+		const message = makeMessage({ stopSequence: "STOP_HERE" });
+		const events = new AssistantMessageEventStream() as AssistantMessageEventStream;
+		events.push({ type: "start", partial: message });
+		events.push({ type: "done", reason: "stop", message });
+
+		const frames = await collectSse(encodeStream(events, "claude-sonnet-4-0"));
+		const delta = lastStopSequence(frames);
+		expect(delta?.stop_reason).toBe("stop_sequence");
+		expect(delta?.stop_sequence).toBe("STOP_HERE");
+	});
+});


### PR DESCRIPTION
## What

Adds `packages/coding-agent/test/core/ruby-executor-lifecycle.test.ts`, mirroring the Python executor lifecycle suite for the Ruby eval kernel. Covers session reuse, reset, dead-kernel restart, failure-triggered restart, unconfirmed-shutdown restart, and concurrent reset coalescing.

## Why

The Ruby eval kernel (`src/eval/rb/kernel.ts`) has no covering tests while the Python kernel has a full suite. This is the first of a planned set of PRs bringing rb/jl kernels to parity with Python (see #5214).

## Testing

- `bun test packages/coding-agent/test/core/ruby-executor-lifecycle.test.ts` → 6 pass
- `bun check` (per-file tsgo type check) → exit 0

Note: Ruby/Julia executors are **session-mode only** (no `per-call`), so those Python cases are intentionally omitted.

Fixes #5214

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated