### PR TITLE
fix(catalog): widen GLM coding-plan idle timeout to OpenCode gateways

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GLM-5.x coding-plan streams via the OpenCode Go/Zen gateways (`opencode.ai/zen/…`) timing out with `OpenAI completions stream stalled while waiting for the next event` during slow plan-writing/reasoning phases. The 600s idle-timeout floor for GLM coding-plan SKUs was gated to the native Z.AI/Zhipu hosts only, so OpenCode-fronted GLM fell back to the 120s default watchdog. ([#4758](https://github.com/can1357/oh-my-pi/issues/4758))
+
 ## [16.3.11] - 2026-07-06
 
 ### Added

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -377,7 +377,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	// for minutes while reasoning or cold-loading weights; widen the idle
 	// timeout so warm-ups stop aborting and retrying.
 	const streamIdleTimeoutMs =
-		GLM_CODING_PLAN_MODEL_PATTERN.test(spec.id) && (isZai || isZhipu)
+		GLM_CODING_PLAN_MODEL_PATTERN.test(spec.id) && (isZai || isZhipu || isOpenCodeHost)
 			? GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS
 			: provider === "alibaba-coding-plan"
 				? ALIBABA_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS

--- a/packages/catalog/test/zhipu-compat.test.ts
+++ b/packages/catalog/test/zhipu-compat.test.ts
@@ -120,6 +120,39 @@ describe("openai-completions compat — zhipu-coding-plan branch", () => {
 	});
 });
 
+describe("openai-completions compat — GLM coding-plan stream idle timeout", () => {
+	function glm52(provider: string, baseUrl: string): ModelSpec<"openai-completions"> {
+		return { ...baseModel, id: "glm-5.2", name: "GLM-5.2", provider, baseUrl };
+	}
+
+	// GLM coding-plan SKUs idle for minutes mid-reasoning; the 600s watchdog
+	// floor must apply on every gateway that fronts them, not just the native
+	// Z.AI/Zhipu hosts (issue #4758: GLM-5.2 via opencode-go stalled with
+	// "OpenAI completions stream stalled while waiting for the next event").
+	it("widens the idle timeout to 600s for GLM-5.x on Z.AI, Zhipu, and OpenCode gateways", () => {
+		expect(buildOpenAICompat(glm52("zai", "https://api.z.ai/api/coding/paas/v4")).streamIdleTimeoutMs).toBe(600_000);
+		expect(
+			buildOpenAICompat(glm52("zhipu-coding-plan", "https://open.bigmodel.cn/api/coding/paas/v4"))
+				.streamIdleTimeoutMs,
+		).toBe(600_000);
+		expect(buildOpenAICompat(glm52("opencode-go", "https://opencode.ai/zen/go/v1")).streamIdleTimeoutMs).toBe(
+			600_000,
+		);
+		expect(buildOpenAICompat(glm52("opencode-zen", "https://opencode.ai/zen/v1")).streamIdleTimeoutMs).toBe(600_000);
+	});
+
+	it("does not widen non-GLM models on the OpenCode gateway via the GLM floor", () => {
+		const kimi = buildOpenAICompat({
+			...baseModel,
+			id: "kimi-k2.5",
+			name: "Kimi K2.5",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+		});
+		expect(kimi.streamIdleTimeoutMs).toBeUndefined();
+	});
+});
+
 describe("zhipu-coding-plan model discovery", () => {
 	it("uses the dedicated Coding Plan endpoint by default", async () => {
 		let requestedUrl = "";


### PR DESCRIPTION
## Repro
`/plan` mode with GLM-5.2 via the `opencode-go` provider (`https://opencode.ai/zen/go/v1`) stalls once it reaches the plan-writing step and eventually errors with `OpenAI completions stream stalled while waiting for the next event`. Resolving `buildOpenAICompat` for GLM-5.2 across hosts confirms the root cause:

```
opencode-go        -> undefined   (falls back to 120s default watchdog)
zai                -> 600000
zhipu-coding-plan  -> 600000
```

## Cause
`packages/catalog/src/compat/openai.ts` widens `streamIdleTimeoutMs` to `GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS` (600s) for GLM coding-plan SKUs because they idle for minutes mid-reasoning. The gate was `GLM_CODING_PLAN_MODEL_PATTERN.test(spec.id) && (isZai || isZhipu)`, which excludes the OpenCode Go/Zen gateways (`opencode.ai/zen/…`) even though they front the same GLM-5.x SKUs. OpenCode-hosted GLM therefore fell back to the 120s default idle watchdog, which aborts the connection during a long silent reasoning gap.

## Fix
- `packages/catalog/src/compat/openai.ts`: extend the GLM idle-timeout gate to `isZai || isZhipu || isOpenCodeHost` (the `isOpenCodeHost` flag is already computed upstream from the `opencode` host matcher).
- `packages/catalog/test/zhipu-compat.test.ts`: add regression coverage asserting the 600s floor applies to GLM-5.x on Z.AI, Zhipu, and both OpenCode gateways, and that a non-GLM model on OpenCode is not widened by this path.
- `packages/catalog/CHANGELOG.md`: `[Unreleased] > Fixed` entry.

## Verification
`bun test packages/catalog/test/zhipu-compat.test.ts` → 8 pass / 0 fail. Also verified via a direct `buildOpenAICompat` resolution that GLM-5.2/5.1/5 on `opencode-go`/`opencode-zen` now resolve `streamIdleTimeoutMs === 600000` while `kimi-k2.6` on `opencode-go` stays unaffected by the GLM floor. Fixes #4758