### PR TITLE
fix(tui): trigger internal-url autocomplete inside slash args

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed internal-URL autocomplete (`agent://`, `skill://`, `omp://`, etc.) not triggering inside slash command arguments: `allowArgs: true` commands returned the base provider's `null` result directly, short-circuiting the internal-URL fallthrough. Completion now falls through to internal-URL suggestions when a command has no argument completion (or its `getArgumentCompletions` yields no match), while `#` prompt-action tokens stay literal inside slash arguments. ([#5263](https://github.com/can1357/oh-my-pi/issues/5263))
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -156,7 +156,12 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 			const commandName = commandText.slice(1, spaceIndex);
 			const command = this.#commands.find(cmd => cmd.name === commandName || cmd.aliases?.includes(commandName));
 			if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
-				return this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+				const argumentSuggestions = await this.#baseProvider.getSuggestions(lines, cursorLine, cursorCol);
+				if (argumentSuggestions) return argumentSuggestions;
+				// No slash-argument completion for this input: fall through to
+				// internal-url completion only. `#` prompt-action tokens stay
+				// literal text inside slash command arguments.
+				return getInternalUrlSuggestions(textBeforeCursor, this.#basePath);
 			}
 		}
 

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -185,6 +185,57 @@ describe("prompt action autocomplete", () => {
 		});
 	});
 
+	it("falls through to internal-url completion for allowArgs commands without argument completions", async () => {
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [{ name: "btw", description: "By the way", allowArgs: true }],
+			basePath: process.cwd(),
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const line = "/btw omp://";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions).not.toBeNull();
+		expect(suggestions?.prefix).toBe("omp://");
+		expect(suggestions?.items.length).toBeGreaterThan(0);
+	});
+
+	it("falls through to internal-url completion when getArgumentCompletions yields no match", async () => {
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [
+				{
+					name: "mcp",
+					description: "MCP",
+					allowArgs: true,
+					getArgumentCompletions: () => null,
+				},
+			],
+			basePath: process.cwd(),
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const line = "/mcp omp://";
+		const suggestions = await provider.getSuggestions([line], 0, line.length);
+
+		expect(suggestions).not.toBeNull();
+		expect(suggestions?.prefix).toBe("omp://");
+		expect(suggestions?.items.length).toBeGreaterThan(0);
+	});
+
 	it("delegates trySyncSlashCompletion to CombinedAutocompleteProvider", () => {
 		const provider = createPromptActionAutocompleteProvider({
 			commands: [{ name: "model", description: "Switch AI model" }],


### PR DESCRIPTION
## Repro
Typing an internal URL scheme inside a slash command's arguments (e.g. `/btw omp://`) produced no completion dropdown, while the same token in a bare prompt (`omp://`) completed correctly. Driving `PromptActionAutocompleteProvider.getSuggestions` directly: normal prompt `omp://` → 25 items; `/btw omp://` → `null`. Affected all `allowArgs: true` commands, both without `getArgumentCompletions` and with one that returns no match.

## Cause
In `packages/coding-agent/src/modes/prompt-action-autocomplete.ts`, the slash-argument branch of `getSuggestions` returned `this.#baseProvider.getSuggestions(...)` verbatim. `CombinedAutocompleteProvider.getSuggestions` (`packages/tui/src/autocomplete.ts:476,481`) returns `null` for URL-style input — either no `getArgumentCompletions`, or `getArgumentCompletions` yielding no match — so the later `getInternalUrlSuggestions` call (line 189) was unreachable for any `allowArgs: true` command.

## Fix
- `packages/coding-agent/src/modes/prompt-action-autocomplete.ts`: in the `allowArgs` branch, await the base provider and return its result only when non-null; otherwise fall through to `getInternalUrlSuggestions(textBeforeCursor, this.#basePath)`. The fallthrough is URL-only, so `#` prompt-action tokens remain literal text inside slash arguments.
- `packages/coding-agent/test/prompt-action-autocomplete.test.ts`: added two regression tests — URL fallthrough for an `allowArgs` command with no argument completion, and for one whose `getArgumentCompletions` returns `null`.
- `packages/coding-agent/CHANGELOG.md`: noted the fix under `[Unreleased]`.

## Verification
`bun test test/prompt-action-autocomplete.test.ts` in `packages/coding-agent` → 10 pass, 0 fail (includes the pre-existing `#`-literal-in-slash-args test). Manual repro via the provider now returns 25 items for `/btw omp://`, matching the bare-prompt path. Fixes #5263