### PR TITLE
fix(prompt): restore non-Linux CPU model metadata

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored CPU model metadata in workstation prompts on non-Linux hosts while retaining the cheap `/proc/cpuinfo` lookup on Linux ([#4755](https://github.com/can1357/oh-my-pi/issues/4755)).
+
 ## [16.3.11] - 2026-07-06
 
 ### Changed

--- a/packages/coding-agent/src/system-prompt.test.ts
+++ b/packages/coding-agent/src/system-prompt.test.ts
@@ -189,3 +189,39 @@ describe.skipIf(process.platform !== "linux")("system prompt CPU model", () => {
 		}
 	});
 });
+
+describe("non-Linux system prompt CPU model", () => {
+	it("includes the model returned by os.cpus", async () => {
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "darwin" });
+		const cpus = spyOn(os, "cpus").mockImplementation(() => [
+			{
+				model: "Synthetic Non-Linux CPU",
+				speed: 0,
+				times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 },
+			},
+		]);
+		try {
+			const systemPrompt = await buildSystemPrompt({
+				resolvedCustomPrompt: "Base prompt",
+				contextFiles: [],
+				skills: [],
+				rules: [],
+				workspaceTree: {
+					rootPath: import.meta.dir,
+					rendered: "",
+					truncated: false,
+					totalLines: 0,
+					agentsMdFiles: [],
+				},
+				activeRepoContext: null,
+			});
+
+			expect(cpus).toHaveBeenCalledTimes(1);
+			expect(systemPrompt.systemPrompt.join("\n")).toContain("- CPU: Synthetic Non-Linux CPU");
+		} finally {
+			cpus.mockRestore();
+			Object.defineProperty(process, "platform", { value: originalPlatform });
+		}
+	});
+});

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -251,7 +251,7 @@ async function getCachedGpu(): Promise<string | undefined> {
 }
 
 async function getCpuModel(): Promise<string | undefined> {
-	if (process.platform !== "linux") return undefined;
+	if (process.platform !== "linux") return os.cpus()[0]?.model;
 	try {
 		const cpuInfo = await Bun.file("/proc/cpuinfo").text();
 		const match = /^model name\s*:\s*(.+)$/m.exec(cpuInfo);


### PR DESCRIPTION
## Repro
On a simulated Darwin host, `buildSystemPrompt()` skipped `os.cpus()` and omitted the CPU line from the workstation block. Reproduced with `cd packages/coding-agent && bun test src/system-prompt.test.ts --filter 'non-Linux system prompt CPU model'`; before the fix, the spy expected 1 call but received 0.

## Cause
`getCpuModel()` in `packages/coding-agent/src/system-prompt.ts` returned `undefined` immediately for every platform except Linux. The `/proc/cpuinfo` optimization from #4717 therefore removed the previous `os.cpus()[0]?.model` behavior on macOS and Windows.

## Fix
- Restore `os.cpus()[0]?.model` for non-Linux hosts.
- Preserve the `/proc/cpuinfo` lookup on Linux.
- Add an end-to-end system prompt regression test covering the non-Linux CPU line, alongside the existing Linux no-`os.cpus()` test.
- Record the fix in the coding-agent changelog.

## Verification
`cd packages/coding-agent && bun test src/system-prompt.test.ts --filter 'CPU model'` passed with 6 tests and 14 assertions. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #4755