### PR TITLE
fix(tui): use Nerd Fonts v3 session icon

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed the `nerd` status-line preset's session icon using a removed Nerd Fonts v2 codepoint instead of the current Nerd Fonts v3 mapping ([#4795](https://github.com/can1357/oh-my-pi/issues/4795)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -607,8 +607,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"icon.throughput": "\uf0e4",
 	// pick:  | alt:  
 	"icon.host": "\uf109",
-	// pick:  | alt:  
-	"icon.session": "\uf550",
+	// pick: 󰁑 (nf-md-arrow_left_bold_hexagon_outline) | alt:  
+	"icon.session": "\u{f0051}",
 	// pick:  | alt: 
 	"icon.package": "\uf487",
 	// pick:  | alt:  

--- a/packages/coding-agent/test/theme-nerd-symbols.test.ts
+++ b/packages/coding-agent/test/theme-nerd-symbols.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getThemeByName } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { getAgentDir, getCustomThemesDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+
+const DARK_THEME_PATH = path.join(import.meta.dir, "..", "src", "modes", "theme", "dark.json");
+
+let tempAgentDir: string | undefined;
+let originalAgentDir = "";
+let originalAgentDirEnv: string | undefined;
+
+afterEach(async () => {
+	if (tempAgentDir === undefined) return;
+	setAgentDir(originalAgentDir);
+	if (originalAgentDirEnv === undefined) {
+		delete process.env.PI_CODING_AGENT_DIR;
+	} else {
+		process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+	}
+	await removeWithRetries(tempAgentDir);
+	tempAgentDir = undefined;
+});
+
+it("uses the Nerd Fonts v3 Material Design session icon", async () => {
+	originalAgentDir = getAgentDir();
+	originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+	tempAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-nerd-symbols-"));
+	setAgentDir(tempAgentDir);
+
+	const dark = await Bun.file(DARK_THEME_PATH).json();
+	const customThemeName = "nerd-symbols";
+	await Bun.write(
+		path.join(getCustomThemesDir(), `${customThemeName}.json`),
+		JSON.stringify({ ...dark, name: customThemeName, symbols: { ...dark.symbols, preset: "nerd" } }),
+	);
+
+	const theme = await getThemeByName(customThemeName);
+	expect(theme?.symbol("icon.session")).toBe("\u{f0051}");
+});


### PR DESCRIPTION
## Repro
Initialize the built-in symbol theme with `initTheme(false, "nerd")` and inspect `theme.symbol("icon.session")`; before the fix it emitted `U+F550` (`EF 95 90`), the removed Nerd Fonts v2 Material Design codepoint.

## Cause
`NERD_SYMBOLS` in `packages/coding-agent/src/modes/theme/theme.ts` hard-coded `icon.session` as `\uf550`, while Nerd Fonts v3 maps `nf-md-arrow_left_bold_hexagon_outline` to `U+F0051`.

## Fix
- Replace the legacy session glyph with the current Nerd Fonts v3 mapping.
- Add contract coverage that loads a `nerd` symbol preset and verifies the exposed session icon.
- Document the user-visible fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/theme-nerd-symbols.test.ts` passed (1 test). A runtime smoke check after `initTheme(false, "nerd")` emitted `U+F0051` with UTF-8 bytes `F3 B0 81 91`. The pre-publish `bun run fix` and `bun check` gate passed. Fixes #4795