### PR TITLE
fix(tui): hand editor tap state to agent hub on double-left open

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Memoized non-message token totals (system prompt, tool schemas, skills) so the per-turn compaction and context-threshold paths recompute them at most once per input change instead of on every call. `getContextBreakdown` and `#estimateStoredContextTokens` previously re-tokenized the system prompt and every tool's wire schema (per-tool `JSON.stringify`) several times per turn over inputs that change at most once per turn.
 
+### Fixed
+
+- Fixed the empty-editor `←←` gesture trapping input when it opens the Agent Hub from persisted/parked subagents: the hub raised by that gesture now accepts the editor's tap state (`armCloseTap`), so the same `←←` that opened it also arms its close and a single `←` dismisses it instead of requiring a fresh `←←` ([#4780](https://github.com/can1357/oh-my-pi/issues/4780)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -310,6 +310,19 @@ export class AgentHubOverlayComponent extends Container {
 	}
 
 	/**
+	 * Seed the table's left-left close detector with the current time so a single
+	 * subsequent `←` (within {@link LEFT_TAP_WINDOW_MS}) dismisses the hub.
+	 *
+	 * The editor's own double-tap detector consumes the `←←` that opens the hub,
+	 * leaving this detector at its fresh `0` — without this handoff the user would
+	 * have to press `←←` a second time to escape. Called by the opener when the hub
+	 * was raised by that gesture.
+	 */
+	armCloseTap(): void {
+		this.#lastLeftTap = Date.now();
+	}
+
+	/**
 	 * Open the fullscreen transcript viewer for an agent id (public for table Enter
 	 * and tests). Mounts {@link AgentTranscriptViewer} as a `fullscreen` overlay so it
 	 * owns the alternate screen; the hub table stays mounted underneath and is

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -518,14 +518,16 @@ export class InputController {
 		// main session, or returns the focused subagent view to the main session.
 		// Focused ←← intentionally matches Esc. From the main session the gesture
 		// stays inert when there are no subagents (requireContent); the explicit
-		// hub key still opens the empty roster.
+		// hub key still opens the empty roster. `armCloseTap` hands this gesture's
+		// tap state to the hub so the same ←← that opened it also arms its close —
+		// otherwise the hub's fresh detector demands a second ←← (issue #4780).
 		this.ctx.editor.onLeftAtStart = () => {
 			if (this.ctx.focusedAgentId) {
 				this.#handleFocusedLeftTap();
 				return;
 			}
 			if (this.#detectLeftDoubleTap()) {
-				this.ctx.showAgentHub({ requireContent: true });
+				this.ctx.showAgentHub({ requireContent: true, armCloseTap: true });
 			}
 		};
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1384,7 +1384,10 @@ export class SelectorController {
 		});
 	}
 
-	showAgentHub(observers: SessionObserverRegistry, options?: { requireContent?: boolean }): void {
+	showAgentHub(
+		observers: SessionObserverRegistry,
+		options?: { requireContent?: boolean; armCloseTap?: boolean },
+	): void {
 		const hubKeys = [
 			...this.ctx.keybindings.getKeys("app.agents.hub"),
 			...this.ctx.keybindings.getKeys("app.session.observe"),
@@ -1439,6 +1442,10 @@ export class SelectorController {
 			this.ctx.editorContainer.clear();
 			this.ctx.editorContainer.addChild(hub);
 			this.ctx.ui.setFocus(hub);
+			// When the hub was raised by the editor's double-← gesture, prime its own
+			// close detector so the *next* single ← dismisses it — the two taps that
+			// opened it were consumed by the editor's detector (issue #4780).
+			if (options?.armCloseTap) hub.armCloseTap();
 			this.ctx.ui.requestRender();
 		};
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -3934,7 +3934,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.#selectorController.showDebugSelector();
 	}
 
-	showAgentHub(options?: { requireContent?: boolean }): void {
+	showAgentHub(options?: { requireContent?: boolean; armCloseTap?: boolean }): void {
 		this.#selectorController.showAgentHub(this.#observerRegistry, options);
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -362,7 +362,7 @@ export interface InteractiveModeContext {
 	showProviderSetup(): Promise<void>;
 	showHookConfirm(title: string, message: string): Promise<boolean>;
 	showDebugSelector(): Promise<void>;
-	showAgentHub(options?: { requireContent?: boolean }): void;
+	showAgentHub(options?: { requireContent?: boolean; armCloseTap?: boolean }): void;
 	resetObserverRegistry(): void;
 
 	// Input handling

--- a/packages/coding-agent/test/agent-hub-activate.test.ts
+++ b/packages/coding-agent/test/agent-hub-activate.test.ts
@@ -192,10 +192,13 @@ describe("Agent hub double-← gating", () => {
 		let shown: AgentHubOverlayComponent | undefined;
 		const shownReady = Promise.withResolvers<AgentHubOverlayComponent>();
 		const editor = {};
+		const focusTargets: unknown[] = [];
 		const ctx = {
 			keybindings: { getKeys: () => [] },
 			ui: {
-				setFocus: () => {},
+				setFocus: (target: unknown) => {
+					focusTargets.push(target);
+				},
 				requestRender: () => {},
 			},
 			editor,
@@ -215,7 +218,13 @@ describe("Agent hub double-← gating", () => {
 			hideThinkingBlock: false,
 		};
 		const controller = new SelectorController(ctx as unknown as InteractiveModeContext);
-		return { controller, shown: () => shown, shownReady: shownReady.promise };
+		return {
+			controller,
+			editor,
+			shown: () => shown,
+			shownReady: shownReady.promise,
+			focusTargets,
+		};
 	}
 
 	function registerWorker(agents: AgentRegistry) {
@@ -284,6 +293,34 @@ describe("Agent hub double-← gating", () => {
 
 		expect(shown()).toBeDefined();
 		shown()!.dispose();
+	});
+
+	it("armCloseTap lets a single ← dismiss the hub the opening ←← raised", () => {
+		const agents = new AgentRegistry();
+		// A parked/persisted agent opens the hub under requireContent (issue #4780).
+		agents.register({
+			id: "Parked",
+			displayName: "Parked",
+			kind: "sub",
+			parentId: "Main",
+			session: { subscribe: () => () => {} } as unknown as AgentSession,
+			sessionFile: null,
+			status: "parked",
+		});
+		const { controller, editor, shown, focusTargets } = setup(agents);
+
+		controller.showAgentHub(new SessionObserverRegistry(), { requireContent: true, armCloseTap: true });
+
+		const hub = shown();
+		expect(hub).toBeDefined();
+		expect(focusTargets.at(-1)).toBe(hub);
+
+		// One ← — the editor's detector consumed the ←← that opened the hub — now
+		// closes it, returning focus to the editor. Without armCloseTap this ← only
+		// primes the hub's fresh detector and the user stays trapped.
+		hub!.handleInput("\x1b[D");
+
+		expect(focusTargets.at(-1)).toBe(editor);
 	});
 });
 


### PR DESCRIPTION
## Repro
On an empty editor with no *live* subagents but persisted/parked ones on disk, pressing `←←` opens the Agent Hub and transfers focus to it, but the hub does not respond to the next single `←` — the user must press a whole new `←←` to escape while text input and hotkeys stay disabled. Reproduced with a unit harness: register a `parked` subagent, open `AgentHubOverlayComponent`, feed one `←`, and observe `onDone` never fires (`test/agent-hub-activate.test.ts`).

## Cause
Two independent double-tap detectors with no state handoff. The editor's `#detectLeftDoubleTap` (`input-controller.ts`) consumes the `←←` and calls `showAgentHub({ requireContent: true })`. The hub's own close detector (`agent-hub.ts` `#handleTableInput`, `#lastLeftTap`) starts fresh at `0`, so the opening gesture is lost and a single subsequent `←` only primes it rather than closing. Staying inert with only persisted agents is not an option — commit `f3e372e7b` (`fix(tui): preserve agent hub persisted gating`) deliberately opens the hub for persisted/parked subagents, asserted by the existing `requireContent opens the hub after persisted subagents load` test.

## Fix
- `agent-hub.ts`: add `AgentHubOverlayComponent.armCloseTap()`, which seeds `#lastLeftTap = Date.now()` so one more `←` within `LEFT_TAP_WINDOW_MS` dismisses the hub.
- `selector-controller.ts`: `showAgentHub` accepts `armCloseTap?: boolean` and calls `hub.armCloseTap()` right after focus transfers to the hub.
- `input-controller.ts`: the `←←` gesture passes `armCloseTap: true`; the explicit hub key still opens without arming.
- `types.ts` / `interactive-mode.ts`: thread the new option through the context interface and delegate.
- `test/agent-hub-activate.test.ts`: regression test — after an armed open, one `←` returns focus to the editor; confirmed to fail when `armCloseTap` is dropped.

## Verification
`bun test test/agent-hub-activate.test.ts` → 10 pass / 0 fail (28 assertions). `bun run check:types` clean; `biome check` clean on all touched files. Verified the new test fails without the `armCloseTap` handoff. Fixes #4780