### PR TITLE
fix(schema): normalize boolean sub-schemas to prevent 400 from Google CCA

### DIFF
--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -236,6 +236,10 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 			exit(value);
 		}
 	}
+	// Normalize JSON Schema draft 6+ boolean schemas to object equivalents.
+	// Providers like Google CCA reject bare booleans on the wire.
+	if (value === true) return {};
+	if (value === false) return { not: {} };
 	if (!isJsonObject(value)) {
 		return value;
 	}


### PR DESCRIPTION
## Root cause\n\n`normalizeSchemaNode` in `packages/ai/src/utils/schema/normalize.ts` (line ~239) bails out early on any value that is not a JSON object:\n\n```ts\nif (!isJsonObject(value)) {\n    return value;\n}\n```\n\nJSON Schema draft 6+ allows boolean values as valid schemas — `true` means "accept anything" and `false` means "reject everything". MCP servers like robloxstudio-mcp use `propertyValue: true` for open-ended parameters. Since booleans pass the `!isJsonObject` guard unchanged, they survive all the way to the Google CCA / Gemini protobuf wire format, which has no representation for bare boolean schemas. The result is HTTP 400 `INVALID_ARGUMENT` that crashes the session.\n\n## Fix\n\nAdd boolean-to-object conversion in `normalizeSchemaNode` before the `isJsonObject` guard:\n\n```ts\nif (value === true) return {};\nif (value === false) return { not: {} };\n```\n\nThis is the same mapping `sanitizeSchemaForOllama` already uses (lines 1087-1088). Because both property loops in `normalizeSchemaObjectNode` pass values through `normalizeSchemaNode`, and the top-level `normalizeSchema` entry also routes through it, a single insertion covers all normalizer targets (Google, CCA, MCP, Moonshot).\n\n## Scope\n\n- Single file, 4 lines added\n- No behavioral change for non-boolean schemas\n- Handles both root-level boolean schemas and nested boolean sub-schemas in properties\n\n## Repro\n\n1. Configure OMP with google-antigravity provider\n2. Add robloxstudio-mcp (ships with OMP, uses `propertyValue: true` in 3 tools)\n3. Send any message — before: 400 crash; after: request succeeds\n\nFixes #5604