### PR TITLE
fix(lsp): send initial workspace configuration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Pyright LSP semantic requests hanging during startup by sending the initial workspace configuration notification after `initialized`. ([#5276](https://github.com/can1357/oh-my-pi/issues/5276))
+
 ## [16.4.7] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -750,8 +750,14 @@ export async function getOrCreateClient(
 
 			client.serverCapabilities = initResult.capabilities as LspClient["serverCapabilities"];
 
-			// Send initialized notification
+			// Finish the initialize handshake before publishing the client as ready.
 			await sendNotification(client, "initialized", {}, signal);
+			await sendNotification(
+				client,
+				"workspace/didChangeConfiguration",
+				{ settings: config.settings ?? {} },
+				signal,
+			);
 
 			client.status = "ready";
 			// Publish only after init succeeds: pre-init clients are reachable

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -366,6 +366,66 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("sends initial workspace configuration after initialized before semantic requests (#5276)", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-initial-config-");
+		try {
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: { hoverProvider: true } } });
+				} else if (message.method === "textDocument/hover") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { contents: "configured hover" } });
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+			const settings = {
+				"typescript-language-server": {
+					preferences: {
+						includePackageJsonAutoImports: "on",
+						importModuleSpecifierPreference: "non-relative",
+					},
+					inlayHints: {
+						includeInlayEnumMemberValueHints: true,
+						includeInlayParameterNameHints: "all",
+					},
+				},
+			};
+			const config: ServerConfig = {
+				command: "fake-lsp",
+				fileTypes: ["ts"],
+				rootMarkers: [],
+				settings,
+			};
+
+			const client = await lspClient.getOrCreateClient(config, tempDir.path(), 1_000);
+			const result = await lspClient.sendRequest(
+				client,
+				"textDocument/hover",
+				{
+					textDocument: { uri: fileToUri(path.join(tempDir.path(), "src", "configured.ts")) },
+					position: { line: 0, character: 0 },
+				},
+				undefined,
+				50,
+			);
+
+			expect(result).toEqual({ contents: "configured hover" });
+			const methods = server.received.map(message => message.method);
+			expect(methods.slice(0, 4)).toEqual([
+				"initialize",
+				"initialized",
+				"workspace/didChangeConfiguration",
+				"textDocument/hover",
+			]);
+			expect(server.received[2].params).toEqual({ settings: config.settings });
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("accepts dynamic capability registration before semantic requests", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-dynamic-registration-");
 		try {


### PR DESCRIPTION
## Repro
A focused fake-LSP regression reproduces the startup sequence from #5276: `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts -t "sends initial workspace configuration"` failed on the baseline because the client sent `initialize`, `initialized`, then `textDocument/hover`; `workspace/didChangeConfiguration` was absent.

## Cause
`packages/coding-agent/src/lsp/client.ts#getOrCreateClient` advertised `workspace.configuration` support in `CLIENT_CAPABILITIES`, completed `initialize`, sent `initialized`, and immediately marked the client ready without sending the initial workspace configuration notification that Pyright waits on before servicing semantic requests.

## Fix
- Sent `workspace/didChangeConfiguration` with `{ settings: config.settings ?? {} }` immediately after `initialized` and before publishing the client as ready.
- Added a fake-LSP regression asserting the JSON-RPC order `initialize` → `initialized` → `workspace/didChangeConfiguration` → semantic `textDocument/hover`.
- Added a changelog entry for the Pyright LSP startup hang fix.

## Verification
`bun test packages/coding-agent/test/tools/lsp-regressions.test.ts -t "sends initial workspace configuration"` now passes: 1 pass, 0 fail. `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts` passes: 58 pass, 0 fail. `gh_push_branch` completed the pre-publish gate before pushing. Fixes #5276