### PR TITLE
fix(web-search): support GPT-5.6 Codex models

### DIFF
--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -7,9 +7,20 @@
  * SQLite store, never POSTs the broker sentinel to an OpenAI token endpoint.
  */
 import * as os from "node:os";
-import { type AuthStorage, type FetchImpl, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
+import {
+	type AuthStorage,
+	type FetchImpl,
+	type OAuthAccess,
+	createOpenAICodexCompatibilityMetadata,
+	withOAuthAccess,
+} from "@oh-my-pi/pi-ai";
 import { decodeJwt } from "@oh-my-pi/pi-ai/oauth/openai-codex";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import {
+	CODEX_CLIENT_VERSION,
+	OPENAI_HEADER_VALUES,
+	OPENAI_HEADERS,
+} from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, readSseJson } from "@oh-my-pi/pi-utils";
 import packageJson from "../../../../package.json" with { type: "json" };
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
@@ -22,6 +33,9 @@ const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const CODEX_RESPONSES_PATH = "/codex/responses";
 const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
+	"gpt-5.6-luna",
+	"gpt-5.6-terra",
+	"gpt-5.6-sol",
 	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5-codex",
@@ -38,6 +52,35 @@ const DEFAULT_INSTRUCTIONS =
 function getConfiguredModel(): string | undefined {
 	const configuredModel = $env.PI_CODEX_WEB_SEARCH_MODEL?.trim();
 	return configuredModel ? configuredModel : undefined;
+}
+type CodexReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
+
+function parseConfiguredModel(configuredModel: string | undefined): {
+	modelId?: string;
+	reasoningEffort: CodexReasoningEffort;
+} {
+	if (!configuredModel) return { reasoningEffort: "xhigh" };
+
+	const separator = configuredModel.indexOf(":");
+	if (separator === -1) return { modelId: configuredModel, reasoningEffort: "xhigh" };
+
+	const modelId = configuredModel.slice(0, separator);
+	const effort = configuredModel.slice(separator + 1);
+	if (
+		!modelId ||
+		configuredModel.indexOf(":", separator + 1) !== -1 ||
+		!["low", "medium", "high", "xhigh", "max"].includes(effort)
+	) {
+		throw new Error(`Unsupported Codex reasoning effort selector in model '${configuredModel}'`);
+	}
+	return { modelId, reasoningEffort: effort as CodexReasoningEffort };
+}
+
+function validateConfiguredModelEffort(modelId: string | undefined, reasoningEffort: CodexReasoningEffort): void {
+	if (!modelId) return;
+	const model = getBundledModels("openai-codex").find(candidate => candidate.id === modelId);
+	if (!model?.thinking || model.thinking.efforts.includes(reasoningEffort)) return;
+	throw new Error(`Unsupported Codex reasoning effort '${reasoningEffort}' for model '${modelId}'`);
 }
 
 function getDefaultModelCandidates(): string[] {
@@ -298,16 +341,39 @@ async function findCodexAuth(
 /**
  * Builds HTTP headers for Codex API requests.
  */
-function buildCodexHeaders(accessToken: string, accountId: string): Record<string, string> {
+function buildCodexHeaders(
+	accessToken: string,
+	accountId: string,
+	useResponsesLite: boolean,
+	compatibilityHeaders?: Record<string, string>,
+): Record<string, string> {
 	return {
 		Authorization: `Bearer ${accessToken}`,
-		"chatgpt-account-id": accountId,
-		"OpenAI-Beta": "responses=experimental",
-		originator: "pi",
+		[OPENAI_HEADERS.ACCOUNT_ID]: accountId,
+		[OPENAI_HEADERS.BETA]: OPENAI_HEADER_VALUES.BETA_RESPONSES,
+		[OPENAI_HEADERS.ORIGINATOR]: "codex_cli_rs",
+		[OPENAI_HEADERS.VERSION]: CODEX_CLIENT_VERSION,
+		...(useResponsesLite ? { [OPENAI_HEADERS.RESPONSES_LITE]: "true" } : {}),
+		...(compatibilityHeaders ?? {}),
 		"User-Agent": `pi/${packageJson.version} (${os.platform()} ${os.release()}; ${os.arch()})`,
 		Accept: "text/event-stream",
 		"Content-Type": "application/json",
 	};
+}
+
+function applyResponsesLiteShape(body: Record<string, unknown>): void {
+	const input = Array.isArray(body.input) ? body.input : [];
+	body.parallel_tool_calls = false;
+	body.input = [
+		{ type: "additional_tools", role: "developer", tools: Array.isArray(body.tools) ? body.tools : [] },
+		...(typeof body.instructions === "string" && body.instructions.length > 0
+			? [{ type: "message", role: "developer", content: [{ type: "input_text", text: body.instructions }] }]
+			: []),
+		...input,
+	];
+	delete body.tools;
+	delete body.instructions;
+	delete body.tool_choice;
 }
 
 /**
@@ -324,6 +390,7 @@ async function callCodexSearch(
 		systemPrompt?: string;
 		searchContextSize?: "low" | "medium" | "high";
 		modelId: string;
+		reasoningEffort: CodexReasoningEffort;
 		fetch?: FetchImpl;
 	},
 ): Promise<{
@@ -334,10 +401,21 @@ async function callCodexSearch(
 	usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
 }> {
 	const url = `${CODEX_BASE_URL}${CODEX_RESPONSES_PATH}`;
-	const headers = buildCodexHeaders(auth.accessToken, auth.accountId);
-
 	const requestedModel = options.modelId;
-
+	const useResponsesLite = getBundledModels("openai-codex").find(model => model.id === requestedModel)?.useResponsesLite === true;
+	const compatibilityMetadata = useResponsesLite
+		? createOpenAICodexCompatibilityMetadata({
+				requestKind: "turn",
+				startNewTurn: true,
+				includeInstallationHeader: true,
+			})
+		: undefined;
+	const headers = buildCodexHeaders(
+		auth.accessToken,
+		auth.accountId,
+		useResponsesLite,
+		compatibilityMetadata?.headers,
+	);
 	const body: Record<string, unknown> = {
 		model: requestedModel,
 		stream: true,
@@ -358,6 +436,14 @@ async function callCodexSearch(
 		tool_choice: { type: "web_search" },
 		instructions: options.systemPrompt ?? DEFAULT_INSTRUCTIONS,
 	};
+	if (useResponsesLite) {
+		body.reasoning = { effort: options.reasoningEffort, summary: "detailed", context: "all_turns" };
+		body.text = { verbosity: "high" };
+		body.include = ["reasoning.encrypted_content"];
+		body.stream_options = { reasoning_summary_delivery: "sequential_cutoff" };
+		if (compatibilityMetadata) body.client_metadata = compatibilityMetadata.clientMetadata;
+		applyResponsesLiteShape(body);
+	}
 
 	const fetchImpl = options.fetch ?? fetch;
 	const response = await fetchImpl(url, {
@@ -503,7 +589,9 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 	}
 
 	const configuredModel = getConfiguredModel();
-	const modelCandidates = configuredModel ? [configuredModel] : getDefaultModelCandidates();
+	const parsedConfiguredModel = parseConfiguredModel(configuredModel);
+	const modelCandidates = parsedConfiguredModel.modelId ? [parsedConfiguredModel.modelId] : getDefaultModelCandidates();
+	validateConfiguredModelEffort(parsedConfiguredModel.modelId, parsedConfiguredModel.reasoningEffort);
 
 	const result = await withOAuthAccess(
 		params.authStorage,
@@ -529,6 +617,7 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 						systemPrompt: params.systemPrompt,
 						searchContextSize: "high",
 						modelId,
+						reasoningEffort: parsedConfiguredModel.reasoningEffort,
 						fetch: params.fetch,
 					});
 				} catch (error) {

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -223,24 +223,43 @@ describe("searchCodex model selection", () => {
 		}
 	});
 
-	it("uses the built-in default model when PI_CODEX_WEB_SEARCH_MODEL is unset", async () => {
+	it("uses gpt-5.6-luna with the Responses Lite contract by default", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
-		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.5")));
+		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.6-luna")));
 
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
-		expect(result.model).toBe("gpt-5.5");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
+		expect(capturedRequest?.body?.tools).toBeUndefined();
+		expect(capturedRequest?.body?.instructions).toBeUndefined();
+		expect(capturedRequest?.body?.tool_choice).toBeUndefined();
+		expect(capturedRequest?.body?.parallel_tool_calls).toBe(false);
+		expect(capturedRequest?.body?.reasoning).toEqual({
+			effort: "xhigh",
+			summary: "detailed",
+			context: "all_turns",
+		});
+		expect(capturedRequest?.body?.input).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "additional_tools",
+					role: "developer",
+					tools: [{ type: "web_search", search_context_size: "high" }],
+				}),
+			]),
+		);
+		expect(new Headers(capturedRequest?.headers).get("x-openai-internal-codex-responses-lite")).toBe("true");
+		expect(result.model).toBe("gpt-5.6-luna");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
-	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
+	it("falls back to gpt-5.6-luna when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
-		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.5")));
+		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.6-luna")));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
-		expect(result.model).toBe("gpt-5.5");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
+		expect(result.model).toBe("gpt-5.6-luna");
 	});
 
 	it("retries the next bundled default when Codex rejects a model for ChatGPT accounts", async () => {
@@ -257,20 +276,20 @@ describe("searchCodex model selection", () => {
 
 			const requestedModel = capturedRequest.body?.model;
 			if (calls === 1) {
-				expect(requestedModel).toBe("gpt-5.5");
+				expect(requestedModel).toBe("gpt-5.6-luna");
 				return Promise.resolve(
 					new Response(
 						JSON.stringify({
-							detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+							detail: "The 'gpt-5.6-luna' model is not supported when using Codex with a ChatGPT account.",
 						}),
 						{ status: 400, headers: { "Content-Type": "application/json" } },
 					),
 				);
 			}
 
-			expect(requestedModel).toBe("gpt-5.4");
+			expect(requestedModel).toBe("gpt-5.6-terra");
 			return Promise.resolve(
-				new Response(makeSseResponse("gpt-5.4"), {
+				new Response(makeSseResponse("gpt-5.6-terra"), {
 					status: 200,
 					headers: { "Content-Type": "text/event-stream" },
 				}),
@@ -280,7 +299,7 @@ describe("searchCodex model selection", () => {
 		const result = await searchCodex(makeSearchParams("retry unsupported default", fetchMock));
 
 		expect(calls).toBe(2);
-		expect(result.model).toBe("gpt-5.4");
+		expect(result.model).toBe("gpt-5.6-terra");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 


### PR DESCRIPTION
## Problem

Codex web search still prefers GPT-5.5 and emits the classic Responses request shape. The bundled catalog now marks `gpt-5.6-luna`, `gpt-5.6-terra`, and `gpt-5.6-sol` as Responses-Lite models, so merely selecting those model IDs would omit the wire adaptation they require.

## Change

- Prefer `gpt-5.6-luna`, then `gpt-5.6-terra`, then `gpt-5.6-sol` before the existing GPT-5.5-and-older fallback chain.
- Detect `useResponsesLite` from the bundled Codex model catalog.
- For Responses-Lite models:
  - move hosted `web_search` into a developer `additional_tools` input item;
  - move instructions into a developer message;
  - remove top-level `tools`, `tool_choice`, and `instructions`;
  - send the Responses-Lite and Codex compatibility headers/metadata;
  - request detailed reasoning with the configured effort and encrypted reasoning content.
- Accept `PI_CODEX_WEB_SEARCH_MODEL=<model>:<effort>` and validate the effort against catalog capabilities.
- Preserve the existing classic Responses request for models without `useResponsesLite`.
- Keep unsupported-default fallback behavior, now advancing Luna → Terra → Sol → GPT-5.5… . Explicit model overrides still fail directly instead of silently changing models.

## Regression coverage

The focused test now asserts:

- Luna is the default model;
- the Responses-Lite header is present;
- top-level hosted-tool fields are removed;
- `additional_tools` carries `web_search` with high search context;
- default reasoning is `xhigh` with detailed summaries;
- a rejected Luna default retries Terra;
- blank model configuration resolves to Luna.

## Verification

```text
bun test packages/coding-agent/test/tools/web-search-codex.test.ts

12 pass
0 fail
37 expect() calls
```
