### PR TITLE
fix(auth): serialize provider OAuth refreshes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed concurrent provider OAuth refreshes by serializing rotating-token updates across processes, fencing stale writes, and preventing background usage probes from disabling otherwise usable credentials ([#5396](https://github.com/can1357/oh-my-pi/issues/5396)).
+
 ## [16.5.0] - 2026-07-13
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -746,6 +746,8 @@ export interface InvalidateCredentialMatchingOptions {
 
 /** Options for refreshing one stored OAuth row through durable ownership. */
 export interface StoredOAuthRefreshOptions<T extends OAuthCredential = OAuthCredential> {
+	/** Stable row id when a provider has multiple OAuth credentials. */
+	credentialId?: number;
 	observedCredential?: T;
 	credentialFromRow: (credential: OAuthCredential) => T | undefined;
 	forceRefresh?: boolean;
@@ -1763,17 +1765,32 @@ export class AuthStorage {
 	}
 
 	/**
-	 * Persist a refreshed credential addressed by id, not a positional index.
-	 * A concurrent disable can reorder/shrink the provider's row array while an
-	 * async refresh is in flight, so a pre-await index is unsafe; resolving the
-	 * row by id at write time lands the rotated token on the correct row. Returns
-	 * the row's current index, or -1 when it was disabled/removed mid-refresh.
+	 * Persist a refreshed credential by id only while the row still matches this
+	 * process's snapshot. A peer rotation wins the CAS and is reloaded instead of
+	 * being overwritten after this process releases its refresh lease.
+	 *
+	 * Returns the row's current index, or -1 when it was disabled or removed.
 	 */
 	#replaceCredentialById(provider: string, id: number, credential: AuthCredential): number {
 		const entries = this.#getStoredCredentials(provider);
 		const index = entries.findIndex(entry => entry.id === id);
 		if (index === -1) return -1;
-		this.#store.updateAuthCredential(id, credential);
+		const expected = serializeCredential(provider, entries[index]!.credential);
+		if (
+			expected &&
+			this.#store.tryUpdateAuthCredentialIfMatches &&
+			!this.#store.tryUpdateAuthCredentialIfMatches(id, expected.data, credential)
+		) {
+			const latest = this.#store.listAuthCredentials(provider);
+			this.#setStoredCredentials(
+				provider,
+				latest.map(row => ({ id: row.id, credential: row.credential })),
+			);
+			return latest.findIndex(row => row.id === id);
+		}
+		if (!expected || !this.#store.tryUpdateAuthCredentialIfMatches) {
+			this.#store.updateAuthCredential(id, credential);
+		}
 		const updated = [...entries];
 		updated[index] = { id, credential };
 		this.#setStoredCredentials(provider, updated);
@@ -1906,7 +1923,11 @@ export class AuthStorage {
 				provider,
 				rows.map(row => ({ id: row.id, credential: row.credential })),
 			);
-			const row = rows.find(entry => entry.credential.type === "oauth");
+			const row = rows.find(
+				entry =>
+					entry.credential.type === "oauth" &&
+					(options.credentialId === undefined || entry.id === options.credentialId),
+			);
 			if (row?.credential.type !== "oauth") {
 				return { credential: undefined, refreshed: false, removed: false };
 			}
@@ -1945,7 +1966,11 @@ export class AuthStorage {
 				provider,
 				rows.map(row => ({ id: row.id, credential: row.credential })),
 			);
-			const row = rows.find(entry => entry.credential.type === "oauth");
+			const row = rows.find(
+				entry =>
+					entry.credential.type === "oauth" &&
+					(options.credentialId === undefined || entry.id === options.credentialId),
+			);
 			if (row?.credential.type !== "oauth") {
 				return { credential: undefined, refreshed: false, removed: false };
 			}
@@ -2526,25 +2551,15 @@ export class AuthStorage {
 	}
 
 	#persistRefreshedUsageCredential(provider: Provider, previous: UsageCredential, next: UsageCredential): void {
-		const entries = this.#getStoredCredentials(provider);
-		const index = entries.findIndex(entry => {
-			if (entry.credential.type !== "oauth") return false;
-			if (previous.refreshToken && entry.credential.refresh === previous.refreshToken) return true;
-			if (previous.accessToken && entry.credential.access === previous.accessToken) return true;
-			return (
-				entry.credential.accountId === previous.accountId &&
-				entry.credential.email === previous.email &&
-				entry.credential.projectId === previous.projectId
-			);
-		});
-		if (index === -1) return;
-		const existing = entries[index]!.credential;
-		if (existing.type !== "oauth") return;
-		this.#replaceCredentialAt(provider, index, {
+		const credentialId = this.#findStoredCredentialIdForUsageCredential(provider, previous);
+		if (credentialId === undefined) return;
+		const entry = this.#getStoredCredentials(provider).find(candidate => candidate.id === credentialId);
+		if (entry?.credential.type !== "oauth") return;
+		this.#replaceCredentialById(provider, credentialId, {
 			type: "oauth",
-			access: next.accessToken ?? existing.access,
-			refresh: next.refreshToken ?? existing.refresh,
-			expires: next.expiresAt ?? existing.expires,
+			access: next.accessToken ?? entry.credential.access,
+			refresh: next.refreshToken ?? entry.credential.refresh,
+			expires: next.expiresAt ?? entry.credential.expires,
 			accountId: next.accountId,
 			projectId: next.projectId,
 			email: next.email,
@@ -2598,46 +2613,9 @@ export class AuthStorage {
 					};
 				} catch (error) {
 					const errorMsg = String(error);
-					// Definitive failure (invalid_grant / 401 not from a network blip) means
-					// the refresh token itself is dead — probing with the original credential
-					// will 401, the catch below will return null, and #fetchUsageCached's
-					// last-good fallback will surface yesterday's report indefinitely
-					// (including its already-elapsed `resetsAt`). CAS-disable the row and
-					// clear the cache so the credential drops out of the report instead of
-					// freezing in place until the user notices and re-logs in.
-					if (AIError.isDefinitiveOAuthFailure(errorMsg)) {
-						const credentialId = this.#findStoredCredentialIdForUsageCredential(
-							request.provider,
-							request.credential,
-						);
-						if (credentialId !== undefined) {
-							const entries = this.#getStoredCredentials(request.provider);
-							const index = entries.findIndex(entry => entry.id === credentialId);
-							if (index !== -1) {
-								const disabled = this.#tryDisableCredentialAtIfMatches(
-									request.provider,
-									index,
-									refreshableCredential,
-									`oauth refresh failed during usage probe: ${errorMsg}`,
-								);
-								if (disabled) {
-									this.#usageLogger?.warn(
-										"Usage credential refresh failed definitively; credential disabled",
-										{ provider: request.provider, credentialId, error: errorMsg },
-									);
-									// Neutralize last-good for this cache key: write a null
-									// entry with an immediately-elapsed expiry so a future
-									// getStale lookup (e.g. on re-login under the same
-									// account identity) can't replay the stale report.
-									this.#usageCache.set(this.#buildUsageReportCacheKey(request), {
-										value: null,
-										expiresAt: 0,
-									});
-									return null;
-								}
-							}
-						}
-					}
+					// Usage polling is advisory. A refresh can fail while the current
+					// access token remains valid inside the refresh skew, so probe with
+					// that token and never mutate credential state from this path.
 					this.#usageLogger?.debug("Usage credential refresh failed, using original credential", {
 						provider: request.provider,
 						error: errorMsg,
@@ -3961,6 +3939,42 @@ export class AuthStorage {
 		credentialId: number | undefined,
 		signal?: AbortSignal,
 	): Promise<OAuthCredentials> {
+		const hasDurableLease =
+			!!this.#store.tryAcquireCredentialRefreshLease &&
+			!!this.#store.getCredentialRefreshLeaseExpiresAt &&
+			!!this.#store.releaseCredentialRefreshLease &&
+			!!this.#store.renewCredentialRefreshLease;
+		if (credentialId !== undefined && hasDurableLease) {
+			const forceRefresh = credential.expires === 0;
+			const result = await this.refreshStoredOAuthCredential(provider, {
+				credentialId,
+				observedCredential: forceRefresh ? undefined : credential,
+				credentialFromRow: row => row,
+				forceRefresh,
+				signal,
+				refresh: (current, refreshSignal) =>
+					this.#requestOAuthCredentialRefresh(
+						provider,
+						current,
+						credentialId,
+						signal && refreshSignal ? AbortSignal.any([signal, refreshSignal]) : (signal ?? refreshSignal),
+					),
+			});
+			if (result.credential) return result.credential;
+			throw new AIError.OAuthError(`OAuth credential no longer exists for provider: ${provider}`, {
+				kind: "token-refresh",
+				provider,
+			});
+		}
+		return this.#requestOAuthCredentialRefresh(provider, credential, credentialId, signal);
+	}
+
+	async #requestOAuthCredentialRefresh(
+		provider: Provider,
+		credential: OAuthCredential,
+		credentialId: number | undefined,
+		signal?: AbortSignal,
+	): Promise<OAuthCredentials> {
 		let refreshPromise: Promise<OAuthCredentials>;
 		// Caller override > store-level hook > local per-provider refresh.
 		// `RemoteAuthCredentialStore` exposes the hook so a broker-backed gateway
@@ -3986,10 +4000,9 @@ export class AuthStorage {
 		// Bound the refresh so a slow/hanging token endpoint cannot stall credential selection.
 		// Caller-driven abort jumps the gun on the timeout — the agent's ESC must
 		// take priority over the floor timeout.
-		let timeout: NodeJS.Timeout | undefined;
-		let onAbort: (() => void) | undefined;
 		const cancellation = Promise.withResolvers<never>();
-		timeout = setTimeout(
+		let onAbort: (() => void) | undefined;
+		const timeout = setTimeout(
 			() =>
 				cancellation.reject(
 					new AIError.OAuthError(`OAuth token refresh timed out for provider: ${provider}`, {
@@ -4010,7 +4023,7 @@ export class AuthStorage {
 		try {
 			return await Promise.race([refreshPromise, cancellation.promise]);
 		} finally {
-			if (timeout) clearTimeout(timeout);
+			clearTimeout(timeout);
 			if (signal && onAbort) signal.removeEventListener("abort", onAbort);
 		}
 	}

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -285,6 +285,113 @@ describe("AuthStorage OAuth refresh race", () => {
 		expect(refreshCalls).toBe(1);
 	});
 
+	test("serializes rotating provider refresh tokens across AuthStorage instances", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		const expires = Date.now() - 60_000;
+		const refreshedExpires = Date.now() + 60 * 60_000;
+		const usedRefreshTokens = new Set<string>();
+		let refreshCalls = 0;
+
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-cross-process",
+			name: "Unit OAuth Cross Process",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: refreshedExpires };
+			},
+			async refreshToken(credentials) {
+				refreshCalls += 1;
+				if (usedRefreshTokens.has(credentials.refresh)) {
+					throw new Error('HTTP 400 invalid_grant {"error":"invalid_grant"}');
+				}
+				usedRefreshTokens.add(credentials.refresh);
+				await Bun.sleep(50);
+				return {
+					...credentials,
+					access: "access-rotated",
+					refresh: "refresh-rotated",
+					expires: refreshedExpires,
+				};
+			},
+			getApiKey(credentials) {
+				return credentials.access;
+			},
+		});
+
+		await authStorage.set("unit-oauth-cross-process", [
+			{ type: "oauth", access: "access-old", refresh: "refresh-old", expires },
+		]);
+
+		const secondStore = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		const secondStorage = new AuthStorage(secondStore);
+		await secondStorage.reload();
+		try {
+			const [first, second] = await Promise.all([
+				authStorage.getApiKey("unit-oauth-cross-process", "session-first"),
+				secondStorage.getApiKey("unit-oauth-cross-process", "session-second"),
+			]);
+
+			expect(first).toBe("access-rotated");
+			expect(second).toBe("access-rotated");
+			expect(refreshCalls).toBe(1);
+			expect(secondStore.listAuthCredentials("unit-oauth-cross-process")).toHaveLength(1);
+		} finally {
+			secondStorage.close();
+		}
+	});
+
+	test("does not overwrite a peer rotation after releasing the refresh lease", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+		const sharedStore = store;
+
+		const expires = Date.now() - 60_000;
+		const refreshedExpires = Date.now() + 60 * 60_000;
+		let credentialId: number | undefined;
+
+		oauthUtils.registerOAuthProvider({
+			id: "unit-oauth-post-lease-race",
+			name: "Unit OAuth Post-Lease Race",
+			sourceId: "auth-storage-oauth-refresh-race-test",
+			async login() {
+				return { access: "unused", refresh: "unused", expires: refreshedExpires };
+			},
+			async refreshToken(credentials) {
+				return {
+					...credentials,
+					access: "access-from-this-process",
+					refresh: "refresh-from-this-process",
+					expires: refreshedExpires,
+				};
+			},
+			getApiKey(credentials) {
+				if (credentialId === undefined) throw new Error("credential id not initialized");
+				sharedStore.updateAuthCredential(credentialId, {
+					type: "oauth",
+					access: "access-from-peer",
+					refresh: "refresh-from-peer",
+					expires: refreshedExpires,
+				});
+				return credentials.access;
+			},
+		});
+
+		await authStorage.set("unit-oauth-post-lease-race", [
+			{ type: "oauth", access: "access-old", refresh: "refresh-old", expires },
+		]);
+		credentialId = store.listAuthCredentials("unit-oauth-post-lease-race")[0]?.id;
+		expect(credentialId).toBeDefined();
+
+		const apiKey = await authStorage.getApiKey("unit-oauth-post-lease-race", "session-post-lease");
+		expect(apiKey).toBe("access-from-this-process");
+		const persisted = store.listAuthCredentials("unit-oauth-post-lease-race")[0]?.credential;
+		expect(persisted?.type).toBe("oauth");
+		if (persisted?.type === "oauth") {
+			expect(persisted.refresh).toBe("refresh-from-peer");
+			expect(persisted.access).toBe("access-from-peer");
+		}
+	});
+
 	test("syncs peer-updated SQLite OAuth rows before returning access tokens", async () => {
 		if (!authStorage || !store) throw new Error("test setup failed");
 

--- a/packages/ai/test/auth-storage-usage-cache.test.ts
+++ b/packages/ai/test/auth-storage-usage-cache.test.ts
@@ -531,39 +531,23 @@ describe("AuthStorage usage cache: header ingestion", () => {
 });
 
 describe("AuthStorage usage cache: terminal refresh failure", () => {
-	// Regression: a revoked refresh token used to fail the in-line OAuth refresh
-	// inside the usage probe, get silently swallowed, then trigger the upstream
-	// 401 → null → last-good fallback chain. The credential was therefore never
-	// removed from the candidate set and the /usage TUI kept rendering yesterday's
-	// report — including its now-elapsed `resetsAt`, which the renderer printed
-	// as e.g. `(-612090ms)`. The fix CAS-disables the row on a definitive refresh
-	// failure and clears the cache, so the credential drops out cleanly.
-	it("disables credential and suppresses last-good when OAuth refresh fails with invalid_grant", async () => {
-		// Row whose access token has just expired — within the 60s refresh skew so
-		// the usage probe is forced to refresh before issuing the upstream call.
+	// Usage polling is non-critical: refresh failure must not disable a
+	// credential whose current access token can still satisfy the probe.
+	it("keeps credential and probes with current access after a definitive refresh failure", async () => {
 		const row = oauthRow(1, "a@example.com");
-		(row.credential as { expires: number }).expires = Date.now() - 1000;
+		if (row.credential.type !== "oauth") throw new Error("expected OAuth test credential");
+		row.credential.expires = Date.now() + 30_000;
 		const rows = [row];
-
-		// `makeStore` returns `false` from `tryDisableAuthCredentialIfMatches`,
-		// which would short-circuit our disable. Use a local store that actually
-		// performs the soft-delete so we can observe the AuthStorage-side effects.
 		const cache = new Map<string, CacheEntry>();
 		let disableCalls = 0;
 		const store: ObservableStore = {
 			cache,
 			close() {},
-			listAuthCredentials: () => rows.filter(r => !r.disabledCause),
+			listAuthCredentials: () => rows.filter(candidate => !candidate.disabledCause),
 			updateAuthCredential() {},
-			deleteAuthCredential(id: number, cause: string) {
-				const target = rows.find(r => r.id === id);
-				if (target) target.disabledCause = cause;
-			},
-			tryDisableAuthCredentialIfMatches(id: number, _data: string, cause: string) {
+			deleteAuthCredential() {},
+			tryDisableAuthCredentialIfMatches() {
 				disableCalls += 1;
-				const target = rows.find(r => r.id === id);
-				if (!target) return false;
-				target.disabledCause = cause;
 				return true;
 			},
 			replaceAuthCredentialsForProvider: () => rows,
@@ -581,16 +565,6 @@ describe("AuthStorage usage cache: terminal refresh failure", () => {
 			cleanExpiredCache() {},
 		};
 
-		// Pre-populate the cache with a "last good" report whose inner expiresAt
-		// is in the past (so `get()` misses) but the entry is still reachable via
-		// `getStale()`. Mirrors what the prior poll would have written.
-		const lastGood = makeReport("a@example.com");
-		const cacheKey = "usage_cache:report:anthropic:default:oauth|account:account-1|email:a@example.com";
-		cache.set(cacheKey, {
-			value: JSON.stringify({ value: lastGood, expiresAt: 1 }),
-			expiresAtSec: Math.floor((Date.now() + 24 * 60 * 60_000) / 1000),
-		});
-
 		const storage = new AuthStorage(store, {
 			usageProviderResolver: provider => (provider === "anthropic" ? claudeUsage.claudeUsageProvider : undefined),
 			refreshOAuthCredential: async () => {
@@ -599,31 +573,18 @@ describe("AuthStorage usage cache: terminal refresh failure", () => {
 		});
 		await storage.reload();
 
-		const fetchSpy = vi.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage");
-
+		const fetchSpy = vi
+			.spyOn(claudeUsage.claudeUsageProvider, "fetchUsage")
+			.mockResolvedValue(makeReport("a@example.com"));
 		try {
 			const reports = anthropicReports(await storage.fetchUsageReports());
 
-			// No last-good fallback: the row was disabled before lastGood could leak.
-			expect(reports).toHaveLength(0);
-			// CAS disable was attempted exactly once on the failing row.
-			expect(disableCalls).toBe(1);
-			expect(rows[0].disabledCause).toContain("invalid_grant");
-			// Upstream probe is short-circuited — no point asking the provider
-			// with a credential we've just torn down.
-			expect(fetchSpy).not.toHaveBeenCalled();
-			// Cache entry was neutralized: a future `getStale` lookup (e.g. on
-			// re-login under the same account identity) returns null, not the
-			// stale report with its already-elapsed `resetsAt`.
-			const rawAfter = cache.get(cacheKey);
-			expect(rawAfter).toBeDefined();
-			const parsedAfter = JSON.parse(rawAfter!.value);
-			expect(parsedAfter.value).toBeNull();
-			// And a second poll surfaces nothing — the credential is gone from
-			// `listAuthCredentials`, so `#collectUsageRequests` doesn't even
-			// look it up.
-			const secondPoll = anthropicReports(await storage.fetchUsageReports());
-			expect(secondPoll).toHaveLength(0);
+			expect(reports).toHaveLength(1);
+			expect(reports[0]?.metadata?.email).toBe("a@example.com");
+			expect(disableCalls).toBe(0);
+			expect(rows[0]?.disabledCause).toBeNull();
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			expect(fetchSpy.mock.calls[0]?.[0].credential.accessToken).toBe("oat-1");
 		} finally {
 			storage.close();
 			vi.restoreAllMocks();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed backgrounded Bash blocks continuing to repaint with live output; they now freeze with a compact job notice while completion is delivered separately.
 - Fixed rendering, status display, and PTY control sequence formatting issues in the `launch` tool.
 - Fixed in-process shell builtins (including `stat`, `date`, `sed`, `mktemp`, `tail`, `find`, `base64`, and `ln`) to correctly detect and translate macOS/BSD-style arguments and flags, preventing failures caused by GNU-only assumptions.
+- Fixed concurrent provider OAuth refreshes from invalidating Anthropic's rotating refresh token, and prevented background usage probes from permanently disabling credentials after refresh failures ([#5396](https://github.com/can1357/oh-my-pi/issues/5396)).
 
 ### Removed
 


### PR DESCRIPTION
## Repro
An Anthropic OAuth row inside the 60-second refresh skew is refreshed by the background usage poller; when that refresh returns `invalid_grant`, the poller soft-disables the row even though its current access token can still serve the usage request. Reproduced with `bun test packages/ai/test/auth-storage-usage-cache.test.ts --test-name-pattern "disables credential and suppresses last-good when OAuth refresh fails with invalid_grant"`, whose previous contract asserted one disable call.

## Cause
Provider/model credential refreshes in `packages/ai/src/auth-storage.ts` used only `AuthStorage.#oauthCredentialRefreshInFlight`, so separate processes could redeem the same rotating refresh token and later overwrite a winner through unconditional persistence. The durable `AuthStorage.refreshStoredOAuthCredential` lease used by MCP was not wired into `#refreshOAuthCredentialUnshared`, while `#fetchUsageUncached` independently treated definitive refresh failures as authority to disable credentials.

## Fix
- Route persisted provider OAuth refreshes through the per-row SQLite refresh lease, re-read the targeted credential after acquiring ownership, and support providers with multiple OAuth rows.
- Fence every follow-up refreshed-credential write with compare-and-set so a peer rotation after lease release cannot be clobbered.
- Keep usage polling advisory: on refresh failure, probe with the current access token and leave credential lifecycle unchanged.
- Add multi-`AuthStorage`, post-lease stale-writer, and usage-probe regression coverage.

## Verification
`bun test packages/ai/test/auth-storage-oauth-refresh-race.test.ts packages/ai/test/auth-storage-usage-cache.test.ts packages/ai/test/auth-storage-force-refresh-rotate.test.ts packages/ai/test/auth-storage-refresh-skew.test.ts packages/ai/test/auth-storage-broker-no-sentinel.test.ts packages/ai/test/auth-storage-check-credentials.test.ts packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts` passed: 62 tests, 315 assertions, 0 failures. `bun check` passed for all packages. Fixes #5396