### PR TITLE
fix(review): fall back to per-file API when PR diff exceeds 20k lines

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fixed `/review` aborting entirely when GitHub rejects a pull request's aggregate diff with HTTP 406 for exceeding the 20,000-line limit: `gh pr diff` now falls back to the paginated per-file endpoint (`/repos/{owner}/{repo}/pulls/{n}/files`) and reassembles a synthetic unified diff, keeping files with omitted (binary/too-large) patches visible with an explicit marker ([#5350](https://github.com/can1357/oh-my-pi/issues/5350))
 - Fixed `/tan` and `/fork` clones cold-missing the provider prompt cache: the per-turn supersede/useless-result prune rewrote the live context without persisting it, so file-based forks and resume rebuilt a divergent (un-pruned) prefix and re-wrote the entire cache
 - Fixed `/tan` pinning the clone's prompt-cache key to the parent's session id instead of the parent's effective cache key, dropping shard affinity when the parent was itself a fork or tan
 - Fixed inconsistent history rendering when toggling the display setting for compacted items

--- a/packages/coding-agent/src/prompts/system/tan-context-switch.md
+++ b/packages/coding-agent/src/prompts/system/tan-context-switch.md
@@ -1,5 +1,5 @@
 <system-notice cause="fork">
-The conversation above belongs to your parent session. 
+The conversation above belongs to your parent session.
 You are a fork created solely to handle the user's request below.
 
 Your parent agent is still working on the original task — that responsibility is

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -10,7 +10,7 @@ import type {
 	ToolApprovalDecision,
 } from "@oh-my-pi/pi-agent-core";
 
-import { getWorktreeDir, hashPath, isEnoent, prompt, untilAborted } from "@oh-my-pi/pi-utils";
+import { getWorktreeDir, hashPath, isEnoent, logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import type { Settings } from "../config/settings";
 import githubDescription from "../prompts/tools/github.md" with { type: "text" };
@@ -239,6 +239,7 @@ const RUN_WATCH_TAIL_DEFAULT = 15;
 const RUN_WATCH_TAIL_MAX = 200;
 const REVIEW_COMMENTS_PAGE_SIZE = 100;
 const RUN_JOBS_PAGE_SIZE = 100;
+const PR_DIFF_FILES_PAGE_SIZE = 100;
 const PR_URL_PATTERN = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)(?:\/.*)?$/;
 const ISSUE_URL_PATTERN = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)(?:\/.*)?$/;
 const RUN_URL_PATTERN = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/actions\/runs\/(\d+)(?:\/.*)?$/;
@@ -2931,6 +2932,111 @@ function parsePrDiffSection(section: string, startOffset: number, endOffset: num
 	return file;
 }
 
+/**
+ * A single entry from `GET /repos/{owner}/{repo}/pulls/{n}/files`. `patch` is
+ * absent for binary files and for individual file diffs GitHub deems too large
+ * to render.
+ */
+interface GhPrFileApi {
+	filename?: string;
+	previous_filename?: string;
+	status?: string;
+	additions?: number;
+	deletions?: number;
+	patch?: string;
+}
+
+/**
+ * GitHub rejects the aggregate PR diff endpoint with HTTP 406 once the diff
+ * exceeds 20,000 lines. Detect that specific failure so the caller can fall
+ * back to the per-file endpoint instead of aborting the whole review.
+ */
+function isPrDiffTooLargeError(err: unknown): boolean {
+	const message = err instanceof Error ? err.message : String(err);
+	return (
+		/\bHTTP 406\b/.test(message) ||
+		/exceeded the maximum number of lines/i.test(message) ||
+		/\btoo_large\b/.test(message)
+	);
+}
+
+/**
+ * Reconstruct a `diff --git` section from a single files-API entry. The API's
+ * `patch` field carries only the hunk body, so the `diff --git`/`---`/`+++`
+ * headers are synthesized to match `gh pr diff` output — this keeps
+ * {@link parsePrUnifiedDiff} and the review parser producing identical section
+ * boundaries and byte offsets. Files whose `patch` is omitted (binary or
+ * too-large) stay visible with an explicit marker rather than being dropped.
+ */
+function buildSyntheticDiffSection(file: GhPrFileApi): string | undefined {
+	const newPath = file.filename;
+	if (!newPath) return undefined;
+	const status = file.status ?? "modified";
+	const oldPath = file.previous_filename ?? newPath;
+	const lines: string[] = [`diff --git a/${oldPath} b/${newPath}`];
+	if (status === "added") {
+		lines.push("new file mode 100644");
+	} else if (status === "removed") {
+		lines.push("deleted file mode 100644");
+	} else if (status === "renamed" || file.previous_filename) {
+		lines.push(`rename from ${oldPath}`, `rename to ${newPath}`);
+	}
+	if (typeof file.patch === "string" && file.patch.length > 0) {
+		lines.push(status === "added" ? "--- /dev/null" : `--- a/${oldPath}`);
+		lines.push(status === "removed" ? "+++ /dev/null" : `+++ b/${newPath}`);
+		lines.push(file.patch);
+	} else {
+		lines.push(
+			`* patch unavailable (binary or too large); additions ${file.additions ?? 0}, deletions ${file.deletions ?? 0}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+/**
+ * Fallback PR diff retrieval via the paginated per-file endpoint, used when the
+ * aggregate `gh pr diff` is rejected for exceeding GitHub's 20,000-line limit.
+ * The per-file patches are not subject to that aggregate cap, so even very
+ * large PRs can be reassembled into a synthetic unified diff.
+ */
+async function fetchPrDiffViaFilesApi(
+	cwd: string,
+	repo: string,
+	number: number,
+	signal: AbortSignal | undefined,
+): Promise<string> {
+	const sections: string[] = [];
+	let page = 1;
+	while (true) {
+		const response = await git.github.json<GhPrFileApi[]>(
+			cwd,
+			[
+				"api",
+				"--method",
+				"GET",
+				`/repos/${repo}/pulls/${number}/files`,
+				"-F",
+				`per_page=${PR_DIFF_FILES_PAGE_SIZE}`,
+				"-F",
+				`page=${page}`,
+			],
+			signal,
+			{ repoProvided: true },
+		);
+		for (const file of response) {
+			const section = buildSyntheticDiffSection(file);
+			if (section) sections.push(section);
+		}
+		if (response.length < PR_DIFF_FILES_PAGE_SIZE) {
+			break;
+		}
+		page += 1;
+	}
+	// Trailing newline mirrors `gh pr diff` so downstream parsers splitting on
+	// `^diff --git ` see identical boundaries.
+	return sections.length > 0 ? `${sections.join("\n")}\n` : "";
+}
+
 async function fetchPrDiffFresh(
 	cwd: string,
 	repo: string,
@@ -2939,7 +3045,18 @@ async function fetchPrDiffFresh(
 ): Promise<{ rendered: string; sourceUrl: string | undefined; payload: PrDiffPayload }> {
 	const args = ["pr", "diff", String(number), "--color", "never"];
 	appendRepoFlag(args, repo, String(number));
-	const text = await git.github.text(cwd, args, signal, { repoProvided: true, trimOutput: false });
+	let text: string;
+	try {
+		text = await git.github.text(cwd, args, signal, { repoProvided: true, trimOutput: false });
+	} catch (err) {
+		if (!isPrDiffTooLargeError(err)) throw err;
+		logger.debug("gh pr diff exceeded GitHub's aggregate line limit; falling back to per-file API", {
+			repo,
+			number,
+			err: String(err),
+		});
+		text = await fetchPrDiffViaFilesApi(cwd, repo, number, signal);
+	}
 	const payload = parsePrUnifiedDiff(text);
 	// `rendered` already carries the verbatim diff; blank the payload copy so
 	// the cache row stores a potentially huge diff once instead of twice.

--- a/packages/coding-agent/test/agent-session-prune-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-prune-persistence.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const message = session.agent.state.messages.find(
 			candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID,
 		);
-		if (!message || message.role !== "toolResult" || !Array.isArray(message.content)) {
+		if (message?.role !== "toolResult" || !Array.isArray(message.content)) {
 			throw new Error("Expected the seeded tool result in live agent state");
 		}
 		const text = message.content.find(block => block.type === "text");
@@ -156,7 +156,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const rebuilt = reloaded
 			.buildSessionContext()
 			.messages.find(candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID);
-		if (!rebuilt || rebuilt.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
+		if (rebuilt?.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
 			throw new Error("Expected the seeded tool result in the from-disk rebuild");
 		}
 		const rebuiltText = rebuilt.content.find(block => block.type === "text");

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -8,6 +8,7 @@ import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	buildSearchDateQualifier,
 	GithubTool,
+	getOrFetchPrDiff,
 	parsePrUnifiedDiff,
 	parseSearchDateBound,
 	resolveDefaultRepoMemoized,
@@ -270,6 +271,86 @@ describe("parsePrUnifiedDiff", () => {
 			deletions: 1,
 			changeType: "modified",
 		});
+	});
+});
+
+describe("getOrFetchPrDiff diff-too-large fallback", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function http406(): Error {
+		return new Error(
+			"could not find pull request diff: HTTP 406: Sorry, the diff exceeded the maximum number of lines (20000)",
+		);
+	}
+
+	it("reassembles a unified diff from the per-file API when gh pr diff returns HTTP 406", async () => {
+		vi.spyOn(git.github, "text").mockRejectedValue(http406());
+		const jsonSpy = vi
+			.spyOn(git.github, "json")
+			.mockResolvedValueOnce([
+				{
+					filename: "src/big.ts",
+					status: "modified",
+					additions: 2,
+					deletions: 1,
+					patch: "@@ -1,2 +1,3 @@\n-old\n+new one\n+new two",
+				},
+				{
+					filename: "src/added.ts",
+					status: "added",
+					additions: 1,
+					deletions: 0,
+					patch: "@@ -0,0 +1 @@\n+brand new",
+				},
+			] as unknown as never)
+			.mockResolvedValueOnce([] as unknown as never);
+
+		const result = await getOrFetchPrDiff({
+			cwd: "/tmp/test",
+			repo: "owner/repo",
+			number: 79,
+			cacheAuthKey: null,
+		});
+
+		expect(result.payload.files.map(f => f.path)).toEqual(["src/big.ts", "src/added.ts"]);
+		expect(result.payload.files[0]).toMatchObject({ additions: 2, deletions: 1, changeType: "modified" });
+		expect(result.payload.files[1]).toMatchObject({ additions: 1, deletions: 0, changeType: "added" });
+		// The reassembled diff parses through parsePrUnifiedDiff identically.
+		expect(result.payload.unified).toContain("diff --git a/src/big.ts b/src/big.ts");
+		expect(result.payload.unified).toContain("new file mode");
+		// The files endpoint should have been hit; the first arg after `api` is GET.
+		expect(jsonSpy.mock.calls[0]?.[1]).toContain("/repos/owner/repo/pulls/79/files");
+	});
+
+	it("keeps files with omitted patches visible instead of dropping them", async () => {
+		vi.spyOn(git.github, "text").mockRejectedValue(http406());
+		vi.spyOn(git.github, "json")
+			.mockResolvedValueOnce([
+				{ filename: "assets/logo.png", status: "modified", additions: 0, deletions: 0 },
+			] as unknown as never)
+			.mockResolvedValueOnce([] as unknown as never);
+
+		const result = await getOrFetchPrDiff({
+			cwd: "/tmp/test",
+			repo: "owner/repo",
+			number: 80,
+			cacheAuthKey: null,
+		});
+
+		expect(result.payload.files.map(f => f.path)).toEqual(["assets/logo.png"]);
+		expect(result.payload.unified).toContain("patch unavailable");
+	});
+
+	it("propagates non-406 errors without hitting the files endpoint", async () => {
+		vi.spyOn(git.github, "text").mockRejectedValue(new Error("authentication required"));
+		const jsonSpy = vi.spyOn(git.github, "json");
+
+		await expect(
+			getOrFetchPrDiff({ cwd: "/tmp/test", repo: "owner/repo", number: 81, cacheAuthKey: null }),
+		).rejects.toThrow("authentication required");
+		expect(jsonSpy).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Repro
Running `/review` against a PR whose aggregate diff exceeds GitHub's 20,000-line limit fails before the review starts. `gh pr diff` hits GitHub's aggregate diff endpoint, which returns `HTTP 406: Sorry, the diff exceeded the maximum number of lines (20000)`. Reproduced with a fake `gh` that emits the 406 on `pr diff`: `getOrFetchPrDiff({ repo, number })` threw `could not find pull request diff: HTTP 406: …` and the whole review workflow aborted.

## Cause
`fetchPrDiffFresh` (`packages/coding-agent/src/tools/gh.ts`) calls `git.github.text(["pr","diff",…])`, which throws on the non-zero exit. The error propagates through `getOrFetchPrDiff` → `buildPrReviewPrompt` (`packages/coding-agent/src/extensibility/custom-commands/bundled/review/index.ts:404`), which had no fallback path — the oversized-diff failure discarded the entire review.

## Fix
- Add `isPrDiffTooLargeError` to detect the specific HTTP 406 / "exceeded the maximum number of lines" / `too_large` failure (other errors still propagate unchanged).
- Add `fetchPrDiffViaFilesApi`: paginated (`per_page=100`) fetch of `GET /repos/{owner}/{repo}/pulls/{n}/files`, which is not subject to the aggregate cap.
- Add `buildSyntheticDiffSection`: reassemble a `diff --git` section per file from the API's `patch` body plus synthesized `---`/`+++` headers, so `parsePrUnifiedDiff` and the review parser produce identical section boundaries/byte offsets. Files with an omitted patch (binary or too-large) stay visible with an explicit `* patch unavailable …` marker instead of being dropped.
- `fetchPrDiffFresh` now wraps the `gh pr diff` call in try/catch and routes 406s to the fallback. All `pr-diff` consumers (`/review` and the `pr://<n>/diff` URL family) benefit.

## Verification
`bun test test/tools/gh.test.ts test/extensibility/custom-commands/review.test.ts` — 65 pass, 0 fail. Added three `getOrFetchPrDiff` fallback tests: reassembly from the per-file API on 406, keeping patch-omitted files visible, and non-406 errors propagating without touching the files endpoint. `bun check` clean.

Fixes #5350