### PR TITLE
fix(tui): constrain GFM autolinks to a valid left boundary

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Markdown rendering turning local file paths into HTTP links when a `www.` or `http(s)://`/`ftp://` sequence was glued to a preceding character (e.g. `~/meta/www.share/blog/index.dj`); extended autolinks now require a valid GFM left boundary (start of line, whitespace, or one of `*_~(`) ([#5652](https://github.com/can1357/oh-my-pi/issues/5652)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Added

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -592,7 +592,42 @@ const mathEnvBlockExtension: TokenizerAndRendererExtension = {
 		return (token as { text?: string }).text ?? "";
 	},
 };
-markdownParser.use({ extensions: [customHrExtension, mathBlockExtension, mathEnvBlockExtension, mathExtension] });
+
+// GFM's extended autolinks (`www.`, `http://`, `https://`, `ftp://`) may only
+// begin at a valid left boundary: start of line, whitespace, or one of `* _ ~ (`
+// (https://github.github.com/gfm/#autolinks-extension-). marked's bundled `url`
+// tokenizer instead fires after ANY character, so a local path such as
+// `~/meta/www.share/blog/index.dj` is mangled into a `http://www.share/...`
+// link. This inline extension runs before the built-in tokenizer: when an
+// autolink candidate is glued to an invalid preceding character it emits the
+// bare scheme prefix as literal text, so the remainder never reaches the `url`
+// tokenizer at a valid start. Candidates at a legal boundary fall through
+// (return undefined) to marked's own autolink handling unchanged.
+const AUTOLINK_SCHEME_REGEX = /^(?:www\.|https?:\/\/|ftp:\/\/)/i;
+const AUTOLINK_SCHEME_SCAN = /www\.|https?:\/\/|ftp:\/\//i;
+const VALID_AUTOLINK_LEFT_BOUNDARY = /[\s*_~(]/;
+const boundedAutolinkExtension: TokenizerAndRendererExtension = {
+	name: "boundedAutolink",
+	level: "inline",
+	start(src) {
+		const m = AUTOLINK_SCHEME_SCAN.exec(src);
+		return m ? m.index : undefined;
+	},
+	tokenizer(src, tokens) {
+		const match = AUTOLINK_SCHEME_REGEX.exec(src);
+		if (!match) return undefined;
+		const prevChar = tokens.at(-1)?.raw?.at(-1);
+		// Start of line or a legal delimiter → let marked autolink it.
+		if (prevChar === undefined || VALID_AUTOLINK_LEFT_BOUNDARY.test(prevChar)) return undefined;
+		// Glued to an invalid character (e.g. `/`, a letter, `.`): consume only
+		// the scheme prefix as text so the built-in `url` tokenizer cannot match.
+		const raw = match[0];
+		return { type: "text", raw, text: raw };
+	},
+};
+markdownParser.use({
+	extensions: [customHrExtension, mathBlockExtension, mathEnvBlockExtension, mathExtension, boundedAutolinkExtension],
+});
 
 // ---------------------------------------------------------------------------
 // Module-level LRU render cache

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -1410,6 +1410,36 @@ bar`,
 				"Should show mailto URL in parentheses",
 			).toBeTruthy();
 		});
+
+		it("does not autolink www. glued to a path separator (issue #5652)", () => {
+			const filePath = "~/meta/www.share/blog/A5-memory-safety-type-system/index.dj";
+			const markdown = new Markdown(filePath, 0, 0, defaultMarkdownTheme);
+
+			const output = markdown.render(120).join("\n");
+			const plain = stripTerminalSequences(output);
+
+			// The bare path must render verbatim, with no injected `(http…)` URL.
+			expect(plain).toContain(filePath);
+			expect(plain.includes("http://www.share")).toBe(false);
+			// No OSC 8 hyperlink target should be emitted for the path.
+			expect(output.includes("\x1b]8;;http://www.share")).toBe(false);
+		});
+
+		it("does not autolink a scheme glued to preceding text", () => {
+			const text = "path/to/foohttp://bar.com/x";
+			const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
+
+			const plain = stripTerminalSequences(markdown.render(120).join("\n"));
+			expect(plain).toContain(text);
+			expect(plain.includes("(http")).toBe(false);
+		});
+
+		it("still autolinks www. at a valid left boundary", () => {
+			const markdown = new Markdown("see www.example.com here", 0, 0, defaultMarkdownTheme);
+
+			const output = markdown.render(80).join("\n");
+			expect(output.includes("\x1b]8;;http://www.example.com\x07")).toBe(true);
+		});
 	});
 
 	describe("HTML-like tags in text", () => {


### PR DESCRIPTION
## Repro
Sending a local path that embeds a `www.`/`http(s)://`/`ftp://` sequence — e.g. `~/meta/www.share/blog/A5-memory-safety-type-system/index.dj` — renders the path as a clickable `http://www.share/...` link instead of plain text. Reproduced directly against the markdown tokenizer:

```
bun -e 'import {Marked} from "marked"; const m=new Marked(); console.log(m.lexer("~/meta/www.share/blog/index.dj")[0].tokens.find(t=>t.type==="link").href)'
# -> http://www.share/blog/index.dj
```

## Cause
The TUI markdown renderer (`packages/tui/src/components/markdown.ts`, `markdownParser`) uses marked's GFM `url` inline tokenizer. GFM's spec only autolinks a `www.`/scheme sequence at a valid left boundary (start of line, whitespace, or one of `*_~(`), but marked's bundled tokenizer fires after *any* preceding character. So `www.` glued to the path separator `/` is linkified.

## Fix
- Added `boundedAutolinkExtension`, an inline tokenizer extension registered ahead of marked's built-in `url` tokenizer in `packages/tui/src/components/markdown.ts`.
- When an autolink candidate (`www.` / `http://` / `https://` / `ftp://`) is glued to an invalid left-boundary character, it consumes only the scheme prefix as literal text, so the built-in tokenizer never matches at that position.
- Candidates at a legal boundary return `undefined` and fall through to marked's own autolink handling unchanged.
- Added regression tests in `packages/tui/test/markdown.test.ts` (Links block) covering the reported path, a scheme glued to preceding text, and a preserved boundary autolink.

## Verification
`bun test test/markdown.test.ts` → 123 pass, 0 fail; `bun test test/markdown-incremental-lex.test.ts test/markdown-math.test.ts test/markdown-stream-prefix-cache.test.ts test/markdown-tree-wrap.test.ts` → 50 pass, 0 fail. Confirmed `~/meta/www.share/blog/A5-memory-safety-type-system/index.dj` now renders verbatim with no OSC 8 target, while `see www.example.com here` still autolinks. Fixes #5652