### PR TITLE
fix(cli): print concise usage error instead of source dump

### DIFF
--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- CLI arg/flag validation errors (e.g. `omp bench` with no model) now print a concise `error:` message plus the command usage line instead of dumping a minified `dist/cli.js` code frame; required variadic positionals render as `MODELS...` in usage rather than the misleading optional `[MODELS]` ([#5369](https://github.com/can1357/oh-my-pi/issues/5369)).
+
 ## [16.4.6] - 2026-07-12
 
 ### Added

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -28,6 +28,20 @@ function startupMarker(text: string): void {
 	}
 }
 
+/**
+ * A user-facing argument/flag validation failure. Thrown by {@link Command.parse}
+ * for missing/invalid positionals and flags. The top-level {@link run} handler
+ * prints its message plus the command usage line to stderr and exits 1, instead
+ * of letting it bubble to the process-level catch — which would dump a minified
+ * `dist/cli.js` code frame over a plain argument mistake (issue #5369).
+ */
+export class CliUsageError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CliUsageError";
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Flag & Arg descriptors
 // ---------------------------------------------------------------------------
@@ -207,7 +221,7 @@ export abstract class Command {
 				} else {
 					const n = Number.parseInt(raw as string, 10);
 					if (Number.isNaN(n)) {
-						throw new Error(`Expected integer for --${name}, got "${raw}"`);
+						throw new CliUsageError(`Expected integer for --${name}, got "${raw}"`);
 					}
 					flags[name] = n;
 				}
@@ -220,14 +234,16 @@ export abstract class Command {
 				// Validate options constraint
 				if (val !== undefined && desc.options && !Array.isArray(val)) {
 					if (!desc.options.includes(val as string)) {
-						throw new Error(`Expected --${name} to be one of: ${[...desc.options].join(", ")}; got "${val}"`);
+						throw new CliUsageError(
+							`Expected --${name} to be one of: ${[...desc.options].join(", ")}; got "${val}"`,
+						);
 					}
 				}
 				flags[name] = val;
 			}
 			// Validate required
 			if (desc.required && flags[name] === undefined) {
-				throw new Error(`Missing required flag: --${name}`);
+				throw new CliUsageError(`Missing required flag: --${name}`);
 			}
 		}
 
@@ -246,13 +262,15 @@ export abstract class Command {
 			}
 			// Validate required
 			if (desc.required && args[argName] === undefined) {
-				throw new Error(`Missing required argument: ${argName}`);
+				throw new CliUsageError(`Missing required argument: ${argName}`);
 			}
 			// Validate options constraint
 			const argVal = args[argName];
 			if (argVal !== undefined && desc.options && typeof argVal === "string") {
 				if (!desc.options.includes(argVal)) {
-					throw new Error(`Expected ${argName} to be one of: ${[...desc.options].join(", ")}; got "${argVal}"`);
+					throw new CliUsageError(
+						`Expected ${argName} to be one of: ${[...desc.options].join(", ")}; got "${argVal}"`,
+					);
 				}
 			}
 		}
@@ -294,15 +312,34 @@ export function renderRootHelp(config: CliConfig): void {
 	process.stdout.write(lines.join("\n"));
 }
 
+/**
+ * Format a command's positional args for a USAGE line. Required args render
+ * bare (`MODELS`), optional args wrapped in brackets (`[MODELS]`), and
+ * `multiple` args get a trailing ellipsis (`MODELS...`) so a required
+ * variadic reads as `MODELS...`, not the misleading optional `[MODELS]`.
+ */
+function formatUsageArgs(Cmd: CommandCtor): string {
+	const entries = Object.entries(Cmd.args ?? {});
+	if (entries.length === 0) return "";
+	const parts = entries.map(([name, desc]) => {
+		const label = `${name.toUpperCase()}${desc.multiple ? "..." : ""}`;
+		return desc.required ? label : `[${label}]`;
+	});
+	return ` ${parts.join(" ")}`;
+}
+
+/** Build the single USAGE line for a command (without the leading label). */
+export function commandUsageLine(bin: string, id: string, Cmd: CommandCtor): string {
+	const hasFlags = Object.keys(Cmd.flags ?? {}).length > 0;
+	return `$ ${bin} ${id}${formatUsageArgs(Cmd)}${hasFlags ? " [FLAGS]" : ""}`;
+}
+
 /** Render help for a single command. */
 export function renderCommandHelp(bin: string, id: string, Cmd: CommandCtor): void {
 	const lines: string[] = [];
 	if (Cmd.description) lines.push(`${Cmd.description}\n`);
 	lines.push("USAGE");
-	const argNames = Object.keys(Cmd.args ?? {});
-	const argStr = argNames.length > 0 ? ` ${argNames.map(n => `[${n.toUpperCase()}]`).join(" ")}` : "";
-	const hasFlags = Object.keys(Cmd.flags ?? {}).length > 0;
-	lines.push(`  $ ${bin} ${id}${argStr}${hasFlags ? " [FLAGS]" : ""}\n`);
+	lines.push(`  ${commandUsageLine(bin, id, Cmd)}\n`);
 	renderCommandBody(lines, Cmd);
 	process.stdout.write(lines.join("\n"));
 }
@@ -435,7 +472,22 @@ export async function run(opts: RunOptions): Promise<void> {
 	const Cmd = await loadEntry(entry);
 	const config: CliConfig = { bin, version, commands: new Map([[entry.name, Cmd]]) };
 	const instance = new Cmd(commandArgv, config);
-	await instance.run();
+	try {
+		await instance.run();
+	} catch (error) {
+		// A usage mistake (missing/invalid arg or flag) is not a crash: print the
+		// message and the command's usage line, then exit 1. Letting it reach the
+		// process-level catch would dump a minified `dist/cli.js` code frame over a
+		// plain argument error (issue #5369).
+		if (error instanceof CliUsageError) {
+			process.stderr.write(`error: ${error.message}\n\n`);
+			process.stderr.write(`USAGE\n  ${commandUsageLine(bin, entry.name, Cmd)}\n`);
+			process.stderr.write(`\nRun \`${bin} ${entry.name} --help\` for details.\n`);
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
 }
 
 /** Load one command module, leaving streaming markers around the import. */

--- a/packages/utils/test/cli-help.test.ts
+++ b/packages/utils/test/cli-help.test.ts
@@ -70,7 +70,7 @@ describe("run() usage errors", () => {
 			await expect(run({ bin: "omp", version: "0.0.0", argv: ["bench"], commands })).resolves.toBeUndefined();
 		} finally {
 			stderrSpy.mockRestore();
-			process.exitCode = prevExitCode;
+			process.exitCode = prevExitCode ?? 0;
 		}
 		const out = errs.join("");
 		expect(out).toContain("error: Missing required argument: models");

--- a/packages/utils/test/cli-help.test.ts
+++ b/packages/utils/test/cli-help.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test";
-import { Command, type CommandEntry, Flags, run } from "@oh-my-pi/pi-utils/cli";
+import { Args, Command, type CommandEntry, Flags, run } from "@oh-my-pi/pi-utils/cli";
 
 class GoodCommand extends Command {
 	static description = "prints good things";
@@ -7,6 +7,19 @@ class GoodCommand extends Command {
 		verbose: Flags.boolean({ description: "be loud" }),
 	};
 	async run(): Promise<void> {}
+}
+
+class BenchLikeCommand extends Command {
+	static description = "benchmark models";
+	static args = {
+		models: Args.string({ description: "model selectors", required: true, multiple: true }),
+	};
+	static flags = {
+		runs: Flags.integer({ description: "requests per model", default: 10 }),
+	};
+	async run(): Promise<void> {
+		await this.parse(BenchLikeCommand);
+	}
 }
 
 describe("run() per-command help", () => {
@@ -38,5 +51,49 @@ describe("run() per-command help", () => {
 		expect(brokenLoads).toBe(0);
 		expect(writes.join("")).toContain("prints good things");
 		expect(writes.join("")).toContain("--verbose");
+	});
+});
+
+describe("run() usage errors", () => {
+	// Contract: a missing required arg prints a concise `error:` + USAGE line to
+	// stderr and exits 1 — it must NOT throw past run() (which would dump a
+	// minified `dist/cli.js` code frame). Regression for #5369.
+	it("prints a concise usage error instead of throwing on a missing required arg", async () => {
+		const commands: CommandEntry[] = [{ name: "bench", load: async () => BenchLikeCommand }];
+		const errs: string[] = [];
+		const stderrSpy = spyOn(process.stderr, "write").mockImplementation(chunk => {
+			errs.push(String(chunk));
+			return true;
+		});
+		const prevExitCode = process.exitCode;
+		try {
+			await expect(run({ bin: "omp", version: "0.0.0", argv: ["bench"], commands })).resolves.toBeUndefined();
+		} finally {
+			stderrSpy.mockRestore();
+			process.exitCode = prevExitCode;
+		}
+		const out = errs.join("");
+		expect(out).toContain("error: Missing required argument: models");
+		expect(out).toContain("$ omp bench MODELS... [FLAGS]");
+		expect(out).not.toContain("dist/cli.js");
+	});
+
+	// Contract: `--help` USAGE renders a required variadic as `MODELS...`, never
+	// the misleading optional `[MODELS]`. Regression for #5369.
+	it("renders a required variadic arg without optional brackets", async () => {
+		const commands: CommandEntry[] = [{ name: "bench", load: async () => BenchLikeCommand }];
+		const writes: string[] = [];
+		const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(chunk => {
+			writes.push(String(chunk));
+			return true;
+		});
+		try {
+			await run({ bin: "omp", version: "0.0.0", argv: ["bench", "--help"], commands });
+		} finally {
+			stdoutSpy.mockRestore();
+		}
+		const out = writes.join("");
+		expect(out).toContain("$ omp bench MODELS... [FLAGS]");
+		expect(out).not.toContain("[MODELS]");
 	});
 });


### PR DESCRIPTION
## Repro

Running `omp bench` with no positional arguments prints a large minified `dist/cli.js` code excerpt before the actual validation message, making a normal argument mistake look like a crash. Reproduced on `main`:

```
$ bun run packages/coding-agent/src/cli.ts bench
244 |                 args[argName] = val;
...
error: Missing required argument: models
      at parse (.../packages/utils/src/cli.ts:249:15)
```

The generated help also rendered the required positional as `[MODELS]`, implying it is optional.

## Cause

The minimal CLI framework in `packages/utils/src/cli.ts` throws a plain `Error` from `Command.parse` for missing/invalid args and flags. Nothing catches it before the process-level handler in `packages/coding-agent/src/cli.ts` (`runCli(...).catch(...)`), which runs `Bun.inspect(err)` and renders a source code frame around the throw site — the minified `dist/cli.js` in a compiled binary. Separately, `renderCommandHelp` formatted every positional as `[NAME]` regardless of `required`/`multiple`.

## Fix

- Add `CliUsageError` (extends `Error`) and throw it from `Command.parse` for every missing/invalid arg and flag.
- Catch `CliUsageError` in `run()`: print `error: <message>` plus the command usage line to stderr and set exit code 1 — no stack, no source dump. Other errors still propagate.
- Extract `commandUsageLine` / `formatUsageArgs`; required args render bare, optional wrapped in `[...]`, and `multiple` args gain a `...` suffix, so a required variadic reads as `MODELS...`.

## Verification

`bun test packages/utils/test/cli-help.test.ts` — 3 pass (added two regression tests: concise usage error with no `dist/cli.js` in output, and `MODELS...` usage rendering). `bun test packages/coding-agent/test/plugin-command.test.ts` still passes (existing `Expected --scope...` message unchanged). `bun run check:types` clean in `packages/utils`. Manual: `omp bench` now prints the concise error + usage; `omp bench --help` shows `$ omp bench MODELS... [FLAGS]`.

Fixes #5369