### PR TITLE
fix(coding-agent): rescue snapcompact dead-end when nothing is summarizable

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a loopback `litellm` proxy fronting a local llama.cpp/vLLM server aborting long prefills with `stream timed out while waiting for the first event` and retry-looping. `litellm` is excluded from `isLocalOpenAICompatBackend` to keep `replayReasoningContent` off proxies (which could 400 an unrelated cloud upstream), but that exclusion also stripped the 300s local stream-timeout floor, leaving the 100s default; a slow reprocess (llama.cpp `non-consecutive token position` KV thrash) then exceeded it. The timeout floor now applies to any loopback/RFC1918 backend, including proxies, while reasoning replay stays gated to first-party local providers. ([#4786](https://github.com/can1357/oh-my-pi/issues/4786))
+
 ## [16.3.11] - 2026-07-06
 
 ### Added

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -318,6 +318,14 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const isLocalOpenAICompatBackend =
 		!PROXY_OPENAI_COMPAT_PROVIDERS.has(provider) &&
 		(LOCAL_OPENAI_COMPAT_PROVIDERS.has(provider) || hasLocalLoopbackBaseUrl(baseUrl));
+	// Stream-timeout floor applies to ANY loopback/RFC1918 backend, INCLUDING
+	// local proxies (litellm) excluded from `isLocalOpenAICompatBackend` above:
+	// widening the first-event/idle abort ceiling only helps a slow local
+	// upstream and never pushes an extra wire field, so the proxy carve-out (a
+	// `replayReasoningContent` safety measure) must not also strip the timeout
+	// floor. Without this, a loopback litellm fronting a cold/reprocessing
+	// llama-server aborts prefill at the 100s default and retry-loops (#4786).
+	const isLocalServingBackend = isLocalOpenAICompatBackend || hasLocalLoopbackBaseUrl(baseUrl);
 
 	const useMaxTokens =
 		isMistral ||
@@ -387,7 +395,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 						? KIMI_K26_REASONING_STREAM_IDLE_TIMEOUT_MS
 						: spec.reasoning && isDirectDeepseekApi
 							? DEEPSEEK_REASONING_STREAM_IDLE_TIMEOUT_MS
-							: isLocalOpenAICompatBackend
+							: isLocalServingBackend
 								? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS
 								: undefined;
 
@@ -605,9 +613,13 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 	const isAnthropicModel = id ? isClaudeModelId(id) || isAnthropicNamespacedModelId(id) : false;
 	const isDeepseekFamily = id ? isDeepseekModelIdOrName(id) || isDeepseekModelIdOrName(spec.name) : false;
 	const reasoningCapable = Boolean(spec.reasoning);
-	const isLocalOpenAICompatBackend =
-		!PROXY_OPENAI_COMPAT_PROVIDERS.has(spec.provider) &&
-		(LOCAL_OPENAI_COMPAT_PROVIDERS.has(spec.provider) || hasLocalLoopbackBaseUrl(baseUrl));
+	// `replayReasoningContent` is Responses-only-false, so the proxy carve-out is
+	// irrelevant here; the stream-timeout floor still applies to ANY loopback /
+	// RFC1918 backend, including local proxies (litellm), so a slow local
+	// upstream is not aborted at the 100s default and retry-looped (#4786).
+	const isLocalServingBackend =
+		(!PROXY_OPENAI_COMPAT_PROVIDERS.has(spec.provider) && LOCAL_OPENAI_COMPAT_PROVIDERS.has(spec.provider)) ||
+		hasLocalLoopbackBaseUrl(baseUrl);
 
 	const compat: ResolvedOpenAIResponsesCompat = {
 		supportsDeveloperRole: isAzure || isOpenAIUrl || hostMatchesUrl(baseUrl, "githubCopilot"),
@@ -667,7 +679,7 @@ export function buildOpenAIResponsesCompat(spec: OpenAIResponsesSpecLike): Resol
 		emptyLengthFinishIsContextError: spec.provider === "ollama",
 		usesOpenAIToolCallIdLimit: spec.provider === "openai",
 		promptCacheSessionHeader: spec.provider === "xai-oauth" ? "x-grok-conv-id" : undefined,
-		streamIdleTimeoutMs: isLocalOpenAICompatBackend
+		streamIdleTimeoutMs: isLocalServingBackend
 			? LOCAL_OPENAI_COMPAT_STREAM_IDLE_TIMEOUT_MS
 			: spec.compat?.streamIdleTimeoutMs,
 	};

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -297,6 +297,36 @@ describe("openai-completions wire-quirk compat detection", () => {
 		expect(buildOpenAICompat(completionsSpec()).dropThinkingWhenReasoningEffort).toBe(false);
 	});
 
+	it("floors the stream timeout for a loopback litellm proxy without enabling reasoning replay (#4786)", () => {
+		// A litellm proxy on a loopback baseUrl fronts a local llama-server whose
+		// prefill can exceed the 100s default first-event budget on large prompts.
+		// The proxy carve-out (which keeps `replayReasoningContent` off so the
+		// field is never forwarded to an unrelated cloud upstream) must NOT also
+		// strip the widened stream-timeout floor, or the turn aborts and
+		// retry-loops during a slow reprocess.
+		const loopback = buildOpenAICompat(
+			completionsSpec({ provider: "litellm", id: "qwen3", baseUrl: "http://127.0.0.1:4000/v1" }),
+		);
+		expect(loopback.streamIdleTimeoutMs).toBe(300_000);
+		expect(loopback.replayReasoningContent).toBe(false);
+
+		// A litellm proxy on a remote baseUrl gets neither: no local upstream to
+		// wait on, and replay would risk a 400 on the cloud upstream.
+		const remote = buildOpenAICompat(
+			completionsSpec({ provider: "litellm", id: "qwen3", baseUrl: "https://litellm.example.com/v1" }),
+		);
+		expect(remote.streamIdleTimeoutMs).toBeUndefined();
+		expect(remote.replayReasoningContent).toBe(false);
+
+		// A first-party local backend (llama.cpp) still gets both the floor and
+		// the reasoning replay it needs for KV-cache reuse.
+		const native = buildOpenAICompat(
+			completionsSpec({ provider: "llama.cpp", id: "qwen3", baseUrl: "http://127.0.0.1:8080/v1" }),
+		);
+		expect(native.streamIdleTimeoutMs).toBe(300_000);
+		expect(native.replayReasoningContent).toBe(true);
+	});
+
 	it("disables the leaked-markup healer for the official OpenAI endpoint only", () => {
 		// Official OpenAI returns structured reasoning and never leaks fences, so
 		// the provider-local healer stays off; every other OpenAI-compatible host

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed auto-compaction dead-ending in a warning loop ("Compaction freed too little context to make progress") when the single most-recent turn is itself over budget so `prepareCompaction` has nothing to summarize (`findCutPoint` never cuts inside a tool result). This `!preparation` short-circuit never ran the artifact-backed `shake` elide rescue that #3786 added to the post-maintenance guard, so snapcompact/context-full maintenance paused with no attempt to shrink the oversized tail. The dead-end now runs the same elide pass, re-prepares on the shrunken branch, and falls through to a normal compaction when the tail became summarizable — only pausing (single warning) when nothing is elide-eligible. ([#4786](https://github.com/can1357/oh-my-pi/issues/4786))
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -12385,35 +12385,73 @@ export class AgentSession {
 				this.#getCompactionModelCandidates(availableModels),
 				this.sessionId,
 			);
-			const preparation = prepareCompaction(pathEntries, compactionSettings, autoCompactionCandidates);
+			let pathEntriesForCompaction = pathEntries;
+			let preparation = prepareCompaction(pathEntriesForCompaction, compactionSettings, autoCompactionCandidates);
 			if (!preparation) {
-				await this.#emitSessionEvent({
-					type: "auto_compaction_end",
-					action,
-					result: undefined,
-					aborted: false,
-					willRetry: false,
-					skipped: true,
-				});
-				const noProgressDeadEnd = reason !== "idle";
-				let continuationScheduled = false;
-				if (!suppressContinuation && this.agent.hasQueuedMessages()) {
-					this.#scheduleAgentContinue({
-						delayMs: 100,
-						generation,
-						shouldContinue: () => this.agent.hasQueuedMessages(),
+				// prepareCompaction found nothing to summarize because the kept region
+				// is a single oversized recent turn — findCutPoint never cuts inside a
+				// tool result, so a huge tool-result / fenced block tail leaves nothing
+				// on the summarizable side and summary compaction cannot even start.
+				// That is exactly the dead-end the elide shake rescues: it reaches
+				// INSIDE the tail and offloads heavy content to an artifact placeholder,
+				// shrinking the tail so findCutPoint can then move the cut and leave
+				// older turns to summarize. Run the same rescue the post-maintenance
+				// guard uses, then re-prepare on the elided branch and fall through to
+				// the normal compaction body when it now succeeds (writing a compaction
+				// entry anchors the stale billed usage so the auto-continue re-check
+				// cannot re-trip and loop the warning — issue #4786). Skip when we
+				// already fell through from a shake strategy pass (it tried and found
+				// nothing) or on the idle timer (it re-checks usage on its own cadence).
+				let rescued: ShakeResult | undefined;
+				if (reason !== "idle" && !fallbackFromShake) {
+					rescued = await this.#tryShakeRescueForDeadEnd(autoCompactionSignal);
+					if (rescued && !autoCompactionSignal.aborted) {
+						pathEntriesForCompaction = this.sessionManager.getBranch();
+						preparation = prepareCompaction(
+							pathEntriesForCompaction,
+							compactionSettings,
+							autoCompactionCandidates,
+						);
+						if (preparation) this.#emitShakeRescueNotice(rescued);
+					}
+				}
+				if (!preparation) {
+					await this.#emitSessionEvent({
+						type: "auto_compaction_end",
+						action,
+						result: undefined,
+						aborted: false,
+						willRetry: false,
+						skipped: true,
 					});
-					continuationScheduled = true;
+					const noProgressDeadEnd = reason !== "idle";
+					let continuationScheduled = false;
+					if (!suppressContinuation && this.agent.hasQueuedMessages()) {
+						this.#scheduleAgentContinue({
+							delayMs: 100,
+							generation,
+							shouldContinue: () => this.agent.hasQueuedMessages(),
+						});
+						continuationScheduled = true;
+					}
+					if (noProgressDeadEnd) {
+						this.emitNotice(
+							"warning",
+							compactionDeadEndWarning("clear large tool output, run `/shake images` to drop attached images,"),
+							"compaction",
+						);
+					}
+					// A rescue that offloaded content but still could not produce a
+					// preparation rewrote the branch; flag it so the overflow-recovery
+					// rollback does not re-restore the just-failed assistant turn on top
+					// of the elided tail.
+					const base = continuationScheduled
+						? COMPACTION_CHECK_CONTINUATION
+						: noProgressDeadEnd
+							? COMPACTION_CHECK_BLOCK_AUTOMATIC_CONTINUATION
+							: COMPACTION_CHECK_NONE;
+					return rescued ? { ...base, historyRewritten: true } : base;
 				}
-				if (noProgressDeadEnd) {
-					this.emitNotice(
-						"warning",
-						compactionDeadEndWarning("shrink it (e.g. clear large tool output)"),
-						"compaction",
-					);
-				}
-				if (continuationScheduled) return COMPACTION_CHECK_CONTINUATION;
-				return noProgressDeadEnd ? COMPACTION_CHECK_BLOCK_AUTOMATIC_CONTINUATION : COMPACTION_CHECK_NONE;
 			}
 
 			let hookCompaction: CompactionResult | undefined;
@@ -12424,7 +12462,7 @@ export class AgentSession {
 				const hookResult = (await this.#extensionRunner.emit({
 					type: "session_before_compact",
 					preparation,
-					branchEntries: pathEntries,
+					branchEntries: pathEntriesForCompaction,
 					customInstructions: undefined,
 					signal: autoCompactionSignal,
 				})) as SessionBeforeCompactResult | undefined;

--- a/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-progress-guard.test.ts
@@ -1162,4 +1162,97 @@ describe("AgentSession auto-compaction progress guard", () => {
 		const recovery = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("dead-end recovery"));
 		expect(recovery.length).toBe(0);
 	});
+
+	it("re-prepares and compacts after a shake rescue frees the un-summarizable tail", async () => {
+		// Issue #4786: the kept region is a single oversized recent turn, so the
+		// first prepareCompaction returns undefined (nothing on the summarizable
+		// side) and summary compaction cannot start. The dead-end runs the elide
+		// shake rescue INSIDE the tail; once it frees enough, prepareCompaction is
+		// retried on the elided branch, now succeeds, and the pass falls through to
+		// a normal (hook-supplied) compaction that creates headroom and
+		// auto-continues instead of looping the no-progress warning.
+		const branch = sessionManager.getBranch();
+		const firstKeptEntryId = branch[branch.length - 1].id;
+		if (!firstKeptEntryId) throw new Error("seeded entry has no id");
+		let shaken = false;
+		const preparation: compactionModule.CompactionPreparation = {
+			firstKeptEntryId,
+			messagesToSummarize: [{ role: "user", content: "old", timestamp: Date.now() }],
+			turnPrefixMessages: [],
+			recentMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 190000,
+			fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+			settings: session.settings.getGroup("compaction"),
+		};
+		vi.spyOn(compactionModule, "prepareCompaction").mockImplementation(() => (shaken ? preparation : undefined));
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+		// Residual is over the band until the rescue elides the tail, then drops.
+		vi.spyOn(session, "getContextUsage").mockImplementation(() =>
+			shaken
+				? { tokens: 1000, contextWindow: 200000, percent: 0.5 }
+				: { tokens: 190000, contextWindow: 200000, percent: 95 },
+		);
+		const shakeSpy = vi.spyOn(session, "shake").mockImplementation(async () => {
+			shaken = true;
+			return { mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 160000, artifactId: "art-1" };
+		});
+
+		const notices = collectNotices();
+
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end" && event.result) onCompactionDone();
+		});
+
+		const assistantMsg = highUsageAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+		await session.waitForIdle();
+
+		expect(shakeSpy).toHaveBeenCalledWith("elide", expect.anything());
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		const noProgress = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes(NO_PROGRESS_FRAGMENT));
+		expect(noProgress.length).toBe(0);
+		const recovery = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes("dead-end recovery"));
+		expect(recovery.length).toBe(1);
+	});
+
+	it("still warns once when a no-preparation dead-end cannot be shaken", async () => {
+		// prepareCompaction returns undefined AND the oversized tail has nothing
+		// elide-eligible: the rescue frees nothing, prepareCompaction still returns
+		// undefined, and the guard MUST pause with a single no-progress warning
+		// (not loop) instead of re-firing on the same oversized tail.
+		vi.spyOn(compactionModule, "prepareCompaction").mockReturnValue(undefined);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined as never);
+		const continueSpy = vi.spyOn(session.agent, "continue").mockResolvedValue();
+		vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 190000, contextWindow: 200000, percent: 95 });
+		const shakeSpy = vi
+			.spyOn(session, "shake")
+			.mockResolvedValue({ mode: "elide", toolResultsDropped: 0, blocksDropped: 0, tokensFreed: 0 });
+
+		const notices = collectNotices();
+
+		const { promise: compactionDone, resolve: onCompactionDone } = Promise.withResolvers<void>();
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_end") onCompactionDone();
+		});
+
+		const assistantMsg = highUsageAssistant();
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMsg });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMsg] });
+
+		await compactionDone;
+		await session.waitForIdle();
+
+		expect(shakeSpy).toHaveBeenCalledWith("elide", expect.anything());
+		expect(promptSpy).not.toHaveBeenCalled();
+		expect(continueSpy).not.toHaveBeenCalled();
+		const noProgress = notices.filter(n => n.source === NOTICE_SOURCE && n.message.includes(NO_PROGRESS_FRAGMENT));
+		expect(noProgress.length).toBe(1);
+		expect(noProgress[0].level).toBe("warning");
+	});
 });


### PR DESCRIPTION
## Repro
Running auto-compaction (snapcompact strategy, or its context-full fallback) on a session whose single most-recent turn is itself over budget loops the warning "Compaction freed too little context to make progress — pausing automatic maintenance to avoid a compaction loop … shrink it (e.g. clear large tool output) or switch to a larger-context model", and a subsequent manual `/compact soft` returns "Nothing to compact (session too small)". Reproduced by driving `#runAutoCompaction` with `prepareCompaction()` returning `undefined` plus a threshold-tripping turn and asserting the elide `shake("elide", …)` rescue is attempted — it currently is not, so the session dead-ends.

## Cause
In `packages/coding-agent/src/session/agent-session.ts`, `#runAutoCompaction`'s `!preparation` short-circuit (~L12389) emits `compactionDeadEndWarning(...)` and returns without recovery. `prepareCompaction` (`packages/agent/src/compaction/compaction.ts`) returns `undefined` when the kept region is a single oversized recent turn: `findCutPoint` never cuts inside a tool result, so the summarizable side is empty and summary compaction cannot start. The artifact-backed elide `shake` dead-end rescue added in #3786 (`#tryShakeRescueForDeadEnd`) was wired only into the *post-successful-maintenance* guard (L12774 / L12796), never this pre-compaction short-circuit — so an irreducible tail loops the warning with no attempt to shrink it. The sibling manual path throws `"Nothing to compact (session too small)"` at L9609 from the same `undefined`.

## Fix
- In the `!preparation` branch of `#runAutoCompaction`, run `#tryShakeRescueForDeadEnd` (same elide pass as the post-maintenance guard) before pausing, when the reason is not `idle` and we did not already fall through from a shake-strategy pass.
- After a successful rescue, re-run `prepareCompaction` on the freshly-elided branch; when it now succeeds, fall through to the normal compaction body (which writes a compaction entry, anchoring the stale billed usage so the auto-continue re-check cannot re-trip and re-loop). The extension hook's `branchEntries` now uses the re-prepared branch.
- Only pause with the single no-progress warning when the rescue frees nothing or the branch is still unpreparable.
- Return `historyRewritten: true` when a rescue offloaded content, so `#runRecoveryCompactionWithRollback` does not re-restore the just-failed assistant turn on top of the elided tail.
- Added two regression tests in `agent-session-auto-compaction-progress-guard.test.ts`: rescue → re-prepare → compact → auto-continue (no warning), and rescue frees nothing → single warning, no continuation.

## Verification
`bun test test/agent-session-auto-compaction-progress-guard.test.ts` → 25 pass / 0 fail. `bun check` (biome + docs + tsgo) clean. Full `packages/coding-agent` suite: only 5 failures, all in unrelated subsystems (plan-mode IRC timing, ModelRegistry command caching, TUI selector, `withHardTimeout`, search abort) and confirmed pre-existing by re-running with the diff stashed. Fixes #4786