### PR TITLE
fix(browser): reject non-string tab selectors with a named error

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed browser `tab.click`/`type`/`fill`/`waitFor*`/`scrollIntoView` crashing with the opaque minified `A.trim is not a function` when handed the `ElementHandle` from `tab.id(n)`/`tab.ref(...)` (or an un-awaited `Promise` of one); the selector funnels now reject non-strings with a `ToolError` naming the recovery (`(await tab.id(n)).click()` or a string selector), and `browser.md` clarifies that handles are called directly rather than passed as selectors ([#5776](https://github.com/can1357/oh-my-pi/issues/5776)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/prompts/tools/browser.md
+++ b/packages/coding-agent/src/prompts/tools/browser.md
@@ -6,7 +6,7 @@ Drives real Chromium tab; full puppeteer access via JS.
 - `run` scope: `page`, `browser`, `tab`, `display`, `assert`, `wait` available. `wait(fn)` polls until truthy — use instead of polling inside `tab.evaluate`.
 
 - `tab` helpers (drop to raw puppeteer `page` for anything uncovered):
-  Element handles: `tab.ref("e5")` / `tab.id(n)`. Also `aria-ref=e5` inline.
+  Element handles: `tab.ref("e5")` / `tab.id(n)` return a handle you call methods on directly — `(await tab.id(n)).click()`, `(await tab.ref("e5")).fill(v)`. They are NOT selectors: `tab.click`/`type`/`fill`/`waitFor*`/`scrollIntoView` take STRING selectors only (pass `"aria-ref=e5"` inline to act on a ref by string).
   Simple: `tab.goto`, `tab.click`, `tab.type`, `tab.fill`, `tab.press`, `tab.scroll`, `tab.scrollIntoView`, `tab.drag`, `tab.uploadFile`, `tab.select`, `tab.screenshot`, `tab.extract`, `tab.evaluate`.
   Waits: `tab.waitFor`, `tab.waitForSelector`, `tab.waitForUrl`, `tab.waitForResponse`, `tab.waitForNavigation`.
   Snapshots: `tab.observe()` → accessibility tree; `tab.ariaSnapshot()` → ARIA YAML with `[ref=eN]`.

--- a/packages/coding-agent/src/tools/browser/aria/aria-snapshot.ts
+++ b/packages/coding-agent/src/tools/browser/aria/aria-snapshot.ts
@@ -1,4 +1,5 @@
 import type { ElementHandle, JSHandle, Page } from "puppeteer-core";
+import { ToolError } from "../../tool-errors";
 import ariaBundle from "./aria-snapshot.bundle.txt" with { type: "text" };
 // `aria-snapshot.bundle.txt` is a generated, committed artifact: Playwright's
 // injected ARIA-snapshot sources (pinned, Apache-2.0) bundled to a CJS module.
@@ -69,6 +70,29 @@ export async function resolveAriaRefHandle(page: Page, ref: string): Promise<Ele
 const ARIA_REF_PREFIXES = ["aria-ref=", "aria-ref/", "ariaref/"];
 
 /**
+ * Guard the selector funnels: `tab.click`/`type`/`fill`/`waitFor*`/`scrollIntoView`
+ * take string selectors only, but user `run` code routinely passes the ElementHandle
+ * from `tab.id(n)`/`tab.ref(...)` (or an un-awaited Promise of one) straight in.
+ * Without this the value reaches `.trim()`/`.startsWith()` and throws the opaque,
+ * minified `A.trim is not a function` instead of a recovery-naming ToolError.
+ */
+export function assertSelectorString(selector: unknown): asserts selector is string {
+	if (typeof selector === "string") return;
+	let kind: string;
+	if (selector !== null && typeof selector === "object") {
+		kind =
+			"then" in selector && typeof selector.then === "function" ? "a Promise (missing await?)" : "an ElementHandle";
+	} else {
+		kind = `a ${typeof selector}`;
+	}
+	throw new ToolError(
+		`Browser selector must be a string; got ${kind}. ` +
+			"tab.click/type/fill/waitFor take string selectors only — " +
+			'call the handle method directly (e.g. (await tab.id(n)).click()) or pass a string like "aria-ref=eN".',
+	);
+}
+
+/**
  * Recognize the explicit `[ref=eN]` selector forms and return the bare ref id,
  * else null. Accepts `aria-ref=e5` (Playwright-MCP style), `aria-ref/e5`, and
  * `ariaref/e5` — lets `tab.click("aria-ref=e5")` etc. act on snapshot refs. A
@@ -78,6 +102,7 @@ const ARIA_REF_PREFIXES = ["aria-ref=", "aria-ref/", "ariaref/"];
  * accepts a bare id directly.)
  */
 export function parseAriaRefSelector(selector: string): string | null {
+	assertSelectorString(selector);
 	const trimmed = selector.trim();
 	for (const prefix of ARIA_REF_PREFIXES) {
 		if (trimmed.startsWith(prefix)) {

--- a/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/cmux-tab.ts
@@ -9,7 +9,7 @@ import type { ToolSession } from "../../index";
 import { resolveToCwd } from "../../path-utils";
 import { formatScreenshot } from "../../render-utils";
 import { ToolAbortError, ToolError, throwIfAborted } from "../../tool-errors";
-import { type AriaSnapshotOptions, buildAriaSnapshotScript } from "../aria/aria-snapshot";
+import { type AriaSnapshotOptions, assertSelectorString, buildAriaSnapshotScript } from "../aria/aria-snapshot";
 import { DEFAULT_VIEWPORT } from "../launch";
 import { extractReadableFromHtml, type ReadableFormat } from "../readable";
 import {
@@ -1015,6 +1015,7 @@ export class CmuxTab {
 	}
 
 	#selectorSpec(selector: string): SelectorSpec {
+		assertSelectorString(selector);
 		const raw = selector;
 		let normalized = selector;
 		if (normalized.startsWith("p-text/")) normalized = `text/${normalized.slice("p-text/".length)}`;

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -24,6 +24,7 @@ import { formatScreenshot } from "../render-utils";
 import { ToolAbortError, ToolError, throwIfAborted } from "../tool-errors";
 import {
 	type AriaSnapshotOptions,
+	assertSelectorString,
 	captureAriaSnapshot,
 	parseAriaRefSelector,
 	resolveAriaRefHandle,
@@ -246,6 +247,7 @@ interface TabApi {
 }
 
 export function normalizeSelector(selector: string): string {
+	assertSelectorString(selector);
 	if (!selector) return selector;
 	if (
 		!SELECTOR_HANDLER_PREFIXES.some(prefix => selector.startsWith(prefix)) &&

--- a/packages/coding-agent/test/tools/browser-aria-snapshot.test.ts
+++ b/packages/coding-agent/test/tools/browser-aria-snapshot.test.ts
@@ -22,6 +22,22 @@ describe("parseAriaRefSelector", () => {
 		expect(parseAriaRefSelector("aria-ref=button")).toBeNull(); // not an eN id
 		expect(parseAriaRefSelector("aria-ref=")).toBeNull();
 	});
+
+	it("rejects non-string selectors (handle/Promise) with a recovery-naming ToolError", () => {
+		// Regression: tab.click(await tab.id(n)) / tab.click(tab.id(n)) used to reach
+		// `selector.trim()` and throw the opaque minified `A.trim is not a function`.
+		const handle = {
+			click: async () => {},
+			asElement() {
+				return this;
+			},
+		};
+		expect(() => parseAriaRefSelector(handle as never)).toThrow(/must be a string; got an ElementHandle/);
+		expect(() => parseAriaRefSelector(handle as never)).toThrow(/\(await tab\.id\(n\)\)\.click\(\)/);
+		const promise = Promise.resolve(handle);
+		expect(() => parseAriaRefSelector(promise as never)).toThrow(/got a Promise \(missing await\?\)/);
+		promise.catch(() => {});
+	});
 });
 
 describe("buildAriaSnapshotScript", () => {

--- a/packages/coding-agent/test/tools/browser-tab-timeouts.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-timeouts.test.ts
@@ -121,4 +121,17 @@ describe("browser selector guard", () => {
 	it("still rewrites legacy p- prefixes", () => {
 		expect(normalizeSelector("p-text/Continue")).toBe("text/Continue");
 	});
+
+	it("rejects non-string selectors (handle/number) instead of crashing on .startsWith", () => {
+		// Regression: passing the ElementHandle from tab.id()/tab.ref() reached
+		// `selector.startsWith(...)` and threw the opaque `A.trim is not a function`.
+		const handle = {
+			click: async () => {},
+			asElement() {
+				return this;
+			},
+		};
+		expect(() => normalizeSelector(handle as never)).toThrow(/must be a string; got an ElementHandle/);
+		expect(() => normalizeSelector(23 as never)).toThrow(/must be a string; got a number/);
+	});
 });


### PR DESCRIPTION
## Repro

Agents following the browser tool docs compose `tab.id`/`tab.ref` (which return an `ElementHandle`) with `tab.click`/`type`/`fill`/`waitFor*`/`scrollIntoView` (which take a string selector):

```js
const obs = await tab.observe();
await tab.click(await tab.id(23)); // or tab.click(tab.id(23))
```

This threw the opaque, minified `A.trim is not a function` instead of an actionable `ToolError`, so agents abandoned `tab.id`/`tab.ref` and fell back to raw Puppeteer. Reproduced against the crash path:

```
$ bun -e "import('./packages/coding-agent/src/tools/browser/aria/aria-snapshot.ts').then(m => m.parseAriaRefSelector({click(){}}))"
TypeError: selector.trim is not a function.
```

## Cause

Every selector-taking `tab.*` op routes its argument through one of two funnels before any validation: `parseAriaRefSelector(selector)` (`packages/coding-agent/src/tools/browser/aria/aria-snapshot.ts`, `selector.trim()`) and `normalizeSelector(selector)` (`packages/coding-agent/src/tools/browser/tab-worker.ts`, `selector.startsWith(...)`). Both call string methods with no type check, so an `ElementHandle` — or an un-awaited `Promise` of one — hits `.trim`/`.startsWith` on a non-string and throws.

## Fix

- Added `assertSelectorString` in `aria-snapshot.ts`: an `asserts selector is string` guard that throws a `ToolError` naming the recovery (`(await tab.id(n)).click()` or a string like `"aria-ref=eN"`) and distinguishing `ElementHandle` / `Promise (missing await?)` / primitive.
- Called it at the top of both selector funnels — `parseAriaRefSelector` and `normalizeSelector` — so every `tab.*` selector path (`click`/`type`/`fill`/`waitFor*`/`scrollIntoView`/`select`/`ariaSnapshot`/`press`) fails fast with the named error.
- Corrected `packages/coding-agent/src/prompts/tools/browser.md`: handles from `tab.id`/`tab.ref` are called directly (`(await tab.id(n)).click()`); `tab.click`/`type`/`fill`/`waitFor*`/`scrollIntoView` take STRING selectors only.
- Added regression tests in `browser-aria-snapshot.test.ts` and `browser-tab-timeouts.test.ts`.

## Verification

`bun test test/tools/browser-aria-snapshot.test.ts test/tools/browser-tab-timeouts.test.ts` → 22 pass, 0 fail. Also verified the guard directly: handle/Promise/number inputs now throw the named `ToolError`, while string selectors (`"aria/Sign in"`, `"aria-ref=e5"`) pass through unchanged.

Fixes #5776