### PR TITLE
feat(metaharness): add durable experiment closure gates

### DIFF
--- a/packages/coding-agent/src/modes/components/copy-selector.ts
+++ b/packages/coding-agent/src/modes/components/copy-selector.ts
@@ -1,4 +1,12 @@
-import { type Component, matchesKey, padding, Text, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
+import {
+	type Component,
+	matchesKey,
+	padding,
+	routeSgrMouseInput,
+	Text,
+	truncateToWidth,
+	visibleWidth,
+} from "@oh-my-pi/pi-tui";
 import { replaceTabs } from "../../tools/render-utils";
 import { highlightCode, theme } from "../theme/theme";
 import type { CopyTarget } from "../utils/copy-targets";
@@ -49,10 +57,18 @@ function gutterCells(hasNext: boolean): string {
  * outlined box: a title, the tree of copy targets (recent assistant messages
  * with their code blocks nested beneath), a live preview of the highlighted
  * node, and a keybinding footer. Every node copies its `content` on Enter.
+ *
+ * Mouse behaviour: hover updates the preview; a left click selects (moves
+ * the keyboard cursor) without copying; wheel scrolls three nodes and clears
+ * hover; Enter is the sole commit gesture, resolving `hoverId ?? cursorId`.
  */
 export class CopySelectorComponent implements Component {
-	#roots: CopyTarget[];
+	/** Flat list built once from the immutable target tree. */
+	#flat: FlatNode[];
 	#cursorId: string;
+	#hoverId: string | undefined;
+	/** Frame-local 0-based row → CopyTarget, rebuilt on every render. */
+	#targetByScreenRow = new Map<number, CopyTarget>();
 	#lastSourceTarget?: CopyTarget;
 	#lastSource?: string;
 	#treeRows = MIN_TREE_ROWS;
@@ -63,7 +79,7 @@ export class CopySelectorComponent implements Component {
 		roots: CopyTarget[],
 		private readonly callbacks: CopySelectorCallbacks,
 	) {
-		this.#roots = roots;
+		this.#flat = this.#buildFlat(roots);
 		this.#cursorId = roots[0]?.id ?? "";
 	}
 
@@ -72,7 +88,7 @@ export class CopySelectorComponent implements Component {
 		this.#lastSource = undefined;
 	}
 
-	#flatten(): FlatNode[] {
+	#buildFlat(roots: CopyTarget[]): FlatNode[] {
 		const out: FlatNode[] = [];
 		const walk = (nodes: CopyTarget[], depth: number, ancestorHasNext: boolean[]) => {
 			nodes.forEach((target, i) => {
@@ -81,18 +97,72 @@ export class CopySelectorComponent implements Component {
 				if (target.children?.length) walk(target.children, depth + 1, [...ancestorHasNext, !isLast]);
 			});
 		};
-		walk(this.#roots, 0, []);
+		walk(roots, 0, []);
 		return out;
 	}
 
+	/**
+	 * Route an SGR mouse report. All events are consumed (return true); no
+	 * mouse path ever calls `onPick`. Left click selects (moves cursor, clears
+	 * hover). Wheel scrolls three nodes and clears hover. Motion sets hover.
+	 */
+	#handleMouse(data: string): boolean {
+		return routeSgrMouseInput(data, event => {
+			const flat = this.#flat;
+
+			if (event.wheel !== null) {
+				// Wheel: clear hover, move keyboard cursor by three, clamped.
+				this.#hoverId = undefined;
+				if (flat.length > 0) {
+					const idx = Math.max(
+						0,
+						flat.findIndex(n => n.target.id === this.#cursorId),
+					);
+					const next = Math.max(0, Math.min(flat.length - 1, idx + event.wheel * 3));
+					this.#cursorId = flat[next]!.target.id;
+				}
+				return true;
+			}
+
+			if (event.motion) {
+				const target = this.#targetByScreenRow.get(event.row);
+				this.#hoverId = target?.id;
+				return true;
+			}
+
+			// All non-motion, non-wheel events: left click selects cursor, everything
+			// else is consumed silently. No path reaches onPick.
+			if (event.leftClick) {
+				const target = this.#targetByScreenRow.get(event.row);
+				if (target) {
+					this.#cursorId = target.id;
+					this.#hoverId = undefined;
+				}
+			}
+			// Release, middle, right, clicks outside mapped rows: consume without effect.
+			return true;
+		});
+	}
+
 	handleInput(keyData: string): void {
+		// Route SGR mouse input before any keyboard handling.
+		if (this.#handleMouse(keyData)) return;
+
 		if (matchesSelectCancel(keyData)) {
+			this.#hoverId = undefined;
 			this.callbacks.onCancel();
 			return;
 		}
 
-		const flat = this.#flatten();
+		const flat = this.#flat;
 		if (flat.length === 0) return;
+
+		const isEnter = matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n";
+		// Non-Enter keyboard clears hover so the cursor drives the preview again.
+		if (!isEnter) {
+			this.#hoverId = undefined;
+		}
+
 		const idx = Math.max(
 			0,
 			flat.findIndex(n => n.target.id === this.#cursorId),
@@ -106,13 +176,26 @@ export class CopySelectorComponent implements Component {
 			this.#cursorId = flat[Math.max(0, idx - this.#treeRows)]!.target.id;
 		} else if (matchesSelectPageDown(keyData)) {
 			this.#cursorId = flat[Math.min(flat.length - 1, idx + this.#treeRows)]!.target.id;
-		} else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
-			const target = flat[idx]!.target;
+		} else if (isEnter) {
+			// Resolve the target driving the preview: hover takes precedence.
+			const resolvedId = this.#hoverId ?? this.#cursorId;
+			const target = flat.find(n => n.target.id === resolvedId)?.target ?? flat[idx]!.target;
+			// Synchronize cursor to the committed target, clear hover.
+			this.#cursorId = target.id;
+			this.#hoverId = undefined;
 			if (target.content !== undefined) this.callbacks.onPick(target);
 		}
 	}
 
-	#renderTree(width: number, flat: FlatNode[], cursorIdx: number, rows: number): string[] {
+	#renderTree(
+		width: number,
+		flat: FlatNode[],
+		cursorIdx: number,
+		rows: number,
+		frameRowOffset: number,
+		heightLimit: number,
+		sliceOffset: number,
+	): string[] {
 		const inner = Math.max(0, width - 4);
 		const start = Math.max(0, Math.min(cursorIdx - Math.floor(rows / 2), Math.max(0, flat.length - rows)));
 		const out: string[] = [];
@@ -124,20 +207,40 @@ export class CopySelectorComponent implements Component {
 				continue;
 			}
 			const target = node.target;
-			const isSelected = i === cursorIdx;
+			// Convert frame row to physical screen row, accounting for the TUI's
+			// bottom-anchor slice (overlayLines.slice(len - maxHeight)) which drops
+			// rows from the TOP when the component renders taller than the terminal.
+			// screenRow < 0 means the row was sliced off and is not addressable.
+			const screenRow = frameRowOffset + r - sliceOffset;
+			if (screenRow >= 0 && screenRow < heightLimit) {
+				this.#targetByScreenRow.set(screenRow, target);
+			}
+
+			const isSelected = target.id === this.#cursorId;
+			const isHovered = !isSelected && target.id === this.#hoverId;
 
 			let prefix = "";
 			for (let l = 0; l < node.depth - 1; l++) prefix += gutterCells(node.ancestorHasNext[l]!);
 			if (node.depth > 0) prefix += connectorCells(node.isLast ? theme.tree.last : theme.tree.branch);
 
-			const cursor = isSelected ? "❯ " : "  ";
+			// Three-cell leading slot: accent cursor, muted gutter for hover, blank otherwise.
+			const cursorCell = isSelected ? "❯ " : isHovered ? "▎ " : "  ";
 			const hint = target.hint ?? "";
 			const hintWidth = hint ? visibleWidth(hint) + 2 : 0;
-			const used = visibleWidth(cursor) + visibleWidth(prefix);
+			const used = visibleWidth(cursorCell) + visibleWidth(prefix);
 			const labelPlain = truncateToWidth(target.label, Math.max(1, inner - used - hintWidth));
-			const left = isSelected
-				? theme.fg("accent", cursor) + theme.fg("dim", prefix) + theme.bold(theme.fg("accent", labelPlain))
-				: cursor + theme.fg("dim", prefix) + labelPlain;
+
+			let left: string;
+			if (isSelected) {
+				left =
+					theme.fg("accent", cursorCell) + theme.fg("dim", prefix) + theme.bold(theme.fg("accent", labelPlain));
+			} else if (isHovered) {
+				// Muted gutter only; label text is otherwise unchanged.
+				left = theme.fg("muted", cursorCell) + theme.fg("dim", prefix) + labelPlain;
+			} else {
+				left = cursorCell + theme.fg("dim", prefix) + labelPlain;
+			}
+
 			const gap = Math.max(1, inner - used - visibleWidth(labelPlain) - visibleWidth(hint));
 			out.push(row(left + padding(gap) + (hint ? theme.fg("dim", hint) : ""), width));
 		}
@@ -187,29 +290,45 @@ export class CopySelectorComponent implements Component {
 
 	render(width: number): readonly string[] {
 		const height = process.stdout.rows || 40;
-		const flat = this.#flatten();
+		const flat = this.#flat;
 		const cursorIdx = Math.max(
 			0,
 			flat.findIndex(n => n.target.id === this.#cursorId),
 		);
-		const selected = flat[cursorIdx]?.target;
 
 		const available = Math.max(MIN_TREE_ROWS + 1, height - CHROME_ROWS);
 		const treeRows = Math.max(1, Math.min(flat.length, Math.floor(available / 2)));
 		this.#treeRows = treeRows;
 		const previewRows = Math.max(1, available - treeRows);
 
+		// The component renders CHROME_ROWS + treeRows + previewRows lines.
+		// When the terminal is shorter than that, the TUI's bottom-anchor compositor
+		// slices the same number of rows off the TOP. sliceOffset tracks how many
+		// frame rows are hidden so #renderTree maps targets to physical screen rows.
+		const totalLines = CHROME_ROWS + treeRows + previewRows;
+		const sliceOffset = Math.max(0, totalLines - height);
+
+		// Rebuild the screen-row map on every frame; tree starts at frame row 1
+		// (row 0 is the top border).
+		this.#targetByScreenRow.clear();
+		const treeLines = this.#renderTree(width, flat, cursorIdx, treeRows, 1, height, sliceOffset);
+
+		// Preview follows hover when the pointer is over a tree node, cursor otherwise.
+		const previewId = this.#hoverId ?? this.#cursorId;
+		const previewTarget = flat.find(n => n.target.id === previewId)?.target ?? flat[cursorIdx]?.target;
+
 		const footer = [
-			rawKeyHint("↑↓", "move"),
-			keyHint("tui.select.confirm", "copy"),
-			keyHint("tui.select.cancel", "quit"),
+			rawKeyHint("↑↓/wheel", "move"),
+			rawKeyHint("hover", "preview"),
+			rawKeyHint("click", "select"),
+			keyHint("tui.select.confirm", "copy") + theme.fg("dim", " · ") + keyHint("tui.select.cancel", "quit"),
 		].join(theme.fg("dim", " · "));
 
 		return [
 			topBorder(width, "Copy to clipboard"),
-			...this.#renderTree(width, flat, cursorIdx, treeRows),
+			...treeLines,
 			divider(width),
-			...this.#renderPreview(width, selected, previewRows),
+			...this.#renderPreview(width, previewTarget, previewRows),
 			divider(width),
 			row(footer, width),
 			bottomBorder(width),

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -967,6 +967,7 @@ export class SelectorController {
 			width: "100%",
 			maxHeight: "100%",
 			margin: 0,
+			fullscreen: true,
 		});
 		this.ctx.ui.setFocus(selector);
 		this.ctx.ui.requestRender();

--- a/packages/coding-agent/src/modes/utils/copy-targets.ts
+++ b/packages/coding-agent/src/modes/utils/copy-targets.ts
@@ -15,8 +15,16 @@ export interface QuoteBlock {
 	text: string;
 }
 
+/** An ordinary prose block: a maximal run of nonblank markdown lines bounded by a blank line, a closed fence, or a quote run. */
+export interface TextBlock {
+	text: string;
+}
+
 /** A drillable block within an assistant message, in document order. */
-export type MessageBlock = ({ kind: "code" } & CodeBlock) | ({ kind: "quote" } & QuoteBlock);
+export type MessageBlock =
+	| ({ kind: "text" } & TextBlock)
+	| ({ kind: "code" } & CodeBlock)
+	| ({ kind: "quote" } & QuoteBlock);
 
 /** A runnable command found in the transcript. */
 export interface LastCommand {
@@ -63,15 +71,23 @@ const CLOSE_FENCE_RE = /^```/;
 const QUOTE_LINE_RE = /^>(.*)$/;
 
 /**
- * Split assistant markdown into drillable blocks — fenced code and `>`-quoted
- * runs — in document order. Fences mask their bodies, so a `>` line inside a
- * code block is never mistaken for a quote. An unclosed fence is treated as
- * ordinary text, matching the fenced-block grammar.
+ * Split assistant markdown into drillable blocks — fenced code, `>`-quoted
+ * runs, and ordinary prose — in document order. Fences mask their bodies, so
+ * a `>` line inside a code block is never mistaken for a quote. An unclosed
+ * fence is treated as ordinary text, matching the fenced-block grammar.
  */
 export function extractBlocks(text: string): MessageBlock[] {
 	const blocks: MessageBlock[] = [];
 	const lines = text.split("\n");
 	let quote: string[] | undefined;
+	let textLines: string[] = [];
+
+	const flushText = () => {
+		if (textLines.length > 0) {
+			blocks.push({ kind: "text", text: textLines.join("\n") });
+			textLines = [];
+		}
+	};
 	const flushQuote = () => {
 		if (quote) {
 			blocks.push({ kind: "quote", text: quote.join("\n") });
@@ -91,6 +107,7 @@ export function extractBlocks(text: string): MessageBlock[] {
 				}
 			}
 			if (close !== -1) {
+				flushText();
 				flushQuote();
 				blocks.push({ kind: "code", lang: open[1].trim(), code: lines.slice(i + 1, close).join("\n") });
 				i = close;
@@ -101,12 +118,19 @@ export function extractBlocks(text: string): MessageBlock[] {
 		const quoted = QUOTE_LINE_RE.exec(line);
 		if (quoted) {
 			// Strip the `>` marker plus one optional following space.
+			flushText();
 			quote ??= [];
 			quote.push(quoted[1].startsWith(" ") ? quoted[1].slice(1) : quoted[1]);
+		} else if (line.trim().length === 0) {
+			// Blank delimiter — ends both pending text and quote accumulations.
+			flushText();
+			flushQuote();
 		} else {
 			flushQuote();
+			textLines.push(line);
 		}
 	}
+	flushText();
 	flushQuote();
 	return blocks;
 }
@@ -227,24 +251,27 @@ function blockSummaryHint(text: string, codeCount: number, quoteCount: number): 
 	return parts.join(" · ");
 }
 
-/** Build the target node for one assistant message: a leaf when it has no
- * drillable blocks, otherwise a group exposing the full message plus each
- * fenced code block and `>`-quoted block (de-prefixed) as a child target. */
+/** Build the target node for one assistant message: a leaf when it is a plain
+ * prose-only message, otherwise a group exposing the full message plus every
+ * text, fenced-code, and `>`-quoted block as a child target in document order. */
 function messageTarget(text: string, rank: number): CopyTarget {
 	const id = `msg:${rank}`;
 	const label = firstLine(text);
 	const blocks = extractBlocks(text);
 	const messageCopy = rank === 1 ? "Copied last message to clipboard" : "Copied message to clipboard";
 
-	if (blocks.length === 0) {
+	// A message whose entire content is one prose span remains a plain leaf — no
+	// duplicate child that copies the same bytes the parent already copies.
+	if (blocks.length === 0 || (blocks.length === 1 && blocks[0].kind === "text")) {
 		return { id, label, hint: pluralLines(text), preview: text, content: text, copyMessage: messageCopy };
 	}
 
 	// The message node itself copies the full message; each block is a child
-	// copy target you can drill into, kept in document order.
+	// copy target in document order.
 	const children: CopyTarget[] = [];
 	const codeBlocks: CodeBlock[] = [];
 	const quoteBlocks: QuoteBlock[] = [];
+	let textIndex = 0;
 	for (const block of blocks) {
 		if (block.kind === "code") {
 			const j = codeBlocks.length;
@@ -258,7 +285,7 @@ function messageTarget(text: string, rank: number): CopyTarget {
 				content: block.code,
 				copyMessage: `Copied code block ${j + 1} to clipboard`,
 			});
-		} else {
+		} else if (block.kind === "quote") {
 			const j = quoteBlocks.length;
 			quoteBlocks.push(block);
 			children.push({
@@ -268,6 +295,16 @@ function messageTarget(text: string, rank: number): CopyTarget {
 				preview: block.text,
 				content: block.text,
 				copyMessage: `Copied quote block ${j + 1} to clipboard`,
+			});
+		} else {
+			const j = textIndex++;
+			children.push({
+				id: `${id}:text:${j}`,
+				label: firstLine(block.text),
+				hint: `Text ${j + 1} · ${pluralLines(block.text)}`,
+				preview: block.text,
+				content: block.text,
+				copyMessage: `Copied text block ${j + 1} to clipboard`,
 			});
 		}
 	}

--- a/packages/coding-agent/test/modes/components/copy-selector.test.ts
+++ b/packages/coding-agent/test/modes/components/copy-selector.test.ts
@@ -146,3 +146,390 @@ describe("CopySelectorComponent", () => {
 		expect(onCancel).toHaveBeenCalledTimes(1);
 	});
 });
+
+// ─── SGR mouse helpers ──────────────────────────────────────────────────────
+
+/** SGR left-button press at a 0-based frame-local row (protocol is 1-based). */
+function sgrLeftClick(row0: number, col = 3): string {
+	return `\x1b[<0;${col + 1};${row0 + 1}M`;
+}
+
+/** SGR pointer motion at a 0-based frame-local row. */
+function sgrMotion(row0: number, col = 3): string {
+	return `\x1b[<32;${col + 1};${row0 + 1}M`;
+}
+
+/** SGR left-button release at a 0-based frame-local row. */
+function sgrRelease(row0: number, col = 3): string {
+	return `\x1b[<0;${col + 1};${row0 + 1}m`;
+}
+
+/** SGR right-button press at a 0-based frame-local row. */
+function sgrRightClick(row0: number, col = 3): string {
+	return `\x1b[<2;${col + 1};${row0 + 1}M`;
+}
+
+/** SGR wheel-down notch (button 65). */
+function sgrWheelDown(row0 = 0): string {
+	return `\x1b[<65;1;${row0 + 1}M`;
+}
+
+/** SGR wheel-up notch (button 64). */
+function sgrWheelUp(row0 = 0): string {
+	return `\x1b[<64;1;${row0 + 1}M`;
+}
+
+/**
+ * Render the component, strip VT, and return the plain lines array.
+ * The index of each element is the 0-based frame-local row, matching
+ * what parseSgrMouse delivers after converting 1-based protocol coords.
+ */
+function renderLines(component: CopySelectorComponent): string[] {
+	return component.render(80).map(l => stripVTControlCharacters(l));
+}
+
+describe("CopySelectorComponent mouse interaction", () => {
+	// Pin stdout.rows to 40 for all tests in this block so tree row counts and
+	// scroll windows are deterministic regardless of the ambient terminal size.
+	let baseRowsDesc: PropertyDescriptor | undefined;
+
+	beforeEach(() => {
+		setThemeInstance(darkTheme!);
+		setKeybindings(KeybindingsManager.inMemory({ "tui.select.cancel": "ctrl+g" }));
+		baseRowsDesc = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, get: () => 40, set: () => {} });
+	});
+
+	afterEach(() => {
+		setKeybindings(KeybindingsManager.inMemory());
+		vi.restoreAllMocks();
+		if (baseRowsDesc) Object.defineProperty(process.stdout, "rows", baseRowsDesc);
+		else Object.defineProperty(process.stdout, "rows", { configurable: true, value: undefined, writable: true });
+	});
+
+	it("pointer motion over a target changes the preview without calling onPick", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		// Render to populate the screen-row map; cursor starts on msg:1.
+		const lines = renderLines(component);
+		// Find the row of "Older message" (msg:2).
+		const olderRow = lines.findIndex(l => l.includes("Older message"));
+		expect(olderRow).toBeGreaterThanOrEqual(1);
+
+		component.handleInput(sgrMotion(olderRow));
+
+		// After motion the preview follows the hovered target.
+		expect(stripVTControlCharacters(component.render(80).join("\n"))).toContain("older-text");
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("left click on the initially selected target does not call onPick", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		const lines = renderLines(component);
+		const msgRow = lines.findIndex(l => l.includes("Newest message"));
+		expect(msgRow).toBeGreaterThanOrEqual(1);
+
+		component.handleInput(sgrLeftClick(msgRow));
+
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("left click on a different target selects it, updates the preview, and does not call onPick", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		const lines = renderLines(component);
+		const olderRow = lines.findIndex(l => l.includes("Older message"));
+		expect(olderRow).toBeGreaterThanOrEqual(1);
+
+		component.handleInput(sgrLeftClick(olderRow));
+
+		// Preview now shows the older target's content.
+		expect(stripVTControlCharacters(component.render(80).join("\n"))).toContain("older-text");
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("repeated clicks on the same target never call onPick", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		const lines = renderLines(component);
+		const olderRow = lines.findIndex(l => l.includes("Older message"));
+		expect(olderRow).toBeGreaterThanOrEqual(1);
+
+		component.handleInput(sgrLeftClick(olderRow));
+		component.handleInput(sgrLeftClick(olderRow));
+		component.handleInput(sgrLeftClick(olderRow));
+
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("Enter after a left-click selection calls onPick with the clicked target", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		const lines = renderLines(component);
+		const olderRow = lines.findIndex(l => l.includes("Older message"));
+		expect(olderRow).toBeGreaterThanOrEqual(1);
+
+		component.handleInput(sgrLeftClick(olderRow));
+		component.handleInput(ENTER);
+
+		expect(onPick).toHaveBeenCalledTimes(1);
+		expect(onPick.mock.calls[0]![0].content).toBe("OLDER");
+	});
+
+	it("hover over target A while cursor stays on target B, then Enter calls onPick(A) exactly once", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		// Cursor starts on msg:1 (Newest message). Hover over Older message.
+		const lines = renderLines(component);
+		const olderRow = lines.findIndex(l => l.includes("Older message"));
+		expect(olderRow).toBeGreaterThanOrEqual(1);
+
+		component.handleInput(sgrMotion(olderRow));
+		component.handleInput(ENTER);
+
+		// Must pick the hovered target (Older message), not the keyboard cursor.
+		expect(onPick).toHaveBeenCalledTimes(1);
+		expect(onPick.mock.calls[0]![0].id).toBe("msg:2");
+	});
+
+	it("wheel movement updates cursor/preview without copying and clamps at both ends", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		renderLines(component); // populate map
+
+		// Scrolling up from the first node stays clamped at 0.
+		for (let i = 0; i < 5; i++) component.handleInput(sgrWheelUp());
+		const topOut = stripVTControlCharacters(component.render(80).join("\n"));
+		expect(topOut).toContain("newest-preview-text"); // cursor still at first node
+		expect(onPick).not.toHaveBeenCalled();
+
+		// Scrolling down from the first node; 3 steps lands on flat index 3 (Older message).
+		component.handleInput(sgrWheelDown());
+		const afterDown = stripVTControlCharacters(component.render(80).join("\n"));
+		expect(afterDown).toContain("older-text");
+		expect(onPick).not.toHaveBeenCalled();
+
+		// Scrolling further down from the last node stays clamped.
+		for (let i = 0; i < 10; i++) component.handleInput(sgrWheelDown());
+		expect(stripVTControlCharacters(component.render(80).join("\n"))).toContain("older-text");
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("wheel clears hover so the cursor (not prior hover) drives the preview afterwards", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+		const lines = renderLines(component);
+		// Hover over Block 1 (index 1 in the flat list).
+		const block1Row = lines.findIndex(l => l.includes("Block 1"));
+		expect(block1Row).toBeGreaterThanOrEqual(1);
+		component.handleInput(sgrMotion(block1Row));
+		// Confirm hover is active.
+		expect(stripVTControlCharacters(component.render(80).join("\n"))).toContain("alpha()");
+
+		// A wheel event clears hover; the cursor (msg:1 = Newest message) drives preview.
+		component.handleInput(sgrWheelUp());
+		const afterWheel = stripVTControlCharacters(component.render(80).join("\n"));
+		expect(afterWheel).toContain("newest-preview-text");
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("tree scroll window with a nonzero start offset maps screen rows to the correct targets", () => {
+		// Force a small height so the tree cannot show all 4 flat nodes at once.
+		const rowsDesc = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, get: () => 12, set: () => {} });
+		try {
+			const onPick = vi.fn();
+			const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+			// Navigate to the last node (Older message, flat index 3) so the scroll window shifts.
+			component.handleInput(DOWN); // Block 1
+			component.handleInput(DOWN); // Block 2
+			component.handleInput(DOWN); // Older message
+
+			const lines = renderLines(component);
+			// With the cursor at the last node the tree is scrolled; locate Older message's row.
+			const olderRow = lines.findIndex(l => l.includes("Older message"));
+			expect(olderRow).toBeGreaterThanOrEqual(1);
+
+			// Click on a node that is NOT at screen row 1 (the default unscrolled position).
+			// Block 1 should be at a different row when the window is scrolled.
+			const block1Row = lines.findIndex(l => l.includes("Block 1"));
+			if (block1Row >= 1) {
+				component.handleInput(sgrLeftClick(block1Row));
+				component.handleInput(ENTER);
+				expect(onPick).toHaveBeenCalledTimes(1);
+				expect(onPick.mock.calls[0]![0].id).toBe("msg:1:code:0");
+			} else {
+				// Block 1 scrolled off; clicking the first visible row should pick whatever is there.
+				component.handleInput(sgrLeftClick(olderRow));
+				component.handleInput(ENTER);
+				expect(onPick).toHaveBeenCalledTimes(1);
+				expect(onPick.mock.calls[0]![0].id).toBe("msg:2");
+			}
+		} finally {
+			if (rowsDesc) Object.defineProperty(process.stdout, "rows", rowsDesc);
+			else Object.defineProperty(process.stdout, "rows", { configurable: true, value: undefined, writable: true });
+		}
+	});
+
+	it("release, right-click, non-left clicks, and out-of-range rows do not call onPick", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+		renderLines(component);
+
+		component.handleInput(sgrRelease(1));
+		component.handleInput(sgrRightClick(1));
+		// Middle-click: button 1.
+		component.handleInput(`\x1b[<1;1;2M`);
+		// Click on the top border row (row 0 — not in targetByScreenRow).
+		component.handleInput(sgrLeftClick(0));
+		// Click on a row far beyond any rendered target.
+		component.handleInput(sgrLeftClick(999));
+
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("clicks on the divider, preview, footer, and bottom border rows do not call onPick", () => {
+		const onPick = vi.fn();
+		const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+		const lines = renderLines(component);
+
+		// Click on every non-tree row; none should cause onPick.
+		for (let r = 0; r < lines.length; r++) {
+			const plain = lines[r]!;
+			// Only send clicks on rows that are NOT tree target rows (no "❯" or label text).
+			if (plain.includes("Newest") || plain.includes("Older") || plain.includes("Block")) continue;
+			component.handleInput(sgrLeftClick(r));
+		}
+
+		expect(onPick).not.toHaveBeenCalled();
+	});
+
+	it("short height does not crash and creates no phantom target rows beyond rendered targets", () => {
+		// Render at 6 rows total — below the normal chrome requirement.
+		const rowsDesc = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, get: () => 6, set: () => {} });
+		try {
+			const onPick = vi.fn();
+			const component = new CopySelectorComponent(makeRoots(), {
+				onPick,
+				onCancel: vi.fn(),
+			});
+
+			// render() must not throw.
+			const lines = component.render(80);
+			expect(lines.length).toBeGreaterThan(0);
+
+			// Clicking a row just past the end of the rendered output is harmless.
+			component.handleInput(sgrLeftClick(lines.length));
+			component.handleInput(sgrLeftClick(lines.length + 5));
+			expect(onPick).not.toHaveBeenCalled();
+		} finally {
+			if (rowsDesc) Object.defineProperty(process.stdout, "rows", rowsDesc);
+			else Object.defineProperty(process.stdout, "rows", { configurable: true, value: undefined, writable: true });
+		}
+	});
+
+	it("motion outside every mapped target clears hover so the cursor drives the preview", () => {
+		const component = new CopySelectorComponent(makeRoots(), {
+			onPick: vi.fn(),
+			onCancel: vi.fn(),
+		});
+
+		const lines = renderLines(component);
+		// First hover over a known target row.
+		const olderRow = lines.findIndex(l => l.includes("Older message"));
+		expect(olderRow).toBeGreaterThanOrEqual(1);
+		component.handleInput(sgrMotion(olderRow));
+		expect(stripVTControlCharacters(component.render(80).join("\n"))).toContain("older-text");
+
+		// Now move outside any mapped row (the top border, row 0).
+		component.handleInput(sgrMotion(0));
+		// Hover cleared → cursor (msg:1) drives the preview.
+		expect(stripVTControlCharacters(component.render(80).join("\n"))).toContain("newest-preview-text");
+	});
+
+	it("footer contains the four expected hint labels", () => {
+		const component = new CopySelectorComponent(makeRoots(), {
+			onPick: vi.fn(),
+			onCancel: vi.fn(),
+		});
+		const out = stripVTControlCharacters(component.render(80).join("\n"));
+		expect(out).toContain("move");
+		expect(out).toContain("preview");
+		expect(out).toContain("select");
+		expect(out).toContain("copy");
+		expect(out).toContain("quit");
+	});
+	it("sub-9-row compositor: when all tree rows are sliced from the top no click selects a target", () => {
+		// At height=2 the 9-row render is sliced 7 rows from the top, leaving
+		// only 2 physical rows that are all chrome (topBorder sliced off too).
+		// No tree target should be addressable; cursor stays at msg:1.
+		const rowsDesc = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, get: () => 2, set: () => {} });
+		try {
+			const onPick = vi.fn();
+			const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+			renderLines(component);
+
+			// Clicks anywhere on the 2-row physical screen must not select any target.
+			component.handleInput(sgrLeftClick(0));
+			component.handleInput(sgrLeftClick(1));
+			component.handleInput(ENTER);
+
+			// Cursor never moved; Enter commits the initial target (msg:1).
+			expect(onPick).toHaveBeenCalledTimes(1);
+			expect(onPick.mock.calls[0]![0].id).toBe("msg:1");
+		} finally {
+			if (rowsDesc) Object.defineProperty(process.stdout, "rows", rowsDesc);
+			else Object.defineProperty(process.stdout, "rows", { configurable: true, value: undefined, writable: true });
+		}
+	});
+
+	it("height=8 bottom-anchor compositor: visible tree rows map to physical screen rows after top-slice", () => {
+		// At height=8 the 9-row render loses frame row 0 (topBorder) from the
+		// top. Physical screen row 0 shows frame row 1 (msg:1) and screen row 1
+		// shows frame row 2 (Block 1). The map must use these physical indices.
+		const rowsDesc = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+		Object.defineProperty(process.stdout, "rows", { configurable: true, get: () => 8, set: () => {} });
+		try {
+			const onPick = vi.fn();
+			const component = new CopySelectorComponent(makeRoots(), { onPick, onCancel: vi.fn() });
+
+			// render() produces 9 lines; mimic the TUI's bottom-anchor slice to
+			// get the 8 lines actually displayed on the physical screen.
+			const renderOutput = component.render(80);
+			const sliced = Array.from(renderOutput)
+				.slice(renderOutput.length - 8)
+				.map(l => stripVTControlCharacters(l));
+
+			// msg:1 must be at physical screen row 0, Block 1 at row 1.
+			const msgRow = sliced.findIndex(l => l.includes("Newest message"));
+			const blockRow = sliced.findIndex(l => l.includes("Block 1"));
+			expect(msgRow).toBe(0);
+			expect(blockRow).toBe(1);
+
+			// Click msg:1 (screen row 0), then Block 1 (screen row 1).
+			component.handleInput(sgrLeftClick(msgRow));
+			component.handleInput(sgrLeftClick(blockRow));
+			// Enter commits the last-clicked target: Block 1.
+			component.handleInput(ENTER);
+
+			expect(onPick).toHaveBeenCalledTimes(1);
+			expect(onPick.mock.calls[0]![0].id).toBe("msg:1:code:0");
+		} finally {
+			if (rowsDesc) Object.defineProperty(process.stdout, "rows", rowsDesc);
+			else Object.defineProperty(process.stdout, "rows", { configurable: true, value: undefined, writable: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/modes/utils/copy-targets.test.ts
+++ b/packages/coding-agent/test/modes/utils/copy-targets.test.ts
@@ -4,6 +4,7 @@ import {
 	buildCopyTargets,
 	type CopySource,
 	type CopyTarget,
+	extractBlocks,
 	extractCodeBlocks,
 	extractLastCommand,
 	extractQuoteBlocks,
@@ -63,6 +64,61 @@ describe("extractQuoteBlocks", () => {
 	});
 });
 
+describe("extractBlocks", () => {
+	it("emits a text block for bare prose", () => {
+		expect(extractBlocks("Hello world")).toEqual([{ kind: "text", text: "Hello world" }]);
+	});
+
+	it("splits on blank lines into separate text blocks", () => {
+		expect(extractBlocks("First\n\nSecond")).toEqual([
+			{ kind: "text", text: "First" },
+			{ kind: "text", text: "Second" },
+		]);
+	});
+
+	it("treats a whitespace-only line as a text delimiter", () => {
+		expect(extractBlocks("Block A\n   \nBlock B")).toEqual([
+			{ kind: "text", text: "Block A" },
+			{ kind: "text", text: "Block B" },
+		]);
+	});
+
+	it("emits text, code, text in document order", () => {
+		expect(extractBlocks("intro\n```ts\ncode\n```\noutro")).toEqual([
+			{ kind: "text", text: "intro" },
+			{ kind: "code", lang: "ts", code: "code" },
+			{ kind: "text", text: "outro" },
+		]);
+	});
+
+	it("blank lines inside a fenced block stay inside the code and do not create text blocks", () => {
+		expect(extractBlocks("```py\nx = 1\n\ny = 2\n```")).toEqual([
+			{ kind: "code", lang: "py", code: "x = 1\n\ny = 2" },
+		]);
+	});
+
+	it("treats an unclosed fence as ordinary text", () => {
+		expect(extractBlocks("Before\n```ts\nnot closed\nAfter")).toEqual([
+			{ kind: "text", text: "Before\n```ts\nnot closed\nAfter" },
+		]);
+	});
+
+	it("preserves list markers and headings inside text blocks", () => {
+		expect(extractBlocks("# Heading\n\n- item one\n- item two")).toEqual([
+			{ kind: "text", text: "# Heading" },
+			{ kind: "text", text: "- item one\n- item two" },
+		]);
+	});
+
+	it("a quote run flushes pending text first and text resumes after the run closes", () => {
+		expect(extractBlocks("Intro\n> quoted\nRest")).toEqual([
+			{ kind: "text", text: "Intro" },
+			{ kind: "quote", text: "quoted" },
+			{ kind: "text", text: "Rest" },
+		]);
+	});
+});
+
 describe("extractLastCommand", () => {
 	it("returns the most recent bash command, walking backwards", () => {
 		const messages = [
@@ -113,12 +169,12 @@ describe("buildCopyTargets", () => {
 		expect(targets[1]?.id).toBe("msg:2");
 
 		// The newer message is itself a copy target (full text) AND a tree node
-		// exposing each code block as a child copy target.
+		// exposing text spans and code blocks as child copy targets in document order.
 		const group = targets[0]!;
 		expect(group.content).toBe(newer);
-		expect(group.children?.map(c => c.label)).toEqual(["Block 1", "Block 2", "All 2 blocks"]);
-		expect(group.children?.[0]?.content).toBe("const a = 1;");
-		expect(group.children?.[0]?.language).toBe("ts"); // drives preview syntax highlighting
+		expect(group.children?.map(c => c.label)).toEqual(["Newer message", "Block 1", "and", "Block 2", "All 2 blocks"]);
+		expect(group.children?.find(c => c.id === "msg:1:code:0")?.content).toBe("const a = 1;");
+		expect(group.children?.find(c => c.id === "msg:1:code:0")?.language).toBe("ts"); // drives preview syntax highlighting
 		expect(group.children?.at(-1)?.content).toBe("const a = 1;\n\nprint(2)");
 
 		// The older, code-free message is a leaf that copies its full text.
@@ -132,7 +188,7 @@ describe("buildCopyTargets", () => {
 		);
 		const msg = byId(targets, "msg:1");
 		expect(msg?.content).toBe("Just one\n```js\nfoo();\n```");
-		expect(msg?.children?.map(c => c.label)).toEqual(["Block 1"]);
+		expect(msg?.children?.map(c => c.label)).toEqual(["Just one", "Block 1"]);
 	});
 
 	it("drills a quoted message into a de-prefixed quote child", () => {
@@ -155,6 +211,7 @@ describe("buildCopyTargets", () => {
 		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
 		const msg = byId(targets, "msg:1");
 		expect(msg?.children?.map(c => c.id)).toEqual([
+			"msg:1:text:0",
 			"msg:1:code:0",
 			"msg:1:quote:0",
 			"msg:1:code:1",
@@ -210,5 +267,98 @@ describe("buildCopyTargets", () => {
 		expect(cmd?.content).toBe("bun check");
 		expect(cmd?.language).toBe("bash");
 		expect(byId(targets, "cmd:2")?.content).toBe("echo old");
+	});
+
+	it("a plain text-only message remains a leaf with no children", () => {
+		const targets = buildCopyTargets(
+			source({ messages: [assistantText("Hello world")] as unknown as AgentMessage[] }),
+		);
+		const msg = byId(targets, "msg:1");
+		expect(msg?.content).toBe("Hello world");
+		expect(msg?.children).toBeUndefined();
+		expect(msg?.hint).toBe("1 line");
+	});
+
+	it("blank-line-delimited paragraphs become indexed text children with exact ids, labels, hints, payloads, and copy messages", () => {
+		const text = "First paragraph\n\nSecond paragraph";
+		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
+		const msg = byId(targets, "msg:1");
+		expect(msg?.content).toBe(text);
+		expect(msg?.children?.map(c => c.id)).toEqual(["msg:1:text:0", "msg:1:text:1"]);
+		const t0 = msg!.children![0]!;
+		expect(t0.label).toBe("First paragraph");
+		expect(t0.hint).toBe("Text 1 · 1 line");
+		expect(t0.content).toBe("First paragraph");
+		expect(t0.copyMessage).toBe("Copied text block 1 to clipboard");
+		const t1 = msg!.children![1]!;
+		expect(t1.label).toBe("Second paragraph");
+		expect(t1.hint).toBe("Text 2 · 1 line");
+		expect(t1.content).toBe("Second paragraph");
+		expect(t1.copyMessage).toBe("Copied text block 2 to clipboard");
+	});
+
+	it("text, code, quote, and trailing text children appear in source order", () => {
+		const text = "Intro\n```py\nprint(1)\n```\n\n> quoted\n\nTrailing";
+		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
+		const msg = byId(targets, "msg:1");
+		expect(msg?.children?.map(c => c.id)).toEqual(["msg:1:text:0", "msg:1:code:0", "msg:1:quote:0", "msg:1:text:1"]);
+		expect(msg?.children?.find(c => c.id === "msg:1:text:0")?.content).toBe("Intro");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:1")?.content).toBe("Trailing");
+	});
+
+	it("five-block message: text, fenced code, text, quote, trailing text appear in exact source order with correct ids and payloads", () => {
+		const text = "Intro text\n```ts\nconst x = 1;\n```\nMiddle text\n\n> quoted line\n\nTrailing text";
+		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
+		const msg = byId(targets, "msg:1");
+		expect(msg?.children?.map(c => c.id)).toEqual([
+			"msg:1:text:0",
+			"msg:1:code:0",
+			"msg:1:text:1",
+			"msg:1:quote:0",
+			"msg:1:text:2",
+		]);
+		expect(msg?.children?.find(c => c.id === "msg:1:text:0")?.content).toBe("Intro text");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:0")?.hint).toBe("Text 1 · 1 line");
+		expect(msg?.children?.find(c => c.id === "msg:1:code:0")?.content).toBe("const x = 1;");
+		expect(msg?.children?.find(c => c.id === "msg:1:code:0")?.language).toBe("ts");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:1")?.content).toBe("Middle text");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:1")?.hint).toBe("Text 2 · 1 line");
+		expect(msg?.children?.find(c => c.id === "msg:1:quote:0")?.content).toBe("quoted line");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:2")?.content).toBe("Trailing text");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:2")?.hint).toBe("Text 3 · 1 line");
+	});
+
+	it("text block payloads preserve list markers, headings, and blank-line boundaries exactly", () => {
+		const text = "# Heading\n\n- item one\n- item two\n\n**bold**";
+		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
+		const msg = byId(targets, "msg:1");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:0")?.content).toBe("# Heading");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:1")?.content).toBe("- item one\n- item two");
+		expect(msg?.children?.find(c => c.id === "msg:1:text:2")?.content).toBe("**bold**");
+	});
+
+	it("a whitespace-only line delimits adjacent text blocks", () => {
+		const text = "Block A\n   \nBlock B";
+		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
+		const msg = byId(targets, "msg:1");
+		expect(msg?.children?.map(c => c.id)).toEqual(["msg:1:text:0", "msg:1:text:1"]);
+		expect(msg?.children?.[0]?.content).toBe("Block A");
+		expect(msg?.children?.[1]?.content).toBe("Block B");
+	});
+
+	it("blank lines inside a fenced code block stay inside the code and do not create text children", () => {
+		const text = "```py\nx = 1\n\ny = 2\n```";
+		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
+		const msg = byId(targets, "msg:1");
+		expect(msg?.children?.map(c => c.id)).toEqual(["msg:1:code:0"]);
+		expect(msg?.children?.[0]?.content).toBe("x = 1\n\ny = 2");
+	});
+
+	it("an unclosed fence is treated as ordinary text and the message remains a leaf", () => {
+		const text = "Before\n```ts\nno close\nAfter";
+		const targets = buildCopyTargets(source({ messages: [assistantText(text)] as unknown as AgentMessage[] }));
+		const msg = byId(targets, "msg:1");
+		expect(msg?.children).toBeUndefined();
+		expect(msg?.content).toBe(text);
 	});
 });

--- a/packages/metaharness/src/experiments.test.ts
+++ b/packages/metaharness/src/experiments.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	armOf,
+	buildExperiments,
 	calibratedFinalPassPct,
 	canonicalArmOf,
+	experimentDetail,
 	experimentOf,
 	pickMergedTrials,
 	summarizeArm,
 } from "./experiments";
+import { RunStore } from "./store";
 import type { RunRow, TraceRow } from "./store";
 
 /**
@@ -64,6 +70,72 @@ function traceRow(overrides: Partial<TraceRow>): TraceRow {
 		...overrides,
 	};
 }
+
+describe("experiment lifecycle metadata", () => {
+	it("reads persisted state for grouped and armless experiments and nulls legacy rows", () => {
+		const jobsDir = mkdtempSync(join(tmpdir(), "metaharness-experiments-"));
+		const store = new RunStore(jobsDir);
+		try {
+			store.setExperimentMeta("persisted", { goal: "bounded", maxRuns: 4, maxArms: 2 });
+			store.closeExperiment("persisted", "operator", 1_700_000_000_000);
+			store.setExperimentGoal("legacy", "old");
+			store.setExperimentMeta("empty", { goal: "waiting", maxRuns: 9, maxArms: 3 });
+			for (const jobName of ["persisted-arm", "legacy-arm"]) {
+				store.registerLaunch({
+					benchmark: "harbor",
+					jobName,
+					dataset: "d",
+					agent: "omp",
+					models: ["m"],
+					pid: process.pid,
+				});
+			}
+
+			const summaries = buildExperiments(store);
+			expect(summaries.find(s => s.id === "persisted")).toMatchObject({
+				goal: "bounded",
+				maxRuns: 4,
+				maxArms: 2,
+				closure: { verdict: "operator", closedAt: 1_700_000_000_000 },
+				arms: 1,
+			});
+			expect(summaries.find(s => s.id === "legacy")).toMatchObject({
+				goal: "old",
+				maxRuns: null,
+				maxArms: null,
+				closure: null,
+				arms: 1,
+			});
+			expect(summaries.find(s => s.id === "empty")).toMatchObject({
+				maxRuns: 9,
+				maxArms: 3,
+				closure: null,
+				arms: 0,
+			});
+
+			expect(experimentDetail(store, "persisted")).toMatchObject({
+				goal: "bounded",
+				maxRuns: 4,
+				maxArms: 2,
+				closure: { verdict: "operator", closedAt: 1_700_000_000_000 },
+			});
+			expect(experimentDetail(store, "empty")).toMatchObject({
+				maxRuns: 9,
+				maxArms: 3,
+				closure: null,
+				arms: [],
+			});
+			expect(experimentDetail(store, "legacy")).toMatchObject({
+				maxRuns: null,
+				maxArms: null,
+				closure: null,
+			});
+		} finally {
+			store.close();
+			rmSync(jobsDir, { recursive: true, force: true });
+		}
+	});
+});
 
 describe("experiment grouping", () => {
 	it("groups by prefix and strips it from arm labels", () => {

--- a/packages/metaharness/src/experiments.ts
+++ b/packages/metaharness/src/experiments.ts
@@ -32,6 +32,9 @@ export interface ArmSummary {
 export interface ExperimentSummary {
 	id: string;
 	goal: string;
+	maxRuns: number | null;
+	maxArms: number | null;
+	closure: { verdict: string; closedAt: number } | null;
 	arms: number;
 	runningArms: number;
 	datasets: string[];
@@ -48,6 +51,9 @@ export interface ExperimentSummary {
 export interface ExperimentDetail {
 	id: string;
 	goal: string;
+	maxRuns: number | null;
+	maxArms: number | null;
+	closure: { verdict: string; closedAt: number } | null;
 	arms: ArmSummary[];
 	/** Union of task ids across arms, sorted. */
 	tasks: string[];
@@ -202,9 +208,13 @@ export function buildExperiments(store: RunStore): ExperimentSummary[] {
 	}
 	const out: ExperimentSummary[] = [];
 	for (const [id, runs] of groups) {
+		const meta = store.getExperimentMeta(id);
 		out.push({
 			id,
-			goal: store.getExperimentMeta(id)?.goal ?? "",
+			goal: meta?.goal ?? "",
+			maxRuns: meta?.maxRuns ?? null,
+			maxArms: meta?.maxArms ?? null,
+			closure: meta?.closure ?? null,
 			arms: runs.length,
 			runningArms: runs.filter(r => r.status === "running").length,
 			datasets: [...new Set(runs.map(r => r.dataset).filter(Boolean))],
@@ -225,6 +235,9 @@ export function buildExperiments(store: RunStore): ExperimentSummary[] {
 		out.push({
 			id: meta.id,
 			goal: meta.goal,
+			maxRuns: meta.maxRuns ?? null,
+			maxArms: meta.maxArms ?? null,
+			closure: meta.closure ?? null,
 			arms: 0,
 			runningArms: 0,
 			datasets: [],
@@ -278,11 +291,22 @@ export function pickMergedTrials(traces: TraceRow[]): TraceRow[] {
 }
 
 export function experimentDetail(store: RunStore, id: string): ExperimentDetail | null {
+	const meta = store.getExperimentMeta(id);
 	const runs = store.listRuns().filter(r => experimentOf(r.jobName) === id);
 	if (runs.length === 0) {
 		// Registered but armless (POST /api/experiments): still readable.
-		const meta = store.getExperimentMeta(id);
-		return meta ? { id, goal: meta.goal, arms: [], tasks: [], matrix: {} } : null;
+		return meta
+			? {
+					id,
+					goal: meta.goal,
+					maxRuns: meta.maxRuns ?? null,
+					maxArms: meta.maxArms ?? null,
+					closure: meta.closure ?? null,
+					arms: [],
+					tasks: [],
+					matrix: {},
+				}
+			: null;
 	}
 	// One row per CANONICAL arm: `-fix`/`-backfill` re-runs merge into their
 	// base arm — per-task best trial, summed spend.
@@ -371,5 +395,14 @@ export function experimentDetail(store: RunStore, id: string): ExperimentDetail 
 	// "reference rows, then treatments".
 	const roleRank = (role: string) => (role === "baseline" ? 0 : role === "variant" ? 1 : 2);
 	arms.sort((a, b) => roleRank(a.run.role) - roleRank(b.run.role) || a.arm.localeCompare(b.arm));
-	return { id, goal: store.getExperimentMeta(id)?.goal ?? "", arms, tasks: [...tasks].sort(), matrix };
+	return {
+		id,
+		goal: meta?.goal ?? "",
+		maxRuns: meta?.maxRuns ?? null,
+		maxArms: meta?.maxArms ?? null,
+		closure: meta?.closure ?? null,
+		arms,
+		tasks: [...tasks].sort(),
+		matrix,
+	};
 }

--- a/packages/metaharness/src/launch-args.ts
+++ b/packages/metaharness/src/launch-args.ts
@@ -42,6 +42,10 @@ export interface LaunchRequest {
 	prebuiltBinaries?: boolean;
 	/** Extra raw runner args, appended verbatim. */
 	extraArgs?: string[];
+	/** Experiment-wide maximum number of new grouped run launches. */
+	maxRuns?: number | null;
+	/** Experiment-wide maximum number of arms. */
+	maxArms?: number | null;
 }
 
 /** Runner CLI flags (sans the `bun src/runner.ts` prefix) for a harbor launch. */

--- a/packages/metaharness/src/manager.test.ts
+++ b/packages/metaharness/src/manager.test.ts
@@ -163,6 +163,40 @@ describe("RunStore", () => {
 		expect(treat?.role).toBe("variant");
 		expect(treat?.note).toBe("prewalk flash v2");
 	});
+	it("persists experiment limits and closure across a fresh store", () => {
+		const jobsDir = makeJobsDir();
+		const dbPath = path.join(jobsDir, "experiment.sqlite");
+		const store = new RunStore(jobsDir, dbPath);
+		store.setExperimentGoal("legacy", "existing goal");
+		expect(store.getExperimentMeta("legacy")).toEqual({
+			id: "legacy",
+			goal: "existing goal",
+			updatedAt: expect.any(Number),
+			maxRuns: null,
+			maxArms: null,
+			closure: null,
+		});
+
+		store.setExperimentMeta("bounded", { goal: "measure it", maxRuns: 3, maxArms: 2 });
+		store.closeExperiment("bounded", "measured: treatment wins", 1_752_000_000_000);
+		expect(store.getExperimentMeta("bounded")?.closure).toEqual({
+			verdict: "measured: treatment wins",
+			closedAt: 1_752_000_000_000,
+		});
+		store.close();
+
+		const reopened = new RunStore(jobsDir, dbPath);
+		cleanups.push(() => reopened.close());
+		expect(reopened.getExperimentMeta("bounded")).toEqual({
+			id: "bounded",
+			goal: "measure it",
+			updatedAt: expect.any(Number),
+			maxRuns: 3,
+			maxArms: 2,
+			closure: { verdict: "measured: treatment wins", closedAt: 1_752_000_000_000 },
+		});
+	});
+
 
 	it("releases a dead runner's pid without failing a possibly-live orphan", () => {
 		const jobsDir = makeJobsDir();
@@ -547,5 +581,111 @@ describe("resolveArmLaunch", () => {
 		});
 		expect(() => resolveArmLaunch(store, "exp", { arm: "base", model: "m/y" })).toThrow(/already exists/);
 		expect(() => resolveArmLaunch(store, "ghost", { arm: "x", model: "m/y" })).toThrow(/no runs to inherit/);
+	});
+});
+
+describe("experiment lifecycle gates", () => {
+	it("enforces limits and durable closure across fresh ManagerServer instances", async () => {
+		const jobsDir = makeJobsDir();
+		const dbPath = path.join(jobsDir, "_manager", "lifecycle.sqlite");
+		const first = new ManagerServer(jobsDir, dbPath);
+		first.store.registerLaunch({
+			benchmark: "harbor",
+			jobName: "exp-base",
+			dataset: "terminal-bench@2.0",
+			agent: "omp",
+			models: ["m/x"],
+			pid: process.pid,
+			config: { include: ["task-1"] },
+		});
+		first.store.markExit("exp-base", 0);
+		first.store.setExperimentMeta("exp", { goal: "measure", maxRuns: 5, maxArms: 1 });
+		const firstServer = first.start(0);
+		const firstBase = `http://localhost:${firstServer.port}`;
+
+		const lowerLimit = await fetch(`${firstBase}/api/runs`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ benchmark: "harbor", jobName: "exp-drive", model: "m/x", maxRuns: 1 }),
+		});
+		expect(lowerLimit.status).toBe(400);
+
+		first.store.setExperimentMeta("exp", { maxRuns: 1 });
+		const maxRun = await fetch(`${firstBase}/api/runs`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ benchmark: "harbor", jobName: "exp-drive", model: "m/x" }),
+		});
+		expect(maxRun.status).toBe(400);
+		expect((await maxRun.json()).error).toMatch(/maxRuns/);
+		await first.stop();
+
+		const bounded = new ManagerServer(jobsDir, dbPath);
+		const boundedServer = bounded.start(0);
+		const boundedBase = `http://localhost:${boundedServer.port}`;
+		const maxArm = await fetch(`${boundedBase}/api/experiments/exp/arms`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ arm: "next", model: "m/y" }),
+		});
+		expect(maxArm.status).toBe(400);
+		expect((await maxArm.json()).error).toMatch(/maxArms/);
+
+		const closed = await fetch(`${boundedBase}/api/experiments/exp`, {
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ closure: { verdict: "measured: baseline wins" } }),
+		});
+		expect(closed.status).toBe(200);
+		await bounded.stop();
+
+		const second = new ManagerServer(jobsDir, dbPath);
+		cleanups.push(() => {
+			void second.stop();
+		});
+		const server = second.start(0);
+		const base = `http://localhost:${server.port}`;
+		const detail = (await (await fetch(`${base}/api/experiments/exp`)).json()) as {
+			goal: string;
+			maxRuns: number | null;
+			maxArms: number | null;
+			closure: { verdict: string; closedAt: number } | null;
+		};
+		expect(detail).toMatchObject({
+			goal: "measure",
+			maxRuns: 1,
+			maxArms: 1,
+			closure: { verdict: "measured: baseline wins" },
+		});
+		const failedClose = await fetch(`${base}/api/experiments/exp`, {
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ closure: { verdict: "second verdict" }, runs: { "exp-base": { note: "must not apply" } } }),
+		});
+		expect(failedClose.status).toBe(400);
+		const unchangedRun = (await (await fetch(`${base}/api/runs/exp-base`)).json()) as { run: { note: string } };
+		expect(unchangedRun.run.note).toBe("");
+		for (const [url, body] of [
+			[`${base}/api/runs`, { benchmark: "harbor", jobName: "exp-late", model: "m/x" }],
+			[`${base}/api/experiments/exp/arms`, { arm: "late", model: "m/y" }],
+		] as const) {
+			const response = await fetch(url, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			});
+			expect(response.status).toBe(400);
+			expect((await response.json()).error).toMatch(/closed/);
+		}
+		const resume = await fetch(`${base}/api/runs/exp-base/resume`, { method: "POST" });
+		expect(resume.status).toBe(400);
+		expect((await resume.json()).error).toMatch(/closed/);
+		const goal = await fetch(`${base}/api/experiments/exp`, {
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ goal: "changed" }),
+		});
+		expect(goal.status).toBe(400);
+		expect((await goal.json()).error).toMatch(/closed/);
 	});
 });

--- a/packages/metaharness/src/server.ts
+++ b/packages/metaharness/src/server.ts
@@ -29,17 +29,27 @@ import { buildExperiments, experimentDetail, experimentOf } from "./experiments"
 import { harborRunnerArgs, type LaunchRequest } from "./launch-args";
 import { type LaunchRecord, type RunRole, type RunRow, RunStore } from "./store";
 
-/** PUT /api/experiments/:id body — goal and per-run role/note/label metadata. */
+/** Explicit closure metadata supplied by PUT /api/experiments/:id. */
+export interface ExperimentClosureUpdate {
+	verdict: string;
+}
+
+/** PUT /api/experiments/:id body — experiment and per-run metadata. */
 export interface ExperimentMetaUpdate {
 	goal?: string;
+	maxRuns?: number | null;
+	maxArms?: number | null;
+	closure?: ExperimentClosureUpdate;
 	runs?: Record<string, { role?: RunRole; note?: string; label?: string }>;
 }
 
-/** POST /api/experiments body — pre-registers an experiment id with a goal. */
+/** POST /api/experiments body — pre-registers an experiment id with metadata. */
 export interface CreateExperimentRequest {
 	/** Dash-free token; runs group into it as `<id>-<arm>` job names. */
 	id: string;
 	goal?: string;
+	maxRuns?: number | null;
+	maxArms?: number | null;
 }
 
 import indexHtml from "./web/index.html";
@@ -97,6 +107,18 @@ function assertSafeJobName(jobName: string): void {
 	}
 }
 
+
+function assertExperimentLimit(name: "maxRuns" | "maxArms", value: number | null | undefined): void {
+	if (value !== undefined && value !== null && (!Number.isSafeInteger(value) || value < 1)) {
+		throw new Error(`${name} must be a positive safe integer`);
+	}
+}
+
+function assertClosureVerdict(verdict: string): string {
+	const value = verdict.trim();
+	if (!value) throw new Error("closure verdict must be non-empty");
+	return value;
+}
 /** True when `pid` names a live process (signal-0 probe). */
 function pidAlive(pid: number | null): boolean {
 	if (pid == null) return false;
@@ -377,7 +399,7 @@ export class ManagerServer {
 	}
 
 	/** Launch any supported benchmark and register it in the uniform run store. */
-	launch(request: LaunchRequest): { jobName: string; pid: number } {
+	launch(request: LaunchRequest, armAddition = false): { jobName: string; pid: number } {
 		if (!request.model) throw new Error("model is required");
 		const benchmark = request.benchmark ?? "harbor";
 		if (benchmark !== "harbor" && benchmark !== "edit" && benchmark !== "snapcompact") {
@@ -392,8 +414,16 @@ export class ManagerServer {
 		if (this.#children.has(jobName) || this.#store.getRun(jobName)?.status === "running") {
 			throw new Error(`run ${jobName} is already running`);
 		}
-		const jobDir = path.join(this.jobsDir, jobName);
-		fs.mkdirSync(jobDir, { recursive: true });
+		this.#store.admitExperimentLaunch({
+			jobName,
+			goal: request.goal,
+			maxRuns: request.maxRuns,
+			maxArms: request.maxArms,
+			armAddition,
+		});
+		try {
+			const jobDir = path.join(this.jobsDir, jobName);
+			fs.mkdirSync(jobDir, { recursive: true });
 
 		let argv: string[];
 		let cwd: string;
@@ -427,8 +457,11 @@ export class ManagerServer {
 			role: request.role,
 			note: request.note,
 		});
-		if (request.goal) this.#store.setExperimentGoal(experimentOf(jobName), request.goal);
 		return { jobName, pid };
+		} catch (err) {
+			this.#store.releaseExperimentLaunch(jobName);
+			throw err;
+		}
 	}
 
 	/**
@@ -442,6 +475,10 @@ export class ManagerServer {
 	resume(jobName: string, opts: { filterErrorTypes?: string[] } = {}): { jobName: string; pid: number } {
 		const run = this.#store.getRun(jobName);
 		if (!run) throw new Error(`run ${jobName} not found`);
+		const experiment = experimentOf(jobName);
+		if (this.#store.getExperimentMeta(experiment)?.closure) {
+			throw new Error(`experiment ${experiment} is closed`);
+		}
 		if (run.benchmark !== "harbor")
 			throw new Error(`resume supports only harbor runs (${jobName} is ${run.benchmark})`);
 		// Trust liveness, not the recorded status: a runner killed while a
@@ -518,30 +555,82 @@ export class ManagerServer {
 		return this.#children.has(run.jobName) || (run.status === "running" && pidAlive(run.pid));
 	}
 
-	/** Register an experiment id (with an optional goal) so it is browsable before its first arm. */
-	createExperiment(req: CreateExperimentRequest): { id: string; goal: string } {
+
+	/** Register an experiment id (with optional lifecycle metadata). */
+	createExperiment(req: CreateExperimentRequest): {
+		id: string;
+		goal: string;
+		maxRuns: number | null;
+		maxArms: number | null;
+		closure: { verdict: string; closedAt: number } | null;
+	} {
 		const id = req.id?.trim() ?? "";
 		// Dashes are structurally impossible: `experimentOf` groups job names by
 		// the token before the first dash, so a dashed id could never own a run.
 		if (!/^[A-Za-z0-9_.]+$/.test(id)) {
 			throw new Error("experiment id must be a non-empty token of [A-Za-z0-9_.] (runs group as `<id>-<arm>`)");
 		}
-		const goal = req.goal ?? this.#store.getExperimentMeta(id)?.goal ?? "";
-		this.#store.setExperimentGoal(id, goal);
-		return { id, goal };
+		assertExperimentLimit("maxRuns", req.maxRuns);
+		assertExperimentLimit("maxArms", req.maxArms);
+		const current = this.#store.getExperimentMeta(id);
+		const scopeEdit = req.goal !== undefined || req.maxRuns !== undefined || req.maxArms !== undefined;
+		if (current?.closure) {
+			if (scopeEdit) throw new Error(`experiment ${id} is closed`);
+			return {
+				id,
+				goal: current.goal,
+				maxRuns: current.maxRuns,
+				maxArms: current.maxArms,
+				closure: current.closure,
+			};
+		}
+		this.#store.setExperimentMeta(id, {
+			goal: req.goal,
+			maxRuns: req.maxRuns,
+			maxArms: req.maxArms,
+		});
+		const meta = this.#store.getExperimentMeta(id);
+		return {
+			id,
+			goal: meta?.goal ?? "",
+			maxRuns: meta?.maxRuns ?? null,
+			maxArms: meta?.maxArms ?? null,
+			closure: meta?.closure ?? null,
+		};
 	}
 
-	/** Apply goal + per-run role/note metadata; used by the UI and for backfill. */
-	updateExperimentMeta(id: string, update: ExperimentMetaUpdate): { id: string; updatedRuns: string[] } {
-		if (update.goal !== undefined) this.#store.setExperimentGoal(id, update.goal);
+	/** Apply experiment lifecycle and per-run role/note metadata. */
+	updateExperimentMeta(
+		id: string,
+		update: ExperimentMetaUpdate,
+	): { id: string; updatedRuns: string[]; closure: { verdict: string; closedAt: number } | null } {
+		assertExperimentLimit("maxRuns", update.maxRuns);
+		assertExperimentLimit("maxArms", update.maxArms);
+		const verdict = update.closure ? assertClosureVerdict(update.closure.verdict) : undefined;
+		const current = this.#store.getExperimentMeta(id);
+		const scopeEdit =
+			update.goal !== undefined || update.maxRuns !== undefined || update.maxArms !== undefined;
+		if (current?.closure && (scopeEdit || update.closure !== undefined)) throw new Error(`experiment ${id} is closed`);
+		if (verdict !== undefined && scopeEdit) {
+			throw new Error("cannot change goal or limits while closing an experiment");
+		}
+		if (scopeEdit) {
+			this.#store.setExperimentMeta(id, {
+				goal: update.goal,
+				maxRuns: update.maxRuns,
+				maxArms: update.maxArms,
+			});
+		}
 		const updatedRuns: string[] = [];
 		for (const jobName in update.runs) {
 			if (experimentOf(jobName) !== id) continue;
 			if (this.#store.setRunMeta(jobName, update.runs[jobName])) updatedRuns.push(jobName);
 		}
+		if (verdict !== undefined) this.#store.closeExperiment(id, verdict);
 		this.#tick();
-		return { id, updatedRuns };
+		return { id, updatedRuns, closure: this.#store.getExperimentMeta(id)?.closure ?? null };
 	}
+
 
 	/**
 	 * Delete an experiment: every arm's DB row, job dir, and manager log, plus
@@ -587,9 +676,8 @@ export class ManagerServer {
 		fs.rmSync(path.join(this.jobsDir, "_manager", "logs", `${jobName}.log`), { force: true });
 	}
 
-	/** Add a comparable arm to an existing experiment, inheriting its sample + config. */
 	addArm(experimentId: string, req: AddArmRequest): { jobName: string; pid: number } {
-		return this.launch(resolveArmLaunch(this.#store, experimentId, req));
+		return this.launch(resolveArmLaunch(this.#store, experimentId, req), true);
 	}
 
 	/** Cancel a managed run. SIGTERM first so the runner forwards the signal to

--- a/packages/metaharness/src/store.ts
+++ b/packages/metaharness/src/store.ts
@@ -72,11 +72,25 @@ export interface TraceRow {
 	tracePath: string | null;
 }
 
-/** Row in the `experiments` table: goal metadata keyed by experiment id. */
+/** Public metadata for an experiment, including optional lifecycle limits. */
 export interface ExperimentMeta {
 	id: string;
 	goal: string;
 	updatedAt: number;
+	maxRuns: number | null;
+	maxArms: number | null;
+	closure: { verdict: string; closedAt: number } | null;
+}
+
+export interface ExperimentMetaUpdate {
+	goal?: string;
+	maxRuns?: number | null;
+	maxArms?: number | null;
+}
+
+export interface ExperimentClosure {
+	verdict: string;
+	closedAt: number;
 }
 
 export interface LaunchRecord {
@@ -139,7 +153,15 @@ CREATE INDEX IF NOT EXISTS idx_trials_job ON trials(job_name);
 CREATE TABLE IF NOT EXISTS experiments (
 	id TEXT PRIMARY KEY,
 	goal TEXT NOT NULL DEFAULT '',
-	updated_at INTEGER NOT NULL
+	updated_at INTEGER NOT NULL,
+	max_runs INTEGER,
+	max_arms INTEGER,
+	closure_verdict TEXT,
+	closed_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS experiment_launches (
+	job_name TEXT PRIMARY KEY,
+	created_at INTEGER NOT NULL
 );
 `;
 
@@ -180,6 +202,31 @@ function enableWal(db: Database): void {
 	}
 }
 
+function validateExperimentLimit(name: string, value: number | null | undefined): void {
+	if (value !== undefined && value !== null && (!Number.isSafeInteger(value) || value <= 0)) {
+		throw new Error(`${name} must be a positive safe integer`);
+	}
+}
+
+function validateExperimentVerdict(verdict: string): string {
+	if (typeof verdict !== "string" || verdict.trim() === "") throw new Error("closure verdict must be non-empty");
+	return verdict;
+}
+
+function experimentIdOf(jobName: string): string {
+	const dash = jobName.indexOf("-");
+	return dash > 0 ? jobName.slice(0, dash) : jobName;
+}
+
+function addColumnIfMissing(db: Database, columns: Set<string>, name: string, sql: string): void {
+	if (columns.has(name)) return;
+	try {
+		db.run(sql);
+	} catch (err) {
+		if (!String(err).toLowerCase().includes("duplicate column")) throw err;
+	}
+}
+
 export class RunStore {
 	#db: Database;
 	readonly jobsDir: string;
@@ -194,29 +241,43 @@ export class RunStore {
 		const runColumns = new Set(
 			(this.#db.query("PRAGMA table_info(runs)").all() as Array<{ name: string }>).map(c => c.name),
 		);
-		if (!runColumns.has("role")) this.#db.run("ALTER TABLE runs ADD COLUMN role TEXT NOT NULL DEFAULT ''");
-		if (!runColumns.has("note")) this.#db.run("ALTER TABLE runs ADD COLUMN note TEXT NOT NULL DEFAULT ''");
-		if (!runColumns.has("label")) this.#db.run("ALTER TABLE runs ADD COLUMN label TEXT NOT NULL DEFAULT ''");
-		if (!runColumns.has("benchmark")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN benchmark TEXT NOT NULL DEFAULT 'harbor'");
-		}
-		if (!runColumns.has("config_json")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN config_json TEXT NOT NULL DEFAULT '{}'");
-		}
-		if (!runColumns.has("score")) this.#db.run("ALTER TABLE runs ADD COLUMN score REAL");
-		if (!runColumns.has("metrics_json")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN metrics_json TEXT NOT NULL DEFAULT '{}'");
-		}
+		addColumnIfMissing(this.#db, runColumns, "role", "ALTER TABLE runs ADD COLUMN role TEXT NOT NULL DEFAULT ''");
+		addColumnIfMissing(this.#db, runColumns, "note", "ALTER TABLE runs ADD COLUMN note TEXT NOT NULL DEFAULT ''");
+		addColumnIfMissing(this.#db, runColumns, "label", "ALTER TABLE runs ADD COLUMN label TEXT NOT NULL DEFAULT ''");
+		addColumnIfMissing(this.#db, runColumns, "benchmark", "ALTER TABLE runs ADD COLUMN benchmark TEXT NOT NULL DEFAULT 'harbor'");
+		addColumnIfMissing(this.#db, runColumns, "config_json", "ALTER TABLE runs ADD COLUMN config_json TEXT NOT NULL DEFAULT '{}'");
+		addColumnIfMissing(this.#db, runColumns, "score", "ALTER TABLE runs ADD COLUMN score REAL");
+		addColumnIfMissing(this.#db, runColumns, "metrics_json", "ALTER TABLE runs ADD COLUMN metrics_json TEXT NOT NULL DEFAULT '{}'");
 		if (runColumns.has("slide") && !runColumns.has("prewalk")) {
 			this.#db.run("ALTER TABLE runs RENAME COLUMN slide TO prewalk");
 		}
 		if (!runColumns.has("slide") && !runColumns.has("prewalk")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN prewalk TEXT");
+			addColumnIfMissing(this.#db, runColumns, "prewalk", "ALTER TABLE runs ADD COLUMN prewalk TEXT");
 		}
 		const traceColumns = new Set(
 			(this.#db.query("PRAGMA table_info(trials)").all() as Array<{ name: string }>).map(c => c.name),
 		);
-		if (!traceColumns.has("trace_path")) this.#db.run("ALTER TABLE trials ADD COLUMN trace_path TEXT");
+		addColumnIfMissing(this.#db, traceColumns, "trace_path", "ALTER TABLE trials ADD COLUMN trace_path TEXT");
+		const experimentColumns = new Set(
+			(this.#db.query("PRAGMA table_info(experiments)").all() as Array<{ name: string }>).map(c => c.name),
+		);
+		addColumnIfMissing(this.#db, experimentColumns, "max_runs", "ALTER TABLE experiments ADD COLUMN max_runs INTEGER");
+		addColumnIfMissing(this.#db, experimentColumns, "max_arms", "ALTER TABLE experiments ADD COLUMN max_arms INTEGER");
+		addColumnIfMissing(
+			this.#db,
+			experimentColumns,
+			"closure_verdict",
+			"ALTER TABLE experiments ADD COLUMN closure_verdict TEXT",
+		);
+		addColumnIfMissing(this.#db, experimentColumns, "closed_at", "ALTER TABLE experiments ADD COLUMN closed_at INTEGER");
+		for (const row of this.#db.query("SELECT job_name FROM experiment_launches").all() as Array<{ job_name: string }>) {
+			if (
+				this.#db.query("SELECT 1 FROM runs WHERE job_name = ?").get(row.job_name) == null &&
+				!fs.existsSync(path.join(this.jobsDir, row.job_name))
+			) {
+				this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(row.job_name);
+			}
+		}
 	}
 
 	close(): void {
@@ -225,66 +286,235 @@ export class RunStore {
 
 	/** Register a run this manager just launched (pid-owning). */
 	registerLaunch(launch: LaunchRecord): void {
-		this.#db.query("DELETE FROM trials WHERE job_name = ?").run(launch.jobName);
-		this.#db
-			.query(
-				`INSERT INTO runs
-				 (job_name, benchmark, dataset, agent, models, prewalk, role, note, config_json, status, pid, created_at)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)
-				 ON CONFLICT(job_name) DO UPDATE SET
-					benchmark = excluded.benchmark, pid = excluded.pid, status = 'running',
-					config_json = excluded.config_json,
-					role = CASE WHEN excluded.role != '' THEN excluded.role ELSE runs.role END,
-					note = CASE WHEN excluded.note != '' THEN excluded.note ELSE runs.note END`,
-			)
-			.run(
-				launch.jobName,
-				launch.benchmark,
-				launch.dataset,
-				launch.agent,
-				launch.models.join(","),
-				launch.prewalk ? JSON.stringify(launch.prewalk) : null,
-				launch.role ?? "",
-				launch.note ?? "",
-				JSON.stringify(launch.config ?? {}),
-				launch.pid,
-				Date.now(),
-			);
+		const tx = this.#db.transaction(() => {
+			this.#db.query("DELETE FROM trials WHERE job_name = ?").run(launch.jobName);
+			this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(launch.jobName);
+			this.#db
+				.query(
+					`INSERT INTO runs
+					 (job_name, benchmark, dataset, agent, models, prewalk, role, note, config_json, status, pid, created_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)
+					 ON CONFLICT(job_name) DO UPDATE SET
+						benchmark = excluded.benchmark, pid = excluded.pid, status = 'running',
+						config_json = excluded.config_json,
+						role = CASE WHEN excluded.role != '' THEN excluded.role ELSE runs.role END,
+						note = CASE WHEN excluded.note != '' THEN excluded.note ELSE runs.note END`,
+				)
+				.run(
+					launch.jobName,
+					launch.benchmark,
+					launch.dataset,
+					launch.agent,
+					launch.models.join(","),
+					launch.prewalk ? JSON.stringify(launch.prewalk) : null,
+					launch.role ?? "",
+					launch.note ?? "",
+					JSON.stringify(launch.config ?? {}),
+					launch.pid,
+					Date.now(),
+				);
+		});
+		tx();
 		const jobDir = path.join(this.jobsDir, launch.jobName);
 		fs.mkdirSync(jobDir, { recursive: true });
 		fs.writeFileSync(path.join(jobDir, "manager.json"), JSON.stringify(launch, null, 2));
 	}
 
+	/** Upsert experiment metadata while preserving omitted fields. */
+	/** Atomically reserve a grouped launch before its child process is spawned. */
+	admitExperimentLaunch(admission: {
+		jobName: string;
+		goal?: string;
+		maxRuns?: number | null;
+		maxArms?: number | null;
+		armAddition?: boolean;
+	}): void {
+		if (!admission.jobName) throw new Error("jobName must be non-empty");
+		validateExperimentLimit("maxRuns", admission.maxRuns);
+		validateExperimentLimit("maxArms", admission.maxArms);
+		const id = experimentIdOf(admission.jobName);
+		const tx = this.#db.transaction(() => {
+			const existing = this.#db.query(
+				"SELECT goal, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+			).get(id) as {
+				goal: string;
+				max_runs: number | null;
+				max_arms: number | null;
+				closure_verdict: string | null;
+				closed_at: number | null;
+			} | null;
+			if (existing && (existing.closure_verdict != null || existing.closed_at != null)) {
+				throw new Error("experiment is closed");
+			}
+			validateExperimentLimit("maxRuns", existing?.max_runs);
+			validateExperimentLimit("maxArms", existing?.max_arms);
+			const hasReservation =
+				this.#db.query("SELECT 1 FROM experiment_launches WHERE job_name = ?").get(admission.jobName) != null;
+			const runNames = this.#db.query("SELECT job_name FROM runs").all() as Array<{ job_name: string }>;
+			const reservationNames = this.#db
+				.query("SELECT job_name FROM experiment_launches")
+				.all() as Array<{ job_name: string }>;
+			const runCount = runNames.filter(r => experimentIdOf(r.job_name) === id).length;
+			const reservationCount = reservationNames.filter(r => experimentIdOf(r.job_name) === id).length;
+			const groupedCount = runCount + reservationCount;
+			const occupiedCount = groupedCount - (hasReservation ? 1 : 0);
+			const maxRuns =
+				groupedCount > 0
+					? (existing?.max_runs ?? null)
+					: (admission.maxRuns !== undefined ? admission.maxRuns : (existing?.max_runs ?? null));
+			const maxArms =
+				groupedCount > 0
+					? (existing?.max_arms ?? null)
+					: (admission.maxArms !== undefined ? admission.maxArms : (existing?.max_arms ?? null));
+			if (groupedCount > 0 && admission.maxRuns != null && admission.maxRuns !== (existing?.max_runs ?? null)) {
+				throw new Error("maxRuns cannot change after grouped launches exist");
+			}
+			if (groupedCount > 0 && admission.maxArms != null && admission.maxArms !== (existing?.max_arms ?? null)) {
+				throw new Error("maxArms cannot change after grouped launches exist");
+			}
+			if (admission.armAddition && maxArms !== null && occupiedCount >= maxArms) {
+				throw new Error("maxArms limit reached");
+			}
+			if (maxRuns !== null && occupiedCount >= maxRuns) throw new Error("maxRuns limit reached");
+			const goal = admission.goal ?? existing?.goal ?? "";
+			this.#db
+				.query(
+					`INSERT INTO experiments
+					 (id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at)
+					 VALUES (?, ?, ?, ?, ?, NULL, NULL)
+					 ON CONFLICT(id) DO UPDATE SET
+						goal = excluded.goal,
+						updated_at = excluded.updated_at,
+						max_runs = excluded.max_runs,
+						max_arms = excluded.max_arms`,
+				)
+				.run(id, goal, Date.now(), maxRuns, maxArms);
+			this.#db
+				.query("INSERT INTO experiment_launches (job_name, created_at) VALUES (?, ?) ON CONFLICT(job_name) DO NOTHING")
+				.run(admission.jobName, Date.now());
+		});
+		tx();
+	}
+
+	/** Release a pre-spawn launch reservation. */
+	releaseExperimentLaunch(jobName: string): void {
+		this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(jobName);
+	}
+
+	setExperimentMeta(id: string, update: ExperimentMetaUpdate): void {
+		validateExperimentLimit("maxRuns", update.maxRuns);
+		validateExperimentLimit("maxArms", update.maxArms);
+		const tx = this.#db.transaction(() => {
+			const existing = this.#db.query(
+				"SELECT goal, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+			).get(id) as {
+				goal: string;
+				max_runs: number | null;
+				max_arms: number | null;
+				closure_verdict: string | null;
+				closed_at: number | null;
+			} | null;
+			if (existing && (existing.closure_verdict != null || existing.closed_at != null)) {
+				throw new Error("experiment is closed");
+			}
+			const goal = update.goal ?? existing?.goal ?? "";
+			const maxRuns = update.maxRuns !== undefined ? update.maxRuns : (existing?.max_runs ?? null);
+			const maxArms = update.maxArms !== undefined ? update.maxArms : (existing?.max_arms ?? null);
+			this.#db
+				.query(
+					`INSERT INTO experiments
+					 (id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at)
+					 VALUES (?, ?, ?, ?, ?, NULL, NULL)
+					 ON CONFLICT(id) DO UPDATE SET
+						goal = excluded.goal,
+						updated_at = excluded.updated_at,
+						max_runs = excluded.max_runs,
+						max_arms = excluded.max_arms`,
+				)
+				.run(id, goal, Date.now(), maxRuns, maxArms);
+		});
+		tx();
+	}
+
 	/** Upsert the experiment's stated goal. */
 	setExperimentGoal(id: string, goal: string): void {
-		this.#db
-			.query(
-				`INSERT INTO experiments (id, goal, updated_at) VALUES (?, ?, ?)
-				 ON CONFLICT(id) DO UPDATE SET goal = excluded.goal, updated_at = excluded.updated_at`,
-			)
-			.run(id, goal, Date.now());
+		this.setExperimentMeta(id, { goal });
+	}
+
+	/** Persist a non-empty measured verdict and close an experiment. */
+	closeExperiment(id: string, verdict: string, closedAt = Date.now()): void {
+		const measuredVerdict = validateExperimentVerdict(verdict);
+		if (!Number.isSafeInteger(closedAt) || closedAt < 0) {
+			throw new Error("closedAt must be a non-negative safe integer");
+		}
+		const tx = this.#db.transaction(() => {
+			const existing = this.#db.query(
+				"SELECT goal, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+			).get(id) as {
+				goal: string;
+				max_runs: number | null;
+				max_arms: number | null;
+				closure_verdict: string | null;
+				closed_at: number | null;
+			} | null;
+			if (existing && (existing.closure_verdict != null || existing.closed_at != null)) {
+				throw new Error("experiment is already closed");
+			}
+			const result = this.#db
+				.query(
+					`INSERT INTO experiments
+					 (id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?)
+					 ON CONFLICT(id) DO UPDATE SET
+						updated_at = excluded.updated_at,
+						closure_verdict = excluded.closure_verdict,
+						closed_at = excluded.closed_at
+					 WHERE experiments.closure_verdict IS NULL AND experiments.closed_at IS NULL`,
+				)
+				.run(
+					id,
+					existing?.goal ?? "",
+					Date.now(),
+					existing?.max_runs ?? null,
+					existing?.max_arms ?? null,
+					measuredVerdict,
+					closedAt,
+				);
+			if (result.changes === 0) throw new Error("experiment is already closed");
+		});
+		tx();
 	}
 
 	/** Stored experiment metadata, or null when the id was never registered. */
 	getExperimentMeta(id: string): ExperimentMeta | null {
-		const row = this.#db.query("SELECT id, goal, updated_at FROM experiments WHERE id = ?").get(id) as {
+		const row = this.#db.query(
+			"SELECT id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+		).get(id) as {
 			id: string;
 			goal: string;
 			updated_at: number;
+			max_runs: number | null;
+			max_arms: number | null;
+			closure_verdict: string | null;
+			closed_at: number | null;
 		} | null;
-		return row ? { id: row.id, goal: row.goal, updatedAt: row.updated_at } : null;
+		return row ? rowToExperimentMeta(row) : null;
 	}
 
 	/** Every registered experiment row, newest first. */
 	listExperimentMeta(): ExperimentMeta[] {
 		const rows = this.#db
-			.query("SELECT id, goal, updated_at FROM experiments ORDER BY updated_at DESC")
+			.query("SELECT id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at FROM experiments ORDER BY updated_at DESC")
 			.all() as Array<{
 			id: string;
 			goal: string;
 			updated_at: number;
+			max_runs: number | null;
+			max_arms: number | null;
+			closure_verdict: string | null;
+			closed_at: number | null;
 		}>;
-		return rows.map(r => ({ id: r.id, goal: r.goal, updatedAt: r.updated_at }));
+		return rows.map(rowToExperimentMeta);
 	}
 
 	/** Drop the experiment metadata row (run rows are deleted separately via deleteRun). */
@@ -344,6 +574,7 @@ export class RunStore {
 					 VALUES (?, ?, ?, ?, 'running', ?)`,
 				)
 				.run(e.name, meta.dataset, meta.agent, meta.models, createdAt);
+			this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(e.name);
 			this.syncRun(e.name);
 			added++;
 		}
@@ -500,6 +731,28 @@ export class RunStore {
 			tracePath: r.trace_path === null ? null : String(r.trace_path),
 		}));
 	}
+}
+
+function rowToExperimentMeta(r: {
+	id: string;
+	goal: string;
+	updated_at: number;
+	max_runs: number | null;
+	max_arms: number | null;
+	closure_verdict: string | null;
+	closed_at: number | null;
+}): ExperimentMeta {
+	return {
+		id: r.id,
+		goal: r.goal,
+		updatedAt: r.updated_at,
+		maxRuns: r.max_runs === null ? null : Number(r.max_runs),
+		maxArms: r.max_arms === null ? null : Number(r.max_arms),
+		closure:
+			r.closure_verdict != null || r.closed_at != null
+				? { verdict: r.closure_verdict ?? "", closedAt: r.closed_at == null ? 0 : Number(r.closed_at) }
+				: null,
+	};
 }
 
 function rowToRun(r: Record<string, unknown>): RunRow {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -3277,6 +3277,73 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+
+		it("normal TUI startup emits no normal-screen mouse tracking sequences", async () => {
+			// The normal screen must never capture mouse events. Normal-screen
+			// mouse reporting makes focus clicks indistinguishable from deliberate
+			// copy intent and prevents terminal-native text selection. These three
+			// modes are enabled exclusively by the fullscreen overlay path.
+			const term = new VirtualTerminal(40, 8, 200);
+			const writes = captureWrites(term);
+			const tui = new TUI(term);
+			tui.addChild(new MutableLinesComponent(rows("base-", 8)));
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const allWrites = writes.join("");
+				expect(allWrites).not.toContain("\x1b[?1000h");
+				expect(allWrites).not.toContain("\x1b[?1003h");
+				expect(allWrites).not.toContain("\x1b[?1006h");
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("an SGR left-click is routed to the focused fullscreen overlay component", async () => {
+			// Proves that once a fullscreen overlay enables mouse tracking, the
+			// terminal's SGR mouse reports reach the focused component's handleInput
+			// verbatim. No normal-screen mouse listener intercepts them; the TUI
+			// routes raw input strings to the focused component unchanged.
+			const term = new VirtualTerminal(40, 8, 200);
+			const tui = new TUI(term);
+			tui.addChild(new MutableLinesComponent(rows("base-", 8)));
+
+			class InputRecorder implements Component, Focusable {
+				focused = false;
+				inputs: string[] = [];
+				invalidate(): void {}
+				handleInput(data: string): void {
+					this.inputs.push(data);
+				}
+				render(_width: number): string[] {
+					return ["OVERLAY"];
+				}
+			}
+
+			const overlay = new InputRecorder();
+
+			try {
+				tui.start();
+				await settle(term);
+
+				tui.showOverlay(overlay, {
+					width: "100%",
+					maxHeight: "100%",
+					margin: 0,
+					fullscreen: true,
+				});
+				await settle(term);
+
+				// SGR left-click at column 5, row 3 (1-based terminal coordinates).
+				term.sendInput("\x1b[<0;5;3M");
+
+				expect(overlay.inputs).toEqual(["\x1b[<0;5;3M"]);
+			} finally {
+				tui.stop();
+			}
+		});
 	});
 
 	describe("stress scenarios", () => {


### PR DESCRIPTION
Durable lifecycle limits now prevent unbounded experiment drive and scope expansion after a measured closure.

## Summary
Before: an experiment could accept later run and arm launches without a durable terminal verdict.

After:
```text
PUT /api/experiments/exp {"closure":{"verdict":"measured: baseline wins"}}
→ {"id":"exp","closure":{"verdict":"measured: baseline wins","closedAt":…}}
POST /api/runs {"jobName":"exp-late",…}
→ 400 {"error":"experiment exp is closed"}
```

- Persists nullable run/arm limits and closure verdicts across fresh stores and servers.
- Atomically reserves bounded launches and rejects post-closure drive, resume, arm expansion, and scope edits.

## Refs
- https://github.com/ryxli/oh-my-pi/commit/8992274c7
