### PR TITLE
fix(tool): support Codex web search GPT-5.6 Responses-Lite models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Codex web search selecting GPT-5.6 Responses-Lite models while still sending the classic Responses request shape. ([#5286](https://github.com/can1357/oh-my-pi/issues/5286))
 - Improved search reliability for Perplexity provider by forcing retrieval for all queries
 - Fixed JS eval cells losing top-level `function` and `var` declarations across cells when the defining cell contained top-level `await` — the async wrapper scoped them to the cell's IIFE instead of publishing them to the worker global
 

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -7,9 +7,14 @@
  * SQLite store, never POSTs the broker sentinel to an OpenAI token endpoint.
  */
 import * as os from "node:os";
-import { type AuthStorage, type FetchImpl, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
+import { type AuthStorage, type FetchImpl, type Model, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
 import { decodeJwt } from "@oh-my-pi/pi-ai/oauth/openai-codex";
+import { applyCodexResponsesLiteShape } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
+import { createOpenAICodexCompatibilityMetadata } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { requireSupportedEffort } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, readSseJson } from "@oh-my-pi/pi-utils";
 import packageJson from "../../../../package.json" with { type: "json" };
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
@@ -22,6 +27,9 @@ const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const CODEX_RESPONSES_PATH = "/codex/responses";
 const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
+	"gpt-5.6-luna",
+	"gpt-5.6-terra",
+	"gpt-5.6-sol",
 	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5-codex",
@@ -35,15 +43,83 @@ const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const DEFAULT_INSTRUCTIONS =
 	"You are a helpful assistant with web search capabilities. Search the web to answer the user's question accurately and cite your sources.";
 
-function getConfiguredModel(): string | undefined {
-	const configuredModel = $env.PI_CODEX_WEB_SEARCH_MODEL?.trim();
-	return configuredModel ? configuredModel : undefined;
+type CodexSearchModel = Model<"openai-codex-responses">;
+type CodexWebSearchEffort = Effort.Minimal | Effort.Low | Effort.Medium | Effort.High | Effort.XHigh | Effort.Max;
+
+interface ConfiguredCodexModel {
+	modelId: string;
+	reasoningEffort?: CodexWebSearchEffort;
 }
 
-function getDefaultModelCandidates(): string[] {
-	const bundledModels = getBundledModels("openai-codex");
-	const bundledIds = new Set(bundledModels.map(model => model.id));
-	const candidates = DEFAULT_MODEL_PREFERENCES.filter(modelId => bundledIds.has(modelId));
+interface CodexModelCandidate {
+	modelId: string;
+	catalogModel?: CodexSearchModel;
+	reasoningEffort?: CodexWebSearchEffort;
+}
+
+const CODEX_WEB_SEARCH_EFFORTS: Record<string, CodexWebSearchEffort> = {
+	minimal: Effort.Minimal,
+	low: Effort.Low,
+	medium: Effort.Medium,
+	high: Effort.High,
+	xhigh: Effort.XHigh,
+	max: Effort.Max,
+};
+const CODEX_WEB_SEARCH_EFFORT_LIST = "minimal, low, medium, high, xhigh, max";
+
+function parseConfiguredModel(): ConfiguredCodexModel | undefined {
+	const configuredModel = $env.PI_CODEX_WEB_SEARCH_MODEL?.trim();
+	if (!configuredModel) return undefined;
+
+	const effortSeparator = configuredModel.lastIndexOf(":");
+	if (effortSeparator === -1) return { modelId: configuredModel };
+
+	const modelId = configuredModel.slice(0, effortSeparator).trim();
+	const effortName = configuredModel
+		.slice(effortSeparator + 1)
+		.trim()
+		.toLowerCase();
+	const reasoningEffort = CODEX_WEB_SEARCH_EFFORTS[effortName];
+	if (!modelId || !reasoningEffort) {
+		throw new Error(
+			`Invalid PI_CODEX_WEB_SEARCH_MODEL value "${configuredModel}". Use "<model>" or "<model>:<effort>" where effort is one of: ${CODEX_WEB_SEARCH_EFFORT_LIST}.`,
+		);
+	}
+
+	return { modelId, reasoningEffort };
+}
+
+function getBundledCodexModels(): CodexSearchModel[] {
+	const models: CodexSearchModel[] = [];
+	for (const model of getBundledModels("openai-codex")) {
+		if (model.api === "openai-codex-responses") {
+			models.push(model as CodexSearchModel);
+		}
+	}
+	return models;
+}
+
+function resolveConfiguredCandidate(configured: ConfiguredCodexModel): CodexModelCandidate {
+	const bundledModels = getBundledCodexModels();
+	const catalogModel = bundledModels.find(model => model.id === configured.modelId);
+	if (configured.reasoningEffort && !catalogModel) {
+		throw new Error(
+			`PI_CODEX_WEB_SEARCH_MODEL requested reasoning effort "${configured.reasoningEffort}" for unknown Codex model "${configured.modelId}". Use a bundled Codex model so the effort can be validated.`,
+		);
+	}
+	if (configured.reasoningEffort && catalogModel) {
+		requireSupportedEffort(catalogModel, configured.reasoningEffort);
+	}
+	return { ...(catalogModel ? { catalogModel } : {}), ...configured };
+}
+
+function getDefaultModelCandidates(): CodexModelCandidate[] {
+	const bundledModels = getBundledCodexModels();
+	const candidates: CodexModelCandidate[] = [];
+	for (const modelId of DEFAULT_MODEL_PREFERENCES) {
+		const catalogModel = bundledModels.find(model => model.id === modelId);
+		if (catalogModel) candidates.push({ modelId, catalogModel });
+	}
 
 	if (candidates.length > 0) {
 		return candidates;
@@ -51,10 +127,11 @@ function getDefaultModelCandidates(): string[] {
 
 	const nonMini = bundledModels.find(model => !model.id.includes("mini") && !model.id.includes("spark"));
 	if (nonMini) {
-		return [nonMini.id];
+		return [{ modelId: nonMini.id, catalogModel: nonMini }];
 	}
 
-	return bundledModels[0]?.id ? [bundledModels[0].id] : [FALLBACK_MODEL];
+	const fallbackModel = bundledModels[0];
+	return fallbackModel ? [{ modelId: fallbackModel.id, catalogModel: fallbackModel }] : [{ modelId: FALLBACK_MODEL }];
 }
 
 function shouldRetryWithNextDefaultModel(error: unknown): boolean {
@@ -296,21 +373,6 @@ async function findCodexAuth(
 }
 
 /**
- * Builds HTTP headers for Codex API requests.
- */
-function buildCodexHeaders(accessToken: string, accountId: string): Record<string, string> {
-	return {
-		Authorization: `Bearer ${accessToken}`,
-		"chatgpt-account-id": accountId,
-		"OpenAI-Beta": "responses=experimental",
-		originator: "pi",
-		"User-Agent": `pi/${packageJson.version} (${os.platform()} ${os.release()}; ${os.arch()})`,
-		Accept: "text/event-stream",
-		"Content-Type": "application/json",
-	};
-}
-
-/**
  * Calls the Codex Responses API with web search tool enabled.
  * The caller provides the exact model id to send; retry / fallback policy
  * lives one layer up in `searchCodex()` so we can distinguish explicit user
@@ -323,7 +385,8 @@ async function callCodexSearch(
 		signal?: AbortSignal;
 		systemPrompt?: string;
 		searchContextSize?: "low" | "medium" | "high";
-		modelId: string;
+		model: CodexModelCandidate;
+		sessionId?: string;
 		fetch?: FetchImpl;
 	},
 ): Promise<{
@@ -334,9 +397,19 @@ async function callCodexSearch(
 	usage?: { inputTokens: number; outputTokens: number; totalTokens: number };
 }> {
 	const url = `${CODEX_BASE_URL}${CODEX_RESPONSES_PATH}`;
-	const headers = buildCodexHeaders(auth.accessToken, auth.accountId);
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${auth.accessToken}`,
+		[OPENAI_HEADERS.ACCOUNT_ID]: auth.accountId,
+		[OPENAI_HEADERS.BETA]: OPENAI_HEADER_VALUES.BETA_RESPONSES,
+		[OPENAI_HEADERS.ORIGINATOR]: OPENAI_HEADER_VALUES.ORIGINATOR_CODEX,
+		[OPENAI_HEADERS.VERSION]: CODEX_CLIENT_VERSION,
+		"User-Agent": `pi/${packageJson.version} (${os.platform()} ${os.release()}; ${os.arch()})`,
+		Accept: "text/event-stream",
+		"Content-Type": "application/json",
+	};
 
-	const requestedModel = options.modelId;
+	const requestedModel = options.model.modelId;
+	const usesResponsesLite = options.model.catalogModel?.useResponsesLite === true;
 
 	const body: Record<string, unknown> = {
 		model: requestedModel,
@@ -358,6 +431,24 @@ async function callCodexSearch(
 		tool_choice: { type: "web_search" },
 		instructions: options.systemPrompt ?? DEFAULT_INSTRUCTIONS,
 	};
+	if (options.model.reasoningEffort || usesResponsesLite) {
+		body.reasoning = {
+			...(options.model.reasoningEffort ? { effort: options.model.reasoningEffort } : {}),
+			...(usesResponsesLite ? { context: "all_turns" } : {}),
+		};
+	}
+	if (usesResponsesLite) {
+		const metadata = createOpenAICodexCompatibilityMetadata({
+			sessionId: options.sessionId,
+			requestKind: "turn",
+			startNewTurn: true,
+		});
+		Object.assign(headers, metadata.headers);
+		headers[OPENAI_HEADERS.RESPONSES_LITE] = "true";
+		body.client_metadata = metadata.clientMetadata;
+		applyCodexResponsesLiteShape(body);
+		delete body.tool_choice;
+	}
 
 	const fetchImpl = options.fetch ?? fetch;
 	const response = await fetchImpl(url, {
@@ -501,9 +592,10 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 			"No Codex OAuth credentials found. Login with 'omp /login openai-codex' to enable Codex web search.",
 		);
 	}
-
-	const configuredModel = getConfiguredModel();
-	const modelCandidates = configuredModel ? [configuredModel] : getDefaultModelCandidates();
+	const configuredModel = parseConfiguredModel();
+	const modelCandidates = configuredModel
+		? [resolveConfiguredCandidate(configuredModel)]
+		: getDefaultModelCandidates();
 
 	const result = await withOAuthAccess(
 		params.authStorage,
@@ -528,7 +620,8 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 						signal: params.signal,
 						systemPrompt: params.systemPrompt,
 						searchContextSize: "high",
-						modelId,
+						model: modelId,
+						sessionId: params.sessionId,
 						fetch: params.fetch,
 					});
 				} catch (error) {

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -186,6 +186,7 @@ describe("searchCodex model selection", () => {
 		},
 	} as unknown as AuthStorage;
 	let capturedRequest: CapturedRequest | null = null;
+	let capturedRequests: CapturedRequest[] = [];
 
 	function makeSearchParams(query: string, fetch?: FetchImpl): SearchParams {
 		return {
@@ -196,14 +197,22 @@ describe("searchCodex model selection", () => {
 		};
 	}
 
+	function captureCodexRequest(url: string | URL | Request, init: RequestInit | undefined): CapturedRequest {
+		const request = {
+			url: typeof url === "string" ? url : url.toString(),
+			headers: init?.headers,
+			body: init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null,
+		};
+		capturedRequest = request;
+		capturedRequests.push(request);
+		return request;
+	}
+
 	function mockCodexFetch(responseModel: string, responseBody?: string): FetchImpl {
 		capturedRequest = null;
+		capturedRequests = [];
 		return (url, init) => {
-			capturedRequest = {
-				url: typeof url === "string" ? url : url.toString(),
-				headers: init?.headers,
-				body: init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null,
-			};
+			captureCodexRequest(url, init);
 			return Promise.resolve(
 				new Response(responseBody ?? makeSseResponse(responseModel), {
 					status: 200,
@@ -216,6 +225,7 @@ describe("searchCodex model selection", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 		capturedRequest = null;
+		capturedRequests = [];
 		if (originalCodexSearchModel === undefined) {
 			delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
 		} else {
@@ -223,54 +233,52 @@ describe("searchCodex model selection", () => {
 		}
 	});
 
-	it("uses the built-in default model when PI_CODEX_WEB_SEARCH_MODEL is unset", async () => {
+	it("starts the built-in default model preference with gpt-5.6-luna", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
-		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.5")));
+		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.6-luna")));
 
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
-		expect(result.model).toBe("gpt-5.5");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
+		expect(result.model).toBe("gpt-5.6-luna");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
-		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.5")));
+		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.6-luna")));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
-		expect(result.model).toBe("gpt-5.5");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
+		expect(result.model).toBe("gpt-5.6-luna");
 	});
 
 	it("retries the next bundled default when Codex rejects a model for ChatGPT accounts", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
 		let calls = 0;
 		capturedRequest = null;
+		capturedRequests = [];
 		const fetchMock: FetchImpl = (url, init) => {
 			calls += 1;
-			capturedRequest = {
-				url: typeof url === "string" ? url : url.toString(),
-				headers: init?.headers,
-				body: init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null,
-			};
+			const request = captureCodexRequest(url, init);
 
-			const requestedModel = capturedRequest.body?.model;
+			const requestedModel = request.body?.model;
+
 			if (calls === 1) {
-				expect(requestedModel).toBe("gpt-5.5");
+				expect(requestedModel).toBe("gpt-5.6-luna");
 				return Promise.resolve(
 					new Response(
 						JSON.stringify({
-							detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+							detail: "The 'gpt-5.6-luna' model is not supported when using Codex with a ChatGPT account.",
 						}),
 						{ status: 400, headers: { "Content-Type": "application/json" } },
 					),
 				);
 			}
 
-			expect(requestedModel).toBe("gpt-5.4");
+			expect(requestedModel).toBe("gpt-5.6-terra");
 			return Promise.resolve(
-				new Response(makeSseResponse("gpt-5.4"), {
+				new Response(makeSseResponse("gpt-5.6-terra"), {
 					status: 200,
 					headers: { "Content-Type": "text/event-stream" },
 				}),
@@ -280,54 +288,129 @@ describe("searchCodex model selection", () => {
 		const result = await searchCodex(makeSearchParams("retry unsupported default", fetchMock));
 
 		expect(calls).toBe(2);
-		expect(result.model).toBe("gpt-5.4");
+		expect(capturedRequests.map(request => request.body?.model)).toEqual(["gpt-5.6-luna", "gpt-5.6-terra"]);
+		expect(result.model).toBe("gpt-5.6-terra");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
-	it("uses PI_CODEX_WEB_SEARCH_MODEL when provided", async () => {
-		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4-mini";
-		const result = await searchCodex(makeSearchParams("overridden codex model", mockCodexFetch("gpt-5.4-mini")));
+	it("encodes explicit gpt-5.6-luna as a Responses-Lite Codex request", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-luna";
+		const result = await searchCodex(makeSearchParams("lite codex model", mockCodexFetch("gpt-5.6-luna")));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.4-mini");
-		expect(result.model).toBe("gpt-5.4-mini");
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
+		expect(headers.get("session-id")).toBeTruthy();
+		expect(headers.get("thread-id")).toBeTruthy();
+		expect(headers.get("x-codex-window-id")).toBeTruthy();
+		const turnMetadata = JSON.parse(headers.get("x-codex-turn-metadata") ?? "{}") as Record<string, unknown>;
+		expect(turnMetadata.request_kind).toBe("turn");
+		expect(turnMetadata.session_id).toBe(headers.get("session-id"));
+		expect(turnMetadata.thread_id).toBe(headers.get("thread-id"));
+		expect(turnMetadata.window_id).toBe(headers.get("x-codex-window-id"));
+
+		const body = capturedRequest?.body;
+		expect(body?.model).toBe("gpt-5.6-luna");
+		expect(body?.tools).toBeUndefined();
+		expect(body?.tool_choice).toBeUndefined();
+		expect(body?.instructions).toBeUndefined();
+		expect(body?.reasoning).toEqual({ context: "all_turns" });
+		expect(body?.parallel_tool_calls).toBe(false);
+		expect(body?.input).toEqual([
+			{
+				type: "additional_tools",
+				role: "developer",
+				tools: [{ type: "web_search", search_context_size: "high" }],
+			},
+			{
+				type: "message",
+				role: "developer",
+				content: [{ type: "input_text", text: "Codex test system prompt" }],
+			},
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: "lite codex model" }],
+			},
+		]);
+		expect(body?.client_metadata).toEqual(
+			expect.objectContaining({
+				session_id: headers.get("session-id"),
+				thread_id: headers.get("thread-id"),
+				"x-codex-window-id": headers.get("x-codex-window-id"),
+				"x-codex-turn-metadata": headers.get("x-codex-turn-metadata"),
+			}),
+		);
+		expect(result.model).toBe("gpt-5.6-luna");
+	});
+
+	it("applies a supported reasoning effort suffix to Responses-Lite requests", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-luna:max";
+		await searchCodex(makeSearchParams("lite codex effort", mockCodexFetch("gpt-5.6-luna")));
+
+		expect(capturedRequest?.body?.reasoning).toEqual({ effort: "max", context: "all_turns" });
+	});
+
+	it("rejects unsupported reasoning effort suffixes before calling Codex", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-luna:minimal";
+		let calls = 0;
+		const fetchMock: FetchImpl = () => {
+			calls += 1;
+			return Promise.resolve(new Response(makeSseResponse("gpt-5.6-luna")));
+		};
+
+		await expect(searchCodex(makeSearchParams("unsupported lite effort", fetchMock))).rejects.toThrow(
+			/Thinking effort minimal is not supported/,
+		);
+		expect(calls).toBe(0);
 	});
 
 	it("does not retry default candidates when PI_CODEX_WEB_SEARCH_MODEL is explicitly unsupported", async () => {
-		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.5";
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-luna";
 		let calls = 0;
 		capturedRequest = null;
+		capturedRequests = [];
 		const fetchMock: FetchImpl = (url, init) => {
 			calls += 1;
-			capturedRequest = {
-				url: typeof url === "string" ? url : url.toString(),
-				headers: init?.headers,
-				body: init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null,
-			};
+			const request = captureCodexRequest(url, init);
 
-			expect(capturedRequest.body?.model).toBe("gpt-5.5");
+			expect(request.body?.model).toBe("gpt-5.6-luna");
 			return Promise.resolve(
 				new Response(
 					JSON.stringify({
-						detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+						detail: "The 'gpt-5.6-luna' model is not supported when using Codex with a ChatGPT account.",
 					}),
 					{ status: 400, headers: { "Content-Type": "application/json" } },
 				),
 			);
 		};
 
-		await expect(searchCodex(makeSearchParams("explicit unsupported model", fetchMock))).rejects.toThrow("gpt-5.5");
+		await expect(searchCodex(makeSearchParams("explicit unsupported model", fetchMock))).rejects.toThrow(
+			"gpt-5.6-luna",
+		);
 		expect(calls).toBe(1);
+		expect(capturedRequests.map(request => request.body?.model)).toEqual(["gpt-5.6-luna"]);
 	});
 
-	it("forces web_search tool choice and extracts markdown link citations when annotations are absent", async () => {
+	it("keeps classic gpt-5.4 request shape while extracting markdown link citations", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
 		const result = await searchCodex(
 			makeSearchParams("markdown citations", mockCodexFetch("gpt-5.4", makeMarkdownLinkSseResponse("gpt-5.4"))),
 		);
 
 		expect(capturedRequest).not.toBeNull();
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("x-openai-internal-codex-responses-lite")).toBeNull();
+		expect(capturedRequest?.body?.instructions).toBe("Codex test system prompt");
+		expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search", search_context_size: "high" }]);
 		expect(capturedRequest?.body?.tool_choice).toEqual({ type: "web_search" });
+		expect(capturedRequest?.body?.input).toEqual([
+			{
+				type: "message",
+				role: "user",
+				content: [{ type: "input_text", text: "markdown citations" }],
+			},
+		]);
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 


### PR DESCRIPTION
## Repro
With `PI_CODEX_WEB_SEARCH_MODEL=gpt-5.6-luna`, a mocked `searchCodex` call against `packages/coding-agent/src/web/search/providers/codex.ts` captured a `/backend-api/codex/responses` request that still had top-level `tools`, `tool_choice`, and `instructions`, began `input` with the user message, and omitted `x-openai-internal-codex-responses-lite: true`. The default model preference chain also started at `gpt-5.5`, so default Codex web search never tried Luna, Terra, or Sol first.

## Cause
`packages/coding-agent/src/web/search/providers/codex.ts` hard-coded `DEFAULT_MODEL_PREFERENCES` to GPT-5.5-and-older models and built one classic Responses request body in `callCodexSearch` for every model. The provider never consulted bundled Codex model metadata, so `useResponsesLite: true` on the GPT-5.6 catalog entries could not affect request encoding.

## Fix
- Added GPT-5.6 Luna, Terra, and Sol to the Codex web-search default preference chain before GPT-5.5.
- Resolved bundled Codex model metadata for default and explicit `PI_CODEX_WEB_SEARCH_MODEL` requests, including validated `<model>:<effort>` suffixes.
- Switched only `useResponsesLite` models to developer `additional_tools`, developer instructions, Responses-Lite headers, Codex compatibility metadata, and `reasoning.context=all_turns`; classic models keep the existing top-level `tools`, `tool_choice`, and `instructions` shape.
- Added focused regression coverage for GPT-5.6 default ordering, default fallback, explicit override behavior, Responses-Lite encoding, effort suffixes, and classic GPT-5.4 shape preservation.
- Added a `packages/coding-agent/CHANGELOG.md` entry for the fix.

## Verification
`bun test packages/coding-agent/test/tools/web-search-codex.test.ts` passed: 14 pass, 0 fail, 54 expect() calls. `bun run check:ts` passed across the TypeScript workspaces. `bun check` fails on `main` for an unrelated Rust formatting diff in `crates/pi-ast/src/ops.rs`; `git diff --name-only origin/main..HEAD -- crates/pi-ast/src/ops.rs` is empty, so the pre-publish gate was skipped. Fixes #5286