### PR TITLE
feat(prompt): model-aware eval-first batching section in system prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a model-aware `Eval-First Batching` section to the system prompt: when the `eval` tool is active, the prompt now instructs models to batch multi-call steps into single eval cells with `parallel([...])`, in-cell control flow, and per-call error handling, with dialects tuned per model family (Claude/GLM, OpenAI, Kimi, and a maximum-emphasis default fallback). Hidden-model prompt rebuilds now key on the eval dialect cohort as well as the task policy.
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -115,6 +115,52 @@ You MUST use the specialized tool over its shell equivalent:
 {{#has tools "bash"}}- `{{toolRefs.bash}}`: real binaries and short fact pipelines only. Commands shadowing the specialized tools above are blocked.{{/has}}
 {{#has tools "bash"}}- Litmus: one external-CLI call or short pipeline returning a count, frequency, set difference, or checksum → bash. Merely moves, pages, or trims bytes a tool can fetch → use the tool.{{/has}}
 
+{{#has tools "eval"}}
+# Eval-First Batching
+{{#when evalPromptStyle "==" "claude"}}
+<eval_first_batching>
+`{{toolRefs.eval}}` is your default execution surface. If a step needs more than one tool call, write ONE eval cell that performs the whole step; never issue the calls one at a time.
+- Before touching any tool, enumerate every lookup the step needs; run all independent ones simultaneously with `parallel([...])` inside the cell. Prefer parallel over sequential whenever calls have no data dependency.
+- Write real code around the calls: loop over targets, branch per case, wrap risky calls in try/except so one failure degrades only its item — recover or retry inside the cell, keep the batch alive.
+- Distill results in-kernel (filter/aggregate/diff) and return facts, not raw dumps.
+- Kernel state persists across cells and subagents: define helpers once, reuse them for the whole session.
+{{#if xdevTools.length}}
+- xd:// devices are callable in-cell: `tool.{{toolRefs.write}}(path="xd://<tool>", content=<json-args>)` — batch `lsp`/AST queries alongside reads.
+{{/if}}
+- A single direct tool call is right only when that one call fully answers the question.
+</eval_first_batching>
+{{else}}{{#when evalPromptStyle "==" "codex"}}
+Route multi-call steps through `{{toolRefs.eval}}`: one cell per step, all independent lookups dispatched together via `parallel([...])`; keep work sequential only when one result determines the next action.
+- Wrap failable calls in try/except inside the cell; a failed item degrades only itself. After two distinct failed strategies for the same fact, fall back to direct tool calls.
+- Reduce large results in-kernel to the facts the task needs before returning.
+- Kernel state persists across cells: define helpers once; do not re-import or re-declare.
+{{#if xdevTools.length}}
+- Mounted xd:// devices are callable in-cell via `tool.{{toolRefs.write}}(path="xd://<tool>", content=<json-args>)`.
+{{/if}}
+- Prefer a direct tool call when one call is sufficient, each result changes the next decision, or an action requires approval.
+{{else}}{{#when evalPromptStyle "==" "kimi"}}
+Treat `{{toolRefs.eval}}` as the standard way to execute any step involving several tool calls: write one cell that performs the whole step.
+- When the lookups are independent, run them together with `parallel([...])` in that cell; when one result feeds the next, keep them sequential inside the same cell.
+- Put try/except around each risky call so the rest of the batch completes; handle the failure in code and continue.
+- Filter and aggregate results in the kernel, then return the distilled facts.
+- Top-level names persist across cells — define a helper once and reuse it in later cells.
+{{#if xdevTools.length}}
+- xd:// devices work in-cell too: `tool.{{toolRefs.write}}(path="xd://<tool>", content=<json-args>)`.
+{{/if}}
+- A single call that fully answers the question is the one case to call the tool directly.
+{{else}}
+**`{{toolRefs.eval}}` IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE eval cell — NEVER as a chain of single tool calls.
+- **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/grep/glob/lookup the step needs and dispatch ALL independent ones in one cell via `parallel([...])`.
+- **WRITE REAL CODE, NOT CALL LISTS.** Loop over targets, branch `if`/`else` per case, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch — handle it, retry differently, keep the rest.
+- **DISTILL IN-KERNEL.** Filter, diff, and aggregate in code before returning; return facts, NOT dumps.
+- **REUSE STATE.** Top-level names persist across cells — define helpers ONCE, reuse them all session.
+{{#if xdevTools.length}}
+- **xd:// devices too:** `tool.{{toolRefs.write}}(path="xd://<tool>", content=<json-args>)` calls mounted devices (e.g. `lsp`) from inside a cell — batch symbol queries with reads.
+{{/if}}
+- A lone direct tool call is allowed ONLY when that single call fully answers the question.
+{{/when}}{{/when}}{{/when}}
+{{/has}}
+
 {{#if autoQaEnabled}}
 <critical>
 `{{toolRefs.write}} xd://report_issue` powers automated QA. If ANY tool returns output inconsistent with its described behavior given your parameters, write `<tool>: <concise description>` as plain text to `xd://report_issue`. Don't hesitate — false positives are fine.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -303,7 +303,7 @@ import {
 	obfuscateProviderContext,
 	type SecretObfuscator,
 } from "../secrets/obfuscator";
-import { usesCodexTaskPrompt } from "../task/prompt-policy";
+import { evalPromptStyle, usesCodexTaskPrompt } from "../task/prompt-policy";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
@@ -7071,7 +7071,8 @@ export class AgentSession {
 	#currentPromptModelKey(): string | undefined {
 		const model = this.model ? formatModelString(this.model) : undefined;
 		if (!model || this.settings.get("includeModelInPrompt")) return model;
-		return usesCodexTaskPrompt(model) ? "task-policy:gpt-5.6" : "task-policy:default";
+		const taskPolicy = usesCodexTaskPrompt(model) ? "gpt-5.6" : "default";
+		return `task-policy:${taskPolicy};eval-style:${evalPromptStyle(model)}`;
 	}
 
 	async #syncAfterModelChange(previousEditMode: EditMode): Promise<void> {

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -23,7 +23,7 @@ import pragmaticPersonality from "./prompts/system/personalities/pragmatic.md" w
 import projectPromptTemplate from "./prompts/system/project-prompt.md" with { type: "text" };
 import systemPromptTemplate from "./prompts/system/system-prompt.md" with { type: "text" };
 import { normalizeConcurrencyLimit } from "./task/parallel";
-import { usesCodexTaskPrompt } from "./task/prompt-policy";
+import { evalPromptStyle, usesCodexTaskPrompt } from "./task/prompt-policy";
 import { shortenPath } from "./tools/render-utils";
 import { type ActiveRepoContext, resolveActiveRepoContext } from "./utils/active-repo-context";
 import { formatLocalCalendarDate } from "./utils/local-date";
@@ -792,6 +792,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		cwd: promptCwd,
 		model: includeModelInPrompt ? (model ?? "") : "",
 		useCodexTaskPrompt: usesCodexTaskPrompt(model),
+		evalPromptStyle: evalPromptStyle(model),
 		personality: personality === "none" ? "" : PERSONALITY_SPECS[personality].trim(),
 		intentTracing: !!intentField,
 		intentField: intentField ?? "",

--- a/packages/coding-agent/src/task/prompt-policy.ts
+++ b/packages/coding-agent/src/task/prompt-policy.ts
@@ -1,8 +1,36 @@
-import { bareModelId, parseOpenAIModel, semverEqual } from "@oh-my-pi/pi-catalog/identity";
+import {
+	bareModelId,
+	isClaudeModelId,
+	isKimiModelId,
+	isOpenAIModelId,
+	parseGlmModel,
+	parseOpenAIModel,
+	semverEqual,
+} from "@oh-my-pi/pi-catalog/identity";
 
 /** Whether task guidance should follow Codex's GPT-5.6-specific delegation policy. */
 export function usesCodexTaskPrompt(modelId: string | undefined): boolean {
 	if (!modelId) return false;
 	const parsed = parseOpenAIModel(bareModelId(modelId));
 	return parsed !== null && semverEqual(parsed.version, "5.6");
+}
+
+/** Prompt dialect for the system prompt's eval-first batching section. */
+export type EvalPromptStyle = "default" | "claude" | "codex" | "kimi";
+
+/**
+ * Selects the eval-first batching dialect for a model:
+ * - `claude`: Claude/GLM — XML-tagged block with direct imperatives (both are
+ *   steered most reliably by explicit tagged directives).
+ * - `codex`: OpenAI reasoning families — terse bounded rules, no emphasis spam.
+ * - `kimi`: Kimi K-series — positive operational constraints; all-caps NEVER
+ *   directives make K2.x overthink instead of comply.
+ * - `default`: everything else — maximum-emphasis fallback.
+ */
+export function evalPromptStyle(modelId: string | undefined): EvalPromptStyle {
+	if (!modelId) return "default";
+	if (isClaudeModelId(modelId) || parseGlmModel(bareModelId(modelId)) !== null) return "claude";
+	if (isKimiModelId(modelId)) return "kimi";
+	if (isOpenAIModelId(modelId)) return "codex";
+	return "default";
 }

--- a/packages/coding-agent/test/system-prompt-eval-style.test.ts
+++ b/packages/coding-agent/test/system-prompt-eval-style.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import { evalPromptStyle } from "@oh-my-pi/pi-coding-agent/task/prompt-policy";
+import { cleanupTempHome } from "./helpers/temp-home-cleanup";
+
+const EMPTY_TREE = {
+	rootPath: "",
+	rendered: "",
+	truncated: false,
+	totalLines: 0,
+	agentsMdFiles: [],
+};
+
+describe("evalPromptStyle model mapping", () => {
+	it("maps model families across namespaced, bare, and variant id shapes", () => {
+		expect(evalPromptStyle("anthropic/claude-fable-5")).toBe("claude");
+		expect(evalPromptStyle("claude-opus-4-8")).toBe("claude");
+		expect(evalPromptStyle("openrouter/anthropic/claude-sonnet-4.5")).toBe("claude");
+		expect(evalPromptStyle("zai/glm-5.2")).toBe("claude");
+		expect(evalPromptStyle("openai/gpt-5.6")).toBe("codex");
+		expect(evalPromptStyle("gpt-5.2-codex")).toBe("codex");
+		expect(evalPromptStyle("o3-mini")).toBe("codex");
+		expect(evalPromptStyle("moonshotai/kimi-k2.6")).toBe("kimi");
+		expect(evalPromptStyle("kimi-k3-turbo")).toBe("kimi");
+		expect(evalPromptStyle("google/gemini-3-pro")).toBe("default");
+		expect(evalPromptStyle("deepseek/deepseek-v4")).toBe("default");
+		expect(evalPromptStyle(undefined)).toBe("default");
+	});
+});
+
+describe("system prompt eval-first batching section", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-eval-style-"));
+		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-prompt-eval-style-home-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tempHomeDir;
+	});
+
+	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
+
+	async function render(model: string | undefined, toolNames: string[]): Promise<string> {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: tempDir,
+			contextFiles: [],
+			skills: [],
+			rules: [],
+			toolNames,
+			workspaceTree: { ...EMPTY_TREE, rootPath: tempDir },
+			model,
+		});
+		return systemPrompt.join("\n\n");
+	}
+
+	function evalSection(rendered: string): string {
+		const start = rendered.indexOf("# Eval-First Batching");
+		expect(start).toBeGreaterThanOrEqual(0);
+		const end = rendered.indexOf("# Exploration", start);
+		expect(end).toBeGreaterThan(start);
+		return rendered.slice(start, end);
+	}
+
+	it("omits the section when the eval tool is not active", async () => {
+		const rendered = await render("anthropic/claude-fable-5", ["read", "bash"]);
+		expect(rendered).not.toContain("Eval-First Batching");
+	});
+
+	it("renders the XML-tagged claude dialect for Claude and GLM models", async () => {
+		for (const model of ["anthropic/claude-fable-5", "zai/glm-5.2"]) {
+			const rendered = await render(model, ["read", "bash", "eval"]);
+			expect(rendered).toContain("<eval_first_batching>");
+			expect(rendered).toContain("</eval_first_batching>");
+			expect(rendered).toContain("your default execution surface");
+		}
+	});
+
+	it("renders the terse codex dialect for OpenAI models", async () => {
+		const rendered = await render("openai/gpt-5.6", ["read", "bash", "eval"]);
+		expect(rendered).toContain("Route multi-call steps through");
+		expect(rendered).not.toContain("<eval_first_batching>");
+		expect(rendered).not.toContain("PRIMARY EXECUTION SURFACE");
+	});
+
+	it("renders the positive-constraint kimi dialect for Kimi models", async () => {
+		const rendered = await render("moonshotai/kimi-k2.6", ["read", "bash", "eval"]);
+		const section = evalSection(rendered);
+		expect(section).toContain("as the standard way to execute");
+		expect(section).not.toContain("NEVER");
+		expect(section).not.toContain("MUST");
+	});
+
+	it("renders the maximum-emphasis default dialect for unmapped models and when no model is set", async () => {
+		for (const model of ["google/gemini-3-pro", undefined]) {
+			const rendered = await render(model, ["read", "bash", "eval"]);
+			expect(rendered).toContain("PRIMARY EXECUTION SURFACE");
+			expect(rendered).toContain("parallel([...])");
+		}
+	});
+});

--- a/packages/coding-agent/test/system-prompt-model.test.ts
+++ b/packages/coding-agent/test/system-prompt-model.test.ts
@@ -10,7 +10,7 @@ import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { buildSystemPrompt } from "@oh-my-pi/pi-coding-agent/system-prompt";
-import { usesCodexTaskPrompt } from "@oh-my-pi/pi-coding-agent/task/prompt-policy";
+import { evalPromptStyle, usesCodexTaskPrompt } from "@oh-my-pi/pi-coding-agent/task/prompt-policy";
 import { removeSyncWithRetries } from "@oh-my-pi/pi-utils";
 import { cleanupTempHome } from "./helpers/temp-home-cleanup";
 
@@ -167,15 +167,16 @@ describe("AgentSession model-change prompt refresh", () => {
 		return [first, second];
 	}
 
-	function pickTwoModelsWithSameTaskPolicy(): [Model, Model] {
+	function pickTwoModelsWithSamePromptPolicy(): [Model, Model] {
 		const all = modelRegistry.getAll();
 		const first = all[0];
 		const second = all.find(
 			model =>
 				(model.provider !== first.provider || model.id !== first.id) &&
-				usesCodexTaskPrompt(model.id) === usesCodexTaskPrompt(first.id),
+				usesCodexTaskPrompt(model.id) === usesCodexTaskPrompt(first.id) &&
+				evalPromptStyle(model.id) === evalPromptStyle(first.id),
 		);
-		if (!first || !second) throw new Error("Expected two distinct models with the same task prompt policy");
+		if (!first || !second) throw new Error("Expected two distinct models with the same prompt policy cohort");
 		return [first, second];
 	}
 
@@ -185,6 +186,19 @@ describe("AgentSession model-change prompt refresh", () => {
 		const codexPolicy = all.find(model => usesCodexTaskPrompt(model.id));
 		if (!defaultPolicy || !codexPolicy) throw new Error("Expected default-policy and GPT-5.6 models");
 		return [defaultPolicy, codexPolicy];
+	}
+
+	function pickModelsAcrossEvalStyles(): [Model, Model] {
+		const all = modelRegistry.getAll();
+		const first = all.find(model => !usesCodexTaskPrompt(model.id));
+		const second = all.find(
+			model =>
+				!usesCodexTaskPrompt(model.id) &&
+				evalPromptStyle(model.id) !== evalPromptStyle(first?.id ?? "") &&
+				(model.provider !== first?.provider || model.id !== first?.id),
+		);
+		if (!first || !second) throw new Error("Expected two same-task-policy models with different eval styles");
+		return [first, second];
 	}
 
 	function newSession(
@@ -228,8 +242,8 @@ describe("AgentSession model-change prompt refresh", () => {
 		expect(rebuildCount).toBe(1);
 	});
 
-	it("does not rebuild a hidden-model prompt when the task policy stays the same", async () => {
-		const [modelA, modelB] = pickTwoModelsWithSameTaskPolicy();
+	it("does not rebuild a hidden-model prompt when the prompt policy cohort stays the same", async () => {
+		const [modelA, modelB] = pickTwoModelsWithSamePromptPolicy();
 		authStorage.setRuntimeApiKey(modelA.provider, "key-a");
 		authStorage.setRuntimeApiKey(modelB.provider, "key-b");
 
@@ -266,5 +280,25 @@ describe("AgentSession model-change prompt refresh", () => {
 		await session.setModel(modelB);
 		expect(rebuildCount).toBe(1);
 		expect(session.agent.state.systemPrompt).toEqual(["policy changed"]);
+	});
+
+	it("rebuilds a hidden-model prompt when the eval style changes", async () => {
+		const [modelA, modelB] = pickModelsAcrossEvalStyles();
+		authStorage.setRuntimeApiKey(modelA.provider, "key-a");
+		authStorage.setRuntimeApiKey(modelB.provider, "key-b");
+
+		let rebuildCount = 0;
+		session = newSession(
+			modelA,
+			Settings.isolated({ "compaction.enabled": false, includeModelInPrompt: false }),
+			async () => {
+				rebuildCount++;
+				return { systemPrompt: ["eval style changed"] };
+			},
+		);
+
+		await session.setModel(modelB);
+		expect(rebuildCount).toBe(1);
+		expect(session.agent.state.systemPrompt).toEqual(["eval style changed"]);
 	});
 });


### PR DESCRIPTION
## Summary

Adds a model-aware **`Eval-First Batching`** section to the system prompt. When the `eval` tool is active, the prompt now explicitly steers the model to route multi-call steps through single eval cells — dispatching independent lookups concurrently via `parallel([...])`, writing real in-cell control flow (loops/branches), wrapping risky calls in `try/except` so one failure never kills a batch, distilling results in-kernel, and reusing persistent kernel state — instead of chaining single tool calls.

The section renders in one of four dialects selected by model family, because the wording that reliably steers one family regresses another:

| Style | Models | Rationale |
|---|---|---|
| `claude` | Claude (incl. Fable/Mythos), GLM | XML-tagged block + direct imperatives — the pattern Anthropic's own guidance uses to push parallel tool calling to ~100%; GLM prompting guidance routes to the same conventions |
| `codex` | OpenAI (gpt-*/chatgpt/codex/o-series) | Terse bounded rules with explicit fallback caps and direct-call escape hatches, per GPT-5.x prompting guidance (no emphasis spam) |
| `kimi` | Kimi K-series | Positive operational constraints only — all-caps `NEVER` directives are a documented overthinking trigger on K2.x |
| `default` | everything else (Gemini, DeepSeek, Qwen, …) + no model | Maximum-emphasis fallback (bold + caps + MUST/NEVER) so weaker-steered models still comply |

When xd:// devices are mounted, each dialect also teaches the in-cell access path (`tool.write(path="xd://<tool>", content=<json-args>)`) — verified empirically: eval's `tool.<name>` proxy resolves only registry tools, while xd devices are reachable through the `write` tool.

## Implementation

- `task/prompt-policy.ts`: new `evalPromptStyle(modelId)` → `"default" | "claude" | "codex" | "kimi"`, built on `@oh-my-pi/pi-catalog/identity` family predicates (sibling of `usesCodexTaskPrompt`).
- `prompts/system/system-prompt.md`: new `# Eval-First Batching` section gated on `{{#has tools "eval"}}`, variants selected with `{{#when evalPromptStyle "==" …}}`; placed after `# Specialized Tools`.
- `system-prompt.ts`: passes `evalPromptStyle: evalPromptStyle(model)` into the template data.
- `session/agent-session.ts`: `#currentPromptModelKey()` cohort now includes the eval style (`task-policy:<x>;eval-style:<y>`), so hidden-model prompts rebuild when a model switch crosses dialect cohorts and stay byte-stable when it doesn't.

## Testing

- New `test/system-prompt-eval-style.test.ts`: mapping matrix across namespaced/bare/variant id shapes, per-dialect rendered-prompt contracts (XML tag presence for claude/GLM, no `<eval_first_batching>`/caps for codex, no `NEVER`/`MUST` inside the kimi section), section absent without the `eval` tool, default fallback for unmapped models and missing model.
- `test/system-prompt-model.test.ts`: picker now holds the full prompt-policy cohort (task policy + eval style) constant for the no-rebuild test; new test proves a rebuild when only the eval style changes.
- `bun check` (biome + tsgo) clean in `packages/coding-agent`; 16/16 tests pass across the three system-prompt test files.
- Smoke-rendered the section for `anthropic/claude-fable-5`, `openai/gpt-5.6`, `moonshotai/kimi-k2.6`, `zai/glm-5.2`, `google/gemini-3-pro` (with and without mounted xd devices) and verified each dialect renders with clean list formatting.
