### PR TITLE
fix(read): support history URL selectors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `history://` read selectors being treated as part of the agent id instead of paging the transcript ([#5806](https://github.com/can1357/oh-my-pi/issues/5806)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -35,6 +35,7 @@ const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
 	agent: true,
 	artifact: true,
 	issue: true,
+	history: true,
 	local: true,
 	memory: true,
 	omp: true,

--- a/packages/coding-agent/test/internal-urls/history-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/history-protocol.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { HistoryProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/history-protocol";
 import {
@@ -21,6 +22,8 @@ import {
 import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { CURRENT_SESSION_VERSION } from "@oh-my-pi/pi-coding-agent/session/session-entries";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ReadTool } from "@oh-my-pi/pi-coding-agent/tools/read";
 import { removeWithRetries } from "@oh-my-pi/pi-utils";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
@@ -34,6 +37,21 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
 
 function fakeLiveSession(messages: unknown[]): AgentSession {
 	return { messages } as unknown as AgentSession;
+}
+
+function makeToolSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => path.join(cwd, "session.jsonl"),
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => path.join(cwd, "artifacts"),
+		allocateOutputArtifact: async toolType => ({
+			id: "history-read",
+			path: path.join(cwd, "artifacts", `history-read.${toolType}.log`),
+		}),
+		settings: Settings.isolated(),
+	};
 }
 
 /** Minimal current-version session JSONL: header + a linear user/assistant chain. */
@@ -116,6 +134,25 @@ describe("history:// protocol", () => {
 		expect(resource.content).toContain("## user");
 		expect(resource.content).toContain("hello from live");
 		expect(resource.notes).toContain("Source: live session");
+	});
+
+	it("read applies line selectors to history transcripts", async () => {
+		AgentRegistry.global().register({
+			id: "HubAgent",
+			displayName: "task",
+			kind: "sub",
+			session: fakeLiveSession([{ role: "user", content: "hello from live", timestamp: 1 }]),
+			status: "idle",
+		});
+		const tool = new ReadTool(makeToolSession(os.tmpdir()));
+
+		const result = await tool.execute("history-range", { path: "history://HubAgent:1-1" });
+		const output = result.content.find(content => content.type === "text");
+
+		expect(output?.type).toBe("text");
+		if (output?.type !== "text") throw new Error("Expected text output");
+		expect(output.text).toContain("# HubAgent (idle)");
+		expect(output.text).not.toContain("hello from live");
 	});
 
 	it("resolves agent ids case-insensitively", async () => {


### PR DESCRIPTION
## Repro

A ranged history read leaves the selector on the resource id: `splitInternalUrlSel("history://HubAgent:2-3")` returned `{ path: "history://HubAgent:2-3" }`, so `read` resolved an unknown agent instead of the transcript range. Reproduced with `bun test packages/coding-agent/test/tools/split-internal-url-sel.test.ts` after adding the failing selector expectation (25 passed, 1 failed).

## Cause

`INTERNAL_SCHEMES_WITH_SELECTORS` in `packages/coding-agent/src/tools/path-utils.ts` omitted `history`, while `ReadTool.execute` in `packages/coding-agent/src/tools/read.ts` delegates internal URL peeling exclusively to `splitInternalUrlSel`; the existing `HistoryProtocolHandler` and in-memory paging path therefore received the selector as part of the agent id.

## Fix

- Add `history` to the selector-aware internal URL schemes.
- Cover a real `ReadTool` request against a registered live agent, asserting `:1-1` pages the transcript instead of changing the agent id.
- Record the fix in the coding-agent changelog.

## Verification

`bun test packages/coding-agent/test/tools/split-internal-url-sel.test.ts packages/coding-agent/test/internal-urls/history-protocol.test.ts` passes: 39 tests, 90 assertions, 0 failures. The pre-publish `bun run fix` and `bun check` gate also passed.

Fixes #5806