### PR TITLE
fix(tui): stop PageUp/PageDown stepping prompt history at idle

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed PageUp/PageDown on an idle (empty) prompt editor stepping through prompt history like the Up/Down arrows instead of paging the draft. The paging keys now only scroll the editor viewport (a no-op on a short draft) and never touch prompt history ([#4754](https://github.com/can1357/oh-my-pi/issues/4754)).
+
 ## [16.3.10] - 2026-07-06
 
 ### Fixed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1357,21 +1357,14 @@ export class Editor implements Component, Focusable {
 		} else if (kb.matches(data, "tui.editor.cursorLineEnd")) {
 			this.#moveToLineEnd();
 		}
-		// Page navigation (PageUp/PageDown)
+		// Page navigation (PageUp/PageDown): page the editor viewport only. On a
+		// short draft this is a no-op — it never steps prompt history (that stays
+		// on Up/Down), so an idle empty editor swallows the keys instead of
+		// surprising the user by loading the previous prompt (#4754).
 		else if (kb.matches(data, "tui.editor.pageUp")) {
-			if (this.#isEditorEmpty()) {
-				this.#navigateHistory(-1);
-			} else if (this.#historyIndex > -1 && this.#isOnFirstVisualLine()) {
-				this.#navigateHistory(-1);
-			} else {
-				this.#pageScroll(-1);
-			}
+			this.#pageScroll(-1);
 		} else if (kb.matches(data, "tui.editor.pageDown")) {
-			if (this.#historyIndex > -1 && this.#isOnLastVisualLine()) {
-				this.#navigateHistory(1);
-			} else {
-				this.#pageScroll(1);
-			}
+			this.#pageScroll(1);
 		}
 		// Forward delete (Fn+Backspace or Delete key, including Shift+Delete)
 		else if (kb.matches(data, "tui.editor.deleteCharForward") || matchesKey(data, "shift+delete")) {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1936,6 +1936,27 @@ describe("Editor component", () => {
 			expect(editor.getCursor()).toEqual({ line: 6, col: 2 });
 		});
 
+		it("PageUp/PageDown on an idle editor never step prompt history (#4754)", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.addToHistory("first prompt");
+			editor.addToHistory("second prompt");
+			editor.render(80);
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("\x1b[5~"); // PageUp on empty editor
+			expect(editor.getText()).toBe("");
+
+			editor.handleInput("\x1b[6~"); // PageDown on empty editor
+			expect(editor.getText()).toBe("");
+
+			// While browsing history (entered via Up), PageUp must not advance it.
+			editor.handleInput("\x1b[A"); // Up - shows "second prompt"
+			expect(editor.getText()).toBe("second prompt");
+			editor.handleInput("\x1b[5~"); // PageUp - stays put
+			expect(editor.getText()).toBe("second prompt");
+		});
+
 		it("moves correctly through wrapped visual lines without getting stuck", () => {
 			const editor = new Editor(defaultEditorTheme);
 


### PR DESCRIPTION
## Repro
At idle (empty prompt editor) with prompt history present, pressing PageUp/PageDown loads the previous/next prompt — identical to the Up/Down arrows — instead of paging. Reporter expected paging over the message window. Minimal repro against the pi-tui `Editor`:
```ts
const editor = new Editor(theme);
editor.addToHistory("first prompt");
editor.addToHistory("second prompt");
editor.render(80);                 // editor is empty
editor.handleInput("\x1b[5~");     // PageUp
// editor.getText() === "second prompt"   ← steps history instead of paging
```

## Cause
`Editor.handleInput` in `packages/tui/src/components/editor.ts` routed the paging keys through prompt-history navigation: the PageUp branch called `#navigateHistory(-1)` when `#isEditorEmpty()` (and while browsing history at the first/last visual line), and PageDown mirrored it. So on an idle editor PageUp/PageDown behaved exactly like Up/Down.

## Fix
- `packages/tui/src/components/editor.ts`: PageUp/PageDown now call only `#pageScroll(±1)` — they page the editor's own viewport (a no-op on a short draft) and never step prompt history, which stays on Up/Down.
- `packages/tui/test/editor.test.ts`: added a regression test asserting PageUp/PageDown leave the editor text unchanged on an idle editor and while browsing history.
- `packages/tui/CHANGELOG.md`: `[Unreleased] → Fixed` entry.

Note: this stops the surprising history behavior. Scrolling the completed-message window remains the terminal's native scrollback (mouse wheel), which the editor does not own.

## Verification
`bun test test/editor.test.ts` in `packages/tui` — 143 pass, 0 fail (includes the new regression test). Fixes #4754