### PR TITLE
fix(browser): observe raw promises before target close

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Fixed
 
+- Fixed raw Puppeteer `page`/`browser` promises from crashing inline browser workers or killing dedicated workers when a target closed before the caller awaited the promise.
 - Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions ([#5535](https://github.com/can1357/oh-my-pi/issues/5535)).
 - Fixed `--tools` silently dropping hidden tool names (`xdev`, `yield`, ...); hidden built-ins are now addressable per the `hidden` tool contract.
 - Fixed the built-in `fd` printing `fd: Broken pipe (os error 32)` when a downstream pipeline reader exited early (e.g. `fd … | head`); it now exits silently with 141 (128+SIGPIPE), matching real fd.

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -37,6 +37,7 @@ import {
 } from "./launch";
 import { extractReadableFromHtml, type ReadableFormat } from "./readable";
 import {
+	bindBrowserRunFacade,
 	CELL_BUDGET_SLACK_MS,
 	markHandled,
 	resolvePredicateTimeout,
@@ -824,9 +825,9 @@ export class WorkerCore {
 			const runtime = this.#ensureRuntime(msg.session);
 			runtime.setCwd(msg.session.cwd);
 			runtime.setRunScope({
-				page,
-				browser,
-				tab: tabApi,
+				page: bindBrowserRunFacade(page, signal),
+				browser: bindBrowserRunFacade(browser, signal),
+				tab: bindBrowserRunFacade(tabApi, signal),
 				assert: (cond: unknown, text?: string): void => {
 					if (!cond) throw new ToolError(text ?? "Assertion failed");
 				},

--- a/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-evaluate.test.ts
@@ -3,6 +3,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { BrowserTool } from "@oh-my-pi/pi-coding-agent/tools/browser";
 import { ensureChromiumExecutable } from "@oh-my-pi/pi-coding-agent/tools/browser/launch";
+import { getTabsMapForTest } from "@oh-my-pi/pi-coding-agent/tools/browser/tab-supervisor";
 
 function makeSession(): ToolSession {
 	return {
@@ -52,6 +53,38 @@ describe.skipIf(!CHROMIUM_AVAILABLE)("browser tab evaluation", () => {
 			});
 
 			expect(result.content).toEqual([{ type: "text", text: "42" }]);
+		} finally {
+			await tool.execute("close", { action: "close", name, kill: true });
+		}
+	}, 30_000);
+
+	it("observes floating raw page promises when the target closes", async () => {
+		const tool = new BrowserTool(makeSession());
+		const name = `target-close-${process.pid}`;
+		const url = `data:text/html,<h1>ready</h1>#${name}`;
+
+		try {
+			await tool.execute("open", { action: "open", name, url });
+			const tabSession = getTabsMapForTest().get(name);
+			if (tabSession?.backend !== "worker") throw new Error("Worker tab was not created");
+			const pages = await tabSession.browser.browser.pages();
+			const targetPage = pages.find(page => page.url() === url);
+			if (!targetPage) throw new Error(`Target page was not found for ${url}`);
+
+			const started = targetPage.waitForFunction("document.documentElement.dataset.floating === 'true'", {
+				polling: "mutation",
+			});
+			const run = tool.execute("run", {
+				action: "run",
+				name,
+				code: "page.evaluate(() => { document.documentElement.dataset.floating = 'true'; return Promise.withResolvers().promise; }); try { await tab.waitForSelector('#never'); } catch {} return 'survived';",
+			});
+			const startedHandle = await started;
+			await startedHandle.dispose();
+			await targetPage.close();
+
+			const result = await run;
+			expect(result.content).toEqual([{ type: "text", text: "survived" }]);
 		} finally {
 			await tool.execute("close", { action: "close", name, kill: true });
 		}


### PR DESCRIPTION
   ## Summary                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                              
   - Wrap run-scoped raw Puppeteer `page`, `browser`, and `tab` objects with the existing cancellation-aware facade.                                                                                                                                                                                                                                                                          
   - Attach rejection observers immediately while preserving rejection behavior for callers that await the promise.                                                                                                                                                                                                                                                                           
   - Add a real-Chromium regression covering target closure during a floating raw page evaluation.                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                              
   ## Problem                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                              
   The Puppeteer worker backend exposed raw browser objects directly, unlike the cmux backend. A promise created before a later `await` could reject when the target closed before an observer was attached.                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                              
   This could terminate a dedicated tab worker and leave the browser run hanging. In the inline fallback, the rejection could reach the process-level `unhandledRejection` handler and exit the session.                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                              
   The regression timed out before the fix and completes successfully after applying `bindBrowserRunFacade` to the Puppeteer run scope.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                              
   ## Testing                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                              
   - `bun test test/tools/browser-tab-evaluate.test.ts`                                                                                                                                                                                                                                                                                                                                       
   - `bun run check` in `packages/coding-agent`                                                                                                                                                                                                                                                                                                                                               
   - `bun run check:ts` at repository root   