### PR TITLE
fix(compaction): strip harmony control tokens from summary payloads

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Improved compaction dead-end notifications with specific recovery instructions
 
+### Fixed
+
+- Fixed GPT-5.6 auto-compaction failing with `Request blocked` when summarizing turns that contain assistant reasoning: Harmony/Gemma transcript serialization no longer embeds chat-template control tokens (`<|channel|>analysis`) in summary payloads ([#5337](https://github.com/can1357/oh-my-pi/issues/5337))
+
 ## [16.4.5] - 2026-07-11
 
 ### Added

--- a/packages/agent/src/compaction/utils.ts
+++ b/packages/agent/src/compaction/utils.ts
@@ -208,6 +208,19 @@ export function truncateToolResultForSummary(text: string): string {
 }
 
 /**
+ * Dialects whose `renderTranscript` embeds chat-template control tokens
+ * (`<|channel|>analysis`, `<|start|>`, …) rather than inline-safe XML/markdown.
+ *
+ * Those tokens are legal on the owned *text transport*, but summarization
+ * re-sends the serialized transcript as plain prompt text to the same model
+ * family, and GPT-5.6 rejects inbound Harmony control tokens with
+ * `Request blocked` (issues #5184, #5337). Summary serialization therefore
+ * falls back to the control-token-free legacy plain-text form for these
+ * dialects — the same carve-out {@link renderDemotedThinking} applies.
+ */
+const SUMMARY_UNSAFE_DIALECTS: Partial<Record<Dialect, true>> = { harmony: true, gemma: true };
+
+/**
  * Serialize LLM messages to text for summarization.
  * This prevents the model from treating it as a conversation to continue.
  * Call convertToLlm() first to handle custom message types.
@@ -223,7 +236,7 @@ export function serializeConversation(messages: Message[], dialect?: Dialect): s
 			uselessCallIds.add(msg.toolCallId);
 		}
 	}
-	if (dialect) {
+	if (dialect && !SUMMARY_UNSAFE_DIALECTS[dialect]) {
 		const processed: Message[] = [];
 		for (const msg of messages) {
 			if (msg.role === "assistant") {

--- a/packages/agent/test/serialize-conversation.test.ts
+++ b/packages/agent/test/serialize-conversation.test.ts
@@ -95,4 +95,43 @@ describe("serializeConversation — useless pairs", () => {
 
 		expect(out).toBe("");
 	});
+
+	// Harmony/Gemma renderTranscript emits chat-template control tokens
+	// (`<|channel|>analysis`, `<|start|>`) that GPT-5.6 rejects with
+	// `Request blocked` when the summary payload is re-sent as prompt text
+	// (issues #5184, #5337). Those dialects must fall back to the plain-text
+	// form while still carrying the reasoning content forward.
+	test("harmony summaries strip control tokens but keep thinking content", () => {
+		const out = serializeConversation(
+			[
+				assistantMessage([
+					{ type: "thinking", thinking: "Planning broad tool discovery." },
+					{ type: "text", text: "Let me search." },
+				]),
+			],
+			"harmony",
+		);
+
+		expect(out).not.toContain("<|channel|>");
+		expect(out).not.toContain("<|start|>");
+		expect(out).toContain("[Think]: Planning broad tool discovery.");
+		expect(out).toContain("[Assistant]: Let me search.");
+	});
+
+	test("gemma summaries strip control tokens but keep thinking content", () => {
+		const out = serializeConversation(
+			[
+				assistantMessage([
+					{ type: "thinking", thinking: "Reasoning step." },
+					{ type: "text", text: "Answer." },
+				]),
+			],
+			"gemma",
+		);
+
+		expect(out).not.toContain("<start_of_turn>");
+		expect(out).not.toContain("<|channel");
+		expect(out).toContain("[Think]: Reasoning step.");
+		expect(out).toContain("[Assistant]: Answer.");
+	});
 });

--- a/packages/coding-agent/src/prompts/system/tan-context-switch.md
+++ b/packages/coding-agent/src/prompts/system/tan-context-switch.md
@@ -1,5 +1,5 @@
 <system-notice cause="fork">
-The conversation above belongs to your parent session. 
+The conversation above belongs to your parent session.
 You are a fork created solely to handle the user's request below.
 
 Your parent agent is still working on the original task — that responsibility is

--- a/packages/coding-agent/test/agent-session-prune-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-prune-persistence.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const message = session.agent.state.messages.find(
 			candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID,
 		);
-		if (!message || message.role !== "toolResult" || !Array.isArray(message.content)) {
+		if (message?.role !== "toolResult" || !Array.isArray(message.content)) {
 			throw new Error("Expected the seeded tool result in live agent state");
 		}
 		const text = message.content.find(block => block.type === "text");
@@ -156,7 +156,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const rebuilt = reloaded
 			.buildSessionContext()
 			.messages.find(candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID);
-		if (!rebuilt || rebuilt.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
+		if (rebuilt?.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
 			throw new Error("Expected the seeded tool result in the from-disk rebuild");
 		}
 		const rebuiltText = rebuilt.content.find(block => block.type === "text");


### PR DESCRIPTION
## Repro

`context-full` auto-compaction fails on GPT-5.6-family models (`gpt-5.6-sol/terra/luna`) during the split-turn turn-prefix summarization pass with `Error Code invalid_prompt: Request blocked`. The failing session contains assistant `thinking` blocks. Serializing that history for summarization through the model's preferred dialect embeds raw Harmony control tokens into the prompt text:

```
serializeConversation([user, assistant(thinking+text)], preferredDialect("gpt-5.6-luna"))
-> preferredDialect: harmony
   contains <|channel|>analysis: true
   <|start|>user<|message|>Find the bug.<|end|><|start|>assistant<|channel|>analysis<|message|>**Planning broad tool discovery** ...<|end|>...
```

GPT-5.6 rejects inbound Harmony control tokens with `Request blocked` (same marker minimized in #5184), so the turn-prefix summary call errors and auto-compaction cannot reduce the session.

## Cause

`generateTurnPrefixSummary` (`packages/agent/src/compaction/compaction.ts:1580-1582`) — and the other summary paths — call `serializeConversation(llmMessages, preferredDialect(model.id))`. For the `openai` family `preferredDialect` returns `"harmony"` (`packages/catalog/src/identity/dialect.ts:36-38`), and `serializeConversation` then renders the transcript via `getDialectDefinition("harmony").renderTranscript(...)` (`packages/agent/src/compaction/utils.ts:249`). Harmony's `renderTranscript` emits assistant reasoning through `renderThinking`, producing `<|start|>assistant<|channel|>analysis<|message|>…<|end|>` (`packages/ai/src/dialect/harmony.ts:295-308`). The repo already documents this hazard for the sibling reasoning-demotion path (`packages/ai/src/dialect/demotion.ts:21-25`), which carves harmony/gemma out because their `renderThinking` emits control tokens "that must not appear inside a structured native message" — the compaction serializer never got the same carve-out.

## Fix

- `packages/agent/src/compaction/utils.ts`: add `SUMMARY_UNSAFE_DIALECTS` (`harmony`, `gemma`) and gate the native-transcript branch of `serializeConversation` behind it, so those dialects fall back to the control-token-free legacy plain-text form (`[Think]:` / `[Assistant]:`). Every summary caller (turn-prefix, full, short, branch) is fixed at once; reasoning content is preserved as plain text.
- `packages/agent/test/serialize-conversation.test.ts`: regression tests asserting harmony/gemma summaries contain no control tokens while still carrying `thinking` and `text` content.
- `packages/agent/CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.

## Verification

`bun test packages/agent/test/serialize-conversation.test.ts` → 6 pass, 0 fail. Manual re-run of the repro after the fix: `preferredDialect("gpt-5.6-luna")` still resolves to `harmony`, but `serializeConversation` output contains no `<|channel|>`/`<|start|>` tokens and retains `[Think]: Planning broad tool discovery.`; gemini/anthropic dialects keep their native inline-safe transcripts unchanged.

Fixes #5337