### PR TITLE
fix(ai): honor custom kimi-code base URL in Anthropic format

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Automatically invalidate and rotate OAuth credentials when an "invalidated oauth token" error occurs
+- Fixed `kimi-code` Anthropic-format requests ignoring custom provider base URLs ([#5722](https://github.com/can1357/oh-my-pi/issues/5722)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
+++ b/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { getBundledModel } from "@oh-my-pi/pi-catalog";
+import * as kimiOauth from "../../registry/oauth/kimi";
 import type { Context } from "../../types";
 import type { MessageCreateParamsStreaming } from "../anthropic-wire";
+import { streamKimi } from "../kimi";
 import { streamOpenAIAnthropicShim } from "../openai-anthropic-shim";
 import {
 	applyChatCompletionsCompatPolicy,
@@ -10,6 +12,15 @@ import {
 } from "../openai-shared";
 
 const BASE_CHAT_COMPLETIONS_PARAMS: OpenAICompletionsParams = { messages: [], model: "unused", stream: true };
+const KIMI_HEADERS = Object.freeze({
+	"User-Agent": "KimiCLI/test",
+	"X-Msh-Platform": "kimi_cli",
+	"X-Msh-Version": "test",
+	"X-Msh-Device-Name": "test",
+	"X-Msh-Device-Model": "test",
+	"X-Msh-Os-Version": "test",
+	"X-Msh-Device-Id": "test",
+});
 const TITLE_CONTEXT: Context = {
 	systemPrompt: ["Generate a title."],
 	messages: [{ role: "user", content: "Explain the login failure", timestamp: 0 }],
@@ -26,6 +37,10 @@ const TITLE_CONTEXT: Context = {
 		},
 	],
 };
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("Kimi K2.7 Code thinking policy", () => {
 	it("omits disabled thinking for title-generator-style Kimi Code requests", () => {
@@ -69,6 +84,39 @@ describe("Kimi K2.7 Code thinking policy", () => {
 
 		expect(payload?.thinking?.type).toBe("enabled");
 		expect(payload?.tool_choice).toEqual({ type: "auto" });
+	});
+
+	it("uses the configured Kimi base URL for Anthropic requests", async () => {
+		vi.spyOn(kimiOauth, "getKimiCommonHeaders").mockReturnValue(KIMI_HEADERS);
+		const bundledModel = getBundledModel<"openai-completions">("kimi-code", "kimi-for-coding");
+		const model = { ...bundledModel, baseUrl: "https://gateway.example.com/v1" };
+		let requestedUrl: string | undefined;
+		const stream = streamKimi(
+			model,
+			{
+				systemPrompt: [],
+				messages: [{ role: "user", content: "Reply OK", timestamp: 0 }],
+				tools: [],
+			},
+			{
+				format: "anthropic",
+				apiKey: "gateway-key",
+				fetch: async input => {
+					requestedUrl = String(input);
+					return new Response(
+						JSON.stringify({
+							type: "error",
+							error: { type: "authentication_error", message: "stop after URL capture" },
+						}),
+						{ status: 401, headers: { "content-type": "application/json" } },
+					);
+				},
+			},
+		);
+
+		await stream.result();
+
+		expect(requestedUrl).toBe("https://gateway.example.com/v1/messages");
 	});
 
 	it("omits disabled thinking for native Moonshot Kimi K2.7 Code variants", () => {

--- a/packages/ai/src/providers/kimi.ts
+++ b/packages/ai/src/providers/kimi.ts
@@ -20,9 +20,6 @@ import {
 
 export type KimiApiFormat = OpenAIAnthropicApiFormat;
 
-// Note: Anthropic SDK appends /v1/messages, so base URL should not include /v1
-const KIMI_ANTHROPIC_BASE_URL = "https://api.kimi.com/coding";
-
 export interface KimiOptions extends OpenAIAnthropicShimOptions {
 	/** API format: "openai" or "anthropic". Default: "anthropic" */
 	format?: KimiApiFormat;
@@ -38,7 +35,7 @@ export function streamKimi(
 	options?: KimiOptions,
 ): AssistantMessageEventStream {
 	return streamOpenAIAnthropicShim(model, context, options, {
-		anthropicBaseUrl: KIMI_ANTHROPIC_BASE_URL,
+		anthropicBaseUrl: model.baseUrl.replace(/\/v1\/?$/, ""),
 		defaultFormat: "anthropic",
 		extraHeaders: getKimiCommonHeaders,
 	});


### PR DESCRIPTION
## Repro
Configure `kimi-code` with `baseUrl: https://gateway.example.com/v1`, select Anthropic format with `omp config set providers.kimiApiFormat anthropic`, then run `omp -p --model kimi-code/kimi-for-coding "Reply OK"`. A fetch-capture reproduction showed the request going to `https://api.kimi.com/coding/v1/messages` instead of the configured gateway.

## Cause
`streamKimi` in `packages/ai/src/providers/kimi.ts` always supplied the constant official Kimi Anthropic root to `streamOpenAIAnthropicShim`; unlike the OpenAI branch, the Anthropic branch never consulted `model.baseUrl` populated from provider configuration.

## Fix
- Derive the Anthropic Messages root from the configured Kimi model URL, removing the OpenAI-compatible trailing `/v1` before the Anthropic SDK appends `/v1/messages`.
- Add a regression test that captures the request generated for `https://gateway.example.com/v1` and asserts `https://gateway.example.com/v1/messages`.
- Record the fix in the `pi-ai` changelog.

## Verification
`bun test packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts` passed: 6 tests, 0 failures. `bun check` passed across all packages. The original fetch-capture smoke reproduction now requests `https://gateway.example.com/v1/messages`. Fixes #5722