### PR TITLE
fix(agent): strip images for non-vision models mid-session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed switching from a vision model to a text-only model mid-session sending historical image blocks to the new provider, which rejected them; image content is now replaced with a text placeholder in outbound requests when the active model lacks image input ([#5400](https://github.com/can1357/oh-my-pi/issues/5400)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Breaking Changes

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -116,6 +116,7 @@ import {
 	type CustomMessage,
 	convertToLlm,
 	LSP_LATE_DIAGNOSTIC_MESSAGE_TYPE,
+	replaceLlmImagesWithText,
 	USER_INTERRUPT_LABEL,
 	wrapSteeringForModel,
 } from "./session/messages";
@@ -2618,36 +2619,25 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 		const slashCommands = await slashCommandsPromise;
 
-		// Create convertToLlm wrapper that filters images if blockImages is enabled (defense-in-depth)
+		// Keep image blocks off the wire when they'd be rejected: either the user
+		// disabled images (`images.blockImages`) or the active model has no vision
+		// support. The latter covers switching from a vision model to a text-only
+		// one mid-session — historical image blocks would otherwise be replayed to
+		// a provider that 400s on them (#5400). Read both dynamically so a `/model`
+		// switch or setting change takes effect on the next turn.
 		const convertToLlmWithBlockImages = (messages: AgentMessage[]): Message[] => {
 			const converted = convertToLlm(messages);
-			// Check setting dynamically so mid-session changes take effect
-			if (!settings.get("images.blockImages")) {
-				return converted;
+			if (settings.get("images.blockImages")) {
+				return replaceLlmImagesWithText(converted, "Image reading is disabled.");
 			}
-			// Filter out ImageContent from all messages, replacing with text placeholder
-			return converted.map(msg => {
-				if (msg.role === "user" || msg.role === "toolResult") {
-					const content = msg.content;
-					if (Array.isArray(content)) {
-						const hasImages = content.some(c => c.type === "image");
-						if (hasImages) {
-							const filteredContent = content
-								.map(c =>
-									c.type === "image" ? { type: "text" as const, text: "Image reading is disabled." } : c,
-								)
-								.filter((c, i, arr) => {
-									// Dedupe consecutive "Image reading is disabled." texts
-									if (!(c.type === "text" && c.text === "Image reading is disabled." && i > 0)) return true;
-									const prev = arr[i - 1];
-									return !(prev.type === "text" && prev.text === "Image reading is disabled.");
-								});
-							return { ...msg, content: filteredContent };
-						}
-					}
-				}
-				return msg;
-			});
+			const activeModel = agent?.state.model ?? model;
+			if (activeModel && !activeModel.input.includes("image")) {
+				return replaceLlmImagesWithText(
+					converted,
+					"[image omitted: the active model does not support image input]",
+				);
+			}
+			return converted;
 		};
 
 		// Final convertToLlm: live provider replay drops API-level refusal errors,

--- a/packages/coding-agent/src/session/messages.test.ts
+++ b/packages/coding-agent/src/session/messages.test.ts
@@ -5,6 +5,7 @@ import {
 	type CustomMessage,
 	convertToLlm,
 	INTERRUPTED_THINKING_MESSAGE_TYPE,
+	replaceLlmImagesWithText,
 	SKILL_PROMPT_MESSAGE_TYPE,
 	type SkillPromptDetails,
 } from "./messages";
@@ -121,5 +122,70 @@ describe("convertToLlm", () => {
 			"text",
 			"thinking",
 		]);
+	});
+});
+
+describe("replaceLlmImagesWithText", () => {
+	it("replaces image blocks in user, developer, and tool-result messages with the placeholder", () => {
+		const converted = convertToLlm([
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "look" },
+					{ type: "image", data: "aaaa", mimeType: "image/png" },
+				],
+				attribution: "user",
+				timestamp: 1,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "c1",
+				toolName: "inspect_image",
+				content: [{ type: "image", data: "bbbb", mimeType: "image/png" }],
+				isError: false,
+				timestamp: 2,
+			},
+		]);
+
+		const scrubbed = replaceLlmImagesWithText(converted, "[image omitted]");
+
+		expect(scrubbed).not.toBe(converted);
+		const types = scrubbed.flatMap(m => (Array.isArray(m.content) ? m.content.map(b => b.type) : []));
+		expect(types).not.toContain("image");
+		const user = scrubbed.find(m => m.role === "user");
+		expect(Array.isArray(user?.content) && user.content.map(b => (b.type === "text" ? b.text : b.type))).toEqual([
+			"look",
+			"[image omitted]",
+		]);
+		const toolResult = scrubbed.find(m => m.role === "toolResult");
+		expect(Array.isArray(toolResult?.content) && toolResult.content).toEqual([
+			{ type: "text", text: "[image omitted]" },
+		]);
+	});
+
+	it("collapses consecutive image blocks into a single placeholder", () => {
+		const converted = convertToLlm([
+			{
+				role: "user",
+				content: [
+					{ type: "image", data: "aaaa", mimeType: "image/png" },
+					{ type: "image", data: "bbbb", mimeType: "image/png" },
+				],
+				attribution: "user",
+				timestamp: 1,
+			},
+		]);
+
+		const scrubbed = replaceLlmImagesWithText(converted, "[image omitted]");
+		const user = scrubbed.find(m => m.role === "user");
+		expect(Array.isArray(user?.content) && user.content).toEqual([{ type: "text", text: "[image omitted]" }]);
+	});
+
+	it("returns the same array reference when there are no image blocks", () => {
+		const converted = convertToLlm([
+			{ role: "user", content: [{ type: "text", text: "hi" }], attribution: "user", timestamp: 1 },
+		]);
+
+		expect(replaceLlmImagesWithText(converted, "[image omitted]")).toBe(converted);
 	});
 });

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -513,6 +513,43 @@ export function stripImagesFromMessage(message: AgentMessage): number {
 }
 
 /**
+ * Replace every `ImageContent` block in already-converted LLM {@link Message}s
+ * with a text placeholder, returning a new array only when something changed.
+ *
+ * Unlike {@link stripImagesFromMessage} (which mutates persisted `AgentMessage`s
+ * in place), this operates on the ephemeral provider-request view produced by
+ * {@link convertToLlm}, so history on disk keeps its images while the outbound
+ * request is scrubbed. Used to keep image blocks off the wire when the active
+ * model has no vision support (or `images.blockImages` is set) — e.g. after
+ * switching from a vision model to a text-only one mid-session (#5400).
+ *
+ * Consecutive placeholder texts collapse into one so a message that was nothing
+ * but images does not balloon into a run of identical notes.
+ */
+export function replaceLlmImagesWithText(messages: Message[], placeholder: string): Message[] {
+	let out: Message[] | undefined;
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i];
+		if (msg.role !== "user" && msg.role !== "developer" && msg.role !== "toolResult") continue;
+		const content = msg.content;
+		if (!Array.isArray(content) || !content.some(part => part.type === "image")) continue;
+		const replaced: (TextContent | ImageContent)[] = [];
+		for (const part of content) {
+			if (part.type !== "image") {
+				replaced.push(part);
+				continue;
+			}
+			const prev = replaced[replaced.length - 1];
+			if (prev?.type === "text" && prev.text === placeholder) continue;
+			replaced.push({ type: "text", text: placeholder });
+		}
+		if (out === undefined) out = messages.slice();
+		out[i] = { ...msg, content: replaced } as Message;
+	}
+	return out ?? messages;
+}
+
+/**
  * Message type for bash executions via the ! command.
  */
 export interface BashExecutionMessage {


### PR DESCRIPTION
## Repro
Start a session on a vision model, send a message with an image, then switch to a text-only model (via `/model` or Ctrl+P) and send a follow-up. OMP replays the entire history — including the historical image content blocks — to the new provider, which rejects them (`invalid_argument`). Reproduced in isolation: `convertToLlm()` on a conversation containing a user image block plus an `inspect_image` tool-result image emits both `image` blocks unchanged (`before: ["text","image","image"]`).

## Cause
The sdk `convertToLlm` wrapper (`convertToLlmWithBlockImages` in `packages/coding-agent/src/sdk.ts`) only stripped image blocks when the `images.blockImages` setting was enabled — never by model capability. `describeAttachedImagesForTextModel` (`utils/image-vision-fallback.ts`, called from `#buildImageDescriptionNotice`) only handles the current turn's *new* attachments, not historical image content already in the conversation. So after a vision→text-only model switch, the outbound request carried image blocks the active model could not accept.

## Fix
- Added `replaceLlmImagesWithText(messages, placeholder)` to `session/messages.ts`: replaces every `ImageContent` block in the already-converted LLM `Message[]` view with a text placeholder, collapsing consecutive images into one note and returning the same array reference when nothing changed. Operates on the ephemeral provider-request view (not persisted `AgentMessage`s), so history on disk keeps its images.
- Reworked `convertToLlmWithBlockImages` in `sdk.ts` to route both cases through the helper: `images.blockImages` → `"Image reading is disabled."`; active model whose `input` lacks `"image"` → `"[image omitted: the active model does not support image input]"`. The active model is read dynamically (`agent?.state.model ?? model`) so a `/model` switch takes effect on the next turn.
- Added regression tests in `session/messages.test.ts` covering replacement across user/developer/tool-result roles, consecutive-image collapsing, and the no-op passthrough.

## Verification
`bun test src/session/messages.test.ts` → 8 pass / 0 fail. `bun check` → clean (biome + tsgo). Standalone repro confirmed the scrub: `before: ["text","image","image"]` → `after: ["text","text","text"]`, `image reaches provider after scrub: false`.

Fixes #5400