### PR TITLE
fix(coding-agent): respect role thinking for temporary model picks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improved search reliability for Perplexity provider by forcing retrieval for all queries
 - Fixed JS eval cells losing top-level `function` and `var` declarations across cells when the defining cell contained top-level `await` — the async wrapper scoped them to the cell's IIFE instead of publishing them to the worker global
+- Fixed temporary model picks (`Alt+P`, `/switch`, `/model --temporary`) ignoring explicit thinking suffixes from matching configured model roles. ([#5290](https://github.com/can1357/oh-my-pi/issues/5290))
 
 ## [16.4.7] - 2026-07-12
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -688,8 +688,8 @@ export class SelectorController {
 				},
 				onPick: async (model, selector) => {
 					try {
-						// Session-only: update agent state but don't persist the model to settings.
-						await this.ctx.session.setModelTemporary(model);
+						const roleThinkingLevel = this.ctx.session.resolveTemporaryModelThinkingLevel(model);
+						await this.ctx.session.setModelTemporary(model, roleThinkingLevel);
 						this.ctx.statusLine.invalidate();
 						this.ctx.updateEditorBorderColor();
 						const roleSelectorHint = this.ctx.keybindings.getKeys("app.model.select")[0] ?? "Alt+M";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -182,7 +182,7 @@ import {
 	resolveModelOverride,
 	resolveModelRoleValue,
 } from "../config/model-resolver";
-import { MODEL_ROLE_IDS, MODEL_ROLES } from "../config/model-roles";
+import { getKnownRoleIds, MODEL_ROLE_IDS, MODEL_ROLES } from "../config/model-roles";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily, serviceTierForAllFamilies, serviceTierSettingToTier } from "../config/service-tier";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -7319,6 +7319,30 @@ export class AgentSession {
 	 */
 	resolveRoleModelWithThinking(role: string): ResolvedModelRoleValue {
 		return this.#resolveRoleModelFull(role, this.#modelRegistry.getAvailable(), this.model);
+	}
+
+	/**
+	 * Resolve the explicit thinking suffix that should apply when a temporary
+	 * picker selects a model already assigned to a configured role.
+	 */
+	resolveTemporaryModelThinkingLevel(model: Model): ConfiguredThinkingLevel | undefined {
+		const availableModels = this.#modelRegistry.getAvailable();
+		if (availableModels.length === 0) return undefined;
+
+		const matchPreferences = getModelMatchPreferences(this.settings);
+		for (const role of getKnownRoleIds(this.settings)) {
+			const roleValue = this.settings.getModelRole(role);
+			if (!roleValue) continue;
+
+			const resolved = resolveModelRoleValue(roleValue, availableModels, {
+				settings: this.settings,
+				matchPreferences,
+			});
+			if (!resolved.explicitThinkingLevel || resolved.thinkingLevel === undefined || !resolved.model) continue;
+			if (modelsAreEqual(resolved.model, model)) return resolved.thinkingLevel;
+		}
+
+		return undefined;
 	}
 
 	get promptTemplates(): ReadonlyArray<PromptTemplate> {

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -48,6 +48,7 @@ describe("AgentSession role model thinking behavior", () => {
 		initialModelId: string;
 		initialThinkingLevel: Effort;
 		modelRoles: Record<string, string>;
+		runtimeApiKeys?: Record<string, string>;
 	}) {
 		const model = getAnthropicModelOrThrow(options.initialModelId);
 		const agent = new Agent({
@@ -62,6 +63,10 @@ describe("AgentSession role model thinking behavior", () => {
 		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
 		authStorages.push(authStorage);
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const runtimeApiKeys = options.runtimeApiKeys ?? {};
+		for (const provider in runtimeApiKeys) {
+			authStorage.setRuntimeApiKey(provider, runtimeApiKeys[provider]);
+		}
 		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
 
 		sessionSettings = Settings.isolated();
@@ -615,6 +620,34 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBeUndefined();
 		expect(session.agent.state.thinkingLevel).toBeUndefined();
 		expect(session.autoResolvedThinkingLevel()).toBeUndefined();
+	});
+
+	it("applies matching role thinking to temporary model picks", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const temporaryModel = getBundledModel("google-antigravity", "gemini-3.5-flash");
+		if (!temporaryModel) throw new Error("Expected google-antigravity model gemini-3.5-flash to exist");
+
+		await createSession({
+			initialModelId: defaultModel.id,
+			initialThinkingLevel: Effort.Low,
+			modelRoles: {
+				smol: `${temporaryModel.provider}/${temporaryModel.id}:high`,
+			},
+			runtimeApiKeys: {
+				[temporaryModel.provider]: "test-key",
+			},
+		});
+
+		const roleResolved = session.resolveRoleModelWithThinking("smol");
+		expect(roleResolved.model?.id).toBe(temporaryModel.id);
+		expect(roleResolved.thinkingLevel).toBe(Effort.High);
+
+		const roleThinkingLevel = session.resolveTemporaryModelThinkingLevel(temporaryModel);
+		await session.setModelTemporary(temporaryModel, roleThinkingLevel);
+
+		expect(session.model?.provider).toBe(temporaryModel.provider);
+		expect(session.model?.id).toBe(temporaryModel.id);
+		expect(session.thinkingLevel).toBe(Effort.High);
 	});
 
 	it("ignores a stale recorded role and cycles from the active model", async () => {


### PR DESCRIPTION
## Repro
A focused session repro configured `modelRoles.smol = google-antigravity/gemini-3.5-flash:high`, verified the role resolver returned `high`, then called `setModelTemporary(selectedModel)` as the temporary picker did. Before the fix, `bun test tmp-repro-5290.test.ts` failed with `Expected: "high"; Received: undefined` for `session.thinkingLevel`.

## Cause
`packages/coding-agent/src/modes/controllers/selector-controller.ts` handled the Model Hub `onPick` callback by calling `session.setModelTemporary(model)` without resolving explicit thinking metadata from configured roles. `AgentSession.setModelTemporary()` only applies a thinking level when its caller passes one, so the temporary picker bypassed the same role-thinking resolution used by role cycling in `AgentSession.getRoleModelCycle()` / `applyRoleModel()`.

## Fix
- Added `AgentSession.resolveTemporaryModelThinkingLevel()` to scan configured model roles, resolve their model selectors with existing match preferences, and return the explicit thinking suffix when a temporary pick matches that role's resolved model.
- Updated the temporary Model Hub picker (`Alt+P`, `/switch`, `/model --temporary`) to pass that resolved thinking level into `setModelTemporary()` while keeping the switch session-only.
- Added regression coverage for `google-antigravity/gemini-3.5-flash:high` so temporary picks apply the role override instead of falling back to the model/default thinking state.
- Updated the coding-agent changelog under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/agent-session-role-thinking.test.ts -t temporary` passed with 1 test, 5 assertions. `bun test packages/coding-agent/test/agent-session-role-thinking.test.ts` passed with 20 tests, 112 assertions. `bun run check` in `packages/coding-agent` passed. Fixes #5290