### PR TITLE
fix(coding-agent): reject prose thinking session titles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed markerless prose thinking preambles becoming session titles when title models omit the required `<title>` marker. ([#5252](https://github.com/can1357/oh-my-pi/issues/5252))
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -40,6 +40,8 @@ const THINKING_TAG_ENVELOPE_RE = /<(think|thinking|reasoning)>\s*[\s\S]*?<\/\1>/
 const THINKING_FENCE_ENVELOPE_RE = /```(?:thinking|reasoning)\b[\s\S]*?```/gi;
 const LEADING_THINKING_TAG_RE = /^\s*<(think|thinking|reasoning)>\s*[\s\S]*?<\/\1>\s*/i;
 const LEADING_THINKING_FENCE_RE = /^\s*```(?:thinking|reasoning)\b[\s\S]*?```\s*/i;
+const LEADING_PROSE_THINKING_PREAMBLE_RE =
+	/^[ \t]*(?:(?:here(?:['’]s| is)[ \t]+(?:a|the|my)[ \t]+)|my[ \t]+)?(?:thinking|thought|reasoning)[ \t]+process[ \t]*:?[ \t]*(?:\r?\n|$)/i;
 
 function getTitleModel(registry: ModelRegistry, settings: Settings, currentModel?: Model<Api>): Model<Api> | undefined {
 	const availableModels = registry.getAvailable();
@@ -250,13 +252,15 @@ function extractGeneratedTitle(contentBlocks: AssistantMessage["content"]): stri
 	}
 	// Stay lenient: prefer the first closed title marker in visible text, then
 	// fall back to a plain sentence after stripping only known leading leaked
-	// thinking envelopes plus any stray/unclosed title tag fragment.
+	// thinking envelopes plus any stray/unclosed title tag fragment. Reject a
+	// prose thinking preamble only on the markerless path: a later marked title
+	// remains authoritative.
 	const markedTitle = extractVisibleMarkedTitle(textTitle);
-	const cleanedTextTitle =
-		markedTitle ??
-		stripLeadingLeakedThinkingMarkup(textTitle)
-			.replace(/<\/?title>/gi, "")
-			.trim();
+	if (markedTitle !== undefined) return unwrapJsonTitle(markedTitle);
+	const cleanedTextTitle = stripLeadingLeakedThinkingMarkup(textTitle)
+		.replace(/<\/?title>/gi, "")
+		.trim();
+	if (LEADING_PROSE_THINKING_PREAMBLE_RE.test(cleanedTextTitle)) return "";
 	return unwrapJsonTitle(cleanedTextTitle);
 }
 

--- a/packages/coding-agent/test/title-generator.test.ts
+++ b/packages/coding-agent/test/title-generator.test.ts
@@ -419,6 +419,26 @@ describe("title generator", () => {
 		expect(title).toBe("Fix login button on mobile");
 	});
 
+	it.each([
+		"Here's a thinking process:",
+		"Thinking process:",
+		"Reasoning process:",
+	])("rejects a markerless prose thinking preamble: %s", async responseText => {
+		const model = getModelFor("deepseek", "deepseek-v4-pro");
+		vi.spyOn(ai, "completeSimple").mockResolvedValue({
+			stopReason: "stop",
+			content: [{ type: "text", text: responseText }],
+		} as never);
+
+		const title = await generateSessionTitle(
+			"the login button is broken on mobile",
+			createRegistry(model),
+			createSettings(model),
+		);
+
+		expect(title).toBeNull();
+	});
+
 	it("preserves a markerless title that mentions a <think> tag", async () => {
 		const model = getModelFor("deepseek", "deepseek-v4-pro");
 		vi.spyOn(ai, "completeSimple").mockResolvedValue({


### PR DESCRIPTION
## Repro
A title-model response without a `<title>` marker is accepted through the plain-text fallback, so prose-only responses such as `Here's a thinking process:` become the session name. Reproduced with `bun test packages/coding-agent/test/title-generator.test.ts --test-name-pattern 'rejects a markerless prose thinking preamble'`, which failed all three preamble cases before the fix.

## Cause
`extractGeneratedTitle()` in `packages/coding-agent/src/utils/title-generator.ts` stripped tagged and fenced reasoning envelopes but accepted every remaining markerless first line as a title. Plain prose thinking preambles therefore reached `normalizeGeneratedTitle()` unchanged.

## Fix
- Reject markerless first-line thinking, thought, and reasoning process preambles while preserving an explicit marked title.
- Add regression coverage for the reported prose preamble and common variants.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/title-generator.test.ts` passes 29 tests; `bun check` passes across all packages. Fixes #5252