### PR TITLE
feat: add FriendliAI as built-in provider

### DIFF
--- a/packages/ai/src/registry/friendli.ts
+++ b/packages/ai/src/registry/friendli.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginFriendli = createApiKeyLogin({
+	providerLabel: "FriendliAI",
+	authUrl: "https://friendli.ai/suite/~/setting/keys",
+	instructions: "Copy your Personal API key from Friendli Suite",
+	promptMessage: "Paste your FriendliAI API key",
+	placeholder: "flp_...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "FriendliAI",
+		modelsUrl: "https://api.friendli.ai/serverless/v1/models",
+	},
+});
+
+export const friendliProvider = {
+	id: "friendli",
+	name: "FriendliAI",
+	login: (cb: OAuthLoginCallbacks) => loginFriendli(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -13,6 +13,7 @@ import { deepseekProvider } from "./deepseek";
 import { devinProvider } from "./devin";
 import { firepassProvider } from "./firepass";
 import { fireworksProvider } from "./fireworks";
+import { friendliProvider } from "./friendli";
 import { githubCopilotProvider } from "./github-copilot";
 import { gitlabDuoProvider } from "./gitlab-duo";
 import { gitLabDuoWorkflowProvider } from "./gitlab-duo-workflow";
@@ -109,6 +110,7 @@ const ALL = [
 	cerebrasProvider,
 	basetenProvider,
 	fireworksProvider,
+	friendliProvider,
 	togetherProvider,
 	nvidiaProvider,
 	novitaProvider,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -18213,6 +18213,7 @@
 			}
 		}
 	},
+	"friendli": {},
 	"github-copilot": {
 		"claude-fable-5": {
 			"id": "claude-fable-5",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -19,6 +19,7 @@ import {
 	deepseekModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
+	friendliModelManagerOptions,
 	githubCopilotModelManagerOptions,
 	groqModelManagerOptions,
 	huggingfaceModelManagerOptions,
@@ -147,6 +148,14 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["FIREWORKS_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => fireworksModelManagerOptions(config),
 		catalogDiscovery: { label: "Fireworks" },
+	},
+	{
+		id: "friendli",
+		defaultModel: "zai-org/GLM-5.2",
+		envVars: ["FRIENDLI_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => friendliModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: { label: "FriendliAI" },
 	},
 	{
 		id: "github-copilot",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1818,6 +1818,64 @@ export function fireworksModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// 7.55 FriendliAI
+// ---------------------------------------------------------------------------
+
+export interface FriendliModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+const FRIENDLI_DEFAULT_BASE_URL = "https://api.friendli.ai/serverless/v1";
+
+export function friendliModelManagerOptions(
+	config?: FriendliModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? FRIENDLI_DEFAULT_BASE_URL;
+	const references = createBundledReferenceMap<"openai-completions">("friendli");
+	return {
+		providerId: "friendli",
+		dynamicModelsAuthoritative: true,
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "friendli",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						const raw = entry as Record<string, unknown> & {
+							context_length?: unknown;
+							max_completion_tokens?: unknown;
+						};
+
+						const contextWindow = toPositiveNumber(
+							raw.context_length,
+							reference?.contextWindow ?? defaults.contextWindow,
+						);
+						const maxTokens = toPositiveNumber(
+							raw.max_completion_tokens,
+							reference?.maxTokens ?? defaults.maxTokens,
+						);
+
+						const baseModel = mapWithBundledReference(entry, defaults, reference);
+
+						return {
+							...baseModel,
+							contextWindow,
+							maxTokens,
+						};
+					},
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 7.6 Fire Pass (Fireworks Kimi K2.6 Turbo subscription)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Add FriendliAI (`friendli`) as a built-in OpenAI-compatible provider.

- **Registry**: `packages/ai/src/registry/friendli.ts` — API key login with validation against `/serverless/v1/models`
- **Catalog**: `friendliModelManagerOptions` in `openai-compat.ts` — dynamic model discovery, `context_length`/`max_completion_tokens` parsing
- **Catalog**: `CATALOG_PROVIDERS` entry with `FRIENDLI_API_KEY` env var, default model `zai-org/GLM-5.2`
- **Registry**: `friendliProvider` registered in `ALL` array
- **Models**: empty `friendli` entry in `models.json` for type resolution

## Why

FriendliAI provides a fully OpenAI-compatible API at `https://api.friendli.ai/serverless/v1`. Their serverless endpoint hosts popular open models (DeepSeek-V3.2, GLM-5.2, Llama 4, etc.) and supports streaming, tool calling, reasoning_content, structured outputs, and vision. Adding FriendliAI as a built-in provider lets users authenticate with `FRIENDLI_API_KEY` and use Friendli-hosted models directly.

FriendliAI-specific notes:
- API key prefix: `flp_...`
- Auth URL: `https://friendli.ai/suite/~/setting/keys`
- Optional `X-Friendli-Team` header for team scoping
- Reasoning models return `reasoning_content` (compatible with existing `openai-completions` handler)
- Friendli-specific reasoning request params (`parse_reasoning`, `include_reasoning`) are not yet forwarded (requires future `extra_body` passthrough support)

## Testing

- `bun check` passes (all packages: pi-catalog, pi-ai, pi-coding-agent, etc.)
- Registry ↔ catalog completeness check satisfied
- Runtime model discovery will be validated once a `FRIENDLI_API_KEY` is configured

---

- [x] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)