### PR TITLE
fix(eval): tail status-event log lines so latest progress stays visible

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed eval `log()`/`phase()` progress showing only the first few status lines: the transcript now tails the most recent events (with a `… N earlier` marker) so long workflows surface their latest progress, and ctrl+o widens the tail window instead of jumping back to the start. ([#5231](https://github.com/can1357/oh-my-pi/issues/5231))
+
 ## [16.4.5] - 2026-07-11
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/__tests__/eval-render.test.ts
+++ b/packages/coding-agent/src/tools/__tests__/eval-render.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Contract: eval status-event rendering keeps the MOST RECENT log()/phase()
+ * events visible.
+ *
+ * A long orchestration streams many status events onto the cell. The collapsed
+ * and expanded transcript views must show the tail (latest progress) with a
+ * `… N earlier` marker on top — not freeze on the first few events. Regression
+ * for #5231 ("eval logs are not scrolling up").
+ */
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { EvalStatusEvent, EvalToolDetails } from "../../eval/types";
+import { getThemeByName, type Theme } from "../../modes/theme/theme";
+import { evalToolRenderer } from "../eval-render";
+
+const strip = (lines: readonly string[]): string[] => lines.map(line => line.replace(/\x1b\[[0-9;]*m/g, ""));
+
+function renderStatusOutput(statusEvents: EvalStatusEvent[], expanded: boolean, theme: Theme): string[] {
+	const details: EvalToolDetails = {
+		language: "js",
+		languages: ["js"],
+		cells: [{ index: 0, code: "for (…) log(…)", language: "js", output: "", status: "complete", statusEvents }],
+	};
+	const component = evalToolRenderer.renderResult(
+		{ content: [{ type: "text", text: "" }], details },
+		{ expanded, isPartial: false },
+		theme,
+	) as { render(width: number): readonly string[] };
+	return strip(component.render(80));
+}
+
+describe("eval status-event rendering", () => {
+	let uiTheme: Theme;
+	beforeAll(async () => {
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("dark theme unavailable");
+		uiTheme = loaded;
+	});
+
+	const manyEvents = (): EvalStatusEvent[] =>
+		Array.from({ length: 20 }, (_, i) => ({ op: "log", message: `step ${i + 1} of workflow` }));
+
+	it("collapsed view shows the latest events, not the first few", () => {
+		const output = renderStatusOutput(manyEvents(), false, uiTheme).join("\n");
+
+		expect(output).toContain("step 20 of workflow");
+		expect(output).toContain("step 18 of workflow");
+		expect(output).not.toContain("step 1 of workflow");
+		expect(output).toContain("17 earlier");
+	});
+
+	it("expanded view widens the tail window toward the newest events", () => {
+		const output = renderStatusOutput(manyEvents(), true, uiTheme).join("\n");
+
+		expect(output).toContain("step 20 of workflow");
+		expect(output).toContain("step 11 of workflow");
+		expect(output).not.toContain("step 10 of workflow");
+		expect(output).toContain("10 earlier");
+	});
+
+	it("shows all events without an elision marker when they fit", () => {
+		const output = renderStatusOutput([{ op: "log", message: "only step" }], false, uiTheme).join("\n");
+
+		expect(output).toContain("only step");
+		expect(output).not.toContain("earlier");
+	});
+});

--- a/packages/coding-agent/src/tools/eval-render.ts
+++ b/packages/coding-agent/src/tools/eval-render.ts
@@ -414,17 +414,32 @@ function formatStatusEventExpanded(event: EvalStatusEvent, theme: Theme): string
 	return lines;
 }
 
-/** Render status events as tree lines. */
+/**
+ * Render status events as tree lines, keeping the MOST RECENT events.
+ *
+ * `log()`/`phase()` calls stream in as status events; a long orchestration
+ * accumulates many. We show the tail (latest progress) with a `… N earlier`
+ * marker on top — mirroring how streamed stdout and the code cell tail their
+ * windows — so the newest lines stay visible instead of freezing on the first
+ * few. Expanding (ctrl+o) widens the tail window rather than jumping to the head.
+ */
 function renderStatusEvents(events: EvalStatusEvent[], theme: Theme, expanded: boolean): string[] {
 	if (events.length === 0) return [];
 
 	const maxCollapsed = 3;
 	const maxExpanded = 10;
-	const displayCount = expanded ? Math.min(events.length, maxExpanded) : Math.min(events.length, maxCollapsed);
+	const cap = expanded ? maxExpanded : maxCollapsed;
+	const displayCount = Math.min(events.length, cap);
+	const startIndex = events.length - displayCount;
+	const hiddenCount = startIndex;
 
 	const lines: string[] = [];
-	for (let i = 0; i < displayCount; i++) {
-		const isLast = i === displayCount - 1 && (expanded || events.length <= maxCollapsed);
+	if (hiddenCount > 0) {
+		lines.push(`${theme.fg("dim", theme.tree.branch)} ${theme.fg("dim", `… ${hiddenCount} earlier`)}`);
+	}
+
+	for (let i = startIndex; i < events.length; i++) {
+		const isLast = i === events.length - 1;
 		const branch = isLast ? theme.tree.last : theme.tree.branch;
 
 		if (expanded) {
@@ -437,12 +452,6 @@ function renderStatusEvents(events: EvalStatusEvent[], theme: Theme, expanded: b
 		} else {
 			lines.push(`${theme.fg("dim", branch)} ${formatStatusEvent(events[i], theme)}`);
 		}
-	}
-
-	if (!expanded && events.length > maxCollapsed) {
-		lines.push(`${theme.fg("dim", theme.tree.last)} ${theme.fg("dim", `… ${events.length - maxCollapsed} more`)}`);
-	} else if (expanded && events.length > maxExpanded) {
-		lines.push(`${theme.fg("dim", theme.tree.last)} ${theme.fg("dim", `… ${events.length - maxExpanded} more`)}`);
 	}
 
 	return lines;


### PR DESCRIPTION
## Repro
Running a long eval workflow that emits many `log()`/`phase()` progress lines shows only the *first* few lines in the TUI, and ctrl+o expands only within those first lines — the current/latest progress is never visible. Reproduced with a renderer harness feeding `evalToolRenderer.renderResult` a cell whose `statusEvents` holds 20 `log()` events: collapsed showed steps 1–3, expanded showed steps 1–10, and steps 11–20 were unreachable.

## Cause
`log()`/`phase()` calls accumulate as per-cell status events (`EvalCellResult.statusEvents`). `renderStatusEvents` in `packages/coding-agent/src/tools/eval-render.ts` sliced those events from the front (`events[0..2]` collapsed, `events[0..9]` expanded) with a trailing `… N more`, so only the oldest events ever rendered and expanding just widened the head window.

## Fix
- Rewrote `renderStatusEvents` to keep the **tail** (most recent events): compute `startIndex = events.length - displayCount`, iterate from there, and emit a `… N earlier` marker on top when events are hidden — mirroring how streamed stdout and the code cell already tail their windows. Expanding (ctrl+o) widens the tail window (3 → 10) toward the newest events rather than jumping to the head.
- Added `packages/coding-agent/src/tools/__tests__/eval-render.test.ts` asserting the collapsed view keeps the latest events (step 20 present, step 1 absent, `17 earlier`), the expanded view widens the tail (step 11 present, step 10 absent, `10 earlier`), and no marker appears when events fit.

## Verification
`bun test packages/coding-agent/src/tools/__tests__/eval-render.test.ts` → 3 pass, 10 expect() calls. Also re-ran the manual renderer harness: collapsed now shows `… 17 earlier` + steps 18–20; expanded shows `… 10 earlier` + steps 11–20. `lsp diagnostics` clean on the changed files.

Fixes #5231