### PR TITLE
fix(coding-agent): migrate legacy nested autoqa/todo settings keys

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Migrated legacy `dev.autoqa.consent` → `dev.autoqaConsent` and `todo.reminders.max` → `todo.remindersMax` on settings load so pre-v17 nested or quoted-dotted config no longer leaves the parent path as an object (which made `dev.autoqa` truthy and enabled Auto QA, and discarded the reminder limit). Explicit new keys win, a separately configured parent boolean is preserved, an irrecoverable object parent falls back to the schema default, and only the new keys persist on save ([#5632](https://github.com/can1357/oh-my-pi/issues/5632)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -172,6 +172,83 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * Migrate a v17 leaf rename that used to nest under a boolean parent path
+ * (`dev.autoqa.consent` → `dev.autoqaConsent`, `todo.reminders.max` →
+ * `todo.remindersMax`). Pre-rename configs left the leaf beneath the parent,
+ * so the parent path resolved to an object and truthy checks like
+ * `isAutoQaEnabled` treated a consent-only container as "enabled".
+ *
+ * Handles nested (`{ parent: { leaf } }`) and quoted-dotted (`"parent.leaf"`)
+ * legacy sources. An explicit new key always wins; a separately configured
+ * boolean parent is preserved; an irrecoverable object-valued parent (only ever
+ * a container for the old leaf) is dropped so the schema default applies.
+ */
+function migrateNestedLeafRename(
+	raw: RawSettings,
+	root: string,
+	parent: string,
+	oldLeaf: string,
+	newLeaf: string,
+	isLeafValue: (value: unknown) => boolean,
+): void {
+	const rootObj = isRecord(raw[root]) ? (raw[root] as Record<string, unknown>) : undefined;
+	const nestedParent = rootObj?.[parent];
+	const flatParent = raw[`${root}.${parent}`];
+	const oldParentPath = `${root}.${parent}`;
+
+	const candidates = [
+		rootObj?.[newLeaf],
+		raw[`${root}.${newLeaf}`],
+		isRecord(nestedParent) ? nestedParent[oldLeaf] : undefined,
+		raw[`${oldParentPath}.${oldLeaf}`],
+	];
+	const resolvedLeaf = candidates.find(isLeafValue);
+
+	const recoveredParent =
+		typeof nestedParent === "boolean" ? nestedParent : typeof flatParent === "boolean" ? flatParent : undefined;
+
+	const ensureRoot = (): Record<string, unknown> => {
+		const current = raw[root];
+		if (isRecord(current)) return current;
+		const created: Record<string, unknown> = {};
+		raw[root] = created;
+		return created;
+	};
+
+	if (resolvedLeaf !== undefined) {
+		const target = ensureRoot();
+		if (!isLeafValue(target[newLeaf])) {
+			target[newLeaf] = resolvedLeaf;
+		}
+	}
+
+	// Strip legacy leaf sources (nested + flat dotted).
+	delete raw[`${oldParentPath}.${oldLeaf}`];
+	delete raw[`${root}.${newLeaf}`];
+	if (isRecord(raw[root]) && isRecord((raw[root] as Record<string, unknown>)[parent])) {
+		const parentObj = (raw[root] as Record<string, unknown>)[parent] as Record<string, unknown>;
+		delete parentObj[oldLeaf];
+		if (Object.keys(parentObj).length === 0) {
+			delete (raw[root] as Record<string, unknown>)[parent];
+		}
+	}
+
+	// The parent path must be a boolean or absent — never a leftover object.
+	if (recoveredParent !== undefined) {
+		const target = ensureRoot();
+		if (typeof target[parent] !== "boolean") {
+			target[parent] = recoveredParent;
+		}
+	} else if (isRecord(raw[root]) && isRecord((raw[root] as Record<string, unknown>)[parent])) {
+		delete (raw[root] as Record<string, unknown>)[parent];
+	}
+	delete raw[oldParentPath];
+	if (isRecord(raw[root]) && Object.keys(raw[root] as Record<string, unknown>).length === 0) {
+		delete raw[root];
+	}
+}
+
 function modelRoleValueFromUnknown(value: unknown): string | undefined {
 	if (typeof value === "string") return value;
 	if (!Array.isArray(value)) return undefined;
@@ -1252,6 +1329,26 @@ export class Settings {
 		}
 		if (tierTouched) raw.tier = tierObj;
 		delete raw.fastModeScope;
+
+		// v17 renames that used to nest under a boolean parent path:
+		//   dev.autoqa.consent -> dev.autoqaConsent
+		//   todo.reminders.max -> todo.remindersMax
+		migrateNestedLeafRename(
+			raw,
+			"dev",
+			"autoqa",
+			"consent",
+			"autoqaConsent",
+			value => value === "unset" || value === "granted" || value === "denied",
+		);
+		migrateNestedLeafRename(
+			raw,
+			"todo",
+			"reminders",
+			"max",
+			"remindersMax",
+			value => typeof value === "number" && Number.isFinite(value),
+		);
 
 		// BM25 tool discovery removal: tools.discoveryMode / tools.essentialOverride /
 		// mcp.discoveryMode / mcp.discoveryDefaultServers are gone with no

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -694,6 +694,102 @@ describe("Settings", () => {
 			expect(settings.get("grep.enabled")).toBe(true);
 		});
 
+		it("migrates nested dev.autoqa.consent and todo.reminders.max without enabling parents", async () => {
+			await writeSettings({
+				dev: { autoqa: { consent: "granted" } },
+				todo: { reminders: { max: 5 } },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("dev.autoqaConsent")).toBe("granted");
+			expect(settings.get("dev.autoqa")).toBe(false);
+			expect(settings.isConfigured("dev.autoqa")).toBe(false);
+			expect(settings.get("todo.remindersMax")).toBe(5);
+			expect(settings.get("todo.reminders")).toBe(true);
+			expect(settings.isConfigured("todo.reminders")).toBe(false);
+		});
+
+		it("migrates quoted dotted legacy keys for consent and reminders max", async () => {
+			await Bun.write(getConfigPath(), `"dev.autoqa.consent": denied\n"todo.reminders.max": 2\n`);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("dev.autoqaConsent")).toBe("denied");
+			expect(settings.get("dev.autoqa")).toBe(false);
+			expect(settings.get("todo.remindersMax")).toBe(2);
+			expect(settings.get("todo.reminders")).toBe(true);
+		});
+
+		it("lets explicit new keys win over legacy nested consent/max values", async () => {
+			await writeSettings({
+				dev: { autoqa: { consent: "denied" }, autoqaConsent: "granted" },
+				todo: { reminders: { max: 1 }, remindersMax: 9 },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("dev.autoqaConsent")).toBe("granted");
+			expect(settings.get("dev.autoqa")).toBe(false);
+			expect(settings.get("todo.remindersMax")).toBe(9);
+			expect(settings.get("todo.reminders")).toBe(true);
+		});
+
+		it("preserves recoverable parent booleans alongside legacy leaf keys", async () => {
+			await Bun.write(
+				getConfigPath(),
+				`dev:\n  autoqa: true\n"dev.autoqa.consent": unset\ntodo:\n  reminders: false\n"todo.reminders.max": 4\n`,
+			);
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("dev.autoqa")).toBe(true);
+			expect(settings.get("dev.autoqaConsent")).toBe("unset");
+			expect(settings.get("todo.reminders")).toBe(false);
+			expect(settings.get("todo.remindersMax")).toBe(4);
+		});
+
+		it("migrates denied/granted/unset consent values through isolated overrides", () => {
+			for (const consent of ["denied", "granted", "unset"] as const) {
+				const settings = Settings.isolated({
+					"dev.autoqa.consent": consent,
+				} as Partial<Record<SettingPath, unknown>>);
+				expect(settings.get("dev.autoqaConsent")).toBe(consent);
+				expect(settings.get("dev.autoqa")).toBe(false);
+			}
+		});
+
+		it("persists migrated consent/max keys and drops legacy nested parents on save", async () => {
+			await writeSettings({
+				dev: { autoqa: { consent: "denied" } },
+				todo: { reminders: { max: 1 } },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+			expect(settings.get("dev.autoqaConsent")).toBe("denied");
+			expect(settings.get("todo.remindersMax")).toBe(1);
+
+			// Touch an unrelated key so the migrated tree is written back.
+			settings.set("display.showTokenUsage", true);
+			await settings.flush();
+
+			const onDisk = await readSettings();
+			const dev = onDisk.dev as Record<string, unknown>;
+			const todo = onDisk.todo as Record<string, unknown>;
+			expect(dev.autoqaConsent).toBe("denied");
+			expect(dev.autoqa).toBeUndefined();
+			expect(todo.remindersMax).toBe(1);
+			expect(todo.reminders).toBeUndefined();
+			expect(onDisk["dev.autoqa.consent"]).toBeUndefined();
+			expect(onDisk["todo.reminders.max"]).toBeUndefined();
+
+			const reloaded = await Settings.loadIsolated({ cwd: projectDir, agentDir });
+			expect(reloaded.get("dev.autoqaConsent")).toBe("denied");
+			expect(reloaded.get("dev.autoqa")).toBe(false);
+			expect(reloaded.get("todo.remindersMax")).toBe(1);
+			expect(reloaded.get("todo.reminders")).toBe(true);
+		});
+
 		it("drops dead BM25-discovery keys and leaves tools.xdev at its default", async () => {
 			await writeSettings({
 				tools: { discoveryMode: "off", essentialOverride: ["read"] },


### PR DESCRIPTION
## Repro
A pre-v17 config with nested (or quoted-dotted) `dev.autoqa.consent` and `todo.reminders.max` loads incorrectly on current `main`:

```yaml
dev:
  autoqa:
    consent: granted
todo:
  reminders:
    max: 5
```

Loading through `Settings.loadIsolated` yields `dev.autoqa = {"consent":"granted"}` (truthy object), `dev.autoqaConsent = "unset"`, `todo.reminders = {"max":5}`, `todo.remindersMax = 3`. Because `isAutoQaEnabled` reads `!!settings.get("dev.autoqa")`, the consent-only object turns Auto QA on, and the legacy reminder limit is discarded.

## Cause
The v17 rename in `46ad908` (`dev.autoqa.consent` → `dev.autoqaConsent`, `todo.reminders.max` → `todo.remindersMax`) renamed the schema keys and callers but added no matching case to `Settings.#migrateRawSettings` in `packages/coding-agent/src/config/settings.ts`. The old leaves stay nested beneath paths now expected to hold booleans, so the parent path resolves to an object.

## Fix
- Added `migrateNestedLeafRename` in `settings.ts`: a single parametrized helper covering both renames (they differ only in key names and leaf validator).
- Wired two calls into `#migrateRawSettings` for `dev.autoqa`/`consent`/`autoqaConsent` and `todo.reminders`/`max`/`remindersMax`.
- Behavior: lifts nested and quoted-dotted legacy leaves onto the new key; an explicit new key wins; a separately configured parent boolean is preserved; an irrecoverable object-valued parent is deleted so the schema default applies; only the new representation persists on the next save.
- Added 6 regression tests in `test/settings-manager.test.ts` (nested, quoted-dotted, explicit-new-key precedence, recoverable parent booleans, isolated-override consent values, save/reload).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/settings-manager.test.ts` → 59 pass / 0 fail (6 new). `bun check` → clean (biome + tsgo). Manually re-ran the repro after the fix: `dev.autoqaConsent = "granted"`, `dev.autoqa = false`, `dev.autoqa.isConfigured = false`, `todo.remindersMax = 5`, `todo.reminders = true`, `todo.reminders.isConfigured = false`. Fixes #5632