### PR TITLE
fix(browser): support cmux TCP socket relays

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `retry.fallbackChains` wildcards now support id-prefixed targets and keys: a chain entry like `"openrouter/google/*"` re-prefixes the failing model's bare id (`google-antigravity/gemini-x` → `openrouter/google/gemini-x`), a plain `"provider/*"` entry falling back *from* an aggregator strips the vendor prefix when the target provider only knows the bare id (`openrouter/google/x` → `google-vertex/x`), and an id-prefixed key (`"openrouter/google/*"`) scopes a chain to that provider's ids under the prefix.
 
+### Fixed
+
+- Fixed cmux browser panes failing in `cmux ssh` sessions because the exported `CMUX_SOCKET_PATH=127.0.0.1:<port>` relay address was treated as a Unix socket path; cmux TCP relay addresses now connect over TCP while local Unix socket paths keep their existing behavior.
+
 ## [17.0.1] - 2026-07-16
 
 ### Changed

--- a/packages/coding-agent/src/tools/browser/cmux/socket-client.ts
+++ b/packages/coding-agent/src/tools/browser/cmux/socket-client.ts
@@ -5,6 +5,16 @@ import { ToolError } from "../../tool-errors";
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+function parseTcpSocketAddress(socketPath: string): { host: string; port: number } | null {
+	const match = /^([A-Za-z0-9.-]+):(\d+)$/.exec(socketPath);
+	const host = match?.[1];
+	const port = Number(match?.[2]);
+	if (!host || !Number.isSafeInteger(port) || port <= 0 || port > 65_535) {
+		return null;
+	}
+	return { host, port };
+}
+
 type RequestJob = {
 	method: string;
 	params: Record<string, unknown>;
@@ -101,7 +111,8 @@ export class CmuxSocketClient {
 	}
 
 	async #openSocket(): Promise<void> {
-		const socket = net.createConnection({ path: this.#socketPath });
+		const tcpAddress = parseTcpSocketAddress(this.#socketPath);
+		const socket = tcpAddress ? net.createConnection(tcpAddress) : net.createConnection({ path: this.#socketPath });
 		this.#socket = socket;
 		this.#buffer = "";
 		socket.setEncoding("utf8");

--- a/packages/coding-agent/test/tools/browser-cmux-socket.test.ts
+++ b/packages/coding-agent/test/tools/browser-cmux-socket.test.ts
@@ -16,6 +16,7 @@ type RequestLine = {
 async function withSocketServer(
 	handleLine: (line: string, socket: net.Socket) => void,
 	run: (socketPath: string) => Promise<void>,
+	transport: "unix" | "tcp" = "unix",
 ): Promise<void> {
 	const dir = await mkdtemp(join(tmpdir(), "cmux-browser-test-"));
 	const socketPath = join(dir, "cmux.sock");
@@ -35,15 +36,28 @@ async function withSocketServer(
 	});
 
 	await new Promise<void>((resolve, reject) => {
-		server.once("error", reject);
-		server.listen(socketPath, () => {
+		const onListening = (): void => {
 			server.off("error", reject);
 			resolve();
-		});
+		};
+		server.once("error", reject);
+		if (transport === "tcp") {
+			server.listen(0, "127.0.0.1", onListening);
+		} else {
+			server.listen(socketPath, onListening);
+		}
 	});
 
 	try {
-		await run(socketPath);
+		let socketAddress = socketPath;
+		if (transport === "tcp") {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				throw new Error("Expected TCP server address");
+			}
+			socketAddress = `127.0.0.1:${address.port}`;
+		}
+		await run(socketAddress);
 	} finally {
 		await new Promise<void>(resolve => server.close(() => resolve()));
 		await rm(dir, { recursive: true, force: true });
@@ -90,6 +104,26 @@ describe("CmuxSocketClient", () => {
 					client.close();
 				}
 			},
+		);
+	});
+
+	it("connects and round-trips requests over a cmux SSH TCP relay address", async () => {
+		const lines: string[] = [];
+		await withSocketServer(
+			(line, socket) => {
+				lines.push(line);
+				socket.write(`${JSON.stringify({ ok: true, result: { transport: "tcp" } })}\n`);
+			},
+			async socketAddress => {
+				const client = new CmuxSocketClient({ socketPath: socketAddress });
+				try {
+					expect(await client.request("browser.list", {})).toEqual({ transport: "tcp" });
+					expect(lines).toHaveLength(1);
+				} finally {
+					client.close();
+				}
+			},
+			"tcp",
 		);
 	});
 


### PR DESCRIPTION
## Context

`cmux ssh` exports its remote CLI relay as `CMUX_SOCKET_PATH=127.0.0.1:<port>`, but `CmuxSocketClient` always passes that value to `net.createConnection({ path })`. As a result, cmux-backed browser panes cannot connect from remote SSH sessions.

## Solution

Detect valid hostname/IPv4 `host:port` values and connect with `net.createConnection({ host, port })`. All other values continue through the existing Unix socket path, with the same connection timeout, authentication, request queue, and error handling. A loopback TCP regression test covers request framing and response round-tripping alongside the existing Unix socket coverage.

## How to test

- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/tools/browser-cmux-socket.test.ts`
- Set `CMUX_SOCKET_PATH` to a loopback TCP server and verify a JSON request/response round trip; repeat with a Unix socket path.

Refs atyrode/dotfiles#65
