### PR TITLE
fix(mcp): preserve source tool semantics

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -513,6 +513,8 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	description: string;
 	/** Parameter schema (Zod, or TypeBox for legacy/extension compat). */
 	parameters: TParams;
+	/** If false, the model may use parameters outside the declared schema. */
+	strict?: boolean;
 	/** If true, tool is excluded unless explicitly listed in --tools or agent's tools field */
 	hidden?: boolean;
 	/** If true, tool is registered but not auto-included in the initial active set.

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -573,7 +573,7 @@ export class MCPManager {
 	}
 
 	#replaceServerTools(name: string, tools: CustomTool<TSchema, MCPToolDetails>[]): void {
-		this.#tools = this.#tools.filter(t => !t.name.startsWith(`mcp__${name}_`));
+		this.#tools = this.#tools.filter(t => t.mcpServerName !== name);
 		this.#tools.push(...tools);
 		// Stable sort by name so reconnect order does not perturb the array.
 		// See `sortMCPToolsByName` for the cache-stability rationale.
@@ -762,8 +762,8 @@ export class MCPManager {
 		}
 
 		// Remove tools from this server and notify consumers
-		const hadTools = this.#tools.some(t => t.name.startsWith(`mcp__${name}_`));
-		this.#tools = this.#tools.filter(t => !t.name.startsWith(`mcp__${name}_`));
+		const hadTools = this.#tools.some(t => t.mcpServerName === name);
+		this.#tools = this.#tools.filter(t => t.mcpServerName !== name);
 		if (hadTools) this.#onToolsChanged?.(this.#tools);
 
 		// Notify prompt consumers so stale commands are cleared

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -325,6 +325,8 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly label: string;
 	readonly description: string;
 	readonly parameters: TSchema;
+	/** MCP tools use permissive schemas because servers own parameter validation. */
+	readonly strict = false;
 	/** Original MCP tool name (before normalization) */
 	readonly mcpToolName: string;
 	/** Server name */
@@ -411,6 +413,8 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly label: string;
 	readonly description: string;
 	readonly parameters: TSchema;
+	/** MCP tools use permissive schemas because servers own parameter validation. */
+	readonly strict = false;
 	/** Original MCP tool name (before normalization) */
 	readonly mcpToolName: string;
 	/** Server name */

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -889,6 +889,7 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		label: tool.label,
 		description: tool.description,
 		parameters: tool.parameters,
+		strict: tool.strict,
 		hidden: tool.hidden,
 		loadMode: tool.loadMode ?? "discoverable",
 		deferrable: tool.deferrable,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -29,7 +29,6 @@ import { getSessionSlashCommands } from "../extensibility/extensions/get-command
 import { buildSkillPromptMessage, type Skill } from "../extensibility/skills";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
-import { callTool } from "../mcp/client";
 import type { MCPManager } from "../mcp/manager";
 import type { MnemopiSessionState } from "../mnemopi/state";
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
@@ -651,61 +650,54 @@ function getUsageTokens(usage: unknown): number {
  * Create proxy tools that reuse the parent's MCP connections.
  */
 export function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
-	return mcpManager.getTools().map(tool => {
-		const mcpTool = tool as { mcpToolName?: string; mcpServerName?: string };
-		return {
-			name: tool.name,
-			label: tool.label ?? tool.name,
-			description: tool.description ?? "",
-			parameters: tool.parameters,
-			execute: async (_toolCallId, params, _onUpdate, _ctx, signal) => {
-				if (signal?.aborted) {
-					throw new ToolAbortError();
-				}
-				const serverName = mcpTool.mcpServerName ?? "";
-				const mcpToolName = mcpTool.mcpToolName ?? "";
-				try {
-					const timeoutController = new AbortController();
-					const timeoutSignal = timeoutController.signal;
-					const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
-					const result = await withAbortTimeout(
-						(async () => {
-							const connection = await untilAborted(combinedSignal, () =>
-								mcpManager.waitForConnection(serverName),
-							);
-							return callTool(connection, mcpToolName, params as Record<string, unknown>, {
-								signal: combinedSignal,
-							});
-						})(),
-						MCP_CALL_TIMEOUT_MS,
-						signal,
-						timeoutController,
+	return mcpManager.getTools().map(tool => ({
+		name: tool.name,
+		label: tool.label ?? tool.name,
+		description: tool.description ?? "",
+		parameters: tool.parameters,
+		strict: tool.strict,
+		execute: async (toolCallId, params, onUpdate, context, signal) => {
+			if (signal?.aborted) {
+				throw new ToolAbortError();
+			}
+			const serverName = tool.mcpServerName ?? "";
+			const mcpToolName = tool.mcpToolName ?? "";
+			try {
+				const timeoutController = new AbortController();
+				const timeoutSignal = timeoutController.signal;
+				const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+				const currentTool = mcpManager
+					.getTools()
+					.find(
+						candidate =>
+							candidate.mcpServerName === tool.mcpServerName && candidate.mcpToolName === tool.mcpToolName,
 					);
-					return {
-						content: (result.content ?? []).map(item =>
-							item.type === "text"
-								? { type: "text" as const, text: item.text ?? "" }
-								: { type: "text" as const, text: JSON.stringify(item) },
-						),
-						details: { serverName, mcpToolName, isError: result.isError },
-					};
-				} catch (error) {
-					if (error instanceof ToolAbortError) {
-						throw error;
-					}
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text: `MCP error: ${error instanceof Error ? error.message : String(error)}`,
-							},
-						],
-						details: { serverName, mcpToolName, isError: true },
-					};
+				if (!currentTool) {
+					throw new Error(`MCP tool "${tool.name}" is no longer available`);
 				}
-			},
-		};
-	});
+				return await withAbortTimeout(
+					currentTool.execute(toolCallId, params, onUpdate, context, combinedSignal),
+					MCP_CALL_TIMEOUT_MS,
+					signal,
+					timeoutController,
+				);
+			} catch (error) {
+				if (error instanceof ToolAbortError) {
+					throw error;
+				}
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `MCP error: ${error instanceof Error ? error.message : String(error)}`,
+						},
+					],
+					details: { serverName, mcpToolName, isError: true },
+					isError: true,
+				};
+			}
+		},
+	}));
 }
 
 export function createSubagentSettings(

--- a/packages/coding-agent/test/core/js-tool-bridge.test.ts
+++ b/packages/coding-agent/test/core/js-tool-bridge.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it, vi } from "bun:test";
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { callSessionTool } from "@oh-my-pi/pi-coding-agent/eval/js/tool-bridge";
+import type { CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
+import { MCPTool, type MCPToolDefinition } from "@oh-my-pi/pi-coding-agent/mcp";
+import type { MCPServerConnection } from "@oh-my-pi/pi-coding-agent/mcp/types";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
 import { type } from "arktype";
+import { createMockConnection, createMockTransport } from "../mcp-test-utils";
 
 function createTool(
 	name: string,
@@ -30,6 +34,48 @@ function createSession(tools: AgentTool[]): ToolSession {
 		settings: Settings.isolated(),
 		getToolByName: name => registry.get(name),
 	};
+}
+
+type CapturedRequest = {
+	method: string;
+	params: Record<string, unknown> | undefined;
+};
+
+function createCapturedConnection(calls: CapturedRequest[]): MCPServerConnection {
+	const transport = createMockTransport(
+		new Map([["tools/call", [{ content: [{ type: "text", text: "ok" }] }]]]),
+		(method, params) => calls.push({ method, params }),
+	);
+	return createMockConnection({ tools: {} }, transport);
+}
+
+async function expectParentMCPOutboundMatchesDirect(
+	definition: MCPToolDefinition,
+	parentArgs: Record<string, unknown>,
+	expectedArgs: Record<string, unknown>,
+): Promise<void> {
+	const directCalls: CapturedRequest[] = [];
+	const directTool = new MCPTool(createCapturedConnection(directCalls), definition);
+	await directTool.execute(
+		"direct-mcp-call",
+		{ ...parentArgs, [INTENT_FIELD]: "js prelude" },
+		undefined,
+		{} as CustomToolContext,
+	);
+
+	const parentCalls: CapturedRequest[] = [];
+	const parentTool = new MCPTool(createCapturedConnection(parentCalls), definition);
+	await callSessionTool(parentTool.name, parentArgs, {
+		session: createSession([parentTool as unknown as AgentTool]),
+	});
+
+	expect(parentCalls).toEqual(directCalls);
+	expect(parentCalls).toEqual([
+		{
+			method: "tools/call",
+			params: { name: definition.name, arguments: expectedArgs },
+		},
+	]);
 }
 
 describe("callSessionTool", () => {
@@ -58,6 +104,59 @@ describe("callSessionTool", () => {
 			undefined,
 		);
 		expect(statuses).toEqual([expect.objectContaining({ op: "read", path: "/tmp/demo.txt", chars: 5 })]);
+	});
+
+	it("matches direct MCP outbound arguments for parent JS sparse issue comments", async () => {
+		await expectParentMCPOutboundMatchesDirect(
+			{
+				name: "save_comment",
+				description: "Save a comment on an issue",
+				inputSchema: {
+					type: "object",
+					properties: { body: { type: "string" }, issueId: { type: "string" } },
+					required: ["body", "issueId"],
+				},
+			},
+			{ body: "x", issueId: "ENG-1" },
+			{ body: "x", issueId: "ENG-1" },
+		);
+	});
+
+	it("preserves parent JS status update pairs at the MCP boundary", async () => {
+		await expectParentMCPOutboundMatchesDirect(
+			{
+				name: "save_comment",
+				description: "Save a comment on an issue",
+				inputSchema: {
+					type: "object",
+					properties: {
+						body: { type: "string" },
+						issueId: { type: "string" },
+						statusUpdateId: { type: "string" },
+						statusUpdateType: { type: "string" },
+					},
+					required: ["body", "issueId"],
+				},
+			},
+			{ body: "x", issueId: "ENG-1", statusUpdateId: "update-1", statusUpdateType: "progress" },
+			{ body: "x", issueId: "ENG-1", statusUpdateId: "update-1", statusUpdateType: "progress" },
+		);
+	});
+
+	it("preserves a schema-declared parent JS intent at the MCP boundary", async () => {
+		await expectParentMCPOutboundMatchesDirect(
+			{
+				name: "echo",
+				description: "Echo an intent",
+				inputSchema: {
+					type: "object",
+					properties: { i: { type: "string" } },
+					required: ["i"],
+				},
+			},
+			{},
+			{ i: "js prelude" },
+		);
 	});
 
 	it("returns structured tool results when details or images are present", async () => {

--- a/packages/coding-agent/test/mcp-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
 import type { MCPReconnect } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
 import { DeferredMCPTool, isRetriableConnectionError, MCPTool } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
-import type { MCPServerConnection, MCPToolCallResult, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import type {
+	MCPServerConnection,
+	MCPStdioServerConfig,
+	MCPToolCallResult,
+	MCPTransport,
+} from "@oh-my-pi/pi-coding-agent/mcp/types";
 import { ToolAbortError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
 
 // ---------------------------------------------------------------------------
@@ -306,5 +313,46 @@ describe("reconnect abort propagation", () => {
 		controller.abort();
 
 		await expect(pending).rejects.toBeInstanceOf(ToolAbortError);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// MCPManager reconnect tool replacement
+// ---------------------------------------------------------------------------
+
+const MANAGER_FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "instructions-mcp.ts");
+const DASHED_SERVER_NAME = "test-server";
+const DASHED_SERVER_TOOL_NAME = "mcp__test_server_do_thing";
+
+describe("MCPManager reconnect tool replacement", () => {
+	it("replaces the old tool identity for a dashed server name", async () => {
+		const manager = new MCPManager(process.cwd());
+		const config: MCPStdioServerConfig = {
+			type: "stdio",
+			command: process.execPath,
+			args: [MANAGER_FIXTURE_PATH],
+		};
+
+		try {
+			const connected = await manager.connectServers({ [DASHED_SERVER_NAME]: config }, {});
+			expect(connected.errors.has(DASHED_SERVER_NAME)).toBe(false);
+
+			const initialTools = manager.getTools().filter(tool => tool.name === DASHED_SERVER_TOOL_NAME);
+			expect(initialTools).toHaveLength(1);
+			const oldTool = initialTools[0];
+			if (!oldTool) throw new Error("expected the fixture tool to be registered");
+			const oldConnection = manager.getConnection(DASHED_SERVER_NAME);
+			if (!oldConnection) throw new Error("expected the fixture server to be connected");
+
+			const replacementConnection = await manager.reconnectServer(DASHED_SERVER_NAME, { manual: true });
+			expect(replacementConnection).not.toBeNull();
+			expect(replacementConnection).not.toBe(oldConnection);
+
+			const replacementTools = manager.getTools().filter(tool => tool.name === DASHED_SERVER_TOOL_NAME);
+			expect(replacementTools).toHaveLength(1);
+			expect(replacementTools[0]).not.toBe(oldTool);
+		} finally {
+			await manager.disconnectAll();
+		}
 	});
 });

--- a/packages/coding-agent/test/mcp-tool-args.test.ts
+++ b/packages/coding-agent/test/mcp-tool-args.test.ts
@@ -74,6 +74,20 @@ async function createLocalImageContext(
 }
 
 describe("MCP tool arguments", () => {
+	it("marks active MCP tools explicitly non-strict", () => {
+		const tool = new MCPTool(createCapturedConnection([]), createSearchToolDefinition());
+
+		expect(tool.strict).toBe(false);
+	});
+
+	it("marks deferred MCP tools explicitly non-strict", () => {
+		const tool = new DeferredMCPTool("intellij-index", createSearchToolDefinition(), async () =>
+			createCapturedConnection([]),
+		);
+
+		expect(tool.strict).toBe(false);
+	});
+
 	it("omits optional empty placeholders before tools/call", async () => {
 		const calls: CapturedRequest[] = [];
 		const tool = new MCPTool(createCapturedConnection(calls), createSearchToolDefinition());

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -98,6 +98,29 @@ describe("createAgentSession defaultInactive tool activation", () => {
 	afterAll(() => {
 		removeSyncWithRetries(registryAuthDir);
 	});
+	it("preserves explicit non-strict custom tools in the model-facing session registry", async () => {
+		const tempDir = makeTempDir();
+		const customTool = {
+			name: "sdk_custom_non_strict_tool",
+			label: "SDK Custom Non-Strict Tool",
+			description: "Checks strict metadata survives SDK registration.",
+			strict: false,
+			parameters: type({ value: "string" }),
+			async execute() {
+				return { content: [{ type: "text" as const, text: "ok" }] };
+			},
+		};
+		const { session } = await createAgentSession({
+			...baseOptions(tempDir),
+			customTools: [customTool],
+		});
+
+		try {
+			expect(session.getToolByName(customTool.name)?.strict).toBe(false);
+		} finally {
+			await session.dispose();
+		}
+	});
 
 	it("excludes defaultInactive extension tools from the initial active set unless explicitly requested", async () => {
 		const tempDir = makeTempDir();

--- a/packages/coding-agent/test/task-executor-mcp-parity.test.ts
+++ b/packages/coding-agent/test/task-executor-mcp-parity.test.ts
@@ -1,0 +1,450 @@
+import { describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { CustomTool, CustomToolContext } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools";
+import { MCPManager } from "@oh-my-pi/pi-coding-agent/mcp/manager";
+import { MCPTool } from "@oh-my-pi/pi-coding-agent/mcp/tool-bridge";
+import type { MCPServerConnection, MCPToolDefinition, MCPTransport } from "@oh-my-pi/pi-coding-agent/mcp/types";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { INTENT_FIELD } from "@oh-my-pi/pi-wire";
+import { createMCPProxyTools } from "../src/task/executor";
+import { createMockConnection, createMockTransport } from "./mcp-test-utils";
+
+type CapturedRequest = {
+	method: string;
+	params: Record<string, unknown> | undefined;
+};
+
+const issueCommentDefinition: MCPToolDefinition = {
+	name: "save_comment",
+	description: "Save a comment on an issue",
+	inputSchema: {
+		type: "object",
+		properties: {
+			body: { type: "string" },
+			issueId: { type: "string" },
+			optionalString: { type: "string" },
+			optionalObject: { type: "object" },
+			optionalUndefined: { type: "string" },
+			count: { type: "number" },
+			enabled: { type: "boolean" },
+			statusUpdateId: { type: "string" },
+			statusUpdateType: { type: "string" },
+		},
+		required: ["body", "issueId"],
+	},
+};
+
+function createCapturedConnection(calls: CapturedRequest[]): MCPServerConnection {
+	const transport = createMockTransport(
+		new Map([["tools/call", [{ content: [{ type: "text" as const, text: "ok" }], isError: false }]]]),
+		(method, params) => calls.push({ method, params }),
+	);
+	return createMockConnection({ tools: {} }, transport);
+}
+
+function createProxy(source: CustomTool, connection: MCPServerConnection): CustomTool {
+	const manager = new MCPManager(process.cwd());
+	vi.spyOn(manager, "getTools").mockReturnValue([source]);
+	vi.spyOn(manager, "waitForConnection").mockResolvedValue(connection);
+	const proxy = createMCPProxyTools(manager)[0];
+	if (!proxy) throw new Error("Expected an MCP proxy tool");
+	return proxy;
+}
+
+function mockTransport(requestFn: (...args: Parameters<MCPTransport["request"]>) => Promise<unknown>): MCPTransport {
+	return {
+		connected: true,
+		request: requestFn as MCPTransport["request"],
+		async notify() {},
+		async close() {},
+	};
+}
+
+function makeConnection(transport: MCPTransport, name: string): MCPServerConnection {
+	return {
+		name,
+		config: { type: "stdio", command: "echo" },
+		transport,
+		serverInfo: { name: "test", version: "1.0" },
+		capabilities: { tools: {} },
+	};
+}
+
+function createFakeMCPTool(execute: CustomTool["execute"], strict: boolean): CustomTool {
+	return {
+		name: "mcp__test_server_save_comment",
+		label: "test-server/save_comment",
+		description: "Save a comment on an issue",
+		strict,
+		mcpToolName: "save_comment",
+		mcpServerName: "test-server",
+		parameters: { type: "object", properties: {} } as CustomTool["parameters"],
+		execute,
+	};
+}
+
+describe("task MCP proxy parity", () => {
+	it("omits optional placeholders while preserving zero and false on task issue comments", async () => {
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const source = new MCPTool(connection, issueCommentDefinition);
+		const proxy = createProxy(source, connection);
+
+		await proxy.execute(
+			"task-call-1",
+			{
+				body: "x",
+				issueId: "ENG-1",
+				optionalString: "",
+				optionalObject: {},
+				optionalUndefined: undefined,
+				count: 0,
+				enabled: false,
+				[INTENT_FIELD]: "js prelude",
+			},
+			undefined,
+			{} as CustomToolContext,
+		);
+
+		expect(calls).toEqual([
+			{
+				method: "tools/call",
+				params: {
+					name: "save_comment",
+					arguments: { body: "x", issueId: "ENG-1", count: 0, enabled: false },
+				},
+			},
+		]);
+	});
+
+	it("strips the harness intent from sparse task issue comments", async () => {
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const source = new MCPTool(connection, issueCommentDefinition);
+		const proxy = createProxy(source, connection);
+
+		await proxy.execute(
+			"task-call-2",
+			{ body: "x", issueId: "ENG-1", [INTENT_FIELD]: "js prelude" },
+			undefined,
+			{} as CustomToolContext,
+		);
+
+		expect(calls).toEqual([
+			{
+				method: "tools/call",
+				params: { name: "save_comment", arguments: { body: "x", issueId: "ENG-1" } },
+			},
+		]);
+	});
+
+	it("preserves a nonempty task status update pair", async () => {
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const source = new MCPTool(connection, issueCommentDefinition);
+		const proxy = createProxy(source, connection);
+
+		await proxy.execute(
+			"task-call-3",
+			{ body: "x", issueId: "ENG-1", statusUpdateId: "update-1", statusUpdateType: "progress" },
+			undefined,
+			{} as CustomToolContext,
+		);
+
+		expect(calls).toEqual([
+			{
+				method: "tools/call",
+				params: {
+					name: "save_comment",
+					arguments: {
+						body: "x",
+						issueId: "ENG-1",
+						statusUpdateId: "update-1",
+						statusUpdateType: "progress",
+					},
+				},
+			},
+		]);
+	});
+
+	it("preserves a schema-declared task i argument", async () => {
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const source = new MCPTool(connection, {
+			name: "echo",
+			description: "Echo an intent",
+			inputSchema: {
+				type: "object",
+				properties: { i: { type: "string" } },
+				required: ["i"],
+			},
+		});
+		const proxy = createProxy(source, connection);
+
+		await proxy.execute("task-call-4", { i: "server intent" }, undefined, {} as CustomToolContext);
+
+		expect(calls).toEqual([{ method: "tools/call", params: { name: "echo", arguments: { i: "server intent" } } }]);
+	});
+
+	it("delegates the original execution tuple with the task combined signal", async () => {
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const sourceResult = { content: [{ type: "text" as const, text: "source result" }] };
+		const sourceExecute = vi.fn<CustomTool["execute"]>(async () => sourceResult);
+		const source = createFakeMCPTool(sourceExecute as CustomTool["execute"], false);
+		const proxy = createProxy(source, connection);
+		const toolCallId = "task-call-5";
+		const params = { body: "x" };
+		const onUpdate = () => {};
+		const context = {} as CustomToolContext;
+		const caller = new AbortController();
+
+		await proxy.execute(toolCallId, params, onUpdate, context, caller.signal);
+
+		expect(sourceExecute).toHaveBeenCalledTimes(1);
+		const forwarded = sourceExecute.mock.calls[0];
+		expect(forwarded?.[0]).toBe(toolCallId);
+		expect(forwarded?.[1]).toBe(params);
+		expect(forwarded?.[2]).toBe(onUpdate);
+		expect(forwarded?.[3]).toBe(context);
+		expect(forwarded?.[4]).toBeDefined();
+		expect(forwarded?.[4]).not.toBe(caller.signal);
+		expect((forwarded?.[4] as AbortSignal | undefined)?.aborted).toBe(false);
+		caller.abort();
+		expect((forwarded?.[4] as AbortSignal | undefined)?.aborted).toBe(true);
+	});
+
+	it("returns the complete source result unchanged", async () => {
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const sourceResult = {
+			content: [{ type: "text" as const, text: "source error" }],
+			isError: true,
+			details: {
+				serverName: "test-server",
+				mcpToolName: "save_comment",
+				isError: true,
+				rawContent: [
+					{ type: "text" as const, text: "source error" },
+					{ type: "image" as const, data: "aW1hZ2U=", mimeType: "image/png" },
+				],
+				provider: "source-provider",
+				providerName: "Source Provider",
+			},
+		};
+		const source = createFakeMCPTool(async () => sourceResult, false);
+		const proxy = createProxy(source, connection);
+
+		const result = await proxy.execute("task-call-6", {}, undefined, {} as CustomToolContext);
+
+		expect(result).toBe(sourceResult);
+		expect(result.isError).toBe(true);
+		expect(result.details).toEqual({
+			serverName: "test-server",
+			mcpToolName: "save_comment",
+			isError: true,
+			rawContent: [
+				{ type: "text", text: "source error" },
+				{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+			],
+			provider: "source-provider",
+			providerName: "Source Provider",
+		});
+	});
+
+	it("resolves local URLs through the source task context", async () => {
+		using tempDir = TempDir.createSync("@pi-task-mcp-local-");
+		const artifactsDir = tempDir.join("artifacts");
+		const writtenPath = path.join(artifactsDir, "local", "issue-attachment.txt");
+		await Bun.write(writtenPath, "attachment");
+		const expectedPath = await fs.realpath(writtenPath);
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const source = new MCPTool(connection, {
+			name: "attach_file",
+			description: "Attach a file",
+			inputSchema: {
+				type: "object",
+				properties: { file: { type: "string" } },
+				required: ["file"],
+			},
+		});
+		const proxy = createProxy(source, connection);
+		const context = {
+			localProtocolOptions: {
+				getArtifactsDir: () => artifactsDir,
+				getSessionId: () => "task-session",
+			},
+		} as CustomToolContext;
+
+		await proxy.execute("task-call-7", { file: "local://issue-attachment.txt" }, undefined, context);
+
+		expect(calls).toEqual([
+			{
+				method: "tools/call",
+				params: { name: "attach_file", arguments: { file: expectedPath } },
+			},
+		]);
+	});
+
+	it("reuses the source reconnect behavior after a task MCP transport failure", async () => {
+		let oldCalls = 0;
+		let newCalls = 0;
+		let reconnects = 0;
+		const oldConnection = makeConnection(
+			mockTransport(async () => {
+				oldCalls++;
+				throw new Error("ECONNREFUSED");
+			}),
+			"test-server",
+		);
+		const newConnection = makeConnection(
+			mockTransport(async () => {
+				newCalls++;
+				return { content: [{ type: "text" as const, text: "reconnected" }], isError: false };
+			}),
+			"reconnected-server",
+		);
+		const source = new MCPTool(oldConnection, issueCommentDefinition, async () => {
+			reconnects++;
+			return newConnection;
+		});
+		const proxy = createProxy(source, oldConnection);
+
+		const result = await proxy.execute(
+			"task-call-8",
+			{ body: "x", issueId: "ENG-1" },
+			undefined,
+			{} as CustomToolContext,
+		);
+
+		expect(reconnects).toBe(1);
+		expect(oldCalls).toBe(1);
+		expect(newCalls).toBe(1);
+		expect(result.content).toEqual([{ type: "text", text: "reconnected" }]);
+	});
+
+	it("routes a pre-existing proxy to the replacement MCP source without reconnecting the stale source", async () => {
+		let staleCalls = 0;
+		let replacementCalls = 0;
+		let staleReconnects = 0;
+		let replacementTeardowns = 0;
+		const replacementRequests: CapturedRequest[] = [];
+		const staleConnection = makeConnection(
+			mockTransport(async () => {
+				staleCalls++;
+				throw new Error("ECONNREFUSED stale connection");
+			}),
+			"test-server",
+		);
+		const replacementTransport = mockTransport(async (method, params) => {
+			replacementCalls++;
+			replacementRequests.push({ method, params });
+			return { content: [{ type: "text" as const, text: "replacement result" }], isError: false };
+		});
+		const replacementConnection = makeConnection(replacementTransport, "test-server");
+		replacementTransport.close = async () => {
+			replacementTeardowns++;
+		};
+		const staleSource = new MCPTool(staleConnection, issueCommentDefinition, async () => {
+			staleReconnects++;
+			await replacementConnection.transport.close();
+			return replacementConnection;
+		});
+		const replacementSource = new MCPTool(replacementConnection, issueCommentDefinition);
+		const replacementExecute = vi.spyOn(replacementSource, "execute");
+		const manager = new MCPManager(process.cwd());
+		let currentTools: CustomTool[] = [staleSource];
+		vi.spyOn(manager, "getTools").mockImplementation(() => currentTools);
+		const proxy = createMCPProxyTools(manager)[0];
+		if (!proxy) throw new Error("Expected an MCP proxy tool");
+
+		currentTools = [replacementSource];
+		const toolCallId = "task-call-after-reconnect";
+		const params = { body: "replacement", issueId: "ENG-317" };
+		const onUpdate = () => {};
+		const context = {} as CustomToolContext;
+		const caller = new AbortController();
+
+		const result = await proxy.execute(toolCallId, params, onUpdate, context, caller.signal);
+
+		expect({ staleCalls, staleReconnects, replacementTeardowns }).toEqual({
+			staleCalls: 0,
+			staleReconnects: 0,
+			replacementTeardowns: 0,
+		});
+		expect(replacementCalls).toBe(1);
+		expect(replacementRequests).toEqual([
+			{
+				method: "tools/call",
+				params: { name: "save_comment", arguments: params },
+			},
+		]);
+		expect(result.content).toEqual([{ type: "text", text: "replacement result" }]);
+		const forwarded = replacementExecute.mock.calls[0];
+		expect(forwarded?.[0]).toBe(toolCallId);
+		expect(forwarded?.[1]).toBe(params);
+		expect(forwarded?.[2]).toBe(onUpdate);
+		expect(forwarded?.[3]).toBe(context);
+		expect(forwarded?.[4]).toBeDefined();
+		expect(forwarded?.[4]).not.toBe(caller.signal);
+		expect((forwarded?.[4] as AbortSignal | undefined)?.aborted).toBe(false);
+	});
+	it("routes a pre-existing proxy by raw MCP server and tool identity when normalized names collide", async () => {
+		const sourceARequests: CapturedRequest[] = [];
+		const collidingBRequests: CapturedRequest[] = [];
+		const sourceAConnection = makeConnection(
+			mockTransport(async (method, params) => {
+				sourceARequests.push({ method, params });
+				return { content: [{ type: "text" as const, text: "source A result" }], isError: false };
+			}),
+			"linear-mcp",
+		);
+		const collidingBConnection = makeConnection(
+			mockTransport(async (method, params) => {
+				collidingBRequests.push({ method, params });
+				return { content: [{ type: "text" as const, text: "colliding B result" }], isError: false };
+			}),
+			"linear_mcp",
+		);
+		const sourceA = new MCPTool(sourceAConnection, { ...issueCommentDefinition, name: "save-comment" });
+		const collidingB = new MCPTool(collidingBConnection, { ...issueCommentDefinition, name: "save_comment" });
+		expect(sourceA.name).toBe(collidingB.name);
+
+		const manager = new MCPManager(process.cwd());
+		let currentTools: CustomTool[] = [sourceA];
+		vi.spyOn(manager, "getTools").mockImplementation(() => currentTools);
+		const proxy = createMCPProxyTools(manager)[0];
+		if (!proxy) throw new Error("Expected an MCP proxy tool");
+
+		currentTools = [collidingB, sourceA];
+		const params = { body: "identity-sensitive", issueId: "ENG-317" };
+		const result = await proxy.execute(
+			"task-call-normalized-name-collision",
+			params,
+			undefined,
+			{} as CustomToolContext,
+		);
+
+		expect({ sourceARequests, collidingBRequests, result: result.content }).toEqual({
+			sourceARequests: [
+				{
+					method: "tools/call",
+					params: { name: "save-comment", arguments: params },
+				},
+			],
+			collidingBRequests: [],
+			result: [{ type: "text", text: "source A result" }],
+		});
+	});
+
+	it("exposes an explicitly non-strict source MCP tool as non-strict to task models", () => {
+		const calls: CapturedRequest[] = [];
+		const connection = createCapturedConnection(calls);
+		const source = createFakeMCPTool(async () => ({ content: [] }), false);
+		const proxy = createProxy(source, connection);
+
+		expect(proxy.strict).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/task-executor-mcp-timeout.test.ts
+++ b/packages/coding-agent/test/task-executor-mcp-timeout.test.ts
@@ -1,7 +1,8 @@
 import { expect, test, vi } from "bun:test";
-import type { CustomTool, CustomToolContext } from "../src/extensibility/custom-tools/types";
+import type { CustomToolContext } from "../src/extensibility/custom-tools/types";
 import { MCPManager } from "../src/mcp/manager";
-import type { MCPRequestOptions, MCPServerConnection, MCPTransport } from "../src/mcp/types";
+import { MCPTool } from "../src/mcp/tool-bridge";
+import type { MCPRequestOptions, MCPServerConnection, MCPToolDefinition, MCPTransport } from "../src/mcp/types";
 import { createMCPProxyTools } from "../src/task/executor";
 import { ToolAbortError } from "../src/tools/tool-errors";
 
@@ -45,24 +46,19 @@ function createFakeConnection() {
 	};
 }
 
+const hangingToolDefinition: MCPToolDefinition = {
+	name: "test_tool",
+	description: "A tool whose source MCP transport hangs until aborted",
+	inputSchema: { type: "object", properties: {} },
+};
+
 test("MCP proxy tool aborts underlying operation on caller abort", async () => {
 	const fake = createFakeConnection();
 	const manager = new MCPManager(process.cwd());
 
-	const toolsData: CustomTool[] = [
-		{
-			name: "test_tool",
-			label: "Test Tool",
-			description: "A test tool",
-			strict: false,
-			mcpToolName: "test_tool",
-			mcpServerName: "test-server",
-			parameters: { type: "object", properties: {} },
-			execute: async () => ({ content: [] }),
-		} as CustomTool,
-	];
+	const sourceTool = new MCPTool(fake.connection, hangingToolDefinition);
 
-	vi.spyOn(manager, "getTools").mockReturnValue(toolsData);
+	vi.spyOn(manager, "getTools").mockReturnValue([sourceTool]);
 	vi.spyOn(manager, "waitForConnection").mockResolvedValue(fake.connection);
 
 	const tools = createMCPProxyTools(manager);
@@ -104,20 +100,9 @@ test("MCP proxy tool aborts underlying operation on timeout", async () => {
 		const fake = createFakeConnection();
 		const manager = new MCPManager(process.cwd());
 
-		const toolsData: CustomTool[] = [
-			{
-				name: "test_tool",
-				label: "Test Tool",
-				description: "A test tool",
-				strict: false,
-				mcpToolName: "test_tool",
-				mcpServerName: "test-server",
-				parameters: { type: "object", properties: {} },
-				execute: async () => ({ content: [] }),
-			} as CustomTool,
-		];
+		const sourceTool = new MCPTool(fake.connection, hangingToolDefinition);
 
-		vi.spyOn(manager, "getTools").mockReturnValue(toolsData);
+		vi.spyOn(manager, "getTools").mockReturnValue([sourceTool]);
 		vi.spyOn(manager, "waitForConnection").mockResolvedValue(fake.connection);
 
 		const tools = createMCPProxyTools(manager);


### PR DESCRIPTION
## Summary

- mark MCP-backed tools explicitly non-strict through model-facing SDK and extension definitions
- delegate task/subagent proxy execution through the current source `MCPTool` instead of reconstructing raw calls
- resolve proxy and manager ownership by exact raw MCP server/tool metadata, including reconnect replacement
- preserve sparse argument shaping, local URL handling, result metadata, aborts, and the 60-second task timeout

## Tests

- `bun test --verbose packages/coding-agent/test/mcp-tool-args.test.ts packages/coding-agent/test/task-executor-mcp-parity.test.ts packages/coding-agent/test/task-executor-mcp-timeout.test.ts packages/coding-agent/test/sdk-tool-activation.test.ts packages/coding-agent/test/core/js-tool-bridge.test.ts packages/ai/test/openai-tool-strict-mode.test.ts packages/coding-agent/test/mcp-reconnect.test.ts` (91 pass)
- `bun run check:types` in `packages/coding-agent`
- `bun biome check` on all changed production and test files

Linear: ENG-317