### PR TITLE
fix: harden yolo critical prompts, harmony discard, OSC, and utils

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed discarded Harmony-leak retry attempts remaining in persisted agent state.
+
 ## [16.4.5] - 2026-07-11
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1656,6 +1656,7 @@ function emitDiscardedHarmonyPartial(
 	stream.push({
 		type: "message_end",
 		message: snapshotAssistantMessage({ ...partialMessage, stopReason: "error", errorMessage }),
+		discarded: true,
 	});
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1226,13 +1226,14 @@ export class Agent {
 
 					case "message_end":
 						partial = null;
+						this.#state.streamMessage = null;
+						if (event.discarded) break;
 						// Check if this is an assistant message with buffered Cursor tool results.
 						// If so, split the message to emit tool results at the correct position.
 						if (event.message.role === "assistant" && this.#cursorToolResultBuffer.length > 0) {
 							this.#emitCursorSplitAssistantMessage(event.message as AssistantMessage);
 							continue; // Skip default emit - split method handles everything
 						}
-						this.#state.streamMessage = null;
 						this.appendMessage(event.message);
 						break;
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -734,7 +734,7 @@ export type AgentEvent =
 	| { type: "message_start"; message: AgentMessage }
 	// Only emitted for assistant messages during streaming
 	| { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantMessageEvent }
-	| { type: "message_end"; message: AgentMessage }
+	| { type: "message_end"; message: AgentMessage; discarded?: boolean }
 	// Tool execution lifecycle
 	| { type: "tool_execution_start"; toolCallId: string; toolName: string; args: any; intent?: string }
 	| { type: "tool_execution_update"; toolCallId: string; toolName: string; args: any; partialResult: any }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -139,6 +139,25 @@ describe("Agent", () => {
 		expect(JSON.stringify(replayedMessages)).not.toContain("I can't assist");
 	});
 
+	it("does not persist discarded Harmony leak attempts", async () => {
+		const leak = "Some prose. analysis to=functions.edit code \u0436\u0443\u0440";
+		const mock = createMockModel({
+			provider: "openai-codex",
+			responses: [{ content: [leak] }, { content: ["clean retry response"] }],
+		});
+		const agent = new Agent({
+			initialState: { model: mock.model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: mock.stream,
+		});
+
+		await agent.prompt("trigger leak mitigation");
+
+		expect(mock.calls).toHaveLength(2);
+		expect(agent.state.messages).toHaveLength(2);
+		expect(JSON.stringify(agent.state.messages)).not.toContain("to=functions.edit");
+		expect(JSON.stringify(agent.state.messages)).toContain("clean retry response");
+	});
+
 	it("prompt() emits assistant error lifecycle for Anthropic output-blocked stream errors before assistant start", async () => {
 		const mock = createMockModel({ responses: [] });
 		const errorText = "Output blocked by content filtering policy";

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed yolo approval mode bypassing critical bash-pattern confirmation prompts.
 - Fixed failure to trigger model fallback when the retry budget is exhausted by credential rotation
 - Fixed uncontrollable mouse-wheel scrolling in the /models hub: the wheel moved the selection (one step per wheel event, so a single trackpad flick skipped many rows) and wrapped from the bottom back to the top. Wheel scrolling now pans the list viewport only, clamps at the ends, and leaves the selection where it is; keyboard navigation still scrolls the selection into view. Likewise, the wheel over the provider sidebar no longer switches the active scope (or triggers provider refreshes) — it just scrolls the sidebar.
 - Fixed TPS being inflated several-fold when a provider hides reasoning tokens until late in the stream (e.g. `google/gemini-3.5` vs `google-vertex/gemini-3.5` reporting 648 vs 186 TPS for identical durations): `omp bench`, the per-turn usage row, and the /models perf aggregates now measure tokens/sec over the total request duration instead of the post-TTFT decode window, matching `omp stats`. Stored perf aggregates are purged and re-backfilled from stats history with the corrected math on first launch.

--- a/packages/coding-agent/src/tools/approval.ts
+++ b/packages/coding-agent/src/tools/approval.ts
@@ -87,8 +87,8 @@ function modeApprovesTier(mode: ApprovalMode, tier: ToolTier): boolean {
  *  2. User per-tool override, if set and valid.
  *  3. Active mode tier comparison.
  *
- * In yolo mode, override-based tool prompts are ignored; user `tools.approval`
- * settings remain authoritative.
+ * Override-based prompts remain active in every mode, including yolo; an
+ * explicit deny remains authoritative.
  */
 export function resolveApproval(
 	tool: ApprovalSubject,
@@ -98,10 +98,6 @@ export function resolveApproval(
 ): ResolvedApproval {
 	const decision = getToolDecision(tool, args);
 	const userPolicy = Object.hasOwn(userConfig, tool.name) ? normalizePolicy(userConfig[tool.name]) : undefined;
-
-	if (mode === "yolo") {
-		return { policy: userPolicy ?? "allow", tier: decision.tier, override: false };
-	}
 
 	if (decision.override) {
 		if (userPolicy === "deny") {
@@ -113,6 +109,10 @@ export function resolveApproval(
 			override: true,
 			...(decision.reason ? { reason: decision.reason } : {}),
 		};
+	}
+
+	if (mode === "yolo") {
+		return { policy: userPolicy ?? "allow", tier: decision.tier, override: false };
 	}
 
 	if (userPolicy) {

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -79,14 +79,18 @@ describe("resolveApproval tier matrix", () => {
 describe("resolveApproval override and user policy", () => {
 	const dangerous = tool("bash", { tier: "exec", override: true, reason: "Critical pattern detected" });
 
-	it("ignores override-based prompts in yolo mode", () => {
+	it("honors override-based prompts in yolo mode", () => {
 		const result = resolveApproval(dangerous, {}, "yolo");
-		expect(result).toMatchObject({ policy: "allow", tier: "exec", override: false });
-		expect(result.reason).toBeUndefined();
+		expect(result).toMatchObject({
+			policy: "prompt",
+			tier: "exec",
+			override: true,
+			reason: "Critical pattern detected",
+		});
 	});
 
-	it("user policy still controls execution in yolo mode", () => {
-		expect(resolveApproval(dangerous, {}, "yolo", { bash: "allow" }).policy).toBe("allow");
+	it("override prompts take precedence over allow while explicit deny remains authoritative", () => {
+		expect(resolveApproval(dangerous, {}, "yolo", { bash: "allow" }).policy).toBe("prompt");
 		expect(resolveApproval(dangerous, {}, "yolo", { bash: "prompt" }).policy).toBe("prompt");
 		expect(resolveApproval(dangerous, {}, "yolo", { bash: "deny" }).policy).toBe("deny");
 		expect(() => requiresApproval(dangerous, {}, "yolo", { bash: "deny" })).toThrow(

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed basic terminal notifications allowing embedded control characters to terminate OSC payloads.
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -101,9 +101,9 @@ export class TerminalInfo {
 			if (this.notifyProtocol === NotifyProtocol.Osc99 && osc99CapabilitiesConfirmed) {
 				return formatOsc99Notification(message);
 			}
-			return `${this.notifyProtocol}${notificationToLine(message)}\x1b\\`;
+			return `${this.notifyProtocol}${sanitizeBasicNotification(notificationToLine(message))}\x1b\\`;
 		}
-		return `${this.notifyProtocol}${message}\x1b\\`;
+		return `${this.notifyProtocol}${sanitizeBasicNotification(message)}\x1b\\`;
 	}
 
 	sendNotification(message: string | TerminalNotification): void {
@@ -1041,6 +1041,12 @@ export function isOsc99Supported(): boolean {
 function notificationToLine(n: TerminalNotification): string {
 	if (n.title && n.body) return `${n.title}: ${n.body}`;
 	return n.title ?? n.body ?? "";
+}
+
+const BASIC_NOTIFICATION_UNSAFE = /[\x00-\x1f\x7f\x80-\x9f]/gu;
+
+function sanitizeBasicNotification(message: string): string {
+	return message.replace(BASIC_NOTIFICATION_UNSAFE, "");
 }
 
 // C0/C1 control characters that are unsafe inside an OSC payload (must base64).

--- a/packages/tui/test/notifications.test.ts
+++ b/packages/tui/test/notifications.test.ts
@@ -99,6 +99,12 @@ describe("terminal notifications", () => {
 		expect(terminal.formatNotification("hello")).toBe("\x1b]99;;hello\x1b\\");
 	});
 
+	it("strips control characters from basic notification payloads", () => {
+		const terminal = getTerminalInfo("kitty");
+		expect(terminal.formatNotification("safe\x07\x1b\\\x9bunsafe")).toBe("\x1b]99;;safe\\unsafe\x1b\\");
+		expect(terminal.formatNotification({ title: "Done\x07", body: "Now\x1b\\" })).toBe("\x1b]99;;Done: Now\\\x1b\\");
+	});
+
 	it("falls back to a single OSC 99 line until rich support is confirmed", () => {
 		const terminal = getTerminalInfo("kitty");
 		expect(terminal.formatNotification({ title: "Session", body: "Complete" })).toBe(

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed retained cross-chunk lines from `readLines` being mutated when its internal buffer was reused.
+- Fixed failed `TempDir.remove()` calls permanently preventing later cleanup retries.
+- Fixed bare `TempDir` prefixes creating temporary directories in the current working directory.
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/utils/src/stream.ts
+++ b/packages/utils/src/stream.ts
@@ -144,7 +144,9 @@ class ConcatSink {
 				this.append(suffix);
 				const payload = this.flush();
 				if (payload) {
-					yield payload;
+					// The sink reuses its backing buffer after this line. Return a copy so
+					// consumers can safely retain previously yielded lines.
+					yield Buffer.from(payload);
 					this.clear();
 				}
 			}

--- a/packages/utils/src/temp.ts
+++ b/packages/utils/src/temp.ts
@@ -33,6 +33,11 @@ export class TempDir {
 		}
 		const removePromise = removeWithRetries(this.#path);
 		this.#removePromise = removePromise;
+		void removePromise.catch(() => {
+			if (this.#removePromise === removePromise) {
+				this.#removePromise = null;
+			}
+		});
 		return removePromise;
 	}
 
@@ -71,10 +76,9 @@ const kTempDir = os.tmpdir();
 function normalizePrefix(prefix?: string): string {
 	if (!prefix) {
 		return `${kTempDir}${path.sep}pi-temp-`;
-	} else if (prefix.startsWith("@")) {
-		return path.join(kTempDir, prefix.slice(1));
 	}
-	return prefix;
+	if (path.isAbsolute(prefix)) return prefix;
+	return path.join(kTempDir, prefix.startsWith("@") ? prefix.slice(1) : prefix);
 }
 
 const kRemoveOptions = { recursive: true, force: true } as const;

--- a/packages/utils/test/stream.test.ts
+++ b/packages/utils/test/stream.test.ts
@@ -61,6 +61,22 @@ describe("readLines", () => {
 
 		expect(output).toEqual(["alpha", "beta", "gamma"]);
 	});
+
+	it("keeps retained cross-chunk lines stable", async () => {
+		const readable = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode("alpha"));
+				controller.enqueue(encoder.encode("-one\nbeta"));
+				controller.enqueue(encoder.encode("-two\ngamma"));
+				controller.enqueue(encoder.encode("-three\n"));
+				controller.close();
+			},
+		});
+
+		const lines = await collectAsync(readLines(readable));
+		const decoder = new TextDecoder();
+		expect(lines.map(line => decoder.decode(line))).toEqual(["alpha-one", "beta-two", "gamma-three"]);
+	});
 });
 
 describe("abortableSource (via readLines)", () => {

--- a/packages/utils/test/temp.test.ts
+++ b/packages/utils/test/temp.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import { TempDir } from "@oh-my-pi/pi-utils/temp";
+
+describe("TempDir", () => {
+	it("creates bare prefixes under the system temporary directory", () => {
+		using tempDir = TempDir.createSync("omp-bare-prefix-");
+		expect(path.dirname(tempDir.path())).toBe(os.tmpdir());
+		expect(path.basename(tempDir.path())).toStartWith("omp-bare-prefix-");
+	});
+});


### PR DESCRIPTION
## Summary

Safe, high-confidence fixes from a multi-package audit (default product behavior unchanged: `approvalMode` remains `yolo`).

- **coding-agent:** Honor critical bash-pattern overrides even in yolo mode (explicit deny still wins).
- **agent:** Do not persist discarded Harmony-leak retry attempts into `Agent.state.messages`.
- **tui:** Strip C0/C1 controls from basic OSC notification payloads to prevent early OSC termination / terminal injection.
- **utils:** Copy multi-chunk `readLines` yields; bare `TempDir` prefixes go under `os.tmpdir()`; failed `remove()` can retry.

## Out of scope (deferred product decisions)

- Changing the default `tools.approvalMode` away from `yolo`
- Hard-blocking exec tools in plan mode
- SSRF private-network blocks, MCP env scrubbing, natives SIXEL caps, etc.

## Test plan

- [x] `bun test packages/utils/test/stream.test.ts packages/utils/test/temp.test.ts packages/coding-agent/test/tools/approval.test.ts packages/tui/test/notifications.test.ts packages/agent/test/agent.test.ts` — 103 pass / 0 fail
- [x] `bun check` (after local natives build) — pass
- [ ] CI green on this PR