### PR TITLE
fix(web-search): isolate provider load failures from the fallback chain

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `web_search` failing on every query when a single provider module threw while being resolved (e.g. a compiled-binary init-order failure surfacing as `undefined is not a constructor … .BingProvider`). Provider load and availability probes are now isolated per provider, so one broken provider is skipped instead of aborting the whole fallback chain and disabling web search entirely.
+
 ## [16.4.5] - 2026-07-11
 
 ### Breaking Changes

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -20,7 +20,7 @@ import { throwIfAborted } from "../../tools/tool-errors";
 import {
 	formatSearchProviderFailure,
 	formatSearchProviderFailures,
-	getSearchProvider,
+	loadAvailableProvider,
 	resolveProviderChain,
 	type SearchProvider,
 } from "./provider";
@@ -130,10 +130,8 @@ async function executeSearch(
 	const explicitProvider = params.provider;
 	let providers: SearchProvider[];
 	if (explicitProvider && explicitProvider !== "auto") {
-		const provider = await getSearchProvider(explicitProvider);
-		providers = (await provider.isExplicitlyAvailable(authStorage))
-			? [provider]
-			: await resolveProviderChain(authStorage, "auto");
+		const provider = await loadAvailableProvider(explicitProvider, authStorage, true);
+		providers = provider ? [provider] : await resolveProviderChain(authStorage, "auto");
 	} else if (explicitProvider === "auto") {
 		// Explicit `--provider auto` bypasses the configured preferred provider
 		// for this invocation; exclusions still apply.

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -9,6 +9,7 @@
 // listings can share it without importing provider implementations.
 
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import { logger } from "@oh-my-pi/pi-utils";
 import type { SearchProvider } from "./providers/base";
 import { SEARCH_PROVIDER_LABELS, SEARCH_PROVIDER_ORDER, SearchProviderError, type SearchProviderId } from "./types";
 
@@ -221,9 +222,45 @@ export function isSearchProviderExcluded(id: SearchProviderId): boolean {
 }
 
 /**
+ * Load a provider and probe its availability, isolating any failure. A provider
+ * whose module throws at import/construction — or whose availability probe
+ * throws — is logged at debug and treated as unavailable rather than allowed to
+ * abort resolution of the rest of the chain.
+ *
+ * This guards against a single poisoned provider module (e.g. an init-order
+ * failure that surfaces as `undefined is not a constructor`) disabling
+ * `web_search` entirely: always-available providers such as DuckDuckGo/Google
+ * must still resolve even when one scraper module fails to load.
+ *
+ * `explicit` selects {@link SearchProvider.isExplicitlyAvailable} (used when the
+ * user forced this provider) over {@link SearchProvider.isAvailable} (auto chain).
+ */
+export async function loadAvailableProvider(
+	id: SearchProviderId,
+	authStorage: AuthStorage,
+	explicit = false,
+): Promise<SearchProvider | null> {
+	try {
+		const provider = await getSearchProvider(id);
+		const available = explicit
+			? await provider.isExplicitlyAvailable(authStorage)
+			: await provider.isAvailable(authStorage);
+		return available ? provider : null;
+	} catch (error) {
+		logger.debug("web search provider skipped after load/probe failure", {
+			provider: id,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return null;
+	}
+}
+
+/**
  * Determine which providers are configured and currently available.
  * Each candidate is loaded (and its `isAvailable()` called) only as the chain
- * is walked, so unconfigured providers never pay the load cost.
+ * is walked, so unconfigured providers never pay the load cost. Loads and
+ * availability probes are isolated per provider via {@link loadAvailableProvider},
+ * so one broken provider module never aborts resolution of the rest.
  */
 export async function resolveProviderChain(
 	authStorage: AuthStorage,
@@ -232,18 +269,14 @@ export async function resolveProviderChain(
 	const providers: SearchProvider[] = [];
 
 	if (preferredProvider !== "auto" && !isSearchProviderExcluded(preferredProvider)) {
-		const provider = await getSearchProvider(preferredProvider);
-		if (await provider.isExplicitlyAvailable(authStorage)) {
-			providers.push(provider);
-		}
+		const provider = await loadAvailableProvider(preferredProvider, authStorage, true);
+		if (provider) providers.push(provider);
 	}
 
 	for (const id of SEARCH_PROVIDER_ORDER) {
 		if (id === preferredProvider || isSearchProviderExcluded(id)) continue;
-		const provider = await getSearchProvider(id);
-		if (await provider.isAvailable(authStorage)) {
-			providers.push(provider);
-		}
+		const provider = await loadAvailableProvider(id, authStorage);
+		if (provider) providers.push(provider);
 	}
 
 	return providers;

--- a/packages/coding-agent/test/web/search/provider-chain.test.ts
+++ b/packages/coding-agent/test/web/search/provider-chain.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import {
@@ -6,6 +6,7 @@ import {
 	setExcludedSearchProviders,
 	setPreferredSearchProvider,
 } from "@oh-my-pi/pi-coding-agent/web/search/provider";
+import { BraveProvider } from "@oh-my-pi/pi-coding-agent/web/search/providers/brave";
 import { SEARCH_PROVIDER_ORDER } from "@oh-my-pi/pi-coding-agent/web/search/types";
 
 const authStorage = {} as AuthStorage;
@@ -35,6 +36,7 @@ afterEach(() => {
 	setPreferredSearchProvider("auto");
 	setExcludedSearchProviders([]);
 	restoreEnv();
+	mock.restore();
 });
 
 describe("resolveProviderChain", () => {
@@ -64,6 +66,22 @@ describe("resolveProviderChain", () => {
 			"providers.webSearchExclude",
 			SEARCH_PROVIDER_ORDER.filter(id => id !== "jina"),
 		);
+
+		const providers = await resolveProviderChain(authStorage, "auto");
+
+		expect(providers.map(provider => provider.id)).toEqual(["jina"]);
+	});
+
+	it("skips a provider that throws while resolving instead of aborting the chain", async () => {
+		// Regression: a poisoned provider module (e.g. an init-order failure that
+		// surfaces as `undefined is not a constructor`) once escaped the resolve
+		// loop and disabled web_search entirely. A throw while loading/probing one
+		// provider must isolate to that provider, leaving the rest of the chain.
+		enableKeyBackedProviders();
+		setExcludedSearchProviders(SEARCH_PROVIDER_ORDER.filter(id => id !== "brave" && id !== "jina"));
+		spyOn(BraveProvider.prototype, "isAvailable").mockImplementation(() => {
+			throw new Error("poisoned provider module");
+		});
 
 		const providers = await resolveProviderChain(authStorage, "auto");
 


### PR DESCRIPTION
## Problem

`web_search` fails on **every** query in compiled release binaries with:

```
undefined is not a constructor (evaluating 'new (await Promise.resolve().then(() => (F8A(), b_6))).BingProvider')
```

One provider module (observed: Bing) throws during init in the bundled binary — a minifier init-order failure that esbuild's one-shot `__esm` wrapper masks into the `undefined is not a constructor` message on every subsequent call. Because `resolveProviderChain()` constructs each provider (to probe `isAvailable()`) with **no per-provider error handling**, that single throw escapes resolution and aborts the entire ~25-provider chain. Always-available providers like DuckDuckGo/Google/Yahoo — which sit in the same chain and construct fine — are never reached, so the tool is 100% dead.

## Fix

Isolate provider loading + availability probing per provider so one broken module degrades gracefully instead of disabling web search:

- Add `loadAvailableProvider()` — wraps `getSearchProvider()` plus the `isAvailable`/`isExplicitlyAvailable` probe in `try/catch`, logs the failure at `debug`, and returns `null` so the caller skips the provider.
- Route both `resolveProviderChain()` branches and the explicit-provider path in `executeSearch()` through it. A poisoned explicitly-selected provider now falls back to the auto chain instead of surfacing the raw `TypeError`.

The underlying provider still fails to construct in affected builds, but it is now skipped and logged rather than taking down the whole tool. `public.ts`'s fan-out already isolated loads this way.

## Verification

- New regression test in `provider-chain.test.ts`: a provider that throws while being resolved is skipped and the rest of the chain still resolves (`4 pass`).
- End-to-end against a real minified/compiled binary (`minifyIdentifiers: true`, same as release), with Bing artificially poisoned to throw at module init and `resolveProviderChain` invoked (probes only, no network):
  - **pre-fix:** `THREW` — the chain aborts.
  - **post-fix:** `RESOLVED: startpage,duckduckgo,yahoo,ecosia,google,mojeek` — Bing skipped, chain intact.
- `bun run check:types` and `biome check` pass on the changed files.
