### PR TITLE
fix(irc): prevent speculative model invocations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed models accidentally invoking IRC during ordinary single-agent work by limiting the model-facing contract to active peer coordination, identifying the caller's own IRC id, and removing speculative roster discovery and self-addressed examples ([#4831](https://github.com/can1357/oh-my-pi/issues/4831)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/prompts/tools/irc.md
+++ b/packages/coding-agent/src/prompts/tools/irc.md
@@ -1,7 +1,12 @@
-Send and receive short text messages between the agents running in this process.
+Coordinate with known peer agents during active multi-agent work.
+
+# Scope
+You MUST use IRC only when a `task` result names a peer, an IRC message arrives, or the user explicitly requests peer coordination.
+- Your IRC id: `{{selfId}}`. NEVER send messages to yourself.
+- Without a coordination trigger, you MUST use task-relevant tools; NEVER call `list`, `inbox`, or `wait` speculatively.
 
 # Addressing and Discovery
-The main agent is always `Main`. Subagents inherit their task ID (e.g., `AuthLoader`). If you don't know who is currently running, use `op: "list"` to view all peers alongside their status, unread message count, and recent activity. Address peers by their exact ID from the roster; NEVER invent names.
+The main agent id is `Main`; subagents inherit their task id (e.g., `AuthLoader`). Address peers by exact ids from task results or incoming messages; NEVER invent names. During active coordination, you MAY use `op: "list"` to recover a roster after ids become unavailable. NEVER use `list` to check whether peers exist.
 
 # Messaging Rules
 Use `op: "send"` to deliver a message to a specific peer or broadcast to `"all"`.
@@ -14,11 +19,11 @@ Use `op: "send"` to deliver a message to a specific peer or broadcast to `"all"`
 Messages only arrive when the peer actively sends one—do not interrogate a peer for status.
 - If you are completely blocked and MUST wait for an answer, use `op: "wait"` (or `await: true` on a send). The wait returns when a matching message arrives, the timeout elapses, or any IRC / steering message interrupts the wait. Parent-agent IRC interrupts with steering-level priority.
 - No need to alternate `irc wait`, `irc inbox`, and `job poll`: waits surface cross-channel interrupts promptly. The next turn includes the interrupt reason and message.
-- To check for messages without blocking, use `op: "inbox"` to drain your queue.
+- After an IRC notification, you MAY use `op: "inbox"` to drain queued messages without blocking.
 
 # When to Coordinate
-Message peers instead of guessing, duplicating work, or spying.
-- Use IRC when you hit an unexpected state (e.g., missing files) or an out-of-scope decision. DM `Main` or your spawner for guidance.
-- If you overlap with another agent's work or need a file they are touching, DM them before editing.
+During active coordination, message known peers instead of guessing, duplicating work, or spying.
+- If a known peer has context needed for an unexpected state or out-of-scope decision, you SHOULD message that peer.
+- Before editing overlapping work, you MUST message the known peer touching it.
 - NEVER use shell tools, grep, or read other sessions' files to figure out what a peer is doing. Message them directly.
 - NEVER use IRC for something a tool can answer (e.g., grepping codebase, running a build).

--- a/packages/coding-agent/src/tools/irc.ts
+++ b/packages/coding-agent/src/tools/irc.ts
@@ -93,54 +93,54 @@ export class IrcTool implements AgentTool<typeof ircSchema, IrcDetails> {
 	readonly name = "irc";
 	readonly approval = "read" as const;
 	readonly label = "IRC";
-	readonly summary = "Send and receive messages between agents";
+	readonly summary = "Coordinate with known peers during active multi-agent work";
 	readonly description: string;
 	readonly parameters = ircSchema;
 	readonly strict = true;
 	readonly interruptible = true;
 
-	readonly examples: readonly ToolExample<typeof ircSchema.infer>[] = [
-		{
-			caption: "List peers",
-			call: { op: "list" },
-		},
-		{
-			caption: "Fire-and-forget DM — same send wakes idle/parked peers",
-			call: {
-				op: "send",
-				to: "AuthLoader",
-				message: "Still touching src/server/auth.ts? I need to add a 401 path.",
-			},
-		},
-		{
-			caption: "Round-trip when you cannot proceed without the answer",
-			call: {
-				op: "send",
-				to: "Main",
-				message: "JWT or session cookies for the auth flow?",
-				await: true,
-			},
-		},
-		{
-			caption: "Block until a specific peer answers",
-			call: { op: "wait", from: "AuthLoader", timeoutMs: 60000 },
-		},
-		{
-			caption: "Drain pending messages",
-			call: { op: "inbox" },
-		},
-		{
-			caption: "Broadcast to live peers (no replies expected)",
-			call: {
-				op: "send",
-				to: "all",
-				message: "About to refactor src/server/middleware/*. Anyone already in there?",
-			},
-		},
-	];
+	readonly examples: readonly ToolExample<typeof ircSchema.infer>[];
 	readonly loadMode = "discoverable";
 	constructor(private readonly session: ToolSession) {
-		this.description = prompt.render(ircDescription);
+		const roundTripPeer = (session.taskDepth ?? 0) > 0 ? MAIN_AGENT_ID : "AuthLoader";
+		this.examples = [
+			{
+				caption: "Fire-and-forget DM to a known peer — same send wakes idle/parked peers",
+				call: {
+					op: "send",
+					to: "AuthLoader",
+					message: "Still touching src/server/auth.ts? I need to add a 401 path.",
+				},
+			},
+			{
+				caption: "Round-trip with a known peer when you cannot proceed without the answer",
+				call: {
+					op: "send",
+					to: roundTripPeer,
+					message: "JWT or session cookies for the auth flow?",
+					await: true,
+				},
+			},
+			{
+				caption: "Block until a known peer answers",
+				call: { op: "wait", from: "AuthLoader", timeoutMs: 60000 },
+			},
+			{
+				caption: "Drain pending messages after an IRC notification",
+				call: { op: "inbox" },
+			},
+			{
+				caption: "Broadcast to known live peers (no replies expected)",
+				call: {
+					op: "send",
+					to: "all",
+					message: "About to refactor src/server/middleware/*. Anyone already in there?",
+				},
+			},
+		];
+		this.description = prompt.render(ircDescription, {
+			selfId: session.getAgentId?.() ?? "this agent",
+		});
 	}
 
 	static createIf(session: ToolSession): IrcTool | null {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -410,6 +410,22 @@ describe("IRC", () => {
 			expect(IrcTool.createIf(session)).toBeNull();
 		});
 
+		it("does not advertise speculative discovery or self-addressed sends to the model", () => {
+			const tool = new IrcTool(makeToolSession(registry, "Main"));
+
+			expect(tool.summary).toContain("known peers");
+			expect(tool.description).toContain("Your IRC id: `Main`");
+			expect(tool.description).toContain("NEVER call `list`, `inbox`, or `wait` speculatively");
+			expect(tool.description).not.toContain("DM `Main`");
+			for (const example of tool.examples) {
+				if (!("call" in example)) continue;
+				expect(example.call.op).not.toBe("list");
+				if (example.call.op === "send") {
+					expect(example.call.to).not.toBe("Main");
+				}
+			}
+		});
+
 		it("op=list includes parked peers, unread counts, and parent ids", async () => {
 			const sub = makeFakeSession();
 			registry.register({


### PR DESCRIPTION
## Repro
Render the live model-facing IRC contract with `bun .omp/skills/tool-prompt-optimization/scripts/probe-builtin.ts --tool irc --show`; before this fix it unconditionally instructed models with an unknown roster to call `op: "list"`, and the injected examples led with roster discovery plus a send addressed to `Main` even when the caller was `Main`.

## Cause
`packages/coding-agent/src/prompts/tools/irc.md` treated missing peer knowledge as a reason to invoke IRC and told every caller to DM `Main`; `IrcTool.examples` in `packages/coding-agent/src/tools/irc.ts` reinforced those paths without accounting for the caller's identity or whether multi-agent coordination had begun.

## Fix
- Scope IRC usage to explicit coordination triggers and render the caller's IRC id into the tool contract.
- Restrict roster, inbox, and wait operations to active coordination instead of speculative discovery.
- Remove the roster example and choose a non-self round-trip peer for top-level callers.
- Add regression coverage for speculative operations and self-addressed model examples.
- Document the fix under the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/irc.test.ts` passes: 41 tests, 0 failures, 138 assertions. The live prompt smoke command above renders the caller id and the new active-coordination guard. The pre-publish `bun run fix` and `bun check` gate passed during branch publication. Fixes #4831