### PR TITLE
feat: Add IXA prefix to session titles when Ixara is detected

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Automatic session titles now receive the `IXA — ` prefix when the Ixara tenant or QuietCare project is detected, while preserving the generated title remainder and explicit user renames.
+
 ## [16.1.22] - 2026-06-26
 
 ### Fixed

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -31,7 +31,12 @@ import { EnhancedPasteController } from "../../utils/enhanced-paste";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
 import { ensureSupportedImageInput, ImageInputTooLargeError, loadImageInput } from "../../utils/image-loading";
 import { resizeImage } from "../../utils/image-resize";
-import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
+import {
+	generateSessionTitle,
+	getSessionTitlePrefix,
+	prefixSessionTitle,
+	setSessionTerminalTitle,
+} from "../../utils/title-generator";
 
 /**
  * Slash commands that may carry secrets in their arguments should never be
@@ -758,6 +763,19 @@ export class InputController {
 			// First, move any pending bash components to chat
 			this.ctx.flushPendingBashComponents();
 
+			const titlePrefix = getSessionTitlePrefix(text, this.ctx.sessionManager.getCwd());
+			const existingName = this.ctx.sessionManager.getSessionName();
+			if (titlePrefix && existingName && this.ctx.sessionManager.titleSource === "auto") {
+				const prefixedName = prefixSessionTitle(existingName, titlePrefix);
+				if (prefixedName !== existingName) {
+					const applied = await this.ctx.sessionManager.setSessionName(prefixedName, "auto");
+					if (applied) {
+						setSessionTerminalTitle(prefixedName, this.ctx.sessionManager.getCwd());
+						this.ctx.updateEditorBorderColor();
+					}
+				}
+			}
+
 			// Auto-generate a session title while the session is still unnamed.
 			// Greetings / acknowledgements / empty input carry no task, so they are
 			// skipped deterministically (no model invoked, no download-progress UI)
@@ -779,7 +797,8 @@ export class InputController {
 						// Re-check: a concurrent attempt for an earlier message may have
 						// already named the session. Don't clobber it.
 						if (title && !this.ctx.sessionManager.getSessionName()) {
-							const applied = await this.ctx.sessionManager.setSessionName(title, "auto");
+							const sessionTitle = prefixSessionTitle(title, titlePrefix);
+							const applied = await this.ctx.sessionManager.setSessionName(sessionTitle, "auto");
 							if (applied) {
 								setSessionTerminalTitle(
 									this.ctx.sessionManager.getSessionName()!,

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -110,7 +110,13 @@ import { vocalizer } from "../tts/vocalizer";
 import type { EventBus } from "../utils/event-bus";
 import { getEditorCommand, openInEditor } from "../utils/external-editor";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../utils/session-color";
-import { popTerminalTitle, pushTerminalTitle, setSessionTerminalTitle } from "../utils/title-generator";
+import {
+	getSessionTitlePrefix,
+	popTerminalTitle,
+	prefixSessionTitle,
+	pushTerminalTitle,
+	setSessionTerminalTitle,
+} from "../utils/title-generator";
 import {
 	isSearchProviderId,
 	isSearchProviderPreference,
@@ -852,6 +858,15 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		// Load initial todos
 		await this.#loadTodoList();
+
+		const titlePrefix = getSessionTitlePrefix("", this.sessionManager.getCwd());
+		const existingName = this.sessionManager.getSessionName();
+		if (titlePrefix && existingName && this.sessionManager.titleSource === "auto") {
+			const prefixedName = prefixSessionTitle(existingName, titlePrefix);
+			if (prefixedName !== existingName) {
+				await this.sessionManager.setSessionName(prefixedName, "auto");
+			}
+		}
 
 		// Start the UI. Cold `omp` launch opts into clearing on the first paint so
 		// the initial welcome frame does not append over the previous run's scrollback.

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -3,8 +3,7 @@
  */
 import * as path from "node:path";
 
-import { type Api, type AssistantMessage, completeSimple, type Model, type Tool } from "@oh-my-pi/pi-ai";
-import { isTerminalHeadless, logger, prompt } from "@oh-my-pi/pi-utils";
+import { $env, isTerminalHeadless, logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 
 import { resolveRoleSelection } from "../config/model-resolver";
@@ -19,6 +18,26 @@ import { tinyTitleClient } from "../tiny/title-client";
 const TITLE_SYSTEM_PROMPT = prompt.render(titleSystemPrompt);
 const TITLE_MARKER_SYSTEM_PROMPT = prompt.render(titleMarkerSystemPrompt);
 const TITLE_MARKER_INSTRUCTION = prompt.render(titleMarkerInstruction);
+
+const IXARA_TITLE_PREFIX = "IXA";
+
+/** Resolve the tenant prefix for a session from explicit context or the QuietCare project. */
+export function getSessionTitlePrefix(firstMessage: string, cwd?: string): string | undefined {
+	const configuredTenant = $env.OMP_TENANT?.trim().toLowerCase();
+	if (configuredTenant === "ixara") return IXARA_TITLE_PREFIX;
+
+	const projectName = cwd ? path.basename(path.resolve(cwd)).toLowerCase() : "";
+	if (projectName === "quietcare" || /\b(ixara|quietcare)\b/i.test(firstMessage)) {
+		return IXARA_TITLE_PREFIX;
+	}
+	return undefined;
+}
+
+/** Prefix automatic titles without changing the generated remainder. */
+export function prefixSessionTitle(title: string, prefix: string | undefined): string {
+	if (!prefix || title === prefix || title.startsWith(`${prefix} — `)) return title;
+	return `${prefix} — ${title}`;
+}
 
 const DEFAULT_TERMINAL_TITLE = "π";
 const TERMINAL_TITLE_CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/g;

--- a/packages/coding-agent/test/session-title-prefix.test.ts
+++ b/packages/coding-agent/test/session-title-prefix.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { getSessionTitlePrefix, prefixSessionTitle } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+
+function withTenant<T>(tenant: string | undefined, fn: () => T): T {
+	const previous = Bun.env.OMP_TENANT;
+	if (tenant === undefined) delete Bun.env.OMP_TENANT;
+	else Bun.env.OMP_TENANT = tenant;
+	try {
+		return fn();
+	} finally {
+		if (previous === undefined) delete Bun.env.OMP_TENANT;
+		else Bun.env.OMP_TENANT = previous;
+	}
+}
+
+describe("automatic IXA session title prefixes", () => {
+	it("detects QuietCare from the project directory", () => {
+		expect(withTenant(undefined, () => getSessionTitlePrefix("Refactor the dashboard", "/tmp/QuietCare"))).toBe(
+			"IXA",
+		);
+	});
+
+	it("detects Ixara from the first user message", () => {
+		expect(
+			withTenant(undefined, () => getSessionTitlePrefix("Investigate the IxArA billing flow", "/tmp/other-project")),
+		).toBe("IXA");
+	});
+
+	it("does not prefix an unrelated context", () => {
+		expect(
+			withTenant(undefined, () => getSessionTitlePrefix("Fix the login flow", "/tmp/other-project")),
+		).toBeUndefined();
+	});
+
+	it("detects an explicit Ixara tenant regardless of message or cwd", () => {
+		expect(withTenant(" ixara ", () => getSessionTitlePrefix("Fix the login flow", "/tmp/other-project"))).toBe(
+			"IXA",
+		);
+	});
+
+	it("does not prefix an explicit non-Ixara tenant", () => {
+		expect(
+			withTenant("acme", () => getSessionTitlePrefix("Fix the login flow", "/tmp/other-project")),
+		).toBeUndefined();
+	});
+
+	it("formats an automatic title and preserves its generated remainder", () => {
+		const generatedTitle = "Fix login redirect for SSO";
+		expect(prefixSessionTitle(generatedTitle, "IXA")).toBe(`IXA — ${generatedTitle}`);
+	});
+
+	it("leaves the generated title unchanged when no prefix is detected", () => {
+		const generatedTitle = "Fix login redirect for SSO";
+		expect(prefixSessionTitle(generatedTitle, undefined)).toBe(generatedTitle);
+	});
+
+	it("does not add a duplicate prefix", () => {
+		const prefixedTitle = "IXA — Fix login redirect for SSO";
+		expect(prefixSessionTitle(prefixedTitle, "IXA")).toBe(prefixedTitle);
+	});
+});


### PR DESCRIPTION
Prefixes OMP session titles with 'IXA - ' if the Ixara Edge profile or ixaracare properties are detected.