### PR TITLE
fix(tui): restore file references after slash commands

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored `@` file-reference completions after slash commands that do not provide argument completions ([#4852](https://github.com/can1357/oh-my-pi/issues/4852)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -429,28 +429,21 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// path (`/tmp/fo` at prompt start, `see /tmp` mid-prompt); fall
 				// through to file-path completion.
 			} else if (!isMidPromptSkillLookup) {
-				// Submitted slash commands own their argument text only when the
-				// matched command accepts args. No-arg slash-looking prompts such
-				// as `/settings @file` still fall through to prompt-composer
-				// completions because submit treats them as normal prompt text.
+				// Slash commands own their argument text only when they provide
+				// context-specific completions. Otherwise prompt-composer
+				// completions handle the trailing token.
 				const commandName = commandText.slice(1, spaceIndex); // Command without "/"
 				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
 				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
-				if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
-					if (!("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
-						return null; // No argument completion for this command
-					}
-
+				if (command && "getArgumentCompletions" in command && command.getArgumentCompletions) {
 					const argumentSuggestions = await command.getArgumentCompletions(argumentText);
-					if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
-						return null;
+					if (Array.isArray(argumentSuggestions) && argumentSuggestions.length > 0) {
+						return {
+							items: argumentSuggestions,
+							prefix: argumentText,
+						};
 					}
-
-					return {
-						items: argumentSuggestions,
-						prefix: argumentText,
-					};
 				}
 			}
 		}

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -119,7 +119,7 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(result?.items.map(item => item.value)).toContain("/tmp/");
 		});
 
-		it("treats @ file-reference tokens as literal text inside slash command arguments without completions", async () => {
+		it("falls through to @ file-reference completions for slash commands without argument completions", async () => {
 			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-rename-args-"));
 			try {
 				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
@@ -130,7 +130,26 @@ describe("CombinedAutocompleteProvider", () => {
 				const line = "/rename repro @";
 				const result = await provider.getSuggestions([line], 0, line.length);
 
-				expect(result).toBeNull();
+				expect(result?.prefix).toBe("@");
+				expect(result?.items.map(item => item.value)).toContain("@copy-target.ts");
+			} finally {
+				fs.rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
+
+		it("returns @ file-reference completions for slash commands that omit allowArgs", async () => {
+			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-undefined-args-"));
+			try {
+				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
+				const provider = new CombinedAutocompleteProvider(
+					[{ name: "hotkeys", description: "Show keyboard shortcuts" }],
+					baseDir,
+				);
+				const line = "/hotkeys @";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result?.prefix).toBe("@");
+				expect(result?.items.map(item => item.value)).toContain("@copy-target.ts");
 			} finally {
 				fs.rmSync(baseDir, { recursive: true, force: true });
 			}


### PR DESCRIPTION
## Repro
Typing `/rename repro @` with a slash command that accepts arguments but does not define `getArgumentCompletions` returns no suggestions instead of opening the file-reference picker. Reproduced with `bun test packages/tui/test/autocomplete.test.ts --test-name-pattern 'treats @ file-reference tokens as literal text inside slash command arguments without completions'`, whose prior regression-lock assertion expected `null`.

## Cause
`CombinedAutocompleteProvider.getSuggestions` in `packages/tui/src/autocomplete.ts` returned `null` from the slash-command argument branch when a matched command omitted `getArgumentCompletions` or returned no items. That early return prevented the later `@` file-reference and path-completion branches from examining the trailing token.

## Fix
- Let slash commands consume argument text only when `getArgumentCompletions` returns suggestions; otherwise fall through to prompt-composer completion.
- Cover both explicit `allowArgs: true` and omitted `allowArgs` slash commands with file-reference regression tests.
- Record the restored behavior in the TUI changelog.

## Verification
`bun test packages/tui/test/autocomplete.test.ts` — 51 passed, 0 failed, 106 assertions. The pre-publish `bun run fix` and `bun check` gate also passed. Fixes #4852