### PR TITLE
fix(catalog): sync OpenCode models from live catalogs

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenCode Zen and Go discovery to replace stale bundled models with each provider's live model catalog. ([#4769](https://github.com/can1357/oh-my-pi/issues/4769))
+
 ## [16.3.11] - 2026-07-06
 
 ### Added

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -302,12 +302,14 @@ export const CATALOG_PROVIDERS = [
 		defaultModel: "kimi-k2.7-code",
 		envVars: ["OPENCODE_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => opencodeGoModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
 	},
 	{
 		id: "opencode-zen",
 		defaultModel: "claude-opus-4-8",
 		envVars: ["OPENCODE_API_KEY"],
 		createModelManagerOptions: (config: ModelManagerConfig) => opencodeZenModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
 	},
 	{
 		id: "openrouter",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1876,6 +1876,16 @@ function openCodeBaseUrlForApi(api: Api, basePath: string): string {
 	return api === "anthropic-messages" ? basePath : `${basePath}/v1`;
 }
 
+function openCodeModelCacheProviderId(
+	providerId: "opencode-go" | "opencode-zen",
+	apiKey: string | undefined,
+	discoveryBaseUrl: string,
+): string {
+	// OpenCode catalogs are entitlement-scoped; isolate authoritative rows by credential and endpoint.
+	const scope = `${apiKey ?? ""}\u0000${discoveryBaseUrl}`;
+	return `${providerId}:models-v1:${Bun.hash(scope).toString(36)}`;
+}
+
 function openCodeModelManagerOptions(
 	providerId: "opencode-go" | "opencode-zen",
 	defaultBasePath: string,
@@ -1887,6 +1897,7 @@ function openCodeModelManagerOptions(
 	const references = createBundledReferenceMap<Api>(providerId);
 	return {
 		providerId,
+		cacheProviderId: openCodeModelCacheProviderId(providerId, apiKey, discoveryBaseUrl),
 		dynamicModelsAuthoritative: true,
 		...(apiKey && {
 			fetchDynamicModels: () =>

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1887,6 +1887,7 @@ function openCodeModelManagerOptions(
 	const references = createBundledReferenceMap<Api>(providerId);
 	return {
 		providerId,
+		dynamicModelsAuthoritative: true,
 		...(apiKey && {
 			fetchDynamicModels: () =>
 				fetchOpenAICompatibleModels<Api>({

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -17,6 +17,15 @@ const LIVE_FREE_MODEL_IDS = [
 	"north-mini-code-free",
 ] as const;
 
+const LIVE_PAID_MODEL_IDS = ["claude-opus-4-8", "gpt-5.5"] as const;
+
+function modelListResponse(ids: readonly string[]): Response {
+	return Response.json({
+		object: "list",
+		data: ids.map(id => ({ id, object: "model", owned_by: "opencode" })),
+	});
+}
+
 describe("OpenCode provider discovery", () => {
 	test("treats the OpenCode model endpoints as authoritative catalogs", () => {
 		for (const providerId of ["opencode-go", "opencode-zen"]) {
@@ -27,24 +36,41 @@ describe("OpenCode provider discovery", () => {
 		expect(opencodeZenModelManagerOptions().dynamicModelsAuthoritative).toBe(true);
 	});
 
-	test("replaces stale bundled Zen models with the live endpoint list", async () => {
+	test("replaces stale bundled Zen models with each credential's live endpoint list", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-zen-"));
 		try {
-			const options = opencodeZenModelManagerOptions({
-				apiKey: "zen-test-key",
-				fetch: async () =>
-					Response.json({
-						object: "list",
-						data: LIVE_FREE_MODEL_IDS.map(id => ({ id, object: "model", owned_by: "opencode" })),
-					}),
+			let freeFetches = 0;
+			const freeOptions = opencodeZenModelManagerOptions({
+				apiKey: "free-account-key",
+				fetch: async () => {
+					freeFetches++;
+					return modelListResponse(LIVE_FREE_MODEL_IDS);
+				},
 			});
-			const result = await resolveProviderModels(
-				{ ...options, cacheDbPath: path.join(tempDir, "models.db") },
-				"online",
+			const freeResult = await resolveProviderModels(
+				{ ...freeOptions, cacheDbPath: path.join(tempDir, "models.db") },
+				"online-if-uncached",
 			);
 
-			expect(result.stale).toBe(false);
-			expect(result.models.map(model => model.id).sort()).toEqual([...LIVE_FREE_MODEL_IDS].sort());
+			let paidFetches = 0;
+			const paidOptions = opencodeZenModelManagerOptions({
+				apiKey: "paid-account-key",
+				fetch: async () => {
+					paidFetches++;
+					return modelListResponse(LIVE_PAID_MODEL_IDS);
+				},
+			});
+			const paidResult = await resolveProviderModels(
+				{ ...paidOptions, cacheDbPath: path.join(tempDir, "models.db") },
+				"online-if-uncached",
+			);
+
+			expect(freeOptions.cacheProviderId).not.toBe(paidOptions.cacheProviderId);
+			expect(freeResult.stale).toBe(false);
+			expect(freeResult.models.map(model => model.id).sort()).toEqual([...LIVE_FREE_MODEL_IDS].sort());
+			expect(paidResult.stale).toBe(false);
+			expect(paidResult.models.map(model => model.id).sort()).toEqual([...LIVE_PAID_MODEL_IDS].sort());
+			expect([freeFetches, paidFetches]).toEqual([1, 1]);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}

--- a/packages/catalog/test/opencode-provider.test.ts
+++ b/packages/catalog/test/opencode-provider.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveProviderModels } from "@oh-my-pi/pi-catalog/model-manager";
+import { PROVIDER_DESCRIPTORS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import {
+	opencodeGoModelManagerOptions,
+	opencodeZenModelManagerOptions,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+
+const LIVE_FREE_MODEL_IDS = [
+	"deepseek-v4-flash-free",
+	"hy3-free",
+	"mimo-v2.5-free",
+	"nemotron-3-ultra-free",
+	"north-mini-code-free",
+] as const;
+
+describe("OpenCode provider discovery", () => {
+	test("treats the OpenCode model endpoints as authoritative catalogs", () => {
+		for (const providerId of ["opencode-go", "opencode-zen"]) {
+			const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === providerId);
+			expect(descriptor?.dynamicModelsAuthoritative).toBe(true);
+		}
+		expect(opencodeGoModelManagerOptions().dynamicModelsAuthoritative).toBe(true);
+		expect(opencodeZenModelManagerOptions().dynamicModelsAuthoritative).toBe(true);
+	});
+
+	test("replaces stale bundled Zen models with the live endpoint list", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-opencode-zen-"));
+		try {
+			const options = opencodeZenModelManagerOptions({
+				apiKey: "zen-test-key",
+				fetch: async () =>
+					Response.json({
+						object: "list",
+						data: LIVE_FREE_MODEL_IDS.map(id => ({ id, object: "model", owned_by: "opencode" })),
+					}),
+			});
+			const result = await resolveProviderModels(
+				{ ...options, cacheDbPath: path.join(tempDir, "models.db") },
+				"online",
+			);
+
+			expect(result.stale).toBe(false);
+			expect(result.models.map(model => model.id).sort()).toEqual([...LIVE_FREE_MODEL_IDS].sort());
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Repro
With an OpenCode Zen `/v1/models` response containing only the five current free model IDs, `resolveProviderModels(opencodeZenModelManagerOptions(...), "online")` returned 68 selectable models and retained 16 `*-free` IDs from the bundled catalog instead of the five live IDs.

## Cause
`openCodeModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` did not mark OpenCode discovery as authoritative, so `resolveProviderModels` merged `/v1/models` results with bundled fallbacks. The corresponding entries in `packages/catalog/src/provider-models/descriptors.ts` also omitted the authoritative flag, preventing the coding-agent registry from replacing cached provider slices during startup and refresh.

## Fix
- Mark OpenCode Zen and Go model-manager discovery as authoritative so successful live responses prune bundled-only IDs.
- Mark both provider descriptors authoritative so cached and refreshed runtime catalogs replace stale provider slices.
- Add regression coverage for exact live-list replacement and provider metadata.
- Document the fix in the catalog changelog.

## Verification
`bun test packages/catalog/test/opencode-provider.test.ts` — 2 passed, 0 failed. `bun test packages/catalog/test` — 403 passed, 0 failed. Live smoke against `https://opencode.ai/zen/v1/models` resolved 55 models, exactly 5 `*-free` IDs, and `stale: false`. Pre-publish `bun run fix` and `bun check` passed via the publish gate.

Fixes #4769