### PR TITLE
fix(write): evaluate function-valued xd:// device approvals

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `write` approval gate misclassifying `xd://` device writes as `exec` when the mounted tool declared a function-valued (argument-dependent) `approval`: the gate discarded the function and never decoded the device JSON payload, so read/write device operations prompted in non-yolo modes their approval mode permits. It now parses valid object payloads and evaluates the mounted tool's normal approval decision, while malformed JSON, non-object payloads, and unknown devices still fall back to `exec` and prompt ([#5727](https://github.com/can1357/oh-my-pi/issues/5727)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/tools/approval.ts
+++ b/packages/coding-agent/src/tools/approval.ts
@@ -75,6 +75,17 @@ function getToolDecision(tool: ApprovalSubject, args: unknown): Omit<ResolvedApp
 	return normalizeDecision(decision);
 }
 
+/**
+ * Evaluate a tool's own approval declaration against `args` and return the
+ * resulting capability tier, defaulting to `exec` when the tool omits an
+ * approval. Unlike reading `tool.approval` directly, this runs function-valued
+ * approvals — the write tool's `xd://` gate uses it to take a mounted device's
+ * argument-dependent tier instead of falling back to `exec`.
+ */
+export function resolveToolTier(tool: ApprovalSubject, args: unknown): ToolTier {
+	return getToolDecision(tool, args).tier;
+}
+
 function modeApprovesTier(mode: ApprovalMode, tier: ToolTier): boolean {
 	return TIER_RANK[tier] <= TIER_RANK[APPROVAL_MODE_MAX_TIER[mode]];
 }

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -402,8 +402,9 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			// Decode the device JSON payload and evaluate the mounted tool's own
 			// approval (which may be argument-dependent, e.g. ast_edit is read-tier
 			// for internal-URL paths, debug is read-tier for inspection actions).
-			// Malformed JSON, non-object payloads, and missing content stay exec so
-			// the gate fails closed — the dispatch itself rejects them too.
+			// Malformed JSON, non-object payloads, missing content, and approval
+			// functions that reject schema-invalid objects stay exec so the gate
+			// fails closed — the dispatch itself rejects invalid arguments too.
 			const rawContent = (args as Partial<WriteParams>).content;
 			if (typeof rawContent !== "string") return "exec";
 			let parsed: unknown;
@@ -413,7 +414,11 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				return "exec";
 			}
 			if (!isRecord(parsed)) return "exec";
-			return resolveToolTier(inst, parsed);
+			try {
+				return resolveToolTier(inst, parsed);
+			} catch {
+				return "exec";
+			}
 		}
 		// Remote SSH writes open an outbound connection and run a remote shell —
 		// gate them like the exec-tier `ssh` tool, ahead of the handler-write

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -36,7 +36,7 @@ import {
 	writeArchive,
 } from "../utils/zip";
 import { routeWriteThroughBridge } from "./acp-bridge";
-import { truncateForPrompt } from "./approval";
+import { resolveToolTier, truncateForPrompt } from "./approval";
 import { assertEditableFile } from "./auto-generated-guard";
 import {
 	type ConflictEntry,
@@ -398,9 +398,22 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 			if (xdevTarget.name === REPORT_ISSUE_DEVICE_NAME) return "write";
 			if (xdevTarget.name && isResolutionDeviceName(xdevTarget.name)) return "read";
 			const inst = xdevTarget.name ? this.session.xdevRegistry?.get(xdevTarget.name) : undefined;
-			const decision = typeof inst?.approval === "function" ? undefined : inst?.approval;
-			const tier = typeof decision === "object" ? decision?.tier : decision;
-			return tier ?? "exec";
+			if (!inst) return "exec";
+			// Decode the device JSON payload and evaluate the mounted tool's own
+			// approval (which may be argument-dependent, e.g. ast_edit is read-tier
+			// for internal-URL paths, debug is read-tier for inspection actions).
+			// Malformed JSON, non-object payloads, and missing content stay exec so
+			// the gate fails closed — the dispatch itself rejects them too.
+			const rawContent = (args as Partial<WriteParams>).content;
+			if (typeof rawContent !== "string") return "exec";
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(rawContent);
+			} catch {
+				return "exec";
+			}
+			if (!isRecord(parsed)) return "exec";
+			return resolveToolTier(inst, parsed);
 		}
 		// Remote SSH writes open an outbound connection and run a remote shell —
 		// gate them like the exec-tier `ssh` tool, ahead of the handler-write

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -115,11 +115,13 @@ describe("read and write route xd:// device URLs", () => {
 			expect(tier("xd://debug", JSON.stringify({ action: "sessions" }))).toBe("read");
 			expect(tier("xd://debug", JSON.stringify({ action: "launch", program: "./app" }))).toBe("exec");
 
-			// Fail closed: malformed JSON, non-object payloads, missing content,
-			// and unknown devices all stay exec so the gate never under-prompts.
+			// Fail closed: malformed JSON, non-object or schema-invalid payloads,
+			// missing content, and unknown devices all stay exec so the gate never
+			// under-prompts.
 			expect(tier("xd://ast_edit", "{ not json")).toBe("exec");
 			expect(tier("xd://ast_edit", "[1,2,3]")).toBe("exec");
 			expect(tier("xd://ast_edit", '"a string"')).toBe("exec");
+			expect(tier("xd://ast_edit", JSON.stringify({ paths: [null] }))).toBe("exec");
 			expect(approval({ path: "xd://ast_edit" })).toBe("exec");
 			expect(tier("xd://no_such_device", "{}")).toBe("exec");
 		} finally {

--- a/packages/coding-agent/test/write-xdev-dispatch.test.ts
+++ b/packages/coding-agent/test/write-xdev-dispatch.test.ts
@@ -59,12 +59,12 @@ describe("read and write route xd:// device URLs", () => {
 				paths: [filePath],
 			});
 
-			// Approval resolves a tier instead of throwing. A mounted tool whose own
-			// approval is a function (unresolvable statically) falls back to exec.
+			// The write gate decodes the device payload and evaluates the mounted
+			// tool's own approval. ast_edit is write-tier for a filesystem path.
 			const approval = write!.approval;
 			expect(typeof approval).toBe("function");
 			if (typeof approval === "function") {
-				expect(approval({ path: "xd://ast_edit", content })).toBe("exec");
+				expect(approval({ path: "xd://ast_edit", content })).toBe("write");
 			}
 
 			// Execute dispatches through the xdev registry to the mounted ast_edit,
@@ -81,6 +81,47 @@ describe("read and write route xd:// device URLs", () => {
 			expect(invoker).toBeDefined();
 			await invoker!({ action: "apply", reason: "apply xdev ast edit" });
 			expect(await Bun.file(filePath).text()).toContain("modernWrap(x, value)");
+		} finally {
+			await removeWithRetries(tempDir);
+		}
+	});
+
+	it("resolves function-valued device approvals per payload and fails closed on bad content", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "write-xdev-approval-"));
+		try {
+			const filePath = path.join(tempDir, "target.ts");
+			await Bun.write(filePath, "legacyWrap(x, value)\n");
+			const tools = await createTools(xdevSession(tempDir));
+			const write = tools.find(entry => entry.name === "write");
+			expect(write).toBeDefined();
+			const approval = write!.approval;
+			expect(typeof approval).toBe("function");
+			if (typeof approval !== "function") throw new Error("expected a function approval");
+			const tier = (path: string, content: string) => approval({ path, content });
+
+			// ast_edit on a filesystem path → write; on internal URLs only → read.
+			const astFsPath = JSON.stringify({
+				ops: [{ pat: "legacyWrap($A, $B)", out: "modernWrap($A, $B)" }],
+				paths: [filePath],
+			});
+			const astInternalPath = JSON.stringify({
+				ops: [{ pat: "a", out: "b" }],
+				paths: ["artifact://abc"],
+			});
+			expect(tier("xd://ast_edit", astFsPath)).toBe("write");
+			expect(tier("xd://ast_edit", astInternalPath)).toBe("read");
+
+			// debug: inspection action → read; a real launch → exec (control).
+			expect(tier("xd://debug", JSON.stringify({ action: "sessions" }))).toBe("read");
+			expect(tier("xd://debug", JSON.stringify({ action: "launch", program: "./app" }))).toBe("exec");
+
+			// Fail closed: malformed JSON, non-object payloads, missing content,
+			// and unknown devices all stay exec so the gate never under-prompts.
+			expect(tier("xd://ast_edit", "{ not json")).toBe("exec");
+			expect(tier("xd://ast_edit", "[1,2,3]")).toBe("exec");
+			expect(tier("xd://ast_edit", '"a string"')).toBe("exec");
+			expect(approval({ path: "xd://ast_edit" })).toBe("exec");
+			expect(tier("xd://no_such_device", "{}")).toBe("exec");
 		} finally {
 			await removeWithRetries(tempDir);
 		}


### PR DESCRIPTION
## Repro
In a session with default `xd://` mounting, `ast_edit` and `debug` unmount as devices. The `write` approval gate resolved every mounted-device write to the `exec` tier whenever the device declared a function-valued (argument-dependent) `approval`, so read/write operations prompted in modes that permit them. Reproduced against the current branch:

```
ast_edit(fs path) tier: exec   (expected write)
debug sessions tier:   exec    (expected read)
debug launch tier:     exec    (control, correct)

write-mode  ast_edit  policy: prompt   (expected allow)
always-ask  debug sessions policy: prompt   (expected allow)
```

## Cause
`WriteTool#approval` in `packages/coding-agent/src/tools/write.ts` did `typeof inst?.approval === "function" ? undefined : inst?.approval`, discarding every function-valued approval, then defaulted the tier to `exec`. It never decoded the device JSON in `content`, so the mounted tool's `approval(args)` (e.g. `ast_edit` → `read` for internal-URL-only paths else `write`; `debug` → `read` for inspection actions else `exec`) never ran.

## Fix
- Added `resolveToolTier(tool, args)` in `packages/coding-agent/src/tools/approval.ts` — runs the tool's own (possibly function-valued) approval declaration and returns the resulting tier, defaulting to `exec` when omitted.
- In `write.ts`, the `xd://` branch now looks up the mounted instance, `JSON.parse`s `content`, and — for valid object payloads — returns `resolveToolTier(inst, parsed)`. Malformed JSON, non-object payloads, missing content, and unknown devices fall back to `exec` (fail closed).
- Updated the existing `write-xdev-dispatch` assertion that encoded the buggy `exec` fallback, and added a matrix test covering ast_edit read/write, debug read/exec, and the malformed/non-object/unknown-device controls.

## Verification
`bun test test/write-xdev-dispatch.test.ts test/tools/approval.test.ts test/tools/approval-mode.test.ts test/tools/ssh-url-approval.test.ts test/tools/ssh-url-approval-gate.test.ts` → all pass (60 tests). `bun run check:types` clean. Manually confirmed the tier matrix via a scratch repro before/after the fix (values above flipped to write/read/exec and allow/allow). Fixes #5727