### PR TITLE
Add Azure OpenAI GPT-5.6 models via curated catalog seed

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Azure OpenAI GPT-5.6 models (gpt-5.6, gpt-5.6-sol, gpt-5.6-luna, gpt-5.6-terra) via a curated seed so the bundled catalog is not gated on models.dev cataloguing the new deployments
+
 ## [16.4.3] - 2026-07-11
 
 ### Fixed

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -30,6 +30,7 @@ import {
 import { PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
 import {
 	ANTHROPIC_CURATED_FALLBACK_MODELS,
+	AZURE_CURATED_FALLBACK_MODELS,
 	buildFireworksFastSeed,
 	buildXaiOAuthStaticSeed,
 	clampFireworksKimiMaxTokens,
@@ -497,6 +498,10 @@ async function generateModels() {
 	// Mythos 5). Deduped behind upstream entries; metadata is pinned in
 	// applyAnthropicCatalogPolicy.
 	allModels.push(...ANTHROPIC_CURATED_FALLBACK_MODELS);
+	// Seed Azure OpenAI gpt-5.6 deployments that models.dev has not catalogued
+	// for the azure provider yet. Deduped behind upstream models.dev entries
+	// once those appear (models.dev rows are pushed first, earlier sources win).
+	allModels.push(...AZURE_CURATED_FALLBACK_MODELS);
 	// Seed Sakana's documented Fugu models so the provider is usable when
 	// catalog generation has no live API key. If live `/v1/models` succeeds,
 	// Sakana is authoritative and stale seed IDs must stay out.

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -12294,6 +12294,126 @@
 			},
 			"contextPromotionTarget": "azure/gpt-5.4"
 		},
+		"gpt-5.6": {
+			"id": "gpt-5.6",
+			"name": "GPT-5.6",
+			"api": "azure-openai-responses",
+			"provider": "azure",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna",
+			"api": "azure-openai-responses",
+			"provider": "azure",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"gpt-5.6-sol": {
+			"id": "gpt-5.6-sol",
+			"name": "GPT-5.6 Sol",
+			"api": "azure-openai-responses",
+			"provider": "azure",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
+		"gpt-5.6-terra": {
+			"id": "gpt-5.6-terra",
+			"name": "GPT-5.6 Terra",
+			"api": "azure-openai-responses",
+			"provider": "azure",
+			"baseUrl": "",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			}
+		},
 		"o1": {
 			"id": "o1",
 			"name": "o1",
@@ -68249,9 +68369,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08399999999999999,
-				"output": 0.16799999999999998,
-				"cacheRead": 0.016800000000000002,
+				"input": 0.077,
+				"output": 0.154,
+				"cacheRead": 0.015399999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -70343,8 +70463,8 @@
 			],
 			"cost": {
 				"input": 0.72,
-				"output": 3.49,
-				"cacheRead": 0.159,
+				"output": 3.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -75667,13 +75787,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.42,
-				"output": 1.32,
-				"cacheRead": 0.078,
+				"input": 0.35,
+				"output": 1.1,
+				"cacheRead": 0.065,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -75870,7 +75990,7 @@
 	"synthetic": {
 		"hf:MiniMaxAI/MiniMax-M3": {
 			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+			"name": "MiniMax-M3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -75885,7 +76005,7 @@
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -75900,7 +76020,7 @@
 		},
 		"hf:moonshotai/Kimi-K2.7-Code": {
 			"id": "hf:moonshotai/Kimi-K2.7-Code",
-			"name": "moonshotai/Kimi-K2.7-Code",
+			"name": "Kimi K2.7 Code",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -75930,7 +76050,7 @@
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
-			"name": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+			"name": "Nemotron 3 Super 120B A12B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -75959,7 +76079,7 @@
 		},
 		"hf:openai/gpt-oss-120b": {
 			"id": "hf:openai/gpt-oss-120b",
-			"name": "openai/gpt-oss-120b",
+			"name": "GPT OSS 120B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -75986,7 +76106,7 @@
 		},
 		"hf:Qwen/Qwen3.6-27B": {
 			"id": "hf:Qwen/Qwen3.6-27B",
-			"name": "Qwen/Qwen3.6-27B",
+			"name": "Qwen3.6 27B",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76015,7 +76135,7 @@
 		},
 		"hf:zai-org/GLM-4.7-Flash": {
 			"id": "hf:zai-org/GLM-4.7-Flash",
-			"name": "zai-org/GLM-4.7-Flash",
+			"name": "GLM-4.7-Flash",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -76044,7 +76164,7 @@
 		},
 		"hf:zai-org/GLM-5.2": {
 			"id": "hf:zai-org/GLM-5.2",
-			"name": "zai-org/GLM-5.2",
+			"name": "GLM-5.2",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
@@ -82468,6 +82588,35 @@
 				]
 			}
 		},
+		"kwaipilot/kat-coder-air-v2.5": {
+			"id": "kwaipilot/kat-coder-air-v2.5",
+			"name": "Kat Coder Air V2.5",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 80000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"kwaipilot/kat-coder-pro-v1": {
 			"id": "kwaipilot/kat-coder-pro-v1",
 			"name": "KAT-Coder-Pro V1",
@@ -82505,6 +82654,35 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000
+		},
+		"kwaipilot/kat-coder-pro-v2.5": {
+			"id": "kwaipilot/kat-coder-pro-v2.5",
+			"name": "Kat Coder Pro V2.5",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.74,
+				"output": 2.96,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 80000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"meituan/longcat-flash-chat": {
 			"id": "meituan/longcat-flash-chat",
@@ -86132,9 +86310,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 3,
-				"output": 10.25,
-				"cacheRead": 0.5,
+				"input": 2.0999999999999996,
+				"output": 6.6000000000000005,
+				"cacheRead": 0.21,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -87299,9 +87477,9 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
-				"supportsReasoningEffort": false,
-				"supportsImageDetailOriginal": false
+				"supportsReasoningEffort": false
 			}
 		},
 		"grok-4.20-0309-reasoning": {
@@ -87329,9 +87507,9 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
-				"supportsReasoningEffort": false,
-				"supportsImageDetailOriginal": false
+				"supportsReasoningEffort": false
 			}
 		},
 		"grok-4.20-multi-agent-0309": {
@@ -87352,6 +87530,16 @@
 			},
 			"contextWindow": 2000000,
 			"maxTokens": 2000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87364,16 +87552,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true,
-				"supportsImageDetailOriginal": false
 			}
 		},
 		"grok-4.3": {
@@ -87395,6 +87573,16 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87407,16 +87595,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true,
-				"supportsImageDetailOriginal": false
 			}
 		},
 		"grok-4.5": {
@@ -87438,6 +87616,16 @@
 			},
 			"contextWindow": 500000,
 			"maxTokens": 500000,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				},
+				"includeEncryptedReasoning": false,
+				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
+				"omitReasoningEffort": false,
+				"supportsReasoningEffort": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -87450,16 +87638,6 @@
 				"effortMap": {
 					"minimal": "low"
 				}
-			},
-			"compat": {
-				"reasoningEffortMap": {
-					"minimal": "low"
-				},
-				"includeEncryptedReasoning": false,
-				"filterReasoningHistory": true,
-				"omitReasoningEffort": false,
-				"supportsReasoningEffort": true,
-				"supportsImageDetailOriginal": false
 			}
 		},
 		"grok-build": {
@@ -87487,9 +87665,9 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
-				"supportsReasoningEffort": false,
-				"supportsImageDetailOriginal": false
+				"supportsReasoningEffort": false
 			}
 		},
 		"grok-build-0.1": {
@@ -87517,9 +87695,9 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
-				"supportsReasoningEffort": false,
-				"supportsImageDetailOriginal": false
+				"supportsReasoningEffort": false
 			}
 		},
 		"grok-composer-2.5-fast": {
@@ -87546,9 +87724,9 @@
 				},
 				"includeEncryptedReasoning": false,
 				"filterReasoningHistory": true,
+				"supportsImageDetailOriginal": false,
 				"omitReasoningEffort": true,
-				"supportsReasoningEffort": false,
-				"supportsImageDetailOriginal": false
+				"supportsReasoningEffort": false
 			}
 		}
 	},

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4564,6 +4564,50 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_GOOGLE_VERTEX: readonly ModelsDevProviderD
 	}),
 ];
 
+/**
+ * Curated Azure OpenAI models that are deployable on Azure (the deployment
+ * name matches the first-party SKU id) but that models.dev has not catalogued
+ * for the `azure` provider yet — currently the gpt-5.6 generation. Seeded into
+ * model generation so the bundled catalog is never gated on models.dev's
+ * update cadence; deduped behind upstream models.dev entries once those
+ * appear. Pricing mirrors the first-party OpenAI rows except `cacheWrite: 0`
+ * (Azure does not bill cache writes), matching every other bundled azure row.
+ * `thinking` is re-baked by the generator's policy pass
+ * (scripts/generated-policies.ts).
+ */
+function createAzureGpt56StaticModel(
+	id: string,
+	name: string,
+	cost: ModelSpec<"azure-openai-responses">["cost"],
+): ModelSpec<"azure-openai-responses"> {
+	return {
+		id,
+		name,
+		api: "azure-openai-responses",
+		provider: "azure",
+		// Empty baseUrl: the deployment host is per-resource, resolved at runtime
+		// from AZURE_OPENAI_BASE_URL / AZURE_OPENAI_RESOURCE_NAME.
+		baseUrl: "",
+		reasoning: true,
+		input: ["text", "image"],
+		cost,
+		contextWindow: 1_050_000,
+		maxTokens: 128_000,
+	};
+}
+
+export const AZURE_CURATED_FALLBACK_MODELS: readonly ModelSpec<"azure-openai-responses">[] = [
+	createAzureGpt56StaticModel("gpt-5.6", "GPT-5.6", { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 }),
+	createAzureGpt56StaticModel("gpt-5.6-sol", "GPT-5.6 Sol", { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 }),
+	createAzureGpt56StaticModel("gpt-5.6-luna", "GPT-5.6 Luna", { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 0 }),
+	createAzureGpt56StaticModel("gpt-5.6-terra", "GPT-5.6 Terra", {
+		input: 2.5,
+		output: 15,
+		cacheRead: 0.25,
+		cacheWrite: 0,
+	}),
+];
+
 const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDescriptor[] = [
 	// --- Azure OpenAI ---
 	// OpenAI-family models hosted on Azure, served via the Responses API. baseUrl

--- a/packages/catalog/test/azure-provider.test.ts
+++ b/packages/catalog/test/azure-provider.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { buildOpenAIResponsesCompat } from "@oh-my-pi/pi-catalog/compat/openai";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import MODELS_JSON from "@oh-my-pi/pi-catalog/models.json" with { type: "json" };
 import {
+	AZURE_CURATED_FALLBACK_MODELS,
 	DEFAULT_MODEL_PER_PROVIDER,
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
 	mapModelsDevToModels,
@@ -78,4 +80,43 @@ describe("azure catalog provider", () => {
 		expect(model.thinking?.mode).toBe("effort");
 		expect(model.thinking?.efforts).toContain(Effort.XHigh);
 	});
+});
+
+// Pins the invariant: bundled `models.json` carries every entry the curated
+// azure gpt-5.6 seed (AZURE_CURATED_FALLBACK_MODELS) emits. models.dev has not
+// catalogued the gpt-5.6 generation for azure yet, so the bundle is the only
+// source for these ids. Failure here means: run `bun run gen:models` and
+// commit the diff.
+describe("azure curated gpt-5.6 seed (regression)", () => {
+	const bundled =
+		(MODELS_JSON as unknown as Record<string, Record<string, ModelSpec<"azure-openai-responses">>>).azure ?? {};
+
+	test("seed covers the gpt-5.6 deployment generation", () => {
+		expect(AZURE_CURATED_FALLBACK_MODELS.map(model => model.id).sort()).toEqual([
+			"gpt-5.6",
+			"gpt-5.6-luna",
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+		]);
+	});
+
+	for (const seeded of AZURE_CURATED_FALLBACK_MODELS) {
+		test(`bundles ${seeded.id} with the azure Responses shape`, () => {
+			const entry = bundled[seeded.id];
+			expect(entry, `azure/${seeded.id} missing from models.json`).toBeDefined();
+			expect(entry.api).toBe("azure-openai-responses");
+			expect(entry.provider).toBe("azure");
+			// Empty baseUrl: the deployment host is per-resource, resolved at runtime.
+			expect(entry.baseUrl).toBe("");
+			expect(entry.reasoning).toBe(true);
+			expect(entry.input).toEqual(["text", "image"]);
+			expect(entry.contextWindow).toBe(seeded.contextWindow);
+			expect(entry.maxTokens).toBe(seeded.maxTokens);
+			// Azure does not bill cache writes; mirrors every other bundled azure row.
+			expect(entry.cost).toEqual(seeded.cost);
+			// Policy pass must bake the gpt-5.6 effort vocabulary (incl. max).
+			expect(entry.thinking?.mode).toBe("effort");
+			expect(entry.thinking?.efforts).toContain(Effort.XHigh);
+		});
+	}
 });


### PR DESCRIPTION
## Summary

The bundled catalog's `azure` provider stopped at `gpt-5.5` because models.dev has not catalogued the gpt-5.6 generation for Azure yet, while the same SKUs are already deployable as Azure OpenAI deployments. This adds the gpt-5.6 deployments to the bundled catalog through the generator (per the repo's generated-files convention — no hand edits to `models.json`).

## Changes

- **`src/provider-models/openai-compat.ts`**: new `AZURE_CURATED_FALLBACK_MODELS` seed — `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-luna`, `gpt-5.6-terra` on `azure-openai-responses` with empty `baseUrl` (deployment host resolved at runtime), pricing mirroring the first-party OpenAI rows with `cacheWrite: 0` (Azure does not bill cache writes, matching every other bundled azure row).
- **`scripts/generate-models.ts`**: pushes the seed after models.dev rows, so it is deduped behind upstream entries once models.dev catalogues them.
- **`src/models.json`**: regenerated via `bun run gen:models` (includes incidental upstream refresh: gateway name normalization, new vercel-ai-gateway entries). The policy pass bakes the gpt-5.6 effort vocabulary (`low`…`max`) onto the new rows.
- **`test/azure-provider.test.ts`**: regression test pinning the seed contents and seed↔bundle parity, so editing the seed without regenerating `models.json` fails CI.

## Testing

- `bun test packages/catalog/test/azure-provider.test.ts` — 9 pass
- `bun test packages/catalog/test/` — 425 pass
- `bun check` — pi-catalog clean