### PR TITLE
fix(tui): prevent settings exit flicker

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the terminal flickering when leaving a fullscreen overlay (e.g. `/settings`) on terminals that re-report their size when the alternate screen buffer toggles: the alt-toggle SIGWINCH echo is height-only, so the resize fast path no longer borrows the alternate screen for it ([#5854](https://github.com/can1357/oh-my-pi/issues/5854)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3725,15 +3725,23 @@ export class TUI extends Container {
 	}
 
 	/**
-	 * Emit a throwaway viewport repaint for the resize fast path as an alternate-
-	 * screen per-row overwrite. The normal buffer may reflow full-width rows on a
-	 * width change before the app can repaint; keeping the drag on the alternate
-	 * screen makes those transient resizes truncate instead of pushing wrapped
-	 * fragments into native scrollback. Normal-screen history is rebuilt once at
-	 * settle via `#emitFullPaint`.
+	 * Emit a throwaway viewport repaint for the resize fast path as a per-row
+	 * overwrite. A width change can make the terminal's normal buffer reflow
+	 * full-width rows before the app repaints, so a width drag borrows the
+	 * alternate screen: transient resizes truncate the viewport instead of
+	 * pushing wrapped fragments into native scrollback. A height-only resize
+	 * reflows nothing, so it repaints the normal screen in place — borrowing the
+	 * alt buffer there is pure flicker, and on terminals that re-report their
+	 * size when the alt buffer toggles it is self-sustaining: leaving a
+	 * fullscreen overlay's alt screen fires a height-only SIGWINCH echo, which
+	 * would otherwise re-borrow the alt buffer for one frame (the settings-exit
+	 * flash, #5854). Normal-screen history is rebuilt once at settle via
+	 * `#emitFullPaint`.
 	 */
 	#emitResizeViewport(window: readonly string[], height: number, contentRows: number, width: number): void {
-		let buffer = `${this.#paintBeginSequence + this.#enterResizeAltSequence()}\x1b[H`;
+		const widthChanged = this.#previousWidth > 0 && this.#previousWidth !== width;
+		const altEnter = widthChanged ? this.#enterResizeAltSequence() : "";
+		let buffer = `${this.#paintBeginSequence + altEnter}\x1b[H`;
 		for (let r = 0; r < height; r++) {
 			if (r > 0) buffer += "\r\n";
 			buffer += this.#lineRewriteSequence(window[r] ?? "", width);

--- a/packages/tui/test/resize-viewport-defer.test.ts
+++ b/packages/tui/test/resize-viewport-defer.test.ts
@@ -492,6 +492,38 @@ describe("non-multiplexer resize viewport fast path", () => {
 			}
 		});
 	});
+
+	it("does not borrow the alternate screen for a height-only resize (settings-exit flash, #5854)", async () => {
+		await withEnvPatch(NO_MULTIPLEXER_ENV, async () => {
+			const term = new VirtualTerminal(40, 10, 1000);
+			const { tui, scheduler } = makeTui(term);
+			try {
+				tui.start();
+				await scheduler.flushImmediates(term);
+
+				const writes = captureWrites(term);
+
+				// A height-only SIGWINCH — width unchanged — reflows nothing in the
+				// terminal's normal buffer, so the fast path repaints it in place.
+				// Borrowing the alt buffer here is pure flicker: on terminals that
+				// re-report their size when the alt buffer toggles, leaving a
+				// fullscreen overlay fires exactly this height-only echo, and an
+				// alt borrow would re-enter the alt screen for one frame (the flash).
+				term.resize(40, 8);
+				await scheduler.flushImmediates(term);
+
+				expect(tui.resizeViewportActive).toBe(true);
+				expect(tui.resizeViewportPaints).toBeGreaterThan(0);
+				const drag = writes.join("");
+				expect(drag).not.toContain(ALT_SCREEN_ENTER);
+				expect(drag).not.toContain("\x1b[2J");
+				expect(drag).not.toContain("\x1b[3J");
+				expect(visible(term).at(-1)).toBe("b14-y");
+			} finally {
+				tui.stop();
+			}
+		});
+	});
 });
 
 describe("resize repaints in place on terminals that re-report size on alt-screen toggle (Warp)", () => {


### PR DESCRIPTION
## Repro
On a Linux terminal that re-reports its size when the alternate screen toggles, open `/settings` and exit it. The overlay writes `CSI ?1049l`; the resulting height-only SIGWINCH enters the resize fast path and v17.0.2 writes `CSI ?1049h` again for one throwaway frame. The regression is covered by `cd packages/tui && bun test test/resize-viewport-defer.test.ts`; without this fix, the new height-only resize assertion fails because the output contains `CSI ?1049h`.

## Cause
`packages/tui/src/tui.ts` restored alternate-screen borrowing for every non-multiplexer resize frame in `TUI.#emitResizeViewport` for v17.0.2. That borrow is required for width drags, where native reflow can push wrapped fragments into scrollback, but it also ran for height-only SIGWINCH echoes caused by leaving a fullscreen overlay. Those echoes re-entered the alternate screen immediately after settings exited, producing the visible flash.

## Fix
- Borrow the alternate screen only when the current width differs from the last committed width.
- Keep height-only resize frames on the normal buffer while preserving the settled authoritative repaint.
- Add a regression test proving height-only resize output contains no alternate-screen entry while width-drag coverage continues to require it.
- Document the fix in `packages/tui/CHANGELOG.md`.

## Verification
`cd packages/tui && bun test test/resize-viewport-defer.test.ts` — 11 passed, 0 failed. `cd packages/tui && bun test test/render-regressions.test.ts` — 102 passed, 0 failed. `cd packages/tui && bun run test` — 1302 passed, 3 skipped, 0 failed. `cd packages/tui && bun run check` — passed. The regression test was also run without the source fix and failed on the unexpected `CSI ?1049h`, confirming it protects the reported behavior. Fixes #5854