### PR TITLE
fix(tui): prevent vibe_wait TV-wall scrollback stacking

### DIFF
--- a/docs/tui-core-renderer.md
+++ b/docs/tui-core-renderer.md
@@ -135,6 +135,10 @@ of history:
 - `getNativeScrollbackLiveRegionStart()` — first row that may still mutate
   (everything below it, including root chrome rendered after it, stays in the
   window).
+- `isNativeScrollbackLiveRegionPinned()` — optional policy for replacing
+  dashboards: rows at/after the live boundary stay viewport-local instead of
+  entering history as frozen snapshots. When the boundary advances or
+  disappears, newly final rows commit in order.
 - `getNativeScrollbackCommitSafeEnd()` — optional **byte-stable** deeper boundary
   (B): the append-only prefix of the live region (a streaming assistant message's
   settled rows), asserted never to re-layout, so it stays under the audit.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed `vibe_wait` TV-wall panels stacking duplicate frozen frames in native scrollback while two or more workers were live ([#5777](https://github.com/can1357/oh-my-pi/issues/5777)).
+
 - Fixed the `omp grep` CLI subcommand failing on paths with a stray leading colon (e.g. `:/abs/path`); it now routes the path argument through `expandPath` like `read`/`edit`/in-agent `grep`. Broadened `expandPath`'s leading-colon strip to also recover Windows-style shapes (`:C:\repo\file`, `:.\src`, `:..\rel`, `:\\server\share`) ([#5624](https://github.com/can1357/oh-my-pi/issues/5624)).
 - Fixed the `tail` builtin exiting the entire omp process with code 13 on Windows when its output pipe broke (e.g. `seq ... | tail -n 3 | head -n 0`); a broken pipe now surfaces as a normal error instead of calling `std::process::exit` ([#5609](https://github.com/can1357/oh-my-pi/issues/5609)).
 - Fixed a late advisor `blocker` after a terminal primary answer being deferred to the next user turn instead of continuing the current turn: `resolveAdvisorDeliveryChannel` preserved every interrupting severity as a passive card once the primary ended with a terminal text answer and no queued work remained, so a `blocker` flagging a mistake in the final output sat idle until the next prompt. A `blocker` now steers a triggered turn so the primary acknowledges and continues before the turn is considered done; a late `concern` still preserves as a visible card ([#5628](https://github.com/can1357/oh-my-pi/issues/5628)).

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -782,6 +782,11 @@ export class ToolExecutionComponent extends Container implements NativeScrollbac
 		return this.isTranscriptBlockFinalized() ? undefined : 0;
 	}
 
+	/** Keeps the in-flight `vibe_wait` TV wall out of immutable native scrollback. */
+	isNativeScrollbackLiveRegionPinned(): boolean {
+		return this.#toolName === "vibe_wait" && !this.isTranscriptBlockFinalized();
+	}
+
 	/**
 	 * Whether this block has reached a terminal state for transcript freezing.
 	 * Reports `false` while it can still visually change so the

--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -175,6 +175,7 @@ export class TranscriptContainer
 	// final: the leading finalized blocks plus the first live block's declared
 	// settled rows. TUI commits rows to native scrollback only above it.
 	#nativeScrollbackLiveRegionStart: number | undefined;
+	#nativeScrollbackLiveRegionPinned = false;
 	// Persistent assembled transcript rows. Rows before the stable floor are
 	// byte-identical to the previous render; rows at/after it were re-pushed.
 	#lines: string[] = [];
@@ -257,6 +258,11 @@ export class TranscriptContainer
 
 	getNativeScrollbackLiveRegionStart(): number | undefined {
 		return this.#nativeScrollbackLiveRegionStart;
+	}
+
+	/** Propagates viewport pinning from the first still-mutating transcript block. */
+	isNativeScrollbackLiveRegionPinned(): boolean {
+		return this.#nativeScrollbackLiveRegionPinned;
 	}
 
 	/**
@@ -352,6 +358,7 @@ export class TranscriptContainer
 	override render(width: number): readonly string[] {
 		width = Math.max(1, width);
 		this.#nativeScrollbackLiveRegionStart = undefined;
+		this.#nativeScrollbackLiveRegionPinned = false;
 
 		const count = this.children.length;
 		if (this.#compactedChildStart > count) this.#compactedChildStart = count;
@@ -384,6 +391,10 @@ export class TranscriptContainer
 			if (!isBlockFinalized(this.children[i]!)) {
 				liveStartIndex = i;
 				hasLiveBlock = true;
+				this.#nativeScrollbackLiveRegionPinned =
+					(
+						this.children[i] as Component & Partial<NativeScrollbackLiveRegion>
+					).isNativeScrollbackLiveRegionPinned?.() === true;
 				break;
 			}
 		}

--- a/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
+++ b/packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { TranscriptContainer } from "@oh-my-pi/pi-coding-agent/modes/components/transcript-container";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { TUI } from "@oh-my-pi/pi-tui";
 
@@ -150,6 +151,36 @@ describe("ToolExecutionComponent live preview spinners", () => {
 			vi.advanceTimersByTime(500);
 			expect(requestRender).not.toHaveBeenCalled();
 			expect(requestComponentRender).not.toHaveBeenCalled();
+		} finally {
+			component.stopAnimation();
+		}
+	});
+
+	it("pins the live vibe_wait wall and releases it after the final result", () => {
+		const component = new ToolExecutionComponent(
+			"vibe_wait",
+			{},
+			{},
+			undefined,
+			{ requestRender: vi.fn(), requestComponentRender: vi.fn() } as unknown as TUI,
+			process.cwd(),
+		);
+		const transcript = new TranscriptContainer();
+		transcript.addChild(component);
+
+		try {
+			transcript.render(80);
+			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(true);
+
+			component.updateResult(
+				{
+					content: [{ type: "text", text: "No turns in flight to wait for." }],
+					details: { op: "wait", screens: [] },
+				},
+				false,
+			);
+			transcript.render(80);
+			expect(transcript.isNativeScrollbackLiveRegionPinned()).toBe(false);
 		} finally {
 			component.stopAnimation();
 		}

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added viewport-pinned live regions so replacing dashboard frames can stay out of immutable native scrollback until they finalize ([#5777](https://github.com/can1357/oh-my-pi/issues/5777)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -192,17 +192,22 @@ export interface OverlayFocusOwner {
  * FINAL — byte-stable at the current width for the component's lifetime — and
  * commit to native scrollback as exact, audited content. Rows at/after the
  * boundary repaint in place inside the visible window; when they scroll above
- * the window top they still commit — the tape records what was on screen —
- * but as frozen visual snapshots that are permanently audit-exempt: later
- * re-layout of their source never re-anchors or recommits them. A root that
- * reports no seam commits everything that scrolls as final (shell semantics).
+ * the window top they normally commit as frozen visual snapshots.
+ *
+ * A viewport-pinned region opts out of those mutable snapshot commits. Its
+ * offscreen mutable rows are virtually clipped until the boundary advances;
+ * use this for fixed-height dashboards whose frames replace each other rather
+ * than append. A root that reports no seam commits everything that scrolls as
+ * final (shell semantics).
  *
  * When several root children report a seam in the same frame, the topmost one
- * defines the boundary: exactness is prefix-only, so everything below the
- * first seam is already excluded.
+ * defines the boundary and pinning policy: commits are prefix-only, so
+ * everything below the first seam is already excluded.
  */
 export interface NativeScrollbackLiveRegion {
 	getNativeScrollbackLiveRegionStart(): number | undefined;
+	/** Keeps the mutable suffix viewport-local instead of recording frozen snapshots. */
+	isNativeScrollbackLiveRegionPinned?(): boolean;
 }
 
 export interface NativeScrollbackCommittedRows {
@@ -632,11 +637,9 @@ interface CursorControlResult extends HardwareCursorUpdate {
 }
 
 /**
- * One root child's contribution to the composed frame: the array reference its
- * render() returned, the frame row it starts at, the row count recorded at
- * compose time (in-place mutators keep the reference but may change length),
- * and the child-local seam report captured at render time — replayed verbatim
- * when a component-scoped frame reuses this segment without re-rendering.
+ * One root child's contribution to the composed frame: its rendered rows,
+ * frame span, and live-region report captured at render time. Component-scoped
+ * frames replay the seam and viewport-pinning policy without re-rendering.
  */
 interface FrameSegment {
 	component: Component;
@@ -644,6 +647,7 @@ interface FrameSegment {
 	start: number;
 	rowCount: number;
 	liveLocalStart?: number;
+	liveRegionPinned: boolean;
 }
 
 /** Depth-first identity search through `Container`-shaped children. */
@@ -1035,6 +1039,7 @@ export class TUI extends Container {
 	// Exactly what is painted on the screen rows (post-composite, prepared).
 	#previousWindow: string[] = [];
 	#nativeScrollbackLiveRegionStart: number | undefined;
+	#nativeScrollbackLiveRegionPinned = false;
 	#fullRedrawCount = 0;
 	// Caps how many inline images render as live graphics; older ones fall back
 	// to text via a purge + full redraw. Cap is configured by the host app.
@@ -1152,6 +1157,7 @@ export class TUI extends Container {
 	override render(width: number): readonly string[] {
 		width = Math.max(1, width);
 		this.#nativeScrollbackLiveRegionStart = undefined;
+		this.#nativeScrollbackLiveRegionPinned = false;
 		const children = this.children;
 		const previousSegments = this.#frameSegments;
 		const segments: FrameSegment[] = new Array(children.length);
@@ -1172,10 +1178,12 @@ export class TUI extends Container {
 				partialRoots !== null && previous !== undefined && previous.component === child && !partialRoots.has(child);
 			let childLines: readonly string[];
 			let liveLocalStart: number | undefined;
+			let liveRegionPinned = false;
 			let reported: number | undefined;
 			if (reuse) {
 				childLines = previous.lines;
 				liveLocalStart = previous.liveLocalStart;
+				liveRegionPinned = previous.liveRegionPinned;
 			} else {
 				// Feed the engine's committed-row claim (from the previous frame's
 				// emit) before rendering so the child can skip re-deriving blocks
@@ -1195,6 +1203,11 @@ export class TUI extends Container {
 						? Math.max(0, Math.min(childLines.length, Math.trunc(liveRegionStart)))
 						: childLines.length;
 				}
+				if (liveLocalStart !== undefined) {
+					liveRegionPinned =
+						(child as Component & Partial<NativeScrollbackLiveRegion>).isNativeScrollbackLiveRegionPinned?.() ===
+						true;
+				}
 				// Consume the stability report unconditionally for implementers:
 				// reading re-bases the component's baseline to the state this
 				// compose is about to ingest (used or not, the current rows are
@@ -1211,6 +1224,7 @@ export class TUI extends Container {
 			// history.
 			if (liveLocalStart !== undefined && this.#nativeScrollbackLiveRegionStart === undefined) {
 				this.#nativeScrollbackLiveRegionStart = offset + liveLocalStart;
+				this.#nativeScrollbackLiveRegionPinned = liveRegionPinned;
 			}
 			if (chainStable) {
 				if (previous !== undefined && previous.component === child && previous.start === offset) {
@@ -1239,6 +1253,7 @@ export class TUI extends Container {
 				start: offset,
 				rowCount: childLines.length,
 				liveLocalStart,
+				liveRegionPinned,
 			};
 			offset += childLines.length;
 		}
@@ -2831,6 +2846,7 @@ export class TUI extends Container {
 		// known. Ascending by frame row.
 		const cursorMarkers = this.#frameCursorMarkers;
 		const liveRegionStart = this.#nativeScrollbackLiveRegionStart;
+		const liveRegionPinned = this.#nativeScrollbackLiveRegionPinned;
 
 		// Exactness boundary (used by the audit-zone math below). Rows below it
 		// are declared FINAL by the component seam: when they commit, they enter
@@ -2957,7 +2973,7 @@ export class TUI extends Container {
 		if (fullPaint) {
 			committedPrefixResliced = true;
 			windowTop = Math.max(0, frameLength - height);
-			chunkTo = windowTop;
+			chunkTo = liveRegionPinned ? Math.min(windowTop, finalBoundary) : windowTop;
 		} else if (
 			frameLength <= this.#committedRows ||
 			(committedRowsResynced &&
@@ -2977,7 +2993,7 @@ export class TUI extends Container {
 			// "duplication, never loss" is the ED3-unsafe fallback contract.
 			committedPrefixResliced = true;
 			windowTop = Math.max(0, frameLength - height);
-			chunkTo = windowTop;
+			chunkTo = liveRegionPinned ? Math.min(windowTop, finalBoundary) : windowTop;
 			this.#committedRows = chunkTo;
 			this.#committedPrefix = rawFrame.slice(0, chunkTo);
 		} else {
@@ -2996,7 +3012,12 @@ export class TUI extends Container {
 			// history — and re-bases the audit prefix at the new width so the
 			// accepted wrap drift does not read as a violation on the next
 			// ordinary frame.
-			chunkTo = hasVisibleOverlay || geometryChanged ? this.#committedRows : windowTop;
+			chunkTo =
+				hasVisibleOverlay || geometryChanged
+					? this.#committedRows
+					: liveRegionPinned
+						? Math.min(windowTop, Math.max(this.#committedRows, finalBoundary))
+						: windowTop;
 			if (geometryChanged) {
 				committedPrefixResliced = true;
 				this.#committedPrefix = rawFrame.slice(0, this.#committedRows);

--- a/packages/tui/test/streaming-scrollback-defer.test.ts
+++ b/packages/tui/test/streaming-scrollback-defer.test.ts
@@ -59,6 +59,12 @@ class SeamLineList extends LineList implements NativeScrollbackLiveRegion {
 	}
 }
 
+class PinnedSeamLineList extends SeamLineList {
+	isNativeScrollbackLiveRegionPinned(): boolean {
+		return true;
+	}
+}
+
 /**
  * Records the engine's committed-row claim visible at each render() call.
  * Pins the propagation contract: the claim must be fed *before* render so the
@@ -271,6 +277,43 @@ describe("streaming scrollback — visual record", () => {
 			tui.requestRender();
 			await settle(term);
 			expect(tape(term)).toEqual(rows("tool-", 10));
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("keeps a tall viewport-pinned wall out of scrollback until it finalizes", async () => {
+		if (process.platform === "win32") return;
+		const term = new VirtualTerminal(60, 8, 1_000);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const wall = new PinnedSeamLineList([]);
+
+		try {
+			tui.addChild(wall);
+			tui.start();
+			await settle(term);
+
+			const writes = capture(term);
+			let frame: string[] = [];
+			for (let tick = 0; tick < 6; tick++) {
+				frame = Array.from(
+					{ length: 14 },
+					(_unused, row) => `frame-${tick} worker-${Math.floor(row / 7)} row-${row % 7}`,
+				);
+				wall.setLines(frame);
+				tui.requestRender();
+				await settle(term);
+			}
+
+			expect(eraseScrollbackCount(writes)).toBe(0);
+			expect(term.getBufferPosition().baseY).toBe(0);
+			expect(tape(term)).toEqual(frame.slice(-8));
+
+			wall.seam = undefined;
+			tui.requestRender();
+			await settle(term);
+			expect(tape(term)).toEqual(frame);
 		} finally {
 			tui.stop();
 		}


### PR DESCRIPTION
## Repro
A 14-row live TV wall (`getNativeScrollbackLiveRegionStart() === 0`) rendered into an 8-row `VirtualTerminal` committed the first six mutable rows (`baseY=6`); later frames repainted the current two-worker wall below that frozen copy. The regression harness is exercised with `bun test packages/tui/test/streaming-scrollback-defer.test.ts`.

## Cause
`TUI.#doRender()` in `packages/tui/src/tui.ts` used `windowTop` as `chunkTo` for every live region, so overflow rows entered immutable native scrollback even when the frame was a replacing dashboard. `TranscriptContainer` exposed only the live boundary, leaving the in-flight `vibe_wait` wall indistinguishable from append-like live output whose scroll-off snapshots are intentionally retained.

## Fix
- Add an opt-in viewport-pinned policy to `NativeScrollbackLiveRegion`; pinned mutable suffixes are virtually clipped until their boundary advances.
- Propagate the first live transcript block’s pinning policy through `TranscriptContainer` and enable it only for an in-flight `vibe_wait` `ToolExecutionComponent`.
- Cover repeated two-worker-height wall frames, finalization, and the `vibe_wait` live-to-final policy transition.

## Verification
`bun test packages/tui/test/streaming-scrollback-defer.test.ts packages/coding-agent/test/modes/components/tool-execution-spinner.test.ts packages/coding-agent/test/modes/components/transcript-container.test.ts` — 80 passed, 0 failed. `bun check` passed across all packages. Manual `VirtualTerminal` smoke check kept the live wall at `baseY=0` and showed only the latest frame before finalization.

Fixes #5777