### PR TITLE
fix(agent): preserve signed thinking-only stops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed signed thinking-only Claude stops being discarded and retried as empty responses ([#5881](https://github.com/can1357/oh-my-pi/issues/5881)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -11912,11 +11912,12 @@ export class AgentSession {
 	#isEmptyAssistantStop(assistantMessage: AssistantMessage): boolean {
 		switch (assistantMessage.stopReason) {
 			case "stop":
-				// Reasoning/thinking-only turns are not actionable: they do not
-				// answer the user and do not give the agent loop a tool call to run.
+				// Unsigned thinking alone is not actionable, but a signature is
+				// provider-authenticated content and makes the stop terminal.
 				for (const content of assistantMessage.content) {
 					if (content.type === "toolCall") return false;
 					if (content.type === "text" && hasNonWhitespace(content.text)) return false;
+					if (content.type === "thinking" && hasNonWhitespace(content.thinkingSignature ?? "")) return false;
 				}
 				return true;
 			case "toolUse":

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { scheduler } from "node:timers/promises";
 import { Agent, type AgentMessage, type AgentTool } from "@oh-my-pi/pi-agent-core";
-import { z } from "@oh-my-pi/pi-ai";
+import { type ThinkingContent, z } from "@oh-my-pi/pi-ai";
 import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -62,6 +62,15 @@ function orphanedToolUseStop(): MockResponse {
 function thinkingOnlyStop(): MockResponse {
 	return {
 		content: [{ type: "thinking", thinking: "I should inspect the next file." }],
+		stopReason: "stop",
+		usage: { output: 1, cacheRead: 100 },
+	};
+}
+
+function signedThinkingOnlyStop(): MockResponse {
+	const content: ThinkingContent = { type: "thinking", thinking: "", thinkingSignature: "nonempty" };
+	return {
+		content: [content],
 		stopReason: "stop",
 		usage: { output: 1, cacheRead: 100 },
 	};
@@ -224,6 +233,20 @@ describe("AgentSession empty stop guard", () => {
 		expect(assistantText(session.agent.state.messages)).toContain("finished after thinking-only retry");
 		expect(reminderMessages(session.agent.state.messages)).toHaveLength(1);
 		expect(emptyAssistantStops(session.agent.state.messages)).toHaveLength(0);
+	});
+
+	it("accepts a signed thinking-only stop without retrying", async () => {
+		const { session, mock } = await createHarness([
+			signedThinkingOnlyStop(),
+			{ content: ["must not be requested"], stopReason: "stop" },
+		]);
+
+		await session.prompt("finish with signed thinking");
+		await session.waitForIdle();
+
+		expect(mock.calls).toHaveLength(1);
+		expect(reminderMessages(session.agent.state.messages)).toHaveLength(0);
+		expect(session.agent.state.messages.at(-1)?.role).toBe("assistant");
 	});
 
 	it("removes orphaned tool-use stops even when retry cap is hit", async () => {


### PR DESCRIPTION
## Repro
A focused `AgentSession` fixture returns `{ type: "thinking", thinking: "", thinkingSignature: "nonempty" }` with `stopReason: "stop"`. Running `bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts` before the fix produced 2 provider calls instead of 1 and failed the regression assertion.

## Cause
`AgentSession.#isEmptyAssistantStop()` in `packages/coding-agent/src/session/agent-session.ts` only recognized non-whitespace text and tool calls as terminal content. It ignored `ThinkingContent.thinkingSignature`, even though same-model Anthropic replay treats a non-empty signature as a load-bearing provider artifact, so `#handleEmptyAssistantStop()` discarded the signed message and scheduled another provider call.

## Fix
- Treat a non-whitespace thinking signature as terminal content for normal `stop` responses while preserving retries for unsigned thinking-only and genuinely empty stops.
- Add an `AgentSession` regression covering empty visible thinking with a non-empty signature and asserting no retry reminder or second provider call.
- Document the fix in the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/agent-session-empty-stop-guard.test.ts` passes: 10 tests, 61 assertions. `bun test packages/coding-agent/test/agent-session-retry-fallback.test.ts -t refusal` passes: 2 tests, 12 assertions. `bun check` passes across all packages.

Fixes #5881