### PR TITLE
fix(ai): preserve Anthropic account identity in usage reports

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Automatically invalidate and rotate OAuth credentials when an "invalidated oauth token" error occurs
+- Fixed Anthropic usage reports treating the organization response header as the account identity, which caused the 5h/7d status-line segment to disappear for OAuth credentials without stored organization metadata. ([#5698](https://github.com/can1357/oh-my-pi/issues/5698))
 
 ## [17.0.1] - 2026-07-16
 

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -96,11 +96,6 @@ interface ParsedApiLimitEntry {
 	displayName?: string;
 }
 
-type ClaudeUsagePayload = {
-	payload: ClaudeUsageResponse;
-	orgId?: string;
-};
-
 function parseIsoTime(value: string | undefined): number | undefined {
 	if (!value) return undefined;
 	const parsed = Date.parse(value);
@@ -178,22 +173,17 @@ function getNestedPayloadString(payload: Record<string, unknown>, key: string, n
 	return isRecord(nested) ? getPayloadString(nested, nestedKey) : undefined;
 }
 
-function extractUsageIdentity(payload: ClaudeUsageResponse, orgId?: string): { accountId?: string; email?: string } {
-	if (!isRecord(payload)) return { accountId: orgId };
+function extractUsageIdentity(payload: ClaudeUsageResponse): { accountId?: string; email?: string } {
+	if (!isRecord(payload)) return {};
 	const accountId =
 		getPayloadString(payload, "account_id") ??
 		getPayloadString(payload, "accountId") ??
 		getPayloadString(payload, "user_id") ??
 		getPayloadString(payload, "userId") ??
-		getPayloadString(payload, "org_id") ??
-		getPayloadString(payload, "orgId") ??
 		getNestedPayloadString(payload, "account", "uuid") ??
 		getNestedPayloadString(payload, "account", "id") ??
-		getNestedPayloadString(payload, "organization", "uuid") ??
-		getNestedPayloadString(payload, "organization", "id") ??
 		getNestedPayloadString(payload, "user", "uuid") ??
-		getNestedPayloadString(payload, "user", "id") ??
-		orgId;
+		getNestedPayloadString(payload, "user", "id");
 	const email =
 		getPayloadString(payload, "email") ??
 		getPayloadString(payload, "user_email") ??
@@ -263,16 +253,13 @@ async function fetchUsagePayload(
 	headers: Record<string, string>,
 	ctx: UsageFetchContext,
 	signal?: AbortSignal,
-): Promise<ClaudeUsagePayload | null> {
+): Promise<ClaudeUsageResponse | null> {
 	if (signal?.aborted) return null;
 
 	let lastPayload: ClaudeUsageResponse | null = null;
-	let lastOrgId: string | undefined;
 	for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
 		try {
 			const response = await ctx.fetch(url, { headers, signal });
-			const orgId = response.headers.get("anthropic-organization-id")?.trim() || undefined;
-			lastOrgId = orgId ?? lastOrgId;
 
 			if (!response.ok) {
 				const retryable = isRetryableStatus(response.status);
@@ -292,7 +279,7 @@ async function fetchUsagePayload(
 			if (isRecord(parsed)) {
 				const payload = parsed as ClaudeUsageResponse;
 				lastPayload = payload;
-				if (hasUsageData(payload)) return { payload, orgId };
+				if (hasUsageData(payload)) return payload;
 			}
 
 			ctx.logger?.warn("Claude usage response missing usage data", {
@@ -311,7 +298,7 @@ async function fetchUsagePayload(
 		}
 	}
 
-	return lastPayload ? { payload: lastPayload, orgId: lastOrgId } : null;
+	return lastPayload;
 }
 
 interface ClaudeProfile {
@@ -507,9 +494,8 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 		authorization: `Bearer ${credential.accessToken}`,
 	};
 
-	const payloadResult = await fetchUsagePayload(url, headers, ctx, params.signal);
-	if (!payloadResult || !isRecord(payloadResult.payload)) return null;
-	const { payload, orgId } = payloadResult;
+	const payload = await fetchUsagePayload(url, headers, ctx, params.signal);
+	if (!payload || !isRecord(payload)) return null;
 
 	const apiLimitEntries = parseApiLimitEntries(payload.limits);
 	const fiveHour = parseBucket(payload.five_hour) ?? apiLimitEntries.find(entry => entry.kind === "session")?.bucket;
@@ -563,7 +549,7 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 	].filter((limit): limit is UsageLimit => limit !== null);
 
 	if (limits.length === 0) return null;
-	const identity = extractUsageIdentity(payload, orgId);
+	const identity = extractUsageIdentity(payload);
 	let accountId = identity.accountId ?? credential.accountId;
 	let email = identity.email ?? credential.email;
 	if ((!accountId || !email) && !params.signal?.aborted) {
@@ -580,7 +566,7 @@ async function fetchClaudeUsage(params: UsageFetchParams, ctx: UsageFetchContext
 			endpoint: url,
 			...(accountId ? { accountId } : {}),
 			...(email ? { email } : {}),
-			...(orgId ? { orgId } : {}),
+			...(credential.orgId ? { orgId: credential.orgId } : {}),
 		},
 		raw: payload,
 	};

--- a/packages/ai/test/claude-usage-retry.test.ts
+++ b/packages/ai/test/claude-usage-retry.test.ts
@@ -24,7 +24,7 @@ function baseParams() {
 		credential: {
 			type: "oauth" as const,
 			accessToken: "oat-test",
-			accountId: "org_test",
+			accountId: "account_test",
 			email: "user@example.com",
 			expiresAt: Date.now() + 60_000,
 		},
@@ -66,6 +66,16 @@ describe("claudeUsageProvider retry contract", () => {
 		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock, instantRetryWait));
 		expect(report).not.toBeNull();
 		expect(attempt).toBe(2);
+	});
+
+	it("does not treat the organization response header as account identity", async () => {
+		const fetchMock = (async () =>
+			jsonResponse(200, VALID_PAYLOAD, { "anthropic-organization-id": "org_header" })) as FetchImpl;
+
+		const report = await claudeUsageProvider.fetchUsage(baseParams(), makeContext(fetchMock));
+
+		expect(report?.metadata?.accountId).toBe("account_test");
+		expect(report?.metadata?.orgId).toBeUndefined();
 	});
 
 	it("does NOT retry on 401 — permanent for this credential", async () => {


### PR DESCRIPTION
## Repro
With a direct Anthropic OAuth credential whose stored identity contains `accountId` and email but no `orgId`, return healthy 5h/7d data with `anthropic-organization-id` set. `omp usage --provider anthropic --json --redact` reports the limits, but the status-line account matcher rejects them because the report used the organization ID as both `metadata.accountId` and `metadata.orgId`.

## Cause
`extractUsageIdentity()` in `packages/ai/src/usage/claude.ts` treated payload organization fields and the `anthropic-organization-id` response header as fallbacks for `metadata.accountId`. The generated report therefore replaced the OAuth credential's real account ID with its organization ID; `limitMatchesActiveAccount()` correctly rejected that report against the active credential, leaving `ctx.usage` null.

## Fix
- Restrict Claude payload account extraction to account/user identity fields.
- Keep the OAuth credential's account and organization identity authoritative when the usage payload omits them.
- Add regression coverage proving an organization response header cannot replace the credential account ID.

## Verification
`bun test packages/ai/test/claude-usage-retry.test.ts packages/ai/test/auth-storage-usage-cache.test.ts packages/ai/test/auth-storage-org-scoped-identity.test.ts packages/coding-agent/test/status-line-usage.test.ts packages/coding-agent/test/active-oauth-account.test.ts` — 64 passed, 0 failed. A direct provider-to-matcher smoke check now returns `reportAccountId: "account-user"`, no conflicting report org, and `matches: true` for both 5h and 7d limits. The pre-publish `bun run fix` and `bun check` gate passed.

Fixes #5698