### PR TITLE
fix(tui): drop stale hidden-lines footer on expanded bash/eval output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed expanded `!` bash and `eval` output keeping a stale `… N more lines (ctrl+o to expand)` footer after Ctrl+O revealed every line ([#5842](https://github.com/can1357/oh-my-pi/issues/5842)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/modes/components/bash-execution.ts
+++ b/packages/coding-agent/src/modes/components/bash-execution.ts
@@ -146,14 +146,18 @@ export class BashExecutionComponent extends Container {
 	#updateDisplay(): void {
 		const availableLines = this.#outputLines;
 
-		// Apply preview truncation based on expanded state
+		// Full output is shown when expanded or when sixel passthrough renders
+		// the raw payload; the collapsed preview shows only the tail window.
 		const previewLogicalLines = availableLines.slice(-PREVIEW_LINES);
-		const hiddenLineCount = availableLines.length - previewLogicalLines.length;
 		const sixelLineMask =
 			TERMINAL.imageProtocol === ImageProtocol.Sixel && isSixelPassthroughEnabled()
 				? getSixelLineMask(availableLines)
 				: undefined;
 		const hasSixelOutput = sixelLineMask?.some(Boolean) ?? false;
+		const showingAllLines = this.#expanded || hasSixelOutput;
+		// Only the collapsed preview hides lines; when the full output is shown
+		// the footer must not keep advertising hidden lines / ctrl+o.
+		const hiddenLineCount = showingAllLines ? 0 : availableLines.length - previewLogicalLines.length;
 
 		// Rebuild content container
 		this.#contentContainer.clear();
@@ -163,7 +167,7 @@ export class BashExecutionComponent extends Container {
 
 		// Output
 		if (availableLines.length > 0) {
-			if (this.#expanded || hasSixelOutput) {
+			if (showingAllLines) {
 				const displayText = availableLines
 					.map((line, index) => (sixelLineMask?.[index] ? line : theme.fg("muted", line)))
 					.join("\n");

--- a/packages/coding-agent/src/modes/components/eval-execution.ts
+++ b/packages/coding-agent/src/modes/components/eval-execution.ts
@@ -114,7 +114,9 @@ export class EvalExecutionComponent extends Container {
 	#updateDisplay(): void {
 		const availableLines = this.#outputLines;
 		const previewLogicalLines = availableLines.slice(-PREVIEW_LINES);
-		const hiddenLineCount = availableLines.length - previewLogicalLines.length;
+		// Only the collapsed preview hides lines; when expanded the footer must
+		// not keep advertising hidden lines / ctrl+o.
+		const hiddenLineCount = this.#expanded ? 0 : availableLines.length - previewLogicalLines.length;
 
 		this.#contentContainer.clear();
 

--- a/packages/coding-agent/test/bash-execution-sixel.test.ts
+++ b/packages/coding-agent/test/bash-execution-sixel.test.ts
@@ -141,3 +141,47 @@ describe("BashExecutionComponent streaming throttle", () => {
 		expect(output).not.toContain("streaming_line");
 	});
 });
+
+describe("BashExecutionComponent expand footer", () => {
+	const ui = { requestRender: () => {}, requestComponentRender: () => {} } as unknown as TUI;
+
+	beforeEach(async () => {
+		const theme = await getThemeByName("dark");
+		expect(theme).toBeDefined();
+		setThemeInstance(theme!);
+	});
+
+	// PREVIEW_LINES is 20: 27 lines leaves 7 hidden in the collapsed preview.
+	const makeComponent = () => {
+		const component = new BashExecutionComponent("ls", ui, false);
+		const lines = Array.from({ length: 27 }, (_, i) => `entry${i}`);
+		component.setComplete(0, false, { output: lines.join("\n") });
+		return component;
+	};
+
+	it("advertises hidden lines while collapsed", () => {
+		const rendered = makeComponent().render(120).join("\n");
+		expect(rendered).toContain("more lines");
+		expect(rendered).toContain("ctrl+o to expand");
+	});
+
+	it("drops the hidden-lines footer once expanded", () => {
+		const component = makeComponent();
+		component.setExpanded(true);
+		const rendered = component.render(120).join("\n");
+		expect(rendered).not.toContain("more lines");
+		expect(rendered).not.toContain("ctrl+o to expand");
+		// Every line is now present, including the previously hidden prefix.
+		expect(rendered).toContain("entry0");
+		expect(rendered).toContain("entry26");
+	});
+
+	it("restores the footer when collapsed again", () => {
+		const component = makeComponent();
+		component.setExpanded(true);
+		component.setExpanded(false);
+		const rendered = component.render(120).join("\n");
+		expect(rendered).toContain("more lines");
+		expect(rendered).toContain("ctrl+o to expand");
+	});
+});


### PR DESCRIPTION
## Repro
For local `!` bash executions, pressing Ctrl+O expands `BashExecutionComponent` to show every output line, but the `… N more lines (ctrl+o to expand)` footer stays. Reproduced deterministically in-process by rendering the component with 27 output lines, calling `setExpanded(true)`, then inspecting the frame:

```
HAS_FOOTER: true
HAS_CTRLO: true
```

This holds at any terminal height (confirmed by the reporter at 120×60, where all 27 entries are visible yet the footer still claims 8 hidden lines).

## Cause
`BashExecutionComponent.#updateDisplay()` (`packages/coding-agent/src/modes/components/bash-execution.ts`) computed `hiddenLineCount = availableLines.length - previewLogicalLines.length` independently of `#expanded`. The output branch renders all `availableLines` when expanded (or under sixel passthrough), but `buildStatusFooter()` always received the collapsed-state count, so it kept advertising hidden lines and Ctrl+O. The sibling `EvalExecutionComponent` (`eval-execution.ts`) had the identical defect.

## Fix
- `bash-execution.ts`: hoist a `showingAllLines = this.#expanded || hasSixelOutput` flag and set `hiddenLineCount` to `0` when the full output is shown; reuse the flag for the output-branch selection.
- `eval-execution.ts`: set `hiddenLineCount` to `0` when `#expanded`.
- `test/bash-execution-sixel.test.ts`: add an "expand footer" suite asserting the footer is present when collapsed, absent (with all lines rendered) when expanded, and restored on re-collapse.

Out of scope: the reporter's second symptom (revealed prefix lines not entering tmux scrollback in an 80×24 viewport) is an architectural constraint of the ED3-unsafe multiplexer paint path — `resetDisplay()` passes `clearScrollback=false` inside tmux, and the rewrap-and-replay (`divergenceRebuild`) is deliberately gated behind `!isMultiplexerSession()` and the off-by-default `PI_TUI_SCROLLBACK_REBUILD` flag to avoid the flash race (issue #2088). That maps to the reporter's own "or an explicit scrollable transcript view" expected-behavior note (a feature), not this footer bug.

## Verification
`bun test test/bash-execution-sixel.test.ts` → 10 pass, 0 fail (7 pre-existing + 3 new). Manually confirmed via an in-process render harness that `HAS_FOOTER`/`HAS_CTRLO` flip from `true` to `false` after `setExpanded(true)`. Fixes #5842