### PR TITLE
fix(catalog): read litellm per-model cost from rich metadata

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed LiteLLM provider ignoring per-model pricing: `mapLiteLLMRichEntry` now reads `input_cost_per_token` / `output_cost_per_token` (plus cache costs) from LiteLLM rich metadata and maps them to `cost.input` / `cost.output`, falling back to the bundled reference only when LiteLLM omits cost, so proxied models no longer display as free ([#5818](https://github.com/can1357/oh-my-pi/issues/5818)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Changed

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3266,6 +3266,7 @@ type LiteLLMRichEndpointModel<TApi extends Api> = {
 	hasMaxTokens: boolean;
 	hasToolMetadata: boolean;
 	hasSupportedOpenAIParams: boolean;
+	hasCost: boolean;
 };
 
 const LITELLM_RICH_ENDPOINTS = ["/model_group/info", "/v2/model/info", "/model/info", "/v1/model/info"] as const;
@@ -3363,6 +3364,32 @@ function getLiteLLMParams(entry: LiteLLMRichModelEntry): LiteLLMRichModelEntry |
 
 function getLiteLLMMetadataValue(entry: LiteLLMRichModelEntry, key: string): unknown {
 	return entry[key] ?? getLiteLLMModelInfo(entry)?.[key];
+}
+
+/** Per-million USD cost from a `*_per_token` LiteLLM field, or `undefined` when absent/non-positive. */
+function getLiteLLMPerMillionCost(entry: LiteLLMRichModelEntry, key: string): number | undefined {
+	const perToken = toNumber(getLiteLLMMetadataValue(entry, key));
+	return perToken !== undefined && perToken > 0 ? perToken * 1_000_000 : undefined;
+}
+
+/**
+ * Map LiteLLM's per-token pricing (`input_cost_per_token`, `output_cost_per_token`,
+ * cache costs) onto {@link ModelSpec.cost} in $/million tokens. Returns `undefined`
+ * when LiteLLM reports neither an input nor an output price so callers keep the
+ * bundled reference cost.
+ */
+function getLiteLLMCost(entry: LiteLLMRichModelEntry): ModelSpec<Api>["cost"] | undefined {
+	const input = getLiteLLMPerMillionCost(entry, "input_cost_per_token");
+	const output = getLiteLLMPerMillionCost(entry, "output_cost_per_token");
+	if (input === undefined && output === undefined) {
+		return undefined;
+	}
+	return {
+		input: input ?? 0,
+		output: output ?? 0,
+		cacheRead: getLiteLLMPerMillionCost(entry, "cache_read_input_token_cost") ?? 0,
+		cacheWrite: getLiteLLMPerMillionCost(entry, "cache_creation_input_token_cost") ?? 0,
+	};
 }
 
 function getLiteLLMRichModelId(entry: LiteLLMRichModelEntry): string | undefined {
@@ -3487,7 +3514,7 @@ function mapLiteLLMRichEntry<TApi extends Api>(
 					: (reference?.input ?? ["text"]),
 		reasoning: typeof supportsReasoning === "boolean" ? supportsReasoning : (reference?.reasoning ?? false),
 		thinking: reference?.thinking,
-		cost: reference?.cost ?? UNKNOWN_PROXY_COST,
+		cost: getLiteLLMCost(entry) ?? reference?.cost ?? UNKNOWN_PROXY_COST,
 		...(supportsTools !== undefined ? { supportsTools } : {}),
 		compat: compat as ModelSpec<TApi>["compat"],
 	};
@@ -3554,6 +3581,7 @@ async function fetchLiteLLMRichEndpoint<TApi extends Api>(
 					supportsFunctionCalling === false ||
 					supportedOpenAIParams !== undefined,
 				hasSupportedOpenAIParams: supportedOpenAIParams !== undefined,
+				hasCost: getLiteLLMCost(entry) !== undefined,
 			});
 		}
 	}
@@ -3600,6 +3628,7 @@ export async function fetchLiteLLMRichModels<TApi extends Api>(
 							? next.model.input
 							: existing.model.input,
 					reasoning: typeof next.supportsReasoning === "boolean" ? next.model.reasoning : existing.model.reasoning,
+					cost: next.hasCost ? next.model.cost : existing.model.cost,
 					compat: next.hasSupportedOpenAIParams ? next.model.compat : existing.model.compat,
 				};
 				if (next.hasToolMetadata) {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3667,13 +3667,13 @@ export function litellmModelManagerOptions(
 	const baseUrl = config?.baseUrl ?? Bun.env.LITELLM_BASE_URL ?? "http://localhost:4000/v1";
 	return {
 		providerId: "litellm",
-		// rich-v4 invalidates rows cached before LiteLLM ids gained bundled
-		// reference fallback and before discovery continued past `/model_group/info`
-		// when that endpoint omitted vision metadata. Earlier versions handled
-		// reseller usage-suffix stripping and placeholder-only `all-team-models`
-		// filtering; bump the version whenever the mappers below change, or warm
-		// authoritative caches keep serving pre-change rows for the full TTL.
-		cacheProviderId: `litellm:rich-v4:${Bun.hash(baseUrl).toString(36)}`,
+		// rich-v5 invalidates rows cached before rich metadata pricing was mapped.
+		// Earlier versions added bundled reference fallback, continued discovery
+		// past incomplete `/model_group/info`, stripped reseller usage suffixes,
+		// and filtered placeholder-only `all-team-models` rows. Bump the version
+		// whenever the mappers below change, or warm authoritative caches keep
+		// serving pre-change rows for the full TTL.
+		cacheProviderId: `litellm:rich-v5:${Bun.hash(baseUrl).toString(36)}`,
 		// litellm is a local-only proxy and is never bundled in models.json (that
 		// would leak the machine's localhost catalog). Prefer the proxy's richer
 		// management metadata, then enrich ids against models.dev with the bundled

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -238,6 +238,49 @@ describe("LiteLLM provider discovery", () => {
 		});
 	});
 
+	test("maps LiteLLM per-token cost onto cost.input/output for models missing from models.dev", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = inputUrl(input);
+			if (url === MODELS_DEV_URL) {
+				return Response.json({});
+			}
+			if (url === "http://primary:4000/model_group/info") {
+				return Response.json({
+					data: [
+						{
+							model_group: "openrouter/acme/big",
+							model_name: "Acme Big",
+							max_input_tokens: 262_144,
+							max_output_tokens: 16_384,
+							input_cost_per_token: 0.000_005,
+							output_cost_per_token: 0.000_03,
+							cache_read_input_token_cost: 0.000_000_5,
+							supports_vision: true,
+						},
+					],
+				});
+			}
+			if (url === "http://primary:4000/v1/models") {
+				throw new Error("/v1/models should not be called when rich metadata succeeds");
+			}
+			throw new Error(`Unexpected URL: ${url}`);
+		}) as FetchImpl;
+		const options = litellmModelManagerOptions({
+			apiKey: "sk-rich",
+			baseUrl: "http://primary:4000/v1",
+			fetch: fetchMock,
+		});
+
+		const models = await options.fetchDynamicModels?.();
+
+		expect(models).toHaveLength(1);
+		expect(models?.[0]).toMatchObject({
+			id: "openrouter/acme/big",
+			contextWindow: 262_144,
+			cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+		});
+	});
+
 	test("enriches LiteLLM rich models missing from models.dev with bundled reasoning metadata", async () => {
 		const fetchMock = vi.fn(async (input: string | URL | Request) => {
 			const url = inputUrl(input);

--- a/packages/catalog/test/litellm-provider.test.ts
+++ b/packages/catalog/test/litellm-provider.test.ts
@@ -125,7 +125,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v4:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
+			`litellm:rich-v5:${Bun.hash("http://litellm.example:4100/v1").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);
@@ -148,7 +148,7 @@ describe("LiteLLM provider discovery", () => {
 		const models = await options.fetchDynamicModels?.();
 
 		expect(options.cacheProviderId).toBe(
-			`litellm:rich-v4:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
+			`litellm:rich-v5:${Bun.hash("http://litellm-config.example:4200/v1/").toString(36)}`,
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(6);
 		expect(models).toHaveLength(1);


### PR DESCRIPTION
## Repro
Running a LiteLLM proxy whose `/model_group/info` (or `/v1/model/info`) reports a model absent from omp's bundled catalog with real per-token pricing (`input_cost_per_token: 0.000005`, `output_cost_per_token: 0.00003`) surfaces the model with its correct context window but a price of "free"/$0 in the picker. Exercised via `fetchLiteLLMRichModels`: the mapped `ModelSpec` had `contextWindow: 262144` (rich metadata consumed) yet `cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }`.

## Cause
In `packages/catalog/src/provider-models/openai-compat.ts`, `mapLiteLLMRichEntry` reads token limits and capabilities through `getLiteLLMMetadataValue` but hardcodes `cost: reference?.cost ?? UNKNOWN_PROXY_COST`, never consulting LiteLLM's `input_cost_per_token` / `output_cost_per_token`. The cross-endpoint merge in `fetchLiteLLMRichModels` combined context window, max tokens, input, reasoning, compat, and tool support across endpoints but not `cost`, so LiteLLM-provided pricing was dropped for every litellm-provider model.

## Fix
- Added `getLiteLLMPerMillionCost` / `getLiteLLMCost` helpers that read `input_cost_per_token`, `output_cost_per_token`, `cache_read_input_token_cost`, and `cache_creation_input_token_cost`, converting LiteLLM's per-token units to omp's per-million `cost` shape.
- `mapLiteLLMRichEntry` now uses `getLiteLLMCost(entry) ?? reference?.cost ?? UNKNOWN_PROXY_COST`, so LiteLLM pricing wins and the bundled reference is the fallback only when LiteLLM omits cost.
- Added a `hasCost` flag to `LiteLLMRichEndpointModel` and threaded `cost` through the cross-endpoint merge in `fetchLiteLLMRichModels`, matching how context window / max tokens / capabilities merge.

## Verification
`bun test packages/catalog/test/litellm-provider.test.ts` → 17 pass / 0 fail, including a new regression test asserting `input_cost_per_token: 0.000005` / `output_cost_per_token: 0.00003` map to `cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 }`. Fixes #5818