### PR TITLE
fix(runtime): recover macOS stdin after read EINTR

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ### Fixed
 
+- Prevented parked subagents and secondary in-process sessions from terminating process-global Tiny and Mnemopi IPC workers; only the primary process owner shuts those shared clients down.
+
 - Fixed inconsistent history rendering when toggling the display setting for compacted items
 - Fixed configured `retry.fallbackChains` never engaging on non-retryable provider errors (e.g. "Cloud Code Assist API returned an empty response"): a hard error on a model covered by a fallback chain now switches to the next candidate instead of failing the turn, while still never backoff-retrying the failing model itself
 - Fixed transcript rebuilds (compaction, `/compact`, and toggling history display) repainting content below stale scrollback when collapsing history; rebuilds now correctly clear the scrollback buffer when history is collapsed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6109,7 +6109,11 @@ export class AgentSession {
 				logger.warn("Failed to release owned browser tabs during dispose", { error: String(error) });
 			}
 		}
-		await shutdownTinyTitleClient();
+		// Tiny and Mnemopi workers are process-global singletons. Their lifetime
+		// follows the primary session that owns the process-global async manager;
+		// parked subagents and secondary in-process sessions must not kill workers
+		// still serving the primary session.
+		if (ownedAsyncManager) await shutdownTinyTitleClient();
 		this.#releasePowerAssertion();
 		// Clean up an empty session created by this session's /move so it doesn't accumulate.
 		await cleanupEmptyMoveSession(this.sessionManager, this.#movedFromEmptySessionFile);
@@ -6153,11 +6157,10 @@ export class AgentSession {
 		hindsightState?.dispose();
 		const mnemopiState = setMnemopiSessionState(this, undefined);
 		await mnemopiState?.dispose({ timeoutMs: options.mnemopiConsolidateTimeoutMs });
-		// Tear down the embeddings subprocess AFTER mnemopi state.dispose:
-		// consolidate-on-dispose may still call `embed()` to store the final
-		// memories, and that round-trips through the worker we are about to
-		// hard-kill (issue #3031).
-		await shutdownMnemopiEmbedClient();
+		// The primary process owner tears down the embeddings subprocess only
+		// AFTER its mnemopi state has finished consolidating; aliased subagent
+		// state disposal intentionally leaves this shared worker alive.
+		if (ownedAsyncManager) await shutdownMnemopiEmbedClient();
 		this.#disconnectFromAgent();
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();

--- a/packages/coding-agent/test/agent-session-shared-worker-ownership.test.ts
+++ b/packages/coding-agent/test/agent-session-shared-worker-ownership.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { mnemopiEmbedClient } from "@oh-my-pi/pi-coding-agent/mnemopi/embed-client";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { tinyTitleClient } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+function createSession(options: {
+	agentKind: "main" | "sub";
+	modelRegistry: ModelRegistry;
+	ownedAsyncJobManager?: AsyncJobManager;
+}): AgentSession {
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
+	});
+	return new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings: Settings.isolated({ "compaction.enabled": false }),
+		modelRegistry: options.modelRegistry,
+		agentKind: options.agentKind,
+		ownedAsyncJobManager: options.ownedAsyncJobManager,
+	});
+}
+
+describe("AgentSession shared worker ownership", () => {
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let tempDir: TempDir;
+	const sessions: AgentSession[] = [];
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-shared-worker-ownership-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		for (const session of sessions.splice(0)) await session.dispose();
+		vi.restoreAllMocks();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("does not terminate process-global workers when a parked subagent disposes", async () => {
+		const tinyTerminate = vi.spyOn(tinyTitleClient, "terminate").mockResolvedValue();
+		const mnemopiTerminate = vi.spyOn(mnemopiEmbedClient, "terminate").mockResolvedValue();
+		const subagent = createSession({ agentKind: "sub", modelRegistry });
+		sessions.push(subagent);
+
+		await subagent.dispose();
+
+		expect(tinyTerminate).not.toHaveBeenCalled();
+		expect(mnemopiTerminate).not.toHaveBeenCalled();
+	});
+
+	it("terminates process-global workers when their primary owner disposes", async () => {
+		const tinyTerminate = vi.spyOn(tinyTitleClient, "terminate").mockResolvedValue();
+		const mnemopiTerminate = vi.spyOn(mnemopiEmbedClient, "terminate").mockResolvedValue();
+		const owner = createSession({
+			agentKind: "main",
+			ownedAsyncJobManager: new AsyncJobManager({ onJobComplete: async () => {} }),
+			modelRegistry,
+		});
+		sessions.push(owner);
+
+		await owner.dispose();
+
+		expect(tinyTerminate).toHaveBeenCalledTimes(1);
+		expect(mnemopiTerminate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recovered terminal input after Bun surfaces a macOS `read` interruption (`EINTR`) by reopening the destroyed TTY stream and restoring its raw-mode input pipeline, including active shutdown-drain listeners; unrelated stream errors remain fatal.
+
 ## [16.4.7] - 2026-07-12
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1,5 +1,6 @@
 import { dlopen, FFIType, ptr } from "bun:ffi";
 import * as fs from "node:fs";
+import { ReadStream as TtyReadStream } from "node:tty";
 import { $env, isBunTestRuntime, isTerminalHeadless, logger, postmortem } from "@oh-my-pi/pi-utils";
 import { setKittyProtocolActive } from "./keys";
 import { StdinBuffer } from "./stdin-buffer";
@@ -192,6 +193,12 @@ function registerStdoutErrorHandler(handler: (err: Error) => void): () => void {
 	return () => {
 		stdoutErrorHandlers.delete(handler);
 	};
+}
+
+function isTransientReadEintr(err: unknown): boolean {
+	if (err === null || typeof err !== "object") return false;
+	if (!("code" in err) || !("syscall" in err)) return false;
+	return err.code === "EINTR" && err.syscall === "read";
 }
 
 const STD_INPUT_HANDLE = -10;
@@ -455,6 +462,12 @@ export class ProcessTerminal implements Terminal {
 	#modifyOtherKeysTimeout?: Timer;
 	#stdinBuffer?: StdinBuffer;
 	#stdinDataHandler?: (data: string) => void;
+	#stdinDrainHandlers = new Set<(data: string) => void>();
+	#stdin: NodeJS.ReadStream;
+	#reopenStdin: () => NodeJS.ReadStream;
+	#stdinErrorHandler = (err: Error): void => {
+		this.#recoverStdin(err);
+	};
 	#dead = false;
 	// Captured at construction and re-read at start(): when true, every real
 	// terminal side effect (writes, probes, raw mode, SIGWINCH, timers) is
@@ -489,6 +502,16 @@ export class ProcessTerminal implements Terminal {
 	#reportedRows?: number;
 	#mode2031DebounceTimer?: Timer;
 	#progressTimer?: Timer;
+
+	constructor(
+		options: {
+			stdin?: NodeJS.ReadStream;
+			reopenStdin?: () => NodeJS.ReadStream;
+		} = {},
+	) {
+		this.#stdin = options.stdin ?? process.stdin;
+		this.#reopenStdin = options.reopenStdin ?? (() => new TtyReadStream(process.stdin.fd));
+	}
 
 	get kittyProtocolActive(): boolean {
 		return this.#kittyProtocolActive;
@@ -552,12 +575,8 @@ export class ProcessTerminal implements Terminal {
 		terminalEverStarted = true;
 
 		// Save previous state and enable raw mode
-		this.#wasRaw = process.stdin.isRaw || false;
-		if (process.stdin.setRawMode) {
-			process.stdin.setRawMode(true);
-		}
-		process.stdin.setEncoding("utf8");
-		process.stdin.resume();
+		this.#wasRaw = this.#stdin.isRaw || false;
+		this.#activateStdin(this.#stdin);
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		this.#safeWrite("\x1b[?2004h");
@@ -1103,7 +1122,7 @@ export class ProcessTerminal implements Terminal {
 	 */
 	#queryAndEnableKittyProtocol(): void {
 		this.#setupStdinBuffer();
-		process.stdin.on("data", this.#stdinDataHandler!);
+		this.#stdin.on("data", this.#stdinDataHandler!);
 		// Progressive enhancement query: CSI ?u asks the terminal for its current
 		// kitty keyboard flags (no side effect on the stack); the DA1 sentinel
 		// guarantees a reply even from terminals that ignore CSI ?u.
@@ -1245,7 +1264,8 @@ export class ProcessTerminal implements Terminal {
 			lastDataTime = Date.now();
 		};
 
-		process.stdin.on("data", onData);
+		this.#stdinDrainHandlers.add(onData);
+		this.#stdin.on("data", onData);
 		const endTime = Date.now() + maxMs;
 
 		try {
@@ -1257,7 +1277,8 @@ export class ProcessTerminal implements Terminal {
 				await new Promise(resolve => setTimeout(resolve, Math.min(idleMs, timeLeft)));
 			}
 		} finally {
-			process.stdin.removeListener("data", onData);
+			this.#stdin.removeListener("data", onData);
+			this.#stdinDrainHandlers.delete(onData);
 			this.#inputHandler = previousHandler;
 		}
 	}
@@ -1344,9 +1365,11 @@ export class ProcessTerminal implements Terminal {
 
 		// Remove event handlers
 		if (this.#stdinDataHandler) {
-			process.stdin.removeListener("data", this.#stdinDataHandler);
+			this.#stdin.removeListener("data", this.#stdinDataHandler);
 			this.#stdinDataHandler = undefined;
 		}
+		for (const handler of this.#stdinDrainHandlers) this.#stdin.removeListener("data", handler);
+		this.#stdinDrainHandlers.clear();
 		this.#inputHandler = undefined;
 		this.#appearance = undefined;
 		if (this.#stdoutResizeListener) {
@@ -1358,14 +1381,46 @@ export class ProcessTerminal implements Terminal {
 		// Pause stdin to prevent any buffered input (e.g., Ctrl+D) from being
 		// re-interpreted after raw mode is disabled. This fixes a race condition
 		// where Ctrl+D could close the parent shell over SSH.
-		process.stdin.pause();
+		this.#stdin.pause();
 
 		// Restore raw mode state
-		if (process.stdin.setRawMode) {
-			process.stdin.setRawMode(this.#wasRaw);
+		if (this.#stdin.setRawMode) {
+			this.#stdin.setRawMode(this.#wasRaw);
 		}
+		this.#stdin.removeListener("error", this.#stdinErrorHandler);
 		this.#stdoutErrorCleanup?.();
 		this.#stdoutErrorCleanup = undefined;
+	}
+
+	#activateStdin(stdin: NodeJS.ReadStream): void {
+		stdin.on("error", this.#stdinErrorHandler);
+		if (stdin.setRawMode) stdin.setRawMode(true);
+		stdin.setEncoding("utf8");
+		if (this.#stdinDataHandler) stdin.on("data", this.#stdinDataHandler);
+		for (const handler of this.#stdinDrainHandlers) stdin.on("data", handler);
+		stdin.resume();
+	}
+
+	#recoverStdin(err: Error): void {
+		if (!isTransientReadEintr(err)) throw err;
+
+		const failed = this.#stdin;
+		failed.removeListener("error", this.#stdinErrorHandler);
+		if (this.#stdinDataHandler) failed.removeListener("data", this.#stdinDataHandler);
+		for (const handler of this.#stdinDrainHandlers) failed.removeListener("data", handler);
+
+		let replacement: NodeJS.ReadStream;
+		try {
+			replacement = this.#reopenStdin();
+			if (replacement === failed || replacement.destroyed) {
+				throw new Error("stdin reopen returned an unusable stream");
+			}
+			this.#stdin = replacement;
+			this.#activateStdin(replacement);
+		} catch (reopenError) {
+			throw new AggregateError([err, reopenError], "Failed to reopen terminal input after interrupted read");
+		}
+		logger.warn("terminal input read interrupted; reopened stdin", { err });
 	}
 
 	#ensureStdoutErrorHandler(): void {

--- a/packages/tui/test/process-terminal-input-recovery.test.ts
+++ b/packages/tui/test/process-terminal-input-recovery.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { PassThrough } from "node:stream";
+import { ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
+import { setTerminalHeadless } from "@oh-my-pi/pi-utils";
+
+class FakeStdin extends PassThrough {
+	readonly fd = 0;
+	readonly isTTY = true;
+	isRaw = false;
+
+	setRawMode(mode: boolean): this {
+		this.isRaw = mode;
+		return this;
+	}
+}
+
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+function restoreStdoutIsTty(): void {
+	if (stdoutIsTtyDescriptor) {
+		Object.defineProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+		return;
+	}
+	Reflect.deleteProperty(process.stdout, "isTTY");
+}
+
+describe("ProcessTerminal stdin recovery", () => {
+	let previousHeadless: boolean;
+	let terminal: ProcessTerminal | undefined;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		previousHeadless = setTerminalHeadless(false);
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		vi.spyOn(process, "kill").mockReturnValue(true);
+		vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		terminal?.stop();
+		terminal = undefined;
+		setTerminalHeadless(previousHeadless);
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+		restoreStdoutIsTty();
+	});
+
+	it("reopens a Bun-destroyed TTY read stream and delivers the next input", () => {
+		const failed = new FakeStdin();
+		const replacement = new FakeStdin();
+		const reopenStdin = vi.fn(() => replacement as unknown as NodeJS.ReadStream);
+		const inputs: string[] = [];
+		terminal = new ProcessTerminal({
+			stdin: failed as unknown as NodeJS.ReadStream,
+			reopenStdin,
+		});
+		terminal.start(
+			data => inputs.push(data),
+			() => {},
+		);
+
+		const interruptedRead = Object.assign(new Error("interrupted system call"), {
+			code: "EINTR",
+			syscall: "read",
+			fd: 25,
+			errno: -4,
+		});
+		failed.destroy();
+		failed.emit("error", interruptedRead);
+		replacement.write("q");
+		vi.advanceTimersByTime(75);
+
+		expect(reopenStdin).toHaveBeenCalledTimes(1);
+		expect(failed.destroyed).toBe(true);
+		expect(replacement.destroyed).toBe(false);
+		expect(replacement.isRaw).toBe(true);
+		expect(inputs).toEqual(["q"]);
+
+		terminal.stop();
+		terminal = undefined;
+		expect(replacement.isRaw).toBe(false);
+		expect(replacement.listenerCount("error")).toBe(0);
+	});
+
+	it("keeps an active input drain on the replacement stream", async () => {
+		const failed = new FakeStdin();
+		const replacement = new FakeStdin();
+		terminal = new ProcessTerminal({
+			stdin: failed as unknown as NodeJS.ReadStream,
+			reopenStdin: () => replacement as unknown as NodeJS.ReadStream,
+		});
+		terminal.start(
+			() => {},
+			() => {},
+		);
+
+		let settled = false;
+		const drain = terminal.drainInput(200, 50).then(() => {
+			settled = true;
+		});
+		const interruptedRead = Object.assign(new Error("interrupted system call"), {
+			code: "EINTR",
+			syscall: "read",
+		});
+		failed.destroy();
+		failed.emit("error", interruptedRead);
+
+		vi.advanceTimersByTime(40);
+		replacement.write("x");
+		vi.advanceTimersByTime(10);
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		vi.advanceTimersByTime(40);
+		replacement.write("y");
+		vi.advanceTimersByTime(10);
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		vi.advanceTimersByTime(50);
+		await Promise.resolve();
+		await drain;
+		expect(settled).toBe(true);
+	});
+
+	it("keeps unrelated stdin errors fatal", () => {
+		const stdin = new FakeStdin();
+		terminal = new ProcessTerminal({
+			stdin: stdin as unknown as NodeJS.ReadStream,
+			reopenStdin: () => new FakeStdin() as unknown as NodeJS.ReadStream,
+		});
+		terminal.start(
+			() => {},
+			() => {},
+		);
+		const failure = Object.assign(new Error("device failure"), { code: "EIO", syscall: "read" });
+
+		expect(() => stdin.emit("error", failure)).toThrow(failure);
+	});
+});

--- a/packages/utils/test/postmortem-cleanup-error.test.ts
+++ b/packages/utils/test/postmortem-cleanup-error.test.ts
@@ -44,6 +44,25 @@ function wrapCause(reason: Error, wrapperCount: number): Error {
 	return current;
 }
 
+describe("postmortem fatal boundary", () => {
+	it("keeps uncaught read EINTR fatal outside its owner", async () => {
+		const result = await runPostmortemProbe(`
+			import "${postmortemModuleUrl}";
+			queueMicrotask(() => {
+				throw Object.assign(new Error("interrupted system call"), {
+					code: "EINTR",
+					syscall: "read",
+					fd: 25,
+					errno: -4,
+				});
+			});
+		`);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("Uncaught Exception");
+		expect(result.stderr).toContain("interrupted system call");
+	});
+});
 describe("postmortem expected cleanup errors", () => {
 	it("marks errors with the well-known cleanup symbol and recognizes them", () => {
 		const reason = new Error("browser run ended");


### PR DESCRIPTION
## Summary

- recover terminal input when Bun destroys the active TTY stream after a macOS `read` `EINTR`
- preserve the raw-mode data pipeline and any active shutdown-drain listeners on the replacement stream
- prevent parked subagents from terminating process-global Tiny/Mnemopi workers still owned by the primary session
- keep unrelated stdin errors and uncaught read `EINTR` outside the owning boundary fatal

## Root cause

Bun 1.3.14 does not retry macOS `read(2)` `EINTR` in its low-level path. Its `process.stdin` wrapper catches the native reader failure and destroys the JS stream. Consuming the later `uncaughtException` can keep the process alive, but cannot repair that destroyed stream and conflicts with Node's documented fatal-boundary semantics.

`ProcessTerminal` owns the stdin listener/raw-mode lifecycle, so it can safely replace the failed fd 0 wrapper, restore encoding/raw mode, and migrate both the normal input handler and active drain handlers. Any reopen failure still propagates as fatal.

Separately, `AgentSession.dispose()` previously shut down module-global Tiny/Mnemopi workers for every session, including a parked subagent. Shutdown is now limited to the primary session that owns the process-global async manager.

## Verification

- focused terminal, ownership, and postmortem regressions: 13 passed
- TUI formatter and TypeScript checks: passed
- coding-agent changed-file formatter check and full TypeScript check: passed
- utils full suite: 455 passed
- real PTY source-level smoke: injected the exact `{ code: "EINTR", syscall: "read" }` shape, recreated stdin, delivered the next input byte, and exited 0
- independent review: PASS after adding active-drain listener migration coverage

Fixes #5328.
Related: #4821, #899.
