### PR TITLE
feat(coding-agent): auto-enable advisor by model and thinking level

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -539,6 +539,9 @@
 - Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
+### Added
+
+- Added model- and reasoning-aware advisor auto-activation through `advisor.autoEnableFor`, plus `/advisor auto` to restore configured behavior after a session override ([#5824](https://github.com/can1357/oh-my-pi/pull/5824) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.1.5] - 2026-07-27
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1187,13 +1187,20 @@ export interface ResolvedModelRoleValue {
 	/** matchedPatternIndex identifies the first configured pattern that matched an available model. */
 	matchedPatternIndex?: number;
 	explicitThinkingLevel: boolean;
+	/** Unclamped explicit thinking selector from the matched pattern. */
+	explicitThinkingSelector?: ConfiguredThinkingLevel;
 	warning: string | undefined;
 }
 
 export function resolveModelRoleValue(
 	roleValue: string | undefined,
 	availableModels: Model<Api>[],
-	options?: { settings?: Settings; roleLookup?: ModelRoleLookup; matchPreferences?: ModelMatchPreferences },
+	options?: {
+		settings?: Settings;
+		roleLookup?: ModelRoleLookup;
+		matchPreferences?: ModelMatchPreferences;
+		allowInvalidThinkingSelectorFallback?: boolean;
+	},
 ): ResolvedModelRoleValue {
 	if (!roleValue) {
 		return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };
@@ -1216,7 +1223,9 @@ export function resolveModelRoleValue(
 	// rebuilding it per pattern inside parseModelPattern.
 	const preferenceContext = buildPreferenceContext(availableModels, matchPreferences);
 	for (const [patternIndex, effectivePattern] of effectivePatterns.entries()) {
-		const resolved = matchPatternWithContext(effectivePattern, availableModels, preferenceContext);
+		const resolved = matchPatternWithContext(effectivePattern, availableModels, preferenceContext, {
+			allowInvalidThinkingSelectorFallback: options?.allowInvalidThinkingSelectorFallback,
+		});
 		if (resolved.model) {
 			return {
 				model: resolved.model,
@@ -1227,6 +1236,7 @@ export function resolveModelRoleValue(
 						: (resolveThinkingLevelForModel(resolved.model, resolved.thinkingLevel) ?? resolved.thinkingLevel)
 					: resolved.thinkingLevel,
 				explicitThinkingLevel: resolved.explicitThinkingLevel,
+				explicitThinkingSelector: resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined,
 				warning: resolved.warning,
 			};
 		}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -450,9 +450,20 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "model",
 			group: "Advisor",
-			label: "Enable Advisor",
+			label: "Always Enable Advisor",
 			description:
-				"Pair a second model (assigned to the 'advisor' role) that passively reviews each turn and injects notes.",
+				"Pair a second model (assigned to the 'advisor' role) that passively reviews every turn. Overrides automatic model rules.",
+		},
+	},
+	"advisor.autoEnableFor": {
+		type: "string",
+		default: "",
+		ui: {
+			tab: "model",
+			group: "Advisor",
+			label: "Auto-Enable For",
+			description:
+				"Comma-separated model or role selectors. Add a thinking suffix such as :low to match that configured level only.",
 		},
 	},
 	"prewalk.enabled": {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -327,6 +327,8 @@ export class Settings {
 	#configFiles: string[] = [];
 	/** Global settings from config.yml/config.yaml */
 	#global: RawSettings = {};
+	/** Host defaults: override global preferences but yield to project/config/runtime layers. */
+	#hostDefaults: RawSettings = {};
 	/** Project settings from .claude/settings.yml etc */
 	#project: RawSettings = {};
 	/** Last successfully loaded native .omp/config.yml contents. */
@@ -530,6 +532,14 @@ export class Settings {
 		this.#fireEffectiveSettingChanged(path, this.get(path), prev);
 	}
 
+	/** Apply a process-host default below project, config-overlay, and runtime layers. */
+	setHostDefault<P extends SettingPath>(path: P, value: SettingValue<P>): void {
+		const prev = this.get(path);
+		setByPath(this.#hostDefaults, path.split("."), value);
+		this.#rebuildMerged();
+		this.#fireEffectiveSettingChanged(path, this.get(path), prev);
+	}
+
 	/**
 	 * Clear a runtime override.
 	 */
@@ -557,6 +567,9 @@ export class Settings {
 		}
 		if (path === "modelRoles") {
 			modelRolesSignal.fire();
+		}
+		if (path === "advisor.enabled" || path === "advisor.autoEnableFor" || path === "advisor.subagents") {
+			advisorActivationSignal.fire();
 		}
 	}
 
@@ -613,6 +626,7 @@ export class Settings {
 		cloned.#storage = this.#storage;
 		cloned.#configPath = this.#configPath;
 		cloned.#global = structuredClone(this.#global);
+		cloned.#hostDefaults = structuredClone(this.#hostDefaults);
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
 		if (!this.#persist) cloned.#projectShellPathSource = this.#projectShellPathSource;
 		cloned.#configFiles = [...this.#configFiles];
@@ -642,12 +656,22 @@ export class Settings {
 		await this.flush();
 		this.#restoreRuntimeModelRoleOverrides();
 		const prevModelRoles = this.get("modelRoles");
+		const prevAdvisorEnabled = this.get("advisor.enabled");
+		const prevAdvisorAutoEnableFor = this.get("advisor.autoEnableFor");
+		const prevAdvisorSubagents = this.get("advisor.subagents");
 		this.#cwd = normalized;
 		if (this.#persist) {
 			this.#project = await this.#loadProjectSettings();
 		}
 		this.#rebuildMerged();
 		this.#fireEffectiveSettingChanged("modelRoles", this.get("modelRoles"), prevModelRoles);
+		this.#fireEffectiveSettingChanged("advisor.enabled", this.get("advisor.enabled"), prevAdvisorEnabled);
+		this.#fireEffectiveSettingChanged(
+			"advisor.autoEnableFor",
+			this.get("advisor.autoEnableFor"),
+			prevAdvisorAutoEnableFor,
+		);
+		this.#fireEffectiveSettingChanged("advisor.subagents", this.get("advisor.subagents"), prevAdvisorSubagents);
 		this.#fireAllHooks();
 	}
 
@@ -2191,7 +2215,8 @@ export class Settings {
 	}
 
 	#rebuildMerged(): void {
-		this.#merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#projectSettingsForMerge());
+		this.#merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#hostDefaults);
+		this.#merged = this.#deepMerge(this.#merged, this.#projectSettingsForMerge());
 		this.#merged = this.#deepMerge(this.#merged, this.#configOverlay);
 		this.#merged = this.#deepMerge(this.#merged, this.#overrides);
 		this.#resolvedCache.clear();
@@ -2338,6 +2363,13 @@ const appendOnlyModeSignal = new SettingSignal<[value: string]>("provider.append
  * can register independently without overwriting each other.
  */
 export const onAppendOnlyModeChanged = (cb: (value: string) => void) => appendOnlyModeSignal.on(cb);
+
+/** Fires when configured advisor activation changes at runtime or after a project reload. */
+const advisorActivationSignal = new SettingSignal("advisor activation");
+
+/** Subscribe to advisor activation setting changes. Returns an unsubscribe function. */
+export const onAdvisorActivationChanged: (cb: () => void) => () => void =
+	advisorActivationSignal.on.bind(advisorActivationSignal);
 
 /** Fires when any model role changes at runtime. */
 const modelRolesSignal = new SettingSignal("modelRoles");

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -154,6 +154,7 @@ const HOST_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 	// instead of inheriting a user's globally-enabled local preference, and when
 	// they do opt in they get the default tuning rather than the user's local tuning.
 	"advisor.enabled",
+	"advisor.autoEnableFor",
 	"advisor.subagents",
 	"advisor.syncBacklog",
 	"advisor.immuneTurns",
@@ -177,7 +178,7 @@ const RPC_BACKGROUND_DEFAULTED_SETTING_PATHS: SettingPath[] = [
 function applyDefaultSettingOverrides(settingPaths: SettingPath[], targetSettings: Settings): void {
 	for (const settingPath of settingPaths) {
 		if (targetSettings.isConfigured(settingPath)) continue;
-		targetSettings.override(settingPath, getDefault(settingPath));
+		targetSettings.setHostDefault(settingPath, getDefault(settingPath));
 	}
 }
 

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -97,7 +97,10 @@ const CONDITIONS: Record<string, () => boolean> = {
 	hasImageProtocol: () => !!TERMINAL.imageProtocol,
 	advisorEnabled: () => {
 		try {
-			return Settings.instance.get("advisor.enabled") === true;
+			return (
+				Settings.instance.get("advisor.enabled") === true ||
+				!!Settings.instance.get("advisor.autoEnableFor")?.trim()
+			);
 		} catch {
 			return false;
 		}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -368,7 +368,7 @@ export class CommandController {
 	async handleAdvisorStatusCommand(): Promise<void> {
 		const stats = this.ctx.session.getAdvisorStats();
 		if (!stats.configured) {
-			this.ctx.presentCommandOutput([new Spacer(1), new Text("Advisor is disabled.", 1, 0)]);
+			this.ctx.presentCommandOutput([new Spacer(1), new Text(this.ctx.session.formatAdvisorStatus(), 1, 0)]);
 			return;
 		}
 		// Fetch live quota data (cached 5 min by the auth-gateway) so we can show
@@ -395,6 +395,7 @@ export class CommandController {
 		// message that hid the per-advisor state the user needs to act on.
 		if (stats.advisors.length > 1 || (stats.configured && !stats.active)) {
 			let info = `${theme.bold("Advisor Status")} (${stats.advisors.length} advisors)\n`;
+			if (stats.automaticMatch) info += `\nAutomatic match: ${stats.automaticMatch}\n`;
 			for (const a of stats.advisors) {
 				const glyph = CommandController.#advisorStatusGlyph[a.status] ?? "?";
 				const label = CommandController.#advisorStatusLabel[a.status] ?? a.status;
@@ -440,6 +441,7 @@ export class CommandController {
 		// Single active advisor — detailed view.
 		const model = stats.model;
 		let info = `${theme.bold("Advisor Status")}\n\n`;
+		if (stats.automaticMatch) info += `Automatic match: ${stats.automaticMatch}\n\n`;
 		if (stats.advisors.length === 1) {
 			const a = stats.advisors[0];
 			const glyph = CommandController.#advisorStatusGlyph[a.status] ?? "?";

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -440,7 +440,7 @@ export class SelectorController {
 				this.ctx.statusLine.setAutoCompactEnabled(value as boolean);
 				break;
 			case "advisor.enabled":
-				this.ctx.session.setAdvisorEnabled(value as boolean);
+			case "advisor.autoEnableFor":
 				this.ctx.statusLine.invalidate();
 				this.ctx.ui.requestRender();
 				break;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9190,7 +9190,7 @@ export class AgentSession {
 			if (this.#advisorAutomaticPatterns().length > 0) {
 				const model = this.model;
 				const modelLabel = model ? formatModelString(model) : "no model";
-				const thinking = this.configuredThinkingLevel() ?? ThinkingLevel.Off;
+				const thinking = this.configuredThinkingLevel() ?? "inherit";
 				return `Advisor is automatic; no rule matches ${modelLabel}:${thinking}.`;
 			}
 			return "Advisor is disabled.";

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1065,6 +1065,7 @@ export class AgentSession {
 			persistedAssistantEntryId: message => (message as PersistedAssistantMessage)[kPersistedSessionEntryId],
 			sessionMessageAlreadyPersisted: message => this.#sessionMessageAlreadyPersisted(message),
 			setModelWithProviderSessionReset: model => this.#setModelWithProviderSessionReset(model),
+			syncAdvisorActivation: () => this.#syncAdvisorActivation(true),
 			resetCurrentResponsesProviderSession: reason => this.#resetCurrentResponsesProviderSession(reason),
 			maybeAutoRedeemCodexReset: activeBlockUnblockAtMs => this.#maybeAutoRedeemCodexReset(activeBlockUnblockAtMs),
 			runAutoCompaction: (reason, willRetry, deferred, allowDefer, options) =>
@@ -1602,7 +1603,7 @@ export class AgentSession {
 		if (!model) return undefined;
 		const availableModels = this.#modelRegistry.getAvailable();
 		const matchPreferences = getModelMatchPreferences(this.settings);
-		const configuredThinking = this.configuredThinkingLevel() ?? ThinkingLevel.Off;
+		const configuredThinking = this.configuredThinkingLevel() ?? ThinkingLevel.Inherit;
 		for (const pattern of patterns) {
 			const resolved = resolveModelRoleValue(pattern, availableModels, {
 				settings: this.settings,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -40,7 +40,7 @@ import {
 	resolveTelemetry,
 	type StreamFn,
 	TERMINAL_TOOL_RESULT_ABORT_REASON,
-	type ThinkingLevel,
+	ThinkingLevel,
 	type ToolChoiceDirective,
 } from "@oh-my-pi/pi-agent-core";
 import {
@@ -101,11 +101,17 @@ import { type AdvisorConfig, type AdvisorRuntimeStatus, loadAdvisorTranscriptCos
 import { type AsyncJob, AsyncJobManager } from "../async";
 import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mode";
 import type { ModelRegistry } from "../config/model-registry";
-import type { ResolvedModelRoleValue } from "../config/model-resolver";
+import {
+	formatModelString,
+	formatModelStringWithRouting,
+	getModelMatchPreferences,
+	type ResolvedModelRoleValue,
+	resolveModelRoleValue,
+} from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import { buildServiceTierByFamily } from "../config/service-tier";
 import type { Settings, SkillsSettings } from "../config/settings";
-import { onAppendOnlyModeChanged, onModelRolesChanged } from "../config/settings";
+import { onAdvisorActivationChanged, onAppendOnlyModeChanged, onModelRolesChanged } from "../config/settings";
 import { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import { getFileSnapshotStore } from "../edit/file-snapshot-store";
 import type { PythonResult } from "../eval/py/executor";
@@ -449,6 +455,7 @@ export class AgentSession {
 	#cancelExitRecorder?: () => void;
 	#cancelFatalRecoveryHint?: () => void;
 	#exitRecorded = false;
+	#unsubscribeAdvisorActivation?: () => void;
 	#unsubscribeAppendOnly?: () => void;
 	#unsubscribeModelRoles?: () => void;
 	/** Last (enable, providerId) tuple resolved by `#syncAppendOnlyContext` — used to skip no-op invalidations. */
@@ -469,6 +476,9 @@ export class AgentSession {
 	#goalModeState: GoalModeState | undefined;
 	#goalRuntime: GoalRuntime;
 	readonly #advisors: SessionAdvisors;
+	#advisorEnabled = false;
+	#advisorEnabledOverride: boolean | undefined;
+	#advisorAutomaticMatch: string | undefined;
 	#goalTurnCounter = 0;
 	#planReferenceSent = false;
 	#planReferencePath = "local://PLAN.md";
@@ -1009,6 +1019,7 @@ export class AgentSession {
 			promptGeneration: () => this.#promptGeneration,
 			resolveActiveEditMode: () => this.#tools.resolveActiveEditMode(),
 			syncAfterModelChange: previousEditMode => this.#tools.syncAfterModelChange(previousEditMode),
+			syncAfterThinkingLevelApplied: () => this.#syncAdvisorActivation(true),
 			setModelWithProviderSessionReset: model => this.#setModelWithProviderSessionReset(model),
 			clearActiveRetryFallback: () => this.#recovery.clearActiveRetryFallback(),
 			clearInheritedProviderPromptCacheKey: () => this.#clearInheritedProviderPromptCacheKey(),
@@ -1558,6 +1569,7 @@ export class AgentSession {
 			syncTodoPhasesFromBranch: () => this.#todo.syncFromBranch(),
 		};
 		this.#handoff = new SessionHandoff(handoffHost);
+		this.#syncAdvisorActivation();
 
 		this.#rehydrateCheckpointRewindState();
 
@@ -1566,7 +1578,64 @@ export class AgentSession {
 		this.#unsubscribeAgent = this.agent.subscribe(this.#handleAgentEvent);
 		// Re-evaluate append-only context mode when the setting changes at runtime.
 		this.#unsubscribeAppendOnly = onAppendOnlyModeChanged(_value => this.#syncAppendOnlyContext(this.model));
-		this.#unsubscribeModelRoles = onModelRolesChanged(() => this.#advisors.onModelRolesChanged());
+		this.#unsubscribeAdvisorActivation = onAdvisorActivationChanged(() => {
+			if (this.#isDisposed) return;
+			this.#syncAdvisorActivation(true);
+		});
+		this.#unsubscribeModelRoles = onModelRolesChanged(() => {
+			if (this.#isDisposed) return;
+			this.#syncAdvisorActivation(true);
+		});
+	}
+
+	#advisorAutomaticPatterns(): string[] {
+		return (this.settings.get("advisor.autoEnableFor") ?? "")
+			.split(",")
+			.map(pattern => pattern.trim())
+			.filter(Boolean);
+	}
+
+	#matchAdvisorAutomaticPattern(): string | undefined {
+		const patterns = this.#advisorAutomaticPatterns();
+		if (patterns.length === 0) return undefined;
+		const model = this.model;
+		if (!model) return undefined;
+		const availableModels = this.#modelRegistry.getAvailable();
+		const matchPreferences = getModelMatchPreferences(this.settings);
+		const configuredThinking = this.configuredThinkingLevel() ?? ThinkingLevel.Off;
+		for (const pattern of patterns) {
+			const resolved = resolveModelRoleValue(pattern, availableModels, {
+				settings: this.settings,
+				matchPreferences,
+				allowInvalidThinkingSelectorFallback: false,
+			});
+			if (!resolved.model || formatModelStringWithRouting(resolved.model) !== formatModelStringWithRouting(model)) {
+				continue;
+			}
+			if (
+				resolved.explicitThinkingSelector !== undefined &&
+				resolved.explicitThinkingSelector !== configuredThinking
+			) {
+				continue;
+			}
+			return pattern;
+		}
+		return undefined;
+	}
+	#syncAdvisorActivation(seedToCurrent = false): boolean {
+		const alwaysEnabled = this.settings.get("advisor.enabled");
+		const automaticMatch =
+			this.#advisorEnabledOverride === undefined && !alwaysEnabled
+				? this.#matchAdvisorAutomaticPattern()
+				: undefined;
+		const enabled = this.#advisorEnabledOverride ?? (alwaysEnabled || automaticMatch !== undefined);
+		this.#advisorAutomaticMatch = automaticMatch;
+		this.#advisorEnabled = enabled;
+		if (!enabled || (this.#agentKind !== "main" && !this.settings.get("advisor.subagents"))) {
+			this.#advisors.setAdvisorEnabled(false);
+			return false;
+		}
+		return this.#advisors.setAdvisorEnabled(true, seedToCurrent);
 	}
 	/** Model registry for API key resolution and model discovery */
 	get modelRegistry(): ModelRegistry {
@@ -3874,6 +3943,10 @@ export class AgentSession {
 		this.setHindsightSessionState(undefined);
 		hindsightState?.dispose();
 		this.#disconnectFromAgent();
+		if (this.#unsubscribeAdvisorActivation) {
+			this.#unsubscribeAdvisorActivation();
+			this.#unsubscribeAdvisorActivation = undefined;
+		}
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();
 			this.#unsubscribeAppendOnly = undefined;
@@ -6654,7 +6727,8 @@ export class AgentSession {
 
 	/** Advances through the thinking selectors supported by the active model. */
 	cycleThinkingLevel(): ConfiguredThinkingLevel | undefined {
-		return this.#models.cycleThinkingLevel();
+		const level = this.#models.cycleThinkingLevel();
+		return level;
 	}
 
 	/** Reports whether `/fast` is enabled for the active model family. */
@@ -7615,6 +7689,7 @@ export class AgentSession {
 						: (sessionContext.thinkingLevel as ThinkingLevel | undefined)
 					: defaultThinkingLevel;
 			this.#models.restoreThinkingLevel(restoredThinkingLevel);
+			this.#syncAdvisorActivation(true);
 			this.#models.restoreServiceTiers(
 				hasServiceTierEntry ? (sessionContext.serviceTier ?? {}) : configuredServiceTierByFamily,
 			);
@@ -7704,6 +7779,7 @@ export class AgentSession {
 			}
 			this.#todo.syncFromBranch();
 			this.#advisors.resetAllRuntimes();
+			this.#syncAdvisorActivation(true);
 			this.#advisors.reattachRecorderFeeds();
 			this.#reconnectToAgent();
 			try {
@@ -8991,13 +9067,28 @@ export class AgentSession {
 	}
 
 	/**
-	 * Enable or disable the advisor for this session. The setting is overridden for the session,
-	 * and the runtime is started or stopped to match.
+	 * Force the advisor on or off for this session, overriding configured automatic activation.
 	 *
-	 * @returns true when the advisor is actively running after the call.
+	 * @returns true when an advisor runtime is actively running after the call.
 	 */
 	setAdvisorEnabled(enabled: boolean): boolean {
-		return this.#advisors.setAdvisorEnabled(enabled);
+		this.#advisorEnabledOverride = enabled;
+		return this.#syncAdvisorActivation(true);
+	}
+
+	/**
+	 * Clear the session override and return to configured always/automatic activation.
+	 *
+	 * @returns true when an advisor runtime is actively running after the call.
+	 */
+	resetAdvisorEnabledOverride(): boolean {
+		this.#advisorEnabledOverride = undefined;
+		return this.#syncAdvisorActivation(true);
+	}
+
+	/** Re-evaluate configured activation while preserving any session override. */
+	refreshAdvisorActivation(): boolean {
+		return this.#syncAdvisorActivation(true);
 	}
 
 	/**
@@ -9006,7 +9097,7 @@ export class AgentSession {
 	 * @returns true when the advisor is actively running after the call.
 	 */
 	toggleAdvisorEnabled(): boolean {
-		return this.#advisors.toggleAdvisorEnabled();
+		return this.setAdvisorEnabled(!this.#advisorEnabled);
 	}
 
 	/**
@@ -9034,7 +9125,7 @@ export class AgentSession {
 	 * Whether the advisor setting is enabled for this session.
 	 */
 	isAdvisorEnabled(): boolean {
-		return this.#advisors.isAdvisorEnabled();
+		return this.#advisorEnabled;
 	}
 
 	/**
@@ -9085,14 +9176,33 @@ export class AgentSession {
 	 * Return structured advisor stats for the status command and TUI panel.
 	 */
 	getAdvisorStats(): AdvisorStats {
-		return this.#advisors.getAdvisorStats();
+		return { ...this.#advisors.getAdvisorStats(), automaticMatch: this.#advisorAutomaticMatch };
 	}
 
 	/**
 	 * Format a concise advisor status line for ACP/text output.
 	 */
 	formatAdvisorStatus(): string {
-		return this.#advisors.formatAdvisorStatus();
+		const stats = this.getAdvisorStats();
+		if (!stats.configured && !stats.active) {
+			if (this.#advisorEnabledOverride === false) return "Advisor is disabled for this session.";
+			if (this.#advisorAutomaticPatterns().length > 0) {
+				const model = this.model;
+				const modelLabel = model ? formatModelString(model) : "no model";
+				const thinking = this.configuredThinkingLevel() ?? ThinkingLevel.Off;
+				return `Advisor is automatic; no rule matches ${modelLabel}:${thinking}.`;
+			}
+			return "Advisor is disabled.";
+		}
+		const status = this.#advisors.formatAdvisorStatus();
+		if (!this.#advisorAutomaticMatch) return status;
+		if (status.startsWith("Advisor is enabled (")) {
+			return status.replace(
+				/^(Advisor is enabled \([^)]+\)\.)/,
+				`$1 Automatic match: ${this.#advisorAutomaticMatch}.`,
+			);
+		}
+		return status.replace(/^(Advisors enabled \(\d+\))/, `$1 via ${this.#advisorAutomaticMatch}`);
 	}
 
 	/**

--- a/packages/coding-agent/src/session/model-controls.ts
+++ b/packages/coding-agent/src/session/model-controls.ts
@@ -53,6 +53,8 @@ export interface ModelControlsHost {
 	promptGeneration(): number;
 	resolveActiveEditMode(): EditMode;
 	syncAfterModelChange(previousEditMode: EditMode): Promise<void>;
+	/** Reconcile session features after the final effective thinking level has been applied. */
+	syncAfterThinkingLevelApplied(): void;
 	setModelWithProviderSessionReset(model: Model): Promise<void>;
 	clearActiveRetryFallback(): void;
 	clearInheritedProviderPromptCacheKey(): void;
@@ -516,6 +518,7 @@ export class ModelControls {
 				this.#host.sessionManager.appendThinkingLevelChange(provisional, AUTO_THINKING);
 				this.#host.emit({ type: "thinking_level_changed", thinkingLevel: provisional, configured: AUTO_THINKING });
 			}
+			this.#host.syncAfterThinkingLevelApplied();
 			return;
 		}
 
@@ -542,6 +545,7 @@ export class ModelControls {
 			}
 			this.#host.emit({ type: "thinking_level_changed", thinkingLevel: effectiveLevel });
 		}
+		this.#host.syncAfterThinkingLevelApplied();
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-advisors.ts
+++ b/packages/coding-agent/src/session/session-advisors.ts
@@ -104,6 +104,8 @@ const ADVISOR_CODEX_SSE_MAX_ATTEMPTS = 1;
 export interface AdvisorStats {
 	configured: boolean;
 	active: boolean;
+	/** Model selector that activated the automatic policy, when applicable. */
+	automaticMatch?: string;
 	model?: Model;
 	contextWindow: number;
 	contextTokens: number;
@@ -1545,13 +1547,14 @@ export class SessionAdvisors {
 	 *
 	 * @returns true when the advisor is actively running after the call.
 	 */
-	setAdvisorEnabled(enabled: boolean): boolean {
+	setAdvisorEnabled(enabled: boolean, seedToCurrent = true): boolean {
 		this.#advisorEnabled = enabled;
 		if (enabled) {
 			if (this.#advisors.length > 0 && !this.#advisorRuntimeMatchesCurrentConfig()) this.#stopAdvisorRuntime();
-			return this.#buildAdvisorRuntime(true);
+			return this.#buildAdvisorRuntime(seedToCurrent);
 		}
 		this.#stopAdvisorRuntime();
+		this.#advisorStatuses.clear();
 		return false;
 	}
 

--- a/packages/coding-agent/src/session/turn-recovery.ts
+++ b/packages/coding-agent/src/session/turn-recovery.ts
@@ -131,6 +131,7 @@ export interface TurnRecoveryHost {
 	persistedAssistantEntryId(message: AssistantMessage): string | undefined;
 	sessionMessageAlreadyPersisted(message: AssistantMessage): boolean;
 	setModelWithProviderSessionReset(model: Model): Promise<void>;
+	syncAdvisorActivation(): void;
 	resetCurrentResponsesProviderSession(reason: string): void;
 	/**
 	 * Spend a saved Codex reset for the blocked pool, if eligible.
@@ -1440,6 +1441,7 @@ export class TurnRecovery {
 		if (!apiKey) return false;
 		const baseSelector = formatModelStringWithRouting(baseModel);
 		await this.#host.setModelWithProviderSessionReset(baseModel);
+		this.#host.syncAdvisorActivation();
 		this.#host.sessionManager.appendModelChange(baseSelector, EPHEMERAL_MODEL_CHANGE_ROLE, true);
 		this.#host.settings.getStorage()?.recordModelUsage(baseSelector);
 		await this.#host.emitSessionEvent({

--- a/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-collaboration.ts
@@ -58,10 +58,11 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 		name: "advisor",
 		description: "Toggle the advisor (a second model that reviews each turn and injects notes)",
 		acpDescription: "Toggle advisor",
-		acpInputHint: "[on|off|status|dump [raw]|configure]",
+		acpInputHint: "[on|off|auto|status|dump [raw]|configure]",
 		subcommands: [
-			{ name: "on", description: "Enable the advisor" },
-			{ name: "off", description: "Disable the advisor" },
+			{ name: "on", description: "Enable the advisor for this session" },
+			{ name: "off", description: "Disable the advisor for this session" },
+			{ name: "auto", description: "Clear the session override and use configured activation" },
 			{ name: "status", description: "Show advisor status" },
 			{ name: "dump", description: "Copy the advisor's transcript to clipboard", usage: "[raw]" },
 			{ name: "configure", description: "Open the advisor configuration editor (TUI)" },
@@ -100,6 +101,13 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				await runtime.output("Advisor disabled.");
 				return commandConsumed();
 			}
+			if (verb === "auto") {
+				const active = runtime.session.resetAdvisorEnabledOverride();
+				await runtime.output(
+					`Advisor session override cleared; configured activation is ${active ? "active" : "inactive"}.`,
+				);
+				return commandConsumed();
+			}
 			if (verb === "status") {
 				await runtime.output(runtime.session.formatAdvisorStatus());
 				return commandConsumed();
@@ -116,7 +124,7 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				);
 				return commandConsumed();
 			}
-			return usage("Usage: /advisor [on|off|status|dump [raw]|configure]", runtime);
+			return usage("Usage: /advisor [on|off|auto|status|dump [raw]|configure]", runtime);
 		},
 		handleTui: async (command, runtime) => {
 			const { verb, rest } = parseSubcommand(command.args);
@@ -150,6 +158,15 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				runtime.ctx.editor.setText("");
 				return;
 			}
+			if (verb === "auto") {
+				const active = runtime.ctx.session.resetAdvisorEnabledOverride();
+				runtime.ctx.showStatus(
+					`Advisor session override cleared; configured activation is ${active ? "active" : "inactive"}.`,
+				);
+				refreshStatusLine(runtime.ctx);
+				runtime.ctx.editor.setText("");
+				return;
+			}
 			if (verb === "status") {
 				await runtime.ctx.handleAdvisorStatusCommand();
 				runtime.ctx.editor.setText("");
@@ -166,7 +183,7 @@ export const BUILTIN_COLLABORATION_SLASH_COMMANDS: ReadonlyArray<SlashCommandSpe
 				runtime.ctx.editor.setText("");
 				return;
 			}
-			runtime.ctx.showStatus("Usage: /advisor [on|off|status|dump [raw]|configure]");
+			runtime.ctx.showStatus("Usage: /advisor [on|off|auto|status|dump [raw]|configure]");
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -263,6 +263,7 @@ describe("ACP lazy startup", () => {
 			"memory.backend": "local",
 			"memories.enabled": true,
 			"advisor.enabled": true,
+			"advisor.autoEnableFor": "pi/smol:low",
 			"advisor.subagents": true,
 			"advisor.syncBacklog": "5",
 			"advisor.immuneTurns": 7,

--- a/packages/coding-agent/test/advisor-status-command.test.ts
+++ b/packages/coding-agent/test/advisor-status-command.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { CommandController } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+import { getThemeByName, setThemeInstance, type Theme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import type { AdvisorStats } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import type { Component } from "@oh-my-pi/pi-tui";
+
+const EMPTY_TOKENS = { input: 0, output: 0, reasoning: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+let priorTheme: Theme | undefined;
+const EMPTY_MESSAGES = { user: 0, assistant: 0, total: 0 };
+
+function renderStatus(stats: AdvisorStats, formattedStatus: string): Promise<string> {
+	let presented: Component[] = [];
+	const controller = new CommandController({
+		session: {
+			getAdvisorStats: () => stats,
+			formatAdvisorStatus: () => formattedStatus,
+		},
+		present: (components: Component[]) => {
+			presented = components;
+		},
+	} as unknown as InteractiveModeContext);
+
+	return controller
+		.handleAdvisorStatusCommand()
+		.then(() => Bun.stripANSI(presented.flatMap(component => component.render(120)).join("\n")));
+}
+
+beforeAll(async () => {
+	priorTheme = theme;
+	const testTheme = await getThemeByName("dark");
+	if (!testTheme) throw new Error("Failed to load dark theme for advisor status test");
+	setThemeInstance(testTheme);
+});
+
+afterAll(() => {
+	if (priorTheme) setThemeInstance(priorTheme);
+});
+
+describe("TUI advisor status command", () => {
+	it("explains an unmatched automatic activation policy", async () => {
+		const rendered = await renderStatus(
+			{
+				configured: false,
+				active: false,
+				contextWindow: 0,
+				contextTokens: 0,
+				tokens: EMPTY_TOKENS,
+				cost: 0,
+				messages: EMPTY_MESSAGES,
+				advisors: [],
+			},
+			"Advisor is automatic; no rule matches openai/gpt-5.6:high.",
+		);
+
+		expect(rendered).toContain("Advisor is automatic; no rule matches openai/gpt-5.6:high.");
+	});
+
+	it("preserves the manual session-off status", async () => {
+		const rendered = await renderStatus(
+			{
+				configured: false,
+				active: false,
+				contextWindow: 0,
+				contextTokens: 0,
+				tokens: EMPTY_TOKENS,
+				cost: 0,
+				messages: EMPTY_MESSAGES,
+				advisors: [],
+			},
+			"Advisor is disabled for this session.",
+		);
+
+		expect(rendered).toContain("Advisor is disabled for this session.");
+	});
+
+	it("shows the selector that activated the advisor", async () => {
+		const automaticMatch = "pi/smol:low";
+		const rendered = await renderStatus(
+			{
+				configured: true,
+				active: true,
+				automaticMatch,
+				contextWindow: 0,
+				contextTokens: 0,
+				tokens: EMPTY_TOKENS,
+				cost: 0,
+				messages: EMPTY_MESSAGES,
+				advisors: [
+					{
+						name: "default",
+						status: "running",
+						contextWindow: 0,
+						contextTokens: 0,
+						tokens: EMPTY_TOKENS,
+						cost: 0,
+						messages: EMPTY_MESSAGES,
+					},
+				],
+			},
+			"Advisor is enabled.",
+		);
+
+		expect(rendered).toContain(`Automatic match: ${automaticMatch}`);
+	});
+});

--- a/packages/coding-agent/test/advisor-status-command.test.ts
+++ b/packages/coding-agent/test/advisor-status-command.test.ts
@@ -16,7 +16,7 @@ function renderStatus(stats: AdvisorStats, formattedStatus: string): Promise<str
 			getAdvisorStats: () => stats,
 			formatAdvisorStatus: () => formattedStatus,
 		},
-		present: (components: Component[]) => {
+		presentCommandOutput: (components: Component[]) => {
 			presented = components;
 		},
 	} as unknown as InteractiveModeContext);

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -190,6 +190,7 @@ describe("AgentSession advisor toggle", () => {
 
 		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}:off`);
 		expect(session.isAdvisorActive()).toBe(false);
+		expect(session.formatAdvisorStatus()).toContain(`${model.provider}/${model.id}:inherit`);
 
 		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}:inherit`);
 		expect(session.isAdvisorActive()).toBe(true);

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { Agent, type AgentMessage, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
@@ -9,6 +9,7 @@ import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
 import { loadAdvisorTranscriptCosts } from "@oh-my-pi/pi-coding-agent/advisor/transcript-recorder";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { parseModelPattern } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
@@ -31,6 +32,7 @@ describe("AgentSession advisor toggle", () => {
 		authStorage.setRuntimeApiKey("anthropic", "test-key");
 		authStorage.setRuntimeApiKey("openai", "test-key");
 		authStorage.setRuntimeApiKey("openrouter", "test-key");
+		authStorage.setRuntimeApiKey("nanogpt", "test-key");
 		modelRegistry = new ModelRegistry(authStorage);
 		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const replacement = getBundledModel("openai", "gpt-4o-mini");
@@ -153,9 +155,229 @@ describe("AgentSession advisor toggle", () => {
 	}
 
 	it("starts with advisor disabled", () => {
+		expect(session.settings.get("advisor.autoEnableFor")).toBe("");
 		expect(session.isAdvisorActive()).toBe(false);
 		expect(session.isAdvisorEnabled()).toBe(false);
 		expect(session.formatAdvisorStatus()).toBe("Advisor is disabled.");
+	});
+
+	it("automatically follows configured model and thinking selectors", async () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set(
+			"advisor.autoEnableFor",
+			`${model.provider}/${model.id}:low, ${replacementModel.provider}/${replacementModel.id}`,
+		);
+
+		session.setThinkingLevel(ThinkingLevel.Low);
+		expect(session.isAdvisorActive()).toBe(true);
+		expect(session.formatAdvisorStatus()).toContain(`Automatic match: ${model.provider}/${model.id}:low.`);
+
+		session.setThinkingLevel(ThinkingLevel.High);
+		expect(session.isAdvisorActive()).toBe(false);
+		expect(session.getAdvisorStats().advisors).toEqual([]);
+		expect(session.formatAdvisorStatus()).toContain("Advisor is automatic; no rule matches");
+
+		await session.setModelTemporary(replacementModel);
+		expect(session.isAdvisorActive()).toBe(true);
+		expect(session.formatAdvisorStatus()).toContain(
+			`Automatic match: ${replacementModel.provider}/${replacementModel.id}.`,
+		);
+	});
+
+	it("matches the final thinking level applied by a temporary model switch", async () => {
+		const thinkingModel = getBundledModel("openai", "o3");
+		if (!thinkingModel) throw new Error("Expected thinking-capable OpenAI model to exist");
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set(
+			"advisor.autoEnableFor",
+			`${thinkingModel.provider}/${thinkingModel.id}:${ThinkingLevel.Low}`,
+		);
+		session.setThinkingLevel(ThinkingLevel.High);
+
+		await session.setModelTemporary(thinkingModel, ThinkingLevel.Low);
+
+		expect(session.thinkingLevel).toBe(ThinkingLevel.Low);
+		expect(session.isAdvisorActive()).toBe(true);
+		expect(session.getAdvisorStats().automaticMatch).toBe(
+			`${thinkingModel.provider}/${thinkingModel.id}:${ThinkingLevel.Low}`,
+		);
+	});
+
+	it("re-evaluates automatic activation when its settings change", () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.setThinkingLevel(ThinkingLevel.Low);
+		expect(session.isAdvisorActive()).toBe(false);
+
+		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}:low`);
+		expect(session.isAdvisorActive()).toBe(true);
+
+		session.settings.set("advisor.autoEnableFor", `${replacementModel.provider}/${replacementModel.id}`);
+		expect(session.isAdvisorActive()).toBe(false);
+	});
+
+	it("keeps routed automatic selectors scoped to the selected upstream", async () => {
+		const available = modelRegistry.getAvailable();
+		const cerebras = parseModelPattern("openrouter/z-ai/glm-4.7@cerebras", available).model;
+		const fireworks = parseModelPattern("openrouter/z-ai/glm-4.7@fireworks", available).model;
+		if (!cerebras || !fireworks) throw new Error("Expected routed OpenRouter models to resolve");
+
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set("advisor.autoEnableFor", "openrouter/z-ai/glm-4.7@cerebras");
+
+		await session.setModelTemporary(fireworks);
+		expect(session.isAdvisorActive()).toBe(false);
+
+		await session.setModelTemporary(cerebras);
+		expect(session.isAdvisorActive()).toBe(true);
+		expect(session.getAdvisorStats().automaticMatch).toBe("openrouter/z-ai/glm-4.7@cerebras");
+
+		session.settings.set("advisor.autoEnableFor", "openrouter/z-ai/glm-4.7");
+		expect(session.refreshAdvisorActivation()).toBe(false);
+	});
+
+	it("treats thinking-like suffixes in literal model IDs as part of the ID", async () => {
+		const literalModel = getBundledModel("nanogpt", "nanogpt/coding-router:low");
+		if (!literalModel) throw new Error("Expected literal thinking-suffix model to exist");
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set("advisor.autoEnableFor", `${literalModel.provider}/${literalModel.id}`);
+		session.setThinkingLevel(ThinkingLevel.High);
+
+		await session.setModelTemporary(literalModel);
+		expect(session.isAdvisorActive()).toBe(true);
+	});
+
+	it("does not match a thinking suffix clamped by the selected model", () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}:max`);
+
+		session.setThinkingLevel(ThinkingLevel.High);
+		expect(session.isAdvisorActive()).toBe(false);
+	});
+
+	it("honors thinking suffixes on short bare model selectors", async () => {
+		const shortModel = getBundledModel("openai", "o3");
+		if (!shortModel) throw new Error("Expected short-name OpenAI model to exist");
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set("advisor.autoEnableFor", "o3:low");
+		await session.setModelTemporary(shortModel);
+
+		session.setThinkingLevel(ThinkingLevel.High);
+		expect(session.isAdvisorActive()).toBe(false);
+
+		session.setThinkingLevel(ThinkingLevel.Low);
+		expect(session.isAdvisorActive()).toBe(true);
+	});
+
+	it("rejects invalid thinking suffixes instead of widening the rule", () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}:hihg`);
+
+		expect(session.refreshAdvisorActivation()).toBe(false);
+	});
+
+	it("uses the matched role fallback's thinking suffix", () => {
+		session.settings.setModelRole("smol", `missing/no-such-model:low, ${model.provider}/${model.id}:high`);
+		session.settings.set("advisor.autoEnableFor", "@smol");
+
+		session.setThinkingLevel(ThinkingLevel.High);
+		expect(session.refreshAdvisorActivation()).toBe(true);
+
+		session.setThinkingLevel(ThinkingLevel.Low);
+		expect(session.refreshAdvisorActivation()).toBe(false);
+	});
+
+	it("re-evaluates automatic activation after switching sessions", async () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set("advisor.autoEnableFor", `${replacementModel.provider}/${replacementModel.id}`);
+
+		const writeSession = async (name: string, primaryModel: Model): Promise<string> => {
+			const sessionFile = path.join(tempDir.path(), name);
+			const timestamp = "2026-07-17T00:00:00.000Z";
+			await Bun.write(
+				sessionFile,
+				`${[
+					{ type: "session", version: 3, id: name, timestamp, cwd: tempDir.path() },
+					{
+						type: "model_change",
+						id: `${name}-model`,
+						parentId: null,
+						timestamp,
+						model: `${primaryModel.provider}/${primaryModel.id}`,
+						role: "default",
+					},
+				]
+					.map(entry => JSON.stringify(entry))
+					.join("\n")}\n`,
+			);
+			return sessionFile;
+		};
+
+		const enabledSession = await writeSession("enabled.jsonl", replacementModel);
+		const disabledSession = await writeSession("disabled.jsonl", model);
+
+		expect(await session.switchSession(enabledSession)).toBe(true);
+		expect(session.isAdvisorActive()).toBe(true);
+		expect(await session.switchSession(disabledSession)).toBe(true);
+		expect(session.isAdvisorActive()).toBe(false);
+	});
+
+	it("keeps manual overrides until auto mode is restored", () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}`);
+		expect(session.resetAdvisorEnabledOverride()).toBe(true);
+
+		expect(session.setAdvisorEnabled(false)).toBe(false);
+		session.setThinkingLevel(ThinkingLevel.Low);
+		expect(session.isAdvisorActive()).toBe(false);
+		expect(session.formatAdvisorStatus()).toBe("Advisor is disabled for this session.");
+
+		session.settings.set("advisor.autoEnableFor", `${replacementModel.provider}/${replacementModel.id}`);
+		expect(session.refreshAdvisorActivation()).toBe(false);
+		expect(session.formatAdvisorStatus()).toBe("Advisor is disabled for this session.");
+
+		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}`);
+		expect(session.resetAdvisorEnabledOverride()).toBe(true);
+		expect(session.isAdvisorActive()).toBe(true);
+
+		expect(session.setAdvisorEnabled(true)).toBe(true);
+		session.settings.set("advisor.enabled", false);
+		expect(session.refreshAdvisorActivation()).toBe(true);
+	});
+
+	it("evaluates automatic activation against a subagent's own model", async () => {
+		const subDir = TempDir.createSync("@pi-advisor-toggle-sub-");
+		const subSettings = Settings.isolated({
+			"advisor.autoEnableFor": `${model.provider}/${model.id}`,
+			"advisor.subagents": false,
+			"compaction.enabled": false,
+		});
+		subSettings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		const subSession = new AgentSession({
+			agent: new Agent({
+				initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.create(subDir.path(), subDir.path()),
+			settings: subSettings,
+			modelRegistry,
+			advisorTools: [],
+			agentKind: "sub",
+		});
+		try {
+			expect(subSession.isAdvisorActive()).toBe(false);
+
+			subSettings.override("advisor.subagents", true);
+
+			expect(subSession.isAdvisorEnabled()).toBe(true);
+			expect(subSession.isAdvisorActive()).toBe(true);
+
+			subSettings.override("advisor.subagents", false);
+
+			expect(subSession.isAdvisorEnabled()).toBe(true);
+			expect(subSession.isAdvisorActive()).toBe(false);
+		} finally {
+			await subSession.dispose();
+			await subDir.remove();
+		}
 	});
 
 	it("toggle enables the advisor and runtime", () => {

--- a/packages/coding-agent/test/advisor-toggle.test.ts
+++ b/packages/coding-agent/test/advisor-toggle.test.ts
@@ -33,6 +33,7 @@ describe("AgentSession advisor toggle", () => {
 		authStorage.setRuntimeApiKey("openai", "test-key");
 		authStorage.setRuntimeApiKey("openrouter", "test-key");
 		authStorage.setRuntimeApiKey("nanogpt", "test-key");
+		authStorage.setRuntimeApiKey("fireworks", "test-key");
 		modelRegistry = new ModelRegistry(authStorage);
 		const bundled = getBundledModel("anthropic", "claude-sonnet-4-5");
 		const replacement = getBundledModel("openai", "gpt-4o-mini");
@@ -182,6 +183,68 @@ describe("AgentSession advisor toggle", () => {
 		expect(session.formatAdvisorStatus()).toContain(
 			`Automatic match: ${replacementModel.provider}/${replacementModel.id}.`,
 		);
+	});
+
+	it("distinguishes inherited thinking from explicitly disabled thinking", () => {
+		session.settings.setModelRole("advisor", `${model.provider}/${model.id}`);
+
+		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}:off`);
+		expect(session.isAdvisorActive()).toBe(false);
+
+		session.settings.set("advisor.autoEnableFor", `${model.provider}/${model.id}:inherit`);
+		expect(session.isAdvisorActive()).toBe(true);
+	});
+
+	it("re-evaluates automatic activation after a Fireworks Fast fallback", async () => {
+		const fastModel = getBundledModel("fireworks", "kimi-k2.6-fast");
+		const baseModel = getBundledModel("fireworks", "kimi-k2.6");
+		if (!fastModel || !baseModel) throw new Error("Expected bundled Fireworks Fast and base models to exist");
+
+		const mock = createMockModel();
+		const fallbackAgent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model: fastModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: (requestedModel, context, options) => {
+				if (requestedModel.id === fastModel.id) {
+					mock.push({ throw: "provider returned error 503" });
+				} else {
+					mock.push({ content: ["Recovered on Fireworks Standard"] });
+				}
+				return mock.stream(requestedModel, context, options);
+			},
+		});
+		const fallbackSettings = Settings.isolated({
+			"advisor.autoEnableFor": `${baseModel.provider}/${baseModel.id}`,
+			"compaction.enabled": false,
+			"retry.baseDelayMs": 1,
+			"retry.maxRetries": 0,
+		});
+		fallbackSettings.setModelRole("advisor", `${model.provider}/${model.id}`);
+		const fallbackSession = new AgentSession({
+			agent: fallbackAgent,
+			sessionManager: SessionManager.inMemory(),
+			settings: fallbackSettings,
+			modelRegistry,
+			advisorTools: [],
+		});
+
+		try {
+			expect(fallbackSession.isAdvisorActive()).toBe(false);
+
+			await fallbackSession.prompt("Trigger Fireworks Fast fallback");
+			await fallbackSession.waitForIdle();
+
+			expect(fallbackSession.model?.id).toBe(baseModel.id);
+			expect(fallbackSession.isAdvisorActive()).toBe(true);
+			expect(fallbackSession.getAdvisorStats().automaticMatch).toBe(`${baseModel.provider}/${baseModel.id}`);
+		} finally {
+			await fallbackSession.dispose();
+		}
 	});
 
 	it("matches the final thinking level applied by a temporary model switch", async () => {

--- a/packages/coding-agent/test/selector-settings-side-effects.test.ts
+++ b/packages/coding-agent/test/selector-settings-side-effects.test.ts
@@ -55,6 +55,24 @@ describe("selector setting side effects", () => {
 		expect(requestRender).toHaveBeenCalledTimes(1);
 	});
 
+	it("invalidates advisor status without clearing the session override", () => {
+		const resetAdvisorEnabledOverride = vi.fn();
+		const invalidate = vi.fn();
+		const requestRender = vi.fn();
+		const controller = new SelectorController({
+			session: { resetAdvisorEnabledOverride },
+			statusLine: { invalidate },
+			ui: { requestRender },
+		} as unknown as InteractiveModeContext);
+
+		controller.handleSettingChange("advisor.autoEnableFor", "pi/smol:low");
+		controller.handleSettingChange("advisor.enabled", false);
+
+		expect(resetAdvisorEnabledOverride).not.toHaveBeenCalled();
+		expect(invalidate).toHaveBeenCalledTimes(2);
+		expect(requestRender).toHaveBeenCalledTimes(2);
+	});
+
 	it("invalidates the UI and requests a repaint when tui.tight changes", () => {
 		const invalidate = vi.fn();
 		const requestRender = vi.fn();
@@ -78,7 +96,7 @@ describe("selector setting side effects", () => {
 
 		expect(applyMemoryBackend).toHaveBeenCalledTimes(1);
 	});
-	it("stops the live advisor runtime when advisor.enabled is turned off in /settings", () => {
+	it("lets settings activation events update the runtime without replacing a session override", () => {
 		const setAdvisorEnabled = vi.fn();
 		const invalidate = vi.fn();
 		const requestRender = vi.fn();
@@ -90,7 +108,7 @@ describe("selector setting side effects", () => {
 
 		controller.handleSettingChange("advisor.enabled", false);
 
-		expect(setAdvisorEnabled).toHaveBeenCalledWith(false);
+		expect(setAdvisorEnabled).not.toHaveBeenCalled();
 		expect(invalidate).toHaveBeenCalledTimes(1);
 		expect(requestRender).toHaveBeenCalledTimes(1);
 	});

--- a/packages/coding-agent/test/settings-reload-cwd.test.ts
+++ b/packages/coding-agent/test/settings-reload-cwd.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { onAdvisorActivationChanged, resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { getProjectAgentDir, removeSyncWithRetries, Snowflake } from "@oh-my-pi/pi-utils";
 import { YAML } from "bun";
 import { beginSettingsTest, restoreSettingsTestState, type SettingsTestState } from "./helpers/settings-test-state";
@@ -230,6 +230,47 @@ describe("Settings.reloadForCwd", () => {
 			resetSettingsForTest();
 			if (fs.existsSync(testDir)) {
 				removeSyncWithRetries(testDir);
+			}
+		});
+
+		it("lets destination project advisor settings override host defaults and emits the effective change", async () => {
+			fs.writeFileSync(
+				path.join(getProjectAgentDir(scopedProject), "settings.json"),
+				JSON.stringify({ advisor: { autoEnableFor: "openai/gpt-5:high" } }),
+			);
+			const settings = await Settings.init({ cwd: startDir, agentDir });
+			settings.setHostDefault("advisor.autoEnableFor", "");
+			let changes = 0;
+			const unsubscribe = onAdvisorActivationChanged(() => {
+				changes += 1;
+			});
+
+			try {
+				await settings.reloadForCwd(scopedProject);
+				expect(settings.get("advisor.autoEnableFor")).toBe("openai/gpt-5:high");
+				expect(changes).toBe(1);
+			} finally {
+				unsubscribe();
+			}
+		});
+
+		it("emits advisor activation when project subagent enablement changes", async () => {
+			fs.writeFileSync(
+				path.join(getProjectAgentDir(scopedProject), "settings.json"),
+				JSON.stringify({ advisor: { subagents: true } }),
+			);
+			const settings = await Settings.init({ cwd: startDir, agentDir });
+			let changes = 0;
+			const unsubscribe = onAdvisorActivationChanged(() => {
+				changes += 1;
+			});
+
+			try {
+				await settings.reloadForCwd(scopedProject);
+				expect(settings.get("advisor.subagents")).toBe(true);
+				expect(changes).toBe(1);
+			} finally {
+				unsubscribe();
 			}
 		});
 

--- a/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
+++ b/packages/coding-agent/test/turn-recovery-replay-unsafe.test.ts
@@ -72,6 +72,7 @@ function createHost(
 		appendSessionMessage: () => {},
 		sessionMessageAlreadyPersisted: () => false,
 		setModelWithProviderSessionReset: async () => {},
+		syncAdvisorActivation: () => {},
 		resetCurrentResponsesProviderSession: () => {},
 		maybeAutoRedeemCodexReset: async () => false,
 		runAutoCompaction: async () =>


### PR DESCRIPTION
## What

- Add `advisor.autoEnableFor`, a comma-separated list of model or role selectors. An optional thinking suffix such as `:low` constrains a rule to that configured reasoning level.
- Match routed models by their full routed selector and use the resolver's matched thinking suffix, including short selectors and later role fallbacks. Invalid suffixes do not broaden a rule.
- Re-evaluate automatic activation when the selected model, configured thinking level, advisor role, or effective advisor settings change, including after a cross-project settings reload.
- Keep `/advisor on` and `/advisor off` as session overrides. `/advisor auto` is the explicit return to configured activation.
- Show matched and unmatched automatic activation state in both text and TUI advisor status output.
- Apply protocol-host defaults through a settings layer that overrides global preferences but yields to destination-project, config-overlay, and runtime settings.

## Why

Pairing a fast model with an advisor otherwise requires repeated manual toggles as model or reasoning selections change. The policy remains enable-only and session-scoped, preserves manual overrides, and follows the active project's configuration after moves or resumes.

Related: #4851 covers per-advisor toggles, status, and quota handling. This PR covers session-wide model/thinking activation and `/advisor auto`.

## Testing

```bash
bun test packages/coding-agent/test/advisor-toggle.test.ts packages/coding-agent/test/advisor-status-command.test.ts packages/coding-agent/test/selector-settings-side-effects.test.ts packages/coding-agent/test/settings-reload-cwd.test.ts packages/coding-agent/test/acp-lazy-startup.test.ts
bun --cwd=packages/coding-agent run check
bun run ci:test:smoke
bun check
```

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
