### PR TITLE
fix(tui): preserve inline images in scrollback

### DIFF
--- a/packages/tui/src/components/box.ts
+++ b/packages/tui/src/components/box.ts
@@ -1,5 +1,6 @@
 import type { Component } from "../tui";
 import { applyBackgroundToLine, getPaddingX, padding, visibleWidth } from "../utils";
+import { getDirectKittyRowWidth } from "./image";
 
 type Cache = {
 	width: number;
@@ -182,12 +183,13 @@ export class Box implements Component {
 	}
 
 	#applyBg(line: string, width: number): string {
-		const visLen = visibleWidth(line);
+		const directKittyWidth = getDirectKittyRowWidth(line);
+		const visLen = directKittyWidth ?? visibleWidth(line);
 		const padNeeded = Math.max(0, width - visLen);
 		const padded = line + padding(padNeeded);
 
 		if (this.#bgFn) {
-			return applyBackgroundToLine(padded, width, this.#bgFn);
+			return directKittyWidth === null ? applyBackgroundToLine(padded, width, this.#bgFn) : this.#bgFn(padded);
 		}
 		return padded;
 	}

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -1,13 +1,16 @@
+import { randomBytes } from "node:crypto";
 import { getKittyGraphics } from "../kitty-graphics";
 import {
 	getCellDimensions,
 	getImageDimensions,
 	type ImageDimensions,
+	ImageProtocol,
 	imageFallback,
 	renderImage,
 	TERMINAL,
 } from "../terminal-capabilities";
 import type { Component } from "../tui";
+import { visibleWidth } from "../utils";
 
 export interface ImageTheme {
 	fallbackColor: (str: string) => string;
@@ -31,9 +34,155 @@ const EMPTY_IDS: readonly number[] = [];
 const EMPTY_TRANSMITS: readonly string[] = [];
 const SAVE_CURSOR = "\x1b7";
 const RESTORE_CURSOR = "\x1b8";
-// Direct placements reserve height with leading zero-width rows. Keep them
-// non-plain so transcript blank-edge trimming does not collapse image-only blocks.
+const ERASE_LINE = "\x1b[2K";
+// Internal line markers consumed by TUI before terminal output. A per-process
+// capability prevents marker-shaped tool/user text from entering this raw
+// control-sequence path. Direct Kitty placements must render on their first
+// logical row so WezTerm can carry the full placement into scrollback;
+// continuation rows then advance without EL, which would detach the image.
+const DIRECT_KITTY_ROW_CAPABILITY = randomBytes(16).toString("hex");
+const DIRECT_KITTY_PLACEMENT_PREFIX = `\x1b]pi:img:${DIRECT_KITTY_ROW_CAPABILITY}:p:`;
+const DIRECT_KITTY_PLACEMENT_SUFFIX = `\x1b]pi:img:${DIRECT_KITTY_ROW_CAPABILITY}:e\x07`;
+const DIRECT_KITTY_PLACEMENT_ANCHOR = `\x1b]pi:img:${DIRECT_KITTY_ROW_CAPABILITY}:a\x07`;
+const DIRECT_KITTY_CONTINUATION_PREFIX = `\x1b]pi:img:${DIRECT_KITTY_ROW_CAPABILITY}:c:`;
+// Direct placements for non-Kitty protocols still reserve height with leading
+// zero-width rows. Keep them non-plain so transcript blank-edge trimming does
+// not collapse image-only blocks.
 const RESERVED_IMAGE_ROW = "\x1b[0m";
+
+interface SizedDirectKittyMarker {
+	markerStart: number;
+	payloadStart: number;
+	columns: number;
+	rows: number;
+}
+
+interface DirectKittyPlacementFrame extends SizedDirectKittyMarker {
+	placementStart: number;
+	placementEnd: number;
+	markerEnd: number;
+}
+
+function findSizedDirectKittyMarker(line: string, prefix: string): SizedDirectKittyMarker | null {
+	const markerStart = line.indexOf(prefix);
+	if (markerStart < 0) return null;
+	const sizeStart = markerStart + prefix.length;
+	const payloadStart = line.indexOf("\x07", sizeStart);
+	if (payloadStart < 0) return null;
+	const match = line.slice(sizeStart, payloadStart).match(/^(\d+)x(\d+)$/);
+	if (match === null) return null;
+	const columns = Number(match[1]);
+	const rows = Number(match[2]);
+	if (!Number.isSafeInteger(columns) || columns <= 0 || !Number.isSafeInteger(rows) || rows <= 0) return null;
+	return { markerStart, payloadStart: payloadStart + 1, columns, rows };
+}
+
+function findDirectKittyPlacementFrame(line: string): DirectKittyPlacementFrame | null {
+	const marker = findSizedDirectKittyMarker(line, DIRECT_KITTY_PLACEMENT_PREFIX);
+	if (marker === null) return null;
+	const placementStart = line.indexOf(DIRECT_KITTY_PLACEMENT_ANCHOR, marker.payloadStart);
+	if (placementStart < 0) return null;
+	const placementEnd = placementStart + DIRECT_KITTY_PLACEMENT_ANCHOR.length;
+	const markerEnd = line.indexOf(DIRECT_KITTY_PLACEMENT_SUFFIX, placementEnd);
+	if (markerEnd < 0) return null;
+	return { ...marker, placementStart, placementEnd, markerEnd };
+}
+
+/** Whether this row contains a capability-framed direct Kitty placement. */
+export function isDirectKittyPlacement(line: string): boolean {
+	return findDirectKittyPlacementFrame(line) !== null;
+}
+/** Expected logical row count for a capability-framed direct Kitty placement. */
+export function getDirectKittyPlacementRows(line: string): number | null {
+	return findDirectKittyPlacementFrame(line)?.rows ?? null;
+}
+
+/** Visible cell width of a marked image row, including any surrounding wrapper. */
+export function getDirectKittyRowWidth(line: string): number | null {
+	const placement = findDirectKittyPlacementFrame(line);
+	if (placement !== null) {
+		return (
+			visibleWidth(line.slice(0, placement.markerStart)) +
+			placement.columns +
+			visibleWidth(line.slice(placement.markerEnd + DIRECT_KITTY_PLACEMENT_SUFFIX.length))
+		);
+	}
+	const continuation = findSizedDirectKittyMarker(line, DIRECT_KITTY_CONTINUATION_PREFIX);
+	if (continuation === null) return null;
+	return (
+		visibleWidth(line.slice(0, continuation.markerStart)) +
+		continuation.columns +
+		visibleWidth(line.slice(continuation.payloadStart))
+	);
+}
+
+/** Remove a framed direct-Kitty placement marker while preserving wrappers. */
+export function unwrapDirectKittyPlacement(line: string): string | null {
+	const frame = findDirectKittyPlacementFrame(line);
+	if (frame === null) return null;
+	const prefix = line.slice(0, frame.markerStart);
+	const sequence = line.slice(frame.placementEnd, frame.markerEnd);
+	const implicitPosition =
+		visibleWidth(prefix) > 0 && !/^\x1b\[\d+G/.test(sequence) ? `\x1b[${visibleWidth(prefix) + 1}G` : "";
+	const suffix = line.slice(frame.markerEnd + DIRECT_KITTY_PLACEMENT_SUFFIX.length);
+	const suffixAdvance = visibleWidth(suffix) > 0 ? `\x1b[${frame.columns}C` : "";
+	// Clear under the default background before emitting wrapper SGR/padding;
+	// BCE terminals otherwise extend a narrow Box background across full rows.
+	return (
+		RESERVED_IMAGE_ROW +
+		line.slice(frame.payloadStart, frame.placementStart) +
+		prefix +
+		implicitPosition +
+		sequence +
+		suffixAdvance +
+		suffix
+	);
+}
+
+/** Position a marked placement without hiding its internal dispatch prefix. */
+export function positionDirectKittyPlacement(line: string, columns: number): string | null {
+	const frame = findDirectKittyPlacementFrame(line);
+	if (frame === null) return null;
+	const offset = Number.isFinite(columns) ? Math.max(0, Math.trunc(columns)) : 0;
+	if (offset === 0) return line;
+	const wrapperPrefix = line.slice(0, frame.markerStart);
+	const wrapperSuffix = line.slice(frame.markerEnd + DIRECT_KITTY_PLACEMENT_SUFFIX.length);
+	const wrapperPosition = wrapperPrefix.length > 0 || wrapperSuffix.length > 0 ? `\x1b[${offset + 1}G` : "";
+	const placementColumn = offset + visibleWidth(wrapperPrefix) + 1;
+	return `${wrapperPosition}${line.slice(0, frame.placementEnd)}\x1b[${placementColumn}G${line.slice(frame.placementEnd)}`;
+}
+
+/** Whether this logical row must advance without erasing its Kitty image cells. */
+export function isDirectKittyContinuation(line: string): boolean {
+	return findSizedDirectKittyMarker(line, DIRECT_KITTY_CONTINUATION_PREFIX) !== null;
+}
+
+/** Remove a continuation marker while retaining wrapper padding and borders. */
+export function unwrapDirectKittyContinuation(line: string): string | null {
+	const frame = findSizedDirectKittyMarker(line, DIRECT_KITTY_CONTINUATION_PREFIX);
+	if (frame === null) return null;
+	const prefix = line.slice(0, frame.markerStart);
+	const suffix = line.slice(frame.payloadStart);
+	const suffixAdvance = visibleWidth(suffix) > 0 ? `\x1b[${frame.columns}C` : "";
+	return prefix + suffixAdvance + suffix;
+}
+
+/** Position a wrapped continuation row within an overlay. */
+export function positionDirectKittyContinuation(line: string, columns: number): string | null {
+	const frame = findSizedDirectKittyMarker(line, DIRECT_KITTY_CONTINUATION_PREFIX);
+	if (frame === null) return null;
+	const offset = Number.isFinite(columns) ? Math.max(0, Math.trunc(columns)) : 0;
+	const hasWrapper = frame.markerStart > 0 || frame.payloadStart < line.length;
+	return offset > 0 && hasWrapper ? `\x1b[${offset + 1}G${line}` : line;
+}
+
+function reserveDirectKittyRows(rows: number): string {
+	let sequence = ERASE_LINE;
+	for (let row = 1; row < rows; row++) {
+		sequence += `\r\n${ERASE_LINE}`;
+	}
+	return `${sequence}\x1b[${rows - 1}A`;
+}
 
 /** Default count of inline images kept as live graphics before older ones fall back to text. */
 export const DEFAULT_MAX_INLINE_IMAGES = 8;
@@ -403,13 +552,26 @@ export class Image implements Component {
 				// Unicode placeholders: the image is already a block of real text-cell
 				// lines (line 0 carries the virtual-placement APC). No cursor moves.
 				lines = result.lines;
+			} else if (result && imageProtocol === ImageProtocol.Kitty && result.rows > 1) {
+				// Place first, then advance across protected continuation rows. A
+				// last-row placement is clipped when its logical origin has already
+				// scrolled above WezTerm's viewport; repainting continuation rows
+				// with EL also detaches the image from those cells. Reserve and
+				// clear the whole block before moving back to its first row, so C=1
+				// always has enough physical rows even when the block starts at the
+				// viewport bottom.
+				lines = [
+					`${DIRECT_KITTY_PLACEMENT_PREFIX}${result.columns}x${result.rows}\x07` +
+						reserveDirectKittyRows(result.rows) +
+						DIRECT_KITTY_PLACEMENT_ANCHOR +
+						(result.sequence ?? "") +
+						DIRECT_KITTY_PLACEMENT_SUFFIX,
+				];
+				for (let i = 1; i < result.rows; i++) {
+					lines.push(`${DIRECT_KITTY_CONTINUATION_PREFIX}${result.columns}x${result.rows}\x07`);
+				}
 			} else if (result) {
-				// Direct placement: return `rows` lines so TUI accounts for image
-				// height. First (rows-1) lines are empty (TUI clears them); the last
-				// saves the final-row cursor, moves up to the image origin, emits the
-				// image sequence, then restores the final-row cursor. Save/restore is
-				// required because CUU clamps at the viewport top when leading rows are
-				// clipped away.
+				// Other direct protocols retain the final-row cursor anchor.
 				lines = [];
 				for (let i = 0; i < result.rows - 1; i++) {
 					lines.push(RESERVED_IMAGE_ROW);

--- a/packages/tui/src/components/scroll-view.ts
+++ b/packages/tui/src/components/scroll-view.ts
@@ -1,6 +1,7 @@
 import { matchesKey } from "../keys";
 import type { Component } from "../tui";
 import { Ellipsis, replaceTabs, truncateToWidth, visibleWidth } from "../utils";
+import { getDirectKittyPlacementRows, isDirectKittyContinuation, isDirectKittyPlacement } from "./image";
 
 const DEFAULT_TRACK = "│";
 const DEFAULT_THUMB = "█";
@@ -186,12 +187,41 @@ export class ScrollView implements Component {
 		const contentWidth = Math.max(0, safeWidth - (showScrollbar ? 1 : 0));
 		const thumb = showScrollbar ? this.#thumbRange() : undefined;
 		const lines: string[] = [];
-		for (let row = 0; row < this.#height; row++) {
-			const sourceIndex = this.#totalRows === undefined ? this.#scrollOffset + row : row;
+		let sourceIndex = this.#totalRows === undefined ? this.#scrollOffset : 0;
+		let row = 0;
+		while (row < this.#height) {
 			const source = this.#lines[sourceIndex] ?? "";
+
+			// Direct terminal images are atomic viewport blocks. Never emit an
+			// orphan continuation after its placement row has scrolled away, and
+			// never start a placement when all of its protected rows cannot fit.
+			if (isDirectKittyContinuation(source)) {
+				sourceIndex++;
+				continue;
+			}
+			if (isDirectKittyPlacement(source)) {
+				let blockEnd = sourceIndex + 1;
+				while (blockEnd < this.#lines.length && isDirectKittyContinuation(this.#lines[blockEnd] ?? "")) {
+					blockEnd++;
+				}
+				const blockHeight = blockEnd - sourceIndex;
+				if (blockHeight !== getDirectKittyPlacementRows(source) || blockHeight > this.#height - row) {
+					sourceIndex = blockEnd;
+					continue;
+				}
+				while (sourceIndex < blockEnd) {
+					lines.push(this.#lines[sourceIndex] ?? "");
+					sourceIndex++;
+					row++;
+				}
+				continue;
+			}
+
 			const truncated = truncateToWidth(replaceTabs(source), contentWidth, this.#ellipsis);
 			if (!showScrollbar) {
 				lines.push(truncated);
+				sourceIndex++;
+				row++;
 				continue;
 			}
 			const content = `${truncated}${" ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)))}`;
@@ -199,6 +229,8 @@ export class ScrollView implements Component {
 			const styledBar =
 				thumb && row >= thumb.start && row < thumb.end ? this.#theme.thumb(barGlyph) : this.#theme.track(barGlyph);
 			lines.push(`${content}${styledBar}`);
+			sourceIndex++;
+			row++;
 		}
 		return lines;
 	}

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -935,7 +935,7 @@ export function renderImage(
 	base64Data: string,
 	imageDimensions: ImageDimensions,
 	options: ImageRenderOptions = {},
-): { sequence?: string; lines?: string[]; rows: number; transmit?: string } | null {
+): { sequence?: string; lines?: string[]; columns: number; rows: number; transmit?: string } | null {
 	if (!TERMINAL.imageProtocol) {
 		return null;
 	}
@@ -964,7 +964,7 @@ export function renderImage(
 					columns: fit.columns,
 					rows: fit.rows,
 				});
-				return { lines, rows: fit.rows, transmit };
+				return { lines, columns: fit.columns, rows: fit.rows, transmit };
 			}
 			// Direct placement: re-emit only the tiny `a=p` on repaints.
 			const sequence = encodeKittyPlacement({
@@ -973,14 +973,14 @@ export function renderImage(
 				columns: fit.columns,
 				rows: fit.rows,
 			});
-			return { sequence, rows: fit.rows, transmit };
+			return { sequence, columns: fit.columns, rows: fit.rows, transmit };
 		}
 		// No stable id (e.g. no budget): self-contained transmit-and-display.
 		const sequence = encodeKitty(base64Data, {
 			columns: fit.columns,
 			rows: fit.rows,
 		});
-		return { sequence, rows: fit.rows };
+		return { sequence, columns: fit.columns, rows: fit.rows };
 	}
 
 	if (TERMINAL.imageProtocol === ImageProtocol.Sixel) {
@@ -1003,7 +1003,7 @@ export function renderImage(
 			const rows = Math.max(1, Math.ceil(targetHeightPx / cellDims.heightPx));
 			const decoded = new Uint8Array(Buffer.from(base64Data, "base64"));
 			const sequence = encodeSixel(decoded, targetWidthPx, targetHeightPx);
-			return { sequence, rows };
+			return { sequence, columns: fit.columns, rows };
 		} catch {
 			return null;
 		}
@@ -1014,7 +1014,7 @@ export function renderImage(
 			height: "auto",
 			preserveAspectRatio: options.preserveAspectRatio ?? true,
 		});
-		return { sequence, rows: fit.rows };
+		return { sequence, columns: fit.columns, rows: fit.rows };
 	}
 
 	return null;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -18,7 +18,17 @@
 import * as fs from "node:fs";
 import { performance } from "node:perf_hooks";
 import { $flag, getDebugLogPath } from "@oh-my-pi/pi-utils";
-import { DEFAULT_MAX_INLINE_IMAGES, ImageBudget } from "./components/image";
+import {
+	DEFAULT_MAX_INLINE_IMAGES,
+	getDirectKittyPlacementRows,
+	ImageBudget,
+	isDirectKittyContinuation,
+	isDirectKittyPlacement,
+	positionDirectKittyContinuation,
+	positionDirectKittyPlacement,
+	unwrapDirectKittyContinuation,
+	unwrapDirectKittyPlacement,
+} from "./components/image";
 import { planDeccaraFills } from "./deccara";
 import { isKeyRelease, matchesKey } from "./keys";
 import { LoopWatchdog } from "./loop-watchdog";
@@ -2515,6 +2525,48 @@ export class TUI extends Container {
 		}
 	}
 
+	#clipOverlayLines(lines: readonly string[], maxHeight: number, fromBottom: boolean): readonly string[] {
+		const limit = Number.isFinite(maxHeight) ? Math.max(0, Math.trunc(maxHeight)) : lines.length;
+
+		const blocks: (readonly string[])[] = [];
+		for (let index = 0; index < lines.length; ) {
+			if (isDirectKittyContinuation(lines[index]!)) {
+				// Never surface a continuation whose placement was clipped away.
+				index++;
+				continue;
+			}
+			let end = index + 1;
+			if (isDirectKittyPlacement(lines[index]!)) {
+				while (end < lines.length && isDirectKittyContinuation(lines[end]!)) end++;
+				if (end - index !== getDirectKittyPlacementRows(lines[index]!)) {
+					index = end;
+					continue;
+				}
+			}
+			blocks.push(lines.slice(index, end));
+			index = end;
+		}
+
+		const selected: string[] = [];
+		let remaining = limit;
+		if (fromBottom) {
+			for (let index = blocks.length - 1; index >= 0 && remaining > 0; index--) {
+				const block = blocks[index]!;
+				if (block.length > remaining) continue;
+				selected.unshift(...block);
+				remaining -= block.length;
+			}
+		} else {
+			for (const block of blocks) {
+				if (remaining <= 0) break;
+				if (block.length > remaining) continue;
+				selected.push(...block);
+				remaining -= block.length;
+			}
+		}
+		return selected;
+	}
+
 	/**
 	 * Composite all visible overlays into the window slice (screen
 	 * coordinates, in stack order, later = on top). Overlays never touch the
@@ -2530,14 +2582,9 @@ export class TUI extends Container {
 			// Get layout with height=0 first to determine width and maxHeight
 			// (width and maxHeight don't depend on overlay height).
 			const { width, maxHeight } = this.#resolveOverlayLayout(options, 0, termWidth, termHeight);
-			let overlayLines = component.render(width);
-			if (overlayLines.length > maxHeight) {
-				const anchor = options?.anchor ?? "center";
-				overlayLines =
-					anchor === "bottom-left" || anchor === "bottom-center" || anchor === "bottom-right"
-						? overlayLines.slice(overlayLines.length - maxHeight)
-						: overlayLines.slice(0, maxHeight);
-			}
+			const anchor = options?.anchor ?? "center";
+			const fromBottom = anchor === "bottom-left" || anchor === "bottom-center" || anchor === "bottom-right";
+			const overlayLines = this.#clipOverlayLines(component.render(width), maxHeight, fromBottom);
 			const { row, col } = this.#resolveOverlayLayout(options, overlayLines.length, termWidth, termHeight);
 			for (let i = 0; i < overlayLines.length; i++) {
 				const idx = row + i;
@@ -2558,7 +2605,17 @@ export class TUI extends Container {
 		overlayWidth: number,
 		totalWidth: number,
 	): string {
-		if (TERMINAL.isImageLine(baseLine)) return baseLine;
+		const positionedDirectKittyPlacement = positionDirectKittyPlacement(overlayLine, startCol);
+		if (positionedDirectKittyPlacement !== null) return positionedDirectKittyPlacement;
+		const positionedDirectKittyContinuation = positionDirectKittyContinuation(overlayLine, startCol);
+		if (positionedDirectKittyContinuation !== null) return positionedDirectKittyContinuation;
+		if (
+			unwrapDirectKittyPlacement(baseLine) !== null ||
+			isDirectKittyContinuation(baseLine) ||
+			TERMINAL.isImageLine(baseLine)
+		) {
+			return baseLine;
+		}
 
 		// Single pass through baseLine extracts both before and after segments
 		const afterStart = startCol + overlayWidth;
@@ -2677,6 +2734,10 @@ export class TUI extends Container {
 	}
 
 	#terminalLine(line: string): string {
+		const directKittyPlacement = unwrapDirectKittyPlacement(line);
+		if (directKittyPlacement !== null) return directKittyPlacement;
+		const directKittyContinuation = unwrapDirectKittyContinuation(line);
+		if (directKittyContinuation !== null) return directKittyContinuation;
 		if (TERMINAL.isImageLine(line)) return line;
 		const coalesced = coalesceAdjacentSgr(line);
 		return coalesced + (line.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET);
@@ -3177,7 +3238,7 @@ export class TUI extends Container {
 	}
 
 	#prepareLine(raw: string, width: number): PreparedLine {
-		if (TERMINAL.isImageLine(raw)) {
+		if (unwrapDirectKittyPlacement(raw) !== null || isDirectKittyContinuation(raw) || TERMINAL.isImageLine(raw)) {
 			return { raw, width, line: raw };
 		}
 		const source = this.#lineFitSource(raw, width);
@@ -3329,6 +3390,10 @@ export class TUI extends Container {
 	}
 
 	#lineRewriteSequence(line: string, width: number): string {
+		const directKittyPlacement = unwrapDirectKittyPlacement(line);
+		if (directKittyPlacement !== null) return directKittyPlacement;
+		const directKittyContinuation = unwrapDirectKittyContinuation(line);
+		if (directKittyContinuation !== null) return directKittyContinuation;
 		if (TERMINAL.isImageLine(line)) return ERASE_LINE + line;
 		const terminalLine = this.#terminalLine(line);
 		const asciiWidth = this.#ansiAsciiLineWidth(line, width);

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { TUI } from "@oh-my-pi/pi-tui";
+import { Box } from "@oh-my-pi/pi-tui/components/box";
 import { Image, ImageBudget } from "@oh-my-pi/pi-tui/components/image";
+import { ScrollView } from "@oh-my-pi/pi-tui/components/scroll-view";
 import { Text } from "@oh-my-pi/pi-tui/components/text";
 import {
 	encodeKittyVirtualPlacement,
@@ -353,10 +355,10 @@ describe("Image budget integration", () => {
 		const lines = image.render(20);
 		budget.endPass();
 
-		const last = lines.at(-1) ?? "";
-		expect(last).toContain("\x1b_G");
-		expect(last).toContain(`i=${id}`);
-		expect(last).not.toContain("[Image:");
+		const placement = lines[0] ?? "";
+		expect(placement).toContain("\x1b_G");
+		expect(placement).toContain(`i=${id}`);
+		expect(placement).not.toContain("[Image:");
 	});
 
 	it("transmits the base64 once via the budget and renders only a placement line", () => {
@@ -379,10 +381,10 @@ describe("Image budget integration", () => {
 		expect(transmits[0]).toContain("\x1b_Ga=t");
 		expect(transmits[0]).toContain(`i=${id}`);
 		expect(transmits[0]).toContain(BASE64_ONE_PIXEL_PNG);
-		// The render line is a placement (`a=p`) without the base64.
-		const last = lines.at(-1) ?? "";
-		expect(last).toContain("\x1b_Ga=p");
-		expect(last).not.toContain(BASE64_ONE_PIXEL_PNG);
+		// The first render line is a placement (`a=p`) without the base64.
+		const placement = lines[0] ?? "";
+		expect(placement).toContain("\x1b_Ga=p");
+		expect(placement).not.toContain(BASE64_ONE_PIXEL_PNG);
 
 		// A second render (cache hit) does not re-enqueue the data.
 		budget.beginPass();
@@ -391,7 +393,7 @@ describe("Image budget integration", () => {
 		expect([...budget.takeTransmits()]).toEqual([]);
 	});
 
-	it("moves back up before multi-row direct Kitty placements and restores the cursor below them", () => {
+	it("places stable multi-row Kitty graphics before reserved rows so they survive scrollback", () => {
 		const budget = new ImageBudget(3, () => {});
 		const id = budget.acquireId("k");
 		const image = new Image(
@@ -406,16 +408,19 @@ describe("Image budget integration", () => {
 		const lines = image.render(20);
 		budget.endPass();
 
-		const last = lines.at(-1) ?? "";
+		const first = lines[0] ?? "";
+		const placementIndex = first.indexOf("\x1b_Ga=p");
 		expect(lines).toHaveLength(4);
-		expect(lines.slice(0, -1)).toEqual(["\x1b[0m", "\x1b[0m", "\x1b[0m"]);
-		expect(last.startsWith("\x1b7\x1b[3A")).toBe(true);
-		expect(last.endsWith("\x1b8")).toBe(true);
-		expect(last).toContain("\x1b_Ga=p");
-		expect(last).toContain("C=1");
-		expect(last).toContain(`i=${id}`);
-		expect(last).toContain("c=4");
-		expect(last).toContain("r=4");
+		expect(placementIndex).toBeGreaterThan(-1);
+		const beforePlacement = first.slice(0, placementIndex);
+		expect(beforePlacement.match(/\x1b\[2K/g) ?? []).toHaveLength(4);
+		expect(beforePlacement.match(/\r\n/g) ?? []).toHaveLength(3);
+		expect(beforePlacement.indexOf("\x1b[3A")).toBeGreaterThan(beforePlacement.lastIndexOf("\r\n"));
+		expect(lines.slice(1).every(line => !line.includes("\x1b_G") && !line.includes("\x1b[K"))).toBe(true);
+		expect(first).toContain("C=1");
+		expect(first).toContain(`i=${id}`);
+		expect(first).toContain("c=4");
+		expect(first).toContain("r=4");
 	});
 
 	it("does not move the cursor around single-row direct Kitty placements", () => {
@@ -472,7 +477,7 @@ describe("Image budget integration", () => {
 
 		expect(olderLines.join("")).toContain("[Image:");
 		expect(olderLines.join("")).not.toContain("\x1b_G");
-		expect(newerLines.at(-1) ?? "").toContain("\x1b_G");
+		expect(newerLines[0] ?? "").toContain("\x1b_G");
 	});
 });
 
@@ -596,7 +601,7 @@ describe("TUI inline-image budget", () => {
 		);
 	}
 
-	it("renders following text below a multi-row direct Kitty placement", async () => {
+	it("advances every reserved row after placing a direct Kitty image", async () => {
 		const originalGraphics = { ...getKittyGraphics() };
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];
@@ -624,12 +629,324 @@ describe("TUI inline-image budget", () => {
 			await settle(term);
 
 			const output = writes.join("");
-			expect(output).toContain("\x1b7\x1b[3A");
-			expect(output).toContain("C=1");
-			expect(output).toContain("\x1b8");
+			const placementStart = output.indexOf("\x1b_Ga=p");
+			const placementEnd = output.indexOf("\x1b\\", placementStart) + 2;
+			const textStart = output.indexOf("after-image", placementEnd);
+			const afterPlacement = output.slice(placementEnd, textStart);
+			expect(placementStart).toBeGreaterThan(-1);
+			expect(placementEnd).toBeGreaterThan(placementStart);
+			expect(textStart).toBeGreaterThan(placementEnd);
+			expect(afterPlacement.match(/\r\n/g) ?? []).toHaveLength(4);
+			expect(afterPlacement).not.toContain("\x1b[K");
+			expect(afterPlacement).not.toContain("\x1b[2K");
+			expect(output.slice(0, placementStart)).toContain("\x1b[2K");
+			expect(output).not.toContain("pi:img:");
 			const viewport = term.getViewport().map(line => line.trimEnd());
 			expect(viewport.slice(0, 5)).toEqual(["", "", "", "", "after-image"]);
 			expect(viewport.slice(0, 4).some(line => line.includes("after-image"))).toBe(false);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("keeps sequential direct Kitty image blocks and following text aligned", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 16);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.addChild(
+			new Image(
+				BASE64_ONE_PIXEL_PNG,
+				"image/png",
+				{ fallbackColor: t => t },
+				{ maxWidthCells: 4, maxHeightCells: 4, budget: tui.imageBudget, imageKey: "first-direct" },
+				{ widthPx: 40, heightPx: 20 },
+			),
+		);
+		tui.addChild(new Text("between-images", 0, 0));
+		tui.addChild(
+			new Image(
+				BASE64_ONE_PIXEL_PNG,
+				"image/png",
+				{ fallbackColor: t => t },
+				{ maxWidthCells: 4, maxHeightCells: 4, budget: tui.imageBudget, imageKey: "second-direct" },
+				{ widthPx: 40, heightPx: 30 },
+			),
+		);
+		tui.addChild(new Text("after-images", 0, 0));
+
+		try {
+			tui.start();
+			await settle(term);
+
+			const output = writes.join("");
+			const firstPlacement = output.indexOf("\x1b_Ga=p");
+			const firstPlacementEnd = output.indexOf("\x1b\\", firstPlacement) + 2;
+			const betweenText = output.indexOf("between-images", firstPlacementEnd);
+			const secondPlacement = output.indexOf("\x1b_Ga=p", betweenText);
+			const secondPlacementEnd = output.indexOf("\x1b\\", secondPlacement) + 2;
+			const afterText = output.indexOf("after-images", secondPlacementEnd);
+			expect(firstPlacement).toBeGreaterThan(-1);
+			expect(firstPlacementEnd).toBeGreaterThan(firstPlacement);
+			expect(betweenText).toBeGreaterThan(firstPlacementEnd);
+			expect(secondPlacement).toBeGreaterThan(betweenText);
+			expect(secondPlacementEnd).toBeGreaterThan(secondPlacement);
+			expect(afterText).toBeGreaterThan(secondPlacementEnd);
+			expect(output.slice(firstPlacementEnd, betweenText)).not.toContain("\x1b[K");
+			expect(output.slice(firstPlacementEnd, betweenText)).not.toContain("\x1b[2K");
+			expect(output.slice(secondPlacementEnd, afterText)).not.toContain("\x1b[K");
+			expect(output.slice(secondPlacementEnd, afterText)).not.toContain("\x1b[2K");
+			expect(output).not.toContain("pi:img:");
+			const viewport = term.getViewport().map(line => line.trimEnd());
+			expect(viewport.slice(0, 7)).toEqual(["", "", "between-images", "", "", "", "after-images"]);
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("does not composite overlays into protected direct Kitty rows", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		tui.addChild(
+			new Image(
+				BASE64_ONE_PIXEL_PNG,
+				"image/png",
+				{ fallbackColor: t => t },
+				{ maxWidthCells: 4, maxHeightCells: 4, budget: tui.imageBudget, imageKey: "overlay-direct" },
+				{ widthPx: 40, heightPx: 40 },
+			),
+		);
+		tui.addChild(new Text("after-overlay-image", 0, 0));
+		tui.showOverlay(
+			{
+				invalidate() {},
+				render: () => ["overlay-row-0", "overlay-row-1"],
+			},
+			{ row: 0, col: 0, width: 14 },
+		);
+
+		try {
+			tui.start();
+			await settle(term);
+
+			const output = writes.join("");
+			const placementStart = output.indexOf("\x1b_Ga=p");
+			const placementEnd = output.indexOf("\x1b\\", placementStart) + 2;
+			const textStart = output.indexOf("after-overlay-image", placementEnd);
+			expect(placementStart).toBeGreaterThan(-1);
+			expect(placementEnd).toBeGreaterThan(placementStart);
+			expect(textStart).toBeGreaterThan(placementEnd);
+			expect(output).not.toContain("overlay-row-");
+			expect(output).not.toContain("pi:img:");
+			expect(output.slice(placementEnd, textStart)).not.toContain("\x1b[K");
+			expect(output.slice(placementEnd, textStart)).not.toContain("\x1b[2K");
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("omits direct Kitty blocks that exceed an overlay maxHeight", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+			tui.showOverlay(
+				new Image(
+					BASE64_ONE_PIXEL_PNG,
+					"image/png",
+					{ fallbackColor: t => t },
+					{ maxWidthCells: 4, maxHeightCells: 4 },
+					{ widthPx: 40, heightPx: 40 },
+				),
+				{ row: 0, col: 0, width: 10, maxHeight: 2, margin: 0 },
+			);
+			await settle(term);
+
+			const output = writes.join("");
+			expect(output).not.toContain("\x1b_Ga=T");
+			expect(output).not.toContain("pi:img:");
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("preserves the requested column for a direct Kitty image overlay", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+			tui.showOverlay(
+				new Image(
+					BASE64_ONE_PIXEL_PNG,
+					"image/png",
+					{ fallbackColor: t => t },
+					{ maxWidthCells: 4, maxHeightCells: 4, budget: tui.imageBudget, imageKey: "positioned-direct" },
+					{ widthPx: 40, heightPx: 40 },
+				),
+				{ row: 0, col: 6, width: 4 },
+			);
+			await settle(term);
+
+			const output = writes.join("");
+			const placementStart = output.indexOf("\x1b_Ga=p");
+			expect(placementStart).toBeGreaterThan(-1);
+			expect(output.slice(0, placementStart).endsWith("\x1b[7G")).toBe(true);
+			expect(output).not.toContain("pi:img:");
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("preserves direct Kitty rows inside a scrolling fullscreen overlay", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+			const image = new Image(
+				BASE64_ONE_PIXEL_PNG,
+				"image/png",
+				{ fallbackColor: t => t },
+				{ maxWidthCells: 4, maxHeightCells: 4, budget: tui.imageBudget, imageKey: "fullscreen-direct" },
+				{ widthPx: 40, heightPx: 40 },
+			);
+			tui.imageBudget.beginPass();
+			const imageRows = image.render(40);
+			tui.imageBudget.endPass();
+			tui.showOverlay(new ScrollView([...imageRows, "viewer-tail"], { height: 6, scrollbar: "always" }), {
+				fullscreen: true,
+				width: "100%",
+				maxHeight: "100%",
+				margin: 0,
+			});
+			await settle(term);
+
+			const output = writes.join("");
+			const placementStart = output.indexOf("\x1b_Ga=p");
+			const placementEnd = output.indexOf("\x1b\\", placementStart) + 2;
+			expect(output).toContain("\x1b[?1049h");
+			expect(placementStart).toBeGreaterThan(-1);
+			expect(placementEnd).toBeGreaterThan(placementStart);
+			expect(output).not.toContain("pi:img:");
+			const afterPlacement = output.slice(placementEnd);
+			const firstUnprotectedNewline = [...afterPlacement.matchAll(/\r\n/g)][imageRows.length - 1]?.index ?? -1;
+			expect(firstUnprotectedNewline).toBeGreaterThan(-1);
+			expect(afterPlacement.slice(0, firstUnprotectedNewline)).not.toContain("\x1b[K");
+			expect(afterPlacement.slice(0, firstUnprotectedNewline)).not.toContain("\x1b[2K");
+		} finally {
+			tui.stop();
+			setKittyGraphics(originalGraphics);
+		}
+	});
+
+	it("preserves Box wrappers on protected direct Kitty rows", async () => {
+		const originalGraphics = { ...getKittyGraphics() };
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		setKittyGraphics({ unicodePlaceholders: false });
+		const tui = new TUI(term);
+		const box = new Box(2, 0, text => `\x1b[41m${text}\x1b[0m`, {
+			chars: {
+				topLeft: "+",
+				topRight: "+",
+				bottomLeft: "+",
+				bottomRight: "+",
+				horizontal: "-",
+				vertical: "|",
+			},
+		});
+		box.setIgnoreTight(true);
+		box.addChild(
+			new Image(
+				BASE64_ONE_PIXEL_PNG,
+				"image/png",
+				{ fallbackColor: t => t },
+				{ maxWidthCells: 3, maxHeightCells: 3 },
+				{ widthPx: 30, heightPx: 30 },
+			),
+		);
+		tui.addChild(box);
+
+		try {
+			tui.start();
+			await settle(term);
+
+			const output = writes.join("");
+			const placementStart = output.indexOf("\x1b_Ga=T");
+			const placementEnd = output.indexOf("\x1b\\", placementStart) + 2;
+			const bottomBorderStart = output.indexOf("+", placementEnd);
+			expect(placementStart).toBeGreaterThan(-1);
+			expect(placementEnd).toBeGreaterThan(placementStart);
+			expect(bottomBorderStart).toBeGreaterThan(placementEnd);
+			expect(output.slice(0, placementStart).endsWith("\x1b[4G")).toBe(true);
+			const lastErase = output.lastIndexOf("\x1b[2K", placementStart);
+			const backgroundStart = output.lastIndexOf("\x1b[41m", placementStart);
+			expect(lastErase).toBeGreaterThan(-1);
+			expect(backgroundStart).toBeGreaterThan(lastErase);
+			const protectedBlock = output.slice(placementEnd, bottomBorderStart);
+			expect(protectedBlock.match(/\x1b\[3C/g) ?? []).toHaveLength(3);
+			expect(protectedBlock.match(/\|/g) ?? []).toHaveLength(5);
+			expect(protectedBlock).not.toContain("\x1b[K");
+			expect(protectedBlock).not.toContain("\x1b[2K");
+			expect(output).not.toContain("pi:img:");
 		} finally {
 			tui.stop();
 			setKittyGraphics(originalGraphics);

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { Image, ImageBudget } from "@oh-my-pi/pi-tui/components/image";
+import { Box } from "@oh-my-pi/pi-tui/components/box";
+import {
+	Image,
+	ImageBudget,
+	isDirectKittyContinuation,
+	positionDirectKittyContinuation,
+	positionDirectKittyPlacement,
+	unwrapDirectKittyContinuation,
+	unwrapDirectKittyPlacement,
+} from "@oh-my-pi/pi-tui/components/image";
 import { getKittyGraphics, setKittyGraphics } from "@oh-my-pi/pi-tui/kitty-graphics";
 import {
 	type CellDimensions,
@@ -187,7 +196,7 @@ describe("terminal image rendering", () => {
 		expect((result?.sequence ?? "").startsWith("\x1bP")).toBe(true);
 	});
 
-	it("moves back up before multi-row direct Kitty output and restores the cursor below it", () => {
+	it("places multi-row direct Kitty output before reserved rows so it survives scrollback", () => {
 		terminal.imageProtocol = ImageProtocol.Kitty;
 		const image = new Image(
 			BASE64_DUMMY,
@@ -198,16 +207,70 @@ describe("terminal image rendering", () => {
 		);
 
 		const lines = image.render(20);
-		const imageLine = lines.at(-1) ?? "";
+		const imageLine = lines[0] ?? "";
+		const placementIndex = imageLine.indexOf("\x1b_Ga=T");
 
 		expect(lines).toHaveLength(3);
-		expect(lines.slice(0, -1)).toEqual(["\x1b[0m", "\x1b[0m"]);
-		expect(imageLine.startsWith("\x1b7\x1b[2A")).toBe(true);
-		expect(imageLine).toContain("\x1b_Ga=T");
+		expect(placementIndex).toBeGreaterThan(-1);
+		const beforePlacement = imageLine.slice(0, placementIndex);
+		expect(beforePlacement.match(/\x1b\[2K/g) ?? []).toHaveLength(3);
+		expect(beforePlacement.match(/\r\n/g) ?? []).toHaveLength(2);
+		expect(beforePlacement.indexOf("\x1b[2A")).toBeGreaterThan(beforePlacement.lastIndexOf("\r\n"));
+		expect(lines.slice(1).every(line => !line.includes("\x1b_G") && !line.includes("\x1b[K"))).toBe(true);
 		expect(imageLine).toContain("C=1");
 		expect(imageLine).toContain("c=3");
 		expect(imageLine).toContain("r=3");
-		expect(imageLine.endsWith("\x1b8")).toBe(true);
+	});
+
+	it("preserves Box padding and borders around direct Kitty image rows", () => {
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		const image = new Image(
+			BASE64_DUMMY,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 10, maxHeightCells: 3 },
+			SQUARE_DIMENSIONS,
+		);
+		const box = new Box(2, 0, undefined, {
+			chars: {
+				topLeft: "+",
+				topRight: "+",
+				bottomLeft: "+",
+				bottomRight: "+",
+				horizontal: "-",
+				vertical: "|",
+			},
+		});
+		box.setIgnoreTight(true);
+		box.addChild(image);
+
+		const rows = box.render(20);
+		const placement = unwrapDirectKittyPlacement(rows[1] ?? "");
+		const continuation = unwrapDirectKittyContinuation(rows[2] ?? "");
+		const positionedPlacement = unwrapDirectKittyPlacement(positionDirectKittyPlacement(rows[1] ?? "", 5) ?? "");
+		const positionedContinuation = unwrapDirectKittyContinuation(
+			positionDirectKittyContinuation(rows[2] ?? "", 5) ?? "",
+		);
+
+		expect(rows).toHaveLength(5);
+		expect(placement).not.toBeNull();
+		expect(placement).toStartWith("\x1b[0m\x1b[2K");
+		expect((placement ?? "").indexOf("|  ")).toBeGreaterThan((placement ?? "").lastIndexOf("\x1b[2K"));
+		expect(placement).toContain("\x1b[4G\x1b_G");
+		expect(placement).toEndWith("|");
+		expect(continuation).not.toBeNull();
+		expect(continuation).toStartWith("|  ");
+		expect(continuation).toContain("\x1b[3C");
+		expect(continuation).toEndWith("|");
+		expect(positionedPlacement).toStartWith("\x1b[0m\x1b[2K");
+		expect(positionedPlacement).toContain("\x1b[6G|  ");
+		expect(positionedPlacement).toContain("\x1b[9G\x1b_G");
+		expect(positionedContinuation).toStartWith("\x1b[6G|  ");
+		expect(positionedContinuation).toContain("\x1b[3C");
+	});
+	it("does not treat marker-shaped external text as internal direct Kitty rows", () => {
+		expect(unwrapDirectKittyPlacement("\x1b]pi:img:p\x07untrusted")).toBeNull();
+		expect(isDirectKittyContinuation("\x1b]pi:img:c\x07")).toBe(false);
 	});
 
 	it("does not emit cursor movement around single-row direct Kitty output", () => {

--- a/packages/tui/test/scroll-view.test.ts
+++ b/packages/tui/test/scroll-view.test.ts
@@ -1,11 +1,42 @@
 import { describe, expect, it } from "bun:test";
+import { Image, isDirectKittyContinuation, unwrapDirectKittyPlacement } from "@oh-my-pi/pi-tui/components/image";
 import { ScrollView } from "@oh-my-pi/pi-tui/components/scroll-view";
+import { getKittyGraphics, setKittyGraphics } from "@oh-my-pi/pi-tui/kitty-graphics";
+import {
+	getCellDimensions,
+	ImageProtocol,
+	setCellDimensions,
+	setTerminalImageProtocol,
+	TERMINAL,
+} from "@oh-my-pi/pi-tui/terminal-capabilities";
 import { Ellipsis, visibleWidth } from "@oh-my-pi/pi-tui/utils";
 
 const theme = {
 	track: () => "T",
 	thumb: () => "B",
 };
+
+function directImageRows(rows: number): readonly string[] {
+	const originalProtocol = TERMINAL.imageProtocol;
+	const originalGraphics = { ...getKittyGraphics() };
+	const originalCellDimensions = { ...getCellDimensions() };
+	try {
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		setKittyGraphics({ unicodePlaceholders: false });
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		return new Image(
+			"AA==",
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: rows, maxHeightCells: rows },
+			{ widthPx: rows * 10, heightPx: rows * 10 },
+		).render(20);
+	} finally {
+		setTerminalImageProtocol(originalProtocol);
+		setKittyGraphics(originalGraphics);
+		setCellDimensions(originalCellDimensions);
+	}
+}
 
 describe("ScrollView", () => {
 	it("renders a fixed-height viewport and omits auto scrollbar when content fits", () => {
@@ -99,5 +130,49 @@ describe("ScrollView", () => {
 		expect(view.handleScrollKey("\x1b[1;2A")).toBe(true); // shift+up
 		expect(view.getScrollOffset()).toBe(1);
 		expect(view.handleScrollKey("x")).toBe(false);
+	});
+	it("keeps protected image markers recognizable with an always-visible scrollbar", () => {
+		const imageRows = directImageRows(4);
+		const view = new ScrollView([...imageRows, "tail"], { height: 4, scrollbar: "always", theme });
+
+		const rendered = view.render(20);
+
+		expect(unwrapDirectKittyPlacement(rendered[0] ?? "")).not.toBeNull();
+		expect(rendered.slice(1).every(isDirectKittyContinuation)).toBe(true);
+	});
+
+	it("skips orphaned continuation rows when the viewport starts inside an image", () => {
+		const imageRows = directImageRows(4);
+		const view = new ScrollView(["before", ...imageRows, "after-a", "after-b"], {
+			height: 3,
+			scrollbar: "never",
+			theme,
+		});
+		view.setScrollOffset(2);
+
+		expect(view.render(20)).toEqual(["after-a", "after-b", ""]);
+	});
+
+	it("does not start an image block that cannot fit in the remaining viewport", () => {
+		const imageRows = directImageRows(4);
+		const view = new ScrollView(["top-a", "top-b", ...imageRows, "after"], {
+			height: 4,
+			scrollbar: "never",
+			theme,
+		});
+
+		expect(view.render(20)).toEqual(["top-a", "top-b", "after", ""]);
+	});
+
+	it("omits a pre-windowed image truncated at the window end", () => {
+		const imageRows = directImageRows(4);
+		const view = new ScrollView(imageRows.slice(0, 2), {
+			height: 2,
+			scrollbar: "never",
+			totalRows: 4,
+			theme,
+		});
+
+		expect(view.render(20)).toEqual(["", ""]);
 	});
 });


### PR DESCRIPTION
## What

- Place multi-row direct Kitty images on their first logical row after pre-reserving the full cell block.
- Protect continuation rows from destructive line erases while preserving Box padding, borders, backgrounds, and overlay offsets.
- Treat direct image blocks atomically when overlays or pre-windowed `ScrollView` content clip vertically.
- Carry capability-framed dimensions through the renderer so internal image rows cannot be mistaken for user text or emitted partially.
- Add focused coverage for sequential images, scrollback, overlays, fullscreen viewers, Box wrappers, and partial viewports.

## Why

WezTerm clips a Kitty placement whose logical origin has already scrolled above the viewport. The previous last-row placement could therefore render only a slice—or nothing—and later `EL` rewrites detached the image from its cells. Screenshots were visibly cut off both in the live OMP transcript and after scrolling through native terminal history.

## Testing

- [x] `bun run check`
- [x] `bun --cwd=packages/tui run test` — 1,304 passed, 0 failed
- [x] 69 focused image, overlay, Box, and `ScrollView` regressions
- [x] WezTerm 20240203 multi-image live-view and Shift+PageUp scrollback probes
- [x] End-to-end `ProcessTerminal` + `TUI` + `Box` probe with padding and every border row intact

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (release tooling generates changelog entries)
