### PR TITLE
feat(coding-agent): formalize the SDK package contract

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -13,15 +13,16 @@ bun add @oh-my-pi/pi-coding-agent
 
 ## Entry points
 
-`@oh-my-pi/pi-coding-agent` exports the SDK APIs from the package root (and also via `@oh-my-pi/pi-coding-agent/sdk`).
+`@oh-my-pi/pi-coding-agent/sdk` is the explicit programmatic entrypoint. The package root continues to export the same APIs for compatibility.
 
 Core exports for embedders:
 
-- `createAgentSession`
-- `SessionManager`
-- `Settings`
-- `AuthStorage`
-- `ModelRegistry`
+- `createAgentSession`, `CreateAgentSessionOptions`, and `CreateAgentSessionResult`
+- `AgentSession` and `AgentSessionDisposeOptions`
+- `SessionManager` and `ReadonlySessionManager`
+- `Settings` and `SkillsSettings`
+- `AuthStorage`, `ModelRegistry`, and `EventBus`
+- `RedisSessionStorage` and `SqlSessionStorage` with their client/options types
 - `discoverAuthStorage`
 - Discovery helpers (`discoverExtensions`, `discoverSkills`, `discoverContextFiles`, `discoverPromptTemplates`, `discoverSlashCommands`, `discoverCustomTSCommands`, `discoverMCPServers`)
 - Tool factory surface (`createTools`, `BUILTIN_TOOLS`, tool classes)
@@ -29,7 +30,7 @@ Core exports for embedders:
 ## Quick start (auto-discovery defaults)
 
 ```ts
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 
 const { session, modelFallbackMessage } = await createAgentSession();
 
@@ -87,7 +88,7 @@ Typically you must provide only what you want to control:
 ### File-backed (default)
 
 ```ts
-import { createAgentSession, SessionManager } from "@oh-my-pi/pi-coding-agent";
+import { createAgentSession, SessionManager } from "@oh-my-pi/pi-coding-agent/sdk";
 
 const { session } = await createAgentSession({
   sessionManager: SessionManager.create(process.cwd()),
@@ -103,7 +104,7 @@ console.log(session.sessionFile); // absolute .jsonl path
 ### In-memory
 
 ```ts
-import { createAgentSession, SessionManager } from "@oh-my-pi/pi-coding-agent";
+import { createAgentSession, SessionManager } from "@oh-my-pi/pi-coding-agent/sdk";
 
 const { session } = await createAgentSession({
   sessionManager: SessionManager.inMemory(),
@@ -119,7 +120,7 @@ console.log(session.sessionFile); // undefined
 ### Resume/open/list helpers
 
 ```ts
-import { SessionManager } from "@oh-my-pi/pi-coding-agent";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/sdk";
 
 const recent = await SessionManager.continueRecent(process.cwd());
 const listed = await SessionManager.list(process.cwd());
@@ -138,7 +139,7 @@ import {
   discoverAuthStorage,
   ModelRegistry,
   SessionManager,
-} from "@oh-my-pi/pi-coding-agent";
+} from "@oh-my-pi/pi-coding-agent/sdk";
 
 const authStorage = await discoverAuthStorage();
 const modelRegistry = new ModelRegistry(authStorage);
@@ -177,6 +178,21 @@ If restore fails, `modelFallbackMessage` explains fallback.
 4. stored OAuth credential, including refresh when needed
 5. provider environment variables
 6. custom-provider resolver fallback
+
+## Lifecycle ownership
+
+Always `await session.dispose()` when an embedder is finished with a session. Disposal is idempotent and closes the session manager plus session-owned MCP, async-job, provider-session, memory, browser, and kernel resources.
+
+| Resource | Owner | Embedder responsibility |
+|:--|:--|:--|
+| `AgentSession` | Session caller | Await `session.dispose()` during normal cleanup; repeated calls are safe. |
+| `SessionManager` | Caller until successful `AgentSession` construction; then session | If construction throws before a session exists, close a caller-supplied manager. After success, `session.dispose()` closes it. Internally created pre-session failure cleanup is a current SDK gap. |
+| Caller-supplied `AuthStorage` / `ModelRegistry` | Caller | Retain both for the host lifetime; after every dependent session is disposed, close `AuthStorage` when the host no longer needs it. `ModelRegistry` has no separate disposal API. |
+| Internally discovered `AuthStorage` / `ModelRegistry` | Current SDK bootstrap | Normal `session.dispose()` does not close the auth storage, and the result does not expose it. Long-lived embedders that require explicit auth-store ownership should supply both objects. |
+| Caller-supplied `MCPManager` | Caller | Disconnect when the host no longer needs it; session disposal disconnects only managers created by that session. |
+| Event subscription | Caller | Call the returned unsubscribe function when updates are no longer needed, preferably before disposal. |
+
+This contract describes one embedded session. It does not promise isolation between independently configured top-level hosts in the same process; several registries remain process-scoped today.
 
 ## Event subscription model
 
@@ -332,7 +348,7 @@ import {
   ModelRegistry,
   SessionManager,
   Settings,
-} from "@oh-my-pi/pi-coding-agent";
+} from "@oh-my-pi/pi-coding-agent/sdk";
 
 const authStorage = await discoverAuthStorage();
 const modelRegistry = new ModelRegistry(authStorage);

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -14,6 +14,8 @@ bun add @oh-my-pi/pi-coding-agent
 ## Entry points
 
 `@oh-my-pi/pi-coding-agent/sdk` is the explicit programmatic entrypoint. The package root continues to export the same APIs for compatibility.
+The install smoke verifies that this entrypoint resolves at runtime and that its published manifest points to the bundled declaration artifact. Full TypeScript checking of the installed transitive dependency graph is currently best-effort.
+
 
 Core exports for embedders:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Formalized `@oh-my-pi/pi-coding-agent/sdk` as an explicit package entrypoint and exposed the reusable session, model, auth, event, and persistence primitives embedders need without deep imports.
+
 
 ## [17.0.7] - 2026-07-21
 
@@ -226,9 +230,6 @@
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers
-### Added
-
-- Formalized `@oh-my-pi/pi-coding-agent/sdk` as an explicit package entrypoint and exposed the reusable session, model, auth, event, and persistence primitives embedders need without deep imports.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -226,6 +226,9 @@
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers
+### Added
+
+- Formalized `@oh-my-pi/pi-coding-agent/sdk` as an explicit package entrypoint and exposed the reusable session, model, auth, event, and persistence primitives embedders need without deep imports.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/coding-agent/examples/sdk/12-redis-sessions.ts
+++ b/packages/coding-agent/examples/sdk/12-redis-sessions.ts
@@ -14,7 +14,7 @@
  * (S3, R2, GCS) if you need those off-host too.
  */
 
-import { createAgentSession, RedisSessionStorage, SessionManager } from "@oh-my-pi/pi-coding-agent";
+import { createAgentSession, RedisSessionStorage, SessionManager } from "@oh-my-pi/pi-coding-agent/sdk";
 import { RedisClient } from "bun";
 
 // `bun:redis` picks up `REDIS_URL` / `VALKEY_URL` from the environment, or

--- a/packages/coding-agent/examples/sdk/13-sql-sessions.ts
+++ b/packages/coding-agent/examples/sdk/13-sql-sessions.ts
@@ -18,7 +18,7 @@
  * if you need those off-host too.
  */
 
-import { createAgentSession, SessionManager, SqlSessionStorage } from "@oh-my-pi/pi-coding-agent";
+import { createAgentSession, SessionManager, SqlSessionStorage } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SQL } from "bun";
 
 // Pick one — Bun.SQL auto-detects the dialect from the URL scheme.

--- a/packages/coding-agent/examples/sdk/README.md
+++ b/packages/coding-agent/examples/sdk/README.md
@@ -4,26 +4,27 @@ Programmatic usage of omp-coding-agent via `createAgentSession()`.
 
 ## Examples
 
-| File                       | Description                                    |
-| -------------------------- | ---------------------------------------------- |
-| `01-minimal.ts`            | Simplest usage with all defaults               |
-| `02-custom-model.ts`       | Select model and thinking level                |
-| `03-custom-prompt.ts`      | Replace or modify system prompt                |
-| `04-skills.ts`             | Discover, filter, or replace skills            |
-| `05-tools.ts`              | Built-in tools, custom tools                   |
-| `06-hooks.ts`              | Logging, blocking, result modification         |
-| `07-context-files.ts`      | AGENTS.md context files                        |
-| `08-slash-commands.ts`     | File-based slash commands                      |
-| `09-api-keys-and-oauth.ts` | API key resolution, OAuth config               |
-| `10-settings.ts`           | Override compaction, retry, terminal settings  |
-| `11-sessions.ts`           | In-memory, persistent, continue, list sessions |
-| `12-full-control.ts`       | Replace everything, no discovery               |
+| File                       | Description                                         |
+| -------------------------- | --------------------------------------------------- |
+| `01-minimal.ts`            | Simplest usage with all defaults                    |
+| `02-custom-model.ts`       | Select model and thinking level                     |
+| `03-custom-prompt.ts`      | Replace or modify system prompt                     |
+| `04-skills.ts`             | Discover, filter, or replace skills                 |
+| `06-extensions.ts`         | Extensions for tools, events, and commands          |
+| `06-hooks.ts`              | Logging, blocking, result modification              |
+| `07-context-files.ts`      | AGENTS.md context files                             |
+| `08-prompt-templates.ts`   | File-based prompt templates                         |
+| `08-slash-commands.ts`     | File-based slash commands (prompt templates)        |
+| `09-api-keys-and-oauth.ts` | API key resolution, OAuth config                    |
+| `11-sessions.ts`           | In-memory, persistent, continue, list sessions      |
+| `12-redis-sessions.ts`     | Redis/Valkey-backed session storage                 |
+| `13-sql-sessions.ts`       | SQL-backed session storage (Postgres/MySQL/SQLite)  |
 
 ## Running
 
 ```bash
 cd packages/coding-agent
-npx tsx examples/sdk/01-minimal.ts
+bun examples/sdk/01-minimal.ts
 ```
 
 ## Quick Reference

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -117,6 +117,10 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts"
     },
+    "./sdk": {
+      "types": "./src/sdk.ts",
+      "import": "./src/sdk.ts"
+    },
     "./*": {
       "types": "./src/*.ts",
       "import": "./src/*.ts"

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -616,6 +616,7 @@ export function resolveDialect(
 
 // Re-exports
 
+export { ModelRegistry } from "./config/model-registry";
 export type { PromptTemplate } from "./config/prompt-templates";
 export { Settings, type SkillsSettings } from "./config/settings";
 export type { CustomCommand, CustomCommandFactory } from "./extensibility/custom-commands/types";
@@ -624,7 +625,22 @@ export type * from "./extensibility/extensions";
 export type { Skill } from "./extensibility/skills";
 export type { FileSlashCommand } from "./extensibility/slash-commands";
 export type { MCPManager, MCPServerConfig, MCPServerConnection, MCPToolsLoadResult } from "./mcp";
+export { AgentSession, type AgentSessionDisposeOptions } from "./session/agent-session";
+export { AuthStorage } from "./session/auth-storage";
+export {
+	RedisSessionStorage,
+	type RedisSessionStorageClient,
+	type RedisSessionStorageOptions,
+} from "./session/redis-session-storage";
+export { type ReadonlySessionManager, SessionManager } from "./session/session-manager";
+export {
+	SqlSessionStorage,
+	type SqlSessionStorageAdapter,
+	type SqlSessionStorageClient,
+	type SqlSessionStorageOptions,
+} from "./session/sql-session-storage";
 export type { Tool } from "./tools";
+export { EventBus } from "./utils/event-bus";
 export { buildDirectoryTree, buildWorkspaceTree, type DirectoryTree, type WorkspaceTree } from "./workspace-tree";
 
 export {

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -8,8 +8,8 @@
  * downloads the matching `.node` artifacts.
  *
  * For each public TypeScript package we:
- *   1. Emit `.d.ts` declarations into `dist/types/` so consumers get
- *      stable types regardless of their tsconfig `lib`.
+ *   1. Emit `.d.ts` declaration artifacts into `dist/types/` for the published
+ *      manifest entries.
  *   2. Rewrite `package.json` in place — every `types`/`exports[*].types`
  *      that points at `./src/*.ts(x)` is repointed to `./dist/types/*.d.ts`,
  *      `dist/types` (plus `dist/client` for `stats`) is added to `files`,

--- a/scripts/ci-release-publish.ts
+++ b/scripts/ci-release-publish.ts
@@ -153,7 +153,7 @@ async function rewriteManifest(pkg: PublishPackage, write: boolean): Promise<Pac
 	return manifest;
 }
 
-async function preparePackage(pkg: PublishPackage): Promise<PackageManifest> {
+export async function preparePackageForPublish(pkg: PublishPackage): Promise<PackageManifest> {
 	const pkgDir = path.join(repoRoot, pkg.dir);
 	for (const argv of pkg.preBuild ?? []) {
 		await $`${argv}`.cwd(pkgDir);
@@ -167,22 +167,6 @@ async function preparePackage(pkg: PublishPackage): Promise<PackageManifest> {
 	// Rewrite them to explicit `.js` so the published types resolve everywhere.
 	await fixDtsExtensions(path.join(pkgDir, "dist/types"));
 	return rewriteManifest(pkg, !isDryRun);
-}
-
-/**
- * Apply only the published `bin` rewrite to a package's working-tree
- * manifest. Used by `scripts/install-tests/run-ci.sh` to pack the coding
- * agent with its published topology (bin → prepack bundle) without running
- * the type-emission steps; the caller backs up and restores the manifest.
- */
-export async function applyPublishBin(pkgRelDir: string, write: boolean): Promise<PackageManifest> {
-	const pkg = packages.find(entry => entry.dir === pkgRelDir);
-	if (!pkg?.publishBin) throw new Error(`No publishBin override declared for ${pkgRelDir}`);
-	const manifestPath = path.join(repoRoot, pkgRelDir, "package.json");
-	const manifest = (await Bun.file(manifestPath).json()) as PackageManifest;
-	manifest.bin = { ...pkg.publishBin };
-	if (write) await Bun.write(manifestPath, `${JSON.stringify(manifest, null, "\t")}\n`);
-	return manifest;
 }
 
 function buildNativeOptionalDependencies(version: string): JsonObject {
@@ -306,7 +290,7 @@ async function publishPackage(pkg: PublishPackage): Promise<void> {
 		return;
 	}
 	const pkgDir = path.join(repoRoot, pkg.dir);
-	const manifest = await preparePackage(pkg);
+	const manifest = await preparePackageForPublish(pkg);
 	const name = manifest.name ?? path.basename(pkg.dir);
 	if (manifest.private) {
 		console.log(`Skipping ${name} (private)`);

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -214,7 +214,7 @@ mkdir -p "$TARBALL_APP_DIR"
       echo "Published SDK types export is incorrect: $sdk_types_export"
       exit 1
    }
-   sdk_exports="$(bun -e 'import { AgentSession, AuthStorage, ModelRegistry, SessionManager, createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk"; process.stdout.write([AgentSession, AuthStorage, ModelRegistry, SessionManager, createAgentSession].every(value => typeof value === "function") ? "ok" : "invalid");')"
+   sdk_exports="$(bun -e 'import { AgentSession, AuthStorage, EventBus, ModelRegistry, RedisSessionStorage, SessionManager, SqlSessionStorage, createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk"; process.stdout.write([AgentSession, AuthStorage, EventBus, ModelRegistry, RedisSessionStorage, SessionManager, SqlSessionStorage, createAgentSession].every(value => typeof value === "function") ? "ok" : "invalid");')"
    [ "$sdk_exports" = "ok" ] || {
       echo "Published SDK entrypoint exports are incomplete: $sdk_exports"
       exit 1

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -100,20 +100,46 @@ for pkg in utils wire hashline catalog ai mnemopi snapcompact agent tui stats co
    )
 done
 
-# 4. Pack the coding agent with its *published* manifest: release swaps
-#    `bin.omp` from `src/cli.ts` to the prepack bundle `dist/cli.js`. The repo
-#    manifest keeps pointing at source so `bun link`/`install.sh --source`
-#    work without a build, so the swap must be reproduced here for the smoke
-#    to exercise the bundled worker-host entry the published package ships.
-#    Always restore the working-tree manifest.
+# 4. Pack the coding agent with its published manifest and declarations. Release
+# emits dist/types, rewrites every source types export to that tree, and swaps
+# bin.omp to dist/cli.js. Back up both mutable paths so this smoke leaves a
+# developer worktree unchanged.
 agent_pkg_backup="$WORK_DIR/coding-agent-package.json.orig"
 cp "$ROOT_DIR/packages/coding-agent/package.json" "$agent_pkg_backup"
+agent_types_backup="$WORK_DIR/coding-agent-dist-types.orig"
+agent_had_types=0
+if [ -d "$ROOT_DIR/packages/coding-agent/dist/types" ]; then
+   cp -a "$ROOT_DIR/packages/coding-agent/dist/types" "$agent_types_backup"
+   agent_had_types=1
+fi
+publish_state_active=1
+restore_publish_state() {
+   if [ "$publish_state_active" -eq 0 ]; then return; fi
+   rm -rf "$ROOT_DIR/packages/coding-agent/dist/types"
+   if [ "$agent_had_types" -eq 1 ] && [ -d "$agent_types_backup" ]; then
+      mv "$agent_types_backup" "$ROOT_DIR/packages/coding-agent/dist/types"
+   fi
+   if [ -f "$agent_pkg_backup" ]; then
+      cp "$agent_pkg_backup" "$ROOT_DIR/packages/coding-agent/package.json"
+   fi
+   publish_state_active=0
+}
+cleanup() {
+   local rc=$?
+   trap - EXIT
+   restore_publish_state
+   rm -rf "$WORK_DIR"
+   exit "$rc"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 agent_rc=0
 {
-   bun -e 'import { applyPublishBin } from "./scripts/ci-release-publish.ts"; await applyPublishBin("packages/coding-agent", true);' &&
+   bun -e 'import { packages, preparePackageForPublish } from "./scripts/ci-release-publish.ts"; const pkg = packages.find(candidate => candidate.dir === "packages/coding-agent"); if (!pkg) throw new Error("Coding-agent publish package not found"); await preparePackageForPublish(pkg);' &&
       (cd "$ROOT_DIR/packages/coding-agent" && bun pm pack --destination "$TARBALL_DIR" --quiet >/dev/null)
 } || agent_rc=$?
-cp "$agent_pkg_backup" "$ROOT_DIR/packages/coding-agent/package.json"
+restore_publish_state
 [ "$agent_rc" -eq 0 ] || exit "$agent_rc"
 
 utils_tgz="$(find_tarball "$TARBALL_DIR"/oh-my-pi-pi-utils-*.tgz)"
@@ -176,6 +202,26 @@ mkdir -p "$TARBALL_APP_DIR"
    }
    [ -f "node_modules/@oh-my-pi/collab-web/dist/index.html" ] || {
       echo "Collab web tarball did not install built dist/index.html"
+      exit 1
+   }
+   sdk_types="node_modules/@oh-my-pi/pi-coding-agent/dist/types/sdk.d.ts"
+   [ -f "$sdk_types" ] || {
+      echo "Published SDK declaration missing: $sdk_types"
+      exit 1
+   }
+   sdk_types_export="$(bun -e 'const manifest = await Bun.file("node_modules/@oh-my-pi/pi-coding-agent/package.json").json(); process.stdout.write(manifest.exports?.["./sdk"]?.types ?? "missing");')"
+   [ "$sdk_types_export" = "./dist/types/sdk.d.ts" ] || {
+      echo "Published SDK types export is incorrect: $sdk_types_export"
+      exit 1
+   }
+   sdk_exports="$(bun -e 'import { AgentSession, AuthStorage, ModelRegistry, SessionManager, createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk"; process.stdout.write([AgentSession, AuthStorage, ModelRegistry, SessionManager, createAgentSession].every(value => typeof value === "function") ? "ok" : "invalid");')"
+   [ "$sdk_exports" = "ok" ] || {
+      echo "Published SDK entrypoint exports are incomplete: $sdk_exports"
+      exit 1
+   }
+   sdk_identity="$(bun -e 'import { createAgentSession as rootCreateAgentSession } from "@oh-my-pi/pi-coding-agent"; import { createAgentSession as sdkCreateAgentSession } from "@oh-my-pi/pi-coding-agent/sdk"; process.stdout.write(rootCreateAgentSession === sdkCreateAgentSession ? "same" : "different");')"
+   [ "$sdk_identity" = "same" ] || {
+      echo "Root and SDK entrypoints resolve different createAgentSession implementations"
       exit 1
    }
    smoke_cli ./node_modules/.bin/omp

--- a/scripts/install-tests/run-ci.sh
+++ b/scripts/install-tests/run-ci.sh
@@ -100,9 +100,9 @@ for pkg in utils wire hashline catalog ai mnemopi snapcompact agent tui stats co
    )
 done
 
-# 4. Pack the coding agent with its published manifest and declarations. Release
-# emits dist/types, rewrites every source types export to that tree, and swaps
-# bin.omp to dist/cli.js. Back up both mutable paths so this smoke leaves a
+# 4. Pack the coding agent with its published manifest and declaration artifacts.
+# Release emits dist/types, rewrites every source types export to that tree, and
+# swaps bin.omp to dist/cli.js. Back up both mutable paths so this smoke leaves a
 # developer worktree unchanged.
 agent_pkg_backup="$WORK_DIR/coding-agent-package.json.orig"
 cp "$ROOT_DIR/packages/coding-agent/package.json" "$agent_pkg_backup"
@@ -206,12 +206,12 @@ mkdir -p "$TARBALL_APP_DIR"
    }
    sdk_types="node_modules/@oh-my-pi/pi-coding-agent/dist/types/sdk.d.ts"
    [ -f "$sdk_types" ] || {
-      echo "Published SDK declaration missing: $sdk_types"
+      echo "Published SDK declaration artifact missing: $sdk_types"
       exit 1
    }
    sdk_types_export="$(bun -e 'const manifest = await Bun.file("node_modules/@oh-my-pi/pi-coding-agent/package.json").json(); process.stdout.write(manifest.exports?.["./sdk"]?.types ?? "missing");')"
    [ "$sdk_types_export" = "./dist/types/sdk.d.ts" ] || {
-      echo "Published SDK types export is incorrect: $sdk_types_export"
+      echo "Published SDK declaration manifest entry is incorrect: $sdk_types_export"
       exit 1
    }
    sdk_exports="$(bun -e 'import { AgentSession, AuthStorage, EventBus, ModelRegistry, RedisSessionStorage, SessionManager, SqlSessionStorage, createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk"; process.stdout.write([AgentSession, AuthStorage, EventBus, ModelRegistry, RedisSessionStorage, SessionManager, SqlSessionStorage, createAgentSession].every(value => typeof value === "function") ? "ok" : "invalid");')"


### PR DESCRIPTION
## What

- add an explicit `@oh-my-pi/pi-coding-agent/sdk` package export while preserving root and wildcard imports
- expose the core session, model, and auth primitives embedders need without deep imports
- document current SDK lifecycle ownership and align the SDK example index with the files that ship
- exercise the published SDK export through the binary, source-link, and packed-tarball install smoke

## Why

The SDK subpath is already documented and used throughout the test suite, but it currently resolves only through the broad wildcard export. Making it explicit turns that existing behavior into a machine-readable package contract and gives future runtime extraction a stable compatibility boundary without changing `createAgentSession()` behavior or existing imports.

## Testing

- `bun check` in `packages/coding-agent`
- root `bun check`
- `bash -n scripts/install-tests/run-ci.sh`
- `bash scripts/install-tests/run-ci.sh`
  - binary install smoke
  - source-link install smoke
  - packed-tarball install smoke
  - published `./sdk.types` rewrite and declaration presence
  - SDK runtime value exports
  - root/SDK `createAgentSession` identity

External compilation against the entire installed declaration graph remains follow-up work: the packed dependency graph currently has unrelated missing prompt assets, optional `fastembed` types, and a `CustomToolAdapter.execute` declaration incompatibility. A dedicated forced-failure regression for the publish-state restoration helper is also follow-up work.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)