### PR TITLE
feat(omp): add configurable context window budgets

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex discovery overwriting bundled context limits when the provider omits `context_window`.
+
+
 ## [16.5.2] - 2026-07-14
 
 ### Fixed

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Codex discovery overwriting bundled context limits when the provider omits `context_window`.
+- Preserved catalog-declared hard context capacity for models with a separate conservative default budget.
 
 
 ## [16.5.2] - 2026-07-14

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -344,6 +344,13 @@ function inferGeneratedApplyPatchToolType(
 }
 
 function applyOpenAICatalogPolicy(model: ModelSpec<Api>, parsedModel: OpenAIModel): void {
+	// GPT-5.6 Codex family: hard capacity 372K, recommended budget 272K, output 128K
+	if (model.api === "openai-codex-responses" && semverEqual(parsedModel.version, "5.6")) {
+		model.contextWindow = 372000;
+		model.defaultContextTokens = 272000;
+		model.maxTokens = 128000;
+		return;
+	}
 	// Codex models: 400K figure includes output budget; input window is 272K.
 	if (parsedModel.variant.startsWith("codex") && parsedModel.variant !== "codex-spark") {
 		model.contextWindow = 272000;

--- a/packages/catalog/src/build.ts
+++ b/packages/catalog/src/build.ts
@@ -45,3 +45,18 @@ export function buildCompat(spec: ModelSpec<Api>): CompatOf<Api> {
 			return undefined;
 	}
 }
+
+export function resolveEffectiveContextWindow(
+	model: { contextWindow: number | null; defaultContextTokens?: number },
+	percent: number | undefined | null
+): number {
+	const hardCapacity = model.contextWindow ?? 0;
+	if (hardCapacity <= 0) {
+		return 0;
+	}
+	if (percent === undefined || percent === null || percent === -1) {
+		return model.defaultContextTokens ?? hardCapacity;
+	}
+	const calculated = Math.floor((hardCapacity * percent) / 100);
+	return Math.min(hardCapacity, Math.max(1, calculated));
+}

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -4,7 +4,6 @@ import { discoveryFetch } from "../utils";
 import { CODEX_BASE_URL, CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "../wire/codex";
 
 const DEFAULT_MODEL_LIST_PATHS = ["/codex/models", "/models"] as const;
-const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
 const CODEX_REMOTE_COMPACTION = {
 	enabled: true,
@@ -214,8 +213,8 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 	}
 
 	const name = toNonEmptyString(payload.display_name) ?? slug;
-	const contextWindow = toPositiveInt(payload.context_window) ?? DEFAULT_CONTEXT_WINDOW;
-	const maxTokens = Math.min(DEFAULT_MAX_TOKENS, contextWindow);
+	const contextWindow = toPositiveInt(payload.context_window);
+	const maxTokens = contextWindow !== null ? Math.min(DEFAULT_MAX_TOKENS, contextWindow) : null;
 	const reasoning = supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels);
 	const input = normalizeInputModalities(payload.input_modalities);
 	const preferWebsockets = toBoolean(payload.prefer_websockets) === true;

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -15,3 +15,4 @@ export * from "./wire/codex";
 export * from "./wire/coreweave";
 export * from "./wire/gemini-headers";
 export * from "./wire/github-copilot";
+export * from "./build";

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -376,6 +376,19 @@ function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamic
 	const supportsImage = dynamicInputAuthoritative
 		? dynamicModel.input.includes("image")
 		: existingModel.input.includes("image") || dynamicModel.input.includes("image");
+	const discoveryContextWindow = preferDiscoveryLimit(dynamicModel.contextWindow, existingModel.contextWindow);
+	const preservesCatalogCapacity =
+		!endpointChanged &&
+		existingModel.defaultContextTokens !== undefined &&
+		existingModel.contextWindow !== null &&
+		dynamicModel.contextWindow !== null &&
+		Number.isFinite(dynamicModel.contextWindow) &&
+		dynamicModel.contextWindow > 0 &&
+		dynamicModel.contextWindow <= existingModel.contextWindow;
+	const contextWindow = preservesCatalogCapacity ? existingModel.contextWindow : discoveryContextWindow;
+	const defaultContextTokens = preservesCatalogCapacity
+		? Math.min(existingModel.defaultContextTokens!, dynamicModel.contextWindow!)
+		: existingModel.defaultContextTokens;
 	// Re-build from spec stage: sparse compat comes from `compatConfig` (the
 	// verbatim override vocabulary), never the resolved `compat` record.
 	return buildModel({
@@ -390,7 +403,8 @@ function mergeDynamicModel<TApi extends Api>(existingModel: Model<TApi>, dynamic
 			cacheRead: preferDiscoveryCost(dynamicModel.cost.cacheRead, existingModel.cost.cacheRead),
 			cacheWrite: preferDiscoveryCost(dynamicModel.cost.cacheWrite, existingModel.cost.cacheWrite),
 		},
-		contextWindow: preferDiscoveryLimit(dynamicModel.contextWindow, existingModel.contextWindow),
+		contextWindow,
+		defaultContextTokens,
 		maxTokens: preferDiscoveryLimit(dynamicModel.maxTokens, existingModel.maxTokens),
 		headers: dynamicModel.headers ? { ...existingModel.headers, ...dynamicModel.headers } : existingModel.headers,
 		compat: dynamicModel.compatConfig ?? existingModel.compatConfig,

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -63545,6 +63545,7 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 372000,
+			"defaultContextTokens": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
@@ -63584,6 +63585,7 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 372000,
+			"defaultContextTokens": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
@@ -63623,6 +63625,7 @@
 				"v2StreamingEnabled": true
 			},
 			"contextWindow": 372000,
+			"defaultContextTokens": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -729,6 +729,8 @@ export interface Model<TApi extends Api = Api> {
 	/** Premium Copilot requests charged per user-initiated request (defaults to 1). */
 	premiumMultiplier?: number;
 	contextWindow: number | null;
+	/** Conservative active-context budget used unless the user selects an explicit percentage of `contextWindow`. */
+	defaultContextTokens?: number;
 	maxTokens: number | null;
 	/**
 	 * When `true`, providers MUST omit `max_output_tokens` (Responses) /

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { buildModel, resolveEffectiveContextWindow } from "@oh-my-pi/pi-catalog/build";
 import { isOfficialAnthropicApiUrl } from "@oh-my-pi/pi-catalog/compat/anthropic";
 import { buildOpenAICompat, buildOpenAIResponsesCompat } from "@oh-my-pi/pi-catalog/compat/openai";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
@@ -555,5 +555,23 @@ describe("isOfficialAnthropicApiUrl", () => {
 
 	it("rejects lookalike hostnames", () => {
 		expect(isOfficialAnthropicApiUrl("https://api.anthropic.com.evil.com")).toBe(false);
+	});
+});
+
+describe("resolveEffectiveContextWindow", () => {
+	it("uses the model default or hard capacity when the percentage is default", () => {
+		expect(resolveEffectiveContextWindow({ contextWindow: 372_000, defaultContextTokens: 272_000 }, -1)).toBe(
+			272_000,
+		);
+		expect(resolveEffectiveContextWindow({ contextWindow: 200_000 }, undefined)).toBe(200_000);
+	});
+
+	it("uses and clamps an explicit percentage of hard capacity", () => {
+		const model = { contextWindow: 372_000, defaultContextTokens: 272_000 };
+		expect(resolveEffectiveContextWindow(model, 100)).toBe(372_000);
+		expect(resolveEffectiveContextWindow(model, 50)).toBe(186_000);
+		expect(resolveEffectiveContextWindow({ contextWindow: 1_000 }, 200)).toBe(1_000);
+		expect(resolveEffectiveContextWindow({ contextWindow: 1_000 }, 0)).toBe(1);
+		expect(resolveEffectiveContextWindow({ contextWindow: null }, 100)).toBe(0);
 	});
 });

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -276,4 +276,38 @@ describe("Codex model discovery", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	it("keeps declared hard capacity when discovery reports the conservative budget", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-context-budget-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const baseModel: ModelSpec<"openai-codex-responses"> = {
+			id: "gpt-5.6-sol",
+			name: "GPT-5.6 Sol",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 372_000,
+			defaultContextTokens: 272_000,
+			maxTokens: 128_000,
+		};
+
+		try {
+			const resolved = await resolveProviderModels<"openai-codex-responses">({
+				providerId: "openai-codex",
+				staticModels: [buildModel(baseModel)],
+				dynamicModelsAuthoritative: true,
+				cacheDbPath: dbPath,
+				fetchDynamicModels: async () => [{ ...baseModel, contextWindow: 272_000, defaultContextTokens: undefined }],
+			});
+
+			const sol = resolved.models.find(model => model.id === "gpt-5.6-sol");
+			expect(sol?.contextWindow).toBe(372_000);
+			expect(sol?.defaultContextTokens).toBe(272_000);
+			expect(sol?.maxTokens).toBe(128_000);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -214,4 +214,66 @@ describe("Codex model discovery", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	it.each([
+		["omitted", undefined, 372_000],
+		["explicit", 400_000, 400_000],
+	] as const)("merges %s discovery limits without inventing a fallback", async (_case, discoveredLimit, expectedLimit) => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-limit-"));
+		const dbPath = path.join(tempDir, "models.db");
+		try {
+			const staticModel = buildModel({
+				id: "gpt-5.6-terra",
+				name: "GPT-5.6 Terra",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				baseUrl: "https://chatgpt.com/backend-api/codex",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 372_000,
+				maxTokens: 128_000,
+			});
+			const fetchFn: typeof fetch = Object.assign(
+				async () =>
+					new Response(
+						JSON.stringify({
+							models: [
+								{
+									slug: "gpt-5.6-terra",
+									display_name: "GPT-5.6 Terra",
+									...(discoveredLimit === undefined ? {} : { context_window: discoveredLimit }),
+									default_reasoning_level: "medium",
+									supported_reasoning_levels: ["low", "medium", "high"],
+									input_modalities: ["text"],
+									supported_in_api: true,
+								},
+							],
+						}),
+					),
+				{ preconnect() {} },
+			);
+			const discoveryResult = await fetchCodexModels({
+				accessToken: "test-token",
+				baseUrl: "https://codex.example/backend-api",
+				clientVersion: "0.99.0",
+				fetchFn,
+			});
+
+			expect(discoveryResult?.models[0].contextWindow).toBe(discoveredLimit ?? null);
+			expect(discoveryResult?.models[0].maxTokens).toBe(discoveredLimit === undefined ? null : 128_000);
+
+			const resolved = await resolveProviderModels<"openai-codex-responses">({
+				providerId: "openai-codex",
+				staticModels: [staticModel],
+				dynamicModelsAuthoritative: true,
+				cacheDbPath: dbPath,
+				fetchDynamicModels: async () => discoveryResult?.models ?? [],
+			});
+			const terra = resolved.models.find(model => model.id === "gpt-5.6-terra");
+			expect(terra?.contextWindow).toBe(expectedLimit);
+			expect(terra?.maxTokens).toBe(128_000);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Added
 
+- Added a Context Window Budget setting that keeps provider capacity metadata intact while allowing conservative model defaults or explicit use of up to 100% of the available context window.
+
 - Added `xd://` virtual tool devices (controlled by the `tools.xdev` setting, default on), allowing mounted tools to be discovered via `read xd://`, documented via `read xd://<tool>`, and executed via `write xd://<tool>`.
 - Added the `edit.enforceSeenLines` setting (default off) to gate the hashline seen-line guard. When enabled, edits anchored on lines that a prior `read` or `grep` never displayed are rejected.
 - Added per-agent prewalk for subagents, featuring a `prewalk` frontmatter field, a `task.agentPrewalk` settings override toggled from the `/agents` dashboard, and a `task.prewalk` boolean (default off) to arm the bundled generic `task` agent.

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -18,7 +18,7 @@
 import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
-import { resolveEffectiveContextWindow } from "@oh-my-pi/pi-catalog";
+import { resolveEffectiveContextWindow } from "@oh-my-pi/pi-catalog/build";
 import { getConfigRootDir, logger } from "@oh-my-pi/pi-utils";
 import type { AgentHubRemote, AgentHubRemoteTranscript } from "../modes/components/agent-hub";
 import type { InteractiveModeContext } from "../modes/types";

--- a/packages/coding-agent/src/collab/guest.ts
+++ b/packages/coding-agent/src/collab/guest.ts
@@ -18,6 +18,7 @@
 import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
+import { resolveEffectiveContextWindow } from "@oh-my-pi/pi-catalog";
 import { getConfigRootDir, logger } from "@oh-my-pi/pi-utils";
 import type { AgentHubRemote, AgentHubRemoteTranscript } from "../modes/components/agent-hub";
 import type { InteractiveModeContext } from "../modes/types";
@@ -556,7 +557,12 @@ export class CollabGuestLink {
 			(session.agent.state.model?.id !== state.model.id ||
 				session.agent.state.model?.provider !== state.model.provider)
 		) {
-			session.agent.setModel(state.model);
+			const percent = session.settings.get("context.windowBudgetPercent");
+			const effectiveWindow = resolveEffectiveContextWindow(state.model, percent);
+			session.agent.setModel({
+				...state.model,
+				contextWindow: effectiveWindow,
+			});
 		}
 		const level = state.thinkingLevel as ThinkingLevel | undefined;
 		session.agent.setThinkingLevel(toReasoningEffort(level));

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1945,6 +1945,26 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"context.windowBudgetPercent": {
+		type: "number",
+		default: -1,
+		ui: {
+			tab: "context",
+			group: "General",
+			label: "Context Window Budget",
+			description: "Percentage of the model's catalog context window to use as the active operating budget",
+			options: [
+				{ value: "default", label: "Default", description: "Use model default context budget" },
+				{ value: "50", label: "50%", description: "Use 50% of context window" },
+				{ value: "75", label: "75%", description: "Use 75% of context window" },
+				{ value: "85", label: "85%", description: "Use 85% of context window" },
+				{ value: "90", label: "90%", description: "Use 90% of context window" },
+				{ value: "95", label: "95%", description: "Use 95% of context window" },
+				{ value: "100", label: "100%", description: "Use 100% of context window" },
+			],
+		},
+	},
+
 	// Compaction
 	"compaction.enabled": {
 		type: "boolean",
@@ -5173,6 +5193,10 @@ export interface TitleSettings {
 	refreshOnReplan: boolean;
 }
 
+
+export interface ContextSettings {
+	windowBudgetPercent: number;
+}
 export interface ContextPromotionSettings {
 	enabled: boolean;
 }
@@ -5320,6 +5344,7 @@ export interface GcSettings {
 export interface GroupTypeMap {
 	compaction: CompactionSettings;
 	recap: RecapSettings;
+	context: ContextSettings;
 	title: TitleSettings;
 	contextPromotion: ContextPromotionSettings;
 	retry: RetrySettings;

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -870,12 +870,14 @@ export class SettingsSelectorComponent implements Component {
 		if (path === "compaction.thresholdPercent" && (rawValue === "-1" || rawValue === "")) {
 			return "default";
 		}
+		if (path === "context.windowBudgetPercent" && (rawValue === "-1" || rawValue === "")) {
+			return "default";
+		}
 		if (path === "compaction.thresholdTokens" && (rawValue === "-1" || rawValue === "")) {
 			return "default";
 		}
 		return rawValue;
 	}
-
 	/**
 	 * Create a submenu for a submenu-type setting.
 	 */
@@ -1040,6 +1042,8 @@ export class SettingsSelectorComponent implements Component {
 		const currentValue = settings.get(path);
 		const schemaType = getType(path);
 		if (path === "compaction.thresholdPercent" && value === "default") {
+			settings.set(path, -1 as never);
+		} else if (path === "context.windowBudgetPercent" && value === "default") {
 			settings.set(path, -1 as never);
 		} else if (path === "compaction.thresholdTokens" && value === "default") {
 			settings.set(path, -1 as never);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -383,9 +383,12 @@ export class SelectorController {
 			}
 			return;
 		}
-
 		switch (id) {
-			// Session-managed settings (not in SettingsManager)
+			case "context.windowBudgetPercent":
+				this.ctx.session.reapplyContextBudget();
+				this.ctx.statusLine.invalidate();
+				this.ctx.ui.requestRender();
+				break;
 			case "autoCompact":
 				this.ctx.session.setAutoCompactionEnabled(value as boolean);
 				this.ctx.statusLine.setAutoCompactEnabled(value as boolean);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -127,6 +127,7 @@ import { type RepeatedToolCallDetection, ToolCallLoopGuard } from "@oh-my-pi/pi-
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
+import { resolveEffectiveContextWindow } from "@oh-my-pi/pi-catalog";
 import { MacOSPowerAssertion } from "@oh-my-pi/pi-natives";
 import {
 	escapeXmlText,
@@ -2486,6 +2487,9 @@ export class AgentSession {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
+		if (this.agent.state.model) {
+			this.agent.setModel(this.#getEffectiveModel(this.agent.state.model));
+		}
 		this.#autoApprove = config.autoApprove === true;
 		// Power assertions are taken per turn (see #beginInFlight); nothing acquired here.
 		this.#evalKernelOwnerId = config.evalKernelOwnerId ?? `agent-session:${Snowflake.next()}`;
@@ -2958,7 +2962,7 @@ export class AgentSession {
 			const advisorAgent = new Agent({
 				initialState: {
 					systemPrompt,
-					model: advisorModel,
+					model: this.#getEffectiveModel(advisorModel),
 					thinkingLevel: toReasoningEffort(advisorThinkingLevel),
 					tools: [adviseTool, ...tools],
 				},
@@ -3239,7 +3243,7 @@ export class AgentSession {
 		// keeps its suffix across a promotion); only the model changes.
 		const advisorThinkingLevel = advisor.thinkingLevel;
 		try {
-			advisor.agent.setModel(targetModel);
+			advisor.agent.setModel(this.#getEffectiveModel(targetModel));
 			advisor.agent.setThinkingLevel(toReasoningEffort(advisorThinkingLevel));
 			advisor.agent.setDisableReasoning(shouldDisableReasoning(advisorThinkingLevel));
 			advisor.agent.appendOnlyContext?.invalidateForModelChange();
@@ -9232,6 +9236,35 @@ export class AgentSession {
 	// Model Management
 	// =========================================================================
 
+	#getEffectiveModel(model: Model): Model {
+		const percent = this.settings.get("context.windowBudgetPercent");
+		const effectiveWindow = resolveEffectiveContextWindow(model, percent);
+		return {
+			...model,
+			contextWindow: effectiveWindow,
+		};
+	}
+
+	reapplyContextBudget(): void {
+		const currentModel = this.model;
+		if (!currentModel) return;
+		const canonicalModel = this.#modelRegistry.find(currentModel.provider, currentModel.id);
+		if (!canonicalModel) return;
+
+		const effectiveModel = this.#getEffectiveModel(canonicalModel);
+		this.agent.setModel(effectiveModel);
+
+		for (const advisor of this.#advisors) {
+			const advModel = advisor.agent.state.model;
+			if (advModel) {
+				const canonicalAdvModel = this.#modelRegistry.find(advModel.provider, advModel.id);
+				if (canonicalAdvModel) {
+					advisor.agent.setModel(this.#getEffectiveModel(canonicalAdvModel));
+				}
+			}
+		}
+	}
+
 	/**
 	 * Set model directly.
 	 * Validates that a credential source is configured (synchronously, without
@@ -9239,7 +9272,6 @@ export class AgentSession {
 	 * always take effect; if the current transcript is too large for the target
 	 * model, the next prompt's compaction/error path owns that recovery instead
 	 * of leaving the session pinned to the old model.
-	 * @throws Error if no API key available for the model
 	 */
 	async setModel(
 		model: Model,
@@ -12041,25 +12073,25 @@ export class AgentSession {
 
 		const candidate = this.#resolveContextPromotionConfiguredTarget(currentModel, availableModels);
 		if (!candidate) return undefined;
-		if (modelsAreEqual(candidate, currentModel)) return undefined;
-		if (candidate.contextWindow == null || candidate.contextWindow <= contextWindow) return undefined;
+		const candidateEffectiveWindow = resolveEffectiveContextWindow(candidate, this.settings.get("context.windowBudgetPercent"));
+		if (candidateEffectiveWindow <= contextWindow) return undefined;
 		const apiKey = await this.#modelRegistry.getApiKey(candidate, this.sessionId);
 		if (!apiKey) return undefined;
 		return candidate;
 	}
-
 	#setModelWithProviderSessionReset(model: Model): void {
+		const effectiveModel = this.#getEffectiveModel(model);
 		const currentModel = this.model;
 		if (currentModel) {
-			this.#closeProviderSessionsForModelSwitch(currentModel, model);
-			if (!modelsAreEqual(currentModel, model)) {
+			this.#closeProviderSessionsForModelSwitch(currentModel, effectiveModel);
+			if (!modelsAreEqual(currentModel, effectiveModel)) {
 				this.#clearInheritedProviderPromptCacheKey();
 			}
 		}
-		this.agent.setModel(model);
+		this.agent.setModel(effectiveModel);
 
 		// Re-evaluate append-only context mode — provider or setting may have changed
-		this.#syncAppendOnlyContext(model);
+		this.#syncAppendOnlyContext(effectiveModel);
 	}
 
 	#closeCodexProviderSessionsForHistoryRewrite(): void {
@@ -15484,7 +15516,7 @@ export class AgentSession {
 					if (shouldResetProviderState) {
 						this.#setModelWithProviderSessionReset(match);
 					} else {
-						this.agent.setModel(match);
+						this.agent.setModel(this.#getEffectiveModel(match));
 					}
 				}
 			}
@@ -15578,7 +15610,7 @@ export class AgentSession {
 			this.#lastCompletedRewind = previousLastCompletedRewind;
 			this.#rewoundToolResultIds = previousRewoundToolResultIds;
 			if (previousModel) {
-				this.agent.setModel(previousModel);
+				this.agent.setModel(this.#getEffectiveModel(previousModel));
 			}
 			this.#thinkingLevel = previousThinkingLevel;
 			this.#autoThinking = previousAutoThinking;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -124,10 +124,10 @@ import { resetOpenAICodexHistoryAfterCompaction } from "@oh-my-pi/pi-ai/provider
 import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
 import { GeminiHeaderRunDetector, isGeminiThinkingModel } from "@oh-my-pi/pi-ai/utils/thinking-loop";
 import { type RepeatedToolCallDetection, ToolCallLoopGuard } from "@oh-my-pi/pi-ai/utils/tool-call-loop-guard";
+import { resolveEffectiveContextWindow } from "@oh-my-pi/pi-catalog/build";
 import { isFireworksFastModelId, toFireworksBaseModelId } from "@oh-my-pi/pi-catalog/fireworks-model-id";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
-import { resolveEffectiveContextWindow } from "@oh-my-pi/pi-catalog";
 import { MacOSPowerAssertion } from "@oh-my-pi/pi-natives";
 import {
 	escapeXmlText,
@@ -12073,7 +12073,10 @@ export class AgentSession {
 
 		const candidate = this.#resolveContextPromotionConfiguredTarget(currentModel, availableModels);
 		if (!candidate) return undefined;
-		const candidateEffectiveWindow = resolveEffectiveContextWindow(candidate, this.settings.get("context.windowBudgetPercent"));
+		const candidateEffectiveWindow = resolveEffectiveContextWindow(
+			candidate,
+			this.settings.get("context.windowBudgetPercent"),
+		);
 		if (candidateEffectiveWindow <= contextWindow) return undefined;
 		const apiKey = await this.#modelRegistry.getApiKey(candidate, this.sessionId);
 		if (!apiKey) return undefined;
@@ -15610,7 +15613,10 @@ export class AgentSession {
 			this.#lastCompletedRewind = previousLastCompletedRewind;
 			this.#rewoundToolResultIds = previousRewoundToolResultIds;
 			if (previousModel) {
-				this.agent.setModel(this.#getEffectiveModel(previousModel));
+				const canonicalPreviousModel = this.#modelRegistry.find(previousModel.provider, previousModel.id);
+				this.agent.setModel(
+					canonicalPreviousModel ? this.#getEffectiveModel(canonicalPreviousModel) : previousModel,
+				);
 			}
 			this.#thinkingLevel = previousThinkingLevel;
 			this.#autoThinking = previousAutoThinking;

--- a/packages/coding-agent/test/agent-session-context-promotion.test.ts
+++ b/packages/coding-agent/test/agent-session-context-promotion.test.ts
@@ -590,4 +590,143 @@ describe("AgentSession context promotion", () => {
 		expect(session.model?.provider).toBe(codexModel.provider);
 		expect(session.model?.id).toBe(codexModel.id);
 	});
+
+	it("compares candidate effective budget and skips promotion if effective budget is not larger", async () => {
+		const gpt55 = modelRegistry.find("openai-codex", "gpt-5.5");
+		const luna = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		if (!gpt55 || !luna) {
+			throw new Error("Expected gpt-5.5 and gpt-5.6-luna to exist");
+		}
+		const originalLunaContextWindow = luna.contextWindow;
+		const originalLunaDefaultContextTokens = luna.defaultContextTokens;
+		luna.contextWindow = 372_000;
+		luna.defaultContextTokens = 272_000;
+
+		// Mutate promotion target to point to luna
+		const originalTarget = gpt55.contextPromotionTarget;
+		gpt55.contextPromotionTarget = "openai-codex/gpt-5.6-luna";
+
+		try {
+			// Under default context budget percent (-1):
+			// gpt-5.5 has 272k budget.
+			// luna has 272k budget (defaultContextTokens).
+			// They are equal, so promotion should be skipped!
+			const settingsDefault = Settings.isolated({
+				"compaction.enabled": false,
+				"contextPromotion.enabled": true,
+				"context.windowBudgetPercent": -1,
+			});
+
+			const agent1 = new Agent({
+				initialState: {
+					model: gpt55,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			});
+
+			const sessionDefault = new AgentSession({
+				agent: agent1,
+				sessionManager: SessionManager.inMemory(),
+				settings: settingsDefault,
+				modelRegistry,
+			});
+
+			const overflowMsg = createOverflowMessage(gpt55);
+			sessionDefault.agent.emitExternalEvent({ type: "message_end", message: overflowMsg });
+			sessionDefault.agent.emitExternalEvent({ type: "agent_end", messages: [overflowMsg] });
+
+			await settle();
+
+			// Should NOT have promoted
+			expect(sessionDefault.model?.id).toBe("gpt-5.5");
+			await sessionDefault.dispose();
+
+			// Under 100% budget percent:
+			// gpt-5.5 has 272k budget.
+			// luna has 372k budget (contextWindow).
+			// 372k > 272k, so promotion should succeed!
+			const settings100 = Settings.isolated({
+				"compaction.enabled": false,
+				"contextPromotion.enabled": true,
+				"context.windowBudgetPercent": 100,
+			});
+
+			const agent2 = new Agent({
+				initialState: {
+					model: gpt55,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			});
+
+			const session100 = new AgentSession({
+				agent: agent2,
+				sessionManager: SessionManager.inMemory(),
+				settings: settings100,
+				modelRegistry,
+			});
+
+			const overflowMsg2 = createOverflowMessage(gpt55);
+			session100.agent.emitExternalEvent({ type: "message_end", message: overflowMsg2 });
+			session100.agent.emitExternalEvent({ type: "agent_end", messages: [overflowMsg2] });
+
+			await settle();
+
+			// Should have promoted to luna
+			expect(session100.model?.id).toBe("gpt-5.6-luna");
+			await session100.dispose();
+		} finally {
+			gpt55.contextPromotionTarget = originalTarget;
+			luna.contextWindow = originalLunaContextWindow;
+			luna.defaultContextTokens = originalLunaDefaultContextTokens;
+		}
+	});
+	it("reapplies a changed budget from the canonical model capacity", async () => {
+		const luna = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		if (!luna) {
+			throw new Error("Expected gpt-5.6-luna to exist");
+		}
+		const originalContextWindow = luna.contextWindow;
+		const originalDefaultContextTokens = luna.defaultContextTokens;
+		luna.contextWindow = 372_000;
+		luna.defaultContextTokens = 272_000;
+
+		const settings = Settings.isolated();
+		const agent = new Agent({
+			initialState: {
+				model: luna,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		const budgetSession = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		expect(budgetSession.model?.contextWindow).toBe(272_000);
+		expect(modelRegistry.find("openai-codex", "gpt-5.6-luna")?.contextWindow).toBe(372_000);
+
+		settings.set("context.windowBudgetPercent", 100);
+		expect(settings.get("context.windowBudgetPercent")).toBe(100);
+		expect(modelRegistry.find("openai-codex", "gpt-5.6-luna")?.contextWindow).toBe(372_000);
+		const setModelSpy = vi.spyOn(budgetSession.agent, "setModel");
+		budgetSession.reapplyContextBudget();
+		expect(setModelSpy).toHaveBeenLastCalledWith(expect.objectContaining({ contextWindow: 372_000 }));
+		expect(budgetSession.model?.contextWindow).toBe(372_000);
+		expect(budgetSession.model?.maxTokens).toBe(128_000);
+
+		settings.set("context.windowBudgetPercent", 50);
+		budgetSession.reapplyContextBudget();
+		expect(budgetSession.model?.contextWindow).toBe(186_000);
+		luna.contextWindow = originalContextWindow;
+		luna.defaultContextTokens = originalDefaultContextTokens;
+		await budgetSession.dispose();
+	});
 });

--- a/packages/coding-agent/test/agent-session-context-promotion.test.ts
+++ b/packages/coding-agent/test/agent-session-context-promotion.test.ts
@@ -694,39 +694,101 @@ describe("AgentSession context promotion", () => {
 		luna.contextWindow = 372_000;
 		luna.defaultContextTokens = 272_000;
 
-		const settings = Settings.isolated();
-		const agent = new Agent({
-			initialState: {
-				model: luna,
-				systemPrompt: ["Test"],
-				tools: [],
-				messages: [],
-			},
-		});
-		const budgetSession = new AgentSession({
-			agent,
-			sessionManager: SessionManager.inMemory(),
-			settings,
-			modelRegistry,
-		});
+		let budgetSession: AgentSession | undefined;
+		try {
+			const settings = Settings.isolated();
+			const agent = new Agent({
+				initialState: {
+					model: luna,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			});
+			budgetSession = new AgentSession({
+				agent,
+				sessionManager: SessionManager.inMemory(),
+				settings,
+				modelRegistry,
+			});
 
-		expect(budgetSession.model?.contextWindow).toBe(272_000);
-		expect(modelRegistry.find("openai-codex", "gpt-5.6-luna")?.contextWindow).toBe(372_000);
+			expect(budgetSession.model?.contextWindow).toBe(272_000);
+			expect(modelRegistry.find("openai-codex", "gpt-5.6-luna")?.contextWindow).toBe(372_000);
 
-		settings.set("context.windowBudgetPercent", 100);
-		expect(settings.get("context.windowBudgetPercent")).toBe(100);
-		expect(modelRegistry.find("openai-codex", "gpt-5.6-luna")?.contextWindow).toBe(372_000);
-		const setModelSpy = vi.spyOn(budgetSession.agent, "setModel");
-		budgetSession.reapplyContextBudget();
-		expect(setModelSpy).toHaveBeenLastCalledWith(expect.objectContaining({ contextWindow: 372_000 }));
-		expect(budgetSession.model?.contextWindow).toBe(372_000);
-		expect(budgetSession.model?.maxTokens).toBe(128_000);
+			settings.set("context.windowBudgetPercent", 100);
+			expect(settings.get("context.windowBudgetPercent")).toBe(100);
+			expect(modelRegistry.find("openai-codex", "gpt-5.6-luna")?.contextWindow).toBe(372_000);
+			const setModelSpy = vi.spyOn(budgetSession.agent, "setModel");
+			budgetSession.reapplyContextBudget();
+			expect(setModelSpy).toHaveBeenLastCalledWith(expect.objectContaining({ contextWindow: 372_000 }));
+			expect(budgetSession.model?.contextWindow).toBe(372_000);
+			expect(budgetSession.model?.maxTokens).toBe(128_000);
 
-		settings.set("context.windowBudgetPercent", 50);
-		budgetSession.reapplyContextBudget();
-		expect(budgetSession.model?.contextWindow).toBe(186_000);
-		luna.contextWindow = originalContextWindow;
-		luna.defaultContextTokens = originalDefaultContextTokens;
-		await budgetSession.dispose();
+			settings.set("context.windowBudgetPercent", 50);
+			budgetSession.reapplyContextBudget();
+			expect(budgetSession.model?.contextWindow).toBe(186_000);
+		} finally {
+			luna.contextWindow = originalContextWindow;
+			luna.defaultContextTokens = originalDefaultContextTokens;
+			await budgetSession?.dispose();
+		}
+	});
+	it("restores a failed session switch from canonical capacity without reducing the budget twice", async () => {
+		const luna = modelRegistry.find("openai-codex", "gpt-5.6-luna");
+		const targetModel = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!luna || !targetModel) {
+			throw new Error("Expected gpt-5.6-luna and gpt-5.5 to exist");
+		}
+		const originalContextWindow = luna.contextWindow;
+		const originalDefaultContextTokens = luna.defaultContextTokens;
+		luna.contextWindow = 372_000;
+		luna.defaultContextTokens = 272_000;
+
+		try {
+			const settings = Settings.isolated({ "context.windowBudgetPercent": 50 });
+			const agent = new Agent({
+				initialState: {
+					model: luna,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			});
+			session = new AgentSession({
+				agent,
+				sessionManager: SessionManager.create(tempDir.path(), path.join(tempDir.path(), "rollback-active")),
+				settings,
+				modelRegistry,
+			});
+			expect(session.model?.contextWindow).toBe(186_000);
+
+			const targetSessionFile = path.join(tempDir.path(), "rollback-target.jsonl");
+			const timestamp = "2026-07-15T00:00:00.000Z";
+			await Bun.write(
+				targetSessionFile,
+				`${[
+					{ type: "session", version: 3, id: "rollback-target", timestamp, cwd: tempDir.path() },
+					{
+						type: "model_change",
+						id: "target-model",
+						parentId: null,
+						timestamp,
+						model: `${targetModel.provider}/${targetModel.id}`,
+					},
+				]
+					.map(entry => JSON.stringify(entry))
+					.join("\n")}\n`,
+			);
+			vi.spyOn(session.agent, "setThinkingLevel").mockImplementationOnce(() => {
+				throw new Error("forced switch failure");
+			});
+
+			await expect(session.switchSession(targetSessionFile)).rejects.toThrow("forced switch failure");
+			expect(session.model?.id).toBe(luna.id);
+			expect(session.model?.contextWindow).toBe(186_000);
+		} finally {
+			luna.contextWindow = originalContextWindow;
+			luna.defaultContextTokens = originalDefaultContextTokens;
+		}
 	});
 });

--- a/packages/coding-agent/test/modes/components/settings-layout.test.ts
+++ b/packages/coding-agent/test/modes/components/settings-layout.test.ts
@@ -135,4 +135,16 @@ describe("settings layout", () => {
 			group: "Available Tools",
 		});
 	});
+	it("exposes the context budget in Context General settings", () => {
+		const def = getSettingsForTab("context").find(def => def.path === "context.windowBudgetPercent");
+
+		expect(def).toMatchObject({
+			type: "submenu",
+			label: "Context Window Budget",
+			group: "General",
+		});
+		if (def?.type !== "submenu") throw new Error("context.windowBudgetPercent should render as a submenu");
+		expect(def.options.map(option => option.value)).toEqual(["default", "50", "75", "85", "90", "95", "100"]);
+	});
+
 });

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -879,3 +879,19 @@ describe("Settings", () => {
 		});
 	});
 });
+
+describe("context.windowBudgetPercent settings", () => {
+	it("defaults to -1", () => {
+		const settings = Settings.isolated();
+		expect(settings.get("context.windowBudgetPercent")).toBe(-1);
+	});
+
+	it("accepts and serializes allowed percentage options", () => {
+		const settings = Settings.isolated();
+		settings.set("context.windowBudgetPercent", 75);
+		expect(settings.get("context.windowBudgetPercent")).toBe(75);
+
+		settings.set("context.windowBudgetPercent", 100);
+		expect(settings.get("context.windowBudgetPercent")).toBe(100);
+	});
+});


### PR DESCRIPTION
## Summary
- add a Context Window Budget setting under Context > General with Default and 50–100% options
- keep model `contextWindow` as hard catalog capacity while `defaultContextTokens` carries a conservative operating budget
- apply effective budgets immediately to active sessions, advisors, compaction, promotion, collaboration guests, and context usage display

Depends on #5627.

## Screenshots
Live TUI verification:
- Default: `ctx: 3.6%/272K`
- 100%: `ctx: 2.6%/372K`
- Restored Default after verification

## Testing
- `bun test test/codex-discovery.test.ts test/generated-policies.test.ts test/build.test.ts` in `packages/catalog` — 48 passed
- `bun test test/settings-manager.test.ts test/agent-session-context-promotion.test.ts test/modes/components/settings-layout.test.ts` in `packages/coding-agent` — 77 passed
- `bun run check:types` in `packages/catalog`
- `bun run check:types` in `packages/coding-agent`
- live `/settings` workflow against GPT-5.6 Sol: Default → 100% changed the status denominator from 272K to 372K; Default was restored

## Risk
- Context budgets affect every local context-capacity decision. Focused tests cover default resolution, explicit percentages, clamping, promotion ordering, live reapplication, registry capacity preservation, and settings UI exposure.
- Models without `defaultContextTokens` retain their existing full-window behavior under Default.

## Notes
- This is stacked on #5627. Once #5627 merges, this PR can be rebased onto `main` and will contain only the context-budget commit.

## AI Review Report
- Reviewed every active-model boundary that sets model metadata, including main sessions, advisors, session switching, promotion, and collaboration guests.
- Added regression coverage for recomputing 100% from canonical registry capacity rather than the already-reduced active model.

## Security Audit
- No authentication, credential storage, authorization, request headers, or secret-handling behavior changed.
- The setting only changes local budgeting metadata and never scales `maxTokens`.