### PR TITLE
fix(ai): order parallel tool outputs before result images

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed parallel Responses tool-result images interleaving synthetic user messages before all pending outputs, preventing strict OpenRouter/Moonshot backends from rejecting follow-up requests. ([#5850](https://github.com/can1357/oh-my-pi/issues/5850))
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -1734,6 +1734,21 @@ export function convertResponsesAssistantMessage<TApi extends Api>(
 	return outputItems;
 }
 
+const syntheticToolImageMessages = new WeakSet<object>();
+
+function insertResponsesToolOutput(messages: ResponseInput, output: ResponseInput[number]): void {
+	let index = messages.length;
+	while (index > 0) {
+		const previous = messages[index - 1];
+		if (typeof previous !== "object" || previous === null || !syntheticToolImageMessages.has(previous)) {
+			break;
+		}
+		index -= 1;
+	}
+	messages.splice(index, 0, output);
+}
+
+/** Appends one tool result while keeping consecutive outputs ahead of its synthetic image messages. */
 export function appendResponsesToolResultMessages<TApi extends Api>(
 	messages: ResponseInput,
 	toolResult: ToolResultMessage,
@@ -1780,13 +1795,13 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 		return;
 	}
 	if (supportsCustomToolCalls && customCallIds?.has(normalized.callId)) {
-		messages.push({
+		insertResponsesToolOutput(messages, {
 			type: "custom_tool_call_output",
 			call_id: normalized.callId,
 			output,
 		} as ResponseInput[number]);
 	} else {
-		messages.push({
+		insertResponsesToolOutput(messages, {
 			type: "function_call_output",
 			call_id: normalized.callId,
 			output,
@@ -1809,7 +1824,9 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 			} satisfies ResponseInputImage);
 		}
 	}
-	messages.push({ role: "user", content: contentParts });
+	const imageMessage = { role: "user", content: contentParts } satisfies ResponseInput[number];
+	syntheticToolImageMessages.add(imageMessage);
+	messages.push(imageMessage);
 }
 
 /**

--- a/packages/ai/test/openai-responses-parallel-tool-result-images.test.ts
+++ b/packages/ai/test/openai-responses-parallel-tool-result-images.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import { convertCodexResponsesMessages } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import type { ResponseInput } from "@oh-my-pi/pi-ai/providers/openai-responses-wire";
+import { buildResponsesInput } from "@oh-my-pi/pi-ai/providers/openai-shared";
+import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+const genericModel = buildModel({
+	id: "moonshotai/kimi-k3",
+	name: "Kimi K3",
+	api: "openai-responses",
+	provider: "openrouter",
+	baseUrl: "https://openrouter.ai/api/v1",
+	reasoning: false,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_000,
+});
+
+const codexModel = buildModel({
+	id: "gpt-5.5",
+	name: "Codex Test",
+	api: "openai-codex-responses",
+	provider: "openai-codex",
+	baseUrl: "https://chatgpt.com/backend-api/codex/responses",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 100_000,
+	compat: { supportsImageDetailOriginal: true },
+});
+
+const zeroUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function makeContext(model: Model): Context {
+	return {
+		messages: [
+			{
+				role: "assistant",
+				content: [
+					{ type: "toolCall", id: "call_read_36", name: "read", arguments: { path: "a.png" } },
+					{ type: "toolCall", id: "call_read_37", name: "read", arguments: { path: "b.png" } },
+					{ type: "toolCall", id: "call_bash_38", name: "bash", arguments: { command: "true" } },
+				],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: zeroUsage,
+				stopReason: "toolUse",
+				timestamp: 1,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call_read_36",
+				toolName: "read",
+				content: [
+					{ type: "text", text: "first" },
+					{ type: "image", mimeType: "image/png", data: "AAAA" },
+				],
+				isError: false,
+				timestamp: 2,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call_read_37",
+				toolName: "read",
+				content: [
+					{ type: "text", text: "second" },
+					{ type: "image", mimeType: "image/png", data: "BBBB" },
+				],
+				isError: false,
+				timestamp: 3,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "call_bash_38",
+				toolName: "bash",
+				content: [{ type: "text", text: "done" }],
+				isError: false,
+				timestamp: 4,
+			},
+			{ role: "user", content: "continue", timestamp: 5 },
+		],
+	};
+}
+
+function expectOrderedToolResults(items: ResponseInput): void {
+	expect(items.slice(0, 3).map(item => ("call_id" in item ? item.call_id : undefined))).toEqual([
+		"call_read_36",
+		"call_read_37",
+		"call_bash_38",
+	]);
+	expect(items.slice(3)).toEqual([
+		{ type: "function_call_output", call_id: "call_read_36", output: "first" },
+		{ type: "function_call_output", call_id: "call_read_37", output: "second" },
+		{ type: "function_call_output", call_id: "call_bash_38", output: "done" },
+		{
+			role: "user",
+			content: [
+				{ type: "input_text", text: "Attached image(s) from tool result:" },
+				{ type: "input_image", detail: "auto", image_url: "data:image/png;base64,AAAA" },
+			],
+		},
+		{
+			role: "user",
+			content: [
+				{ type: "input_text", text: "Attached image(s) from tool result:" },
+				{ type: "input_image", detail: "auto", image_url: "data:image/png;base64,BBBB" },
+			],
+		},
+		{ role: "user", content: [{ type: "input_text", text: "continue" }] },
+	]);
+}
+
+describe("parallel Responses tool-result images", () => {
+	it("keeps generic Responses outputs ahead of synthetic image messages", () => {
+		const items = buildResponsesInput({
+			model: genericModel,
+			context: makeContext(genericModel),
+			strictResponsesPairing: true,
+			supportsImageDetailOriginal: true,
+		});
+
+		expectOrderedToolResults(items);
+	});
+
+	it("keeps Codex Responses outputs ahead of synthetic image messages", () => {
+		const items = convertCodexResponsesMessages(codexModel, makeContext(codexModel));
+
+		expectOrderedToolResults(items);
+	});
+});


### PR DESCRIPTION
## Repro
A deterministic assistant turn with three parallel calls, two image-bearing `toolResult` messages, one text-only result, and a genuine user message was passed through both serializers with `eval(js): buildResponsesInput(...) and convertCodexResponsesMessages(...)`. Before the fix, both emitted `output(read_36) → user(image) → output(read_37) → user(image) → output(bash_38) → user(genuine)`, leaving pending calls after a non-tool message.

## Cause
`appendResponsesToolResultMessages()` in `packages/ai/src/providers/openai-shared.ts` appended each output and immediately appended that result's synthetic `role: "user"` image message. Repeating the helper for a consecutive parallel batch therefore interleaved non-tool messages between pending Responses outputs in generic/OpenRouter, Azure, and Codex conversion paths.

## Fix
- Track synthetic tool-image messages by object identity and insert each consecutive tool output before the trailing synthetic image block.
- Stop reordering at any untagged tail item, preserving genuine user-message batch boundaries.
- Add generic Responses and Codex Responses regression coverage for call IDs, attachment order, output ordering, and the following genuine user message.
- Document the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/openai-responses-parallel-tool-result-images.test.ts packages/ai/test/openai-responses-empty-tool-result.test.ts packages/ai/test/issue-967-vision-guard.test.ts` passed: 9 tests, 0 failures. `bun check` passed across the repository. Manual serializer smoke checks produced all three outputs before both image messages, with the genuine user message last, for generic and Codex Responses. Fixes #5850