### PR TITLE
fix(slash-commands): added /q alias for /quit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed `/q` + Enter running `/queue` instead of `/quit`: the newer `/queue` command is registered before `/quit`, and the editor's sync slash-completion applies the first same-prefix match on Enter, so `/q` shadowed to `/queue`. Added an explicit `q` alias to `/quit` (exact matches outrank prefix matches) so `/q` deterministically quits ([#5335](https://github.com/can1357/oh-my-pi/issues/5335))
 - Fixed `/tan` and `/fork` clones cold-missing the provider prompt cache: the per-turn supersede/useless-result prune rewrote the live context without persisting it, so file-based forks and resume rebuilt a divergent (un-pruned) prefix and re-wrote the entire cache
 - Fixed `/tan` pinning the clone's prompt-cache key to the parent's session id instead of the parent's effective cache key, dropping shard affinity when the parent was itself a fork or tan
 - Fixed inconsistent history rendering when toggling the display setting for compacted items

--- a/packages/coding-agent/src/prompts/system/tan-context-switch.md
+++ b/packages/coding-agent/src/prompts/system/tan-context-switch.md
@@ -1,5 +1,5 @@
 <system-notice cause="fork">
-The conversation above belongs to your parent session. 
+The conversation above belongs to your parent session.
 You are a fork created solely to handle the user's request below.
 
 Your parent agent is still working on the original task — that responsibility is

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2314,6 +2314,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "quit",
+		aliases: ["q"],
 		description: "Quit the application",
 		handleTui: shutdownHandlerTui,
 	},

--- a/packages/coding-agent/test/agent-session-prune-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-prune-persistence.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const message = session.agent.state.messages.find(
 			candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID,
 		);
-		if (!message || message.role !== "toolResult" || !Array.isArray(message.content)) {
+		if (message?.role !== "toolResult" || !Array.isArray(message.content)) {
 			throw new Error("Expected the seeded tool result in live agent state");
 		}
 		const text = message.content.find(block => block.type === "text");
@@ -156,7 +156,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const rebuilt = reloaded
 			.buildSessionContext()
 			.messages.find(candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID);
-		if (!rebuilt || rebuilt.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
+		if (rebuilt?.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
 			throw new Error("Expected the seeded tool result in the from-disk rebuild");
 		}
 		const rebuiltText = rebuilt.content.find(block => block.type === "text");

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -800,6 +800,23 @@ describe("trySyncSlashCompletion", () => {
 		expect(result!.items[0]?.value).toBe("providers");
 	});
 
+	it("prefers an exact alias over an earlier same-prefix command (/q -> quit, not queue)", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "queue", description: "Queue a message for after the agent yields" },
+				{ name: "quit", aliases: ["q"], description: "Quit the application" },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/q");
+		expect(result).not.toBeNull();
+		// The sync-completion path applies items[0] on Enter. Even though `queue`
+		// is registered first and shares the `q` prefix, the exact `q` alias on
+		// `quit` must win (score 1000 > 900) so /q + Enter dispatches the `q`
+		// alias, which resolves to `quit` (#5335).
+		expect(result!.items[0]?.value).toBe("q");
+	});
+
 	it("uses aliases when completing slash command arguments", async () => {
 		const provider = new CombinedAutocompleteProvider(
 			[


### PR DESCRIPTION
## Repro
On 16.4.8, typing `/q` and pressing Enter runs `/queue` instead of `/quit`. The `/queue` command (new this version) is registered before `/quit` in the builtin registry. When Enter is pressed on a slash-command prefix, the editor applies the first sync-completion match (`packages/tui/src/components/editor.ts` → `trySyncSlashCommand` on Enter → `CombinedAutocompleteProvider.trySyncSlashCompletion` → `buildSlashCommandCompletions` in `packages/tui/src/autocomplete.ts`). Both `queue` and `quit` are prefix matches scoring 900, and the stable sort preserves registry order, so `queue` wins.

Reproduced with a unit test mirroring the real registry order:
```ts
const provider = new CombinedAutocompleteProvider(
  [{ value: "queue", label: "queue" }, { value: "quit", label: "quit" }],
  "/tmp",
);
provider.trySyncSlashCompletion("/q").items.map(i => i.value);
// => ["queue", "quit"]  -> Enter applies "queue"
```

## Cause
`scoreCommandTextMatch` in `packages/tui/src/autocomplete.ts` gives every prefix match a flat 900 (deliberately, so same-prefix commands keep registry order). With `/queue` now registered ahead of `/quit`, `/q` resolves to the first-registered prefix match, `queue`. Prior versions had no `/queue`, so `/q` matched only `/quit`.

## Fix
- Added `aliases: ["q"]` to the `quit` command in `packages/coding-agent/src/slash-commands/builtin-registry.ts`. An exact name/alias match scores 1000, outranking both 900 prefix matches, so `/q` + Enter now dispatches the `q` alias, which `BUILTIN_SLASH_COMMAND_LOOKUP` resolves to `quit` — deterministic regardless of registry order.
- Added a regression test in `packages/tui/test/autocomplete.test.ts` pinning `/q` → `q` (quit's alias) as `items[0]` even when `queue` is registered first.
- Changelog entry under `[Unreleased] → Fixed`.

## Verification
`cd packages/tui && bun test test/autocomplete.test.ts` → 56 pass, 0 fail (includes the new regression test; the old repro test failed before the alias, passes after).
`cd packages/coding-agent && bun test test/slash-commands/` → 101 pass, 0 fail.
Pre-publish gate (`bun run fix` + `bun check`) passed on push.

Fixes #5335