### PR TITLE
fix(session): land tree navigation on /skill: injection node

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/tree` navigation onto a `/skill:` injection node landing on the entry before it (dropping the skill off the active branch and prefilling the editor with the expanded skill body); selecting a skill injection now lands the leaf on the injection node ([#5374](https://github.com/can1357/oh-my-pi/issues/5374)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -15993,7 +15993,7 @@ export class AgentSession {
 			// User message: leaf = parent (null if root), text goes to editor
 			newLeafId = targetEntry.parentId;
 			editorText = this.#extractUserMessageText(targetEntry.message.content);
-		} else if (targetEntry.type === "custom_message") {
+		} else if (targetEntry.type === "custom_message" && targetEntry.customType !== SKILL_PROMPT_MESSAGE_TYPE) {
 			// Custom message: leaf = parent (null if root), text goes to editor
 			newLeafId = targetEntry.parentId;
 			editorText =
@@ -16004,7 +16004,10 @@ export class AgentSession {
 							.map(c => c.text)
 							.join("");
 		} else {
-			// Non-user message: leaf = selected node
+			// Non-user message (or a user-invoked skill-prompt injection): land the
+			// leaf on the selected node so it stays on the active branch. Skill
+			// prompts are custom_message entries but must not be re-editable — their
+			// content is a large expanded body, not a user turn (issue #5374).
 			newLeafId = targetId;
 		}
 

--- a/packages/coding-agent/test/agent-session-tree-skill-injection.test.ts
+++ b/packages/coding-agent/test/agent-session-tree-skill-injection.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression: `/tree` navigation onto a `/skill:` injection node (issue #5374).
+ *
+ * A user-invoked skill injection is persisted as a `custom_message` entry
+ * (customType `skill-prompt`). Selecting it in the tree must leave the leaf ON
+ * the injection node so the skill stays on the active branch — not on its
+ * parent with the expanded skill body dumped into the editor.
+ */
+import { describe, expect, it } from "bun:test";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { assistantMsg, createTestSession, userMsg } from "./utilities";
+
+describe("AgentSession tree navigation onto skill injection", () => {
+	it("lands the leaf on the skill injection node and keeps it on the active branch", async () => {
+		const ctx = await createTestSession({ inMemory: true });
+		try {
+			const { session, sessionManager } = ctx;
+
+			// u1 -> skill injection -> a1 -> a2
+			sessionManager.appendMessage(userMsg("hello"));
+			const skillId = sessionManager.appendCustomMessageEntry(
+				SKILL_PROMPT_MESSAGE_TYPE,
+				"<skill>huge expanded skill body</skill>",
+				true,
+				{ name: "some-skill", path: "/skills/some-skill/SKILL.md", lineCount: 1 },
+				"user",
+			);
+			sessionManager.appendMessage(assistantMsg("first reply"));
+			sessionManager.appendMessage(assistantMsg("second reply"));
+
+			const result = await session.navigateTree(skillId);
+
+			expect(result.cancelled).toBe(false);
+			// Leaf must be the skill node itself, not its parent.
+			expect(sessionManager.getLeafId()).toBe(skillId);
+			// The skill injection must remain on the active branch.
+			expect(sessionManager.getBranch().some(e => e.id === skillId)).toBe(true);
+			// The expanded skill body must NOT be dumped into the editor.
+			expect(result.editorText).toBeUndefined();
+		} finally {
+			await ctx.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
After a `/skill:<name>` invocation, selecting the skill injection node in `/tree` did not leave the leaf on the injection. Navigation moved to the entry *before* the injection, the skill dropped off the active branch, and the editor was prefilled with the expanded skill body. Reproduced with a focused test (`packages/coding-agent/test/agent-session-tree-skill-injection.test.ts`): navigating to the skill node left the leaf on its parent (`hello`) instead of the injection node.

## Cause
`AgentSession.navigateTree()` in `packages/coding-agent/src/session/agent-session.ts` treated *every* `custom_message` entry as a re-editable user turn — `newLeafId = targetEntry.parentId` plus dumping the message content into `editorText`. A user-invoked `/skill:` command is persisted as a `custom_message` with `customType === SKILL_PROMPT_MESSAGE_TYPE` (`"skill-prompt"`), so it hit that branch. The documented workaround (selecting the assistant reply after the skill) worked because that entry hits the `else` branch, `newLeafId = targetId`.

## Fix
- Exclude `skill-prompt` custom messages from the parent-leaf/editor-prefill branch in `navigateTree()`, so they fall through to the `else` branch and land the leaf on the injection node itself (no editor prefill), keeping the skill on the active branch.
- Added a regression test asserting the leaf lands on the skill node, the node stays on the active branch, and no editor text is returned.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/agent-session-tree-navigation.test.ts test/agent-session-tree-skill-injection.test.ts src/session/messages.test.ts` → 6 pass, 10 skip (e2e requiring API key), 0 fail. The new test fails before the fix (leaf lands on parent) and passes after.

Fixes #5374