### PR TITLE
fix(ai): fail over exhausted OpenRouter daily keys

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenRouter daily free-model allowance errors (`free-models-per-day`) being treated as transient rate limits, so requests rotate from an exhausted API key to a healthy sibling credential. ([#4832](https://github.com/can1357/oh-my-pi/issues/4832))
+
 ## [16.3.11] - 2026-07-06
 
 ### Fixed

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -19,6 +19,7 @@ const SERVER_ERROR_BACKOFF_MS = 20 * 1000; // 20s
 const ACCOUNT_RATE_LIMIT_PATTERN =
 	/\baccount(?:'s)?\b[^\n]{0,80}\brate.?limit\b|\brate.?limit\b[^\n]{0,80}\baccount\b/i;
 const INSUFFICIENT_BALANCE_PATTERN = /insufficient.?balance/i;
+const OPENROUTER_DAILY_FREE_LIMIT_PATTERN = /\bfree[-_ ]models[-_ ]per[-_ ]day\b/i;
 
 /**
  * Classify a rate-limit error message into a reason category.
@@ -51,6 +52,10 @@ export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	}
 
 	if (ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage)) {
+		return "QUOTA_EXHAUSTED";
+	}
+
+	if (OPENROUTER_DAILY_FREE_LIMIT_PATTERN.test(errorMessage)) {
 		return "QUOTA_EXHAUSTED";
 	}
 
@@ -157,5 +162,9 @@ export function isOpaqueStatusBody(message: string): boolean {
  * {@link isUsageLimitOutcome} uses it for the account-rotation decision.
  */
 export function matchesUsageLimitText(errorMessage: string): boolean {
-	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);
+	return (
+		USAGE_LIMIT_PATTERN.test(errorMessage) ||
+		ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage) ||
+		OPENROUTER_DAILY_FREE_LIMIT_PATTERN.test(errorMessage)
+	);
 }

--- a/packages/ai/test/auth-retry.test.ts
+++ b/packages/ai/test/auth-retry.test.ts
@@ -99,6 +99,26 @@ describe("withAuth", () => {
 		]);
 	});
 
+	it("switches credentials when OpenRouter exhausts the daily free-model allowance", async () => {
+		const keys: string[] = [];
+		const result = await withAuth(
+			ctx => (ctx.error === undefined || !ctx.lastChance ? "exhausted-key" : "healthy-key"),
+			async key => {
+				keys.push(key);
+				if (key === "healthy-key") return "success";
+				throw Object.assign(
+					new Error(
+						"429 Rate limit exceeded: free-models-per-day. Add 10 credits to unlock 1000 free model requests per day",
+					),
+					{ status: 429 },
+				);
+			},
+		);
+
+		expect(result).toBe("success");
+		expect(keys).toEqual(["exhausted-key", "healthy-key"]);
+	});
+
 	it("stops retrying when the resolver returns undefined", async () => {
 		const keys: string[] = [];
 		const original = authError();


### PR DESCRIPTION
## Repro
Added the reported OpenRouter `429 Rate limit exceeded: free-models-per-day` response to the `withAuth` regression scenario and ran `bun test packages/ai/test/auth-retry.test.ts`; before the fix it failed with 15 passing/1 failing because only `exhausted-key` was attempted and the 429 surfaced instead of selecting `healthy-key`.

## Cause
`isUsageLimitOutcome` in `packages/ai/src/error/rate-limit.ts` did not recognize OpenRouter's `free-models-per-day` reason code. `parseRateLimitReason` therefore matched the generic “rate limit” text first and classified the account's daily allowance exhaustion as transient, preventing `withAuth` from entering credential refresh/rotation.

## Fix
- Classify OpenRouter's `free-models-per-day` reason as quota exhaustion in both usage-limit detection and rate-limit reason parsing.
- Add contract-level coverage proving `withAuth` switches from the exhausted key to a healthy sibling.
- Document the fix in the AI package changelog.

## Verification
`bun test packages/ai/test/auth-retry.test.ts packages/ai/test/rate-limit-utils.test.ts` passes: 42 tests, 0 failures. A direct `withAuth` smoke scenario now attempts `['exhausted-key', 'healthy-key']` and returns `continued`. The pre-publish `bun run fix` and `bun check` gate passed during branch push.

Fixes #4832