### PR TITLE
fix(prompting): restore gpt-5.6 autonomous sub-agent fan-out

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ### Fixed
 
+- Fixed GPT-5.6 sessions suppressing autonomous sub-agent fan-out: the Codex-specific delegation policy emitted a hard "do not spawn sub-agents unless the user explicitly asks" gate for default (`task.eager: default`) sessions, contradicting the delegation-gates guidance below it and collapsing batched `task` calls to single-agent spawns. Replaced it with a conservative parallelism gate that permits autonomous fan-out when the work has genuinely independent runnable slices ([#5334](https://github.com/can1357/oh-my-pi/issues/5334))
+
 - Fixed inconsistent history rendering when toggling the display setting for compacted items
 - Fixed configured `retry.fallbackChains` never engaging on non-retryable provider errors (e.g. "Cloud Code Assist API returned an empty response"): a hard error on a model covered by a fallback chain now switches to the next candidate instead of failing the turn, while still never backoff-retrying the failing model itself
 - Fixed transcript rebuilds (compaction, `/compact`, and toggling history display) repainting content below stale scrollback when collapsing history; rebuilds now correctly clear the scrollback buffer when history is collapsed

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -147,7 +147,7 @@ You SHOULD use syntax-aware tools before text hacks:
 {{#if eagerTasks}}
 Proactive multi-agent delegation is active. Any earlier instruction requiring an explicit user request before spawning sub-agents no longer applies. Use sub-agents when parallel work would materially improve speed or quality. This mode remains active until a later multi-agent mode developer message changes it.
 {{else}}
-Do not spawn sub-agents unless the user or applicable AGENTS.md/skill instructions explicitly ask for sub-agents, delegation, or parallel agent work.
+Use sub-agents only when the work has at least two genuinely independent runnable slices and parallel execution would materially improve speed or quality. The user does not need to request delegation explicitly; do not spawn merely to offload planning or a single sequential slice.
 {{/if}}
 {{else}}
 {{#if eagerTasks}}

--- a/packages/coding-agent/src/prompts/system/tan-context-switch.md
+++ b/packages/coding-agent/src/prompts/system/tan-context-switch.md
@@ -1,5 +1,5 @@
 <system-notice cause="fork">
-The conversation above belongs to your parent session. 
+The conversation above belongs to your parent session.
 You are a fork created solely to handle the user's request below.
 
 Your parent agent is still working on the original task — that responsibility is

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -138,6 +138,46 @@ describe("system prompt model identifier", () => {
 	});
 });
 
+describe("GPT-5.6 delegation prompt policy", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-deleg-"));
+		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-deleg-home-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tempHomeDir;
+	});
+
+	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
+
+	async function renderDelegation(eagerTasks: boolean): Promise<string> {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["task", "read", "bash"],
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			model: "openai/gpt-5.6",
+			eagerTasks,
+		});
+		return systemPrompt.join("\n\n");
+	}
+
+	it("classifies GPT-5.6 under the Codex task prompt policy", () => {
+		expect(usesCodexTaskPrompt("openai/gpt-5.6")).toBe(true);
+	});
+
+	it("permits conservative autonomous fan-out for a default GPT-5.6 session", async () => {
+		const text = await renderDelegation(false);
+		expect(text).not.toContain("Do not spawn sub-agents unless the user");
+		expect(text).toContain("two genuinely independent runnable slices");
+		expect(text).toContain("The user does not need to request delegation explicitly");
+	});
+});
+
 describe("AgentSession model-change prompt refresh", () => {
 	let authStorage: AuthStorage;
 	let modelRegistry: ModelRegistry;


### PR DESCRIPTION
## Repro
Rendering the system prompt for a default `openai/gpt-5.6` session (`task.eager: default` → `eagerTasks=false`, `useCodexTaskPrompt=true`) emits the hard sub-agent prohibition. Verified via `buildSystemPrompt({ model: "openai/gpt-5.6", eagerTasks: false, toolNames: ["task", ...] })`, whose rendered `# Delegation` section contained `Do not spawn sub-agents unless the user or applicable AGENTS.md/skill instructions explicitly ask for sub-agents, delegation, or parallel agent work.` This collapsed batched `task` fan-out to single-agent spawns (reporter aggregated a ~92% drop, 2.78 → 0.22 spawns/100 turns, around commit `1b490044f`).

## Cause
The GPT-5.6 branch of the delegation guidance in `packages/coding-agent/src/prompts/system/system-prompt.md` (added in `1b490044f`). For `useCodexTaskPrompt` models with `eagerTasks` false, the template rendered a hard explicit-user-request gate that directly contradicts the "Delegation gates" block immediately below it, which assumes autonomous fan-out is permitted. `usesCodexTaskPrompt` (`packages/coding-agent/src/task/prompt-policy.ts`) matches all `5.6` OpenAI models, and `task.eager` defaults to `default` (`settings-schema.ts`), so every default GPT-5.6 session hit the prohibition.

## Fix
- `packages/coding-agent/src/prompts/system/system-prompt.md`: replaced the `useCodexTaskPrompt`/non-eager hard prohibition with a conservative parallelism gate — fan out only when the work has at least two genuinely independent runnable slices and parallelism materially helps; the user need not request delegation explicitly.
- `packages/coding-agent/test/system-prompt-model.test.ts`: added a `GPT-5.6 delegation prompt policy` suite asserting a default GPT-5.6 rendered prompt no longer contains the explicit-user-request prohibition and does carry the conservative gate, plus that `usesCodexTaskPrompt("openai/gpt-5.6")` is true.
- `packages/coding-agent/CHANGELOG.md`: added a `Fixed` entry under `[Unreleased]`.

## Verification
`bun test test/system-prompt-model.test.ts` → 8 pass, 0 fail (includes the two new delegation-gate assertions). Manual render of `buildSystemPrompt` for `openai/gpt-5.6` confirms the prohibition string is gone and the conservative gate is present. Fixes #5334