### PR TITLE
fix(tui): preserve drafts on skill autocomplete

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Enter accepting a mid-prompt `/skill:<name>` autocomplete from submitting and clearing the draft; acceptance now inserts the skill token and leaves the prompt open ([#4773](https://github.com/can1357/oh-my-pi/issues/4773)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -421,7 +421,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 						// Preserve the full text-before-cursor for submitted slash
 						// commands so the editor's Enter-staleness check still applies
 						// completion for `  /sk`. Mid-prompt skill lookup keeps only
-						// the slash token because accepting it replaces the whole draft.
+						// the slash token because acceptance replaces only that token.
 						prefix: isMidPromptSkillLookup ? commandText : textBeforeCursor,
 					};
 				}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1159,11 +1159,12 @@ export class Editor implements Component, Focusable {
 					return;
 				}
 
-				// If Enter was pressed on a slash command (not an absolute-path
-				// completion sharing the leading-slash prefix), apply and submit
+				// If Enter was pressed on a submitted slash command (not an absolute-path
+				// completion sharing the leading-slash prefix), apply and submit.
 				if (
 					(kb.matches(data, "tui.input.submit") || data === "\n") &&
 					findLeadingSlashCommandStart(this.#autocompletePrefix) !== null &&
+					this.#isInSubmittedSlashCommandContext() &&
 					!this.#selectedCompletionIsPath()
 				) {
 					// Check for stale autocomplete state due to debounce
@@ -1192,7 +1193,7 @@ export class Editor implements Component, Focusable {
 					}
 					// Don't return - fall through to submission logic
 				}
-				// If Enter was pressed on a file path, apply completion
+				// Otherwise, apply the completion without submitting the surrounding draft.
 				else if (kb.matches(data, "tui.input.submit") || data === "\n") {
 					// Check for stale autocomplete state due to buffer edits since last refresh.
 					const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2876,12 +2876,12 @@ export class Editor implements Component, Focusable {
 	 * - Exact match → always safe.
 	 * - Path branch is safe when the prefix is still a live suffix of the text; the
 	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
-	 * - Slash branch re-anchors when both the prefix and the current text carry a
-	 *   leading slash command and the current slash token is clean (no whitespace or
-	 *   inner slash), matching `applyCompletion`'s slash-branch guard. It only
-	 *   engages for command-shaped selections: absolute-path completions (`/tmp/fo`
-	 *   via the no-command-match fall-through) share the leading-slash prefix shape
-	 *   but must use the live-suffix path rule so the apply slice stays anchored.
+	 * - Slash branch re-anchors when the prefix is command-shaped and the current
+	 *   text carries either a leading submitted command or a trailing mid-prompt
+	 *   slash token. The live token must remain clean (no whitespace or inner slash),
+	 *   matching `applyCompletion`'s slash-branch guard. Absolute-path completions
+	 *   (`/tmp/fo` via the no-command-match fall-through) share the leading-slash
+	 *   prefix shape but use the live-suffix path rule instead.
 	 * - `@`-file branch re-anchors via `#extractAtPrefix`; safe when the current text
 	 *   still ends in a whitespace-anchored `@<token>`.
 	 * - Everything else is stale — accepting it would corrupt the buffer (issue #4295).
@@ -2890,9 +2890,11 @@ export class Editor implements Component, Focusable {
 		if (currentTextBeforeCursor === this.#autocompletePrefix) return true;
 
 		if (findLeadingSlashCommandStart(this.#autocompletePrefix) !== null && !this.#selectedCompletionIsPath()) {
-			const currentLeadingStart = findLeadingSlashCommandStart(currentTextBeforeCursor);
-			if (currentLeadingStart !== null) {
-				const token = currentTextBeforeCursor.slice(currentLeadingStart);
+			const currentSlashStart =
+				findLeadingSlashCommandStart(currentTextBeforeCursor) ??
+				findTrailingSlashCommandStart(currentTextBeforeCursor);
+			if (currentSlashStart !== null) {
+				const token = currentTextBeforeCursor.slice(currentSlashStart);
 				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;
 			}
 			return false;

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2877,11 +2877,11 @@ export class Editor implements Component, Focusable {
 	 * - Path branch is safe when the prefix is still a live suffix of the text; the
 	 *   provider's default slice at `cursorCol - prefix.length` then hits the right span.
 	 * - Slash branch re-anchors when the prefix is command-shaped and the current
-	 *   text carries either a leading submitted command or a trailing mid-prompt
-	 *   slash token. The live token must remain clean (no whitespace or inner slash),
-	 *   matching `applyCompletion`'s slash-branch guard. Absolute-path completions
-	 *   (`/tmp/fo` via the no-command-match fall-through) share the leading-slash
-	 *   prefix shape but use the live-suffix path rule instead.
+	 *   text carries either a leading submitted command or, for a selected skill,
+	 *   a trailing mid-prompt slash token. The live token must remain clean (no
+	 *   whitespace or inner slash), matching `applyCompletion`'s slash-branch guard.
+	 *   Absolute-path completions (`/tmp/fo` via the no-command-match fall-through)
+	 *   share the leading-slash prefix shape but use the live-suffix path rule instead.
 	 * - `@`-file branch re-anchors via `#extractAtPrefix`; safe when the current text
 	 *   still ends in a whitespace-anchored `@<token>`.
 	 * - Everything else is stale — accepting it would corrupt the buffer (issue #4295).
@@ -2890,9 +2890,11 @@ export class Editor implements Component, Focusable {
 		if (currentTextBeforeCursor === this.#autocompletePrefix) return true;
 
 		if (findLeadingSlashCommandStart(this.#autocompletePrefix) !== null && !this.#selectedCompletionIsPath()) {
-			const currentSlashStart =
-				findLeadingSlashCommandStart(currentTextBeforeCursor) ??
-				findTrailingSlashCommandStart(currentTextBeforeCursor);
+			const selected = this.#autocompleteList?.getSelectedItem();
+			const currentTrailingStart = selected?.value.startsWith("skill:")
+				? findTrailingSlashCommandStart(currentTextBeforeCursor)
+				: null;
+			const currentSlashStart = findLeadingSlashCommandStart(currentTextBeforeCursor) ?? currentTrailingStart;
 			if (currentSlashStart !== null) {
 				const token = currentTextBeforeCursor.slice(currentSlashStart);
 				if (!token.includes(" ") && !token.slice(1).includes("/")) return true;

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -232,6 +232,35 @@ describe("Editor Enter handler sync slash completion", () => {
 		expect(editor.getText()).toBe("explain this\n/skill:security-scan ");
 	});
 
+	it("inserts a mid-prompt skill token without submitting on Enter", async () => {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider(
+				[
+					{ name: "skill:security-scan", description: "Security scan" },
+					{ name: "model", description: "Switch model" },
+				],
+				"/tmp",
+			),
+		);
+		let submitted: string | undefined;
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.setText("explain this\n");
+		editor.handleInput("/");
+		await Promise.resolve();
+
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("security");
+		editor.handleInput("\r");
+
+		expect(editor.getText()).toBe("explain this\n/skill:security-scan ");
+		expect(submitted).toBeUndefined();
+	});
+
 	it("preserves Tab file completion for an absolute path token after prose", async () => {
 		let forceFileCalls = 0;
 		const editor = new Editor(defaultEditorTheme);

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -248,7 +248,7 @@ describe("Editor Enter handler sync slash completion", () => {
 			submitted = text;
 		};
 
-		editor.setText("explain this\n");
+		editor.setText("fix bug ");
 		editor.handleInput("/");
 		await Promise.resolve();
 
@@ -257,7 +257,7 @@ describe("Editor Enter handler sync slash completion", () => {
 		editor.handleInput("security");
 		editor.handleInput("\r");
 
-		expect(editor.getText()).toBe("explain this\n/skill:security-scan ");
+		expect(editor.getText()).toBe("fix bug /skill:security-scan ");
 		expect(submitted).toBeUndefined();
 	});
 

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -205,6 +205,28 @@ class SyncSlashProvider implements AutocompleteProvider {
 }
 
 describe("Editor Enter handler sync slash completion", () => {
+	async function createRelocatedModelPopup() {
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(
+			new CombinedAutocompleteProvider([{ name: "model", description: "Switch AI model" }], "/tmp"),
+		);
+		const submissions: string[] = [];
+		editor.onSubmit = text => {
+			submissions.push(text);
+		};
+
+		editor.handleInput("/mo");
+		await Promise.resolve();
+		expect(editor.isShowingAutocomplete()).toBe(true);
+
+		editor.handleInput("\x01"); // Ctrl+A: move before the command.
+		editor.handleInput("fix ");
+		editor.handleInput("\x05"); // Ctrl+E: return to the stale command prefix.
+		expect(editor.getText()).toBe("fix /mo");
+
+		return { editor, submissions };
+	}
+
 	it("opens mid-prompt skill autocomplete and inserts the skill token without wiping the draft on Tab", async () => {
 		const editor = new Editor(defaultEditorTheme);
 		editor.setAutocompleteProvider(
@@ -259,6 +281,24 @@ describe("Editor Enter handler sync slash completion", () => {
 
 		expect(editor.getText()).toBe("fix bug /skill:security-scan ");
 		expect(submitted).toBeUndefined();
+	});
+
+	it("submits the raw draft when Enter sees a relocated non-skill popup", async () => {
+		const { editor, submissions } = await createRelocatedModelPopup();
+
+		editor.handleInput("\r");
+
+		expect(submissions).toEqual(["fix /mo"]);
+		expect(editor.getText()).toBe("");
+	});
+
+	it("leaves the raw draft when Tab sees a relocated non-skill popup", async () => {
+		const { editor, submissions } = await createRelocatedModelPopup();
+
+		editor.handleInput("\t");
+
+		expect(submissions).toEqual([]);
+		expect(editor.getText()).toBe("fix /mo");
 	});
 
 	it("preserves Tab file completion for an absolute path token after prose", async () => {


### PR DESCRIPTION
## Repro
Compose a draft with preceding prose, type a partial mid-prompt `/skill:` invocation, then press Enter while its autocomplete popup is open. Before the fix, `bun test packages/tui/test/editor-autocomplete-actions.test.ts` failed because Enter submitted and cleared the editor: the completed draft was expected, but `editor.getText()` returned `""`.

## Cause
`Editor.handleInput()` in `packages/tui/src/components/editor.ts` treated every selected completion whose prefix looked like a slash command as a submitted slash command. Mid-prompt skill prefixes have the same leading-slash shape, so their Enter acceptance applied the token and then fell through to `#submitValue()` instead of remaining in the composer.

## Fix
- Gate the slash-command apply-and-submit branch with `#isInSubmittedSlashCommandContext()`.
- Route mid-prompt skill completion through the existing apply-without-submit branch, preserving surrounding draft text.
- Add an Enter-specific regression test and document the fix in the TUI changelog.

## Verification
`bun test packages/tui/test/editor-autocomplete-actions.test.ts` passes with 21 tests. `bun test packages/tui/test` passes with 1,180 tests and 3 skips. The pre-publish `bun run fix` and `bun check` gate passed. Fixes #4773