### PR TITLE
fix(session): retain bash ownership across session/branch transitions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed late user-initiated bash results and minimized-output artifacts being recorded in whichever session or branch was active when execution finished; bash now retains its originating transcript across `new_session`/`switch_session`/`branch`/tree navigation, and an intentionally dropped session stays deleted instead of being recreated by a straggling result ([#5743](https://github.com/can1357/oh-my-pi/issues/5743)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -393,6 +393,34 @@ import { YieldQueue } from "./yield-queue";
 const SESSION_STOP_CONTINUATION_CAP = 8;
 const PLAN_MODE_REMINDER_MAX = 3;
 
+type BashAppendDestination =
+	| { kind: "current"; manager: SessionManager }
+	| { kind: "detached"; manager: SessionManager }
+	| { kind: "branch"; manager: SessionManager; parentId: string | null };
+
+interface BashSessionTarget {
+	sessionId: string;
+	refs: number;
+	destination?: BashAppendDestination;
+	pending?: Promise<BashAppendDestination>;
+}
+
+interface PendingBashMessage {
+	target: BashSessionTarget;
+	message: BashExecutionMessage;
+}
+
+interface BashSessionTransition {
+	oldTarget: BashSessionTarget;
+	newTarget: BashSessionTarget;
+	oldSessionId: string;
+	oldSessionFile: string | undefined;
+	oldLeafId: string | null;
+	detachedManager: SessionManager | undefined;
+	resolveOld: ((destination: BashAppendDestination) => void) | undefined;
+	resolveNew: (destination: BashAppendDestination) => void;
+}
+
 /**
  * Mutating tool results (`bash`/`eval`/`edit`/`write`/`ast_edit`) without the
  * agent touching the `todo` tool that trip the mid-run reconciliation nudge.
@@ -1864,7 +1892,8 @@ export class AgentSession {
 
 	// Bash execution state
 	#bashAbortControllers = new Set<AbortController>();
-	#pendingBashMessages: BashExecutionMessage[] = [];
+	#pendingBashMessages: PendingBashMessage[] = [];
+	#bashSessionTarget!: BashSessionTarget;
 
 	// Python execution state
 	#evalAbortControllers = new Set<AbortController>();
@@ -2494,6 +2523,11 @@ export class AgentSession {
 	constructor(config: AgentSessionConfig) {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
+		this.#bashSessionTarget = {
+			sessionId: this.sessionManager.getSessionId(),
+			refs: 0,
+			destination: { kind: "current", manager: this.sessionManager },
+		};
 		this.settings = config.settings;
 		this.#autoApprove = config.autoApprove === true;
 		// Power assertions are taken per turn (see #beginInFlight); nothing acquired here.
@@ -8072,7 +8106,7 @@ export class AgentSession {
 		const generation = this.#promptGeneration;
 		try {
 			// Flush any pending bash messages before the new prompt
-			this.#flushPendingBashMessages();
+			await this.#flushPendingBashMessages();
 			this.#flushPendingPythonMessages();
 			this.#flushPendingIrcAsides();
 
@@ -9139,27 +9173,36 @@ export class AgentSession {
 		await this.abort();
 		this.#cancelOwnAsyncJobs();
 		this.#closeAllProviderSessions("new session");
-		this.agent.reset();
-		if (options?.drop && previousSessionFile) {
-			// Detach the advisor recorder feed and drain its writer BEFORE deleting the
-			// old artifacts dir: `await this.abort()` only stops the primary, so a still-
-			// running advisor turn could otherwise finish, emit `message_end`, and recreate
-			// `<old>/__advisor.jsonl`. #resetAdvisorSessionState (after newSession) re-primes
-			// the advisor and re-attaches the feed at the new session's path.
-			for (const a of this.#advisors) {
-				a.agentUnsubscribe?.();
-				a.agentUnsubscribe = undefined;
-				await a.recorder.close();
+		await this.#flushPendingBashMessages();
+		const bashTransition = this.#beginBashSessionTransition({ persistDetached: options?.drop !== true });
+		let sessionTransitioned = false;
+		try {
+			this.agent.reset();
+			if (options?.drop && previousSessionFile) {
+				// Detach the advisor recorder feed and drain its writer BEFORE deleting the
+				// old artifacts dir: `await this.abort()` only stops the primary, so a still-
+				// running advisor turn could otherwise finish, emit `message_end`, and recreate
+				// `<old>/__advisor.jsonl`. #resetAdvisorSessionState (after newSession) re-primes
+				// the advisor and re-attaches the feed at the new session's path.
+				for (const a of this.#advisors) {
+					a.agentUnsubscribe?.();
+					a.agentUnsubscribe = undefined;
+					await a.recorder.close();
+				}
+				try {
+					await this.sessionManager.dropSession(previousSessionFile);
+				} catch (err) {
+					logger.error("Failed to delete session during /drop", { err });
+				}
+			} else {
+				await this.sessionManager.flush();
 			}
-			try {
-				await this.sessionManager.dropSession(previousSessionFile);
-			} catch (err) {
-				logger.error("Failed to delete session during /drop", { err });
-			}
-		} else {
-			await this.sessionManager.flush();
+			await this.sessionManager.newSession(options);
+			this.#markBashSessionTransition(bashTransition);
+			sessionTransitioned = true;
+		} finally {
+			this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
 		}
-		await this.sessionManager.newSession(options);
 
 		this.#clearCheckpointRuntimeState();
 		this.setTodoPhases([]);
@@ -9225,14 +9268,25 @@ export class AgentSession {
 			}
 		}
 
+		await this.#flushPendingBashMessages();
 		// Flush current session to ensure all entries are written
 		await this.sessionManager.flush();
+		const bashTransition = this.#beginBashSessionTransition();
 
 		// Fork the session (creates new session file with same entries)
-		const forkResult = await this.sessionManager.fork();
+		let forkResult: { oldSessionFile: string; newSessionFile: string } | undefined;
+		try {
+			forkResult = await this.sessionManager.fork();
+		} catch (error) {
+			this.#finishBashSessionTransition(bashTransition, false);
+			throw error;
+		}
 		if (!forkResult) {
+			this.#finishBashSessionTransition(bashTransition, false);
 			return false;
 		}
+		this.#markBashSessionTransition(bashTransition);
+		this.#finishBashSessionTransition(bashTransition, true);
 
 		// Copy artifacts directory if it exists
 		const oldArtifactDir = forkResult.oldSessionFile.slice(0, -6);
@@ -10608,9 +10662,20 @@ export class AgentSession {
 					return undefined;
 				}
 			}
+			await this.#flushPendingBashMessages();
 			await this.sessionManager.flush();
+			const bashTransition = this.#beginBashSessionTransition();
 			this.#cancelOwnAsyncJobs();
-			await this.sessionManager.newSession(previousSessionFile ? { parentSession: previousSessionFile } : undefined);
+			let sessionTransitioned = false;
+			try {
+				await this.sessionManager.newSession(
+					previousSessionFile ? { parentSession: previousSessionFile } : undefined,
+				);
+				this.#markBashSessionTransition(bashTransition);
+				sessionTransitioned = true;
+			} finally {
+				this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
+			}
 
 			this.#clearCheckpointRuntimeState();
 			// agent.reset() clears the core steering/follow-up queues. Preserve any queued
@@ -11503,11 +11568,13 @@ export class AgentSession {
 
 		if (!branchEntry) return;
 		const targetParentId = prunePrompt ? parentEntry.parentId : branchEntry.parentId;
-		if (targetParentId === null) {
-			this.sessionManager.resetLeaf();
-		} else {
-			this.sessionManager.branch(targetParentId);
-		}
+		this.#withBashBranchTransition(() => {
+			if (targetParentId === null) {
+				this.sessionManager.resetLeaf();
+			} else {
+				this.sessionManager.branch(targetParentId);
+			}
+		});
 		this.sessionManager.appendCustomEntry("accepted-terminal-empty-stop");
 	}
 
@@ -11534,11 +11601,13 @@ export class AgentSession {
 		if (!branchEntry) {
 			return;
 		}
-		if (branchEntry.parentId === null) {
-			this.sessionManager.resetLeaf();
-		} else {
-			this.sessionManager.branch(branchEntry.parentId);
-		}
+		this.#withBashBranchTransition(() => {
+			if (branchEntry.parentId === null) {
+				this.sessionManager.resetLeaf();
+			} else {
+				this.sessionManager.branch(branchEntry.parentId);
+			}
+		});
 	}
 
 	#isSameAssistantMessage(left: AssistantMessage, right: AssistantMessage): boolean {
@@ -11593,16 +11662,18 @@ export class AgentSession {
 		if (!checkpointState) {
 			return;
 		}
-		try {
-			this.sessionManager.branchWithSummary(checkpointState.checkpointEntryId, report, {
-				startedAt: checkpointState.startedAt,
-			});
-		} catch (error) {
-			logger.warn("Rewind branch checkpoint missing, falling back to root", {
-				error: error instanceof Error ? error.message : String(error),
-			});
-			this.sessionManager.branchWithSummary(null, report, { startedAt: checkpointState.startedAt });
-		}
+		this.#withBashBranchTransition(() => {
+			try {
+				this.sessionManager.branchWithSummary(checkpointState.checkpointEntryId, report, {
+					startedAt: checkpointState.startedAt,
+				});
+			} catch (error) {
+				logger.warn("Rewind branch checkpoint missing, falling back to root", {
+					error: error instanceof Error ? error.message : String(error),
+				});
+				this.sessionManager.branchWithSummary(null, report, { startedAt: checkpointState.startedAt });
+			}
+		});
 
 		const rewoundAt = new Date().toISOString();
 		const details = { report, startedAt: checkpointState.startedAt, rewoundAt };
@@ -14706,71 +14777,22 @@ export class AgentSession {
 	// Bash Execution
 	// =========================================================================
 
-	async #saveBashOriginalArtifact(originalText: string): Promise<string | undefined> {
+	async #saveBashOriginalArtifact(target: BashSessionTarget, originalText: string): Promise<string | undefined> {
 		try {
-			return await this.sessionManager.saveArtifact(originalText, "bash-original");
+			const destination = target.destination ?? (await target.pending);
+			return await destination?.manager.saveArtifact(originalText, "bash-original");
 		} catch {
 			return undefined;
 		}
 	}
 
-	/**
-	 * Execute a bash command.
-	 * Adds result to agent context and session.
-	 * @param command The bash command to execute
-	 * @param onChunk Optional streaming callback for output
-	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
-	 * @param options.useUserShell If true, allow caller to request configured user-shell routing
-	 */
-	async executeBash(
+	#createBashMessage(
 		command: string,
-		onChunk?: (chunk: string) => void,
-		options?: { excludeFromContext?: boolean; useUserShell?: boolean },
-	): Promise<BashResult> {
-		const excludeFromContext = options?.excludeFromContext === true;
-		const cwd = this.sessionManager.getCwd();
-
-		if (this.#extensionRunner?.hasHandlers("user_bash")) {
-			const hookResult = await this.#extensionRunner.emitUserBash({
-				type: "user_bash",
-				command,
-				excludeFromContext,
-				cwd,
-			});
-			if (hookResult?.result) {
-				this.recordBashResult(command, hookResult.result, options);
-				return hookResult.result;
-			}
-		}
-
-		const abortController = new AbortController();
-		this.#bashAbortControllers.add(abortController);
-
-		try {
-			const result = await executeBashCommand(command, {
-				onChunk,
-				signal: abortController.signal,
-				sessionKey: this.sessionId,
-				cwd,
-				timeout: clampTimeout("bash") * 1000,
-				onMinimizedSave: originalText => this.#saveBashOriginalArtifact(originalText),
-				useUserShell: options?.useUserShell,
-			});
-
-			this.recordBashResult(command, result, options);
-			return result;
-		} finally {
-			this.#bashAbortControllers.delete(abortController);
-		}
-	}
-
-	/**
-	 * Record a bash execution result in session history.
-	 * Used by executeBash and by extensions that handle bash execution themselves.
-	 */
-	recordBashResult(command: string, result: BashResult, options?: { excludeFromContext?: boolean }): void {
+		result: BashResult,
+		options?: { excludeFromContext?: boolean },
+	): BashExecutionMessage {
 		const meta = outputMeta().truncationFromSummary(result, { direction: "tail" }).get();
-		const bashMessage: BashExecutionMessage = {
+		return {
 			role: "bashExecution",
 			command,
 			output: result.output,
@@ -14781,18 +14803,237 @@ export class AgentSession {
 			timestamp: Date.now(),
 			excludeFromContext: options?.excludeFromContext,
 		};
+	}
 
-		// If agent is streaming, defer adding to avoid breaking tool_use/tool_result ordering
-		if (this.isStreaming) {
-			// Queue for later - will be flushed on agent_end
-			this.#pendingBashMessages.push(bashMessage);
-		} else {
-			// Add to agent state immediately
-			this.agent.appendMessage(bashMessage);
+	#captureBashSessionTarget(): BashSessionTarget {
+		this.#bashSessionTarget.refs++;
+		return this.#bashSessionTarget;
+	}
 
-			// Save to session
-			this.sessionManager.appendMessage(bashMessage);
+	async #releaseBashSessionTarget(target: BashSessionTarget): Promise<void> {
+		if (target.refs <= 0) throw new Error("Bash session target released more than once");
+		target.refs--;
+		if (target.refs === 0 && target.destination?.kind === "detached") {
+			await target.destination.manager.close();
 		}
+	}
+
+	#appendBashMessage(destination: BashAppendDestination, message: BashExecutionMessage): void {
+		switch (destination.kind) {
+			case "current":
+				this.agent.appendMessage(message);
+				destination.manager.appendMessage(message);
+				break;
+			case "detached":
+				destination.manager.appendMessage(message);
+				break;
+			case "branch":
+				destination.parentId = destination.manager.appendMessageToBranch(message, destination.parentId);
+				break;
+		}
+	}
+
+	async #appendOwnedBashMessage(target: BashSessionTarget, message: BashExecutionMessage): Promise<void> {
+		try {
+			const destination = target.destination ?? (await target.pending);
+			if (!destination) throw new Error("Bash session target has no append destination");
+			this.#appendBashMessage(destination, message);
+		} finally {
+			await this.#releaseBashSessionTarget(target);
+		}
+	}
+
+	async #recordBashResultForTarget(
+		target: BashSessionTarget,
+		command: string,
+		result: BashResult,
+		options?: { excludeFromContext?: boolean },
+	): Promise<void> {
+		const message = this.#createBashMessage(command, result, options);
+		if (this.isStreaming && target === this.#bashSessionTarget) {
+			this.#pendingBashMessages.push({ target, message });
+			return;
+		}
+		await this.#appendOwnedBashMessage(target, message);
+	}
+
+	/** Run a leaf rewrite while retaining any in-flight bash on its originating branch. */
+	#withBashBranchTransition<T>(mutate: () => T): T {
+		const bashTransition = this.#beginBashSessionTransition();
+		let branchTransitioned = false;
+		try {
+			const result = mutate();
+			this.#markBashSessionTransition(bashTransition);
+			branchTransitioned = true;
+			return result;
+		} finally {
+			this.#finishBashSessionTransition(bashTransition, branchTransitioned);
+		}
+	}
+
+	/**
+	 * Snapshot the session/branch that owns any in-flight bash before a transition.
+	 * When an owner is still active, its target is detached to a clone so a failed
+	 * or intentionally dropped transition never redirects the late result.
+	 */
+	#beginBashSessionTransition(options?: { persistDetached?: boolean }): BashSessionTransition {
+		const oldTarget = this.#bashSessionTarget;
+		let detachedManager: SessionManager | undefined;
+		let resolveOld: ((destination: BashAppendDestination) => void) | undefined;
+		if (oldTarget.refs > 0) {
+			detachedManager = this.sessionManager.cloneCurrentSession({ persist: options?.persistDetached });
+			const pendingOld = Promise.withResolvers<BashAppendDestination>();
+			oldTarget.destination = undefined;
+			oldTarget.pending = pendingOld.promise;
+			resolveOld = pendingOld.resolve;
+		}
+
+		const pendingNew = Promise.withResolvers<BashAppendDestination>();
+		return {
+			oldTarget,
+			newTarget: {
+				sessionId: this.sessionManager.getSessionId(),
+				refs: 0,
+				pending: pendingNew.promise,
+			},
+			oldSessionId: this.sessionManager.getSessionId(),
+			oldSessionFile: this.sessionManager.getSessionFile(),
+			oldLeafId: this.sessionManager.getLeafId(),
+			detachedManager,
+			resolveOld,
+			resolveNew: pendingNew.resolve,
+		};
+	}
+
+	/** Adopt the transition's new target as the live bash owner. */
+	#markBashSessionTransition(transition: BashSessionTransition): void {
+		transition.newTarget.sessionId = this.sessionManager.getSessionId();
+		this.#bashSessionTarget = transition.newTarget;
+	}
+
+	/**
+	 * Resolve the pending append destinations opened by {@link #beginBashSessionTransition}.
+	 * On success the old owner keeps its original session/branch (same file → current or
+	 * branch destination; different file → detached clone); on failure both fall back to
+	 * the still-current manager and the clone is discarded.
+	 */
+	#finishBashSessionTransition(transition: BashSessionTransition, success: boolean): void {
+		const currentDestination: BashAppendDestination = { kind: "current", manager: this.sessionManager };
+		let oldDestination: BashAppendDestination = currentDestination;
+		if (success && transition.resolveOld) {
+			const currentFile = this.sessionManager.getSessionFile();
+			const sameFile =
+				transition.oldSessionFile === currentFile ||
+				(transition.oldSessionFile !== undefined &&
+					currentFile !== undefined &&
+					path.resolve(transition.oldSessionFile) === path.resolve(currentFile));
+			const sameSession = transition.oldSessionId === this.sessionManager.getSessionId() && sameFile;
+			if (sameSession) {
+				oldDestination =
+					transition.oldLeafId === this.sessionManager.getLeafId()
+						? currentDestination
+						: { kind: "branch", manager: this.sessionManager, parentId: transition.oldLeafId };
+			} else if (transition.detachedManager) {
+				oldDestination = { kind: "detached", manager: transition.detachedManager };
+			}
+		}
+
+		if (transition.resolveOld) {
+			transition.oldTarget.pending = undefined;
+			transition.oldTarget.destination = oldDestination;
+			transition.resolveOld(oldDestination);
+		}
+
+		transition.newTarget.pending = undefined;
+		transition.newTarget.destination = currentDestination;
+		if (!success) transition.newTarget.sessionId = this.sessionManager.getSessionId();
+		transition.resolveNew(currentDestination);
+
+		if (transition.detachedManager && (oldDestination.kind !== "detached" || transition.oldTarget.refs === 0)) {
+			void transition.detachedManager.close().catch(error => {
+				logger.warn("Failed to close detached bash session writer", { error: String(error) });
+			});
+		}
+	}
+
+	/**
+	 * Execute a bash command and retain the session/branch that owned its start.
+	 * @param command The bash command to execute
+	 * @param onChunk Optional streaming callback for output
+	 * @param options.excludeFromContext If true, command output won't be sent to LLM (!! prefix)
+	 * @param options.useUserShell If true, allow caller to request configured user-shell routing
+	 */
+	async executeBash(
+		command: string,
+		onChunk?: (chunk: string) => void,
+		options?: { excludeFromContext?: boolean; useUserShell?: boolean },
+	): Promise<BashResult> {
+		const target = this.#captureBashSessionTarget();
+		let targetTransferred = false;
+		const excludeFromContext = options?.excludeFromContext === true;
+		const cwd = this.sessionManager.getCwd();
+
+		try {
+			if (this.#extensionRunner?.hasHandlers("user_bash")) {
+				const hookResult = await this.#extensionRunner.emitUserBash({
+					type: "user_bash",
+					command,
+					excludeFromContext,
+					cwd,
+				});
+				if (hookResult?.result) {
+					targetTransferred = true;
+					await this.#recordBashResultForTarget(target, command, hookResult.result, options);
+					return hookResult.result;
+				}
+			}
+
+			const abortController = new AbortController();
+			this.#bashAbortControllers.add(abortController);
+			let result: BashResult;
+			try {
+				result = await executeBashCommand(command, {
+					onChunk,
+					signal: abortController.signal,
+					sessionKey: target.sessionId,
+					cwd,
+					timeout: clampTimeout("bash") * 1000,
+					onMinimizedSave: originalText => this.#saveBashOriginalArtifact(target, originalText),
+					useUserShell: options?.useUserShell,
+				});
+			} finally {
+				this.#bashAbortControllers.delete(abortController);
+			}
+
+			targetTransferred = true;
+			await this.#recordBashResultForTarget(target, command, result, options);
+			return result;
+		} finally {
+			if (!targetTransferred) await this.#releaseBashSessionTarget(target);
+		}
+	}
+
+	/** Record a bash result supplied outside executeBash in the current ownership scope. */
+	recordBashResult(command: string, result: BashResult, options?: { excludeFromContext?: boolean }): void {
+		const target = this.#captureBashSessionTarget();
+		const message = this.#createBashMessage(command, result, options);
+		if (this.isStreaming && target === this.#bashSessionTarget) {
+			this.#pendingBashMessages.push({ target, message });
+			return;
+		}
+
+		if (target.destination) {
+			try {
+				this.#appendBashMessage(target.destination, message);
+			} finally {
+				void this.#releaseBashSessionTarget(target);
+			}
+			return;
+		}
+
+		void this.#appendOwnedBashMessage(target, message).catch(error => {
+			logger.error("Failed to record bash result in its owning session", { error: String(error) });
+		});
 	}
 
 	/**
@@ -14814,22 +15055,14 @@ export class AgentSession {
 		return this.#pendingBashMessages.length > 0;
 	}
 
-	/**
-	 * Flush pending bash messages to agent state and session.
-	 * Called after agent turn completes to maintain proper message ordering.
-	 */
-	#flushPendingBashMessages(): void {
+	/** Flush pending bash messages after the active turn without changing their ownership. */
+	async #flushPendingBashMessages(): Promise<void> {
 		if (this.#pendingBashMessages.length === 0) return;
-
-		for (const bashMessage of this.#pendingBashMessages) {
-			// Add to agent state
-			this.agent.appendMessage(bashMessage);
-
-			// Save to session
-			this.sessionManager.appendMessage(bashMessage);
-		}
-
+		const pending = this.#pendingBashMessages;
 		this.#pendingBashMessages = [];
+		for (const { target, message } of pending) {
+			await this.#appendOwnedBashMessage(target, message);
+		}
 	}
 
 	// =========================================================================
@@ -15422,9 +15655,11 @@ export class AgentSession {
 		this.#disconnectFromAgent();
 		await this.abort({ goalReason: "internal" });
 
+		await this.#flushPendingBashMessages();
 		// Flush pending writes before switching so restore snapshots reflect committed state.
 		await this.sessionManager.flush();
 		const previousSessionState = this.sessionManager.captureState();
+		const bashTransition = this.#beginBashSessionTransition();
 		// Only same-session reloads compare against the prior context to detect
 		// rollback edits (`#didSessionMessagesChange` below). Building it for a
 		// different-session switch is a pure waste — and on huge pre-fix sessions
@@ -15469,6 +15704,7 @@ export class AgentSession {
 
 		try {
 			await this.sessionManager.setSessionFile(sessionPath);
+			this.#markBashSessionTransition(bashTransition);
 			if (switchingToDifferentSession) {
 				this.#freshProviderSessionId = undefined;
 				this.#clearInheritedProviderPromptCacheKey();
@@ -15602,6 +15838,7 @@ export class AgentSession {
 					error: String(error),
 				});
 			}
+			this.#finishBashSessionTransition(bashTransition, true);
 			return true;
 		} catch (error) {
 			this.sessionManager.restoreState(previousSessionState);
@@ -15633,6 +15870,7 @@ export class AgentSession {
 			this.#syncTodoPhasesFromBranch();
 			this.#resetAllAdvisorRuntimes();
 			this.#reconnectToAgent();
+			this.#finishBashSessionTransition(bashTransition, false);
 			throw error;
 		}
 	}
@@ -15678,14 +15916,23 @@ export class AgentSession {
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 
+		await this.#flushPendingBashMessages();
 		// Flush pending writes before branching
 		await this.sessionManager.flush();
+		const bashTransition = this.#beginBashSessionTransition();
 		this.#cancelOwnAsyncJobs();
 
-		if (!selectedEntry.parentId) {
-			await this.sessionManager.newSession({ parentSession: previousSessionFile });
-		} else {
-			this.sessionManager.createBranchedSession(selectedEntry.parentId);
+		let sessionTransitioned = false;
+		try {
+			if (!selectedEntry.parentId) {
+				await this.sessionManager.newSession({ parentSession: previousSessionFile });
+			} else {
+				this.sessionManager.createBranchedSession(selectedEntry.parentId);
+			}
+			this.#markBashSessionTransition(bashTransition);
+			sessionTransitioned = true;
+		} finally {
+			this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
 		}
 		this.#rehydrateCheckpointRewindState();
 		this.#syncTodoPhasesFromBranch();
@@ -15769,10 +16016,19 @@ export class AgentSession {
 			await this.abort({ goalReason: "internal", reason: "branching /btw" });
 			this.agent.replaceQueues([], []);
 		}
+		await this.#flushPendingBashMessages();
 		await this.sessionManager.flush();
+		const bashTransition = this.#beginBashSessionTransition();
 		this.#cancelOwnAsyncJobs();
 
-		this.sessionManager.createBranchedSession(leafId);
+		let sessionTransitioned = false;
+		try {
+			this.sessionManager.createBranchedSession(leafId);
+			this.#markBashSessionTransition(bashTransition);
+			sessionTransitioned = true;
+		} finally {
+			this.#finishBashSessionTransition(bashTransition, sessionTransitioned);
+		}
 
 		this.#rehydrateCheckpointRewindState();
 		this.sessionManager.appendMessage({
@@ -15828,6 +16084,7 @@ export class AgentSession {
 		/** Raw session context built during navigation — pass to renderInitialMessages to skip a second O(N) walk. */
 		sessionContext?: SessionContext;
 	}> {
+		await this.#flushPendingBashMessages();
 		const oldLeafId = this.sessionManager.getLeafId();
 
 		// No-op if already at target
@@ -15955,18 +16212,28 @@ export class AgentSession {
 
 		// Switch leaf (with or without summary)
 		// Summary is attached at the navigation target position (newLeafId), not the old branch
+		const bashTransition = this.#beginBashSessionTransition();
 		let summaryEntry: BranchSummaryEntry | undefined;
-		if (summaryText) {
-			// Create summary at target position (can be null for root)
-			const summaryId = this.sessionManager.branchWithSummary(newLeafId, summaryText, summaryDetails, fromExtension);
-
-			summaryEntry = this.sessionManager.getEntry(summaryId) as BranchSummaryEntry;
-		} else if (newLeafId === null) {
-			// No summary, navigating to root - reset leaf
-			this.sessionManager.resetLeaf();
-		} else {
-			// No summary, navigating to non-root
-			this.sessionManager.branch(newLeafId);
+		let branchTransitioned = false;
+		try {
+			if (summaryText) {
+				// Create summary at target position (can be null for root)
+				const summaryId = this.sessionManager.branchWithSummary(
+					newLeafId,
+					summaryText,
+					summaryDetails,
+					fromExtension,
+				);
+				summaryEntry = this.sessionManager.getEntry(summaryId) as BranchSummaryEntry;
+			} else if (newLeafId === null) {
+				this.sessionManager.resetLeaf();
+			} else {
+				this.sessionManager.branch(newLeafId);
+			}
+			this.#markBashSessionTransition(bashTransition);
+			branchTransitioned = true;
+		} finally {
+			this.#finishBashSessionTransition(bashTransition, branchTransitioned);
 		}
 
 		// Update agent state — build display context to populate agent messages.

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -935,6 +935,26 @@ export class SessionManager {
 		};
 	}
 
+	/**
+	 * Create an independent manager for the current logical session and branch.
+	 * The clone shares the storage backend but owns its entry index and writer, so
+	 * callers can finish session-owned work after this manager switches elsewhere.
+	 * Set `persist` false when the original session is intentionally being dropped.
+	 */
+	cloneCurrentSession(options?: { persist?: boolean }): SessionManager {
+		const persist = options?.persist ?? this.#persist;
+		const clone = new SessionManager(this.#cwd, this.#sessionDir, persist, this.#storage);
+		clone.#suppressBreadcrumb = true;
+		clone.restoreState(this.captureState());
+		if (!persist) {
+			clone.#sessionFile = undefined;
+			clone.#fileIsCurrent = false;
+			clone.#rewriteRequired = false;
+			clone.#forceFileCreation = false;
+		}
+		return clone;
+	}
+
 	restoreState(snapshot: SessionManagerStateSnapshot): void {
 		this.#closeWriterEventually();
 		this.#diskTail = Promise.resolve();
@@ -1467,6 +1487,34 @@ export class SessionManager {
 	): string {
 		const entry: SessionMessageEntry = { type: "message", ...this.#freshEntryFields(), message };
 		this.#recordEntry(entry);
+		return entry.id;
+	}
+
+	/**
+	 * Append to a non-active branch without changing the current leaf.
+	 * Used by work that retains ownership of a branch across tree navigation.
+	 */
+	appendMessageToBranch(
+		message:
+			| Message
+			| CustomMessage
+			| HookMessage
+			| BashExecutionMessage
+			| PythonExecutionMessage
+			| FileMentionMessage,
+		parentId: string | null,
+	): string {
+		if (parentId !== null && !this.#index.has(parentId)) throw new Error(`Entry ${parentId} not found`);
+		const activeLeafId = this.#index.leafId();
+		const entry: SessionMessageEntry = {
+			type: "message",
+			id: generateId(this.#index),
+			parentId,
+			timestamp: nowIso(),
+			message,
+		};
+		this.#recordEntry(entry);
+		this.#index.setLeaf(activeLeafId);
 		return entry.id;
 	}
 

--- a/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
+++ b/packages/coding-agent/test/agent-session-bash-session-ownership.test.ts
@@ -1,0 +1,389 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as bashExecutor from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { createAssistantMessage } from "./helpers/agent-session-setup";
+
+const bashResult = {
+	output: "old-output",
+	exitCode: 0,
+	cancelled: false,
+	truncated: false,
+	totalLines: 1,
+	totalBytes: 10,
+	outputLines: 1,
+	outputBytes: 10,
+};
+
+describe("AgentSession bash session ownership", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let additionalManagers: SessionManager[];
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-bash-session-owner-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		additionalManagers = [];
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		await session?.dispose();
+		await Promise.all(additionalManagers.map(manager => manager.close()));
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function createSession(
+		sessionManager: SessionManager = SessionManager.inMemory(tempDir.path()),
+		extensionRunner?: ExtensionRunner,
+		responseContent: () => string[] = () => ["Done"],
+	): AgentSession {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
+		const mock = createMockModel({ handler: () => ({ content: responseContent() }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			extensionRunner,
+		});
+		return session;
+	}
+
+	function createGatedBashRunner() {
+		const completion = Promise.withResolvers<{ result: typeof bashResult }>();
+		const emitUserBash = vi.fn(() => completion.promise);
+		const extensionRunner = {
+			hasHandlers: vi.fn((eventType: string) => eventType === "user_bash"),
+			emitUserBash,
+			emit: vi.fn().mockResolvedValue(undefined),
+			emitBeforeAgentStart: vi.fn().mockResolvedValue(undefined),
+		} as unknown as ExtensionRunner;
+		return { completion, emitUserBash, extensionRunner };
+	}
+
+	async function seedPersistedSession(): Promise<string> {
+		await session.prompt("seed prompt");
+		await session.waitForIdle();
+		const sessionFile = session.sessionFile;
+		if (!sessionFile) throw new Error("Expected persisted session file");
+		return sessionFile;
+	}
+
+	it("does not flush a pending bash result into a replacement session", async () => {
+		createSession();
+		let forceStreaming = true;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => forceStreaming,
+		});
+
+		const oldSessionId = session.sessionId;
+		session.recordBashResult("old-session-command", bashResult);
+		expect(session.hasPendingBashMessages).toBe(true);
+
+		forceStreaming = false;
+		await session.newSession();
+		expect(session.sessionId).not.toBe(oldSessionId);
+		expect(session.hasPendingBashMessages).toBe(false);
+
+		await session.prompt("new-session-prompt");
+		await session.waitForIdle();
+
+		expect(session.messages.some(message => message.role === "bashExecution")).toBe(false);
+	});
+
+	it("keeps a queued bash result on the branch discarded by an empty stop", async () => {
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		let returnEmptyStop = true;
+		createSession(sessionManager, undefined, () => (returnEmptyStop ? [] : ["Done"]));
+		let forceStreaming = false;
+		Object.defineProperty(session, "isStreaming", {
+			configurable: true,
+			get: () => forceStreaming,
+		});
+		let discardedAssistantTimestamp: number | undefined;
+		const unsubscribe = session.agent.subscribe(event => {
+			if (event.type === "message_end" && event.message.role === "assistant" && returnEmptyStop) {
+				forceStreaming = true;
+				discardedAssistantTimestamp = event.message.timestamp;
+				session.recordBashResult("discarded-turn-command", bashResult);
+			} else if (event.type === "agent_end") {
+				forceStreaming = false;
+			}
+		});
+
+		const started = await session.sendCustomMessage(
+			{
+				customType: "ownership-test",
+				content: "Run an accepted empty turn",
+				display: false,
+				attribution: "agent",
+			},
+			{ deliverAs: "nextTurn", triggerTurn: true, acceptTerminalEmptyStop: true },
+		);
+		unsubscribe();
+		expect(started).toBe(true);
+		expect(session.hasPendingBashMessages).toBe(true);
+		const discardedAssistantEntry = sessionManager
+			.getEntries()
+			.find(
+				entry =>
+					entry.type === "message" &&
+					entry.message.role === "assistant" &&
+					entry.message.timestamp === discardedAssistantTimestamp,
+			);
+		if (!discardedAssistantEntry) throw new Error("Expected discarded assistant entry");
+
+		returnEmptyStop = false;
+		await session.prompt("flush queued bash result");
+		await session.waitForIdle();
+
+		const bashEntry = sessionManager
+			.getEntries()
+			.find(
+				entry =>
+					entry.type === "message" &&
+					entry.message.role === "bashExecution" &&
+					entry.message.command === "discarded-turn-command",
+			);
+		expect(bashEntry?.parentId).toBe(discardedAssistantEntry.id);
+		expect(
+			sessionManager
+				.getBranch()
+				.some(
+					entry =>
+						entry.type === "message" &&
+						entry.message.role === "bashExecution" &&
+						entry.message.command === "discarded-turn-command",
+				),
+		).toBe(false);
+	});
+
+	it("releases the bash owner when session transition preparation fails", async () => {
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const { completion, emitUserBash, extensionRunner } = createGatedBashRunner();
+		createSession(SessionManager.create(tempDir.path(), sessionDir), extensionRunner);
+		await seedPersistedSession();
+		const oldSessionId = session.sessionId;
+		const bashPromise = session.executeBash("old-session-command");
+		expect(emitUserBash).toHaveBeenCalledTimes(1);
+		vi.spyOn(session.sessionManager, "flush").mockRejectedValueOnce(new Error("synthetic flush failure"));
+
+		await expect(session.newSession()).rejects.toThrow("synthetic flush failure");
+		expect(session.sessionId).toBe(oldSessionId);
+		completion.resolve({ result: bashResult });
+		const settledResult = await bashPromise;
+
+		expect(settledResult).toEqual(bashResult);
+		expect(
+			session.messages.some(
+				message => message.role === "bashExecution" && message.command === "old-session-command",
+			),
+		).toBe(true);
+	});
+
+	it.each([
+		"new",
+		"switch",
+		"branch",
+	] as const)("records a late bash result in its original session after %s", async transition => {
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const { completion, emitUserBash, extensionRunner } = createGatedBashRunner();
+		createSession(SessionManager.create(tempDir.path(), sessionDir), extensionRunner);
+		const oldSessionFile = await seedPersistedSession();
+		const oldSessionId = session.sessionId;
+
+		const bashPromise = session.executeBash("old-session-command");
+		expect(emitUserBash).toHaveBeenCalledTimes(1);
+
+		switch (transition) {
+			case "new":
+				await session.newSession();
+				break;
+			case "switch": {
+				const targetManager = SessionManager.create(tempDir.path(), sessionDir);
+				targetManager.appendMessage({ role: "user", content: "target", timestamp: Date.now() });
+				targetManager.appendMessage(createAssistantMessage("target reply"));
+				await targetManager.ensureOnDisk();
+				const targetFile = targetManager.getSessionFile();
+				if (!targetFile) throw new Error("Expected target session file");
+				await targetManager.close();
+				await session.switchSession(targetFile);
+				break;
+			}
+			case "branch": {
+				const userEntry = session.sessionManager
+					.getEntries()
+					.find(entry => entry.type === "message" && entry.message.role === "user");
+				if (!userEntry) throw new Error("Expected user entry for branch");
+				await session.branch(userEntry.id);
+				break;
+			}
+		}
+
+		expect(session.sessionId).not.toBe(oldSessionId);
+		completion.resolve({ result: bashResult });
+		await bashPromise;
+
+		expect(
+			session.messages.some(
+				message => message.role === "bashExecution" && message.command === "old-session-command",
+			),
+		).toBe(false);
+
+		const oldSession = await SessionManager.open(oldSessionFile, sessionDir, undefined, {
+			initialCwd: tempDir.path(),
+			suppressBreadcrumb: true,
+		});
+		additionalManagers.push(oldSession);
+		const oldMessages = oldSession.getBranch().flatMap(entry => (entry.type === "message" ? [entry.message] : []));
+		expect(oldMessages.slice(-3).map(message => message.role)).toEqual(["user", "assistant", "bashExecution"]);
+		expect(oldMessages.at(-1)).toMatchObject({
+			role: "bashExecution",
+			command: "old-session-command",
+			output: "old-output",
+		});
+	});
+
+	it("stores minimized bash output with the originating session", async () => {
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		createSession(SessionManager.create(tempDir.path(), sessionDir));
+		const oldSessionFile = await seedPersistedSession();
+		const bashStarted = Promise.withResolvers<void>();
+		const finishBash = Promise.withResolvers<void>();
+		let artifactId: string | undefined;
+		vi.spyOn(bashExecutor, "executeBash").mockImplementation(async (_command, options) => {
+			bashStarted.resolve();
+			await finishBash.promise;
+			artifactId = await options?.onMinimizedSave?.("full old-session output", {
+				filter: "test",
+				inputBytes: 23,
+				outputBytes: 10,
+			});
+			return { ...bashResult, output: artifactId ? `[raw output: artifact://${artifactId}]` : "missing artifact" };
+		});
+
+		const bashPromise = session.executeBash("large old-session command");
+		await bashStarted.promise;
+		await session.newSession();
+		finishBash.resolve();
+		await bashPromise;
+
+		expect(artifactId).toBeDefined();
+		const oldSession = await SessionManager.open(oldSessionFile, sessionDir, undefined, {
+			initialCwd: tempDir.path(),
+			suppressBreadcrumb: true,
+		});
+		additionalManagers.push(oldSession);
+		const artifactPath = await oldSession.getArtifactPath(artifactId!);
+		expect(artifactPath).not.toBeNull();
+		expect(await Bun.file(artifactPath!).text()).toBe("full old-session output");
+		expect(await session.sessionManager.getArtifactPath(artifactId!)).toBeNull();
+		expect(
+			oldSession
+				.getBranch()
+				.some(
+					entry =>
+						entry.type === "message" &&
+						entry.message.role === "bashExecution" &&
+						entry.message.output.includes(`artifact://${artifactId}`),
+				),
+		).toBe(true);
+	});
+
+	it("does not recreate a dropped session for a late bash result or artifact", async () => {
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		createSession(SessionManager.create(tempDir.path(), sessionDir));
+		const oldSessionFile = await seedPersistedSession();
+		const oldArtifactsDir = oldSessionFile.slice(0, -6);
+		const bashStarted = Promise.withResolvers<void>();
+		const finishBash = Promise.withResolvers<void>();
+		vi.spyOn(bashExecutor, "executeBash").mockImplementation(async (_command, options) => {
+			bashStarted.resolve();
+			await finishBash.promise;
+			const artifactId = await options?.onMinimizedSave?.("discarded raw output", {
+				filter: "test",
+				inputBytes: 20,
+				outputBytes: 9,
+			});
+			return { ...bashResult, output: artifactId ? `[raw output: artifact://${artifactId}]` : "discarded" };
+		});
+
+		const bashPromise = session.executeBash("dropped-session-command");
+		await bashStarted.promise;
+		await session.newSession({ drop: true });
+		expect(fs.existsSync(oldSessionFile)).toBe(false);
+		expect(fs.existsSync(oldArtifactsDir)).toBe(false);
+
+		finishBash.resolve();
+		await bashPromise;
+
+		expect(fs.existsSync(oldSessionFile)).toBe(false);
+		expect(fs.existsSync(oldArtifactsDir)).toBe(false);
+		expect(
+			session.messages.some(
+				message => message.role === "bashExecution" && message.command === "dropped-session-command",
+			),
+		).toBe(false);
+	});
+
+	it("keeps a late bash result on the branch where it started", async () => {
+		const sessionDir = path.join(tempDir.path(), "sessions");
+		const { completion, extensionRunner } = createGatedBashRunner();
+		createSession(SessionManager.create(tempDir.path(), sessionDir), extensionRunner);
+		await session.prompt("first prompt");
+		await session.waitForIdle();
+		await session.prompt("second prompt");
+		await session.waitForIdle();
+
+		const firstUserEntry = session.sessionManager
+			.getEntries()
+			.find(entry => entry.type === "message" && entry.message.role === "user");
+		if (!firstUserEntry) throw new Error("Expected first user entry");
+		const originalLeafId = session.sessionManager.getLeafId();
+		if (!originalLeafId) throw new Error("Expected original branch leaf");
+
+		const bashPromise = session.executeBash("old-branch-command");
+		await session.navigateTree(firstUserEntry.id);
+		const navigatedLeafId = firstUserEntry.parentId;
+		expect(session.sessionManager.getLeafId()).toBe(navigatedLeafId);
+
+		completion.resolve({ result: bashResult });
+		await bashPromise;
+
+		const bashEntry = session.sessionManager
+			.getEntries()
+			.find(
+				entry =>
+					entry.type === "message" &&
+					entry.message.role === "bashExecution" &&
+					entry.message.command === "old-branch-command",
+			);
+		expect(bashEntry?.parentId).toBe(originalLeafId);
+		expect(session.sessionManager.getLeafId()).toBe(navigatedLeafId);
+		expect(
+			session.messages.some(message => message.role === "bashExecution" && message.command === "old-branch-command"),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
A user-initiated `bash` runs in the background so `abort_bash` and other RPC commands can proceed. If `new_session`, `switch_session`, `branch`, or a transcript-leaf rewrite happens before the bash finishes, `AgentSession` records the eventual result — and any minimized-output artifact — against whichever session/branch is active at completion, not the originator. Reproduced with a focused suite driving a real `AgentSession` + gated `user_bash` hook: `bun test packages/coding-agent/test/agent-session-bash-session-ownership.test.ts` (1 pass, 8 fail on `main`).

## Cause
In `packages/coding-agent/src/session/agent-session.ts`, `executeBash()` awaited execution then called `recordBashResult()`, which wrote through the mutable live `sessionManager`. `#pendingBashMessages` stored messages without session/branch ownership, and `#saveBashOriginalArtifact()` used the live manager too. Any session transition during execution therefore redirected both transcript entries and artifacts; a `/drop`ed session could even be recreated by a straggling result.

## Fix
- `SessionManager.cloneCurrentSession()` and `SessionManager.appendMessageToBranch()` (`session-manager.ts`) give callers an independent manager for the originating session and an off-leaf branch append.
- `AgentSession` captures a ref-counted `BashSessionTarget` when a bash starts; `#begin/#mark/#finishBashSessionTransition` snapshot the owner before each transition and resolve its append destination afterward — same file/leaf → current, moved leaf → off-leaf branch, changed file → detached clone, `/drop` → discard.
- `executeBash`, `recordBashResult`, `#saveBashOriginalArtifact`, and `#flushPendingBashMessages` route through the captured target; every transition site (`newSession`, `fork`, dispose/handoff, `switchSession`, `branch`, `branchFromBtw`, `navigateTree`, empty-stop leaf rewrites, rewind branch) wraps its mutation in a transition and releases ownership on failure.
- RPC dispatch concurrency and immediate `abort_bash` behavior are unchanged (that path was already background-dispatched on `main`).

## Verification
- `bun test packages/coding-agent/test/agent-session-bash-session-ownership.test.ts` → 9 pass (new/switch/branch late completion, streaming-queued results, empty-stop branch, minimized artifacts, intentional drop, transition-failure cleanup, tree navigation).
- `bun test` rpc-input-frame → 15 pass; branching, tree-navigation, handoff, bash-detach, btw-branch, checkpoint-rewind-branch, switch-prev-context, empty-stop-guard, fork-prompt-cache-key, session-manager-branch-order/internal-details → 72 pass / 13 skip; plus yield-empty-stop, gemini-header-interrupt, concurrent, session-messages, bash-executor, bash-execution-clamp → 119 pass.
- `bun --cwd=packages/coding-agent check` → clean (biome + tsgo).

Fixes #5743