### PR TITLE
fix(coding-agent): disable thinking on local llama.cpp Qwen models

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Local llama.cpp Qwen-family models (including the Qwen3.6-based PrismLM Ternary Bonsai GGUFs) now honor `--thinking off`. Discovery routes them through the chat-completions API with the `qwen-template-false` disable dialect, `qwenPreserveThinking`, and a `/v1` base URL (models kept on a custom transport such as `pi-native` retain their gateway URL so the suffix is not doubled). The upgrade is re-applied as the outermost step after discovery merges, provider `baseUrl` overrides, and cache fallbacks, so a configured native-root base URL or a pre-fix cached row cannot leave the model on the old `openai-responses` / `reasoning: false` spec.
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/config/model-discovery.ts
+++ b/packages/coding-agent/src/config/model-discovery.ts
@@ -10,6 +10,7 @@ import type { Api, Model, RemoteCompactionConfig } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
 	getBundledModelReferenceIndex,
+	isQwenModelId,
 	resolveModelReference,
 	stripBracketedModelIdAffixes,
 } from "@oh-my-pi/pi-catalog/identity";
@@ -512,6 +513,48 @@ async function discoverLlamaCppServerMetadata(
 	}
 }
 
+/**
+ * PrismLM Ternary/1-bit Bonsai GGUFs are Qwen3.6-27B derivatives served locally
+ * via llama.cpp; their ids do not contain "qwen", so match them explicitly here
+ * rather than broadening the global `isQwenModelId` predicate.
+ */
+function isBonsaiQwenGguf(id: string): boolean {
+	return /(?:ternary-)?bonsai-27b/i.test(id);
+}
+
+/**
+ * applyLlamaCppQwenThinking rewrites a discovered or cached llama.cpp model so a
+ * Qwen-family chat template (which defaults `enable_thinking: true`) can be
+ * turned off. Qwen ids and the Qwen3.6-based PrismLM Ternary Bonsai GGUFs are
+ * routed through chat-completions (the implicit llama.cpp provider defaults to
+ * `openai-responses`, whose disable path has no Qwen encoding) with the
+ * `qwen-template-false` dialect; omp emits `preserve_thinking` inside
+ * `chat_template_kwargs` for Qwen, so the toggle rides there too and history
+ * `<think>` blocks survive (`qwenPreserveThinking`). The runtime base URL gets a
+ * `/v1` suffix because the chat-completions request would otherwise POST to the
+ * native root, which does not serve it. A model with a custom transport (e.g.
+ * `pi-native`, whose client appends `/v1/pi/stream`) keeps its base URL so the
+ * suffix is not doubled. Non-Qwen models pass through unchanged. Applied on both
+ * fresh discovery and cache load, so an upgraded cache is corrected without
+ * waiting for re-discovery.
+ */
+export function applyLlamaCppQwenThinking(model: Model<Api>): Model<Api> {
+	if (!isQwenModelId(model.id) && !isBonsaiQwenGguf(model.id)) return model;
+	return buildModel({
+		...model,
+		api: "openai-completions",
+		baseUrl: model.transport ? model.baseUrl : ensureLlamaCppV1BaseUrl(normalizeLlamaCppBaseUrl(model.baseUrl)),
+		reasoning: true,
+		compat: {
+			...model.compatConfig,
+			supportsReasoningParams: true,
+			thinkingFormat: "qwen-chat-template",
+			reasoningDisableMode: "qwen-template-false",
+			qwenPreserveThinking: true,
+		},
+	} as unknown as ModelSpec<Api>);
+}
+
 export async function discoverLlamaCppModels(
 	providerConfig: DiscoveryProviderConfig,
 	ctx: DiscoveryContext,
@@ -553,26 +596,31 @@ export async function discoverLlamaCppModels(
 			serverMetadata?.contextWindow ??
 			item.trainingContextWindow ??
 			DISCOVERY_DEFAULT_CONTEXT_WINDOW;
+		// Local llama.cpp models stamp `reasoning: false` with a minimal compat;
+		// applyLlamaCppQwenThinking upgrades Qwen-family ids (which cannot disable
+		// their default-on thinking otherwise) after the base model is built.
 		discovered.push(
-			buildModel({
-				id,
-				name: id,
-				api: providerConfig.api,
-				provider: providerConfig.provider,
-				baseUrl,
-				reasoning: false,
-				input: item.input ?? serverMetadata?.input ?? ["text"],
-				imageInputDecoder: "stb",
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				contextWindow,
-				maxTokens: resolveLlamaCppMaxTokens(contextWindow, serverMetadata?.maxTokens),
-				headers,
-				compat: {
-					supportsStore: false,
-					supportsDeveloperRole: false,
-					supportsReasoningEffort: false,
-				},
-			} as ModelSpec<Api>),
+			applyLlamaCppQwenThinking(
+				buildModel({
+					id,
+					name: id,
+					api: providerConfig.api,
+					provider: providerConfig.provider,
+					baseUrl,
+					reasoning: false,
+					input: item.input ?? serverMetadata?.input ?? ["text"],
+					imageInputDecoder: "stb",
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow,
+					maxTokens: resolveLlamaCppMaxTokens(contextWindow, serverMetadata?.maxTokens),
+					headers,
+					compat: {
+						supportsStore: false,
+						supportsDeveloperRole: false,
+						supportsReasoningEffort: false,
+					},
+				} as ModelSpec<Api>),
+			),
 		);
 	}
 	return discovered;
@@ -583,7 +631,12 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 	ctx: DiscoveryContext,
 ): Promise<LlamaCppDiscoveredModelRuntimeMetadata | undefined> {
 	const baseUrl = normalizeLlamaCppBaseUrl(model.baseUrl);
-	const modelsUrl = `${baseUrl}/models`;
+	// Probe the native `/models` endpoint (not the OpenAI-compatible `/v1/models`)
+	// so the runtime `meta`, `status.args`, and `architecture.input_modalities`
+	// fields survive; a Qwen model routed to chat-completions carries a `/v1`
+	// base URL, which would otherwise send this to `/v1/models`.
+	const nativeBaseUrl = toLlamaCppNativeBaseUrl(baseUrl);
+	const modelsUrl = `${nativeBaseUrl}/models`;
 	const baseHeaders: Record<string, string> = { ...(model.headers ?? {}) };
 	const attempt = async (headers: Record<string, string>) => {
 		const [entries, serverMetadata] = await Promise.all([
@@ -597,7 +650,7 @@ export async function discoverLlamaCppModelRuntimeMetadata(
 				}
 				return parseLlamaCppModelList(await response.json());
 			}),
-			discoverLlamaCppServerMetadata(ctx, baseUrl, headers),
+			discoverLlamaCppServerMetadata(ctx, nativeBaseUrl, headers),
 		]);
 		if (!entries) {
 			return undefined;
@@ -896,6 +949,13 @@ function normalizeLlamaCppBaseUrl(baseUrl?: string): string {
 	} catch {
 		return raw;
 	}
+}
+
+// ensureLlamaCppV1BaseUrl appends the OpenAI-compatible `/v1` prefix a
+// chat-completions request needs; native discovery keeps the bare root, which
+// serves `/models` and `/props` but not `/chat/completions`.
+function ensureLlamaCppV1BaseUrl(baseUrl: string): string {
+	return baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
 }
 
 function toLlamaCppNativeBaseUrl(baseUrl: string): string {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -71,6 +71,7 @@ import type { AuthStorage, OAuthCredential } from "../session/auth-storage";
 import { type ApiKeyResolverModel, type ApiKeyResolverOptions, createApiKeyResolver } from "./api-key-resolver";
 import type { ConfigError, ConfigFile } from "./config-file";
 import {
+	applyLlamaCppQwenThinking,
 	DISCOVERY_DEFAULT_MAX_TOKENS,
 	type DiscoveryContext,
 	type DiscoveryProviderConfig,
@@ -1020,7 +1021,7 @@ export class ModelRegistry {
 		// Custom/config providers bypass the model-manager merge point —
 		// collapse effort-tier variants here so X/X-thinking twins fold.
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		this.#models = this.#applyRuntimeProviderOverrides(withModelOverrides);
+		this.#models = this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides));
 		this.#lastStaticLoadMtime = this.#modelsConfigFile.getMtimeMs();
 	}
 
@@ -1417,7 +1418,7 @@ export class ModelRegistry {
 		// Merge runtime extension models so they survive online discovery completion
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		const withModelOverrides = this.#applyModelOverrides(collapseBuiltModelVariants(combined), this.#modelOverrides);
-		this.#models = this.#applyRuntimeProviderOverrides(withModelOverrides);
+		this.#models = this.#applyLlamaCppQwenThinkingToModels(this.#applyRuntimeProviderOverrides(withModelOverrides));
 	}
 
 	#configuredDiscoveryCacheProviderId(providerConfig: DiscoveryProviderConfig): string {
@@ -1777,6 +1778,22 @@ export class ModelRegistry {
 			if (!override) return model;
 			return applyModelOverride(model, override);
 		});
+	}
+
+	// #applyLlamaCppQwenThinkingToModels re-runs applyLlamaCppQwenThinking as the
+	// outermost transform for llama.cpp-provider models, after discovery merges,
+	// cache fallbacks, and provider/transport overrides have run. It is
+	// idempotent, so it restores the routed Qwen model's chat-completions api,
+	// `/v1` runtime base URL, and disable dialect even when a configured `baseUrl`
+	// override (which wins in mergeDiscoveredModel) or a fallback to a pre-fix
+	// cached row would otherwise leave the old spec in place.
+	#applyLlamaCppQwenThinkingToModels(models: Model<Api>[]): Model<Api>[] {
+		const llamaCppProviders = new Set<string>();
+		for (const provider of this.#discoverableProviders) {
+			if (provider.discovery.type === "llama.cpp") llamaCppProviders.add(provider.provider);
+		}
+		if (llamaCppProviders.size === 0) return models;
+		return models.map(model => (llamaCppProviders.has(model.provider) ? applyLlamaCppQwenThinking(model) : model));
 	}
 
 	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
@@ -2306,10 +2323,12 @@ export class ModelRegistry {
 				transportOverride,
 			);
 			this.#runtimeProviderOverrides.set(providerName, nextRuntimeOverride);
-			this.#models = this.#models.map(m => {
-				if (m.provider !== providerName) return m;
-				return this.#applyProviderTransportOverride(m, transportOverride);
-			});
+			this.#models = this.#applyLlamaCppQwenThinkingToModels(
+				this.#models.map(m => {
+					if (m.provider !== providerName) return m;
+					return this.#applyProviderTransportOverride(m, transportOverride);
+				}),
+			);
 		}
 	}
 

--- a/packages/coding-agent/test/model-discovery.test.ts
+++ b/packages/coding-agent/test/model-discovery.test.ts
@@ -7,6 +7,7 @@ import type { OAuthCredentials } from "@oh-my-pi/pi-ai/oauth/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { writeModelCache } from "@oh-my-pi/pi-catalog/model-cache";
 import type { OpenAICompat } from "@oh-my-pi/pi-catalog/types";
+import { applyLlamaCppQwenThinking } from "@oh-my-pi/pi-coding-agent/config/model-discovery";
 import { kNoAuth, ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -964,6 +965,128 @@ describe("ModelRegistry runtime discovery", () => {
 		expect(llama?.contextWindow).toBe(262144);
 		expect(llama?.maxTokens).toBe(262144);
 		expect(llama?.input).toEqual(["text", "image"]);
+	});
+
+	test("llama.cpp discovery routes Qwen models to chat-completions with the chat-template disable dialect", async () => {
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return new Response(
+					JSON.stringify({
+						data: [{ id: "qwen3-8b" }, { id: "ternary-bonsai-27b-q2_0" }, { id: "llama-3.1-8b" }],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return new Response(
+					JSON.stringify({
+						default_generation_settings: { n_ctx: 32768, params: { max_tokens: -1, n_predict: -1 } },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+
+		type DialectFields = { thinkingFormat?: string; reasoningDisableMode?: string; qwenPreserveThinking?: boolean };
+		for (const id of ["qwen3-8b", "ternary-bonsai-27b-q2_0"]) {
+			const qwen = registry.find("llama.cpp", id);
+			expect(qwen?.reasoning).toBe(true);
+			expect(qwen?.api).toBe("openai-completions");
+			expect(qwen?.baseUrl).toBe("http://127.0.0.1:8080/v1");
+			const compat = qwen?.compat as DialectFields | undefined;
+			expect(compat?.thinkingFormat).toBe("qwen-chat-template");
+			expect(compat?.reasoningDisableMode).toBe("qwen-template-false");
+			expect(compat?.qwenPreserveThinking).toBe(true);
+		}
+
+		const plain = registry.find("llama.cpp", "llama-3.1-8b");
+		expect(plain?.reasoning).toBe(false);
+		expect(plain?.api).toBe("openai-responses");
+		expect(plain?.baseUrl).toBe("http://127.0.0.1:8080");
+		expect((plain?.compat as DialectFields | undefined)?.reasoningDisableMode).not.toBe("qwen-template-false");
+	});
+
+	test("configured llama.cpp Qwen model keeps its /v1 runtime URL despite a native-root baseUrl override", async () => {
+		writeRawModelsJson({
+			"llama.cpp": {
+				baseUrl: "http://127.0.0.1:8080",
+				api: "openai-responses",
+				auth: "none",
+				discovery: { type: "llama.cpp" },
+			},
+		});
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			if (url === "http://127.0.0.1:8080/models") {
+				return Response.json({ data: [{ id: "qwen3-8b" }] });
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return Response.json({ default_generation_settings: { n_ctx: 32768 } });
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+
+		// The configured provider's native-root baseUrl wins in mergeDiscoveredModel,
+		// so without the outermost re-application the routed completions model would
+		// revert to `http://127.0.0.1:8080` and POST to `/chat/completions`.
+		const qwen = registry.find("llama.cpp", "qwen3-8b");
+		expect(qwen?.api).toBe("openai-completions");
+		expect(qwen?.baseUrl).toBe("http://127.0.0.1:8080/v1");
+	});
+
+	test("applyLlamaCppQwenThinking keeps a pi-native gateway base URL without doubling /v1", () => {
+		const upgraded = applyLlamaCppQwenThinking(
+			buildModel({
+				id: "qwen3-8b",
+				name: "qwen3-8b",
+				api: "openai-responses",
+				provider: "llama.cpp",
+				baseUrl: "http://gw:4000",
+				transport: "pi-native",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 32_768,
+				maxTokens: 4096,
+			}),
+		);
+		// streamPiNative appends `/v1/pi/stream`, so the gateway URL must stay bare
+		// rather than gaining a `/v1` that would double to `.../v1/v1/pi/stream`.
+		expect(upgraded.baseUrl).toBe("http://gw:4000");
+		expect(upgraded.transport).toBe("pi-native");
+		expect(upgraded.reasoning).toBe(true);
+		expect((upgraded.compat as { reasoningDisableMode?: string }).reasoningDisableMode).toBe("qwen-template-false");
+	});
+
+	test("runtime metadata refresh probes native /models for a /v1-routed Qwen model", async () => {
+		const requested: string[] = [];
+		const fetchMock: FetchImpl = async input => {
+			const url = String(input);
+			requested.push(url);
+			if (url === "http://127.0.0.1:8080/models") {
+				return Response.json({ data: [{ id: "qwen3-8b" }] });
+			}
+			if (url === "http://127.0.0.1:8080/props") {
+				return Response.json({ default_generation_settings: { n_ctx: 32_768 } });
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		};
+		const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+		await registry.refresh();
+		const qwen = registry.find("llama.cpp", "qwen3-8b");
+		expect(qwen?.baseUrl).toBe("http://127.0.0.1:8080/v1");
+
+		await registry.refreshSelectedModelMetadata(qwen!);
+		// The routed model carries a /v1 base URL, but the native metadata probe
+		// (meta/status.args/architecture.input_modalities) must stay on /models.
+		expect(requested).toContain("http://127.0.0.1:8080/models");
+		expect(requested).not.toContain("http://127.0.0.1:8080/v1/models");
 	});
 
 	test("llama.cpp discovery marks per-model architecture image modalities as vision-capable", async () => {


### PR DESCRIPTION
## Repro

Serve a Qwen-family model through `llama.cpp` (its bundled jinja template defaults `enable_thinking: true`), register it as a local `llama.cpp` provider, and run a turn with thinking disabled:

```
omp -p --thinking off "2+2?"
```

The model still emits a full reasoning block. Capturing the outgoing request (`PI_REQ_DEBUG=1`) shows the body carries **no thinking control at all**, so the server's chat template keeps thinking on.

## Cause

`discoverLlamaCppModels` stamps every locally discovered model with `reasoning: false` and a minimal `compat` (`supportsStore` / `supportsDeveloperRole` / `supportsReasoningEffort` only). With `reasoning: false` the model is treated as non-thinking, and with no `thinkingFormat` / `reasoningDisableMode` the caller-disabled branch has nothing to emit, so `--thinking off` never reaches the wire and the Qwen template's `enable_thinking: true` default wins.

## Fix

In `discoverLlamaCppModels`, detect Qwen-family ids and give them `reasoning: true` plus the Qwen disable dialect, and route them through the chat-completions API (the implicit `llama.cpp` provider defaults to `openai-responses`, whose disable path has no Qwen encoding). A caller-disabled turn then emits `enable_thinking: false` via `chat_template_kwargs`. Non-Qwen local models keep the original minimal compat and configured api.

## Verification

Against a local `llama.cpp` server hosting a Qwen-family GGUF, request captured with `PI_REQ_DEBUG=1`:

- `omp -p --thinking off "2+2?"` produces `POST /v1/chat/completions` with `chat_template_kwargs: {"preserve_thinking": true, "enable_thinking": false}`; the server generates 2 tokens with no reasoning block.
- `omp -p --thinking medium "..."` produces `chat_template_kwargs: {"preserve_thinking": true, "enable_thinking": true}`; the model reasons as before.

`biome check` is clean on the changed files.

---

- [x] `bun check` passes (biome check clean on the branch; workspace typecheck via CI)
- [x] Tested locally (request captured with `PI_REQ_DEBUG`, both thinking on and off)
- [ ] CHANGELOG updated (no CHANGELOG in repo)
