### PR TITLE
fix(ai): honor proxies for Codex WebSockets

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Codex WebSocket connections ignoring `PI_PROXY`, provider-specific proxy settings, and standard HTTPS/ALL proxy variables ([#5384](https://github.com/can1357/oh-my-pi/issues/5384)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Added

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -60,6 +60,7 @@ import {
 	getOpenAIStreamIdleTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
+import { getProxyForProvider, shouldBypassProxy } from "../utils/proxy";
 import { createRequestDebugSession, isRequestDebugEnabled, type RequestDebugResponseLog } from "../utils/request-debug";
 import { adaptSchemaForStrict, NO_STRICT, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
 import { notifyRawSseEvent } from "../utils/sse-debug";
@@ -1464,6 +1465,7 @@ async function openCodexWebSocketTransport(
 		websocketState,
 		toWebSocketUrl(requestContext.url),
 		websocketHeaders,
+		model.provider,
 		requestSetup.requestSignal,
 	);
 	const eventStream = websocketConnection.streamRequest(
@@ -2587,6 +2589,7 @@ export async function prewarmOpenAICodexResponses(
 		state,
 		toWebSocketUrl(url),
 		headers,
+		model.provider,
 		options?.signal,
 	);
 	state.prewarmed = true;
@@ -3049,11 +3052,13 @@ interface CodexWebSocketRequestTimeouts {
 
 interface CodexWebSocketConnectionOptions {
 	onHandshakeHeaders?: (headers: Headers) => void;
+	proxy?: string;
 }
 
 class CodexWebSocketConnection {
 	#url: string;
 	#headers: Record<string, string>;
+	#proxy?: string;
 	#onHandshakeHeaders?: (headers: Headers) => void;
 	#socket: Bun.WebSocket | null = null;
 	#queue: Array<Record<string, unknown> | Error | null> = [];
@@ -3084,6 +3089,7 @@ class CodexWebSocketConnection {
 	constructor(url: string, headers: Record<string, string>, options: CodexWebSocketConnectionOptions) {
 		this.#url = url;
 		this.#headers = headers;
+		this.#proxy = options.proxy;
 		this.#onHandshakeHeaders = options.onHandshakeHeaders;
 	}
 
@@ -3145,7 +3151,7 @@ class CodexWebSocketConnection {
 		this.#connectPromise = promise;
 		const socket = new (WebSocket as unknown as new (url: string, opts: Bun.WebSocketOptions) => Bun.WebSocket)(
 			this.#url,
-			{ headers: this.#headers },
+			{ headers: this.#headers, proxy: this.#proxy },
 		);
 		socket.binaryType = "nodebuffer";
 		this.#socket = socket;
@@ -3636,8 +3642,18 @@ async function getOrCreateCodexWebSocketConnection(
 	state: CodexWebSocketSessionState,
 	url: string,
 	headers: Headers,
+	provider: string,
 	signal?: AbortSignal,
 ): Promise<CodexWebSocketConnection> {
+	const targetUrl = new URL(url);
+	const proxy = shouldBypassProxy(targetUrl)
+		? undefined
+		: (getProxyForProvider(provider) ??
+			(targetUrl.protocol === "wss:"
+				? Bun.env.HTTPS_PROXY || Bun.env.https_proxy
+				: Bun.env.HTTP_PROXY || Bun.env.http_proxy) ??
+			Bun.env.ALL_PROXY ??
+			Bun.env.all_proxy);
 	const headerRecord = headersToRecord(headers);
 	// Join an in-flight handshake instead of tearing it down: closing a
 	// CONNECTING socket rejects the concurrent caller (prewarm racing the first
@@ -3680,6 +3696,7 @@ async function getOrCreateCodexWebSocketConnection(
 		onHandshakeHeaders: handshakeHeaders => {
 			updateCodexSessionMetadataFromHeaders(state, handshakeHeaders);
 		},
+		proxy,
 	});
 	await state.connection.connect(signal);
 	return state.connection;

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -15,6 +15,7 @@ import type {
 	ModelSpec,
 	ProviderSessionState,
 } from "@oh-my-pi/pi-ai/types";
+import { __resetProxyCache } from "@oh-my-pi/pi-ai/utils/proxy";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import * as piUtils from "@oh-my-pi/pi-utils";
 
@@ -23,6 +24,16 @@ const { getAgentDir, setAgentDir, TempDir } = piUtils;
 const originalAgentDir = getAgentDir();
 const originalWebSocket = global.WebSocket;
 const originalCodexWebSocketV2 = Bun.env.PI_CODEX_WEBSOCKET_V2;
+const originalProxyEnv: Record<string, string | undefined> = {
+	PI_PROXY: Bun.env.PI_PROXY,
+	PI_PROXY_CODEX_PROXY_TEST: Bun.env.PI_PROXY_CODEX_PROXY_TEST,
+	HTTPS_PROXY: Bun.env.HTTPS_PROXY,
+	https_proxy: Bun.env.https_proxy,
+	ALL_PROXY: Bun.env.ALL_PROXY,
+	all_proxy: Bun.env.all_proxy,
+	NO_PROXY: Bun.env.NO_PROXY,
+	no_proxy: Bun.env.no_proxy,
+};
 const TEST_INSTALLATION_ID = "00000000-0000-4000-8000-000000000001";
 
 function restoreEnv(name: string, value: string | undefined): void {
@@ -34,6 +45,8 @@ function restoreEnv(name: string, value: string | undefined): void {
 }
 
 beforeEach(() => {
+	for (const key in originalProxyEnv) delete Bun.env[key];
+	__resetProxyCache();
 	vi.spyOn(piUtils, "getInstallId").mockReturnValue(TEST_INSTALLATION_ID);
 });
 
@@ -41,6 +54,8 @@ afterEach(() => {
 	global.WebSocket = originalWebSocket;
 	setAgentDir(originalAgentDir);
 	restoreEnv("PI_CODEX_WEBSOCKET_V2", originalCodexWebSocketV2);
+	for (const key in originalProxyEnv) restoreEnv(key, originalProxyEnv[key]);
+	__resetProxyCache();
 	vi.restoreAllMocks();
 });
 
@@ -169,6 +184,7 @@ function encodeWebSocketMessage(value: Record<string, unknown>): Uint8Array {
 }
 
 type WsHeaders = Record<string, string>;
+type WsOptions = { headers?: WsHeaders; proxy?: string };
 type WsEventType = "open" | "message" | "error" | "close";
 
 type CodexTestUsage = {
@@ -208,7 +224,7 @@ class MockWebSocket {
 
 	constructor(
 		public readonly url: string,
-		public readonly options?: { headers?: WsHeaders },
+		public readonly options?: WsOptions,
 	) {}
 
 	send(_data: string): void {}
@@ -1223,6 +1239,107 @@ describe("openai-codex streaming", () => {
 		expect(capturedHeaders?.["content-type"]).toBeUndefined();
 		expect(capturedHeaders?.["openai-beta"]).toBe("responses_websockets=2026-02-06");
 		expect(Object.keys(capturedHeaders ?? {}).filter(key => key.toLowerCase() === "openai-beta")).toHaveLength(1);
+	});
+
+	it("passes the provider proxy to websocket handshakes", async () => {
+		const proxy = "socks5://127.0.0.1:7890";
+		Bun.env.PI_PROXY_CODEX_PROXY_TEST = proxy;
+		__resetProxyCache();
+		let capturedProxy: string | undefined;
+		class ProxyCaptureWebSocket extends MockWebSocket {
+			constructor(url: string, options?: WsOptions) {
+				super(url, options);
+				capturedProxy = options?.proxy;
+				this.scheduleOpen();
+			}
+		}
+		global.WebSocket = ProxyCaptureWebSocket as unknown as typeof WebSocket;
+		const model = {
+			...createCodexTestModel("https://chatgpt.com/backend-api"),
+			provider: "codex-proxy-test",
+		};
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		try {
+			await prewarmOpenAICodexResponses(model, {
+				apiKey: createCodexTestToken(),
+				sessionId: "ws-proxy-session",
+				providerSessionState,
+			});
+			expect(capturedProxy).toBe(proxy);
+		} finally {
+			for (const state of providerSessionState.values()) state.close();
+			delete Bun.env.PI_PROXY_CODEX_PROXY_TEST;
+		}
+	});
+
+	it("falls back to standard proxy variables for websocket handshakes", async () => {
+		const cases: Array<{ env: string; proxy: string }> = [
+			{ env: "HTTPS_PROXY", proxy: "http://127.0.0.1:7890" },
+			{ env: "ALL_PROXY", proxy: "socks5://127.0.0.1:7891" },
+		];
+
+		for (const { env, proxy } of cases) {
+			delete Bun.env.HTTPS_PROXY;
+			delete Bun.env.ALL_PROXY;
+			Bun.env[env] = proxy;
+			let capturedProxy: string | undefined;
+			class StandardProxyWebSocket extends MockWebSocket {
+				constructor(url: string, options?: WsOptions) {
+					super(url, options);
+					capturedProxy = options?.proxy;
+					this.scheduleOpen();
+				}
+			}
+			global.WebSocket = StandardProxyWebSocket as unknown as typeof WebSocket;
+			const model = {
+				...createCodexTestModel("https://chatgpt.com/backend-api"),
+				provider: `codex-${env.toLowerCase()}-test`,
+			};
+			const providerSessionState = new Map<string, ProviderSessionState>();
+
+			try {
+				await prewarmOpenAICodexResponses(model, {
+					apiKey: createCodexTestToken(),
+					sessionId: `ws-${env.toLowerCase()}-proxy-session`,
+					providerSessionState,
+				});
+				expect(capturedProxy).toBe(proxy);
+			} finally {
+				for (const state of providerSessionState.values()) state.close();
+			}
+		}
+	});
+
+	it("bypasses configured proxies for NO_PROXY websocket targets", async () => {
+		Bun.env.PI_PROXY_CODEX_PROXY_TEST = "http://127.0.0.1:7890";
+		Bun.env.NO_PROXY = "chatgpt.com";
+		__resetProxyCache();
+		let capturedProxy: string | undefined;
+		class NoProxyWebSocket extends MockWebSocket {
+			constructor(url: string, options?: WsOptions) {
+				super(url, options);
+				capturedProxy = options?.proxy;
+				this.scheduleOpen();
+			}
+		}
+		global.WebSocket = NoProxyWebSocket as unknown as typeof WebSocket;
+		const model = {
+			...createCodexTestModel("https://chatgpt.com/backend-api"),
+			provider: "codex-proxy-test",
+		};
+		const providerSessionState = new Map<string, ProviderSessionState>();
+
+		try {
+			await prewarmOpenAICodexResponses(model, {
+				apiKey: createCodexTestToken(),
+				sessionId: "ws-no-proxy-session",
+				providerSessionState,
+			});
+			expect(capturedProxy).toBeUndefined();
+		} finally {
+			for (const state of providerSessionState.values()) state.close();
+		}
 	});
 
 	it("sends the Responses Lite marker on the upgrade and in response.create client_metadata", async () => {


### PR DESCRIPTION
## Repro
A Codex prewarm with `PI_PROXY_CODEX_PROXY_TEST=socks5://127.0.0.1:7890` left Bun's WebSocket constructor `proxy` option undefined. `bun test packages/ai/test/openai-codex-stream.test.ts --test-name-pattern "passes the provider proxy"` reproduced the regression with `0 pass, 1 fail` before the fix.

## Cause
`getOrCreateCodexWebSocketConnection()` in `packages/ai/src/providers/openai-codex-responses.ts` constructed `CodexWebSocketConnection` without resolving provider proxy configuration, and `CodexWebSocketConnection.connect()` passed only headers to Bun's `WebSocket` constructor. Unlike the SSE/fetch path, Bun WebSockets do not infer proxy environment variables.

## Fix
- Resolve provider-specific `PI_PROXY_<PROVIDER>` / `PI_PROXY` settings for Codex WebSocket targets.
- Fall back to standard `HTTPS_PROXY` or `ALL_PROXY` variables, including lowercase variants, and preserve local/metadata and `NO_PROXY` bypasses.
- Pass the resolved proxy into both prewarmed and request-created WebSocket connections.
- Cover provider, HTTPS, SOCKS/ALL, and bypass behavior in the Codex transport suite.

## Verification
`bun test packages/ai/test/openai-codex-stream.test.ts` passed 60 tests; `bun test packages/ai/test/proxy.test.ts` passed 36 tests. The pre-publish `bun run fix` and `bun check` gate passed while pushing and opening this PR.

Fixes #5384