### PR TITLE
fix(cli): embed compiled binary header assets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed compiled release binaries embedding `header-generator` and `@anush008/tokenizers` build-machine paths; header-generator data is now embedded into the compiled bundle, and fastembed stays external so Mnemopi resolves its runtime install instead. ([#5195](https://github.com/can1357/oh-my-pi/issues/5195))
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -99,7 +99,6 @@ async function main(): Promise<void> {
 				outfile: outputPath,
 				transformersVersion,
 				target: crossBuild?.target,
-				external: ["fastembed", "onnxruntime-node"],
 				skipBuiltinCodesign: shouldAdhocSignDarwinBinary(crossBuild),
 			});
 

--- a/packages/coding-agent/scripts/compile-binary.ts
+++ b/packages/coding-agent/scripts/compile-binary.ts
@@ -1,5 +1,85 @@
+import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import * as path from "node:path";
+
 import { buildDocsIndexPayload } from "./generate-docs-index";
 import { createLegacyPiVirtualModulePlugin } from "./legacy-pi-virtual-module";
+
+/** Dependencies always resolved from runtime installs instead of embedded into compiled binaries. */
+export const COMPILED_EXTERNAL_DEPENDENCIES: readonly string[] = Object.freeze(["fastembed", "onnxruntime-node"]);
+
+function replaceRequiredSource(source: string, needle: string, replacement: string): string {
+	const next = source.replace(needle, replacement);
+	if (next === source) {
+		throw new Error(`header-generator compile transform could not find expected source: ${needle}`);
+	}
+	return next;
+}
+
+async function buildEmbeddedHeaderGeneratorSource(repoRoot: string): Promise<{ path: string; source: string }> {
+	const requireFromRepo = createRequire(path.join(repoRoot, "package.json"));
+	const headerGeneratorRoot = path.dirname(requireFromRepo.resolve("header-generator"));
+	const headerGeneratorModulePath = path.join(headerGeneratorRoot, "header-generator.js");
+	const dataFilesRoot = path.join(headerGeneratorRoot, "data_files");
+
+	const [source, headersOrderJson, browserHelperJson, inputNetworkZip, headerNetworkZip] = await Promise.all([
+		Bun.file(headerGeneratorModulePath).text(),
+		Bun.file(path.join(dataFilesRoot, "headers-order.json")).text(),
+		Bun.file(path.join(dataFilesRoot, "browser-helper-file.json")).text(),
+		fs.readFile(path.join(dataFilesRoot, "input-network-definition.zip")),
+		fs.readFile(path.join(dataFilesRoot, "header-network-definition.zip")),
+	]);
+	const dirnameTemplatePlaceholder = "$" + "{__dirname}";
+
+	let embeddedSource = replaceRequiredSource(
+		source,
+		'const utils_1 = require("./utils");',
+		[
+			'const utils_1 = require("./utils");',
+			`const __OMP_HEADERS_ORDER_JSON = ${JSON.stringify(headersOrderJson)};`,
+			`const __OMP_BROWSER_HELPER_JSON = ${JSON.stringify(browserHelperJson)};`,
+			`const __OMP_INPUT_NETWORK_ZIP = Buffer.from(${JSON.stringify(inputNetworkZip.toString("base64"))}, "base64");`,
+			`const __OMP_HEADER_NETWORK_ZIP = Buffer.from(${JSON.stringify(headerNetworkZip.toString("base64"))}, "base64");`,
+		].join("\n"),
+	);
+	embeddedSource = replaceRequiredSource(
+		embeddedSource,
+		`this.headersOrder = JSON.parse((0, fs_1.readFileSync)(\`${dirnameTemplatePlaceholder}/data_files/headers-order.json\`).toString());`,
+		"this.headersOrder = JSON.parse(__OMP_HEADERS_ORDER_JSON);",
+	);
+	embeddedSource = replaceRequiredSource(
+		embeddedSource,
+		`const uniqueBrowserStrings = JSON.parse((0, fs_1.readFileSync)(\`${dirnameTemplatePlaceholder}/data_files/browser-helper-file.json\`, 'utf8').toString());`,
+		"const uniqueBrowserStrings = JSON.parse(__OMP_BROWSER_HELPER_JSON);",
+	);
+	embeddedSource = replaceRequiredSource(
+		embeddedSource,
+		`path: \`${dirnameTemplatePlaceholder}/data_files/input-network-definition.zip\`,`,
+		"path: __OMP_INPUT_NETWORK_ZIP,",
+	);
+	embeddedSource = replaceRequiredSource(
+		embeddedSource,
+		`path: \`${dirnameTemplatePlaceholder}/data_files/header-network-definition.zip\`,`,
+		"path: __OMP_HEADER_NETWORK_ZIP,",
+	);
+
+	return { path: headerGeneratorModulePath, source: embeddedSource };
+}
+
+/** Embeds header-generator data files so compiled binaries do not read build-machine paths. */
+export async function createHeaderGeneratorCompilePlugin(repoRoot: string): Promise<Bun.BunPlugin> {
+	const embedded = await buildEmbeddedHeaderGeneratorSource(repoRoot);
+
+	return {
+		name: "omp-header-generator-data",
+		setup(build) {
+			build.onLoad({ filter: /[/\\]header-generator[/\\]header-generator\.js$/ }, args => {
+				if (path.normalize(args.path) !== path.normalize(embedded.path)) return undefined;
+				return { contents: embedded.source, loader: "js" };
+			});
+		},
+	};
+}
 
 /** Inputs shared by local and release coding-agent binary builds. */
 export interface CodingAgentCompileOptions {
@@ -31,20 +111,26 @@ export async function compileCodingAgent(options: CodingAgentCompileOptions): Pr
 		Bun.env.BUN_NO_CODESIGN_MACHO_BINARY = "1";
 	}
 	try {
+		const external = [...new Set([...COMPILED_EXTERNAL_DEPENDENCIES, ...(options.external ?? [])])];
+		const [docsIndex, headerGeneratorPlugin, legacyPiPlugin] = await Promise.all([
+			buildDocsIndexPayload(),
+			createHeaderGeneratorCompilePlugin(options.repoRoot),
+			createLegacyPiVirtualModulePlugin(),
+		]);
 		const output = await Bun.build({
 			entrypoints: [options.entrypoint],
 			root: options.repoRoot,
-			external: options.external ? [...options.external] : undefined,
+			external,
 			define: {
 				"process.env.PI_COMPILED": JSON.stringify("true"),
 				"process.env.PI_TINY_TRANSFORMERS_VERSION": JSON.stringify(options.transformersVersion),
-				"process.env.PI_DOCS_EMBED": JSON.stringify((await buildDocsIndexPayload()).payload),
+				"process.env.PI_DOCS_EMBED": JSON.stringify(docsIndex.payload),
 			},
 			minify: {
 				identifiers: options.minifyIdentifiers ?? false,
 				keepNames: true,
 			},
-			plugins: [await createLegacyPiVirtualModulePlugin()],
+			plugins: [headerGeneratorPlugin, legacyPiPlugin],
 			compile: {
 				...(options.target ? { target: options.target } : {}),
 				outfile: options.outfile,

--- a/packages/coding-agent/test/tools/web-search-browser-headers.test.ts
+++ b/packages/coding-agent/test/tools/web-search-browser-headers.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildBrowserNavigationHeaders } from "@oh-my-pi/pi-coding-agent/web/search/providers/browser-headers";
 import { browserFetch } from "@oh-my-pi/pi-coding-agent/web/search/providers/browser-page";
+import { compileCodingAgent } from "../../scripts/compile-binary";
 
-afterEach(() => {
+afterEach(async () => {
 	vi.restoreAllMocks();
+	for (const tempDir of tempDirs.splice(0)) {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
 });
 
 const CHROME_FALLBACK_HEADERS: Record<string, string> = {
@@ -29,7 +34,9 @@ const CHROME_FALLBACK_HEADERS: Record<string, string> = {
 };
 
 const packageRoot = path.join(import.meta.dir, "../..");
+const repoRoot = path.join(packageRoot, "../..");
 const headerGeneratorRoot = path.dirname(fileURLToPath(import.meta.resolve("header-generator")));
+const tempDirs: string[] = [];
 
 describe("browser navigation headers", () => {
 	it("builds a randomized, internally consistent browser profile", () => {
@@ -105,6 +112,62 @@ describe("browser navigation headers", () => {
 			}
 
 			expect(JSON.parse(stdout)).toEqual(CHROME_FALLBACK_HEADERS);
+		} finally {
+			await fs.rename(unavailableDataFilesDir, dataFilesDir);
+		}
+	});
+
+	it("keeps generated headers embedded in compiled probes after header-generator data files disappear", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-browser-headers-compile-"));
+		tempDirs.push(tempDir);
+		const entrypoint = path.join(tempDir, "headers-probe.ts");
+		const outfile = path.join(tempDir, process.platform === "win32" ? "headers-probe.exe" : "headers-probe");
+		await Bun.write(
+			entrypoint,
+			[
+				`import { buildBrowserNavigationHeaders } from ${JSON.stringify(path.join(packageRoot, "src/web/search/providers/browser-headers.ts"))};`,
+				"Math.random = () => 0;",
+				"const stable = buildBrowserNavigationHeaders({ randomized: false });",
+				"const randomized = buildBrowserNavigationHeaders();",
+				"process.stdout.write(JSON.stringify({ randomized, stable }));",
+			].join("\n"),
+		);
+
+		await compileCodingAgent({
+			repoRoot,
+			entrypoint,
+			outfile,
+			transformersVersion: "0.0.0-test",
+		});
+
+		const dataFilesDir = path.join(headerGeneratorRoot, "data_files");
+		const unavailableDataFilesDir = path.join(
+			headerGeneratorRoot,
+			`.data_files-compiled-unavailable-${process.pid}-${Date.now()}`,
+		);
+
+		await fs.rename(dataFilesDir, unavailableDataFilesDir);
+		try {
+			const proc = Bun.spawn([outfile], {
+				cwd: packageRoot,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+
+			const [exitCode, stdout, stderr] = await Promise.all([
+				proc.exited,
+				new Response(proc.stdout).text(),
+				new Response(proc.stderr).text(),
+			]);
+
+			if (exitCode !== 0) {
+				throw new Error(`compiled browser header probe failed with exit ${exitCode}:\n${stderr}`);
+			}
+
+			const payload: { randomized: Record<string, string>; stable: Record<string, string> } = JSON.parse(stdout);
+			expect(payload.stable).toEqual(CHROME_FALLBACK_HEADERS);
+			expect(payload.randomized).not.toEqual(payload.stable);
+			expect(payload.randomized["User-Agent"]).toContain("Mozilla/5.0");
 		} finally {
 			await fs.rename(unavailableDataFilesDir, dataFilesDir);
 		}

--- a/scripts/ci-release-build-binaries.test.ts
+++ b/scripts/ci-release-build-binaries.test.ts
@@ -18,6 +18,7 @@ describe("Windows release binary target", () => {
 		expect(output).toContain(
 			"DRY RUN Bun.build target=bun-windows-x64-baseline outfile=packages/coding-agent/binaries/omp-windows-x64.exe",
 		);
+		expect(output).toContain("external=fastembed,onnxruntime-node");
 		expect(output).not.toContain("bun-windows-x64-modern");
 	});
 

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -3,7 +3,7 @@
 import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import * as path from "node:path";
-import { compileCodingAgent } from "../packages/coding-agent/scripts/compile-binary";
+import { COMPILED_EXTERNAL_DEPENDENCIES, compileCodingAgent } from "../packages/coding-agent/scripts/compile-binary";
 
 interface BinaryTarget {
 	id: string;
@@ -121,7 +121,9 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
-		console.log(`DRY RUN Bun.build target=${target.target} outfile=${target.outfile}`);
+		console.log(
+			`DRY RUN Bun.build target=${target.target} outfile=${target.outfile} external=${COMPILED_EXTERNAL_DEPENDENCIES.join(",")}`,
+		);
 		return;
 	}
 


### PR DESCRIPTION
## Repro
A minimal `bun build --compile` probe that imports `header-generator`, instantiates `HeaderGenerator`, then runs after `node_modules/header-generator/data_files` is hidden exits 1 with `ENOENT .../node_modules/header-generator/data_files/headers-order.json`; this matches the reporter's Linux `/home/runner/...` path and the follow-up macOS `/Users/runner/...` Homebrew binary report.

## Cause
`packages/coding-agent/scripts/compile-binary.ts` bundled `header-generator` unchanged, so Bun compiled the dependency's `__dirname` into the executable and its constructor still called `readFileSync(`${__dirname}/data_files/...`)` at runtime. The release path in `scripts/ci-release-build-binaries.ts` also did not use the local build's fastembed/onnxruntime externalization, allowing fastembed's `@anush008/tokenizers` dependency graph to be embedded into release binaries.

## Fix
- Added a compile-time `header-generator` build plugin that embeds `headers-order.json`, `browser-helper-file.json`, and both Bayesian network zip files into the transformed module before `bun --compile` runs.
- Centralized compiled-binary externals for `fastembed` and `onnxruntime-node`, then applied them to every `compileCodingAgent` caller so Mnemopi keeps using its on-demand runtime install path.
- Extended release dry-run output to expose the externalized dependency contract.
- Added a compiled smoke test that runs generated browser headers after `header-generator/data_files` is removed, plus a release dry-run regression assertion for fastembed/onnxruntime externalization.

## Verification
`bun test packages/coding-agent/test/tools/web-search-browser-headers.test.ts scripts/ci-release-build-binaries.test.ts` passed with 7 tests and 21 assertions. `bun run check:types` passed in `packages/coding-agent`. `bun run check:tools` passed at the repo root. A local `compileCodingAgent` smoke binary ran successfully after `header-generator/data_files` was hidden and its bytes did not contain `/node_modules/header-generator`, `data_files/headers-order.json`, or `/node_modules/@anush008/tokenizers`. `gh_push_branch` also completed the pre-publish gate before pushing. Fixes #5195