### PR TITLE
fix(ai): classify 402/balance-exhausted quota errors as usage limits

### DIFF
--- a/packages/ai/src/error/flags.ts
+++ b/packages/ai/src/error/flags.ts
@@ -7,7 +7,7 @@ import {
 	ProviderHttpError,
 	STREAM_ENVELOPE_ERROR_PREFIX,
 } from "./classes";
-import { isOpaqueStatusBody, matchesUsageLimitText, parseRateLimitReason } from "./rate-limit";
+import { isOpaqueStatusBody, isUsageLimitStatus, matchesUsageLimitText, parseRateLimitReason } from "./rate-limit";
 
 export const Flag = {
 	Class: 0x1000,
@@ -318,7 +318,7 @@ function classifyText(errorMessage: string | undefined, errorStatus: number | un
 		const cleanMessage = errorMessage;
 		const isOpaque = isOpaqueStatusBody(cleanMessage);
 
-		const isLimitStatus = statusClean === 429;
+		const isLimitStatus = isUsageLimitStatus(statusClean);
 		if (
 			matchesUsageLimitText(cleanMessage) ||
 			(isLimitStatus && (isOpaque || parseRateLimitReason(cleanMessage) === "QUOTA_EXHAUSTED"))

--- a/packages/ai/src/error/rate-limit.ts
+++ b/packages/ai/src/error/rate-limit.ts
@@ -116,16 +116,19 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?(?:exceeded|reached|insufficient)|额度不足|额度耗尽|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?(?:balance|quota)|run out of credits|out of credits|spending[- _]?limit|personal-team-blocked/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?(?:exceeded|reached|insufficient)|额度不足|额度耗尽|resource.?exhausted|exhausted your capacity|quota will reset|insufficient.?(?:balance|quota)|balance.?exhausted|run out of credits|out of credits|spending[- _]?limit|personal-team-blocked/i;
 
 /**
  * HTTP status codes that, absent richer body classification, represent an
  * account-local usage cap rather than a bad credential or a transient blip.
+ * HTTP 402 Payment Required is categorically an account-billing cap (xAI
+ * Grok Build "usage balance exhausted", DeepSeek "Insufficient Balance",
+ * OpenRouter credit exhaustion) — never a transient blip or bad credential.
  * Always combine with {@link isUsageLimitOutcome} when a message is available
  * — a 429 carrying transient rate-limit wording is NOT a usage cap.
  */
 export function isUsageLimitStatus(status: number | undefined): boolean {
-	return status === 429;
+	return status === 429 || status === 402;
 }
 
 /**
@@ -135,7 +138,7 @@ export function isUsageLimitStatus(status: number | undefined): boolean {
  *  1. Body matches {@link isUsageLimitError} (Codex `usage_limit_reached`,
  *     Anthropic account rate-limit, Google `resource_exhausted`, OpenAI
  *     `insufficient_quota`, …) → rotate.
- *  2. Status is not 429 → backoff (caller's domain).
+ *  2. Status is not a usage-limit status (429/402) → backoff (caller's domain).
  *  3. Body is absent or {@link isOpaqueStatusBody opaque} (just the status,
  *     empty JSON, HTTP framing only) → rotate conservatively: the server
  *     gave us nothing else to go on.
@@ -154,14 +157,15 @@ export function isUsageLimitOutcome(status: number | undefined, message: string 
 }
 
 /**
- * A 429 body is opaque when it carries no signal beyond the status itself —
- * empty, whitespace-only, the status digits with HTTP/JSON framing, or
- * generic punctuation. Anything else (retry hints, capacity wording, error
- * descriptions) is informative enough to defer to the classifier.
+ * A usage-limit status body is opaque when it carries no signal beyond the
+ * status itself — empty, whitespace-only, the status digits with HTTP/JSON
+ * framing, or generic punctuation. Anything else (retry hints, capacity
+ * wording, error descriptions) is informative enough to defer to the
+ * classifier.
  */
 export function isOpaqueStatusBody(message: string): boolean {
 	const cleaned = message
-		.replace(/\b429\b/g, "")
+		.replace(/\b(?:429|402)\b/g, "")
 		.replace(/\b(?:http|https|status|error|code|response|message)\b/gi, "");
 	return !/[a-z\d]{3,}/i.test(cleaned);
 }

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -234,6 +234,20 @@ describe("isUsageLimitOutcome", () => {
 		expect(isUsageLimitOutcome(429, message)).toBe(true);
 	});
 
+	it("rotates on xAI Grok Build 402 usage-balance exhaustion regardless of status", () => {
+		const message = "402 Grok Build usage balance exhausted";
+		expect(isUsageLimitOutcome(402, message)).toBe(true);
+		expect(isUsageLimitOutcome(undefined, message)).toBe(true);
+		expect(isUsageLimit(message)).toBe(true);
+	});
+
+	it("treats 402 as a usage-limit status (opaque body rotates, informative non-quota body does not)", () => {
+		expect(isUsageLimitStatus(402)).toBe(true);
+		expect(isUsageLimitOutcome(402, undefined)).toBe(true);
+		expect(isUsageLimitOutcome(402, "HTTP 402")).toBe(true);
+		expect(isUsageLimitOutcome(402, "A subscription is required for this endpoint")).toBe(false);
+	});
+
 	it("does not rotate on auth/invalid-request statuses with unrelated bodies", () => {
 		expect(isUsageLimitOutcome(401, "Invalid API key")).toBe(false);
 		expect(isUsageLimitOutcome(400, "invalid_request_error: model unsupported")).toBe(false);


### PR DESCRIPTION
## Why

Grok Build reports exhausted account balances as HTTP 402 with `usage balance exhausted`. Neither the status nor that wording entered the host's usage-limit lane, so multi-account requests surfaced a hard error instead of rotating to a sibling credential.

## Changes

- recognize `balance exhausted` wording and HTTP 402 as usage-limit signals
- treat opaque 402 bodies like opaque 429 bodies while keeping informative non-quota responses out of rotation
- reuse the shared usage-limit status classifier in error flags
- cover Grok Build wording, opaque 402 responses, and informative non-quota 402 responses

| Commit | Purpose |
| --- | --- |
| `c0ec090a9` | Classify Grok Build 402/balance-exhausted quota failures for account rotation |

## Verification

- `bun test packages/ai/test/rate-limit-utils.test.ts` — 33 passed, 0 failed
- `cd packages/ai && bun run check` — passed (`root biome: ok`)
- `bun test packages/ai/test` — 2911 passed, 337 skipped, 0 failed

## Out of scope

- no plugin account storage or balancing changes
- no Grok identity-header changes
- no package publishing, versioning, changelog, or README changes
