### PR TITLE
fix(web-search): scope Kimi search to Kimi Code credentials

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `providers.webSearch: kimi` sending a Moonshot Open Platform credential (`MOONSHOT_API_KEY` / stored `moonshot` auth) to the Kimi Code search endpoint (`api.kimi.com/coding/v1/search`), which rejects it with `401` and silently falls back to another provider. Kimi web search now resolves and advertises Kimi Code credentials only — a Kimi Code Console key via `KIMI_SEARCH_API_KEY` / `MOONSHOT_SEARCH_API_KEY` or `omp /login kimi-code` ([#5762](https://github.com/can1357/oh-my-pi/issues/5762)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/web/search/providers/kimi.ts
+++ b/packages/coding-agent/src/web/search/providers/kimi.ts
@@ -1,7 +1,10 @@
 /**
  * Kimi Web Search Provider
  *
- * Uses Moonshot Kimi Code search API to retrieve web results.
+ * Uses the Kimi Code search API to retrieve web results. This is the Kimi Code
+ * membership service, distinct from the Moonshot Open Platform — it requires a
+ * Kimi Code Console credential (`omp /login kimi-code` or an explicit
+ * `MOONSHOT_SEARCH_API_KEY` / `KIMI_SEARCH_API_KEY`), not `MOONSHOT_API_KEY`.
  * Endpoint: POST https://api.kimi.com/coding/v1/search
  */
 import { type ApiKey, type AuthStorage, type FetchImpl, withAuth } from "@oh-my-pi/pi-ai";
@@ -58,11 +61,17 @@ function resolveBaseUrl(): string {
 }
 
 /**
- * Resolve the Kimi search credential. Highest precedence is the static env key;
- * otherwise an AuthStorage-backed resolver for whichever stored provider id
- * holds a key (`moonshot` first, then `kimi-code`), so a stale token triggers
- * the central force-refresh / sibling-rotate retry. Returns `undefined` when
- * neither is configured.
+ * Resolve the Kimi Code search credential. Highest precedence is the explicit
+ * search-key env override; otherwise an AuthStorage-backed resolver for a
+ * stored `kimi-code` credential (from `omp /login kimi-code`), so a stale token
+ * triggers the central force-refresh / sibling-rotate retry. Returns
+ * `undefined` when neither is configured.
+ *
+ * The endpoint (`https://api.kimi.com/coding/v1/search`) is the Kimi Code
+ * membership service, which has a different credential system from the Moonshot
+ * Open Platform (`https://api.moonshot.ai`). A stored `moonshot` credential
+ * (or `MOONSHOT_API_KEY`) is NOT accepted here — it 401s against Kimi Code
+ * (issue #5762).
  */
 async function resolveKey(
 	authStorage: AuthStorage,
@@ -72,10 +81,8 @@ async function resolveKey(
 	const envKey = asTrimmed($env.MOONSHOT_SEARCH_API_KEY) ?? asTrimmed($env.KIMI_SEARCH_API_KEY);
 	if (envKey) return envKey;
 
-	for (const provider of ["moonshot", "kimi-code"] as const) {
-		const stored = await authStorage.getApiKey(provider, sessionId, { signal });
-		if (stored) return authStorage.resolver(provider, { sessionId });
-	}
+	const stored = await authStorage.getApiKey("kimi-code", sessionId, { signal });
+	if (stored) return authStorage.resolver("kimi-code", { sessionId });
 	return undefined;
 }
 
@@ -127,7 +134,7 @@ export async function searchKimi(params: KimiSearchParams): Promise<SearchRespon
 	const keyOrResolver = await resolveKey(params.authStorage, params.sessionId, params.signal);
 	if (!keyOrResolver) {
 		throw new Error(
-			"Kimi search credentials not found. Set MOONSHOT_SEARCH_API_KEY, KIMI_SEARCH_API_KEY, MOONSHOT_API_KEY, or login with 'omp /login moonshot'.",
+			"Kimi search credentials not found. Kimi web search uses the Kimi Code service (api.kimi.com); set MOONSHOT_SEARCH_API_KEY / KIMI_SEARCH_API_KEY to a Kimi Code Console key, or login with 'omp /login kimi-code'. A Moonshot Open Platform key (MOONSHOT_API_KEY) is not accepted here.",
 		);
 	}
 
@@ -176,7 +183,6 @@ export class KimiProvider extends SearchProvider {
 		return (
 			!!asTrimmed($env.MOONSHOT_SEARCH_API_KEY) ||
 			!!asTrimmed($env.KIMI_SEARCH_API_KEY) ||
-			authStorage.hasAuth("moonshot") ||
 			authStorage.hasAuth("kimi-code")
 		);
 	}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -39,7 +39,12 @@ export const SEARCH_PROVIDER_OPTIONS = [
 	{ value: "tavily", label: "Tavily", description: "Requires TAVILY_API_KEY" },
 	{ value: "firecrawl", label: "Firecrawl", description: "Requires FIRECRAWL_API_KEY" },
 	{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },
-	{ value: "kimi", label: "Kimi", description: "Requires MOONSHOT_SEARCH_API_KEY or MOONSHOT_API_KEY" },
+	{
+		value: "kimi",
+		label: "Kimi",
+		description:
+			"Kimi Code search (requires a Kimi Code Console key via KIMI_SEARCH_API_KEY/MOONSHOT_SEARCH_API_KEY or /login kimi-code; not MOONSHOT_API_KEY)",
+	},
 	{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
 	{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },

--- a/packages/coding-agent/test/tools/web-search-kimi.test.ts
+++ b/packages/coding-agent/test/tools/web-search-kimi.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { KimiProvider, searchKimi } from "@oh-my-pi/pi-coding-agent/web/search/providers/kimi";
+import { removeWithRetries } from "@oh-my-pi/pi-utils";
+
+async function withLocalAuthStorage<T>(run: (authStorage: AuthStorage) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "web-search-kimi-auth-"));
+	const authStorage = await AuthStorage.create(path.join(dir, "auth.db"));
+	try {
+		return await run(authStorage);
+	} finally {
+		authStorage.close();
+		await removeWithRetries(dir);
+	}
+}
+
+describe("KimiProvider availability", () => {
+	afterEach(() => {
+		delete process.env.MOONSHOT_SEARCH_API_KEY;
+		delete process.env.KIMI_SEARCH_API_KEY;
+		vi.restoreAllMocks();
+	});
+
+	it("does not advertise availability for a stored moonshot Open Platform credential", async () => {
+		delete process.env.MOONSHOT_SEARCH_API_KEY;
+		delete process.env.KIMI_SEARCH_API_KEY;
+		const available = await withLocalAuthStorage(authStorage => {
+			// A Moonshot Open Platform key is a different credential system than the
+			// Kimi Code search endpoint (issue #5762) — it must not mark Kimi available.
+			authStorage.setRuntimeApiKey("moonshot", "moonshot-open-platform-key");
+			return Promise.resolve(new KimiProvider().isAvailable(authStorage));
+		});
+		expect(available).toBe(false);
+	});
+
+	it("advertises availability for a stored kimi-code credential", async () => {
+		delete process.env.MOONSHOT_SEARCH_API_KEY;
+		delete process.env.KIMI_SEARCH_API_KEY;
+		const available = await withLocalAuthStorage(authStorage => {
+			authStorage.setRuntimeApiKey("kimi-code", "kimi-code-console-key");
+			return Promise.resolve(new KimiProvider().isAvailable(authStorage));
+		});
+		expect(available).toBe(true);
+	});
+
+	it("advertises availability for the explicit search-key env override", async () => {
+		process.env.MOONSHOT_SEARCH_API_KEY = "kimi-code-console-key";
+		const available = await withLocalAuthStorage(authStorage =>
+			Promise.resolve(new KimiProvider().isAvailable(authStorage)),
+		);
+		expect(available).toBe(true);
+	});
+});
+
+describe("searchKimi credential resolution", () => {
+	afterEach(() => {
+		delete process.env.MOONSHOT_SEARCH_API_KEY;
+		delete process.env.KIMI_SEARCH_API_KEY;
+		vi.restoreAllMocks();
+	});
+
+	it("sends the kimi-code credential to the Kimi Code search endpoint", async () => {
+		delete process.env.MOONSHOT_SEARCH_API_KEY;
+		delete process.env.KIMI_SEARCH_API_KEY;
+		let capturedUrl: string | undefined;
+		let capturedAuth: string | null | undefined;
+		const fetchMock: FetchImpl = (url, init) => {
+			capturedUrl = String(url);
+			capturedAuth = new Headers(init?.headers).get("Authorization");
+			return Promise.resolve(
+				new Response(JSON.stringify({ search_results: [] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			);
+		};
+
+		await withLocalAuthStorage(async authStorage => {
+			authStorage.setRuntimeApiKey("kimi-code", "kimi-code-console-key");
+			const result = await searchKimi({ query: "kimi docs", authStorage, fetch: fetchMock });
+			expect(result.provider).toBe("kimi");
+		});
+
+		expect(capturedUrl).toBe("https://api.kimi.com/coding/v1/search");
+		expect(capturedAuth).toBe("Bearer kimi-code-console-key");
+	});
+
+	it("ignores a stored moonshot credential and reports missing Kimi Code credentials", async () => {
+		delete process.env.MOONSHOT_SEARCH_API_KEY;
+		delete process.env.KIMI_SEARCH_API_KEY;
+		const fetchMock: FetchImpl = () => {
+			throw new Error("fetch should not run without a Kimi Code credential");
+		};
+
+		await withLocalAuthStorage(async authStorage => {
+			authStorage.setRuntimeApiKey("moonshot", "moonshot-open-platform-key");
+			await expect(searchKimi({ query: "kimi docs", authStorage, fetch: fetchMock })).rejects.toThrow(/Kimi Code/);
+		});
+	});
+});


### PR DESCRIPTION
## Repro
With `providers.webSearch: kimi` and only a Moonshot Open Platform credential configured (`MOONSHOT_API_KEY`, valid against `https://api.moonshot.ai`), Kimi web search fails. A minimal repro calling `searchKimi()` with only a stored `moonshot` credential and a mock `fetch` shows the Open Platform key being POSTed to the Kimi Code endpoint and rejected:

```
URL the Moonshot key was sent to: https://api.kimi.com/coding/v1/search
Authorization header: Bearer moonshot-open-platform-key
Error surfaced: kimi: 401 unauthorized status: 401
```

Because `providers.webSearch` is a preference, normal `web_search` calls hide the 401 and fall through to Gemini, so the setting looks ignored.

## Cause
`packages/coding-agent/src/web/search/providers/kimi.ts` targets the Kimi Code membership service (`POST https://api.kimi.com/coding/v1/search`, provider id `kimi-code`, keys from the Kimi Code Console), but `resolveKey()` resolved a stored `moonshot` credential first and `isAvailable()` advertised `authStorage.hasAuth("moonshot")`. Moonshot Open Platform and Kimi Code are distinct credential systems, so a valid Open Platform key (or `MOONSHOT_API_KEY` via the moonshot provider's env fallback) is sent to Kimi Code and 401s. `types.ts` also documented the provider as requiring `MOONSHOT_API_KEY`.

## Fix
- `resolveKey()` in `kimi.ts` now resolves the `kimi-code` credential only (after the explicit `MOONSHOT_SEARCH_API_KEY` / `KIMI_SEARCH_API_KEY` env override); it no longer consumes a stored `moonshot` credential.
- `KimiProvider.isAvailable()` now checks `hasAuth("kimi-code")` only, so a stored `moonshot` credential no longer marks Kimi as available for the auto chain or explicit selection.
- Missing-credential error message and the module header now name the Kimi Code requirement and explicitly note `MOONSHOT_API_KEY` is not accepted.
- `types.ts` provider description updated to point at Kimi Code Console keys / `omp /login kimi-code`.
- Added `test/tools/web-search-kimi.test.ts` covering availability (moonshot rejected, kimi-code and env override accepted) and credential routing (kimi-code key hits the Kimi Code endpoint; a stored moonshot credential is ignored and surfaces a Kimi Code error).
- Changelog entry under `[Unreleased]`.

## Verification
`bun test test/tools/web-search-kimi.test.ts` → 5 pass / 0 fail. `bun check` clean (types + biome). Manually confirmed via the repro above that only a `kimi-code` credential now reaches `https://api.kimi.com/coding/v1/search`. Fixes #5762