### PR TITLE
fix(tools): stop column cap from faking window truncation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash/eval/ssh output that was only per-line column-capped being misreported as byte-window truncation, which appended a bogus `Showing lines X-Y of Z (…B limit). Read artifact://N for full output` footer even though every line was shown. Column-cap trimming now surfaces solely as the `Some lines truncated to N chars` notice ([#4735](https://github.com/can1357/oh-my-pi/issues/4735)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/session/streaming-output.ts
+++ b/packages/coding-agent/src/session/streaming-output.ts
@@ -43,6 +43,8 @@ export interface OutputSummary {
 	columnDroppedBytes?: number;
 	/** Number of distinct lines that hit the per-line column cap. */
 	columnTruncatedLines?: number;
+	/** Configured per-line column cap in effect (chars), when > 0. */
+	columnMax?: number;
 	/** Artifact ID for internal URL access (artifact://<id>) when truncated */
 	artifactId?: string;
 }
@@ -837,7 +839,6 @@ export class OutputSink {
 		const capped = this.#maxColumns > 0 ? this.#applyColumnCap(chunk) : chunk;
 		const cappedBytes = capped === chunk ? rawBytes : Buffer.byteLength(capped, "utf-8");
 		const cappedThisChunk = cappedBytes < rawBytes;
-		if (cappedThisChunk) this.#truncated = true;
 
 		// Mirror RAW chunk to the artifact file so the on-disk record is the full
 		// uncapped stream. Mirror triggers on: in-memory overflow OR this chunk's
@@ -1248,6 +1249,7 @@ export class OutputSink {
 			elidedLines,
 			columnDroppedBytes: this.#columnDroppedBytes > 0 ? this.#columnDroppedBytes : undefined,
 			columnTruncatedLines: this.#columnTruncatedLines > 0 ? this.#columnTruncatedLines : undefined,
+			columnMax: this.#columnTruncatedLines > 0 ? this.#maxColumns : undefined,
 			artifactId: this.#file?.artifactId,
 		};
 	}

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -191,6 +191,13 @@ export class OutputMetaBuilder {
 
 	/** Add truncation info from OutputSummary. No-op if not truncated. */
 	truncationFromSummary(summary: OutputSummary, options: TruncationSummaryOptions): this {
+		// A per-line column cap only trims individual lines (with a `…` marker);
+		// it is not a window/byte truncation, so surface it as its own limit
+		// notice rather than a "Showing lines X-Y … limit" range. This runs even
+		// when the output is otherwise complete (`truncated === false`).
+		if (summary.columnMax != null && summary.columnMax > 0 && (summary.columnTruncatedLines ?? 0) > 0) {
+			this.columnTruncated(summary.columnMax);
+		}
 		if (!summary.truncated) return this;
 
 		const { direction, startLine = 1, totalFileLines } = options;

--- a/packages/coding-agent/test/streaming-output.test.ts
+++ b/packages/coding-agent/test/streaming-output.test.ts
@@ -15,6 +15,7 @@ import {
 	truncateTail,
 	truncateTailBytes,
 } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
+import { formatOutputNotice, outputMeta } from "@oh-my-pi/pi-coding-agent/tools/output-meta";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 const createdTempDirs: string[] = [];
@@ -636,7 +637,11 @@ describe("OutputSink maxColumns (per-line cap)", () => {
 		await sink.push(`short\n${"x".repeat(50)}\nfooter`);
 
 		const dumped = await sink.dump();
-		expect(dumped.truncated).toBe(true);
+		// A per-line column cap trims individual lines but does not truncate the
+		// output window: every line is still present, so `truncated` stays false.
+		// (Regression: column-cap-only output was misreported as a byte-window
+		// truncation, producing a bogus "Showing lines X-Y … limit" footer — #4735.)
+		expect(dumped.truncated).toBe(false);
 		expect(dumped.output).toContain("short\n");
 		expect(dumped.output).toContain("\nfooter");
 		expect(dumped.output).toContain("…");
@@ -644,8 +649,30 @@ describe("OutputSink maxColumns (per-line cap)", () => {
 		expect(dumped.output).not.toContain("x".repeat(50));
 		expect(dumped.columnTruncatedLines).toBe(1);
 		expect(dumped.columnDroppedBytes ?? 0).toBeGreaterThan(0);
+		expect(dumped.columnMax).toBe(8);
 		// totalBytes still reflects the raw stream, not the post-cap view.
 		expect(dumped.totalBytes).toBe(byteLength(`short\n${"x".repeat(50)}\nfooter`));
+	});
+
+	test("column-cap-only output surfaces a column notice, not a window/byte truncation footer", async () => {
+		// Regression for #4735: fully-shown output whose only trimming was the
+		// per-line column cap must not emit "Showing lines X-Y of Z (…B limit).
+		// Read artifact://… for full output" — every line is present.
+		const sink = new OutputSink({ maxColumns: 8, spillThreshold: 100_000 });
+		const lines = ["a", "b", "c", "x".repeat(50), "d"];
+		await sink.push(`${lines.join("\n")}\n`);
+		const dumped = await sink.dump();
+
+		const meta = outputMeta().truncationFromSummary(dumped, { direction: "tail" }).get();
+		// No window truncation → no styled TUI warning and no range/limit footer.
+		expect(meta?.truncation).toBeUndefined();
+		expect(meta?.limits?.columnTruncated).toEqual({ maxColumn: 8 });
+
+		const notice = formatOutputNotice(meta);
+		expect(notice).toContain("Some lines truncated to 8 chars");
+		expect(notice).not.toContain("Showing lines");
+		expect(notice).not.toContain("limit");
+		expect(notice).not.toContain("artifact://");
 	});
 
 	test("persists per-line state across chunk boundaries", async () => {

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -1328,10 +1328,10 @@ function b() {
 
 		it("should write truncated output to artifacts", async () => {
 			const result = await bashTool.execute("test-call-8-artifact", {
-				// A single line past the 768-byte column cap is the minimal output
-				// that trips truncation + artifact spill; the old 60K-arg brace
-				// expansion paid ~60ms of shell time to prove the same path.
-				command: "printf 'a%.0s' {1..2000}",
+				// Emit well past the ~50KB inline window across many lines so the
+				// output is genuinely window-truncated (not merely column-capped),
+				// which is what allocates the spill artifact.
+				command: "seq 1 30000",
 			});
 
 			const artifactId = result.details?.meta?.truncation?.artifactId;


### PR DESCRIPTION
## Repro
A short bash/eval/ssh result that contained a single line wider than the per-line column cap (`tools.outputMaxColumns`, default 768) printed a misleading footer:

```
[Showing lines 1-13 of 13 (1019B limit). Read artifact://22 for full output]
```

Every line was actually shown, yet the notice claimed a byte-window limit and pointed at an artifact. Reproduced by feeding `OutputSink({ maxColumns: 768 })` twelve short lines plus one 1200-char line, then formatting the notice via `truncationFromSummary` + `formatOutputNotice`: `truncated=true`, `outputBytes(856) < totalBytes(1288)`, notice `[Showing lines 1-14 of 14 (856B limit)]`.

## Cause
The bash/eval/ssh streaming path runs output through `OutputSink` (`packages/coding-agent/src/session/streaming-output.ts`). Its per-line column cap drops overflow bytes with a `…` marker and set `#truncated = true` on any capped chunk. `dump()` then returned `truncated=true` with `outputBytes < totalBytes` (the gap being entirely column-dropped bytes). `OutputMetaBuilder.truncationFromSummary` (`packages/coding-agent/src/tools/output-meta.ts`) classified that byte gap as a *tail byte-window* truncation, populating `meta.truncation` — which drives both the LLM-facing `[Showing lines … limit]` footer and the styled TUI `⟦…⟧` warning. Column trimming is meant to surface only as the separate `Some lines truncated to N chars` limit notice.

## Fix
- `OutputSink.push` no longer flips `#truncated` for column-cap-only drops (`streaming-output.ts`); `#truncated` stays reserved for genuine window/middle truncation.
- `OutputSummary` gains `columnMax` (the configured cap, set when a line was actually capped), populated in `dump()`.
- `truncationFromSummary` surfaces the column cap as the `columnTruncated` limit notice up front — even when the output is otherwise complete (`truncated === false`) — so bash/eval/ssh keep the correct `Some lines truncated to N chars` message without a fake range/artifact footer. Genuine window truncation still reports the range + byte limit, and both notices coexist when both apply.
- Tests: updated the `OutputSink` column-cap test to the corrected `truncated=false`/`columnMax` contract, added a notice-level regression asserting no `Showing lines`/`limit`/`artifact://` for column-cap-only output, and restored the bash artifact-spill test to trigger real window truncation (`seq 1 30000`) rather than the old column-cap path.

## Verification
`bun test test/streaming-output.test.ts test/tools.test.ts` → 157 pass, 1 skip, 0 fail. Manual notice checks confirm: column-cap-only → `[Some lines truncated to 768 chars]` (no range/limit/artifact, no `meta.truncation`); genuine byte truncation → `[Showing lines 4945-5001 of 5001 (500B limit)]`; both → `[Showing lines … (2.0KB limit). Some lines truncated to 768 chars]`; clean output → no notice. A pre-existing, unrelated `tool-views.generated.js` module-resolution error affects only HTML-export tests (generated file absent in this checkout), not the changed area. Fixes #4735