### PR TITLE
fix(cli): error on unknown __omp_worker_ selectors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unknown `__omp_worker_*` CLI selectors exiting 0 with empty output instead of erroring; an unrecognized worker-host selector now writes `Error: unknown worker selector: …` to stderr and exits nonzero, so a stale or mistyped selector can no longer look healthy to a parent process or install smoke path ([#5712](https://github.com/can1357/oh-my-pi/issues/5712)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -338,7 +338,11 @@ export async function runCli(argv: string[]): Promise<void> {
 	// worker's parked initial messages as soon as the entry module's
 	// top-level evaluation finishes.
 	if (resolvedArgv[0]?.startsWith("__omp_worker_")) {
-		await runWorkerEntrypoint(resolvedArgv[0]);
+		const dispatched = await runWorkerEntrypoint(resolvedArgv[0]);
+		if (!dispatched) {
+			process.stderr.write(`Error: unknown worker selector: ${resolvedArgv[0]}\n`);
+			process.exitCode = 1;
+		}
 		return;
 	}
 

--- a/packages/coding-agent/test/worker-selector.test.ts
+++ b/packages/coding-agent/test/worker-selector.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { runCli } from "../src/cli";
+
+// The worker-host re-entry seam dispatches any `__omp_worker_*` selector to
+// `runWorkerEntrypoint`. An unrecognized selector must fail loudly rather than
+// exit 0 with empty output, so a stale/mistyped selector cannot look healthy to
+// a parent process or install smoke path (issue #5712).
+describe("worker selector dispatch", () => {
+	beforeEach(() => {
+		process.exitCode = 0;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		process.exitCode = 0;
+	});
+
+	it("fails with a nonzero exit and stderr error on an unknown selector", async () => {
+		const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+		await runCli(["__omp_worker_does_not_exist"]);
+
+		expect(process.exitCode).toBe(1);
+		expect(stderr).toHaveBeenCalledWith("Error: unknown worker selector: __omp_worker_does_not_exist\n");
+	});
+
+	it("leaves normal root flags untouched", async () => {
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+		await runCli(["--version"]);
+
+		expect(process.exitCode).toBe(0);
+		expect(stdout).toHaveBeenCalled();
+		expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining("unknown worker selector"));
+	});
+});


### PR DESCRIPTION
## Repro
On the worker-host re-entry path, an unrecognized reserved selector exits successfully with no output. `bun packages/coding-agent/src/cli.ts __omp_worker_does_not_exist; echo "EXIT=$?"` prints only `EXIT=0` — empty stdout, empty stderr, no worker started. A stale, mistyped, or out-of-sync selector therefore looks healthy to a parent process or install smoke path.

## Cause
`runCli` in `packages/coding-agent/src/cli.ts` dispatches any argv starting with `__omp_worker_` to `runWorkerEntrypoint(...)`, which returns `false` for selectors it does not recognize. The dispatch seam ignored that boolean and unconditionally `return`ed, so the process fell out as a silent success.

## Fix
- Capture `runWorkerEntrypoint`'s return at the dispatch seam; on `false`, write `Error: unknown worker selector: <arg>` to stderr and set `process.exitCode = 1` before returning. Known selectors and normal CLI arguments are unchanged.
- Add `packages/coding-agent/test/worker-selector.test.ts` covering the unknown-selector failure (nonzero exit + stderr error) and the preserved `--version` path.
- Changelog entry under `[Unreleased] / Fixed`.

## Verification
`bun test packages/coding-agent/test/worker-selector.test.ts` → 2 pass, 0 fail. Manual: `bun packages/coding-agent/src/cli.ts __omp_worker_does_not_exist` now prints `Error: unknown worker selector: __omp_worker_does_not_exist` and exits `1`; `--version` still exits `0` with normal output. Fixes #5712