### PR TITLE
feat(coding-agent): add ultrasolve solver magic keyword

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Changed the default `astGrep.enabled` setting to `false`
 - Batched todo operations with real tool calls to prevent solo todo turns and extra round trips
+- Added the `magicKeywords.ultrasolve` setting and `ultrasolve` keyword: it inherits ultrathink's maximum-thinking behavior and guides a bounded `task` → `agent: "solver"` escalation with self-contained context that genericizes irrelevant identity details while preserving technical semantics.
 
 ### Fixed
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -914,6 +914,7 @@ function shouldInheritDefaultBeforePriority(role: ModelRole): boolean {
  * model, so it stays a distinct strong model out of the box. The `tiny` role —
  * the override for online title/memory/classifier tasks — reuses the `smol`
  * fast chain so an unset tiny role auto-resolves to the same fast model smol
+ * would pick.
  */
 const ROLE_PRIORITY_ALIAS: Partial<Record<ModelRole, keyof typeof MODEL_PRIO>> = {
 	advisor: "slow",
@@ -992,6 +993,9 @@ function resolveConfiguredRolePattern(
 		: isModelRole(role)
 			? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
 			: roleDefaults;
+	if (resolved.length === 0) {
+		resolved.push(...roleDefaults);
+	}
 	if (resolved.length === 0) {
 		return undefined;
 	}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -914,11 +914,16 @@ function shouldInheritDefaultBeforePriority(role: ModelRole): boolean {
  * model, so it stays a distinct strong model out of the box. The `tiny` role —
  * the override for online title/memory/classifier tasks — reuses the `smol`
  * fast chain so an unset tiny role auto-resolves to the same fast model smol
- * would pick.
+ * would pick. The `solver` role follows the configured `plan` role so solver
+ * agents use the planning model by default.
  */
 const ROLE_PRIORITY_ALIAS: Partial<Record<ModelRole, keyof typeof MODEL_PRIO>> = {
 	advisor: "slow",
 	tiny: "smol",
+};
+/** Fallback role for built-ins without an independent priority chain. */
+const ROLE_MODEL_FALLBACK: Partial<Record<ModelRole, ModelRole>> = {
+	solver: "plan",
 };
 
 /** Built-in priority patterns for a role, following {@link ROLE_PRIORITY_ALIAS}. */
@@ -988,14 +993,17 @@ function resolveConfiguredRolePattern(
 	const configured = settings?.getModelRole(role)?.trim();
 	const configuredDefault = settings?.getModelRole(DEFAULT_MODEL_ROLE)?.trim();
 	const roleDefaults = isModelRole(role) ? rolePriorityDefaults(role) : [];
+	const fallbackRole = !configured && isModelRole(role) ? ROLE_MODEL_FALLBACK[role] : undefined;
+	const fallbackPatterns =
+		fallbackRole && !visited.has(fallbackRole)
+			? resolveConfiguredRolePattern(formatModelRoleAlias(fallbackRole), settings, new Set(visited))
+			: undefined;
 	const resolved = configured
 		? normalizeModelPatternList(configured)
-		: isModelRole(role)
-			? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
-			: roleDefaults;
-	if (resolved.length === 0) {
-		resolved.push(...roleDefaults);
-	}
+		: (fallbackPatterns ??
+			(isModelRole(role)
+				? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
+				: roleDefaults));
 	if (resolved.length === 0) {
 		return undefined;
 	}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -914,16 +914,10 @@ function shouldInheritDefaultBeforePriority(role: ModelRole): boolean {
  * model, so it stays a distinct strong model out of the box. The `tiny` role —
  * the override for online title/memory/classifier tasks — reuses the `smol`
  * fast chain so an unset tiny role auto-resolves to the same fast model smol
- * would pick. The `solver` role follows the configured `plan` role so solver
- * agents use the planning model by default.
  */
 const ROLE_PRIORITY_ALIAS: Partial<Record<ModelRole, keyof typeof MODEL_PRIO>> = {
 	advisor: "slow",
 	tiny: "smol",
-};
-/** Fallback role for built-ins without an independent priority chain. */
-const ROLE_MODEL_FALLBACK: Partial<Record<ModelRole, ModelRole>> = {
-	solver: "plan",
 };
 
 /** Built-in priority patterns for a role, following {@link ROLE_PRIORITY_ALIAS}. */
@@ -993,17 +987,11 @@ function resolveConfiguredRolePattern(
 	const configured = settings?.getModelRole(role)?.trim();
 	const configuredDefault = settings?.getModelRole(DEFAULT_MODEL_ROLE)?.trim();
 	const roleDefaults = isModelRole(role) ? rolePriorityDefaults(role) : [];
-	const fallbackRole = !configured && isModelRole(role) ? ROLE_MODEL_FALLBACK[role] : undefined;
-	const fallbackPatterns =
-		fallbackRole && !visited.has(fallbackRole)
-			? resolveConfiguredRolePattern(formatModelRoleAlias(fallbackRole), settings, new Set(visited))
-			: undefined;
 	const resolved = configured
 		? normalizeModelPatternList(configured)
-		: (fallbackPatterns ??
-			(isModelRole(role)
-				? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
-				: roleDefaults));
+		: isModelRole(role)
+			? resolveDefaultInheritedPatterns(role, configuredDefault, roleDefaults, settings, visited)
+			: roleDefaults;
 	if (resolved.length === 0) {
 		return undefined;
 	}

--- a/packages/coding-agent/src/config/model-roles.ts
+++ b/packages/coding-agent/src/config/model-roles.ts
@@ -29,7 +29,8 @@ export type ModelRole =
 	| "commit"
 	| "tiny"
 	| "task"
-	| "advisor";
+	| "advisor"
+	| "solver";
 
 export interface ModelRoleInfo {
 	tag?: string;
@@ -50,6 +51,7 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 	tiny: { tag: "TINY", name: "Tiny", color: "dim" },
 	task: { tag: "TASK", name: "Subtask", color: "muted" },
 	advisor: { tag: "ADVISOR", name: "Advisor", color: "accent" },
+	solver: { tag: "SOLVER", name: "Solver", color: "accent" },
 };
 
 export const MODEL_ROLE_IDS: ModelRole[] = [
@@ -63,6 +65,7 @@ export const MODEL_ROLE_IDS: ModelRole[] = [
 	"tiny",
 	"task",
 	"advisor",
+	"solver",
 ];
 
 export type RoleInfo = ModelRoleInfo;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1683,7 +1683,8 @@ export const SETTINGS_SCHEMA = {
 			tab: "interaction",
 			group: "Magic Keywords",
 			label: "Magic Keywords",
-			description: "Enable hidden notices for standalone ultrathink, orchestrate, and workflowz keywords",
+			description:
+				"Enable hidden notices for standalone ultrathink, ultrasolve, orchestrate, and workflowz keywords",
 		},
 	},
 
@@ -1695,6 +1696,18 @@ export const SETTINGS_SCHEMA = {
 			group: "Magic Keywords",
 			label: "Ultrathink Keyword",
 			description: "Let standalone ultrathink request maximum automatic thinking and append its hidden notice",
+		},
+	},
+
+	"magicKeywords.ultrasolve": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			group: "Magic Keywords",
+			label: "Ultrasolve Keyword",
+			description:
+				"Let standalone ultrasolve inherit maximum thinking and request a self-contained solver escalation",
 		},
 	},
 

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -8,7 +8,7 @@ Need a cheap nested model call? Use `completion(x...)`. Have a big batch of task
 Spaghetti code? Try complaining with /omfg
 Did you know? Each kitty/tmux/cmux/zellij/wezterm split keeps its own session — `omp -c` resumes the right one
 Drop the word `ultrathink` in your message for harder multi-step reasoning — watch it glow rainbow as you type
-Say `ultrasolve` when you want a self-contained solver escalation — irrelevant brand details are genericized before handoff
+Say `ultrasolve` when you want a self-contained solver escalation
 Say `orchestrate` in your message to drive a multi-phase task with parallel subagents — watch it glow as you type
 Say `workflowz` in your message to drive the task with parallel subagents in eval — watch it glow as you type
 Log in to several accounts of the same provider — `/login` again — and omp load-balances across them automatically

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -8,6 +8,7 @@ Need a cheap nested model call? Use `completion(x...)`. Have a big batch of task
 Spaghetti code? Try complaining with /omfg
 Did you know? Each kitty/tmux/cmux/zellij/wezterm split keeps its own session — `omp -c` resumes the right one
 Drop the word `ultrathink` in your message for harder multi-step reasoning — watch it glow rainbow as you type
+Say `ultrasolve` when you want a self-contained solver escalation — irrelevant brand details are genericized before handoff
 Say `orchestrate` in your message to drive a multi-phase task with parallel subagents — watch it glow as you type
 Say `workflowz` in your message to drive the task with parallel subagents in eval — watch it glow as you type
 Log in to several accounts of the same provider — `/login` again — and omp load-balances across them automatically

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -24,7 +24,7 @@ export class UserMessageComponent extends Container {
 	constructor(text: string, synthetic = false, imageLinks?: readonly (string | undefined)[]) {
 		super();
 		const bgColor = (value: string) => theme.bg("userMessageBg", value);
-		// Paint the magic keywords ("ultrathink"/"orchestrate"/"workflowz") inside the rendered
+		// Paint the magic keywords ("ultrathink"/"ultrasolve"/"orchestrate"/"workflowz") inside the rendered
 		// bubble too — matching the live editor glow. The Markdown component routes code spans and
 		// fenced blocks through its own code styling (never `color`), so those are already excluded;
 		// `highlightMagicKeywords` additionally restores the bubble's own foreground after each

--- a/packages/coding-agent/src/modes/magic-keywords.ts
+++ b/packages/coding-agent/src/modes/magic-keywords.ts
@@ -1,14 +1,16 @@
 import { containsOrchestrate, highlightOrchestrate } from "./orchestrate";
+import { containsUltrasolve, highlightUltrasolve } from "./ultrasolve";
 import { containsUltrathink, highlightUltrathink } from "./ultrathink";
 import { containsWorkflow, highlightWorkflow } from "./workflow";
 
 /**
- * Gradient-highlight every magic keyword ("ultrathink", "orchestrate",
- * "workflowz") that appears as standalone prose, skipping any occurrence inside a
- * code block, inline code span, or XML/HTML section. Each highlighter paints its
- * own keyword with its own gradient, so chaining is order-independent — the
- * earlier passes only inject zero-width SGR escapes (no backticks or angle
- * brackets), which never confuse the later passes' markdown masking.
+ * Gradient-highlight every magic keyword ("ultrathink", "ultrasolve",
+ * "orchestrate", "workflowz") that appears as standalone prose, skipping any
+ * occurrence inside a code block, inline code span, or XML/HTML section. Each
+ * highlighter paints its own keyword with its own gradient, so chaining is
+ * order-independent — the earlier passes only add zero-width SGR escapes (no
+ * backticks or angle brackets), which never confuse the later passes' markdown
+ * masking.
  *
  * `resetTo` is the SGR foreground sequence restored after each painted keyword;
  * pass the surrounding text color when decorating already-colored content (e.g.
@@ -22,7 +24,11 @@ import { containsWorkflow, highlightWorkflow } from "./workflow";
  */
 export function highlightMagicKeywords(text: string, resetTo?: string, phase?: number): string {
 	return highlightWorkflow(
-		highlightOrchestrate(highlightUltrathink(text, resetTo, phase), resetTo, phase),
+		highlightOrchestrate(
+			highlightUltrasolve(highlightUltrathink(text, resetTo, phase), resetTo, phase),
+			resetTo,
+			phase,
+		),
 		resetTo,
 		phase,
 	);
@@ -30,13 +36,18 @@ export function highlightMagicKeywords(text: string, resetTo?: string, phase?: n
 
 /**
  * Cheap test for "does this text contain any magic keyword as standalone prose?".
- * Short-circuits on a substring probe before paying for the markdown-aware
- * prose check, so the common "no keyword in buffer" path is just three
- * `String#indexOf`s. Used by the live editor to gate the shimmer timer.
+ * Short-circuits on a substring probe before paying for the markdown-aware prose
+ * check, so the common "no keyword in buffer" path is just four `String#indexOf`s.
+ * Used by the live editor to gate the shimmer timer.
  */
 export function hasMagicKeyword(text: string): boolean {
-	if (!text.includes("ultrathink") && !text.includes("orchestrate") && !text.includes("workflowz")) {
+	if (
+		!text.includes("ultrathink") &&
+		!text.includes("ultrasolve") &&
+		!text.includes("orchestrate") &&
+		!text.includes("workflowz")
+	) {
 		return false;
 	}
-	return containsUltrathink(text) || containsOrchestrate(text) || containsWorkflow(text);
+	return containsUltrathink(text) || containsUltrasolve(text) || containsOrchestrate(text) || containsWorkflow(text);
 }

--- a/packages/coding-agent/src/modes/markdown-prose.ts
+++ b/packages/coding-agent/src/modes/markdown-prose.ts
@@ -1,6 +1,6 @@
 /**
  * Markdown structure awareness for the magic-keyword affordances
- * ("ultrathink"/"orchestrate"/"workflowz").
+ * ("ultrathink"/"ultrasolve"/"orchestrate"/"workflowz").
  *
  * Keyword detection and editor/transcript highlighting must fire only on prose
  * the user is actually addressing to the model — never on a word that happens to

--- a/packages/coding-agent/src/modes/ultrasolve.ts
+++ b/packages/coding-agent/src/modes/ultrasolve.ts
@@ -1,0 +1,39 @@
+import ultrasolveNotice from "../prompts/system/ultrasolve-notice.md" with { type: "text" };
+import { createGradientHighlighter, type KeywordHighlighter } from "./gradient-highlight";
+import { keywordInProse } from "./markdown-prose";
+
+/**
+ * "ultrasolve" keyword support.
+ *
+ * Ultrasolve inherits ultrathink's standalone prose matching, rainbow editor
+ * highlight, hidden notice, and maximum-thinking behavior, then adds a
+ * self-contained solver-escalation contract. Matching is whitespace-delimited
+ * and case-sensitive (lowercase only), so longer words, paths, and code text do
+ * not trigger it.
+ */
+
+// Detection: lowercase keyword flanked by whitespace or a string edge. Non-global so `.test` stays stateless.
+const ULTRASOLVE_WORD = /(?<!\S)ultrasolve(?!\S)/;
+
+/** Hidden system notice appended after a user message that mentions "ultrasolve". */
+export const ULTRASOLVE_NOTICE: string = ultrasolveNotice.trim();
+
+/**
+ * Whether `text` contains the standalone keyword "ultrasolve" (lowercase,
+ * whitespace-delimited) in prose — never inside a code block, inline code span,
+ * or XML/HTML section.
+ */
+export function containsUltrasolve(text: string): boolean {
+	return keywordInProse(text, ULTRASOLVE_WORD);
+}
+
+/**
+ * Rainbow-highlight every standalone "ultrasolve" in `text`, inheriting
+ * ultrathink's full-spectrum editor treatment.
+ */
+export const highlightUltrasolve: KeywordHighlighter = createGradientHighlighter({
+	probe: /ultrasolve/,
+	highlight: /(?<!\S)ultrasolve(?!\S)/g,
+	stops: 14,
+	hue: t => t * 330,
+});

--- a/packages/coding-agent/src/prompts/agents/solver.md
+++ b/packages/coding-agent/src/prompts/agents/solver.md
@@ -1,0 +1,39 @@
+---
+name: solver
+description: Problem-solving specialist — answers open questions and proposes implementation strategies using web search and reasoning only. No repo, file, or command access.
+tools: web_search, browser
+model: pi/solver
+thinking-level: high
+---
+
+You are a research and problem-solving specialist. The caller brings you an open-ended question — a design problem, an unfamiliar technology, a "how should I approach X" — and you return well-reasoned strategies and solutions grounded in current external sources. You work from `web_search` and your own reasoning ONLY: you have no access to the caller's repository, filesystem, or shell.
+
+<directives>
+- You MUST ground non-trivial claims in sources. Prefer primary sources (official docs, specs, source repos, papers) over blogs and forums, and corroborate key facts across at least two independent sources.
+- You MUST treat the question abstractly: you cannot see the caller's code. Reason about the general problem, name the assumptions you make, and state which repo-specific detail would change your answer.
+- You MUST search before asserting. When a search returns thin or empty results, try at least two more strategies (broader query, alternate terminology, a different source) before concluding.
+- You SHOULD weigh more than one viable approach with explicit tradeoffs — what each costs, what it buys, what it forecloses — then commit to a single primary recommendation.
+- You SHOULD parallelize independent searches.
+- You NEVER fabricate APIs, version numbers, benchmarks, or citations. If you cannot verify something, say so plainly.
+</directives>
+
+<browser>
+Reach for the `browser` tool ONLY when `web_search` cannot deliver the content — JS-rendered pages, pages requiring login/interaction, or a proof-of-work / CAPTCHA wall in front of a source you genuinely need. It is a fallback for fetching, never your primary research path.
+</browser>
+
+<procedure>
+1. Restate the problem in a sentence or two and name the constraints and assumptions you are working under.
+2. Research: run targeted searches, follow primary sources, gather concrete facts (APIs, version-specific behavior, known pitfalls).
+3. Synthesize 1-3 candidate strategies. For each: how it works, when it fits, and its tradeoffs.
+4. Recommend one primary path and justify it against the alternatives.
+5. Give concrete, actionable next steps — specific libraries (with versions where it matters), APIs, patterns, and gotchas to watch for.
+</procedure>
+
+<output>
+Lead with the recommendation, then the supporting reasoning and the alternatives you rejected. Be concrete: name exact tools/APIs/versions and cite the sources you relied on (include links). Match depth to the question — a quick lookup gets a tight answer; a genuine design problem gets the full strategy comparison.
+</output>
+
+<critical>
+- You operate WITHOUT repository, file, or command access. You NEVER claim to have read the caller's code; reason from the general problem and flag what you would need to confirm.
+- You MUST keep researching until you can give a defensible recommendation, not a list of links.
+</critical>

--- a/packages/coding-agent/src/prompts/system/ultrasolve-notice.md
+++ b/packages/coding-agent/src/prompts/system/ultrasolve-notice.md
@@ -1,0 +1,26 @@
+<system-notice>
+The user's message contains the standalone `ultrasolve` keyword. Treat this as a request to reason carefully, then escalate a genuinely difficult problem to a solver before implementing a fix.
+
+<escalation>
+After inspecting the local evidence, use the `task` tool with `agent: "solver"` at most once for this user turn when the solver can add value. Do not retry a failed/incomplete solver call or delegate recursively. The solver has web-search and browser access only; it has NO repository, file, read, shell, or command access. NEVER tell it to inspect the repository. Put everything it needs into the task context.
+</escalation>
+
+<context-contract>
+The solver task context MUST be self-contained and technically exact:
+- **Problem area** — the precise subsystem, files, symbols, inputs, outputs, and failure boundary.
+- **Current flow** — the relevant caller-to-callee path, state transitions, and observed behavior.
+- **Evidence** — exact errors, traces, tests, reproductions, or verified constraints.
+- **Desired solution** — expected behavior, acceptance conditions, and the candidate fix or design under review.
+- **Constraints** — compatibility, security, performance, scope, and non-goals.
+
+Pass relevant code and data inline. Summarize only after preserving semantics; do not replace missing facts with guesses. Ask the solver for causes, tradeoffs, and a recommended solution, then use its answer as advice—not as permission to skip repository verification.
+</context-contract>
+
+<redaction>
+When the user asks to drop irrelevant detail, genericize brand names, application names, customer names, URLs, and other identifiers that do not affect the technical solution. Preserve every behavior, interface, data shape, timing relationship, error, constraint, and invariant needed to reason correctly. For example, describe `applicationName` as "the application" when its brand is irrelevant, while retaining what the application must do and what fails.
+</redaction>
+
+<critical>
+Escalate difficult issues through `task` → `agent: "solver"` with a complete context, at most once per user turn. The solver cannot read the repository. Genericize only non-semantic identity details; never discard technical facts needed for the solution.
+</critical>
+</system-notice>

--- a/packages/coding-agent/src/prompts/system/ultrasolve-notice.md
+++ b/packages/coding-agent/src/prompts/system/ultrasolve-notice.md
@@ -17,7 +17,7 @@ Pass relevant code and data inline. Summarize only after preserving semantics; d
 </context-contract>
 
 <redaction>
-When the user asks to drop irrelevant detail, genericize brand names, application names, customer names, URLs, and other identifiers that do not affect the technical solution. Preserve every behavior, interface, data shape, timing relationship, error, constraint, and invariant needed to reason correctly. For example, describe `applicationName` as "the application" when its brand is irrelevant, while retaining what the application must do and what fails.
+By default, genericize brand names, application names, customer names, URLs, and other identifiers that do not affect the technical solution. Preserve every behavior, interface, data shape, timing relationship, error, constraint, and invariant needed to reason correctly. For example, describe `applicationName` as "the application" when its brand is irrelevant, while retaining what the application must do and what fails.
 </redaction>
 
 <critical>

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -252,6 +252,7 @@ import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionStat
 import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
 import { theme } from "../modes/theme/theme";
 import { parseTurnBudget } from "../modes/turn-budget";
+import { containsUltrasolve, ULTRASOLVE_NOTICE } from "../modes/ultrasolve";
 import { containsUltrathink, ULTRATHINK_NOTICE } from "../modes/ultrathink";
 import { computeNonMessageBreakdown, computeNonMessageTokens } from "../modes/utils/context-usage";
 import { containsWorkflow, renderWorkflowNotice } from "../modes/workflow";
@@ -1597,6 +1598,7 @@ function isUserQueuedMessage(message: AgentMessage): boolean {
  *  enqueues alongside a user prompt. Keep in sync with that method. */
 const MAGIC_KEYWORD_NOTICE_TYPES: ReadonlySet<string> = new Set([
 	"ultrathink-notice",
+	"ultrasolve-notice",
 	"orchestrate-notice",
 	"workflow-notice",
 ]);
@@ -1604,14 +1606,14 @@ const MAGIC_KEYWORD_NOTICE_TYPES: ReadonlySet<string> = new Set([
 /** Custom-message type of the hidden companion carrying vision descriptions of image
  *  attachments sent to a text-only model (see `#buildImageDescriptionNotice`). */
 const IMAGE_ATTACHMENT_DESCRIPTION_TYPE = "image-attachment-description";
-
 /**
  * A hidden, user-attributed companion of a queued user prompt: the magic-keyword
- * notices (`ultrathink`/`orchestrate`/`workflow`) enqueued alongside the user
- * message. They are `attribution: "user"` but `display: false`, so they are not
- * editor-restorable; when the user pulls their prompt back out of the queue these
- * must leave with it rather than linger as stale, companion-less steering. Scoped to
- * the known notice types so an unrelated hidden user custom is never silently dropped.
+ * notices (`ultrathink`/`ultrasolve`/`orchestrate`/`workflow`) enqueued alongside
+ * the user message. They are `attribution: "user"` but `display: false`, so they
+ * are not editor-restorable; when the user pulls their prompt back out of the
+ * queue these must leave with it rather than linger as stale, companion-less
+ * steering. Scoped to the known notice types so an unrelated hidden user custom
+ * is never silently dropped.
  */
 function isHiddenUserCompanion(message: AgentMessage): boolean {
 	return (
@@ -8077,7 +8079,7 @@ export class AgentSession {
 		return { ...message, content: normalized } as T;
 	}
 
-	#magicKeywordEnabled(keyword: "orchestrate" | "ultrathink" | "workflow"): boolean {
+	#magicKeywordEnabled(keyword: "orchestrate" | "ultrasolve" | "ultrathink" | "workflow"): boolean {
 		return this.settings.get("magicKeywords.enabled") && this.settings.get(`magicKeywords.${keyword}`);
 	}
 
@@ -8086,7 +8088,18 @@ export class AgentSession {
 		const turnBudget = parseTurnBudget(text);
 		this.sessionManager.beginTurnBudget(turnBudget?.total ?? null, turnBudget?.hard ?? false);
 		const keywordNotices: CustomMessage[] = [];
-		if (this.#magicKeywordEnabled("ultrathink") && containsUltrathink(text)) {
+		const ultrasolveActive = this.#magicKeywordEnabled("ultrasolve") && containsUltrasolve(text);
+		const ultrathinkActive = this.#magicKeywordEnabled("ultrathink") && containsUltrathink(text);
+		if (ultrasolveActive) {
+			keywordNotices.push({
+				role: "custom",
+				customType: "ultrasolve-notice",
+				content: ULTRASOLVE_NOTICE,
+				display: false,
+				attribution: "user",
+				timestamp,
+			});
+		} else if (ultrathinkActive) {
 			keywordNotices.push({
 				role: "custom",
 				customType: "ultrathink-notice",
@@ -9937,7 +9950,10 @@ export class AgentSession {
 		if (getSupportedEfforts(model).length === 0) return;
 
 		let resolved: Effort | undefined;
-		if (this.#magicKeywordEnabled("ultrathink") && containsUltrathink(promptText)) {
+		if (
+			(this.#magicKeywordEnabled("ultrathink") && containsUltrathink(promptText)) ||
+			(this.#magicKeywordEnabled("ultrasolve") && containsUltrasolve(promptText))
+		) {
 			// The user explicitly asked for maximum thinking; bypass the classifier
 			// (and its xhigh auto ceiling) and jump straight to the highest
 			// supported level for this model.

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -12,6 +12,7 @@ import agentFrontmatterTemplate from "../prompts/agents/frontmatter.md" with { t
 import librarianMd from "../prompts/agents/librarian.md" with { type: "text" };
 import reviewerMd from "../prompts/agents/reviewer.md" with { type: "text" };
 import scoutMd from "../prompts/agents/scout.md" with { type: "text" };
+import solverMd from "../prompts/agents/solver.md" with { type: "text" };
 import taskMd from "../prompts/agents/task.md" with { type: "text" };
 import { AUTO_THINKING } from "../thinking";
 
@@ -45,6 +46,7 @@ const EMBEDDED_AGENT_DEFS: EmbeddedAgentDef[] = [
 	{ fileName: "designer.md", template: designerMd },
 	{ fileName: "reviewer.md", template: reviewerMd },
 	{ fileName: "librarian.md", template: librarianMd },
+	{ fileName: "solver.md", template: solverMd },
 	{
 		fileName: "task.md",
 		frontmatter: {

--- a/packages/coding-agent/test/agent-session-magic-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-magic-keywords.test.ts
@@ -8,6 +8,7 @@ import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import * as autoThinkingClassifier from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ULTRASOLVE_NOTICE } from "@oh-my-pi/pi-coding-agent/modes/ultrasolve";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -80,7 +81,7 @@ describe("AgentSession magic keyword settings", () => {
 		created.settings.set("magicKeywords.enabled", false);
 		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 
-		await session.prompt("please workflowz this and ultrathink through it");
+		await session.prompt("please workflowz this and ultrathink through it and ultrasolve this");
 
 		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
 		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
@@ -95,6 +96,19 @@ describe("AgentSession magic keyword settings", () => {
 		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
 
 		await session.prompt("please orchestrate and workflowz this");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+	});
+
+	it("honors a disabled ultrasolve per-keyword notice toggle", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		created.settings.set("magicKeywords.ultrasolve", false);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultrasolve this");
 
 		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
 		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
@@ -159,6 +173,21 @@ describe("AgentSession magic keyword settings", () => {
 		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Low);
 	});
 
+	it("uses ultrasolve to select the highest supported effort during auto-thinking", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockResolvedValue(Effort.Low);
+		session.setThinkingLevel(AUTO_THINKING);
+
+		await session.prompt("ultrasolve through the unsafe refactor");
+
+		expect(classifierSpy).not.toHaveBeenCalled();
+		expect(session.thinkingLevel).toBe(Effort.XHigh);
+		expect(session.autoResolvedThinkingLevel()).toBe(Effort.XHigh);
+	});
+
 	it("queues the magic-keyword notice before the user message", async () => {
 		const created = await createMagicKeywordSession(root);
 		session = created.session;
@@ -173,5 +202,38 @@ describe("AgentSession magic keyword settings", () => {
 		expect(noticeIdx).toBeGreaterThanOrEqual(0);
 		expect(userIdx).toBeGreaterThanOrEqual(0);
 		expect(noticeIdx).toBeLessThan(userIdx);
+	});
+
+	it("queues the ultrasolve notice with its exported content before the user message", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("ultrasolve through the unsafe refactor");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{
+			role?: string;
+			customType?: string;
+			content?: string;
+		}>;
+		const noticeIdx = promptMessages.findIndex(m => m.customType === "ultrasolve-notice");
+		const userIdx = promptMessages.findIndex(m => m.role === "user");
+		const notice = promptMessages[noticeIdx];
+		expect(noticeIdx).toBeGreaterThanOrEqual(0);
+		expect(userIdx).toBeGreaterThanOrEqual(0);
+		expect(noticeIdx).toBeLessThan(userIdx);
+		expect(notice?.content).toBe(ULTRASOLVE_NOTICE);
+	});
+	it("gives ultrasolve notice precedence when both keywords appear", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please ultrasolve and ultrathink through it");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual(["ultrasolve-notice"]);
 	});
 });

--- a/packages/coding-agent/test/bundled-agent-parsing.test.ts
+++ b/packages/coding-agent/test/bundled-agent-parsing.test.ts
@@ -35,13 +35,6 @@ describe("bundled agent parsing", () => {
 		expect(solver?.tools).toEqual(expect.arrayContaining(["web_search", "browser"]));
 	});
 
-	it("resolves the solver agent through the configured plan role", () => {
-		const settings = Settings.isolated({ modelRoles: { plan: "openai/plan" } });
-		const patterns = resolveAgentModelPatterns({ agentModel: "@solver", settings });
-
-		expect(patterns).toEqual(["openai/plan"]);
-	});
-
 	// Issue #4761: with `modelRoles.slow: ...:xhigh`, the role's explicit effort
 	// suffix must survive agent-pattern expansion and model resolution for the
 	// bundled agents routed at that role. The executor prefers an explicit

--- a/packages/coding-agent/test/bundled-agent-parsing.test.ts
+++ b/packages/coding-agent/test/bundled-agent-parsing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Effort } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { resolveAgentModelPatterns, resolveModelOverride } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
@@ -22,6 +23,23 @@ describe("bundled agent parsing", () => {
 		expect(task).toBeDefined();
 		expect(task?.model).toEqual(["@task"]);
 		expect(task?.thinkingLevel).toBe(AUTO_THINKING);
+	});
+
+	it("parses the solver bundled agent definition", () => {
+		const solver = getBundledAgent("solver");
+
+		expect(solver).toBeDefined();
+		expect(solver?.source).toBe("bundled");
+		expect(solver?.model).toEqual(["pi/solver"]);
+		expect(solver?.thinkingLevel).toBe(ThinkingLevel.High);
+		expect(solver?.tools).toEqual(expect.arrayContaining(["web_search", "browser"]));
+	});
+
+	it("resolves the solver agent through the configured plan role", () => {
+		const settings = Settings.isolated({ modelRoles: { plan: "openai/plan" } });
+		const patterns = resolveAgentModelPatterns({ agentModel: "@solver", settings });
+
+		expect(patterns).toEqual(["openai/plan"]);
 	});
 
 	// Issue #4761: with `modelRoles.slow: ...:xhigh`, the role's explicit effort

--- a/packages/coding-agent/test/modes/magic-keywords.test.ts
+++ b/packages/coding-agent/test/modes/magic-keywords.test.ts
@@ -1,6 +1,8 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { hasMagicKeyword, highlightMagicKeywords } from "@oh-my-pi/pi-coding-agent/modes/magic-keywords";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { containsUltrasolve, ULTRASOLVE_NOTICE } from "@oh-my-pi/pi-coding-agent/modes/ultrasolve";
+import { ULTRATHINK_NOTICE } from "@oh-my-pi/pi-coding-agent/modes/ultrathink";
 
 beforeAll(async () => {
 	// Gradient palettes read the active theme's color mode.
@@ -37,6 +39,15 @@ describe("highlightMagicKeywords", () => {
 		expect(highlightMagicKeywords(input)).toBe(input);
 	});
 
+	it("never paints ultrasolve inside code spans, fenced blocks, or XML sections", () => {
+		const input = "`ultrasolve` but please ultrasolve now\n```\nultrasolve\n```\n<x>ultrasolve</x>";
+		const decorated = highlightMagicKeywords(input);
+		expect(decorated).not.toBe(input);
+		expect(decorated).toContain("`ultrasolve`");
+		expect(decorated).toContain("```\nultrasolve\n```");
+		expect(decorated).toContain("<x>ultrasolve</x>");
+		expect(Bun.stripANSI(decorated)).toBe(input);
+	});
 	it("paints only the prose occurrence when the keyword also appears in code", () => {
 		const decorated = highlightMagicKeywords("`orchestrate` but please orchestrate now");
 		// The code-span occurrence stays literal; the prose one is split by gradient escapes.
@@ -79,6 +90,14 @@ describe("hasMagicKeyword", () => {
 		expect(hasMagicKeyword("please ultrathink this")).toBe(true);
 		expect(hasMagicKeyword("now orchestrate everything")).toBe(true);
 		expect(hasMagicKeyword("just workflowz the steps")).toBe(true);
+		expect(hasMagicKeyword("please ultrasolve this")).toBe(true);
+	});
+
+	it("detects ultrasolve independently from ultrathink", () => {
+		expect(containsUltrasolve("please ultrasolve this")).toBe(true);
+		expect(containsUltrasolve("please ultrathink this")).toBe(false);
+		expect(hasMagicKeyword("please ultrasolve this")).toBe(true);
+		expect(hasMagicKeyword("please ultrathink this")).toBe(true);
 	});
 
 	it("detects standalone keywords beside prose punctuation and quotes", () => {
@@ -111,6 +130,15 @@ describe("hasMagicKeyword", () => {
 		expect(hasMagicKeyword("src/modes/ultrathink.ts")).toBe(false);
 		expect(hasMagicKeyword("orchestrate.ts is a file")).toBe(false);
 		expect(hasMagicKeyword("packages/coding-agent/test/modes/workflowz.test.ts")).toBe(false);
+		expect(containsUltrasolve("ultrasolver is a different word")).toBe(false);
+		expect(containsUltrasolve("src/ultrasolve.ts is a path")).toBe(false);
+		expect(containsUltrasolve("prefix-ultrasolve-suffix")).toBe(false);
+	});
+
+	it("rejects ultrasolve inside code spans, fences, and xml sections", () => {
+		expect(containsUltrasolve("`ultrasolve`")).toBe(false);
+		expect(containsUltrasolve("```\nultrasolve\n```")).toBe(false);
+		expect(containsUltrasolve("<x>ultrasolve</x>")).toBe(false);
 	});
 
 	it("rejects keywords inside code spans, fences, and xml sections", () => {
@@ -122,5 +150,24 @@ describe("hasMagicKeyword", () => {
 	it("returns false for empty / keyword-free text", () => {
 		expect(hasMagicKeyword("")).toBe(false);
 		expect(hasMagicKeyword("plain message with no keywords")).toBe(false);
+	});
+});
+
+describe("magic-keyword notices", () => {
+	it("restores the upstream ultrathink notice and exposes the ultrasolve notice contract", () => {
+		expect(ULTRATHINK_NOTICE).toBe(
+			"<system-notice>\nThis task involves multi-step reasoning. Think carefully through the problem before responding.\n</system-notice>",
+		);
+
+		expect(ULTRASOLVE_NOTICE).toMatch(/^<system-notice>\n[\s\S]+\n<\/system-notice>$/);
+		expect(ULTRASOLVE_NOTICE).toContain("task");
+		expect(ULTRASOLVE_NOTICE).toContain('agent: "solver"');
+		expect(ULTRASOLVE_NOTICE).toMatch(/self-contained[\s\S]*context|context[\s\S]*self-contained/i);
+		expect(ULTRASOLVE_NOTICE).toMatch(
+			/solver[\s\S]{0,300}(?:no|not|without|cannot)[\s\S]{0,120}(?:repository|repo|read|file|shell|command)/i,
+		);
+		expect(ULTRASOLVE_NOTICE).toMatch(/generici[sz]\w*/i);
+		expect(ULTRASOLVE_NOTICE).toMatch(/technically exact|technical solution/i);
+		expect(ULTRASOLVE_NOTICE).toMatch(/preserv\w* (?:every )?(?:behavior|semantics)/i);
 	});
 });

--- a/packages/coding-agent/test/tools/task-agent-capabilities.test.ts
+++ b/packages/coding-agent/test/tools/task-agent-capabilities.test.ts
@@ -14,7 +14,7 @@ describe("task agent capability descriptions", () => {
 		const agents = loadBundledAgents();
 
 		expect(isReadOnlyAgent(agentByName(agents, "scout"))).toBe(true);
-		for (const name of ["task", "sonic", "reviewer", "designer"]) {
+		for (const name of ["task", "sonic", "reviewer", "designer", "solver"]) {
 			expect(isReadOnlyAgent(agentByName(agents, name))).toBe(false);
 		}
 	});
@@ -32,7 +32,7 @@ describe("task agent capability descriptions", () => {
 		const agents = loadBundledAgents();
 
 		expect(agentByName(agents, "task").prewalk).toBe(true);
-		for (const name of ["scout", "sonic", "reviewer", "designer", "librarian"]) {
+		for (const name of ["scout", "sonic", "reviewer", "designer", "librarian", "solver"]) {
 			expect(agentByName(agents, name).prewalk).toBeUndefined();
 		}
 	});


### PR DESCRIPTION
## What

Adds ultrasolve magic keyword and 'solver' agent type.

## Why

It's nice being able to call out to a stronger model to attempt to solve a problem in the most token-efficient way possible. Solver agent does not have read and is forced to keep itself within scope. What I also noticed is that the solver agent is invoked by both luna and terra automatically whenever it is unsure about something so it's an automatic win regardless.

What I also noticed is that it also becomes a deep research engine whenever a problem requires sourcing advanced solutions i.e. deobfuscation techniques... Somewhat like an agent invoked /plan?


