### PR TITLE
fix(session): honor quiet startup for xdev mount notices

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `startup.quiet` still rendering the `xdev: xd://: mounted …` status line when MCP tools connect; quiet startup now suppresses only the user-visible mount notice while retaining the hidden model-facing device update ([#5670](https://github.com/can1357/oh-my-pi/issues/5670)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6825,6 +6825,7 @@ export class AgentSession {
 			display: false,
 			timestamp: Date.now(),
 		});
+		if (this.settings.get("startup.quiet")) return;
 		const parts: string[] = [];
 		if (added.length > 0) parts.push(`mounted ${added.map(entry => entry.name).join(", ")}`);
 		if (removed.length > 0) parts.push(`unmounted ${removed.map(entry => entry.name).join(", ")}`);

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -549,4 +549,25 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(rebuildCount).toBe(1);
 		expect(noticeTexts().length).toBe(noticeCount);
 	});
+
+	it("keeps xd:// mount deltas model-visible without rendering them during quiet startup", async () => {
+		const { session } = newSession(async toolNames => `tools:${toolNames.join(",")}`, {
+			xdevRegistry: new XdevRegistry([]),
+		});
+		session.settings.set("startup.quiet", true);
+		const notices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "xdev") notices.push(event.message);
+		});
+
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		await session.refreshMCPTools([search]);
+
+		expect(notices).toEqual([]);
+		expect(
+			session.agent
+				.peekSteeringQueue()
+				.some(message => message.role === "custom" && message.customType === "xdev-mount-notice"),
+		).toBe(true);
+	});
 });


### PR DESCRIPTION
## Repro
With `startup.quiet=true`, mounting one MCP tool through `AgentSession.refreshMCPTools()` still emitted `xd://: mounted mcp__nucleus_search`. Reproduced with `cd packages/coding-agent && bun test test/agent-session-tool-rebuild-skip.test.ts`; before the fix, the new quiet-startup assertion failed with 14 passing tests and 1 failure.

## Cause
`AgentSession.#notifyXdevMountDelta()` in `packages/coding-agent/src/session/agent-session.ts` unconditionally emitted the user-visible `xdev` notice after steering the model-facing mount delta. This event path bypassed the existing `startup.quiet` guards used by MCP/LSP startup status handlers.

## Fix
- Keep the hidden `xdev-mount-notice` steering message unconditional so the model learns about mounted devices.
- Return before emitting the user-visible mount status when `startup.quiet` is enabled.
- Add regression coverage proving quiet mode suppresses the UI notice without suppressing model steering, plus an Unreleased changelog entry.

## Verification
`cd packages/coding-agent && bun test test/agent-session-tool-rebuild-skip.test.ts` — 15 passed, 0 failed, 53 expectations. `cd packages/coding-agent && bun check` — passed. The publish gate also completed `bun run fix` and `bun check` successfully. Fixes #5670