### PR TITLE
fix(eval): honor timeout zero and classify session deadlines

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed session deadline abort signals carrying a generic string reason, allowing timeout-aware tools to classify deadline cancellation ([#5250](https://github.com/can1357/oh-my-pi/issues/5250)).
+
 ## [16.4.5] - 2026-07-11
 
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -766,12 +766,13 @@ async function runLoopBody(
 	let deadlineTimer: Timer | undefined;
 	if (config.deadline !== undefined) {
 		const deadlineAbortController = new AbortController();
+		const deadlineReason = new DOMException("Deadline exceeded", "TimeoutError");
 		const delay = config.deadline - Date.now();
 		if (delay <= 0) {
-			deadlineAbortController.abort("Deadline exceeded");
+			deadlineAbortController.abort(deadlineReason);
 		} else {
 			deadlineTimer = setTimeout(() => {
-				deadlineAbortController.abort("Deadline exceeded");
+				deadlineAbortController.abort(deadlineReason);
 			}, delay);
 		}
 		signal = signal ? AbortSignal.any([signal, deadlineAbortController.signal]) : deadlineAbortController.signal;

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -2855,9 +2855,11 @@ describe("agentLoopContinue with AgentMessage", () => {
 		// loop hands it. The merged deadline signal must fire and cancel the request,
 		// surfacing the deadline reason on the synthesized aborted message.
 		let providerSignalAborted = false;
+		let providerSignalReason: unknown;
 		const stream = agentLoop([createUserMessage("Wait")], context, config, undefined, (_model, _context, options) => {
 			options?.signal?.addEventListener("abort", () => {
 				providerSignalAborted = true;
+				providerSignalReason = options.signal?.reason;
 			});
 			return new AssistantMessageEventStream();
 		});
@@ -2865,6 +2867,9 @@ describe("agentLoopContinue with AgentMessage", () => {
 		const messages = await stream.result();
 
 		expect(providerSignalAborted).toBe(true);
+		if (!(providerSignalReason instanceof DOMException)) throw new Error("Expected a DOMException deadline reason");
+		expect(providerSignalReason.name).toBe("TimeoutError");
+		expect(providerSignalReason.message).toBe("Deadline exceeded");
 		const finalMessage = messages[messages.length - 1];
 		expect(finalMessage.role).toBe("assistant");
 		if (finalMessage.role !== "assistant") throw new Error("Expected assistant message");

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed eval cells treating `timeout: 0` as a one-second deadline and reporting session-deadline cancellation as a user abort ([#5250](https://github.com/can1357/oh-my-pi/issues/5250)).
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/eval/backend.ts
+++ b/packages/coding-agent/src/eval/backend.ts
@@ -15,10 +15,10 @@ export interface ExecutorBackendExecOptions {
 	 * driven entirely by `signal`, which the eval tool arms as a watchdog that
 	 * pauses on bridge timeout-control status events and fires a `TimeoutError`
 	 * reason only while the Python/JS runtime owns control. Backends use this
-	 * value only for timeout-annotation text and as cold-start headroom; they MUST
-	 * NOT derive a competing wall-clock timer from it.
+	 * value only for timeout-annotation text and as cold-start headroom; undefined
+	 * disables the cell timeout. Backends MUST NOT derive a competing wall-clock timer from it.
 	 */
-	idleTimeoutMs: number;
+	idleTimeoutMs?: number;
 	reset: boolean;
 	onChunk: (chunk: string) => void;
 	/**

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -10,7 +10,7 @@ Fields:
 - `language` — {{#if py}}`"py"` IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}`"js"` persistent JavaScript VM{{/if}}{{#if rb}}{{#ifAny py js}}, {{/ifAny}}`"rb"` persistent Ruby kernel{{/if}}{{#if jl}}{{#ifAny py js rb}}, {{/ifAny}}`"jl"` persistent Julia kernel{{/if}}.
 - `code` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - `title` (optional) — short transcript label (e.g. `"imports"`).
-- `timeout` (optional) — seconds. Raise only for heavy compute or long non-agent tool calls.
+- `timeout` (optional) — seconds; `0` disables the cell timeout. Raise only for heavy compute or long non-agent tool calls.
 - `reset` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a `py` reset never touches the JS VM.{{/ifAll}}
 
 {{#if py}}Live event loop: use top-level `await` directly; `asyncio.run(…)` raises "cannot be called from a running event loop".{{/if}}

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -85,7 +85,7 @@ function enabledEvalLanguages(backends: EvalBackendsAllowance): EvalLanguageToke
 
 const evalCellCommonFields = {
 	"title?": type("string").describe('short label shown in transcript (e.g. "imports", "load config")'),
-	"timeout?": type("number").describe("timeout for this eval call in seconds"),
+	"timeout?": type("number").describe("timeout for this eval call in seconds; 0 disables the cell timeout"),
 	"reset?": type("boolean").describe("wipe this language's kernel before running. Other languages are untouched."),
 };
 
@@ -538,11 +538,16 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 					// ordinary tool calls all count against the budget. The watchdog drives
 					// `combinedSignal`; we pass no wall-clock deadline downstream so the
 					// backends never arm a competing fixed timer.
-					const idleTimeoutMs = timeoutSecondsFromMs(cell.timeoutMs) * 1000;
-					const idle = new IdleTimeout(idleTimeoutMs);
-					const combinedSignal = signal
-						? AbortSignal.any([signal, idle.signal, sessionAbortController.signal])
-						: AbortSignal.any([idle.signal, sessionAbortController.signal]);
+					const idleTimeoutMs = cell.timeoutMs === 0 ? undefined : timeoutSecondsFromMs(cell.timeoutMs) * 1000;
+					const idle = idleTimeoutMs === undefined ? undefined : new IdleTimeout(idleTimeoutMs);
+					const combinedSignal =
+						signal && idle
+							? AbortSignal.any([signal, idle.signal, sessionAbortController.signal])
+							: signal
+								? AbortSignal.any([signal, sessionAbortController.signal])
+								: idle
+									? AbortSignal.any([idle.signal, sessionAbortController.signal])
+									: sessionAbortController.signal;
 
 					const cellResult = cellResults[i];
 					cellResult.status = "running";
@@ -570,11 +575,11 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 							},
 							onStatus: event => {
 								if (event.op === EVAL_TIMEOUT_PAUSE_OP) {
-									idle.pause();
+									idle?.pause();
 									return;
 								}
 								if (event.op === EVAL_TIMEOUT_RESUME_OP) {
-									idle.resume();
+									idle?.resume();
 									return;
 								}
 								cellResult.statusEvents ??= [];
@@ -583,7 +588,7 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 							},
 						});
 					} finally {
-						idle.dispose();
+						idle?.dispose();
 						activeLiveCell = undefined;
 					}
 					const durationMs = Date.now() - startTime;

--- a/packages/coding-agent/test/tools/eval-description.test.ts
+++ b/packages/coding-agent/test/tools/eval-description.test.ts
@@ -21,11 +21,13 @@ function makeSession(opts: { spawns?: string | null; backends?: Record<string, b
 function wireCellFields(tool: EvalTool): {
 	languages: string[];
 	languageDescription?: string;
+	timeoutDescription?: string;
 	codeDescription?: string;
 } {
 	const wire = toolWireSchema(tool as unknown as AiTool) as {
 		properties?: {
 			language?: { enum?: string[]; const?: string; description?: string };
+			timeout?: { description?: string };
 			code?: { description?: string };
 		};
 	};
@@ -36,7 +38,12 @@ function wireCellFields(tool: EvalTool): {
 		: typeof language?.const === "string"
 			? [language.const]
 			: [];
-	return { languages, languageDescription: language?.description, codeDescription: props?.code?.description };
+	return {
+		languages,
+		languageDescription: language?.description,
+		codeDescription: props?.code?.description,
+		timeoutDescription: props?.timeout?.description,
+	};
 }
 
 describe("eval tool description", () => {
@@ -57,6 +64,13 @@ describe("eval tool description", () => {
 		const denied = new EvalTool(makeSession({ spawns: "" })).description;
 		expect(wildcard).toContain("agent(prompt");
 		expect(denied).not.toContain("agent(prompt");
+	});
+
+	it("documents zero as the unlimited timeout value", () => {
+		const tool = new EvalTool(makeSession({}));
+		const fields = wireCellFields(tool);
+		expect(fields.timeoutDescription).toContain("0 disables the cell timeout");
+		expect(tool.description).toContain("`0` disables the cell timeout");
 	});
 });
 

--- a/packages/coding-agent/test/tools/eval-timeout.test.ts
+++ b/packages/coding-agent/test/tools/eval-timeout.test.ts
@@ -26,6 +26,20 @@ describe("EvalTool timeout semantics", () => {
 		await disposeAllVmContexts();
 	});
 
+	it("disables the cell timeout when timeout is zero", async () => {
+		const tool = new EvalTool(makeSession());
+		const result = await tool.execute("call-unlimited-timeout", {
+			language: "js",
+			// This integration test must cross the former 1s watchdog boundary;
+			// fake timers do not drive the isolated JS worker's clock.
+			code: "await Bun.sleep(1250); print('completed');",
+			timeout: 0,
+		});
+
+		expect(result.content.some(block => block.type === "text" && block.text.includes("completed"))).toBe(true);
+		expect(result.details?.cells?.[0]?.status).toBe("complete");
+	});
+
 	it("bounds a compute cell (no agent/completion) by a plain wall-clock timeout", async () => {
 		const tool = new EvalTool(makeSession());
 		// 1s budget; the cell idles for 5s and emits no status, so nothing extends


### PR DESCRIPTION
## Repro
Before the fix, `bun test packages/coding-agent/test/tools/eval-timeout.test.ts` fails because a JS cell using `timeout: 0` is terminated after one second, and `bun test packages/agent/test/agent-loop.test.ts` fails because the deadline signal carries the string `Deadline exceeded` instead of a timeout-classifiable error.

## Cause
`EvalTool.execute()` in `packages/coding-agent/src/tools/eval.ts` passed zero through `timeoutSecondsFromMs()`, whose normal timeout clamp converted it to one second before constructing `IdleTimeout`. Separately, `runLoopBody()` in `packages/agent/src/agent-loop.ts` aborted the session-deadline controller with a string, while eval timeout detection only recognizes errors named `TimeoutError`.

## Fix
- Skip the eval cell watchdog and backend timeout budget when `timeout` is explicitly zero.
- Abort session deadlines with `DOMException("Deadline exceeded", "TimeoutError")`, preserving the displayed message while enabling timeout classification.
- Document `timeout: 0` in the eval schema/tool prompt and add regression coverage for both contracts.
- Add coding-agent and agent changelog entries.

## Verification
`bun test packages/coding-agent/test/tools/eval-timeout.test.ts packages/coding-agent/test/tools/eval-description.test.ts packages/agent/test/agent-loop.test.ts` passed: 69 tests, 318 assertions. A workspace smoke script completed a two-second JS cell configured with `timeout: 0` in 2.083s; a simulated session deadline surfaced `Command timed out` instead of `Command aborted`. The pre-publish `bun run fix` and `bun check` gate passed during branch push. Fixes #5250