### PR TITLE
fix(read): recover approved plans from cwd aliases

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed approved-plan execution looping through filesystem searches when a model rewrites the required `local://<slug>-plan.md` read as a same-basename working-directory path; a missing cwd-root alias now recovers the active session-local plan while preserving any real working-tree file ([#5704](https://github.com/can1357/oh-my-pi/issues/5704)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -36,7 +36,7 @@ import {
 import { normalizeToLF } from "../edit/normalize";
 import { isNotebookPath, readEditableNotebookText } from "../edit/notebook";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
-import { InternalUrlRouter, resolveLocalUrlToFile } from "../internal-urls";
+import { InternalUrlRouter, resolveLocalUrlToFile, resolveLocalUrlToPath } from "../internal-urls";
 import { type ResolvedArtifactFile, resolveArtifactFile } from "../internal-urls/artifact-protocol";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
@@ -918,6 +918,32 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			IS_LINE_NUMBER_MODE: !displayMode.hashLines && displayMode.lineNumbers,
 			INSPECT_IMAGE_ENABLED: this.#inspectImageEnabled,
 		});
+	}
+
+	/**
+	 * Recover the active approved plan when a model rewrites its `local://` URL
+	 * as a same-basename path in the working-directory root.
+	 *
+	 * Only missing cwd-root paths qualify, so a real working-tree file always
+	 * wins and unrelated paths cannot escape into the session artifact sandbox.
+	 */
+	#approvedPlanAlias(missingAbsolutePath: string): string | undefined {
+		const planReferencePath = this.session.getPlanReferencePath?.();
+		if (!planReferencePath?.startsWith("local:")) return undefined;
+
+		const requestedPath = path.resolve(missingAbsolutePath);
+		if (path.dirname(requestedPath) !== path.resolve(this.session.cwd)) return undefined;
+
+		const localProtocolOptions = this.session.localProtocolOptions ?? {
+			getArtifactsDir: () => this.session.getArtifactsDir?.() ?? null,
+			getSessionId: () => this.session.getSessionId?.() ?? null,
+		};
+		try {
+			const approvedPlanPath = resolveLocalUrlToPath(planReferencePath, localProtocolOptions);
+			return path.basename(requestedPath) === path.basename(approvedPlanPath) ? approvedPlanPath : undefined;
+		} catch {
+			return undefined;
+		}
 	}
 
 	async #tryReadDelimitedPaths(
@@ -2292,8 +2318,23 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			isDirectory = stat.isDirectory();
 		} catch (error) {
 			if (isNotFoundError(error)) {
+				let recoveredApprovedPlan = false;
+				const approvedPlanPath = this.#approvedPlanAlias(absolutePath);
+				if (approvedPlanPath) {
+					try {
+						const approvedPlanStat = await Bun.file(approvedPlanPath).stat();
+						absolutePath = approvedPlanPath;
+						fileSize = approvedPlanStat.size;
+						isDirectory = approvedPlanStat.isDirectory();
+						recoveredApprovedPlan = true;
+					} catch {
+						// The referenced plan disappeared after resolution; continue through
+						// ordinary suffix recovery and the original not-found error.
+					}
+				}
+
 				// Attempt unique suffix resolution before falling back to fuzzy suggestions
-				if (!isRemoteMountPath(absolutePath)) {
+				if (!recoveredApprovedPlan && !isRemoteMountPath(absolutePath)) {
 					const suffixMatch = await this.#findSuffixMatchCached(suffixCache, localReadPath, signal);
 					if (suffixMatch) {
 						try {
@@ -2308,7 +2349,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 					}
 				}
 
-				if (!suffixResolution) {
+				if (!recoveredApprovedPlan && !suffixResolution) {
 					const delimitedResult = await this.#tryReadDelimitedPaths(readPath, signal);
 					if (delimitedResult) return delimitedResult;
 					throw new ToolError(`Path '${localReadPath}' not found`);

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2318,23 +2318,9 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			isDirectory = stat.isDirectory();
 		} catch (error) {
 			if (isNotFoundError(error)) {
-				let recoveredApprovedPlan = false;
-				const approvedPlanPath = this.#approvedPlanAlias(absolutePath);
-				if (approvedPlanPath) {
-					try {
-						const approvedPlanStat = await Bun.file(approvedPlanPath).stat();
-						absolutePath = approvedPlanPath;
-						fileSize = approvedPlanStat.size;
-						isDirectory = approvedPlanStat.isDirectory();
-						recoveredApprovedPlan = true;
-					} catch {
-						// The referenced plan disappeared after resolution; continue through
-						// ordinary suffix recovery and the original not-found error.
-					}
-				}
-
-				// Attempt unique suffix resolution before falling back to fuzzy suggestions
-				if (!recoveredApprovedPlan && !isRemoteMountPath(absolutePath)) {
+				// Attempt unique suffix resolution before falling back to the approved-plan
+				// alias or fuzzy suggestions. Existing workspace files retain precedence.
+				if (!isRemoteMountPath(absolutePath)) {
 					const suffixMatch = await this.#findSuffixMatchCached(suffixCache, localReadPath, signal);
 					if (suffixMatch) {
 						try {
@@ -2344,7 +2330,25 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 							isDirectory = retryStat.isDirectory();
 							suffixResolution = { from: localReadPath, to: suffixMatch.displayPath };
 						} catch {
-							// Suffix match candidate no longer stats — fall through to error path
+							// Suffix match candidate no longer stats — continue through
+							// approved-plan recovery and the original not-found error.
+						}
+					}
+				}
+
+				let recoveredApprovedPlan = false;
+				if (!suffixResolution) {
+					const approvedPlanPath = this.#approvedPlanAlias(absolutePath);
+					if (approvedPlanPath) {
+						try {
+							const approvedPlanStat = await Bun.file(approvedPlanPath).stat();
+							absolutePath = approvedPlanPath;
+							fileSize = approvedPlanStat.size;
+							isDirectory = approvedPlanStat.isDirectory();
+							recoveredApprovedPlan = true;
+						} catch {
+							// The referenced plan disappeared after resolution; continue through
+							// the ordinary delimited-path fallback and not-found error.
 						}
 					}
 				}

--- a/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
+++ b/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
@@ -140,4 +140,21 @@ describe("read → edit round-trip for out-of-cwd files", () => {
 		expect(textOutput(result)).toContain("Workspace content.");
 		expect(textOutput(result)).not.toContain("Artifact content.");
 	});
+
+	it("prefers a unique workspace suffix match over the approved local plan alias", async () => {
+		const artifactsDir = path.join(outDir, "artifacts");
+		const planFilePath = "local://windows-packaging-plan.md";
+		const planPath = path.join(artifactsDir, "local", "windows-packaging-plan.md");
+		const workspacePlanPath = path.join(cwdDir, "docs", "windows-packaging-plan.md");
+		await Bun.write(planPath, "# Local plan\n\nArtifact content.\n");
+		await Bun.write(workspacePlanPath, "# Workspace plan\n\nNested workspace content.\n");
+
+		const session = createSession(cwdDir, { artifactsDir, planFilePath });
+		const result = await new ReadTool(session).execute("read-workspace-suffix-plan", {
+			path: "windows-packaging-plan.md",
+		});
+
+		expect(textOutput(result)).toContain("Nested workspace content.");
+		expect(textOutput(result)).not.toContain("Artifact content.");
+	});
 });

--- a/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
+++ b/packages/coding-agent/test/read-edit-out-of-cwd.test.ts
@@ -23,17 +23,27 @@ beforeAll(async () => {
 	await Settings.init({ inMemory: true, cwd: process.cwd() });
 });
 
-function createSession(cwd: string): ToolSession {
+function createSession(cwd: string, approvedPlan?: { artifactsDir: string; planFilePath: string }): ToolSession {
 	const settings = Settings.isolated();
 	settings.set("read.summarize.enabled", false);
+	const artifactsDir = approvedPlan?.artifactsDir ?? path.join(cwd, "artifacts");
 	return {
 		cwd,
 		hasUI: false,
 		getSessionFile: () => path.join(cwd, "session.jsonl"),
 		getSessionSpawns: () => "*",
-		getArtifactsDir: () => path.join(cwd, "artifacts"),
+		getArtifactsDir: () => artifactsDir,
 		allocateOutputArtifact: async () => ({ id: "artifact-1", path: path.join(cwd, "artifact-1.log") }),
 		settings,
+		...(approvedPlan
+			? {
+					getPlanReferencePath: () => approvedPlan.planFilePath,
+					localProtocolOptions: {
+						getArtifactsDir: () => artifactsDir,
+						getSessionId: () => "approved-plan-session",
+					},
+				}
+			: {}),
 	} as unknown as ToolSession;
 }
 
@@ -102,5 +112,32 @@ describe("read → edit round-trip for out-of-cwd files", () => {
 
 		expect(header).toMatch(/^\[settings\.json#[0-9A-F]{4}\]$/);
 		expect(header).not.toContain("src");
+	});
+
+	it("recovers a missing cwd path from the active approved local plan", async () => {
+		const artifactsDir = path.join(outDir, "artifacts");
+		const planFilePath = "local://windows-packaging-plan.md";
+		const planPath = path.join(artifactsDir, "local", "windows-packaging-plan.md");
+		await Bun.write(planPath, "# Windows packaging\n\nBuild the installer.\n");
+
+		const session = createSession(cwdDir, { artifactsDir, planFilePath });
+		const cwdPlanPath = path.join(cwdDir, "windows-packaging-plan.md");
+		const result = await new ReadTool(session).execute("read-approved-plan", { path: cwdPlanPath });
+		expect(textOutput(result)).toContain("Build the installer.");
+	});
+
+	it("prefers an existing cwd file over the approved local plan alias", async () => {
+		const artifactsDir = path.join(outDir, "artifacts");
+		const planFilePath = "local://windows-packaging-plan.md";
+		const planPath = path.join(artifactsDir, "local", "windows-packaging-plan.md");
+		const cwdPlanPath = path.join(cwdDir, "windows-packaging-plan.md");
+		await Bun.write(planPath, "# Local plan\n\nArtifact content.\n");
+		await Bun.write(cwdPlanPath, "# Working tree\n\nWorkspace content.\n");
+
+		const session = createSession(cwdDir, { artifactsDir, planFilePath });
+		const result = await new ReadTool(session).execute("read-workspace-plan", { path: cwdPlanPath });
+
+		expect(textOutput(result)).toContain("Workspace content.");
+		expect(textOutput(result)).not.toContain("Artifact content.");
 	});
 });


### PR DESCRIPTION
## Repro
After approving `local://windows-packaging-plan.md` with **Approve and execute**, submit the provider-emitted call `read { path: "/tmp/test-project/windows-packaging-plan.md" }`; equivalently run `cd packages/coding-agent && bun test test/read-edit-out-of-cwd.test.ts -t "recovers a missing cwd path"`. Before the fix, `ReadTool.execute()` throws `Path '<cwd>/windows-packaging-plan.md' not found` even though the approved plan exists in the fresh session's local artifact root.

## Cause
The approved-plan handoff in `src/prompts/system/plan-mode-approved.md` supplied the exact `local://` URL and the session correctly copied that artifact, but Gemini rewrote the URL into a same-basename cwd path. `ReadTool.execute()` in `src/tools/read.ts` treated that value only as a working-tree path, then ran ordinary suffix recovery; it did not consult `ToolSession.getPlanReferencePath()` when the cwd file was absent.

## Fix
- Recover a missing cwd-root path from the session's active approved `local://` plan when their basenames match.
- Preserve precedence for a real same-named working-tree file and reject unrelated/non-root paths.
- Add regression coverage for both recovery and working-tree precedence.
- Document the fix in the coding-agent changelog.

## Verification
`bun test test/read-edit-out-of-cwd.test.ts` — 4 passed, 0 failed. `bun test test/read-edit-out-of-cwd.test.ts test/interactive-mode-plan-review.test.ts -t "carries pre-approval local artifacts|approved local plan|existing cwd file"` — 3 passed, 0 failed. Pre-publish `bun run fix` and `bun check` passed. Fixes #5704