### PR TITLE
fix(bash): drain piped output before timeout return

### DIFF
--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -558,4 +558,31 @@ mod tests {
 			.expect("shell run should return");
 		assert!(result.cancelled);
 	}
+
+	#[tokio::test(flavor = "multi_thread")]
+	async fn timeout_drains_pipeline_output_before_stopping_reader() {
+		let shell = CoreShell::new(None);
+		let (tx, rx) = flume::unbounded::<String>();
+		let result = shell
+			.run(
+				CoreShellRunOptions {
+					command:    "yes x | tail -5".to_string(),
+					cwd:        None,
+					env:        None,
+					timeout_ms: Some(50),
+				},
+				Some(tx),
+				CancelToken::new(Some(50)),
+			)
+			.await
+			.expect("shell run");
+
+		let mut output = String::new();
+		while let Ok(chunk) = rx.recv_async().await {
+			output.push_str(&chunk);
+		}
+
+		assert!(result.timed_out);
+		assert_eq!(output.lines().filter(|line| *line == "x").count(), 5);
+	}
 }

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -1141,11 +1141,16 @@ async fn run_shell_command_once(
 			}
 		}
 	});
+	// Let pipeline consumers flush output after cancellation kills their
+	// producers. The outer run cancellation remains bounded, and this delayed
+	// fallback still releases readers whose writers never close.
+	const CANCEL_READER_GRACE: Duration = Duration::from_millis(500);
 	let cancel_bridge = tokio::spawn({
 		let cancel_token = cancel_token.clone();
 		let reader_cancel = reader_cancel.clone();
 		async move {
 			cancel_token.cancelled().await;
+			time::sleep(CANCEL_READER_GRACE).await;
 			reader_cancel.cancel();
 		}
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Updated status event log to prioritize the most recent entries in the display window
 
+### Fixed
+
+- Fixed Windows bash crashes when a piped command times out while flushing output; explicit-timeout watchdogs now wait for bounded native teardown instead of returning mid-drain. ([#5316](https://github.com/can1357/oh-my-pi/issues/5316))
+
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -70,6 +70,9 @@ const shellSessionsInUse = new Set<string>();
  */
 const retainedShells = new Set<Shell>();
 const RETAIN_REAP_INTERVAL_MS = 5_000;
+// Native cancellation may spend two seconds unwinding the shell before its
+// N-API chunk bridge drains. The JS watchdog must not race that teardown.
+const NATIVE_TIMEOUT_FALLBACK_GRACE_MS = 5_000;
 
 async function retainShellWithLiveBackgroundJobs(shell: Shell): Promise<void> {
 	let live: number;
@@ -302,16 +305,18 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 	const nativeTimeoutMs = requestedTimeoutMs !== undefined && requestedTimeoutMs > 0 ? requestedTimeoutMs : undefined;
 	const nativeOwnsTimeout = nativeTimeoutMs !== undefined;
 	if (deadlineTimeoutMs !== undefined) {
+		const fallbackTimeoutMs = nativeOwnsTimeout
+			? deadlineTimeoutMs + NATIVE_TIMEOUT_FALLBACK_GRACE_MS
+			: deadlineTimeoutMs;
 		timeoutTimer = setTimeout(() => {
-			// Explicit timeouts are already enforced inside pi-natives via
-			// `timeoutMs`. Do not also abort the JS AbortSignal here: on Windows,
-			// aborting that signal while a piped command is still forwarding output
-			// can terminate the Bun host before the native timeout result resolves.
+			// Explicit timeouts are enforced inside pi-natives via `timeoutMs`.
+			// Give native cancellation time to flush pipeline output and drain the
+			// N-API bridge before this result-only watchdog quarantines the run.
 			if (!nativeOwnsTimeout) {
 				abortCurrentExecution();
 			}
 			timeoutDeferred.resolve("timeout");
-		}, deadlineTimeoutMs);
+		}, fallbackTimeoutMs);
 	}
 
 	let resetSession = false;

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -520,18 +520,53 @@ exit 64
 		expect(next.output.trim()).toBe("still_persistent");
 	});
 
-	it("does not abort the native signal when the JavaScript timeout fallback returns streamed output", async () => {
-		// Compress the JS-side fallback timer (floored at 1000ms in the source) so
-		// the safety-net fires deterministically without a real 1s wait. Only long
-		// timers are shrunk — fs/subprocess setup keeps real scheduling — and the
-		// reported "1 seconds" derives from the configured timeout, not the timer.
+	it("waits for native timeout teardown to flush piped output", async () => {
 		const realSetTimeout = globalThis.setTimeout;
 		vi.spyOn(globalThis, "setTimeout").mockImplementation(((handler: () => void, ms?: number, ...rest: unknown[]) =>
 			realSetTimeout(
 				handler,
-				typeof ms === "number" && ms >= 1000 ? 5 : ms,
+				ms === 1000 ? 5 : typeof ms === "number" && ms > 1000 ? 50 : ms,
 				...rest,
 			)) as typeof globalThis.setTimeout);
+
+		let nativeSignal: AbortSignal | undefined;
+		vi.spyOn(piNatives.Shell.prototype, "run").mockImplementation((options, onChunk) => {
+			if (options.signal instanceof AbortSignal) {
+				nativeSignal = options.signal;
+			}
+			const nativeResult = Promise.withResolvers<piNatives.ShellRunResult>();
+			realSetTimeout(() => {
+				onChunk?.(null, "flushed-during-timeout\n");
+				nativeResult.resolve({ exitCode: undefined, cancelled: false, timedOut: true });
+			}, 20);
+			return nativeResult.promise;
+		});
+		const abortSpy = vi.spyOn(piNatives.Shell.prototype, "abort").mockResolvedValue();
+
+		const result = await executeBash("producer | tail -5", {
+			cwd: tempDir,
+			timeout: 1000,
+			sessionKey: "native-timeout-flushes-pipeline",
+		});
+
+		expect(result.cancelled).toBe(true);
+		expect(result.output).toContain("flushed-during-timeout");
+		expect(result.output).toContain("Command timed out after 1 seconds");
+		expect(nativeSignal).toBeDefined();
+		expect(nativeSignal?.aborted).toBe(false);
+		expect(abortSpy).not.toHaveBeenCalled();
+	});
+
+	it("keeps a delayed JavaScript fallback for stalled native timeout cleanup", async () => {
+		const realSetTimeout = globalThis.setTimeout;
+		let fallbackDelayMs = 0;
+		vi.spyOn(globalThis, "setTimeout").mockImplementation(((handler: () => void, ms?: number, ...rest: unknown[]) => {
+			if (typeof ms === "number" && ms >= 1000) {
+				fallbackDelayMs = Math.max(fallbackDelayMs, ms);
+				return realSetTimeout(handler, 5, ...rest);
+			}
+			return realSetTimeout(handler, ms, ...rest);
+		}) as typeof globalThis.setTimeout);
 
 		let nativeSignal: AbortSignal | undefined;
 		vi.spyOn(piNatives.Shell.prototype, "run").mockImplementation((options, onChunk) => {
@@ -552,6 +587,7 @@ exit 64
 		expect(result.cancelled).toBe(true);
 		expect(result.output).toContain("streamed-before-timeout");
 		expect(result.output).toContain("Command timed out after 1 seconds");
+		expect(fallbackDelayMs).toBeGreaterThan(1000);
 		expect(nativeSignal).toBeDefined();
 		expect(nativeSignal?.aborted).toBe(false);
 		expect(abortSpy).not.toHaveBeenCalled();

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed timed-out shell pipelines cancelling their output reader while the final stage was still flushing, which dropped captured output and could terminate Windows hosts during teardown. ([#5316](https://github.com/can1357/oh-my-pi/issues/5316))
+
 ## [16.4.6] - 2026-07-12
 
 ### Added


### PR DESCRIPTION
## Repro
The reported command, `python -c "import time; [print('x'*100) or time.sleep(0.05) for _ in range(1000)]" 2>&1 | tail -5`, with bash `timeout=2` exited omp on native Windows. The same command through `executeBash` on Linux reproduced the shared teardown race: it returned after ~2.02s with only `[Command timed out after 2 seconds]`, dropping all five lines retained by `tail`.

## Cause
`run_shell_command_once` in `crates/pi-shell/src/shell.rs` cancelled its output reader immediately when timeout cancellation began, while process termination and the final pipeline stage were still unwinding. At the same deadline, `executeBash` in `packages/coding-agent/src/exec/bash-executor.ts` let its JavaScript fallback beat native cleanup and quarantine the live run. This closed/abandoned capture while `tail` was flushing timeout-time output—the Windows teardown hazard left after #5023.

## Fix
- Give native pipeline consumers a bounded 500ms drain window before the reader-cancellation fallback fires.
- Move the JavaScript result watchdog behind native shell cancellation and N-API bridge cleanup while retaining a delayed fallback for stalled native cleanup.
- Add native pipeline-drain and executor timeout-ordering regressions.
- Document the fix in the coding-agent and natives changelogs.

## Verification
`cargo test -p pi-natives shell::tests` passed (11 tests). `bun test packages/coding-agent/test/bash-executor.test.ts` passed (39 tests). `bun run build:native` succeeded. After rebuilding the addon, the exact repro returned in ~2.10s, kept omp alive, and captured the five `tail` lines plus the timeout annotation. `bun run fix` passed; the push/open pre-publish gates also passed. Fixes #5316