### PR TITLE
fix(catalog): source Umans PAYG model pricing

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Umans PAYG models showing as "Free" in `/models` by sourcing the provider's published per-token rates instead of the all-zero coding-plan catalog ([#5733](https://github.com/can1357/oh-my-pi/issues/5733)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Added

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -231,6 +231,30 @@ function hasBillableCost(cost: ModelSpec["cost"]): boolean {
 	return cost.input !== 0 || cost.output !== 0 || cost.cacheRead !== 0 || cost.cacheWrite !== 0;
 }
 
+function applyUmansPricingFallback(models: readonly ModelSpec[], modelsDevModels: readonly ModelSpec[]): ModelSpec[] {
+	const paygCosts = new Map<string, ModelSpec["cost"]>();
+	for (const model of modelsDevModels) {
+		if (model.provider === "umans" && hasBillableCost(model.cost)) {
+			paygCosts.set(model.id, model.cost);
+		}
+	}
+
+	// The public endpoint exposes this technical alias for Umans Flash, but
+	// models.dev publishes pricing only for the recommended `umans-flash` id.
+	const flashCost = paygCosts.get("umans-flash");
+	if (flashCost) {
+		paygCosts.set("umans-qwen3.6-35b-a3b", flashCost);
+	}
+
+	return models.map(model => {
+		if (model.provider !== "umans" || hasBillableCost(model.cost)) {
+			return model;
+		}
+		const cost = paygCosts.get(model.id);
+		return cost ? { ...model, cost: { ...cost } } : model;
+	});
+}
+
 function applyCodexPricingFallback(models: readonly ModelSpec[]): ModelSpec[] {
 	const openAIModels = new Map(
 		models
@@ -571,6 +595,7 @@ async function generateModels() {
 	}
 
 	allModels = applyGlobalModelsDevFallback(allModels, modelsDevModels);
+	allModels = applyUmansPricingFallback(allModels, modelsDevModels);
 	allModels = applyPremiumMultiplierOverrides(allModels);
 	allModels = applyCodexPricingFallback(allModels);
 	allModels = applyKimiMaxTokensCap(allModels);

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -77533,9 +77533,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -77599,9 +77599,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 1,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -77638,9 +77638,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.4,
+				"output": 4.4,
+				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
 			"contextWindow": 405504,
@@ -77661,9 +77661,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.19,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -77695,9 +77695,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 1,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -4513,8 +4513,11 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	// the identical model ids, so the enumerated token costs line up with the other
 	// subscription providers for comparison (issue #5598).
 	anthropicMessagesDescriptor("zai", "zai", "https://api.z.ai/api/anthropic"),
-	// --- Umans AI Coding Plan ---
-	anthropicMessagesDescriptor("umans-ai-coding-plan", "umans", UMANS_BASE_URL),
+	// --- Umans AI ---
+	// Source the pay-as-you-go catalog: the coding-plan key publishes subscription
+	// costs as zero, while `/models/info` omits pricing entirely. The generator
+	// overlays these rates onto the authoritative endpoint discovery (issue #5733).
+	anthropicMessagesDescriptor("umans-ai", "umans", UMANS_BASE_URL),
 	// --- Xiaomi ---
 	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {
 		defaultContextWindow: 262144,

--- a/packages/catalog/test/umans-provider.test.ts
+++ b/packages/catalog/test/umans-provider.test.ts
@@ -12,24 +12,7 @@ import {
 import type { FetchImpl, ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import modelsJson from "../src/models.json";
 
-interface BundledModel {
-	api: string;
-	provider: string;
-	baseUrl: string;
-	reasoning: boolean;
-	input: string[];
-	contextWindow: number | null;
-	maxTokens: number | null;
-	thinking?: {
-		defaultLevel?: string;
-		requiresEffort?: boolean;
-		efforts?: string[];
-		effortMap?: Record<string, string>;
-	};
-	compat?: {
-		escapeBuiltinToolNames?: boolean;
-	};
-}
+const bundledModels = modelsJson;
 
 describe("umans provider catalog", () => {
 	it("discovers Anthropic-route models from the public models info endpoint", async () => {
@@ -98,6 +81,7 @@ describe("umans provider catalog", () => {
 			baseUrl: "https://api.code.umans.ai",
 			reasoning: true,
 			input: ["text", "image"],
+			cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
 			contextWindow: 262_144,
 			maxTokens: 32_768,
 			thinking: { defaultLevel: "medium" },
@@ -179,8 +163,7 @@ describe("umans provider catalog", () => {
 	});
 
 	it("bundles Umans GLM via-handoff models as text-only", () => {
-		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
-		const model = providers.umans?.["umans-glm-5.2"];
+		const model = bundledModels.umans?.["umans-glm-5.2"];
 		expect(model, "umans-glm-5.2 should be bundled").toBeDefined();
 		expect(model.input, "umans-glm-5.2 input should be text-only").toEqual(["text"]);
 	});
@@ -245,9 +228,21 @@ describe("umans provider catalog", () => {
 		}
 	});
 
-	it("maps the models.dev Umans provider to the Anthropic endpoint", () => {
+	it("maps the models.dev Umans PAYG pricing to the Anthropic endpoint", () => {
 		const models = mapModelsDevToModels(
 			{
+				"umans-ai": {
+					models: {
+						"umans-coder": {
+							name: "Umans Coder",
+							tool_call: true,
+							reasoning: true,
+							modalities: { input: ["text", "image"] },
+							limit: { context: 262_144, output: 262_144 },
+							cost: { input: 0.95, output: 4, cache_read: 0.19 },
+						},
+					},
+				},
 				"umans-ai-coding-plan": {
 					models: {
 						"umans-coder": {
@@ -272,14 +267,14 @@ describe("umans provider catalog", () => {
 			baseUrl: "https://api.code.umans.ai",
 			reasoning: true,
 			input: ["text", "image"],
+			cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
 			contextWindow: 262_144,
 			maxTokens: 262_144,
 		});
 	});
 
 	it("bundles the default Umans coding model", () => {
-		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
-		const model = providers.umans?.["umans-coder"];
+		const model = bundledModels.umans?.["umans-coder"];
 
 		expect(model).toBeDefined();
 		expect(model).toMatchObject({
@@ -294,9 +289,28 @@ describe("umans provider catalog", () => {
 		});
 	});
 
+	it("bundles published Umans PAYG pricing", () => {
+		const models = bundledModels.umans;
+
+		expect(models?.["umans-coder"].cost).toEqual({ input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 });
+		expect(models?.["umans-kimi-k2.7"].cost).toEqual({
+			input: 0.95,
+			output: 4,
+			cacheRead: 0.19,
+			cacheWrite: 0,
+		});
+		expect(models?.["umans-glm-5.2"].cost).toEqual({ input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 0 });
+		expect(models?.["umans-flash"].cost).toEqual({ input: 0.15, output: 1, cacheRead: 0.05, cacheWrite: 0 });
+		expect(models?.["umans-qwen3.6-35b-a3b"].cost).toEqual({
+			input: 0.15,
+			output: 1,
+			cacheRead: 0.05,
+			cacheWrite: 0,
+		});
+	});
+
 	it("bundles Umans mandatory reasoning metadata", () => {
-		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
-		const model = providers.umans?.["umans-kimi-k2.7"];
+		const model = bundledModels.umans?.["umans-kimi-k2.7"];
 
 		expect(model).toBeDefined();
 		expect(model.maxTokens).toBe(32_768);
@@ -307,14 +321,13 @@ describe("umans provider catalog", () => {
 	});
 
 	it("bundles Umans GLM 5.2 with the wire-exact high/max ladder", () => {
-		const providers = modelsJson as Record<string, Record<string, BundledModel>>;
-		const model = providers.umans?.["umans-glm-5.2"];
+		const model = bundledModels.umans?.["umans-glm-5.2"];
 
 		expect(model).toBeDefined();
 		expect(model.thinking).toMatchObject({
 			mode: "anthropic-budget-effort",
 			efforts: ["high", "max"],
 		});
-		expect(model.thinking?.effortMap).toBeUndefined();
+		expect("effortMap" in model.thinking).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro
Loading `packages/catalog/src/models.json` and filtering `catalog.umans` for models with `cost.input === 0 && cost.output === 0` reports `6/6 Umans models show Free`; the same zero costs survive authenticated `/models/info` discovery because the endpoint omits pricing and the mapper retains bundled reference costs.

## Cause
`MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS` in `packages/catalog/src/provider-models/openai-compat.ts` sourced `umans-ai-coding-plan`, whose subscription catalog intentionally publishes all-zero costs. Umans discovery is authoritative and `/models/info` has no cost fields, so `packages/catalog/scripts/generate-models.ts` replaced the models.dev rows with dynamically discovered rows backed by the previous zero-cost bundle.

## Fix
- Source the `umans-ai` pay-as-you-go models.dev key, which matches Umans's published per-million-token rates.
- Backfill zero-cost authoritative discovery rows from provider-scoped PAYG references, including the technical `umans-qwen3.6-35b-a3b` alias for `umans-flash`.
- Regenerate the Umans catalog records and cover descriptor mapping, runtime discovery, bundled pricing, and the alias.

## Verification
`bun test packages/catalog` passed: 441 tests, 0 failures. `bun check` passed. A post-generation catalog check reports published costs for Umans Coder/Kimi (`0.95` input, `4` output, `0.19` cache read), GLM 5.2 (`1.4`, `4.4`, `0.26`), and Flash plus its technical alias (`0.15`, `1`, `0.05`) per million tokens. Fixes #5733