### PR TITLE
fix(coding-agent): forward sessionId to getApiKey in subagent auth fallback (Closes #5325)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagent model and thinking level intermittently resolving to the parent session's model instead of the configured `modelRoles.task` selector ([#5325](https://github.com/can1357/oh-my-pi/issues/5325)). The pre-flight auth check in `resolveModelOverrideWithAuthFallback` called `getApiKey` without a session id, so providers with session-sticky OAuth credentials returned `undefined` even though the credential was usable once the subagent session started. The subagent's id is now forwarded as the session id so session-sticky credentials resolve correctly. Model resolution warnings (e.g. invalid thinking level in a pattern) are also now logged instead of silently dropped.
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1209,20 +1209,27 @@ export function resolveModelOverride(
 	modelPatterns: string[],
 	modelRegistry: ModelLookupRegistry,
 	settings?: Settings,
-): { model?: Model<Api>; thinkingLevel?: ConfiguredThinkingLevel; explicitThinkingLevel: boolean } {
+): { model?: Model<Api>; thinkingLevel?: ConfiguredThinkingLevel; explicitThinkingLevel: boolean; warning?: string } {
 	if (modelPatterns.length === 0) return { explicitThinkingLevel: false };
 	const availableModels = modelRegistry.getAvailable();
 	const matchPreferences = getModelMatchPreferences(settings);
+	let warning: string | undefined;
 	for (const pattern of modelPatterns) {
-		const { model, thinkingLevel, explicitThinkingLevel } = resolveModelRoleValue(pattern, availableModels, {
+		const {
+			model,
+			thinkingLevel,
+			explicitThinkingLevel,
+			warning: patternWarning,
+		} = resolveModelRoleValue(pattern, availableModels, {
 			settings,
 			matchPreferences,
 		});
 		if (model) {
-			return { model, thinkingLevel, explicitThinkingLevel };
+			return { model, thinkingLevel, explicitThinkingLevel, warning: patternWarning };
 		}
+		if (!warning && patternWarning) warning = patternWarning;
 	}
-	return { explicitThinkingLevel: false };
+	return { explicitThinkingLevel: false, warning };
 }
 
 /**
@@ -1235,6 +1242,11 @@ export function resolveModelOverride(
  * silently routing to a provider the user can't actually call (e.g.
  * `modelRoles.task` pointing at an unqualified id whose only available
  * provider variant has no configured credentials — see #985).
+ *
+ * `sessionId` is forwarded to `getApiKey` so that session-sticky OAuth
+ * credentials resolve correctly during the pre-flight auth check. Without it,
+ * providers with multiple OAuth accounts may return `undefined` even though
+ * the credential is usable once the subagent session starts — see #5325.
  *
  * Keyless-by-design providers (llama.cpp, ollama, lm-studio) advertise the
  * `kNoAuth` sentinel from `getApiKey` to signal that they do not require
@@ -1251,18 +1263,20 @@ export async function resolveModelOverrideWithAuthFallback(
 	parentActiveModelPattern: string | undefined,
 	modelRegistry: ModelLookupRegistry & Pick<ModelRegistry, "getApiKey">,
 	settings?: Settings,
+	sessionId?: string,
 ): Promise<{
 	model?: Model<Api>;
 	thinkingLevel?: ConfiguredThinkingLevel;
 	explicitThinkingLevel: boolean;
 	authFallbackUsed: boolean;
+	warning?: string;
 }> {
 	const primary = resolveModelOverride(modelPatterns, modelRegistry, settings);
 	if (!primary.model || !parentActiveModelPattern) {
 		return { ...primary, authFallbackUsed: false };
 	}
 
-	const primaryKey = await modelRegistry.getApiKey(primary.model);
+	const primaryKey = await modelRegistry.getApiKey(primary.model, sessionId);
 	if (primaryKey === kNoAuth || isAuthenticated(primaryKey)) {
 		return { ...primary, authFallbackUsed: false };
 	}
@@ -1274,7 +1288,7 @@ export async function resolveModelOverrideWithAuthFallback(
 	if (modelsAreEqual(fallback.model, primary.model)) {
 		return { ...primary, authFallbackUsed: false };
 	}
-	const fallbackKey = await modelRegistry.getApiKey(fallback.model);
+	const fallbackKey = await modelRegistry.getApiKey(fallback.model, sessionId);
 	if (!isAuthenticated(fallbackKey)) {
 		return { ...primary, authFallbackUsed: false };
 	}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -2325,14 +2325,22 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				thinkingLevel: resolvedThinkingLevel,
 				explicitThinkingLevel,
 				authFallbackUsed,
+				warning: modelResolutionWarning,
 			} = await awaitAbortable(
 				resolveModelOverrideWithAuthFallback(
 					modelPatterns,
 					options.parentActiveModelPattern,
 					modelRegistry,
 					settings,
+					id,
 				),
 			);
+			if (modelResolutionWarning) {
+				logger.warn("Subagent model resolution warning", {
+					warning: modelResolutionWarning,
+					requested: modelPatterns,
+				});
+			}
 			if (authFallbackUsed && model) {
 				logger.warn("Subagent model has no working credentials; falling back to parent session model", {
 					requested: modelPatterns,

--- a/packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts
+++ b/packages/coding-agent/test/issue-985-subagent-auth-fallback.test.ts
@@ -177,3 +177,62 @@ describe("issue #985: subagent dispatch auth fallback", () => {
 		expect(result.model?.id).toBe("qwen3.6-plus-free");
 	});
 });
+
+describe("issue #5325: sessionId forwarded to getApiKey for session-sticky OAuth", () => {
+	// The pre-flight auth check in resolveModelOverrideWithAuthFallback calls
+	// getApiKey without a session id. For providers with session-sticky OAuth
+	// credentials, this can return undefined even though the credential is
+	// usable once the subagent session starts. The fix forwards a sessionId
+	// so session-sticky credentials resolve during the pre-flight check.
+	test("forwards sessionId to getApiKey for the primary model", async () => {
+		let receivedSessionId: string | undefined;
+		const registry: ModelLookupRegistry & { getApiKey(model: Model<Api>): Promise<string | undefined> } = {
+			getAvailable: () => [parentModel, unauthedTaskModel],
+			getApiKey: async (model: Model<Api>, sessionId?: string) => {
+				if (model.provider === "opencode-zen") {
+					receivedSessionId = sessionId;
+					// Without sessionId, OAuth can't resolve; with it, it can.
+					return sessionId ? "sk-resolved-token" : undefined;
+				}
+				if (model.provider === "deepseek") return "sk-test";
+				return undefined;
+			},
+		} as never;
+
+		const result = await resolveModelOverrideWithAuthFallback(
+			["qwen3.6-plus-free"],
+			"deepseek/deepseek-v4-pro",
+			registry,
+			undefined,
+			"subagent-session-123",
+		);
+
+		expect(receivedSessionId).toBe("subagent-session-123");
+		expect(result.authFallbackUsed).toBe(false);
+		expect(result.model?.provider).toBe("opencode-zen");
+		expect(result.model?.id).toBe("qwen3.6-plus-free");
+	});
+
+	test("still falls back when getApiKey returns undefined even with sessionId", async () => {
+		const registry: ModelLookupRegistry & { getApiKey(model: Model<Api>): Promise<string | undefined> } = {
+			getAvailable: () => [parentModel, unauthedTaskModel],
+			getApiKey: async (model: Model<Api>, _sessionId?: string) => {
+				if (model.provider === "deepseek") return "sk-test";
+				// Genuinely broken: undefined even with sessionId (stale OAuth, revoked token)
+				return undefined;
+			},
+		} as never;
+
+		const result = await resolveModelOverrideWithAuthFallback(
+			["qwen3.6-plus-free"],
+			"deepseek/deepseek-v4-pro",
+			registry,
+			undefined,
+			"subagent-session-456",
+		);
+
+		expect(result.authFallbackUsed).toBe(true);
+		expect(result.model?.provider).toBe("deepseek");
+		expect(result.model?.id).toBe("deepseek-v4-pro");
+	});
+});


### PR DESCRIPTION
## Summary

Preserve the configured `modelRoles.task` selector when the pre-flight auth check calls `getApiKey` without a session id, instead of silently falling back to the parent session's model.

## Motivation

`resolveModelOverrideWithAuthFallback` calls `getApiKey` to decide whether to fall back to the parent's model when the subagent's configured model has no working credentials. The call passed no session id, so providers with session-sticky OAuth credentials returned `undefined` — triggering the fallback even though the credential was usable once the subagent session started. This caused intermittent wrong-model and wrong-thinking-level behavior (#5325).

The prior attempt used `hasConfiguredAuth` as a guard, which was too broad: it suppressed the fallback for stale OAuth and broken `!cmd` keys where the fallback is the correct behavior.

The fix forwards the subagent's id as the session id to `getApiKey`, so session-sticky OAuth credentials resolve during the pre-flight check. Genuinely broken auth still falls back as before.

## Changes

- `resolveModelOverrideWithAuthFallback`: Accept an optional `sessionId` parameter and forward it to both `getApiKey` calls (primary and fallback). This resolves session-sticky OAuth credentials during the pre-flight auth check.
- `runSubprocess` (executor): Pass the subagent's `id` as the session id.
- `resolveModelOverride`: Propagate the `warning` field from `resolveModelRoleValue` instead of silently dropping it.
- `runSubprocess`: Log model resolution warnings via `logger.warn`.

## Notes

- The auth fallback (#985) is preserved for genuinely broken auth (stale OAuth, revoked tokens, unconfigured providers) — those cases still return `undefined` even with a session id.
- A small number of callers outside the executor path (e.g. `agent-dashboard.ts`) don't have a session id to pass; they continue to call the function without the new `sessionId` parameter, which is fine since those paths are CLI/admin UI, not subagent spawning.

## Resolves

Fixes #5325