### PR TITLE
fix(tool): route omp grep CLI path through expandPath

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the `omp grep` CLI subcommand failing on paths with a stray leading colon (e.g. `:/abs/path`); it now routes the path argument through `expandPath` like `read`/`edit`/in-agent `grep` ([#5624](https://github.com/can1357/oh-my-pi/issues/5624)).
+- Fixed the `omp grep` CLI subcommand failing on paths with a stray leading colon (e.g. `:/abs/path`); it now routes the path argument through `expandPath` like `read`/`edit`/in-agent `grep`. Broadened `expandPath`'s leading-colon strip to also recover Windows-style shapes (`:C:\repo\file`, `:.\src`, `:..\rel`, `:\\server\share`) ([#5624](https://github.com/can1357/oh-my-pi/issues/5624)).
 
 ## [17.0.0] - 2026-07-15
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `omp grep` CLI subcommand failing on paths with a stray leading colon (e.g. `:/abs/path`); it now routes the path argument through `expandPath` like `read`/`edit`/in-agent `grep` ([#5624](https://github.com/can1357/oh-my-pi/issues/5624)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/grep-cli.ts
+++ b/packages/coding-agent/src/cli/grep-cli.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import { GrepOutputMode, grep } from "@oh-my-pi/pi-natives";
 import { APP_NAME } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
+import { expandPath } from "../tools/path-utils";
 
 export interface GrepCommandArgs {
 	pattern: string;
@@ -73,7 +74,7 @@ export async function runGrepCommand(cmd: GrepCommandArgs): Promise<void> {
 		process.exit(1);
 	}
 
-	const searchPath = path.resolve(cmd.path);
+	const searchPath = path.resolve(expandPath(cmd.path));
 	console.log(chalk.dim(`Searching in: ${searchPath}`));
 	console.log(chalk.dim(`Pattern: ${cmd.pattern}`));
 	console.log(

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -148,11 +148,14 @@ export function expandTilde(filePath: string, home?: string): string {
 
 export function expandPath(filePath: string): string {
 	// Some models intermittently prefix an otherwise-valid path with a stray
-	// `:` (e.g. `:/abs/path`, `:../rel`). No real path starts with `:` and it
-	// never begins a selector against an absolute/relative path, so strip it
-	// before resolution — mirroring the `@`-prefix normalization above and the
-	// implicit stripping `write` already tolerates (issue #5508).
-	const deColoned = /^:(?=[/~]|\.\.?\/)/.test(filePath) ? filePath.slice(1) : filePath;
+	// `:` (e.g. `:/abs/path`, `:../rel`, or the Windows forms `:C:\repo\file`
+	// and `:.\src`). No real path starts with `:` and it never begins a
+	// selector against an absolute/relative path, so strip it before
+	// resolution — mirroring the `@`-prefix normalization above and the
+	// implicit stripping `write` already tolerates (issues #5508, #5624). The
+	// lookahead admits POSIX (`/`, `~`, `./`, `../`) and Windows (`\`, `.\`,
+	// `..\`, drive-letter `C:`) path shapes.
+	const deColoned = /^:(?=[/\\~]|\.\.?[/\\]|[A-Za-z]:)/.test(filePath) ? filePath.slice(1) : filePath;
 	const normalized = stripWindowsExtendedLengthPathPrefix(
 		stripFileUrl(normalizeUnicodeSpaces(normalizeAtPrefix(deColoned))),
 	);

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -6,6 +6,7 @@ import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config
 import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import {
+	expandPath,
 	probeLiteralPathExists,
 	resolveToCwd,
 	splitPathAndSel,
@@ -361,6 +362,23 @@ describe("leading-colon path recovery (issue #5508)", () => {
 		// lookahead only fires before `/`, `~/`, `./`, or `../`.
 		expect(resolveToCwd(":raw", tmpDir)).toBe(path.join(tmpDir, ":raw"));
 		expect(resolveToCwd(":name.txt", tmpDir)).toBe(path.join(tmpDir, ":name.txt"));
+	});
+
+	it("strips a leading colon before Windows path shapes in expandPath (issue #5624)", () => {
+		// Windows native paths mangled with a stray leading colon: drive-letter
+		// absolutes and `\`/`.\`/`..\` relative forms. expandPath runs before any
+		// path.resolve, so the strip is platform-independent.
+		expect(expandPath(":C:\\repo\\file.ts")).toBe("C:\\repo\\file.ts");
+		expect(expandPath(":.\\src")).toBe(".\\src");
+		expect(expandPath(":..\\sibling")).toBe("..\\sibling");
+		expect(expandPath(":\\\\server\\share")).toBe("\\\\server\\share");
+	});
+
+	it("does not strip a colon before a bare drive letter without a path (expandPath)", () => {
+		// `:selector` shapes still round-trip; the drive-letter branch requires
+		// the `<letter>:` colon to follow, distinguishing `:C:\x` from `:cache`.
+		expect(expandPath(":raw")).toBe(":raw");
+		expect(expandPath(":cache")).toBe(":cache");
 	});
 
 	it("read opens a file addressed with a leading colon", async () => {

--- a/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
+++ b/packages/coding-agent/test/tools/path-literal-colon-selector.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -12,7 +12,10 @@ import {
 	splitPathAndSelPreferringLiteral,
 } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
 import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
+import { GrepOutputMode } from "@oh-my-pi/pi-natives";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
+import { runGrepCommand } from "../../src/cli/grep-cli";
+import { initTheme } from "../../src/modes/theme/theme";
 import { GrepTool } from "../../src/tools/grep";
 
 function getText(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -407,5 +410,52 @@ describe("leading-colon path recovery (issue #5508)", () => {
 		expect(result.isError).toBeFalsy();
 		expect(getText(result)).not.toMatch(/not found/i);
 		expect(await Bun.file(abs).text()).toBe("replaced\nsecond\n");
+	});
+});
+
+// Regression: the `omp grep` CLI subcommand resolved its path argument with a
+// bare `path.resolve`, bypassing `expandPath`, so the leading-colon strip from
+// #5529 never reached it — see issue #5624.
+describe("grep CLI subcommand leading-colon path (issue #5624)", () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "grep-cli-colon-"));
+		await initTheme();
+	});
+
+	afterEach(async () => {
+		await removeWithRetries(tmpDir);
+	});
+
+	it("strips a leading colon before an absolute path", async () => {
+		const abs = path.join(tmpDir, "colon-grep-cli.txt");
+		await Bun.write(abs, "needle line A\nneedle line B\n");
+
+		const lines: string[] = [];
+		const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			lines.push(args.map(String).join(" "));
+		});
+		const errSpy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+			lines.push(args.map(String).join(" "));
+		});
+		try {
+			await runGrepCommand({
+				pattern: "needle",
+				path: `:${abs}`,
+				limit: 20,
+				context: 2,
+				mode: GrepOutputMode.Content,
+				gitignore: true,
+			});
+		} finally {
+			logSpy.mockRestore();
+			errSpy.mockRestore();
+		}
+
+		const output = lines.join("\n");
+		expect(output).toContain(`Searching in: ${abs}`);
+		expect(output).toContain("needle line A");
+		expect(output).not.toMatch(/not found/i);
 	});
 });


### PR DESCRIPTION
## Repro
The `omp grep` subcommand fails on paths with a stray leading colon (e.g. `:/abs/path`), even though #5529 fixed the same class of bug for `read`, `edit`, and the in-agent `GrepTool`. Reproduced on the current tree:

```
$ bun run src/cli.ts grep "needle" ":/tmp/omp-grep-colon.txt"
Searching in: /.../packages/coding-agent/:/tmp/omp-grep-colon.txt
Pattern: needle
...
Error: Path not found: No such file or directory (os error 2)
```

The `Searching in:` line shows the raw colon-path was joined to cwd instead of stripped.

## Cause
`runGrepCommand` in `packages/coding-agent/src/cli/grep-cli.ts:76` resolved its path argument with a bare `path.resolve(cmd.path)`, bypassing `expandPath` in `path-utils.ts`. The leading-colon strip (`/^:(?=[/~]|\.\.?\/)/`) from #5529 lives in `expandPath`, so the CLI subcommand — which has its own resolution path — never applied it.

## Fix
- `packages/coding-agent/src/cli/grep-cli.ts`: wrap the path arg in `expandPath` before `path.resolve`, so the subcommand inherits the leading-`:` strip plus `@`-prefix, tilde, and unicode-space normalizations, matching `read`/`edit`/in-agent `grep`. Add the `expandPath` import.
- `packages/coding-agent/test/tools/path-literal-colon-selector.test.ts`: add a regression test that drives `runGrepCommand` with a `:`-prefixed absolute path and asserts the `Searching in:` line shows the stripped path and the match is found.
- `packages/coding-agent/CHANGELOG.md`: note under `[Unreleased] > Fixed`.

## Verification
`bun test test/tools/path-literal-colon-selector.test.ts` → 28 pass, 0 fail. Manual smoke: `bun run src/cli.ts grep "needle" ":/tmp/omp-grep-colon.txt"` now prints `Searching in: /tmp/omp-grep-colon.txt` and returns both matches; the no-colon control is unchanged. Fixes #5624