### PR TITLE
fix(tools): accept empty GitHub search date placeholders

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub code search rejecting empty optional date placeholders before making a request ([#5370](https://github.com/can1357/oh-my-pi/issues/5370)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -3419,7 +3419,9 @@ async function executeSearchCode(
 	signal: AbortSignal | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
 	const query = requireNonEmpty(params.query, "query");
-	if (params.since !== undefined || params.until !== undefined) {
+	const since = normalizeOptionalString(params.since);
+	const until = normalizeOptionalString(params.until);
+	if (since !== undefined || until !== undefined) {
 		throw new ToolError("search_code does not support since/until; GitHub code search has no date qualifier.");
 	}
 	const limit = resolveSearchLimit(params.limit);

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -2,7 +2,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:te
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { ToolCall } from "@oh-my-pi/pi-ai";
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { validateToolArguments } from "@oh-my-pi/pi-ai/utils/validation";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
@@ -584,12 +586,54 @@ describe("github tool", () => {
 		expect(args).toContain("q=language:rust pushed:>=2026-05-01");
 	});
 
-	it("search_code: rejects since/until since GitHub code search has no date qualifier", async () => {
+	it("search_code: treats validated empty date placeholders as omitted", async () => {
 		const spy = vi.spyOn(git.github, "json").mockResolvedValue({ items: [] });
 		const tool = new GithubTool(createSession());
-		await expect(tool.execute("search-code", { op: "search_code", query: "foo", since: "3d" })).rejects.toThrow(
-			/search_code does not support since\/until/,
-		);
+		const request: ToolCall = {
+			type: "toolCall",
+			id: "search-code-empty-dates",
+			name: tool.name,
+			arguments: {
+				op: "search_code",
+				query: "transformer_infer.py",
+				repo: "ModelTC/LightX2V",
+				since: "",
+				until: "",
+				dateField: "created",
+			},
+		};
+
+		const result = await tool.execute(request.id, tool.parameters.assert(validateToolArguments(tool, request)));
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(text).toContain("No code matches found.");
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy.mock.calls[0]?.[1]).toContain("q=transformer_infer.py repo:ModelTC/LightX2V");
+	});
+
+	it("search_code: rejects validated non-empty since and until values", async () => {
+		const spy = vi.spyOn(git.github, "json").mockResolvedValue({ items: [] });
+		const tool = new GithubTool(createSession());
+		const requests: ToolCall[] = [
+			{
+				type: "toolCall",
+				id: "search-code-since",
+				name: tool.name,
+				arguments: { op: "search_code", query: "foo", since: "3d" },
+			},
+			{
+				type: "toolCall",
+				id: "search-code-until",
+				name: tool.name,
+				arguments: { op: "search_code", query: "foo", until: "2026-05-01" },
+			},
+		];
+
+		for (const request of requests) {
+			await expect(
+				tool.execute(request.id, tool.parameters.assert(validateToolArguments(tool, request))),
+			).rejects.toThrow(/search_code does not support since\/until/);
+		}
 		expect(spy).not.toHaveBeenCalled();
 	});
 
@@ -605,14 +649,20 @@ describe("github tool", () => {
 				},
 			],
 		});
-
 		const tool = new GithubTool(createSession());
-		const result = await tool.execute("search-code", {
-			op: "search_code",
-			query: "findThing",
-			repo: "owner/repo",
-			limit: 1,
-		});
+
+		const request: ToolCall = {
+			type: "toolCall",
+			id: "search-code-results",
+			name: tool.name,
+			arguments: {
+				op: "search_code",
+				query: "findThing",
+				repo: "owner/repo",
+				limit: 1,
+			},
+		};
+		const result = await tool.execute(request.id, tool.parameters.assert(validateToolArguments(tool, request)));
 		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
 
 		expect(text).toContain("# GitHub code search");


### PR DESCRIPTION
## Repro
A validated `search_code` call with `query: "transformer_infer.py"`, `repo: "ModelTC/LightX2V"`, `since: ""`, `until: ""`, and `dateField: "created"` reproduced the failure with `bun test packages/coding-agent/test/tools/repro-5370.test.ts`: `validateToolArguments` preserved both empty strings, `GithubTool.execute` threw the date-qualifier error, and `git.github.json` was never called.

## Cause
`packages/ai/src/utils/validation.ts` intentionally preserves optional empty strings when their schema accepts strings, while the flat `githubSchema` in `packages/coding-agent/src/tools/gh.ts` permits `since` and `until` for every operation. `executeSearchCode` checked property presence instead of normalized values, so empty placeholders were treated as real date bounds.

## Fix
- Normalize `since` and `until` with the existing `normalizeOptionalString` helper before enforcing the code-search restriction.
- Exercise empty placeholders, non-empty `since` and `until`, and normal code-search success through `validateToolArguments`.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/gh.test.ts` passed: 40 tests, 0 failures, 187 expectations. The pre-publish `bun run fix` and `bun check` gate also passed. Fixes #5370