### PR TITLE
fix(acp): await teardown on stdio disconnect

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed ACP stdio EOF/EPIPE disconnects bypassing awaited session teardown and leaving in-flight tool calls pending in persisted rollouts ([#4788](https://github.com/can1357/oh-my-pi/issues/4788)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -42,7 +42,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
-import { getBlobsDir, isEnoent, logger, VERSION } from "@oh-my-pi/pi-utils";
+import { getBlobsDir, isEnoent, logger, type postmortem, VERSION } from "@oh-my-pi/pi-utils";
 import { disableProvider, enableProvider, reset as resetCapabilities } from "../../capability";
 import { Settings } from "../../config/settings";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
@@ -1006,7 +1006,7 @@ export class AcpAgent implements Agent {
 		this.#connection.signal.addEventListener(
 			"abort",
 			() => {
-				void this.#disposeAllSessions();
+				void this.dispose();
 			},
 			{ once: true },
 		);
@@ -2316,7 +2316,7 @@ export class AcpAgent implements Agent {
 		}
 	}
 
-	async #disposeSessionRecord(record: ManagedSessionRecord): Promise<void> {
+	async #disposeSessionRecord(record: ManagedSessionRecord, reason?: postmortem.Reason): Promise<void> {
 		record.lifetimeUnsubscribe?.();
 		if (record.mcpManager) {
 			try {
@@ -2327,21 +2327,22 @@ export class AcpAgent implements Agent {
 			record.mcpManager = undefined;
 		}
 		try {
-			await record.session.dispose();
+			await record.session.dispose({ reason });
 		} catch (error) {
 			logger.warn("Failed to dispose ACP session", { error });
 		}
 	}
 
-	async #disposeStandaloneSession(session: AgentSession): Promise<void> {
+	async #disposeStandaloneSession(session: AgentSession, reason?: postmortem.Reason): Promise<void> {
 		try {
-			await session.dispose();
+			await session.dispose({ reason });
 		} catch (error) {
 			logger.warn("Failed to dispose ACP session", { error });
 		}
 	}
 
-	async #disposeAllSessions(): Promise<void> {
+	/** Dispose every session owned by this ACP connection and await persisted teardown. */
+	async dispose(reason?: postmortem.Reason): Promise<void> {
 		if (this.#disposePromise) {
 			await this.#disposePromise;
 			return;
@@ -2357,7 +2358,7 @@ export class AcpAgent implements Agent {
 							"ACP agent disposed before queued prompt could run",
 						);
 						await this.#cancelPromptForClose(record);
-						await this.#disposeSessionRecord(record);
+						await this.#disposeSessionRecord(record, reason);
 					} catch (error) {
 						logger.warn("Failed to clean up ACP session", { sessionId, error });
 					}
@@ -2367,7 +2368,7 @@ export class AcpAgent implements Agent {
 			const initialSession = this.#initialSession;
 			this.#initialSession = undefined;
 			if (initialSession) {
-				await this.#disposeStandaloneSession(initialSession);
+				await this.#disposeStandaloneSession(initialSession, reason);
 			}
 		})();
 

--- a/packages/coding-agent/src/modes/acp/acp-mode.ts
+++ b/packages/coding-agent/src/modes/acp/acp-mode.ts
@@ -1,23 +1,38 @@
 import * as stream from "node:stream";
 import { AgentSideConnection, ndJsonStream, type Stream } from "@agentclientprotocol/sdk";
+import { postmortem } from "@oh-my-pi/pi-utils";
 import type { AgentSession } from "../../session/agent-session";
 import { AcpAgent } from "./acp-agent";
 
+/** Creates sessions requested by an ACP client. */
 export type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
 
+/** Creates an ACP connection and exposes its agent when process-level teardown must own it. */
 export function createAcpConnection(
 	transport: Stream,
 	createSession: AcpSessionFactory,
 	initialSession?: AgentSession,
+	onAgent?: (agent: AcpAgent) => void,
 ): AgentSideConnection {
-	return new AgentSideConnection(conn => new AcpAgent(conn, createSession, initialSession), transport);
+	return new AgentSideConnection(connection => {
+		const agent = new AcpAgent(connection, createSession, initialSession);
+		onAgent?.(agent);
+		return agent;
+	}, transport);
 }
 
-export async function runAcpMode(createSession: AcpSessionFactory, initialSession?: AgentSession): Promise<never> {
+/** Serves ACP over stdio until the peer disconnects, then awaits session teardown before exit. */
+export async function runAcpMode(createSession: AcpSessionFactory, initialSession?: AgentSession): Promise<void> {
+	let agent: AcpAgent | undefined;
+	postmortem.register("acp-session-teardown", reason => agent?.dispose(reason));
+	postmortem.registerStdioDisconnectHandling();
+
 	const input = stream.Writable.toWeb(process.stdout);
 	const output = stream.Readable.toWeb(process.stdin);
 	const transport = ndJsonStream(input, output);
-	const connection = createAcpConnection(transport, createSession, initialSession);
+	const connection = createAcpConnection(transport, createSession, initialSession, createdAgent => {
+		agent = createdAgent;
+	});
 	await connection.closed;
-	process.exit(0);
+	await postmortem.quit(0);
 }

--- a/packages/coding-agent/test/acp-disconnect.test.ts
+++ b/packages/coding-agent/test/acp-disconnect.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { runAcpMode } from "@oh-my-pi/pi-coding-agent/modes/acp/acp-mode";
+import { postmortem } from "@oh-my-pi/pi-utils";
+
+const childFlag = "--acp-eof-child";
+const childFlagIndex = process.argv.indexOf(childFlag);
+if (childFlagIndex >= 0) {
+	const marker = process.argv[childFlagIndex + 1];
+	if (!marker) throw new Error("Missing cleanup marker path");
+	const releaseCleanup = Promise.withResolvers<void>();
+	process.once("SIGUSR2", releaseCleanup.resolve);
+	postmortem.register("acp-eof-test", async () => {
+		process.stderr.write("cleanup started\n");
+		await releaseCleanup.promise;
+		await Bun.write(marker, "cleanup complete");
+	});
+	await runAcpMode(async () => {
+		throw new Error("Session factory is unused by the EOF harness");
+	});
+}
+
+describe("ACP stdio disconnect", () => {
+	it("awaits postmortem cleanup before exiting on client EOF", async () => {
+		const marker = `/tmp/omp-acp-eof-${process.pid}-${Date.now()}`;
+		const child = Bun.spawn([process.execPath, import.meta.path, childFlag, marker], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		try {
+			child.stdin.end();
+			const stderrReader = child.stderr.getReader();
+			const started = await stderrReader.read();
+			stderrReader.releaseLock();
+			expect(new TextDecoder().decode(started.value)).toBe("cleanup started\n");
+			child.kill("SIGUSR2");
+			const [exitCode, stdout] = await Promise.all([child.exited, new Response(child.stdout).text()]);
+			expect(stdout).toBe("");
+			expect(exitCode).toBe(0);
+			expect(await Bun.file(marker).text()).toBe("cleanup complete");
+		} finally {
+			try {
+				child.kill("SIGUSR2");
+			} catch {
+				// Already exited after completing teardown.
+			}
+			await child.exited;
+			await Bun.file(marker)
+				.delete()
+				.catch(() => {});
+		}
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added scoped graceful handling for stdio-write EPIPE rejections so protocol servers can await postmortem cleanup when their peer disconnects ([#4788](https://github.com/can1357/oh-my-pi/issues/4788)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Added

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -26,6 +26,7 @@ const callbackList: ((reason: Reason) => Promise<void> | void)[] = [];
 // Tracks cleanup run state (to prevent recursion/reentry issues)
 let cleanupStage: "idle" | "running" | "complete" = "idle";
 const CLEANUP_DEADLINE_MS = 10_000;
+let stdioDisconnectRegistrations = 0;
 
 /**
  * Internal: runs all registered cleanup callbacks for the given reason.
@@ -76,17 +77,35 @@ function runCleanup(reason: Reason): Promise<void> {
 // Worker thread: exit only (workers use self.addEventListener for exceptions)
 let inspectorOpened = false;
 
+/** Origin of an EPIPE raised by a process communication channel. */
+export type BrokenPipeSource = "ipc-send" | "stdio-write";
+
 /**
- * Detect an EPIPE rejection that originated from an IPC `send()` to a worker
- * subprocess (`syscall: "send"`), as opposed to a stdin/stdout pipe write
- * (`syscall: "write"`). Only the IPC-send path can break an optional worker
- * subsystem without affecting the main process, so only this shape is safe to
- * swallow at the global `unhandledRejection` level. See issue #2997.
+ * Classify EPIPE errors from worker IPC and stdio without treating unrelated
+ * broken pipes as globally recoverable.
  */
-export function isIpcSendEpipe(err: Error): boolean {
-	const code = (err as { code?: unknown }).code;
-	const syscall = (err as { syscall?: unknown }).syscall;
-	return code === "EPIPE" && syscall === "send";
+export function classifyBrokenPipe(err: Error): BrokenPipeSource | undefined {
+	if (!("code" in err) || err.code !== "EPIPE" || !("syscall" in err)) return undefined;
+	if (err.syscall === "send") return "ipc-send";
+	if (err.syscall === "write") return "stdio-write";
+	return undefined;
+}
+
+/**
+ * Treat unhandled stdout EPIPE rejections as a graceful peer disconnect.
+ *
+ * Stdio protocol servers call this for their process lifetime so a closed
+ * client pipe runs registered cleanup callbacks instead of the fatal path.
+ * The returned callback removes the registration.
+ */
+export function registerStdioDisconnectHandling(): () => void {
+	let registered = true;
+	stdioDisconnectRegistrations++;
+	return () => {
+		if (!registered) return;
+		registered = false;
+		stdioDisconnectRegistrations--;
+	};
 }
 
 // Well-known key marking an error as an *expected* teardown artifact (e.g. a
@@ -155,6 +174,7 @@ if (isMainThread) {
 		})
 		.on("unhandledRejection", async reason => {
 			const err = reason instanceof Error ? reason : new Error(String(reason));
+			const brokenPipeSource = classifyBrokenPipe(err);
 			// EPIPE from an IPC `send()` (`syscall: "send"`) originates from a
 			// worker subprocess whose pipe broke between the exit being observed
 			// and the next `proc.send()` — a race window that Bun surfaces as an
@@ -164,8 +184,13 @@ if (isMainThread) {
 			// send pipe must never take down the whole session. Log and continue
 			// instead of exiting; the owning client detects the dead worker via
 			// its own `onExit`/error path and respawns or disables it. See #2997.
-			if (isIpcSendEpipe(err)) {
+			if (brokenPipeSource === "ipc-send") {
 				logger.warn("Ignoring EPIPE from worker IPC send; optional subsystem will self-recover", { err });
+				return;
+			}
+			if (brokenPipeSource === "stdio-write" && stdioDisconnectRegistrations > 0) {
+				logger.warn("Stdio peer disconnected; shutting down gracefully", { err });
+				await quit(0);
 				return;
 			}
 			if (isExpectedCleanupError(reason)) {

--- a/packages/utils/test/postmortem-epipe.test.ts
+++ b/packages/utils/test/postmortem-epipe.test.ts
@@ -1,42 +1,69 @@
 import { describe, expect, it } from "bun:test";
 import { postmortem } from "@oh-my-pi/pi-utils";
 
-/**
- * Contract for issue #2997: an EPIPE rejection from an IPC `send()` to a worker
- * subprocess (`syscall: "send"`) must be recognizable as a non-fatal, optional-
- * subsystem failure so the global `unhandledRejection` handler can swallow it
- * instead of terminating the session. The predicate must be narrow: a bare
- * EPIPE, or an EPIPE from a stdin/stdout write (`syscall: "write"`), is NOT
- * swallowed — those may signal a real broken pipe to a critical stream.
- */
-describe("postmortem.isIpcSendEpipe", () => {
+const childFlag = "--stdio-epipe-child";
+const childFlagIndex = process.argv.indexOf(childFlag);
+if (childFlagIndex >= 0) {
+	const marker = process.argv[childFlagIndex + 1];
+	if (!marker) throw new Error("Missing cleanup marker path");
+	postmortem.registerStdioDisconnectHandling();
+	postmortem.register("stdio-epipe-test", async () => {
+		process.stderr.write("cleanup started\n");
+		await new Response(Bun.stdin.stream()).text();
+		await Bun.write(marker, "cleanup complete");
+	});
+	const err = Object.assign(new Error("broken pipe"), { code: "EPIPE", syscall: "write" });
+	void Promise.reject(err);
+	const keepAlive = Promise.withResolvers<void>();
+	await keepAlive.promise;
+}
+
+describe("postmortem broken-pipe handling", () => {
 	function makeErr(props: { code?: string; syscall?: string; message?: string }): Error {
 		const err = new Error(props.message ?? "broken pipe");
 		Object.assign(err, { code: props.code, syscall: props.syscall });
 		return err;
 	}
 
-	it("matches EPIPE with syscall 'send' (worker IPC send)", () => {
-		expect(postmortem.isIpcSendEpipe(makeErr({ code: "EPIPE", syscall: "send" }))).toBe(true);
+	it("classifies worker IPC and stdio EPIPE errors", () => {
+		expect(postmortem.classifyBrokenPipe(makeErr({ code: "EPIPE", syscall: "send" }))).toBe("ipc-send");
+		expect(postmortem.classifyBrokenPipe(makeErr({ code: "EPIPE", syscall: "write" }))).toBe("stdio-write");
 	});
 
-	it("does not match EPIPE from a stdin/stdout write (syscall 'write')", () => {
-		expect(postmortem.isIpcSendEpipe(makeErr({ code: "EPIPE", syscall: "write" }))).toBe(false);
+	it("does not classify unrelated errors as recoverable broken pipes", () => {
+		expect(postmortem.classifyBrokenPipe(makeErr({ code: "EPIPE" }))).toBeUndefined();
+		expect(postmortem.classifyBrokenPipe(makeErr({ code: "ENOENT", syscall: "send" }))).toBeUndefined();
+		expect(postmortem.classifyBrokenPipe(new Error("boom"))).toBeUndefined();
+		expect(postmortem.classifyBrokenPipe(makeErr({ code: undefined, syscall: undefined }))).toBeUndefined();
 	});
 
-	it("does not match a bare EPIPE without a syscall", () => {
-		expect(postmortem.isIpcSendEpipe(makeErr({ code: "EPIPE" }))).toBe(false);
-	});
-
-	it("does not match a non-EPIPE error even with syscall 'send'", () => {
-		expect(postmortem.isIpcSendEpipe(makeErr({ code: "ENOENT", syscall: "send" }))).toBe(false);
-	});
-
-	it("does not match a plain Error with no code/syscall", () => {
-		expect(postmortem.isIpcSendEpipe(new Error("boom"))).toBe(false);
-	});
-
-	it("does not match nullish/missing errno-style fields gracefully", () => {
-		expect(postmortem.isIpcSendEpipe(makeErr({ code: undefined, syscall: undefined }))).toBe(false);
+	it("awaits cleanup and exits successfully when a registered stdio peer disconnects", async () => {
+		const marker = `/tmp/omp-postmortem-stdio-${process.pid}-${Date.now()}`;
+		const child = Bun.spawn([process.execPath, import.meta.path, childFlag, marker], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		try {
+			const stderrReader = child.stderr.getReader();
+			const started = await stderrReader.read();
+			stderrReader.releaseLock();
+			expect(new TextDecoder().decode(started.value)).toBe("cleanup started\n");
+			child.stdin.end();
+			const [exitCode, stdout] = await Promise.all([child.exited, new Response(child.stdout).text()]);
+			expect(stdout).toBe("");
+			expect(exitCode).toBe(0);
+			expect(await Bun.file(marker).text()).toBe("cleanup complete");
+		} finally {
+			try {
+				child.stdin.end();
+			} catch {
+				// Already closed after the cleanup gate was released.
+			}
+			await child.exited;
+			await Bun.file(marker)
+				.delete()
+				.catch(() => {});
+		}
 	});
 });


### PR DESCRIPTION
## Repro
A minimal ACP child registered a delayed postmortem cleanup marker, entered `runAcpMode()`, and received EOF on stdin via `bun /tmp/omp-acp-eof-repro.ts < /dev/null`; it exited 0 while the marker remained absent, proving the hard exit skipped awaited cleanup.

## Cause
`packages/coding-agent/src/modes/acp/acp-mode.ts` called `process.exit(0)` immediately after `AgentSideConnection.closed`, while `AcpAgent.#registerConnectionCleanup()` launched `#disposeAllSessions()` without exposing its promise to process teardown. Separately, `packages/utils/src/postmortem.ts` only recognized worker-IPC `syscall: "send"` EPIPE, so an unhandled stdio `syscall: "write"` EPIPE followed the fatal exit path.

## Fix
- Expose idempotent, awaited `AcpAgent.dispose()` and register it with postmortem for the ACP process lifetime.
- Replace the hard EOF exit with `postmortem.quit(0)` so in-flight session/tool disposal finishes before process exit.
- Classify stdio-write EPIPE separately and allow ACP mode to scope it to graceful peer-disconnect handling.
- Add subprocess regressions proving EOF and EPIPE both block process exit until cleanup completes.

## Verification
`bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/acp-lazy-startup.test.ts packages/coding-agent/test/acp-disconnect.test.ts packages/utils/test/postmortem-epipe.test.ts` passed: 58 tests, 0 failures. `bun check` passed across all packages. The EOF subprocess regression exits 0 only after its cleanup marker is persisted.

Fixes #4788