### PR TITLE
fix(catalog): preserve bundled Codex limits

### DIFF
--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -4,7 +4,6 @@ import { discoveryFetch } from "../utils";
 import { CODEX_BASE_URL, CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "../wire/codex";
 
 const DEFAULT_MODEL_LIST_PATHS = ["/codex/models", "/models"] as const;
-const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
 const CODEX_REMOTE_COMPACTION = {
 	enabled: true,
@@ -214,8 +213,8 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 	}
 
 	const name = toNonEmptyString(payload.display_name) ?? slug;
-	const contextWindow = toPositiveInt(payload.context_window) ?? DEFAULT_CONTEXT_WINDOW;
-	const maxTokens = Math.min(DEFAULT_MAX_TOKENS, contextWindow);
+	const contextWindow = toPositiveInt(payload.context_window);
+	const maxTokens = contextWindow === null ? null : Math.min(DEFAULT_MAX_TOKENS, contextWindow);
 	const reasoning = supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels);
 	const input = normalizeInputModalities(payload.input_modalities);
 	const preferWebsockets = toBoolean(payload.prefer_websockets) === true;

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -56,7 +56,7 @@ describe("Codex model discovery", () => {
 		});
 	});
 
-	it("carries use_responses_lite and prefer_websockets onto the model spec", async () => {
+	it("preserves bundled limits when discovery omits them", async () => {
 		const fetchFn: typeof fetch = Object.assign(
 			async () =>
 				new Response(
@@ -65,7 +65,6 @@ describe("Codex model discovery", () => {
 							{
 								slug: "gpt-5.6-terra",
 								display_name: "GPT-5.6-Terra",
-								context_window: 372_000,
 								default_reasoning_level: "medium",
 								supported_reasoning_levels: ["low", "medium", "high"],
 								input_modalities: ["text", "image"],
@@ -95,9 +94,32 @@ describe("Codex model discovery", () => {
 		});
 
 		const terra = result?.models.find(model => model.id === "gpt-5.6-terra");
-		expect(terra).toMatchObject({ preferWebsockets: true, useResponsesLite: true });
+		expect(terra).toMatchObject({
+			preferWebsockets: true,
+			useResponsesLite: true,
+			contextWindow: null,
+			maxTokens: null,
+		});
 		const legacy = result?.models.find(model => model.id === "gpt-5.5");
 		expect(legacy?.useResponsesLite).toBeUndefined();
+
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-limits-"));
+		try {
+			const resolved = await resolveProviderModels<"openai-codex-responses">(
+				{
+					providerId: "openai-codex",
+					cacheDbPath: path.join(tempDir, "models.db"),
+					fetchDynamicModels: async () => result?.models ?? null,
+				},
+				"online",
+			);
+			expect(resolved.models.find(model => model.id === "gpt-5.6-terra")).toMatchObject({
+				contextWindow: 372_000,
+				maxTokens: 128_000,
+			});
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("ignores pre-V2 Codex discovery cache rows", async () => {


### PR DESCRIPTION
## Problem

Codex discovery currently turns an omitted `context_window` into an explicit 272K limit. The model-manager correctly treats that as authoritative, so a live refresh overwrites the bundled 372K limits for `gpt-5.6-{luna,sol,terra}`.

Reproduced against the live Codex discovery endpoint with `omp models refresh openai-codex`: all three GPT-5.6 variants resolved to 272K. There are no local GPT-5.6/context overrides in `config.yml` or the custom model files; the refreshed authoritative cache contains 272000.

## Fix

Keep omitted Codex limits unknown (`null`), matching openai-compatible discovery. The existing model-manager merge then preserves bundled limits while explicit positive provider limits remain authoritative.

No model-name/version heuristic and no global default change.

## Verification

- `bun test packages/catalog/test/codex-discovery.test.ts` — 4 pass
- `bun run check` in `packages/catalog` — passed
- Regression covers omitted discovery limits resolving to bundled 372K/128K.