### PR TITLE
fix(ai): classify OpenAI Codex k12 (ChatGPT Edu) accounts as paid

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Codex `k12` (ChatGPT Edu) accounts being classified as an "unknown" plan and excluded by the paid-model plan filter. A pool of healthy `k12` seats alongside a single exhausted `plus` seat funneled every paid-model request (e.g. `gpt-5.6`) to the lone `plus` account, which then surfaced `usage_limit_reached` on every turn (including fresh sessions) while the `k12` siblings sat idle with headroom. `k12` now classifies as a paid tier, so healthy educational seats are selected and the exhausted account is correctly ranked last.
+
 ## [16.5.0] - 2026-07-13
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -829,6 +829,11 @@ const OPENAI_CODEX_PAID_PLAN_TOKENS: Record<string, true> = {
 	enterprise: true,
 	edu: true,
 	education: true,
+	// ChatGPT Edu seats report `k12` (alongside the broader edu tokens above).
+	// They are paid educational tiers with access to paid models — without this
+	// they classify as "unknown" and the plan filter excludes healthy k12
+	// accounts, funneling every request to a lone exhausted paid account.
+	k12: true,
 	teacher: true,
 	teachers: true,
 	health: true,

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -228,6 +228,38 @@ describe("AuthStorage codex oauth ranking", () => {
 		expectWeightedPreference(counts, "api-acct-near", "api-acct-far");
 	});
 
+	test("selects a healthy k12 account over an exhausted plus account for a paid model", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+		// k12 is an educational paid tier: it must be plan-eligible for paid models
+		// (e.g. gpt-5.6), else the plan filter classifies it "unknown", excludes it,
+		// and funnels every request to the lone (exhausted) plus account.
+		await authStorage.set("openai-codex", [
+			{ type: "oauth", ...createCredential("acct-plus", "plus@example.com") },
+			{ type: "oauth", ...createCredential("acct-k12", "k12@example.com") },
+		]);
+		usageByAccount.set(
+			"acct-plus",
+			createCodexUsageReport({
+				accountId: "acct-plus",
+				primary: { usedFraction: 1, resetInMs: 6 * 24 * HOUR_MS },
+				secondary: { usedFraction: 0.95, resetInMs: 6 * 24 * HOUR_MS },
+				metadata: { planType: "plus", allowed: false, limitReached: true, email: "plus@example.com" },
+			}),
+		);
+		usageByAccount.set(
+			"acct-k12",
+			createCodexUsageReport({
+				accountId: "acct-k12",
+				primary: { usedFraction: 0.01, resetInMs: 4 * HOUR_MS },
+				secondary: { usedFraction: 0.1, resetInMs: 6 * 24 * HOUR_MS },
+				metadata: { planType: "k12", allowed: true, limitReached: false, email: "k12@example.com" },
+			}),
+		);
+
+		const apiKey = await authStorage.getApiKey("openai-codex", "k12-paid-model", { modelId: "gpt-5.6" });
+		expect(apiKey).toBe("api-acct-k12");
+	});
+
 	test("weights fresh 5h ticker account at 0% usage", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 


### PR DESCRIPTION
## Problem

OpenAI Codex OAuth pools that include ChatGPT Edu seats get stuck routing every request to a single exhausted paid account.

Edu seats report `planType: "k12"`, which is missing from `OPENAI_CODEX_PAID_PLAN_TOKENS`, so `classifyOpenAICodexPlan` returns `"unknown"` for them. For a paid-tier model (e.g. `gpt-5.6`, `resolveOpenAICodexPlanRequirement` → `"paid"`), the credential resolution ladder keeps only *confirmed* plan-eligible accounts and drops `"unknown"`-plan accounts whenever at least one confirmed-eligible account exists.

Result: a pool of many healthy `k12` seats plus a single `plus` seat treats only the `plus` account as eligible. Once that account hits its limit, every request — including on fresh sessions — surfaces `usage_limit_reached`, while the healthy `k12` siblings sit idle with plenty of headroom. Disabling the `plus` account "fixes" it only because the ladder then falls back to trying every account unfiltered.

## Fix

Add `k12` to `OPENAI_CODEX_PAID_PLAN_TOKENS`. ChatGPT Edu is a paid educational tier with access to paid models, so `k12` should classify as `paid`. Healthy edu seats then rank normally and an exhausted account is correctly sorted last.

## Test

Adds a regression test to `auth-storage-codex-selection.test.ts`: with an exhausted `plus` account and a healthy `k12` account, a `gpt-5.6` (paid) request now selects the `k12` account.