### PR TITLE
fix(catalog): correct kimi-code/k3 effort metadata

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `kimi-code/k3` catalog metadata to expose its supported max-only reasoning effort instead of generic unsupported tiers ([#5831](https://github.com/can1357/oh-my-pi/issues/5831)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Changed

--- a/packages/catalog/scripts/generated-policies.ts
+++ b/packages/catalog/scripts/generated-policies.ts
@@ -233,6 +233,13 @@ function applyGeneratedModelPolicy(model: ModelSpec<Api>): void {
 	) {
 		model.contextWindow = 1_000_000;
 	}
+	if (model.provider === "kimi-code" && model.id === "k3") {
+		model.reasoning = true;
+		model.compat = {
+			...(model.compat ?? {}),
+			thinkingFormat: "openai",
+		};
+	}
 
 	if (
 		model.api === "openai-completions" &&

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -61,6 +61,7 @@ const GEMINI_3_FLASH_EFFORTS: readonly Effort[] = [Effort.Minimal, Effort.Low, E
 const GPT_5_2_PLUS_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
 const GPT_5_1_CODEX_MINI_EFFORTS: readonly Effort[] = [Effort.Medium, Effort.High];
 const LOW_MEDIUM_HIGH_REASONING_EFFORTS: readonly Effort[] = [Effort.Low, Effort.Medium, Effort.High];
+const MAX_ONLY_REASONING_EFFORTS: readonly Effort[] = [Effort.Max];
 /** Wire-exact two-tier scale (`high`/`max`): GLM-5.2 on Z.ai/Umans/Ollama Cloud/Baseten, Sakana Fugu, DeepSeek. */
 const HIGH_MAX_REASONING_EFFORTS: readonly Effort[] = [Effort.High, Effort.Max];
 /** OpenRouter's DeepSeek route accepts only `high`. */
@@ -173,7 +174,7 @@ function fillThinkingWireDefaults<TApi extends Api>(
 		thinking.supportsDisplay === undefined &&
 		(spec.api === "anthropic-messages" || spec.api === "bedrock-converse-stream") &&
 		supportsAdaptiveThinkingDisplay(spec.id);
-	const needsRequiresEffort = thinking.requiresEffort === undefined && impliesMandatoryReasoning(parsed, spec.id);
+	const needsRequiresEffort = thinking.requiresEffort === undefined && impliesMandatoryReasoning(parsed, spec);
 	if (!effortsChanged && !shouldReplaceEffortMap && !needsDisplay && !needsRequiresEffort) {
 		return thinking;
 	}
@@ -218,7 +219,7 @@ export function deriveThinking<TApi extends Api>(spec: ModelSpec<TApi>, compat: 
 	) {
 		config.supportsDisplay = true;
 	}
-	if (impliesMandatoryReasoning(parsed, spec.id)) {
+	if (impliesMandatoryReasoning(parsed, spec)) {
 		config.requiresEffort = true;
 	}
 	return config;
@@ -301,6 +302,9 @@ function getModelDefinedEfforts<TApi extends Api>(
 	spec: ModelSpec<TApi>,
 	compat: CompatOf<TApi>,
 ): readonly Effort[] | undefined {
+	if (spec.provider === "kimi-code" && spec.id === "k3") {
+		return MAX_ONLY_REASONING_EFFORTS;
+	}
 	if (isGlm52ReasoningEffortModelId(spec.id)) {
 		// GLM-5.2's reasoning_effort dialect is host-specific (verified against
 		// live endpoints):
@@ -539,14 +543,15 @@ const OPENAI_O_SERIES_RE = /^o[134](?:$|[-:.])/i;
  *   (variant-collapse) and the collapsed entry owns off — this floor protects
  *   the orphans.
  */
-function impliesMandatoryReasoning(parsed: ParsedModel, modelId: string): boolean {
+function impliesMandatoryReasoning<TApi extends Api>(parsed: ParsedModel, spec: ModelSpec<TApi>): boolean {
 	if (parsed.family === "gemini") {
 		if (semverGte(parsed.version, "3.0")) return true;
 		if (parsed.kind === "pro" && semverGte(parsed.version, "2.5")) return true;
 	}
-	if (isMinimaxM2FamilyModelId(modelId)) return true;
-	if (OPENAI_O_SERIES_RE.test(bareModelId(modelId))) return true;
-	return findThinkingVariantToken(modelId) !== undefined;
+	if (isMinimaxM2FamilyModelId(spec.id)) return true;
+	if (spec.provider === "kimi-code" && spec.id === "k3") return true;
+	if (OPENAI_O_SERIES_RE.test(bareModelId(spec.id))) return true;
+	return findThinkingVariantToken(spec.id) !== undefined;
 }
 
 function inferAnthropicSupportedEfforts<TApi extends Api>(

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -35700,14 +35700,12 @@
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high"
-				]
+					"max"
+				],
+				"requiresEffort": true
 			},
 			"compat": {
-				"thinkingFormat": "zai",
+				"thinkingFormat": "openai",
 				"reasoningContentField": "reasoning_content",
 				"supportsDeveloperRole": false
 			}

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -26,6 +26,7 @@ import {
 import { createBundledReferenceMap, createReferenceResolver, toModelSpec } from "./bundled-references";
 
 const MODELS_DEV_URL = "https://models.dev/api.json";
+const KIMI_K3_THINKING: ThinkingConfig = { mode: "effort", efforts: [Effort.Max], requiresEffort: true };
 
 /**
  * Uses a cancellable timer rather than the native abort-timeout helper so
@@ -2528,15 +2529,18 @@ export function kimiCodeModelManagerOptions(
 						_context: OpenAICompatibleModelMapperContext<"openai-completions">,
 					): ModelSpec<"openai-completions"> => {
 						const id = defaults.id;
+						const isK3 = id === "k3";
 						return {
 							...defaults,
 							name: typeof entry.display_name === "string" ? entry.display_name : defaults.name,
-							reasoning: entry.supports_reasoning === true || id.includes("thinking"),
-							input: entry.supports_image_in === true || id.includes("k2.5") ? ["text", "image"] : ["text"],
+							reasoning: isK3 || entry.supports_reasoning === true || id.includes("thinking"),
+							input:
+								isK3 || entry.supports_image_in === true || id.includes("k2.5") ? ["text", "image"] : ["text"],
 							contextWindow: typeof entry.context_length === "number" ? entry.context_length : 262144,
 							maxTokens: 32000,
+							thinking: isK3 ? KIMI_K3_THINKING : undefined,
 							compat: {
-								thinkingFormat: "zai",
+								thinkingFormat: isK3 ? "openai" : "zai",
 								reasoningContentField: "reasoning_content",
 								supportsDeveloperRole: false,
 							},
@@ -2932,7 +2936,6 @@ export interface MoonshotModelManagerConfig {
 const MOONSHOT_KIMI_K3_COST = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 } as const;
 const MOONSHOT_KIMI_K3_CONTEXT_WINDOW = 1_048_576;
 const MOONSHOT_KIMI_K3_MAX_TOKENS = 131_072;
-const MOONSHOT_KIMI_K3_THINKING: ThinkingConfig = { mode: "effort", efforts: [Effort.Max], requiresEffort: true };
 
 export function moonshotModelManagerOptions(
 	config?: MoonshotModelManagerConfig,
@@ -2972,7 +2975,7 @@ export function moonshotModelManagerOptions(
 								cost: isZeroCost ? { ...MOONSHOT_KIMI_K3_COST } : model.cost,
 								contextWindow: model.contextWindow ?? MOONSHOT_KIMI_K3_CONTEXT_WINDOW,
 								maxTokens: model.maxTokens ?? MOONSHOT_KIMI_K3_MAX_TOKENS,
-								thinking: model.thinking ?? { ...MOONSHOT_KIMI_K3_THINKING },
+								thinking: model.thinking ?? { ...KIMI_K3_THINKING },
 							};
 						}
 						// Moonshot's K2.x family (K2.5, K2.6, kimi-k2-thinking, …) is reasoning-capable

--- a/packages/catalog/test/issue-5831-repro.test.ts
+++ b/packages/catalog/test/issue-5831-repro.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as kimiOauth from "@oh-my-pi/pi-ai/oauth/kimi";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { kimiCodeModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import { applyGeneratedModelPolicies } from "../scripts/generated-policies";
+
+const KIMI_HEADERS = Object.freeze({
+	"User-Agent": "KimiCLI/test",
+	"X-Msh-Platform": "kimi_cli",
+	"X-Msh-Version": "test",
+	"X-Msh-Device-Name": "test",
+	"X-Msh-Device-Model": "test",
+	"X-Msh-Os-Version": "test",
+	"X-Msh-Device-Id": "test",
+});
+
+const context: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+};
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+async function discoverKimiCodeK3(): Promise<Model<"openai-completions">> {
+	const fetchMock: FetchImpl = async () =>
+		new Response(
+			JSON.stringify({
+				data: [
+					{
+						id: "k3",
+						display_name: "K3",
+						supports_reasoning: true,
+						supports_image_in: true,
+						context_length: 1_048_576,
+					},
+				],
+			}),
+			{ status: 200, headers: { "content-type": "application/json" } },
+		);
+	const models = await kimiCodeModelManagerOptions({ apiKey: "test-key", fetch: fetchMock }).fetchDynamicModels?.();
+	const k3 = models?.find(model => model.id === "k3");
+	if (!k3) throw new Error("kimi-code/k3 was not discovered");
+	return buildModel(k3);
+}
+
+describe("issue #5831 — kimi-code/k3 max-only effort", () => {
+	it("corrects generated K3 metadata to the provider's max-only contract", () => {
+		const k3: ModelSpec<"openai-completions"> = {
+			id: "k3",
+			name: "K3",
+			api: "openai-completions",
+			provider: "kimi-code",
+			baseUrl: "https://api.kimi.com/coding/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1_048_576,
+			maxTokens: 32_000,
+			thinking: { mode: "effort", efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High] },
+			compat: { thinkingFormat: "zai" },
+		};
+
+		applyGeneratedModelPolicies([k3]);
+
+		expect(k3.thinking).toEqual({ mode: "effort", efforts: [Effort.Max], requiresEffort: true });
+		expect(k3.compat?.thinkingFormat).toBe("openai");
+	});
+
+	it("keeps dynamically discovered K3 metadata max-only", async () => {
+		const k3 = await discoverKimiCodeK3();
+
+		expect(k3.thinking).toEqual({ mode: "effort", efforts: [Effort.Max], requiresEffort: true });
+		expect(k3.compat.thinkingFormat).toBe("openai");
+		expect(k3.compat.reasoningDisableMode).toBe("lowest-effort");
+	});
+
+	it("sends selected max effort through the OpenAI reasoning dialect", async () => {
+		vi.spyOn(kimiOauth, "getKimiCommonHeaders").mockReturnValue(KIMI_HEADERS);
+		const k3 = await discoverKimiCodeK3();
+		let requestBody: string | undefined;
+		const fetchMock: FetchImpl = async (_input, init) => {
+			requestBody = typeof init?.body === "string" ? init.body : undefined;
+			return new Response('{"error":{"message":"captured"}}', { status: 400 });
+		};
+
+		const stream = streamOpenAICompletions(k3, context, {
+			apiKey: "test-key",
+			reasoning: Effort.Max,
+			fetch: fetchMock,
+		});
+		for await (const _event of stream) {
+			// Drain the response so the request body is captured.
+		}
+		if (!requestBody) throw new Error("K3 request body was not captured");
+		const body = JSON.parse(requestBody) as { reasoning_effort?: string; thinking?: unknown };
+
+		expect(body.reasoning_effort).toBe("max");
+		expect(body.thinking).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
`kimi-code/k3` in the bundled catalog advertised `thinking.efforts = ["minimal", "low", "medium", "high"]` and `compat.thinkingFormat = "zai"`; inspecting it with `bun -e 'const c=await Bun.file("packages/catalog/src/models.json").json(); console.log(c["kimi-code"].k3)'` reproduces the metadata shown by `omp models kimi-code --json`.

## Cause
`kimiCodeModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` applied the K2-style z.ai thinking dialect to every Kimi Code model, while `getModelDefinedEfforts` and `impliesMandatoryReasoning` in `packages/catalog/src/model-thinking.ts` had no provider-scoped rule for Kimi Code’s bare `k3` ID. The generator therefore rebaked K3 with the generic effort ladder.

## Fix
- Treat `kimi-code/k3` as a mandatory max-only reasoning model during thinking metadata derivation.
- Map dynamically discovered K3 entries and generated bundled metadata to the OpenAI reasoning-effort dialect.
- Regenerate the bundled K3 entry and add generated-policy, discovery, and wire-format regression coverage.

## Verification
`bun test test/identity-family.test.ts test/model-thinking.test.ts test/generated-policies.test.ts test/issue-5756-repro.test.ts test/issue-5831-repro.test.ts` passed: 78 tests, 388 assertions. `bun check` in `packages/catalog` passed. The fixed bundled entry now reports `thinking.efforts = ["max"]`, `requiresEffort = true`, and `thinkingFormat = "openai"`.

Fixes #5831