### PR TITLE
fix(tui): close plan review overlay before execution dispatch

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the fullscreen plan-review overlay staying visible until the approved execution turn finished, so after picking "Approve and keep context" (or any approve option) work proceeded underneath while the operator was stuck on the plan-review screen. The overlay is now hidden once execution begins — after the async transcript rebuild, before the blocking synthetic prompt is dispatched — instead of only after the whole turn returns ([#5688](https://github.com/can1357/oh-my-pi/issues/5688)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2851,17 +2851,6 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.#applyPlanExecutionModel(options.executionModel);
 		}
 
-		// Close the review overlay now that the flicker-prone async rebuild is done
-		// (#exitPlanMode / compaction restored the transcript, tools and model are
-		// back). The synthetic execution turn dispatched below blocks in
-		// `session.prompt` for the whole run, so deferring the hide until #approvePlan
-		// returns would strand the operator on the plan-review screen while work
-		// proceeds (issue #5688). Hiding here — after the rebuild, before dispatch —
-		// keeps issue #5319's stale-buffer guard intact. `#hidePlanReview` is
-		// idempotent, so the caller's trailing `closePlanReview()` is a safe no-op.
-		this.#hidePlanReview();
-		this.ui.requestRender();
-
 		if (compactOutcome === "cancelled") {
 			// Explicit abort: honor it. `executeCompaction` already surfaced
 			// `showError("Compaction cancelled")`; we add the deferred-dispatch
@@ -2892,6 +2881,18 @@ export class InteractiveMode implements InteractiveModeContext {
 			planFilePath: options.planFilePath,
 			contextPreserved: options.preserveContext === true,
 		});
+		// Close the review overlay only now — after the async title write and plan
+		// prompt are prepared, immediately before the execution turn is queued. The
+		// synthetic prompt below blocks in `session.prompt` for the whole run, so
+		// hiding here (rather than after #approvePlan returns) keeps the operator off
+		// the stale plan-review screen (issue #5688) while #5319's stale-buffer guard
+		// stays intact. Deferring the hide past the awaited `setSessionName` also
+		// prevents restored editor focus from letting operator keystrokes submit a
+		// normal turn ahead of the approved execution turn (PR #5689 review).
+		// `#hidePlanReview` is idempotent, so the caller's trailing `closePlanReview()`
+		// — and the cancelled/error early returns above — stay safe no-ops.
+		this.#hidePlanReview();
+		this.ui.requestRender();
 		// A user turn queued during compaction was already fired by
 		// `flushCompactionQueue` before we returned from `handleCompactCommand`; the
 		// old abort-then-prompt path would have discarded that operator turn AND

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2851,6 +2851,17 @@ export class InteractiveMode implements InteractiveModeContext {
 			await this.#applyPlanExecutionModel(options.executionModel);
 		}
 
+		// Close the review overlay now that the flicker-prone async rebuild is done
+		// (#exitPlanMode / compaction restored the transcript, tools and model are
+		// back). The synthetic execution turn dispatched below blocks in
+		// `session.prompt` for the whole run, so deferring the hide until #approvePlan
+		// returns would strand the operator on the plan-review screen while work
+		// proceeds (issue #5688). Hiding here — after the rebuild, before dispatch —
+		// keeps issue #5319's stale-buffer guard intact. `#hidePlanReview` is
+		// idempotent, so the caller's trailing `closePlanReview()` is a safe no-op.
+		this.#hidePlanReview();
+		this.ui.requestRender();
+
 		if (compactOutcome === "cancelled") {
 			// Explicit abort: honor it. `executeCompaction` already surfaced
 			// `showError("Compaction cancelled")`; we add the deferred-dispatch

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -723,6 +723,60 @@ describe("InteractiveMode plan review rendering", () => {
 		});
 	});
 
+	it("hides the review overlay before the blocking execution turn resolves", async () => {
+		// Regression (issue #5688): the flicker fix moved #hidePlanReview out of the
+		// picker's `finish` and into a `closePlanReview()` reached only AFTER
+		// #approvePlan returns. #approvePlan awaits `session.prompt(planApproved)`,
+		// which blocks for the whole execution turn — so the operator stayed stuck on
+		// the plan-review screen until work finished. The overlay must be hidden once
+		// execution BEGINS (after the async transcript rebuild), not when it ends.
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nKeep context.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(session, "getContextUsage").mockReturnValue(undefined);
+
+		// Drive the pick synchronously the moment the real overlay mounts: move to
+		// "Approve and keep context" (index 2) — that branch keeps the session, so no
+		// clear machinery runs — and confirm with Enter. `showOverlay` runs inside
+		// `showPlanReview`, so the pick resolves the picker promise without a wait.
+		const overlayHandle = { hide: vi.fn() };
+		vi.spyOn(mode.ui, "showOverlay").mockImplementation(component => {
+			const overlay = component as PlanReviewOverlay;
+			overlay.handleInput("j");
+			overlay.handleInput("j");
+			overlay.handleInput("\n");
+			return overlayHandle as never;
+		});
+
+		// Block the execution dispatch until released, mirroring a real turn that
+		// streams for a long time. Record whether the overlay was already hidden when
+		// the blocking prompt began, and signal that the prompt was reached.
+		const gate = Promise.withResolvers<boolean>();
+		const promptEntered = Promise.withResolvers<void>();
+		let hiddenWhenPromptEntered: boolean | undefined;
+		vi.spyOn(session, "prompt").mockImplementation(async () => {
+			hiddenWhenPromptEntered = overlayHandle.hide.mock.calls.length > 0;
+			promptEntered.resolve();
+			return gate.promise;
+		});
+
+		const approval = mode.handlePlanApproval({ planFilePath, planExists: true, title: "PLAN" });
+
+		// Await the real dispatch signal instead of a wall-clock guess.
+		await promptEntered.promise;
+		expect(hiddenWhenPromptEntered).toBe(true);
+		expect(overlayHandle.hide).toHaveBeenCalledTimes(1);
+
+		gate.resolve(true);
+		await approval;
+	});
+
 	it("queues the approved plan as a synthetic follow-up when a turn is already in flight", async () => {
 		// Regression: the previous fix aborted the in-flight turn and re-dispatched
 		// the plan-approved prompt. When the in-flight turn was an operator turn


### PR DESCRIPTION
## Repro
On v17.0.1, entering plan mode, opening plan review, and picking "Approve and keep context" leaves the fullscreen plan-review overlay on screen for the entire approved run — work proceeds underneath, but the operator stays stuck on the review screen until the turn finishes. Reproduced with a focused test that asserts the overlay handle's `hide()` fires before the blocking execution prompt resolves: `bun test test/interactive-mode-plan-review.test.ts -t "hides the review overlay before the blocking execution turn resolves"` fails on `main` (`hiddenWhenPromptEntered === false`).

## Cause
Commit `68f84d7c205` ("fix(tui): prevented stale-buffer flicker", #5319) moved `#hidePlanReview()` out of the picker's synchronous `finish()` callback in `InteractiveMode.showPlanReview` and into a new `closePlanReview()` in `handlePlanApproval`. `closePlanReview()` only runs after `#approvePlan()` returns, but `#approvePlan()` awaits `session.prompt(planApprovedPrompt, { synthetic: true })` (`interactive-mode.ts`), which resolves only when the whole execution turn completes. So the overlay hide is deferred until work finishes.

## Fix
- Hide the overlay inside `#approvePlan` after the flicker-prone async rebuild (`#exitPlanMode` / compaction, tool-set and model restore) completes but before the blocking synthetic-prompt dispatch, in `packages/coding-agent/src/modes/interactive-mode.ts`.
- `#hidePlanReview()` is idempotent, so the caller's trailing `closePlanReview()` remains a safe no-op and #5319's stale-buffer guard (overlay stays mounted through the transcript rebuild) is preserved.
- Added a regression test in `packages/coding-agent/test/interactive-mode-plan-review.test.ts` asserting the overlay is hidden before the blocking `session.prompt` resolves.
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/interactive-mode-plan-review.test.ts` → 51 pass / 0 fail. The new test fails when the added `#hidePlanReview()` call is reverted (confirming it catches the regression) and passes with the fix. Fixes #5688.