### PR TITLE
fix(tui): require Enter for single-select Ask answers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Ask dialogs immediately accepting their highlighted single-select answer when they appear while the user is typing a space in the prompt editor ([#5717](https://github.com/can1357/oh-my-pi/issues/5717)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/ask-dialog.test.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import type { ExtensionAskDialogSubmitResult } from "../../extensibility/extensions";
+import { AskDialogComponent } from "./ask-dialog";
+
+describe("AskDialogComponent input", () => {
+	it("ignores space for a highlighted single-select answer", () => {
+		let submitted: ExtensionAskDialogSubmitResult | undefined;
+		const dialog = new AskDialogComponent(
+			[
+				{
+					id: "continue",
+					question: "Continue?",
+					options: [{ label: "Yes" }, { label: "No" }],
+					recommended: 0,
+				},
+			],
+			{
+				onSubmit(result) {
+					submitted = result;
+				},
+				onCancel() {
+					throw new Error("unexpected cancel");
+				},
+				async onPrompt() {
+					throw new Error("unexpected prompt");
+				},
+			},
+		);
+
+		dialog.handleInput(" ");
+		expect(submitted).toBeUndefined();
+
+		dialog.handleInput("\r");
+		expect(submitted?.results[0]?.selectedOptions).toEqual(["Yes"]);
+	});
+});

--- a/packages/coding-agent/src/modes/components/ask-dialog.ts
+++ b/packages/coding-agent/src/modes/components/ask-dialog.ts
@@ -556,7 +556,7 @@ export class AskDialogComponent implements Component {
 		}
 		const isEnter = matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n";
 		const isSpace = matchesKey(keyData, "space") || keyData === " ";
-		if (!isEnter && !isSpace) return;
+		if (!isEnter && !(question.multi && isSpace)) return;
 		if (rowItem.kind === "other") {
 			void this.#promptForCustomInput(question, state, rowItem);
 			return;


### PR DESCRIPTION
## Repro
A single-select `AskDialogComponent` initialized on its recommended option called `onSubmit` when its next input was `handleInput(" ")`; the captured payload selected the recommended answer immediately. The scenario is codified in `ask-dialog.test.ts`; with the old handler, `bun test packages/coding-agent/src/modes/components/ask-dialog.test.ts` fails at the assertion that Space leaves the dialog open.

## Cause
`AskDialogComponent.#handleQuestionInput` in `packages/coding-agent/src/modes/components/ask-dialog.ts` treated Space and Enter as equivalent before branching on single-select versus multi-select behavior. Space therefore reached `#advanceAfterQuestion()` for a single question and submitted the highlighted answer.

## Fix
- Ignore Space for single-select Ask questions so only Enter confirms the highlighted answer.
- Preserve Space/Enter toggling for multi-select questions.
- Add a component regression test and an Unreleased changelog entry.

## Verification
`bun test packages/coding-agent/src/modes/components/ask-dialog.test.ts` passes (1 test, 2 assertions). A direct component smoke check reported `after-space=true` before Enter and then submitted the highlighted answer on Enter. The publish gate completed `bun run fix` and `bun check` before pushing.

Fixes #5717