### PR TITLE
fix(cursor): surface actionable error when h2 ALPN negotiation fails

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Replaced the opaque `h2 is not supported` failure on the Cursor run transport with an actionable error naming the ALPN-stripping proxy as the cause and pointing at the `providers.cursor.baseUrl` HTTP/2 bridge workaround. The run RPC is HTTP/2-only, so behind a TLS-intercepting proxy that strips ALPN (e.g. Zscaler) bun cannot negotiate `h2` and the completion cannot proceed ([#5828](https://github.com/can1357/oh-my-pi/issues/5828)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -213,6 +213,34 @@ function parseConnectEndStream(data: Uint8Array): Error | null {
 	}
 }
 
+/**
+ * Maps an opaque HTTP/2 negotiation failure into an actionable error.
+ *
+ * bun only opens an HTTP/2 session when TLS-ALPN negotiates `h2`. Behind a
+ * TLS-intercepting proxy that strips ALPN (e.g. Zscaler), the handshake yields
+ * no `h2` protocol and bun throws `ERR_HTTP2_ERROR: h2 is not supported`. The
+ * Cursor run RPC is HTTP/2-only (the ALB rejects HTTP/1.1 with 464), so there
+ * is no h1 fallback the way model discovery has one — the run simply cannot
+ * proceed. Replace the opaque message with one that names the cause and points
+ * at the `providers.cursor.baseUrl` workaround.
+ *
+ * Non-ALPN errors pass through untouched.
+ */
+export function mapH2TransportError(error: unknown, baseUrl: string): unknown {
+	const code = (error as { code?: unknown } | null)?.code;
+	const message = error instanceof Error ? error.message : String(error);
+	if (code === "ERR_HTTP2_ERROR" && /h2 is not supported/i.test(message)) {
+		return new AIError.ProviderResponseError(
+			`Cursor run transport could not negotiate HTTP/2 with ${baseUrl}: "h2 is not supported". ` +
+				"This host serves the run RPC over HTTP/2 only, and the TLS handshake did not negotiate " +
+				"h2 via ALPN — typically an ALPN-stripping TLS-intercepting proxy (e.g. Zscaler). " +
+				"Front the provider with a local HTTP/2 bridge and set providers.cursor.baseUrl to it.",
+			{ provider: "cursor", kind: "runtime", cause: error },
+		);
+	}
+	return error;
+}
+
 function debugBytes(bytes: Uint8Array, asHex: boolean): string {
 	if (asHex) {
 		return Buffer.from(bytes).toString("hex");
@@ -431,7 +459,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			} else {
 				h2Client = http2.connect(baseUrl);
 			}
-			h2Client.on("error", error => settleH2(error));
+			h2Client.on("error", error => settleH2(mapH2TransportError(error, baseUrl)));
 
 			h2Request = h2Client.request(requestHeaders);
 
@@ -573,7 +601,8 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 			});
 
 			h2Request.on("error", error => {
-				void closeDebugLog().finally(() => settleH2(error));
+				const mapped = mapH2TransportError(error, baseUrl);
+				void closeDebugLog().finally(() => settleH2(mapped));
 			});
 
 			if (options?.signal) {

--- a/packages/ai/test/cursor-h2-transport-error.test.ts
+++ b/packages/ai/test/cursor-h2-transport-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { ProviderResponseError } from "@oh-my-pi/pi-ai/error";
+import { mapH2TransportError } from "@oh-my-pi/pi-ai/providers/cursor";
+
+const BASE_URL = "https://api2.cursor.sh";
+
+describe("mapH2TransportError", () => {
+	it("rewrites the opaque bun ALPN failure into an actionable Cursor error", () => {
+		const raw = Object.assign(new Error("h2 is not supported"), { code: "ERR_HTTP2_ERROR" });
+		const mapped = mapH2TransportError(raw, BASE_URL);
+		expect(mapped).toBeInstanceOf(ProviderResponseError);
+		const err = mapped as ProviderResponseError;
+		expect(err.provider).toBe("cursor");
+		expect(err.kind).toBe("runtime");
+		expect(err.message).toContain(BASE_URL);
+		expect(err.message).toContain("ALPN");
+		expect(err.message).toContain("providers.cursor.baseUrl");
+		expect(err.cause).toBe(raw);
+	});
+
+	it("matches the h2-not-supported message case-insensitively", () => {
+		const raw = Object.assign(new Error("H2 Is Not Supported"), { code: "ERR_HTTP2_ERROR" });
+		expect(mapH2TransportError(raw, BASE_URL)).toBeInstanceOf(ProviderResponseError);
+	});
+
+	it("passes through an HTTP/2 error whose message is unrelated to ALPN", () => {
+		const raw = Object.assign(new Error("Stream closed with error code NGHTTP2_INTERNAL_ERROR"), {
+			code: "ERR_HTTP2_ERROR",
+		});
+		expect(mapH2TransportError(raw, BASE_URL)).toBe(raw);
+	});
+
+	it("passes through a non-HTTP/2 error even when it mentions h2", () => {
+		const raw = Object.assign(new Error("h2 is not supported"), { code: "ECONNRESET" });
+		expect(mapH2TransportError(raw, BASE_URL)).toBe(raw);
+	});
+});


### PR DESCRIPTION
## Repro
Behind a TLS-intercepting proxy that strips ALPN (e.g. Zscaler), the `cursor` provider lists models but every run fails instantly with the opaque `h2 is not supported`. Reproduced locally with a TLS server offering only `http/1.1` in ALPN: bun's `http2.connect` emits `ERR_HTTP2_ERROR: h2 is not supported` on the client `error` event, which is exactly the string that reaches the run stream (`bun -e` posting `POST /agent.v1.AgentService/Run` to such a server).

## Cause
`streamCursor` in `packages/ai/src/providers/cursor.ts` forwarded the raw HTTP/2 session error to `settleH2` unchanged, so bun's opaque `h2 is not supported` surfaced verbatim. The run RPC is HTTP/2-only — `api2.cursor.sh` rejects HTTP/1.1 with 464 and there is no documented h1 run endpoint — while model discovery (`fetchViaHttp2` in `packages/catalog/src/discovery/cursor.ts`) swallows the same failure and falls back to bundled `models.json`, which is why `omp models cursor` works but runs do not.

## Fix
- Add `mapH2TransportError(error, baseUrl)` in `packages/ai/src/providers/cursor.ts`: when the error is `code === "ERR_HTTP2_ERROR"` with an `h2 is not supported` message, return a `ProviderResponseError` (`provider: "cursor"`, `kind: "runtime"`) that names the ALPN-stripping proxy as the cause and points at the `providers.cursor.baseUrl` HTTP/2 bridge workaround; all other errors pass through untouched.
- Wire the mapper into both the session `h2Client.on("error", …)` and request `h2Request.on("error", …)` handlers.
- Add `packages/ai/test/cursor-h2-transport-error.test.ts` covering the rewrite, case-insensitive matching, and both pass-through paths (unrelated h2 error, non-h2 error mentioning h2).
- Changelog entry under `packages/ai` `[Unreleased]`.

## Verification
`bun test packages/ai/test/cursor-h2-transport-error.test.ts packages/ai/test/cursor-terminal-error.test.ts` → 9 pass, 0 fail. `bun check` → clean. Fixes #5828