### PR TITLE
feat(providers): add DaoXE multi-model gateway

### DIFF
--- a/packages/ai/src/registry/daoxe.ts
+++ b/packages/ai/src/registry/daoxe.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginDaoXE = createApiKeyLogin({
+	providerLabel: "DaoXE",
+	authUrl: "https://daoxe.com/dashboard",
+	instructions: "Create or copy your API key from the DaoXE dashboard",
+	promptMessage: "Paste your DaoXE API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "DaoXE",
+		modelsUrl: "https://daoxe.com/v1/models",
+	},
+});
+
+export const daoxeProvider = {
+	id: "daoxe",
+	name: "DaoXE",
+	login: (cb: OAuthLoginCallbacks) => loginDaoXE(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -10,6 +10,7 @@ import { cloudflareAiGatewayProvider } from "./cloudflare-ai-gateway";
 import { coreWeaveProvider } from "./coreweave";
 import { cursorProvider } from "./cursor";
 import { deepseekProvider } from "./deepseek";
+import { daoxeProvider } from "./daoxe";
 import { devinProvider } from "./devin";
 import { firepassProvider } from "./firepass";
 import { fireworksProvider } from "./fireworks";
@@ -105,6 +106,7 @@ const ALL = [
 	xiaomiTokenPlanCnProvider,
 	firepassProvider,
 	deepseekProvider,
+	daoxeProvider,
 	moonshotProvider,
 	cerebrasProvider,
 	basetenProvider,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -15828,6 +15828,188 @@
 			}
 		}
 	},
+	"daoxe": {
+		"claude-haiku-4-5-20251001": {
+			"id": "claude-haiku-4-5-20251001",
+			"name": "Claude Haiku 4.5",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 5
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"grok-4.3": {
+			"id": "grok-4.3",
+			"name": "Grok 4.3",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 2.5,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 30000
+		},
+		"claude-opus-4-8": {
+			"id": "claude-opus-4-8",
+			"name": "Claude Opus 4.8",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000
+		},
+		"grok-4.5": {
+			"id": "grok-4.5",
+			"name": "Grok 4.5",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 6,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 500000
+		},
+		"kimi-k2.5": {
+			"id": "kimi-k2.5",
+			"name": "Kimi K2.5",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 3,
+				"cacheRead": 0.1,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144
+		},
+		"gpt-5.4": {
+			"id": "gpt-5.4",
+			"name": "GPT-5.4",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000
+		},
+		"gemini-3.1-pro-preview": {
+			"id": "gemini-3.1-pro-preview",
+			"name": "Gemini 3.1 Pro Preview",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536
+		},
+		"claude-sonnet-4-6": {
+			"id": "claude-sonnet-4-6",
+			"name": "Claude Sonnet 4.6",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000
+		},
+		"gpt-5.5": {
+			"id": "gpt-5.5",
+			"name": "GPT-5.5",
+			"api": "openai-completions",
+			"provider": "daoxe",
+			"baseUrl": "https://daoxe.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000
+		}
+	},
 	"devin": {
 		"claude-5-fable-high": {
 			"id": "claude-5-fable-high",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -17,6 +17,7 @@ import {
 	cloudflareAiGatewayModelManagerOptions,
 	coreWeaveModelManagerOptions,
 	deepseekModelManagerOptions,
+	daoxeModelManagerOptions,
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
 	githubCopilotModelManagerOptions,
@@ -126,6 +127,14 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["DEEPSEEK_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => deepseekModelManagerOptions(config),
 		catalogDiscovery: { label: "DeepSeek" },
+	},
+	{
+		id: "daoxe",
+		defaultModel: "claude-sonnet-4-6",
+		envVars: ["DAOXE_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => daoxeModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: { label: "DaoXE" },
 	},
 	{
 		id: "devin",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -2853,6 +2853,26 @@ export function togetherModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// DaoXE multi-model multi-protocol gateway (OpenAI-compatible Chat Completions)
+// ---------------------------------------------------------------------------
+
+export interface DaoXEModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function daoxeModelManagerOptions(
+	config?: DaoXEModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	return {
+		...createSimpleOpenAICompletionsOptions("daoxe", "https://daoxe.com/v1", config),
+		// Live account catalog is authoritative; models.dev seed is a bootstrap only.
+		dynamicModelsAuthoritative: true,
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 15.5 CoreWeave Serverless Inference
 // ---------------------------------------------------------------------------
 
@@ -4674,6 +4694,10 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDes
 		defaultMaxTokens: 8192,
 	}),
 
+	// --- DaoXE ---
+	openAiCompletionsDescriptor("daoxe", "daoxe", "https://daoxe.com/v1", {
+		filterModel: filterActiveToolCallModels,
+	}),
 	// --- ZenMux ---
 	openAiCompletionsDescriptor("zenmux", "zenmux", ZENMUX_OPENAI_BASE_URL, {
 		filterModel: filterActiveToolCallModels,


### PR DESCRIPTION
## Summary
- Add **DaoXE** as a first-class chat-model provider following `docs/adding-a-provider.md`.
- Catalog: `CATALOG_PROVIDERS` entry with `DAOXE_API_KEY`, `createSimpleOpenAICompletionsOptions` + `dynamicModelsAuthoritative: true` (live `GET /v1/models` wins over seed).
- Auth registry: `packages/ai/src/registry/daoxe.ts` API-key login with models-endpoint validation at `https://daoxe.com/v1/models`.
- models.dev mapping: `openAiCompletionsDescriptor("daoxe", ...)` so `generate-models` can refresh the seed.
- Seeded `packages/catalog/src/models.json` `daoxe` from current models.dev DaoXE listing (bootstrap only).

DaoXE is a multi-model multi-protocol API gateway (`https://daoxe.com/v1` OpenAI Chat Completions path used here; also exposes OpenAI Responses + Anthropic Messages for other clients).

I am a DaoXE maintainer. Examples: https://github.com/seven7763/DaoXE-AI

## Test plan
- [ ] Typecheck / registry completeness (`KnownProvider` ↔ registry) passes
- [ ] `/login` shows DaoXE and accepts a key that can hit `/v1/models`
- [ ] With a key, dynamic model list replaces the seed catalog
- [ ] Default model id `claude-sonnet-4-6` resolves when present in catalog