### PR TITLE
fix(coding-agent): restored xdev for explicit tool sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 - `retry.fallbackChains` wildcards now support id-prefixed targets and keys: a chain entry like `"openrouter/google/*"` re-prefixes the failing model's bare id (`google-antigravity/gemini-x` → `openrouter/google/gemini-x`), a plain `"provider/*"` entry falling back *from* an aggregator strips the vendor prefix when the target provider only knows the bare id (`openrouter/google/x` → `google-vertex/x`), and an id-prefixed key (`"openrouter/google/*"`) scopes a chain to that provider's ids under the prefix.
+### Fixed
+
+- Fixed explicit-tool sessions bypassing `xd://` presentation for ambient discoverable custom and MCP tools, which sent their schemas top-level and could exceed provider tool limits or trigger schema-compatibility errors.
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2120,11 +2120,11 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async #clearTransientModeState(): Promise<void> {
 		if (this.planModeEnabled || this.planModePaused) {
+			this.session.setPlanModeState(undefined);
 			if (this.#planModePreviousTools !== undefined) {
 				await this.session.setActiveToolsByName(this.#planModePreviousTools);
 			}
 			this.session.setPlanProposalHandler?.(null);
-			this.session.setPlanModeState(undefined);
 			this.planModeEnabled = false;
 			this.planModePaused = false;
 			this.planModePlanFilePath = undefined;
@@ -2345,6 +2345,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
+		this.session.setPlanModeState(undefined);
 		const previousTools = this.#planModePreviousTools;
 		if (previousTools && previousTools.length > 0) {
 			await this.session.setActiveToolsByName(previousTools);
@@ -2371,7 +2372,6 @@ export class InteractiveMode implements InteractiveModeContext {
 			}
 		}
 		this.session.setPlanProposalHandler?.(null);
-		this.session.setPlanModeState(undefined);
 		this.planModeEnabled = false;
 		// Suppress cache-miss marker on the next turn: plan exit changes the system
 		// prompt, which predictably invalidates the cache.

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2121,18 +2121,21 @@ export class InteractiveMode implements InteractiveModeContext {
 	async #clearTransientModeState(): Promise<void> {
 		if (this.planModeEnabled || this.planModePaused) {
 			this.session.setPlanModeState(undefined);
-			if (this.#planModePreviousTools !== undefined) {
-				await this.session.setActiveToolsByName(this.#planModePreviousTools);
+			try {
+				if (this.#planModePreviousTools !== undefined) {
+					await this.session.setActiveToolsByName(this.#planModePreviousTools);
+				}
+			} finally {
+				this.session.setPlanProposalHandler?.(null);
+				this.planModeEnabled = false;
+				this.planModePaused = false;
+				this.planModePlanFilePath = undefined;
+				this.#planModePreviousTools = undefined;
+				this.#planModePreviousModelState = undefined;
+				this.#pendingModelSwitch = undefined;
+				this.#planModeHasEntered = false;
+				this.#updatePlanModeStatus();
 			}
-			this.session.setPlanProposalHandler?.(null);
-			this.planModeEnabled = false;
-			this.planModePaused = false;
-			this.planModePlanFilePath = undefined;
-			this.#planModePreviousTools = undefined;
-			this.#planModePreviousModelState = undefined;
-			this.#pendingModelSwitch = undefined;
-			this.#planModeHasEntered = false;
-			this.#updatePlanModeStatus();
 		}
 
 		if (this.goalModeEnabled || this.goalModePaused) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2345,10 +2345,15 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
+		const planModeState = this.session.getPlanModeState();
 		this.session.setPlanModeState(undefined);
-		const previousTools = this.#planModePreviousTools;
-		if (previousTools && previousTools.length > 0) {
-			await this.session.setActiveToolsByName(previousTools);
+		try {
+			if (this.#planModePreviousTools !== undefined) {
+				await this.session.setActiveToolsByName(this.#planModePreviousTools);
+			}
+		} catch (error) {
+			this.session.setPlanModeState(planModeState);
+			throw error;
 		}
 		if (this.#planModePreviousModelState) {
 			if (!options?.deferModelRestore) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -2349,19 +2349,45 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		const planModeState = this.session.getPlanModeState();
+		const planModeTools = this.session.getActiveToolNames();
+		const planModeModelState = this.session.model
+			? { model: this.session.model, thinkingLevel: this.session.configuredThinkingLevel() }
+			: undefined;
 		this.session.setPlanModeState(undefined);
 		try {
 			if (this.#planModePreviousTools !== undefined) {
 				await this.session.setActiveToolsByName(this.#planModePreviousTools);
 			}
+			if (this.#planModePreviousModelState && !options?.deferModelRestore) {
+				await this.#restorePlanPreviousModel(this.#planModePreviousModelState);
+			}
 		} catch (error) {
 			this.session.setPlanModeState(planModeState);
+			if (
+				planModeModelState &&
+				(!modelsAreEqual(this.session.model, planModeModelState.model) ||
+					this.session.configuredThinkingLevel() !== planModeModelState.thinkingLevel)
+			) {
+				try {
+					await this.#restorePlanPreviousModel(planModeModelState);
+				} catch (rollbackError) {
+					logger.warn("Failed to restore plan model after plan exit failure", { error: String(rollbackError) });
+				}
+			}
+			const activeTools = this.session.getActiveToolNames();
+			if (
+				activeTools.length !== planModeTools.length ||
+				activeTools.some((name, index) => name !== planModeTools[index])
+			) {
+				try {
+					await this.session.setActiveToolsByName(planModeTools);
+				} catch (rollbackError) {
+					logger.warn("Failed to restore plan tools after plan exit failure", { error: String(rollbackError) });
+				}
+			}
 			throw error;
 		}
 		if (this.#planModePreviousModelState) {
-			if (!options?.deferModelRestore) {
-				await this.#restorePlanPreviousModel(this.#planModePreviousModelState);
-			}
 			// If #applyPlanModeModel queued a deferred switch to the plan-role model
 			// (because the session was streaming on entry), drop it now: we are
 			// leaving plan mode, so flushing it on the next agent_end would land the

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2247,15 +2247,21 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			builtInRegistryToolNames.delete("edit");
 		}
 
-		const ensureWriteRegistered = async (): Promise<void> => {
-			if (toolRegistry.has("write")) return;
-			const writeTool = await logger.time("createTools:write:session", BUILTIN_TOOLS.write, toolSession);
-			if (!writeTool) return;
-			toolRegistry.set(
-				writeTool.name,
-				new ExtensionToolWrapper(wrapToolWithMetaNotice(writeTool), extensionRunner) as Tool,
-			);
-			builtInRegistryToolNames.add(writeTool.name);
+		let writeRegistration: Promise<void> | undefined;
+		const ensureWriteRegistered = (): Promise<void> => {
+			if (toolRegistry.has("write")) return Promise.resolve();
+			writeRegistration ??= (async () => {
+				const writeTool = await logger.time("createTools:write:session", BUILTIN_TOOLS.write, toolSession);
+				if (!writeTool || toolRegistry.has("write")) return;
+				toolRegistry.set(
+					writeTool.name,
+					new ExtensionToolWrapper(wrapToolWithMetaNotice(writeTool), extensionRunner) as Tool,
+				);
+				builtInRegistryToolNames.add(writeTool.name);
+			})().finally(() => {
+				writeRegistration = undefined;
+			});
+			return writeRegistration;
 		};
 
 		// Existing staged/device paths need write registered before active-set assembly.
@@ -2768,6 +2774,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			initialMountedXdevToolNames,
 			presentationPinnedToolNames: explicitlyRequestedToolNameSet,
 			setActiveToolNames,
+			ensureWriteRegistered,
 			getMcpServerInstructions: mcpManager
 				? () => {
 						const raw = mcpManager.getServerInstructions();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2412,7 +2412,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 		const requestedToolNames = explicitlyRequestedToolNames ?? toolNamesFromRegistry;
 		const normalizedRequested = requestedToolNames.filter(name => toolRegistry.has(name));
-		const requestedToolNameSet = new Set(normalizedRequested);
 		const defaultInactiveToolNames = new Set(
 			registeredTools.filter(tool => tool.definition.defaultInactive).map(tool => tool.definition.name),
 		);
@@ -2767,7 +2766,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getXdevToolEntries: () => toolSession.xdevRegistry?.entries() ?? [],
 			xdevRegistry: toolSession.xdevRegistry,
 			initialMountedXdevToolNames,
-			requestedToolNames: requestedToolNameSet,
+			presentationPinnedToolNames: explicitlyRequestedToolNameSet,
 			setActiveToolNames,
 			getMcpServerInstructions: mcpManager
 				? () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2427,7 +2427,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			? new Set(explicitlyRequestedToolNames)
 			: undefined;
 		const xdevReadAvailable =
-			explicitlyRequestedToolNameSet === undefined || explicitlyRequestedToolNameSet.has("read");
+			builtInRegistryToolNames.has("read") &&
+			(explicitlyRequestedToolNameSet === undefined || explicitlyRequestedToolNameSet.has("read"));
 		const initialRequestedActiveToolNames = options.toolNames
 			? requestedActiveToolNames
 			: requestedActiveToolNames.filter(name => !defaultInactiveToolNames.has(name));

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2425,6 +2425,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const explicitlyRequestedToolNameSet = explicitlyRequestedToolNames
 			? new Set(explicitlyRequestedToolNames)
 			: undefined;
+		const xdevReadAvailable =
+			explicitlyRequestedToolNameSet === undefined || explicitlyRequestedToolNameSet.has("read");
 		const initialRequestedActiveToolNames = options.toolNames
 			? requestedActiveToolNames
 			: requestedActiveToolNames.filter(name => !defaultInactiveToolNames.has(name));
@@ -2468,7 +2470,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			for (const name of initialToolNames) {
 				const tool = toolRegistry.get(name);
 				const explicitlyRequested = explicitlyRequestedToolNameSet?.has(name) === true;
-				if (tool && !explicitlyRequested && isMountableUnderXdev(tool)) mountedTools.push(tool);
+				if (tool && xdevReadAvailable && !explicitlyRequested && isMountableUnderXdev(tool))
+					mountedTools.push(tool);
 				else topLevelToolNames.push(name);
 			}
 			toolSession.xdevRegistry.reconcile(mountedTools);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2247,25 +2247,24 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			builtInRegistryToolNames.delete("edit");
 		}
 
-		// Staged actions (tool previews, plan approval) resolve through `write`
-		// to the resolution devices (`xd://resolve`, `xd://reject`,
-		// `xd://propose`), so `write` must stay in the registry whenever any
-		// code path can stage one: a deferrable tool, or plan mode installing a
-		// plan-proposal handler (issue #1428). Dropping it on read-only sessions
-		// (e.g. plan-mode toolset `read`, `search`, `find`, `web_search`) leaves
-		// plan mode unable to exit through the intended path.
+		const ensureWriteRegistered = async (): Promise<void> => {
+			if (toolRegistry.has("write")) return;
+			const writeTool = await logger.time("createTools:write:session", BUILTIN_TOOLS.write, toolSession);
+			if (!writeTool) return;
+			toolRegistry.set(
+				writeTool.name,
+				new ExtensionToolWrapper(wrapToolWithMetaNotice(writeTool), extensionRunner) as Tool,
+			);
+			builtInRegistryToolNames.add(writeTool.name);
+		};
+
+		// Existing staged/device paths need write registered before active-set assembly.
+		// Deferred MCP also registers it now, but refresh activates it only after a server connects.
 		const hasDeferrableTools = Array.from(toolRegistry.values()).some(tool => tool.deferrable === true);
 		const hasXdevTools = (toolSession.xdevRegistry?.size ?? 0) > 0;
 		const planModeAvailable = settings.get("plan.enabled");
-		if ((hasDeferrableTools || hasXdevTools || planModeAvailable) && !toolRegistry.has("write")) {
-			const writeTool = await logger.time("createTools:write:session", BUILTIN_TOOLS.write, toolSession);
-			if (writeTool) {
-				toolRegistry.set(
-					writeTool.name,
-					new ExtensionToolWrapper(wrapToolWithMetaNotice(writeTool), extensionRunner) as Tool,
-				);
-				builtInRegistryToolNames.add(writeTool.name);
-			}
+		if (hasDeferrableTools || hasXdevTools || planModeAvailable || deferMCPDiscoveryForUI) {
+			await ensureWriteRegistered();
 		}
 
 		let cursorEventEmitter: ((event: AgentEvent) => void) | undefined;
@@ -2418,6 +2417,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			registeredTools.filter(tool => tool.definition.defaultInactive).map(tool => tool.definition.name),
 		);
 		const requestedActiveToolNames = normalizedRequested.filter(name => name !== "goal");
+		const explicitlyRequestedToolNameSet = explicitlyRequestedToolNames
+			? new Set(explicitlyRequestedToolNames)
+			: undefined;
 		const initialRequestedActiveToolNames = options.toolNames
 			? requestedActiveToolNames
 			: requestedActiveToolNames.filter(name => !defaultInactiveToolNames.has(name));
@@ -2449,24 +2451,28 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		});
 		hasRegistered = true;
 
-		// Partition the initial enabled set for the xd:// transport: discoverable
-		// tools become mounted devices; the rest stay top-level. The registry
-		// already holds the built-in devices (mounted in createTools); this
-		// reconciles the initial dynamic mounts (image-gen, TTS, startup MCP,
-		// active extension tools) and drops them from the top-level names so they
-		// never ship a schema. Presentation only — selection already happened.
+		// Partition the initial enabled set for the xd:// transport: ambient
+		// discoverable tools become mounted devices, while explicitly requested
+		// tools keep their top-level presentation. The registry already holds the
+		// default-set built-in devices from createTools; this reconciles dynamic
+		// mounts (image-gen, TTS, startup MCP, active extension tools).
 		let initialMountedXdevToolNames: string[] = [];
 		if (toolSession.xdevRegistry) {
 			const topLevelToolNames: string[] = [];
 			const mountedTools: Tool[] = [];
 			for (const name of initialToolNames) {
 				const tool = toolRegistry.get(name);
-				if (tool && isMountableUnderXdev(tool)) mountedTools.push(tool);
+				const explicitlyRequested = explicitlyRequestedToolNameSet?.has(name) === true;
+				if (tool && !explicitlyRequested && isMountableUnderXdev(tool)) mountedTools.push(tool);
 				else topLevelToolNames.push(name);
 			}
 			toolSession.xdevRegistry.reconcile(mountedTools);
 			initialMountedXdevToolNames = mountedTools.map(tool => tool.name);
 			initialToolNames = topLevelToolNames;
+			if (initialMountedXdevToolNames.length > 0) {
+				await ensureWriteRegistered();
+				if (!initialToolNames.includes("write")) initialToolNames.push("write");
+			}
 		}
 
 		setActiveToolNames(initialToolNames);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2247,17 +2247,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			builtInRegistryToolNames.delete("edit");
 		}
 
-		let writeRegistration: Promise<void> | undefined;
-		const ensureWriteRegistered = (): Promise<void> => {
-			if (toolRegistry.has("write")) return Promise.resolve();
+		let writeRegistration: Promise<boolean> | undefined;
+		const ensureWriteRegistered = (): Promise<boolean> => {
+			if (toolRegistry.has("write")) return Promise.resolve(builtInRegistryToolNames.has("write"));
 			writeRegistration ??= (async () => {
 				const writeTool = await logger.time("createTools:write:session", BUILTIN_TOOLS.write, toolSession);
-				if (!writeTool || toolRegistry.has("write")) return;
+				if (!writeTool || toolRegistry.has("write")) return builtInRegistryToolNames.has("write");
 				toolRegistry.set(
 					writeTool.name,
 					new ExtensionToolWrapper(wrapToolWithMetaNotice(writeTool), extensionRunner) as Tool,
 				);
 				builtInRegistryToolNames.add(writeTool.name);
+				return true;
 			})().finally(() => {
 				writeRegistration = undefined;
 			});
@@ -2474,12 +2475,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					mountedTools.push(tool);
 				else topLevelToolNames.push(name);
 			}
-			toolSession.xdevRegistry.reconcile(mountedTools);
-			initialMountedXdevToolNames = mountedTools.map(tool => tool.name);
-			initialToolNames = topLevelToolNames;
-			if (initialMountedXdevToolNames.length > 0) {
-				await ensureWriteRegistered();
-				if (!initialToolNames.includes("write")) initialToolNames.push("write");
+			const writeTransportAvailable = mountedTools.length === 0 || (await ensureWriteRegistered());
+			if (writeTransportAvailable) {
+				toolSession.xdevRegistry.reconcile(mountedTools);
+				initialMountedXdevToolNames = mountedTools.map(tool => tool.name);
+				initialToolNames = topLevelToolNames;
+				if (initialMountedXdevToolNames.length > 0 && !initialToolNames.includes("write"))
+					initialToolNames.push("write");
+			} else {
+				toolSession.xdevRegistry.reconcile([]);
 			}
 		}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1963,6 +1963,7 @@ export class AgentSession {
 	#ensureWriteRegistered: (() => Promise<void>) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
+	#runtimeSelectedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
 	#baseSystemPromptBeforeMemoryPromotion: string[] | undefined;
 	/**
@@ -6780,18 +6781,18 @@ export class AgentSession {
 		const validToolNames: string[] = [];
 		const mountedTools: AgentTool[] = [];
 		const xdevReadAvailable =
-			this.#presentationPinnedToolNames === undefined || this.#presentationPinnedToolNames.has("read");
+			(this.#presentationPinnedToolNames === undefined && this.#runtimeSelectedToolNames === undefined) ||
+			this.#presentationPinnedToolNames?.has("read") === true ||
+			this.#runtimeSelectedToolNames?.has("read") === true;
+
 		for (const name of toolNames) {
 			const tool = this.#toolRegistry.get(name);
 			if (!tool) continue;
 			// Discoverable tools are presented as `xd://` devices (kept out of the
-			// top-level schema) when the transport is active; presentation pins stay top-level.
-			if (
-				this.#xdevRegistry &&
-				xdevReadAvailable &&
-				this.#presentationPinnedToolNames?.has(name) !== true &&
-				isMountableUnderXdev(tool)
-			) {
+			// top-level schema) when read transport is available; presentation pins stay top-level.
+			const presentationPinned =
+				this.#presentationPinnedToolNames?.has(name) === true || this.#runtimeSelectedToolNames?.has(name) === true;
+			if (this.#xdevRegistry && xdevReadAvailable && !presentationPinned && isMountableUnderXdev(tool)) {
 				mountedTools.push(tool);
 			} else {
 				tools.push(this.#wrapToolForAcpPermission(tool));
@@ -6799,10 +6800,12 @@ export class AgentSession {
 			}
 		}
 
-		const pinnedWrite = this.#presentationPinnedToolNames?.has("write") === true;
+		const pinnedWrite =
+			this.#presentationPinnedToolNames?.has("write") === true ||
+			this.#runtimeSelectedToolNames?.has("write") === true;
 		const activeDeferrableTool = tools.some(tool => tool.deferrable === true);
 		const transportNeeded =
-			mountedTools.length > 0 || activeDeferrableTool || this.settings.get("plan.enabled") || pinnedWrite;
+			mountedTools.length > 0 || activeDeferrableTool || this.#planModeState?.enabled === true || pinnedWrite;
 		if (transportNeeded) {
 			await this.#ensureWriteRegistered?.();
 			const write = this.#toolRegistry.get("write");
@@ -6810,25 +6813,23 @@ export class AgentSession {
 				tools.push(this.#wrapToolForAcpPermission(write));
 				validToolNames.push("write");
 			}
-		} else if (this.#presentationPinnedToolNames !== undefined) {
+		} else if (this.#presentationPinnedToolNames !== undefined || this.#runtimeSelectedToolNames !== undefined) {
 			const writeNameIndex = validToolNames.indexOf("write");
 			if (writeNameIndex >= 0) validToolNames.splice(writeNameIndex, 1);
 			const writeToolIndex = tools.findIndex(tool => tool.name === "write");
 			if (writeToolIndex >= 0) tools.splice(writeToolIndex, 1);
 		}
 
-		// Reconcile dynamic `xd://` mounts; absent tools must not remain callable.
+		// Reconcile dynamic `xd://` mounts; removed devices must not stay callable.
 		const previousMounted = this.#mountedXdevToolNames;
 		this.#mountedXdevToolNames = new Set(mountedTools.map(tool => tool.name));
 		this.#xdevRegistry?.reconcile(mountedTools);
 		this.#notifyXdevMountDelta(previousMounted);
 		this.#setActiveToolNames?.(validToolNames);
 		this.agent.setTools(tools);
-		// Rebuild base system prompt with new tool set, but only when the tool set
-		// actually changed. MCP servers can reconnect at arbitrary times and call
-		// `refreshMCPTools` -> `#applyActiveToolsByName` even though the resulting
-		// tool list is byte-identical. Skipping the rebuild keeps the system prompt
-		// stable, which is required for Anthropic prompt caching to keep hitting.
+
+		// Rebuild only when the top-level tool signature changes. Mount deltas are
+		// announced separately so provider prompt-cache prefixes stay stable.
 		if (this.#rebuildSystemPrompt) {
 			const signature = this.#computeAppliedToolSignature(validToolNames, tools);
 			if (signature !== this.#lastAppliedToolSignature) {
@@ -6911,6 +6912,7 @@ export class AgentSession {
 	 * Changes take effect before the next model call.
 	 */
 	async setActiveToolsByName(toolNames: string[]): Promise<void> {
+		this.#runtimeSelectedToolNames = new Set(normalizeToolNames(toolNames));
 		await this.#applyActiveToolsByName(toolNames);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2454,12 +2454,12 @@ export class AgentSession {
 			readPlan: url => this.#readPlanYoloFile(url),
 			listPlanFiles: () => this.#listPlanYoloFiles(),
 		});
+		this.setPlanModeState(undefined);
 		const previousTools = this.#planYoloPreviousTools;
 		if (previousTools) {
 			await this.setActiveToolsByName(previousTools);
 		}
 		this.setPlanProposalHandler(null);
-		this.setPlanModeState(undefined);
 		this.#planYolo = undefined;
 		this.#planYoloPreviousTools = undefined;
 		await this.setModelTemporary(planYolo.target, planYolo.thinkingLevel, { ephemeral: true });

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7054,9 +7054,20 @@ export class AgentSession {
 			this.#toolRegistry.set(finalTool.name, finalTool);
 		}
 
-		// Every connected MCP tool is enabled; re-derive the active set from the
-		// current non-MCP tools plus all freshly registered MCP tools.
+		// Every connected MCP tool is enabled. When xdev presents them as devices,
+		// keep the registered write transport active so they remain callable.
 		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...mcpTools.map(tool => tool.name)])];
+		if (
+			this.#xdevRegistry &&
+			mcpTools.some(tool => {
+				const registered = this.#toolRegistry.get(tool.name);
+				return registered !== undefined && isMountableUnderXdev(registered);
+			}) &&
+			this.#toolRegistry.has("write") &&
+			!nextActive.includes("write")
+		) {
+			nextActive.push("write");
+		}
 		await this.#applyActiveToolsByName(nextActive);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6923,7 +6923,8 @@ export class AgentSession {
 	 * Changes take effect before the next model call.
 	 */
 	async setActiveToolsByName(toolNames: string[]): Promise<void> {
-		this.#runtimeSelectedToolNames = new Set(normalizeToolNames(toolNames));
+		const mounted = this.#mountedXdevToolNames;
+		this.#runtimeSelectedToolNames = new Set(normalizeToolNames(toolNames).filter(name => !mounted.has(name)));
 		await this.#applyActiveToolsByName(toolNames);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7467,6 +7467,11 @@ export class AgentSession {
 			.filter((tool): tool is AgentTool => tool !== undefined)
 			.map(tool => this.#wrapToolForAcpPermission(tool));
 		this.agent.setTools(activeTools);
+		const mountedTools = [...this.#mountedXdevToolNames]
+			.map(name => this.#toolRegistry.get(name))
+			.filter((tool): tool is AgentTool => tool !== undefined)
+			.map(tool => this.#wrapToolForAcpPermission(tool));
+		this.#xdevRegistry?.reconcile(mountedTools);
 	}
 
 	#clearCheckpointRuntimeState(): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -844,7 +844,7 @@ export interface AgentSessionConfig {
 	/** Update tool-session predicates that render guidance from the live active tool set. */
 	setActiveToolNames?: (names: Iterable<string>) => void;
 	/** Register the write transport lazily when runtime xdev mounts first need it. */
-	ensureWriteRegistered?: () => Promise<void>;
+	ensureWriteRegistered?: () => Promise<boolean>;
 	/** Current session pre-LLM message transform pipeline */
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	/**
@@ -1960,7 +1960,7 @@ export class AgentSession {
 	#getLocalCalendarDate: () => string;
 	#getMcpServerInstructions: (() => Map<string, string> | undefined) | undefined;
 	#setActiveToolNames: ((names: Iterable<string>) => void) | undefined;
-	#ensureWriteRegistered: (() => Promise<void>) | undefined;
+	#ensureWriteRegistered: (() => Promise<boolean>) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
 	#runtimeSelectedToolNames: ReadonlySet<string> | undefined;
@@ -6777,22 +6777,35 @@ export class AgentSession {
 
 	async #applyActiveToolsByName(toolNames: string[]): Promise<void> {
 		toolNames = normalizeToolNames(toolNames);
-		const tools: AgentTool[] = [];
-		const validToolNames: string[] = [];
-		const mountedTools: AgentTool[] = [];
+		const selectedTools = toolNames.flatMap(name => {
+			const tool = this.#toolRegistry.get(name);
+			return tool ? [{ name, tool }] : [];
+		});
 		const xdevReadAvailable =
 			(this.#presentationPinnedToolNames === undefined && this.#runtimeSelectedToolNames === undefined) ||
 			this.#presentationPinnedToolNames?.has("read") === true ||
 			this.#runtimeSelectedToolNames?.has("read") === true;
+		const isPresentationPinned = (name: string): boolean =>
+			this.#presentationPinnedToolNames?.has(name) === true || this.#runtimeSelectedToolNames?.has(name) === true;
+		const mountCandidates = selectedTools.filter(
+			({ name, tool }) =>
+				this.#xdevRegistry !== undefined &&
+				xdevReadAvailable &&
+				!isPresentationPinned(name) &&
+				isMountableUnderXdev(tool),
+		);
 
-		for (const name of toolNames) {
-			const tool = this.#toolRegistry.get(name);
-			if (!tool) continue;
-			// Discoverable tools are presented as `xd://` devices (kept out of the
-			// top-level schema) when read transport is available; presentation pins stay top-level.
-			const presentationPinned =
-				this.#presentationPinnedToolNames?.has(name) === true || this.#runtimeSelectedToolNames?.has(name) === true;
-			if (this.#xdevRegistry && xdevReadAvailable && !presentationPinned && isMountableUnderXdev(tool)) {
+		let builtInWriteAvailable = this.#builtInToolNames.has("write");
+		if (mountCandidates.length > 0 && !builtInWriteAvailable) {
+			builtInWriteAvailable = (await this.#ensureWriteRegistered?.()) === true;
+			if (builtInWriteAvailable) this.#builtInToolNames.add("write");
+		}
+		const mountNames = builtInWriteAvailable ? new Set(mountCandidates.map(({ name }) => name)) : new Set<string>();
+		const tools: AgentTool[] = [];
+		const validToolNames: string[] = [];
+		const mountedTools: AgentTool[] = [];
+		for (const { name, tool } of selectedTools) {
+			if (mountNames.has(name)) {
 				mountedTools.push(tool);
 			} else {
 				tools.push(this.#wrapToolForAcpPermission(tool));
@@ -6800,27 +6813,29 @@ export class AgentSession {
 			}
 		}
 
-		const pinnedWrite =
-			this.#presentationPinnedToolNames?.has("write") === true ||
-			this.#runtimeSelectedToolNames?.has("write") === true;
+		const pinnedWrite = isPresentationPinned("write");
 		const activeDeferrableTool = tools.some(tool => tool.deferrable === true);
-		const transportNeeded =
-			mountedTools.length > 0 || activeDeferrableTool || this.#planModeState?.enabled === true || pinnedWrite;
-		if (transportNeeded) {
-			await this.#ensureWriteRegistered?.();
+		const transportNeeded = mountedTools.length > 0 || activeDeferrableTool || this.#planModeState?.enabled === true;
+		if (transportNeeded && !builtInWriteAvailable) {
+			builtInWriteAvailable = (await this.#ensureWriteRegistered?.()) === true;
+			if (builtInWriteAvailable) this.#builtInToolNames.add("write");
+		}
+		if (transportNeeded && builtInWriteAvailable) {
 			const write = this.#toolRegistry.get("write");
 			if (write && !validToolNames.includes("write")) {
 				tools.push(this.#wrapToolForAcpPermission(write));
 				validToolNames.push("write");
 			}
-		} else if (this.#presentationPinnedToolNames !== undefined || this.#runtimeSelectedToolNames !== undefined) {
+		} else if (
+			!pinnedWrite &&
+			(this.#presentationPinnedToolNames !== undefined || this.#runtimeSelectedToolNames !== undefined)
+		) {
 			const writeNameIndex = validToolNames.indexOf("write");
-			if (writeNameIndex >= 0) validToolNames.splice(writeNameIndex, 1);
-			const writeToolIndex = tools.findIndex(tool => tool.name === "write");
+			if (writeNameIndex >= 0 && this.#builtInToolNames.has("write")) validToolNames.splice(writeNameIndex, 1);
+			const writeToolIndex = tools.findIndex(tool => tool.name === "write" && this.#builtInToolNames.has("write"));
 			if (writeToolIndex >= 0) tools.splice(writeToolIndex, 1);
 		}
 
-		// Reconcile dynamic `xd://` mounts; removed devices must not stay callable.
 		const previousMounted = this.#mountedXdevToolNames;
 		this.#mountedXdevToolNames = new Set(mountedTools.map(tool => tool.name));
 		this.#xdevRegistry?.reconcile(mountedTools);
@@ -6828,14 +6843,10 @@ export class AgentSession {
 		this.#setActiveToolNames?.(validToolNames);
 		this.agent.setTools(tools);
 
-		// Rebuild only when the top-level tool signature changes. Mount deltas are
-		// announced separately so provider prompt-cache prefixes stay stable.
 		if (this.#rebuildSystemPrompt) {
 			const signature = this.#computeAppliedToolSignature(validToolNames, tools);
 			if (signature !== this.#lastAppliedToolSignature) {
-				if (this.#lastAppliedToolSignature !== undefined) {
-					this.#clearInheritedProviderPromptCacheKey();
-				}
+				if (this.#lastAppliedToolSignature !== undefined) this.#clearInheritedProviderPromptCacheKey();
 				const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
 				this.#baseSystemPrompt = built.systemPrompt;
 				this.#baseSystemPromptBeforeMemoryPromotion = undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -889,7 +889,8 @@ export interface AgentSessionConfig {
 	xdevRegistry?: XdevRegistry;
 	/** Discoverable tools mounted under `xd://` in the initial enabled set (startup partition in `sdk.ts`). */
 	initialMountedXdevToolNames?: string[];
-	requestedToolNames?: ReadonlySet<string>;
+	/** Explicit/effective names pinned top-level during runtime repartitioning. */
+	presentationPinnedToolNames?: ReadonlySet<string>;
 	/**
 	 * Optional accessor for live MCP server instructions. Read by the session's
 	 * `rebuildSystemPrompt`-skip optimization to detect server-side instruction
@@ -1958,7 +1959,7 @@ export class AgentSession {
 	#getMcpServerInstructions: (() => Map<string, string> | undefined) | undefined;
 	#setActiveToolNames: ((names: Iterable<string>) => void) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
-	#requestedToolNames: ReadonlySet<string> | undefined;
+	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
 	#baseSystemPromptBeforeMemoryPromotion: string[] | undefined;
 	/**
@@ -2562,7 +2563,7 @@ export class AgentSession {
 		this.#toolRegistry = config.toolRegistry ?? new Map();
 		this.#createVibeTools = config.createVibeTools;
 		this.#builtInToolNames = new Set(config.builtInToolNames ?? []);
-		this.#requestedToolNames = config.requestedToolNames;
+		this.#presentationPinnedToolNames = config.presentationPinnedToolNames;
 		this.#transformContext = config.transformContext ?? (messages => messages);
 		this.#transformProviderContext = config.transformProviderContext;
 		this.#sideStreamFn = config.sideStreamFn ?? streamSimple;
@@ -6780,7 +6781,11 @@ export class AgentSession {
 			// Discoverable tools are presented as `xd://` devices (kept out of the
 			// top-level schema) when the transport is active; everything else stays
 			// top-level. `loadMode` decides presentation only — selection is upstream.
-			if (this.#xdevRegistry && isMountableUnderXdev(tool)) {
+			if (
+				this.#xdevRegistry &&
+				this.#presentationPinnedToolNames?.has(name) !== true &&
+				isMountableUnderXdev(tool)
+			) {
 				mountedTools.push(tool);
 			} else {
 				tools.push(this.#wrapToolForAcpPermission(tool));
@@ -7054,21 +7059,31 @@ export class AgentSession {
 			this.#toolRegistry.set(finalTool.name, finalTool);
 		}
 
-		// Every connected MCP tool is enabled. When xdev presents them as devices,
-		// keep the registered write transport active so they remain callable.
-		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...mcpTools.map(tool => tool.name)])];
-		if (
-			this.#xdevRegistry &&
+		// Every connected MCP tool is enabled. Keep write while any selected device,
+		// deferrable tool, plan flow, or presentation pin still needs the transport.
+		const nextActive = new Set([...this.#getActiveNonMCPToolNames(), ...mcpTools.map(tool => tool.name)]);
+		const incomingMcpDevice =
+			this.#xdevRegistry !== undefined &&
 			mcpTools.some(tool => {
 				const registered = this.#toolRegistry.get(tool.name);
-				return registered !== undefined && isMountableUnderXdev(registered);
-			}) &&
-			this.#toolRegistry.has("write") &&
-			!nextActive.includes("write")
-		) {
-			nextActive.push("write");
-		}
-		await this.#applyActiveToolsByName(nextActive);
+				return (
+					registered !== undefined &&
+					this.#presentationPinnedToolNames?.has(tool.name) !== true &&
+					isMountableUnderXdev(registered)
+				);
+			});
+		const remainingNonMcpDevice = [...this.#mountedXdevToolNames].some(name => !isMCPToolName(name));
+		const activeDeferrableTool = [...nextActive].some(name => this.#toolRegistry.get(name)?.deferrable === true);
+		const pinnedWrite = this.#presentationPinnedToolNames?.has("write") === true;
+		const transportNeeded =
+			incomingMcpDevice ||
+			remainingNonMcpDevice ||
+			activeDeferrableTool ||
+			this.settings.get("plan.enabled") ||
+			pinnedWrite;
+		if (transportNeeded && this.#toolRegistry.has("write")) nextActive.add("write");
+		else if (this.#presentationPinnedToolNames !== undefined) nextActive.delete("write");
+		await this.#applyActiveToolsByName([...nextActive]);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6782,9 +6782,10 @@ export class AgentSession {
 			return tool ? [{ name, tool }] : [];
 		});
 		const xdevReadAvailable =
-			(this.#presentationPinnedToolNames === undefined && this.#runtimeSelectedToolNames === undefined) ||
-			this.#presentationPinnedToolNames?.has("read") === true ||
-			this.#runtimeSelectedToolNames?.has("read") === true;
+			this.#builtInToolNames.has("read") &&
+			((this.#presentationPinnedToolNames === undefined && this.#runtimeSelectedToolNames === undefined) ||
+				this.#presentationPinnedToolNames?.has("read") === true ||
+				this.#runtimeSelectedToolNames?.has("read") === true);
 		const isPresentationPinned = (name: string): boolean =>
 			this.#presentationPinnedToolNames?.has(name) === true || this.#runtimeSelectedToolNames?.has(name) === true;
 		const mountCandidates = selectedTools.filter(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6781,11 +6781,7 @@ export class AgentSession {
 			const tool = this.#toolRegistry.get(name);
 			return tool ? [{ name, tool }] : [];
 		});
-		const xdevReadAvailable =
-			this.#builtInToolNames.has("read") &&
-			((this.#presentationPinnedToolNames === undefined && this.#runtimeSelectedToolNames === undefined) ||
-				this.#presentationPinnedToolNames?.has("read") === true ||
-				this.#runtimeSelectedToolNames?.has("read") === true);
+		const xdevReadAvailable = this.#builtInToolNames.has("read") && selectedTools.some(({ name }) => name === "read");
 		const isPresentationPinned = (name: string): boolean =>
 			this.#presentationPinnedToolNames?.has(name) === true || this.#runtimeSelectedToolNames?.has(name) === true;
 		const mountCandidates = selectedTools.filter(
@@ -6807,7 +6803,7 @@ export class AgentSession {
 		const mountedTools: AgentTool[] = [];
 		for (const { name, tool } of selectedTools) {
 			if (mountNames.has(name)) {
-				mountedTools.push(tool);
+				mountedTools.push(this.#wrapToolForAcpPermission(tool));
 			} else {
 				tools.push(this.#wrapToolForAcpPermission(tool));
 				validToolNames.push(name);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -7104,6 +7104,12 @@ export class AgentSession {
 	 */
 	async refreshMCPTools(mcpTools: CustomTool[]): Promise<void> {
 		const existingNames = Array.from(this.#toolRegistry.keys());
+		const previousMcpTools = new Map(
+			existingNames.flatMap(name => {
+				const tool = this.#toolRegistry.get(name);
+				return isMCPToolName(name) && tool ? [[name, tool] as const] : [];
+			}),
+		);
 		for (const name of existingNames) {
 			if (isMCPToolName(name)) {
 				this.#toolRegistry.delete(name);
@@ -7134,7 +7140,15 @@ export class AgentSession {
 		// Every connected MCP tool is selected; centralized repartitioning owns
 		// presentation pins and write-transport activation/removal.
 		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...mcpTools.map(tool => tool.name)])];
-		await this.#applyActiveToolsByName(nextActive);
+		try {
+			await this.#applyActiveToolsByName(nextActive);
+		} catch (error) {
+			for (const name of this.#toolRegistry.keys()) {
+				if (isMCPToolName(name)) this.#toolRegistry.delete(name);
+			}
+			for (const [name, tool] of previousMcpTools) this.#toolRegistry.set(name, tool);
+			throw error;
+		}
 	}
 
 	/**
@@ -7155,6 +7169,12 @@ export class AgentSession {
 
 		const previousRpcHostToolNames = new Set(this.#rpcHostToolNames);
 		const previousActiveToolNames = this.getEnabledToolNames();
+		const previousRpcHostTools = new Map(
+			[...previousRpcHostToolNames].flatMap(name => {
+				const tool = this.#toolRegistry.get(name);
+				return tool ? [[name, tool] as const] : [];
+			}),
+		);
 		for (const name of previousRpcHostToolNames) {
 			this.#toolRegistry.delete(name);
 		}
@@ -7176,9 +7196,16 @@ export class AgentSession {
 		const autoActivatedRpcToolNames = rpcTools
 			.filter(tool => !tool.hidden && !previousRpcHostToolNames.has(tool.name))
 			.map(tool => tool.name);
-		await this.#applyActiveToolsByName(
-			Array.from(new Set([...activeNonRpcToolNames, ...preservedRpcToolNames, ...autoActivatedRpcToolNames])),
-		);
+		try {
+			await this.#applyActiveToolsByName(
+				Array.from(new Set([...activeNonRpcToolNames, ...preservedRpcToolNames, ...autoActivatedRpcToolNames])),
+			);
+		} catch (error) {
+			for (const name of this.#rpcHostToolNames) this.#toolRegistry.delete(name);
+			this.#rpcHostToolNames = previousRpcHostToolNames;
+			for (const [name, tool] of previousRpcHostTools) this.#toolRegistry.set(name, tool);
+			throw error;
+		}
 	}
 
 	/** Whether auto-compaction is currently running */

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -843,6 +843,8 @@ export interface AgentSessionConfig {
 	builtInToolNames?: Iterable<string>;
 	/** Update tool-session predicates that render guidance from the live active tool set. */
 	setActiveToolNames?: (names: Iterable<string>) => void;
+	/** Register the write transport lazily when runtime xdev mounts first need it. */
+	ensureWriteRegistered?: () => Promise<void>;
 	/** Current session pre-LLM message transform pipeline */
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	/**
@@ -1958,6 +1960,7 @@ export class AgentSession {
 	#getLocalCalendarDate: () => string;
 	#getMcpServerInstructions: (() => Map<string, string> | undefined) | undefined;
 	#setActiveToolNames: ((names: Iterable<string>) => void) | undefined;
+	#ensureWriteRegistered: (() => Promise<void>) | undefined;
 	#disconnectOwnedMcpManager: (() => Promise<void>) | undefined;
 	#presentationPinnedToolNames: ReadonlySet<string> | undefined;
 	#baseSystemPrompt: string[];
@@ -2564,6 +2567,7 @@ export class AgentSession {
 		this.#createVibeTools = config.createVibeTools;
 		this.#builtInToolNames = new Set(config.builtInToolNames ?? []);
 		this.#presentationPinnedToolNames = config.presentationPinnedToolNames;
+		this.#ensureWriteRegistered = config.ensureWriteRegistered;
 		this.#transformContext = config.transformContext ?? (messages => messages);
 		this.#transformProviderContext = config.transformProviderContext;
 		this.#sideStreamFn = config.sideStreamFn ?? streamSimple;
@@ -6779,8 +6783,7 @@ export class AgentSession {
 			const tool = this.#toolRegistry.get(name);
 			if (!tool) continue;
 			// Discoverable tools are presented as `xd://` devices (kept out of the
-			// top-level schema) when the transport is active; everything else stays
-			// top-level. `loadMode` decides presentation only — selection is upstream.
+			// top-level schema) when the transport is active; presentation pins stay top-level.
 			if (
 				this.#xdevRegistry &&
 				this.#presentationPinnedToolNames?.has(name) !== true &&
@@ -6792,16 +6795,32 @@ export class AgentSession {
 				validToolNames.push(name);
 			}
 		}
-		// Reconcile the dynamic `xd://` mounts: newly-active discoverable tools are
-		// mounted, deactivated ones dropped (built-in devices are preserved). A
-		// removed or disconnected tool must not stay callable through a stale device.
+
+		const pinnedWrite = this.#presentationPinnedToolNames?.has("write") === true;
+		const activeDeferrableTool = tools.some(tool => tool.deferrable === true);
+		const transportNeeded =
+			mountedTools.length > 0 || activeDeferrableTool || this.settings.get("plan.enabled") || pinnedWrite;
+		if (transportNeeded) {
+			await this.#ensureWriteRegistered?.();
+			const write = this.#toolRegistry.get("write");
+			if (write && !validToolNames.includes("write")) {
+				tools.push(this.#wrapToolForAcpPermission(write));
+				validToolNames.push("write");
+			}
+		} else if (this.#presentationPinnedToolNames !== undefined) {
+			const writeNameIndex = validToolNames.indexOf("write");
+			if (writeNameIndex >= 0) validToolNames.splice(writeNameIndex, 1);
+			const writeToolIndex = tools.findIndex(tool => tool.name === "write");
+			if (writeToolIndex >= 0) tools.splice(writeToolIndex, 1);
+		}
+
+		// Reconcile dynamic `xd://` mounts; absent tools must not remain callable.
 		const previousMounted = this.#mountedXdevToolNames;
 		this.#mountedXdevToolNames = new Set(mountedTools.map(tool => tool.name));
 		this.#xdevRegistry?.reconcile(mountedTools);
 		this.#notifyXdevMountDelta(previousMounted);
 		this.#setActiveToolNames?.(validToolNames);
 		this.agent.setTools(tools);
-
 		// Rebuild base system prompt with new tool set, but only when the tool set
 		// actually changed. MCP servers can reconnect at arbitrary times and call
 		// `refreshMCPTools` -> `#applyActiveToolsByName` even though the resulting
@@ -7059,31 +7078,10 @@ export class AgentSession {
 			this.#toolRegistry.set(finalTool.name, finalTool);
 		}
 
-		// Every connected MCP tool is enabled. Keep write while any selected device,
-		// deferrable tool, plan flow, or presentation pin still needs the transport.
-		const nextActive = new Set([...this.#getActiveNonMCPToolNames(), ...mcpTools.map(tool => tool.name)]);
-		const incomingMcpDevice =
-			this.#xdevRegistry !== undefined &&
-			mcpTools.some(tool => {
-				const registered = this.#toolRegistry.get(tool.name);
-				return (
-					registered !== undefined &&
-					this.#presentationPinnedToolNames?.has(tool.name) !== true &&
-					isMountableUnderXdev(registered)
-				);
-			});
-		const remainingNonMcpDevice = [...this.#mountedXdevToolNames].some(name => !isMCPToolName(name));
-		const activeDeferrableTool = [...nextActive].some(name => this.#toolRegistry.get(name)?.deferrable === true);
-		const pinnedWrite = this.#presentationPinnedToolNames?.has("write") === true;
-		const transportNeeded =
-			incomingMcpDevice ||
-			remainingNonMcpDevice ||
-			activeDeferrableTool ||
-			this.settings.get("plan.enabled") ||
-			pinnedWrite;
-		if (transportNeeded && this.#toolRegistry.has("write")) nextActive.add("write");
-		else if (this.#presentationPinnedToolNames !== undefined) nextActive.delete("write");
-		await this.#applyActiveToolsByName([...nextActive]);
+		// Every connected MCP tool is selected; centralized repartitioning owns
+		// presentation pins and write-transport activation/removal.
+		const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...mcpTools.map(tool => tool.name)])];
+		await this.#applyActiveToolsByName(nextActive);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6779,6 +6779,8 @@ export class AgentSession {
 		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];
 		const mountedTools: AgentTool[] = [];
+		const xdevReadAvailable =
+			this.#presentationPinnedToolNames === undefined || this.#presentationPinnedToolNames.has("read");
 		for (const name of toolNames) {
 			const tool = this.#toolRegistry.get(name);
 			if (!tool) continue;
@@ -6786,6 +6788,7 @@ export class AgentSession {
 			// top-level schema) when the transport is active; presentation pins stay top-level.
 			if (
 				this.#xdevRegistry &&
+				xdevReadAvailable &&
 				this.#presentationPinnedToolNames?.has(name) !== true &&
 				isMountableUnderXdev(tool)
 			) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2456,8 +2456,13 @@ export class AgentSession {
 		});
 		this.setPlanModeState(undefined);
 		const previousTools = this.#planYoloPreviousTools;
-		if (previousTools) {
-			await this.setActiveToolsByName(previousTools);
+		try {
+			if (previousTools) {
+				await this.setActiveToolsByName(previousTools);
+			}
+		} catch (error) {
+			this.setPlanModeState(state);
+			throw error;
 		}
 		this.setPlanProposalHandler(null);
 		this.#planYolo = undefined;
@@ -6834,23 +6839,42 @@ export class AgentSession {
 		}
 
 		const previousMounted = this.#mountedXdevToolNames;
+		const previousMountedTools = [...previousMounted].flatMap(name => {
+			const tool = this.#xdevRegistry?.get(name);
+			return tool ? [tool] : [];
+		});
+		const previousActiveToolNames = this.getActiveToolNames();
 		this.#mountedXdevToolNames = new Set(mountedTools.map(tool => tool.name));
 		this.#xdevRegistry?.reconcile(mountedTools);
-		this.#notifyXdevMountDelta(previousMounted);
 		this.#setActiveToolNames?.(validToolNames);
-		this.agent.setTools(tools);
 
-		if (this.#rebuildSystemPrompt) {
-			const signature = this.#computeAppliedToolSignature(validToolNames, tools);
-			if (signature !== this.#lastAppliedToolSignature) {
-				if (this.#lastAppliedToolSignature !== undefined) this.#clearInheritedProviderPromptCacheKey();
-				const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
-				this.#baseSystemPrompt = built.systemPrompt;
-				this.#baseSystemPromptBeforeMemoryPromotion = undefined;
-				this.agent.setSystemPrompt(this.#baseSystemPrompt);
-				this.#lastAppliedToolSignature = signature;
-				this.#promptModelKey = this.#currentPromptModelKey();
+		let rebuiltSystemPrompt: string[] | undefined;
+		let rebuiltSignature: string | undefined;
+		try {
+			if (this.#rebuildSystemPrompt) {
+				const signature = this.#computeAppliedToolSignature(validToolNames, tools);
+				if (signature !== this.#lastAppliedToolSignature) {
+					const built = await this.#rebuildSystemPrompt(validToolNames, this.#toolRegistry);
+					rebuiltSystemPrompt = built.systemPrompt;
+					rebuiltSignature = signature;
+				}
 			}
+		} catch (error) {
+			this.#mountedXdevToolNames = previousMounted;
+			this.#xdevRegistry?.reconcile(previousMountedTools);
+			this.#setActiveToolNames?.(previousActiveToolNames);
+			throw error;
+		}
+
+		this.#notifyXdevMountDelta(previousMounted);
+		this.agent.setTools(tools);
+		if (rebuiltSystemPrompt && rebuiltSignature) {
+			if (this.#lastAppliedToolSignature !== undefined) this.#clearInheritedProviderPromptCacheKey();
+			this.#baseSystemPrompt = rebuiltSystemPrompt;
+			this.#baseSystemPromptBeforeMemoryPromotion = undefined;
+			this.agent.setSystemPrompt(this.#baseSystemPrompt);
+			this.#lastAppliedToolSignature = rebuiltSignature;
+			this.#promptModelKey = this.#currentPromptModelKey();
 		}
 	}
 
@@ -6921,8 +6945,23 @@ export class AgentSession {
 	 */
 	async setActiveToolsByName(toolNames: string[]): Promise<void> {
 		const mounted = this.#mountedXdevToolNames;
-		this.#runtimeSelectedToolNames = new Set(normalizeToolNames(toolNames).filter(name => !mounted.has(name)));
-		await this.#applyActiveToolsByName(toolNames);
+		const normalized = normalizeToolNames(toolNames);
+		const transportWriteActive =
+			this.#builtInToolNames.has("write") &&
+			this.getActiveToolNames().includes("write") &&
+			this.#presentationPinnedToolNames?.has("write") !== true &&
+			this.#runtimeSelectedToolNames?.has("write") !== true &&
+			(mounted.size > 0 || this.#planModeState?.enabled === true);
+		const previousRuntimeSelectedToolNames = this.#runtimeSelectedToolNames;
+		this.#runtimeSelectedToolNames = new Set(
+			normalized.filter(name => !mounted.has(name) && !(name === "write" && transportWriteActive)),
+		);
+		try {
+			await this.#applyActiveToolsByName(normalized);
+		} catch (error) {
+			this.#runtimeSelectedToolNames = previousRuntimeSelectedToolNames;
+			throw error;
+		}
 	}
 
 	/** Rebuild the base system prompt using the current active tool set. */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -568,15 +568,16 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 	);
 	let tools = baseResults.filter((r): r is Tool => r !== null);
 
-	// xd:// mounting: unmount discoverable built-ins from the tools array and
-	// expose them as virtual device URLs driven through read/write. Active for
-	// default tool sets when `tools.xdev` is enabled.
-	const xdevEnabled = requestedTools === undefined && session.settings.get("tools.xdev");
+	// Always create the xd:// registry when enabled so SDK assembly can mount
+	// discoverable custom/MCP tools later. Explicitly requested built-ins keep
+	// their top-level presentation; default tool sets mount discoverable built-ins.
+	const xdevEnabled = session.settings.get("tools.xdev");
+	const mountBuiltinTools = requestedTools === undefined;
 	if (xdevEnabled) {
 		const mounted: Tool[] = [];
 		const kept: Tool[] = [];
 		for (const tool of tools) {
-			const mountable = isMountableUnderXdev(tool) && tool.name in BUILTIN_TOOLS;
+			const mountable = mountBuiltinTools && isMountableUnderXdev(tool) && tool.name in BUILTIN_TOOLS;
 			(mountable ? mounted : kept).push(tool);
 		}
 		session.xdevRegistry = new XdevRegistry(mounted);

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -21,6 +21,7 @@ import type {
 import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 
@@ -76,6 +77,7 @@ async function createSession(
 	tools: AgentTool[],
 	bridge?: ClientBridge,
 	settingsOverrides: Partial<Record<SettingPath, unknown>> = {},
+	options?: { xdevRegistry?: XdevRegistry; builtInToolNames?: string[] },
 ): Promise<AgentSession> {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 	if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
@@ -101,6 +103,8 @@ async function createSession(
 		settings,
 		modelRegistry: {} as never,
 		toolRegistry: new Map(tools.map(t => [t.name, t])),
+		xdevRegistry: options?.xdevRegistry,
+		builtInToolNames: options?.builtInToolNames,
 	});
 
 	if (bridge) sess.setClientBridge(bridge);
@@ -252,6 +256,39 @@ it("delete and move tools request ACP permission before executing", async () => 
 	expect(moveTool.executeCalls).toBe(1);
 });
 
+it("mounted destructive tools retain the ACP permission gate", async () => {
+	const readTool = makeFakeTool("read");
+	const writeTool = makeFakeTool("write");
+	const deleteTool = makeFakeTool("delete");
+	deleteTool.loadMode = "discoverable";
+	const bridge = makeBridge({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
+	const permissionSpy = spyOn(bridge, "requestPermission");
+	const xdevRegistry = new XdevRegistry([]);
+	session = await createSession(
+		[readTool, writeTool],
+		bridge,
+		{},
+		{
+			xdevRegistry,
+			builtInToolNames: ["read", "write"],
+		},
+	);
+
+	await session.refreshRpcHostTools([deleteTool]);
+	const mountedDelete = xdevRegistry.get("delete");
+	expect(mountedDelete).toBeDefined();
+	expect(session.getActiveToolNames()).not.toContain("delete");
+	await mountedDelete!.execute(
+		"call-mounted-delete",
+		{ path: "/tmp/gone.ts" },
+		undefined,
+		undefined as never,
+		undefined as never,
+	);
+
+	expect(permissionSpy).toHaveBeenCalledTimes(1);
+	expect(deleteTool.executeCalls).toBe(1);
+});
 it("edit, write, and ast_edit do not request ACP permission", async () => {
 	const editTool = makeFakeTool("edit");
 	const writeTool = makeFakeTool("write");

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -77,7 +77,7 @@ async function createSession(
 	tools: AgentTool[],
 	bridge?: ClientBridge,
 	settingsOverrides: Partial<Record<SettingPath, unknown>> = {},
-	options?: { xdevRegistry?: XdevRegistry; builtInToolNames?: string[] },
+	options?: { xdevRegistry?: XdevRegistry; builtInToolNames?: string[]; initialMountedXdevToolNames?: string[] },
 ): Promise<AgentSession> {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 	if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
@@ -105,6 +105,7 @@ async function createSession(
 		toolRegistry: new Map(tools.map(t => [t.name, t])),
 		xdevRegistry: options?.xdevRegistry,
 		builtInToolNames: options?.builtInToolNames,
+		initialMountedXdevToolNames: options?.initialMountedXdevToolNames,
 	});
 
 	if (bridge) sess.setClientBridge(bridge);
@@ -280,6 +281,40 @@ it("mounted destructive tools retain the ACP permission gate", async () => {
 	expect(session.getActiveToolNames()).not.toContain("delete");
 	await mountedDelete!.execute(
 		"call-mounted-delete",
+		{ path: "/tmp/gone.ts" },
+		undefined,
+		undefined as never,
+		undefined as never,
+	);
+
+	expect(permissionSpy).toHaveBeenCalledTimes(1);
+	expect(deleteTool.executeCalls).toBe(1);
+});
+
+it("startup-mounted destructive tools gain the ACP permission gate when the bridge attaches", async () => {
+	const readTool = makeFakeTool("read");
+	const writeTool = makeFakeTool("write");
+	const deleteTool = makeFakeTool("delete");
+	deleteTool.loadMode = "discoverable";
+	const bridge = makeBridge({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
+	const permissionSpy = spyOn(bridge, "requestPermission");
+	const xdevRegistry = new XdevRegistry([]);
+	xdevRegistry.reconcile([deleteTool]);
+	session = await createSession(
+		[readTool, writeTool, deleteTool],
+		bridge,
+		{},
+		{
+			xdevRegistry,
+			builtInToolNames: ["read", "write"],
+			initialMountedXdevToolNames: ["delete"],
+		},
+	);
+
+	const mountedDelete = xdevRegistry.get("delete");
+	expect(mountedDelete).toBeDefined();
+	await mountedDelete!.execute(
+		"call-startup-delete",
 		{ path: "/tmp/gone.ts" },
 		undefined,
 		undefined as never,

--- a/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
+++ b/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
@@ -95,7 +95,12 @@ describe("AgentSession plan-mode convergence", () => {
 
 	async function createPlanSession(
 		responses: MockResponse[],
-		options?: { advisorResponses?: MockResponse[]; sideResponses?: MockResponse[]; planYolo?: boolean },
+		options?: {
+			advisorResponses?: MockResponse[];
+			sideResponses?: MockResponse[];
+			planYolo?: boolean;
+			rebuildGate?: { fail: boolean };
+		},
 	): Promise<PlanHarness> {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled anthropic model to exist");
@@ -155,6 +160,12 @@ describe("AgentSession plan-mode convergence", () => {
 			advisorStreamFn,
 			sideStreamFn,
 			planYolo: options?.planYolo ? { target: model } : undefined,
+			rebuildSystemPrompt: options?.rebuildGate
+				? async () => {
+						if (options.rebuildGate?.fail) throw new Error("rebuild failed");
+						return { systemPrompt: ["Test"] };
+					}
+				: undefined,
 		});
 		if (!options?.planYolo) created.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
 		session = created;
@@ -324,6 +335,33 @@ describe("AgentSession plan-mode convergence", () => {
 		expect(handler).toBeDefined();
 		await handler!("demo");
 
+		expect(harness.session.getPlanModeState()).toBeUndefined();
+		expect(harness.session.getActiveToolNames()).toEqual(["read"]);
+	});
+
+	it("keeps PlanYolo retryable when pre-plan tool restoration fails", async () => {
+		const rebuildGate = { fail: false };
+		const harness = await createPlanSession([{ content: ["planning"] }], { planYolo: true, rebuildGate });
+		await harness.session.prompt("make a plan");
+		await harness.session.waitForIdle();
+		const planPath = resolveLocalUrlToPath("local://retry-plan.md", {
+			getArtifactsDir: () => harness.session.sessionManager.getArtifactsDir(),
+			getSessionId: () => harness.session.sessionManager.getSessionId(),
+		});
+		await Bun.write(planPath, "# Retry plan\n\nImplement it.\n");
+		const handler = harness.session.peekPlanProposalHandler();
+		expect(handler).toBeDefined();
+		const activeBefore = harness.session.getActiveToolNames();
+		const mountedBefore = harness.session.getMountedXdevToolNames();
+		rebuildGate.fail = true;
+
+		await expect(handler!("retry")).rejects.toThrow("rebuild failed");
+		expect(harness.session.getPlanModeState()?.enabled).toBe(true);
+		expect(harness.session.peekPlanProposalHandler()).toBe(handler);
+		expect(harness.session.getActiveToolNames()).toEqual(activeBefore);
+		expect(harness.session.getMountedXdevToolNames()).toEqual(mountedBefore);
+		rebuildGate.fail = false;
+		await handler!("retry");
 		expect(harness.session.getPlanModeState()).toBeUndefined();
 		expect(harness.session.getActiveToolNames()).toEqual(["read"]);
 	});

--- a/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
+++ b/packages/coding-agent/test/agent-session-plan-mode-convergence.test.ts
@@ -16,6 +16,7 @@ import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { IrcBus, type IrcMessage } from "@oh-my-pi/pi-coding-agent/irc/bus";
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
@@ -94,7 +95,7 @@ describe("AgentSession plan-mode convergence", () => {
 
 	async function createPlanSession(
 		responses: MockResponse[],
-		options?: { advisorResponses?: MockResponse[]; sideResponses?: MockResponse[] },
+		options?: { advisorResponses?: MockResponse[]; sideResponses?: MockResponse[]; planYolo?: boolean },
 	): Promise<PlanHarness> {
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled anthropic model to exist");
@@ -108,7 +109,12 @@ describe("AgentSession plan-mode convergence", () => {
 			getApiKey: () => "test-key",
 			// All three tools active so a scripted ask/write/read call (and a
 			// forced "required" choice) can actually execute (isToolChoiceActive).
-			initialState: { model, systemPrompt: ["Test"], tools: [askTool, writeTool, readTool], messages: [] },
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: options?.planYolo ? [readTool] : [askTool, writeTool, readTool],
+				messages: [],
+			},
 			streamFn: mock.stream,
 		});
 
@@ -148,8 +154,9 @@ describe("AgentSession plan-mode convergence", () => {
 			advisorTools: [],
 			advisorStreamFn,
 			sideStreamFn,
+			planYolo: options?.planYolo ? { target: model } : undefined,
 		});
-		created.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
+		if (!options?.planYolo) created.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
 		session = created;
 		return { session: created, mock, advisorMock, sideMock };
 	}
@@ -291,5 +298,33 @@ describe("AgentSession plan-mode convergence", () => {
 
 		expect(countReminders(harness.session.agent.state.messages)).toBe(2);
 		expect(harness.mock.calls.length).toBe(4);
+	});
+
+	it("restores the pre-plan tool set after PlanYolo approval", async () => {
+		const harness = await createPlanSession(
+			[
+				{ content: ["planning A"] },
+				{ content: ["planning B"] },
+				{ content: ["planning C"] },
+				{ content: ["planning D"] },
+			],
+			{ planYolo: true },
+		);
+		await harness.session.prompt("make a plan");
+		await harness.session.waitForIdle();
+		expect(harness.session.getPlanModeState()?.enabled).toBe(true);
+		expect(harness.session.getActiveToolNames()).toContain("write");
+
+		const planPath = resolveLocalUrlToPath("local://demo-plan.md", {
+			getArtifactsDir: () => harness.session.sessionManager.getArtifactsDir(),
+			getSessionId: () => harness.session.sessionManager.getSessionId(),
+		});
+		await Bun.write(planPath, "# Demo plan\n\nImplement it.\n");
+		const handler = harness.session.peekPlanProposalHandler();
+		expect(handler).toBeDefined();
+		await handler!("demo");
+
+		expect(harness.session.getPlanModeState()).toBeUndefined();
+		expect(harness.session.getActiveToolNames()).toEqual(["read"]);
 	});
 });

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -80,15 +80,19 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 	} {
 		const readTool = createBasicTool("read", "Read");
 		const initialMcp = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		const writeTool = createBasicTool("write", "Write");
 		const toolRegistry = new Map<string, AgentTool>([
 			[readTool.name, readTool],
 			[initialMcp.name, initialMcp as unknown as AgentTool],
 		]);
+		if (options.xdevRegistry) toolRegistry.set(writeTool.name, writeTool);
 		const agent = new Agent({
 			initialState: {
 				model: createModel(),
 				systemPrompt: ["initial"],
-				tools: [readTool, initialMcp as unknown as AgentTool],
+				tools: options.xdevRegistry
+					? [readTool, writeTool, initialMcp as unknown as AgentTool]
+					: [readTool, initialMcp as unknown as AgentTool],
 				messages: [],
 			},
 		});
@@ -98,6 +102,8 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry: {} as never,
 			toolRegistry,
+			builtInToolNames: options.xdevRegistry ? ["read", "write"] : ["read"],
+			ensureWriteRegistered: async () => options.xdevRegistry !== undefined,
 			rebuildSystemPrompt: async (toolNames, _tools) => ({
 				systemPrompt: [await rebuildSystemPrompt(toolNames)],
 			}),

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -589,4 +589,62 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(session.getActiveToolNames()).toContain("write");
 		expect(session.getMountedXdevToolNames()).toContain(search.name);
 	});
+
+	it("rolls back MCP catalog replacement when prompt rebuild fails", async () => {
+		let failRebuild = false;
+		let date = "2026-07-16";
+		const xdevRegistry = new XdevRegistry([]);
+		const { session } = newSession(
+			async toolNames => {
+				if (failRebuild) throw new Error("rebuild failed");
+				return `tools:${toolNames.join(",")}`;
+			},
+			{ xdevRegistry, getLocalCalendarDate: () => date },
+		);
+		const oldTool = createMcpCustomTool("mcp__nucleus_old", "nucleus", "old", "Old tool");
+		const newTool = createMcpCustomTool("mcp__nucleus_new", "nucleus", "new", "New tool");
+		await session.refreshMCPTools([oldTool]);
+		date = "2026-07-17";
+		failRebuild = true;
+
+		await expect(session.refreshMCPTools([newTool])).rejects.toThrow("rebuild failed");
+		expect(session.getToolByName(oldTool.name)).toBeDefined();
+		expect(session.getToolByName(newTool.name)).toBeUndefined();
+		expect(session.getMountedXdevToolNames()).toContain(oldTool.name);
+
+		failRebuild = false;
+		await session.refreshMCPTools([newTool]);
+		expect(session.getToolByName(oldTool.name)).toBeUndefined();
+		expect(session.getToolByName(newTool.name)).toBeDefined();
+		expect(session.getMountedXdevToolNames()).toContain(newTool.name);
+	});
+
+	it("rolls back RPC catalog replacement when prompt rebuild fails", async () => {
+		let failRebuild = false;
+		let date = "2026-07-16";
+		const xdevRegistry = new XdevRegistry([]);
+		const { session } = newSession(
+			async toolNames => {
+				if (failRebuild) throw new Error("rebuild failed");
+				return `tools:${toolNames.join(",")}`;
+			},
+			{ xdevRegistry, getLocalCalendarDate: () => date },
+		);
+		const oldTool = { ...createBasicTool("rpc_old", "RPC Old"), loadMode: "discoverable" as const };
+		const newTool = { ...createBasicTool("rpc_new", "RPC New"), loadMode: "discoverable" as const };
+		await session.refreshRpcHostTools([oldTool]);
+		date = "2026-07-17";
+		failRebuild = true;
+
+		await expect(session.refreshRpcHostTools([newTool])).rejects.toThrow("rebuild failed");
+		expect(session.getToolByName(oldTool.name)).toBeDefined();
+		expect(session.getToolByName(newTool.name)).toBeUndefined();
+		expect(session.getMountedXdevToolNames()).toContain(oldTool.name);
+
+		failRebuild = false;
+		await session.refreshRpcHostTools([newTool]);
+		expect(session.getToolByName(oldTool.name)).toBeUndefined();
+		expect(session.getToolByName(newTool.name)).toBeDefined();
+		expect(session.getMountedXdevToolNames()).toContain(newTool.name);
+	});
 });

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -70,6 +70,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		getMcpServerInstructions?: () => Map<string, string> | undefined;
 		getLocalCalendarDate?: () => string;
 		xdevRegistry?: XdevRegistry;
+		lazyWrite?: boolean;
 	}
 
 	function newSession(
@@ -85,13 +86,15 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			[readTool.name, readTool],
 			[initialMcp.name, initialMcp as unknown as AgentTool],
 		]);
-		if (options.xdevRegistry) toolRegistry.set(writeTool.name, writeTool);
+		if (options.xdevRegistry && !options.lazyWrite) toolRegistry.set(writeTool.name, writeTool);
 		const agent = new Agent({
 			initialState: {
 				model: createModel(),
 				systemPrompt: ["initial"],
 				tools: options.xdevRegistry
-					? [readTool, writeTool, initialMcp as unknown as AgentTool]
+					? options.lazyWrite
+						? [readTool, initialMcp as unknown as AgentTool]
+						: [readTool, writeTool, initialMcp as unknown as AgentTool]
 					: [readTool, initialMcp as unknown as AgentTool],
 				messages: [],
 			},
@@ -102,8 +105,12 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry: {} as never,
 			toolRegistry,
-			builtInToolNames: options.xdevRegistry ? ["read", "write"] : ["read"],
-			ensureWriteRegistered: async () => options.xdevRegistry !== undefined,
+			builtInToolNames: options.xdevRegistry && !options.lazyWrite ? ["read", "write"] : ["read"],
+			ensureWriteRegistered: async () => {
+				if (!options.xdevRegistry) return false;
+				if (!toolRegistry.has("write")) toolRegistry.set("write", writeTool);
+				return true;
+			},
 			rebuildSystemPrompt: async (toolNames, _tools) => ({
 				systemPrompt: [await rebuildSystemPrompt(toolNames)],
 			}),
@@ -554,5 +561,32 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 		expect(rebuildCount).toBe(1);
 		expect(noticeTexts().length).toBe(noticeCount);
+	});
+
+	it("keeps lazy write registration while rolling back applied state on rebuild failure", async () => {
+		let failRebuild = true;
+		const xdevRegistry = new XdevRegistry([]);
+		const { session } = newSession(
+			async toolNames => {
+				if (failRebuild) throw new Error("rebuild failed");
+				return `tools:${toolNames.join(",")}`;
+			},
+			{ xdevRegistry, lazyWrite: true },
+		);
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		const activeBefore = session.getActiveToolNames();
+		const mountedBefore = session.getMountedXdevToolNames();
+
+		await expect(session.refreshMCPTools([search])).rejects.toThrow("rebuild failed");
+
+		expect(session.getActiveToolNames()).toEqual(activeBefore);
+		expect(session.getMountedXdevToolNames()).toEqual(mountedBefore);
+		expect(session.getToolByName("write")).toBeDefined();
+		expect(session.hasBuiltInTool("write")).toBe(true);
+
+		failRebuild = false;
+		await session.refreshMCPTools([search]);
+		expect(session.getActiveToolNames()).toContain("write");
+		expect(session.getMountedXdevToolNames()).toContain(search.name);
 	});
 });

--- a/packages/coding-agent/test/fixtures/instructions-mcp.ts
+++ b/packages/coding-agent/test/fixtures/instructions-mcp.ts
@@ -28,6 +28,7 @@ export const SERVER_INSTRUCTIONS =
 
 /** Single tool advertised by the fixture so `tools/list` is non-empty. */
 export const TOOL_NAME = "do_thing";
+export const TOOL_RESULT = "MCP_DEFERRED_SMOKE_OK_5c92";
 
 type JsonRpcRequest = {
 	jsonrpc: "2.0";
@@ -52,11 +53,13 @@ function buildResult(method: string): Record<string, unknown> {
 				tools: [
 					{
 						name: TOOL_NAME,
-						description: "Fixture tool; never actually called by this test.",
+						description: "Fixture tool returning a deterministic sentinel.",
 						inputSchema: { type: "object", properties: {}, additionalProperties: false },
 					},
 				],
 			};
+		case "tools/call":
+			return { content: [{ type: "text", text: TOOL_RESULT }], isError: false };
 		default:
 			// `ping` and any other request: a benign empty result keeps the
 			// transport happy without modelling methods the test never exercises.

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -27,6 +27,7 @@ function makeTool(name: string): AgentTool {
 interface HarnessOptions {
 	extraRegistryTools?: readonly AgentTool[];
 	builtInToolNames?: Iterable<string>;
+	rebuildGate?: { fail: boolean };
 }
 
 describe("InteractiveMode plan.defaultOnStartup", () => {
@@ -99,6 +100,12 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 			modelRegistry: registry,
 			toolRegistry,
 			builtInToolNames: options.builtInToolNames ?? ["read"],
+			rebuildSystemPrompt: options.rebuildGate
+				? async () => {
+						if (options.rebuildGate?.fail) throw new Error("rebuild failed");
+						return { systemPrompt: ["Test"] };
+					}
+				: undefined,
 		});
 		session = createdSession;
 		mode = new InteractiveMode(createdSession, "test");
@@ -158,6 +165,30 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 
 		await created.handlePlanModeCommand();
 
+		expect(created.planModeEnabled).toBe(false);
+		expect(session?.getPlanModeState()).toBeUndefined();
+		expect(session?.getActiveToolNames()).toEqual(["read"]);
+	});
+
+	it("keeps plan mode retryable when prior-tool restoration fails", async () => {
+		const writeTool = makeTool("write");
+		const rebuildGate = { fail: false };
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), {
+			extraRegistryTools: [writeTool],
+			builtInToolNames: ["read", "write"],
+			rebuildGate,
+		});
+		await created.init({ suppressWelcomeIntro: true });
+		const activeBefore = session?.getActiveToolNames();
+		rebuildGate.fail = true;
+
+		await expect(created.handlePlanModeCommand()).rejects.toThrow("rebuild failed");
+		expect(created.planModeEnabled).toBe(true);
+		expect(session?.getPlanModeState()?.enabled).toBe(true);
+		expect(session?.getActiveToolNames()).toEqual(activeBefore);
+
+		rebuildGate.fail = false;
+		await created.handlePlanModeCommand();
 		expect(created.planModeEnabled).toBe(false);
 		expect(session?.getPlanModeState()).toBeUndefined();
 		expect(session?.getActiveToolNames()).toEqual(["read"]);

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -27,7 +27,7 @@ function makeTool(name: string): AgentTool {
 interface HarnessOptions {
 	extraRegistryTools?: readonly AgentTool[];
 	builtInToolNames?: Iterable<string>;
-	rebuildGate?: { fail: boolean };
+	rebuildGate?: { fail: boolean; calls?: number };
 }
 
 describe("InteractiveMode plan.defaultOnStartup", () => {
@@ -102,6 +102,7 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 			builtInToolNames: options.builtInToolNames ?? ["read"],
 			rebuildSystemPrompt: options.rebuildGate
 				? async () => {
+						if (options.rebuildGate) options.rebuildGate.calls = (options.rebuildGate.calls ?? 0) + 1;
 						if (options.rebuildGate?.fail) throw new Error("rebuild failed");
 						return { systemPrompt: ["Test"] };
 					}
@@ -192,6 +193,35 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		expect(created.planModeEnabled).toBe(false);
 		expect(session?.getPlanModeState()).toBeUndefined();
 		expect(session?.getActiveToolNames()).toEqual(["read"]);
+	});
+
+	it("clears old plan UI state when target-session reconciliation restore fails", async () => {
+		const writeTool = makeTool("write");
+		const rebuildGate = { fail: false, calls: 0 };
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), {
+			extraRegistryTools: [writeTool],
+			builtInToolNames: ["read", "write"],
+			rebuildGate,
+		});
+		await created.init({ suppressWelcomeIntro: true });
+		expect(created.planModeEnabled).toBe(true);
+		expect(session?.peekPlanProposalHandler()).toBeDefined();
+
+		const targetManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "target-sessions"));
+		await targetManager.flush();
+		const targetSessionFile = targetManager.getSessionFile();
+		expect(targetSessionFile).toBeString();
+		await targetManager.close();
+		const callsBeforeSwitch = rebuildGate.calls;
+		rebuildGate.fail = true;
+
+		await expect(session!.switchSession(targetSessionFile!)).resolves.toBe(true);
+		expect(session?.sessionFile).toBe(targetSessionFile);
+		expect(created.planModeEnabled).toBe(false);
+		expect(rebuildGate.calls).toBeGreaterThan(callsBeforeSwitch);
+		expect(created.planModePaused).toBe(false);
+		expect(session?.getPlanModeState()).toBeUndefined();
+		expect(session?.peekPlanProposalHandler()).toBeUndefined();
 	});
 
 	it("does not enter plan mode at startup by default", async () => {

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -147,6 +147,22 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		expect(session?.getActiveToolNames()).not.toContain("write");
 	});
 
+	it("removes plan-only write when exiting to the previous read-only tool set", async () => {
+		const writeTool = makeTool("write");
+		const created = createHarness(Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false }), {
+			extraRegistryTools: [writeTool],
+			builtInToolNames: ["read", "write"],
+		});
+		await created.init({ suppressWelcomeIntro: true });
+		expect(session?.getActiveToolNames()).toContain("write");
+
+		await created.handlePlanModeCommand();
+
+		expect(created.planModeEnabled).toBe(false);
+		expect(session?.getPlanModeState()).toBeUndefined();
+		expect(session?.getActiveToolNames()).toEqual(["read"]);
+	});
+
 	it("does not enter plan mode at startup by default", async () => {
 		const created = createHarness(Settings.isolated({ "compaction.enabled": false }));
 

--- a/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
+++ b/packages/coding-agent/test/interactive-mode-default-plan-mode.test.ts
@@ -195,6 +195,45 @@ describe("InteractiveMode plan.defaultOnStartup", () => {
 		expect(session?.getActiveToolNames()).toEqual(["read"]);
 	});
 
+	it("keeps plan mode coherent when prior-model restoration fails", async () => {
+		const settings = Settings.isolated({ "plan.defaultOnStartup": true, "compaction.enabled": false });
+		settings.setModelRole("plan", "anthropic/claude-haiku-4-5:high");
+		const writeTool = makeTool("write");
+		const created = createHarness(settings, {
+			extraRegistryTools: [writeTool],
+			builtInToolNames: ["read", "write"],
+		});
+		const previousModel = session?.model;
+		await created.init({ suppressWelcomeIntro: true });
+		const planModel = session?.model;
+		const planTools = session?.getActiveToolNames();
+		expect(planModel?.id).toBe("claude-haiku-4-5");
+		expect(session?.configuredThinkingLevel()).toBe(Effort.High);
+
+		const setModelTemporary = session!.setModelTemporary.bind(session);
+		const restoreModel = vi.spyOn(session!, "setModelTemporary").mockImplementationOnce(async (...args) => {
+			await setModelTemporary(...args);
+			throw new Error("model restore failed after switch");
+		});
+		await expect(created.handlePlanModeCommand()).rejects.toThrow("model restore failed after switch");
+
+		expect(created.planModeEnabled).toBe(true);
+		expect(created.planModePaused).toBe(false);
+		expect(session?.getPlanModeState()?.enabled).toBe(true);
+		expect(session?.peekPlanProposalHandler()).toBeDefined();
+		expect(session?.model?.id).toBe(planModel?.id);
+		expect(session?.configuredThinkingLevel()).toBe(Effort.High);
+		expect(session?.getActiveToolNames()).toEqual(planTools);
+		expect(restoreModel).toHaveBeenCalledTimes(2);
+
+		restoreModel.mockRestore();
+		await created.handlePlanModeCommand();
+		expect(created.planModeEnabled).toBe(false);
+		expect(session?.getPlanModeState()).toBeUndefined();
+		expect(session?.model?.id).toBe(previousModel?.id);
+		expect(session?.getActiveToolNames()).toEqual(["read"]);
+	});
+
 	it("clears old plan UI state when target-session reconciliation restore fails", async () => {
 		const writeTool = makeTool("write");
 		const rebuildGate = { fail: false, calls: 0 };

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -264,6 +264,27 @@ describe("generate_image tool gating", () => {
 		expect(session.getActiveToolNames()).toContain(rpcTool.name);
 		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(rpcTool.name);
 	});
+
+	it("keeps newly discovered tools top-level after runtime read removal", async () => {
+		const session = await sessionWithCustomTools(["read", "bash"], []);
+		await session.setActiveToolsByName(["bash"]);
+
+		const rpcTool: AgentTool = {
+			name: "rpc_without_read",
+			label: "RPC Without Read",
+			description: "Search RPC host data",
+			parameters: type({}),
+			loadMode: "discoverable",
+			async execute() {
+				return { content: [] };
+			},
+		};
+		await session.refreshRpcHostTools([rpcTool]);
+
+		expect(session.getActiveToolNames()).not.toContain("read");
+		expect(session.getActiveToolNames()).toContain(rpcTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(rpcTool.name);
+	});
 	it("activates write when an RPC host tool mounts under xd://", async () => {
 		const { session } = await createAgentSession({
 			cwd: registryDir,

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { AuthStorage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
@@ -11,6 +12,7 @@ import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
 
 // Regression for issue #5305: image-gen is registered as a custom tool, and
 // custom tools are force-activated regardless of the `toolNames` filter. Before
@@ -69,6 +71,7 @@ describe("generate_image tool gating", () => {
 		const { session } = await createAgentSession({
 			cwd: registryDir,
 			agentDir: registryDir,
+			enableMCP: false,
 			modelRegistry,
 			sessionManager: SessionManager.inMemory(),
 			settings: Settings.isolated({ "plan.enabled": false }),
@@ -190,6 +193,38 @@ describe("generate_image tool gating", () => {
 		await session.refreshMCPTools([]);
 
 		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain(ambientTool.name);
+		expect(session.getActiveToolNames()).toContain("write");
+	});
+
+	it("activates write when an RPC host tool mounts under xd://", async () => {
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "plan.enabled": false, "generate_image.enabled": false }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			enableMCP: false,
+			toolNames: ["read"],
+		});
+		sessions.push(session);
+		expect(session.getXdevToolEntries()).toEqual([]);
+		expect(session.getActiveToolNames()).not.toContain("write");
+
+		const rpcTool: AgentTool = {
+			name: "rpc_search",
+			label: "RPC Search",
+			description: "Search RPC host data",
+			parameters: type({}),
+			loadMode: "discoverable",
+			async execute() {
+				return { content: [] };
+			},
+		};
+		await session.refreshRpcHostTools([rpcTool]);
+
+		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain("rpc_search");
 		expect(session.getActiveToolNames()).toContain("write");
 	});
 });

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -126,6 +126,17 @@ describe("generate_image tool gating", () => {
 		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain("generate_image");
 	});
 
+	it("keeps carried mounted devices under xd after runtime tool selection", async () => {
+		const ambientTool = customTool("ambient_search");
+		const session = await sessionWithCustomTools(["read"], [ambientTool]);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain(ambientTool.name);
+
+		await session.setActiveToolsByName(session.getEnabledToolNames());
+
+		expect(session.getActiveToolNames()).not.toContain(ambientTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain(ambientTool.name);
+	});
+
 	it("keeps explicit discoverable tools top-level while mounting ambient MCP-shaped custom tools", async () => {
 		let mcpCalls = 0;
 		const mcpTool = {

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -6,6 +6,7 @@ import { AuthStorage } from "@oh-my-pi/pi-ai";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -69,7 +70,7 @@ describe("generate_image tool gating", () => {
 		expect(names).not.toContain("generate_image");
 	});
 
-	it("includes generate_image when explicitly requested and enabled", async () => {
+	it("includes generate_image top-level when explicitly requested and enabled", async () => {
 		const names = await activeToolNames(Settings.isolated({}), ["read", "generate_image"]);
 		expect(names).toContain("generate_image");
 	});
@@ -90,5 +91,48 @@ describe("generate_image tool gating", () => {
 		sessions.push(session);
 		expect(session.getActiveToolNames()).not.toContain("generate_image");
 		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain("generate_image");
+	});
+
+	it("keeps explicit discoverable tools top-level while mounting ambient MCP-shaped custom tools", async () => {
+		let mcpCalls = 0;
+		const mcpTool = {
+			name: "mcp__test__search",
+			label: "test/search",
+			description: "Search the test MCP server",
+			parameters: { type: "object", properties: {} },
+			mcpServerName: "test",
+			mcpToolName: "search",
+			execute: async () => {
+				mcpCalls++;
+				return { content: [{ type: "text" as const, text: "ok" }] };
+			},
+		} as CustomTool;
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({}),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			toolNames: ["read", "generate_image"],
+			customTools: [mcpTool],
+		});
+		sessions.push(session);
+
+		expect(session.getActiveToolNames()).toContain("generate_image");
+		expect(session.getActiveToolNames()).not.toContain(mcpTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain(mcpTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain("generate_image");
+		expect(session.getAllToolNames()).toContain(mcpTool.name);
+		expect(session.getActiveToolNames()).toContain("write");
+		const writeTool = session.getToolByName("write");
+		expect(writeTool).toBeDefined();
+		const result = await writeTool!.execute("mcp-xdev-dispatch", {
+			path: `xd://${mcpTool.name}`,
+			content: "{}",
+		});
+		expect(result.content.find(part => part.type === "text")?.text).toBe("ok");
+		expect(mcpCalls).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -205,6 +205,30 @@ describe("generate_image tool gating", () => {
 		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(ambientTool.name);
 	});
 
+	it("keeps ambient tools top-level when write is shadowed by a custom tool", async () => {
+		const ambientTool = customTool("ambient_search");
+		const shadowWrite = customTool("write");
+		const session = await sessionWithCustomTools(["read"], [ambientTool, shadowWrite]);
+
+		expect(session.hasBuiltInTool("write")).toBe(false);
+		expect(session.getActiveToolNames()).toContain(ambientTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(ambientTool.name);
+
+		const rpcTool: AgentTool = {
+			name: "rpc_shadow_search",
+			label: "RPC Shadow Search",
+			description: "Search RPC host data",
+			parameters: type({}),
+			loadMode: "discoverable",
+			async execute() {
+				return { content: [] };
+			},
+		};
+		await session.refreshRpcHostTools([rpcTool]);
+		expect(session.hasBuiltInTool("write")).toBe(false);
+		expect(session.getActiveToolNames()).toContain(rpcTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(rpcTool.name);
+	});
 	it("activates write when an RPC host tool mounts under xd://", async () => {
 		const { session } = await createAgentSession({
 			cwd: registryDir,

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -189,6 +189,16 @@ describe("generate_image tool gating", () => {
 		expect(session.getActiveToolNames()).not.toContain("write");
 	});
 
+	it("does not pin transport-only write during enabled-set round trips", async () => {
+		const session = await sessionWithCustomTools(["read"], [customTool("mcp__test__search", true)]);
+		expect(session.getActiveToolNames()).toContain("write");
+
+		await session.setActiveToolsByName(session.getEnabledToolNames());
+		await session.refreshMCPTools([]);
+
+		expect(session.getActiveToolNames()).not.toContain("write");
+	});
+
 	it("preserves explicitly requested write after MCP devices disconnect", async () => {
 		const session = await sessionWithCustomTools(["read", "write"], [customTool("mcp__test__search", true)]);
 

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -30,8 +30,11 @@ describe("generate_image tool gating", () => {
 		modelRegistry = new ModelRegistry(authStorage);
 	});
 
-	afterAll(async () => {
-		for (const session of sessions) await session.dispose().catch(() => {});
+	afterEach(async () => {
+		for (const session of sessions.splice(0)) await session.dispose().catch(() => {});
+	});
+
+	afterAll(() => {
 		authStorage.close();
 		if (fs.existsSync(registryDir)) removeSyncWithRetries(registryDir);
 	});
@@ -49,6 +52,33 @@ describe("generate_image tool gating", () => {
 		});
 		sessions.push(session);
 		return session.getActiveToolNames();
+	}
+
+	function customTool(name: string, mcp = false): CustomTool {
+		return {
+			name,
+			label: name,
+			description: name,
+			parameters: { type: "object", properties: {} },
+			...(mcp ? { mcpServerName: "test", mcpToolName: "search" } : {}),
+			execute: async () => ({ content: [] }),
+		} as CustomTool;
+	}
+
+	async function sessionWithCustomTools(toolNames: string[], customTools: CustomTool[]): Promise<AgentSession> {
+		const { session } = await createAgentSession({
+			cwd: registryDir,
+			agentDir: registryDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "plan.enabled": false }),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			toolNames,
+			customTools,
+		});
+		sessions.push(session);
+		return session;
 	}
 
 	it("excludes generate_image from a restricted tool whitelist", async () => {
@@ -134,5 +164,32 @@ describe("generate_image tool gating", () => {
 		});
 		expect(result.content.find(part => part.type === "text")?.text).toBe("ok");
 		expect(mcpCalls).toBe(1);
+	});
+
+	it("drops transport-only write after the last MCP device disconnects", async () => {
+		const session = await sessionWithCustomTools(["read"], [customTool("mcp__test__search", true)]);
+		expect(session.getActiveToolNames()).toContain("write");
+
+		await session.refreshMCPTools([]);
+
+		expect(session.getActiveToolNames()).not.toContain("write");
+	});
+
+	it("preserves explicitly requested write after MCP devices disconnect", async () => {
+		const session = await sessionWithCustomTools(["read", "write"], [customTool("mcp__test__search", true)]);
+
+		await session.refreshMCPTools([]);
+
+		expect(session.getActiveToolNames()).toContain("write");
+	});
+
+	it("preserves write while a non-MCP device remains mounted", async () => {
+		const ambientTool = customTool("ambient_search");
+		const session = await sessionWithCustomTools(["read"], [ambientTool, customTool("mcp__test__search", true)]);
+
+		await session.refreshMCPTools([]);
+
+		expect(session.getXdevToolEntries().map(entry => entry.name)).toContain(ambientTool.name);
+		expect(session.getActiveToolNames()).toContain("write");
 	});
 });

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -240,6 +240,30 @@ describe("generate_image tool gating", () => {
 		expect(session.getActiveToolNames()).toContain(rpcTool.name);
 		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(rpcTool.name);
 	});
+
+	it("keeps ambient tools top-level when read is shadowed by a custom tool", async () => {
+		const ambientTool = customTool("ambient_search");
+		const shadowRead = customTool("read");
+		const session = await sessionWithCustomTools(["read"], [ambientTool, shadowRead]);
+
+		expect(session.hasBuiltInTool("read")).toBe(false);
+		expect(session.getActiveToolNames()).toContain(ambientTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(ambientTool.name);
+
+		const rpcTool: AgentTool = {
+			name: "rpc_shadow_read_search",
+			label: "RPC Shadow Read Search",
+			description: "Search RPC host data",
+			parameters: type({}),
+			loadMode: "discoverable",
+			async execute() {
+				return { content: [] };
+			},
+		};
+		await session.refreshRpcHostTools([rpcTool]);
+		expect(session.getActiveToolNames()).toContain(rpcTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(rpcTool.name);
+	});
 	it("activates write when an RPC host tool mounts under xd://", async () => {
 		const { session } = await createAgentSession({
 			cwd: registryDir,

--- a/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
+++ b/packages/coding-agent/test/sdk-generate-image-tool-gating.test.ts
@@ -196,6 +196,15 @@ describe("generate_image tool gating", () => {
 		expect(session.getActiveToolNames()).toContain("write");
 	});
 
+	it("keeps ambient custom tools top-level when an explicit session omitted read", async () => {
+		const ambientTool = customTool("ambient_search");
+		const session = await sessionWithCustomTools(["bash"], [ambientTool]);
+
+		expect(session.getActiveToolNames()).not.toContain("read");
+		expect(session.getActiveToolNames()).toContain(ambientTool.name);
+		expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(ambientTool.name);
+	});
+
 	it("activates write when an RPC host tool mounts under xd://", async () => {
 		const { session } = await createAgentSession({
 			cwd: registryDir,

--- a/packages/coding-agent/test/sdk-mcp-instructions.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-instructions.test.ts
@@ -192,4 +192,44 @@ describe("createAgentSession MCP server instructions (deferred UI)", () => {
 			await session.dispose();
 		}
 	}, 20_000);
+
+	it("keeps deferred tools top-level when an explicit session omitted read", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({}),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			hasUI: true,
+			toolNames: ["bash"],
+		});
+		try {
+			const deadline = Date.now() + 12_000;
+			let prompt = session.systemPrompt.join("\n");
+			while (!prompt.includes(SERVER_INSTRUCTIONS) && Date.now() < deadline) {
+				await Bun.sleep(50);
+				prompt = session.systemPrompt.join("\n");
+			}
+			let activeNames = session.getActiveToolNames();
+			while (!activeNames.includes(MCP_TOOL_NAME) && Date.now() < deadline) {
+				await Bun.sleep(50);
+				activeNames = session.getActiveToolNames();
+			}
+
+			expect(activeNames).not.toContain("read");
+			expect(activeNames).toContain(MCP_TOOL_NAME);
+			expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(MCP_TOOL_NAME);
+		} finally {
+			await session.dispose();
+		}
+	}, 20_000);
 });

--- a/packages/coding-agent/test/sdk-mcp-instructions.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-instructions.test.ts
@@ -157,4 +157,39 @@ describe("createAgentSession MCP server instructions (deferred UI)", () => {
 			await session.dispose();
 		}
 	}, 20_000);
+
+	it("keeps an explicitly requested deferred MCP tool top-level after connection", async () => {
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			modelRegistry,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({}),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableLsp: false,
+			skipPythonPreflight: true,
+			enableMCP: true,
+			hasUI: true,
+			toolNames: ["read", MCP_TOOL_NAME],
+		});
+		try {
+			const deadline = Date.now() + 12_000;
+			let prompt = session.systemPrompt.join("\n");
+			while (!prompt.includes(SERVER_INSTRUCTIONS) && Date.now() < deadline) {
+				await Bun.sleep(50);
+				prompt = session.systemPrompt.join("\n");
+			}
+			const activeNames = session.getActiveToolNames();
+
+			expect(activeNames).toContain(MCP_TOOL_NAME);
+			expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain(MCP_TOOL_NAME);
+		} finally {
+			await session.dispose();
+		}
+	}, 20_000);
 });

--- a/packages/coding-agent/test/sdk-mcp-instructions.test.ts
+++ b/packages/coding-agent/test/sdk-mcp-instructions.test.ts
@@ -9,7 +9,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
-import { SERVER_INSTRUCTIONS, TOOL_NAME } from "./fixtures/instructions-mcp";
+import { SERVER_INSTRUCTIONS, TOOL_NAME, TOOL_RESULT } from "./fixtures/instructions-mcp";
 
 // Contract: a deferred interactive (`hasUI`) session runs MCP discovery off the
 // first-paint path, so an MCP server's `instructions` are not available when the
@@ -137,19 +137,22 @@ describe("createAgentSession MCP server instructions (deferred UI)", () => {
 		try {
 			expect(session.getActiveToolNames()).toContain("read");
 
-			// Deferred MCP discovery is fire-and-forget and exposes no promise or
-			// event; fake timers cannot drive the real subprocess handshake, so we
-			// poll the live active-tool state and exit as soon as the fixture tool
-			// appears.
+			// Deferred discovery mounts MCP under xd:// and activates write as its transport.
 			const deadline = Date.now() + 12_000;
-			let activeToolNames = session.getActiveToolNames();
-			while (!activeToolNames.includes(MCP_TOOL_NAME) && Date.now() < deadline) {
+			let deviceNames = session.getXdevToolEntries().map(entry => entry.name);
+			while (!deviceNames.includes(MCP_TOOL_NAME) && Date.now() < deadline) {
 				await Bun.sleep(50);
-				activeToolNames = session.getActiveToolNames();
+				deviceNames = session.getXdevToolEntries().map(entry => entry.name);
 			}
 
-			expect(activeToolNames).toContain("read");
-			expect(activeToolNames).toContain(MCP_TOOL_NAME);
+			expect(session.getActiveToolNames()).toContain("read");
+			expect(session.getActiveToolNames()).toContain("write");
+			expect(session.getActiveToolNames()).not.toContain(MCP_TOOL_NAME);
+			expect(deviceNames).toContain(MCP_TOOL_NAME);
+			const write = session.getToolByName("write");
+			expect(write).toBeDefined();
+			const result = await write!.execute("deferred-mcp-call", { path: `xd://${MCP_TOOL_NAME}`, content: "{}" });
+			expect(result.content.find(part => part.type === "text")?.text).toBe(TOOL_RESULT);
 		} finally {
 			await session.dispose();
 		}

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -228,6 +228,36 @@ describe("createAgentSession defaultInactive tool activation", () => {
 		}
 	});
 
+	it("does not activate write merely because plan mode is available", async () => {
+		const tempDir = makeTempDir();
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			toolNames: ["read"],
+		});
+
+		try {
+			await session.setActiveToolsByName(["read"]);
+			expect(session.getActiveToolNames()).not.toContain("write");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("preserves write explicitly selected by a runtime caller", async () => {
+		const tempDir = makeTempDir();
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			toolNames: ["read"],
+		});
+
+		try {
+			await session.setActiveToolsByName(["read", "write"]);
+			await session.refreshMCPTools([]);
+			expect(session.getActiveToolNames()).toContain("write");
+		} finally {
+			await session.dispose();
+		}
+	});
 	it("registers vibe tools only during explicit vibe activation", async () => {
 		const tempDir = makeTempDir();
 		const { session } = await createAgentSession(baseOptions(tempDir));

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -135,8 +135,11 @@ describe("createAgentSession defaultInactive tool activation", () => {
 
 		try {
 			expect(session.getActiveToolNames()).toEqual(
-				expect.arrayContaining(["read", "default_active_tool", "default_inactive_tool"]),
+				expect.arrayContaining(["read", "default_inactive_tool", "write"]),
 			);
+			expect(session.getActiveToolNames()).not.toContain("default_active_tool");
+			expect(session.getXdevToolEntries().map(entry => entry.name)).toContain("default_active_tool");
+			expect(session.getXdevToolEntries().map(entry => entry.name)).not.toContain("default_inactive_tool");
 			expect(session.systemPrompt.join("\n")).toContain("default_inactive_tool");
 		} finally {
 			await session.dispose();

--- a/packages/coding-agent/test/tools/index.test.ts
+++ b/packages/coding-agent/test/tools/index.test.ts
@@ -148,6 +148,15 @@ describe("createTools", () => {
 		expect(names).toEqual(["read", "write"]);
 	});
 
+	it("creates an xd:// registry without remounting explicitly requested built-ins", async () => {
+		const session = createTestSession();
+		const tools = await createTools(session, ["read", "lsp"]);
+
+		expect(session.xdevRegistry).toBeDefined();
+		expect(session.xdevRegistry?.entries()).toEqual([]);
+		expect(tools.map(tool => tool.name)).toEqual(["read", "lsp"]);
+	});
+
 	it("lowercases requested tool subset", async () => {
 		const session = createTestSession();
 		const tools = await createTools(session, ["Read", "Write"]);
@@ -206,8 +215,14 @@ describe("createTools", () => {
 		const tools = await createTools(session);
 		expect(tools.map(t => t.name)).not.toContain("ask");
 
-		const requested = await createTools(session, ["ask", "read"]);
-		expect(requested.map(t => t.name)).toEqual(["read", "write"]);
+		const requested = await createTools(
+			createTestSession({
+				hasUI: true,
+				settings: createSettingsWithOverrides({ "ask.enabled": false }),
+			}),
+			["ask", "read"],
+		);
+		expect(requested.map(t => t.name)).toEqual(["read"]);
 	});
 
 	it("includes ask tool when ask.enabled is true and hasUI is true", async () => {
@@ -246,8 +261,8 @@ describe("createTools", () => {
 		expect(names).not.toContain("browser");
 		expect(names).not.toContain("inspect_image");
 
-		const requestedTools = await createTools(session, ["bash", "read"]);
-		expect(requestedTools.map(t => t.name)).toEqual(["read", "write"]);
+		const requestedTools = await createTools(createTestSession({ settings: session.settings }), ["bash", "read"]);
+		expect(requestedTools.map(t => t.name)).toEqual(["read"]);
 	});
 
 	it("auto-includes goal when goal mode is active", async () => {


### PR DESCRIPTION
## What

Restore `xd://` presentation for ambient discoverable custom and MCP tools in sessions that declare an explicit tool list.

Explicitly requested tools remain top-level. Ambient discoverable tools mount under `xd://`, and `write` is activated only when a mounted device needs the execution transport. Deferred MCP connections follow the same lifecycle.

## Why

The xdev consolidation in `5ff277349` created the registry only for default tool sets. Explicit-tool task agents therefore skipped SDK partitioning for inherited MCP proxies and serialized every MCP schema top-level.

With a large MCP catalog this produced a restricted scout request with 194 provider tools instead of the parent's 13-device presentation, tripping provider tool-count and schema-compatibility limits.

This PR fixes presentation only. It preserves inherited MCP reachability; least-privilege MCP authorization remains the separate policy discussion in #2110.

## Testing

- `bun test test/sdk-tool-activation.test.ts test/sdk-generate-image-tool-gating.test.ts test/sdk-mcp-instructions.test.ts test/tools/index.test.ts test/write-xdev-dispatch.test.ts test/task-executor-mcp-timeout.test.ts`
  - 44 pass, 0 fail, 163 assertions
- `bun check` (workspace Biome + TypeScript + Rust checks): passed, no fixes applied
- Worktree CLI smoke with an explicit-tool project scout and one callable local MCP server:
  - project scout override loaded
  - MCP tool absent from top-level schemas
  - MCP tool present under `xd://`
  - `write xd://mcp__instr_do_thing` returned `MCP_SMOKE_OK_7f31`

Broader serial SDK/xdev run: 96 pass plus one pre-existing `AsyncJobManager` singleton failure. The identical serial command on clean `upstream/main` produced the same sole failure (94 pass plus that test); the singleton file passes 4/4 alone.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (user-facing)