### PR TITLE
fix(tui): guard DynamicBorder against uninitialized module-level theme

### DIFF
--- a/packages/coding-agent/src/modes/components/__tests__/dynamic-border.test.ts
+++ b/packages/coding-agent/src/modes/components/__tests__/dynamic-border.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { getThemeByName, setThemeInstance, theme } from "../../theme/theme";
+import { DynamicBorder } from "../dynamic-border";
+
+describe("DynamicBorder", () => {
+	// Regression for #5366: extensions importing legacy pi UI components get a
+	// second `src` module graph whose module-level `theme` is never assigned by
+	// host startup. `render()` must degrade to plain glyphs instead of throwing
+	// "undefined is not an object (evaluating 'theme.boxRound')" and killing the
+	// TUI. Bun isolates modules per test file, so `theme` is undefined here.
+	it("renders plain glyphs when the module-level theme is uninitialized", () => {
+		expect(theme).toBeUndefined();
+
+		const border = new DynamicBorder(str => `<${str}>`);
+		const lines = border.render(4);
+
+		expect(lines).toEqual(["<────>"]);
+	});
+
+	it("degrades the default color to plain text when theme is uninitialized", () => {
+		expect(theme).toBeUndefined();
+
+		// The default color function must not dereference `theme.fg`.
+		const border = new DynamicBorder();
+		expect(border.render(3)).toEqual(["───"]);
+	});
+
+	it("paints with theme.boxRound.horizontal once the theme is initialized", async () => {
+		const loaded = await getThemeByName("dark");
+		if (!loaded) throw new Error("theme unavailable");
+		setThemeInstance(loaded);
+
+		const border = new DynamicBorder(str => `<${str}>`);
+		expect(border.render(3)).toEqual([`<${loaded.boxRound.horizontal.repeat(3)}>`]);
+	});
+});

--- a/packages/coding-agent/src/modes/components/dynamic-border.ts
+++ b/packages/coding-agent/src/modes/components/dynamic-border.ts
@@ -1,19 +1,21 @@
 import type { Component } from "@oh-my-pi/pi-tui";
-import { theme } from "../../modes/theme/theme";
+import { fgOrPlain, theme } from "../../modes/theme/theme";
 
 /**
  * Dynamic border component that adjusts to viewport width.
  *
- * Note: When used from hooks loaded via jiti, the global `theme` may be undefined
- * because jiti creates a separate module cache. Always pass an explicit color
- * function when using DynamicBorder in components exported for hook use.
+ * Note: the module-level `theme` may be `undefined` — when loaded through jiti
+ * (separate module cache) or from a second `src` module graph in npm-package
+ * installs, where the host bundle assigns `theme` but this copy never sees it
+ * (issue #5366). Both the default color and `render()` degrade to plain,
+ * unstyled output instead of crashing the TUI.
  */
 export class DynamicBorder implements Component {
 	#color: (str: string) => string;
 	#cachedWidth = -1;
 	#cachedLines: string[] | undefined;
 
-	constructor(color: (str: string) => string = str => theme.fg("border", str)) {
+	constructor(color: (str: string) => string = str => fgOrPlain("border", str)) {
 		this.#color = color;
 	}
 
@@ -26,7 +28,8 @@ export class DynamicBorder implements Component {
 		if (this.#cachedLines && this.#cachedWidth === width) {
 			return this.#cachedLines;
 		}
-		const lines = [this.#color(theme.boxRound.horizontal.repeat(Math.max(1, width)))];
+		const horizontal = typeof theme === "undefined" ? "─" : theme.boxRound.horizontal;
+		const lines = [this.#color(horizontal.repeat(Math.max(1, width)))];
 		this.#cachedWidth = width;
 		this.#cachedLines = lines;
 		return lines;


### PR DESCRIPTION
## Repro
In an npm-package (`dist/cli.js`) install, any extension that imports a legacy-pi UI component (e.g. `import { DynamicBorder } from "@earendil-works/pi-coding-agent"`) is served the package's `src` module graph via the source shim, separate from the running dist bundle. The bundle assigns the module-level `theme`; the src-graph copy stays `undefined` forever, so first render throws `TypeError: undefined is not an object (evaluating 'theme.boxRound')` and the TUI dies. Reproduced in-process by rendering `DynamicBorder` before any theme init: `new DynamicBorder(str => str).render(10)` throws the identical error at `dynamic-border.ts:29`.

## Cause
`DynamicBorder.render` (`packages/coding-agent/src/modes/components/dynamic-border.ts:29`) dereferenced `theme.boxRound` unconditionally, and the constructor's default color (`str => theme.fg("border", str)`) dereferenced `theme.fg`. Both crash whenever the module-level `theme` binding is `undefined` — the state of a second `src` module graph (npm install) or a jiti-loaded hook. The codebase already handles this elsewhere with a `typeof theme === "undefined"` guard (`fgOrPlain`, `getSettingsListTheme` in `theme.ts`), but `DynamicBorder` predated it.

## Fix
- `render()`: fall back to the default rounded glyph (`"─"`) when `theme` is undefined, else use `theme.boxRound.horizontal`.
- Constructor: route the default color through the existing `fgOrPlain("border", ...)` helper instead of `theme.fg`, so the default path never dereferences an undefined `theme`.
- Added `__tests__/dynamic-border.test.ts` covering the uninitialized-graph path (both explicit and default color) and the initialized path (paints with `theme.boxRound.horizontal`). Bun's per-file module isolation reproduces the undefined-`theme` condition naturally.

## Verification
`bun test packages/coding-agent/src/modes/components/__tests__/dynamic-border.test.ts` → 3 pass, 0 fail. Manual in-process repro now prints `["──────────"]` instead of crashing. Fixes #5366