### PR TITLE
fix: disable eager tool streaming for custom Anthropic endpoints

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed custom Anthropic endpoints receiving the first-party legacy fine-grained tool-streaming beta when eager tool input streaming is disabled ([#5572](https://github.com/can1357/oh-my-pi/issues/5572)).
 - Parsed Ollama NDJSON response bytes directly instead of decoding and buffering every network chunk as text. ([#5542](https://github.com/can1357/oh-my-pi/issues/5542))
 - Fixed Amazon Bedrock stream error handling for non-`Error` values that `JSON.stringify` cannot serialize ([#5539](https://github.com/can1357/oh-my-pi/issues/5539)).
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed custom Anthropic endpoints receiving the first-party legacy fine-grained tool-streaming beta when eager tool input streaming is disabled ([#5572](https://github.com/can1357/oh-my-pi/issues/5572)).
+- Fixed custom and Foundry-routed Anthropic endpoints receiving first-party eager/legacy tool-streaming controls ([#5572](https://github.com/can1357/oh-my-pi/issues/5572)).
 - Parsed Ollama NDJSON response bytes directly instead of decoding and buffering every network chunk as text. ([#5542](https://github.com/can1357/oh-my-pi/issues/5542))
 - Fixed Amazon Bedrock stream error handling for non-`Error` values that `JSON.stringify` cannot serialize ([#5539](https://github.com/can1357/oh-my-pi/issues/5539)).
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2682,7 +2682,8 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	const compat = model.compat;
 	const disableStrictTools = disableStrictToolsOverride ?? compat.disableStrictTools;
 	const needsInterleavedBeta = interleavedThinking && !model.thinking?.supportsDisplay;
-	const needsFineGrainedToolStreamingBeta = hasTools && !compat.supportsEagerToolInputStreaming;
+	const needsFineGrainedToolStreamingBeta =
+		hasTools && compat.officialEndpoint && !compat.supportsEagerToolInputStreaming;
 	const oauthToken = isOAuth ?? isAnthropicOAuthToken(apiKey);
 	const baseUrl = resolveAnthropicBaseUrl(model, apiKey);
 	const foundryCustomHeaders = resolveAnthropicCustomHeaders(model);
@@ -2699,9 +2700,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	if (model.provider === "github-copilot") {
 		const copilotApiKey = parseGitHubCopilotApiKey(apiKey).accessToken;
 		// The GitHub Copilot Anthropic proxy doesn't accept Anthropic beta
-		// features (and the catalog already forces `supportsEagerToolInputStreaming
-		// = false` for this host, so `needsFineGrainedToolStreamingBeta` is true
-		// whenever tools are present). Forward only caller-supplied betas.
+		// features. Forward only caller-supplied betas.
 		const betaFeatures = [...extraBetas];
 		const defaultHeaders = mergeHeaders(
 			{

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1167,6 +1167,15 @@ function resolveAnthropicBaseUrl(model: Model<"anthropic-messages">, apiKey?: st
 	return normalizeAnthropicBaseUrl(model.baseUrl);
 }
 
+function resolveEagerToolInputStreamingSupport(
+	model: Model<"anthropic-messages">,
+	effectiveBaseUrl: string | undefined,
+): boolean {
+	if (!model.compat.supportsEagerToolInputStreaming) return false;
+	if (isOfficialAnthropicApiUrl(effectiveBaseUrl)) return true;
+	return normalizeAnthropicBaseUrl(model.baseUrl) === effectiveBaseUrl;
+}
+
 function parseAnthropicCustomHeaders(rawHeaders: string | undefined): Record<string, string> | undefined {
 	const source = rawHeaders?.trim();
 	if (!source) return undefined;
@@ -1741,6 +1750,7 @@ const streamAnthropicOnce = (
 			}
 			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
 			const baseUrl = resolveAnthropicBaseUrl(model, apiKey) ?? "https://api.anthropic.com";
+			const supportsEagerToolInputStreaming = resolveEagerToolInputStreamingSupport(model, baseUrl);
 			const providerSessionState = getAnthropicProviderSessionState(
 				options?.providerSessionState,
 				baseUrl,
@@ -1854,15 +1864,12 @@ const streamAnthropicOnce = (
 			}
 			const preparedContext = await prepareAnthropicManyImageContext(context, model.input.includes("image"));
 			const prepareParams = async (): Promise<MessageCreateParamsStreaming> => {
-				let nextParams = buildParams(
-					model,
-					preparedContext,
-					isOAuthToken,
-					options,
+				let nextParams = buildParams(model, preparedContext, isOAuthToken, options, {
 					disableStrictTools,
-					umansGatewayWebSearchHeader !== undefined,
+					useUmansGatewayWebSearch: umansGatewayWebSearchHeader !== undefined,
 					forceDemoteUnsignedThinking,
-				);
+					supportsEagerToolInputStreaming,
+				});
 				if (disableStrictTools) {
 					dropAnthropicStrictTools(nextParams);
 				}
@@ -2682,10 +2689,11 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	const compat = model.compat;
 	const disableStrictTools = disableStrictToolsOverride ?? compat.disableStrictTools;
 	const needsInterleavedBeta = interleavedThinking && !model.thinking?.supportsDisplay;
-	const needsFineGrainedToolStreamingBeta =
-		hasTools && compat.officialEndpoint && !compat.supportsEagerToolInputStreaming;
 	const oauthToken = isOAuth ?? isAnthropicOAuthToken(apiKey);
 	const baseUrl = resolveAnthropicBaseUrl(model, apiKey);
+	const supportsEagerToolInputStreaming = resolveEagerToolInputStreamingSupport(model, baseUrl);
+	const needsFineGrainedToolStreamingBeta =
+		hasTools && isOfficialAnthropicApiUrl(baseUrl) && !supportsEagerToolInputStreaming;
 	const foundryCustomHeaders = resolveAnthropicCustomHeaders(model);
 	const tlsFetchOptions = buildClaudeCodeTlsFetchOptions(model, baseUrl);
 	// Disable Bun's native ~300s pre-response fetch timeout (issue #2422).
@@ -3128,15 +3136,26 @@ function extractClaudeCodeFirstUserMessageText(messages: readonly Message[]): st
 	return "";
 }
 
+type AnthropicParamBuildOptions = {
+	disableStrictTools: boolean;
+	useUmansGatewayWebSearch: boolean;
+	forceDemoteUnsignedThinking: boolean;
+	supportsEagerToolInputStreaming: boolean;
+};
+
 function buildParams(
 	model: Model<"anthropic-messages">,
 	context: Context,
 	isOAuthToken: boolean,
-	options?: AnthropicOptions,
-	disableStrictTools = false,
-	useUmansGatewayWebSearch = false,
-	forceDemoteUnsignedThinking = false,
+	options: AnthropicOptions | undefined,
+	buildOptions: AnthropicParamBuildOptions,
 ): MessageCreateParamsStreaming {
+	const {
+		disableStrictTools,
+		useUmansGatewayWebSearch,
+		forceDemoteUnsignedThinking,
+		supportsEagerToolInputStreaming,
+	} = buildOptions;
 	// A session-scoped auto-demote (learned from a live signing 400) clones the
 	// resolved compat with `replayUnsignedThinking: false` so every subsequent
 	// downstream read (convertAnthropicMessages, transformMessages) sees the
@@ -3164,7 +3183,7 @@ function buildParams(
 			context.tools,
 			isOAuthToken,
 			disableStrictTools || model.provider === "github-copilot",
-			model.compat.supportsEagerToolInputStreaming,
+			supportsEagerToolInputStreaming,
 			model.compat.escapeBuiltinToolNames,
 			useUmansGatewayWebSearch,
 		);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1172,8 +1172,18 @@ function resolveEagerToolInputStreamingSupport(
 	effectiveBaseUrl: string | undefined,
 ): boolean {
 	if (!model.compat.supportsEagerToolInputStreaming) return false;
+	// First-party Anthropic endpoints accept the per-tool flag.
 	if (isOfficialAnthropicApiUrl(effectiveBaseUrl)) return true;
-	return normalizeAnthropicBaseUrl(model.baseUrl) === effectiveBaseUrl;
+	// Non-official effective endpoint. `supportsEagerToolInputStreaming` may be
+	// stale-true here because compat is materialized once at build time and is
+	// never rebuilt for a baseUrl-only reroute — either a runtime provider
+	// override (`pi.registerProvider("anthropic", { baseUrl })`) or Foundry
+	// (`CLAUDE_CODE_USE_FOUNDRY`). Both leave the canonical model's resolved
+	// compat in place. `officialEndpoint` records whether compat was built for
+	// the canonical Anthropic URL, so only endpoints whose compat was authored
+	// for a non-official host (an explicit `compat.supportsEagerToolInputStreaming`
+	// opt-in on a custom `baseUrl`) still send the field.
+	return !model.compat.officialEndpoint;
 }
 
 function parseAnthropicCustomHeaders(rawHeaders: string | undefined): Record<string, string> | undefined {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1682,13 +1682,14 @@ describe("Anthropic request fingerprint alignment", () => {
 				FOUNDRY_BASE_URL: "https://foundry.example.com/anthropic/",
 				ANTHROPIC_CUSTOM_HEADERS: "user-id: alice, x-route: engineering",
 			},
-			() => {
+			async () => {
 				const options = buildAnthropicClientOptions({
 					model: ANTHROPIC_MODEL,
 					apiKey: "foundry-token",
 					extraBetas: [],
 					stream: true,
 					interleavedThinking: false,
+					hasTools: true,
 					dynamicHeaders: {},
 				});
 
@@ -1697,6 +1698,24 @@ describe("Anthropic request fingerprint alignment", () => {
 				expect(options.defaultHeaders["X-Api-Key"]).toBeUndefined();
 				expect(options.defaultHeaders["user-id"]).toBe("alice");
 				expect(options.defaultHeaders["x-route"]).toBe("engineering");
+				expect(options.defaultHeaders["anthropic-beta"] ?? "").not.toContain(
+					"fine-grained-tool-streaming-2025-05-14",
+				);
+
+				const payload = await captureAnthropicPayload(ANTHROPIC_MODEL, {
+					systemPrompt: ["Stay concise."],
+					messages: [{ role: "user", content: "Hi", timestamp: 0 }],
+					tools: [
+						{
+							name: "ping",
+							description: "ping",
+							parameters: { type: "object", properties: {}, additionalProperties: false },
+						},
+					],
+				});
+				expect(payload).toMatchObject({
+					tools: [expect.not.objectContaining({ eager_input_streaming: expect.anything() })],
+				});
 			},
 		);
 	});

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom Anthropic endpoints receiving the first-party-only `eager_input_streaming` tool field by default ([#5572](https://github.com/can1357/oh-my-pi/issues/5572)).
+
 ## [16.5.2] - 2026-07-14
 
 ### Fixed

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -109,7 +109,7 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		signingEndpoint,
 		disableStrictTools: isAzure,
 		disableAdaptiveThinking: false,
-		supportsEagerToolInputStreaming: !isCopilot,
+		supportsEagerToolInputStreaming: official,
 		// Long cache retention is only sent to the official API by default;
 		// proxies opt in explicitly via `compat.supportsLongCacheRetention: true`.
 		supportsLongCacheRetention: official,

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -372,7 +372,7 @@ export interface AnthropicCompat {
 	 * tags: 'disabled', 'enabled'`.
 	 */
 	disableAdaptiveThinking?: boolean;
-	/** Whether tools may include Anthropic's per-tool eager_input_streaming flag. Default: true. */
+	/** Whether tools may include Anthropic's per-tool eager_input_streaming flag. Default: true for the canonical Anthropic API. */
 	supportsEagerToolInputStreaming?: boolean;
 	/** Whether long prompt-cache retention (`ttl: "1h"`) is supported. Default: true for canonical Anthropic API. */
 	supportsLongCacheRetention?: boolean;

--- a/packages/catalog/test/issue-5572-repro.test.ts
+++ b/packages/catalog/test/issue-5572-repro.test.ts
@@ -70,6 +70,75 @@ describe("issue #5572 — custom Anthropic endpoints reject eager_input_streamin
 		expect(options.defaultHeaders["anthropic-beta"] ?? "").not.toContain("fine-grained-tool-streaming-2025-05-14");
 	});
 
+	it("omits eager_input_streaming when a baseUrl-only override reroutes a canonical model", async () => {
+		// Mirrors `pi.registerProvider("anthropic", { baseUrl })`: the registry
+		// mutates `baseUrl` without rebuilding compat, so the resolved
+		// `supportsEagerToolInputStreaming` stays canonical-true. The authored
+		// spec never opted in, so the custom endpoint must not receive the flag.
+		const model = buildModel({
+			...CUSTOM_MODEL_SPEC,
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+		});
+		expect(model.compat.supportsEagerToolInputStreaming).toBe(true);
+		model.baseUrl = "https://proxy.example.com";
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamAnthropic(model, CONTEXT, {
+			apiKey: "sk-ant-test",
+			signal: aborted(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = (await promise) as { tools?: Array<Record<string, unknown>> };
+		expect(payload.tools).toHaveLength(1);
+		expect(payload.tools?.[0]).not.toHaveProperty("eager_input_streaming");
+	});
+
+	it("omits eager_input_streaming after a baseUrl override even when the spec baked a resolved official compat", async () => {
+		// Some bundled models (e.g. `claude-3-7-sonnet-20250219`) ship a
+		// fully-resolved compat block in models.json, so `compatConfig` carries
+		// `supportsEagerToolInputStreaming: true`. Gating on `compatConfig` alone
+		// would leak the field; the fix keys on the resolved `officialEndpoint`
+		// provenance instead.
+		const model = buildModel({
+			...CUSTOM_MODEL_SPEC,
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			compat: { supportsEagerToolInputStreaming: true },
+		});
+		expect(model.compat.officialEndpoint).toBe(true);
+		expect(model.compatConfig?.supportsEagerToolInputStreaming).toBe(true);
+		model.baseUrl = "https://proxy.example.com";
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamAnthropic(model, CONTEXT, {
+			apiKey: "sk-ant-test",
+			signal: aborted(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = (await promise) as { tools?: Array<Record<string, unknown>> };
+		expect(payload.tools?.[0]).not.toHaveProperty("eager_input_streaming");
+	});
+
+	it("honors explicit compat opt-in on a custom endpoint", async () => {
+		const model = buildModel({
+			...CUSTOM_MODEL_SPEC,
+			compat: { supportsEagerToolInputStreaming: true },
+		});
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamAnthropic(model, CONTEXT, {
+			apiKey: "sk-ant-test",
+			signal: aborted(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = (await promise) as { tools?: Array<Record<string, unknown>> };
+		expect(payload.tools?.[0]).toHaveProperty("eager_input_streaming", true);
+	});
+
 	it("keeps eager tool input streaming on the official Anthropic endpoint", () => {
 		const model = buildModel({
 			...CUSTOM_MODEL_SPEC,

--- a/packages/catalog/test/issue-5572-repro.test.ts
+++ b/packages/catalog/test/issue-5572-repro.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import { buildAnthropicClientOptions, streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { Context, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
@@ -54,6 +54,20 @@ describe("issue #5572 — custom Anthropic endpoints reject eager_input_streamin
 		const payload = (await promise) as { tools?: Array<Record<string, unknown>> };
 		expect(payload.tools).toHaveLength(1);
 		expect(payload.tools?.[0]).not.toHaveProperty("eager_input_streaming");
+	});
+
+	it("omits the legacy fine-grained streaming beta from custom endpoint requests", () => {
+		const model = buildModel(CUSTOM_MODEL_SPEC);
+		const options = buildAnthropicClientOptions({
+			model,
+			apiKey: "sk-ant-test",
+			extraBetas: [],
+			stream: true,
+			interleavedThinking: false,
+			hasTools: true,
+		});
+
+		expect(options.defaultHeaders["anthropic-beta"] ?? "").not.toContain("fine-grained-tool-streaming-2025-05-14");
 	});
 
 	it("keeps eager tool input streaming on the official Anthropic endpoint", () => {

--- a/packages/catalog/test/issue-5572-repro.test.ts
+++ b/packages/catalog/test/issue-5572-repro.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { streamAnthropic } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { Context, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+const CUSTOM_MODEL_SPEC: ModelSpec<"anthropic-messages"> = {
+	id: "claude-haiku-4.5",
+	name: "Claude Haiku 4.5",
+	api: "anthropic-messages",
+	provider: "internal-anthropic",
+	baseUrl: "https://llm.example.com/v1/messages",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const TOOLS: Tool[] = [
+	{
+		name: "ping",
+		description: "ping",
+		parameters: {
+			type: "object",
+			properties: { msg: { type: "string" } },
+			required: ["msg"],
+		} as TJsonSchema,
+	},
+];
+
+const CONTEXT: Context = {
+	systemPrompt: ["Stay concise."],
+	messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+	tools: TOOLS,
+};
+
+function aborted(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+describe("issue #5572 — custom Anthropic endpoints reject eager_input_streaming", () => {
+	it("omits eager_input_streaming from custom endpoint tool definitions", async () => {
+		const model = buildModel(CUSTOM_MODEL_SPEC);
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamAnthropic(model, CONTEXT, {
+			apiKey: "sk-ant-test",
+			signal: aborted(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = (await promise) as { tools?: Array<Record<string, unknown>> };
+		expect(payload.tools).toHaveLength(1);
+		expect(payload.tools?.[0]).not.toHaveProperty("eager_input_streaming");
+	});
+
+	it("keeps eager tool input streaming on the official Anthropic endpoint", () => {
+		const model = buildModel({
+			...CUSTOM_MODEL_SPEC,
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+		});
+
+		expect(model.compat.supportsEagerToolInputStreaming).toBe(true);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed `models.yml` rejecting the Anthropic `compat.supportsEagerToolInputStreaming` override for custom endpoints ([#5572](https://github.com/can1357/oh-my-pi/issues/5572)).
 - Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions ([#5535](https://github.com/can1357/oh-my-pi/issues/5535)).
 - Fixed the built-in `fd` printing `fd: Broken pipe (os error 32)` when a downstream pipeline reader exited early (e.g. `fd … | head`); it now exits silently with 141 (128+SIGPIPE), matching real fd.
 - Fixed prewalk repeatedly continuing after a bash-only task such as `commit` had already completed ([#5551](https://github.com/can1357/oh-my-pi/issues/5551)).

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -60,6 +60,7 @@ const OpenAICompatFields = {
 	"strictResponsesPairing?": "boolean",
 	"supportsImageDetailOriginal?": "boolean",
 	// anthropic-messages compat flags (same `compat` slot, per-api interpretation)
+	"supportsEagerToolInputStreaming?": "boolean",
 	"requiresToolResultId?": "boolean",
 	"replayUnsignedThinking?": "boolean",
 } as const;

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -511,6 +511,7 @@ describe("ModelRegistry", () => {
 		let customCompat: ModelRegistry;
 		let customModelCompat: ModelRegistry;
 		let customResponsesCompat: ModelRegistry;
+		let customAnthropicCompat: ModelRegistry;
 		beforeAll(() => {
 			providerCompat = readonlyRegistry({
 				providers: {
@@ -544,6 +545,28 @@ describe("ModelRegistry", () => {
 								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 								contextWindow: 1000,
 								maxTokens: 100,
+							},
+						],
+					},
+				},
+			});
+			customAnthropicCompat = readonlyRegistry({
+				providers: {
+					"anthropic-proxy": {
+						baseUrl: "https://example.com/v1/messages",
+						apiKey: "ANTHROPIC_PROXY_KEY",
+						api: "anthropic-messages",
+						compat: {
+							supportsEagerToolInputStreaming: true,
+						},
+						models: [
+							{
+								id: "claude-haiku-4.5",
+								reasoning: false,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 200_000,
+								maxTokens: 8_192,
 							},
 						],
 					},
@@ -632,6 +655,11 @@ describe("ModelRegistry", () => {
 			expect(compat?.supportsUsageInStreaming).toBe(false);
 			expect(compat?.maxTokensField).toBe("max_tokens");
 			expect(compat?.cacheControlFormat).toBe("anthropic");
+		});
+
+		test("custom Anthropic providers can opt into eager tool input streaming", () => {
+			const model = customAnthropicCompat.find("anthropic-proxy", "claude-haiku-4.5");
+			expect(model?.compat).toMatchObject({ supportsEagerToolInputStreaming: true });
 		});
 
 		test("custom Responses providers can disable original image detail", () => {


### PR DESCRIPTION
## Repro
A custom model using `api: anthropic-messages` and a non-canonical `baseUrl` emitted `eager_input_streaming: true` in every tool definition. `bun test packages/catalog/test/issue-5572-repro.test.ts` reproduced the failure before the fix: the payload assertion expected the field to be absent but received `true`.

## Cause
`buildAnthropicCompat` in `packages/catalog/src/compat/anthropic.ts` defaulted `supportsEagerToolInputStreaming` to true for every endpoint except GitHub Copilot, although the field is a first-party Anthropic capability. `OpenAICompatFields` in `packages/coding-agent/src/config/models-config-schema.ts` also omitted that Anthropic compat key, so `models.yml` could not explicitly override the inferred capability.

## Fix
- Default eager tool-input streaming to canonical `api.anthropic.com` endpoints only; custom endpoints omit the unsupported tool field.
- Accept `compat.supportsEagerToolInputStreaming` in custom provider/model configuration so compatible proxies can opt in.
- Cover custom endpoint wire payloads, the official endpoint boundary, config opt-in, and the existing GitHub Copilot behavior.

## Verification
`bun test packages/catalog/test/issue-5572-repro.test.ts packages/catalog/test/issue-2558-repro.test.ts packages/coding-agent/test/model-registry.test.ts` passed 88 tests with 0 failures. `bun check` passed across all packages. Fixes #5572