### PR TITLE
fix(tui): render keyed hook statuses separately

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Fixed
 
+- Fixed independently keyed extension hook statuses sharing one truncated line; each status now renders on its own deterministic line ([#5617](https://github.com/can1357/oh-my-pi/issues/5617)).
 - Fixed a bug where a nested configuration value (like `dev.autoqa.consent` / `dev.autoqaConsent`) would incorrectly satisfy a parent key lookup (like `dev.autoqa`), causing Auto QA to be enabled and prompt for consent by default when it should have been disabled.
 - Fixed compiled appserver startup deadlocking before socket creation when user extensions were present.
 - Fixed Bash internal URLs remaining unresolved when used as unquoted arguments inside command substitutions.

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1334,10 +1334,8 @@ export class StatusLineComponent implements Component {
 			return [];
 		}
 
-		const sortedStatuses = Array.from(this.#hookStatuses.entries())
+		return Array.from(this.#hookStatuses.entries())
 			.sort(([a], [b]) => a.localeCompare(b))
-			.map(([, text]) => sanitizeStatusText(text));
-		const hookLine = sortedStatuses.join(" ");
-		return [truncateToWidth(hookLine, width)];
+			.map(([, text]) => truncateToWidth(sanitizeStatusText(text), width));
 	}
 }

--- a/packages/coding-agent/test/status-line-settings-cache.test.ts
+++ b/packages/coding-agent/test/status-line-settings-cache.test.ts
@@ -268,3 +268,13 @@ describe("StatusLineComponent effective settings cache", () => {
 		}
 	});
 });
+
+describe("StatusLineComponent hook statuses", () => {
+	it("renders every keyed status on a deterministic line", () => {
+		const component = makeComponent({ showHookStatus: true });
+		component.setHookStatus("project-time", "$0.04 (dev)");
+		component.setHookStatus("ponytail", "Ponytail");
+
+		expect(component.render(8)).toEqual(["Ponytail", "$0.04 (…"]);
+	});
+});


### PR DESCRIPTION
## Repro
With `statusLine.showHookStatus=true`, set `project-time` to `$0.04 (dev)` and `ponytail` to `○ 🐴 ponytail: ⚡ FULL`, then render the hook-status surface at 23 columns. `bun packages/coding-agent/.tmp-repro-5617.ts` returned only `["○ 🐴 ponytail: ⚡ FULL…"]`, hiding the second keyed status.

## Cause
`StatusLineComponent.render()` in `packages/coding-agent/src/modes/components/status-line/component.ts` sorted the keyed map, joined every value into one string, and truncated that combined string once. An earlier key could therefore consume the whole width and make later keys invisible.

## Fix
- Render each sorted keyed status as its own line.
- Sanitize and truncate each entry independently to the available width.
- Cover deterministic multi-key rendering at narrow widths.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/status-line-settings-cache.test.ts` — 11 passed, 0 failed. Manual 23-column smoke returned `["○ 🐴 ponytail: ⚡ FULL","$0.04 (dev)"]`. `bun check` passed through the pre-publish gate.

Fixes #5617