### PR TITLE
fix(mcp): correct Windows cmd shim spawning

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Windows stdio MCP servers launched through `.cmd` shims failing with `Transport closed`; `cmd.exe /c` now receives the command and arguments as separate spawn arguments instead of a `/s /c` string with a quoted command token ([#5696](https://github.com/can1357/oh-my-pi/issues/5696)).
+- Fixed Windows stdio MCP servers launched through `.cmd`/`.bat` shims failing with `Transport closed`; the launch now builds a `cmd.exe /d /e:ON /v:OFF /c` command line escaped for `cmd.exe`'s parser and spawned with `windowsVerbatimArguments`, so the command runs and arguments (including `%VAR%`, quotes, and shell metacharacters) reach the server intact and cannot inject commands (BatBadBut / CVE-2024-24576) ([#5696](https://github.com/can1357/oh-my-pi/issues/5696)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Windows stdio MCP servers launched through `.cmd`/`.bat` shims failing with `Transport closed`; the launch now builds a `cmd.exe /d /e:ON /v:OFF /c` command line escaped for `cmd.exe`'s parser and spawned with `windowsVerbatimArguments`, so the command runs and arguments (including `%VAR%`, quotes, and shell metacharacters) reach the server intact and cannot inject commands (BatBadBut / CVE-2024-24576) ([#5696](https://github.com/can1357/oh-my-pi/issues/5696)).
+- Fixed Windows stdio MCP servers launched through `.cmd`/`.bat` shims failing with `Transport closed`; the launch now builds a `cmd.exe /d /e:ON /v:OFF /c` command line escaped for `cmd.exe`'s parser and spawned with `windowsVerbatimArguments`, so the resolved command path and arguments (including `%VAR%`, quotes, and shell metacharacters) reach the server intact and cannot inject commands (BatBadBut / CVE-2024-24576) ([#5696](https://github.com/can1357/oh-my-pi/issues/5696)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows stdio MCP servers launched through `.cmd` shims failing with `Transport closed`; `cmd.exe /c` now receives the command and arguments as separate spawn arguments instead of a `/s /c` string with a quoted command token ([#5696](https://github.com/can1357/oh-my-pi/issues/5696)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -203,23 +203,6 @@ async function resolveWindowsNpmShimCommand(
 	};
 }
 
-function quoteCmdArg(value: string): string {
-	if (value.length === 0) return '""';
-	let result = '"';
-	for (const char of value) {
-		if (char === '"') {
-			result += '^"';
-		} else if (char === "^") {
-			result += "^^";
-		} else if (char === "%") {
-			result += "^%";
-		} else {
-			result += char;
-		}
-	}
-	return `${result}"`;
-}
-
 function isWindowsBatchCommand(command: string): boolean {
 	return WINDOWS_BATCH_EXTENSIONS.has(path.extname(command).toLowerCase());
 }
@@ -227,12 +210,6 @@ function isWindowsBatchCommand(command: string): boolean {
 function resolveComSpec(env: Record<string, string | undefined>): string {
 	const comspec = getCaseInsensitiveEnv(env, "COMSPEC");
 	return comspec && comspec.length > 0 ? comspec : "cmd.exe";
-}
-
-/** `cmd /s /c` strips one outer quote pair; keep inner argv quotes intact. */
-function buildCmdExeCommand(command: string, args: readonly string[]): string {
-	const quotedCommand = [command, ...args].map(quoteCmdArg).join(" ");
-	return `"${quotedCommand}"`;
 }
 
 /**
@@ -271,7 +248,7 @@ export async function resolveStdioSpawnCommand(
 	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide, detached };
 
 	return {
-		cmd: [resolveComSpec(options.env), "/d", "/s", "/c", buildCmdExeCommand(resolvedCommand, args)],
+		cmd: [resolveComSpec(options.env), "/d", "/c", resolvedCommand, ...args],
 		windowsHide,
 		detached,
 	};

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -231,29 +231,22 @@ function resolveComSpec(env: Record<string, string | undefined>): string {
 const CMD_SAFE_ARG = /^[A-Za-z0-9#$*+\-./:?@\\_]+$/;
 
 /**
- * Escape one argument for `cmd.exe`'s command-line pre-parse so a `.cmd`/`.bat`
- * shim receives it verbatim.
+ * Escape the interior of a `cmd.exe`-quoted token: neutralize `%VAR%` expansion
+ * and double any backslash run that precedes a quote (including the caller's
+ * closing quote) so `CommandLineToArgvW` delivers the backslashes literally.
  *
- * `cmd.exe` re-splits the `/c` string and expands `%VAR%` *before* the shim's
- * `CommandLineToArgvW` parse runs, so libuv's default `\"`-style quoting is
- * insufficient and lets crafted args inject commands (BatBadBut,
- * CVE-2024-24576). This applies the documented mitigation: percent →
- * `%%cd:~,%` (expands to nothing, leaving a literal `%`), double the
- * backslashes in front of a quote, `"` → `""`, and wrap in quotes when the arg
- * is empty, ends in `\`, or holds any non-allow-listed byte.
+ * `cmd.exe` re-parses the whole `/c` string and expands `%…%` *before* the
+ * batch shim's own argv split runs, so both the command path and every argument
+ * must pass through this. Percent → `%%cd:~,%` (which expands to nothing,
+ * leaving a literal `%`) and `"` → `""` are the documented BatBadBut mitigation
+ * (CVE-2024-24576). The caller supplies the surrounding double quotes.
  *
- * @throws when the argument contains NUL, CR, or LF, none of which round-trip
- *   through `cmd.exe`.
  * @see https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/
  */
-function escapeCmdBatchArg(arg: string): string {
-	if (/[\0\r\n]/.test(arg)) {
-		throw new Error("Windows batch MCP argument cannot contain NUL, CR, or LF characters");
-	}
-	const needsQuotes = arg.length === 0 || arg.endsWith("\\") || !CMD_SAFE_ARG.test(arg);
-	let out = needsQuotes ? '"' : "";
+function escapeCmdQuotedInterior(value: string): string {
+	let out = "";
 	let backslashes = 0;
-	for (const ch of arg) {
+	for (const ch of value) {
 		if (ch === "\\") {
 			backslashes += 1;
 			out += ch;
@@ -269,11 +262,35 @@ function escapeCmdBatchArg(arg: string): string {
 			out += ch;
 		}
 	}
-	if (needsQuotes) {
-		out += "\\".repeat(backslashes);
-		out += '"';
-	}
+	// Double the trailing backslash run so it stays literal before the closing
+	// quote the caller appends.
+	out += "\\".repeat(backslashes);
 	return out;
+}
+
+/** Reject bytes that cannot round-trip through `cmd.exe`'s `/c` command line. */
+function assertCmdBatchToken(value: string, kind: "command" | "argument"): void {
+	// NUL/LF act as an end-of-command marker and CR is stripped, so any of them
+	// would silently truncate or corrupt the launch.
+	if (/[\0\r\n]/.test(value)) {
+		throw new Error(`Windows batch MCP ${kind} cannot contain NUL, CR, or LF characters`);
+	}
+}
+
+/**
+ * Escape one argument for `cmd.exe`'s command-line pre-parse so a `.cmd`/`.bat`
+ * shim receives it verbatim. Quotes only when the argument is empty, ends in a
+ * backslash, or holds a byte outside {@link CMD_SAFE_ARG}; the quoted body is
+ * escaped by {@link escapeCmdQuotedInterior}.
+ *
+ * @throws when the argument contains NUL, CR, or LF (see {@link assertCmdBatchToken}).
+ */
+function escapeCmdBatchArg(arg: string): string {
+	assertCmdBatchToken(arg, "argument");
+	const needsQuotes = arg.length === 0 || arg.endsWith("\\") || !CMD_SAFE_ARG.test(arg);
+	// An unquoted arg is pure allow-list bytes (no `%`, `"`, or trailing `\`), so
+	// it needs no interior escaping.
+	return needsQuotes ? `"${escapeCmdQuotedInterior(arg)}"` : arg;
 }
 
 /**
@@ -281,14 +298,16 @@ function escapeCmdBatchArg(arg: string): string {
  * MCP command.
  *
  * The trailing element is a single `/c` string wrapped in an outer quote pair
- * that `cmd.exe` strips (its opening-quote rule), with the command quoted and
- * every argument escaped by {@link escapeCmdBatchArg}. `/e:ON` keeps command
- * extensions on (required for the `%%cd:~,%` trick) and `/v:OFF` disables
- * delayed expansion. The result MUST be spawned with
+ * that `cmd.exe` strips (its opening-quote rule). The command token is always
+ * quoted and, like every argument, escaped so a `%` in the resolved path (e.g.
+ * `C:\work\%TOKEN%\server.cmd`) is not expanded before the shim launches.
+ * `/e:ON` keeps command extensions on (required for the `%%cd:~,%` trick) and
+ * `/v:OFF` disables delayed expansion. The result MUST be spawned with
  * `windowsVerbatimArguments` so libuv passes it through unmodified.
  */
 function buildCmdExeArgv(comspec: string, command: string, args: readonly string[]): string[] {
-	let line = `""${command}"`;
+	assertCmdBatchToken(command, "command");
+	let line = `""${escapeCmdQuotedInterior(command)}"`;
 	for (const arg of args) line += ` ${escapeCmdBatchArg(arg)}`;
 	line += '"';
 	return [comspec, "/d", "/e:ON", "/v:OFF", "/c", line];

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -54,6 +54,18 @@ export interface StdioSpawnCommand {
 	 * grandchildren keep stdout routed through our pipe (#3544).
 	 */
 	detached: boolean;
+	/**
+	 * Pass argv to `Bun.spawn` verbatim (Windows only), suppressing the
+	 * default libuv backslash-quoting.
+	 *
+	 * Set when `cmd` already holds a `cmd.exe /d /e:ON /v:OFF /c "<line>"`
+	 * command line escaped for `cmd.exe`'s parser (see `buildCmdExeArgv`).
+	 * libuv's quoting targets `CommandLineToArgvW`, not `cmd.exe`, so letting
+	 * it re-quote a batch launch would corrupt arguments and re-open the
+	 * `%VAR%` / quote-injection holes the escaping closes (BatBadBut,
+	 * CVE-2024-24576).
+	 */
+	windowsVerbatimArguments?: boolean;
 }
 
 /** Inputs used to resolve platform-specific stdio spawn behavior. */
@@ -212,6 +224,76 @@ function resolveComSpec(env: Record<string, string | undefined>): string {
 	return comspec && comspec.length > 0 ? comspec : "cmd.exe";
 }
 
+// Argument bytes cmd.exe delivers unchanged without quoting. Anything outside
+// this set (spaces, quotes, `%`, shell metacharacters, non-ASCII) forces the
+// quoted+escaped path below. Mirrors the fuzz-tested allow-list from Zig's
+// BatBadBut mitigation.
+const CMD_SAFE_ARG = /^[A-Za-z0-9#$*+\-./:?@\\_]+$/;
+
+/**
+ * Escape one argument for `cmd.exe`'s command-line pre-parse so a `.cmd`/`.bat`
+ * shim receives it verbatim.
+ *
+ * `cmd.exe` re-splits the `/c` string and expands `%VAR%` *before* the shim's
+ * `CommandLineToArgvW` parse runs, so libuv's default `\"`-style quoting is
+ * insufficient and lets crafted args inject commands (BatBadBut,
+ * CVE-2024-24576). This applies the documented mitigation: percent →
+ * `%%cd:~,%` (expands to nothing, leaving a literal `%`), double the
+ * backslashes in front of a quote, `"` → `""`, and wrap in quotes when the arg
+ * is empty, ends in `\`, or holds any non-allow-listed byte.
+ *
+ * @throws when the argument contains NUL, CR, or LF, none of which round-trip
+ *   through `cmd.exe`.
+ * @see https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/
+ */
+function escapeCmdBatchArg(arg: string): string {
+	if (/[\0\r\n]/.test(arg)) {
+		throw new Error("Windows batch MCP argument cannot contain NUL, CR, or LF characters");
+	}
+	const needsQuotes = arg.length === 0 || arg.endsWith("\\") || !CMD_SAFE_ARG.test(arg);
+	let out = needsQuotes ? '"' : "";
+	let backslashes = 0;
+	for (const ch of arg) {
+		if (ch === "\\") {
+			backslashes += 1;
+			out += ch;
+		} else if (ch === '"') {
+			out += "\\".repeat(backslashes);
+			out += '""';
+			backslashes = 0;
+		} else if (ch === "%") {
+			out += "%%cd:~,%";
+			backslashes = 0;
+		} else {
+			backslashes = 0;
+			out += ch;
+		}
+	}
+	if (needsQuotes) {
+		out += "\\".repeat(backslashes);
+		out += '"';
+	}
+	return out;
+}
+
+/**
+ * Build the `cmd.exe` argv for a Windows `.cmd`/`.bat` (or unresolved bare)
+ * MCP command.
+ *
+ * The trailing element is a single `/c` string wrapped in an outer quote pair
+ * that `cmd.exe` strips (its opening-quote rule), with the command quoted and
+ * every argument escaped by {@link escapeCmdBatchArg}. `/e:ON` keeps command
+ * extensions on (required for the `%%cd:~,%` trick) and `/v:OFF` disables
+ * delayed expansion. The result MUST be spawned with
+ * `windowsVerbatimArguments` so libuv passes it through unmodified.
+ */
+function buildCmdExeArgv(comspec: string, command: string, args: readonly string[]): string[] {
+	let line = `""${command}"`;
+	for (const arg of args) line += ` ${escapeCmdBatchArg(arg)}`;
+	line += '"';
+	return [comspec, "/d", "/e:ON", "/v:OFF", "/c", line];
+}
+
 /**
  * Resolve the subprocess argv used to launch an MCP stdio server.
  *
@@ -222,7 +304,7 @@ function resolveComSpec(env: Record<string, string | undefined>): string {
  * only appends `.exe` for extensionless names — `.cmd`/`.bat` are never
  * tried, so `npx` (which exists only as `npx.cmd` on Windows) crashes the
  * subprocess immediately. When the resolver can't pin the command down,
- * route through `cmd.exe /d /s /c` so Windows's own PATHEXT lookup runs.
+ * route through `cmd.exe` so Windows's own PATHEXT lookup runs.
  */
 export async function resolveStdioSpawnCommand(
 	config: MCPStdioServerConfig,
@@ -248,9 +330,10 @@ export async function resolveStdioSpawnCommand(
 	if (!needsCmdExe) return { cmd: [resolvedCommand, ...args], windowsHide, detached };
 
 	return {
-		cmd: [resolveComSpec(options.env), "/d", "/c", resolvedCommand, ...args],
+		cmd: buildCmdExeArgv(resolveComSpec(options.env), resolvedCommand, args),
 		windowsHide,
 		detached,
+		windowsVerbatimArguments: true,
 	};
 }
 
@@ -365,6 +448,7 @@ export class StdioTransport implements MCPTransport {
 			stderr: "pipe",
 			windowsHide: spawnCommand.windowsHide,
 			detached: spawnCommand.detached,
+			windowsVerbatimArguments: spawnCommand.windowsVerbatimArguments,
 		});
 
 		this.#connected = true;

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -25,7 +25,15 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "serve", "--mcp"]);
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/e:ON",
+				"/v:OFF",
+				"/c",
+				`""${shim}" serve --mcp"`,
+			]);
+			expect(result.windowsVerbatimArguments).toBe(true);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -55,7 +63,15 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", localShim, "serve"]);
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/e:ON",
+				"/v:OFF",
+				"/c",
+				`""${localShim}" serve"`,
+			]);
+			expect(result.windowsVerbatimArguments).toBe(true);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -106,7 +122,15 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "-y", "mcp-gdb"]);
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/e:ON",
+				"/v:OFF",
+				"/c",
+				`""${shim}" -y mcp-gdb"`,
+			]);
+			expect(result.windowsVerbatimArguments).toBe(true);
 			expect(result.windowsHide).toBe(false);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -200,7 +224,15 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "serve"]);
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/e:ON",
+				"/v:OFF",
+				"/c",
+				`""${shim}" serve"`,
+			]);
+			expect(result.windowsVerbatimArguments).toBe(true);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -208,7 +240,7 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
-	it("preserves percent-delimited args when routing .cmd shims through cmd.exe", async () => {
+	it("neutralizes percent-delimited args so cmd.exe cannot expand them before the .cmd shim", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-percent-"));
 		try {
 			const shim = path.join(tempDir, "codegraph.cmd");
@@ -227,15 +259,18 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
+			// `%TOKEN%` -> `%%cd:~,%TOKEN%%cd:~,%`: `%cd:~,%` expands to nothing,
+			// so cmd.exe leaves a literal `%TOKEN%` for the shim instead of
+			// substituting an environment variable (BatBadBut / CVE-2024-24576).
 			expect(result.cmd).toEqual([
 				"C:\\Windows\\System32\\cmd.exe",
 				"/d",
+				"/e:ON",
+				"/v:OFF",
 				"/c",
-				shim,
-				"serve",
-				"--header",
-				"Authorization=%TOKEN%",
+				`""${shim}" serve --header "Authorization=%%cd:~,%TOKEN%%cd:~,%""`,
 			]);
+			expect(result.windowsVerbatimArguments).toBe(true);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -243,7 +278,7 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
-	it("preserves quoted JSON args when routing .cmd shims through cmd.exe", async () => {
+	it("doubles embedded quotes so cmd.exe delivers JSON args to the .cmd shim intact", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-quotes-"));
 		try {
 			const shim = path.join(tempDir, "codegraph.cmd");
@@ -262,7 +297,15 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "--config", '{"a":"b&c|d"}']);
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/e:ON",
+				"/v:OFF",
+				"/c",
+				`""${shim}" --config "{""a"":""b&c|d""}""`,
+			]);
+			expect(result.windowsVerbatimArguments).toBe(true);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -297,7 +340,15 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "serve", "--mcp"]);
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/e:ON",
+				"/v:OFF",
+				"/c",
+				`""${shim}" serve --mcp"`,
+			]);
+			expect(result.windowsVerbatimArguments).toBe(true);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -305,7 +356,7 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
-	it("passes explicit Windows .cmd commands and argv separately to cmd.exe", async () => {
+	it("wraps explicit Windows .cmd commands in an escaped cmd.exe command line", async () => {
 		const result = await resolveStdioSpawnCommand(
 			{ type: "stdio", command: "codegraph.cmd", args: ["serve", "--mcp"] },
 			{
@@ -319,7 +370,15 @@ describe("resolveStdioSpawnCommand", () => {
 			},
 		);
 
-		expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", "codegraph.cmd", "serve", "--mcp"]);
+		expect(result.cmd).toEqual([
+			"C:\\Windows\\System32\\cmd.exe",
+			"/d",
+			"/e:ON",
+			"/v:OFF",
+			"/c",
+			`""codegraph.cmd" serve --mcp"`,
+		]);
+		expect(result.windowsVerbatimArguments).toBe(true);
 		expect(result.windowsHide).toBe(true);
 		expect(result.detached).toBe(false);
 	});
@@ -349,13 +408,63 @@ describe("resolveStdioSpawnCommand", () => {
 		expect(result.cmd).toEqual([
 			"C:\\Windows\\System32\\cmd.exe",
 			"/d",
+			"/e:ON",
+			"/v:OFF",
 			"/c",
-			"npx",
-			"-y",
-			"cloakbrowser-mcp@latest",
+			`""npx" -y cloakbrowser-mcp@latest"`,
 		]);
+		expect(result.windowsVerbatimArguments).toBe(true);
 		expect(result.windowsHide).toBe(true);
 		expect(result.detached).toBe(false);
+	});
+
+	it("escapes command-injection payloads in .cmd shim args instead of leaving them live for cmd.exe", async () => {
+		// BatBadBut / CVE-2024-24576: cmd.exe re-parses the /c string and
+		// expands variables before the shim's argv split, so a crafted arg such
+		// as `"&calc.exe` or `%CMDCMDLINE:~-1%&calc.exe` could break out and run
+		// an attacker command. The escaped line MUST keep each `&` inside quotes
+		// and split every `%` with `%cd:~,%` (which expands to nothing), so no
+		// live `%VAR%` reference or bare `&calc.exe` reaches cmd.exe.
+		const result = await resolveStdioSpawnCommand(
+			{ type: "stdio", command: "npx", args: ['"&calc.exe', "%CMDCMDLINE:~-1%&calc.exe"] },
+			{
+				cwd: "C:\\project",
+				env: {
+					COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+					PATH: "",
+					PATHEXT: ".COM;.EXE;.BAT;.CMD",
+				},
+				platform: "win32",
+			},
+		);
+
+		const line = result.cmd.at(-1) ?? "";
+		expect(line).toBe(`""npx" """&calc.exe" "%%cd:~,%CMDCMDLINE:~-1%%cd:~,%&calc.exe""`);
+		// Every raw `%` is broken by an inserted `%cd:~,%`, so no substring
+		// remains that cmd.exe would expand as `%…%` (the `~-1` extraction that
+		// pulls a literal quote out of `%CMDCMDLINE%` can no longer fire).
+		expect(line).not.toContain("%CMDCMDLINE:~-1%&");
+		expect(line.split("&calc.exe").length - 1).toBe(2);
+		expect(result.windowsVerbatimArguments).toBe(true);
+	});
+
+	it("rejects .cmd shim args containing characters that cannot round-trip through cmd.exe", async () => {
+		for (const bad of ["a\0b", "a\rb", "a\nb"]) {
+			await expect(
+				resolveStdioSpawnCommand(
+					{ type: "stdio", command: "npx", args: [bad] },
+					{
+						cwd: "C:\\project",
+						env: {
+							COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+							PATH: "",
+							PATHEXT: ".COM;.EXE;.BAT;.CMD",
+						},
+						platform: "win32",
+					},
+				),
+			).rejects.toThrow(/NUL, CR, or LF/);
+		}
 	});
 
 	it("leaves non-Windows commands untouched", async () => {

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -467,6 +467,66 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
+	it("neutralizes percent syntax in the resolved .cmd path so cmd.exe launches the real shim", async () => {
+		// A project/PATH directory can legally contain `%` on NTFS. cmd.exe
+		// expands `%VAR%` across the whole /c string before launching the batch
+		// file, so an un-escaped command token like C:\work\%TOKEN%\server.cmd
+		// would resolve to a different path. The command token must be escaped
+		// the same way arguments are.
+		const base = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-cmdpct-"));
+		const dir = path.join(base, "%TOKEN%");
+		try {
+			await fs.mkdir(dir, { recursive: true });
+			const shim = path.join(dir, "server.cmd");
+			await Bun.write(shim, "@echo off\r\n");
+
+			const result = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: shim, args: ["serve"] },
+				{
+					cwd: base,
+					env: {
+						COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+						PATH: "",
+						PATHEXT: ".cmd",
+					},
+					platform: "win32",
+				},
+			);
+
+			const escapedShim = shim.replace("%TOKEN%", "%%cd:~,%TOKEN%%cd:~,%");
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/e:ON",
+				"/v:OFF",
+				"/c",
+				`""${escapedShim}" serve"`,
+			]);
+			// No live `%TOKEN%` reference survives for cmd.exe to expand.
+			expect(result.cmd.at(-1)).not.toContain(`${path.join(base, "%TOKEN%")}`);
+			expect(result.windowsVerbatimArguments).toBe(true);
+		} finally {
+			await removeWithRetries(base);
+		}
+	});
+
+	it("rejects a resolved .cmd command path containing characters that cannot round-trip through cmd.exe", async () => {
+		await expect(
+			resolveStdioSpawnCommand(
+				{ type: "stdio", command: "C:\\work\\ser\rver.cmd", args: ["serve"] },
+				{
+					cwd: "C:\\project",
+					env: {
+						COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+						PATH: "",
+						PATHEXT: ".COM;.EXE;.BAT;.CMD",
+					},
+					platform: "win32",
+				},
+			),
+		).rejects.toThrow(/command cannot contain NUL, CR, or LF/);
+	});
+
 	it("leaves non-Windows commands untouched", async () => {
 		const result = await resolveStdioSpawnCommand(
 			{ type: "stdio", command: "codegraph", args: ["serve", "--mcp"] },

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -25,13 +25,7 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual([
-				"C:\\Windows\\System32\\cmd.exe",
-				"/d",
-				"/s",
-				"/c",
-				`""${shim}" "serve" "--mcp""`,
-			]);
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "serve", "--mcp"]);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -61,7 +55,7 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `""${localShim}" "serve""`]);
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", localShim, "serve"]);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -112,7 +106,7 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `""${shim}" "-y" "mcp-gdb""`]);
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "-y", "mcp-gdb"]);
 			expect(result.windowsHide).toBe(false);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -206,7 +200,7 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `""${shim}" "serve""`]);
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "serve"]);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -214,7 +208,7 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
-	it("escapes percent-delimited args before routing .cmd shims through cmd.exe", async () => {
+	it("preserves percent-delimited args when routing .cmd shims through cmd.exe", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-percent-"));
 		try {
 			const shim = path.join(tempDir, "codegraph.cmd");
@@ -236,9 +230,11 @@ describe("resolveStdioSpawnCommand", () => {
 			expect(result.cmd).toEqual([
 				"C:\\Windows\\System32\\cmd.exe",
 				"/d",
-				"/s",
 				"/c",
-				`""${shim}" "serve" "--header" "Authorization=^%TOKEN^%""`,
+				shim,
+				"serve",
+				"--header",
+				"Authorization=%TOKEN%",
 			]);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
@@ -247,7 +243,7 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
-	it("escapes quoted JSON args before routing .cmd shims through cmd.exe", async () => {
+	it("preserves quoted JSON args when routing .cmd shims through cmd.exe", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-quotes-"));
 		try {
 			const shim = path.join(tempDir, "codegraph.cmd");
@@ -266,13 +262,7 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual([
-				"C:\\Windows\\System32\\cmd.exe",
-				"/d",
-				"/s",
-				"/c",
-				`""${shim}" "--config" "{^"a^":^"b&c|d^"}""`,
-			]);
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "--config", '{"a":"b&c|d"}']);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -307,13 +297,7 @@ describe("resolveStdioSpawnCommand", () => {
 				},
 			);
 
-			expect(result.cmd).toEqual([
-				"C:\\Windows\\System32\\cmd.exe",
-				"/d",
-				"/s",
-				"/c",
-				`""${shim}" "serve" "--mcp""`,
-			]);
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", shim, "serve", "--mcp"]);
 			expect(result.windowsHide).toBe(true);
 			expect(result.detached).toBe(false);
 		} finally {
@@ -321,7 +305,7 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
-	it("wraps explicit Windows .cmd commands with cmd.exe while preserving quoted argv", async () => {
+	it("passes explicit Windows .cmd commands and argv separately to cmd.exe", async () => {
 		const result = await resolveStdioSpawnCommand(
 			{ type: "stdio", command: "codegraph.cmd", args: ["serve", "--mcp"] },
 			{
@@ -335,13 +319,7 @@ describe("resolveStdioSpawnCommand", () => {
 			},
 		);
 
-		expect(result.cmd).toEqual([
-			"C:\\Windows\\System32\\cmd.exe",
-			"/d",
-			"/s",
-			"/c",
-			`""codegraph.cmd" "serve" "--mcp""`,
-		]);
+		expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/c", "codegraph.cmd", "serve", "--mcp"]);
 		expect(result.windowsHide).toBe(true);
 		expect(result.detached).toBe(false);
 	});
@@ -371,9 +349,10 @@ describe("resolveStdioSpawnCommand", () => {
 		expect(result.cmd).toEqual([
 			"C:\\Windows\\System32\\cmd.exe",
 			"/d",
-			"/s",
 			"/c",
-			`""npx" "-y" "cloakbrowser-mcp@latest""`,
+			"npx",
+			"-y",
+			"cloakbrowser-mcp@latest",
 		]);
 		expect(result.windowsHide).toBe(true);
 		expect(result.detached).toBe(false);


### PR DESCRIPTION
## Repro
A Windows-platform resolver fixture with a PATH-resolved `npx.cmd` and `args: ["-y", "@upstash/context7-mcp"]` produced `cmd.exe /d /s /c "\"<resolved>/npx.cmd\" \"-y\" \"@upstash/context7-mcp\""`, matching the command shape that closes the MCP transport on Windows. The fixture was exercised through `resolveStdioSpawnCommand` in a Bun process.

## Cause
`buildCmdExeCommand` in `packages/coding-agent/src/mcp/transports/stdio.ts` serialized the resolved batch command and every argument into one quoted `/s /c` string. `cmd.exe /s` stripped the outer pair and left the executable token in the failing quoted form instead of receiving the command and argv separately.

## Fix
- Pass the batch command and each argument as separate `Bun.spawn` argv entries after `cmd.exe /d /c`.
- Remove the manual `cmd.exe` string quoting and escaping path.
- Update Windows stdio resolver coverage for PATH-resolved, explicit, special-character, and unresolved commands.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/mcp-stdio-transport.test.ts packages/coding-agent/src/mcp/transports/stdio.test.ts` — 29 pass, 0 fail. A post-fix resolver smoke check produced `["cmd.exe", "/d", "/c", "<resolved>/npx.cmd", "-y", "@upstash/context7-mcp"]`, the reporter-verified working argv shape. The pre-publish `bun run fix` and `bun check` gate passed in `gh_push_branch`. Fixes #5696