### PR TITLE
fix(advisor): accept silent reasoning stops as valid reviews

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the advisor treating a deliberate silent review from a reasoning model (empty `stop` completion that still spent output/reasoning tokens) as an empty-response failure, which surfaced `Advisor unavailable for … Advisor turn returned an empty stop response without advice` and disabled advice with models such as `openai-codex/gpt-5.6-sol` ([#5521](https://github.com/can1357/oh-my-pi/issues/5521)).
+
 ## [16.5.1] - 2026-07-14
 
 ### Changed

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1960,6 +1960,67 @@ describe("advisor", () => {
 			expect(runtime.backlog).toBe(0);
 		});
 
+		it("accepts a silent empty stop that spent output tokens as a successful review", async () => {
+			const promptInputs: string[] = [];
+			const turnErrors: unknown[] = [];
+			const failures: unknown[] = [];
+			const state: { messages: AgentMessage[]; error?: string } = { messages: [] };
+			let promptCalls = 0;
+			const agent: AdvisorAgent = {
+				prompt: async input => {
+					promptCalls++;
+					promptInputs.push(input);
+					state.messages.push({ role: "user", content: input, timestamp: promptCalls * 2 - 1 } as AgentMessage);
+					state.messages.push({
+						role: "assistant",
+						content: [],
+						api: "mock",
+						provider: "mock",
+						model: "mock-advisor",
+						usage: {
+							input: 120,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							reasoningTokens: 640,
+							totalTokens: 760,
+						},
+						stopReason: "stop",
+						timestamp: promptCalls * 2,
+					} as unknown as AgentMessage);
+					state.error = undefined;
+				},
+				abort: () => {},
+				reset: () => {
+					state.messages.length = 0;
+					state.error = undefined;
+				},
+				state,
+			};
+			const messages: AgentMessage[] = [{ role: "user", content: "aaa", timestamp: 1 } as AgentMessage];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+				onTurnError: error => {
+					turnErrors.push(error);
+				},
+				notifyFailure: error => {
+					failures.push(error);
+				},
+			};
+			const runtime = new AdvisorRuntime(agent, host, 0);
+
+			runtime.onTurnEnd(messages);
+			await runtime.waitForCatchup(1000, 1);
+
+			// A reasoning model that thought (reasoningTokens > 0) then chose to stay
+			// silent is a valid review, not a failed turn — no retry, no failure.
+			expect(promptInputs).toHaveLength(1);
+			expect(turnErrors).toEqual([]);
+			expect(failures).toEqual([]);
+			expect(runtime.backlog).toBe(0);
+		});
+
 		it("calls onTurnError with state.error before retrying the batch", async () => {
 			const promptInputs: string[] = [];
 			const turnErrors: unknown[] = [];

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -1960,7 +1960,16 @@ describe("advisor", () => {
 			expect(runtime.backlog).toBe(0);
 		});
 
-		it("accepts a silent empty stop that spent output tokens as a successful review", async () => {
+		it.each([
+			{ name: "output 0, no reasoning", output: 0, reasoningTokens: undefined, silent: false },
+			{ name: "output 1 (EOS-only), no reasoning", output: 1, reasoningTokens: undefined, silent: false },
+			{ name: "output 0, reasoning 640", output: 0, reasoningTokens: 640, silent: true },
+			{ name: "output 66, reasoning absent", output: 66, reasoningTokens: undefined, silent: true },
+		])("classifies a content-less advisor stop by billed work ($name)", async ({
+			output,
+			reasoningTokens,
+			silent,
+		}) => {
 			const promptInputs: string[] = [];
 			const turnErrors: unknown[] = [];
 			const failures: unknown[] = [];
@@ -1970,7 +1979,11 @@ describe("advisor", () => {
 				prompt: async input => {
 					promptCalls++;
 					promptInputs.push(input);
-					state.messages.push({ role: "user", content: input, timestamp: promptCalls * 2 - 1 } as AgentMessage);
+					state.messages.push({
+						role: "user",
+						content: input,
+						timestamp: promptCalls * 2 - 1,
+					} as AgentMessage);
 					state.messages.push({
 						role: "assistant",
 						content: [],
@@ -1979,11 +1992,11 @@ describe("advisor", () => {
 						model: "mock-advisor",
 						usage: {
 							input: 120,
-							output: 0,
+							output,
 							cacheRead: 0,
 							cacheWrite: 0,
-							reasoningTokens: 640,
-							totalTokens: 760,
+							...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+							totalTokens: 120 + output,
 						},
 						stopReason: "stop",
 						timestamp: promptCalls * 2,
@@ -1993,6 +2006,10 @@ describe("advisor", () => {
 				abort: () => {},
 				reset: () => {
 					state.messages.length = 0;
+					state.error = undefined;
+				},
+				rollbackTo: count => {
+					state.messages.length = count;
 					state.error = undefined;
 				},
 				state,
@@ -2013,11 +2030,25 @@ describe("advisor", () => {
 			runtime.onTurnEnd(messages);
 			await runtime.waitForCatchup(1000, 1);
 
-			// A reasoning model that thought (reasoningTokens > 0) then chose to stay
-			// silent is a valid review, not a failed turn — no retry, no failure.
-			expect(promptInputs).toHaveLength(1);
-			expect(turnErrors).toEqual([]);
-			expect(failures).toEqual([]);
+			if (silent) {
+				// A turn that spent reasoning tokens or more than one output token
+				// (past the terminal-EOS boundary) is a deliberate silent review:
+				// accepted as-is, no retry, no failure.
+				expect(promptInputs).toHaveLength(1);
+				expect(turnErrors).toEqual([]);
+				expect(failures).toEqual([]);
+			} else {
+				// Zero-work stops (no reasoning, output <= 1) are the #5212 broken
+				// provider response: retried to the drop threshold and reported.
+				expect(promptInputs).toHaveLength(3);
+				expect(turnErrors).toHaveLength(3);
+				expect(failures).toHaveLength(1);
+				for (const error of turnErrors) {
+					const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+					expect(message).toContain("empty");
+					expect(message).toContain("response");
+				}
+			}
 			expect(runtime.backlog).toBe(0);
 		});
 

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -601,10 +601,30 @@ function getAdvisorEmptyResponseError(messages: readonly AgentMessage[]): Error 
 		sawAssistant = true;
 		if (message.stopReason !== "stop") return undefined;
 		if (hasAdvisorResponseContent(message)) return undefined;
+		// An empty-content stop that still burned output/reasoning tokens is a
+		// deliberate silent review: the advisor is instructed to "prefer silence
+		// when the agent is on track", and reasoning models (e.g. codex
+		// gpt-5.6) routinely spend their turn thinking, then emit no visible
+		// content and skip `advise`. Only a stop with zero output tokens is the
+		// broken provider response from #5212 (HTTP 200, `content: []`, zero
+		// usage) that must be treated as a failed turn.
+		if (advisorTurnDidWork(message)) return undefined;
 	}
 	if (sawAssistant) return new Error("Advisor turn returned an empty stop response without advice");
 	if (messages.length > 0) return new Error("Advisor turn ended without an assistant response");
 	return undefined;
+}
+
+/**
+ * Whether an advisor assistant turn actually produced model output, measured by
+ * billed output/reasoning tokens. Distinguishes a deliberate silent review from
+ * a content-less HTTP-200 with zero usage (the broken provider response of
+ * #5212).
+ */
+function advisorTurnDidWork(message: AssistantMessage): boolean {
+	const usage = message.usage;
+	if (!usage) return false;
+	return usage.output > 0 || (usage.reasoningTokens ?? 0) > 0;
 }
 
 function hasAdvisorResponseContent(message: AssistantMessage): boolean {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -605,9 +605,9 @@ function getAdvisorEmptyResponseError(messages: readonly AgentMessage[]): Error 
 		// deliberate silent review: the advisor is instructed to "prefer silence
 		// when the agent is on track", and reasoning models (e.g. codex
 		// gpt-5.6) routinely spend their turn thinking, then emit no visible
-		// content and skip `advise`. Only a stop with zero output tokens is the
-		// broken provider response from #5212 (HTTP 200, `content: []`, zero
-		// usage) that must be treated as a failed turn.
+		// content and skip `advise`. A stop with no such work is the broken
+		// provider response from #5212 (HTTP 200, `content: []`, near-zero usage)
+		// that must be treated as a failed turn.
 		if (advisorTurnDidWork(message)) return undefined;
 	}
 	if (sawAssistant) return new Error("Advisor turn returned an empty stop response without advice");
@@ -618,13 +618,18 @@ function getAdvisorEmptyResponseError(messages: readonly AgentMessage[]): Error 
 /**
  * Whether an advisor assistant turn actually produced model output, measured by
  * billed output/reasoning tokens. Distinguishes a deliberate silent review from
- * a content-less HTTP-200 with zero usage (the broken provider response of
+ * a content-less HTTP-200 with near-zero usage (the broken provider response of
  * #5212).
+ *
+ * The `output > 1` boundary (not `> 0`) mirrors the shared empty-completion
+ * retry policy in `packages/ai/src/utils/empty-completion-retry.ts`, which
+ * treats `output <= 1` as an empty completion because some providers bill a
+ * single terminal EOS token on an otherwise-invisible stop.
  */
 function advisorTurnDidWork(message: AssistantMessage): boolean {
 	const usage = message.usage;
 	if (!usage) return false;
-	return usage.output > 0 || (usage.reasoningTokens ?? 0) > 0;
+	return (usage.reasoningTokens ?? 0) > 0 || usage.output > 1;
 }
 
 function hasAdvisorResponseContent(message: AssistantMessage): boolean {


### PR DESCRIPTION
## Repro
With `openai-codex/gpt-5.6-sol` on max reasoning as the advisor model, every advisor turn surfaced `Advisor unavailable for openai-codex/gpt-5.6-sol: Advisor turn returned an empty stop response without advice`, disabling advice. A reasoning model spends its turn thinking, then deliberately stays silent (the advisor is told to "prefer silence when the agent is on track"), producing an empty `stop` completion. A focused advisor-runtime regression reproduces it: `bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts -t "accepts a silent empty stop"` fails before the fix (`Expected length: 1, Received length: 3` — the silent turn is retried 3× and flagged as a failure).

## Cause
`getAdvisorEmptyResponseError` in `packages/coding-agent/src/advisor/runtime.ts` (added in PR #5216 for #5212) treats **every** content-less `stop` completion as a failed turn. But a deliberate silent review from a reasoning model has `content: []`, `stopReason: "stop"`, yet `usage.output`/`usage.reasoningTokens > 0`. #5212's actual bug was a broken HTTP-200 with `content: []` **and zero usage** — the discriminator is billed output/reasoning tokens, which the original check ignored.

## Fix
- `packages/coding-agent/src/advisor/runtime.ts`: added `advisorTurnDidWork(message)` — a content-less `stop` is only a failure when it produced zero output **and** zero reasoning tokens (the #5212 signature); a silent turn that actually spent tokens is accepted as a valid review.
- `packages/coding-agent/src/advisor/__tests__/advisor.test.ts`: added a regression test asserting a silent empty stop with `reasoningTokens > 0` yields exactly one prompt, no `onTurnError`, no `notifyFailure`, and zero backlog. The existing zero-usage empty-stop test (the #5212 case) still passes unchanged.
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased] > Fixed` entry.

## Verification
`bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts` → 94 pass, 0 fail. Confirmed the new test fails without the runtime change (silent turn retried 3× + flagged) and passes with it. `Fixes #5521`