### PR TITLE
fix: exclude xd://-mounted tools from TOOL INVENTORY

### DIFF
--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -729,13 +729,19 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		if (!toolPromptNames.has(mounted.name)) toolPromptNames.set(mounted.name, mounted.name);
 	}
 	const toolRefs = Object.fromEntries(toolPromptNames.entries());
-	const toolInfo = toolNames.map(name => ({
+	// xd://-mounted tools are only accessible via write xd://<tool> — exclude
+	// them from the flat TOOL INVENTORY so the model never tries to call them
+	// directly as function-call tools. They remain in `tools` for handlebars
+	// gates ({{#has tools "web_search"}}) and in `toolPromptNames` for refs.
+	const xdevNames = new Set(xdevTools.map(m => m.name));
+	const displayToolNames = toolNames.filter(n => !xdevNames.has(n));
+	const toolInfo = displayToolNames.map(name => ({
 		name: toolPromptNames.get(name) ?? name,
 		internalName: name,
 		label: tools?.get(name)?.label ?? "",
 		description: tools?.get(name)?.description ?? "",
 	}));
-	const inventoryTools = toolNames.map(name => {
+	const inventoryTools = displayToolNames.map(name => {
 		const meta = tools?.get(name);
 		return {
 			name: toolPromptNames.get(name) ?? name,
@@ -749,7 +755,6 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	// Otherwise render full `# Tool:` sections inline in the system prompt.
 	const toolListMode = !inlineToolDescriptors && nativeTools;
 	const toolInventory = toolListMode ? "" : renderToolInventory(inventoryTools, model ?? "");
-
 	// Filter skills for the rendered system prompt:
 	// - require the `read` tool so the model can actually fetch skill content;
 	// - drop skills with frontmatter `hide: true` (still loadable via skill:// and /skill:<name>).


### PR DESCRIPTION
## Problem

Closes #5797. See discussion #5796.

xd:// device tools (`web_search`, `browser`, `lsp`, `ast_edit`, `debug`, `inspect_image`, `generate_image`, `headroom_*`, `mcp__*`) appear in both the TOOL INVENTORY flat list and the xd:// Tool Devices section. The TOOL INVENTORY lists them alongside regular function-call tools, causing models to attempt direct invocation → `Tool web_search not found`.

## Fix

Filter `toolNames` to exclude xd://-mounted tools when building `toolInfo` and `inventoryTools`. xd:// tools remain in:
- `tools` set for handlebars gates (`{{#has tools "web_search"}}`)
- `toolPromptNames` for `{{toolRefs}}` references
- The separate xd:// Tool Devices section

## Change

`packages/coding-agent/src/system-prompt.ts`: 3 lines changed, 8 added. Create `displayToolNames` filtered to exclude xd:// tools, use for inventory rendering only.

## Verification

- `bun run --cwd=packages/coding-agent check:types` — passes cleanly
- Existing `system-prompt.test.ts` tests unaffected (GPU probe / CPU model only)