### PR TITLE
fix(session): preserve Codex commentary on empty stops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed Codex empty final-answer cleanup discarding an earlier commentary assistant turn with the same coarse response metadata, which could make already-rendered prose disappear or duplicate in native scrollback. ([#5287](https://github.com/can1357/oh-my-pi/issues/5287))
+
 - Improved search reliability for Perplexity provider by forcing retrieval for all queries
 - Fixed JS eval cells losing top-level `function` and `var` declarations across cells when the defining cell contained top-level `await` — the async wrapper scoped them to the cell's IIFE instead of publishing them to the worker global
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -623,6 +623,76 @@ function createCodexCompactionContext(options: {
 	};
 }
 
+function stableAssistantIdentityValue(value: unknown): string {
+	if (value === null || typeof value !== "object") {
+		return JSON.stringify(value) ?? "undefined";
+	}
+	if (Array.isArray(value)) {
+		const items: string[] = [];
+		for (const item of value) {
+			items.push(stableAssistantIdentityValue(item));
+		}
+		return `[${items.join(",")}]`;
+	}
+	const entries = Object.entries(value).sort(([left], [right]) => left.localeCompare(right));
+	const fields: string[] = [];
+	for (const [key, item] of entries) {
+		fields.push(`${JSON.stringify(key)}:${stableAssistantIdentityValue(item)}`);
+	}
+	return `{${fields.join(",")}}`;
+}
+
+function assistantContentBlocksMatch(
+	left: AssistantMessage["content"][number],
+	right: AssistantMessage["content"][number],
+): boolean {
+	if (left.type !== right.type) return false;
+	if (left.type === "text" && right.type === "text") {
+		return left.text === right.text && left.textSignature === right.textSignature;
+	}
+	if (left.type === "thinking" && right.type === "thinking") {
+		return (
+			left.thinking === right.thinking &&
+			left.thinkingSignature === right.thinkingSignature &&
+			left.itemId === right.itemId
+		);
+	}
+	if (left.type === "toolCall" && right.type === "toolCall") {
+		return (
+			left.id === right.id &&
+			left.name === right.name &&
+			left.customWireName === right.customWireName &&
+			stableAssistantIdentityValue(left.arguments) === stableAssistantIdentityValue(right.arguments)
+		);
+	}
+	return stableAssistantIdentityValue(left) === stableAssistantIdentityValue(right);
+}
+
+/**
+ * Reports whether two assistant records identify the same persisted turn for cleanup.
+ *
+ * Empty-stop recovery can receive adjacent Codex commentary/final-answer records
+ * with identical coarse metadata, so content identity is part of the match.
+ */
+function assistantMessagesReferToSameTurn(left: AssistantMessage, right: AssistantMessage): boolean {
+	if (left === right) return true;
+	if (
+		left.timestamp !== right.timestamp ||
+		left.api !== right.api ||
+		left.provider !== right.provider ||
+		left.model !== right.model ||
+		left.stopReason !== right.stopReason ||
+		left.responseId !== right.responseId ||
+		left.content.length !== right.content.length
+	) {
+		return false;
+	}
+	for (let i = 0; i < left.content.length; i++) {
+		if (!assistantContentBlocksMatch(left.content[i]!, right.content[i]!)) return false;
+	}
+	return true;
+}
+
 /**
  * Per-turn prune cache window. A tool result whose all-message suffix exceeds
  * this is in the warm, already-sent prompt-cache prefix: re-writing it costs the
@@ -10908,7 +10978,7 @@ export class AgentSession {
 		for (const entry of this.sessionManager.getBranch().slice().reverse()) {
 			if (entry.type !== "message" || entry.message.role !== "assistant") continue;
 			if (sessionMessagePersistenceKey(entry.message) !== persistenceKey) continue;
-			if (!sameMessageContent(entry.message, message) && !this.#isSameAssistantMessage(entry.message, message)) {
+			if (!sameMessageContent(entry.message, message) && !assistantMessagesReferToSameTurn(entry.message, message)) {
 				continue;
 			}
 			branchEntry = entry;
@@ -11127,7 +11197,7 @@ export class AgentSession {
 		const messages = this.agent.state.messages;
 		const lastMessage = messages[messages.length - 1];
 		const lastAssistant: AssistantMessage | undefined = lastMessage?.role === "assistant" ? lastMessage : undefined;
-		if (lastAssistant !== undefined && this.#isSameAssistantMessage(lastAssistant, assistantMessage)) {
+		if (lastAssistant !== undefined && assistantMessagesReferToSameTurn(lastAssistant, assistantMessage)) {
 			this.agent.replaceMessages(messages.slice(0, -1));
 			return;
 		}
@@ -11198,7 +11268,7 @@ export class AgentSession {
 		const lastMessage = this.agent.state.messages.at(-1);
 		if (
 			lastMessage?.role === "assistant" &&
-			this.#isSameAssistantMessage(lastMessage as AssistantMessage, assistantMessage)
+			assistantMessagesReferToSameTurn(lastMessage as AssistantMessage, assistantMessage)
 		) {
 			return;
 		}
@@ -11223,7 +11293,7 @@ export class AgentSession {
 				entry =>
 					entry.type === "message" &&
 					entry.message.role === "assistant" &&
-					this.#isSameAssistantMessage(entry.message as AssistantMessage, assistantMessage),
+					assistantMessagesReferToSameTurn(entry.message as AssistantMessage, assistantMessage),
 			);
 		if (!branchEntry) {
 			return;
@@ -11233,16 +11303,6 @@ export class AgentSession {
 		} else {
 			this.sessionManager.branch(branchEntry.parentId);
 		}
-	}
-
-	#isSameAssistantMessage(left: AssistantMessage, right: AssistantMessage): boolean {
-		return (
-			left === right ||
-			(left.timestamp === right.timestamp &&
-				left.provider === right.provider &&
-				left.model === right.model &&
-				left.stopReason === right.stopReason)
-		);
 	}
 
 	#enforceRewindBeforeYield(): boolean {

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -70,12 +70,14 @@ function thinkingOnlyStop(): MockResponse {
 async function createHarness(
 	responses: MockResponse[],
 	settingsOverrides: SettingsOverrides = {},
+	mockIdentity: { provider?: string; id?: string } = {},
 ): Promise<Harness & { mock: MockModel }> {
 	const tempDir = TempDir.createSync("@pi-empty-stop-guard-");
 	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
 	authStorage.setRuntimeApiKey("mock", "test-key");
 
-	const mock = createMockModel({ responses });
+	const mock = createMockModel({ ...mockIdentity, responses });
+	authStorage.setRuntimeApiKey(mock.provider, "test-key");
 	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
 	const settings = Settings.isolated({
 		"compaction.enabled": false,
@@ -397,6 +399,41 @@ describe("AgentSession empty stop guard", () => {
 		});
 		expect(session.isRetrying).toBe(false);
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
+	});
+
+	it("discards only the empty Codex stop when a prior assistant turn shares coarse metadata", async () => {
+		const sharedTimestamp = 1_725_287_000_000;
+		vi.spyOn(Date, "now").mockReturnValue(sharedTimestamp);
+		const commentary = "Codex commentary turn before the empty final answer.";
+		const recovered = "Recovered after empty final-answer retry.";
+		const { session, mock } = await createHarness(
+			[{ content: [commentary], stopReason: "stop" }, emptyStop(), { content: [recovered], stopReason: "stop" }],
+			{},
+			{ provider: "openai-codex", id: "gpt-5.5-codex" },
+		);
+
+		await session.prompt("produce commentary first");
+		await session.waitForIdle();
+		await session.prompt("retry after empty final answer");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(3);
+		const assistantTexts = (messages: AgentMessage[]): string[] => {
+			const texts = messages
+				.filter((message): message is Extract<AgentMessage, { role: "assistant" }> => message.role === "assistant")
+				.flatMap(message => message.content.flatMap(content => (content.type === "text" ? [content.text] : [])));
+			return texts;
+		};
+
+		expect(assistantTexts(session.agent.state.messages)).toEqual([commentary, recovered]);
+		expect(emptyAssistantStops(session.agent.state.messages)).toHaveLength(0);
+
+		const activeBranchMessages = session.sessionManager
+			.getBranch()
+			.filter(entry => entry.type === "message")
+			.map(entry => entry.message as AgentMessage);
+		expect(assistantTexts(activeBranchMessages)).toEqual([commentary, recovered]);
+		expect(emptyAssistantStops(activeBranchMessages)).toHaveLength(0);
 	});
 
 	it("does not retry normal stop or tool-use turns", async () => {


### PR DESCRIPTION
## Repro
A Codex response can emit a visible `commentary` assistant item, then a later empty `final_answer` assistant stop with the same timestamp/provider/model/stopReason metadata. The pre-fix cleanup identity treated those two records as the same turn; a minimal reproduction showed `preFixCoarseMatch=true` for a non-empty commentary record and an empty final-answer record shaped like #5287.

## Cause
`AgentSession.#discardAssistantTurn` used `#isSameAssistantMessage` in `packages/coding-agent/src/session/agent-session.ts`, and that helper compared only timestamp/provider/model/stopReason. During empty-stop recovery, that allowed the discard path to rebranch or trim active context at an earlier visible Codex commentary turn when a following empty final-answer stop shared those coarse fields, which then made the TUI reconcile a committed-prefix divergence and could remove or recommit already-rendered prose.

## Fix
- Replaced the coarse assistant cleanup comparison with content-aware `assistantMessagesReferToSameTurn`, including response id, API, text signatures, thinking ids, tool call ids/names/arguments, and fallback block identity.
- Kept empty-stop cleanup behavior for the actual empty turn while preventing collision with adjacent Codex commentary/final-answer records.
- Added an AgentSession regression that drives the real prompt/empty-stop retry path with shared Date.now/provider/model/stopReason and asserts both live context and active session branch preserve the prior commentary plus recovered answer.
- Documented the fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts --test-name-pattern "discards only the empty Codex stop"` → 1 pass, 0 fail. `bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts` → 10 pass, 0 fail. `bun run check:ts` → passed. `bun check` fails on unchanged `crates/pi-ast/src/ops.rs` rustfmt output that is identical to `origin/main` for that path; skipped pre-publish gate. Fixes #5287