### PR TITLE
fix(advisor): stop retrying terminal failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Updated status event log to prioritize the most recent entries in the display window
 
+### Fixed
+
+- Fixed advisor turns retrying terminal non-retriable provider failures such as Codex `invalid_prompt` errors; these failures now roll back and notify immediately while transient failures retain bounded retries ([#5312](https://github.com/can1357/oh-my-pi/issues/5312))
+
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "bun:test";
 import type { AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import type { TUI } from "@oh-my-pi/pi-tui";
 import { type } from "arktype";
 import type { ModelRegistry } from "../../config/model-registry";
@@ -1459,6 +1461,7 @@ describe("advisor", () => {
 							content: [{ type: "text", text: "" }],
 							stopReason: "error",
 							errorMessage: "404 No endpoints available",
+							errorId: AIError.create(AIError.Flag.Transient),
 							timestamp: Date.now(),
 						} as unknown as AgentMessage);
 						state.error = "404 No endpoints available";
@@ -1514,6 +1517,74 @@ describe("advisor", () => {
 			expect(lengthsBeforePrompt[lengthsBeforePrompt.length - 1]).toBe(0);
 			expect(rollbackCalls).toHaveLength(3);
 			expect(state.messages).toHaveLength(2);
+		});
+
+		it("drops a terminal non-retriable assistant failure without retrying", async () => {
+			const errorMessage = "Codex error event: Request blocked. (code=invalid_prompt)";
+			const promptInputs: string[] = [];
+			const rollbackCalls: number[] = [];
+			const turnErrors: unknown[] = [];
+			const failures: unknown[] = [];
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptInputs.push(input);
+					state.messages.push({ role: "user", content: input, timestamp: 1 } as AgentMessage);
+					const failure: AssistantMessage = {
+						role: "assistant",
+						content: [],
+						api: "openai-codex-responses",
+						provider: "openai-codex",
+						model: "gpt-5.6-sol",
+						usage: {
+							input: 1,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 1,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+						},
+						stopReason: "error",
+						errorMessage,
+						errorId: 0,
+						timestamp: 2,
+					};
+					state.messages.push(failure);
+					state.error = errorMessage;
+				},
+				abort: () => {},
+				reset: () => {
+					state.messages.length = 0;
+					state.error = undefined;
+				},
+				rollbackTo: count => {
+					rollbackCalls.push(count);
+					state.messages.length = Math.min(count, state.messages.length);
+					state.error = undefined;
+				},
+				state,
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				onTurnError: error => {
+					turnErrors.push(error);
+				},
+				notifyFailure: error => {
+					failures.push(error);
+				},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 1);
+
+			runtime.onTurnEnd(messages);
+			await runtime.waitForCatchup(1000, 1);
+
+			expect(promptInputs).toHaveLength(1);
+			expect(rollbackCalls).toEqual([0]);
+			expect(turnErrors).toHaveLength(1);
+			expect(failures).toHaveLength(1);
+			expect(runtime.backlog).toBe(0);
 		});
 
 		it("drops the in-flight batch when a reset aborts the advisor prompt", async () => {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import { logger } from "@oh-my-pi/pi-utils";
 import { obfuscateToolArguments, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
@@ -270,6 +271,15 @@ export class AdvisorRuntime {
 	 * append-only context); falls back to truncating `state.messages` for tests
 	 * that hand-roll a minimal facade.
 	 */
+	#terminalAssistantFailure(snapshot: number): AssistantMessage | undefined {
+		const messages = this.agent.state.messages;
+		for (let i = messages.length - 1; i >= snapshot; i--) {
+			const message = messages[i];
+			if (message.role === "assistant" && message.stopReason === "error") return message;
+		}
+		return undefined;
+	}
+
 	#rollbackFailedTurn(snapshot: number): void {
 		const messages = this.agent.state.messages;
 		if (messages.length <= snapshot) return;
@@ -361,6 +371,13 @@ export class AdvisorRuntime {
 					// (reset already cleared #pending and rewound the cursor) instead of
 					// requeuing it into the post-reset conversation.
 					if (this.#epoch !== epoch) continue;
+					const terminalFailure = this.#terminalAssistantFailure(messageSnapshot);
+					const terminalFailureId =
+						terminalFailure === undefined ? undefined : AIError.classifyMessage(terminalFailure);
+					const terminalFailureRetriable =
+						terminalFailureId === undefined ||
+						AIError.retriable(terminalFailureId) ||
+						AIError.is(terminalFailureId, AIError.Flag.ContextOverflow);
 					this.#rollbackFailedTurn(messageSnapshot);
 					logger.debug("advisor turn failed", { err: String(err) });
 					try {
@@ -371,9 +388,8 @@ export class AdvisorRuntime {
 					// The hook awaits; a reset during it invalidates this batch like the
 					// prompt await above — drop it instead of requeueing stale content.
 					if (this.#epoch !== epoch) continue;
-					this.#consecutiveFailures++;
-					if (this.#consecutiveFailures >= 3) {
-						logger.warn("advisor failed consecutively 3 times; dropping backlog to prevent stall");
+					if (!terminalFailureRetriable) {
+						logger.warn("advisor terminal failure is non-retriable; dropping bounded batch");
 						if (!this.#failureNotified) {
 							this.#failureNotified = true;
 							try {
@@ -383,14 +399,30 @@ export class AdvisorRuntime {
 							}
 						}
 						this.#consecutiveFailures = 0;
-						// The dropped batch may carry primary-context we never delivered; drop
-						// the seen-state too so the next turn re-expands it instead of marking
-						// it "unchanged" against content the advisor never received.
 						this.#seenContext.clear();
 						success = true;
 					} else {
-						this.#pending.unshift({ text: batch, turns: finalTurns });
-						await Bun.sleep(this.retryDelayMs);
+						this.#consecutiveFailures++;
+						if (this.#consecutiveFailures >= 3) {
+							logger.warn("advisor failed consecutively 3 times; dropping backlog to prevent stall");
+							if (!this.#failureNotified) {
+								this.#failureNotified = true;
+								try {
+									this.host.notifyFailure?.(err);
+								} catch (notifyErr) {
+									logger.warn("advisor failure notification failed", { err: String(notifyErr) });
+								}
+							}
+							this.#consecutiveFailures = 0;
+							// The dropped batch may carry primary-context we never delivered; drop
+							// the seen-state too so the next turn re-expands it instead of marking
+							// it "unchanged" against content the advisor never received.
+							this.#seenContext.clear();
+							success = true;
+						} else {
+							this.#pending.unshift({ text: batch, turns: finalTurns });
+							await Bun.sleep(this.retryDelayMs);
+						}
 					}
 				}
 


### PR DESCRIPTION
## Repro
A real-shaped Codex terminal assistant message with `stopReason: "error"`, `errorId: 0`, and `Codex error event: Request blocked. (code=invalid_prompt)` was supplied to `AdvisorRuntime`; `bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts -t "drops a terminal non-retriable assistant failure without retrying"` failed before the fix because the runtime issued three prompts instead of one.

## Cause
`AdvisorRuntime.#drain()` in `packages/coding-agent/src/advisor/runtime.ts` converted `agent.state.error` into a generic `Error`, rolled the failed turn back, and then requeued every failure without retaining or classifying the terminal assistant message that carried the provider's structured retry policy.

## Fix
- Retain the terminal assistant failure before rollback and classify it with `AIError.classifyMessage()`.
- Drop, notify, reset failure accounting, and clear undelivered context deduplication state immediately when the terminal failure is non-retriable.
- Preserve bounded retries for transient terminal failures, context-overflow-classified failures, and errors without a terminal assistant message.
- Add focused terminal and transient regression coverage plus an unreleased changelog entry.

## Verification
`bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts` passed: 73 tests, 268 assertions, 0 failures. `bun run check:types` passed in `packages/coding-agent`. The pre-publish `bun run fix` and `bun check` gate also passed. Fixes #5312