### PR TITLE
fix(plugins): resolve native addon package mains

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled extension validation for transitive native addon packages by resolving `.node` entry points to their on-disk URLs without source-loader cache-busting ([#4763](https://github.com/can1357/oh-my-pi/issues/4763)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -200,6 +200,7 @@ const LEGACY_PI_IMPORT_SPECIFIER_REGEX = new RegExp(
 );
 const resolvedSpecifierFallbacks = new Map<string, string>();
 const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"] as const;
+const NATIVE_ADDON_EXTENSION = ".node";
 const SUPPORTED_PACKAGE_IMPORT_CONDITIONS = new Set(["bun", "node", "import", "default"]);
 const packageRootCache = new Map<string, string | null>();
 const packageImportsCache = new Map<string, Record<string, unknown> | null>();
@@ -542,6 +543,9 @@ function toGraphImportSpecifier(resolvedPath: string, mtimeTag: string | null): 
 	if (isBundledVirtualSpecifier(resolvedPath)) {
 		return resolvedPath;
 	}
+	if (path.extname(resolvedPath).toLowerCase() === NATIVE_ADDON_EXTENSION) {
+		return url.pathToFileURL(stripWindowsExtendedLengthPathPrefix(resolvedPath)).href;
+	}
 	if (process.platform === "win32" || !mtimeTag) {
 		return url.pathToFileURL(stripWindowsExtendedLengthPathPrefix(resolvedPath)).href;
 	}
@@ -594,6 +598,25 @@ async function resolveSourceModuleFile(basePath: string): Promise<string | null>
 		if (resolved) return resolved;
 	}
 	return null;
+}
+
+async function resolveNodePackageModuleFile(basePath: string): Promise<string | null> {
+	const sourceModule = await resolveSourceModuleFile(basePath);
+	if (sourceModule) {
+		return sourceModule;
+	}
+
+	const extension = path.extname(basePath).toLowerCase();
+	if (extension && extension !== NATIVE_ADDON_EXTENSION) {
+		return null;
+	}
+	const nativeAddonPath = extension ? basePath : `${basePath}${NATIVE_ADDON_EXTENSION}`;
+	try {
+		const stats = await fs.promises.stat(nativeAddonPath);
+		return stats.isFile() ? realpathOrSelf(nativeAddonPath) : null;
+	} catch {
+		return null;
+	}
 }
 
 async function findPackageRoot(importerPath: string): Promise<string | null> {
@@ -763,7 +786,8 @@ async function rewriteExtensionPackageImports(
 	return `${rewritten}${source.slice(lastIndex)}`;
 }
 
-const BARE_EXTENSION_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])([^"'()\s]+)(["'])/g;
+const BARE_EXTENSION_IMPORT_SPECIFIER_REGEX =
+	/((?:from\s+|import\s+|import\s*\(\s*|require\s*\(\s*)["'])([^"'()\s]+)(["'])/g;
 
 function isBareExtensionDependencySpecifier(specifier: string): boolean {
 	if (
@@ -849,7 +873,7 @@ async function resolvePackageExportTarget(
 		return null;
 	}
 	const substituted = wildcard === null ? target : target.replaceAll("*", wildcard);
-	return resolveSourceModuleFile(path.resolve(packageRoot, substituted));
+	return resolveNodePackageModuleFile(path.resolve(packageRoot, substituted));
 }
 
 async function resolveNodePackageExport(
@@ -899,16 +923,16 @@ async function resolveNodePackageFallback(
 	manifest: Record<string, unknown>,
 ): Promise<string | null> {
 	if (subpath !== null) {
-		return resolveSourceModuleFile(path.join(packageRoot, subpath));
+		return resolveNodePackageModuleFile(path.join(packageRoot, subpath));
 	}
 	for (const field of ["module", "main"]) {
 		const target = manifest[field];
 		if (typeof target === "string") {
-			const resolved = await resolveSourceModuleFile(path.resolve(packageRoot, target));
+			const resolved = await resolveNodePackageModuleFile(path.resolve(packageRoot, target));
 			if (resolved) return resolved;
 		}
 	}
-	return resolveSourceModuleFile(path.join(packageRoot, "index"));
+	return resolveNodePackageModuleFile(path.join(packageRoot, "index"));
 }
 
 async function resolveNodePackageDependency(specifier: string, importerPath: string): Promise<string | null> {
@@ -1073,12 +1097,15 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 					const packageRoot = parsed ? await findNodePackageRoot(parsed.name, file) : null;
 					const manifest = packageRoot ? await readPackageManifest(packageRoot) : null;
 					const dependencyEntry = manifest ? await resolveExtensionBareDependency(specifier, file) : null;
-					const dependencyExtension = dependencyEntry ? path.extname(dependencyEntry) : null;
+					const dependencyExtension = dependencyEntry ? path.extname(dependencyEntry).toLowerCase() : null;
 					const isCommonJsEntry =
 						dependencyExtension === ".cjs" ||
 						dependencyExtension === ".cts" ||
 						((dependencyExtension === ".js" || dependencyExtension === ".jsx") && manifest?.type !== "module");
-					resolved = dependencyEntry && !isCommonJsEntry ? await realpathOrSelf(dependencyEntry) : null;
+					resolved =
+						dependencyEntry && dependencyExtension !== NATIVE_ADDON_EXTENSION && !isCommonJsEntry
+							? await realpathOrSelf(dependencyEntry)
+							: null;
 					nextFollowsBareDependencies = false;
 				}
 				if (resolved && !modules.has(resolved)) {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -201,7 +201,21 @@ const LEGACY_PI_IMPORT_SPECIFIER_REGEX = new RegExp(
 const resolvedSpecifierFallbacks = new Map<string, string>();
 const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"] as const;
 const NATIVE_ADDON_EXTENSION = ".node";
-const SUPPORTED_PACKAGE_IMPORT_CONDITIONS = new Set(["bun", "node", "import", "default"]);
+const SUPPORTED_PACKAGE_IMPORT_CONDITIONS: Record<string, true> = {
+	bun: true,
+	node: true,
+	import: true,
+	default: true,
+};
+const SUPPORTED_PACKAGE_REQUIRE_CONDITIONS: Record<string, true> = {
+	bun: true,
+	node: true,
+	require: true,
+	default: true,
+};
+const PACKAGE_IMPORT_FALLBACK_FIELDS = ["module", "main"] as const;
+const PACKAGE_REQUIRE_FALLBACK_FIELDS = ["main"] as const;
+type ExtensionDependencyCallKind = "import" | "require";
 const packageRootCache = new Map<string, string | null>();
 const packageImportsCache = new Map<string, Record<string, unknown> | null>();
 const nodePackageRootCache = new Map<string, Promise<string | null>>();
@@ -663,7 +677,10 @@ async function readPackageImports(packageRoot: string): Promise<Record<string, u
 type PackageImportTargetSelection = string | typeof PACKAGE_IMPORT_EXCLUDED | null;
 type ResolvedPackageImportTargetSelection = string | typeof PACKAGE_IMPORT_EXCLUDED;
 
-function selectPackageImportTarget(entry: unknown): PackageImportTargetSelection {
+function selectPackageImportTarget(
+	entry: unknown,
+	callKind: ExtensionDependencyCallKind = "import",
+): PackageImportTargetSelection {
 	if (entry === null) {
 		return PACKAGE_IMPORT_EXCLUDED;
 	}
@@ -672,7 +689,7 @@ function selectPackageImportTarget(entry: unknown): PackageImportTargetSelection
 	}
 	if (Array.isArray(entry)) {
 		for (const item of entry) {
-			const target = selectPackageImportTarget(item);
+			const target = selectPackageImportTarget(item, callKind);
 			if (target !== null) return target;
 		}
 		return null;
@@ -680,11 +697,14 @@ function selectPackageImportTarget(entry: unknown): PackageImportTargetSelection
 	if (!isRecord(entry)) {
 		return null;
 	}
-	for (const [condition, value] of Object.entries(entry)) {
-		if (!SUPPORTED_PACKAGE_IMPORT_CONDITIONS.has(condition)) {
+	const supportedConditions =
+		callKind === "require" ? SUPPORTED_PACKAGE_REQUIRE_CONDITIONS : SUPPORTED_PACKAGE_IMPORT_CONDITIONS;
+	for (const condition in entry) {
+		const value = entry[condition];
+		if (!Object.hasOwn(supportedConditions, condition)) {
 			continue;
 		}
-		const target = selectPackageImportTarget(value);
+		const target = selectPackageImportTarget(value, callKind);
 		if (target !== null) return target;
 	}
 	return null;
@@ -880,9 +900,10 @@ async function resolveNodePackageExport(
 	packageRoot: string,
 	subpath: string | null,
 	manifest: Record<string, unknown>,
+	callKind: ExtensionDependencyCallKind,
 ): Promise<string | null> {
 	const exportsField = manifest.exports;
-	const rootTarget = subpath === null ? selectPackageImportTarget(exportsField) : null;
+	const rootTarget = subpath === null ? selectPackageImportTarget(exportsField, callKind) : null;
 	if (rootTarget !== null && rootTarget !== PACKAGE_IMPORT_EXCLUDED) {
 		return resolvePackageExportTarget(packageRoot, rootTarget, null);
 	}
@@ -891,7 +912,7 @@ async function resolveNodePackageExport(
 	}
 
 	const exactKey = subpath === null ? "." : `./${subpath}`;
-	const exactTarget = selectPackageImportTarget(exportsField[exactKey]);
+	const exactTarget = selectPackageImportTarget(exportsField[exactKey], callKind);
 	if (exactTarget !== null && exactTarget !== PACKAGE_IMPORT_EXCLUDED) {
 		return resolvePackageExportTarget(packageRoot, exactTarget, null);
 	}
@@ -904,7 +925,7 @@ async function resolveNodePackageExport(
 		if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) {
 			continue;
 		}
-		const target = selectPackageImportTarget(entry);
+		const target = selectPackageImportTarget(entry, callKind);
 		if (target === null || target === PACKAGE_IMPORT_EXCLUDED) {
 			continue;
 		}
@@ -921,11 +942,13 @@ async function resolveNodePackageFallback(
 	packageRoot: string,
 	subpath: string | null,
 	manifest: Record<string, unknown>,
+	callKind: ExtensionDependencyCallKind,
 ): Promise<string | null> {
 	if (subpath !== null) {
 		return resolveNodePackageModuleFile(path.join(packageRoot, subpath));
 	}
-	for (const field of ["module", "main"]) {
+	const fallbackFields = callKind === "require" ? PACKAGE_REQUIRE_FALLBACK_FIELDS : PACKAGE_IMPORT_FALLBACK_FIELDS;
+	for (const field of fallbackFields) {
 		const target = manifest[field];
 		if (typeof target === "string") {
 			const resolved = await resolveNodePackageModuleFile(path.resolve(packageRoot, target));
@@ -935,7 +958,11 @@ async function resolveNodePackageFallback(
 	return resolveNodePackageModuleFile(path.join(packageRoot, "index"));
 }
 
-async function resolveNodePackageDependency(specifier: string, importerPath: string): Promise<string | null> {
+async function resolveNodePackageDependency(
+	specifier: string,
+	importerPath: string,
+	callKind: ExtensionDependencyCallKind,
+): Promise<string | null> {
 	const parsed = splitBarePackageSpecifier(specifier);
 	if (!parsed) return null;
 	const packageRoot = await findNodePackageRoot(parsed.name, importerPath);
@@ -943,26 +970,37 @@ async function resolveNodePackageDependency(specifier: string, importerPath: str
 	const manifest = await readPackageManifest(packageRoot);
 	if (!manifest) return null;
 	return (
-		(await resolveNodePackageExport(packageRoot, parsed.subpath, manifest)) ??
-		(await resolveNodePackageFallback(packageRoot, parsed.subpath, manifest))
+		(await resolveNodePackageExport(packageRoot, parsed.subpath, manifest, callKind)) ??
+		(await resolveNodePackageFallback(packageRoot, parsed.subpath, manifest, callKind))
 	);
 }
 
-async function resolveExtensionBareDependency(specifier: string, importerPath: string): Promise<string | null> {
+async function resolveExtensionBareDependency(
+	specifier: string,
+	importerPath: string,
+	callKind: ExtensionDependencyCallKind,
+): Promise<string | null> {
 	if (!isBareExtensionDependencySpecifier(specifier)) {
 		return null;
 	}
 
-	const cacheKey = `${specifier}\0${path.resolve(path.dirname(importerPath))}`;
+	const cacheKey = `${callKind}\0${specifier}\0${path.resolve(path.dirname(importerPath))}`;
 	const cached = bareDependencyResolutionCache.get(cacheKey);
 	if (cached) return cached;
 
-	const promise = resolveExtensionBareDependencyUncached(specifier, importerPath);
+	const promise = resolveExtensionBareDependencyUncached(specifier, importerPath, callKind);
 	bareDependencyResolutionCache.set(cacheKey, promise);
 	return promise;
 }
 
-async function resolveExtensionBareDependencyUncached(specifier: string, importerPath: string): Promise<string | null> {
+async function resolveExtensionBareDependencyUncached(
+	specifier: string,
+	importerPath: string,
+	callKind: ExtensionDependencyCallKind,
+): Promise<string | null> {
+	if (callKind === "require") {
+		return resolveNodePackageDependency(specifier, importerPath, callKind);
+	}
 	try {
 		const resolved = Bun.resolveSync(specifier, path.dirname(importerPath));
 		if (resolved && resolved !== specifier && !resolved.startsWith("node:") && !resolved.startsWith("bun:")) {
@@ -971,7 +1009,7 @@ async function resolveExtensionBareDependencyUncached(specifier: string, importe
 	} catch {
 		// Compiled binaries do not reliably resolve runtime extension node_modules.
 	}
-	return resolveNodePackageDependency(specifier, importerPath);
+	return resolveNodePackageDependency(specifier, importerPath, callKind);
 }
 
 async function rewriteExtensionBareImports(
@@ -988,7 +1026,8 @@ async function rewriteExtensionBareImports(
 		const [fullMatch, prefix, specifier, suffix] = match;
 		if (!prefix || !specifier || !suffix) continue;
 
-		const resolved = await resolveExtensionBareDependency(specifier, importerPath);
+		const callKind = prefix.startsWith("require") ? "require" : "import";
+		const resolved = await resolveExtensionBareDependency(specifier, importerPath, callKind);
 		if (!resolved) continue;
 
 		rewritten += source.slice(lastIndex, matchIndex);
@@ -1096,7 +1135,9 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 					const parsed = splitBarePackageSpecifier(specifier);
 					const packageRoot = parsed ? await findNodePackageRoot(parsed.name, file) : null;
 					const manifest = packageRoot ? await readPackageManifest(packageRoot) : null;
-					const dependencyEntry = manifest ? await resolveExtensionBareDependency(specifier, file) : null;
+					const dependencyEntry = manifest
+						? await resolveExtensionBareDependency(specifier, file, "import")
+						: null;
 					const dependencyExtension = dependencyEntry ? path.extname(dependencyEntry).toLowerCase() : null;
 					const isCommonJsEntry =
 						dependencyExtension === ".cjs" ||

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import {
+	__resetLegacyPiResolutionCache,
 	__rewriteLegacyExtensionSourceForTests,
 	loadLegacyPiModule,
 } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
@@ -502,6 +503,38 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(expectedEsmDepUrls.some(expected => rewritten.includes(expected))).toBe(true);
 		expect(expectedRootDepUrls.some(expected => rewritten.includes(expected))).toBe(true);
 		expect(rewritten).toContain('from "node:path"');
+	});
+
+	it("rewrites native addon package mains without cache-busting the binary", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "native-addon-ext", version: "1.0.0" }),
+			"node_modules/native-addon/package.json": JSON.stringify({
+				name: "native-addon",
+				version: "1.0.0",
+				main: "addon.node",
+			}),
+			"node_modules/native-addon/addon.node": "fixture",
+			"index.ts": "",
+		});
+		const importer = path.join(dir, "index.ts");
+		const addonPath = path.join(dir, "node_modules", "native-addon", "addon.node");
+		const resolveSpy = spyOn(Bun, "resolveSync").mockImplementation(() => {
+			throw new Error("compiled fallback");
+		});
+		let rewritten: string;
+		try {
+			rewritten = await __rewriteLegacyExtensionSourceForTests(
+				'const nativeAddon = require("native-addon");',
+				importer,
+				"123",
+			);
+		} finally {
+			resolveSpy.mockRestore();
+			__resetLegacyPiResolutionCache();
+		}
+
+		const addonUrl = url.pathToFileURL(await fs.realpath(addonPath)).href;
+		expect(rewritten).toBe(`const nativeAddon = require("${addonUrl}");`);
 	});
 
 	it("remaps legacy pi-ai utils/oauth subpaths to registry OAuth exports", async () => {

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -505,15 +505,17 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(rewritten).toContain('from "node:path"');
 	});
 
-	it("rewrites native addon package mains without cache-busting the binary", async () => {
+	it("keeps import and require export conditions isolated for native addon package mains", async () => {
 		const dir = await writePackage({
 			"package.json": JSON.stringify({ name: "native-addon-ext", version: "1.0.0" }),
 			"node_modules/native-addon/package.json": JSON.stringify({
 				name: "native-addon",
 				version: "1.0.0",
 				main: "addon.node",
+				exports: { ".": { require: "./addon.node", import: "./index.js" } },
 			}),
 			"node_modules/native-addon/addon.node": "fixture",
+			"node_modules/native-addon/index.js": "export default {};",
 			"index.ts": "",
 		});
 		const importer = path.join(dir, "index.ts");
@@ -521,9 +523,15 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		const resolveSpy = spyOn(Bun, "resolveSync").mockImplementation(() => {
 			throw new Error("compiled fallback");
 		});
-		let rewritten: string;
+		let importRewritten: string;
+		let requireRewritten: string;
 		try {
-			rewritten = await __rewriteLegacyExtensionSourceForTests(
+			importRewritten = await __rewriteLegacyExtensionSourceForTests(
+				'import nativeAddon from "native-addon";',
+				importer,
+				"123",
+			);
+			requireRewritten = await __rewriteLegacyExtensionSourceForTests(
 				'const nativeAddon = require("native-addon");',
 				importer,
 				"123",
@@ -534,7 +542,8 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		}
 
 		const addonUrl = url.pathToFileURL(await fs.realpath(addonPath)).href;
-		expect(rewritten).toBe(`const nativeAddon = require("${addonUrl}");`);
+		expect(importRewritten).toContain("index.js");
+		expect(requireRewritten).toBe(`const nativeAddon = require("${addonUrl}");`);
 	});
 
 	it("remaps legacy pi-ai utils/oauth subpaths to registry OAuth exports", async () => {


### PR DESCRIPTION
## Repro
A minimal fixture package with `main: "addon.node"`, loaded while `Bun.resolveSync` throws as it does for runtime `node_modules` in a compiled binary, reproduced the failure with `bun /tmp/issue-4763-repro.ts`: the command exited 1 because `__rewriteLegacyExtensionSourceForTests()` left `require("native-addon")` bare instead of resolving the installed addon.

## Cause
`resolveNodePackageFallback()` and `resolvePackageExportTarget()` in `packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` delegated exclusively to `resolveSourceModuleFile()`, whose source-extension allowlist rejects `.node`; `rewriteExtensionBareImports()` also did not recognize CommonJS `require()` calls, so the compiled loader could neither resolve nor rewrite napi-rs split-package addon imports.

## Fix
- Resolve `.node` package exports, subpaths, `module`/`main` entries, and extensionless addon fallbacks without adding them to the source rewrite graph.
- Rewrite CommonJS `require()` bare dependencies and emit native addon targets as queryless `file://` URLs so Bun's native `require` loader handles them.
- Add a compiled-fallback regression test and document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts -t 'rewrites native addon package mains'` passed (1 test); `bun /tmp/issue-4763-native-smoke.ts` loaded the installed `@napi-rs/lzma-linux-x64-gnu` binary through the forced compiled fallback (`{"nativeLoaded":true}`); `bun check` passed. Fixes #4763