### PR TITLE
feat(metaharness): add durable experiment closure gates

### DIFF
--- a/packages/metaharness/src/experiments.test.ts
+++ b/packages/metaharness/src/experiments.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	armOf,
+	buildExperiments,
 	calibratedFinalPassPct,
 	canonicalArmOf,
+	experimentDetail,
 	experimentOf,
 	pickMergedTrials,
 	summarizeArm,
 } from "./experiments";
+import { RunStore } from "./store";
 import type { RunRow, TraceRow } from "./store";
 
 /**
@@ -64,6 +70,72 @@ function traceRow(overrides: Partial<TraceRow>): TraceRow {
 		...overrides,
 	};
 }
+
+describe("experiment lifecycle metadata", () => {
+	it("reads persisted state for grouped and armless experiments and nulls legacy rows", () => {
+		const jobsDir = mkdtempSync(join(tmpdir(), "metaharness-experiments-"));
+		const store = new RunStore(jobsDir);
+		try {
+			store.setExperimentMeta("persisted", { goal: "bounded", maxRuns: 4, maxArms: 2 });
+			store.closeExperiment("persisted", "operator", 1_700_000_000_000);
+			store.setExperimentGoal("legacy", "old");
+			store.setExperimentMeta("empty", { goal: "waiting", maxRuns: 9, maxArms: 3 });
+			for (const jobName of ["persisted-arm", "legacy-arm"]) {
+				store.registerLaunch({
+					benchmark: "harbor",
+					jobName,
+					dataset: "d",
+					agent: "omp",
+					models: ["m"],
+					pid: process.pid,
+				});
+			}
+
+			const summaries = buildExperiments(store);
+			expect(summaries.find(s => s.id === "persisted")).toMatchObject({
+				goal: "bounded",
+				maxRuns: 4,
+				maxArms: 2,
+				closure: { verdict: "operator", closedAt: 1_700_000_000_000 },
+				arms: 1,
+			});
+			expect(summaries.find(s => s.id === "legacy")).toMatchObject({
+				goal: "old",
+				maxRuns: null,
+				maxArms: null,
+				closure: null,
+				arms: 1,
+			});
+			expect(summaries.find(s => s.id === "empty")).toMatchObject({
+				maxRuns: 9,
+				maxArms: 3,
+				closure: null,
+				arms: 0,
+			});
+
+			expect(experimentDetail(store, "persisted")).toMatchObject({
+				goal: "bounded",
+				maxRuns: 4,
+				maxArms: 2,
+				closure: { verdict: "operator", closedAt: 1_700_000_000_000 },
+			});
+			expect(experimentDetail(store, "empty")).toMatchObject({
+				maxRuns: 9,
+				maxArms: 3,
+				closure: null,
+				arms: [],
+			});
+			expect(experimentDetail(store, "legacy")).toMatchObject({
+				maxRuns: null,
+				maxArms: null,
+				closure: null,
+			});
+		} finally {
+			store.close();
+			rmSync(jobsDir, { recursive: true, force: true });
+		}
+	});
+});
 
 describe("experiment grouping", () => {
 	it("groups by prefix and strips it from arm labels", () => {

--- a/packages/metaharness/src/experiments.ts
+++ b/packages/metaharness/src/experiments.ts
@@ -32,6 +32,9 @@ export interface ArmSummary {
 export interface ExperimentSummary {
 	id: string;
 	goal: string;
+	maxRuns: number | null;
+	maxArms: number | null;
+	closure: { verdict: string; closedAt: number } | null;
 	arms: number;
 	runningArms: number;
 	datasets: string[];
@@ -48,6 +51,9 @@ export interface ExperimentSummary {
 export interface ExperimentDetail {
 	id: string;
 	goal: string;
+	maxRuns: number | null;
+	maxArms: number | null;
+	closure: { verdict: string; closedAt: number } | null;
 	arms: ArmSummary[];
 	/** Union of task ids across arms, sorted. */
 	tasks: string[];
@@ -202,9 +208,13 @@ export function buildExperiments(store: RunStore): ExperimentSummary[] {
 	}
 	const out: ExperimentSummary[] = [];
 	for (const [id, runs] of groups) {
+		const meta = store.getExperimentMeta(id);
 		out.push({
 			id,
-			goal: store.getExperimentMeta(id)?.goal ?? "",
+			goal: meta?.goal ?? "",
+			maxRuns: meta?.maxRuns ?? null,
+			maxArms: meta?.maxArms ?? null,
+			closure: meta?.closure ?? null,
 			arms: runs.length,
 			runningArms: runs.filter(r => r.status === "running").length,
 			datasets: [...new Set(runs.map(r => r.dataset).filter(Boolean))],
@@ -225,6 +235,9 @@ export function buildExperiments(store: RunStore): ExperimentSummary[] {
 		out.push({
 			id: meta.id,
 			goal: meta.goal,
+			maxRuns: meta.maxRuns ?? null,
+			maxArms: meta.maxArms ?? null,
+			closure: meta.closure ?? null,
 			arms: 0,
 			runningArms: 0,
 			datasets: [],
@@ -278,11 +291,22 @@ export function pickMergedTrials(traces: TraceRow[]): TraceRow[] {
 }
 
 export function experimentDetail(store: RunStore, id: string): ExperimentDetail | null {
+	const meta = store.getExperimentMeta(id);
 	const runs = store.listRuns().filter(r => experimentOf(r.jobName) === id);
 	if (runs.length === 0) {
 		// Registered but armless (POST /api/experiments): still readable.
-		const meta = store.getExperimentMeta(id);
-		return meta ? { id, goal: meta.goal, arms: [], tasks: [], matrix: {} } : null;
+		return meta
+			? {
+					id,
+					goal: meta.goal,
+					maxRuns: meta.maxRuns ?? null,
+					maxArms: meta.maxArms ?? null,
+					closure: meta.closure ?? null,
+					arms: [],
+					tasks: [],
+					matrix: {},
+				}
+			: null;
 	}
 	// One row per CANONICAL arm: `-fix`/`-backfill` re-runs merge into their
 	// base arm — per-task best trial, summed spend.
@@ -371,5 +395,14 @@ export function experimentDetail(store: RunStore, id: string): ExperimentDetail 
 	// "reference rows, then treatments".
 	const roleRank = (role: string) => (role === "baseline" ? 0 : role === "variant" ? 1 : 2);
 	arms.sort((a, b) => roleRank(a.run.role) - roleRank(b.run.role) || a.arm.localeCompare(b.arm));
-	return { id, goal: store.getExperimentMeta(id)?.goal ?? "", arms, tasks: [...tasks].sort(), matrix };
+	return {
+		id,
+		goal: meta?.goal ?? "",
+		maxRuns: meta?.maxRuns ?? null,
+		maxArms: meta?.maxArms ?? null,
+		closure: meta?.closure ?? null,
+		arms,
+		tasks: [...tasks].sort(),
+		matrix,
+	};
 }

--- a/packages/metaharness/src/launch-args.ts
+++ b/packages/metaharness/src/launch-args.ts
@@ -42,6 +42,10 @@ export interface LaunchRequest {
 	prebuiltBinaries?: boolean;
 	/** Extra raw runner args, appended verbatim. */
 	extraArgs?: string[];
+	/** Experiment-wide maximum number of new grouped run launches. */
+	maxRuns?: number | null;
+	/** Experiment-wide maximum number of arms. */
+	maxArms?: number | null;
 }
 
 /** Runner CLI flags (sans the `bun src/runner.ts` prefix) for a harbor launch. */

--- a/packages/metaharness/src/manager.test.ts
+++ b/packages/metaharness/src/manager.test.ts
@@ -163,6 +163,40 @@ describe("RunStore", () => {
 		expect(treat?.role).toBe("variant");
 		expect(treat?.note).toBe("prewalk flash v2");
 	});
+	it("persists experiment limits and closure across a fresh store", () => {
+		const jobsDir = makeJobsDir();
+		const dbPath = path.join(jobsDir, "experiment.sqlite");
+		const store = new RunStore(jobsDir, dbPath);
+		store.setExperimentGoal("legacy", "existing goal");
+		expect(store.getExperimentMeta("legacy")).toEqual({
+			id: "legacy",
+			goal: "existing goal",
+			updatedAt: expect.any(Number),
+			maxRuns: null,
+			maxArms: null,
+			closure: null,
+		});
+
+		store.setExperimentMeta("bounded", { goal: "measure it", maxRuns: 3, maxArms: 2 });
+		store.closeExperiment("bounded", "measured: treatment wins", 1_752_000_000_000);
+		expect(store.getExperimentMeta("bounded")?.closure).toEqual({
+			verdict: "measured: treatment wins",
+			closedAt: 1_752_000_000_000,
+		});
+		store.close();
+
+		const reopened = new RunStore(jobsDir, dbPath);
+		cleanups.push(() => reopened.close());
+		expect(reopened.getExperimentMeta("bounded")).toEqual({
+			id: "bounded",
+			goal: "measure it",
+			updatedAt: expect.any(Number),
+			maxRuns: 3,
+			maxArms: 2,
+			closure: { verdict: "measured: treatment wins", closedAt: 1_752_000_000_000 },
+		});
+	});
+
 
 	it("releases a dead runner's pid without failing a possibly-live orphan", () => {
 		const jobsDir = makeJobsDir();
@@ -547,5 +581,120 @@ describe("resolveArmLaunch", () => {
 		});
 		expect(() => resolveArmLaunch(store, "exp", { arm: "base", model: "m/y" })).toThrow(/already exists/);
 		expect(() => resolveArmLaunch(store, "ghost", { arm: "x", model: "m/y" })).toThrow(/no runs to inherit/);
+	});
+});
+
+describe("experiment lifecycle gates", () => {
+	it("enforces limits and durable closure across fresh ManagerServer instances", async () => {
+		const jobsDir = makeJobsDir();
+		const dbPath = path.join(jobsDir, "_manager", "lifecycle.sqlite");
+		const first = new ManagerServer(jobsDir, dbPath);
+		first.store.registerLaunch({
+			benchmark: "harbor",
+			jobName: "exp-base",
+			dataset: "terminal-bench@2.0",
+			agent: "omp",
+			models: ["m/x"],
+			pid: process.pid,
+			config: { include: ["task-1"] },
+		});
+		first.store.markExit("exp-base", 0);
+		first.store.setExperimentMeta("exp", { goal: "measure", maxRuns: 5, maxArms: 1 });
+		const firstServer = first.start(0);
+		const firstBase = `http://localhost:${firstServer.port}`;
+
+		const lowerLimit = await fetch(`${firstBase}/api/runs`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ benchmark: "harbor", jobName: "exp-drive", model: "m/x", maxRuns: 1 }),
+		});
+		expect(lowerLimit.status).toBe(400);
+
+		const genericArm = await fetch(`${firstBase}/api/runs`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ benchmark: "harbor", jobName: "exp-extra", model: "m/x" }),
+		});
+		expect(genericArm.status).toBe(400);
+		expect((await genericArm.json()).error).toMatch(/maxArms/);
+
+		first.store.setExperimentMeta("exp", { maxRuns: 1, maxArms: null });
+		const maxRun = await fetch(`${firstBase}/api/runs`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ benchmark: "harbor", jobName: "exp-drive", model: "m/x" }),
+		});
+		expect(maxRun.status).toBe(400);
+		expect((await maxRun.json()).error).toMatch(/maxRuns/);
+		first.store.setExperimentMeta("exp", { maxRuns: 5, maxArms: 1 });
+		await first.stop();
+
+		const bounded = new ManagerServer(jobsDir, dbPath);
+		const boundedServer = bounded.start(0);
+		const boundedBase = `http://localhost:${boundedServer.port}`;
+		const maxArm = await fetch(`${boundedBase}/api/experiments/exp/arms`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ arm: "next", model: "m/y" }),
+		});
+		expect(maxArm.status).toBe(400);
+		expect((await maxArm.json()).error).toMatch(/maxArms/);
+
+		const closed = await fetch(`${boundedBase}/api/experiments/exp`, {
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ closure: { verdict: "measured: baseline wins" } }),
+		});
+		expect(closed.status).toBe(200);
+		await bounded.stop();
+
+		const second = new ManagerServer(jobsDir, dbPath);
+		cleanups.push(() => {
+			void second.stop();
+		});
+		const server = second.start(0);
+		const base = `http://localhost:${server.port}`;
+		const detail = (await (await fetch(`${base}/api/experiments/exp`)).json()) as {
+			goal: string;
+			maxRuns: number | null;
+			maxArms: number | null;
+			closure: { verdict: string; closedAt: number } | null;
+		};
+		expect(detail).toMatchObject({
+			goal: "measure",
+			maxRuns: 5,
+			maxArms: 1,
+			closure: { verdict: "measured: baseline wins" },
+		});
+		const failedClose = await fetch(`${base}/api/experiments/exp`, {
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ closure: { verdict: "second verdict" }, runs: { "exp-base": { note: "must not apply" } } }),
+		});
+		expect(failedClose.status).toBe(400);
+		const unchangedRun = (await (await fetch(`${base}/api/runs/exp-base`)).json()) as { run: { note: string } };
+		expect(unchangedRun.run.note).toBe("");
+		for (const [url, body] of [
+			[`${base}/api/runs`, { benchmark: "harbor", jobName: "exp-late", model: "m/x" }],
+			[`${base}/api/experiments/exp/arms`, { arm: "late", model: "m/y" }],
+		] as const) {
+			const response = await fetch(url, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify(body),
+			});
+			expect(response.status).toBe(400);
+			expect((await response.json()).error).toMatch(/closed/);
+		}
+		const resume = await fetch(`${base}/api/runs/exp-base/resume`, { method: "POST" });
+		expect(resume.status).toBe(400);
+		expect((await resume.json()).error).toMatch(/closed/);
+		const goal = await fetch(`${base}/api/experiments/exp`, {
+			method: "PUT",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ goal: "changed" }),
+		});
+		expect(goal.status).toBe(400);
+		expect((await goal.json()).error).toMatch(/closed/);
 	});
 });

--- a/packages/metaharness/src/server.ts
+++ b/packages/metaharness/src/server.ts
@@ -29,17 +29,27 @@ import { buildExperiments, experimentDetail, experimentOf } from "./experiments"
 import { harborRunnerArgs, type LaunchRequest } from "./launch-args";
 import { type LaunchRecord, type RunRole, type RunRow, RunStore } from "./store";
 
-/** PUT /api/experiments/:id body — goal and per-run role/note/label metadata. */
+/** Explicit closure metadata supplied by PUT /api/experiments/:id. */
+export interface ExperimentClosureUpdate {
+	verdict: string;
+}
+
+/** PUT /api/experiments/:id body — experiment and per-run metadata. */
 export interface ExperimentMetaUpdate {
 	goal?: string;
+	maxRuns?: number | null;
+	maxArms?: number | null;
+	closure?: ExperimentClosureUpdate;
 	runs?: Record<string, { role?: RunRole; note?: string; label?: string }>;
 }
 
-/** POST /api/experiments body — pre-registers an experiment id with a goal. */
+/** POST /api/experiments body — pre-registers an experiment id with metadata. */
 export interface CreateExperimentRequest {
 	/** Dash-free token; runs group into it as `<id>-<arm>` job names. */
 	id: string;
 	goal?: string;
+	maxRuns?: number | null;
+	maxArms?: number | null;
 }
 
 import indexHtml from "./web/index.html";
@@ -97,6 +107,18 @@ function assertSafeJobName(jobName: string): void {
 	}
 }
 
+
+function assertExperimentLimit(name: "maxRuns" | "maxArms", value: number | null | undefined): void {
+	if (value !== undefined && value !== null && (!Number.isSafeInteger(value) || value < 1)) {
+		throw new Error(`${name} must be a positive safe integer`);
+	}
+}
+
+function assertClosureVerdict(verdict: string): string {
+	const value = verdict.trim();
+	if (!value) throw new Error("closure verdict must be non-empty");
+	return value;
+}
 /** True when `pid` names a live process (signal-0 probe). */
 function pidAlive(pid: number | null): boolean {
 	if (pid == null) return false;
@@ -392,8 +414,15 @@ export class ManagerServer {
 		if (this.#children.has(jobName) || this.#store.getRun(jobName)?.status === "running") {
 			throw new Error(`run ${jobName} is already running`);
 		}
-		const jobDir = path.join(this.jobsDir, jobName);
-		fs.mkdirSync(jobDir, { recursive: true });
+		this.#store.admitExperimentLaunch({
+			jobName,
+			goal: request.goal,
+			maxRuns: request.maxRuns,
+			maxArms: request.maxArms,
+		});
+		try {
+			const jobDir = path.join(this.jobsDir, jobName);
+			fs.mkdirSync(jobDir, { recursive: true });
 
 		let argv: string[];
 		let cwd: string;
@@ -427,8 +456,11 @@ export class ManagerServer {
 			role: request.role,
 			note: request.note,
 		});
-		if (request.goal) this.#store.setExperimentGoal(experimentOf(jobName), request.goal);
 		return { jobName, pid };
+		} catch (err) {
+			this.#store.releaseExperimentLaunch(jobName);
+			throw err;
+		}
 	}
 
 	/**
@@ -442,6 +474,10 @@ export class ManagerServer {
 	resume(jobName: string, opts: { filterErrorTypes?: string[] } = {}): { jobName: string; pid: number } {
 		const run = this.#store.getRun(jobName);
 		if (!run) throw new Error(`run ${jobName} not found`);
+		const experiment = experimentOf(jobName);
+		if (this.#store.getExperimentMeta(experiment)?.closure) {
+			throw new Error(`experiment ${experiment} is closed`);
+		}
 		if (run.benchmark !== "harbor")
 			throw new Error(`resume supports only harbor runs (${jobName} is ${run.benchmark})`);
 		// Trust liveness, not the recorded status: a runner killed while a
@@ -518,30 +554,82 @@ export class ManagerServer {
 		return this.#children.has(run.jobName) || (run.status === "running" && pidAlive(run.pid));
 	}
 
-	/** Register an experiment id (with an optional goal) so it is browsable before its first arm. */
-	createExperiment(req: CreateExperimentRequest): { id: string; goal: string } {
+
+	/** Register an experiment id (with optional lifecycle metadata). */
+	createExperiment(req: CreateExperimentRequest): {
+		id: string;
+		goal: string;
+		maxRuns: number | null;
+		maxArms: number | null;
+		closure: { verdict: string; closedAt: number } | null;
+	} {
 		const id = req.id?.trim() ?? "";
 		// Dashes are structurally impossible: `experimentOf` groups job names by
 		// the token before the first dash, so a dashed id could never own a run.
 		if (!/^[A-Za-z0-9_.]+$/.test(id)) {
 			throw new Error("experiment id must be a non-empty token of [A-Za-z0-9_.] (runs group as `<id>-<arm>`)");
 		}
-		const goal = req.goal ?? this.#store.getExperimentMeta(id)?.goal ?? "";
-		this.#store.setExperimentGoal(id, goal);
-		return { id, goal };
+		assertExperimentLimit("maxRuns", req.maxRuns);
+		assertExperimentLimit("maxArms", req.maxArms);
+		const current = this.#store.getExperimentMeta(id);
+		const scopeEdit = req.goal !== undefined || req.maxRuns !== undefined || req.maxArms !== undefined;
+		if (current?.closure) {
+			if (scopeEdit) throw new Error(`experiment ${id} is closed`);
+			return {
+				id,
+				goal: current.goal,
+				maxRuns: current.maxRuns,
+				maxArms: current.maxArms,
+				closure: current.closure,
+			};
+		}
+		this.#store.setExperimentMeta(id, {
+			goal: req.goal,
+			maxRuns: req.maxRuns,
+			maxArms: req.maxArms,
+		});
+		const meta = this.#store.getExperimentMeta(id);
+		return {
+			id,
+			goal: meta?.goal ?? "",
+			maxRuns: meta?.maxRuns ?? null,
+			maxArms: meta?.maxArms ?? null,
+			closure: meta?.closure ?? null,
+		};
 	}
 
-	/** Apply goal + per-run role/note metadata; used by the UI and for backfill. */
-	updateExperimentMeta(id: string, update: ExperimentMetaUpdate): { id: string; updatedRuns: string[] } {
-		if (update.goal !== undefined) this.#store.setExperimentGoal(id, update.goal);
+	/** Apply experiment lifecycle and per-run role/note metadata. */
+	updateExperimentMeta(
+		id: string,
+		update: ExperimentMetaUpdate,
+	): { id: string; updatedRuns: string[]; closure: { verdict: string; closedAt: number } | null } {
+		assertExperimentLimit("maxRuns", update.maxRuns);
+		assertExperimentLimit("maxArms", update.maxArms);
+		const verdict = update.closure ? assertClosureVerdict(update.closure.verdict) : undefined;
+		const current = this.#store.getExperimentMeta(id);
+		const scopeEdit =
+			update.goal !== undefined || update.maxRuns !== undefined || update.maxArms !== undefined;
+		if (current?.closure && (scopeEdit || update.closure !== undefined)) throw new Error(`experiment ${id} is closed`);
+		if (verdict !== undefined && scopeEdit) {
+			throw new Error("cannot change goal or limits while closing an experiment");
+		}
+		if (scopeEdit) {
+			this.#store.setExperimentMeta(id, {
+				goal: update.goal,
+				maxRuns: update.maxRuns,
+				maxArms: update.maxArms,
+			});
+		}
 		const updatedRuns: string[] = [];
 		for (const jobName in update.runs) {
 			if (experimentOf(jobName) !== id) continue;
 			if (this.#store.setRunMeta(jobName, update.runs[jobName])) updatedRuns.push(jobName);
 		}
+		if (verdict !== undefined) this.#store.closeExperiment(id, verdict);
 		this.#tick();
-		return { id, updatedRuns };
+		return { id, updatedRuns, closure: this.#store.getExperimentMeta(id)?.closure ?? null };
 	}
+
 
 	/**
 	 * Delete an experiment: every arm's DB row, job dir, and manager log, plus
@@ -587,7 +675,6 @@ export class ManagerServer {
 		fs.rmSync(path.join(this.jobsDir, "_manager", "logs", `${jobName}.log`), { force: true });
 	}
 
-	/** Add a comparable arm to an existing experiment, inheriting its sample + config. */
 	addArm(experimentId: string, req: AddArmRequest): { jobName: string; pid: number } {
 		return this.launch(resolveArmLaunch(this.#store, experimentId, req));
 	}

--- a/packages/metaharness/src/store.ts
+++ b/packages/metaharness/src/store.ts
@@ -72,11 +72,25 @@ export interface TraceRow {
 	tracePath: string | null;
 }
 
-/** Row in the `experiments` table: goal metadata keyed by experiment id. */
+/** Public metadata for an experiment, including optional lifecycle limits. */
 export interface ExperimentMeta {
 	id: string;
 	goal: string;
 	updatedAt: number;
+	maxRuns: number | null;
+	maxArms: number | null;
+	closure: { verdict: string; closedAt: number } | null;
+}
+
+export interface ExperimentMetaUpdate {
+	goal?: string;
+	maxRuns?: number | null;
+	maxArms?: number | null;
+}
+
+export interface ExperimentClosure {
+	verdict: string;
+	closedAt: number;
 }
 
 export interface LaunchRecord {
@@ -139,7 +153,15 @@ CREATE INDEX IF NOT EXISTS idx_trials_job ON trials(job_name);
 CREATE TABLE IF NOT EXISTS experiments (
 	id TEXT PRIMARY KEY,
 	goal TEXT NOT NULL DEFAULT '',
-	updated_at INTEGER NOT NULL
+	updated_at INTEGER NOT NULL,
+	max_runs INTEGER,
+	max_arms INTEGER,
+	closure_verdict TEXT,
+	closed_at INTEGER
+);
+CREATE TABLE IF NOT EXISTS experiment_launches (
+	job_name TEXT PRIMARY KEY,
+	created_at INTEGER NOT NULL
 );
 `;
 
@@ -180,6 +202,31 @@ function enableWal(db: Database): void {
 	}
 }
 
+function validateExperimentLimit(name: string, value: number | null | undefined): void {
+	if (value !== undefined && value !== null && (!Number.isSafeInteger(value) || value <= 0)) {
+		throw new Error(`${name} must be a positive safe integer`);
+	}
+}
+
+function validateExperimentVerdict(verdict: string): string {
+	if (typeof verdict !== "string" || verdict.trim() === "") throw new Error("closure verdict must be non-empty");
+	return verdict;
+}
+
+function experimentIdOf(jobName: string): string {
+	const dash = jobName.indexOf("-");
+	return dash > 0 ? jobName.slice(0, dash) : jobName;
+}
+
+function addColumnIfMissing(db: Database, columns: Set<string>, name: string, sql: string): void {
+	if (columns.has(name)) return;
+	try {
+		db.run(sql);
+	} catch (err) {
+		if (!String(err).toLowerCase().includes("duplicate column")) throw err;
+	}
+}
+
 export class RunStore {
 	#db: Database;
 	readonly jobsDir: string;
@@ -194,29 +241,43 @@ export class RunStore {
 		const runColumns = new Set(
 			(this.#db.query("PRAGMA table_info(runs)").all() as Array<{ name: string }>).map(c => c.name),
 		);
-		if (!runColumns.has("role")) this.#db.run("ALTER TABLE runs ADD COLUMN role TEXT NOT NULL DEFAULT ''");
-		if (!runColumns.has("note")) this.#db.run("ALTER TABLE runs ADD COLUMN note TEXT NOT NULL DEFAULT ''");
-		if (!runColumns.has("label")) this.#db.run("ALTER TABLE runs ADD COLUMN label TEXT NOT NULL DEFAULT ''");
-		if (!runColumns.has("benchmark")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN benchmark TEXT NOT NULL DEFAULT 'harbor'");
-		}
-		if (!runColumns.has("config_json")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN config_json TEXT NOT NULL DEFAULT '{}'");
-		}
-		if (!runColumns.has("score")) this.#db.run("ALTER TABLE runs ADD COLUMN score REAL");
-		if (!runColumns.has("metrics_json")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN metrics_json TEXT NOT NULL DEFAULT '{}'");
-		}
+		addColumnIfMissing(this.#db, runColumns, "role", "ALTER TABLE runs ADD COLUMN role TEXT NOT NULL DEFAULT ''");
+		addColumnIfMissing(this.#db, runColumns, "note", "ALTER TABLE runs ADD COLUMN note TEXT NOT NULL DEFAULT ''");
+		addColumnIfMissing(this.#db, runColumns, "label", "ALTER TABLE runs ADD COLUMN label TEXT NOT NULL DEFAULT ''");
+		addColumnIfMissing(this.#db, runColumns, "benchmark", "ALTER TABLE runs ADD COLUMN benchmark TEXT NOT NULL DEFAULT 'harbor'");
+		addColumnIfMissing(this.#db, runColumns, "config_json", "ALTER TABLE runs ADD COLUMN config_json TEXT NOT NULL DEFAULT '{}'");
+		addColumnIfMissing(this.#db, runColumns, "score", "ALTER TABLE runs ADD COLUMN score REAL");
+		addColumnIfMissing(this.#db, runColumns, "metrics_json", "ALTER TABLE runs ADD COLUMN metrics_json TEXT NOT NULL DEFAULT '{}'");
 		if (runColumns.has("slide") && !runColumns.has("prewalk")) {
 			this.#db.run("ALTER TABLE runs RENAME COLUMN slide TO prewalk");
 		}
 		if (!runColumns.has("slide") && !runColumns.has("prewalk")) {
-			this.#db.run("ALTER TABLE runs ADD COLUMN prewalk TEXT");
+			addColumnIfMissing(this.#db, runColumns, "prewalk", "ALTER TABLE runs ADD COLUMN prewalk TEXT");
 		}
 		const traceColumns = new Set(
 			(this.#db.query("PRAGMA table_info(trials)").all() as Array<{ name: string }>).map(c => c.name),
 		);
-		if (!traceColumns.has("trace_path")) this.#db.run("ALTER TABLE trials ADD COLUMN trace_path TEXT");
+		addColumnIfMissing(this.#db, traceColumns, "trace_path", "ALTER TABLE trials ADD COLUMN trace_path TEXT");
+		const experimentColumns = new Set(
+			(this.#db.query("PRAGMA table_info(experiments)").all() as Array<{ name: string }>).map(c => c.name),
+		);
+		addColumnIfMissing(this.#db, experimentColumns, "max_runs", "ALTER TABLE experiments ADD COLUMN max_runs INTEGER");
+		addColumnIfMissing(this.#db, experimentColumns, "max_arms", "ALTER TABLE experiments ADD COLUMN max_arms INTEGER");
+		addColumnIfMissing(
+			this.#db,
+			experimentColumns,
+			"closure_verdict",
+			"ALTER TABLE experiments ADD COLUMN closure_verdict TEXT",
+		);
+		addColumnIfMissing(this.#db, experimentColumns, "closed_at", "ALTER TABLE experiments ADD COLUMN closed_at INTEGER");
+		for (const row of this.#db.query("SELECT job_name FROM experiment_launches").all() as Array<{ job_name: string }>) {
+			if (
+				this.#db.query("SELECT 1 FROM runs WHERE job_name = ?").get(row.job_name) == null &&
+				!fs.existsSync(path.join(this.jobsDir, row.job_name))
+			) {
+				this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(row.job_name);
+			}
+		}
 	}
 
 	close(): void {
@@ -225,66 +286,232 @@ export class RunStore {
 
 	/** Register a run this manager just launched (pid-owning). */
 	registerLaunch(launch: LaunchRecord): void {
-		this.#db.query("DELETE FROM trials WHERE job_name = ?").run(launch.jobName);
-		this.#db
-			.query(
-				`INSERT INTO runs
-				 (job_name, benchmark, dataset, agent, models, prewalk, role, note, config_json, status, pid, created_at)
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)
-				 ON CONFLICT(job_name) DO UPDATE SET
-					benchmark = excluded.benchmark, pid = excluded.pid, status = 'running',
-					config_json = excluded.config_json,
-					role = CASE WHEN excluded.role != '' THEN excluded.role ELSE runs.role END,
-					note = CASE WHEN excluded.note != '' THEN excluded.note ELSE runs.note END`,
-			)
-			.run(
-				launch.jobName,
-				launch.benchmark,
-				launch.dataset,
-				launch.agent,
-				launch.models.join(","),
-				launch.prewalk ? JSON.stringify(launch.prewalk) : null,
-				launch.role ?? "",
-				launch.note ?? "",
-				JSON.stringify(launch.config ?? {}),
-				launch.pid,
-				Date.now(),
-			);
+		const tx = this.#db.transaction(() => {
+			this.#db.query("DELETE FROM trials WHERE job_name = ?").run(launch.jobName);
+			this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(launch.jobName);
+			this.#db
+				.query(
+					`INSERT INTO runs
+					 (job_name, benchmark, dataset, agent, models, prewalk, role, note, config_json, status, pid, created_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)
+					 ON CONFLICT(job_name) DO UPDATE SET
+						benchmark = excluded.benchmark, pid = excluded.pid, status = 'running',
+						config_json = excluded.config_json,
+						role = CASE WHEN excluded.role != '' THEN excluded.role ELSE runs.role END,
+						note = CASE WHEN excluded.note != '' THEN excluded.note ELSE runs.note END`,
+				)
+				.run(
+					launch.jobName,
+					launch.benchmark,
+					launch.dataset,
+					launch.agent,
+					launch.models.join(","),
+					launch.prewalk ? JSON.stringify(launch.prewalk) : null,
+					launch.role ?? "",
+					launch.note ?? "",
+					JSON.stringify(launch.config ?? {}),
+					launch.pid,
+					Date.now(),
+				);
+		});
+		tx();
 		const jobDir = path.join(this.jobsDir, launch.jobName);
 		fs.mkdirSync(jobDir, { recursive: true });
 		fs.writeFileSync(path.join(jobDir, "manager.json"), JSON.stringify(launch, null, 2));
 	}
 
+	/** Upsert experiment metadata while preserving omitted fields. */
+	/** Atomically reserve a grouped launch before its child process is spawned. */
+	admitExperimentLaunch(admission: {
+		jobName: string;
+		goal?: string;
+		maxRuns?: number | null;
+		maxArms?: number | null;
+	}): void {
+		if (!admission.jobName) throw new Error("jobName must be non-empty");
+		validateExperimentLimit("maxRuns", admission.maxRuns);
+		validateExperimentLimit("maxArms", admission.maxArms);
+		const id = experimentIdOf(admission.jobName);
+		const tx = this.#db.transaction(() => {
+			const existing = this.#db.query(
+				"SELECT goal, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+			).get(id) as {
+				goal: string;
+				max_runs: number | null;
+				max_arms: number | null;
+				closure_verdict: string | null;
+				closed_at: number | null;
+			} | null;
+			if (existing && (existing.closure_verdict != null || existing.closed_at != null)) {
+				throw new Error("experiment is closed");
+			}
+			validateExperimentLimit("maxRuns", existing?.max_runs);
+			validateExperimentLimit("maxArms", existing?.max_arms);
+			const hasReservation =
+				this.#db.query("SELECT 1 FROM experiment_launches WHERE job_name = ?").get(admission.jobName) != null;
+			const runNames = this.#db.query("SELECT job_name FROM runs").all() as Array<{ job_name: string }>;
+			const reservationNames = this.#db
+				.query("SELECT job_name FROM experiment_launches")
+				.all() as Array<{ job_name: string }>;
+			const runCount = runNames.filter(r => experimentIdOf(r.job_name) === id).length;
+			const reservationCount = reservationNames.filter(r => experimentIdOf(r.job_name) === id).length;
+			const groupedCount = runCount + reservationCount;
+			const occupiedCount = groupedCount - (hasReservation ? 1 : 0);
+			const maxRuns =
+				groupedCount > 0
+					? (existing?.max_runs ?? null)
+					: (admission.maxRuns !== undefined ? admission.maxRuns : (existing?.max_runs ?? null));
+			const maxArms =
+				groupedCount > 0
+					? (existing?.max_arms ?? null)
+					: (admission.maxArms !== undefined ? admission.maxArms : (existing?.max_arms ?? null));
+			if (groupedCount > 0 && admission.maxRuns != null && admission.maxRuns !== (existing?.max_runs ?? null)) {
+				throw new Error("maxRuns cannot change after grouped launches exist");
+			}
+			if (groupedCount > 0 && admission.maxArms != null && admission.maxArms !== (existing?.max_arms ?? null)) {
+				throw new Error("maxArms cannot change after grouped launches exist");
+			}
+			if (maxArms !== null && occupiedCount >= maxArms) throw new Error("maxArms limit reached");
+			if (maxRuns !== null && occupiedCount >= maxRuns) throw new Error("maxRuns limit reached");
+			const goal = admission.goal ?? existing?.goal ?? "";
+			this.#db
+				.query(
+					`INSERT INTO experiments
+					 (id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at)
+					 VALUES (?, ?, ?, ?, ?, NULL, NULL)
+					 ON CONFLICT(id) DO UPDATE SET
+						goal = excluded.goal,
+						updated_at = excluded.updated_at,
+						max_runs = excluded.max_runs,
+						max_arms = excluded.max_arms`,
+				)
+				.run(id, goal, Date.now(), maxRuns, maxArms);
+			this.#db
+				.query("INSERT INTO experiment_launches (job_name, created_at) VALUES (?, ?) ON CONFLICT(job_name) DO NOTHING")
+				.run(admission.jobName, Date.now());
+		});
+		tx();
+	}
+
+	/** Release a pre-spawn launch reservation. */
+	releaseExperimentLaunch(jobName: string): void {
+		this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(jobName);
+	}
+
+	setExperimentMeta(id: string, update: ExperimentMetaUpdate): void {
+		validateExperimentLimit("maxRuns", update.maxRuns);
+		validateExperimentLimit("maxArms", update.maxArms);
+		const tx = this.#db.transaction(() => {
+			const existing = this.#db.query(
+				"SELECT goal, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+			).get(id) as {
+				goal: string;
+				max_runs: number | null;
+				max_arms: number | null;
+				closure_verdict: string | null;
+				closed_at: number | null;
+			} | null;
+			if (existing && (existing.closure_verdict != null || existing.closed_at != null)) {
+				throw new Error("experiment is closed");
+			}
+			const goal = update.goal ?? existing?.goal ?? "";
+			const maxRuns = update.maxRuns !== undefined ? update.maxRuns : (existing?.max_runs ?? null);
+			const maxArms = update.maxArms !== undefined ? update.maxArms : (existing?.max_arms ?? null);
+			this.#db
+				.query(
+					`INSERT INTO experiments
+					 (id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at)
+					 VALUES (?, ?, ?, ?, ?, NULL, NULL)
+					 ON CONFLICT(id) DO UPDATE SET
+						goal = excluded.goal,
+						updated_at = excluded.updated_at,
+						max_runs = excluded.max_runs,
+						max_arms = excluded.max_arms`,
+				)
+				.run(id, goal, Date.now(), maxRuns, maxArms);
+		});
+		tx();
+	}
+
 	/** Upsert the experiment's stated goal. */
 	setExperimentGoal(id: string, goal: string): void {
-		this.#db
-			.query(
-				`INSERT INTO experiments (id, goal, updated_at) VALUES (?, ?, ?)
-				 ON CONFLICT(id) DO UPDATE SET goal = excluded.goal, updated_at = excluded.updated_at`,
-			)
-			.run(id, goal, Date.now());
+		this.setExperimentMeta(id, { goal });
+	}
+
+	/** Persist a non-empty measured verdict and close an experiment. */
+	closeExperiment(id: string, verdict: string, closedAt = Date.now()): void {
+		const measuredVerdict = validateExperimentVerdict(verdict);
+		if (!Number.isSafeInteger(closedAt) || closedAt < 0) {
+			throw new Error("closedAt must be a non-negative safe integer");
+		}
+		const tx = this.#db.transaction(() => {
+			const existing = this.#db.query(
+				"SELECT goal, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+			).get(id) as {
+				goal: string;
+				max_runs: number | null;
+				max_arms: number | null;
+				closure_verdict: string | null;
+				closed_at: number | null;
+			} | null;
+			if (existing && (existing.closure_verdict != null || existing.closed_at != null)) {
+				throw new Error("experiment is already closed");
+			}
+			const result = this.#db
+				.query(
+					`INSERT INTO experiments
+					 (id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at)
+					 VALUES (?, ?, ?, ?, ?, ?, ?)
+					 ON CONFLICT(id) DO UPDATE SET
+						updated_at = excluded.updated_at,
+						closure_verdict = excluded.closure_verdict,
+						closed_at = excluded.closed_at
+					 WHERE experiments.closure_verdict IS NULL AND experiments.closed_at IS NULL`,
+				)
+				.run(
+					id,
+					existing?.goal ?? "",
+					Date.now(),
+					existing?.max_runs ?? null,
+					existing?.max_arms ?? null,
+					measuredVerdict,
+					closedAt,
+				);
+			if (result.changes === 0) throw new Error("experiment is already closed");
+		});
+		tx();
 	}
 
 	/** Stored experiment metadata, or null when the id was never registered. */
 	getExperimentMeta(id: string): ExperimentMeta | null {
-		const row = this.#db.query("SELECT id, goal, updated_at FROM experiments WHERE id = ?").get(id) as {
+		const row = this.#db.query(
+			"SELECT id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at FROM experiments WHERE id = ?",
+		).get(id) as {
 			id: string;
 			goal: string;
 			updated_at: number;
+			max_runs: number | null;
+			max_arms: number | null;
+			closure_verdict: string | null;
+			closed_at: number | null;
 		} | null;
-		return row ? { id: row.id, goal: row.goal, updatedAt: row.updated_at } : null;
+		return row ? rowToExperimentMeta(row) : null;
 	}
 
 	/** Every registered experiment row, newest first. */
 	listExperimentMeta(): ExperimentMeta[] {
 		const rows = this.#db
-			.query("SELECT id, goal, updated_at FROM experiments ORDER BY updated_at DESC")
+			.query("SELECT id, goal, updated_at, max_runs, max_arms, closure_verdict, closed_at FROM experiments ORDER BY updated_at DESC")
 			.all() as Array<{
 			id: string;
 			goal: string;
 			updated_at: number;
+			max_runs: number | null;
+			max_arms: number | null;
+			closure_verdict: string | null;
+			closed_at: number | null;
 		}>;
-		return rows.map(r => ({ id: r.id, goal: r.goal, updatedAt: r.updated_at }));
+		return rows.map(rowToExperimentMeta);
 	}
 
 	/** Drop the experiment metadata row (run rows are deleted separately via deleteRun). */
@@ -344,6 +571,7 @@ export class RunStore {
 					 VALUES (?, ?, ?, ?, 'running', ?)`,
 				)
 				.run(e.name, meta.dataset, meta.agent, meta.models, createdAt);
+			this.#db.query("DELETE FROM experiment_launches WHERE job_name = ?").run(e.name);
 			this.syncRun(e.name);
 			added++;
 		}
@@ -500,6 +728,28 @@ export class RunStore {
 			tracePath: r.trace_path === null ? null : String(r.trace_path),
 		}));
 	}
+}
+
+function rowToExperimentMeta(r: {
+	id: string;
+	goal: string;
+	updated_at: number;
+	max_runs: number | null;
+	max_arms: number | null;
+	closure_verdict: string | null;
+	closed_at: number | null;
+}): ExperimentMeta {
+	return {
+		id: r.id,
+		goal: r.goal,
+		updatedAt: r.updated_at,
+		maxRuns: r.max_runs === null ? null : Number(r.max_runs),
+		maxArms: r.max_arms === null ? null : Number(r.max_arms),
+		closure:
+			r.closure_verdict != null || r.closed_at != null
+				? { verdict: r.closure_verdict ?? "", closedAt: r.closed_at == null ? 0 : Number(r.closed_at) }
+				: null,
+	};
 }
 
 function rowToRun(r: Record<string, unknown>): RunRow {


### PR DESCRIPTION
Durable lifecycle limits now prevent unbounded experiment drive and scope expansion after a measured closure.

## Summary
Before: an experiment could accept later run and arm launches without a durable terminal verdict.

After:
```text
PUT /api/experiments/exp {"closure":{"verdict":"measured: baseline wins"}}
→ {"id":"exp","closure":{"verdict":"measured: baseline wins","closedAt":…}}
POST /api/runs {"jobName":"exp-extra",…}
→ 400 {"error":"maxArms limit reached"}
```

- Persists nullable run and arm limits plus measured closure verdicts across fresh stores and servers.
- Atomically reserves grouped runs, including generic `/api/runs` launches, and rejects post-closure drive, resume, arm expansion, and scope edits.

## Refs
- Supersedes closed PR https://github.com/can1357/oh-my-pi/pull/5695
- https://github.com/ryxli/oh-my-pi/commit/eca02928d
