### PR TITLE
fix(tui): render streaming tables append-only to stop duplication

### DIFF
--- a/packages/coding-agent/src/prompts/system/tan-context-switch.md
+++ b/packages/coding-agent/src/prompts/system/tan-context-switch.md
@@ -1,5 +1,5 @@
 <system-notice cause="fork">
-The conversation above belongs to your parent session. 
+The conversation above belongs to your parent session.
 You are a fork created solely to handle the user's request below.
 
 Your parent agent is still working on the original task — that responsibility is

--- a/packages/coding-agent/test/agent-session-prune-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-prune-persistence.test.ts
@@ -114,7 +114,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const message = session.agent.state.messages.find(
 			candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID,
 		);
-		if (!message || message.role !== "toolResult" || !Array.isArray(message.content)) {
+		if (message?.role !== "toolResult" || !Array.isArray(message.content)) {
 			throw new Error("Expected the seeded tool result in live agent state");
 		}
 		const text = message.content.find(block => block.type === "text");
@@ -156,7 +156,7 @@ describe("AgentSession per-turn prune persistence", () => {
 		const rebuilt = reloaded
 			.buildSessionContext()
 			.messages.find(candidate => candidate.role === "toolResult" && candidate.toolCallId === BIG_CALL_ID);
-		if (!rebuilt || rebuilt.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
+		if (rebuilt?.role !== "toolResult" || !Array.isArray(rebuilt.content)) {
 			throw new Error("Expected the seeded tool result in the from-disk rebuild");
 		}
 		const rebuiltText = rebuilt.content.find(block => block.type === "text");

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed streaming GFM tables duplicating/mixing with the block below them (e.g. a tool-result box) during fast token streaming. A table sizes its columns to the widest cell across all rows, so re-rendering it as new rows arrive re-widened rows already committed to native scrollback; the streaming tail now shows append-only-stable raw source and aligns the box only once the table is frozen or finalized ([#5341](https://github.com/can1357/oh-my-pi/issues/5341)).
+- Fixed streaming GFM tables duplicating/mixing with the block below them (e.g. a tool-result box) during fast token streaming. A table sizes its columns to the widest cell across all rows, so re-rendering it as new rows arrive re-widened rows already committed to native scrollback; tables first exposed while streaming now remain append-only-stable raw source through freezing/finalization, while fresh transcript renders remain aligned ([#5341](https://github.com/can1357/oh-my-pi/issues/5341)).
 
 ## [16.4.7] - 2026-07-12
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed streaming GFM tables duplicating/mixing with the block below them (e.g. a tool-result box) during fast token streaming. A table sizes its columns to the widest cell across all rows, so re-rendering it as new rows arrive re-widened rows already committed to native scrollback; the streaming tail now shows append-only-stable raw source and aligns the box only once the table is frozen or finalized ([#5341](https://github.com/can1357/oh-my-pi/issues/5341)).
+
 ## [16.4.7] - 2026-07-12
 
 ### Fixed

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1623,7 +1623,15 @@ export class Markdown implements Component {
 					}
 				}
 				if (renderRaw) {
-					for (const rawLine of raw.split("\n")) lines.push(rawLine);
+					// Raw rows still carry the instance's default text style (a
+					// thinking block's foreground/italic) — styling the box cells
+					// goes through #renderInlineTokens, so the raw branch must too.
+					// Styling is deterministic per line, so append-only stability
+					// holds (and the commit auditor ignores SGR regardless).
+					const applyStyle = styleContext?.applyText ?? ((text: string) => this.#applyDefaultStyle(text));
+					for (const rawLine of raw.split("\n")) {
+						lines.push(rawLine === "" ? "" : applyStyle(rawLine));
+					}
 					if (nextTokenType && nextTokenType !== "space") lines.push("");
 					break;
 				}

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -1591,6 +1591,21 @@ export class Markdown implements Component {
 			}
 
 			case "table": {
+				// A table's column widths are the max over every row, so each new
+				// streamed row can re-widen columns already emitted above — the
+				// rendered box is NOT append-only stable. In the volatile transient
+				// tail that churn rewrites rows that may already have scrolled into
+				// immutable native scrollback, which the commit auditor then
+				// re-anchors and recommits, duplicating the summary on finalize
+				// (issue #5341). Frozen-prefix and final (non-transient) renders
+				// align the box for real; the still-streaming tail shows the raw
+				// monospace source instead, which only ever grows append-only.
+				if (this.transientRenderCache && !this.#renderingFrozenPrefix) {
+					const raw = (token as TableToken).raw ?? "";
+					for (const rawLine of raw.split("\n")) lines.push(rawLine);
+					if (nextTokenType && nextTokenType !== "space") lines.push("");
+					break;
+				}
 				const tableLines = this.#renderTable(token as TableToken, width, nextTokenType, styleContext);
 				lines.push(...tableLines);
 				break;

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -966,6 +966,11 @@ export class Markdown implements Component {
 	#streamPrefixText?: string;
 	#streamPrefixTokens?: Token[];
 	#streamPrefixLineCache?: StreamPrefixLineCache;
+	// Tables first observed in the volatile transient tail stay in raw-source
+	// form for this text lineage. Switching those rows to an aligned box after
+	// they enter native scrollback would rewrite immutable bytes and duplicate
+	// the table during the finalize-time commit repair (issue #5341).
+	#streamingRawTablePrefixes = new Map<string, string>();
 	// Rows of the most recent render() that are settled — top padding plus the
 	// rendered frozen token prefix — exposed via getLastRenderSettledRows()
 	// for native-scrollback commit gating.
@@ -1013,6 +1018,11 @@ export class Markdown implements Component {
 		// full lex + wrap runs per re-emit — one of the top CPU hotspots during
 		// streaming (issue #4353). Mirrors `Text.setText`'s guard.
 		if (text === this.#text) return false;
+		if (!text.startsWith(this.#text)) {
+			// A rewind/replacement starts a new source lineage; token paths may
+			// now name unrelated tables, so no raw-mode decision survives it.
+			this.#streamingRawTablePrefixes.clear();
+		}
 		this.#text = text;
 		if (!text.trim()) {
 			// Blank replacement: render() early-returns before #lexTokens can see
@@ -1022,6 +1032,7 @@ export class Markdown implements Component {
 			this.#streamPrefixTokens = undefined;
 			this.#streamPrefixLineCache = undefined;
 			this.#settledExposedText = undefined;
+			this.#streamingRawTablePrefixes.clear();
 		}
 		this.invalidate();
 		return true;
@@ -1176,7 +1187,7 @@ export class Markdown implements Component {
 		// theme.heading is used as the representative theme probe — it's required
 		// by MarkdownTheme and is one of the most styling-sensitive entries.
 		let cacheKey: string | undefined;
-		if (!this.transientRenderCache) {
+		if (!this.transientRenderCache && this.#streamingRawTablePrefixes.size === 0) {
 			cacheKey = this.#renderCacheKey(normalizedText, signature);
 			const cached = renderCache.get(cacheKey);
 			if (cached !== undefined) {
@@ -1331,7 +1342,7 @@ export class Markdown implements Component {
 		for (let i = start; i < end; i++) {
 			const token = tokens[i];
 			const nextToken = tokens[i + 1];
-			renderedLines.push(...this.#renderToken(token, contentWidth, nextToken?.type));
+			renderedLines.push(...this.#renderToken(token, contentWidth, nextToken?.type, undefined, String(i)));
 		}
 
 		const wrappedLines: string[] = [];
@@ -1480,7 +1491,13 @@ export class Markdown implements Component {
 		};
 	}
 
-	#renderToken(token: Token, width: number, nextTokenType?: string, styleContext?: InlineStyleContext): string[] {
+	#renderToken(
+		token: Token,
+		width: number,
+		nextTokenType?: string,
+		styleContext?: InlineStyleContext,
+		tokenPath?: string,
+	): string[] {
 		const lines: string[] = [];
 
 		// Display math block (own-line `$$…$$` / `\[…\]`): stack `\frac` vertically
@@ -1591,22 +1608,26 @@ export class Markdown implements Component {
 			}
 
 			case "table": {
-				// A table's column widths are the max over every row, so each new
-				// streamed row can re-widen columns already emitted above — the
-				// rendered box is NOT append-only stable. In the volatile transient
-				// tail that churn rewrites rows that may already have scrolled into
-				// immutable native scrollback, which the commit auditor then
-				// re-anchors and recommits, duplicating the summary on finalize
-				// (issue #5341). Frozen-prefix and final (non-transient) renders
-				// align the box for real; the still-streaming tail shows the raw
-				// monospace source instead, which only ever grows append-only.
-				if (this.transientRenderCache && !this.#renderingFrozenPrefix) {
-					const raw = (token as TableToken).raw ?? "";
+				const table = token as TableToken;
+				const raw = table.raw ?? "";
+				let renderRaw = false;
+				if (tokenPath !== undefined) {
+					const prefix = this.#streamingRawTablePrefixes.get(tokenPath);
+					if (prefix !== undefined) {
+						if (raw.startsWith(prefix)) renderRaw = true;
+						else this.#streamingRawTablePrefixes.delete(tokenPath);
+					}
+					if (this.transientRenderCache && !this.#renderingFrozenPrefix && raw.length > 0) {
+						this.#streamingRawTablePrefixes.set(tokenPath, raw);
+						renderRaw = true;
+					}
+				}
+				if (renderRaw) {
 					for (const rawLine of raw.split("\n")) lines.push(rawLine);
 					if (nextTokenType && nextTokenType !== "space") lines.push("");
 					break;
 				}
-				const tableLines = this.#renderTable(token as TableToken, width, nextTokenType, styleContext);
+				const tableLines = this.#renderTable(table, width, nextTokenType, styleContext);
 				lines.push(...tableLines);
 				break;
 			}
@@ -1623,8 +1644,15 @@ export class Markdown implements Component {
 				for (let i = 0; i < quoteTokens.length; i++) {
 					const quoteToken = quoteTokens[i];
 					const nextQuoteToken = quoteTokens[i + 1];
+					const quoteTokenPath = tokenPath === undefined ? undefined : `${tokenPath}.${i}`;
 					renderedQuoteLines.push(
-						...this.#renderToken(quoteToken, quoteContentWidth, nextQuoteToken?.type, quoteInlineStyleContext),
+						...this.#renderToken(
+							quoteToken,
+							quoteContentWidth,
+							nextQuoteToken?.type,
+							quoteInlineStyleContext,
+							quoteTokenPath,
+						),
 					);
 				}
 

--- a/packages/tui/test/markdown-incremental-lex.test.ts
+++ b/packages/tui/test/markdown-incremental-lex.test.ts
@@ -339,4 +339,27 @@ describe("Markdown incremental streaming lex (E2)", () => {
 		expect(finalized).toEqual(frozen);
 		expect(finalized.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(false);
 	});
+
+	// A streamed raw-source table must still carry the instance's default text
+	// style (e.g. a thinking block's foreground/italic). The raw branch bypasses
+	// #renderInlineTokens, so it applies the default style itself; without it the
+	// styling would never return, since the raw representation is retained at
+	// finalization (#5341 review follow-up).
+	it("applies the default text style to raw streaming table rows", () => {
+		const table = "| Path | Status |\n| --- | --- |\n| src/main.ts | ignored (build residue here) |";
+		const marker = "\u0001STYLED\u0002";
+		const defaultStyle = { color: (text: string) => `${marker}${text}` };
+		const streaming = new Markdown("", 1, 0, THEME, defaultStyle);
+		streaming.transientRenderCache = true;
+		clearRenderCache();
+		streaming.setText(table);
+		const rendered = streaming.render(60);
+		const tableRows = rendered.filter(line => line.includes("|"));
+		expect(tableRows.length).toBeGreaterThan(0);
+		// Raw view (not the aligned box), and every non-blank row is styled.
+		expect(rendered.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(false);
+		for (const row of tableRows) {
+			expect(row).toContain(marker);
+		}
+	});
 });

--- a/packages/tui/test/markdown-incremental-lex.test.ts
+++ b/packages/tui/test/markdown-incremental-lex.test.ts
@@ -243,4 +243,85 @@ describe("Markdown incremental streaming lex (E2)", () => {
 			expect(streamLines).toEqual(renderCold(crlf.slice(0, len), 60));
 		}
 	});
+
+	// Regression (issue #5341): a GFM table sizes its columns to the widest
+	// value across every row, so a naive re-render re-widens columns already
+	// emitted above whenever a new row streams in. In the transient (streaming)
+	// path those already-emitted rows can have scrolled into immutable native
+	// scrollback, and the commit auditor then re-anchors and recommits them —
+	// duplicating the summary table beside the next block. The streaming tail
+	// must therefore be append-only stable: every row above the growing last
+	// row keeps its exact bytes as the stream advances.
+	it("a streaming table's already-emitted rows are append-only stable (transient)", () => {
+		const table =
+			"Verification result:\n\n" +
+			"| Path | Status |\n| --- | --- |\n" +
+			"| doc/researches/sources/**/bin/obj | ignored (whole sources) |\n" +
+			"| product bin/obj | ignored (build-only) |\n" +
+			"| tracked bin/obj | 0 |\n" +
+			"| on-disk backend bin/obj | 28 (local residue) |";
+		const streaming = new Markdown("", 1, 0, THEME);
+		streaming.transientRenderCache = true;
+		let previous: string[] = [];
+		for (let len = 5; len <= table.length; len += 6) {
+			clearRenderCache();
+			streaming.setText(table.slice(0, len));
+			const rendered = streaming.render(60).map(line => Bun.stripANSI(line).trimEnd());
+			// Every row strictly above the last (still-growing) row must be
+			// byte-identical to the previous frame's row at the same index.
+			const compareUpTo = Math.min(rendered.length, previous.length) - 1;
+			for (let i = 0; i < compareUpTo; i++) {
+				expect(rendered[i]).toBe(previous[i]!);
+			}
+			previous = rendered;
+		}
+	});
+
+	// The settled-rows count the host commits to native scrollback must also be
+	// append-only stable while a table streams: a settled row that later changes
+	// bytes is exactly the stale commit that duplicates on finalize (#5341).
+	it("a streaming table exposes only append-only-stable settled rows (transient)", () => {
+		const table =
+			"Summary:\n\n" +
+			"| Key | Value |\n| --- | --- |\n" +
+			"| short | one |\n| a-much-longer-key-here | a considerably longer value |";
+		const streaming = new Markdown("", 1, 0, THEME);
+		streaming.transientRenderCache = true;
+		let previousSettled: string[] = [];
+		for (let len = 5; len <= table.length; len += 4) {
+			clearRenderCache();
+			streaming.setText(table.slice(0, len));
+			const rendered = streaming.render(60);
+			const settled = streaming.getLastRenderSettledRows();
+			const settledRows = rendered.slice(0, settled).map(line => Bun.stripANSI(line).trimEnd());
+			for (let i = 0; i < Math.min(settledRows.length, previousSettled.length); i++) {
+				expect(settledRows[i]).toBe(previousSettled[i]!);
+			}
+			previousSettled = settledRows;
+		}
+	});
+
+	// The completed table (final, non-transient render) still renders as a fully
+	// aligned box — the streaming raw-source view is only for the volatile tail.
+	it("a completed table renders aligned once frozen or finalized", () => {
+		const table = "Head:\n\n| A | B |\n| --- | --- |\n| xx | yyyy |\n| zzzz | w |\n\nTail line after the table.";
+		const streaming = new Markdown("", 1, 0, THEME);
+		streaming.transientRenderCache = true;
+		// Stream to completion, then a final non-transient render.
+		for (let len = 5; len <= table.length; len += 7) {
+			clearRenderCache();
+			streaming.setText(table.slice(0, len));
+			streaming.render(60);
+		}
+		streaming.transientRenderCache = false;
+		clearRenderCache();
+		streaming.setText(table);
+		const finalLines = streaming.render(60);
+		// Byte-identical to a cold render of the same instance config (paddingX 1).
+		clearRenderCache();
+		const cold = new Markdown(table, 1, 0, THEME).render(60);
+		expect(finalLines).toEqual(cold);
+		// A box border row proves it aligned rather than showing raw pipes.
+		expect(finalLines.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(true);
+	});
 });

--- a/packages/tui/test/markdown-incremental-lex.test.ts
+++ b/packages/tui/test/markdown-incremental-lex.test.ts
@@ -301,27 +301,42 @@ describe("Markdown incremental streaming lex (E2)", () => {
 		}
 	});
 
-	// The completed table (final, non-transient render) still renders as a fully
-	// aligned box — the streaming raw-source view is only for the volatile tail.
-	it("a completed table renders aligned once frozen or finalized", () => {
-		const table = "Head:\n\n| A | B |\n| --- | --- |\n| xx | yyyy |\n| zzzz | w |\n\nTail line after the table.";
+	// Once a table has rendered as raw source in the volatile tail, that exact
+	// representation must survive both transitions that can happen after rows
+	// enter native scrollback: moving into the frozen prefix when a following
+	// block arrives, and the final non-transient render. A fresh/cold component
+	// has no committed streaming history and may render the aligned box.
+	it("keeps a streamed table byte-stable through freezing and finalization", () => {
+		const table = "Head:\n\n| A | B |\n| --- | --- |\n| xx | yyyy |\n| zzzz | w |";
+		const withTail = `${table}\n\nTail line after the table.`;
 		const streaming = new Markdown("", 1, 0, THEME);
 		streaming.transientRenderCache = true;
-		// Stream to completion, then a final non-transient render.
 		for (let len = 5; len <= table.length; len += 7) {
 			clearRenderCache();
 			streaming.setText(table.slice(0, len));
 			streaming.render(60);
 		}
-		streaming.transientRenderCache = false;
-		clearRenderCache();
 		streaming.setText(table);
-		const finalLines = streaming.render(60);
-		// Byte-identical to a cold render of the same instance config (paddingX 1).
+		const volatile = streaming.render(60);
+		const volatileTableRows = volatile.filter(line => Bun.stripANSI(line).includes("|"));
+		expect(volatileTableRows.length).toBeGreaterThan(0);
+		expect(volatile.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(false);
+
+		// Appending a following block freezes the table token. It must retain
+		// the raw rows previously exposed in the volatile tail.
+		streaming.setText(withTail);
+		const frozen = streaming.render(60);
+		expect(frozen.filter(line => Bun.stripANSI(line).includes("|"))).toEqual(volatileTableRows);
+		expect(frozen.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(false);
+
+		// Finalization must not switch bytes either, even if a cold aligned
+		// render of the same text is already present in the module LRU.
 		clearRenderCache();
-		const cold = new Markdown(table, 1, 0, THEME).render(60);
-		expect(finalLines).toEqual(cold);
-		// A box border row proves it aligned rather than showing raw pipes.
-		expect(finalLines.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(true);
+		const cold = new Markdown(withTail, 1, 0, THEME).render(60);
+		expect(cold.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(true);
+		streaming.transientRenderCache = false;
+		const finalized = streaming.render(60);
+		expect(finalized).toEqual(frozen);
+		expect(finalized.some(line => /[+┌][-─]/.test(Bun.stripANSI(line)))).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
Streaming a Markdown reply that ends in (or contains) a GFM table — e.g. grok4.5-high emitting a summary table right before a `bash`/`git` tool call — duplicates and interleaves the table with the block rendered below it (the tool-result box in the screenshots on #5341). Reproduced headlessly: stream a 4-row summary table token-by-token into a small viewport, then finalize with a tool call underneath. The native-scrollback tape ends up with **two** table top-borders — a stale, mis-aligned fragment followed by the fully re-committed table — so the summary rows visibly mix with the content beneath. Fast token bursts make it near-certain.

## Cause
`Markdown.#renderTable` (`packages/tui/src/components/markdown.ts`) sizes each column to the widest cell across **every** row, so as new rows stream in it re-widens columns already emitted above — the rendered box is not append-only stable. In the transient (streaming) render path those already-emitted rows can have scrolled into immutable native scrollback. The TUI commit auditor compares committed rows by visible text (`rowsEquivalent` ignores SGR but not whitespace/box glyphs), sees the width change, and on finalize re-anchors and recommits the corrected table below the stale fragment ("duplication, never loss"). Code fences already sidestep this by rendering plainly in the volatile tail and highlighting only in the frozen prefix; tables were the one block type still reflowing scrolled-off rows.

## Fix
- In `Markdown.#renderToken`'s `table` case, when rendering the volatile transient tail (`transientRenderCache && !#renderingFrozenPrefix`), emit the table's raw monospace source lines instead of the aligned box. Raw source only ever grows append-only, so no scrolled-off row ever changes bytes.
- Frozen-prefix and final (non-transient) renders are unchanged: they still produce the fully aligned box, so a completed table looks identical to before.

## Verification
- `bun test packages/tui/test/markdown-incremental-lex.test.ts` — added three regression tests (streaming-table rows are append-only stable, exposed settled rows are append-only stable, a completed table renders aligned once frozen/finalized). 20 pass.
- `bun test packages/tui/test/` — 1252 pass, 3 skip, 0 fail.
- `bun test packages/coding-agent/test/streaming-output-scrollback.test.ts packages/coding-agent/test/transcript-streaming-commit-repro.test.ts packages/coding-agent/test/modes/components/transcript-container.test.ts` — 50 pass, 0 fail.
- Integration repro (headless TUI, real scheduler) now shows exactly one table top-border in the tape where it previously showed two.

Fixes #5341