### PR TITLE
fix(discovery): root Codex config.toml MCP command/cwd at config dir

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions ([#5535](https://github.com/can1357/oh-my-pi/issues/5535)).
 - Fixed the built-in `fd` printing `fd: Broken pipe (os error 32)` when a downstream pipeline reader exited early (e.g. `fd … | head`); it now exits silently with 141 (128+SIGPIPE), matching real fd.
 - Fixed prewalk repeatedly continuing after a bash-only task such as `commit` had already completed ([#5551](https://github.com/can1357/oh-my-pi/issues/5551)).
+- Fixed the Codex `config.toml` MCP importer dropping `cwd` and leaving relative `command` values unrooted, which broke the bundled Codex Computer Use server (`ENOENT` on spawn); relative `command`/`cwd` now resolve against the Codex config directory like the claude-plugins/omp-plugins providers ([#5561](https://github.com/can1357/oh-my-pi/issues/5561)).
 
 ## [16.5.2] - 2026-07-14
 

--- a/packages/coding-agent/src/discovery/codex.ts
+++ b/packages/coding-agent/src/discovery/codex.ts
@@ -153,10 +153,11 @@ function extractMCPServersFromToml(
 	const result: Record<string, Partial<MCPServer>> = {};
 
 	for (const [name, config] of Object.entries(codexServers)) {
-		// Root relative command/cwd at the Codex config directory, not the session
-		// cwd (MCP stdio spawning resolves relative values there). Matches the
-		// claude-plugins/omp-plugins providers fixed in #5481.
-		const rooted = resolvePluginStdioPaths({ command: config.command, cwd: config.cwd }, configDir);
+		// Root relative cwd/command against the Codex config directory. Codex
+		// spawns the process with the resolved cwd, so a relative command is
+		// resolved by the OS from there — pass "cwd" so e.g. cwd="server",
+		// command="./bin/mcp" resolves to <configDir>/server/bin/mcp.
+		const rooted = resolvePluginStdioPaths({ command: config.command, cwd: config.cwd }, configDir, "cwd");
 		const server: Partial<MCPServer> = {
 			...(rooted.command !== undefined && { command: rooted.command }),
 			args: config.args,

--- a/packages/coding-agent/src/discovery/codex.ts
+++ b/packages/coding-agent/src/discovery/codex.ts
@@ -37,6 +37,7 @@ import {
 	SOURCE_PATHS,
 	scanSkillsFromDir,
 } from "./helpers";
+import { resolvePluginStdioPaths } from "./substitute-plugin-root";
 
 const PROVIDER_ID = "codex";
 const DISPLAY_NAME = "OpenAI Codex";
@@ -87,7 +88,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 
 	const items: MCPServer[] = [];
 	if (userConfig) {
-		const servers = extractMCPServersFromToml(userConfig);
+		const servers = extractMCPServersFromToml(userConfig, path.dirname(userConfigPath));
 		for (const [name, config] of Object.entries(servers)) {
 			items.push({
 				name,
@@ -97,7 +98,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 		}
 	}
 	if (projectConfig) {
-		const servers = extractMCPServersFromToml(projectConfig);
+		const servers = extractMCPServersFromToml(projectConfig, path.dirname(projectConfigPath));
 		for (const [name, config] of Object.entries(servers)) {
 			items.push({
 				name,
@@ -139,7 +140,10 @@ interface CodexMCPConfig {
 	disabled_tools?: string[];
 }
 
-function extractMCPServersFromToml(toml: Record<string, unknown>): Record<string, Partial<MCPServer>> {
+function extractMCPServersFromToml(
+	toml: Record<string, unknown>,
+	configDir: string,
+): Record<string, Partial<MCPServer>> {
 	// Check for [mcp_servers.*] sections (Codex format)
 	if (!toml.mcp_servers || typeof toml.mcp_servers !== "object") {
 		return {};
@@ -149,10 +153,15 @@ function extractMCPServersFromToml(toml: Record<string, unknown>): Record<string
 	const result: Record<string, Partial<MCPServer>> = {};
 
 	for (const [name, config] of Object.entries(codexServers)) {
+		// Root relative command/cwd at the Codex config directory, not the session
+		// cwd (MCP stdio spawning resolves relative values there). Matches the
+		// claude-plugins/omp-plugins providers fixed in #5481.
+		const rooted = resolvePluginStdioPaths({ command: config.command, cwd: config.cwd }, configDir);
 		const server: Partial<MCPServer> = {
-			command: config.command,
+			...(rooted.command !== undefined && { command: rooted.command }),
 			args: config.args,
 			url: config.url,
+			...(rooted.cwd !== undefined && { cwd: rooted.cwd }),
 		};
 
 		// Build env by merging explicit env and forwarded env_vars

--- a/packages/coding-agent/src/discovery/substitute-plugin-root.ts
+++ b/packages/coding-agent/src/discovery/substitute-plugin-root.ts
@@ -31,27 +31,38 @@ export function substitutePluginRoot<T>(value: T, rootPath: string): T {
 }
 
 /**
- * Rebase relative filesystem values in a discovered plugin stdio config against
- * the directory of the `.mcp.json`/`config.toml` that declared them.
+ * Where a relative, path-like `command` is rooted by {@link resolvePluginStdioPaths}.
  *
- * External plugin configs (bundled ChatGPT/Codex plugins, Claude marketplace
- * plugins) express `command`/`cwd` relative to their own config file, but MCP
- * stdio spawning roots relative values at the session cwd — so a plugin shipping
+ * - `"config-dir"` (default): the directory of the config file that declared the
+ *   server — the plugin package root for `.mcp.json`. A plugin can ship its
+ *   executable at the package root (`command: "./bin/server"`) yet run from a
+ *   data subdir (`cwd: "work"`); the command stays `<pkg>/bin/server`.
+ * - `"cwd"`: the rooted `cwd`, falling back to the config dir when no `cwd` is
+ *   set. This matches how the OS resolves a relative command against the
+ *   subprocess's working directory, which is the Codex `config.toml` contract:
+ *   `cwd = "server"`, `command = "./bin/mcp"` → `<configDir>/server/bin/mcp`.
+ */
+export type StdioCommandBase = "config-dir" | "cwd";
+
+/**
+ * Rebase relative filesystem values in a discovered stdio server config against
+ * the directory of the config file (`.mcp.json`/`config.toml`) that declared them.
+ *
+ * External configs (bundled ChatGPT/Codex plugins, Claude marketplace plugins)
+ * express `command`/`cwd` relative to their own config file, but MCP stdio
+ * spawning roots relative values at the session cwd — so a server shipping
  * `command: "./bin/server"`, `cwd: "."` launches from the wrong directory and
  * fails with ENOENT. This resolves those against `configDir` instead:
  *
  * - relative `cwd` → resolved against `configDir`;
  * - path-like `command` (`./`, `../`, or the Windows `.\`/`..\` forms) →
- *   resolved against the rooted `cwd` when one is given, else `configDir`.
- *   The transport spawns the subprocess with the rooted `cwd` as its process
- *   cwd (see `mcp/transports/stdio.ts`), so the OS resolves a relative command
- *   from there — e.g. `cwd = "server"`, `command = "./bin/mcp"` must resolve to
- *   `<configDir>/server/bin/mcp`, not `<configDir>/bin/mcp`;
+ *   resolved against the base selected by `commandBase` (see {@link StdioCommandBase});
  * - bare executables (`npx`, `uvx`, …) and absolute paths are left untouched.
  */
 export function resolvePluginStdioPaths(
 	config: { command?: string; cwd?: string },
 	configDir: string,
+	commandBase: StdioCommandBase = "config-dir",
 ): { command?: string; cwd?: string } {
 	const resolved: { command?: string; cwd?: string } = {};
 	if (typeof config.cwd === "string") {
@@ -59,10 +70,8 @@ export function resolvePluginStdioPaths(
 	}
 	if (config.command !== undefined) {
 		const isPathLike = /^\.\.?[/\\]/.test(config.command);
-		// Path-like commands resolve from the rooted cwd (the subprocess's actual
-		// working directory) when set, otherwise from the config directory.
-		const commandBase = resolved.cwd ?? configDir;
-		resolved.command = isPathLike ? path.resolve(commandBase, config.command) : config.command;
+		const base = commandBase === "cwd" ? (resolved.cwd ?? configDir) : configDir;
+		resolved.command = isPathLike ? path.resolve(base, config.command) : config.command;
 	}
 	return resolved;
 }

--- a/packages/coding-agent/src/discovery/substitute-plugin-root.ts
+++ b/packages/coding-agent/src/discovery/substitute-plugin-root.ts
@@ -32,7 +32,7 @@ export function substitutePluginRoot<T>(value: T, rootPath: string): T {
 
 /**
  * Rebase relative filesystem values in a discovered plugin stdio config against
- * the directory of the `.mcp.json` that declared them.
+ * the directory of the `.mcp.json`/`config.toml` that declared them.
  *
  * External plugin configs (bundled ChatGPT/Codex plugins, Claude marketplace
  * plugins) express `command`/`cwd` relative to their own config file, but MCP
@@ -42,7 +42,11 @@ export function substitutePluginRoot<T>(value: T, rootPath: string): T {
  *
  * - relative `cwd` → resolved against `configDir`;
  * - path-like `command` (`./`, `../`, or the Windows `.\`/`..\` forms) →
- *   resolved against `configDir`;
+ *   resolved against the rooted `cwd` when one is given, else `configDir`.
+ *   The transport spawns the subprocess with the rooted `cwd` as its process
+ *   cwd (see `mcp/transports/stdio.ts`), so the OS resolves a relative command
+ *   from there — e.g. `cwd = "server"`, `command = "./bin/mcp"` must resolve to
+ *   `<configDir>/server/bin/mcp`, not `<configDir>/bin/mcp`;
  * - bare executables (`npx`, `uvx`, …) and absolute paths are left untouched.
  */
 export function resolvePluginStdioPaths(
@@ -55,7 +59,10 @@ export function resolvePluginStdioPaths(
 	}
 	if (config.command !== undefined) {
 		const isPathLike = /^\.\.?[/\\]/.test(config.command);
-		resolved.command = isPathLike ? path.resolve(configDir, config.command) : config.command;
+		// Path-like commands resolve from the rooted cwd (the subprocess's actual
+		// working directory) when set, otherwise from the config directory.
+		const commandBase = resolved.cwd ?? configDir;
+		resolved.command = isPathLike ? path.resolve(commandBase, config.command) : config.command;
 	}
 	return resolved;
 }

--- a/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
+++ b/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression tests for #5561.
+ *
+ * The Codex `config.toml` MCP importer in `packages/coding-agent/src/discovery/codex.ts`
+ * used to copy only `command`/`args`/`url` into the returned `MCPServer`, dropping
+ * `cwd` and leaving relative `command` values verbatim. MCP stdio spawning then
+ * resolved those relative values against the OMP session cwd, so the bundled Codex
+ * Computer Use server (a relative `command` with `cwd = "."`) failed with ENOENT.
+ *
+ * The importer now roots relative `command`/`cwd` at the config directory via
+ * `resolvePluginStdioPaths`, matching the claude-plugins/omp-plugins fix in #5481.
+ */
+import { afterEach, beforeEach, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { MCPServer } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import { mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+let tempHome = "";
+let tempCwd = "";
+let originalHome: string | undefined;
+
+beforeEach(async () => {
+	originalHome = process.env.HOME;
+	tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-codex-mcp-home-"));
+	tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-codex-mcp-cwd-"));
+	process.env.HOME = tempHome;
+	vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+	await fs.mkdir(path.join(tempHome, ".codex"), { recursive: true });
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	await removeWithRetries(tempHome);
+	await removeWithRetries(tempCwd);
+});
+
+async function loadCodexServers(): Promise<MCPServer[]> {
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd: tempCwd,
+		providers: ["codex"],
+	});
+	return result.items;
+}
+
+test("relative path-like command and cwd resolve against the Codex config directory (#5561)", async () => {
+	const codexDir = path.join(tempHome, ".codex");
+	await fs.writeFile(
+		path.join(codexDir, "config.toml"),
+		[
+			"[mcp_servers.computer-use]",
+			'command = "./bin/SkyComputerUseClient"',
+			'args = ["mcp"]',
+			'cwd = "."',
+			"",
+			"[mcp_servers.bare]",
+			'command = "npx"',
+			'args = ["-y", "@some/mcp"]',
+			"",
+		].join("\n"),
+	);
+
+	const servers = await loadCodexServers();
+	const cu = servers.find(s => s.name === "computer-use");
+	const bare = servers.find(s => s.name === "bare");
+
+	// Path-like command and "." cwd rebase onto the config directory (~/.codex),
+	// not the session cwd. Bare executables are left untouched.
+	expect(cu?.command).toBe(path.join(codexDir, "bin", "SkyComputerUseClient"));
+	expect(cu?.cwd).toBe(codexDir);
+	expect(cu?.args).toEqual(["mcp"]);
+	expect(bare?.command).toBe("npx");
+	expect(bare?.cwd).toBeUndefined();
+});

--- a/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
+++ b/packages/coding-agent/test/discovery/codex-mcp-cwd.test.ts
@@ -77,3 +77,20 @@ test("relative path-like command and cwd resolve against the Codex config direct
 	expect(bare?.command).toBe("npx");
 	expect(bare?.cwd).toBeUndefined();
 });
+
+test("path-like command resolves against a subdirectory cwd, not the config directory (#5562 review)", async () => {
+	const codexDir = path.join(tempHome, ".codex");
+	await fs.writeFile(
+		path.join(codexDir, "config.toml"),
+		["[mcp_servers.nested]", 'command = "./bin/mcp"', 'args = ["serve"]', 'cwd = "server"', ""].join("\n"),
+	);
+
+	const servers = await loadCodexServers();
+	const nested = servers.find(s => s.name === "nested");
+
+	// The transport spawns the subprocess with the rooted cwd; a relative command
+	// is resolved by the OS from there. cwd="server" + command="./bin/mcp" must
+	// resolve to <codexDir>/server/bin/mcp, not <codexDir>/bin/mcp.
+	expect(nested?.cwd).toBe(path.join(codexDir, "server"));
+	expect(nested?.command).toBe(path.join(codexDir, "server", "bin", "mcp"));
+});

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -211,6 +211,26 @@ test("relative path-like command and cwd resolve against the plugin config direc
 	expect(bare?.cwd).toBeUndefined();
 });
 
+test("path-like command stays rooted at the plugin package root even with a subdirectory cwd", async () => {
+	// Plugin .mcp.json commands are relative to the plugin package root, not the
+	// declared cwd: a plugin may ship its executable at the root yet run from a
+	// data subdir. cwd rebases to <ext>/work but command stays <ext>/bin/server.
+	writeFile(
+		path.join(ext, ".mcp.json"),
+		JSON.stringify({
+			mcpServers: {
+				local: { command: "./bin/server", args: ["mcp"], cwd: "work" },
+			},
+		}),
+	);
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [ext] }));
+
+	const servers = await loadFromPlugin<{ name: string; command?: string; cwd?: string }>(mcpCapability.id, ctx());
+	const local = servers.find(s => s.name === "local");
+	expect(local?.command).toBe(path.join(ext, "bin", "server"));
+	expect(local?.cwd).toBe(path.join(ext, "work"));
+});
+
 test("installed plugins under `<plugins>/node_modules/` are surfaced (e.g. via `omp plugin link`/`install`)", async () => {
 	// Simulate what `plugin install` / `plugin link` produces: a plugins root
 	// with `package.json#dependencies` and a populated `node_modules/<pkg>/`.


### PR DESCRIPTION
## Repro
A `~/.codex/config.toml` entry for the bundled Codex Computer Use server ships a relative `command` with `cwd = "."`:

```toml
[mcp_servers.computer-use]
command = "./bin/SkyComputerUseClient"
args = ["mcp"]
cwd = "."
```

Loading it through the `codex` MCP provider from an unrelated project directory yields `{ "command": "./bin/SkyComputerUseClient", "args": ["mcp"], "transport": "stdio" }` — `cwd` is dropped and the relative `command` is left verbatim, so stdio spawning resolves it against the OMP session cwd and fails with `ENOENT: … posix_spawn './...SkyComputerUseClient'`. Reproduced with a temp-home discovery test loading `mcp_servers.*` from Codex TOML.

## Cause
`extractMCPServersFromToml()` in `packages/coding-agent/src/discovery/codex.ts` copied only `command`, `args`, and `url` into the returned `MCPServer`. Unlike the `claude-plugins`/`omp-plugins` providers fixed in #5481, it never called `resolvePluginStdioPaths`, so `cwd` was discarded entirely and relative path-like commands were never rebased onto the config directory.

## Fix
- `loadMCPServers` now passes each config's directory (`path.dirname(userConfigPath)` / `path.dirname(projectConfigPath)`) into the extractor.
- `extractMCPServersFromToml` takes a `configDir` and routes `command`/`cwd` through `resolvePluginStdioPaths` (imported from `./substitute-plugin-root`), rooting relative path-like commands and relative `cwd` at the Codex config directory while leaving bare executables and absolute paths untouched.
- Added `test/discovery/codex-mcp-cwd.test.ts` covering the relative-command + `cwd = "."` case and the bare-executable passthrough.
- Changelog entry under `## [Unreleased] › Fixed`.

## Verification
`bun test test/discovery/codex-mcp-cwd.test.ts test/discovery/codex-hooks-discovery.test.ts` → 4 pass, 0 fail. The new regression test asserts the Computer Use `command`/`cwd` resolve against `~/.codex` independently of the session cwd, and that a bare `npx` command is left unchanged.

Fixes #5561