### PR TITLE
fix(rpc): bound oversized agent_end frames

### DIFF
--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -363,6 +363,11 @@ Extension runner errors are emitted separately as:
 
 `message_update` includes streaming deltas in `assistantMessageEvent` (text/thinking/toolcall deltas).
 
+RPC stdout keeps `agent_end` frames below a one MiB JSONL reader ceiling. When
+the redundant terminal aggregate would exceed that bound, `messages` contains
+the newest contiguous suffix that fits and the event includes the original
+`messageCount` plus a `status` of `completed`, `failed`, or `cancelled`.
+
 ## Prompt/Queue Concurrency and Ordering
 
 This is the most important operational behavior.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -88,6 +88,9 @@
 - Fixed Pyright LSP semantic requests hanging during startup.
 - Fixed Codex web search requests for GPT-5.6 Responses-Lite models.
 - Fixed custom model/provider configuration discovery to correctly load ~/.omp/agent/models.yaml when models.yml is absent.
+### Fixed
+
+- Fixed long RPC turns emitting an oversized terminal `agent_end` JSONL frame by retaining the newest message suffix that fits and preserving the original message count and completion status.
 
 ## [16.5.0] - 2026-07-13
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Fixed `--reasoning-slide-plan` silently ending the run with no code written when the model answered with a text-only reply.
 - Fixed launch tool rendering issues, including stacked pending headers and confusing start/wait results when readiness timed out.
 - Fixed the in-process `stat` and other GNU-flavored shell builtins (such as `date`, `sed`, `mktemp`, `tail`, `find`, `base64`, and `ln`) mangling or failing on macOS/BSD-style invocations.
+- Fixed long RPC turns emitting an oversized terminal `agent_end` JSONL frame by retaining the newest message suffix that fits and preserving the original message count and completion status.
 
 ## [16.5.1] - 2026-07-14
 
@@ -88,9 +89,6 @@
 - Fixed Pyright LSP semantic requests hanging during startup.
 - Fixed Codex web search requests for GPT-5.6 Responses-Lite models.
 - Fixed custom model/provider configuration discovery to correctly load ~/.omp/agent/models.yaml when models.yml is absent.
-### Fixed
-
-- Fixed long RPC turns emitting an oversized terminal `agent_end` JSONL frame by retaining the newest message suffix that fits and preserving the original message count and completion status.
 
 ## [16.5.0] - 2026-07-13
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -5,14 +5,16 @@
  */
 
 import { isPromise } from "node:util/types";
-import type { AgentEvent, AgentMessage, AgentToolResult, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { AgentMessage, AgentToolResult, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type { ImageContent, Model } from "@oh-my-pi/pi-ai";
 import { isRecord, ptree, readJsonl } from "@oh-my-pi/pi-utils";
 import type { FileSink } from "bun";
 import type { BashResult } from "../../exec/bash-executor";
-import type { AgentSessionEvent, SessionStats } from "../../session/agent-session";
+import type { SessionStats } from "../../session/agent-session";
 import type {
+	RpcAgentEvent,
+	RpcAgentSessionEvent,
 	RpcAvailableCommandsUpdateFrame,
 	RpcAvailableSlashCommand,
 	RpcCommand,
@@ -61,8 +63,8 @@ export interface RpcClientOptions {
 
 export type ModelInfo = Pick<Model, "provider" | "id" | "contextWindow" | "reasoning" | "thinking">;
 
-export type RpcEventListener = (event: AgentEvent) => void;
-export type RpcSessionEventListener = (event: AgentSessionEvent) => void;
+export type RpcEventListener = (event: RpcAgentEvent) => void;
+export type RpcSessionEventListener = (event: RpcAgentSessionEvent) => void;
 export type RpcSubagentLifecycleListener = (payload: RpcSubagentLifecycleFrame["payload"]) => void;
 export type RpcSubagentProgressListener = (payload: RpcSubagentProgressFrame["payload"]) => void;
 export type RpcSubagentEventListener = (payload: RpcSubagentEventFrame["payload"]) => void;
@@ -94,7 +96,7 @@ export function defineRpcClientTool<
 	return tool;
 }
 
-const agentEventTypes = new Set<AgentEvent["type"]>([
+const agentEventTypes = new Set<RpcAgentEvent["type"]>([
 	"agent_start",
 	"agent_end",
 	"turn_start",
@@ -107,7 +109,7 @@ const agentEventTypes = new Set<AgentEvent["type"]>([
 	"tool_execution_end",
 ]);
 
-const sessionEventTypes = new Set<AgentSessionEvent["type"]>([
+const sessionEventTypes = new Set<RpcAgentSessionEvent["type"]>([
 	...agentEventTypes,
 	"auto_compaction_start",
 	"auto_compaction_end",
@@ -136,18 +138,18 @@ function isRpcResponse(value: unknown): value is RpcResponse {
 	return true;
 }
 
-function isAgentEvent(value: unknown): value is AgentEvent {
+function isAgentEvent(value: unknown): value is RpcAgentEvent {
 	if (!isRecord(value)) return false;
 	const type = value.type;
 	if (typeof type !== "string") return false;
-	return agentEventTypes.has(type as AgentEvent["type"]);
+	return agentEventTypes.has(type as RpcAgentEvent["type"]);
 }
 
-function isAgentSessionEvent(value: unknown): value is AgentSessionEvent {
+function isAgentSessionEvent(value: unknown): value is RpcAgentSessionEvent {
 	if (!isRecord(value)) return false;
 	const type = value.type;
 	if (typeof type !== "string") return false;
-	return sessionEventTypes.has(type as AgentSessionEvent["type"]);
+	return sessionEventTypes.has(type as RpcAgentSessionEvent["type"]);
 }
 
 function isRpcSubagentLifecycleFrame(value: unknown): value is RpcSubagentLifecycleFrame {
@@ -828,9 +830,9 @@ export class RpcClient {
 	/**
 	 * Collect events until agent becomes idle.
 	 */
-	collectEvents(timeout = 60000): Promise<AgentEvent[]> {
-		const { promise, resolve, reject } = Promise.withResolvers<AgentEvent[]>();
-		const events: AgentEvent[] = [];
+	collectEvents(timeout = 60000): Promise<RpcAgentEvent[]> {
+		const { promise, resolve, reject } = Promise.withResolvers<RpcAgentEvent[]>();
+		const events: RpcAgentEvent[] = [];
 		let settled = false;
 		const unsubscribe = this.onEvent(event => {
 			events.push(event);
@@ -854,7 +856,7 @@ export class RpcClient {
 	/**
 	 * Send prompt and wait for completion, returning all events.
 	 */
-	async promptAndWait(message: string, images?: ImageContent[], timeout = 60000): Promise<AgentEvent[]> {
+	async promptAndWait(message: string, images?: ImageContent[], timeout = 60000): Promise<RpcAgentEvent[]> {
 		const eventsPromise = this.collectEvents(timeout);
 		await this.prompt(message, images);
 		return eventsPromise;

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -48,6 +48,7 @@ import type {
 	RpcHostUriResult,
 	RpcResponse,
 	RpcSessionState,
+	RpcSubagentFrame,
 	RpcSubagentSubscriptionLevel,
 } from "./rpc-types";
 
@@ -154,6 +155,14 @@ export function boundedRpcSessionEvent(event: AgentSessionEvent): AgentSessionEv
 	}
 
 	return low === 0 ? fallback : { ...event, messages: event.messages.slice(-low), ...terminal };
+}
+
+/** Apply the same terminal-frame bound to nested streamed subagent events. */
+export function boundedRpcSubagentFrame(frame: RpcSubagentFrame): RpcSubagentFrame {
+	if (frame.type !== "subagent_event") return frame;
+	const event = boundedRpcSessionEvent(frame.payload.event);
+	if (event === frame.payload.event) return frame;
+	return { ...frame, payload: { ...frame.payload, event } };
 }
 
 export type RpcSessionChangeCommand = Extract<
@@ -702,7 +711,9 @@ export async function runRpcMode(
 	const pendingExtensionRequests = new RpcPendingExtensionRequests();
 	const hostToolBridge = new RpcHostToolBridge(output);
 	const hostUriBridge = new RpcHostUriBridge(output);
-	const subagentRegistry = eventBus ? new RpcSubagentRegistry(eventBus, output) : undefined;
+	const subagentRegistry = eventBus
+		? new RpcSubagentRegistry(eventBus, frame => output(boundedRpcSubagentFrame(frame)))
+		: undefined;
 
 	// Shutdown request flag (wrapped in object to allow mutation with const)
 	const shutdownState = { requested: false };

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -25,7 +25,7 @@ import {
 import { buildSkillPromptMessage, parseSkillInvocation } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { type Theme, theme } from "../../modes/theme/theme";
-import type { AgentSession } from "../../session/agent-session";
+import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, USER_INTERRUPT_LABEL } from "../../session/messages";
 import { executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { buildAvailableSlashCommands } from "../../slash-commands/available-commands";
@@ -92,6 +92,69 @@ type RpcOutput = (
 		| RpcHostUriCancelRequest
 		| object,
 ) => void;
+
+/** Leave 64 KiB of framing headroom below a one MiB JSONL reader limit. */
+export const RPC_AGENT_END_MAX_BYTES = 1024 * 1024 - 64 * 1024;
+
+const rpcTextEncoder = new TextEncoder();
+
+type RpcAgentEndStatus = "completed" | "failed" | "cancelled";
+
+function serializedJsonBytes(value: object): number | undefined {
+	try {
+		const encoded = JSON.stringify(value);
+		if (encoded === undefined) return undefined;
+		return rpcTextEncoder.encode(encoded).byteLength;
+	} catch {
+		return undefined;
+	}
+}
+
+function fitsRpcLine(value: object): boolean {
+	const bytes = serializedJsonBytes(value);
+	return bytes !== undefined && bytes <= RPC_AGENT_END_MAX_BYTES;
+}
+
+function rpcAgentEndStatus(messages: Extract<AgentSessionEvent, { type: "agent_end" }>["messages"]): RpcAgentEndStatus {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (!message || typeof message !== "object" || !("role" in message) || message.role !== "assistant") continue;
+		if ("stopReason" in message && message.stopReason === "error") return "failed";
+		if ("stopReason" in message && message.stopReason === "aborted") return "cancelled";
+		return "completed";
+	}
+	return "completed";
+}
+
+/**
+ * Keep terminal RPC events below common JSONL reader ceilings.
+ *
+ * `agent_end.messages` repeats messages already delivered by lifecycle events,
+ * so an oversized aggregate can retain the newest contiguous suffix while the
+ * terminal status and original count remain explicit.
+ */
+export function boundedRpcSessionEvent(event: AgentSessionEvent): AgentSessionEvent {
+	if (event.type !== "agent_end" || fitsRpcLine(event)) return event;
+
+	const terminal = {
+		messageCount: event.messages.length,
+		status: rpcAgentEndStatus(event.messages),
+	};
+	const emptyEvent = { ...event, messages: [], ...terminal };
+	const minimalEvent = { type: "agent_end" as const, messages: [], ...terminal };
+	const fallback = fitsRpcLine(emptyEvent) ? emptyEvent : minimalEvent;
+
+	let low = 0;
+	let high = event.messages.length;
+	while (low < high) {
+		const candidateLength = Math.ceil((low + high) / 2);
+		const candidate = { ...event, messages: event.messages.slice(-candidateLength), ...terminal };
+		if (fitsRpcLine(candidate)) low = candidateLength;
+		else high = candidateLength - 1;
+	}
+
+	return low === 0 ? fallback : { ...event, messages: event.messages.slice(-low), ...terminal };
+}
 
 export type RpcSessionChangeCommand = Extract<
 	RpcCommand,
@@ -904,7 +967,7 @@ export async function runRpcMode(
 
 	// Output all agent events as JSON
 	session.subscribe(event => {
-		output(event);
+		output(boundedRpcSessionEvent(event));
 	});
 
 	const getAvailableCommands = async () => buildAvailableSlashCommands(session);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -35,6 +35,8 @@ import { isRpcHostToolResult, isRpcHostToolUpdate, RpcHostToolBridge } from "./h
 import { isRpcHostUriResult, RpcHostUriBridge } from "./host-uris";
 import { RpcSubagentRegistry, readRpcSubagentTranscript } from "./rpc-subagents";
 import type {
+	RpcAgentEndStatus,
+	RpcAgentSessionEvent,
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
@@ -99,8 +101,6 @@ export const RPC_AGENT_END_MAX_BYTES = 1024 * 1024 - 64 * 1024;
 
 const rpcTextEncoder = new TextEncoder();
 
-type RpcAgentEndStatus = "completed" | "failed" | "cancelled";
-
 function serializedJsonBytes(value: object): number | undefined {
 	try {
 		const encoded = JSON.stringify(value);
@@ -134,7 +134,7 @@ function rpcAgentEndStatus(messages: Extract<AgentSessionEvent, { type: "agent_e
  * so an oversized aggregate can retain the newest contiguous suffix while the
  * terminal status and original count remain explicit.
  */
-export function boundedRpcSessionEvent(event: AgentSessionEvent): AgentSessionEvent {
+export function boundedRpcSessionEvent(event: AgentSessionEvent): RpcAgentSessionEvent {
 	if (event.type !== "agent_end" || fitsRpcLine(event)) return event;
 
 	const terminal = {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -4,7 +4,7 @@
  * Commands are sent as JSON lines on stdin.
  * Responses and events are emitted as JSON lines on stdout.
  */
-import type { AgentMessage, AgentToolResult, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { AgentEvent, AgentMessage, AgentToolResult, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type { Effort, ImageContent, Model, ToolExample } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
@@ -162,6 +162,24 @@ export interface RpcSubagentMessagesResult {
 	messages: AgentMessage[];
 }
 
+export type RpcAgentEndStatus = "completed" | "failed" | "cancelled";
+
+/** RPC terminal metadata is emitted as a pair only when an oversized aggregate is compacted. */
+export type RpcAgentEndEvent = Extract<AgentEvent, { type: "agent_end" }> &
+	(
+		| { messageCount?: never; status?: never }
+		| {
+				messageCount: number;
+				status: RpcAgentEndStatus;
+		  }
+	);
+
+/** Core agent events after applying the RPC terminal-frame bound. */
+export type RpcAgentEvent = Exclude<AgentEvent, { type: "agent_end" }> | RpcAgentEndEvent;
+
+/** Session events as emitted on the RPC wire. */
+export type RpcAgentSessionEvent = Exclude<AgentSessionEvent, { type: "agent_end" }> | RpcAgentEndEvent;
+
 // ============================================================================
 // RPC Responses (stdout)
 // ============================================================================
@@ -312,14 +330,16 @@ export interface RpcSubagentProgressFrame {
 	payload: SubagentProgressPayload;
 }
 
+export type RpcSubagentEventPayload = Omit<SubagentEventPayload, "event"> & { event: RpcAgentSessionEvent };
+
 export interface RpcSubagentEventFrame {
 	type: "subagent_event";
-	payload: SubagentEventPayload;
+	payload: RpcSubagentEventPayload;
 }
 
 export type RpcSubagentFrame = RpcSubagentLifecycleFrame | RpcSubagentProgressFrame | RpcSubagentEventFrame;
 
-export type RpcSessionEventFrame = AgentSessionEvent | RpcSubagentFrame;
+export type RpcSessionEventFrame = RpcAgentSessionEvent | RpcSubagentFrame;
 
 // ============================================================================
 // Extension UI Events (stdout)

--- a/packages/coding-agent/test/rpc-agent-end.test.ts
+++ b/packages/coding-agent/test/rpc-agent-end.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { boundedRpcSessionEvent, RPC_AGENT_END_MAX_BYTES } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+
+const encodedBytes = (value: object): number => new TextEncoder().encode(JSON.stringify(value)).byteLength;
+
+describe("RPC terminal event bounds", () => {
+	test("preserves ordinary agent_end events exactly", () => {
+		const event: Extract<AgentSessionEvent, { type: "agent_end" }> = {
+			type: "agent_end",
+			messages: [{ role: "user", content: "done", timestamp: 1 }],
+		};
+
+		expect(boundedRpcSessionEvent(event)).toBe(event);
+	});
+
+	test("keeps the newest message suffix when agent_end exceeds the line ceiling", () => {
+		const messages = Array.from({ length: 20 }, (_, index) => ({
+			role: "user" as const,
+			content: `${index}:${"x".repeat(60_000)}`,
+			timestamp: index,
+		}));
+		const event: Extract<AgentSessionEvent, { type: "agent_end" }> = { type: "agent_end", messages };
+		expect(encodedBytes(event)).toBeGreaterThan(1024 * 1024);
+
+		const bounded = boundedRpcSessionEvent(event);
+		expect(bounded.type).toBe("agent_end");
+		if (bounded.type !== "agent_end") throw new Error("expected agent_end");
+		const terminal = bounded as unknown as Record<string, unknown>;
+		expect(encodedBytes(bounded)).toBeLessThanOrEqual(RPC_AGENT_END_MAX_BYTES);
+		expect(bounded.messages.length).toBeGreaterThan(0);
+		expect(bounded.messages.length).toBeLessThan(messages.length);
+		expect(bounded.messages.at(-1)).toEqual(messages.at(-1));
+		expect(terminal.messageCount).toBe(messages.length);
+		expect(terminal.status).toBe("completed");
+		expect(event.messages).toHaveLength(20);
+	});
+
+	test("counts multibyte content by encoded bytes", () => {
+		const messages = Array.from({ length: 8 }, (_, index) => ({
+			role: "user" as const,
+			content: `${index}:${"🦀".repeat(40_000)}`,
+			timestamp: index,
+		}));
+		const event: Extract<AgentSessionEvent, { type: "agent_end" }> = { type: "agent_end", messages };
+		expect(JSON.stringify(event).length).toBeLessThan(RPC_AGENT_END_MAX_BYTES);
+		expect(encodedBytes(event)).toBeGreaterThan(RPC_AGENT_END_MAX_BYTES);
+
+		const bounded = boundedRpcSessionEvent(event);
+		expect(encodedBytes(bounded)).toBeLessThanOrEqual(RPC_AGENT_END_MAX_BYTES);
+		if (bounded.type !== "agent_end") throw new Error("expected agent_end");
+		expect(bounded.messages.at(-1)).toEqual(messages.at(-1));
+	});
+
+	test("preserves failure metadata when the final assistant message cannot fit", () => {
+		const event = {
+			type: "agent_end",
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "x".repeat(1_000_000) }],
+					stopReason: "error",
+					timestamp: 1,
+				},
+			],
+		} as unknown as Extract<AgentSessionEvent, { type: "agent_end" }>;
+
+		const bounded = boundedRpcSessionEvent(event);
+		expect(bounded.type).toBe("agent_end");
+		if (bounded.type !== "agent_end") throw new Error("expected agent_end");
+		const terminal = bounded as unknown as Record<string, unknown>;
+		expect(encodedBytes(bounded)).toBeLessThanOrEqual(RPC_AGENT_END_MAX_BYTES);
+		expect(bounded.messages).toEqual([]);
+		expect(terminal.messageCount).toBe(1);
+		expect(terminal.status).toBe("failed");
+	});
+});

--- a/packages/coding-agent/test/rpc-agent-end.test.ts
+++ b/packages/coding-agent/test/rpc-agent-end.test.ts
@@ -30,13 +30,12 @@ describe("RPC terminal event bounds", () => {
 		const bounded = boundedRpcSessionEvent(event);
 		expect(bounded.type).toBe("agent_end");
 		if (bounded.type !== "agent_end") throw new Error("expected agent_end");
-		const terminal = bounded as unknown as Record<string, unknown>;
 		expect(encodedBytes(bounded)).toBeLessThanOrEqual(RPC_AGENT_END_MAX_BYTES);
 		expect(bounded.messages.length).toBeGreaterThan(0);
 		expect(bounded.messages.length).toBeLessThan(messages.length);
 		expect(bounded.messages.at(-1)).toEqual(messages.at(-1));
-		expect(terminal.messageCount).toBe(messages.length);
-		expect(terminal.status).toBe("completed");
+		expect(bounded.messageCount).toBe(messages.length);
+		expect(bounded.status).toBe("completed");
 		expect(event.messages).toHaveLength(20);
 	});
 
@@ -72,11 +71,32 @@ describe("RPC terminal event bounds", () => {
 		const bounded = boundedRpcSessionEvent(event);
 		expect(bounded.type).toBe("agent_end");
 		if (bounded.type !== "agent_end") throw new Error("expected agent_end");
-		const terminal = bounded as unknown as Record<string, unknown>;
 		expect(encodedBytes(bounded)).toBeLessThanOrEqual(RPC_AGENT_END_MAX_BYTES);
 		expect(bounded.messages).toEqual([]);
-		expect(terminal.messageCount).toBe(1);
-		expect(terminal.status).toBe("failed");
+		expect(bounded.messageCount).toBe(1);
+		expect(bounded.status).toBe("failed");
+	});
+
+	test("preserves cancellation metadata when an oversized assistant response was aborted", () => {
+		const event = {
+			type: "agent_end",
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "x".repeat(1_000_000) }],
+					stopReason: "aborted",
+					timestamp: 1,
+				},
+			],
+		} as unknown as Extract<AgentSessionEvent, { type: "agent_end" }>;
+
+		const bounded = boundedRpcSessionEvent(event);
+		expect(bounded.type).toBe("agent_end");
+		if (bounded.type !== "agent_end") throw new Error("expected agent_end");
+		expect(encodedBytes(bounded)).toBeLessThanOrEqual(RPC_AGENT_END_MAX_BYTES);
+		expect(bounded.messages).toEqual([]);
+		expect(bounded.messageCount).toBe(1);
+		expect(bounded.status).toBe("cancelled");
 	});
 
 	test("bounds agent_end events nested in streamed subagent frames", () => {
@@ -101,5 +121,7 @@ describe("RPC terminal event bounds", () => {
 		}
 		expect(bounded.payload.event.messages.length).toBeLessThan(messages.length);
 		expect(bounded.payload.event.messages.at(-1)).toEqual(messages.at(-1));
+		expect(bounded.payload.event.messageCount).toBe(messages.length);
+		expect(bounded.payload.event.status).toBe("completed");
 	});
 });

--- a/packages/coding-agent/test/rpc-agent-end.test.ts
+++ b/packages/coding-agent/test/rpc-agent-end.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { boundedRpcSessionEvent, RPC_AGENT_END_MAX_BYTES } from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
+import {
+	boundedRpcSessionEvent,
+	boundedRpcSubagentFrame,
+	RPC_AGENT_END_MAX_BYTES,
+} from "@oh-my-pi/pi-coding-agent/modes/rpc/rpc-mode";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 
 const encodedBytes = (value: object): number => new TextEncoder().encode(JSON.stringify(value)).byteLength;
@@ -73,5 +77,29 @@ describe("RPC terminal event bounds", () => {
 		expect(bounded.messages).toEqual([]);
 		expect(terminal.messageCount).toBe(1);
 		expect(terminal.status).toBe("failed");
+	});
+
+	test("bounds agent_end events nested in streamed subagent frames", () => {
+		const messages = Array.from({ length: 20 }, (_, index) => ({
+			role: "user" as const,
+			content: `${index}:${"x".repeat(60_000)}`,
+			timestamp: index,
+		}));
+		const frame = {
+			type: "subagent_event" as const,
+			payload: {
+				id: "subagent-1",
+				event: { type: "agent_end" as const, messages },
+			},
+		};
+
+		const bounded = boundedRpcSubagentFrame(frame);
+		expect(encodedBytes(bounded)).toBeLessThan(1024 * 1024);
+		expect(bounded.type).toBe("subagent_event");
+		if (bounded.type !== "subagent_event" || bounded.payload.event.type !== "agent_end") {
+			throw new Error("expected nested agent_end");
+		}
+		expect(bounded.payload.event.messages.length).toBeLessThan(messages.length);
+		expect(bounded.payload.event.messages.at(-1)).toEqual(messages.at(-1));
 	});
 });


### PR DESCRIPTION
## Repro

A long `omp --mode rpc` turn can emit an `agent_end` JSONL frame above one MiB. The terminal event repeats the turn messages after their lifecycle events have already streamed. A host with a bounded line reader rejects that final frame and loses the explicit turn-completion signal.

## Cause

RPC forwards every `AgentSessionEvent` directly to stdout. `agent_end.messages` grows with the turn and has no byte bound.

## Fix

- Leave ordinary RPC events unchanged.
- Keep terminal frames below 960 KiB, leaving 64 KiB of framing headroom under a one MiB reader limit.
- Retain the newest contiguous message suffix that fits.
- Include the original `messageCount` and terminal `status` when compaction occurs.
- Count UTF-8 bytes rather than JavaScript string length.
- Document the terminal-frame contract.

This is the small RPC hardening slice found while validating the persistent client work in #5405. It is useful independently of the proposed appserver.

## Testing

- `bun test packages/coding-agent/test/rpc-agent-end.test.ts packages/coding-agent/test/rpc-prompt-result.test.ts` — 15 passed
- `bun check`

Refs #5405
