### PR TITLE
fix(auth): isolate import tests from ambient broker config

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `retry.fallbackChains` wildcards now support id-prefixed targets and keys: a chain entry like `"openrouter/google/*"` re-prefixes the failing model's bare id (`google-antigravity/gemini-x` → `openrouter/google/gemini-x`), a plain `"provider/*"` entry falling back *from* an aggregator strips the vendor prefix when the target provider only knows the bare id (`openrouter/google/x` → `google-vertex/x`), and an id-prefixed key (`"openrouter/google/*"`) scopes a chain to that provider's ids under the prefix.
 
+### Fixed
+
+- Isolated the CLIProxyAPI auth-broker import tests from ambient broker configuration so fixture credentials cannot be uploaded to a live broker ([#5782](https://github.com/can1357/oh-my-pi/issues/5782)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/test/auth-broker-import.test.ts
+++ b/packages/coding-agent/test/auth-broker-import.test.ts
@@ -22,9 +22,14 @@ describe("auth-broker import (CLIProxyAPI)", () => {
 	let agentDir = "";
 	let cliproxyDir = "";
 	let originalAgentDir: string | undefined;
+	const savedEnv: Record<string, string | undefined> = {};
 
 	beforeEach(async () => {
 		originalAgentDir = process.env.OMP_AGENT_DIR;
+		savedEnv.OMP_AUTH_BROKER_URL = process.env.OMP_AUTH_BROKER_URL;
+		savedEnv.OMP_AUTH_BROKER_TOKEN = process.env.OMP_AUTH_BROKER_TOKEN;
+		delete process.env.OMP_AUTH_BROKER_URL;
+		delete process.env.OMP_AUTH_BROKER_TOKEN;
 		agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-import-agent-"));
 		cliproxyDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-import-cliproxy-"));
 		setAgentDir(agentDir);
@@ -36,6 +41,10 @@ describe("auth-broker import (CLIProxyAPI)", () => {
 		else process.env.OMP_AGENT_DIR = originalAgentDir;
 		await removeWithRetries(agentDir);
 		await removeWithRetries(cliproxyDir);
+		for (const key of ["OMP_AUTH_BROKER_URL", "OMP_AUTH_BROKER_TOKEN"] as const) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
 	});
 
 	async function writeCliProxyJson(name: string, body: Record<string, unknown>): Promise<string> {


### PR DESCRIPTION
## Repro
With an isolated broker listening on `127.0.0.1:45991`, `OMP_AUTH_BROKER_URL=http://127.0.0.1:45991 OMP_AUTH_BROKER_TOKEN=repro-token bun test packages/coding-agent/test/auth-broker-import.test.ts` failed three CLIProxyAPI local-store assertions and sent four fixture credentials to `POST /v1/credential`.

## Cause
The `auth-broker import (CLIProxyAPI)` lifecycle in `packages/coding-agent/test/auth-broker-import.test.ts` isolated `OMP_AGENT_DIR` but retained ambient `OMP_AUTH_BROKER_URL` and `OMP_AUTH_BROKER_TOKEN`. `runImport` in `packages/coding-agent/src/cli/auth-broker-cli.ts` therefore resolved the configured broker and selected `AuthBrokerClient.uploadCredential` instead of the local SQLite store.

## Fix
- Save and clear both auth-broker environment variables before each CLIProxyAPI import test.
- Restore their original values after each test, matching the broker-routed block's lifecycle.
- Document the test isolation fix in the coding-agent changelog.

## Verification
`OMP_AUTH_BROKER_URL=http://127.0.0.1:45991 OMP_AUTH_BROKER_TOKEN=repro-token bun test packages/coding-agent/test/auth-broker-import.test.ts` passes all 6 tests with no broker listening at the ambient URL. The pre-publish `bun run fix` and `bun check` gate also passed. Fixes #5782