### PR TITLE
fix(ai): keep literal think tags inside markdown code visible

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Automatically invalidate and rotate OAuth credentials when an "invalidated oauth token" error occurs
+- Fixed leaked-thinking healing consuming a literal reasoning tag (e.g. `` `<think>` ``) inside a Markdown inline-code span or fenced code block as a reasoning boundary, which split the visible text into `text` + `thinking` blocks and corrupted the rendered Markdown ([#5665](https://github.com/can1357/oh-my-pi/issues/5665)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/ai/src/dialect/thinking.ts
+++ b/packages/ai/src/dialect/thinking.ts
@@ -32,8 +32,12 @@ export class ThinkingInbandScanner implements InbandScanner {
 	#thinking = "";
 	/** Fence-aware close-matcher while inside a ` ```thinking ` block; undefined otherwise. */
 	#fenced: FencedThinkingScanner | undefined;
-	/** Backtick count that closes the Markdown code span/fence we are inside; 0 when not in code. */
+	/** Backtick count that opened the Markdown code span/fence we are inside; 0 when not in code. */
 	#codeTicks = 0;
+	/** True when {@link #codeTicks} opened a fenced block (closes on a fence line), not an inline span. */
+	#codeFenced = false;
+	/** Last visible character emitted; `\n` initially so a leading fence is recognized at line start. */
+	#prevChar = "\n";
 
 	feed(text: string): InbandScanEvent[] {
 		if (text.length === 0) return [];
@@ -89,41 +93,27 @@ export class ThinkingInbandScanner implements InbandScanner {
 				continue;
 			}
 			if (this.#codeTicks > 0) {
-				// Inside a Markdown code span/fence: pass text through verbatim and
-				// suppress reasoning-tag detection until the closing backtick run.
-				const close = findBacktickRun(this.#buffer, 0, this.#codeTicks);
-				if (close !== -1 && (final || close + this.#codeTicks < this.#buffer.length)) {
-					const end = close + this.#codeTicks;
-					events.push({ type: "text", text: this.#buffer.slice(0, end) });
-					this.#buffer = this.#buffer.slice(end);
-					this.#codeTicks = 0;
-					continue;
-				}
-				// No committed close yet: emit text, holding a trailing backtick run
-				// (it may still grow into — or past — the closing delimiter).
-				const hold = final ? 0 : trailingBacktickRun(this.#buffer);
-				const emit = this.#buffer.slice(0, this.#buffer.length - hold);
-				if (emit.length > 0) events.push({ type: "text", text: emit });
-				this.#buffer = this.#buffer.slice(this.#buffer.length - hold);
-				if (final) this.#codeTicks = 0;
+				if (this.#emitCode(final, events)) continue;
 				break;
 			}
 
 			const hit = scanVisible(this.#buffer, final);
 			if (hit.kind === "none") {
-				events.push({ type: "text", text: this.#buffer });
+				this.#emitText(this.#buffer, events);
 				this.#buffer = "";
 				break;
 			}
-			if (hit.index > 0) events.push({ type: "text", text: this.#buffer.slice(0, hit.index) });
+			if (hit.index > 0) this.#emitText(this.#buffer.slice(0, hit.index), events);
 			if (hit.kind === "hold") {
 				this.#buffer = this.#buffer.slice(hit.index);
 				break;
 			}
 			if (hit.kind === "code") {
-				events.push({ type: "text", text: this.#buffer.slice(hit.index, hit.index + hit.ticks) });
+				const atLineStart = this.#prevChar === "\n";
+				this.#emitText(this.#buffer.slice(hit.index, hit.index + hit.ticks), events);
 				this.#buffer = this.#buffer.slice(hit.index + hit.ticks);
 				this.#codeTicks = hit.ticks;
+				this.#codeFenced = hit.ticks >= 3 && atLineStart;
 				continue;
 			}
 			this.#buffer = this.#buffer.slice(hit.index + hit.tag.open.length);
@@ -133,6 +123,60 @@ export class ThinkingInbandScanner implements InbandScanner {
 			events.push({ type: "thinkingStart" });
 		}
 		return events;
+	}
+
+	/**
+	 * Emit buffered content while inside a Markdown code region, suppressing
+	 * reasoning-tag detection. A fenced block closes only on a fence line (a line
+	 * of backticks ≥ the opener); an inline span closes on the first backtick run
+	 * of exactly the opener length. Returns true when the region closed and the
+	 * loop should continue, false when it held back and should break.
+	 */
+	#emitCode(final: boolean, events: InbandScanEvent[]): boolean {
+		if (this.#codeFenced) {
+			const end = findFenceCloseEnd(this.#buffer, this.#codeTicks, final);
+			if (end !== -1) {
+				this.#emitText(this.#buffer.slice(0, end), events);
+				this.#buffer = this.#buffer.slice(end);
+				this.#codeTicks = 0;
+				this.#codeFenced = false;
+				return true;
+			}
+			if (final) {
+				this.#emitText(this.#buffer, events);
+				this.#buffer = "";
+				this.#codeTicks = 0;
+				this.#codeFenced = false;
+				return false;
+			}
+			// Stream committed lines; hold only the last (possibly partial) fence line.
+			const lastNl = this.#buffer.lastIndexOf("\n");
+			if (lastNl !== -1) {
+				this.#emitText(this.#buffer.slice(0, lastNl + 1), events);
+				this.#buffer = this.#buffer.slice(lastNl + 1);
+			}
+			return false;
+		}
+		const close = findBacktickRun(this.#buffer, 0, this.#codeTicks);
+		if (close !== -1 && (final || close + this.#codeTicks < this.#buffer.length)) {
+			this.#emitText(this.#buffer.slice(0, close + this.#codeTicks), events);
+			this.#buffer = this.#buffer.slice(close + this.#codeTicks);
+			this.#codeTicks = 0;
+			return true;
+		}
+		// No committed close yet: emit text, holding a trailing backtick run that
+		// may still grow into — or past — the closing delimiter.
+		const hold = final ? 0 : trailingBacktickRun(this.#buffer);
+		this.#emitText(this.#buffer.slice(0, this.#buffer.length - hold), events);
+		this.#buffer = this.#buffer.slice(this.#buffer.length - hold);
+		if (final) this.#codeTicks = 0;
+		return false;
+	}
+
+	#emitText(text: string, events: InbandScanEvent[]): void {
+		if (text.length === 0) return;
+		events.push({ type: "text", text });
+		this.#prevChar = text[text.length - 1]!;
 	}
 
 	#emitThinking(delta: string, events: InbandScanEvent[]): void {
@@ -162,7 +206,12 @@ function scanVisible(buffer: string, final: boolean): VisibleHit {
 	for (let i = 0; i < buffer.length; i++) {
 		const tag = TAGS.find(candidate => buffer.startsWith(candidate.open, i));
 		if (tag) return { kind: "tag", index: i, tag };
-		if (!final && isOpenPrefix(buffer, i)) return { kind: "hold", index: i };
+		if (!final) {
+			const rest = buffer.slice(i);
+			if (OPENS.some(open => open.length > rest.length && open.startsWith(rest))) {
+				return { kind: "hold", index: i };
+			}
+		}
 		if (buffer[i] === "`") {
 			const ticks = backtickRun(buffer, i);
 			if (!final && i + ticks === buffer.length) return { kind: "hold", index: i };
@@ -170,12 +219,6 @@ function scanVisible(buffer: string, final: boolean): VisibleHit {
 		}
 	}
 	return { kind: "none" };
-}
-
-/** True when `buffer.slice(from)` is a strict prefix of some reasoning-tag open. */
-function isOpenPrefix(buffer: string, from: number): boolean {
-	const rest = buffer.length - from;
-	return OPENS.some(open => open.length > rest && open.startsWith(buffer.slice(from)));
 }
 
 /** Length of the maximal backtick run beginning at `from`. */
@@ -200,4 +243,31 @@ function trailingBacktickRun(buffer: string): number {
 	let start = buffer.length;
 	while (start > 0 && buffer[start - 1] === "`") start--;
 	return buffer.length - start;
+}
+
+/**
+ * Index just past the first closing fence line for a fenced block opened with
+ * `ticks` backticks, or -1 when none is committed yet. A closing fence is a whole
+ * line whose trimmed content is only backticks, at least `ticks` of them. A line
+ * without a terminating newline is committed only when `final` (no more input can
+ * extend it into a non-fence line).
+ */
+function findFenceCloseEnd(buffer: string, ticks: number, final: boolean): number {
+	for (let start = 0; start <= buffer.length; ) {
+		const nl = buffer.indexOf("\n", start);
+		const terminated = nl !== -1;
+		const line = buffer.slice(start, terminated ? nl : buffer.length).trim();
+		if (line.length >= ticks && isAllBackticks(line) && (terminated || final)) {
+			return terminated ? nl + 1 : buffer.length;
+		}
+		if (!terminated) break;
+		start = nl + 1;
+	}
+	return -1;
+}
+
+/** True when `text` is non-empty and every character is a backtick. */
+function isAllBackticks(text: string): boolean {
+	for (let i = 0; i < text.length; i++) if (text[i] !== "`") return false;
+	return text.length > 0;
 }

--- a/packages/ai/src/dialect/thinking.ts
+++ b/packages/ai/src/dialect/thinking.ts
@@ -32,6 +32,8 @@ export class ThinkingInbandScanner implements InbandScanner {
 	#thinking = "";
 	/** Fence-aware close-matcher while inside a ` ```thinking ` block; undefined otherwise. */
 	#fenced: FencedThinkingScanner | undefined;
+	/** Backtick count that closes the Markdown code span/fence we are inside; 0 when not in code. */
+	#codeTicks = 0;
 
 	feed(text: string): InbandScanEvent[] {
 		if (text.length === 0) return [];
@@ -86,20 +88,48 @@ export class ThinkingInbandScanner implements InbandScanner {
 				this.#closeTag = "";
 				continue;
 			}
-
-			const tag = findEarliestOpen(this.#buffer);
-			if (!tag) {
-				const hold = final ? 0 : partialSuffixOverlapAny(this.#buffer, OPENS);
+			if (this.#codeTicks > 0) {
+				// Inside a Markdown code span/fence: pass text through verbatim and
+				// suppress reasoning-tag detection until the closing backtick run.
+				const close = findBacktickRun(this.#buffer, 0, this.#codeTicks);
+				if (close !== -1 && (final || close + this.#codeTicks < this.#buffer.length)) {
+					const end = close + this.#codeTicks;
+					events.push({ type: "text", text: this.#buffer.slice(0, end) });
+					this.#buffer = this.#buffer.slice(end);
+					this.#codeTicks = 0;
+					continue;
+				}
+				// No committed close yet: emit text, holding a trailing backtick run
+				// (it may still grow into — or past — the closing delimiter).
+				const hold = final ? 0 : trailingBacktickRun(this.#buffer);
 				const emit = this.#buffer.slice(0, this.#buffer.length - hold);
 				if (emit.length > 0) events.push({ type: "text", text: emit });
 				this.#buffer = this.#buffer.slice(this.#buffer.length - hold);
+				if (final) this.#codeTicks = 0;
 				break;
 			}
-			if (tag.index > 0) events.push({ type: "text", text: this.#buffer.slice(0, tag.index) });
-			this.#buffer = this.#buffer.slice(tag.index + tag.open.length);
-			this.#closeTag = tag.close;
+
+			const hit = scanVisible(this.#buffer, final);
+			if (hit.kind === "none") {
+				events.push({ type: "text", text: this.#buffer });
+				this.#buffer = "";
+				break;
+			}
+			if (hit.index > 0) events.push({ type: "text", text: this.#buffer.slice(0, hit.index) });
+			if (hit.kind === "hold") {
+				this.#buffer = this.#buffer.slice(hit.index);
+				break;
+			}
+			if (hit.kind === "code") {
+				events.push({ type: "text", text: this.#buffer.slice(hit.index, hit.index + hit.ticks) });
+				this.#buffer = this.#buffer.slice(hit.index + hit.ticks);
+				this.#codeTicks = hit.ticks;
+				continue;
+			}
+			this.#buffer = this.#buffer.slice(hit.index + hit.tag.open.length);
+			this.#closeTag = hit.tag.close;
 			this.#thinking = "";
-			if (tag.fenced) this.#fenced = new FencedThinkingScanner();
+			if (hit.tag.fenced) this.#fenced = new FencedThinkingScanner();
 			events.push({ type: "thinkingStart" });
 		}
 		return events;
@@ -112,11 +142,62 @@ export class ThinkingInbandScanner implements InbandScanner {
 	}
 }
 
-function findEarliestOpen(buffer: string): (Tag & { index: number }) | undefined {
-	let best: (Tag & { index: number }) | undefined;
-	for (const tag of TAGS) {
-		const index = buffer.indexOf(tag.open);
-		if (index !== -1 && (!best || index < best.index)) best = { ...tag, index };
+/** Outcome of scanning idle visible text for the next reasoning-tag or code-span boundary. */
+type VisibleHit =
+	| { readonly kind: "tag"; readonly index: number; readonly tag: Tag }
+	| { readonly kind: "code"; readonly index: number; readonly ticks: number }
+	| { readonly kind: "hold"; readonly index: number }
+	| { readonly kind: "none" };
+
+/**
+ * Walk idle visible text for the earliest boundary: a leaked reasoning-tag open,
+ * a Markdown code-span/fence opener (a backtick run), or — when more chunks may
+ * follow — a held partial delimiter at the buffer tail.
+ *
+ * Reasoning tags win at any position so the gemini ` ```thinking ` fence is
+ * healed instead of being read as a code fence. Backtick runs enter code mode so
+ * a literal `<think>` inside inline code or a fenced block stays visible text.
+ */
+function scanVisible(buffer: string, final: boolean): VisibleHit {
+	for (let i = 0; i < buffer.length; i++) {
+		const tag = TAGS.find(candidate => buffer.startsWith(candidate.open, i));
+		if (tag) return { kind: "tag", index: i, tag };
+		if (!final && isOpenPrefix(buffer, i)) return { kind: "hold", index: i };
+		if (buffer[i] === "`") {
+			const ticks = backtickRun(buffer, i);
+			if (!final && i + ticks === buffer.length) return { kind: "hold", index: i };
+			return { kind: "code", index: i, ticks };
+		}
 	}
-	return best;
+	return { kind: "none" };
+}
+
+/** True when `buffer.slice(from)` is a strict prefix of some reasoning-tag open. */
+function isOpenPrefix(buffer: string, from: number): boolean {
+	const rest = buffer.length - from;
+	return OPENS.some(open => open.length > rest && open.startsWith(buffer.slice(from)));
+}
+
+/** Length of the maximal backtick run beginning at `from`. */
+function backtickRun(buffer: string, from: number): number {
+	let end = from;
+	while (end < buffer.length && buffer[end] === "`") end++;
+	return end - from;
+}
+
+/** Index of the first maximal backtick run of exactly `ticks` at/after `from`, else -1. */
+function findBacktickRun(buffer: string, from: number, ticks: number): number {
+	for (let i = buffer.indexOf("`", from); i !== -1; i = buffer.indexOf("`", i)) {
+		const run = backtickRun(buffer, i);
+		if (run === ticks) return i;
+		i += run;
+	}
+	return -1;
+}
+
+/** Length of a backtick run that ends at the buffer tail; 0 when the tail is not a backtick. */
+function trailingBacktickRun(buffer: string): number {
+	let start = buffer.length;
+	while (start > 0 && buffer[start - 1] === "`") start--;
+	return buffer.length - start;
 }

--- a/packages/ai/src/dialect/thinking.ts
+++ b/packages/ai/src/dialect/thinking.ts
@@ -36,8 +36,12 @@ export class ThinkingInbandScanner implements InbandScanner {
 	#codeTicks = 0;
 	/** True when {@link #codeTicks} opened a fenced block (closes on a fence line), not an inline span. */
 	#codeFenced = false;
-	/** Last visible character emitted; `\n` initially so a leading fence is recognized at line start. */
-	#prevChar = "\n";
+	/**
+	 * Leading-space count on the current output line, or -1 once a non-space
+	 * character has appeared. Starts at 0 (line start) so a fence opening the
+	 * stream — or one indented ≤3 spaces, as CommonMark allows — is recognized.
+	 */
+	#lineIndent = 0;
 
 	feed(text: string): InbandScanEvent[] {
 		if (text.length === 0) return [];
@@ -109,11 +113,11 @@ export class ThinkingInbandScanner implements InbandScanner {
 				break;
 			}
 			if (hit.kind === "code") {
-				const atLineStart = this.#prevChar === "\n";
+				const fenced = hit.ticks >= 3 && this.#lineIndent >= 0 && this.#lineIndent <= 3;
 				this.#emitText(this.#buffer.slice(hit.index, hit.index + hit.ticks), events);
 				this.#buffer = this.#buffer.slice(hit.index + hit.ticks);
 				this.#codeTicks = hit.ticks;
-				this.#codeFenced = hit.ticks >= 3 && atLineStart;
+				this.#codeFenced = fenced;
 				continue;
 			}
 			this.#buffer = this.#buffer.slice(hit.index + hit.tag.open.length);
@@ -176,7 +180,7 @@ export class ThinkingInbandScanner implements InbandScanner {
 	#emitText(text: string, events: InbandScanEvent[]): void {
 		if (text.length === 0) return;
 		events.push({ type: "text", text });
-		this.#prevChar = text[text.length - 1]!;
+		this.#lineIndent = trailingLineIndent(text, this.#lineIndent);
 	}
 
 	#emitThinking(delta: string, events: InbandScanEvent[]): void {
@@ -243,6 +247,21 @@ function trailingBacktickRun(buffer: string): number {
 	let start = buffer.length;
 	while (start > 0 && buffer[start - 1] === "`") start--;
 	return buffer.length - start;
+}
+
+/**
+ * Leading-space count of the line at the tail of `text`, continuing from the
+ * prior line's `indent` state (see {@link ThinkingInbandScanner.#lineIndent}).
+ * Returns -1 once any non-space character has appeared on the current line.
+ */
+function trailingLineIndent(text: string, prior: number): number {
+	const lastNl = text.lastIndexOf("\n");
+	let indent = lastNl === -1 ? prior : 0;
+	for (let i = lastNl + 1; i < text.length; i++) {
+		if (indent === -1) break;
+		indent = text[i] === " " ? indent + 1 : -1;
+	}
+	return indent;
 }
 
 /**

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -523,6 +523,35 @@ describe("StreamMarkupHealing thinking pattern", () => {
 		expect(heal("see <div>content</div> end")).toEqual({ text: "see <div>content</div> end", thinking: "" });
 	});
 
+	// Issue #5665: a literal reasoning tag inside a Markdown inline-code span was
+	// read as a leaked <think> boundary, splitting the visible row into
+	// text + thinking and corrupting the rendered Markdown.
+	it("keeps a literal think tag inside inline code as visible text", () => {
+		const literal = `<${"think"}>`;
+		const row = `| [#1203 MiniMax CN leaks \`${literal}\` text](https://x) | Fixed | PR merged |`;
+		expect(heal(row)).toEqual({ text: row, thinking: "" });
+	});
+
+	it("keeps a literal think tag inside inline code when streamed char by char", () => {
+		const literal = `<${"think"}>`;
+		const row = `prefix \`${literal}\` suffix`;
+		expect(heal(...row)).toEqual({ text: row, thinking: "" });
+	});
+
+	it("keeps a literal think tag inside a fenced code block as visible text", () => {
+		const literal = `<${"think"}>`;
+		const block = `\`\`\`md\n${literal}\n\`\`\`\nafter`;
+		expect(heal(block)).toEqual({ text: block, thinking: "" });
+	});
+
+	it("still heals a leaked think tag outside inline code", () => {
+		const literal = `<${"think"}>`;
+		expect(heal(`before \`code\` ${literal}secret</think> after`)).toEqual({
+			text: "before `code`  after",
+			thinking: "secret",
+		});
+	});
+
 	it("emits one balanced thinking boundary for a healed fence", () => {
 		const scanner = new ThinkingInbandScanner();
 		const events: InbandScanEvent[] = [...scanner.feed("a```thinking\nx\n```b"), ...scanner.flush()];

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -554,6 +554,18 @@ describe("StreamMarkupHealing thinking pattern", () => {
 		expect(heal(...block)).toEqual({ text: block, thinking: "" });
 	});
 
+	// Issue #5665 (review follow-up): CommonMark treats a fence indented by up to
+	// three spaces as fenced code. The scanner must still open a fenced block (not
+	// an inline span) so an inner triple-backtick literal does not close it early.
+	it("recognizes a fence indented up to three spaces as a fenced block", () => {
+		const literal = `<${"think"}>literal</${"think"}>`;
+		for (const indent of ["", " ", "   "]) {
+			const block = `${indent}\`\`\`md\nconst fence = '\`\`\`';\n${literal}\n${indent}\`\`\`\nafter`;
+			expect(heal(block)).toEqual({ text: block, thinking: "" });
+			expect(heal(...block)).toEqual({ text: block, thinking: "" });
+		}
+	});
+
 	it("still heals a leaked think tag outside inline code", () => {
 		const literal = `<${"think"}>`;
 		expect(heal(`before \`code\` ${literal}secret</think> after`)).toEqual({

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -544,6 +544,16 @@ describe("StreamMarkupHealing thinking pattern", () => {
 		expect(heal(block)).toEqual({ text: block, thinking: "" });
 	});
 
+	// Issue #5665 (review follow-up): a fenced block only closes on its own fence
+	// line. An inline backtick run inside the block (a `` ``` `` string literal)
+	// must not exit code mode early and let a later literal think tag be healed.
+	it("keeps a fenced block open across an inner triple-backtick literal", () => {
+		const literal = `<${"think"}>literal</${"think"}>`;
+		const block = `\`\`\`md\nconst fence = '\`\`\`';\n${literal}\n\`\`\`\nafter`;
+		expect(heal(block)).toEqual({ text: block, thinking: "" });
+		expect(heal(...block)).toEqual({ text: block, thinking: "" });
+	});
+
 	it("still heals a leaked think tag outside inline code", () => {
 		const literal = `<${"think"}>`;
 		expect(heal(`before \`code\` ${literal}secret</think> after`)).toEqual({


### PR DESCRIPTION
## Repro
A visible assistant response containing a literal reasoning tag inside a Markdown inline-code span (e.g. a table row `` | [#1203 MiniMax CN leaks `<think>` text](…) | Fixed | ``) was split into `text` + `thinking` blocks before rendering, cutting the row at the opening backtick and dumping the remainder outside the table as raw Markdown. Reproduced against `StreamMarkupHealing` with the issue's minimal snippet:

```
bun run-repro.ts
[
  { "type": "text",    "text": "…| [#1203 MiniMax CN leaks `" },
  { "type": "thinking", "thinking": "` text](…) | Fixed | PR merged |" }
]
```

## Cause
`ThinkingInbandScanner` (`packages/ai/src/dialect/thinking.ts`) heals leaked reasoning idioms out of the visible-text channel by scanning for open tags (`<think>`, `<thinking>`, …) with a plain `indexOf` (`findEarliestOpen`). It had no awareness of Markdown code spans, so a literal `` `<think>` `` was treated as a reasoning boundary. With no matching `</think>`, everything after the tag was emitted as `thinking`, corrupting the visible row.

## Fix
- `packages/ai/src/dialect/thinking.ts`: replaced `findEarliestOpen` with `scanVisible`, which walks idle text for the earliest boundary — a reasoning-tag open, a Markdown backtick run (code-span/fence opener), or a held partial delimiter at the buffer tail.
- Added persistent `#codeTicks` state: entering a backtick run suppresses reasoning-tag detection and streams content through verbatim until the matching closing run (works for inline code and fenced blocks, streaming-safe across chunk boundaries).
- Reasoning tags still win at any position, so the gemini `` ```thinking `` fence continues to heal.
- Added regression tests covering inline-code (whole + char-by-char), fenced code block, and the still-healed leak-outside-code case.

## Verification
`bun test packages/ai/test/stream-markup-healing.test.ts` → 53 pass, 0 fail. `bun check` → exit 0. Manually confirmed the reported row round-trips as a single intact `text` value and that char-by-char streaming, unclosed code spans, double-backtick spans, fenced blocks, and real leaked-thinking outside code all behave correctly. Fixes #5665