### PR TITLE
fix(ai): classify Anthropic spend-limit as persistent usage limit

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic account quota exhaustion (`This request would exceed your account's monthly spend limit`) hanging until the local deadline instead of surfacing the error: the `rate_limit_error` "spend limit" wording is now classified as a persistent usage limit, so it fails fast and rotates to a sibling credential rather than looping in the provider retry backoff. ([#4787](https://github.com/can1357/oh-my-pi/issues/4787))
+
 ## [16.3.11] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -100,7 +100,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?(?:exceeded|reached|insufficient)|额度不足|额度耗尽|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?(?:balance|quota)/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?(?:exceeded|reached|insufficient)|额度不足|额度耗尽|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?(?:balance|quota)|spend.?limit/i;
 
 /**
  * HTTP status codes that, absent richer body classification, represent an

--- a/packages/ai/test/anthropic-retry.test.ts
+++ b/packages/ai/test/anthropic-retry.test.ts
@@ -83,6 +83,16 @@ describe("isProviderRetryableError", () => {
 		).toBe(false);
 		expect(isProviderRetryableError(new Error("usage_limit_reached"))).toBe(false);
 		expect(isProviderRetryableError(new Error("You have hit your ChatGPT usage limit"))).toBe(false);
+		// Anthropic monthly spend-cap 429 (issue #4787): must not retry, or the
+		// provider loop burns its budget on minutes-long retry-after backoff and
+		// surfaces "Deadline exceeded" instead of the quota error.
+		expect(
+			isProviderRetryableError(
+				new Error(
+					'429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account\'s monthly spend limit. Please try again later."}}',
+				),
+			),
+		).toBe(false);
 		// A generic transient rate limit (no account/usage framing) still retries.
 		expect(isProviderRetryableError(new Error("Rate limit exceeded"))).toBe(true);
 	});

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -120,6 +120,19 @@ describe("isUsageLimit", () => {
 		).toBe(true);
 	});
 
+	// Anthropic returns a `rate_limit_error` when the account's monthly spend
+	// cap is hit ("This request would exceed your account's monthly spend
+	// limit."). Without the `spend limit` branch the message classifies as a
+	// transient rate limit, so `isProviderRetryableError` retries it until the
+	// local deadline instead of surfacing the quota error (issue #4787).
+	it("detects Anthropic monthly spend-limit as a credential-rotatable usage limit", () => {
+		expect(
+			isUsageLimit(
+				'429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account\'s monthly spend limit. Please try again later."}}',
+			),
+		).toBe(true);
+	});
+
 	it("detects bare 'quota reached' phrasing", () => {
 		expect(isUsageLimit("quota reached")).toBe(true);
 		expect(isUsageLimit("quota_reached")).toBe(true);


### PR DESCRIPTION
## Repro
On an Anthropic account whose monthly spend cap is exhausted, `omp` hangs until its local deadline and exits `Deadline exceeded` with zero tokens, instead of surfacing the Anthropic error. A direct `curl` with the same token returns an immediate `rate_limit_error`: `This request would exceed your account's monthly spend limit. Please try again later.` Reported with `omp --model anthropic/claude-opus-4-8 -p --max-time=20 --no-tools --no-skills --no-rules --no-extensions --no-title --no-session "Reply with exactly OK."`.

## Cause
The Anthropic quota response is a `rate_limit_error` whose message contains "spend limit". In `packages/ai/src/error`, `USAGE_LIMIT_PATTERN` (`rate-limit.ts`) had no `spend limit` alternative and `ACCOUNT_RATE_LIMIT_PATTERN` requires the literal "rate limit" near "account", so `matchesUsageLimitText`, `isUsageLimitOutcome`, and `parseRateLimitReason` all missed it. Consequently `isProviderRetryableError` (`retryable.ts`) fell through to `TRANSIENT_TRANSPORT_PATTERN`, which matches `rate_limit_error`/`rate.?limit` in the wire body, and returned `true`. `streamAnthropicOnce` (`anthropic.ts`, `PROVIDER_MAX_RETRIES = 10`) then retried the request, honoring the server's minutes-long `retry-after`, until the agent-loop deadline (`agent-loop.ts`) aborted with `Deadline exceeded`.

## Fix
- Add a `spend.?limit` alternative to `USAGE_LIMIT_PATTERN` in `packages/ai/src/error/rate-limit.ts`. This flips the message to a persistent usage-limit classification across both classifiers that key off `matchesUsageLimitText`: `isProviderRetryableError` now returns `false` (surfaces immediately), and `isUsageLimitOutcome` returns `true` (credential-rotation layer rotates to a sibling account when one exists).
- Regression tests in `rate-limit-utils.test.ts` (`isUsageLimit` matches the spend-limit wire message) and `anthropic-retry.test.ts` (`isProviderRetryableError` does not retry it).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/anthropic-retry.test.ts test/rate-limit-utils.test.ts` → 38 pass, 0 fail. Full `packages/ai` suite: 2689 pass, 1 fail — the one failure (`getProxyForProvider > normalizes hyphenated provider ids to underscores`) is a pre-existing `Bun.env` test-pollution issue unrelated to this diff (passes in isolation; this change touches only `rate-limit.ts` and two test files, none touching proxy/env). Fixes #4787.