### PR TITLE
fix(auth): route OSC 5522 paste into login prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OSC 5522 paste in direct API-key login prompts being routed to the hidden main chat editor instead of the focused credential field ([#5394](https://github.com/can1357/oh-my-pi/issues/5394)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/components/login-dialog.ts
@@ -164,6 +164,11 @@ export class LoginDialogComponent extends Container {
 		this.#tui.requestRender();
 	}
 
+	/** Route non-bracketed paste transports into the active login input. */
+	pasteText(text: string): void {
+		this.#input.pasteText(text);
+	}
+
 	handleInput(data: string): void {
 		const kb = getKeybindings();
 

--- a/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
@@ -1,8 +1,10 @@
 import { beforeAll, describe, expect, it, vi } from "bun:test";
+import { LoginDialogComponent } from "@oh-my-pi/pi-coding-agent/modes/components/login-dialog";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import type { TUI } from "@oh-my-pi/pi-tui";
 
 interface RenderableBlock {
 	render(width: number): string[];
@@ -112,5 +114,15 @@ describe("SelectorController login", () => {
 		expect(ctx.showStatus).toHaveBeenCalledWith("Login cancelled");
 		expect(editorSlot).toEqual([editor]);
 		expect(renderPresented(presentedBlocks)).not.toContain("Successfully logged in");
+	});
+	it("routes enhanced paste into a direct API-key prompt", async () => {
+		const tui = { requestRender: vi.fn() } as unknown as TUI;
+		const dialog = new LoginDialogComponent(tui, "openrouter", vi.fn());
+		const prompt = dialog.showPrompt("Paste your OpenRouter API key");
+
+		dialog.pasteText("OMP_PASTE_TEST_123");
+		dialog.handleInput("\n");
+
+		await expect(prompt).resolves.toBe("OMP_PASTE_TEST_123");
 	});
 });


### PR DESCRIPTION
## Repro
In Kitty with OSC 5522 enabled, `/login` focuses `LoginDialogComponent`; pasting into a direct API-key prompt leaves its field empty because the component does not expose the paste-target contract. The regression test reproduces this with `bun test packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts`, which failed with `TypeError: dialog.pasteText is not a function` before the fix.

## Cause
`InputController.#setupEnhancedPaste` routes text to the focused component only when it exposes `pasteText`. `SelectorController.#handleOAuthLogin` focuses `LoginDialogComponent`, but `packages/coding-agent/src/modes/components/login-dialog.ts` only forwarded keyboard input to its inner `Input`; OSC 5522 text therefore fell back to the detached main editor.

## Fix
- Forward non-bracketed paste payloads from `LoginDialogComponent.pasteText` to the inner credential `Input`.
- Cover direct API-key prompt submission with the OSC 5522 paste-target contract.
- Document the regression fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts` — 3 passed, 0 failed. `bun test packages/coding-agent/test/issue-2127-repro.test.ts packages/coding-agent/test/hook-input-timeout.test.ts packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts packages/tui/test/input.test.ts` — 25 passed, 0 failed. `bun run check:types` in `packages/coding-agent` completed successfully. The pre-publish `bun run fix` and `bun check` gates also passed.

Fixes #5394