### PR TITLE
fix(plugins): preserve native CommonJS helper loading

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plugin installation failing when an ES module extension synchronously requires CommonJS helpers ([#5373](https://github.com/can1357/oh-my-pi/issues/5373)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1135,10 +1135,9 @@ async function realpathOrSelfUncached(p: string): Promise<string> {
  * Extension-local bare dependency entries are also included so their relative
  * children receive the reload mtime tag; bare imports inside those dependencies
  * remain native Bun resolutions to avoid taking over full third-party graphs.
- * CommonJS dependency entries stay native too, with one exception: napi-rs
- * style loaders whose bare requires resolve to `.node` addons are hooked so
- * their requires can be pinned to absolute paths (unresolvable by bare
- * specifier inside `bun build --compile` binaries).
+ * CommonJS modules reached through `require()` stay on Bun's native loader.
+ * The only exception is a module whose bare requires resolve to native addons:
+ * those require a synchronous hook that pins the addon to an absolute path.
  */
 async function collectExtensionModules(entryRealPath: string): Promise<Map<string, string>> {
 	const modules = new Map<string, string>();
@@ -1159,32 +1158,40 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 		let source: string;
 		try {
 			source = await Bun.file(file).text();
-			if (nativeAddonLoaderModulePaths.has(file)) {
-				// CJS requires cannot await an async onLoad hook. Resolve and
-				// rewrite native-addon paths before installing its sync hook.
-				source = await rewriteExtensionNativeAddonRequires(source, file);
-			}
 		} catch {
 			continue;
 		}
 		modules.set(file, source);
 		const dir = path.dirname(file);
 		const specifiers = new Set<string>();
+		const requiredSpecifiers = new Set<string>();
 		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
 			if (match[2]) specifiers.add(match[2]);
 		}
 		for (const match of source.matchAll(NATIVE_ADDON_REQUIRE_SPECIFIER_REGEX)) {
-			if (match[2]) specifiers.add(match[2]);
+			if (match[2]) {
+				specifiers.add(match[2]);
+				requiredSpecifiers.add(match[2]);
+			}
 		}
 		for (const specifier of specifiers) {
 			try {
 				let resolved: string | null = null;
 				let nextFollowsBareDependencies = followBareDependencies;
+				const isRequired = requiredSpecifiers.has(specifier);
 				if (specifier.startsWith(".")) {
 					const candidate = Bun.resolveSync(specifier, dir);
-					resolved = hasSourceModuleExtension(candidate) ? await realpathOrSelf(candidate) : null;
+					if (
+						hasSourceModuleExtension(candidate) &&
+						(!isRequired || (await moduleRequiresNativeAddon(candidate)))
+					) {
+						resolved = await realpathOrSelf(candidate);
+					}
 				} else if (specifier.startsWith("#")) {
-					resolved = await resolvePackageImportSpecifier(specifier, file);
+					const candidate = await resolvePackageImportSpecifier(specifier, file);
+					if (candidate && (!isRequired || (await moduleRequiresNativeAddon(candidate)))) {
+						resolved = candidate;
+					}
 				} else if (
 					followBareDependencies &&
 					isBareExtensionDependencySpecifier(specifier) &&
@@ -1206,13 +1213,16 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 						isHookableEntry && isCommonJsEntry && dependencyEntry
 							? await moduleRequiresNativeAddon(dependencyEntry)
 							: false;
-					if (isHookableEntry && dependencyEntry && (!isCommonJsEntry || hookCommonJsEntry)) {
+					if (isHookableEntry && dependencyEntry && ((!isRequired && !isCommonJsEntry) || hookCommonJsEntry)) {
 						resolved = await realpathOrSelf(dependencyEntry);
-						if (hookCommonJsEntry) {
-							nativeAddonLoaderModulePaths.add(resolved);
-						}
+					}
+					if (resolved && hookCommonJsEntry) {
+						nativeAddonLoaderModulePaths.add(resolved);
 					}
 					nextFollowsBareDependencies = false;
+				}
+				if (resolved && isRequired) {
+					nativeAddonLoaderModulePaths.add(resolved);
 				}
 				if (resolved && !modules.has(resolved)) {
 					const queuedFollowsBareDependencies = queuedFollowBareDependencies.get(resolved) ?? false;
@@ -1223,6 +1233,12 @@ async function collectExtensionModules(entryRealPath: string): Promise<Map<strin
 			} catch {
 				// Unresolvable import (e.g. a type-only path); skip it.
 			}
+		}
+	}
+	for (const modulePath of nativeAddonLoaderModulePaths) {
+		const source = modules.get(modulePath);
+		if (source !== undefined) {
+			modules.set(modulePath, await rewriteExtensionNativeAddonRequires(source, modulePath));
 		}
 	}
 	return modules;

--- a/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts
@@ -60,6 +60,24 @@ describe("legacy-pi in-place module loading (issue #1674)", () => {
 		expect(mod.html).toBe("<html>PLAN-UI</html>");
 	});
 
+	it("loads CommonJS helpers required by an ES module extension", async () => {
+		const dir = await writePackage({
+			"package.json": JSON.stringify({ name: "cjs-helper-ext", version: "1.0.0" }),
+			"config.js": 'module.exports = { value: "config-ok" };\n',
+			"index.js": [
+				'import { createRequire } from "node:module";',
+				"const require = createRequire(import.meta.url);",
+				'const { value } = require("./config.js");',
+				"export { value };",
+				"export default function (pi) { void pi; }",
+			].join("\n"),
+		});
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.js"))) as { value: string };
+
+		expect(mod.value).toBe("config-ok");
+	});
+
 	it("reloads an edited entry module without polluting fileURLToPath-derived paths", async () => {
 		const entrySource = (version: string): string =>
 			[


### PR DESCRIPTION
## Repro
With an isolated config home, `HOME=/tmp/omp-5373-repro PI_CONFIG_DIR=.omp bun packages/coding-agent/src/cli.ts install git:github.com/DietrichGebert/ponytail` exited 1 because extension validation rejected Ponytail’s synchronous `require("../hooks/ponytail-config.js")` as an async module.

## Cause
`collectExtensionModules()` in `packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` added every relative `require()` target to the extension graph. `installExtensionGraphHook()` then assigned the CommonJS helper an async `Bun.plugin().onLoad` callback, which Bun cannot await during synchronous `require()` resolution.

## Fix
- Keep ordinary CommonJS modules reached through `require()` on Bun’s native loader.
- Preserve synchronous graph hooks only for CommonJS loaders that need native-addon path rewriting.
- Add regression coverage for an ES module extension loading a CommonJS helper, plus an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/test/extensibility/legacy-pi-inplace-load.test.ts -t "loads CommonJS helpers required by an ES module extension"` passed (1 test); `bun test packages/coding-agent/test/plugin-install-validation.test.ts` passed (8 tests); the original install command now reports `Installed @dietrichgebert/ponytail@4.8.4`. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #5373