### PR TITLE
fix(web-search): honor configured xAI transport

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixed
 
+- Fixed xAI web search bypassing configured `xai` / `xai-oauth` proxy endpoints and headers, while preventing official OAuth tokens from being sent to custom endpoints ([#5599](https://github.com/can1357/oh-my-pi/issues/5599)).
 - Fixed a bug where a nested configuration value (like `dev.autoqa.consent` / `dev.autoqaConsent`) would incorrectly satisfy a parent key lookup (like `dev.autoqa`), causing Auto QA to be enabled and prompt for consent by default when it should have been disabled.
 - Fixed compiled appserver startup deadlocking before socket creation when user extensions were present.
 - Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1993,6 +1993,12 @@ export class ModelRegistry {
 	getProviderBaseUrl(provider: string): string | undefined {
 		return this.#models.find(m => m.provider === provider && m.baseUrl)?.baseUrl;
 	}
+	/**
+	 * Get the configured headers associated with a provider, if any model defines them.
+	 */
+	getProviderHeaders(provider: string): Record<string, string> | undefined {
+		return this.#models.find(model => model.provider === provider && model.headers)?.headers;
+	}
 
 	/**
 	 * Get API key for a model.

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1994,10 +1994,13 @@ export class ModelRegistry {
 		return this.#models.find(m => m.provider === provider && m.baseUrl)?.baseUrl;
 	}
 	/**
-	 * Get the configured headers associated with a provider, if any model defines them.
+	 * Get provider-level headers without including per-model overrides.
 	 */
 	getProviderHeaders(provider: string): Record<string, string> | undefined {
-		return this.#models.find(model => model.provider === provider && model.headers)?.headers;
+		return createLiveConfigHeaders([
+			this.#providerOverrides.get(provider)?.headers,
+			this.#runtimeProviderOverrides.get(provider)?.headers,
+		]);
 	}
 
 	/**

--- a/packages/coding-agent/src/lib/xai-http.ts
+++ b/packages/coding-agent/src/lib/xai-http.ts
@@ -16,7 +16,14 @@ export function ohMyPiXAIUserAgent(): string {
 	return "oh-my-pi/xai";
 }
 
-type XAIProvider = "xai-oauth" | "xai";
+/** xAI provider ids supported by shared HTTP tool transport resolution. */
+export type XAIHttpProvider = "xai-oauth" | "xai";
+
+/** Resolved endpoint and configured headers for an xAI HTTP tool request. */
+export interface XAIHttpTransport {
+	baseURL: string;
+	headers?: Record<string, string>;
+}
 
 /**
  * Resolve the HTTP base URL for an xAI tool call.
@@ -48,7 +55,11 @@ type XAIProvider = "xai-oauth" | "xai";
  * let xai-oauth entries hijack a xai tool call (or vice versa) when the
  * same model id ships under both descriptors.
  */
-function resolveXAIBaseURL(modelRegistry: ModelRegistry, provider: XAIProvider, modelId: string | undefined): string {
+function resolveXAIBaseURL(
+	modelRegistry: ModelRegistry,
+	provider: XAIHttpProvider,
+	modelId: string | undefined,
+): string {
 	if (modelId) {
 		const merged = modelRegistry.getAll().find(m => m.id === modelId && m.provider === provider);
 		if (merged?.baseUrl) {
@@ -67,6 +78,21 @@ function resolveXAIBaseURL(modelRegistry: ModelRegistry, provider: XAIProvider, 
 		if (normalized !== DEFAULT_BASE_URL) return normalized;
 	}
 	return ($env.XAI_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, "");
+}
+/**
+ * Resolve an xAI tool endpoint and its provider/model header overrides.
+ */
+export function resolveXAIHttpTransport(
+	modelRegistry: ModelRegistry,
+	provider: XAIHttpProvider,
+	modelId?: string,
+): XAIHttpTransport {
+	return {
+		baseURL: resolveXAIBaseURL(modelRegistry, provider, modelId),
+		headers:
+			(modelId ? modelRegistry.find(provider, modelId)?.headers : undefined) ??
+			modelRegistry.getProviderHeaders(provider),
+	};
 }
 
 /**

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -8,6 +8,7 @@ import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallb
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
+import { ModelRegistry } from "../../config/model-registry";
 import { settings } from "../../config/settings";
 import type { CustomTool, CustomToolContext, RenderResultOptions } from "../../extensibility/custom-tools/types";
 import type { Theme } from "../../modes/theme/theme";
@@ -118,6 +119,7 @@ function hasRenderableSearchContent(response: SearchResponse): boolean {
 
 interface ExecuteSearchOptions {
 	authStorage: AuthStorage;
+	modelRegistry?: ModelRegistry;
 	sessionId?: string;
 	signal?: AbortSignal;
 }
@@ -128,7 +130,7 @@ async function executeSearch(
 	params: SearchQueryParams,
 	options: ExecuteSearchOptions,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
-	const { authStorage, sessionId, signal } = options;
+	const { authStorage, modelRegistry, sessionId, signal } = options;
 	const explicitProvider = params.provider;
 	let candidates: SearchProviderCandidate[];
 	if (explicitProvider && explicitProvider !== "auto") {
@@ -187,6 +189,7 @@ async function executeSearch(
 				temperature: params.temperature,
 				signal,
 				authStorage,
+				modelRegistry,
 				sessionId,
 				antigravityEndpointMode,
 				geminiModel,
@@ -246,16 +249,18 @@ async function executeSearch(
  */
 export async function runSearchQuery(
 	params: SearchQueryParams,
-	options: { authStorage?: AuthStorage; sessionId?: string; signal?: AbortSignal } = {},
+	options: { authStorage?: AuthStorage; modelRegistry?: ModelRegistry; sessionId?: string; signal?: AbortSignal } = {},
 ): Promise<{ content: Array<{ type: "text"; text: string }>; details: SearchRenderDetails }> {
 	const createdAuthStorage = options.authStorage ? undefined : await discoverAuthStorage();
 	const authStorage = options.authStorage ?? createdAuthStorage;
 	if (!authStorage) {
 		throw new Error("Failed to initialize authentication storage");
 	}
+	const modelRegistry = options.modelRegistry ?? (createdAuthStorage ? new ModelRegistry(authStorage) : undefined);
 	try {
 		return await executeSearch("cli-web-search", params, {
 			authStorage,
+			modelRegistry,
 			sessionId: options.sessionId,
 			signal: options.signal,
 		});
@@ -295,7 +300,12 @@ export class WebSearchTool implements AgentTool<typeof webSearchSchema, SearchRe
 	): Promise<AgentToolResult<SearchRenderDetails>> {
 		const authStorage = this.#session.authStorage ?? (await discoverAuthStorage());
 		const sessionId = this.#session.getSessionId?.() ?? undefined;
-		return executeSearch(_toolCallId, params, { authStorage, sessionId, signal });
+		return executeSearch(_toolCallId, params, {
+			authStorage,
+			modelRegistry: this.#session.modelRegistry,
+			sessionId,
+			signal,
+		});
 	}
 }
 
@@ -316,7 +326,12 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 	) {
 		const authStorage = ctx.modelRegistry?.authStorage ?? (await discoverAuthStorage());
 		const sessionId = ctx.sessionManager.getSessionId();
-		return executeSearch(toolCallId, params, { authStorage, sessionId, signal });
+		return executeSearch(toolCallId, params, {
+			authStorage,
+			modelRegistry: ctx.modelRegistry,
+			sessionId,
+			signal,
+		});
 	},
 
 	renderCall(args: SearchToolParams, options: RenderResultOptions, theme: Theme) {

--- a/packages/coding-agent/src/web/search/providers/base.ts
+++ b/packages/coding-agent/src/web/search/providers/base.ts
@@ -1,4 +1,5 @@
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "../../../config/model-registry";
 import type { SearchProviderId, SearchResponse } from "../types";
 
 /**
@@ -45,6 +46,8 @@ export interface SearchParams {
 	 * the per-credential single-flight refresh.
 	 */
 	authStorage: AuthStorage;
+	/** Provider/model transport settings used by native search endpoints. */
+	modelRegistry?: ModelRegistry;
 	/**
 	 * Optional session id used as the round-robin / sticky key when selecting
 	 * among multiple credentials for the same provider. Pass through from the

--- a/packages/coding-agent/src/web/search/providers/xai.ts
+++ b/packages/coding-agent/src/web/search/providers/xai.ts
@@ -1,5 +1,6 @@
 import { type ApiKey, type ApiKeyResolver, type AuthStorage, withAuth } from "@oh-my-pi/pi-ai";
 import { $env } from "@oh-my-pi/pi-utils";
+import { resolveXAIHttpTransport, type XAIHttpProvider, type XAIHttpTransport } from "../../../lib/xai-http";
 import type { SearchCitation, SearchResponse, SearchSource, SearchUsage } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
 import { clampNumResults } from "../utils";
@@ -7,7 +8,7 @@ import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
 import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
-const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
+const XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1";
 const XAI_WEB_SEARCH_MODEL = "grok-4.3";
 const DEFAULT_NUM_RESULTS = 10;
 const MAX_NUM_RESULTS = 30;
@@ -75,10 +76,12 @@ async function postXAIResponses(
 	apiKey: string,
 	params: SearchParams,
 	body: Record<string, unknown>,
+	transport: XAIHttpTransport,
 ): Promise<Response> {
-	return (params.fetch ?? fetch)(XAI_RESPONSES_URL, {
+	return (params.fetch ?? fetch)(`${transport.baseURL.replace(/\/+$/, "")}/responses`, {
 		method: "POST",
 		headers: {
+			...transport.headers,
 			"Content-Type": "application/json",
 			Authorization: `Bearer ${apiKey}`,
 		},
@@ -93,9 +96,13 @@ function throwXAIResponsesError(status: number, errorText: string): never {
 	throw new SearchProviderError("xai", `xAI Responses API error (${status}): ${errorText}`, status);
 }
 
-async function callXAIResponses(apiKey: string, params: SearchParams): Promise<XAIResponsesResponse> {
+async function callXAIResponses(
+	apiKey: string,
+	params: SearchParams,
+	transport: XAIHttpTransport,
+): Promise<XAIResponsesResponse> {
 	const requestBody = buildRequestBody(params);
-	const response = await postXAIResponses(apiKey, params, requestBody);
+	const response = await postXAIResponses(apiKey, params, requestBody, transport);
 
 	if (!response.ok) {
 		throwXAIResponsesError(response.status, await response.text());
@@ -235,19 +242,24 @@ function shouldPreferXAIOAuth(authStorage: AuthStorage): boolean {
 	return true;
 }
 
-function resolveXAIWebSearchApiKey(params: SearchParams): ApiKeyResolver {
+interface XAIWebSearchAuth {
+	provider: XAIHttpProvider;
+	keyOrResolver: ApiKey;
+}
+
+function resolveXAIWebSearchAuth(params: SearchParams): XAIWebSearchAuth {
 	const xaiResolver = params.authStorage.resolver("xai", {
 		sessionId: params.sessionId,
 	});
 	const xaiOAuthOrigin = params.authStorage.getCredentialOrigin("xai-oauth");
 	if (!shouldPreferXAIOAuth(params.authStorage)) {
-		return xaiResolver;
+		return { provider: "xai", keyOrResolver: xaiResolver };
 	}
 
 	const xaiOAuthResolver = params.authStorage.resolver("xai-oauth", {
 		sessionId: params.sessionId,
 	});
-	return async ctx => {
+	const keyOrResolver: ApiKeyResolver = async ctx => {
 		const xaiOAuthKey = await xaiOAuthResolver(ctx);
 		if (xaiOAuthKey) {
 			const borrowedSharedEnvKey =
@@ -259,14 +271,33 @@ function resolveXAIWebSearchApiKey(params: SearchParams): ApiKeyResolver {
 		}
 		return xaiResolver(ctx);
 	};
+	return { provider: "xai-oauth", keyOrResolver };
 }
 
 /** Execute xAI Responses API web search. */
 export async function searchXAI(params: SearchParams): Promise<SearchResponse> {
-	const keyOrResolver: ApiKey = resolveXAIWebSearchApiKey(params);
+	const auth = resolveXAIWebSearchAuth(params);
+	const transport = params.modelRegistry
+		? resolveXAIHttpTransport(params.modelRegistry, auth.provider, XAI_WEB_SEARCH_MODEL)
+		: { baseURL: XAI_DEFAULT_BASE_URL };
+	const customEndpoint = transport.baseURL.replace(/\/+$/, "") !== XAI_DEFAULT_BASE_URL;
+	const credentialOrigin = params.authStorage.getCredentialOrigin(auth.provider);
+	if (
+		customEndpoint &&
+		auth.provider === "xai-oauth" &&
+		(credentialOrigin?.kind === "oauth" || credentialOrigin?.kind === "env")
+	) {
+		throw new SearchProviderError(
+			"xai",
+			`Refusing to send official xAI OAuth credentials to custom endpoint ${transport.baseURL}. Configure an API key for provider "xai-oauth".`,
+		);
+	}
+	const keyOrResolver: ApiKey = customEndpoint
+		? params.authStorage.resolver(auth.provider, { sessionId: params.sessionId })
+		: auth.keyOrResolver;
 
 	const resultCap = clampNumResults(params.numSearchResults ?? params.limit, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
-	const response = await withAuth(keyOrResolver, (key: string) => callXAIResponses(key, params), {
+	const response = await withAuth(keyOrResolver, (key: string) => callXAIResponses(key, params, transport), {
 		signal: params.signal,
 		missingKeyMessage: 'xAI credentials not found. Set XAI_API_KEY or configure an API key for provider "xai".',
 	});

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -268,6 +268,8 @@ describe("ModelRegistry", () => {
 		let anthropicHeadersOnly: ModelRegistry;
 		let anthropicAuthHeader: ModelRegistry;
 		let mixGoogleCustom: ModelRegistry;
+		let xaiModelScopedHeaders: ModelRegistry;
+		let otherXaiModelId: string;
 		beforeAll(() => {
 			anthropicProxy = readonlyRegistry({
 				providers: { anthropic: overrideConfig("https://my-proxy.example.com/v1") },
@@ -297,6 +299,21 @@ describe("ModelRegistry", () => {
 						[{ id: "gemini-custom" }],
 						"google-generative-ai",
 					),
+				},
+			});
+			const otherXaiModel = sharedBuiltin
+				.getAll()
+				.find(model => model.provider === "xai" && model.id !== "grok-4.3");
+			if (!otherXaiModel) throw new Error("Expected another bundled xAI model");
+			otherXaiModelId = otherXaiModel.id;
+			xaiModelScopedHeaders = readonlyRegistry({
+				providers: {
+					xai: {
+						headers: { "X-Provider-Tenant": "search-tenant" },
+						modelOverrides: {
+							[otherXaiModelId]: { headers: { "X-Model-Tenant": "other-model-tenant" } },
+						},
+					},
 				},
 			});
 		});
@@ -329,6 +346,15 @@ describe("ModelRegistry", () => {
 			for (const model of anthropicModels) {
 				expect(model.headers?.["X-Custom-Header"]).toBe("custom-only");
 			}
+		});
+
+		test("provider header lookup excludes unrelated model overrides", () => {
+			expect(xaiModelScopedHeaders.find("xai", otherXaiModelId)?.headers?.["X-Model-Tenant"]).toBe(
+				"other-model-tenant",
+			);
+			expect({ ...xaiModelScopedHeaders.getProviderHeaders("xai") }).toEqual({
+				"X-Provider-Tenant": "search-tenant",
+			});
 		});
 
 		test("authHeader override applies bearer auth to built-in models without custom models", () => {

--- a/packages/coding-agent/test/tools/web-search-xai.test.ts
+++ b/packages/coding-agent/test/tools/web-search-xai.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, setSystemTime, vi } from "bun:test";
 import type { AuthStorage, CredentialOriginKind, FetchImpl } from "@oh-my-pi/pi-ai";
+import type { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { searchXAI, XAIProvider } from "@oh-my-pi/pi-coding-agent/web/search/providers/xai";
 import { SearchProviderError } from "@oh-my-pi/pi-coding-agent/web/search/types";
 
@@ -116,6 +117,13 @@ function citationUrls(prefix: string, count: number): string[] {
 	return Array.from({ length: count }, (_, index) => `https://example.com/${prefix}-${index + 1}`);
 }
 
+const proxyXaiRegistry = {
+	getAll: () => [],
+	find: () => undefined,
+	getProviderBaseUrl: (provider: string) => (provider === "xai-oauth" ? "https://proxy.example/v1/" : undefined),
+	getProviderHeaders: (provider: string) => (provider === "xai-oauth" ? { "X-Proxy-Tenant": "tenant-1" } : undefined),
+} as unknown as ModelRegistry;
+
 describe("xAI web search provider", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -169,6 +177,53 @@ describe("xAI web search provider", () => {
 		expect(capture.capturedRequest?.headers).toMatchObject({
 			Authorization: "Bearer test-xai-oauth-token",
 		});
+	});
+
+	it("uses configured xai-oauth endpoint, API key, and headers together", async () => {
+		const capture = captureFetch({ id: "resp_proxy", model: "grok-4.3", output_text: "proxy answer" });
+
+		await searchXAI({
+			...makeParams(
+				capture.fetchMock,
+				makeAuthStorage({
+					"xai-oauth": { key: "proxy-key", kind: "config" },
+				}),
+			),
+			modelRegistry: proxyXaiRegistry,
+		});
+
+		expect(capture.capturedRequest).not.toBeNull();
+		expect(capture.capturedRequest?.url).toBe("https://proxy.example/v1/responses");
+		expect(capture.capturedRequest?.headers).toMatchObject({
+			"Content-Type": "application/json",
+			Authorization: "Bearer proxy-key",
+			"X-Proxy-Tenant": "tenant-1",
+		});
+	});
+
+	it("never sends official xAI OAuth credentials to a configured custom endpoint", async () => {
+		const capture = captureFetch({ id: "must_not_send", output_text: "unexpected" });
+
+		try {
+			await searchXAI({
+				...makeParams(
+					capture.fetchMock,
+					makeAuthStorage({
+						"xai-oauth": { key: "official-oauth-token", kind: "oauth" },
+					}),
+				),
+				modelRegistry: proxyXaiRegistry,
+			});
+			expect.unreachable("official xAI OAuth credentials should be rejected for a custom endpoint");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SearchProviderError);
+			expect(error).toHaveProperty(
+				"message",
+				'Refusing to send official xAI OAuth credentials to custom endpoint https://proxy.example/v1. Configure an API key for provider "xai-oauth".',
+			);
+		}
+
+		expect(capture.capturedRequests).toHaveLength(0);
 	});
 
 	it("prefers dedicated xAI OAuth credentials over xAI API keys", async () => {


### PR DESCRIPTION
## Repro
With an `xai-oauth` provider configured for `https://proxy.example/v1`, `bun /tmp/repro-xai-search-5599.ts` showed `searchXAI` POSTing to `https://api.x.ai/v1/responses` and omitting the configured proxy header while using the proxy bearer key.

## Cause
`packages/coding-agent/src/web/search/providers/xai.ts` used a module-level `XAI_RESPONSES_URL`, while `SearchParams` and the `executeSearch` call path carried only `AuthStorage`; provider transport metadata from `ModelRegistry` never reached the native xAI Responses request.

## Fix
- Thread `ModelRegistry` through web-search execution and expose configured provider headers alongside existing base URL resolution.
- Reuse the shared xAI HTTP transport resolver for `<baseUrl>/responses`, merging configured headers with the selected provider credential.
- Keep credential retries scoped to the custom endpoint's provider and reject stored/ambient official xAI OAuth credentials before any custom-endpoint request.
- Add regression coverage for proxy routing, configured headers/API key coupling, and OAuth token non-disclosure.

## Verification
`bun test packages/coding-agent/test/tools/web-search-xai.test.ts` passed 26 tests; `bun check` passed all workspace checks. The reproduction probe then POSTed to `https://proxy.example/v1/responses` with `X-Proxy-Tenant: tenant-1` and `Authorization: Bearer proxy-key`.

Fixes #5599