### PR TITLE
fix(advisor): steer late blocker after terminal answer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a late advisor `blocker` after a terminal primary answer being deferred to the next user turn instead of continuing the current turn: `resolveAdvisorDeliveryChannel` preserved every interrupting severity as a passive card once the primary ended with a terminal text answer and no queued work remained, so a `blocker` flagging a mistake in the final output sat idle until the next prompt. A `blocker` now steers a triggered turn so the primary acknowledges and continues before the turn is considered done; a late `concern` still preserves as a visible card ([#5628](https://github.com/can1357/oh-my-pi/issues/5628)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -2568,18 +2568,28 @@ describe("advisor", () => {
 			}
 		});
 
-		it("preserves a late interrupting note when the primary already ended with a terminal answer", () => {
-			for (const severity of ["concern", "blocker"] as const) {
-				expect(
-					resolveAdvisorDeliveryChannel({
-						severity,
-						autoResumeSuppressed: false,
-						streaming: false,
-						aborting: false,
-						terminalAnswerNoQueuedWork: true,
-					}),
-				).toBe("preserve");
-			}
+		it("preserves a late concern when the primary already ended with a terminal answer", () => {
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "concern",
+					autoResumeSuppressed: false,
+					streaming: false,
+					aborting: false,
+					terminalAnswerNoQueuedWork: true,
+				}),
+			).toBe("preserve");
+		});
+
+		it("steers a late blocker after a terminal answer so the primary continues and acknowledges it (#5628)", () => {
+			expect(
+				resolveAdvisorDeliveryChannel({
+					severity: "blocker",
+					autoResumeSuppressed: false,
+					streaming: false,
+					aborting: false,
+					terminalAnswerNoQueuedWork: true,
+				}),
+			).toBe("steer");
 		});
 
 		it("routes interrupting notes to the aside queue during immune turns without overriding preservation", () => {

--- a/packages/coding-agent/src/advisor/advise-tool.ts
+++ b/packages/coding-agent/src/advisor/advise-tool.ts
@@ -106,8 +106,11 @@ export function isAdvisorInterruptImmuneTurnActive(opts: {
  *   the live turn while one is streaming, or (when idle) a triggered turn so the
  *   advice is acted on immediately.
  * - If the primary tail is already a terminal text answer and there is no queued
- *   work, late interrupting advice is preserved as a visible card instead of
- *   waking the primary to restate completion.
+ *   work, a late `concern` is preserved as a visible card instead of waking the
+ *   primary to restate completion. A `blocker` is the exception: it means the
+ *   agent handed off broken or unexercised work, so it still steers a triggered
+ *   turn to force the primary to acknowledge and continue before the turn is
+ *   considered done (#5628) — deferring it to the next user turn is the bug.
  * - After a deliberate user interrupt (`autoResumeSuppressed`) the advisor must
  *   not auto-resume the stopped run. While the agent is idle — or still tearing
  *   the interrupted turn down (`aborting`) — the note is preserved as a visible
@@ -129,7 +132,8 @@ export function resolveAdvisorDeliveryChannel(opts: {
 }): AdvisorDeliveryChannel {
 	if (!isInterruptingSeverity(opts.severity)) return "aside";
 	if (opts.autoResumeSuppressed && (opts.aborting || !opts.streaming)) return "preserve";
-	if (opts.terminalAnswerNoQueuedWork && !opts.streaming && !opts.aborting) return "preserve";
+	if (opts.terminalAnswerNoQueuedWork && opts.severity !== "blocker" && !opts.streaming && !opts.aborting)
+		return "preserve";
 	if (opts.interruptImmuneTurnActive) return "aside";
 	return "steer";
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3172,9 +3172,19 @@ export class AgentSession {
 			return;
 		}
 		this.#recordAdvisorInterruptDelivered();
-		if (this.#planModeState?.enabled) {
-			// Plan mode: record advice visibly in context but never wake an
-			// autonomous turn — only user-driven turns converge on ask/resolve.
+		// A steered interrupting note only continues the run when the session can
+		// actually start (or is already running) a turn. Two idle cases cannot, so
+		// `sendCustomMessage({ triggerTurn: true })` would silently bury the card in
+		// `#pendingNextTurnMessages` until the next user prompt — strictly worse than
+		// the visible preserved card. Preserve instead:
+		//  - Plan mode: only user-driven turns converge on ask/resolve.
+		//  - ACP bridges with `deferAgentInitiatedTurns`: the client cannot show an
+		//    agent-initiated turn as busy, so idle triggers are refused (#5628 review).
+		const cannotAutoTrigger =
+			!this.agent.state.isStreaming &&
+			this.#clientBridge?.deferAgentInitiatedTurns === true &&
+			!this.#allowAcpAgentInitiatedTurns;
+		if (this.#planModeState?.enabled || cannotAutoTrigger) {
 			this.#preserveAdvisorCard({
 				role: "custom",
 				customType: "advisor",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3171,7 +3171,6 @@ export class AgentSession {
 			});
 			return;
 		}
-		this.#recordAdvisorInterruptDelivered();
 		// A steered interrupting note only continues the run when the session can
 		// actually start (or is already running) a turn. Two idle cases cannot, so
 		// `sendCustomMessage({ triggerTurn: true })` would silently bury the card in
@@ -3196,6 +3195,11 @@ export class AgentSession {
 			});
 			return;
 		}
+		// Arm the post-interrupt immune window only now that a turn is actually
+		// being steered/triggered. A merely preserved card never interrupts, so
+		// arming earlier would downgrade the next `advisor.immuneTurns` worth of
+		// real concerns/blockers to skip-idle-flush asides (#5628 review).
+		this.#recordAdvisorInterruptDelivered();
 		void this.sendCustomMessage(
 			{ customType: "advisor", content, display: true, attribution: "agent", details },
 			{ deliverAs: "steer", triggerTurn: true },


### PR DESCRIPTION
## Repro
When the advisor raises a `blocker` about a mistake in the model's final output, the blocker lands at the very end of the turn and the model ignores it until the next user prompt. Minimal unit repro against the delivery-channel decision:

```
resolveAdvisorDeliveryChannel({ severity: "blocker", terminalAnswerNoQueuedWork: true,
                                autoResumeSuppressed: false, streaming: false, aborting: false })
// Expected: "steer"   Received: "preserve"
```

## Cause
`resolveAdvisorDeliveryChannel` in `packages/coding-agent/src/advisor/advise-tool.ts`. Commit `708eafaf8d` (#4840) added `if (opts.terminalAnswerNoQueuedWork && !opts.streaming && !opts.aborting) return "preserve"` to stop a late confirmation from waking a duplicate "restate completion" turn. That rule fired for **every** interrupting severity, so a `blocker` — defined in `prompts/advisor/system.md` as "Stop and reconsider" / "Hand off as 'done' work that was never exercised" — was recorded as a passive advisor card via `#preserveAdvisorCard` instead of steered into a triggered turn. Acknowledgement was deferred to the next user turn.

## Fix
- `advise-tool.ts`: scope the terminal-answer `preserve` branch to `opts.severity !== "blocker"`. A `blocker` now falls through to `steer`, triggering a turn so the primary acknowledges and continues; a late `concern` still preserves. Updated the doc comment.
- `advisor/__tests__/advisor.test.ts`: split the terminal-answer case into a `concern`-preserves test and a `blocker`-steers regression test (#5628).
- `CHANGELOG.md`: Fixed entry under `[Unreleased]`.

## Verification
`bun test src/advisor/__tests__/advisor.test.ts` → 96 pass, 0 fail. `bun test test/agent-session-advisor-suppression.test.ts` → 13 pass, 0 fail (the #4840 `concern`-preserve integration coverage stays green). Pre-publish `bun run fix` + `bun check` passed on push. Fixes #5628