### PR TITLE
fix(coding-agent): hide xdev mount notices

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Hid the verbose `xd://` device mount inventory from the interactive startup transcript while preserving hidden model-facing mount updates.
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6825,10 +6825,6 @@ export class AgentSession {
 			display: false,
 			timestamp: Date.now(),
 		});
-		const parts: string[] = [];
-		if (added.length > 0) parts.push(`mounted ${added.map(entry => entry.name).join(", ")}`);
-		if (removed.length > 0) parts.push(`unmounted ${removed.map(entry => entry.name).join(", ")}`);
-		this.emitNotice("info", `xd://: ${parts.join("; ")}`, "xdev");
 	}
 
 	/**

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -501,7 +501,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(rebuildCount).toBe(2);
 	});
 
-	it("announces xd:// mount deltas as steered notices instead of rebuilding the prompt", async () => {
+	it("keeps xd:// mount deltas hidden from the UI while steering them to the model", async () => {
 		let rebuildCount = 0;
 		const { session } = newSession(
 			async toolNames => {
@@ -510,6 +510,10 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			},
 			{ xdevRegistry: new XdevRegistry([]) },
 		);
+		const xdevNotices: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "notice" && event.source === "xdev") xdevNotices.push(event.message);
+		});
 		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
 		const fetch = createMcpCustomTool("mcp__nucleus_fetch", "nucleus", "fetch", "Fetch nucleus");
 		const noticeTexts = () =>
@@ -548,5 +552,6 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 		expect(rebuildCount).toBe(1);
 		expect(noticeTexts().length).toBe(noticeCount);
+		expect(xdevNotices).toEqual([]);
 	});
 });


### PR DESCRIPTION
## What

Hide `xd://` mount inventories from the TUI while retaining hidden model-facing mount updates.

## Why

Startup printed every mounted MCP tool, adding noisy implementation detail without user actionability.

## Testing

- `bun test packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts` (14 pass)
- `bun check` (Biome passed; type checking remains blocked by existing `packages/ai` provider errors)

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)