### PR TITLE
fix(ai): wait for Cursor protocol end after turnEnded

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed OpenRouter cost reporting to use the provider's authoritative account charge instead of catalog token-price estimates on both Responses and Chat Completions streams.
+- Fixed Cursor streams reporting success before late CONNECT or gRPC terminal failures were observed, and rejecting transport ends without `turnEnded` ([#5634](https://github.com/can1357/oh-my-pi/issues/5634)).
 
 ## [17.0.0] - 2026-07-15
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -352,7 +352,30 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 		let heartbeatTimer: NodeJS.Timeout | null = null;
 		let debugResponseLogPromise: Promise<RequestDebugResponseLog | undefined> | undefined;
 		const h2Completion = Promise.withResolvers<void>();
-		let resolveH2: (() => void) | undefined = h2Completion.resolve;
+		let h2Settled = false;
+		let sawTurnEnded = false;
+		let endStreamError: Error | null = null;
+		const settleH2 = (error?: unknown): void => {
+			if (h2Settled) return;
+			h2Settled = true;
+			if (error !== undefined) {
+				h2Completion.reject(error);
+				return;
+			}
+			if (endStreamError) {
+				h2Completion.reject(endStreamError);
+				return;
+			}
+			if (!sawTurnEnded) {
+				h2Completion.reject(
+					new AIError.ProviderResponseError("Cursor stream ended before turnEnded", {
+						kind: "incomplete-stream",
+					}),
+				);
+				return;
+			}
+			h2Completion.resolve();
+		};
 
 		try {
 			const apiKey = options?.apiKey;
@@ -408,14 +431,13 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			} else {
 				h2Client = http2.connect(baseUrl);
 			}
-			h2Client.on("error", h2Completion.reject);
+			h2Client.on("error", error => settleH2(error));
 
 			h2Request = h2Client.request(requestHeaders);
 
 			stream.push({ type: "start", partial: output });
 
 			let pendingBuffer = Buffer.alloc(0);
-			let endStreamError: Error | null = null;
 			let currentTextBlock: (TextContent & { [kStreamingBlockIndex]: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { [kStreamingBlockIndex]: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
@@ -505,12 +527,9 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 							log("error", "handleServerMessage", { error: String(error) });
 						});
 
-						// Resolve only on explicit turnEnded. stopReason defaults to "stop"
-						// and is not a reliable signal for stream completion.
-						if (isTurnEnded && resolveH2) {
-							const r = resolveH2;
-							resolveH2 = undefined;
-							r();
+						// Application completion is not protocol success; wait for a clean HTTP/2 end.
+						if (isTurnEnded) {
+							sawTurnEnded = true;
 						}
 					} catch (e) {
 						log("error", "parseServerMessage", { error: String(e) });
@@ -537,40 +556,29 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			h2Request.on("trailers", trailers => {
 				const status = trailers["grpc-status"];
 				const msg = trailers["grpc-message"];
-				if (status && status !== "0") {
-					void closeDebugLog().finally(() => {
-						h2Completion.reject(
-							new AIError.ProviderResponseError(
-								`gRPC error ${status}: ${decodeURIComponent(String(msg || ""))}`,
-								{ kind: "envelope" },
-							),
-						);
-					});
+				if (status && status !== "0" && !endStreamError) {
+					endStreamError = new AIError.ProviderResponseError(
+						`gRPC error ${status}: ${decodeURIComponent(String(msg || ""))}`,
+						{ kind: "envelope" },
+					);
 				}
 			});
 
 			h2Request.on("end", () => {
-				resolveH2 = undefined;
 				void closeDebugLog()
-					.then(() => {
-						if (endStreamError) {
-							h2Completion.reject(endStreamError);
-							return;
-						}
-						h2Completion.resolve();
-					})
-					.catch(h2Completion.reject);
+					.then(() => settleH2())
+					.catch(error => settleH2(error));
 			});
 
 			h2Request.on("error", error => {
-				void closeDebugLog().finally(() => h2Completion.reject(error));
+				void closeDebugLog().finally(() => settleH2(error));
 			});
 
 			if (options?.signal) {
 				options.signal.addEventListener("abort", () => {
 					h2Request?.close();
 					void closeDebugLog().finally(() => {
-						h2Completion.reject(new AIError.AbortError());
+						settleH2(new AIError.AbortError());
 					});
 				});
 			}

--- a/packages/ai/test/cursor-terminal-error.test.ts
+++ b/packages/ai/test/cursor-terminal-error.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as http2 from "node:http2";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { streamCursor } from "@oh-my-pi/pi-ai/providers/cursor";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import {
+	AgentServerMessageSchema,
+	InteractionUpdateSchema,
+	TextDeltaUpdateSchema,
+	TurnEndedUpdateSchema,
+} from "@oh-my-pi/pi-catalog/discovery/cursor-gen/agent_pb";
+
+const CONNECT_END_STREAM_FLAG = 0b00000010;
+
+type Scenario =
+	| { kind: "success" }
+	| { kind: "connect-error-after-turn" }
+	| { kind: "grpc-trailer-after-turn" }
+	| { kind: "end-before-turn" }
+	| { kind: "hang-after-turn" };
+
+let server: http2.Http2Server | undefined;
+const sessions = new Set<http2.Http2Session>();
+let scenario: Scenario = { kind: "success" };
+
+function frameConnectMessage(data: Uint8Array, flags = 0): Buffer {
+	const frame = Buffer.alloc(5 + data.length);
+	frame[0] = flags;
+	frame.writeUInt32BE(data.length, 1);
+	frame.set(data, 5);
+	return frame;
+}
+
+function textDeltaFrame(text: string): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "interactionUpdate",
+			value: create(InteractionUpdateSchema, {
+				message: {
+					case: "textDelta",
+					value: create(TextDeltaUpdateSchema, { text }),
+				},
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function turnEndedFrame(): Buffer {
+	const message = create(AgentServerMessageSchema, {
+		message: {
+			case: "interactionUpdate",
+			value: create(InteractionUpdateSchema, {
+				message: {
+					case: "turnEnded",
+					value: create(TurnEndedUpdateSchema, {}),
+				},
+			}),
+		},
+	});
+	return frameConnectMessage(toBinary(AgentServerMessageSchema, message));
+}
+
+function connectEndErrorFrame(code: string, message: string): Buffer {
+	const payload = Buffer.from(JSON.stringify({ error: { code, message } }), "utf8");
+	return frameConnectMessage(payload, CONNECT_END_STREAM_FLAG);
+}
+
+async function startServer(): Promise<string> {
+	server = http2.createServer();
+	server.on("session", session => {
+		sessions.add(session);
+		session.on("close", () => sessions.delete(session));
+	});
+	server.on("stream", (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
+		stream.on("data", () => {});
+
+		if (headers[":path"] !== "/agent.v1.AgentService/Run") {
+			stream.respond({ ":status": 404 });
+			stream.end();
+			return;
+		}
+
+		if (scenario.kind === "grpc-trailer-after-turn") {
+			stream.respond(
+				{
+					":status": 200,
+					"content-type": "application/connect+proto",
+				},
+				{ waitForTrailers: true },
+			);
+			stream.on("wantTrailers", () => {
+				stream.sendTrailers({
+					"grpc-status": "13",
+					"grpc-message": encodeURIComponent("post-turn trailer failure"),
+				});
+			});
+			stream.write(textDeltaFrame("hello"));
+			stream.write(turnEndedFrame());
+			stream.end();
+			return;
+		}
+
+		stream.respond({
+			":status": 200,
+			"content-type": "application/connect+proto",
+		});
+
+		if (scenario.kind === "end-before-turn") {
+			stream.write(textDeltaFrame("partial"));
+			stream.end();
+			return;
+		}
+
+		stream.write(Buffer.concat([textDeltaFrame("hello"), turnEndedFrame()]));
+
+		if (scenario.kind === "connect-error-after-turn") {
+			stream.write(connectEndErrorFrame("unavailable", "post-turn connect failure"));
+			stream.end();
+			return;
+		}
+
+		if (scenario.kind === "hang-after-turn") {
+			return;
+		}
+
+		stream.end();
+	});
+
+	const listening = Promise.withResolvers<void>();
+	server.once("error", listening.reject);
+	server.listen(0, "127.0.0.1", listening.resolve);
+	await listening.promise;
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("expected http2 fixture server to bind a tcp port");
+	}
+	return `http://127.0.0.1:${address.port}`;
+}
+
+function makeModel(baseUrl: string): Model<"cursor-agent"> {
+	return buildModel({
+		id: "cursor-terminal-fixture",
+		name: "Cursor terminal fixture",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1,
+		maxTokens: 1,
+	});
+}
+
+const context: Context = {
+	messages: [{ role: "user", content: "terminal lifecycle", timestamp: 1 }],
+};
+
+async function collectStream(model: Model<"cursor-agent">, options?: { signal?: AbortSignal }) {
+	const stream = streamCursor(model, context, { apiKey: "test-token", signal: options?.signal });
+	const eventTypes: string[] = [];
+	for await (const event of stream) {
+		eventTypes.push(event.type);
+	}
+	const result = await stream.result();
+	return { eventTypes, result };
+}
+
+async function stopServer(): Promise<void> {
+	for (const session of sessions) {
+		session.destroy();
+	}
+	sessions.clear();
+	if (!server) return;
+	const closing = server;
+	server = undefined;
+	const closed = Promise.withResolvers<void>();
+	closing.close(error => {
+		if (error) {
+			closed.reject(error);
+		} else {
+			closed.resolve();
+		}
+	});
+	await closed.promise;
+}
+
+afterEach(async () => {
+	scenario = { kind: "success" };
+	await stopServer();
+});
+
+describe("Cursor terminal lifecycle after turnEnded", () => {
+	it("emits done only after turnEnded and a clean protocol end", async () => {
+		scenario = { kind: "success" };
+		const baseUrl = await startServer();
+		const { eventTypes, result } = await collectStream(makeModel(baseUrl));
+		expect(eventTypes).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+		expect(result.stopReason).toBe("stop");
+		expect(result.errorMessage).toBeUndefined();
+	});
+
+	it("surfaces CONNECT end-stream errors that arrive after turnEnded", async () => {
+		scenario = { kind: "connect-error-after-turn" };
+		const baseUrl = await startServer();
+		const { eventTypes, result } = await collectStream(makeModel(baseUrl));
+		expect(eventTypes[0]).toBe("start");
+		expect(eventTypes.at(-1)).toBe("error");
+		expect(eventTypes).not.toContain("done");
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Connect error unavailable: post-turn connect failure");
+	});
+
+	it("surfaces nonzero gRPC trailers that arrive after turnEnded", async () => {
+		scenario = { kind: "grpc-trailer-after-turn" };
+		const baseUrl = await startServer();
+		const { eventTypes, result } = await collectStream(makeModel(baseUrl));
+		expect(eventTypes[0]).toBe("start");
+		expect(eventTypes.at(-1)).toBe("error");
+		expect(eventTypes).not.toContain("done");
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("gRPC error 13: post-turn trailer failure");
+	});
+
+	it("rejects when the stream ends before turnEnded", async () => {
+		scenario = { kind: "end-before-turn" };
+		const baseUrl = await startServer();
+		const { eventTypes, result } = await collectStream(makeModel(baseUrl));
+		expect(eventTypes[0]).toBe("start");
+		expect(eventTypes.at(-1)).toBe("error");
+		expect(eventTypes).not.toContain("done");
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("Cursor stream ended before turnEnded");
+	});
+
+	it("aborts without emitting done when the signal fires", async () => {
+		scenario = { kind: "hang-after-turn" };
+		const baseUrl = await startServer();
+		const controller = new AbortController();
+		const stream = streamCursor(makeModel(baseUrl), context, {
+			apiKey: "test-token",
+			signal: controller.signal,
+		});
+		const eventTypes: string[] = [];
+		for await (const event of stream) {
+			eventTypes.push(event.type);
+			if (event.type === "text_delta") controller.abort();
+		}
+		const result = await stream.result();
+		expect(eventTypes[0]).toBe("start");
+		expect(eventTypes.at(-1)).toBe("error");
+		expect(eventTypes).not.toContain("done");
+		expect(result.stopReason).toBe("aborted");
+	});
+});


### PR DESCRIPTION
## Repro
A deterministic local HTTP/2 fixture sends a text delta and `turnEnded`, then injects a CONNECT end-stream error, a non-zero `grpc-status` trailer, an early protocol end, or an abort while the transport remains open. On the unfixed code, `bun test packages/ai/test/cursor-terminal-error.test.ts` reported 1 pass and 4 failures because each failure scenario ended with `done` instead of `error`.

## Cause
`streamCursor` in `packages/ai/src/providers/cursor.ts` resolved `h2Completion` directly from the response data handler when it decoded `interactionUpdate.turnEnded`. Because promise settlement is one-shot, subsequent CONNECT frames and the request trailer/end/error handlers could not replace that success with a transport failure.

## Fix
- Record `turnEnded` as application-level completion without settling the HTTP/2 completion promise.
- Settle only from protocol terminal handlers, prioritizing CONNECT and gRPC errors and rejecting a clean transport end that lacks `turnEnded`.
- Add deterministic coverage for clean completion, late CONNECT and trailer failures, incomplete streams, and aborts after `turnEnded`.
- Document the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/cursor-terminal-error.test.ts packages/ai/test/cursor-transport-error.test.ts` — 6 passed, 0 failed. `cd packages/ai && bun run check` — passed. The pre-publish gate also completed `bun run fix` and `bun check` before publishing.

Fixes #5634