### PR TITLE
fix(shell): materialize process substitution fds for builtins

### DIFF
--- a/crates/pi-shell/src/coreutils.rs
+++ b/crates/pi-shell/src/coreutils.rs
@@ -9,7 +9,7 @@
 
 use std::{
 	collections::HashMap,
-	ffi::OsString,
+	ffi::{OsStr, OsString},
 	io::{self, Read, Write},
 	panic::catch_unwind,
 	sync::{
@@ -18,6 +18,8 @@ use std::{
 	},
 };
 
+#[cfg(unix)]
+use brush_core::ShellFd;
 use brush_core::{
 	Error,
 	builtins::{BoxFuture, ContentOptions, ContentType, Registration},
@@ -30,6 +32,34 @@ use brush_core::{
 /// Signature of a patched uutils `run` entry point: consumes `argv` (with the
 /// command name at index 0) and returns a process-style exit code.
 type UutilRun = fn(Vec<OsString>) -> i32;
+
+#[cfg(unix)]
+fn process_substitution_fd(arg: &OsStr) -> Option<ShellFd> {
+	let fd = arg.to_str()?.strip_prefix("/dev/fd/")?.parse().ok()?;
+	(fd > OpenFiles::STDERR_FD).then_some(fd)
+}
+
+#[cfg(unix)]
+fn materialize_process_substitution_fds<SE: ShellExtensions>(
+	context: &ExecutionContext<'_, SE>,
+	argv: &mut [OsString],
+) -> Result<Vec<std::os::fd::OwnedFd>, Error> {
+	use std::os::fd::AsRawFd as _;
+
+	let mut fds = Vec::new();
+	for arg in argv {
+		let Some(shell_fd) = process_substitution_fd(arg) else {
+			continue;
+		};
+		let Some(file) = context.try_fd(shell_fd) else {
+			continue;
+		};
+		let fd = file.try_borrow_as_fd()?.try_clone_to_owned()?;
+		*arg = OsString::from(format!("/dev/fd/{}", fd.as_raw_fd()));
+		fds.push(fd);
+	}
+	Ok(fds)
+}
 
 /// Drives a patched uutils utility to completion under a [`pi_uutils_ctx`]
 /// scope derived from the command execution context.
@@ -76,14 +106,18 @@ async fn run_uutil<SE: ShellExtensions>(
 
 	// brush passes the command name as the first `CommandArg`, which is exactly
 	// the argv[0] uutils' argument parsing expects.
-	let argv: Vec<OsString> = args
+	let mut argv: Vec<OsString> = args
 		.iter()
 		.map(|arg| OsString::from(arg.to_string()))
 		.collect();
+	#[cfg(unix)]
+	let process_substitution_fds = materialize_process_substitution_fds(&context, &mut argv)?;
 
 	drop(context);
 
 	let mut handle = tokio::task::spawn_blocking(move || {
+		#[cfg(unix)]
+		let _process_substitution_fds = process_substitution_fds;
 		let stdin: Box<dyn Read + Send> = match stdin {
 			Some(file) => Box::new(file),
 			None => Box::new(io::empty()),

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -3216,6 +3216,20 @@ mod tests {
 	}
 
 	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn uutils_diff_reads_process_substitution_fds() {
+		let (result, output) = time::timeout(
+			Duration::from_secs(5),
+			run_command_capture("diff <(echo a) <(echo b)", None, None, CancelToken::default()),
+		)
+		.await
+		.expect("process substitution should not hang");
+
+		assert_eq!(result.exit_code, Some(1));
+		assert!(output.contains("-a\n+b\n"), "diff output missing changed lines: {output:?}");
+	}
+
+	#[cfg(unix)]
 	fn printf_minimizer(
 		settings_path: &std::path::Path,
 		max_capture_bytes: Option<u32>,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions ([#5535](https://github.com/can1357/oh-my-pi/issues/5535)).
+- Fixed the Bash tool hanging when in-process commands read process substitution operands such as `<(cmd)` ([#5557](https://github.com/can1357/oh-my-pi/issues/5557)).
 
 ## [16.5.2] - 2026-07-14
 


### PR DESCRIPTION
## Repro
Running `diff <(echo "a") <(echo "b")` through the Bash tool produced no output and timed out after 5 seconds; external `/usr/bin/rev <(echo abc)` completed, isolating the failure to in-process uutils commands.

## Cause
`brush-core` stores process-substitution pipes under logical shell descriptors and passes operands such as `/dev/fd/63`. External commands receive those descriptors through `compose_std_command`/`inject_fds`, but `run_uutil` in `crates/pi-shell/src/coreutils.rs` invokes builtins such as `diff` in-process, so their direct filesystem opens resolved `/dev/fd/63` against an unrelated host descriptor and blocked.

## Fix
- Materialize referenced process-substitution descriptors as live OS descriptors before invoking an in-process uutils builtin.
- Rewrite each logical `/dev/fd/N` operand to its materialized descriptor while keeping the descriptor alive for the builtin invocation.
- Add regression coverage for `diff` reading two process substitutions and record the user-visible fix in the coding-agent changelog.

## Verification
`cargo test -p pi-shell uutils_diff_reads_process_substitution_fds` passed. `cargo test -p pi-shell` passed all 831 tests on rerun (one unrelated session-lifecycle test raced once, then passed alone and in the rerun). A direct `executeBash('diff <(echo "a") <(echo "b")', { timeout: 5000 })` smoke check completed without cancellation at exit code 1 and produced the `a`/`b` diff. The pre-publish `bun check` gate passed. Fixes #5557