### PR TITLE
fix(shell): parse uv run --extra values

### DIFF
--- a/crates/pi-shell/src/minimizer/filters/mod.rs
+++ b/crates/pi-shell/src/minimizer/filters/mod.rs
@@ -376,6 +376,7 @@ fn uv_wrapper_tool<'a>(ctx: &'a MinimizerCtx<'_>) -> Option<&'a str> {
 /// is already a single flag token and needs no entry here.
 const WRAPPER_VALUE_OPTIONS: &[&str] = &[
 	// uv run
+	"--extra",
 	"--with",
 	"--with-requirements",
 	"--with-editable",
@@ -633,7 +634,7 @@ mod tests {
 	#[test]
 	fn uv_run_pytest_routes_to_python_filter() {
 		let config = MinimizerConfig::default();
-		let context = ctx("uv", Some("run"), "uv run pytest", &config);
+		let context = ctx("uv", Some("run"), "uv run --extra turso pytest", &config);
 		let input = "============================= test session starts \
 		             ==============================\ncollected 2 items\n\na.py .\nb.py \
 		             F\n\n=================================== FAILURES \

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `uv run --extra <package> pytest ...` bypassing native pytest minimization because the wrapper parser mistook the `--extra` value for the executable.
+
 ## [17.0.1] - 2026-07-16
 
 ### Fixed


### PR DESCRIPTION
## Summary

- treat `uv run --extra <package>` as a value-taking wrapper option
- keep the option value from being mistaken for the wrapped executable
- cover the regression through the pytest wrapper filter test

Without this, `uv run --extra turso pytest ...` resolves `turso` as the command and bypasses pytest output minimization.

## Verification

- `cargo test -p pi-shell` (832 passed)
- `cargo test -p pi-shell uv_run_pytest_routes_to_python_filter`