### PR TITLE
fix(coding-agent): clear inline images when disabled

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,11 @@
 - Fixed `/quit` and `/exit` hanging during interactive shutdown by making the mnemopi dispose path retain the current session and flush in-flight extractions without sleeping the bank; the `/memory enqueue` path and end-of-session backend enqueue still perform full cross-session consolidation. ([#3641](https://github.com/can1357/oh-my-pi/issues/3641))
 
 ## [17.0.3] - 2026-07-17
+### Fixed
+
+- Fixed disabling **Show Inline Images** leaving previously rendered Kitty graphics over the Ghostty/tmux transcript. The runtime toggle now updates tool and assistant image owners, deletes tracked terminal graphics before replay, and retains hidden read images so they can return when re-enabled.
+
+## [17.0.1] - 2026-07-16
 
 ### Changed
 

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -247,7 +247,6 @@ export class EventController {
 		toolCallId: string,
 		result: { content: Array<{ type: string; data?: string; mimeType?: string }> },
 	): boolean {
-		if (!settings.get("terminal.showImages")) return false;
 		const assistantComponent = this.#readToolCallAssistantComponents.get(toolCallId);
 		if (!assistantComponent) return false;
 		const images: ImageContent[] = result.content
@@ -258,7 +257,7 @@ export class EventController {
 			.map(content => ({ type: "image", data: content.data, mimeType: content.mimeType }));
 		if (images.length === 0) return false;
 		assistantComponent.setToolResultImages(toolCallId, images);
-		return true;
+		return settings.get("terminal.showImages");
 	}
 
 	#insertAfterTranscriptComponent(anchor: Component | undefined, component: Component): boolean {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -442,13 +442,19 @@ export class SelectorController {
 				break;
 
 			// Settings with UI side effects
-			case "showImages":
+			case "showImages": {
+				const visible = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {
 					if (child instanceof ToolExecutionComponent) {
-						child.setShowImages(value as boolean);
+						child.setShowImages(visible);
+					} else if (child instanceof AssistantMessageComponent) {
+						child.setImagesVisible(visible);
 					}
 				}
+				if (!visible) this.ctx.ui.clearInlineImages();
+				this.ctx.ui.resetDisplay();
 				break;
+			}
 			case "hideThinkingBlock":
 				this.ctx.hideThinkingBlock = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -519,10 +519,10 @@ export class UiHelpers {
 					const images: ImageContent[] = message.content.filter(
 						(content): content is ImageContent => content.type === "image",
 					);
-					if (images.length > 0 && assistantComponent && settings.get("terminal.showImages")) {
+					if (images.length > 0 && assistantComponent) {
 						assistantComponent.setToolResultImages(message.toolCallId, images);
 						const hasText = message.content.some(c => c.type === "text");
-						if (!hasText) {
+						if (!hasText && settings.get("terminal.showImages")) {
 							readToolCallArgs.delete(message.toolCallId);
 							readToolCallAssistantComponents.delete(message.toolCallId);
 							continue;

--- a/packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts
+++ b/packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts
@@ -13,18 +13,21 @@
  * one-entry block).
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { ReadToolGroupComponent } from "@oh-my-pi/pi-coding-agent/modes/components/read-tool-group";
 import { EventController } from "@oh-my-pi/pi-coding-agent/modes/controllers/event-controller";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
-import { Container } from "@oh-my-pi/pi-tui";
+import { type Component, Container, Image, ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
 
 beforeAll(async () => {
 	await initTheme(false, undefined, undefined, "dark", "light");
 });
+
+const originalImageProtocol = TERMINAL.imageProtocol;
 
 beforeEach(async () => {
 	resetSettingsForTest();
@@ -33,6 +36,7 @@ beforeEach(async () => {
 
 afterEach(() => {
 	resetSettingsForTest();
+	setTerminalImageProtocol(originalImageProtocol);
 	vi.restoreAllMocks();
 });
 
@@ -104,6 +108,12 @@ function header(group: ReadToolGroupComponent): string {
 	return Bun.stripANSI(group.render(120).join("\n")).split("\n")[0] ?? "";
 }
 
+function hasImageComponent(component: Component): boolean {
+	if (component instanceof Image) return true;
+	if (!("children" in component) || !Array.isArray(component.children)) return false;
+	return component.children.some(child => hasImageComponent(child));
+}
+
 describe("EventController read-group accretion", () => {
 	it("collapses a run of single-read completions into one group (mixed/empty thinking)", async () => {
 		const { controller, chatContainer } = createFixture();
@@ -154,5 +164,34 @@ describe("EventController read-group accretion", () => {
 		// A visible-reasoning completion breaks the run and finalizes the prior group.
 		await streamCompletion(controller, [thinking("done exploring"), read("b.ts:1-50")]);
 		expect(group!.isTranscriptBlockFinalized()).toBe(true);
+	});
+
+	it("retains live read images while hidden so the visibility toggle can reveal them", async () => {
+		Settings.instance.override("terminal.showImages", false);
+		setTerminalImageProtocol(ImageProtocol.Sixel);
+		const { controller, chatContainer } = createFixture();
+		const toolCall = read("hidden.png");
+		await streamCompletion(controller, [toolCall]);
+		const image: ImageContent = {
+			type: "image",
+			data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+			mimeType: "image/png",
+		};
+
+		await controller.handleEvent({
+			type: "tool_execution_end",
+			toolCallId: toolCall.type === "toolCall" ? toolCall.id : "",
+			toolName: "read",
+			result: { content: [image], isError: false },
+			isError: false,
+		} as AgentSessionEvent);
+
+		const assistant = chatContainer.children.find(
+			(child): child is AssistantMessageComponent => child instanceof AssistantMessageComponent,
+		);
+		expect(assistant).toBeDefined();
+		expect(hasImageComponent(assistant!)).toBe(false);
+		assistant?.setImagesVisible(true);
+		expect(hasImageComponent(assistant!)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
+++ b/packages/coding-agent/test/modes/utils/render-initial-messages.test.ts
@@ -16,6 +16,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, ImageContent, Usage } from "@oh-my-pi/pi-ai";
 import { kStreamingPartialJson } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
@@ -127,16 +128,18 @@ function transcriptWith(messages: AgentMessage[]): SessionContext {
 
 function countImageComponents(component: Component): number {
 	const own = component instanceof Image ? 1 : 0;
-	const children = (component as { children?: unknown }).children;
-	if (!Array.isArray(children)) return own;
-	return own + children.reduce((count, child) => count + countImageComponents(child as Component), 0);
+	if (!("children" in component) || !Array.isArray(component.children)) return own;
+	return own + component.children.reduce((count, child) => count + countImageComponents(child), 0);
 }
 
 function hasImageComponent(component: Component): boolean {
 	return countImageComponents(component) > 0;
 }
 
-function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContext; chatContainer: Container } {
+function makeRenderCtx(
+	transcript: SessionContext,
+	showImages = true,
+): { ctx: InteractiveModeContext; chatContainer: Container } {
 	const chatContainer = new Container();
 	let helpers: UiHelpers;
 	const ctx = {
@@ -152,7 +155,7 @@ function makeRenderCtx(transcript: SessionContext): { ctx: InteractiveModeContex
 		resetTranscript: () => chatContainer.clear(),
 		// Rebuild paths honor terminal.showImages since the native-image work;
 		// keep it on so the image-replay contracts below stay meaningful.
-		settings: { get: (key: string) => key === "terminal.showImages" },
+		settings: { get: (key: string) => key === "terminal.showImages" && showImages },
 		toolOutputExpanded: false,
 		hideThinkingBlock: false,
 		focusedAgentId: undefined,
@@ -270,6 +273,33 @@ describe("UiHelpers.renderInitialMessages — image replay", () => {
 
 		expect(hasImageComponent(chatContainer)).toBe(true);
 		expect(Bun.stripANSI(chatContainer.render(100).join("\n"))).toContain("display image 1: 1x1");
+	});
+
+	it("preserves hidden read images so enabling them later can replay the image", async () => {
+		await Settings.init({ inMemory: true, overrides: { "terminal.showImages": false } });
+		setTerminalImageProtocol(ImageProtocol.Sixel);
+		const transcript = transcriptWith([
+			assistantToolCall("read-hidden", "read", { path: "hidden.png" }),
+			{
+				role: "toolResult",
+				toolCallId: "read-hidden",
+				toolName: "read",
+				content: [{ type: "text", text: "Read image: hidden.png" }, pngImage],
+				isError: false,
+				timestamp: 2,
+			},
+		]);
+		const { ctx, chatContainer } = makeRenderCtx(transcript, false);
+
+		new UiHelpers(ctx).renderInitialMessages();
+
+		expect(hasImageComponent(chatContainer)).toBe(false);
+		const assistant = chatContainer.children.find(
+			(child): child is AssistantMessageComponent => child instanceof AssistantMessageComponent,
+		);
+		expect(assistant).toBeDefined();
+		assistant?.setImagesVisible(true);
+		expect(hasImageComponent(chatContainer)).toBe(true);
 	});
 
 	it("replays reopened session image blocks through the cold-start rebuild path", async () => {

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -8,6 +8,8 @@ import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
@@ -64,6 +66,35 @@ describe("selector setting side effects", () => {
 		expect(invalidate).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
 	});
+
+	for (const visible of [false, true]) {
+		it(`updates every image owner and rebuilds the transcript when showImages=${visible}`, () => {
+			const setShowImages = vi.fn();
+			const setImagesVisible = vi.fn();
+			const clearInlineImages = vi.fn();
+			const resetDisplay = vi.fn();
+			const tool = Object.create(ToolExecutionComponent.prototype) as ToolExecutionComponent;
+			tool.setShowImages = setShowImages;
+			const assistant = Object.create(AssistantMessageComponent.prototype) as AssistantMessageComponent;
+			assistant.setImagesVisible = setImagesVisible;
+			const controller = new SelectorController({
+				chatContainer: { children: [tool, assistant] },
+				ui: { clearInlineImages, resetDisplay },
+			} as unknown as InteractiveModeContext);
+
+			controller.handleSettingChange("showImages", visible);
+
+			expect(setShowImages).toHaveBeenCalledWith(visible);
+			expect(setImagesVisible).toHaveBeenCalledWith(visible);
+			expect(clearInlineImages).toHaveBeenCalledTimes(visible ? 0 : 1);
+			expect(resetDisplay).toHaveBeenCalledTimes(1);
+			if (!visible) {
+				expect(clearInlineImages.mock.invocationCallOrder[0]).toBeLessThan(
+					resetDisplay.mock.invocationCallOrder[0],
+				);
+			}
+		});
+	}
 
 	it("clears stale default role thinking when auto is selected", async () => {
 		const testTheme = await getThemeByName("dark");

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -25,6 +25,9 @@
 - Fixed Markdown rendering incorrectly turning local file paths containing `www.` or protocol sequences into HTTP links by requiring a valid GFM left boundary for autolinks.
 - Fixed terminal resize behavior by restoring alternate-screen rendering during drag frames, preventing wrapped fragments from polluting native scrollback while preserving the overlay-exit flicker fix.
 - Added optional right-border scrollbar to the `Editor` component (`setScrollbarVisible`): shows a thumb glyph on the right border when content overflows `maxHeight`, enabling scrollable multi-line editors (e.g. advisor instructions) without losing the submit hint off-screen.
+### Fixed
+
+- Added live-session cleanup for tracked Kitty graphics so consumers can delete retained inline images before replaying text fallbacks.
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1347,6 +1347,20 @@ export class TUI extends Container {
 		this.#imageBudget.setCap(cap);
 	}
 
+	/** Delete every tracked Kitty image from the terminal graphics store. */
+	clearInlineImages(): void {
+		if (this.#stopped) return;
+		this.#purgeInlineImages();
+	}
+
+	#purgeInlineImages(): void {
+		const transmittedIds = this.#imageBudget.takeAllTransmittedIds();
+		if (TERMINAL.imageProtocol !== ImageProtocol.Kitty) return;
+		for (const id of transmittedIds) {
+			this.terminal.write(encodeKittyDeleteImage(id));
+		}
+	}
+
 	/**
 	 * Get whether scrollback divergence rebuild is enabled.
 	 */
@@ -1771,11 +1785,7 @@ export class TUI extends Container {
 			this.#altPreviousLines = [];
 			this.#pendingAltExit = "";
 		}
-		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
-			for (const id of this.#imageBudget.takeAllTransmittedIds()) {
-				this.terminal.write(encodeKittyDeleteImage(id));
-			}
-		}
+		this.#purgeInlineImages();
 		this.#clearSixelProbeState();
 		this.#stopped = true;
 		this.#watchdog.stop();

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -675,6 +675,38 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("deletes every tracked Kitty image during live cleanup", async () => {
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		const tui = new TUI(term);
+		const firstId = tui.imageBudget.acquireId("first");
+		const secondId = tui.imageBudget.acquireId("second");
+		tui.addChild(makeImage(tui.imageBudget, "first"));
+		tui.addChild(makeImage(tui.imageBudget, "second"));
+
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+
+			tui.clearInlineImages();
+
+			const output = writes.join("");
+			expect(output).toContain(encodeKittyDeleteImage(firstId));
+			expect(output).toContain(encodeKittyDeleteImage(secondId));
+			expect(tui.imageBudget.shouldTransmit(firstId)).toBe(true);
+			expect([...tui.imageBudget.takeAllTransmittedIds()]).toEqual([]);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("transmits image data only once; a later full redraw re-emits just the placement", async () => {
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];


### PR DESCRIPTION
## Summary

- propagate the runtime `Show Inline Images` setting to both tool-result and assistant-owned image components
- explicitly delete every tracked Kitty graphics ID before rebuilding the display
- preserve hidden image data so re-enabling the setting can render the images again
- expose terminal-session image cleanup through `TUI.clearInlineImages()` and reuse it during `TUI.stop()`
- cover live toggling, transcript replay, retained read images, and terminal cleanup

## Verification

- `bun test packages/tui/test/image-budget.test.ts packages/coding-agent/test/selector-settings-side-effects.test.ts packages/coding-agent/test/modes/controllers/event-controller-read-grouping.test.ts packages/coding-agent/test/modes/utils/render-initial-messages.test.ts` — 69 passed
- `bun run check:types` in `packages/coding-agent`
- `bun run check:types` in `packages/tui`
- `bun run check:ts` at repository root
- `RUSTUP_TOOLCHAIN=nightly-2026-04-29 bun run check:rs` at repository root

Closes #5766

## Related

- Primary report: #5766
- Parallel implementation generated after reproduction: #5769
- Contributor vouch request: https://github.com/can1357/oh-my-pi/discussions/5976
