### PR TITLE
fix(tui): enable tree branch summary option by default

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the session tree selector hiding the summarize-and-branch choice by default, so `/tree` and default `/branch` selections can route to branch summaries. ([#5152](https://github.com/can1357/oh-my-pi/issues/5152))
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2305,12 +2305,12 @@ export const SETTINGS_SCHEMA = {
 	// Branch summaries
 	"branchSummary.enabled": {
 		type: "boolean",
-		default: false,
+		default: true,
 		ui: {
 			tab: "context",
 			group: "General",
 			label: "Branch Summaries",
-			description: "Prompt to summarize when leaving a branch",
+			description: "Offer a summarize-and-branch choice when leaving the current tree branch",
 		},
 	},
 

--- a/packages/coding-agent/test/selector-controller-tree-summary.test.ts
+++ b/packages/coding-agent/test/selector-controller-tree-summary.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
+
+let settingsState: SettingsTestState | undefined;
+
+beforeAll(() => {
+	initTheme();
+});
+
+beforeEach(async () => {
+	settingsState = beginSettingsTest();
+	await Settings.init({ inMemory: true });
+});
+
+afterEach(() => {
+	restoreSettingsTestState(settingsState);
+	settingsState = undefined;
+});
+
+function userNode(id: string, parentId: string | null, text: string): SessionTreeNode {
+	const message: AgentMessage = { role: "user", content: text, timestamp: 1 };
+	return {
+		entry: {
+			type: "message",
+			id,
+			parentId,
+			timestamp: "2026-01-01T00:00:00Z",
+			message,
+		},
+		children: [],
+	};
+}
+
+type NavigateTree = (
+	entryId: string,
+	options: { summarize: boolean; customInstructions: string | undefined },
+) => Promise<{ cancelled: boolean }>;
+type ShowHookSelector = (title: string, options: string[]) => Promise<string | undefined>;
+
+interface TreeSummaryHarness {
+	controller: SelectorController;
+	navigateTree: Mock<NavigateTree>;
+	navigation: Promise<void>;
+	selector(): { handleInput(key: string): void };
+	showHookSelector: Mock<ShowHookSelector>;
+}
+
+function createHarness(summaryChoice: string): TreeSummaryHarness {
+	const navigation = Promise.withResolvers<void>();
+	const root = userNode("root", null, "Root prompt");
+	const showHookSelector = vi.fn<ShowHookSelector>(async () => summaryChoice);
+	const navigateTree = vi.fn<NavigateTree>(async () => {
+		navigation.resolve();
+		return { cancelled: false };
+	});
+	let selector: { handleInput(key: string): void } | undefined;
+	const ctx = {
+		sessionManager: {
+			getTree: () => [root],
+			getLeafId: () => null,
+			appendLabelChange: vi.fn(),
+		},
+		ui: {
+			terminal: { rows: 40 },
+			setFocus: vi.fn(),
+			requestRender: vi.fn(),
+			requestComponentRender: vi.fn(),
+		},
+		editorContainer: {
+			clear: vi.fn(),
+			addChild: vi.fn(),
+		},
+		editor: {
+			getText: () => "",
+			setText: vi.fn(),
+			onEscape: undefined,
+		},
+		showStatus: vi.fn(),
+		showError: vi.fn(),
+		showHookSelector,
+		showHookEditor: vi.fn(),
+		chatContainer: { addChild: vi.fn() },
+		statusContainer: {
+			addChild: vi.fn(),
+			disposeChildren: vi.fn(),
+		},
+		renderInitialMessages: vi.fn(),
+		reloadTodos: vi.fn(async () => {}),
+		session: {
+			navigateTree,
+			abortBranchSummary: vi.fn(),
+		},
+	} as unknown as InteractiveModeContext;
+	const controller = new SelectorController(ctx);
+	controller.showSelector = create => {
+		const result = create(() => {});
+		selector = result.component as { handleInput(key: string): void };
+	};
+	return {
+		controller,
+		navigateTree,
+		navigation: navigation.promise,
+		selector: () => {
+			if (!selector) throw new Error("Expected tree selector to be shown");
+			return selector;
+		},
+		showHookSelector,
+	};
+}
+
+describe("SelectorController tree branch summaries", () => {
+	it("offers the summary choice by default before switching without a summary", async () => {
+		const harness = createHarness("No summary");
+
+		harness.controller.showTreeSelector();
+		harness.selector().handleInput("\n");
+		await harness.navigation;
+
+		expect(harness.showHookSelector).toHaveBeenCalledWith("Summarize branch?", [
+			"No summary",
+			"Summarize",
+			"Summarize with custom prompt",
+		]);
+		expect(harness.navigateTree).toHaveBeenCalledWith("root", {
+			summarize: false,
+			customInstructions: undefined,
+		});
+	});
+
+	it("passes the summarize option when the user chooses branch summary", async () => {
+		const harness = createHarness("Summarize");
+
+		harness.controller.showTreeSelector();
+		harness.selector().handleInput("\n");
+		await harness.navigation;
+
+		expect(harness.navigateTree).toHaveBeenCalledWith("root", {
+			summarize: true,
+			customInstructions: undefined,
+		});
+	});
+});


### PR DESCRIPTION
## Repro
In pi-mono, selecting a past message in the tree view offered a summarize-and-branch choice. In OMP, a default `/tree` selection (or `/branch` when `doubleEscapeAction` routes to the tree selector) just switches branches with no summarize option. Reproduce by opening `/tree` on a fresh install and selecting a prior message: no "Summarize branch?" prompt appears.

## Cause
`SelectorController.showTreeSelector()` (`packages/coding-agent/src/modes/controllers/selector-controller.ts:856-916`) already presents the "Summarize branch?" selector and wires the chosen result into `session.navigateTree(entryId, { summarize, customInstructions })`. But that whole block is guarded by `const branchSummariesEnabled = settings.get("branchSummary.enabled")`, and the `branchSummary.enabled` setting defaulted to `false` in `packages/coding-agent/src/config/settings-schema.ts`. With the default config the `while (branchSummariesEnabled)` loop never runs, `wantsSummary` stays `false`, and navigation always calls `navigateTree(..., { summarize: false })`.

## Fix
- Flip `branchSummary.enabled` default from `false` to `true` in `settings-schema.ts` and clarify its UI description, so the existing summarize path is offered out of the box.
- Add `packages/coding-agent/test/selector-controller-tree-summary.test.ts` covering the tree selector contract: the summary choice is shown by default, "No summary" routes to `navigateTree(..., { summarize: false })`, and "Summarize" routes to `navigateTree(..., { summarize: true })`.

## Verification
`bun test packages/coding-agent/test/selector-controller-tree-summary.test.ts` → 2 pass. `bun test packages/coding-agent/test/agent-session-tree-navigation.test.ts` → 10 skip (environment-gated, unaffected). `bun check` → passed. Fixes #5152