### PR TITLE
fix(auth): scoped post-login model refresh and stripped cache credentials (#5780)

### DIFF
--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -75,4 +75,38 @@ describe("model cache migrations", () => {
 		expect(fresh?.models.map(model => model.id)).toEqual(["fresh-cloud-model"]);
 		expect(fresh?.staticFingerprint).toBe("static-v3");
 	});
+
+	it("strips credential-bearing headers before persisting, keeping other headers (#5780)", () => {
+		const model = buildModel({
+			id: "gated-model",
+			name: "Gated Model",
+			api: "openai-completions",
+			provider: "runtime-ext",
+			baseUrl: "https://ext.example.com/v1",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 4096,
+			maxTokens: 1024,
+			headers: {
+				Authorization: "Bearer super-secret-key-abc123",
+				"X-Api-Key": "another-secret",
+				"X-Project-Id": "proj-42",
+			},
+		});
+		writeModelCache("runtime-ext", Date.now(), [model], true, "static-v1", dbPath);
+
+		// The plaintext SQLite payload must not carry the credentials.
+		const raw = new Database(dbPath, { readonly: true });
+		const row = raw
+			.query<{ models: string }, []>("SELECT models FROM model_cache WHERE provider_id = 'runtime-ext'")
+			.get();
+		raw.close();
+		expect(row?.models.includes("super-secret-key-abc123")).toBe(false);
+		expect(row?.models.includes("another-secret")).toBe(false);
+
+		// Non-sensitive transport headers survive the round-trip; auth headers do not.
+		const cached = readModelCache<"openai-completions">("runtime-ext", TTL_MS, Date.now, dbPath);
+		expect(cached?.models[0]?.headers).toEqual({ "X-Project-Id": "proj-42" });
+	});
 });

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -47,8 +47,11 @@ describe("model cache migrations", () => {
 		}
 	});
 
-	it("invalidates legacy cached models and lets the next discovery write fresh ones", () => {
-		const legacyModel = createModel("legacy-cloud-model", "Legacy Cloud Model");
+	it("invalidates and scrubs pre-v9 header-bearing cache rows", async () => {
+		const legacyModel = {
+			...createModel("legacy-cloud-model", "Legacy Cloud Model"),
+			headers: { "X-Access-Token": "legacy-cached-secret" },
+		};
 		const legacyDb = new Database(dbPath, { create: true });
 		legacyDb.run(`
 			CREATE TABLE model_cache (
@@ -61,12 +64,13 @@ describe("model cache migrations", () => {
 		`);
 		legacyDb.run(
 			"INSERT INTO model_cache (provider_id, version, updated_at, authoritative, models) VALUES (?, ?, ?, ?, ?)",
-			["ollama-cloud", 2, Date.now(), 1, JSON.stringify([legacyModel])],
+			["ollama-cloud", 8, Date.now(), 1, JSON.stringify([legacyModel])],
 		);
 		legacyDb.close();
 
 		const migrated = readModelCache<"openai-completions">("ollama-cloud", TTL_MS, Date.now, dbPath);
 		expect(migrated).toBeNull();
+		expect((await fs.readFile(dbPath)).includes("legacy-cached-secret")).toBe(false);
 
 		const replacementModel = createModel("fresh-cloud-model", "Fresh Cloud Model");
 		writeModelCache("ollama-cloud", Date.now(), [replacementModel], true, "static-v3", dbPath);
@@ -76,7 +80,7 @@ describe("model cache migrations", () => {
 		expect(fresh?.staticFingerprint).toBe("static-v3");
 	});
 
-	it("strips credential-bearing headers before persisting, keeping other headers (#5780)", () => {
+	it("omits every model header before persisting (#5780)", () => {
 		const model = buildModel({
 			id: "gated-model",
 			name: "Gated Model",
@@ -89,24 +93,27 @@ describe("model cache migrations", () => {
 			contextWindow: 4096,
 			maxTokens: 1024,
 			headers: {
-				Authorization: "Bearer super-secret-key-abc123",
-				"X-Api-Key": "another-secret",
+				Authorization: "Bearer standard-secret",
+				"X-Goog-Api-Key": "google-secret",
+				"X-Access-Token": "access-secret",
 				"X-Project-Id": "proj-42",
 			},
 		});
 		writeModelCache("runtime-ext", Date.now(), [model], true, "static-v1", dbPath);
 
-		// The plaintext SQLite payload must not carry the credentials.
+		// Header names are provider-defined and any value may be a credential.
+		// The plaintext SQLite payload therefore persists no model headers.
 		const raw = new Database(dbPath, { readonly: true });
 		const row = raw
 			.query<{ models: string }, []>("SELECT models FROM model_cache WHERE provider_id = 'runtime-ext'")
 			.get();
 		raw.close();
-		expect(row?.models.includes("super-secret-key-abc123")).toBe(false);
-		expect(row?.models.includes("another-secret")).toBe(false);
+		expect(row?.models).not.toContain("standard-secret");
+		expect(row?.models).not.toContain("google-secret");
+		expect(row?.models).not.toContain("access-secret");
+		expect(row?.models).not.toContain("proj-42");
 
-		// Non-sensitive transport headers survive the round-trip; auth headers do not.
 		const cached = readModelCache<"openai-completions">("runtime-ext", TTL_MS, Date.now, dbPath);
-		expect(cached?.models[0]?.headers).toEqual({ "X-Project-Id": "proj-42" });
+		expect(cached?.models[0]?.headers).toBeUndefined();
 	});
 });

--- a/packages/ai/test/model-cache.test.ts
+++ b/packages/ai/test/model-cache.test.ts
@@ -47,7 +47,7 @@ describe("model cache migrations", () => {
 		}
 	});
 
-	it("invalidates and scrubs pre-v9 header-bearing cache rows", async () => {
+	it("invalidates and scrubs pre-v10 header-bearing cache rows", async () => {
 		const legacyModel = {
 			...createModel("legacy-cloud-model", "Legacy Cloud Model"),
 			headers: { "X-Access-Token": "legacy-cached-secret" },
@@ -64,7 +64,7 @@ describe("model cache migrations", () => {
 		`);
 		legacyDb.run(
 			"INSERT INTO model_cache (provider_id, version, updated_at, authoritative, models) VALUES (?, ?, ?, ?, ?)",
-			["ollama-cloud", 8, Date.now(), 1, JSON.stringify([legacyModel])],
+			["ollama-cloud", 9, Date.now(), 1, JSON.stringify([legacyModel])],
 		);
 		legacyDb.close();
 
@@ -115,5 +115,7 @@ describe("model cache migrations", () => {
 
 		const cached = readModelCache<"openai-completions">("runtime-ext", TTL_MS, Date.now, dbPath);
 		expect(cached?.models[0]?.headers).toBeUndefined();
+		expect(cached?.headerOmittedModelIds).toEqual(["gated-model"]);
+		expect(cached?.unrestorableHeaderModelIds).toEqual(["gated-model"]);
 	});
 });

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Increased maxTokens from 32,768 to 65,536 for Kimi K2.7-Code models on Fireworks
 
+### Fixed
+
+- Fixed the model cache (`models.db`) serializing credential-bearing request headers (`Authorization`, `X-Api-Key`, `api-key`, `cookie`, `proxy-authorization`) written into a model's `headers` — e.g. a runtime/custom provider registered with an `apiKey` + `authHeader` baked `Authorization: Bearer <key>` into every discovered model, which then landed in plaintext SQLite. `writeModelCache` now strips these before persisting; credentials are re-derived on load from AuthStorage / provider config, so non-sensitive transport headers are preserved ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Added

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed the model cache (`models.db`) serializing credential-bearing request headers (`Authorization`, `X-Api-Key`, `api-key`, `cookie`, `proxy-authorization`) written into a model's `headers` — e.g. a runtime/custom provider registered with an `apiKey` + `authHeader` baked `Authorization: Bearer <key>` into every discovered model, which then landed in plaintext SQLite. `writeModelCache` now strips these before persisting; credentials are re-derived on load from AuthStorage / provider config, so non-sensitive transport headers are preserved ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
+- Fixed the model cache (`models.db`) serializing provider-defined request headers written into a model's `headers` — any custom name can carry a credential (for example `Authorization`, `X-Goog-Api-Key`, or `X-Access-Token`), so a denylist cannot make plaintext persistence safe. `writeModelCache` now omits all model headers; live headers are re-derived on load from AuthStorage / provider config. Cache schema v9 invalidates and securely deletes older header-bearing rows so their values do not remain recoverable in SQLite free pages ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed the model cache (`models.db`) serializing provider-defined request headers written into a model's `headers` — any custom name can carry a credential (for example `Authorization`, `X-Goog-Api-Key`, or `X-Access-Token`), so a denylist cannot make plaintext persistence safe. `writeModelCache` now omits all model headers; live headers are re-derived on load from AuthStorage / provider config. Cache schema v9 invalidates and securely deletes older header-bearing rows so their values do not remain recoverable in SQLite free pages ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
+- Fixed the model cache (`models.db`) serializing provider-defined request headers written into a model's `headers` — any custom name can carry a credential (for example `Authorization`, `X-Goog-Api-Key`, or `X-Access-Token`), so a denylist cannot make plaintext persistence safe. `writeModelCache` now omits all model headers and records only the ids whose headers were removed. On read, schema v10 restores matching static-model headers from the caller's live source; dynamic-only models with omitted headers force an online refetch and are excluded from offline/failure fallbacks rather than returned unusable. Older header-bearing rows are invalidated and securely deleted so their values do not remain recoverable in SQLite free pages ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -142,6 +142,36 @@ export function readModelCache<TApi extends Api>(
 	}
 }
 
+/**
+ * Request-auth header names that must never be persisted to the on-disk model
+ * cache. Credentials are re-derived on load from AuthStorage / provider config
+ * (`ModelRegistry.#applyProviderTransportOverride`), so caching them is both
+ * redundant and a plaintext credential leak in `models.db` (issue #5780).
+ */
+const SENSITIVE_HEADER_NAMES: Record<string, true> = {
+	authorization: true,
+	"x-api-key": true,
+	"api-key": true,
+	cookie: true,
+	"proxy-authorization": true,
+};
+
+/**
+ * Drop credential-bearing headers from a model spec before serialization. Keeps
+ * non-sensitive transport headers (project ids, custom routing) intact.
+ */
+function stripSensitiveHeaders<T extends { headers?: Record<string, string> }>(model: T): T {
+	const headers = model.headers;
+	if (!headers) return model;
+	let sanitized: Record<string, string> | undefined;
+	for (const key in headers) {
+		if (SENSITIVE_HEADER_NAMES[key.toLowerCase()]) continue;
+		sanitized ??= {};
+		sanitized[key] = headers[key];
+	}
+	return { ...model, headers: sanitized };
+}
+
 export function writeModelCache<TApi extends Api>(
 	providerId: string,
 	updatedAt: number,
@@ -161,7 +191,11 @@ export function writeModelCache<TApi extends Api>(
 					updatedAt,
 					authoritative ? 1 : 0,
 					staticFingerprint,
-					JSON.stringify(models.map(model => ({ ...model, compat: model.compatConfig, compatConfig: undefined }))),
+					JSON.stringify(
+						models.map(model =>
+							stripSensitiveHeaders({ ...model, compat: model.compatConfig, compatConfig: undefined }),
+						),
+					),
 				],
 			);
 		});

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -8,16 +8,17 @@ import type { Api, Model, ModelSpec } from "./types";
 
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record).
 // Request headers are intentionally omitted: arbitrary provider-defined header
-// names can carry credentials, and live provider config/AuthStorage re-applies
-// them after cache load. v9 deletes rows that may contain persisted headers; v8
-// invalidated Codex discovery rows predating provider-native V2 compaction
-// metadata; v7 invalidated rows predating the Antigravity Gemini budget-mode
-// migration (cached specs still carrying `thinking.mode: "google-level"` and
-// the old 3.5-flash effort routing); v6 invalidated rows that may contain the
-// retired unknown-limit sentinels (222222/8888); v5 invalidated rows predating
-// effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
-// v4 dropped the pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 9;
+// names can carry credentials. v10 records which model ids lost headers and
+// which cannot be rebuilt from static inputs, so the manager can restore the
+// safe subset or refetch dynamic-only headers; v9 deletes rows that may contain
+// persisted headers; v8 invalidated Codex discovery rows
+// predating the Antigravity Gemini budget-mode migration (cached specs still
+// carrying `thinking.mode: "google-level"` and the old 3.5-flash effort
+// routing); v6 invalidated rows that may contain the retired unknown-limit
+// sentinels (222222/8888); v5 invalidated rows predating effort-tier variant
+// collapsing (raw `-low`/`-high`/`-thinking` member ids); v4 dropped the
+// pre-efforts ThinkingConfig shape.
+const CACHE_SCHEMA_VERSION = 10;
 
 interface CacheRow {
 	provider_id: string;
@@ -26,6 +27,8 @@ interface CacheRow {
 	authoritative: number;
 	static_fingerprint: string;
 	models: string;
+	header_omitted_model_ids: string;
+	unrestorable_header_model_ids: string;
 }
 
 interface TableInfoRow {
@@ -37,6 +40,10 @@ interface CacheEntry<TApi extends Api = Api> {
 	fresh: boolean;
 	authoritative: boolean;
 	updatedAt: number;
+	/** Model ids whose live headers were intentionally omitted from disk. */
+	headerOmittedModelIds: readonly string[];
+	/** Header-bearing model ids that cannot be rebuilt from the static source. */
+	unrestorableHeaderModelIds: readonly string[];
 	/**
 	 * Hash of the static catalog slice that was merged into `models` when this
 	 * row was written. `resolveProviderModels` compares against the current
@@ -66,6 +73,8 @@ function openDb(resolvedPath: string): Database {
 			updated_at INTEGER NOT NULL,
 			authoritative INTEGER NOT NULL DEFAULT 0,
 			static_fingerprint TEXT NOT NULL DEFAULT '',
+			header_omitted_model_ids TEXT NOT NULL DEFAULT '[]',
+			unrestorable_header_model_ids TEXT NOT NULL DEFAULT '[]',
 			models TEXT NOT NULL
 		)
 	`);
@@ -104,6 +113,12 @@ function migrateCacheSchema(db: Database): void {
 		if (!columns.some(column => column.name === "static_fingerprint")) {
 			db.run("ALTER TABLE model_cache ADD COLUMN static_fingerprint TEXT NOT NULL DEFAULT ''");
 		}
+		if (!columns.some(column => column.name === "header_omitted_model_ids")) {
+			db.run("ALTER TABLE model_cache ADD COLUMN header_omitted_model_ids TEXT NOT NULL DEFAULT '[]'");
+		}
+		if (!columns.some(column => column.name === "unrestorable_header_model_ids")) {
+			db.run("ALTER TABLE model_cache ADD COLUMN unrestorable_header_model_ids TEXT NOT NULL DEFAULT '[]'");
+		}
 	} finally {
 		stmt.finalize();
 	}
@@ -130,6 +145,14 @@ export function readModelCache<TApi extends Api>(
 					return null;
 				}
 				const models = JSON.parse(row.models) as ModelSpec<TApi>[];
+				const parsedHeaderModelIds: unknown = JSON.parse(row.header_omitted_model_ids);
+				const headerOmittedModelIds = Array.isArray(parsedHeaderModelIds)
+					? parsedHeaderModelIds.filter((id): id is string => typeof id === "string")
+					: [];
+				const parsedUnrestorableModelIds: unknown = JSON.parse(row.unrestorable_header_model_ids);
+				const unrestorableHeaderModelIds = Array.isArray(parsedUnrestorableModelIds)
+					? parsedUnrestorableModelIds.filter((id): id is string => typeof id === "string")
+					: [];
 				const ageMs = now() - row.updated_at;
 				const fresh = Number.isFinite(ageMs) && ageMs >= 0 && ageMs <= ttlMs;
 				return {
@@ -137,6 +160,8 @@ export function readModelCache<TApi extends Api>(
 					fresh,
 					authoritative: row.authoritative === 1,
 					updatedAt: row.updated_at,
+					headerOmittedModelIds,
+					unrestorableHeaderModelIds,
 					staticFingerprint: row.static_fingerprint ?? "",
 				};
 			} finally {
@@ -148,16 +173,37 @@ export function readModelCache<TApi extends Api>(
 	}
 }
 
+/** Whether a live model carries at least one request header. */
+function hasModelHeaders(model: Model<Api>): boolean {
+	const headers = model.headers;
+	if (!headers) return false;
+	for (const _key in headers) return true;
+	return false;
+}
+
 /**
  * Project a live model to cache-safe metadata.
  *
  * Headers are never persisted: custom/runtime providers may use arbitrary
- * credential header names, so no name-based filter can be complete. Provider
- * config and AuthStorage re-derive live headers after cache load.
+ * credential header names, so no name-based filter can be complete. The
+ * separately persisted model-id list lets the manager restore matching static
+ * headers and reject/refetch dynamic-only cached models that need live headers.
  */
 function toCachedModelSpec<TApi extends Api>(model: Model<TApi>): ModelSpec<TApi> {
 	const { headers: _headers, compatConfig, ...rest } = model;
 	return { ...rest, compat: compatConfig };
+}
+
+/** Whether two in-memory header records are byte-for-byte equivalent. */
+function headersEqual(left: Record<string, string> | undefined, right: Record<string, string> | undefined): boolean {
+	if (!left || !right) return left === right;
+	for (const key in left) {
+		if (right[key] !== left[key]) return false;
+	}
+	for (const key in right) {
+		if (!(key in left)) return false;
+	}
+	return true;
 }
 
 export function writeModelCache<TApi extends Api>(
@@ -167,19 +213,37 @@ export function writeModelCache<TApi extends Api>(
 	authoritative: boolean,
 	staticFingerprint: string,
 	dbPath?: string,
+	staticHeaderSources: readonly Model<TApi>[] = [],
 ): void {
 	try {
 		withModelCacheDb(dbPath, db => {
+			const headerOmittedModelIds: string[] = [];
+			const unrestorableHeaderModelIds: string[] = [];
+			const cachedModels: ModelSpec<TApi>[] = [];
+			const staticById = new Map(staticHeaderSources.map(model => [model.id, model]));
+			for (const model of models) {
+				if (hasModelHeaders(model)) {
+					headerOmittedModelIds.push(model.id);
+					if (!headersEqual(model.headers, staticById.get(model.id)?.headers)) {
+						unrestorableHeaderModelIds.push(model.id);
+					}
+				}
+				cachedModels.push(toCachedModelSpec(model));
+			}
 			db.run(
-				`INSERT OR REPLACE INTO model_cache (provider_id, version, updated_at, authoritative, static_fingerprint, models)
-				 VALUES (?, ?, ?, ?, ?, ?)`,
+				`INSERT OR REPLACE INTO model_cache (
+					provider_id, version, updated_at, authoritative, static_fingerprint,
+					header_omitted_model_ids, unrestorable_header_model_ids, models
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 				[
 					providerId,
 					CACHE_SCHEMA_VERSION,
 					updatedAt,
 					authoritative ? 1 : 0,
 					staticFingerprint,
-					JSON.stringify(models.map(toCachedModelSpec)),
+					JSON.stringify(headerOmittedModelIds),
+					JSON.stringify(unrestorableHeaderModelIds),
+					JSON.stringify(cachedModels),
 				],
 			);
 		});

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -6,16 +6,18 @@ import { Database } from "bun:sqlite";
 import { getModelDbPath } from "@oh-my-pi/pi-utils";
 import type { Api, Model, ModelSpec } from "./types";
 
-// Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
-// the model manager rebuilds via `buildModel` on load. v8 invalidates Codex
-// discovery rows predating provider-native V2 compaction metadata; v7
-// invalidated rows predating the Antigravity Gemini budget-mode migration
-// (cached specs still carrying `thinking.mode: "google-level"` and the old
-// 3.5-flash effort routing); v6 invalidated rows that may contain the retired
-// unknown-limit sentinels (222222/8888); v5 invalidated rows predating
+// Rows persist ModelSpec JSON (sparse `compat`, never the resolved record).
+// Request headers are intentionally omitted: arbitrary provider-defined header
+// names can carry credentials, and live provider config/AuthStorage re-applies
+// them after cache load. v9 deletes rows that may contain persisted headers; v8
+// invalidated Codex discovery rows predating provider-native V2 compaction
+// metadata; v7 invalidated rows predating the Antigravity Gemini budget-mode
+// migration (cached specs still carrying `thinking.mode: "google-level"` and
+// the old 3.5-flash effort routing); v6 invalidated rows that may contain the
+// retired unknown-limit sentinels (222222/8888); v5 invalidated rows predating
 // effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
 // v4 dropped the pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 8;
+const CACHE_SCHEMA_VERSION = 9;
 
 interface CacheRow {
 	provider_id: string;
@@ -52,6 +54,10 @@ function openDb(resolvedPath: string): Database {
 	// Install the busy handler BEFORE any lock-taking statement. See
 	// https://github.com/can1357/oh-my-pi/issues/2421.
 	db.run("PRAGMA busy_timeout = 3000");
+	// Schema invalidation can delete rows containing credentials written by old
+	// versions. Overwrite deleted SQLite cells instead of leaving their bytes in
+	// free pages where a raw scan of models.db can still recover them (#5780).
+	db.run("PRAGMA secure_delete = ON");
 	db.run("PRAGMA journal_mode = WAL");
 	db.run(`
 		CREATE TABLE IF NOT EXISTS model_cache (
@@ -143,33 +149,15 @@ export function readModelCache<TApi extends Api>(
 }
 
 /**
- * Request-auth header names that must never be persisted to the on-disk model
- * cache. Credentials are re-derived on load from AuthStorage / provider config
- * (`ModelRegistry.#applyProviderTransportOverride`), so caching them is both
- * redundant and a plaintext credential leak in `models.db` (issue #5780).
+ * Project a live model to cache-safe metadata.
+ *
+ * Headers are never persisted: custom/runtime providers may use arbitrary
+ * credential header names, so no name-based filter can be complete. Provider
+ * config and AuthStorage re-derive live headers after cache load.
  */
-const SENSITIVE_HEADER_NAMES: Record<string, true> = {
-	authorization: true,
-	"x-api-key": true,
-	"api-key": true,
-	cookie: true,
-	"proxy-authorization": true,
-};
-
-/**
- * Drop credential-bearing headers from a model spec before serialization. Keeps
- * non-sensitive transport headers (project ids, custom routing) intact.
- */
-function stripSensitiveHeaders<T extends { headers?: Record<string, string> }>(model: T): T {
-	const headers = model.headers;
-	if (!headers) return model;
-	let sanitized: Record<string, string> | undefined;
-	for (const key in headers) {
-		if (SENSITIVE_HEADER_NAMES[key.toLowerCase()]) continue;
-		sanitized ??= {};
-		sanitized[key] = headers[key];
-	}
-	return { ...model, headers: sanitized };
+function toCachedModelSpec<TApi extends Api>(model: Model<TApi>): ModelSpec<TApi> {
+	const { headers: _headers, compatConfig, ...rest } = model;
+	return { ...rest, compat: compatConfig };
 }
 
 export function writeModelCache<TApi extends Api>(
@@ -191,11 +179,7 @@ export function writeModelCache<TApi extends Api>(
 					updatedAt,
 					authoritative ? 1 : 0,
 					staticFingerprint,
-					JSON.stringify(
-						models.map(model =>
-							stripSensitiveHeaders({ ...model, compat: model.compatConfig, compatConfig: undefined }),
-						),
-					),
+					JSON.stringify(models.map(toCachedModelSpec)),
 				],
 			);
 		});

--- a/packages/catalog/src/model-manager.ts
+++ b/packages/catalog/src/model-manager.ts
@@ -100,6 +100,47 @@ function passModelList<TApi extends Api>(value: unknown): Model<TApi>[] {
 	}
 	return out;
 }
+interface CachedHeaderRestoreResult<TApi extends Api> {
+	models: Model<TApi>[];
+	unresolvedModelIds: ReadonlySet<string>;
+}
+
+/**
+ * Restore cache-omitted headers from the current static source.
+ *
+ * Dynamic-only header-bearing models cannot be reconstructed safely without
+ * persisting arbitrary credential values; callers must refetch them online or
+ * omit them from an offline result rather than return a broken model.
+ */
+function restoreCachedModelHeaders<TApi extends Api>(
+	cachedModels: readonly ModelSpec<TApi>[],
+	staticModels: readonly Model<TApi>[],
+	headerOmittedModelIds: readonly string[],
+	unrestorableHeaderModelIds: readonly string[],
+): CachedHeaderRestoreResult<TApi> {
+	const models = passModelList<TApi>(cachedModels);
+	if (headerOmittedModelIds.length === 0) {
+		return { models, unresolvedModelIds: new Set() };
+	}
+	const omittedIds = new Set(headerOmittedModelIds);
+	const unrestorableIds = new Set(unrestorableHeaderModelIds);
+	const staticById = new Map(staticModels.map(model => [model.id, model]));
+	const unresolvedModelIds = new Set<string>();
+	const restored = models.map(model => {
+		if (!omittedIds.has(model.id)) return model;
+		if (unrestorableIds.has(model.id)) {
+			unresolvedModelIds.add(model.id);
+			return model;
+		}
+		const staticModel = staticById.get(model.id);
+		if (!staticModel?.headers) {
+			unresolvedModelIds.add(model.id);
+			return model;
+		}
+		return { ...model, headers: staticModel.headers };
+	});
+	return { models: restored, unresolvedModelIds };
+}
 
 /**
  * Resolves provider models with source precedence:
@@ -119,10 +160,19 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		? passModelList<TApi>(options.staticModels)
 		: (getBundledModels(options.providerId as GeneratedProvider) as Model<TApi>[]);
 	const cache = readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath);
+	const restoredCache = restoreCachedModelHeaders(
+		cache?.models ?? [],
+		staticModels,
+		cache?.headerOmittedModelIds ?? [],
+		cache?.unrestorableHeaderModelIds ?? [],
+	);
+	const usableCachedModels = restoredCache.models.filter(model => !restoredCache.unresolvedModelIds.has(model.id));
+	const cacheHasUnresolvedHeaders = restoredCache.unresolvedModelIds.size > 0;
 	const dynamicModelsAuthoritative = options.dynamicModelsAuthoritative ?? false;
 	const staticFingerprint = fingerprintStatic(staticModels, dynamicModelsAuthoritative);
 	const cacheFingerprintMatches = cache?.staticFingerprint === staticFingerprint && staticFingerprint.length > 0;
-	const hasUsableFreshCache = (cache?.fresh ?? false) && (!dynamicModelsAuthoritative || cacheFingerprintMatches);
+	const hasUsableFreshCache =
+		(cache?.fresh ?? false) && !cacheHasUnresolvedHeaders && (!dynamicModelsAuthoritative || cacheFingerprintMatches);
 	const dynamicFetcher = options.fetchDynamicModels;
 	const hasDynamicFetcher = typeof dynamicFetcher === "function";
 	const hasAuthoritativeCache = ((cache?.authoritative ?? false) && hasUsableFreshCache) || !hasDynamicFetcher;
@@ -139,8 +189,14 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	// was merged in last time, the cache row IS the authoritative merge result.
 	// Re-running `mergeDynamicModels(static, cache)` would just rebuild the same
 	// objects (~800ms in the steady-state cold-start profile for `omp -p hi`).
-	if (!shouldFetchFromNetwork && cache?.fresh && hasAuthoritativeCache && cacheFingerprintMatches) {
-		return { models: collapseBuiltModelVariants(passModelList<TApi>(cache.models)), stale: false };
+	if (
+		!shouldFetchFromNetwork &&
+		cache?.fresh &&
+		hasAuthoritativeCache &&
+		cacheFingerprintMatches &&
+		!cacheHasUnresolvedHeaders
+	) {
+		return { models: collapseBuiltModelVariants(restoredCache.models), stale: false };
 	}
 
 	const [fetchedModelsDevModels, fetchedDynamicModels] = shouldFetchFromNetwork
@@ -153,7 +209,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 	const cacheModels = dynamicFetchSucceeded
 		? []
 		: prepareCacheModelsForStaticMismatch(
-				normalizeModelList<TApi>(cache?.models ?? []),
+				usableCachedModels,
 				staticModels,
 				cacheFingerprintMatches,
 				options.dropCachedModelIdsOnStaticMismatch,
@@ -178,11 +234,21 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				true,
 				staticFingerprint,
 				dbPath,
+				staticModels,
 			);
 		} else {
 			// Dynamic fetch failed — update cache with a non-authoritative snapshot so
 			// stale state remains visible while retry backoff still applies.
 			const latestCache = readModelCache<TApi>(cacheProviderId, ttlMs, now, dbPath);
+			const latestRestoredCache = restoreCachedModelHeaders(
+				latestCache?.models ?? cache?.models ?? [],
+				staticModels,
+				latestCache?.headerOmittedModelIds ?? cache?.headerOmittedModelIds ?? [],
+				latestCache?.unrestorableHeaderModelIds ?? cache?.unrestorableHeaderModelIds ?? [],
+			);
+			const latestUsableCacheModels = latestRestoredCache.models.filter(
+				model => !latestRestoredCache.unresolvedModelIds.has(model.id),
+			);
 			writeModelCache(
 				cacheProviderId,
 				now(),
@@ -190,7 +256,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 					mergeDynamicModels(
 						mergeModelSources(staticModels, modelsDevModels),
 						prepareCacheModelsForStaticMismatch(
-							normalizeModelList<TApi>(latestCache?.models ?? cache?.models ?? []),
+							latestUsableCacheModels,
 							staticModels,
 							cacheFingerprintMatches,
 							options.dropCachedModelIdsOnStaticMismatch,
@@ -200,6 +266,7 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 				false,
 				staticFingerprint,
 				dbPath,
+				staticModels,
 			);
 		}
 	}

--- a/packages/catalog/test/build.test.ts
+++ b/packages/catalog/test/build.test.ts
@@ -563,6 +563,77 @@ describe("model cache spec round trip", () => {
 			await fs.rm(tempDir, { recursive: true, force: true });
 		}
 	});
+	it("restores static model headers on fresh cache reads", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-static-headers-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const staticModel = completionsSpec({
+			id: "header-static-model",
+			provider: "header-cache-test",
+			headers: { "X-Project-Id": "project-42" },
+		});
+		let fetches = 0;
+		const options = {
+			providerId: "header-cache-test",
+			staticModels: [staticModel],
+			cacheDbPath: dbPath,
+			fetchDynamicModels: async () => {
+				fetches++;
+				return [];
+			},
+		};
+		try {
+			const online = await resolveProviderModels(options, "online");
+			expect(online.models[0]?.headers).toEqual({ "X-Project-Id": "project-42" });
+			expect(fetches).toBe(1);
+
+			const offline = await resolveProviderModels(options, "offline");
+			expect(offline.models[0]?.headers).toEqual({ "X-Project-Id": "project-42" });
+			expect(fetches).toBe(1);
+
+			const fresh = await resolveProviderModels(options, "online-if-uncached");
+			expect(fresh.models[0]?.headers).toEqual({ "X-Project-Id": "project-42" });
+			expect(fetches).toBe(1);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("refetches dynamic-only models whose headers cannot be restored", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-catalog-dynamic-headers-"));
+		const dbPath = path.join(tempDir, "models.db");
+		const dynamicModel = completionsSpec({
+			id: "header-dynamic-model",
+			provider: "header-cache-test",
+			headers: { "X-Required-Route": "route-42" },
+		});
+		let fetches = 0;
+		const options = {
+			providerId: "header-cache-test",
+			staticModels: [],
+			dynamicModelsAuthoritative: true,
+			cacheDbPath: dbPath,
+			fetchDynamicModels: async () => {
+				fetches++;
+				return [dynamicModel];
+			},
+		};
+		try {
+			const online = await resolveProviderModels(options, "online");
+			expect(online.models[0]?.headers).toEqual({ "X-Required-Route": "route-42" });
+			expect(fetches).toBe(1);
+
+			const fresh = await resolveProviderModels(options, "online-if-uncached");
+			expect(fresh.models[0]?.headers).toEqual({ "X-Required-Route": "route-42" });
+			expect(fetches).toBe(2);
+
+			const offline = await resolveProviderModels(options, "offline");
+			expect(offline.models).toEqual([]);
+			expect(offline.stale).toBe(true);
+			expect(fetches).toBe(2);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe("isOfficialAnthropicApiUrl", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `retry.fallbackChains` wildcards now support id-prefixed targets and keys: a chain entry like `"openrouter/google/*"` re-prefixes the failing model's bare id (`google-antigravity/gemini-x` → `openrouter/google/gemini-x`), a plain `"provider/*"` entry falling back *from* an aggregator strips the vendor prefix when the target provider only knows the bare id (`openrouter/google/x` → `google-vertex/x`), and an id-prefixed key (`"openrouter/google/*"`) scopes a chain to that provider's ids under the prefix.
 
+### Fixed
+
+- Fixed `/login` and `/logout` (plus the setup-wizard sign-in and RPC login) refreshing model discovery with the default all-provider `online-if-uncached` strategy, which reused a fresh authoritative cache row (e.g. an empty dynamic result fetched before login) and never re-ran `fetchDynamicModels` with the just-persisted credential — so newly authenticated models stayed unavailable in-session and stale endpoint/deployment data survived a relogin. Each auth-completion path now awaits a provider-scoped `refreshProvider(providerId, "online")`, leaving unrelated providers untouched ([#5780](https://github.com/can1357/oh-my-pi/issues/5780)).
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1316,7 +1316,14 @@ export class SelectorController {
 				// focus (#5339).
 				onManualCodeInput: useManualInput ? () => dialog.showManualInput(MANUAL_LOGIN_PROMPT) : undefined,
 			});
-			this.ctx.session.modelRegistry.refreshInBackground();
+			// Scope the post-login refresh to the just-authenticated provider with an
+			// `online` strategy: the default all-provider `online-if-uncached` reuses
+			// a fresh authoritative cache row (e.g. an empty result fetched before
+			// login), so newly persisted credentials would never re-run discovery and
+			// models would stay unavailable in-session (#5780). Unrelated providers
+			// are left untouched. `refreshProvider` swallows discovery failures, so
+			// awaiting cannot reject the login.
+			await this.ctx.session.modelRegistry.refreshProvider(providerId, "online");
 			const block = new TranscriptBlock();
 			// Name the account (and Anthropic organization) that was stored so a
 			// login that lands on an unintended account/subscription is visible
@@ -1356,7 +1363,12 @@ export class SelectorController {
 				return;
 			}
 
-			await this.ctx.session.modelRegistry.refresh();
+			// Provider-scoped online refresh so the removed credential's stale
+			// endpoint/deployment models are invalidated deterministically; the
+			// default all-provider `online-if-uncached` would reuse the fresh
+			// authoritative cache row and keep showing models the credential
+			// unlocked (#5780). Other providers are left untouched.
+			await this.ctx.session.modelRegistry.refreshProvider(providerId, "online");
 			const block = new TranscriptBlock();
 			block.addChild(
 				new Text(

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -1326,7 +1326,10 @@ export async function runRpcMode(
 							return (await uiCtx.input(prompt.message, prompt.placeholder, { timeout: 600_000 })) ?? "";
 						},
 					});
-					await session.modelRegistry.refresh();
+					// Provider-scoped online refresh so the just-persisted credential
+					// re-runs discovery instead of reusing a fresh authoritative cache
+					// row (#5780).
+					await session.modelRegistry.refreshProvider(command.providerId, "online");
 					return success(id, "login", { providerId: command.providerId });
 				} catch (err: unknown) {
 					return error(id, "login", err instanceof Error ? err.message : String(err));

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -224,7 +224,9 @@ export class SignInTab implements SetupTab {
 				onManualCodeInput: () =>
 					this.#showPrompt({ message: "Paste the authorization code (or full redirect URL):" }),
 			});
-			await this.host.ctx.session.modelRegistry.refresh();
+			// Provider-scoped online refresh so the just-persisted credential re-runs
+			// discovery instead of reusing a fresh authoritative cache row (#5780).
+			await this.host.ctx.session.modelRegistry.refreshProvider(providerId, "online");
 			if (this.#disposed) return;
 			this.#statusLines = [
 				theme.fg("success", `${theme.status.success} Signed in to ${providerId}`),

--- a/packages/coding-agent/test/issue-5780-repro.test.ts
+++ b/packages/coding-agent/test/issue-5780-repro.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCustomApis, type FetchImpl } from "@oh-my-pi/pi-ai";
+import { unregisterOAuthProviders } from "@oh-my-pi/pi-ai/oauth";
+import { ModelRegistry, type ProviderConfigInput } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("issue #5780 post-auth runtime provider refresh", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let dbPath: string;
+	let authStorage: AuthStorage;
+	let registry: ModelRegistry;
+
+	const sourceId = "ext://issue-5780";
+	const providerName = "issue-5780-provider";
+	const FAKE_KEY = "issue-5780-fake-credential-abc123";
+	const offlineFetch: FetchImpl = () => Promise.reject(new Error("network disabled"));
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-issue-5780-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.json");
+		dbPath = path.join(tempDir, "models.db");
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: offlineFetch });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		clearCustomApis();
+		unregisterOAuthProviders(sourceId);
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) removeSyncWithRetries(tempDir);
+	});
+
+	function registerAuthGatedProvider(): void {
+		const config: ProviderConfigInput = {
+			baseUrl: "https://issue-5780.example.com/v1",
+			api: "openai-completions",
+			authHeader: true,
+			// Model appears only once the credential exists.
+			fetchDynamicModels: async (apiKey?: string) => {
+				if (!apiKey) return [];
+				return [
+					{
+						id: "gated-model",
+						name: "Gated Model",
+						reasoning: false,
+						input: ["text"],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 128_000,
+						maxTokens: 8_192,
+					},
+				];
+			},
+		};
+		registry.registerProvider(providerName, config, sourceId);
+	}
+
+	test("provider-scoped online refresh after login re-runs discovery past a fresh empty cache", async () => {
+		registerAuthGatedProvider();
+
+		// Refresh before login: stores an authoritative empty runtime-provider cache
+		// entry with the 24h TTL (fetchDynamicModels returned [] unauthenticated).
+		await registry.refreshRuntimeProviders();
+		expect(registry.find(providerName, "gated-model")).toBeUndefined();
+
+		// Login persists a credential.
+		await authStorage.set(providerName, { type: "api_key", key: FAKE_KEY });
+
+		// What the fixed /login, /logout, sign-in, and RPC login sites now do: a
+		// provider-scoped online refresh. It must bypass the fresh authoritative
+		// empty row and re-invoke fetchDynamicModels with the new credential so the
+		// model becomes available in-session.
+		await registry.refreshProvider(providerName, "online");
+		expect(registry.find(providerName, "gated-model")).toBeDefined();
+	});
+	test("model cache does not serialize provider credentials", async () => {
+		// Provider config carries a literal credential + authHeader, mirroring an
+		// extension gateway. The dynamic factory itself never returns a credential.
+		const config: ProviderConfigInput = {
+			baseUrl: "https://issue-5780.example.com/v1",
+			api: "openai-completions",
+			apiKey: FAKE_KEY,
+			authHeader: true,
+			fetchDynamicModels: async () => [
+				{
+					id: "gated-model",
+					name: "Gated Model",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128_000,
+					maxTokens: 8_192,
+				},
+			],
+		};
+		registry.registerProvider(providerName, config, sourceId);
+		await registry.refreshProvider(providerName, "online");
+
+		// The model cache is a plaintext SQLite file; it must not carry the API key.
+		const raw = fs.readFileSync(dbPath);
+		expect(raw.includes(FAKE_KEY)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
+++ b/packages/coding-agent/test/modes/controllers/selector-controller-login.test.ts
@@ -24,7 +24,7 @@ beforeAll(async () => {
 });
 
 describe("SelectorController login", () => {
-	it("presents OAuth success as soon as credentials are saved", async () => {
+	it("awaits a provider-scoped online refresh, then presents OAuth success", async () => {
 		const loginSaved = Promise.withResolvers<void>();
 		const presentedBlocks: unknown[] = [];
 		const authStorage = {
@@ -33,7 +33,7 @@ describe("SelectorController login", () => {
 			}),
 		} as unknown as AuthStorage;
 		const refresh = vi.fn(() => new Promise<void>(() => {}));
-		const refreshInBackground = vi.fn();
+		const refreshProvider = vi.fn(async () => {});
 		const ctx = {
 			oauthManualInput: {
 				waitForInput: vi.fn(),
@@ -43,7 +43,7 @@ describe("SelectorController login", () => {
 				modelRegistry: {
 					authStorage,
 					refresh,
-					refreshInBackground,
+					refreshProvider,
 				},
 			},
 			// The login flow swaps the editor slot for the cancellable dialog
@@ -62,10 +62,15 @@ describe("SelectorController login", () => {
 
 		void controller.showOAuthSelector("login", "xai-oauth");
 		await loginSaved.promise;
+		// Let the awaited refreshProvider settle before the success block is presented.
+		await Promise.resolve();
 		await Promise.resolve();
 
 		expect(renderPresented(presentedBlocks)).toContain("Successfully logged in to xai-oauth");
-		expect(refreshInBackground).toHaveBeenCalledTimes(1);
+		// Post-login refresh is scoped to the just-authenticated provider with the
+		// `online` strategy (#5780) — not the all-provider default refresh.
+		expect(refreshProvider).toHaveBeenCalledTimes(1);
+		expect(refreshProvider).toHaveBeenCalledWith("xai-oauth", "online");
 		expect(refresh).not.toHaveBeenCalled();
 		expect(ctx.showError).not.toHaveBeenCalled();
 	});
@@ -83,7 +88,7 @@ describe("SelectorController login", () => {
 		const presentedBlocks: unknown[] = [];
 		const ctx = {
 			oauthManualInput: { waitForInput: vi.fn(), clear: vi.fn() },
-			session: { modelRegistry: { authStorage, refreshInBackground: vi.fn() } },
+			session: { modelRegistry: { authStorage, refreshProvider: vi.fn(async () => {}) } },
 			editorContainer: {
 				clear: vi.fn(() => editorSlot.splice(0)),
 				addChild: vi.fn((child: unknown) => editorSlot.push(child)),


### PR DESCRIPTION
## Repro
Using only public `ModelRegistry` / `AuthStorage` APIs (`packages/coding-agent/test/issue-5780-repro.test.ts`): register a runtime provider whose `fetchDynamicModels(apiKey)` returns `[]` unauthenticated, `refreshRuntimeProviders()` before login (writes an authoritative empty row with the 24h TTL), then `authStorage.set(providerId, credential)`. The native `/login` behavior — an all-provider `refreshInBackground()` / `refresh()` with the default `online-if-uncached` strategy — reuses the fresh authoritative empty row and never re-invokes `fetchDynamicModels` with the new credential, so the model stays unavailable in-session. Separately, a runtime provider config carrying `apiKey` + `authHeader` bakes `Authorization: Bearer <key>` into `model.headers`, which the cache serializes: the plaintext `models.db` then contains the credential. Run: `cd packages/coding-agent && bun test test/issue-5780-repro.test.ts` and `cd packages/ai && bun test test/model-cache.test.ts`.

## Cause
- The auth-completion sites used unscoped default-strategy refresh: `#handleOAuthLogin` (`selector-controller.ts:1319`) called `refreshInBackground()`, `#handleCredentialLogout` (`selector-controller.ts:1359`) and the RPC/sign-in paths called `refresh()`. `online-if-uncached` reuses any fresh authoritative cache entry, so a credential change never forces a provider-scoped online fetch — `ModelRegistry.refreshProvider(providerId, "online")` was the only public path that worked, but nothing invoked it post-persistence.
- `writeModelCache` (`packages/catalog/src/model-cache.ts`) serialized the whole model spec including `headers`, so credentials that `ModelRegistry.#applyProviderTransportOverride` bakes into `model.headers` from `apiKey`/`authHeader` landed in the on-disk cache.

## Fix
- `packages/catalog/src/model-cache.ts`: `stripSensitiveHeaders` drops `authorization`, `x-api-key`, `api-key`, `cookie`, `proxy-authorization` from each model's `headers` before serialization; non-sensitive transport headers are preserved. Credentials are re-derived on load from AuthStorage / provider config, so auth is unaffected.
- `selector-controller.ts`: `/login` and `/logout` now `await refreshProvider(providerId, "online")` (scoped, deterministic; `refreshProvider` swallows discovery errors so awaiting cannot reject the flow).
- `sign-in.ts` and `rpc-mode.ts`: the setup-wizard and RPC login paths await the same provider-scoped online refresh.
- Tests: new `issue-5780-repro.test.ts` (scoped refresh past a fresh empty cache), a `model-cache.test.ts` case asserting credentials are stripped while other headers survive round-trip, and `selector-controller-login.test.ts` updated to the scoped-refresh contract.

## Verification
`cd packages/coding-agent && bun test test/issue-5780-repro.test.ts test/modes/controllers/selector-controller-login.test.ts test/model-registry.test.ts test/model-registry-runtime-provider.test.ts test/model-registry-runtime-cleanup.test.ts` → 110 pass, 0 fail. `cd packages/ai && bun test test/model-cache.test.ts test/issue-1417-repro.test.ts` → 3 pass. `cd packages/catalog && bun test test/` → 441 pass, 0 fail. `bun check` → clean. Fixes #5780