### PR TITLE
fix(extensions): let tool_result rewrite thrown failure content

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `tool_result` extension handlers being unable to rewrite the model-visible content of a thrown tool failure while keeping it an error — `ExtensionToolWrapper` rethrew the original exception and discarded the replacement `content`/`details`; it now surfaces the modified result with `isError: true` ([#5302](https://github.com/can1357/oh-my-pi/issues/5302))
+
 ## [16.4.8] - 2026-07-12
 
 ### Fixed

--- a/packages/coding-agent/src/cursor.ts
+++ b/packages/coding-agent/src/cursor.ts
@@ -93,6 +93,7 @@ async function executeTool(
 		result = buildToolErrorResult(message);
 		isError = true;
 	}
+	isError ||= result.isError === true;
 
 	const sanitizedFinalResult: AgentToolResult<unknown> = {
 		content: result.content.map(c => (c.type === "text" ? { ...c, text: sanitizeText(c.text) } : c)),
@@ -283,6 +284,7 @@ export class CursorExecHandlers implements ICursorExecHandlers {
 			result = buildToolErrorResult(message);
 			isError = true;
 		}
+		isError ||= result.isError === true;
 
 		// onUpdate may not fire for every chunk — flush any remaining output
 		// from the final result that wasn't already streamed.

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -1,7 +1,7 @@
 /**
  * Tool wrappers for extensions.
  */
-import type { AgentTool, AgentToolContext, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai";
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
@@ -110,7 +110,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 		signal?: AbortSignal,
 		onUpdate?: AgentToolUpdateCallback<TDetails, TParameters>,
 		context?: AgentToolContext,
-	) {
+	): Promise<AgentToolResult<TDetails, TParameters>> {
 		// 1. Check approval policy (before extension handlers).
 		// CLI `--auto-approve` / `--yolo` sets approval mode to yolo.
 		// User `tools.approval.<tool>` policies are still applied in all modes.
@@ -237,23 +237,23 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				const modifiedContent: (TextContent | ImageContent)[] = resultResult.content ?? result.content;
 				const modifiedDetails = (resultResult.details ?? result.details) as TDetails;
 
-				// Extension can override error status
-				if (resultResult.isError === true && !executionError) {
-					// Extension marks a successful result as error
-					const textBlocks = (modifiedContent ?? []).filter((c): c is TextContent => c.type === "text");
-					const errorText = textBlocks.map(t => t.text).join("\n") || "Tool result marked as error by extension";
-					throw new Error(errorText);
-				}
-				if (resultResult.isError === false && executionError) {
-					// Extension clears the error - return success
-					return { content: modifiedContent, details: modifiedDetails };
-				}
+				// Effective error state: an explicit handler override wins; otherwise the
+				// original execution outcome stands. This lets a handler rewrite a failed
+				// call's model-visible content/details while keeping it an error, flip a
+				// failure to success, or flag a success as an error.
+				const effectiveError = resultResult.isError ?? !!executionError;
 
-				// Error status unchanged, but content/details may be modified
-				if (executionError) {
-					throw executionError;
-				}
-				return { content: modifiedContent, details: modifiedDetails };
+				// Return the (possibly modified) result carrying the error flag rather than
+				// rethrowing the original exception. The agent loop honors
+				// `AgentToolResult.isError` and surfaces it as a tool error on the wire (see
+				// `coerceToolResult` in agent-loop), so replacement failure content reaches
+				// the model while the call remains an error — the original exception text is
+				// no longer forced through, which previously discarded the replacement.
+				return {
+					content: modifiedContent,
+					details: modifiedDetails,
+					...(effectiveError ? { isError: true } : {}),
+				};
 			}
 		}
 

--- a/packages/coding-agent/test/cursor-exec.test.ts
+++ b/packages/coding-agent/test/cursor-exec.test.ts
@@ -2,10 +2,14 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { create } from "@bufbuild/protobuf";
+import type { AgentEvent, AgentTool } from "@oh-my-pi/pi-agent-core";
+import { ReadArgsSchema, ShellArgsSchema } from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { CursorExecHandlers } from "@oh-my-pi/pi-coding-agent/cursor";
 import { GrepTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
 
 function createTestSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
 	return {
@@ -63,5 +67,57 @@ describe("CursorExecHandlers.grep bridge", () => {
 			caseInsensitive: false,
 		} as any);
 		expect((sensitiveResult.details as { matchCount?: number } | undefined)?.matchCount).toBe(1);
+	});
+});
+
+describe("CursorExecHandlers error results", () => {
+	const rewrittenErrorTool = (name: string): AgentTool => ({
+		name,
+		label: name,
+		description: "returns a rewritten tool failure",
+		parameters: type({}),
+		execute: async () => ({
+			content: [{ type: "text", text: "Enriched recovery guidance" }],
+			details: { enriched: true },
+			isError: true,
+		}),
+	});
+
+	it("propagates returned isError through the standard exec bridge", async () => {
+		const events: AgentEvent[] = [];
+		const handlers = new CursorExecHandlers({
+			cwd: ".",
+			tools: new Map([["read", rewrittenErrorTool("read")]]),
+			emitEvent: event => events.push(event),
+		});
+
+		const result = await handlers.read(create(ReadArgsSchema, { toolCallId: "call-read", path: "ignored" }));
+		expect(result.isError).toBe(true);
+		expect(result.content).toEqual([{ type: "text", text: "Enriched recovery guidance" }]);
+		const end = events.find(event => event.type === "tool_execution_end");
+		expect(end?.isError).toBe(true);
+	});
+
+	it("propagates returned isError through the shell stream bridge", async () => {
+		const events: AgentEvent[] = [];
+		const stdout: string[] = [];
+		const handlers = new CursorExecHandlers({
+			cwd: ".",
+			tools: new Map([["bash", rewrittenErrorTool("bash")]]),
+			emitEvent: event => events.push(event),
+		});
+
+		const result = await handlers.shellStream(
+			create(ShellArgsSchema, { toolCallId: "call-shell", command: "ignored" }),
+			{
+				onStdout: data => stdout.push(data),
+				onStderr: () => {},
+			},
+		);
+		expect(result.isError).toBe(true);
+		expect(result.content).toEqual([{ type: "text", text: "Enriched recovery guidance" }]);
+		expect(stdout).toEqual(["Enriched recovery guidance"]);
+		const end = events.find(event => event.type === "tool_execution_end");
+		expect(end?.isError).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -6,6 +6,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { discoverAndLoadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import {
@@ -835,6 +836,99 @@ describe("ExtensionRunner", () => {
 				details: { source: "ext1" },
 				isError: true,
 			});
+		});
+	});
+
+	describe("tool_result rewrite of thrown failures", () => {
+		const throwingTool: AgentTool = {
+			name: "boom",
+			label: "Boom",
+			description: "always throws",
+			parameters: {} as never,
+			execute: async () => {
+				throw new Error("original explosion");
+			},
+		};
+
+		const okTool: AgentTool = {
+			name: "fine",
+			label: "Fine",
+			description: "always succeeds",
+			parameters: {} as never,
+			execute: async () => ({ content: [{ type: "text" as const, text: "success" }] }),
+		};
+
+		const firstText = (result: { content: readonly (TextContent | ImageContent)[] }): string | undefined => {
+			const block = result.content[0];
+			return block?.type === "text" ? block.text : undefined;
+		};
+
+		const runnerFor = async (extCode: string): Promise<ExtensionRunner> => {
+			fs.writeFileSync(path.join(extensionsDir, "rewrite.ts"), extCode);
+			const result = await loadTestExtensions();
+			return new ExtensionRunner(result.extensions, result.runtime, tempDir.path(), sessionManager, modelRegistry);
+		};
+
+		it("surfaces replacement content while keeping the call an error", async () => {
+			const runner = await runnerFor(`
+				export default function(pi) {
+					pi.on("tool_result", (event) => {
+						if (!event.isError) return;
+						return {
+							content: [{ type: "text", text: "Enriched recovery guidance" }],
+							details: { enriched: true },
+							isError: true,
+						};
+					});
+				}
+			`);
+			const wrapper = new ExtensionToolWrapper(throwingTool, runner);
+			const res = await wrapper.execute("call-rewrite", {} as never, undefined, undefined, undefined);
+			expect(firstText(res)).toBe("Enriched recovery guidance");
+			expect(res.isError).toBe(true);
+			expect(res.details).toEqual({ enriched: true });
+		});
+
+		it("preserves the original exception when no handler modifies the result", async () => {
+			const runner = await runnerFor(`
+				export default function(pi) {
+					pi.on("tool_result", () => {});
+				}
+			`);
+			const wrapper = new ExtensionToolWrapper(throwingTool, runner);
+			await expect(wrapper.execute("call-untouched", {} as never, undefined, undefined, undefined)).rejects.toThrow(
+				"original explosion",
+			);
+		});
+
+		it("converts a failure to success when a handler clears isError", async () => {
+			const runner = await runnerFor(`
+				export default function(pi) {
+					pi.on("tool_result", (event) => {
+						if (!event.isError) return;
+						return { content: [{ type: "text", text: "recovered" }], isError: false };
+					});
+				}
+			`);
+			const wrapper = new ExtensionToolWrapper(throwingTool, runner);
+			const res = await wrapper.execute("call-cleared", {} as never, undefined, undefined, undefined);
+			expect(firstText(res)).toBe("recovered");
+			expect(res.isError).toBeUndefined();
+		});
+
+		it("marks a successful result as an error when a handler sets isError", async () => {
+			const runner = await runnerFor(`
+				export default function(pi) {
+					pi.on("tool_result", () => ({
+						content: [{ type: "text", text: "now failing" }],
+						isError: true,
+					}));
+				}
+			`);
+			const wrapper = new ExtensionToolWrapper(okTool, runner);
+			const res = await wrapper.execute("call-flagged", {} as never, undefined, undefined, undefined);
+			expect(firstText(res)).toBe("now failing");
+			expect(res.isError).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## Repro
A builtin/extension tool that throws is caught by `ExtensionToolWrapper`, which emits a `tool_result` event with `isError: true`. A handler that returns replacement `content`/`details` while keeping `isError: true` should surface the replacement as a failure — but the model receives the original exception text instead. The only way to surface modified content was `isError: false`, which wrongly converted the failed call into a success. Reproduced with a throwing fake tool wrapped by a real `ExtensionRunner` whose `tool_result` handler returns `{ content: [{ type: "text", text: "Enriched recovery guidance" }], isError: true }`: `wrapper.execute(...)` rejected with `original explosion` rather than returning the enriched content.

## Cause
`ExtensionToolWrapper.execute` in `packages/coding-agent/src/extensibility/extensions/wrapper.ts`: after applying handler modifications, whenever the effective error state stayed true it hit `if (executionError) throw executionError;`, rethrowing the original exception and discarding the handler's `modifiedContent`/`modifiedDetails`. The agent loop already honors a non-throwing `AgentToolResult.isError` flag (`coerceToolResult` in `packages/agent/src/agent-loop.ts:2085`) and surfaces it as a tool error on the wire, so the rethrow was both lossy and unnecessary.

## Fix
- Compute `effectiveError = resultResult.isError ?? !!executionError` after handler modifications.
- Return `{ content: modifiedContent, details: modifiedDetails, ...(effectiveError ? { isError: true } : {}) }` instead of rethrowing — replacement failure content now reaches the model while the call stays an error. The no-modification path still rethrows the original exception verbatim; error→success (`isError: false`) and success→error (`isError: true`) keep their existing semantics.
- Annotate `execute` with its `Promise<AgentToolResult<TDetails, TParameters>>` return type so the `isError` field is part of the inferred contract.
- Added four regression tests in `test/extensions-runner.test.ts` (throwing fake tool + real runner): replacement content with `isError: true`, unmodified failure preserves the original exception, failure→success, and success→error.

## Verification
`bun test test/extensions-runner.test.ts` → 43 pass / 0 fail (2 pre-existing `tool_result` chaining tests + 4 new). `bun run check:types` clean. Fixes #5302