### PR TITLE
Fix /review for oversized GitHub PR diffs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers
 
 ### Fixed
+- Fixed `/review` aborting when GitHub rejects aggregate pull-request diffs over 20,000 lines by falling back to paginated per-file patches and identifying skipped patches ([#5350](https://github.com/can1357/oh-my-pi/issues/5350))
 
 - Fixed `/tan` and `/fork` clones cold-missing the provider prompt cache: the per-turn supersede/useless-result prune rewrote the live context without persisting it, so file-based forks and resume rebuilt a divergent (un-pruned) prefix and re-wrote the entire cache
 - Fixed `/tan` pinning the clone's prompt-cache key to the parent's session id instead of the parent's effective cache key, dropping shard affinity when the parent was itself a fork or tan

--- a/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
+++ b/packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts
@@ -124,38 +124,18 @@ function parseDiff(diffOutput: string): DiffStats {
 	let totalAdded = 0;
 	let totalRemoved = 0;
 
-	// Split by file boundary: "diff --git a/... b/..."
-	const fileChunks = diffOutput.split(/^diff --git /m).filter(Boolean);
-
-	for (const chunk of fileChunks) {
-		// Extract file path from "a/path b/path" line
-		const headerMatch = chunk.match(/^a\/(.+?) b\/(.+)/);
-		if (!headerMatch) continue;
-
-		const path = headerMatch[2];
-
-		// Count added/removed lines (lines starting with + or - but not ++ or --)
-		let linesAdded = 0;
-		let linesRemoved = 0;
-
-		const lines = chunk.split("\n");
-		for (const line of lines) {
-			if (line.startsWith("+") && !line.startsWith("+++")) {
-				linesAdded++;
-			} else if (line.startsWith("-") && !line.startsWith("---")) {
-				linesRemoved++;
-			}
-		}
-
-		const exclusionReason = getExclusionReason(path);
+	for (const file of gh.parsePrUnifiedDiff(diffOutput).files) {
+		const linesAdded = file.additions;
+		const linesRemoved = file.deletions;
+		const exclusionReason = getExclusionReason(file.path);
 		if (exclusionReason) {
-			excluded.push({ path, reason: exclusionReason, linesAdded, linesRemoved });
+			excluded.push({ path: file.path, reason: exclusionReason, linesAdded, linesRemoved });
 		} else {
 			files.push({
-				path,
+				path: file.path,
 				linesAdded,
 				linesRemoved,
-				hunks: `diff --git ${chunk}`,
+				hunks: diffOutput.slice(file.startOffset, file.endOffset),
 			});
 			totalAdded += linesAdded;
 			totalRemoved += linesRemoved;
@@ -236,7 +216,12 @@ function buildReviewPrompt(
 	mode: string,
 	stats: DiffStats,
 	rawDiff: string,
-	options: { additionalInstructions?: string; diffInstruction?: string; contextInstruction?: string } = {},
+	options: {
+		additionalInstructions?: string;
+		diffInstruction?: string;
+		contextInstruction?: string;
+		warnings?: string[];
+	} = {},
 ): string {
 	const agentCount = getRecommendedAgentCount(stats);
 	const skipDiff = rawDiff.length > MAX_DIFF_CHARS || stats.files.length > MAX_FILES_FOR_INLINE_DIFF;
@@ -264,6 +249,7 @@ function buildReviewPrompt(
 		additionalInstructions: options.additionalInstructions,
 		diffInstruction: options.diffInstruction ?? DEFAULT_LARGE_DIFF_INSTRUCTION,
 		contextInstruction: options.contextInstruction ?? DEFAULT_CONTEXT_INSTRUCTION,
+		warnings: options.warnings ?? [],
 	});
 }
 
@@ -372,7 +358,13 @@ function buildReviewPromptFromDiff(
 	diffText: string,
 	extraInstructions: string | undefined,
 	emptyMessage: string,
-	options: { diffInstruction?: string; filteredMessage?: string; contextInstruction?: string } = {},
+	options: {
+		diffInstruction?: string;
+		filteredMessage?: string;
+		contextInstruction?: string;
+		additionalExcluded?: DiffStats["excluded"];
+		warnings?: string[];
+	} = {},
 ): string | undefined {
 	if (!diffText.trim()) {
 		if (ctx.hasUI) ctx.ui.notify(emptyMessage, "warning");
@@ -380,6 +372,7 @@ function buildReviewPromptFromDiff(
 	}
 
 	const stats = parseDiff(diffText);
+	stats.excluded.push(...(options.additionalExcluded ?? []));
 	if (stats.files.length === 0) {
 		if (ctx.hasUI)
 			ctx.ui.notify(options.filteredMessage ?? "No reviewable files (all changes filtered out)", "warning");
@@ -390,7 +383,29 @@ function buildReviewPromptFromDiff(
 		additionalInstructions: extraInstructions,
 		diffInstruction: options.diffInstruction,
 		contextInstruction: options.contextInstruction,
+		warnings: options.warnings,
 	});
+}
+
+function getReviewablePrDiff(payload: gh.PrDiffPayload): {
+	diffText: string;
+	unavailable: DiffStats["excluded"];
+} {
+	const slices: string[] = [];
+	const unavailable: DiffStats["excluded"] = [];
+	for (const file of payload.files) {
+		if (file.patchUnavailable) {
+			unavailable.push({
+				path: file.path,
+				reason: "patch unavailable from GitHub; skipped",
+				linesAdded: file.additions,
+				linesRemoved: file.deletions,
+			});
+			continue;
+		}
+		slices.push(payload.unified.slice(file.startOffset, file.endOffset));
+	}
+	return { diffText: slices.join("\n"), unavailable };
 }
 
 async function buildPrReviewPrompt(
@@ -399,10 +414,10 @@ async function buildPrReviewPrompt(
 	ref: ReviewPrRef,
 	extraInstructions: string,
 ): Promise<string | undefined> {
-	let diffText: string;
+	let payload: gh.PrDiffPayload;
 	try {
 		const lookup = await gh.getOrFetchPrDiff({ cwd: api.cwd, repo: ref.repo, number: ref.number });
-		diffText = lookup.payload.unified;
+		payload = lookup.payload;
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		const failure = `Failed to fetch PR diff for ${ref.repo}#${ref.number}: ${message}`;
@@ -413,13 +428,28 @@ async function buildPrReviewPrompt(
 		return failure;
 	}
 
+	if (payload.files.length > 0 && payload.files.every(file => file.patchUnavailable === true)) {
+		const unavailable = `Unable to review PR ${ref.repo}#${ref.number}: GitHub rejected the aggregate diff as too large and the files API supplied no reviewable patches. Inspect pr://${ref.repo}/${ref.number}/diff for skipped files.`;
+		if (ctx.hasUI) {
+			ctx.ui.notify(unavailable, "warning");
+			return undefined;
+		}
+		return unavailable;
+	}
+
+	const reviewable = getReviewablePrDiff(payload);
 	const promptText = buildReviewPromptFromDiff(
 		ctx,
 		`PR ${ref.repo}#${ref.number}`,
-		diffText,
+		reviewable.diffText,
 		extraInstructions || undefined,
 		`PR ${ref.repo}#${ref.number} has no diff content available`,
-		{ diffInstruction: buildPrLargeDiffInstruction(ref), contextInstruction: buildPrContextInstruction(ref) },
+		{
+			diffInstruction: buildPrLargeDiffInstruction(ref),
+			contextInstruction: buildPrContextInstruction(ref),
+			additionalExcluded: reviewable.unavailable,
+			warnings: payload.warnings,
+		},
 	);
 	if (promptText !== undefined || ctx.hasUI) return promptText;
 	return `Unable to review PR ${ref.repo}#${ref.number}: no diff content available.`;

--- a/packages/coding-agent/src/internal-urls/issue-pr-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/issue-pr-protocol.ts
@@ -393,7 +393,8 @@ function buildSingleResource({
 function formatFileLine(idx: number, file: PrDiffFile, repo: string, prNumber: number): string {
 	const stats = file.changeType === "binary" ? "(binary)" : `+${file.additions} -${file.deletions}`;
 	const rename = file.oldPath ? `  (renamed from ${file.oldPath})` : "";
-	return `${idx}. ${file.path}  ${stats}  [${file.changeType}]${rename}\n   pr://${repo}/${prNumber}/diff/${idx}`;
+	const unavailable = file.patchUnavailable ? " (patch unavailable; skipped)" : "";
+	return `${idx}. ${file.path}  ${stats}  [${file.changeType}]${rename}${unavailable}\n   pr://${repo}/${prNumber}/diff/${idx}`;
 }
 
 async function fetchAndRenderPrDiff(
@@ -432,6 +433,7 @@ async function fetchAndRenderPrDiff(
 			size: Buffer.byteLength(content, "utf-8"),
 			notes: [
 				freshness,
+				...(lookup.payload.warnings ?? []),
 				`Full diff for pr://${repo}/${parsed.number} (${files.length} file${files.length === 1 ? "" : "s"})`,
 			],
 		};
@@ -456,6 +458,7 @@ async function fetchAndRenderPrDiff(
 			size: Buffer.byteLength(content, "utf-8"),
 			notes: [
 				freshness,
+				...(lookup.payload.warnings ?? []),
 				`Showing file ${index}/${files.length}: ${file.path}`,
 				`Read all: pr://${repo}/${parsed.number}/diff/all`,
 			],
@@ -475,7 +478,7 @@ async function fetchAndRenderPrDiff(
 		content,
 		contentType: "text/markdown",
 		size: Buffer.byteLength(content, "utf-8"),
-		notes: [freshness, `File listing for pr://${repo}/${parsed.number}`],
+		notes: [freshness, ...(lookup.payload.warnings ?? []), `File listing for pr://${repo}/${parsed.number}`],
 	};
 }
 

--- a/packages/coding-agent/src/prompts/review-request.md
+++ b/packages/coding-agent/src/prompts/review-request.md
@@ -21,6 +21,14 @@ _No files to review._
 {{/list}}
 {{/if}}
 
+{{#if warnings.length}}
+### Retrieval Warnings
+
+{{#list warnings prefix="- " join="\n"}}
+{{this}}
+{{/list}}
+{{/if}}
+
 ### Distribution Guidelines
 
 Use the `task` tool with `agent: "reviewer"` and a `tasks` array.

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -2693,6 +2693,8 @@ export interface PrDiffFile {
 	changeType: "modified" | "added" | "deleted" | "renamed" | "binary";
 	/** Pre-image path for renames/deletes; same as `path` otherwise. */
 	oldPath?: string;
+	/** Whether GitHub's files API omitted this file's patch. */
+	patchUnavailable?: true;
 	/** Byte offset of the section's `diff --git` line in the unified diff. */
 	startOffset: number;
 	/** Byte offset of the next section (or end-of-text). */
@@ -2703,6 +2705,7 @@ export interface PrDiffPayload {
 	/** Full unified diff text as returned by `gh pr diff --color never`. */
 	unified: string;
 	files: PrDiffFile[];
+	warnings?: string[];
 }
 
 export interface PrDiffLookupOptions {
@@ -2861,6 +2864,11 @@ function isPrDiffFileHeaderLine(line: string): boolean {
 	);
 }
 
+function parsePrDiffMetadataPath(value: string): string {
+	const token = parseDiffQuotedToken(value, 0);
+	return token?.nextIndex === value.length ? token.value : value;
+}
+
 function parsePrDiffSection(section: string, startOffset: number, endOffset: number): PrDiffFile {
 	const lines = section.split("\n");
 	const header = lines[0] ?? "";
@@ -2886,11 +2894,11 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 		}
 		if (line.startsWith("rename from ")) {
 			changeType = "renamed";
-			oldPath = line.slice("rename from ".length);
+			oldPath = parsePrDiffMetadataPath(line.slice("rename from ".length));
 			continue;
 		}
 		if (line.startsWith("rename to ")) {
-			newPath = line.slice("rename to ".length);
+			newPath = parsePrDiffMetadataPath(line.slice("rename to ".length));
 			continue;
 		}
 		if (line.startsWith("Binary files ") && line.endsWith(" differ")) {
@@ -2931,6 +2939,179 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 	return file;
 }
 
+interface PrFilesApiEntry {
+	filename: string;
+	status: "added" | "removed" | "modified" | "renamed" | "copied" | "changed" | "unchanged";
+	additions: number;
+	deletions: number;
+	previous_filename?: string;
+	patch?: string;
+}
+
+const PR_FILES_PAGE_SIZE = 100;
+const PR_FILES_MAX_COUNT = 3_000;
+const OVERSIZED_DIFF_WARNING =
+	"GitHub rejected the aggregate diff as too large; reconstructed the available diff from the pull-request files API.";
+const PR_FILES_LIMIT_WARNING =
+	"GitHub's pull-request files API returns at most 3,000 files; additional changed files may be omitted.";
+const PATCH_UNAVAILABLE_MARKER = "Patch unavailable from GitHub files API; skipped by /review.";
+
+function isOversizedPrDiffError(error: unknown): boolean {
+	if (!(error instanceof Error) || !error.message.includes("HTTP 406")) return false;
+	return (
+		error.message.includes("PullRequest.diff too_large") ||
+		/diff exceeded the maximum number of lines/i.test(error.message)
+	);
+}
+
+function formatSyntheticDiffPath(path: string, prefix: "a/" | "b/" | undefined = undefined): string {
+	const value = `${prefix ?? ""}${path}`;
+	if (/^[\x21-\x7e]+$/.test(value) && !/["\\]/.test(value)) return value;
+
+	let escaped = "";
+	for (const char of value) {
+		switch (char) {
+			case "\x07":
+				escaped += "\\a";
+				break;
+			case "\b":
+				escaped += "\\b";
+				break;
+			case "\f":
+				escaped += "\\f";
+				break;
+			case "\n":
+				escaped += "\\n";
+				break;
+			case "\r":
+				escaped += "\\r";
+				break;
+			case "\t":
+				escaped += "\\t";
+				break;
+			case "\v":
+				escaped += "\\v";
+				break;
+			case "\\":
+				escaped += "\\\\";
+				break;
+			case '"':
+				escaped += '\\"';
+				break;
+			default: {
+				const code = char.charCodeAt(0);
+				escaped += code <= 0x1f || code === 0x7f ? `\\${code.toString(8).padStart(3, "0")}` : char;
+			}
+		}
+	}
+	return `"${escaped}"`;
+}
+
+function mapPrFilesApiChangeType(status: PrFilesApiEntry["status"]): PrDiffFile["changeType"] {
+	switch (status) {
+		case "added":
+			return "added";
+		case "removed":
+			return "deleted";
+		case "renamed":
+			return "renamed";
+		default:
+			return "modified";
+	}
+}
+
+function reconstructPrFilesApiDiff(entries: PrFilesApiEntry[]): string {
+	const sections = entries.map(entry => {
+		const oldPath = entry.previous_filename ?? entry.filename;
+		const section = [
+			`diff --git ${formatSyntheticDiffPath(oldPath, "a/")} ${formatSyntheticDiffPath(entry.filename, "b/")}`,
+		];
+		switch (entry.status) {
+			case "added":
+				section.push("new file mode 100644");
+				break;
+			case "removed":
+				section.push("deleted file mode 100644");
+				break;
+			case "renamed":
+				section.push(
+					`rename from ${formatSyntheticDiffPath(oldPath)}`,
+					`rename to ${formatSyntheticDiffPath(entry.filename)}`,
+				);
+				break;
+		}
+		section.push(
+			`--- ${entry.status === "added" ? "/dev/null" : formatSyntheticDiffPath(oldPath, "a/")}`,
+			`+++ ${entry.status === "removed" ? "/dev/null" : formatSyntheticDiffPath(entry.filename, "b/")}`,
+			entry.patch ? entry.patch : PATCH_UNAVAILABLE_MARKER,
+		);
+		return section.join("\n");
+	});
+	return sections.join("\n");
+}
+
+async function fetchPrFilesApiFallback(
+	cwd: string,
+	repo: string,
+	number: number,
+	signal: AbortSignal | undefined,
+): Promise<{ rendered: string; sourceUrl: undefined; payload: PrDiffPayload }> {
+	const entries: PrFilesApiEntry[] = [];
+	let page = 1;
+	let reachedLimit = false;
+	while (entries.length < PR_FILES_MAX_COUNT) {
+		const response = await git.github.json<PrFilesApiEntry[]>(
+			cwd,
+			[
+				"api",
+				"--method",
+				"GET",
+				`/repos/${repo}/pulls/${number}/files`,
+				"-F",
+				`per_page=${PR_FILES_PAGE_SIZE}`,
+				"-F",
+				`page=${page}`,
+			],
+			signal,
+			{ repoProvided: true },
+		);
+		entries.push(...response.slice(0, PR_FILES_MAX_COUNT - entries.length));
+		if (response.length < PR_FILES_PAGE_SIZE) break;
+		if (entries.length === PR_FILES_MAX_COUNT) {
+			reachedLimit = true;
+			break;
+		}
+		page += 1;
+	}
+
+	const rendered = reconstructPrFilesApiDiff(entries);
+	const parsed = parsePrUnifiedDiff(rendered);
+	const files = parsed.files.map((file, index) => {
+		const entry = entries[index];
+		if (!entry) return file;
+		const overlay: PrDiffFile = {
+			...file,
+			path: entry.filename,
+			additions: entry.additions,
+			deletions: entry.deletions,
+			changeType: mapPrFilesApiChangeType(entry.status),
+		};
+		if (entry.previous_filename && entry.previous_filename !== entry.filename) {
+			overlay.oldPath = entry.previous_filename;
+		} else {
+			delete overlay.oldPath;
+		}
+		if (!entry.patch) overlay.patchUnavailable = true;
+		return overlay;
+	});
+	const warnings = reachedLimit ? [OVERSIZED_DIFF_WARNING, PR_FILES_LIMIT_WARNING] : [OVERSIZED_DIFF_WARNING];
+	return {
+		rendered,
+		sourceUrl: undefined,
+		payload: { unified: "", files, warnings },
+	};
+}
+
 async function fetchPrDiffFresh(
 	cwd: string,
 	repo: string,
@@ -2939,7 +3120,13 @@ async function fetchPrDiffFresh(
 ): Promise<{ rendered: string; sourceUrl: string | undefined; payload: PrDiffPayload }> {
 	const args = ["pr", "diff", String(number), "--color", "never"];
 	appendRepoFlag(args, repo, String(number));
-	const text = await git.github.text(cwd, args, signal, { repoProvided: true, trimOutput: false });
+	let text: string;
+	try {
+		text = await git.github.text(cwd, args, signal, { repoProvided: true, trimOutput: false });
+	} catch (error) {
+		if (!isOversizedPrDiffError(error)) throw error;
+		return fetchPrFilesApiFallback(cwd, repo, number, signal);
+	}
 	const payload = parsePrUnifiedDiff(text);
 	// `rendered` already carries the verbatim diff; blank the payload copy so
 	// the cache row stores a potentially huge diff once instead of twice.
@@ -2969,7 +3156,7 @@ export async function getOrFetchPrDiff(options: PrDiffLookupOptions): Promise<Vi
 		rendered: lookup.rendered,
 		sourceUrl: lookup.sourceUrl,
 		// Rehydrate the unified text from `rendered` (stored once per row).
-		payload: { unified: lookup.rendered, files: lookup.payload.files },
+		payload: { unified: lookup.rendered, files: lookup.payload.files, warnings: lookup.payload.warnings },
 		status: lookup.status,
 		fetchedAt: lookup.fetchedAt,
 	};

--- a/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-commands/review.test.ts
@@ -51,11 +51,85 @@ interface NotifyCall {
 	type: "info" | "warning" | "error" | undefined;
 }
 
+const FALLBACK_WARNING =
+	"GitHub rejected the aggregate diff as too large; reconstructed the available diff from the pull-request files API.";
+const FALLBACK_REVIEWABLE_PATH = 'src/new "quoted"\\file.ts';
+const FALLBACK_UNAVAILABLE_PATH = "src/missing.bin";
+const FALLBACK_UNAVAILABLE_MARKER = "Patch unavailable from GitHub files API; skipped by /review.";
+const FALLBACK_REVIEWABLE_DIFF = String.raw`diff --git "a/src/old \"quoted\"\\file.ts" "b/src/new \"quoted\"\\file.ts"
+similarity index 90%
+rename from "src/old \"quoted\"\\file.ts"
+rename to "src/new \"quoted\"\\file.ts"
+--- "a/src/old \"quoted\"\\file.ts"
++++ "b/src/new \"quoted\"\\file.ts"
+@@ -1 +1 @@
+-old value
++new value`;
+const FALLBACK_UNAVAILABLE_DIFF = `diff --git a/${FALLBACK_UNAVAILABLE_PATH} b/${FALLBACK_UNAVAILABLE_PATH}
+--- a/${FALLBACK_UNAVAILABLE_PATH}
++++ b/${FALLBACK_UNAVAILABLE_PATH}
+${FALLBACK_UNAVAILABLE_MARKER}`;
+
 function makePrDiffLookup(unified: string): ViewLookupResult<PrDiffPayload> {
+	const payload = gh.parsePrUnifiedDiff(unified);
 	return {
 		rendered: unified,
 		sourceUrl: undefined,
-		payload: { unified, files: [] },
+		payload,
+		status: "fresh",
+		fetchedAt: Date.now(),
+	};
+}
+
+function makeFallbackPrDiffLookup(): ViewLookupResult<PrDiffPayload> {
+	const unified = [FALLBACK_REVIEWABLE_DIFF, FALLBACK_UNAVAILABLE_DIFF].join("\n");
+	const parsed = gh.parsePrUnifiedDiff(unified);
+	const reviewable = parsed.files[0];
+	const unavailable = parsed.files[1];
+	if (!reviewable || !unavailable) throw new Error("fallback fixture did not produce two diff files");
+
+	return {
+		rendered: unified,
+		sourceUrl: undefined,
+		payload: {
+			unified,
+			files: [
+				reviewable,
+				{
+					...unavailable,
+					additions: 17,
+					deletions: 9,
+					patchUnavailable: true,
+				},
+			],
+			warnings: [FALLBACK_WARNING],
+		},
+		status: "fresh",
+		fetchedAt: Date.now(),
+	};
+}
+
+function makeAllUnavailablePrDiffLookup(): ViewLookupResult<PrDiffPayload> {
+	const unified = FALLBACK_UNAVAILABLE_DIFF;
+	const parsed = gh.parsePrUnifiedDiff(unified);
+	const unavailable = parsed.files[0];
+	if (!unavailable) throw new Error("all-unavailable fixture did not produce a diff file");
+
+	return {
+		rendered: unified,
+		sourceUrl: undefined,
+		payload: {
+			unified,
+			files: [
+				{
+					...unavailable,
+					additions: 17,
+					deletions: 9,
+					patchUnavailable: true,
+				},
+			],
+			warnings: [FALLBACK_WARNING],
+		},
 		status: "fresh",
 		fetchedAt: Date.now(),
 	};
@@ -301,6 +375,60 @@ describe("ReviewCommand", () => {
 		expect(result!).toContain("per-file `pr://owner/repo/123/diff/<index>`");
 		expect(result!).toContain("NEVER use local `git diff`/`git show` for PR diff content");
 		expect(result!).not.toContain("MUST run `git diff`/`git show` for assigned files");
+	});
+
+	it("reviews available PR patches while excluding unavailable fallback files", async () => {
+		const dir = await createTempDir();
+		spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makeFallbackPrDiffLookup());
+		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+		const ctx = { hasUI: false } as unknown as HookCommandContext;
+
+		const result = await command.execute(["https://github.com/owner/example/pull/77"], ctx);
+
+		expect(result).toBeDefined();
+		const promptText = result!;
+		expect(promptText).toContain(FALLBACK_REVIEWABLE_PATH);
+		expect(promptText).toContain("`src/missing.bin` (+17/-9) — patch unavailable from GitHub; skipped");
+		expect(promptText).toContain("### Retrieval Warnings");
+		expect(promptText).toContain(FALLBACK_WARNING);
+		expect(promptText).toContain("+new value");
+		expect(promptText).not.toContain(FALLBACK_UNAVAILABLE_MARKER);
+	});
+
+	it("returns the exact all-unavailable PR limitation in headless mode", async () => {
+		const dir = await createTempDir();
+		spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makeAllUnavailablePrDiffLookup());
+		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+		const ctx = { hasUI: false } as unknown as HookCommandContext;
+
+		const result = await command.execute(["https://github.com/owner/example/pull/77"], ctx);
+
+		expect(result).toBe(
+			"Unable to review PR owner/example#77: GitHub rejected the aggregate diff as too large and the files API supplied no reviewable patches. Inspect pr://owner/example/77/diff for skipped files.",
+		);
+	});
+
+	it("notifies and stops with the exact all-unavailable PR limitation in UI mode", async () => {
+		const dir = await createTempDir();
+		spyOn(gh, "getOrFetchPrDiff").mockResolvedValue(makeAllUnavailablePrDiffLookup());
+		const notifications: NotifyCall[] = [];
+		const command = new ReviewCommand({ cwd: dir } as unknown as CustomCommandAPI);
+		const ctx = createContext({
+			onNotify: call => {
+				notifications.push(call);
+			},
+		});
+
+		const result = await command.execute(["https://github.com/owner/example/pull/77"], ctx);
+
+		expect(result).toBeUndefined();
+		expect(notifications).toEqual([
+			{
+				message:
+					"Unable to review PR owner/example#77: GitHub rejected the aggregate diff as too large and the files API supplied no reviewable patches. Inspect pr://owner/example/77/diff for skipped files.",
+				type: "warning",
+			},
+		]);
 	});
 
 	it("rejects unsupported PR-like URL formats as normal instructions", async () => {

--- a/packages/coding-agent/test/internal-urls/issue-pr-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/issue-pr-protocol.test.ts
@@ -128,6 +128,14 @@ interface DiffFileSpec {
 	oldName?: string;
 	binary?: boolean;
 }
+interface PrFilesApiFixtureEntry {
+	filename: string;
+	status: "added" | "removed" | "modified" | "renamed" | "copied" | "changed" | "unchanged";
+	additions: number;
+	deletions: number;
+	previous_filename?: string;
+	patch?: string;
+}
 
 function makePrDiff(files: DiffFileSpec[]): string {
 	return files
@@ -325,6 +333,185 @@ describe("pr://.../diff family", () => {
 		expect(resource.content).toContain("pr://owner/example/77/diff/2");
 		expect(resource.notes?.[0]).toBe("Fetched live");
 		expect(textSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to paginated pull-request files after an oversized aggregate diff error", async () => {
+		const oversizedError = new Error("gh: HTTP 406: PullRequest.diff too_large");
+		const textSpy = vi.spyOn(git.github, "text").mockRejectedValueOnce(oversizedError);
+		const specialName = 'src/special "quoted"\\name.ts';
+		const entries: PrFilesApiFixtureEntry[] = [
+			{
+				filename: "src/one.ts",
+				status: "modified",
+				additions: 3,
+				deletions: 1,
+				patch: "@@ -1,1 +1,3 @@\n-old line\n+new line\n+another line\n+third line",
+			},
+			{
+				filename: "src/new.ts",
+				status: "added",
+				additions: 2,
+				deletions: 0,
+				patch: "@@ -0,0 +1,2 @@\n+new line 0\n+new line 1",
+			},
+			{
+				filename: "src/renamed.ts",
+				status: "renamed",
+				additions: 1,
+				deletions: 1,
+				previous_filename: "src/original.ts",
+				patch: "@@ -1,1 +1,1 @@\n-old rename\n+new rename",
+			},
+			{
+				filename: specialName,
+				status: "modified",
+				additions: 7,
+				deletions: 2,
+				patch: "@@ -1,2 +1,2 @@\n-special old\n+special new",
+			},
+			{
+				filename: "src/unavailable.bin",
+				status: "modified",
+				additions: 4,
+				deletions: 6,
+			},
+			...Array.from(
+				{ length: 95 },
+				(_, index): PrFilesApiFixtureEntry => ({
+					filename: `src/filler-${String(index + 1).padStart(3, "0")}.ts`,
+					status: "modified",
+					additions: 0,
+					deletions: 0,
+					patch: "@@ -0,0 +0,0 @@",
+				}),
+			),
+			{
+				filename: "src/page-two.ts",
+				status: "modified",
+				additions: 1,
+				deletions: 0,
+				patch: "@@ -0,0 +1,1 @@\n+page two",
+			},
+		];
+		const pageOne = entries.slice(0, 100);
+		const pageTwo = entries.slice(100);
+		const jsonSpy = vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			const endpoint = "/repos/owner/example/pulls/77/files";
+			const pageArg = args.find(value => value.startsWith("page="));
+			if (!args.includes(endpoint) || !pageArg) {
+				throw new Error(`unexpected files API args: ${args.join(" ")}`);
+			}
+			if (pageArg === "page=1") return pageOne as never;
+			if (pageArg === "page=2") return pageTwo as never;
+			throw new Error(`unexpected files API page: ${pageArg}`);
+		});
+
+		const router = InternalUrlRouter.instance();
+		const list = await router.resolve("pr://owner/example/77/diff");
+
+		expect(list.content).toContain("# Pull Request Diff: owner/example#77 (101 files)");
+		const listingPositions = entries.map(entry => list.content.indexOf(entry.filename));
+		expect(
+			listingPositions.every(
+				(position, index) => position >= 0 && (index === 0 || position > (listingPositions[index - 1] ?? -1)),
+			),
+		).toBe(true);
+		expect(list.content).toContain("1. src/one.ts  +3 -1  [modified]");
+		expect(list.content).toContain("2. src/new.ts  +2 -0  [added]");
+		expect(list.content).toContain("3. src/renamed.ts  +1 -1  [renamed]  (renamed from src/original.ts)");
+		expect(list.content).toContain(`4. ${specialName}  +7 -2  [modified]`);
+		expect(list.content).toContain("5. src/unavailable.bin  +4 -6  [modified] (patch unavailable; skipped)");
+		const fallbackWarning =
+			"GitHub rejected the aggregate diff as too large; reconstructed the available diff from the pull-request files API.";
+		expect(list.notes).toEqual(expect.arrayContaining([fallbackWarning]));
+
+		const escapedSpecialName = specialName.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+		const expectedSpecialSection = [
+			`diff --git "a/${escapedSpecialName}" "b/${escapedSpecialName}"`,
+			`--- "a/${escapedSpecialName}"`,
+			`+++ "b/${escapedSpecialName}"`,
+			"@@ -1,2 +1,2 @@",
+			"-special old",
+			"+special new",
+		].join("\n");
+		const full = await router.resolve("pr://owner/example/77/diff/all");
+		expect(full.contentType).toBe("text/plain");
+		expect(full.content).toContain(expectedSpecialSection);
+		expect(full.content).toContain("diff --git a/src/original.ts b/src/renamed.ts");
+		expect(full.content).toContain("rename from src/original.ts");
+		expect(full.content).toContain("rename to src/renamed.ts");
+		expect(full.content).toContain("--- /dev/null");
+		expect(full.content).toContain("Patch unavailable from GitHub files API; skipped by /review.");
+		expect(full.notes?.[0]).toMatch(/^Cached:/);
+		expect(full.notes).toEqual(expect.arrayContaining([fallbackWarning]));
+
+		const slice = await router.resolve("pr://owner/example/77/diff/4");
+		expect(slice.contentType).toBe("text/plain");
+		expect(slice.content).toBe(`${expectedSpecialSection}\n`);
+		expect(slice.content).not.toContain("src/one.ts");
+		expect(slice.notes?.[0]).toMatch(/^Cached:/);
+		expect(slice.notes).toEqual(expect.arrayContaining([fallbackWarning]));
+
+		expect(textSpy).toHaveBeenCalledTimes(1);
+		expect(jsonSpy).toHaveBeenCalledTimes(2);
+		expect(jsonSpy.mock.calls.map(call => call[1])).toEqual([
+			["api", "--method", "GET", "/repos/owner/example/pulls/77/files", "-F", "per_page=100", "-F", "page=1"],
+			["api", "--method", "GET", "/repos/owner/example/pulls/77/files", "-F", "per_page=100", "-F", "page=2"],
+		]);
+	});
+
+	it("does not invoke the files API for an unrelated aggregate-diff error", async () => {
+		const textSpy = vi
+			.spyOn(git.github, "text")
+			.mockRejectedValueOnce(new Error("GitHub CLI is not authenticated. Run `gh auth login`."));
+		const jsonSpy = vi.spyOn(git.github, "json");
+
+		const router = InternalUrlRouter.instance();
+		await expect(router.resolve("pr://owner/example/77/diff")).rejects.toThrow(/GitHub CLI is not authenticated/);
+		expect(textSpy).toHaveBeenCalledTimes(1);
+		expect(jsonSpy).not.toHaveBeenCalled();
+	});
+
+	it("stops the files API fallback at 3,000 entries without requesting page 31", async () => {
+		const textSpy = vi
+			.spyOn(git.github, "text")
+			.mockRejectedValueOnce(new Error("gh: HTTP 406: PullRequest.diff too_large"));
+		const jsonSpy = vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			const endpoint = "/repos/owner/example/pulls/77/files";
+			const pageArg = args.find(value => value.startsWith("page="));
+			if (!args.includes(endpoint) || !pageArg) {
+				throw new Error(`unexpected files API args: ${args.join(" ")}`);
+			}
+			const page = Number(pageArg.slice("page=".length));
+			if (!Number.isInteger(page) || page < 1 || page > 30) {
+				throw new Error(`unexpected files API page: ${pageArg}`);
+			}
+			return Array.from(
+				{ length: 100 },
+				(_, index): PrFilesApiFixtureEntry => ({
+					filename: `src/cap-${String((page - 1) * 100 + index + 1).padStart(4, "0")}.ts`,
+					status: "modified",
+					additions: 1,
+					deletions: 0,
+					patch: "@@ -0,0 +1,1 @@\n+line",
+				}),
+			) as never;
+		});
+
+		const router = InternalUrlRouter.instance();
+		const resource = await router.resolve("pr://owner/example/77/diff");
+
+		const limitWarning =
+			"GitHub's pull-request files API returns at most 3,000 files; additional changed files may be omitted.";
+		expect(resource.content).toContain("# Pull Request Diff: owner/example#77 (3000 files)");
+		expect(resource.notes).toEqual(expect.arrayContaining([limitWarning]));
+		expect(textSpy).toHaveBeenCalledTimes(1);
+		expect(jsonSpy).toHaveBeenCalledTimes(30);
+		const pages = jsonSpy.mock.calls.map(call => {
+			const pageArg = call[1].find(value => value.startsWith("page="));
+			return pageArg ? Number(pageArg.slice("page=".length)) : -1;
+		});
+		expect(pages).toEqual(Array.from({ length: 30 }, (_, index) => index + 1));
 	});
 
 	it("pr://owner/repo/<n>/diff renders an empty-file body when the PR has no changes", async () => {

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -251,6 +251,21 @@ describe("parsePrUnifiedDiff", () => {
 		expect(parsed.files[0]?.oldPath).toBeUndefined();
 	});
 
+	it("decodes C-quoted renamed paths in headers and metadata", () => {
+		const diff = [
+			'diff --git "a/src/old folder/He said \\"hi\\" \\\\path.ts" "b/src/new folder/He said \\"hi\\" \\\\path.ts"',
+			"similarity index 100%",
+			'rename from "src/old folder/He said \\"hi\\" \\\\path.ts"',
+			'rename to "src/new folder/He said \\"hi\\" \\\\path.ts"',
+		].join("\n");
+
+		const parsed = parsePrUnifiedDiff(diff);
+		expect(parsed.files).toHaveLength(1);
+		expect(parsed.files[0]?.path).toBe('src/new folder/He said "hi" \\path.ts');
+		expect(parsed.files[0]?.oldPath).toBe('src/old folder/He said "hi" \\path.ts');
+		expect(parsed.files[0]?.changeType).toBe("renamed");
+	});
+
 	it("counts hunk lines whose content starts with file-header markers", () => {
 		const diff = [
 			"diff --git a/src/headings.md b/src/headings.md",


### PR DESCRIPTION
## Summary

- recover from GitHub's deterministic HTTP 406 `PullRequest.diff too_large` response by reconstructing the available unified diff from the paginated pull-request files API
- preserve cache-backed `pr://` list/full/slice behavior, quote and decode special paths, and explicitly identify files whose patches GitHub omitted
- let `/review` continue with available patches, surface retrieval warnings and skipped files, and return an actionable limitation when every patch is unavailable

Fixes #5350.

## Verification

- `bun run check` in `packages/coding-agent` — passed
- `bun test test/internal-urls/issue-pr-protocol.test.ts` — 26 passed
- `bun test test/extensibility/custom-commands/review.test.ts` — 26 passed
- `bun test test/tools/gh.test.ts --test-name-pattern parsePrUnifiedDiff` — 3 passed
- combined focused suite — 91 passed; one pre-existing Windows path-separator assertion in `pr_checkout` still fails identically to baseline
- live private-repository reproduction: 22,220 added lines caused the real GitHub HTTP 406; the changed source reconstructed 91 reviewable files, listed 10 omitted patches under `Excluded Files`, rendered the fallback warning, and progressed to dispatching 16 reviewers