### PR TITLE
feat(mcp): per-server lifecycle: lazy|eager + idleTimeoutMs

### DIFF
--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -123,6 +123,16 @@
         },
         "oauth": {
           "$ref": "#/$defs/oauthConfig"
+        },
+        "lifecycle": {
+          "type": "string",
+          "enum": ["eager", "lazy"],
+          "description": "Connection lifecycle. \"eager\" (default) connects at startup. \"lazy\" connects once to populate the tool cache, then defers reconnection until a tool call needs the server, disconnecting again after idleTimeoutMs of inactivity."
+        },
+        "idleTimeoutMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Idle time in milliseconds before a lifecycle: \"lazy\" server disconnects after its last active call. Falls back to mcp.defaultIdleTimeoutMs when unset. 0 disables idle disconnection. Ignored for \"eager\" servers."
         }
       }
     },

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3937,6 +3937,18 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"mcp.defaultIdleTimeoutMs": {
+		type: "number",
+		default: 300_000,
+		ui: {
+			tab: "tools",
+			group: "Discovery & MCP",
+			label: "MCP Lazy Idle Timeout",
+			description:
+				"Default idle time in milliseconds before a lazy-lifecycle MCP server is disconnected after its last use. Per-server idleTimeoutMs overrides this. 0 disables idle disconnection.",
+		},
+	},
+
 	// ────────────────────────────────────────────────────────────────────────
 	// Tasks
 	// ────────────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -279,6 +279,13 @@ export function validateServerConfig(name: string, config: MCPServerConfig): str
 		errors.push(`Server "${name}": unknown server type "${serverType}"`);
 	}
 
+	if (config.lifecycle !== undefined && config.lifecycle !== "eager" && config.lifecycle !== "lazy") {
+		errors.push(`Server "${name}": "lifecycle" must be "eager" or "lazy", got "${config.lifecycle}"`);
+	}
+	if (config.idleTimeoutMs !== undefined && (!Number.isFinite(config.idleTimeoutMs) || config.idleTimeoutMs < 0)) {
+		errors.push(`Server "${name}": "idleTimeoutMs" must be a non-negative number`);
+	}
+
 	return errors;
 }
 

--- a/packages/coding-agent/src/mcp/loader.ts
+++ b/packages/coding-agent/src/mcp/loader.ts
@@ -39,6 +39,8 @@ export interface MCPToolsLoadOptions {
 	cacheStorage?: AgentStorage | null;
 	/** Auth storage used to resolve OAuth credentials before initial MCP connect */
 	authStorage?: AuthStorage;
+	/** Fallback idle timeout (ms) for `lifecycle: "lazy"` servers without a per-server `idleTimeoutMs` */
+	defaultIdleTimeoutMs?: number;
 }
 
 async function resolveToolCache(storage: AgentStorage | null | undefined): Promise<MCPToolCache | null> {
@@ -61,7 +63,7 @@ async function resolveToolCache(storage: AgentStorage | null | undefined): Promi
  */
 export async function discoverAndLoadMCPTools(cwd: string, options?: MCPToolsLoadOptions): Promise<MCPToolsLoadResult> {
 	const toolCache = await resolveToolCache(options?.cacheStorage);
-	const manager = new MCPManager(cwd, toolCache);
+	const manager = new MCPManager(cwd, toolCache, options?.defaultIdleTimeoutMs);
 	if (options?.authStorage) {
 		manager.setAuthStorage(options.authStorage);
 	}

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -34,7 +34,7 @@ import {
 } from "./oauth-credentials";
 import { type MCPStoredOAuthCredential, refreshMCPOAuthToken } from "./oauth-flow";
 import type { McpConnectionStatusEvent } from "./startup-events";
-import type { MCPToolDetails } from "./tool-bridge";
+import type { MCPLazyActivity, MCPToolDetails } from "./tool-bridge";
 import { DeferredMCPTool, MCPTool } from "./tool-bridge";
 import type { MCPToolCache } from "./tool-cache";
 import type {
@@ -55,6 +55,22 @@ type ToolLoadResult = {
 	connection: MCPServerConnection;
 	serverTools: MCPToolDefinition[];
 };
+
+/**
+ * Bookkeeping for a `lifecycle: "lazy"` server. Lives for as long as the
+ * server is known (config discovered), independent of whether it currently
+ * has a live connection.
+ */
+interface LazyServerState {
+	/** Resolved per-server idle timeout; `0` disables idle disconnection. */
+	idleTimeoutMs: number;
+	/** In-flight tool calls. The idle timer only arms while this is `0`. */
+	activeCalls: number;
+	/** Pending idle-reap timer, if armed. */
+	idleTimer?: NodeJS.Timeout;
+	/** Most recently loaded tool definitions, used to rebuild deferred tools on idle-reap or unexpected close. */
+	cachedTools: MCPToolDefinition[];
+}
 
 interface AuthRefreshableMCPTransport extends MCPTransport {
 	onAuthError?: () => Promise<Record<string, string> | null>;
@@ -207,10 +223,16 @@ export class MCPManager {
 	#reconnectHistory = new Map<string, number[]>();
 	/** Monotonic epoch incremented on disconnectAll to invalidate stale reconnections. */
 	#epoch = 0;
+	/** Per-server state for `lifecycle: "lazy"` servers, keyed by server name. */
+	#lazyServers = new Map<string, LazyServerState>();
+	/** Single-flight connect-on-demand attempts for lazy servers. */
+	#pendingLazyConnections = new Map<string, Promise<MCPServerConnection>>();
 
 	constructor(
 		private cwd: string,
 		private toolCache: MCPToolCache | null = null,
+		/** Fallback idle timeout for `lifecycle: "lazy"` servers without a per-server `idleTimeoutMs`. */
+		private defaultIdleTimeoutMs = 300_000,
 	) {}
 
 	/**
@@ -362,6 +384,31 @@ export class MCPManager {
 		// Prepare connection tasks
 		const connectionTasks: ConnectionTask[] = [];
 
+		// Pre-pass: for `lifecycle: "lazy"` servers not yet connected/pending,
+		// check the tool cache up front. A cache hit means startup can skip
+		// the network connect entirely and hand back cache-backed deferred
+		// tools immediately — the opposite default of eager's "connect now,
+		// fall back to cache only if slow". A cold cache (or no cache
+		// storage) falls through to the normal connection-task path below so
+		// the server connects once to populate it.
+		const lazyCacheHits = new Map<string, MCPToolDefinition[]>();
+		if (this.toolCache) {
+			const lazyLookups = Object.entries(configs).filter(
+				([name, config]) =>
+					config.lifecycle === "lazy" &&
+					!this.#connections.has(name) &&
+					!this.#pendingConnections.has(name) &&
+					!this.#pendingToolLoads.has(name) &&
+					!this.#pendingReconnections.has(name),
+			);
+			await Promise.all(
+				lazyLookups.map(async ([name, config]) => {
+					const cached = await this.toolCache?.get(name, config);
+					if (cached && cached.length > 0) lazyCacheHits.set(name, cached);
+				}),
+			);
+		}
+
 		for (const [name, config] of Object.entries(configs)) {
 			if (sources[name]) {
 				this.#sources.set(name, sources[name]);
@@ -382,6 +429,36 @@ export class MCPManager {
 				this.#pendingToolLoads.has(name) ||
 				this.#pendingReconnections.has(name)
 			) {
+				continue;
+			}
+
+			const lazyCached = lazyCacheHits.get(name);
+			if (lazyCached) {
+				const validationErrors = validateServerConfig(name, config);
+				if (validationErrors.length > 0) {
+					const message = validationErrors.join("; ");
+					errors.set(name, message);
+					reportedErrors.add(name);
+					onStatus?.({ type: "failed", serverName: name, error: message });
+					continue;
+				}
+				this.#serverConfigs.set(name, config);
+				this.#lazyServers.set(name, {
+					idleTimeoutMs: this.#lazyIdleTimeoutMs(config),
+					activeCalls: 0,
+					cachedTools: lazyCached,
+				});
+				allTools.push(
+					...DeferredMCPTool.fromTools(
+						name,
+						lazyCached,
+						() => this.ensureConnection(name),
+						sources[name],
+						undefined,
+						this.#lazyActivity(name),
+					),
+				);
+				onStatus?.({ type: "connected", serverName: name });
 				continue;
 			}
 
@@ -444,8 +521,14 @@ export class MCPManager {
 					}
 
 					// Re-establish connection if the transport closes (server restart,
-					// network interruption).
+					// network interruption). Lazy servers instead defer back to
+					// cache-backed tools without retrying — see `#deferLazyServer`.
 					connection.transport.onClose = () => {
+						if (config.lifecycle === "lazy") {
+							logger.debug("MCP lazy server transport closed, deferring reconnection", { path: `mcp:${name}` });
+							this.#deferLazyServer(name);
+							return;
+						}
 						logger.debug("MCP transport lost, triggering reconnect", { path: `mcp:${name}` });
 						void this.reconnectServer(name);
 					};
@@ -474,11 +557,21 @@ export class MCPManager {
 				.then(async ({ connection, serverTools }) => {
 					if (this.#pendingToolLoads.get(name) !== toolsPromise) return;
 					this.#pendingToolLoads.delete(name);
-					const reconnect = () => this.reconnectServer(name);
-					const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
+					const isLazy = config.lifecycle === "lazy";
+					const reconnect = isLazy ? undefined : () => this.reconnectServer(name);
+					const activity = isLazy ? this.#lazyActivity(name) : undefined;
+					const customTools = MCPTool.fromTools(connection, serverTools, reconnect, activity);
 					this.#replaceServerTools(name, customTools);
 					this.#onToolsChanged?.(this.#tools);
 					void this.toolCache?.set(name, config, serverTools);
+					if (isLazy) {
+						this.#lazyServers.set(name, {
+							idleTimeoutMs: this.#lazyIdleTimeoutMs(config),
+							activeCalls: 0,
+							cachedTools: serverTools,
+						});
+						this.#armIdleReap(name);
+					}
 
 					onStatus?.({ type: "connected", serverName: name });
 					await this.#loadServerResourcesAndPrompts(name, connection);
@@ -536,8 +629,18 @@ export class MCPManager {
 					if (!value) continue;
 					const { connection, serverTools } = value;
 					connectedServers.add(name);
-					const reconnect = () => this.reconnectServer(name);
-					allTools.push(...MCPTool.fromTools(connection, serverTools, reconnect));
+					const isLazy = task.config.lifecycle === "lazy";
+					const reconnect = isLazy ? undefined : () => this.reconnectServer(name);
+					const activity = isLazy ? this.#lazyActivity(name) : undefined;
+					allTools.push(...MCPTool.fromTools(connection, serverTools, reconnect, activity));
+					if (isLazy) {
+						this.#lazyServers.set(name, {
+							idleTimeoutMs: this.#lazyIdleTimeoutMs(task.config),
+							activeCalls: 0,
+							cachedTools: serverTools,
+						});
+						this.#armIdleReap(name);
+					}
 				} else if (task.tracked.status === "rejected") {
 					const message =
 						task.tracked.reason instanceof Error ? task.tracked.reason.message : String(task.tracked.reason);
@@ -710,6 +813,141 @@ export class MCPManager {
 	}
 
 	/**
+	 * Single-flight connect-on-demand for `lifecycle: "lazy"` servers.
+	 *
+	 * Returns the live connection if one exists, awaits an in-flight
+	 * connect-on-demand attempt if one is already running, otherwise
+	 * establishes a fresh connection via {@link #connectAndWireServer} —
+	 * the same wiring reconnects use — and re-arms the idle reaper. Unlike
+	 * {@link waitForConnection}, this method itself initiates the connect;
+	 * it is the `getConnection` callback handed to a lazy server's
+	 * `DeferredMCPTool` instances.
+	 */
+	async ensureConnection(name: string): Promise<MCPServerConnection> {
+		const existing = this.#connections.get(name);
+		if (existing) return existing;
+
+		const pending = this.#pendingLazyConnections.get(name);
+		if (pending) return pending;
+
+		const config = this.#serverConfigs.get(name);
+		if (!config) throw new Error(`MCP server not connected: ${name}`);
+
+		const attempt = (async () => {
+			const connection = await this.#connectAndWireServer(name, config, this.#sources.get(name), this.#epoch);
+			this.#armIdleReap(name);
+			return connection;
+		})();
+		this.#pendingLazyConnections.set(name, attempt);
+		return attempt.finally(() => this.#pendingLazyConnections.delete(name));
+	}
+
+	/** Resolve the effective idle timeout for a lazy server's config. */
+	#lazyIdleTimeoutMs(config: MCPServerConfig): number {
+		return config.idleTimeoutMs ?? this.defaultIdleTimeoutMs;
+	}
+
+	/** Idle-reap suppression hooks bound to one lazy server's active-call counter. */
+	#lazyActivity(name: string): MCPLazyActivity {
+		return {
+			begin: () => this.#beginLazyActivity(name),
+			end: () => this.#endLazyActivity(name),
+		};
+	}
+
+	#beginLazyActivity(name: string): void {
+		const state = this.#lazyServers.get(name);
+		if (!state) return;
+		state.activeCalls++;
+		if (state.idleTimer) {
+			clearTimeout(state.idleTimer);
+			state.idleTimer = undefined;
+		}
+	}
+
+	#endLazyActivity(name: string): void {
+		const state = this.#lazyServers.get(name);
+		if (!state) return;
+		state.activeCalls = Math.max(0, state.activeCalls - 1);
+		if (state.activeCalls === 0) this.#armIdleReap(name);
+	}
+
+	/**
+	 * (Re-)arm a lazy server's idle-reap timer. No-op while a call is active
+	 * or `idleTimeoutMs` is `0` (idle reaping disabled — the connection
+	 * stays up indefinitely once activated, per the lazy-lifecycle RFC).
+	 */
+	#armIdleReap(name: string): void {
+		const state = this.#lazyServers.get(name);
+		if (!state || state.activeCalls > 0) return;
+		clearTimeout(state.idleTimer);
+		if (state.idleTimeoutMs <= 0) {
+			state.idleTimer = undefined;
+			return;
+		}
+		state.idleTimer = setTimeout(() => {
+			void this.#reapIdleServer(name);
+		}, state.idleTimeoutMs);
+	}
+
+	/**
+	 * Tear down a lazy server's live connection because it has been idle past
+	 * its timeout, and replace its tools with cache-backed deferred wrappers.
+	 */
+	async #reapIdleServer(name: string): Promise<void> {
+		const state = this.#lazyServers.get(name);
+		if (!state || state.activeCalls > 0) return;
+		const connection = this.#connections.get(name);
+		if (!connection) return;
+		logger.debug("MCP lazy server idle, disconnecting", { path: `mcp:${name}`, idleTimeoutMs: state.idleTimeoutMs });
+		// Detach onClose first so this expected, clean disconnect doesn't
+		// re-enter #deferLazyServer via the transport's own close callback.
+		connection.transport.onClose = undefined;
+		this.#deferLazyServer(name);
+		await disconnectServer(connection).catch(error => {
+			logger.debug("Failed to cleanly disconnect idle MCP server", { path: `mcp:${name}`, error });
+		});
+	}
+
+	/**
+	 * Replace a lazy server's live tools with cache-backed `DeferredMCPTool`
+	 * wrappers and drop its connection bookkeeping. Called on idle-reap and
+	 * on unexpected transport close. Does not touch `#serverConfigs` or
+	 * `#sources` — the server stays known so the next tool call can
+	 * reconnect through {@link ensureConnection}.
+	 *
+	 * Deliberately omits the `reconnect` fallback both `MCPTool` and
+	 * `DeferredMCPTool` otherwise use to retry a call after a retriable
+	 * connection error: a lazy invocation interrupted by transport close
+	 * must surface its original failure rather than implicitly replay a
+	 * possibly side-effecting call. Reconnection happens single-flight, on
+	 * the next invocation, via `getConnection` alone.
+	 */
+	#deferLazyServer(name: string): void {
+		const state = this.#lazyServers.get(name);
+		if (!state) return;
+		if (state.idleTimer) {
+			clearTimeout(state.idleTimer);
+			state.idleTimer = undefined;
+		}
+		state.activeCalls = 0;
+		this.#connections.delete(name);
+
+		const source = this.#sources.get(name);
+		const activity = this.#lazyActivity(name);
+		const deferredTools = DeferredMCPTool.fromTools(
+			name,
+			state.cachedTools,
+			() => this.ensureConnection(name),
+			source,
+			undefined,
+			activity,
+		);
+		this.#replaceServerTools(name, deferredTools);
+		this.#onToolsChanged?.(this.#tools);
+	}
+
+	/**
 	 * Resolve auth and shell-command substitutions in config before connecting.
 	 * Pass `oauth: false` to skip OAuth credential injection (used by reauth's
 	 * unauthenticated probe, which must observe the server's bare 401).
@@ -745,6 +983,10 @@ export class MCPManager {
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
 		this.#reconnectHistory.delete(name);
+		this.#pendingLazyConnections.delete(name);
+		const lazyState = this.#lazyServers.get(name);
+		if (lazyState) clearTimeout(lazyState.idleTimer);
+		this.#lazyServers.delete(name);
 
 		const connection = this.#connections.get(name);
 
@@ -794,6 +1036,11 @@ export class MCPManager {
 		this.#tools = [];
 		this.#subscribedResources.clear();
 		this.#reconnectHistory.clear();
+		this.#pendingLazyConnections.clear();
+		for (const state of this.#lazyServers.values()) {
+			clearTimeout(state.idleTimer);
+		}
+		this.#lazyServers.clear();
 	}
 
 	/**
@@ -976,16 +1223,27 @@ export class MCPManager {
 			};
 		}
 		connection.transport.onClose = () => {
+			if (config.lifecycle === "lazy") {
+				logger.debug("MCP lazy server transport closed, deferring reconnection", { path: `mcp:${name}` });
+				this.#deferLazyServer(name);
+				return;
+			}
 			logger.debug("MCP transport lost, triggering reconnect", { path: `mcp:${name}` });
 			void this.reconnectServer(name);
 		};
 		try {
 			const serverTools = await listTools(connection);
-			const reconnect = () => this.reconnectServer(name);
-			const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
+			const isLazy = config.lifecycle === "lazy";
+			const reconnect = isLazy ? undefined : () => this.reconnectServer(name);
+			const activity = isLazy ? this.#lazyActivity(name) : undefined;
+			const customTools = MCPTool.fromTools(connection, serverTools, reconnect, activity);
 			void this.toolCache?.set(name, config, serverTools);
 			this.#replaceServerTools(name, customTools);
 			this.#onToolsChanged?.(this.#tools);
+			if (isLazy) {
+				const lazyState = this.#lazyServers.get(name);
+				if (lazyState) lazyState.cachedTools = serverTools;
+			}
 			void this.#loadServerResourcesAndPrompts(name, connection);
 			return connection;
 		} catch (error) {
@@ -1038,9 +1296,15 @@ export class MCPManager {
 
 		// Reload tools
 		const serverTools = await listTools(connection);
-		const reconnect = () => this.reconnectServer(name);
-		const customTools = MCPTool.fromTools(connection, serverTools, reconnect);
+		const isLazy = connection.config.lifecycle === "lazy";
+		const reconnect = isLazy ? undefined : () => this.reconnectServer(name);
+		const activity = isLazy ? this.#lazyActivity(name) : undefined;
+		const customTools = MCPTool.fromTools(connection, serverTools, reconnect, activity);
 		void this.toolCache?.set(name, connection.config, serverTools);
+		if (isLazy) {
+			const lazyState = this.#lazyServers.get(name);
+			if (lazyState) lazyState.cachedTools = serverTools;
+		}
 
 		// Replace tools from this server
 		this.#replaceServerTools(name, customTools);

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -28,6 +28,17 @@ import type { MCPContent, MCPServerConnection, MCPToolCallParams, MCPToolCallRes
 export type MCPReconnect = () => Promise<MCPServerConnection | null>;
 
 /**
+ * Idle-reap suppression hooks for `lifecycle: "lazy"` MCP servers. The
+ * manager increments an active-call count on `begin()` and decrements on
+ * `end()`; the idle timer only arms while the count is zero, so a
+ * long-running tool call can never be torn down mid-flight.
+ */
+export interface MCPLazyActivity {
+	begin(): void;
+	end(): void;
+}
+
+/**
  * Network-level and stale-session errors that warrant a reconnect + single retry.
  * Conservative: only catches errors where the server is likely alive but the
  * connection object is stale (dead SSE, expired session, refused after restart).
@@ -334,14 +345,25 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mergeCallAndResult = true;
 
 	/** Create MCPTool instances for all tools from an MCP server connection */
-	static fromTools(connection: MCPServerConnection, tools: MCPToolDefinition[], reconnect?: MCPReconnect): MCPTool[] {
-		return tools.map(tool => new MCPTool(connection, tool, reconnect));
+	static fromTools(
+		connection: MCPServerConnection,
+		tools: MCPToolDefinition[],
+		reconnect?: MCPReconnect,
+		activity?: MCPLazyActivity,
+	): MCPTool[] {
+		return tools.map(tool => new MCPTool(connection, tool, reconnect, activity));
 	}
 
 	constructor(
 		private connection: MCPServerConnection,
 		private readonly tool: MCPToolDefinition,
 		private readonly reconnect?: MCPReconnect,
+		/**
+		 * Idle-reap suppression hook for `lifecycle: "lazy"` servers — see
+		 * {@link MCPLazyActivity}. Undefined for eager servers, which have no
+		 * idle timer.
+		 */
+		private readonly activity?: MCPLazyActivity,
 	) {
 		this.name = createMCPToolName(connection.name, tool.name);
 		this.label = `${connection.name}/${tool.name}`;
@@ -371,6 +393,7 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		const provider = this.connection._source?.provider;
 		const providerName = this.connection._source?.providerName;
 
+		this.activity?.begin();
 		try {
 			const result = await callTool(this.connection, this.tool.name, args, { signal });
 			return buildResult(result, this.connection.name, this.tool.name, provider, providerName);
@@ -399,6 +422,8 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 				}
 			}
 			return buildErrorResult(error, this.connection.name, this.tool.name, provider, providerName);
+		} finally {
+			this.activity?.end();
 		}
 	}
 }
@@ -429,8 +454,9 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		getConnection: () => Promise<MCPServerConnection>,
 		source?: SourceMeta,
 		reconnect?: MCPReconnect,
+		activity?: MCPLazyActivity,
 	): DeferredMCPTool[] {
-		return tools.map(tool => new DeferredMCPTool(serverName, tool, getConnection, source, reconnect));
+		return tools.map(tool => new DeferredMCPTool(serverName, tool, getConnection, source, reconnect, activity));
 	}
 
 	constructor(
@@ -439,6 +465,15 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		private readonly getConnection: () => Promise<MCPServerConnection>,
 		source?: SourceMeta,
 		private readonly reconnect?: MCPReconnect,
+		/**
+		 * Idle-reap suppression hook for `lifecycle: "lazy"` servers. `begin()`
+		 * is called before connection resolution and `end()` in a `finally`
+		 * once the call settles, so the manager's idle timer never fires
+		 * mid-call. Absent for eager-cache-backed deferred tools (the
+		 * pre-lazy-lifecycle fallback path used when a server is still
+		 * connecting at startup), which have no idle timer to suppress.
+		 */
+		private readonly activity?: MCPLazyActivity,
 	) {
 		this.name = createMCPToolName(serverName, tool.name);
 		this.label = `${serverName}/${tool.name}`;
@@ -470,6 +505,20 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		const provider = this.#fallbackProvider;
 		const providerName = this.#fallbackProviderName;
 
+		this.activity?.begin();
+		try {
+			return await this.#executeInner(args, provider, providerName, signal);
+		} finally {
+			this.activity?.end();
+		}
+	}
+
+	async #executeInner(
+		args: MCPToolArgs,
+		provider: string | undefined,
+		providerName: string | undefined,
+		signal?: AbortSignal,
+	): Promise<CustomToolResult<MCPToolDetails>> {
 		try {
 			const connection = await untilAborted(signal, () => this.getConnection());
 			throwIfAborted(signal);

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -77,6 +77,22 @@ interface MCPServerConfigBase {
 		/** `prompt` param for the authorization request (default "consent"; "" to omit) */
 		prompt?: string;
 	};
+	/**
+	 * Connection lifecycle. `"eager"` (default) connects at startup like
+	 * every other server. `"lazy"` connects once on first run to populate
+	 * the tool cache, then defers reconnection until a tool call actually
+	 * needs the server, disconnecting again after `idleTimeoutMs` of no
+	 * active calls.
+	 */
+	lifecycle?: "eager" | "lazy";
+	/**
+	 * Idle time in milliseconds before a `lifecycle: "lazy"` server is
+	 * disconnected after its last active call. Falls back to
+	 * `mcp.defaultIdleTimeoutMs` when unset. `0` disables idle
+	 * disconnection — the server stays connected indefinitely once
+	 * activated. Ignored for `"eager"` servers.
+	 */
+	idleTimeoutMs?: number;
 }
 
 /** Stdio server configuration */

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1701,10 +1701,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// Filter browser MCP servers when builtin browser tool is active
 			filterBrowser: settings.get("browser.enabled") ?? false,
 		};
+		const mcpDefaultIdleTimeoutMs = settings.get("mcp.defaultIdleTimeoutMs") ?? 300_000;
 		if (enableMCP && !mcpManager) {
 			if (deferMCPDiscoveryForUI) {
 				const cacheStorage = settings.getStorage();
-				mcpManager = new MCPManager(cwd, cacheStorage ? new MCPToolCache(cacheStorage) : null);
+				mcpManager = new MCPManager(
+					cwd,
+					cacheStorage ? new MCPToolCache(cacheStorage) : null,
+					mcpDefaultIdleTimeoutMs,
+				);
 				mcpManager.setAuthStorage(authStorage);
 				toolSession.mcpManager = mcpManager;
 
@@ -1743,6 +1748,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					...mcpDiscoverOptions,
 					cacheStorage: settings.getStorage(),
 					authStorage,
+					defaultIdleTimeoutMs: mcpDefaultIdleTimeoutMs,
 				});
 				mcpManager = mcpResult.manager;
 				toolSession.mcpManager = mcpManager;

--- a/packages/coding-agent/test/fixtures/lazy-lifecycle-mcp.ts
+++ b/packages/coding-agent/test/fixtures/lazy-lifecycle-mcp.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture for `lifecycle: "lazy"` MCP server tests.
+ *
+ * A minimal, long-lived stdio MCP server that answers `initialize` +
+ * `tools/list` with a single `echo` tool and answers `tools/call` for it.
+ * Unlike `crash-after-init-mcp.ts` it does NOT exit after the handshake —
+ * lazy-lifecycle tests need a connection that stays open until the manager
+ * (or the test) tears it down, so idle-reap and reconnect-on-demand
+ * behavior can be observed independently of process lifetime.
+ *
+ * Each invocation atomically appends the PID + timestamp to the path in
+ * `$OMP_TEST_SPAWN_LOG`, so tests can assert exactly how many times the
+ * manager connected (zero for a warm cache hit, one for a cold-cache
+ * activation, two after an idle-reap + on-demand reconnect, etc.).
+ */
+import * as fs from "node:fs";
+import * as readline from "node:readline";
+
+const spawnLog = Bun.env.OMP_TEST_SPAWN_LOG;
+if (spawnLog) {
+	fs.appendFileSync(spawnLog, `${process.pid} ${Date.now()}\n`);
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(message: Record<string, unknown>): void {
+	process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+rl.on("line", line => {
+	let message: { id?: number | string; method?: string; params?: { name?: string; arguments?: unknown } };
+	try {
+		message = JSON.parse(line);
+	} catch {
+		return;
+	}
+
+	if (message.method === "initialize" && message.id !== undefined) {
+		send({
+			jsonrpc: "2.0",
+			id: message.id,
+			result: {
+				protocolVersion: "2025-03-26",
+				capabilities: { tools: {} },
+				serverInfo: { name: "lazy-lifecycle-fixture", version: "1.0.0" },
+			},
+		});
+		return;
+	}
+
+	if (message.method === "tools/list" && message.id !== undefined) {
+		send({
+			jsonrpc: "2.0",
+			id: message.id,
+			result: {
+				tools: [
+					{
+						name: "echo",
+						description: "Echoes back its input",
+						inputSchema: { type: "object", properties: { text: { type: "string" } } },
+					},
+				],
+			},
+		});
+		return;
+	}
+
+	if (message.method === "tools/call" && message.id !== undefined) {
+		const text = (message.params?.arguments as { text?: string } | undefined)?.text ?? "";
+		send({
+			jsonrpc: "2.0",
+			id: message.id,
+			result: { content: [{ type: "text", text }] },
+		});
+		return;
+	}
+});
+
+rl.on("close", () => process.exit(0));

--- a/packages/coding-agent/test/mcp-config-lazy-lifecycle.test.ts
+++ b/packages/coding-agent/test/mcp-config-lazy-lifecycle.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for the `lifecycle`/`idleTimeoutMs` fields added to
+ * `MCPServerConfigBase` by RFC #2888 ("per-server MCP lifecycle: lazy|eager
+ * + idleTimeout"). Pure config validation — no subprocess, no manager.
+ */
+import { describe, expect, it } from "bun:test";
+import { validateServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/config";
+import type { MCPStdioServerConfig } from "@oh-my-pi/pi-coding-agent/mcp/types";
+
+function baseConfig(): MCPStdioServerConfig {
+	return { type: "stdio", command: "echo" };
+}
+
+describe("MCP lazy-lifecycle config validation", () => {
+	it("accepts an eager server (the default) with no lifecycle field", () => {
+		expect(validateServerConfig("s", baseConfig())).toEqual([]);
+	});
+
+	it('accepts an explicit lifecycle: "eager"', () => {
+		expect(validateServerConfig("s", { ...baseConfig(), lifecycle: "eager" })).toEqual([]);
+	});
+
+	it('accepts lifecycle: "lazy" with an idleTimeoutMs', () => {
+		expect(validateServerConfig("s", { ...baseConfig(), lifecycle: "lazy", idleTimeoutMs: 60_000 })).toEqual([]);
+	});
+
+	it('accepts lifecycle: "lazy" with idleTimeoutMs: 0 (idle reaping disabled)', () => {
+		expect(validateServerConfig("s", { ...baseConfig(), lifecycle: "lazy", idleTimeoutMs: 0 })).toEqual([]);
+	});
+
+	it('accepts lifecycle: "lazy" with no idleTimeoutMs (falls back to the manager default)', () => {
+		expect(validateServerConfig("s", { ...baseConfig(), lifecycle: "lazy" })).toEqual([]);
+	});
+
+	it("rejects an unknown lifecycle value", () => {
+		const errors = validateServerConfig("s", {
+			...baseConfig(),
+			// @ts-expect-error intentionally invalid for the test
+			lifecycle: "eventually",
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('"lifecycle" must be "eager" or "lazy"');
+	});
+
+	it("rejects a negative idleTimeoutMs", () => {
+		const errors = validateServerConfig("s", { ...baseConfig(), lifecycle: "lazy", idleTimeoutMs: -1 });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('"idleTimeoutMs" must be a non-negative number');
+	});
+
+	it("rejects a non-finite idleTimeoutMs", () => {
+		const errors = validateServerConfig("s", { ...baseConfig(), lifecycle: "lazy", idleTimeoutMs: Number.NaN });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('"idleTimeoutMs" must be a non-negative number');
+	});
+});

--- a/packages/coding-agent/test/mcp-lazy-lifecycle.test.ts
+++ b/packages/coding-agent/test/mcp-lazy-lifecycle.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Integration tests for `lifecycle: "lazy"` MCP servers (RFC #2888).
+ *
+ * Contract under test, confirmed with the maintainer on the RFC thread:
+ *  - a lazy server with a *cold* cache connects once at startup (same as
+ *    eager) so the tool cache gets populated, then arms an idle-reap timer;
+ *  - a lazy server with a *warm* cache skips the network connect entirely at
+ *    startup and hands back cache-backed `DeferredMCPTool` instances — the
+ *    opposite default of eager's "connect now, fall back to cache only if
+ *    slow";
+ *  - once idle past `idleTimeoutMs` with no active calls, the manager
+ *    disconnects the live connection and swaps back to cache-backed
+ *    deferred tools, publishing the existing tools-changed notification;
+ *  - the next tool call reconnects single-flight through
+ *    `MCPManager.ensureConnection`, independent of `xd://` mounting;
+ *  - `idleTimeoutMs: 0` disables idle reaping — once activated, the
+ *    connection stays up indefinitely;
+ *  - an invocation interrupted by an unexpected transport close surfaces
+ *    its original failure rather than being silently retried, and the
+ *    server re-arms as deferred so the *next* invocation reconnects.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DeferredMCPTool, MCPTool } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
+import type { MCPStdioServerConfig, MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import type { AgentStorage } from "@oh-my-pi/pi-coding-agent/session/agent-storage";
+import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
+import { MCPManager } from "../src/mcp/manager";
+import { MCPToolCache } from "../src/mcp/tool-cache";
+
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "lazy-lifecycle-mcp.ts");
+const BUN_EXEC = process.execPath;
+
+/** In-memory stand-in for `AgentStorage`'s cache surface, used to pre-warm or inspect the MCP tool cache without a real SQLite file. */
+function createFakeCacheStorage(): AgentStorage {
+	const rows = new Map<string, { value: string; expiresAtSec: number }>();
+	return {
+		getCache(key: string): string | null {
+			const row = rows.get(key);
+			if (!row) return null;
+			if (row.expiresAtSec * 1000 < Date.now()) {
+				rows.delete(key);
+				return null;
+			}
+			return row.value;
+		},
+		setCache(key: string, value: string, expiresAtSec: number): void {
+			rows.set(key, { value, expiresAtSec });
+		},
+	} as unknown as AgentStorage;
+}
+
+/**
+ * Polls a real wall-clock condition instead of faking timers. The idle-reap
+ * timer under test is a genuine `setTimeout` racing against a real spawned
+ * `bun` subprocess's transport close — there is no promise or event the
+ * production code exposes to await directly, and fake timers cannot
+ * advance a real subprocess's I/O. See mcp-reconnect-storm.test.ts and
+ * mcp-startup-no-block.test.ts for the same established pattern.
+ */
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 5_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!(await predicate())) {
+		if (Date.now() >= deadline) throw new Error("waitFor timed out");
+		await Bun.sleep(5);
+	}
+}
+
+describe("MCP lazy lifecycle (RFC #2888)", () => {
+	let workDir: string;
+	let spawnLog: string;
+
+	beforeEach(() => {
+		workDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mcp-lazy-"));
+		spawnLog = path.join(workDir, "spawns.log");
+		fs.writeFileSync(spawnLog, "");
+	});
+
+	afterEach(() => {
+		removeSyncWithRetries(workDir);
+	});
+
+	function countSpawns(): number {
+		const text = fs.readFileSync(spawnLog, "utf8");
+		return text.split("\n").filter(line => line.trim().length > 0).length;
+	}
+
+	function lazyConfig(
+		overrides?: Partial<Pick<MCPStdioServerConfig, "idleTimeoutMs" | "lifecycle">>,
+	): MCPStdioServerConfig {
+		return {
+			type: "stdio",
+			command: BUN_EXEC,
+			args: [FIXTURE_PATH],
+			env: { OMP_TEST_SPAWN_LOG: spawnLog },
+			lifecycle: "lazy",
+			idleTimeoutMs: 60_000,
+			...overrides,
+		};
+	}
+
+	it("cold cache: connects once at startup to populate the cache, then arms the idle reaper", async () => {
+		const cache = new MCPToolCache(createFakeCacheStorage());
+		const manager = new MCPManager(workDir, cache);
+		try {
+			const result = await manager.connectServers({ lazy: lazyConfig() }, {});
+
+			expect(countSpawns()).toBe(1);
+			expect(result.tools.map(t => t.name)).toEqual(["mcp__lazy_echo"]);
+			expect(result.tools[0]).toBeInstanceOf(MCPTool);
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+
+			// Tool cache is now warm for the next session. The write is
+			// fire-and-forget (`void this.toolCache?.set(...)`, matching the
+			// pre-existing eager-path pattern), so poll for it rather than
+			// asserting immediately after `connectServers` resolves.
+			const deadline = Date.now() + 5_000;
+			let cached: MCPToolDefinition[] | null = await cache.get("lazy", lazyConfig());
+			while (cached === null) {
+				if (Date.now() >= deadline) throw new Error("MCP tool cache was never populated");
+				await Bun.sleep(5);
+				cached = await cache.get("lazy", lazyConfig());
+			}
+			expect(cached.map(t => t.name)).toEqual(["echo"]);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	it("warm cache: skips the network connect entirely at startup", async () => {
+		const cache = new MCPToolCache(createFakeCacheStorage());
+		const config = lazyConfig();
+		const cachedTool: MCPToolDefinition = {
+			name: "echo",
+			description: "Echoes back its input",
+			inputSchema: { type: "object", properties: { text: { type: "string" } } },
+		};
+		await cache.set("lazy", config, [cachedTool]);
+
+		const manager = new MCPManager(workDir, cache);
+		try {
+			const result = await manager.connectServers({ lazy: config }, {});
+
+			expect(countSpawns()).toBe(0);
+			expect(result.tools.map(t => t.name)).toEqual(["mcp__lazy_echo"]);
+			expect(result.tools[0]).toBeInstanceOf(DeferredMCPTool);
+			// A warm-cache lazy server isn't actually connected yet — matches
+			// the pre-existing eager "slow server + cached fallback" semantics.
+			expect(result.connectedServers).toEqual([]);
+			expect(manager.getConnectionStatus("lazy")).toBe("disconnected");
+
+			// The deferred tool still works: calling it connects on demand.
+			const callResult = await result.tools[0].execute("call-1", { text: "hi" }, undefined, {} as never, undefined);
+			expect(countSpawns()).toBe(1);
+			expect(callResult.isError).not.toBe(true);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	it("idle-reaps a connected lazy server and reconnects on the next call", async () => {
+		const cache = new MCPToolCache(createFakeCacheStorage());
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: lazyConfig({ idleTimeoutMs: 30 }) }, {});
+			expect(countSpawns()).toBe(1);
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+
+			// No active calls: the idle timer fires and tears the connection down.
+			await waitFor(() => manager.getConnectionStatus("lazy") === "disconnected");
+
+			const toolsAfterReap = manager.getTools();
+			expect(toolsAfterReap).toHaveLength(1);
+			expect(toolsAfterReap[0]).toBeInstanceOf(DeferredMCPTool);
+
+			// The next call reconnects single-flight through `ensureConnection`.
+			const connection = await manager.ensureConnection("lazy");
+			expect(connection.name).toBe("lazy");
+			expect(countSpawns()).toBe(2);
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	it("idleTimeoutMs: 0 disables idle reaping — the connection stays up indefinitely", async () => {
+		const cache = new MCPToolCache(createFakeCacheStorage());
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: lazyConfig({ idleTimeoutMs: 0 }) }, {});
+			expect(countSpawns()).toBe(1);
+
+			// Proving a negative (no timer fires) has no event to await; hold
+			// real wall-clock time well past the other tests' 20-30ms
+			// idleTimeoutMs values, which already fire reliably against a real
+			// spawned subprocess in this file.
+			await Bun.sleep(150);
+
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+			expect(countSpawns()).toBe(1);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	it("concurrent on-demand calls single-flight the reconnect (no duplicate spawns)", async () => {
+		const cache = new MCPToolCache(createFakeCacheStorage());
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: lazyConfig({ idleTimeoutMs: 20 }) }, {});
+			await waitFor(() => manager.getConnectionStatus("lazy") === "disconnected");
+			expect(countSpawns()).toBe(1);
+
+			const [a, b, c] = await Promise.all([
+				manager.ensureConnection("lazy"),
+				manager.ensureConnection("lazy"),
+				manager.ensureConnection("lazy"),
+			]);
+			expect(countSpawns()).toBe(2);
+			expect(a).toBe(b);
+			expect(b).toBe(c);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+
+	it("an unexpected transport close defers the server without retrying the interrupted call", async () => {
+		const cache = new MCPToolCache(createFakeCacheStorage());
+		const manager = new MCPManager(workDir, cache);
+		try {
+			await manager.connectServers({ lazy: lazyConfig({ idleTimeoutMs: 60_000 }) }, {});
+			expect(manager.getConnectionStatus("lazy")).toBe("connected");
+
+			const connection = manager.getConnection("lazy");
+			expect(connection).toBeDefined();
+
+			// Simulate the transport dropping unexpectedly (server restart,
+			// network blip) while the connection is otherwise idle.
+			connection?.transport.onClose?.();
+
+			expect(manager.getConnectionStatus("lazy")).toBe("disconnected");
+			const toolsAfterClose = manager.getTools();
+			expect(toolsAfterClose).toHaveLength(1);
+			expect(toolsAfterClose[0]).toBeInstanceOf(DeferredMCPTool);
+
+			// Reconnects single-flight on the next call rather than auto-retrying
+			// inside the interrupted invocation.
+			const fresh = await manager.ensureConnection("lazy");
+			expect(fresh.name).toBe("lazy");
+			expect(countSpawns()).toBe(2);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});

--- a/packages/collab-web/CHANGELOG.md
+++ b/packages/collab-web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added per-server MCP `lifecycle: "eager" | "lazy"` and `idleTimeoutMs`: a `lazy` server skips connecting at startup when its tool cache is warm, connects on demand through the first tool call, and disconnects again after `idleTimeoutMs` of inactivity. ([#2888](https://github.com/can1357/oh-my-pi/issues/2888))
+
 ## [17.0.1] - 2026-07-16
 
 ### Fixed


### PR DESCRIPTION
Implements the design confirmed on RFC #2888 (design direction confirmed by @roboomp on 2026-07-16, five lifecycle-decision defaults matched: `idleTimeoutMs` spelling, cold-cache-connect-once, all-transports, defer-not-retry on unexpected close, `idleTimeoutMs: 0` semantics).

## What changed

- `MCPServerConfigBase` gains `lifecycle: "eager" | "lazy"` (default `"eager"`, unchanged behavior) and `idleTimeoutMs`, validated in `validateServerConfig` and documented in `mcp-schema.json`. `mcp.defaultIdleTimeoutMs` is the global fallback (`settings-schema.ts`), threaded through `loader.ts` and `sdk.ts` into the `MCPManager` constructor.
- `MCPManager` tracks per-server lazy state (idle timer, active-call count, cached tool defs). `connectServers` pre-checks the tool cache for lazy servers: a **warm cache skips the network connect entirely** at startup and returns cache-backed `DeferredMCPTool` instances — the opposite default of eager's "connect now, fall back to cache only if slow." A **cold cache connects once** (like eager) to populate it, then arms the idle reaper.
- Activation is direct tool dispatch, as specified: `DeferredMCPTool.execute()` calls a new single-flight `MCPManager.ensureConnection(name)` path, then invokes the MCP tool. `waitForConnection()` is untouched (still a pure waiter). Presentation (`xd://` vs top-level) is not touched — both dispatch paths converge on the same `DeferredMCPTool.execute()`.
- `MCPTool` and `DeferredMCPTool` take an optional `MCPLazyActivity` hook (`begin()`/`end()`) so an in-flight call always suppresses the idle timer; the reaper can never fire mid-call.
- On idle-reap or an unexpected transport close, the manager swaps a lazy server's live tools back to cache-backed `DeferredMCPTool` instances and publishes the existing tools-changed notification, so `xd://` reconciliation/top-level refresh pick up the change through the existing path — no separate activation mechanism.
- Deliberately **never** wires the existing reconnect-and-retry path into a lazy server's live or deferred tools: an invocation interrupted by transport close surfaces its original failure instead of implicitly replaying a possibly side-effecting call. The next invocation reconnects single-flight via `ensureConnection()` alone.

## Why not revive #4933

Confirmed on the RFC thread (checked against current `main`, 2026-07-16): `search_tool_bm25` was removed from `src` after PR #4933 was opened, and #4933's `mcp.lazyDiscovery` couples activation to that now-removed tool. `@roboomp` confirmed a fresh implementation from current `main` was preferred over reviving #4933's BM25 integration.

## Testing

- `test/mcp-lazy-lifecycle.test.ts`: cold cache connects once and arms the idle reaper; warm cache skips the connect entirely; idle-reap + on-demand reconnect; `idleTimeoutMs: 0` disables reaping; concurrent on-demand calls single-flight the reconnect; an unexpected transport close defers without retrying the interrupted call.
- `test/mcp-config-lazy-lifecycle.test.ts`: config validation (valid/invalid `lifecycle`, `idleTimeoutMs`).
- Full existing MCP suite (187 tests) and `bun run check:types` pass unchanged.

Refs #2888