### PR TITLE
fix(launch): stop wrapping Windows PTY args in unnecessary double quotes

### DIFF
--- a/packages/coding-agent/src/launch/broker.ts
+++ b/packages/coding-agent/src/launch/broker.ts
@@ -85,7 +85,8 @@ function quoteShellArg(value: string): string {
 	return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 function quoteCmdArg(value: string): string {
-	return `"${value.replaceAll('"', '""')}"`;
+	if (/[ \t"]/.test(value)) return `"${value.replaceAll('"', '""')}"`;
+	return value;
 }
 
 function terminalState(state: DaemonSnapshot["state"]): boolean {


### PR DESCRIPTION
## Root cause

`quoteCmdArg` in `packages/coding-agent/src/launch/broker.ts` unconditionally wraps every argument in double quotes before passing the command string to the PTY session on Windows.

In `#launchPty`, the Windows branch maps every argv entry through this helper. For example, `{ application: "flutter", args: ["--version"] }` produces the PTY command `"flutter" "--version"`. The PTY session runs under `cmd.exe` (via `COMSPEC`), which interprets the literal double quotes as part of the executable name, producing the error shown in the issue.

This affects every Windows PTY launch: bare executables, batch files, absolute paths, and even `cmd.exe` itself.

## Fix

Only quote cmd.exe arguments when they actually contain characters that require quoting (spaces, tabs, or double quotes). Bare names and paths without spaces pass through unquoted.

Changed `quoteCmdArg` from unconditional quoting to conditional:

```ts
function quoteCmdArg(value: string): string {
	if (/[ \t"]/.test(value)) return quote(value);
	return value;
}
```

This matches the cmd.exe quoting convention: arguments without spaces need no wrapping. Paths with spaces are still correctly quoted.

## Verification

- `flutter` -- broken before, works after
- `flutter.bat` -- broken before, works after
- `C:/path/to/flutter.bat` -- broken before, works after
- `cmd.exe` -- broken before, works after
- `C:\Program Files\foo.exe` -- correct in both cases (contains space)
- args with double quotes -- correct in both cases (contains quote)

The `#launchPipe` path (`Bun.spawn` with argv array) and `#launchDetached` are unaffected -- only the PTY path uses `quoteCmdArg`.

Fixes #5416