### PR TITLE
fix(tui): recognize remote cmux resize sessions

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native cmux SSH pane resizes inserting blank rows into terminal scrollback by routing remote-transport sessions through the in-place repaint path ([#5857](https://github.com/can1357/oh-my-pi/issues/5857)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -180,12 +180,13 @@ export class TerminalInfo {
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
 export function isInsideTerminalMultiplexer(env: NodeJS.ProcessEnv = Bun.env): boolean {
-	// TMUX/STY/ZELLIJ/CMUX workspace+surface ids are authoritative session
-	// signals. TERM can also survive when those are stripped (`sudo` without -E,
-	// `su`, env-sanitizing launchers/ssh). Do not use CMUX_SOCKET_PATH here: it is
-	// a CLI socket override and can be set outside a CMUX terminal.
+	// TMUX/STY/ZELLIJ and CMUX workspace/surface/remote-transport markers are
+	// authoritative session signals. TERM can also survive when those are
+	// stripped (`sudo` without -E, `su`, env-sanitizing launchers/ssh). Do not
+	// use CMUX_SOCKET_PATH here: it is a CLI socket override and can be set
+	// outside a CMUX terminal.
 	if (env.TMUX || env.STY || env.ZELLIJ) return true;
-	if (env.CMUX_WORKSPACE_ID || env.CMUX_SURFACE_ID) return true;
+	if (env.CMUX_WORKSPACE_ID || env.CMUX_SURFACE_ID || env.CMUX_REMOTE_TRANSPORT) return true;
 	const term = env.TERM?.toLowerCase() ?? "";
 	return term.startsWith("tmux") || term.startsWith("screen");
 }

--- a/packages/tui/test/resize-viewport-defer.test.ts
+++ b/packages/tui/test/resize-viewport-defer.test.ts
@@ -21,6 +21,9 @@ const NO_MULTIPLEXER_ENV: Record<string, string | undefined> = {
 	TMUX: undefined,
 	STY: undefined,
 	ZELLIJ: undefined,
+	CMUX_WORKSPACE_ID: undefined,
+	CMUX_SURFACE_ID: undefined,
+	CMUX_REMOTE_TRANSPORT: undefined,
 	// Pin terminal identity so the alt-screen fast-path assertions below are
 	// deterministic even when the suite runs inside Warp (which otherwise takes
 	// the in-place path — see the Warp describe block at the bottom).
@@ -494,12 +497,18 @@ describe("non-multiplexer resize viewport fast path", () => {
 	});
 });
 
-describe("resize repaints in place on terminals that re-report size on alt-screen toggle (Warp)", () => {
+describe("resize repaints in place on sensitive terminal hosts", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
 	const WARP_ENV: Record<string, string | undefined> = { ...NO_MULTIPLEXER_ENV, TERM_PROGRAM: "WarpTerminal" };
+	const CMUX_REMOTE_ENV: Record<string, string | undefined> = {
+		...NO_MULTIPLEXER_ENV,
+		TERM: "xterm-ghostty",
+		TERM_PROGRAM: "ghostty",
+		CMUX_REMOTE_TRANSPORT: "ws",
+	};
 
 	function makeTui(term: VirtualTerminal): { tui: TUI; blocks: CountingBlock[]; scheduler: DeferScheduler } {
 		const blocks = Array.from({ length: 15 }, (_v, i) => new CountingBlock([`b${i}-x`, `b${i}-y`]));
@@ -542,6 +551,31 @@ describe("resize repaints in place on terminals that re-report size on alt-scree
 				await scheduler.flushAll(term);
 				expect(eraseScrollbackCount(writes)).toBe(0);
 				expect(writes.join("")).not.toContain(ALT_SCREEN_ENTER);
+				expect(visible(term).at(-1)).toBe("b14-y");
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("never borrows the alternate screen in a native cmux SSH workspace", async () => {
+		await withEnvPatch(CMUX_REMOTE_ENV, async () => {
+			const term = new VirtualTerminal(40, 10, 1000);
+			const { tui, scheduler } = makeTui(term);
+			try {
+				tui.start();
+				await scheduler.flushImmediates(term);
+
+				const writes = captureWrites(term);
+				term.resize(60, 10);
+				await scheduler.flushImmediates(term);
+
+				expect(tui.resizeViewportActive).toBe(false);
+				expect(tui.resizeViewportPaints).toBe(0);
+				expect(writes.join("")).not.toContain(ALT_SCREEN_ENTER);
+
+				await scheduler.flushAll(term);
+				expect(eraseScrollbackCount(writes)).toBe(0);
 				expect(visible(term).at(-1)).toBe("b14-y");
 			} finally {
 				tui.stop();


### PR DESCRIPTION
## Repro
With `TERM=xterm-ghostty`, `TERM_PROGRAM=ghostty`, and `CMUX_REMOTE_TRANSPORT=ws` while `TMUX`, `STY`, and `ZELLIJ` are unset, run `bun test packages/tui/test/resize-viewport-defer.test.ts -t "native cmux SSH"`. Before the fix, one virtual-terminal resize entered the alternate-screen fast path (`resizeViewportActive === true`), failing with `Expected: false, Received: true`.

## Cause
`isInsideTerminalMultiplexer()` in `packages/tui/src/terminal-capabilities.ts` recognized cmux only through `CMUX_WORKSPACE_ID` or `CMUX_SURFACE_ID`. Native cmux SSH workspaces expose `CMUX_REMOTE_TRANSPORT=ws` on the remote host, so `packages/tui/src/tui.ts` misclassified the session as a direct terminal and used the alternate-screen resize plus authoritative scrollback replay path.

## Fix
- Treat a non-empty `CMUX_REMOTE_TRANSPORT` as an authoritative cmux session marker.
- Cover the reported native cmux SSH environment at the resize-renderer level, asserting no alternate-screen borrow and no ED3 scrollback erase.
- Document the regression fix in the TUI changelog.

## Verification
`bun test packages/tui/test/resize-viewport-defer.test.ts -t "native cmux SSH"` passes (1 test, 5 assertions). `bun test packages/tui/test/resize-viewport-defer.test.ts packages/tui/test/terminal-capabilities.test.ts` passes (48 tests, 200 assertions). The publish gate also completed `bun run fix` and `bun check` successfully. Fixes #5857