### PR TITLE
docs: document magic keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,16 @@ Setting-gated, off by default: `github`, `inspect_image`, `tts`, `checkpoint`, `
 
 [Full reference →](https://omp.sh/docs/tools)
 
+### Prompt controls
+
+Three standalone, lowercase words opt a turn into specialized agent behavior:
+
+- `ultrathink` — request careful multi-step reasoning and the highest supported automatic thinking effort.
+- `orchestrate` — run substantial independent work through parallel subagents and verify each phase.
+- `workflowz` — build a deterministic multi-subagent workflow with the active `task` tool.
+
+They trigger only in prose, not inside code spans, fenced code blocks, XML/HTML sections, identifiers, or paths. See [Magic keywords](docs/magic-keywords.md) for exact matching rules and configuration.
+
 ## Forty-plus providers, hundreds of models, _one /model away_.
 
 Roles route work by intent. `default` for normal turns. `smol` for cheap subagent fan-out. `slow` for deep reasoning. `plan` for plan mode. `commit` for changelogs. Override at launch with `--smol`, `--slow`, or `--plan`; cycle through the configured models for the active role with `Ctrl+P`. Swap the active model mid-session with the `/model` slash command.

--- a/docs/magic-keywords.md
+++ b/docs/magic-keywords.md
@@ -1,0 +1,46 @@
+# Magic keywords
+
+Magic keywords are standalone words in a user prompt that add a hidden instruction for that turn. They are enabled by default and glow in the editor when `omp` recognizes them.
+
+## Keywords
+
+| Keyword | Effect |
+|---|---|
+| `ultrathink` | Asks the agent to reason carefully through a multi-step task. When automatic thinking is active, it also selects the highest reasoning effort supported by the current model for that turn. |
+| `orchestrate` | Switches the agent to the multi-agent orchestration contract: scope the full task, delegate substantial independent work in parallel, verify each phase, and continue until the request is complete. |
+| `workflowz` | Asks the agent to build and run a deterministic multi-subagent workflow with the `task` tool. It is intended for broad research, reviews, migrations, or other work that benefits from parallel coverage. The keyword only adds its instruction when `task` is available in the active tool set. |
+
+Use the keyword anywhere in the prose of the prompt:
+
+```text
+ultrathink about the failure modes before changing this API
+
+orchestrate the migration described in docs/plan.md
+
+workflowz an adversarial review of the authentication changes
+```
+
+## Matching rules
+
+Matching is deliberate so source code and paths do not accidentally change agent behavior:
+
+- Use the exact lowercase spelling. `Ultrathink`, `Orchestrate`, and `Workflowz` do not trigger.
+- The keyword must be standalone. Sentence punctuation may touch it, but identifiers, inflections, paths, and file extensions do not match. For example, `orchestrate,` matches; `orchestrated` and `orchestrate.ts` do not.
+- Fenced code blocks, inline code spans, and XML/HTML sections are ignored.
+- The instruction applies to the user turn containing the keyword. The highlighted word remains part of the visible prompt; the added instruction is hidden.
+
+## Configuration
+
+Open `/settings` and use **Interaction → Magic Keywords**, or change the settings from a shell:
+
+```bash
+# Disable every magic keyword
+omp config set magicKeywords.enabled false
+
+# Disable one keyword while leaving the others enabled
+omp config set magicKeywords.ultrathink false
+omp config set magicKeywords.orchestrate false
+omp config set magicKeywords.workflow false
+```
+
+All four settings default to `true`. Run `omp config list` to inspect every available setting and its current value. See [Settings](./settings.md) for configuration scopes, precedence, and project-local overrides.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -8,6 +8,7 @@ Settings are stored as plain YAML mappings. Every key, its type, default, and en
 - For custom model definitions in `models.yml`, see [Models](./models.md).
 - For instruction files discovered into the agent context (`AGENTS.md`, `.omp/`, etc.), see [Context files](./context-files.md).
 - For the full catalog of environment variables, see [Environment variables](./environment-variables.md).
+- For prompt words that activate specialized per-turn behavior, see [Magic keywords](./magic-keywords.md).
 
 ## Where settings live
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Fixed
 
+- Documented the `ultrathink`, `orchestrate`, and `workflowz` magic keywords, including their effects, matching rules, and settings ([#5590](https://github.com/can1357/oh-my-pi/issues/5590)).
 - Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions ([#5535](https://github.com/can1357/oh-my-pi/issues/5535)).
 - Fixed `--tools` silently dropping hidden tool names (`xdev`, `yield`, ...); hidden built-ins are now addressable per the `hidden` tool contract.
 - Fixed the built-in `fd` printing `fd: Broken pipe (os error 32)` when a downstream pipeline reader exited early (e.g. `fd … | head`); it now exits silently with 141 (128+SIGPIPE), matching real fd.


### PR DESCRIPTION
## Repro
Searching the public documentation for the implemented magic keywords with `search 'ultrathink|orchestrate|workflowz' README.md docs` returned no matches, leaving their behavior and configuration undiscoverable.

## Cause
The keyword implementations in `packages/coding-agent/src/modes/ultrathink.ts`, `orchestrate.ts`, and `workflow.ts` and their `magicKeywords.*` settings existed without a user-facing reference or links from `README.md` and `docs/settings.md`.

## Fix
- Add `docs/magic-keywords.md` with keyword effects, exact matching boundaries, examples, and configuration commands.
- Add a compact prompt-controls overview to `README.md`.
- Link the reference from `docs/settings.md` and record the fix in the coding-agent changelog.

## Verification
The post-fix search finds all three keywords in both `README.md` and `docs/magic-keywords.md`; the documentation was re-read against the implementation, and the pre-publish `bun run fix` / `bun check` gate passed. Fixes #5590