### PR TITLE
fix(registry): coordinate park/dispose with ensureLive and IRC delivery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a race where hub/IRC `send` and `ensureLive` could hand out or inject into a subagent session mid-`park` dispose: park now detaches and flips status to `parked` before `session.dispose()`, concurrent `ensureLive` cancels a pre-detach park or waits then revives, and IRC delivery always gates through `ensureLive` so receipts/unread counts stay truthful ([#5633](https://github.com/can1357/oh-my-pi/issues/5633)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -127,12 +127,24 @@ export class IrcBus {
 			};
 		}
 
+		// Gate through ensureLive only when the recipient may be mid-park or
+		// parked. Main/non-adopted live peers skip this (they have no park
+		// lifecycle), and pending waiters still win without a session.
+		const lifecycle = this.#lifecycle();
+		const needsLifecycleGate =
+			ref.status === "parked" || lifecycle.isParking(message.to) || lifecycle.has(message.to);
+
+		const priorSession = ref.session;
 		let revived = false;
-		if (ref.status === "parked") {
+		if (needsLifecycleGate) {
 			try {
-				await this.#lifecycle().ensureLive(message.to);
-				revived = true;
+				const liveSession = await lifecycle.ensureLive(message.to);
+				// Revival = we did not keep the same live instance (parked start, or
+				// park completed and a fresh session was rebuilt).
+				revived = !priorSession || liveSession !== priorSession;
 			} catch (error) {
+				// Not revivable / released / revive failed. Do not buffer: a permanent
+				// failure must not inflate unread counts or pretend delivery is pending.
 				return {
 					to: message.to,
 					outcome: "failed",

--- a/packages/coding-agent/src/irc/bus.ts
+++ b/packages/coding-agent/src/irc/bus.ts
@@ -127,12 +127,19 @@ export class IrcBus {
 			};
 		}
 
-		// Gate through ensureLive only when the recipient may be mid-park or
-		// parked. Main/non-adopted live peers skip this (they have no park
-		// lifecycle), and pending waiters still win without a session.
+		// A `parked` recipient always needs the lifecycle to revive it — this is
+		// read from *this* bus's registry, so it holds for any registry. The
+		// mid-park / adopted checks below query the lifecycle's own state, which
+		// only describes the registry it manages: consult them only when the
+		// lifecycle owns this bus's registry, otherwise a custom-registry bus
+		// (fallen back to the global manager) would gate a live recipient on
+		// unrelated global park state. Main/non-adopted live peers skip the gate,
+		// and pending waiters still win without a session.
 		const lifecycle = this.#lifecycle();
+		const lifecycleOwnsRegistry = lifecycle.manages(this.#registry);
 		const needsLifecycleGate =
-			ref.status === "parked" || lifecycle.isParking(message.to) || lifecycle.has(message.to);
+			ref.status === "parked" ||
+			(lifecycleOwnsRegistry && (lifecycle.isParking(message.to) || lifecycle.has(message.to)));
 
 		const priorSession = ref.session;
 		let revived = false;

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -8,6 +8,12 @@
  * sessionFile), and revives it on demand through
  * {@link AgentLifecycleManager.ensureLive}. Only this manager flips
  * `parked` ↔ `idle`.
+ *
+ * Park/dispose is gated against concurrent ensureLive/hub-send:
+ * - A disposing session is never handed out.
+ * - ensureLive during an in-flight park either cancels the park (session still
+ *   live) or waits for detach+park and then revives.
+ * - Concurrent ensureLive/park operations coalesce per id.
  */
 
 import { logger } from "@oh-my-pi/pi-utils";
@@ -38,6 +44,17 @@ interface AdoptedAgent {
 	timer?: NodeJS.Timeout;
 }
 
+interface ParkInFlight {
+	/** Resolves when the park attempt finishes (success, cancel, or dispose error). */
+	promise: Promise<void>;
+	/** Cancel before the session is detached. Returns true if cancel took effect. */
+	cancel: () => boolean;
+	/** True once cancel() succeeded (ensureLive kept the live session). */
+	cancelled: boolean;
+	/** True once the live session has been detached and status is parked. */
+	detached: boolean;
+}
+
 export class AgentLifecycleManager {
 	static #global: AgentLifecycleManager | undefined;
 
@@ -59,7 +76,7 @@ export class AgentLifecycleManager {
 			}
 			current.#adopted.clear();
 			current.#revivals.clear();
-			current.#parking.clear();
+			current.#parks.clear();
 			current.#persistedReviverFactory = undefined;
 		}
 		AgentLifecycleManager.#global = undefined;
@@ -67,8 +84,11 @@ export class AgentLifecycleManager {
 
 	readonly #registry: AgentRegistry;
 	readonly #adopted = new Map<string, AdoptedAgent>();
-	/** Ids whose session is being disposed by {@link park} right now. */
-	readonly #parking = new Set<string>();
+	/**
+	 * In-flight park attempts. A park is cancelable until the live session is
+	 * detached; after detach, ensureLive waits for the park and revives.
+	 */
+	readonly #parks = new Map<string, ParkInFlight>();
 	/** In-flight revives, so concurrent {@link ensureLive} calls coalesce. */
 	readonly #revivals = new Map<string, Promise<AgentSession>>();
 	#unsubscribe: (() => void) | undefined;
@@ -114,44 +134,119 @@ export class AgentLifecycleManager {
 		return this.#adopted.has(id);
 	}
 
-	/** True while {@link park} is disposing this agent's session (lets dispose hooks distinguish park from teardown). */
+	/**
+	 * True while {@link park} is disposing this agent's session (lets dispose
+	 * hooks distinguish park from teardown). False once the park is cancelled
+	 * by ensureLive or after detach+dispose completes.
+	 */
 	isParking(id: string): boolean {
-		return this.#parking.has(id);
+		const park = this.#parks.get(id);
+		return Boolean(park && !park.cancelled);
 	}
 
 	/**
 	 * Dispose the live session, detach it from the registry, and mark the
 	 * agent `parked`. No-op unless the id is adopted and live.
+	 *
+	 * The session is detached (and status flipped to `parked`) *before*
+	 * `session.dispose()` so concurrent {@link ensureLive}/hub-send never
+	 * observe or inject into a disposing session. A concurrent ensureLive that
+	 * arrives before detach cancels the park and keeps the live session.
 	 */
 	async park(id: string): Promise<void> {
+		const existing = this.#parks.get(id);
+		if (existing) return existing.promise;
+
 		const adopted = this.#adopted.get(id);
 		if (!adopted) return;
 		const ref = this.#registry.get(id);
-		if (!ref?.session) return;
+		const session = ref?.session;
+		if (!session) return;
+
 		if (adopted.timer) {
 			clearTimeout(adopted.timer);
 			adopted.timer = undefined;
 		}
-		this.#parking.add(id);
-		try {
+
+		let cancelled = false;
+		const park: ParkInFlight = {
+			promise: undefined as unknown as Promise<void>,
+			cancel: () => {
+				// Cancel only before detach — once detached the old session is already
+				// leaving the registry and must finish disposing.
+				if (park.detached || cancelled) return cancelled;
+				cancelled = true;
+				park.cancelled = true;
+				return true;
+			},
+			cancelled: false,
+			detached: false,
+		};
+
+		park.promise = (async () => {
 			try {
-				await ref.session.dispose();
-			} catch (error) {
-				logger.warn("AgentLifecycleManager.park: session dispose failed", { id, error: String(error) });
+				// Yield so a same-tick ensureLive/hub-send can cancel before we
+				// commit to dispose. Deterministic with Promise microtasks; no timers.
+				await Promise.resolve();
+				if (cancelled) return;
+
+				// Re-check liveness: release/unregister may have raced us.
+				const live = this.#registry.get(id);
+				if (!live?.session || live.session !== session) return;
+				if (!this.#adopted.has(id)) return;
+
+				// Commit: detach + parked *before* dispose so callers never see a
+				// dying session via ref.session / idle status.
+				park.detached = true;
+				this.#registry.detachSession(id);
+				this.#registry.setStatus(id, "parked");
+
+				try {
+					await session.dispose();
+				} catch (error) {
+					logger.warn("AgentLifecycleManager.park: session dispose failed", { id, error: String(error) });
+				}
+			} finally {
+				// Only clear if we are still the in-flight entry (a later park would
+				// have replaced us only after we resolved).
+				if (this.#parks.get(id) === park) this.#parks.delete(id);
 			}
-			this.#registry.detachSession(id);
-			this.#registry.setStatus(id, "parked");
-		} finally {
-			this.#parking.delete(id);
-		}
+		})();
+
+		this.#parks.set(id, park);
+		return park.promise;
 	}
 
 	/**
 	 * Return the live session, reviving from the sessionFile if parked.
 	 * Throws a plain Error if the id is unknown or parked without a reviver.
 	 * Concurrent calls share one in-flight revive.
+	 *
+	 * Never returns a session that is mid-dispose: an in-flight park is either
+	 * cancelled (session still live) or awaited to completion before revive.
 	 */
 	async ensureLive(id: string): Promise<AgentSession> {
+		const park = this.#parks.get(id);
+		if (park) {
+			const ref = this.#registry.get(id);
+			// Cancel if the live session is still attached — keep it instead of
+			// thrashing dispose + revive.
+			if (ref?.session && !park.detached && park.cancel()) {
+				await park.promise;
+				const kept = this.#registry.get(id)?.session;
+				if (kept) {
+					// Park cleared the idle timer; re-arm so TTL park still works.
+					const adopted = this.#adopted.get(id);
+					if (adopted && ref.status === "idle") this.#armTimer(id, adopted);
+					return kept;
+				}
+			} else {
+				// Already committed to detach (or no live session): wait for park,
+				// then fall through to the revive path.
+				await park.promise;
+			}
+		}
+
 		const ref = this.#registry.get(id);
 		if (!ref) {
 			throw new Error(
@@ -208,6 +303,14 @@ export class AgentLifecycleManager {
 		const adopted = this.#adopted.get(id);
 		clearTimeout(adopted?.timer);
 		this.#adopted.delete(id);
+
+		const park = this.#parks.get(id);
+		if (park) {
+			// Prefer cancel when the session is still live so release owns dispose.
+			if (!park.detached) park.cancel();
+			await park.promise;
+		}
+
 		const ref = this.#registry.get(id);
 		if (ref?.session) {
 			try {
@@ -223,10 +326,10 @@ export class AgentLifecycleManager {
 	async dispose(): Promise<void> {
 		this.#unsubscribe?.();
 		this.#unsubscribe = undefined;
-		const ids = [...this.#adopted.keys()];
+		const ids = [...new Set([...this.#adopted.keys(), ...this.#parks.keys()])];
 		await Promise.all(ids.map(id => this.release(id)));
 		this.#revivals.clear();
-		this.#parking.clear();
+		this.#parks.clear();
 		this.#persistedReviverFactory = undefined;
 	}
 
@@ -264,6 +367,8 @@ export class AgentLifecycleManager {
 				adopted.timer = undefined;
 			}
 		} else if (event.ref.status === "idle") {
+			// Don't re-arm while a park is in flight — the park owns the transition.
+			if (this.#parks.has(event.ref.id)) return;
 			this.#armTimer(event.ref.id, adopted);
 		}
 	}

--- a/packages/coding-agent/src/registry/agent-lifecycle.ts
+++ b/packages/coding-agent/src/registry/agent-lifecycle.ts
@@ -135,6 +135,16 @@ export class AgentLifecycleManager {
 	}
 
 	/**
+	 * True when this manager owns `registry` — i.e. its adopt/park/revive state
+	 * describes that registry's refs. Lets a caller holding a specific registry
+	 * (e.g. a custom-registry {@link IrcBus} that fell back to the global
+	 * manager) skip lifecycle gating that would consult unrelated park state.
+	 */
+	manages(registry: AgentRegistry): boolean {
+		return this.#registry === registry;
+	}
+
+	/**
 	 * True while {@link park} is disposing this agent's session (lets dispose
 	 * hooks distinguish park from teardown). False once the park is cancelled
 	 * by ensureLive or after detach+dispose completes.

--- a/packages/coding-agent/test/registry/agent-lifecycle.test.ts
+++ b/packages/coding-agent/test/registry/agent-lifecycle.test.ts
@@ -270,19 +270,30 @@ describe("AgentLifecycleManager", () => {
 		expect(stub.disposeCalls()).toBe(0);
 	});
 
-	it("isParking is true exactly while park's dispose is in flight; parked only after it completes", async () => {
+	it("isParking is true while park is in flight; session is detached before dispose", async () => {
 		const gate = deferred();
 		const stub = makeSessionStub(() => gate.promise);
 		registerIdleSub("7-Sub", stub.session);
 		lifecycle.adopt("7-Sub", { idleTtlMs: 0 });
 
-		// park() runs synchronously up to `await session.dispose()`, which we hold open.
+		// park() registers the in-flight entry synchronously, then yields a
+		// cancel window before detach. During dispose we hold the gate open.
 		const parking = lifecycle.park("7-Sub");
+
+		expect(lifecycle.isParking("7-Sub")).toBe(true);
+		expect(registry.get("7-Sub")?.status).toBe("idle"); // cancel window not yet elapsed
+		expect(registry.get("7-Sub")?.session).toBe(stub.session);
+
+		// Cancel window + detach + start dispose.
+		await Promise.resolve();
+		await Promise.resolve();
 
 		expect(stub.disposeCalls()).toBe(1);
 		expect(lifecycle.isParking("7-Sub")).toBe(true);
-		expect(registry.get("7-Sub")).toBeDefined();
-		expect(registry.get("7-Sub")?.status).toBe("idle"); // not yet flipped
+		// Detach + parked happen BEFORE dispose resolves — callers never see a
+		// dying session attached to an idle ref.
+		expect(registry.get("7-Sub")?.status).toBe("parked");
+		expect(registry.get("7-Sub")?.session).toBeNull();
 
 		gate.resolve();
 		await parking;
@@ -290,6 +301,154 @@ describe("AgentLifecycleManager", () => {
 		expect(lifecycle.isParking("7-Sub")).toBe(false);
 		expect(registry.get("7-Sub")?.status).toBe("parked");
 		expect(registry.get("7-Sub")?.session).toBeNull();
+	});
+
+	it("ensureLive during pre-detach park cancels park and keeps the live session", async () => {
+		const gate = deferred();
+		const stub = makeSessionStub(() => gate.promise);
+		registerIdleSub("Race-Keep", stub.session, "/tmp/Race-Keep.jsonl");
+		lifecycle.adopt("Race-Keep", { idleTtlMs: 0 });
+
+		const parking = lifecycle.park("Race-Keep");
+		// Same tick as park start: cancel window is still open.
+		const live = lifecycle.ensureLive("Race-Keep");
+
+		const session = await live;
+		await parking;
+
+		expect(session).toBe(stub.session);
+		expect(stub.disposeCalls()).toBe(0);
+		expect(lifecycle.isParking("Race-Keep")).toBe(false);
+		expect(registry.get("Race-Keep")?.status).toBe("idle");
+		expect(registry.get("Race-Keep")?.session).toBe(stub.session);
+	});
+
+	it("ensureLive after park detaches waits for dispose then revives once", async () => {
+		const gate = deferred();
+		const stub = makeSessionStub(() => gate.promise);
+		const revived = makeSessionStub();
+		let reviverRuns = 0;
+		registerIdleSub("Race-Revive", stub.session, "/tmp/Race-Revive.jsonl");
+		lifecycle.adopt("Race-Revive", {
+			idleTtlMs: 0,
+			revive: async () => {
+				reviverRuns++;
+				return revived.session;
+			},
+		});
+
+		const parking = lifecycle.park("Race-Revive");
+		// Let park pass the cancel window and detach before ensureLive.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(registry.get("Race-Revive")?.status).toBe("parked");
+		expect(registry.get("Race-Revive")?.session).toBeNull();
+		expect(stub.disposeCalls()).toBe(1);
+
+		const first = lifecycle.ensureLive("Race-Revive");
+		const second = lifecycle.ensureLive("Race-Revive");
+
+		// ensureLive is blocked on park until dispose finishes — never hands out
+		// the dying session.
+		let firstSettled = false;
+		void first.then(() => {
+			firstSettled = true;
+		});
+		await flushAsync();
+		expect(firstSettled).toBe(false);
+		expect(reviverRuns).toBe(0);
+
+		gate.resolve();
+		const [a, b] = await Promise.all([first, second, parking]);
+
+		expect(reviverRuns).toBe(1);
+		expect(a).toBe(revived.session);
+		expect(b).toBe(revived.session);
+		expect(registry.get("Race-Revive")?.status).toBe("idle");
+		expect(registry.get("Race-Revive")?.session).toBe(revived.session);
+		expect(stub.disposeCalls()).toBe(1);
+	});
+
+	it("concurrent park calls coalesce into one dispose", async () => {
+		const stub = makeSessionStub();
+		registerIdleSub("Race-ParkOnce", stub.session);
+		lifecycle.adopt("Race-ParkOnce", { idleTtlMs: 0 });
+
+		const a = lifecycle.park("Race-ParkOnce");
+		const b = lifecycle.park("Race-ParkOnce");
+		await Promise.all([a, b]);
+
+		expect(stub.disposeCalls()).toBe(1);
+		expect(registry.get("Race-ParkOnce")?.status).toBe("parked");
+		expect(registry.get("Race-ParkOnce")?.session).toBeNull();
+	});
+
+	it("dispose failure still leaves the agent parked and detached", async () => {
+		const stub = makeSessionStub(async () => {
+			throw new Error("dispose blew up");
+		});
+		registerIdleSub("Park-FailDispose", stub.session, "/tmp/Park-FailDispose.jsonl");
+		lifecycle.adopt("Park-FailDispose", {
+			idleTtlMs: 0,
+			revive: async () => makeSessionStub().session,
+		});
+
+		await lifecycle.park("Park-FailDispose");
+
+		expect(stub.disposeCalls()).toBe(1);
+		expect(registry.get("Park-FailDispose")?.status).toBe("parked");
+		expect(registry.get("Park-FailDispose")?.session).toBeNull();
+		expect(lifecycle.isParking("Park-FailDispose")).toBe(false);
+
+		// Still revivable after a failed dispose.
+		const session = await lifecycle.ensureLive("Park-FailDispose");
+		expect(session).toBeTruthy();
+		expect(registry.get("Park-FailDispose")?.status).toBe("idle");
+	});
+
+	it("revive failure leaves the agent parked without a live session", async () => {
+		const gate = deferred();
+		const stub = makeSessionStub(() => gate.promise);
+		registerIdleSub("Park-FailRevive", stub.session, "/tmp/Park-FailRevive.jsonl");
+		lifecycle.adopt("Park-FailRevive", {
+			idleTtlMs: 0,
+			revive: async () => {
+				throw new Error("revive blew up");
+			},
+		});
+
+		const parking = lifecycle.park("Park-FailRevive");
+		await Promise.resolve();
+		await Promise.resolve();
+		const ensure = lifecycle.ensureLive("Park-FailRevive");
+		gate.resolve();
+		await parking;
+
+		await expect(ensure).rejects.toThrow(/revive blew up/);
+		expect(registry.get("Park-FailRevive")?.status).toBe("parked");
+		expect(registry.get("Park-FailRevive")?.session).toBeNull();
+		expect(lifecycle.has("Park-FailRevive")).toBe(true);
+	});
+
+	it("cancelled park re-arms the idle TTL so a later park still fires", async () => {
+		vi.useFakeTimers();
+		const stub = makeSessionStub();
+		registerIdleSub("Park-Rearm", stub.session, "/tmp/Park-Rearm.jsonl");
+		lifecycle.adopt("Park-Rearm", { idleTtlMs: TTL });
+
+		// Force an early park, then cancel it via ensureLive.
+		const parking = lifecycle.park("Park-Rearm");
+		const kept = await lifecycle.ensureLive("Park-Rearm");
+		await parking;
+		expect(kept).toBe(stub.session);
+		expect(stub.disposeCalls()).toBe(0);
+		expect(registry.get("Park-Rearm")?.status).toBe("idle");
+
+		// Fresh TTL from the cancel path.
+		vi.advanceTimersByTime(TTL);
+		await flushAsync();
+		expect(registry.get("Park-Rearm")?.status).toBe("parked");
+		expect(stub.disposeCalls()).toBe(1);
 	});
 
 	it("idleTtlMs <= 0 adopts without a timer: the agent never parks", async () => {

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -191,6 +191,174 @@ describe("IRC", () => {
 			expect(receipt.error).toBeTruthy();
 		});
 
+		it("send during pre-detach park keeps the live session and does not revive", async () => {
+			let resolveDispose!: () => void;
+			const disposeGate = new Promise<void>(r => {
+				resolveDispose = r;
+			});
+			let disposeCalls = 0;
+			const delivered: IrcMessage[] = [];
+			const session = {
+				deliverIrcMessage: async (msg: IrcMessage) => {
+					delivered.push(msg);
+					return "injected" as const;
+				},
+				emitIrcRelayObservation: () => {},
+				dispose: async () => {
+					disposeCalls++;
+					await disposeGate;
+				},
+			} as unknown as AgentSession;
+			registry.register({
+				id: "0-Parking",
+				displayName: "task",
+				kind: "sub",
+				session,
+				sessionFile: "/tmp/0-Parking.jsonl",
+				status: "idle",
+			});
+			let reviverRuns = 0;
+			AgentLifecycleManager.global().adopt("0-Parking", {
+				idleTtlMs: 0,
+				revive: async () => {
+					reviverRuns++;
+					return session;
+				},
+			});
+
+			const parking = AgentLifecycleManager.global().park("0-Parking");
+			// Same tick: cancel window still open — send must keep the live session.
+			const receipt = await bus.send({ from: "0-Main", to: "0-Parking", body: "stay alive" });
+			await parking;
+
+			expect(receipt.outcome).toBe("injected");
+			expect(delivered.map(msg => msg.body)).toEqual(["stay alive"]);
+			expect(disposeCalls).toBe(0);
+			expect(reviverRuns).toBe(0);
+			expect(registry.get("0-Parking")?.session).toBe(session);
+			expect(registry.get("0-Parking")?.status).toBe("idle");
+			expect(bus.unreadCount("0-Parking")).toBe(0);
+			resolveDispose();
+		});
+
+		it("send after park detaches waits for dispose, revives, and delivers once", async () => {
+			let resolveDispose!: () => void;
+			const disposeGate = new Promise<void>(r => {
+				resolveDispose = r;
+			});
+			let disposeCalls = 0;
+			const oldSession = {
+				deliverIrcMessage: async () => {
+					throw new Error("dying session must not receive mail");
+				},
+				emitIrcRelayObservation: () => {},
+				dispose: async () => {
+					disposeCalls++;
+					await disposeGate;
+				},
+			} as unknown as AgentSession;
+			const revived = makeFakeSession();
+			revived.setOutcome("woken");
+			registry.register({
+				id: "0-Parking",
+				displayName: "task",
+				kind: "sub",
+				session: oldSession,
+				sessionFile: "/tmp/0-Parking.jsonl",
+				status: "idle",
+			});
+			let reviverRuns = 0;
+			AgentLifecycleManager.global().adopt("0-Parking", {
+				idleTtlMs: 0,
+				revive: async () => {
+					reviverRuns++;
+					return revived.session;
+				},
+			});
+
+			const parking = AgentLifecycleManager.global().park("0-Parking");
+			// Pass the cancel window so park detaches before send.
+			await Promise.resolve();
+			await Promise.resolve();
+			expect(registry.get("0-Parking")?.status).toBe("parked");
+			expect(registry.get("0-Parking")?.session).toBeNull();
+			expect(disposeCalls).toBe(1);
+
+			const sendPromise = bus.send({ from: "0-Main", to: "0-Parking", body: "after park" });
+			let sendSettled = false;
+			void sendPromise.then(() => {
+				sendSettled = true;
+			});
+			await Promise.resolve();
+			await Promise.resolve();
+			// Blocked on dispose — must not inject into the dying session or buffer.
+			expect(sendSettled).toBe(false);
+			expect(reviverRuns).toBe(0);
+			expect(bus.unreadCount("0-Parking")).toBe(0);
+
+			resolveDispose();
+			const receipt = await sendPromise;
+			await parking;
+
+			expect(receipt.outcome).toBe("revived");
+			expect(revived.delivered.map(msg => msg.body)).toEqual(["after park"]);
+			expect(reviverRuns).toBe(1);
+			expect(registry.get("0-Parking")?.session).toBe(revived.session);
+			expect(bus.unreadCount("0-Parking")).toBe(0);
+		});
+
+		it("multiple concurrent sends during park coalesce revive and all deliver", async () => {
+			let resolveDispose!: () => void;
+			const disposeGate = new Promise<void>(r => {
+				resolveDispose = r;
+			});
+			const oldSession = {
+				deliverIrcMessage: async () => {
+					throw new Error("dying session must not receive mail");
+				},
+				emitIrcRelayObservation: () => {},
+				dispose: async () => {
+					await disposeGate;
+				},
+			} as unknown as AgentSession;
+			const revived = makeFakeSession();
+			revived.setOutcome("injected");
+			registry.register({
+				id: "0-Parking",
+				displayName: "task",
+				kind: "sub",
+				session: oldSession,
+				sessionFile: "/tmp/0-Parking.jsonl",
+				status: "idle",
+			});
+			let reviverRuns = 0;
+			AgentLifecycleManager.global().adopt("0-Parking", {
+				idleTtlMs: 0,
+				revive: async () => {
+					reviverRuns++;
+					return revived.session;
+				},
+			});
+
+			const parking = AgentLifecycleManager.global().park("0-Parking");
+			await Promise.resolve();
+			await Promise.resolve();
+
+			const sends = Promise.all([
+				bus.send({ from: "0-Main", to: "0-Parking", body: "one" }),
+				bus.send({ from: "0-Main", to: "0-Parking", body: "two" }),
+				bus.send({ from: "0-Main", to: "0-Parking", body: "three" }),
+			]);
+			resolveDispose();
+			const receipts = await sends;
+			await parking;
+
+			expect(reviverRuns).toBe(1);
+			expect(receipts.every(r => r.outcome === "revived")).toBe(true);
+			expect(revived.delivered.map(msg => msg.body).sort()).toEqual(["one", "three", "two"]);
+			expect(bus.unreadCount("0-Parking")).toBe(0);
+		});
+
 		it("wait consumes a matching send instead of delivering it to the session", async () => {
 			const main = makeFakeSession();
 			registry.register({ id: "0-Main", displayName: "main", kind: "main", session: main.session });

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -192,10 +192,7 @@ describe("IRC", () => {
 		});
 
 		it("send during pre-detach park keeps the live session and does not revive", async () => {
-			let resolveDispose!: () => void;
-			const disposeGate = new Promise<void>(r => {
-				resolveDispose = r;
-			});
+			const { promise: disposeGate, resolve: resolveDispose } = Promise.withResolvers<void>();
 			let disposeCalls = 0;
 			const delivered: IrcMessage[] = [];
 			const session = {
@@ -242,10 +239,7 @@ describe("IRC", () => {
 		});
 
 		it("send after park detaches waits for dispose, revives, and delivers once", async () => {
-			let resolveDispose!: () => void;
-			const disposeGate = new Promise<void>(r => {
-				resolveDispose = r;
-			});
+			const { promise: disposeGate, resolve: resolveDispose } = Promise.withResolvers<void>();
 			let disposeCalls = 0;
 			const oldSession = {
 				deliverIrcMessage: async () => {
@@ -308,10 +302,7 @@ describe("IRC", () => {
 		});
 
 		it("multiple concurrent sends during park coalesce revive and all deliver", async () => {
-			let resolveDispose!: () => void;
-			const disposeGate = new Promise<void>(r => {
-				resolveDispose = r;
-			});
+			const { promise: disposeGate, resolve: resolveDispose } = Promise.withResolvers<void>();
 			const oldSession = {
 				deliverIrcMessage: async () => {
 					throw new Error("dying session must not receive mail");

--- a/packages/coding-agent/test/tools/irc.test.ts
+++ b/packages/coding-agent/test/tools/irc.test.ts
@@ -191,6 +191,39 @@ describe("IRC", () => {
 			expect(receipt.error).toBeTruthy();
 		});
 
+		it("custom-registry bus delivers live without gating on global park state for the same id", async () => {
+			// Global lifecycle has this id adopted + mid-park; a bus on a separate
+			// registry must NOT consult that unrelated state for its live recipient.
+			const globalStub = makeFakeSession();
+			registry.register({
+				id: "0-Sub",
+				displayName: "task",
+				kind: "sub",
+				session: globalStub.session,
+				sessionFile: "/tmp/0-Sub.jsonl",
+				status: "idle",
+			});
+			const { promise: neverDispose } = Promise.withResolvers<void>();
+			globalStub.session.dispose = (async () => {
+				await neverDispose;
+			}) as AgentSession["dispose"];
+			AgentLifecycleManager.global().adopt("0-Sub", { idleTtlMs: 0 });
+			void AgentLifecycleManager.global().park("0-Sub");
+			expect(AgentLifecycleManager.global().has("0-Sub")).toBe(true);
+
+			const customRegistry = new AgentRegistry();
+			const customBus = new IrcBus(customRegistry);
+			const live = makeFakeSession();
+			live.setOutcome("injected");
+			customRegistry.register({ id: "0-Sub", displayName: "task", kind: "sub", session: live.session });
+
+			const receipt = await customBus.send({ from: "0-Main", to: "0-Sub", body: "hi" });
+
+			expect(receipt).toEqual({ to: "0-Sub", outcome: "injected" });
+			expect(live.delivered.map(msg => msg.body)).toEqual(["hi"]);
+			expect(globalStub.delivered).toEqual([]);
+		});
+
 		it("send during pre-detach park keeps the live session and does not revive", async () => {
 			const { promise: disposeGate, resolve: resolveDispose } = Promise.withResolvers<void>();
 			let disposeCalls = 0;


### PR DESCRIPTION
## Repro
Register and adopt an idle subagent, gate its `session.dispose()` open, call `AgentLifecycleManager.park(id)`, then — while dispose is still in flight — call `ensureLive(id)` (or `IrcBus.send({to: id})`). On `main`, `ensureLive` returns the very session object `park` is disposing (`session === dying`, `disposeCalls === 1`) because the registry still exposes `ref.session` at `idle` status until `dispose()` resolves. Confirmed with a focused test that asserted `session === dying` and passed on `main`.

## Cause
`AgentLifecycleManager.park()` (`packages/coding-agent/src/registry/agent-lifecycle.ts`) ordered the transition as `await session.dispose()` → `detachSession()` → `setStatus("parked")`. During the pending `dispose()`: the registry still exposes `ref.session`, status is still `idle`, so `ensureLive()` returns the attached (dying) session immediately, and `IrcBus.send()` (`src/irc/bus.ts`) only took the revive path when status was already `parked`. `#parking` was a bare disposal guard and did not coordinate `park`/`ensureLive`/IRC.

## Fix
- Replace the `#parking` `Set` with a `#parks` `Map<string, ParkInFlight>` holding cancelable in-flight park state.
- `park()`: register the in-flight entry synchronously, yield a microtask cancel window, then **detach + flip to `parked` before `session.dispose()`**; coalesce concurrent `park()` calls onto one dispose; clear the entry in `finally`.
- `ensureLive()`: cancel a pre-detach park and keep the live session (re-arming the idle TTL), or — once detach has committed — await the park then perform one coalesced revive; never returns a disposing session.
- `release()`/`dispose()` drain any in-flight park; `#onRegistryEvent` skips re-arming the idle timer while a park owns the transition.
- `IrcBus.send()` gates parkable/mid-park recipients through `ensureLive` and derives the `revived` receipt from session identity, so a permanent failure isn't buffered and receipts/unread counts reflect actual delivery.

## Verification
`bun test test/registry/agent-lifecycle.test.ts test/tools/irc.test.ts` → 67 pass / 0 fail. New regression tests: pre-detach cancel keeps the live session, post-detach wait/revive, concurrent park coalescing, dispose failure still parks+detaches, revive failure, TTL re-arm after cancel, and IRC delivery on both sides of the detach boundary (single + concurrent sends). `bun check` passes clean. Fixes #5633