### PR TITLE
docs: explain macOS Alt hotkeys

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -14,6 +14,18 @@ app.plan.toggle: Alt+Shift+P
 
 Chord names are case-insensitive and use the same notation shown in the UI, such as `Ctrl+P`, `Alt+Shift+P`, `Shift+Enter`, and `Ctrl+Backspace`.
 
+## macOS Alt / Option keys
+
+On macOS, `Alt` means the Option (`⌥`) key only when your terminal sends Option as Meta/Alt. If Option plus a letter inserts a symbol such as `µ`, the terminal is handling Option as text input instead of passing the shortcut to `omp`.
+
+Use one of these terminal settings, then press the listed `Alt` chord with `Option`:
+
+- iTerm2: set Profiles › Keys › Left Option Key to `Esc+` or `Meta`.
+- Terminal.app: enable Profiles › Keyboard › Use Option as Meta key.
+- VS Code integrated terminal: set `terminal.integrated.macOptionIsMeta` to `true`.
+
+If you want to keep Option for accents and symbols, remap the affected actions in `~/.omp/agent/keybindings.yml` to non-Alt chords.
+
 Set an action to an empty array to disable it:
 
 ```yaml

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Added macOS Option-as-Alt guidance to `/hotkeys` and the keybindings documentation.
+
 ## [16.5.2] - 2026-07-14
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -10,6 +10,9 @@ function appKey(bindings: HotkeysMarkdownBindings, action: AppKeybinding): strin
 
 export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string {
 	return [
+		"On macOS, `Alt` means Option (⌥) only when the terminal sends Option as Meta/Alt.",
+		"If Option+letter inserts symbols such as `µ`, enable Option-as-Meta/Esc+ in your terminal or remap the action in `~/.omp/agent/keybindings.yml`.",
+		"",
 		"**Navigation**",
 		"| Key | Action |",
 		"|-----|--------|",

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -34,7 +34,10 @@ describe("buildHotkeysMarkdown", () => {
 		});
 
 		const lines = markdown.split("\n");
-		expect(lines[0]).toBe("**Navigation**");
+		expect(lines[0]).toBe("On macOS, `Alt` means Option (⌥) only when the terminal sends Option as Meta/Alt.");
+		expect(lines[1]).toContain("Option+letter inserts symbols");
+		expect(lines[3]).toBe("**Navigation**");
+		expect(markdown).toContain("`~/.omp/agent/keybindings.yml`");
 		expect(markdown).toContain("| `Ctrl+Shift+P` | Copy whole prompt |");
 		expect(markdown).toContain("| `Ctrl+Shift+L` | Select model (temporary) |");
 		expect(markdown).toContain("| `Alt+M` | Select model (set roles) |");


### PR DESCRIPTION
## Summary
- add macOS Option-as-Alt guidance to the generated `/hotkeys` markdown
- document iTerm2, Terminal.app, and VS Code settings for sending Option as Meta/Alt
- cover the new visible `/hotkeys` guidance in the focused hotkeys markdown test

## Verification
- `bun test packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts`
- `bun run check:tools -- docs/keybindings.md packages/coding-agent/src/modes/utils/hotkeys-markdown.ts packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts packages/coding-agent/CHANGELOG.md`
- `bun --cwd=packages/coding-agent run check:types`

## Review
- Internal reviewer PASS: macOS Option-as-Alt guidance is clear in both `/hotkeys` and docs; test and changelog placement are appropriate.