### PR TITLE
feat: dynamic timeout window for bash commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Dynamic timeout window for bash commands: automatically adjusts per-call timeouts based on recent execution history keyed by command signature (first two tokens), enabled by default via `bash.dynamicTimeout.enabled`. Timeouts scale with confidence — conservative with few samples, aggressive with a full history window. Configurable via `bash.dynamicTimeout.multiplier`, `.minTimeout`, and `.maxTimeout`.
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3795,6 +3795,50 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"bash.dynamicTimeout.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			group: "Execution",
+			label: "Dynamic Timeout",
+			description: "Automatically adjust bash command timeouts based on recent execution history per command type",
+		},
+	},
+
+	"bash.dynamicTimeout.multiplier": {
+		type: "number",
+		default: 2,
+		ui: {
+			tab: "tools",
+			group: "Execution",
+			label: "Dynamic Timeout Multiplier",
+			description: "Headroom multiplier applied to the predicted duration (e.g. 2x = twice the p90 wall time)",
+		},
+	},
+
+	"bash.dynamicTimeout.minTimeout": {
+		type: "number",
+		default: 10,
+		ui: {
+			tab: "tools",
+			group: "Execution",
+			label: "Dynamic Timeout Minimum",
+			description: "Hard floor in seconds for dynamically computed timeouts",
+		},
+	},
+
+	"bash.dynamicTimeout.maxTimeout": {
+		type: "number",
+		default: 600,
+		ui: {
+			tab: "tools",
+			group: "Execution",
+			label: "Dynamic Timeout Maximum",
+			description: "Ceiling in seconds for dynamically computed timeouts",
+		},
+	},
+
 	// Async jobs
 	"async.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -56,6 +56,9 @@ Use bash ONLY for: a single binary call, or one short pipeline that COMPUTES a f
 
 - `timeout` is seconds; nonzero values are clamped to `1..3600` and the process is killed on elapse. Set `timeout: 0` only for finite commands whose completion is cancellation-owned.
 - `async: true` defers only reporting; it does NOT extend a nonzero timeout.
+{{#if dynamicTimeoutEnabled}}
+- When you don't specify a `timeout`, OMP dynamically computes one from recent execution history for the same command type. Quick commands that consistently finish fast get shorter timeouts; commands that consistently take longer get extended timeouts. Only set `timeout` explicitly when you need to override the dynamic prediction.
+{{/if}}
 {{#if hasLaunch}}- Need a service, watcher, debugger, REPL, or later stdin? MUST use `launch`. NEVER use `cmd &`, `nohup`, or async bash as a process supervisor.{{else}}- Need a long-running process or >3600s run? Use an external process supervisor; avoid detached shell jobs you cannot later observe or stop.{{/if}}
 {{/if}}
 {{#if autoBackgroundEnabled}}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -27,6 +27,7 @@ import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-intera
 import { checkBashInterception } from "./bash-interceptor";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
+import { DynamicTimeoutResolver } from "./dynamic-timeout";
 import { resolveEvalBackends } from "./eval-backends";
 import { invalidateGithubCacheForBashCommand } from "./gh-cache-invalidation";
 import {
@@ -397,6 +398,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		return prompt.render(bashDescription, {
 			asyncEnabled: this.#asyncEnabled,
 			autoBackgroundEnabled: this.#autoBackgroundEnabled,
+			dynamicTimeoutEnabled: this.#dynamicTimeoutEnabled,
 			autoBackgroundThresholdSeconds: Math.max(0, Math.floor(this.#autoBackgroundThresholdMs / 1000)),
 			hasAstGrep: isToolActive("ast_grep", this.session.settings.get("astGrep.enabled")),
 			hasAstEdit: isToolActive("ast_edit", this.session.settings.get("astEdit.enabled")),
@@ -420,6 +422,8 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 	readonly #asyncEnabled: boolean;
 	readonly #autoBackgroundEnabled: boolean;
 	readonly #autoBackgroundThresholdMs: number;
+	readonly #dynamicTimeoutEnabled: boolean;
+	readonly #dynamicTimeoutResolver = new DynamicTimeoutResolver();
 
 	constructor(private readonly session: ToolSession) {
 		this.#asyncEnabled = this.session.settings.get("async.enabled");
@@ -430,6 +434,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				this.session.settings.get("bash.autoBackground.thresholdMs") ?? DEFAULT_AUTO_BACKGROUND_THRESHOLD_MS,
 			),
 		);
+		this.#dynamicTimeoutEnabled = this.session.settings.get("bash.dynamicTimeout.enabled");
 		this.parameters = this.#asyncEnabled ? bashSchemaWithAsync : bashSchemaBase;
 	}
 
@@ -704,7 +709,7 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		{
 			command: rawCommand,
 			env: rawEnv,
-			timeout: rawTimeout = 300,
+			timeout: rawTimeout,
 			cwd,
 
 			async: asyncRequested = false,
@@ -801,11 +806,31 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 		// must still cancel the call or job, but OMP does not impose a deadline.
 		const requestedTimeoutSec = rawTimeout;
 		const timeoutDisabled = requestedTimeoutSec === 0;
-		const timeoutSec = timeoutDisabled ? undefined : clampTimeout("bash", requestedTimeoutSec);
-		const timeoutMs = timeoutSec === undefined ? undefined : timeoutSec * 1000;
+		let effectiveTimeoutSec = requestedTimeoutSec;
 		const pendingNotices: string[] = [];
-		if (timeoutSec !== undefined) {
-			const timeoutClampNotice = formatTimeoutClampNotice(requestedTimeoutSec, timeoutSec);
+		// When the LLM omits the timeout and dynamic timeouts are enabled, compute
+		// a per-command-signature timeout from recent wall-time history. Timeouts
+		// scale with confidence — conservative with few samples, aggressive with a
+		// full history window.
+		if (requestedTimeoutSec === undefined && this.#dynamicTimeoutEnabled && !timeoutDisabled) {
+			const dynamic = this.#dynamicTimeoutResolver.resolve(
+				command,
+				this.session.settings.get("bash.dynamicTimeout.multiplier"),
+				this.session.settings.get("bash.dynamicTimeout.minTimeout"),
+				this.session.settings.get("bash.dynamicTimeout.maxTimeout"),
+				TOOL_TIMEOUTS.bash.default,
+			);
+			if (dynamic !== undefined) {
+				effectiveTimeoutSec = dynamic.timeoutSec;
+				pendingNotices.push(
+					`Dynamic timeout: ${dynamic.timeoutSec}s (based on ${dynamic.sampleCount} recent "${dynamic.signature}" samples, p90=${Math.round(dynamic.p90Ms / 1000)}s)`,
+				);
+			}
+		}
+		const timeoutSec = timeoutDisabled ? undefined : clampTimeout("bash", effectiveTimeoutSec);
+		const timeoutMs = timeoutSec === undefined ? undefined : timeoutSec * 1000;
+		if (timeoutSec !== undefined && effectiveTimeoutSec !== undefined) {
+			const timeoutClampNotice = formatTimeoutClampNotice(effectiveTimeoutSec, timeoutSec);
 			if (timeoutClampNotice) pendingNotices.push(timeoutClampNotice);
 		}
 
@@ -991,6 +1016,9 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 								outputLines: current.output.length > 0 ? current.output.split("\n").length : 0,
 								outputBytes: current.output.length,
 							};
+							if (this.#dynamicTimeoutEnabled) {
+								this.#dynamicTimeoutResolver.record(command, performance.now() - bridgeWallTimeStart);
+							}
 							return this.#buildCompletedResult(timedOutResult, timeoutSec, {
 								requestedTimeoutSec,
 								notices: pendingNotices,
@@ -1052,6 +1080,9 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 				if (finalOutput.truncated) bridgeNotices.push("(output truncated)");
 				for (const notice of pendingNotices) bridgeNotices.push(notice);
 
+				if (this.#dynamicTimeoutEnabled) {
+					this.#dynamicTimeoutResolver.record(command, performance.now() - bridgeWallTimeStart);
+				}
 				return this.#buildCompletedResult(bridgeResult, timeoutSec, {
 					requestedTimeoutSec,
 					notices: bridgeNotices,
@@ -1100,6 +1131,9 @@ export class BashTool implements AgentTool<typeof bashSchemaBase | typeof bashSc
 					onMinimizedSave: originalText => saveBashOriginalArtifact(this.session, originalText),
 				});
 		const wallTimeMs = performance.now() - wallTimeStart;
+		if (this.#dynamicTimeoutEnabled) {
+			this.#dynamicTimeoutResolver.record(command, wallTimeMs);
+		}
 		if (result.cancelled) {
 			const out = normalizeResultOutput(result);
 			// PTY output carries no cancel/timeout notice of its own; annotate so

--- a/packages/coding-agent/src/tools/dynamic-timeout.test.ts
+++ b/packages/coding-agent/src/tools/dynamic-timeout.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { DynamicTimeoutResolver } from "./dynamic-timeout";
+
+describe("DynamicTimeoutResolver.commandSignature", () => {
+	it("keys on the first two tokens so npm test ≠ npm install", () => {
+		expect(DynamicTimeoutResolver.commandSignature("npm test")).toBe("npm test");
+		expect(DynamicTimeoutResolver.commandSignature("npm install")).toBe("npm install");
+		expect(DynamicTimeoutResolver.commandSignature("npm test")).not.toBe(
+			DynamicTimeoutResolver.commandSignature("npm install"),
+		);
+	});
+
+	it("strips leading env assignments (KEY=value)", () => {
+		expect(DynamicTimeoutResolver.commandSignature("FOO=bar baz qux")).toBe("baz qux");
+		expect(DynamicTimeoutResolver.commandSignature("A=1 B=2 C=3 git status")).toBe("git status");
+	});
+
+	it("strips sudo and path prefixes", () => {
+		expect(DynamicTimeoutResolver.commandSignature("sudo /usr/bin/git status")).toBe("git status");
+		expect(DynamicTimeoutResolver.commandSignature("sudo git status")).toBe("git status");
+	});
+
+	it("strips shell builtins: time, nohup, env", () => {
+		expect(DynamicTimeoutResolver.commandSignature("time npm test")).toBe("npm test");
+		expect(DynamicTimeoutResolver.commandSignature("nohup cargo build")).toBe("cargo build");
+		expect(DynamicTimeoutResolver.commandSignature("env make all")).toBe("make all");
+	});
+
+	it("handles a single-token command", () => {
+		expect(DynamicTimeoutResolver.commandSignature("git")).toBe("git");
+		expect(DynamicTimeoutResolver.commandSignature("ls")).toBe("ls");
+	});
+
+	it("returns empty string for empty or whitespace-only input", () => {
+		expect(DynamicTimeoutResolver.commandSignature("")).toBe("");
+		expect(DynamicTimeoutResolver.commandSignature("   ")).toBe("");
+		expect(DynamicTimeoutResolver.commandSignature("\t\n")).toBe("");
+	});
+});
+
+describe("DynamicTimeoutResolver.resolve", () => {
+	it("returns undefined when fewer than MIN_SAMPLES (3) samples exist", () => {
+		const r = new DynamicTimeoutResolver();
+		r.record("git status", 50);
+		r.record("git status", 60);
+		expect(r.resolve("git status", 2, 10, 600, 300)).toBeUndefined();
+	});
+
+	it("at 3 samples with fast wall times, floors at staticDefaultSec (conservative)", () => {
+		const r = new DynamicTimeoutResolver();
+		for (const ms of [50, 60, 55]) r.record("git status", ms);
+		// p90 of [50,55,60] = 60ms; predicted = ceil(0.06 * 2) = 1s
+		// confidenceRatio = 0 → floor = 300 → max(300, 1) = 300
+		const result = r.resolve("git status", 2, 10, 600, 300);
+		expect(result?.timeoutSec).toBe(300);
+	});
+
+	it("at 20 samples with fast wall times, floor drops to ~30s (aggressive)", () => {
+		const r = new DynamicTimeoutResolver();
+		for (let i = 0; i < 20; i++) r.record("git status", 50);
+		// confidenceRatio = 1 → floor = ceil(300 * 0.1) = 30
+		// predicted = ceil(0.05 * 2) = 1 → max(30, 1) = 30
+		const result = r.resolve("git status", 2, 10, 600, 300);
+		expect(result?.timeoutSec).toBe(30);
+	});
+
+	it("extends beyond static default for slow commands", () => {
+		const r = new DynamicTimeoutResolver();
+		for (let i = 0; i < 20; i++) r.record("npm test", 200_000); // 200s each
+		// p90 = 200_000ms; predicted = ceil(200 * 2) = 400
+		// floor = 30 → max(30, 400) = 400 → clamp(10, 600, 400) = 400
+		const result = r.resolve("npm test", 2, 10, 600, 300);
+		expect(result?.timeoutSec).toBe(400);
+	});
+
+	it("clamps to maxSec when predicted exceeds the ceiling", () => {
+		const r = new DynamicTimeoutResolver();
+		for (let i = 0; i < 20; i++) r.record("npm test", 400_000); // 400s each
+		// p90 = 400_000ms; predicted = ceil(400 * 2) = 800
+		// max(30, 800) = 800 → clamp(10, 600, 800) = 600
+		const result = r.resolve("npm test", 2, 10, 600, 300);
+		expect(result?.timeoutSec).toBe(600);
+	});
+
+	it("clamps to minSec when the confidence floor would go below it", () => {
+		const r = new DynamicTimeoutResolver();
+		for (let i = 0; i < 20; i++) r.record("ls", 5); // 5ms each
+		// floor = 30; predicted = ceil(0.005 * 2) = 1 → max(30, 1) = 30
+		// clamp(120, 600, 30) = 120
+		const result = r.resolve("ls", 2, 120, 600, 300);
+		expect(result?.timeoutSec).toBe(120);
+	});
+
+	it("returns a DynamicTimeoutResult with all fields", () => {
+		const r = new DynamicTimeoutResolver();
+		for (let i = 0; i < 20; i++) r.record("git status", 50);
+		const result = r.resolve("git status", 2, 10, 600, 300);
+		expect(result).toBeDefined();
+		expect(result).toEqual({
+			timeoutSec: 30,
+			sampleCount: 20,
+			p90Ms: 50,
+			signature: "git status",
+		});
+	});
+});
+
+describe("DynamicTimeoutResolver.record", () => {
+	it("maintains a rolling window of the last 20 samples", () => {
+		const r = new DynamicTimeoutResolver();
+		// Record 25 samples at 10ms, then 5 at 5000ms.
+		// If the window keeps only 20, the p90 reflects the recent slow batch.
+		for (let i = 0; i < 25; i++) r.record("cargo build", 10);
+		for (let i = 0; i < 5; i++) r.record("cargo build", 5000);
+		// After 30 records, window should have 20 samples: 15 at 10ms + 5 at 5000ms.
+		// Sorted: [10×15, 5000×5]. p90 index = floor(20 * 0.9) = 18 → 5000ms.
+		const result = r.resolve("cargo build", 1, 10, 600, 300);
+		expect(result?.sampleCount).toBe(20);
+		expect(result?.p90Ms).toBe(5000);
+	});
+
+	it("keeps separate histories per command signature", () => {
+		const r = new DynamicTimeoutResolver();
+		for (let i = 0; i < 5; i++) r.record("git status", 50);
+		for (let i = 0; i < 5; i++) r.record("npm test", 200_000);
+
+		const gitResult = r.resolve("git status", 2, 10, 600, 300);
+		const npmResult = r.resolve("npm test", 2, 10, 600, 300);
+
+		// git status: fast → 5 samples, p90=50ms, floor=300 (conservative at 5 samples)
+		// confidenceRatio = (5-3)/(20-3) = 2/17 ≈ 0.118
+		// floor = ceil(300 * (1 - 0.9*0.118)) = ceil(300 * 0.894) = 269
+		// predicted = ceil(0.05 * 2) = 1 → max(269, 1) = 269
+		expect(gitResult?.timeoutSec).toBe(269);
+
+		// npm test: slow → p90=200s, predicted=400, floor=269 → max(269, 400) = 400
+		expect(npmResult?.timeoutSec).toBe(400);
+	});
+});

--- a/packages/coding-agent/src/tools/dynamic-timeout.ts
+++ b/packages/coding-agent/src/tools/dynamic-timeout.ts
@@ -1,0 +1,111 @@
+/**
+ * Dynamic timeout window resolver for bash commands.
+ *
+ * When the LLM omits the `timeout` parameter, this resolver computes a
+ * per-command-signature timeout based on recent wall-time history. Keying by
+ * command signature (first two meaningful tokens) means `npm test` informs
+ * `npm test` timeouts, not `npm install` timeouts.
+ *
+ * Timeouts scale with confidence — conservative with few samples, aggressive
+ * with a full history window. At MIN_SAMPLES (3) the floor equals the static
+ * default; at WINDOW_SIZE (20) the floor drops to 10% of the static default.
+ * This prevents a fast-command streak from shrinking the timeout too early
+ * while still allowing well-sampled quick commands to get tight deadlines.
+ *
+ * History is kept per-instance (per session) and bounded to a rolling window.
+ */
+
+const MIN_SAMPLES = 3;
+const WINDOW_SIZE = 20;
+
+export interface DynamicTimeoutResult {
+	timeoutSec: number;
+	sampleCount: number;
+	p90Ms: number;
+	signature: string;
+}
+
+export class DynamicTimeoutResolver {
+	#history = new Map<string, number[]>();
+
+	/**
+	 * Extract a command signature: first two meaningful tokens, normalized.
+	 * Strips leading env assignments, sudo, shell builtins (time, nohup, env),
+	 * and path prefixes so that `FOO=bar sudo /usr/bin/git status` resolves to
+	 * `git status` and `npm test` ≠ `npm install`.
+	 */
+	static commandSignature(command: string): string {
+		let cmd = command.trim();
+		// Strip leading env assignments: KEY=value command ...
+		cmd = cmd.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)+/, "");
+		// Strip leading sudo
+		cmd = cmd.replace(/^sudo\s+/, "");
+		// Strip leading shell builtins that wrap the real command: time, nohup, env
+		cmd = cmd.replace(/^(?:time|nohup|env)\s+/, "");
+		// Take first two tokens up to whitespace, |, &, ;, (, <
+		const tokens = cmd
+			.split(/[\s|&;(<]+/)
+			.filter(Boolean)
+			.slice(0, 2);
+		if (tokens.length === 0) return "";
+		// Strip path prefix from each token: /usr/bin/git -> git
+		const normalized = tokens.map(t => (t.includes("/") ? (t.split("/").pop() ?? "") : t));
+		return normalized.join(" ");
+	}
+
+	/**
+	 * Record a completed command's wall time (ms) against its signature.
+	 */
+	record(command: string, wallTimeMs: number): void {
+		const sig = DynamicTimeoutResolver.commandSignature(command);
+		if (!sig) return;
+		let samples = this.#history.get(sig);
+		if (!samples) {
+			samples = [];
+			this.#history.set(sig, samples);
+		}
+		samples.push(wallTimeMs);
+		if (samples.length > WINDOW_SIZE) samples.shift();
+	}
+
+	/**
+	 * Resolve a dynamic timeout in seconds, or `undefined` if insufficient
+	 * data (fewer than {@link MIN_SAMPLES} recorded wall times for this
+	 * command signature).
+	 *
+	 * Uses the p90 of recent wall times multiplied by the given multiplier.
+	 * A confidence-scaled safety floor prevents the timeout from shrinking
+	 * too aggressively when few samples exist:
+	 * - At MIN_SAMPLES (3): floor = staticDefaultSec (conservative)
+	 * - At WINDOW_SIZE (20): floor = 10% of staticDefaultSec (aggressive)
+	 * The result is clamped to `[minSec, maxSec]`.
+	 */
+	resolve(
+		command: string,
+		multiplier: number,
+		minSec: number,
+		maxSec: number,
+		staticDefaultSec: number,
+	): DynamicTimeoutResult | undefined {
+		const sig = DynamicTimeoutResolver.commandSignature(command);
+		if (!sig) return undefined;
+		const samples = this.#history.get(sig);
+		if (!samples || samples.length < MIN_SAMPLES) return undefined;
+		// p90 of recent wall times
+		const sorted = [...samples].sort((a, b) => a - b);
+		const p90Index = Math.floor(sorted.length * 0.9);
+		const p90Ms = sorted[p90Index]!;
+		const predictedSec = Math.ceil((p90Ms / 1000) * multiplier);
+		// Confidence-scaled safety floor: with few samples (3-5), stay closer to
+		// the static default. As sample count grows (approaching WINDOW_SIZE),
+		// trust the history more and allow the timeout to shrink further.
+		// At MIN_SAMPLES (3): floor = staticDefaultSec (conservative)
+		// At WINDOW_SIZE (20): floor = 10% of staticDefaultSec (aggressive)
+		const confidenceRatio = Math.min(1, (samples.length - MIN_SAMPLES) / (WINDOW_SIZE - MIN_SAMPLES));
+		const confidenceFloorSec = Math.ceil(staticDefaultSec * (1 - 0.9 * confidenceRatio));
+		const dynamicSec = Math.max(confidenceFloorSec, predictedSec);
+		// Clamp to user-configured [minSec, maxSec] range
+		const clamped = Math.max(minSec, Math.min(maxSec, dynamicSec));
+		return { timeoutSec: clamped, sampleCount: samples.length, p90Ms, signature: sig };
+	}
+}


### PR DESCRIPTION
## Summary

The bash tool's `timeout` parameter defaulted to a flat 300s. The LLM almost never passes an explicit timeout, so `ls` (10ms) and `npm test` (60s) both got the same 300s deadline. This PR adds a dynamic timeout window that learns from execution history and adjusts timeouts per command type.

## How it works

1. **Command signature keying** — uses the first two meaningful tokens (stripping env assignments, `sudo`, shell builtins, path prefixes) so `npm test` ≠ `npm install` ≠ `npm run build`
2. **Rolling window** — keeps the last 20 wall times per signature, per session
3. **p90 × multiplier** — computes the 90th percentile of recent wall times, multiplied by 2x (configurable) for headroom
4. **Confidence-scaled floor** — the key safety mechanism:
   - 3 samples (just enough): floor = 300s → conservative, no change from old behavior
   - 10 samples: floor ≈ 189s → starts shrinking as confidence grows
   - 20 samples (full window): floor = 30s → aggressive shrink for well-known quick commands
5. **Clamped to `[minTimeout, maxTimeout]`** — user-configurable hard bounds (default 10s–600s)

## Safety model

| Scenario | Result |
|---|---|
| Unknown command (no history) | 300s static default (unchanged) |
| 3 fast samples (e.g. `git status`) | Still 300s (too few samples to shrink) |
| 20 fast samples (e.g. `git status` at 50ms) | 30s — tight deadline, no more 300s hangs |
| 20 slow samples (e.g. `npm test` at 200s) | 400s — extended beyond default |
| LLM passes explicit `timeout` | Dynamic logic skipped entirely |

## Settings (Tools → Execution)

- `bash.dynamicTimeout.enabled` — true (default)
- `bash.dynamicTimeout.multiplier` — 2 (headroom on p90)
- `bash.dynamicTimeout.minTimeout` — 10 (hard floor in seconds)
- `bash.dynamicTimeout.maxTimeout` — 600 (ceiling in seconds)

## Test plan

- [x] `bun check` passes (no errors from changed files)
- [x] `bun test packages/coding-agent/src/tools/dynamic-timeout.test.ts` — 15 pass, 0 fail
- [x] Tests cover: signature parsing (env/sudo/path/builtin stripping, 2-token keying), confidence-scaled floor (undefined <3 samples, 300s at 3, 30s at 20), p90×multiplier, clamping to [min,max], rolling window eviction, per-signature isolation
