### PR TITLE
fix(tui): classify underscore as word char for Ctrl+W

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Ctrl+W` (delete word backward) stopping at underscores in snake_case identifiers; `_` is now classified as a word character so `allowed_openai_params` deletes as a single word ([#4776](https://github.com/can1357/oh-my-pi/issues/4776)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -394,6 +394,7 @@ export function getWordNavKind(grapheme: string): WordNavKind {
 	const ch = firstCodePointChar(grapheme);
 	if (!ch) return "other";
 	if (WORD_NAV_RE_WHITESPACE.test(ch)) return "whitespace";
+	if (ch === "_") return "word";
 	if (WORD_NAV_RE_PUNCT.test(ch) || WORD_NAV_RE_SYMBOL.test(ch)) return "delimiter";
 	if (
 		WORD_NAV_RE_HAN.test(ch) ||
@@ -403,7 +404,7 @@ export function getWordNavKind(grapheme: string): WordNavKind {
 	) {
 		return "cjk";
 	}
-	if (ch === "_" || WORD_NAV_RE_LETTER.test(ch) || WORD_NAV_RE_NUMBER.test(ch)) return "word";
+	if (WORD_NAV_RE_LETTER.test(ch) || WORD_NAV_RE_NUMBER.test(ch)) return "word";
 	return "other";
 }
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -590,6 +590,11 @@ describe("Editor component", () => {
 			editor.handleInput("\x17");
 			expect(editor.getText()).toBe("foo bar");
 
+			// snake_case identifier deletes as a single word (issue #4776)
+			editor.setText("allowed_openai_params");
+			editor.handleInput("\x17");
+			expect(editor.getText()).toBe("");
+
 			// Delete across multiple lines
 			editor.setText("line one\nline two");
 			editor.handleInput("\x17");


### PR DESCRIPTION
## Repro
With the cursor at the end of `allowed_openai_params`, pressing `Ctrl+W` deletes only `params`, leaving `allowed_openai_`, instead of removing the whole snake_case identifier (fish/bash/zsh/readline all delete the full word).

```
$ bun -e 'import {moveWordLeft, getWordNavKind} from "./packages/tui/src/utils.ts"; const s="allowed_openai_params"; console.log(moveWordLeft(s, s.length), getWordNavKind("_"))'
15 delimiter
```

`moveWordLeft` returns 15 (leaves `allowed_openai_`) and `_` classifies as `"delimiter"`.

## Cause
In `getWordNavKind` (`packages/tui/src/utils.ts`), the `\p{P}` punctuation test (`WORD_NAV_RE_PUNCT`) ran before the `ch === "_"` check. Underscore is Unicode `Pc` (connector punctuation), so it matched `\p{P}` and returned `"delimiter"` — the later `ch === "_"` branch was unreachable dead code. `moveWordLeft`/`moveWordRight` then treat each `_` as a word boundary, so word-delete stops at the last underscore.

## Fix
- `packages/tui/src/utils.ts`: move the `ch === "_"` check ahead of the punctuation/symbol test in `getWordNavKind`, so `_` returns `"word"`. Remove the now-dead `ch === "_"` disjunct from the later letter/number branch.
- `packages/tui/test/editor.test.ts`: extend the existing `Ctrl+W` test with a snake_case case asserting `allowed_openai_params` deletes fully.
- `packages/tui/CHANGELOG.md`: add `[Unreleased]` Fixed entry.

## Verification
`bun test test/editor.test.ts test/input.test.ts` → 158 pass, 0 fail. Verified `moveWordLeft("allowed_openai_params", 21)` now returns `0` and `getWordNavKind("_")` returns `"word"`, while regressions (`foo bar` → 4, `a.b` → 2) hold.

Fixes #4776