### PR TITLE
fix(coding-agent): resolve thinking level overrides in temporary model switcher

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed the temporary model selector (`Alt+P` / `/switch` / `/model --temporary`) ignoring custom role-specific thinking level overrides from `config.yml` (e.g. `:high`), reverting to the model's native default level instead
 - Improved search reliability for Perplexity provider by forcing retrieval for all queries
 - Fixed JS eval cells losing top-level `function` and `var` declarations across cells when the defining cell contained top-level `await` — the async wrapper scoped them to the cell's IIFE instead of publishing them to the worker global
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -18,7 +18,7 @@ import {
 	resolveAdvisorRoleSelection,
 	resolveModelRoleValue,
 } from "../../config/model-resolver";
-import { getRoleInfo, MODEL_ROLE_IDS } from "../../config/model-roles";
+import { getRoleInfo } from "../../config/model-roles";
 import { settings } from "../../config/settings";
 import { disableProvider, enableProvider } from "../../discovery";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -698,9 +698,7 @@ export class SelectorController {
 						const matchPreferences = getModelMatchPreferences(this.ctx.settings);
 						let resolvedThinkingLevel: ConfiguredThinkingLevel | undefined;
 
-						for (const role of MODEL_ROLE_IDS) {
-							const roleModelStr = this.ctx.settings.getModelRole(role);
-							if (!roleModelStr) continue;
+						for (const [, roleModelStr] of Object.entries(this.ctx.settings.getModelRoles())) {
 							const resolved = resolveModelRoleValue(roleModelStr, availableModels, {
 								settings: this.ctx.settings,
 								matchPreferences,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -12,8 +12,13 @@ import {
 	resolveAdvisorConfigEditPath,
 	saveWatchdogConfigFile,
 } from "../../advisor";
-import { formatModelSelectorValue, resolveAdvisorRoleSelection } from "../../config/model-resolver";
-import { getRoleInfo } from "../../config/model-roles";
+import {
+	formatModelSelectorValue,
+	getModelMatchPreferences,
+	resolveAdvisorRoleSelection,
+	resolveModelRoleValue,
+} from "../../config/model-resolver";
+import { getRoleInfo, MODEL_ROLE_IDS } from "../../config/model-roles";
 import { settings } from "../../config/settings";
 import { disableProvider, enableProvider } from "../../discovery";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -688,8 +693,32 @@ export class SelectorController {
 				},
 				onPick: async (model, selector) => {
 					try {
+						// Resolve configured thinking level from settings roles if it matches this model
+						const availableModels = this.ctx.session.modelRegistry.getAvailable();
+						const matchPreferences = getModelMatchPreferences(this.ctx.settings);
+						let resolvedThinkingLevel: ConfiguredThinkingLevel | undefined;
+
+						for (const role of MODEL_ROLE_IDS) {
+							const roleModelStr = this.ctx.settings.getModelRole(role);
+							if (!roleModelStr) continue;
+							const resolved = resolveModelRoleValue(roleModelStr, availableModels, {
+								settings: this.ctx.settings,
+								matchPreferences,
+							});
+							if (
+								resolved.model &&
+								resolved.model.provider === model.provider &&
+								resolved.model.id === model.id
+							) {
+								if (resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined) {
+									resolvedThinkingLevel = resolved.thinkingLevel;
+									break;
+								}
+							}
+						}
+
 						// Session-only: update agent state but don't persist the model to settings.
-						await this.ctx.session.setModelTemporary(model);
+						await this.ctx.session.setModelTemporary(model, resolvedThinkingLevel);
 						this.ctx.statusLine.invalidate();
 						this.ctx.updateEditorBorderColor();
 						const roleSelectorHint = this.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";


### PR DESCRIPTION
## What

- Resolves configured thinking level overrides from `config.yml` when picking a model temporarily (e.g. `Alt+P` or `/switch`).
- Gracefully handles missing `docs/` directory in `generate-docs-index.ts` so the build/bundle works outside the monorepo context.

## Why

Fixes #5290. When switching a model temporarily via `Alt+P` or `/switch`, the switcher immediately sets the session model to its native default reasoning level (e.g., `medium` for `google-antigravity/gemini-3.5-flash`), completely ignoring custom role-specific thinking level overrides defined in `config.yml` (e.g. `smol: google-antigravity/gemini-3.5-flash:high` or `tiny: google-antigravity/gemini-3.5-flash:high`). 

With this change, the switcher looks up your role configurations in `config.yml` to see if a custom thinking level (like `:high`) is configured for the selected model, and applies it.

## Testing

- Verified resolution behavior against mock configurations.
- Verified that `bun run check:types` and Biome checks pass cleanly.
- Updated `packages/coding-agent/CHANGELOG.md`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)