### PR TITLE
fix(lsp): sync documents after applied rename

### DIFF
--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -2630,6 +2630,17 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 						const shouldApply = apply !== false;
 						if (shouldApply) {
 							const applied = await applyWorkspaceEdit(result, this.session.cwd);
+							// Workspace edits bypass open-document state. Synchronize every affected
+							// document before returning so a consecutive rename cannot reuse stale ranges.
+							const changedFiles = [...flattenWorkspaceTextEdits(result).keys()].map(uriToFile);
+							await Promise.all(
+								changedFiles.map(async changedFile => {
+									const content = await Bun.file(changedFile).text();
+									const changedFileServers = getServersForFile(config, changedFile);
+									await syncFileContent(changedFile, content, this.session.cwd, changedFileServers, signal);
+									await notifyFileSaved(changedFile, this.session.cwd, changedFileServers, signal);
+								}),
+							);
 							output = `Applied rename:\n${applied.map(a => `  ${a}`).join("\n")}`;
 						} else {
 							const preview = formatWorkspaceEdit(result, this.session.cwd);

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -258,6 +258,78 @@ describe("lsp regressions", () => {
 		expect(clampTimeout("lsp", 1)).toBe(5);
 		expect(clampTimeout("lsp", 1000)).toBe(60);
 	});
+	it("synchronizes every LSP document after applying a symbol rename", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rename-sync-");
+		try {
+			const targetFile = path.join(tempDir.path(), "component.ts");
+			const targetUri = fileToUri(targetFile);
+			await Bun.write(targetFile, "export class OldComponent {}\n");
+
+			const server = installFakeLsp((message, srv) => {
+				if (message.method === "initialize") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: { capabilities: { renameProvider: true } } });
+				} else if (message.method === "textDocument/rename") {
+					srv.send({
+						jsonrpc: "2.0",
+						id: message.id,
+						result: {
+							changes: {
+								[targetUri]: [
+									{
+										range: {
+											start: { line: 0, character: 13 },
+											end: { line: 0, character: 25 },
+										},
+										newText: "NewComponent",
+									},
+								],
+							},
+						},
+					});
+				} else if (message.method === "shutdown") {
+					srv.send({ jsonrpc: "2.0", id: message.id, result: null });
+				} else if (message.method === "exit") {
+					srv.exit(0);
+				}
+			});
+
+			const config: ServerConfig = {
+				command: "fake-lsp",
+				fileTypes: [".ts"],
+				rootMarkers: [],
+				isLinter: true,
+			};
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "fake-lsp": config },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["fake-lsp", config]]);
+
+			const tool = new LspTool({ cwd: tempDir.path() } as ToolSession);
+			const result = await tool.execute("rename-sync", {
+				action: "rename",
+				file: targetFile,
+				line: 1,
+				symbol: "OldComponent",
+				new_name: "NewComponent",
+				timeout: 5,
+			});
+
+			expect(textResult(result)).toContain("Applied rename");
+			expect(await Bun.file(targetFile).text()).toBe("export class NewComponent {}\n");
+
+			const methods = server.received.map(message => message.method);
+			const renameIndex = methods.indexOf("textDocument/rename");
+			const changeIndex = methods.lastIndexOf("textDocument/didChange");
+			const saveIndex = methods.lastIndexOf("textDocument/didSave");
+			expect(renameIndex).toBeGreaterThanOrEqual(0);
+			expect(changeIndex).toBeGreaterThan(renameIndex);
+			expect(saveIndex).toBeGreaterThan(changeIndex);
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
 
 	it("sends the LSP exit notification after shutdown completes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-shutdown-");


### PR DESCRIPTION
## Summary
- Synchronize every text document changed by an applied `lsp.rename` workspace edit with each applicable LSP client.
- Follow ordered `documentChanges` resource operations so renamed text-edited files synchronize at their final path and deleted paths are skipped.
- Send `textDocument/didSave` after each document refresh.
- Add regressions for normal rename sync plus text edit → rename and text edit → delete resource-operation sequences.

## Why
`applyWorkspaceEdit` writes directly to disk. Without refreshing active LSP documents, an immediately following rename can calculate ranges against stale in-memory content and corrupt the source. Resource operations may also move or remove a pre-operation text-edit URI; reading that stale path caused `ENOENT` after a successful workspace edit.

## Validation
- `bun test test/tools/lsp-regressions.test.ts --test-name-pattern 'tracks final text-edit|synchronizes every LSP document'`
- `bun run check:types`
- `bunx biome check src/lsp/index.ts src/lsp/edits.ts test/tools/lsp-regressions.test.ts`