### PR TITLE
Run Plugin Uninstall Lifecycle Hooks

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/manager-uninstall-hook.test.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager-uninstall-hook.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const ORIGINAL_ENV = {
+	HOME: process.env.HOME,
+	XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+	PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+	OMP_PROFILE: process.env.OMP_PROFILE,
+	PI_PROFILE: process.env.PI_PROFILE,
+};
+
+function restoreEnv(): void {
+	for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
+test("PluginManager.uninstall runs lifecycle hook before removing package", async () => {
+	const root = await mkdtemp(path.join(tmpdir(), "omp-plugin-uninstall-hook-"));
+	const agentDir = path.join(root, "agent");
+	const projectDir = path.join(root, "project");
+	const markerPath = path.join(root, "uninstall-hook.json");
+	const pluginName = "hooked-plugin";
+
+	process.env.HOME = root;
+	process.env.XDG_DATA_HOME = path.join(root, "xdg-data");
+	process.env.PI_CODING_AGENT_DIR = agentDir;
+	delete process.env.OMP_PROFILE;
+	delete process.env.PI_PROFILE;
+
+	// Test changes environment before loading dir singletons; static imports would snapshot the wrong roots.
+	const dirs = await import("@oh-my-pi/pi-utils/dirs");
+	dirs.__resetDirsFromEnvForTests();
+
+	try {
+		// Test intentionally loads the manager after resetting plugin roots.
+		const { PluginManager } = await import("./manager");
+		const pluginsDir = dirs.getPluginsDir();
+		const pluginPath = path.join(dirs.getPluginsNodeModules(), pluginName);
+		await mkdir(pluginPath, { recursive: true });
+		await mkdir(projectDir, { recursive: true });
+		await writeFile(
+			path.join(pluginPath, "package.json"),
+			JSON.stringify({
+				name: pluginName,
+				version: "1.0.0",
+				type: "module",
+				omp: { version: "1.0.0", lifecycle: { uninstall: "./uninstall.mjs" } },
+			}),
+		);
+		await writeFile(
+			path.join(pluginPath, "uninstall.mjs"),
+			`import { access, writeFile } from "node:fs/promises";\nexport async function uninstall(ctx) {\n  await access(ctx.pluginPath + "/package.json");\n  await writeFile(${JSON.stringify(markerPath)}, JSON.stringify(ctx));\n}\n`,
+		);
+		await mkdir(pluginsDir, { recursive: true });
+		await writeFile(
+			dirs.getPluginsPackageJson(),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: { [pluginName]: "file:node_modules/hooked-plugin" },
+			}),
+		);
+
+		const manager = new PluginManager(projectDir);
+		await manager.uninstall(pluginName);
+
+		const hookContext = JSON.parse(await readFile(markerPath, "utf8"));
+		assert.equal(hookContext.cwd, projectDir);
+		assert.equal(hookContext.agentDir, agentDir);
+		assert.equal(hookContext.pluginPath, pluginPath);
+		await access(markerPath);
+	} finally {
+		restoreEnv();
+		dirs.__resetDirsFromEnvForTests();
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -1,7 +1,9 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
+	getAgentDir,
 	getPluginsDir,
 	getPluginsLockfile,
 	getPluginsNodeModules,
@@ -27,6 +29,7 @@ import type {
 	PluginManifest,
 	PluginRuntimeConfig,
 	PluginSettingSchema,
+	PluginUninstallContext,
 	ProjectPluginOverrides,
 } from "./types";
 
@@ -111,6 +114,14 @@ interface PluginPackageSnapshot {
 
 interface RuntimePackageJson {
 	name?: unknown;
+}
+
+interface PluginLifecycleModule {
+	uninstall?: (ctx: PluginUninstallContext) => Promise<void> | void;
+}
+
+function isPluginLifecycleModule(value: unknown): value is PluginLifecycleModule {
+	return value !== null && typeof value === "object" && "uninstall" in value;
 }
 // =============================================================================
 // Plugin Manager
@@ -625,12 +636,42 @@ export class PluginManager {
 		}
 	}
 
+	async #runUninstallHook(name: string): Promise<void> {
+		const pluginPath = path.join(getPluginsNodeModules(), name);
+		const packageJsonPath = path.join(pluginPath, "package.json");
+		let pluginPkg: { omp?: PluginManifest; pi?: PluginManifest };
+		try {
+			pluginPkg = await Bun.file(packageJsonPath).json();
+		} catch (err) {
+			if (isEnoent(err)) return;
+			throw err;
+		}
+
+		const hook = (pluginPkg.omp || pluginPkg.pi)?.lifecycle?.uninstall;
+		if (!hook) return;
+		if (path.isAbsolute(hook)) throw new Error(`Plugin uninstall hook for ${name} must be relative`);
+
+		const hookPath = path.resolve(pluginPath, hook);
+		const relativeHookPath = path.relative(pluginPath, hookPath);
+		if (relativeHookPath.startsWith("..") || path.isAbsolute(relativeHookPath)) {
+			throw new Error(`Plugin uninstall hook for ${name} must stay inside the plugin package`);
+		}
+
+		// Plugin hook paths come from the installed package manifest, so static import cannot name them.
+		const module = await import(pathToFileURL(hookPath).href);
+		if (!isPluginLifecycleModule(module) || typeof module.uninstall !== "function") {
+			throw new Error(`Plugin uninstall hook for ${name} must export uninstall(ctx)`);
+		}
+		await module.uninstall({ cwd: this.#cwd, agentDir: getAgentDir(), pluginPath });
+	}
+
 	/**
 	 * Uninstall a plugin.
 	 */
 	async uninstall(name: string): Promise<void> {
 		validatePackageName(name);
 		await this.#ensurePackageJson();
+		await this.#runUninstallHook(name);
 
 		const proc = Bun.spawn(["bun", "uninstall", name], {
 			cwd: getPluginsDir(),

--- a/packages/coding-agent/src/extensibility/plugins/types.ts
+++ b/packages/coding-agent/src/extensibility/plugins/types.ts
@@ -21,6 +21,17 @@ export interface PluginFeature {
 	commands?: string[];
 }
 
+export interface PluginLifecycle {
+	/** Module exporting `uninstall(ctx)`, called before the package is removed. */
+	uninstall?: string;
+}
+
+export interface PluginUninstallContext {
+	cwd: string;
+	agentDir: string;
+	pluginPath: string;
+}
+
 /**
  * Plugin manifest from package.json omp or pi field.
  */
@@ -40,6 +51,9 @@ export interface PluginManifest {
 	extensions?: string[];
 	/** Command files (relative paths from package root) */
 	commands?: string[];
+
+	/** Optional lifecycle hook modules. */
+	lifecycle?: PluginLifecycle;
 
 	/** Feature definitions for selective installation */
 	features?: Record<string, PluginFeature>;


### PR DESCRIPTION
## Related links

Fixes #5531

## Context

Plugins that generate user files need a cleanup path when users run `omp plugin uninstall <name>`. Without a lifecycle hook, generated files remain after the package is removed.

## Implementation

- Adds optional manifest support for `omp.lifecycle.uninstall` / `pi.lifecycle.uninstall`.
- Calls the hook before `bun uninstall` removes the package.
- Passes `{ cwd, agentDir, pluginPath }` to the hook.
- Aborts uninstall if the hook is invalid or fails, so cleanup is not silently skipped after package removal.
- Rejects absolute or package-escaping hook paths.
- Adds a regression test proving the hook sees the package before uninstall removes it.

## Testing instructions

Run:

```bash
cd packages/coding-agent
bun test src/extensibility/plugins/manager-uninstall-hook.test.ts
bunx biome check src/extensibility/plugins/manager.ts src/extensibility/plugins/types.ts src/extensibility/plugins/manager-uninstall-hook.test.ts
bun run check:types
```

Observed locally: all three passed.