### PR TITLE
fix(extensions): isolate self-scheduled callbacks from killing the session

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -160,6 +160,30 @@ Handlers and tool `execute` receive `ctx` with:
 - `shutdown()`
 - `getSystemPrompt()`
 - `memory` (optional structured memory runtime — status/search/save across the configured backend)
+- `setInterval(fn, ms, ...args)` / `setTimeout(fn, ms, ...args)` / `clearTimer(timer)` — managed timers (see below)
+
+### Background work (`ctx.setInterval` / `ctx.setTimeout`)
+
+Extensions run **in-process with no isolation**. A raw `setInterval`/`setTimeout`/detached-promise callback that throws runs outside the handler-dispatch try/catch, surfaces as a process-level `uncaughtException`, and the global postmortem handler treats it as fatal — **the whole session is torn down**, not just the offending extension.
+
+Use `ctx.setInterval` / `ctx.setTimeout` for any periodic or deferred background work. They mirror the platform signatures but:
+
+- run the callback with the same isolation as handler dispatch — a synchronous throw or a rejected promise is logged and reported through the extension error channel, and the session keeps running;
+- return a handle you can pass to `ctx.clearTimer(handle)`;
+- are `unref`'d (never keep the process alive on their own) and are cleared automatically on `session_shutdown`.
+
+```ts
+pi.on("session_start", async (_event, ctx) => {
+  const timer = ctx.setInterval(() => {
+    // A throw here is contained — it will not crash the session.
+    ctx.ui.notify("tick", "info");
+  }, 60_000);
+  // Optional: clear it yourself; otherwise it is cleared on shutdown.
+  pi.on("session_shutdown", () => ctx.clearTimer(timer));
+});
+```
+
+If you use raw `setInterval`/`setTimeout` or detached promises instead, you own the isolation: wrap the callback body in your own `try/catch` (an unhandled throw will take down the session) and clear the timer on `session_shutdown`.
 
 ### Model selection (`ctx.models`)
 

--- a/docs/skills/authoring-extensions.md
+++ b/docs/skills/authoring-extensions.md
@@ -246,6 +246,7 @@ The derived name is the filename stem (or directory name for `index.ts`-style en
 
 - **Do not call runtime actions during load.** Methods like `pi.sendMessage()` throw `ExtensionRuntimeNotInitializedError` if called synchronously during module evaluation (before a session is active). Register handlers/tools/commands during load; perform runtime actions only from event handlers, tools, or commands.
 - **`tool_call` errors are fail-closed.** If a `tool_call` handler throws, the tool is blocked.
+- **Self-scheduled callbacks run in-process with no isolation.** A raw `setInterval`/`setTimeout`/detached-promise callback that throws escapes the handler-dispatch try/catch and crashes the whole session (`uncaughtException`). Use `ctx.setInterval` / `ctx.setTimeout` for background work — they contain callback throws and auto-clear on `session_shutdown`. With raw timers you must add your own `try/catch` and cleanup.
 - **Command names must not clash with built-ins.** Conflicts are skipped with a diagnostic log.
 - **Reserved shortcuts are ignored** (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `alt+m`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added managed `ctx.setInterval` / `ctx.setTimeout` / `ctx.clearTimer` helpers on the extension context. Callbacks scheduled through them run with the same isolation as handler dispatch — a throw or rejected promise is logged and reported through the extension error channel instead of escaping as a process-fatal `uncaughtException` — and every outstanding timer is `unref`'d and cleared automatically on `session_shutdown` ([#5664](https://github.com/can1357/oh-my-pi/issues/5664)).
+
+### Fixed
+
+- Fixed an extension's self-scheduled `setInterval`/`setTimeout` callback throwing being able to tear down the whole session. Such callbacks ran outside the handler-dispatch try/catch, surfaced as a process-level `uncaughtException`, and the global postmortem handler treated them as fatal; extension authors now have sanctioned managed timers (see Added), and the constraint is documented in `docs/extensions.md` / `docs/skills/authoring-extensions.md` ([#5664](https://github.com/can1357/oh-my-pi/issues/5664)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/extensibility/extensions/managed-timers.ts
+++ b/packages/coding-agent/src/extensibility/extensions/managed-timers.ts
@@ -1,0 +1,83 @@
+/**
+ * Managed timers for extensions.
+ *
+ * Extensions scheduling their own background work through raw `setInterval` /
+ * `setTimeout` used to be able to take down the whole session: a throw inside
+ * the callback runs on a fresh stack outside the handler-dispatch try/catch,
+ * surfaces as a process-level `uncaughtException`, and the global postmortem
+ * handler treats that as fatal (issue #5664).
+ *
+ * {@link ManagedTimers} backs the sanctioned `ctx.setInterval` /
+ * `ctx.setTimeout` helpers. Each callback runs inside the same isolation the
+ * runner already applies to handler dispatch — a synchronous throw or a
+ * rejected promise is reported through `onError` and swallowed — and every
+ * outstanding handle is `unref`'d (never keeps the process alive) and cleared
+ * on session teardown via {@link clearAll}.
+ */
+import { logger } from "@oh-my-pi/pi-utils";
+
+/** Callback invoked when a managed timer's callback throws or rejects. */
+export type ManagedTimerErrorHandler = (event: string, error: string, stack?: string) => void;
+
+export class ManagedTimers {
+	readonly #timers = new Set<Timer>();
+
+	constructor(private readonly onError: ManagedTimerErrorHandler) {}
+
+	/** Schedule a repeating callback whose throws are contained. */
+	setInterval(callback: (...args: unknown[]) => void, ms?: number, ...args: unknown[]): Timer {
+		const timer = setInterval(() => this.#run("interval", callback, args), ms, ...args);
+		timer.unref?.();
+		this.#timers.add(timer);
+		return timer;
+	}
+
+	/** Schedule a one-shot callback whose throws are contained. Deregisters after it fires. */
+	setTimeout(callback: (...args: unknown[]) => void, ms?: number, ...args: unknown[]): Timer {
+		const timer = setTimeout(
+			() => {
+				this.#timers.delete(timer);
+				this.#run("timeout", callback, args);
+			},
+			ms,
+			...args,
+		);
+		timer.unref?.();
+		this.#timers.add(timer);
+		return timer;
+	}
+
+	/** Clear one managed timer. Accepts an interval or timeout handle. */
+	clear(timer: Timer): void {
+		if (!this.#timers.delete(timer)) return;
+		clearInterval(timer);
+		clearTimeout(timer);
+	}
+
+	/** Clear every outstanding managed timer. Called on session teardown. */
+	clearAll(): void {
+		for (const timer of this.#timers) {
+			clearInterval(timer);
+			clearTimeout(timer);
+		}
+		this.#timers.clear();
+	}
+
+	#run(kind: "interval" | "timeout", callback: (...args: unknown[]) => void, args: unknown[]): void {
+		try {
+			const result = callback(...args) as unknown;
+			if (result instanceof Promise) {
+				result.catch((err: unknown) => this.#report(kind, err));
+			}
+		} catch (err) {
+			this.#report(kind, err);
+		}
+	}
+
+	#report(kind: "interval" | "timeout", err: unknown): void {
+		const message = err instanceof Error ? err.message : String(err);
+		const stack = err instanceof Error ? err.stack : undefined;
+		logger.warn("Extension timer callback threw", { event: `${kind}_callback`, error: message });
+		this.onError(`${kind}_callback`, message, stack);
+	}
+}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -12,6 +12,7 @@ import type { MemoryRuntimeContext } from "../../memory-backend";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { SessionManager } from "../../session/session-manager";
 import type { BranchHandler, NavigateTreeHandler, NewSessionHandler } from "../session-handler-types";
+import { ManagedTimers } from "./managed-timers";
 import { createExtensionModelQuery } from "./model-api";
 import type {
 	AfterProviderResponseEvent,
@@ -248,6 +249,18 @@ export class ExtensionRunner {
 	 * {@link MAX_PENDING_CREDENTIAL_DISABLED}; oldest entries are dropped under pressure.
 	 */
 	#pendingCredentialDisabled: CredentialDisabledEvent[] = [];
+
+	/**
+	 * Timers scheduled by extensions through the sanctioned `ctx.setInterval` /
+	 * `ctx.setTimeout` helpers. Callbacks run with the same isolation as handler
+	 * dispatch — a throw is logged and routed through {@link onError} instead of
+	 * escaping to the process `uncaughtException` handler and tearing down the
+	 * whole session (issue #5664). Handles are `unref`'d and every outstanding
+	 * timer is cleared on session teardown via {@link clearManagedTimers}.
+	 */
+	#managedTimers = new ManagedTimers((event, error, stack) =>
+		this.emitError({ extensionPath: "<timer>", event, error, stack }),
+	);
 
 	constructor(
 		private readonly extensions: Extension[],
@@ -542,6 +555,9 @@ export class ExtensionRunner {
 			getSystemPrompt: () => this.#getSystemPromptFn(),
 			localProtocolOptions: this.localProtocolOptions,
 			memory: this.#getMemoryFn?.(),
+			setInterval: (callback, ms, ...args) => this.#managedTimers.setInterval(callback, ms, ...args),
+			setTimeout: (callback, ms, ...args) => this.#managedTimers.setTimeout(callback, ms, ...args),
+			clearTimer: timer => this.#managedTimers.clear(timer),
 		};
 	}
 
@@ -550,6 +566,16 @@ export class ExtensionRunner {
 	 */
 	shutdown(): void {
 		this.#shutdownHandler();
+	}
+
+	/**
+	 * Clear every timer scheduled through `ctx.setInterval` / `ctx.setTimeout`.
+	 * Called during session teardown so extension background work does not
+	 * outlive the session (a self-scheduling interval would otherwise keep
+	 * firing against a disposed session).
+	 */
+	clearManagedTimers(): void {
+		this.#managedTimers.clearAll();
 	}
 
 	createCommandContext(): ExtensionCommandContext {

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -440,6 +440,24 @@ export interface ExtensionContext {
 	getSystemPrompt(): string[];
 	/** Structured memory runtime for status/search/save across the configured backend. */
 	memory?: MemoryRuntimeContext;
+	/**
+	 * Schedule a repeating callback whose throws are contained. Unlike raw
+	 * `setInterval`, a synchronous throw or rejected promise from `callback` is
+	 * logged and surfaced through the extension error channel instead of
+	 * escaping as a process-fatal `uncaughtException` — one misbehaving timer
+	 * can no longer take down the whole session. The handle is `unref`'d and
+	 * cleared automatically on `session_shutdown`. Prefer this over raw
+	 * `setInterval` for any extension background work.
+	 */
+	setInterval(callback: (...args: unknown[]) => void, ms?: number, ...args: unknown[]): Timer;
+	/**
+	 * Schedule a one-shot callback whose throws are contained, mirroring
+	 * {@link setInterval}. Cleared automatically on `session_shutdown` if it has
+	 * not yet fired.
+	 */
+	setTimeout(callback: (...args: unknown[]) => void, ms?: number, ...args: unknown[]): Timer;
+	/** Clear a timer scheduled via {@link setInterval} or {@link setTimeout}. */
+	clearTimer(timer: Timer): void;
 }
 
 /**

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -21,7 +21,6 @@ import type {
 	TerminalInputHandler,
 } from "../../extensibility/extensions";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
-import { createExtensionModelQuery } from "../../extensibility/extensions/model-api";
 import { AskDialogComponent, boundPromptTitle } from "../../modes/components/ask-dialog";
 import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { HookInputComponent } from "../../modes/components/hook-input";
@@ -494,32 +493,15 @@ export class ExtensionUiController {
 		if (!uiContext) {
 			return;
 		}
-		for (const registeredTool of this.ctx.session.extensionRunner?.getAllRegisteredTools() ?? []) {
+		const runner = this.ctx.session.extensionRunner;
+		for (const registeredTool of runner?.getAllRegisteredTools() ?? []) {
 			if (registeredTool.definition.onSession) {
 				try {
 					await registeredTool.definition.onSession(event, {
+						...runner!.createContext(),
 						ui: uiContext,
-						getContextUsage: () => this.ctx.session.getContextUsage(),
-						compact: instructionsOrOptions => this.#compactSession(instructionsOrOptions),
 						hasUI: true,
-						cwd: this.ctx.sessionManager.getCwd(),
-						sessionManager: this.ctx.session.sessionManager,
-						modelRegistry: this.ctx.session.modelRegistry,
-						model: this.ctx.session.model,
-						models: createExtensionModelQuery(
-							this.ctx.session.modelRegistry,
-							this.ctx.session.settings,
-							() => this.ctx.session.model,
-						),
-						isIdle: () => !this.ctx.session.isStreaming,
-						hasPendingMessages: () => this.ctx.session.queuedMessageCount > 0,
-						abort: () => {
-							this.ctx.session.abort({ reason: USER_INTERRUPT_LABEL });
-						},
-						shutdown: () => {
-							// Signal shutdown request
-						},
-						getSystemPrompt: () => this.ctx.session.systemPrompt,
+						compact: instructionsOrOptions => this.#compactSession(instructionsOrOptions),
 					});
 				} catch (err) {
 					this.showToolError(registeredTool.definition.name, err instanceof Error ? err.message : String(err));

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -233,6 +233,7 @@ import type {
 	TurnEndEvent,
 	TurnStartEvent,
 } from "../extensibility/extensions";
+import { ManagedTimers } from "../extensibility/extensions/managed-timers";
 import { createExtensionModelQuery } from "../extensibility/extensions/model-api";
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
@@ -1901,6 +1902,12 @@ export class AgentSession {
 	#isDisposed = false;
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
+	/**
+	 * Backs `ctx.setInterval`/`setTimeout`/`clearTimer` for the runner-less
+	 * command-context fallback (SDK embeddings with no extension runner). Lazily
+	 * created; cleared on dispose alongside the runner's own timers (#5664).
+	 */
+	#fallbackExtensionTimers: ManagedTimers | undefined = undefined;
 	#turnIndex = 0;
 	#messageEndPersistenceTail: Promise<void> = Promise.resolve();
 	#pendingMessageEndPersistence = new Map<string, Promise<void>>();
@@ -6262,6 +6269,10 @@ export class AgentSession {
 		} catch (error) {
 			logger.warn("Failed to emit session_shutdown event", { error: String(error) });
 		}
+		// Clear any timers extensions scheduled via `ctx.setInterval`/`ctx.setTimeout`
+		// so their background work does not outlive the session (issue #5664).
+		this.#extensionRunner?.clearManagedTimers();
+		this.#fallbackExtensionTimers?.clearAll();
 		// Abort post-prompt work so the drain below can complete. Without this, a
 		// deferred-handoff task that has already advanced into
 		// `await this.handoff(...) → generateHandoff(...)` keeps awaiting a live LLM stream
@@ -8346,7 +8357,18 @@ export class AgentSession {
 				await this.reload();
 			},
 			getSystemPrompt: () => this.systemPrompt,
+			setInterval: (callback, ms, ...args) => this.#fallbackTimers().setInterval(callback, ms, ...args),
+			setTimeout: (callback, ms, ...args) => this.#fallbackTimers().setTimeout(callback, ms, ...args),
+			clearTimer: timer => this.#fallbackTimers().clear(timer),
 		};
+	}
+
+	/** Lazily create the runner-less command-context timer registry (#5664). */
+	#fallbackTimers(): ManagedTimers {
+		this.#fallbackExtensionTimers ??= new ManagedTimers((event, error) =>
+			logger.warn("Extension timer callback threw", { event, error }),
+		);
+		return this.#fallbackExtensionTimers;
 	}
 
 	/**

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -8,12 +8,13 @@ import * as path from "node:path";
 import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
-import { discoverAndLoadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { discoverAndLoadExtensions, ExtensionRuntime } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import {
 	EXTENSION_HANDLER_TIMEOUT_MS,
 	ExtensionRunner,
 	testSetExtensionHandlerTimeoutMs,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import type { ExtensionError } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
 import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
 import { Type } from "@oh-my-pi/pi-coding-agent/extensibility/typebox";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -1945,6 +1946,122 @@ describe("ExtensionRunner", () => {
 			expect(events).toHaveLength(32);
 			// Drop-oldest policy: provider-0 was evicted, provider-1 survived as the head.
 			expect(events[0]?.provider).toBe("provider-1");
+		});
+	});
+
+	describe("managed timers (ctx.setInterval / ctx.setTimeout)", () => {
+		it("contains a throwing interval callback instead of letting it escape as uncaughtException", () => {
+			vi.useFakeTimers();
+			try {
+				const runner = new ExtensionRunner(
+					[],
+					new ExtensionRuntime(),
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+				const errors: ExtensionError[] = [];
+				runner.onError(err => errors.push(err));
+
+				const ctx = runner.createContext();
+				let ticks = 0;
+				ctx.setInterval(() => {
+					ticks += 1;
+					throw new Error("boom from interval");
+				}, 1000);
+
+				// Two ticks: the throw is swallowed each time, so the interval keeps firing.
+				expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+				expect(ticks).toBe(2);
+				expect(errors).toHaveLength(2);
+				expect(errors[0]?.event).toBe("interval_callback");
+				expect(errors[0]?.extensionPath).toBe("<timer>");
+				expect(errors[0]?.error).toContain("boom from interval");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("contains a throwing timeout callback and reports it once", () => {
+			vi.useFakeTimers();
+			try {
+				const runner = new ExtensionRunner(
+					[],
+					new ExtensionRuntime(),
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+				const errors: ExtensionError[] = [];
+				runner.onError(err => errors.push(err));
+
+				runner.createContext().setTimeout(() => {
+					throw new Error("boom from timeout");
+				}, 500);
+
+				expect(() => vi.advanceTimersByTime(1000)).not.toThrow();
+				expect(errors).toHaveLength(1);
+				expect(errors[0]?.event).toBe("timeout_callback");
+				expect(errors[0]?.error).toContain("boom from timeout");
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("clearTimer stops a managed interval from firing again", () => {
+			vi.useFakeTimers();
+			try {
+				const runner = new ExtensionRunner(
+					[],
+					new ExtensionRuntime(),
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+				const ctx = runner.createContext();
+				let ticks = 0;
+				const timer = ctx.setInterval(() => {
+					ticks += 1;
+				}, 1000);
+
+				vi.advanceTimersByTime(1000);
+				expect(ticks).toBe(1);
+
+				ctx.clearTimer(timer);
+				vi.advanceTimersByTime(3000);
+				expect(ticks).toBe(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it("clearManagedTimers cancels every outstanding timer on teardown", () => {
+			vi.useFakeTimers();
+			try {
+				const runner = new ExtensionRunner(
+					[],
+					new ExtensionRuntime(),
+					tempDir.path(),
+					sessionManager,
+					modelRegistry,
+				);
+				const ctx = runner.createContext();
+				let intervalTicks = 0;
+				let timeoutFired = false;
+				ctx.setInterval(() => {
+					intervalTicks += 1;
+				}, 1000);
+				ctx.setTimeout(() => {
+					timeoutFired = true;
+				}, 1000);
+
+				runner.clearManagedTimers();
+				vi.advanceTimersByTime(5000);
+				expect(intervalTicks).toBe(0);
+				expect(timeoutFired).toBe(false);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Repro
A minimal extension that registers `session_start` and inside it schedules `setInterval(() => { throw new Error("boom"); }, 1000)` crashes the entire session after the first tick, rather than disabling/logging against that one extension. The handler-dispatch try/catch in `runner.ts` (`#runHandlerWithTimeout`, `emitToolCall`) wraps only the handler *invocation*; a callback the handler schedules runs on a fresh stack outside that scope. A minimal model of the runner's containment confirms the escape:

```
$ bun repro-ext-timer.ts
handler dispatch returned; caught-by-handler-trycatch=false
[uncaughtException] Error: boom from self-scheduled callback
exit=7
```

## Cause
The throw escapes every handler try/catch and becomes a process-level `uncaughtException`, caught by the global postmortem handler (`packages/utils/src/postmortem.ts:191`), which runs the `session-teardown` cleanup (`interactive-mode.ts:840`) and `process.exit(1)` — full session teardown, not per-extension isolation. The extension SDK supports self-scheduled background work but offered no isolated primitive, and the behavior was undocumented.

## Fix
- New `packages/coding-agent/src/extensibility/extensions/managed-timers.ts`: `ManagedTimers` schedules interval/timeout callbacks that run with the same isolation as handler dispatch (sync throw or rejected promise logged and reported via `onError`), `unref`'s each handle, and clears all on teardown.
- `ExtensionRunner.createContext()` exposes `ctx.setInterval` / `ctx.setTimeout` / `ctx.clearTimer` backed by that registry; `clearManagedTimers()` is called from `AgentSession.#doDispose` right after the `session_shutdown` emit.
- `ExtensionContext` type gains the three methods; the runner-less command-context fallback in `agent-session.ts` is backed by a lazily-created `ManagedTimers` (also cleared on dispose), and the `onSession` path in `extension-ui-controller.ts` now inherits `runner.createContext()` instead of re-building a context literal.
- Docs: `docs/extensions.md` gains a "Background work" subsection and `docs/skills/authoring-extensions.md` an "Important constraints" bullet calling out the in-process no-isolation reality and the sanctioned helpers.

## Verification
`bun test packages/coding-agent/test/extensions-runner.test.ts` → 48 pass (4 new managed-timer tests: throwing interval/timeout contained + reported via `onError` with `not.toThrow`, `clearTimer` and `clearManagedTimers` stop firing). `bun test packages/coding-agent/src/modes/session-teardown.test.ts` → 9 pass (dispose path untouched behaviorally). `bun check` clean. Fixes #5664