### PR TITLE
feat: add volcengine-coding-plan provider

### DIFF
--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -67,6 +67,7 @@ import { xiaomiTokenPlanSgpProvider } from "./xiaomi-token-plan-sgp";
 import { zaiProvider } from "./zai";
 import { zenmuxProvider } from "./zenmux";
 import { zhipuCodingPlanProvider } from "./zhipu-coding-plan";
+import { volcengineCodingPlanProvider } from "./volcengine-coding-plan";
 
 /**
  * The single per-provider list. Adding a provider = create `./providers/<id>.ts`
@@ -94,6 +95,7 @@ const ALL = [
 	alibabaCodingPlanProvider,
 	aimlApiProvider,
 	zhipuCodingPlanProvider,
+	volcengineCodingPlanProvider,
 	umansProvider,
 	qwenPortalProvider,
 	sakanaProvider,

--- a/packages/ai/src/registry/volcengine-coding-plan.ts
+++ b/packages/ai/src/registry/volcengine-coding-plan.ts
@@ -1,0 +1,27 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://console.volcengine.com/ark/region:cn-beijing/subscription/coding-plan";
+const API_BASE_URL = "https://ark.cn-beijing.volces.com/api/coding/v3";
+const VALIDATION_MODEL = "doubao-seed-code";
+
+export const loginVolcengineCodingPlan = createApiKeyLogin({
+	providerLabel: "Volcengine Coding Plan",
+	authUrl: AUTH_URL,
+	instructions: "Copy your API key from the Volcengine Ark console (API Key Management)",
+	promptMessage: "Paste your Volcengine API key",
+	placeholder: "ark-...",
+	validation: {
+		kind: "chat-completions",
+		provider: "Volcengine",
+		baseUrl: API_BASE_URL,
+		model: VALIDATION_MODEL,
+	},
+});
+
+export const volcengineCodingPlanProvider = {
+	id: "volcengine-coding-plan",
+	name: "Volcengine Coding Plan (火山方舟)",
+	login: (cb: OAuthLoginCallbacks) => loginVolcengineCodingPlan(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -51,6 +51,7 @@ import {
 	xiaomiModelManagerOptions,
 	zenmuxModelManagerOptions,
 	zhipuCodingPlanModelManagerOptions,
+	volcengineCodingPlanModelManagerOptions,
 } from "./openai-compat";
 import {
 	cursorModelManagerOptions,
@@ -483,6 +484,13 @@ export const CATALOG_PROVIDERS = [
 		createModelManagerOptions: (config: ModelManagerConfig) => zhipuCodingPlanModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,
 		catalogDiscovery: { label: "Zhipu Coding Plan" },
+	},
+	{
+		id: "volcengine-coding-plan",
+		defaultModel: "doubao-seed-code",
+		envVars: ["VOLCENGINE_CODING_PLAN_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => volcengineCodingPlanModelManagerOptions(config),
+		catalogDiscovery: { label: "Volcengine Coding Plan" },
 	},
 ] as const satisfies readonly ProviderCatalogEntry[];
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -1480,6 +1480,56 @@ export function zhipuCodingPlanModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// 6.8 Volcengine Coding Plan (火山方舟)
+// ---------------------------------------------------------------------------
+
+export interface VolcengineCodingPlanModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function volcengineCodingPlanModelManagerOptions(
+	config?: VolcengineCodingPlanModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://ark.cn-beijing.volces.com/api/coding/v3";
+	return {
+		providerId: "volcengine-coding-plan",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "volcengine-coding-plan",
+					baseUrl,
+					apiKey,
+					mapModel: (
+						_entry: OpenAICompatibleModelRecord,
+						defaults: ModelSpec<"openai-completions">,
+						_context: OpenAICompatibleModelMapperContext<"openai-completions">,
+					): ModelSpec<"openai-completions"> => {
+						const id = defaults.id;
+						const isReasoning = /deepseek|glm-[456789]|thinking/.test(id);
+						return {
+							...defaults,
+							reasoning: isReasoning,
+							input: ["text"],
+							compat: {
+								supportsDeveloperRole: false,
+								...(isReasoning && {
+									thinkingFormat: "zai",
+									reasoningContentField: "reasoning_content",
+								}),
+							},
+						};
+					},
+					fetch: config?.fetch,
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 7.5 Fireworks
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #4201

Adds support for the **Volcengine (火山方舟) Coding Plan** provider, following the existing `zhipu-coding-plan` / `alibaba-coding-plan` pattern.

## Provider Details

| Field | Value |
|---|---|
| Provider ID | `volcengine-coding-plan` |
| Base URL | `https://ark.cn-beijing.volces.com/api/coding/v3` |
| Default model | `doubao-seed-code` |
| Env var | `VOLCENGINE_CODING_PLAN_API_KEY` |
| API key format | `ark-...` |
| Auth URL | `https://console.volcengine.com/ark/region:cn-beijing/subscription/coding-plan` |

### ⚠️ Critical: Coding Plan URL prefix

The `/api/coding/v3` prefix is **mandatory** for Coding Plan quota. Using the standard `/api/v3` endpoint will **not** consume the subscription and will silently charge standard API rates instead. This is confirmed by the official docs:

> 如未使用指定的 Base URL，将无法使用 Coding Plan 额度，并可能产生额外 API 请求的费用。

## Changes

1. **`packages/ai/src/registry/volcengine-coding-plan.ts`** (new) — API-key-paste login via `createApiKeyLogin`, validates against `POST /chat/completions` with `doubao-seed-code`
2. **`packages/ai/src/registry/registry.ts`** — import + register in `ALL` list
3. **`packages/catalog/src/provider-models/openai-compat.ts`** — `volcengineCodingPlanModelManagerOptions` with dynamic model discovery via `/models`, reasoning compat (`thinkingFormat: "zai"`) for deepseek/glm/thinking models
4. **`packages/catalog/src/provider-models/descriptors.ts`** — catalog entry with `VOLCENGINE_CODING_PLAN_API_KEY` env var

## Verification

Tested end-to-end with a real Coding Plan API key:

- ✅ `GET /api/coding/v3/models` returns **126 models** (doubao-seed-code, deepseek-v4-pro, kimi-k2-thinking, glm-5-2, etc.)
- ✅ `POST /api/coding/v3/chat/completions` with `doubao-seed-code` returns valid responses
- ✅ `POST /api/v3/chat/completions` (wrong endpoint) returns **401 Unauthorized** — confirms `/api/coding/v3` is the correct path
- ✅ TypeScript compiles, registry/catalog/model-manager all resolve correctly

## Available Models (subset)

The Coding Plan exposes 126 models including:
- `doubao-seed-code`, `doubao-seed-2-0-code-preview-260215`
- `deepseek-v4-pro-260425`, `deepseek-v4-flash-260425`, `deepseek-v3-2-251201`
- `kimi-k2-thinking-251104`, `kimi-k2-250905`
- `glm-5-2-260617`, `glm-4-7-251222`
- `doubao-seed-2-1-pro-260628`, `doubao-seed-2-1-turbo-260628`

## Usage

```bash
# Set env var
export VOLCENGINE_CODING_PLAN_API_KEY="ark-..."

# Or login interactively
/login volcengine-coding-plan
```

## References

- Issue: #4201
- Official docs: https://console.volcengine.com/ark/region:cn-beijing/docs/82379/1925114