### PR TITLE
fix(agent-loop): reclassify empty toolUse stop as retryable error

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reclassified a `toolUse` stop that carries zero tool call blocks (a provider stream that closed after the thinking block but before the tool call JSON was emitted) as a retryable transient error instead of a silent successful turn, so the standard retry-with-backoff path fires rather than rendering an empty tool widget ([#5600](https://github.com/can1357/oh-my-pi/issues/5600)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1397,6 +1397,12 @@ async function streamAssistantResponse(
 			let partialMessage: AssistantMessage | null = null;
 			let addedPartial = false;
 			const completedToolCallIds = new Set<string>();
+			// Ids of tool calls delivered via granular streaming (`toolcall_start` /
+			// `toolcall_delta`). A streamed id absent from `completedToolCallIds`
+			// never reached `toolcall_end` — the stream dropped mid-call. Atomic
+			// deliveries (a single `done`/`end(result)` message, e.g. Cursor) emit
+			// no granular events, so their tool calls are never flagged incomplete.
+			const streamedToolCallIds = new Set<string>();
 
 			const responseIterator = response[Symbol.asyncIterator]();
 			const finishAbortedStream = async (): Promise<AssistantMessage> => {
@@ -1456,6 +1462,8 @@ async function streamAssistantResponse(
 								retainCompletedToolCalls(await response.result(), completedToolCallIds),
 								context.tools ?? [],
 							),
+							streamedToolCallIds,
+							completedToolCallIds,
 						);
 						if (harmonyMitigationEnabled) {
 							const detection = detectHarmonyLeakInAssistantMessage(finalMessage);
@@ -1507,6 +1515,7 @@ async function streamAssistantResponse(
 							if (addedPartial) {
 								context.messages[context.messages.length - 1] = partialMessage;
 								completedToolCallIds.clear();
+								streamedToolCallIds.clear();
 								// `message` and `assistantMessageEvent.partial` intentionally share one
 								// immutable snapshot of the streaming partial: every message_update
 								// consumer treats both as read-only, so cloning the identical partial
@@ -1534,6 +1543,10 @@ async function streamAssistantResponse(
 						case "toolcall_delta":
 						case "toolcall_end":
 							if (partialMessage) {
+								if (event.type === "toolcall_start" || event.type === "toolcall_delta") {
+									const block = event.partial.content[event.contentIndex];
+									if (block?.type === "toolCall") streamedToolCallIds.add(block.id);
+								}
 								if (event.type === "toolcall_end") {
 									completedToolCallIds.add(event.toolCall.id);
 								}
@@ -1563,6 +1576,8 @@ async function streamAssistantResponse(
 					retainCompletedToolCalls(await response.result(), completedToolCallIds),
 					context.tools ?? [],
 				),
+				streamedToolCallIds,
+				completedToolCallIds,
 			);
 			if (harmonyMitigationEnabled) {
 				const detection = detectHarmonyLeakInAssistantMessage(trailing);
@@ -1658,26 +1673,42 @@ function recoverTransientErrorToolTurn(
 	};
 }
 
-/** Synthetic error text for a `toolUse` stop that carried no tool call blocks. */
+/** Synthetic error text for a `toolUse` stop that yielded no usable tool call. */
 const EMPTY_TOOL_USE_STOP_MESSAGE =
-	"Stream closed before the tool call was emitted (socket connection closed unexpectedly): provider reported toolUse stop with no tool call blocks.";
+	"Stream closed before the tool call was emitted (socket connection closed unexpectedly): provider reported toolUse stop with no usable tool call blocks.";
 
 /**
- * Reclassify a `toolUse` stop that carried zero tool call blocks as a
+ * Reclassify a `toolUse` stop that produced no *usable* tool call as a
  * retryable transport error. Providers (confirmed Bedrock + extended thinking,
  * issue #5600) finalize a dropped stream with `stop_reason: "tool_use"` when the
  * socket closes after the thinking block but before the tool call JSON streams.
- * The loop would otherwise treat it as a successful turn: dispatch zero tools,
- * render an empty tool widget, and never retry. Stamping `stopReason: "error"`
- * with the {@link AIError.Flag.Transient} bit routes it through the standard
- * retry-with-backoff path. The bit is set explicitly (not left to text
- * classification) so retry fires regardless of message-pattern drift.
+ * The loop would otherwise treat it as a successful turn: dispatch zero (or
+ * partially-parsed) tools, render an empty tool widget, and never retry.
+ * Stamping `stopReason: "error"` with the {@link AIError.Flag.Transient} bit
+ * routes it through the standard retry-with-backoff path. The bit is set
+ * explicitly (not left to text classification) so retry fires regardless of
+ * message-pattern drift.
+ *
+ * A tool call is *usable* unless it was streamed granularly (`streamedToolCallIds`)
+ * but never reached `toolcall_end` (`completedToolCallIds`) — that combination
+ * means the stream dropped mid-`toolcall_delta`, leaving empty or partially
+ * parsed arguments. Atomic deliveries (a single `done`/`end(result)` message,
+ * e.g. Cursor) emit no granular events, so their tool calls are never streamed
+ * and stay usable. When no usable tool call remains, the incomplete blocks are
+ * stripped so the outer loop cannot dispatch them before the retry fires.
  */
-function reclassifyEmptyToolUseStop(message: AssistantMessage): AssistantMessage {
+function reclassifyEmptyToolUseStop(
+	message: AssistantMessage,
+	streamedToolCallIds: ReadonlySet<string>,
+	completedToolCallIds: ReadonlySet<string>,
+): AssistantMessage {
 	if (message.stopReason !== "toolUse") return message;
-	if (message.content.some(block => block.type === "toolCall")) return message;
+	const isIncomplete = (id: string): boolean => streamedToolCallIds.has(id) && !completedToolCallIds.has(id);
+	const hasUsableToolCall = message.content.some(block => block.type === "toolCall" && !isIncomplete(block.id));
+	if (hasUsableToolCall) return message;
 	return {
 		...message,
+		content: message.content.filter(block => block.type !== "toolCall"),
 		stopReason: "error",
 		errorMessage: EMPTY_TOOL_USE_STOP_MESSAGE,
 		errorId: AIError.create(AIError.Flag.Transient),

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1558,7 +1558,12 @@ async function streamAssistantResponse(
 				detachAbortListener?.();
 			}
 
-			let trailing = await response.result();
+			let trailing = reclassifyEmptyToolUseStop(
+				recoverTransientErrorToolTurn(
+					retainCompletedToolCalls(await response.result(), completedToolCallIds),
+					context.tools ?? [],
+				),
+			);
 			if (harmonyMitigationEnabled) {
 				const detection = detectHarmonyLeakInAssistantMessage(trailing);
 				if (detection) {

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1451,9 +1451,11 @@ async function streamAssistantResponse(
 
 					const event = next.value;
 					if (event.type === "done" || event.type === "error") {
-						let finalMessage = recoverTransientErrorToolTurn(
-							retainCompletedToolCalls(await response.result(), completedToolCallIds),
-							context.tools ?? [],
+						let finalMessage = reclassifyEmptyToolUseStop(
+							recoverTransientErrorToolTurn(
+								retainCompletedToolCalls(await response.result(), completedToolCallIds),
+								context.tools ?? [],
+							),
 						);
 						if (harmonyMitigationEnabled) {
 							const detection = detectHarmonyLeakInAssistantMessage(finalMessage);
@@ -1648,6 +1650,32 @@ function recoverTransientErrorToolTurn(
 		errorMessage: undefined,
 		errorId: undefined,
 		errorStatus: undefined,
+	};
+}
+
+/** Synthetic error text for a `toolUse` stop that carried no tool call blocks. */
+const EMPTY_TOOL_USE_STOP_MESSAGE =
+	"Stream closed before the tool call was emitted (socket connection closed unexpectedly): provider reported toolUse stop with no tool call blocks.";
+
+/**
+ * Reclassify a `toolUse` stop that carried zero tool call blocks as a
+ * retryable transport error. Providers (confirmed Bedrock + extended thinking,
+ * issue #5600) finalize a dropped stream with `stop_reason: "tool_use"` when the
+ * socket closes after the thinking block but before the tool call JSON streams.
+ * The loop would otherwise treat it as a successful turn: dispatch zero tools,
+ * render an empty tool widget, and never retry. Stamping `stopReason: "error"`
+ * with the {@link AIError.Flag.Transient} bit routes it through the standard
+ * retry-with-backoff path. The bit is set explicitly (not left to text
+ * classification) so retry fires regardless of message-pattern drift.
+ */
+function reclassifyEmptyToolUseStop(message: AssistantMessage): AssistantMessage {
+	if (message.stopReason !== "toolUse") return message;
+	if (message.content.some(block => block.type === "toolCall")) return message;
+	return {
+		...message,
+		stopReason: "error",
+		errorMessage: EMPTY_TOOL_USE_STOP_MESSAGE,
+		errorId: AIError.create(AIError.Flag.Transient),
 	};
 }
 

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -15,6 +15,7 @@ import type {
 	ToolCallContext,
 } from "@oh-my-pi/pi-agent-core/types";
 import type { AssistantMessage, AssistantMessageEvent, Message, ToolResultMessage } from "@oh-my-pi/pi-ai";
+import * as AIError from "@oh-my-pi/pi-ai/error";
 import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
@@ -3284,5 +3285,71 @@ describe("agentLoop kCursorExecResolved (issue #4348)", () => {
 		if (executionStarts[0]?.type !== "tool_execution_start") throw new Error("expected tool_execution_start");
 		expect(executionStarts[0].toolCallId).toBe("runnable-1");
 		expect(executionStarts[0].toolName).toBe("echo");
+	});
+});
+
+describe("agentLoop empty toolUse stop (issue #5600)", () => {
+	it("reclassifies a toolUse stop with zero tool call blocks as a retryable transient error", async () => {
+		const context: AgentContext = { systemPrompt: ["You are helpful."], messages: [], tools: [] };
+		// Provider closed the stream after the thinking block but before the tool
+		// call JSON was emitted: stopReason=toolUse, no toolCall content blocks.
+		const mock = createMockModel({
+			responses: [{ content: [{ type: "thinking", thinking: "planning..." }], stopReason: "toolUse" }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		const messages = await stream.result();
+		const assistant = messages.find((m): m is AssistantMessage => m.role === "assistant");
+		if (!assistant) throw new Error("expected an assistant message");
+
+		// The empty tool-use turn is surfaced as an error, not a silent success.
+		expect(assistant.stopReason).toBe("error");
+		expect(assistant.content.filter(b => b.type === "toolCall")).toHaveLength(0);
+		expect(assistant.errorMessage).toBeDefined();
+		// The synthesized error carries the Transient classifier bit so
+		// AgentSession's retry path fires regardless of message-text matching.
+		expect(AIError.is(assistant.errorId, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.retriable(assistant.errorId)).toBe(true);
+	});
+
+	it("leaves a toolUse stop that carries a tool call block untouched", async () => {
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_id, params) {
+				return { content: [{ type: "text", text: `echoed: ${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: ["You are helpful."], messages: [], tools: [tool] };
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [{ type: "toolCall", id: "tc-1", name: "echo", arguments: { value: "hi" } }],
+					stopReason: "toolUse",
+				},
+				{ content: ["done"] },
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("run echo")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		const messages = await stream.result();
+		const firstAssistant = messages.find((m): m is AssistantMessage => m.role === "assistant");
+		if (!firstAssistant) throw new Error("expected an assistant message");
+
+		// A real tool call under toolUse is dispatched normally, never reclassified.
+		expect(firstAssistant.stopReason).toBe("toolUse");
+		expect(firstAssistant.errorMessage).toBeUndefined();
+		expect(messages.some(m => m.role === "toolResult")).toBe(true);
 	});
 });

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -3352,4 +3352,35 @@ describe("agentLoop empty toolUse stop (issue #5600)", () => {
 		expect(firstAssistant.errorMessage).toBeUndefined();
 		expect(messages.some(m => m.role === "toolResult")).toBe(true);
 	});
+
+	it("reclassifies an empty toolUse turn finalized by end(result) with no terminal event", async () => {
+		const context: AgentContext = { systemPrompt: ["You are helpful."], messages: [], tools: [] };
+		// A provider/wrapper that settles the stream via end(result) instead of
+		// yielding a terminal `done`/`error` event drives the trailing-result
+		// finalization branch. The empty toolUse turn must be reclassified there too.
+		const streamFn = () => {
+			const stream = new AssistantMessageEventStream();
+			const partial = createAssistantMessage([{ type: "thinking", thinking: "planning..." }], "toolUse");
+			stream.push({ type: "start", partial });
+			stream.push({ type: "thinking_start", contentIndex: 0, partial });
+			stream.push({ type: "thinking_delta", contentIndex: 0, delta: "planning...", partial });
+			stream.push({ type: "thinking_end", contentIndex: 0, content: "planning...", partial });
+			stream.end(partial);
+			return stream;
+		};
+		const config: AgentLoopConfig = { model: createMockModel().model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, streamFn);
+		for await (const _event of stream) {
+			// drain
+		}
+		const messages = await stream.result();
+		const assistant = messages.find((m): m is AssistantMessage => m.role === "assistant");
+		if (!assistant) throw new Error("expected an assistant message");
+
+		expect(assistant.stopReason).toBe("error");
+		expect(assistant.content.filter(b => b.type === "toolCall")).toHaveLength(0);
+		expect(AIError.is(assistant.errorId, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.retriable(assistant.errorId)).toBe(true);
+	});
 });

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -3383,4 +3383,53 @@ describe("agentLoop empty toolUse stop (issue #5600)", () => {
 		expect(AIError.is(assistant.errorId, AIError.Flag.Transient)).toBe(true);
 		expect(AIError.retriable(assistant.errorId)).toBe(true);
 	});
+
+	it("reclassifies a toolUse turn whose only tool call never reached toolcall_end", async () => {
+		const echoCalls: string[] = [];
+		const toolSchema = type({ value: "string" });
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(id, params) {
+				echoCalls.push(id);
+				return { content: [{ type: "text", text: `echoed: ${params.value}` }], details: { value: params.value } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: ["You are helpful."], messages: [], tools: [tool] };
+		// The stream drops mid-tool-call: toolcall_start + a partial delta land an
+		// incomplete toolCall block in content, but toolcall_end never fires, so the
+		// id is absent from completedToolCallIds. The provider still finalizes with
+		// stopReason=toolUse. The incomplete call must NOT be dispatched.
+		const streamFn = () => {
+			const stream = new AssistantMessageEventStream();
+			const partial = createAssistantMessage(
+				[{ type: "toolCall", id: "tc-partial", name: "echo", arguments: {} }],
+				"toolUse",
+			);
+			stream.push({ type: "start", partial });
+			stream.push({ type: "toolcall_start", contentIndex: 0, partial });
+			stream.push({ type: "toolcall_delta", contentIndex: 0, delta: '{"val', partial });
+			stream.end(partial);
+			return stream;
+		};
+		const config: AgentLoopConfig = { model: createMockModel().model, convertToLlm: identityConverter };
+
+		const stream = agentLoop([createUserMessage("run echo")], context, config, undefined, streamFn);
+		for await (const _event of stream) {
+			// drain
+		}
+		const messages = await stream.result();
+		const assistant = messages.find((m): m is AssistantMessage => m.role === "assistant");
+		if (!assistant) throw new Error("expected an assistant message");
+
+		// The incomplete call is stripped and the turn is routed through retry.
+		expect(echoCalls).toHaveLength(0);
+		expect(assistant.stopReason).toBe("error");
+		expect(assistant.content.filter(b => b.type === "toolCall")).toHaveLength(0);
+		expect(messages.some(m => m.role === "toolResult")).toBe(false);
+		expect(AIError.is(assistant.errorId, AIError.Flag.Transient)).toBe(true);
+		expect(AIError.retriable(assistant.errorId)).toBe(true);
+	});
 });


### PR DESCRIPTION
## Repro

When a provider stream closes after the thinking block but before the tool call JSON is emitted, the message finalizes with `stopReason: "toolUse"` and **zero** `toolCall` content blocks (confirmed on Bedrock + extended thinking, issue #5600). `agent-loop.ts` treated this as a valid tool-use turn: `hasMoreToolCalls = runnableStop && toolCalls.length > 0` is `false`, so nothing executed, but the turn was recorded as successful — rendering an empty tool widget with no error and no retry. Reproduced with a mock provider scripted to emit `stopReason: "toolUse"` after a thinking block with no tool call:

```
bun test test/agent-loop.test.ts
# before fix: stopReason=toolUse, errorMessage=undefined, toolCalls=0, mock calls=1 (no retry)
```

## Cause

In `streamAssistantResponse` (`packages/agent/src/agent-loop.ts`), the terminal `done`/`error` handler resolved `finalMessage` and emitted `message_end` unconditionally. Because `stopReason !== "error"`, `AgentSession.#isRetryableError` was never consulted, so the transport failure was silently swallowed as a completed turn. The reporter's suggested `errorMessage` text does not match `TRANSIENT_TRANSPORT_PATTERN` / `isUnexpectedSocketCloseMessage` / `STREAM_READ_ERROR_PATTERN`, so reclassifying to `"error"` alone would still leave `AIError.retriable` returning `false`.

## Fix

- Added `reclassifyEmptyToolUseStop` in `agent-loop.ts`: a `toolUse` stop carrying no `toolCall` block is stamped `stopReason: "error"` with `errorId = AIError.create(AIError.Flag.Transient)` and a descriptive synthetic message.
- The classifier bit is set **explicitly** rather than relying on text pattern matching, so `AgentSession`'s standard retry-with-backoff path fires robustly regardless of message-pattern drift.
- Wired the reclassifier into the terminal handler, wrapping the existing `recoverTransientErrorToolTurn(retainCompletedToolCalls(...))` chain.
- Added a changelog entry under `[Unreleased]`.

## Verification

`bun test` in `packages/agent`: 375 pass, 0 fail (added two regression tests — one asserting the empty toolUse stop becomes a retryable transient error via `AIError.is(errorId, Flag.Transient)` and `AIError.retriable(errorId)`, one asserting a real tool call under `toolUse` is dispatched untouched). Confirmed the reproduction no longer resolves as a silent success: `stopReason` is now `error` with `errorId` carrying `Class|Transient`.

Fixes #5600