### PR TITLE
fix(natives): bound glob traversal depth for non-recursive patterns

### DIFF
--- a/crates/pi-natives/src/glob.rs
+++ b/crates/pi-natives/src/glob.rs
@@ -172,6 +172,12 @@ fn run_glob(
 	ct: task::CancelToken,
 ) -> Result<GlobResult> {
 	let walk_glob_pattern = glob_util::build_glob_pattern(&config.pattern, config.recursive);
+	// A pattern without `**` matches at a fixed depth (globs compile with
+	// literal_separator, so `*` never crosses `/`). Bound traversal to that
+	// depth so a non-recursive glob (`dir/*`) does not descend the whole
+	// subtree — the walker descends on `WalkDecision::Skip`, so an unbounded
+	// depth would scan every non-matching directory until the timeout.
+	let max_depth = glob_util::max_match_depth(&walk_glob_pattern);
 	let walk_glob = pi_walker::CompiledWalkGlob::new([walk_glob_pattern])
 		.map_err(|err| Error::from_reason(format!("Invalid glob pattern: {err}")))?;
 	if config.max_results == 0 {
@@ -192,7 +198,7 @@ fn run_glob(
 		.detail(scan_detail)
 		.order(pi_walker::WalkOrder::Path)
 		.emit_root(false)
-		.depth(1, usize::MAX)
+		.depth(1, max_depth)
 		.directory_errors(pi_walker::DirectoryErrorMode::SkipSkippable)
 		.cache(config.cache)
 		.empty_recheck(pi_walker::EmptyRecheck::Configured)
@@ -376,6 +382,76 @@ mod tests {
 				.iter()
 				.any(|entry| entry.path.starts_with("ignored/")),
 			"gitignored directory should be pruned before matching, got {paths:?}"
+		);
+	}
+
+	#[test]
+	fn run_glob_non_recursive_matches_direct_child_and_ignores_nested() {
+		let root = TempDirGuard::new();
+		fs::create_dir_all(root.path().join("widget-direct")).expect("create direct match dir");
+		fs::create_dir_all(root.path().join("workspace-a/widget-nested"))
+			.expect("create nested match dir");
+		// A deep unrelated subtree the pre-fix walker would descend fully.
+		fs::create_dir_all(root.path().join("workspace-a/deep/deeper/deepest"))
+			.expect("create deep subtree");
+
+		let result = super::run_glob(
+			super::GlobConfig {
+				root:                  root.path().to_path_buf(),
+				pattern:               "*widget*".to_string(),
+				recursive:             false,
+				include_hidden:        true,
+				file_type_filter:      None,
+				max_results:           usize::MAX,
+				use_gitignore:         false,
+				mentions_node_modules: false,
+				sort_by_mtime:         false,
+				cache:                 false,
+			},
+			None,
+			crate::task::CancelToken::default(),
+		)
+		.expect("glob succeeds");
+
+		let paths = match_paths(&result);
+		assert_eq!(paths, ["widget-direct"], "only the direct child should match");
+		assert!(
+			!result.matches.iter().any(|entry| entry.path.contains('/')),
+			"non-recursive glob must not return nested matches, got {paths:?}"
+		);
+	}
+
+	#[test]
+	fn run_glob_non_recursive_two_segment_pattern_matches_at_its_depth() {
+		let root = TempDirGuard::new();
+		fs::create_dir_all(root.path().join("workspace-a/widget-nested"))
+			.expect("create depth-2 match dir");
+		fs::create_dir_all(root.path().join("workspace-a/widget-nested/too-deep"))
+			.expect("create depth-3 dir");
+
+		let result = super::run_glob(
+			super::GlobConfig {
+				root:                  root.path().to_path_buf(),
+				pattern:               "*/*widget*".to_string(),
+				recursive:             false,
+				include_hidden:        true,
+				file_type_filter:      None,
+				max_results:           usize::MAX,
+				use_gitignore:         false,
+				mentions_node_modules: false,
+				sort_by_mtime:         false,
+				cache:                 false,
+			},
+			None,
+			crate::task::CancelToken::default(),
+		)
+		.expect("glob succeeds");
+
+		let paths = match_paths(&result);
+		assert_eq!(
+			paths,
+			["workspace-a/widget-nested"],
+			"a two-segment pattern must match at depth 2 but not deeper"
 		);
 	}
 }

--- a/crates/pi-natives/src/glob_util.rs
+++ b/crates/pi-natives/src/glob_util.rs
@@ -64,6 +64,25 @@ pub fn build_glob_pattern(glob: &str, recursive: bool) -> String {
 	fix_unclosed_braces(pattern)
 }
 
+/// Maximum walk-relative traversal depth a compiled glob pattern can match.
+///
+/// Patterns are compiled with [`GlobBuilder::literal_separator`] enabled, so
+/// `*`, `?`, and `[...]` never cross a `/`. A pattern without a `**` component
+/// can therefore only match paths whose segment count equals the pattern's, so
+/// the walker never needs to descend past that depth. `**` matches across
+/// separators, so any pattern containing it stays unbounded ([`usize::MAX`]).
+///
+/// Root children are walk-relative depth 1 (zero `/`), so the bound is the
+/// number of `/` separators plus one. The result is a safe upper bound: brace
+/// unions (e.g. `{a,b/c}`) are counted by total `/`, which is always at least
+/// the separator count of every concrete expansion, so no match is ever pruned.
+pub fn max_match_depth(pattern: &str) -> usize {
+	if pattern.contains("**") {
+		return usize::MAX;
+	}
+	pattern.bytes().filter(|&byte| byte == b'/').count() + 1
+}
+
 /// Compile a glob pattern string into a [`CompiledGlob`].
 ///
 /// When `recursive` is true, simple patterns (no path separators, no leading
@@ -277,5 +296,19 @@ mod tests {
 	#[test]
 	fn glob_brace_union_still_gets_recursive_prefix() {
 		assert_eq!(build_glob_pattern("{*.ts,*.tsx}", true), "**/{*.ts,*.tsx}");
+	}
+
+	#[test]
+	fn max_match_depth_bounds_non_recursive_patterns_by_segment_count() {
+		assert_eq!(max_match_depth("*widget*"), 1);
+		assert_eq!(max_match_depth("foo/*"), 2);
+		assert_eq!(max_match_depth("foo/bar/*.ts"), 3);
+	}
+
+	#[test]
+	fn max_match_depth_is_unbounded_for_recursive_patterns() {
+		assert_eq!(max_match_depth("**/*.ts"), usize::MAX);
+		assert_eq!(max_match_depth("**/*"), usize::MAX);
+		assert_eq!(max_match_depth("src/**/widget"), usize::MAX);
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed the native build script failing to locate the `@napi-rs/cli` `napi` binary on Windows because the `PATH` lookup joined entries with a Unix `:` separator instead of the platform delimiter (`path.delimiter`).
+- Fixed non-recursive `glob` patterns traversing the entire subtree: `run_glob` now bounds walker depth to the glob's segment count when the pattern has no `**`, so `dir/*` no longer descends unrelated subdirectories and times out with zero matches on large roots. Patterns containing `**` stay fully recursive ([#4793](https://github.com/can1357/oh-my-pi/issues/4793)).
 
 ## [16.3.6] - 2026-07-04
 


### PR DESCRIPTION
## Repro
A non-recursive `glob` pattern like `*widget*` against a large workspace root returns `No files found matching pattern` plus `glob timed out after 5s; returning 0 partial matches`, while the scoped equivalent `example-workspace/*widget*` returns immediately. The pattern preserves direct-child match semantics, but the filesystem walker still traverses the entire subtree. Reproduced via `natives.glob({ pattern: "*widget*", path: "<large-root>", recursive: false })`.

## Cause
`run_glob` (`crates/pi-natives/src/glob.rs`) built the walker with `.depth(1, usize::MAX)` unconditionally. For a non-matching directory, `WalkFilter::stream_decision` (`crates/pi-walker/src/lib.rs:355`) returns `WalkDecision::Skip` rather than `SkipDescend`, and the walker descends on `Skip` (`lib.rs:1650`, `lib.rs:2927`). Globs compile with `literal_separator(true)`, so `*`/`?`/`[...]` never cross `/` — a pattern without `**` can only match paths at its own segment depth, yet the walker still entered every subtree until the 5s timeout, yielding zero matches on large roots.

## Fix
- Added `glob_util::max_match_depth(pattern)`: `usize::MAX` when the pattern contains `**`, otherwise `/`-separator count + 1 (root children are walk-relative depth 1). Brace unions are counted by total `/`, a safe upper bound over every concrete expansion, so no match is pruned.
- `run_glob` now bounds the walker to `.depth(1, max_depth)` derived from the compiled walk pattern instead of `usize::MAX`. `parseFindPattern("src") -> **/*` stays fully recursive.
- Tests: `max_match_depth` unit cases (`*widget* -> 1`, `foo/* -> 2`, `foo/bar/*.ts -> 3`, `**/* -> MAX`); `run_glob` integration tests asserting a non-recursive `*widget*` matches only the direct child (not `workspace-a/widget-nested/`) and a two-segment `*/*widget*` matches at depth 2 but not depth 3. All three fail on an off-by-one undercount, confirming they guard the bound.

## Verification
`cd crates/pi-natives && cargo test --lib` → 156 passed, 0 failed. Confirmed the new tests fail when `max_match_depth` undercounts (guards the fix's contract). Match semantics are unchanged; only traversal scope is bounded. Fixes #4793