### PR TITLE
fix(cli): bound print-mode mnemopi teardown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed headless `omp -p` waiting indefinitely after a completed turn when final mnemopi consolidation stalls; print mode now applies the same bounded consolidation shutdown budget as interactive exit and reaps the embed worker ([#5753](https://github.com/can1357/oh-my-pi/issues/5753)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -8,7 +8,7 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import { logger, sanitizeText } from "@oh-my-pi/pi-utils";
-import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
+import { type AgentSession, type AgentSessionEvent, SHUTDOWN_CONSOLIDATE_BUDGET_MS } from "../session/agent-session";
 import { isSilentAbort } from "../session/messages";
 import { flushTelemetryExport } from "../telemetry-export";
 import { initializeExtensions } from "./runtime-init";
@@ -152,7 +152,7 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				// OMP-owned Chromium survives this exit (issue #5643). `dispose()`
 				// is idempotent, so the unreachable call below is a harmless no-op.
 				await flushTelemetryExport();
-				await session.dispose();
+				await session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
 				const flushed = process.stderr.write(`${errorLine}\n`);
 				if (flushed) {
 					process.exit(1);
@@ -189,5 +189,5 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 		});
 	});
 
-	await session.dispose();
+	await session.dispose({ mnemopiConsolidateTimeoutMs: SHUTDOWN_CONSOLIDATE_BUDGET_MS });
 }

--- a/packages/coding-agent/test/silent-abort-print-mode.test.ts
+++ b/packages/coding-agent/test/silent-abort-print-mode.test.ts
@@ -9,7 +9,11 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "bun:
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
 import { runPrintMode } from "@oh-my-pi/pi-coding-agent/modes/print-mode";
-import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import {
+	type AgentSession,
+	type AgentSessionDisposeOptions,
+	SHUTDOWN_CONSOLIDATE_BUDGET_MS,
+} from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 
 function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
@@ -34,7 +38,10 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
 }
 
 /** Minimal mock of AgentSession for print-mode text output path */
-function createMockSession(messages: AssistantMessage[]): AgentSession {
+function createMockSession(
+	messages: AssistantMessage[],
+	dispose: (options?: AgentSessionDisposeOptions) => Promise<void> = async () => {},
+): AgentSession {
 	return {
 		state: { messages },
 		sessionManager: {
@@ -43,7 +50,7 @@ function createMockSession(messages: AssistantMessage[]): AgentSession {
 		extensionRunner: undefined,
 		subscribe: () => () => {},
 		prompt: async () => {},
-		dispose: async () => {},
+		dispose,
 	} as unknown as AgentSession;
 }
 
@@ -89,6 +96,17 @@ describe("Print-mode silent-abort regression", () => {
 		expect(stderrText).not.toContain(SILENT_ABORT_MARKER);
 		// process.exit MUST NOT have been called (clean termination)
 		expect(exitSpy).not.toHaveBeenCalled();
+	});
+
+	it("bounds final memory consolidation so print mode can exit", async () => {
+		let disposeOptions: AgentSessionDisposeOptions | undefined;
+		const session = createMockSession([makeAssistantMessage()], async options => {
+			disposeOptions = options;
+		});
+
+		await runPrintMode(session, { mode: "text" });
+
+		expect(disposeOptions?.mnemopiConsolidateTimeoutMs).toBe(SHUTDOWN_CONSOLIDATE_BUDGET_MS);
 	});
 
 	it("does not write bit-classified silent aborts to stderr or exit non-zero", async () => {


### PR DESCRIPTION
## Repro
A completed headless turn can remain alive when final mnemopi consolidation stalls because the embed subprocess is not terminated until session disposal advances past consolidation. `bun test packages/coding-agent/test/silent-abort-print-mode.test.ts` reproduced the missing bound with `Expected: 1500, Received: undefined` for print-mode disposal.

## Cause
`runPrintMode()` in `packages/coding-agent/src/modes/print-mode.ts` called `AgentSession.dispose()` without `mnemopiConsolidateTimeoutMs` on both normal and assistant-error exits. `AgentSession.#doDispose()` waits for `MnemopiSessionState.dispose()` before reaching `shutdownMnemopiEmbedClient()`, so a stalled final consolidation kept the parent CLI and `__omp_worker_mnemopi_embed` child alive indefinitely.

## Fix
- Pass `SHUTDOWN_CONSOLIDATE_BUDGET_MS` through print-mode session disposal on normal completion.
- Apply the same bound before the assistant-error hard exit.
- Add regression coverage asserting that print mode uses the bounded mnemopi shutdown contract.
- Record the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/silent-abort-print-mode.test.ts` passes with 5 tests and 9 assertions. `bun run check` passes in `packages/coding-agent`. Fixes #5753