### PR TITLE
fix(coding-agent): accept Auto-Learn capture empty stops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed `autolearn.autoContinue` treating the hidden capture turn's terminal empty assistant stop as a retryable empty response instead of successful completion. ([#5211](https://github.com/can1357/oh-my-pi/issues/5211))
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/src/autolearn/controller.ts
+++ b/packages/coding-agent/src/autolearn/controller.ts
@@ -132,7 +132,7 @@ export class AutoLearnController {
 					display: false,
 					attribution: "user",
 				},
-				{ deliverAs: "nextTurn", triggerTurn: true },
+				{ deliverAs: "nextTurn", triggerTurn: true, acceptTerminalEmptyStop: true },
 			)
 			.then(started => {
 				if (!started) this.#suppressNext = false;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1846,6 +1846,7 @@ export class AgentSession {
 	// on `agent_end` can fire its next `prompt` before #promptWithMessage's finally
 	#emptyStopRetryCount = 0;
 	#unexpectedStopRetryCount = 0;
+	#acceptTerminalEmptyStopForPrompt = false;
 	#promptGeneration = 0;
 	#pendingAgentEndEmit: AgentSessionEvent | undefined;
 	#pendingContextSnapshot:
@@ -1886,6 +1887,7 @@ export class AgentSession {
 		this.#emptyStopRetryCount = 0;
 		this.#unexpectedStopRetryCount = 0;
 		this.#yieldTerminationPending = false;
+		this.#acceptTerminalEmptyStopForPrompt = false;
 	}
 
 	#acquirePowerAssertion(): void {
@@ -7794,6 +7796,7 @@ export class AgentSession {
 		options?: Pick<PromptOptions, "toolChoice" | "images" | "skipCompactionCheck"> & {
 			prependMessages?: AgentMessage[];
 			skipPostPromptRecoveryWait?: boolean;
+			acceptTerminalEmptyStop?: boolean;
 		},
 	): Promise<void> {
 		this.#beginInFlight();
@@ -7810,6 +7813,7 @@ export class AgentSession {
 			this.#mutationsSinceLastTodoTouch = 0;
 			this.#midRunNudgeCount = 0;
 			this.#resetPromptMaintenanceState();
+			this.#acceptTerminalEmptyStopForPrompt = options?.acceptTerminalEmptyStop === true;
 
 			await this.#maybeRestoreRetryFallbackPrimary();
 
@@ -8349,9 +8353,16 @@ export class AgentSession {
 		}
 	}
 
-	async #promptAgentInitiatedMessage(message: CustomMessage): Promise<void> {
+	async #promptAgentInitiatedMessage(
+		message: CustomMessage,
+		options?: { acceptTerminalEmptyStop?: boolean },
+	): Promise<void> {
 		this.#beginInFlight();
 		try {
+			if (options?.acceptTerminalEmptyStop) {
+				this.#resetPromptMaintenanceState();
+				this.#acceptTerminalEmptyStopForPrompt = true;
+			}
 			await this.agent.prompt(message);
 			await this.#waitForPostPromptRecovery();
 		} finally {
@@ -8409,7 +8420,12 @@ export class AgentSession {
 	 */
 	async sendCustomMessage<T = unknown>(
 		message: CustomMessagePayload<T>,
-		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn"; queueChipText?: string },
+		options?: {
+			triggerTurn?: boolean;
+			deliverAs?: "steer" | "followUp" | "nextTurn";
+			queueChipText?: string;
+			acceptTerminalEmptyStop?: boolean;
+		},
 	): Promise<boolean> {
 		const normalizedPayload = normalizeCustomMessagePayload<T>(message);
 		const details =
@@ -8452,7 +8468,9 @@ export class AgentSession {
 					this.#queueHiddenNextTurnMessage(normalizedAppMessage, false);
 					return false;
 				}
-				await this.#promptAgentInitiatedMessage(normalizedAppMessage);
+				await this.#promptAgentInitiatedMessage(normalizedAppMessage, {
+					acceptTerminalEmptyStop: options.acceptTerminalEmptyStop === true,
+				});
 				return true;
 			}
 			this.agent.appendMessage(normalizedAppMessage);
@@ -10958,6 +10976,12 @@ export class AgentSession {
 
 	async #handleEmptyAssistantStop(assistantMessage: AssistantMessage): Promise<boolean> {
 		if (!this.#isEmptyAssistantStop(assistantMessage)) {
+			this.#emptyStopRetryCount = 0;
+			return false;
+		}
+
+		if (this.#acceptTerminalEmptyStopForPrompt && assistantMessage.stopReason === "stop") {
+			this.#acceptTerminalEmptyStopForPrompt = false;
 			this.#emptyStopRetryCount = 0;
 			return false;
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8359,13 +8359,15 @@ export class AgentSession {
 	): Promise<void> {
 		this.#beginInFlight();
 		try {
-			if (options?.acceptTerminalEmptyStop) {
+			const acceptTerminalEmptyStop = options?.acceptTerminalEmptyStop === true;
+			if (acceptTerminalEmptyStop) {
 				this.#resetPromptMaintenanceState();
-				this.#acceptTerminalEmptyStopForPrompt = true;
 			}
+			this.#acceptTerminalEmptyStopForPrompt = acceptTerminalEmptyStop;
 			await this.agent.prompt(message);
 			await this.#waitForPostPromptRecovery();
 		} finally {
+			this.#acceptTerminalEmptyStopForPrompt = false;
 			this.#endInFlight();
 		}
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -10984,6 +10984,7 @@ export class AgentSession {
 
 		if (this.#acceptTerminalEmptyStopForPrompt && assistantMessage.stopReason === "stop") {
 			this.#acceptTerminalEmptyStopForPrompt = false;
+			this.#discardAcceptedTerminalEmptyStop(assistantMessage);
 			this.#emptyStopRetryCount = 0;
 			return false;
 		}
@@ -11203,6 +11204,37 @@ export class AgentSession {
 			return;
 		}
 		this.agent.appendMessage(assistantMessage);
+	}
+
+	#discardAcceptedTerminalEmptyStop(assistantMessage: AssistantMessage): void {
+		const branch = this.sessionManager.getBranch();
+		const branchEntry = branch
+			.slice()
+			.reverse()
+			.find(
+				entry =>
+					entry.type === "message" &&
+					entry.message.role === "assistant" &&
+					this.#isSameAssistantMessage(entry.message, assistantMessage),
+			);
+		const parentEntry =
+			branchEntry?.parentId === null || branchEntry?.parentId === undefined
+				? undefined
+				: branch.find(entry => entry.id === branchEntry.parentId);
+		const prunePrompt = parentEntry?.type === "custom_message";
+
+		this.#removeAssistantMessageFromActiveContext(assistantMessage, "accepted-terminal-empty-stop");
+		if (prunePrompt && this.agent.state.messages.at(-1)?.role === "custom") {
+			this.agent.replaceMessages(this.agent.state.messages.slice(0, -1));
+		}
+
+		if (!branchEntry) return;
+		const targetParentId = prunePrompt ? parentEntry.parentId : branchEntry.parentId;
+		if (targetParentId === null) {
+			this.sessionManager.resetLeaf();
+		} else {
+			this.sessionManager.branch(targetParentId);
+		}
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -4,6 +4,7 @@ import { scheduler } from "node:timers/promises";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { z } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { AutoLearnController } from "@oh-my-pi/pi-coding-agent/autolearn/controller";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -397,6 +398,54 @@ describe("AgentSession empty stop guard", () => {
 		});
 		expect(session.isRetrying).toBe(false);
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
+	});
+
+	it("accepts an auto-learn capture turn that ends with an empty terminal stop", async () => {
+		const { session, mock } = await createHarness(
+			[
+				recordCall("learn-alpha", "call-record-learn-alpha"),
+				recordCall("learn-beta", "call-record-learn-beta"),
+				{ content: ["normal turn complete"], stopReason: "stop" },
+				emptyStop(),
+				emptyStop(),
+				emptyStop(),
+				emptyStop(),
+			],
+			{
+				"autolearn.enabled": true,
+				"autolearn.autoContinue": true,
+				"autolearn.minToolCalls": 2,
+			},
+		);
+		const retryEndEvents: Array<Extract<AgentSessionEvent, { type: "auto_retry_end" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+		new AutoLearnController({ session, settings: session.settings });
+
+		await session.prompt("record enough facts for auto-learn");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(4);
+		expect(assistantText(session.agent.state.messages)).toContain("normal turn complete");
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
+		expect(retryEndEvents.filter(event => event.success === false)).toEqual([]);
+		expect(emptyAssistantStops(session.agent.state.messages)).toHaveLength(1);
+		const captureCall = mock.calls[3];
+		if (!captureCall) throw new Error("Expected auto-learn capture turn to call the model");
+		const messageHasText = (message: (typeof captureCall.context.messages)[number], text: string): boolean => {
+			const { content } = message;
+			if (typeof content === "string") return content.includes(text);
+			return (
+				Array.isArray(content) &&
+				content.some(block => "text" in block && typeof block.text === "string" && block.text.includes(text))
+			);
+		};
+		expect(
+			captureCall.context.messages.some(message =>
+				messageHasText(message, "If your previous turn produced anything reusable"),
+			),
+		).toBe(true);
 	});
 
 	it("does not retry normal stop or tool-use turns", async () => {

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -448,6 +448,61 @@ describe("AgentSession empty stop guard", () => {
 		).toBe(true);
 	});
 
+	it("does not let a non-opt-in custom turn inherit auto-learn terminal empty-stop acceptance", async () => {
+		const { session, mock } = await createHarness(
+			[
+				recordCall("learn-alpha", "call-record-learn-alpha"),
+				recordCall("learn-beta", "call-record-learn-beta"),
+				{ content: ["normal turn complete"], stopReason: "stop" },
+				{ content: ["auto-learn captured non-empty text"], stopReason: "stop" },
+				emptyStop(),
+				emptyStop(),
+				emptyStop(),
+				emptyStop(),
+			],
+			{
+				"autolearn.enabled": true,
+				"autolearn.autoContinue": true,
+				"autolearn.minToolCalls": 2,
+			},
+		);
+		const retryEndEvents: Array<Extract<AgentSessionEvent, { type: "auto_retry_end" }>> = [];
+		session.subscribe(event => {
+			if (event.type === "auto_retry_end") retryEndEvents.push(event);
+		});
+		new AutoLearnController({ session, settings: session.settings });
+
+		await session.prompt("record enough facts for auto-learn");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(4);
+		expect(assistantText(session.agent.state.messages)).toContain("auto-learn captured non-empty text");
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
+
+		await expectPromptCompletes(
+			session.sendCustomMessage(
+				{
+					customType: "advisor",
+					content: "check",
+					display: false,
+					attribution: "agent",
+				},
+				{ triggerTurn: true },
+			),
+		);
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(8);
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(3);
+		expect(retryEndEvents).toHaveLength(1);
+		expect(retryEndEvents[0]).toMatchObject({
+			type: "auto_retry_end",
+			success: false,
+			attempt: 3,
+		});
+		expect(retryEndEvents[0]?.finalError).toContain("empty stop");
+	});
+
 	it("does not retry normal stop or tool-use turns", async () => {
 		const normal = await createHarness([{ content: ["already done"], stopReason: "stop" }]);
 

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -407,9 +407,6 @@ describe("AgentSession empty stop guard", () => {
 				recordCall("learn-beta", "call-record-learn-beta"),
 				{ content: ["normal turn complete"], stopReason: "stop" },
 				emptyStop(),
-				emptyStop(),
-				emptyStop(),
-				emptyStop(),
 			],
 			{
 				"autolearn.enabled": true,
@@ -430,7 +427,19 @@ describe("AgentSession empty stop guard", () => {
 		expect(assistantText(session.agent.state.messages)).toContain("normal turn complete");
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
 		expect(retryEndEvents.filter(event => event.success === false)).toEqual([]);
-		expect(emptyAssistantStops(session.agent.state.messages)).toHaveLength(1);
+		expect(emptyAssistantStops(session.agent.state.messages)).toHaveLength(0);
+
+		const branchMessagesAfterCapture = session.sessionManager
+			.getBranch()
+			.filter(entry => entry.type === "message")
+			.map(entry => entry.message as AgentMessage);
+		expect(emptyAssistantStops(branchMessagesAfterCapture)).toHaveLength(0);
+		expect(
+			session.sessionManager
+				.getBranch()
+				.some(entry => entry.type === "custom_message" && entry.customType === "autolearn-nudge"),
+		).toBe(false);
+
 		const captureCall = mock.calls[3];
 		if (!captureCall) throw new Error("Expected auto-learn capture turn to call the model");
 		const messageHasText = (message: (typeof captureCall.context.messages)[number], text: string): boolean => {
@@ -441,11 +450,30 @@ describe("AgentSession empty stop guard", () => {
 				content.some(block => "text" in block && typeof block.text === "string" && block.text.includes(text))
 			);
 		};
+		const autoLearnNudgeText = "If your previous turn produced anything reusable";
+		expect(captureCall.context.messages.some(message => messageHasText(message, autoLearnNudgeText))).toBe(true);
+
+		mock.push({ content: ["next real turn complete"], stopReason: "stop" });
+		await session.prompt("next real prompt after auto-learn no-op");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(5);
+		const nextPromptCall = mock.calls[4];
+		if (!nextPromptCall) throw new Error("Expected next real prompt to call the model");
+		expect(nextPromptCall.context.messages.some(message => messageHasText(message, autoLearnNudgeText))).toBe(false);
+		expect(assistantText(session.agent.state.messages)).toContain("next real turn complete");
+		expect(emptyAssistantStops(session.agent.state.messages)).toHaveLength(0);
+
+		const branchMessagesAfterNextPrompt = session.sessionManager
+			.getBranch()
+			.filter(entry => entry.type === "message")
+			.map(entry => entry.message as AgentMessage);
+		expect(emptyAssistantStops(branchMessagesAfterNextPrompt)).toHaveLength(0);
 		expect(
-			captureCall.context.messages.some(message =>
-				messageHasText(message, "If your previous turn produced anything reusable"),
-			),
-		).toBe(true);
+			session.sessionManager
+				.getBranch()
+				.some(entry => entry.type === "custom_message" && entry.customType === "autolearn-nudge"),
+		).toBe(false);
 	});
 
 	it("does not let a non-opt-in custom turn inherit auto-learn terminal empty-stop acceptance", async () => {


### PR DESCRIPTION
## Repro
With `autolearn.enabled: true`, `autolearn.autoContinue: true`, and enough tool calls to trigger Auto-Learn, the hidden `autolearn-nudge` capture turn can legally end with an empty assistant `stop` after the model captures nothing or finishes after `learn`; the pre-fix focused regression `bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts -t auto-learn` observed seven mock model calls instead of four because that terminal empty stop was retried three times.

## Cause
`AutoLearnController` sent the capture nudge through `AgentSession.sendCustomMessage(..., { deliverAs: "nextTurn", triggerTurn: true })`, but `AgentSession.#handleEmptyAssistantStop` treated every empty `stop` as retryable. The terminal contract lived only in `packages/coding-agent/src/prompts/system/autolearn-nudge-autocontinue.md`; `packages/coding-agent/src/session/agent-session.ts` had no per-turn signal that this synthetic prompt accepts an empty terminal stop.

## Fix
- Added an `acceptTerminalEmptyStop` option for agent-initiated custom message turns and latched it for the current prompt maintenance cycle.
- Passed that option from `AutoLearnController` when auto-running the hidden capture nudge.
- Kept orphaned `toolUse` empty stops retryable while accepting only terminal empty `stop` responses for the marked capture turn.
- Added an `AgentSession` regression that installs `AutoLearnController`, triggers the auto-continue capture turn, and asserts no empty-stop retry reminders or retry-cap failures occur.
- Added the `packages/coding-agent` changelog entry.

## Verification
Reproduced pre-fix in a detached worktree with `bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts -t auto-learn`: expected four mock model calls, received seven. Verified the fix with `bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts -t auto-learn` (1 pass, 9 filtered, 0 fail) and `bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts` (10 pass, 0 fail). `gh_push_branch` completed its pre-publish gate and pushed `e2afc87a40ef`. Fixes #5211