### PR TITLE
fix(collab-web): render user and host messages as markdown

### DIFF
--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Rendered user and host transcript messages as Markdown and separated adjacent assistant content blocks. ([#5559](https://github.com/can1357/oh-my-pi/issues/5559))
+
 ## [16.5.1] - 2026-07-14
 
 ### Fixed

--- a/packages/collab-web/src/components/transcript/Transcript.tsx
+++ b/packages/collab-web/src/components/transcript/Transcript.tsx
@@ -54,19 +54,15 @@ function ThinkingBlock({ text, redacted }: { text: string; redacted?: boolean })
 	);
 }
 
-/** Plain text + image thumbnails for user / custom message content. */
+/** Markdown + image thumbnails for user / custom message content. */
 function MsgContent({ content }: { content: string | readonly (TextContent | ImageContent)[] }): ReactNode {
-	if (typeof content === "string") return <div className="tr-text">{content}</div>;
+	if (typeof content === "string") return <Markdown text={content} />;
 	return (
 		<>
 			{content.map((block, i) => {
 				switch (block.type) {
 					case "text":
-						return (
-							<div key={i} className="tr-text">
-								{block.text}
-							</div>
-						);
+						return <Markdown key={i} text={block.text} />;
 					case "image":
 						return (
 							<img

--- a/packages/collab-web/src/components/transcript/transcript.css
+++ b/packages/collab-web/src/components/transcript/transcript.css
@@ -52,15 +52,14 @@
 	gap: 4px;
 }
 
-.tr-body > .tr-md,
-.tr-body > .tr-text {
+.tr-row--assistant .tr-body {
+	gap: 8px;
+}
+
+.tr-body > .tr-md {
 	align-self: stretch;
 }
 
-.tr-text {
-	white-space: pre-wrap;
-	word-break: break-word;
-}
 
 .tr-row--custom .tr-body {
 	color: var(--fg-muted);

--- a/packages/collab-web/test/transcript.test.tsx
+++ b/packages/collab-web/test/transcript.test.tsx
@@ -112,3 +112,36 @@ describe("Transcript live tool rendering", () => {
 		expect(html).toContain("thinking…");
 	});
 });
+
+describe("Transcript message Markdown", () => {
+	it("renders host strings and guest text blocks as Markdown", () => {
+		const entries: SessionEntry[] = [
+			{
+				type: "message",
+				id: "host-markdown",
+				parentId: null,
+				timestamp: "2026-07-15T00:00:00Z",
+				message: {
+					role: "user",
+					content: "Use `381866285601915778`",
+					timestamp: 1,
+				},
+			},
+			{
+				type: "custom_message",
+				id: "guest-markdown",
+				parentId: "host-markdown",
+				timestamp: "2026-07-15T00:00:01Z",
+				customType: "collab-prompt",
+				content: [{ type: "text", text: "Guest uses **Markdown**" }],
+				details: { from: "guest" },
+				display: true,
+			},
+		];
+
+		const html = renderTranscript({ entries, working: false });
+
+		expect(countElements(html, ".tr-row--user .tr-md code")).toBe(1);
+		expect(countElements(html, ".tr-row--user .tr-md strong")).toBe(1);
+	});
+});


### PR DESCRIPTION
## Repro
A collab transcript containing a host `user` message with inline code and a `collab-prompt` custom message with bold text rendered both delimiters literally. `cd packages/collab-web && bun test test/transcript.test.tsx` reproduced the failure before the fix: `.tr-row--user .tr-md code` had `Expected: 1`, `Received: 0`.

## Cause
`MsgContent` in `packages/collab-web/src/components/transcript/Transcript.tsx` emitted string and text-block content through raw `.tr-text` elements, bypassing the sanitized `Markdown` renderer already used by `AssistantBody`. Assistant content siblings also inherited the transcript body's 4px gap, which did not clearly separate consecutive text and tool-call blocks.

## Fix
- Route string and text-block user/custom content through `Markdown`, preserving the existing image path.
- Increase spacing between assistant transcript content blocks while leaving other row layouts unchanged.
- Cover both host string content and guest array text content with a transcript regression test.
- Record the fix in the collab-web changelog.

## Verification
`cd packages/collab-web && bun test --parallel` passed 62 tests with 0 failures; `bun run check` passed; `bun run build` bundled 106 modules successfully. The focused regression now passes with 3 tests and 0 failures. Browser visual smoke testing was attempted but unavailable in the runner because Chromium could not load `libglib-2.0.so.0`. Fixes #5559