### PR TITLE
fix(tools): prefer active image provider and fall back

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed visible per-keystroke lag while searching in the `/resume` session picker. Literal matches now rank synchronously from a cached per-session haystack, fuzzy scoring runs in bounded background chunks that converge to the same ranking (large listings previously rebuilt a fuzzy index per token per session on every keystroke), and the prompt-history SQLite lookup — an FTS query plus a LIKE scan over every stored prompt — is debounced off the keystroke path.
 - Fixed compiled Linux binary extension loading when bundled web-search header generation cannot read `header-generator` data files from the build-time path. ([#5178](https://github.com/can1357/oh-my-pi/issues/5178))
+- Fixed `generate_image` preferring Antigravity over the active session provider and stopping instead of trying the next credentialed provider after an image HTTP failure. ([#5218](https://github.com/can1357/oh-my-pi/issues/5218))
 
 ## [16.4.4] - 2026-07-11
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4402,7 +4402,8 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "auto",
 					label: "Auto",
-					description: "Priority: GPT model image tool > Antigravity > xAI > OpenRouter > Gemini",
+					description:
+						"Priority: active session provider > GPT model image tool > Antigravity > xAI > OpenRouter > Gemini",
 				},
 				{ value: "openai", label: "OpenAI", description: "Uses the active GPT Responses/Codex model" },
 				{

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -906,9 +906,10 @@ async function generateOpenAIHostedImage(
 
 	if (!response.ok) {
 		const errorText = await response.text();
-		throw Object.assign(
-			new Error(`OpenAI image request failed (${response.status}): ${getOpenAIResponseErrorMessage(errorText)}`),
-			{ status: response.status },
+		throw new ProviderHttpError(
+			`OpenAI image request failed (${response.status}): ${getOpenAIResponseErrorMessage(errorText)}`,
+			response.status,
+			{ headers: response.headers },
 		);
 	}
 

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -58,6 +58,7 @@ const COMMON_IMAGE_ASPECT_RATIOS = ["1:1", "3:4", "4:3", "9:16", "16:9"] as cons
 const XAI_IMAGE_ASPECT_RATIOS = [...COMMON_IMAGE_ASPECT_RATIOS, "3:2", "2:3"] as const;
 const COMMON_IMAGE_ASPECT_RATIO_SET = new Set<string>(COMMON_IMAGE_ASPECT_RATIOS);
 const IMAGE_PROVIDER_PREFERENCES = new Set<string>(["auto", "antigravity", "gemini", "openai", "openrouter", "xai"]);
+const AUTO_IMAGE_PROVIDER_ORDER = ["openai", "antigravity", "xai", "openrouter", "gemini"] as const;
 
 const responseModalitySchema = type('"IMAGE" | "TEXT"');
 
@@ -547,53 +548,58 @@ async function findOpenAIHostedImageCredentials(
 	};
 }
 
+function activeImageProvider(model: Model | undefined): Exclude<ImageProviderPreference, "auto"> | null {
+	switch (model?.provider) {
+		case "openai":
+		case "openai-codex":
+			return "openai";
+		case "google-antigravity":
+			return "antigravity";
+		case "xai":
+		case "xai-oauth":
+			return "xai";
+		case "openrouter":
+			return "openrouter";
+		case "google":
+			return "gemini";
+		default:
+			return null;
+	}
+}
+
+function imageProviderOrder(activeModel: Model | undefined): Array<Exclude<ImageProviderPreference, "auto">> {
+	const providers: Array<Exclude<ImageProviderPreference, "auto">> = [];
+	const added = new Set<Exclude<ImageProviderPreference, "auto">>();
+	const add = (provider: Exclude<ImageProviderPreference, "auto"> | null): void => {
+		if (!provider || added.has(provider)) return;
+		added.add(provider);
+		providers.push(provider);
+	};
+
+	if (preferredImageProvider !== "auto") add(preferredImageProvider);
+	add(activeImageProvider(activeModel));
+	for (const provider of AUTO_IMAGE_PROVIDER_ORDER) add(provider);
+	return providers;
+}
+
 async function findImageApiKey(
+	provider: Exclude<ImageProviderPreference, "auto">,
 	modelRegistry?: ModelRegistry,
 	activeModel?: Model,
 	sessionId?: string,
 ): Promise<ImageApiKey | null> {
-	// If a specific provider is preferred, try it first.
-	if (preferredImageProvider === "openai") {
-		const openAI = await findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
-		if (openAI) return openAI;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "antigravity" && modelRegistry) {
-		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
-		if (antigravity) return antigravity;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "gemini") {
-		const gemini = await findGeminiImageCredentials(modelRegistry, sessionId);
-		if (gemini) return gemini;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "openrouter") {
-		const openRouter = await findOpenRouterImageCredentials(modelRegistry, sessionId);
-		if (openRouter) return openRouter;
-		// Fall through to auto-detect if preferred provider key not found.
-	} else if (preferredImageProvider === "xai") {
-		const xai = await findXAIImageCredentials(modelRegistry);
-		if (xai) return xai;
-		// Fall through to auto-detect if preferred provider key not found.
+	switch (provider) {
+		case "openai":
+			return findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
+		case "antigravity":
+			return modelRegistry ? findAntigravityCredentials(modelRegistry, sessionId) : null;
+		case "xai":
+			return findXAIImageCredentials(modelRegistry);
+		case "openrouter":
+			return findOpenRouterImageCredentials(modelRegistry, sessionId);
+		case "gemini":
+			return findGeminiImageCredentials(modelRegistry, sessionId);
 	}
-
-	// Auto-detect: GPT hosted image generation, then Antigravity, xAI, OpenRouter, Gemini.
-	const openAI = await findOpenAIHostedImageCredentials(modelRegistry, activeModel, sessionId);
-	if (openAI) return openAI;
-
-	if (modelRegistry) {
-		const antigravity = await findAntigravityCredentials(modelRegistry, sessionId);
-		if (antigravity) return antigravity;
-	}
-
-	const xai = await findXAIImageCredentials(modelRegistry);
-	if (xai) return xai;
-
-	const openRouter = await findOpenRouterImageCredentials(modelRegistry, sessionId);
-	if (openRouter) return openRouter;
-
-	const gemini = await findGeminiImageCredentials(modelRegistry, sessionId);
-	if (gemini) return gemini;
-
-	return null;
 }
 
 async function loadImageFromPath(imagePath: string, cwd: string): Promise<InlineImageData> {
@@ -1040,533 +1046,563 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 	async execute(_toolCallId, params, _onUpdate, ctx, signal) {
 		return untilAborted(signal, async () => {
 			const sessionId = ctx.sessionManager.getSessionId();
-			const apiKey = await findImageApiKey(ctx.modelRegistry, ctx.model, sessionId);
-			if (!apiKey) {
+			const providerOrder = imageProviderOrder(ctx.model);
+			const cwd = ctx.sessionManager.getCwd();
+			const requestSignal = ptree.combineSignals(signal, IMAGE_TIMEOUT);
+			const fetchImpl = ctx.fetch ?? fetch;
+			const failures: Array<{ provider: ImageProvider; error: ProviderHttpError }> = [];
+			let foundCredentials = false;
+			let resolvedImageCache: InlineImageData[] | undefined;
+
+			for (const preferredProvider of providerOrder) {
+				const apiKey = await findImageApiKey(preferredProvider, ctx.modelRegistry, ctx.model, sessionId);
+				if (!apiKey) continue;
+				foundCredentials = true;
+				if (!resolvedImageCache) {
+					resolvedImageCache = [];
+					if (params.input?.length) {
+						for (const input of params.input) {
+							resolvedImageCache.push(await resolveInputImage(input, cwd));
+						}
+					}
+				}
+				const resolvedImages = resolvedImageCache;
+
+				const provider = apiKey.provider;
+				try {
+					const model =
+						provider === "openai" || provider === "openai-codex"
+							? (apiKey.model?.id ?? "gpt")
+							: provider === "antigravity"
+								? DEFAULT_ANTIGRAVITY_MODEL
+								: provider === "openrouter"
+									? DEFAULT_OPENROUTER_MODEL
+									: provider === "xai"
+										? DEFAULT_XAI_IMAGE_MODEL
+										: DEFAULT_MODEL;
+					const resolvedModel = provider === "openrouter" ? resolveOpenRouterModel(model) : model;
+					assertImageAspectRatioSupported(provider, params.aspect_ratio);
+					if (provider === "openai" || provider === "openai-codex") {
+						if (!apiKey.model) {
+							throw new Error("Missing active GPT model for OpenAI image generation");
+						}
+
+						const hostedModel = apiKey.model;
+						const hostedKey: ApiKey = ctx.modelRegistry.resolver(hostedModel, sessionId);
+
+						const parsed = await withAuth(
+							hostedKey,
+							key =>
+								generateOpenAIHostedImage(
+									key,
+									hostedModel,
+									params,
+									resolvedImages,
+									fetchImpl,
+									requestSignal,
+									sessionId,
+								),
+							{ signal: requestSignal },
+						);
+
+						if (parsed.images.length === 0) {
+							const messageText = parsed.responseText ? `\n\n${parsed.responseText}` : "";
+							return {
+								content: [{ type: "text", text: `No image data returned.${messageText}` }],
+								details: {
+									provider,
+									model,
+									imageCount: 0,
+									imagePaths: [],
+									images: [],
+									responseText: parsed.responseText,
+									revisedPrompt: parsed.revisedPrompt,
+									usage: parsed.usage,
+								},
+							};
+						}
+
+						const imagePaths = await saveImagesToTemp(parsed.images);
+
+						return {
+							content: [
+								{ type: "text", text: buildResponseSummary(provider, model, imagePaths, parsed.responseText) },
+							],
+							details: {
+								provider,
+								model,
+								imageCount: parsed.images.length,
+								imagePaths,
+								images: parsed.images,
+								responseText: parsed.responseText,
+								revisedPrompt: parsed.revisedPrompt,
+								usage: parsed.usage,
+							},
+						};
+					}
+
+					if (provider === "antigravity") {
+						if (!apiKey.projectId) {
+							throw new Error("Missing projectId in antigravity credentials");
+						}
+
+						const prompt = assemblePrompt(params);
+						const antigravityKey: ApiKey = ctx.modelRegistry.resolver("google-antigravity", {
+							sessionId,
+							modelId: DEFAULT_ANTIGRAVITY_MODEL,
+						});
+
+						const response = await withAuth(
+							antigravityKey,
+							async key => {
+								// On a retry the resolver yields the raw stored credential JSON
+								// ({ token, projectId }); the initial seed is the already-parsed
+								// access token. Tolerate both, falling back to the seed projectId.
+								const rotated = parseAntigravityCredentials(key);
+								const bearer = rotated?.accessToken ?? key;
+								const projectId = rotated?.projectId ?? apiKey.projectId!;
+								const requestBody = buildAntigravityRequest(
+									prompt,
+									model,
+									projectId,
+									params.aspect_ratio,
+									params.image_size,
+									resolvedImages,
+								);
+
+								let endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
+								try {
+									const mode = settings.get("providers.antigravityEndpoint");
+									if (mode === "production") {
+										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD];
+									} else if (mode === "sandbox") {
+										endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
+									}
+								} catch {
+									// Ignored
+								}
+
+								let resp: Response | undefined;
+								let lastError: Error | undefined;
+
+								for (let i = 0; i < endpoints.length; i++) {
+									const endpoint = endpoints[i];
+									const isLastEndpoint = i === endpoints.length - 1;
+									try {
+										resp = await fetchImpl(`${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
+											method: "POST",
+											headers: {
+												Authorization: `Bearer ${bearer}`,
+												"Content-Type": "application/json",
+												Accept: "text/event-stream",
+												"User-Agent": getAntigravityUserAgent(),
+											},
+											body: JSON.stringify(requestBody),
+											signal: requestSignal,
+										});
+
+										if (resp.ok) {
+											break;
+										}
+
+										const errorText = await resp.text();
+										let message = errorText;
+										try {
+											const parsedErr = JSON.parse(errorText) as { error?: { message?: string } };
+											message = parsedErr.error?.message ?? message;
+										} catch {
+											// Keep raw text.
+										}
+
+										lastError = new ProviderHttpError(
+											`Antigravity image request failed (${resp.status}): ${message}`,
+											resp.status,
+											{ headers: resp.headers },
+										);
+
+										if (resp.status === 429 || (resp.status >= 500 && resp.status < 600)) {
+											if (!isLastEndpoint) {
+												continue;
+											}
+										}
+										break;
+									} catch (error) {
+										lastError = error as Error;
+										if (isLastEndpoint) {
+											break;
+										}
+									}
+								}
+
+								if (!resp?.ok) {
+									throw lastError ?? new Error("Antigravity image generation failed");
+								}
+
+								return resp;
+							},
+							{ signal: requestSignal },
+						);
+
+						const parsed = await parseAntigravitySseForImage(response, requestSignal);
+						const responseText = parsed.text.length > 0 ? parsed.text.join(" ") : undefined;
+
+						if (parsed.images.length === 0) {
+							const messageText = responseText ? `\n\n${responseText}` : "";
+							return {
+								content: [{ type: "text", text: `No image data returned.${messageText}` }],
+								details: {
+									provider,
+									model,
+									imageCount: 0,
+									imagePaths: [],
+									images: [],
+									responseText,
+									usage: parsed.usage,
+								},
+							};
+						}
+
+						const imagePaths = await saveImagesToTemp(parsed.images);
+
+						return {
+							content: [{ type: "text", text: buildResponseSummary(provider, model, imagePaths, responseText) }],
+							details: {
+								provider,
+								model,
+								imageCount: parsed.images.length,
+								imagePaths,
+								images: parsed.images,
+								responseText,
+								usage: parsed.usage,
+							},
+						};
+					}
+
+					if (provider === "xai") {
+						if (!ctx.modelRegistry) {
+							throw new Error("Missing modelRegistry for xAI image generation");
+						}
+						const xaiCreds = await resolveXAIHttpCredentials(ctx.modelRegistry, resolvedModel);
+						if (!xaiCreds) {
+							throw new Error(
+								"No xAI credentials. Run /login → xAI Grok OAuth (SuperGrok or X Premium+) or set XAI_API_KEY.",
+							);
+						}
+
+						const prompt = assemblePrompt(params);
+						const aspectRatio = params.aspect_ratio ?? "1:1";
+						const xaiResolution = resolveXAIResolution(params.image_size);
+
+						const isEdit = resolvedImages.length > 0;
+						if (isEdit && resolvedImages.length > XAI_MAX_EDIT_IMAGES) {
+							throw new Error(
+								`xAI image edits accept up to ${XAI_MAX_EDIT_IMAGES} reference images; got ${resolvedImages.length}.`,
+							);
+						}
+
+						const xaiBaseBody: XAIImageRequestBase = {
+							model: resolvedModel,
+							prompt,
+							aspect_ratio: aspectRatio,
+							resolution: xaiResolution,
+							n: 1,
+							response_format: "b64_json",
+						};
+						const xaiBody: XAIImageRequestBody = isEdit
+							? buildXAIEditPayload(xaiBaseBody, resolvedImages)
+							: xaiBaseBody;
+						const xaiEndpoint = isEdit ? "/images/edits" : "/images/generations";
+
+						const xaiKey: ApiKey = ctx.modelRegistry.resolver(xaiCreds.provider, {
+							sessionId,
+							baseUrl: xaiCreds.baseURL,
+						});
+
+						const xaiRawText = await withAuth(
+							xaiKey,
+							async key => {
+								const resp = await fetchImpl(`${xaiCreds.baseURL}${xaiEndpoint}`, {
+									method: "POST",
+									headers: {
+										Authorization: `Bearer ${key}`,
+										"Content-Type": "application/json",
+										"User-Agent": ohMyPiXAIUserAgent(),
+									},
+									body: JSON.stringify(xaiBody),
+									signal: requestSignal,
+								});
+								const rawText = await resp.text();
+								if (!resp.ok) {
+									let message = rawText;
+									try {
+										const parsedErr = JSON.parse(rawText) as { error?: { message?: string } };
+										message = parsedErr.error?.message ?? message;
+									} catch {
+										// Keep raw text.
+									}
+									throw new ProviderHttpError(
+										`xAI image request failed (${resp.status}): ${message}`,
+										resp.status,
+										{
+											headers: resp.headers,
+										},
+									);
+								}
+								return rawText;
+							},
+							{ signal: requestSignal },
+						);
+
+						const xaiData = JSON.parse(xaiRawText) as {
+							data?: Array<{ b64_json?: string; url?: string }>;
+						};
+						const xaiInlineImages: InlineImageData[] = [];
+						for (const entry of xaiData.data ?? []) {
+							if (entry.b64_json) {
+								const bytes = Buffer.from(entry.b64_json, "base64");
+								const mimeType = parseImageMetadata(bytes)?.mimeType ?? "image/png";
+								xaiInlineImages.push({ data: entry.b64_json, mimeType });
+							} else if (entry.url) {
+								xaiInlineImages.push(await loadImageFromUrl(entry.url, fetchImpl, requestSignal));
+							}
+						}
+
+						if (xaiInlineImages.length === 0) {
+							return {
+								content: [{ type: "text", text: "No image data returned." }],
+								details: {
+									provider,
+									model: resolvedModel,
+									imageCount: 0,
+									imagePaths: [],
+									images: [],
+								},
+							};
+						}
+
+						const xaiImagePaths = await saveImagesToTemp(xaiInlineImages);
+
+						return {
+							content: [
+								{ type: "text", text: buildResponseSummary(provider, resolvedModel, xaiImagePaths, undefined) },
+							],
+							details: {
+								provider,
+								model: resolvedModel,
+								imageCount: xaiInlineImages.length,
+								imagePaths: xaiImagePaths,
+								images: xaiInlineImages,
+							},
+						};
+					}
+
+					if (provider === "openrouter") {
+						const prompt = assemblePrompt(params);
+						const contentParts: OpenRouterContentPart[] = [{ type: "text", text: prompt }];
+						for (const image of resolvedImages) {
+							contentParts.push({ type: "image_url", image_url: { url: toDataUrl(image) } });
+						}
+
+						const requestBody = {
+							model: resolvedModel,
+							messages: [{ role: "user" as const, content: contentParts }],
+						};
+
+						const rawText = await withAuth(
+							apiKey.apiKey,
+							async key => {
+								const resp = await fetchImpl("https://openrouter.ai/api/v1/chat/completions", {
+									method: "POST",
+									headers: {
+										"Content-Type": "application/json",
+										Authorization: `Bearer ${key}`,
+										"HTTP-Referer": "https://omp.sh/",
+										"X-OpenRouter-Title": "Oh-My-Pi",
+										"X-OpenRouter-Categories": "cli-agent",
+									},
+									body: JSON.stringify(requestBody),
+									signal: requestSignal,
+								});
+								const text = await resp.text();
+								if (!resp.ok) {
+									let message = text;
+									try {
+										const parsed = JSON.parse(text) as { error?: { message?: string } };
+										message = parsed.error?.message ?? message;
+									} catch {
+										// Keep raw text.
+									}
+									throw new ProviderHttpError(
+										`OpenRouter image request failed (${resp.status}): ${message}`,
+										resp.status,
+										{ headers: resp.headers },
+									);
+								}
+								return text;
+							},
+							{ signal: requestSignal },
+						);
+
+						const data = JSON.parse(rawText) as OpenRouterResponse;
+						const message = data.choices?.[0]?.message;
+						const responseText = collectOpenRouterResponseText(message);
+						const imageUrls = extractOpenRouterImageUrls(message);
+						const inlineImages: InlineImageData[] = [];
+						for (const imageUrl of imageUrls) {
+							inlineImages.push(await loadImageFromUrl(imageUrl, fetchImpl, requestSignal));
+						}
+
+						if (inlineImages.length === 0) {
+							const messageText = responseText ? `\n\n${responseText}` : "";
+							return {
+								content: [{ type: "text", text: `No image data returned.${messageText}` }],
+								details: {
+									provider,
+									model: resolvedModel,
+									imageCount: 0,
+									imagePaths: [],
+									images: [],
+									responseText,
+								},
+							};
+						}
+
+						const imagePaths = await saveImagesToTemp(inlineImages);
+
+						return {
+							content: [
+								{ type: "text", text: buildResponseSummary(provider, resolvedModel, imagePaths, responseText) },
+							],
+							details: {
+								provider,
+								model: resolvedModel,
+								imageCount: inlineImages.length,
+								imagePaths,
+								images: inlineImages,
+								responseText,
+							},
+						};
+					}
+
+					const parts = [] as Array<{ text?: string; inlineData?: InlineImageData }>;
+					for (const image of resolvedImages) {
+						parts.push({ inlineData: image });
+					}
+					parts.push({ text: assemblePrompt(params) });
+
+					const generationConfig: {
+						responseModalities: GeminiResponseModality[];
+						imageConfig?: { aspectRatio?: string; imageSize?: string };
+					} = {
+						responseModalities: ["IMAGE"],
+					};
+
+					if (params.aspect_ratio || params.image_size) {
+						generationConfig.imageConfig = {
+							aspectRatio: params.aspect_ratio,
+							imageSize: params.image_size,
+						};
+					}
+
+					const requestBody = {
+						contents: [{ role: "user" as const, parts }],
+						generationConfig,
+					};
+
+					const rawText = await withAuth(
+						apiKey.apiKey,
+						async key => {
+							const resp = await fetchImpl(
+								`https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
+								{
+									method: "POST",
+									headers: {
+										"Content-Type": "application/json",
+										"x-goog-api-key": key,
+									},
+									body: JSON.stringify(requestBody),
+									signal: requestSignal,
+								},
+							);
+							const text = await resp.text();
+							if (!resp.ok) {
+								let message = text;
+								try {
+									const parsed = JSON.parse(text) as { error?: { message?: string } };
+									message = parsed.error?.message ?? message;
+								} catch {
+									// Keep raw text.
+								}
+								throw new ProviderHttpError(
+									`Gemini image request failed (${resp.status}): ${message}`,
+									resp.status,
+									{
+										headers: resp.headers,
+									},
+								);
+							}
+							return text;
+						},
+						{ signal: requestSignal },
+					);
+
+					const data = JSON.parse(rawText) as GeminiGenerateContentResponse;
+					const responseParts = combineParts(data);
+					const responseText = collectResponseText(responseParts);
+					const inlineImages = collectInlineImages(responseParts);
+
+					if (inlineImages.length === 0) {
+						const blocked = data.promptFeedback?.blockReason
+							? `Blocked: ${data.promptFeedback.blockReason}`
+							: "No image data returned.";
+						return {
+							content: [{ type: "text", text: `${blocked}${responseText ? `\n\n${responseText}` : ""}` }],
+							details: {
+								provider,
+								model,
+								imageCount: 0,
+								imagePaths: [],
+								images: [],
+								responseText,
+								promptFeedback: data.promptFeedback,
+								usage: data.usageMetadata,
+							},
+						};
+					}
+
+					const imagePaths = await saveImagesToTemp(inlineImages);
+
+					return {
+						content: [{ type: "text", text: buildResponseSummary(provider, model, imagePaths, responseText) }],
+						details: {
+							provider,
+							model,
+							imageCount: inlineImages.length,
+							imagePaths,
+							images: inlineImages,
+							responseText,
+							promptFeedback: data.promptFeedback,
+							usage: data.usageMetadata,
+						},
+					};
+				} catch (error) {
+					if (!(error instanceof ProviderHttpError) || requestSignal?.aborted) {
+						throw error;
+					}
+					failures.push({ provider, error });
+				}
+			}
+
+			if (!foundCredentials) {
 				throw new Error(
 					"No image API credentials found. Use a GPT Responses/Codex model with OpenAI credentials, login with google-antigravity or xAI Grok OAuth, or set XAI_API_KEY, OPENROUTER_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY.",
 				);
 			}
 
-			const provider = apiKey.provider;
-			const model =
-				provider === "openai" || provider === "openai-codex"
-					? (apiKey.model?.id ?? "gpt")
-					: provider === "antigravity"
-						? DEFAULT_ANTIGRAVITY_MODEL
-						: provider === "openrouter"
-							? DEFAULT_OPENROUTER_MODEL
-							: provider === "xai"
-								? DEFAULT_XAI_IMAGE_MODEL
-								: DEFAULT_MODEL;
-			const resolvedModel = provider === "openrouter" ? resolveOpenRouterModel(model) : model;
-			assertImageAspectRatioSupported(provider, params.aspect_ratio);
-			const cwd = ctx.sessionManager.getCwd();
-
-			const resolvedImages: InlineImageData[] = [];
-			if (params.input?.length) {
-				for (const input of params.input) {
-					resolvedImages.push(await resolveInputImage(input, cwd));
-				}
-			}
-
-			const requestSignal = ptree.combineSignals(signal, IMAGE_TIMEOUT);
-			const fetchImpl = ctx.fetch ?? fetch;
-
-			if (provider === "openai" || provider === "openai-codex") {
-				if (!apiKey.model) {
-					throw new Error("Missing active GPT model for OpenAI image generation");
-				}
-
-				const hostedModel = apiKey.model;
-				const hostedKey: ApiKey = ctx.modelRegistry.resolver(hostedModel, sessionId);
-
-				const parsed = await withAuth(
-					hostedKey,
-					key =>
-						generateOpenAIHostedImage(
-							key,
-							hostedModel,
-							params,
-							resolvedImages,
-							fetchImpl,
-							requestSignal,
-							sessionId,
-						),
-					{ signal: requestSignal },
-				);
-
-				if (parsed.images.length === 0) {
-					const messageText = parsed.responseText ? `\n\n${parsed.responseText}` : "";
-					return {
-						content: [{ type: "text", text: `No image data returned.${messageText}` }],
-						details: {
-							provider,
-							model,
-							imageCount: 0,
-							imagePaths: [],
-							images: [],
-							responseText: parsed.responseText,
-							revisedPrompt: parsed.revisedPrompt,
-							usage: parsed.usage,
-						},
-					};
-				}
-
-				const imagePaths = await saveImagesToTemp(parsed.images);
-
-				return {
-					content: [
-						{ type: "text", text: buildResponseSummary(provider, model, imagePaths, parsed.responseText) },
-					],
-					details: {
-						provider,
-						model,
-						imageCount: parsed.images.length,
-						imagePaths,
-						images: parsed.images,
-						responseText: parsed.responseText,
-						revisedPrompt: parsed.revisedPrompt,
-						usage: parsed.usage,
-					},
-				};
-			}
-
-			if (provider === "antigravity") {
-				if (!apiKey.projectId) {
-					throw new Error("Missing projectId in antigravity credentials");
-				}
-
-				const prompt = assemblePrompt(params);
-				const antigravityKey: ApiKey = ctx.modelRegistry.resolver("google-antigravity", {
-					sessionId,
-					modelId: DEFAULT_ANTIGRAVITY_MODEL,
-				});
-
-				const response = await withAuth(
-					antigravityKey,
-					async key => {
-						// On a retry the resolver yields the raw stored credential JSON
-						// ({ token, projectId }); the initial seed is the already-parsed
-						// access token. Tolerate both, falling back to the seed projectId.
-						const rotated = parseAntigravityCredentials(key);
-						const bearer = rotated?.accessToken ?? key;
-						const projectId = rotated?.projectId ?? apiKey.projectId!;
-						const requestBody = buildAntigravityRequest(
-							prompt,
-							model,
-							projectId,
-							params.aspect_ratio,
-							params.image_size,
-							resolvedImages,
-						);
-
-						let endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD, DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-						try {
-							const mode = settings.get("providers.antigravityEndpoint");
-							if (mode === "production") {
-								endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_PROD];
-							} else if (mode === "sandbox") {
-								endpoints = [DEFAULT_ANTIGRAVITY_ENDPOINT_SANDBOX];
-							}
-						} catch {
-							// Ignored
-						}
-
-						let resp: Response | undefined;
-						let lastError: Error | undefined;
-
-						for (let i = 0; i < endpoints.length; i++) {
-							const endpoint = endpoints[i];
-							const isLastEndpoint = i === endpoints.length - 1;
-							try {
-								resp = await fetchImpl(`${endpoint}/v1internal:streamGenerateContent?alt=sse`, {
-									method: "POST",
-									headers: {
-										Authorization: `Bearer ${bearer}`,
-										"Content-Type": "application/json",
-										Accept: "text/event-stream",
-										"User-Agent": getAntigravityUserAgent(),
-									},
-									body: JSON.stringify(requestBody),
-									signal: requestSignal,
-								});
-
-								if (resp.ok) {
-									break;
-								}
-
-								const errorText = await resp.text();
-								let message = errorText;
-								try {
-									const parsedErr = JSON.parse(errorText) as { error?: { message?: string } };
-									message = parsedErr.error?.message ?? message;
-								} catch {
-									// Keep raw text.
-								}
-
-								lastError = new ProviderHttpError(
-									`Antigravity image request failed (${resp.status}): ${message}`,
-									resp.status,
-									{ headers: resp.headers },
-								);
-
-								if (resp.status === 429 || (resp.status >= 500 && resp.status < 600)) {
-									if (!isLastEndpoint) {
-										continue;
-									}
-								}
-								break;
-							} catch (error) {
-								lastError = error as Error;
-								if (isLastEndpoint) {
-									break;
-								}
-							}
-						}
-
-						if (!resp?.ok) {
-							throw lastError ?? new Error("Antigravity image generation failed");
-						}
-
-						return resp;
-					},
-					{ signal: requestSignal },
-				);
-
-				const parsed = await parseAntigravitySseForImage(response, requestSignal);
-				const responseText = parsed.text.length > 0 ? parsed.text.join(" ") : undefined;
-
-				if (parsed.images.length === 0) {
-					const messageText = responseText ? `\n\n${responseText}` : "";
-					return {
-						content: [{ type: "text", text: `No image data returned.${messageText}` }],
-						details: {
-							provider,
-							model,
-							imageCount: 0,
-							imagePaths: [],
-							images: [],
-							responseText,
-							usage: parsed.usage,
-						},
-					};
-				}
-
-				const imagePaths = await saveImagesToTemp(parsed.images);
-
-				return {
-					content: [{ type: "text", text: buildResponseSummary(provider, model, imagePaths, responseText) }],
-					details: {
-						provider,
-						model,
-						imageCount: parsed.images.length,
-						imagePaths,
-						images: parsed.images,
-						responseText,
-						usage: parsed.usage,
-					},
-				};
-			}
-
-			if (provider === "xai") {
-				if (!ctx.modelRegistry) {
-					throw new Error("Missing modelRegistry for xAI image generation");
-				}
-				const xaiCreds = await resolveXAIHttpCredentials(ctx.modelRegistry, resolvedModel);
-				if (!xaiCreds) {
-					throw new Error(
-						"No xAI credentials. Run /login → xAI Grok OAuth (SuperGrok or X Premium+) or set XAI_API_KEY.",
-					);
-				}
-
-				const prompt = assemblePrompt(params);
-				const aspectRatio = params.aspect_ratio ?? "1:1";
-				const xaiResolution = resolveXAIResolution(params.image_size);
-
-				const isEdit = resolvedImages.length > 0;
-				if (isEdit && resolvedImages.length > XAI_MAX_EDIT_IMAGES) {
-					throw new Error(
-						`xAI image edits accept up to ${XAI_MAX_EDIT_IMAGES} reference images; got ${resolvedImages.length}.`,
-					);
-				}
-
-				const xaiBaseBody: XAIImageRequestBase = {
-					model: resolvedModel,
-					prompt,
-					aspect_ratio: aspectRatio,
-					resolution: xaiResolution,
-					n: 1,
-					response_format: "b64_json",
-				};
-				const xaiBody: XAIImageRequestBody = isEdit
-					? buildXAIEditPayload(xaiBaseBody, resolvedImages)
-					: xaiBaseBody;
-				const xaiEndpoint = isEdit ? "/images/edits" : "/images/generations";
-
-				const xaiKey: ApiKey = ctx.modelRegistry.resolver(xaiCreds.provider, {
-					sessionId,
-					baseUrl: xaiCreds.baseURL,
-				});
-
-				const xaiRawText = await withAuth(
-					xaiKey,
-					async key => {
-						const resp = await fetchImpl(`${xaiCreds.baseURL}${xaiEndpoint}`, {
-							method: "POST",
-							headers: {
-								Authorization: `Bearer ${key}`,
-								"Content-Type": "application/json",
-								"User-Agent": ohMyPiXAIUserAgent(),
-							},
-							body: JSON.stringify(xaiBody),
-							signal: requestSignal,
-						});
-						const rawText = await resp.text();
-						if (!resp.ok) {
-							let message = rawText;
-							try {
-								const parsedErr = JSON.parse(rawText) as { error?: { message?: string } };
-								message = parsedErr.error?.message ?? message;
-							} catch {
-								// Keep raw text.
-							}
-							throw new ProviderHttpError(`xAI image request failed (${resp.status}): ${message}`, resp.status, {
-								headers: resp.headers,
-							});
-						}
-						return rawText;
-					},
-					{ signal: requestSignal },
-				);
-
-				const xaiData = JSON.parse(xaiRawText) as {
-					data?: Array<{ b64_json?: string; url?: string }>;
-				};
-				const xaiInlineImages: InlineImageData[] = [];
-				for (const entry of xaiData.data ?? []) {
-					if (entry.b64_json) {
-						const bytes = Buffer.from(entry.b64_json, "base64");
-						const mimeType = parseImageMetadata(bytes)?.mimeType ?? "image/png";
-						xaiInlineImages.push({ data: entry.b64_json, mimeType });
-					} else if (entry.url) {
-						xaiInlineImages.push(await loadImageFromUrl(entry.url, fetchImpl, requestSignal));
-					}
-				}
-
-				if (xaiInlineImages.length === 0) {
-					return {
-						content: [{ type: "text", text: "No image data returned." }],
-						details: {
-							provider,
-							model: resolvedModel,
-							imageCount: 0,
-							imagePaths: [],
-							images: [],
-						},
-					};
-				}
-
-				const xaiImagePaths = await saveImagesToTemp(xaiInlineImages);
-
-				return {
-					content: [
-						{ type: "text", text: buildResponseSummary(provider, resolvedModel, xaiImagePaths, undefined) },
-					],
-					details: {
-						provider,
-						model: resolvedModel,
-						imageCount: xaiInlineImages.length,
-						imagePaths: xaiImagePaths,
-						images: xaiInlineImages,
-					},
-				};
-			}
-
-			if (provider === "openrouter") {
-				const prompt = assemblePrompt(params);
-				const contentParts: OpenRouterContentPart[] = [{ type: "text", text: prompt }];
-				for (const image of resolvedImages) {
-					contentParts.push({ type: "image_url", image_url: { url: toDataUrl(image) } });
-				}
-
-				const requestBody = {
-					model: resolvedModel,
-					messages: [{ role: "user" as const, content: contentParts }],
-				};
-
-				const rawText = await withAuth(
-					apiKey.apiKey,
-					async key => {
-						const resp = await fetchImpl("https://openrouter.ai/api/v1/chat/completions", {
-							method: "POST",
-							headers: {
-								"Content-Type": "application/json",
-								Authorization: `Bearer ${key}`,
-								"HTTP-Referer": "https://omp.sh/",
-								"X-OpenRouter-Title": "Oh-My-Pi",
-								"X-OpenRouter-Categories": "cli-agent",
-							},
-							body: JSON.stringify(requestBody),
-							signal: requestSignal,
-						});
-						const text = await resp.text();
-						if (!resp.ok) {
-							let message = text;
-							try {
-								const parsed = JSON.parse(text) as { error?: { message?: string } };
-								message = parsed.error?.message ?? message;
-							} catch {
-								// Keep raw text.
-							}
-							throw new ProviderHttpError(
-								`OpenRouter image request failed (${resp.status}): ${message}`,
-								resp.status,
-								{ headers: resp.headers },
-							);
-						}
-						return text;
-					},
-					{ signal: requestSignal },
-				);
-
-				const data = JSON.parse(rawText) as OpenRouterResponse;
-				const message = data.choices?.[0]?.message;
-				const responseText = collectOpenRouterResponseText(message);
-				const imageUrls = extractOpenRouterImageUrls(message);
-				const inlineImages: InlineImageData[] = [];
-				for (const imageUrl of imageUrls) {
-					inlineImages.push(await loadImageFromUrl(imageUrl, fetchImpl, requestSignal));
-				}
-
-				if (inlineImages.length === 0) {
-					const messageText = responseText ? `\n\n${responseText}` : "";
-					return {
-						content: [{ type: "text", text: `No image data returned.${messageText}` }],
-						details: {
-							provider,
-							model: resolvedModel,
-							imageCount: 0,
-							imagePaths: [],
-							images: [],
-							responseText,
-						},
-					};
-				}
-
-				const imagePaths = await saveImagesToTemp(inlineImages);
-
-				return {
-					content: [
-						{ type: "text", text: buildResponseSummary(provider, resolvedModel, imagePaths, responseText) },
-					],
-					details: {
-						provider,
-						model: resolvedModel,
-						imageCount: inlineImages.length,
-						imagePaths,
-						images: inlineImages,
-						responseText,
-					},
-				};
-			}
-
-			const parts = [] as Array<{ text?: string; inlineData?: InlineImageData }>;
-			for (const image of resolvedImages) {
-				parts.push({ inlineData: image });
-			}
-			parts.push({ text: assemblePrompt(params) });
-
-			const generationConfig: {
-				responseModalities: GeminiResponseModality[];
-				imageConfig?: { aspectRatio?: string; imageSize?: string };
-			} = {
-				responseModalities: ["IMAGE"],
-			};
-
-			if (params.aspect_ratio || params.image_size) {
-				generationConfig.imageConfig = {
-					aspectRatio: params.aspect_ratio,
-					imageSize: params.image_size,
-				};
-			}
-
-			const requestBody = {
-				contents: [{ role: "user" as const, parts }],
-				generationConfig,
-			};
-
-			const rawText = await withAuth(
-				apiKey.apiKey,
-				async key => {
-					const resp = await fetchImpl(
-						`https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
-						{
-							method: "POST",
-							headers: {
-								"Content-Type": "application/json",
-								"x-goog-api-key": key,
-							},
-							body: JSON.stringify(requestBody),
-							signal: requestSignal,
-						},
-					);
-					const text = await resp.text();
-					if (!resp.ok) {
-						let message = text;
-						try {
-							const parsed = JSON.parse(text) as { error?: { message?: string } };
-							message = parsed.error?.message ?? message;
-						} catch {
-							// Keep raw text.
-						}
-						throw new ProviderHttpError(`Gemini image request failed (${resp.status}): ${message}`, resp.status, {
-							headers: resp.headers,
-						});
-					}
-					return text;
-				},
-				{ signal: requestSignal },
+			throw new AggregateError(
+				failures.map(failure => failure.error),
+				`Image generation failed for all credentialed providers: ${failures.map(failure => failure.provider).join(", ")}`,
 			);
-
-			const data = JSON.parse(rawText) as GeminiGenerateContentResponse;
-			const responseParts = combineParts(data);
-			const responseText = collectResponseText(responseParts);
-			const inlineImages = collectInlineImages(responseParts);
-
-			if (inlineImages.length === 0) {
-				const blocked = data.promptFeedback?.blockReason
-					? `Blocked: ${data.promptFeedback.blockReason}`
-					: "No image data returned.";
-				return {
-					content: [{ type: "text", text: `${blocked}${responseText ? `\n\n${responseText}` : ""}` }],
-					details: {
-						provider,
-						model,
-						imageCount: 0,
-						imagePaths: [],
-						images: [],
-						responseText,
-						promptFeedback: data.promptFeedback,
-						usage: data.usageMetadata,
-					},
-				};
-			}
-
-			const imagePaths = await saveImagesToTemp(inlineImages);
-
-			return {
-				content: [{ type: "text", text: buildResponseSummary(provider, model, imagePaths, responseText) }],
-				details: {
-					provider,
-					model,
-					imageCount: inlineImages.length,
-					imagePaths,
-					images: inlineImages,
-					responseText,
-					promptFeedback: data.promptFeedback,
-					usage: data.usageMetadata,
-				},
-			};
 		});
 	},
 };

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -394,6 +394,59 @@ describe("imageGenTool", () => {
 		expect(result.details?.provider).toBe("xai");
 	});
 
+	it("falls back to xAI after the active OpenAI provider HTTP failure", async () => {
+		const requestUrls: string[] = [];
+		const fetchMock = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.startsWith("https://api.openai.com/")) {
+				return new Response(JSON.stringify({ error: { message: "model unavailable" } }), {
+					status: 404,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("openai-fallback-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const model = {
+			api: "openai-responses",
+			provider: "openai",
+			id: "gpt-5.5",
+			name: "GPT 5.5",
+			baseUrl: "https://api.openai.com/v1",
+		} as Model;
+		const ctx: CustomToolContext = {
+			fetch: fetchMock,
+			sessionManager: {
+				getCwd: () => "/tmp",
+				getSessionId: () => "test-session",
+			} as unknown as ReadonlySessionManager,
+			modelRegistry: {
+				getApiKey: async () => "test-openai-key",
+				getApiKeyForProvider: async (provider: string) => (provider === "xai-oauth" ? "test-xai-token" : undefined),
+				getProviderBaseUrl: () => undefined,
+				getAll: () => [],
+				authStorage: {
+					hasNonEnvCredential: (provider: string) => provider === "xai-oauth",
+					rotateSessionCredential: async () => false,
+				},
+				resolver: () => async () => "test-openai-key",
+			} as unknown as ModelRegistry,
+			model,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort: () => {},
+		};
+
+		const result = await imageGenTool.execute("call-openai-fallback-xai", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual(["https://api.openai.com/v1/responses", "https://api.x.ai/v1/images/generations"]);
+		expect(result.details?.provider).toBe("xai");
+	});
+
 	it("falls back to xAI after an earlier provider HTTP failure", async () => {
 		const requestUrls: string[] = [];
 		const fetchMock = (async (input: string | URL | Request) => {

--- a/packages/coding-agent/test/tools/image-gen.test.ts
+++ b/packages/coding-agent/test/tools/image-gen.test.ts
@@ -24,6 +24,37 @@ afterEach(async () => {
 	setPreferredImageProvider("auto");
 });
 
+function createAntigravityXAIContext(model: Model | undefined, fetchMock: typeof fetch): CustomToolContext {
+	const antigravityCredentials = JSON.stringify({ token: "test-antigravity-token", projectId: "test-project" });
+	return {
+		fetch: fetchMock,
+		sessionManager: {
+			getCwd: () => "/tmp",
+			getSessionId: () => "test-session",
+		} as unknown as ReadonlySessionManager,
+		modelRegistry: {
+			getApiKey: async () => undefined,
+			getApiKeyForProvider: async (provider: string) => {
+				if (provider === "google-antigravity") return antigravityCredentials;
+				if (provider === "xai-oauth") return "test-xai-token";
+				return undefined;
+			},
+			getProviderBaseUrl: () => undefined,
+			getAll: () => [],
+			authStorage: {
+				hasNonEnvCredential: (provider: string) => provider === "xai-oauth",
+				rotateSessionCredential: async () => false,
+			},
+			resolver: (provider: string) => async () =>
+				provider === "google-antigravity" ? antigravityCredentials : "test-xai-token",
+		} as unknown as ModelRegistry,
+		model,
+		isIdle: () => true,
+		hasQueuedMessages: () => false,
+		abort: () => {},
+	};
+}
+
 describe("imageGenTool", () => {
 	it("registers without resolving image provider credentials", async () => {
 		const modelRegistry = {
@@ -332,5 +363,62 @@ describe("imageGenTool", () => {
 		const savedPath = result.details?.imagePaths[0];
 		if (!savedPath) throw new Error("Expected generated image path");
 		expect(await Bun.file(savedPath).bytes()).toEqual(Buffer.from("fake-xai-image"));
+	});
+
+	it("prefers the active xAI provider over unrelated credentialed providers", async () => {
+		const requestUrls: string[] = [];
+		const fetchMock = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (!url.startsWith("https://api.x.ai/")) {
+				throw new Error(`Unexpected provider request: ${url}`);
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("active-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const model = {
+			api: "openai-completions",
+			provider: "xai-oauth",
+			id: "grok-4.5",
+			name: "Grok 4.5",
+			baseUrl: "https://api.x.ai/v1",
+		} as Model;
+		const ctx = createAntigravityXAIContext(model, fetchMock);
+
+		const result = await imageGenTool.execute("call-active-xai", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual(["https://api.x.ai/v1/images/generations"]);
+		expect(result.details?.provider).toBe("xai");
+	});
+
+	it("falls back to xAI after an earlier provider HTTP failure", async () => {
+		const requestUrls: string[] = [];
+		const fetchMock = (async (input: string | URL | Request) => {
+			const url = input.toString();
+			requestUrls.push(url);
+			if (url.includes("streamGenerateContent")) {
+				return new Response(JSON.stringify({ error: { message: "image endpoint unavailable" } }), {
+					status: 404,
+					headers: { "content-type": "application/json" },
+				});
+			}
+			return new Response(
+				JSON.stringify({ data: [{ b64_json: Buffer.from("fallback-xai-image").toString("base64") }] }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+		const ctx = createAntigravityXAIContext(undefined, fetchMock);
+
+		const result = await imageGenTool.execute("call-fallback-xai", { subject: "a cat" }, undefined, ctx);
+		generatedImagePaths.push(...(result.details?.imagePaths ?? []));
+
+		expect(requestUrls).toEqual([
+			"https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse",
+			"https://api.x.ai/v1/images/generations",
+		]);
+		expect(result.details?.provider).toBe("xai");
 	});
 });


### PR DESCRIPTION
## Repro
With both `google-antigravity` and xAI credentials available, run `bun test packages/coding-agent/test/tools/image-gen.test.ts`: before the fix, an active `xai-oauth/grok-4.5` model still dispatched to Antigravity, and a mocked Antigravity `404` stopped the call before xAI was requested.

## Cause
`packages/coding-agent/src/tools/image-gen.ts` resolved one credential through `findImageApiKey` using a fixed OpenAI → Antigravity → xAI order, except for a soft explicit preference. The active model only influenced OpenAI eligibility, and `imageGenTool.execute` dispatched exactly once, so a selected provider's `ProviderHttpError` could not re-enter resolution.

## Fix
- Build a deduplicated provider order from the explicit preference, active session provider family, and existing automatic priority.
- Resolve credentials lazily and continue to the next credentialed provider after `ProviderHttpError`, while preserving aborts and non-provider failures.
- Cover active xAI affinity and Antigravity-404-to-xAI fallback, update the settings description, and document the fix in the changelog.

## Verification
`bun test packages/coding-agent/test/tools/image-gen.test.ts` — 8 passed, 0 failed. `bun check` — passed across all packages. Fixes #5218