### PR TITLE
fix(browser): bound headless browser close to unblock tab cleanup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the browser tool hanging indefinitely at the "Closing tab" phase when the headless Chromium process is wedged (a Windows failure mode): `disposeBrowserHandle` awaited Puppeteer's `browser.close()` with no timeout, so a process that never exits froze tab cleanup forever. The dispose now caps the close at 5s and force-kills the Chromium process tree on timeout so the tool call always releases. ([#5260](https://github.com/can1357/oh-my-pi/issues/5260))
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/tools/browser/registry.ts
+++ b/packages/coding-agent/src/tools/browser/registry.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, withTimeout } from "@oh-my-pi/pi-utils";
 import type { Subprocess } from "bun";
 import type { Browser, CDPSession } from "puppeteer-core";
 import { ToolAbortError, ToolError } from "../tool-errors";
@@ -16,6 +16,13 @@ export type PuppeteerBrowserKind =
 export type BrowserKind = PuppeteerBrowserKind | CmuxKind;
 
 export type BrowserKindTag = BrowserKind["kind"];
+
+/**
+ * Upper bound on `browser.close()` for headless Chromium. Puppeteer waits for
+ * the process to fully exit; a wedged Chromium would otherwise hang cleanup
+ * forever (issue #5260), so we cap the wait and force-kill on timeout.
+ */
+const HEADLESS_CLOSE_TIMEOUT_MS = 5_000;
 
 interface BrowserHandleCommon {
 	key: string;
@@ -232,10 +239,17 @@ async function disposeBrowserHandle(handle: BrowserHandle, opts: { kill: boolean
 	}
 	if (handle.kind.kind === "headless") {
 		if (handle.browser.connected) {
+			// Puppeteer's `browser.close()` resolves only once the Chromium
+			// process fully exits. A wedged Chromium (a known Windows failure
+			// mode) leaves this await pending forever, freezing `releaseTab` in
+			// the "Closing tab" phase (issue #5260). Bound it, then SIGKILL the
+			// process tree so cleanup always completes.
+			const proc = handle.browser.process();
 			try {
-				await handle.browser.close();
+				await withTimeout(handle.browser.close(), HEADLESS_CLOSE_TIMEOUT_MS, "Timed out closing headless browser");
 			} catch (err) {
-				logger.debug("Failed to close headless browser", { error: (err as Error).message });
+				logger.debug("Failed to close headless browser; force-killing", { error: (err as Error).message });
+				if (proc?.pid !== undefined) await gracefulKillTreeOnce(proc.pid).catch(() => undefined);
 			}
 		}
 		return;

--- a/packages/coding-agent/test/tools/browser-dispose-timeout.test.ts
+++ b/packages/coding-agent/test/tools/browser-dispose-timeout.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression test for issue #5260: the browser tool can hang indefinitely at
+ * the "Closing tab" phase.
+ *
+ * `releaseTab` bounds the worker-close handshake, but the subsequent
+ * `releaseBrowser` -> `disposeBrowserHandle` awaited Puppeteer's
+ * `browser.close()` for the headless kind with no timeout. `browser.close()`
+ * resolves only once the Chromium process fully exits; a wedged Chromium (a
+ * known Windows failure mode) left that await pending forever, freezing
+ * cleanup. The dispose must now cap the wait and force-kill the process tree
+ * on timeout so cleanup always completes.
+ */
+
+import { describe, expect, it, spyOn } from "bun:test";
+import * as attach from "@oh-my-pi/pi-coding-agent/tools/browser/attach";
+import { type BrowserHandle, releaseBrowser } from "@oh-my-pi/pi-coding-agent/tools/browser/registry";
+
+/** Build a headless handle whose `browser.close()` never resolves. */
+function makeHangingHeadlessHandle(pid: number | undefined): {
+	handle: BrowserHandle;
+	closeCalls: () => number;
+} {
+	let closeCalls = 0;
+	const handle = {
+		key: "headless:1",
+		kind: { kind: "headless", headless: true },
+		refCount: 1,
+		browser: {
+			connected: true,
+			process: () => (pid === undefined ? null : { pid }),
+			close: () => {
+				closeCalls++;
+				return new Promise<void>(() => {}); // never resolves
+			},
+		},
+		stealth: { browserSession: null, override: null },
+	} as unknown as BrowserHandle;
+	return { handle, closeCalls: () => closeCalls };
+}
+
+describe("browser dispose — headless close must not hang forever (issue #5260)", () => {
+	it("bounds a wedged browser.close() and force-kills the process tree", async () => {
+		const killSpy = spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		try {
+			const { handle, closeCalls } = makeHangingHeadlessHandle(4242);
+			const start = Date.now();
+			await releaseBrowser(handle, { kill: false });
+			const elapsed = Date.now() - start;
+
+			// close() was attempted, but the release still returned rather than
+			// hanging on the never-resolving promise.
+			expect(closeCalls()).toBe(1);
+			expect(elapsed).toBeLessThan(15_000);
+			// On timeout, the Chromium process tree is force-killed by pid.
+			expect(killSpy).toHaveBeenCalledTimes(1);
+			expect(killSpy.mock.calls[0]?.[0]).toBe(4242);
+		} finally {
+			killSpy.mockRestore();
+		}
+	}, 20_000);
+
+	it("does not attempt a force-kill when no process handle is available", async () => {
+		const killSpy = spyOn(attach, "gracefulKillTreeOnce").mockResolvedValue(undefined);
+		try {
+			const { handle } = makeHangingHeadlessHandle(undefined);
+			await releaseBrowser(handle, { kill: false });
+			expect(killSpy).not.toHaveBeenCalled();
+		} finally {
+			killSpy.mockRestore();
+		}
+	}, 20_000);
+});


### PR DESCRIPTION
## Repro
On Windows, the browser tool can freeze at the in-progress status `Closing tab`: the tab-cleanup phase never finishes and the agent turn stalls. The root await is `disposeBrowserHandle` → `handle.browser.close()` for the headless kind. Driving the module directly with a headless handle whose `browser.close()` returns a never-resolving promise reproduces it: the release call fires `close()` but never returns.

```
closeCalled: true
outcome: timeout-2s elapsed: 2002 ms   # releaseBrowser never resolved within 2s
```

## Cause
`releaseTab` (`packages/coding-agent/src/tools/browser/tab-supervisor.ts`) bounds the worker-close handshake with `raceWithTimeout(..., GRACE_MS)`, but the subsequent `releaseBrowser` → `disposeBrowserHandle` (`packages/coding-agent/src/tools/browser/registry.ts`) `await`ed `handle.browser.close()` for the headless kind with **no timeout**. Puppeteer's `browser.close()` resolves only once the Chromium process fully exits; a wedged Chromium (a known Windows failure mode) leaves that await pending forever, so cleanup and the tool call never complete.

## Fix
- `disposeBrowserHandle` (registry.ts): capture `handle.browser.process()`, then wrap `browser.close()` in `withTimeout(..., HEADLESS_CLOSE_TIMEOUT_MS)` (5s).
- On timeout (or close error), log at debug and `gracefulKillTreeOnce(proc.pid)` to force-kill the Chromium process tree so the dispose always returns.
- Added `HEADLESS_CLOSE_TIMEOUT_MS = 5_000` and imported `withTimeout` from `@oh-my-pi/pi-utils`.
- Added `test/tools/browser-dispose-timeout.test.ts`: a headless handle whose `browser.close()` never resolves must still release (bounded time) and force-kill by pid; no force-kill is attempted when no process handle is available.

## Verification
`bun test test/tools/browser-dispose-timeout.test.ts test/tools/browser-lifecycle-leak.test.ts test/tools/browser-launch.test.ts test/tools/browser-attach.test.ts` → 12 pass, 0 fail. Before the fix the direct-module repro hung indefinitely; after, `releaseBrowser` returns after the 5s bound and invokes the force-kill path. Fixes #5260