### PR TITLE
fix(session): abort title generation during dispose

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/quit` and `/exit` leaving failed or stalled automatic title-generation requests alive during session teardown; disposal now aborts both online provider and local tiny-model title requests ([#5666](https://github.com/can1357/oh-my-pi/issues/5666)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -35,7 +35,6 @@ import { EnhancedPasteController } from "../../utils/enhanced-paste";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { generateSessionTitle } from "../../utils/title-generator";
 
 /**
  * Slash commands that may carry secrets in their arguments should never be
@@ -821,16 +820,8 @@ export class InputController {
 			// chance, so titling defers past "hi" instead of latching onto it.
 			if (!this.ctx.sessionManager.getSessionName() && !$env.PI_NO_TITLE && !isLowSignalTitleInput(text)) {
 				this.#showTinyTitleDownloadProgress(this.ctx.settings.get("providers.tinyModel"));
-				const registry = this.ctx.session.modelRegistry;
-				generateSessionTitle(
-					text,
-					registry,
-					this.ctx.settings,
-					this.ctx.session.sessionId,
-					this.ctx.session.model,
-					provider => this.ctx.session.agent.metadataForProvider(provider),
-					this.ctx.session.titleSystemPrompt,
-				)
+				this.ctx.session
+					.generateTitle(text)
 					.then(async title => {
 						// Re-check: a concurrent attempt for an earlier message may have
 						// already named the session. Don't clobber it. Terminal title and

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1860,6 +1860,7 @@ export class AgentSession {
 	 *  generation path. Refresh via {@link AgentSession.setTitleSystemPrompt} when
 	 *  the session cwd changes. */
 	#titleSystemPrompt: string | undefined;
+	#titleGenerationAbortController = new AbortController();
 	#toolChoiceQueue = new ToolChoiceQueue();
 
 	// Bash execution state
@@ -6226,6 +6227,7 @@ export class AgentSession {
 	 */
 	beginDispose(): void {
 		this.#isDisposed = true;
+		this.#titleGenerationAbortController.abort();
 		this.#flushPendingIrcAsides();
 		this.yieldQueue.clear();
 		this.agent.setAsideMessageProvider(undefined);
@@ -8982,16 +8984,26 @@ export class AgentSession {
 		this.#replanTitleRefreshInFlight = refresh;
 	}
 
-	async #refreshTitleAfterReplan(context: string, sessionId: string): Promise<void> {
-		const title = await generateSessionTitle(
-			context,
+	/**
+	 * Generate an automatic session title tied to this session's lifecycle.
+	 * Input and replan callers share the signal so disposal cancels provider and
+	 * local-worker requests instead of leaving background inference alive.
+	 */
+	generateTitle(firstMessage: string): Promise<string | null> {
+		return generateSessionTitle(
+			firstMessage,
 			this.#modelRegistry,
 			this.settings,
-			sessionId,
+			this.sessionManager.getSessionId(),
 			this.model,
 			provider => this.agent.metadataForProvider(provider),
 			this.#titleSystemPrompt,
+			this.#titleGenerationAbortController.signal,
 		);
+	}
+
+	async #refreshTitleAfterReplan(context: string, sessionId: string): Promise<void> {
+		const title = await this.generateTitle(context);
 		if (!title) return;
 		if (this.sessionManager.getSessionId() !== sessionId) return;
 		if (!this.settings.get("title.refreshOnReplan")) return;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8994,7 +8994,7 @@ export class AgentSession {
 			firstMessage,
 			this.#modelRegistry,
 			this.settings,
-			this.sessionManager.getSessionId(),
+			this.sessionId,
 			this.model,
 			provider => this.agent.metadataForProvider(provider),
 			this.#titleSystemPrompt,

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -68,6 +68,7 @@ function getTitleModel(registry: ModelRegistry, settings: Settings, currentModel
  *   resolver instead of a pre-evaluated value ensures the metadata's account_uuid
  *   reflects the credential actually selected for this request.
  * @param customSystemPrompt Optional title-specific system prompt override
+ * @param signal Session-lifecycle cancellation for background title requests
  */
 export async function generateSessionTitle(
 	firstMessage: string,
@@ -77,6 +78,7 @@ export async function generateSessionTitle(
 	currentModel?: Model<Api>,
 	metadataResolver?: (provider: string) => Record<string, unknown> | undefined,
 	customSystemPrompt?: string,
+	signal?: AbortSignal,
 ): Promise<string | null> {
 	// Defer titling for greetings / acknowledgements / empty input. The default
 	// tiny title model can't reliably decline trivial input, so this happens
@@ -97,7 +99,7 @@ export async function generateSessionTitle(
 			sessionId,
 			currentModel,
 			metadataResolver,
-			undefined,
+			signal,
 			titleSystemPrompt,
 		);
 	}
@@ -117,9 +119,10 @@ export async function generateSessionTitle(
 		return null;
 	}
 	try {
-		const localTitle = titleSystemPrompt
-			? await tinyTitleClient.generate(tinyModel, firstMessage, { systemPrompt: titleSystemPrompt })
-			: await tinyTitleClient.generate(tinyModel, firstMessage);
+		const localTitle = await tinyTitleClient.generate(tinyModel, firstMessage, {
+			signal,
+			systemPrompt: titleSystemPrompt,
+		});
 		if (!localTitle) {
 			logger.warn("title-generator: local tiny model produced no title; skipping (no online fallback)", {
 				sessionId,

--- a/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
+++ b/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import * as ai from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+let session: AgentSession | undefined;
+let authStorage: AuthStorage | undefined;
+let tempDir: TempDir | undefined;
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await session?.dispose();
+	authStorage?.close();
+	tempDir?.removeSync();
+	session = undefined;
+	authStorage = undefined;
+	tempDir = undefined;
+});
+
+describe("AgentSession title generation disposal", () => {
+	it("aborts an in-flight automatic title request when disposal begins", async () => {
+		tempDir = TempDir.createSync("@pi-title-dispose-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+
+		const settings = Settings.isolated({
+			"compaction.enabled": false,
+			"providers.tinyModel": "online",
+		});
+		settings.overrideModelRoles({ smol: `${model.provider}/${model.id}` });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		const started = Promise.withResolvers<void>();
+		const response = Promise.withResolvers<ai.AssistantMessage>();
+		let requestSignal: AbortSignal | undefined;
+		vi.spyOn(ai, "completeSimple").mockImplementation((_model, _context, options) => {
+			requestSignal = options?.signal;
+			requestSignal?.addEventListener("abort", () => response.resolve(createAssistantMessage("")), { once: true });
+			started.resolve();
+			return response.promise;
+		});
+
+		const generation = session.generateTitle("Investigate shutdown");
+		await started.promise;
+		session.beginDispose();
+
+		expect(requestSignal?.aborted).toBe(true);
+		expect(await generation).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
+++ b/packages/coding-agent/test/agent-session-title-generation-dispose.test.ts
@@ -27,12 +27,13 @@ afterEach(async () => {
 });
 
 describe("AgentSession title generation disposal", () => {
-	it("aborts an in-flight automatic title request when disposal begins", async () => {
+	it("uses the active provider session and aborts an in-flight title request during disposal", async () => {
 		tempDir = TempDir.createSync("@pi-title-dispose-");
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const providerSessionId = "provider-session";
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
@@ -44,11 +45,15 @@ describe("AgentSession title generation disposal", () => {
 			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
 			streamFn: createMockModel({ responses: [{ content: ["Done"] }] }).stream,
 		});
+		const modelRegistry = new ModelRegistry(authStorage);
+		const getApiKey = vi.spyOn(modelRegistry, "getApiKey");
+		const resolver = vi.spyOn(modelRegistry, "resolver");
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
 			settings,
-			modelRegistry: new ModelRegistry(authStorage),
+			modelRegistry,
+			providerSessionId,
 		});
 		const started = Promise.withResolvers<void>();
 		const response = Promise.withResolvers<ai.AssistantMessage>();
@@ -62,6 +67,8 @@ describe("AgentSession title generation disposal", () => {
 
 		const generation = session.generateTitle("Investigate shutdown");
 		await started.promise;
+		expect(getApiKey.mock.calls[0]?.[1]).toBe(providerSessionId);
+		expect(resolver.mock.calls[0]?.[1]).toBe(providerSessionId);
 		session.beginDispose();
 
 		expect(requestSignal?.aborted).toBe(true);


### PR DESCRIPTION
## Repro
An isolated regression harness launched the same `generateSessionTitle()` call used by `InputController` with a provider completion held in flight; `cd .wt && bun test ./repro-5666.test.ts` confirmed that `completeSimple()` received no `AbortSignal`, leaving `AgentSession.beginDispose()` unable to cancel the background request.

## Cause
`packages/coding-agent/src/modes/controllers/input-controller.ts` invoked `generateSessionTitle()` directly as a fire-and-forget task, while `AgentSession.#refreshTitleAfterReplan()` did the same for replan refreshes. `AgentSession.beginDispose()` therefore had no controller for either request, and `packages/coding-agent/src/utils/title-generator.ts` did not accept a lifecycle signal to forward to online `completeSimple()` or the local tiny-model client.

## Fix
- Added an `AgentSession`-owned title-generation abort controller and aborted it synchronously in `beginDispose()`.
- Routed first-input and replan title generation through `AgentSession.generateTitle()` so both paths share the session lifecycle.
- Propagated the lifecycle signal through online provider and local tiny-model title generation.
- Added a regression test covering an in-flight request settling when disposal begins.

## Verification
`bun test ./test/title-generator.test.ts ./test/agent-session-title-generation-dispose.test.ts` passed 30 tests with 55 assertions; `bun check` passed for `packages/coding-agent`. The post-fix shutdown reproducer passed with the in-flight request aborted and resolved to no title. Fixes #5666