### PR TITLE
fix(tui): use role tag in model selector status messages

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,10 @@
 - Renamed the system prompt's project-context section wrapper from `<context>` to `<repo-rules>` to stop it colliding with the `task` tool's `context` parameter under in-band XML tool dialects: models were closing `<parameter name="context">` with a stray `</context>` (primed by the ambient section tag) and emitting sibling params as bare `<tasks>` elements, so `tasks` arrived missing.
 - Rendered `read xd://` calls in the compact grouped read view instead of a full tool-execution card; other internal URLs (`skill://`, `agent://`, …) still render full so their resolved content stays visible.
 
+### Fixed
+
+- Made the model selector status messages use the role tag (`SMOL`, `SLOW`) instead of the display name (`Fast`, `Thinking`), matching the rest of the TUI and CLI/env role terminology ([#5585](https://github.com/can1357/oh-my-pi/issues/5585)).
+
 ### Removed
 
 - Removed the `tools.essentialOverride` setting; essential tools are configured through device mounting

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -745,7 +745,7 @@ export class SelectorController {
 								this.ctx.session.setThinkingLevel(AUTO_THINKING, true);
 							}
 							const roleInfo = getRoleInfo(role, settings);
-							this.ctx.showStatus(`${roleInfo?.name ?? role} model: ${selector ?? model.id}`);
+							this.ctx.showStatus(`${roleInfo?.tag ?? roleInfo?.name ?? role} model: ${selector ?? model.id}`);
 						}
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
@@ -755,7 +755,9 @@ export class SelectorController {
 					try {
 						this.ctx.settings.setModelRole(role, undefined);
 						const roleInfo = getRoleInfo(role, settings);
-						this.ctx.showStatus(`${roleInfo?.name ?? role} role cleared — auto-selection applies`);
+						this.ctx.showStatus(
+							`${roleInfo?.tag ?? roleInfo?.name ?? role} role cleared — auto-selection applies`,
+						);
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));
 					}
@@ -772,8 +774,8 @@ export class SelectorController {
 						const roleInfo = getRoleInfo(role, settings);
 						this.ctx.showStatus(
 							chain.length > 0
-								? `${roleInfo?.name ?? role} fallbacks: ${chain.join(" → ")}`
-								: `${roleInfo?.name ?? role} fallbacks cleared`,
+								? `${roleInfo?.tag ?? roleInfo?.name ?? role} fallbacks: ${chain.join(" → ")}`
+								: `${roleInfo?.tag ?? roleInfo?.name ?? role} fallbacks cleared`,
 						);
 					} catch (error) {
 						this.ctx.showError(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## Repro
Opening the model selector (`Ctrl`+`M`) and assigning, clearing, or changing the fallback chain for a role emits a status message keyed on the role's display name rather than its tag. Assigning the `smol` role shows `Fast model: <model>` and clearing it shows `Fast role cleared — auto-selection applies`, where the rest of the TUI/CLI consistently says `SMOL`. Verified with `MODEL_ROLES.smol = { tag: "SMOL", name: "Fast" }`: `` `${roleInfo?.name ?? role} model: gpt-x` `` → `Fast model: gpt-x` instead of `SMOL model: gpt-x`.

## Cause
`packages/coding-agent/src/modes/controllers/selector-controller.ts` built all three status messages (`onAssign`, `onUnassign`, `onFallbackChainChange`) from `roleInfo?.name ?? role`. Every other role-labeled surface — `model-browser.ts:262`, `model-hub.ts:782,1551,1666` — uses `info.tag ?? info.name ?? role`, so the selector controller was the lone place preferring `name`.

## Fix
- `selector-controller.ts`: changed all three status-message interpolations to `roleInfo?.tag ?? roleInfo?.name ?? role`, matching the shared precedence.
- Added a `### Fixed` changelog entry under `[Unreleased]`.

## Verification
`bun check` in `packages/coding-agent` passes (biome + tsgo, 2120 files, 0 errors). Confirmed the corrected precedence yields `SMOL model: …` / `SMOL role cleared …` for the `smol` role. Fixes #5585