### PR TITLE
Handle uninitialized Mnemopi memory tools

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3026,23 +3026,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 		};
 
-		// Auto-learn can immediately trigger a synthetic capture turn after the
-		// first real stop. When a memory backend is selected, install that backend's
-		// per-session state first so the capture turn's `learn` tool observes the
-		// same initialized state as normal memory tools. Other sessions keep memory
-		// startup in the background to preserve the existing startup profile.
-		//
-		// Gated on `autolearn.enabled` to match the tools: `createTools` builds the
-		// `learn`/`manage_skill` registry ONCE at session start and no settings
-		// change rebuilds it, so installing the controller while disabled would let a
-		// mid-session enable fire a nudge pointing at tools the session never built.
-		// Activation is therefore a session-start decision for BOTH the controller
-		// and the tools; the fire-time re-check in `#onAgentEnd` still handles a
-		// mid-session DISABLE. The subscription lives for the session's lifetime; the
-		// reference is intentionally discarded (the listener retains it).
-		if (settings.get("autolearn.enabled") && taskDepth === 0) {
+		// Memory tools are exposed from `memory.backend` at tool-build time, so the
+		// selected backend's per-session state must exist before the first model turn
+		// can call `recall` / `retain` / `reflect`. Auto-learn also needs this for
+		// its synthetic capture turn. Subagents inherit parent memory state when one
+		// exists; keeping their startup non-blocking preserves the existing spawn path.
+		const shouldAwaitMemoryStartup =
+			taskDepth === 0 &&
+			(settings.get("autolearn.enabled") || ["hindsight", "mnemopi"].includes(settings.get("memory.backend") ?? ""));
+		if (shouldAwaitMemoryStartup) {
 			await logger.time("startMemoryStartupTask", startMemoryBackend);
-			new AutoLearnController({ session, settings });
+			if (settings.get("autolearn.enabled")) new AutoLearnController({ session, settings });
 		} else {
 			void logger.time("startMemoryStartupTask", startMemoryBackend);
 		}

--- a/packages/coding-agent/src/tools/learn.ts
+++ b/packages/coding-agent/src/tools/learn.ts
@@ -55,7 +55,17 @@ export class LearnTool implements AgentTool<typeof learnSchema> {
 		if (backend === "mnemopi") {
 			const state = this.session.getMnemopiSessionState?.();
 			if (!state) {
-				throw new Error("Mnemopi backend is not initialised for this session.");
+				const suffix = params.skill ? " and managed skill was not changed" : "";
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Mnemopi memory is configured but not initialised for this session; lesson was not stored${suffix}.`,
+						},
+					],
+					details: { backend: "mnemopi", initialized: false, stored: 0, skill: null },
+					useless: true,
+				};
 			}
 			const id = state.rememberScoped(params.memory, {
 				source: "coding-agent-learn",

--- a/packages/coding-agent/src/tools/memory-edit.ts
+++ b/packages/coding-agent/src/tools/memory-edit.ts
@@ -34,7 +34,16 @@ export class MemoryEditTool implements AgentTool<typeof memoryEditSchema> {
 	async execute(_id: string, params: MemoryEditParams): Promise<AgentToolResult> {
 		const state = this.session.getMnemopiSessionState?.();
 		if (!state) {
-			throw new Error("Mnemopi backend is not initialised for this session.");
+			return {
+				content: [
+					{
+						type: "text",
+						text: "Mnemopi memory is configured but not initialised for this session; no memory edit was applied.",
+					},
+				],
+				details: { backend: "mnemopi", initialized: false, op: params.op, id: params.id, applied: false },
+				useless: true,
+			};
 		}
 		if (params.op === "update" && params.content === undefined && params.importance === undefined) {
 			throw new Error("memory_edit update requires content or importance.");

--- a/packages/coding-agent/src/tools/memory-recall.ts
+++ b/packages/coding-agent/src/tools/memory-recall.ts
@@ -35,7 +35,16 @@ export class MemoryRecallTool implements AgentTool<typeof memoryRecallSchema> {
 			if (backend === "mnemopi") {
 				const state = this.session.getMnemopiSessionState?.();
 				if (!state) {
-					throw new Error("Mnemopi backend is not initialised for this session.");
+					return {
+						content: [
+							{
+								type: "text",
+								text: "Mnemopi memory is configured but not initialised for this session; no memories were recalled.",
+							},
+						],
+						details: { backend: "mnemopi", initialized: false },
+						useless: true,
+					};
 				}
 				try {
 					const results = await state.recallResultsScoped(params.query);

--- a/packages/coding-agent/src/tools/memory-reflect.ts
+++ b/packages/coding-agent/src/tools/memory-reflect.ts
@@ -36,7 +36,16 @@ export class MemoryReflectTool implements AgentTool<typeof memoryReflectSchema> 
 			if (backend === "mnemopi") {
 				const state = this.session.getMnemopiSessionState?.();
 				if (!state) {
-					throw new Error("Mnemopi backend is not initialised for this session.");
+					return {
+						content: [
+							{
+								type: "text",
+								text: "Mnemopi memory is configured but not initialised for this session; no information was available to reflect on.",
+							},
+						],
+						details: { backend: "mnemopi", initialized: false },
+						useless: true,
+					};
 				}
 
 				try {

--- a/packages/coding-agent/src/tools/memory-retain.ts
+++ b/packages/coding-agent/src/tools/memory-retain.ts
@@ -37,7 +37,16 @@ export class MemoryRetainTool implements AgentTool<typeof memoryRetainSchema> {
 		if (backend === "mnemopi") {
 			const state = this.session.getMnemopiSessionState?.();
 			if (!state) {
-				throw new Error("Mnemopi backend is not initialised for this session.");
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Mnemopi memory is configured but not initialised for this session; no memories were stored.",
+						},
+					],
+					details: { backend: "mnemopi", initialized: false, requested: params.items.length, count: 0, stored: 0 },
+					useless: true,
+				};
 			}
 
 			for (const item of params.items) {

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -25,6 +25,7 @@ import {
 	setMnemopiSessionState,
 } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
+import { LearnTool } from "@oh-my-pi/pi-coding-agent/tools/learn";
 import { MemoryEditTool } from "@oh-my-pi/pi-coding-agent/tools/memory-edit";
 import { MemoryRecallTool } from "@oh-my-pi/pi-coding-agent/tools/memory-recall";
 import { MemoryReflectTool } from "@oh-my-pi/pi-coding-agent/tools/memory-reflect";
@@ -418,12 +419,21 @@ describe("retain.execute (Mnemopi backend)", () => {
 		});
 		expect((alphaRecall.content[0] as { text: string }).text).toContain("alpha uses tabs");
 	});
-	it("throws when no per-session Mnemopi state is registered", async () => {
+	it("returns an explicit no-op when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
 		const tool = MemoryRetainTool.createIf(makeSession(settings))!;
-		await expect(tool.execute("call-mnemopi-no-state", { items: [{ content: "x" }] })).rejects.toThrow(
-			/not initialised/i,
-		);
+		const result = await tool.execute("call-mnemopi-no-state", { items: [{ content: "x" }] });
+
+		expect(result).toMatchObject({
+			content: [
+				{
+					type: "text",
+					text: "Mnemopi memory is configured but not initialised for this session; no memories were stored.",
+				},
+			],
+			details: { backend: "mnemopi", initialized: false, requested: 1, count: 0, stored: 0 },
+			useless: true,
+		});
 	});
 });
 
@@ -1075,10 +1085,21 @@ describe("recall.execute (Mnemopi backend)", () => {
 		expect(text).not.toContain("project beta deploys to staging first");
 	});
 
-	it("throws when no per-session Mnemopi state is registered", async () => {
+	it("returns an explicit no-op when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
 		const tool = MemoryRecallTool.createIf(makeSession(settings))!;
-		await expect(tool.execute("call-mnemopi-no-state", { query: "anything" })).rejects.toThrow(/not initialised/i);
+		const result = await tool.execute("call-mnemopi-no-state", { query: "anything" });
+
+		expect(result).toMatchObject({
+			content: [
+				{
+					type: "text",
+					text: "Mnemopi memory is configured but not initialised for this session; no memories were recalled.",
+				},
+			],
+			details: { backend: "mnemopi", initialized: false },
+			useless: true,
+		});
 	});
 });
 
@@ -1168,12 +1189,21 @@ describe("memory_edit.execute (Mnemopi backend)", () => {
 		expect((result.content[0] as { text: string }).text).toContain("not found");
 	});
 
-	it("throws when no per-session Mnemopi state is registered", async () => {
+	it("returns an explicit no-op when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
 		const tool = MemoryEditTool.createIf(makeSession(settings))!;
-		await expect(tool.execute("call-memory-edit-no-state", { op: "forget", id: "anything" })).rejects.toThrow(
-			/not initialised/i,
-		);
+		const result = await tool.execute("call-memory-edit-no-state", { op: "forget", id: "anything" });
+
+		expect(result).toMatchObject({
+			content: [
+				{
+					type: "text",
+					text: "Mnemopi memory is configured but not initialised for this session; no memory edit was applied.",
+				},
+			],
+			details: { backend: "mnemopi", initialized: false, op: "forget", id: "anything", applied: false },
+			useless: true,
+		});
 	});
 
 	it("renders backend stats and diagnostics for scoped banks", async () => {
@@ -1343,11 +1373,75 @@ describe("reflect.execute (Mnemopi backend)", () => {
 		expect(text).toContain("project alpha uses turbo for task orchestration");
 	});
 
-	it("throws when no per-session Mnemopi state is registered", async () => {
+	it("returns an explicit no-op when no per-session Mnemopi state is registered", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
 		const tool = MemoryReflectTool.createIf(makeSession(settings))!;
-		await expect(tool.execute("call-mnemopi-reflect-no-state", { query: "anything" })).rejects.toThrow(
-			/not initialised/i,
-		);
+		const result = await tool.execute("call-mnemopi-reflect-no-state", { query: "anything" });
+
+		expect(result).toMatchObject({
+			content: [
+				{
+					type: "text",
+					text: "Mnemopi memory is configured but not initialised for this session; no information was available to reflect on.",
+				},
+			],
+			details: { backend: "mnemopi", initialized: false },
+			useless: true,
+		});
+	});
+});
+
+describe("learn.execute (Mnemopi backend)", () => {
+	beforeEach(() => {
+		resetSettingsForTest();
+		registeredMnemopiState = undefined;
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await registeredMnemopiState?.dispose();
+		registeredMnemopiState = undefined;
+	});
+
+	it("returns an explicit no-op when no per-session Mnemopi state is registered", async () => {
+		const settings = Settings.isolated({ "memory.backend": "mnemopi", "autolearn.enabled": true });
+		const tool = LearnTool.createIf(makeSession(settings))!;
+		const result = await tool.execute("call-learn-no-state", { memory: "store this lesson" });
+
+		expect(result).toMatchObject({
+			content: [
+				{
+					type: "text",
+					text: "Mnemopi memory is configured but not initialised for this session; lesson was not stored.",
+				},
+			],
+			details: { backend: "mnemopi", initialized: false, stored: 0, skill: null },
+			useless: true,
+		});
+	});
+
+	it("does not change managed skills when memory state is missing", async () => {
+		const settings = Settings.isolated({ "memory.backend": "mnemopi", "autolearn.enabled": true });
+		const tool = LearnTool.createIf(makeSession(settings))!;
+		const result = await tool.execute("call-learn-skill-no-state", {
+			memory: "store this lesson",
+			skill: {
+				action: "create",
+				name: "missing-state-skill",
+				description: "unused",
+				body: "unused",
+			},
+		});
+
+		expect(result).toMatchObject({
+			content: [
+				{
+					type: "text",
+					text: "Mnemopi memory is configured but not initialised for this session; lesson was not stored and managed skill was not changed.",
+				},
+			],
+			details: { backend: "mnemopi", initialized: false, stored: 0, skill: null },
+			useless: true,
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- await top-level memory startup whenever a real memory backend is selected so built-in memory tools do not race missing per-session state
- make Mnemopi memory tools return explicit no-op results instead of throwing when session state is unavailable
- add regression coverage for recall, retain, reflect, learn, and memory_edit no-state Mnemopi behavior

## Verification
- `bunx biome check packages/coding-agent/src/sdk.ts packages/coding-agent/src/tools/memory-recall.ts packages/coding-agent/src/tools/memory-retain.ts packages/coding-agent/src/tools/memory-reflect.ts packages/coding-agent/src/tools/learn.ts packages/coding-agent/src/tools/memory-edit.ts packages/coding-agent/test/memory-tools.test.ts`
- `bun run check:types` from `packages/coding-agent`
- `bun test packages/coding-agent/test/memory-tools.test.ts -t 'per-session Mnemopi state'`
- `bun test packages/coding-agent/test/memory-tools.test.ts -t 'managed skills when memory state is missing'`