### PR TITLE
fix(auth): keep plan-gated Codex sessions on their sticky OAuth account

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Healed GLM in-band tool calls whose `<arg_value>` closer is missing or mistyped as `</arg_key>`; the scanner now ends the value at the next-pair signature instead of swallowing the remaining arguments into one field.
 - Healed the same `arg_key`/`arg_value` spill when it arrives through native tool calling (provider parses the in-band syntax server-side): as a last resort after validation and coercion fail, contaminated string arguments are split at the spill boundary and the swallowed pairs restored.
+- Fixed plan-gated OpenAI Codex models (Sol/Luna) silently re-routing an active session to a sibling OAuth account when usage headroom changed: `AuthStorage.#resolveOAuthSelection` now promotes the session-preferred credential back to the front of the ranked candidates whenever it is still usable, unblocked, and plan-eligible, so a session stays sticky unless the sticky account is blocked, exhausted, or ineligible for the current model ([#5203](https://github.com/can1357/oh-my-pi/issues/5203)).
 
 ## [16.4.3] - 2026-07-11
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3775,10 +3775,10 @@ export class AuthStorage {
 			sessionPreferredCredential !== undefined &&
 			(sessionPreferredCredential.refresh.trim().length > 0 ||
 				Date.now() + OAUTH_REFRESH_SKEW_MS < sessionPreferredCredential.expires);
-		// Skip ranking only when the session already has a working preferred credential — re-ranking
-		// mid-session causes account switches that cold-start the server-side prompt cache. New sessions
-		// (no preference) and sessions whose preferred is blocked still rank, so we pick the account
-		// with the most headroom proactively and fall back intelligently when rate-limited.
+		// Skip ranking only when the session already has a working preferred credential.
+		// Plan-requiring Codex models still rank to verify the sticky account's tier,
+		// but an eligible sticky account is promoted back below so usage-headroom
+		// changes cannot silently move an active session to a sibling account.
 		const sessionPreferredIsAvailable =
 			sessionPreferredIndex !== undefined &&
 			sessionPreferredCanRefreshOrUse &&
@@ -3803,17 +3803,6 @@ export class AuthStorage {
 					.filter((selection): selection is { credential: OAuthCredential; index: number } => Boolean(selection))
 					.map(selection => ({ selection, usage: null, usageChecked: false }));
 
-		if (sessionPreferredIndex !== undefined && !hasPlanRequirement) {
-			const sessionPreferredCandidate = candidates.findIndex(
-				candidate =>
-					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScope) &&
-					candidate.selection.index === sessionPreferredIndex,
-			);
-			if (sessionPreferredCandidate > 0) {
-				const [preferred] = candidates.splice(sessionPreferredCandidate, 1);
-				candidates.unshift(preferred);
-			}
-		}
 		// Step (b) of the auth-retry policy: when `forceRefresh` is set, re-mint
 		// the session-preferred credential (or the first candidate when no
 		// session preference exists yet) even if its cached token still looks
@@ -3889,6 +3878,24 @@ export class AuthStorage {
 		const enforcePlanRequirement =
 			hasPlanRequirement &&
 			candidates.some(candidate => getOpenAICodexPlanEligibility(candidate.usage, planRequirement) === true);
+
+		if (sessionPreferredIndex !== undefined) {
+			const sessionPreferredCandidate = candidates.findIndex(
+				candidate =>
+					!this.#isCredentialBlocked(provider, providerKey, candidate.selection.index, blockScope) &&
+					candidate.selection.index === sessionPreferredIndex,
+			);
+			if (sessionPreferredCandidate > 0) {
+				const preferred = candidates[sessionPreferredCandidate]!;
+				const planEligibility = hasPlanRequirement
+					? getOpenAICodexPlanEligibility(preferred.usage, planRequirement)
+					: true;
+				if (planEligibility === true || !enforcePlanRequirement) {
+					candidates.splice(sessionPreferredCandidate, 1);
+					candidates.unshift(preferred);
+				}
+			}
+		}
 
 		const fallback = candidates[0];
 

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -1484,6 +1484,55 @@ describe("AuthStorage codex oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-low-usage");
 	});
 
+	test("keeps an eligible Codex session credential when usage headroom makes its sibling rank better", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		const modelId = "gpt-5.6-sol";
+		const sessionId = "codex-sticky-usage-rerank";
+		const accounts = [
+			{ id: "acct-sticky-usage-a", email: "sticky-usage-a@example.com" },
+			{ id: "acct-sticky-usage-b", email: "sticky-usage-b@example.com" },
+		];
+		const reportByAccount: Record<string, UsageReport> = {};
+		const setUsedFraction = (report: UsageReport, usedFraction: number): void => {
+			const used = usedFraction * 100;
+			for (const limit of report.limits) {
+				limit.amount.used = used;
+				limit.amount.remaining = 100 - used;
+				limit.amount.usedFraction = usedFraction;
+				limit.amount.remainingFraction = 1 - usedFraction;
+				limit.status = usedFraction >= 1 ? "exhausted" : usedFraction >= 0.9 ? "warning" : "ok";
+			}
+		};
+
+		await authStorage.set(
+			"openai-codex",
+			accounts.map(account => ({ type: "oauth", ...createCredential(account.id, account.email) })),
+		);
+		for (const account of accounts) {
+			const report = createCodexUsageReport({
+				accountId: account.id,
+				primary: { usedFraction: 0.25, resetInMs: 30 * 60 * 1000 },
+				secondary: { usedFraction: 0.25, resetInMs: 6 * 24 * 60 * 60 * 1000 },
+				metadata: { planType: "business", email: account.email },
+			});
+			reportByAccount[account.id] = report;
+			usageByAccount.set(account.id, report);
+		}
+
+		const firstApiKey = await authStorage.getApiKey("openai-codex", sessionId, { modelId });
+		if (!firstApiKey) throw new Error("expected initial Codex credential");
+		const stickyAccount = firstApiKey.replace(/^api-/, "");
+		const siblingAccount = stickyAccount === accounts[0]!.id ? accounts[1]!.id : accounts[0]!.id;
+		const stickyReport = reportByAccount[stickyAccount];
+		const siblingReport = reportByAccount[siblingAccount];
+		if (!stickyReport || !siblingReport) throw new Error("expected reports for both Codex accounts");
+
+		setUsedFraction(stickyReport, 0.85);
+		setUsedFraction(siblingReport, 0.01);
+		expect(await authStorage.getApiKey("openai-codex", sessionId, { modelId })).toBe(firstApiKey);
+	});
+
 	test("reranks a Terra session on a Go account when it switches to Sol", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 


### PR DESCRIPTION
## Repro
With two active `openai-codex` OAuth accounts, `/usage show` reported different subscription accounts within one session. The reporter confirmed (`16.4.8`) the session's persisted `session:sticky:openai-codex:<sessionId>` row was actually rewritten mid-session — not just a display glitch. Deterministic offline repro: two Plus accounts, one fixed session, `gpt-5.6-sol`; resolve once (returns account A), invert the two accounts' usage headroom, resolve again with the same session/model → returns account B. `gpt-5.6-terra` stayed sticky. Reproduced as a unit test: `bun test packages/ai/test/auth-storage-codex-selection.test.ts -t "keeps an eligible Codex session credential"` fails before the fix.

## Cause
`AuthStorage.#resolveOAuthSelection` (`packages/ai/src/auth-storage.ts`) computes `shouldRank = checkUsage && (!sessionPreferredIsAvailable || hasPlanRequirement)`. Sol/Luna set a plan requirement (`resolveOpenAICodexPlanRequirement`), so `hasPlanRequirement` is true and the OAuth candidates are usage-ranked on every request even when the session-preferred credential is still usable. `#orderRankedOAuthCandidates` mixes the stable session hash with usage-derived weights, so when the 5h/7d headroom ordering between two eligible Plus accounts flips, the same session hash lands on the sibling; `#tryOAuthCredential` then returns that account and `#recordSessionCredential` overwrites the sticky binding. The pre-existing session-preferred promotion was gated behind `!hasPlanRequirement`, so it never ran for plan-gated models.

## Fix
- `packages/ai/src/auth-storage.ts`: after ranking + preflight refresh, promote the session-preferred candidate back to the front of the candidate list whenever it is unblocked and — for plan-gated models — still plan-eligible (`getOpenAICodexPlanEligibility(...) === true`, or the requirement is not being enforced). Removed the earlier `!hasPlanRequirement`-gated promotion that never applied to Sol/Luna. Ranking still runs so a blocked/exhausted/ineligible sticky account correctly falls through to a sibling; Terra→Sol switching when the sticky account is not paid-eligible is preserved.
- `packages/ai/test/auth-storage-codex-selection.test.ts`: regression asserting a `gpt-5.6-sol` session keeps its initially selected eligible credential after the sibling's usage headroom improves.
- `packages/ai/CHANGELOG.md`: entry under `[Unreleased] > Fixed`.

## Verification
- `bun test packages/ai/test/auth-storage-codex-selection.test.ts` → 42 pass, 0 fail (new regression fails on pre-fix code, passes after; existing Terra-to-Sol plan-switch and block/exhaustion tests still pass).
- Pre-publish gate (`bun run fix` + `bun check`) ran clean on push.

Fixes #5203