### PR TITLE
fix(rpc): tolerate malformed stdin lines instead of crashing

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed RPC mode (`--mode rpc`) crashing the whole process with an uncaught `SyntaxError: Failed to parse JSONL` on any non-JSON stdin line. Malformed lines are now reported via a `Failed to parse command` error frame and the frame loop keeps running. ([#5194](https://github.com/can1357/oh-my-pi/issues/5194))
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -12,7 +12,7 @@
  */
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import { isZodSchema, zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
-import { $env, isRecord, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, isRecord, readLines, Snowflake } from "@oh-my-pi/pi-utils";
 import { reset as resetCapabilities } from "../../capability";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
@@ -1279,11 +1279,18 @@ export async function runRpcMode(
 		onHostUriResult: frame => hostUriBridge.handleResult(frame),
 	};
 
-	// Listen for JSON input using Bun's stdin. Frame dispatch lives in
-	// dispatchRpcInputFrame so it can be exercised directly by tests; see the
-	// helper's docstring for the concurrency contract.
-	for await (const parsed of readJsonl(Bun.stdin.stream())) {
+	// Listen for JSON input using Bun's stdin. Frames are read line-by-line and
+	// parsed here (not via readJsonl) so a single malformed line is reported as
+	// an error frame and the loop keeps running instead of throwing out of the
+	// generator and killing the whole process (issue #5194). Frame dispatch
+	// lives in dispatchRpcInputFrame so it can be exercised directly by tests;
+	// see the helper's docstring for the concurrency contract.
+	const decoder = new TextDecoder();
+	for await (const line of readLines(Bun.stdin.stream())) {
+		const text = decoder.decode(line).trim();
+		if (!text) continue;
 		try {
+			const parsed = JSON.parse(text);
 			const awaited = dispatchRpcInputFrame(parsed, dispatchFrameDeps);
 			if (awaited) {
 				await awaited;

--- a/packages/coding-agent/test/rpc-malformed-input.test.ts
+++ b/packages/coding-agent/test/rpc-malformed-input.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { isRecord, readJsonl } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression test for issue #5194: a non-JSON stdin line crashed the whole RPC
+ * process with an uncaught `SyntaxError: Failed to parse JSONL` escaping the
+ * frame loop. A malformed line must instead be reported as an error frame and
+ * the process must keep reading subsequent frames.
+ */
+describe("RPC mode malformed stdin", () => {
+	test("reports a bad line as an error frame and keeps serving subsequent commands", async () => {
+		const cliPath = path.join(import.meta.dir, "..", "src", "cli.ts");
+		const child = Bun.spawn(
+			["bun", cliPath, "--mode", "rpc", "--provider", "anthropic", "--model", "claude-sonnet-4-5"],
+			{
+				cwd: path.join(import.meta.dir, ".."),
+				env: { ...Bun.env, PI_NO_TITLE: "1" },
+				stdin: "pipe",
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+
+		// A non-JSON line followed by a valid command. Pre-fix the first line
+		// crashed the generator before the second was ever read.
+		child.stdin.write("this is not json\n");
+		child.stdin.write(`${JSON.stringify({ type: "get_state", id: "probe" })}\n`);
+		await child.stdin.flush();
+
+		let parseError: Record<string, unknown> | undefined;
+		let stateResponse: Record<string, unknown> | undefined;
+
+		for await (const frame of readJsonl<unknown>(child.stdout as ReadableStream<Uint8Array>)) {
+			if (!isRecord(frame)) continue;
+			if (frame.type === "response" && frame.command === "parse" && frame.success === false) {
+				parseError = frame;
+			}
+			if (frame.type === "response" && frame.id === "probe") {
+				stateResponse = frame;
+				break;
+			}
+		}
+
+		child.stdin.end();
+		child.kill();
+		await child.exited.catch(() => {});
+
+		expect(parseError).toBeDefined();
+		expect(String(parseError?.error)).toContain("Failed to parse command");
+		expect(stateResponse).toBeDefined();
+		expect(stateResponse?.success).toBe(true);
+	}, 30000);
+});


### PR DESCRIPTION
## Repro
`omp --mode rpc` terminated the entire process with an uncaught `SyntaxError: Failed to parse JSONL` on the first non-JSON stdin line. Reproduced on `main` with `printf 'ls\n' | omp --mode rpc`: after emitting `ready` and the command catalog, the process crashed with exit code 1 as soon as the `ls` line was read.

## Cause
`runRpcMode` in `packages/coding-agent/src/modes/rpc/rpc-mode.ts` iterated `readJsonl(Bun.stdin.stream())`, but JSON parsing happens inside that async generator (`packages/utils/src/stream.ts` → `parseJsonlChunkCompat` → `Bun.JSONL.parseChunk`). A parse error thrown from the generator's `next()` propagates through the `for await`, bypassing the loop's `try/catch` — which only wrapped `dispatchRpcInputFrame` — unwinding `runRpcMode` and exiting the process. The generator is also unrecoverable once it throws, so subsequent frames are never read.

## Fix
- Swapped the RPC stdin loop from `readJsonl` to `readLines`, decoding and `JSON.parse`ing each line inside the existing `try/catch`. A malformed line now emits the same `{"type":"response","command":"parse","success":false,"error":"Failed to parse command: ..."}` frame the dispatch catch already produced, and the loop keeps reading subsequent frames. Blank lines are skipped.
- Shared `readJsonl` stays strict, preserving the fail-fast contract for session-file (`.jsonl`) reads.
- Added `test/rpc-malformed-input.test.ts`: spawns the CLI in RPC mode, feeds a non-JSON line followed by a valid `get_state`, and asserts the parse-error frame is emitted and the later command still succeeds.

## Verification
`bun test test/rpc-malformed-input.test.ts` → 1 pass (confirmed failing before the fix by stashing the `rpc-mode.ts` change: `expect(parseError).toBeDefined()` received `undefined` because the process crashed). `bun run check:types` clean. Manual: `printf 'not json\n{"type":"get_state","id":"1"}\n' | bun run packages/coding-agent/src/cli.ts --mode rpc ...` emits the parse-error frame then a successful `get_state` response, exit 0.

Fixes #5194