### PR TITLE
fix(tui): restore modifyOtherKeys fallback in tmux

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a tmux regression where every non-Kitty pane was forced into legacy keyboard input, collapsing Ctrl+H into Backspace and Shift+Enter into Enter even with `extended-keys on`; the xterm modifyOtherKeys fallback is requested again so tmux honors or ignores it per its own `extended-keys` setting ([#5620](https://github.com/can1357/oh-my-pi/issues/5620)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -13,7 +13,6 @@ import { setKittyProtocolActive } from "./keys";
 import { StdinBuffer } from "./stdin-buffer";
 import {
 	isInsideTerminalMultiplexer,
-	isInsideTmux,
 	NotifyProtocol,
 	setCellDimensions,
 	setOsc99Supported,
@@ -45,7 +44,6 @@ export function resolveHangulCompatibilityJamoWidthFromTerminalIdentity(
 }
 
 function shouldEnableModifyOtherKeysFallback(env: NodeJS.ProcessEnv = Bun.env): boolean {
-	if (isInsideTmux(env)) return false;
 	if (!env.SSH_CONNECTION && !env.SSH_TTY && !env.SSH_CLIENT) return true;
 	return TERMINAL.id !== "base" && TERMINAL.id !== "trueColor";
 }

--- a/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
+++ b/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
@@ -112,7 +112,12 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 		expect(harness.terminal.keyboardEnhancementEnterSequence).toBeNull();
 	});
 
-	it("keeps legacy keyboard input under tmux when kitty is unavailable", async () => {
+	it("enables modifyOtherKeys fallback under tmux so extended-keys panes keep modified keys (#5620)", async () => {
+		// tmux answers DA1 but not `CSI ? u`. omp must still request the xterm
+		// modifyOtherKeys fallback; tmux honors it under `extended-keys on`/`always`
+		// (delivering Ctrl+H and Shift+Enter distinctly) and ignores it under
+		// `extended-keys off`, so tmux — not omp — is the capability gate. A blanket
+		// tmux exclusion (#5502) collapsed those keys to legacy bytes in every pane.
 		Bun.env.TMUX = "/tmp/tmux-501/default,1234,0";
 		delete Bun.env.SSH_CONNECTION;
 		delete Bun.env.SSH_TTY;
@@ -125,8 +130,9 @@ describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () =
 
 		const out = harness.writes.join("");
 		expect(harness.terminal.kittyProtocolActive).toBe(false);
-		expect(out).not.toContain("\x1b[>4;2m");
-		expect(harness.terminal.keyboardEnhancementEnterSequence).toBeNull();
+		expect(out).toContain("\x1b[>4;2m");
+		expect(out).not.toContain("\x1b[>1u");
+		expect(harness.terminal.keyboardEnhancementEnterSequence).toBe("\x1b[>4;2m");
 	});
 
 	it("reasserts modifyOtherKeys fallback when fullscreen overlays enter the alternate screen", async () => {


### PR DESCRIPTION
## Repro
Inside tmux with `extended-keys on`, omp collapses modified keys to their legacy bytes: Ctrl+H arrives as Backspace (`0x08`) and Shift+Enter arrives as plain Enter (`0x0d`), so `ctrl+h` bindings never fire and Shift+Enter submits instead of inserting a newline. Driving a real `ProcessTerminal` under `TMUX` and feeding tmux's DA1 reply (`CSI ?1;2c`) with the kitty query unanswered shows the terminal emits no `CSI >4;2m`, so the `modifyOtherKeys` fallback never engages.

## Cause
`shouldEnableModifyOtherKeysFallback` in `packages/tui/src/terminal.ts` opened with a blanket `if (isInsideTmux(env)) return false;`, added in #5502 to address #5378. That short-circuited the `CSI >4;2m` request in every non-Kitty tmux pane, forcing legacy input regardless of tmux's `extended-keys` setting. Per the #5378 thread the reporter confirmed 16.5.2 still wedged all input from a separate read-side cause, so the gate never fixed #5378 — it only introduced this modified-key regression.

## Fix
- Removed the blanket `isInsideTmux` gate from `shouldEnableModifyOtherKeysFallback` (and its now-unused import). tmux itself gates `CSI >4;2m` on its `extended-keys` setting — honoring it under `on`/`always`, ignoring it under `off` — so tmux remains the capability gate.
- Flipped the DA1-under-tmux negotiation test to assert the fallback engages (`CSI >4;2m` emitted, no kitty push), documenting that tmux is the gate.
- Added a `[Unreleased]` changelog entry.

## Verification
`bun test test/kitty-keyboard-da1-ordering.test.ts test/keys.test.ts` in `packages/tui` — 34 pass, 91 assertions. The pre-fix repro (feed DA1 under `TMUX`, expect `CSI >4;2m`) failed before the change and passes after. Fixes #5620