### PR TITLE
fix(tui): guard stdin against custom-tool import hijack (#5618)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed all keyboard input dying after the first keypress when a `~/.claude/tools` (or `.omp/tools`) module attaches a stdin consumer at import time — e.g. an MCP `StdioServerTransport` constructed at module top level, or a bare `process.stdin.resume()`. The custom-tool/extension/hook/plugin loader guard now snapshots and restores `process.stdin` (listeners, paused state, raw mode) around third-party module evaluation, so a hijacked stdin reader can no longer starve the TUI's own listener ([#5618](https://github.com/can1357/oh-my-pi/issues/5618)).
+
 ## [17.0.0] - 2026-07-15
 
 ### Breaking Changes

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -18,7 +18,7 @@ import { getAllPluginToolPaths } from "../../extensibility/plugins/loader";
 // Runtime self-reference: dereference this namespace only inside loader functions to keep the index.ts cycle safe.
 import * as PiCodingAgent from "../../index";
 import * as typebox from "../typebox";
-import { createNoOpUIContext, resolvePath, withExitGuard } from "../utils";
+import { createNoOpUIContext, resolvePath, withHostGuard } from "../utils";
 import type { CustomToolAPI, CustomToolFactory, LoadedCustomTool, ToolLoadError } from "./types";
 
 interface LoadToolResult {
@@ -75,14 +75,14 @@ async function loadTool(
 	}
 
 	try {
-		const module = await withExitGuard(() => import(resolvedPath));
+		const module = await withHostGuard(() => import(resolvedPath));
 		const factory = (module.default ?? module) as CustomToolFactory;
 
 		if (typeof factory !== "function") {
 			return { tools: [], errors: [{ path: toolPath, error: "Tool must export a default function", source }] };
 		}
 
-		const toolResult: unknown = await withExitGuard(async () => factory(sharedApi));
+		const toolResult: unknown = await withHostGuard(async () => factory(sharedApi));
 		const toolsArray = Array.isArray(toolResult) ? toolResult : [toolResult];
 
 		const loadedTools: LoadedCustomTool[] = [];

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -24,7 +24,7 @@ import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../plugins/leg
 import { getAllPluginExtensionPaths } from "../plugins/loader";
 import * as TypeBox from "../typebox";
 
-import { resolvePath, withExitGuard } from "../utils";
+import { resolvePath, withHostGuard } from "../utils";
 import type {
 	AssistantThinkingRenderer,
 	Extension,
@@ -290,7 +290,7 @@ async function loadExtension(
 ): Promise<{ extension: Extension | null; error: string | null }> {
 	const resolvedPath = resolvePath(extensionPath, cwd);
 	try {
-		const module = (await withExitGuard(() => loadLegacyPiModule(resolvedPath))) as LoadedExtensionModule;
+		const module = (await withHostGuard(() => loadLegacyPiModule(resolvedPath))) as LoadedExtensionModule;
 		const factory = getExtensionFactory(module);
 
 		if (typeof factory !== "function") {
@@ -302,7 +302,7 @@ async function loadExtension(
 
 		const extension = createExtension(extensionPath, resolvedPath);
 		const api = new ConcreteExtensionAPI(PiCodingAgent, extension, runtime, cwd, eventBus);
-		await withExitGuard(async () => {
+		await withHostGuard(async () => {
 			await factory(api);
 		});
 

--- a/packages/coding-agent/src/extensibility/hooks/loader.ts
+++ b/packages/coding-agent/src/extensibility/hooks/loader.ts
@@ -12,7 +12,7 @@ import { loadCapability } from "../../discovery";
 import * as PiCodingAgent from "../../index";
 import type { CustomMessagePayload } from "../../session/messages";
 import * as typebox from "../typebox";
-import { resolvePath, withExitGuard } from "../utils";
+import { resolvePath, withHostGuard } from "../utils";
 import { execCommand } from "./runner";
 import type { ExecOptions, HookAPI, HookFactory, HookMessageRenderer, RegisteredCommand } from "./types";
 
@@ -149,7 +149,7 @@ async function loadHook(hookPath: string, cwd: string): Promise<{ hook: LoadedHo
 
 	try {
 		// Import the module using native Bun import
-		const module = await withExitGuard(() => import(resolvedPath));
+		const module = await withHostGuard(() => import(resolvedPath));
 		const factory = module.default as HookFactory;
 
 		if (typeof factory !== "function") {
@@ -164,7 +164,7 @@ async function loadHook(hookPath: string, cwd: string): Promise<{ hook: LoadedHo
 		);
 
 		// Call factory to register handlers
-		await withExitGuard(async () => factory(api));
+		await withHostGuard(async () => factory(api));
 
 		return {
 			hook: {

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -11,7 +11,7 @@ import {
 	isEnoent,
 	logger,
 } from "@oh-my-pi/pi-utils";
-import { withExitGuard } from "../utils";
+import { withHostGuard } from "../utils";
 import { refreshBunGitCache } from "./bun-git-cache";
 import { type GitSource, parseGitUrl } from "./git-url";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "./legacy-pi-compat";
@@ -375,7 +375,7 @@ export class PluginManager {
 			installLegacyPiSpecifierShim();
 			for (const extensionPath of loadable) {
 				try {
-					const module = await withExitGuard(() => loadLegacyPiModule(extensionPath));
+					const module = await withHostGuard(() => loadLegacyPiModule(extensionPath));
 					if (!hasExtensionFactoryExport(module)) {
 						errors.push(`${extensionPath}: extension does not export a valid factory function`);
 					}

--- a/packages/coding-agent/src/extensibility/utils.ts
+++ b/packages/coding-agent/src/extensibility/utils.ts
@@ -44,7 +44,7 @@ export function createNoOpUIContext(): HookUIContext {
 }
 
 /**
- * Raised by {@link withExitGuard} when a guarded callback synchronously
+ * Raised by {@link withHostGuard} when a guarded callback synchronously
  * attempts to terminate the host process. Callers catch this like any other
  * load-time failure so the extension/hook is skipped with a logged error
  * instead of taking the CLI down with it.
@@ -66,22 +66,46 @@ export class ExtensionExitError extends Error {
 
 type ExitAliasName = "process.exit" | "process.reallyExit";
 
-let exitGuardDepth = 0;
-let exitGuardOriginalProcessExit: typeof process.exit | null = null;
-let exitGuardOriginalReallyExit: typeof process.reallyExit | null = null;
+/**
+ * stdin events a loaded module must not be allowed to leave hijacked. A
+ * top-level `new StdioServerTransport()` (or a bare `process.stdin.resume()`)
+ * inside a `~/.claude/tools` MCP server attaches a `data` consumer and puts the
+ * shared stdin into flowing mode; Bun delivers one `data` event to that
+ * consumer and the TUI's own listener (attached later in `terminal.start()`)
+ * then never re-arms — every keypress after the first is swallowed (#5618).
+ */
+const HOST_GUARD_STDIN_EVENTS = ["data", "readable", "end", "close", "error"] as const;
+type StdinGuardEvent = (typeof HOST_GUARD_STDIN_EVENTS)[number];
+type StdinGuardListener = (...args: unknown[]) => void;
+
+let hostGuardDepth = 0;
+let hostGuardOriginalProcessExit: typeof process.exit | null = null;
+let hostGuardOriginalReallyExit: typeof process.reallyExit | null = null;
+let hostGuardStdinListeners: Record<StdinGuardEvent, StdinGuardListener[]> | null = null;
+let hostGuardStdinWasPaused = false;
+let hostGuardStdinWasRaw = false;
 
 /**
- * Run `fn` with hard-exit APIs patched so any synchronous attempt to terminate
- * the host raises {@link ExtensionExitError} instead. Restored in `finally`.
+ * Run `fn` with host-owned process state fenced off from third-party module
+ * evaluation, restored in `finally`. Guards the dynamic-import and
+ * factory-invocation sites that load extension / hook / tool / plugin modules
+ * from user directories (including Claude Code's `~/.claude/tools`, which OMP
+ * slurps wholesale). Two hazards are neutralized:
  *
- * Guards the dynamic-import and factory-invocation sites that load third-party
- * extension / hook modules — a `process.exit(0)` or `process.reallyExit(0)` in
- * a stranger's script (e.g. a Codex hook script that happens to live next to
- * OMP-shaped modules) would otherwise kill OMP during startup with no error
- * surface, since `try/catch` cannot intercept a synchronous exit.
+ * - **Hard exit.** `process.exit(0)` / `process.reallyExit(0)` in a stranger's
+ *   script (e.g. a CLI-shaped module with `main()` at the bottom) would kill
+ *   OMP during startup with no error surface, since `try/catch` cannot
+ *   intercept a synchronous exit. Both are patched to throw
+ *   {@link ExtensionExitError} instead.
+ * - **stdin hijack.** A module that attaches a stdin consumer at evaluation
+ *   time (an MCP `StdioServerTransport`, or a bare `resume()`) steals Bun's
+ *   single stdin reader, so the TUI goes permanently deaf after one keypress
+ *   (#5618). Any `data`/`readable`/`end`/`close`/`error` listener the module
+ *   adds is removed, and the stream's paused and raw-mode state is restored to
+ *   the pre-load snapshot.
  *
  * Nested and concurrent guard windows are safe: only the outermost guard
- * restores the real hard-exit APIs.
+ * snapshots and restores host state.
  */
 function guardedExit(alias: ExitAliasName): (code?: number | string) => never {
 	return (code?: number | string): never => {
@@ -89,29 +113,60 @@ function guardedExit(alias: ExitAliasName): (code?: number | string) => never {
 	};
 }
 
-export async function withExitGuard<T>(fn: () => Promise<T>): Promise<T> {
-	if (exitGuardDepth === 0) {
-		exitGuardOriginalProcessExit = process.exit;
+export async function withHostGuard<T>(fn: () => Promise<T>): Promise<T> {
+	if (hostGuardDepth === 0) {
+		hostGuardOriginalProcessExit = process.exit;
 		process.exit = guardedExit("process.exit") as typeof process.exit;
 
 		if (typeof process.reallyExit === "function") {
-			exitGuardOriginalReallyExit = process.reallyExit;
+			hostGuardOriginalReallyExit = process.reallyExit;
 			process.reallyExit = guardedExit("process.reallyExit") as typeof process.reallyExit;
 		}
+
+		const stdin = process.stdin;
+		hostGuardStdinWasPaused = stdin.isPaused();
+		hostGuardStdinWasRaw = stdin.isRaw ?? false;
+		const snapshot = {} as Record<StdinGuardEvent, StdinGuardListener[]>;
+		for (const event of HOST_GUARD_STDIN_EVENTS) {
+			snapshot[event] = stdin.listeners(event) as StdinGuardListener[];
+		}
+		hostGuardStdinListeners = snapshot;
 	}
-	exitGuardDepth++;
+	hostGuardDepth++;
 	try {
 		return await fn();
 	} finally {
-		exitGuardDepth--;
-		if (exitGuardDepth === 0) {
-			if (exitGuardOriginalProcessExit) {
-				process.exit = exitGuardOriginalProcessExit;
-				exitGuardOriginalProcessExit = null;
+		hostGuardDepth--;
+		if (hostGuardDepth === 0) {
+			if (hostGuardOriginalProcessExit) {
+				process.exit = hostGuardOriginalProcessExit;
+				hostGuardOriginalProcessExit = null;
 			}
-			if (exitGuardOriginalReallyExit) {
-				process.reallyExit = exitGuardOriginalReallyExit;
-				exitGuardOriginalReallyExit = null;
+			if (hostGuardOriginalReallyExit) {
+				process.reallyExit = hostGuardOriginalReallyExit;
+				hostGuardOriginalReallyExit = null;
+			}
+			if (hostGuardStdinListeners) {
+				const stdin = process.stdin;
+				for (const event of HOST_GUARD_STDIN_EVENTS) {
+					const before = hostGuardStdinListeners[event];
+					for (const listener of stdin.listeners(event) as StdinGuardListener[]) {
+						if (!before.includes(listener)) {
+							stdin.removeListener(event, listener);
+						}
+					}
+				}
+				if (
+					stdin.isTTY &&
+					typeof stdin.setRawMode === "function" &&
+					(stdin.isRaw ?? false) !== hostGuardStdinWasRaw
+				) {
+					stdin.setRawMode(hostGuardStdinWasRaw);
+				}
+				if (hostGuardStdinWasPaused && !stdin.isPaused()) {
+					stdin.pause();
+				}
+				hostGuardStdinListeners = null;
 			}
 		}
 	}

--- a/packages/coding-agent/src/extensibility/utils.ts
+++ b/packages/coding-agent/src/extensibility/utils.ts
@@ -128,7 +128,7 @@ export async function withHostGuard<T>(fn: () => Promise<T>): Promise<T> {
 		hostGuardStdinWasRaw = stdin.isRaw ?? false;
 		const snapshot = {} as Record<StdinGuardEvent, StdinGuardListener[]>;
 		for (const event of HOST_GUARD_STDIN_EVENTS) {
-			snapshot[event] = stdin.listeners(event) as StdinGuardListener[];
+			snapshot[event] = stdin.rawListeners(event) as StdinGuardListener[];
 		}
 		hostGuardStdinListeners = snapshot;
 	}
@@ -150,10 +150,19 @@ export async function withHostGuard<T>(fn: () => Promise<T>): Promise<T> {
 				const stdin = process.stdin;
 				for (const event of HOST_GUARD_STDIN_EVENTS) {
 					const before = hostGuardStdinListeners[event];
-					for (const listener of stdin.listeners(event) as StdinGuardListener[]) {
-						if (!before.includes(listener)) {
-							stdin.removeListener(event, listener);
-						}
+					// Reconcile the stream back to the pre-load snapshot: drop any
+					// listener the module added, and reinstate any snapshot listener
+					// it removed (e.g. a factory calling `removeAllListeners("data")`
+					// would otherwise permanently strip ProcessTerminal's input
+					// handler, leaving the parent TUI deaf). removeAllListeners then
+					// re-adding in snapshot order restores both membership and order.
+					const current = stdin.rawListeners(event) as StdinGuardListener[];
+					const added = current.some(listener => !before.includes(listener));
+					const removed = before.some(listener => !current.includes(listener));
+					if (!added && !removed) continue;
+					stdin.removeAllListeners(event);
+					for (const listener of before) {
+						stdin.on(event, listener);
 					}
 				}
 				if (

--- a/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
@@ -212,4 +212,38 @@ describe("custom tool loader", () => {
 			if (pausedBefore && !process.stdin.isPaused()) process.stdin.pause();
 		}
 	});
+
+	it("reinstates a host stdin listener a tool removes at import time (#5744)", async () => {
+		// A tool factory that calls process.stdin.removeAllListeners("data")
+		// during (re)load — e.g. a subagent re-running preloaded factories while
+		// the parent TUI is live — must not permanently strip ProcessTerminal's
+		// input handler. The guard reconciles stdin back to the pre-load snapshot,
+		// reinstating any listener the module removed.
+		const stripTool = await writeTool(
+			"stdin-strip.js",
+			[
+				'process.stdin.removeAllListeners("data");',
+				"export default api => ({",
+				'\tname: "stdin_strip_tool",',
+				'\tdescription: "Removes host data listeners at import",',
+				"\tparameters: api.zod.object({}),",
+				"\tasync execute() {",
+				'\t\treturn { content: [{ type: "text", text: "ok" }] };',
+				"\t},",
+				"});",
+			].join("\n"),
+		);
+
+		const hostListener = (): void => {};
+		process.stdin.on("data", hostListener);
+		const dataBefore = process.stdin.listenerCount("data");
+		try {
+			const result = await loadCustomTools([{ path: stripTool }], requireTempRoot(), []);
+			expect(result.tools.map(tool => tool.tool.name)).toEqual(["stdin_strip_tool"]);
+			expect(process.stdin.listenerCount("data")).toBe(dataBefore);
+			expect(process.stdin.listeners("data")).toContain(hostListener);
+		} finally {
+			process.stdin.removeListener("data", hostListener);
+		}
+	});
 });

--- a/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
@@ -172,4 +172,44 @@ describe("custom tool loader", () => {
 		expect(result.errors[0]?.error.toLowerCase()).toContain("invalid");
 		expect(result.errors[0]?.error).toContain("index 1");
 	});
+
+	it("restores host stdin after a tool hijacks it at import time (#5618)", async () => {
+		// A ~/.claude/tools MCP server attaches a stdin consumer at module top
+		// level (a bare `resume()` here stands in for `new StdioServerTransport()`).
+		// Without the stdin guard this steals Bun's single stdin reader and the
+		// TUI goes permanently deaf after one keypress. The tool also exports a
+		// valid default, so the guard must restore stdin on the success path too.
+		const hijackTool = await writeTool(
+			"stdin-hijack.js",
+			[
+				'process.stdin.on("data", () => {});',
+				"process.stdin.resume();",
+				"export default api => ({",
+				'\tname: "stdin_hijack_tool",',
+				'\tdescription: "Loads fine but hijacks stdin at import",',
+				"\tparameters: api.zod.object({}),",
+				"\tasync execute() {",
+				'\t\treturn { content: [{ type: "text", text: "ok" }] };',
+				"\t},",
+				"});",
+			].join("\n"),
+		);
+
+		const dataBefore = process.stdin.listenerCount("data");
+		const pausedBefore = process.stdin.isPaused();
+		try {
+			const result = await loadCustomTools([{ path: hijackTool }], requireTempRoot(), []);
+			expect(result.tools.map(tool => tool.tool.name)).toEqual(["stdin_hijack_tool"]);
+			expect(process.stdin.listenerCount("data")).toBe(dataBefore);
+			expect(process.stdin.isPaused()).toBe(pausedBefore);
+		} finally {
+			// Defensive: if the guard regressed and leaked a listener, drop the
+			// extras so this test cannot poison later files in the suite.
+			const leaked = process.stdin.listeners("data").slice(dataBefore);
+			for (const listener of leaked) {
+				process.stdin.removeListener("data", listener as (...args: unknown[]) => void);
+			}
+			if (pausedBefore && !process.stdin.isPaused()) process.stdin.pause();
+		}
+	});
 });

--- a/packages/coding-agent/test/extension-loader-process-exit.test.ts
+++ b/packages/coding-agent/test/extension-loader-process-exit.test.ts
@@ -2,7 +2,7 @@
  * Regression test for #3680: third-party extension / hook modules that call
  * `process.exit()` at the top level must not terminate the host OMP process.
  *
- * The harness intercepts the load via `withExitGuard`; this test pins that the
+ * The harness intercepts the load via `withHostGuard`; this test pins that the
  * intercepted error surfaces as a per-module load failure (so OMP keeps going)
  * instead of crashing the test runner.
  */
@@ -11,7 +11,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import { loadHooks } from "@oh-my-pi/pi-coding-agent/extensibility/hooks/loader";
-import { ExtensionExitError, withExitGuard } from "@oh-my-pi/pi-coding-agent/extensibility/utils";
+import { ExtensionExitError, withHostGuard } from "@oh-my-pi/pi-coding-agent/extensibility/utils";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("extension/hook loader process.exit guard (#3680)", () => {
@@ -111,7 +111,7 @@ describe("extension/hook loader process.exit guard (#3680)", () => {
 		const originalExit = process.exit;
 
 		await expect(
-			withExitGuard(async () => {
+			withHostGuard(async () => {
 				throw new Error("boom");
 			}),
 		).rejects.toThrow("boom");
@@ -122,7 +122,7 @@ describe("extension/hook loader process.exit guard (#3680)", () => {
 	it("raises ExtensionExitError when the guarded callback calls process.exit", async () => {
 		const originalExit = process.exit;
 
-		await expect(withExitGuard(async () => process.exit(7))).rejects.toBeInstanceOf(ExtensionExitError);
+		await expect(withHostGuard(async () => process.exit(7))).rejects.toBeInstanceOf(ExtensionExitError);
 
 		expect(process.exit).toBe(originalExit);
 	});
@@ -130,11 +130,11 @@ describe("extension/hook loader process.exit guard (#3680)", () => {
 	it("only the outermost guard restores process.exit when guards nest", async () => {
 		const originalExit = process.exit;
 
-		await withExitGuard(async () => {
+		await withHostGuard(async () => {
 			const outer = process.exit;
 			expect(outer).not.toBe(originalExit);
 
-			await withExitGuard(async () => {
+			await withHostGuard(async () => {
 				expect(process.exit).toBe(outer);
 			});
 


### PR DESCRIPTION
## Repro

Inside a session that has a `~/.claude/tools` MCP stdio server (or any tool module that touches stdin at import), every keypress after the first is swallowed — under tmux the very first keystroke is already dead, which is the input-deafness reported in #5378 and #5618. The reporter bisected it to a real file: `~/.claude/tools/teams-bot/mcp/server.js`, whose top level runs `new StdioServerTransport()`. Minimal, SDK-free repro:

```bash
mkdir -p ~/.claude/tools/x && cat > ~/.claude/tools/x/boom.js <<'EOF'
process.stdin.resume();
process.stdin.on("data", () => {});
export default () => ({ name: "x", description: "d", parameters: {}, execute: async () => ({ content: [] }) });
EOF
omp   # first keypress works, second is dead
```

## Cause

`createAgentSession` → `loadCustomTools` → `loadTool` (`packages/coding-agent/src/extensibility/custom-tools/loader.ts`) evaluates every module under the tools directories with live side effects, via `withExitGuard` (`packages/coding-agent/src/extensibility/utils.ts`). That guard neutralized `process.exit`/`process.reallyExit` but nothing else. A module that attaches a stdin consumer at evaluation time — an MCP `StdioServerTransport` constructed at module top level, or a bare `process.stdin.resume()` — steals Bun's single stdin reader and puts the shared stream into flowing mode. Bun delivers one `data` event to that consumer; the TUI's own listener, attached later in `terminal.start()`, then never re-arms, so all subsequent input is lost. Under tmux the terminal's automatic DA1 reply is that one consumed event, which is why the original report presented as tmux-specific total deafness.

This was not Darwin- or tmux-specific: the maintainer's Linux runner simply had no `~/.claude/tools` MCP server present.

## Fix

- Broadened the loader guard in `packages/coding-agent/src/extensibility/utils.ts` and renamed it `withExitGuard` → `withHostGuard` to match the wider contract. The outermost guard now also snapshots `process.stdin` before third-party evaluation and restores it in `finally`: any `data`/`readable`/`end`/`close`/`error` listener the module added is removed, and the stream's paused and raw-mode state is reset to the pre-load snapshot. Nested/concurrent guard windows still only snapshot/restore at the outermost frame.
- Updated the four call sites (`custom-tools/loader.ts`, `extensions/loader.ts`, `hooks/loader.ts`, `plugins/manager.ts`) and the existing exit-guard test to the new name — the guard is the shared chokepoint for tools, extensions, hooks, and plugins, so all four load paths get the stdin protection.
- Added a regression test in `test/extensibility/custom-tool-loader.test.ts` that loads a tool hijacking stdin at import (the SDK-free repro above) and asserts the host's `data` listener count and paused state are unchanged after load; the test is self-cleaning so a regression cannot poison later suite files.
- Changelog entry under `[Unreleased]`.

## Verification

`bun test test/extensibility/custom-tool-loader.test.ts test/extension-loader-process-exit.test.ts` → 13 pass. The new test fails without the fix (stdin `data` listener leaks: `Expected 0, Received 1`) and passes with it — verified by temporarily neutralizing the snapshot restore. `bun run check` (biome + tsgo) is clean on the coding-agent package. The unit test drives the real `loadCustomTools` path with the reporter's minimal repro. Fixes #5618