### PR TITLE
fix(tui): restore file completion in slash arguments

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Display LaTeX renders multi-letter script words (`N_{turns}`) as raised/lowered blocks instead of ragged per-character Unicode sub/superscript glyphs; single letters and digits keep the compact Unicode forms.
 - Added opt-in `Editor.setImeSafeCursorLayout()` protection for macOS IME preedit while retaining the compact bordered layout by default ([#5563](https://github.com/can1357/oh-my-pi/issues/5563)).
 
+### Fixed
+
+- Fixed `@` file-reference and path completion falling through incorrectly inside slash command arguments when command-specific argument completion has no matches ([#5580](https://github.com/can1357/oh-my-pi/issues/5580)).
+
 ## [16.5.2] - 2026-07-14
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -464,10 +464,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				// path (`/tmp/fo` at prompt start, `see /tmp` mid-prompt); fall
 				// through to file-path completion.
 			} else if (!isMidPromptSkillLookup) {
-				// Submitted slash commands own their argument text only when the
-				// matched command accepts args. No-arg slash-looking prompts such
-				// as `/settings @file` still fall through to prompt-composer
-				// completions because submit treats them as normal prompt text.
+				// Give matched commands first chance to complete arguments, then
+				// fall through to prompt-composer file completion when they have
+				// no argument provider or it has no matches.
 				const commandName = commandText.slice(1, spaceIndex); // Command without "/"
 				const argumentText = commandText.slice(spaceIndex + 1); // Text after space
 
@@ -475,20 +474,19 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				if (command && "allowArgs" in command && command.allowArgs === false && !/\S/.test(argumentText)) {
 					return null;
 				}
-				if (command && (!("allowArgs" in command) || command.allowArgs !== false)) {
-					if (!("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
-						return null; // No argument completion for this command
-					}
-
+				if (
+					command &&
+					(!("allowArgs" in command) || command.allowArgs !== false) &&
+					"getArgumentCompletions" in command &&
+					command.getArgumentCompletions
+				) {
 					const argumentSuggestions = await command.getArgumentCompletions(argumentText);
-					if (!Array.isArray(argumentSuggestions) || argumentSuggestions.length === 0) {
-						return null;
+					if (Array.isArray(argumentSuggestions) && argumentSuggestions.length > 0) {
+						return {
+							items: argumentSuggestions,
+							prefix: argumentText,
+						};
 					}
-
-					return {
-						items: argumentSuggestions,
-						prefix: argumentText,
-					};
 				}
 			}
 		}

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -199,7 +199,7 @@ describe("CombinedAutocompleteProvider", () => {
 			}
 		});
 
-		it("treats @ file-reference tokens as literal text inside slash command arguments without completions", async () => {
+		it("returns @ file-reference completions inside slash command arguments without command completions", async () => {
 			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-rename-args-"));
 			try {
 				fs.writeFileSync(path.join(baseDir, "copy-target.ts"), "export {};\n");
@@ -210,7 +210,8 @@ describe("CombinedAutocompleteProvider", () => {
 				const line = "/rename repro @";
 				const result = await provider.getSuggestions([line], 0, line.length);
 
-				expect(result).toBeNull();
+				expect(result?.prefix).toBe("@");
+				expect(result?.items.map(item => item.value)).toContain("@copy-target.ts");
 			} finally {
 				fs.rmSync(baseDir, { recursive: true, force: true });
 			}
@@ -259,6 +260,37 @@ describe("CombinedAutocompleteProvider", () => {
 					prefix: "repro @",
 					items: [{ value: "repro @literal", label: "Keep @ in the title" }],
 				});
+			} finally {
+				fs.rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
+
+		it("falls back to path completions when slash command argument completions have no match", async () => {
+			const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "autocomplete-rename-path-"));
+			try {
+				fs.mkdirSync(path.join(baseDir, "src"));
+				fs.writeFileSync(path.join(baseDir, "src", "app.ts"), "export {};\n");
+				const provider = new CombinedAutocompleteProvider(
+					[
+						{
+							name: "btw",
+							description: "Ask a side question",
+							allowArgs: true,
+							getArgumentCompletions(argumentPrefix) {
+								if (argumentPrefix === "option") {
+									return [{ value: "option", label: "option" }];
+								}
+								return null;
+							},
+						},
+					],
+					baseDir,
+				);
+				const line = "/btw ./src/ap";
+				const result = await provider.getSuggestions([line], 0, line.length);
+
+				expect(result?.prefix).toBe("./src/ap");
+				expect(result?.items.map(item => item.value)).toContain("./src/app.ts");
 			} finally {
 				fs.rmSync(baseDir, { recursive: true, force: true });
 			}


### PR DESCRIPTION
## Repro
Typing `/btw @file` in the interactive editor produced no dropdown because the matched slash command accepted arguments but did not provide matching argument completions. The existing failure was reproduced with `bun test packages/tui/test/autocomplete.test.ts --test-name-pattern 'treats @ file-reference tokens as literal text inside slash command arguments without completions'`, whose passing assertion confirmed that the provider returned `null`.

## Cause
`CombinedAutocompleteProvider.getSuggestions()` in `packages/tui/src/autocomplete.ts` returned early whenever a matched slash command had no `getArgumentCompletions`, or when that callback returned no items. Those early returns prevented the shared `@` file-reference and path-completion branches from running.

## Fix
- Let command-specific argument suggestions retain precedence when they return items.
- Fall through to normal file-reference and path completion when the command has no argument provider or no current matches.
- Replace the obsolete suppression test and cover both fallback cases.
- Document the fix in the TUI changelog.

## Verification
`bun test packages/tui/test/autocomplete.test.ts` passed with 57 tests and 119 assertions. A direct provider smoke check returned `@src/app.ts` for `/btw @app` and `./src/app.ts` for `/btw ./src/ap`. The pre-publish `bun check` gate passed. Fixes #5580