### PR TITLE
fix(lsp): support pull diagnostics

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+- Fixed LSP diagnostics and edit-time diagnostics writethrough for pull-only servers that advertise `textDocument/diagnostic` statically or through dynamic registration ([#5825](https://github.com/can1357/oh-my-pi/issues/5825)).
 - Fixed loading issues for linked legacy extensions importing `DefaultPackageManager` or `linkedom`.
 - Fixed the advisor retrying terminal, non-retriable provider failures (e.g., blocked prompts), ensuring they fail immediately while transient failures still retry.
 - Fixed an issue where reassigning the `plan` role model mid-planning did not take effect until the next plan-mode entry; it now applies at the next turn boundary.

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -142,6 +142,9 @@ const CLIENT_CAPABILITIES = {
 			codeDescriptionSupport: true,
 			dataSupport: true,
 		},
+		diagnostic: {
+			dynamicRegistration: true,
+		},
 	},
 	window: {
 		workDoneProgress: true,
@@ -456,6 +459,58 @@ async function handleApplyEditRequest(client: LspClient, message: LspJsonRpcRequ
 	}
 }
 
+interface DynamicCapabilityRegistration {
+	id?: unknown;
+	method?: unknown;
+}
+
+interface DynamicCapabilityParams {
+	registrations?: DynamicCapabilityRegistration[];
+	unregisterations?: DynamicCapabilityRegistration[];
+	unregistrations?: DynamicCapabilityRegistration[];
+}
+
+function updateDynamicCapabilities(client: LspClient, message: LspJsonRpcRequest): void {
+	const params = message.params as DynamicCapabilityParams;
+	if (message.method === "client/registerCapability") {
+		if (!Array.isArray(params.registrations)) return;
+		let registrations = client.dynamicCapabilityRegistrations;
+		if (!registrations) {
+			registrations = new Map();
+			client.dynamicCapabilityRegistrations = registrations;
+		}
+		for (const registration of params.registrations) {
+			if (typeof registration.id === "string" && typeof registration.method === "string") {
+				registrations.set(registration.id, registration.method);
+			}
+		}
+		return;
+	}
+
+	const registrations = client.dynamicCapabilityRegistrations;
+	if (!registrations) return;
+	const unregistrations = params.unregisterations ?? params.unregistrations;
+	if (!Array.isArray(unregistrations)) return;
+	for (const registration of unregistrations) {
+		if (typeof registration.id === "string") {
+			registrations.delete(registration.id);
+		}
+	}
+}
+
+/** Whether the server advertised LSP 3.17 document diagnostic pulls statically or through registration. */
+export function supportsDocumentDiagnostics(client: LspClient): boolean {
+	const staticProvider = client.serverCapabilities?.diagnosticProvider;
+	if (staticProvider) return true;
+
+	const registrations = client.dynamicCapabilityRegistrations;
+	if (!registrations) return false;
+	for (const method of registrations.values()) {
+		if (method === "textDocument/diagnostic") return true;
+	}
+	return false;
+}
+
 /**
  * Respond to a server-initiated request.
  */
@@ -478,6 +533,7 @@ async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest
 		return;
 	}
 	if (message.method === "client/registerCapability" || message.method === "client/unregisterCapability") {
+		updateDynamicCapabilities(client, message);
 		// Some servers block semantic requests until dynamic registration succeeds.
 		await sendResponse(client, message.id, null, message.method);
 		return;
@@ -685,6 +741,7 @@ export async function getOrCreateClient(
 			requestId: 0,
 			diagnostics: new Map(),
 			diagnosticsVersion: 0,
+			dynamicCapabilityRegistrations: new Map(),
 			openFiles: new Map(),
 			pendingRequests: new Map(),
 			messageBuffer: new Uint8Array(0),

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -560,13 +560,18 @@ async function waitForDiagnostics(
 ): Promise<Diagnostic[]> {
 	const { timeoutMs = 3000, signal, minVersion, expectedDocumentVersion, settleMs = DIAGNOSTICS_SETTLE_MS } = options;
 	const deadline = Date.now() + timeoutMs;
-	let pullPromise: Promise<Diagnostic[] | undefined> | undefined;
+	let pullAttempted = false;
+	let pullResultPromise: Promise<{ diagnostics: Diagnostic[] | undefined }> | undefined;
+	let pulled: Diagnostic[] | undefined;
 	let settledRef: PublishedDiagnostics | undefined;
 	let settledAt = 0;
 	while (Date.now() < deadline) {
 		throwIfAborted(signal);
-		if (!pullPromise && supportsDocumentDiagnostics(client)) {
-			pullPromise = requestDocumentDiagnostics(client, uri, signal, Math.max(1, deadline - Date.now()));
+		if (!pullAttempted && supportsDocumentDiagnostics(client)) {
+			pullAttempted = true;
+			pullResultPromise = requestDocumentDiagnostics(client, uri, signal, Math.max(1, deadline - Date.now())).then(
+				diagnostics => ({ diagnostics }),
+			);
 		}
 
 		const versionOk = minVersion === undefined || client.diagnosticsVersion > minVersion;
@@ -585,7 +590,18 @@ async function waitForDiagnostics(
 				return published.diagnostics;
 			}
 		}
-		await Bun.sleep(Math.min(DIAGNOSTICS_POLL_MS, Math.max(0, deadline - Date.now())));
+
+		const pollMs = Math.min(DIAGNOSTICS_POLL_MS, Math.max(0, deadline - Date.now()));
+		if (!pullResultPromise) {
+			await Bun.sleep(pollMs);
+			continue;
+		}
+		const pullResult = await Promise.race([pullResultPromise, Bun.sleep(pollMs).then(() => undefined)]);
+		if (pullResult) {
+			pullResultPromise = undefined;
+			pulled = pullResult.diagnostics;
+			if (pulled !== undefined) break;
+		}
 	}
 
 	const versionOk = minVersion === undefined || client.diagnosticsVersion > minVersion;
@@ -593,9 +609,9 @@ async function waitForDiagnostics(
 	if (published && versionOk) {
 		return published.diagnostics;
 	}
-	if (!pullPromise) return [];
-
-	const pulled = await pullPromise;
+	if (pullResultPromise) {
+		pulled = (await pullResultPromise).diagnostics;
+	}
 	throwIfAborted(signal);
 	if (pulled === undefined) return [];
 	client.diagnostics.set(uri, {

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -28,6 +28,7 @@ import {
 	sendNotification,
 	sendRequest,
 	setIdleTimeout,
+	supportsDocumentDiagnostics,
 	syncContent,
 	WARMUP_TIMEOUT_MS,
 	waitForProjectLoaded,
@@ -530,17 +531,44 @@ interface WaitForDiagnosticsOptions {
 	settleMs?: number;
 }
 
+function requestDocumentDiagnostics(
+	client: LspClient,
+	uri: string,
+	signal: AbortSignal | undefined,
+	timeoutMs: number,
+): Promise<Diagnostic[] | undefined> {
+	return sendRequest(client, "textDocument/diagnostic", { textDocument: { uri } }, signal, timeoutMs)
+		.then(report => {
+			if (!report || typeof report !== "object" || !("kind" in report) || report.kind !== "full") {
+				return undefined;
+			}
+			if (!("items" in report) || !Array.isArray(report.items)) return undefined;
+			return report.items;
+		})
+		.catch(err => {
+			if (!signal?.aborted) {
+				logger.debug("LSP document diagnostic pull failed", { server: client.name, uri, error: String(err) });
+			}
+			return undefined;
+		});
+}
+
 async function waitForDiagnostics(
 	client: LspClient,
 	uri: string,
 	options: WaitForDiagnosticsOptions = {},
 ): Promise<Diagnostic[]> {
 	const { timeoutMs = 3000, signal, minVersion, expectedDocumentVersion, settleMs = DIAGNOSTICS_SETTLE_MS } = options;
-	const start = Date.now();
+	const deadline = Date.now() + timeoutMs;
+	let pullPromise: Promise<Diagnostic[] | undefined> | undefined;
 	let settledRef: PublishedDiagnostics | undefined;
 	let settledAt = 0;
-	while (Date.now() - start < timeoutMs) {
+	while (Date.now() < deadline) {
 		throwIfAborted(signal);
+		if (!pullPromise && supportsDocumentDiagnostics(client)) {
+			pullPromise = requestDocumentDiagnostics(client, uri, signal, Math.max(1, deadline - Date.now()));
+		}
+
 		const versionOk = minVersion === undefined || client.diagnosticsVersion > minVersion;
 		const published = client.diagnostics.get(uri);
 		if (published && versionOk) {
@@ -557,13 +585,25 @@ async function waitForDiagnostics(
 				return published.diagnostics;
 			}
 		}
-		await Bun.sleep(DIAGNOSTICS_POLL_MS);
+		await Bun.sleep(Math.min(DIAGNOSTICS_POLL_MS, Math.max(0, deadline - Date.now())));
 	}
+
 	const versionOk = minVersion === undefined || client.diagnosticsVersion > minVersion;
-	if (!versionOk) {
-		return [];
+	const published = client.diagnostics.get(uri);
+	if (published && versionOk) {
+		return published.diagnostics;
 	}
-	return client.diagnostics.get(uri)?.diagnostics ?? [];
+	if (!pullPromise) return [];
+
+	const pulled = await pullPromise;
+	throwIfAborted(signal);
+	if (pulled === undefined) return [];
+	client.diagnostics.set(uri, {
+		diagnostics: pulled,
+		version: expectedDocumentVersion ?? client.openFiles.get(uri)?.version ?? null,
+	});
+	client.diagnosticsVersion += 1;
+	return pulled;
 }
 
 /** Project type detection result */

--- a/packages/coding-agent/src/lsp/types.ts
+++ b/packages/coding-agent/src/lsp/types.ts
@@ -387,6 +387,7 @@ export interface LspServerCapabilities {
 	referencesProvider?: boolean;
 	documentSymbolProvider?: boolean;
 	workspaceSymbolProvider?: boolean;
+	diagnosticProvider?: boolean | Record<string, unknown>;
 	[key: string]: unknown;
 }
 
@@ -398,6 +399,8 @@ export interface LspClient {
 	requestId: number;
 	diagnostics: Map<string, PublishedDiagnostics>;
 	diagnosticsVersion: number;
+	/** Dynamic capability registrations keyed by the server-provided registration ID. */
+	dynamicCapabilityRegistrations?: Map<string, string>;
 	openFiles: Map<string, OpenFile>;
 	pendingRequests: Map<number | string, PendingRequest>;
 	messageBuffer: Uint8Array;

--- a/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
+++ b/packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts
@@ -294,6 +294,55 @@ describe("LSP diagnostics freshness", () => {
 		expect(result?.messages.some(m => m.includes("stale error"))).toBe(false);
 	});
 
+	it("returns completed pull diagnostics inside the inline write window", async () => {
+		const filePath = path.join(tempDir.path(), "pull-only.ts");
+		const uri = fileToUri(filePath);
+		const client = createClient(tempDir.path(), TEST_SERVER);
+		client.openFiles.set(uri, { version: 1, languageId: "typescript" });
+		client.serverCapabilities = { diagnosticProvider: true };
+
+		vi.spyOn(lspConfig, "loadConfig").mockReturnValue({ servers: {}, idleTimeoutMs: undefined });
+		vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["test-lsp", TEST_SERVER]]);
+		vi.spyOn(lspClient, "getOrCreateClient").mockResolvedValue(client);
+		vi.spyOn(lspClient, "syncContent").mockImplementation(async (mockClient, syncedFilePath) => {
+			const syncedUri = fileToUri(syncedFilePath);
+			mockClient.diagnostics.delete(syncedUri);
+			const openFile = mockClient.openFiles.get(syncedUri);
+			if (openFile) {
+				openFile.version += 1;
+			} else {
+				mockClient.openFiles.set(syncedUri, { version: 1, languageId: "typescript" });
+			}
+		});
+		vi.spyOn(lspClient, "notifySaved").mockResolvedValue();
+		vi.spyOn(lspClient, "sendRequest").mockResolvedValue({
+			kind: "full",
+			items: [createDiagnostic("pull error")],
+		});
+		const onDeferredDiagnostics = vi.fn();
+		const deferredController = new AbortController();
+		const handle = {
+			onDeferredDiagnostics,
+			signal: deferredController.signal,
+			finalize: () => {},
+		};
+
+		const writethrough = createLspWritethrough(tempDir.path(), { enableFormat: false, enableDiagnostics: true });
+		const inline = await writethrough(
+			filePath,
+			"export const value: number = 'x';\n",
+			undefined,
+			undefined,
+			undefined,
+			() => handle,
+		);
+		deferredController.abort();
+
+		expect(inline?.errored).toBe(true);
+		expect(inline?.messages.some(message => message.includes("pull error"))).toBe(true);
+		expect(onDeferredDiagnostics).not.toHaveBeenCalled();
+	});
+
 	it("returns promptly and delivers diagnostics via the deferred channel when the server is slow", async () => {
 		const filePath = path.join(tempDir.path(), "example.ts");
 		const uri = fileToUri(filePath);

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -1184,6 +1184,103 @@ describe("lsp regressions", () => {
 		expect(resultText.replace(/\s+/g, " ")).toContain("too many arguments in call");
 	});
 
+	for (const dynamicRegistration of [false, true]) {
+		it(`reports pull diagnostics advertised through ${dynamicRegistration ? "dynamic registration" : "server capabilities"}`, async () => {
+			const tempDir = TempDir.createSync("@omp-lsp-pull-diags-");
+			try {
+				const targetFile = path.join(tempDir.path(), "target.ts");
+				await Bun.write(targetFile, "const broken: string = 42;\n");
+				const diagnostic: Diagnostic = {
+					message: "Type 'number' is not assignable to type 'string'.",
+					severity: 1,
+					code: 2322,
+					source: "ts",
+					range: {
+						start: { line: 0, character: 6 },
+						end: { line: 0, character: 12 },
+					},
+				};
+
+				const fakeServer = installFakeLsp((message, server) => {
+					if (message.method === "initialize") {
+						server.send({
+							jsonrpc: "2.0",
+							id: message.id,
+							result: { capabilities: dynamicRegistration ? {} : { diagnosticProvider: true } },
+						});
+						server.send({
+							jsonrpc: "2.0",
+							method: "$/progress",
+							params: { token: "workspace", value: { kind: "begin" } },
+						});
+						server.send({
+							jsonrpc: "2.0",
+							method: "$/progress",
+							params: { token: "workspace", value: { kind: "end" } },
+						});
+					} else if (dynamicRegistration && message.method === "initialized") {
+						server.send({
+							jsonrpc: "2.0",
+							id: "register-diagnostics",
+							method: "client/registerCapability",
+							params: {
+								registrations: [
+									{
+										id: "pull-diagnostics",
+										method: "textDocument/diagnostic",
+										registerOptions: {},
+									},
+								],
+							},
+						});
+					} else if (message.method === "textDocument/diagnostic") {
+						server.send({
+							jsonrpc: "2.0",
+							id: message.id,
+							result: { kind: "full", items: [diagnostic] },
+						});
+					} else if (message.method === "shutdown") {
+						server.send({ jsonrpc: "2.0", id: message.id, result: null });
+					} else if (message.method === "exit") {
+						server.exit(0);
+					}
+				});
+
+				const serverConfig: ServerConfig = {
+					command: "fake-lsp",
+					fileTypes: ["ts"],
+					rootMarkers: [],
+				};
+				vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+					servers: { "fake-lsp": serverConfig },
+					idleTimeoutMs: undefined,
+				});
+				vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["fake-lsp", serverConfig]]);
+
+				const tool = new LspTool({ cwd: tempDir.path() } as ToolSession);
+				const result = await tool.execute(`pull-diagnostics-${dynamicRegistration}`, {
+					action: "diagnostics",
+					file: targetFile,
+					timeout: 20,
+				});
+				const initialize = fakeServer.received.find(message => message.method === "initialize");
+
+				expect(initialize).toMatchObject({
+					params: {
+						capabilities: {
+							textDocument: { diagnostic: { dynamicRegistration: true } },
+						},
+					},
+				});
+				expect(fakeServer.received.map(message => message.method)).toContain("textDocument/diagnostic");
+				expect(textResult(result)).toContain("Type 'number' is not assignable to type 'string'.");
+			} finally {
+				await lspClient.shutdownAll();
+				tempDir.removeSync();
+			}
+		}, 15_000);
+	}
+
 	it("does not reuse stale file diagnostics after another URI publishes", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-stale-diags-");
 		try {


### PR DESCRIPTION
## Repro
A fake pull-only LSP server advertising either static `diagnosticProvider` support or a Roslyn-shaped dynamic `textDocument/diagnostic` registration returned a full report containing TS2322, but `lsp diagnostics` returned `OK`. Reproduced with `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts -t "reports pull diagnostics"`.

## Cause
`packages/coding-agent/src/lsp/client.ts` advertised and recorded only push diagnostics from `textDocument/publishDiagnostics`; `handleServerRequest` acknowledged dynamic capability registrations without retaining them. Consequently, `waitForDiagnostics` in `packages/coding-agent/src/lsp/index.ts` had no way to detect pull support or issue `textDocument/diagnostic`.

## Fix
- Advertise the LSP 3.17 document diagnostic client capability and track static plus dynamically registered pull support.
- Start a bounded document diagnostic pull during the existing diagnostics wait window, retain push precedence, and feed full pull reports into the existing diagnostics ledger.
- Cover static and dynamic pull-only servers while retaining the existing push-diagnostics regression coverage.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/tools/lsp-regressions.test.ts packages/coding-agent/test/tools/lsp-diagnostics-freshness.test.ts` passed: 70 tests, 256 assertions. `bun run check:types` in `packages/coding-agent` passed. The pre-publish `bun run fix` and `bun check` gate passed before push and PR creation.

Fixes #5825