### PR TITLE
fix(hub): restore persisted peers after resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+- Fixed `hub`/`irc` peer discovery after process-crash resume by restoring persisted subagents as parked peers before listing the roster ([#5864](https://github.com/can1357/oh-my-pi/issues/5864)).
 - Fixed loading issues for linked legacy extensions importing `DefaultPackageManager` or `linkedom`.
 - Fixed the advisor retrying terminal, non-retriable provider failures (e.g., blocked prompts), ensuring they fail immediately while transient failures still retry.
 - Fixed an issue where reassigning the `plan` role model mid-planning did not take effect until the next plan-mode entry; it now applies at the next turn boundary.

--- a/packages/coding-agent/src/modes/components/agent-hub.ts
+++ b/packages/coding-agent/src/modes/components/agent-hub.ts
@@ -13,17 +13,15 @@
  *
  * Replaces the old SessionObserverOverlayComponent (ctrl+s observer).
  */
-import * as fs from "node:fs";
-import * as path from "node:path";
 import { type AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Container, Ellipsis, matchesKey, type OverlayHandle, padding, type TUI, visibleWidth } from "@oh-my-pi/pi-tui";
 import { formatAge, getProjectDir, logger } from "@oh-my-pi/pi-utils";
-import { ADVISOR_TRANSCRIPT_FILENAME, isAdvisorTranscriptName } from "../../advisor";
 import type { KeyId } from "../../config/keybindings";
 import type { MessageRenderer } from "../../extensibility/extensions/types";
 import { IrcBus } from "../../irc/bus";
 import { AgentLifecycleManager } from "../../registry/agent-lifecycle";
 import { type AgentRef, AgentRegistry, type AgentStatus, MAIN_AGENT_ID } from "../../registry/agent-registry";
+import { registerPersistedSubagents } from "../../registry/persisted-agents";
 import { USER_INTERRUPT_LABEL } from "../../session/messages";
 import { parseThinkingLevel } from "../../thinking";
 import { replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
@@ -98,75 +96,6 @@ function modelBadge(ref: AgentRef, observed: ObservableSession | undefined): str
 	const level = colon >= 0 ? parseThinkingLevel(resolved.slice(colon + 1)) : undefined;
 	const selector = level !== undefined ? resolved.slice(0, colon) : resolved;
 	return formatModelBadge(selector.slice(selector.indexOf("/") + 1), level);
-}
-
-async function registerPersistedSubagents(
-	registry: AgentRegistry,
-	sessionFile: string | null | undefined,
-): Promise<void> {
-	if (!sessionFile?.endsWith(".jsonl")) return;
-	const root = sessionFile.slice(0, -6);
-	await registerPersistedSubagentsFromDir(registry, root, undefined);
-}
-
-async function registerPersistedSubagentsFromDir(
-	registry: AgentRegistry,
-	dir: string,
-	parentId: string | undefined,
-): Promise<void> {
-	let entries: fs.Dirent[];
-	try {
-		entries = await fs.promises.readdir(dir, { withFileTypes: true });
-	} catch {
-		return;
-	}
-	for (const entry of entries) {
-		if (!entry.isFile() || !entry.name.endsWith(".jsonl") || entry.name.includes(".bak")) continue;
-		const sessionFile = path.join(dir, entry.name);
-		// The advisor transcript is observability-only: register it as a non-peer
-		// `advisor` kind under its owning session so the Hub can show its read-only
-		// transcript, but it never joins agent-facing rosters and is not revivable.
-		if (isAdvisorTranscriptName(entry.name)) {
-			const owner = parentId ?? MAIN_AGENT_ID;
-			// `__advisor.jsonl` → the default advisor (no slug); `__advisor.<slug>.jsonl`
-			// → a named advisor, keyed and labeled by its slug.
-			const slug =
-				entry.name === ADVISOR_TRANSCRIPT_FILENAME ? "" : entry.name.slice("__advisor.".length, -".jsonl".length);
-			const advisorId = slug ? `${owner}/advisor:${slug}` : `${owner}/advisor`;
-			const displayName = slug ? `advisor:${slug}` : "advisor";
-			const existing = registry.get(advisorId);
-			// Never clobber a non-advisor ref that happens to share this id (a freak
-			// user task literally named `<owner>/advisor`): leave it, skip the advisor.
-			if (existing && existing.kind !== "advisor") continue;
-			if (existing?.sessionFile !== sessionFile) {
-				// The id is reused across `/new`; refresh it to the current session's file.
-				if (existing) registry.unregister(advisorId);
-				registry.register({
-					id: advisorId,
-					displayName,
-					kind: "advisor",
-					parentId: owner,
-					session: null,
-					sessionFile,
-					status: "parked",
-				});
-			}
-			continue;
-		}
-		const id = entry.name.slice(0, -6);
-		if (!registry.get(id)) {
-			registry.register({
-				id,
-				displayName: id,
-				kind: "sub",
-				parentId: parentId ?? MAIN_AGENT_ID,
-				session: null,
-				sessionFile,
-				status: "parked",
-			});
-		}
-		await registerPersistedSubagentsFromDir(registry, path.join(dir, id), id);
-	}
 }
 
 /** Result of one host-backed transcript read for the Agent Hub viewer. */

--- a/packages/coding-agent/src/registry/persisted-agents.ts
+++ b/packages/coding-agent/src/registry/persisted-agents.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ADVISOR_TRANSCRIPT_FILENAME, isAdvisorTranscriptName } from "../advisor/transcript-recorder";
+import { type AgentRegistry, MAIN_AGENT_ID } from "./agent-registry";
+
+/** Register persisted subagent and advisor transcripts as parked registry refs. */
+export async function registerPersistedSubagents(
+	registry: AgentRegistry,
+	sessionFile: string | null | undefined,
+): Promise<void> {
+	if (!sessionFile?.endsWith(".jsonl")) return;
+	const root = sessionFile.slice(0, -6);
+	await registerPersistedSubagentsFromDir(registry, root, undefined);
+}
+
+async function registerPersistedSubagentsFromDir(
+	registry: AgentRegistry,
+	dir: string,
+	parentId: string | undefined,
+): Promise<void> {
+	let entries: fs.Dirent[];
+	try {
+		entries = await fs.promises.readdir(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith(".jsonl") || entry.name.includes(".bak")) continue;
+		const sessionFile = path.join(dir, entry.name);
+		// The advisor transcript is observability-only: register it as a non-peer
+		// `advisor` kind under its owning session so the Hub can show its read-only
+		// transcript, but it never joins agent-facing rosters and is not revivable.
+		if (isAdvisorTranscriptName(entry.name)) {
+			const owner = parentId ?? MAIN_AGENT_ID;
+			// `__advisor.jsonl` → the default advisor (no slug); `__advisor.<slug>.jsonl`
+			// → a named advisor, keyed and labeled by its slug.
+			const slug =
+				entry.name === ADVISOR_TRANSCRIPT_FILENAME ? "" : entry.name.slice("__advisor.".length, -".jsonl".length);
+			const advisorId = slug ? `${owner}/advisor:${slug}` : `${owner}/advisor`;
+			const displayName = slug ? `advisor:${slug}` : "advisor";
+			const existing = registry.get(advisorId);
+			// Never clobber a non-advisor ref that happens to share this id (a freak
+			// user task literally named `<owner>/advisor`): leave it, skip the advisor.
+			if (existing && existing.kind !== "advisor") continue;
+			if (existing?.sessionFile !== sessionFile) {
+				// The id is reused across `/new`; refresh it to the current session's file.
+				if (existing) registry.unregister(advisorId);
+				registry.register({
+					id: advisorId,
+					displayName,
+					kind: "advisor",
+					parentId: owner,
+					session: null,
+					sessionFile,
+					status: "parked",
+				});
+			}
+			continue;
+		}
+		const id = entry.name.slice(0, -6);
+		if (!registry.get(id)) {
+			registry.register({
+				id,
+				displayName: id,
+				kind: "sub",
+				parentId: parentId ?? MAIN_AGENT_ID,
+				session: null,
+				sessionFile,
+				status: "parked",
+			});
+		}
+		await registerPersistedSubagentsFromDir(registry, path.join(dir, id), id);
+	}
+}

--- a/packages/coding-agent/src/tools/hub/messaging.ts
+++ b/packages/coding-agent/src/tools/hub/messaging.ts
@@ -17,6 +17,7 @@ import type { RenderResultOptions } from "../../extensibility/custom-tools/types
 import { IrcBus, type IrcDeliveryReceipt, type IrcMessage } from "../../irc/bus";
 import type { Theme } from "../../modes/theme/theme";
 import { type AgentRegistry, MAIN_AGENT_ID } from "../../registry/agent-registry";
+import { registerPersistedSubagents } from "../../registry/persisted-agents";
 import { canSpawnAtDepth } from "../../task/types";
 import { Ellipsis, renderStatusLine, renderTreeList, truncateToWidth } from "../../tui";
 import {
@@ -81,10 +82,22 @@ export function messageResult(senderId: string, waited: IrcMessage): AgentToolRe
 	};
 }
 
-export function executeList(registry: AgentRegistry, senderId: string): AgentToolResult<CoordinationDetails> {
+/**
+ * List every addressable peer, restoring parked refs from disk when a resumed
+ * session has no in-memory roster.
+ */
+export async function executeList(
+	registry: AgentRegistry,
+	senderId: string,
+): Promise<AgentToolResult<CoordinationDetails>> {
+	let refs = registry.list();
+	if (!refs.some(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")) {
+		await registerPersistedSubagents(registry, registry.get(senderId)?.sessionFile);
+		refs = registry.list();
+	}
+
 	const bus = IrcBus.global();
-	const peers = registry
-		.list()
+	const peers = refs
 		.filter(ref => ref.id !== senderId && ref.status !== "aborted" && ref.kind !== "advisor")
 		.map(ref => ({
 			id: ref.id,

--- a/packages/coding-agent/test/tools/hub-list.test.ts
+++ b/packages/coding-agent/test/tools/hub-list.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { AgentRegistry, MAIN_AGENT_ID } from "@oh-my-pi/pi-coding-agent/registry/agent-registry";
+import { executeList } from "@oh-my-pi/pi-coding-agent/tools/hub/messaging";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("hub list", () => {
+	it("restores persisted peers after the process registry is lost", async () => {
+		using tempDir = TempDir.createSync("@omp-hub-list-persisted-");
+		const sessionFile = path.join(tempDir.path(), "main.jsonl");
+		const workerSessionFile = path.join(tempDir.path(), "main", "Worker.jsonl");
+		await Bun.write(sessionFile, "");
+		await Bun.write(workerSessionFile, "");
+
+		const registry = new AgentRegistry();
+		registry.register({
+			id: MAIN_AGENT_ID,
+			displayName: MAIN_AGENT_ID,
+			kind: "main",
+			session: null,
+			sessionFile,
+			status: "running",
+		});
+
+		const result = await executeList(registry, MAIN_AGENT_ID);
+		if (!result.details) throw new Error("Expected coordination details");
+
+		expect(result.details.peers).toEqual([
+			expect.objectContaining({
+				id: "Worker",
+				kind: "sub",
+				status: "parked",
+				parentId: MAIN_AGENT_ID,
+			}),
+		]);
+		const content = result.content[0];
+		if (content?.type !== "text") throw new Error("Expected text result");
+		expect(content.text).toContain("Worker");
+		expect(content.text).toContain("parked");
+		expect(registry.get("Worker")?.sessionFile).toBe(workerSessionFile);
+	});
+});


### PR DESCRIPTION
## Repro
Create a main session file with `Peer.jsonl` under its artifacts directory, reset the process-global `AgentRegistry`, register only `Main`, then run `bun /tmp/repro-5864.ts`; before the fix, `executeList(registry, "Main")` returned `No other agents.` with exit code 1 despite the persisted peer file.

## Cause
`packages/coding-agent/src/tools/hub/messaging.ts` built `executeList` exclusively from `AgentRegistry.list()`, while `registerPersistedSubagents` lived privately in `packages/coding-agent/src/modes/components/agent-hub.ts` and therefore ran only when a human opened the Agent Hub overlay.

## Fix
- Moved persisted subagent/advisor registration into `packages/coding-agent/src/registry/persisted-agents.ts` for shared use.
- Rehydrated parked refs from the sender's active session file before returning an empty `hub`/`irc` roster.
- Kept Agent Hub UI restoration on the shared registration path and added a model-facing crash/resume regression test.
- Added the coding-agent changelog entry.

## Verification
`bun test test/tools/hub-list.test.ts test/agent-hub-activate.test.ts` passed 11 tests; `bun /tmp/repro-5864.ts` listed `Peer` as `parked` and exited 0; `bun check` passed for all packages. Fixes #5864