### PR TITLE
fix(tools): report failures from shipped custom tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `report_tool_issue` rejecting reports for active OMP-shipped custom tools such as `generate_image`. ([#5175](https://github.com/can1357/oh-my-pi/issues/5175))
+
 ## [16.4.3] - 2026-07-11
 
 ### Added

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2601,7 +2601,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 		}
 
-		if (isAutoQaEnabled(settings) && toolRegistry.has("report_tool_issue")) {
+		if (isAutoQaEnabled(settings) && builtInRegistryToolNames.has("report_tool_issue")) {
 			const reportableToolNames = initialToolNames.filter(
 				name => builtInRegistryToolNames.has(name) || reportableCustomToolNames.has(name),
 			);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2602,9 +2602,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 
 		if (isAutoQaEnabled(settings) && builtInRegistryToolNames.has("report_tool_issue")) {
-			const reportableToolNames = initialToolNames.filter(
-				name => builtInRegistryToolNames.has(name) || reportableCustomToolNames.has(name),
-			);
+			// Snapshot from the full constructed registry, not `initialToolNames`:
+			// `tools.discoveryMode: "all"` strips discoverable built-ins (grep,
+			// browser, github, …) from the initial active set until the model
+			// activates them via `search_tool_bm25`. Those tools stay in the
+			// registry, so keying the allowlist off `initialToolNames` would
+			// silently drop their reports once activated.
+			const reportableToolNames = [...builtInRegistryToolNames, ...reportableCustomToolNames];
 			const qaTool = createReportToolIssueTool(toolSession, reportableToolNames);
 			toolRegistry.set(
 				qaTool.name,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -160,6 +160,7 @@ import {
 	BashTool,
 	BUILTIN_TOOLS,
 	computeEssentialBuiltinNames,
+	createReportToolIssueTool,
 	createTools,
 	createVibeTools,
 	type DeferredDiagnosticsEntry,
@@ -171,6 +172,7 @@ import {
 	GrepTool,
 	getSearchTools,
 	HIDDEN_TOOLS,
+	isAutoQaEnabled,
 	isImageProviderPreference,
 	isSearchProviderId,
 	isSearchProviderPreference,
@@ -1704,6 +1706,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const enableMCP = options.enableMCP ?? true;
 		const deferMCPDiscoveryForUI = enableMCP && !mcpManager && options.hasUI === true;
 		const customTools: CustomTool[] = [];
+		const reportableCustomToolNames = new Set<string>();
 		let startDeferredMCPDiscovery:
 			| ((liveSession: AgentSession, activation: DeferredMCPActivation) => void)
 			| undefined;
@@ -1815,16 +1818,24 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// Add image tools when the active model or configured image providers can generate images.
 		const imageGenTools = await logger.time("getImageGenTools", () => getImageGenTools(modelRegistry, model));
 		if (imageGenTools.length > 0) {
+			for (const tool of imageGenTools) {
+				reportableCustomToolNames.add(tool.name);
+			}
 			customTools.push(...(imageGenTools as unknown as CustomTool[]));
 		}
 
 		if (settings.get("speechgen.enabled")) {
+			reportableCustomToolNames.add(ttsTool.name);
 			customTools.push(ttsTool as unknown as CustomTool);
 		}
 
 		// Add web search tools
 		if (options.toolNames?.includes("web_search")) {
-			customTools.push(...getSearchTools());
+			const searchTools = getSearchTools();
+			for (const tool of searchTools) {
+				reportableCustomToolNames.add(tool.name);
+			}
+			customTools.push(...searchTools);
 		}
 
 		// Discover custom tools from `.omp/tools/`, `.claude/tools/`, plugins, etc.
@@ -1844,8 +1855,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		for (const { path, error } of customToolsLoadResult.errors) {
 			logger.error("Custom tool load failed", { path, error });
 		}
-		if (customToolsLoadResult.tools.length > 0) {
-			customTools.push(...customToolsLoadResult.tools.map(loaded => loaded.tool));
+		for (const { tool } of customToolsLoadResult.tools) {
+			reportableCustomToolNames.delete(tool.name);
+			customTools.push(tool);
 		}
 		// Forward the path list (NOT the loaded tools) to subagents so they
 		// re-bind under their own `CustomToolAPI` while skipping the FS scan.
@@ -2211,6 +2223,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 		const registeredTools = extensionRunner.getAllRegisteredTools();
 		const sdkCustomTools = options.customTools?.filter(tool => !isLegacyBuiltinToolDefinition(tool)) ?? [];
+		for (const tool of sdkCustomTools) {
+			reportableCustomToolNames.delete(tool.name);
+		}
 		const allCustomTools = [
 			...registeredTools,
 			...sdkCustomTools.map(tool => {
@@ -2584,6 +2599,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				restored: new Set(existingSession.selectedMCPToolNames.map(normalizeRenamedBuiltinToolName)),
 				forceActive,
 			});
+		}
+
+		if (isAutoQaEnabled(settings) && toolRegistry.has("report_tool_issue")) {
+			const reportableToolNames = initialToolNames.filter(
+				name => builtInRegistryToolNames.has(name) || reportableCustomToolNames.has(name),
+			);
+			const qaTool = createReportToolIssueTool(toolSession, reportableToolNames);
+			toolRegistry.set(
+				qaTool.name,
+				new ExtensionToolWrapper(wrapToolWithMetaNotice(qaTool), extensionRunner) as Tool,
+			);
 		}
 
 		// Pre-register in the global agent registry BEFORE building the system prompt,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -677,10 +677,10 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	// Injected unconditionally into every agent, regardless of requested tool list.
 	const autoQA = isAutoQaEnabled(session.settings);
 	if (autoQA && !tools.some(t => t.name === "report_tool_issue")) {
-		// Build the enum from tools we just constructed via BUILTIN_TOOLS / HIDDEN_TOOLS.
-		// Extension overrides (e.g. a user's custom `bash`) get added later by
-		// other code paths, so they're absent here — exactly what we want; MCP /
-		// extension tools never end up in the report enum.
+		// Build the provisional enum from tools constructed via BUILTIN_TOOLS /
+		// HIDDEN_TOOLS. `createAgentSession` rebuilds this tool after the complete
+		// registry exists so active OMP-shipped custom tools join the allowlist
+		// without admitting MCP or user-extension tools.
 		const activeBuiltinNames = tools
 			.map(t => t.name)
 			.filter(name => (name in BUILTIN_TOOLS || name in HIDDEN_TOOLS) && name !== "report_tool_issue");

--- a/packages/coding-agent/src/tools/report-tool-issue.ts
+++ b/packages/coding-agent/src/tools/report-tool-issue.ts
@@ -27,11 +27,11 @@ import { type } from "arktype";
 import type { Settings } from "..";
 import type { ToolSession } from "./index";
 
-function buildReportToolIssueParams(activeBuiltinNames: readonly string[]) {
+function buildReportToolIssueParams(reportableToolNames: readonly string[]) {
 	// Enum gives the model a tight schema; the runtime check in `execute` is the
 	// source of truth (handles models that ignore the enum and the empty-list
 	// fallback used by call sites that don't know the active set yet).
-	const toolSchema = activeBuiltinNames.length > 0 ? type.enumerated(...activeBuiltinNames) : type("string");
+	const toolSchema = reportableToolNames.length > 0 ? type.enumerated(...reportableToolNames) : type("string");
 	return type({
 		tool: toolSchema.describe("tool name"),
 		report: type("string").describe(
@@ -184,6 +184,12 @@ export async function resolveAutoQaConsent(settings: Settings | undefined): Prom
 }
 
 let cachedDb: Database | null = null;
+
+/** Test-only: close and forget the cached auto-QA database handle. */
+export function __resetAutoQaDbForTests(): void {
+	cachedDb?.close();
+	cachedDb = null;
+}
 
 /**
  * Open (or return the cached handle for) the auto-QA SQLite database at
@@ -457,12 +463,15 @@ export async function flushGrievances(
 	}
 }
 
-export function createReportToolIssueTool(session: ToolSession, activeBuiltinNames: readonly string[] = []): AgentTool {
+export function createReportToolIssueTool(
+	session: ToolSession,
+	reportableToolNames: readonly string[] = [],
+): AgentTool {
 	const getModel = () => session.getActiveModelString?.() ?? "unknown";
 	// Snapshotted at construction time. The model's enum is built from the same
 	// snapshot; mid-session drift (extensions registering later, etc.) is caught
 	// by the silent-drop guard below.
-	const allowedToolNames = new Set(activeBuiltinNames);
+	const allowedToolNames = new Set(reportableToolNames);
 
 	return {
 		name: "report_tool_issue",
@@ -470,7 +479,7 @@ export function createReportToolIssueTool(session: ToolSession, activeBuiltinNam
 		strict: false,
 		approval: "write",
 		description: "Report unexpected tool behavior for automated QA tracking.",
-		parameters: buildReportToolIssueParams(activeBuiltinNames),
+		parameters: buildReportToolIssueParams(reportableToolNames),
 		intent: "omit",
 		async execute(_toolCallId, rawParams) {
 			// Save is unconditional: the row lives in the user's own SQLite
@@ -485,8 +494,8 @@ export function createReportToolIssueTool(session: ToolSession, activeBuiltinNam
 				// passthrough wrapper. Strip the prefix before allowlist check so
 				// `proxy_read` lands as a report against `read`, not a silent drop.
 				const canonicalTool = params.tool.startsWith("proxy_") ? params.tool.slice("proxy_".length) : params.tool;
-				// Silently drop reports targeting tools that aren't shipped built-ins
-				// (MCP servers, extensions that overrode a built-in name, typos).
+				// Silently drop reports targeting tools that aren't OMP-shipped
+				// reportable tools (MCP servers, extensions, typos).
 				// Not the model's fault — no error, no DB row, just acknowledge.
 				// Empty allowlist means the factory was called without a known active
 				// set, so behave as before and record everything.

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -351,4 +351,32 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await session.dispose();
 		}
 	});
+
+	it("keeps discovery-all built-ins reportable even when hidden from the initial active set", async () => {
+		const tempDir = makeTempDir();
+		const settings = Settings.isolated({ "dev.autoqa": true, "tools.discoveryMode": "all" });
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			settings,
+		});
+
+		try {
+			// discovery-all hides discoverable built-ins from the initial active set.
+			expect(session.getActiveToolNames()).not.toContain("grep");
+			expect(session.getAllToolNames()).toContain("grep");
+
+			const reportTool = session.agent.state.tools.find(tool => tool.name === "report_tool_issue");
+			if (!reportTool) throw new Error("expected report_tool_issue");
+			const parameters = type(reportTool.parameters);
+			expect(
+				parameters({
+					tool: "grep",
+					report: "A discoverable built-in returned output inconsistent with its schema.",
+				}) instanceof type.errors,
+			).toBe(false);
+		} finally {
+			await session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -318,4 +318,37 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await session.dispose();
 		}
 	});
+
+	it("preserves an extension override of report_tool_issue when Auto QA is enabled", async () => {
+		const tempDir = makeTempDir();
+		const settings = Settings.isolated({ "dev.autoqa": true });
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			settings,
+			extensions: [
+				pi => {
+					pi.registerTool({
+						name: "report_tool_issue",
+						label: "Custom Report Tool",
+						description: "Record a report through the extension override.",
+						parameters: type({}),
+						async execute() {
+							return { content: [{ type: "text", text: "custom report handled" }] };
+						},
+					});
+				},
+			],
+		});
+
+		try {
+			const reportTool = session.getToolByName("report_tool_issue");
+			if (!reportTool) throw new Error("expected report_tool_issue override");
+
+			const result = await reportTool.execute("call-custom-report", {});
+			expect(result.content).toEqual([{ type: "text", text: "custom report handled" }]);
+		} finally {
+			await session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -278,4 +278,44 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await session.dispose();
 		}
 	});
+
+	it("includes reportable built-in custom tools in the Auto QA schema", async () => {
+		const tempDir = makeTempDir();
+		const settings = Settings.isolated({ "dev.autoqa": true });
+
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			settings,
+			extensions: [toolActivationExtension],
+		});
+
+		try {
+			expect(session.getActiveToolNames()).toContain("generate_image");
+			expect(session.getActiveToolNames()).toContain("default_active_tool");
+
+			const reportTool = session.agent.state.tools.find(tool => tool.name === "report_tool_issue");
+			if (!reportTool) throw new Error("expected report_tool_issue");
+			const parameters = type(reportTool.parameters);
+			expect(
+				parameters({
+					tool: "generate_image",
+					report: "A schema-valid image generation request failed before reaching the provider.",
+				}) instanceof type.errors,
+			).toBe(false);
+			expect(
+				parameters({
+					tool: "report_tool_issue",
+					report: "The reporting tool itself rejected a valid report.",
+				}) instanceof type.errors,
+			).toBe(false);
+			expect(
+				parameters({
+					tool: "default_active_tool",
+					report: "Extension tool names must not be collected by Auto QA.",
+				}) instanceof type.errors,
+			).toBe(true);
+		} finally {
+			await session.dispose();
+		}
+	});
 });

--- a/packages/coding-agent/test/tools/report-tool-issue.test.ts
+++ b/packages/coding-agent/test/tools/report-tool-issue.test.ts
@@ -1,12 +1,19 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
+	__resetAutoQaDbForTests,
 	__resetAutoQaFlushStateForTests,
+	createReportToolIssueTool,
 	flushGrievances,
 	isAutoQaEnabled,
+	openAutoQaDb,
 } from "@oh-my-pi/pi-coding-agent/tools/report-tool-issue";
 import * as piUtils from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
 import { mockFetch } from "../helpers/fetch-mock";
 
 function openTempDb(): Database {
@@ -70,6 +77,82 @@ function restoreAutoQaEnv(): void {
 	}
 	Bun.env.PI_AUTO_QA = originalPiAutoQa;
 }
+
+describe("createReportToolIssueTool", () => {
+	let autoQaTempDir: string | null = null;
+
+	afterEach(() => {
+		__resetAutoQaDbForTests();
+		vi.restoreAllMocks();
+		if (autoQaTempDir) {
+			fs.rmSync(autoQaTempDir, { recursive: true, force: true });
+			autoQaTempDir = null;
+		}
+	});
+
+	it("accepts reportable built-in custom tools in its parameter schema", () => {
+		const tool = createReportToolIssueTool(
+			{
+				cwd: "/tmp",
+				hasUI: false,
+				settings: Settings.isolated(),
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+			},
+			["read", "generate_image"],
+		);
+		const parameters = type(tool.parameters);
+
+		expect(
+			parameters({
+				tool: "generate_image",
+				report: "A schema-valid image generation request failed before reaching the provider.",
+			}) instanceof type.errors,
+		).toBe(false);
+		expect(
+			parameters({
+				tool: "extension_tool",
+				report: "A schema-valid image generation request failed before reaching the provider.",
+			}) instanceof type.errors,
+		).toBe(true);
+	});
+
+	it("records reportable custom tools and silently drops extension names at runtime", async () => {
+		autoQaTempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-report-tool-issue-"));
+		vi.spyOn(piUtils, "getAutoQaDbDir").mockReturnValue(path.join(autoQaTempDir, "autoqa.db"));
+		const tool = createReportToolIssueTool(
+			{
+				cwd: "/tmp",
+				hasUI: false,
+				settings: Settings.isolated(),
+				getActiveModelString: () => "test-model",
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+			},
+			["read", "generate_image"],
+		);
+
+		await tool.execute("call-image", {
+			tool: "generate_image",
+			report: "A schema-valid image generation request failed before reaching the provider.",
+		});
+		await tool.execute("call-extension", {
+			tool: "extension_tool",
+			report: "Extension tool names must not be collected by Auto QA.",
+		});
+
+		const db = openAutoQaDb();
+		if (!db) throw new Error("expected auto-QA database");
+		const rows = db.prepare("SELECT model, tool, report FROM grievances ORDER BY id ASC").all();
+		expect(rows).toEqual([
+			{
+				model: "test-model",
+				tool: "generate_image",
+				report: "A schema-valid image generation request failed before reaching the provider.",
+			},
+		]);
+	});
+});
 
 describe("flushGrievances", () => {
 	let db: Database;


### PR DESCRIPTION
## Repro
With Auto QA enabled, construct the active session registry containing `generate_image`, then validate `{ tool: "generate_image", report: "A schema-valid image generation request failed before reaching the provider." }` against `report_tool_issue`; before this fix the schema rejected it with `tool must be tool name (was "generate_image")` before execution.

## Cause
`packages/coding-agent/src/tools/index.ts` constructed `report_tool_issue` before OMP-shipped custom tools were registered, so `createReportToolIssueTool` received only `BUILTIN_TOOLS`/`HIDDEN_TOOLS` names. `packages/coding-agent/src/sdk.ts` later added `generate_image`, TTS, and custom-rendered web search tools without rebuilding the report schema or runtime allowlist.

## Fix
- Track active OMP-shipped custom tool names while assembling the SDK tool registry.
- Rebuild `report_tool_issue` from the complete active reportable set after registration, while excluding MCP, discovered extension, and SDK custom tools.
- Add schema, persistence, hidden-tool, and extension-name regression coverage plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/report-tool-issue.test.ts packages/coding-agent/test/sdk-tool-activation.test.ts` — 25 passed, 0 failed. `bun check` — passed across all packages. Fixes #5175