### PR TITLE
fix(coding-agent/launch): handle EISDIR from realpath on Windows drive roots

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a startup crash when the project directory resolves to a Windows drive root (e.g. `R:\`): `canonicalProjectDir` now treats `EISDIR` from `fs.realpath` as a recoverable fallback, matching the existing `ENOENT` handling.
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/launch/client.ts
+++ b/packages/coding-agent/src/launch/client.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { isEexist, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
+import { isEexist, isEisdir, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
 import { resolveWorkerSpawnCmd, workerEnvFromParent } from "../subprocess/worker-client";
 import { daemonBrokerEndpoint, daemonRuntimeDir } from "./paths";
 import {
@@ -49,7 +49,7 @@ async function canonicalProjectDir(projectDir: string): Promise<string> {
 	try {
 		return await fs.realpath(resolved);
 	} catch (error) {
-		if (isEnoent(error)) return resolved;
+		if (isEnoent(error) || isEisdir(error)) return resolved;
 		throw error;
 	}
 }

--- a/packages/coding-agent/src/launch/presence.ts
+++ b/packages/coding-agent/src/launch/presence.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { isEnoent, postmortem } from "@oh-my-pi/pi-utils";
+import { isEisdir, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
 import { daemonRuntimeDir } from "./paths";
 
 const CLIENTS_DIR = "clients";
@@ -15,7 +15,7 @@ async function canonicalProjectDir(projectDir: string): Promise<string> {
 	try {
 		return await fs.realpath(resolved);
 	} catch (error) {
-		if (isEnoent(error)) return resolved;
+		if (isEnoent(error) || isEisdir(error)) return resolved;
 		throw error;
 	}
 }

--- a/packages/coding-agent/test/tools/launch-eisdir-fallback.test.ts
+++ b/packages/coding-agent/test/tools/launch-eisdir-fallback.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { PathLike } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { registerDaemonProjectPresence } from "../../src/launch/presence";
+
+describe("daemon presence canonicalProjectDir EISDIR fallback", () => {
+	const originalRealpath = fs.realpath.bind(fs);
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("falls back to the resolved path when realpath throws EISDIR", async () => {
+		const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-eisdir-fallback-"));
+		const runtimeDir = path.join(projectDir, "runtime");
+		const resolvedProjectDir = path.resolve(projectDir);
+		let realpathCalls = 0;
+
+		vi.spyOn(fs, "realpath").mockImplementation((async (p: PathLike) => {
+			if (path.resolve(String(p)) === resolvedProjectDir) {
+				realpathCalls++;
+				const err = new Error("EISDIR: illegal operation on a directory") as NodeJS.ErrnoException;
+				err.code = "EISDIR";
+				err.errno = -21;
+				err.syscall = "lstat";
+				err.path = "R:" + path.sep;
+				throw err;
+			}
+			return originalRealpath(p);
+		}) as typeof fs.realpath);
+
+		try {
+			const presence = await registerDaemonProjectPresence(projectDir, runtimeDir);
+			expect(typeof presence.close).toBe("function");
+			expect(realpathCalls).toBe(1);
+
+			const clientsDir = path.join(runtimeDir, "clients");
+			const entries = await fs.readdir(clientsDir);
+			expect(entries).toHaveLength(1);
+
+			await presence.close();
+		} finally {
+			await fs.rm(projectDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## What

`canonicalProjectDir()` in both `packages/coding-agent/src/launch/presence.ts` and `packages/coding-agent/src/launch/client.ts` now treats `EISDIR` from `fs.realpath()` as a recoverable error, just like it already does for `ENOENT`.

Also added a regression test (`packages/coding-agent/test/tools/launch-eisdir-fallback.test.ts`) that mocks `fs.realpath` to throw `EISDIR` and verifies `registerDaemonProjectPresence()` still succeeds.

## Why

On Windows, `fs.realpath()` can throw `EISDIR` when called on a drive root such as `R:\`:

```
EISDIR: illegal operation on a directory, lstat 'R:\'
```

The current code only caught `ENOENT`, so starting omp from a Windows drive root crashed during daemon presence registration.

## Testing

- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] `bun test packages/coding-agent/test/tools/launch-eisdir-fallback.test.ts` passes
- [x] Built `packages/coding-agent/dist/omp.exe` and ran `omp -p "hi"` from `R:\` — no crash
- [x] `CHANGELOG.md` updated under `[Unreleased]`