### PR TITLE
fix(codex): force tool_choice auto on responses-lite requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Automatically invalidate and rotate OAuth credentials when an "invalidated oauth token" error occurs
+- Fixed GPT-5.6 Codex Responses-Lite requests leaving a forced top-level `tool_choice` (e.g. `{ type: "web_search" }`) after the Lite rewrite moves tools into an `additional_tools` developer item and drops top-level `tools`, which the ChatGPT Codex endpoint rejected with `HTTP 400 Tool choice '…' not found in 'tools' parameter`. `applyCodexResponsesLiteShape` now forces `tool_choice: "auto"`, matching codex-rs `build_responses_request` ([#5771](https://github.com/can1357/oh-my-pi/issues/5771)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/ai/src/providers/openai-codex/request-transformer.ts
+++ b/packages/ai/src/providers/openai-codex/request-transformer.ts
@@ -269,6 +269,7 @@ function stripImageDetails(input: unknown[]): void {
 export interface CodexLiteShapedBody {
 	instructions?: unknown;
 	tools?: unknown;
+	tool_choice?: unknown;
 	input?: unknown;
 	parallel_tool_calls?: unknown;
 }
@@ -278,9 +279,14 @@ export interface CodexLiteShapedBody {
  * `build_responses_request` with `use_responses_lite`): strips pinned image
  * detail, forces parallel tool calling off, moves tools into a leading
  * `additional_tools` developer item and the base instructions into a
- * developer message, then omits top-level `instructions`/`tools`. Shared by
- * normal turns and both remote-compaction paths — codex-rs routes
- * `/responses/compact` through the same builder.
+ * developer message, then omits top-level `instructions`/`tools` and forces
+ * `tool_choice: "auto"`. Because the rewrite removes top-level `tools`, any
+ * forced hosted-tool choice (e.g. `{ type: "web_search" }`) would leave the
+ * backend unable to validate the choice against a tools collection and it
+ * rejects the request with HTTP 400 (#5771); codex-rs always sends
+ * `tool_choice: "auto"` here. Shared by normal turns and both
+ * remote-compaction paths — codex-rs routes `/responses/compact` through the
+ * same builder.
  */
 export function applyCodexResponsesLiteShape(body: CodexLiteShapedBody): void {
 	const input = Array.isArray(body.input) ? body.input : [];
@@ -297,6 +303,7 @@ export function applyCodexResponsesLiteShape(body: CodexLiteShapedBody): void {
 		});
 	}
 	body.input = [...prefix, ...input];
+	body.tool_choice = "auto";
 	delete body.instructions;
 	delete body.tools;
 }

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -297,7 +297,7 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest?.body).toEqual(
 			expect.objectContaining({
 				model: "gpt-5.6-sol",
-				tool_choice: { type: "web_search" },
+				tool_choice: "auto",
 				reasoning: { context: "all_turns" },
 				parallel_tool_calls: false,
 				input: [
@@ -327,6 +327,22 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest?.body?.tools).toBeUndefined();
 		expect(capturedRequest?.body?.instructions).toBeUndefined();
 		expect(result.model).toBe("gpt-5.6-sol");
+	});
+
+	it("never leaves a forced hosted tool_choice on a Responses-Lite request (#5771)", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.6-sol";
+		await searchCodex(makeSearchParams("forced choice guard", mockCodexFetch("gpt-5.6-sol")));
+
+		const body = capturedRequest?.body;
+		expect(body).not.toBeNull();
+		// Lite moves tools into `additional_tools` and drops top-level `tools`;
+		// a forced hosted choice against absent top-level tools is rejected 400.
+		const additionalTools = (body?.input as Array<Record<string, unknown>>)?.[0];
+		expect(additionalTools?.type).toBe("additional_tools");
+		expect(additionalTools?.tools).toEqual([{ type: "web_search", search_context_size: "high" }]);
+		expect(body?.tools).toBeUndefined();
+		expect(body?.tool_choice).toBe("auto");
+		expect(body?.tool_choice).not.toEqual({ type: "web_search" });
 	});
 
 	it("does not retry default candidates when PI_CODEX_WEB_SEARCH_MODEL is explicitly unsupported", async () => {


### PR DESCRIPTION
## Repro
With `providers.webSearch: codex` and a GPT-5.6 Responses-Lite default (`gpt-5.6-luna`/`gpt-5.6-sol`), `omp search --provider codex "…"` fails with `Codex API error (400): Tool choice 'web_search_preview' not found in 'tools' parameter`, and without `--provider` the preferred provider silently falls through to Gemini. Reproduced in-process by capturing the outgoing `searchCodex()` body with `PI_CODEX_WEB_SEARCH_MODEL=gpt-5.6-sol`: the request carried `tool_choice: {"type":"web_search"}` while top-level `tools` was `undefined` and the tool had been moved into an `additional_tools` developer item.

## Cause
`applyCodexResponsesLiteShape` in `packages/ai/src/providers/openai-codex/request-transformer.ts` implements the Responses-Lite contract: it relocates `tools` into a leading `additional_tools` developer input and `delete`s top-level `tools`, but it never rewrote the forced top-level `tool_choice`. `callCodexSearch` (`packages/coding-agent/src/web/search/providers/codex.ts`) sets `tool_choice: { type: "web_search" }` before calling the shaper, so the resulting Lite request forces a hosted-tool choice with no top-level tools collection to validate it against. codex-rs `build_responses_request` always sends `tool_choice: "auto"` for the Responses API, so the forced choice was never valid on the Lite path.

## Fix
- `applyCodexResponsesLiteShape` now sets `body.tool_choice = "auto"` (and `CodexLiteShapedBody` gains a `tool_choice?` field), matching codex-rs. This is the single shared Lite shaper, so the web-search, turn-transformer, and both remote-compaction callers are all fixed at once. Classic (non-Lite) Responses requests are untouched and keep their forced choice since top-level `tools` remains present.
- Updated the existing `gpt-5.6-sol` Lite test to expect `tool_choice: "auto"` and added a regression test asserting the Lite request never leaves a forced hosted `tool_choice` alongside absent top-level `tools`.

## Verification
- `bun test test/tools/web-search-codex.test.ts` (coding-agent): 13 pass.
- `bun test test/openai-codex-responses-lite.test.ts test/issue-1701-repro.test.ts` (ai): 39 pass — confirms the classic forced-choice path is unchanged.
- `bun test` (agent): 376 pass — confirms the shared compaction consumers of the shaper are unaffected.

Fixes #5771