### PR TITLE
fix(acp): pick up MCP tools that connect after the startup race

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -2367,6 +2367,18 @@ export class AcpAgent implements Agent {
 		}
 
 		const manager = new MCPManager(record.session.sessionManager.getCwd());
+		manager.setOnToolsChanged(tools => {
+			// `connectServers` below only waits `STARTUP_TIMEOUT_MS` (250ms) before
+			// returning; slower servers (stdio JVM processes, remote HTTP MCPs) finish
+			// connecting afterward and report their tools through this callback. Without
+			// it those tools would connect successfully but never reach the model.
+			if (record.mcpManager !== manager) return;
+			void record.session.refreshMCPTools(tools, { activateAll: true }).catch(error => {
+				logger.warn("ACP MCP tool refresh failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		});
 		const configs: MCPConfigMap = {};
 		const sources: MCPSourceMap = {};
 		for (const server of servers) {


### PR DESCRIPTION
## What

Refresh MCP tools if one gets registered after startup timeout.

Under `acp-agent.ts`, subscribe to `MCPManager#setOnToolsChanged` in `#configureMcpServers`, mirroring the existing pattern in `sdk.ts`, so tools that finish connecting after the initial race still reach `session.refreshMCPTools(...)`.

## Why

Under `acp-agent.ts`,  `#configureMcpServers` calls `manager.connectServers`, which only waits for `STARTUP_TIMEOUT_MS` (250ms) before returning, which is quite tight. This means any mcp server registrations thats slower, like pycharm's heavy java mcp server, doesnt get registered. They also dont return an error, they are just silently dropped.

Running `omp acp` under PyCharm (or any ACP client), MCP servers passed via `session/new`'s `mcpServers` param never shows up as tools, if they miss the 250ms timeout.

## Testing

Tested omp acp agent under pycharm with `tavily` and `pycharm` mcps. MCP's did not register even though pycharm sent them. After the fix, mcps successfully register with omp acp. 

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
