### PR TITLE
fix(coding-agent): resolve agent:// slash form for nested subagent output

### DIFF
--- a/docs/tools/task.md
+++ b/docs/tools/task.md
@@ -68,7 +68,7 @@ Settled response (`async.enabled=false`, no job manager, every item's agent `blo
 
 Artifacts and side channels:
 - Every subagent with an artifacts dir writes `<id>.md`; `agent://<id>` resolves to that file.
-- If the output file is JSON, `agent://<id>/<path>` and `agent://<id>?q=<query>` perform JSON extraction.
+- A subagent's own children are dot-qualified (`<id>.<child>`); `agent://<id>/<child>` reads that nested output. When the path names no nested output and the file is JSON, `agent://<id>/<path>` and `agent://<id>?q=<query>` perform JSON extraction.
 - Each subagent gets `<id>.jsonl` session history when the parent persists artifacts; `history://<id>` renders it as a concise transcript (works for live and parked agents).
 - Isolated patch mode writes `<id>.patch` before merge.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `agent://<parent>/<child>` slash form failing to resolve a nested subagent's output: the path segment was always treated as a jq JSON-extraction key against `<parent>.md`, so a precise-planner reading its own scout child (`agent://Plan/Scout`) got `Not found`. The slash is now a hierarchy separator first (`agent://Parent/Child` → `Parent.Child.md`), falling back to JSON extraction only when no nested output matches the path. ([#5238](https://github.com/can1357/oh-my-pi/issues/5238))
+
 ## [16.4.5] - 2026-07-11
 
 ### Breaking Changes

--- a/packages/coding-agent/src/internal-urls/__tests__/agent-protocol-nested.test.ts
+++ b/packages/coding-agent/src/internal-urls/__tests__/agent-protocol-nested.test.ts
@@ -66,3 +66,74 @@ it("agent:// resolves a depth-2 subagent's .md output while its session is live 
 	const resource = await new AgentProtocolHandler().resolve(new URL(`agent://${grandchildId}`) as never);
 	expect(resource.content).toBe("full report content");
 });
+
+it("agent:// slash form resolves a nested subagent child (hierarchy separator)", async () => {
+	const root = tempDir.path();
+	const rootSessionFile = path.join(root, "slash-session.jsonl");
+	const rootArtifactsDir = rootSessionFile.slice(0, -6);
+	await fs.mkdir(rootArtifactsDir, { recursive: true });
+	const sharedArtifactManager = new ArtifactManager(rootArtifactsDir);
+
+	// Parent subagent adopts the root ArtifactManager; its own children are
+	// written one level deeper under its sessionFile-derived dir, dot-qualified.
+	const parentSessionFile = path.join(rootArtifactsDir, "Parent.jsonl");
+	const parentOwnDir = parentSessionFile.slice(0, -6);
+	await fs.mkdir(parentOwnDir, { recursive: true });
+	await fs.writeFile(path.join(parentOwnDir, "Parent.Child.md"), "child capsule");
+
+	const fakeSession = {
+		sessionManager: { getArtifactsDir: () => sharedArtifactManager.dir },
+	} as unknown as AgentSession;
+	const registry = AgentRegistry.global();
+	registry.register({
+		id: "Main",
+		displayName: "main",
+		kind: "main",
+		session: fakeSession,
+		sessionFile: rootSessionFile,
+	});
+	registry.register({
+		id: "Parent",
+		displayName: "sub",
+		kind: "sub",
+		parentId: "Main",
+		session: fakeSession,
+		sessionFile: parentSessionFile,
+	});
+
+	const handler = new AgentProtocolHandler();
+	// Slash form is a hierarchy hop, not a jq extraction.
+	const slash = await handler.resolve(new URL("agent://Parent/Child") as never);
+	expect(slash.content).toBe("child capsule");
+	expect(slash.contentType).toBe("text/markdown");
+	// The canonical dotted id resolves to the same output.
+	const dotted = await handler.resolve(new URL("agent://Parent.Child") as never);
+	expect(dotted.content).toBe("child capsule");
+});
+
+it("agent:// path form falls back to JSON extraction when no nested output matches", async () => {
+	const root = tempDir.path();
+	const rootSessionFile = path.join(root, "json-session.jsonl");
+	const rootArtifactsDir = rootSessionFile.slice(0, -6);
+	await fs.mkdir(rootArtifactsDir, { recursive: true });
+	const sharedArtifactManager = new ArtifactManager(rootArtifactsDir);
+	await fs.writeFile(path.join(rootArtifactsDir, "Worker.md"), JSON.stringify({ result: { ok: true } }));
+
+	const fakeSession = {
+		sessionManager: { getArtifactsDir: () => sharedArtifactManager.dir },
+	} as unknown as AgentSession;
+	const registry = AgentRegistry.global();
+	registry.register({
+		id: "Main",
+		displayName: "main",
+		kind: "main",
+		session: fakeSession,
+		sessionFile: rootSessionFile,
+	});
+
+	const handler = new AgentProtocolHandler();
+	// `result` names no nested output, so the path extracts JSON from Worker.md.
+	const extracted = await handler.resolve(new URL("agent://Worker/result") as never);
+	expect(extracted.contentType).toBe("application/json");
+	expect(JSON.parse(extracted.content)).toEqual({ ok: true });
+});

--- a/packages/coding-agent/src/internal-urls/agent-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/agent-protocol.ts
@@ -8,7 +8,11 @@
  *
  * URL forms:
  * - agent://<id> - Full output content
- * - agent://<id>/<path> - JSON extraction via path form
+ * - agent://<id>/<child> - Nested subagent output (hierarchy separator; the
+ *   registry allocates a subagent's own children as dot-qualified ids, so
+ *   `agent://Parent/Child` resolves `Parent.Child.md`)
+ * - agent://<id>/<path> - JSON extraction via path form (fallback when no
+ *   nested output matches the path)
  * - agent://<id>?q=<query> - JSON extraction via query form
  */
 import * as fs from "node:fs/promises";
@@ -44,65 +48,56 @@ export class AgentProtocolHandler implements ProtocolHandler {
 		}
 
 		const dirs = artifactsDirsFromRegistry();
-
 		if (dirs.length === 0) {
 			throw new Error("No session - agent outputs unavailable");
 		}
 
-		let foundPath: string | undefined;
-		let anyDirExists = false;
-		const availableIds = new Set<string>();
-
-		for (const dir of dirs) {
+		// A subagent allocates its own children as dot-qualified ids
+		// (`Parent.Child`), so the slash path form is first tried as a hierarchy
+		// separator: `agent://Parent/Child` resolves `Parent.Child.md`. Only when
+		// no such nested output exists does the path fall back to jq-style JSON
+		// extraction on `<outputId>.md`. Query form (`?q=`) is always extraction.
+		const pathSegments = hasPathExtraction ? urlPath.split("/").filter(Boolean) : [];
+		const decodedSegments = pathSegments.map(segment => {
 			try {
-				await fs.stat(dir);
-				anyDirExists = true;
-			} catch (err) {
-				if (isEnoent(err)) continue;
-				throw err;
+				return decodeURIComponent(segment);
+			} catch {
+				return segment;
 			}
-			const candidate = path.join(dir, `${outputId}.md`);
-			try {
-				await fs.stat(candidate);
-				foundPath = candidate;
-				break;
-			} catch (err) {
-				if (!isEnoent(err)) throw err;
-				try {
-					const files = await fs.readdir(dir);
-					for (const f of files) {
-						if (f.endsWith(".md")) availableIds.add(f.replace(/\.md$/, ""));
-					}
-				} catch {
-					// Listing failures are non-fatal; continue searching.
-				}
-			}
-		}
+		});
+		const nestedId =
+			decodedSegments.length > 0 && decodedSegments.every(segment => !segment.includes("."))
+				? [outputId, ...decodedSegments].join(".")
+				: undefined;
 
-		if (!anyDirExists) {
+		const scan = await this.#findOutput(dirs, nestedId ? [nestedId, outputId] : [outputId]);
+		if (!scan.anyDirExists) {
 			throw new Error("No artifacts directory found");
 		}
-
-		if (!foundPath) {
-			const availableStr = availableIds.size > 0 ? [...availableIds].join(", ") : "none";
-			throw new Error(`Not found: ${outputId}\nAvailable: ${availableStr}`);
+		if (!scan.foundPath) {
+			const target = nestedId ?? outputId;
+			const availableStr = scan.availableIds.size > 0 ? [...scan.availableIds].join(", ") : "none";
+			throw new Error(`Not found: ${target}\nAvailable: ${availableStr}`);
 		}
 
-		const rawContent = await Bun.file(foundPath).text();
+		const rawContent = await Bun.file(scan.foundPath).text();
 		const notes: string[] = [];
 		let content = rawContent;
 		let contentType: InternalResource["contentType"] = "text/markdown";
 
-		if (hasPathExtraction || hasQueryExtraction) {
+		// Extraction applies only when the URL did NOT resolve to a nested output
+		// (a slash that named a real child is a hierarchy hop, not a jq path).
+		const extract = hasQueryExtraction || (hasPathExtraction && scan.matchedId !== nestedId);
+		if (extract) {
 			let jsonValue: unknown;
 			try {
 				jsonValue = JSON.parse(rawContent);
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
-				throw new Error(`Output ${outputId} is not valid JSON: ${message}`);
+				throw new Error(`Output ${scan.matchedId} is not valid JSON: ${message}`);
 			}
 
-			const query = hasPathExtraction ? pathToQuery(urlPath) : queryParam!;
+			const query = hasQueryExtraction ? queryParam! : pathToQuery(urlPath);
 			if (query) {
 				const extracted = applyQuery(jsonValue, query);
 				try {
@@ -122,9 +117,48 @@ export class AgentProtocolHandler implements ProtocolHandler {
 			content,
 			contentType,
 			size: Buffer.byteLength(content, "utf-8"),
-			sourcePath: foundPath,
+			sourcePath: scan.foundPath,
 			notes,
 		};
+	}
+
+	/**
+	 * Scan every registered artifacts dir for the first `<id>.md` among
+	 * `candidateIds` (tried in order, so a hierarchy match wins over the base
+	 * id). Returns the resolved path and the id it matched, plus the set of
+	 * available ids gathered from the scanned dirs for the not-found message.
+	 */
+	async #findOutput(
+		dirs: string[],
+		candidateIds: string[],
+	): Promise<{ foundPath?: string; matchedId?: string; anyDirExists: boolean; availableIds: Set<string> }> {
+		// Build a full id→path map across every registered dir before picking, so
+		// candidate priority is global: a nested id in a deeper dir must win over
+		// the base id even when the base id's dir is scanned first.
+		const byId = new Map<string, string>();
+		let anyDirExists = false;
+		for (const dir of dirs) {
+			let files: string[];
+			try {
+				files = await fs.readdir(dir);
+			} catch (err) {
+				if (isEnoent(err)) continue;
+				throw err;
+			}
+			anyDirExists = true;
+			for (const f of files) {
+				if (!f.endsWith(".md")) continue;
+				const id = f.slice(0, -3);
+				if (!byId.has(id)) byId.set(id, path.join(dir, f));
+			}
+		}
+		for (const id of candidateIds) {
+			const foundPath = byId.get(id);
+			if (foundPath) {
+				return { foundPath, matchedId: id, anyDirExists, availableIds: new Set(byId.keys()) };
+			}
+		}
+		return { anyDirExists, availableIds: new Set(byId.keys()) };
 	}
 
 	async complete(): Promise<UrlCompletion[]> {

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -56,7 +56,7 @@ Special URLs for internal resources; with most FS/bash tools they auto-resolve t
   {{#if hasMemoryRoot}}
 - `memory://root`: project memory summary
   {{/if}}
-- `agent://<id>`: agent output artifact; `/<path>` extracts a JSON field
+- `agent://<id>`: agent output artifact; `/<child>` reads a nested subagent's output, else `/<path>` extracts a JSON field
 - `artifact://<id>`: artifact content
 - `local://<name>.md`: plan artifacts or shared content for subagents
 {{#if hasObsidian}}


### PR DESCRIPTION
## Repro
From a subagent spawned via `task`, reading its own finished child through the slash form fails. On current `main`, testing each form the issue tried against `AgentProtocolHandler`:

```
bare   agent://Child            => Not found: Child
dotted agent://Parent.Child     => OK (child capsule)   # already fixed by #4650
slash  agent://Parent/Child     => Not found: Parent
```

The reporter's production session (2026-07-11) predated #4650, so even the dotted form failed there; on `main` only the slash form the session used verbatim (`agent://Plan005Retry/Reconcile005`, `agent://PlanIssue005/ScoutSchema`) still breaks. Covered by `src/internal-urls/__tests__/agent-protocol-nested.test.ts`.

## Cause
`AgentProtocolHandler.resolve` in `packages/coding-agent/src/internal-urls/agent-protocol.ts` always treated a non-empty URL path as a jq JSON-extraction key (`pathToQuery` → `applyQuery`) against `<outputId>.md`. A subagent allocates its own children as dot-qualified ids (`Parent.Child`, via `AgentOutputManager`'s `parentPrefix`), written one level deeper under the parent's `sessionFile`-derived dir. So `agent://Parent/Child` loaded `Parent.md` and applied `.Child` instead of resolving the nested capsule `Parent.Child.md`, yielding `Not found` (or a JSON parse error).

## Fix
- `agent-protocol.ts`: the slash path is now a hierarchy separator first. Path segments (none containing a `.`) are dot-joined onto the host id to form a `nestedId` candidate; `#findOutput` scans every registered artifacts dir, builds a global id→path map, and picks by candidate priority (`nestedId` before the base id), so a nested output in a deeper dir wins.
- JSON extraction is now the fallback: it runs only for `?q=` (always) or when a path form resolved to the base id rather than a nested output — so `agent://Worker/result` on a JSON `Worker.md` still extracts `.result`.
- `#findOutput` replaces the inline per-dir scan and centralizes the available-ids collection for the not-found message.
- Tests: two contract cases in `agent-protocol-nested.test.ts` — slash form resolves the nested child (and matches the canonical dotted id), and path form falls back to JSON extraction when no nested output matches.
- Docs: `system-prompt.md` and `docs/tools/task.md` describe `/<child>` as a nested-output hop with JSON-extraction fallback; CHANGELOG `[Unreleased]` entry.

## Verification
`bun test src/internal-urls` → 33 pass, 0 fail. `bun test src/eval/__tests__/agent-bridge.test.ts src/internal-urls` → 72 pass, 0 fail (agent-bridge exercises `agent://` resolution end to end; required generating `tool-views.generated.js` via `bun run gen:tool-views`, an untracked build artifact unrelated to this change). Fixes #5238