### PR TITLE
fix(coding-agent): show loop state in status line

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the status line loop indicator to distinguish waiting, running, and paused states and show the remaining loop budget ([#5832](https://github.com/can1357/oh-my-pi/pull/5832) by [@wolfiesch](https://github.com/wolfiesch)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed
@@ -45,7 +49,6 @@
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers
-- Fixed the status line loop indicator to distinguish waiting, running, and paused states and show the remaining loop budget.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### Removed
 
 - Removed the unreliable Bing and Yahoo HTML-scraping web search providers
+- Fixed the status line loop indicator to distinguish waiting, running, and paused states and show the remaining loop budget.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -273,7 +273,7 @@ export class StatusLineComponent implements Component {
 	 */
 	#activeMeters: WeakMap<AgentSession, ActiveMeter> = new WeakMap();
 	#planModeStatus: { enabled: boolean; paused: boolean } | null = null;
-	#loopModeStatus: { enabled: boolean } | null = null;
+	#loopModeStatus: SegmentContext["loopMode"] = null;
 	#goalModeStatus: { enabled: boolean; paused: boolean } | null = null;
 	#vibeModeStatus: { enabled: boolean } | null = null;
 	#collabStatus: CollabStatus | null = null;
@@ -496,7 +496,7 @@ export class StatusLineComponent implements Component {
 		this.#planModeStatus = status ?? null;
 	}
 
-	setLoopModeStatus(status: { enabled: boolean } | undefined): void {
+	setLoopModeStatus(status: NonNullable<SegmentContext["loopMode"]> | undefined): void {
 		this.#loopModeStatus = status ?? null;
 	}
 

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -210,6 +210,19 @@ function renderGoalMode(ctx: SegmentContext, mode: { enabled: boolean; paused: b
 	return { content: theme.fg(color, parts.join(" ")), visible: true };
 }
 
+function formatLoopLimit(limit: NonNullable<SegmentContext["loopMode"]>["limit"]): string | undefined {
+	if (!limit) return undefined;
+	if (limit.kind === "iterations") return `${limit.remaining}/${limit.initial}`;
+
+	const totalSeconds = Math.max(0, Math.ceil((limit.deadlineMs - Date.now()) / 1_000));
+	const hours = Math.floor(totalSeconds / 3_600);
+	const minutes = Math.floor((totalSeconds % 3_600) / 60);
+	const seconds = totalSeconds % 60;
+	if (hours > 0) return `${hours}h${minutes > 0 ? `${minutes}m` : ""} left`;
+	if (minutes > 0) return `${minutes}m${seconds > 0 ? `${seconds}s` : ""} left`;
+	return `${seconds}s left`;
+}
+
 const modeSegment: StatusLineSegment = {
 	id: "mode",
 	render(ctx) {
@@ -241,9 +254,13 @@ const modeSegment: StatusLineSegment = {
 		}
 
 		const loop = ctx.loopMode;
-		if (loop?.enabled) {
-			const content = withIcon(theme.icon.loop, "Loop");
-			return { content: theme.fg("customMessageLabel", content), visible: true };
+		if (loop) {
+			const icon = loop.state === "paused" ? theme.icon.pause || theme.icon.loop : theme.icon.loop;
+			const color: ThemeColor = loop.state === "paused" ? "warning" : "customMessageLabel";
+			const parts = [withIcon(icon, `Loop ${loop.state}`)];
+			const limit = formatLoopLimit(loop.limit);
+			if (limit) parts.push(limit);
+			return { content: theme.fg(color, parts.join(" ")), visible: true };
 		}
 
 		return { content: "", visible: false };

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -2,6 +2,7 @@ import type { CollabSessionState } from "../../../collab/protocol";
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../../config/settings-schema";
 import type { AgentSession } from "../../../session/agent-session";
 import type { ActiveRepoContext } from "../../../utils/active-repo-context";
+import type { LoopLimitRuntime } from "../../loop-limit";
 
 export type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle };
 
@@ -64,7 +65,8 @@ export interface SegmentContext {
 		enabled: boolean;
 	} | null;
 	loopMode: {
-		enabled: boolean;
+		state: "waiting" | "running" | "paused";
+		limit?: LoopLimitRuntime;
 	} | null;
 	goalMode: {
 		enabled: boolean;

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -771,7 +771,7 @@ export class InputController {
 			// While loop mode is on, every user-typed prompt becomes the new loop
 			// prompt that auto-resubmits after each yield.
 			if (this.ctx.loopModeEnabled) {
-				this.ctx.loopPrompt = text;
+				this.ctx.setLoopPrompt(text);
 			}
 
 			// Queue input during compaction

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -451,6 +451,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	vibeModeEnabled = false;
 	planModePlanFilePath: string | undefined = undefined;
 	loopModeEnabled = false;
+	loopModePaused = false;
 	loopPrompt: string | undefined = undefined;
 	loopLimit: LoopLimitRuntime | undefined = undefined;
 	#loopAutoSubmitTimer: NodeJS.Timeout | undefined;
@@ -1349,6 +1350,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.disableLoopMode("Loop limit reached. Loop mode disabled.");
 			return;
 		}
+		this.#syncLoopModeStatus();
 
 		if (action === "compact") {
 			await this.handleCompactCommand();
@@ -1358,17 +1360,34 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#submitLoopPromptWhenReady(prompt);
 	}
 
+	#syncLoopModeStatus(): void {
+		const state: "waiting" | "running" | "paused" = this.loopModePaused
+			? "paused"
+			: this.loopPrompt
+				? "running"
+				: "waiting";
+		this.statusLine.setLoopModeStatus(this.loopModeEnabled ? { state, limit: this.loopLimit } : undefined);
+		this.ui.requestRender();
+	}
+
 	disableLoopMode(message = "Loop mode disabled."): void {
 		const wasEnabled = this.loopModeEnabled;
 		this.loopModeEnabled = false;
+		this.loopModePaused = false;
 		this.loopPrompt = undefined;
 		this.loopLimit = undefined;
 		this.#cancelLoopAutoSubmit();
-		this.statusLine.setLoopModeStatus(undefined);
-		this.ui.requestRender();
+		this.#syncLoopModeStatus();
 		if (wasEnabled) {
 			this.showStatus(message);
 		}
+	}
+
+	setLoopPrompt(prompt: string): void {
+		if (!this.loopModeEnabled) return;
+		this.loopPrompt = prompt;
+		this.loopModePaused = false;
+		this.#syncLoopModeStatus();
 	}
 
 	/**
@@ -1378,7 +1397,9 @@ export class InteractiveMode implements InteractiveModeContext {
 	 */
 	pauseLoop(): void {
 		this.loopPrompt = undefined;
+		this.loopModePaused = true;
 		this.#cancelLoopAutoSubmit();
+		this.#syncLoopModeStatus();
 	}
 
 	async handleLoopCommand(args = ""): Promise<string | undefined> {
@@ -1392,10 +1413,10 @@ export class InteractiveMode implements InteractiveModeContext {
 			return undefined;
 		}
 		this.loopModeEnabled = true;
+		this.loopModePaused = false;
 		this.loopPrompt = undefined;
 		this.loopLimit = createLoopLimitRuntime(parsed.limit);
-		this.statusLine.setLoopModeStatus({ enabled: true });
-		this.ui.requestRender();
+		this.#syncLoopModeStatus();
 		const limitSuffix = parsed.limit ? ` Limited to ${describeLoopLimit(parsed.limit)}.` : "";
 		const remainingSuffix = this.loopLimit ? ` ${describeLoopLimitRuntime(this.loopLimit)}.` : "";
 		const tail = parsed.prompt ? "Repeating it after each turn." : "Your next prompt will repeat after each turn.";

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -159,6 +159,7 @@ export interface InteractiveModeContext {
 	goalModeEnabled: boolean;
 	goalModePaused: boolean;
 	loopModeEnabled: boolean;
+	loopModePaused: boolean;
 	loopPrompt?: string;
 	loopLimit?: LoopLimitRuntime;
 	planModePlanFilePath?: string;
@@ -413,6 +414,7 @@ export interface InteractiveModeContext {
 	handleGoalModeCommand(rest?: string): Promise<void>;
 	handleGuidedGoalCommand(rest?: string): Promise<void>;
 	handleLoopCommand(args?: string): Promise<string | undefined>;
+	setLoopPrompt(prompt: string): void;
 	disableLoopMode(): void;
 	pauseLoop(): void;
 	handlePlanApproval(details: PlanApprovalDetails): Promise<void>;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -316,6 +316,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		allowArgs: true,
 		getTuiAutocompleteDescription: runtime => {
 			if (!runtime.ctx.loopModeEnabled) return "Loop: off";
+			if (runtime.ctx.loopModePaused) return "Loop: paused";
 			if (runtime.ctx.loopLimit) return `Loop: on (${describeLoopLimitRuntime(runtime.ctx.loopLimit)})`;
 			if (runtime.ctx.loopPrompt) return "Loop: on (repeating prompt)";
 			return "Loop: on (waiting for next prompt)";

--- a/packages/coding-agent/test/interactive-mode-loop.test.ts
+++ b/packages/coding-agent/test/interactive-mode-loop.test.ts
@@ -137,4 +137,35 @@ describe("InteractiveMode loop auto-submit", () => {
 		expect(resolved).toHaveLength(1);
 		expect(resolved[0].text).toBe("deliver this");
 	});
+
+	it("reports waiting, running, paused, resumed, and disabled loop states", async () => {
+		const setLoopModeStatus = vi.spyOn(mode.statusLine, "setLoopModeStatus");
+
+		await mode.handleLoopCommand("3");
+		expect(setLoopModeStatus).toHaveBeenLastCalledWith({
+			state: "waiting",
+			limit: { kind: "iterations", initial: 3, remaining: 3 },
+		});
+
+		mode.setLoopPrompt("repeat this");
+		expect(setLoopModeStatus).toHaveBeenLastCalledWith({
+			state: "running",
+			limit: { kind: "iterations", initial: 3, remaining: 3 },
+		});
+
+		mode.pauseLoop();
+		expect(setLoopModeStatus).toHaveBeenLastCalledWith({
+			state: "paused",
+			limit: { kind: "iterations", initial: 3, remaining: 3 },
+		});
+
+		mode.setLoopPrompt("resume this");
+		expect(setLoopModeStatus).toHaveBeenLastCalledWith({
+			state: "running",
+			limit: { kind: "iterations", initial: 3, remaining: 3 },
+		});
+
+		mode.disableLoopMode();
+		expect(setLoopModeStatus).toHaveBeenLastCalledWith(undefined);
+	});
 });

--- a/packages/coding-agent/test/status-line-loop.test.ts
+++ b/packages/coding-agent/test/status-line-loop.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import type { SegmentContext } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { renderSegment } from "@oh-my-pi/pi-coding-agent/modes/components/status-line/segments";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function createContext(loopMode: SegmentContext["loopMode"]): SegmentContext {
+	return {
+		session: {} as SegmentContext["session"],
+		width: 120,
+		compactThinkingLevel: false,
+		options: {},
+		planMode: null,
+		loopMode,
+		prewalk: null,
+		goalMode: null,
+		vibeMode: null,
+		collab: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			orchestrationInput: 0,
+			orchestrationOutput: 0,
+			orchestrationCacheRead: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		activeMs: 0,
+		activeRepo: null,
+		worktree: null,
+		git: { branch: null, status: null, pr: null },
+		usage: null,
+	};
+}
+
+function withIcon(icon: string, text: string): string {
+	return icon ? `${icon} ${text}` : text;
+}
+
+describe("status line loop mode segment", () => {
+	it("shows that a bounded loop is waiting for its first prompt", () => {
+		const rendered = renderSegment(
+			"mode",
+			createContext({ state: "waiting", limit: { kind: "iterations", initial: 10, remaining: 10 } }),
+		);
+
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop waiting 10/10"));
+	});
+
+	it("shows the live remaining duration while a loop is running", () => {
+		const now = Date.parse("2026-07-17T12:00:00Z");
+		vi.spyOn(Date, "now").mockReturnValue(now);
+		const rendered = renderSegment(
+			"mode",
+			createContext({
+				state: "running",
+				limit: { kind: "duration", durationMs: 90_000, deadlineMs: now + 90_000 },
+			}),
+		);
+
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(theme.icon.loop, "Loop running 1m30s left"));
+	});
+
+	it("distinguishes a paused loop from an active loop", () => {
+		const rendered = renderSegment("mode", createContext({ state: "paused" }));
+		const icon = theme.icon.pause || theme.icon.loop;
+
+		expect(Bun.stripANSI(rendered.content)).toBe(withIcon(icon, "Loop paused"));
+		expect(rendered.content).toBe(theme.fg("warning", withIcon(icon, "Loop paused")));
+	});
+});


### PR DESCRIPTION
## What

- Show `/loop` as `waiting`, `running`, or `paused` in the status line.
- Show the remaining iteration or duration budget beside the loop state.
- Update the slash-command description to distinguish a paused loop.

## Why

The existing footer rendered only `Loop`, so an enabled loop waiting for its first prompt, an active loop, and a loop paused with Esc looked identical. Bounded loops also hid their remaining budget.

## Testing

- `bun test packages/coding-agent/test/status-line-loop.test.ts packages/coding-agent/test/interactive-mode-loop.test.ts packages/coding-agent/test/loop-limit.test.ts`
- `bun --cwd=packages/coding-agent run check`
- `bun check`
- Source CLI smoke: enabled `/loop 3`, submitted a prompt, paused with Esc, and observed each footer transition.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: status line reads Loop](https://github.com/user-attachments/assets/4e8076cb-b356-4c12-9103-e2474a2e4b63) | ![After: status line reads Loop waiting 3/3](https://github.com/user-attachments/assets/357c675f-0ab3-4942-b517-27421e5c2fab) |

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)