### PR TITLE
fix(tui): bound retained transcript render memory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Released finalized transcript blocks after their rendered rows enter native scrollback, bounding resumed-session render state to the live tail and attributing transcript, Markdown, context-build, and compaction-check event-loop stalls to concrete phases ([#4820](https://github.com/can1357/oh-my-pi/issues/4820)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -3,9 +3,11 @@ import {
 	Container,
 	type NativeScrollbackCommittedRows,
 	type NativeScrollbackLiveRegion,
+	type NativeScrollbackRowRetirement,
 	type RenderStablePrefix,
 	type ViewportTailProvider,
 } from "@oh-my-pi/pi-tui";
+import { popLoopPhase, pushLoopPhase } from "@oh-my-pi/pi-utils";
 
 /**
  * A transcript block that is still mutating (a foreground tool awaiting its
@@ -126,17 +128,22 @@ const EMPTY_TAIL: readonly string[] = [];
  * a late tool result, a post-finalize error pin, or an expand toggle is
  * always reflected on screen while it remains in the window.
  *
- * Assembly is incremental: the returned array is persistent and mutated in
- * place. Each block's render is still called every frame, but a block whose
- * render returned the same array reference at an unchanged offset reuses its
- * previously assembled rows; the array is truncated and re-pushed only from
- * the first divergent block. The leading byte-identical row count is reported
- * through {@link RenderStablePrefix} so the engine can skip marker scanning,
- * line preparation, and the committed-prefix audit for those rows.
+ * Assembly is incremental and bounded to the retained tail. Each block's
+ * render is still called while it remains live, but finalized leading blocks
+ * are released once every row they contributed has entered native scrollback.
+ * Within the retained tail, the returned array is persistent and only the
+ * first divergent suffix is rebuilt. The leading byte-identical row count is
+ * reported through {@link RenderStablePrefix} so the engine can skip marker
+ * scanning, line preparation, and committed-prefix audits for those rows.
  */
 export class TranscriptContainer
 	extends Container
-	implements NativeScrollbackLiveRegion, NativeScrollbackCommittedRows, RenderStablePrefix, ViewportTailProvider
+	implements
+		NativeScrollbackLiveRegion,
+		NativeScrollbackCommittedRows,
+		NativeScrollbackRowRetirement,
+		RenderStablePrefix,
+		ViewportTailProvider
 {
 	// Bumped to retire every block segment at once (theme change / clear); a
 	// segment is only reused when its stored generation matches.
@@ -154,6 +161,10 @@ export class TranscriptContainer
 	// Finalized blocks wholly before this boundary are immutable on-screen history;
 	// their previous contribution can be replayed without calling render().
 	#committedRows = 0;
+	// A retired prefix still exists immediately above this retained frame in
+	// native scrollback. Preserve the one-row inter-block separator at the seam.
+	#hasRetiredPrefix = false;
+	#retiredRowsPending = 0;
 	// Stable-prefix floor accumulated across renders since the last
 	// getRenderStablePrefixRows() read (see RenderStablePrefix: reading
 	// consumes the report and re-bases the baseline). Out-of-band renders
@@ -168,11 +179,62 @@ export class TranscriptContainer
 
 	override clear(): void {
 		this.#generation++;
+		this.#hasRetiredPrefix = false;
+		this.#retiredRowsPending = 0;
 		super.clear();
 	}
 
 	setNativeScrollbackCommittedRows(rows: number): void {
-		this.#committedRows = Number.isFinite(rows) ? Math.max(0, Math.trunc(rows)) : 0;
+		const committedRows = Number.isFinite(rows) ? Math.max(0, Math.trunc(rows)) : 0;
+		const segmentCount = Math.min(this.#segments.length, this.children.length);
+		let removeCount = 0;
+		let retiredRows = 0;
+		// Keep at least the last block: it anchors the visible tail even when a
+		// zero-height/transition frame temporarily reports the whole transcript
+		// committed. Every removed block must be both currently finalized and
+		// represented by a finalized render wholly inside native scrollback.
+		while (removeCount < segmentCount - 1) {
+			const segment = this.#segments[removeCount]!;
+			const child = this.children[removeCount]!;
+			if (
+				segment.component !== child ||
+				!segment.finalized ||
+				!isBlockFinalized(child) ||
+				segment.startRow + segment.rowCount > committedRows
+			) {
+				break;
+			}
+			retiredRows = segment.startRow + segment.rowCount;
+			removeCount++;
+		}
+		if (removeCount === 0) {
+			this.#committedRows = committedRows;
+			return;
+		}
+
+		for (let i = 0; i < removeCount; i++) this.children[i]!.dispose?.();
+		this.children.copyWithin(0, removeCount);
+		this.children.length -= removeCount;
+		this.#lines.copyWithin(0, retiredRows);
+		this.#lines.length -= retiredRows;
+		this.#segments.copyWithin(0, removeCount);
+		this.#segments.length -= removeCount;
+		for (const segment of this.#segments) segment.startRow -= retiredRows;
+
+		this.#hasRetiredPrefix ||= retiredRows > 0;
+		this.#committedRows = Math.max(0, committedRows - retiredRows);
+		this.#stableRowsFloor = Math.max(0, this.#stableRowsFloor - retiredRows);
+		if (this.#nativeScrollbackLiveRegionStart !== undefined) {
+			this.#nativeScrollbackLiveRegionStart = Math.max(0, this.#nativeScrollbackLiveRegionStart - retiredRows);
+		}
+		this.#retiredRowsPending += retiredRows;
+	}
+
+	/** Consume the leading-row retirement produced by the last commit update. */
+	takeNativeScrollbackRetiredRows(): number {
+		const retiredRows = this.#retiredRowsPending;
+		this.#retiredRowsPending = 0;
+		return retiredRows;
 	}
 
 	getRenderStablePrefixRows(): number {
@@ -270,6 +332,15 @@ export class TranscriptContainer
 	}
 
 	override render(width: number): readonly string[] {
+		pushLoopPhase("ui.transcript-render");
+		try {
+			return this.#render(width);
+		} finally {
+			popLoopPhase();
+		}
+	}
+
+	#render(width: number): readonly string[] {
 		width = Math.max(1, width);
 		this.#nativeScrollbackLiveRegionStart = undefined;
 
@@ -386,11 +457,11 @@ export class TranscriptContainer
 			}
 
 			// Every block is separated from preceding visible content by exactly one
-			// blank row — skipped when it opens the transcript or the prior row is
-			// already a plain blank (a fragment's own trailing pad), never doubling.
-			// `lines[row - 1]` is valid in both modes: reused rows are still present
-			// in the persistent array, re-pushed rows were just written.
-			const sep = row > 0 && !isPlainBlank(lines[row - 1]!) ? 1 : 0;
+			// blank row — skipped only when it opens a brand-new transcript or the
+			// prior retained row is already blank. After prefix retirement, native
+			// scrollback owns preceding content, so the retained tail keeps its
+			// boundary separator even though its local row index starts at zero.
+			const sep = (row > 0 && !isPlainBlank(lines[row - 1]!)) || (row === 0 && this.#hasRetiredPrefix) ? 1 : 0;
 
 			// The separator before the first live block stays in the committed
 			// prefix (it is deterministic once the prior block's body is

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1023,15 +1023,16 @@ export class InteractiveMode implements InteractiveModeContext {
 				clearMermaidCache();
 				this.ui.invalidate();
 				this.updateEditorBorderColor();
-				if (event.ephemeral || isInsideTerminalMultiplexer()) {
-					// Theme previews and multiplexer panes cannot safely replace native
-					// scrollback: previews must stay non-destructive, and multiplexers
-					// suppress ED3 so a forced replay would duplicate transcript history.
+				if (event.ephemeral || isInsideTerminalMultiplexer() || this.ui.hasRetiredNativeScrollback) {
+					// Theme previews, multiplexer panes, and sessions whose old rows
+					// now live only in terminal-owned scrollback cannot safely replace
+					// native history. Repaint the retained viewport without ED3;
+					// retired rows keep the palette they had when committed.
 					this.ui.requestRender();
 					return;
 				}
-				// Rows already committed to native scrollback are immutable; replay them
-				// after a theme swap so a reader scrolled up sees the same palette.
+				// A fully retained transcript can be replayed so committed history
+				// receives the new palette.
 				this.ui.requestRender(true, { clearScrollback: true });
 			}),
 		);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -131,8 +131,10 @@ import {
 	isBunTestRuntime,
 	isEnoent,
 	logger,
+	popLoopPhase,
 	postmortem,
 	prompt,
+	pushLoopPhase,
 	relativePathWithinRoot,
 	Snowflake,
 	withTimeout,
@@ -10450,7 +10452,13 @@ export class AgentSession {
 		const assistantUsageContextTokens = assistantPredatesCompaction
 			? 0
 			: calculateContextTokens(assistantMessage.usage);
-		const storedContextTokens = this.#estimateStoredContextTokens();
+		let storedContextTokens: number;
+		pushLoopPhase("session.compaction-check");
+		try {
+			storedContextTokens = this.#estimateStoredContextTokens();
+		} finally {
+			popLoopPhase();
+		}
 		// Pruning frees bytes for the NEXT prompt; it does not change the size of
 		// the prompt the LLM just billed for. Earlier revisions subtracted the
 		// per-turn supersede/prune `tokensSaved` from the threshold input, which

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -15,6 +15,8 @@ import {
 	getSessionsDir,
 	isEnoent,
 	logger,
+	popLoopPhase,
+	pushLoopPhase,
 	toError,
 } from "@oh-my-pi/pi-utils";
 import { ArtifactManager } from "./artifacts";
@@ -1681,7 +1683,12 @@ export class SessionManager {
 	 * the full-history display transcript, from the current leaf path.
 	 */
 	buildSessionContext(options?: BuildSessionContextOptions): SessionContext {
-		return buildSessionContext(this.#entries, this.#index.leafId(), this.#index.entriesById(), options);
+		pushLoopPhase("session.context-build");
+		try {
+			return buildSessionContext(this.#entries, this.#index.leafId(), this.#index.entriesById(), options);
+		} finally {
+			popLoopPhase();
+		}
 	}
 
 	/** Strip stale OpenAI Responses assistant replay metadata from loaded entries. */

--- a/packages/coding-agent/test/modes/components/transcript-container.test.ts
+++ b/packages/coding-agent/test/modes/components/transcript-container.test.ts
@@ -7,6 +7,7 @@ import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { type Component, Text } from "@oh-my-pi/pi-tui";
+import { takeRecentLoopPhase } from "@oh-my-pi/pi-utils";
 
 // Models a transcript block that re-lays-out (tool preview collapsing, assistant
 // message finalizing, late async result) after newer blocks were appended below
@@ -164,6 +165,16 @@ function plain(lines: readonly string[]): string {
 }
 
 describe("TranscriptContainer", () => {
+	it("attributes synchronous render work to the transcript phase", () => {
+		takeRecentLoopPhase();
+		const container = new TranscriptContainer();
+		container.addChild(new Text("history"));
+
+		container.render(40);
+
+		expect(takeRecentLoopPhase()).toBe("ui.transcript-render");
+	});
+
 	it("always renders a block's current content, even after newer blocks append below it", () => {
 		const container = new TranscriptContainer();
 		const a = new MutableBlock(["a1"]);
@@ -348,7 +359,7 @@ describe("TranscriptContainer", () => {
 		expect(container.render(40)).toEqual(["history", "", "live", "", "finalized-below-0", "finalized-below-1"]);
 		expect(container.getNativeScrollbackLiveRegionStart()).toBe(2);
 	});
-	it("does not re-render finalized rows already committed to native scrollback", () => {
+	it("retires finalized leading blocks after their rows enter native scrollback", () => {
 		const container = new TranscriptContainer();
 		const committed = new CountingFinalizedBlock(["committed"]);
 		const liveTail = new CountingFinalizedBlock(["tail"]);
@@ -360,13 +371,16 @@ describe("TranscriptContainer", () => {
 		expect(liveTail.renderCount).toBe(1);
 
 		container.setNativeScrollbackCommittedRows(1);
-		expect(container.render(40)).toEqual(["committed", "", "tail"]);
+		expect(container.takeNativeScrollbackRetiredRows()).toBe(1);
+		expect(container.children).toEqual([liveTail]);
+		expect(container.render(40)).toEqual(["", "tail"]);
 		expect(committed.renderCount).toBe(1);
 		expect(liveTail.renderCount).toBe(2);
 
 		container.invalidate();
-		expect(container.render(40)).toEqual(["committed", "", "tail"]);
-		expect(committed.renderCount).toBe(2);
+		expect(container.render(40)).toEqual(["", "tail"]);
+		expect(committed.renderCount).toBe(1);
+		expect(liveTail.renderCount).toBe(3);
 	});
 	it("re-renders a committed finalized block when its version changes", () => {
 		const container = new TranscriptContainer();
@@ -409,11 +423,12 @@ describe("TranscriptContainer", () => {
 		expect(container.render(40)).toEqual(["streaming", "done", "", "tail"]);
 		expect(block.renderCount).toBe(rendersBeforeTransition + 1);
 
-		// The post-finalize render is now trustworthy history: once its rows are
-		// committed, the bypass replays it without calling render().
+		// Once its final bytes are committed, the whole leading block is retired;
+		// only the separator and retained tail remain in the JS render surface.
 		container.setNativeScrollbackCommittedRows(2);
+		expect(container.takeNativeScrollbackRetiredRows()).toBe(2);
 		const rendersAfterTransition = block.renderCount;
-		expect(container.render(40)).toEqual(["streaming", "done", "", "tail"]);
+		expect(container.render(40)).toEqual(["", "tail"]);
 		expect(block.renderCount).toBe(rendersAfterTransition);
 	});
 	it("reports a new assistant block version after post-finalize error unpinning", () => {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bounded retained render memory by weighting the shared Markdown cache by approximate bytes and allowing native-scrollback-aware components to release committed frame rows without losing terminal-owned history ([#4820](https://github.com/can1357/oh-my-pi/issues/4820)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1,3 +1,4 @@
+import { popLoopPhase, pushLoopPhase } from "@oh-my-pi/pi-utils";
 import { LRUCache } from "lru-cache/raw";
 import { Marked, type Token, Tokenizer, type TokenizerAndRendererExtension, type Tokens } from "marked";
 import { latexToBlock } from "../latex-block";
@@ -452,9 +453,22 @@ markdownParser.use({ extensions: [customHrExtension, mathBlockExtension, mathEnv
 // component lifetimes and eliminates redundant marked.lexer + highlightCode
 // (Rust FFI) work for content/layout combinations already seen this session.
 
-const RENDER_CACHE_MAX = 256; // sane cap: ~256 distinct message × width combos
+const RENDER_CACHE_MAX = 256;
+const RENDER_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+const RENDER_CACHE_MAX_ENTRY_BYTES = 512 * 1024;
 const EMPTY_RENDER_LINES: readonly string[] = [];
-const renderCache = new LRUCache<string, readonly string[]>({ max: RENDER_CACHE_MAX });
+const renderCache = new LRUCache<string, readonly string[]>({
+	max: RENDER_CACHE_MAX,
+	maxSize: RENDER_CACHE_MAX_BYTES,
+	maxEntrySize: RENDER_CACHE_MAX_ENTRY_BYTES,
+	// Approximate retained UTF-16 storage for both the source-bearing key and
+	// rendered rows, plus one pointer per row. Oversized renders bypass L2.
+	sizeCalculation: (lines, key) => {
+		let bytes = key.length * 2 + lines.length * 8;
+		for (const line of lines) bytes += line.length * 2;
+		return Math.max(1, bytes);
+	},
+});
 
 // A reference-link definition (`[label]: dest`) resolves across the whole
 // document, so a split lex cannot reproduce it — disable the streaming fast path
@@ -986,6 +1000,15 @@ export class Markdown implements Component {
 	}
 
 	render(width: number): readonly string[] {
+		pushLoopPhase("ui.markdown-render");
+		try {
+			return this.#render(width);
+		} finally {
+			popLoopPhase();
+		}
+	}
+
+	#render(width: number): readonly string[] {
 		// L1: per-instance cache — fastest path for repeated renders of the same
 		// instance at the same width (e.g. resize debounce, repeated redraws).
 		// Returning the cached reference is load-bearing: parents memoize their

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -203,12 +203,26 @@ export interface NativeScrollbackLiveRegion {
 	getNativeScrollbackLiveRegionStart(): number | undefined;
 }
 
+/** Receives the component-local prefix already committed to native scrollback. */
 export interface NativeScrollbackCommittedRows {
 	setNativeScrollbackCommittedRows(rows: number): void;
 }
 
-function setNativeScrollbackCommittedRows(component: Component, rows: number): void {
-	(component as Component & Partial<NativeScrollbackCommittedRows>).setNativeScrollbackCommittedRows?.(rows);
+/**
+ * Lets a component report leading rows it released after receiving the
+ * committed-row boundary. Reading consumes the report.
+ */
+export interface NativeScrollbackRowRetirement {
+	takeNativeScrollbackRetiredRows(): number;
+}
+
+function setNativeScrollbackCommittedRows(component: Component, rows: number): number {
+	const committed = component as Component &
+		Partial<NativeScrollbackCommittedRows> &
+		Partial<NativeScrollbackRowRetirement>;
+	committed.setNativeScrollbackCommittedRows?.(rows);
+	const retired = committed.takeNativeScrollbackRetiredRows?.();
+	return typeof retired === "number" && Number.isFinite(retired) ? Math.max(0, Math.trunc(retired)) : 0;
 }
 
 function isOverlayFocusTarget(owner: Component, component: Component | null): boolean {
@@ -965,6 +979,10 @@ export class TUI extends Container {
 	// references to component-cached strings, so the audit is a pointer walk
 	// in the common case.
 	#committedPrefix: string[] = [];
+	// Rows released from the retained frame after entering native scrollback.
+	// While non-zero, geometry changes must preserve terminal-owned history
+	// instead of clearing and replaying an intentionally incomplete frame.
+	#retiredNativeRows = 0;
 	// Rows of the committed prefix that were HARD-VERIFIED as exact-final
 	// bytes (committed below the exactness boundary, or frozen snapshots that
 	// passed the one-time strict scan when the boundary rose past them). Rows
@@ -1129,10 +1147,27 @@ export class TUI extends Container {
 				liveLocalStart = previous.liveLocalStart;
 			} else {
 				// Feed the engine's committed-row claim (from the previous frame's
-				// emit) before rendering so the child can skip re-deriving blocks
-				// that already live in immutable native scrollback. Reused segments
-				// skip this: they never call render(), so the signal is moot.
-				setNativeScrollbackCommittedRows(child, Math.max(0, this.#committedRows - offset));
+				// emit) before rendering so the child can skip or retire blocks
+				// that already live in immutable native scrollback. A retiring child
+				// reports the number of leading local rows it released; mirror that
+				// cut through every root-frame cache before composing its tail.
+				const retiredRows = setNativeScrollbackCommittedRows(child, Math.max(0, this.#committedRows - offset));
+				if (retiredRows > 0) {
+					if (
+						previous === undefined ||
+						previous.component !== child ||
+						previous.start !== offset ||
+						retiredRows > previous.rowCount ||
+						retiredRows > this.#committedRows - offset
+					) {
+						throw new Error("Component retired rows outside its previously composed committed prefix");
+					}
+					this.#retireComposedRows(offset, retiredRows);
+					previous.rowCount -= retiredRows;
+					for (let later = index + 1; later < previousSegments.length; later++) {
+						previousSegments[later]!.start -= retiredRows;
+					}
+				}
 				childLines = child.render(width);
 				const liveRegionStart = getNativeScrollbackLiveRegionStart(child);
 				if (liveRegionStart !== undefined) {
@@ -1210,6 +1245,58 @@ export class TUI extends Container {
 		return frame;
 	}
 
+	/** Release a component-retired range from every row-aligned frame ledger. */
+	#retireComposedRows(from: number, count: number): void {
+		const to = from + count;
+		this.#composedFrame.splice(from, count);
+		this.#preparedFrame.splice(from, count);
+		this.#preparedMeta.splice(from, count);
+		this.#committedPrefix.splice(from, count);
+		this.#committedRows -= count;
+		const auditedInRange = Math.max(0, Math.min(count, this.#committedPrefixAuditRows - from));
+		this.#committedPrefixAuditRows -= auditedInRange;
+		if (this.#windowTopRow >= to) {
+			this.#windowTopRow -= count;
+		} else if (this.#windowTopRow > from) {
+			this.#windowTopRow = from;
+		}
+		this.#previousFrameLength = Math.max(0, this.#previousFrameLength - count);
+		if (this.#hardwareCursorRow >= to) {
+			this.#hardwareCursorRow -= count;
+		} else if (this.#hardwareCursorRow > from) {
+			this.#hardwareCursorRow = from;
+		}
+		if (this.#hardwareCursorState) {
+			const row =
+				this.#hardwareCursorState.row >= to
+					? this.#hardwareCursorState.row - count
+					: Math.min(this.#hardwareCursorState.row, from);
+			this.#hardwareCursorState = { ...this.#hardwareCursorState, row };
+		}
+		for (let i = this.#frameCursorMarkers.length - 1; i >= 0; i--) {
+			const marker = this.#frameCursorMarkers[i]!;
+			if (marker.row < from) continue;
+			if (marker.row < to) {
+				this.#frameCursorMarkers.splice(i, 1);
+			} else {
+				marker.row -= count;
+			}
+		}
+		if (this.#nativeScrollbackLiveRegionStart !== undefined) {
+			this.#nativeScrollbackLiveRegionStart =
+				this.#nativeScrollbackLiveRegionStart >= to
+					? this.#nativeScrollbackLiveRegionStart - count
+					: Math.min(this.#nativeScrollbackLiveRegionStart, from);
+		}
+		if (this.#renderStablePrefixRows > from) {
+			this.#renderStablePrefixRows -= Math.min(count, this.#renderStablePrefixRows - from);
+		}
+		if (this.#preparedValidRows > from) {
+			this.#preparedValidRows -= Math.min(count, this.#preparedValidRows - from);
+		}
+		this.#retiredNativeRows += count;
+	}
+
 	/** Drop cached cursor markers at/after `fromRow` (those rows re-ingest). */
 	#pruneFrameCursorMarkers(fromRow: number): void {
 		const markers = this.#frameCursorMarkers;
@@ -1263,6 +1350,11 @@ export class TUI extends Container {
 	/** Whether a non-multiplexer resize drag is currently in flight. */
 	get resizeViewportActive(): boolean {
 		return this.#resizeViewportActive;
+	}
+
+	/** Whether this TUI has released rows now owned only by native scrollback. */
+	get hasRetiredNativeScrollback(): boolean {
+		return this.#retiredNativeRows > 0;
 	}
 
 	/** Shared budget that caps how many inline images render as live graphics. */
@@ -1474,10 +1566,12 @@ export class TUI extends Container {
 				// `#resizeEventPending` is set first so the eventual render still
 				// classifies as a resize.
 				this.#resizeEventPending = true;
-				if (!resizeRepaintsInPlace()) {
-					// Enter the viewport fast path and (re)arm the settle timer, then
-					// request the cheap viewport-only paint. The authoritative full
-					// replay fires from the settle timer once the drag goes quiet.
+				if (!resizeRepaintsInPlace() && this.#retiredNativeRows === 0) {
+					// A fully retained frame can use the alternate-screen viewport
+					// fast path and replay authoritatively after the drag. Once rows
+					// live only in native scrollback, keep the normal buffer active
+					// and use the in-place debounced path below so terminal-owned
+					// history survives the resize.
 					this.#beginResizeViewport();
 					this.#requestResizeViewportPaint();
 					return;
@@ -2686,7 +2780,7 @@ export class TUI extends Container {
 		// feedback loop), so committed history keeps its old wrap.
 		const firstPaint = !this.#hasEverRendered;
 		const replaceRequested = this.#clearScrollbackOnNextRender;
-		const geometryRebuild = geometryChanged && !resizeRepaintsInPlace();
+		const geometryRebuild = geometryChanged && !resizeRepaintsInPlace() && this.#retiredNativeRows === 0;
 		const fullPaint = firstPaint || replaceRequested || geometryRebuild;
 		let windowTop: number;
 		let chunkTo: number;
@@ -3268,6 +3362,7 @@ export class TUI extends Container {
 				};
 
 		this.#committedRows = chunkTo;
+		if (options.clearScrollback) this.#retiredNativeRows = 0;
 		this.#windowTopRow = windowTop;
 		this.#commit(frame, window, width, height, committedCursor);
 	}
@@ -3292,7 +3387,9 @@ export class TUI extends Container {
 			// rebuild — ED3 + full history — and the clearScrollback intent below
 			// matches the gesture-driven reset path.
 			this.#resizeEventPending = true;
-			this.requestRender(true, { clearScrollback: !isMultiplexerSession() });
+			this.requestRender(true, {
+				clearScrollback: !isMultiplexerSession() && this.#retiredNativeRows === 0,
+			});
 		}, TUI.#RESIZE_VIEWPORT_SETTLE_MS);
 	}
 

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -4,6 +4,7 @@ import { clearRenderCache, Markdown, renderInlineMarkdown } from "@oh-my-pi/pi-t
 import { setTerminalTextSizing, TERMINAL } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import { type Component, TUI } from "@oh-my-pi/pi-tui/tui";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
+import { takeRecentLoopPhase } from "@oh-my-pi/pi-utils";
 import { Chalk } from "chalk";
 import { defaultMarkdownTheme } from "./test-themes.js";
 import { VirtualTerminal } from "./virtual-terminal.js";
@@ -1317,6 +1318,14 @@ describe("Inline color swatches", () => {
 });
 
 describe("Module-level LRU render cache", () => {
+	it("attributes synchronous render work to the Markdown phase", () => {
+		takeRecentLoopPhase();
+
+		new Markdown("phase probe", 0, 0, defaultMarkdownTheme).render(80);
+
+		expect(takeRecentLoopPhase()).toBe("ui.markdown-render");
+	});
+
 	it("invokes highlightCode only once for two distinct instances with identical (text, width, theme)", () => {
 		// Build a theme with a spy on highlightCode. The theme object reference
 		// is stable across both instances so objectId() returns the same ID,
@@ -1363,6 +1372,15 @@ describe("Module-level LRU render cache", () => {
 		// cache entry — same reference, not just equal content.
 		const l2Markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
 		expect(l2Markdown.render(width)).toBe(first);
+	});
+
+	it("does not retain an oversized rendered entry in the shared cache", () => {
+		clearRenderCache();
+		const text = "x".repeat(300 * 1024);
+		const first = new Markdown(text, 0, 0, defaultMarkdownTheme).render(80);
+		const second = new Markdown(text, 0, 0, defaultMarkdownTheme).render(80);
+
+		expect(second).not.toBe(first);
 	});
 
 	it("skips code-block highlighting for transient streaming renders", () => {

--- a/packages/tui/test/streaming-scrollback-defer.test.ts
+++ b/packages/tui/test/streaming-scrollback-defer.test.ts
@@ -3,6 +3,7 @@ import {
 	type Component,
 	type NativeScrollbackCommittedRows,
 	type NativeScrollbackLiveRegion,
+	type NativeScrollbackRowRetirement,
 	TUI,
 } from "@oh-my-pi/pi-tui";
 import { VirtualTerminal } from "./virtual-terminal";
@@ -77,6 +78,36 @@ class CommittedRowsProbe extends SeamLineList implements NativeScrollbackCommitt
 	override render(width: number): string[] {
 		this.committedRowsAtRender.push(this.#committedRows);
 		return super.render(width);
+	}
+}
+
+/** Drops committed leading rows while retaining a four-row live tail. */
+class RetiringRowsProbe implements Component, NativeScrollbackCommittedRows, NativeScrollbackRowRetirement {
+	#lines: string[];
+	#retiredRowsPending = 0;
+	retiredRows = 0;
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	setNativeScrollbackCommittedRows(rows: number): void {
+		const count = Math.min(Math.max(0, Math.trunc(rows)), Math.max(0, this.#lines.length - 4));
+		if (count === 0) return;
+		this.#lines.copyWithin(0, count);
+		this.#lines.length -= count;
+		this.#retiredRowsPending += count;
+		this.retiredRows += count;
+	}
+
+	takeNativeScrollbackRetiredRows(): number {
+		const rows = this.#retiredRowsPending;
+		this.#retiredRowsPending = 0;
+		return rows;
+	}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
 	}
 }
 
@@ -599,6 +630,37 @@ describe("streaming scrollback — visual record", () => {
 			await settle(term);
 
 			expect(probe.committedRowsAtRender.at(-1)!).toBeGreaterThan(0);
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("releases committed rows without clearing terminal-owned history", async () => {
+		if (process.platform === "win32") return;
+		const term = new VirtualTerminal(20, 4);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const output = rows("retained-", 12);
+		const probe = new RetiringRowsProbe(output);
+
+		try {
+			tui.addChild(probe);
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+
+			tui.requestRender();
+			await settle(term);
+
+			expect(probe.retiredRows).toBe(8);
+			expect(tui.hasRetiredNativeScrollback).toBe(true);
+			expect(tape(term)).toEqual(output);
+
+			term.resize(30, 6);
+			await settleResize(term);
+
+			expect(eraseScrollbackCount(writes)).toBe(0);
+			expect(tape(term)).toEqual(output);
 		} finally {
 			tui.stop();
 		}


### PR DESCRIPTION
## Repro
A focused Bun harness rendered 256 distinct 96 KiB Markdown entries and a 1,601-block transcript, then marked all but 100 rows committed with `bun .wt/repro-4820.ts`. Before the fix, the first Markdown render remained cache-addressable after GC and the transcript retained all 59,236 rendered rows; this reproduced the count-only cache and committed-prefix retention independently of the reporter’s session file.

## Cause
`TranscriptContainer` in `packages/coding-agent/src/modes/components/transcript-container.ts` kept every finalized child, `BlockSegment`, and assembled row after `TUI` had committed those rows to native scrollback. `TUI` in `packages/tui/src/tui.ts` also retained the same prefix across its composed, prepared, audit, and segment ledgers, while `renderCache` in `packages/tui/src/components/markdown.ts` limited entries only by count, allowing a few hundred large source/output pairs to remain live.

## Fix
- Added a native-scrollback retirement contract so `TranscriptContainer` releases finalized leading blocks and `TUI` removes the same rows from every aligned frame ledger while preserving terminal-owned history across resize and theme repaint paths.
- Weighted the shared Markdown LRU by approximate retained bytes, capped individual entries, and kept the existing entry-count ceiling.
- Added concrete loop-phase breadcrumbs for transcript render, Markdown render, session-context construction, and compaction estimation.
- Added regression coverage for transcript retirement, terminal-history preservation across resize, weighted-cache bypass, and phase attribution; documented both affected packages.

## Verification
`bun test packages/coding-agent/test/modes/components/transcript-container.test.ts` passed (39 tests); `bun test packages/tui/test/streaming-scrollback-defer.test.ts` passed (22 tests); `bun test packages/tui/test/markdown.test.ts` passed (114 tests); `bun check` passed across all packages. The focused harness changed from a retained L2 cache hit and 59,236 retained transcript rows to an evicted oversized cache entry and 111 retained tail rows after 59,136 rows were committed. Fixes #4820