### PR TITLE
fix(generate_image): fail loudly when explicit provider preference is unresolvable

### DIFF
--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -552,27 +552,44 @@ async function findImageApiKey(
 	activeModel?: Model,
 	sessionId?: string,
 ): Promise<ImageApiKey | null> {
-	// If a specific provider is preferred, try it first.
+	// If a specific provider is preferred, try it — and fail loudly if unavailable
+	// so the user is never silently routed to a different provider.
 	if (preferredImageProvider === "openai") {
 		const openAI = await findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
 		if (openAI) return openAI;
-		// Fall through to auto-detect if preferred provider key not found.
+		throw new Error(
+			`providers.image is set to "openai" but no eligible OpenAI image model was found. ` +
+			`The active session model must be a GPT or o3 Responses model (e.g. gpt-4o, o3) with valid OpenAI credentials. ` +
+			`Switch to a compatible model, or change providers.image to "auto" to allow automatic provider selection.`,
+		);
 	} else if (preferredImageProvider === "antigravity" && modelRegistry) {
 		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
 		if (antigravity) return antigravity;
-		// Fall through to auto-detect if preferred provider key not found.
+		throw new Error(
+			`providers.image is set to "antigravity" but no Antigravity credentials were found. ` +
+			`Log in with google-antigravity OAuth, or change providers.image to "auto" to allow automatic provider selection.`,
+		);
 	} else if (preferredImageProvider === "gemini") {
 		const gemini = await findGeminiImageCredentials(modelRegistry, sessionId);
 		if (gemini) return gemini;
-		// Fall through to auto-detect if preferred provider key not found.
+		throw new Error(
+			`providers.image is set to "gemini" but no Gemini/Google credentials were found. ` +
+			`Set GEMINI_API_KEY or GOOGLE_API_KEY, or change providers.image to "auto" to allow automatic provider selection.`,
+		);
 	} else if (preferredImageProvider === "openrouter") {
 		const openRouter = await findOpenRouterImageCredentials(modelRegistry, sessionId);
 		if (openRouter) return openRouter;
-		// Fall through to auto-detect if preferred provider key not found.
+		throw new Error(
+			`providers.image is set to "openrouter" but no OpenRouter credentials were found. ` +
+			`Set OPENROUTER_API_KEY, or change providers.image to "auto" to allow automatic provider selection.`,
+		);
 	} else if (preferredImageProvider === "xai") {
 		const xai = await findXAIImageCredentials(modelRegistry);
 		if (xai) return xai;
-		// Fall through to auto-detect if preferred provider key not found.
+		throw new Error(
+			`providers.image is set to "xai" but no xAI credentials were found. ` +
+			`Log in with xAI Grok OAuth or set XAI_API_KEY, or change providers.image to "auto" to allow automatic provider selection.`,
+		);
 	}
 
 	// Auto-detect: GPT hosted image generation, then Antigravity, xAI, OpenRouter, Gemini.


### PR DESCRIPTION
## Problem\n\nWhen `providers.image` is set to a specific provider (e.g. `openai`), the credential resolver silently falls through to the auto-detect chain if the preferred provider fails. This means:\n\n- User sets `providers.image: openai`\n- Active session model is not an OpenAI/Codex GPT/o3 Responses model\n- `findOpenAIHostedImageCredentials` returns null\n- **Silent fallthrough** to auto-detect: OpenAI → Antigravity → xAI → OpenRouter → Gemini\n- If Antigravity OAuth resolves, it is selected — even though the user explicitly asked for OpenAI\n- Antigravity image endpoint returns 404 → tool fails without trying other providers\n\n## Fix\n\nReplace the silent "Fall through to auto-detect" behavior with explicit `throw new Error(...)` for each provider branch. When a user explicitly selects a provider and its credentials cannot be resolved, the error message now:\n\n1. Names the provider that was requested\n2. Explains what credentials or model configuration is needed\n3. Suggests changing to `auto` if fallback behavior is desired\n\nThis applies to all five explicit provider branches: `openai`, `antigravity`, `gemini`, `openrouter`, and `xai`.\n\n## Changes\n\n- `packages/coding-agent/src/tools/image-gen.ts`: Modified `findImageApiKey` to throw descriptive errors instead of silently falling through when an explicit provider preference cannot be resolved.\n\n## Verification\n\nThe change is minimal and targeted — it only affects the code path when `preferredImageProvider !== "auto"`. The auto-detect chain (the final section of `findImageApiKey`) is completely unchanged.\n\nFixes #5218