### PR TITLE
fix(browser): keep Windows headless window off-screen

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added regression coverage and documentation for configuring OpenAI-compatible relay providers through `models.yml`, including provider-level `baseUrl`, `apiKey`, discovery, and selector availability.
+
+### Fixed
+
+- Fixed headless browser automation on Windows occasionally exposing a blank Chrome window by keeping its hidden native fallback surface off-screen. ([#5397](https://github.com/can1357/oh-my-pi/issues/5397))
+
 ## [16.5.1] - 2026-07-14
 
 ### Changed

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -30,6 +30,7 @@ export const DEFAULT_VIEWPORT = { width: 1365, height: 768, deviceScaleFactor: 1
  */
 export const BROWSER_PROTOCOL_TIMEOUT_MS = 60_000;
 const ENABLE_AUTOMATION_FLAG = "--enable-automation";
+const WINDOWS_HEADLESS_WINDOW_POSITION_ARG = "--window-position=-10000,-10000";
 // Automation-tell launch flags that puppeteer-core adds by default. We suppress
 // them via `ignoreDefaultArgs` (the supported escape hatch) to mirror xxxx's
 // chromiumSwitches patch. `--enable-automation` is the loudest: it normally sets
@@ -280,20 +281,37 @@ export interface LaunchHeadlessOptions {
 	viewport?: { width: number; height: number; deviceScaleFactor?: number };
 }
 
-export async function launchHeadlessBrowser(opts: LaunchHeadlessOptions): Promise<Browser> {
+export interface BrowserLaunchConfig {
+	initialViewport: { width: number; height: number; deviceScaleFactor: number };
+	launchArgs: string[];
+}
+
+export function buildBrowserLaunchConfig(
+	opts: LaunchHeadlessOptions,
+	platform: NodeJS.Platform = process.platform,
+): BrowserLaunchConfig {
 	const vp = opts.viewport ?? DEFAULT_VIEWPORT;
 	const initialViewport = {
 		width: vp.width,
 		height: vp.height,
 		deviceScaleFactor: vp.deviceScaleFactor ?? DEFAULT_VIEWPORT.deviceScaleFactor,
 	};
-	const puppeteer = await loadPuppeteer();
 	const launchArgs = [
 		"--no-sandbox",
 		"--disable-setuid-sandbox",
 		"--disable-blink-features=AutomationControlled",
 		`--window-size=${initialViewport.width},${initialViewport.height}`,
 	];
+	// Unified headless Chrome still owns a hidden native window. Some Windows
+	// builds can compose and expose it as a blank white window (Chromium
+	// 359921643), so keep that fallback surface outside the visible desktop.
+	if (opts.headless && platform === "win32") launchArgs.push(WINDOWS_HEADLESS_WINDOW_POSITION_ARG);
+	return { initialViewport, launchArgs };
+}
+
+export async function launchHeadlessBrowser(opts: LaunchHeadlessOptions): Promise<Browser> {
+	const { initialViewport, launchArgs } = buildBrowserLaunchConfig(opts);
+	const puppeteer = await loadPuppeteer();
 	const proxy = process.env.PUPPETEER_PROXY;
 	if (proxy) {
 		launchArgs.push(`--proxy-server=${proxy}`);

--- a/packages/coding-agent/test/tools/browser-launch.test.ts
+++ b/packages/coding-agent/test/tools/browser-launch.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { stealthIgnoreDefaultArgsForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
+import {
+	buildBrowserLaunchConfig,
+	stealthIgnoreDefaultArgsForTest,
+} from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
 
 const AUTOMATION_FLAG = "--enable-automation";
 
@@ -31,5 +34,17 @@ describe("browser launch stealth defaults", () => {
 
 			expect(ignoreDefaultArgs).toContain(AUTOMATION_FLAG);
 		}
+	});
+});
+
+describe("browser launch platform safety", () => {
+	it("moves only the Windows headless fallback window off-screen", () => {
+		const windowsHeadless = buildBrowserLaunchConfig({ headless: true }, "win32");
+		const windowsVisible = buildBrowserLaunchConfig({ headless: false }, "win32");
+		const linuxHeadless = buildBrowserLaunchConfig({ headless: true }, "linux");
+
+		expect(windowsHeadless.launchArgs).toContain("--window-position=-10000,-10000");
+		expect(windowsVisible.launchArgs).not.toContain("--window-position=-10000,-10000");
+		expect(linuxHeadless.launchArgs).not.toContain("--window-position=-10000,-10000");
 	});
 });


### PR DESCRIPTION
## Summary

- keep unified-headless Chrome's hidden native fallback window off-screen on Windows
- leave visible browser, spawned-app, and CDP-attached modes unchanged
- add regression coverage for the platform/mode boundary and an Unreleased changelog entry

## Root cause

Unified headless Chrome still creates a hidden native top-level window. Chromium documents that affected Windows builds can compose that hidden window and expose it as a blank white surface (`SetWindowDisplayAffinity`, Chromium issue 359921643; fixed upstream in chromium/src@44faa98aeb3f970cb12022426c09dbbcd80a0213).

Oh My Pi's browser registry is process-global and intentionally shared by main, task/subagent, and vibe sessions. Those longer-lived/concurrent workflows make the Chrome surface easier to notice, but the existing owner-scoped teardown is intact; this is not an unrelated-process or post-exit leak. The launch workaround positions only OMP-owned Windows headless windows off-screen, so affected browser builds cannot expose desktop UI.

## Verification

- `bun test packages/coding-agent/test/tools/browser-launch.test.ts`
- `bun run check:types` in `packages/coding-agent`
- Windows 11 smoke: launched the real OMP Puppeteer path against system Chrome 150, loaded a data URL, confirmed `--window-position=-10000,-10000`, and confirmed the Chrome process tree had no visible main window

Closes #5397