### PR TITLE
fix(tail): stop windows broken-pipe flush from killing omp

### DIFF
--- a/crates/vendor/uu-tail/src/tail.rs
+++ b/crates/vendor/uu-tail/src/tail.rs
@@ -633,16 +633,12 @@ fn unbounded_tail<T: Read>(reader: &mut BufReader<T>, settings: &Settings) -> UR
 		},
 		_ => {},
 	}
-	#[cfg(not(target_os = "windows"))]
+	// pi-uutils: upstream emulates Unix SIGPIPE on Windows by calling
+	// `std::process::exit(13)` on a broken-pipe flush. That would kill the
+	// long-lived host shell process. An in-process builtin must never
+	// `process::exit`; let the broken pipe surface as a normal `io::Error` and
+	// propagate to the caller, matching every other pi-uutils builtin.
 	writer.flush()?;
-
-	// SIGPIPE is not available on Windows.
-	#[cfg(target_os = "windows")]
-	writer.flush().inspect_err(|err| {
-		if err.kind() == ErrorKind::BrokenPipe {
-			std::process::exit(13);
-		}
-	})?;
 	Ok(())
 }
 
@@ -854,5 +850,48 @@ mod tests {
 		});
 
 		assert_ne!(code, 0, "broken pipe must surface as a non-zero exit, not a panic");
+	}
+
+	#[test]
+	fn unbounded_tail_broken_pipe_does_not_abort() {
+		use std::{
+			collections::HashMap,
+			ffi::OsString,
+			io::{self, Cursor, ErrorKind, Write},
+			sync::{Arc, atomic::AtomicBool},
+		};
+
+		// Same broken-pipe consumer as above, but here stdin is a plain reader
+		// so `tail_stdin` always takes the streaming `unbounded_tail` path — the
+		// one the reported repro (`seq ... | tail -n 3 | head -n 0`) exercises,
+		// and where the Windows SIGPIPE emulation used to `std::process::exit`.
+		struct BrokenPipeWriter;
+		impl Write for BrokenPipeWriter {
+			fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+				Err(io::Error::new(ErrorKind::BrokenPipe, "Broken pipe"))
+			}
+
+			fn flush(&mut self) -> io::Result<()> {
+				Err(io::Error::new(ErrorKind::BrokenPipe, "Broken pipe"))
+			}
+		}
+
+		let input = b"1\n2\n3\n4\n5\n".to_vec();
+		let io = pi_uutils_ctx::ScopeIo {
+			stdin:                 Box::new(Cursor::new(input)),
+			stdin_fd:              None,
+			stdin_is_search_input: false,
+			stdout:                Box::new(BrokenPipeWriter),
+			stderr:                Box::new(io::sink()),
+			cwd:                   std::env::temp_dir(),
+			env:                   HashMap::new(),
+			cancel:                Arc::new(AtomicBool::new(false)),
+		};
+
+		let code = pi_uutils_ctx::scope(io, || {
+			crate::run(vec![OsString::from("tail"), OsString::from("-n"), OsString::from("3")])
+		});
+
+		assert_ne!(code, 0, "broken pipe must surface as a non-zero exit, not process::exit");
 	}
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `tail` builtin exiting the entire omp process with code 13 on Windows when its output pipe broke (e.g. `seq ... | tail -n 3 | head -n 0`); a broken pipe now surfaces as a normal error instead of calling `std::process::exit` ([#5609](https://github.com/can1357/oh-my-pi/issues/5609)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes


### PR DESCRIPTION
## Repro
On Windows, `tail`'s output pipe breaking terminates the entire `omp` host process with exit code 13 and no other output. Reported command: `omp shell --no-snapshot` then `seq 1 200000 | tail -n 3 | head -n 0`. The `head -n 0` consumer closes its read end immediately, so `tail`'s flush hits `BrokenPipe`. Reproduced in-process via `cargo test -p uu_tail unbounded_tail_broken_pipe_does_not_abort`, which drives the streaming path with a writer that fails every write/flush with `BrokenPipe`.

## Cause
`unbounded_tail` in `crates/vendor/uu-tail/src/tail.rs` carried a Windows-only SIGPIPE emulation that called `std::process::exit(13)` on a broken-pipe flush:

```rust
#[cfg(target_os = "windows")]
writer.flush().inspect_err(|err| {
    if err.kind() == ErrorKind::BrokenPipe {
        std::process::exit(13);
    }
})?;
```

Correct for a standalone binary, fatal for an in-process builtin: it kills the long-lived host shell. It also contradicts `run`'s own contract (tail.rs:126-130, "never calls `std::process::exit`") and the pattern every other pi-uutils builtin follows (`uu-cat`'s no-op `handle_broken_pipe`: "a broken pipe surfaces as a normal io::Error and propagates to the caller"). The reported command routes stdin through the streaming `unbounded_tail` path, so it hits this exact block.

## Fix
- Removed the `#[cfg(target_os = "windows")]` / `#[cfg(not(...))]` split in `unbounded_tail` and flush uniformly with `writer.flush()?`, so a broken pipe propagates as an `io::Error` on every platform.
- Added `unbounded_tail_broken_pipe_does_not_abort`, a regression test covering the streaming path the repro exercises (the existing `bounded_tail_broken_pipe_does_not_abort` only covered the seekable branch).
- Added a `### Fixed` changelog entry under `[Unreleased]`.

## Verification
`cargo test -p uu_tail broken_pipe` → 2 passed, 0 failed (both the streaming and seekable broken-pipe tests). The fix is Windows-specific behavior; the test locks in the now-uniform error-propagating flush that runs on all platforms. Fixes #5609