### PR TITLE
fix(github): add dedicated repository file reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed GitHub-hosted repository file reads falling back to `curl` by adding a dedicated `github` file-read operation and explicit tool-routing guidance ([#4805](https://github.com/can1357/oh-my-pi/issues/4805)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -6,6 +6,8 @@ The shell invokes **real binaries** with simple args. It is NOT full GNU Bash.
 
 Use bash ONLY for: a single binary call, or one short pipeline that COMPUTES a fact and does not depend on shell-specific regex/quoting (`wc -l`, `sort | uniq -c`, `comm`, `diff`, a checksum, `git status`).
 
+GitHub repository file? MUST use `github` `file_read` when available; otherwise `read`. NEVER use `curl`/`wget`.
+
 Anything below → `eval` cell, not bash:
 - Inline interpreter scripts (`-e`/`-c`/`--eval`) when an eval runtime exists for that language
 - Heredocs (`<<EOF`), `while`/`for`/`if`/`case` shell control flow

--- a/packages/coding-agent/src/prompts/tools/github.md
+++ b/packages/coding-agent/src/prompts/tools/github.md
@@ -1,8 +1,9 @@
-Op-based `gh` wrapper: repos, PRs, search, checkout, push, Actions watch. Read an issue/PR via `issue://<N>`/`pr://<N>`. PR diffs: `pr://<N>/diff` (file listing), `pr://<N>/diff/<i>` (file slice, 1-indexed), `pr://<N>/diff/all` (full diff).
+Op-based `gh` wrapper: repos, repository files, PRs, search, checkout, push, Actions watch. Read an issue/PR via `issue://<N>`/`pr://<N>`. PR diffs: `pr://<N>/diff` (file listing), `pr://<N>/diff/<i>` (file slice, 1-indexed), `pr://<N>/diff/all` (full diff).
 
 <instruction>
 Pick op via `op`. Beyond the field descriptions, per op:
 - `repo_view` — omit `repo` to view the current checkout.
+- `file_read` — reads `path` from `repo`; omit `repo` for the current checkout and `branch` for its default branch.
 - `pr_create` — `head` defaults to the current branch.
 - `pr_checkout` — checks PR(s) out into dedicated git worktrees, not your working tree; pass an array of `pr` to batch multiple in one call.
 - `pr_push` — requires the branch to have been checked out first via `op: pr_checkout`.
@@ -15,3 +16,7 @@ Pick op via `op`. Beyond the field descriptions, per op:
 <output>
 Concise summary per op. `run_watch` failures save full logs to a session artifact.
 </output>
+
+<critical>
+GitHub-hosted repository file? MUST use `file_read`; NEVER `curl`/`wget`.
+</critical>

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -3,6 +3,7 @@ Read files, directories, archives, SQLite, images, documents, internal resources
 <instruction>
 - SHOULD parallelize independent reads.
 - SHOULD use `read` (not a browser tool) for web content; browser only when `read` can't deliver.
+- GitHub repository file? MUST use `github` `file_read` when available; otherwise `read`. NEVER use `curl`/`wget`.
 </instruction>
 
 ## Parameters

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -247,6 +247,7 @@ const RUN_FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "a
 const JOB_FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
 const GITHUB_READONLY_OPS: ReadonlySet<string> = new Set([
 	"repo_view",
+	"file_read",
 	"search_issues",
 	"search_prs",
 	"search_code",
@@ -257,10 +258,11 @@ const GITHUB_READONLY_OPS: ReadonlySet<string> = new Set([
 
 const githubSchema = type({
 	op: type(
-		"'repo_view' | 'pr_create' | 'pr_checkout' | 'pr_push' | 'search_issues' | 'search_prs' | 'search_code' | 'search_commits' | 'search_repos' | 'run_watch'",
+		"'repo_view' | 'file_read' | 'pr_create' | 'pr_checkout' | 'pr_push' | 'search_issues' | 'search_prs' | 'search_code' | 'search_commits' | 'search_repos' | 'run_watch'",
 	).describe("github operation"),
 	"repo?": type("string").describe("owner/repo"),
 	"branch?": type("string").describe("branch"),
+	"path?": type("string").describe("repository-relative file path"),
 	"pr?": type("string | string[]").describe("pr number, url, or branch"),
 	"force?": type("boolean").describe("reset existing local branch"),
 	"forceWithLease?": type("boolean").describe("force-with-lease push"),
@@ -2453,7 +2455,7 @@ export class GithubTool implements AgentTool<typeof githubSchema, GhToolDetails>
 		const op = typeof rawOp === "string" ? rawOp : "";
 		return GITHUB_READONLY_OPS.has(op) ? "read" : "exec";
 	};
-	readonly summary = "Interact with GitHub issues, pull requests, and repositories";
+	readonly summary = "Interact with GitHub repositories, files, pull requests, and Actions";
 	readonly loadMode = "discoverable";
 	readonly label = "GitHub";
 	readonly description = prompt.render(githubDescription);
@@ -2478,6 +2480,8 @@ export class GithubTool implements AgentTool<typeof githubSchema, GhToolDetails>
 			switch (params.op) {
 				case "repo_view":
 					return executeRepoView(this.session, params, signal);
+				case "file_read":
+					return executeFileRead(this.session, params, signal);
 				case "pr_create":
 					return executePrCreate(this.session, params, signal);
 				case "pr_checkout":
@@ -2521,6 +2525,40 @@ async function executeRepoView(
 		repoProvided: Boolean(repo),
 	});
 	return buildTextResult(formatRepoView(data, { repo, branch }), data.url);
+}
+
+async function executeFileRead(
+	session: ToolSession,
+	params: GithubInput,
+	signal: AbortSignal | undefined,
+): Promise<AgentToolResult<GhToolDetails>> {
+	const repo = await resolveGitHubRepo(session.cwd, normalizeOptionalString(params.repo), undefined, signal);
+	const filePath = requireNonEmpty(normalizeOptionalString(params.path), "path");
+	if (filePath.startsWith("/")) {
+		throw new ToolError("path must be repository-relative");
+	}
+	const branch = normalizeOptionalString(params.branch);
+	const endpointPath = filePath
+		.split("/")
+		.map(segment => encodeURIComponent(segment))
+		.join("/");
+	const args = [
+		"api",
+		`/repos/${repo}/contents/${endpointPath}`,
+		"--method",
+		"GET",
+		"-H",
+		"Accept: application/vnd.github.raw+json",
+	];
+	if (branch) {
+		args.push("-f", `ref=${branch}`);
+	}
+	const text = await git.github.text(session.cwd, args, signal, {
+		repoProvided: true,
+		trimOutput: false,
+	});
+	const sourceUrl = `https://github.com/${repo}/blob/${encodeURIComponent(branch ?? "HEAD")}/${endpointPath}`;
+	return buildTextResult(text, sourceUrl, { repo, branch });
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -319,6 +319,35 @@ describe("github tool", () => {
 		expect(text).toContain("Topics: cli, github");
 	});
 
+	it("reads repository files through the GitHub contents API", async () => {
+		const textSpy = vi.spyOn(git.github, "text").mockResolvedValue('{"version":"16.3.11"}\n');
+		const tool = new GithubTool(createSession());
+		const result = await tool.execute("file-read", {
+			op: "file_read",
+			repo: "can1357/oh-my-pi",
+			branch: "main",
+			path: "packages/coding-agent/package.json",
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(text).toBe('{"version":"16.3.11"}\n');
+		expect(textSpy).toHaveBeenCalledWith(
+			"/tmp/test",
+			[
+				"api",
+				"/repos/can1357/oh-my-pi/contents/packages/coding-agent/package.json",
+				"--method",
+				"GET",
+				"-H",
+				"Accept: application/vnd.github.raw+json",
+				"-f",
+				"ref=main",
+			],
+			undefined,
+			{ repoProvided: true, trimOutput: false },
+		);
+	});
+
 	it("creates a pull request via gh and renders the resulting summary", async () => {
 		const textCalls: string[][] = [];
 		const textSpy = vi.spyOn(git.github, "text").mockImplementation(async (_cwd, args) => {


### PR DESCRIPTION
## Repro
With the GitHub tool enabled, run `omp -p --config github-enabled.yml --tools github,read,bash "Read packages/coding-agent/package.json from the main branch of can1357/oh-my-pi on GitHub, without using the local checkout."`; the `github` op schema has no repository-file operation, so the request cannot stay on the dedicated tool and may fall back to `curl`.

## Cause
`packages/coding-agent/src/tools/gh.ts` exposed repository metadata, PR, search, and Actions operations through `GithubTool`, but no operation accepted a repository-relative path or fetched GitHub contents; the tool prompts also lacked an explicit GitHub-file routing rule.

## Fix
- Add the read-only `file_read` operation backed by GitHub's contents API, with optional repository and branch selection.
- Preserve file contents and attach the canonical GitHub blob URL to results.
- Route GitHub repository file requests to `github.file_read` when available and prohibit `curl`/`wget` fallbacks.
- Add regression coverage for the branch-aware contents API request and exact returned text.

## Verification
`bun test test/tools/gh.test.ts` passes: 40 tests, 0 failures. `bun check` passes for `packages/coding-agent`. A source-CLI smoke run with GitHub enabled selected `github` with `op: "file_read"` and returned the fixture's `16.3.11` version. The pre-publish formatter and repository check passed during push. Fixes #4805