### PR TITLE
feat: add model profiles for saving and switching model configurations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added model profiles: save and switch between named model configurations (role assignments + thinking level) with `/profiles save|switch|delete|list` or press `s` in the `/models` roles view.
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added model profiles: save and switch between named model configurations (role assignments + thinking level) with `/profiles save|switch|delete|list` or press `s` in the `/models` roles view.
+- Added model profiles: save and switch between named model configurations (role assignments + thinking level) with `/profiles save|switch|delete|list`, browse profiles interactively with `/profiles` (no args), or press `ctrl+s` in the `/models` roles view.
 
 ## [16.4.6] - 2026-07-12
 

--- a/packages/coding-agent/src/config/profiles.ts
+++ b/packages/coding-agent/src/config/profiles.ts
@@ -1,3 +1,6 @@
+import type { Model } from "@oh-my-pi/pi-ai";
+import type { ConfiguredThinkingLevel } from "../thinking";
+import { resolveModelRoleValue } from "./model-resolver";
 import type { Settings } from "./settings";
 import type { ProfileSnapshot } from "./settings-schema";
 
@@ -54,4 +57,37 @@ export function deleteProfile(settings: Settings, name: string): boolean {
 	delete profiles[name];
 	settings.set("profiles", profiles);
 	return true;
+}
+
+export interface ProfileSwitchResult {
+	ok: boolean;
+	model?: Model;
+	thinkingLevel?: ConfiguredThinkingLevel;
+}
+
+/**
+ * Switch to a named profile and resolve the default role's model + thinking
+ * level from the available models. Returns the resolved model and thinking
+ * level so the caller can apply them to the live session.
+ *
+ * This is the single source of truth for profile switching — the slash
+ * command handlers and the interactive picker all call this.
+ */
+export function switchProfileAndResolve(
+	settings: Settings,
+	name: string,
+	availableModels: ReadonlyArray<Model>,
+): ProfileSwitchResult {
+	const ok = switchProfile(settings, name);
+	if (!ok) return { ok: false };
+	const defaultRole = settings.getModelRole("default");
+	if (!defaultRole) return { ok: true };
+	const resolved = resolveModelRoleValue(defaultRole, availableModels as Model[], {
+		settings,
+	});
+	return {
+		ok: true,
+		model: resolved.model,
+		thinkingLevel: resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined,
+	};
 }

--- a/packages/coding-agent/src/config/profiles.ts
+++ b/packages/coding-agent/src/config/profiles.ts
@@ -73,6 +73,10 @@ export interface ProfileSwitchResult {
 	/** True when the profile has no explicit default role — the caller should
 	 *  reset the session to its automatic/default model. */
 	needsReset?: boolean;
+	/** True when the profile has a default role but it couldn't resolve against
+	 *  available models (provider disabled, credentials removed, typo). The
+	 *  caller should warn the user and reset to the automatic default. */
+	unresolvedDefault?: boolean;
 }
 
 /**
@@ -95,6 +99,11 @@ export function switchProfileAndResolve(
 	const resolved = resolveModelRoleValue(defaultRole, availableModels as Model[], {
 		settings,
 	});
+	if (!resolved.model) {
+		// Profile has a default role but it doesn't resolve — fall back to
+		// automatic default and warn the user.
+		return { ok: true, needsReset: true, unresolvedDefault: true };
+	}
 	return {
 		ok: true,
 		model: resolved.model,

--- a/packages/coding-agent/src/config/profiles.ts
+++ b/packages/coding-agent/src/config/profiles.ts
@@ -1,0 +1,57 @@
+import type { Settings } from "./settings";
+import type { ProfileSnapshot } from "./settings-schema";
+
+/** Get all profiles as a typed record. */
+export function getProfiles(settings: Settings): Record<string, ProfileSnapshot> {
+	const value = settings.get("profiles");
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	return value as Record<string, ProfileSnapshot>;
+}
+
+/** Get sorted profile names. */
+export function getProfileNames(settings: Settings): string[] {
+	return Object.keys(getProfiles(settings)).sort((a, b) => a.localeCompare(b));
+}
+
+/** Save the current model configuration as a named profile. Overwrites if exists. */
+export function saveProfile(settings: Settings, name: string): void {
+	const modelRoles: Record<string, string> = {};
+	for (const [role, selector] of Object.entries(settings.getModelRoles())) {
+		if (selector) modelRoles[role] = selector;
+	}
+	const defaultThinkingLevel = settings.get("defaultThinkingLevel");
+	const snapshot: ProfileSnapshot = {
+		modelRoles,
+		defaultThinkingLevel,
+	};
+	const profiles = getProfiles(settings);
+	profiles[name] = snapshot;
+	settings.set("profiles", profiles);
+}
+
+/**
+ * Switch to a named profile. Replaces the entire modelRoles record and
+ * defaultThinkingLevel — clean cutover, NOT a merge. This ensures stale
+ * role assignments from the previously-active profile are removed.
+ *
+ * Returns true if the profile existed and was applied.
+ */
+export function switchProfile(settings: Settings, name: string): boolean {
+	const profiles = getProfiles(settings);
+	const profile = profiles[name];
+	if (!profile) return false;
+	settings.set("modelRoles", profile.modelRoles);
+	if (profile.defaultThinkingLevel !== undefined) {
+		settings.set("defaultThinkingLevel", profile.defaultThinkingLevel);
+	}
+	return true;
+}
+
+/** Delete a named profile. Returns true if it existed. */
+export function deleteProfile(settings: Settings, name: string): boolean {
+	const profiles = getProfiles(settings);
+	if (!(name in profiles)) return false;
+	delete profiles[name];
+	settings.set("profiles", profiles);
+	return true;
+}

--- a/packages/coding-agent/src/config/profiles.ts
+++ b/packages/coding-agent/src/config/profiles.ts
@@ -70,6 +70,9 @@ export interface ProfileSwitchResult {
 	ok: boolean;
 	model?: Model;
 	thinkingLevel?: ConfiguredThinkingLevel;
+	/** True when the profile has no explicit default role — the caller should
+	 *  reset the session to its automatic/default model. */
+	needsReset?: boolean;
 }
 
 /**
@@ -88,7 +91,7 @@ export function switchProfileAndResolve(
 	const ok = switchProfile(settings, name);
 	if (!ok) return { ok: false };
 	const defaultRole = settings.getModelRole("default");
-	if (!defaultRole) return { ok: true };
+	if (!defaultRole) return { ok: true, needsReset: true };
 	const resolved = resolveModelRoleValue(defaultRole, availableModels as Model[], {
 		settings,
 	});

--- a/packages/coding-agent/src/config/profiles.ts
+++ b/packages/coding-agent/src/config/profiles.ts
@@ -24,7 +24,7 @@ export function saveProfile(settings: Settings, name: string): void {
 		modelRoles,
 		defaultThinkingLevel,
 	};
-	const profiles = getProfiles(settings);
+	const profiles = { ...getProfiles(settings) };
 	profiles[name] = snapshot;
 	settings.set("profiles", profiles);
 }
@@ -49,7 +49,7 @@ export function switchProfile(settings: Settings, name: string): boolean {
 
 /** Delete a named profile. Returns true if it existed. */
 export function deleteProfile(settings: Settings, name: string): boolean {
-	const profiles = getProfiles(settings);
+	const profiles = { ...getProfiles(settings) };
 	if (!(name in profiles)) return false;
 	delete profiles[name];
 	settings.set("profiles", profiles);

--- a/packages/coding-agent/src/config/profiles.ts
+++ b/packages/coding-agent/src/config/profiles.ts
@@ -27,7 +27,9 @@ export function saveProfile(settings: Settings, name: string): void {
 		modelRoles,
 		defaultThinkingLevel,
 	};
-	const profiles = { ...getProfiles(settings) };
+	// Read from the global layer only — not the merged view — so we don't
+	// copy project-scoped profiles into the global config.
+	const profiles = { ...settings.getGlobalProfiles() };
 	profiles[name] = snapshot;
 	settings.set("profiles", profiles);
 }
@@ -55,7 +57,9 @@ export function switchProfile(settings: Settings, name: string): boolean {
 
 /** Delete a named profile. Returns true if it existed. */
 export function deleteProfile(settings: Settings, name: string): boolean {
-	const profiles = { ...getProfiles(settings) };
+	// Read from the global layer only — not the merged view — so we don't
+	// copy project-scoped profiles into the global config.
+	const profiles = { ...settings.getGlobalProfiles() };
 	if (!(name in profiles)) return false;
 	delete profiles[name];
 	settings.set("profiles", profiles);

--- a/packages/coding-agent/src/config/profiles.ts
+++ b/packages/coding-agent/src/config/profiles.ts
@@ -47,6 +47,9 @@ export function switchProfile(settings: Settings, name: string): boolean {
 	if (profile.defaultThinkingLevel !== undefined) {
 		settings.set("defaultThinkingLevel", profile.defaultThinkingLevel);
 	}
+	// Clear any runtime model-role overrides (from --model or env) so the
+	// profile's assignments take effect instead of the override winning.
+	settings.clearOverride("modelRoles");
 	return true;
 }
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -279,6 +279,12 @@ export interface ModelTagsSettings {
 	[key: string]: ModelTagDef;
 }
 
+/** Snapshot of model configuration captured by a named profile. */
+export interface ProfileSnapshot {
+	modelRoles: Record<string, string>;
+	defaultThinkingLevel: SettingValue<"defaultThinkingLevel">;
+}
+
 // Typed defaults for array/record settings — named constants avoid `as` casts
 // under `as const` while still letting SettingValue infer the correct element type.
 const EMPTY_STRING_ARRAY: string[] = [];
@@ -287,6 +293,7 @@ const EMPTY_NUMBER_RECORD: Record<string, number> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const DEFAULT_TOOL_CALL_LOOP_EXEMPT_TOOLS: string[] = ["job", "irc"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
+const EMPTY_PROFILES_RECORD: Record<string, ProfileSnapshot> = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	{
@@ -480,6 +487,8 @@ export const SETTINGS_SCHEMA = {
 	disabledExtensions: { type: "array", default: EMPTY_STRING_ARRAY },
 
 	modelRoles: { type: "record", default: EMPTY_STRING_RECORD },
+
+	profiles: { type: "record", default: EMPTY_PROFILES_RECORD },
 
 	modelTags: { type: "record", default: EMPTY_MODEL_TAGS_RECORD },
 
@@ -5254,6 +5263,7 @@ export interface GroupTypeMap {
 	thinkingBudgets: ThinkingBudgetsSettings;
 	stt: SttSettings;
 	modelRoles: Record<string, string>;
+	profiles: Record<string, ProfileSnapshot>;
 	modelTags: ModelTagsSettings;
 	cycleOrder: string[];
 	shellMinimizer: ShellMinimizerSettings;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -40,6 +40,7 @@ import {
 	type GroupPrefix,
 	type GroupTypeMap,
 	getDefault,
+	type ProfileSnapshot,
 	SETTINGS_SCHEMA,
 	type SettingPath,
 	type SettingValue,
@@ -659,6 +660,17 @@ export class Settings {
 			}
 		}
 		return normalized;
+	}
+
+	/**
+	 * Get profiles from the global/persisted layer only (not merged with project
+	 * or runtime overrides). Used by saveProfile/deleteProfile to avoid copying
+	 * project-scoped profiles into the global config.
+	 */
+	getGlobalProfiles(): Record<string, ProfileSnapshot> {
+		const value = getByPath(this.#global, ["profiles"]);
+		if (!isRecord(value)) return {};
+		return value as Record<string, ProfileSnapshot>;
 	}
 
 	/*

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -1422,7 +1422,7 @@ export class ModelHubComponent implements Component {
 			this.#openRoleNameStrip();
 			return;
 		}
-		if (printable === "s") {
+		if (matchesKey(data, "ctrl+s")) {
 			this.#openProfileNameStrip();
 			return;
 		}
@@ -1921,7 +1921,7 @@ export class ModelHubComponent implements Component {
 			if (row?.kind === "newFallback") {
 				return "↑/↓ rows · Enter new model/provider fallback chain · ← providers";
 			}
-			return "↑/↓ rows · Enter pick · f fallback · x clear · t thinking · c cycle · [/] reorder · n new · s save profile";
+			return "↑/↓ rows · Enter pick · f fallback · x clear · t thinking · c cycle · [/] reorder · n new · ctrl+s save profile";
 		}
 		if (entry.kind === "provider" && entry.locked) {
 			return entry.oauth ? "Enter log in · ↑/↓ providers · Esc close" : "↑/↓ providers · Esc close";

--- a/packages/coding-agent/src/modes/components/model-hub.ts
+++ b/packages/coding-agent/src/modes/components/model-hub.ts
@@ -95,6 +95,8 @@ export interface ModelHubCallbacks {
 	onLoginRequest?: (providerId: string) => void;
 	/** Persist a new quick-switch cycle order (the ctrl+p role cycle). */
 	onCycleOrderChange?: (order: string[]) => void;
+	/** Save the current model configuration as a named profile. */
+	onSaveProfile?: (name: string) => void;
 	onCancel: () => void;
 }
 
@@ -143,6 +145,11 @@ type StripState =
 	| {
 			/** Footer text input naming a new custom role. */
 			kind: "roleName";
+			input: Input;
+	  }
+	| {
+			/** Footer text input naming a profile to save. */
+			kind: "profileName";
 			input: Input;
 	  };
 
@@ -925,7 +932,7 @@ export class ModelHubComponent implements Component {
 
 	#activateStripChip(): void {
 		const strip = this.#strip;
-		if (!strip || strip.kind === "roleName") return;
+		if (!strip || strip.kind === "roleName" || strip.kind === "profileName") return;
 		const chip = strip.chips[strip.index];
 		if (!chip) return;
 		switch (chip.action) {
@@ -1135,6 +1142,22 @@ export class ModelHubComponent implements Component {
 		this.#startAssign(name);
 	}
 
+	/** Open the footer name input that saves the current config as a profile. */
+	#openProfileNameStrip(): void {
+		this.#strip = { kind: "profileName", input: new Input() };
+	}
+
+	/** Validate and commit the profile name: save current model config. */
+	#submitProfileName(): void {
+		const strip = this.#strip;
+		if (strip?.kind !== "profileName") return;
+		const name = strip.input.getValue().trim();
+		if (!/^[a-zA-Z][\w-]*$/.test(name)) return;
+		this.#strip = null;
+		this.#chipRanges = [];
+		this.#callbacks.onSaveProfile?.(name);
+	}
+
 	// ═══════════════════════════════════════════════════════════════════════
 	// Input
 	// ═══════════════════════════════════════════════════════════════════════
@@ -1234,6 +1257,14 @@ export class ModelHubComponent implements Component {
 		if (strip.kind === "roleName") {
 			if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
 				this.#submitRoleName();
+				return;
+			}
+			strip.input.handleInput(data);
+			return;
+		}
+		if (strip.kind === "profileName") {
+			if (matchesKey(data, "enter") || matchesKey(data, "return") || data === "\n") {
+				this.#submitProfileName();
 				return;
 			}
 			strip.input.handleInput(data);
@@ -1391,6 +1422,10 @@ export class ModelHubComponent implements Component {
 			this.#openRoleNameStrip();
 			return;
 		}
+		if (printable === "s") {
+			this.#openProfileNameStrip();
+			return;
+		}
 		if (printable === "t") {
 			const assignment = role ? this.#roles[role] : undefined;
 			if (role && assignment) {
@@ -1431,7 +1466,7 @@ export class ModelHubComponent implements Component {
 		// Footer strip chips.
 		if (event.row === this.#footerRow && this.#strip) {
 			const strip = this.#strip;
-			if (event.leftClick && strip.kind !== "roleName") {
+			if (event.leftClick && strip.kind !== "roleName" && strip.kind !== "profileName") {
 				for (const range of this.#chipRanges) {
 					if (event.col >= range.start && event.col < range.end) {
 						strip.index = range.index;
@@ -1854,6 +1889,9 @@ export class ModelHubComponent implements Component {
 			if (strip.kind === "roleName") {
 				return "Enter create + pick model · Esc cancel";
 			}
+			if (strip.kind === "profileName") {
+				return "Enter save · Esc cancel";
+			}
 			return strip.kind === "role"
 				? "←/→ choose · Enter assign/clear · Esc cancel"
 				: "←/→ thinking level · Enter apply · Esc keep";
@@ -1883,7 +1921,7 @@ export class ModelHubComponent implements Component {
 			if (row?.kind === "newFallback") {
 				return "↑/↓ rows · Enter new model/provider fallback chain · ← providers";
 			}
-			return "↑/↓ rows · Enter pick · f fallback · x clear · t thinking · c cycle · [/] reorder · n new";
+			return "↑/↓ rows · Enter pick · f fallback · x clear · t thinking · c cycle · [/] reorder · n new · s save profile";
 		}
 		if (entry.kind === "provider" && entry.locked) {
 			return entry.oauth ? "Enter log in · ↑/↓ providers · Esc close" : "↑/↓ providers · Esc close";
@@ -1907,6 +1945,13 @@ export class ModelHubComponent implements Component {
 		if (strip.kind === "roleName") {
 			const label = theme.fg("accent", "New role name:");
 			const inputWidth = Math.max(8, Math.min(32, width - visibleWidth("New role name:") - 24));
+			const inputLine = strip.input.render(inputWidth)[0] ?? "";
+			return truncateToWidth(`${label} ${inputLine} ${theme.fg("dim", "(letters, digits, - and _)")}`, width);
+		}
+
+		if (strip.kind === "profileName") {
+			const label = theme.fg("accent", "Profile name:");
+			const inputWidth = Math.max(8, Math.min(32, width - visibleWidth("Profile name:") - 24));
 			const inputLine = strip.input.render(inputWidth)[0] ?? "";
 			return truncateToWidth(`${label} ${inputLine} ${theme.fg("dim", "(letters, digits, - and _)")}`, width);
 		}

--- a/packages/coding-agent/src/modes/components/profile-selector.ts
+++ b/packages/coding-agent/src/modes/components/profile-selector.ts
@@ -1,0 +1,52 @@
+import { Container, type SelectItem, SelectList, type SgrMouseEvent } from "@oh-my-pi/pi-tui";
+import { getSelectListTheme } from "../theme/theme";
+import { DynamicBorder } from "./dynamic-border";
+import { routeSelectListMouseWithTopBorder } from "./select-list-mouse-routing";
+
+export interface ProfileSelectorCallbacks {
+	onPick: (profileName: string) => void;
+	onCancel: () => void;
+}
+
+/**
+ * Interactive profile picker: lists saved profiles with keyboard navigation
+ * and fuzzy search. Rendered as an editor-slot selector (like /thinking).
+ */
+export class ProfileSelectorComponent extends Container {
+	#selectList: SelectList;
+
+	constructor(profileNames: string[], callbacks: ProfileSelectorCallbacks) {
+		super();
+
+		const items: SelectItem[] = profileNames.map(name => ({
+			value: name,
+			label: name,
+		}));
+
+		this.addChild(new DynamicBorder());
+
+		this.#selectList = new SelectList(
+			items.length > 0
+				? items
+				: [{ value: "", label: "No profiles saved. Use /profiles save <name> to create one." }],
+			Math.min(Math.max(items.length, 1), 15),
+			getSelectListTheme(),
+		);
+
+		this.#selectList.onSelect = item => {
+			if (item.value) callbacks.onPick(item.value);
+		};
+
+		this.#selectList.onCancel = () => {
+			callbacks.onCancel();
+		};
+
+		this.addChild(this.#selectList);
+
+		this.addChild(new DynamicBorder());
+	}
+
+	routeMouse(event: SgrMouseEvent, line: number, col: number): void {
+		routeSelectListMouseWithTopBorder(this.#selectList, event, line, col);
+	}
+}

--- a/packages/coding-agent/src/modes/components/profile-selector.ts
+++ b/packages/coding-agent/src/modes/components/profile-selector.ts
@@ -49,4 +49,8 @@ export class ProfileSelectorComponent extends Container {
 	routeMouse(event: SgrMouseEvent, line: number, col: number): void {
 		routeSelectListMouseWithTopBorder(this.#selectList, event, line, col);
 	}
+
+	handleInput(data: string): void {
+		this.#selectList.handleInput(data);
+	}
 }

--- a/packages/coding-agent/src/modes/components/profile-selector.ts
+++ b/packages/coding-agent/src/modes/components/profile-selector.ts
@@ -50,7 +50,7 @@ export class ProfileSelectorComponent extends Container {
 		routeSelectListMouseWithTopBorder(this.#selectList, event, line, col);
 	}
 
-	handleInput(data: string): void {
-		this.#selectList.handleInput(data);
+	getSelectList(): SelectList {
+		return this.#selectList;
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1480,6 +1480,9 @@ export class SelectorController {
 						this.ctx.showError(`Profile not found: ${name}`);
 						return;
 					}
+					if (result.unresolvedDefault) {
+						this.ctx.showWarning(`Profile "${name}" default unavailable — using automatic selection`);
+					}
 					if (result.model) {
 						try {
 							await this.ctx.session.setModel(result.model);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1472,7 +1472,7 @@ export class SelectorController {
 		const names = getProfileNames(this.ctx.settings);
 		this.showSelector(done => {
 			const selector = new ProfileSelectorComponent(names, {
-				onPick: name => {
+				onPick: async name => {
 					done();
 					const availableModels = this.ctx.session.getAvailableModels?.() ?? [];
 					const result = switchProfileAndResolve(this.ctx.settings, name, availableModels);
@@ -1482,7 +1482,7 @@ export class SelectorController {
 					}
 					if (result.model) {
 						try {
-							void this.ctx.session.setModel(result.model);
+							await this.ctx.session.setModel(result.model);
 							if (result.thinkingLevel && result.thinkingLevel !== ThinkingLevel.Inherit) {
 								this.ctx.session.setThinkingLevel(result.thinkingLevel);
 							}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1492,6 +1492,15 @@ export class SelectorController {
 							// Settings applied, model switch failed
 						}
 					}
+					if (result.needsReset) {
+						try {
+							await this.ctx.session.resetToDefaultModel?.();
+							this.ctx.statusLine.invalidate();
+							this.ctx.updateEditorBorderColor();
+						} catch {
+							// Non-critical — settings are still applied
+						}
+					}
 					this.ctx.statusLine.invalidate();
 					this.ctx.showStatus(`Switched to profile: ${name}`);
 				},

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -14,7 +14,7 @@ import {
 } from "../../advisor";
 import { formatModelSelectorValue, resolveAdvisorRoleSelection } from "../../config/model-resolver";
 import { getRoleInfo } from "../../config/model-roles";
-import { saveProfile } from "../../config/profiles";
+import { getProfileNames, saveProfile, switchProfileAndResolve } from "../../config/profiles";
 import { settings } from "../../config/settings";
 import { disableProvider, enableProvider } from "../../discovery";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -71,6 +71,7 @@ import { LogoutAccountSelectorComponent } from "../components/logout-account-sel
 import { ModelHubComponent, type ModelHubMode } from "../components/model-hub";
 import { OAuthSelectorComponent } from "../components/oauth-selector";
 import { PluginSelectorComponent } from "../components/plugin-selector";
+import { ProfileSelectorComponent } from "../components/profile-selector";
 import { ResetUsageSelectorComponent } from "../components/reset-usage-selector";
 import { SessionSelectorComponent } from "../components/session-selector";
 import { SettingsSelectorComponent } from "../components/settings-selector";
@@ -1463,6 +1464,42 @@ export class SelectorController {
 		const { DebugSelectorComponent } = await import("../../debug");
 		this.showSelector(done => {
 			const selector = new DebugSelectorComponent(this.ctx, done);
+			return { component: selector, focus: selector };
+		});
+	}
+
+	showProfileSelector(): void {
+		const names = getProfileNames(this.ctx.settings);
+		this.showSelector(done => {
+			const selector = new ProfileSelectorComponent(names, {
+				onPick: name => {
+					done();
+					const availableModels = this.ctx.session.getAvailableModels?.() ?? [];
+					const result = switchProfileAndResolve(this.ctx.settings, name, availableModels);
+					if (!result.ok) {
+						this.ctx.showError(`Profile not found: ${name}`);
+						return;
+					}
+					if (result.model) {
+						try {
+							void this.ctx.session.setModel(result.model);
+							if (result.thinkingLevel && result.thinkingLevel !== ThinkingLevel.Inherit) {
+								this.ctx.session.setThinkingLevel(result.thinkingLevel);
+							}
+							this.ctx.statusLine.invalidate();
+							this.ctx.updateEditorBorderColor();
+						} catch {
+							// Settings applied, model switch failed
+						}
+					}
+					this.ctx.statusLine.invalidate();
+					this.ctx.showStatus(`Switched to profile: ${name}`);
+				},
+				onCancel: () => {
+					done();
+					this.ctx.ui.requestRender();
+				},
+			});
 			return { component: selector, focus: selector };
 		});
 	}

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1500,7 +1500,7 @@ export class SelectorController {
 					this.ctx.ui.requestRender();
 				},
 			});
-			return { component: selector, focus: selector };
+			return { component: selector, focus: selector.getSelectList() };
 		});
 	}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -14,6 +14,7 @@ import {
 } from "../../advisor";
 import { formatModelSelectorValue, resolveAdvisorRoleSelection } from "../../config/model-resolver";
 import { getRoleInfo } from "../../config/model-roles";
+import { saveProfile } from "../../config/profiles";
 import { settings } from "../../config/settings";
 import { disableProvider, enableProvider } from "../../discovery";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -711,6 +712,14 @@ export class SelectorController {
 						this.ctx.showStatus(
 							order.length > 0 ? `Quick-switch cycle: ${order.join(" → ")}` : "Quick-switch cycle cleared",
 						);
+					} catch (error) {
+						this.ctx.showError(error instanceof Error ? error.message : String(error));
+					}
+				},
+				onSaveProfile: name => {
+					try {
+						saveProfile(this.ctx.settings, name);
+						this.ctx.showStatus(`Profile saved: ${name}`);
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
 					}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -4139,6 +4139,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#selectorController.showDebugSelector();
 	}
 
+	showProfileSelector(): void {
+		this.#selectorController.showProfileSelector();
+	}
+
 	showAgentHub(options?: { requireContent?: boolean }): void {
 		this.#selectorController.showAgentHub(this.#observerRegistry, options);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -368,6 +368,7 @@ export interface InteractiveModeContext {
 	showProviderSetup(): Promise<void>;
 	showHookConfirm(title: string, message: string): Promise<boolean>;
 	showDebugSelector(): Promise<void>;
+	showProfileSelector(): void;
 	showAgentHub(options?: { requireContent?: boolean }): void;
 	resetObserverRegistry(): void;
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -177,6 +177,7 @@ import {
 	formatModelStringWithRouting,
 	getModelMatchPreferences,
 	parseModelString,
+	pickDefaultAvailableModel,
 	type ResolvedModelRoleValue,
 	resolveAdvisorRoleSelection,
 	resolveModelOverride,
@@ -9306,6 +9307,20 @@ export class AgentSession {
 		const patterns = this.settings.get("enabledModels");
 		if (!patterns || patterns.length === 0) return all;
 		return filterAvailableModelsByEnabledPatterns(all, patterns);
+	}
+
+	/**
+	 * Reset the live model to the automatic default — the first authed model
+	 * chosen by {@link pickDefaultAvailableModel}, mirroring startup resolution
+	 * when no `modelRoles.default` is set. Used when switching to a profile
+	 * that has no explicit default role.
+	 * @throws Error if no model with configured auth is available
+	 */
+	async resetToDefaultModel(): Promise<void> {
+		const candidates = this.getAvailableModels().filter(m => this.#modelRegistry.hasConfiguredAuth(m));
+		const target = pickDefaultAvailableModel(candidates);
+		if (!target) throw new Error("No model with configured credentials available for default selection");
+		await this.setModel(target, "default");
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -429,6 +429,11 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					await runtime.output(`Profile not found: ${name}`);
 					return commandConsumed();
 				}
+				if (result.unresolvedDefault) {
+					await runtime.output(
+						`Warning: profile "${name}" default model is unavailable — using automatic selection.`,
+					);
+				}
 				if (result.model) {
 					try {
 						await runtime.session.setModel(result.model);
@@ -504,6 +509,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				if (!result.ok) {
 					runtime.ctx.showWarning(`Profile not found: ${name}`);
 					return commandConsumed();
+				}
+				if (result.unresolvedDefault) {
+					runtime.ctx.showWarning(`Profile "${name}" default unavailable — using automatic selection`);
 				}
 				if (result.model) {
 					try {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
@@ -437,6 +438,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					if (resolved.model) {
 						try {
 							await runtime.session.setModel(resolved.model);
+							const thinking = resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined;
+							if (thinking && thinking !== ThinkingLevel.Inherit) {
+								runtime.session.setThinkingLevel(thinking);
+							}
 						} catch {
 							// Settings still applied — user can /model manually
 						}
@@ -503,6 +508,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					if (resolved.model) {
 						try {
 							await runtime.ctx.session.setModel(resolved.model);
+							const thinking = resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined;
+							if (thinking && thinking !== ThinkingLevel.Inherit) {
+								runtime.ctx.session.setThinkingLevel(thinking);
+							}
 							runtime.ctx.statusLine.invalidate();
 							runtime.ctx.updateEditorBorderColor();
 						} catch {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -6,6 +6,8 @@ import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
+import { resolveModelRoleValue } from "../config/model-resolver";
+import { deleteProfile, getProfileNames, saveProfile, switchProfile } from "../config/profiles";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
@@ -377,6 +379,154 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		handleTui: (_command, runtime) => {
 			runtime.ctx.showModelSelector();
 			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "profiles",
+		description: "Manage model profiles (save, switch, delete, list)",
+		acpDescription: "Manage model profiles",
+		acpInputHint: "<subcommand>",
+		inlineHint: "<subcommand>",
+		subcommands: [
+			{ name: "save", description: "Save current model configuration as a profile", usage: "<name>" },
+			{ name: "switch", description: "Switch to a saved profile", usage: "<name>" },
+			{ name: "delete", description: "Delete a saved profile", usage: "<name>" },
+			{ name: "list", description: "List all saved profiles" },
+		],
+		allowArgs: true,
+		getTuiAutocompleteDescription: runtime => {
+			const names = getProfileNames(runtime.ctx.settings);
+			return names.length > 0 ? `Profiles: ${names.length} saved` : "Profiles: none saved";
+		},
+		handle: async (command, runtime) => {
+			const [sub, ...rest] = command.args.trim().split(/\s+/);
+			const name = rest.join(" ").trim();
+
+			if (!sub || sub === "list") {
+				const names = getProfileNames(runtime.settings);
+				if (names.length === 0) {
+					await runtime.output("No profiles saved. Use /profiles save <name> to create one.");
+				} else {
+					const lines = names.map(n => `  • ${n}`);
+					await runtime.output(`Saved profiles:\n${lines.join("\n")}`);
+				}
+				return commandConsumed();
+			}
+
+			if (sub === "save") {
+				if (!name) return usage("Usage: /profiles save <name>", runtime);
+				saveProfile(runtime.settings, name);
+				await runtime.output(`Profile saved: ${name}`);
+				await runtime.notifyConfigChanged?.();
+				return commandConsumed();
+			}
+
+			if (sub === "switch") {
+				if (!name) return usage("Usage: /profiles switch <name>", runtime);
+				const ok = switchProfile(runtime.settings, name);
+				if (!ok) {
+					await runtime.output(`Profile not found: ${name}`);
+					return commandConsumed();
+				}
+				const defaultRole = runtime.settings.getModelRole("default");
+				if (defaultRole) {
+					const availableModels = runtime.session.getAvailableModels?.() ?? [];
+					const resolved = resolveModelRoleValue(defaultRole, availableModels, {
+						settings: runtime.settings,
+					});
+					if (resolved.model) {
+						try {
+							await runtime.session.setModel(resolved.model);
+						} catch {
+							// Settings still applied — user can /model manually
+						}
+					}
+				}
+				await runtime.output(`Switched to profile: ${name}`);
+				await runtime.notifyTitleChanged?.();
+				await runtime.notifyConfigChanged?.();
+				return commandConsumed();
+			}
+
+			if (sub === "delete") {
+				if (!name) return usage("Usage: /profiles delete <name>", runtime);
+				const ok = deleteProfile(runtime.settings, name);
+				await runtime.output(ok ? `Profile deleted: ${name}` : `Profile not found: ${name}`);
+				await runtime.notifyConfigChanged?.();
+				return commandConsumed();
+			}
+
+			return usage("Usage: /profiles <save|switch|delete|list> [name]", runtime);
+		},
+		handleTui: async (command, runtime) => {
+			const [sub, ...rest] = command.args.trim().split(/\s+/);
+			const name = rest.join(" ").trim();
+
+			runtime.ctx.editor.setText("");
+
+			if (!sub || sub === "list") {
+				const names = getProfileNames(runtime.ctx.settings);
+				if (names.length === 0) {
+					runtime.ctx.showStatus("No profiles saved. Use /profiles save <name> to create one.");
+				} else {
+					runtime.ctx.showStatus(`Saved profiles: ${names.join(", ")}`);
+				}
+				return commandConsumed();
+			}
+
+			if (sub === "save") {
+				if (!name) {
+					runtime.ctx.showWarning("Usage: /profiles save <name>");
+					return commandConsumed();
+				}
+				saveProfile(runtime.ctx.settings, name);
+				runtime.ctx.showStatus(`Profile saved: ${name}`);
+				return commandConsumed();
+			}
+
+			if (sub === "switch") {
+				if (!name) {
+					runtime.ctx.showWarning("Usage: /profiles switch <name>");
+					return commandConsumed();
+				}
+				const ok = switchProfile(runtime.ctx.settings, name);
+				if (!ok) {
+					runtime.ctx.showWarning(`Profile not found: ${name}`);
+					return commandConsumed();
+				}
+				const defaultRole = runtime.ctx.settings.getModelRole("default");
+				if (defaultRole) {
+					const availableModels = runtime.ctx.session.getAvailableModels?.() ?? [];
+					const resolved = resolveModelRoleValue(defaultRole, availableModels, {
+						settings: runtime.ctx.settings,
+					});
+					if (resolved.model) {
+						try {
+							await runtime.ctx.session.setModel(resolved.model);
+							runtime.ctx.statusLine.invalidate();
+							runtime.ctx.updateEditorBorderColor();
+						} catch {
+							// Settings applied, model switch failed
+						}
+					}
+				}
+				runtime.ctx.statusLine.invalidate();
+				runtime.ctx.showStatus(`Switched to profile: ${name}`);
+				return commandConsumed();
+			}
+
+			if (sub === "delete") {
+				if (!name) {
+					runtime.ctx.showWarning("Usage: /profiles delete <name>");
+					return commandConsumed();
+				}
+				const ok = deleteProfile(runtime.ctx.settings, name);
+				runtime.ctx.showStatus(ok ? `Profile deleted: ${name}` : `Profile not found: ${name}`);
+				return commandConsumed();
+			}
+
+			runtime.ctx.showWarning("Usage: /profiles <save|switch|delete|list> [name]");
+			return commandConsumed();
 		},
 	},
 	{

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -439,6 +439,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						// Settings applied, model switch failed
 					}
 				}
+				if (result.needsReset) {
+					try {
+						await runtime.session.resetToDefaultModel?.();
+					} catch {
+						// Non-critical — settings are still applied
+					}
+				}
 				await runtime.output(`Switched to profile: ${name}`);
 				await runtime.notifyTitleChanged?.();
 				await runtime.notifyConfigChanged?.();
@@ -508,6 +515,15 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 						runtime.ctx.updateEditorBorderColor();
 					} catch {
 						// Settings applied, model switch failed
+					}
+				}
+				if (result.needsReset) {
+					try {
+						await runtime.ctx.session.resetToDefaultModel?.();
+						runtime.ctx.statusLine.invalidate();
+						runtime.ctx.updateEditorBorderColor();
+					} catch {
+						// Non-critical — settings are still applied
 					}
 				}
 				runtime.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -7,8 +7,7 @@ import { type AutocompleteItem, Spacer } from "@oh-my-pi/pi-tui";
 import { APP_NAME, getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 import { COLLAB_GUEST_ALLOWED_COMMANDS, CollabGuestLink } from "../collab/guest";
 import { CollabHost } from "../collab/host";
-import { resolveModelRoleValue } from "../config/model-resolver";
-import { deleteProfile, getProfileNames, saveProfile, switchProfile } from "../config/profiles";
+import { deleteProfile, getProfileNames, saveProfile, switchProfileAndResolve } from "../config/profiles";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
@@ -424,27 +423,20 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 
 			if (sub === "switch") {
 				if (!name) return usage("Usage: /profiles switch <name>", runtime);
-				const ok = switchProfile(runtime.settings, name);
-				if (!ok) {
+				const availableModels = runtime.session.getAvailableModels?.() ?? [];
+				const result = switchProfileAndResolve(runtime.settings, name, availableModels);
+				if (!result.ok) {
 					await runtime.output(`Profile not found: ${name}`);
 					return commandConsumed();
 				}
-				const defaultRole = runtime.settings.getModelRole("default");
-				if (defaultRole) {
-					const availableModels = runtime.session.getAvailableModels?.() ?? [];
-					const resolved = resolveModelRoleValue(defaultRole, availableModels, {
-						settings: runtime.settings,
-					});
-					if (resolved.model) {
-						try {
-							await runtime.session.setModel(resolved.model);
-							const thinking = resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined;
-							if (thinking && thinking !== ThinkingLevel.Inherit) {
-								runtime.session.setThinkingLevel(thinking);
-							}
-						} catch {
-							// Settings still applied — user can /model manually
+				if (result.model) {
+					try {
+						await runtime.session.setModel(result.model);
+						if (result.thinkingLevel && result.thinkingLevel !== ThinkingLevel.Inherit) {
+							runtime.session.setThinkingLevel(result.thinkingLevel);
 						}
+					} catch {
+						// Settings applied, model switch failed
 					}
 				}
 				await runtime.output(`Switched to profile: ${name}`);
@@ -469,7 +461,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 
 			runtime.ctx.editor.setText("");
 
-			if (!sub || sub === "list") {
+			if (!sub) {
+				// No args — open the interactive profile picker
+				runtime.ctx.showProfileSelector();
+				return commandConsumed();
+			}
+
+			if (sub === "list") {
 				const names = getProfileNames(runtime.ctx.settings);
 				if (names.length === 0) {
 					runtime.ctx.showStatus("No profiles saved. Use /profiles save <name> to create one.");
@@ -494,29 +492,22 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 					runtime.ctx.showWarning("Usage: /profiles switch <name>");
 					return commandConsumed();
 				}
-				const ok = switchProfile(runtime.ctx.settings, name);
-				if (!ok) {
+				const availableModels = runtime.ctx.session.getAvailableModels?.() ?? [];
+				const result = switchProfileAndResolve(runtime.ctx.settings, name, availableModels);
+				if (!result.ok) {
 					runtime.ctx.showWarning(`Profile not found: ${name}`);
 					return commandConsumed();
 				}
-				const defaultRole = runtime.ctx.settings.getModelRole("default");
-				if (defaultRole) {
-					const availableModels = runtime.ctx.session.getAvailableModels?.() ?? [];
-					const resolved = resolveModelRoleValue(defaultRole, availableModels, {
-						settings: runtime.ctx.settings,
-					});
-					if (resolved.model) {
-						try {
-							await runtime.ctx.session.setModel(resolved.model);
-							const thinking = resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined;
-							if (thinking && thinking !== ThinkingLevel.Inherit) {
-								runtime.ctx.session.setThinkingLevel(thinking);
-							}
-							runtime.ctx.statusLine.invalidate();
-							runtime.ctx.updateEditorBorderColor();
-						} catch {
-							// Settings applied, model switch failed
+				if (result.model) {
+					try {
+						await runtime.ctx.session.setModel(result.model);
+						if (result.thinkingLevel && result.thinkingLevel !== ThinkingLevel.Inherit) {
+							runtime.ctx.session.setThinkingLevel(result.thinkingLevel);
 						}
+						runtime.ctx.statusLine.invalidate();
+						runtime.ctx.updateEditorBorderColor();
+					} catch {
+						// Settings applied, model switch failed
 					}
 				}
 				runtime.ctx.statusLine.invalidate();

--- a/packages/coding-agent/test/profile-needs-reset.test.ts
+++ b/packages/coding-agent/test/profile-needs-reset.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { saveProfile, switchProfileAndResolve } from "@oh-my-pi/pi-coding-agent/config/profiles";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+
+const mockModels: Model<"anthropic-messages">[] = [
+	buildModel({
+		id: "claude-sonnet-4-5",
+		name: "Claude Sonnet 4.5",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: true,
+		thinking: {
+			mode: "budget",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+		},
+		input: ["text", "image"],
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+	}),
+	buildModel({
+		id: "gpt-4o",
+		name: "GPT-4o",
+		api: "anthropic-messages",
+		provider: "openai",
+		baseUrl: "https://api.openai.com",
+		reasoning: false,
+		input: ["text", "image"],
+		cost: { input: 5, output: 15, cacheRead: 0.5, cacheWrite: 5 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	}),
+];
+
+describe("switchProfileAndResolve — needsReset", () => {
+	test("returns needsReset=true when profile has no explicit default role", () => {
+		const settings = Settings.isolated();
+
+		// Save a profile while no default model role is set — simulates the
+		// "automatic default" state where modelRoles.default is absent.
+		saveProfile(settings, "auto-default");
+
+		// Verify the profile was saved with no default role
+		const profiles = settings.get("profiles");
+		expect(profiles).toBeDefined();
+		expect(profiles?.["auto-default"]).toBeDefined();
+
+		const result = switchProfileAndResolve(settings, "auto-default", mockModels);
+
+		expect(result.ok).toBe(true);
+		expect(result.needsReset).toBe(true);
+		expect(result.model).toBeUndefined();
+	});
+
+	test("returns model (no needsReset) when profile has explicit default role", () => {
+		const settings = Settings.isolated();
+		settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
+
+		saveProfile(settings, "explicit-default");
+
+		const result = switchProfileAndResolve(settings, "explicit-default", mockModels);
+
+		expect(result.ok).toBe(true);
+		expect(result.needsReset).toBeUndefined();
+		expect(result.model).toBeDefined();
+		expect(result.model?.provider).toBe("anthropic");
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+	});
+
+	test("returns ok=false for nonexistent profile", () => {
+		const settings = Settings.isolated();
+
+		const result = switchProfileAndResolve(settings, "does-not-exist", mockModels);
+
+		expect(result.ok).toBe(false);
+		expect(result.needsReset).toBeUndefined();
+		expect(result.model).toBeUndefined();
+	});
+
+	test("switching from explicit-default profile to no-default profile signals reset", () => {
+		const settings = Settings.isolated();
+
+		// Profile A: has explicit default
+		settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
+		saveProfile(settings, "profile-a");
+
+		// Profile B: no explicit default (auto)
+		settings.setModelRole("default", "");
+		saveProfile(settings, "profile-b");
+
+		// Switch to profile-a first (explicit model)
+		const resultA = switchProfileAndResolve(settings, "profile-a", mockModels);
+		expect(resultA.ok).toBe(true);
+		expect(resultA.model).toBeDefined();
+		expect(resultA.needsReset).toBeUndefined();
+
+		// Now switch to profile-b (no default) — should signal needsReset
+		const resultB = switchProfileAndResolve(settings, "profile-b", mockModels);
+		expect(resultB.ok).toBe(true);
+		expect(resultB.needsReset).toBe(true);
+		expect(resultB.model).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/profile-needs-reset.test.ts
+++ b/packages/coding-agent/test/profile-needs-reset.test.ts
@@ -103,4 +103,20 @@ describe("switchProfileAndResolve — needsReset", () => {
 		expect(resultB.needsReset).toBe(true);
 		expect(resultB.model).toBeUndefined();
 	});
+
+	test("signals unresolvedDefault when default role doesn't resolve", () => {
+		const settings = Settings.isolated();
+
+		// Save a profile with a default role that won't resolve against
+		// available models (nonexistent provider).
+		settings.setModelRole("default", "nonexistent-provider/some-model");
+		saveProfile(settings, "unresolved-profile");
+
+		const result = switchProfileAndResolve(settings, "unresolved-profile", mockModels);
+
+		expect(result.ok).toBe(true);
+		expect(result.needsReset).toBe(true);
+		expect(result.unresolvedDefault).toBe(true);
+		expect(result.model).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary

Add the ability to save and switch between named "profiles" that capture the current model configuration (model selections per role + thinking level).

## Changes

### New files
- **`src/config/profiles.ts`** — `saveProfile`, `switchProfile`, `deleteProfile`, `getProfiles`, `getProfileNames` helpers. Pure settings operations, no session dependency.

### Modified files
- **`src/config/settings-schema.ts`** — `ProfileSnapshot` interface (`modelRoles` + `defaultThinkingLevel`), `profiles` record schema entry, `GroupTypeMap` entry
- **`src/slash-commands/builtin-registry.ts`** — `/profiles` slash command with `save`, `switch`, `delete`, `list` subcommands (both ACP `handle` and TUI `handleTui`); uses `resolveModelRoleValue` for model selector resolution on switch
- **`src/modes/components/model-hub.ts`** — `onSaveProfile` callback, `profileName` strip variant, `s` keybinding in roles view to save current config as a named profile
- **`src/modes/controllers/selector-controller.ts`** — wires `onSaveProfile` callback to `saveProfile()`
- **`CHANGELOG.md`** — entry under `[Unreleased]` → `Added`

## Usage

### `/profiles` slash command
```
/profiles save my-setup      # Save current model config as "my-setup"
/profiles switch my-setup    # Switch to "my-setup" (replaces all role assignments)
/profiles delete my-setup    # Delete "my-setup"
/profiles list               # List all saved profiles
```

### `/models` roles view
Press `s` in the roles view to open a footer name input — type a name and press Enter to save the current model configuration as a profile.

## Key design decisions

- **Clean cutover on switch**: `switchProfile` uses `settings.set("modelRoles", profile.modelRoles)` to replace the ENTIRE record — not a loop of `setModelRole()` per entry. This ensures stale role assignments from the previously-active profile are removed.
- **Model selector resolution**: Profile switch uses `resolveModelRoleValue()` from `model-resolver.ts` — not manual `split("/")`/`split(":")` — to handle multi-slash provider IDs (e.g. OpenRouter passthrough) and thinking-level suffixes correctly.
- **Profile snapshot**: Captures `modelRoles` (all role → selector assignments) + `defaultThinkingLevel`. These together represent "what model is selected for each role."
- **No settings UI**: The `profiles` setting has no `ui` metadata — managed via the slash command and model hub keybinding, same pattern as `modelRoles`.

## Verification

- **Type check**: `bun run check:types` — PASS
- **Biome**: Clean on all modified files
- **Smoke test**: save/switch/delete/list all verified; non-existent profile switch/delete returns false; overwrite works correctly

## Test plan

- [ ] `cd packages/coding-agent && bun run check:types`
- [ ] Open `/models`, press `s`, type a profile name, Enter — verify "Profile saved" status
- [ ] `/profiles list` — verify the profile appears
- [ ] Change model assignments, then `/profiles switch <name>` — verify all roles revert
- [ ] `/profiles delete <name>` — verify it disappears from list