### PR TITLE
fix(build): externalize fastembed native addon in release binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed local Mnemopi embeddings never loading via the fast direct `import("fastembed")` in released standalone binaries (Homebrew, GitHub release downloads): `scripts/ci-release-build-binaries.ts` omitted the `--external fastembed --external onnxruntime-node` flags that `build-binary.ts` and `bundle-dist.ts` both pass, so the compiled binary inlined fastembed's native `.node` addon. Bun extracts only the `.node` to `$TMPDIR` at load, never its `@loader_path`-linked ORT dylib/so, so the direct import always failed `ERR_DLOPEN_FAILED` on macOS/Linux and every embedding worker fell through to the slower on-demand runtime install on each launch. Both packages are now external in the release build, matching the other two build paths ([#4792](https://github.com/can1357/oh-my-pi/issues/4792)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -129,6 +129,18 @@ function buildCompileCommand(target: BinaryTarget): string[] {
 		'process.env.PI_COMPILED="true"',
 		"--define",
 		`process.env.PI_TINY_TRANSFORMERS_VERSION=${JSON.stringify(transformersVersion)}`,
+		// fastembed + onnxruntime-node ship a native addon that links its ORT
+		// dylib/so via `@loader_path`. `bun --compile` inlines the `.node` but
+		// extracts only that file to $TMPDIR at load time, never its sibling
+		// dylib, so an in-binary `import("fastembed")` always fails
+		// ERR_DLOPEN_FAILED (macOS #4792) and every worker falls back. Keep both
+		// external so the direct import cleanly ERR_MODULE_NOT_FOUNDs and routes
+		// straight to the on-demand runtime install, which places the dylib next
+		// to the addon. Matches `build-binary.ts` and `bundle-dist.ts`.
+		"--external",
+		"fastembed",
+		"--external",
+		"onnxruntime-node",
 		"--root",
 		".",
 		"--target",


### PR DESCRIPTION
## Repro
Released standalone `omp` binaries (Homebrew `can1357/tap/omp`, GitHub release downloads) never load local Mnemopi embeddings via the fast direct `import("fastembed")` — every embedding worker falls back to the slower on-demand runtime install on each launch, after a failed `dlopen`. Reproduced on Linux x64 (Bun 1.3.14), same failure class as the macOS `.dylib` in the report:

```
# Release-style compile (matching ci-release-build-binaries.ts, no --external),
# run standalone with no node_modules present:
1245 | module.exports = __require("/$bunfs/root/onnxruntime_binding-s1mv0c2k.node");
error: libonnxruntime.so.1: cannot open shared object file: No such file or directory
 code: "ERR_DLOPEN_FAILED"

# Same source compiled with --external fastembed --external onnxruntime-node:
error: Cannot find package 'onnxruntime-node' from '/$bunfs/root/omp_external'   # ERR_MODULE_NOT_FOUND
```

## Cause
`scripts/ci-release-build-binaries.ts` — the script that produces the shipped release/Homebrew binaries — omitted the `--external fastembed --external onnxruntime-node` flags that both `packages/coding-agent/scripts/build-binary.ts` (lines 98-101) and `scripts/bundle-dist.ts` (`ALWAYS_EXTERNAL`) pass. Without them `bun build --compile` inlines fastembed's native `.node` addon into the binary. At runtime Bun extracts only the `.node` to `$TMPDIR`, never its `@loader_path`-linked `libonnxruntime.*.dylib`/`.so.1` sibling, so `loadFastembedOnce`'s direct `import("fastembed")` in `packages/mnemopi/src/core/fastembed-runtime.ts` always throws `ERR_DLOPEN_FAILED` and every worker falls into `loadFromRuntimeInstall()`.

## Fix
- `scripts/ci-release-build-binaries.ts`: add `--external fastembed --external onnxruntime-node` to `buildCompileCommand`, with a comment explaining why (parity with the other two build paths).
- The externalized build makes the direct import cleanly `ERR_MODULE_NOT_FOUND`, which `isRecoverableFastembedLoadError` catches → straight to `loadFromRuntimeInstall()`, where the runtime cache places the dylib next to the `.node`.

## Verification
- Repro: bundled build → `ERR_DLOPEN_FAILED`; `--external` build → recoverable `ERR_MODULE_NOT_FOUND`.
- `bun scripts/ci-release-build-binaries.ts --dry-run --targets darwin-arm64` now emits `--external fastembed --external onnxruntime-node` in the compile command.
- No unit test added: the script runs `await main()` at top level and does not export `buildCompileCommand`; asserting the flag strings would be a banned source-grep/wiring test. The behavioral proof is the repro above.

Fixes #4792