### PR TITLE
fix(anthropic): gate effort beta off google-vertex header path

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed thinking-enabled Claude requests routed to `google-vertex` sending the `effort-2025-11-24` beta as an `anthropic-beta` HTTP header, which Vertex rawPredict rejects with a 400. The effort beta and the `output_config.effort` field are now gated off the Vertex path the same way `context-management-2025-06-27` already is ([#5614](https://github.com/can1357/oh-my-pi/issues/5614)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Changed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1776,6 +1776,10 @@ const streamAnthropicOnce = (
 				// the toggle cannot 400); the beta must accompany the field in both.
 				// MiniMax uses `thinking.type:"adaptive"` itself as the control surface,
 				// so the sentinel "adaptive" value intentionally sends no output_config.
+				// Skip Vertex rawPredict: that adapter needs betas in the body
+				// (`anthropic_beta`), not as an `anthropic-beta` HTTP header, so the
+				// effort field is dropped from the body there too (see buildParams) and
+				// advertising the beta would only earn a 400 (#5614).
 				const sendsAdaptiveEffortPin =
 					options?.thinkingEnabled === false &&
 					model.thinking?.mode === "anthropic-adaptive" &&
@@ -1783,6 +1787,7 @@ const streamAnthropicOnce = (
 					!usesAdaptiveThinkingTagOnly(model);
 				if (
 					model.reasoning &&
+					model.provider !== "google-vertex" &&
 					((options?.thinkingEnabled && options.effort !== "adaptive") || sendsAdaptiveEffortPin) &&
 					!extraBetas.includes(effortBeta)
 				) {
@@ -3255,9 +3260,12 @@ function buildParams(
 		? { edits: [{ type: "clear_thinking_20251015" as const, keep: "all" as const }] }
 		: undefined;
 
-	// Pre-compute output_config.
+	// Pre-compute output_config. Skip `effort` on Vertex rawPredict: it requires
+	// the `effort-2025-11-24` beta, which that adapter can only accept in the body
+	// (`anthropic_beta`), never as the `anthropic-beta` HTTP header this path sets
+	// — so the field is dropped alongside the beta to avoid a 400 (#5614).
 	const outputConfigEntries: AnthropicOutputConfig = {};
-	if (outputConfigEffort) outputConfigEntries.effort = outputConfigEffort;
+	if (outputConfigEffort && model.provider !== "google-vertex") outputConfigEntries.effort = outputConfigEffort;
 	if (options?.taskBudget) outputConfigEntries.task_budget = options.taskBudget;
 	const outputConfig = Object.keys(outputConfigEntries).length ? outputConfigEntries : undefined;
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1752,6 +1752,23 @@ const streamAnthropicOnce = (
 			let forceDemoteUnsignedThinking = providerSessionState?.replayUnsignedThinkingDisabled ?? false;
 			const mergedCallerHeaders = mergeHeaders(model.headers, options?.headers);
 			const umansGatewayWebSearchHeader = getUmansWebSearchHeader(model, mergedCallerHeaders);
+			// Keep fallback payloads aligned with the top-level Vertex effort gate:
+			// no nested effort field means the fallback scan cannot re-add its beta.
+			let fallbacks = options?.fallbacks;
+			if (
+				model.provider === "google-vertex" &&
+				fallbacks?.some(entry => entry.output_config?.effort !== undefined)
+			) {
+				fallbacks = fallbacks.map(entry => {
+					const outputConfig = entry.output_config;
+					if (outputConfig?.effort === undefined) return entry;
+					return {
+						...entry,
+						output_config:
+							outputConfig.task_budget === undefined ? undefined : { task_budget: outputConfig.task_budget },
+					};
+				});
+			}
 
 			let client: AnthropicMessagesClientLike;
 			let isOAuthToken: boolean;
@@ -1821,11 +1838,11 @@ const streamAnthropicOnce = (
 				// `output_config.task_budget`) reuse the same top-level betas
 				// Anthropic requires for the primary request, so scan the chain
 				// and add every companion beta the fallback entries touch.
-				if (options?.fallbacks?.length) {
+				if (fallbacks?.length) {
 					if (!extraBetas.includes(serverSideFallbackBeta)) {
 						extraBetas.push(serverSideFallbackBeta);
 					}
-					for (const entry of options.fallbacks) {
+					for (const entry of fallbacks) {
 						if (entry.speed === "fast" && !extraBetas.includes(fastModeBeta)) {
 							extraBetas.push(fastModeBeta);
 						}
@@ -1867,6 +1884,7 @@ const streamAnthropicOnce = (
 					disableStrictTools,
 					umansGatewayWebSearchHeader !== undefined,
 					forceDemoteUnsignedThinking,
+					fallbacks,
 				);
 				if (disableStrictTools) {
 					dropAnthropicStrictTools(nextParams);
@@ -1893,9 +1911,9 @@ const streamAnthropicOnce = (
 
 			// Opt-in flag: the response parser only honors `fallback` content
 			// blocks and `usage.iterations` when the current request opted into
-			// the server-side-fallback beta chain. Leaving `options.fallbacks`
-			// unset preserves the pre-fallback stream shape on every event.
-			const serverSideFallback = !!options?.fallbacks?.length;
+			// server-side-fallback beta chain. Leaving `fallbacks` unset preserves
+			// the pre-fallback stream shape on every event.
+			const serverSideFallback = !!fallbacks?.length;
 			type Block = (
 				| ThinkingContent
 				| RedactedThinkingContent
@@ -3142,6 +3160,7 @@ function buildParams(
 	disableStrictTools = false,
 	useUmansGatewayWebSearch = false,
 	forceDemoteUnsignedThinking = false,
+	fallbacks = options?.fallbacks,
 ): MessageCreateParamsStreaming {
 	// A session-scoped auto-demote (learned from a live signing 400) clones the
 	// resolved compat with `replayUnsignedThinking: false` so every subsequent
@@ -3280,7 +3299,7 @@ function buildParams(
 	const params: MessageCreateParamsStreaming = {
 		model: options?.requestModelId ?? model.requestModelId ?? model.id,
 		messages: convertAnthropicMessages(context.messages, effectiveModel, isOAuthToken, {
-			serverSideFallbackEnabled: !!options?.fallbacks?.length,
+			serverSideFallbackEnabled: !!fallbacks?.length,
 		}),
 		...(systemBlocks && { system: systemBlocks }),
 		...(tools !== undefined && { tools }),
@@ -3289,7 +3308,7 @@ function buildParams(
 		...(thinking && { thinking }),
 		...(contextManagement && { context_management: contextManagement }),
 		...(outputConfig && { output_config: outputConfig }),
-		...(options?.fallbacks?.length ? { fallbacks: options.fallbacks } : {}),
+		...(fallbacks?.length ? { fallbacks } : {}),
 		stream: true,
 	};
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -429,7 +429,16 @@ describe("Anthropic request fingerprint alignment", () => {
 
 	it("gates the effort beta and field off google-vertex requests (#5614)", async () => {
 		let capturedBeta: string | undefined;
-		let capturedBody: { output_config?: { effort?: unknown } } | undefined;
+		let capturedBody:
+			| {
+					output_config?: { effort?: unknown };
+					fallbacks?: Array<{
+						model: string;
+						max_tokens?: number;
+						output_config?: { effort?: unknown };
+					}>;
+			  }
+			| undefined;
 		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
 			capturedBeta = (init?.headers as Record<string, string> | undefined)?.["anthropic-beta"];
 			capturedBody = JSON.parse(String(init?.body ?? "{}"));
@@ -441,7 +450,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		// Claude on Vertex uses api "anthropic-messages" and the rawPredict adapter,
 		// which rejects any `anthropic-beta` HTTP header value it doesn't understand.
 		// The effort beta must ride the body (`anthropic_beta`) instead — since this
-		// path can't deliver it there, both the beta and the effort field are dropped.
+		// path can't deliver it there, primary and fallback effort fields are dropped.
 		const vertexModel: Model<"anthropic-messages"> = buildModel({
 			...ANTHROPIC_MODEL_SPEC,
 			id: "claude-haiku-4-5@20260101",
@@ -458,11 +467,23 @@ describe("Anthropic request fingerprint alignment", () => {
 		await streamAnthropic(
 			vertexModel,
 			{ systemPrompt: ["Stay concise."], messages: [{ role: "user", content: "Hi", timestamp: Date.now() }] },
-			{ apiKey: "vertex-adc", thinkingEnabled: true, fetch: fetchMock },
+			{
+				apiKey: "vertex-adc",
+				thinkingEnabled: true,
+				fetch: fetchMock,
+				fallbacks: [
+					{
+						model: "claude-sonnet-4-6@20260101",
+						max_tokens: 4_096,
+						output_config: { effort: "high" },
+					},
+				],
+			},
 		).result();
 
 		expect(capturedBeta ?? "").not.toContain("effort-2025-11-24");
 		expect(capturedBody?.output_config?.effort).toBeUndefined();
+		expect(capturedBody?.fallbacks).toEqual([{ model: "claude-sonnet-4-6@20260101", max_tokens: 4_096 }]);
 	});
 
 	it("adds the context-management beta to API-key thinking requests", async () => {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -427,6 +427,44 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(capturedBeta).toContain("mid-conversation-system-2026-04-07");
 	});
 
+	it("gates the effort beta and field off google-vertex requests (#5614)", async () => {
+		let capturedBeta: string | undefined;
+		let capturedBody: { output_config?: { effort?: unknown } } | undefined;
+		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedBeta = (init?.headers as Record<string, string> | undefined)?.["anthropic-beta"];
+			capturedBody = JSON.parse(String(init?.body ?? "{}"));
+			return new Response(
+				JSON.stringify({ type: "error", error: { type: "invalid_request_error", message: "captured" } }),
+				{ status: 400, headers: { "Content-Type": "application/json" } },
+			);
+		}) as typeof fetch;
+		// Claude on Vertex uses api "anthropic-messages" and the rawPredict adapter,
+		// which rejects any `anthropic-beta` HTTP header value it doesn't understand.
+		// The effort beta must ride the body (`anthropic_beta`) instead — since this
+		// path can't deliver it there, both the beta and the effort field are dropped.
+		const vertexModel: Model<"anthropic-messages"> = buildModel({
+			...ANTHROPIC_MODEL_SPEC,
+			id: "claude-haiku-4-5@20260101",
+			name: "Claude Haiku via Vertex",
+			provider: "google-vertex",
+			baseUrl:
+				"https://us-east5-aiplatform.googleapis.com/v1/projects/p/locations/us-east5/publishers/anthropic/models/claude-haiku-4-5:rawPredict",
+			thinking: {
+				mode: "anthropic-adaptive",
+				efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+			},
+		});
+
+		await streamAnthropic(
+			vertexModel,
+			{ systemPrompt: ["Stay concise."], messages: [{ role: "user", content: "Hi", timestamp: Date.now() }] },
+			{ apiKey: "vertex-adc", thinkingEnabled: true, fetch: fetchMock },
+		).result();
+
+		expect(capturedBeta ?? "").not.toContain("effort-2025-11-24");
+		expect(capturedBody?.output_config?.effort).toBeUndefined();
+	});
+
 	it("adds the context-management beta to API-key thinking requests", async () => {
 		let capturedBeta: string | undefined;
 		const fetchMock = (async (_input: string | URL | Request, init?: RequestInit) => {


### PR DESCRIPTION
## Repro
Thinking-enabled Claude requests routed to the `google-vertex` provider (api `anthropic-messages`, rawPredict URL) emit the `effort-2025-11-24` beta as an `anthropic-beta` HTTP header. Vertex rejects unrecognized header betas with `400 invalid_request_error`, so any Claude sub-agent that resolves to Vertex with default `auto` thinking 400s before its first turn. Driving `streamAnthropic` with a Vertex Claude model and `thinkingEnabled: true`, capturing the outgoing header:

```
anthropic-beta: "effort-2025-11-24,interleaved-thinking-2025-05-14"
```

## Cause
`packages/ai/src/providers/anthropic.ts` — in `streamAnthropicOnce`, the `extraBetas.push(effortBeta)` block gated only on `model.reasoning` and the thinking/effort conditions, with no provider check. The companion `output_config.effort` field in `buildParams` was likewise ungated. Both leaked onto the Vertex path, unlike `contextManagementBeta` and the thinking-context directive, which already carry `model.provider !== "google-vertex"` guards (Vertex rawPredict needs betas in the JSON body `anthropic_beta`, not as the HTTP header this code path sets).

## Fix
- `streamAnthropicOnce`: add `model.provider !== "google-vertex"` to the `effortBeta` push condition so the beta is never sent as an HTTP header on Vertex requests.
- `buildParams`: drop `output_config.effort` for `google-vertex` so the field isn't sent without its (now-omitted) beta, mirroring how `context_management` is already dropped for Vertex.
- Added a regression test in `packages/ai/test/anthropic-alignment.test.ts` asserting the Vertex path emits neither the header beta nor the `output_config.effort` field.
- Changelog entry under `packages/ai/CHANGELOG.md` `[Unreleased]`.

## Verification
`cd packages/ai && bun test test/anthropic-alignment.test.ts` → 84 pass / 0 fail (includes the new regression test). `bun test test/anthropic-prior-turn-thinking.test.ts` → 13 pass / 0 fail. Pre-fix header capture showed `effort-2025-11-24,interleaved-thinking-2025-05-14`; post-fix it shows only `interleaved-thinking-2025-05-14`. Fixes #5614