### PR TITLE
fix(coding-agent): skip autolearn capture after aborted turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed autolearn firing a capture nudge after an aborted assistant turn (ESC/cancel): `AutoLearnController` now inspects the `agent_end` payload and skips the nudge when the last assistant message stopped with `stopReason: "aborted"` ([#4925](https://github.com/can1357/oh-my-pi/issues/4925)).
+
 ## [16.3.12] - 2026-07-08
 
 ### Added

--- a/packages/coding-agent/src/autolearn/controller.ts
+++ b/packages/coding-agent/src/autolearn/controller.ts
@@ -10,6 +10,8 @@
  * for the session's lifetime — `newSession` resets the session in place
  * without re-running startup — so the controller needs no disposal.
  */
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { StopReason } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
 import autolearnGuidance from "../prompts/system/autolearn-guidance.md" with { type: "text" };
@@ -19,6 +21,19 @@ import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 
 const AUTOLEARN_NUDGE_AUTOCONTINUE = autolearnNudgeAutoContinue.trim();
 const DEFAULT_MIN_TOOL_CALLS = 5;
+
+/**
+ * Stop reason of the last assistant message in an `agent_end` payload, or
+ * `undefined` when the turn produced none. Walks from the end because a turn
+ * may append trailing tool-result messages after the assistant stop.
+ */
+function lastAssistantStopReason(messages: readonly AgentMessage[]): StopReason | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message.role === "assistant") return message.stopReason;
+	}
+	return undefined;
+}
 
 /**
  * Build the standing auto-learn guidance for the system prompt from the tools
@@ -76,11 +91,11 @@ export class AutoLearnController {
 			return;
 		}
 		if (event.type === "agent_end") {
-			this.#onAgentEnd();
+			this.#onAgentEnd(event);
 		}
 	}
 
-	#onAgentEnd(): void {
+	#onAgentEnd(event: Extract<AgentSessionEvent, { type: "agent_end" }>): void {
 		// Snapshot and reset every turn: the counter describes only the
 		// just-finished turn, so below-threshold, disabled, and plan-mode stops
 		// must not let tool calls accumulate into a later turn.
@@ -107,6 +122,11 @@ export class AutoLearnController {
 		// still in it: a passive nudge would ride the goal continuation, and
 		// auto-continue would compete with it.
 		if (startedInGoalMode || this.#session.getGoalModeState()?.enabled) return;
+		// Never nudge after an aborted assistant turn. A user ESC/cancel (or any
+		// lifecycle abort) leaves the final assistant message with
+		// stopReason: "aborted"; auto-continuing would resurrect a turn the user
+		// deliberately stopped and inject a capture prompt into a cancelled flow.
+		if (lastAssistantStopReason(event.messages) === "aborted") return;
 
 		// Auto-run a capture turn only when explicitly enabled. Passive mode used to
 		// queue a hidden custom message for the next real turn, but that mutates the

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -51,20 +51,20 @@ Decompose first, then {{#if taskBatch}}batch the independent leaves{{else}}issue
 
 {{#if taskBatch}}
     task(
-      context: "# Goal\nReview the auth diff...\n# Constraints\nRead-only...\n# Contract\nReturn findings as severity/file/line/fix...",
+      context: "# Goal\nReview the auth diff…\n# Constraints\nRead-only…\n# Contract\nReturn findings as severity/file/line/fix…",
       tasks: [
-        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection...\n# Acceptance\nReturn confirmed findings only..." },
-        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance...\n# Acceptance\nReturn mismatches and exact prompt lines..." },
+        { id: "AuthOwner", role: "Auth Storage Reviewer", assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nTrace credential selection…\n# Acceptance\nReturn confirmed findings only…" },
+        { id: "PromptOwner", role: "Prompt Contract Reviewer", assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance…\n# Acceptance\nReturn mismatches and exact prompt lines…" },
       ]
     )
 {{else}}
     task(
       role: "Auth Storage Reviewer",
-      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/ai/src/auth-storage.ts\n# Change\nReview the auth diff. Shared contract: read-only; return findings as severity/file/line/fix.\n# Acceptance\nReturn confirmed findings only…"
     )
     task(
       role: "Prompt Contract Reviewer",
-      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only..."
+      assignment: "# Target\npackages/coding-agent/src/prompts/**\n# Change\nCheck active-tool guidance. Shared contract: read-only; return mismatches and exact prompt lines.\n# Acceptance\nReturn confirmed findings only…"
     )
 {{/if}}
 

--- a/packages/coding-agent/test/autolearn-controller.test.ts
+++ b/packages/coding-agent/test/autolearn-controller.test.ts
@@ -55,6 +55,11 @@ class FakeSession {
 	agentEnd(): void {
 		this.emit({ type: "agent_end", messages: [] });
 	}
+
+	agentEndAborted(): void {
+		const aborted = { role: "assistant", stopReason: "aborted", content: [] } as unknown as AgentSessionEvent;
+		this.emit({ type: "agent_end", messages: [aborted] } as unknown as AgentSessionEvent);
+	}
 }
 
 function install(session: FakeSession, overrides: Record<string, unknown> = {}): Settings {
@@ -186,6 +191,27 @@ describe("AutoLearnController", () => {
 		// The capture is per-turn: a fresh turn that did not start in goal mode
 		// nudges normally, proving the latch resets.
 		session.agentStart();
+		session.toolCalls(5);
+		session.agentEnd();
+		expect(session.sent).toHaveLength(1);
+	});
+
+	it("does not nudge after an aborted assistant turn (#4925)", () => {
+		const session = new FakeSession();
+		install(session, { "autolearn.autoContinue": true });
+		session.toolCalls(5);
+		// ESC/cancel leaves the final assistant message with stopReason "aborted".
+		session.agentEndAborted();
+		expect(session.sent).toHaveLength(0);
+	});
+
+	it("does not arm suppression on an aborted stop, so the next real stop nudges", () => {
+		const session = new FakeSession();
+		install(session, { "autolearn.autoContinue": true });
+		session.toolCalls(5);
+		session.agentEndAborted();
+		expect(session.sent).toHaveLength(0);
+		// The skipped abort must not swallow the following non-aborted stop.
 		session.toolCalls(5);
 		session.agentEnd();
 		expect(session.sent).toHaveLength(1);


### PR DESCRIPTION
## Repro
With `autolearn.enabled` + `autolearn.autoContinue`, an aborted assistant turn still triggers an auto-continue capture nudge. Driving 5 `tool_execution_end` events followed by an `agent_end` whose only message is an assistant with `stopReason: "aborted"` (the ESC/cancel shape) fires `sendCustomMessage`. Expected 0 nudges; observed 1. Covered by the new test `does not nudge after an aborted assistant turn (#4925)` in `packages/coding-agent/test/autolearn-controller.test.ts`.

## Cause
`AutoLearnController.#onAgentEnd` in `packages/coding-agent/src/autolearn/controller.ts` gated the nudge only on tool-call count, live opt-out, plan mode, and goal mode. It never consulted the `agent_end` payload, so a turn the user deliberately aborted was treated like any other qualifying stop.

## Fix
- `#onEvent` now forwards the `agent_end` event to `#onAgentEnd`, which is typed to the `agent_end` variant.
- New module-level `lastAssistantStopReason(messages)` walks the payload from the end (past trailing tool-result messages) to the last assistant message's `stopReason`.
- `#onAgentEnd` returns early when that stop reason is `"aborted"`, placed after the goal-mode guard and before the suppression-arming/auto-continue path so an aborted stop never arms the one-shot suppression latch.
- Changelog entry under `[Unreleased] > Fixed`.

## Verification
`bun test packages/coding-agent/test/autolearn-controller.test.ts` — 18 pass, 0 fail (adds two regression tests: the aborted turn produces no nudge, and the aborted stop does not swallow the next real stop). `bun check` — clean (biome + docs index + tsgo). `Fixes #4925`