### PR TITLE
fix(mcp): match tool ownership by server name, not tool-name prefix

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP tools repeatedly unmounting and remounting mid-session when server names have overlapping sanitized prefixes (e.g. `atlassian` alongside an imported `atlassian:atlassian`), and stale tools remaining registered after disconnecting a server with special characters in its name.
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -572,8 +572,14 @@ export class MCPManager {
 		};
 	}
 
+	/**
+	 * Ownership is matched via `mcpServerName`, never a `mcp__${name}_` name
+	 * prefix: tool names are lossy-sanitized, so one server's sanitized name
+	 * can prefix another's (`atlassian` vs `atlassian:atlassian`) and a name
+	 * with sanitized characters never prefix-matches its own tools at all.
+	 */
 	#replaceServerTools(name: string, tools: CustomTool<TSchema, MCPToolDetails>[]): void {
-		this.#tools = this.#tools.filter(t => !t.name.startsWith(`mcp__${name}_`));
+		this.#tools = this.#tools.filter(t => t.mcpServerName !== name);
 		this.#tools.push(...tools);
 		// Stable sort by name so reconnect order does not perturb the array.
 		// See `sortMCPToolsByName` for the cache-stability rationale.
@@ -762,8 +768,8 @@ export class MCPManager {
 		}
 
 		// Remove tools from this server and notify consumers
-		const hadTools = this.#tools.some(t => t.name.startsWith(`mcp__${name}_`));
-		this.#tools = this.#tools.filter(t => !t.name.startsWith(`mcp__${name}_`));
+		const hadTools = this.#tools.some(t => t.mcpServerName === name);
+		this.#tools = this.#tools.filter(t => t.mcpServerName !== name);
 		if (hadTools) this.#onToolsChanged?.(this.#tools);
 
 		// Notify prompt consumers so stale commands are cleared

--- a/packages/coding-agent/test/mcp-server-tool-ownership.test.ts
+++ b/packages/coding-agent/test/mcp-server-tool-ownership.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Regression test: MCP tool ownership must be tracked via `mcpServerName`,
+ * not a `mcp__${serverName}_` tool-name prefix.
+ *
+ * Tool names are sanitized (server "atlassian:atlassian" mints
+ * `mcp__atlassian_atlassian_*`), which breaks prefix matching two ways:
+ *
+ * 1. Collision: server "atlassian"'s prefix `mcp__atlassian_` also matches
+ *    every `mcp__atlassian_atlassian_*` tool, so each reconnect/refresh of
+ *    "atlassian" evicted the sibling server's tools and fired
+ *    `onToolsChanged` with them missing — the session then steered paired
+ *    unmount/mount notices into the conversation on every transport flap.
+ * 2. Never-match: the raw prefix `mcp__atlassian:atlassian_` matches no
+ *    sanitized tool name, so disconnecting "atlassian:atlassian" left its
+ *    tools registered (and callable through a dead connection) and never
+ *    notified consumers.
+ *
+ * Both server names here serve the identical fixture toolset, mirroring the
+ * real-world duplicate-config shape (`<name>` plus imported `<source>:<name>`).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import type { MCPStdioServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import { MANY_TOOL_COUNT, manyToolName } from "./fixtures/many-tools-mcp";
+
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "many-tools-mcp.ts");
+
+const SHORT_SERVER = "atlassian";
+const COLON_SERVER = "atlassian:atlassian";
+/** Sanitized names minted by `createMCPToolName` for the first fixture tool. */
+const SHORT_TOOL = `mcp__atlassian_${manyToolName(0)}`;
+const COLON_TOOL = `mcp__atlassian_atlassian_${manyToolName(0)}`;
+
+function fixtureConfig(): MCPStdioServerConfig {
+	return { type: "stdio", command: process.execPath, args: [FIXTURE_PATH] };
+}
+
+describe("MCP tool ownership with prefix-colliding server names", () => {
+	let workDir: string;
+	let manager: MCPManager;
+
+	beforeEach(() => {
+		workDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mcp-ownership-"));
+		manager = new MCPManager(workDir);
+	});
+
+	afterEach(async () => {
+		await manager.disconnectAll();
+		removeSyncWithRetries(workDir);
+	});
+
+	it("refreshing one server keeps the sibling server's tools registered", async () => {
+		await manager.connectServers({ [SHORT_SERVER]: fixtureConfig(), [COLON_SERVER]: fixtureConfig() }, {});
+		const names = () => manager.getTools().map(t => t.name);
+		expect(names()).toContain(SHORT_TOOL);
+		expect(names()).toContain(COLON_TOOL);
+		expect(names()).toHaveLength(MANY_TOOL_COUNT * 2);
+
+		const payloads: string[][] = [];
+		manager.setOnToolsChanged(tools => payloads.push(tools.map(t => t.name)));
+
+		// Same code path a reconnect takes: replace the named server's tools.
+		await manager.refreshServerTools(SHORT_SERVER);
+
+		expect(names()).toHaveLength(MANY_TOOL_COUNT * 2);
+		expect(names()).toContain(COLON_TOOL);
+		// No emitted tool list may ever lose the sibling's tools — that delta is
+		// what the session surfaces to the model as unmount/mount churn.
+		expect(payloads.length).toBeGreaterThan(0);
+		for (const payload of payloads) {
+			expect(payload).toContain(COLON_TOOL);
+			expect(payload).toHaveLength(MANY_TOOL_COUNT * 2);
+		}
+	}, 20_000);
+
+	it("disconnecting a server with sanitized name characters removes exactly its tools", async () => {
+		await manager.connectServers({ [SHORT_SERVER]: fixtureConfig(), [COLON_SERVER]: fixtureConfig() }, {});
+		const payloads: string[][] = [];
+		manager.setOnToolsChanged(tools => payloads.push(tools.map(t => t.name)));
+
+		await manager.disconnectServer(COLON_SERVER);
+
+		const remaining = manager.getTools();
+		expect(remaining.map(t => t.name)).toContain(SHORT_TOOL);
+		expect(remaining).toHaveLength(MANY_TOOL_COUNT);
+		expect(remaining.every(t => t.mcpServerName === SHORT_SERVER)).toBe(true);
+		// Consumers must be told the tools are gone (previously: no event, and
+		// the colon-named server's tools lingered as callable zombies).
+		expect(payloads.at(-1)?.some(name => name === COLON_TOOL)).toBe(false);
+		expect(payloads.at(-1)).toHaveLength(MANY_TOOL_COUNT);
+	}, 20_000);
+});


### PR DESCRIPTION
## What

`MCPManager` now matches tool ownership by `mcpServerName` when replacing or removing a server's tools, instead of filtering on the `mcp__<server>_` tool-name prefix.

## Why

Tool names are lossy-sanitized, so prefix matching breaks two ways:

- **Collision**: one server's sanitized name can prefix another's (e.g. `atlassian` alongside an imported `atlassian:atlassian`). Every reconnect of the shorter-named server evicted the sibling's tools and fired `onToolsChanged` without them; the sibling's reconnect re-added them seconds later. With a flapping remote transport this spammed paired `xd://` unmount/mount notices (UI + steered model notices) every 1-2 minutes.
- **Never-match**: `mcp__atlassian:atlassian_` matches no sanitized name, so disconnecting/disabling such a server left its tools registered and callable through a dead connection, with no `onToolsChanged` fired.

Both tool classes already carry `mcpServerName`; `mcp-command-controller` already filters on it. The manager was the only remaining prefix-matching site.

## Testing

- New `test/mcp-server-tool-ownership.test.ts`: two stdio fixture servers with prefix-colliding names, driven through `connectServers`/`refreshServerTools`/`disconnectServer`. Both tests fail on the old code, pass on the fix.
- `bun test mcp`: 212 pass. `bun check` green.
- Verified against a live repro: a session whose Atlassian transports flapped every ~1-2 min shows zero mount churn on reconnect with the fix; a real reconnect of both servers produced no session events.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

<img width="1389" height="565" alt="image" src="https://github.com/user-attachments/assets/f4eeb24d-3658-4aff-96c6-eee1df318a37" />

