### PR TITLE
fix(tools): strip stray leading colon from tool paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `read`, `edit`, and `grep` hard-failing on paths with a stray leading colon (e.g. `:/abs/path`, `:../rel`) that some models intermittently emit; the mangled prefix is now stripped before resolution ([#5508](https://github.com/can1357/oh-my-pi/issues/5508)).
+
 ## [16.5.1] - 2026-07-14
 
 ### Changed

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -147,8 +147,14 @@ export function expandTilde(filePath: string, home?: string): string {
 }
 
 export function expandPath(filePath: string): string {
+	// Some models intermittently prefix an otherwise-valid path with a stray
+	// `:` (e.g. `:/abs/path`, `:../rel`). No real path starts with `:` and it
+	// never begins a selector against an absolute/relative path, so strip it
+	// before resolution — mirroring the `@`-prefix normalization above and the
+	// implicit stripping `write` already tolerates (issue #5508).
+	const deColoned = /^:(?=[/~]|\.\.?\/)/.test(filePath) ? filePath.slice(1) : filePath;
 	const normalized = stripWindowsExtendedLengthPathPrefix(
-		stripFileUrl(normalizeUnicodeSpaces(normalizeAtPrefix(filePath))),
+		stripFileUrl(normalizeUnicodeSpaces(normalizeAtPrefix(deColoned))),
 	);
 	return expandTilde(normalized);
 }

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
 	probeLiteralPathExists,
+	resolveToCwd,
 	splitPathAndSel,
 	splitPathAndSelPreferringLiteral,
 } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
@@ -342,5 +344,109 @@ describe("literal colon filename resolution (issue #4618)", () => {
 			expect(rangedOutput).not.toContain("three");
 			expect(rangedOutput).not.toContain("four");
 		});
+	});
+});
+
+// Regression: some models intermittently prefix an otherwise-valid path with a
+// stray leading `:` (e.g. `:/abs/path`, `:../rel`). The literal `:/abs/path`
+// does not exist on disk, so the #4618 literal-preferring probe cannot save it;
+// `expandPath` strips the mangled prefix before resolution so `read`, `grep`,
+// and `edit` all open the intended file — see issue #5508.
+describe("leading-colon path recovery (issue #5508)", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "leading-colon-"));
+		await Settings.init({ inMemory: true, cwd: tmpDir });
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		await removeWithRetries(tmpDir);
+	});
+
+	function createSession(overrides: Partial<ToolSession> = {}): ToolSession {
+		return {
+			cwd: tmpDir,
+			hasUI: false,
+			enableLsp: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			getArtifactsDir: () => null,
+			getSessionId: () => null,
+			getPlanModeState: () => undefined,
+			settings: Settings.isolated({
+				"grep.contextBefore": 0,
+				"grep.contextAfter": 0,
+				"edit.mode": "patch",
+			}),
+			...overrides,
+		} as unknown as ToolSession;
+	}
+
+	it("strips a leading colon before an absolute path in resolveToCwd", () => {
+		expect(resolveToCwd(":/tmp/omp-colon-test.txt", tmpDir)).toBe("/tmp/omp-colon-test.txt");
+	});
+
+	it("strips a leading colon before `./` and `../` relative paths in resolveToCwd", () => {
+		expect(resolveToCwd(":./sub/file.md", tmpDir)).toBe(path.join(tmpDir, "sub/file.md"));
+		expect(resolveToCwd(":../sibling.md", tmpDir)).toBe(path.resolve(tmpDir, "../sibling.md"));
+	});
+
+	it("does not strip a colon that is not a mangled path prefix", () => {
+		// `:selector` shapes and bare tokens must round-trip unchanged — the
+		// lookahead only fires before `/`, `~/`, `./`, or `../`.
+		expect(resolveToCwd(":raw", tmpDir)).toBe(path.join(tmpDir, ":raw"));
+		expect(resolveToCwd(":name.txt", tmpDir)).toBe(path.join(tmpDir, ":name.txt"));
+	});
+
+	it("read opens a file addressed with a leading colon", async () => {
+		const abs = path.join(tmpDir, "colon-read.txt");
+		await Bun.write(abs, "test line A\ntest line B\n");
+
+		const result = await new ReadTool(createSession()).execute("read-leading-colon", { path: `:${abs}` });
+		const output = getText(result);
+
+		expect(output).toContain("test line A");
+		expect(output).not.toMatch(/not found/i);
+	});
+
+	it("read opens a relative file addressed with a leading colon", async () => {
+		await Bun.write(path.join(tmpDir, "rel.txt"), "relative body\n");
+
+		const result = await new ReadTool(createSession()).execute("read-leading-colon-rel", { path: ":./rel.txt" });
+		const output = getText(result);
+
+		expect(output).toContain("relative body");
+		expect(output).not.toMatch(/not found/i);
+	});
+
+	it("grep searches a file addressed with a leading colon", async () => {
+		const abs = path.join(tmpDir, "colon-grep.txt");
+		await Bun.write(abs, "needle here\nsecond line\n");
+
+		const result = await new GrepTool(createSession()).execute("grep-leading-colon", {
+			pattern: "needle",
+			path: `:${abs}`,
+		});
+		const output = getText(result);
+
+		expect(output).toContain("needle");
+		expect(output).not.toMatch(/not found/i);
+	});
+
+	it("edit updates a file addressed with a leading colon", async () => {
+		const abs = path.join(tmpDir, "colon-edit.txt");
+		await Bun.write(abs, "needle here\nsecond\n");
+
+		const result = await new EditTool(createSession()).execute("edit-leading-colon", {
+			path: `:${abs}`,
+			edits: [{ op: "update", diff: "@@\n-needle here\n+replaced" }],
+		});
+
+		expect(result.isError).toBeFalsy();
+		expect(getText(result)).not.toMatch(/not found/i);
+		expect(await Bun.file(abs).text()).toBe("replaced\nsecond\n");
 	});
 });


### PR DESCRIPTION
## Repro
`read`, `edit`, and `grep` hard-fail when a path carries a stray leading colon (e.g. `:/abs/path`, `:../rel`) that some models — observed with `kimi-for-coding-highspeed` — intermittently emit. The file exists at the colon-less path, but the tools return `Path ':...' not found` / `File not found: :...`.

```
$ bun run src/cli.ts read ":/tmp/omp-colon-test.txt"
Path ':/tmp/omp-colon-test.txt' not found
$ bun run src/cli.ts read ":../repo/AGENTS.md"
Path ':../repo/AGENTS.md' not found
# control (no colon) works
$ bun run src/cli.ts read "/tmp/omp-colon-test.txt"
[/tmp/omp-colon-test.txt#096A]
1:test line A
2:test line B
```

## Cause
This is distinct from the *trailing*-colon fix in #4618 (`splitPathAndSelPreferringLiteral`), which only recovers when the literal colon-path is a real file on disk. For a leading colon the literal `:/abs/path` does not exist, so `fs.stat` returns `ENOENT`, the selector peel proceeds, and the path is left empty. Critically, the reporter's suggested seam (`splitPathAndSel`) only covers `read`/`grep`: the `edit` tool never calls it — it resolves through `resolvePlanPath` → `resolveToCwd` → `expandPath`. `read` (`resolveReadPath`) and `grep` (`resolveToolSearchScope`) also funnel through `expandPath`. `resolveToCwd` left the colon intact, so resolution missed the real file in all three.

## Fix
- `packages/coding-agent/src/tools/path-utils.ts` — `expandPath` now strips a leading `:` when it precedes `/`, `~/`, `./`, or `../`, mirroring the existing `normalizeAtPrefix` `@`-prefix normalization. Placed at the shared resolution funnel so `read`, `edit`, and `grep` are all fixed in one place. The lookahead never fires for selector-shaped tokens (`:raw`, `:name.txt`), so trailing-selector and literal-colon semantics are preserved.
- `packages/coding-agent/test/tools/path-literal-colon-selector.test.ts` — new `leading-colon path recovery (issue #5508)` block: `resolveToCwd` strip (absolute + `./`/`../`), non-strip guard for `:raw`/`:name.txt`, and end-to-end `read`/`grep`/`edit` through the real tools.
- `packages/coding-agent/CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`.

## Verification
`bun test test/tools/path-literal-colon-selector.test.ts` → 29 pass / 0 fail (8 new). Confirmed non-tautological: stashing the `path-utils.ts` fix makes the 6 new behavior-asserting cases fail (read/grep/edit + `resolveToCwd`), and they pass with it. `bun check` (TS) green across the workspace. Pre-existing, unrelated `search-url-paths.test.ts` failure (`Cannot find module './tool-views.generated.js'`) reproduces identically on the clean tree and is not touched by this change. Fixes #5508