### PR TITLE
feat: add sglang-strict thinkingFormat for SGLang hard thinking budgets

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -582,12 +582,13 @@ Reasoning / thinking:
 - `supportsReasoningEffort` — accept `reasoning_effort`. Default: auto (off for Grok, Z.ai/Zhipu, and Xiaomi MiMo).
 - `supportsReasoningParams` — whether request shaping may send reasoning params at all. Default: auto (off for GitHub Copilot chat-completions).
 - `reasoningEffortMap` — partial map from internal effort levels (`minimal|low|medium|high|xhigh|max`) to provider-specific strings (e.g. Fireworks GLM maps `minimal -> "none"`).
-- `thinkingFormat` — request shape for thinking: `"openai"` (`reasoning_effort`), `"openrouter"` (`reasoning: { effort }`), `"zai"` (`thinking: { type: "enabled" }`), `"qwen"` (top-level `enable_thinking`), or `"qwen-chat-template"` (`chat_template_kwargs.enable_thinking`). Default: `"openai"`.
+- `thinkingFormat` — request shape for thinking: `"openai"` (`reasoning_effort`), `"openrouter"` (`reasoning: { effort }`), `"zai"` (`thinking: { type: "enabled" }`), `"qwen"` (top-level `enable_thinking`), `"qwen-chat-template"` (`chat_template_kwargs.enable_thinking`), or `"sglang-strict"` (`custom_params.thinking_budget` from the model's `effortBudgets`; requires SGLang launched with `--enable-strict-thinking`). Default: `"openai"`.
 - `reasoningContentField` — assistant field carrying chain-of-thought: `"reasoning_content"`, `"reasoning"`, or `"reasoning_text"`. Default: auto.
 - `requiresReasoningContentForToolCalls` — assistant tool-call turns must round-trip the reasoning field (DeepSeek-R1, Kimi, OpenRouter when reasoning is on). Default: `false`.
 - `allowsSyntheticReasoningContentForToolCalls` — allow a placeholder reasoning field when a prior assistant tool-call turn lacks provider reasoning content. Default: `true`; set `false` for providers that validate the exact reasoning value.
 - `requiresAssistantContentForToolCalls` — assistant tool-call turns must include non-empty text content (Kimi). Default: `false`.
 - `whenThinking` — partial compat overrides applied only when a request actually engages thinking mode (deep-merged over the baseline compat).
+- `effortBudgets` — per-effort token budgets (`{ minimal: 256, low: 512, ... }`) for `mode: "budget"` thinking. Used by `"sglang-strict"` thinkingFormat to inject `custom_params.thinking_budget`.
 
 Tool / message normalization:
 

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -610,7 +610,23 @@ export function applyOpenAIExtraBody<P extends object>(
 	options?: OpenAIExtraBodyOptions,
 ): void {
 	if (!extraBody) return;
-	Object.assign(params, extraBody);
+	// Shallow-assign all extraBody fields EXCEPT known nested objects,
+	// then deep-merge those so dynamic per-request values injected by
+	// applyChatCompletionsCompatPolicy (custom_params.thinking_budget,
+	// chat_template_kwargs.enable_thinking) take precedence over static
+	// extraBody values.
+	const nestedKeys = ["custom_params", "chat_template_kwargs"] as const;
+	const shallow: Record<string, unknown> = {};
+	const p = params as Record<string, unknown>;
+	for (const [k, v] of Object.entries(extraBody)) {
+		if (nestedKeys.includes(k as (typeof nestedKeys)[number]) && typeof v === "object" && v !== null) {
+			// Deep-merge: static extraBody first, then dynamic params win.
+			p[k] = { ...(v as Record<string, unknown>), ...(typeof p[k] === "object" && p[k] !== null ? p[k] : {}) };
+		} else {
+			shallow[k] = v;
+		}
+	}
+	Object.assign(params, shallow);
 	if (options?.dropThinkingWhenReasoningEffort) {
 		const shaped = params as { reasoning_effort?: unknown; thinking?: unknown };
 		if (shaped.reasoning_effort !== undefined) {
@@ -638,6 +654,7 @@ export type OpenAICompletionsParams = Omit<ChatCompletionCreateParamsStreaming, 
 	reasoning_effort?: string | null;
 	service_tier?: ServiceTier;
 	tool_stream?: boolean;
+	custom_params?: { thinking_budget?: number; [key: string]: unknown };
 	provider?: OpenAICompat["openRouterRouting"];
 	providerOptions?: { gateway?: { only?: string[]; order?: string[] } };
 };
@@ -682,6 +699,7 @@ export interface OpenAICompatPolicy {
 		dialect: ResolvedOpenAISharedCompat["thinkingFormat"];
 		disableMode: OpenAIReasoningDisableMode;
 		omitReasoningEffort: boolean;
+		effortBudget?: number;
 		includeEncryptedReasoning: boolean;
 		filterReasoningHistory: boolean;
 		requiresReasoningContentForToolCalls: boolean;
@@ -804,6 +822,10 @@ export function resolveOpenAICompatPolicy<TApi extends Api>(
 			supportsParams: compat.supportsReasoningParams,
 			requestedEffort,
 			wireEffort,
+			effortBudget:
+				enabled && requestedEffort !== undefined
+					? model.thinking?.effortBudgets?.[requestedEffort as Effort]
+					: undefined,
 			enabled,
 			disabled,
 			disableReason: disableReason ?? (disabledWithoutRequest || disabledByNoneEffort ? "not-requested" : undefined),
@@ -853,6 +875,9 @@ function encodeChatCompletionsDisabledReasoning(
 			params.enable_thinking = false;
 			break;
 		case "qwen-template-false":
+			params.chat_template_kwargs = { ...params.chat_template_kwargs, enable_thinking: false };
+			break;
+		case "sglang-template-false":
 			params.chat_template_kwargs = { ...params.chat_template_kwargs, enable_thinking: false };
 			break;
 		case "openrouter-enabled-false":
@@ -940,6 +965,16 @@ export function applyChatCompletionsCompatPolicy(params: OpenAICompletionsParams
 					(params as typeof params & { reasoning?: { effort?: string } }).reasoning = {
 						effort: reasoning.wireEffort,
 					};
+				}
+				break;
+			case "sglang-template-false":
+				// SGLang strict thinking: inject custom_params.thinking_budget
+				// from the model's effortBudgets (resolved by internal effort
+				// level, not wireEffort). Merge with existing custom_params to
+				// preserve unrelated fields. Requires SGLang
+				// --enable-strict-thinking server-side.
+				if (reasoning.effortBudget !== undefined) {
+					params.custom_params = { ...params.custom_params, thinking_budget: reasoning.effortBudget };
 				}
 				break;
 			default:

--- a/packages/ai/test/sglang-strict-thinking.test.ts
+++ b/packages/ai/test/sglang-strict-thinking.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "bun:test";
+import { applyOpenAIExtraBody, applyChatCompletionsCompatPolicy, resolveOpenAICompatPolicy } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { OpenAICompletionsParams } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { Model, ModelSpec } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+
+/**
+ * These tests exercise the pure request-shaping functions directly,
+ * avoiding the streaming provider chain (and its native-addon dependency).
+ */
+function createModel(
+	effortBudgets?: Partial<Record<Effort, number>>,
+	extraCompat?: Partial<NonNullable<ModelSpec<"openai-completions">["compat"]>>,
+): Model<"openai-completions"> {
+	return buildModel({
+		id: "glm-5.2-v2",
+		name: "GLM-5.2 v2",
+		api: "openai-completions",
+		provider: "custom",
+		baseUrl: "https://proxy.example.com/v1",
+		reasoning: true,
+		thinking: {
+			mode: "budget",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			...(effortBudgets ? { effortBudgets } : {}),
+		},
+		compat: {
+			thinkingFormat: "sglang-strict",
+			supportsReasoningParams: true,
+			...extraCompat,
+		},
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100_000,
+		maxTokens: 20_000,
+	} as ModelSpec<"openai-completions">);
+}
+
+function buildParams(): OpenAICompletionsParams {
+	return {
+		model: "glm-5.2-v2",
+		messages: [],
+		stream: true,
+	};
+}
+
+describe("sglang-strict thinking format — resolver", () => {
+	it("maps thinkingFormat sglang-strict to disableMode sglang-template-false", () => {
+		const model = createModel();
+		const policy = resolveOpenAICompatPolicy(model, {
+			endpoint: "chat-completions",
+			reasoning: "high",
+		});
+		expect(policy.reasoning.dialect).toBe("sglang-strict");
+		expect(policy.reasoning.disableMode).toBe("sglang-template-false");
+	});
+});
+
+describe("sglang-strict thinking format — enabled reasoning", () => {
+	const budgets: Partial<Record<Effort, number>> = {
+		[Effort.Minimal]: 256,
+		[Effort.Low]: 512,
+		[Effort.Medium]: 1024,
+		[Effort.High]: 2048,
+		[Effort.XHigh]: 4096,
+	};
+
+	for (const [effort, expected] of [
+		["minimal", 256],
+		["low", 512],
+		["medium", 1024],
+		["high", 2048],
+		["xhigh", 4096],
+	] as const) {
+		it(`injects thinking_budget=${expected} for ${effort} effort`, () => {
+			const model = createModel(budgets);
+			const policy = resolveOpenAICompatPolicy(model, {
+				endpoint: "chat-completions",
+				reasoning: effort,
+			});
+			const params = buildParams();
+			applyChatCompletionsCompatPolicy(params, policy);
+			expect(params.custom_params).toEqual({ thinking_budget: expected });
+			expect(params.reasoning_effort).toBeUndefined();
+		});
+	}
+
+	it("omits custom_params when effortBudgets has no entry for the requested effort", () => {
+		const model = createModel({ [Effort.High]: 2048 });
+		const policy = resolveOpenAICompatPolicy(model, {
+			endpoint: "chat-completions",
+			reasoning: "medium",
+		});
+		const params = buildParams();
+		applyChatCompletionsCompatPolicy(params, policy);
+		expect(params.custom_params).toBeUndefined();
+	});
+});
+
+describe("sglang-strict thinking format — disabled reasoning", () => {
+	it("sends chat_template_kwargs.enable_thinking=false when reasoning is disabled", () => {
+		const model = createModel();
+		const policy = resolveOpenAICompatPolicy(model, {
+			endpoint: "chat-completions",
+			disableReasoning: true,
+		});
+		const params = buildParams();
+		applyChatCompletionsCompatPolicy(params, policy);
+		expect(params.chat_template_kwargs).toEqual({ enable_thinking: false });
+		expect(params.custom_params).toBeUndefined();
+		expect(params.reasoning_effort).toBeUndefined();
+	});
+});
+
+describe("sglang-strict thinking format — extraBody deep-merge", () => {
+	it("preserves dynamic thinking_budget over static extraBody custom_params", () => {
+		const model = createModel(
+			{ [Effort.Medium]: 1024 },
+			{
+				extraBody: {
+					custom_params: { thinking_budget: 99999, unrelated_param: "keep-me" },
+				},
+			},
+		);
+		const policy = resolveOpenAICompatPolicy(model, {
+			endpoint: "chat-completions",
+			reasoning: "medium",
+		});
+		const params = buildParams();
+		applyChatCompletionsCompatPolicy(params, policy);
+		applyOpenAIExtraBody(params, model.compat!.extraBody);
+		expect(params.custom_params).toEqual({ thinking_budget: 1024, unrelated_param: "keep-me" });
+	});
+
+	it("preserves dynamic enable_thinking=false over static extraBody chat_template_kwargs", () => {
+		const model = createModel(
+			undefined,
+			{
+				extraBody: {
+					chat_template_kwargs: { preserve_thinking: true, enable_thinking: true },
+				},
+			},
+		);
+		const policy = resolveOpenAICompatPolicy(model, {
+			endpoint: "chat-completions",
+			disableReasoning: true,
+		});
+		const params = buildParams();
+		applyChatCompletionsCompatPolicy(params, policy);
+		applyOpenAIExtraBody(params, model.compat!.extraBody);
+		expect(params.chat_template_kwargs).toEqual({ preserve_thinking: true, enable_thinking: false });
+	});
+
+	it("preserves unrelated static extraBody top-level fields", () => {
+		const model = createModel(
+			{ [Effort.High]: 2048 },
+			{
+				extraBody: {
+					top_level_field: "survive",
+					custom_params: { thinking_budget: 99999 },
+				},
+			},
+		);
+		const policy = resolveOpenAICompatPolicy(model, {
+			endpoint: "chat-completions",
+			reasoning: "high",
+		});
+		const params = buildParams();
+		applyChatCompletionsCompatPolicy(params, policy);
+		applyOpenAIExtraBody(params, model.compat!.extraBody);
+		expect((params as Record<string, unknown>).top_level_field).toBe("survive");
+		expect(params.custom_params).toEqual({ thinking_budget: 2048 });
+	});
+});

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -89,6 +89,8 @@ function resolveReasoningDisableMode(
 			return "qwen-enable-thinking-false";
 		case "qwen-chat-template":
 			return "qwen-template-false";
+		case "sglang-strict":
+			return "sglang-template-false";
 		default:
 			return "lowest-effort";
 	}

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -148,7 +148,7 @@ export interface Usage {
 	};
 }
 
-export type OpenAIReasoningFormat = "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template";
+export type OpenAIReasoningFormat = "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template" | "sglang-strict";
 
 export type OpenAIReasoningDisableMode =
 	| "omit"
@@ -156,7 +156,8 @@ export type OpenAIReasoningDisableMode =
 	| "openrouter-enabled-false"
 	| "zai-thinking-disabled"
 	| "qwen-enable-thinking-false"
-	| "qwen-template-false";
+	| "qwen-template-false"
+	| "sglang-template-false";
 
 export type OpenAIStreamMarkupHealingPattern = "kimi" | "dsml" | "thinking";
 
@@ -205,7 +206,7 @@ export interface OpenAICompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether tool call IDs must be normalized to Mistral format (exactly 9 alphanumeric chars). Default: auto-detected from URL. */
 	requiresMistralToolIds?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses thinking: { type: "enabled" | "disabled" } (also used by Moonshot Kimi), "qwen" uses top-level enable_thinking, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
+	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses thinking: { type: "enabled" | "disabled" } (also used by Moonshot Kimi), "qwen" uses top-level enable_thinking, "qwen-chat-template" uses chat_template_kwargs.enable_thinking, and "sglang-strict" uses custom_params.thinking_budget from the model's effortBudgets (requires SGLang --enable-strict-thinking). Default: "openai". */
 	thinkingFormat?: OpenAIReasoningFormat;
 	/** Request-time disable encoding for the selected reasoning/thinking format. Default: derived from `thinkingFormat`. */
 	reasoningDisableMode?: OpenAIReasoningDisableMode;

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -46,7 +46,7 @@ const OpenAICompatFields = {
 	"supportsForcedToolChoice?": "boolean",
 	"disableReasoningOnForcedToolChoice?": "boolean",
 	"disableReasoningOnToolChoice?": "boolean",
-	"thinkingFormat?": '"openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template"',
+	"thinkingFormat?": '"openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template" | "sglang-strict"',
 	"openRouterRouting?": OpenRouterRoutingSchema,
 	"vercelGatewayRouting?": VercelGatewayRoutingSchema,
 	"extraBody?": { "[string]": "unknown" },
@@ -94,6 +94,7 @@ const ModelThinkingSchema = type({
 	"efforts?": EffortSchema.array(),
 	"defaultLevel?": EffortSchema,
 	"effortMap?": ReasoningEffortMapSchema,
+	"effortBudgets?": { "[string]": "number" },
 	"supportsDisplay?": "boolean",
 	// Legacy range vocabulary (pre-efforts configs).
 	"minLevel?": EffortSchema,


### PR DESCRIPTION
## Summary

Adds a new `thinkingFormat: "sglang-strict"` for OpenAI-compatible providers backed by SGLang with `--enable-strict-thinking`. This enables **per-effort hard token ceilings** via `custom_params.thinking_budget`, as an alternative to the qualitative `reasoning_effort` string that GLM-5.2's chat template ignores at `low`/`medium` levels.

## Motivation

GLM-5.2 served via SGLang has a known issue: the model's chat template treats `reasoning_effort` as qualitative prompt injection (`low`/`medium` fall through to "Max"), and there's no hard thinking budget enforcement without `--enable-strict-thinking`. This format:

- **Enabled**: injects `custom_params.thinking_budget: N` from `model.thinking.effortBudgets[effort]`
- **Disabled**: sends `chat_template_kwargs: { enable_thinking: false }`

## Changes

- `OpenAIReasoningFormat`: add `"sglang-strict"`
- `OpenAIReasoningDisableMode`: add `"sglang-template-false"`
- `resolveReasoningDisableMode`: map `sglang-strict` → `sglang-template-false`
- `OpenAICompletionsParams`: add `custom_params` field
- `resolveOpenAICompatPolicy`: resolve `effortBudget` from `model.thinking.effortBudgets`, keyed by internal effort level (not `wireEffort`, which may be remapped by `reasoningEffortMap`)
- `applyChatCompletionsCompatPolicy`: inject `custom_params.thinking_budget` for enabled reasoning; `chat_template_kwargs.enable_thinking=false` for disabled
- `applyOpenAIExtraBody`: deep-merge `custom_params` and `chat_template_kwargs` so dynamic per-request values take precedence over static `extraBody` values
- `models-config-schema`: accept `"sglang-strict"` in `thinkingFormat` and `effortBudgets` on thinking config
- `docs/models.md`: document new format and `effortBudgets` field

## Example models.yml

```yaml
providers:
  cloud-litellm:
    models:
      - id: glm-5.2-v2
        reasoning: true
        thinking:
          mode: budget
          efforts: [minimal, low, medium, high, xhigh]
          effortBudgets:
            minimal: 256
            low: 512
            medium: 1024
            high: 2048
            xhigh: 4096
        compat:
          thinkingFormat: sglang-strict
```

## Test plan

- [x] Typecheck passes (all 3 packages: ai, catalog, coding-agent)
- [ ] Pure-function serialization tests (blocked by native addon build locally; CI will verify)
  - 5 effort tiers emit correct `custom_params.thinking_budget`
  - Off path emits `chat_template_kwargs.enable_thinking=false`
  - `extraBody` deep-merge preserves dynamic values over static
  - Unrelated `extraBody` fields survive