### PR TITLE
fix(generate_image): make concrete providers.image selection strict

### DIFF
--- a/docs/tools/generate_image.md
+++ b/docs/tools/generate_image.md
@@ -32,7 +32,9 @@
 
 ## Flow
 1. The SDK injects `generate_image` as a custom tool via `getImageGenTools()`.
-2. `execute(...)` resolves credentials and provider from the active model registry / session credentials.
+2. `execute(...)` resolves credentials and provider from settings + session credentials:
+   - `providers.image: auto` uses the built-in auto chain (OpenAI hosted → Antigravity → xAI → OpenRouter → Gemini).
+   - A concrete `providers.image` value is **strict**: only that provider is tried; local credential/model-gate failures throw a provider-specific diagnostic and do **not** soft-fall through into auto.
 3. Input images are resolved from `path` relative to the session cwd or from inline `data` + `mime_type`.
 4. The tool validates provider-specific `aspect_ratio` support.
 5. Provider dispatch:
@@ -62,8 +64,9 @@
 - `image_size` schema accepts `1024x1024`, `1536x1024`, and `1024x1536`.
 
 ## Errors
-- Missing credentials: `No image API credentials found...`
-- OpenAI path without an active GPT model: `Missing active GPT model for OpenAI image generation`.
+- Missing credentials under `auto`: `No image API credentials found...`
+- Concrete `providers.image` unavailable: provider-specific diagnostic (for example OpenAI requires an eligible active GPT/o3 Responses/Codex host; no silent fallthrough to Antigravity/xAI/etc.).
+- OpenAI path without an active GPT model after credentials resolved: `Missing active GPT model for OpenAI image generation`.
 - Antigravity credentials without `projectId`: `Missing projectId in antigravity credentials`.
 - Provider HTTP failures surface as provider-specific error messages with status metadata where available.
 - Unsupported provider/aspect-ratio combinations fail before the provider request.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### Fixed
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
+- Fixed `generate_image` treating concrete `providers.image` values as soft preferences and silently falling through into the auto provider chain (for example `providers.image=openai` with a non-GPT active model selecting Antigravity). Concrete values are now strict and fail closed with a provider-specific local diagnostic. ([#5218](https://github.com/can1357/oh-my-pi/issues/5218))
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
 
 ## [16.4.4] - 2026-07-11

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4397,14 +4397,18 @@ export const SETTINGS_SCHEMA = {
 			tab: "providers",
 			group: "Services",
 			label: "Image Provider",
-			description: "Preferred provider for image generation",
+			description: "Image generation provider. Concrete values are strict (no silent auto fallthrough).",
 			options: [
 				{
 					value: "auto",
 					label: "Auto",
 					description: "Priority: GPT model image tool > Antigravity > xAI > OpenRouter > Gemini",
 				},
-				{ value: "openai", label: "OpenAI", description: "Uses the active GPT Responses/Codex model" },
+				{
+					value: "openai",
+					label: "OpenAI",
+					description: "Requires active GPT/o3 Responses/Codex host; fails closed if unavailable",
+				},
 				{
 					value: "antigravity",
 					label: "Antigravity",

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -547,32 +547,66 @@ async function findOpenAIHostedImageCredentials(
 	};
 }
 
+function describePreferredImageProviderFailure(
+	provider: Exclude<ImageProviderPreference, "auto">,
+	activeModel: Model | undefined,
+): string {
+	switch (provider) {
+		case "openai": {
+			const active = activeModel != null ? `${activeModel.provider}/${activeModel.id}` : "none (no active model)";
+			if (!isOpenAIHostedImageModel(activeModel)) {
+				return (
+					`providers.image is set to openai, but the active model is not an eligible OpenAI/Codex GPT/o3 Responses host ` +
+					`(got ${active}). Switch the session model to a GPT/o3 Responses model, or set providers.image to auto/xai/antigravity/gemini/openrouter.`
+				);
+			}
+			return (
+				`providers.image is set to openai, but the active OpenAI/Codex model is not authenticated ` +
+				`(${activeModel.provider}/${activeModel.id}). Provide OpenAI credentials for that model, or set providers.image to another provider.`
+			);
+		}
+		case "antigravity":
+			return "providers.image is set to antigravity, but no usable google-antigravity credentials with projectId were found. Authenticate google-antigravity or set providers.image to another provider.";
+		case "xai":
+			return "providers.image is set to xai, but no usable xAI credentials were found. Authenticate xAI or set providers.image to another provider.";
+		case "openrouter":
+			return "providers.image is set to openrouter, but no usable OpenRouter credentials were found. Provide openrouter auth or set providers.image to another provider.";
+		case "gemini":
+			return "providers.image is set to gemini, but no usable Gemini/Google API credentials were found. Provide gemini/google auth or set providers.image to another provider.";
+	}
+}
+
+async function findPreferredImageApiKey(
+	provider: Exclude<ImageProviderPreference, "auto">,
+	modelRegistry?: ModelRegistry,
+	activeModel?: Model,
+	sessionId?: string,
+): Promise<ImageApiKey | null> {
+	switch (provider) {
+		case "openai":
+			return findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
+		case "antigravity":
+			if (!modelRegistry) return null;
+			return findAntigravityCredentials(modelRegistry, sessionId);
+		case "gemini":
+			return findGeminiImageCredentials(modelRegistry, sessionId);
+		case "openrouter":
+			return findOpenRouterImageCredentials(modelRegistry, sessionId);
+		case "xai":
+			return findXAIImageCredentials(modelRegistry);
+	}
+}
+
 async function findImageApiKey(
 	modelRegistry?: ModelRegistry,
 	activeModel?: Model,
 	sessionId?: string,
 ): Promise<ImageApiKey | null> {
-	// If a specific provider is preferred, try it first.
-	if (preferredImageProvider === "openai") {
-		const openAI = await findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
-		if (openAI) return openAI;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "antigravity" && modelRegistry) {
-		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
-		if (antigravity) return antigravity;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "gemini") {
-		const gemini = await findGeminiImageCredentials(modelRegistry, sessionId);
-		if (gemini) return gemini;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "openrouter") {
-		const openRouter = await findOpenRouterImageCredentials(modelRegistry, sessionId);
-		if (openRouter) return openRouter;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "xai") {
-		const xai = await findXAIImageCredentials(modelRegistry);
-		if (xai) return xai;
-		// Fall through to auto-detect if preferred provider key not found.
+	// Concrete providers.image values are strict: never soft-fall through into auto.
+	if (preferredImageProvider !== "auto") {
+		const preferred = await findPreferredImageApiKey(preferredImageProvider, modelRegistry, activeModel, sessionId);
+		if (preferred) return preferred;
+		throw new Error(describePreferredImageProviderFailure(preferredImageProvider, activeModel));
 	}
 
 	// Auto-detect: GPT hosted image generation, then Antigravity, xAI, OpenRouter, Gemini.

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -333,4 +333,187 @@ describe("imageGenTool", () => {
 		if (!savedPath) throw new Error("Expected generated image path");
 		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-xai-image"));
 	});
+
+	it("keeps providers.image=openai strict when active model is Grok", async () => {
+		setPreferredImageProvider("openai");
+		let fetchCalls = 0;
+		let antigravityLookups = 0;
+
+		const fetchMock: typeof fetch = (async () => {
+			fetchCalls += 1;
+			return new Response(null, { status: 500 });
+		}) as unknown as typeof fetch;
+
+		const activeModel = {
+			api: "openai-responses",
+			provider: "xai-oauth",
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			baseUrl: "https://api.x.ai/v1",
+		} as Model;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "unused-openai-key",
+				getApiKeyForProvider: async (provider: string) => {
+					if (provider === "google-antigravity") {
+						antigravityLookups += 1;
+						return JSON.stringify({ token: "ag-token", projectId: "proj-1" });
+					}
+					if (provider === "xai-oauth") return "xai-token";
+					return undefined;
+				},
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: (provider: string) => provider === "xai-oauth" || provider === "google-antigravity",
+					rotateSessionCredential: async () => false,
+				},
+				resolver: () => async () => "unused",
+			} as unknown as ModelRegistry,
+			model: activeModel,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		await expect(imageGenTool.execute("call-strict-openai", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(
+			/providers\.image is set to openai[\s\S]*eligible OpenAI\/Codex GPT\/o3 Responses host[\s\S]*xai-oauth\/grok-4\.5/,
+		);
+		expect(fetchCalls).toBe(0);
+		expect(antigravityLookups).toBe(0);
+	});
+
+	it("leaves providers.image=auto legacy order unchanged when OpenAI host is ineligible", async () => {
+		setPreferredImageProvider("auto");
+		let requestUrl: string | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request) => {
+			requestUrl = input.toString();
+			if (String(input).includes("streamGenerateContent")) {
+				return new Response(
+					[
+						"data: " +
+							JSON.stringify({
+								response: {
+									candidates: [
+										{
+											content: {
+												parts: [
+													{
+														inlineData: {
+															data: Buffer.from("fake-ag-image").toString("base64"),
+															mimeType: "image/png",
+														},
+													},
+												],
+											},
+										},
+									],
+								},
+							}),
+						"",
+					].join("\n"),
+					{ status: 200, headers: { "content-type": "text/event-stream" } },
+				);
+			}
+			return new Response(null, { status: 500 });
+		}) as unknown as typeof fetch;
+
+		const activeModel = {
+			api: "openai-responses",
+			provider: "xai-oauth",
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			baseUrl: "https://api.x.ai/v1",
+		} as Model;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => undefined,
+				getApiKeyForProvider: async (provider: string) => {
+					if (provider === "google-antigravity") {
+						return JSON.stringify({ token: "ag-token", projectId: "proj-1" });
+					}
+					if (provider === "xai-oauth") return "xai-token";
+					return undefined;
+				},
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: (provider: string) => provider === "xai-oauth" || provider === "google-antigravity",
+					rotateSessionCredential: async () => false,
+				},
+				resolver: () => async () => "ag-token",
+			} as unknown as ModelRegistry,
+			model: activeModel,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-auto-antigravity", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toContain("streamGenerateContent");
+		expect(result.details?.provider).toBe("antigravity");
+		expect(result.details?.model).toBe("gemini-3-pro-image");
+		expect(result.details?.imageCount).toBe(1);
+	});
+
+	it("keeps providers.image=xai strict when xAI credentials are missing", async () => {
+		setPreferredImageProvider("xai");
+		let fetchCalls = 0;
+		let antigravityLookups = 0;
+
+		const fetchMock: typeof fetch = (async () => {
+			fetchCalls += 1;
+			return new Response(null, { status: 500 });
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => undefined,
+				getApiKeyForProvider: async (provider: string) => {
+					if (provider === "google-antigravity") {
+						antigravityLookups += 1;
+						return JSON.stringify({ token: "ag-token", projectId: "proj-1" });
+					}
+					return undefined;
+				},
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: (provider: string) => provider === "google-antigravity",
+					rotateSessionCredential: async () => false,
+				},
+				resolver: () => async () => "unused",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		await expect(imageGenTool.execute("call-strict-xai", { subject: "a cat" }, undefined, ctx)).rejects.toThrow(
+			/providers\.image is set to xai[\s\S]*no usable xAI credentials/,
+		);
+		expect(fetchCalls).toBe(0);
+		expect(antigravityLookups).toBe(0);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #5218.

Concrete `providers.image` values (`openai`, `xai`, `antigravity`, `gemini`, `openrouter`) are now **strict**:

- only that provider is attempted
- local credential / model-gate failure throws a provider-specific diagnostic
- **no silent fallthrough** into the auto chain (which previously could select Antigravity)

`providers.image=auto` keeps the existing legacy auto order unchanged.

## Why

With `providers.image=openai` and an active non-GPT session model (e.g. `xai-oauth/grok-4.5`), OpenAI hosted-image selection failed the active-model gate and soft-fell through to auto. Auto then preferred Antigravity whenever those credentials resolved, which is surprising for an explicit non-`auto` setting.

## Changes

- `findImageApiKey`: concrete preference is fail-closed
- provider-specific local diagnostics (OpenAI points at eligible GPT/o3 Responses/Codex host requirement)
- settings UI copy notes strict concrete values
- docs updated
- changelog entry under Unreleased

## Tests

- `providers.image=openai` + active Grok + Antigravity creds present → throws OpenAI host diagnostic; **no network**, **no Antigravity credential lookup**
- `providers.image=xai` with no xAI creds + Antigravity present → throws xAI diagnostic; no Antigravity selection
- `providers.image=auto` with ineligible OpenAI host + Antigravity+xAI creds → still selects Antigravity (legacy auto order unchanged)

```bash
bun test packages/coding-agent/test/tools/image-gen.test.ts
# 9 pass
```

### Local verification note

Focused tests were run with Bun `1.3.14` after `bun install`. The local natives addon was loaded via the published `@oh-my-pi/pi-natives-darwin-arm64@16.4.4` optional dependency because this environment could not build `packages/natives` from source (no Cargo). Please treat CI as the authoritative natives-linked verification.

## Non-goals (intentionally not in this PR)

- session-provider affinity under `auto`
- network-error cross-provider retry / continue-on-failure
- image model defaults from registry metadata (#5219)