### PR TITLE
fix(plan): reapply plan role model when reassigned mid-planning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed reassigning the `plan` role model mid-planning not taking effect on the active planning turn; the change now applies at the next turn boundary instead of only the next plan-mode entry ([#5657](https://github.com/can1357/oh-my-pi/issues/5657)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -56,8 +56,15 @@ import { reset as resetCapabilities } from "../capability";
 import type { CollabGuestLink } from "../collab/guest";
 import type { CollabHost } from "../collab/host";
 import { KeybindingsManager } from "../config/keybindings";
+import type { ResolvedModelRoleValue } from "../config/model-resolver";
 import { applyProviderGlobalsFromSettings } from "../config/provider-globals";
-import { isSettingsInitialized, onStatusLineSessionAccentChanged, Settings, settings } from "../config/settings";
+import {
+	isSettingsInitialized,
+	onModelRolesChanged,
+	onStatusLineSessionAccentChanged,
+	Settings,
+	settings,
+} from "../config/settings";
 import { clearClaudePluginRootsCache } from "../discovery/helpers";
 import type {
 	AutocompleteProviderFactory,
@@ -88,6 +95,7 @@ import {
 	resolveApprovedPlan,
 	resolvePlanTitle,
 } from "../plan-mode/approved-plan";
+import { resolvePlanModelTransition } from "../plan-mode/model-transition";
 import planModeApprovedPrompt from "../prompts/system/plan-mode-approved.md" with { type: "text" };
 import planModeCompactInstructionsPrompt from "../prompts/system/plan-mode-compact-instructions.md" with {
 	type: "text",
@@ -1021,6 +1029,11 @@ export class InteractiveMode implements InteractiveModeContext {
 			onStatusLineSessionAccentChanged(() => {
 				this.#syncStatusLineSettings();
 				this.#handleSessionAccentInputsChanged();
+			}),
+		);
+		this.#eventBusUnsubscribers.push(
+			onModelRolesChanged(() => {
+				void this.#reapplyPlanModeModelOnRoleChange();
 			}),
 		);
 		this.#eventBusUnsubscribers.push(
@@ -2080,27 +2093,54 @@ export class InteractiveMode implements InteractiveModeContext {
 		if (!resolved.model) return;
 
 		const currentModel = this.session.model;
-		const sameModel = modelsAreEqual(currentModel, resolved.model);
-		const planThinkingLevel = resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined;
-
+		// Capture the pre-plan model so #exitPlanMode can restore it. Only the
+		// entry path records this — a mid-planning role change (below) leaves the
+		// active model on the plan role, so overwriting here would restore the old
+		// plan model instead of the user's real pre-plan model.
 		this.#planModePreviousModelState = currentModel
 			? { model: currentModel, thinkingLevel: this.session.configuredThinkingLevel() }
 			: undefined;
 
-		if (!sameModel) {
-			if (this.session.isStreaming) {
-				this.#pendingModelSwitch = { model: resolved.model, thinkingLevel: planThinkingLevel };
+		await this.#applyPlanModelTransition(currentModel, resolved);
+	}
+
+	/**
+	 * Re-resolve the `plan` role and move the active model onto it. Fires when
+	 * the plan role is reassigned while plan mode is active: the active model IS
+	 * the plan model there, so a settings-only change would otherwise leave the
+	 * current turn on the model plan mode was entered with (issue #5657). No-op
+	 * outside plan mode — role reassignment for an inactive role only touches
+	 * settings.
+	 */
+	async #reapplyPlanModeModelOnRoleChange(): Promise<void> {
+		if (!this.planModeEnabled) return;
+		const resolved = this.session.resolveRoleModelWithThinking("plan");
+		if (!resolved.model) return;
+		await this.#applyPlanModelTransition(this.session.model, resolved);
+	}
+
+	/** Apply (or defer) the model/thinking change implied by the resolved plan role. */
+	async #applyPlanModelTransition(currentModel: Model | undefined, resolved: ResolvedModelRoleValue): Promise<void> {
+		const transition = resolvePlanModelTransition(currentModel, resolved, this.session.isStreaming);
+		switch (transition.kind) {
+			case "none":
 				return;
-			}
-			try {
-				await this.session.setModelTemporary(resolved.model, planThinkingLevel);
-			} catch (error) {
-				this.showWarning(
-					`Failed to switch to plan model for plan mode: ${error instanceof Error ? error.message : String(error)}`,
-				);
-			}
-		} else if (planThinkingLevel) {
-			this.session.setThinkingLevel(planThinkingLevel);
+			case "thinking":
+				this.session.setThinkingLevel(transition.thinkingLevel);
+				return;
+			case "apply":
+				if (transition.deferred) {
+					this.#pendingModelSwitch = { model: transition.model, thinkingLevel: transition.thinkingLevel };
+					return;
+				}
+				try {
+					await this.session.setModelTemporary(transition.model, transition.thinkingLevel);
+				} catch (error) {
+					this.showWarning(
+						`Failed to switch to plan model for plan mode: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				}
+				return;
 		}
 	}
 

--- a/packages/coding-agent/src/plan-mode/model-transition.test.ts
+++ b/packages/coding-agent/src/plan-mode/model-transition.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
+import type { ResolvedModelRoleValue } from "../config/model-resolver";
+import { AUTO_THINKING } from "../thinking";
+import { resolvePlanModelTransition } from "./model-transition";
+
+/**
+ * Plan-mode model transition policy (issue #5657). The active model in plan
+ * mode IS the plan-role model, so reassigning that role mid-planning must move
+ * the session onto the new model — or defer the switch when a turn is streaming.
+ */
+const model = (provider: string, id: string): Model => ({ provider, id }) as unknown as Model;
+
+const resolved = (
+	m: Model | undefined,
+	thinking?: ResolvedModelRoleValue["thinkingLevel"],
+): ResolvedModelRoleValue => ({
+	model: m,
+	thinkingLevel: thinking,
+	explicitThinkingLevel: thinking !== undefined,
+	warning: undefined,
+});
+
+describe("resolvePlanModelTransition", () => {
+	it("switches to the resolved plan model when it differs from the active one", () => {
+		const plan = model("anthropic", "opus");
+		const transition = resolvePlanModelTransition(model("openai", "gpt"), resolved(plan), false);
+		expect(transition).toEqual({ kind: "apply", model: plan, thinkingLevel: undefined, deferred: false });
+	});
+
+	it("defers the switch while the session is streaming", () => {
+		const plan = model("anthropic", "opus");
+		const transition = resolvePlanModelTransition(model("openai", "gpt"), resolved(plan), true);
+		expect(transition).toEqual({ kind: "apply", model: plan, thinkingLevel: undefined, deferred: true });
+	});
+
+	it("carries the plan role's explicit thinking level into the switch", () => {
+		const plan = model("anthropic", "opus");
+		const transition = resolvePlanModelTransition(model("openai", "gpt"), resolved(plan, ThinkingLevel.High), false);
+		expect(transition).toEqual({ kind: "apply", model: plan, thinkingLevel: ThinkingLevel.High, deferred: false });
+	});
+
+	it("only adjusts thinking when the model is unchanged but the level is explicit", () => {
+		const plan = model("anthropic", "opus");
+		const transition = resolvePlanModelTransition(plan, resolved(model("anthropic", "opus"), AUTO_THINKING), false);
+		expect(transition).toEqual({ kind: "thinking", thinkingLevel: AUTO_THINKING });
+	});
+
+	it("is a no-op when the model matches and no explicit thinking level is set", () => {
+		const plan = model("anthropic", "opus");
+		const transition = resolvePlanModelTransition(plan, resolved(model("anthropic", "opus")), false);
+		expect(transition).toEqual({ kind: "none" });
+	});
+
+	it("is a no-op when the plan role resolves to no model", () => {
+		const transition = resolvePlanModelTransition(model("openai", "gpt"), resolved(undefined), false);
+		expect(transition).toEqual({ kind: "none" });
+	});
+});

--- a/packages/coding-agent/src/plan-mode/model-transition.ts
+++ b/packages/coding-agent/src/plan-mode/model-transition.ts
@@ -1,0 +1,51 @@
+/**
+ * Plan-mode model transition policy.
+ *
+ * Plan mode drives the active session model from the `plan` role: it switches
+ * to the plan model on entry and restores the pre-plan model on exit. The same
+ * policy also runs when the `plan` role is reassigned mid-planning, so a
+ * correction to the wrong plan model takes effect at the next turn boundary
+ * (issue #5657).
+ *
+ * This module holds only the pure decision — what transition a given
+ * (current model, resolved role, streaming) triple implies — so the branching
+ * is testable without a live session or TUI. The interactive mode performs the
+ * resulting side effect.
+ */
+import type { Model } from "@oh-my-pi/pi-ai";
+import { modelsAreEqual } from "@oh-my-pi/pi-catalog/models";
+import type { ResolvedModelRoleValue } from "../config/model-resolver";
+import type { ConfiguredThinkingLevel } from "../thinking";
+
+/** The action implied by resolving the `plan` role against the active model. */
+export type PlanModelTransition =
+	/** Already on the plan model with no thinking-level change to apply. */
+	| { kind: "none" }
+	/** Same model; only the plan role's explicit thinking level differs. */
+	| { kind: "thinking"; thinkingLevel: ConfiguredThinkingLevel }
+	/**
+	 * Switch to `model`. `deferred` is set when the session is mid-stream: the
+	 * switch must wait for the current turn to end (a live `setModelTemporary`
+	 * resets the provider session), so the caller queues it instead.
+	 */
+	| { kind: "apply"; model: Model; thinkingLevel: ConfiguredThinkingLevel | undefined; deferred: boolean };
+
+/**
+ * Decide how to reconcile the active model with the resolved `plan` role.
+ *
+ * @param currentModel - The session's active model, or `undefined` before one is set.
+ * @param resolved - The `plan` role resolved against the available models.
+ * @param isStreaming - Whether the session is mid-turn (forces a deferred switch).
+ */
+export function resolvePlanModelTransition(
+	currentModel: Model | undefined,
+	resolved: ResolvedModelRoleValue,
+	isStreaming: boolean,
+): PlanModelTransition {
+	if (!resolved.model) return { kind: "none" };
+	const planThinkingLevel = resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined;
+	if (modelsAreEqual(currentModel, resolved.model)) {
+		return planThinkingLevel ? { kind: "thinking", thinkingLevel: planThinkingLevel } : { kind: "none" };
+	}
+	return { kind: "apply", model: resolved.model, thinkingLevel: planThinkingLevel, deferred: isStreaming };
+}


### PR DESCRIPTION
## Repro
Start plan mode with one model; while the agent is drafting the plan, open the model hub and reassign the `plan` role to a different model. Planning keeps running on the model plan mode was entered with — the new model only takes effect the next time plan mode is entered.

## Cause
In plan mode the active session model **is** the plan-role model: `InteractiveMode.#applyPlanModeModel` (`packages/coding-agent/src/modes/interactive-mode.ts`) switches to it on entry. Reassigning any non-`default` role through the model hub goes through `SelectorController` `onAssign` (`packages/coding-agent/src/modes/controllers/selector-controller.ts:742-750`), which only calls `settings.setModelRole("plan", …)`. It never re-applies the new model to the live session, and `InteractiveMode` had no subscription to model-role changes — so the in-flight planning turn stayed on the entry model.

## Fix
- Added `resolvePlanModelTransition()` in `packages/coding-agent/src/plan-mode/model-transition.ts`: a pure policy mapping `(current model, resolved plan role, streaming)` to a `none` / `thinking` / `apply` transition (with `deferred` set while a turn streams). Refactored `#applyPlanModeModel` to record the pre-plan model and delegate to this policy via a shared `#applyPlanModelTransition`.
- Added `#reapplyPlanModeModelOnRoleChange`: re-resolves the `plan` role and applies the transition, no-op outside plan mode (so it never clobbers the recorded pre-plan model).
- Subscribed `InteractiveMode` to `onModelRolesChanged` (disposed via `#eventBusUnsubscribers`), which `settings.setModelRole` already fires, so a plan-role reassignment now re-applies live.

## Verification
`bun test src/plan-mode/` → 10 pass (6 new for `resolvePlanModelTransition`). `bun check` clean. The 4 failing tests in `src/modes/` are pre-existing (`Cannot find module './tool-views.generated.js'`, a missing build artifact) and reproduce identically on a stashed clean tree — unrelated to this diff.

Fixes #5657