### PR TITLE
Incorrect operation

### DIFF
--- a/.github/workflows/app-viewport-backend-rebase.yml
+++ b/.github/workflows/app-viewport-backend-rebase.yml
@@ -1,0 +1,73 @@
+name: Rebase app viewport backend
+
+on:
+   schedule:
+      - cron: "17 * * * *"
+   workflow_dispatch:
+
+concurrency:
+   group: app-viewport-backend-rebase
+   cancel-in-progress: false
+
+permissions:
+   contents: write
+
+env:
+   TARGET_BRANCH: demo/app-viewport-backend
+   UPSTREAM_REPOSITORY: can1357/oh-my-pi
+
+jobs:
+   rebase:
+      name: Rebase onto upstream main
+      if: github.repository == 'shoucandanghehe/oh-my-pi'
+      runs-on: ubuntu-22.04
+      steps:
+         - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+           with:
+              ref: ${{ env.TARGET_BRANCH }}
+              fetch-depth: 0
+
+         - name: Rebase onto upstream main
+           id: rebase
+           shell: bash
+           run: |
+              set -euo pipefail
+              git fetch --no-tags origin "+refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+              expected_remote="$(git rev-parse "origin/${TARGET_BRANCH}")"
+              echo "expected-remote=$expected_remote" >> "$GITHUB_OUTPUT"
+
+              git remote add upstream "https://github.com/${UPSTREAM_REPOSITORY}.git"
+              git fetch --no-tags upstream "+refs/heads/main:refs/remotes/upstream/main"
+              if git merge-base --is-ancestor upstream/main HEAD; then
+                echo "changed=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git rebase upstream/main
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+
+         - uses: ./.github/actions/bun-install
+           if: steps.rebase.outputs.changed == 'true'
+
+         - name: Run app viewport regression tests
+           if: steps.rebase.outputs.changed == 'true'
+           run: >-
+              bun test
+              packages/tui/test/app-viewport.test.ts
+              packages/coding-agent/test/modes/components/anchored-live-container.test.ts
+              packages/utils/test/mermaid-ascii.test.ts
+
+         - name: Run compiled-entry smoke test
+           if: steps.rebase.outputs.changed == 'true'
+           run: bun packages/coding-agent/src/cli.ts --smoke-test
+
+         - name: Push rebased branch
+           if: steps.rebase.outputs.changed == 'true'
+           shell: bash
+           run: |
+              set -euo pipefail
+              git push origin \
+                "HEAD:refs/heads/${TARGET_BRANCH}" \
+                "--force-with-lease=refs/heads/${TARGET_BRANCH}:${{ steps.rebase.outputs.expected-remote }}"


### PR DESCRIPTION
## Problem

Today whether a `task` subagent blocks the parent turn is determined solely by the **agent definition** (`blocking: true` in agent frontmatter) or by the global `async.enabled` switch. The caller — the parent agent issuing the `task` tool call — cannot declare "I need this result before I can do anything else."

This leads to a concrete inefficiency described in #3515: when the parent has no useful parallel work, it spawns a background subagent and then either sits idle or burns tokens repeatedly calling `job poll` until the result arrives. The subagent is async not because the parent can overlap work, but because the agent type happens to default to non-blocking.

## Proposed change

Add an optional top-level `blocking?: boolean` parameter to the `task` tool schema. Semantics:

- `blocking: true`  → every spawn in this call runs to completion inline; the `task` call does not return until all results are available.
- `blocking: false` → spawns run as background jobs (subject to `async.enabled` / manager availability).
- omitted → fall back to the agent definition's `blocking` default, preserving current behavior.

This makes the agent-level `blocking` flag a **default recommendation**, not a hard contract, and puts the scheduling decision where the information lives: the parent agent knows whether it has parallel work to do.

## Concrete example

```json
{
  "agent": "designer",
  "task": "Pick a retry strategy for the streaming client...",
  "blocking": true
}
```

With this flag, the parent waits once and receives the result inline, avoiding the `spawn → idle → poll → idle` cycle.

## Schema impact

Add one optional boolean at the top level of both supported shapes.

**Batch-spawn form** (`task.batch=true`, default):

```json
{
  "context": "Review this PR...",
  "tasks": [
    { "agent": "reviewer", "task": "Check auth logic" },
    { "agent": "reviewer", "task": "Check DB migrations" }
  ],
  "blocking": true
}
```

**Single-spawn form** (`task.batch=false`):

```json
{
  "agent": "reviewer",
  "task": "Check auth logic",
  "blocking": true
}
```

No per-item `blocking` flag: the decision applies to the whole call, which keeps the semantics unambiguous.

## Behavior details

1. **`blocking: true`** — route through the existing sync fan-out path (`#executeSyncFanout` / `#runSyncSpawns`). Spawns still run in parallel bounded by the session semaphore; the parent waits for the merged result.
2. **`blocking: false` or omitted with non-blocking agent default** — register as `AsyncJobManager` jobs and return immediately, same as today.
3. **Mixed intent.** If the parent wants some subagents to block and others to run in the background, it issues two separate `task` calls. This is clearer than allowing a single batch to mix execution models.
4. **`async.enabled=false`.** The global switch already forces sync execution; the new flag is valid but redundant in that mode.
5. **Resolution order.** Per-call `blocking` → agent definition `blocking` → non-blocking default.

## Backward compatibility

Fully backward compatible. Existing calls omitting `blocking` keep today's behavior: agent definition decides, and built-in agents remain non-blocking by default.

## Related issues

- #3515 — main agent polls subagents instead of waiting for automatic delivery
- #2301 — `async.enabled=false` no longer made task subagents blocking
- #2574 — extension primitive for steerable subagents (same "caller controls lifecycle" theme)