### PR TITLE
fix(coding-agent): support keyless runtime providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevented keyless OpenAI-compatible providers from sending the public no-auth sentinel as a Bearer token.
+
 ## [17.0.0] - 2026-07-15
 
 ### Changed

--- a/packages/ai/src/api-key.ts
+++ b/packages/ai/src/api-key.ts
@@ -1,0 +1,1 @@
+export const kNoAuth = "N/A";

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,5 +1,6 @@
 export { type Type, type } from "arktype";
 export { type ZodType, z } from "zod/v4";
+export * from "./api-key";
 export * from "./api-registry";
 export type * from "./auth-broker";
 export type { AuthGatewayBootOptions, ModelResolver } from "./auth-gateway/server";

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -30,6 +30,7 @@ import {
 	stringifyJson,
 	structuredCloneJSON,
 } from "@oh-my-pi/pi-utils";
+import { kNoAuth } from "../api-key";
 import * as AIError from "../error";
 import {
 	type Api,
@@ -278,7 +279,7 @@ export function resolveOpenAIRequestSetup(
 		baseUrl = baseUrl ?? ($env.OPENAI_BASE_URL?.trim() || options.defaultBaseUrl);
 	}
 	const requestHeaders = { ...headers };
-	headers.Authorization ??= `Bearer ${apiKey}`;
+	if (apiKey !== kNoAuth) headers.Authorization ??= `Bearer ${apiKey}`;
 	return { copilotPremiumRequests, baseUrl, headers, query, requestHeaders };
 }
 

--- a/packages/ai/test/openai-keyless-auth.test.ts
+++ b/packages/ai/test/openai-keyless-auth.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { kNoAuth } from "@oh-my-pi/pi-ai";
+import { resolveOpenAIRequestSetup } from "@oh-my-pi/pi-ai/providers/openai-shared";
+
+describe("OpenAI keyless authentication", () => {
+	test("does not turn the no-auth sentinel into an Authorization header", () => {
+		const setup = resolveOpenAIRequestSetup(
+			{
+				provider: "local-openai",
+				id: "local-model",
+				baseUrl: "http://127.0.0.1:8080/v1",
+			},
+			{ apiKey: kNoAuth, messages: [] },
+		);
+
+		expect(setup.headers).not.toHaveProperty("Authorization");
+	});
+
+	test("keeps Bearer authorization for authenticated providers", () => {
+		const setup = resolveOpenAIRequestSetup(
+			{
+				provider: "openai-compatible",
+				id: "authenticated-model",
+				baseUrl: "https://api.example.com/v1",
+			},
+			{ apiKey: "secret-key", messages: [] },
+		);
+
+		expect(setup.headers.Authorization).toBe("Bearer secret-key");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `auth: "none"` support to extension runtime providers with static models, preserving keyless state across registry reloads and source handoffs.
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -62,6 +62,7 @@ const BUILT_IN_DISCOVERY_CACHE_TTL_MS = 2 * 60 * 60 * 1000;
 const BUILT_IN_DISCOVERY_NON_AUTHORITATIVE_RETRY_MS = 5 * 60 * 1000;
 
 import type { ApiKeyResolver, FetchImpl } from "@oh-my-pi/pi-ai";
+import { kNoAuth } from "@oh-my-pi/pi-ai/api-key";
 import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/oauth/types";
 import { getBundledModelReferenceIndex, resolveModelReference } from "@oh-my-pi/pi-catalog/identity";
@@ -84,7 +85,7 @@ import { ModelsConfigFile, type ProviderValidationModel, validateProviderConfigu
 import type { ModelOverride, ModelsConfig, ProviderAuthMode } from "./models-config-schema";
 import { settings } from "./settings";
 
-export const kNoAuth = "N/A";
+export { kNoAuth } from "@oh-my-pi/pi-ai/api-key";
 
 export function isAuthenticated(apiKey: string | undefined | null): apiKey is string {
 	return Boolean(apiKey) && apiKey !== kNoAuth;
@@ -760,6 +761,7 @@ export class ModelRegistry {
 	// models registered by extensions survive the model selector's offline reload.
 	#runtimeModelOverlays: CustomModelOverlay[] = [];
 	#runtimeProviderApiKeys: Map<string, string> = new Map();
+	#runtimeKeylessProviders: Set<string> = new Set();
 	#runtimeProviderOverrides: Map<string, ProviderOverride> = new Map();
 	#runtimeProvidersBySource: Map<string, Set<string>> = new Map();
 	#runtimeProviderSourceByName: Map<string, string> = new Map();
@@ -980,7 +982,7 @@ export class ModelRegistry {
 			error: configError,
 		} = this.#loadCustomModels();
 		this.#configError = configError;
-		this.#keylessProviders = keylessProviders;
+		this.#keylessProviders = new Set([...keylessProviders, ...this.#runtimeKeylessProviders]);
 		this.#discoverableProviders = discoverableProviders;
 		this.#customModelOverlays = customModels;
 		this.#providerOverrides = overrides;
@@ -2070,6 +2072,7 @@ export class ModelRegistry {
 
 	#clearRuntimeProviderState(providerName: string): void {
 		this.#runtimeProviderApiKeys.delete(providerName);
+		this.#runtimeKeylessProviders.delete(providerName);
 		this.#runtimeProviderOverrides.delete(providerName);
 		this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(overlay => overlay.provider !== providerName);
 		this.#runtimeModelManagers.delete(providerName);
@@ -2131,6 +2134,7 @@ export class ModelRegistry {
 				baseUrl: config.baseUrl,
 				headers: config.headers,
 				apiKey: config.apiKey,
+				auth: config.auth,
 				api: config.api,
 				oauthConfigured: Boolean(config.oauth),
 				models: (config.models ?? []) as ProviderValidationModel[],
@@ -2181,6 +2185,10 @@ export class ModelRegistry {
 			// Persist runtime API keys so they survive #reloadStaticModels() cycles
 			this.#runtimeProviderApiKeys.set(providerName, config.apiKey);
 		}
+		if (config.auth === "none") {
+			this.#runtimeKeylessProviders.add(providerName);
+			this.#keylessProviders.add(providerName);
+		}
 
 		if (config.models && config.models.length > 0) {
 			// Build model overlays that persist across refresh() cycles
@@ -2194,7 +2202,7 @@ export class ModelRegistry {
 					config.apiKey,
 					config.authHeader,
 					config.compat,
-					undefined,
+					config.auth,
 					config.remoteCompaction,
 					modelDef as CustomModelDefinitionLike,
 				);
@@ -2262,7 +2270,7 @@ export class ModelRegistry {
 							providerApiKey,
 							providerAuthHeader,
 							providerCompat,
-							undefined,
+							config.auth,
 							config.remoteCompaction,
 							modelDef as CustomModelDefinitionLike,
 						);
@@ -2355,6 +2363,7 @@ export class ModelRegistry {
 export interface ProviderConfigInput {
 	baseUrl?: string;
 	apiKey?: string;
+	auth?: "none";
 	api?: Api;
 	streamSimple?: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 	headers?: Record<string, string>;

--- a/packages/coding-agent/src/config/models-config.ts
+++ b/packages/coding-agent/src/config/models-config.ts
@@ -67,14 +67,11 @@ export function validateProviderConfiguration(
 		if (!config.baseUrl) {
 			throw new Error(`Provider ${providerName}: "baseUrl" is required when defining custom models.`);
 		}
-		const requiresAuth =
-			mode === "runtime-register"
-				? !config.apiKey && !config.oauthConfigured
-				: !config.apiKey && (config.auth ?? "apiKey") !== "none";
+		const requiresAuth = !config.apiKey && !config.oauthConfigured && (config.auth ?? "apiKey") !== "none";
 		if (requiresAuth) {
 			throw new Error(
 				mode === "runtime-register"
-					? `Provider ${providerName}: "apiKey" or "oauth" is required when defining models.`
+					? `Provider ${providerName}: "apiKey" or "oauth" is required when defining models unless auth is "none".`
 					: `Provider ${providerName}: "apiKey" is required when defining custom models unless auth is "none".`,
 			);
 		}

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1266,8 +1266,10 @@ export interface ExtensionAPI {
 export interface ProviderConfig {
 	/** Base URL for the API endpoint. Required when defining models. */
 	baseUrl?: string;
-	/** API key or environment variable name. Required when defining models unless oauth is provided. */
+	/** API key or environment variable name. Required when defining models unless oauth is provided or auth is "none". */
 	apiKey?: string;
+	/** Set to "none" for providers that do not require authentication. */
+	auth?: "none";
 	/** API type identifier. Required when registering streamSimple or when models don't specify one. */
 	api?: Api;
 	/** Custom streaming function for non-built-in APIs. */

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -11,7 +11,8 @@ import {
 } from "@oh-my-pi/pi-ai";
 import { getOAuthProviders, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
 import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
-import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { kNoAuth, ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import type { ProviderConfig } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 
@@ -189,6 +190,32 @@ describe("ModelRegistry runtime provider registration", () => {
 
 		registry.clearSourceRegistrations("ext://runtime");
 		expectProviderHeader(registry, providerName, "Authorization", undefined);
+	});
+
+	test("auth none runtime models stay keyless across reloads and source handoffs", async () => {
+		const providerName = "keyless-runtime-provider";
+		const config = (id: string): ProviderConfig => ({
+			auth: "none",
+			baseUrl: "http://127.0.0.1:8080/v1",
+			api: "openai-completions",
+			models: [{ ...baseModel, id }],
+		});
+		const expectKeyless = async (modelId: string): Promise<void> => {
+			const model = registry.find(providerName, modelId);
+			if (!model) throw new Error(`Expected ${providerName}/${modelId}`);
+			expect(await registry.getApiKey(model)).toBe(kNoAuth);
+		};
+
+		registry.registerProvider(providerName, config("source-a-model"), "ext://runtime");
+		await expectKeyless("source-a-model");
+		await registry.refresh("offline");
+		await expectKeyless("source-a-model");
+
+		registry.registerProvider(providerName, config("source-b-model"), "ext://atomic");
+		expect(registry.find(providerName, "source-a-model")).toBeUndefined();
+		await expectKeyless("source-b-model");
+		await registry.refreshProvider(providerName, "offline");
+		await expectKeyless("source-b-model");
 	});
 
 	test("registerProvider applies remoteCompaction-only overrides to existing provider models across refresh", async () => {


### PR DESCRIPTION
## Summary

- add `auth: "none"` to extension runtime provider registration for static and dynamically discovered models
- preserve source-scoped keyless state across model registry reloads and provider source handoffs
- publish the no-auth sentinel from `pi-ai` and prevent OpenAI-compatible transports from serializing it as Bearer authorization

## Root cause

Runtime provider validation only accepted API-key or OAuth-backed static models, and keyless state was rebuilt exclusively from `models.yml` during registry reloads. The OpenAI-compatible request setup also treated every truthy API-key value as a Bearer token, including the no-auth sentinel.

## Verification

- `bun test packages/coding-agent/test/model-registry-runtime-provider.test.ts`
- `bun test packages/ai/test/openai-keyless-auth.test.ts packages/ai/test/coreweave-project-header.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/coding-agent run check`
