### PR TITLE
fix(catalog): pinned gpt-5.6 codex context window to 372k

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `openai-codex` GPT-5.6 Luna/Sol/Terra `contextWindow` regressing from 372000 to 272000: Codex discovery falls back to `DEFAULT_CONTEXT_WINDOW` (272000) when upstream omits `context_window`, overwriting the previously-bundled hard capacity. Pinned these SKUs to the upstream-declared 372000 in `applyOpenAICatalogPolicy` ([#5705](https://github.com/can1357/oh-my-pi/issues/5705)).
+- Fixed `openai-codex` GPT-5.6 Luna/Sol/Terra `contextWindow` regressing from 372000 to 272000: when upstream omits `context_window`, Codex discovery fell back to the generic `DEFAULT_CONTEXT_WINDOW` (272000), which both overwrote the bundled hard capacity on regen and — for logged-in Codex users — re-overwrote it on every live discovery refresh. Codex discovery now falls back to the upstream-declared 372000 for GPT-5.6 SKUs, and `applyOpenAICatalogPolicy` pins the same value at generation time ([#5705](https://github.com/can1357/oh-my-pi/issues/5705)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `openai-codex` GPT-5.6 Luna/Sol/Terra `contextWindow` regressing from 372000 to 272000: Codex discovery falls back to `DEFAULT_CONTEXT_WINDOW` (272000) when upstream omits `context_window`, overwriting the previously-bundled hard capacity. Pinned these SKUs to the upstream-declared 372000 in `applyOpenAICatalogPolicy` ([#5705](https://github.com/can1357/oh-my-pi/issues/5705)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Added

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -362,4 +362,12 @@ function applyOpenAICatalogPolicy(model: ModelSpec<Api>, parsedModel: OpenAIMode
 			model.contextWindow = 272000;
 		}
 	}
+	// GPT-5.6 luna/sol/terra on the Codex transport: OpenAI's Codex model
+	// registry declares context_window = max_context_window = 372000, but Codex
+	// discovery omits `context_window` for these SKUs and falls back to
+	// DEFAULT_CONTEXT_WINDOW (272000, src/discovery/codex.ts), which regressed
+	// the bundled hard capacity (#5705). Pin the true 372K input window.
+	if (model.api === "openai-codex-responses" && semverEqual(parsedModel.version, "5.6")) {
+		model.contextWindow = 372000;
+	}
 }

--- a/packages/catalog/src/discovery/codex.ts
+++ b/packages/catalog/src/discovery/codex.ts
@@ -1,4 +1,5 @@
 import { type } from "arktype";
+import { parseKnownModel, semverEqual } from "../identity/classify";
 import type { ModelSpec } from "../types";
 import { discoveryFetch } from "../utils";
 import { CODEX_BASE_URL, CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "../wire/codex";
@@ -6,6 +7,14 @@ import { CODEX_BASE_URL, CODEX_CLIENT_VERSION, OPENAI_HEADER_VALUES, OPENAI_HEAD
 const DEFAULT_MODEL_LIST_PATHS = ["/codex/models", "/models"] as const;
 const DEFAULT_CONTEXT_WINDOW = 272_000;
 const DEFAULT_MAX_TOKENS = 128_000;
+/**
+ * GPT-5.6 luna/sol/terra hard context capacity. Codex discovery omits
+ * `context_window` for these SKUs, so the generic {@link DEFAULT_CONTEXT_WINDOW}
+ * (272000) would understate the real window — OpenAI's Codex model registry
+ * declares context_window = max_context_window = 372000 (#5705). Used as the
+ * fallback only when upstream reports no value.
+ */
+const GPT_5_6_CONTEXT_WINDOW = 372_000;
 const CODEX_REMOTE_COMPACTION = {
 	enabled: true,
 	api: "openai-codex-responses",
@@ -214,7 +223,14 @@ function normalizeCodexModelEntry(entry: unknown, baseUrl: string): NormalizedCo
 	}
 
 	const name = toNonEmptyString(payload.display_name) ?? slug;
-	const contextWindow = toPositiveInt(payload.context_window) ?? DEFAULT_CONTEXT_WINDOW;
+	// Codex discovery omits `context_window` for GPT-5.6 luna/sol/terra; the
+	// generic 272000 fallback understates their real 372000 window (#5705).
+	const parsed = parseKnownModel(slug);
+	const fallbackContextWindow =
+		parsed.family === "openai" && semverEqual(parsed.version, "5.6")
+			? GPT_5_6_CONTEXT_WINDOW
+			: DEFAULT_CONTEXT_WINDOW;
+	const contextWindow = toPositiveInt(payload.context_window) ?? fallbackContextWindow;
 	const maxTokens = Math.min(DEFAULT_MAX_TOKENS, contextWindow);
 	const reasoning = supportsReasoning(payload.default_reasoning_level, payload.supported_reasoning_levels);
 	const input = normalizeInputModalities(payload.input_modalities);

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -64078,7 +64078,7 @@
 				"api": "openai-codex-responses",
 				"v2StreamingEnabled": true
 			},
-			"contextWindow": 272000,
+			"contextWindow": 372000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
@@ -64117,7 +64117,7 @@
 				"api": "openai-codex-responses",
 				"v2StreamingEnabled": true
 			},
-			"contextWindow": 272000,
+			"contextWindow": 372000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,
@@ -64156,7 +64156,7 @@
 				"api": "openai-codex-responses",
 				"v2StreamingEnabled": true
 			},
-			"contextWindow": 272000,
+			"contextWindow": 372000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
 			"useResponsesLite": true,

--- a/packages/catalog/test/codex-discovery.test.ts
+++ b/packages/catalog/test/codex-discovery.test.ts
@@ -100,6 +100,46 @@ describe("Codex model discovery", () => {
 		expect(legacy?.useResponsesLite).toBeUndefined();
 	});
 
+	it("falls back to the 372K window for GPT-5.6 SKUs when upstream omits context_window (#5705)", async () => {
+		const fetchFn: typeof fetch = Object.assign(
+			async () =>
+				new Response(
+					JSON.stringify({
+						models: [
+							{
+								slug: "gpt-5.6-sol",
+								display_name: "GPT-5.6-Sol",
+								default_reasoning_level: "medium",
+								supported_reasoning_levels: ["low", "medium", "high"],
+								input_modalities: ["text", "image"],
+								supported_in_api: true,
+							},
+							{
+								slug: "gpt-5.5",
+								display_name: "GPT-5.5",
+								default_reasoning_level: "high",
+								supported_reasoning_levels: ["low", "high"],
+								input_modalities: ["text"],
+								supported_in_api: true,
+							},
+						],
+					}),
+				),
+			{ preconnect() {} },
+		);
+		const result = await fetchCodexModels({
+			accessToken: "test-token",
+			baseUrl: "https://codex.example/backend-api",
+			clientVersion: "0.99.0",
+			fetchFn,
+		});
+
+		const sol = result?.models.find(model => model.id === "gpt-5.6-sol");
+		expect(sol?.contextWindow).toBe(372_000);
+		const legacy = result?.models.find(model => model.id === "gpt-5.5");
+		expect(legacy?.contextWindow).toBe(272_000);
+	});
+
 	it("ignores pre-V2 Codex discovery cache rows", async () => {
 		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-codex-v7-cache-"));
 		const dbPath = path.join(tempDir, "models.db");

--- a/packages/catalog/test/generated-policies.test.ts
+++ b/packages/catalog/test/generated-policies.test.ts
@@ -86,6 +86,39 @@ describe("generated model policies", () => {
 		expect(models[3]?.priority).toBe(1);
 	});
 
+	it("pins GPT-5.6 Codex-transport context window to the 372K hard capacity (#5705)", () => {
+		const models: ModelSpec<Api>[] = [
+			// Codex discovery underreports these via DEFAULT_CONTEXT_WINDOW=272000.
+			createSpec({
+				id: "gpt-5.6-luna",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				contextWindow: 272000,
+			}),
+			createSpec({
+				id: "gpt-5.6-sol",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				contextWindow: 272000,
+			}),
+			createSpec({
+				id: "gpt-5.6-terra",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				contextWindow: 272000,
+			}),
+			// The first-party API-key entry uses openai-responses and is untouched.
+			createSpec({ id: "gpt-5.6-sol", api: "openai-responses", provider: "openai", contextWindow: 1050000 }),
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.contextWindow).toBe(372000);
+		expect(models[1]?.contextWindow).toBe(372000);
+		expect(models[2]?.contextWindow).toBe(372000);
+		expect(models[3]?.contextWindow).toBe(1050000);
+	});
+
 	it("pins Claude Mythos 5 first-party Anthropic catalog metadata", () => {
 		const models: ModelSpec<Api>[] = [
 			createSpec({


### PR DESCRIPTION
## Repro
The bundled `openai-codex` GPT-5.6 variants regressed to a 272K context window:

```
$ python3 -c "import json; c=json.load(open('packages/catalog/src/models.json'))['openai-codex']; print({k: c[k]['contextWindow'] for k in ['gpt-5.6-luna','gpt-5.6-sol','gpt-5.6-terra']})"
{'gpt-5.6-luna': 272000, 'gpt-5.6-sol': 272000, 'gpt-5.6-terra': 272000}
```

At `03c48d073bd~1` these were `372000`; commit `03c48d073bd` regressed them to `272000`. This shrinks the TUI denominator and the compaction/context budget. A direct Responses request with 350,317 input tokens completes (`HTTP 200`, `completed`), proving 272K is not the route's hard capacity, and OpenAI's Codex model registry declares `context_window = max_context_window = 372000`.

## Cause
Codex discovery (`packages/catalog/src/discovery/codex.ts:7`) falls back to `DEFAULT_CONTEXT_WINDOW = 272_000` when upstream omits/underreports `context_window`, and that value overwrote the previously-bundled `372000` on catalog regen. `applyOpenAICatalogPolicy` (`packages/catalog/scripts/generated-policies.ts`) pins `272000` only for the older `codex`/`codex-mini` variants and GPT-5.4 mini/nano — it had no pin for the 5.6 Codex-transport SKUs (luna/sol/terra parse as `variant: "base"`, version `5.6`), so the discovery fallback stood.

## Fix
- `packages/catalog/scripts/generated-policies.ts`: added a pin in `applyOpenAICatalogPolicy` setting `contextWindow = 372000` for `openai-codex-responses` models with parsed version `5.6`.
- `packages/catalog/src/models.json`: refreshed the three bundled `openai-codex` GPT-5.6 entries to `372000` (the deterministic output of the policy above).
- `packages/catalog/test/generated-policies.test.ts`: added a regression test asserting the policy pins luna/sol/terra to `372000` while leaving the first-party `openai`/`openai-responses` entry untouched.
- `packages/catalog/CHANGELOG.md`: documented under `[Unreleased] > Fixed`.

## Verification
`bun test test/generated-policies.test.ts` — 13 pass, 0 fail. Confirmed the bundled entries now read `372000`. The first-party `openai` GPT-5.6 rows (1050000, `openai-responses`) are intentionally unaffected.

Fixes #5705