### PR TITLE
fix(mcp): resolve DCR registration endpoint from issuer, not authorization endpoint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP OAuth dynamic client registration (DCR) failing against authorization servers whose `authorization_endpoint` path differs from their issuer path (e.g. Supabase/GoTrue-style servers with an `/auth/v1` issuer). Discovery now captures the `registration_endpoint` advertised in the RFC 8414 metadata instead of discarding it, and the DCR fallback probe derives the well-known URL from the OAuth issuer (with RFC 8414 §3.3 issuer validation) rather than the authorization endpoint — so servers that advertise DCR no longer wrongly fall back to demanding a manual `oauth.clientId`. ([#5267](https://github.com/can1357/oh-my-pi/issues/5267))
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -13,6 +13,14 @@ export interface OAuthEndpoints {
 	clientId?: string;
 	scopes?: string;
 	resource?: string;
+	/**
+	 * RFC 7591 dynamic client registration endpoint, when the authorization
+	 * server advertises one in its RFC 8414 metadata. Captured during discovery
+	 * so the OAuth flow never has to re-derive the well-known URL.
+	 */
+	registrationEndpoint?: string;
+	/** OAuth issuer identifier from the metadata document (RFC 8414 `issuer`). */
+	issuer?: string;
 }
 
 export interface AuthDetectionResult {
@@ -101,8 +109,15 @@ export function extractOAuthEndpoints(error: Error): OAuthEndpoints | null {
 			(obj.resource as string | undefined) ||
 			(obj.resource_uri as string | undefined) ||
 			(obj.resourceUri as string | undefined);
+		const registrationEndpoint =
+			typeof obj.registration_endpoint === "string"
+				? obj.registration_endpoint
+				: typeof obj.registrationEndpoint === "string"
+					? obj.registrationEndpoint
+					: undefined;
+		const issuer = typeof obj.issuer === "string" ? obj.issuer : undefined;
 
-		return { authorizationUrl, tokenUrl, clientId, scopes, resource };
+		return { authorizationUrl, tokenUrl, clientId, scopes, resource, registrationEndpoint, issuer };
 	};
 
 	const clientIdFromAuthUrl = (authorizationUrl: string): string | undefined => {
@@ -292,7 +307,7 @@ function normalizeIssuerUrl(value: string): string | undefined {
  *     today's permissive behavior), or
  *   - the issuer matches `baseUrl` after trailing-slash normalization.
  */
-function issuerMatchesBase(metadataIssuer: unknown, baseUrl: string): boolean {
+export function issuerMatchesBase(metadataIssuer: unknown, baseUrl: string): boolean {
 	if (typeof metadataIssuer !== "string" || !metadataIssuer.trim()) {
 		return true;
 	}
@@ -427,6 +442,9 @@ export async function discoverOAuthEndpoints(
 									: undefined,
 				scopes: readMetadataScopes(metadata) ?? protectedScopes,
 				resource,
+				registrationEndpoint:
+					typeof metadata.registration_endpoint === "string" ? metadata.registration_endpoint : undefined,
+				issuer: typeof metadata.issuer === "string" ? metadata.issuer : undefined,
 			};
 		}
 
@@ -450,6 +468,14 @@ export async function discoverOAuthEndpoints(
 										: undefined,
 					scopes: readMetadataScopes(oauthData) ?? protectedScopes,
 					resource,
+					registrationEndpoint:
+						typeof oauthData.registration_endpoint === "string" ? oauthData.registration_endpoint : undefined,
+					issuer:
+						typeof oauthData.issuer === "string"
+							? oauthData.issuer
+							: typeof metadata.issuer === "string"
+								? metadata.issuer
+								: undefined,
 				};
 			}
 		}
@@ -517,7 +543,7 @@ export async function discoverOAuthEndpoints(
 	return null;
 }
 
-function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[] {
+export function buildWellKnownUrls(wellKnownPath: string, baseUrl: string): URL[] {
 	let parsed: URL;
 	try {
 		parsed = new URL(baseUrl);

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -11,6 +11,7 @@ import type { OAuthController, OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/ty
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
 import { getActiveProfile } from "@oh-my-pi/pi-utils/dirs";
 import type { OAuthCredential } from "../session/auth-storage";
+import { buildWellKnownUrls, issuerMatchesBase } from "./oauth-discovery";
 
 /** Credential-id prefix for OMP-managed MCP OAuth credentials keyed by profile and server URL. */
 const MCP_OAUTH_URL_CREDENTIAL_PREFIX = "mcp_oauth:";
@@ -307,6 +308,19 @@ export interface MCPOAuthConfig {
 	stripSameOriginResource?: boolean;
 	/** Fetch implementation for token exchange and discovery requests. */
 	fetch?: FetchImpl;
+	/**
+	 * RFC 7591 dynamic client registration endpoint advertised by the
+	 * authorization server's RFC 8414 metadata, captured during discovery.
+	 * When set, DCR uses it directly instead of re-deriving the well-known URL.
+	 */
+	registrationEndpoint?: string;
+	/**
+	 * OAuth issuer / authorization-server base URL. Used to derive the RFC 8414
+	 * §3.1 well-known metadata URL for DCR fallback probing when
+	 * {@link registrationEndpoint} is absent — RFC 8414 anchors the well-known
+	 * suffix at the issuer, not the authorization endpoint.
+	 */
+	authServerUrl?: string;
 }
 
 /**
@@ -619,38 +633,38 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 	}
 
 	async #resolveRegistrationEndpoint(): Promise<string | null> {
-		const authorizationUrl = new URL(this.config.authorizationUrl);
+		// Preferred: the registration endpoint captured alongside the other
+		// OAuth endpoints during discovery (RFC 8414 metadata). Avoids
+		// re-deriving — and mis-deriving — the well-known URL. See
+		// discoverOAuthEndpoints / findEndpoints in oauth-discovery.ts.
+		const advertised = this.config.registrationEndpoint?.trim();
+		if (advertised) return advertised;
 
-		// origin-root well-known; most servers serve metadata here.
-		const rootUrl = new URL("/.well-known/oauth-authorization-server", authorizationUrl.origin).toString();
-		const endpoint = await this.#tryWellKnownForRegistration(rootUrl);
-		if (endpoint) return endpoint;
-
-		// path-prefixed well-known for gateways (e.g. https://gateway.example.com/my-service/).
-		const normalizedPath = authorizationUrl.pathname.replace(/\/$/, "");
-		const lastSlash = normalizedPath.lastIndexOf("/");
-		// Bare-origin authorization URL — nothing further to try.
-		if (lastSlash < 0) return null;
-
-		// Single-segment paths are the gateway prefix itself; multi-segment paths
-		// drop the trailing segment (typically a service endpoint).
-		const prefixPath = lastSlash === 0 ? normalizedPath : normalizedPath.slice(0, lastSlash);
-		const prefixedUrl = new URL(
-			".well-known/oauth-authorization-server",
-			`${authorizationUrl.origin}${prefixPath}/`,
-		).toString();
-		const prefixedEndpoint = await this.#tryWellKnownForRegistration(prefixedUrl);
-		if (prefixedEndpoint) return prefixedEndpoint;
-
-		// RFC 8414 §3.1 path-ful issuer form: /.well-known/oauth-authorization-server/<path>.
-		const pathfulUrl = new URL(
-			`/.well-known/oauth-authorization-server${normalizedPath}`,
-			authorizationUrl.origin,
-		).toString();
-		return await this.#tryWellKnownForRegistration(pathfulUrl);
+		// Fallback (JSON-error-body path, where endpoints came from the
+		// challenge rather than a metadata fetch): probe the well-known metadata
+		// document. RFC 8414 §3.1 anchors the well-known suffix at the OAuth
+		// *issuer*, NOT the authorization endpoint, so derive candidates from
+		// the issuer when known; only fall back to the authorization endpoint's
+		// origin/path when no issuer is available.
+		const rawIssuer = this.config.authServerUrl?.trim();
+		let issuerBase: string | undefined;
+		if (rawIssuer) {
+			try {
+				new URL(rawIssuer);
+				issuerBase = rawIssuer;
+			} catch {
+				// Malformed issuer URL — fall back to the authorization endpoint.
+			}
+		}
+		const base = issuerBase ?? this.config.authorizationUrl;
+		for (const candidate of buildWellKnownUrls("/.well-known/oauth-authorization-server", base)) {
+			const endpoint = await this.#tryWellKnownForRegistration(candidate.toString(), issuerBase);
+			if (endpoint) return endpoint;
+		}
+		return null;
 	}
 
-	async #tryWellKnownForRegistration(wellKnownUrl: string): Promise<string | null> {
+	async #tryWellKnownForRegistration(wellKnownUrl: string, expectedIssuer?: string): Promise<string | null> {
 		try {
 			const response = await this.#fetch(wellKnownUrl, {
 				method: "GET",
@@ -658,7 +672,14 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 				signal: this.ctrl.signal,
 			});
 			if (!response.ok) return null;
-			const metadata = (await response.json()) as { registration_endpoint?: string };
+			const metadata = (await response.json()) as { registration_endpoint?: string; issuer?: string };
+			// RFC 8414 §3.3: a metadata document's `issuer` must match the issuer
+			// we queried. Enforcing it stops a multi-tenant root document from
+			// being mistaken for a path-scoped tenant's metadata, since the
+			// origin-root candidate is probed before the path-ful one.
+			if (expectedIssuer !== undefined && !issuerMatchesBase(metadata.issuer, expectedIssuer)) {
+				return null;
+			}
 			if (metadata.registration_endpoint && metadata.registration_endpoint.trim() !== "") {
 				return metadata.registration_endpoint;
 			}

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -63,6 +63,8 @@ export interface MCPAddWizardOAuthResult {
 interface MCPAddWizardOAuthOptions {
 	serverUrl?: string;
 	resource?: string;
+	registrationEndpoint?: string;
+	authServerUrl?: string;
 	/**
 	 * External cancellation source. Aborting it tears down the in-flight OAuth
 	 * flow and surfaces a neutral cancellation error. The wizard wires its own
@@ -86,6 +88,8 @@ interface WizardState {
 	oauthClientSecret: string;
 	oauthScopes: string;
 	oauthResource: string;
+	oauthRegistrationEndpoint: string;
+	oauthAuthServerUrl: string;
 	oauthCredentialId: string | null;
 	apiKey: string;
 	authLocation: AuthLocation | null;
@@ -117,6 +121,8 @@ export class MCPAddWizard extends Container {
 		oauthClientSecret: "",
 		oauthScopes: "",
 		oauthResource: "",
+		oauthRegistrationEndpoint: "",
+		oauthAuthServerUrl: "",
 		oauthCredentialId: null,
 		apiKey: "",
 		authLocation: null,
@@ -1029,6 +1035,8 @@ export class MCPAddWizard extends Container {
 					this.#state.oauthClientId = oauth.clientId || "";
 					this.#state.oauthScopes = oauth.scopes || "";
 					this.#state.oauthResource = oauth.resource || (this.#state.transport === "stdio" ? "" : this.#state.url);
+					this.#state.oauthRegistrationEndpoint = oauth.registrationEndpoint ?? "";
+					this.#state.oauthAuthServerUrl = oauth.issuer ?? authResult.authServerUrl ?? "";
 					this.#state.authMethod = "oauth";
 
 					this.#contentContainer.clear();
@@ -1197,6 +1205,8 @@ export class MCPAddWizard extends Container {
 				{
 					serverUrl: this.#state.url || undefined,
 					resource: oauthResource || undefined,
+					registrationEndpoint: this.#state.oauthRegistrationEndpoint || undefined,
+					authServerUrl: this.#state.oauthAuthServerUrl || undefined,
 					abortSignal: this.#oauthAbort.signal,
 				},
 			);

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -606,6 +606,8 @@ export class MCPCommandController {
 									serverUrl: finalConfig.url,
 									resource: oauthResource,
 									stripSameOriginResource: oauthResourceIsFallback,
+									registrationEndpoint: oauth.registrationEndpoint,
+									authServerUrl: oauth.issuer ?? authResult.authServerUrl,
 								},
 							);
 							finalConfig = this.#persistOAuthResult(finalConfig, oauthResult, {
@@ -686,6 +688,8 @@ export class MCPCommandController {
 			serverUrl?: string;
 			resource?: string;
 			stripSameOriginResource?: boolean;
+			registrationEndpoint?: string;
+			authServerUrl?: string;
 			/**
 			 * External cancellation source: when this signal aborts, the in-flight
 			 * OAuth flow is torn down and {@link MCPOAuthCancelledError} is thrown.
@@ -756,6 +760,8 @@ export class MCPCommandController {
 					callbackPath: opts?.callbackPath,
 					resource: opts?.resource,
 					stripSameOriginResource: opts?.stripSameOriginResource,
+					registrationEndpoint: opts?.registrationEndpoint,
+					authServerUrl: opts?.authServerUrl,
 				},
 				{
 					onAuth: (info: { url: string; launchUrl?: string; instructions?: string }) => {
@@ -1044,6 +1050,8 @@ export class MCPCommandController {
 		clientId?: string;
 		scopes?: string;
 		resource?: string;
+		registrationEndpoint?: string;
+		issuer?: string;
 	}> {
 		// Stdio servers manage credentials inside the child process; OMP's OAuth
 		// flow only applies to http/sse transports. Without this guard the
@@ -1095,7 +1103,7 @@ export class MCPCommandController {
 			throw new Error("Could not discover OAuth endpoints from server response.");
 		}
 
-		return oauth;
+		return { ...oauth, issuer: oauth.issuer ?? authResult.authServerUrl };
 	}
 
 	async #waitForServerConnectionWithAnimation(
@@ -1742,6 +1750,8 @@ export class MCPCommandController {
 					serverUrl,
 					resource: oauthResource,
 					stripSameOriginResource: oauthResourceIsFallback,
+					registrationEndpoint: oauth.registrationEndpoint,
+					authServerUrl: oauth.issuer,
 				},
 			);
 

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -320,6 +320,7 @@ describe("resource_metadata chain", () => {
 			tokenUrl: "https://sso.example.com/oauth/token",
 			scopes: "k8s.logging-mcp-server k8s.annotations",
 			resource: "https://gateway.example.com",
+			issuer: "https://sso.example.com",
 		});
 	});
 
@@ -509,6 +510,8 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 		expect(oauth).toEqual({
 			authorizationUrl: "https://mcp.atlassian.com/v1/authorize",
 			tokenUrl: "https://cf.mcp.atlassian.com/v1/token",
+			registrationEndpoint: "https://cf.mcp.atlassian.com/v1/register",
+			issuer: "https://cf.mcp.atlassian.com",
 		});
 		expect(calls[0]).toBe("https://mcp.atlassian.com/.well-known/oauth-authorization-server");
 	});
@@ -575,6 +578,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 			authorizationUrl: "https://mcp.plane.so/http/authorize",
 			tokenUrl: "https://mcp.plane.so/http/token",
 			resource: "https://mcp.plane.so/http/mcp",
+			issuer: "https://mcp.plane.so/http",
 		});
 		// Wrong-issuer origin-root metadata WAS fetched and skipped.
 		expect(calls).toContain("https://mcp.plane.so/.well-known/oauth-authorization-server");
@@ -606,6 +610,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 		expect(oauth).toEqual({
 			authorizationUrl: "https://auth.example.com/oauth/authorize",
 			tokenUrl: "https://auth.example.com/oauth/token",
+			issuer: "https://auth.example.com/",
 		});
 	});
 
@@ -634,5 +639,39 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 			authorizationUrl: "https://auth.example.com/oauth",
 			tokenUrl: "https://auth.example.com/token",
 		});
+	});
+});
+
+describe("RFC 7591 registration endpoint capture", () => {
+	it("captures registration_endpoint and issuer from path-ful RFC 8414 metadata", async () => {
+		// GoTrue/Supabase shape: the issuer carries a sub-path (/auth/v1) and the
+		// authorization-server metadata lives at the RFC 8414 §3.1 path-ful
+		// well-known URL — /.well-known/oauth-authorization-server/auth/v1 — while
+		// the authorization endpoint sits deeper (/auth/v1/oauth/authorize).
+		const fetchImpl = mockFetch((input: FetchInput) => {
+			const url = String(input);
+			if (url === "https://api.example.com/.well-known/oauth-authorization-server/auth/v1") {
+				return new Response(
+					JSON.stringify({
+						issuer: "https://api.example.com/auth/v1",
+						authorization_endpoint: "https://api.example.com/auth/v1/oauth/authorize",
+						token_endpoint: "https://api.example.com/auth/v1/oauth/token",
+						registration_endpoint: "https://api.example.com/auth/v1/oauth/clients/register",
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response("not found", { status: 404 });
+		});
+
+		const oauth = await discoverOAuthEndpoints(
+			"https://mcp.example.com/mcp",
+			"https://api.example.com/auth/v1",
+			undefined,
+			{ fetch: fetchImpl },
+		);
+
+		expect(oauth?.registrationEndpoint).toBe("https://api.example.com/auth/v1/oauth/clients/register");
+		expect(oauth?.issuer).toBe("https://api.example.com/auth/v1");
 	});
 });

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -1155,3 +1155,87 @@ describe("mcp oauth flow", () => {
 		expect(flow.authorizationUrl).toBe("https://auth.example.com/authorize");
 	});
 });
+
+describe("mcp oauth flow — registration endpoint resolution", () => {
+	it("uses config.registrationEndpoint directly without probing well-known metadata", async () => {
+		const requestedUrls: string[] = [];
+		let registrationPayload: Record<string, unknown> | null = null;
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://api.example.com/auth/v1/oauth/authorize",
+				tokenUrl: "https://api.example.com/auth/v1/oauth/token",
+				registrationEndpoint: "https://api.example.com/auth/v1/oauth/clients/register",
+				fetch: async (input, init) => {
+					const url = String(input);
+					requestedUrls.push(url);
+					if (url === "https://api.example.com/auth/v1/oauth/clients/register") {
+						registrationPayload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+						return new Response(JSON.stringify({ client_id: "dcr-client-id" }), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					throw new Error(`Unexpected fetch: ${url}`);
+				},
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("state", "http://127.0.0.1:53270/callback");
+
+		expect(registrationPayload).not.toBeNull();
+		expect(new URL(url).searchParams.get("client_id")).toBe("dcr-client-id");
+		// The advertised endpoint is used directly — no well-known GET at all.
+		expect(requestedUrls).toEqual(["https://api.example.com/auth/v1/oauth/clients/register"]);
+	});
+
+	it("derives the fallback DCR endpoint from the issuer path and skips a mismatched root document", async () => {
+		const requestedUrls: string[] = [];
+		const flow = new MCPOAuthFlow(
+			{
+				authorizationUrl: "https://api.example.com/auth/v1/oauth/authorize",
+				tokenUrl: "https://api.example.com/auth/v1/oauth/token",
+				authServerUrl: "https://api.example.com/auth/v1",
+				fetch: async input => {
+					const url = String(input);
+					requestedUrls.push(url);
+					// Origin-root metadata belongs to a DIFFERENT (root) issuer and
+					// must be rejected by RFC 8414 §3.3 issuer validation.
+					if (url === "https://api.example.com/.well-known/oauth-authorization-server") {
+						return new Response(
+							JSON.stringify({
+								issuer: "https://api.example.com",
+								registration_endpoint: "https://api.example.com/oauth/clients/register",
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					// Path-ful metadata for the /auth/v1 issuer carries the correct DCR endpoint.
+					if (url === "https://api.example.com/.well-known/oauth-authorization-server/auth/v1") {
+						return new Response(
+							JSON.stringify({
+								issuer: "https://api.example.com/auth/v1",
+								registration_endpoint: "https://api.example.com/auth/v1/oauth/clients/register",
+							}),
+							{ status: 200, headers: { "Content-Type": "application/json" } },
+						);
+					}
+					if (url === "https://api.example.com/auth/v1/oauth/clients/register") {
+						return new Response(JSON.stringify({ client_id: "tenant-client-id" }), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					return new Response("not found", { status: 404 });
+				},
+			},
+			{},
+		);
+
+		const { url } = await flow.generateAuthUrl("state", "http://127.0.0.1:53271/callback");
+
+		expect(new URL(url).searchParams.get("client_id")).toBe("tenant-client-id");
+		// The root document's DCR endpoint (wrong tenant) must never be POSTed to.
+		expect(requestedUrls).not.toContain("https://api.example.com/oauth/clients/register");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes MCP OAuth dynamic client registration (DCR) failing against authorization servers whose `authorization_endpoint` path differs from their `issuer` path — a common shape for Supabase/GoTrue-style servers (issuer `…/auth/v1`, authorize endpoint `…/auth/v1/oauth/authorize`). Affected users saw the opaque:

```
OAuth provider requires client_id, and no dynamic-client-registration endpoint was advertised.
```

and were forced to configure a manual `oauth.clientId`, even though the server advertised a working `registration_endpoint`.

Closes #5267.

## Root cause

Two defects, walked end-to-end:

1. **Discovery discards the advertised `registration_endpoint`.** `discoverOAuthEndpoints` already fetches the correct RFC 8414 metadata document — `buildWellKnownUrls` is fed the **issuer**, so its §3.1 path-ful URL (`/.well-known/oauth-authorization-server/auth/v1`) is built correctly and returns 200 with `authorization_endpoint`, `token_endpoint`, **and `registration_endpoint`**. But `findEndpoints`/`OAuthEndpoints` only extracted the first two — the registration endpoint was dropped on the floor.

2. **The fallback re-derivation used the wrong base URL.** Because the endpoint was discarded, `MCPOAuthFlow#resolveRegistrationEndpoint` re-derived the well-known URL from `config.authorizationUrl` (the **authorization endpoint** path, `/auth/v1/oauth/authorize`) instead of the issuer. Its RFC 8414 §3.1 path-ful probe became `/.well-known/oauth-authorization-server/auth/v1/oauth/authorize` → 404, so all probes missed and it returned `null` → the "no DCR endpoint advertised" error.

## Fix

- Capture `registration_endpoint` and `issuer` during discovery (`OAuthEndpoints` + `findEndpoints`, and the JSON-error-body path in `extractOAuthEndpoints`).
- Thread both into `MCPOAuthConfig` (`registrationEndpoint`, `authServerUrl`) via all flow-construction sites (reauth, quick-add, and the add wizard).
- `#resolveRegistrationEndpoint` now returns the advertised `registrationEndpoint` directly when present. When it must fall back (challenge-only / JSON-error-body path), it derives candidates from the **issuer** (reusing the now-exported `buildWellKnownUrls`) and validates each document's `issuer` against the queried issuer (RFC 8414 §3.3, reusing `issuerMatchesBase`) — so a multi-tenant root document can't be mistaken for a path-scoped tenant's metadata (the origin-root candidate is probed before the path-ful one).

## Testing

- `bun test test/oauth-discovery.test.ts test/oauth-flow.test.ts` — 66 pass (3 new: registration/issuer capture from path-ful metadata; flow prefers `config.registrationEndpoint` without probing; issuer-based fallback that skips a mismatched root document).
- Updated 4 existing discovery tests whose mock metadata advertises `issuer`/`registration_endpoint` to assert the newly-captured fields.
- `bun run check:types` — clean. `biome check` (pinned 2.5.3) on changed files — clean.
