### PR TITLE
fix(catalog): sourced zai GLM pricing from PAYG models.dev key

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Z.AI (GLM) coding-plan token costs all showing as "Free" in `/models`: the `zai` provider descriptor sourced the models.dev `zai-coding-plan` key (all-$0 subscription rates) instead of the `zai` pay-as-you-go key, which carries the real per-token rates for the identical GLM ids ([#5598](https://github.com/can1357/oh-my-pi/issues/5598)).
+
 ## [16.5.2] - 2026-07-14
 
 ### Fixed

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -88126,9 +88126,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 2.2,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -88155,9 +88155,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.2,
+				"output": 1.1,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
@@ -88214,8 +88214,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.6,
+				"output": 1.8,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -88243,9 +88243,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 2.2,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -88273,8 +88273,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
+				"input": 0.3,
+				"output": 0.9,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -88302,9 +88302,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.6,
+				"output": 2.2,
+				"cacheRead": 0.11,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -88389,9 +88389,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1,
+				"output": 3.2,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
@@ -88418,9 +88418,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.2,
+				"output": 4,
+				"cacheRead": 0.24,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -88447,9 +88447,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -88476,9 +88476,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -88503,9 +88503,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.2,
+				"output": 4,
+				"cacheRead": 0.24,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4505,7 +4505,12 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CORE: readonly ModelsDevProviderDescriptor
 
 const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDescriptor[] = [
 	// --- zAI ---
-	anthropicMessagesDescriptor("zai-coding-plan", "zai", "https://api.z.ai/api/anthropic"),
+	// Source the models.dev `zai` (pay-as-you-go) key rather than `zai-coding-plan`:
+	// the coding-plan key reports all-$0 subscription rates, which surface every GLM
+	// SKU as "Free" in `/models`. The PAYG key carries the real per-token rates for
+	// the identical model ids, so the enumerated token costs line up with the other
+	// subscription providers for comparison (issue #5598).
+	anthropicMessagesDescriptor("zai", "zai", "https://api.z.ai/api/anthropic"),
 	// --- Umans AI Coding Plan ---
 	anthropicMessagesDescriptor("umans-ai-coding-plan", "umans", UMANS_BASE_URL),
 	// --- Xiaomi ---

--- a/packages/catalog/test/issue-5598-repro.test.ts
+++ b/packages/catalog/test/issue-5598-repro.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+	MODELS_DEV_PROVIDER_DESCRIPTORS,
+	mapModelsDevToModels,
+} from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+
+// Z.AI GLM coding-plan token costs all showed as "Free" (issue #5598): the `zai`
+// provider descriptor sourced the models.dev `zai-coding-plan` key, which reports
+// all-$0 subscription rates. The `zai` (pay-as-you-go) key carries the real
+// per-token rates for the identical GLM ids, matching how other subscription
+// providers surface comparison pricing in `/models`.
+describe("zai GLM pricing sources the PAYG models.dev key (issue #5598)", () => {
+	test("descriptor maps the `zai` models.dev key, not `zai-coding-plan`", () => {
+		const descriptor = MODELS_DEV_PROVIDER_DESCRIPTORS.find(d => d.providerId === "zai");
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.modelsDevKey).toBe("zai");
+		expect(descriptor?.api).toBe("anthropic-messages");
+		expect(descriptor?.baseUrl).toBe("https://api.z.ai/api/anthropic");
+	});
+
+	test("mapped zai models carry the PAYG per-token costs, not the coding-plan $0 rates", () => {
+		const payload = {
+			zai: {
+				models: {
+					"glm-5.2": {
+						name: "GLM-5.2",
+						reasoning: true,
+						tool_call: true,
+						modalities: { input: ["text"], output: ["text"] },
+						cost: { input: 1.4, output: 4.4, cache_read: 0.26, cache_write: 0 },
+						limit: { context: 1_000_000, output: 131_072 },
+					},
+				},
+			},
+			"zai-coding-plan": {
+				models: {
+					"glm-5.2": {
+						name: "GLM-5.2",
+						reasoning: true,
+						tool_call: true,
+						modalities: { input: ["text"], output: ["text"] },
+						cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+						limit: { context: 1_000_000, output: 131_072 },
+					},
+				},
+			},
+		};
+
+		const zai = mapModelsDevToModels(payload, MODELS_DEV_PROVIDER_DESCRIPTORS).filter(
+			model => model.provider === "zai",
+		);
+		const glm52 = zai.find(model => model.id === "glm-5.2");
+		expect(glm52).toBeDefined();
+		expect(glm52?.cost).toEqual({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 });
+	});
+});


### PR DESCRIPTION
## Repro
On a Z.AI (GLM) coding-plan subscription, `/models` shows every GLM SKU except `glm-4.7-flashx` with token cost "Free", inconsistent with other subscription providers (opencode-go and openai-codex surface comparison pricing). Reproduced against the bundled catalog:

```
$ bun -e "const z=require('./packages/catalog/src/models.json').zai; console.log(Object.values(z).filter(x=>x.cost.input===0&&x.cost.output===0).length+'/'+Object.keys(z).length+' show Free')"
13/14 show Free
```

## Cause
The `zai` provider descriptor in `packages/catalog/src/provider-models/openai-compat.ts` (`MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS`) mapped the models.dev `zai-coding-plan` key, which reports all-$0 subscription rates for its GLM ids. The models.dev `zai` (pay-as-you-go) key carries the real per-token rates for the identical model ids (e.g. `glm-5.2` → input 1.4 / output 4.4 / cacheRead 0.26 per M), which is what other subscription providers display for comparison.

## Fix
- Point the `zai` descriptor at the `zai` models.dev key instead of `zai-coding-plan`.
- Regenerate the bundled `zai` cost blocks in `models.json` from the PAYG rates (11 SKUs updated; `glm-4.5-flash`/`glm-4.7-flash` stay $0 because upstream lists them as genuinely free, and `glm-4.7-flashx` was already correct).
- Add `packages/catalog/test/issue-5598-repro.test.ts` asserting the descriptor's `modelsDevKey` and that `mapModelsDevToModels` maps the PAYG cost rather than the coding-plan $0 rate.

## Verification
`bun test packages/catalog` → 428 pass / 0 fail. `bun check` → clean. New repro test passes. Manually confirmed 12/14 GLM SKUs now carry non-zero token cost in the bundled catalog (only the two upstream-free `-flash` SKUs remain $0). Fixes #5598