### PR TITLE
fix(internal-urls): serve history:// transcripts from disk fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `history://` URLs (direct lookup, the bare `history://` index, and prompt-mode autocomplete) only surfacing agents still present in the in-memory `AgentRegistry`, so transcripts of unregistered one-shot helpers (`keepAlive: false`), released agents (Agent Hub / vibe kill), or any subagent after a session resume threw `Unknown agent` despite their `.jsonl` session file persisting on disk. `HistoryProtocolHandler` now falls back to scanning artifacts dirs for `<id>.jsonl` (excluding `__advisor*` and `.bak`) and loads them read-only, mirroring how `agent://` reads `.md` outputs off disk. Also documented `history://` in the system prompt's Internal URLs section. ([#5261](https://github.com/can1357/oh-my-pi/issues/5261))
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/internal-urls/history-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/history-protocol.ts
@@ -5,14 +5,22 @@
  * in-memory message array; parked refs (session disposed, sessionFile
  * retained) load read-only from the JSONL session file — no writer, no lock.
  *
+ * Agents that are no longer in the `AgentRegistry` — one-shot helpers
+ * unregistered after `finalizeSubagentLifecycle` (`keepAlive: false`, e.g. the
+ * `eval` `agent()` bridge), agents released via the Agent Hub / vibe kill, or
+ * any agent after a session resume — remain reachable: `resolve`, `complete`,
+ * and the index all fall back to scanning artifacts dirs for `<id>.jsonl`,
+ * mirroring how `agent://` reads `.md` outputs straight off disk.
+ *
  * URL forms:
- * - history:// - Index of all registry agents (id, status, kind, last activity)
+ * - history:// - Index of all registry + on-disk agents (id, status, kind, last activity)
  * - history://<agentId> - Concise markdown transcript of that agent
  */
 import type { AgentRef } from "../registry/agent-registry";
 import { AgentRegistry } from "../registry/agent-registry";
 import { formatSessionHistoryMarkdown } from "../session/session-history-format";
 import { loadSessionMessagesReadOnly } from "../session/session-loader";
+import { sessionFilesFromDisk } from "./registry-helpers";
 import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
 
 /** Humanize a last-activity timestamp as `Ns/Nm/Nh/Nd ago`. */
@@ -27,11 +35,21 @@ function formatAgo(timestamp: number): string {
 	return `${Math.floor(hours / 24)}d ago`;
 }
 
+/** One row of the history index — either a registered ref or a disk-only transcript. */
+interface IndexEntry {
+	id: string;
+	status: string;
+	kind: string;
+	parent: string;
+	lastActivity: string;
+}
+
 /**
  * Handler for history:// URLs.
  *
- * Resolves agent ids against the global AgentRegistry, serving transcripts
- * for both live and parked agents.
+ * Resolves agent ids against the global AgentRegistry, then falls back to
+ * on-disk `.jsonl` transcripts, serving read-only history for live, parked,
+ * and unregistered agents alike.
  */
 export class HistoryProtocolHandler implements ProtocolHandler {
 	readonly scheme = "history";
@@ -45,7 +63,7 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 		const visible = registry.list().filter(ref => ref.kind !== "advisor");
 
 		if (!agentId) {
-			const content = this.#renderIndex(visible);
+			const content = await this.#renderIndex(visible);
 			return {
 				url: url.href,
 				content,
@@ -61,7 +79,13 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 			const lower = agentId.toLowerCase();
 			ref = visible.find(candidate => candidate.id.toLowerCase() === lower);
 		}
+
 		if (!ref) {
+			// Registry miss — the agent may have been unregistered or lost on resume.
+			// Serve its transcript straight from disk if the session file persists.
+			const disk = await this.#resolveFromDisk(agentId);
+			if (disk) return { ...disk, url: url.href };
+
 			const known = visible.map(candidate => candidate.id);
 			const knownStr = known.length > 0 ? known.join(", ") : "none";
 			throw new Error(`Unknown agent: ${agentId}\nKnown agents: ${knownStr}\nList all with history://`);
@@ -76,6 +100,10 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 			messages = await loadSessionMessagesReadOnly(ref.sessionFile);
 			notes.push(`Source: session file (read-only, ${ref.status})`);
 		} else {
+			// No live session and no retained sessionFile — try the disk scan before
+			// giving up, in case the transcript lingers under an artifacts dir.
+			const disk = await this.#resolveFromDisk(ref.id);
+			if (disk) return { ...disk, url: url.href };
 			throw new Error(`Agent ${ref.id} has no transcript: session is gone and no session file was retained`);
 		}
 
@@ -90,29 +118,81 @@ export class HistoryProtocolHandler implements ProtocolHandler {
 		};
 	}
 
-	#renderIndex(refs: AgentRef[]): string {
+	/**
+	 * Load a transcript for `agentId` from an on-disk `.jsonl` session file,
+	 * matched case-insensitively. Returns `undefined` when no file is found.
+	 */
+	async #resolveFromDisk(agentId: string): Promise<InternalResource | undefined> {
+		const files = await sessionFilesFromDisk();
+		const lower = agentId.toLowerCase();
+		let matchedId: string | undefined;
+		let sessionFile: string | undefined;
+		for (const [id, file] of files) {
+			if (id === agentId || id.toLowerCase() === lower) {
+				matchedId = id;
+				sessionFile = file;
+				if (id === agentId) break;
+			}
+		}
+		if (!matchedId || !sessionFile) return undefined;
+		const messages = await loadSessionMessagesReadOnly(sessionFile);
+		const content = formatSessionHistoryMarkdown(messages, { title: `${matchedId} (on disk)` });
+		return {
+			url: "",
+			content,
+			contentType: "text/markdown",
+			size: Buffer.byteLength(content, "utf-8"),
+			sourcePath: sessionFile,
+			notes: ["Source: session file (read-only, unregistered)"],
+		};
+	}
+
+	async #renderIndex(refs: AgentRef[]): Promise<string> {
+		const entries: IndexEntry[] = refs.map(ref => ({
+			id: ref.id,
+			status: ref.status,
+			kind: ref.kind,
+			parent: ref.parentId ?? "—",
+			lastActivity: formatAgo(ref.lastActivity),
+		}));
+		// Merge on-disk transcripts for agents absent from the registry.
+		const registered = new Set(refs.map(ref => ref.id));
+		const disk = await sessionFilesFromDisk();
+		for (const id of disk.keys()) {
+			if (registered.has(id)) continue;
+			entries.push({ id, status: "on disk", kind: "—", parent: "—", lastActivity: "—" });
+		}
+
 		const lines: string[] = ["# Agents", ""];
-		if (refs.length === 0) {
+		if (entries.length === 0) {
 			lines.push("No agents registered.");
 			return `${lines.join("\n")}\n`;
 		}
 		lines.push("| id | status | kind | parent | last activity |", "|---|---|---|---|---|");
-		for (const ref of refs) {
-			lines.push(
-				`| ${ref.id} | ${ref.status} | ${ref.kind} | ${ref.parentId ?? "—"} | ${formatAgo(ref.lastActivity)} |`,
-			);
+		for (const entry of entries) {
+			lines.push(`| ${entry.id} | ${entry.status} | ${entry.kind} | ${entry.parent} | ${entry.lastActivity} |`);
 		}
 		lines.push("", "Read a transcript with `read history://<id>`.");
 		return `${lines.join("\n")}\n`;
 	}
 
 	async complete(): Promise<UrlCompletion[]> {
-		return AgentRegistry.global()
-			.list()
-			.filter(ref => ref.kind !== "advisor")
-			.map(ref => ({
+		const completions: UrlCompletion[] = [];
+		const seen = new Set<string>();
+		for (const ref of AgentRegistry.global().list()) {
+			if (ref.kind === "advisor") continue;
+			seen.add(ref.id);
+			completions.push({
 				value: ref.id,
 				description: `${ref.status} · ${ref.kind}${ref.parentId ? ` · parent ${ref.parentId}` : ""}`,
-			}));
+			});
+		}
+		const disk = await sessionFilesFromDisk();
+		for (const id of disk.keys()) {
+			if (seen.has(id)) continue;
+			seen.add(id);
+			completions.push({ value: id, description: "on disk" });
+		}
+		return completions;
 	}
 }

--- a/packages/coding-agent/src/internal-urls/registry-helpers.ts
+++ b/packages/coding-agent/src/internal-urls/registry-helpers.ts
@@ -2,6 +2,11 @@
  * Shared helpers for internal-url protocol handlers that resolve IDs against
  * registered agent sessions.
  */
+
+import type { Dirent } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
 import { AgentRegistry } from "../registry/agent-registry";
 
 const extraArtifactsDirs = new Set<string>();
@@ -35,9 +40,53 @@ export function artifactsDirsFromRegistry(): string[] {
 		if (!dirs.includes(dir)) dirs.push(dir);
 	};
 	for (const ref of AgentRegistry.global().list()) {
-		addDir(ref.session?.sessionManager.getArtifactsDir());
+		addDir(ref.session?.sessionManager?.getArtifactsDir());
 		if (ref.sessionFile) addDir(ref.sessionFile.slice(0, -6));
 	}
 	for (const dir of extraArtifactsDirs) addDir(dir);
 	return dirs;
+}
+
+/**
+ * Recursively scan artifacts dirs for agent session transcripts, keyed by
+ * agent id (the `.jsonl` basename). Used by `history://` so transcripts of
+ * agents no longer in the registry (unregistered one-shot helpers, released
+ * agents, or any agent after session resume) remain reachable — mirroring how
+ * `agent://` reads `.md` outputs straight off disk.
+ *
+ * Layout follows `task/index.ts`: a subagent's transcript is
+ * `<artifactsDir>/<AgentId>.jsonl`, and its own children nest one level deeper
+ * under `<artifactsDir>/<AgentId>/<AgentId>.<ChildId>.jsonl`. Advisor
+ * transcripts (`__advisor*.jsonl`) are observability-only and excluded;
+ * EPERM-rewrite backups (`.bak`) are skipped. When the same id appears in
+ * multiple dirs, the first hit wins (registry dirs are scanned first).
+ */
+export async function sessionFilesFromDisk(): Promise<Map<string, string>> {
+	const found = new Map<string, string>();
+	const seenDirs = new Set<string>();
+	const scan = async (dir: string, depth: number): Promise<void> => {
+		if (depth > 8 || seenDirs.has(dir)) return;
+		seenDirs.add(dir);
+		let entries: Dirent[];
+		try {
+			entries = await fs.readdir(dir, { withFileTypes: true });
+		} catch (err) {
+			if (isEnoent(err)) return;
+			throw err;
+		}
+		for (const entry of entries) {
+			if (entry.isDirectory()) {
+				await scan(path.join(dir, entry.name), depth + 1);
+				continue;
+			}
+			if (!entry.isFile()) continue;
+			const name = entry.name;
+			if (!name.endsWith(".jsonl")) continue;
+			if (name.startsWith("__advisor")) continue;
+			const id = name.slice(0, -".jsonl".length);
+			if (!found.has(id)) found.set(id, path.join(dir, name));
+		}
+	};
+	for (const dir of artifactsDirsFromRegistry()) await scan(dir, 0);
+	return found;
 }

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -57,6 +57,7 @@ Special URLs for internal resources; with most FS/bash tools they auto-resolve t
 - `memory://root`: project memory summary
   {{/if}}
 - `agent://<id>`: agent output artifact; `/<path>` extracts a JSON field
+- `history://<id>`: read-only markdown transcript of an agent (live, parked, or released); bare `history://` lists all agents. Serves any agent whose session file persists on disk, not just registered peers.
 - `artifact://<id>`: artifact content
 - `local://<name>.md`: plan artifacts or shared content for subagents
 {{#if hasObsidian}}

--- a/packages/coding-agent/test/internal-urls/history-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/history-protocol.test.ts
@@ -14,6 +14,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { HistoryProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/history-protocol";
+import { resetRegisteredArtifactDirsForTests } from "@oh-my-pi/pi-coding-agent/internal-urls/registry-helpers";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
@@ -72,11 +73,13 @@ describe("history:// protocol", () => {
 	beforeEach(() => {
 		AgentRegistry.resetGlobalForTests();
 		InternalUrlRouter.resetForTests();
+		resetRegisteredArtifactDirsForTests();
 	});
 
 	afterEach(() => {
 		InternalUrlRouter.resetForTests();
 		AgentRegistry.resetGlobalForTests();
+		resetRegisteredArtifactDirsForTests();
 	});
 
 	it("bare history:// renders an index listing registered agents", async () => {
@@ -250,5 +253,109 @@ describe("history:// protocol", () => {
 		const values = completions.map(c => c.value);
 		expect(values).toContain("HubAgent");
 		expect(values).not.toContain("AdvisorProbe");
+	});
+
+	it("history://<id> serves an unregistered subagent's transcript from disk", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "session.jsonl");
+			const artifactsDir = sessionFile.slice(0, -6);
+			await fs.mkdir(artifactsDir, { recursive: true });
+			await Bun.write(path.join(artifactsDir, "Sub1.jsonl"), sessionFixtureJsonl());
+			// Only Main is registered; Sub1 exists solely on disk.
+			AgentRegistry.global().register({
+				id: "Main",
+				displayName: "main",
+				kind: "main",
+				session: {
+					messages: [],
+					sessionManager: { getArtifactsDir: () => artifactsDir },
+				} as unknown as AgentSession,
+				sessionFile,
+				status: "idle",
+			});
+
+			const resource = await InternalUrlRouter.instance().resolve("history://Sub1");
+			expect(resource.content).toContain("# Sub1 (on disk)");
+			expect(resource.content).toContain("parked hello");
+			expect(resource.sourcePath).toBe(path.join(artifactsDir, "Sub1.jsonl"));
+			expect(resource.notes?.join("\n")).toContain("unregistered");
+		});
+	});
+
+	it("resolves an on-disk-only transcript case-insensitively", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "session.jsonl");
+			const artifactsDir = sessionFile.slice(0, -6);
+			await fs.mkdir(artifactsDir, { recursive: true });
+			await Bun.write(path.join(artifactsDir, "AuthLoader.jsonl"), sessionFixtureJsonl());
+			AgentRegistry.global().register({
+				id: "Main",
+				displayName: "main",
+				kind: "main",
+				session: {
+					messages: [],
+					sessionManager: { getArtifactsDir: () => artifactsDir },
+				} as unknown as AgentSession,
+				sessionFile,
+				status: "idle",
+			});
+
+			const resource = await InternalUrlRouter.instance().resolve("history://authloader");
+			expect(resource.content).toContain("# AuthLoader (on disk)");
+		});
+	});
+
+	it("bare history:// and completions include on-disk agents but never advisor transcripts", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "session.jsonl");
+			const artifactsDir = sessionFile.slice(0, -6);
+			await fs.mkdir(artifactsDir, { recursive: true });
+			await Bun.write(path.join(artifactsDir, "Sub1.jsonl"), sessionFixtureJsonl());
+			await Bun.write(path.join(artifactsDir, "__advisor.jsonl"), sessionFixtureJsonl());
+			AgentRegistry.global().register({
+				id: "Main",
+				displayName: "main",
+				kind: "main",
+				session: {
+					messages: [],
+					sessionManager: { getArtifactsDir: () => artifactsDir },
+				} as unknown as AgentSession,
+				sessionFile,
+				status: "idle",
+			});
+
+			const index = await InternalUrlRouter.instance().resolve("history://");
+			expect(index.content).toContain("| Sub1 | on disk |");
+			expect(index.content).not.toContain("__advisor");
+
+			const completions = await new HistoryProtocolHandler().complete();
+			const values = completions.map(c => c.value);
+			expect(values).toContain("Sub1");
+			expect(values).not.toContain("__advisor");
+		});
+	});
+
+	it("resolves a nested child transcript one level deeper on disk", async () => {
+		await withTempDir(async dir => {
+			const sessionFile = path.join(dir, "session.jsonl");
+			const artifactsDir = sessionFile.slice(0, -6);
+			const childDir = path.join(artifactsDir, "Parent");
+			await fs.mkdir(childDir, { recursive: true });
+			await Bun.write(path.join(childDir, "Parent.Child.jsonl"), sessionFixtureJsonl());
+			AgentRegistry.global().register({
+				id: "Main",
+				displayName: "main",
+				kind: "main",
+				session: {
+					messages: [],
+					sessionManager: { getArtifactsDir: () => artifactsDir },
+				} as unknown as AgentSession,
+				sessionFile,
+				status: "idle",
+			});
+
+			const resource = await InternalUrlRouter.instance().resolve("history://Parent.Child");
+			expect(resource.content).toContain("# Parent.Child (on disk)");
+		});
 	});
 });


### PR DESCRIPTION
## Repro
`history://` URLs — direct lookup, the bare `history://` index, and prompt-mode autocomplete — only surfaced agents still present in the in-memory `AgentRegistry`. A subagent whose `.jsonl` session file persists on disk under the parent's artifacts dir but is absent from the registry (unregistered `keepAlive: false` helpers after `finalizeSubagentLifecycle`, agents released via the Agent Hub / vibe kill, or any agent after a session resume) threw `Unknown agent`. Minimal repro: register only `Main`, write `<artifactsDir>/Sub1.jsonl`, then `read history://Sub1`:

```
$ bun test test/internal-urls/history-protocol.test.ts
error: Unknown agent: Sub1
Known agents: Main
List all with history://
  at resolve (src/internal-urls/history-protocol.ts:67:14)
```

## Cause
`HistoryProtocolHandler.resolve()`, `.complete()`, and `#renderIndex()` (`packages/coding-agent/src/internal-urls/history-protocol.ts`) queried `AgentRegistry.global().list()` exclusively and never looked beyond the registry. `resolve()` threw immediately on a registry miss with no disk fallback — even though the read-only load path (`loadSessionMessagesReadOnly`) already existed for `parked` refs. In contrast, `AgentProtocolHandler` (`agent://`) scans artifacts dirs via `artifactsDirsFromRegistry()` and finds the same agents' `.md` outputs on disk.

## Fix
- `registry-helpers.ts`: added `sessionFilesFromDisk()` — a bounded recursive scan of `artifactsDirsFromRegistry()` returning a `Map<agentId, jsonlPath>`. Follows the `task/index.ts` nesting layout (`<artifactsDir>/<AgentId>.jsonl`, children one level deeper), excludes advisor transcripts (`__advisor*.jsonl`) and EPERM backups (`.bak`), and dedupes dirs/ids. Hardened the `sessionManager?.getArtifactsDir()` deref for refs without a live session manager.
- `history-protocol.ts`: `resolve()` falls back to `#resolveFromDisk()` on a registry miss (and in the no-transcript `else` branch) — case-insensitive id match, read-only load, `# <id> (on disk)` title. `#renderIndex()` merges on-disk-only agents as `on disk` rows. `complete()` unions on-disk ids with registered peers. Advisor exclusion is preserved through the `__advisor*` filter.
- `system-prompt.md`: documented `history://` in the Internal URLs section (previously unlisted, per the issue).

## Verification
`bun test test/internal-urls src/internal-urls` → 161 pass, 0 fail (added 4 contract tests to `history-protocol.test.ts`: on-disk resolve, case-insensitive on-disk resolve, index/completion merge with advisor exclusion, nested-child resolve). `bun check` → clean. Fixes #5261