### PR TITLE
fix(tui): align ask "Other" custom-input chrome to prompt gutter

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Updated status event log to prioritize the most recent entries in the display window
 
+### Fixed
+
+- Fixed the ask tool's "Other" custom-input dialog rendering the title, options, and hint one column to the right of the `> ` input gutter; the prompt-style editor chrome now aligns to column 0 ([#5313](https://github.com/can1357/oh-my-pi/issues/5313))
+
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers

--- a/packages/coding-agent/src/modes/components/hook-editor.ts
+++ b/packages/coding-agent/src/modes/components/hook-editor.ts
@@ -47,8 +47,11 @@ export class HookEditorComponent extends Container {
 		this.addChild(new DynamicBorder());
 		this.addChild(new Spacer(1));
 
-		// Title
-		this.addChild(new Text(theme.fg("accent", title), 1, 0));
+		// Title. Prompt-style renders the borderless editor's `> ` gutter at
+		// column 0, so pad the title to match; hook-style keeps the 1-col indent
+		// that lines up with its bordered editor body (#5313).
+		const chromePadX = this.#promptStyle ? 0 : 1;
+		this.addChild(new Text(theme.fg("accent", title), chromePadX, 0));
 		this.addChild(new Spacer(1));
 
 		// Editor
@@ -69,7 +72,7 @@ export class HookEditorComponent extends Container {
 		const hint = this.#promptStyle
 			? "enter or ctrl+q submit  esc cancel  ctrl+g external editor"
 			: "ctrl+q/ctrl+enter submit  esc cancel  ctrl+g external editor";
-		this.addChild(new Text(theme.fg("dim", hint), 1, 0));
+		this.addChild(new Text(theme.fg("dim", hint), chromePadX, 0));
 
 		this.addChild(new Spacer(1));
 		this.addChild(new DynamicBorder());

--- a/packages/coding-agent/test/hook-editor.test.ts
+++ b/packages/coding-agent/test/hook-editor.test.ts
@@ -359,7 +359,7 @@ describe("HookEditorComponent prompt-style mode", () => {
 		expect(lines[0]).toMatch(/^─+$/);
 		expect(lines.at(-1)).toMatch(/^─+$/);
 		expect(lines[4]?.startsWith("> ")).toBe(true);
-		expect(rendered).toContain(" enter or ctrl+q submit  esc cancel");
+		expect(rendered).toContain("enter or ctrl+q submit  esc cancel");
 		expect(rendered).not.toContain("shift+enter newline");
 		expect(rendered).toContain("ctrl+g external editor");
 	});
@@ -418,6 +418,26 @@ describe("HookEditorComponent prompt-style mode", () => {
 
 		expect(onCancel).toHaveBeenCalledTimes(1);
 		expect(onSubmit).not.toHaveBeenCalled();
+	});
+
+	it("aligns the title and hint with the editor prompt gutter at column zero (#5313)", () => {
+		const title = "◆ Other (type your own)\nEnter your response:";
+		const component = new HookEditorComponent(createTui(), title, "不太清楚，", vi.fn(), vi.fn(), {
+			promptStyle: true,
+		});
+		const lines = renderLines(component);
+
+		const titleRow = lines.find(line => line.includes("Enter your response:"));
+		const gutterRow = lines.find(line => line.startsWith("> "));
+		const hintRow = lines.find(line => line.includes("esc cancel"));
+
+		expect(titleRow).toBeDefined();
+		expect(gutterRow).toBeDefined();
+		expect(hintRow).toBeDefined();
+		// The borderless prompt-style editor renders `> ` starting at column 0, so
+		// the surrounding title/hint chrome must not carry a leading indent.
+		expect(titleRow!.startsWith("Enter your response:")).toBe(true);
+		expect(hintRow!.startsWith(" ")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Repro
When the agent asks a multiple-choice question and the user picks **Other (type your own)**, the custom-input dialog renders misaligned: the title, option list, `Enter your response:` label, and the hint all sit one column to the right of the `> ` input row. Reproduced by rendering `HookEditorComponent` with `promptStyle: true` (the surface the `ask` tool uses for "Other") and comparing the column of the chrome rows against the editor gutter:

```
| ◆ Other (type your own)      |
| Enter your response:         |
|> 不太清楚，▏                 |   <- gutter one column left of everything above
```

## Cause
`HookEditorComponent` (`packages/coding-agent/src/modes/components/hook-editor.ts`) builds its title and hint as `Text(..., padX=1)`, giving them a 1-column left indent. In prompt-style mode the inner `Editor` is borderless (`setBorderVisible(false)`) with a `> ` prompt gutter, which `Editor.render` emits starting at column 0. The bordered hook-style mode has no such mismatch because its editor body is inset by the border chrome, which the `padX=1` title indent matches.

## Fix
- `hook-editor.ts`: compute `chromePadX = this.#promptStyle ? 0 : 1` and use it for both the title and hint `Text` children. Prompt-style chrome now starts at column 0, aligning with the `> ` gutter; hook-style keeps its 1-column indent.
- `hook-editor.test.ts`: added a regression test asserting the prompt-style title and hint start at column 0 alongside the gutter; updated the existing "legacy ask chrome" test whose assertion had encoded the old leading-space indent.

## Verification
`bun test test/hook-editor.test.ts` → 26 pass, 0 fail. Also manually rendered the prompt-style component with CJK input and confirmed the title, `Other` row, `Enter your response:` label, hint, and `> ` gutter all begin at column 0, while the bordered hook-style dialog is unchanged.

Fixes #5313