### PR TITLE
fix(session): await session.dispose() on non-interactive exit paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Routed the print-mode assistant-error/aborted exit, RPC `pi.shutdown()` and stdin-EOF shutdowns, and the extension command-context `shutdown()` through the awaited, idempotent `session.dispose()` before `process.exit()`, so the bounded browser reaper (`releaseTabsForOwner`) always runs and OMP-owned Chromium no longer outlives the process ([#5643](https://github.com/can1357/oh-my-pi/issues/5643)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/noninteractive-dispose.test.ts
+++ b/packages/coding-agent/src/modes/noninteractive-dispose.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Contract: the print-mode assistant-error/aborted exit path MUST run the
+ * awaited `session.dispose()` (which contains the bounded browser reaper
+ * `releaseTabsForOwner`) before terminating the process. It previously called
+ * `process.exit(1)` ahead of the `dispose()` at the end of `runPrintMode`, so
+ * an OMP-owned Chromium survived the exit (issue #5643).
+ */
+import { describe, expect, it, spyOn } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AgentSession } from "../session/agent-session";
+import { runPrintMode } from "./print-mode";
+
+/** Stand-in for `process.exit`: it terminates, so nothing after it should run. */
+class ProcessExit extends Error {
+	constructor(readonly code: number) {
+		super(`process.exit(${code})`);
+	}
+}
+
+describe("print-mode error exit disposes the session before exit", () => {
+	it("disposes on the assistant-error path before process.exit(1)", async () => {
+		const order: string[] = [];
+		const errorMsg: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-test",
+			usage: {} as AssistantMessage["usage"],
+			stopReason: "error",
+			errorMessage: "boom",
+			timestamp: 1,
+		};
+		const session = {
+			extensionRunner: undefined,
+			subscribe: () => {},
+			state: { messages: [errorMsg] },
+			dispose: async () => {
+				order.push("dispose");
+			},
+		} as unknown as AgentSession;
+
+		const exitSpy = spyOn(process, "exit").mockImplementation(((code: number) => {
+			order.push("exit");
+			throw new ProcessExit(code);
+		}) as never);
+		const stderrSpy = spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+
+		try {
+			await runPrintMode(session, { mode: "text" });
+		} catch (err) {
+			if (!(err instanceof ProcessExit)) throw err;
+		} finally {
+			exitSpy.mockRestore();
+			stderrSpy.mockRestore();
+		}
+
+		expect(order).toEqual(["dispose", "exit"]);
+	});
+});

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -144,10 +144,15 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				!isSilentAbort(assistantMsg)
 			) {
 				const errorLine = sanitizeText(assistantMsg.errorMessage || `Request ${assistantMsg.stopReason}`);
-				// Flush before this hard exit — it bypasses the awaited postmortem.quit()
-				// in main(), and the postmortem `exit` handler can't await, so the error
-				// spans would otherwise stay buffered in the batch processor and drop.
+				// This branch hard-exits, bypassing the `await session.dispose()` at
+				// the end of runPrintMode. Flush telemetry and dispose the session
+				// HERE so error spans reach the exporter (the postmortem `exit`
+				// handler can't await) and the browser reaper installed in
+				// `dispose()` (releaseTabsForOwner) actually runs — otherwise an
+				// OMP-owned Chromium survives this exit (issue #5643). `dispose()`
+				// is idempotent, so the unreachable call below is a harmless no-op.
 				await flushTelemetryExport();
+				await session.dispose();
 				const flushed = process.stderr.write(`${errorLine}\n`);
 				if (flushed) {
 					process.exit(1);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1346,9 +1346,12 @@ export async function runRpcMode(
 	const shutdownCoordinator = new RpcShutdownCoordinator({
 		isShutdownRequested: () => shutdownState.requested,
 		performShutdown: async () => {
-			if (session.extensionRunner?.hasHandlers("session_shutdown")) {
-				await session.extensionRunner.emit({ type: "session_shutdown" });
-			}
+			// Route through the idempotent session.dispose() so the browser
+			// reaper (releaseTabsForOwner) and other bounded teardown run before
+			// the process exits. dispose() also emits `session_shutdown`, so we
+			// must NOT emit it separately here or the event fires twice. Skipping
+			// dispose left OMP-owned Chromium alive after RPC shutdown (#5643).
+			await session.dispose();
 			process.exit(0);
 		},
 	});
@@ -1384,5 +1387,10 @@ export async function runRpcMode(
 	await inputDispatcher.drain();
 	await shutdownCoordinator.drain();
 	subagentRegistry?.dispose();
+	// Dispose the main session before exiting so the browser reaper and other
+	// bounded teardown run on the stdin-EOF path too (#5643). Idempotent: a
+	// prior pi.shutdown() through the coordinator makes this await settle
+	// immediately.
+	await session.dispose();
 	process.exit(0);
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8264,8 +8264,11 @@ export class AgentSession {
 			},
 			hasPendingMessages: () => this.queuedMessageCount > 0,
 			shutdown: () => {
-				void this.dispose();
-				process.exit(0);
+				// Await the idempotent dispose() before exiting so the browser
+				// reaper and other bounded teardown complete — a fire-and-forget
+				// `void this.dispose()` raced process.exit() and could leave an
+				// OMP-owned Chromium alive (#5643).
+				void this.dispose().finally(() => process.exit(0));
 			},
 			getContextUsage: () => this.getContextUsage(),
 			waitForIdle: () => this.waitForIdle(),


### PR DESCRIPTION
## Repro
A browser-owned Chrome for Testing / Chromium (`~/.omp/puppeteer` profile) was observed alive with `PPID=1` ~30h after its OMP parent exited. The browser reaper `releaseTabsForOwner(..., { kill: true })` lives inside `AgentSession.dispose()` (#3963/#3968), but several graceful non-interactive shutdown paths call `process.exit()` before — or racing — `dispose()`, so the reaper never completes. A behavioral test that mocks `process.exit` to halt (throw) and records call order proves the print-mode boundary: on an assistant `error`/`aborted` stop reason, `runPrintMode` exits with `["exit"]` and never reaches `dispose()`. Run: `bun test src/modes/noninteractive-dispose.test.ts`.

## Cause
Four callers bypass or race the awaited `session.dispose()`:
- `modes/print-mode.ts:146-156` — assistant-error branch flushes telemetry and calls `process.exit(1)`; the `await session.dispose()` at the end of `runPrintMode` is never reached.
- `modes/rpc/rpc-mode.ts:1346-1354` — `RpcShutdownCoordinator.performShutdown` emits `session_shutdown` directly, then `process.exit(0)`, without `dispose()`.
- `modes/rpc/rpc-mode.ts:1379-1387` — stdin-EOF drains dispatch/background work and disposes only the subagent registry, then `process.exit(0)`, never disposing the main session.
- `session/agent-session.ts:8266-8269` — extension command-context `shutdown()` fires `void this.dispose()` then immediately `process.exit(0)`, racing the async teardown.

## Fix
- print-mode: flush telemetry then `await session.dispose()` before the hard exit; the trailing (now unreachable) `dispose()` is a harmless no-op since `dispose()` is idempotent.
- RPC `performShutdown`: `await session.dispose()` before exit; drop the direct `session_shutdown` emit (`dispose()` emits it — avoids a double emit).
- RPC stdin-EOF: `await session.dispose()` before `process.exit(0)`; idempotent with a prior coordinator shutdown.
- extension command-context `shutdown()`: `void this.dispose().finally(() => process.exit(0))` so teardown settles before exit.
- Added `modes/noninteractive-dispose.test.ts` asserting the print-mode error path disposes before exiting.

## Verification
`bun test src/modes/noninteractive-dispose.test.ts src/modes/session-teardown.test.ts src/modes/print-mode.test.ts` → 15 pass, 0 fail. `bun run check:types` clean. Pre-publish `bun run fix` + `bun check` gate passed on push. Fixes #5643