### PR TITLE
fix(browser): handle detached run cleanup rejections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed browser run cleanup from surfacing detached run-scoped cancellations as fatal unhandled rejections, preserving the active CLI session when a cmux browser run ends ([#4672](https://github.com/can1357/oh-my-pi/issues/4672)).
+
 ## [16.3.9] - 2026-07-06
 
 ### Added

--- a/packages/coding-agent/src/tools/browser/run-cancellation.ts
+++ b/packages/coding-agent/src/tools/browser/run-cancellation.ts
@@ -1,14 +1,22 @@
 import { untilAborted } from "@oh-my-pi/pi-utils";
 import { throwIfAborted } from "../tool-errors";
 
-/** Sleeps inside evaluated browser code while honoring the owning run's cancellation signal. */
-export async function waitForBrowserRun(ms: number, signal: AbortSignal): Promise<void> {
-	throwIfAborted(signal);
-	await untilAborted(signal, () => Bun.sleep(ms));
-	throwIfAborted(signal);
+function markHandled<T>(promise: Promise<T>): Promise<T> {
+	void promise.catch(() => {});
+	return promise;
 }
 
-/** Binds a long-lived browser facade to one evaluated run's abort signal. */
+/** Sleeps inside evaluated browser code while honoring cancellation without leaking detached rejections. */
+export function waitForBrowserRun(ms: number, signal: AbortSignal): Promise<void> {
+	const promise = (async () => {
+		throwIfAborted(signal);
+		await untilAborted(signal, () => Bun.sleep(ms));
+		throwIfAborted(signal);
+	})();
+	return markHandled(promise);
+}
+
+/** Binds a long-lived browser facade to one run and marks detached call rejections as handled. */
 export function bindBrowserRunFacade<T extends object>(target: T, signal: AbortSignal): T {
 	const cache = new Map<PropertyKey, unknown>();
 	return new Proxy(target, {
@@ -24,10 +32,11 @@ export function bindBrowserRunFacade<T extends object>(target: T, signal: AbortS
 					if (result && typeof result === "object") {
 						const then = Reflect.get(result, "then");
 						if (typeof then === "function") {
-							return Promise.resolve(result).then(resolved => {
+							const promise = Promise.resolve(result).then(resolved => {
 								throwIfAborted(signal);
 								return resolved;
 							});
+							return markHandled(promise);
 						}
 					}
 					throwIfAborted(signal);

--- a/packages/coding-agent/test/tools/browser-run-cancellation.test.ts
+++ b/packages/coding-agent/test/tools/browser-run-cancellation.test.ts
@@ -56,4 +56,34 @@ describe("browser run cancellation", () => {
 		expect(state.lateNavigation).toBeUndefined();
 		expect(state.displays).toEqual([]);
 	});
+
+	it("does not emit unhandledRejection when unawaited run-scoped promises are aborted", async () => {
+		const runAc = new AbortController();
+		const { promise: navigation, resolve: finishNavigation } = Promise.withResolvers<void>();
+		const tab = bindBrowserRunFacade(
+			{
+				goto: async (): Promise<void> => {
+					await navigation;
+				},
+			},
+			runAc.signal,
+		);
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+
+		try {
+			void waitForBrowserRun(60_000, runAc.signal);
+			void tab.goto();
+			runAc.abort(new Error("Browser run ended"));
+			finishNavigation();
+			for (let flush = 0; flush < 5; flush++) await Promise.resolve();
+
+			expect(unhandled).toEqual([]);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
 });


### PR DESCRIPTION
## Repro
Run `bun test packages/coding-agent/test/tools/browser-run-cancellation.test.ts` with a run that starts `void wait(60_000)` and an unawaited run-scoped facade call, then aborts the run with `Browser run ended`; before the fix, Bun reports orphaned `AbortError` and `ToolAbortError` rejections and the regression test fails.

## Cause
`waitForBrowserRun` and the promise branch in `bindBrowserRunFacade` (`packages/coding-agent/src/tools/browser/run-cancellation.ts`) returned rejecting promises without passive consumers. When `runCmuxCode` aborted its run controller during cleanup, unawaited user-code calls rejected with zero consumers, reached the global `unhandledRejection` postmortem path, and terminated the CLI.

## Fix
- Attach a passive rejection handler to run-scoped wait and facade promises while returning the original promise so awaited callers still receive failures.
- Cover run-end cleanup with simultaneous unawaited `wait` and facade calls.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/browser-run-cancellation.test.ts` — 2 passed, 0 failed. `bun test packages/coding-agent/test/tools/browser-run-cancellation.test.ts packages/coding-agent/test/tools/browser-cmux-release-mid-run.test.ts packages/coding-agent/test/tools/browser-lifecycle-leak.test.ts packages/coding-agent/test/tools/browser-tab-timeouts.test.ts` — 19 passed, 0 failed. The publish gate also ran `bun run fix` and `bun check` successfully. Fixes #4672