### PR TITLE
fix(coding-agent): support GPT-5.6 Codex web search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex web search requests for GPT-5.6 Responses-Lite models, including `gpt-5.6-sol`. ([#5286](https://github.com/can1357/oh-my-pi/issues/5286))
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -7,9 +7,12 @@
  * SQLite store, never POSTs the broker sentinel to an OpenAI token endpoint.
  */
 import * as os from "node:os";
-import { type AuthStorage, type FetchImpl, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
+import { type AuthStorage, type FetchImpl, type Model, type OAuthAccess, withOAuthAccess } from "@oh-my-pi/pi-ai";
 import { decodeJwt } from "@oh-my-pi/pi-ai/oauth/openai-codex";
+import { applyCodexResponsesLiteShape } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
+import { createOpenAICodexCompatibilityMetadata } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
+import { CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "@oh-my-pi/pi-catalog/wire/codex";
 import { $env, readSseJson } from "@oh-my-pi/pi-utils";
 import packageJson from "../../../../package.json" with { type: "json" };
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
@@ -22,6 +25,9 @@ const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const CODEX_RESPONSES_PATH = "/codex/responses";
 const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
+	"gpt-5.6-luna",
+	"gpt-5.6-terra",
+	"gpt-5.6-sol",
 	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5-codex",
@@ -35,15 +41,38 @@ const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const DEFAULT_INSTRUCTIONS =
 	"You are a helpful assistant with web search capabilities. Search the web to answer the user's question accurately and cite your sources.";
 
-function getConfiguredModel(): string | undefined {
-	const configuredModel = $env.PI_CODEX_WEB_SEARCH_MODEL?.trim();
-	return configuredModel ? configuredModel : undefined;
+type CodexSearchModel = Model<"openai-codex-responses">;
+
+interface CodexModelCandidate {
+	modelId: string;
+	catalogModel?: CodexSearchModel;
 }
 
-function getDefaultModelCandidates(): string[] {
-	const bundledModels = getBundledModels("openai-codex");
-	const bundledIds = new Set(bundledModels.map(model => model.id));
-	const candidates = DEFAULT_MODEL_PREFERENCES.filter(modelId => bundledIds.has(modelId));
+function getBundledCodexModels(): CodexSearchModel[] {
+	const models: CodexSearchModel[] = [];
+	for (const model of getBundledModels("openai-codex")) {
+		if (model.api === "openai-codex-responses") {
+			models.push(model as CodexSearchModel);
+		}
+	}
+	return models;
+}
+
+function getConfiguredModel(): CodexModelCandidate | undefined {
+	const configuredModel = $env.PI_CODEX_WEB_SEARCH_MODEL?.trim();
+	if (!configuredModel) return undefined;
+
+	const catalogModel = getBundledCodexModels().find(model => model.id === configuredModel);
+	return { modelId: configuredModel, ...(catalogModel ? { catalogModel } : {}) };
+}
+
+function getDefaultModelCandidates(): CodexModelCandidate[] {
+	const bundledModels = getBundledCodexModels();
+	const candidates: CodexModelCandidate[] = [];
+	for (const modelId of DEFAULT_MODEL_PREFERENCES) {
+		const catalogModel = bundledModels.find(model => model.id === modelId);
+		if (catalogModel) candidates.push({ modelId, catalogModel });
+	}
 
 	if (candidates.length > 0) {
 		return candidates;
@@ -51,10 +80,11 @@ function getDefaultModelCandidates(): string[] {
 
 	const nonMini = bundledModels.find(model => !model.id.includes("mini") && !model.id.includes("spark"));
 	if (nonMini) {
-		return [nonMini.id];
+		return [{ modelId: nonMini.id, catalogModel: nonMini }];
 	}
 
-	return bundledModels[0]?.id ? [bundledModels[0].id] : [FALLBACK_MODEL];
+	const fallbackModel = bundledModels[0];
+	return fallbackModel ? [{ modelId: fallbackModel.id, catalogModel: fallbackModel }] : [{ modelId: FALLBACK_MODEL }];
 }
 
 function shouldRetryWithNextDefaultModel(error: unknown): boolean {
@@ -301,9 +331,10 @@ async function findCodexAuth(
 function buildCodexHeaders(accessToken: string, accountId: string): Record<string, string> {
 	return {
 		Authorization: `Bearer ${accessToken}`,
-		"chatgpt-account-id": accountId,
-		"OpenAI-Beta": "responses=experimental",
-		originator: "pi",
+		[OPENAI_HEADERS.ACCOUNT_ID]: accountId,
+		[OPENAI_HEADERS.BETA]: OPENAI_HEADER_VALUES.BETA_RESPONSES,
+		[OPENAI_HEADERS.ORIGINATOR]: OPENAI_HEADER_VALUES.ORIGINATOR_CODEX,
+		[OPENAI_HEADERS.VERSION]: CODEX_CLIENT_VERSION,
 		"User-Agent": `pi/${packageJson.version} (${os.platform()} ${os.release()}; ${os.arch()})`,
 		Accept: "text/event-stream",
 		"Content-Type": "application/json",
@@ -323,7 +354,8 @@ async function callCodexSearch(
 		signal?: AbortSignal;
 		systemPrompt?: string;
 		searchContextSize?: "low" | "medium" | "high";
-		modelId: string;
+		model: CodexModelCandidate;
+		sessionId?: string;
 		fetch?: FetchImpl;
 	},
 ): Promise<{
@@ -336,7 +368,8 @@ async function callCodexSearch(
 	const url = `${CODEX_BASE_URL}${CODEX_RESPONSES_PATH}`;
 	const headers = buildCodexHeaders(auth.accessToken, auth.accountId);
 
-	const requestedModel = options.modelId;
+	const requestedModel = options.model.modelId;
+	const usesResponsesLite = options.model.catalogModel?.useResponsesLite === true;
 
 	const body: Record<string, unknown> = {
 		model: requestedModel,
@@ -358,6 +391,18 @@ async function callCodexSearch(
 		tool_choice: { type: "web_search" },
 		instructions: options.systemPrompt ?? DEFAULT_INSTRUCTIONS,
 	};
+	if (usesResponsesLite) {
+		const metadata = createOpenAICodexCompatibilityMetadata({
+			sessionId: options.sessionId,
+			requestKind: "turn",
+			startNewTurn: true,
+		});
+		Object.assign(headers, metadata.headers);
+		headers[OPENAI_HEADERS.RESPONSES_LITE] = "true";
+		body.client_metadata = metadata.clientMetadata;
+		body.reasoning = { context: "all_turns" };
+		applyCodexResponsesLiteShape(body);
+	}
 
 	const fetchImpl = options.fetch ?? fetch;
 	const response = await fetchImpl(url, {
@@ -489,10 +534,11 @@ async function callCodexSearch(
  * Default-model behavior:
  * - If `PI_CODEX_WEB_SEARCH_MODEL` is set, use it exactly once and surface any
  *   upstream error verbatim.
- * - Otherwise prefer ChatGPT-account-safe bundled defaults (GPT-5.4, GPT-5
- *   Codex, GPT-5, …) and retry the next candidate only when Codex returns the
- *   known 400 "model is not supported" family. This avoids selecting
- *   `gpt-5-codex-mini` first on ChatGPT accounts, which OpenAI rejects.
+ * - Otherwise prefer ChatGPT-account-safe bundled defaults (GPT-5.6 Luna,
+ *   Terra, Sol, GPT-5.5, …) and retry the next candidate only when Codex
+ *   returns the known 400 "model is not supported" family. This avoids
+ *   selecting `gpt-5-codex-mini` first on ChatGPT accounts, which OpenAI
+ *   rejects.
  */
 export async function searchCodex(params: SearchParams): Promise<SearchResponse> {
 	const seed = await findCodexAuth(params.authStorage, params.sessionId, params.signal);
@@ -520,15 +566,16 @@ export async function searchCodex(params: SearchParams): Promise<SearchResponse>
 
 			let lastError: unknown;
 			for (let index = 0; index < modelCandidates.length; index += 1) {
-				const modelId = modelCandidates[index];
-				if (!modelId) continue;
+				const candidate = modelCandidates[index];
+				if (!candidate) continue;
 
 				try {
 					return await callCodexSearch(auth, params.query, {
 						signal: params.signal,
 						systemPrompt: params.systemPrompt,
 						searchContextSize: "high",
-						modelId,
+						model: candidate,
+						sessionId: params.sessionId,
 						fetch: params.fetch,
 					});
 				} catch (error) {

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -223,24 +223,24 @@ describe("searchCodex model selection", () => {
 		}
 	});
 
-	it("uses the built-in default model when PI_CODEX_WEB_SEARCH_MODEL is unset", async () => {
+	it("uses GPT-5.6 Luna as the first bundled default", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
-		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.5")));
+		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.6-luna")));
 
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
-		expect(result.model).toBe("gpt-5.5");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
+		expect(result.model).toBe("gpt-5.6-luna");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
-		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.5")));
+		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.6-luna")));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
-		expect(result.model).toBe("gpt-5.5");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
+		expect(result.model).toBe("gpt-5.6-luna");
 	});
 
 	it("retries the next bundled default when Codex rejects a model for ChatGPT accounts", async () => {
@@ -257,20 +257,20 @@ describe("searchCodex model selection", () => {
 
 			const requestedModel = capturedRequest.body?.model;
 			if (calls === 1) {
-				expect(requestedModel).toBe("gpt-5.5");
+				expect(requestedModel).toBe("gpt-5.6-luna");
 				return Promise.resolve(
 					new Response(
 						JSON.stringify({
-							detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+							detail: "The 'gpt-5.6-luna' model is not supported when using Codex with a ChatGPT account.",
 						}),
 						{ status: 400, headers: { "Content-Type": "application/json" } },
 					),
 				);
 			}
 
-			expect(requestedModel).toBe("gpt-5.4");
+			expect(requestedModel).toBe("gpt-5.6-terra");
 			return Promise.resolve(
-				new Response(makeSseResponse("gpt-5.4"), {
+				new Response(makeSseResponse("gpt-5.6-terra"), {
 					status: 200,
 					headers: { "Content-Type": "text/event-stream" },
 				}),
@@ -280,17 +280,53 @@ describe("searchCodex model selection", () => {
 		const result = await searchCodex(makeSearchParams("retry unsupported default", fetchMock));
 
 		expect(calls).toBe(2);
-		expect(result.model).toBe("gpt-5.4");
+		expect(result.model).toBe("gpt-5.6-terra");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
-	it("uses PI_CODEX_WEB_SEARCH_MODEL when provided", async () => {
-		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4-mini";
-		const result = await searchCodex(makeSearchParams("overridden codex model", mockCodexFetch("gpt-5.4-mini")));
+	it("encodes explicit gpt-5.6-sol as a Responses-Lite request", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-sol";
+		const result = await searchCodex(makeSearchParams("Sol web search", mockCodexFetch("gpt-5.6-sol")));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.4-mini");
-		expect(result.model).toBe("gpt-5.4-mini");
+		const headers = new Headers(capturedRequest?.headers);
+		expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
+		expect(headers.get("session-id")).toBeTruthy();
+		expect(headers.get("thread-id")).toBeTruthy();
+		expect(headers.get("x-codex-window-id")).toBeTruthy();
+		expect(capturedRequest?.body).toEqual(
+			expect.objectContaining({
+				model: "gpt-5.6-sol",
+				tool_choice: { type: "web_search" },
+				reasoning: { context: "all_turns" },
+				parallel_tool_calls: false,
+				input: [
+					{
+						type: "additional_tools",
+						role: "developer",
+						tools: [{ type: "web_search", search_context_size: "high" }],
+					},
+					{
+						type: "message",
+						role: "developer",
+						content: [{ type: "input_text", text: "Codex test system prompt" }],
+					},
+					{
+						type: "message",
+						role: "user",
+						content: [{ type: "input_text", text: "Sol web search" }],
+					},
+				],
+				client_metadata: expect.objectContaining({
+					session_id: headers.get("session-id"),
+					thread_id: headers.get("thread-id"),
+					"x-codex-window-id": headers.get("x-codex-window-id"),
+				}),
+			}),
+		);
+		expect(capturedRequest?.body?.tools).toBeUndefined();
+		expect(capturedRequest?.body?.instructions).toBeUndefined();
+		expect(result.model).toBe("gpt-5.6-sol");
 	});
 
 	it("does not retry default candidates when PI_CODEX_WEB_SEARCH_MODEL is explicitly unsupported", async () => {


### PR DESCRIPTION
## What

- Prefer bundled GPT-5.6 Codex models for web search.
- Encode `useResponsesLite` models, including `gpt-5.6-sol`, with Lite body metadata and headers while preserving forced `web_search`.

## Why

GPT-5.6 Codex models require the Responses-Lite wire contract. Fixes #5286.

## Testing

- `bun test packages/coding-agent/test/tools/web-search-codex.test.ts packages/coding-agent/test/web/search/codex-broker.test.ts` — 13 pass
- `bunx biome check packages/coding-agent/src/web/search/providers/codex.ts packages/coding-agent/test/tools/web-search-codex.test.ts` — pass
- `bun check` — blocked by existing `packages/ai/src/providers/cursor.ts` type errors

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)