### PR TITLE
fix(vibe): keep background workers visible in TUI

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added regression coverage and documentation for configuring OpenAI-compatible relay providers through `models.yml`, including provider-level `baseUrl`, `apiKey`, discovery, and selector availability.
+
+### Fixed
+
+- Fixed vibe mode background workers being invisible after the director went idle: status line now shows live run/idle counts, the anchored HUD keeps a Vibe roster while workers are alive, and roster changes refresh the TUI without requiring another `vibe_wait`/`vibe_list`.
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -275,7 +275,7 @@ export class StatusLineComponent implements Component {
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#loopModeStatus: { enabled: boolean } | null = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
-	#vibeModeStatus: { enabled: boolean } | null = null;
+	#vibeModeStatus: { enabled: boolean; total?: number; running?: number; idle?: number } | null = null;
 	#collabStatus: CollabStatus | null = null;
 	#focusedAgentId: string | undefined;
 	#activeRepoCache: ActiveRepoCache | undefined;
@@ -504,7 +504,9 @@ export class StatusLineComponent implements Component {
 		this.#goalModeStatus = status ?? null;
 	}
 
-	setVibeModeStatus(status: { enabled: boolean } | undefined): void {
+	setVibeModeStatus(
+		status: { enabled: boolean; total?: number; running?: number; idle?: number } | undefined,
+	): void {
 		this.#vibeModeStatus = status ?? null;
 	}
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -221,8 +221,18 @@ const modeSegment: StatusLineSegment = {
 
 		const vibe = ctx.vibeMode;
 		if (vibe?.enabled) {
-			const content = withIcon(theme.icon.agents, "Vibe");
-			return { content: theme.fg("accent", content), visible: true };
+			// Keep a persistent roster count so background workers remain visible
+			// after the director goes idle and tool TV walls stop updating.
+			const parts = ["Vibe"];
+			const running = vibe.running ?? 0;
+			const idle = vibe.idle ?? 0;
+			const total = vibe.total ?? running + idle;
+			if (running > 0) parts.push(`${running} run`);
+			if (idle > 0) parts.push(`${idle} idle`);
+			if (running === 0 && idle === 0 && total > 0) parts.push(`${total}`);
+			const content = withIcon(theme.icon.agents, parts.join(" · "));
+			const color = running > 0 ? "accent" : "dim";
+			return { content: theme.fg(color, content), visible: true };
 		}
 
 		const loop = ctx.loopMode;

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -72,6 +72,12 @@ export interface SegmentContext {
 	} | null;
 	vibeMode: {
 		enabled: boolean;
+		/** Non-dead worker sessions owned by the director. */
+		total?: number;
+		/** Sessions currently starting or mid-turn. */
+		running?: number;
+		/** Sessions parked between turns. */
+		idle?: number;
 	} | null;
 	collab: CollabStatus | null;
 	// Cached values for performance (computed once per render)

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -125,7 +125,7 @@ import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
 import { messageHasDisplayableThinking } from "../utils/thinking-display";
 import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
-import { VibeSessionRegistry } from "../vibe/runtime";
+import { type VibeScreenSnapshot, VibeSessionRegistry } from "../vibe/runtime";
 import type { AssistantMessageComponent } from "./components/assistant-message";
 import type { BashExecutionComponent } from "./components/bash-execution";
 import { ChatBlock, type ChatBlockHost } from "./components/chat-block";
@@ -361,45 +361,100 @@ const SUBAGENT_OBSERVER_UI_COALESCE_MS = 100;
  * Only detached background spawns are listed: a sync task call blocks the
  * parent turn and its inline tool block already renders progress live, and
  * eval `agent()` spawns are rendered by their own eval cell tree.
+ *
+ * When vibe mode has worker sessions, a sibling "Vibe" block lists them so
+ * background turns stay visible after the director goes idle (spawn/send alone
+ * only leave a one-shot "turn started" ack in the transcript).
  * Returns an empty array when nothing is running so the container can clear.
  */
-export function renderSubagentHudLines(sessions: ObservableSession[], columns: number): string[] {
+export function renderSubagentHudLines(
+	sessions: ObservableSession[],
+	columns: number,
+	vibeScreens: VibeScreenSnapshot[] = [],
+): string[] {
+	const vibeWorkers = vibeScreens.filter(screen => screen.state !== "dead");
+	const vibeIds = new Set(vibeWorkers.map(screen => screen.id));
+	// Vibe keep-alive workers also emit detached subagent lifecycle events.
+	// Prefer the dedicated Vibe block so they don't double-list under Subagents.
 	const running = sessions.filter(
-		session => session.kind === "subagent" && session.status === "active" && session.detached === true,
+		session =>
+			session.kind === "subagent" &&
+			session.status === "active" &&
+			session.detached === true &&
+			!vibeIds.has(session.id),
 	);
-	if (running.length === 0) return [];
+	if (running.length === 0 && vibeWorkers.length === 0) return [];
 
+	const lines: string[] = [""];
 	const dot = theme.styledSymbol("status.done", "accent");
-	const visible = running.slice(0, SUBAGENT_HUD_VISIBLE_LIMIT);
-	const hiddenCount = running.length - visible.length;
-	const rows = renderTreeList(
-		{
-			items: visible,
-			expanded: true,
-			renderItem: session => {
-				const displayId = formatTaskId(session.id);
-				let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}`;
-				const description = session.description?.trim() || session.progress?.description?.trim();
-				if (description) {
-					const budget = Math.max(TRUNCATE_LENGTHS.SHORT, columns - visibleWidth(displayId) - 10);
-					line += `${theme.fg("accent", ":")} ${theme.fg("accent", truncateToWidth(replaceTabs(description), budget))}`;
-				} else {
-					// No spawn description: fall back to a muted task preview, same as
-					// the inline task rows when a row has no label.
-					const taskPreview = session.progress?.task?.trim();
-					if (taskPreview) {
-						line += ` ${theme.fg("muted", truncateToWidth(replaceTabs(taskPreview), TRUNCATE_LENGTHS.SHORT))}`;
+
+	if (running.length > 0) {
+		const visible = running.slice(0, SUBAGENT_HUD_VISIBLE_LIMIT);
+		const hiddenCount = running.length - visible.length;
+		const rows = renderTreeList(
+			{
+				items: visible,
+				expanded: true,
+				renderItem: session => {
+					const displayId = formatTaskId(session.id);
+					let line = `${dot} ${theme.fg("accent", theme.bold(displayId))}`;
+					const description = session.description?.trim() || session.progress?.description?.trim();
+					if (description) {
+						const budget = Math.max(TRUNCATE_LENGTHS.SHORT, columns - visibleWidth(displayId) - 10);
+						line += `${theme.fg("accent", ":")} ${theme.fg("accent", truncateToWidth(replaceTabs(description), budget))}`;
+					} else {
+						// No spawn description: fall back to a muted task preview, same as
+						// the inline task rows when a row has no label.
+						const taskPreview = session.progress?.task?.trim();
+						if (taskPreview) {
+							line += ` ${theme.fg("muted", truncateToWidth(replaceTabs(taskPreview), TRUNCATE_LENGTHS.SHORT))}`;
+						}
 					}
-				}
-				return line;
+					return line;
+				},
 			},
-		},
-		theme,
-	);
-	if (hiddenCount > 0) {
-		rows.push(theme.fg("dim", `… ${hiddenCount} more running — open Agent Hub for full list`));
+			theme,
+		);
+		if (hiddenCount > 0) {
+			rows.push(theme.fg("dim", `… ${hiddenCount} more running — open Agent Hub for full list`));
+		}
+		lines.push(theme.bold(theme.fg("accent", "Subagents")), ...rows.map(line => ` ${line}`));
 	}
-	return ["", theme.bold(theme.fg("accent", "Subagents")), ...rows.map(line => ` ${line}`)];
+
+	if (vibeWorkers.length > 0) {
+		const visible = vibeWorkers.slice(0, SUBAGENT_HUD_VISIBLE_LIMIT);
+		const hiddenCount = vibeWorkers.length - visible.length;
+		const rows = renderTreeList(
+			{
+				items: visible,
+				expanded: true,
+				renderItem: screen => {
+					const displayId = formatTaskId(screen.id);
+					const live = screen.state === "running" || screen.state === "starting";
+					const idColor = live ? "accent" : "dim";
+					let line = `${dot} ${theme.fg(idColor, theme.bold(displayId))}`;
+					line += ` ${theme.fg("muted", `[${screen.cli}]`)}`;
+					line += ` ${theme.fg(live ? "accent" : "dim", screen.state)}`;
+					const activity =
+						screen.currentTool
+							? `${screen.currentTool}${screen.currentToolArgs ? ` ${screen.currentToolArgs}` : ""}`
+							: (screen.lastIntent ?? screen.turnMessage ?? screen.lastActivity);
+					if (activity) {
+						const budget = Math.max(TRUNCATE_LENGTHS.SHORT, columns - visibleWidth(displayId) - 24);
+						line += `${theme.fg(idColor, ":")} ${theme.fg(live ? "accent" : "muted", truncateToWidth(replaceTabs(activity), budget))}`;
+					}
+					return line;
+				},
+			},
+			theme,
+		);
+		if (hiddenCount > 0) {
+			rows.push(theme.fg("dim", `… ${hiddenCount} more workers — use vibe_list for full roster`));
+		}
+		lines.push(theme.bold(theme.fg("accent", "Vibe")), ...rows.map(line => ` ${line}`));
+	}
+
+	return lines;
 }
 
 export class InteractiveMode implements InteractiveModeContext {
@@ -615,6 +670,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#eventBusUnsubscribers: Array<() => void> = [];
 	#observerUiSyncTimer?: NodeJS.Timeout;
 	#observerUiSyncNeedsTodoReconcile = false;
+	#vibeRosterUnsubscribe?: () => void;
 	#agentRegistryUnsubscribe?: () => void;
 	#agentRegistrySubscriptionTarget?: AgentRegistry;
 	#mcpStatusOrder: string[] = [];
@@ -941,6 +997,13 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#observerRegistry.onChange(kind => {
 			this.#scheduleObserverUiSync(kind);
 		});
+		// Vibe workers keep running after the director turn ends. Subscribe so
+		// the status line / anchored HUD refresh while background turns progress.
+		this.#vibeRosterUnsubscribe = VibeSessionRegistry.global().onChange(() => {
+			this.#scheduleObserverUiSync("progress");
+		});
+		this.#syncVibeModeStatus();
+		this.#renderSubagentList();
 
 		// Load initial todos
 		await this.#loadTodoList();
@@ -1850,6 +1913,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#reconcileTodosWithSubagents();
 		}
 		this.#syncTodoAutoClearTimer();
+		this.#syncVibeModeStatus();
 		this.#renderTodoList();
 		this.#renderSubagentList();
 		this.ui.requestRender();
@@ -1934,11 +1998,18 @@ export class InteractiveMode implements InteractiveModeContext {
 	 * Anchored HUD of in-flight subagents, mirroring the Todos block above the
 	 * editor. Driven entirely by observer-registry change events, so rows appear
 	 * on spawn and the whole block clears itself once the last subagent leaves
-	 * the "active" state.
+	 * the "active" state. While vibe mode is on, also lists the director's
+	 * worker roster so background turns stay visible after the main turn ends.
 	 */
 	#renderSubagentList(): void {
 		this.subagentContainer.clear();
-		const lines = renderSubagentHudLines(this.#observerRegistry.getSessions(), this.ui.terminal.columns);
+		const ownerId = this.session.getAgentId() ?? MAIN_AGENT_ID;
+		const vibeScreens = this.vibeModeEnabled ? VibeSessionRegistry.global().screens(ownerId) : [];
+		const lines = renderSubagentHudLines(
+			this.#observerRegistry.getSessions(),
+			this.ui.terminal.columns,
+			vibeScreens,
+		);
 		if (lines.length === 0) return;
 		this.subagentContainer.addChild(new Text(lines.join("\n"), 1, 0));
 	}
@@ -1976,8 +2047,24 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.requestRender();
 	}
 
+	#syncVibeModeStatus(): void {
+		if (!this.vibeModeEnabled) {
+			this.statusLine.setVibeModeStatus(undefined);
+			return;
+		}
+		const ownerId = this.session.getAgentId() ?? MAIN_AGENT_ID;
+		const summary = VibeSessionRegistry.global().summary(ownerId);
+		this.statusLine.setVibeModeStatus({
+			enabled: true,
+			total: summary.total,
+			running: summary.running,
+			idle: summary.idle,
+		});
+	}
+
 	#updateVibeModeStatus(): void {
-		this.statusLine.setVibeModeStatus(this.vibeModeEnabled ? { enabled: true } : undefined);
+		this.#syncVibeModeStatus();
+		this.#renderSubagentList();
 		this.ui.requestRender();
 	}
 
@@ -3603,6 +3690,8 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		this.#eventBusUnsubscribers = [];
 		this.#observerRegistry.dispose();
+		this.#vibeRosterUnsubscribe?.();
+		this.#vibeRosterUnsubscribe = undefined;
 		this.#agentRegistryUnsubscribe?.();
 		this.#agentRegistryUnsubscribe = undefined;
 		this.#agentRegistrySubscriptionTarget = undefined;

--- a/packages/coding-agent/src/vibe/runtime.ts
+++ b/packages/coding-agent/src/vibe/runtime.ts
@@ -166,6 +166,16 @@ export interface VibeWaitOutcome {
 	timedOut: boolean;
 }
 
+/** Compact roster counts for status-line / HUD visibility while the director is idle. */
+export interface VibeRosterSummary {
+	/** Non-dead sessions owned by the director. */
+	total: number;
+	/** Sessions currently starting or mid-turn. */
+	running: number;
+	/** Sessions parked between turns. */
+	idle: number;
+}
+
 /** Normalize a text fragment to one bounded roster/trace line. */
 function firstLine(text: string, max = 100): string {
 	return oneLineLabel(text, max);
@@ -208,6 +218,29 @@ export class VibeSessionRegistry {
 	}
 
 	readonly #records = new Map<string, VibeRecord>();
+	readonly #listeners = new Set<() => void>();
+
+	/**
+	 * Subscribe to roster / live-activity changes. Used by the TUI so status line
+	 * and the anchored HUD refresh while workers keep running after the director
+	 * has gone idle. Returns an unsubscribe function.
+	 */
+	onChange(cb: () => void): () => void {
+		this.#listeners.add(cb);
+		return () => this.#listeners.delete(cb);
+	}
+
+	#notifyChange(): void {
+		for (const cb of this.#listeners) {
+			try {
+				cb();
+			} catch (error) {
+				logger.warn("vibe: roster change listener failed", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+			}
+		}
+	}
 
 	#manager(session: ToolSession): AsyncJobManager {
 		const manager = session.asyncJobManager;
@@ -234,6 +267,20 @@ export class VibeSessionRegistry {
 			if (record.ownerId === owner && record.state !== "dead") ids.push(record.id);
 		}
 		return ids;
+	}
+
+	/** Running / idle / total counts for the director's roster (dead sessions excluded). */
+	summary(owner: string): VibeRosterSummary {
+		let total = 0;
+		let running = 0;
+		let idle = 0;
+		for (const record of this.#records.values()) {
+			if (record.ownerId !== owner || record.state === "dead") continue;
+			total++;
+			if (record.state === "running" || record.state === "starting") running++;
+			else if (record.state === "idle") idle++;
+		}
+		return { total, running, idle };
 	}
 
 	/**
@@ -314,12 +361,14 @@ export class VibeSessionRegistry {
 			killed: false,
 		};
 		this.#records.set(id, record);
+		this.#notifyChange();
 
 		try {
 			const jobId = this.#registerTurnJob(session, manager, record, args.prompt, { first: true });
 			return { id, jobId };
 		} catch (error) {
 			this.#records.delete(id);
+			this.#notifyChange();
 			throw error;
 		}
 	}
@@ -343,10 +392,12 @@ export class VibeSessionRegistry {
 			if (live?.isStreaming) {
 				await live.steer(message);
 				record.lastActivityAt = Date.now();
+				this.#notifyChange();
 				return { id: record.id, mode: "steered" };
 			}
 			record.queue.push(message);
 			record.lastActivityAt = Date.now();
+			this.#notifyChange();
 			return { id: record.id, mode: "queued" };
 		}
 
@@ -468,6 +519,7 @@ export class VibeSessionRegistry {
 		record.state = "dead";
 		record.lastActivityAt = Date.now();
 		record.lastActivity = "killed";
+		this.#notifyChange();
 		try {
 			await AgentLifecycleManager.global().release(record.id);
 		} catch (error) {
@@ -570,6 +622,7 @@ export class VibeSessionRegistry {
 				(progress.currentTool ? `${progress.currentTool} ${progress.currentToolArgs ?? ""}` : undefined);
 			if (gist) record.lastActivity = firstLine(gist);
 			record.lastActivityAt = Date.now();
+			this.#notifyChange();
 		};
 
 		const jobId = manager.register(
@@ -579,6 +632,7 @@ export class VibeSessionRegistry {
 				record.state = "running";
 				record.turnCount = turnIndex;
 				record.lastActivityAt = Date.now();
+				this.#notifyChange();
 				try {
 					const result = options.first
 						? await runSubprocess(await this.#buildSpawnOptions(session, record, message, signal, onProgress))
@@ -607,6 +661,9 @@ export class VibeSessionRegistry {
 		);
 		turn.jobId = jobId;
 		record.turn = turn;
+		// Keep the roster in "starting" until the job body flips it to running.
+		if (record.state === "idle") record.state = "starting";
+		this.#notifyChange();
 		return jobId;
 	}
 
@@ -618,11 +675,13 @@ export class VibeSessionRegistry {
 		record.lastActivityAt = Date.now();
 		if (record.killed) {
 			record.state = "dead";
+			this.#notifyChange();
 			return;
 		}
 		// A spawn that failed before its session ever registered leaves nothing
 		// to continue — mark the record dead so sends fail with clear guidance.
 		record.state = AgentRegistry.global().get(record.id) ? "idle" : "dead";
+		this.#notifyChange();
 		if (record.state === "dead" || record.queue.length === 0) return;
 		const nextMessage = record.queue.splice(0, record.queue.length).join("\n\n");
 		try {
@@ -634,6 +693,7 @@ export class VibeSessionRegistry {
 				id: record.id,
 				error: error instanceof Error ? error.message : String(error),
 			});
+			this.#notifyChange();
 		}
 	}
 
@@ -655,6 +715,7 @@ export class VibeSessionRegistry {
 				? `turn ${turnIndex} ${status}: ${result.abortReason ?? result.error ?? ""}`
 				: (result.lastIntent ?? result.output),
 		);
+		this.#notifyChange();
 
 		const traceLines = turn.trace.map(entry =>
 			firstLine(`${entry.tool}${entry.args ? `(${entry.args})` : ""}`, TRACE_LINE_MAX),

--- a/packages/coding-agent/test/status-line-vibe.test.ts
+++ b/packages/coding-agent/test/status-line-vibe.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Contract: vibe mode status-line segment keeps a persistent roster count so
+ * background workers remain visible after the director goes idle.
+ */
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function createModeContext(vibeMode: SegmentContext["vibeMode"]): SegmentContext {
+	return {
+		session: {
+			state: { model: { id: "test-model", name: "Test Model" } },
+			isFastModeActive: () => false,
+			isAutoThinking: false,
+			autoResolvedThinkingLevel: () => undefined,
+			isAdvisorActive: () => false,
+		} as unknown as SegmentContext["session"],
+		width: 120,
+		compactThinkingLevel: false,
+		options: {},
+		planMode: null,
+		loopMode: null,
+		prewalk: null,
+		goalMode: null,
+		vibeMode,
+		collab: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			orchestrationInput: 0,
+			orchestrationOutput: 0,
+			orchestrationCacheRead: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		activeMs: 0,
+		activeRepo: null,
+		worktree: null,
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+	};
+}
+
+describe("status line vibe mode segment", () => {
+	it("renders Vibe alone when the roster is empty", () => {
+		const rendered = renderSegment("mode", createModeContext({ enabled: true, total: 0, running: 0, idle: 0 }));
+		expect(rendered.visible).toBe(true);
+		expect(Bun.stripANSI(rendered.content)).toContain("Vibe");
+		expect(Bun.stripANSI(rendered.content)).not.toContain("run");
+		expect(Bun.stripANSI(rendered.content)).not.toContain("idle");
+	});
+
+	it("shows running and idle worker counts while vibe mode is active", () => {
+		const rendered = renderSegment(
+			"mode",
+			createModeContext({ enabled: true, total: 3, running: 2, idle: 1 }),
+		);
+		const text = Bun.stripANSI(rendered.content);
+		expect(text).toContain("Vibe");
+		expect(text).toContain("2 run");
+		expect(text).toContain("1 idle");
+	});
+});

--- a/packages/coding-agent/test/subagent-hud-render.test.ts
+++ b/packages/coding-agent/test/subagent-hud-render.test.ts
@@ -4,6 +4,11 @@
  * `Id: description` rows and yields no output once nothing qualifies, so the
  * block self-clears. Sync task spawns and eval `agent()` spawns are excluded:
  * their progress is already rendered inline (tool block / eval cell).
+ *
+ * When vibe worker screens are provided, a sibling "Vibe" block lists them so
+ * background turns stay visible after the director goes idle. Vibe keep-alive
+ * workers that also emit detached lifecycle events are de-duplicated into the
+ * Vibe block only.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
@@ -26,6 +31,7 @@ import {
 	TASK_SUBAGENT_LIFECYCLE_CHANNEL,
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
 } from "@oh-my-pi/pi-coding-agent/task";
+import type { VibeScreenSnapshot } from "@oh-my-pi/pi-coding-agent/vibe/runtime";
 import { EventBus } from "@oh-my-pi/pi-coding-agent/utils/event-bus";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
@@ -88,8 +94,21 @@ function makeProgressPayload(
 	};
 }
 
-function render(sessions: ObservableSession[], columns = 120): string {
-	return Bun.stripANSI(renderSubagentHudLines(sessions, columns).join("\n"));
+function makeVibeScreen(overrides: Partial<VibeScreenSnapshot> & { id: string }): VibeScreenSnapshot {
+	return {
+		cli: "fast",
+		state: "running",
+		turns: 1,
+		queued: 0,
+		trace: [],
+		outputTail: [],
+		lastActivityAt: Date.now(),
+		...overrides,
+	};
+}
+
+function render(sessions: ObservableSession[], columns = 120, vibeScreens: VibeScreenSnapshot[] = []): string {
+	return Bun.stripANSI(renderSubagentHudLines(sessions, columns, vibeScreens).join("\n"));
 }
 
 describe("subagent HUD lines", () => {
@@ -170,6 +189,57 @@ describe("subagent HUD lines", () => {
 		for (const line of out.split("\n")) {
 			expect(Bun.stringWidth(line)).toBeLessThanOrEqual(60);
 		}
+	});
+
+	it("renders vibe workers under a Vibe header with state and live activity", () => {
+		const out = render(
+			[],
+			120,
+			[
+				makeVibeScreen({
+					id: "FastWorker",
+					cli: "fast",
+					state: "running",
+					currentTool: "edit",
+					currentToolArgs: "src/a.ts",
+				}),
+				makeVibeScreen({
+					id: "GoodWorker",
+					cli: "good",
+					state: "idle",
+					lastActivity: "turn finished",
+				}),
+			],
+		);
+		expect(out).toContain("Vibe");
+		expect(out).toContain("FastWorker");
+		expect(out).toContain("[fast]");
+		expect(out).toContain("running");
+		expect(out).toContain("edit src/a.ts");
+		expect(out).toContain("GoodWorker");
+		expect(out).toContain("[good]");
+		expect(out).toContain("idle");
+		expect(out).toContain("turn finished");
+		expect(out).not.toContain("Subagents");
+	});
+
+	it("dedupes vibe keep-alive workers out of the Subagents list", () => {
+		const out = render(
+			[
+				makeSession({ id: "FastWorker", description: "vibe fast session" }),
+				makeSession({ id: "RegularTask", description: "detached non-vibe work" }),
+			],
+			120,
+			[makeVibeScreen({ id: "FastWorker", cli: "fast", state: "running", currentTool: "read" })],
+		);
+		expect(out).toContain("Subagents");
+		expect(out).toContain("RegularTask: detached non-vibe work");
+		expect(out).toContain("Vibe");
+		expect(out).toContain("FastWorker");
+		expect(out).toContain("read");
+		// FastWorker should only appear once (in the Vibe block), not also as a Subagents row description.
+		const occurrences = out.split("FastWorker").length - 1;
+		expect(occurrences).toBe(1);
 	});
 
 	it("keeps subagent registry order stable while progress arrives out of order", () => {

--- a/packages/coding-agent/test/vibe/vibe-runtime.test.ts
+++ b/packages/coding-agent/test/vibe/vibe-runtime.test.ts
@@ -498,6 +498,49 @@ describe("vibe session registry", () => {
 		gate.resolve();
 	});
 
+	it("summary + onChange expose live roster counts for TUI visibility", async () => {
+		const gate = deferred();
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {
+			AgentRegistry.global().register({
+				id: options.id,
+				displayName: options.id,
+				kind: "sub",
+				parentId: "Main",
+				session: createFakeWorkerSession().session,
+				status: "running",
+			});
+			options.onProgress?.(
+				progressSnapshot(options.id, {
+					currentTool: "read",
+					currentToolArgs: "file.ts",
+					lastIntent: "reading file",
+				}),
+			);
+			await gate.promise;
+			return makeResult(options.id, { lastIntent: "done reading" });
+		});
+
+		const manager = createManager();
+		const session = createSession({ manager });
+		const registry = VibeSessionRegistry.global();
+		const changes: Array<{ total: number; running: number; idle: number }> = [];
+		const unsub = registry.onChange(() => {
+			changes.push(registry.summary("Main"));
+		});
+
+		expect(registry.summary("Main")).toEqual({ total: 0, running: 0, idle: 0 });
+		await registry.spawn(session, { cli: "fast", name: "Visible", prompt: "Stay visible." });
+		await pollUntil(() => registry.summary("Main").running >= 1);
+		expect(registry.summary("Main")).toEqual({ total: 1, running: 1, idle: 0 });
+		expect(changes.some(entry => entry.running >= 1)).toBe(true);
+
+		gate.resolve();
+		await pollUntil(() => registry.summary("Main").idle === 1);
+		expect(registry.summary("Main")).toEqual({ total: 1, running: 0, idle: 1 });
+		expect(changes.some(entry => entry.idle === 1)).toBe(true);
+		unsub();
+	});
+
 	it("killAll terminates every session for the owner (mode-exit path)", async () => {
 		const gates = new Map<string, Deferred>();
 		vi.spyOn(executorModule, "runSubprocess").mockImplementation(async options => {


### PR DESCRIPTION
## Summary
- keep vibe worker run/idle counts visible on the status line after the director goes idle
- show a persistent Vibe roster in the anchored HUD with live activity
- refresh TUI from roster changes without requiring another `vibe_wait`/`vibe_list`

## Root cause
Vibe workers keep running as async background jobs after spawn/send return. The status line only rendered a static `Vibe` badge, the anchored HUD ignored vibe keep-alive workers, and TV-wall rendering only updated during `vibe_wait`/`vibe_list`. Once the main turn finished, background work had no persistent TUI surface.

## Verification
- `bun test packages/coding-agent/test/status-line-vibe.test.ts packages/coding-agent/test/vibe/vibe-runtime.test.ts packages/coding-agent/test/subagent-hud-render.test.ts -t "subagent HUD lines|status line vibe|vibe session registry|summary + onChange"`
- `bun --cwd=packages/coding-agent run check:types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)