### PR TITLE
fix(coding-agent): accept silent advisor stops with output tokens

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the built-in advisor treating a deliberate silent review (an empty `stop` completion that still spent output/reasoning tokens) as a failed turn, which triggered spurious retries and an "unavailable" warning; only content-less stops with no output signal are now retried ([#5493](https://github.com/can1357/oh-my-pi/issues/5493)).
+
 ## [16.5.1] - 2026-07-14
 
 ### Changed

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1960,6 +1960,75 @@ describe("advisor", () => {
 			expect(runtime.backlog).toBe(0);
 		});
 
+		it("treats a content-less stop that generated output tokens as a successful silent review", async () => {
+			const turnErrors: unknown[] = [];
+			const failures: unknown[] = [];
+			const adviceNotes: string[] = [];
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			let promptCalls = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptCalls++;
+					state.messages.push({ role: "user", content: input, timestamp: promptCalls * 2 - 1 } as AgentMessage);
+					// A real model turn that CHOSE silence: it reasoned, spent
+					// output/reasoning tokens, and emitted no `advise` call. This is
+					// the documented verifier behavior, not a provider malfunction.
+					state.messages.push({
+						role: "assistant",
+						content: [],
+						api: "mock",
+						provider: "mock",
+						model: "mock-advisor",
+						usage: {
+							input: 1200,
+							output: 340,
+							cacheRead: 0,
+							cacheWrite: 0,
+							totalTokens: 1540,
+							reasoningTokens: 300,
+						},
+						stopReason: "stop",
+						timestamp: promptCalls * 2,
+					} as unknown as AgentMessage);
+					state.error = undefined;
+				},
+				abort: () => {},
+				reset: () => {
+					state.messages.length = 0;
+					state.error = undefined;
+				},
+				rollbackTo: count => {
+					state.messages.length = count;
+					state.error = undefined;
+				},
+				state,
+			};
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "Reply exactly: OK", timestamp: 1 } as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: note => adviceNotes.push(note),
+				onTurnError: error => {
+					turnErrors.push(error);
+				},
+				notifyFailure: error => {
+					failures.push(error);
+				},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await runtime.waitForCatchup(1000, 1);
+
+			// No retries, no failure hook, no unavailable notification.
+			expect(promptCalls).toBe(1);
+			expect(turnErrors).toEqual([]);
+			expect(failures).toEqual([]);
+			expect(adviceNotes).toEqual([]);
+			expect(runtime.backlog).toBe(0);
+		});
+
 		it("calls onTurnError with state.error before retrying the batch", async () => {
 			const promptInputs: string[] = [];
 			const turnErrors: unknown[] = [];

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -601,10 +601,26 @@ function getAdvisorEmptyResponseError(messages: readonly AgentMessage[]): Error 
 		sawAssistant = true;
 		if (message.stopReason !== "stop") return undefined;
 		if (hasAdvisorResponseContent(message)) return undefined;
+		// A content-less stop that still generated output tokens is a deliberate
+		// silent review — the documented verifier behavior ("prefer silence when
+		// the agent is on track"), not a provider malfunction. Only a stop that
+		// produced no output signal at all is a failed turn worth retrying (#5493).
+		if (producedAdvisorOutputSignal(message)) return undefined;
 	}
 	if (sawAssistant) return new Error("Advisor turn returned an empty stop response without advice");
 	if (messages.length > 0) return new Error("Advisor turn ended without an assistant response");
 	return undefined;
+}
+
+/**
+ * True when the assistant turn consumed output-side tokens (visible output or
+ * internal reasoning). Silent provider failures report zero here; a model that
+ * deliberately stayed silent still burns reasoning/output budget.
+ */
+function producedAdvisorOutputSignal(message: AssistantMessage): boolean {
+	const usage = message.usage;
+	if (!usage) return false;
+	return (usage.output ?? 0) > 0 || (usage.reasoningTokens ?? 0) > 0;
 }
 
 function hasAdvisorResponseContent(message: AssistantMessage): boolean {


### PR DESCRIPTION
## Repro
With the advisor enabled and the omp-verifier guidance that instructs it to stay silent when evidence is sufficient, a normal stop with no advice raised `Warning: advisor: Advisor "default" unavailable for openai-codex/gpt-5.6-sol: Advisor turn returned an empty stop response without advice`. A minimal `AdvisorRuntime` repro that drives a real model turn which reasoned, spent output/reasoning tokens, and emitted no `advise` call (`stopReason: "stop"`, empty content, non-zero `usage.output`) reproduces it:

```
$ bun test packages/coding-agent/repro-advisor.test.ts
expect(promptCalls).toBe(1)
Expected: 1
Received: 3   # two spurious retries, then the "unavailable" notify
```

## Cause
`getAdvisorEmptyResponseError` in `packages/coding-agent/src/advisor/runtime.ts` (added by `8608395` for #5212) rejected **every** content-less `stop` completion as a failed turn. It could not distinguish a silent provider malfunction (produced nothing) from a deliberate silent review (the documented verifier behavior — "prefer silence when the agent is on track"), so both were retried twice and dropped into the `unavailable` warning.

## Fix
- `getAdvisorEmptyResponseError` now also returns `undefined` (success) for a content-less stop that carries an output signal, via a new `producedAdvisorOutputSignal` helper that checks `usage.output`/`usage.reasoningTokens > 0`. A malfunction (zero output tokens) is still treated as a failed turn and retried.
- Added a regression test asserting a token-bearing silent stop produces exactly one prompt, no `onTurnError`, no `notifyFailure`, and no advice — the existing #5212 test (zero-usage empty stop still fails) is unchanged.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts` → 94 pass / 0 fail. `bun --cwd=packages/coding-agent run check:types` → exit 0. Fixes #5493