### PR TITLE
fix(coding-agent): repair GPT web search

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Codex web search for Responses-Lite GPT models and prioritized GPT-5.6 Sol, Terra, then Luna by default.
+- Fixed Codex web search for Responses-Lite GPT models and prioritized GPT-5.6 Sol, Terra, then Luna by default. ([#5678](https://github.com/can1357/oh-my-pi/pull/5678) by [@daandden](https://github.com/daandden))
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Codex web search for Responses-Lite GPT models and prioritized GPT-5.6 Sol, Terra, then Luna by default.
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -25,9 +25,9 @@ const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const CODEX_RESPONSES_PATH = "/codex/responses";
 const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
-	"gpt-5.6-luna",
-	"gpt-5.6-terra",
 	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
 	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5-codex",
@@ -402,6 +402,7 @@ async function callCodexSearch(
 		body.client_metadata = metadata.clientMetadata;
 		body.reasoning = { context: "all_turns" };
 		applyCodexResponsesLiteShape(body);
+		delete body.tool_choice;
 	}
 
 	const fetchImpl = options.fetch ?? fetch;
@@ -534,8 +535,8 @@ async function callCodexSearch(
  * Default-model behavior:
  * - If `PI_CODEX_WEB_SEARCH_MODEL` is set, use it exactly once and surface any
  *   upstream error verbatim.
- * - Otherwise prefer ChatGPT-account-safe bundled defaults (GPT-5.6 Luna,
- *   Terra, Sol, GPT-5.5, …) and retry the next candidate only when Codex
+ * - Otherwise prefer ChatGPT-account-safe bundled defaults (GPT-5.6 Sol,
+ *   Terra, Luna, GPT-5.5, …) and retry the next candidate only when Codex
  *   returns the known 400 "model is not supported" family. This avoids
  *   selecting `gpt-5-codex-mini` first on ChatGPT accounts, which OpenAI
  *   rejects.

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -223,27 +223,27 @@ describe("searchCodex model selection", () => {
 		}
 	});
 
-	it("uses GPT-5.6 Luna as the first bundled default", async () => {
+	it("uses GPT-5.6 Sol as the first bundled default", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
-		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.6-luna")));
+		const result = await searchCodex(makeSearchParams("default codex model", mockCodexFetch("gpt-5.6-sol")));
 
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
-		expect(result.model).toBe("gpt-5.6-luna");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-sol");
+		expect(result.model).toBe("gpt-5.6-sol");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
-		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.6-luna")));
+		const result = await searchCodex(makeSearchParams("blank codex model", mockCodexFetch("gpt-5.6-sol")));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.6-luna");
-		expect(result.model).toBe("gpt-5.6-luna");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.6-sol");
+		expect(result.model).toBe("gpt-5.6-sol");
 	});
 
-	it("retries the next bundled default when Codex rejects a model for ChatGPT accounts", async () => {
+	it("retries unsupported defaults in Sol, Terra, Luna order", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
 		let calls = 0;
 		capturedRequest = null;
@@ -256,21 +256,22 @@ describe("searchCodex model selection", () => {
 			};
 
 			const requestedModel = capturedRequest.body?.model;
-			if (calls === 1) {
-				expect(requestedModel).toBe("gpt-5.6-luna");
+			if (calls <= 2) {
+				const expectedModel = calls === 1 ? "gpt-5.6-sol" : "gpt-5.6-terra";
+				expect(requestedModel).toBe(expectedModel);
 				return Promise.resolve(
 					new Response(
 						JSON.stringify({
-							detail: "The 'gpt-5.6-luna' model is not supported when using Codex with a ChatGPT account.",
+							detail: `The '${expectedModel}' model is not supported when using Codex with a ChatGPT account.`,
 						}),
 						{ status: 400, headers: { "Content-Type": "application/json" } },
 					),
 				);
 			}
 
-			expect(requestedModel).toBe("gpt-5.6-terra");
+			expect(requestedModel).toBe("gpt-5.6-luna");
 			return Promise.resolve(
-				new Response(makeSseResponse("gpt-5.6-terra"), {
+				new Response(makeSseResponse("gpt-5.6-luna"), {
 					status: 200,
 					headers: { "Content-Type": "text/event-stream" },
 				}),
@@ -279,12 +280,12 @@ describe("searchCodex model selection", () => {
 
 		const result = await searchCodex(makeSearchParams("retry unsupported default", fetchMock));
 
-		expect(calls).toBe(2);
-		expect(result.model).toBe("gpt-5.6-terra");
+		expect(calls).toBe(3);
+		expect(result.model).toBe("gpt-5.6-luna");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
-	it("encodes explicit gpt-5.6-sol as a Responses-Lite request", async () => {
+	it("encodes explicit gpt-5.6-sol as a valid Responses-Lite request", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-sol";
 		const result = await searchCodex(makeSearchParams("Sol web search", mockCodexFetch("gpt-5.6-sol")));
 
@@ -297,7 +298,6 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest?.body).toEqual(
 			expect.objectContaining({
 				model: "gpt-5.6-sol",
-				tool_choice: { type: "web_search" },
 				reasoning: { context: "all_turns" },
 				parallel_tool_calls: false,
 				input: [
@@ -325,6 +325,7 @@ describe("searchCodex model selection", () => {
 			}),
 		);
 		expect(capturedRequest?.body?.tools).toBeUndefined();
+		expect(capturedRequest?.body?.tool_choice).toBeUndefined();
 		expect(capturedRequest?.body?.instructions).toBeUndefined();
 		expect(result.model).toBe("gpt-5.6-sol");
 	});

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { getBundledModels } from "@oh-my-pi/pi-catalog/models";
 import type { SearchParams } from "@oh-my-pi/pi-coding-agent/web/search/providers/base";
 import { searchCodex } from "@oh-my-pi/pi-coding-agent/web/search/providers/codex";
 
@@ -10,6 +11,7 @@ type CapturedRequest = {
 };
 
 const originalCodexSearchModel = process.env.PI_CODEX_WEB_SEARCH_MODEL;
+const bundledCodexGptModels = getBundledModels("openai-codex").filter(model => model.id.startsWith("gpt-"));
 
 function makeSseResponse(model: string): string {
 	return [
@@ -328,6 +330,45 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest?.body?.tool_choice).toBeUndefined();
 		expect(capturedRequest?.body?.instructions).toBeUndefined();
 		expect(result.model).toBe("gpt-5.6-sol");
+	});
+
+	it("encodes every bundled GPT model with its catalog transport", async () => {
+		for (const model of bundledCodexGptModels) {
+			process.env.PI_CODEX_WEB_SEARCH_MODEL = model.id;
+			const result = await searchCodex(makeSearchParams(`${model.id} web search`, mockCodexFetch(model.id)));
+			const headers = new Headers(capturedRequest?.headers);
+
+			expect(capturedRequest?.body?.model).toBe(model.id);
+			if (model.useResponsesLite) {
+				expect(headers.get("x-openai-internal-codex-responses-lite")).toBe("true");
+				expect(capturedRequest?.body?.tools).toBeUndefined();
+				expect(capturedRequest?.body?.tool_choice).toBeUndefined();
+				expect(capturedRequest?.body?.instructions).toBeUndefined();
+				expect(capturedRequest?.body?.input).toEqual([
+					{
+						type: "additional_tools",
+						role: "developer",
+						tools: [{ type: "web_search", search_context_size: "high" }],
+					},
+					{
+						type: "message",
+						role: "developer",
+						content: [{ type: "input_text", text: "Codex test system prompt" }],
+					},
+					{
+						type: "message",
+						role: "user",
+						content: [{ type: "input_text", text: `${model.id} web search` }],
+					},
+				]);
+			} else {
+				expect(headers.get("x-openai-internal-codex-responses-lite")).toBeNull();
+				expect(capturedRequest?.body?.tools).toEqual([{ type: "web_search", search_context_size: "high" }]);
+				expect(capturedRequest?.body?.tool_choice).toEqual({ type: "web_search" });
+				expect(capturedRequest?.body?.instructions).toBe("Codex test system prompt");
+			}
+			expect(result.model).toBe(model.id);
+		}
 	});
 
 	it("does not retry default candidates when PI_CODEX_WEB_SEARCH_MODEL is explicitly unsupported", async () => {


### PR DESCRIPTION
## What

- Fix GPT-5.6 Responses-Lite web search.
- Prefer Sol, Terra, then Luna.

## Why

Responses-Lite retained an incompatible top-level `tool_choice`, causing Codex to fail and fall back to public providers.

## Testing

- `bun test packages/coding-agent/test/tools/web-search-codex.test.ts packages/coding-agent/test/web/search/codex-broker.test.ts` — 13 pass
- Live Codex searches — Sol, Terra, Luna, and GPT-5.5 pass
- `bunx biome check packages/coding-agent/src/web/search/providers/codex.ts packages/coding-agent/test/tools/web-search-codex.test.ts packages/coding-agent/CHANGELOG.md` — pass
- `bun check` — blocked by existing Rust formatting drift and `packages/ai/src/providers/{cursor,devin}.ts` type errors

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)