### PR TITLE
fix(editor): accept upstream-pi editor constructor in CustomEditor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed omp crashing at startup (`TypeError: undefined is not an object (evaluating 'this.#theme.symbols.boxRound')`) after installing a plugin whose custom editor subclasses `CustomEditor`/`Editor` and forwards the upstream-pi `super(tui, theme, keybindings)` constructor — the arg order that `setEditorComponent`'s factory contract advertises. `CustomEditor` now resolves the real `EditorTheme` by shape rather than position and captures a leading `TUI` for plugin overrides ([#4766](https://github.com/can1357/oh-my-pi/issues/4766)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/custom-editor-plugin-ctor.test.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor-plugin-ctor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { ProcessTerminal, TUI } from "@oh-my-pi/pi-tui";
+import { getEditorTheme, initTheme } from "../theme/theme";
+import { CustomEditor } from "./custom-editor";
+
+/**
+ * Regression for issue #4766: plugins written against upstream pi subclass
+ * `CustomEditor`/`Editor` and forward `super(tui, theme, keybindings)`. omp's
+ * `setEditorComponent` factory contract advertises exactly that arg order, so
+ * the base constructor must resolve the real theme by shape (not position) or
+ * every render throws `undefined is not an object (evaluating
+ * 'this.#theme.symbols.boxRound')`.
+ */
+describe("CustomEditor upstream-pi constructor compatibility (#4766)", () => {
+	it("renders when constructed as (tui, theme, keybindings)", async () => {
+		await initTheme();
+		const tui = new TUI(new ProcessTerminal());
+		const editor = new CustomEditor(tui, getEditorTheme(), {});
+		editor.setText("run this workflow");
+		expect(() => editor.render(80)).not.toThrow();
+		// The rounded border glyphs from the resolved theme must reach the frame.
+		const frame = editor.render(80).join("\n");
+		expect(frame).toContain(getEditorTheme().symbols.boxRound.horizontal);
+		// The leading TUI is captured so plugin overrides calling
+		// `this.tui.requestRender()` keep working.
+		expect(editor.tui).toBe(tui);
+	});
+
+	it("still accepts omp's own (theme) constructor", async () => {
+		await initTheme();
+		const editor = new CustomEditor(getEditorTheme());
+		editor.setText("hello");
+		expect(() => editor.render(80)).not.toThrow();
+		expect(editor.tui).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,6 +1,15 @@
 import { fileURLToPath } from "node:url";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
-import { addKeyAliases, canonicalKeyId, Editor, type KeyId, parseKey, parseKittySequence } from "@oh-my-pi/pi-tui";
+import {
+	addKeyAliases,
+	canonicalKeyId,
+	Editor,
+	type EditorTheme,
+	type KeyId,
+	parseKey,
+	parseKittySequence,
+	TUI,
+} from "@oh-my-pi/pi-tui";
 import { BracketedPasteHandler } from "@oh-my-pi/pi-tui/bracketed-paste";
 import type { AppKeybinding } from "../../config/keybindings";
 import { isSettingsInitialized, settings } from "../../config/settings";
@@ -284,6 +293,31 @@ export function extractImagePathFromText(text: string): string | undefined {
 }
 
 /**
+ * Resolve the {@link EditorTheme} from a `CustomEditor`/`Editor` constructor
+ * argument list, tolerating both the omp `(theme)` and upstream-pi
+ * `(tui, theme, keybindings)` conventions (see {@link CustomEditor}'s
+ * constructor). A real `EditorTheme` is identified structurally — it exposes a
+ * `borderColor` function and a `symbols` object — so a `TUI` passed in the first
+ * slot is skipped rather than mistaken for the theme.
+ */
+function pickEditorTheme(args: readonly unknown[]): EditorTheme {
+	for (const arg of args) {
+		if (isEditorTheme(arg)) return arg;
+	}
+	// Fall back to the first argument so a caller passing a bare theme that
+	// somehow fails the shape probe still reaches the base constructor.
+	return args[0] as EditorTheme;
+}
+
+function isEditorTheme(value: unknown): value is EditorTheme {
+	if (typeof value !== "object" || value === null) return false;
+	const candidate = value as Partial<EditorTheme>;
+	return (
+		typeof candidate.borderColor === "function" && typeof candidate.symbols === "object" && candidate.symbols !== null
+	);
+}
+
+/**
  * Custom editor that handles configurable app-level shortcuts for coding-agent.
  */
 export class CustomEditor extends Editor {
@@ -295,6 +329,33 @@ export class CustomEditor extends Editor {
 	/** Per-image source links (file:// targets) parallel to {@link pendingImages};
 	 *  `undefined` entries are images without a backing reference yet. */
 	pendingImageLinks: (string | undefined)[] = [];
+
+	/**
+	 * The host {@link TUI}, captured when a plugin constructs this editor through
+	 * the upstream-pi `(tui, theme, keybindings)` convention. Undefined for omp's
+	 * own `new CustomEditor(theme)` callers (they drive repaints through the
+	 * interactive-mode wiring instead). Plugins that call `this.tui.requestRender()`
+	 * in their overrides read it here (issue #4766).
+	 */
+	tui?: TUI;
+
+	/**
+	 * Accept both the omp constructor convention — `new CustomEditor(theme)` —
+	 * and the upstream-pi `Editor` convention — `new Editor(tui, theme, keybindings)`
+	 * — that {@link ExtensionUIContext.setEditorComponent}'s factory contract
+	 * advertises `(tui, theme, keybindings)`. Plugins written against upstream pi
+	 * subclass `CustomEditor`/`Editor` and forward `super(tui, theme, keybindings)`;
+	 * without this shim the `TUI` lands in the `theme` slot and every render throws
+	 * `undefined is not an object (evaluating 'this.#theme.symbols.boxRound')`
+	 * (issue #4766). We locate the real {@link EditorTheme} among the args by shape
+	 * (it carries `symbols`/`borderColor`) rather than by position, and capture a
+	 * leading {@link TUI} so plugin overrides calling `this.tui.requestRender()`
+	 * keep working.
+	 */
+	constructor(...args: readonly unknown[]) {
+		super(pickEditorTheme(args));
+		if (args[0] instanceof TUI) this.tui = args[0];
+	}
 
 	/** Clear the composer draft: optionally commit `historyText` to history, then
 	 *  reset the editor text and all pending draft-image state. The shared tail of


### PR DESCRIPTION
## Repro
Installing a plugin whose custom editor subclasses `CustomEditor`/`Editor` and forwards `super(tui, theme, keybindings)` (the upstream-pi `Editor(tui, theme, ...)` argument order) crashes omp at the first render:

```
[Uncaught Exception] TypeError: undefined is not an object (evaluating 'this.#theme.symbols.boxRound')
    at render (…/omp)
    at render (…/@quintinshaw/pi-dynamic-workflows/src/workflow-editor.ts:232)
```

Reported against `omp install npm:@quintinshaw/pi-dynamic-workflows` then launching `omp`. Reproduced in-repo by constructing `CustomEditor(tui, theme, {})` the way the plugin does — `bun test src/modes/components/custom-editor-plugin-ctor.test.ts` fails on the same `boxRound` TypeError before the fix.

## Cause
`ExtensionUIContext.setEditorComponent`'s factory contract advertises `(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => CustomEditor` (`src/extensibility/extensions/types.ts`, `src/modes/interactive-mode.ts` invokes `factory(this.ui, getEditorTheme(), this.keybindings)`). But omp's base `Editor` constructor in `packages/tui/src/components/editor.ts` is `constructor(theme)`, and `CustomEditor` declared no constructor. A plugin forwarding `super(tui, theme, keybindings)` therefore put the `TUI` into the `theme` slot, so `this.#theme = tui` and `Editor.render()` dereferenced `this.#theme.symbols.boxRound` on the TUI, which is `undefined`.

## Fix
- `CustomEditor` (`src/modes/components/custom-editor.ts`) now takes a variadic constructor and forwards the real `EditorTheme` to `super()`, resolved by shape (`borderColor` fn + `symbols` object) via the new `pickEditorTheme`/`isEditorTheme` helpers — so a leading `TUI` is skipped instead of mistaken for the theme. Both the omp `(theme)` and upstream-pi `(tui, theme, keybindings)` orders work.
- Captures a leading `TUI` into `this.tui` so plugin overrides that call `this.tui.requestRender()` (as `pi-dynamic-workflows` does in `handleInput`/animation) keep working; `undefined` for omp's own `new CustomEditor(theme)` callers.
- Adds a regression test asserting both constructor orders render without throwing and that the rounded border glyph reaches the frame.

## Verification
`bun test src/modes/components/custom-editor.test.ts src/modes/controllers/extension-ui-controller.test.ts src/modes/components/custom-editor-plugin-ctor.test.ts` → 29 pass, 0 fail. `bun check` clean (biome + docs index + tsgo). Fixes #4766