### PR TITLE
fix: preserve oauth links across wrapped rows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ctrl-clicking a wrapped OAuth authorization URL opening only the clicked row's truncated fragment by preserving the complete hyperlink target on every rendered row.
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/components/login-dialog.ts
@@ -1,6 +1,7 @@
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
-import { Container, getKeybindings, Input, Spacer, Text, type TUI } from "@oh-my-pi/pi-tui";
+import { Container, getKeybindings, Input, Spacer, Text, type TUI, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
 import { theme } from "../../modes/theme/theme";
+import { urlHyperlinkAlways, WidthAwareText } from "../../tui";
 import { openPath } from "../../utils/open";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -75,13 +76,22 @@ export class LoginDialogComponent extends Container {
 	 * is offered as an additional local shortcut so narrow local terminals still
 	 * have a truncation-safe copy target (viewport clipping on a long authorize
 	 * URL silently drops trailing OAuth query parameters — e.g.
-	 * `code_challenge_method=S256`). The OSC 8 hyperlink carries the full URL
-	 * for terminals that support click-through.
+	 * `code_challenge_method=S256`). Every physical URL row carries its own OSC 8
+	 * link to the full URL, so clicking any wrapped fragment opens the same target.
 	 */
 	showAuth(url: string, instructions?: string, launchUrl?: string): void {
 		this.#contentContainer.clear();
 		this.#contentContainer.addChild(new Spacer(1));
-		this.#contentContainer.addChild(new Text(theme.fg("accent", url), 1, 0));
+		this.#contentContainer.addChild(
+			new WidthAwareText(
+				contentWidth =>
+					wrapTextWithAnsi(url, contentWidth)
+						.map(row => theme.fg("accent", urlHyperlinkAlways(url, row)))
+						.join("\n"),
+				1,
+				0,
+			),
+		);
 
 		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
 		const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;

--- a/packages/coding-agent/test/modes/components/login-dialog.test.ts
+++ b/packages/coding-agent/test/modes/components/login-dialog.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { resetSettingsForTest, Settings, settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { LoginDialogComponent } from "@oh-my-pi/pi-coding-agent/modes/components/login-dialog";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import * as openModule from "@oh-my-pi/pi-coding-agent/utils/open";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterEach(() => {
+	settings.clearOverride("tui.hyperlinks");
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
+
+describe("LoginDialogComponent", () => {
+	it("links every wrapped authorization URL row to the complete URL", () => {
+		settings.override("tui.hyperlinks", "always");
+		const openSpy = spyOn(openModule, "openPath").mockImplementation(() => {});
+		try {
+			const tui = { requestRender() {} } as unknown as TUI;
+			const dialog = new LoginDialogComponent(tui, "google-antigravity", () => {});
+			const authorizationUrl =
+				"https://accounts.google.com/o/oauth2/v2/auth?client_id=x&response_type=code&redirect_uri=http%3A%2F%2F127.0.0.1%3A51121%2Foauth-callback&scope=cloud-platform&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+			dialog.showAuth(authorizationUrl);
+			const linkTarget = `${authorizationUrl}\x07`;
+			const urlRows = dialog
+				.render(40)
+				.filter(line => line.includes(linkTarget) && !Bun.stripANSI(line).includes("click to open"));
+
+			expect(urlRows.length).toBeGreaterThan(1);
+			expect(urlRows.map(line => Bun.stripANSI(line).trim()).join("")).toBe(authorizationUrl);
+			expect(urlRows.every(line => line.includes(linkTarget))).toBe(true);
+			expect(openSpy).toHaveBeenCalledWith(authorizationUrl);
+		} finally {
+			openSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## What

Make every wrapped row of an OAuth authorization URL carry an OSC 8 hyperlink to the complete URL. Add regression coverage for long URLs rendered in narrow terminals.

## Why

Long authorization URLs are hard-wrapped into separate terminal rows. Ctrl-clicking a visible continuation row could therefore open only that truncated fragment, producing an invalid OAuth request. Linking each row to the complete URL makes every visible fragment open the same correct target.

## Testing

- `bun test packages/coding-agent/test/modes/components/login-dialog.test.ts`
- `bun run check:types` in `packages/coding-agent`
- Biome check on the changed source and test files
- `bun packages/coding-agent/src/cli.ts --version`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)