### PR TITLE
fix(catalog): preserve bundled Codex context limits

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex discovery overwriting bundled context limits when the provider omits `context_window`.
+
+
 ## [16.5.2] - 2026-07-14
 
 ### Fixed

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -4,7 +4,6 @@ import { discoveryFetch } from "../utils";
 import { CODEX_BASE_URL, CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "../wire/codex";
 
 const DEFAULT_MODEL_LIST_PATHS = ["/codex/models", "/models"] as const;
-const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
 const CODEX_REMOTE_COMPACTION = {
 	enabled: true,
@@ -214,8 +213,8 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 	}
 
 	const name = toNonEmptyString(payload.display_name) ?? slug;
-	const contextWindow = toPositiveInt(payload.context_window) ?? DEFAULT_CONTEXT_WINDOW;
-	const maxTokens = Math.min(DEFAULT_MAX_TOKENS, contextWindow);
+	const contextWindow = toPositiveInt(payload.context_window);
+	const maxTokens = contextWindow !== null ? Math.min(DEFAULT_MAX_TOKENS, contextWindow) : null;
 	const reasoning = supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels);
 	const input = normalizeInputModalities(payload.input_modalities);
 	const preferWebsockets = toBoolean(payload.prefer_websockets) === true;

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -214,4 +214,66 @@ describe("Codex model discovery", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	it.each([
+		["omitted", undefined, 372_000],
+		["explicit", 400_000, 400_000],
+	] as const)("merges %s discovery limits without inventing a fallback", async (_case, discoveredLimit, expectedLimit) => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-limit-"));
+		const dbPath = path.join(tempDir, "models.db");
+		try {
+			const staticModel = buildModel({
+				id: "gpt-5.6-terra",
+				name: "GPT-5.6 Terra",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				baseUrl: "https://chatgpt.com/backend-api/codex",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 372_000,
+				maxTokens: 128_000,
+			});
+			const fetchFn: typeof fetch = Object.assign(
+				async () =>
+					new Response(
+						JSON.stringify({
+							models: [
+								{
+									slug: "gpt-5.6-terra",
+									display_name: "GPT-5.6 Terra",
+									...(discoveredLimit === undefined ? {} : { context_window: discoveredLimit }),
+									default_reasoning_level: "medium",
+									supported_reasoning_levels: ["low", "medium", "high"],
+									input_modalities: ["text"],
+									supported_in_api: true,
+								},
+							],
+						}),
+					),
+				{ preconnect() {} },
+			);
+			const discoveryResult = await fetchCodexModels({
+				accessToken: "test-token",
+				baseUrl: "https://codex.example/backend-api",
+				clientVersion: "0.99.0",
+				fetchFn,
+			});
+
+			expect(discoveryResult?.models[0].contextWindow).toBe(discoveredLimit ?? null);
+			expect(discoveryResult?.models[0].maxTokens).toBe(discoveredLimit === undefined ? null : 128_000);
+
+			const resolved = await resolveProviderModels<"openai-codex-responses">({
+				providerId: "openai-codex",
+				staticModels: [staticModel],
+				dynamicModelsAuthoritative: true,
+				cacheDbPath: dbPath,
+				fetchDynamicModels: async () => discoveryResult?.models ?? [],
+			});
+			const terra = resolved.models.find(model => model.id === "gpt-5.6-terra");
+			expect(terra?.contextWindow).toBe(expectedLimit);
+			expect(terra?.maxTokens).toBe(128_000);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- keep omitted Codex discovery limits unknown instead of inventing a 272K value
- preserve bundled context and output limits during model-manager merging
- retain explicit positive provider limits as authoritative

## Screenshots
No visual change.

## Testing
- `bun test test/codex-discovery.test.ts` in `packages/catalog`
- `bun run check:types` in `packages/catalog`

## Risk
- Low. The change only alters normalization when Codex omits `context_window`; explicit positive values retain the existing behavior.

## Notes
- Supersedes the closed unvouched proposal in #5622 with focused regression coverage.

## AI Review Report
- Reviewed merge behavior for omitted and explicit positive discovery limits.
- Added deterministic cache-backed coverage for both cases.

## Security Audit
- No authentication, credential storage, request headers, or authorization behavior changed.