### PR TITLE
fix: bound fatal TUI teardown and isolate log rotation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed orphaned TUI processes with revoked terminal descriptors remaining alive after a fatal error and amplifying shared log-rotation races into runaway memory, file-descriptor, swap, and disk consumption ([#5716](https://github.com/can1357/oh-my-pi/issues/5716)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/debug/report-bundle.ts
+++ b/packages/coding-agent/src/debug/report-bundle.ts
@@ -241,7 +241,7 @@ export async function getLogText(): Promise<string> {
 	return readLastLines(getLogPath(), MAX_LOG_LINES);
 }
 
-const LOG_FILE_PATTERN = new RegExp(`^${APP_NAME}\\.(\\d{4}-\\d{2}-\\d{2})\\.log$`);
+const LOG_FILE_PATTERN = new RegExp(`^${APP_NAME}\\.(\\d{4}-\\d{2}-\\d{2})\\.\\d+\\.log$`);
 
 export async function createDebugLogSource(): Promise<DebugLogSource> {
 	const logsDir = getLogsDir();

--- a/packages/coding-agent/src/debug/report-bundle.ts
+++ b/packages/coding-agent/src/debug/report-bundle.ts
@@ -105,9 +105,10 @@ export async function createReportBundle(options: ReportBundleOptions): Promise<
 		files.push("config.json");
 	}
 
-	// Recent logs (last 1000 lines)
-	const logPath = getLogPath();
-	const logs = await readLastLines(logPath, 1000);
+	// Recent logs (last 1000 lines) across every same-day process. PID-qualified
+	// filenames mean a report generated from a later invocation must still gather
+	// the crashed process's log, so read all of today's files, not just our own.
+	const logs = await collectSameDayLogs(1000);
 	if (logs) {
 		data["logs.txt"] = logs;
 		files.push("logs.txt");
@@ -239,6 +240,41 @@ async function addSubagentSessions(
 /** Get recent log entries for display (tail-limited to avoid OOM on large files). */
 export async function getLogText(): Promise<string> {
 	return readLastLines(getLogPath(), MAX_LOG_LINES);
+}
+
+/**
+ * Concatenate the tail of every same-day process log so a report generated
+ * after a crash still captures the fatal PID's `omp.<date>.<pid>.log`. Files
+ * are ordered oldest-first by mtime and separated by a filename header.
+ */
+async function collectSameDayLogs(linesPerFile: number): Promise<string> {
+	const logsDir = getLogsDir();
+	const today = new Date().toISOString().slice(0, 10);
+	const sameDay: Array<{ name: string; mtimeMs: number }> = [];
+	try {
+		const entries = await fs.readdir(logsDir, { withFileTypes: true });
+		for (const entry of entries) {
+			if (!entry.isFile()) continue;
+			const match = LOG_FILE_PATTERN.exec(entry.name);
+			if (!match || match[1] !== today) continue;
+			try {
+				const stat = await fs.stat(path.join(logsDir, entry.name));
+				sameDay.push({ name: entry.name, mtimeMs: stat.mtimeMs });
+			} catch {
+				// File may have rotated away between readdir and stat.
+			}
+		}
+	} catch {
+		return "";
+	}
+	sameDay.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+	const chunks: string[] = [];
+	for (const { name } of sameDay) {
+		const text = await readLastLines(path.join(logsDir, name), linesPerFile);
+		if (text) chunks.push(`===== ${name} =====\n${text}`);
+	}
+	return chunks.join("\n\n");
 }
 
 const LOG_FILE_PATTERN = new RegExp(`^${APP_NAME}\\.(\\d{4}-\\d{2}-\\d{2})\\.\\d+\\.log$`);

--- a/packages/coding-agent/test/debug/report-bundle-logs.test.ts
+++ b/packages/coding-agent/test/debug/report-bundle-logs.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createReportBundle } from "@oh-my-pi/pi-coding-agent/debug/report-bundle";
+import { getConfigRootDir, getLogsDir, removeWithRetries, setAgentDir } from "@oh-my-pi/pi-utils";
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const originalXdgStateHome = process.env.XDG_STATE_HOME;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+let cleanupRoot: string | undefined;
+
+afterEach(async () => {
+	if (originalXdgStateHome === undefined) {
+		delete process.env.XDG_STATE_HOME;
+	} else {
+		process.env.XDG_STATE_HOME = originalXdgStateHome;
+	}
+	if (originalAgentDir) {
+		setAgentDir(originalAgentDir);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.PI_CODING_AGENT_DIR;
+	}
+	if (cleanupRoot) {
+		await removeWithRetries(cleanupRoot);
+		cleanupRoot = undefined;
+	}
+});
+
+describe("report bundle logs", () => {
+	it("collects every same-day PID log, not only the current process", async () => {
+		cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-report-logs-"));
+		const xdgStateHome = path.join(cleanupRoot, "state");
+		await fs.mkdir(path.join(xdgStateHome, "omp"), { recursive: true });
+		process.env.XDG_STATE_HOME = xdgStateHome;
+		setAgentDir(fallbackAgentDir);
+
+		const logsDir = getLogsDir();
+		await fs.mkdir(logsDir, { recursive: true });
+		const today = new Date().toISOString().slice(0, 10);
+		const crashedName = `omp.${today}.4242.log`;
+		const currentName = `omp.${today}.${process.pid}.log`;
+		await Bun.write(path.join(logsDir, crashedName), '{"pid":4242,"message":"fatal in crashed pid"}\n');
+		await fs.utimes(path.join(logsDir, crashedName), 1, 1);
+		await Bun.write(path.join(logsDir, currentName), '{"pid":0,"message":"later invocation"}\n');
+		await fs.utimes(path.join(logsDir, currentName), 2, 2);
+
+		const result = await createReportBundle({ sessionFile: undefined });
+
+		expect(result.files).toContain("logs.txt");
+		const archive = new Bun.Archive(await Bun.file(result.path).bytes());
+		const files = await archive.files();
+		const logsText = (await files.get("logs.txt")?.text()) ?? "";
+		expect(logsText).toContain(crashedName);
+		expect(logsText).toContain("fatal in crashed pid");
+		expect(logsText).toContain(currentName);
+		expect(logsText).toContain("later invocation");
+		expect(logsText.indexOf(crashedName)).toBeLessThan(logsText.indexOf(currentName));
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed fatal cleanup failing to reach `process.exit()` when terminal stderr is revoked, and isolated rotating log files/audit state per process to prevent concurrent OMP instances from racing compression and rotation ([#5716](https://github.com/can1357/oh-my-pi/issues/5716)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Fixed

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -513,9 +513,9 @@ export function getLogsDir(): string {
 	return dirs.rootSubdir("logs", "state");
 }
 
-/** Get the path to a dated log file (~/.omp/logs/omp.YYYY-MM-DD.log). */
-export function getLogPath(date = new Date()): string {
-	return path.join(getLogsDir(), `${APP_NAME}.${date.toISOString().slice(0, 10)}.log`);
+/** Get this process's dated log path (~/.omp/logs/omp.YYYY-MM-DD.PID.log). */
+export function getLogPath(date = new Date(), pid = process.pid): string {
+	return path.join(getLogsDir(), `${APP_NAME}.${date.toISOString().slice(0, 10)}.${pid}.log`);
 }
 
 /**

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,7 +1,7 @@
 /**
  * Centralized logger for omp.
  *
- * Default: rotating `~/.omp/logs/omp.<DATE>.log`, no console output (writing
+ * Default: rotating `~/.omp/logs/omp.<DATE>.<PID>.log`, no console output (writing
  * to stdout/stderr would corrupt the TUI). Long-running headless services
  * (the auth broker, etc.) call {@link setTransports} to swap in a console
  * transport so a process supervisor (pm2, journald, k8s) captures the logs.
@@ -76,11 +76,11 @@ function getLogFormat(): winston.Logform.Format {
 function makeFileTransport(dir?: string): winston.transport {
 	return new DailyRotateFile({
 		dirname: ensureDir(dir ?? getLogsDir()),
-		filename: "omp.%DATE%.log",
+		filename: `omp.%DATE%.${process.pid}.log`,
 		datePattern: "YYYY-MM-DD",
 		maxSize: "10m",
 		maxFiles: 5,
-		zippedArchive: true,
+		zippedArchive: false,
 	});
 }
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -11,11 +11,72 @@
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { isPromise } from "node:util/types";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
 import { getLogsDir } from "./dirs";
 import { drainModuleLoadEvents } from "./timing-buffer";
+
+const PROCESS_LOG_PATTERN = /^omp\.\d{4}-\d{2}-\d{2}\.(\d+)\.log(?:\.\d+)?$/;
+const PROCESS_AUDIT_PATTERN = /^\.omp\.(\d+)-audit\.json$/;
+const RETAINED_STALE_LOG_FILES = 5;
+
+function processIsRunning(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return !(error instanceof Error && "code" in error && (error.code === "ESRCH" || error.code === "EINVAL"));
+	}
+}
+
+/**
+ * Retain the newest completed-process logs globally and remove their one-use
+ * audit files. Live PID namespaces are never touched.
+ */
+function pruneStaleProcessLogs(dir: string): void {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+
+	const staleLogs: Array<{ path: string; mtimeMs: number }> = [];
+	for (const entry of entries) {
+		if (!entry.isFile()) continue;
+		const logMatch = PROCESS_LOG_PATTERN.exec(entry.name);
+		const auditMatch = PROCESS_AUDIT_PATTERN.exec(entry.name);
+		const pidText = logMatch?.[1] ?? auditMatch?.[1];
+		if (!pidText || processIsRunning(Number(pidText))) continue;
+		const entryPath = path.join(dir, entry.name);
+
+		if (auditMatch) {
+			try {
+				fs.rmSync(entryPath, { force: true });
+			} catch {
+				// Retention is best-effort; logging must still initialize.
+			}
+			continue;
+		}
+
+		try {
+			staleLogs.push({ path: entryPath, mtimeMs: fs.statSync(entryPath).mtimeMs });
+		} catch {
+			// Another process may have pruned the same stale namespace.
+		}
+	}
+
+	staleLogs.sort((a, b) => b.mtimeMs - a.mtimeMs);
+	for (const stale of staleLogs.slice(RETAINED_STALE_LOG_FILES)) {
+		try {
+			fs.rmSync(stale.path, { force: true });
+		} catch {
+			// Another process may have pruned the same stale namespace.
+		}
+	}
+}
 
 /** Ensure a logs directory exists; return the resolved path. */
 function ensureDir(dir: string): string {
@@ -72,15 +133,18 @@ function getLogFormat(): winston.Logform.Format {
 	return logFormat;
 }
 
-/** Build a rotating file transport, materializing the target directory lazily. */
+/** Build a rotating file transport with process-local rotation and shared retention. */
 function makeFileTransport(dir?: string): winston.transport {
+	const logsDir = ensureDir(dir ?? getLogsDir());
+	pruneStaleProcessLogs(logsDir);
 	return new DailyRotateFile({
-		dirname: ensureDir(dir ?? getLogsDir()),
+		dirname: logsDir,
 		filename: `omp.%DATE%.${process.pid}.log`,
 		datePattern: "YYYY-MM-DD",
 		maxSize: "10m",
 		maxFiles: 5,
 		zippedArchive: false,
+		auditFile: path.join(logsDir, `.omp.${process.pid}-audit.json`),
 	});
 }
 

--- a/packages/utils/src/postmortem.ts
+++ b/packages/utils/src/postmortem.ts
@@ -5,6 +5,8 @@
  * in response to process exit, signals, or fatal exceptions. It is intended to
  * allow reliably releasing resources or shutting down subprocesses, files, sockets, etc.
  */
+
+import * as fs from "node:fs";
 import inspector from "node:inspector";
 import { isMainThread } from "node:worker_threads";
 import { logger } from ".";
@@ -68,7 +70,6 @@ function runCleanup(reason: Reason): Promise<void> {
 		cleanupStage = "complete";
 		deadline.resolve();
 	}, CLEANUP_DEADLINE_MS);
-	deadlineTimer.unref();
 	cleanupPromise = Promise.race([cleanupSettled, deadline.promise]).finally(() => {
 		clearTimeout(deadlineTimer);
 	});
@@ -175,6 +176,23 @@ function formatFatalError(label: string, err: Error): string {
 	return `\n[${label}] ${name}: ${message}${formattedStack}\n`;
 }
 
+async function exitAfterFatal(label: string, logMessage: string, err: Error, reason: Reason): Promise<void> {
+	const forcedExit = setTimeout(() => process.exit(1), CLEANUP_DEADLINE_MS);
+	try {
+		restoreTerminalStderr();
+		// A revoked terminal can make stream writes raise another fatal error. Use
+		// the descriptor directly so failure stays synchronous and contained.
+		try {
+			fs.writeSync(2, formatFatalError(label, err));
+		} catch {}
+		logger.error(logMessage, { err });
+		await runCleanup(reason);
+	} finally {
+		clearTimeout(forcedExit);
+		process.exit(1);
+	}
+}
+
 if (isMainThread) {
 	process
 		.on("SIGINT", async () => {
@@ -193,15 +211,7 @@ if (isMainThread) {
 				logger.warn("Ignoring expected cleanup exception", { err });
 				return;
 			}
-			// fd 2 may be redirected to the log while a TUI owns the terminal
-			// (stderr-guard); re-point it at the real terminal so the fatal
-			// report is visible. Terminal modes are restored moments later by
-			// the terminal-restore cleanup callback inside runCleanup().
-			restoreTerminalStderr();
-			process.stderr.write(formatFatalError("Uncaught Exception", err));
-			logger.error("Uncaught exception", { err });
-			await runCleanup(Reason.UNCAUGHT_EXCEPTION);
-			process.exit(1);
+			await exitAfterFatal("Uncaught Exception", "Uncaught exception", err, Reason.UNCAUGHT_EXCEPTION);
 		})
 		.on("unhandledRejection", async reason => {
 			const err = reason instanceof Error ? reason : new Error(String(reason));
@@ -237,12 +247,7 @@ if (isMainThread) {
 					});
 				}
 			}
-			// See uncaughtException above: surface the report on the real stderr.
-			restoreTerminalStderr();
-			process.stderr.write(formatFatalError("Unhandled Rejection", err));
-			logger.error("Unhandled rejection", { err });
-			await runCleanup(Reason.UNHANDLED_REJECTION);
-			process.exit(1);
+			await exitAfterFatal("Unhandled Rejection", "Unhandled rejection", err, Reason.UNHANDLED_REJECTION);
 		})
 		.on("exit", async () => {
 			void runCleanup(Reason.EXIT); // fire and forget (exit imminent)

--- a/packages/utils/test/logger-multiprocess.test.ts
+++ b/packages/utils/test/logger-multiprocess.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const loggerModuleUrl = pathToFileURL(path.join(import.meta.dir, "../src/logger.ts")).href;
+const roots: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function makeProbe(logsDir: string): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-logger-probe-"));
+	roots.push(root);
+	const probePath = path.join(root, "probe.ts");
+	await Bun.write(
+		probePath,
+		`import { info, setTransports } from ${JSON.stringify(loggerModuleUrl)};\n` +
+			`setTransports({ file: ${JSON.stringify(logsDir)} });\n` +
+			`info("multiprocess probe");\n` +
+			`setTransports({ file: false });\n`,
+	);
+	return probePath;
+}
+
+async function waitForExit(proc: Bun.Subprocess): Promise<number> {
+	const code = await proc.exited;
+	return code;
+}
+
+describe("multiprocess file logging", () => {
+	it("gives concurrent processes independent rotation files and audit state", async () => {
+		const logsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-logger-output-"));
+		roots.push(logsDir);
+		const probePath = await makeProbe(logsDir);
+		const processes = [
+			Bun.spawn([process.execPath, probePath], { stdout: "ignore", stderr: "pipe" }),
+			Bun.spawn([process.execPath, probePath], { stdout: "ignore", stderr: "pipe" }),
+		];
+
+		expect(await Promise.all(processes.map(waitForExit))).toEqual([0, 0]);
+		const entries = await fs.readdir(logsDir);
+		const datedPrefix = `omp.${new Date().toISOString().slice(0, 10)}`;
+		for (const proc of processes) {
+			expect(entries).toContain(`${datedPrefix}.${proc.pid}.log`);
+		}
+		expect(entries.filter(name => name.endsWith("-audit.json"))).toHaveLength(2);
+	});
+});

--- a/packages/utils/test/logger-multiprocess.test.ts
+++ b/packages/utils/test/logger-multiprocess.test.ts
@@ -20,14 +20,11 @@ async function makeProbe(logsDir: string): Promise<string> {
 		`import { info, setTransports } from ${JSON.stringify(loggerModuleUrl)};\n` +
 			`setTransports({ file: ${JSON.stringify(logsDir)} });\n` +
 			`info("multiprocess probe");\n` +
+			`console.log("ready");\n` +
+			`await new Response(Bun.stdin.stream()).text();\n` +
 			`setTransports({ file: false });\n`,
 	);
 	return probePath;
-}
-
-async function waitForExit(proc: Bun.Subprocess): Promise<number> {
-	const code = await proc.exited;
-	return code;
 }
 
 describe("multiprocess file logging", () => {
@@ -36,16 +33,53 @@ describe("multiprocess file logging", () => {
 		roots.push(logsDir);
 		const probePath = await makeProbe(logsDir);
 		const processes = [
-			Bun.spawn([process.execPath, probePath], { stdout: "ignore", stderr: "pipe" }),
-			Bun.spawn([process.execPath, probePath], { stdout: "ignore", stderr: "pipe" }),
+			Bun.spawn([process.execPath, probePath], { stdin: "pipe", stdout: "pipe", stderr: "pipe" }),
+			Bun.spawn([process.execPath, probePath], { stdin: "pipe", stdout: "pipe", stderr: "pipe" }),
 		];
 
-		expect(await Promise.all(processes.map(waitForExit))).toEqual([0, 0]);
+		const ready = await Promise.all(
+			processes.map(async proc => {
+				const reader = proc.stdout.getReader();
+				const result = await reader.read();
+				reader.releaseLock();
+				return result.value ? new TextDecoder().decode(result.value) : "";
+			}),
+		);
+		expect(ready).toEqual(["ready\n", "ready\n"]);
+		for (const proc of processes) proc.stdin.end();
+
+		expect(await Promise.all(processes.map(proc => proc.exited))).toEqual([0, 0]);
 		const entries = await fs.readdir(logsDir);
 		const datedPrefix = `omp.${new Date().toISOString().slice(0, 10)}`;
 		for (const proc of processes) {
 			expect(entries).toContain(`${datedPrefix}.${proc.pid}.log`);
 		}
 		expect(entries.filter(name => name.endsWith("-audit.json"))).toHaveLength(2);
+	});
+
+	it("prunes completed PID namespaces across short-lived invocations", async () => {
+		const logsDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-logger-retention-"));
+		roots.push(logsDir);
+		const exited = Array.from({ length: 7 }, () =>
+			Bun.spawn([process.execPath, "--version"], { stdout: "ignore", stderr: "ignore" }),
+		);
+		expect(await Promise.all(exited.map(proc => proc.exited))).toEqual(Array(7).fill(0));
+
+		const date = "2026-07-01";
+		for (const [index, proc] of exited.entries()) {
+			const logPath = path.join(logsDir, `omp.${date}.${proc.pid}.log`);
+			await Bun.write(logPath, `completed process ${proc.pid}`);
+			await fs.utimes(logPath, index + 1, index + 1);
+			await Bun.write(path.join(logsDir, `.omp.${proc.pid}-audit.json`), "{}");
+		}
+
+		const probePath = await makeProbe(logsDir);
+		const current = Bun.spawn([process.execPath, probePath], { stdout: "ignore", stderr: "pipe" });
+		expect(await current.exited).toBe(0);
+
+		const entries = await fs.readdir(logsDir);
+		const completedLogs = entries.filter(name => name.startsWith(`omp.${date}.`));
+		expect(completedLogs).toHaveLength(5);
+		expect(entries.filter(name => name.endsWith("-audit.json"))).toEqual([`.omp.${current.pid}-audit.json`]);
 	});
 });

--- a/packages/utils/test/postmortem-cleanup-error.test.ts
+++ b/packages/utils/test/postmortem-cleanup-error.test.ts
@@ -121,6 +121,24 @@ describe("postmortem expected cleanup errors", () => {
 		expect(result.stderr).toContain("[Unhandled Rejection] Error: unexpected cleanup rejection");
 	});
 
+	it("exits after an uncaught exception when terminal stderr is revoked", async () => {
+		const result = await runPostmortemProbe(`
+			import { spyOn } from "bun:test";
+			import "${postmortemModuleUrl}";
+
+			spyOn(process.stderr, "write").mockImplementation(() => {
+				throw Object.assign(new Error("terminal revoked"), { code: "EIO" });
+			});
+			queueMicrotask(() => {
+				throw new Error("fatal after disconnect");
+			});
+			await Promise.withResolvers<void>().promise;
+		`);
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toContain("[Uncaught Exception] Error: fatal after disconnect");
+	});
+
 	it("releases manual cleanup at the deadline even when a callback never settles", async () => {
 		const result = await runPostmortemProbe(`
 			import { vi } from "bun:test";


### PR DESCRIPTION
## Repro
Two concurrent processes using the production rotating logger under bounded high-rate writes retained 235/171 file descriptors and about 1.2 GB RSS each after three seconds (`bun /tmp/omp-5716-repro.ts`). A second probe replaced the revoked terminal stream’s `stderr.write` with an `EIO` failure; `bun /tmp/omp-5716-revoked-probe.ts` remained alive until the three-second harness timeout instead of reaching fatal exit.

## Cause
`packages/utils/src/postmortem.ts` wrote fatal diagnostics through `process.stderr` before entering cleanup, so a revoked stream could raise another fatal error and strand the original handler before `process.exit(1)`; its cleanup deadline was also unreferenced. Independently, `packages/utils/src/logger.ts` gave every process the same `DailyRotateFile` filename/options, which made `file-stream-rotator` share one audit file and let concurrent processes race size counters, rotated paths, and gzip pipelines.

## Fix
- Write fatal diagnostics directly to fd 2 inside a contained synchronous failure boundary, keep the cleanup deadline referenced, and arm an independent forced-exit watchdog before fatal reporting.
- Namespace active logs and derived audit files by PID, and disable gzip rotation pipelines so processes cannot share compression inputs/outputs.
- Update log-path/debug-log discovery for PID-qualified filenames and cover revoked stderr plus concurrent logger namespaces with subprocess regressions.

## Verification
`bun test packages/utils/test` passed 462 tests; `bun test packages/coding-agent/test/debug` passed 82 tests; `bun check` passed every package. The revoked-stderr probe now exits with code 1 in 0.13 seconds, and the concurrent logger regression observes distinct PID-qualified log files and audit state. Fixes #5716