### PR TITLE
fix(discovery): isolate Claude local marketplace plugins

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude Code marketplace plugins with `scope: "local"` leaking skills, hooks, tools, commands, and MCP servers into unrelated projects ([#5750](https://github.com/can1357/oh-my-pi/issues/5750)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -741,13 +741,16 @@ export function buildExtensionModuleItems(
  * Entry for an installed Claude Code plugin.
  */
 export interface ClaudePluginEntry {
-	scope: "user" | "project";
+	/** Claude registry scope; local entries are restricted to their project path. */
+	scope?: "user" | "project" | "local";
 	installPath: string;
 	version: string;
 	installedAt: string;
 	lastUpdated: string;
 	gitCommitSha?: string;
 	enabled?: boolean;
+	/** Project root recorded by Claude for a local installation. */
+	projectPath?: string;
 }
 
 /**
@@ -862,6 +865,14 @@ export async function resolveOrDefaultProjectRegistryPath(cwd: string): Promise<
 	return path.join(cwd, getConfigDirName(), "plugins", "installed_plugins.json");
 }
 
+async function canonicalClaudeProjectPath(projectPath: string): Promise<string | null> {
+	try {
+		return await fs.promises.realpath(path.resolve(projectPath));
+	} catch {
+		return null;
+	}
+}
+
 const pluginRootsCache = new Map<string, { roots: ClaudePluginRoot[]; warnings: string[] }>();
 
 const pluginCacheInvalidators = new Set<() => void>();
@@ -876,20 +887,23 @@ export function registerPluginCacheInvalidator(invalidator: () => void): void {
  * Reads ~/.claude/plugins/installed_plugins.json and ~/.omp/plugins/installed_plugins.json,
  * and optionally the nearest project-scoped registry resolved from `cwd`.
  *
- * Results are cached per `home:resolvedProjectPath` key to avoid repeated parsing.
+ * Results are cached per home, project registry, and canonical active project.
  */
 export async function listClaudePluginRoots(
 	home: string,
 	cwd?: string,
 ): Promise<{ roots: ClaudePluginRoot[]; warnings: string[] }> {
 	const resolvedProjectPath = cwd ? await resolveActiveProjectRegistryPath(cwd) : null;
-	const cacheKey = `${home}:${resolvedProjectPath ?? ""}`;
+	const projectRoot = resolvedProjectPath ? path.dirname(path.dirname(path.dirname(resolvedProjectPath))) : cwd;
+	const activeClaudeProjectPath = projectRoot ? await canonicalClaudeProjectPath(projectRoot) : null;
+	const cacheKey = `${home}:${resolvedProjectPath ?? ""}:${activeClaudeProjectPath ?? ""}`;
 	const cached = pluginRootsCache.get(cacheKey);
 	if (cached) return cached;
 
 	const roots: ClaudePluginRoot[] = [];
 	const warnings: string[] = [];
 	const projectRoots: ClaudePluginRoot[] = [];
+	const canonicalClaudeProjectPaths = new Map<string, string | null>();
 
 	// ── Claude Code registry ──────────────────────────────────────────────────
 	const registryPath = path.join(home, ".claude", "plugins", "installed_plugins.json");
@@ -921,6 +935,15 @@ export async function listClaudePluginRoots(
 						continue;
 					}
 					if (entry.enabled === false) continue;
+					if (entry.scope === "local") {
+						if (!entry.projectPath || !activeClaudeProjectPath) continue;
+						let entryProjectPath = canonicalClaudeProjectPaths.get(entry.projectPath);
+						if (entryProjectPath === undefined) {
+							entryProjectPath = await canonicalClaudeProjectPath(entry.projectPath);
+							canonicalClaudeProjectPaths.set(entry.projectPath, entryProjectPath);
+						}
+						if (entryProjectPath !== activeClaudeProjectPath) continue;
+					}
 
 					roots.push({
 						id: pluginId,
@@ -928,7 +951,7 @@ export async function listClaudePluginRoots(
 						plugin: pluginName,
 						version: entry.version || "unknown",
 						path: entry.installPath,
-						scope: entry.scope || "user",
+						scope: entry.scope === "local" ? "project" : entry.scope || "user",
 					});
 				}
 			}
@@ -976,7 +999,7 @@ export async function listClaudePluginRoots(
 						plugin: pluginName,
 						version: entry.version || "unknown",
 						path: entry.installPath,
-						scope: entry.scope || "user",
+						scope: entry.scope === "local" ? "project" : entry.scope || "user",
 					});
 				}
 			}

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -124,6 +124,44 @@ describe("listClaudePluginRoots", () => {
 		});
 	});
 
+	test("isolates local plugins to their canonical project", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const projectA = path.join(tempDir, "project-a");
+		const projectB = path.join(tempDir, "project-b");
+		const projectBAlias = path.join(tempDir, "project-b-alias");
+		const projectBSubdir = path.join(projectB, "packages", "app");
+		await Promise.all([
+			fs.mkdir(pluginsDir, { recursive: true }),
+			fs.mkdir(path.join(projectA, ".git"), { recursive: true }),
+			fs.mkdir(path.join(projectB, ".git"), { recursive: true }),
+			fs.mkdir(projectBSubdir, { recursive: true }),
+		]);
+		await fs.symlink(projectB, projectBAlias, "dir");
+
+		const entry = (scope: "user" | "local", installPath: string, projectPath?: string) => ({
+			scope,
+			installPath,
+			projectPath,
+			version: "1.0.0",
+			installedAt: "2025-01-01T00:00:00Z",
+			lastUpdated: "2025-01-01T00:00:00Z",
+		});
+		const registry = {
+			version: 2,
+			plugins: {
+				"user-plugin@market": [entry("user", "/plugins/user")],
+				"active-plugin@market": [entry("local", "/plugins/active", projectB)],
+				"foreign-plugin@market": [entry("local", "/plugins/foreign", projectA)],
+			},
+		};
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+
+		const result = await listClaudePluginRoots(tempDir, path.join(projectBAlias, "packages", "app"));
+
+		expect(result.roots.map(root => root.id)).toEqual(["user-plugin@market", "active-plugin@market"]);
+		expect(result.roots.find(root => root.id === "active-plugin@market")?.scope).toBe("project");
+	});
+
 	test("parses plugin with project scope", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		await fs.mkdir(pluginsDir, { recursive: true });


### PR DESCRIPTION
## Repro
A Claude `installed_plugins.json` containing a user entry, a matching `scope: "local"` entry, and a foreign-project local entry exposed all three roots when OMP launched from the matching project through a symlinked subdirectory. Reproduced with `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts --test-name-pattern "isolates local plugins"`; before the fix it failed because `foreign-plugin@market` remained in the discovered roots.

## Cause
`listClaudePluginRoots()` in `packages/coding-agent/src/discovery/helpers.ts` accepted every enabled Claude registry entry after validating `installPath`; it neither recognized Claude's `local` scope nor compared `projectPath` with the active project, and its cache key did not distinguish unanchored working directories.

## Fix
- Canonicalize the active project and each Claude local entry's `projectPath`, resolving symlinks and failing closed when a project path cannot be resolved.
- Exclude nonmatching local entries and expose matching local roots as project-scoped.
- Include the canonical active project in plugin-root cache isolation.
- Add a regression covering user, matching-local, foreign-local, nested-cwd, and symlinked-project behavior; document the fix in the changelog.

## Verification
`bun test packages/coding-agent/test/discovery/claude-plugins.test.ts packages/coding-agent/test/marketplace/project-scope.test.ts` passed: 39 tests, 97 assertions, 0 failures. `bun check` passed across all packages. Fixes #5750