### PR TITLE
fix(skills): reload runtime skill state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/reload-plugins`, plugin setting changes, and `manage_skill` writes leaving runtime skills and `skill://` resolution stale until restart; sessions now rediscover enabled skills and rebuild `/skill:<name>` commands before the next prompt ([#4996](https://github.com/can1357/oh-my-pi/issues/4996)).
+
 ## [16.3.15] - 2026-07-09
 
 ### Changed

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1845,6 +1845,7 @@ export class AcpAgent implements Agent {
 		const projectPath = await resolveActiveProjectRegistryPath(cwd);
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
 		resetCapabilities();
+		await record.session.refreshSkills();
 		const fileCommands = await loadSlashCommands({ cwd });
 		record.session.setSlashCommands(fileCommands);
 		await record.session.refreshSshTool({ activateIfAvailable: true });

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -184,6 +184,7 @@ export class SelectorController {
 					onPluginsChanged: async () => {
 						const projectPath = await resolveActiveProjectRegistryPath(this.ctx.sessionManager.getCwd());
 						clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+						await this.ctx.refreshSkillState();
 						await this.ctx.refreshSlashCommandState();
 						await this.ctx.session.refreshSshTool({ activateIfAvailable: true });
 						this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -725,15 +725,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			description: `${loaded.command.description} (${loaded.source})`,
 		}));
 
-		// Build skill commands from session.skills (if enabled)
-		const skillCommandList: SlashCommand[] = [];
-		if (settings.get("skills.enableSkillCommands")) {
-			for (const skill of this.session.skills) {
-				const commandName = `skill:${skill.name}`;
-				this.skillCommands.set(commandName, skill);
-				skillCommandList.push({ name: commandName, description: skill.description });
-			}
-		}
+		const skillCommandList = this.#rebuildSkillCommandsFromSession();
 
 		const builtinCommands = buildTuiBuiltinSlashCommands({ ctx: this });
 		// Store pending commands for init() where file commands are loaded async
@@ -1069,6 +1061,27 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.session.setTitleSystemPrompt(resolved);
 	}
 
+	#rebuildSkillCommandsFromSession(): SlashCommand[] {
+		const commands: SlashCommand[] = [];
+		this.skillCommands.clear();
+		if (this.session.skillsSettings?.enableSkillCommands !== false) {
+			for (const skill of this.session.skills) {
+				const commandName = `skill:${skill.name}`;
+				this.skillCommands.set(commandName, skill);
+				commands.push({ name: commandName, description: skill.description });
+			}
+		}
+		return commands;
+	}
+
+	/** Reload session skills and the `/skill:<name>` command list. */
+	async refreshSkillState(): Promise<void> {
+		await this.session.refreshSkills();
+		const retainedCommands = this.#pendingSlashCommands.filter(command => !command.name.startsWith("skill:"));
+		const skillCommands = this.#rebuildSkillCommandsFromSession();
+		this.#pendingSlashCommands = [...retainedCommands, ...skillCommands];
+	}
+
 	/** Reload slash commands and autocomplete for the provided working directory. */
 	async refreshSlashCommandState(cwd?: string): Promise<void> {
 		const basePath = cwd ?? this.sessionManager.getCwd();
@@ -1167,6 +1180,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		clearClaudePluginRootsCache();
 		await this.refreshTitleSystemPrompt(newCwd);
 		resetCapabilities();
+		await this.refreshSkillState();
 		await this.refreshSlashCommandState(newCwd);
 		await this.session.refreshSshTool({ activateIfAvailable: true });
 		setSessionTerminalTitle(this.sessionManager.getSessionName(), this.sessionManager.getCwd());

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -828,6 +828,7 @@ export async function runRpcMode(
 		const projectPath = await resolveActiveProjectRegistryPath(cwd);
 		clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
 		resetCapabilities();
+		await session.refreshSkills();
 		session.setSlashCommands(await loadSlashCommands({ cwd }));
 		await session.refreshSshTool({ activateIfAvailable: true });
 		await emitAvailableCommandsUpdate();

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -344,6 +344,8 @@ export interface InteractiveModeContext {
 	): Promise<CompactionOutcome>;
 	openInBrowser(urlOrPath: string): void;
 	refreshSlashCommandState(cwd?: string): Promise<void>;
+	/** Reload session skills and derived `/skill:<name>` commands. */
+	refreshSkillState(): Promise<void>;
 	applyCwdChange(newCwd: string): Promise<void>;
 
 	// Selector handling

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1547,7 +1547,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			skipPythonPreflight: options.skipPythonPreflight,
 			contextFiles,
 			workspaceTree: resolvedWorkspaceTree,
-			skills,
+			get skills() {
+				return session?.skills ?? skills;
+			},
+			refreshSkills: () => session.refreshSkills(),
 			rules: allRules,
 			eventBus,
 			outputSchema: options.outputSchema,
@@ -2399,7 +2402,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd,
 				resolvedCustomPrompt: options.customSystemPrompt,
-				skills,
+				skills: session?.skills ?? skills,
 				contextFiles,
 				tools: promptTools,
 				toolNames,
@@ -2847,6 +2850,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			customCommands: customCommandsResult.commands,
 			skills,
 			skillWarnings,
+			skillsReloadable: options.skills === undefined,
 			skillsSettings: settings.getGroup("skills"),
 			modelRegistry,
 			toolRegistry,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -230,7 +230,7 @@ import type { CompactOptions, ContextUsage } from "../extensibility/extensions/t
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import type { HookCommandContext } from "../extensibility/hooks/types";
 import type { RecoveredRetryError } from "../extensibility/shared-events";
-import type { Skill, SkillWarning } from "../extensibility/skills";
+import { loadSkills, type Skill, type SkillWarning, setActiveSkills } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
 import { GoalRuntime } from "../goals/runtime";
 import type { Goal, GoalModeState } from "../goals/state";
@@ -686,6 +686,8 @@ export interface AgentSessionConfig {
 	skills?: Skill[];
 	/** Skill loading warnings (already captured by SDK) */
 	skillWarnings?: SkillWarning[];
+	/** Whether runtime reloads may rediscover disk-backed skills for this session. */
+	skillsReloadable?: boolean;
 	/** Custom commands (TypeScript slash commands) */
 	customCommands?: LoadedCustomCommand[];
 	skillsSettings?: SkillsSettings;
@@ -1714,6 +1716,7 @@ export class AgentSession {
 	#mcpPromptCommands: LoadedCustomCommand[] = [];
 
 	#skillsSettings: SkillsSettings | undefined;
+	#skillsReloadable: boolean;
 
 	// Model registry for API key resolution
 	#modelRegistry: ModelRegistry;
@@ -2066,6 +2069,7 @@ export class AgentSession {
 		this.#skills = config.skills ?? [];
 		this.#skillWarnings = config.skillWarnings ?? [];
 		this.#customCommands = config.customCommands ?? [];
+		this.#skillsReloadable = config.skillsReloadable ?? true;
 		this.#skillsSettings = config.skillsSettings;
 		this.#modelRegistry = config.modelRegistry;
 		// Resolve the wire service-tier per request so the Fireworks Priority
@@ -6425,6 +6429,33 @@ export class AgentSession {
 			nextActive.push(refreshedTool.name);
 		}
 		await this.#applyActiveToolsByName(nextActive);
+	}
+
+	/**
+	 * Rediscover disk-backed skills and rebuild prompt-facing state without
+	 * recreating the session. Explicit skill snapshots (`--no-skills`,
+	 * SDK-provided `skills`) remain fixed for the lifetime of the session.
+	 */
+	async refreshSkills(): Promise<void> {
+		if (!this.#skillsReloadable) {
+			return;
+		}
+
+		resetCapabilities();
+		const skillsSettings = this.settings.getGroup("skills");
+		const discovered = await loadSkills({
+			...skillsSettings,
+			cwd: this.sessionManager.getCwd(),
+			disabledExtensions: this.settings.get("disabledExtensions") ?? [],
+		});
+		this.#skills = discovered.skills;
+		this.#skillWarnings = discovered.warnings;
+		this.#skillsSettings = skillsSettings;
+
+		if (this.#agentKind === "main") {
+			setActiveSkills(this.#skills);
+		}
+		await this.refreshBaseSystemPrompt();
 	}
 
 	/**

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -2198,6 +2198,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			// listClaudePluginRoots re-reads from disk on next access.
 			const projectPath = await resolveActiveProjectRegistryPath(runtime.ctx.sessionManager.getCwd());
 			clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+			await runtime.ctx.refreshSkillState();
 			await runtime.ctx.refreshSlashCommandState();
 			await runtime.ctx.session.refreshSshTool({ activateIfAvailable: true });
 			runtime.ctx.showStatus("Plugins reloaded.");
@@ -2537,6 +2538,7 @@ export async function executeBuiltinSlashCommand(
 			reloadPlugins: async () => {
 				const projectPath = await resolveActiveProjectRegistryPath(ctx.sessionManager.getCwd());
 				clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+				await ctx.refreshSkillState();
 				await ctx.refreshSlashCommandState();
 				await ctx.session.refreshSshTool({ activateIfAvailable: true });
 			},

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -64,10 +64,10 @@ export interface SlashCommandRuntime {
 	/** Re-advertise the available command list (no-op outside ACP). */
 	refreshCommands: () => Promise<void> | void;
 	/**
-	 * Reload plugin state (caches, slash command registry, project registries)
-	 * and re-emit available commands. Used by `/reload-plugins`, `/move`, and
-	 * `/marketplace`/`/plugins` mutations so the session sees a consistent view
-	 * after plugin or project-scope changes.
+	 * Reload plugin state (caches, skills, slash command registry, project
+	 * registries) and re-emit available commands. Used by `/reload-plugins`,
+	 * `/move`, and `/marketplace`/`/plugins` mutations so the session sees a
+	 * consistent view after plugin or project-scope changes.
 	 */
 	reloadPlugins: () => Promise<void>;
 	notifyTitleChanged?: () => Promise<void> | void;

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -468,7 +468,7 @@ export interface BuildSystemPromptOptions {
 	/** Pre-loaded context files (skips discovery if provided). */
 	contextFiles?: Array<{ path: string; content: string; depth?: number }>;
 	/** Skills provided directly to system prompt construction. */
-	skills?: Skill[];
+	skills?: readonly Skill[];
 	/** Pre-loaded rulebook rules (descriptions, excluding TTSR and always-apply). */
 	rules?: Array<{ name: string; description?: string; path: string; globs?: string[] }>;
 	/** Intent field name injected into every tool schema. If set, explains the field in the prompt. */
@@ -623,7 +623,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 						totalLines: 0,
 						agentsMdFiles: [],
 					});
-	const skillsPromise: Promise<Skill[]> =
+	const skillsPromise: Promise<readonly Skill[]> =
 		providedSkills !== undefined
 			? Promise.resolve(providedSkills)
 			: skillsSettings?.enabled !== false

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -174,7 +174,9 @@ export interface ToolSession {
 	/** Pre-loaded workspace tree (forwarded to subagents to skip re-scanning) */
 	workspaceTree?: WorkspaceTree;
 	/** Pre-loaded skills */
-	skills?: Skill[];
+	skills?: readonly Skill[];
+	/** Rediscover live session skills after a tool mutates their backing files. */
+	refreshSkills?: () => Promise<void>;
 	/** Pre-loaded prompt templates */
 	promptTemplates?: PromptTemplate[];
 	/** Pre-loaded rules (forwarded to subagents to skip re-discovery). */

--- a/packages/coding-agent/src/tools/manage-skill.ts
+++ b/packages/coding-agent/src/tools/manage-skill.ts
@@ -45,16 +45,17 @@ export class ManageSkillTool implements AgentTool<typeof manageSkillSchema> {
 	readonly loadMode = "essential" as const;
 	readonly summary = "Create, update, or delete an isolated managed skill";
 
-	// No session state needed: createIf reads settings; writes target the
-	// home-based managed-skills dir directly.
+	constructor(private readonly refreshSkills?: () => Promise<void>) {}
+
 	static createIf(session: ToolSession): ManageSkillTool | null {
 		if (!session.settings.get("autolearn.enabled")) return null;
-		return new ManageSkillTool();
+		return new ManageSkillTool(session.refreshSkills);
 	}
 
 	async execute(_id: string, params: ManageSkillParams): Promise<AgentToolResult> {
 		if (params.action === "delete") {
 			await deleteManagedSkill(params.name);
+			await this.refreshSkills?.();
 			return {
 				content: [{ type: "text", text: `Deleted managed skill "${params.name}".` }],
 				details: { action: "delete", name: params.name },
@@ -90,6 +91,7 @@ export class ManageSkillTool implements AgentTool<typeof manageSkillSchema> {
 			description: params.description,
 			body: params.body,
 		});
+		await this.refreshSkills?.();
 		const relativePath = path.relative(getManagedSkillsDir(), skillPath);
 		const verb = params.action === "create" ? "Created" : "Updated";
 		return {

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -4,11 +4,13 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { getActiveSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/sdk";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import { getAgentDir, setAgentDir } from "@oh-my-pi/pi-utils/dirs";
 import { cleanupTempHome } from "./helpers/temp-home-cleanup";
 
 function createIsolatedSkillsSettings(): Settings {
@@ -132,6 +134,94 @@ Loaded via symbolic link.
 
 		expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
 	});
+
+	it("refreshSkills reloads project skills on an existing session", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			modelRegistry: sharedModelRegistry,
+			settings: createIsolatedSkillsSettings(),
+		});
+
+		expect(session.skills.some((s: Skill) => s.name === "runtime-added-skill")).toBe(false);
+
+		const runtimeSkillDir = path.join(tempDir, ".omp", "skills", "runtime-added-skill");
+		fs.mkdirSync(runtimeSkillDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(runtimeSkillDir, "SKILL.md"),
+			`---
+name: runtime-added-skill
+description: Added after the session is created.
+---
+
+# Runtime Added Skill
+
+This skill is added after session creation.
+`,
+		);
+
+		await session.refreshSkills();
+
+		expect(session.skills.some((s: Skill) => s.name === "runtime-added-skill")).toBe(true);
+
+		removeSyncWithRetries(runtimeSkillDir);
+
+		await session.refreshSkills();
+
+		expect(session.skills.some((s: Skill) => s.name === "runtime-added-skill")).toBe(false);
+	});
+
+	it("manage_skill hot-registers managed skills in the active session", async () => {
+		const originalAgentDir = getAgentDir();
+		const managedAgentDir = path.join(tempHomeDir, ".omp", "agent");
+		setAgentDir(managedAgentDir);
+		const settings = createIsolatedSkillsSettings();
+		settings.set("autolearn.enabled", true);
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: managedAgentDir,
+			sessionManager: SessionManager.inMemory(tempDir),
+			modelRegistry: sharedModelRegistry,
+			settings,
+		});
+
+		try {
+			const manageSkill = session.getToolByName("manage_skill");
+			expect(manageSkill).toBeDefined();
+			await manageSkill!.execute("manage-skill-create", {
+				action: "create",
+				name: "runtime-managed-skill",
+				description: "Created by manage_skill during the session.",
+				body: "# Runtime Managed Skill\n\nUse this immediately.",
+			});
+
+			expect(session.skills.some(skill => skill.name === "runtime-managed-skill")).toBe(true);
+			expect(getActiveSkills().some(skill => skill.name === "runtime-managed-skill")).toBe(true);
+			expect(session.agent.state.systemPrompt.join("\n")).toContain("runtime-managed-skill");
+			const readSkill = session.getToolByName("read");
+			expect(readSkill).toBeDefined();
+			const readResult = await readSkill!.execute("read-managed-skill", { path: "skill://runtime-managed-skill" });
+			expect(
+				readResult.content.some(part => part.type === "text" && part.text.includes("# Runtime Managed Skill")),
+			).toBe(true);
+
+			await manageSkill!.execute("manage-skill-delete", {
+				action: "delete",
+				name: "runtime-managed-skill",
+			});
+			expect(session.skills.some(skill => skill.name === "runtime-managed-skill")).toBe(false);
+			expect(getActiveSkills().some(skill => skill.name === "runtime-managed-skill")).toBe(false);
+			expect(session.agent.state.systemPrompt.join("\n")).not.toContain("runtime-managed-skill");
+			await expect(
+				readSkill!.execute("read-deleted-managed-skill", { path: "skill://runtime-managed-skill" }),
+			).rejects.toThrow(/Unknown skill/);
+		} finally {
+			await session.dispose();
+			setAgentDir(originalAgentDir);
+		}
+	});
+
 	it("should have empty skills when options.skills is empty array (--no-skills)", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,


### PR DESCRIPTION
## Repro
Create or enable a skill after an `AgentSession` starts, then run `/reload-plugins` or invoke `manage_skill` and try `/skill:<name>` / `read skill://<name>` in the same session. Before this fix, `bun test packages/coding-agent/test/sdk-skills.test.ts -t refreshSkills` and `bun test packages/coding-agent/test/sdk-skills.test.ts -t manage_skill` both failed because the live skill snapshot stayed stale.

## Cause
`AgentSession` received a startup-only skill array, while the TUI, ACP, and RPC plugin reload paths refreshed slash commands and SSH state but never rediscovered skills. `ManageSkillTool.execute` wrote managed `SKILL.md` files without notifying the owning session, and SDK tool/system-prompt closures retained the original array, leaving `session.skills`, the `skill://` active snapshot, `/skill:<name>` commands, and the system `<skills>` block out of sync.

## Fix
- Add `AgentSession.refreshSkills()` to rediscover enabled skills, replace warnings and active resolver state, and rebuild the base system prompt.
- Invoke skill refresh from TUI, ACP, RPC, plugin-setting, cwd-change, and `/reload-plugins` paths; rebuild interactive `/skill:<name>` commands from the refreshed session.
- Wire `manage_skill` create, update, and delete mutations to refresh the owning session immediately.
- Keep explicit SDK skill snapshots and `--no-skills` sessions fixed, and add regression coverage for add/remove reloads plus live managed-skill creation, deletion, prompt updates, and `skill://` resolution.

## Verification
`bun test packages/coding-agent/test/sdk-skills.test.ts packages/coding-agent/test/skills.test.ts packages/coding-agent/test/rpc-skill-command.test.ts packages/coding-agent/test/autolearn-tools-gating.test.ts` — 71 passed, 0 failed. `bun check` passed across all packages. Fixes #4996