### PR TITLE
Add ElectronHub DevPass provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -19,6 +19,10 @@
 ### Removed
 
 - Removed automatic /interactions chaining for follow-up turns in Google provider calls, along with the useInteractionsApi, storeInteraction, and previousInteractionId stream options.
+### Added
+
+- Added ElectronHub Coding Plan (DevPass) as a `/login electronhub` API-key provider, validating `ek-dev-…` keys against `kimi-k2.6:dev` on `https://api.electronhub.ai/v1`.
+- Added a `reasoning-effort-none` OpenAI-completions reasoning-disable mode that sends an explicit `reasoning_effort: "none"` on the wire, for OpenAI-shaped gateways (e.g. ElectronHub) that document `"none"` as a distinct value below their lowest selectable effort tier — unlike the existing `"lowest-effort"` mode (sends the floor tier) or `"omit"` (drops the field, falling back to the gateway's own default).
 
 ## [16.4.6] - 2026-07-12
 
@@ -146,9 +150,6 @@
 - Fixed Azure Foundry Anthropic utility requests to omit the structured-output beta whenever strict tools are disabled, preventing `structured_outputs not supported in your workspace` failures for Sonnet 5 compaction ([#4679](https://github.com/can1357/oh-my-pi/issues/4679)).
 - Fixed OAuth `launchUrl` advertisement for flows whose redirect never returns to the local callback server: custom-scheme redirects (e.g. GitLab Duo's `vscode://` URI, which `new URL` parses without complaint) and fixed non-loopback hosts no longer receive a `http://localhost:<port>/launch` copy target that misrepresents the callback endpoint and resolves nowhere for remote users.
 - Codex load balancing: clear stale persisted and in-memory usage-limit blocks for an `openai-codex` account when a fresh live usage report shows it is allowed and below all limits, including broker-backed gateway snapshots, so traffic returns to recovered accounts instead of funneling to one sibling.
-### Added
-
-- Added ElectronHub Coding Plan (DevPass) as a `/login electronhub` API-key provider, validating `ek-dev-…` keys against `kimi-k2.6:dev` on `https://api.electronhub.ai/v1`.
 
 ## [16.3.11] - 2026-07-06
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -146,6 +146,9 @@
 - Fixed Azure Foundry Anthropic utility requests to omit the structured-output beta whenever strict tools are disabled, preventing `structured_outputs not supported in your workspace` failures for Sonnet 5 compaction ([#4679](https://github.com/can1357/oh-my-pi/issues/4679)).
 - Fixed OAuth `launchUrl` advertisement for flows whose redirect never returns to the local callback server: custom-scheme redirects (e.g. GitLab Duo's `vscode://` URI, which `new URL` parses without complaint) and fixed non-loopback hosts no longer receive a `http://localhost:<port>/launch` copy target that misrepresents the callback endpoint and resolves nowhere for remote users.
 - Codex load balancing: clear stale persisted and in-memory usage-limit blocks for an `openai-codex` account when a fresh live usage report shows it is allowed and below all limits, including broker-backed gateway snapshots, so traffic returns to recovered accounts instead of funneling to one sibling.
+### Added
+
+- Added ElectronHub Coding Plan (DevPass) as a `/login electronhub` API-key provider, validating `ek-dev-…` keys against `kimi-k2.6:dev` on `https://api.electronhub.ai/v1`.
 
 ## [16.3.11] - 2026-07-06
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added ElectronHub Coding Plan (DevPass) as a `/login electronhub` API-key provider, validating `ek-dev-…` keys against `kimi-k2.6:dev` on `https://api.electronhub.ai/v1`.
+- Added a `reasoning-effort-none` OpenAI-completions reasoning-disable mode that sends an explicit `reasoning_effort: "none"` on the wire, for OpenAI-shaped gateways (e.g. ElectronHub) that document `"none"` as a distinct value below their lowest selectable effort tier — unlike the existing `"lowest-effort"` mode (sends the floor tier) or `"omit"` (drops the field, falling back to the gateway's own default).
+
 ## [16.5.0] - 2026-07-13
 
 ### Added
@@ -19,10 +24,6 @@
 ### Removed
 
 - Removed automatic /interactions chaining for follow-up turns in Google provider calls, along with the useInteractionsApi, storeInteraction, and previousInteractionId stream options.
-### Added
-
-- Added ElectronHub Coding Plan (DevPass) as a `/login electronhub` API-key provider, validating `ek-dev-…` keys against `kimi-k2.6:dev` on `https://api.electronhub.ai/v1`.
-- Added a `reasoning-effort-none` OpenAI-completions reasoning-disable mode that sends an explicit `reasoning_effort: "none"` on the wire, for OpenAI-shaped gateways (e.g. ElectronHub) that document `"none"` as a distinct value below their lowest selectable effort tier — unlike the existing `"lowest-effort"` mode (sends the floor tier) or `"omit"` (drops the field, falling back to the gateway's own default).
 
 ## [16.4.6] - 2026-07-12
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -860,6 +860,13 @@ function encodeChatCompletionsDisabledReasoning(
 				enabled: false,
 			};
 			break;
+		case "reasoning-effort-none":
+			// Distinct from the `default` branch below: gateways that document
+			// "none" as its own reasoning_effort wire value (e.g. ElectronHub)
+			// need it sent explicitly — omitting the field falls back to the
+			// gateway's own default, which is not necessarily "no reasoning".
+			params.reasoning_effort = "none";
+			break;
 		default:
 			delete params.reasoning;
 			break;

--- a/packages/ai/src/registry/electronhub.ts
+++ b/packages/ai/src/registry/electronhub.ts
@@ -1,0 +1,27 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://app.electronhub.ai";
+const API_BASE_URL = "https://api.electronhub.ai/v1";
+const VALIDATION_MODEL = "kimi-k2.6:dev";
+
+export const loginElectronHub = createApiKeyLogin({
+	providerLabel: "ElectronHub Coding Plan",
+	authUrl: AUTH_URL,
+	instructions: "Copy your ek-dev- API key from the ElectronHub dashboard Coding Plan tab",
+	promptMessage: "Paste your ElectronHub DevPass API key",
+	placeholder: "ek-dev-...",
+	validation: {
+		kind: "chat-completions",
+		provider: "ElectronHub",
+		baseUrl: API_BASE_URL,
+		model: VALIDATION_MODEL,
+	},
+});
+
+export const electronHubProvider = {
+	id: "electronhub",
+	name: "ElectronHub Coding Plan (DevPass)",
+	login: (cb: OAuthLoginCallbacks) => loginElectronHub(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -11,6 +11,7 @@ import { coreWeaveProvider } from "./coreweave";
 import { cursorProvider } from "./cursor";
 import { deepseekProvider } from "./deepseek";
 import { devinProvider } from "./devin";
+import { electronHubProvider } from "./electronhub";
 import { firepassProvider } from "./firepass";
 import { fireworksProvider } from "./fireworks";
 import { githubCopilotProvider } from "./github-copilot";
@@ -85,6 +86,7 @@ const ALL = [
 	githubCopilotProvider,
 	cursorProvider,
 	devinProvider,
+	electronHubProvider,
 	googleAntigravityProvider,
 	googleGeminiCliProvider,
 	openaiCodexDeviceProvider,

--- a/packages/ai/test/electronhub-login.test.ts
+++ b/packages/ai/test/electronhub-login.test.ts
@@ -1,0 +1,128 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import { loginElectronHub } from "@oh-my-pi/pi-ai/registry/electronhub";
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/registry/oauth";
+import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+
+const originalElectronHubDevKey = Bun.env.ELECTRONHUB_DEV_API_KEY;
+const originalElectronHubKey = Bun.env.ELECTRONHUB_API_KEY;
+
+afterEach(() => {
+	if (originalElectronHubDevKey === undefined) {
+		delete Bun.env.ELECTRONHUB_DEV_API_KEY;
+	} else {
+		Bun.env.ELECTRONHUB_DEV_API_KEY = originalElectronHubDevKey;
+	}
+	if (originalElectronHubKey === undefined) {
+		delete Bun.env.ELECTRONHUB_API_KEY;
+	} else {
+		Bun.env.ELECTRONHUB_API_KEY = originalElectronHubKey;
+	}
+	vi.restoreAllMocks();
+});
+
+describe("electronhub login wiring", () => {
+	test("registers ElectronHub in the /login provider selector", () => {
+		const provider = getOAuthProviders().find(item => item.id === "electronhub");
+		expect(provider).toBeDefined();
+		expect(provider?.name).toBe("ElectronHub Coding Plan (DevPass)");
+		expect(provider?.available).toBe(true);
+	});
+
+	test("resolves ELECTRONHUB_DEV_API_KEY first, then ELECTRONHUB_API_KEY", () => {
+		Bun.env.ELECTRONHUB_DEV_API_KEY = "ek-dev-env";
+		Bun.env.ELECTRONHUB_API_KEY = "ek-fallback";
+		expect(getEnvApiKey("electronhub")).toBe("ek-dev-env");
+
+		delete Bun.env.ELECTRONHUB_DEV_API_KEY;
+		expect(getEnvApiKey("electronhub")).toBe("ek-fallback");
+	});
+
+	test("loginElectronHub trims key and validates against /v1/chat/completions with kimi-k2.6:dev", async () => {
+		const originalFetch = globalThis.fetch;
+		const globalFetchSpy = vi.fn(async () => {
+			throw new Error("unexpected global fetch (live network)");
+		});
+		globalThis.fetch = globalFetchSpy as unknown as typeof globalThis.fetch;
+		try {
+			let validationBody: Record<string, unknown> | undefined;
+			let validationUrl = "";
+			const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+				validationUrl =
+					typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+				expect(validationUrl).toBe("https://api.electronhub.ai/v1/chat/completions");
+				expect(init?.method).toBe("POST");
+				const headers = new Headers(init?.headers);
+				expect(headers.get("Content-Type")).toBe("application/json");
+				expect(headers.get("Authorization")).toBe("Bearer ek-dev-test");
+
+				validationBody =
+					typeof init?.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : undefined;
+				return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			});
+
+			const apiKey = await loginElectronHub({
+				onPrompt: async () => "  ek-dev-test  ",
+				fetch: fetchMock,
+			});
+
+			expect(apiKey).toBe("ek-dev-test");
+			expect(validationBody).toMatchObject({
+				model: "kimi-k2.6:dev",
+				messages: [{ role: "user", content: "ping" }],
+				max_tokens: 1,
+				temperature: 0,
+			});
+			expect(validationUrl).toBe("https://api.electronhub.ai/v1/chat/completions");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(globalFetchSpy).toHaveBeenCalledTimes(0);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	test("AuthStorage.login('electronhub') validates and stores the trimmed key", async () => {
+		const fetchCalls: Array<{ url: string; init: RequestInit | undefined }> = [];
+		const fetchMock: FetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			const url =
+				typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			fetchCalls.push({ url, init });
+			if (url === "https://api.electronhub.ai/v1/chat/completions") {
+				return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		const storage = new AuthStorage(store);
+		await storage.reload();
+
+		await storage.login("electronhub", {
+			onAuth: () => {},
+			onPrompt: async () => "  ek-dev-trimmed  ",
+			fetch: fetchMock,
+		});
+
+		expect(await storage.get("electronhub")).toEqual({ type: "api_key", key: "ek-dev-trimmed" });
+
+		expect(fetchCalls.map(call => call.url)).toEqual(["https://api.electronhub.ai/v1/chat/completions"]);
+		const headers = new Headers(fetchCalls[0]?.init?.headers);
+		expect(headers.get("Authorization")).toBe("Bearer ek-dev-trimmed");
+
+		const body =
+			typeof fetchCalls[0]?.init?.body === "string"
+				? (JSON.parse(fetchCalls[0]!.init!.body as string) as Record<string, unknown>)
+				: undefined;
+		expect(body).toMatchObject({ model: "kimi-k2.6:dev" });
+
+		store.close();
+	});
+});

--- a/packages/ai/test/electronhub-login.test.ts
+++ b/packages/ai/test/electronhub-login.test.ts
@@ -111,7 +111,7 @@ describe("electronhub login wiring", () => {
 			fetch: fetchMock,
 		});
 
-		expect(await storage.get("electronhub")).toEqual({ type: "api_key", key: "ek-dev-trimmed" });
+		expect(await storage.get("electronhub")).toEqual({ type: "api_key", key: "ek-dev-trimmed", source: "login" });
 
 		expect(fetchCalls.map(call => call.url)).toEqual(["https://api.electronhub.ai/v1/chat/completions"]);
 		const headers = new Headers(fetchCalls[0]?.init?.headers);

--- a/packages/ai/test/openai-completions-disable-reasoning.test.ts
+++ b/packages/ai/test/openai-completions-disable-reasoning.test.ts
@@ -100,6 +100,40 @@ describe("OpenAI completions disableReasoning and thinking dialects", () => {
 		expect(payload.reasoning).toBeUndefined();
 	});
 
+	it("sends an explicit reasoning_effort: none for gateways using the reasoning-effort-none disable mode", async () => {
+		// ElectronHub's /v1/chat/completions documents reasoning_effort: "none" as its
+		// own distinct wire value (below "minimal") for fully hiding reasoning output.
+		// Neither the generic "lowest-effort" disable mode (sends the ladder floor,
+		// e.g. "minimal") nor "omit" (drops the field, falling back to the gateway's
+		// own default) honor that — this dedicated mode must send "none" explicitly.
+		const model = buildModel({
+			id: "reasoning-effort-none-gateway",
+			name: "Reasoning Effort None Gateway",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://gateway.example.com/v1",
+			reasoning: true,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+			},
+			compat: {
+				thinkingFormat: "openai",
+				supportsReasoningParams: true,
+				supportsReasoningEffort: true,
+				reasoningDisableMode: "reasoning-effort-none",
+			},
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 16_384,
+		});
+
+		const payload = await captureDisableReasoningPayload(model);
+		expect(payload.reasoning_effort).toBe("none");
+		expect(payload.reasoning).toBeUndefined();
+	});
+
 	// Additional requested tests for applyChatCompletionsReasoningParams dialect / behavior verification
 	it("sets OpenRouter thinking disabled when disableReasoning: true", async () => {
 		const model = buildModel({

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed ElectronHub DevPass reasoning dialect mapping: `glm-5.2:dev` and `qwen3.6-27b:dev` now use ElectronHub's OpenAI-shaped `reasoning_effort` surface instead of each model's native Z.ai/Qwen dialect, with `glm-5.2:dev`'s top effort tier remapped onto ElectronHub's actual top tier `xhigh`. Disabling reasoning now sends an explicit `reasoning_effort: "none"` for four of the six DevPass models instead of falling back to a reduced-effort or provider-default request. `minimax-m2.7:dev` (mandatory-reasoning architecture) and `gpt-oss-120b:dev` (Harmony's tested-safe lowest-effort disable path, matching every other GPT-OSS host in the catalog) are deliberately excluded and keep their existing lowest-effort clamp.
 - Fixed ElectronHub DevPass dynamic discovery disabling tool calling whenever a live `/v1/models` record reported stale `metadata.function_call: false`; every DevPass model supports function calling per ElectronHub's docs, so discovery no longer trusts that flag.
+- Fixed ElectronHub DevPass requests sending the unhonored `max_completion_tokens` field instead of the documented `max_tokens` output cap; ElectronHub silently ignores `max_completion_tokens` (confirmed live), which had made `kimi-k2.6:dev`'s always-send-a-cap safeguard (protecting against runaway reasoning traces) a no-op on this provider.
 
 ## [16.4.3] - 2026-07-11
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -103,7 +103,7 @@
 - Detected Azure AI Inference / Foundry Anthropic routes as strict-tool-incompatible so resolved Anthropic compat disables strict tools before request construction ([#4679](https://github.com/can1357/oh-my-pi/issues/4679)).
 ### Added
 
-- Added ElectronHub Coding Plan (DevPass) catalog support with bundled `kimi-k2.6:dev` and `minimax-m2.7:dev` models plus runtime discovery filtered to DevPass-only models.
+- Added ElectronHub Coding Plan (DevPass) catalog support with all six live `:dev` models (`kimi-k2.6:dev`, `minimax-m2.7:dev`, `gpt-oss-120b:dev`, `glm-5.2:dev`, `gemma-4-31b-it:dev`, `qwen3.6-27b:dev`) bundled statically, plus runtime discovery filtered to DevPass-only models (`:dev` suffix, `metadata.devpass_only`, or `pricing.plan === "devpass"`) and a fixture-backed contract test asserting the static seed matches a live `/v1/models` snapshot.
 
 ## [16.3.11] - 2026-07-06
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed ElectronHub DevPass reasoning dialect mapping: `glm-5.2:dev` and `qwen3.6-27b:dev` now use ElectronHub's OpenAI-shaped `reasoning_effort` surface instead of each model's native Z.ai/Qwen dialect, with `glm-5.2:dev`'s top effort tier remapped onto ElectronHub's actual top tier `xhigh`. Disabling reasoning now sends an explicit `reasoning_effort: "none"` for five of the six DevPass models instead of falling back to a reduced-effort or provider-default request (`minimax-m2.7:dev` is a mandatory-reasoning architecture confirmed to ignore `reasoning_effort` entirely, so it keeps its existing lowest-effort clamp).
+- Fixed ElectronHub DevPass reasoning dialect mapping: `glm-5.2:dev` and `qwen3.6-27b:dev` now use ElectronHub's OpenAI-shaped `reasoning_effort` surface instead of each model's native Z.ai/Qwen dialect, with `glm-5.2:dev`'s top effort tier remapped onto ElectronHub's actual top tier `xhigh`. Disabling reasoning now sends an explicit `reasoning_effort: "none"` for four of the six DevPass models instead of falling back to a reduced-effort or provider-default request. `minimax-m2.7:dev` (mandatory-reasoning architecture) and `gpt-oss-120b:dev` (Harmony's tested-safe lowest-effort disable path, matching every other GPT-OSS host in the catalog) are deliberately excluded and keep their existing lowest-effort clamp.
 - Fixed ElectronHub DevPass dynamic discovery disabling tool calling whenever a live `/v1/models` record reported stale `metadata.function_call: false`; every DevPass model supports function calling per ElectronHub's docs, so discovery no longer trusts that flag.
 
 ## [16.4.3] - 2026-07-11

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -101,6 +101,9 @@
 - Fixed LiteLLM discovery stopping at `/model_group/info` when that endpoint omitted `supports_vision`; it now continues to `/model/info` and preserves `model_info.supports_vision=true` for vision-capable proxy models. ([#4747](https://github.com/can1357/oh-my-pi/issues/4747))
 - Fixed LiteLLM discovery to fall back to bundled catalog metadata when `models.dev` lacks a model reference, preserving reasoning and thinking support for models such as `glm-5.2`. ([#4695](https://github.com/can1357/oh-my-pi/issues/4695))
 - Detected Azure AI Inference / Foundry Anthropic routes as strict-tool-incompatible so resolved Anthropic compat disables strict tools before request construction ([#4679](https://github.com/can1357/oh-my-pi/issues/4679)).
+### Added
+
+- Added ElectronHub Coding Plan (DevPass) catalog support with bundled `kimi-k2.6:dev` and `minimax-m2.7:dev` models plus runtime discovery filtered to DevPass-only models.
 
 ## [16.3.11] - 2026-07-06
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added ElectronHub Coding Plan (DevPass) catalog support with all six live `:dev` models (`kimi-k2.6:dev`, `minimax-m2.7:dev`, `gpt-oss-120b:dev`, `glm-5.2:dev`, `gemma-4-31b-it:dev`, `qwen3.6-27b:dev`) bundled statically, plus runtime discovery filtered to DevPass-only models (`:dev` suffix, `metadata.devpass_only`, or `pricing.plan === "devpass"`) and a fixture-backed contract test asserting the static seed matches a live `/v1/models` snapshot.
+
+### Fixed
+
+- Fixed ElectronHub DevPass reasoning dialect mapping: `glm-5.2:dev` and `qwen3.6-27b:dev` now use ElectronHub's OpenAI-shaped `reasoning_effort` surface instead of each model's native Z.ai/Qwen dialect, with `glm-5.2:dev`'s top effort tier remapped onto ElectronHub's actual top tier `xhigh`. Disabling reasoning now sends an explicit `reasoning_effort: "none"` across all six DevPass models instead of falling back to a reduced-effort or provider-default request.
+- Fixed ElectronHub DevPass dynamic discovery disabling tool calling whenever a live `/v1/models` record reported stale `metadata.function_call: false`; every DevPass model supports function calling per ElectronHub's docs, so discovery no longer trusts that flag.
+
 ## [16.4.3] - 2026-07-11
 
 ### Fixed
@@ -101,9 +110,6 @@
 - Fixed LiteLLM discovery stopping at `/model_group/info` when that endpoint omitted `supports_vision`; it now continues to `/model/info` and preserves `model_info.supports_vision=true` for vision-capable proxy models. ([#4747](https://github.com/can1357/oh-my-pi/issues/4747))
 - Fixed LiteLLM discovery to fall back to bundled catalog metadata when `models.dev` lacks a model reference, preserving reasoning and thinking support for models such as `glm-5.2`. ([#4695](https://github.com/can1357/oh-my-pi/issues/4695))
 - Detected Azure AI Inference / Foundry Anthropic routes as strict-tool-incompatible so resolved Anthropic compat disables strict tools before request construction ([#4679](https://github.com/can1357/oh-my-pi/issues/4679)).
-### Added
-
-- Added ElectronHub Coding Plan (DevPass) catalog support with all six live `:dev` models (`kimi-k2.6:dev`, `minimax-m2.7:dev`, `gpt-oss-120b:dev`, `glm-5.2:dev`, `gemma-4-31b-it:dev`, `qwen3.6-27b:dev`) bundled statically, plus runtime discovery filtered to DevPass-only models (`:dev` suffix, `metadata.devpass_only`, or `pricing.plan === "devpass"`) and a fixture-backed contract test asserting the static seed matches a live `/v1/models` snapshot.
 
 ## [16.3.11] - 2026-07-06
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed ElectronHub DevPass reasoning dialect mapping: `glm-5.2:dev` and `qwen3.6-27b:dev` now use ElectronHub's OpenAI-shaped `reasoning_effort` surface instead of each model's native Z.ai/Qwen dialect, with `glm-5.2:dev`'s top effort tier remapped onto ElectronHub's actual top tier `xhigh`. Disabling reasoning now sends an explicit `reasoning_effort: "none"` across all six DevPass models instead of falling back to a reduced-effort or provider-default request.
+- Fixed ElectronHub DevPass reasoning dialect mapping: `glm-5.2:dev` and `qwen3.6-27b:dev` now use ElectronHub's OpenAI-shaped `reasoning_effort` surface instead of each model's native Z.ai/Qwen dialect, with `glm-5.2:dev`'s top effort tier remapped onto ElectronHub's actual top tier `xhigh`. Disabling reasoning now sends an explicit `reasoning_effort: "none"` for five of the six DevPass models instead of falling back to a reduced-effort or provider-default request (`minimax-m2.7:dev` is a mandatory-reasoning architecture confirmed to ignore `reasoning_effort` entirely, so it keeps its existing lowest-effort clamp).
 - Fixed ElectronHub DevPass dynamic discovery disabling tool calling whenever a live `/v1/models` record reported stale `metadata.function_call: false`; every DevPass model supports function calling per ElectronHub's docs, so discovery no longer trusts that flag.
 
 ## [16.4.3] - 2026-07-11

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -34,6 +34,7 @@ import {
 	buildXaiOAuthStaticSeed,
 	clampFireworksKimiMaxTokens,
 	clampKimiK27CodeMaxTokens,
+	ELECTRONHUB_DEVPASS_STATIC_MODELS,
 	isFireworksKimiK2ModelId,
 	isKimiK27CodeModelId,
 	MODELS_DEV_PROVIDER_DESCRIPTORS,
@@ -344,6 +345,17 @@ function normalizeAntigravityEndpoint(models: readonly ModelSpec[]): ModelSpec[]
 	});
 }
 
+/**
+ * ElectronHub exposes a model-wide `tokens` context field on `/v1/models`, but
+ * not a documented output-token ceiling. Keep `maxTokens` unknown instead of
+ * borrowing caps from same-family models on other providers.
+ */
+function preserveElectronHubUnknownMaxTokens(models: readonly ModelSpec[]): ModelSpec[] {
+	return models.map(model =>
+		model.provider === "electronhub" && model.maxTokens !== null ? { ...model, maxTokens: null } : model,
+	);
+}
+
 const ANTIGRAVITY_ENDPOINT = ANTIGRAVITY_PRIMARY_ENDPOINT;
 
 async function getOAuthAccessFromStorage(provider: OAuthProvider): Promise<OAuthAccess | null> {
@@ -517,6 +529,11 @@ async function generateModels() {
 	if (!authoritativeCatalogProviders.has("gitlab-duo-agent")) {
 		allModels.push(buildGitLabDuoWorkflowFallbackModel());
 	}
+	// Seed ElectronHub DevPass models so `/login electronhub` has a usable
+	// offline catalog even when generation runs without an ElectronHub key.
+	if (!authoritativeCatalogProviders.has("electronhub")) {
+		allModels.push(...ELECTRONHUB_DEVPASS_STATIC_MODELS);
+	}
 	// Seed Fireworks "Fast" serving-path variants (`<id>-fast`). Fast routers are
 	// not enumerated by the serverless control-plane list, so discovery never
 	// surfaces them; the seed projects each base entry into a fast variant.
@@ -597,8 +614,10 @@ async function generateModels() {
 	// previous-snapshot raw members into their logical families.
 	allModels = collapseEffortVariantsAcrossProviders(allModels);
 	// Fill remaining null endpoint limits from each model's canonical-family
-	// reference. Runs last so canonical ids and explicit policy limits are final.
+	// reference, then restore provider-specific unknowns where cross-provider
+	// caps would be misleading.
 	applyCanonicalLimitFallback(allModels);
+	allModels = preserveElectronHubUnknownMaxTokens(allModels);
 
 	for (const model of allModels) {
 		canonicalizeModelCompat(model);

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17523,6 +17523,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"maxTokensField": "max_tokens",
 				"reasoningDisableMode": "reasoning-effort-none"
 			}
 		},
@@ -17560,6 +17561,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"maxTokensField": "max_tokens",
 				"reasoningDisableMode": "reasoning-effort-none",
 				"thinkingFormat": "openai",
 				"reasoningContentField": "reasoning_content",
@@ -17598,6 +17600,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"maxTokensField": "max_tokens",
 				"reasoningDisableMode": "lowest-effort"
 			}
 		},
@@ -17632,6 +17635,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"maxTokensField": "max_tokens",
 				"reasoningDisableMode": "reasoning-effort-none"
 			}
 		},
@@ -17665,6 +17669,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"maxTokensField": "max_tokens",
 				"reasoningDisableMode": "reasoning-effort-none"
 			}
 		},
@@ -17700,6 +17705,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"maxTokensField": "max_tokens",
 				"reasoningDisableMode": "reasoning-effort-none",
 				"thinkingFormat": "openai"
 			}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17546,16 +17546,26 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
+					"minimal",
+					"low",
+					"medium",
 					"high",
 					"max"
-				]
+				],
+				"effortMap": {
+					"max": "xhigh"
+				}
 			},
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
-				"thinkingFormat": "zai",
+				"thinkingFormat": "openai",
 				"reasoningDisableMode": "omit",
-				"reasoningContentField": "reasoning_content"
+				"reasoningContentField": "reasoning_content",
+				"reasoningEffortMap": {
+					"max": "xhigh"
+				},
+				"replayReasoningContent": true
 			}
 		},
 		"gpt-oss-120b:dev": {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17546,19 +17546,9 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
-					"low",
-					"medium",
 					"high",
-					"xhigh"
-				],
-				"effortMap": {
-					"minimal": "none",
-					"low": "high",
-					"medium": "high",
-					"high": "high",
-					"xhigh": "max"
-				}
+					"max"
+				]
 			},
 			"compat": {
 				"supportsStore": false,
@@ -17689,12 +17679,14 @@
 					"minimal",
 					"low",
 					"medium",
-					"high"
+					"high",
+					"xhigh"
 				]
 			},
 			"compat": {
 				"supportsStore": false,
-				"supportsDeveloperRole": false
+				"supportsDeveloperRole": false,
+				"thinkingFormat": "openai"
 			}
 		}
 	},

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17491,6 +17491,114 @@
 		}
 	},
 	"electronhub": {
+		"gemma-4-31b-it:dev": {
+			"id": "gemma-4-31b-it:dev",
+			"name": "Gemma 4 31B (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
+			}
+		},
+		"glm-5.2:dev": {
+			"id": "glm-5.2:dev",
+			"name": "GLM 5.2 (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "none",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
+					"xhigh": "max"
+				}
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"thinkingFormat": "zai",
+				"reasoningDisableMode": "omit",
+				"reasoningContentField": "reasoning_content"
+			}
+		},
+		"gpt-oss-120b:dev": {
+			"id": "gpt-oss-120b:dev",
+			"name": "GPT OSS 120B (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
+			}
+		},
 		"kimi-k2.6:dev": {
 			"id": "kimi-k2.6:dev",
 			"name": "Kimi K2.6 (DevPass)",
@@ -17509,10 +17617,6 @@
 			},
 			"contextWindow": 240000,
 			"maxTokens": null,
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -17522,6 +17626,10 @@
 					"high",
 					"xhigh"
 				]
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
 			}
 		},
 		"minimax-m2.7:dev": {
@@ -17542,10 +17650,6 @@
 			},
 			"contextWindow": 180000,
 			"maxTokens": null,
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false
-			},
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -17554,6 +17658,43 @@
 					"high"
 				],
 				"requiresEffort": true
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
+			}
+		},
+		"qwen3.6-27b:dev": {
+			"id": "qwen3.6-27b:dev",
+			"name": "Qwen3.6 27B (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262000,
+			"maxTokens": null,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
 			}
 		}
 	},

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17522,7 +17522,8 @@
 			},
 			"compat": {
 				"supportsStore": false,
-				"supportsDeveloperRole": false
+				"supportsDeveloperRole": false,
+				"reasoningDisableMode": "reasoning-effort-none"
 			}
 		},
 		"glm-5.2:dev": {
@@ -17559,8 +17560,8 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"reasoningDisableMode": "reasoning-effort-none",
 				"thinkingFormat": "openai",
-				"reasoningDisableMode": "omit",
 				"reasoningContentField": "reasoning_content",
 				"reasoningEffortMap": {
 					"max": "xhigh"
@@ -17596,7 +17597,8 @@
 			},
 			"compat": {
 				"supportsStore": false,
-				"supportsDeveloperRole": false
+				"supportsDeveloperRole": false,
+				"reasoningDisableMode": "reasoning-effort-none"
 			}
 		},
 		"kimi-k2.6:dev": {
@@ -17629,7 +17631,8 @@
 			},
 			"compat": {
 				"supportsStore": false,
-				"supportsDeveloperRole": false
+				"supportsDeveloperRole": false,
+				"reasoningDisableMode": "reasoning-effort-none"
 			}
 		},
 		"minimax-m2.7:dev": {
@@ -17661,7 +17664,8 @@
 			},
 			"compat": {
 				"supportsStore": false,
-				"supportsDeveloperRole": false
+				"supportsDeveloperRole": false,
+				"reasoningDisableMode": "reasoning-effort-none"
 			}
 		},
 		"qwen3.6-27b:dev": {
@@ -17696,6 +17700,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
+				"reasoningDisableMode": "reasoning-effort-none",
 				"thinkingFormat": "openai"
 			}
 		}

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17598,7 +17598,7 @@
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
-				"reasoningDisableMode": "reasoning-effort-none"
+				"reasoningDisableMode": "lowest-effort"
 			}
 		},
 		"kimi-k2.6:dev": {

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -17490,6 +17490,73 @@
 			"maxTokens": 64000
 		}
 	},
+	"electronhub": {
+		"kimi-k2.6:dev": {
+			"id": "kimi-k2.6:dev",
+			"name": "Kimi K2.6 (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 240000,
+			"maxTokens": null,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"minimax-m2.7:dev": {
+			"id": "minimax-m2.7:dev",
+			"name": "MiniMax M2.7 (DevPass)",
+			"api": "openai-completions",
+			"provider": "electronhub",
+			"baseUrl": "https://api.electronhub.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 180000,
+			"maxTokens": null,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			}
+		}
+	},
 	"firepass": {
 		"kimi-k2.6-turbo": {
 			"id": "kimi-k2.6-turbo",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -17,6 +17,7 @@ import {
 	cloudflareAiGatewayModelManagerOptions,
 	coreWeaveModelManagerOptions,
 	deepseekModelManagerOptions,
+	electronHubModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
 	githubCopilotModelManagerOptions,
@@ -134,6 +135,17 @@ export const CATALOG_PROVIDERS = [
 		createModelManagerOptions: (config: ModelManagerConfig) => devinModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,
 		catalogDiscovery: { label: "Devin", envVars: ["DEVIN_API_KEY"], oauthProvider: "devin" },
+	},
+	{
+		id: "electronhub",
+		defaultModel: "kimi-k2.6:dev",
+		envVars: ["ELECTRONHUB_DEV_API_KEY", "ELECTRONHUB_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => electronHubModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: {
+			label: "ElectronHub Coding Plan",
+			envVars: ["ELECTRONHUB_DEV_API_KEY", "ELECTRONHUB_API_KEY"],
+		},
 	},
 	{
 		id: "firepass",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1858,6 +1858,34 @@ const ELECTRONHUB_OPENAI_COMPAT = {
 	supportsDeveloperRole: false,
 } as const satisfies ModelSpec<"openai-completions">["compat"];
 
+function electronHubCompatForModel(id: string, base: ModelSpec<"openai-completions">["compat"] | undefined) {
+	return {
+		...(base ?? {}),
+		...ELECTRONHUB_OPENAI_COMPAT,
+		...(isReasoningGlmModelId(id)
+			? {
+					thinkingFormat: "zai",
+					reasoningDisableMode: "omit",
+					reasoningContentField: "reasoning_content",
+				}
+			: {}),
+	} as const satisfies ModelSpec<"openai-completions">["compat"];
+}
+
+/**
+ * Static seed of the ElectronHub Coding Plan (DevPass) catalogue, covering
+ * all six live `:dev` models so `/login electronhub` has a usable offline
+ * catalog before dynamic discovery ever runs. `dynamicModelsAuthoritative:
+ * true` below means live `/v1/models` data replaces these at runtime — this
+ * seed only matters pre-login / pre-refresh.
+ *
+ * Context windows mirror a live `/v1/models` snapshot (see
+ * `test/fixtures/electronhub-devpass-models.json`), but ElectronHub has
+ * revised the newer three entries' (`glm-5.2:dev`, `gemma-4-31b-it:dev`,
+ * `qwen3.6-27b:dev`) advertised `tokens` value more than once within the
+ * same day during integration — treat these three as best-effort until
+ * discovery refreshes them.
+ */
 export const ELECTRONHUB_DEVPASS_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
 	{
 		id: "kimi-k2.6:dev",
@@ -1885,12 +1913,70 @@ export const ELECTRONHUB_DEVPASS_STATIC_MODELS: readonly ModelSpec<"openai-compl
 		maxTokens: null,
 		compat: ELECTRONHUB_OPENAI_COMPAT,
 	},
+	{
+		id: "gpt-oss-120b:dev",
+		name: "GPT OSS 120B (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: null,
+		compat: ELECTRONHUB_OPENAI_COMPAT,
+	},
+	{
+		id: "glm-5.2:dev",
+		name: "GLM 5.2 (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: null,
+		compat: electronHubCompatForModel("glm-5.2:dev", ELECTRONHUB_OPENAI_COMPAT),
+	},
+	{
+		id: "gemma-4-31b-it:dev",
+		name: "Gemma 4 31B (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: null,
+		compat: ELECTRONHUB_OPENAI_COMPAT,
+	},
+	{
+		id: "qwen3.6-27b:dev",
+		name: "Qwen3.6 27B (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 262_000,
+		maxTokens: null,
+		compat: ELECTRONHUB_OPENAI_COMPAT,
+	},
 ];
 
 function isElectronHubDevpassModel(entry: OpenAICompatibleModelRecord, id: string): boolean {
 	if (id.endsWith(":dev")) return true;
 	const metadata = isRecord(entry.metadata) ? entry.metadata : undefined;
-	return metadata?.devpass_only === true;
+	if (metadata?.devpass_only === true) return true;
+	// Secondary signal: two of the six live DevPass records omit
+	// `metadata.devpass_only` entirely, so a `:dev`-less future entry could
+	// still slip past the checks above. `pricing.plan` has been populated on
+	// every DevPass record observed so far.
+	const pricing = isRecord(entry.pricing) ? entry.pricing : undefined;
+	return pricing?.plan === "devpass";
 }
 
 function toElectronHubModelName(name: string): string {
@@ -1911,7 +1997,10 @@ function mapElectronHubDevpassModel(
 	return {
 		...base,
 		name: toElectronHubModelName(base.name),
-		reasoning: metadata?.reasoning === true || base.reasoning,
+		// All DevPass models support reasoning per docs.electronhub.ai/billing/coding-plan;
+		// trust that over live metadata — `qwen3.6-27b:dev` reports `reasoning: false`
+		// but has been observed returning non-zero `reasoning_tokens` in usage.
+		reasoning: true,
 		input,
 		cost: {
 			input: toNumber(pricing?.input) ?? base.cost.input,
@@ -1921,7 +2010,7 @@ function mapElectronHubDevpassModel(
 		},
 		contextWindow: toPositiveNumber(entry.tokens, base.contextWindow),
 		...(metadata?.function_call === false ? { supportsTools: false } : {}),
-		compat: { ...(base.compat ?? {}), ...ELECTRONHUB_OPENAI_COMPAT },
+		compat: electronHubCompatForModel(base.id, base.compat),
 	};
 }
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1942,6 +1942,22 @@ export const ELECTRONHUB_DEVPASS_STATIC_MODELS: readonly ModelSpec<"openai-compl
 		api: "openai-completions",
 		provider: "electronhub",
 		baseUrl: ELECTRONHUB_API_BASE_URL,
+		// MiniMax M2 is a reasoning-first architecture: isMinimaxM2FamilyModelId
+		// backfills thinking.requiresEffort for every host (see model-thinking.ts
+		// and the Fireworks/native-host precedent in model-thinking.test.ts), so
+		// Thinking Off requests never reach this model's reasoningDisableMode at
+		// all — normalizeMandatoryReasoningOptions (stream.ts) clamps
+		// disableReasoning to the ladder's lowest effort ("low") before any
+		// compat-level disable encoding runs. That's intentional, not a gap left
+		// by the reasoning-effort-none change above: live-probed directly against
+		// ElectronHub's /v1/chat/completions, reasoning_effort "none", "minimal",
+		// "low", and an omitted field all produced comparable non-trivial
+		// reasoning content (roughly 200-600 chars, no measurable suppression) —
+		// the gateway does not make this architecturally mandatory-reasoning model
+		// honor "off" either. Sending "none" here would be no more effective than
+		// the existing "low" clamp, so this model is deliberately left on the
+		// shared mandatory-reasoning floor rather than exempted via
+		// thinking.suppressWhenOff.
 		reasoning: true,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -9,6 +9,7 @@ import {
 	isGlmVisionModelId,
 	isGrokReasoningEffortCapable,
 	isKimiModelId,
+	isOpenAIGptOssModelId,
 	isQwenModelId,
 	isReasoningGlmModelId,
 } from "../identity/family";
@@ -1904,7 +1905,24 @@ function electronHubCompatForModel(id: string, base: ModelSpec<"openai-completio
 						// not honour — silently dropping user-selected effort levels.
 						thinkingFormat: "openai",
 					}
-				: {}),
+				: isOpenAIGptOssModelId(id)
+					? {
+							// GPT-OSS's Harmony reasoning format only accepts low/medium/high
+							// for reasoning_effort and rejects minimal/xhigh/none on its
+							// native hosts (see isOpenAIGptOssModelId in identity/family.ts,
+							// and the issue #2315 regression coverage in
+							// packages/ai/test/issue-2315-repro.test.ts, which locks every
+							// other GPT-OSS host onto the "low" floor instead of "none" —
+							// built from a real prior production failure). ElectronHub's
+							// gateway did not reject reasoning_effort:"none" when live-probed
+							// directly, but that's weaker evidence than an established
+							// cross-provider regression test: keep this one model on the
+							// tested-safe "lowest-effort" disable path rather than opting into
+							// the shared reasoning-effort-none mode, so a future gateway-side
+							// validation tightening can't reintroduce #2315.
+							reasoningDisableMode: "lowest-effort",
+						}
+					: {}),
 	} as const satisfies ModelSpec<"openai-completions">["compat"];
 }
 
@@ -1976,7 +1994,7 @@ export const ELECTRONHUB_DEVPASS_STATIC_MODELS: readonly ModelSpec<"openai-compl
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 128_000,
 		maxTokens: null,
-		compat: ELECTRONHUB_OPENAI_COMPAT,
+		compat: electronHubCompatForModel("gpt-oss-120b:dev", ELECTRONHUB_OPENAI_COMPAT),
 	},
 	{
 		id: "glm-5.2:dev",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1857,6 +1857,12 @@ const ELECTRONHUB_API_BASE_URL = "https://api.electronhub.ai/v1";
 const ELECTRONHUB_OPENAI_COMPAT = {
 	supportsStore: false,
 	supportsDeveloperRole: false,
+	// ElectronHub's /v1/chat/completions documents reasoning_effort: "none" as
+	// the way to fully hide reasoning output — the generic "openai" dialect's
+	// default ("lowest-effort", sending the ladder's floor tier) still produces
+	// some reasoning, and simply omitting the field falls back to ElectronHub's
+	// own server-side default rather than honoring the caller's disable choice.
+	reasoningDisableMode: "reasoning-effort-none",
 } as const satisfies ModelSpec<"openai-completions">["compat"];
 
 function electronHubCompatForModel(id: string, base: ModelSpec<"openai-completions">["compat"] | undefined) {
@@ -1875,7 +1881,6 @@ function electronHubCompatForModel(id: string, base: ModelSpec<"openai-completio
 					// ladder's top "max" tier onto ElectronHub's actual top tier "xhigh"
 					// before it reaches the wire.
 					thinkingFormat: "openai",
-					reasoningDisableMode: "omit",
 					reasoningContentField: "reasoning_content",
 					reasoningEffortMap: { [Effort.Max]: "xhigh" },
 					// Moving off thinkingFormat "zai" also drops its reasoning_content

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -9,6 +9,7 @@ import {
 	isGlmVisionModelId,
 	isGrokReasoningEffortCapable,
 	isKimiModelId,
+	isQwenModelId,
 	isReasoningGlmModelId,
 } from "../identity/family";
 import type { ModelManagerOptions } from "../model-manager";
@@ -1868,7 +1869,19 @@ function electronHubCompatForModel(id: string, base: ModelSpec<"openai-completio
 					reasoningDisableMode: "omit",
 					reasoningContentField: "reasoning_content",
 				}
-			: {}),
+			: isQwenModelId(id)
+				? {
+						// ElectronHub is a gateway that normalizes every backend onto its
+						// own OpenAI-shaped reasoning surface (`reasoning_effort` /
+						// docs.electronhub.ai/api-reference/chat/completions), not each
+						// upstream model's native dialect. Without this override,
+						// `buildOpenAICompat`'s id-based detection classifies any
+						// "qwen"-named id into the native Qwen dialect (top-level
+						// `enable_thinking` boolean), which ElectronHub's endpoint does
+						// not honour — silently dropping user-selected effort levels.
+						thinkingFormat: "openai",
+					}
+				: {}),
 	} as const satisfies ModelSpec<"openai-completions">["compat"];
 }
 
@@ -1963,7 +1976,7 @@ export const ELECTRONHUB_DEVPASS_STATIC_MODELS: readonly ModelSpec<"openai-compl
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 262_000,
 		maxTokens: null,
-		compat: ELECTRONHUB_OPENAI_COMPAT,
+		compat: electronHubCompatForModel("qwen3.6-27b:dev", ELECTRONHUB_OPENAI_COMPAT),
 	},
 ];
 
@@ -2008,8 +2021,10 @@ function mapElectronHubDevpassModel(
 			cacheRead: toNumber(pricing?.cache_read) ?? base.cost.cacheRead,
 			cacheWrite: toNumber(pricing?.cache_write) ?? base.cost.cacheWrite,
 		},
+		// All DevPass models support function calling per docs.electronhub.ai/billing/coding-plan;
+		// trust that over live metadata rather than gating on `function_call === false`, which
+		// would let a stale/bad /v1/models record silently strip tool use from a coding agent.
 		contextWindow: toPositiveNumber(entry.tokens, base.contextWindow),
-		...(metadata?.function_call === false ? { supportsTools: false } : {}),
 		compat: electronHubCompatForModel(base.id, base.compat),
 	};
 }

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1865,9 +1865,27 @@ function electronHubCompatForModel(id: string, base: ModelSpec<"openai-completio
 		...ELECTRONHUB_OPENAI_COMPAT,
 		...(isReasoningGlmModelId(id)
 			? {
-					thinkingFormat: "zai",
+					// ElectronHub's /v1/chat/completions documents a flat, OpenAI-shaped
+					// reasoning_effort enum (none/minimal/low/medium/high/xhigh) for every
+					// proxied model — not Z.ai's native two-tier high/max scale. Staying on
+					// thinkingFormat "zai" restricts the exposed ladder to high/max (see
+					// getModelDefinedEfforts in model-thinking.ts) and lets the unsupported
+					// "max" value reach the wire. Use the generic OpenAI dialect instead —
+					// it already resolves to the correct five-tier ladder — and remap that
+					// ladder's top "max" tier onto ElectronHub's actual top tier "xhigh"
+					// before it reaches the wire.
+					thinkingFormat: "openai",
 					reasoningDisableMode: "omit",
 					reasoningContentField: "reasoning_content",
+					reasoningEffortMap: { [Effort.Max]: "xhigh" },
+					// Moving off thinkingFormat "zai" also drops its reasoning_content
+					// continuation replay (openai-completions.ts only fires that branch
+					// when thinkingFormat === "zai"). ElectronHub is exactly the documented
+					// "custom proxy setup" escape hatch for this flag (see the
+					// PROXY_OPENAI_COMPAT_PROVIDERS comment in compat/openai.ts): opt back
+					// into replaying prior-turn reasoning_content on continuation turns so
+					// GLM's cross-turn behavior is unchanged by the dialect switch.
+					replayReasoningContent: true,
 				}
 			: isQwenModelId(id)
 				? {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1858,6 +1858,18 @@ const ELECTRONHUB_API_BASE_URL = "https://api.electronhub.ai/v1";
 const ELECTRONHUB_OPENAI_COMPAT = {
 	supportsStore: false,
 	supportsDeveloperRole: false,
+	// ElectronHub's /v1/chat/completions documents `max_tokens` as the output
+	// cap field, not the newer `max_completion_tokens` buildOpenAICompat
+	// defaults to for hosts outside its useMaxTokens allowlist (compat/openai.ts
+	// — Mistral, Moonshot-native, Z.ai/Zhipu, Chutes, Fireworks, direct
+	// DeepSeek). Confirmed live: sending max_completion_tokens against
+	// kimi-k2.6:dev was silently ignored (100-line response despite a cap of
+	// 5), while max_tokens correctly capped it (finish_reason "length",
+	// completion_tokens 5). Without this override, kimi-k2.6:dev's
+	// alwaysSendMaxTokens (isKimiModel, compat/openai.ts) would send the wrong,
+	// silently-dropped field on every request, defeating the very runaway-
+	// reasoning protection that flag exists for.
+	maxTokensField: "max_tokens",
 	// ElectronHub's /v1/chat/completions documents reasoning_effort: "none" as
 	// the way to fully hide reasoning output — the generic "openai" dialect's
 	// default ("lowest-effort", sending the ladder's floor tier) still produces

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1843,7 +1843,118 @@ export function firepassModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
-// 7.7 Wafer Serverless
+// 7.7 ElectronHub Coding Plan (DevPass)
+// ---------------------------------------------------------------------------
+
+export interface ElectronHubModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+const ELECTRONHUB_API_BASE_URL = "https://api.electronhub.ai/v1";
+const ELECTRONHUB_OPENAI_COMPAT = {
+	supportsStore: false,
+	supportsDeveloperRole: false,
+} as const satisfies ModelSpec<"openai-completions">["compat"];
+
+export const ELECTRONHUB_DEVPASS_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	{
+		id: "kimi-k2.6:dev",
+		name: "Kimi K2.6 (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 240_000,
+		maxTokens: null,
+		compat: ELECTRONHUB_OPENAI_COMPAT,
+	},
+	{
+		id: "minimax-m2.7:dev",
+		name: "MiniMax M2.7 (DevPass)",
+		api: "openai-completions",
+		provider: "electronhub",
+		baseUrl: ELECTRONHUB_API_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 180_000,
+		maxTokens: null,
+		compat: ELECTRONHUB_OPENAI_COMPAT,
+	},
+];
+
+function isElectronHubDevpassModel(entry: OpenAICompatibleModelRecord, id: string): boolean {
+	if (id.endsWith(":dev")) return true;
+	const metadata = isRecord(entry.metadata) ? entry.metadata : undefined;
+	return metadata?.devpass_only === true;
+}
+
+function toElectronHubModelName(name: string): string {
+	const separator = name.indexOf(": ");
+	return separator > 0 ? name.slice(separator + 2) : name;
+}
+
+function mapElectronHubDevpassModel(
+	entry: OpenAICompatibleModelRecord,
+	defaults: ModelSpec<"openai-completions">,
+	reference: ModelSpec<"openai-completions"> | undefined,
+): ModelSpec<"openai-completions"> {
+	const base = mapWithBundledReference(entry, defaults, reference);
+	const metadata = isRecord(entry.metadata) ? entry.metadata : undefined;
+	const pricing = isRecord(entry.pricing) ? entry.pricing : undefined;
+	const input: ("text" | "image")[] =
+		metadata?.vision === true ? ["text", "image"] : metadata?.vision === false ? ["text"] : base.input;
+	return {
+		...base,
+		name: toElectronHubModelName(base.name),
+		reasoning: metadata?.reasoning === true || base.reasoning,
+		input,
+		cost: {
+			input: toNumber(pricing?.input) ?? base.cost.input,
+			output: toNumber(pricing?.output) ?? base.cost.output,
+			cacheRead: toNumber(pricing?.cache_read) ?? base.cost.cacheRead,
+			cacheWrite: toNumber(pricing?.cache_write) ?? base.cost.cacheWrite,
+		},
+		contextWindow: toPositiveNumber(entry.tokens, base.contextWindow),
+		...(metadata?.function_call === false ? { supportsTools: false } : {}),
+		compat: { ...(base.compat ?? {}), ...ELECTRONHUB_OPENAI_COMPAT },
+	};
+}
+
+export function electronHubModelManagerOptions(
+	config?: ElectronHubModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? ELECTRONHUB_API_BASE_URL;
+	return {
+		providerId: "electronhub",
+		dynamicModelsAuthoritative: true,
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "electronhub",
+					baseUrl,
+					apiKey,
+					filterModel: (entry, model) => isElectronHubDevpassModel(entry, model.id),
+					mapModel: (entry, defaults) =>
+						mapElectronHubDevpassModel(
+							entry,
+							defaults,
+							ELECTRONHUB_DEVPASS_STATIC_MODELS.find(model => model.id === defaults.id),
+						),
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// 7.8 Wafer Serverless
 // ---------------------------------------------------------------------------
 
 export interface WaferModelManagerConfig {

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -156,7 +156,16 @@ export type OpenAIReasoningDisableMode =
 	| "openrouter-enabled-false"
 	| "zai-thinking-disabled"
 	| "qwen-enable-thinking-false"
-	| "qwen-template-false";
+	| "qwen-template-false"
+	// Sends an explicit top-level `reasoning_effort: "none"` (distinct from
+	// "omit", which drops the field, and "lowest-effort", which sends the
+	// ladder's lowest tier). For gateways whose OpenAI-shaped dialect
+	// documents "none" as its own wire value for fully hiding reasoning
+	// output — e.g. ElectronHub's `/v1/chat/completions` reasoning_effort
+	// enum (none/minimal/low/medium/high/xhigh) — sending the lowest tier
+	// still produces some reasoning, and omitting the field falls back to
+	// the gateway's own default rather than honoring the caller's disable.
+	| "reasoning-effort-none";
 
 export type OpenAIStreamMarkupHealingPattern = "kimi" | "dsml" | "thinking";
 

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -56,6 +56,40 @@ describe("ElectronHub provider catalog", () => {
 		}
 	});
 
+	it("overrides qwen3.6-27b:dev onto ElectronHub's OpenAI-shaped reasoning dialect, not native Qwen enable_thinking", () => {
+		// Without an explicit override, buildOpenAICompat's id-based detection classifies
+		// any "qwen"-named id into the native Qwen dialect (top-level `enable_thinking`
+		// boolean), which ElectronHub's gateway does not honour — it expects the generic
+		// OpenAI-shaped reasoning_effort surface for every proxied model
+		// (docs.electronhub.ai/api-reference/chat/completions).
+		const qwen = getBundledModel<"openai-completions">("electronhub", "qwen3.6-27b:dev");
+		expect(qwen.compat.thinkingFormat).toBe("openai");
+		expect(qwen.compat.thinkingFormat).not.toBe("qwen");
+	});
+
+	it("applies the same OpenAI-shaped dialect override to qwen3.6-27b:dev via dynamic discovery", async () => {
+		const fetchImpl: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "qwen3.6-27b:dev",
+							name: "ElectronHub: Qwen3.6 27B (DevPass)",
+							tokens: 262_000,
+							metadata: { devpass_only: false, reasoning: false, vision: true, function_call: true },
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const options = getElectronHubOptions(fetchImpl);
+		const models = (await options.fetchDynamicModels?.()) as ModelSpec<"openai-completions">[] | null | undefined;
+		const qwen = models?.find(candidate => candidate.id === "qwen3.6-27b:dev");
+		expect(qwen).toBeDefined();
+		expect(qwen?.compat?.thinkingFormat).toBe("openai");
+	});
+
 	it("keeps DevPass models from /v1/models discovery via :dev suffix, devpass_only, or pricing.plan=devpass", async () => {
 		const requestedUrls: string[] = [];
 		const fetchImpl: FetchImpl = async input => {
@@ -156,8 +190,9 @@ describe("ElectronHub provider catalog", () => {
 		expect(thirdparty?.name).toBe("Custom DevPass Name");
 		expect(thirdparty?.contextWindow).toBe(123_456);
 		expect(thirdparty?.input).toEqual(["text", "image"]);
-		// metadata.function_call === false still disables tools.
-		expect(thirdparty?.supportsTools).toBe(false);
+		// All DevPass models support function calling per docs — a stale/false
+		// function_call metadata flag must not disable tools.
+		expect(thirdparty?.supportsTools).not.toBe(false);
 		expect(thirdparty?.compat?.supportsStore).toBe(false);
 
 		const minimax = models?.find(candidate => candidate.id === "minimax-m2.7:dev");
@@ -165,7 +200,6 @@ describe("ElectronHub provider catalog", () => {
 		expect(minimax?.name).toBe("MiniMax M2.7 (DevPass)");
 		expect(minimax?.contextWindow).toBe(180_000);
 		expect(minimax?.input).toEqual(["text"]);
-		// function_call === true (not false) must not disable tools.
 		expect(minimax?.supportsTools).not.toBe(false);
 	});
 });

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -79,6 +79,26 @@ describe("ElectronHub provider catalog", () => {
 		expect(qwen.compat.thinkingFormat).not.toBe("qwen");
 	});
 
+	it("keeps minimax-m2.7:dev on the mandatory-reasoning floor instead of reasoning-effort-none", () => {
+		// MiniMax M2 is a reasoning-first architecture: isMinimaxM2FamilyModelId
+		// backfills thinking.requiresEffort for every host (Fireworks, native,
+		// ElectronHub alike — see model-thinking.test.ts), so Thinking Off
+		// requests never reach this model's reasoningDisableMode at all;
+		// normalizeMandatoryReasoningOptions (packages/ai/src/stream.ts) clamps
+		// disableReasoning to the ladder's lowest effort ("low") first. Confirmed
+		// live against ElectronHub's /v1/chat/completions that "none", "minimal",
+		// "low", and an omitted field all produce comparable non-trivial
+		// reasoning content for this model — the gateway does not make this
+		// architecturally mandatory-reasoning model honor "off" either, so it's
+		// deliberately NOT exempted via thinking.suppressWhenOff.
+		const minimax = getBundledModel<"openai-completions">("electronhub", "minimax-m2.7:dev");
+		expect(minimax.thinking?.requiresEffort).toBe(true);
+		expect(minimax.thinking?.suppressWhenOff).not.toBe(true);
+		// The shared reasoning-effort-none disable mode is still configured (and
+		// harmless) here — it's just structurally unreachable for this model.
+		expect(minimax.compat.reasoningDisableMode).toBe("reasoning-effort-none");
+	});
+
 	it("applies the same OpenAI-shaped dialect override to qwen3.6-27b:dev via dynamic discovery", async () => {
 		const fetchImpl: FetchImpl = async () =>
 			new Response(

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, FetchImpl as AiFetchImpl } from "@oh-my-pi/pi-ai/types";
 import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
@@ -37,7 +39,47 @@ describe("ElectronHub provider catalog", () => {
 			expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 			// ElectronHub is OpenAI-compatible but does not support the OpenAI `store` flag.
 			expect(model.compat.supportsStore).toBe(false);
+			// ElectronHub's /v1/chat/completions documents `max_tokens` as the output
+			// cap field, not the newer `max_completion_tokens` the generic OpenAI
+			// dialect defaults to outside buildOpenAICompat's useMaxTokens allowlist.
+			expect(model.compat.maxTokensField).toBe("max_tokens");
 		}
+	});
+
+	it("sends max_tokens (not max_completion_tokens) on the wire for kimi-k2.6:dev, honoring the caller's cap", async () => {
+		// kimi-k2.6:dev also carries alwaysSendMaxTokens (isKimiModel in
+		// compat/openai.ts), so it sends a max-tokens field on EVERY request, even
+		// when the caller set no cap. Live-probed against the real ElectronHub
+		// endpoint: a max_completion_tokens:5 cap was silently ignored (the model
+		// produced a full ~100-line response), while max_tokens:5 correctly capped
+		// it (finish_reason "length", completion_tokens 5) -- confirming
+		// ElectronHub only honors max_tokens, and the previously-unset
+		// maxTokensField default would have made this model's runaway-reasoning
+		// protection a silent no-op on this provider.
+		const model = getBundledModel<"openai-completions">("electronhub", "kimi-k2.6:dev");
+		let capturedBody: Record<string, unknown> = {};
+		const fetchMock: AiFetchImpl = Object.assign(
+			async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+				const raw = typeof init?.body === "string" ? init.body : "{}";
+				capturedBody = JSON.parse(raw) as Record<string, unknown>;
+				return new Response("data: [DONE]\n\n", {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				});
+			},
+			{ preconnect: fetch.preconnect },
+		);
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+		};
+
+		const stream = streamOpenAICompletions(model, context, { apiKey: "test-key", fetch: fetchMock, maxTokens: 5 });
+		for await (const _ of stream) {
+			// drain until terminal event
+		}
+
+		expect(capturedBody.max_tokens).toBe(5);
+		expect(capturedBody.max_completion_tokens).toBeUndefined();
 	});
 
 	it("keeps glm-5.2:dev on ElectronHub's OpenAI-shaped reasoning_effort surface, remapping max to xhigh", () => {

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -36,6 +36,10 @@ describe("ElectronHub provider catalog", () => {
 			expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 			// ElectronHub is OpenAI-compatible but does not support the OpenAI `store` flag.
 			expect(model.compat.supportsStore).toBe(false);
+			// ElectronHub documents reasoning_effort: "none" as the explicit way to hide
+			// reasoning output; the generic "openai" dialect default ("lowest-effort") would
+			// still send the ladder's floor tier instead of actually turning reasoning off.
+			expect(model.compat.reasoningDisableMode).toBe("reasoning-effort-none");
 		}
 	});
 
@@ -48,9 +52,8 @@ describe("ElectronHub provider catalog", () => {
 		const glm = getBundledModel<"openai-completions">("electronhub", "glm-5.2:dev");
 		expect(glm.compat.thinkingFormat).toBe("openai");
 		expect(glm.compat.thinkingFormat).not.toBe("zai");
-		// "omit" is exclusive to glm-5.2:dev among the six DevPass models — the other five
-		// fall through to the generic openai-format default ("lowest-effort").
-		expect(glm.compat.reasoningDisableMode).toBe("omit");
+		// reasoningDisableMode is asserted uniformly across all six DevPass models
+		// (including glm-5.2:dev) in the "bundles all six DevPass models" test above.
 		expect(glm.compat.reasoningContentField).toBe("reasoning_content");
 		// Leaving thinkingFormat "zai" also drops its reasoning_content continuation
 		// replay (openai-completions.ts only fires that branch for thinkingFormat ===
@@ -63,11 +66,6 @@ describe("ElectronHub provider catalog", () => {
 		// and on the model's resolved thinking.effortMap.
 		expect(glm.compat.reasoningEffortMap?.max).toBe("xhigh");
 		expect(glm.thinking?.effortMap?.max).toBe("xhigh");
-
-		for (const id of DEVPASS_IDS.filter(candidate => candidate !== "glm-5.2:dev")) {
-			const model = getBundledModel<"openai-completions">("electronhub", id);
-			expect(model.compat.reasoningDisableMode).not.toBe("omit");
-		}
 	});
 
 	it("overrides qwen3.6-27b:dev onto ElectronHub's OpenAI-shaped reasoning dialect, not native Qwen enable_thinking", () => {

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
@@ -36,10 +37,6 @@ describe("ElectronHub provider catalog", () => {
 			expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
 			// ElectronHub is OpenAI-compatible but does not support the OpenAI `store` flag.
 			expect(model.compat.supportsStore).toBe(false);
-			// ElectronHub documents reasoning_effort: "none" as the explicit way to hide
-			// reasoning output; the generic "openai" dialect default ("lowest-effort") would
-			// still send the ladder's floor tier instead of actually turning reasoning off.
-			expect(model.compat.reasoningDisableMode).toBe("reasoning-effort-none");
 		}
 	});
 
@@ -52,8 +49,10 @@ describe("ElectronHub provider catalog", () => {
 		const glm = getBundledModel<"openai-completions">("electronhub", "glm-5.2:dev");
 		expect(glm.compat.thinkingFormat).toBe("openai");
 		expect(glm.compat.thinkingFormat).not.toBe("zai");
-		// reasoningDisableMode is asserted uniformly across all six DevPass models
-		// (including glm-5.2:dev) in the "bundles all six DevPass models" test above.
+		// reasoningDisableMode is not uniform across all six DevPass models (see
+		// the dedicated minimax-m2.7:dev and gpt-oss-120b:dev tests below); the
+		// four models sharing reasoning-effort-none are asserted together in
+		// "opts kimi/glm/gemma/qwen into ElectronHub's explicit reasoning_effort:none".
 		expect(glm.compat.reasoningContentField).toBe("reasoning_content");
 		// Leaving thinkingFormat "zai" also drops its reasoning_content continuation
 		// replay (openai-completions.ts only fires that branch for thinkingFormat ===
@@ -99,6 +98,34 @@ describe("ElectronHub provider catalog", () => {
 		expect(minimax.compat.reasoningDisableMode).toBe("reasoning-effort-none");
 	});
 
+	it("opts kimi/glm/gemma/qwen into ElectronHub's explicit reasoning_effort:none, unlike minimax/gpt-oss", () => {
+		// kimi-k2.6:dev, glm-5.2:dev, gemma-4-31b-it:dev, and qwen3.6-27b:dev have no
+		// mandatory-reasoning floor and no narrower Harmony-style effort vocabulary,
+		// so they inherit the shared ElectronHub base's reasoning-effort-none disable
+		// mode uncontested — minimax-m2.7:dev and gpt-oss-120b:dev are the two
+		// deliberate exceptions, covered by their own dedicated tests.
+		for (const id of ["kimi-k2.6:dev", "glm-5.2:dev", "gemma-4-31b-it:dev", "qwen3.6-27b:dev"] as const) {
+			const model = getBundledModel<"openai-completions">("electronhub", id);
+			expect(model.compat.reasoningDisableMode).toBe("reasoning-effort-none");
+		}
+	});
+
+	it("keeps gpt-oss-120b:dev on the tested-safe lowest-effort disable path instead of reasoning-effort-none", () => {
+		// GPT-OSS's Harmony reasoning format only accepts low/medium/high for
+		// reasoning_effort and rejects minimal/xhigh/none on its native hosts (see
+		// isOpenAIGptOssModelId in identity/family.ts, and the issue #2315
+		// regression coverage in packages/ai/test/issue-2315-repro.test.ts, which
+		// locks every other GPT-OSS host onto the "low" floor instead of "none" —
+		// built from a real prior production failure). ElectronHub's gateway did
+		// not reject reasoning_effort:"none" when live-probed directly, but that's
+		// weaker evidence than an established cross-provider regression test, so
+		// this model deliberately stays off the shared reasoning-effort-none mode.
+		const gptOss = getBundledModel<"openai-completions">("electronhub", "gpt-oss-120b:dev");
+		expect(gptOss.compat.reasoningDisableMode).toBe("lowest-effort");
+		expect(gptOss.compat.reasoningDisableMode).not.toBe("reasoning-effort-none");
+		expect(gptOss.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High]);
+	});
+
 	it("applies the same OpenAI-shaped dialect override to qwen3.6-27b:dev via dynamic discovery", async () => {
 		const fetchImpl: FetchImpl = async () =>
 			new Response(
@@ -120,6 +147,30 @@ describe("ElectronHub provider catalog", () => {
 		const qwen = models?.find(candidate => candidate.id === "qwen3.6-27b:dev");
 		expect(qwen).toBeDefined();
 		expect(qwen?.compat?.thinkingFormat).toBe("openai");
+	});
+
+	it("applies the same lowest-effort disable override to gpt-oss-120b:dev via dynamic discovery", async () => {
+		const fetchImpl: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "gpt-oss-120b:dev",
+							name: "ElectronHub: GPT OSS 120B (DevPass)",
+							tokens: 128_000,
+							metadata: { devpass_only: false, reasoning: true, vision: false, function_call: true },
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const options = getElectronHubOptions(fetchImpl);
+		const models = (await options.fetchDynamicModels?.()) as ModelSpec<"openai-completions">[] | null | undefined;
+		const gptOss = models?.find(candidate => candidate.id === "gpt-oss-120b:dev");
+		expect(gptOss).toBeDefined();
+		expect(gptOss?.compat?.reasoningDisableMode).toBe("lowest-effort");
+		expect(gptOss?.compat?.reasoningDisableMode).not.toBe("reasoning-effort-none");
 	});
 
 	it("keeps DevPass models from /v1/models discovery via :dev suffix, devpass_only, or pricing.plan=devpass", async () => {

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -39,20 +39,34 @@ describe("ElectronHub provider catalog", () => {
 		}
 	});
 
-	it("only bundles GLM/Z.AI thinking compat on glm-5.2:dev, not the other five DevPass models", () => {
+	it("keeps glm-5.2:dev on ElectronHub's OpenAI-shaped reasoning_effort surface, remapping max to xhigh", () => {
+		// ElectronHub's /v1/chat/completions documents a flat reasoning_effort enum
+		// (none/minimal/low/medium/high/xhigh) for every proxied model, not Z.ai's native
+		// two-tier high/max scale. thinkingFormat "zai" would restrict the exposed ladder
+		// to high/max (getModelDefinedEfforts in model-thinking.ts) and let the unsupported
+		// "max" value reach the wire — so glm-5.2:dev must stay off it.
 		const glm = getBundledModel<"openai-completions">("electronhub", "glm-5.2:dev");
-		expect(glm.compat.thinkingFormat).toBe("zai");
+		expect(glm.compat.thinkingFormat).toBe("openai");
+		expect(glm.compat.thinkingFormat).not.toBe("zai");
+		// "omit" is exclusive to glm-5.2:dev among the six DevPass models — the other five
+		// fall through to the generic openai-format default ("lowest-effort").
 		expect(glm.compat.reasoningDisableMode).toBe("omit");
 		expect(glm.compat.reasoningContentField).toBe("reasoning_content");
+		// Leaving thinkingFormat "zai" also drops its reasoning_content continuation
+		// replay (openai-completions.ts only fires that branch for thinkingFormat ===
+		// "zai"); glm-5.2:dev opts back in explicitly so cross-turn behavior is
+		// unchanged by the dialect switch.
+		expect(glm.compat.replayReasoningContent).toBe(true);
+		// The resolved effort ladder still exposes a top "max" tier (from the generic
+		// openai-compat GLM-5.2 policy), but it must be remapped to ElectronHub's actual
+		// top tier "xhigh" before it reaches the wire — both on the raw compat override
+		// and on the model's resolved thinking.effortMap.
+		expect(glm.compat.reasoningEffortMap?.max).toBe("xhigh");
+		expect(glm.thinking?.effortMap?.max).toBe("xhigh");
 
-		// "zai" is the exclusive Z.AI/GLM thinkingFormat marker in this codebase — other
-		// DevPass families get their own generic thinking defaults (e.g. gpt-oss-120b:dev's
-		// harmony-family reasoningDisableMode/reasoningContentField, which happen to reuse
-		// some of the same generic field *names* as GLM but never this value), so only
-		// assert the one signal that is exclusively GLM's.
 		for (const id of DEVPASS_IDS.filter(candidate => candidate !== "glm-5.2:dev")) {
 			const model = getBundledModel<"openai-completions">("electronhub", id);
-			expect(model.compat.thinkingFormat).not.toBe("zai");
+			expect(model.compat.reasoningDisableMode).not.toBe("omit");
 		}
 	});
 

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "bun:test";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
 import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import ELECTRONHUB_LIVE_DEVPASS from "./fixtures/electronhub-devpass-models.json" with { type: "json" };
+
+const DEVPASS_IDS = [
+	"kimi-k2.6:dev",
+	"minimax-m2.7:dev",
+	"gpt-oss-120b:dev",
+	"glm-5.2:dev",
+	"gemma-4-31b-it:dev",
+	"qwen3.6-27b:dev",
+] as const;
 
 function getElectronHubOptions(fetch: FetchImpl) {
 	const descriptor = PROVIDER_DESCRIPTORS.find(candidate => candidate.providerId === "electronhub");
@@ -12,42 +22,41 @@ function getElectronHubOptions(fetch: FetchImpl) {
 }
 
 describe("ElectronHub provider catalog", () => {
-	it("bundles DevPass models offline with zero token cost and supportsStore=false", () => {
-		const kimi = getBundledModel<"openai-completions">("electronhub", "kimi-k2.6:dev");
-		const minimax = getBundledModel<"openai-completions">("electronhub", "minimax-m2.7:dev");
-
-		expect(kimi).toBeDefined();
-		expect(minimax).toBeDefined();
-
-		expect(kimi).toMatchObject({
-			provider: "electronhub",
-			api: "openai-completions",
-			baseUrl: "https://api.electronhub.ai/v1",
-			reasoning: true,
-			input: ["text"],
-			contextWindow: 240_000,
-			maxTokens: null,
-		});
-		expect(minimax).toMatchObject({
-			provider: "electronhub",
-			api: "openai-completions",
-			baseUrl: "https://api.electronhub.ai/v1",
-			reasoning: true,
-			input: ["text"],
-			contextWindow: 180_000,
-			maxTokens: null,
-		});
-
-		// Cost is a flat-rate DevPass plan (zero marginal token cost).
-		expect(kimi.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
-		expect(minimax.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
-
-		// ElectronHub is OpenAI-compatible but does not support the OpenAI `store` flag.
-		expect(kimi.compat.supportsStore).toBe(false);
-		expect(minimax.compat.supportsStore).toBe(false);
+	it("bundles all six DevPass models offline with zero token cost, reasoning=true, supportsStore=false", () => {
+		for (const id of DEVPASS_IDS) {
+			const model = getBundledModel<"openai-completions">("electronhub", id);
+			expect(model).toBeDefined();
+			expect(model.provider).toBe("electronhub");
+			expect(model.api).toBe("openai-completions");
+			expect(model.baseUrl).toBe("https://api.electronhub.ai/v1");
+			expect(model.maxTokens).toBeNull();
+			// Per docs.electronhub.ai/billing/coding-plan, every DevPass model supports reasoning.
+			expect(model.reasoning).toBe(true);
+			// Flat-rate DevPass plan — zero marginal token cost.
+			expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+			// ElectronHub is OpenAI-compatible but does not support the OpenAI `store` flag.
+			expect(model.compat.supportsStore).toBe(false);
+		}
 	});
 
-	it("keeps only DevPass models from /v1/models discovery (filters out non-:dev + non-devpass_only)", async () => {
+	it("only bundles GLM/Z.AI thinking compat on glm-5.2:dev, not the other five DevPass models", () => {
+		const glm = getBundledModel<"openai-completions">("electronhub", "glm-5.2:dev");
+		expect(glm.compat.thinkingFormat).toBe("zai");
+		expect(glm.compat.reasoningDisableMode).toBe("omit");
+		expect(glm.compat.reasoningContentField).toBe("reasoning_content");
+
+		// "zai" is the exclusive Z.AI/GLM thinkingFormat marker in this codebase — other
+		// DevPass families get their own generic thinking defaults (e.g. gpt-oss-120b:dev's
+		// harmony-family reasoningDisableMode/reasoningContentField, which happen to reuse
+		// some of the same generic field *names* as GLM but never this value), so only
+		// assert the one signal that is exclusively GLM's.
+		for (const id of DEVPASS_IDS.filter(candidate => candidate !== "glm-5.2:dev")) {
+			const model = getBundledModel<"openai-completions">("electronhub", id);
+			expect(model.compat.thinkingFormat).not.toBe("zai");
+		}
+	});
+
+	it("keeps DevPass models from /v1/models discovery via :dev suffix, devpass_only, or pricing.plan=devpass", async () => {
 		const requestedUrls: string[] = [];
 		const fetchImpl: FetchImpl = async input => {
 			requestedUrls.push(input instanceof Request ? input.url : String(input));
@@ -55,17 +64,23 @@ describe("ElectronHub provider catalog", () => {
 				JSON.stringify({
 					data: [
 						{ id: "kimi-k2.6:dev", name: "ElectronHub: Kimi K2.6 (DevPass)", tokens: 240_000 },
-						{ id: "minimax-m2.7:dev", name: "MiniMax M2.7 (DevPass)", tokens: 180_000 },
-						// Keep via metadata.devpass_only even without :dev suffix
+						// Keep via metadata.devpass_only even without :dev suffix.
 						{
 							id: "rollout-preview",
 							name: "ElectronHub: Preview",
 							metadata: { devpass_only: true },
 							tokens: 9_999,
 						},
-						// Must be dropped: not a DevPass record
+						// Keep via pricing.plan="devpass" even without :dev suffix or devpass_only metadata
+						// (two of the six live DevPass records omit metadata.devpass_only entirely).
+						{
+							id: "plan-only-devpass",
+							name: "ElectronHub: Plan Only",
+							pricing: { input: "0", output: "0", plan: "devpass" },
+							tokens: 100_000,
+						},
+						// Must be dropped: plain model, no DevPass signal at all.
 						{ id: "kimi-k2.6", name: "Kimi K2.6", tokens: 240_000 },
-						// Must be dropped: not a DevPass record
 						{ id: "random-model", name: "Random", metadata: { devpass_only: false }, tokens: 1 },
 					],
 				}),
@@ -80,11 +95,36 @@ describe("ElectronHub provider catalog", () => {
 		// Uses the OpenAI-compatible discovery endpoint.
 		expect(requestedUrls).toEqual(["https://api.electronhub.ai/v1/models"]);
 
-		const ids = (models ?? []).map(model => model.id);
-		expect(ids).toEqual(["kimi-k2.6:dev", "minimax-m2.7:dev", "rollout-preview"]);
+		const ids = (models ?? []).map(model => model.id).sort();
+		expect(ids).toEqual(["kimi-k2.6:dev", "plan-only-devpass", "rollout-preview"].sort());
 	});
 
-	it("maps ElectronHub discovery metadata into ModelSpec (name cleanup, tokens->contextWindow, function_call=false)", async () => {
+	it("forces reasoning=true on discovery even when upstream metadata reports reasoning=false", async () => {
+		const fetchImpl: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						// Models the real qwen3.6-27b:dev case: ElectronHub reports reasoning:false,
+						// but the model has been observed returning non-zero reasoning_tokens in usage.
+						{
+							id: "qwen3.6-27b:dev",
+							name: "ElectronHub: Qwen3.6 27B (DevPass)",
+							tokens: 262_000,
+							metadata: { devpass_only: false, reasoning: false, vision: true, function_call: true },
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const options = getElectronHubOptions(fetchImpl);
+		const models = (await options.fetchDynamicModels?.()) as ModelSpec<"openai-completions">[] | null | undefined;
+		const qwen = models?.find(candidate => candidate.id === "qwen3.6-27b:dev");
+		expect(qwen).toBeDefined();
+		expect(qwen?.reasoning).toBe(true);
+	});
+
+	it("maps ElectronHub discovery metadata into ModelSpec (name cleanup, tokens->contextWindow, vision->input)", async () => {
 		const fetchImpl: FetchImpl = async () =>
 			new Response(
 				JSON.stringify({
@@ -93,12 +133,14 @@ describe("ElectronHub provider catalog", () => {
 							id: "thirdparty:dev",
 							name: "ElectronHub: Custom DevPass Name",
 							tokens: 123_456,
-							metadata: {
-								devpass_only: true,
-								reasoning: true,
-								vision: true,
-								function_call: false,
-							},
+							metadata: { devpass_only: true, reasoning: true, vision: true, function_call: false },
+							pricing: { input: "0", output: "0", cache_read: "0", cache_write: "0" },
+						},
+						{
+							id: "minimax-m2.7:dev",
+							name: "ElectronHub: MiniMax M2.7 (DevPass)",
+							tokens: 180_000,
+							metadata: { devpass_only: true, reasoning: true, vision: false, function_call: true },
 							pricing: { input: "0", output: "0", cache_read: "0", cache_write: "0" },
 						},
 					],
@@ -108,14 +150,54 @@ describe("ElectronHub provider catalog", () => {
 
 		const options = getElectronHubOptions(fetchImpl);
 		const models = (await options.fetchDynamicModels?.()) as ModelSpec<"openai-completions">[] | null | undefined;
-		const model = models?.find(candidate => candidate.id === "thirdparty:dev");
 
-		expect(model).toBeDefined();
-		expect(model?.name).toBe("Custom DevPass Name");
-		expect(model?.contextWindow).toBe(123_456);
-		expect(model?.reasoning).toBe(true);
-		expect(model?.input).toEqual(["text", "image"]);
-		expect(model?.supportsTools).toBe(false);
-		expect(model?.compat?.supportsStore).toBe(false);
+		const thirdparty = models?.find(candidate => candidate.id === "thirdparty:dev");
+		expect(thirdparty).toBeDefined();
+		expect(thirdparty?.name).toBe("Custom DevPass Name");
+		expect(thirdparty?.contextWindow).toBe(123_456);
+		expect(thirdparty?.input).toEqual(["text", "image"]);
+		// metadata.function_call === false still disables tools.
+		expect(thirdparty?.supportsTools).toBe(false);
+		expect(thirdparty?.compat?.supportsStore).toBe(false);
+
+		const minimax = models?.find(candidate => candidate.id === "minimax-m2.7:dev");
+		expect(minimax).toBeDefined();
+		expect(minimax?.name).toBe("MiniMax M2.7 (DevPass)");
+		expect(minimax?.contextWindow).toBe(180_000);
+		expect(minimax?.input).toEqual(["text"]);
+		// function_call === true (not false) must not disable tools.
+		expect(minimax?.supportsTools).not.toBe(false);
+	});
+});
+
+describe("ElectronHub DevPass static seed mirrors a live /v1/models snapshot", () => {
+	// Source evidence for the static seed: a sanitized snapshot of the live
+	// `/v1/models` DevPass entries (no API key, only the fields the resolver
+	// relies on). Guards against the seed silently drifting from reality.
+	const liveEntries = ELECTRONHUB_LIVE_DEVPASS.data as Array<Record<string, unknown>>;
+
+	it("every DevPass id has a live fixture entry with :dev suffix or pricing.plan=devpass", () => {
+		const liveById = new Map(liveEntries.map(entry => [entry.id as string, entry]));
+		for (const id of DEVPASS_IDS) {
+			const entry = liveById.get(id);
+			expect(entry).toBeDefined();
+			const pricing = entry?.pricing as { plan?: string } | undefined;
+			expect(id.endsWith(":dev") || pricing?.plan === "devpass").toBe(true);
+		}
+	});
+
+	it("static seed contextWindow matches the live fixture's tokens for every DevPass model", () => {
+		const liveTokens = new Map(liveEntries.map(entry => [entry.id as string, entry.tokens as number | undefined]));
+		const seeds: Record<string, number | null> = {
+			"kimi-k2.6:dev": getBundledModel<"openai-completions">("electronhub", "kimi-k2.6:dev").contextWindow,
+			"minimax-m2.7:dev": getBundledModel<"openai-completions">("electronhub", "minimax-m2.7:dev").contextWindow,
+			"gpt-oss-120b:dev": getBundledModel<"openai-completions">("electronhub", "gpt-oss-120b:dev").contextWindow,
+			"glm-5.2:dev": getBundledModel<"openai-completions">("electronhub", "glm-5.2:dev").contextWindow,
+			"gemma-4-31b-it:dev": getBundledModel<"openai-completions">("electronhub", "gemma-4-31b-it:dev").contextWindow,
+			"qwen3.6-27b:dev": getBundledModel<"openai-completions">("electronhub", "qwen3.6-27b:dev").contextWindow,
+		};
+		for (const [id, seedContextWindow] of Object.entries(seeds)) {
+			expect(seedContextWindow).toBe(liveTokens.get(id) ?? null);
+		}
 	});
 });

--- a/packages/catalog/test/electronhub-provider.test.ts
+++ b/packages/catalog/test/electronhub-provider.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+function getElectronHubOptions(fetch: FetchImpl) {
+	const descriptor = PROVIDER_DESCRIPTORS.find(candidate => candidate.providerId === "electronhub");
+	if (!descriptor) throw new Error("ElectronHub descriptor missing");
+	const options = descriptor.createModelManagerOptions({ apiKey: "ek-dev-test", fetch });
+	expect(options.providerId).toBe("electronhub");
+	return options;
+}
+
+describe("ElectronHub provider catalog", () => {
+	it("bundles DevPass models offline with zero token cost and supportsStore=false", () => {
+		const kimi = getBundledModel<"openai-completions">("electronhub", "kimi-k2.6:dev");
+		const minimax = getBundledModel<"openai-completions">("electronhub", "minimax-m2.7:dev");
+
+		expect(kimi).toBeDefined();
+		expect(minimax).toBeDefined();
+
+		expect(kimi).toMatchObject({
+			provider: "electronhub",
+			api: "openai-completions",
+			baseUrl: "https://api.electronhub.ai/v1",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 240_000,
+			maxTokens: null,
+		});
+		expect(minimax).toMatchObject({
+			provider: "electronhub",
+			api: "openai-completions",
+			baseUrl: "https://api.electronhub.ai/v1",
+			reasoning: true,
+			input: ["text"],
+			contextWindow: 180_000,
+			maxTokens: null,
+		});
+
+		// Cost is a flat-rate DevPass plan (zero marginal token cost).
+		expect(kimi.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		expect(minimax.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+
+		// ElectronHub is OpenAI-compatible but does not support the OpenAI `store` flag.
+		expect(kimi.compat.supportsStore).toBe(false);
+		expect(minimax.compat.supportsStore).toBe(false);
+	});
+
+	it("keeps only DevPass models from /v1/models discovery (filters out non-:dev + non-devpass_only)", async () => {
+		const requestedUrls: string[] = [];
+		const fetchImpl: FetchImpl = async input => {
+			requestedUrls.push(input instanceof Request ? input.url : String(input));
+			return new Response(
+				JSON.stringify({
+					data: [
+						{ id: "kimi-k2.6:dev", name: "ElectronHub: Kimi K2.6 (DevPass)", tokens: 240_000 },
+						{ id: "minimax-m2.7:dev", name: "MiniMax M2.7 (DevPass)", tokens: 180_000 },
+						// Keep via metadata.devpass_only even without :dev suffix
+						{
+							id: "rollout-preview",
+							name: "ElectronHub: Preview",
+							metadata: { devpass_only: true },
+							tokens: 9_999,
+						},
+						// Must be dropped: not a DevPass record
+						{ id: "kimi-k2.6", name: "Kimi K2.6", tokens: 240_000 },
+						// Must be dropped: not a DevPass record
+						{ id: "random-model", name: "Random", metadata: { devpass_only: false }, tokens: 1 },
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		};
+
+		const options = getElectronHubOptions(fetchImpl);
+		const models = await options.fetchDynamicModels?.();
+		expect(models).not.toBeNull();
+
+		// Uses the OpenAI-compatible discovery endpoint.
+		expect(requestedUrls).toEqual(["https://api.electronhub.ai/v1/models"]);
+
+		const ids = (models ?? []).map(model => model.id);
+		expect(ids).toEqual(["kimi-k2.6:dev", "minimax-m2.7:dev", "rollout-preview"]);
+	});
+
+	it("maps ElectronHub discovery metadata into ModelSpec (name cleanup, tokens->contextWindow, function_call=false)", async () => {
+		const fetchImpl: FetchImpl = async () =>
+			new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "thirdparty:dev",
+							name: "ElectronHub: Custom DevPass Name",
+							tokens: 123_456,
+							metadata: {
+								devpass_only: true,
+								reasoning: true,
+								vision: true,
+								function_call: false,
+							},
+							pricing: { input: "0", output: "0", cache_read: "0", cache_write: "0" },
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+
+		const options = getElectronHubOptions(fetchImpl);
+		const models = (await options.fetchDynamicModels?.()) as ModelSpec<"openai-completions">[] | null | undefined;
+		const model = models?.find(candidate => candidate.id === "thirdparty:dev");
+
+		expect(model).toBeDefined();
+		expect(model?.name).toBe("Custom DevPass Name");
+		expect(model?.contextWindow).toBe(123_456);
+		expect(model?.reasoning).toBe(true);
+		expect(model?.input).toEqual(["text", "image"]);
+		expect(model?.supportsTools).toBe(false);
+		expect(model?.compat?.supportsStore).toBe(false);
+	});
+});

--- a/packages/catalog/test/fixtures/electronhub-devpass-models.json
+++ b/packages/catalog/test/fixtures/electronhub-devpass-models.json
@@ -1,0 +1,117 @@
+{
+	"object": "list",
+	"data": [
+		{
+			"id": "kimi-k2.6:dev",
+			"name": "MoonshotAI: Kimi K2.6 (DevPass)",
+			"object": "model",
+			"tokens": 240000,
+			"pricing": {
+				"type": "per_million_tokens",
+				"input": 0,
+				"output": 0,
+				"plan": "devpass"
+			},
+			"metadata": {
+				"vision": false,
+				"function_call": true,
+				"web_search": false,
+				"reasoning": true,
+				"devpass_only": true
+			}
+		},
+		{
+			"id": "minimax-m2.7:dev",
+			"name": "MiniMax: MiniMax M2.7 (DevPass)",
+			"object": "model",
+			"tokens": 180000,
+			"pricing": {
+				"type": "per_million_tokens",
+				"input": 0,
+				"output": 0,
+				"plan": "devpass"
+			},
+			"metadata": {
+				"vision": false,
+				"function_call": true,
+				"web_search": false,
+				"reasoning": true,
+				"devpass_only": true
+			}
+		},
+		{
+			"id": "gpt-oss-120b:dev",
+			"name": "OpenAI: GPT OSS 120B (DevPass)",
+			"object": "model",
+			"tokens": 128000,
+			"pricing": {
+				"type": "per_million_tokens",
+				"input": 0,
+				"output": 0,
+				"plan": "devpass"
+			},
+			"metadata": {
+				"vision": false,
+				"function_call": true,
+				"web_search": false,
+				"reasoning": true,
+				"devpass_only": true
+			}
+		},
+		{
+			"id": "glm-5.2:dev",
+			"name": "ZhipuAI: GLM 5.2 (DevPass)",
+			"object": "model",
+			"tokens": 200000,
+			"pricing": {
+				"type": "per_million_tokens",
+				"input": 0,
+				"output": 0,
+				"plan": "devpass"
+			},
+			"metadata": {
+				"vision": false,
+				"function_call": true,
+				"web_search": false,
+				"reasoning": true,
+				"devpass_only": true
+			}
+		},
+		{
+			"id": "gemma-4-31b-it:dev",
+			"name": "Google: Gemma 4 31B (DevPass)",
+			"object": "model",
+			"tokens": 200000,
+			"pricing": {
+				"type": "per_million_tokens",
+				"input": 0,
+				"output": 0,
+				"plan": "devpass"
+			},
+			"metadata": {
+				"vision": true,
+				"function_call": true,
+				"web_search": false,
+				"reasoning": true
+			}
+		},
+		{
+			"id": "qwen3.6-27b:dev",
+			"name": "Alibaba: Qwen3.6 27B (DevPass)",
+			"object": "model",
+			"tokens": 262000,
+			"pricing": {
+				"type": "per_million_tokens",
+				"input": 0,
+				"output": 0,
+				"plan": "devpass"
+			},
+			"metadata": {
+				"vision": true,
+				"function_call": true,
+				"web_search": false,
+				"reasoning": false
+			}
+		}
+	]
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -291,6 +291,9 @@
 ### Added
 
 - Typing `#<number>` (e.g. `#3164`) in the prompt now offers PR and Issue autocomplete candidates that rewrite to the `pr://`/`issue://` internal URL, resolved from the current repo's git remote via the existing `read` tool → InternalUrlRouter → `gh` pipeline. Naming the type (`pr #3164` / `issue #3164`) constrains the candidates to that kind, and embedded hashes like `owner/repo#N`, `foo#N`, or URL fragments are left untouched ([#3218](https://github.com/can1357/oh-my-pi/issues/3218))
+### Added
+
+- Documented the `ELECTRONHUB_DEV_API_KEY` environment variable in `omp --help` for ElectronHub Coding Plan (DevPass) models.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Redesigned Agent Hub entries into a cleaner two-line card layout showing identity, active model, reasoning level, age, and task description.
 - Added a project-scoped `launch` tool (gated by `launch.enabled`) for managing shared long-running services and debuggers, featuring readiness probes, bounded logs, PTY input, restart policies, and automatic teardown.
 - Added support for `detached` launches, allowing standalone services to survive broker shutdowns and reconnect to subsequent sessions.
+- Added a compact session-only model picker (Alt+P) for quick model switching without changing roles
+- Documented the `ELECTRONHUB_DEV_API_KEY` environment variable in `omp --help` for ElectronHub Coding Plan (DevPass) models.
 
 ### Changed
 
@@ -291,9 +293,6 @@
 ### Added
 
 - Typing `#<number>` (e.g. `#3164`) in the prompt now offers PR and Issue autocomplete candidates that rewrite to the `pr://`/`issue://` internal URL, resolved from the current repo's git remote via the existing `read` tool → InternalUrlRouter → `gh` pipeline. Naming the type (`pr #3164` / `issue #3164`) constrains the candidates to that kind, and embedded hashes like `owner/repo#N`, `foo#N`, or URL fragments are left untouched ([#3218](https://github.com/can1357/oh-my-pi/issues/3218))
-### Added
-
-- Documented the `ELECTRONHUB_DEV_API_KEY` environment variable in `omp --help` for ElectronHub Coding Plan (DevPass) models.
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Documented the `ELECTRONHUB_DEV_API_KEY` environment variable in `omp --help` for ElectronHub Coding Plan (DevPass) models.
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes
@@ -19,7 +23,6 @@
 - Added a project-scoped `launch` tool (gated by `launch.enabled`) for managing shared long-running services and debuggers, featuring readiness probes, bounded logs, PTY input, restart policies, and automatic teardown.
 - Added support for `detached` launches, allowing standalone services to survive broker shutdowns and reconnect to subsequent sessions.
 - Added a compact session-only model picker (Alt+P) for quick model switching without changing roles
-- Documented the `ELECTRONHUB_DEV_API_KEY` environment variable in `omp --help` for ElectronHub Coding Plan (DevPass) models.
 
 ### Changed
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -336,6 +336,7 @@ export function getExtraHelpText(): string {
   MISTRAL_API_KEY            - Mistral models
   ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
   UMANS_AI_CODING_PLAN_API_KEY - Umans AI Coding Plan models
+  ELECTRONHUB_DEV_API_KEY    - ElectronHub Coding Plan (DevPass) models
   UMANS_WEBSEARCH_PROVIDER    - Umans gateway web search backend (native or exa)
   MINIMAX_API_KEY            - MiniMax models
   OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models


### PR DESCRIPTION
Remakes closed PR #4858 (auto-closed: author not vouched). Adds ElectronHub Coding Plan (DevPass) as a login/model provider with all six live DevPass models (kimi-k2.6:dev, minimax-m2.7:dev, gpt-oss-120b:dev, glm-5.2:dev, gemma-4-31b-it:dev, qwen3.6-27b:dev), dynamic discovery filtered to DevPass-only records, GLM/Z.AI thinking compat, and a fixture-backed contract test asserting the static seed matches a live /v1/models snapshot. See #4858 and #4872 for prior context/review discussion.