### PR TITLE
fix(mcp): preserve discovered registration endpoint

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed MCP OAuth dynamic client registration for pathful authorization-server issuers by preserving the discovered `registration_endpoint` instead of re-deriving metadata from the authorization endpoint. ([#5267](https://github.com/can1357/oh-my-pi/issues/5267))
 - Fixed failure to trigger model fallback when the retry budget is exhausted by credential rotation
 - Fixed uncontrollable mouse-wheel scrolling in the /models hub: the wheel moved the selection (one step per wheel event, so a single trackpad flick skipped many rows) and wrapped from the bottom back to the top. Wheel scrolling now pans the list viewport only, clamps at the ends, and leaves the selection where it is; keyboard navigation still scrolls the selection into view. Likewise, the wheel over the provider sidebar no longer switches the active scope (or triggers provider refreshes) — it just scrolls the sidebar.
 - Fixed TPS being inflated several-fold when a provider hides reasoning tokens until late in the stream (e.g. `google/gemini-3.5` vs `google-vertex/gemini-3.5` reporting 648 vs 186 TPS for identical durations): `omp bench`, the per-turn usage row, and the /models perf aggregates now measure tokens/sec over the total request duration instead of the post-TTFT decode window, matching `omp stats`. Stored perf aggregates are purged and re-backfilled from stats history with the corrected math on first launch.

--- a/packages/coding-agent/src/mcp/oauth-discovery.ts
+++ b/packages/coding-agent/src/mcp/oauth-discovery.ts
@@ -11,8 +11,21 @@ export interface OAuthEndpoints {
 	authorizationUrl: string;
 	tokenUrl: string;
 	clientId?: string;
+	/** Dynamic client registration endpoint advertised by the authorization server. */
+	registrationUrl?: string;
 	scopes?: string;
 	resource?: string;
+}
+
+function readRegistrationUrl(metadata: Record<string, unknown>): string | undefined {
+	const value =
+		metadata.registration_endpoint ??
+		metadata.registrationEndpoint ??
+		metadata.registration_url ??
+		metadata.registrationUrl ??
+		metadata.registration_uri ??
+		metadata.registrationUri;
+	return typeof value === "string" && value.trim() !== "" ? value : undefined;
 }
 
 export interface AuthDetectionResult {
@@ -102,7 +115,7 @@ export function extractOAuthEndpoints(error: Error): OAuthEndpoints | null {
 			(obj.resource_uri as string | undefined) ||
 			(obj.resourceUri as string | undefined);
 
-		return { authorizationUrl, tokenUrl, clientId, scopes, resource };
+		return { authorizationUrl, tokenUrl, registrationUrl: readRegistrationUrl(obj), clientId, scopes, resource };
 	};
 
 	const clientIdFromAuthUrl = (authorizationUrl: string): string | undefined => {
@@ -175,6 +188,10 @@ export function extractOAuthEndpoints(error: Error): OAuthEndpoints | null {
 			return {
 				authorizationUrl,
 				tokenUrl,
+				registrationUrl:
+					challengeValues.get("registration_endpoint") ||
+					challengeValues.get("registration_url") ||
+					challengeValues.get("registration_uri"),
 				clientId: challengeValues.get("client_id") || clientIdFromAuthUrl(authorizationUrl),
 				scopes: challengeValues.get("scope") || challengeValues.get("scopes") || scopeFromAuthUrl(authorizationUrl),
 				resource,
@@ -415,6 +432,7 @@ export async function discoverOAuthEndpoints(
 			return {
 				authorizationUrl: String(metadata.authorization_endpoint),
 				tokenUrl: String(metadata.token_endpoint),
+				registrationUrl: readRegistrationUrl(metadata),
 				clientId:
 					typeof metadata.client_id === "string"
 						? metadata.client_id
@@ -438,6 +456,7 @@ export async function discoverOAuthEndpoints(
 				return {
 					authorizationUrl: oauthData.authorization_url || String(oauthData.authorizationUrl),
 					tokenUrl: oauthData.token_url || String(oauthData.tokenUrl),
+					registrationUrl: readRegistrationUrl(oauthData),
 					clientId:
 						typeof oauthData.client_id === "string"
 							? oauthData.client_id

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -277,6 +277,8 @@ export interface MCPOAuthConfig {
 	authorizationUrl: string;
 	/** Token endpoint URL */
 	tokenUrl: string;
+	/** Dynamic client registration endpoint advertised by the authorization server. */
+	registrationUrl?: string;
 	/** Client ID (optional when already embedded in authorization URL) */
 	clientId?: string;
 	/** Client secret (optional for PKCE flows) */
@@ -561,7 +563,7 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 	 * accept the later authorize request for the same scope set.
 	 */
 	async #tryRegisterClient(redirectUri: string): Promise<void> {
-		const registrationEndpoint = await this.#resolveRegistrationEndpoint();
+		const registrationEndpoint = this.config.registrationUrl;
 		if (!registrationEndpoint) return;
 
 		try {
@@ -616,56 +618,6 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 				detail: error instanceof Error ? truncateDetail(error.message) : undefined,
 			};
 		}
-	}
-
-	async #resolveRegistrationEndpoint(): Promise<string | null> {
-		const authorizationUrl = new URL(this.config.authorizationUrl);
-
-		// origin-root well-known; most servers serve metadata here.
-		const rootUrl = new URL("/.well-known/oauth-authorization-server", authorizationUrl.origin).toString();
-		const endpoint = await this.#tryWellKnownForRegistration(rootUrl);
-		if (endpoint) return endpoint;
-
-		// path-prefixed well-known for gateways (e.g. https://gateway.example.com/my-service/).
-		const normalizedPath = authorizationUrl.pathname.replace(/\/$/, "");
-		const lastSlash = normalizedPath.lastIndexOf("/");
-		// Bare-origin authorization URL — nothing further to try.
-		if (lastSlash < 0) return null;
-
-		// Single-segment paths are the gateway prefix itself; multi-segment paths
-		// drop the trailing segment (typically a service endpoint).
-		const prefixPath = lastSlash === 0 ? normalizedPath : normalizedPath.slice(0, lastSlash);
-		const prefixedUrl = new URL(
-			".well-known/oauth-authorization-server",
-			`${authorizationUrl.origin}${prefixPath}/`,
-		).toString();
-		const prefixedEndpoint = await this.#tryWellKnownForRegistration(prefixedUrl);
-		if (prefixedEndpoint) return prefixedEndpoint;
-
-		// RFC 8414 §3.1 path-ful issuer form: /.well-known/oauth-authorization-server/<path>.
-		const pathfulUrl = new URL(
-			`/.well-known/oauth-authorization-server${normalizedPath}`,
-			authorizationUrl.origin,
-		).toString();
-		return await this.#tryWellKnownForRegistration(pathfulUrl);
-	}
-
-	async #tryWellKnownForRegistration(wellKnownUrl: string): Promise<string | null> {
-		try {
-			const response = await this.#fetch(wellKnownUrl, {
-				method: "GET",
-				headers: { Accept: "application/json" },
-				signal: this.ctrl.signal,
-			});
-			if (!response.ok) return null;
-			const metadata = (await response.json()) as { registration_endpoint?: string };
-			if (metadata.registration_endpoint && metadata.registration_endpoint.trim() !== "") {
-				return metadata.registration_endpoint;
-			}
-		} catch {
-			// Ignore fetch/parse failures.
-		}
-		return null;
 	}
 
 	async #assertClientIdNotRequired(authorizationUrl: string): Promise<void> {

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -63,6 +63,7 @@ export interface MCPAddWizardOAuthResult {
 interface MCPAddWizardOAuthOptions {
 	serverUrl?: string;
 	resource?: string;
+	registrationUrl?: string;
 	/**
 	 * External cancellation source. Aborting it tears down the in-flight OAuth
 	 * flow and surfaces a neutral cancellation error. The wizard wires its own
@@ -82,6 +83,7 @@ interface WizardState {
 	authMethod: AuthMethod;
 	oauthAuthUrl: string;
 	oauthTokenUrl: string;
+	oauthRegistrationUrl: string;
 	oauthClientId: string;
 	oauthClientSecret: string;
 	oauthScopes: string;
@@ -113,6 +115,7 @@ export class MCPAddWizard extends Container {
 		authMethod: "none",
 		oauthAuthUrl: "",
 		oauthTokenUrl: "",
+		oauthRegistrationUrl: "",
 		oauthClientId: "",
 		oauthClientSecret: "",
 		oauthScopes: "",
@@ -1026,6 +1029,7 @@ export class MCPAddWizard extends Container {
 				if (oauth) {
 					this.#state.oauthAuthUrl = oauth.authorizationUrl;
 					this.#state.oauthTokenUrl = oauth.tokenUrl;
+					this.#state.oauthRegistrationUrl = oauth.registrationUrl || "";
 					this.#state.oauthClientId = oauth.clientId || "";
 					this.#state.oauthScopes = oauth.scopes || "";
 					this.#state.oauthResource = oauth.resource || (this.#state.transport === "stdio" ? "" : this.#state.url);
@@ -1196,6 +1200,7 @@ export class MCPAddWizard extends Container {
 				this.#state.oauthScopes,
 				{
 					serverUrl: this.#state.url || undefined,
+					registrationUrl: this.#state.oauthRegistrationUrl || undefined,
 					resource: oauthResource || undefined,
 					abortSignal: this.#oauthAbort.signal,
 				},

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -14,6 +14,7 @@ import {
 	fetchResourceMetadataScopes,
 	loadAllMCPConfigs,
 	MCPManager,
+	type OAuthEndpoints,
 } from "../../mcp";
 import { connectToServer, disconnectServer, listTools } from "../../mcp/client";
 import {
@@ -603,6 +604,7 @@ export class MCPCommandController {
 									callbackPath: finalConfig.oauth?.callbackPath,
 									redirectUri: finalConfig.oauth?.redirectUri,
 									prompt: finalConfig.oauth?.prompt,
+									registrationUrl: oauth.registrationUrl,
 									serverUrl: finalConfig.url,
 									resource: oauthResource,
 									stripSameOriginResource: oauthResourceIsFallback,
@@ -684,6 +686,7 @@ export class MCPCommandController {
 			redirectUri?: string;
 			prompt?: string;
 			serverUrl?: string;
+			registrationUrl?: string;
 			resource?: string;
 			stripSameOriginResource?: boolean;
 			/**
@@ -747,6 +750,7 @@ export class MCPCommandController {
 				{
 					authorizationUrl: authUrl,
 					tokenUrl: tokenUrl,
+					registrationUrl: opts?.registrationUrl,
 					clientId: resolvedClientId,
 					clientSecret: resolvedClientSecret,
 					scopes: scopes || undefined,
@@ -1038,13 +1042,7 @@ export class MCPCommandController {
 		return next;
 	}
 
-	async #resolveOAuthEndpointsFromServer(config: MCPServerConfig): Promise<{
-		authorizationUrl: string;
-		tokenUrl: string;
-		clientId?: string;
-		scopes?: string;
-		resource?: string;
-	}> {
+	async #resolveOAuthEndpointsFromServer(config: MCPServerConfig): Promise<OAuthEndpoints> {
 		// Stdio servers manage credentials inside the child process; OMP's OAuth
 		// flow only applies to http/sse transports. Without this guard the
 		// unauthenticated preflight below spawns the child, which happily reuses
@@ -1739,6 +1737,7 @@ export class MCPCommandController {
 					callbackPath: found.config.oauth?.callbackPath,
 					redirectUri: found.config.oauth?.redirectUri,
 					prompt: found.config.oauth?.prompt,
+					registrationUrl: oauth.registrationUrl,
 					serverUrl,
 					resource: oauthResource,
 					stripSameOriginResource: oauthResourceIsFallback,

--- a/packages/coding-agent/test/mcp-command-reauth.test.ts
+++ b/packages/coding-agent/test/mcp-command-reauth.test.ts
@@ -177,6 +177,72 @@ describe("/mcp auth commands", () => {
 		expect(savedServer?.auth).toBeUndefined();
 	});
 
+	test("uses the registration endpoint discovered from a pathful issuer", async () => {
+		const authStorage = freshAuthStorage();
+		await authStorage.reload();
+		const resourceMetadataUrl = "https://gateway.example.com/.well-known/oauth-protected-resource/my-service/mcp";
+		vi.spyOn(mcpClient, "connectToServer").mockRejectedValue(
+			new Error(`HTTP 401: WWW-Authenticate: Bearer resource_metadata="${resourceMetadataUrl}"`),
+		);
+		const registrationRequests: string[] = [];
+		const fetchMock = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit | BunFetchRequestInit): Promise<Response> => {
+				const url = String(input);
+				if (url === resourceMetadataUrl) {
+					return new Response(
+						JSON.stringify({
+							resource: "https://gateway.example.com/my-service/mcp",
+							authorization_servers: ["https://auth.example.com/auth/v1"],
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url === "https://auth.example.com/.well-known/oauth-authorization-server/auth/v1") {
+					return new Response(
+						JSON.stringify({
+							issuer: "https://auth.example.com/auth/v1",
+							authorization_endpoint: "https://auth.example.com/auth/v1/oauth/authorize",
+							token_endpoint: "https://auth.example.com/auth/v1/oauth/token",
+							registration_endpoint: "https://auth.example.com/auth/v1/oauth/register",
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				if (url === "https://auth.example.com/auth/v1/oauth/register" && init?.method === "POST") {
+					registrationRequests.push(url);
+					return new Response(JSON.stringify({ client_id: "pathful-dcr-client" }), {
+						status: 201,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+			{ preconnect: globalThis.fetch.preconnect },
+		);
+		vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
+		vi.spyOn(oauthFlow.MCPOAuthFlow.prototype, "login").mockImplementation(async function (
+			this: oauthFlow.MCPOAuthFlow,
+		) {
+			const { url } = await this.generateAuthUrl("state", "http://127.0.0.1:53192/callback");
+			expect(new URL(url).searchParams.get("client_id")).toBe("pathful-dcr-client");
+			return {
+				access: "fresh-access",
+				refresh: "fresh-refresh",
+				expires: Date.now() + 3_600_000,
+			};
+		});
+		const { controller, showError } = createController(authStorage);
+
+		await controller.handle("/mcp reauth envserver");
+
+		expect(showError).not.toHaveBeenCalled();
+		expect(registrationRequests).toEqual(["https://auth.example.com/auth/v1/oauth/register"]);
+		expect(authStorage.get(oauthFlow.mcpOAuthCredentialId(EXPANDED_SERVER_URL))).toMatchObject({
+			type: "oauth",
+			clientId: "pathful-dcr-client",
+		});
+	});
+
 	test("reuses embedded DCR client secret during reauth token exchange", async () => {
 		const authStorage = freshAuthStorage();
 		await authStorage.reload();

--- a/packages/coding-agent/test/oauth-discovery.test.ts
+++ b/packages/coding-agent/test/oauth-discovery.test.ts
@@ -139,6 +139,7 @@ describe("path-prefixed auth servers", () => {
 					JSON.stringify({
 						authorization_endpoint: "https://gateway.example.com/my-service/oauth",
 						token_endpoint: "https://gateway.example.com/my-service/token",
+						registration_endpoint: "https://gateway.example.com/my-service/register",
 					}),
 					{ status: 200, headers: { "Content-Type": "application/json" } },
 				);
@@ -154,6 +155,7 @@ describe("path-prefixed auth servers", () => {
 		expect(oauth).toEqual({
 			authorizationUrl: "https://gateway.example.com/my-service/oauth",
 			tokenUrl: "https://gateway.example.com/my-service/token",
+			registrationUrl: "https://gateway.example.com/my-service/register",
 		});
 		expect(calls).toContain("https://gateway.example.com/.well-known/oauth-authorization-server/my-service");
 	});
@@ -509,6 +511,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 		expect(oauth).toEqual({
 			authorizationUrl: "https://mcp.atlassian.com/v1/authorize",
 			tokenUrl: "https://cf.mcp.atlassian.com/v1/token",
+			registrationUrl: "https://cf.mcp.atlassian.com/v1/register",
 		});
 		expect(calls[0]).toBe("https://mcp.atlassian.com/.well-known/oauth-authorization-server");
 	});
@@ -556,6 +559,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 						issuer: "https://mcp.plane.so/http",
 						authorization_endpoint: "https://mcp.plane.so/http/authorize",
 						token_endpoint: "https://mcp.plane.so/http/token",
+						registration_endpoint: "https://mcp.plane.so/http/register",
 					}),
 					{ status: 200, headers: { "Content-Type": "application/json" } },
 				);
@@ -574,6 +578,7 @@ describe("RFC 8414 §3.3 issuer validation", () => {
 		expect(oauth).toEqual({
 			authorizationUrl: "https://mcp.plane.so/http/authorize",
 			tokenUrl: "https://mcp.plane.so/http/token",
+			registrationUrl: "https://mcp.plane.so/http/register",
 			resource: "https://mcp.plane.so/http/mcp",
 		});
 		// Wrong-issuer origin-root metadata WAS fetched and skipped.

--- a/packages/coding-agent/test/oauth-flow.test.ts
+++ b/packages/coding-agent/test/oauth-flow.test.ts
@@ -28,12 +28,6 @@ function mockProviderTokenEndpoint(onBody: (body: string) => void): FetchImpl {
 function mockFigmaRegistration(onRegistration: (payload: Record<string, unknown>) => void): FetchImpl {
 	return async (input, init) => {
 		const url = String(input);
-		if (url === "https://www.figma.com/.well-known/oauth-authorization-server") {
-			return new Response(JSON.stringify({ registration_endpoint: "https://www.figma.com/oauth/register" }), {
-				status: 200,
-				headers: { "Content-Type": "application/json" },
-			});
-		}
 		if (url === "https://www.figma.com/oauth/register") {
 			onRegistration(JSON.parse(String(init?.body)) as Record<string, unknown>);
 			return new Response(
@@ -68,6 +62,7 @@ describe("mcp oauth flow", () => {
 			{
 				authorizationUrl: "https://www.figma.com/oauth/mcp",
 				tokenUrl: "https://api.figma.com/v1/oauth/token",
+				registrationUrl: "https://www.figma.com/oauth/register",
 				fetch: mockFigmaRegistration(payload => {
 					registrationPayload = payload;
 				}),
@@ -93,6 +88,7 @@ describe("mcp oauth flow", () => {
 			{
 				authorizationUrl: "https://www.figma.com/oauth/mcp",
 				tokenUrl: "https://api.figma.com/v1/oauth/token",
+				registrationUrl: "https://www.figma.com/oauth/register",
 				scopes,
 				fetch: mockFigmaRegistration(payload => {
 					registrationPayload = payload;
@@ -573,6 +569,7 @@ describe("mcp oauth flow", () => {
 				{
 					authorizationUrl: "https://provider.example/authorize",
 					tokenUrl: "https://provider.example/token",
+					registrationUrl: "https://provider.example/register",
 					// No clientId, no redirectUri — pure DCR flow.
 					callbackPort: blockerPort,
 					fetch: fetchImpl,
@@ -618,6 +615,7 @@ describe("mcp oauth flow", () => {
 			{
 				authorizationUrl: "https://www.figma.com/oauth/mcp",
 				tokenUrl: "https://api.figma.com/v1/oauth/token",
+				registrationUrl: "https://www.figma.com/oauth/register",
 				fetch: mockFigmaRegistration(() => {}),
 			},
 			{},
@@ -683,6 +681,7 @@ describe("mcp oauth flow", () => {
 			{
 				authorizationUrl: "https://www.figma.com/oauth/mcp",
 				tokenUrl: "https://api.figma.com/v1/oauth/token",
+				registrationUrl: "https://api.figma.com/v1/oauth/mcp/register",
 				fetch: fetchImpl,
 			},
 			{},


### PR DESCRIPTION
## Repro
A pathful authorization-server issuer such as `https://auth.example.com/auth/v1` advertises `registration_endpoint` from `https://auth.example.com/.well-known/oauth-authorization-server/auth/v1`, but the endpoint was absent from `discoverOAuthEndpoints()`'s result. Reproduced with `bun test packages/coding-agent/test/oauth-discovery.test.ts --test-name-pattern 'Plane regression'`, which failed with the expected `registrationUrl` missing from the returned endpoint object.

## Cause
`packages/coding-agent/src/mcp/oauth-discovery.ts` parsed authorization and token endpoints but discarded `registration_endpoint`. `MCPOAuthFlow.#resolveRegistrationEndpoint()` then repeated well-known discovery using `MCPOAuthConfig.authorizationUrl`, so RFC 8414's pathful candidate was anchored to the authorization endpoint path rather than the issuer path and returned 404.

## Fix
- Preserve advertised dynamic-registration endpoints in `OAuthEndpoints`, including metadata, JSON error bodies, and authentication challenges.
- Thread `registrationUrl` through quick-add, the add wizard, reauth, and `MCPOAuthConfig`.
- Register directly against the discovered endpoint and remove the divergent authorization-URL-based metadata probes.
- Cover RFC 8414 pathful discovery and the full `/mcp reauth` discovery-to-DCR handoff.

## Verification
`bun test packages/coding-agent/test/oauth-discovery.test.ts packages/coding-agent/test/oauth-flow.test.ts packages/coding-agent/test/mcp-command-reauth.test.ts` passed: 71 tests, 176 assertions. `bun check` passed for all packages. Fixes #5267