### PR TITLE
fix(prompting): hide xd tools from direct inventory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `xd://` device tools appearing in the direct tool inventory and prompting invalid function calls ([#5797](https://github.com/can1357/oh-my-pi/issues/5797)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -729,13 +729,15 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		if (!toolPromptNames.has(mounted.name)) toolPromptNames.set(mounted.name, mounted.name);
 	}
 	const toolRefs = Object.fromEntries(toolPromptNames.entries());
-	const toolInfo = toolNames.map(name => ({
+	const xdevToolNames = new Set(xdevTools.map(mounted => mounted.name));
+	const inventoryToolNames = xdevToolNames.size === 0 ? toolNames : toolNames.filter(name => !xdevToolNames.has(name));
+	const toolInfo = inventoryToolNames.map(name => ({
 		name: toolPromptNames.get(name) ?? name,
 		internalName: name,
 		label: tools?.get(name)?.label ?? "",
 		description: tools?.get(name)?.description ?? "",
 	}));
-	const inventoryTools = toolNames.map(name => {
+	const inventoryTools = inventoryToolNames.map(name => {
 		const meta = tools?.get(name);
 		return {
 			name: toolPromptNames.get(name) ?? name,

--- a/packages/coding-agent/test/system-prompt-inventory.test.ts
+++ b/packages/coding-agent/test/system-prompt-inventory.test.ts
@@ -130,6 +130,32 @@ describe("system prompt tool inventory", () => {
 		expect(text).not.toContain("- Read: `read`");
 	});
 
+	it.each([
+		["compact", true, false],
+		["inline", false, false],
+	] as const)("omits xd-mounted tools from the %s inventory", async (_mode, nativeTools, inlineToolDescriptors) => {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames: ["read", "web_search"],
+			tools: TOOLS,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			nativeTools,
+			inlineToolDescriptors,
+			xdevTools: [{ name: "web_search", summary: "Searches the web." }],
+			xdevDocs: "Mounted web search documentation.",
+		});
+		const text = systemPrompt.join("\n\n");
+		const inventory = nativeTools ? inventoryFrom(text) : text;
+
+		expect(inventory).toContain(nativeTools ? "`read`" : "# Tool: read");
+		expect(inventory).not.toContain(nativeTools ? "`web_search`" : "# Tool: web_search");
+		expect(text).toContain("# xd:// Tool Devices");
+		expect(text).toContain("Mounted web search documentation.");
+	});
+
 	it("uses a conservative fallback inventory when no tools map is provided", async () => {
 		const { systemPrompt } = await buildSystemPrompt({
 			cwd: tempDir,


### PR DESCRIPTION
## Repro
When `toolNames` contains an `xd://`-mounted tool such as `web_search`, both system-prompt inventory modes advertise it as directly callable. After generating the required HTML test artifact with `bun --cwd packages/coding-agent run gen:tool-views`, `bun test packages/coding-agent/test/system-prompt-inventory.test.ts` reproduced the bug: the compact inventory rendered ``- `web_search` ``, and the inline inventory rendered `# Tool: web_search`.

## Cause
`buildSystemPrompt` in `packages/coding-agent/src/system-prompt.ts` used the unfiltered `toolNames` array to construct both `toolInfo` and `inventoryTools`. xd-mounted names must remain available to prompt feature gates and `toolRefs`, but they are not provider-callable definitions and must not enter either direct inventory representation.

## Fix
- Build a set of mounted xd tool names and filter only the names used by compact and inline inventory rendering.
- Preserve xd tool names for prompt gates, references, and the dedicated `# xd:// Tool Devices` protocol section.
- Cover both inventory modes with an observable system-prompt regression test.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/system-prompt-inventory.test.ts` passes: 13 tests, 50 assertions, 0 failures. The publish gate also completed `bun run fix` and `bun check` successfully.

Fixes #5797