### PR TITLE
fix(tui): restore slash description wrapping

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored wrapped descriptions in the slash-command autocomplete picker so long skill descriptions remain readable at normal terminal widths ([#5848](https://github.com/can1357/oh-my-pi/issues/5848)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -31,6 +31,7 @@ const AUTOCOMPLETE_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 	minPrimaryColumnWidth: 12,
 	maxPrimaryColumnWidth: 32,
+	wrapDescription: true,
 	overflowSearch: false,
 };
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -320,17 +320,13 @@ describe("Editor component", () => {
 			expect(editor.render(80).some(line => line.includes(CURSOR_MARKER))).toBe(true);
 		});
 
-		it("renders slash-command suggestions as compact item rows", async () => {
+		it("wraps long slash-command descriptions instead of dropping the tail", async () => {
 			const editor = new Editor(defaultEditorTheme);
-			editor.setAutocompleteMaxVisible(10);
 			const longDescription =
-				"Plan and execute non-trivial architectural improvements to the codebase without turning each slash command into a multi-line block.";
+				"Plan and execute non-trivial architectural improvements to the codebase. Use this skill when you need to refactor existing systems.";
 			editor.setAutocompleteProvider(
 				new CombinedAutocompleteProvider(
-					Array.from({ length: 12 }, (_, i) => ({
-						name: `cmd${i}`,
-						description: longDescription,
-					})),
+					[{ name: "improve-codebase-architecture", description: longDescription }],
 					"/tmp",
 				),
 			);
@@ -342,10 +338,8 @@ describe("Editor component", () => {
 			await autocompleteUpdated;
 
 			const rendered = editor.render(80).map(line => stripVTControlCharacters(line));
-			for (let i = 0; i < 10; i += 1) {
-				expect(rendered.some(line => line.includes(`cmd${i}`))).toBe(true);
-			}
-			expect(rendered.some(line => line.includes("cmd10"))).toBe(false);
+			expect(rendered.some(line => line.includes("improve-codebase-architecture"))).toBe(true);
+			expect(rendered.join("\n")).toContain("refactor existing systems.");
 		});
 
 		it("triggers file-reference autocomplete when typing at-sign", async () => {


### PR DESCRIPTION
## Repro
At 80 columns, open slash autocomplete with `improve-codebase-architecture` and its long description; `Editor.render(80)` previously emitted only `Plan and execute non-trivial architectural im`. The regression test reproduces this with `bun test packages/tui/test/editor.test.ts --test-name-pattern "wraps long slash-command descriptions"`.

## Cause
`SLASH_COMMAND_SELECT_LIST_LAYOUT` in `packages/tui/src/components/editor.ts` stopped setting `wrapDescription`, so `SelectList.#renderItem()` in `packages/tui/src/components/select-list.ts` took its default single-row `truncateToWidth(..., Ellipsis.Omit)` path and discarded the description tail.

## Fix
- Re-enable `wrapDescription` for slash-command autocomplete while retaining the existing visual-row popup budget and narrow-width fallback.
- Replace the compact-row editor regression with an end-to-end assertion that a long slash-command description renders through its final words.
- Record the restored behavior in the TUI changelog.

## Verification
`bun test packages/tui/test/editor.test.ts packages/tui/test/select-list.test.ts` passed: 169 tests, 0 failures. A manual `Editor.render(80)` smoke check rendered the description on three indented rows and reported `contains tail: true`.

Fixes #5848