### PR TITLE
fix(eval): delegate Python URI reads to host resolver

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ### Fixed
 
-- Fixed Python eval `read()` rejecting every non-`local://` URI before the host resolver could handle it; URI reads now delegate through the session `read` tool with `offset`/`limit` preserved as line selectors, including spilled `artifact://` output ([#5353](https://github.com/can1357/oh-my-pi/issues/5353)).
+- Fixed eval `read()` URI handling: Python rejected every non-`local://` URI before host resolution, while JS pagination appended ranges to opaque resource URIs; Python now delegates URI reads through the session `read` tool and both runtimes pass `offset`/`limit` through its explicit selector argument ([#5353](https://github.com/can1357/oh-my-pi/issues/5353)).
 - Fixed `/tan` and `/fork` clones cold-missing the provider prompt cache: the per-turn supersede/useless-result prune rewrote the live context without persisting it, so file-based forks and resume rebuilt a divergent (un-pruned) prefix and re-wrote the entire cache
 - Fixed `/tan` pinning the clone's prompt-cache key to the parent's session id instead of the parent's effective cache key, dropping shard affinity when the parent was itself a fork or tan
 - Fixed inconsistent history rendering when toggling the display setting for compacted items

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed Python eval `read()` rejecting every non-`local://` URI before the host resolver could handle it; URI reads now delegate through the session `read` tool with `offset`/`limit` preserved as line selectors, including spilled `artifact://` output ([#5353](https://github.com/can1357/oh-my-pi/issues/5353)).
 - Fixed `/tan` and `/fork` clones cold-missing the provider prompt cache: the per-turn supersede/useless-result prune rewrote the live context without persisting it, so file-based forks and resume rebuilt a divergent (un-pruned) prefix and re-wrote the entire cache
 - Fixed `/tan` pinning the clone's prompt-cache key to the parent's session id instead of the parent's effective cache key, dropping shard affinity when the parent was itself a fork or tan
 - Fixed inconsistent history rendering when toggling the display setting for compacted items

--- a/packages/coding-agent/src/eval/__tests__/prelude-agent.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/prelude-agent.test.ts
@@ -105,3 +105,23 @@ describe("eval js agent() handle", () => {
 		expect("branchName" in node).toBe(false);
 	});
 });
+
+describe("eval js read() URI delegation", () => {
+	it("passes line selectors separately from opaque MCP resource paths", async () => {
+		const calls: Array<{ name: string; args: unknown }> = [];
+		const sandbox = loadPrelude(async (name, args) => {
+			calls.push({ name, args });
+			return { text: "resource contents" };
+		});
+
+		const result = await vm.runInContext(`read("mcp://server/resource", { offset: 10, limit: 5 })`, sandbox);
+
+		expect(result).toBe("resource contents");
+		expect(calls).toEqual([
+			{
+				name: "read",
+				args: { path: "mcp://server/resource", selector: "10-14" },
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/src/eval/js/shared/prelude.txt
+++ b/packages/coding-agent/src/eval/js/shared/prelude.txt
@@ -39,17 +39,19 @@ if (!globalThis.__omp_js_prelude_loaded__) {
 	const callHelper = (name, ...args) => globalThis.__omp_helpers__[name](...args);
 	const hasScheme = path => typeof path === "string" && /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(path);
 	const shouldDelegateRead = path => hasScheme(path) && !path.toLowerCase().startsWith("local://");
-	const withReadLineSelector = (path, options) => {
+	const readLineSelector = options => {
 		const offset = typeof options.offset === "number" ? options.offset : 1;
 		const limit = typeof options.limit === "number" ? options.limit : undefined;
-		if (offset <= 1 && limit === undefined) return path;
+		if (offset <= 1 && limit === undefined) return undefined;
 		if (limit !== undefined && limit <= 0) return null;
 		const start = Math.max(1, offset);
-		if (limit === undefined) return `${path}:${start}-`;
-		return `${path}:${start}-${start + limit - 1}`;
+		if (limit === undefined) return `${start}-`;
+		return `${start}-${start + limit - 1}`;
 	};
-	const readToolText = async path => {
-		const res = await globalThis.__omp_call_tool__("read", { path });
+	const readToolText = async (path, selector) => {
+		const args = { path };
+		if (selector !== undefined) args.selector = selector;
+		const res = await globalThis.__omp_call_tool__("read", args);
 		return res && typeof res === "object" && "text" in res ? res.text : res;
 	};
 
@@ -57,8 +59,8 @@ if (!globalThis.__omp_js_prelude_loaded__) {
 	const read = async (path, opts, ...rest) => {
 		const options = optionsArg("read", opts, rest, ["offset", "limit"], "{ offset, limit }");
 		if (shouldDelegateRead(path)) {
-			const toolPath = withReadLineSelector(path, options);
-			return toolPath === null ? "" : readToolText(toolPath);
+			const selector = readLineSelector(options);
+			return selector === null ? "" : readToolText(path, selector);
 		}
 		return callHelper("read", path, options);
 	};

--- a/packages/coding-agent/src/eval/py/__tests__/prelude.test.ts
+++ b/packages/coding-agent/src/eval/py/__tests__/prelude.test.ts
@@ -41,7 +41,7 @@ describe("python prelude", () => {
 		expect(signature).toContain("limit");
 	});
 
-	it("delegates artifact URI reads through the host read tool with line selectors", async () => {
+	it("passes delegated URI selectors separately from opaque resource paths", async () => {
 		const requests: unknown[] = [];
 		const server = Bun.serve({
 			hostname: "127.0.0.1",
@@ -50,25 +50,38 @@ describe("python prelude", () => {
 				requests.push(await request.json());
 				return Response.json({
 					ok: true,
-					value: { text: "artifact contents", details: { resolvedPath: "/tmp/21.txt" } },
+					value: { text: "resource contents", details: { resolvedPath: "/tmp/resource.txt" } },
 				});
 			},
 		});
 
 		try {
-			const result = await runPrelude(`print(read("artifact://21", 3, 2))`, {
-				PI_TOOL_BRIDGE_URL: server.url.toString(),
-				PI_TOOL_BRIDGE_TOKEN: "test-token",
-				PI_TOOL_BRIDGE_SESSION: "test-session",
-			});
+			const result = await runPrelude(
+				[`print(read("artifact://21", 3, 2))`, `print(read("mcp://server/resource", 10, 5))`].join("\n"),
+				{
+					PI_TOOL_BRIDGE_URL: server.url.toString(),
+					PI_TOOL_BRIDGE_TOKEN: "test-token",
+					PI_TOOL_BRIDGE_SESSION: "test-session",
+				},
+			);
 
-			expect(result).toEqual({ stdout: "artifact contents\n", stderr: "", exitCode: 0 });
+			expect(result).toEqual({
+				stdout: "resource contents\nresource contents\n",
+				stderr: "",
+				exitCode: 0,
+			});
 			expect(requests).toEqual([
 				{
 					session: "test-session",
 					run: null,
 					name: "read",
-					args: { path: "artifact://21:3-4" },
+					args: { path: "artifact://21", selector: "3-4" },
+				},
+				{
+					session: "test-session",
+					run: null,
+					name: "read",
+					args: { path: "mcp://server/resource", selector: "10-14" },
 				},
 			]);
 		} finally {

--- a/packages/coding-agent/src/eval/py/__tests__/prelude.test.ts
+++ b/packages/coding-agent/src/eval/py/__tests__/prelude.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from "bun:test";
 import { PYTHON_PRELUDE } from "../prelude";
 
+const pythonPath = Bun.env.PYTHON ?? "python3";
+
+async function runPrelude(
+	code: string,
+	env: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const prelude = PYTHON_PRELUDE.replace(
+		"from __future__ import annotations",
+		"from __future__ import annotations\n__omp_display = lambda *args, **kwargs: None",
+	);
+	const script = `${prelude}\n${code}`;
+	const proc = Bun.spawn([pythonPath, "-c", script], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env, ...env },
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { stdout, stderr, exitCode };
+}
+
 describe("python prelude", () => {
 	it("exposes read(path, offset?, limit?) with positional optional args", () => {
 		// The eval docs advertise `read(path, offset?=1, limit?=None)`. A
@@ -15,6 +39,41 @@ describe("python prelude", () => {
 		expect(signature).not.toContain("*,");
 		expect(signature).toContain("offset");
 		expect(signature).toContain("limit");
+	});
+
+	it("delegates artifact URI reads through the host read tool with line selectors", async () => {
+		const requests: unknown[] = [];
+		const server = Bun.serve({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch: async request => {
+				requests.push(await request.json());
+				return Response.json({
+					ok: true,
+					value: { text: "artifact contents", details: { resolvedPath: "/tmp/21.txt" } },
+				});
+			},
+		});
+
+		try {
+			const result = await runPrelude(`print(read("artifact://21", 3, 2))`, {
+				PI_TOOL_BRIDGE_URL: server.url.toString(),
+				PI_TOOL_BRIDGE_TOKEN: "test-token",
+				PI_TOOL_BRIDGE_SESSION: "test-session",
+			});
+
+			expect(result).toEqual({ stdout: "artifact contents\n", stderr: "", exitCode: 0 });
+			expect(requests).toEqual([
+				{
+					session: "test-session",
+					run: null,
+					name: "read",
+					args: { path: "artifact://21:3-4" },
+				},
+			]);
+		} finally {
+			server.stop(true);
+		}
 	});
 
 	it("exposes isolation artifacts on the agent() handle node", () => {

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -57,6 +57,29 @@ if "__omp_prelude_loaded__" not in globals():
 
     _OMP_INTERNAL_URL_RE = re.compile(r"^([a-z][a-z0-9+.-]*)://(.*)$", re.IGNORECASE)
 
+    def _should_delegate_read(path: str | Path) -> bool:
+        return (
+            isinstance(path, str)
+            and _OMP_INTERNAL_URL_RE.match(path) is not None
+            and not path.lower().startswith("local://")
+        )
+
+    def _with_read_line_selector(path: str, offset: int, limit: int | None) -> str | None:
+        if offset <= 1 and limit is None:
+            return path
+        if limit is not None and limit <= 0:
+            return None
+        start = max(1, offset)
+        if limit is None:
+            return f"{path}:{start}-"
+        return f"{path}:{start}-{start + limit - 1}"
+
+    def _read_tool_text(path: str) -> str:
+        result = _bridge_call("read", {"path": path})
+        if isinstance(result, dict) and "text" in result:
+            return result["text"]
+        return result
+
     def _resolve_omp_path(path: str | Path) -> Path:
         """Map a helper path to a real filesystem Path.
 
@@ -94,7 +117,10 @@ if "__omp_prelude_loaded__" not in globals():
         return Path(resolved)
 
     def read(path: str | Path, offset: int = 1, limit: int | None = None) -> str:
-        """Read file contents. offset/limit are 1-indexed line numbers."""
+        """Read file or read-tool URI contents. offset/limit are 1-indexed lines."""
+        if _should_delegate_read(path):
+            tool_path = _with_read_line_selector(path, offset, limit)
+            return "" if tool_path is None else _read_tool_text(tool_path)
         p = _resolve_omp_path(path)
         data = p.read_text(encoding="utf-8")
         lines = data.splitlines(keepends=True)

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -64,18 +64,19 @@ if "__omp_prelude_loaded__" not in globals():
             and not path.lower().startswith("local://")
         )
 
-    def _with_read_line_selector(path: str, offset: int, limit: int | None) -> str | None:
+    def _read_line_selector(offset: int, limit: int | None) -> str | None:
         if offset <= 1 and limit is None:
-            return path
-        if limit is not None and limit <= 0:
             return None
         start = max(1, offset)
         if limit is None:
-            return f"{path}:{start}-"
-        return f"{path}:{start}-{start + limit - 1}"
+            return f"{start}-"
+        return f"{start}-{start + limit - 1}"
 
-    def _read_tool_text(path: str) -> str:
-        result = _bridge_call("read", {"path": path})
+    def _read_tool_text(path: str, selector: str | None) -> str:
+        args = {"path": path}
+        if selector is not None:
+            args["selector"] = selector
+        result = _bridge_call("read", args)
         if isinstance(result, dict) and "text" in result:
             return result["text"]
         return result
@@ -119,8 +120,9 @@ if "__omp_prelude_loaded__" not in globals():
     def read(path: str | Path, offset: int = 1, limit: int | None = None) -> str:
         """Read file or read-tool URI contents. offset/limit are 1-indexed lines."""
         if _should_delegate_read(path):
-            tool_path = _with_read_line_selector(path, offset, limit)
-            return "" if tool_path is None else _read_tool_text(tool_path)
+            if limit is not None and limit <= 0:
+                return ""
+            return _read_tool_text(path, _read_line_selector(offset, limit))
         p = _resolve_omp_path(path)
         data = p.read_text(encoding="utf-8")
         lines = data.splitlines(keepends=True)

--- a/packages/coding-agent/src/prompts/system/tan-context-switch.md
+++ b/packages/coding-agent/src/prompts/system/tan-context-switch.md
@@ -1,5 +1,5 @@
 <system-notice cause="fork">
-The conversation above belongs to your parent session. 
+The conversation above belongs to your parent session.
 You are a fork created solely to handle the user's request below.
 
 Your parent agent is still working on the original task — that responsibility is

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -28,7 +28,7 @@ display(value) → None
 print(value, ...) → None
     Text output.
 read(path, offset?=1, limit?=None) → str
-    File as text; offset/limit 1-indexed lines. Accepts `local://…`.
+    File/resource text; offset/limit = 1-indexed lines. `local://…` works everywhere; Python/JS also accept top-level `read` URI schemes.
 write(path, content) → str
     Write file (creates parents) → resolved path. `local://…` persists across turns/subagents.
 env(key?=None, value?=None) → str | None | dict

--- a/packages/coding-agent/test/agent-session-prune-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-prune-persistence.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const message = session.agent.state.messages.find(
 			candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID,
 		);
-		if (!message || message.role !== "toolResult" || !Array.isArray(message.content)) {
+		if (message?.role !== "toolResult" || !Array.isArray(message.content)) {
 			throw new Error("Expected the seeded tool result in live agent state");
 		}
 		const text = message.content.find(block => block.type === "text");
@@ -156,7 +156,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const rebuilt = reloaded
 			.buildSessionContext()
 			.messages.find(candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID);
-		if (!rebuilt || rebuilt.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
+		if (rebuilt?.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
 			throw new Error("Expected the seeded tool result in the from-disk rebuild");
 		}
 		const rebuiltText = rebuilt.content.find(block => block.type === "text");


### PR DESCRIPTION
## Repro
In a Python eval cell, `read("artifact://0")` failed before host resolution with `ValueError: Protocol paths are not supported by this helper: artifact://0`; the exact reproduction was `eval(language="py", code='read("artifact://0")', reset=true)`.

## Cause
`packages/coding-agent/src/eval/py/prelude.py` sent every `read()` argument through `_resolve_omp_path`, whose injected filesystem-root map currently resolves only `local://`; non-local schemes therefore raised locally instead of reaching the session `read` tool and its `InternalUrlRouter` handlers.

## Fix
- Delegate non-`local://` scheme reads from the Python prelude through the session `read` tool and unwrap its text result.
- Translate `offset` and `limit` into the same line selectors used by the JS eval helper.
- Document the runtime-specific URI support and add a subprocess regression test against the shipped Python prelude.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/src/eval/py/__tests__` passed: 7 tests, 0 failures. The publish gate also completed `bun run fix` and `bun check` successfully. Fixes #5353