### PR TITLE
fix(advisor): reconcile rewritten transcript prefixes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the advisor skipping the next real user instruction after auto-learn accepted and pruned a terminal empty assistant stop; advisor transcript cursors now detect rewritten prefixes and re-prime before slicing the next update ([#5731](https://github.com/can1357/oh-my-pi/issues/5731)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -843,6 +843,57 @@ describe("advisor", () => {
 			expect(promptInputs[1]).toContain("second");
 		});
 
+		it("preserves the next user turn when an accepted empty stop is pruned", async () => {
+			const promptInputs: string[] = [];
+			const agent = makeAgent(promptInputs);
+			const messages: AgentMessage[] = [
+				{ role: "user", content: "synthetic capture", synthetic: true, timestamp: 1 } as AgentMessage,
+			];
+			const host: AdvisorRuntimeHost = {
+				snapshotMessages: () => messages,
+				enqueueAdvice: () => {},
+			};
+			const runtime = new AdvisorRuntime(agent, host);
+
+			runtime.onTurnEnd(messages);
+			await runtime.waitForCatchup(1000, 1);
+
+			messages.push({
+				role: "assistant",
+				content: [],
+				api: "mock",
+				provider: "mock",
+				model: "mock-primary",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+				stopReason: "stop",
+				timestamp: 2,
+			} as unknown as AgentMessage);
+			runtime.onTurnEnd(messages);
+			await runtime.waitForCatchup(1000, 1);
+
+			messages.pop();
+			messages.push(
+				{ role: "user", content: "real user instruction", timestamp: 3 } as AgentMessage,
+				{
+					role: "assistant",
+					content: [{ type: "thinking", thinking: "checking files" }],
+					api: "mock",
+					provider: "mock",
+					model: "mock-primary",
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+					stopReason: "toolUse",
+					timestamp: 4,
+				} as unknown as AgentMessage,
+			);
+			runtime.onTurnEnd(messages);
+			await runtime.waitForCatchup(1000, 1);
+
+			const nextTurn = promptInputs.at(-1);
+			expect(nextTurn).toContain("real user instruction");
+			expect(nextTurn?.match(/real user instruction/g)).toHaveLength(1);
+			expect(nextTurn?.indexOf("real user instruction")).toBeLessThan(nextTurn?.indexOf("checking files") ?? -1);
+		});
+
 		it("coalesces late-arriving deltas into the batch after context maintenance", async () => {
 			const promptInputs: string[] = [];
 			const { promise: firstMaintainStarted, resolve: startFirstMaintain } = Promise.withResolvers<void>();

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -192,8 +192,28 @@ interface CatchupWaiter {
 	timer?: NodeJS.Timeout;
 }
 
+interface DeliveredMessage {
+	message: AgentMessage;
+	fingerprint: bigint | undefined;
+}
+
+function fingerprintMessage(message: AgentMessage): bigint | undefined {
+	try {
+		const serialized = JSON.stringify(message);
+		if (serialized === undefined) return undefined;
+		return Bun.hash.wyhash(serialized);
+	} catch {
+		return undefined;
+	}
+}
+
 export class AdvisorRuntime {
 	#lastCount = 0;
+	/**
+	 * Delivered prefix identities. References make the normal append-only path
+	 * allocation-free; fingerprints preserve identity across equivalent clones.
+	 */
+	#deliveredPrefix: DeliveredMessage[] = [];
 	/** Last-shown body, keyed by primary-context customType (plan/goal mode rules,
 	 *  approved plan). These prompts are re-injected verbatim every primary turn;
 	 *  this lets {@link #renderDelta} collapse an unchanged copy to a one-line
@@ -295,6 +315,7 @@ export class AdvisorRuntime {
 
 	#resetAdvisorContext(clearBacklog: boolean, wakeWaiters: boolean): void {
 		this.#lastCount = 0;
+		this.#deliveredPrefix = [];
 		this.#pending = [];
 		this.#consecutiveFailures = 0;
 		this.#failureNotified = false;
@@ -331,7 +352,12 @@ export class AdvisorRuntime {
 	 * advisor (which would be expensive and likely stale).
 	 */
 	seedTo(count: number): void {
-		this.#lastCount = count;
+		const messages = this.host.snapshotMessages().slice(0, count);
+		this.#lastCount = messages.length;
+		this.#deliveredPrefix = messages.map(message => ({
+			message,
+			fingerprint: fingerprintMessage(message),
+		}));
 		this.#pending = [];
 		this.#backlog = 0;
 		this.#consecutiveFailures = 0;
@@ -342,15 +368,39 @@ export class AdvisorRuntime {
 
 	#renderDelta(messages?: AgentMessage[], wip = false): string | null {
 		const all = messages ?? this.#latestMessages ?? this.host.snapshotMessages();
-		if (all.length < this.#lastCount) {
-			this.#lastCount = all.length;
-			this.#seenContext.clear();
-			return null;
+		let prefixChanged = all.length < this.#lastCount;
+		for (let i = 0; !prefixChanged && i < this.#lastCount; i++) {
+			const delivered = this.#deliveredPrefix[i];
+			const current = all[i];
+			if (delivered === undefined || current === undefined) {
+				prefixChanged = true;
+				break;
+			}
+			if (delivered.message === current) continue;
+			const fingerprint = fingerprintMessage(current);
+			if (
+				delivered.fingerprint === undefined ||
+				fingerprint === undefined ||
+				delivered.fingerprint !== fingerprint
+			) {
+				prefixChanged = true;
+				break;
+			}
+			delivered.message = current;
+		}
+		if (prefixChanged) {
+			this.#epoch++;
+			this.#resetAdvisorContext(true, true);
 		}
 		const delta = all
 			.slice(this.#lastCount)
 			.filter(m => !(m.role === "custom" && m.customType === "advisor"))
 			.map(m => this.#dedupContextMessage(m));
+		for (let i = this.#lastCount; i < all.length; i++) {
+			const message = all[i];
+			if (message === undefined) continue;
+			this.#deliveredPrefix.push({ message, fingerprint: fingerprintMessage(message) });
+		}
 		this.#lastCount = all.length;
 		if (delta.length === 0) return null;
 		const obfuscator = this.host.obfuscator;


### PR DESCRIPTION
## Repro
An advisor cursor that has observed a synthetic capture user turn and a terminal empty assistant stop skips the next real user message after the live session prunes that stop. Reproduced with `bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts -t "preserves the next user turn when an accepted empty stop is pruned"`; before the fix the update contained only the following assistant thinking block.

## Cause
`AdvisorRuntime.#renderDelta` in `packages/coding-agent/src/advisor/runtime.ts` tracked only `#lastCount` and treated a transcript as rewritten only when its total length shrank below that count. Accepted-terminal-empty-stop pruning removed the cursor's last delivered message, but the following user and assistant messages restored the length before the next callback, so `slice(#lastCount)` began after the real user instruction.

## Fix
- Track delivered prefix entries by object identity plus a structural fingerprint for equivalent cloned snapshots.
- Detect shortened or divergent prefixes before slicing, invalidate in-flight advisor work, and re-prime from the current live transcript.
- Add a regression covering synthetic capture, accepted empty-stop pruning, and the ordered next real user/assistant turn.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/src/advisor/__tests__/advisor.test.ts` passed: 97 tests, 345 assertions. The focused regression passed independently: 1 test, 3 assertions. The publish gate also completed `bun run fix` and `bun check` successfully.

Fixes #5731