### PR TITLE
fix(coding-agent): route /guided-goal oneshot through Codex websocket transport

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/guided-goal` throwing `Model not found` on websocket-only Codex models (e.g. `gpt-5.6-luna`): the interview oneshot now routes through the session's provider transport (`providerSessionState` + `preferWebsockets`) with an isolated session id instead of forcing an SSE fallback the Codex `/responses` endpoint rejects for those models — same class as the `/btw` regression. ([#5304](https://github.com/can1357/oh-my-pi/issues/5304))
+
 ## [16.4.8] - 2026-07-12
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/guided-goal` throwing `Model not found` on websocket-only Codex models (e.g. `gpt-5.6-luna`): the interview oneshot now routes through the session's provider transport (`providerSessionState` + `preferWebsockets`) with an isolated session id instead of forcing an SSE fallback the Codex `/responses` endpoint rejects for those models — same class as the `/btw` regression. ([#5304](https://github.com/can1357/oh-my-pi/issues/5304))
+- Fixed `/guided-goal` throwing `Model not found` on websocket-only Codex models (e.g. `gpt-5.6-luna`): the interview now routes through the session's provider transport (`providerSessionState` + `preferWebsockets`) instead of forcing an SSE fallback the Codex `/responses` endpoint rejects for those models — same class as the `/btw` regression. The whole interview reuses a single isolated Codex side session, so a multi-question run shares one socket instead of leaking one per turn. ([#5304](https://github.com/can1357/oh-my-pi/issues/5304))
 
 ## [16.4.8] - 2026-07-12
 

--- a/packages/coding-agent/src/goals/guided-setup.ts
+++ b/packages/coding-agent/src/goals/guided-setup.ts
@@ -1,6 +1,6 @@
 import { instrumentedCompleteSimple, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { Tool } from "@oh-my-pi/pi-ai";
-import { prompt } from "@oh-my-pi/pi-utils";
+import { prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import { extractTextContent, extractToolCall, parseJsonPayload } from "../commit/utils";
 import guidedGoalInterviewPrompt from "../prompts/goals/guided-goal-interview.md" with { type: "text" };
 import guidedGoalSystemPrompt from "../prompts/goals/guided-goal-system.md" with { type: "text" };
@@ -106,6 +106,16 @@ export async function runGuidedGoalTurn(
 			reasoning: toReasoningEffort(thinkingLevel),
 			disableReasoning: shouldDisableReasoning(thinkingLevel),
 			toolChoice: { type: "tool", name: RESPOND_TOOL_NAME },
+			// Route through the session's provider transport so websocket-only Codex
+			// models (gpt-5.6-luna/sol/terra) get a websocket session instead of
+			// falling back to SSE — the Codex SSE /responses endpoint does not serve
+			// those ids and rejects the turn with "Model not found" (#5304, same class
+			// as the /btw regression in #5213). A unique session id keeps this oneshot's
+			// append-only turn state isolated from the main conversation.
+			sessionId: `${session.sessionId}:guided-goal:${Snowflake.next()}`,
+			promptCacheKey: session.sessionId,
+			preferWebsockets: session.preferWebsockets,
+			providerSessionState: session.providerSessionState,
 		},
 		{ telemetry: resolveTelemetry(session.agent.telemetry, session.sessionId), oneshotKind: "guided_goal_setup" },
 	);

--- a/packages/coding-agent/src/goals/guided-setup.ts
+++ b/packages/coding-agent/src/goals/guided-setup.ts
@@ -37,6 +37,21 @@ export type GuidedGoalTurnResult =
 export interface GuidedGoalTurnOptions {
 	messages: readonly GuidedGoalMessage[];
 	signal?: AbortSignal;
+	/**
+	 * Stable Codex transport session id reused across every turn of one
+	 * interview. `handleGuidedGoalCommand` runs up to six turns; minting a fresh
+	 * id per turn opens a new websocket-only Codex socket each time (kept in
+	 * `providerSessionState` until session dispose), which can trip
+	 * `websocket_connection_limit_reached` and drop back to the SSE path this
+	 * fix avoids. Callers pass one id for the whole interview; omitted for
+	 * one-shot callers, which mint a unique id per call.
+	 */
+	sideSessionId?: string;
+}
+
+/** Mint a guided-goal Codex side-session id keyed off the main session id. */
+export function newGuidedGoalSessionId(session: AgentSession): string {
+	return `${session.sessionId}:guided-goal:${Snowflake.next()}`;
 }
 
 function parseGuidedGoalPayload(value: unknown): GuidedGoalTurnResult {
@@ -110,9 +125,12 @@ export async function runGuidedGoalTurn(
 			// models (gpt-5.6-luna/sol/terra) get a websocket session instead of
 			// falling back to SSE — the Codex SSE /responses endpoint does not serve
 			// those ids and rejects the turn with "Model not found" (#5304, same class
-			// as the /btw regression in #5213). A unique session id keeps this oneshot's
-			// append-only turn state isolated from the main conversation.
-			sessionId: `${session.sessionId}:guided-goal:${Snowflake.next()}`,
+			// as the /btw regression in #5213). The side session id is minted once per
+			// interview and reused across turns so a multi-question interview shares one
+			// Codex socket instead of opening a fresh one each turn; it stays distinct
+			// from the main session id so the oneshot's append-only turn state never
+			// pollutes the main conversation.
+			sessionId: options.sideSessionId ?? newGuidedGoalSessionId(session),
 			promptCacheKey: session.sessionId,
 			preferWebsockets: session.preferWebsockets,
 			providerSessionState: session.providerSessionState,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -71,7 +71,7 @@ import type {
 import type { CompactOptions } from "../extensibility/extensions/types";
 import type { Skill } from "../extensibility/skills";
 import { loadSlashCommands } from "../extensibility/slash-commands";
-import { type GuidedGoalMessage, runGuidedGoalTurn } from "../goals/guided-setup";
+import { type GuidedGoalMessage, newGuidedGoalSessionId, runGuidedGoalTurn } from "../goals/guided-setup";
 import type { Goal, GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
@@ -3111,8 +3111,12 @@ export class InteractiveMode implements InteractiveModeContext {
 
 			const messages: GuidedGoalMessage[] = [{ role: "user", content: initial }];
 			let latestDraftObjective: string | undefined;
+			// One Codex side session for the whole interview: every follow-up turn
+			// reuses it so a multi-question interview shares a single websocket-only
+			// Codex socket instead of leaking one per turn (#5471 review).
+			const guidedGoalSessionId = newGuidedGoalSessionId(this.session);
 			for (let turn = 0; turn < 6; turn++) {
-				const result = await runGuidedGoalTurn(this.session, { messages });
+				const result = await runGuidedGoalTurn(this.session, { messages, sideSessionId: guidedGoalSessionId });
 				if (result.objective?.trim()) latestDraftObjective = result.objective.trim();
 				if (result.kind === "question") {
 					messages.push({ role: "assistant", content: result.question });

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -45,6 +45,8 @@ function createSession(options?: {
 		model: current ? currentModel : undefined,
 		thinkingLevel: options?.thinkingLevel,
 		sessionId: "session-1",
+		preferWebsockets: true,
+		providerSessionState: new Map(),
 		agent: { telemetry: undefined },
 	} as unknown as AgentSession;
 }
@@ -144,6 +146,26 @@ describe("guided goal setup", () => {
 
 		expect(result).toEqual({ kind: "question", question: "What is done?" });
 		expect(complete.mock.calls[0]?.[0]).toBe(planModel);
+	});
+
+	it("routes the guided-goal request through the session provider transport", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple").mockResolvedValue(
+			mockResponse({ kind: "question", question: "What is done?" }) as never,
+		);
+		const session = createSession();
+
+		await runGuidedGoalTurn(session, { messages: [{ role: "user", content: "Ship it" }] });
+
+		// Regression (#5304): without a websocket-capable provider session, Codex
+		// falls back to SSE and rejects websocket-only models (gpt-5.6-luna) with
+		// "Model not found". The oneshot must inherit the session transport and use
+		// an isolated session id so it never pollutes the main conversation state.
+		const requestOptions = complete.mock.calls[0]?.[2];
+		expect(requestOptions?.preferWebsockets).toBe(true);
+		expect(requestOptions?.providerSessionState).toBe(session.providerSessionState);
+		expect(requestOptions?.promptCacheKey).toBe("session-1");
+		expect(requestOptions?.sessionId).toStartWith("session-1:guided-goal:");
+		expect(requestOptions?.sessionId).not.toBe("session-1");
 	});
 
 	it("falls back to slow when plan is unavailable", async () => {

--- a/packages/coding-agent/test/goals/guided-goal.test.ts
+++ b/packages/coding-agent/test/goals/guided-goal.test.ts
@@ -168,6 +168,23 @@ describe("guided goal setup", () => {
 		expect(requestOptions?.sessionId).not.toBe("session-1");
 	});
 
+	it("reuses a supplied side session id across interview turns", async () => {
+		const complete = spyOn(core, "instrumentedCompleteSimple").mockResolvedValue(
+			mockResponse({ kind: "question", question: "What is done?" }) as never,
+		);
+		const session = createSession();
+		const sideSessionId = "session-1:guided-goal:fixed";
+
+		// Regression (#5471 review): a multi-question interview must share one Codex
+		// side session so it does not leak a websocket-only socket per turn and trip
+		// websocket_connection_limit_reached (which drops back to the rejected SSE path).
+		await runGuidedGoalTurn(session, { messages: [{ role: "user", content: "Ship it" }], sideSessionId });
+		await runGuidedGoalTurn(session, { messages: [{ role: "user", content: "More" }], sideSessionId });
+
+		expect(complete.mock.calls[0]?.[2]?.sessionId).toBe(sideSessionId);
+		expect(complete.mock.calls[1]?.[2]?.sessionId).toBe(sideSessionId);
+	});
+
 	it("falls back to slow when plan is unavailable", async () => {
 		const complete = spyOn(core, "instrumentedCompleteSimple").mockResolvedValue(
 			mockResponse({ kind: "ready", objective: "Deliver the confirmed feature." }) as never,


### PR DESCRIPTION
## Repro
Setting the active model to a websocket-only Codex model (`gpt-5.6-luna` from ChatGPT Plus/Pro) and running `/guided-goal <objective>` throws `Error: Model not found gpt-5.6-luna` instead of starting the interview. Captured by a regression test in `test/goals/guided-goal.test.ts`: run `bun test packages/coding-agent/test/goals/guided-goal.test.ts -t "routes the guided-goal request"` against the pre-fix source and it fails (`preferWebsockets` is `undefined`).

## Cause
`runGuidedGoalTurn` (`packages/coding-agent/src/goals/guided-setup.ts`) calls `instrumentedCompleteSimple` with only `apiKey`/`signal`/`reasoning`/`toolChoice`. It never forwards `providerSessionState`, `sessionId`, or `preferWebsockets`. In `packages/ai/src/providers/openai-codex-responses.ts` (`buildCodexRequestContext`), the Codex `websocketState` is only allocated when both `providerSessionState` and `sessionId` are present; absent them, `openInitialCodexEventStream` always falls back to `openCodexSseTransport`. The Codex SSE `/responses` endpoint does not serve the websocket-only GPT-5.6 models (`gpt-5.6-luna`/`sol`/`terra`, `preferWebsockets: true`), so it rejects the turn with "Model not found". Same class as the `/btw` regression fixed in #5213.

## Fix
- Forwarded `providerSessionState` and `preferWebsockets` from the session to the guided-goal completion options, plus `promptCacheKey: session.sessionId`.
- Gave the oneshot a unique isolated `sessionId` (`${session.sessionId}:guided-goal:${Snowflake.next()}`) so its append-only Codex turn state never pollutes the main conversation, mirroring the side-channel pattern.
- Added a regression test asserting the guided-goal request inherits the session transport (`preferWebsockets`, `providerSessionState`) and uses an isolated session id keyed off the cache session id.

## Verification
`bun test packages/coding-agent/test/goals/guided-goal.test.ts` → 10 pass / 0 fail. New test fails against pre-fix source (`Expected: true, Received: undefined` for `preferWebsockets`) and passes with the fix. `bun check` passes clean across the workspace. Fixes #5304