### PR TITLE
fix(context): floor displayed context usage by stored estimate when provider usage under-reports

### DIFF
--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -229,13 +229,28 @@ export function calculatePromptTokens(usage: Usage): number {
 }
 
 /**
+ * True when provider usage can anchor context display/compaction.
+ * All-zero usage is treated as missing: some providers under-report or emit
+ * placeholder zeros, which must not collapse the context footer/status.
+ */
+export function isUsableAssistantUsage(usage: Usage): boolean {
+	return !(calculatePromptTokens(usage) === 0 && calculateContextTokens(usage) === 0);
+}
+
+/**
  * Get usage from an assistant message if available.
  * Skips aborted and error messages as they don't have valid usage data.
+ * Also skips all-zero usage so it cannot become a context anchor.
  */
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {
 	if (msg.role === "assistant" && "usage" in msg) {
 		const assistantMsg = msg as AssistantMessage;
-		if (assistantMsg.stopReason !== "aborted" && assistantMsg.stopReason !== "error" && assistantMsg.usage) {
+		if (
+			assistantMsg.stopReason !== "aborted" &&
+			assistantMsg.stopReason !== "error" &&
+			assistantMsg.usage &&
+			isUsableAssistantUsage(assistantMsg.usage)
+		) {
 			return assistantMsg.usage;
 		}
 	}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -63,6 +63,7 @@ import {
 	estimateTokens,
 	generateBranchSummary,
 	generateHandoffFromContext,
+	isUsableAssistantUsage,
 	prepareCompaction,
 	renderHandoffPrompt,
 	resolveBudgetReserveTokens,
@@ -17007,7 +17008,12 @@ export class AgentSession {
 			const entry = branchEntries[i];
 			if (entry.type === "message" && entry.message.role === "assistant") {
 				const assistant = entry.message;
-				if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error" && assistant.usage) {
+				if (
+					assistant.stopReason !== "aborted" &&
+					assistant.stopReason !== "error" &&
+					assistant.usage &&
+					isUsableAssistantUsage(assistant.usage)
+				) {
 					anchorEntry = entry;
 					break;
 				}
@@ -17073,7 +17079,13 @@ export class AgentSession {
 			// Fallback: look for the latest assistant message with usage/snapshot in this.messages (for branchless/fake sessions in tests)
 			for (let i = resolvedActiveMessages.length - 1; i >= 0; i--) {
 				const msg = resolvedActiveMessages[i];
-				if (msg.role === "assistant" && msg.stopReason !== "aborted" && msg.stopReason !== "error" && msg.usage) {
+				if (
+					msg.role === "assistant" &&
+					msg.stopReason !== "aborted" &&
+					msg.stopReason !== "error" &&
+					msg.usage &&
+					isUsableAssistantUsage(msg.usage)
+				) {
 					const promptTokens = msg.contextSnapshot?.promptTokens ?? calculatePromptTokens(msg.usage);
 					const nonMessageTokens = msg.contextSnapshot?.nonMessageTokens ?? computeNonMessageTokens(this);
 
@@ -17102,6 +17114,12 @@ export class AgentSession {
 				messagesTokens +
 				pendingMessages.reduce((sum, msg) => sum + estimateTokens(msg), 0);
 		}
+
+		// Floor display/residual the same way compaction does: provider usage can
+		// under-report (or be all zeros), while the local stored estimate remains a
+		// reliable lower bound for footer/status and /context.
+		const storedEstimate = this.#estimateStoredContextTokens(pendingMessages);
+		usedTokens = compactionContextTokens(usedTokens, storedEstimate);
 
 		const messagesTokens = Math.max(0, usedTokens - categoryNonMessageTokens);
 

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -10,6 +10,7 @@ import {
 	estimateTokens,
 	findCutPoint,
 	getLastAssistantUsage,
+	isUsableAssistantUsage,
 	prepareCompaction,
 	resolveThresholdTokens,
 	shouldCompact,
@@ -224,6 +225,42 @@ describe("getLastAssistantUsage", () => {
 	it("should return undefined if no assistant messages", () => {
 		const entries: SessionEntry[] = [createMessageEntry(createUserMessage("Hello"))];
 		expect(getLastAssistantUsage(entries)).toBeUndefined();
+	});
+
+	it("should skip a terminal all-zero usage and return earlier usable usage", () => {
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("Hello")),
+			createMessageEntry(createAssistantMessage("Hi", createMockUsage(100, 50))),
+			createMessageEntry(createUserMessage("Again")),
+			createMessageEntry(createAssistantMessage("Zero", createMockUsage(0, 0))),
+		];
+
+		const usage = getLastAssistantUsage(entries);
+		expect(usage).not.toBeUndefined();
+		expect(usage!.input).toBe(100);
+	});
+
+	it("should return undefined when only all-zero assistant usage exists", () => {
+		const entries: SessionEntry[] = [
+			createMessageEntry(createUserMessage("Hello")),
+			createMessageEntry(createAssistantMessage("Zero", createMockUsage(0, 0))),
+		];
+		expect(getLastAssistantUsage(entries)).toBeUndefined();
+	});
+});
+
+describe("isUsableAssistantUsage", () => {
+	it("accepts usage when prompt tokens are non-zero even if total context is otherwise sparse", () => {
+		expect(isUsableAssistantUsage(createMockUsage(10, 0))).toBe(true);
+	});
+
+	it("accepts usage when context total is non-zero even if prompt components are zero", () => {
+		const usage = createMockUsage(0, 25);
+		expect(isUsableAssistantUsage(usage)).toBe(true);
+	});
+
+	it("rejects all-zero usage", () => {
+		expect(isUsableAssistantUsage(createMockUsage(0, 0))).toBe(false);
 	});
 });
 

--- a/packages/coding-agent/test/context-consolidation.test.ts
+++ b/packages/coding-agent/test/context-consolidation.test.ts
@@ -548,4 +548,197 @@ describe("Context usage consolidation", () => {
 
 		await tempDir.remove();
 	});
+
+	it("skips all-zero terminal usage as an anchor and floors tokens by stored estimate", async () => {
+		const tempDir = TempDir.createSync("@zero-usage-floor-");
+		const bulky = "context under-report filler ".repeat(400);
+		const { session, sessionManager, agent } = createSession(tempDir);
+
+		sessionManager.appendMessage({ role: "user", content: bulky, timestamp: 1000 } as Message);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "zero usage reply" }],
+			api: mockModel.api,
+			provider: mockModel.provider,
+			model: mockModel.id,
+			stopReason: "stop",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			contextSnapshot: { promptTokens: 0, nonMessageTokens: 10 },
+			timestamp: 2000,
+		} as AssistantMessage);
+
+		syncSession(session, agent);
+
+		const messageEstimate =
+			estimateTokens({ role: "user", content: bulky, timestamp: 1000 } as Message, {
+				excludeEncryptedReasoning: true,
+			}) +
+			estimateTokens(
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "zero usage reply" }],
+					api: mockModel.api,
+					provider: mockModel.provider,
+					model: mockModel.id,
+					stopReason: "stop",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					timestamp: 2000,
+				} as AssistantMessage,
+				{ excludeEncryptedReasoning: true },
+			);
+
+		const breakdown = session.getContextBreakdown();
+		const cu = session.getContextUsage();
+		// All-zero usage must not be treated as a provider-truth anchor.
+		expect(breakdown?.anchored).toBe(false);
+		expect(cu?.tokens).toBeGreaterThan(0);
+		// usedTokens includes non-message tokens as well, so it is at least the message estimate.
+		expect(cu?.tokens).toBeGreaterThanOrEqual(messageEstimate);
+
+		await tempDir.remove();
+	});
+
+	it("floors a deliberately tiny provider anchor by the stored conversation estimate", async () => {
+		const tempDir = TempDir.createSync("@tiny-provider-floor-");
+		const bulky = "stored conversation estimate filler ".repeat(800);
+		const { session, sessionManager, agent } = createSession(tempDir);
+
+		sessionManager.appendMessage({ role: "user", content: bulky, timestamp: 1000 } as Message);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "under-reported" }],
+			api: mockModel.api,
+			provider: mockModel.provider,
+			model: mockModel.id,
+			stopReason: "stop",
+			usage: {
+				input: 985,
+				output: 20,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 1005,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			contextSnapshot: { promptTokens: 985, nonMessageTokens: 10 },
+			timestamp: 2000,
+		} as AssistantMessage);
+
+		syncSession(session, agent);
+
+		const messageEstimate =
+			estimateTokens({ role: "user", content: bulky, timestamp: 1000 } as Message, {
+				excludeEncryptedReasoning: true,
+			}) +
+			estimateTokens(
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "under-reported" }],
+					api: mockModel.api,
+					provider: mockModel.provider,
+					model: mockModel.id,
+					stopReason: "stop",
+					usage: {
+						input: 985,
+						output: 20,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 1005,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					timestamp: 2000,
+				} as AssistantMessage,
+				{ excludeEncryptedReasoning: true },
+			);
+
+		const breakdown = session.getContextBreakdown();
+		expect(breakdown?.anchored).toBe(true);
+		expect(breakdown!.usedTokens).toBeGreaterThan(985);
+		expect(breakdown!.usedTokens).toBeGreaterThanOrEqual(messageEstimate);
+		expect(session.getContextUsage()?.tokens).toBe(breakdown!.usedTokens);
+
+		// /context + status-line still observe the same floored value
+		const cb = computeContextBreakdown(session);
+		expect(cb.usedTokens).toBe(breakdown!.usedTokens);
+		const sl = new StatusLineComponent(session);
+		expect(sl.getCachedContextBreakdown().usedTokens).toBe(breakdown!.usedTokens);
+
+		await tempDir.remove();
+	});
+
+	it("keeps a large provider anchor unchanged when it exceeds the stored estimate", async () => {
+		const tempDir = TempDir.createSync("@large-provider-truth-");
+		const { session, sessionManager, agent } = createSession(tempDir);
+
+		sessionManager.appendMessage({ role: "user", content: "short", timestamp: 1000 } as Message);
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "provider truth" }],
+			api: mockModel.api,
+			provider: mockModel.provider,
+			model: mockModel.id,
+			stopReason: "stop",
+			usage: {
+				input: 90000,
+				output: 20,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 90020,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			contextSnapshot: { promptTokens: 90000, nonMessageTokens: 10 },
+			timestamp: 2000,
+		} as AssistantMessage);
+
+		syncSession(session, agent);
+
+		const breakdown = session.getContextBreakdown();
+		expect(breakdown?.anchored).toBe(true);
+		// Provider prompt dominates; floor must not lower provider truth.
+		// Exact value is promptTokens + max(0, currentNonMessage - snapshotNonMessage).
+		expect(breakdown!.usedTokens).toBeGreaterThanOrEqual(90000);
+		const messageOnlyEstimate =
+			estimateTokens({ role: "user", content: "short", timestamp: 1000 } as Message, {
+				excludeEncryptedReasoning: true,
+			}) +
+			estimateTokens(
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "provider truth" }],
+					api: mockModel.api,
+					provider: mockModel.provider,
+					model: mockModel.id,
+					stopReason: "stop",
+					usage: {
+						input: 90000,
+						output: 20,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 90020,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					timestamp: 2000,
+				} as AssistantMessage,
+				{ excludeEncryptedReasoning: true },
+			);
+		expect(messageOnlyEstimate).toBeLessThan(90000);
+		expect(breakdown!.usedTokens).toBeGreaterThan(messageOnlyEstimate);
+		// Should remain provider-anchored magnitude, not collapse to tiny local text estimate.
+		expect(breakdown!.usedTokens).toBeLessThan(90000 + 5000);
+
+		await tempDir.remove();
+	});
 });


### PR DESCRIPTION
## Summary
Primary-session footer/status and `/context` can under-report occupied context when a provider returns tiny or all-zero usage while the locally stored conversation estimate is much larger.

Local evidence from OMP 17.0.2 sessions:
- `assistantUsageContextTokens=985` vs `storedContextTokens=70788` (resolved to stored for compaction, but display stayed provider-anchored)
- all-zero assistant usage with stored context around `49242`

Merged #5463 / #5282 covers advisor maintenance. This patch covers the **primary session** display path.

## Changes
- Add `isUsableAssistantUsage()` and treat all-zero provider usage as missing in `getAssistantUsage()` / `getLastAssistantUsage()`.
- In `AgentSession.getContextBreakdown()`, skip all-zero anchors in both branch and branchless scans.
- Floor final `usedTokens` with existing `compactionContextTokens(usedTokens, storedEstimate)` before deriving message/category breakdown.

## Test plan
- [x] `bun test packages/coding-agent/test/compaction.test.ts packages/coding-agent/test/context-consolidation.test.ts` → 64 pass / 0 fail
  - terminal all-zero usage falls back to earlier usable usage
  - only all-zero usage returns no anchor
  - tiny provider usage is floored by stored estimate
  - large provider usage remains unchanged
  - `/context`, status-line, and `getContextUsage()` still agree on the floored value
- [x] `bun run check` in `packages/coding-agent` (biome + `tsgo --noEmit`)
- [x] `bun run check:types` in `packages/agent`