### PR TITLE
fix: add /clear as alias for /new to prevent fuzzy-match to /autoresearch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `/clear` as an alias for `/new` so that typing `/clear` starts a new session instead of fuzzy-matching to `/autoresearch` ([#5349](https://github.com/can1357/oh-my-pi/issues/5349)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1384,6 +1384,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "new",
+		aliases: ["clear"],
 		description: "Start a new session",
 		handleTui: async (_command, runtime) => {
 			runtime.ctx.editor.setText("");

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -800,6 +800,22 @@ describe("trySyncSlashCompletion", () => {
 		expect(result!.items[0]?.value).toBe("providers");
 	});
 
+	it("/clear alias resolves to /new instead of fuzzy-matching /autoresearch description (#5349)", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "new", aliases: ["clear"], description: "Start a new session" },
+				{
+					name: "autoresearch",
+					description: "Toggle builtin autoresearch mode, or pass off / clear, or a goal message.",
+				},
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/clear");
+		expect(result).not.toBeNull();
+		expect(result!.items[0]?.value).toBe("clear");
+	});
+
 	it("uses aliases when completing slash command arguments", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[


### PR DESCRIPTION
## Problem

When a user types `/clear` in the TUI input, the fuzzy autocomplete matches it to `/autoresearch` instead of `/new`. This happens because:

1. `/new` gets a fuzzy score of **0** against "clear" (no character overlap)
2. `/autoresearch` gets a description match score of **30** because its description literally contains the word "clear": *"...pass off / **clear**, or a goal message."*

Since `/new` scores 0, the sync completion path picks `/autoresearch` as the top match.

Fixes #5349.

## Solution

Add `aliases: ["clear"]` to the `/new` command definition. The alias mechanism already exists and is proven to work — several commands use it (`/setup` → `providers`, `/model` → `models`, etc.).

With the alias, `scoreCommandTextMatch("clear", "clear")` returns **1000** (exact match), which decisively beats the autoresearch description score of 30.

## Changes

| File | Change |
|------|--------|
| `packages/coding-agent/src/slash-commands/builtin-registry.ts` | Add `aliases: ["clear"]` to `/new` command |
| `packages/tui/test/autocomplete.test.ts` | Add regression test for the exact `/clear` → `/new` vs `/autoresearch` scenario |
| `packages/coding-agent/CHANGELOG.md` | Add entry under `[Unreleased]` |

## Testing

- Added a regression test that creates a `CombinedAutocompleteProvider` with `/new` (alias `clear`) and `/autoresearch`, then verifies `trySyncSlashCompletion("/clear")` returns `clear` as the top item.
- The existing test at line 790 ("prefers exact command aliases over fuzzy description matches") already proves the alias-scoring mechanism works.
- Verified the scoring math independently: alias score 1000 > autoresearch desc score 30.

## Notes for Reviewer

- This is a minimal, single-line code change in `builtin-registry.ts`.
- The `BUILTIN_SLASH_COMMAND_LOOKUP` map already indexes aliases (lines 2322-2328), so dispatch-time routing works automatically.
- Windows users are most affected by this bug due to muscle-memory from other coding agents where `/clear` starts a new session.