### PR TITLE
fix(coding-agent): preserve /btw Codex websocket routing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 
+- Fixed `/btw` side-channel turns on Codex models such as `gpt-5.6-luna` by preserving the session websocket preference instead of forcing SSE, and made Esc dismiss the active `/btw` panel before interrupting loop/maintenance work. ([#5213](https://github.com/can1357/oh-my-pi/issues/5213))
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -266,6 +266,8 @@ export class InputController {
 			});
 		}
 		this.ctx.editor.onEscape = () => {
+			// Side-channel panels are the topmost view. Esc dismisses them before
+			// touching loop mode, maintenance, or the underlying main turn.
 			// Active context maintenance owns Esc: auto/manual compaction,
 			// handoff generation, and auto-retry backoff all advertise
 			// "(esc to cancel)". Dispatch on live session state instead of
@@ -281,6 +283,13 @@ export class InputController {
 			// (see EventController). Main-session maintenance still owns Esc and
 			// stays cancellable from the main view (focused submit gates /compact
 			// and handoff, so manual maintenance is main-only anyway).
+			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
+				return;
+			}
+			if (this.ctx.hasActiveOmfg() && this.ctx.handleOmfgEscape()) {
+				return;
+			}
+
 			if (!this.ctx.focusedAgentId) {
 				const viewSession = this.ctx.viewSession;
 				let aborted = false;
@@ -306,12 +315,6 @@ export class InputController {
 				} else {
 					this.ctx.cancelPendingSubmission();
 				}
-				return;
-			}
-			if (this.ctx.hasActiveBtw() && this.ctx.handleBtwEscape()) {
-				return;
-			}
-			if (this.ctx.hasActiveOmfg() && this.ctx.handleOmfgEscape()) {
 				return;
 			}
 			if (this.ctx.focusedAgentId) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -14706,7 +14706,7 @@ export class AgentSession {
 				// stable, but give provider routing a unique request lineage.
 				sessionId: `${cacheSessionId}:side:${Snowflake.next()}`,
 				promptCacheKey: cacheSessionId,
-				preferWebsockets: false,
+				preferWebsockets: this.#preferWebsockets,
 				reasoning: toReasoningEffort(this.thinkingLevel),
 				disableReasoning: shouldDisableReasoning(this.thinkingLevel),
 				hideThinkingSummary: this.agent.hideThinkingSummary,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -14703,10 +14703,13 @@ export class AgentSession {
 				// Side-channel turns must not share OpenAI/Codex append-only
 				// conversation state with the main agent turn: IRC and /btw can run
 				// while the main turn is mid-tool-call. Keep the prompt-cache key
-				// stable, but give provider routing a unique request lineage.
+				// stable, but give provider routing a unique request lineage. The
+				// shared provider state map is still required so Codex can allocate
+				// websocket state under that side-channel session id.
 				sessionId: `${cacheSessionId}:side:${Snowflake.next()}`,
 				promptCacheKey: cacheSessionId,
 				preferWebsockets: this.#preferWebsockets,
+				providerSessionState: this.#providerSessionState,
 				reasoning: toReasoningEffort(this.thinkingLevel),
 				disableReasoning: shouldDisableReasoning(this.thinkingLevel),
 				hideThinkingSummary: this.agent.hideThinkingSummary,

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -233,7 +233,7 @@ describe("AgentSession message pipeline", () => {
 		expect(requestOnPayload).toHaveBeenCalledWith({ original: true, session: true }, undefined);
 		expect(result).toEqual({ original: true, session: true });
 	});
-	it("keeps ephemeral side-channel cache key separate from provider routing", async () => {
+	it("keeps ephemeral side-channel cache key separate from provider routing while preserving websocket preference", async () => {
 		const api = "test-ephemeral-side-channel";
 		let capturedOptions: SimpleStreamOptions | undefined;
 		registerCustomApi(api, (_model, _context, options) => {
@@ -271,6 +271,7 @@ describe("AgentSession message pipeline", () => {
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry: createModelRegistryStub() as never,
+			preferWebsockets: true,
 		});
 		sessions.push(session);
 		const cacheSessionId = session.sessionId;
@@ -281,7 +282,7 @@ describe("AgentSession message pipeline", () => {
 		expect(capturedOptions?.promptCacheKey).toBe(cacheSessionId);
 		expect(capturedOptions?.sessionId).toStartWith(`${cacheSessionId}:side:`);
 		expect(capturedOptions?.sessionId).not.toBe(cacheSessionId);
-		expect(capturedOptions?.preferWebsockets).toBe(false);
+		expect(capturedOptions?.preferWebsockets).toBe(true);
 	});
 
 	it("runs ephemeral side-channel requests through the configured side stream function", async () => {

--- a/packages/coding-agent/test/agent-session-message-pipeline.test.ts
+++ b/packages/coding-agent/test/agent-session-message-pipeline.test.ts
@@ -233,7 +233,7 @@ describe("AgentSession message pipeline", () => {
 		expect(requestOnPayload).toHaveBeenCalledWith({ original: true, session: true }, undefined);
 		expect(result).toEqual({ original: true, session: true });
 	});
-	it("keeps ephemeral side-channel cache key separate from provider routing while preserving websocket preference", async () => {
+	it("keeps ephemeral side-channel cache key separate from provider routing while preserving websocket state", async () => {
 		const api = "test-ephemeral-side-channel";
 		let capturedOptions: SimpleStreamOptions | undefined;
 		registerCustomApi(api, (_model, _context, options) => {
@@ -283,6 +283,7 @@ describe("AgentSession message pipeline", () => {
 		expect(capturedOptions?.sessionId).toStartWith(`${cacheSessionId}:side:`);
 		expect(capturedOptions?.sessionId).not.toBe(cacheSessionId);
 		expect(capturedOptions?.preferWebsockets).toBe(true);
+		expect(capturedOptions?.providerSessionState).toBe(session.providerSessionState);
 	});
 
 	it("runs ephemeral side-channel requests through the configured side stream function", async () => {

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -448,6 +448,35 @@ describe("InputController escape behavior", () => {
 		expect(spies.abort).not.toHaveBeenCalled();
 	});
 
+	it("dismisses an active /btw panel before aborting loop mode", () => {
+		const { ctx, editor, spies } = createContext();
+		ctx.loopModeEnabled = true;
+		mutableSessionState(ctx).isStreaming = true;
+		spies.hasActiveBtw.mockReturnValue(true);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.handleBtwEscape).toHaveBeenCalledTimes(1);
+		expect(spies.abort).not.toHaveBeenCalled();
+		expect(ctx.loopModeEnabled).toBe(true);
+	});
+
+	it("dismisses an active /btw panel before aborting maintenance", () => {
+		const { ctx, editor, spies } = createContext();
+		abortViewSession(ctx).isGeneratingHandoff = true;
+		spies.hasActiveBtw.mockReturnValue(true);
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+		editor.onEscape?.();
+
+		expect(spies.handleBtwEscape).toHaveBeenCalledTimes(1);
+		expect(spies.abortHandoff).not.toHaveBeenCalled();
+		expect(spies.abort).not.toHaveBeenCalled();
+	});
+
 	it("aborts an active streaming turn on the first Esc without asking for confirmation", () => {
 		const { ctx, editor, spies } = createContext();
 		mutableSessionState(ctx).isStreaming = true;


### PR DESCRIPTION
## Repro
With a session configured for Codex websocket routing, `/btw` side-channel requests forced `preferWebsockets: false`, which reproduced as `bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts -t ephemeral` failing because the captured side-stream options received `false` instead of `true`. The Escape path reproduced with `bun test packages/coding-agent/test/input-controller-escape.test.ts -t /btw`, where active loop/maintenance state ran before the active `/btw` panel dismissal.

## Cause
`AgentSession.runEphemeralTurn` in `packages/coding-agent/src/session/agent-session.ts` hardcoded `preferWebsockets: false` for all side-channel turns, so Codex models that need the websocket transport (such as `gpt-5.6-luna`) were sent over SSE. `InputController.setupKeyHandlers` in `packages/coding-agent/src/modes/controllers/input-controller.ts` checked loop mode and maintenance interrupts before `hasActiveBtw()`, so Esc could interrupt underlying work instead of closing the topmost `/btw` view.

## Fix
- Preserve the session-level websocket preference when building `/btw`/ephemeral stream options.
- Move `/btw` and `/omfg` Escape dismissal ahead of loop, maintenance, and main-turn interrupt handling.
- Add regression coverage for side-channel websocket option propagation and `/btw` Escape priority over loop/maintenance work.
- Record the fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/agent-session-message-pipeline.test.ts -t ephemeral` passed: 7 pass, 0 fail. `bun test packages/coding-agent/test/input-controller-escape.test.ts -t /btw` passed: 6 pass, 0 fail. `bun run check` in `packages/coding-agent` passed. Fixes #5213