### PR TITLE
feat(catalog, ai): add Neuralwatt provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Neuralwatt provider for API key login (`omp login neuralwatt`).
+
 
 ### Fixed
 

--- a/packages/ai/src/registry/neuralwatt.ts
+++ b/packages/ai/src/registry/neuralwatt.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginNeuralwatt = createApiKeyLogin({
+	providerLabel: "Neuralwatt",
+	authUrl: "https://api.neuralwatt.com/v1",
+	instructions: "Create or copy your Neuralwatt API key",
+	promptMessage: "Paste your Neuralwatt API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "Neuralwatt",
+		modelsUrl: "https://api.neuralwatt.com/v1/models",
+	},
+});
+
+export const neuralwattProvider = {
+	id: "neuralwatt",
+	name: "Neuralwatt",
+	login: (cb: OAuthLoginCallbacks) => loginNeuralwatt(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -34,6 +34,7 @@ import { minimaxCodeCnProvider } from "./minimax-code-cn";
 import { mistralProvider } from "./mistral";
 import { moonshotProvider } from "./moonshot";
 import { nanogptProvider } from "./nanogpt";
+import { neuralwattProvider } from "./neuralwatt";
 import { novitaProvider } from "./novita";
 import { nvidiaProvider } from "./nvidia";
 import { ollamaProvider } from "./ollama";
@@ -118,6 +119,7 @@ const ALL = [
 	veniceProvider,
 	syntheticProvider,
 	nanogptProvider,
+	neuralwattProvider,
 	waferServerlessProvider,
 	coreWeaveProvider,
 	vercelAiGatewayProvider,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Neuralwatt provider to the model catalog with dynamic discovery.
+
 
 ## [16.4.3] - 2026-07-11
 

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -268,7 +268,7 @@ export const CATALOG_PROVIDERS = [
 	},
 	{
 		id: "neuralwatt",
-		defaultModel: "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+		defaultModel: "glm-5.2-short",
 		envVars: ["NEURALWATT_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => neuralwattModelManagerOptions(config),
 		catalogDiscovery: { label: "Neuralwatt" },

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -29,6 +29,7 @@ import {
 	mistralModelManagerOptions,
 	moonshotModelManagerOptions,
 	nanoGptModelManagerOptions,
+	neuralwattModelManagerOptions,
 	novitaModelManagerOptions,
 	nvidiaModelManagerOptions,
 	ollamaModelManagerOptions,
@@ -264,6 +265,13 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["NANO_GPT_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => nanoGptModelManagerOptions(config),
 		catalogDiscovery: { label: "NanoGPT" },
+	},
+	{
+		id: "neuralwatt",
+		defaultModel: "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+		envVars: ["NEURALWATT_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => neuralwattModelManagerOptions(config),
+		catalogDiscovery: { label: "Neuralwatt" },
 	},
 	{
 		id: "nvidia",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1069,6 +1069,22 @@ export function novitaModelManagerOptions(
 	};
 }
 
+export interface NeuralwattModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function neuralwattModelManagerOptions(
+	config?: NeuralwattModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	return createSimpleOpenAICompletionsOptions(
+		"neuralwatt" as Parameters<typeof getBundledModels>[0],
+		"https://api.neuralwatt.com/v1",
+		config,
+	);
+}
+
 // ---------------------------------------------------------------------------
 // 6. xAI
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Added Neuralwatt as a new provider in the AI catalog. The configuration implements the `NeuralwattModelManagerConfig` using `createSimpleOpenAICompletionsOptions`, registers the endpoint (`https://api.neuralwatt.com/v1`) along with dynamic model discovery, and sets up the interactive API key login flow via the CLI.

## Why

This enables the runtime to use models from Neuralwatt Cloud (like Qwen, Kimi, Mistral Devstral, and NVIDIA Nemotron variants). The provider ID `neuralwatt` maps to the `NEURALWATT_API_KEY` and allows seamless OpenAI-compatible model invocation and interactive `/login` via `omp`.

## Testing

Verified `bun check` passes across the workspace successfully, confirming the provider definitions are perfectly aligned with `KnownProvider` and `OAuthProvider` types.

---

- [x] `bun check` passes
- [ ] Tested locally
- [x] CHANGELOG updated (if user-facing)