### PR TITLE
fix(cli): alias /clear to /new

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed `/clear` autocomplete selecting `/autoresearch`; `/clear` now starts a new session as an alias for `/new` ([#5349](https://github.com/can1357/oh-my-pi/issues/5349))
 - Fixed `/tan` and `/fork` clones cold-missing the provider prompt cache: the per-turn supersede/useless-result prune rewrote the live context without persisting it, so file-based forks and resume rebuilt a divergent (un-pruned) prefix and re-wrote the entire cache
 - Fixed `/tan` pinning the clone's prompt-cache key to the parent's session id instead of the parent's effective cache key, dropping shard affinity when the parent was itself a fork or tan
 - Fixed inconsistent history rendering when toggling the display setting for compacted items

--- a/packages/coding-agent/src/prompts/system/tan-context-switch.md
+++ b/packages/coding-agent/src/prompts/system/tan-context-switch.md
@@ -1,5 +1,5 @@
 <system-notice cause="fork">
-The conversation above belongs to your parent session. 
+The conversation above belongs to your parent session.
 You are a fork created solely to handle the user's request below.
 
 Your parent agent is still working on the original task — that responsibility is

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1384,6 +1384,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "new",
+		aliases: ["clear"],
 		description: "Start a new session",
 		handleTui: async (_command, runtime) => {
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/test/agent-session-prune-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-prune-persistence.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const message = session.agent.state.messages.find(
 			candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID,
 		);
-		if (!message || message.role !== "toolResult" || !Array.isArray(message.content)) {
+		if (message?.role !== "toolResult" || !Array.isArray(message.content)) {
 			throw new Error("Expected the seeded tool result in live agent state");
 		}
 		const text = message.content.find(block => block.type === "text");
@@ -156,7 +156,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const rebuilt = reloaded
 			.buildSessionContext()
 			.messages.find(candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID);
-		if (!rebuilt || rebuilt.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
+		if (rebuilt?.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
 			throw new Error("Expected the seeded tool result in the from-disk rebuild");
 		}
 		const rebuiltText = rebuilt.content.find(block => block.type === "text");

--- a/packages/coding-agent/test/slash-commands/clear-alias.test.ts
+++ b/packages/coding-agent/test/slash-commands/clear-alias.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { BUILTIN_SLASH_COMMANDS } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+import { CombinedAutocompleteProvider } from "@oh-my-pi/pi-tui/autocomplete";
+
+describe("/clear slash command alias", () => {
+	it("ranks the new-session action above fuzzy description matches", async () => {
+		const provider = new CombinedAutocompleteProvider([...BUILTIN_SLASH_COMMANDS], process.cwd());
+
+		const suggestions = await provider.getSuggestions(["/clear"], 0, 6);
+
+		expect(suggestions?.items[0]).toMatchObject({
+			value: "clear",
+			description: "Start a new session",
+		});
+	});
+});


### PR DESCRIPTION
## Repro
Typing `/clear` in the prompt autocomplete selected `/autoresearch`; an isolated `CombinedAutocompleteProvider` reproduction run with `bun /tmp/repro-5349.ts` returned `[ "autoresearch" ]` before the fix.

## Cause
`buildSlashCommandCompletions` in `packages/tui/src/autocomplete.ts` fuzzy-matches static descriptions as well as command names and aliases. `/new` had no `clear` alias, while the `/autoresearch` description contains `clear`, so `/autoresearch` was the only match.

## Fix
- Add `clear` as an alias of the builtin `/new` command, making it an exact match and routing execution through the existing new-session handler.
- Add a regression test using the real builtin registry and autocomplete provider.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/slash-commands/clear-alias.test.ts` passed (1 test); the post-fix smoke run ranked `clear` first with `Start a new session` and dispatched the new-session handler once. The pre-publish `bun check` gate passed. Fixes #5349