### PR TITLE
feat(coding-agent): compose goal mode with vibe mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Goal mode now composes with vibe mode: `/goal` and `/vibe` can be active together, turning the vibe director into a goal-guided autonomous orchestrator. Goal prompts adapt to directing (verify with `read`, delegate checks to workers), goal auto-continuation defers while worker turns are in flight, worker-session token usage counts toward the goal budget, and the combined mode persists across session resume.
+
 ## [16.5.2] - 2026-07-14
 
 ### Breaking Changes

--- a/packages/coding-agent/src/goals/runtime.ts
+++ b/packages/coding-agent/src/goals/runtime.ts
@@ -8,6 +8,8 @@ export interface GoalRuntimeHost {
 	getState(): GoalModeState | undefined;
 	setState(state: GoalModeState | undefined): void;
 	getCurrentUsage(): GoalTokenUsage;
+	/** True while the session is in vibe mode (goal prompts switch to director guidance). */
+	isVibeModeActive?(): boolean;
 	emit(event: GoalRuntimeEvent): void | Promise<void>;
 	persist(mode: "goal" | "goal_paused" | "none", state?: GoalModeState): void;
 	sendHiddenMessage(message: {
@@ -76,7 +78,7 @@ export function goalTokenDelta(current: GoalTokenUsage, baseline: GoalTokenUsage
 	);
 }
 
-export function renderGoalPrompt(kind: GoalPromptKind, goal: Goal): string {
+export function renderGoalPrompt(kind: GoalPromptKind, goal: Goal, options?: { vibe?: boolean }): string {
 	const template =
 		kind === "active"
 			? goalModeActivePrompt
@@ -89,6 +91,7 @@ export function renderGoalPrompt(kind: GoalPromptKind, goal: Goal): string {
 		tokenBudget: budgetValue(goal),
 		remainingTokens: remainingValue(goal),
 		timeUsedSeconds: String(goal.timeUsedSeconds),
+		vibe: options?.vibe === true,
 	});
 }
 
@@ -366,6 +369,38 @@ export class GoalRuntime {
 		await this.#withAccounting(() => this.#flushUsageLocked(steering, currentUsage));
 	}
 
+	/**
+	 * Account tokens consumed outside this session's own LLM stream (vibe worker
+	 * turns, delegated subagent work). Applies the same input+cacheWrite+output
+	 * rule as {@link goalTokenDelta}. Independent of the per-turn snapshot
+	 * accounting: external usage never appears in the host's getCurrentUsage()
+	 * stream, so the two paths cannot double-count.
+	 */
+	async addExternalUsage(usage: GoalTokenUsage): Promise<void> {
+		const tokens = goalTokenDelta(usage, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+		if (tokens <= 0 || !this.#hasAccountingState()) return;
+		await this.#withAccounting(async () => {
+			const state = this.#getStateClone();
+			if (!state?.enabled || !isAccountingStatus(state.goal)) return;
+			state.goal.tokensUsed += tokens;
+			state.goal.updatedAt = this.#now();
+			const flippedToBudgetLimited =
+				state.goal.tokenBudget !== undefined &&
+				state.goal.tokensUsed >= state.goal.tokenBudget &&
+				state.goal.status === "active";
+			if (flippedToBudgetLimited) {
+				state.goal.status = "budget-limited";
+			}
+			await this.#commitState(state, { persist: "goal" });
+			if (state.goal.status !== "budget-limited") {
+				this.#budgetReportedFor = undefined;
+			}
+			if (flippedToBudgetLimited) {
+				await this.#sendBudgetLimitSteer(state.goal);
+			}
+		});
+	}
+
 	#createGoalState(objective: string, tokenBudget: number | undefined): GoalModeState {
 		const now = this.#now();
 		const goal: Goal = {
@@ -495,17 +530,21 @@ export class GoalRuntime {
 		});
 	}
 
+	#promptOptions(): { vibe: boolean } {
+		return { vibe: this.#host.isVibeModeActive?.() === true };
+	}
+
 	buildActivePrompt(): string | undefined {
 		const state = this.#host.getState();
 		return state?.enabled && state.goal && state.goal.status === "active"
-			? renderGoalPrompt("active", state.goal)
+			? renderGoalPrompt("active", state.goal, this.#promptOptions())
 			: undefined;
 	}
 
 	buildContinuationPrompt(): string | undefined {
 		const state = this.#host.getState();
 		return state?.enabled && state.goal.status === "active"
-			? renderGoalPrompt("continuation", state.goal)
+			? renderGoalPrompt("continuation", state.goal, this.#promptOptions())
 			: undefined;
 	}
 
@@ -514,7 +553,7 @@ export class GoalRuntime {
 		this.#budgetReportedFor = goal.id;
 		await this.#host.sendHiddenMessage({
 			customType: "goal-budget-limit",
-			content: renderGoalPrompt("budget-limit", goal),
+			content: renderGoalPrompt("budget-limit", goal, this.#promptOptions()),
 			deliverAs: "steer",
 		});
 	}

--- a/packages/coding-agent/src/modes/components/status-line/component.test.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.test.ts
@@ -80,4 +80,35 @@ describe("StatusLineComponent", () => {
 		const stripped = border.content.replace(/\x1b\[[0-9;]*m/g, "");
 		expect(stripped).toContain("Prewalk");
 	});
+
+	it("shows the vibe marker inside the goal chip only while both modes are active", () => {
+		const sessionStub = makeSessionWithLastMessage(null) as Record<string, unknown>;
+		sessionStub.getGoalModeState = () => ({
+			enabled: true,
+			mode: "active",
+			goal: {
+				id: "g-1",
+				objective: "Ship the release",
+				status: "active",
+				tokensUsed: 5,
+				tokenBudget: 10,
+				timeUsedSeconds: 0,
+				createdAt: 0,
+				updatedAt: 0,
+			},
+		});
+		sessionStub.settings = Settings.isolated({});
+		const statusLine = new StatusLineComponent(sessionStub as unknown as AgentSession);
+
+		statusLine.setGoalModeStatus({ enabled: true, paused: false });
+		statusLine.setVibeModeStatus({ enabled: true });
+		const combined = statusLine.getTopBorder(160).content.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(combined).toContain("Goal");
+		expect(combined).toContain("Vibe");
+
+		statusLine.setVibeModeStatus(undefined);
+		const goalOnly = statusLine.getTopBorder(160).content.replace(/\x1b\[[0-9;]*m/g, "");
+		expect(goalOnly).toContain("Goal");
+		expect(goalOnly).not.toContain("Vibe");
+	});
 });

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -188,6 +188,9 @@ function renderGoalMode(ctx: SegmentContext, mode: { enabled: boolean; paused: b
 	}
 
 	const parts: string[] = [withIcon(icon, "Goal")];
+	if (ctx.vibeMode?.enabled) {
+		parts.push(withIcon(theme.icon.agents, "Vibe"));
+	}
 	const showBudget = ctx.session.settings.get("goal.statusInFooter") === true;
 	if (showBudget && goal) {
 		parts.push(formatGoalBudget(goal.tokensUsed, goal.tokenBudget));

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -530,8 +530,13 @@ export class InteractiveMode implements InteractiveModeContext {
 	readonly #version: string;
 	readonly #changelogMarkdown: string | undefined;
 	#planModePreviousTools: string[] | undefined;
-	#goalModePreviousTools: string[] | undefined;
-	#vibeModePreviousTools: string[] | undefined;
+	/**
+	 * Pre-restricted-mode toolset, captured once by whichever of vibe/goal mode
+	 * enters first (never contains "goal" or vibe tools), cleared when the last
+	 * of them exits. One shared baseline — separate per-mode "previous tools"
+	 * would capture each other's restricted sets when the modes compose.
+	 */
+	#modeBaselineTools: string[] | undefined;
 	#goalContinuationTimer: NodeJS.Timeout | undefined;
 	#goalTurnHadToolCalls = false;
 	#goalContinuationTurnInFlight = false;
@@ -1237,12 +1242,18 @@ export class InteractiveMode implements InteractiveModeContext {
 		if ((this.editor.pendingImages?.length ?? 0) > 0) return;
 		const state = this.session.getGoalModeState();
 		if (!state?.enabled || state.goal.status !== "active") return;
+		// In vibe mode, a worker turn in flight will wake the director on its own
+		// (async settle self-delivery); firing a continuation meanwhile just makes
+		// the director poll. A hung worker turn defers (not loses) continuation:
+		// any later agent_end or user input reschedules.
+		if (this.#vibeWorkerTurnInFlight()) return;
 		const prompt = this.session.goalRuntime.buildContinuationPrompt();
 		if (!prompt) return;
 		this.#goalContinuationTimer = setTimeout(() => {
 			this.#goalContinuationTimer = undefined;
 			if (!this.onInputCallback) return;
 			if (!this.goalModeEnabled || this.goalModePaused) return;
+			if (this.#vibeWorkerTurnInFlight()) return;
 			// The 800ms timer can outlive the idle window that scheduled it: a
 			// `/goal set` taken via the streaming branch (or any extension/hook
 			// path that starts a turn while we wait) leaves the agent busy. Firing
@@ -1272,6 +1283,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			clearTimeout(this.#goalContinuationTimer);
 			this.#goalContinuationTimer = undefined;
 		}
+	}
+
+	#vibeWorkerTurnInFlight(): boolean {
+		return (
+			this.vibeModeEnabled &&
+			VibeSessionRegistry.global().hasInFlightTurn(this.session.getAgentId() ?? MAIN_AGENT_ID)
+		);
 	}
 
 	#isAutoSubmitBlocked(): boolean {
@@ -2114,13 +2132,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (this.goalModeEnabled || this.goalModePaused) {
-			if (this.#goalModePreviousTools !== undefined) {
-				await this.session.setActiveToolsByName(this.#goalModePreviousTools);
-			}
 			this.session.setGoalModeState(undefined);
 			this.goalModeEnabled = false;
 			this.goalModePaused = false;
-			this.#goalModePreviousTools = undefined;
 			this.#goalTurnHadToolCalls = false;
 			this.#goalContinuationTurnInFlight = false;
 			this.#goalSuppressNextContinuation = false;
@@ -2129,16 +2143,19 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		if (this.vibeModeEnabled) {
-			await this.session.deactivateVibeTools(this.#vibeModePreviousTools ?? []);
+			await this.session.deactivateVibeTools(this.#modeBaselineTools ?? []);
 			this.session.setVibeModeState(undefined);
 			this.vibeModeEnabled = false;
-			this.#vibeModePreviousTools = undefined;
 			await VibeSessionRegistry.global().killAll(
 				this.session.getAgentId() ?? MAIN_AGENT_ID,
 				this.session.asyncJobManager,
 			);
 			this.#updateVibeModeStatus();
+		} else if (this.#modeBaselineTools !== undefined) {
+			// Goal mode (alone) was the only restricted mode; restore its baseline.
+			await this.session.setActiveToolsByName(this.#modeBaselineTools);
 		}
+		this.#modeBaselineTools = undefined;
 	}
 
 	/** Reconcile mode state from session entries on resume/switch. */
@@ -2162,6 +2179,11 @@ export class InteractiveMode implements InteractiveModeContext {
 				mode: "active",
 				goal,
 			});
+			// Restore vibe mode before onThreadResumed so its persist snapshots
+			// carry `vibe: true`, and before the toolset recompute below.
+			if (sessionContext.modeData?.vibe === true) {
+				await this.#enterVibeMode({ silent: true });
+			}
 			const restored = await this.session.goalRuntime.onThreadResumed({
 				preserveActiveGoal: options?.preserveActiveGoal,
 			});
@@ -2170,9 +2192,8 @@ export class InteractiveMode implements InteractiveModeContext {
 			// sdk.ts excludes "goal" from the initial active tool set unconditionally.
 			// Re-add it now so the agent can call resume, complete, or drop on this goal.
 			if (restored?.goal) {
-				const previousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
-				this.#goalModePreviousTools = previousTools;
-				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+				this.#captureModeToolBaseline();
+				await this.#applyModeToolset();
 			}
 			this.#updateGoalModeStatus();
 			return;
@@ -2371,6 +2392,53 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
+	#captureModeToolBaseline(): void {
+		if (this.#modeBaselineTools !== undefined) return;
+		this.#modeBaselineTools = this.session.getActiveToolNames().filter(name => name !== "goal");
+	}
+
+	/**
+	 * Recompute the active toolset from the current vibe/goal flags. The modes
+	 * compose: vibe+goal is the vibe restricted set plus the goal tool. The
+	 * goal tool stays active for paused goals so the agent can resume, complete,
+	 * or drop them (matching the resume-reconcile convention).
+	 */
+	async #applyModeToolset(): Promise<void> {
+		const goalToolWanted = this.goalModeEnabled || this.goalModePaused;
+		if (this.vibeModeEnabled) {
+			const active = this.session.getActiveToolNames();
+			await this.session.setActiveToolsByName(
+				goalToolWanted ? [...new Set([...active, "goal"])] : active.filter(name => name !== "goal"),
+			);
+			return;
+		}
+		const baseline = this.#modeBaselineTools ?? this.session.getActiveToolNames().filter(name => name !== "goal");
+		if (goalToolWanted) {
+			await this.session.setActiveToolsByName([...new Set([...baseline, "goal"])]);
+			return;
+		}
+		await this.session.setActiveToolsByName(baseline);
+		this.#modeBaselineTools = undefined;
+	}
+
+	/**
+	 * Persist the current (possibly combined) mode as the latest mode-change
+	 * entry. Keyed on session goal state rather than the interactive flags so
+	 * it stays correct mid-reconcile.
+	 */
+	#persistModeSnapshot(): void {
+		const goalState = this.session.getGoalModeState();
+		if (goalState?.goal && (goalState.enabled || goalState.goal.status === "paused")) {
+			const mode = goalState.enabled ? "goal" : "goal_paused";
+			this.sessionManager.appendModeChange(
+				mode,
+				this.vibeModeEnabled ? { goal: goalState.goal, vibe: true } : { goal: goalState.goal },
+			);
+			return;
+		}
+		this.sessionManager.appendModeChange(this.vibeModeEnabled ? "vibe" : "none");
+	}
+
 	async #enterGoalMode(options: { objective?: string; resume?: boolean; silent?: boolean }): Promise<void> {
 		if (this.goalModeEnabled) {
 			return;
@@ -2379,20 +2447,14 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit plan mode first.");
 			return;
 		}
-		if (this.vibeModeEnabled) {
-			this.showWarning("Exit vibe mode first.");
-			return;
-		}
-		const previousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
-		const goalTools = [...new Set([...previousTools, "goal"])];
-		this.#goalModePreviousTools = previousTools;
+		this.#captureModeToolBaseline();
 		this.goalModePaused = false;
 		const state = options.resume
 			? await this.session.goalRuntime.resumeGoal()
 			: await this.session.goalRuntime.createGoal({ objective: options.objective ?? "" });
-		await this.session.setActiveToolsByName(goalTools);
 		this.session.setGoalModeState(state);
 		this.goalModeEnabled = true;
+		await this.#applyModeToolset();
 		this.#resetGoalContinuationSuppression();
 		this.#updateGoalModeStatus();
 		if (this.session.isStreaming) {
@@ -2408,14 +2470,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		paused?: boolean;
 		reason?: "completed" | "paused" | "dropped";
 	}): Promise<void> {
-		const previousTools = this.#goalModePreviousTools;
-		if (this.goalModeEnabled && previousTools) {
-			await this.session.setActiveToolsByName(previousTools);
-		}
 		const currentState = this.session.getGoalModeState();
 		if (options?.reason === "completed") {
 			this.session.setGoalModeState(undefined);
-			this.sessionManager.appendModeChange("none");
+			this.#persistModeSnapshot();
 			this.sessionManager.appendCustomEntry("goal-completed", {
 				objective: currentState?.goal?.objective,
 				tokensUsed: currentState?.goal?.tokensUsed,
@@ -2425,7 +2483,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		this.goalModeEnabled = false;
 		this.goalModePaused = options?.paused ?? false;
-		this.#goalModePreviousTools = undefined;
+		// Derived recompute is idempotent, so the drop path's double invocation
+		// (goal_updated handler + #confirmAndDropGoal) is safe.
+		await this.#applyModeToolset();
 		this.#goalContinuationTurnInFlight = false;
 		this.#cancelGoalContinuation();
 		this.#updateGoalModeStatus();
@@ -2953,17 +3013,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit plan mode first.");
 			return;
 		}
-		if (this.goalModeEnabled || this.goalModePaused) {
-			this.showWarning("Exit goal mode first.");
-			return;
-		}
 		await this.#enterVibeMode();
 		if (initialPrompt && this.onInputCallback) {
 			this.onInputCallback(this.startPendingSubmission({ text: initialPrompt }));
 		}
 	}
 
-	async #enterVibeMode(): Promise<void> {
+	async #enterVibeMode(options?: { silent?: boolean }): Promise<void> {
 		if (this.vibeModeEnabled) {
 			return;
 		}
@@ -2971,14 +3027,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.showWarning("Exit plan mode first.");
 			return;
 		}
-		if (this.goalModeEnabled || this.goalModePaused) {
-			this.showWarning("Exit goal mode first.");
-			return;
-		}
 
-		const previousTools = this.session.getActiveToolNames();
-		await this.session.activateVibeTools(["read"]);
-		this.#vibeModePreviousTools = previousTools;
+		this.#captureModeToolBaseline();
+		await this.session.activateVibeTools(this.goalModeEnabled || this.goalModePaused ? ["read", "goal"] : ["read"]);
 		this.vibeModeEnabled = true;
 		// Suppress cache-miss marker on the next turn: vibe mode changes the
 		// injected context, which predictably invalidates the cache.
@@ -2988,25 +3039,35 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.session.sendVibeModeContext({ deliverAs: "steer" });
 		}
 		this.#updateVibeModeStatus();
-		this.sessionManager.appendModeChange("vibe");
-		this.showStatus("Vibe mode enabled. You direct fast/good worker sessions; toolset is read + vibe tools.");
+		this.#persistModeSnapshot();
+		if (!options?.silent) {
+			this.showStatus(
+				this.goalModeEnabled
+					? "Vibe mode enabled. You direct fast/good worker sessions toward the active goal; toolset is read + vibe + goal tools."
+					: "Vibe mode enabled. You direct fast/good worker sessions; toolset is read + vibe tools.",
+			);
+		}
 	}
 
 	async #exitVibeMode(): Promise<void> {
 		if (!this.vibeModeEnabled) {
 			return;
 		}
-		await this.session.deactivateVibeTools(this.#vibeModePreviousTools ?? []);
+		const goalToolWanted = this.goalModeEnabled || this.goalModePaused;
+		const baseline = this.#modeBaselineTools ?? [];
+		await this.session.deactivateVibeTools(goalToolWanted ? [...new Set([...baseline, "goal"])] : baseline);
 		this.session.setVibeModeState(undefined);
 		this.vibeModeEnabled = false;
-		this.#vibeModePreviousTools = undefined;
+		if (!goalToolWanted) {
+			this.#modeBaselineTools = undefined;
+		}
 		this.lastAssistantUsage = undefined;
 		const killed = await VibeSessionRegistry.global().killAll(
 			this.session.getAgentId() ?? MAIN_AGENT_ID,
 			this.session.asyncJobManager,
 		);
 		this.#updateVibeModeStatus();
-		this.sessionManager.appendModeChange("none");
+		this.#persistModeSnapshot();
 		this.showStatus(
 			killed > 0
 				? `Vibe mode disabled. Killed ${killed} worker session${killed === 1 ? "" : "s"}.`
@@ -3044,10 +3105,6 @@ export class InteractiveMode implements InteractiveModeContext {
 		try {
 			if (this.planModeEnabled || this.planModePaused) {
 				this.showWarning("Exit plan mode first.");
-				return;
-			}
-			if (this.vibeModeEnabled) {
-				this.showWarning("Exit vibe mode first.");
 				return;
 			}
 			if (!this.session.settings.get("goal.enabled")) {

--- a/packages/coding-agent/src/prompts/goals/goal-continuation.md
+++ b/packages/coding-agent/src/prompts/goals/goal-continuation.md
@@ -13,12 +13,20 @@ Budget:
 - Time used: {{timeUsedSeconds}} seconds
 
 This is an autonomous continuation. The objective persists across turns; NEVER redefine success around a smaller, easier, or already-completed subset.
+{{#if vibe}}
+
+You are the vibe-mode DIRECTOR. Keep every workstream moving: review settled worker turns, follow up with `vibe_send`, and route new work to the right session instead of respawning. The token budget includes worker-session spend.
+{{/if}}
 
 Before calling `goal({op:"complete"})`, you MUST perform a completion audit against the current repo state:
 
 1. **Restate the objective as concrete deliverables.** What files, behaviors, tests, gates, or artifacts must exist for the objective to be true? Write them down (todo, or in your reasoning).
 2. **Map each deliverable to evidence.** For every requirement, identify the authoritative source that would prove it: a file's contents, a command's output, a test's pass status, a PR/issue state.
+{{#if vibe}}
+3. **Inspect the actual current state.** Read the files with `read`; delegate commands, builds, and tests to worker sessions and review their settled turn results. Do not call complete while any worker turn is still in flight. NEVER rely on memory of earlier work in this session — the repo may have changed.
+{{else}}
 3. **Inspect the actual current state.** Read the files. Run the commands. Check the tests. NEVER rely on memory of earlier work in this session — the repo may have changed.
+{{/if}}
 4. **Match verification scope to claim scope.** A narrow check (one file passes its unit test) does not prove a broad claim (the feature works end-to-end).
 5. **Treat uncertainty as not-yet-achieved.** Indirect evidence, partial coverage, missing artifacts, or "looks right" without inspection mean continue working. Gather stronger evidence or do more work.
 6. **Budget exhaustion is not completion.** NEVER call complete merely because tokens are nearly out. If the budget is tight and the work is unfinished, leave the goal active and stop the turn — the user or runtime decides next steps.

--- a/packages/coding-agent/src/prompts/goals/goal-mode-active.md
+++ b/packages/coding-agent/src/prompts/goals/goal-mode-active.md
@@ -17,7 +17,13 @@ Use the `goal` tool to inspect or complete the active goal:
 
 You MUST keep the full objective intact across turns. NEVER redefine success around a smaller, easier, or already-completed subset.
 
+{{#if vibe}}
+You pursue this goal as the vibe-mode DIRECTOR: delegate edits, builds, tests, and checks to worker sessions, and verify their claims yourself with `read`. Review every settled worker turn before building on it. The token budget includes worker-session spend.
+
+Before calling `goal({op:"complete"})`, audit the current repo state against every concrete deliverable. Verify files with `read`, have workers run the relevant checks and report output, and make the verification scope match the claim scope. Wait for all in-flight worker turns to settle and review their results first. If any deliverable lacks direct current-state evidence, keep working.
+{{else}}
 Before calling `goal({op:"complete"})`, audit the current repo state against every concrete deliverable. Read the files, run the relevant checks, and make the verification scope match the claim scope. If any deliverable lacks direct current-state evidence, keep working.
+{{/if}}
 
 Budget exhaustion is not completion. If the work is unfinished, leave the goal active.
 </goal_context>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2702,16 +2702,24 @@ export class AgentSession {
 					cacheWrite: usage.cacheWrite,
 				};
 			},
+			isVibeModeActive: () => this.#vibeModeState?.enabled === true,
 			emit: event => {
 				if (event.type === "goal_updated") {
 					return this.#emitSessionEvent({ type: "goal_updated", goal: event.goal, state: event.state });
 				}
 			},
 			persist: (mode, state) => {
+				// Goal persistence is vibe-aware: while vibe mode is on, dropping the
+				// goal must leave the session marked "vibe" (not "none"), and goal
+				// snapshots carry `vibe: true` so resume restores the combined mode.
+				const vibeActive = this.#vibeModeState?.enabled === true;
 				if (mode === "none") {
-					this.sessionManager.appendModeChange("none");
+					this.sessionManager.appendModeChange(vibeActive ? "vibe" : "none");
 				} else if (state) {
-					this.sessionManager.appendModeChange(mode, { goal: state.goal });
+					this.sessionManager.appendModeChange(
+						mode,
+						vibeActive ? { goal: state.goal, vibe: true } : { goal: state.goal },
+					);
 				}
 			},
 			sendHiddenMessage: async message => {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -240,6 +240,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 				return `Plan: on${planFile ? ` (${path.basename(planFile)})` : ""}`;
 			}
 			if (runtime.ctx.goalModeEnabled) return "Plan: blocked by goal mode";
+			if (runtime.ctx.vibeModeEnabled) return "Plan: blocked by vibe mode";
 			return "Plan: off";
 		},
 		handleTui: async (command, runtime) => {
@@ -259,13 +260,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "vibe",
-		description: "Toggle vibe mode (direct persistent fast/good worker sessions; read-only toolset)",
+		description:
+			"Toggle vibe mode (direct persistent fast/good worker sessions; read-only toolset; composes with /goal)",
 		inlineHint: "[prompt]",
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {
-			if (runtime.ctx.vibeModeEnabled) return "Vibe: on";
+			if (runtime.ctx.vibeModeEnabled) return runtime.ctx.goalModeEnabled ? "Vibe: on (goal-guided)" : "Vibe: on";
 			if (runtime.ctx.planModeEnabled) return "Vibe: blocked by plan mode";
-			if (runtime.ctx.goalModeEnabled) return "Vibe: blocked by goal mode";
 			return "Vibe: off";
 		},
 		handleTui: async (command, runtime) => {
@@ -290,7 +291,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			if (!runtime.ctx.settings.get("goal.enabled" as SettingPath)) return "Goal: disabled in settings";
 			if (runtime.ctx.planModeEnabled) return "Goal: blocked by plan mode";
 			const state = runtime.ctx.session.getGoalModeState();
-			return state ? `Goal: ${state.goal.status} (${shortDetail(state.goal.objective)})` : "Goal: off";
+			if (!state) return "Goal: off";
+			const vibeSuffix = runtime.ctx.vibeModeEnabled ? " + vibe" : "";
+			return `Goal: ${state.goal.status}${vibeSuffix} (${shortDetail(state.goal.objective)})`;
 		},
 		handleTui: async (command, runtime) => {
 			await runtime.ctx.handleGoalModeCommand(command.args || undefined);

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -236,6 +236,14 @@ export class VibeSessionRegistry {
 		return ids;
 	}
 
+	/** True when any of `owner`'s sessions has a turn in flight (set synchronously at turn registration). */
+	hasInFlightTurn(owner: string): boolean {
+		for (const record of this.#records.values()) {
+			if (record.ownerId === owner && record.state !== "dead" && record.turn !== undefined) return true;
+		}
+		return false;
+	}
+
 	/**
 	 * Live screen snapshots for rich rendering (the "TV wall"): one entry per
 	 * session in creation order, carrying the in-flight turn's trace, current
@@ -592,7 +600,7 @@ export class VibeSessionRegistry {
 								eventBus: session.eventBus,
 								artifactsDir: session.getSessionFile()?.slice(0, -6),
 							});
-					return this.#settleTurn(session, manager, record, turn, ownJobId, turnIndex, result);
+					return await this.#settleTurn(session, manager, record, turn, ownJobId, turnIndex, result);
 				} catch (error) {
 					if (error instanceof VibeTurnError) throw error;
 					this.#finishTurn(session, manager, record, ownJobId);
@@ -638,7 +646,7 @@ export class VibeSessionRegistry {
 	}
 
 	/** Format a settled turn into the self-delivering result text (activity trace + response). */
-	#settleTurn(
+	async #settleTurn(
 		session: ToolSession,
 		manager: AsyncJobManager,
 		record: VibeRecord,
@@ -646,7 +654,21 @@ export class VibeSessionRegistry {
 		settledJobId: string,
 		turnIndex: number,
 		result: SingleResult,
-	): string {
+	): Promise<string> {
+		// Worker turns never reach the director's own session stats; feed their
+		// usage into the goal budget. No-op when no goal is actively accounting,
+		// and failed/aborted turns still burned the tokens they report.
+		const goalRuntime = session.getGoalRuntime?.();
+		if (goalRuntime && result.usage) {
+			try {
+				await goalRuntime.addExternalUsage(result.usage);
+			} catch (error) {
+				logger.warn("vibe: goal usage accounting for worker turn failed", {
+					id: record.id,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
 		this.#finishTurn(session, manager, record, settledJobId);
 		const failed = result.exitCode !== 0 || result.aborted === true;
 		const status = result.aborted ? "aborted" : failed ? "failed" : "completed";

--- a/packages/coding-agent/test/goals/goal-runtime.test.ts
+++ b/packages/coding-agent/test/goals/goal-runtime.test.ts
@@ -52,10 +52,11 @@ function cloneEvent(event: GoalRuntimeEvent): GoalRuntimeEvent {
 	return { ...event };
 }
 
-function createHarness(initial: { state?: GoalModeState; usage?: GoalTokenUsage; now?: number } = {}) {
+function createHarness(initial: { state?: GoalModeState; usage?: GoalTokenUsage; now?: number; vibe?: boolean } = {}) {
 	let state = cloneState(initial.state);
 	let usage = createUsage(initial.usage);
 	let now = initial.now ?? 0;
+	let vibe = initial.vibe ?? false;
 	const events: GoalRuntimeEvent[] = [];
 	const persists: Array<{ mode: "goal" | "goal_paused" | "none"; state?: GoalModeState }> = [];
 	const hiddenMessages: Array<{ customType: string; content: string; deliverAs?: "steer" | "followUp" | "nextTurn" }> =
@@ -66,6 +67,7 @@ function createHarness(initial: { state?: GoalModeState; usage?: GoalTokenUsage;
 			state = cloneState(next);
 		},
 		getCurrentUsage: () => createUsage(usage),
+		isVibeModeActive: () => vibe,
 		emit: async event => {
 			events.push(cloneEvent(event));
 		},
@@ -85,6 +87,9 @@ function createHarness(initial: { state?: GoalModeState; usage?: GoalTokenUsage;
 		},
 		setUsage: (next: Partial<GoalTokenUsage>) => {
 			usage = createUsage(next);
+		},
+		setVibe: (next: boolean) => {
+			vibe = next;
 		},
 		advance: (ms: number) => {
 			now += ms;
@@ -446,5 +451,98 @@ describe("goal runtime", () => {
 		expect(state?.enabled).toBe(false);
 		expect(state?.mode).toBe("exiting");
 		expect(state?.goal.status).toBe("complete");
+	});
+
+	it("addExternalUsage counts input+cacheWrite+output, ignores cacheRead, and persists a goal snapshot", async () => {
+		const harness = createHarness({
+			state: { enabled: true, mode: "active", goal: createGoal() },
+		});
+
+		await harness.runtime.addExternalUsage(createUsage({ input: 10, output: 5, cacheRead: 999, cacheWrite: 3 }));
+
+		expect(harness.getState()?.goal.tokensUsed).toBe(18);
+		expect(harness.persists.at(-1)).toMatchObject({ mode: "goal", state: { goal: { tokensUsed: 18 } } });
+	});
+
+	it("addExternalUsage leaves the per-turn snapshot baseline alone so turn flushes cannot double-count", async () => {
+		const harness = createHarness({
+			state: { enabled: true, mode: "active", goal: createGoal() },
+		});
+
+		harness.runtime.onTurnStart("turn-1", createUsage());
+		await harness.runtime.addExternalUsage(createUsage({ input: 100 }));
+		// The director's own turn later flushes a session-stats delta; external
+		// usage must not have consumed or shifted that baseline.
+		harness.setUsage({ input: 7 });
+		await harness.runtime.flushUsage("suppressed");
+
+		expect(harness.getState()?.goal.tokensUsed).toBe(107);
+	});
+
+	it("addExternalUsage flips active to budget-limited at the threshold, steers once, and keeps accounting", async () => {
+		const harness = createHarness({
+			state: {
+				enabled: true,
+				mode: "active",
+				goal: createGoal({ tokenBudget: 20, tokensUsed: 10 }),
+			},
+		});
+
+		await harness.runtime.addExternalUsage(createUsage({ input: 12 }));
+		expect(harness.getState()?.goal.status).toBe("budget-limited");
+		expect(harness.hiddenMessages).toHaveLength(1);
+		expect(harness.hiddenMessages[0]).toMatchObject({ customType: "goal-budget-limit", deliverAs: "steer" });
+
+		// budget-limited still accounts (worker turns finishing late), but the
+		// steer is not repeated for the same goal.
+		await harness.runtime.addExternalUsage(createUsage({ output: 4 }));
+		expect(harness.getState()?.goal.tokensUsed).toBe(26);
+		expect(harness.hiddenMessages).toHaveLength(1);
+	});
+
+	it("addExternalUsage no-ops for paused goals, absent goals, and zero-token usage", async () => {
+		const paused = createHarness({
+			state: { enabled: false, mode: "active", goal: createGoal({ status: "paused", tokensUsed: 5 }) },
+		});
+		await paused.runtime.addExternalUsage(createUsage({ input: 50 }));
+		expect(paused.getState()?.goal.tokensUsed).toBe(5);
+		expect(paused.persists).toHaveLength(0);
+
+		const absent = createHarness();
+		await absent.runtime.addExternalUsage(createUsage({ input: 50 }));
+		expect(absent.getState()).toBeUndefined();
+		expect(absent.persists).toHaveLength(0);
+
+		const active = createHarness({
+			state: { enabled: true, mode: "active", goal: createGoal() },
+		});
+		await active.runtime.addExternalUsage(createUsage({ cacheRead: 500 }));
+		expect(active.getState()?.goal.tokensUsed).toBe(0);
+		expect(active.persists).toHaveLength(0);
+	});
+
+	it("renders director guidance in goal prompts only while vibe mode is active", () => {
+		const goal = createGoal();
+
+		const activeVibe = renderGoalPrompt("active", goal, { vibe: true });
+		expect(activeVibe).toContain("worker sessions");
+		const activePlain = renderGoalPrompt("active", goal);
+		expect(activePlain).not.toContain("worker sessions");
+		expect(activePlain).toContain("run the relevant checks");
+
+		const continuationVibe = renderGoalPrompt("continuation", goal, { vibe: true });
+		expect(continuationVibe).toContain("vibe_send");
+		const continuationPlain = renderGoalPrompt("continuation", goal);
+		expect(continuationPlain).not.toContain("vibe_send");
+	});
+
+	it("buildActivePrompt follows the host's live isVibeModeActive flag", () => {
+		const harness = createHarness({
+			state: { enabled: true, mode: "active", goal: createGoal() },
+		});
+
+		expect(harness.runtime.buildActivePrompt()).not.toContain("worker sessions");
+		harness.setVibe(true);
+		expect(harness.runtime.buildActivePrompt()).toContain("worker sessions");
 	});
 });

--- a/packages/coding-agent/test/goals/goal-vibe-compose.test.ts
+++ b/packages/coding-agent/test/goals/goal-vibe-compose.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Contracts: /vibe ∘ /goal composition (goal-guided vibe mode).
+ *
+ * 1. Both entry orders compose: the active toolset becomes read + vibe tools +
+ *    goal, and each mode exits back to the correct toolset regardless of order.
+ * 2. The combined mode persists as a "goal" mode-change entry carrying
+ *    `vibe: true`, and a fresh InteractiveMode resumes BOTH modes from it.
+ * 3. Goal auto-continuation defers while a vibe worker turn is in flight and
+ *    fires the director-variant continuation when workers are idle.
+ * 4. Goal completion leaves vibe mode (and its toolset) active.
+ */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { Goal } from "@oh-my-pi/pi-coding-agent/goals/state";
+import { GoalTool } from "@oh-my-pi/pi-coding-agent/goals/tools/goal-tool";
+import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentLifecycleManager } from "@oh-my-pi/pi-coding-agent/registry/agent-lifecycle";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import * as executorModule from "@oh-my-pi/pi-coding-agent/task/executor";
+import type { SingleResult } from "@oh-my-pi/pi-coding-agent/task/types";
+import { createTools, type Tool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { VIBE_TOOL_NAMES } from "@oh-my-pi/pi-coding-agent/tools/vibe";
+import { VibeSessionRegistry } from "@oh-my-pi/pi-coding-agent/vibe/runtime";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+function stubTool(name: string): AgentTool {
+	return {
+		name,
+		label: name,
+		description: `${name} tool`,
+		parameters: type({ value: "string" }),
+		strict: true,
+		async execute() {
+			return { content: [{ type: "text", text: `${name} executed` }] };
+		},
+	};
+}
+
+function createToolSession(cwd: string, settings: Settings, overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings,
+		...overrides,
+	};
+}
+
+function createGoalRecord(overrides: Partial<Goal> = {}): Goal {
+	return {
+		id: "goal-1",
+		objective: "Ship the release",
+		status: "active",
+		tokenBudget: undefined,
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 1,
+		updatedAt: 1,
+		...overrides,
+	};
+}
+
+type ComposeHarness = {
+	tempDir: TempDir;
+	settings: Settings;
+	session: AgentSession;
+	sessionManager: SessionManager;
+	mode: InteractiveMode;
+	cleanup: () => Promise<void>;
+};
+
+type SharedFixture = {
+	authStorage: AuthStorage;
+	modelRegistry: ModelRegistry;
+	model: Model;
+	baseDir: TempDir;
+};
+
+async function createSharedFixture(): Promise<SharedFixture> {
+	const baseDir = TempDir.createSync("@pi-goal-vibe-shared-");
+	const authStorage = await AuthStorage.create(path.join(baseDir.path(), "testauth.db"));
+	const modelRegistry = new ModelRegistry(authStorage);
+	const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+	if (!model) {
+		throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+	}
+	return { authStorage, modelRegistry, model, baseDir };
+}
+
+async function createComposeHarness(
+	shared: SharedFixture,
+	options: { sessionManager?: SessionManager } = {},
+): Promise<ComposeHarness> {
+	resetSettingsForTest();
+	const tempDir = TempDir.createSync("@pi-goal-vibe-");
+	await Settings.init({ inMemory: true, cwd: tempDir.path() });
+	const settings = Settings.isolated({
+		"compaction.enabled": false,
+		"goal.enabled": true,
+		"plan.enabled": true,
+	});
+	const bootstrapToolSession = createToolSession(tempDir.path(), settings);
+	// Pin the baseline to exactly `read` (createTools also emits companions like
+	// `resolve`) so toolset assertions stay deterministic.
+	const initialTools = (await createTools(bootstrapToolSession, ["read"])).filter(tool => tool.name === "read");
+	const toolRegistry = new Map<string, Tool>(initialTools.map(tool => [tool.name, tool] as const));
+	const sessionManager = options.sessionManager ?? SessionManager.create(tempDir.path(), tempDir.path());
+
+	const session = new AgentSession({
+		agent: new Agent({
+			initialState: {
+				model: shared.model,
+				systemPrompt: ["Test"],
+				tools: initialTools,
+				messages: [],
+			},
+		}),
+		sessionManager,
+		settings,
+		modelRegistry: shared.modelRegistry,
+		toolRegistry,
+		createVibeTools: () => VIBE_TOOL_NAMES.map(stubTool),
+		rebuildSystemPrompt: async () => ({ systemPrompt: ["Test"] }),
+	});
+	const mode = new InteractiveMode(session, "test");
+	const toolSession = createToolSession(tempDir.path(), settings, {
+		getGoalModeState: () => session.getGoalModeState(),
+		getGoalRuntime: () => session.goalRuntime,
+	});
+	toolRegistry.set("goal", new GoalTool(toolSession) as unknown as Tool);
+
+	return {
+		tempDir,
+		settings,
+		session,
+		sessionManager,
+		mode,
+		cleanup: async () => {
+			mode.stop();
+			await session.dispose();
+			tempDir.removeSync();
+			resetSettingsForTest();
+		},
+	};
+}
+
+function activeToolsSorted(harness: ComposeHarness): string[] {
+	return harness.session.getActiveToolNames().toSorted();
+}
+
+const COMBINED_TOOLS = ["read", "goal", ...VIBE_TOOL_NAMES].toSorted();
+const VIBE_ONLY_TOOLS = ["read", ...VIBE_TOOL_NAMES].toSorted();
+
+async function waitForMicrotasks(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+async function pollUntil(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+	const start = Date.now();
+	while (!predicate()) {
+		if (Date.now() - start > timeoutMs) throw new Error("pollUntil timed out");
+		await Bun.sleep(5);
+	}
+}
+
+function makeWorkerResult(id: string, overrides: Partial<SingleResult> = {}): SingleResult {
+	return {
+		index: 0,
+		id,
+		agent: "task",
+		agentSource: "bundled",
+		task: "prompt",
+		exitCode: 0,
+		output: "All done.",
+		stderr: "",
+		truncated: false,
+		durationMs: 5,
+		tokens: 0,
+		requests: 1,
+		...overrides,
+	};
+}
+
+describe("goal-guided vibe mode composition", () => {
+	let shared: SharedFixture;
+	let harness: ComposeHarness;
+
+	beforeAll(async () => {
+		await initTheme();
+		shared = await createSharedFixture();
+	});
+
+	afterAll(() => {
+		shared.authStorage.close();
+		shared.baseDir.removeSync();
+	});
+
+	beforeEach(async () => {
+		AgentRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		VibeSessionRegistry.resetGlobalForTests();
+		harness = await createComposeHarness(shared);
+	});
+
+	afterEach(async () => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		await harness.cleanup();
+		VibeSessionRegistry.resetGlobalForTests();
+		AgentLifecycleManager.resetGlobalForTests();
+		AgentRegistry.resetGlobalForTests();
+	});
+
+	it("composes and unwinds the toolset for vibe-then-goal", async () => {
+		expect(activeToolsSorted(harness)).toEqual(["read"]);
+
+		await harness.mode.handleVibeModeCommand();
+		expect(harness.mode.vibeModeEnabled).toBe(true);
+		expect(activeToolsSorted(harness)).toEqual(VIBE_ONLY_TOOLS);
+
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		expect(harness.mode.goalModeEnabled).toBe(true);
+		expect(harness.mode.vibeModeEnabled).toBe(true);
+		expect(activeToolsSorted(harness)).toEqual(COMBINED_TOOLS);
+
+		// Exit goal (drop) while vibe stays on: back to the vibe-only set.
+		vi.spyOn(harness.mode, "showHookConfirm").mockResolvedValue(true);
+		await harness.mode.handleGoalModeCommand("drop");
+		expect(harness.mode.goalModeEnabled).toBe(false);
+		expect(harness.mode.vibeModeEnabled).toBe(true);
+		expect(activeToolsSorted(harness)).toEqual(VIBE_ONLY_TOOLS);
+		expect(harness.sessionManager.buildSessionContext().mode).toBe("vibe");
+
+		await harness.mode.handleVibeModeCommand();
+		expect(harness.mode.vibeModeEnabled).toBe(false);
+		expect(activeToolsSorted(harness)).toEqual(["read"]);
+	});
+
+	it("composes and unwinds the toolset for goal-then-vibe", async () => {
+		await harness.mode.handleGoalModeCommand("Ship the release");
+		expect(activeToolsSorted(harness)).toEqual(["goal", "read"]);
+
+		await harness.mode.handleVibeModeCommand();
+		expect(harness.mode.vibeModeEnabled).toBe(true);
+		expect(harness.mode.goalModeEnabled).toBe(true);
+		expect(activeToolsSorted(harness)).toEqual(COMBINED_TOOLS);
+
+		// Exit vibe while the goal stays active: full pre-vibe toolset + goal.
+		await harness.mode.handleVibeModeCommand();
+		expect(harness.mode.vibeModeEnabled).toBe(false);
+		expect(harness.mode.goalModeEnabled).toBe(true);
+		expect(activeToolsSorted(harness)).toEqual(["goal", "read"]);
+		const context = harness.sessionManager.buildSessionContext();
+		expect(context.mode).toBe("goal");
+		expect(context.modeData?.vibe).toBeUndefined();
+
+		vi.spyOn(harness.mode, "showHookConfirm").mockResolvedValue(true);
+		await harness.mode.handleGoalModeCommand("drop");
+		expect(activeToolsSorted(harness)).toEqual(["read"]);
+	});
+
+	it("persists the combined mode with vibe:true in either entry order", async () => {
+		await harness.mode.handleVibeModeCommand();
+		await harness.mode.handleGoalModeCommand("Ship the release");
+
+		const context = harness.sessionManager.buildSessionContext();
+		expect(context.mode).toBe("goal");
+		expect(context.modeData?.vibe).toBe(true);
+		const persistedGoal = context.modeData?.goal as Goal | undefined;
+		expect(persistedGoal?.objective).toBe("Ship the release");
+	});
+
+	it("resumes both modes from a goal mode-change entry carrying vibe:true", async () => {
+		const goal = createGoalRecord();
+		harness.sessionManager.appendModeChange("goal", { goal, vibe: true });
+
+		const resumed = await createComposeHarness(shared, { sessionManager: harness.sessionManager });
+		try {
+			await resumed.mode.init({ suppressWelcomeIntro: true });
+
+			expect(resumed.mode.vibeModeEnabled).toBe(true);
+			// A resumed active goal auto-pauses (onThreadResumed contract); the
+			// goal tool stays active so the agent can resume/complete/drop it.
+			expect(resumed.mode.goalModePaused).toBe(true);
+			expect(activeToolsSorted(resumed)).toEqual(COMBINED_TOOLS);
+
+			const context = resumed.sessionManager.buildSessionContext();
+			expect(context.mode).toBe("goal_paused");
+			expect(context.modeData?.vibe).toBe(true);
+		} finally {
+			resumed.mode.stop();
+			await resumed.session.dispose();
+			resumed.tempDir.removeSync();
+		}
+	});
+
+	it("defers goal continuation while a worker turn is in flight and fires the director variant when idle", async () => {
+		await harness.mode.handleVibeModeCommand();
+		await harness.mode.handleGoalModeCommand("Ship the release");
+
+		// Real registry turn owned by "Main" (both the interactive session and
+		// the spawning tool session default to MAIN_AGENT_ID).
+		const gate = Promise.withResolvers<void>();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			await gate.promise;
+			return makeWorkerResult(options.id);
+		});
+		const manager = new AsyncJobManager({ onJobComplete: () => {} });
+		const spawnSession = createToolSession(harness.tempDir.path(), harness.settings, {
+			asyncJobManager: manager,
+		});
+		const registry = VibeSessionRegistry.global();
+		const { jobId } = await registry.spawn(spawnSession, { cli: "fast", name: "Fast", prompt: "Task A." });
+		expect(registry.hasInFlightTurn("Main")).toBe(true);
+
+		vi.useFakeTimers();
+		let firstResolved: SubmittedUserInput | undefined;
+		const first = harness.mode.getUserInput().then(input => {
+			firstResolved = input;
+			return input;
+		});
+		await waitForMicrotasks();
+
+		// The continuation is not scheduled while the worker turn is in flight.
+		vi.advanceTimersByTime(800);
+		await waitForMicrotasks();
+		expect(firstResolved).toBeUndefined();
+		vi.useRealTimers();
+
+		// Settle the worker turn.
+		gate.resolve();
+		await manager.getJob(jobId)!.promise;
+		expect(registry.hasInFlightTurn("Main")).toBe(false);
+
+		// Flush the armed waiter and clear its pending record like the run loop would.
+		const noop = harness.mode.startPendingSubmission({ text: "noop" });
+		harness.mode.onInputCallback?.(noop);
+		harness.mode.finishPendingSubmission(await first);
+
+		// With workers idle, the next idle window schedules and fires the
+		// continuation, carrying the director (vibe) variant.
+		vi.useFakeTimers();
+		const second = harness.mode.getUserInput();
+		await waitForMicrotasks();
+		vi.advanceTimersByTime(800);
+		await waitForMicrotasks();
+		vi.useRealTimers();
+		const continuation = await second;
+
+		expect(continuation.customType).toBe("goal-continuation");
+		expect(continuation.text).toContain("vibe_send");
+		harness.mode.finishPendingSubmission(continuation);
+		await manager.dispose({ timeoutMs: 1000 });
+	});
+
+	it("keeps vibe mode and its toolset alive when the goal completes", async () => {
+		await harness.mode.handleVibeModeCommand();
+		await harness.mode.handleGoalModeCommand("Ship the release");
+
+		await harness.session.goalRuntime.completeGoalFromTool();
+		// Completion exits goal mode at the next idle window (getUserInput awaits
+		// the exit before arming its input callback).
+		let resolved = false;
+		const waiter = harness.mode.getUserInput().then(input => {
+			resolved = true;
+			return input;
+		});
+		await pollUntil(() => harness.mode.onInputCallback !== undefined);
+		const noop = harness.mode.startPendingSubmission({ text: "noop" });
+		harness.mode.onInputCallback?.(noop);
+		harness.mode.finishPendingSubmission(await waiter);
+		expect(resolved).toBe(true);
+
+		expect(harness.mode.goalModeEnabled).toBe(false);
+		expect(harness.mode.vibeModeEnabled).toBe(true);
+		expect(activeToolsSorted(harness)).toEqual(VIBE_ONLY_TOOLS);
+		expect(harness.sessionManager.buildSessionContext().mode).toBe("vibe");
+	});
+});

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -27,7 +27,7 @@ import type { AgentProgress, SingleResult } from "@oh-my-pi/pi-coding-agent/task
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { VibeSessionRegistry } from "@oh-my-pi/pi-coding-agent/vibe/runtime";
 
-function createSession(options: { manager?: AsyncJobManager } = {}): ToolSession {
+function createSession(options: { manager?: AsyncJobManager; goalRuntime?: unknown } = {}): ToolSession {
 	return {
 		cwd: "/tmp",
 		hasUI: false,
@@ -35,6 +35,7 @@ function createSession(options: { manager?: AsyncJobManager } = {}): ToolSession
 		getSessionFile: () => null,
 		getSessionSpawns: () => "*",
 		asyncJobManager: options.manager,
+		getGoalRuntime: options.goalRuntime ? () => options.goalRuntime : undefined,
 	} as unknown as ToolSession;
 }
 
@@ -496,6 +497,99 @@ describe("vibe session registry", () => {
 		await expect(registry.send(session, { session: "Doomed", message: "hello?" })).rejects.toThrow("dead");
 
 		gate.resolve();
+	});
+
+	it("hasInFlightTurn tracks the turn lifecycle per owner: spawn, settle, follow-up, kill", async () => {
+		const gate = deferred();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			AgentRegistry.global().register({
+				id: options.id,
+				displayName: options.id,
+				kind: "sub",
+				parentId: "Main",
+				session: createFakeWorkerSession().session,
+				status: "running",
+			});
+			await gate.promise;
+			AgentRegistry.global().setStatus(options.id, "idle");
+			return makeResult(options.id);
+		});
+		const followUpGate = deferred();
+		vi.spyOn(executorModule, "runSubagentFollowUpTurn").mockImplementation(async options => {
+			await followUpGate.promise;
+			return makeResult(options.id);
+		});
+
+		const manager = createManager();
+		const session = createSession({ manager });
+		const registry = VibeSessionRegistry.global();
+		expect(registry.hasInFlightTurn("Main")).toBe(false);
+
+		const { jobId } = await registry.spawn(session, { cli: "fast", name: "Fast", prompt: "Task A." });
+		expect(registry.hasInFlightTurn("Main")).toBe(true);
+		// Owner-scoped: another agent's roster is unaffected.
+		expect(registry.hasInFlightTurn("Other")).toBe(false);
+
+		gate.resolve();
+		await manager.getJob(jobId)!.promise;
+		expect(registry.hasInFlightTurn("Main")).toBe(false);
+
+		const outcome = await registry.send(session, { session: "Fast", message: "Task B." });
+		expect(registry.hasInFlightTurn("Main")).toBe(true);
+
+		await registry.kill(session, "Fast");
+		expect(registry.hasInFlightTurn("Main")).toBe(false);
+
+		followUpGate.resolve();
+		await manager.getJob(outcome.jobId!)!.promise;
+	});
+
+	it("feeds settled worker-turn usage into the goal runtime, including failed turns", async () => {
+		const recorded: Array<{ input: number; output: number; cacheRead: number; cacheWrite: number }> = [];
+		const goalRuntime = {
+			addExternalUsage: async (usage: { input: number; output: number; cacheRead: number; cacheWrite: number }) => {
+				recorded.push({
+					input: usage.input,
+					output: usage.output,
+					cacheRead: usage.cacheRead,
+					cacheWrite: usage.cacheWrite,
+				});
+			},
+		};
+		const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+		const usage = { input: 120, output: 40, cacheRead: 999, cacheWrite: 8, totalTokens: 1167, cost: zeroCost };
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			AgentRegistry.global().register({
+				id: options.id,
+				displayName: options.id,
+				kind: "sub",
+				parentId: "Main",
+				session: createFakeWorkerSession().session,
+				status: "running",
+			});
+			AgentRegistry.global().setStatus(options.id, "idle");
+			return makeResult(options.id, { usage });
+		});
+		const failedUsage = { input: 30, output: 5, cacheRead: 0, cacheWrite: 1, totalTokens: 36, cost: zeroCost };
+		vi.spyOn(executorModule, "runSubagentFollowUpTurn").mockImplementation(async options =>
+			makeResult(options.id, { exitCode: 1, error: "worker crashed", usage: failedUsage }),
+		);
+
+		const manager = createManager();
+		const session = createSession({ manager, goalRuntime });
+		const registry = VibeSessionRegistry.global();
+
+		const spawn = await registry.spawn(session, { cli: "fast", name: "Fast", prompt: "Task A." });
+		await manager.getJob(spawn.jobId)!.promise;
+		expect(recorded).toEqual([{ input: 120, output: 40, cacheRead: 999, cacheWrite: 8 }]);
+
+		// A failed turn still burned its reported tokens.
+		const followUp = await registry.send(session, { session: "Fast", message: "Task B." });
+		const failedJob = manager.getJob(followUp.jobId!)!;
+		await failedJob.promise;
+		expect(failedJob.status).toBe("failed");
+		expect(recorded).toHaveLength(2);
+		expect(recorded[1]).toEqual({ input: 30, output: 5, cacheRead: 0, cacheWrite: 1 });
 	});
 
 	it("killAll terminates every session for the owner (mode-exit path)", async () => {


### PR DESCRIPTION
## Summary

`/goal` and `/vibe` now compose instead of blocking each other: the vibe director can pursue a persistent objective with hidden auto-continuation and a token budget that reflects **worker-session spend**, not just the director's own turns. Both entry orders work (`/vibe` then `/goal <obj>`, or `/goal <obj>` then `/vibe`); plan mode still blocks both.

## What changed

- **Mutual exclusion removed, toolsets unified** — the four `/vibe` ⟷ `/goal` guards are gone. A single `#modeBaselineTools` baseline replaces `#goalModePreviousTools`/`#vibeModePreviousTools` (two separate fields capture each other's restricted sets once the modes nest), and `#applyModeToolset()` derives the active set from the mode flags: vibe+goal → `read` + vibe tools + `goal`. The recompute is idempotent, so the drop path's double `#exitGoalMode` invocation stays safe, and it also fixes the goal tool lingering after `goal({op:"complete"})` (the `goal_updated` event syncs the flags before `#exitGoalMode` runs, so the old `goalModeEnabled && previousTools` guard skipped the restore).
- **Worker tokens count toward the goal budget** — `GoalRuntime.addExternalUsage()` applies the same input+cacheWrite+output rule as `goalTokenDelta` (cacheRead excluded), accumulates while `budget-limited`, flips `active → budget-limited` at the threshold, and sends the budget-limit steer once. `VibeSessionRegistry.#settleTurn` feeds every settled worker turn's `SingleResult.usage` into it — including failed/aborted turns, which still burned the tokens they report. This can't double-count: worker turns never reach `getSessionStats()` (they self-deliver as `async-result` custom messages, not `task` toolResults), and the method deliberately leaves the per-turn snapshot/wall-clock accounting alone.
- **Continuation defers to workers** — `#scheduleGoalContinuation` skips (at schedule and at fire time) while `VibeSessionRegistry.hasInFlightTurn(owner)` is true: the settling turn's async self-delivery wakes the director on its own, so a continuation would only make it poll. Once workers are idle the 800 ms continuation fires as usual, keeping the director directing. A hung worker turn defers (never loses) continuation — any later `agent_end` or user input reschedules.
- **Director-aware goal prompts** — `goal-mode-active.md` / `goal-continuation.md` gain `{{#if vibe}}` variants: verify with `read`, delegate builds/tests to worker sessions, review every settled worker turn before completing, budget includes worker spend. Rendered per turn via a new optional `GoalRuntimeHost.isVibeModeActive()`, so mid-session `/vibe` toggles pick up the right variant automatically.
- **Combined persistence + resume** — while vibe is active, goal persists write `"goal"`/`"goal_paused"` with `{goal, vibe: true}` (and goal-drop leaves `"vibe"` instead of `"none"`). `#reconcileModeFromSession` restores vibe before `goalRuntime.onThreadResumed()` so re-persists stay combined, then recomputes the toolset (goal tool stays active for the auto-paused goal, matching the existing reconcile convention).
- **Lifecycle** — goal completion leaves vibe mode and its workers alive; `/vibe` exit mid-goal kills workers as before and restores the full toolset + goal tool.
- **UI** — the status-line goal chip gains a Vibe marker when both are active; `/vibe`, `/goal`, and `/plan` autocomplete blurbs updated.

## Testing

- `test/goals/goal-runtime.test.ts` — `addExternalUsage` semantics (cacheRead exclusion, persist, budget flip + single steer, no-op when paused/absent, independence from the turn-snapshot baseline) and the vibe prompt-variant contract.
- `test/vibe/vibe-runtime.test.ts` — `hasInFlightTurn` lifecycle (spawn/settle/follow-up/kill, owner-scoped) and settle-time usage reporting incl. failed turns.
- `test/goals/goal-vibe-compose.test.ts` (new) — both entry orderings' toolset transitions, persisted mode shapes, resume via `InteractiveMode.init()` from a `"goal"+{vibe:true}` entry, continuation gating against a real in-flight registry turn, and completion-keeps-vibe.
- Status line: combined Goal+Vibe chip coverage in `component.test.ts`.
- `bun run check` clean; targeted suites (`test/goals`, `test/vibe`, `test/interactive-mode*`, `test/plan-mode*`, `test/modes`, status-line) all pass; `bun run format-prompts` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1rZZTZV3Dg6C1kutmcJG7
