### PR TITLE
Expose Terminal Focus Events to Extensions

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -312,7 +312,7 @@ Supported:
 - dialogs: `select`, `confirm`, `input`, `editor`
 - input editing: `setEditorText`, `getEditorText`, `pasteToEditor`, `editor`
 - autocomplete stacking: `addAutocompleteProvider(factory)` wraps the built-in editor provider (factories apply in registration order and re-apply on every slash-command refresh)
-- terminal title and working message (`setTitle`, `setWorkingMessage`)
+- terminal title, working message, and focus reports (`setTitle`, `setWorkingMessage`, `onTerminalFocusChange`)
 - notifications/status/editor text/terminal input/custom overlays
 - theme listing/loading by name (`setTheme` supports string names)
 - tools expanded toggle
@@ -334,6 +334,7 @@ Current no-op methods in this controller:
 Unsupported/no-op in RPC implementation:
 
 - `onTerminalInput`
+- `onTerminalFocusChange`
 - `custom`
 - `setFooter`, `setHeader`, `setEditorComponent`, `addAutocompleteProvider`
 - `setWorkingMessage`
@@ -346,7 +347,7 @@ When no UI context is supplied to runner init, `ctx.hasUI` is `false` and method
 
 ### ACP mode
 
-ACP installs an elicitation-bridged UI context (`createAcpExtensionUiContext` in `acp-agent.ts`). `ctx.hasUI` is `true` while only `select`/`confirm`/`input` round-trip (as ACP elicitations; defaults are returned when the client lacks the `elicitation.form` capability). The non-elicitation surface (widgets, editor, theming, terminal input, autocomplete stacking) is stubbed no-op.
+ACP installs an elicitation-bridged UI context (`createAcpExtensionUiContext` in `acp-agent.ts`). `ctx.hasUI` is `true` while only `select`/`confirm`/`input` round-trip (as ACP elicitations; defaults are returned when the client lacks the `elicitation.form` capability). The non-elicitation surface (widgets, editor, theming, terminal input/focus, autocomplete stacking) is stubbed no-op.
 
 ## Session and state patterns
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added extension access to resolved plugin settings and interactive terminal-focus notifications.
+
 ## [16.5.1] - 2026-07-14
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -21,7 +21,12 @@ import * as PiCodingAgent from "../../index";
 import type { CustomMessagePayload } from "../../session/messages";
 import { EventBus } from "../../utils/event-bus";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../plugins/legacy-pi-compat";
-import { getAllPluginExtensionPaths } from "../plugins/loader";
+import {
+	getAllPluginExtensionPaths,
+	getEnabledPlugins,
+	getPluginSettings,
+	resolvePluginExtensionPaths,
+} from "../plugins/loader";
 import * as TypeBox from "../typebox";
 
 import { resolvePath, withExitGuard } from "../utils";
@@ -138,6 +143,7 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		private readonly extension: Extension,
 		private readonly runtime: IExtensionRuntime,
 		private readonly cwd: string,
+		private readonly pluginSettings: Readonly<Record<string, unknown>>,
 		public readonly events: EventBus,
 	) {}
 
@@ -200,6 +206,10 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 	getFlag(name: string): boolean | string | undefined {
 		if (!this.extension.flags.has(name)) return undefined;
 		return this.runtime.flagValues.get(name);
+	}
+
+	getPluginSettings(): Readonly<Record<string, unknown>> {
+		return this.pluginSettings;
 	}
 
 	sendMessage<T = unknown>(
@@ -282,6 +292,18 @@ function createExtension(extensionPath: string, resolvedPath: string): Extension
 	};
 }
 
+async function getExtensionPluginSettings(
+	extensionPath: string,
+	cwd: string,
+): Promise<Readonly<Record<string, unknown>>> {
+	for (const plugin of await getEnabledPlugins(cwd)) {
+		if (resolvePluginExtensionPaths(plugin).includes(extensionPath)) {
+			return await getPluginSettings(plugin.name, cwd);
+		}
+	}
+	return {};
+}
+
 async function loadExtension(
 	extensionPath: string,
 	cwd: string,
@@ -301,7 +323,8 @@ async function loadExtension(
 		}
 
 		const extension = createExtension(extensionPath, resolvedPath);
-		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
+		const pluginSettings = await getExtensionPluginSettings(resolvedPath, cwd);
+		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, pluginSettings, eventBus);
 		await withExitGuard(async () => {
 			await factory(api);
 		});
@@ -324,7 +347,7 @@ export async function loadExtensionFromFactory(
 	name = "<inline>",
 ): Promise<Extension> {
 	const extension = createExtension(name, name);
-	const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
+	const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, {}, eventBus);
 	await factory(api);
 	return extension;
 }

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -197,6 +197,7 @@ const noOpUIContext: ExtensionUIContext = {
 	input: async (_title, _placeholder, _dialogOptions) => undefined,
 	notify: () => {},
 	onTerminalInput: () => () => {},
+	onTerminalFocusChange: () => () => {},
 	setStatus: () => {},
 	setWorkingMessage: () => {},
 	setWidget: () => {},

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -197,6 +197,8 @@ export interface ExtensionUIDialogOptions {
 
 /** Raw terminal input listener for extensions. */
 export type TerminalInputHandler = (data: string) => { consume?: boolean; data?: string } | undefined;
+/** Terminal focus listener for extensions. */
+export type TerminalFocusHandler = (focused: boolean) => void | Promise<void>;
 
 export type WidgetPlacement = "aboveEditor" | "belowEditor";
 
@@ -247,6 +249,9 @@ export interface ExtensionUIContext {
 
 	/** Listen to raw terminal input (interactive mode only). Returns an unsubscribe function. */
 	onTerminalInput(handler: TerminalInputHandler): () => void;
+
+	/** Listen to xterm focus reports (interactive mode only). Returns an unsubscribe function. */
+	onTerminalFocusChange(handler: TerminalFocusHandler): () => void;
 
 	/** Set status text in the footer/status bar. Pass undefined to clear. */
 	setStatus(key: string, text: string | undefined): void;
@@ -1146,6 +1151,9 @@ export interface ExtensionAPI {
 
 	/** Get the value of a registered CLI flag. */
 	getFlag(name: string): boolean | string | undefined;
+
+	/** Get resolved settings for the plugin that owns this extension. */
+	getPluginSettings(): Readonly<Record<string, unknown>>;
 
 	// =========================================================================
 	// Message Rendering

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -431,6 +431,7 @@ export function createAcpExtensionUiContext(
 			logger.debug("ACP extension notification", { message, type });
 		},
 		onTerminalInput: () => () => {},
+		onTerminalFocusChange: () => () => {},
 		setStatus: () => {},
 		setWorkingMessage: () => {},
 		setWidget: () => {},

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -18,6 +18,7 @@ import type {
 	ExtensionWidgetContent,
 	ExtensionWidgetOptions,
 	SendUserMessageHandler,
+	TerminalFocusHandler,
 	TerminalInputHandler,
 } from "../../extensibility/extensions";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
@@ -64,6 +65,7 @@ function toWireSelectOptions(options: ExtensionUISelectItem[]): CollabUiSelectIt
 
 export class ExtensionUiController {
 	#extensionTerminalInputUnsubscribers = new Set<() => void>();
+	#extensionTerminalFocusUnsubscribers = new Set<() => void>();
 	#hookWidgetsAbove = new Map<string, ExtensionUiComponent>();
 	#hookWidgetsBelow = new Map<string, ExtensionUiComponent>();
 	// Single-file dialog surface (`editorContainer` + focus) is shared by the
@@ -86,6 +88,7 @@ export class ExtensionUiController {
 			askDialog: (questions, dialogOptions) => this.showAskDialog(questions, dialogOptions),
 			notify: (message, type) => this.showHookNotify(message, type),
 			onTerminalInput: handler => this.addExtensionTerminalInputListener(handler),
+			onTerminalFocusChange: handler => this.addExtensionTerminalFocusListener(handler),
 			setStatus: (key, text) => this.setHookStatus(key, text),
 			setWorkingMessage: message => this.ctx.setWorkingMessage(message),
 			setWidget: (key, content, options) => this.setHookWidget(key, content, options),
@@ -1072,6 +1075,17 @@ export class ExtensionUiController {
 		};
 	}
 
+	addExtensionTerminalFocusListener(handler: TerminalFocusHandler): () => void {
+		if (!this.ctx.ui.terminal.onFocusChange) return () => {};
+
+		const unsubscribe = this.ctx.ui.terminal.onFocusChange(handler);
+		this.#extensionTerminalFocusUnsubscribers.add(unsubscribe);
+		return () => {
+			unsubscribe();
+			this.#extensionTerminalFocusUnsubscribers.delete(unsubscribe);
+		};
+	}
+
 	clearHookWidgets(): void {
 		for (const widget of this.#hookWidgetsAbove.values()) {
 			widget.dispose?.();
@@ -1089,6 +1103,10 @@ export class ExtensionUiController {
 			unsubscribe();
 		}
 		this.#extensionTerminalInputUnsubscribers.clear();
+		for (const unsubscribe of this.#extensionTerminalFocusUnsubscribers) {
+			unsubscribe();
+		}
+		this.#extensionTerminalFocusUnsubscribers.clear();
 	}
 
 	showExtensionError(extensionPath: string, error: string): void {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -749,6 +749,11 @@ export async function runRpcMode(
 			return () => {};
 		}
 
+		onTerminalFocusChange(): () => void {
+			// Terminal focus reports are not supported in RPC mode.
+			return () => {};
+		}
+
 		notify(message: string, type?: "info" | "warning" | "error"): void {
 			// Fire and forget - no response needed
 			this.output({

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1339,6 +1339,7 @@ const noOpUIContext: ExtensionUIContext = {
 	input: async (_title, _placeholder, _dialogOptions) => undefined,
 	notify: () => {},
 	onTerminalInput: () => () => {},
+	onTerminalFocusChange: () => () => {},
 	setStatus: () => {},
 	setWorkingMessage: () => {},
 	setWidget: () => {},

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -1178,6 +1178,7 @@ describe("ExtensionRunner", () => {
 					input: async () => undefined,
 					notify: () => {},
 					onTerminalInput: () => () => {},
+					onTerminalFocusChange: () => () => {},
 					setStatus: () => {},
 					setWorkingMessage: () => {},
 					setWidget: () => {},

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added extension-facing xterm focus reports with scoped DECSET 1004 lifecycle management.
+
 ## [16.5.1] - 2026-07-14
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -318,6 +318,7 @@ export function emergencyTerminalRestore(): void {
 					"\x1b[?5522l" + // Disable enhanced paste notifications
 					"\x1b[<u" + // Pop kitty keyboard protocol
 					"\x1b[>4;0m" + // Disable modifyOtherKeys fallback
+					"\x1b[?1004l" + // Disable focus reporting
 					"\x1b[?1006l\x1b[?1003l\x1b[?1000l" + // Disable mouse tracking (fullscreen overlays)
 					// Leave the alternate screen only when a fullscreen overlay
 					// actually holds it — on Windows, DECRST 1049 on the main
@@ -335,6 +336,7 @@ export function emergencyTerminalRestore(): void {
 		// Terminal may already be dead during crash cleanup - ignore errors
 	}
 }
+type TerminalFocusCallback = (focused: boolean) => void | Promise<void>;
 /** Terminal-reported appearance (dark/light mode). */
 export type TerminalAppearance = "dark" | "light";
 export interface Terminal {
@@ -410,8 +412,12 @@ export interface Terminal {
 	 * status resolves. Optional: only real terminals implement capability probing.
 	 */
 	onPrivateModeReport?(callback: (mode: number, supported: boolean) => void): void;
+	/**
+	 * Subscribe to xterm focus reports. The first subscriber enables DECSET
+	 * 1004; the final unsubscriber restores the terminal mode.
+	 */
+	onFocusChange?(callback: TerminalFocusCallback): () => void;
 }
-
 /**
  * True when stdout flows through a ConPTY pseudo-console (native win32, or
  * Linux running under WSL where stdout still crosses into ConPTY at the
@@ -498,6 +504,9 @@ export class ProcessTerminal implements Terminal {
 	/** Resolved DECRQM support per private mode (mode → supported). */
 	#privateModeSupport = new Map<number, boolean>();
 	#privateModeCallbacks: Array<(mode: number, supported: boolean) => void> = [];
+	#focusCallbacks: TerminalFocusCallback[] = [];
+	#focused: boolean | undefined;
+	#focusReportingActive = false;
 	/** Whether DEC 2048 in-band resize notifications are currently enabled. */
 	#inBandResizeActive = false;
 	/** Reassembly buffer for a DEC 2048 in-band resize report split across stdin reads. */
@@ -547,6 +556,26 @@ export class ProcessTerminal implements Terminal {
 				/* ignore callback errors */
 			}
 		}
+	}
+
+	onFocusChange(callback: TerminalFocusCallback): () => void {
+		this.#focusCallbacks.push(callback);
+		this.#setFocusReporting(true);
+		if (this.#focused !== undefined) {
+			try {
+				void Promise.resolve(callback(this.#focused)).catch(() => {});
+			} catch {
+				/* ignore callback errors */
+			}
+		}
+		let subscribed = true;
+		return () => {
+			if (!subscribed) return;
+			subscribed = false;
+			const index = this.#focusCallbacks.indexOf(callback);
+			if (index >= 0) this.#focusCallbacks.splice(index, 1);
+			if (this.#focusCallbacks.length === 0) this.#setFocusReporting(false);
+		};
 	}
 
 	onPrivateModeReport(callback: (mode: number, supported: boolean) => void): void {
@@ -610,6 +639,7 @@ export class ProcessTerminal implements Terminal {
 		// See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 		this.#queryAndEnableKittyProtocol();
 		setHangulCompatibilityJamoWidth(resolveHangulCompatibilityJamoWidthFromTerminalIdentity());
+		if (this.#focusCallbacks.length > 0) this.#setFocusReporting(true);
 
 		// Query terminal background color via OSC 11 for dark/light detection.
 		// Uses DA1 (Primary Device Attributes) as a sentinel: terminals process
@@ -765,6 +795,15 @@ export class ProcessTerminal implements Terminal {
 				if (this.#inputHandler) {
 					this.#inputHandler(sequence);
 				}
+				return;
+			}
+
+			if (this.#focusReportingActive && sequence === "\x1b[I") {
+				this.#handleFocusChange(true);
+				return;
+			}
+			if (this.#focusReportingActive && sequence === "\x1b[O") {
+				this.#handleFocusChange(false);
 				return;
 			}
 
@@ -1349,6 +1388,11 @@ export class ProcessTerminal implements Terminal {
 			clearTimeout(this.#mode2031DebounceTimer);
 			this.#mode2031DebounceTimer = undefined;
 		}
+		if (this.#focusReportingActive) {
+			this.#safeWrite("\x1b[?1004l");
+			this.#focusReportingActive = false;
+		}
+		this.#focused = undefined;
 		this.#appearanceCallbacks = [];
 		this.#osc11Pending = false;
 		this.#clearWindowsTerminalAppearancePoll();
@@ -1413,6 +1457,24 @@ export class ProcessTerminal implements Terminal {
 		}
 		this.#stdoutErrorCleanup?.();
 		this.#stdoutErrorCleanup = undefined;
+	}
+
+	#setFocusReporting(active: boolean): void {
+		if (this.#headless || this.#focusReportingActive === active) return;
+		this.#safeWrite(active ? "\x1b[?1004h" : "\x1b[?1004l");
+		this.#focusReportingActive = active;
+	}
+
+	#handleFocusChange(focused: boolean): void {
+		if (this.#focused === focused) return;
+		this.#focused = focused;
+		for (const callback of this.#focusCallbacks) {
+			try {
+				void Promise.resolve(callback(focused)).catch(() => {});
+			} catch {
+				/* ignore callback errors */
+			}
+		}
 	}
 
 	#ensureStdoutErrorHandler(): void {

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -450,6 +450,33 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 		const pops = writes.filter(w => w === "\x1b[<u").length;
 		expect(pops).toBe(1);
 	});
+
+	it("enables and consumes focus reports only while an extension subscribes", () => {
+		const { terminal, writes, received } = setupTerminal();
+		const focusStates: boolean[] = [];
+
+		expect(writes).not.toContain("\x1b[?1004h");
+		process.stdin.emit("data", "\x1b[I");
+		expect(received).toContain("\x1b[I");
+		received.length = 0;
+
+		const unsubscribe = terminal.onFocusChange(focused => {
+			focusStates.push(focused);
+		});
+		const unsubscribeLast = terminal.onFocusChange(() => {});
+		process.stdin.emit("data", "\x1b[I");
+		process.stdin.emit("data", "\x1b[O");
+		unsubscribe();
+		expect(writes).not.toContain("\x1b[?1004l");
+		unsubscribeLast();
+		expect(writes).toContain("\x1b[?1004l");
+		terminal.stop();
+
+		expect(writes).toContain("\x1b[?1004h");
+		expect(focusStates).toEqual([true, false]);
+		expect(received).not.toContain("\x1b[I");
+		expect(received).not.toContain("\x1b[O");
+	});
 });
 
 describe("ProcessTerminal DECRQM + in-band resize (DEC 2026/2048)", () => {


### PR DESCRIPTION
## Related links

- Implements the runtime half of [klondikemarlen/omp-vscode-context#29](https://github.com/klondikemarlen/omp-vscode-context/issues/29).

## Context

Runtime extensions need terminal focus reports to route editor context to the OMP instance that most recently receives focus.

## Implementation

- Expose `ctx.ui.onTerminalFocusChange` in interactive mode, with safe no-ops elsewhere.
- Enable xterm DECSET 1004 only while listeners exist; consume focus reports before ordinary input; restore mode on cleanup.
- Expose resolved owning-plugin settings to extension APIs.

## Screenshots

N/A — terminal runtime API.

## Testing instructions

```bash
bun --cwd=packages/tui run check
bun --cwd=packages/coding-agent run check
bun --cwd=packages/tui test test/terminal-appearance.test.ts
bun --cwd=packages/coding-agent test test/extensions-runner.test.ts
```

Manual: load an extension that subscribes to `ctx.ui.onTerminalFocusChange`, focus its terminal, and verify the callback receives `true` without focus bytes entering the prompt.