### PR TITLE
fix: allow tests before implementation

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -192,7 +192,7 @@ EXECUTION WORKFLOW
 
 # 3. Decompose
 - Update todos as you go; skip them for trivial requests. Marking a todo done is a transition: start the next in the same turn.
-- Plan only what makes the request work. Cleanup—changelog, tests, docs—is NOT planned up front; it belongs to the final phase below.
+- Plan only what makes the request work. Housekeeping—changelog, docs, removing scaffolding—is NOT planned up front; it belongs to the final phase below. Tests are NOT housekeeping: write them whenever they best serve the change, including before implementation when project conventions or TDD call for it.
 
 # 4. Implement
 - Fix problems at the source. Remove obsolete code—no leftover comments, aliases, or re-exports.
@@ -209,9 +209,9 @@ EXECUTION WORKFLOW
 - Run only touched tests; small/no-test changes still REQUIRE a focused behavioral smoke test.
 
 # 6. Cleanup
-Changelog, tests, docs, and removing scaffolding are the LAST phase—NEVER skipped, but gated on the request demonstrably working.
+Changelog, docs, and removing scaffolding are the LAST phase—NEVER skipped, but gated on the request demonstrably working.
 
-- NEVER start, pre-plan, or pre-allocate todos for cleanup before you've made the request work and smoke-tested it. Until then, every edit serves correctness; housekeeping NEVER steers the design.
+- NEVER start, pre-plan, or pre-allocate todos for housekeeping before you've made the request work and smoke-tested it. Until then, every edit serves correctness; housekeeping NEVER steers the design.
 - Once your smoke test confirms “it works,” do the cleanup in full before yielding.
 
 DELIVERY CONTRACT

--- a/packages/coding-agent/test/system-prompt-cleanup-wording.test.ts
+++ b/packages/coding-agent/test/system-prompt-cleanup-wording.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import { cleanupTempHome } from "./helpers/temp-home-cleanup";
+
+const EMPTY_TREE = {
+	rootPath: "",
+	rendered: "",
+	truncated: false,
+	totalLines: 0,
+	agentsMdFiles: [],
+};
+
+/**
+ * Cleanup-phase wording contract: the standing system prompt must never
+ * categorize tests as post-implementation housekeeping. Tests may precede
+ * implementation when project conventions or TDD call for it, while
+ * changelog/docs/scaffolding removal remain the gated final phase and
+ * behavioral verification stays required before yielding.
+ */
+describe("system prompt cleanup-phase wording", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-cleanup-"));
+		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-cleanup-home-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tempHomeDir;
+	});
+
+	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
+
+	async function render(): Promise<string> {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: [],
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+		});
+		return systemPrompt.join("\n\n");
+	}
+
+	it("permits tests before implementation instead of deferring them to cleanup", async () => {
+		const rendered = await render();
+
+		// Tests must never be lumped into the deferred housekeeping list.
+		expect(rendered).not.toMatch(/changelog, tests/i);
+		expect(rendered).toContain("Tests are NOT housekeeping");
+		expect(rendered).toContain("before implementation when project conventions or TDD call for it");
+	});
+
+	it("keeps housekeeping gated last and verification mandatory", async () => {
+		const rendered = await render();
+
+		expect(rendered).toContain("Changelog, docs, and removing scaffolding are the LAST phase");
+		expect(rendered).toContain("NEVER yield non-trivial work without proof");
+	});
+});


### PR DESCRIPTION
## Summary

- stop categorizing tests as post-implementation cleanup
- allow tests before implementation when project conventions or TDD call for it
- keep changelog, docs, and scaffolding removal in the final housekeeping phase
- preserve mandatory focused behavioral verification before yielding

## Verification

- `bun test test/system-prompt-cleanup-wording.test.ts`
- 2 tests passed, 0 failed

This removes a conflict between OMP's generic workflow and repositories that require integration-first TDD without weakening verification or final cleanup requirements.