### PR TITLE
fix(tui): clear stale inline images on runtime toggle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed disabling **Show Inline Images** leaving stale Kitty graphics over the transcript; runtime toggles now update tool and assistant image owners, delete tracked graphics, and replay committed scrollback with text fallbacks ([#5766](https://github.com/can1357/oh-my-pi/issues/5766)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -559,13 +559,14 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	#renderImageEntries(entries: Array<{ image: ImageContent; key: string }>, withLeadingSpacer: boolean): void {
-		if (!this.#showImages || entries.length === 0) return;
-		this.#convertImagesForKitty(entries);
+		if (entries.length === 0) return;
+		if (this.#showImages) this.#convertImagesForKitty(entries);
 
 		if (withLeadingSpacer) this.#contentContainer.addChild(new Spacer(1));
 		for (const { image, key } of entries) {
-			const displayImage =
-				TERMINAL.imageProtocol === ImageProtocol.Kitty && image.mimeType !== "image/png"
+			const displayImage = !this.#showImages
+				? undefined
+				: TERMINAL.imageProtocol === ImageProtocol.Kitty && image.mimeType !== "image/png"
 					? this.#convertedKittyImages.get(key)
 					: image;
 			if (TERMINAL.imageProtocol && displayImage) {
@@ -834,7 +835,7 @@ export class AssistantMessageComponent extends Container {
 				}
 			} else if (content.type === "image" && content.data && content.mimeType) {
 				this.#renderImageEntries([{ image: content, key: `native:${i}` }], hasRenderedContent);
-				hasRenderedContent ||= this.#showImages;
+				hasRenderedContent = true;
 			}
 		}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -417,13 +417,19 @@ export class SelectorController {
 				break;
 
 			// Settings with UI side effects
-			case "showImages":
+			case "showImages": {
+				const showImages = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {
 					if (child instanceof ToolExecutionComponent) {
-						child.setShowImages(value as boolean);
+						child.setShowImages(showImages);
+					} else if (child instanceof AssistantMessageComponent) {
+						child.setImagesVisible(showImages);
 					}
 				}
+				if (!showImages) this.ctx.ui.purgeImages();
+				this.ctx.ui.resetDisplay();
 				break;
+			}
 			case "hideThinkingBlock":
 				this.ctx.hideThinkingBlock = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -1,15 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { getSupportedEfforts } from "@oh-my-pi/pi-catalog/model-thinking";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
 import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import type { ResolvedRoleModel } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
+import { ImageProtocol, setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui/terminal-capabilities";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
 
 let settingsState: SettingsTestState | undefined;
@@ -314,5 +318,64 @@ describe("selector setting side effects", () => {
 		expect(setModelTemporary).not.toHaveBeenCalled();
 		expect(showModelCycleTrack).toHaveBeenCalledTimes(1);
 		expect(showError).not.toHaveBeenCalled();
+	});
+	it("replays image owners as fallbacks after disabling inline images", () => {
+		const previousProtocol = TERMINAL.imageProtocol;
+		setTerminalImageProtocol(ImageProtocol.Kitty);
+		const actions: string[] = [];
+		const ui = {
+			requestRender: vi.fn(),
+			requestComponentRender: vi.fn(),
+			purgeImages: () => actions.push("purge"),
+			resetDisplay: () => actions.push("reset"),
+		};
+		const message: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "image",
+					data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==",
+					mimeType: "image/png",
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "test",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+		const assistant = new AssistantMessageComponent(message);
+		const tool = new ToolExecutionComponent("image_tool", {}, {}, undefined, ui);
+		tool.updateResult({ content: [message.content[0]] });
+		const controller = new SelectorController({
+			chatContainer: { children: [assistant, tool] },
+			ui,
+		} as unknown as InteractiveModeContext);
+
+		try {
+			controller.handleSettingChange("showImages", false);
+
+			expect(stripVTControlCharacters(assistant.render(80).join("\n"))).toContain("[Image: image/png]");
+			expect(stripVTControlCharacters(tool.render(80).join("\n"))).toContain("[Image: [image/png]");
+			expect(actions).toEqual(["purge", "reset"]);
+
+			actions.length = 0;
+			controller.handleSettingChange("showImages", true);
+
+			expect(assistant.render(80).join("\n")).toContain("\x1b_Ga=T");
+			expect(tool.render(80).join("\n")).toContain("\x1b_Ga=T");
+			expect(actions).toEqual(["reset"]);
+		} finally {
+			setTerminalImageProtocol(previousProtocol);
+			tool.dispose();
+		}
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed runtime image visibility changes lacking a way to delete every tracked Kitty graphic and reset its transmit identity ([#5766](https://github.com/can1357/oh-my-pi/issues/5766)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1334,6 +1334,15 @@ export class TUI extends Container {
 		this.#imageBudget.setCap(cap);
 	}
 
+	/** Delete every tracked Kitty image and reset their transmit identities. */
+	purgeImages(): void {
+		const ids = this.#imageBudget.takeAllTransmittedIds();
+		if (TERMINAL.imageProtocol !== ImageProtocol.Kitty) return;
+		for (const id of ids) {
+			this.terminal.write(encodeKittyDeleteImage(id));
+		}
+	}
+
 	/**
 	 * Get whether scrollback divergence rebuild is enabled.
 	 */
@@ -1750,11 +1759,7 @@ export class TUI extends Container {
 			this.#altPreviousLines = [];
 			this.#pendingAltExit = "";
 		}
-		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
-			for (const id of this.#imageBudget.takeAllTransmittedIds()) {
-				this.terminal.write(encodeKittyDeleteImage(id));
-			}
-		}
+		this.purgeImages();
 		this.#clearSixelProbeState();
 		this.#stopped = true;
 		this.#watchdog.stop();

--- a/packages/tui/test/image-budget.test.ts
+++ b/packages/tui/test/image-budget.test.ts
@@ -675,6 +675,41 @@ describe("TUI inline-image budget", () => {
 		}
 	});
 
+	it("deletes tracked Kitty graphics and retransmits them after a purge", async () => {
+		const term = new VirtualTerminal(40, 12);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+
+		const tui = new TUI(term);
+		const imageId = tui.imageBudget.acquireId("only");
+		tui.addChild(makeImage(tui.imageBudget, "only"));
+
+		try {
+			tui.start();
+			await settle(term);
+			writes.length = 0;
+
+			tui.purgeImages();
+
+			expect(writes.join("")).toContain(encodeKittyDeleteImage(imageId));
+			writes.length = 0;
+
+			tui.clear();
+			tui.addChild(makeImage(tui.imageBudget, "only"));
+			tui.requestRender(true, { clearScrollback: true });
+			await settle(term);
+
+			expect(writes.join("")).toContain("\x1b_Ga=t");
+			expect(writes.join("")).toContain(BASE64_ONE_PIXEL_PNG);
+		} finally {
+			tui.stop();
+		}
+	});
+
 	it("transmits image data only once; a later full redraw re-emits just the placement", async () => {
 		const term = new VirtualTerminal(40, 12);
 		const writes: string[] = [];


### PR DESCRIPTION
## Repro
With Kitty graphics enabled, render an assistant-owned or tool-result image and disable **Show Inline Images** at runtime. `bun test packages/coding-agent/test/selector-settings-side-effects.test.ts` reproduced the bug before the fix: the new setting test failed because `SelectorController.handleSettingChange("showImages", false)` left assistant graphics active and performed no graphics purge or transcript replay.

## Cause
`packages/coding-agent/src/modes/controllers/selector-controller.ts` updated only `ToolExecutionComponent` children for the `showImages` setting. It omitted `AssistantMessageComponent.setImagesVisible()`, did not clear IDs tracked by `TUI.imageBudget`, and did not call `resetDisplay()`, so Kitty retained graphics independently of text redraws and committed transcript snapshots were never rebuilt.

## Fix
- Update tool and assistant image owners on every runtime visibility change; render assistant images as text fallbacks while disabled.
- Add `TUI.purgeImages()` to delete every tracked Kitty image and reset transmit identities before the disabling replay.
- Force a full display reset for both disabling and re-enabling so committed transcript blocks replay in the selected mode.
- Cover graphics deletion/retransmission and both visibility transitions with focused regression tests.

## Verification
`bun test packages/coding-agent/test/selector-settings-side-effects.test.ts packages/tui/test/image-budget.test.ts` — 41 passed, 0 failed, 175 assertions. `bun run check` passed in both `packages/coding-agent` and `packages/tui`. Fixes #5766