### PR TITLE
fix(coding-agent/launch): handle EISDIR from realpath on drive roots

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a startup crash on Windows when running from a drive root (e.g. `R:\`): `fs.realpath` throws `EISDIR` there, but `canonicalProjectDir` in `launch/presence.ts` and `launch/client.ts` only recovered `ENOENT`. It now also falls back to `path.resolve()` on `EISDIR` ([#5708](https://github.com/can1357/oh-my-pi/issues/5708) by [@ve3xone](https://github.com/ve3xone)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/launch/client.ts
+++ b/packages/coding-agent/src/launch/client.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs/promises";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { isEexist, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
+import { isEexist, isEisdir, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
 import { resolveWorkerSpawnCmd, workerEnvFromParent } from "../subprocess/worker-client";
 import { daemonBrokerEndpoint, daemonRuntimeDir } from "./paths";
 import {
@@ -49,7 +49,7 @@ async function canonicalProjectDir(projectDir: string): Promise<string> {
 	try {
 		return await fs.realpath(resolved);
 	} catch (error) {
-		if (isEnoent(error)) return resolved;
+		if (isEnoent(error) || isEisdir(error)) return resolved;
 		throw error;
 	}
 }

--- a/packages/coding-agent/src/launch/presence.ts
+++ b/packages/coding-agent/src/launch/presence.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { isEnoent, postmortem } from "@oh-my-pi/pi-utils";
+import { isEisdir, isEnoent, postmortem } from "@oh-my-pi/pi-utils";
 import { daemonRuntimeDir } from "./paths";
 
 const CLIENTS_DIR = "clients";
@@ -15,7 +15,7 @@ async function canonicalProjectDir(projectDir: string): Promise<string> {
 	try {
 		return await fs.realpath(resolved);
 	} catch (error) {
-		if (isEnoent(error)) return resolved;
+		if (isEnoent(error) || isEisdir(error)) return resolved;
 		throw error;
 	}
 }

--- a/packages/coding-agent/test/tools/launch-eisdir-fallback.test.ts
+++ b/packages/coding-agent/test/tools/launch-eisdir-fallback.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { PathLike } from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { registerDaemonProjectPresence } from "../../src/launch/presence";
+
+describe("daemon presence canonicalProjectDir EISDIR fallback", () => {
+	const originalRealpath = fs.realpath.bind(fs);
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("falls back to the resolved path when realpath throws EISDIR", async () => {
+		const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-eisdir-fallback-"));
+		const runtimeDir = path.join(projectDir, "runtime");
+		const resolvedProjectDir = path.resolve(projectDir);
+		let realpathCalls = 0;
+
+		vi.spyOn(fs, "realpath").mockImplementation((async (p: PathLike) => {
+			if (path.resolve(String(p)) === resolvedProjectDir) {
+				realpathCalls++;
+				const err = new Error("EISDIR: illegal operation on a directory") as NodeJS.ErrnoException;
+				err.code = "EISDIR";
+				err.errno = -21;
+				err.syscall = "lstat";
+				err.path = `R:${path.sep}`;
+				throw err;
+			}
+			return originalRealpath(p);
+		}) as typeof fs.realpath);
+
+		try {
+			const presence = await registerDaemonProjectPresence(projectDir, runtimeDir);
+			expect(typeof presence.close).toBe("function");
+			expect(realpathCalls).toBe(1);
+
+			const clientsDir = path.join(runtimeDir, "clients");
+			const entries = await fs.readdir(clientsDir);
+			expect(entries).toHaveLength(1);
+
+			await presence.close();
+		} finally {
+			await fs.rm(projectDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Repro
On Windows, running omp from a drive root (`cd R:\` then `omp -p "hi"`) crashes at startup with `EISDIR: illegal operation on a directory, lstat 'R:\...'`. `fs.realpath()` throws `EISDIR` for drive-root paths on Windows. Simulating `fs.realpath` throwing `EISDIR` through `canonicalProjectDir`'s try/catch reproduces the propagation: the `ENOENT`-only guard rethrows and aborts startup.

## Cause
`canonicalProjectDir()` in `packages/coding-agent/src/launch/presence.ts` and `packages/coding-agent/src/launch/client.ts` wraps `fs.realpath(resolved)` in a try/catch that only recovers `ENOENT` (`if (isEnoent(error)) return resolved`). Any other error — including the `EISDIR` that `fs.realpath` raises on Windows drive roots — propagates out of daemon-presence registration and takes down the process before the agent can run.

## Fix
- `launch/presence.ts`: import `isEisdir` and recover `EISDIR` in `canonicalProjectDir` (`if (isEnoent(error) || isEisdir(error)) return resolved`), falling back to `path.resolve()` like the existing `ENOENT` path.
- `launch/client.ts`: same import + guard change in its `canonicalProjectDir`.
- Added `test/tools/launch-eisdir-fallback.test.ts`: spies `fs.realpath` to throw `EISDIR` and asserts `registerDaemonProjectPresence` still succeeds and writes a client presence entry.
- Changelog entry under `[Unreleased]`, crediting @ve3xone whose fork commit prompted this.

## Verification
`bun test test/tools/launch-eisdir-fallback.test.ts` → 1 pass. Confirmed the test fails (`EISDIR` propagates) when the `presence.ts` change is stashed, and passes with it. `bun check` ran clean via the pre-publish gate on push.

Fixes #5708