### PR TITLE
fix(bash): resolve internal URLs in command substitutions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions ([#5535](https://github.com/can1357/oh-my-pi/issues/5535)).
+
 ## [16.5.2] - 2026-07-14
 
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -142,7 +142,14 @@ function unquoteToken(token: string): string {
 }
 
 function isInsideShellQuote(command: string, index: number): boolean {
-	let quote: "'" | '"' | undefined;
+	type ShellQuote = "'" | '"' | undefined;
+	interface CommandSubstitution {
+		outerQuote: ShellQuote;
+		depth: number;
+	}
+
+	let quote: ShellQuote;
+	const substitutions: CommandSubstitution[] = [];
 	for (let i = 0; i < index; i++) {
 		const char = command[i];
 		if (char === "\\" && quote !== "'") {
@@ -155,6 +162,25 @@ function isInsideShellQuote(command: string, index: number): boolean {
 		}
 		if (char === '"' && quote !== "'") {
 			quote = quote === '"' ? undefined : '"';
+			continue;
+		}
+		if (char === "$" && command[i + 1] === "(" && quote !== "'") {
+			substitutions.push({ outerQuote: quote, depth: 1 });
+			quote = undefined;
+			i++;
+			continue;
+		}
+		if (quote !== undefined) continue;
+
+		const substitution = substitutions.at(-1);
+		if (!substitution) continue;
+		if (char === "(") {
+			substitution.depth++;
+		} else if (char === ")") {
+			substitution.depth--;
+			if (substitution.depth === 0) {
+				quote = substitutions.pop()?.outerQuote;
+			}
 		}
 	}
 	return quote !== undefined;

--- a/packages/coding-agent/test/tools/bash-skill-urls.test.ts
+++ b/packages/coding-agent/test/tools/bash-skill-urls.test.ts
@@ -206,6 +206,16 @@ describe("expandInternalUrls", () => {
 		);
 	});
 
+	it("expands an unquoted URL inside a double-quoted command substitution", async () => {
+		const skills = [createSkill("valid-skill", "/tmp/skills/valid-skill")];
+		const command = 'echo "$(realpath skill://valid-skill/SKILL.md 2>&1)"';
+		const expectedPath = path.join(skills[0].baseDir, "SKILL.md");
+
+		await expect(expandInternalUrls(command, { skills })).resolves.toBe(
+			`echo "$(realpath ${shellEscape(expectedPath)} 2>&1)"`,
+		);
+	});
+
 	it("leaves literal internal URLs embedded in quoted text unchanged", async () => {
 		const router = createInternalRouter({
 			"memory://root/summary.md": { sourcePath: "/tmp/memories/summary.md" },


### PR DESCRIPTION
## Repro
`expandInternalUrls('echo "$(realpath skill://using-superpowers/SKILL.md 2>&1)"', { skills })` returned the command byte-for-byte unchanged, causing `realpath` to receive the literal internal URL; the same URL explicitly quoted inside `$(…)` resolved correctly.

## Cause
`isInsideShellQuote` in `packages/coding-agent/src/tools/bash-skill-urls.ts` tracked one quote state across the full command. An outer double quote therefore made an unquoted token inside `$(…)` look like quoted prose, and `isEmbeddedInQuotedText` skipped expansion.

## Fix
- Track independent quote state and parenthesis depth for nested command substitutions.
- Preserve the outer quote state when each substitution closes.
- Add regression coverage for an unquoted `skill://` argument inside a double-quoted `$(…)` expression.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/bash-skill-urls.test.ts` passed 33 tests. A direct smoke run expanded the reported command to `echo "$(realpath '/tmp/omp-5535/using-superpowers/SKILL.md' 2>&1)"`, executed it successfully, and printed the resolved filesystem path with exit code 0. The pre-publish `bun run fix` and `bun check` gate passed. Fixes #5535