### PR TITLE
fix(ai): route Z.AI API keys by usage

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3276,8 +3276,14 @@ export class AuthStorage {
 				return report;
 			}
 		}
+		const usageCredential = this.#buildUsageCredential(credential);
+		if (credential.type === "api_key") {
+			const resolvedApiKey = await this.#configValueResolver(credential.key);
+			if (!resolvedApiKey) return null;
+			usageCredential.apiKey = resolvedApiKey;
+		}
 		return this.#fetchUsageCached(
-			this.#buildUsageRequest(provider, this.#buildUsageCredential(credential), options?.baseUrl),
+			this.#buildUsageRequest(provider, usageCredential, options?.baseUrl),
 			options?.timeoutMs ?? this.#usageRequestTimeoutMs,
 		);
 	}

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -55,7 +55,7 @@ import {
 	listCodexResetCredits,
 } from "./usage/openai-codex-reset";
 import { opencodeGoUsageProvider } from "./usage/opencode-go";
-import { zaiUsageProvider } from "./usage/zai";
+import { zaiRankingStrategy, zaiUsageProvider } from "./usage/zai";
 
 const USAGE_RANKING_METRIC_EPSILON = 1e-9;
 
@@ -911,6 +911,7 @@ const DEFAULT_RANKING_STRATEGIES = new Map<Provider, CredentialRankingStrategy>(
 	["openai-codex", codexRankingStrategy],
 	["anthropic", claudeRankingStrategy],
 	["google-antigravity", antigravityRankingStrategy],
+	["zai", zaiRankingStrategy],
 ]);
 
 function resolveDefaultRankingStrategy(provider: Provider): CredentialRankingStrategy | undefined {
@@ -1035,16 +1036,22 @@ class AuthStorageUsageCache implements UsageCache {
 // ─────────────────────────────────────────────────────────────────────────────
 
 type StoredCredential = { id: number; credential: AuthCredential };
-type OAuthSelection = { credential: OAuthCredential; index: number };
+type CredentialSelection<T extends AuthCredential> = { credential: T; index: number };
+type OAuthSelection = CredentialSelection<OAuthCredential>;
+type ApiKeySelection = CredentialSelection<ApiKeyCredential>;
 type StoredOAuthSelection = { credentialId: number; credential: OAuthCredential; index: number };
 
-type OAuthCandidate = {
-	selection: OAuthSelection;
+type UsageCandidate<T extends AuthCredential> = {
+	selection: CredentialSelection<T>;
 	usage: UsageReport | null;
 	usageChecked: boolean;
 };
 
-type RankedOAuthCandidate = OAuthCandidate & {
+type OAuthCandidate = UsageCandidate<OAuthCredential>;
+type ApiKeyCandidate = UsageCandidate<ApiKeyCredential>;
+type UsageRankingResult<T extends AuthCredential> = UsageCandidate<T> & { blockedUntil: number | undefined };
+
+type UsageRankedCandidate<T extends AuthCredential> = UsageCandidate<T> & {
 	blocked: boolean;
 	blockedUntil?: number;
 	hasPriorityBoost: boolean;
@@ -1055,6 +1062,8 @@ type RankedOAuthCandidate = OAuthCandidate & {
 	primaryDrainRate: number;
 	orderPos: number;
 };
+type RankedOAuthCandidate = UsageRankedCandidate<OAuthCredential>;
+type RankedApiKeyCandidate = UsageRankedCandidate<ApiKeyCredential>;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // AuthStorage Class
@@ -1704,6 +1713,151 @@ export class AuthStorage {
 		}
 
 		return fallback;
+	}
+
+	async #rankApiKeySelections(args: {
+		providerKey: string;
+		provider: string;
+		order: number[];
+		credentials: ApiKeySelection[];
+		options?: AuthApiKeyOptions;
+		sessionId?: string;
+		strategy: CredentialRankingStrategy;
+		rankingContext: CredentialRankingContext;
+		blockScope?: string;
+	}): Promise<ApiKeyCandidate[]> {
+		const nowMs = Date.now();
+		const { strategy } = args;
+		const ranked: RankedApiKeyCandidate[] = [];
+		const usageTimeout = Math.max(5000, this.#usageRequestTimeoutMs * 1.5);
+		const usagePromise: Promise<Array<UsageRankingResult<ApiKeyCredential> | null>> = Promise.all(
+			args.order.map(async idx => {
+				const selection = args.credentials[idx];
+				if (!selection) return null;
+				const blockedUntil = this.#getCredentialBlockedUntil(
+					args.provider,
+					args.providerKey,
+					selection.index,
+					args.blockScope,
+				);
+				if (blockedUntil !== undefined) {
+					return { selection, usage: null, usageChecked: false, blockedUntil };
+				}
+				const usage = await this.#getUsageReport(args.provider, selection.credential, {
+					...args.options,
+					timeoutMs: this.#usageRequestTimeoutMs,
+				});
+				return { selection, usage, usageChecked: true, blockedUntil: undefined };
+			}),
+		);
+		const timeoutSignal = Promise.withResolvers<null>();
+		const timer = setTimeout(() => timeoutSignal.resolve(null), usageTimeout);
+		timer.unref?.();
+		const usageResults = await Promise.race([usagePromise, timeoutSignal.promise]).then(result => {
+			clearTimeout(timer);
+			if (result) return result;
+			return args.order.map(idx => {
+				const selection = args.credentials[idx];
+				if (!selection) return null;
+				const blockedUntil = this.#getCredentialBlockedUntil(
+					args.provider,
+					args.providerKey,
+					selection.index,
+					args.blockScope,
+				);
+				return { selection, usage: null, usageChecked: false, blockedUntil };
+			});
+		});
+
+		for (let orderPos = 0; orderPos < usageResults.length; orderPos += 1) {
+			const result = usageResults[orderPos];
+			if (!result) continue;
+			const { selection, usage, usageChecked } = result;
+			let { blockedUntil } = result;
+			let blocked = blockedUntil !== undefined;
+			const scopedLimits = usage ? this.#getScopedUsageLimits(strategy, usage, args.rankingContext) : undefined;
+			if (!blocked && scopedLimits && this.#isUsageLimitReached(scopedLimits)) {
+				const resetAtMs = this.#getUsageResetAtMs(scopedLimits, nowMs);
+				blockedUntil = resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs;
+				this.#markCredentialBlocked(
+					args.provider,
+					args.providerKey,
+					selection.index,
+					blockedUntil,
+					args.blockScope,
+				);
+				blocked = true;
+			}
+			const windows = usage ? strategy.findWindowLimits(usage, args.rankingContext) : undefined;
+			const primary = windows?.primary;
+			const secondary = windows?.secondary;
+			const secondaryTarget = secondary ?? primary;
+			ranked.push({
+				selection,
+				usage,
+				usageChecked,
+				blocked,
+				blockedUntil,
+				hasPriorityBoost: strategy.hasPriorityBoost?.(primary) ?? false,
+				planPriority: 0,
+				secondaryUsed: this.#normalizeUsageFraction(secondaryTarget),
+				secondaryDrainRate: this.#computeWindowDrainRate(
+					secondaryTarget,
+					nowMs,
+					strategy.windowDefaults.secondaryMs,
+				),
+				primaryUsed: this.#normalizeUsageFraction(primary),
+				primaryDrainRate: this.#computeWindowDrainRate(primary, nowMs, strategy.windowDefaults.primaryMs),
+				orderPos,
+			});
+		}
+		return this.#orderUsageRankedCandidates(ranked, args.sessionId, "none");
+	}
+
+	async #selectApiKeyCredential(
+		provider: string,
+		sessionId: string | undefined,
+		options: AuthApiKeyOptions | undefined,
+		filter?: (credential: ApiKeyCredential) => boolean,
+	): Promise<ApiKeySelection | undefined> {
+		const credentials = this.#getCredentialsForProvider(provider)
+			.map((credential, index) => ({ credential, index }))
+			.filter((entry): entry is ApiKeySelection => {
+				if (entry.credential.type !== "api_key") return false;
+				return filter?.(entry.credential) ?? true;
+			});
+
+		if (credentials.length === 0) return undefined;
+		if (credentials.length === 1) return credentials[0];
+
+		const providerKey = this.#getProviderTypeKey(provider, "api_key");
+		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
+		const fallback = credentials[order[0]];
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		if (!strategy) {
+			for (const idx of order) {
+				const candidate = credentials[idx];
+				if (!this.#isCredentialBlocked(provider, providerKey, candidate.index)) {
+					return candidate;
+				}
+			}
+			return fallback;
+		}
+
+		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const blockScope = strategy.blockScope?.(rankingContext);
+		const candidates = await this.#rankApiKeySelections({
+			providerKey,
+			provider,
+			order,
+			credentials,
+			options,
+			sessionId,
+			strategy,
+			rankingContext,
+			blockScope,
+		});
+		return candidates[0]?.selection ?? fallback;
 	}
 
 	/**
@@ -2374,7 +2528,13 @@ export class AuthStorage {
 	// Queries provider usage endpoints to detect rate limits before they occur.
 	// ─────────────────────────────────────────────────────────────────────────────
 
-	#buildUsageCredential(credential: OAuthCredential): UsageCredential {
+	#buildUsageCredential(credential: AuthCredential): UsageCredential {
+		if (credential.type === "api_key") {
+			return {
+				type: "api_key",
+				apiKey: credential.key,
+			};
+		}
 		return {
 			type: "oauth",
 			accessToken: credential.access,
@@ -3094,26 +3254,30 @@ export class AuthStorage {
 
 	async #getUsageReport(
 		provider: Provider,
-		credential: OAuthCredential,
+		credential: AuthCredential,
 		options?: { baseUrl?: string; timeoutMs?: number; signal?: AbortSignal },
 	): Promise<UsageReport | null> {
 		// Store-level hook (e.g. `RemoteAuthCredentialStore`) is authoritative
-		// when present: the broker already aggregates usage from a less-throttled
-		// IP, and falling back to the local per-credential fetch would defeat the
-		// whole point of routing through it.
-		const storeHook = this.#store.getUsageReport?.bind(this.#store);
-		if (storeHook) {
-			const report = await storeHook(provider, credential, options?.signal);
-			if (report) {
-				this.#reconcileCodexUsageBlock(
-					this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
-					report,
-				);
+		// when present for OAuth: the broker already aggregates usage from a
+		// less-throttled IP, and falling back to the local per-credential fetch
+		// would defeat the point of routing through it. API-key credentials do
+		// not have a broker per-credential hook, so they use the normal cached
+		// provider fetch path.
+		if (credential.type === "oauth") {
+			const storeHook = this.#store.getUsageReport?.bind(this.#store);
+			if (storeHook) {
+				const report = await storeHook(provider, credential, options?.signal);
+				if (report) {
+					this.#reconcileCodexUsageBlock(
+						this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
+						report,
+					);
+				}
+				return report;
 			}
-			return report;
 		}
 		return this.#fetchUsageCached(
-			this.#buildUsageRequestForOauth(provider, credential, options?.baseUrl),
+			this.#buildUsageRequest(provider, this.#buildUsageCredential(credential), options?.baseUrl),
 			options?.timeoutMs ?? this.#usageRequestTimeoutMs,
 		);
 	}
@@ -3513,9 +3677,9 @@ export class AuthStorage {
 		return usedFraction / elapsedHours;
 	}
 
-	#compareRankedOAuthCandidatePriority(
-		left: RankedOAuthCandidate,
-		right: RankedOAuthCandidate,
+	#compareUsageRankedCandidatePriority(
+		left: UsageRankedCandidate<AuthCredential>,
+		right: UsageRankedCandidate<AuthCredential>,
 		planRequirement: OpenAICodexPlanRequirement,
 	): number {
 		if (left.blocked !== right.blocked) return left.blocked ? 1 : -1;
@@ -3540,21 +3704,21 @@ export class AuthStorage {
 		return 0;
 	}
 
-	#compareRankedOAuthCandidates(
-		left: RankedOAuthCandidate,
-		right: RankedOAuthCandidate,
+	#compareUsageRankedCandidates(
+		left: UsageRankedCandidate<AuthCredential>,
+		right: UsageRankedCandidate<AuthCredential>,
 		planRequirement: OpenAICodexPlanRequirement,
 	): number {
-		const priority = this.#compareRankedOAuthCandidatePriority(left, right, planRequirement);
+		const priority = this.#compareUsageRankedCandidatePriority(left, right, planRequirement);
 		return priority !== 0 ? priority : left.orderPos - right.orderPos;
 	}
 
-	#orderRankedOAuthCandidates(
-		candidates: RankedOAuthCandidate[],
+	#orderUsageRankedCandidates<T extends AuthCredential>(
+		candidates: UsageRankedCandidate<T>[],
 		sessionId: string | undefined,
 		planRequirement: OpenAICodexPlanRequirement,
-	): OAuthCandidate[] {
-		candidates.sort((left, right) => this.#compareRankedOAuthCandidates(left, right, planRequirement));
+	): UsageCandidate<T>[] {
+		candidates.sort((left, right) => this.#compareUsageRankedCandidates(left, right, planRequirement));
 		if (!sessionId) {
 			return candidates.map(candidate => ({
 				selection: candidate.selection,
@@ -3572,14 +3736,14 @@ export class AuthStorage {
 			}));
 		}
 
-		const priorityByCandidate = new Map<RankedOAuthCandidate, number>();
+		const priorityByCandidate = new Map<UsageRankedCandidate<T>, number>();
 		let bucketIndex = 0;
 		let previous = unblocked[0];
-		const bucketByCandidate = new Map<RankedOAuthCandidate, number>();
+		const bucketByCandidate = new Map<UsageRankedCandidate<T>, number>();
 		for (const candidate of unblocked) {
 			if (
 				candidate !== previous &&
-				this.#compareRankedOAuthCandidatePriority(previous, candidate, planRequirement) !== 0
+				this.#compareUsageRankedCandidatePriority(previous, candidate, planRequirement) !== 0
 			) {
 				bucketIndex += 1;
 			}
@@ -3736,7 +3900,7 @@ export class AuthStorage {
 				orderPos,
 			});
 		}
-		return this.#orderRankedOAuthCandidates(ranked, args.sessionId, args.planRequirement);
+		return this.#orderUsageRankedCandidates(ranked, args.sessionId, args.planRequirement);
 	}
 
 	/**
@@ -4371,12 +4535,11 @@ export class AuthStorage {
 		if (oauthResolved) {
 			return oauthResolved.apiKey;
 		}
-
-		const loginApiKeySelection = this.#selectCredentialByType(
+		const loginApiKeySelection = await this.#selectApiKeyCredential(
 			provider,
-			"api_key",
 			sessionId,
-			credential => credential.type === "api_key" && credential.source === "login",
+			options,
+			credential => credential.source === "login",
 		);
 		if (loginApiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", loginApiKeySelection.index);
@@ -4390,12 +4553,11 @@ export class AuthStorage {
 
 		const envKey = getEnvApiKey(provider);
 		if (envKey) return envKey;
-
-		const apiKeySelection = this.#selectCredentialByType(
+		const apiKeySelection = await this.#selectApiKeyCredential(
 			provider,
-			"api_key",
 			sessionId,
-			credential => credential.type !== "api_key" || credential.source !== "login",
+			options,
+			credential => credential.source !== "login",
 		);
 		if (apiKeySelection) {
 			this.#recordSessionCredential(provider, sessionId, "api_key", apiKeySelection.index);

--- a/packages/ai/src/usage/zai.ts
+++ b/packages/ai/src/usage/zai.ts
@@ -1,5 +1,6 @@
 import { toNumber } from "@oh-my-pi/pi-catalog/utils";
 import type {
+	CredentialRankingStrategy,
 	UsageAmount,
 	UsageFetchContext,
 	UsageFetchParams,
@@ -191,6 +192,21 @@ function buildModelUsageUrl(baseUrl: string, now: Date): string {
 	return `${baseUrl}${MODEL_USAGE_PATH}?startTime=${encodeURIComponent(startTime)}&endTime=${encodeURIComponent(endTime)}`;
 }
 
+function rankZaiRequestLimits(report: UsageReport): UsageLimit[] {
+	const requestLimits = report.limits.filter(limit => limit.id.startsWith("zai:requests:"));
+	const limits = requestLimits.length > 0 ? requestLimits : report.limits;
+	const ranked = [...limits];
+	ranked.sort((left, right) => {
+		const leftDuration = left.window?.durationMs ?? Number.POSITIVE_INFINITY;
+		const rightDuration = right.window?.durationMs ?? Number.POSITIVE_INFINITY;
+		if (leftDuration !== rightDuration) return leftDuration - rightDuration;
+		const leftReset = left.window?.resetsAt ?? Number.POSITIVE_INFINITY;
+		const rightReset = right.window?.resetsAt ?? Number.POSITIVE_INFINITY;
+		return leftReset - rightReset;
+	});
+	return ranked;
+}
+
 async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): Promise<UsageReport | null> {
 	if (params.provider !== "zai") return null;
 	const credential = params.credential;
@@ -318,4 +334,15 @@ export const zaiUsageProvider: UsageProvider = {
 	id: "zai",
 	fetchUsage: fetchZaiUsage,
 	supports: params => params.provider === "zai" && params.credential.type === "api_key",
+};
+
+export const zaiRankingStrategy: CredentialRankingStrategy = {
+	findWindowLimits(report) {
+		const ranked = rankZaiRequestLimits(report);
+		return { primary: ranked[0], secondary: ranked[1] };
+	},
+	windowDefaults: {
+		primaryMs: 5 * HOUR_MS,
+		secondaryMs: WEEK_MS,
+	},
 };

--- a/packages/ai/src/usage/zai.ts
+++ b/packages/ai/src/usage/zai.ts
@@ -176,12 +176,14 @@ function buildZaiWindow(parsed: ZaiUsageLimitItem): UsageWindow {
 	};
 }
 
-function requestQuotaLabel(parsed: ZaiUsageLimitItem): string {
+function isZaiFeatureRequestLimit(parsed: ZaiUsageLimitItem): boolean {
 	const detailCodes =
 		parsed.usageDetails?.map(detail => detail.modelCode).filter((code): code is string => !!code) ?? [];
-	if (detailCodes.includes("search-prime") && detailCodes.includes("web-reader") && detailCodes.includes("zread")) {
-		return "ZAI Web Search / Reader / Zread Quota";
-	}
+	return detailCodes.includes("search-prime") && detailCodes.includes("web-reader") && detailCodes.includes("zread");
+}
+
+function requestQuotaLabel(parsed: ZaiUsageLimitItem): string {
+	if (isZaiFeatureRequestLimit(parsed)) return "ZAI Web Search / Reader / Zread Quota";
 	return "ZAI Request Quota";
 }
 
@@ -192,9 +194,17 @@ function buildModelUsageUrl(baseUrl: string, now: Date): string {
 	return `${baseUrl}${MODEL_USAGE_PATH}?startTime=${encodeURIComponent(startTime)}&endTime=${encodeURIComponent(endTime)}`;
 }
 
+function getZaiCredentialLimits(report: UsageReport): UsageLimit[] {
+	const limits = report.limits.filter(
+		limit => limit.id.startsWith("zai:requests:") || limit.id.startsWith("zai:tokens:"),
+	);
+	return limits;
+}
+
 function rankZaiRequestLimits(report: UsageReport): UsageLimit[] {
 	const requestLimits = report.limits.filter(limit => limit.id.startsWith("zai:requests:"));
-	const limits = requestLimits.length > 0 ? requestLimits : report.limits;
+	const credentialLimits = getZaiCredentialLimits(report);
+	const limits = requestLimits.length > 0 ? requestLimits : credentialLimits;
 	const ranked = [...limits];
 	ranked.sort((left, right) => {
 		const leftDuration = left.window?.durationMs ?? Number.POSITIVE_INFINITY;
@@ -279,13 +289,15 @@ async function fetchZaiUsage(params: UsageFetchParams, ctx: UsageFetchContext): 
 				percentage: parsed.percentage,
 				unit: "requests",
 			});
+			const featureLimit = isZaiFeatureRequestLimit(parsed);
 			limits.push({
-				id: `zai:requests:${window.id}`,
+				id: featureLimit ? `zai:features:web-search-reader-zread:${window.id}` : `zai:requests:${window.id}`,
 				label: requestQuotaLabel(parsed),
 				scope: {
 					provider: params.provider,
 					windowId: window.id,
-					shared: true,
+					shared: !featureLimit,
+					...(featureLimit ? { tier: "web-search-reader-zread" } : {}),
 				},
 				window,
 				amount,
@@ -340,6 +352,10 @@ export const zaiRankingStrategy: CredentialRankingStrategy = {
 	findWindowLimits(report) {
 		const ranked = rankZaiRequestLimits(report);
 		return { primary: ranked[0], secondary: ranked[1] };
+	},
+	scopeLimits(report) {
+		const limits = getZaiCredentialLimits(report);
+		return limits;
 	},
 	windowDefaults: {
 		primaryMs: 5 * HOUR_MS,

--- a/packages/ai/test/auth-storage-zai-api-key-selection.test.ts
+++ b/packages/ai/test/auth-storage-zai-api-key-selection.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import type { UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+import { removeWithRetries } from "../../utils/src/temp";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+describe("AuthStorage Z.AI API-key usage ranking", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	const usageByKey = new Map<string, UsageReport>();
+
+	const usageProvider: UsageProvider = {
+		id: "zai",
+		async fetchUsage(params) {
+			const apiKey = params.credential.apiKey;
+			if (!apiKey) return null;
+			return usageByKey.get(apiKey) ?? null;
+		},
+		supports: params => params.provider === "zai" && params.credential.type === "api_key",
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-zai-selection-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "zai" ? usageProvider : undefined),
+		});
+		usageByKey.clear();
+	});
+
+	afterEach(async () => {
+		authStorage?.close();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir.length > 0) {
+			await removeWithRetries(tempDir);
+		}
+		tempDir = "";
+	});
+
+	test("skips an exhausted login API key when a Z.AI sibling has request quota", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "zai-exhausted", source: "login" },
+			{ type: "api_key", key: "zai-healthy", source: "login" },
+		]);
+		usageByKey.set("zai-exhausted", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + HOUR_MS },
+					amount: {
+						unit: "requests",
+						used: 100,
+						limit: 100,
+						remaining: 0,
+						usedFraction: 1,
+						remainingFraction: 0,
+					},
+					status: "exhausted",
+				},
+			],
+		});
+		usageByKey.set("zai-healthy", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + 2 * HOUR_MS },
+					amount: {
+						unit: "requests",
+						used: 20,
+						limit: 100,
+						remaining: 80,
+						usedFraction: 0.2,
+						remainingFraction: 0.8,
+					},
+					status: "ok",
+				},
+			],
+		});
+
+		expect(await authStorage.getApiKey("zai")).toBe("zai-healthy");
+	});
+});

--- a/packages/ai/test/auth-storage-zai-api-key-selection.test.ts
+++ b/packages/ai/test/auth-storage-zai-api-key-selection.test.ts
@@ -29,6 +29,11 @@ describe("AuthStorage Z.AI API-key usage ranking", () => {
 		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
 		authStorage = new AuthStorage(store, {
 			usageProviderResolver: provider => (provider === "zai" ? usageProvider : undefined),
+			async configValueResolver(config) {
+				if (config === "ZAI_EXHAUSTED_REF") return "zai-exhausted";
+				if (config === "ZAI_HEALTHY_REF") return "zai-healthy";
+				return config;
+			},
 		});
 		usageByKey.clear();
 	});
@@ -95,5 +100,126 @@ describe("AuthStorage Z.AI API-key usage ranking", () => {
 		});
 
 		expect(await authStorage.getApiKey("zai")).toBe("zai-healthy");
+	});
+
+	test("resolves stored API-key references before probing Z.AI usage", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "ZAI_EXHAUSTED_REF", source: "login" },
+			{ type: "api_key", key: "ZAI_HEALTHY_REF", source: "login" },
+		]);
+		usageByKey.set("zai-exhausted", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + HOUR_MS },
+					amount: {
+						unit: "requests",
+						used: 100,
+						limit: 100,
+						remaining: 0,
+						usedFraction: 1,
+						remainingFraction: 0,
+					},
+					status: "exhausted",
+				},
+			],
+		});
+		usageByKey.set("zai-healthy", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + 2 * HOUR_MS },
+					amount: {
+						unit: "requests",
+						used: 20,
+						limit: 100,
+						remaining: 80,
+						usedFraction: 0.2,
+						remainingFraction: 0.8,
+					},
+					status: "ok",
+				},
+			],
+		});
+
+		expect(await authStorage.getApiKey("zai")).toBe("zai-healthy");
+	});
+
+	test("ignores exhausted Z.AI feature quotas for model request routing", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("zai", [
+			{ type: "api_key", key: "zai-feature-exhausted", source: "login" },
+			{ type: "api_key", key: "zai-general-busier", source: "login" },
+		]);
+		usageByKey.set("zai-feature-exhausted", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:features:web-search-reader-zread:5h",
+					label: "ZAI Web Search / Reader / Zread Quota",
+					scope: { provider: "zai", windowId: "5h", tier: "web-search-reader-zread", shared: false },
+					window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + HOUR_MS },
+					amount: {
+						unit: "requests",
+						used: 100,
+						limit: 100,
+						remaining: 0,
+						usedFraction: 1,
+						remainingFraction: 0,
+					},
+					status: "exhausted",
+				},
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + 2 * HOUR_MS },
+					amount: {
+						unit: "requests",
+						used: 10,
+						limit: 100,
+						remaining: 90,
+						usedFraction: 0.1,
+						remainingFraction: 0.9,
+					},
+					status: "ok",
+				},
+			],
+		});
+		usageByKey.set("zai-general-busier", {
+			provider: "zai",
+			fetchedAt: Date.now(),
+			limits: [
+				{
+					id: "zai:requests:5h",
+					label: "ZAI Request Quota",
+					scope: { provider: "zai", windowId: "5h", shared: true },
+					window: { id: "5h", label: "5 Hour", durationMs: 5 * HOUR_MS, resetsAt: Date.now() + 2 * HOUR_MS },
+					amount: {
+						unit: "requests",
+						used: 80,
+						limit: 100,
+						remaining: 20,
+						usedFraction: 0.8,
+						remainingFraction: 0.2,
+					},
+					status: "ok",
+				},
+			],
+		});
+
+		expect(await authStorage.getApiKey("zai")).toBe("zai-feature-exhausted");
 	});
 });

--- a/packages/ai/test/zai-usage.test.ts
+++ b/packages/ai/test/zai-usage.test.ts
@@ -58,13 +58,19 @@ describe("zai usage provider", () => {
 		);
 
 		expect(report).not.toBeNull();
-		expect(report!.limits.map(limit => limit.id)).toEqual(["zai:requests:1mo", "zai:tokens:5h", "zai:tokens:1w"]);
+		expect(report!.limits.map(limit => limit.id)).toEqual([
+			"zai:features:web-search-reader-zread:1mo",
+			"zai:tokens:5h",
+			"zai:tokens:1w",
+		]);
 		expect(report!.limits.map(limit => limit.label)).toEqual([
 			"ZAI Web Search / Reader / Zread Quota",
 			"ZAI 5 Hours Token Quota",
 			"ZAI Weekly Token Quota",
 		]);
 		expect(report!.limits.map(limit => limit.scope.windowId)).toEqual(["1mo", "5h", "1w"]);
+		expect(report!.limits.map(limit => limit.scope.shared)).toEqual([false, true, true]);
+		expect(report!.limits[0]?.scope.tier).toBe("web-search-reader-zread");
 		expect(report!.limits.map(limit => limit.window?.durationMs)).toEqual([
 			30 * 24 * 60 * 60 * 1000,
 			5 * 60 * 60 * 1000,


### PR DESCRIPTION
## Repro
A focused AuthStorage reproduction configured two stored Z.AI login API keys with a custom usage provider: the first key reported an exhausted shared `zai:requests:5h` window and the second reported request headroom. Before the fix, `bun test tmp-repro/zai-api-key-ranking-repro.test.ts` failed because `getApiKey("zai")` returned `"zai-exhausted"` instead of `"zai-healthy"`.

## Cause
`packages/ai/src/auth-storage.ts` only applied `CredentialRankingStrategy` usage reports in the OAuth path (`#rankOAuthSelections` / `#resolveOAuthSelection`). Stored API-key credentials still used the synchronous round-robin selector, and `packages/ai/src/usage/zai.ts` exported only `zaiUsageProvider`, so Z.AI usage data populated `/usage` but never affected request-time credential selection.

## Fix
- Added a Z.AI ranking strategy that ranks request quota windows by duration/reset and registers it in the default ranking strategy map.
- Extended API-key credential selection to prefetch cached usage reports, proactively mark exhausted credentials blocked until reset, and return the highest-ranked healthy sibling before dispatch.
- Kept OAuth ranking on the same shared ordering path and added a Z.AI API-key AuthStorage regression test.

## Verification
`bun test packages/ai/test/auth-storage-zai-api-key-selection.test.ts packages/ai/test/auth-storage-codex-selection.test.ts packages/ai/test/auth-storage-antigravity-selection.test.ts` passed: 47 tests, 112 expects. `bun check` passed. Fixes #5265.