### PR TITLE
fix(tui): round SIXEL encode height to multiple of 6 to prevent image…

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Display LaTeX renders multi-letter script words (`N_{turns}`) as raised/lowered blocks instead of ragged per-character Unicode sub/superscript glyphs; single letters and digits keep the compact Unicode forms.
 - Added opt-in `Editor.setImeSafeCursorLayout()` protection for macOS IME preedit while retaining the compact bordered layout by default ([#5563](https://github.com/can1357/oh-my-pi/issues/5563)).
 
+### Fixed
+
+- Fixed SIXEL image rendering stripping a horizontal slice from images when the cell height was not a multiple of 6. SIXEL encodes in 6-pixel vertical bands; a non-multiple-of-6 height was padded, causing the terminal to allocate an extra row that the TUI did not reserve — the next line of content then overwrote the bottom of the image. The encode height is now rounded down to the largest multiple of 6 within the requested row budget, eliminating padding without exceeding the caller's height cap, and the width is scaled by the same ratio to preserve the image aspect ratio.
+
 ## [16.5.2] - 2026-07-14
 
 ### Fixed

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -952,11 +952,25 @@ export function renderImage(
 
 	if (TERMINAL.imageProtocol === ImageProtocol.Sixel) {
 		try {
-			const targetWidthPx = Math.max(1, fit.columns * cellDims.widthPx);
-			const targetHeightPx = Math.max(1, fit.rows * cellDims.heightPx);
+			// SIXEL encodes in 6-pixel vertical bands. A height that is not a
+			// multiple of 6 is padded with transparent rows, but the terminal
+			// still allocates cell rows for the padded height. When the padded
+			// height crosses a cell boundary the terminal uses one more row
+			// than fit.rows, so the next line of content overwrites the bottom
+			// of the image — a visible slice stripped from the image. Round the
+			// encode height DOWN to the largest multiple of 6 that fits within
+			// the requested row budget, so the band boundary aligns without
+			// padding and the reserved row count never exceeds fit.rows. Scale
+			// the width by the same ratio so resize_exact preserves the aspect
+			// ratio instead of squashing the image vertically.
+			const rawHeightPx = Math.max(1, fit.rows * cellDims.heightPx);
+			const targetHeightPx = Math.max(6, Math.floor(rawHeightPx / 6) * 6);
+			const heightScale = targetHeightPx / rawHeightPx;
+			const targetWidthPx = Math.max(1, Math.round(fit.columns * cellDims.widthPx * heightScale));
+			const rows = Math.max(1, Math.ceil(targetHeightPx / cellDims.heightPx));
 			const decoded = new Uint8Array(Buffer.from(base64Data, "base64"));
 			const sequence = encodeSixel(decoded, targetWidthPx, targetHeightPx);
-			return { sequence, rows: fit.rows };
+			return { sequence, rows };
 		} catch {
 			return null;
 		}

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -180,6 +180,9 @@ describe("terminal image rendering", () => {
 		});
 
 		expect(result).not.toBeNull();
+		// SIXEL height is rounded DOWN to a multiple of 6 (band size) so it
+		// never exceeds the caller's maxHeightCells cap. With 10px cells and
+		// maxHeightCells=2, targetHeightPx=18 (not 20), rows=2 — within cap.
 		expect(result?.rows).toBe(2);
 		expect((result?.sequence ?? "").startsWith("\x1bP")).toBe(true);
 	});


### PR DESCRIPTION
… slice

SIXEL encodes in 6-pixel vertical bands. When targetHeightPx was not a multiple of 6 (common for cell heights like 16, 19, 20, 21, 22), the encoder padded the last band. The terminal allocated cell rows for the padded height, which could cross into one more row than the TUI reserved. The next line of content then overwrote the bottom of the image, carving a visible slice out of it.

Fix: round targetHeightPx up to a multiple of 6 before encoding (eliminating padding) and derive the returned row count from the rounded height so the TUI reserves the exact number of terminal rows the image occupies.

## What

sixel fix

## Why

sixel broke

## Testing

bun run dev

---

- [ ] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)
