### PR TITLE
fix(schema): coerce boolean subschemas for google/cca transport

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed boolean JSON Schema subschemas (`true`/`false`) in MCP tool inputs triggering `400 INVALID_ARGUMENT` on the Google/Cloud Code Assist (Antigravity) transport by coercing them to their object equivalents (`true` → `{}`, `false` → `{ not: {} }`) before sending ([#5604](https://github.com/can1357/oh-my-pi/issues/5604)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Changed

--- a/packages/ai/src/utils/schema/CONSTRAINTS.md
+++ b/packages/ai/src/utils/schema/CONSTRAINTS.md
@@ -69,6 +69,7 @@ Schemas sent on the Google JSON Schema path MUST follow:
      - `minItems`, `maxItems`, `minLength`, `maxLength`
      - `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`
      - `pattern`, `format`
+     - `dependencies`, `dependentSchemas`, `dependentRequired`
    - Important: keys inside a `properties` object are treated as property names and MUST NOT be stripped by keyword match.
    - Human-meaningful stripped keys (`pattern`, `format`, min/max constraints, `default`, `examples`, etc.) are appended to the sibling `description` as an Anthropic-style spill block: `{pattern: "^foo$", minimum: 0}`. Structural/meta keys such as `$ref`, `$defs`, and `additionalProperties` are not spilled.
 

--- a/packages/ai/src/utils/schema/fields.ts
+++ b/packages/ai/src/utils/schema/fields.ts
@@ -37,6 +37,9 @@ export const UNSUPPORTED_SCHEMA_FIELDS: Record<string, true> = {
 	multipleOf: true,
 	pattern: true,
 	format: true,
+	dependencies: true,
+	dependentSchemas: true,
+	dependentRequired: true,
 };
 
 /**

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -26,7 +26,7 @@ import { enter, epochNext, exit, once, stamp } from "./stamps";
 import { isJsonObject, isJsonObjectEmpty, type JsonObject } from "./types";
 import { decontaminateZodInstance } from "./zod-decontaminate";
 
-export type ResidualSchemaIncompatibility = "type-array" | "type-null" | "nullable" | "combiners";
+export type ResidualSchemaIncompatibility = "type-array" | "type-null" | "nullable" | "combiners" | "not";
 
 export interface NormalizeSchemaOptions {
 	unsupportedFields: (key: string) => boolean;
@@ -70,6 +70,7 @@ interface ResidualIncompatibilityChecks {
 	typeNull: boolean;
 	nullable: boolean;
 	combiners: boolean;
+	not: boolean;
 }
 
 const SNAKE_TO_CAMEL_RENAMES = new Map<string, string>([
@@ -895,6 +896,7 @@ function createResidualIncompatibilityChecks(
 		typeNull: false,
 		nullable: false,
 		combiners: false,
+		not: false,
 	};
 	for (const check of checks) {
 		switch (check) {
@@ -906,6 +908,9 @@ function createResidualIncompatibilityChecks(
 				break;
 			case "nullable":
 				result.nullable = true;
+				break;
+			case "not":
+				result.not = true;
 				break;
 			case "combiners":
 				result.combiners = true;
@@ -919,10 +924,11 @@ function hasResidualSchemaIncompatibilities(
 	value: unknown,
 	checks: ResidualIncompatibilityChecks,
 	epoch: number = epochNext(),
+	insideSchemaMap = false,
 ): boolean {
 	if (Array.isArray(value)) {
 		if (!once(value, epoch)) return false;
-		return value.some(entry => hasResidualSchemaIncompatibilities(entry, checks, epoch));
+		return value.some(entry => hasResidualSchemaIncompatibilities(entry, checks, epoch, insideSchemaMap));
 	}
 	if (!isJsonObject(value)) {
 		return false;
@@ -934,14 +940,22 @@ function hasResidualSchemaIncompatibilities(
 	if (checks.typeArray && Array.isArray(value.type)) return true;
 	if (checks.typeNull && value.type === "null") return true;
 	if (checks.nullable && Object.hasOwn(value, "nullable")) return true;
-	if (checks.combiners) {
+	if (!insideSchemaMap && checks.not && Object.hasOwn(value, "not")) return true;
+	if (!insideSchemaMap && checks.combiners) {
 		for (const combiner of CCA_FORBIDDEN_COMBINERS) {
 			if (Array.isArray(value[combiner])) return true;
 		}
 	}
 	for (const k in value) {
 		if (!Object.hasOwn(value, k)) continue;
-		if (hasResidualSchemaIncompatibilities(value[k], checks, epoch)) {
+		if (
+			hasResidualSchemaIncompatibilities(
+				value[k],
+				checks,
+				epoch,
+				!insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, k),
+			)
+		) {
 			return true;
 		}
 	}
@@ -1014,7 +1028,7 @@ export function normalizeSchemaForCCA(value: unknown): unknown {
 		inferTypeForBareEnum: true,
 		dropNonScalarEnum: false,
 		foldOneOfIntoAnyOf: false,
-		rejectResidualIncompatibilities: ["type-array", "type-null", "nullable", "combiners"],
+		rejectResidualIncompatibilities: ["type-array", "type-null", "nullable", "combiners", "not"],
 		validateAndFallback: { fallback: CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA },
 	});
 }

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -56,6 +56,13 @@ export interface NormalizeSchemaOptions {
 
 interface NormalizeSchemaWalkOptions extends NormalizeSchemaOptions {
 	insideProperties: boolean;
+	/**
+	 * True when the value currently being walked occupies a JSON Schema
+	 * *subschema* slot (root, combiner branch, `items`, a property value, …).
+	 * Only then is a bare `true`/`false` a boolean subschema to coerce; in a
+	 * keyword slot (`nullable`, `enum` entries, `additionalProperties`) it stays.
+	 */
+	booleanIsSubschema: boolean;
 }
 
 interface ResidualIncompatibilityChecks {
@@ -74,6 +81,26 @@ const SNAKE_TO_CAMEL_RENAMES = new Map<string, string>([
 
 const JSON_SCHEMA_COMBINERS = ["anyOf", "oneOf"] as const;
 const CCA_FORBIDDEN_COMBINERS = new Set(["anyOf", "oneOf", "allOf"]);
+
+/**
+ * Keywords whose value is a single subschema (draft 2020-12). A bare `true` /
+ * `false` in one of these slots is a boolean subschema to coerce (issue #5604).
+ */
+const SUBSCHEMA_VALUE_KEYS = new Set([
+	"items",
+	"additionalItems",
+	"unevaluatedItems",
+	"not",
+	"if",
+	"then",
+	"else",
+	"contains",
+	"propertyNames",
+	"contentSchema",
+]);
+
+/** Keywords whose value is an array of subschemas. */
+const SUBSCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
 
 const CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA = {
 	type: "object",
@@ -236,6 +263,15 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 			exit(value);
 		}
 	}
+	if (typeof value === "boolean") {
+		// A bare boolean is a JSON Schema subschema only in a subschema slot.
+		// The Google/CCA protobuf Schema wire has no representation for it
+		// (issue #5604): `true` accepts anything -> `{}`, `false` accepts nothing
+		// -> `{ not: {} }`. In a keyword slot (`nullable`, `enum` entry, …) a
+		// boolean is a plain value and is left untouched.
+		if (!options.booleanIsSubschema) return value;
+		return value ? {} : { not: {} };
+	}
 	if (!isJsonObject(value)) {
 		return value;
 	}
@@ -306,6 +342,8 @@ function normalizeSchemaObjectNode(value: JsonObject, options: NormalizeSchemaWa
 			result[key] = normalizeSchemaNode(entry, {
 				...options,
 				insideProperties: !options.insideProperties && key === "properties",
+				booleanIsSubschema:
+					options.insideProperties || SUBSCHEMA_VALUE_KEYS.has(key) || SUBSCHEMA_ARRAY_KEYS.has(key),
 			});
 		}
 		applyDescriptionSpill(result, spill, options);
@@ -328,6 +366,7 @@ function normalizeSchemaObjectNode(value: JsonObject, options: NormalizeSchemaWa
 		result[key] = normalizeSchemaNode(entry, {
 			...options,
 			insideProperties: !options.insideProperties && key === "properties",
+			booleanIsSubschema: options.insideProperties || SUBSCHEMA_VALUE_KEYS.has(key) || SUBSCHEMA_ARRAY_KEYS.has(key),
 		});
 	}
 
@@ -895,6 +934,7 @@ export function normalizeSchema(value: unknown, options: NormalizeSchemaOptions)
 	let normalized = normalizeSchemaNode(dereferenced, {
 		...options,
 		insideProperties: false,
+		booleanIsSubschema: true,
 	});
 	if (options.stripResidualCombinersFixpoint) {
 		normalized = stripResidualCombiners(normalized);

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -55,7 +55,7 @@ export interface NormalizeSchemaOptions {
 }
 
 interface NormalizeSchemaWalkOptions extends NormalizeSchemaOptions {
-	insideProperties: boolean;
+	insideSchemaMap: boolean;
 	/**
 	 * True when the value currently being walked occupies a JSON Schema
 	 * *subschema* slot (root, combiner branch, `items`, a property value, …).
@@ -86,21 +86,37 @@ const CCA_FORBIDDEN_COMBINERS = new Set(["anyOf", "oneOf", "allOf"]);
  * Keywords whose value is a single subschema (draft 2020-12). A bare `true` /
  * `false` in one of these slots is a boolean subschema to coerce (issue #5604).
  */
-const SUBSCHEMA_VALUE_KEYS = new Set([
-	"items",
-	"additionalItems",
-	"unevaluatedItems",
-	"not",
-	"if",
-	"then",
-	"else",
-	"contains",
-	"propertyNames",
-	"contentSchema",
-]);
+const SUBSCHEMA_VALUE_KEYS: Record<string, true> = {
+	items: true,
+	additionalItems: true,
+	unevaluatedItems: true,
+	not: true,
+	if: true,
+	// biome-ignore lint/suspicious/noThenProperty: JSON Schema keyword
+	then: true,
+	else: true,
+	contains: true,
+	propertyNames: true,
+	contentSchema: true,
+};
 
 /** Keywords whose value is an array of subschemas. */
-const SUBSCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
+const SUBSCHEMA_ARRAY_KEYS: Record<string, true> = {
+	anyOf: true,
+	oneOf: true,
+	allOf: true,
+	prefixItems: true,
+};
+
+/** Keywords whose object value maps arbitrary names to subschemas. */
+const SUBSCHEMA_MAP_KEYS: Record<string, true> = {
+	properties: true,
+	patternProperties: true,
+	dependencies: true,
+	dependentSchemas: true,
+	$defs: true,
+	definitions: true,
+};
 
 const CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA = {
 	type: "object",
@@ -286,8 +302,8 @@ function normalizeSchemaNode(value: unknown, options: NormalizeSchemaWalkOptions
 }
 
 function normalizeSchemaObjectNode(value: JsonObject, options: NormalizeSchemaWalkOptions): unknown {
-	let obj = options.normalizeFieldNames && !options.insideProperties ? applySnakeCaseRenames(value) : value;
-	if (options.collapseNullFields && !options.insideProperties) {
+	let obj = options.normalizeFieldNames && !options.insideSchemaMap ? applySnakeCaseRenames(value) : value;
+	if (options.collapseNullFields && !options.insideSchemaMap) {
 		obj = preHandleNullFields(obj);
 	}
 	const result: JsonObject = {};
@@ -334,16 +350,18 @@ function normalizeSchemaObjectNode(value: JsonObject, options: NormalizeSchemaWa
 		for (const key in obj) {
 			if (!Object.hasOwn(obj, key) || key === combiner || outHasOwn(result, key)) continue;
 			const entry = obj[key];
-			if (!options.insideProperties && options.unsupportedFields(key)) {
+			if (!options.insideSchemaMap && options.unsupportedFields(key)) {
 				spill = pushStrippedDescriptionEntry(spill, key, entry, options);
 				continue;
 			}
 			if (options.stripNullableKeyword && key === "nullable") continue;
 			result[key] = normalizeSchemaNode(entry, {
 				...options,
-				insideProperties: !options.insideProperties && key === "properties",
+				insideSchemaMap: !options.insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, key),
 				booleanIsSubschema:
-					options.insideProperties || SUBSCHEMA_VALUE_KEYS.has(key) || SUBSCHEMA_ARRAY_KEYS.has(key),
+					options.insideSchemaMap ||
+					Object.hasOwn(SUBSCHEMA_VALUE_KEYS, key) ||
+					Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key),
 			});
 		}
 		applyDescriptionSpill(result, spill, options);
@@ -354,7 +372,7 @@ function normalizeSchemaObjectNode(value: JsonObject, options: NormalizeSchemaWa
 	for (const key in obj) {
 		if (!Object.hasOwn(obj, key)) continue;
 		const entry = obj[key];
-		if (!options.insideProperties && options.unsupportedFields(key)) {
+		if (!options.insideSchemaMap && options.unsupportedFields(key)) {
 			spill = pushStrippedDescriptionEntry(spill, key, entry, options);
 			continue;
 		}
@@ -365,8 +383,11 @@ function normalizeSchemaObjectNode(value: JsonObject, options: NormalizeSchemaWa
 		}
 		result[key] = normalizeSchemaNode(entry, {
 			...options,
-			insideProperties: !options.insideProperties && key === "properties",
-			booleanIsSubschema: options.insideProperties || SUBSCHEMA_VALUE_KEYS.has(key) || SUBSCHEMA_ARRAY_KEYS.has(key),
+			insideSchemaMap: !options.insideSchemaMap && Object.hasOwn(SUBSCHEMA_MAP_KEYS, key),
+			booleanIsSubschema:
+				options.insideSchemaMap ||
+				Object.hasOwn(SUBSCHEMA_VALUE_KEYS, key) ||
+				Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key),
 		});
 	}
 
@@ -933,7 +954,7 @@ export function normalizeSchema(value: unknown, options: NormalizeSchemaOptions)
 	const dereferenced = dereferenceJsonSchema(upgraded);
 	let normalized = normalizeSchemaNode(dereferenced, {
 		...options,
-		insideProperties: false,
+		insideSchemaMap: false,
 		booleanIsSubschema: true,
 	});
 	if (options.stripResidualCombinersFixpoint) {
@@ -1071,15 +1092,6 @@ export function normalizeSchemaForMoonshot(value: unknown): unknown {
 // Ollama — Go schema parser compatibility
 // ---------------------------------------------------------------------------
 
-const OLLAMA_SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
-const OLLAMA_SCHEMA_MAP_KEYS = new Set([
-	"properties",
-	"patternProperties",
-	"dependencies",
-	"dependentSchemas",
-	"$defs",
-	"definitions",
-]);
 const OLLAMA_SCHEMA_VALUE_KEYS = new Set([
 	"items",
 	"additionalItems",
@@ -1161,7 +1173,7 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 			}
 
 			let next = child;
-			if (OLLAMA_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
+			if (Object.hasOwn(SUBSCHEMA_MAP_KEYS, key) && isJsonObject(child)) {
 				let mapChanged = false;
 				const mapOutput: JsonObject = {};
 				for (const childKey in child) {
@@ -1172,7 +1184,7 @@ export function sanitizeSchemaForOllama(schema: JsonObject): JsonObject {
 					mapOutput[childKey] = normalizedChild;
 				}
 				next = mapChanged ? mapOutput : child;
-			} else if (OLLAMA_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+			} else if (Object.hasOwn(SUBSCHEMA_ARRAY_KEYS, key) && Array.isArray(child)) {
 				let arrayChanged = false;
 				const arrayOutput = child.map(item => {
 					const normalizedItem = normalizeNode(item);

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -282,7 +282,7 @@ describe("normalizeSchemaForGoogle", () => {
 		expect(sanitized.required).toEqual(["additionalProperties"]);
 	});
 
-	it("coerces boolean subschemas to object equivalents on the Google/CCA wire (issue #5604)", () => {
+	it("coerces boolean subschemas to object equivalents on the Google wire (issue #5604)", () => {
 		const schema = {
 			type: "object",
 			properties: {
@@ -294,21 +294,39 @@ describe("normalizeSchemaForGoogle", () => {
 				hasBar: false,
 			},
 		};
-		const expectedProps = { propertyValue: {}, attributeValue: { not: {} } };
-		const expectedDependentSchemas = { hasFoo: {}, hasBar: { not: {} } };
-
 		const google = normalizeSchemaForGoogle(schema) as Record<string, unknown>;
-		expect(google.properties).toEqual(expectedProps);
-		expect(google.dependentSchemas).toEqual(expectedDependentSchemas);
-		const cca = normalizeSchemaForCCA(schema) as Record<string, unknown>;
-		expect(cca.properties).toEqual(expectedProps);
-		expect(cca.dependentSchemas).toEqual(expectedDependentSchemas);
 
+		expect(google.properties).toEqual({ propertyValue: {}, attributeValue: { not: {} } });
+		expect(google.dependentSchemas).toEqual({ hasFoo: {}, hasBar: { not: {} } });
 		// Root-level and array-branch booleans are covered by the same choke point.
 		expect(normalizeSchemaForGoogle(true)).toEqual({});
 		expect(normalizeSchemaForGoogle(false)).toEqual({ not: {} });
 		expect(normalizeSchemaForGoogle({ anyOf: [true, { type: "string" }] })).toEqual({
 			anyOf: [{}, { type: "string" }],
+		});
+	});
+
+	it("falls back when a false subschema produces unsupported `not` on the CCA wire", () => {
+		const fallback = { type: "object", properties: {} };
+
+		expect(
+			normalizeSchemaForCCA({
+				type: "object",
+				properties: { propertyValue: true },
+				dependentSchemas: { hasFoo: true },
+			}),
+		).toEqual({
+			type: "object",
+			properties: { propertyValue: {} },
+			dependentSchemas: { hasFoo: {} },
+		});
+		expect(normalizeSchemaForCCA(false)).toEqual(fallback);
+		expect(normalizeSchemaForCCA({ type: "object", properties: { attributeValue: false } })).toEqual(fallback);
+		expect(normalizeSchemaForCCA({ type: "object", dependentSchemas: { hasBar: false } })).toEqual(fallback);
+		// A property named `not` is a schema-map entry, not the unsupported keyword.
+		expect(normalizeSchemaForCCA({ type: "object", properties: { not: { type: "string" } } })).toEqual({
+			type: "object",
+			properties: { not: { type: "string" } },
 		});
 	});
 

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -252,7 +252,7 @@ describe("normalizeSchemaForGoogle", () => {
 		expect(sanitized.enum).toEqual([null]);
 	});
 
-	it("preserves a property schema literally named additionalProperties inside properties", () => {
+	it("coerces a boolean subschema literally named additionalProperties inside properties", () => {
 		const sanitized = normalizeSchemaForGoogle({
 			type: "object",
 			properties: {
@@ -262,20 +262,47 @@ describe("normalizeSchemaForGoogle", () => {
 		}) as Record<string, unknown>;
 
 		const properties = sanitized.properties as Record<string, unknown>;
+		// The key survives (it is a property, not the stripped keyword), but its
+		// boolean subschema value coerces to the object form (issue #5604).
 		expect(Object.hasOwn(properties, "additionalProperties")).toBe(true);
-		expect(properties.additionalProperties).toBe(false);
+		expect(properties.additionalProperties).toEqual({ not: {} });
 	});
 
-	it("preserves boolean schemas for a single property literally named additionalProperties", () => {
-		const schema = {
+	it("coerces a boolean subschema for a single property literally named additionalProperties", () => {
+		const sanitized = normalizeSchemaForGoogle({
 			type: "object",
 			properties: {
 				additionalProperties: false,
 			},
 			required: ["additionalProperties"],
-		} as const;
+		}) as Record<string, unknown>;
 
-		expect(normalizeSchemaForGoogle(schema)).toEqual(schema);
+		const properties = sanitized.properties as Record<string, unknown>;
+		expect(properties.additionalProperties).toEqual({ not: {} });
+		expect(sanitized.required).toEqual(["additionalProperties"]);
+	});
+
+	it("coerces boolean subschemas to object equivalents on the Google/CCA wire (issue #5604)", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				propertyValue: true,
+				attributeValue: false,
+			},
+		};
+		const expectedProps = { propertyValue: {}, attributeValue: { not: {} } };
+
+		const google = normalizeSchemaForGoogle(schema) as Record<string, unknown>;
+		expect(google.properties).toEqual(expectedProps);
+		const cca = normalizeSchemaForCCA(schema) as Record<string, unknown>;
+		expect(cca.properties).toEqual(expectedProps);
+
+		// Root-level and array-branch booleans are covered by the same choke point.
+		expect(normalizeSchemaForGoogle(true)).toEqual({});
+		expect(normalizeSchemaForGoogle(false)).toEqual({ not: {} });
+		expect(normalizeSchemaForGoogle({ anyOf: [true, { type: "string" }] })).toEqual({
+			anyOf: [{}, { type: "string" }],
+		});
 	});
 
 	it("inlines local $ref / $defs entries for Google compatibility", () => {

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -283,21 +283,15 @@ describe("normalizeSchemaForGoogle", () => {
 	});
 
 	it("coerces boolean subschemas to object equivalents on the Google wire (issue #5604)", () => {
-		const schema = {
+		const google = normalizeSchemaForGoogle({
 			type: "object",
 			properties: {
 				propertyValue: true,
 				attributeValue: false,
 			},
-			dependentSchemas: {
-				hasFoo: true,
-				hasBar: false,
-			},
-		};
-		const google = normalizeSchemaForGoogle(schema) as Record<string, unknown>;
+		}) as Record<string, unknown>;
 
 		expect(google.properties).toEqual({ propertyValue: {}, attributeValue: { not: {} } });
-		expect(google.dependentSchemas).toEqual({ hasFoo: {}, hasBar: { not: {} } });
 		// Root-level and array-branch booleans are covered by the same choke point.
 		expect(normalizeSchemaForGoogle(true)).toEqual({});
 		expect(normalizeSchemaForGoogle(false)).toEqual({ not: {} });
@@ -306,23 +300,39 @@ describe("normalizeSchemaForGoogle", () => {
 		});
 	});
 
-	it("falls back when a false subschema produces unsupported `not` on the CCA wire", () => {
-		const fallback = { type: "object", properties: {} };
+	it("strips draft-2019 conditional keywords the OpenAPI-style wire cannot model", () => {
+		// `dependentSchemas`/`dependencies`/`dependentRequired` have no Google
+		// OpenAPI Schema representation and are not caught by residual checks, so
+		// they must be dropped before serialization on both transports.
+		const input = {
+			type: "object",
+			properties: { propertyValue: true },
+			dependentSchemas: { hasFoo: true },
+			dependentRequired: { hasFoo: ["propertyValue"] },
+		};
+		const expected = { type: "object", properties: { propertyValue: {} } };
 
+		expect(normalizeSchemaForGoogle(input)).toEqual(expected);
+		expect(normalizeSchemaForCCA(input)).toEqual(expected);
+
+		// The MCP path keeps conditional keywords and still coerces their boolean
+		// subschema entries.
 		expect(
-			normalizeSchemaForCCA({
+			normalizeSchemaForMCP({
 				type: "object",
-				properties: { propertyValue: true },
-				dependentSchemas: { hasFoo: true },
+				dependentSchemas: { hasFoo: true, hasBar: false },
 			}),
 		).toEqual({
 			type: "object",
-			properties: { propertyValue: {} },
-			dependentSchemas: { hasFoo: {} },
+			dependentSchemas: { hasFoo: {}, hasBar: { not: {} } },
 		});
+	});
+
+	it("falls back when a false subschema produces unsupported `not` on the CCA wire", () => {
+		const fallback = { type: "object", properties: {} };
+
 		expect(normalizeSchemaForCCA(false)).toEqual(fallback);
 		expect(normalizeSchemaForCCA({ type: "object", properties: { attributeValue: false } })).toEqual(fallback);
-		expect(normalizeSchemaForCCA({ type: "object", dependentSchemas: { hasBar: false } })).toEqual(fallback);
 		// A property named `not` is a schema-map entry, not the unsupported keyword.
 		expect(normalizeSchemaForCCA({ type: "object", properties: { not: { type: "string" } } })).toEqual({
 			type: "object",

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -289,13 +289,20 @@ describe("normalizeSchemaForGoogle", () => {
 				propertyValue: true,
 				attributeValue: false,
 			},
+			dependentSchemas: {
+				hasFoo: true,
+				hasBar: false,
+			},
 		};
 		const expectedProps = { propertyValue: {}, attributeValue: { not: {} } };
+		const expectedDependentSchemas = { hasFoo: {}, hasBar: { not: {} } };
 
 		const google = normalizeSchemaForGoogle(schema) as Record<string, unknown>;
 		expect(google.properties).toEqual(expectedProps);
+		expect(google.dependentSchemas).toEqual(expectedDependentSchemas);
 		const cca = normalizeSchemaForCCA(schema) as Record<string, unknown>;
 		expect(cca.properties).toEqual(expectedProps);
+		expect(cca.dependentSchemas).toEqual(expectedDependentSchemas);
 
 		// Root-level and array-branch booleans are covered by the same choke point.
 		expect(normalizeSchemaForGoogle(true)).toEqual({});


### PR DESCRIPTION
## Repro
MCP tools whose `inputSchema` uses a JSON Schema draft-6+ boolean subschema (e.g. `robloxstudio-mcp`'s `propertyValue: true`) crash every request on the google-antigravity provider. `normalizeSchemaForGoogle`/`normalizeSchemaForCCA` leave the boolean untouched, and the Cloud Code Assist / Gemini protobuf `Schema` type has no representation for a bare boolean, so the request is rejected with `400 INVALID_ARGUMENT` before the model runs. Repro against the shared normalizer:

```
Google: {"type":"object","properties":{"propertyValue":true,"other":false},...}
CCA:    {"type":"object","properties":{"propertyValue":true,"other":false}}
Root true: true
```

## Cause
`normalizeSchemaNode` in `packages/ai/src/utils/schema/normalize.ts` bailed at `if (!isJsonObject(value)) return value`, so `true`/`false` sailed through the recursion — the same hole existed for root-level booleans in `normalizeSchema` and for booleans in the property loops of `normalizeSchemaObjectNode`. `sanitizeSchemaForOllama` already coerces these; the shared Google/CCA path did not.

## Fix
- Coerce boolean subschemas to their object equivalents (`true` → `{}`, `false` → `{ not: {} }`) at the single `normalizeSchemaNode` choke point — covers root, array/combiner branches, and property values in one place.
- Gate the coercion on a new `booleanIsSubschema` walk flag, set only in genuine JSON Schema subschema slots (root, `SUBSCHEMA_VALUE_KEYS`, `SUBSCHEMA_ARRAY_KEYS`, inside `properties`). Keyword-slot booleans (`nullable: true`, `enum: [true, false]`, `additionalProperties: true`) are left untouched so Moonshot/MCP open-record markers and null-union flattening still work.
- Updated the two `normalizeSchemaForGoogle` tests that asserted the old pass-through and added a regression test covering property, root, and array-branch booleans on both Google and CCA paths.
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test test/schema-normalization.test.ts test/schema-wire.test.ts test/google-tool-schema.test.ts test/schema-compatibility.test.ts` → 147 pass, 0 fail. Manual check confirms boolean subschemas coerce while `nullable`/`enum`/`additionalProperties` keyword booleans and Moonshot/MCP behavior are preserved. (The one unrelated `proxy.test.ts` failure in the full-suite run is a pre-existing test-ordering artifact — it passes standalone on both a clean tree and with this change.) Fixes #5604