### PR TITLE
fix(catalog): route Copilot mai-code models to the /responses endpoint

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot `mai-code-1-flash-picker` (and other `mai-*` models) to route through the `/responses` endpoint instead of `/chat/completions`, which rejected them with `400 unsupported_api_for_model` ([#5612](https://github.com/can1357/oh-my-pi/issues/5612)).
+
 ## [16.5.2] - 2026-07-14
 
 ### Fixed

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -19406,7 +19406,7 @@
 		"mai-code-1-flash-picker": {
 			"id": "mai-code-1-flash-picker",
 			"name": "MAI-Code-1-Flash",
-			"api": "openai-completions",
+			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
 			"reasoning": true,
@@ -19424,11 +19424,6 @@
 			"headers": {
 				"User-Agent": "opencode/1.3.15",
 				"X-GitHub-Api-Version": "2026-06-01"
-			},
-			"compat": {
-				"supportsStore": false,
-				"supportsDeveloperRole": false,
-				"supportsReasoningEffort": false
 			},
 			"thinking": {
 				"mode": "effort",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3724,7 +3724,7 @@ export interface GithubCopilotModelManagerConfig {
 
 const COPILOT_ANTHROPIC_MODEL_PATTERN = /^claude-(haiku|sonnet|opus|fable|mythos)-\d/;
 const isCopilotResponsesModelId = (modelId: string): boolean =>
-	modelId.startsWith("gpt-5") || modelId.startsWith("oswe");
+	modelId.startsWith("gpt-5") || modelId.startsWith("oswe") || modelId.startsWith("mai-");
 
 function inferCopilotApi(modelId: string): Api {
 	if (COPILOT_ANTHROPIC_MODEL_PATTERN.test(modelId)) {

--- a/packages/catalog/test/github-copilot-model-limits.test.ts
+++ b/packages/catalog/test/github-copilot-model-limits.test.ts
@@ -303,6 +303,22 @@ describe("github copilot model limits mapping", () => {
 		// not the OpenAI global reference (1050k).
 		expect(model?.contextWindow).toBe(272_000);
 	});
+	it("routes mai-code models to the openai-responses endpoint (#5612)", async () => {
+		// Copilot's /chat/completions rejects mai-* models with
+		// `unsupported_api_for_model` (400); they are served only via /responses.
+		const { models } = await discoverCopilotModels({
+			data: [
+				{
+					id: "mai-code-1-flash-picker",
+					name: "MAI-Code-1-Flash",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "mai-code-1-flash-picker");
+		expect(model).toBeDefined();
+		expect(model?.api).toBe("openai-responses");
+	});
 });
 
 /**


### PR DESCRIPTION
## Repro
Selecting the GitHub Copilot `mai-code-1-flash-picker` model and sending a message fails immediately with `400 model "mai-code-1-flash-picker" is not accessible via the /chat/completions endpoint (type=unsupported_api_for_model)`. Copilot serves MAI-Code models only via `/responses`, but the catalog routed the model to `openai-completions` (`/chat/completions`). Confirmed by evaluating the classifier: `inferCopilotApi("mai-code-1-flash-picker")` returned `openai-completions` instead of `openai-responses`.

## Cause
The Copilot model-API classifier in `packages/catalog/src/provider-models/openai-compat.ts` only routes `gpt-5*` / `oswe*` ids to the `/responses` API. `isCopilotResponsesModelId` feeds both the dynamic discovery path (`inferCopilotApi`, used by `githubCopilotModelManagerOptions`) and the generator's `COPILOT_API_RESOLUTION_RULES`, so every other id — including `mai-*` — falls through to the `openai-completions` default. The bundled `models.json` entry was likewise pinned to `"api": "openai-completions"` with an `openai-completions`-only `compat` block.

## Fix
- Add the `mai-` prefix to `isCopilotResponsesModelId` so both the dynamic classifier and the bundled resolver select `openai-responses`.
- Update the bundled `mai-code-1-flash-picker` entry in `models.json` to `"api": "openai-responses"` and drop the `compat` block (the generator's `transformModel` only attaches it to `openai-completions` models). Verified this matches a full `gen:models` run; only the mai-code entry was applied to keep the diff focused (the full regen also swept unrelated upstream discovery drift).
- Add a regression test in `github-copilot-model-limits.test.ts` that discovers a `mai-code-1-flash-picker` model and asserts it resolves to `openai-responses`.

## Verification
`bun test test/github-copilot-model-limits.test.ts` → 26 pass / 0 fail (includes the new `#5612` regression test). Fixes #5612