### PR TITLE
fix(tui): refresh appearance on Ctrl+L display reset

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed Ctrl+L display reset retaining a stale light/dark palette when terminal appearance notifications are unavailable or do not cross a multiplexer boundary: the explicit reset now performs one OSC 11 background-color query before repainting, without restoring the periodic polling that cleared terminal text selections.
 - Fixed `/tan` and `/fork` clones cold-missing the provider prompt cache: the per-turn supersede/useless-result prune rewrote the live context without persisting it, so file-based forks and resume rebuilt a divergent (un-pruned) prefix and re-wrote the entire cache
 - Fixed `/tan` pinning the clone's prompt-cache key to the parent's session id instead of the parent's effective cache key, dropping shard affinity when the parent was itself a fork or tan
 - Fixed inconsistent history rendering when toggling the display setting for compacted items

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -392,7 +392,13 @@ export class InputController {
 		this.ctx.editor.onClear = () => this.handleCtrlC();
 		this.ctx.editor.setActionKeys("app.exit", this.ctx.keybindings.getKeys("app.exit"));
 		this.ctx.editor.setActionKeys("app.display.reset", this.ctx.keybindings.getKeys("app.display.reset"));
-		this.ctx.editor.onDisplayReset = () => this.ctx.ui.resetDisplay();
+		this.ctx.editor.onDisplayReset = () => {
+			// Mode 2031 is not end-to-end reliable through every terminal/multiplexer
+			// combination. A user-requested reset gets one fresh OSC 11 probe without
+			// restoring the periodic polling that cleared text selections (#3297).
+			this.ctx.ui.terminal.refreshAppearance?.();
+			this.ctx.ui.resetDisplay();
+		};
 		this.ctx.editor.onExit = () => this.handleCtrlD();
 		this.ctx.editor.setActionKeys("app.suspend", this.ctx.keybindings.getKeys("app.suspend"));
 		this.ctx.editor.onSuspend = () => this.handleCtrlZ();

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -79,6 +79,7 @@ async function createContext() {
 	});
 	const addStartListener = vi.fn();
 	const terminalWrite = vi.fn();
+	const refreshAppearance = vi.fn();
 	const prompt = vi.fn(async () => {});
 	const retry = vi.fn(async () => true);
 	const abort = vi.fn(async () => {});
@@ -135,7 +136,7 @@ async function createContext() {
 			addInputListener,
 			addStartListener,
 			getFocused: vi.fn(() => focused),
-			terminal: { write: terminalWrite },
+			terminal: { write: terminalWrite, refreshAppearance },
 		} as unknown as InteractiveModeContext["ui"],
 		loadingAnimation: undefined,
 		autoCompactionLoader: undefined,
@@ -217,6 +218,7 @@ async function createContext() {
 			retry,
 			abort,
 			resetDisplay,
+			refreshAppearance,
 			handleBtwBranchKey,
 			addInputListener,
 			canBranchBtw,
@@ -249,6 +251,7 @@ describe("InputController keybinding setup", () => {
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
 		expect(spies.resetDisplay).toHaveBeenCalledTimes(1);
+		expect(spies.refreshAppearance).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not mark pasted shell prompts as Python mode while editing", async () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an explicit, user-gesture-safe terminal appearance refresh that performs one OSC 11 background-color query without restoring periodic polling.
+
 ## [16.4.7] - 2026-07-12
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -389,6 +389,14 @@ export interface Terminal {
 	/** The last detected terminal appearance, or undefined if not yet known. */
 	get appearance(): TerminalAppearance | undefined;
 	/**
+	 * Request one fresh OSC 11 background-color probe.
+	 *
+	 * Optional so custom Terminal implementations built against older pi-tui
+	 * versions remain compatible. Intended for explicit user gestures, not
+	 * periodic polling: OSC 11/DA1 writes can clear terminal text selections.
+	 */
+	refreshAppearance?(): void;
+	/**
 	 * Register a callback fired once per DEC private mode when its DECRQM support
 	 * status resolves. Optional: only real terminals implement capability probing.
 	 */
@@ -529,6 +537,10 @@ export class ProcessTerminal implements Terminal {
 				/* ignore callback errors */
 			}
 		}
+	}
+
+	refreshAppearance(): void {
+		this.#queryBackgroundColor();
 	}
 
 	onPrivateModeReport(callback: (mode: number, supported: boolean) => void): void {

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -144,6 +144,24 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		terminal.stop();
 	});
 
+	it("explicit appearance refresh sends one OSC 11 query through a Mode 2031 bridge", () => {
+		const { terminal, queryCount } = setupTerminal();
+
+		// Complete the startup appearance probe. tmux 3.6 reports Mode 2031 as
+		// supported even when its outer terminal cannot produce appearance-change
+		// notifications, so capability support alone cannot suppress a manual refresh.
+		process.stdin.emit("data", "\x1b]11;rgb:ffff/ffff/ffff\x07");
+		process.stdin.emit("data", "\x1b[?1;2c");
+		process.stdin.emit("data", "\x1b[?1;2c");
+		process.stdin.emit("data", "\x1b[?2031;2$y");
+		const afterStartup = queryCount();
+
+		terminal.refreshAppearance();
+
+		expect(queryCount()).toBe(afterStartup + 1);
+		terminal.stop();
+	});
+
 	it("replays already detected OSC 11 appearance to late subscribers", () => {
 		const { terminal } = setupTerminal();
 


### PR DESCRIPTION
## Problem

OMP caches the terminal's OSC 11-derived dark/light appearance. Since periodic OSC 11 polling was removed in #3297, terminals without usable end-to-end Mode 2031 notifications keep the startup palette after their background changes. Ctrl+L currently only repaints the cached theme.

This is reproducible with iTerm2 behind tmux 3.6: tmux reports DEC Mode 2031 as supported, but the outer iTerm2 client does not generate an appearance-change notification, so capability probing alone cannot identify the stale path.

## Change

- Add optional `Terminal.refreshAppearance()` backed by one existing OSC 11 + DA1 query cycle.
- Invoke it only from the explicit `app.display.reset` / Ctrl+L gesture, immediately before `ui.resetDisplay()`.
- Keep periodic polling disabled, preserving the text-selection fix from #3297.
- Keep the API optional for custom `Terminal` implementations built against older pi-tui versions.

## Why query even when DECRQM reports Mode 2031 support?

A multiplexer can report Mode 2031 support while its outer terminal cannot emit the corresponding appearance notification. In the observed iTerm2 + tmux 3.6 setup, `CSI ? 2031 $ p` returns status 2 (recognized/reset), yet no notification reaches OMP when iTerm2 switches its light/dark profile colors. The user-requested reset is therefore the reliable and bounded fallback.

## Verification

- `bun test packages/tui/test/terminal-appearance.test.ts` — 38 passed
- `bun test packages/coding-agent/test/input-controller-keybindings.test.ts packages/coding-agent/test/keybindings-migration.test.ts` — 36 passed
- `bun run check` in `packages/tui` — passed
- `bun run check` in `packages/coding-agent` — passed

The regression coverage verifies that an explicit refresh emits exactly one OSC 11 query even through a Mode 2031-capable bridge, and that Ctrl+L invokes the refresh before resetting the display.