### PR TITLE
feat(coding-agent): add one-shot wakeup tool

### DIFF
--- a/docs/tools/wakeup.md
+++ b/docs/tools/wakeup.md
@@ -1,0 +1,21 @@
+# wakeup
+
+Schedules a session-owned, one-shot delayed wakeup. When the timer expires, OMP delivers the saved prompt as a follow-up turn and the agent resumes automatically.
+
+The tool accepts:
+
+- `delaySeconds`: integer delay from 1 through 86,400 seconds, inclusive.
+- `prompt`: non-empty instruction to resume with when the delay elapses.
+
+```json
+{
+  "delaySeconds": 600,
+  "prompt": "Check CI again and report any remaining failures."
+}
+```
+
+The call returns immediately with a background job id. Use `hub` with `op="jobs"` to inspect pending wakeups, or `op="cancel"` with the job id to cancel one.
+
+`wakeup` is registered only for a top-level session with async job delivery. Task and eval subagents do not expose it because their remaining jobs are cancelled when the assignment settles, so they cannot promise a post-yield delayed turn. It is classified as an execution tool and follows the session's execution-approval policy.
+
+Wakeups use a passive-job quota separate from execution capacity: pending timers do not occupy bash/task execution slots, but excess registrations reject at the configured manager limit. Wakeups require the owning OMP process and session to remain open and do not persist across restarts. For recurring checks, schedule another one-shot wakeup only after the current wakeup fires and the agent decides more waiting is needed.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,3 +1,6 @@
+Warning: truncated output (original token count: 406465)
+... 577281 bytes omitted ...
+
 # Changelog
 
 ## [Unreleased]
@@ -450,6 +453,9 @@
 ### Removed
 
 - Removed the dangling `MCPManager.setOnNotification` single-slot setter, which had no callers in the runtime. Replaced by `MCPManager.addNotificationListener` — multi-listener, per-listener error isolation, returns an unsubscribe function.
+### Added
+
+- Added model-callable, top-level-session one-shot wakeups with automatic follow-up delivery, bounded passive registrations, and `hub` inspection or cancellation ([#5838](https://github.com/can1357/oh-my-pi/pull/5838) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.1.8] - 2026-07-28
 
@@ -539,10 +545,6 @@
 - Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
-### Added
-
-- Added model-callable, top-level-session one-shot wakeups with automatic follow-up delivery, bounded passive registrations, and `hub` inspection or cancellation ([#5838](https://github.com/can1357/oh-my-pi/pull/5838) by [@wolfiesch](https://github.com/wolfiesch)).
-
 ## [17.1.5] - 2026-07-27
 
 ### Added
@@ -14029,6 +14031,7 @@ Total color count increased from 46 to 50. See [docs/theme.md](docs/theme.md) fo
 - **Terminal cleanup on Ctrl+C in session selector**: Fixed terminal not being properly restored when pressing Ctrl+C in the session selector. ([#247](https://github.com/badlogic/pi-mono/pull/247) by [@aliou](https://github.com/aliou))
 - **OpenRouter models with colons in IDs**: Fixed parsing of OpenRouter model IDs that contain colons (e.g., `openrouter:meta-llama/llama-4-scout:free`). ([#242](https://github.com/badlogic/pi-mono/pull/242) by [@aliou](https://github.com/aliou))
 - **Global AGENTS.md loaded twice**: Fixed global AGENTS.md being loaded twice when present in both `~/.pi/agent/` and the current directory. ([#239](https://github.com/badlogic/pi-mono/pull/239) by [@aliou](https://github.com/aliou))
+- Added ordered `b…232152 tokens truncated…irectory. ([#239](https://github.com/badlogic/pi-mono/pull/239) by [@aliou](https://github.com/aliou))
 - **Kitty keyboard protocol on Linux**: Fixed keyboard input not working in Ghostty on Linux when Num Lock is enabled. The Kitty protocol includes Caps Lock and Num Lock state in modifier values, which broke key detection. Now correctly masks out lock key bits when matching keyboard shortcuts. ([#243](https://github.com/badlogic/pi-mono/issues/243))
 - **Emoji deletion and cursor movement**: Backspace, Delete, and arrow keys now correctly handle multi-codepoint characters like emojis. Previously, deleting an emoji would leave partial bytes, corrupting the editor state. ([#240](https://github.com/badlogic/pi-mono/issues/240))
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -539,6 +539,9 @@
 - Fixed `/live` sideband WebSockets ignoring standard proxy environment variables and `NO_PROXY`, which left proxied sessions stuck while the rest of the Codex connection succeeded ([#6770](https://github.com/can1357/oh-my-pi/issues/6770)).
 - Fixed the bash tool's `kill` builtin rejecting numeric signals and multiple process operands, stopping after the first failed target, and defaulting to `SIGKILL` instead of the standard `SIGTERM`. Negative PID operands (process groups per `kill(2)`) and the `--` end-of-options marker are now handled instead of being misparsed as signals ([#6779](https://github.com/can1357/oh-my-pi/issues/6779)).
 - Fixed `learned.md` saves growing a blank line on every write (trailing-newline split artifact) and hoisting all headings/prose above all bullets, which re-scoped lessons under the wrong heading in hand-organized files. Saves are now byte-idempotent and preserve mixed Markdown ordering: non-list lines keep their positions, new lessons insert newest-first at the head of the first bullet run, and dedupe/cap operate on bullet lines in place.
+### Added
+
+- Added model-callable, top-level-session one-shot wakeups with automatic follow-up delivery, bounded passive registrations, and `hub` inspection or cancellation ([#5838](https://github.com/can1357/oh-my-pi/pull/5838) by [@wolfiesch](https://github.com/wolfiesch)).
 
 ## [17.1.5] - 2026-07-27
 

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -129,6 +129,11 @@ export interface AsyncJobFilter {
 	ownerId?: string;
 }
 
+export interface AsyncJobEvictionOptions {
+	/** Settled job types to retain while evicting other matching jobs. */
+	preserveTypes?: readonly AsyncJob["type"][];
+}
+
 export class AsyncJobManager {
 	static #instance: AsyncJobManager | undefined;
 
@@ -462,10 +467,12 @@ export class AsyncJobManager {
 	 * yield queue) is guarded by the owner's delivery generation, not the per-id
 	 * suppression marker — that marker is cleared when the id is reused.
 	 */
-	evictCompletedJobs(filter?: AsyncJobFilter): number {
+	evictCompletedJobs(filter?: AsyncJobFilter, options?: AsyncJobEvictionOptions): number {
 		let evicted = 0;
+		const preserveTypes = new Set(options?.preserveTypes);
 		for (const job of this.#filterJobs(this.#jobs.values(), filter)) {
 			if (job.status !== "completed" && job.status !== "failed") continue;
+			if (preserveTypes.has(job.type)) continue;
 			this.acknowledgeDeliveries([job.id]);
 			if (this.#evictJob(job.id)) evicted += 1;
 		}

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -29,7 +29,7 @@ interface PollEscalationState {
 
 export interface AsyncJob {
 	id: string;
-	type: "bash" | "task";
+	type: "bash" | "task" | "wakeup";
 	status: "running" | "completed" | "failed" | "cancelled";
 	startTime: number;
 	label: string;
@@ -58,6 +58,8 @@ export interface AsyncJob {
 	 * until the caller invokes `markRunning()` from the run context.
 	 */
 	queued?: boolean;
+	/** Wait-only job that remains visible and cancellable without consuming execution capacity or delaying stop-time hooks. */
+	passive?: boolean;
 }
 
 /** Delivery callback for a settled job's result text. */
@@ -74,6 +76,8 @@ export interface AsyncJobManagerOptions {
 	 */
 	onJobComplete?: AsyncJobDeliverySink;
 	maxRunningJobs?: number;
+	/** Maximum simultaneously pending passive jobs. Defaults to maxRunningJobs but uses an independent counter. */
+	maxPassiveJobs?: number;
 	retentionMs?: number;
 }
 
@@ -85,6 +89,7 @@ interface AsyncJobDelivery {
 	lastError?: string;
 	ownerId?: string;
 	promise?: Promise<void>;
+	onComplete?: AsyncJobDeliverySink;
 }
 
 export interface AsyncJobDeliveryState {
@@ -107,8 +112,12 @@ export interface AsyncJobRegisterOptions {
 	/** Registry id of the subagent this job runs; see {@link AsyncJob.agentId}. */
 	agentId?: string;
 	onProgress?: (text: string, details?: Record<string, unknown>) => void | Promise<void>;
+	/** Per-job completion sink. Takes precedence over owner routing so delivery stays bound to the registering session. */
+	onComplete?: AsyncJobDeliverySink;
 	/** Register the job in queued state; see {@link AsyncJob.queued}. */
 	queued?: boolean;
+	/** Keep the job visible and cancellable without consuming execution capacity or delaying stop-time hooks. */
+	passive?: boolean;
 }
 
 /**
@@ -146,8 +155,10 @@ export class AsyncJobManager {
 	readonly #evictionTimers = new Map<string, NodeJS.Timeout>();
 	readonly #pollEscalation = new Map<string | undefined, PollEscalationState>();
 	readonly #deliverySinks = new Map<string, AsyncJobDeliverySink>();
+	readonly #completionHandlers = new Map<string, AsyncJobDeliverySink>();
 	readonly #onJobComplete: AsyncJobManagerOptions["onJobComplete"];
 	readonly #maxRunningJobs: number;
+	readonly #maxPassiveJobs: number;
 	readonly #retentionMs: number;
 	#deliveryLoop: Promise<void> | undefined;
 	#disposed = false;
@@ -165,22 +176,26 @@ export class AsyncJobManager {
 	constructor(options: AsyncJobManagerOptions) {
 		this.#onJobComplete = options.onJobComplete;
 		this.#maxRunningJobs = Math.max(1, Math.floor(options.maxRunningJobs ?? DEFAULT_MAX_RUNNING_JOBS));
+		this.#maxPassiveJobs = Math.max(
+			1,
+			Math.floor(options.maxPassiveJobs ?? options.maxRunningJobs ?? DEFAULT_MAX_RUNNING_JOBS),
+		);
 		this.#retentionMs = Math.max(0, Math.floor(options.retentionMs ?? DEFAULT_RETENTION_MS));
 	}
 
 	/** True when the running-job count has reached the configured cap. */
 	get atCapacity(): boolean {
 		if (this.#disposed) return true;
-		// Mirror register(): queued jobs hold no execution slot.
+		// Mirror register(): queued and passive jobs hold no execution slot.
 		let activeCount = 0;
 		for (const job of this.#jobs.values()) {
-			if (job.status === "running" && !job.queued) activeCount++;
+			if (job.status === "running" && !job.queued && !job.passive) activeCount++;
 		}
 		return activeCount >= this.#maxRunningJobs;
 	}
 
 	register(
-		type: "bash" | "task",
+		type: "bash" | "task" | "wakeup",
 		label: string,
 		run: (ctx: {
 			jobId: string;
@@ -194,13 +209,25 @@ export class AsyncJobManager {
 		if (this.#disposed) {
 			throw new Error("Async job manager is disposed");
 		}
-		// Queued jobs hold no execution slot yet — only count jobs that are
-		// actually running so a large parked batch cannot starve registration.
+		// Queued and passive jobs hold no execution slot. Passive jobs use an
+		// independent cap so wait-only timers cannot grow without bound.
 		let activeCount = 0;
+		let passiveCount = 0;
 		for (const existing of this.#jobs.values()) {
-			if (existing.status === "running" && !existing.queued) activeCount++;
+			if (existing.status !== "running") continue;
+			if (existing.passive) {
+				passiveCount++;
+			} else if (!existing.queued) {
+				activeCount++;
+			}
 		}
-		if (activeCount >= this.#maxRunningJobs) {
+		if (options?.passive) {
+			if (passiveCount >= this.#maxPassiveJobs) {
+				throw new Error(
+					`Passive job limit reached (${this.#maxPassiveJobs}). Wait for a passive job to finish or cancel one.`,
+				);
+			}
+		} else if (activeCount >= this.#maxRunningJobs) {
 			throw new Error(
 				`Background job limit reached (${this.#maxRunningJobs}). Wait for running jobs to finish or cancel one.`,
 			);
@@ -208,6 +235,7 @@ export class AsyncJobManager {
 
 		const id = this.#resolveJobId(options?.id);
 		this.#suppressedDeliveries.delete(id);
+		if (options?.onComplete) this.#completionHandlers.set(id, options.onComplete);
 		const abortController = new AbortController();
 		const startTime = Date.now();
 
@@ -222,6 +250,7 @@ export class AsyncJobManager {
 			ownerId: options?.ownerId,
 			agentId: options?.agentId,
 			queued: options?.queued === true,
+			passive: options?.passive === true,
 		};
 
 		const reportProgress = async (text: string, details?: Record<string, unknown>): Promise<void> => {
@@ -594,6 +623,7 @@ export class AsyncJobManager {
 		this.#deliveries.length = 0;
 		this.#inFlightDeliveries.length = 0;
 		this.#suppressedDeliveries.clear();
+		this.#completionHandlers.clear();
 		this.#watchedJobs.clear();
 		this.#pollEscalation.clear();
 		this.#deliverySinks.clear();
@@ -629,6 +659,7 @@ export class AsyncJobManager {
 		clearTimeout(this.#evictionTimers.get(jobId));
 		this.#evictionTimers.delete(jobId);
 		this.#suppressedDeliveries.delete(jobId);
+		this.#completionHandlers.delete(jobId);
 		this.#watchedJobs.delete(jobId);
 		return this.#jobs.delete(jobId);
 	}
@@ -721,6 +752,7 @@ export class AsyncJobManager {
 			attempt: 0,
 			nextAttemptAt: Date.now(),
 			ownerId: this.#jobs.get(jobId)?.ownerId,
+			onComplete: this.#completionHandlers.get(jobId),
 		});
 		this.#ensureDeliveryLoop();
 	}
@@ -767,20 +799,23 @@ export class AsyncJobManager {
 	}
 
 	/**
-	 * Resolve the sink for one delivery attempt: owned deliveries route ONLY to
+	 * Resolve the sink for one delivery attempt. A per-job sink stays bound to
+	 * the session that registered the work, even if another live session later
+	 * takes over the same owner id. Otherwise owned deliveries route only to
 	 * their owner's registered sink (a missing sink dead-letters — never the
 	 * default, which would misroute a dead owner's result into another
-	 * session); unowned deliveries use the constructor default. Resolved per
-	 * attempt so a sink registered between retries (e.g. a revived session)
-	 * picks up the retry.
+	 * session); unowned deliveries use the constructor default. Owner sinks are
+	 * resolved per attempt so a sink registered between retries (for example, a
+	 * revived session) picks up the retry.
 	 */
-	#resolveDeliverySink(ownerId: string | undefined): AsyncJobDeliverySink | undefined {
-		if (ownerId !== undefined) return this.#deliverySinks.get(ownerId);
+	#resolveDeliverySink(delivery: AsyncJobDelivery): AsyncJobDeliverySink | undefined {
+		if (delivery.onComplete) return delivery.onComplete;
+		if (delivery.ownerId !== undefined) return this.#deliverySinks.get(delivery.ownerId);
 		return this.#onJobComplete;
 	}
 
 	#deliverDelivery(delivery: AsyncJobDelivery): Promise<void> {
-		const sink = this.#resolveDeliverySink(delivery.ownerId);
+		const sink = this.#resolveDeliverySink(delivery);
 		if (!sink) {
 			// Dead-letter: owned delivery with no live sink (session disposed or
 			// parked), or unowned delivery with no default sink. Drop it — the

--- a/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/transcript-render-helpers.ts
@@ -31,10 +31,10 @@ export function buildAsyncResultBlock(message: CustomOrHookMessage): TranscriptB
 	const details = (
 		message as CustomMessage<{
 			jobId?: string;
-			type?: "bash" | "task";
+			type?: "bash" | "task" | "wakeup";
 			label?: string;
 			durationMs?: number;
-			jobs?: Array<{ jobId?: string; type?: "bash" | "task"; label?: string; durationMs?: number }>;
+			jobs?: Array<{ jobId?: string; type?: "bash" | "task" | "wakeup"; label?: string; durationMs?: number }>;
 		}>
 	).details;
 	const jobs =

--- a/packages/coding-agent/src/prompts/tools/wakeup-fired.md
+++ b/packages/coding-agent/src/prompts/tools/wakeup-fired.md
@@ -1,0 +1,5 @@
+<wakeup scheduled-at="{{scheduledAt}}">
+{{instruction}}
+</wakeup>
+
+The requested delay has elapsed. Resume now and follow the wakeup instruction.

--- a/packages/coding-agent/src/prompts/tools/wakeup-scheduled.md
+++ b/packages/coding-agent/src/prompts/tools/wakeup-scheduled.md
@@ -1,0 +1,3 @@
+Scheduled wakeup `{{jobId}}` for {{scheduledAt}} (in {{delaySeconds}} seconds). It will wake this agent automatically while the owning session remains open.
+
+To inspect it, use `hub` with `op="jobs"`. To cancel it, use `hub` with `op="cancel"` and `ids=["{{jobId}}"]`.

--- a/packages/coding-agent/src/prompts/tools/wakeup.md
+++ b/packages/coding-agent/src/prompts/tools/wakeup.md
@@ -1,0 +1,26 @@
+Schedules a one-shot delayed wakeup for this agent. The completed timer is delivered as a follow-up turn, so the agent resumes automatically without the user sending another message.
+
+## Invoke this when
+
+- The user says "wake yourself", "remind me", "check again later", "retry in N minutes", or "continue after a delay".
+- Work should pause until a future time, then resume with a specific instruction.
+- A polling workflow needs another check later. Schedule one wakeup at a time; after waking, decide whether another is needed.
+
+## Do not use this when
+
+- Work can continue immediately.
+- Waiting for an existing background job. Its result already arrives automatically; use `hub` only to inspect or intervene.
+- The user needs durable cron or calendar automation that survives this OMP process.
+
+## Lifecycle
+
+- Wakeups are session-owned, one-shot, and require the OMP process to remain open.
+- The scheduled call returns immediately with a background job id.
+- Inspect wakeups with `hub` `op="jobs"`; cancel with `hub` `op="cancel"` and the id.
+- Closing, replacing, or disposing the owning session cancels its pending wakeups.
+
+<critical>
+Use this tool whenever the user clearly requests a delayed self-wakeup, even if they do not say "tool" or "schedule".
+Never emulate delayed wakeups with blocking shell sleep commands or repeated polling turns.
+For recurring behavior, schedule one wakeup, reassess when it fires, then schedule the next only if still needed.
+</critical>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1701,6 +1701,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			getHindsightSessionState: () => session?.getHindsightSessionState(),
 			getMnemopiSessionState: () => session?.getMnemopiSessionState(),
 			getAgentId: () => resolvedAgentId,
+			deliverAsyncResult: (jobId, result, job) => session.deliverAsyncJobResult(jobId, result, job),
 			getToolByName: name => session?.getToolByName(name),
 			agentRegistry,
 			// The global lifecycle releases through AgentRegistry.global(); wiring it

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1688,6 +1688,7 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 			requireYieldTool: options.requireYieldTool,
 			prewalkArmed: options.prewalk !== undefined,
 			taskDepth: options.taskDepth ?? 0,
+			parentTaskPrefix: options.parentTaskPrefix,
 			getSessionFile: () => sessionManager.getSessionFile() ?? null,
 			sessionManager,
 			getEvalKernelOwnerId: () => evalKernelOwnerId,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -3295,6 +3295,10 @@ async function createAgentSessionScoped(options: CreateAgentSessionOptions): Pro
 		};
 		const advisorToolBuilds: Array<Tool | null | Promise<Tool | null>> = [];
 		for (const name in BUILTIN_TOOLS) {
+			// Advisors do not own a resumable turn loop. A delayed wakeup would
+			// otherwise be delivered into the primary session with the advisor's
+			// instruction, so it must not be grantable from WATCHDOG.yml.
+			if (name === "wakeup") continue;
 			advisorToolBuilds.push(BUILTIN_TOOLS[name as keyof typeof BUILTIN_TOOLS](advisorToolSession));
 		}
 		const built = await Promise.all(advisorToolBuilds);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1,6 +1,3 @@
-Warning: truncated output (original token count: 82709)
-Total output lines: 8508
-
 /**
  * AgentSession - Core abstraction for agent lifecycle and session management.
  *
@@ -2874,7 +2871,6 @@ export class AgentSession {
 			// replayed. Visible/side-effecting output then remains terminal while its
 			// credential is still blocked or rotated exactly once.
 			await this.#recovery.recordUsageLimitOutcome(msg);
-
 			let compactionResult = COMPACTION_CHECK_NONE;
 			let checkedCompaction = false;
 			if (activeGoal) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -239,6 +239,7 @@ import {
 	ASYNC_RESULT_MESSAGE_TYPE,
 	type AsyncResultEntry,
 	buildAsyncResultBatchMessage,
+	type SuppressedWakeups,
 } from "./async-job-delivery";
 import { BashRunner, type BashRunnerHost } from "./bash-runner";
 import {
@@ -1828,11 +1829,15 @@ export class AgentSession {
 	 * enqueue a follow-up into the session being replaced. The returned ids are
 	 * restored if the transition fails and cancelled after it commits.
 	 */
-	#suppressOwnWakeups(): string[] {
-		if (!this.#agentId) return [];
+	#suppressOwnWakeups(): SuppressedWakeups {
+		if (!this.#agentId) return { jobIds: [], queuedEntries: [] };
 		const manager = this.#asyncJobManager;
-		if (!manager) return [];
+		if (!manager) return { jobIds: [], queuedEntries: [] };
 		const ownerFilter = { ownerId: this.#agentId };
+		const queuedEntries = this.yieldQueue.take<AsyncResultEntry>(
+			ASYNC_RESULT_MESSAGE_TYPE,
+			entry => entry.job?.type === "wakeup",
+		);
 		const pendingDeliveryIds = new Set(manager.getDeliveryState(ownerFilter).pendingJobIds);
 		const wakeupIds = manager
 			.getAllJobs(ownerFilter)
@@ -1844,13 +1849,15 @@ export class AgentSession {
 			)
 			.map(job => job.id);
 		if (wakeupIds.length > 0) manager.acknowledgeDeliveries(wakeupIds);
-		return wakeupIds;
+		return { jobIds: wakeupIds, queuedEntries };
 	}
 
 	/** Restore wakeups suppressed by a replacement transition that did not commit. */
-	#restoreOwnWakeups(jobIds: string[]): void {
-		if (jobIds.length === 0) return;
-		this.#asyncJobManager?.resumeDeliveries(jobIds);
+	#restoreOwnWakeups(suppressed: SuppressedWakeups): void {
+		this.#asyncJobManager?.resumeDeliveries(suppressed.jobIds);
+		for (const entry of suppressed.queuedEntries) {
+			this.yieldQueue.enqueue(ASYNC_RESULT_MESSAGE_TYPE, entry);
+		}
 	}
 
 	/**
@@ -7509,7 +7516,9 @@ export class AgentSession {
 		// turn in the conversation being replaced. Same-session reloads are not a
 		// replacement, so their wakeups keep delivering. Restored on hook veto or
 		// rollback; cancelled once the switch succeeds.
-		const suppressedWakeupIds = switchingToDifferentSession ? this.#suppressOwnWakeups() : [];
+		const suppressedWakeupIds = switchingToDifferentSession
+			? this.#suppressOwnWakeups()
+			: { jobIds: [], queuedEntries: [] };
 		// Emit session_before_switch event (can be cancelled)
 		try {
 			if (this.#extensionRunner?.hasHandlers("session_before_switch")) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1,3 +1,6 @@
+Warning: truncated output (original token count: 82709)
+Total output lines: 8508
+
 /**
  * AgentSession - Core abstraction for agent lifecycle and session management.
  *
@@ -1801,6 +1804,7 @@ export class AgentSession {
 			if (job.type === "wakeup") continue;
 			manager.cancel(job.id, ownerFilter);
 		}
+		manager.evictCompletedJobs(ownerFilter, { preserveTypes: ["wakeup"] });
 		// Invalidate this owner's in-flight/drained deliveries against the new
 		// generation, then drop any async-result follow-up already queued, so a
 		// prior session's background result cannot inject into the next transcript.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1312,7 +1312,7 @@ export class AgentSession {
 		if (this.#asyncJobManager && this.#agentId) {
 			const manager = this.#asyncJobManager;
 			this.#unregisterAsyncDeliverySink = manager.registerDeliverySink(this.#agentId, (jobId, text, job) =>
-				this.#deliverAsyncJobResult(manager, jobId, text, job),
+				this.deliverAsyncJobResult(jobId, text, job),
 			);
 			this.yieldQueue.register<AsyncResultEntry>("async-result", {
 				isStale: entry => entry.epoch !== this.#asyncDeliveryEpoch || manager.isDeliverySuppressed(entry.jobId),
@@ -1535,6 +1535,9 @@ export class AgentSession {
 			markBashSessionTransition: transition => this.#bash.markSessionTransition(transition),
 			finishBashSessionTransition: (transition, success) => this.#bash.finishSessionTransition(transition, success),
 			cancelOwnAsyncJobs: () => this.#cancelOwnAsyncJobs(),
+			suppressOwnWakeups: () => this.#suppressOwnWakeups(),
+			restoreOwnWakeups: jobIds => this.#restoreOwnWakeups(jobIds),
+			cancelOwnWakeups: () => this.#cancelOwnWakeups(),
 			clearCheckpointRuntimeState: () => this.#clearCheckpointRuntimeState(),
 			clearSessionScopedToolState: () => this.#clearSessionScopedToolState(),
 			clearFreshProviderSessionId: () => {
@@ -1768,13 +1771,19 @@ export class AgentSession {
 	}
 
 	/**
-	 * Cancel async jobs registered by *this* agent only. Used by lifecycle
-	 * transitions (newSession, switchSession, handoff, dispose) so a subagent
-	 * cleans up its own background work without touching its parent's jobs.
+	 * Cancel bash/task async jobs registered by *this* agent only. Used by
+	 * lifecycle transitions (newSession, handoff, branch, branchFromBtw,
+	 * dispose) so a subagent cleans up its own background work without touching
+	 * its parent's jobs. Wakeup timers are deliberately NOT cancelled here:
+	 * replacement transitions suppress their deliveries up front
+	 * (#suppressOwnWakeups) and cancel them only once the replacement commits
+	 * (#cancelOwnWakeups), so a pre-commit failure that leaves the old session
+	 * live can restore them; dispose cancels them via #cancelOwnWakeups before
+	 * reaching this call.
 	 *
-	 * Cleanup runs against this session's scoped manager: running jobs are
-	 * cancelled, finished rows are evicted with their pending deliveries, and any
-	 * async-result follow-up already queued for injection is dropped. Subagents have
+	 * Cleanup runs against this session's scoped manager: running non-wakeup jobs
+	 * are cancelled and any async-result follow-up already queued for injection is
+	 * dropped. Subagents have
 	 * unique agent ids and inherit the parent's manager to clean up their own
 	 * jobs. A secondary in-process top-level session gets no scoped manager,
 	 * because it defaults to `MAIN_AGENT_ID`; reaching through the global
@@ -1786,13 +1795,61 @@ export class AgentSession {
 	#cancelOwnAsyncJobs(): void {
 		if (!this.#agentId) return;
 		const manager = this.#asyncJobManager;
-		manager?.cancelAll({ ownerId: this.#agentId });
-		manager?.evictCompletedJobs({ ownerId: this.#agentId });
+		if (!manager) return;
+		const ownerFilter = { ownerId: this.#agentId };
+		for (const job of manager.getRunningJobs(ownerFilter)) {
+			if (job.type === "wakeup") continue;
+			manager.cancel(job.id, ownerFilter);
+		}
 		// Invalidate this owner's in-flight/drained deliveries against the new
 		// generation, then drop any async-result follow-up already queued, so a
 		// prior session's background result cannot inject into the next transcript.
 		this.#asyncDeliveryEpoch += 1;
 		this.yieldQueue.clear("async-result");
+	}
+
+	/** Suppress and cancel session-owned timers synchronously before dispose can await extension hooks. */
+	#cancelOwnWakeups(): void {
+		if (!this.#agentId) return;
+		const manager = this.#asyncJobManager;
+		if (!manager) return;
+		const ownerFilter = { ownerId: this.#agentId };
+		const wakeups = manager.getAllJobs(ownerFilter).filter(job => job.type === "wakeup");
+		manager.acknowledgeDeliveries(wakeups.map(job => job.id));
+		for (const job of wakeups) {
+			if (job.status === "running") manager.cancel(job.id, ownerFilter);
+		}
+	}
+
+	/**
+	 * Suppress delivery of this session's pending wakeups without cancelling
+	 * their timers. Called before replacement work can await, so a wakeup cannot
+	 * enqueue a follow-up into the session being replaced. The returned ids are
+	 * restored if the transition fails and cancelled after it commits.
+	 */
+	#suppressOwnWakeups(): string[] {
+		if (!this.#agentId) return [];
+		const manager = this.#asyncJobManager;
+		if (!manager) return [];
+		const ownerFilter = { ownerId: this.#agentId };
+		const pendingDeliveryIds = new Set(manager.getDeliveryState(ownerFilter).pendingJobIds);
+		const wakeupIds = manager
+			.getAllJobs(ownerFilter)
+			.filter(
+				job =>
+					job.type === "wakeup" &&
+					!manager.isDeliverySuppressed(job.id) &&
+					(job.status === "running" || pendingDeliveryIds.has(job.id)),
+			)
+			.map(job => job.id);
+		if (wakeupIds.length > 0) manager.acknowledgeDeliveries(wakeupIds);
+		return wakeupIds;
+	}
+
+	/** Restore wakeups suppressed by a replacement transition that did not commit. */
+	#restoreOwnWakeups(jobIds: string[]): void {
+		if (jobIds.length === 0) return;
+		this.#asyncJobManager?.resumeDeliveries(jobIds);
 	}
 
 	/**
@@ -1804,20 +1861,20 @@ export class AgentSession {
 	 * stop-time passes (todo reminder, session_stop hooks) defer to the settle
 	 * reached once the session is fully idle. Suppressed deliveries
 	 * (acknowledged, or watched by an in-flight `hub` wait) never wake the loop,
-	 * so they don't count.
+	 * so they don't count. Passive wait-only jobs also do not count until they
+	 * finish and enqueue a delivery.
 	 */
 	#hasPendingAsyncWake(): boolean {
 		const manager = this.#asyncJobManager;
 		if (!manager) return false;
 		const ownerFilter = this.#agentId ? { ownerId: this.#agentId } : undefined;
 		return (
-			manager.getRunningJobs(ownerFilter).some(job => !manager.isDeliverySuppressed(job.id)) ||
+			manager.getRunningJobs(ownerFilter).some(job => !job.passive && !manager.isDeliverySuppressed(job.id)) ||
 			manager.hasPendingDeliveries(ownerFilter) ||
 			// Delivered but not yet injected: the sink has enqueued the
 			// async-result follow-up on the yield queue, and the manager no
 			// longer reports it. Without this leg a terminal yield in the
-			// (idle-flush delay / step-boundary) handoff window would read as
-			// quiescent and the run driver would drop the queued result.
+			// handoff window would read as quiescent and drop the queued result.
 			this.yieldQueue.has(ASYNC_RESULT_MESSAGE_TYPE)
 		);
 	}
@@ -1854,10 +1911,13 @@ export class AgentSession {
 	 * (spilling oversized output to an artifact) and enqueue it as an
 	 * async-result follow-up on the yield queue. The queue's idle flush starts
 	 * the follow-up turn when the session is between turns.
+	 *
+	 * Public for ToolSession's per-job wakeup callback, which must remain bound
+	 * to this exact session if another session later takes over the same agent id.
 	 */
-	async #deliverAsyncJobResult(manager: AsyncJobManager, jobId: string, text: string, job?: AsyncJob): Promise<void> {
-		if (this.#isDisposed) return;
-		if (manager.isDeliverySuppressed(jobId)) return;
+	async deliverAsyncJobResult(jobId: string, text: string, job?: AsyncJob): Promise<void> {
+		const manager = this.#asyncJobManager;
+		if (!manager || this.#isDisposed || manager.isDeliverySuppressed(jobId)) return;
 		// Snapshot the generation before the async format step: a `/new` during it
 		// bumps the epoch, so this delivery belongs to the replaced session and
 		// must not enqueue — the suppression marker alone is unreliable because
@@ -3712,6 +3772,7 @@ export class AgentSession {
 		this.#detachUsageBeforeModelCall?.();
 		this.#detachUsageBeforeModelCall = undefined;
 		this.#memory.cancelLocalMemoryStartup();
+		this.#cancelOwnWakeups();
 		this.#titleGenerationAbortController.abort();
 		this.#abortAutolearnCapture();
 		this.#irc.flushPending();
@@ -6388,27 +6449,29 @@ export class AgentSession {
 		this.#assertVibeSessionTransitionAllowed("start a new session");
 		const previousSessionFile = this.sessionFile;
 
-		// Emit session_before_switch event with reason "new" (can be cancelled)
-		if (this.#extensionRunner?.hasHandlers("session_before_switch")) {
-			const result = (await this.#extensionRunner.emit({
-				type: "session_before_switch",
-				reason: "new",
-			})) as SessionBeforeSwitchResult | undefined;
-
-			if (result?.cancel) {
-				return false;
-			}
-		}
-
-		this.#disconnectFromAgent();
+		const suppressedWakeupIds = this.#suppressOwnWakeups();
 		let advisorRecordersDetached = false;
-		await this.abort();
-		this.#cancelOwnAsyncJobs();
-		this.#closeAllProviderSessions("new session");
-		await this.#bash.flushPending();
-		const bashTransition = this.#bash.beginSessionTransition({ persistDetached: options?.drop !== true });
 		let sessionTransitioned = false;
 		try {
+			// Emit session_before_switch event with reason "new" (can be cancelled)
+			if (this.#extensionRunner?.hasHandlers("session_before_switch")) {
+				const result = (await this.#extensionRunner.emit({
+					type: "session_before_switch",
+					reason: "new",
+				})) as SessionBeforeSwitchResult | undefined;
+
+				if (result?.cancel) {
+					this.#restoreOwnWakeups(suppressedWakeupIds);
+					return false;
+				}
+			}
+
+			this.#disconnectFromAgent();
+			await this.abort();
+			this.#cancelOwnAsyncJobs();
+			this.#closeAllProviderSessions("new session");
+			await this.#bash.flushPending();
+			const bashTransition = this.#bash.beginSessionTransition({ persistDetached: options?.drop !== true });
 			advisorRecordersDetached = true;
 			await this.#advisors.drainAndDetachRecorders();
 			try {
@@ -6435,6 +6498,9 @@ export class AgentSession {
 			} finally {
 				this.#bash.finishSessionTransition(bashTransition, sessionTransitioned);
 			}
+			// Committed: the old conversation is gone, so its pending wakeup timers
+			// are cancelled for good.
+			this.#cancelOwnWakeups();
 
 			this.#clearSessionScopedToolState();
 			this.#clearCheckpointRuntimeState();
@@ -6472,6 +6538,10 @@ export class AgentSession {
 			}
 
 			return true;
+		} catch (error) {
+			if (sessionTransitioned) this.#cancelOwnWakeups();
+			else this.#restoreOwnWakeups(suppressedWakeupIds);
+			throw error;
 		} finally {
 			if (advisorRecordersDetached) {
 				if (sessionTransitioned) this.#advisors.resetSessionState();
@@ -7434,26 +7504,37 @@ export class AgentSession {
 		const switchingToDifferentSession = previousSessionFile
 			? path.resolve(previousSessionFile) !== path.resolve(sessionPath)
 			: true;
+		// Suppress this session's wakeup deliveries before the hook/abort/flush
+		// awaits below: a wakeup expiring inside that window must not start a
+		// turn in the conversation being replaced. Same-session reloads are not a
+		// replacement, so their wakeups keep delivering. Restored on hook veto or
+		// rollback; cancelled once the switch succeeds.
+		const suppressedWakeupIds = switchingToDifferentSession ? this.#suppressOwnWakeups() : [];
 		// Emit session_before_switch event (can be cancelled)
-		if (this.#extensionRunner?.hasHandlers("session_before_switch")) {
-			const result = (await this.#extensionRunner.emit({
-				type: "session_before_switch",
-				reason: "resume",
-				targetSessionFile: sessionPath,
-			})) as SessionBeforeSwitchResult | undefined;
+		try {
+			if (this.#extensionRunner?.hasHandlers("session_before_switch")) {
+				const result = (await this.#extensionRunner.emit({
+					type: "session_before_switch",
+					reason: "resume",
+					targetSessionFile: sessionPath,
+				})) as SessionBeforeSwitchResult | undefined;
 
-			if (result?.cancel) {
-				return false;
+				if (result?.cancel) {
+					this.#restoreOwnWakeups(suppressedWakeupIds);
+					return false;
+				}
 			}
+
+			this.#disconnectFromAgent();
+			await this.abort({ goalReason: "internal" });
+			await this.#sessionBeforeSwitchReconciler?.();
+			await this.#bash.flushPending();
+			// Flush pending writes before switching so restore snapshots reflect committed state.
+			await this.sessionManager.flush();
+		} catch (error) {
+			this.#restoreOwnWakeups(suppressedWakeupIds);
+			throw error;
 		}
-
-		this.#disconnectFromAgent();
-		await this.abort({ goalReason: "internal" });
-		await this.#sessionBeforeSwitchReconciler?.();
-
-		await this.#bash.flushPending();
-		// Flush pending writes before switching so restore snapshots reflect committed state.
-		await this.sessionManager.flush();
 		const previousSessionState = this.sessionManager.captureState();
 		const bashTransition = this.#bash.beginSessionTransition();
 		// Only same-session reloads compare against the prior context to detect
@@ -7652,6 +7733,7 @@ export class AgentSession {
 			// of restarting at zero.
 			if (switchingToDifferentSession) {
 				this.#advisors.restoreCost(await loadAdvisorTranscriptCosts(this.sessionFile));
+				this.#cancelOwnWakeups();
 			}
 			this.#bash.finishSessionTransition(bashTransition, true);
 			if (previousSessionState.sessionId !== this.sessionManager.getSessionId()) {
@@ -7714,6 +7796,7 @@ export class AgentSession {
 					error: String(reconcileError),
 				});
 			}
+			this.#restoreOwnWakeups(suppressedWakeupIds);
 			this.#bash.finishSessionTransition(bashTransition, false);
 			throw error;
 		}
@@ -7743,39 +7826,39 @@ export class AgentSession {
 
 		const selectedText = this.#extractUserMessageText(selectedEntry.message.content);
 		const selectedImages = this.#extractUserMessageImages(selectedEntry.message.content);
-
+		const suppressedWakeupIds = this.#suppressOwnWakeups();
 		let skipConversationRestore = false;
-
-		// Emit session_before_branch event (can be cancelled)
-		if (this.#extensionRunner?.hasHandlers("session_before_branch")) {
-			const result = (await this.#extensionRunner.emit({
-				type: "session_before_branch",
-				entryId,
-			})) as SessionBeforeBranchResult | undefined;
-
-			if (result?.cancel) {
-				return { selectedText, selectedImages, cancelled: true };
-			}
-			skipConversationRestore = result?.skipConversationRestore ?? false;
-		}
-
-		// Clear pending messages (bound to old session state)
-		this.#pendingNextTurnMessages = [];
-		this.#scheduledHiddenNextTurnGeneration = undefined;
-		this.#queuedMessageDrainBlocked = false;
-		this.#usagePreflightReadyForNextModelCall = false;
-
-		await this.#bash.flushPending();
-		// Flush pending writes before branching
-		await this.sessionManager.flush();
-		const bashTransition = this.#bash.beginSessionTransition();
-		this.#cancelOwnAsyncJobs();
-		this.#abortAutolearnCapture();
-		await this.#drainAutolearnCapture();
 
 		let sessionTransitioned = false;
 		let advisorRecordersDetached = false;
 		try {
+			// Emit session_before_branch event (can be cancelled)
+			if (this.#extensionRunner?.hasHandlers("session_before_branch")) {
+				const result = (await this.#extensionRunner.emit({
+					type: "session_before_branch",
+					entryId,
+				})) as SessionBeforeBranchResult | undefined;
+
+				if (result?.cancel) {
+					this.#restoreOwnWakeups(suppressedWakeupIds);
+					return { selectedText, selectedImages, cancelled: true };
+				}
+				skipConversationRestore = result?.skipConversationRestore ?? false;
+			}
+			// Clear pending messages (bound to old session state)
+			this.#pendingNextTurnMessages = [];
+			this.#scheduledHiddenNextTurnGeneration = undefined;
+			this.#queuedMessageDrainBlocked = false;
+			this.#usagePreflightReadyForNextModelCall = false;
+
+			await this.#bash.flushPending();
+			// Flush pending writes before branching
+			await this.sessionManager.flush();
+			const bashTransition = this.#bash.beginSessionTransition();
+			this.#cancelOwnAsyncJobs();
+			this.#abortAutolearnCapture();
+			await this.#drainAutolearnCapture();
+
 			advisorRecordersDetached = true;
 			await this.#advisors.drainAndDetachRecorders();
 			try {
@@ -7793,6 +7876,7 @@ export class AgentSession {
 			} finally {
 				this.#bash.finishSessionTransition(bashTransition, sessionTransitioned);
 			}
+			this.#cancelOwnWakeups();
 			this.#clearSessionScopedToolState();
 			this.#rehydrateCheckpointRewindState();
 			this.#todo.syncFromBranch();
@@ -7822,6 +7906,10 @@ export class AgentSession {
 			this.#advisors.reattachRecorderFeeds();
 			advisorRecordersDetached = false;
 			return { selectedText, selectedImages, cancelled: false };
+		} catch (error) {
+			if (sessionTransitioned) this.#cancelOwnWakeups();
+			else this.#restoreOwnWakeups(suppressedWakeupIds);
+			throw error;
 		} finally {
 			if (advisorRecordersDetached) {
 				if (sessionTransitioned) this.#advisors.resetSessionState();
@@ -7857,52 +7945,57 @@ export class AgentSession {
 			throw new Error("Cannot branch /btw while session maintenance or user work is still running");
 		}
 
-		if (this.#extensionRunner?.hasHandlers("session_before_branch")) {
-			const result = (await this.#extensionRunner.emit({
-				type: "session_before_branch",
-				entryId: leafId,
-			})) as SessionBeforeBranchResult | undefined;
-
-			if (result?.cancel) {
-				return { cancelled: true, sessionFile: previousSessionFile };
-			}
-		}
-
-		if (this.sessionManager.getSessionId() !== sessionId || this.sessionManager.getLeafId() !== leafId) {
-			throw new Error("Cannot branch /btw: session changed since /btw started");
-		}
-
-		await withTimeout(
-			this.#cancelPostPromptTasks(),
-			POST_PROMPT_DRAIN_TIMEOUT_MS,
-			"Timed out draining post-prompt tasks before /btw branch",
-		);
-		if (
-			this.isStreaming ||
-			this.isBashRunning ||
-			this.isEvalRunning ||
-			this.isCompacting ||
-			this.isGeneratingHandoff ||
-			this.isRetrying
-		) {
-			throw new Error("Cannot branch /btw while session maintenance or user work is still running");
-		}
-
-		this.#pendingNextTurnMessages = [];
-		this.#scheduledHiddenNextTurnGeneration = undefined;
-		this.agent.replaceQueues([], []);
-		this.#queuedMessageDrainBlocked = false;
-		this.#usagePreflightReadyForNextModelCall = false;
-		await this.#bash.flushPending();
-		await this.sessionManager.flush();
-		const bashTransition = this.#bash.beginSessionTransition();
-		this.#cancelOwnAsyncJobs();
-		this.#abortAutolearnCapture();
-		await this.#drainAutolearnCapture();
-
+		const suppressedWakeupIds = this.#suppressOwnWakeups();
 		let sessionTransitioned = false;
 		let advisorRecordersDetached = false;
 		try {
+			if (this.#extensionRunner?.hasHandlers("session_before_branch")) {
+				const result = (await this.#extensionRunner.emit({
+					type: "session_before_branch",
+					entryId: leafId,
+				})) as SessionBeforeBranchResult | undefined;
+
+				if (result?.cancel) {
+					this.#restoreOwnWakeups(suppressedWakeupIds);
+					return { cancelled: true, sessionFile: previousSessionFile };
+				}
+			}
+
+			if (this.sessionManager.getSessionId() !== sessionId || this.sessionManager.getLeafId() !== leafId) {
+				throw new Error("Cannot branch /btw: session changed since /btw started");
+			}
+
+			await withTimeout(
+				this.#cancelPostPromptTasks(),
+				POST_PROMPT_DRAIN_TIMEOUT_MS,
+				"Timed out draining post-prompt tasks before /btw branch",
+			);
+			if (
+				this.isBashRunning ||
+				this.isEvalRunning ||
+				this.isCompacting ||
+				this.isGeneratingHandoff ||
+				this.isRetrying
+			) {
+				throw new Error("Cannot branch /btw while session maintenance or user work is still running");
+			}
+
+			this.#pendingNextTurnMessages = [];
+			this.#scheduledHiddenNextTurnGeneration = undefined;
+			this.agent.replaceQueues([], []);
+			this.#queuedMessageDrainBlocked = false;
+			this.#usagePreflightReadyForNextModelCall = false;
+			if (this.isStreaming) {
+				await this.abort({ goalReason: "internal", reason: "branching /btw" });
+				this.agent.replaceQueues([], []);
+			}
+			await this.#bash.flushPending();
+			await this.sessionManager.flush();
+			const bashTransition = this.#bash.beginSessionTransition();
+			this.#cancelOwnAsyncJobs();
+			this.#abortAutolearnCapture();
+			await this.#drainAutolearnCapture();
+
 			advisorRecordersDetached = true;
 			await this.#advisors.drainAndDetachRecorders();
 			try {
@@ -7916,9 +8009,8 @@ export class AgentSession {
 			} finally {
 				this.#bash.finishSessionTransition(bashTransition, sessionTransitioned);
 			}
-
+			this.#cancelOwnWakeups();
 			this.#clearSessionScopedToolState();
-
 			this.#rehydrateCheckpointRewindState();
 			this.sessionManager.appendMessage({
 				role: "user",
@@ -7947,6 +8039,10 @@ export class AgentSession {
 			advisorRecordersDetached = false;
 
 			return { cancelled: false, sessionFile: this.sessionFile };
+		} catch (error) {
+			if (sessionTransitioned) this.#cancelOwnWakeups();
+			else this.#restoreOwnWakeups(suppressedWakeupIds);
+			throw error;
 		} finally {
 			if (advisorRecordersDetached) {
 				if (sessionTransitioned) this.#advisors.resetSessionState();

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1856,7 +1856,10 @@ export class AgentSession {
 	#restoreOwnWakeups(suppressed: SuppressedWakeups): void {
 		this.#asyncJobManager?.resumeDeliveries(suppressed.jobIds);
 		for (const entry of suppressed.queuedEntries) {
-			this.yieldQueue.enqueue(ASYNC_RESULT_MESSAGE_TYPE, entry);
+			this.yieldQueue.enqueue(ASYNC_RESULT_MESSAGE_TYPE, {
+				...entry,
+				epoch: this.#asyncDeliveryEpoch,
+			});
 		}
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1855,12 +1855,10 @@ export class AgentSession {
 	/** Restore wakeups suppressed by a replacement transition that did not commit. */
 	#restoreOwnWakeups(suppressed: SuppressedWakeups): void {
 		this.#asyncJobManager?.resumeDeliveries(suppressed.jobIds);
-		for (const entry of suppressed.queuedEntries) {
-			this.yieldQueue.enqueue(ASYNC_RESULT_MESSAGE_TYPE, {
-				...entry,
-				epoch: this.#asyncDeliveryEpoch,
-			});
-		}
+		this.yieldQueue.restore(
+			ASYNC_RESULT_MESSAGE_TYPE,
+			suppressed.queuedEntries.map(entry => ({ ...entry, epoch: this.#asyncDeliveryEpoch })),
+		);
 	}
 
 	/**
@@ -7516,12 +7514,10 @@ export class AgentSession {
 			: true;
 		// Suppress this session's wakeup deliveries before the hook/abort/flush
 		// awaits below: a wakeup expiring inside that window must not start a
-		// turn in the conversation being replaced. Same-session reloads are not a
-		// replacement, so their wakeups keep delivering. Restored on hook veto or
-		// rollback; cancelled once the switch succeeds.
-		const suppressedWakeupIds = switchingToDifferentSession
-			? this.#suppressOwnWakeups()
-			: { jobIds: [], queuedEntries: [] };
+		// turn while either a replacement or same-session reload is rebuilding
+		// session state. Restored on hook veto, rollback, or a successful reload;
+		// cancelled only once a different-session switch succeeds.
+		const suppressedWakeupIds = this.#suppressOwnWakeups();
 		// Emit session_before_switch event (can be cancelled)
 		try {
 			if (this.#extensionRunner?.hasHandlers("session_before_switch")) {
@@ -7746,6 +7742,8 @@ export class AgentSession {
 			if (switchingToDifferentSession) {
 				this.#advisors.restoreCost(await loadAdvisorTranscriptCosts(this.sessionFile));
 				this.#cancelOwnWakeups();
+			} else {
+				this.#restoreOwnWakeups(suppressedWakeupIds);
 			}
 			this.#bash.finishSessionTransition(bashTransition, true);
 			if (previousSessionState.sessionId !== this.sessionManager.getSessionId()) {

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -41,7 +41,7 @@ export interface AsyncResultEntry {
 
 type AsyncResultJobDetails = {
 	jobId: string;
-	type?: "bash" | "task";
+	type?: "bash" | "task" | "wakeup";
 	label?: string;
 	durationMs?: number;
 };

--- a/packages/coding-agent/src/session/async-job-delivery.ts
+++ b/packages/coding-agent/src/session/async-job-delivery.ts
@@ -39,6 +39,11 @@ export interface AsyncResultEntry {
 	epoch: number;
 }
 
+export interface SuppressedWakeups {
+	jobIds: string[];
+	queuedEntries: AsyncResultEntry[];
+}
+
 type AsyncResultJobDetails = {
 	jobId: string;
 	type?: "bash" | "task" | "wakeup";

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -17,6 +17,7 @@ import type { ExtensionRunner, SessionBeforeSwitchResult } from "../extensibilit
 import { obfuscateProviderContext } from "../secrets/message-transform";
 import type { SecretObfuscator } from "../secrets/obfuscator";
 import type { HandoffResult, SessionHandoffOptions } from "./agent-session-types";
+import type { SuppressedWakeups } from "./async-job-delivery";
 import type { BashSessionTransition } from "./bash-runner";
 import type { SessionContext } from "./session-context";
 import type { SessionManager } from "./session-manager";
@@ -67,8 +68,8 @@ export interface SessionHandoffHost {
 	markBashSessionTransition(transition: BashSessionTransition): void;
 	finishBashSessionTransition(transition: BashSessionTransition, success: boolean): void;
 	cancelOwnAsyncJobs(): void;
-	suppressOwnWakeups(): string[];
-	restoreOwnWakeups(jobIds: string[]): void;
+	suppressOwnWakeups(): SuppressedWakeups;
+	restoreOwnWakeups(suppressed: SuppressedWakeups): void;
 	cancelOwnWakeups(): void;
 	clearCheckpointRuntimeState(): void;
 	clearSessionScopedToolState(): void;

--- a/packages/coding-agent/src/session/session-handoff.ts
+++ b/packages/coding-agent/src/session/session-handoff.ts
@@ -67,6 +67,9 @@ export interface SessionHandoffHost {
 	markBashSessionTransition(transition: BashSessionTransition): void;
 	finishBashSessionTransition(transition: BashSessionTransition, success: boolean): void;
 	cancelOwnAsyncJobs(): void;
+	suppressOwnWakeups(): string[];
+	restoreOwnWakeups(jobIds: string[]): void;
+	cancelOwnWakeups(): void;
 	clearCheckpointRuntimeState(): void;
 	clearSessionScopedToolState(): void;
 	clearFreshProviderSessionId(): void;
@@ -140,6 +143,7 @@ export class SessionHandoff {
 		}
 
 		let advisorRecordersDetached = false;
+		const suppressedWakeupIds = this.#host.suppressOwnWakeups();
 		let sessionTransitioned = false;
 		try {
 			throwIfHandoffAborted(handoffSignal);
@@ -246,6 +250,7 @@ export class SessionHandoff {
 
 				if (result?.cancel) {
 					options?.onSwitchCancelled?.();
+					this.#host.restoreOwnWakeups(suppressedWakeupIds);
 					return undefined;
 				}
 			}
@@ -270,6 +275,7 @@ export class SessionHandoff {
 			} finally {
 				this.#host.finishBashSessionTransition(bashTransition, sessionTransitioned);
 			}
+			this.#host.cancelOwnWakeups();
 
 			this.#host.clearSessionScopedToolState();
 
@@ -331,6 +337,8 @@ export class SessionHandoff {
 
 			return { document: handoffText, savedPath };
 		} catch (error) {
+			if (sessionTransitioned) this.#host.cancelOwnWakeups();
+			else this.#host.restoreOwnWakeups(suppressedWakeupIds);
 			// Only a genuine cancellation (user Esc or an unreasoned source-signal
 			// abort) maps to "Handoff cancelled". A harness-provided abort reason and
 			// provider failures surface verbatim.

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -117,14 +117,29 @@ export class YieldQueue {
 		const entries = this.#entries.get(kind);
 		if (!entries || entries.length === 0) return [];
 		const taken: P[] = [];
-		const retained: unknown[] = [];
+		const retained: StoredEntry[] = [];
 		for (const entry of entries) {
-			if (predicate(entry as P)) taken.push(entry as P);
+			if (predicate(entry.value as P)) taken.push(entry.value as P);
 			else retained.push(entry);
 		}
 		if (retained.length > 0) this.#entries.set(kind, retained);
 		else this.#entries.delete(kind);
 		return taken;
+	}
+
+	/** Restore entries previously removed by {@link take} without replaying enqueue observers. */
+	restore<P>(kind: string, restored: readonly P[]): void {
+		if (restored.length === 0 || !this.#dispatchers.has(kind)) return;
+		const entries = this.#entries.get(kind);
+		if (entries) entries.push(...restored.map(value => ({ value })));
+		else
+			this.#entries.set(
+				kind,
+				restored.map(value => ({ value })),
+			);
+		if (!this.#options.isStreaming() && !this.#dispatchers.get(kind)!.skipIdleFlush) {
+			this.#scheduleIdleFlush();
+		}
 	}
 
 	async flush(mode: YieldFlushMode): Promise<void> {

--- a/packages/coding-agent/src/session/yield-queue.ts
+++ b/packages/coding-agent/src/session/yield-queue.ts
@@ -112,6 +112,21 @@ export class YieldQueue {
 		}
 	}
 
+	/** Remove and return entries matching a predicate while preserving the rest. */
+	take<P>(kind: string, predicate: (entry: P) => boolean): P[] {
+		const entries = this.#entries.get(kind);
+		if (!entries || entries.length === 0) return [];
+		const taken: P[] = [];
+		const retained: unknown[] = [];
+		for (const entry of entries) {
+			if (predicate(entry as P)) taken.push(entry as P);
+			else retained.push(entry);
+		}
+		if (retained.length > 0) this.#entries.set(kind, retained);
+		else this.#entries.delete(kind);
+		return taken;
+	}
+
 	async flush(mode: YieldFlushMode): Promise<void> {
 		if (mode === "idle") {
 			this.#idleFlushPending = false;

--- a/packages/coding-agent/src/tools/builtin-names.ts
+++ b/packages/coding-agent/src/tools/builtin-names.ts
@@ -20,6 +20,7 @@ export const BUILTIN_TOOL_NAMES = [
 	"task",
 	"hub",
 	"todo",
+	"wakeup",
 	"web_search",
 	"write",
 	"memory_edit",

--- a/packages/coding-agent/src/tools/essential-tools.ts
+++ b/packages/coding-agent/src/tools/essential-tools.ts
@@ -30,6 +30,7 @@ export const ESSENTIAL_BUILTIN_TOOL_NAMES: Record<string, true> = {
 	eval: true,
 	task: true,
 	hub: true,
+	wakeup: true,
 	learn: true,
 	manage_skill: true,
 };

--- a/packages/coding-agent/src/tools/hub/jobs.ts
+++ b/packages/coding-agent/src/tools/hub/jobs.ts
@@ -132,7 +132,7 @@ function describeAgents(agents: AgentActivitySnapshot[]): string[] {
 
 interface TrackedJobLike {
 	id: string;
-	type: "bash" | "task";
+	type: "bash" | "task" | "wakeup";
 	status: string;
 	label: string;
 	startTime: number;

--- a/packages/coding-agent/src/tools/hub/types.ts
+++ b/packages/coding-agent/src/tools/hub/types.ts
@@ -42,7 +42,7 @@ export interface HubPeerInfo {
 /** Background-job row surfaced by `wait`/`cancel`/`jobs` results. */
 export interface JobSnapshot {
 	id: string;
-	type: "bash" | "task";
+	type: "bash" | "task" | "wakeup";
 	status: "running" | "completed" | "failed" | "cancelled";
 	label: string;
 	durationMs: number;

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -2,7 +2,7 @@ import type { Clipboard, InMemorySnapshotStore } from "@oh-my-pi/hashline";
 import type { AgentOptions, AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
 import type { FetchImpl, ImageContent, Model, ServiceTierByFamily, ToolChoice } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
-import type { AsyncJobManager } from "../async/job-manager";
+import type { AsyncJobDeliverySink, AsyncJobManager } from "../async/job-manager";
 import type { Rule } from "../capability/rule";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings } from "../config/settings";
@@ -63,6 +63,7 @@ import { ReadTool } from "./read";
 import type { PlanProposalHandler } from "./resolve";
 import { SecurityScanTool } from "./security-scan";
 import { type TodoPhase, TodoTool } from "./todo";
+import { WakeupTool } from "./wakeup";
 import { WriteTool } from "./write";
 import { isMountableUnderXdev, type XdevState } from "./xdev";
 import { YieldTool } from "./yield";
@@ -105,6 +106,7 @@ export * from "./security-scan";
 export * from "./todo";
 export * from "./tts";
 export * from "./vibe";
+export * from "./wakeup";
 export * from "./write";
 export * from "./xdev";
 export * from "./yield";
@@ -247,6 +249,8 @@ export interface ToolSession {
 	getMnemopiSessionState?: () => MnemopiSessionState | undefined;
 	/** Agent identity used for IRC routing. Returns the registry id (e.g. "Main", "AuthLoader"). */
 	getAgentId?: () => string | null;
+	/** Deliver a completed async job to this exact session rather than whichever session currently owns its registry id. */
+	deliverAsyncResult?: AsyncJobDeliverySink;
 	/** Look up a registered tool by name (used by the eval js backend's tool bridge). */
 	getToolByName?: (name: string) => AgentTool | undefined;
 	/** Return whether a built-in tool is active in this turn's tool set. */
@@ -433,6 +437,7 @@ export const BUILTIN_TOOLS: Record<BuiltinToolName, ToolFactory> = {
 	task: s => TaskTool.create(s),
 	hub: s => new HubTool(s),
 	todo: s => new TodoTool(s),
+	wakeup: WakeupTool.createIf,
 	web_search: s => new WebSearchTool(s),
 	write: s => new WriteTool(s),
 	memory_edit: MemoryEditTool.createIf,

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -229,6 +229,8 @@ export interface ToolSession {
 	restrictToolNames?: boolean;
 	/** Task recursion depth (0 = top-level, 1 = first child, etc.) */
 	taskDepth?: number;
+	/** Artifact/output-id prefix assigned to disposable subagent sessions, including `/tan` clones. */
+	parentTaskPrefix?: string;
 	/** Get shared eval executor session ID. Subagents inherit this to share JS/Python/Ruby/Julia state. */
 	getEvalSessionId?: () => string | null;
 	/** Get session file */

--- a/packages/coding-agent/src/tools/wakeup.ts
+++ b/packages/coding-agent/src/tools/wakeup.ts
@@ -1,6 +1,7 @@
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { ToolExample } from "@oh-my-pi/pi-ai";
-import { abortableSleep, prompt } from "@oh-my-pi/pi-utils";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { abortableSleep } from "@oh-my-pi/pi-utils/abortable";
 import { type } from "arktype";
 import wakeupDescription from "../prompts/tools/wakeup.md" with { type: "text" };
 import wakeupFiredTemplate from "../prompts/tools/wakeup-fired.md" with { type: "text" };
@@ -77,9 +78,12 @@ export class WakeupTool implements AgentTool<typeof wakeupSchema, WakeupDetails>
 	constructor(private readonly session: ToolSession) {}
 
 	static createIf(session: ToolSession): WakeupTool | null {
-		// Task/eval subagents are reaped when their assignment settles, so they
-		// cannot truthfully promise a delayed turn after yielding.
-		return session.asyncJobManager && (session.taskDepth ?? 0) === 0 ? new WakeupTool(session) : null;
+		// Disposable sessions are reaped when their assignment settles, so they
+		// cannot truthfully promise a delayed turn after yielding. `/tan` clones
+		// use parentTaskPrefix while keeping taskDepth at zero.
+		return session.asyncJobManager && (session.taskDepth ?? 0) === 0 && !session.parentTaskPrefix
+			? new WakeupTool(session)
+			: null;
 	}
 
 	async execute(

--- a/packages/coding-agent/src/tools/wakeup.ts
+++ b/packages/coding-agent/src/tools/wakeup.ts
@@ -1,6 +1,6 @@
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { ToolExample } from "@oh-my-pi/pi-ai";
-import { prompt } from "@oh-my-pi/pi-utils";
+import { abortableSleep, prompt } from "@oh-my-pi/pi-utils";
 import { type } from "arktype";
 import wakeupDescription from "../prompts/tools/wakeup.md" with { type: "text" };
 import wakeupFiredTemplate from "../prompts/tools/wakeup-fired.md" with { type: "text" };
@@ -30,24 +30,11 @@ export interface WakeupDetails {
 }
 
 async function waitForDelay(delayMs: number, signal: AbortSignal): Promise<void> {
-	const { promise, resolve, reject } = Promise.withResolvers<void>();
-	const timer: NodeJS.Timeout = setTimeout(resolve, delayMs);
-	const abort = (): void => {
-		clearTimeout(timer);
-		reject(new ToolAbortError());
-	};
-
-	if (signal.aborted) {
-		abort();
-	} else {
-		signal.addEventListener("abort", abort, { once: true });
-	}
-
 	try {
-		await promise;
-	} finally {
-		clearTimeout(timer);
-		signal.removeEventListener("abort", abort);
+		await abortableSleep(delayMs, signal);
+	} catch (error) {
+		if (signal.aborted) throw new ToolAbortError(undefined, { cause: error });
+		throw error;
 	}
 }
 

--- a/packages/coding-agent/src/tools/wakeup.ts
+++ b/packages/coding-agent/src/tools/wakeup.ts
@@ -1,8 +1,8 @@
+import { type } from "@oh-my-pi/omptype";
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import type { ToolExample } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { abortableSleep } from "@oh-my-pi/pi-utils/abortable";
-import { type } from "arktype";
 import wakeupDescription from "../prompts/tools/wakeup.md" with { type: "text" };
 import wakeupFiredTemplate from "../prompts/tools/wakeup-fired.md" with { type: "text" };
 import wakeupScheduledTemplate from "../prompts/tools/wakeup-scheduled.md" with { type: "text" };

--- a/packages/coding-agent/src/tools/wakeup.ts
+++ b/packages/coding-agent/src/tools/wakeup.ts
@@ -1,0 +1,148 @@
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import type { ToolExample } from "@oh-my-pi/pi-ai";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+import wakeupDescription from "../prompts/tools/wakeup.md" with { type: "text" };
+import wakeupFiredTemplate from "../prompts/tools/wakeup-fired.md" with { type: "text" };
+import wakeupScheduledTemplate from "../prompts/tools/wakeup-scheduled.md" with { type: "text" };
+import type { ToolSession } from ".";
+import type { OutputMeta } from "./output-meta";
+import { previewLine, TRUNCATE_LENGTHS } from "./render-utils";
+import { ToolAbortError, ToolError, throwIfAborted } from "./tool-errors";
+import { toolResult } from "./tool-result";
+
+const MIN_DELAY_SECONDS = 1;
+const MAX_DELAY_SECONDS = 86_400;
+
+const wakeupSchema = type({
+	delaySeconds: type("number.integer").describe("delay before waking, from 1 to 86400 seconds"),
+	prompt: type("string").describe("instruction to resume with when the delay elapses"),
+});
+
+export type WakeupParams = typeof wakeupSchema.infer;
+
+export interface WakeupDetails {
+	jobId: string;
+	delaySeconds: number;
+	scheduledAt: string;
+	prompt: string;
+	meta?: OutputMeta;
+}
+
+async function waitForDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	const timer: NodeJS.Timeout = setTimeout(resolve, delayMs);
+	const abort = (): void => {
+		clearTimeout(timer);
+		reject(new ToolAbortError());
+	};
+
+	if (signal.aborted) {
+		abort();
+	} else {
+		signal.addEventListener("abort", abort, { once: true });
+	}
+
+	try {
+		await promise;
+	} finally {
+		clearTimeout(timer);
+		signal.removeEventListener("abort", abort);
+	}
+}
+
+/** Session-owned, one-shot delayed wakeup delivered through AsyncJobManager. */
+export class WakeupTool implements AgentTool<typeof wakeupSchema, WakeupDetails> {
+	readonly name = "wakeup";
+	readonly approval = "exec" as const;
+	readonly label = "Wakeup";
+	readonly summary = "Schedule a one-shot future wakeup for this agent";
+	readonly description = prompt.render(wakeupDescription);
+	readonly parameters = wakeupSchema;
+	readonly strict = true;
+	readonly loadMode = "essential" as const;
+	readonly intent = (args: Partial<WakeupParams>) =>
+		typeof args.delaySeconds === "number" ? `waking in ${args.delaySeconds}s` : "scheduling wakeup";
+	readonly formatApprovalDetails = (args: unknown): string[] => {
+		const params = args as Partial<WakeupParams>;
+		const lines = [`Delay: ${params.delaySeconds ?? "(missing)"} seconds`];
+		if (typeof params.prompt === "string") {
+			lines.push(`Prompt: ${previewLine(params.prompt, TRUNCATE_LENGTHS.CONTENT)}`);
+		}
+		return lines;
+	};
+
+	readonly examples: readonly ToolExample<WakeupParams>[] = [
+		{
+			caption: "Retry a check in ten minutes",
+			call: { delaySeconds: 600, prompt: "Check CI again and report any remaining failures." },
+		},
+		{
+			caption: "Continue a self-paced polling loop",
+			call: {
+				delaySeconds: 300,
+				prompt:
+					"Check the deployment. If it is still pending, schedule another wakeup; otherwise report the result.",
+			},
+		},
+	];
+
+	constructor(private readonly session: ToolSession) {}
+
+	static createIf(session: ToolSession): WakeupTool | null {
+		// Task/eval subagents are reaped when their assignment settles, so they
+		// cannot truthfully promise a delayed turn after yielding.
+		return session.asyncJobManager && (session.taskDepth ?? 0) === 0 ? new WakeupTool(session) : null;
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: WakeupParams,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<WakeupDetails>> {
+		throwIfAborted(signal);
+		if (params.delaySeconds < MIN_DELAY_SECONDS || params.delaySeconds > MAX_DELAY_SECONDS) {
+			throw new ToolError(`delaySeconds must be between ${MIN_DELAY_SECONDS} and ${MAX_DELAY_SECONDS}, inclusive.`);
+		}
+		if (params.prompt.trim().length === 0) {
+			throw new ToolError("prompt must not be empty.");
+		}
+
+		const manager = this.session.asyncJobManager;
+		if (!manager) throw new ToolError("Wakeups are unavailable in this session.");
+
+		const scheduledAt = new Date(Date.now() + params.delaySeconds * 1_000).toISOString();
+		const jobId = manager.register(
+			"wakeup",
+			`Wakeup at ${scheduledAt}`,
+			async ({ signal: jobSignal }) => {
+				await waitForDelay(params.delaySeconds * 1_000, jobSignal);
+				return prompt.render(wakeupFiredTemplate, {
+					instruction: params.prompt,
+					scheduledAt,
+				});
+			},
+			{
+				ownerId: this.session.getAgentId?.() ?? undefined,
+				onComplete: this.session.deliverAsyncResult,
+				passive: true,
+			},
+		);
+
+		const details: WakeupDetails = {
+			jobId,
+			delaySeconds: params.delaySeconds,
+			scheduledAt,
+			prompt: params.prompt,
+		};
+		return toolResult<WakeupDetails>(details)
+			.text(
+				prompt.render(wakeupScheduledTemplate, {
+					delaySeconds: params.delaySeconds,
+					jobId,
+					scheduledAt,
+				}),
+			)
+			.done();
+	}
+}

--- a/packages/coding-agent/test/agent-session-async-delivery.test.ts
+++ b/packages/coding-agent/test/agent-session-async-delivery.test.ts
@@ -193,7 +193,12 @@ describe("AgentSession owner-routed async delivery", () => {
 			id: "other-session-job",
 			ownerId: "Other",
 		});
-		manager.watchJobs([completedJobId, failedJobId, otherOwnerJobId]);
+		const wakeupJobId = manager.register("wakeup", "prior session wakeup", async () => "wake up", {
+			id: "prior-session-wakeup",
+			ownerId: "Main",
+			passive: true,
+		});
+		manager.watchJobs([completedJobId, failedJobId, otherOwnerJobId, wakeupJobId]);
 		await manager.waitForAll();
 
 		expect(manager.getJob(completedJobId)?.status).toBe("completed");
@@ -201,6 +206,7 @@ describe("AgentSession owner-routed async delivery", () => {
 		expect(await session.newSession()).toBe(true);
 		expect(manager.getJob(completedJobId)).toBeUndefined();
 		expect(manager.getJob(failedJobId)).toBeUndefined();
+		expect(manager.getJob(wakeupJobId)?.status).toBe("completed");
 		expect(manager.getJob(otherOwnerJobId)?.status).toBe("completed");
 	});
 

--- a/packages/coding-agent/test/agent-session-todo-reminder-async-jobs.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-reminder-async-jobs.test.ts
@@ -195,6 +195,19 @@ describe("AgentSession todo reminder async-job deferral", () => {
 		expect(agentEndTerminalStates).toEqual([false]);
 	});
 
+	it("does not defer stop-time work for a passive owned wakeup", async () => {
+		setIncompleteTodos();
+		vi.spyOn(session.agent, "continue").mockResolvedValue();
+		const gate = Promise.withResolvers<string>();
+		gates.push(gate);
+		manager.register("wakeup", "future wakeup", async () => await gate.promise, { ownerId: "Main", passive: true });
+
+		emitTextOnlyStop();
+		await withTimeout(firstReminderPromise, 1000, "todo_reminder never fired with passive wakeup");
+
+		expect(reminderAttempts).toEqual([1]);
+	});
+
 	it("does not defer for a running job owned by a different agent", async () => {
 		setIncompleteTodos();
 		vi.spyOn(session.agent, "continue").mockResolvedValue();

--- a/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
+++ b/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
@@ -208,6 +208,23 @@ describe("AgentSession wakeup suppression across session replacement", () => {
 		expect(session.yieldQueue.has("async-result")).toBe(true);
 	});
 
+	it("restamps an already queued wakeup when replacement fails after epoch advance", async () => {
+		const { jobId } = registerGatedWakeup();
+		session.yieldQueue.enqueue("async-result", {
+			jobId,
+			result: "queued wakeup after failed replacement",
+			job: manager.getJob(jobId),
+			durationMs: undefined,
+			epoch: 0,
+		});
+		vi.spyOn(sessionManager, "newSession").mockRejectedValue(new Error("session create failed"));
+
+		await expect(session.newSession()).rejects.toThrow("session create failed");
+
+		const restored = session.yieldQueue.drainLazy().map(build => build());
+		expect(restored.some(message => message !== null)).toBe(true);
+	});
+
 	it("restores and delivers a suppressed wakeup exactly once when the pre-switch hook vetoes", async () => {
 		const { jobId, fire } = registerGatedWakeup();
 		let deliveriesDuringTransition = -1;

--- a/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
+++ b/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import * as compactionModule from "@oh-my-pi/pi-agent-core/compaction";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression coverage for the wakeup / session-replacement timing race:
+ * a wakeup can complete while a replacement transition (newSession, handoff,
+ * switchSession, branch, branchFromBtw) is still awaiting pre-work — handoff
+ * generation, the `session_before_switch` hook, `abort()`, or
+ * `sessionManager.flush()` — before the transition's cancellation point. Its
+ * completion delivery would then enqueue an async-result follow-up and start
+ * a turn in the session being replaced, and that turn survives the reset.
+ *
+ * The contract these tests defend:
+ * 1. Wakeup deliveries are suppressed from the transition's first await
+ *    onward — nothing is delivered into the session *during* the transition.
+ * 2. Wakeup timers are cancelled only once the replacement commits. A hook
+ *    veto, hook emit rejection, or any pre-commit failure leaves the old
+ *    session live with its wakeups intact: a wakeup that completed while
+ *    suppressed is delivered exactly once afterwards, and a still-pending
+ *    timer keeps running and delivers normally later.
+ * 3. Suppression snapshots only deliveries the transition newly owns: a
+ *    wakeup whose delivery already drained is never re-delivered by a
+ *    restore, and suppression owned by someone else (e.g. a `hub`
+ *    acknowledgement) is never lifted.
+ * 4. Ordinary delivery with no transition in flight keeps working.
+ */
+describe("AgentSession wakeup suppression across session replacement", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let manager: AsyncJobManager;
+	let gates: Array<PromiseWithResolvers<string>>;
+	let enqueue: Mock<(kind: string, entry: unknown) => void>;
+	let beforeSwitchHandler: (() => Promise<{ cancel?: boolean } | undefined>) | undefined;
+
+	/** Register a session-owned wakeup that stays pending until fired or cancelled. */
+	function registerGatedWakeup(): { jobId: string; fire: (text: string) => void } {
+		const gate = Promise.withResolvers<string>();
+		gates.push(gate);
+		const jobId = manager.register(
+			"wakeup",
+			"pending wakeup",
+			async ({ signal }) => {
+				signal.addEventListener("abort", () => gate.resolve("cancelled"), { once: true });
+				return await gate.promise;
+			},
+			{
+				ownerId: "Main",
+				passive: true,
+			},
+		);
+		return { jobId, fire: text => gate.resolve(text) };
+	}
+
+	function seedPersistedMessages(): Promise<void> {
+		sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "seed" }], timestamp: Date.now() });
+		sessionManager.appendMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "ack" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			stopReason: "stop",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		});
+		return sessionManager.flush();
+	}
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-wakeup-replacement-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+		sessionManager = SessionManager.create(tempDir.path(), path.join(tempDir.path(), "sessions"));
+		// Mirrors the SDK's completion sink: the manager's delivery loop already
+		// skips suppressed job ids before invoking this handler.
+		manager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				session.yieldQueue.enqueue("async-result", { jobId, result: text });
+			},
+		});
+		gates = [];
+		beforeSwitchHandler = undefined;
+		const extensionRunner = {
+			hasHandlers: vi.fn((eventType: string) => eventType === "session_before_switch" && !!beforeSwitchHandler),
+			emit: vi.fn(async (event: { type: string }) =>
+				event.type === "session_before_switch" && beforeSwitchHandler ? await beforeSwitchHandler() : undefined,
+			),
+			emitBeforeAgentStart: vi.fn().mockResolvedValue(undefined),
+		} as unknown as ExtensionRunner;
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			agentId: "Main",
+			asyncJobManager: manager,
+			extensionRunner,
+		});
+		enqueue = vi.spyOn(session.yieldQueue, "enqueue");
+	});
+
+	afterEach(async () => {
+		for (const gate of gates) gate.resolve("done");
+		await session.dispose();
+		manager.cancelAll();
+		await manager.dispose();
+		authStorage.close();
+		try {
+			await tempDir.remove();
+		} catch {}
+		vi.restoreAllMocks();
+	});
+
+	it("suppresses a wakeup that completes during replacement pre-work, before the cancellation point", async () => {
+		const { jobId, fire } = registerGatedWakeup();
+		// Fire the wakeup inside the session_before_switch await — the window
+		// between "replacement committed" and the transition's cancellation
+		// point. The hook drains the manager so the completion would have fully
+		// delivered here without suppression.
+		let deliveriesDuringTransition = -1;
+		beforeSwitchHandler = async () => {
+			fire("old-session wakeup");
+			await manager.waitForAll();
+			await manager.drainDeliveries();
+			deliveriesDuringTransition = enqueue.mock.calls.length;
+			return undefined;
+		};
+
+		await expect(session.newSession()).resolves.toBe(true);
+		await manager.drainDeliveries();
+
+		expect(deliveriesDuringTransition).toBe(0);
+		expect(enqueue).not.toHaveBeenCalled();
+		expect(manager.isDeliverySuppressed(jobId)).toBe(true);
+	});
+
+	it("restores and delivers a suppressed wakeup exactly once when the pre-switch hook vetoes", async () => {
+		const { jobId, fire } = registerGatedWakeup();
+		let deliveriesDuringTransition = -1;
+		beforeSwitchHandler = async () => {
+			fire("vetoed-transition wakeup");
+			await manager.waitForAll();
+			await manager.drainDeliveries();
+			deliveriesDuringTransition = enqueue.mock.calls.length;
+			return { cancel: true };
+		};
+
+		await expect(session.newSession()).resolves.toBe(false);
+		await manager.drainDeliveries();
+
+		expect(deliveriesDuringTransition).toBe(0);
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith(
+			"async-result",
+			expect.objectContaining({ jobId, result: "vetoed-transition wakeup" }),
+		);
+	});
+
+	it("restores a suppressed wakeup when the pre-switch hook emit rejects", async () => {
+		const { jobId, fire } = registerGatedWakeup();
+		// The real ExtensionRunner contains handler errors, but AgentSession also
+		// runs against injected runners whose emit can reject — a leaked
+		// suppression would silently swallow the wakeup forever.
+		let deliveriesDuringTransition = -1;
+		beforeSwitchHandler = async () => {
+			fire("hook-failure wakeup");
+			await manager.waitForAll();
+			await manager.drainDeliveries();
+			deliveriesDuringTransition = enqueue.mock.calls.length;
+			throw new Error("hook emit failed");
+		};
+
+		await expect(session.newSession()).rejects.toThrow("hook emit failed");
+		await manager.drainDeliveries();
+
+		expect(deliveriesDuringTransition).toBe(0);
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith(
+			"async-result",
+			expect.objectContaining({ jobId, result: "hook-failure wakeup" }),
+		);
+	});
+
+	it("restores a suppressed wakeup when the replacement fails after the cancellation point", async () => {
+		// The commit itself fails: the old session stays live, so the wakeup
+		// must survive — its delivery restored and its timer NOT cancelled.
+		const { jobId, fire } = registerGatedWakeup();
+		vi.spyOn(sessionManager, "newSession").mockRejectedValue(new Error("session create failed"));
+
+		await expect(session.newSession()).rejects.toThrow("session create failed");
+
+		expect(manager.getJob(jobId)?.status).toBe("running");
+		expect(manager.isDeliverySuppressed(jobId)).toBe(false);
+
+		fire("post-failure wakeup");
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith(
+			"async-result",
+			expect.objectContaining({ jobId, result: "post-failure wakeup" }),
+		);
+	});
+
+	it("does not re-deliver an already-delivered wakeup when a transition is vetoed", async () => {
+		const { jobId, fire } = registerGatedWakeup();
+		fire("already delivered");
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+		expect(enqueue).toHaveBeenCalledTimes(1);
+
+		// The finished job is still retained by the manager. A veto restore must
+		// not re-enqueue its long-drained delivery.
+		beforeSwitchHandler = async () => ({ cancel: true });
+		await expect(session.newSession()).resolves.toBe(false);
+		await manager.drainDeliveries();
+
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(manager.getJob(jobId)?.status).toBe("completed");
+	});
+
+	it("does not lift suppression owned by someone else when a transition is vetoed", async () => {
+		const { jobId, fire } = registerGatedWakeup();
+		// Someone else (e.g. a `hub` acknowledgement) suppressed this wakeup's
+		// delivery before the transition began; it then completes while
+		// suppressed. A veto restore must not lift that foreign suppression.
+		manager.acknowledgeDeliveries([jobId]);
+		fire("hub-acknowledged wakeup");
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+		expect(enqueue).not.toHaveBeenCalled();
+
+		beforeSwitchHandler = async () => ({ cancel: true });
+		await expect(session.newSession()).resolves.toBe(false);
+		await manager.drainDeliveries();
+
+		expect(enqueue).not.toHaveBeenCalled();
+		expect(manager.isDeliverySuppressed(jobId)).toBe(true);
+	});
+
+	it("suppresses a wakeup that fires during handoff pre-work and restores it when the handoff fails", async () => {
+		await seedPersistedMessages();
+		const { jobId, fire } = registerGatedWakeup();
+		// Fail at handoff's FIRST await — the generation phase, long before the
+		// pre-switch hook. The wakeup fires inside that await window.
+		let deliveriesDuringHandoff = -1;
+		vi.spyOn(modelRegistry, "getApiKey").mockImplementation(async () => {
+			fire("mid-handoff wakeup");
+			await manager.waitForAll();
+			await manager.drainDeliveries();
+			deliveriesDuringHandoff = enqueue.mock.calls.length;
+			return undefined;
+		});
+
+		await expect(session.handoff()).rejects.toThrow("No API key");
+		await manager.drainDeliveries();
+
+		expect(deliveriesDuringHandoff).toBe(0);
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith(
+			"async-result",
+			expect.objectContaining({ jobId, result: "mid-handoff wakeup" }),
+		);
+	});
+
+	it("restores a suppressed wakeup when handoff generation returns empty", async () => {
+		await seedPersistedMessages();
+		const { jobId, fire } = registerGatedWakeup();
+		let deliveriesDuringHandoff = -1;
+		vi.spyOn(compactionModule, "generateHandoffFromContext").mockImplementation(async () => {
+			fire("empty-handoff wakeup");
+			await manager.waitForAll();
+			await manager.drainDeliveries();
+			deliveriesDuringHandoff = enqueue.mock.calls.length;
+			return "";
+		});
+
+		await expect(session.handoff()).resolves.toBeUndefined();
+		await manager.drainDeliveries();
+
+		expect(deliveriesDuringHandoff).toBe(0);
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith(
+			"async-result",
+			expect.objectContaining({ jobId, result: "empty-handoff wakeup" }),
+		);
+	});
+
+	it("restores a suppressed wakeup when switchSession fails and rolls back", async () => {
+		await seedPersistedMessages();
+		const { jobId, fire } = registerGatedWakeup();
+		let deliveriesDuringSwitch = -1;
+		vi.spyOn(sessionManager, "setSessionFile").mockImplementation(async () => {
+			await manager.waitForAll();
+			await manager.drainDeliveries();
+			deliveriesDuringSwitch = enqueue.mock.calls.length;
+			throw new Error("switch load failed");
+		});
+
+		const switching = session.switchSession(path.join(tempDir.path(), "sessions", "other-session.jsonl"));
+		// Suppression is synchronous at switchSession entry; the wakeup fires
+		// inside the abort/flush await window that precedes the failing load.
+		fire("rollback wakeup");
+		await expect(switching).rejects.toThrow("switch load failed");
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+
+		expect(deliveriesDuringSwitch).toBe(0);
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith(
+			"async-result",
+			expect.objectContaining({ jobId, result: "rollback wakeup" }),
+		);
+	});
+
+	it("cancels pending wakeup timers when a different-session switch commits", async () => {
+		await seedPersistedMessages();
+		const { jobId } = registerGatedWakeup();
+
+		await expect(session.switchSession(path.join(tempDir.path(), "sessions", "fresh-target.jsonl"))).resolves.toBe(
+			true,
+		);
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+
+		expect(manager.getJob(jobId)?.status).toBe("cancelled");
+		expect(enqueue).not.toHaveBeenCalled();
+	});
+
+	it("delivers a wakeup normally when no replacement transition is in flight", async () => {
+		const { jobId, fire } = registerGatedWakeup();
+		fire("ordinary wakeup");
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith(
+			"async-result",
+			expect.objectContaining({ jobId, result: "ordinary wakeup" }),
+		);
+	});
+});

--- a/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
+++ b/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
@@ -169,6 +169,45 @@ describe("AgentSession wakeup suppression across session replacement", () => {
 		expect(manager.isDeliverySuppressed(jobId)).toBe(true);
 	});
 
+	it("removes an already queued wakeup before replacement pre-work can flush it", async () => {
+		const { jobId } = registerGatedWakeup();
+		session.yieldQueue.enqueue("async-result", {
+			jobId,
+			result: "queued old-session wakeup",
+			job: manager.getJob(jobId),
+			durationMs: undefined,
+			epoch: 0,
+		});
+		expect(session.yieldQueue.has("async-result")).toBe(true);
+		beforeSwitchHandler = async () => {
+			expect(session.yieldQueue.has("async-result")).toBe(false);
+			return undefined;
+		};
+
+		await expect(session.newSession()).resolves.toBe(true);
+
+		expect(session.yieldQueue.has("async-result")).toBe(false);
+	});
+
+	it("restores an already queued wakeup when replacement is vetoed", async () => {
+		const { jobId } = registerGatedWakeup();
+		session.yieldQueue.enqueue("async-result", {
+			jobId,
+			result: "queued wakeup for live session",
+			job: manager.getJob(jobId),
+			durationMs: undefined,
+			epoch: 0,
+		});
+		beforeSwitchHandler = async () => {
+			expect(session.yieldQueue.has("async-result")).toBe(false);
+			return { cancel: true };
+		};
+
+		await expect(session.newSession()).resolves.toBe(false);
+
+		expect(session.yieldQueue.has("async-result")).toBe(true);
+	});
+
 	it("restores and delivers a suppressed wakeup exactly once when the pre-switch hook vetoes", async () => {
 		const { jobId, fire } = registerGatedWakeup();
 		let deliveriesDuringTransition = -1;

--- a/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
+++ b/packages/coding-agent/test/agent-session-wakeup-replacement.test.ts
@@ -367,7 +367,7 @@ describe("AgentSession wakeup suppression across session replacement", () => {
 			return "";
 		});
 
-		await expect(session.handoff()).resolves.toBeUndefined();
+		await expect(session.handoff()).rejects.toThrow("Handoff generation produced no content");
 		await manager.drainDeliveries();
 
 		expect(deliveriesDuringHandoff).toBe(0);
@@ -403,6 +403,28 @@ describe("AgentSession wakeup suppression across session replacement", () => {
 			"async-result",
 			expect.objectContaining({ jobId, result: "rollback wakeup" }),
 		);
+	});
+
+	it("suppresses a wakeup throughout a same-session reload and restores it after commit", async () => {
+		await seedPersistedMessages();
+		const sessionFile = sessionManager.getSessionFile();
+		if (!sessionFile) throw new Error("Expected persisted session file");
+		const { jobId, fire } = registerGatedWakeup();
+		let deliveriesDuringReload = -1;
+		beforeSwitchHandler = async () => {
+			fire("reload wakeup");
+			await manager.waitForAll();
+			await manager.drainDeliveries();
+			deliveriesDuringReload = enqueue.mock.calls.length;
+			return undefined;
+		};
+
+		await expect(session.switchSession(sessionFile)).resolves.toBe(true);
+		await manager.drainDeliveries();
+
+		expect(deliveriesDuringReload).toBe(0);
+		expect(enqueue).toHaveBeenCalledTimes(1);
+		expect(enqueue).toHaveBeenCalledWith("async-result", expect.objectContaining({ jobId, result: "reload wakeup" }));
 	});
 
 	it("cancels pending wakeup timers when a different-session switch commits", async () => {

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -159,6 +159,69 @@ describe("AsyncJobManager", () => {
 		manager.cancel(firstJobId);
 	});
 
+	test("passive jobs remain cancellable without consuming execution capacity", async () => {
+		const manager = new AsyncJobManager({
+			maxRunningJobs: 1,
+			onJobComplete: async () => {},
+		});
+		const passiveGate = Promise.withResolvers<string>();
+		const runningGate = Promise.withResolvers<string>();
+
+		const runningJobId = manager.register("bash", "running", async () => await runningGate.promise);
+		expect(manager.atCapacity).toBe(true);
+
+		const passiveJobId = manager.register("wakeup", "future wakeup", async () => await passiveGate.promise, {
+			passive: true,
+		});
+		expect(manager.getJob(passiveJobId)?.passive).toBe(true);
+		expect(() => manager.register("task", "blocked", async () => "done")).toThrow(/Background job limit reached/);
+		expect(manager.cancel(passiveJobId)).toBe(true);
+
+		passiveGate.resolve("cancelled");
+		runningGate.resolve("done");
+		await manager.waitForAll();
+		expect(manager.getJob(passiveJobId)?.status).toBe("cancelled");
+		expect(manager.getJob(runningJobId)?.status).toBe("completed");
+	});
+
+	test("bounds passive registrations independently from execution capacity", async () => {
+		const manager = new AsyncJobManager({
+			maxRunningJobs: 1,
+			maxPassiveJobs: 2,
+			onJobComplete: async () => {},
+		});
+		const firstGate = Promise.withResolvers<string>();
+		const secondGate = Promise.withResolvers<string>();
+		const replacementGate = Promise.withResolvers<string>();
+		const runningGate = Promise.withResolvers<string>();
+
+		const first = manager.register("wakeup", "first wakeup", async () => await firstGate.promise, {
+			passive: true,
+		});
+		manager.register("wakeup", "second wakeup", async () => await secondGate.promise, { passive: true });
+		expect(manager.atCapacity).toBe(false);
+
+		manager.register("bash", "running", async () => await runningGate.promise);
+		expect(manager.atCapacity).toBe(true);
+		expect(() => manager.register("wakeup", "excess wakeup", async () => "done", { passive: true })).toThrow(
+			/Passive job limit reached/,
+		);
+
+		expect(manager.cancel(first)).toBe(true);
+		const replacement = manager.register("wakeup", "replacement wakeup", async () => await replacementGate.promise, {
+			passive: true,
+		});
+		expect(manager.getJob(replacement)?.passive).toBe(true);
+		expect(manager.atCapacity).toBe(true);
+
+		manager.cancelAll();
+		firstGate.resolve("cancelled");
+		secondGate.resolve("cancelled");
+		replacementGate.resolve("cancelled");
+		runningGate.resolve("cancelled");
+		await manager.waitForAll();
+	});
+
 	test("queued jobs do not count toward the cap until markRunning", async () => {
 		const manager = new AsyncJobManager({
 			maxRunningJobs: 1,

--- a/packages/coding-agent/test/async-yield-queue.test.ts
+++ b/packages/coding-agent/test/async-yield-queue.test.ts
@@ -21,7 +21,7 @@ type AsyncEntry = {
 type AsyncDetails = {
 	jobs: Array<{
 		jobId: string;
-		type?: "bash" | "task";
+		type?: "bash" | "task" | "wakeup";
 		label?: string;
 		durationMs?: number;
 	}>;

--- a/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
+++ b/packages/coding-agent/test/modes/controllers/tan-command-controller.test.ts
@@ -97,7 +97,12 @@ function createContext(overrides?: {
 	let capturedOptions: AsyncJobRegisterOptions | undefined;
 	const sequence: string[] = [];
 	const register = vi.fn(
-		(_type: "bash" | "task", _label: string, run: CapturedJobRun, options?: AsyncJobRegisterOptions): string => {
+		(
+			_type: "bash" | "task" | "wakeup",
+			_label: string,
+			run: CapturedJobRun,
+			options?: AsyncJobRegisterOptions,
+		): string => {
 			sequence.push("register");
 			capturedRun = run;
 			capturedOptions = options;

--- a/packages/coding-agent/test/sdk-async-job-manager-singleton.test.ts
+++ b/packages/coding-agent/test/sdk-async-job-manager-singleton.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -6,6 +6,7 @@ import { type } from "@oh-my-pi/omptype";
 import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async/job-manager";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentRegistry } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
 import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
 import type { AsyncJobSnapshot } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
@@ -34,13 +35,19 @@ describe("AsyncJobManager singleton across concurrent top-level sessions", () =>
 	});
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		for (const tempDir of tempDirs.splice(0)) {
 			removeSyncWithRetries(tempDir);
 		}
 		AsyncJobManager.resetForTests();
 	});
 
-	async function spawnTopLevelSession(extraSettings?: Record<string, unknown>, extensions: ExtensionFactory[] = []) {
+	async function spawnTopLevelSession(
+		extraSettings?: Record<string, unknown>,
+		agentRegistry?: AgentRegistry,
+		identity?: { agentId: string; parentAgentId: string; parentTaskPrefix: string; taskDepth: number },
+		extensions: ExtensionFactory[] = [],
+	) {
 		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-async-singleton-${Snowflake.next()}-`));
 		tempDirs.push(tempDir);
 		const cwd = path.join(tempDir, `project-${Snowflake.next()}`);
@@ -59,6 +66,8 @@ describe("AsyncJobManager singleton across concurrent top-level sessions", () =>
 			enableMCP: false,
 			enableLsp: false,
 			modelRegistry: sharedModelRegistry,
+			agentRegistry,
+			...identity,
 		});
 		return session;
 	}
@@ -148,7 +157,7 @@ describe("AsyncJobManager singleton across concurrent top-level sessions", () =>
 				},
 			});
 		};
-		const session = await spawnTopLevelSession(undefined, [snapshotExtension]);
+		const session = await spawnTopLevelSession(undefined, undefined, undefined, [snapshotExtension]);
 		const manager = AsyncJobManager.instance();
 		expect(manager).toBeDefined();
 		const release = Promise.withResolvers<string>();
@@ -191,6 +200,100 @@ describe("AsyncJobManager singleton across concurrent top-level sessions", () =>
 			// the primary's manager.
 			expect(primaryManager!.getAllJobs().length).toBe(primaryJobCountBefore);
 		} finally {
+			await primary.dispose();
+		}
+	}, 60000);
+
+	it("keeps a wakeup bound to its session when another top-level session replaces the Main registry entry", async () => {
+		const registry = new AgentRegistry();
+		const primary = await spawnTopLevelSession(undefined, registry);
+		const secondary = await spawnTopLevelSession(undefined, registry);
+		try {
+			expect(registry.get("Main")?.session).toBe(secondary);
+			const manager = AsyncJobManager.instance();
+			expect(manager).toBeDefined();
+			const primaryEnqueue = vi.spyOn(primary.yieldQueue, "enqueue");
+			const secondaryEnqueue = vi.spyOn(secondary.yieldQueue, "enqueue");
+			const wakeup = primary.getToolByName("wakeup");
+			expect(wakeup).toBeDefined();
+
+			vi.useFakeTimers();
+			await wakeup!.execute("wakeup-call", {
+				delaySeconds: 1,
+				prompt: "Resume the primary session.",
+			});
+			vi.advanceTimersByTime(1_000);
+			await manager!.waitForAll();
+			await manager!.drainDeliveries();
+
+			expect(primaryEnqueue).toHaveBeenCalledWith(
+				"async-result",
+				expect.objectContaining({ result: expect.stringContaining("Resume the primary session.") }),
+			);
+			expect(secondaryEnqueue).not.toHaveBeenCalled();
+		} finally {
+			vi.useRealTimers();
+			await secondary.dispose();
+			await primary.dispose();
+		}
+	}, 60000);
+
+	it("cancels owned wakeups when disposal begins", async () => {
+		const primary = await spawnTopLevelSession();
+		try {
+			const manager = AsyncJobManager.instance();
+			expect(manager).toBeDefined();
+			const gate = Promise.withResolvers<string>();
+			const jobId = manager!.register(
+				"wakeup",
+				"pending wakeup",
+				async ({ signal }) => {
+					signal.addEventListener("abort", () => gate.resolve("cancelled"), { once: true });
+					return await gate.promise;
+				},
+				{ ownerId: "Main", passive: true },
+			);
+
+			primary.beginDispose();
+			expect(manager!.getJob(jobId)?.status).toBe("cancelled");
+			await manager!.getJob(jobId)?.promise;
+			expect(manager!.getDeliveryState().queued).toBe(0);
+		} finally {
+			await primary.dispose();
+		}
+	}, 60000);
+
+	it("suppresses an in-flight wakeup delivery when its session is replaced", async () => {
+		const primary = await spawnTopLevelSession();
+		const manager = AsyncJobManager.instance();
+		expect(manager).toBeDefined();
+		const deliveryStarted = Promise.withResolvers<void>();
+		const releaseDelivery = Promise.withResolvers<void>();
+		const enqueue = vi.spyOn(primary.yieldQueue, "enqueue");
+		const jobId = manager!.register("wakeup", "expired wakeup", async () => "old-session wakeup", {
+			ownerId: "Main",
+			passive: true,
+			onComplete: async completedJobId => {
+				deliveryStarted.resolve();
+				await releaseDelivery.promise;
+				if (!manager!.isDeliverySuppressed(completedJobId)) {
+					primary.yieldQueue.enqueue("async-result", {
+						jobId: completedJobId,
+						result: "old-session wakeup",
+					});
+				}
+			},
+		});
+
+		try {
+			await deliveryStarted.promise;
+			await primary.newSession();
+			expect(manager!.isDeliverySuppressed(jobId)).toBe(true);
+			releaseDelivery.resolve();
+			await manager!.drainDeliveries();
+			expect(enqueue).not.toHaveBeenCalled();
+		} finally {
+			releaseDelivery.resolve();
 			await primary.dispose();
 		}
 	}, 60000);

--- a/packages/coding-agent/test/tools/wakeup.test.ts
+++ b/packages/coding-agent/test/tools/wakeup.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { createTools } from "@oh-my-pi/pi-coding-agent/tools";
+import { HubTool } from "@oh-my-pi/pi-coding-agent/tools/hub";
+import { WakeupTool } from "@oh-my-pi/pi-coding-agent/tools/wakeup";
+
+describe("WakeupTool", () => {
+	let manager: AsyncJobManager;
+	let completions: Array<{ jobId: string; text: string }>;
+	let session: ToolSession;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.spyOn(Date, "now").mockReturnValue(new Date("2026-07-17T12:00:00.000Z").getTime());
+		completions = [];
+		manager = new AsyncJobManager({});
+		session = {
+			cwd: "/tmp/test",
+			hasUI: false,
+			getSessionFile: () => null,
+			getSessionSpawns: () => "*",
+			getAgentId: () => "Main",
+			settings: Settings.isolated(),
+			asyncJobManager: manager,
+			deliverAsyncResult: async (jobId, text) => {
+				completions.push({ jobId, text });
+			},
+		};
+	});
+
+	afterEach(async () => {
+		manager.cancelAll();
+		await manager.dispose();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("is an essential builtin when async delivery is available", async () => {
+		const tools = await createTools(session);
+		const wakeup = tools.find(tool => tool.name === "wakeup");
+
+		expect(wakeup).toBeDefined();
+		expect(wakeup?.loadMode).toBe("essential");
+		expect(wakeup?.description).toContain("wake yourself");
+	});
+
+	it("is unavailable to task subagents whose jobs are reaped when they yield", async () => {
+		session.taskDepth = 1;
+
+		expect(WakeupTool.createIf(session)).toBeNull();
+		expect((await createTools(session)).map(tool => tool.name)).not.toContain("wakeup");
+	});
+
+	it("sanitizes the prompt shown in execution approval details", () => {
+		const tool = new WakeupTool(session);
+		const details = tool.formatApprovalDetails?.({
+			delaySeconds: 60,
+			prompt: `first\tsecond\n${"x".repeat(200)}`,
+		});
+
+		expect(details).toBeDefined();
+		expect(details?.[1]).toStartWith("Prompt: first second ");
+		expect(details?.[1]).not.toContain("\t");
+		expect(details?.[1]).not.toContain("\n");
+		expect(Bun.stringWidth(details?.[1] ?? "")).toBeLessThanOrEqual(88);
+	});
+
+	it("delivers the saved prompt once after the requested delay", async () => {
+		const tool = new WakeupTool(session);
+		const result = await tool.execute("call-1", {
+			delaySeconds: 60,
+			prompt: "Check CI again and report the result.",
+		});
+		const details = result.details;
+		if (!details) throw new Error("Expected wakeup result details");
+
+		expect(result.content.map(block => (block.type === "text" ? block.text : "")).join("\n")).toContain(
+			"Scheduled wakeup",
+		);
+		expect(details.scheduledAt).toBe("2026-07-17T12:01:00.000Z");
+		expect(manager.getJob(details.jobId)).toMatchObject({
+			type: "wakeup",
+			status: "running",
+			ownerId: "Main",
+			passive: true,
+		});
+
+		vi.advanceTimersByTime(59_999);
+		await Promise.resolve();
+		expect(completions).toEqual([]);
+
+		vi.advanceTimersByTime(1);
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+
+		expect(completions).toEqual([
+			{
+				jobId: details.jobId,
+				text: expect.stringContaining("Check CI again and report the result."),
+			},
+		]);
+		expect(manager.getJob(details.jobId)?.status).toBe("completed");
+	});
+
+	it("lists and cancels a pending wakeup through hub", async () => {
+		const tool = new WakeupTool(session);
+		const result = await tool.execute("call-2", {
+			delaySeconds: 600,
+			prompt: "This should never be delivered.",
+		});
+		const details = result.details;
+		if (!details) throw new Error("Expected wakeup result details");
+
+		const hub = new HubTool(session);
+		const jobsResult = await hub.execute("hub-jobs", { op: "jobs" });
+		const jobsText = jobsResult.content.map(block => (block.type === "text" ? block.text : "")).join("\n");
+		expect(jobsText).toContain(details.jobId);
+		expect(jobsText).toContain("wakeup");
+
+		await hub.execute("hub-cancel", { op: "cancel", ids: [details.jobId] });
+		await manager.waitForAll();
+		await manager.drainDeliveries();
+
+		expect(manager.getJob(details.jobId)?.status).toBe("cancelled");
+		expect(completions).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/tools/wakeup.test.ts
+++ b/packages/coding-agent/test/tools/wakeup.test.ts
@@ -53,6 +53,13 @@ describe("WakeupTool", () => {
 		expect((await createTools(session)).map(tool => tool.name)).not.toContain("wakeup");
 	});
 
+	it("is unavailable to disposable top-level clones", async () => {
+		session.parentTaskPrefix = "Tan-clone";
+
+		expect(WakeupTool.createIf(session)).toBeNull();
+		expect((await createTools(session)).map(tool => tool.name)).not.toContain("wakeup");
+	});
+
 	it("sanitizes the prompt shown in execution approval details", () => {
 		const tool = new WakeupTool(session);
 		const details = tool.formatApprovalDetails?.({

--- a/packages/utils/src/abortable.ts
+++ b/packages/utils/src/abortable.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { scheduler } from "node:timers/promises";
 
 export class AbortError extends Error {
 	constructor(signal: AbortSignal) {
@@ -88,6 +89,25 @@ export function untilAborted<T>(
 	})();
 
 	return promise;
+}
+
+/**
+ * Sleep without hand-rolling a timer. The ordinary path uses Bun's sleep
+ * primitive; the signalled path uses the platform's abortable scheduler so
+ * cancellation also releases the pending timer immediately.
+ */
+export async function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+	if (!signal) {
+		await Bun.sleep(ms);
+		return;
+	}
+	if (signal.aborted) throw new AbortError(signal);
+	try {
+		await scheduler.wait(ms, { signal });
+	} catch (error) {
+		if (signal.aborted) throw new AbortError(signal);
+		throw error;
+	}
 }
 
 /**

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,4 @@
-export { abortableSleep, once, untilAborted } from "./abortable";
+export * from "./abortable";
 export * from "./async";
 export * from "./binary";
 export * from "./color";

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,4 @@
-export { once, untilAborted } from "./abortable";
+export { abortableSleep, once, untilAborted } from "./abortable";
 export * from "./async";
 export * from "./binary";
 export * from "./color";

--- a/packages/utils/test/abortable.test.ts
+++ b/packages/utils/test/abortable.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { AbortError, abortableSleep } from "../src/abortable";
+
+describe("abortableSleep", () => {
+	it("uses the ordinary sleep path without a signal", async () => {
+		await abortableSleep(0);
+	});
+
+	it("releases a pending sleep when aborted", async () => {
+		const controller = new AbortController();
+		const sleeping = abortableSleep(60_000, controller.signal);
+		controller.abort("cancelled");
+
+		await expect(sleeping).rejects.toBeInstanceOf(AbortError);
+	});
+});


### PR DESCRIPTION
## What

- Add an essential `wakeup` tool that schedules a session-owned, one-shot delayed follow-up.
- Accept `{ delaySeconds, prompt }`, with an integer delay from 1 through 86,400 seconds and a non-empty resume instruction.
- Register the tool only when async job delivery is available; classify it as an execution tool so the session's execution-approval policy applies.
- Deliver the saved instruction through the existing async-result path so the agent resumes automatically.
- Keep pending wakeups visible and cancellable through `hub` without consuming async execution capacity or delaying stop-time hooks.

## Why

`/loop` repeats the current prompt immediately and is only available through the interactive command path. The model had no callable primitive for requests such as “wake yourself in ten minutes” or “check this again later.” A blocking shell sleep also ties up execution and does not provide a clean cancellation or delivery lifecycle.

This change stays deliberately session-scoped: wakeups are one-shot and require the owning OMP process and session to remain open. They do not persist across restarts and do not add cron or a recurring scheduler.

Related: #3534 adds an `omp loop` CLI/runtime for scheduled-safe loop iterations, specs, logs, and verifiers; this PR only schedules one delayed instruction inside the current session. #5785 uses the same async wake/delivery path for command and WebSocket event monitors; this PR adds no external monitor source or persistent scheduler.

## Testing

```bash
bun --cwd=packages/coding-agent test test/sdk-async-job-manager-singleton.test.ts test/tools/wakeup.test.ts test/async-job-manager.test.ts test/async-yield-queue.test.ts
bun --cwd=packages/coding-agent run check:types
```

Contract coverage includes one-shot firing, owner-scoped delivery and cancellation, session-isolated async managers, async queue delivery, prompt sanitization, and width-bounded approval rendering without modifying the scheduled prompt.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
