### PR TITLE
fix(session): make /new an atomic boundary against queued steers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `/new` starting an unsolicited old-context provider turn when a hidden steer (e.g. an `xd://` mount notice) was queued: the session transition is now an atomic boundary, so a queued steer/follow-up can no longer auto-resume against the pre-`/new` context while the session is disconnected mid-transition ([#5800](https://github.com/can1357/oh-my-pi/issues/5800)).
+- Fixed `/new` starting an unsolicited old-context provider turn when a hidden steer (e.g. an `xd://` mount notice) was queued: the session transition is now an atomic boundary, so a queued steer/follow-up can no longer auto-resume against the pre-`/new` context while the session is disconnected mid-transition. `/compact` still resumes a steer/follow-up that arrives while it runs, draining the queue once it reconnects ([#5800](https://github.com/can1357/oh-my-pi/issues/5800)).
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/new` starting an unsolicited old-context provider turn when a hidden steer (e.g. an `xd://` mount notice) was queued: the session transition is now an atomic boundary, so a queued steer/follow-up can no longer auto-resume against the pre-`/new` context while the session is disconnected mid-transition ([#5800](https://github.com/can1357/oh-my-pi/issues/5800)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2242,6 +2242,15 @@ export class AgentSession {
 	 *  queue was consumed normally or a new turn already started. */
 	#drainStrandedQueuedMessages(): void {
 		if (this.#abortInProgress) return;
+		// Session transitions (newSession/`/new`, compact, model-switch, session-switch,
+		// dispose) call #disconnectFromAgent() BEFORE `await abort()`, so abort's own
+		// finally lands here with no listener attached. Auto-resuming now would snapshot
+		// the still-old context (the transition hasn't reached agent.reset() yet), start a
+		// stale provider turn that races the reset, and — once reconnected — append its
+		// output to the fresh session (issue #5800). A disconnected session never owns the
+		// queue: the transition does. Leave any queued steer/follow-up for the post-transition
+		// state (reset drops them; an explicit prompt flushes them).
+		if (this.#unsubscribeAgent === undefined) return;
 		// A concern steered into a resumed streaming run after a user interrupt can
 		// strand at the turn tail (steered past the loop's final boundary poll). While
 		// that interrupt's suppression is still in effect, reclaim such advisor steers

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2248,8 +2248,10 @@ export class AgentSession {
 		// the still-old context (the transition hasn't reached agent.reset() yet), start a
 		// stale provider turn that races the reset, and — once reconnected — append its
 		// output to the fresh session (issue #5800). A disconnected session never owns the
-		// queue: the transition does. Leave any queued steer/follow-up for the post-transition
-		// state (reset drops them; an explicit prompt flushes them).
+		// queue: the transition does. newSession/switchSession drop the queue (reset /
+		// clearAllQueues), so nothing survives; compaction preserves it and re-drains itself
+		// after #reconnectToAgent (see compact()'s finally); an explicit prompt flushes it
+		// in every case.
 		if (this.#unsubscribeAgent === undefined) return;
 		// A concern steered into a resumed streaming run after a user interrupt can
 		// strand at the turn tail (steered past the loop's final boundary poll). While
@@ -11023,6 +11025,13 @@ export class AgentSession {
 				this.#compactionAbortController = undefined;
 			}
 			this.#reconnectToAgent();
+			// Compaction disconnected before `await abort()`, so abort's finally drain
+			// (and any steer/follow-up that arrived mid-compaction — async IRC, an
+			// `xd://` mount notice, an SDK/RPC steer) was suppressed while disconnected
+			// (issue #5800). Unlike `/new`/switchSession, compaction preserves the agent
+			// queues, so nothing else resumes them: re-drain now that the listener is back
+			// and `isCompacting` is false, or the queued turn hangs until the next prompt.
+			this.#drainStrandedQueuedMessages();
 		}
 	}
 

--- a/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts
@@ -268,6 +268,65 @@ describe("AgentSession auto-compaction queue resume", () => {
 		expect(compactingDuringAbort).toBe(true);
 	});
 
+	it("resumes a message queued during manual compaction once it completes (#5800)", async () => {
+		// Regression for #5800 review: manual /compact disconnects the agent
+		// listener before `await abort()`, so the abort-finally stranded-message
+		// drain is suppressed while disconnected. Unlike /new (which resets the
+		// queue), compaction preserves the agent queues, so a steer/follow-up that
+		// arrives mid-compaction (async IRC, an xd:// mount notice, an SDK steer)
+		// would hang until the next explicit prompt unless compact() re-drains
+		// after reconnecting.
+		session.settings.set("compaction.keepRecentTokens", 1);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "previous answer" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1_000,
+				output: 100,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1_100,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		session.agent.replaceMessages(session.buildDisplaySessionContext().messages);
+
+		const continueSpy = vi.spyOn(session.agent, "continue").mockImplementation(async () => {
+			session.agent.clearAllQueues();
+		});
+
+		// Park compaction inside its awaited hook so we can queue a follow-up while
+		// the session is disconnected and abort has already run its finally.
+		const gate = Promise.withResolvers<void>();
+		(globalThis as typeof globalThis & { __ompManualCompactGate?: Promise<void> }).__ompManualCompactGate =
+			gate.promise;
+
+		const compactPromise = session.compact();
+		while (!getRuntimeSignals().includes("before_compact:enter")) {
+			await Promise.resolve();
+		}
+
+		// A message arrives DURING compaction (post-abort, still disconnected).
+		session.agent.followUp({
+			role: "user",
+			content: "please respond after compaction",
+			timestamp: Date.now(),
+		});
+		expect(session.agent.hasQueuedMessages()).toBe(true);
+
+		gate.resolve();
+		await compactPromise;
+		await session.waitForIdle();
+
+		// compact()'s finally re-drained the stranded queue after reconnecting.
+		expect(continueSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("cancels an in-flight auto-compaction when manual compact startup aborts", async () => {
 		// Give the branch something to summarize so auto-compaction reaches the
 		// awaited session_before_compact hook, where the test parks it.

--- a/packages/coding-agent/test/agent-session-new-session-queued-steer.test.ts
+++ b/packages/coding-agent/test/agent-session-new-session-queued-steer.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { createMockModel, type MockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
+
+const OLD_USER = "OLD_SESSION_USER_SENTINEL";
+const OLD_ASSISTANT = "OLD_SESSION_ASSISTANT_SENTINEL";
+const HIDDEN_XDEV = "HIDDEN_XDEV_STEER_SENTINEL";
+const LATE_OUTPUT = "LATE_OUTPUT_FROM_OLD_CONTINUE";
+
+/** Collect the text of every message, tolerant of the AgentMessage union
+ *  (some variants carry no `content`, and content blocks are a mixed union
+ *  where only text blocks expose `text`). */
+function collectText(messages: readonly unknown[]): string[] {
+	const out: string[] = [];
+	for (const message of messages) {
+		if (!message || typeof message !== "object" || !("content" in message)) continue;
+		const content = message.content;
+		if (typeof content === "string") {
+			out.push(content);
+			continue;
+		}
+		if (!Array.isArray(content)) continue;
+		for (const block of content) {
+			if (block && typeof block === "object" && "type" in block && block.type === "text" && "text" in block) {
+				const text = block.text;
+				if (typeof text === "string") out.push(text);
+			}
+		}
+	}
+	return out;
+}
+describe("newSession() atomic boundary vs queued hidden steer", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	const authStorages: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-new-session-steer-");
+	});
+
+	afterEach(async () => {
+		try {
+			await session?.dispose();
+		} finally {
+			for (const authStorage of authStorages.splice(0)) authStorage.close();
+			await Bun.sleep(0);
+			await tempDir?.remove();
+		}
+	});
+
+	it("does not start an old-context turn from a queued steer during /new", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const secondCallStarted = Promise.withResolvers<void>();
+		const releaseSecondCall = Promise.withResolvers<void>();
+		let secondRequestMessages: string[] = [];
+		let providerCalls = 0;
+
+		const mock: MockModel = createMockModel({
+			handler: async context => {
+				providerCalls++;
+				if (providerCalls === 1) {
+					return { content: [OLD_ASSISTANT], stopReason: "stop" };
+				}
+				// Second (stale) turn: snapshot the request tail and hold the
+				// stream open so newSession() can complete before it appends.
+				secondRequestMessages = collectText(context.messages);
+				secondCallStarted.resolve();
+				await releaseSecondCall.promise;
+				return { content: [LATE_OUTPUT], stopReason: "stop" };
+			},
+		});
+
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["Test"], tools: [] },
+			streamFn: mock.stream,
+		});
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated({ "compaction.enabled": false });
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		session = new AgentSession({ agent, sessionManager, settings, modelRegistry });
+
+		// Build an old session with recognizable user + assistant messages.
+		await session.prompt(OLD_USER);
+		await agent.waitForIdle();
+		expect(agent.state.messages.some(m => m.role === "assistant")).toBe(true);
+
+		// Queue a hidden custom steer (xdev-mount-notice equivalent) while idle.
+		agent.steer({
+			role: "custom",
+			customType: "xdev-mount-notice",
+			content: HIDDEN_XDEV,
+			display: false,
+			timestamp: Date.now(),
+		});
+		expect(agent.hasQueuedMessages()).toBe(true);
+
+		// Drive /new. The stale steer must NOT start an old-context turn.
+		const newSessionDone = session.newSession();
+
+		// Give the abort finally / post-prompt drain a chance to schedule.
+		const raced = await Promise.race([
+			secondCallStarted.promise.then(() => "second-started" as const),
+			newSessionDone.then(() => "new-resolved" as const),
+		]);
+
+		const secondStartedBeforeReset = raced === "second-started";
+
+		await newSessionDone;
+
+		// After the transition the fresh agent owns no queued messages: reset drops them.
+		expect(agent.hasQueuedMessages()).toBe(false);
+
+		// Release the deferred stream (only relevant if a stale turn regressed into
+		// starting) and let any stream settle.
+		releaseSecondCall.resolve();
+		await agent.waitForIdle();
+
+		const branchText = collectText(agent.state.messages);
+
+		// Contract 1: no second provider request starts during newSession().
+		expect(secondStartedBeforeReset).toBe(false);
+		expect(providerCalls).toBe(1);
+		// Contract 2: fresh branch contains no old markers or hidden steer.
+		expect(secondRequestMessages).not.toContain(OLD_USER);
+		expect(secondRequestMessages).not.toContain(HIDDEN_XDEV);
+		expect(branchText).not.toContain(OLD_USER);
+		expect(branchText).not.toContain(OLD_ASSISTANT);
+		// Contract 3: no late output appended to the fresh session.
+		expect(branchText).not.toContain(LATE_OUTPUT);
+	});
+});


### PR DESCRIPTION
## Repro

After startup `autoResume` restores an existing conversation, invoking `/new` while a hidden steer is queued (the common trigger being `#notifyXdevMountDelta()` queuing an invisible `xdev-mount-notice` steer when MCP devices appear) starts an unsolicited provider turn against the **pre-`/new`** context. No user message is submitted; the stale turn races the reset and its assistant output is appended to the fresh session.

Reproduced with a focused `AgentSession` test (fake stream, no network): queue a hidden steer on an idle restored session, then call `newSession()`. Before the fix the second provider request starts before `newSession()` resolves, carries the old user/assistant messages plus the hidden steer, and its late output lands in the fresh branch.

```
bun test test/agent-session-new-session-queued-steer.test.ts
expect(secondStartedBeforeReset).toBe(false)  // Expected: false, Received: true
```

## Cause

`newSession()` calls `#disconnectFromAgent()` then `await this.abort()` **before** `agent.reset()` (`packages/coding-agent/src/session/agent-session.ts`). `abort()`'s `finally` clears `#abortInProgress` and synchronously calls `#drainStrandedQueuedMessages()`, which schedules `agent.continue()` on a fresh post-prompt `AbortController`. `Agent.continue()` dequeues the hidden steer and snapshots the still-old `#state.messages` before the transition reaches `agent.reset()`. When the stale stream finishes after reconnect, `Agent` appends it to current state and the reconnected session listener persists it in the fresh session. So `await abort()` was not a quiescent boundary — abort's own `finally` scheduled a new old-context turn immediately before reset.

## Fix

- `#drainStrandedQueuedMessages()` now returns early when the session is disconnected from the agent event stream (`#unsubscribeAgent === undefined`). Every session transition (`newSession`/`/new`, `compact`, model-switch, session-switch, dispose) disconnects before `await abort()`, so its `finally` drain no longer auto-resumes: the transition owns the queue and `agent.reset()` drops it. A plain user-interrupt `abort()` keeps the listener attached, so its legitimate stranded-message drain is unaffected.
- Added `test/agent-session-new-session-queued-steer.test.ts` covering the three regression contracts: no second provider request starts during `newSession()`, the fresh branch contains no old markers/hidden steer, and releasing a pre-transition deferred stream cannot append output to the fresh session.

## Verification

`bun test test/agent-session-new-session-queued-steer.test.ts` → 1 pass / 10 assertions. Verified the new test fails without the guard (`secondStartedBeforeReset` is `true`) and passes with it. Regression pass over `agent-session-advisor-suppression`, `agent-session-steer-idle-drain`, `agent-session-queued-steer-delivery`, `agent-session-auto-compaction-queue`, `compaction-lifecycle` → 26 pass / 0 fail. `bun run check:types` for `pi-coding-agent` clean.

Fixes #5800