### PR TITLE
fix(extensions): restore legacy Kimi provider compatibility

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the `createAssistantMessageEventStream()` root export used by legacy provider extensions ([#5879](https://github.com/can1357/oh-my-pi/issues/5879)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -195,3 +195,8 @@ export class AssistantMessageEventStream extends EventStream<AssistantMessageEve
 		this.endWaiting();
 	}
 }
+
+/** Create an assistant-message event stream for legacy extension providers. */
+export function createAssistantMessageEventStream(): AssistantMessageEventStream {
+	return new AssistantMessageEventStream();
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy provider extensions failing to load when they use the historical synchronous auth-storage surface ([#5879](https://github.com/can1357/oh-my-pi/issues/5879)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -13,7 +13,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import { type AuthCredential, SqliteAuthCredentialStore, type TSchema } from "@oh-my-pi/pi-ai";
@@ -612,16 +612,16 @@ export function createLsToolDefinition(cwd: string, options?: LsToolOptions): To
 			const ops = options?.operations;
 			const exists = ops
 				? await ops.exists(absolutePath)
-				: await fs.stat(absolutePath).then(
+				: await fs.promises.stat(absolutePath).then(
 						() => true,
 						() => false,
 					);
 			if (!exists) throw new Error(`Path not found: ${absolutePath}`);
-			const stat = ops ? await ops.stat(absolutePath) : await fs.stat(absolutePath);
+			const stat = ops ? await ops.stat(absolutePath) : await fs.promises.stat(absolutePath);
 			if (!stat.isDirectory()) {
 				return { content: [{ type: "text", text: rawPath }] };
 			}
-			const entries = ops ? await ops.readdir(absolutePath) : await fs.readdir(absolutePath);
+			const entries = ops ? await ops.readdir(absolutePath) : await fs.promises.readdir(absolutePath);
 			const sorted = [...entries].sort((a, b) => a.localeCompare(b));
 			const limited = sorted.slice(0, limit);
 			const output = limited.join("\n");
@@ -1106,7 +1106,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 				: path.resolve(this.#state.cwd, resourcePath);
 			const files: string[] = [];
 			try {
-				const stat = await fs.stat(resolvedPath);
+				const stat = await fs.promises.stat(resolvedPath);
 				if (stat.isDirectory()) {
 					const glob = new Bun.Glob("**/*.md");
 					for await (const entry of glob.scan({ cwd: resolvedPath, absolute: false, onlyFiles: true })) {
@@ -1301,6 +1301,10 @@ export async function createAgentSession(
  * call `AuthStorage.create().get()` during module initialization.
  */
 export class AuthStorage {
+	constructor() {
+		fs.mkdirSync(path.dirname(getAgentDbPath()), { recursive: true, mode: 0o700 });
+	}
+
 	static create(): AuthStorage {
 		return new AuthStorage();
 	}

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -12,12 +12,18 @@
  * the same module identity as a direct `@oh-my-pi/pi-coding-agent` import.
  */
 
+import { Database } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
-import type { TSchema } from "@oh-my-pi/pi-ai";
+import { type AuthCredential, SqliteAuthCredentialStore, type TSchema } from "@oh-my-pi/pi-ai";
 import { Text } from "@oh-my-pi/pi-tui";
-import { getAgentDir, getProjectDir, parseFrontmatter as parseOmpFrontmatter } from "@oh-my-pi/pi-utils";
+import {
+	getAgentDbPath,
+	getAgentDir,
+	getProjectDir,
+	parseFrontmatter as parseOmpFrontmatter,
+} from "@oh-my-pi/pi-utils";
 import type { PromptTemplate } from "../config/prompt-templates";
 import { type SettingPath, Settings } from "../config/settings";
 import { EditTool } from "../edit";
@@ -1286,6 +1292,42 @@ export async function createAgentSession(
 	}
 
 	return ompCreateAgentSession(forwarded);
+}
+
+/**
+ * Synchronous auth storage surface retained for legacy extensions.
+ *
+ * Modern OMP auth storage is asynchronous, while older provider extensions
+ * call `AuthStorage.create().get()` during module initialization.
+ */
+export class AuthStorage {
+	static create(): AuthStorage {
+		return new AuthStorage();
+	}
+
+	get(provider: string): AuthCredential | undefined {
+		const store = new SqliteAuthCredentialStore(new Database(getAgentDbPath()));
+		try {
+			return store.listAuthCredentials(provider)[0]?.credential;
+		} finally {
+			store.close();
+		}
+	}
+
+	set(provider: string, credential: AuthCredential): void {
+		const store = new SqliteAuthCredentialStore(new Database(getAgentDbPath()));
+		try {
+			store.upsertAuthCredentialForProvider(provider, credential);
+		} finally {
+			store.close();
+		}
+	}
+}
+
+/** Read the first active credential for a legacy extension provider. */
+export function readStoredCredential(provider: string): AuthCredential | undefined {
+	const storage = AuthStorage.create();
+	return storage.get(provider);
 }
 
 export * from "../index";

--- a/packages/coding-agent/test/issue-5879-legacy-event-stream-factory.test.ts
+++ b/packages/coding-agent/test/issue-5879-legacy-event-stream-factory.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("issue #5879: legacy provider compatibility", () => {
+	it("loads an extension that calls historical stream and auth exports", async () => {
+		const projectDir = TempDir.createSync("@issue-5879-");
+		const extensionPath = path.join(projectDir.path(), "pi-provider-like-plugin", "index.ts");
+		await Bun.write(
+			extensionPath,
+			[
+				'import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";',
+				'import { AuthStorage } from "@earendil-works/pi-coding-agent";',
+				"",
+				"export default function() {",
+				"\tconst stream = createAssistantMessageEventStream();",
+				'\tconst credential = AuthStorage.create().get("issue-5879-missing-provider");',
+				'\tif (credential !== undefined) throw new Error("Unexpected test credential");',
+				'\tif (typeof stream.push !== "function") throw new Error("Invalid assistant message event stream");',
+				"}",
+			].join("\n"),
+		);
+
+		try {
+			const result = await loadExtensions([extensionPath], projectDir.path());
+
+			expect(result.errors).toEqual([]);
+			expect(result.extensions).toHaveLength(1);
+		} finally {
+			projectDir.removeSync();
+		}
+	});
+});

--- a/packages/coding-agent/test/issue-5879-legacy-event-stream-factory.test.ts
+++ b/packages/coding-agent/test/issue-5879-legacy-event-stream-factory.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { __resetDirsFromEnvForTests, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
 describe("issue #5879: legacy provider compatibility", () => {
-	it("loads an extension that calls historical stream and auth exports", async () => {
+	it("creates a fresh agent database while loading historical auth exports", async () => {
 		const projectDir = TempDir.createSync("@issue-5879-");
+		const freshAgentDir = projectDir.join("fresh", "agent");
+		const originalDirEnv: Record<string, string | undefined> = {
+			PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+			OMP_PROFILE: process.env.OMP_PROFILE,
+			PI_PROFILE: process.env.PI_PROFILE,
+		};
 		const extensionPath = path.join(projectDir.path(), "pi-provider-like-plugin", "index.ts");
 		await Bun.write(
 			extensionPath,
@@ -22,12 +28,21 @@ describe("issue #5879: legacy provider compatibility", () => {
 			].join("\n"),
 		);
 
+		setAgentDir(freshAgentDir);
+
 		try {
 			const result = await loadExtensions([extensionPath], projectDir.path());
 
 			expect(result.errors).toEqual([]);
 			expect(result.extensions).toHaveLength(1);
+			expect(await Bun.file(path.join(freshAgentDir, "agent.db")).exists()).toBe(true);
 		} finally {
+			for (const key in originalDirEnv) {
+				const value = originalDirEnv[key];
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+			__resetDirsFromEnvForTests();
 			projectDir.removeSync();
 		}
 	});


### PR DESCRIPTION
## Repro
With an isolated OMP home, `HOME=/tmp/omp-5879-repro XDG_CONFIG_HOME=/tmp/omp-5879-repro/config XDG_DATA_HOME=/tmp/omp-5879-repro/data bun packages/coding-agent/src/cli.ts plugin install npm:pi-provider-kimi-code` exited 1 because the legacy pi-ai root lacked `createAssistantMessageEventStream`; after restoring it, loading the installed provider exposed a second legacy-surface mismatch where modern asynchronous `AuthStorage.create()` was consumed as the historical synchronous API.

## Cause
`packages/ai/src/utils/event-stream.ts` had dropped the historical factory while `packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts` continued to rely on the pi-ai root barrel. Separately, `packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts` re-exported modern `AuthStorage`, producing a hybrid legacy surface incompatible with `pi-provider-kimi-code@0.6.7`. The current bundled catalog already contains `kimi-code/k3` with the coding endpoint, reasoning metadata, zero subscription cost, and 1M context window; that part was stale in the reporter's 17.0.1 snapshot.

## Fix
- Restore the public `createAssistantMessageEventStream()` compatibility factory.
- Provide the historical synchronous `AuthStorage.create().get()/set()` and `readStoredCredential()` facade over the current SQLite credential store for legacy extensions.
- Add a loader regression covering both aliased legacy package roots.
- Document the fixes in the affected package changelogs.

## Verification
`bun test packages/ai/test/event-stream.test.ts packages/coding-agent/test/issue-1215-legacy-pi-ai-import.test.ts packages/coding-agent/test/issue-5879-legacy-event-stream-factory.test.ts` passed 8 tests; `bun run check` passed in both `packages/ai` and `packages/coding-agent`; the isolated plugin-install command now reports `✔ Installed pi-provider-kimi-code@0.6.7`, and loading the installed extension exposes its `kimi-coding/k3` model without a compatibility error. A direct bundled-catalog probe confirmed `kimi-code/k3` resolves to `https://api.kimi.com/coding/v1`, reasoning enabled, zero costs, and a 1,048,576-token context window. Fixes #5879