### PR TITLE
fix(tui): keep tmux keyboard input in legacy mode

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tmux sessions becoming unresponsive after terminal capability replies by keeping keyboard input in legacy mode when the Kitty protocol is unavailable ([#5378](https://github.com/can1357/oh-my-pi/issues/5378)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Changed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -36,6 +36,7 @@ export function resolveHangulCompatibilityJamoWidthFromTerminalIdentity(
 }
 
 function shouldEnableModifyOtherKeysFallback(env: NodeJS.ProcessEnv = Bun.env): boolean {
+	if (isInsideTmux(env)) return false;
 	if (!env.SSH_CONNECTION && !env.SSH_TTY && !env.SSH_CLIENT) return true;
 	return TERMINAL.id !== "base" && TERMINAL.id !== "trueColor";
 }

--- a/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
+++ b/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
@@ -22,9 +22,10 @@ class ModalProbe implements Component {
 const originalSshConnection = Bun.env.SSH_CONNECTION;
 const originalSshTty = Bun.env.SSH_TTY;
 const originalSshClient = Bun.env.SSH_CLIENT;
+const originalTmux = Bun.env.TMUX;
 const originalTerminalId = TERMINAL.id;
 
-function restoreEnv(name: "SSH_CONNECTION" | "SSH_TTY" | "SSH_CLIENT", value: string | undefined): void {
+function restoreEnv(name: "SSH_CONNECTION" | "SSH_TTY" | "SSH_CLIENT" | "TMUX", value: string | undefined): void {
 	if (value === undefined) {
 		delete Bun.env[name];
 		return;
@@ -41,6 +42,7 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 		restoreEnv("SSH_CONNECTION", originalSshConnection);
 		restoreEnv("SSH_TTY", originalSshTty);
 		restoreEnv("SSH_CLIENT", originalSshClient);
+		restoreEnv("TMUX", originalTmux);
 		Object.defineProperty(TERMINAL, "id", { value: originalTerminalId, configurable: true });
 	});
 
@@ -98,6 +100,23 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 		delete Bun.env.SSH_TTY;
 		delete Bun.env.SSH_CLIENT;
 		Object.defineProperty(TERMINAL, "id", { value: "base", configurable: true });
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		harness.writes.length = 0;
+
+		await harness.feed("\x1b[?1;2c");
+
+		const out = harness.writes.join("");
+		expect(harness.terminal.kittyProtocolActive).toBe(false);
+		expect(out).not.toContain("\x1b[>4;2m");
+		expect(harness.terminal.keyboardEnhancementEnterSequence).toBeNull();
+	});
+
+	it("keeps legacy keyboard input under tmux when kitty is unavailable", async () => {
+		Bun.env.TMUX = "/tmp/tmux-501/default,1234,0";
+		delete Bun.env.SSH_CONNECTION;
+		delete Bun.env.SSH_TTY;
+		delete Bun.env.SSH_CLIENT;
 		harness = createProcessTerminalRenderHarness(100, 30);
 		await harness.settle();
 		harness.writes.length = 0;


### PR DESCRIPTION
## Repro
With `TMUX` set, run `cd packages/tui && bun test test/kitty-keyboard-da1-ordering.test.ts`; before the fix, feeding tmux’s DA1 response (`CSI ? 1 ; 2 c`) made `ProcessTerminal` emit `CSI > 4 ; 2 m`, and the regression test failed because tmux should remain on legacy keyboard input when Kitty negotiation is unavailable.

## Cause
`shouldEnableModifyOtherKeysFallback()` in `packages/tui/src/terminal.ts` treated every local session as safe for xterm `modifyOtherKeys`. A DA1 response therefore activated `CSI > 4 ; 2 m` inside tmux even when tmux exposed only legacy input, wedging key delivery.

## Fix
- Skip the `modifyOtherKeys` fallback when `isInsideTmux(env)` is true; Kitty-capable tmux sessions still use the negotiated Kitty path.
- Add a DA1-driven regression test proving tmux remains in legacy keyboard mode.
- Document the fix in `packages/tui/CHANGELOG.md`.

## Verification
`cd packages/tui && bun test test/kitty-keyboard-da1-ordering.test.ts test/terminal-appearance.test.ts test/process-terminal-headless.test.ts` passed: 46 tests, 149 assertions. `cd packages/tui && bun run check` passed. A source-level PTY smoke probe with `TMUX` set delivered printable input and emitted no `CSI > 4 ; 2 m`. The pre-publish `bun run fix` and `bun check` gate passed. Fixes #5378