### PR TITLE
fix(model-resolver): strip thinking suffix before fuzzy model match

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a role with a `:high` thinking suffix resolving to a longer sibling model whose id embeds the tier name (e.g. `kimi-for-coding:high` → `kimi-for-coding-highspeed`). The thinking suffix is now stripped before any fuzzy match, so `provider/model:high` keeps the exact model at high effort ([#5151](https://github.com/can1357/oh-my-pi/issues/5151)).
+
 ## [16.4.2] - 2026-07-10
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -617,11 +617,18 @@ function findExactModelReferenceMatch(modelReference: string, availableModels: M
  * 4. provider-scoped fuzzy match,
  * 5. substring match with the alias-vs-dated pick.
  * Returns the matched model or undefined if no match found.
+ *
+ * `exactOnly` stops after the exact phases (1-3), skipping the fuzzy/substring
+ * fallbacks (4-5). Callers use it to resolve the full selector exactly before
+ * a trailing `:<level>` thinking suffix is split off, so the suffix can never
+ * be fuzzily absorbed into a longer sibling id (e.g. `kimi-for-coding:high`
+ * must not match `kimi-for-coding-highspeed`).
  */
 function matchModel(
 	modelPattern: string,
 	availableModels: Model<Api>[],
 	context: ModelPreferenceContext,
+	options?: { exactOnly?: boolean },
 ): Model<Api> | undefined {
 	const exactRefMatch = findExactModelReferenceMatch(modelPattern, availableModels);
 	if (exactRefMatch) {
@@ -656,6 +663,14 @@ function matchModel(
 			const preferred = bareAlias ? aliasMatches.filter(m => bareAlias.providers.includes(m.provider)) : [];
 			return pickPreferredModel(preferred.length > 0 ? preferred : aliasMatches, context);
 		}
+	}
+
+	// Exact phases exhausted. Fuzzy/substring fallbacks (below) subsequence-match
+	// the whole pattern and would let a trailing `:<level>` thinking suffix bleed
+	// into a longer sibling id; callers that still hold an unstripped suffix ask
+	// for exact-only so the suffix is split off before any fuzzy attempt.
+	if (options?.exactOnly) {
+		return undefined;
 	}
 	// Check for provider/modelId format — fuzzy match within provider only.
 	const slashIndex = modelPattern.indexOf("/");
@@ -760,15 +775,18 @@ function parseModelPatternWithContext(
 	context: ModelPreferenceContext,
 	options?: { allowInvalidThinkingSelectorFallback?: boolean },
 ): ParsedModelResult {
-	// Try exact match first
-	const exactMatch = matchModel(pattern, availableModels, context);
+	// Exact match on the full pattern first (no fuzzy): a literal id that
+	// contains a colon (`coding-router:max`) wins over any suffix split.
+	const exactMatch = matchModel(pattern, availableModels, context, { exactOnly: true });
 	if (exactMatch) {
 		return { model: exactMatch, thinkingLevel: undefined, warning: undefined, explicitThinkingLevel: false };
 	}
 
-	// No match - try stripping a valid thinking suffix and recursing.
-	// `max` is accepted only after the full pattern failed, so literal model IDs
-	// ending in `:max` keep winning over the thinking suffix.
+	// Strip a valid thinking suffix and recurse BEFORE any fuzzy match, so a
+	// `:<level>` suffix can never be subsequence-absorbed into a longer sibling
+	// id (e.g. `kimi-for-coding:high` must not match `kimi-for-coding-highspeed`).
+	// `max` is accepted only after the exact match above failed, so literal model
+	// IDs ending in `:max` keep winning over the thinking suffix.
 	const { base, level } = splitThinkingSuffix(pattern, -1, MAX_THINKING_SUFFIX_OPTIONS);
 	if (level) {
 		const result = parseModelPatternWithContext(base, availableModels, context, options);
@@ -783,6 +801,13 @@ function parseModelPatternWithContext(
 			};
 		}
 		return result;
+	}
+
+	// No valid thinking suffix: fall back to fuzzy/substring matching on the
+	// whole pattern.
+	const fallbackMatch = matchModel(pattern, availableModels, context);
+	if (fallbackMatch) {
+		return { model: fallbackMatch, thinkingLevel: undefined, warning: undefined, explicitThinkingLevel: false };
 	}
 
 	const lastColonIndex = pattern.lastIndexOf(":");

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -142,6 +142,38 @@ const mockMaxSuffixModels: Model<Api>[] = [
 	}),
 ];
 
+// Sibling models where one id is a prefix of the other AND the longer id embeds
+// a thinking-tier token (`-highspeed` contains `high`). Regression fixture for
+// the fuzzy match swallowing a `:high` thinking suffix into the longer id.
+const mockThinkingSuffixSiblingModels: Model<"openai-completions">[] = [
+	buildModel({
+		id: "kimi-for-coding",
+		name: "K2.7 Code",
+		api: "openai-completions",
+		provider: "kimi-code",
+		baseUrl: "https://api.kimi.com/coding/v1",
+		reasoning: true,
+		thinking: { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] },
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 262144,
+		maxTokens: 32000,
+	}),
+	buildModel({
+		id: "kimi-for-coding-highspeed",
+		name: "K2.7 Code Highspeed",
+		api: "openai-completions",
+		provider: "kimi-code",
+		baseUrl: "https://api.kimi.com/coding/v1",
+		reasoning: true,
+		thinking: { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] },
+		input: ["text", "image"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 262144,
+		maxTokens: 32000,
+	}),
+];
+
 const mockAutoSuffixModels: Model<Api>[] = [
 	buildModel({
 		id: "runtime:auto",
@@ -467,6 +499,30 @@ describe("parseModelPattern", () => {
 			expect(result.thinkingLevel).toBeUndefined();
 			expect(result.explicitThinkingLevel).toBe(false);
 			expect(result.warning).toBeUndefined();
+		});
+
+		test("thinking suffix is stripped before fuzzy match, never absorbed into a longer sibling id", () => {
+			// `kimi-for-coding:high` must resolve to the standard model at high effort,
+			// not fuzzy-match `kimi-for-coding-highspeed` (issue #5151).
+			const result = parseModelPattern("kimi-code/kimi-for-coding:high", mockThinkingSuffixSiblingModels);
+			expect(result.model?.id).toBe("kimi-for-coding");
+			expect(result.thinkingLevel).toBe(Effort.High);
+			expect(result.explicitThinkingLevel).toBe(true);
+			expect(result.warning).toBeUndefined();
+		});
+
+		test("bare id thinking suffix is stripped before fuzzy match against a longer sibling", () => {
+			const result = parseModelPattern("kimi-for-coding:high", mockThinkingSuffixSiblingModels);
+			expect(result.model?.id).toBe("kimi-for-coding");
+			expect(result.thinkingLevel).toBe(Effort.High);
+			expect(result.explicitThinkingLevel).toBe(true);
+		});
+
+		test("the longer sibling still resolves exactly with its own thinking suffix", () => {
+			const result = parseModelPattern("kimi-code/kimi-for-coding-highspeed:high", mockThinkingSuffixSiblingModels);
+			expect(result.model?.id).toBe("kimi-for-coding-highspeed");
+			expect(result.thinkingLevel).toBe(Effort.High);
+			expect(result.explicitThinkingLevel).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## Repro
Configuring a role with `kimi-for-coding` and `thinking=high`, then reloading, resolves the role to the distinct `kimi-for-coding-highspeed` model (different billing tier). Only `high` triggers it. Minimal repro against the resolver:

```
parseModelPattern("kimi-code/kimi-for-coding:high", [kimi-for-coding, kimi-for-coding-highspeed])
  → model.id === "kimi-for-coding-highspeed"   (expected "kimi-for-coding", thinkingLevel "high")
```

## Cause
In `packages/coding-agent/src/config/model-resolver.ts`, `parseModelPatternWithContext` ran the full matching engine `matchModel` on the **whole** pattern — including the trailing `:high` thinking suffix — and only stripped the suffix if that first pass returned nothing. `matchModel`'s provider-scoped fuzzy match (`fuzzyMatch`) normalizes `:` away and does subsequence matching, so `kimi-for-coding:high` (→ `kimiforcodinghigh`) matched `kimi-for-coding-highspeed` and returned before the suffix was ever recognized as a thinking level. `-highspeed` is the only sibling id that embeds a tier token (`high`) as a substring, which is why no other tier reproduces it.

## Fix
- Added an `exactOnly` mode to `matchModel` that returns after the exact phases (provider/id reference, exact bare id, retired variant alias) and skips the fuzzy/substring fallbacks.
- Reordered `parseModelPatternWithContext`: exact-match the full pattern first (`exactOnly`), then strip a valid `:<level>` thinking suffix and recurse **before** any fuzzy match, and only fuzzy-match the whole pattern as a last resort. Literal ids ending in `:max` still win via the exact pass.
- Added three regression tests (`kimi-for-coding:high` bare and provider-qualified; longer sibling still resolves with its own suffix) plus a prefix-sibling fixture.

## Verification
`bun test test/model-resolver.test.ts` → 123 pass, 0 fail (3 new). The two unrelated failures in the broader model-test glob (`tool-views.generated.js` missing build artifact; `resolveCommandConfig` cache test) reproduce identically on the base branch with my changes stashed. `Fixes #5151`