### PR TITLE
feat(coding-agent): generate_image per-request provider + Codex-subscription images

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Codex (ChatGPT subscription) support to `generate_image`. The tool now resolves a connected `openai-codex` OAuth credential and drives OpenAI's hosted `image_generation` tool through the ChatGPT backend (`chatgpt.com/backend-api/codex/responses`, `chatgpt-account-id` header) **independent of the active chat model** — so image generation works on a ChatGPT/Codex subscription with no metered `OPENAI_API_KEY`, even when the active model is Claude/Gemini/etc. A new `providers.image: "openai-codex"` option forces it; `auto` now auto-detects a connected subscription (priority: active GPT image tool > Codex subscription > Antigravity > xAI > OpenRouter > Gemini), and the `openai` preference falls back to it when no `OPENAI_API_KEY`/active GPT model is present.
+- Added an optional `provider` parameter to `generate_image` (`auto` | `openai` | `openai-codex` | `antigravity` | `xai` | `gemini` | `openrouter`) that overrides the `providers.image` setting **for a single request** — so "generate this using gemini / codex / xai" routes per-call without changing the global setting. Absent → the `providers.image` setting applies, unchanged; the named provider uses the same resolution semantics (falls back to auto-detect if it has no credentials). File: `tools/image-gen.ts` (`imageProviderSchema`, `findImageApiKey` `preference` arg).
+
 ## [16.3.8] - 2026-07-05
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4370,7 +4370,7 @@ export const SETTINGS_SCHEMA = {
 	},
 	"providers.image": {
 		type: "enum",
-		values: ["auto", "openai", "antigravity", "xai", "gemini", "openrouter"] as const,
+		values: ["auto", "openai", "openai-codex", "antigravity", "xai", "gemini", "openrouter"] as const,
 		default: "auto",
 		ui: {
 			tab: "providers",
@@ -4381,9 +4381,20 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "auto",
 					label: "Auto",
-					description: "Priority: GPT model image tool > Antigravity > xAI > OpenRouter > Gemini",
+					description:
+						"Priority: GPT model image tool > Codex subscription > Antigravity > xAI > OpenRouter > Gemini",
 				},
-				{ value: "openai", label: "OpenAI", description: "Uses the active GPT Responses/Codex model" },
+				{
+					value: "openai",
+					label: "OpenAI",
+					description:
+						"OPENAI_API_KEY (gpt-image-2) or active GPT model; falls back to a connected Codex subscription",
+				},
+				{
+					value: "openai-codex",
+					label: "OpenAI Codex (ChatGPT)",
+					description: "Uses a connected Codex / ChatGPT subscription — no OPENAI_API_KEY needed",
+				},
 				{
 					value: "antigravity",
 					label: "Antigravity",

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -45,7 +45,7 @@ const IMAGE_SYSTEM_INSTRUCTION =
 	"You are an AI image generator. Generate images based on user descriptions. Focus on creating high-quality, visually appealing images that match the user's request.";
 
 export type ImageProvider = "antigravity" | "gemini" | "openai" | "openai-codex" | "openrouter" | "xai";
-export type ImageProviderPreference = Exclude<ImageProvider, "openai-codex"> | "auto";
+export type ImageProviderPreference = ImageProvider | "auto";
 
 interface ImageApiKey {
 	provider: ImageProvider;
@@ -57,7 +57,16 @@ interface ImageApiKey {
 const COMMON_IMAGE_ASPECT_RATIOS = ["1:1", "3:4", "4:3", "9:16", "16:9"] as const;
 const XAI_IMAGE_ASPECT_RATIOS = [...COMMON_IMAGE_ASPECT_RATIOS, "3:2", "2:3"] as const;
 const COMMON_IMAGE_ASPECT_RATIO_SET = new Set<string>(COMMON_IMAGE_ASPECT_RATIOS);
-const IMAGE_PROVIDER_PREFERENCES = new Set<string>(["auto", "antigravity", "gemini", "openai", "openrouter", "xai"]);
+const IMAGE_PROVIDER_CHOICES = [
+	"auto",
+	"antigravity",
+	"gemini",
+	"openai",
+	"openai-codex",
+	"openrouter",
+	"xai",
+] as const;
+const IMAGE_PROVIDER_PREFERENCES = new Set<string>(IMAGE_PROVIDER_CHOICES);
 
 const responseModalitySchema = type('"IMAGE" | "TEXT"');
 
@@ -69,6 +78,10 @@ const inputImageSchema = type({
 	"data?": type("string").describe("base64 image data"),
 	"mime_type?": type("string").describe("mime type"),
 });
+
+const imageProviderSchema = type
+	.enumerated(...IMAGE_PROVIDER_CHOICES)
+	.describe("image provider for this request; overrides the providers.image setting (default: use the setting)");
 
 export const imageGenSchema = type({
 	subject: type("string").describe("main subject"),
@@ -82,6 +95,7 @@ export const imageGenSchema = type({
 	"aspect_ratio?": aspectRatioSchema,
 	"image_size?": imageSizeSchema,
 	"input?": inputImageSchema.array().describe("input images"),
+	"provider?": imageProviderSchema,
 });
 export type ImageGenParams = typeof imageGenSchema.infer;
 export type GeminiResponseModality = typeof responseModalitySchema.infer;
@@ -547,37 +561,92 @@ async function findOpenAIHostedImageCredentials(
 	};
 }
 
+// Codex (ChatGPT subscription) chat models that carry OpenAI's hosted
+// `image_generation` tool. Priority: newest general model first, then Codex
+// variants; any available openai-codex hosted-image model is the last resort.
+const CODEX_IMAGE_MODEL_PRIORITY = ["gpt-5.5", "gpt-5.4", "gpt-5.1", "gpt-5", "gpt-5-codex"] as const;
+
+function resolveDefaultCodexImageModel(modelRegistry: ModelRegistry): Model | undefined {
+	for (const id of CODEX_IMAGE_MODEL_PRIORITY) {
+		const model = modelRegistry.find("openai-codex", id);
+		if (model && isOpenAIHostedImageModel(model)) return model;
+	}
+	return modelRegistry.getAll().find(model => model.provider === "openai-codex" && isOpenAIHostedImageModel(model));
+}
+
+/**
+ * Codex subscription (ChatGPT OAuth) image credentials — engages OpenAI's hosted
+ * `image_generation` tool through a CONNECTED Codex account, independent of the
+ * active chat model. This is what lets image generation run on a ChatGPT
+ * subscription (no metered OPENAI_API_KEY) even when the active model is, e.g.,
+ * Claude. The active-model-is-codex case is already served by
+ * {@link findOpenAIHostedImageCredentials}, so it is skipped here to avoid a
+ * duplicate resolution.
+ */
+async function findCodexSubscriptionImageCredentials(
+	modelRegistry: ModelRegistry | undefined,
+	activeModel: Model | undefined,
+	sessionId?: string,
+): Promise<ImageApiKey | null> {
+	if (!modelRegistry) return null;
+	if (isOpenAIHostedImageModel(activeModel) && getOpenAIHostedImageProvider(activeModel) === "openai-codex") {
+		return null;
+	}
+	// Only when a Codex / ChatGPT subscription is actually connected.
+	const token = await modelRegistry.getApiKeyForProvider("openai-codex", sessionId);
+	if (!token) return null;
+	const model = resolveDefaultCodexImageModel(modelRegistry);
+	if (!model) return null;
+	const apiKey = await modelRegistry.getApiKey(model, sessionId);
+	if (!isAuthenticated(apiKey)) return null;
+	return { provider: "openai-codex", apiKey, model };
+}
+
 async function findImageApiKey(
 	modelRegistry?: ModelRegistry,
 	activeModel?: Model,
 	sessionId?: string,
+	preference: ImageProviderPreference = preferredImageProvider,
 ): Promise<ImageApiKey | null> {
-	// If a specific provider is preferred, try it first.
-	if (preferredImageProvider === "openai") {
+	// If a specific provider is preferred — a per-request `provider` override or
+	// the providers.image setting — try it first, then fall through to auto-detect.
+	if (preference === "openai-codex") {
+		// Explicit: use a connected Codex (ChatGPT subscription) account's hosted
+		// image_generation tool — no metered OPENAI_API_KEY, any active chat model.
+		const codex = await findCodexSubscriptionImageCredentials(modelRegistry, activeModel, sessionId);
+		if (codex) return codex;
+		// Fall through to auto-detect if the subscription is not connected.
+	} else if (preference === "openai") {
 		const openAI = await findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
 		if (openAI) return openAI;
+		const codex = await findCodexSubscriptionImageCredentials(modelRegistry, activeModel, sessionId);
+		if (codex) return codex;
 		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "antigravity" && modelRegistry) {
+	} else if (preference === "antigravity" && modelRegistry) {
 		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
 		if (antigravity) return antigravity;
 		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "gemini") {
+	} else if (preference === "gemini") {
 		const gemini = await findGeminiImageCredentials(modelRegistry, sessionId);
 		if (gemini) return gemini;
 		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "openrouter") {
+	} else if (preference === "openrouter") {
 		const openRouter = await findOpenRouterImageCredentials(modelRegistry, sessionId);
 		if (openRouter) return openRouter;
 		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "xai") {
+	} else if (preference === "xai") {
 		const xai = await findXAIImageCredentials(modelRegistry);
 		if (xai) return xai;
 		// Fall through to auto-detect if preferred provider key not found.
 	}
 
-	// Auto-detect: GPT hosted image generation, then Antigravity, xAI, OpenRouter, Gemini.
+	// Auto-detect: active GPT hosted image tool, then a connected Codex
+	// subscription, then Antigravity, xAI, OpenRouter, Gemini.
 	const openAI = await findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
 	if (openAI) return openAI;
+
+	const codexSubscription = await findCodexSubscriptionImageCredentials(modelRegistry, activeModel, sessionId);
+	if (codexSubscription) return codexSubscription;
 
 	if (modelRegistry) {
 		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
@@ -1041,10 +1110,10 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 	async execute(_toolCallId, params, _onUpdate, ctx, signal) {
 		return untilAborted(signal, async () => {
 			const sessionId = ctx.sessionManager.getSessionId();
-			const apiKey = await findImageApiKey(ctx.modelRegistry, ctx.model, sessionId);
+			const apiKey = await findImageApiKey(ctx.modelRegistry, ctx.model, sessionId, params.provider);
 			if (!apiKey) {
 				throw new Error(
-					"No image API credentials found. Use a GPT Responses/Codex model with OpenAI credentials, login with google-antigravity or xAI Grok OAuth, or set XAI_API_KEY, OPENROUTER_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY.",
+					"No image API credentials found. Connect a Codex (ChatGPT) subscription, use a GPT Responses/Codex model with OpenAI credentials, log in with google-antigravity or xAI Grok OAuth, or set OPENAI_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY.",
 				);
 			}
 

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -133,6 +133,219 @@ describe("imageGenTool", () => {
 		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-webp"));
 	});
 
+	it("routes OpenAI Images edits through the Responses image tool", async () => {
+		setPreferredImageProvider("openai");
+		let requestUrl: string | undefined;
+		let requestBody: Record<string, unknown> | undefined;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			requestUrl = input.toString();
+			requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return new Response(
+				JSON.stringify({
+					output: [
+						{
+							type: "image_generation_call",
+							result: Buffer.from("edited-webp").toString("base64"),
+							status: "completed",
+						},
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const model = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.5",
+			name: "GPT 5.5",
+			baseUrl: "https://api.openai.com/v1",
+		} as Model;
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "test-openai-key",
+				getApiKeyForProvider: async (provider: string) => (provider === "openai" ? "test-openai-key" : undefined),
+				authStorage: { rotateSessionCredential: async () => false },
+				resolver: () => async () => "test-openai-key",
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute(
+			"call-openai-edit",
+			{
+				subject: "a cat",
+				changes: ["make the reference noir"],
+				input: [{ data: Buffer.from("reference").toString("base64"), mime_type: "image/png" }],
+			},
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe("https://api.openai.com/v1/responses");
+		expect(requestBody).toMatchObject({
+			model: "gpt-5.5",
+			tools: [{ type: "image_generation", output_format: "webp", action: "edit" }],
+		});
+		const input = requestBody?.input as Array<{ content?: Array<Record<string, unknown>> }> | undefined;
+		const content = input?.[0]?.content ?? [];
+		expect(content.some(part => part.type === "input_image")).toBe(true);
+		expect(result.details?.provider).toBe("openai");
+		expect(result.details?.imageCount).toBe(1);
+	});
+
+	it("routes image generation through a connected Codex (ChatGPT) subscription when the active model is not OpenAI", async () => {
+		setPreferredImageProvider("openai-codex");
+		let requestUrl: string | undefined;
+		let accountHeader: string | null | undefined;
+		let requestBody: Record<string, unknown> | undefined;
+
+		// A fake Codex JWT (header.payload.signature) so getCodexAccountId can read
+		// chatgpt_account_id from the base64 payload claim.
+		const payload = Buffer.from(
+			JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct-codex-1" } }),
+		).toString("base64");
+		const codexToken = `header.${payload}.signature`;
+
+		const sse = `data: ${JSON.stringify({
+			type: "response.completed",
+			response: {
+				output: [
+					{
+						type: "image_generation_call",
+						result: Buffer.from("codex-webp").toString("base64"),
+						revised_prompt: "A neon skyline.",
+						status: "completed",
+					},
+				],
+				usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+			},
+		})}\n\n`;
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			requestUrl = input.toString();
+			accountHeader = new Headers(init?.headers).get("chatgpt-account-id");
+			requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			return new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } });
+		}) as unknown as typeof fetch;
+
+		const codexModel = {
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			baseUrl: "https://chatgpt.com/backend-api",
+		} as Model;
+		// Active model is Claude — proves the codex subscription path is independent of it.
+		const activeModel = {
+			api: "anthropic-messages",
+			provider: "anthropic",
+			id: "claude-opus-4",
+			name: "Claude",
+		} as Model;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				find: (provider: string, id: string) =>
+					provider === "openai-codex" && id === "gpt-5.5" ? codexModel : undefined,
+				getAll: () => [codexModel],
+				getApiKey: async () => codexToken,
+				getApiKeyForProvider: async (provider: string) => (provider === "openai-codex" ? codexToken : undefined),
+				authStorage: { rotateSessionCredential: async () => false },
+				resolver: () => async () => codexToken,
+			} as unknown as ModelRegistry,
+			model: activeModel,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute(
+			"call-codex",
+			{ subject: "a neon skyline", aspect_ratio: "1:1" },
+			undefined,
+			ctx,
+		);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrl).toBe("https://chatgpt.com/backend-api/codex/responses");
+		expect(accountHeader).toBe("acct-codex-1");
+		expect(requestBody).toMatchObject({
+			model: "gpt-5.5",
+			tools: [{ type: "image_generation", output_format: "webp", size: "1024x1024", action: "generate" }],
+			stream: true,
+		});
+		expect(result.details?.provider).toBe("openai-codex");
+		expect(result.details?.model).toBe("gpt-5.5");
+		expect(result.details?.imageCount).toBe(1);
+		const savedPath = result.details?.imagePaths[0];
+		if (!savedPath) throw new Error("Expected generated image path");
+		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("codex-webp"));
+	});
+
+	it("honors a per-request provider override over the providers.image setting", async () => {
+		// Setting selects Codex and a Codex subscription IS connected...
+		setPreferredImageProvider("openai-codex");
+		let requestUrl: string | undefined;
+		const captured: { authorization: string | null } = { authorization: null };
+
+		const fetchMock: typeof fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+			requestUrl = input.toString();
+			captured.authorization = new Headers(init?.headers).get("authorization");
+			return new Response(JSON.stringify({ data: [{ b64_json: Buffer.from("override-xai").toString("base64") }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				// Both Codex (the setting) and xAI credentials exist; the per-request
+				// `provider: "xai"` override must still win over the setting.
+				getApiKeyForProvider: async (provider: string) =>
+					provider === "xai-oauth" || provider === "openai-codex" ? "test-token" : undefined,
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: (provider: string) => provider === "xai-oauth",
+					rotateSessionCredential: async () => false,
+				},
+				resolver: () => async () => "test-xai-token",
+			} as unknown as ModelRegistry,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-override", { subject: "a cat", provider: "xai" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		// Routed to xAI (the override), NOT the Codex subscription the setting selects.
+		expect(requestUrl).toBe("https://api.x.ai/v1/images/generations");
+		expect(captured.authorization).toBe("Bearer test-xai-token");
+		expect(result.details?.provider).toBe("xai");
+	});
 	it("routes xAI image generation with xAI-only aspect ratios", async () => {
 		setPreferredImageProvider("xai");
 		let requestUrl: string | undefined;


### PR DESCRIPTION
## What

Two additions to `generate_image`:

1. **Codex-subscription image generation independent of the active chat model.** Today images ride a Codex (ChatGPT OAuth) subscription only when the active model is an OpenAI hosted-image model; otherwise the tool falls back to the metered `OPENAI_API_KEY`. This resolves a connected `openai-codex` credential directly (`chatgpt.com/backend-api/codex/responses`, `chatgpt-account-id` header), so images run on the subscription even while chatting with Claude/Gemini. `providers.image` gains `openai-codex`; `auto` detects a connected subscription (priority: active GPT image tool > Codex subscription > Antigravity > xAI > OpenRouter > Gemini).
2. **Per-request `provider` param** (`auto | openai | openai-codex | antigravity | xai | gemini | openrouter`) — overrides the setting for one call ("generate this using gemini"); absent → the setting applies, semantics unchanged.

## Why

Subscription-first users (code on Claude, ChatGPT plan for images) currently burn metered API credit for every image, or can't generate at all when no `OPENAI_API_KEY` is set. Proven in production in our downstream fork — including live with a hard-capped API key where only the subscription path could succeed.

## Testing

- `image-gen.test.ts` 7/7, incl. 3 new tests: codex-subscription routing with a non-OpenAI active model; per-request override beating the setting; the Responses edit path.
- `check:ts` green across all 16 packages on the branch base.
- Note: `check:rs` has a pre-existing win32-only failure (`pi-uutils-ctx` dead-code) unrelated to this diff (touches no Rust).

Vouched in #4628 (thank you!). Happy to adjust in review — e.g. the codex image-model priority ladder is a hardcoded const and could be made configurable if preferred.