### PR TITLE
fix(extensions): disambiguate .agent dirs provider tab label

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `/extensions` dashboard tab labeled "Agents (standard)" being confused with the `/agents` subagents feature — the `.agent`/`.agents` config-standard provider now presents as "Agent Dirs (.agent/.agents)" since it lists skills, rules, prompts, commands, and context/system files, never subagents ([#5821](https://github.com/can1357/oh-my-pi/issues/5821)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -1,5 +1,5 @@
 /**
- * Agents (standard) Provider
+ * Agent Dirs (.agent/.agents) Provider
  *
  * Loads skills, rules, prompts, commands, context files, and system prompts
  * from .agent/ and .agents/ directories at both user (~/) and project levels.
@@ -24,7 +24,7 @@ import {
 } from "./helpers";
 
 const PROVIDER_ID = "agents";
-const DISPLAY_NAME = "Agents (standard)";
+const DISPLAY_NAME = "Agent Dirs (.agent/.agents)";
 const PRIORITY = 70;
 const AGENT_DIR_CANDIDATES = [".agent", ".agents"] as const;
 

--- a/packages/coding-agent/test/discovery/agents-provider-label.test.ts
+++ b/packages/coding-agent/test/discovery/agents-provider-label.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Regression test for #5821:
+ * The `.agent`/`.agents` config-standard provider must not present as "a list
+ * of agents" in the /extensions dashboard — its tab label collided with the
+ * first-class /agents subagents feature even though it surfaces only skills,
+ * rules, prompts, commands, and context/system files (never agents).
+ */
+import { describe, expect, test } from "bun:test";
+import { getAllProvidersInfo } from "@oh-my-pi/pi-coding-agent/discovery";
+
+describe("agents (config-standard) provider label", () => {
+	test("display name disambiguates from the /agents subagents feature", () => {
+		const info = getAllProvidersInfo().find(p => p.id === "agents");
+		expect(info).toBeDefined();
+
+		// It surfaces .agent/.agents config-standard capabilities, never agents.
+		expect(info?.capabilities).not.toContain("agent");
+		expect(info?.capabilities).toEqual(expect.arrayContaining(["skills", "rules", "prompts"]));
+
+		// The tab label (used verbatim by buildProviderTabs) must reference the
+		// directories it scans, not read as "a list of agents".
+		expect(info?.displayName).toContain(".agent");
+		expect(info?.displayName).not.toBe("Agents (standard)");
+	});
+});


### PR DESCRIPTION
## Repro
In `/extensions` (Extension Control Center), the tab labeled **Agents (standard)** lists only `.agent`/`.agents` config-standard items (skills, rules, prompts, commands, context/system files) — never any agents — while colliding with the first-class `/agents` subagents feature. Confirmed with a probe over the provider registry:

```
$ bun /tmp/repro-agents-tab.ts
agents provider displayName: "Agents (standard)"
capabilities: ["skills","rules","prompts","slash-commands","context-files","system-prompt"]
```

## Cause
`buildProviderTabs` (`packages/coding-agent/src/modes/components/extensions/state-manager.ts:488-497`) emits one tab per registered provider using each provider's `displayName`. The `.agent`/`.agents` config-standard provider set `DISPLAY_NAME = "Agents (standard)"` (`packages/coding-agent/src/discovery/agents.ts:27`) but registers only for the `skills`, `rules`, `prompts`, `slash-commands`, `context-files`, and `system-prompt` capabilities — there is deliberately no `"agent"` `ExtensionKind`. The label thus reads as "a list of agents" and collides with the separate `/agents` subagents subsystem.

## Fix
- Renamed `DISPLAY_NAME` in `discovery/agents.ts` from `"Agents (standard)"` to `"Agent Dirs (.agent/.agents)"`, and updated the module docstring header to match.
- Added `test/discovery/agents-provider-label.test.ts` asserting the provider's `displayName` references the scanned directories (not "Agents (standard)") and that its capability set never contains `"agent"`.
- Added a `[Unreleased]` changelog entry.

## Verification
`bun test test/discovery/` → 169 pass / 0 fail (includes the new regression test). Manually re-ran the provider probe after the fix:

```
agents provider displayName: "Agent Dirs (.agent/.agents)"
capabilities: ["skills","rules","prompts","slash-commands","context-files","system-prompt"]
```

Fixes #5821