### PR TITLE
fix(tool): route attachments to inspect_image

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed attached-image turns leaving `inspect_image` hidden under full tool discovery, preventing the model from selecting the image-aware tool and omitting its routing guidance ([#4817](https://github.com/can1357/oh-my-pi/issues/4817)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7232,7 +7232,14 @@ export class AgentSession {
 		});
 	}
 
-	#normalizeImagesForModel(images: ImageContent[] | undefined): Promise<ImageContent[] | undefined> {
+	async #normalizeImagesForModel(images: ImageContent[] | undefined): Promise<ImageContent[] | undefined> {
+		if (
+			images?.length &&
+			this.hasBuiltInTool("inspect_image") &&
+			!this.getActiveToolNames().includes("inspect_image")
+		) {
+			await this.activateDiscoveredTools(["inspect_image"]);
+		}
 		return normalizeModelContextImages(images, { model: this.model });
 	}
 

--- a/packages/coding-agent/test/sdk-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-discovery.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import { AuthStorage, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { AuthStorage, Effort, type ImageContent, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -44,6 +44,12 @@ function createReasoningModel(): Model<"openai-responses"> {
 		maxTokens: 2048,
 	});
 }
+
+const TINY_PNG: ImageContent = {
+	type: "image",
+	data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2Z0AAAAASUVORK5CYII=",
+	mimeType: "image/png",
+};
 
 const oldSessionMtime = new Date("2000-01-01T00:00:00.000Z");
 
@@ -157,6 +163,31 @@ describe("createAgentSession MCP discovery prompt gating", () => {
 		expect(session.getActiveToolNames()).not.toContain("search");
 		expect(prompt).toContain("call `search_tool_bm25` before concluding no such tool exists");
 		expect(searchTool?.description).toContain("Total discoverable tools available:");
+	});
+
+	it("activates inspect_image when a user attaches an image under discovery all", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "tools.discoveryMode": "all", "inspect_image.enabled": true }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+
+		expect(session.getActiveToolNames()).not.toContain("inspect_image");
+		await session.steer("Inspect the attached image", [TINY_PNG]);
+
+		expect(session.getActiveToolNames()).toContain("inspect_image");
+		expect(session.systemPrompt.join("\n")).toContain("Image tasks: prefer `inspect_image` over `read`");
+		await session.dispose();
 	});
 
 	it("exposes task under tools.discoveryMode all when task.eager is preferred", async () => {


### PR DESCRIPTION
## Repro
With `inspect_image.enabled=true` and `tools.discoveryMode=all`, create an interactive session and attach an image; `bun .wt/repro-4817.ts` reported `{"active":false,"discoverable":true,"promptMentionsInspectImage":false}`, proving the tool was absent from the model’s active schema despite being registered for discovery.

## Cause
`filterInitialToolsForDiscoveryAll` in `packages/coding-agent/src/tools/index.ts` correctly hid the discoverable `inspect_image` tool at session startup, but `AgentSession.prompt` and its queued-message paths in `packages/coding-agent/src/session/agent-session.ts` normalized attachments without activating that tool. The next model request therefore omitted both the tool schema and the system prompt’s image-routing guidance.

## Fix
- Activate the built-in `inspect_image` tool while preparing attached images when discovery previously left it inactive.
- Rebuild the active tool schema and system prompt before the attached-image turn reaches the model.
- Cover discovery-all attachment routing with an SDK regression test and document the fix in the coding-agent changelog.

## Verification
`bun .wt/repro-4817.ts` now reports `{"active":true,"discoverable":false,"promptMentionsInspectImage":true}`. `bun test packages/coding-agent/test/sdk-mcp-discovery.test.ts` passed 13 tests, and `bun test packages/coding-agent/test/tools/inspect-image.test.ts` passed 12 tests. The publish gate also completed `bun run fix` and `bun check` before push. Fixes #4817