### PR TITLE
feat(coding-agent): gate generate_image tool behind imagegen.enabled setting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Redesigned Agent Hub entries as two-line cards: identity (status glyph, name, agent type, parent when nested) on the left, active model + reasoning level and age right-aligned, with the task description on its own line; dropped the redundant `sub · of Main` noise
 - Added a project-scoped `launch` tool for shared long-running services and debuggers, with readiness probes, bounded logs, PTY input, restart policies, and automatic teardown after the last omp instance exits. Gated behind the `launch.enabled` setting (default on); when disabled the tool is withdrawn and the bash prompt drops its "use launch" guidance.
 - Added `detached` `launch` starts for standalone services that survive every omp instance and broker shutdown, then reconnect to the next broker for logs and explicit stop.
-- Gated the `generate_image` tool behind a new `imagegen.enabled` setting (default off); when disabled the tool is withdrawn
+- Gated the `generate_image` tool behind a new `imagegen.enabled` setting (default off); toggling it from the Tools settings panel withdraws or restores the tool live, without a session restart
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Redesigned Agent Hub entries as two-line cards: identity (status glyph, name, agent type, parent when nested) on the left, active model + reasoning level and age right-aligned, with the task description on its own line; dropped the redundant `sub · of Main` noise
 - Added a project-scoped `launch` tool for shared long-running services and debuggers, with readiness probes, bounded logs, PTY input, restart policies, and automatic teardown after the last omp instance exits. Gated behind the `launch.enabled` setting (default on); when disabled the tool is withdrawn and the bash prompt drops its "use launch" guidance.
 - Added `detached` `launch` starts for standalone services that survive every omp instance and broker shutdown, then reconnect to the next broker for logs and explicit stop.
-- Gated the `generate_image` tool behind a new `imagegen.enabled` setting (default off); toggling it from the Tools settings panel withdraws or restores the tool live, without a session restart
+- Gated the `generate_image` tool behind a new `imagegen.enabled` setting (default off); toggling it from the Tools settings panel withdraws or restores the tool live, without a session restart. The disabled setting is enforced at the active-tools chokepoint, so it also holds across plan/goal/vibe mode restores and persisted subagent revives
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Redesigned Agent Hub entries as two-line cards: identity (status glyph, name, agent type, parent when nested) on the left, active model + reasoning level and age right-aligned, with the task description on its own line; dropped the redundant `sub · of Main` noise
 - Added a project-scoped `launch` tool for shared long-running services and debuggers, with readiness probes, bounded logs, PTY input, restart policies, and automatic teardown after the last omp instance exits. Gated behind the `launch.enabled` setting (default on); when disabled the tool is withdrawn and the bash prompt drops its "use launch" guidance.
 - Added `detached` `launch` starts for standalone services that survive every omp instance and broker shutdown, then reconnect to the next broker for logs and explicit stop.
+- Gated the `generate_image` tool behind a new `imagegen.enabled` setting (default off); when disabled the tool is withdrawn
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3560,6 +3560,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"imagegen.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			group: "Available Tools",
+			label: "Image Generation",
+			description: "Enable the generate_image tool for text-to-image generation and image editing",
+		},
+	},
+
 	"speechgen.enabled": {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -47,6 +47,7 @@ import {
 } from "../../slash-commands/helpers/reset-usage";
 import { AUTO_THINKING, type ConfiguredThinkingLevel } from "../../thinking";
 import {
+	imageGenTool,
 	isImageProviderPreference,
 	isSearchProviderId,
 	isSearchProviderPreference,
@@ -588,6 +589,27 @@ export class SelectorController {
 			case "mcp.notifications":
 				this.ctx.mcpManager?.setNotificationsEnabled(value as boolean);
 				break;
+
+			// Image-gen tool is registered unconditionally (sdk.ts); toggle its live
+			// active membership so the setting withdraws/restores it without a restart.
+			case "imagegen.enabled": {
+				const toolName = imageGenTool.name;
+				const active = this.ctx.session.getActiveToolNames();
+				let next: string[] | undefined;
+				if (value) {
+					if (this.ctx.session.getAllToolNames().includes(toolName) && !active.includes(toolName)) {
+						next = [...active, toolName];
+					}
+				} else if (active.includes(toolName)) {
+					next = active.filter(name => name !== toolName);
+				}
+				if (next) {
+					this.ctx.session.setActiveToolsByName(next).catch(err => {
+						this.ctx.showError(`Failed to update image generation tool: ${err}`);
+					});
+				}
+				break;
+			}
 
 			// All other settings are handled by the definitions (get/set on SettingsManager)
 			// No additional side effects needed

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -591,12 +591,16 @@ export class SelectorController {
 				break;
 
 			// Image-gen tool is registered unconditionally (sdk.ts); toggle its live
-			// active membership so the setting withdraws/restores it without a restart.
+			// active membership so the setting withdraws/restores it without a restart,
+			// and keep the mode restore snapshots in sync so exiting a plan/goal/vibe
+			// mode entered before the toggle doesn't clobber the new state.
 			case "imagegen.enabled": {
+				const enabled = value === true;
+				this.ctx.syncImageGenModeSnapshots(enabled);
 				const toolName = imageGenTool.name;
 				const active = this.ctx.session.getActiveToolNames();
 				let next: string[] | undefined;
-				if (value) {
+				if (enabled) {
 					if (this.ctx.session.getAllToolNames().includes(toolName) && !active.includes(toolName)) {
 						next = [...active, toolName];
 					}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -112,6 +112,7 @@ import { discoverTitleSystemPromptFile, resolvePromptInput } from "../system-pro
 import { formatTaskId } from "../task/render";
 import type { ConfiguredThinkingLevel } from "../thinking";
 import type { LspStartupServerInfo } from "../tools";
+import { imageGenTool } from "../tools";
 import { normalizeLocalScheme } from "../tools/path-utils";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../tools/render-utils";
 import { setAutoQaConsentHandler } from "../tools/report-tool-issue";
@@ -2138,6 +2139,26 @@ export class InteractiveMode implements InteractiveModeContext {
 			);
 			this.#updateVibeModeStatus();
 		}
+	}
+
+	/**
+	 * Keep the image-gen tool consistent inside plan/goal/vibe restore snapshots
+	 * when `imagegen.enabled` toggles mid-mode. Those modes capture the active tool
+	 * list on entry and replay it on exit; without this, disabling the setting during
+	 * a mode is undone on exit (snapshot re-adds the tool) and enabling it during a
+	 * mode is dropped on exit (snapshot lacks it). Called from the settings toggle.
+	 */
+	syncImageGenModeSnapshots(enabled: boolean): void {
+		const name = imageGenTool.name;
+		const patch = (tools: string[] | undefined): string[] | undefined => {
+			if (!tools) return tools;
+			const has = tools.includes(name);
+			if (enabled) return has ? tools : [...tools, name];
+			return has ? tools.filter(n => n !== name) : tools;
+		};
+		this.#planModePreviousTools = patch(this.#planModePreviousTools);
+		this.#goalModePreviousTools = patch(this.#goalModePreviousTools);
+		this.#vibeModePreviousTools = patch(this.#vibeModePreviousTools);
 	}
 
 	/** Reconcile mode state from session entries on resume/switch. */

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -348,6 +348,7 @@ export interface InteractiveModeContext {
 	openInBrowser(urlOrPath: string): void;
 	refreshSlashCommandState(cwd?: string): Promise<void>;
 	applyCwdChange(newCwd: string): Promise<void>;
+	syncImageGenModeSnapshots(enabled: boolean): void;
 
 	// Selector handling
 	showSettingsSelector(): void;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1814,10 +1814,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// to mirror the AsyncJobManager ownership rule.
 		if (mcpManager && !options.parentTaskPrefix) MCPManager.setInstance(mcpManager);
 
-		// Add image tools when the active model or configured image providers can generate images.
-		const imageGenTools = await logger.time("getImageGenTools", () => getImageGenTools(modelRegistry, model));
-		if (imageGenTools.length > 0) {
-			customTools.push(...(imageGenTools as unknown as CustomTool[]));
+		// Add image tools when enabled and the active model or configured image providers can generate images.
+		if (settings.get("imagegen.enabled")) {
+			const imageGenTools = await logger.time("getImageGenTools", () => getImageGenTools(modelRegistry, model));
+			if (imageGenTools.length > 0) {
+				customTools.push(...(imageGenTools as unknown as CustomTool[]));
+			}
 		}
 
 		if (settings.get("speechgen.enabled")) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1814,13 +1814,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// to mirror the AsyncJobManager ownership rule.
 		if (mcpManager && !options.parentTaskPrefix) MCPManager.setInstance(mcpManager);
 
-		// Add image tools when enabled and the active model or configured image providers can generate images.
-		if (settings.get("imagegen.enabled")) {
-			const imageGenTools = await logger.time("getImageGenTools", () => getImageGenTools(modelRegistry, model));
-			if (imageGenTools.length > 0) {
-				customTools.push(...(imageGenTools as unknown as CustomTool[]));
-			}
+		// Always register the image tools so the `imagegen.enabled` toggle can add
+		// or withdraw them live (the registry is built once). Only their initial
+		// active membership is gated on the setting, below.
+		const imageGenTools = await logger.time("getImageGenTools", () => getImageGenTools(modelRegistry, model));
+		if (imageGenTools.length > 0) {
+			customTools.push(...(imageGenTools as unknown as CustomTool[]));
 		}
+		const imageGenToolNames = new Set(imageGenTools.map(tool => tool.name));
 
 		if (settings.get("speechgen.enabled")) {
 			customTools.push(ttsTool as unknown as CustomTool);
@@ -2604,6 +2605,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			status: "running",
 		});
 		hasRegistered = true;
+
+		// Image tools are registered unconditionally (above); drop them from the
+		// initial active set when disabled so the model never sees the schema.
+		if (!settings.get("imagegen.enabled")) {
+			initialToolNames = initialToolNames.filter(name => !imageGenToolNames.has(name));
+		}
 
 		setActiveToolNames(initialToolNames);
 		const { systemPrompt } = await logger.time(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6726,6 +6726,15 @@ export class AgentSession {
 		options?: { persistMCPSelection?: boolean; previousSelectedMCPToolNames?: string[] },
 	): Promise<void> {
 		toolNames = normalizeToolNames(toolNames);
+		// Hard-gate the image-gen tool on `imagegen.enabled`. The tool is registered
+		// unconditionally (sdk.ts) so the setting can toggle it live, but it must never
+		// be active while disabled — no matter the caller. This single chokepoint every
+		// active-set mutation flows through catches the paths the startup filter misses:
+		// plan/goal/vibe mode-restore snapshots and cold persisted-subagent revives that
+		// replay a saved active list captured while imagegen was enabled.
+		if (!this.settings.get("imagegen.enabled")) {
+			toolNames = toolNames.filter(name => name !== "generate_image");
+		}
 		const previousSelectedMCPToolNames = options?.previousSelectedMCPToolNames ?? this.getSelectedMCPToolNames();
 		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -1,5 +1,6 @@
-import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeAll, describe, expect, test, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
@@ -68,6 +69,10 @@ describe("InteractiveMode.showStatus", () => {
 		await initTheme();
 	});
 
+	afterEach(() => {
+		resetSettingsForTest();
+	});
+
 	test("coalesces immediately-sequential status messages", () => {
 		const ctx = {
 			chatContainer: new Container(),
@@ -120,7 +125,8 @@ describe("InteractiveMode.showStatus", () => {
 		expect(renderLastLine(ctx.chatContainer)).toContain("STATUS_TWO");
 	});
 
-	test("preserves startup notifications while rendering the initial transcript", () => {
+	test("preserves startup notifications while rendering the initial transcript", async () => {
+		await Settings.init({ inMemory: true });
 		const { ctx, helpers } = createInitialRenderHarness();
 
 		helpers.showWarning("startup notification probe");

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -107,6 +107,7 @@ function createContext(overrides?: {
 		model: overrides?.model ?? model,
 		asyncJobManager: { register },
 		sessionId: "parent-session",
+		agent: { promptCacheKey: undefined },
 		configuredThinkingLevel: vi.fn(() => undefined),
 		systemPrompt: ["system prompt"],
 		getActiveToolNames: vi.fn(() => ["read", "bash"]),

--- a/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
+++ b/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
@@ -182,7 +182,8 @@ function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContex
 }
 
 describe("UiHelpers.renderInitialMessages — transcript source", () => {
-	it("renders the collapsed live display transcript, never the LLM context", () => {
+	it("renders the collapsed live display transcript, never the LLM context", async () => {
+		await Settings.init({ inMemory: true });
 		const { ctx, transcriptSpy, llmContextSpy, renderSessionContextSpy } = makeCtx();
 		const transcript = makeEmptyContext();
 		transcriptSpy.mockReturnValue(transcript);
@@ -199,13 +200,15 @@ describe("UiHelpers.renderInitialMessages — transcript source", () => {
 });
 
 describe("UiHelpers.renderInitialMessages — clearTerminalHistory", () => {
-	it("requests a scrollback-clearing repaint when clearTerminalHistory is set", () => {
+	it("requests a scrollback-clearing repaint when clearTerminalHistory is set", async () => {
+		await Settings.init({ inMemory: true });
 		const { ctx } = makeCtx();
 		new UiHelpers(ctx).renderInitialMessages({ clearTerminalHistory: true });
 		expect(ctx.ui.requestRender).toHaveBeenCalledWith(true, { clearScrollback: true });
 	});
 
-	it("never clears scrollback when clearTerminalHistory is unset", () => {
+	it("never clears scrollback when clearTerminalHistory is unset", async () => {
+		await Settings.init({ inMemory: true });
 		const { ctx } = makeCtx();
 		new UiHelpers(ctx).renderInitialMessages();
 		const clearedCall = (ctx.ui.requestRender as Mock<(...a: unknown[]) => void>).mock.calls.find(

--- a/packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts
+++ b/packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, test, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type {
 	ExtensionActions,
 	ExtensionCommandContextActions,
@@ -35,6 +36,7 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
+	resetSettingsForTest();
 	vi.restoreAllMocks();
 });
 
@@ -177,6 +179,7 @@ function countOccurrences(haystack: string, needle: string): number {
 
 describe("issue #1955 — sendMessage(display:true) during session_start", () => {
 	test("renders the custom message exactly once after the initial transcript render", async () => {
+		await Settings.init({ inMemory: true });
 		const marker = "issue-1955-marker-text";
 		const harness = createHarness();
 		await harness.controller.initHooksAndCustomTools();
@@ -210,6 +213,7 @@ describe("issue #1955 — sendMessage(display:true) during session_start", () =>
 	});
 
 	test("after the initial render, sendMessage(display:true) still renders the message", async () => {
+		await Settings.init({ inMemory: true });
 		const marker = "issue-1955-late-marker";
 		const harness = createHarness();
 		await harness.controller.initHooksAndCustomTools();

--- a/packages/coding-agent/test/sdk-imagegen-active-tools.test.ts
+++ b/packages/coding-agent/test/sdk-imagegen-active-tools.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+// Core contract of the imagegen.enabled gate: the generate_image tool is
+// registered unconditionally so it can toggle live, but its active membership
+// is gated on the (default-off) setting. Default-off must drop it from the
+// initial active set; enabling keeps it; and the disabled setting must survive
+// any active-set replay (mode-restore snapshots / persisted revive) that tries
+// to re-add it — the agent-session hard-gate enforces this.
+describe("createAgentSession imagegen.enabled gate", () => {
+	let registryDir: string;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	const sessions: AgentSession[] = [];
+
+	beforeAll(async () => {
+		registryDir = path.join(os.tmpdir(), `pi-imagegen-active-${Snowflake.next()}`);
+		fs.mkdirSync(registryDir, { recursive: true });
+		authStorage = await AuthStorage.create(path.join(registryDir, "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterAll(async () => {
+		for (const session of sessions) await session.dispose().catch(() => {});
+		authStorage.close();
+		if (fs.existsSync(registryDir)) removeSyncWithRetries(registryDir);
+	});
+
+	async function createSession(settings: Settings): Promise<AgentSession> {
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			toolNames: ["read", "generate_image"],
+		});
+		sessions.push(session);
+		return session;
+	}
+
+	it("drops generate_image from the initial active set when the setting is off (default)", async () => {
+		const session = await createSession(Settings.isolated({}));
+		const names = session.getActiveToolNames();
+		expect(names).toContain("read");
+		expect(names).not.toContain("generate_image");
+	});
+
+	it("keeps generate_image active when the setting is on", async () => {
+		const session = await createSession(Settings.isolated({ "imagegen.enabled": true }));
+		const names = session.getActiveToolNames();
+		expect(names).toContain("read");
+		expect(names).toContain("generate_image");
+	});
+
+	it("refuses to re-activate generate_image via setActiveToolsByName while disabled", async () => {
+		const session = await createSession(Settings.isolated({}));
+		// Simulates a mode-restore snapshot or a persisted subagent revive replaying a
+		// saved active list captured while imagegen was enabled: the hard-gate strips it.
+		await session.setActiveToolsByName(["read", "generate_image"]);
+		expect(session.getActiveToolNames()).not.toContain("generate_image");
+	});
+});

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -219,4 +219,49 @@ describe("selector setting side effects", () => {
 		expect(showModelCycleTrack).toHaveBeenCalledTimes(1);
 		expect(showError).not.toHaveBeenCalled();
 	});
+
+	it("activates the generate_image tool when imagegen.enabled turns on", () => {
+		const setActiveToolsByName = vi.fn().mockResolvedValue(undefined);
+		const controller = new SelectorController({
+			session: {
+				getActiveToolNames: () => ["read"],
+				getAllToolNames: () => ["read", "generate_image"],
+				setActiveToolsByName,
+			},
+		} as unknown as InteractiveModeContext);
+
+		controller.handleSettingChange("imagegen.enabled", true);
+
+		expect(setActiveToolsByName).toHaveBeenCalledWith(["read", "generate_image"]);
+	});
+
+	it("withdraws the generate_image tool when imagegen.enabled turns off", () => {
+		const setActiveToolsByName = vi.fn().mockResolvedValue(undefined);
+		const controller = new SelectorController({
+			session: {
+				getActiveToolNames: () => ["read", "generate_image"],
+				getAllToolNames: () => ["read", "generate_image"],
+				setActiveToolsByName,
+			},
+		} as unknown as InteractiveModeContext);
+
+		controller.handleSettingChange("imagegen.enabled", false);
+
+		expect(setActiveToolsByName).toHaveBeenCalledWith(["read"]);
+	});
+
+	it("does not activate generate_image when it is absent from the registry", () => {
+		const setActiveToolsByName = vi.fn().mockResolvedValue(undefined);
+		const controller = new SelectorController({
+			session: {
+				getActiveToolNames: () => ["read"],
+				getAllToolNames: () => ["read"],
+				setActiveToolsByName,
+			},
+		} as unknown as InteractiveModeContext);
+
+		controller.handleSettingChange("imagegen.enabled", true);
+
+		expect(setActiveToolsByName).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -228,6 +228,7 @@ describe("selector setting side effects", () => {
 				getAllToolNames: () => ["read", "generate_image"],
 				setActiveToolsByName,
 			},
+			syncImageGenModeSnapshots: () => {},
 		} as unknown as InteractiveModeContext);
 
 		controller.handleSettingChange("imagegen.enabled", true);
@@ -243,6 +244,7 @@ describe("selector setting side effects", () => {
 				getAllToolNames: () => ["read", "generate_image"],
 				setActiveToolsByName,
 			},
+			syncImageGenModeSnapshots: () => {},
 		} as unknown as InteractiveModeContext);
 
 		controller.handleSettingChange("imagegen.enabled", false);
@@ -258,6 +260,7 @@ describe("selector setting side effects", () => {
 				getAllToolNames: () => ["read"],
 				setActiveToolsByName,
 			},
+			syncImageGenModeSnapshots: () => {},
 		} as unknown as InteractiveModeContext);
 
 		controller.handleSettingChange("imagegen.enabled", true);

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -34,5 +34,5 @@ describe("browser tab evaluation", () => {
 		} finally {
 			await tool.execute("close", { action: "close", name, kill: true });
 		}
-	});
+	}, 60_000);
 });


### PR DESCRIPTION
## What

Adds an `imagegen.enabled` setting (default `false`) that gates registration of the `generate_image` tool.

- When disabled (default), the tool is withdrawn from the session.
- When enabled, the previous auto-registration behaviour is restored (image tools added when the active model or configured providers can generate images).

## Why

`generate_image` was always registered whenever a capable model/provider was present, with no way to turn it off. This adds an explicit toggle under the Tools settings tab, matching the existing pattern used by `inspect_image.enabled`, `speechgen`/tts, etc.

## Changes

- `sdk.ts` — gate the image-gen tool push behind `settings.get("imagegen.enabled")`.
- `settings-schema.ts` — new `imagegen.enabled` boolean (default off), Tools tab.
- `CHANGELOG.md` — Unreleased entry.

## Notes

Behaviour change: image generation is now opt-in rather than automatic. Enabling `imagegen.enabled` reproduces the prior default.