### PR TITLE
Add GMI Cloud as a first-class provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -287,6 +287,9 @@
 - Fixed Kimi Code K3 requests to send native named efforts (`low`, `high`, `max`) and use adaptive effort rather than generic token budgets on explicit Anthropic transport overrides ([#5893](https://github.com/can1357/oh-my-pi/issues/5893)).
 - Automatically invalidate and rotate OAuth credentials when an "invalidated oauth token" error occurs
 - Fixed Anthropic usage reports treating the organization response header as the account identity, which caused the 5h/7d status-line segment to disappear for OAuth credentials without stored organization metadata. ([#5698](https://github.com/can1357/oh-my-pi/issues/5698))
+### Added
+
+- Added the `gmi-cloud` provider registry definition with an API-key paste login (validates against `https://api.gmi-serving.com/v1/models`) and wired it into the provider registry, pairing with the catalog entry in `@oh-my-pi/pi-catalog`.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `gmi-cloud` provider registry definition with an API-key paste login (validates against `https://api.gmi-serving.com/v1/models`) and wired it into the provider registry, pairing with the catalog entry in `@oh-my-pi/pi-catalog`.
+
 ## [17.2.1] - 2026-07-30
 
 ### Added
@@ -287,9 +291,6 @@
 - Fixed Kimi Code K3 requests to send native named efforts (`low`, `high`, `max`) and use adaptive effort rather than generic token budgets on explicit Anthropic transport overrides ([#5893](https://github.com/can1357/oh-my-pi/issues/5893)).
 - Automatically invalidate and rotate OAuth credentials when an "invalidated oauth token" error occurs
 - Fixed Anthropic usage reports treating the organization response header as the account identity, which caused the 5h/7d status-line segment to disappear for OAuth credentials without stored organization metadata. ([#5698](https://github.com/can1357/oh-my-pi/issues/5698))
-### Added
-
-- Added the `gmi-cloud` provider registry definition with an API-key paste login (validates against `https://api.gmi-serving.com/v1/models`) and wired it into the provider registry, pairing with the catalog entry in `@oh-my-pi/pi-catalog`.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/ai/src/registry/gmi-cloud.ts
+++ b/packages/ai/src/registry/gmi-cloud.ts
@@ -1,0 +1,22 @@
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
+import type { ProviderDefinition } from "./types";
+
+export const loginGmiCloud = createApiKeyLogin({
+	providerLabel: "GMI Cloud",
+	authUrl: "https://console.gmicloud.ai",
+	instructions: "Create or copy your GMI Cloud API key",
+	promptMessage: "Paste your GMI Cloud API key",
+	placeholder: "eyJ...",
+	validation: {
+		kind: "models-endpoint",
+		provider: "GMI Cloud",
+		modelsUrl: "https://api.gmi-serving.com/v1/models",
+	},
+});
+
+export const gmiCloudProvider = {
+	id: "gmi-cloud",
+	name: "GMI Cloud",
+	login: (cb: OAuthLoginCallbacks) => loginGmiCloud(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -130,7 +130,6 @@ const ALL = [
 	siliconflowCnProvider,
 	syntheticProvider,
 	nanogptProvider,
-	gmiCloudProvider,
 	waferServerlessProvider,
 	coreWeaveProvider,
 	vercelAiGatewayProvider,
@@ -156,6 +155,7 @@ const ALL = [
 	mistralProvider,
 	minimaxProvider,
 	amazonBedrockProvider,
+	gmiCloudProvider,
 ];
 
 export type RegistryDef = (typeof ALL)[number];

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -18,6 +18,7 @@ import { fireworksProvider } from "./fireworks";
 import { githubCopilotProvider } from "./github-copilot";
 import { gitlabDuoProvider } from "./gitlab-duo";
 import { gitLabDuoWorkflowProvider } from "./gitlab-duo-workflow";
+import { gmiCloudProvider } from "./gmi-cloud";
 import { googleProvider } from "./google";
 import { googleAntigravityProvider } from "./google-antigravity";
 import { googleGeminiCliProvider } from "./google-gemini-cli";
@@ -129,6 +130,7 @@ const ALL = [
 	siliconflowCnProvider,
 	syntheticProvider,
 	nanogptProvider,
+	gmiCloudProvider,
 	waferServerlessProvider,
 	coreWeaveProvider,
 	vercelAiGatewayProvider,

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the GMI Cloud provider (`gmi-cloud`), an OpenAI-compatible inference gateway at `https://api.gmi-serving.com/v1` with dynamic model discovery via `/v1/models` and an API-key paste login. Authenticates with the `GMI_API_KEY` environment variable. The default model (`deepseek-ai/DeepSeek-V4-Flash`) is seeded into the bundled catalog so a fresh install resolves it before the first discovery pass.
+
 ## [17.2.1] - 2026-07-30
 
 ### Fixed
@@ -167,9 +171,6 @@
 - Logged LiteLLM rich-metadata endpoint failures once with their endpoint and status before falling back to incomplete `/v1/models` data ([#5801](https://github.com/can1357/oh-my-pi/issues/5801)).
 - Fixed authenticated Kimi Code discovery to preserve live effort levels, default effort, mandatory-thinking state, and per-model protocol metadata ([#5893](https://github.com/can1357/oh-my-pi/issues/5893)).
 - Fixed LiteLLM provider ignoring per-model pricing: `mapLiteLLMRichEntry` now reads `input_cost_per_token` / `output_cost_per_token` (plus cache costs) from LiteLLM rich metadata and maps them to `cost.input` / `cost.output`, falling back to the bundled reference only when LiteLLM omits cost, so proxied models no longer display as free ([#5818](https://github.com/can1357/oh-my-pi/issues/5818)).
-### Added
-
-- Added the GMI Cloud provider (`gmi-cloud`), an OpenAI-compatible inference gateway at `https://api.gmi-serving.com/v1` with dynamic model discovery via `/v1/models` and an API-key paste login. Authenticates with the `GMI_API_KEY` environment variable.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -167,6 +167,9 @@
 - Logged LiteLLM rich-metadata endpoint failures once with their endpoint and status before falling back to incomplete `/v1/models` data ([#5801](https://github.com/can1357/oh-my-pi/issues/5801)).
 - Fixed authenticated Kimi Code discovery to preserve live effort levels, default effort, mandatory-thinking state, and per-model protocol metadata ([#5893](https://github.com/can1357/oh-my-pi/issues/5893)).
 - Fixed LiteLLM provider ignoring per-model pricing: `mapLiteLLMRichEntry` now reads `input_cost_per_token` / `output_cost_per_token` (plus cache costs) from LiteLLM rich metadata and maps them to `cost.input` / `cost.output`, falling back to the bundled reference only when LiteLLM omits cost, so proxied models no longer display as free ([#5818](https://github.com/can1357/oh-my-pi/issues/5818)).
+### Added
+
+- Added the GMI Cloud provider (`gmi-cloud`), an OpenAI-compatible inference gateway at `https://api.gmi-serving.com/v1` with dynamic model discovery via `/v1/models` and an API-key paste login. Authenticates with the `GMI_API_KEY` environment variable.
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/catalog/scripts/generate-models.ts
+++ b/packages/catalog/scripts/generate-models.ts
@@ -35,6 +35,7 @@ import {
 	buildXaiOAuthStaticSeed,
 	clampFireworksKimiMaxTokens,
 	clampKimiK27CodeMaxTokens,
+	GMI_CLOUD_STATIC_MODELS,
 	isFireworksKimiK2ModelId,
 	isKimiK27CodeModelId,
 	kimiCodeMaxTokens,
@@ -558,6 +559,12 @@ async function generateModels() {
 	// Sakana is authoritative and stale seed IDs must stay out.
 	if (!authoritativeCatalogProviders.has("sakana")) {
 		allModels.push(...SAKANA_FUGU_STATIC_MODELS);
+	}
+	// Seed the GMI Cloud default model so a fresh install (and a regen without a
+	// `GMI_API_KEY`) still resolves the descriptor's `defaultModel` synchronously
+	// at boot. If live `/v1/models` discovery succeeds, it is authoritative.
+	if (!authoritativeCatalogProviders.has("gmi-cloud")) {
+		allModels.push(...GMI_CLOUD_STATIC_MODELS);
 	}
 	// Seed the GitLab Duo Agent fallback model so a fresh install (no credentialed
 	// dynamic discovery/cache yet) still surfaces the provider's default model in the

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -2925,8 +2925,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 131072,
+			"maxTokens": 16384
 		},
 		"gemma-3n-e4b-it": {
 			"id": "gemma-3n-e4b-it",
@@ -10017,10 +10017,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.22,
+				"output": 1.32,
+				"cacheRead": 0.022,
+				"cacheWrite": 0.275
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
@@ -10047,10 +10047,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 30,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 5.5,
+				"output": 33,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.88
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
@@ -10077,10 +10077,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2.2,
+				"output": 13.2,
+				"cacheRead": 0.22,
+				"cacheWrite": 2.75
 			},
 			"contextWindow": 272000,
 			"maxTokens": 128000,
@@ -12800,9 +12800,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
@@ -12860,9 +12860,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
@@ -13091,6 +13091,26 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"inception/mercury-2": {
+			"id": "inception/mercury-2",
+			"name": "Mercury 2",
+			"api": "openai-completions",
+			"provider": "baseten",
+			"baseUrl": "https://inference.baseten.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 8192,
+			"maxTokens": 5000,
+			"supportsComputerUse": false
+		},
 		"moonshotai/Kimi-K2.6": {
 			"id": "moonshotai/Kimi-K2.6",
 			"name": "Kimi K2.6",
@@ -13173,8 +13193,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 1048576,
-			"supportsComputerUse": false
+			"maxTokens": 262144,
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
@@ -13235,6 +13256,26 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"sid/sid-1": {
+			"id": "sid/sid-1",
+			"name": "SID-1",
+			"api": "openai-completions",
+			"provider": "baseten",
+			"baseUrl": "https://inference.baseten.co/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32768,
+			"maxTokens": 5000,
+			"supportsComputerUse": false
+		},
 		"thinkingmachines/inkling": {
 			"id": "thinkingmachines/inkling",
 			"name": "Inkling",
@@ -13256,6 +13297,27 @@
 			"maxTokens": 32768,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"thinkingmachines/inkling-small": {
+			"id": "thinkingmachines/inkling-small",
+			"name": "Inkling Small",
+			"api": "openai-completions",
+			"provider": "baseten",
+			"baseUrl": "https://inference.baseten.co/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 32768,
+			"supportsComputerUse": false
 		},
 		"zai-org/GLM-4.7": {
 			"id": "zai-org/GLM-4.7",
@@ -13304,8 +13366,8 @@
 				"cacheRead": 0.14,
 				"cacheWrite": 0
 			},
-			"contextWindow": 524288,
-			"maxTokens": 524288,
+			"contextWindow": 1048576,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -13336,7 +13398,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 524288,
-			"maxTokens": 524288,
+			"maxTokens": 262144,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		}
@@ -15145,6 +15207,39 @@
 				]
 			}
 		},
+		"moonshotai/Kimi-K3": {
+			"id": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
+			"api": "openai-completions",
+			"provider": "coreweave",
+			"baseUrl": "https://api.inference.wandb.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			}
+		},
 		"nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8": {
 			"id": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
 			"name": "Nemotron 3 Super",
@@ -15557,9 +15652,47 @@
 		}
 	},
 	"cursor": {
+		"claude-4-sonnet": {
+			"id": "claude-4-sonnet",
+			"name": "Sonnet 4",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-4-sonnet",
+					"minimal": "claude-4-sonnet-thinking",
+					"low": "claude-4-sonnet-thinking",
+					"medium": "claude-4-sonnet-thinking",
+					"high": "claude-4-sonnet-thinking"
+				}
+			},
+			"supportsComputerUse": false
+		},
 		"claude-4.5-opus-high": {
 			"id": "claude-4.5-opus-high",
-			"name": "Claude 4.5 Opus",
+			"name": "Opus 4.5",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -15591,11 +15724,13 @@
 					"medium": "claude-4.5-opus-high-thinking",
 					"high": "claude-4.5-opus-high-thinking"
 				}
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"claude-4.5-sonnet": {
 			"id": "claude-4.5-sonnet",
-			"name": "Claude 4.5 Sonnet",
+			"name": "Sonnet 4.5",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -15627,11 +15762,13 @@
 					"medium": "claude-4.5-sonnet-thinking",
 					"high": "claude-4.5-sonnet-thinking"
 				}
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"claude-4.6-opus-high": {
 			"id": "claude-4.6-opus-high",
-			"name": "Claude 4.6 Opus",
+			"name": "Opus 4.6 1M",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -15662,11 +15799,51 @@
 					"medium": "claude-4.6-opus-high-thinking",
 					"high": "claude-4.6-opus-high-thinking"
 				}
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
+		},
+		"claude-4.6-opus-max": {
+			"id": "claude-4.6-opus-max",
+			"name": "Opus 4.6 1M Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-4.6-opus-max",
+					"minimal": "claude-4.6-opus-max-thinking",
+					"low": "claude-4.6-opus-max-thinking",
+					"medium": "claude-4.6-opus-max-thinking",
+					"high": "claude-4.6-opus-max-thinking"
+				}
+			},
+			"supportsComputerUse": false
 		},
 		"claude-4.6-sonnet-medium": {
 			"id": "claude-4.6-sonnet-medium",
-			"name": "Claude 4.6 Sonnet",
+			"name": "Sonnet 4.6 1M",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -15697,7 +15874,1465 @@
 					"medium": "claude-4.6-sonnet-medium-thinking",
 					"high": "claude-4.6-sonnet-medium-thinking"
 				}
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
+		},
+		"claude-fable-5-high": {
+			"id": "claude-fable-5-high",
+			"name": "Fable 5 1M (NO ZDR)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-fable-5-high",
+					"minimal": "claude-fable-5-thinking-high",
+					"low": "claude-fable-5-thinking-high",
+					"medium": "claude-fable-5-thinking-high",
+					"high": "claude-fable-5-thinking-high"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-fable-5-low": {
+			"id": "claude-fable-5-low",
+			"name": "Fable 5 1M Low (NO ZDR)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-fable-5-low",
+					"minimal": "claude-fable-5-thinking-low",
+					"low": "claude-fable-5-thinking-low",
+					"medium": "claude-fable-5-thinking-low",
+					"high": "claude-fable-5-thinking-low"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-fable-5-max": {
+			"id": "claude-fable-5-max",
+			"name": "Fable 5 1M Max (NO ZDR)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-fable-5-max",
+					"minimal": "claude-fable-5-thinking-max",
+					"low": "claude-fable-5-thinking-max",
+					"medium": "claude-fable-5-thinking-max",
+					"high": "claude-fable-5-thinking-max"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-fable-5-medium": {
+			"id": "claude-fable-5-medium",
+			"name": "Fable 5 1M Medium (NO ZDR)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-fable-5-medium",
+					"minimal": "claude-fable-5-thinking-medium",
+					"low": "claude-fable-5-thinking-medium",
+					"medium": "claude-fable-5-thinking-medium",
+					"high": "claude-fable-5-thinking-medium"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-fable-5-xhigh": {
+			"id": "claude-fable-5-xhigh",
+			"name": "Fable 5 1M Extra High (NO ZDR)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-fable-5-xhigh",
+					"minimal": "claude-fable-5-thinking-xhigh",
+					"low": "claude-fable-5-thinking-xhigh",
+					"medium": "claude-fable-5-thinking-xhigh",
+					"high": "claude-fable-5-thinking-xhigh"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-high": {
+			"id": "claude-opus-4-7-high",
+			"name": "Opus 4.7 1M High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-high",
+					"minimal": "claude-opus-4-7-thinking-high",
+					"low": "claude-opus-4-7-thinking-high",
+					"medium": "claude-opus-4-7-thinking-high",
+					"high": "claude-opus-4-7-thinking-high"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-high-fast": {
+			"id": "claude-opus-4-7-high-fast",
+			"name": "Opus 4.7 1M High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-high-fast",
+					"minimal": "claude-opus-4-7-thinking-high-fast",
+					"low": "claude-opus-4-7-thinking-high-fast",
+					"medium": "claude-opus-4-7-thinking-high-fast",
+					"high": "claude-opus-4-7-thinking-high-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-low": {
+			"id": "claude-opus-4-7-low",
+			"name": "Opus 4.7 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-low",
+					"minimal": "claude-opus-4-7-thinking-low",
+					"low": "claude-opus-4-7-thinking-low",
+					"medium": "claude-opus-4-7-thinking-low",
+					"high": "claude-opus-4-7-thinking-low"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-low-fast": {
+			"id": "claude-opus-4-7-low-fast",
+			"name": "Opus 4.7 1M Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-low-fast",
+					"minimal": "claude-opus-4-7-thinking-low-fast",
+					"low": "claude-opus-4-7-thinking-low-fast",
+					"medium": "claude-opus-4-7-thinking-low-fast",
+					"high": "claude-opus-4-7-thinking-low-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-max": {
+			"id": "claude-opus-4-7-max",
+			"name": "Opus 4.7 1M Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-max",
+					"minimal": "claude-opus-4-7-thinking-max",
+					"low": "claude-opus-4-7-thinking-max",
+					"medium": "claude-opus-4-7-thinking-max",
+					"high": "claude-opus-4-7-thinking-max"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-max-fast": {
+			"id": "claude-opus-4-7-max-fast",
+			"name": "Opus 4.7 1M Max Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-max-fast",
+					"minimal": "claude-opus-4-7-thinking-max-fast",
+					"low": "claude-opus-4-7-thinking-max-fast",
+					"medium": "claude-opus-4-7-thinking-max-fast",
+					"high": "claude-opus-4-7-thinking-max-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-medium": {
+			"id": "claude-opus-4-7-medium",
+			"name": "Opus 4.7 1M Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-medium",
+					"minimal": "claude-opus-4-7-thinking-medium",
+					"low": "claude-opus-4-7-thinking-medium",
+					"medium": "claude-opus-4-7-thinking-medium",
+					"high": "claude-opus-4-7-thinking-medium"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-medium-fast": {
+			"id": "claude-opus-4-7-medium-fast",
+			"name": "Opus 4.7 1M Medium Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-medium-fast",
+					"minimal": "claude-opus-4-7-thinking-medium-fast",
+					"low": "claude-opus-4-7-thinking-medium-fast",
+					"medium": "claude-opus-4-7-thinking-medium-fast",
+					"high": "claude-opus-4-7-thinking-medium-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-xhigh": {
+			"id": "claude-opus-4-7-xhigh",
+			"name": "Opus 4.7 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-xhigh",
+					"minimal": "claude-opus-4-7-thinking-xhigh",
+					"low": "claude-opus-4-7-thinking-xhigh",
+					"medium": "claude-opus-4-7-thinking-xhigh",
+					"high": "claude-opus-4-7-thinking-xhigh"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-7-xhigh-fast": {
+			"id": "claude-opus-4-7-xhigh-fast",
+			"name": "Opus 4.7 1M Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-7-xhigh-fast",
+					"minimal": "claude-opus-4-7-thinking-xhigh-fast",
+					"low": "claude-opus-4-7-thinking-xhigh-fast",
+					"medium": "claude-opus-4-7-thinking-xhigh-fast",
+					"high": "claude-opus-4-7-thinking-xhigh-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-high": {
+			"id": "claude-opus-4-8-high",
+			"name": "Opus 4.8 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-high",
+					"minimal": "claude-opus-4-8-thinking-high",
+					"low": "claude-opus-4-8-thinking-high",
+					"medium": "claude-opus-4-8-thinking-high",
+					"high": "claude-opus-4-8-thinking-high"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-high-fast": {
+			"id": "claude-opus-4-8-high-fast",
+			"name": "Opus 4.8 1M Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-high-fast",
+					"minimal": "claude-opus-4-8-thinking-high-fast",
+					"low": "claude-opus-4-8-thinking-high-fast",
+					"medium": "claude-opus-4-8-thinking-high-fast",
+					"high": "claude-opus-4-8-thinking-high-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-low": {
+			"id": "claude-opus-4-8-low",
+			"name": "Opus 4.8 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-low",
+					"minimal": "claude-opus-4-8-thinking-low",
+					"low": "claude-opus-4-8-thinking-low",
+					"medium": "claude-opus-4-8-thinking-low",
+					"high": "claude-opus-4-8-thinking-low"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-low-fast": {
+			"id": "claude-opus-4-8-low-fast",
+			"name": "Opus 4.8 1M Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-low-fast",
+					"minimal": "claude-opus-4-8-thinking-low-fast",
+					"low": "claude-opus-4-8-thinking-low-fast",
+					"medium": "claude-opus-4-8-thinking-low-fast",
+					"high": "claude-opus-4-8-thinking-low-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-max": {
+			"id": "claude-opus-4-8-max",
+			"name": "Opus 4.8 1M Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-max",
+					"minimal": "claude-opus-4-8-thinking-max",
+					"low": "claude-opus-4-8-thinking-max",
+					"medium": "claude-opus-4-8-thinking-max",
+					"high": "claude-opus-4-8-thinking-max"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-max-fast": {
+			"id": "claude-opus-4-8-max-fast",
+			"name": "Opus 4.8 1M Max Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-max-fast",
+					"minimal": "claude-opus-4-8-thinking-max-fast",
+					"low": "claude-opus-4-8-thinking-max-fast",
+					"medium": "claude-opus-4-8-thinking-max-fast",
+					"high": "claude-opus-4-8-thinking-max-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-medium": {
+			"id": "claude-opus-4-8-medium",
+			"name": "Opus 4.8 1M Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-medium",
+					"minimal": "claude-opus-4-8-thinking-medium",
+					"low": "claude-opus-4-8-thinking-medium",
+					"medium": "claude-opus-4-8-thinking-medium",
+					"high": "claude-opus-4-8-thinking-medium"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-medium-fast": {
+			"id": "claude-opus-4-8-medium-fast",
+			"name": "Opus 4.8 1M Medium Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-medium-fast",
+					"minimal": "claude-opus-4-8-thinking-medium-fast",
+					"low": "claude-opus-4-8-thinking-medium-fast",
+					"medium": "claude-opus-4-8-thinking-medium-fast",
+					"high": "claude-opus-4-8-thinking-medium-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-xhigh": {
+			"id": "claude-opus-4-8-xhigh",
+			"name": "Opus 4.8 1M Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-xhigh",
+					"minimal": "claude-opus-4-8-thinking-xhigh",
+					"low": "claude-opus-4-8-thinking-xhigh",
+					"medium": "claude-opus-4-8-thinking-xhigh",
+					"high": "claude-opus-4-8-thinking-xhigh"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-4-8-xhigh-fast": {
+			"id": "claude-opus-4-8-xhigh-fast",
+			"name": "Opus 4.8 1M Extra High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-4-8-xhigh-fast",
+					"minimal": "claude-opus-4-8-thinking-xhigh-fast",
+					"low": "claude-opus-4-8-thinking-xhigh-fast",
+					"medium": "claude-opus-4-8-thinking-xhigh-fast",
+					"high": "claude-opus-4-8-thinking-xhigh-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-high": {
+			"id": "claude-opus-5-high",
+			"name": "Opus 5 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-5-high",
+					"minimal": "claude-opus-5-thinking-high",
+					"low": "claude-opus-5-thinking-high",
+					"medium": "claude-opus-5-thinking-high",
+					"high": "claude-opus-5-thinking-high"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-high-fast": {
+			"id": "claude-opus-5-high-fast",
+			"name": "Opus 5 1M Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-5-high-fast",
+					"minimal": "claude-opus-5-thinking-high-fast",
+					"low": "claude-opus-5-thinking-high-fast",
+					"medium": "claude-opus-5-thinking-high-fast",
+					"high": "claude-opus-5-thinking-high-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-low": {
+			"id": "claude-opus-5-low",
+			"name": "Opus 5 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-5-low",
+					"minimal": "claude-opus-5-thinking-low",
+					"low": "claude-opus-5-thinking-low",
+					"medium": "claude-opus-5-thinking-low",
+					"high": "claude-opus-5-thinking-low"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-low-fast": {
+			"id": "claude-opus-5-low-fast",
+			"name": "Opus 5 1M Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-5-low-fast",
+					"minimal": "claude-opus-5-thinking-low-fast",
+					"low": "claude-opus-5-thinking-low-fast",
+					"medium": "claude-opus-5-thinking-low-fast",
+					"high": "claude-opus-5-thinking-low-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-medium": {
+			"id": "claude-opus-5-medium",
+			"name": "Opus 5 1M Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-5-medium",
+					"minimal": "claude-opus-5-thinking-medium",
+					"low": "claude-opus-5-thinking-medium",
+					"medium": "claude-opus-5-thinking-medium",
+					"high": "claude-opus-5-thinking-medium"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-medium-fast": {
+			"id": "claude-opus-5-medium-fast",
+			"name": "Opus 5 1M Medium Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-opus-5-medium-fast",
+					"minimal": "claude-opus-5-thinking-medium-fast",
+					"low": "claude-opus-5-thinking-medium-fast",
+					"medium": "claude-opus-5-thinking-medium-fast",
+					"high": "claude-opus-5-thinking-medium-fast"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-thinking-max": {
+			"id": "claude-opus-5-thinking-max",
+			"name": "Opus 5 1M Max Thinking",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-thinking-max-fast": {
+			"id": "claude-opus-5-thinking-max-fast",
+			"name": "Opus 5 1M Max Thinking Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-thinking-xhigh": {
+			"id": "claude-opus-5-thinking-xhigh",
+			"name": "Opus 5 1M Extra High Thinking",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"claude-opus-5-thinking-xhigh-fast": {
+			"id": "claude-opus-5-thinking-xhigh-fast",
+			"name": "Opus 5 1M Extra High Thinking Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": true,
+			"supportsComputerUse": false
+		},
+		"claude-sonnet-5-high": {
+			"id": "claude-sonnet-5-high",
+			"name": "Sonnet 5 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-sonnet-5-high",
+					"minimal": "claude-sonnet-5-thinking-high",
+					"low": "claude-sonnet-5-thinking-high",
+					"medium": "claude-sonnet-5-thinking-high",
+					"high": "claude-sonnet-5-thinking-high"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-sonnet-5-low": {
+			"id": "claude-sonnet-5-low",
+			"name": "Sonnet 5 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-sonnet-5-low",
+					"minimal": "claude-sonnet-5-thinking-low",
+					"low": "claude-sonnet-5-thinking-low",
+					"medium": "claude-sonnet-5-thinking-low",
+					"high": "claude-sonnet-5-thinking-low"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-sonnet-5-max": {
+			"id": "claude-sonnet-5-max",
+			"name": "Sonnet 5 1M Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-sonnet-5-max",
+					"minimal": "claude-sonnet-5-thinking-max",
+					"low": "claude-sonnet-5-thinking-max",
+					"medium": "claude-sonnet-5-thinking-max",
+					"high": "claude-sonnet-5-thinking-max"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-sonnet-5-medium": {
+			"id": "claude-sonnet-5-medium",
+			"name": "Sonnet 5 1M Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-sonnet-5-medium",
+					"minimal": "claude-sonnet-5-thinking-medium",
+					"low": "claude-sonnet-5-thinking-medium",
+					"medium": "claude-sonnet-5-thinking-medium",
+					"high": "claude-sonnet-5-thinking-medium"
+				}
+			},
+			"supportsComputerUse": false
+		},
+		"claude-sonnet-5-xhigh": {
+			"id": "claude-sonnet-5-xhigh",
+			"name": "Sonnet 5 1M Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"effortRouting": {
+					"off": "claude-sonnet-5-xhigh",
+					"minimal": "claude-sonnet-5-thinking-xhigh",
+					"low": "claude-sonnet-5-thinking-xhigh",
+					"medium": "claude-sonnet-5-thinking-xhigh",
+					"high": "claude-sonnet-5-thinking-xhigh"
+				}
+			},
+			"supportsComputerUse": false
 		},
 		"composer-1": {
 			"id": "composer-1",
@@ -15716,7 +17351,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
 		},
 		"composer-1.5": {
 			"id": "composer-1.5",
@@ -15735,7 +17371,176 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
+		},
+		"composer-2.5": {
+			"id": "composer-2.5",
+			"name": "Composer 2.5",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"composer-2.5-fast": {
+			"id": "composer-2.5-fast",
+			"name": "Composer 2.5 Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"cursor-grok-4.5-high": {
+			"id": "cursor-grok-4.5-high",
+			"name": "Cursor Grok 4.5",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"cursor-grok-4.5-high-fast": {
+			"id": "cursor-grok-4.5-high-fast",
+			"name": "Cursor Grok 4.5 Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"cursor-grok-4.5-low": {
+			"id": "cursor-grok-4.5-low",
+			"name": "Cursor Grok 4.5 Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"cursor-grok-4.5-low-fast": {
+			"id": "cursor-grok-4.5-low-fast",
+			"name": "Cursor Grok 4.5 Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"cursor-grok-4.5-medium": {
+			"id": "cursor-grok-4.5-medium",
+			"name": "Cursor Grok 4.5 Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"cursor-grok-4.5-medium-fast": {
+			"id": "cursor-grok-4.5-medium-fast",
+			"name": "Cursor Grok 4.5 Medium Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
 		},
 		"default": {
 			"id": "default",
@@ -15755,7 +17560,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gemini-3-flash": {
 			"id": "gemini-3-flash",
@@ -15785,7 +17592,9 @@
 					"high"
 				],
 				"requiresEffort": true
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gemini-3-pro": {
 			"id": "gemini-3-pro",
@@ -15813,7 +17622,8 @@
 					"high"
 				],
 				"requiresEffort": true
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gemini-3.1-pro": {
 			"id": "gemini-3.1-pro",
@@ -15841,7 +17651,233 @@
 					"high"
 				],
 				"requiresEffort": true
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
+		},
+		"gemini-3.5-flash": {
+			"id": "gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
+		"gemini-3.6-flash-high": {
+			"id": "gemini-3.6-flash-high",
+			"name": "Gemini 3.6 Flash",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gemini-3.6-flash-low": {
+			"id": "gemini-3.6-flash-low",
+			"name": "Gemini 3.6 Flash Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gemini-3.6-flash-medium": {
+			"id": "gemini-3.6-flash-medium",
+			"name": "Gemini 3.6 Flash Medium",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gemini-3.6-flash-minimal": {
+			"id": "gemini-3.6-flash-minimal",
+			"name": "Gemini 3.6 Flash Minimal",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"glm-5.2-high": {
+			"id": "glm-5.2-high",
+			"name": "GLM 5.2",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"glm-5.2-max": {
+			"id": "glm-5.2-max",
+			"name": "GLM 5.2 Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5-mini": {
+			"id": "gpt-5-mini",
+			"name": "GPT-5 Mini",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"gpt-5.1": {
+			"id": "gpt-5.1",
+			"name": "GPT-5.1",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex-max": {
 			"id": "gpt-5.1-codex-max",
@@ -15870,7 +17906,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex-max-high": {
 			"id": "gpt-5.1-codex-max-high",
@@ -15899,7 +17936,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-codex-mini": {
 			"id": "gpt-5.1-codex-mini",
@@ -15926,7 +17964,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.1-high": {
 			"id": "gpt-5.1-high",
@@ -15945,7 +17984,31 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
+		},
+		"gpt-5.1-low": {
+			"id": "gpt-5.1-low",
+			"name": "GPT-5.1 Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2": {
 			"id": "gpt-5.2",
@@ -15974,7 +18037,9 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -16003,7 +18068,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex-fast": {
 			"id": "gpt-5.2-codex-fast",
@@ -16022,7 +18088,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex-high": {
 			"id": "gpt-5.2-codex-high",
@@ -16041,7 +18108,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex-high-fast": {
 			"id": "gpt-5.2-codex-high-fast",
@@ -16060,7 +18128,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex-low": {
 			"id": "gpt-5.2-codex-low",
@@ -16079,7 +18148,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex-low-fast": {
 			"id": "gpt-5.2-codex-low-fast",
@@ -16098,7 +18168,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex-xhigh": {
 			"id": "gpt-5.2-codex-xhigh",
@@ -16117,7 +18188,8 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-codex-xhigh-fast": {
 			"id": "gpt-5.2-codex-xhigh-fast",
@@ -16136,7 +18208,30 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false
+		},
+		"gpt-5.2-fast": {
+			"id": "gpt-5.2-fast",
+			"name": "GPT-5.2 Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
 		},
 		"gpt-5.2-high": {
 			"id": "gpt-5.2-high",
@@ -16165,7 +18260,119 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
+		},
+		"gpt-5.2-high-fast": {
+			"id": "gpt-5.2-high-fast",
+			"name": "GPT-5.2 High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.2-low": {
+			"id": "gpt-5.2-low",
+			"name": "GPT-5.2 Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.2-low-fast": {
+			"id": "gpt-5.2-low-fast",
+			"name": "GPT-5.2 Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.2-xhigh": {
+			"id": "gpt-5.2-xhigh",
+			"name": "GPT-5.2 Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.2-xhigh-fast": {
+			"id": "gpt-5.2-xhigh-fast",
+			"name": "GPT-5.2 Extra High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
@@ -16194,11 +18401,13 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.3-codex-fast": {
 			"id": "gpt-5.3-codex-fast",
-			"name": "GPT-5.3 Codex Fast",
+			"name": "Codex 5.3 Fast",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16213,11 +18422,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.3-codex-high": {
 			"id": "gpt-5.3-codex-high",
-			"name": "GPT-5.3 Codex High",
+			"name": "Codex 5.3 High",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16232,11 +18443,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.3-codex-high-fast": {
 			"id": "gpt-5.3-codex-high-fast",
-			"name": "GPT-5.3 Codex High Fast",
+			"name": "Codex 5.3 High Fast",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16251,11 +18464,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.3-codex-low": {
 			"id": "gpt-5.3-codex-low",
-			"name": "GPT-5.3 Codex Low",
+			"name": "Codex 5.3 Low",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16270,11 +18485,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.3-codex-low-fast": {
 			"id": "gpt-5.3-codex-low-fast",
-			"name": "GPT-5.3 Codex Low Fast",
+			"name": "Codex 5.3 Low Fast",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16289,7 +18506,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.3-codex-spark-preview": {
 			"id": "gpt-5.3-codex-spark-preview",
@@ -16308,11 +18527,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.5-low"
 		},
 		"gpt-5.3-codex-xhigh": {
 			"id": "gpt-5.3-codex-xhigh",
-			"name": "GPT-5.3 Codex Extra High",
+			"name": "Codex 5.3 Extra High",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16327,11 +18548,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.3-codex-xhigh-fast": {
 			"id": "gpt-5.3-codex-xhigh-fast",
-			"name": "GPT-5.3 Codex Extra High Fast",
+			"name": "Codex 5.3 Extra High Fast",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16346,11 +18569,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.4-high": {
 			"id": "gpt-5.4-high",
-			"name": "GPT-5.4 High",
+			"name": "GPT-5.4 1M High",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16365,7 +18590,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.4-high-fast": {
 			"id": "gpt-5.4-high-fast",
@@ -16384,11 +18611,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.4-low": {
 			"id": "gpt-5.4-low",
-			"name": "GPT-5.4 Low",
+			"name": "GPT-5.4 1M Low",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16403,11 +18632,13 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.4-medium": {
 			"id": "gpt-5.4-medium",
-			"name": "GPT-5.4",
+			"name": "GPT-5.4 1M",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16422,7 +18653,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.4-medium-fast": {
 			"id": "gpt-5.4-medium-fast",
@@ -16441,11 +18674,233 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
+		},
+		"gpt-5.4-mini-high": {
+			"id": "gpt-5.4-mini-high",
+			"name": "GPT-5.4 Mini High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-mini-low": {
+			"id": "gpt-5.4-mini-low",
+			"name": "GPT-5.4 Mini Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-mini-medium": {
+			"id": "gpt-5.4-mini-medium",
+			"name": "GPT-5.4 Mini",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-mini-none": {
+			"id": "gpt-5.4-mini-none",
+			"name": "GPT-5.4 Mini None",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-mini-xhigh": {
+			"id": "gpt-5.4-mini-xhigh",
+			"name": "GPT-5.4 Mini Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-nano-high": {
+			"id": "gpt-5.4-nano-high",
+			"name": "GPT-5.4 Nano High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-nano-low": {
+			"id": "gpt-5.4-nano-low",
+			"name": "GPT-5.4 Nano Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-nano-medium": {
+			"id": "gpt-5.4-nano-medium",
+			"name": "GPT-5.4 Nano",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-nano-none": {
+			"id": "gpt-5.4-nano-none",
+			"name": "GPT-5.4 Nano None",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.4-nano-xhigh": {
+			"id": "gpt-5.4-nano-xhigh",
+			"name": "GPT-5.4 Nano Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
 		},
 		"gpt-5.4-xhigh": {
 			"id": "gpt-5.4-xhigh",
-			"name": "GPT-5.4 Extra High",
+			"name": "GPT-5.4 1M Extra High",
 			"api": "cursor-agent",
 			"provider": "cursor",
 			"baseUrl": "https://api2.cursor.sh",
@@ -16460,7 +18915,9 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
 		},
 		"gpt-5.4-xhigh-fast": {
 			"id": "gpt-5.4-xhigh-fast",
@@ -16479,7 +18936,1031 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 64000
+			"maxTokens": 64000,
+			"supportsComputerUse": false,
+			"cursorMaxMode": false
+		},
+		"gpt-5.5-extra-high": {
+			"id": "gpt-5.5-extra-high",
+			"name": "GPT-5.5 1M Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-extra-high-fast": {
+			"id": "gpt-5.5-extra-high-fast",
+			"name": "GPT-5.5 Extra High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-high": {
+			"id": "gpt-5.5-high",
+			"name": "GPT-5.5 1M High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-high-fast": {
+			"id": "gpt-5.5-high-fast",
+			"name": "GPT-5.5 High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-low": {
+			"id": "gpt-5.5-low",
+			"name": "GPT-5.5 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-low-fast": {
+			"id": "gpt-5.5-low-fast",
+			"name": "GPT-5.5 Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-medium": {
+			"id": "gpt-5.5-medium",
+			"name": "GPT-5.5 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-medium-fast": {
+			"id": "gpt-5.5-medium-fast",
+			"name": "GPT-5.5 Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-none": {
+			"id": "gpt-5.5-none",
+			"name": "GPT-5.5 1M None",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.5-none-fast": {
+			"id": "gpt-5.5-none-fast",
+			"name": "GPT-5.5 None Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "cursor/gpt-5.4-low"
+		},
+		"gpt-5.6-luna-high": {
+			"id": "gpt-5.6-luna-high",
+			"name": "GPT-5.6 Luna 1M High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-high-fast": {
+			"id": "gpt-5.6-luna-high-fast",
+			"name": "GPT-5.6 Luna High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-low": {
+			"id": "gpt-5.6-luna-low",
+			"name": "GPT-5.6 Luna 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-low-fast": {
+			"id": "gpt-5.6-luna-low-fast",
+			"name": "GPT-5.6 Luna Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-max": {
+			"id": "gpt-5.6-luna-max",
+			"name": "GPT-5.6 Luna 1M Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-max-fast": {
+			"id": "gpt-5.6-luna-max-fast",
+			"name": "GPT-5.6 Luna Max Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-medium": {
+			"id": "gpt-5.6-luna-medium",
+			"name": "GPT-5.6 Luna 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-medium-fast": {
+			"id": "gpt-5.6-luna-medium-fast",
+			"name": "GPT-5.6 Luna Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-none": {
+			"id": "gpt-5.6-luna-none",
+			"name": "GPT-5.6 Luna 1M None",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-none-fast": {
+			"id": "gpt-5.6-luna-none-fast",
+			"name": "GPT-5.6 Luna None Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-xhigh": {
+			"id": "gpt-5.6-luna-xhigh",
+			"name": "GPT-5.6 Luna 1M Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-luna-xhigh-fast": {
+			"id": "gpt-5.6-luna-xhigh-fast",
+			"name": "GPT-5.6 Luna Extra High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-high": {
+			"id": "gpt-5.6-sol-high",
+			"name": "GPT-5.6 Sol 1M High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-high-fast": {
+			"id": "gpt-5.6-sol-high-fast",
+			"name": "GPT-5.6 Sol High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-low": {
+			"id": "gpt-5.6-sol-low",
+			"name": "GPT-5.6 Sol 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-low-fast": {
+			"id": "gpt-5.6-sol-low-fast",
+			"name": "GPT-5.6 Sol Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-max": {
+			"id": "gpt-5.6-sol-max",
+			"name": "GPT-5.6 Sol 1M Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-max-fast": {
+			"id": "gpt-5.6-sol-max-fast",
+			"name": "GPT-5.6 Sol Max Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-medium": {
+			"id": "gpt-5.6-sol-medium",
+			"name": "GPT-5.6 Sol 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-medium-fast": {
+			"id": "gpt-5.6-sol-medium-fast",
+			"name": "GPT-5.6 Sol Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-none": {
+			"id": "gpt-5.6-sol-none",
+			"name": "GPT-5.6 Sol 1M None",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-none-fast": {
+			"id": "gpt-5.6-sol-none-fast",
+			"name": "GPT-5.6 Sol None Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-xhigh": {
+			"id": "gpt-5.6-sol-xhigh",
+			"name": "GPT-5.6 Sol 1M Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-sol-xhigh-fast": {
+			"id": "gpt-5.6-sol-xhigh-fast",
+			"name": "GPT-5.6 Sol Extra High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-high": {
+			"id": "gpt-5.6-terra-high",
+			"name": "GPT-5.6 Terra 1M High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-high-fast": {
+			"id": "gpt-5.6-terra-high-fast",
+			"name": "GPT-5.6 Terra High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-low": {
+			"id": "gpt-5.6-terra-low",
+			"name": "GPT-5.6 Terra 1M Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-low-fast": {
+			"id": "gpt-5.6-terra-low-fast",
+			"name": "GPT-5.6 Terra Low Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-max": {
+			"id": "gpt-5.6-terra-max",
+			"name": "GPT-5.6 Terra 1M Max",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-max-fast": {
+			"id": "gpt-5.6-terra-max-fast",
+			"name": "GPT-5.6 Terra Max Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-medium": {
+			"id": "gpt-5.6-terra-medium",
+			"name": "GPT-5.6 Terra 1M",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-medium-fast": {
+			"id": "gpt-5.6-terra-medium-fast",
+			"name": "GPT-5.6 Terra Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-none": {
+			"id": "gpt-5.6-terra-none",
+			"name": "GPT-5.6 Terra 1M None",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-none-fast": {
+			"id": "gpt-5.6-terra-none-fast",
+			"name": "GPT-5.6 Terra None Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-xhigh": {
+			"id": "gpt-5.6-terra-xhigh",
+			"name": "GPT-5.6 Terra 1M Extra High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"gpt-5.6-terra-xhigh-fast": {
+			"id": "gpt-5.6-terra-xhigh-fast",
+			"name": "GPT-5.6 Terra Extra High Fast",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -16507,7 +19988,8 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
@@ -16536,7 +20018,102 @@
 					"medium",
 					"high"
 				]
-			}
+			},
+			"supportsComputerUse": false
+		},
+		"kimi-k2.7-code": {
+			"id": "kimi-k2.7-code",
+			"name": "Kimi K2.7 Code",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"kimi-k3-high": {
+			"id": "kimi-k3-high",
+			"name": "Kimi K3 High",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"kimi-k3-low": {
+			"id": "kimi-k3-low",
+			"name": "Kimi K3 Low",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
+		},
+		"kimi-k3-max": {
+			"id": "kimi-k3-max",
+			"name": "Kimi K3",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"cursorMaxMode": false,
+			"supportsComputerUse": false
 		}
 	},
 	"deepseek": {
@@ -16840,7 +20417,8 @@
 					"minimal": "none"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"glm-5.1-fast": {
 			"id": "glm-5.1-fast",
@@ -16958,6 +20536,40 @@
 			"supportsTools": false,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"inkling": {
+			"id": "inkling",
+			"name": "Inkling",
+			"api": "openai-completions",
+			"provider": "fireworks",
+			"baseUrl": "https://api.fireworks.ai/inference/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 5.0625,
+				"cacheRead": 0.2125,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				],
+				"effortMap": {
+					"minimal": "none"
+				}
+			},
+			"supportsComputerUse": false
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
@@ -19236,6 +22848,34 @@
 			"contextWindow": 1000000,
 			"maxTokens": null,
 			"supportsTools": true
+		}
+	},
+	"gmi-cloud": {
+		"deepseek-ai/DeepSeek-V4-Flash": {
+			"id": "deepseek-ai/DeepSeek-V4-Flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "gmi-cloud",
+			"baseUrl": "https://api.gmi-serving.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high",
+					"max"
+				]
+			}
 		}
 	},
 	"google": {
@@ -22799,6 +26439,39 @@
 				]
 			}
 		},
+		"moonshotai/Kimi-K3": {
+			"id": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			}
+		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
 			"name": "GPT OSS 120B",
@@ -23284,6 +26957,65 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"tencent/Hy3": {
+			"id": "tencent/Hy3",
+			"name": "Hy3",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.58,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"thinkingmachines/Inkling": {
+			"id": "thinkingmachines/Inkling",
+			"name": "Inkling",
+			"api": "openai-completions",
+			"provider": "huggingface",
+			"baseUrl": "https://router.huggingface.co/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 4.05,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -25995,6 +29727,26 @@
 				]
 			}
 		},
+		"deepseek/deepseek-v4-flash-0731": {
+			"id": "deepseek/deepseek-v4-flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"supportsComputerUse": false
+		},
 		"deepseek/deepseek-v4-flash:discounted": {
 			"id": "deepseek/deepseek-v4-flash:discounted",
 			"name": "DeepSeek V4 Flash (lowest price)",
@@ -26796,13 +30548,14 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12B",
+			"name": "Gemma 3 12B IT",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -26836,13 +30589,14 @@
 		},
 		"google/gemma-3-4b-it": {
 			"id": "google/gemma-3-4b-it",
-			"name": "Gemma 3 4B",
+			"name": "Gemma 3 4B IT",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -26850,8 +30604,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 16384,
 			"supportsComputerUse": false
 		},
 		"google/gemma-3n-e4b-it": {
@@ -28560,7 +32314,7 @@
 		},
 		"mistralai/mistral-7b-instruct-v0.3": {
 			"id": "mistralai/mistral-7b-instruct-v0.3",
-			"name": "Mistral 7B Instruct v0.3",
+			"name": "Mistral-7B-Instruct-v0.3",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -28574,8 +32328,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 65536,
+			"maxTokens": 65536,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -29495,7 +33249,7 @@
 		},
 		"nvidia/llama-3.1-nemotron-70b-instruct": {
 			"id": "nvidia/llama-3.1-nemotron-70b-instruct",
-			"name": "Llama 3.1 Nemotron 70b Instruct",
+			"name": "Llama 3.1 Nemotron 70B Instruct",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -29516,7 +33270,7 @@
 		},
 		"nvidia/llama-3.1-nemotron-ultra-253b-v1": {
 			"id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-			"name": "Llama-3.1-Nemotron-Ultra-253B-v1",
+			"name": "Llama 3.1 Nemotron Ultra 253B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -29764,13 +33518,14 @@
 		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
 			"id": "nvidia/nemotron-nano-12b-v2-vl",
-			"name": "Nemotron Nano 12B 2 VL",
+			"name": "Nemotron Nano 12B v2 VL",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -29778,10 +33533,20 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 128000,
+			"maxTokens": 128000,
 			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUseConfig": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nvidia/nemotron-nano-9b-v2": {
 			"id": "nvidia/nemotron-nano-9b-v2",
@@ -30294,7 +34059,8 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 16384,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5-codex": {
 			"id": "openai/gpt-5-codex",
@@ -31944,7 +35710,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"poolside/laguna-m.1:free": {
 			"id": "poolside/laguna-m.1:free",
@@ -32021,7 +35788,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -32033,7 +35800,17 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"poolside/laguna-xs-2.1:free": {
 			"id": "poolside/laguna-xs-2.1:free",
@@ -33462,6 +37239,26 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"qwen/qwen3.7-flash": {
+			"id": "qwen/qwen3.7-flash",
+			"name": "Qwen3.7 Flash",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"supportsComputerUse": false
+		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
 			"name": "Qwen3.7 Max",
@@ -34270,6 +38067,37 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"supportsComputerUse": false,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"thinkingmachines/inkling-small": {
+			"id": "thinkingmachines/inkling-small",
+			"name": "Inkling Small",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": false,
 			"input": [
 				"text"
@@ -34280,8 +38108,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 65536,
+			"contextWindow": 1048576,
+			"maxTokens": 32768,
 			"supportsComputerUse": false
 		},
 		"tngtech/deepseek-r1t2-chimera": {
@@ -41115,6 +44943,26 @@
 					"max"
 				]
 			}
+		},
+		"deepseek/deepseek-v4-flash-0731": {
+			"id": "deepseek/deepseek-v4-flash-0731",
+			"name": "deepseek/deepseek-v4-flash-0731",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-flash:thinking": {
 			"id": "deepseek/deepseek-v4-flash:thinking",
@@ -48694,8 +52542,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 65536,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -52826,8 +56674,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -54346,6 +58194,26 @@
 			"contextWindow": 262144,
 			"maxTokens": 65536
 		},
+		"TEE/kimi-k3": {
+			"id": "TEE/kimi-k3",
+			"name": "TEE/kimi-k3",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"supportsComputerUse": false
+		},
 		"TEE/llama3-3-70b": {
 			"id": "TEE/llama3-3-70b",
 			"name": "TEE/llama3-3-70b",
@@ -54998,6 +58866,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"thinkingmachines/Inkling-Small": {
+			"id": "thinkingmachines/Inkling-Small",
+			"name": "thinkingmachines/Inkling-Small",
+			"api": "openai-completions",
+			"provider": "nanogpt",
+			"baseUrl": "https://nano-gpt.com/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"THUDM/GLM-4-32B-0414": {
 			"id": "THUDM/GLM-4-32B-0414",
 			"name": "THUDM/GLM-4-32B-0414",
@@ -55318,8 +59216,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null,
+			"contextWindow": 131072,
+			"maxTokens": 16384,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -57559,7 +61457,7 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma3 12B",
+			"name": "Gemma 3 12B IT",
 			"api": "openai-completions",
 			"provider": "novita",
 			"baseUrl": "https://api.novita.ai/openai/v1",
@@ -57999,6 +61897,37 @@
 			"supportsTools": false,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"mindai/macaron-v1-tall": {
+			"id": "mindai/macaron-v1-tall",
+			"name": "Macaron V1 Tall",
+			"api": "openai-completions",
+			"provider": "novita",
+			"baseUrl": "https://api.novita.ai/openai/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"supportsTools": true,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"mindai/macaron-v1-venti": {
 			"id": "mindai/macaron-v1-venti",
@@ -60013,7 +63942,7 @@
 		},
 		"abacusai/dracarys-llama-3.1-70b-instruct": {
 			"id": "abacusai/dracarys-llama-3.1-70b-instruct",
-			"name": "abacusai/dracarys-llama-3.1-70b-instruct",
+			"name": "dracarys-llama-3.1-70b-instruct",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -60027,8 +63956,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 16384
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"adept/fuyu-8b": {
 			"id": "adept/fuyu-8b",
@@ -60454,13 +64383,14 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12b It",
+			"name": "Gemma 3 12B IT",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -60468,8 +64398,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 4096
+			"contextWindow": 131072,
+			"maxTokens": 16384
 		},
 		"google/gemma-3-1b-it": {
 			"id": "google/gemma-3-1b-it",
@@ -60513,13 +64443,14 @@
 		},
 		"google/gemma-3-4b-it": {
 			"id": "google/gemma-3-4b-it",
-			"name": "google/gemma-3-4b-it",
+			"name": "Gemma 3 4B IT",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -60527,8 +64458,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 131072,
+			"maxTokens": 16384
 		},
 		"google/gemma-3n-e2b-it": {
 			"id": "google/gemma-3n-e2b-it",
@@ -61388,11 +65319,11 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144
+			"maxTokens": 16384
 		},
 		"mistralai/mistral-7b-instruct-v0.3": {
 			"id": "mistralai/mistral-7b-instruct-v0.3",
-			"name": "mistralai/mistral-7b-instruct-v0.3",
+			"name": "Mistral-7B-Instruct-v0.3",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -61406,8 +65337,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 65536,
+			"maxTokens": 65536
 		},
 		"mistralai/mistral-7b-instruct-v03": {
 			"id": "mistralai/mistral-7b-instruct-v03",
@@ -61488,7 +65419,7 @@
 		},
 		"mistralai/mistral-medium-3.5-128b": {
 			"id": "mistralai/mistral-medium-3.5-128b",
-			"name": "Mistral Medium 3.5 128B",
+			"name": "Mistral Medium 3.5",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -61504,7 +65435,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -61828,13 +65759,14 @@
 		},
 		"nvidia/cosmos-reason2-8b": {
 			"id": "nvidia/cosmos-reason2-8b",
-			"name": "nvidia/cosmos-reason2-8b",
+			"name": "Cosmos Reason2 8B",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -61842,8 +65774,18 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 131072,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nvidia/embed-qa-4": {
 			"id": "nvidia/embed-qa-4",
@@ -62019,7 +65961,7 @@
 		},
 		"nvidia/llama-3.1-nemotron-70b-instruct": {
 			"id": "nvidia/llama-3.1-nemotron-70b-instruct",
-			"name": "Llama 3.1 Nemotron 70b Instruct",
+			"name": "Llama 3.1 Nemotron 70B Instruct",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -62034,15 +65976,15 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 8192
 		},
 		"nvidia/llama-3.1-nemotron-nano-8b-v1": {
 			"id": "nvidia/llama-3.1-nemotron-nano-8b-v1",
-			"name": "nvidia/llama-3.1-nemotron-nano-8b-v1",
+			"name": "Llama 3.1 Nemotron Nano 8B v1",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -62052,18 +65994,29 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 131072,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nvidia/llama-3.1-nemotron-nano-vl-8b-v1": {
 			"id": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
-			"name": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
+			"name": "Llama 3.1 Nemotron Nano VL 8B v1",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -62071,8 +66024,18 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 32768,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
 			"id": "nvidia/llama-3.1-nemotron-safety-guard-8b-v3",
@@ -62095,7 +66058,7 @@
 		},
 		"nvidia/llama-3.1-nemotron-ultra-253b-v1": {
 			"id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-			"name": "Llama-3.1-Nemotron-Ultra-253B-v1",
+			"name": "Llama 3.1 Nemotron Ultra 253B",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -62109,8 +66072,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8192,
+			"contextWindow": 128000,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62162,26 +66125,7 @@
 		},
 		"nvidia/llama-3.3-nemotron-super-49b-v1": {
 			"id": "nvidia/llama-3.3-nemotron-super-49b-v1",
-			"name": "nvidia/llama-3.3-nemotron-super-49b-v1",
-			"api": "openai-completions",
-			"provider": "nvidia",
-			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": null,
-			"maxTokens": null
-		},
-		"nvidia/llama-3.3-nemotron-super-49b-v1.5": {
-			"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-			"name": "Llama 3.3 Nemotron Super 49B V1.5",
+			"name": "Llama 3.3 Nemotron Super 49B v1",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -62196,7 +66140,36 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 16384,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
+		"nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+			"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+			"name": "Llama 3.3 Nemotron Super 49B v1.5",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -62537,13 +66510,14 @@
 		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
 			"id": "nvidia/nemotron-nano-12b-v2-vl",
-			"name": "nvidia/nemotron-nano-12b-v2-vl",
+			"name": "Nemotron Nano 12B v2 VL",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -62551,8 +66525,18 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 128000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
 		},
 		"nvidia/nemotron-nano-3-30b-a3b": {
 			"id": "nvidia/nemotron-nano-3-30b-a3b",
@@ -62865,6 +66849,35 @@
 				]
 			}
 		},
+		"poolside/laguna-xs-2.1": {
+			"id": "poolside/laguna-xs-2.1",
+			"name": "Laguna XS 2.1",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"qwen/qwen2.5-coder-32b-instruct": {
 			"id": "qwen/qwen2.5-coder-32b-instruct",
 			"name": "Qwen2.5 Coder 32b Instruct",
@@ -63172,6 +67185,36 @@
 			"contextWindow": null,
 			"maxTokens": null
 		},
+		"thinkingmachines/inkling": {
+			"id": "thinkingmachines/inkling",
+			"name": "Inkling",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			}
+		},
 		"upstage/solar-10_7b-instruct": {
 			"id": "upstage/solar-10_7b-instruct",
 			"name": "solar-10.7b-instruct",
@@ -63193,7 +67236,7 @@
 		},
 		"upstage/solar-10.7b-instruct": {
 			"id": "upstage/solar-10.7b-instruct",
-			"name": "upstage/solar-10.7b-instruct",
+			"name": "solar-10.7b-instruct",
 			"api": "openai-completions",
 			"provider": "nvidia",
 			"baseUrl": "https://integrate.api.nvidia.com/v1",
@@ -63207,8 +67250,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": null,
-			"maxTokens": null
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"writer/palmyra-creative-122b": {
 			"id": "writer/palmyra-creative-122b",
@@ -64106,11 +68149,24 @@
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
-			"name": "Kimi K3",
+			"name": "kimi-k3",
 			"api": "ollama-chat",
 			"provider": "ollama-cloud",
 			"baseUrl": "https://ollama.com",
 			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"omitMaxOutputTokens": true,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -64120,21 +68176,7 @@
 				],
 				"defaultLevel": "max",
 				"requiresEffort": true
-			},
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 8192,
-			"omitMaxOutputTokens": true,
-			"supportsComputerUse": false
+			}
 		},
 		"minimax-m2": {
 			"id": "minimax-m2",
@@ -65625,10 +69667,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -65656,10 +69698,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -65753,10 +69795,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -65784,10 +69826,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -66245,10 +70287,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"remoteCompaction": {
 				"enabled": true,
@@ -66323,10 +70365,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 2.5
 			},
 			"remoteCompaction": {
 				"enabled": true,
@@ -66501,7 +70543,7 @@
 	"opencode-go": {
 		"deepseek-v4-flash": {
 			"id": "deepseek-v4-flash",
-			"name": "DeepSeek V4 Flash",
+			"name": "DeepSeek V4 Flash (New)",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -66646,6 +70688,36 @@
 					"low",
 					"medium",
 					"high",
+					"max"
+				]
+			}
+		},
+		"gpt-5.6-luna": {
+			"id": "gpt-5.6-luna",
+			"name": "GPT-5.6 Luna (2x usage)",
+			"api": "openai-responses",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.6,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.125
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
 					"max"
 				]
 			}
@@ -66804,7 +70876,7 @@
 		},
 		"kimi-k3": {
 			"id": "kimi-k3",
-			"name": "Kimi K3 (2x usage)",
+			"name": "Kimi K3",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -67603,7 +71675,7 @@
 		},
 		"deepseek-v4-flash-free": {
 			"id": "deepseek-v4-flash-free",
-			"name": "DeepSeek V4 Flash Free",
+			"name": "DeepSeek V4 Flash Free (New)",
 			"api": "openai-completions",
 			"provider": "opencode-zen",
 			"baseUrl": "https://opencode.ai/zen/v1",
@@ -68479,10 +72551,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.1,
-				"cacheWrite": 1.25
+				"input": 0.2,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -69622,13 +73694,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
+				"input": 2.9000000000000004,
+				"output": 14,
+				"cacheRead": 0.29,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 262144,
+			"maxTokens": 1048576,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -70186,6 +74258,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"anthropic/claude-fable-5:batch": {
+			"id": "anthropic/claude-fable-5:batch",
+			"name": "Claude Fable 5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
 			"name": "Claude Haiku 4.5",
@@ -70216,6 +74319,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-haiku-4.5:batch": {
+			"id": "anthropic/claude-haiku-4.5:batch",
+			"name": "Claude Haiku 4.5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 2.5,
+				"cacheRead": 0.049999999999999996,
+				"cacheWrite": 0.625
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -70279,6 +74412,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"anthropic/claude-opus-4.1:batch": {
+			"id": "anthropic/claude-opus-4.1:batch",
+			"name": "Claude Opus 4.1 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 7.5,
+				"output": 37.5,
+				"cacheRead": 0.75,
+				"cacheWrite": 9.375
+			},
+			"contextWindow": 200000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
 			"name": "Claude Opus 4.5",
@@ -70309,6 +74472,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-opus-4.5:batch": {
+			"id": "anthropic/claude-opus-4.5:batch",
+			"name": "Claude Opus 4.5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.6": {
 			"id": "anthropic/claude-opus-4.6",
@@ -70371,6 +74564,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-opus-4.6:batch": {
+			"id": "anthropic/claude-opus-4.6:batch",
+			"name": "Claude Opus 4.6 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -70436,6 +74659,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"anthropic/claude-opus-4.7:batch": {
+			"id": "anthropic/claude-opus-4.7:batch",
+			"name": "Claude Opus 4.7 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"anthropic/claude-opus-4.8": {
 			"id": "anthropic/claude-opus-4.8",
 			"name": "Claude Opus 4.8",
@@ -70499,6 +74753,37 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-opus-4.8:batch": {
+			"id": "anthropic/claude-opus-4.8:batch",
+			"name": "Claude Opus 4.8 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 12.5,
+				"cacheRead": 0.25,
+				"cacheWrite": 3.125
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
@@ -70626,6 +74911,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"anthropic/claude-sonnet-4.5:batch": {
+			"id": "anthropic/claude-sonnet-4.5:batch",
+			"name": "Claude Sonnet 4.5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0.15,
+				"cacheWrite": 1.875
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"anthropic/claude-sonnet-4.6": {
 			"id": "anthropic/claude-sonnet-4.6",
 			"name": "Claude Sonnet 4.6",
@@ -70688,6 +75003,37 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"anthropic/claude-sonnet-5:batch": {
+			"id": "anthropic/claude-sonnet-5:batch",
+			"name": "Claude Sonnet 5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"arcee-ai/trinity-large-preview": {
 			"id": "arcee-ai/trinity-large-preview",
@@ -71203,8 +75549,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.20020000000000002,
-				"output": 0.8000999999999999,
+				"input": 0.2574,
+				"output": 1.0287,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
@@ -71450,6 +75796,32 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"deepseek/deepseek-v4-flash-0731": {
+			"id": "deepseek/deepseek-v4-flash-0731",
+			"name": "DeepSeek V4 Flash 0731",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.0028,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"deepseek/deepseek-v4-flash:free": {
 			"id": "deepseek/deepseek-v4-flash:free",
 			"name": "DeepSeek V4 Flash (free)",
@@ -71662,6 +76034,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"google/gemini-2.5-flash-lite:batch": {
+			"id": "google/gemini-2.5-flash-lite:batch",
+			"name": "Gemini 2.5 Flash Lite (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.049999999999999996,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65535,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"google/gemini-2.5-flash-preview-09-2025": {
 			"id": "google/gemini-2.5-flash-preview-09-2025",
 			"name": "Gemini 2.5 Flash Preview 09-2025",
@@ -71692,6 +76094,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"google/gemini-2.5-flash:batch": {
+			"id": "google/gemini-2.5-flash:batch",
+			"name": "Gemini 2.5 Flash (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.25,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65535,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-2.5-pro": {
 			"id": "google/gemini-2.5-pro",
@@ -71789,6 +76221,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"google/gemini-2.5-pro:batch": {
+			"id": "google/gemini-2.5-pro:batch",
+			"name": "Gemini 2.5 Pro (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.625,
+				"output": 5,
+				"cacheRead": 0.125,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
 		"google/gemini-3-flash-preview": {
 			"id": "google/gemini-3-flash-preview",
 			"name": "Gemini 3 Flash (Preview)",
@@ -71820,6 +76283,37 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"google/gemini-3-flash-preview:batch": {
+			"id": "google/gemini-3-flash-preview:batch",
+			"name": "Gemini 3 Flash Preview (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65535,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3-pro-image": {
 			"id": "google/gemini-3-pro-image",
@@ -71935,6 +76429,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"google/gemini-3.1-flash-lite:batch": {
+			"id": "google/gemini-3.1-flash-lite:batch",
+			"name": "Gemini 3.1 Flash Lite (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.125,
+				"output": 0.75,
+				"cacheRead": 0.012499999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
 			"name": "Gemini 3.1 Pro (Preview)",
@@ -71994,6 +76519,35 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"google/gemini-3.1-pro-preview:batch": {
+			"id": "google/gemini-3.1-pro-preview:batch",
+			"name": "Gemini 3.1 Pro Preview (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 6,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
@@ -72059,6 +76613,68 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"google/gemini-3.5-flash-lite:batch": {
+			"id": "google/gemini-3.5-flash-lite:batch",
+			"name": "Gemini 3.5 Flash Lite (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.25,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
+		"google/gemini-3.5-flash:batch": {
+			"id": "google/gemini-3.5-flash:batch",
+			"name": "Gemini 3.5 Flash (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 4.5,
+				"cacheRead": 0.075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
 			"name": "Gemini 3.6 Flash",
@@ -72091,9 +76707,40 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"google/gemini-3.6-flash:batch": {
+			"id": "google/gemini-3.6-flash:batch",
+			"name": "Gemini 3.6 Flash (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 3.75,
+				"cacheRead": 0.075,
+				"cacheWrite": 0.08333333333333334
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				],
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false
+		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12B",
+			"name": "Gemma 3 12B IT",
 			"api": "openrouter",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -72169,13 +76816,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.42,
+				"input": 0.07,
+				"output": 0.33999999999999997,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -72231,9 +76878,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.39999999999999997,
-				"cacheRead": 0.09,
+				"input": 0.09999999999999999,
+				"output": 0.33999999999999997,
+				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -73129,6 +77776,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"minimax/minimax-m3:batch": {
+			"id": "minimax/minimax-m3:batch",
+			"name": "MiniMax M3 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 524288,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
 			"name": "Codestral 2508",
@@ -73589,8 +78266,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.3,
+				"input": 0.075,
+				"output": 0.19999999999999998,
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
@@ -73842,9 +78519,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.646,
-				"output": 2.7199999999999998,
-				"cacheRead": 0.1088,
+				"input": 0.589,
+				"output": 2.48,
+				"cacheRead": 0.0992,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -74134,7 +78811,7 @@
 		},
 		"nvidia/llama-3.1-nemotron-70b-instruct": {
 			"id": "nvidia/llama-3.1-nemotron-70b-instruct",
-			"name": "Llama 3.1 Nemotron 70b Instruct",
+			"name": "Llama 3.1 Nemotron 70B Instruct",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -74155,7 +78832,7 @@
 		},
 		"nvidia/llama-3.3-nemotron-super-49b-v1.5": {
 			"id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-			"name": "Llama 3.3 Nemotron Super 49B V1.5",
+			"name": "Llama 3.3 Nemotron Super 49B v1.5",
 			"api": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -74196,11 +78873,11 @@
 			"cost": {
 				"input": 0.049999999999999996,
 				"output": 0.19999999999999998,
-				"cacheRead": 0,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 228000,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -74346,9 +79023,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 2.2,
-				"cacheRead": 0.09999999999999999,
+				"input": 0.6,
+				"output": 3.5999999999999996,
+				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 512288,
@@ -75051,6 +79728,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5-mini:batch": {
+			"id": "openai/gpt-5-mini:batch",
+			"name": "GPT-5 Mini (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.125,
+				"output": 1,
+				"cacheRead": 0.012499999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5-nano": {
 			"id": "openai/gpt-5-nano",
 			"name": "GPT-5 Nano",
@@ -75082,6 +79789,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5-nano:batch": {
+			"id": "openai/gpt-5-nano:batch",
+			"name": "GPT-5 Nano (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.024999999999999998,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.0025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5-pro": {
 			"id": "openai/gpt-5-pro",
 			"name": "GPT-5 Pro",
@@ -75112,6 +79849,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-5:batch": {
+			"id": "openai/gpt-5:batch",
+			"name": "GPT-5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.625,
+				"output": 5,
+				"cacheRead": 0.0625,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.1": {
 			"id": "openai/gpt-5.1",
@@ -75257,6 +80024,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5.1:batch": {
+			"id": "openai/gpt-5.1:batch",
+			"name": "GPT-5.1 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.625,
+				"output": 5,
+				"cacheRead": 0.0625,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5.2": {
 			"id": "openai/gpt-5.2",
 			"name": "GPT-5.2",
@@ -75371,6 +80168,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-5.2:batch": {
+			"id": "openai/gpt-5.2:batch",
+			"name": "GPT-5.2 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.875,
+				"output": 7,
+				"cacheRead": 0.0875,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.3-chat": {
 			"id": "openai/gpt-5.3-chat",
@@ -75487,6 +80314,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5.4-mini:batch": {
+			"id": "openai/gpt-5.4-mini:batch",
+			"name": "GPT-5.4 Mini (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.375,
+				"output": 2.25,
+				"cacheRead": 0.0375,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
 			"name": "GPT-5.4 Nano",
@@ -75518,6 +80375,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5.4-nano:batch": {
+			"id": "openai/gpt-5.4-nano:batch",
+			"name": "GPT-5.4 Nano (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.09999999999999999,
+				"output": 0.625,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"openai/gpt-5.4-pro": {
 			"id": "openai/gpt-5.4-pro",
 			"name": "GPT-5.4 Pro",
@@ -75548,6 +80435,36 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
+		},
+		"openai/gpt-5.4:batch": {
+			"id": "openai/gpt-5.4:batch",
+			"name": "GPT-5.4 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 7.5,
+				"cacheRead": 0.125,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"openai/gpt-5.5": {
 			"id": "openai/gpt-5.5",
@@ -75613,6 +80530,37 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"openai/gpt-5.5:batch": {
+			"id": "openai/gpt-5.5:batch",
+			"name": "GPT-5.5 (batch)",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false,
+			"contextPromotionTarget": "openrouter/openai/gpt-5.4"
+		},
 		"openai/gpt-5.6-luna": {
 			"id": "openai/gpt-5.6-luna",
 			"name": "GPT-5.6 Luna",
@@ -75625,10 +80573,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 3,
-				"cacheRead": 0.049999999999999996,
-				"cacheWrite": 0.625
+				"input": 0.09999999999999999,
+				"output": 0.6000000000000001,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.12500000000000003
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75657,10 +80605,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 3,
-				"cacheRead": 0.049999999999999996,
-				"cacheWrite": 0.625
+				"input": 0.09999999999999999,
+				"output": 0.6000000000000001,
+				"cacheRead": 0.01,
+				"cacheWrite": 0.12500000000000003
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75753,10 +80701,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 7.5,
-				"cacheRead": 0.125,
-				"cacheWrite": 1.5625
+				"input": 1.0000000000000002,
+				"output": 6,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -75785,10 +80733,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.25,
-				"output": 7.5,
-				"cacheRead": 0.125,
-				"cacheWrite": 1.5625
+				"input": 1.0000000000000002,
+				"output": 6,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -76637,9 +81585,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.19999999999999998,
-				"cacheRead": 0.01,
+				"input": 0.09,
+				"output": 0.18,
+				"cacheRead": 0.009,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -76868,8 +81816,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.04,
-				"output": 0.09999999999999999,
+				"input": 0.09999999999999999,
+				"output": 0.19999999999999998,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -76952,10 +81900,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 0.78,
+				"input": 0.39999999999999997,
+				"output": 1.2,
 				"cacheRead": 0,
-				"cacheWrite": 0.325
+				"cacheWrite": 0.5
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32768,
@@ -77106,8 +82054,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 3,
+				"input": 0.22999999999999998,
+				"output": 2.3,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
@@ -77188,8 +82136,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 1.56,
+				"input": 0.19999999999999998,
+				"output": 2.4,
 				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
@@ -77402,7 +82350,7 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.11,
+				"input": 0.12,
 				"output": 0.7999999999999999,
 				"cacheRead": 0.07,
 				"cacheWrite": 0
@@ -77492,7 +82440,7 @@
 				"cacheWrite": 0.975
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 65536,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -77513,7 +82461,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 32768,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -77580,8 +82528,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.0975,
-				"output": 0.78,
+				"input": 0.15,
+				"output": 1.2,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -77634,8 +82582,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.26,
-				"output": 2.6,
+				"input": 0.39999999999999997,
+				"output": 4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -77666,13 +82614,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.6,
+				"input": 0.13,
+				"output": 0.52,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 32768,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
@@ -77688,8 +82636,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 1.56,
+				"input": 0.19999999999999998,
+				"output": 2.4,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -77764,8 +82712,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.117,
-				"output": 1.365,
+				"input": 0.18,
+				"output": 2.0999999999999996,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -78136,10 +83084,10 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.04,
-				"output": 6.24,
+				"input": 1.0270000000000001,
+				"output": 6.162,
 				"cacheRead": 0,
-				"cacheWrite": 1.3
+				"cacheWrite": 1.28375
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
@@ -78247,6 +83195,36 @@
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
 		},
+		"qwen/qwen3.7-flash": {
+			"id": "qwen/qwen3.7-flash",
+			"name": "Qwen3.7 Flash",
+			"api": "openrouter",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.006,
+				"cacheWrite": 0.038000000000000006
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
+		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
 			"name": "Qwen3.7 Max",
@@ -78264,7 +83242,7 @@
 				"cacheWrite": 1.84375
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 65536,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -78295,7 +83273,7 @@
 				"cacheWrite": 0.39999999999999997
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 65536,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -78733,7 +83711,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 1024000,
 			"maxTokens": 32768,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
@@ -79798,13 +84776,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.7714000000000001,
-				"output": 2.4244,
-				"cacheRead": 0.14326,
+				"input": 1.12,
+				"output": 3.52,
+				"cacheRead": 0.20800000000000002,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"efforts": [
@@ -80003,69 +84981,25 @@
 		}
 	},
 	"synthetic": {
-		"hf:MiniMaxAI/MiniMax-M3": {
-			"id": "hf:MiniMaxAI/MiniMax-M3",
-			"name": "MiniMaxAI/MiniMax-M3",
+		"hf:moonshotai/Kimi-K3": {
+			"id": "hf:moonshotai/Kimi-K3",
+			"name": "moonshotai/Kimi-K3",
 			"api": "openai-completions",
 			"provider": "synthetic",
 			"baseUrl": "https://api.synthetic.new/openai/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 1.2,
-				"cacheRead": 0.6,
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
-		},
-		"hf:moonshotai/Kimi-K2.7-Code": {
-			"id": "hf:moonshotai/Kimi-K2.7-Code",
-			"name": "moonshotai/Kimi-K2.7-Code",
-			"api": "openai-completions",
-			"provider": "synthetic",
-			"baseUrl": "https://api.synthetic.new/openai/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.95,
-				"output": 4,
-				"cacheRead": 0.95,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "effort",
-				"efforts": [
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh"
-				]
-			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"contextWindow": 524288,
+			"maxTokens": 8192,
+			"supportsComputerUse": false
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -80257,7 +85191,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 524288,
 			"maxTokens": 8192,
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false
@@ -80722,6 +85656,39 @@
 					"high",
 					"xhigh"
 				]
+			}
+		},
+		"moonshotai/Kimi-K3": {
+			"id": "moonshotai/Kimi-K3",
+			"name": "Kimi K3",
+			"api": "openai-completions",
+			"provider": "together",
+			"baseUrl": "https://api.together.xyz/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
 			}
 		},
 		"nvidia/nemotron-3-ultra-550b-a55b": {
@@ -81276,7 +86243,7 @@
 		},
 		"umans-kimi-k3": {
 			"id": "umans-kimi-k3",
-			"name": "Umans Kimi K3 (prerelease)",
+			"name": "Umans Kimi K3",
 			"api": "anthropic-messages",
 			"provider": "umans",
 			"baseUrl": "https://api.code.umans.ai",
@@ -81304,6 +86271,7 @@
 			"contextWindow": 1048576,
 			"maxTokens": 131071,
 			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
 			"compat": {
 				"escapeBuiltinToolNames": true
 			}
@@ -83114,7 +88082,7 @@
 				"cacheRead": 0.2125,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 524288,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -83652,7 +88620,8 @@
 					"high",
 					"xhigh"
 				]
-			}
+			},
+			"supportsComputerUse": false
 		},
 		"olafangensan-glm-4.7-flash-heretic": {
 			"id": "olafangensan-glm-4.7-flash-heretic",
@@ -84467,9 +89436,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
+				"input": 0.1,
 				"output": 1,
-				"cacheRead": 0.05,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 256000,
@@ -85544,6 +90513,37 @@
 				"cacheWrite": 0.625
 			},
 			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"alibaba/qwen3.7-flash": {
+			"id": "alibaba/qwen3.7-flash",
+			"name": "Qwen 3.7 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.006,
+				"cacheWrite": 0.038000000000000006
+			},
+			"contextWindow": 991000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -86680,8 +91680,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
+				"input": 0.13799999999999998,
+				"output": 0.275,
 				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
@@ -86984,7 +91984,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-3.1-flash-lite": {
 			"id": "google/gemini-3.1-flash-lite",
@@ -88723,7 +93724,7 @@
 		},
 		"nvidia/nemotron-nano-12b-v2-vl": {
 			"id": "nvidia/nemotron-nano-12b-v2-vl",
-			"name": "Nvidia Nemotron Nano 12B V2 VL",
+			"name": "Nemotron Nano 12B v2 VL",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -89035,7 +94036,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -89155,7 +94156,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -89215,7 +94216,7 @@
 			"cost": {
 				"input": 0.25,
 				"output": 2,
-				"cacheRead": 0.024999999999999998,
+				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -89243,7 +94244,7 @@
 			"cost": {
 				"input": 1.25,
 				"output": 10,
-				"cacheRead": 0.125,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -89647,10 +94648,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 1,
-				"output": 6,
-				"cacheRead": 0.09999999999999999,
-				"cacheWrite": 1.25
+				"input": 0.19999999999999998,
+				"output": 1.2,
+				"cacheRead": 0.02,
+				"cacheWrite": 0.25
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -89709,10 +94710,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 2.5,
-				"output": 15,
-				"cacheRead": 0.25,
-				"cacheWrite": 3.125
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 2.5
 			},
 			"contextWindow": 1050000,
 			"maxTokens": 128000,
@@ -90285,6 +95286,37 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 256000,
+			"thinking": {
+				"mode": "budget",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
+			"supportsComputerUse": false
+		},
+		"thinkingmachines/inkling-small": {
+			"id": "thinkingmachines/inkling-small",
+			"name": "Inkling Small",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 1.2,
+				"cacheRead": 0.09999999999999999,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
 			"thinking": {
 				"mode": "budget",
 				"efforts": [
@@ -91286,8 +96318,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.95,
-				"output": 3.15,
+				"input": 1,
+				"output": 3.1999999999999997,
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
@@ -91347,8 +96379,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 1.3,
-				"output": 4.300000000000001,
+				"input": 1.4,
+				"output": 4.4,
 				"cacheRead": 0.26,
 				"cacheWrite": 0
 			},
@@ -91377,12 +96409,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.4,
-				"output": 4.4,
-				"cacheRead": 0.26,
+				"input": 1.1,
+				"output": 3.851,
+				"cacheRead": 0.275,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1040000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -91541,6 +96573,7 @@
 				]
 			},
 			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false,
 			"compat": {
 				"reasoningContentField": "reasoning_content",
 				"supportsDeveloperRole": false
@@ -91748,6 +96781,84 @@
 			},
 			"supportsComputerUse": false,
 			"supportsComputerUseConfig": false,
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
+			}
+		},
+		"Kimi-K3": {
+			"id": "Kimi-K3",
+			"name": "Kimi-K3",
+			"api": "openai-completions",
+			"provider": "wafer-serverless",
+			"baseUrl": "https://pass.wafer.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3.75,
+				"output": 18.75,
+				"cacheRead": 0.375,
+				"cacheWrite": 0
+			},
+			"contextWindow": 912384,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false,
+			"compat": {
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"supportsDeveloperRole": false
+			}
+		},
+		"kimi-k3-fast": {
+			"id": "kimi-k3-fast",
+			"name": "Kimi-K3-Fast",
+			"api": "openai-completions",
+			"provider": "wafer-serverless",
+			"baseUrl": "https://pass.wafer.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5.625,
+				"output": 28.125,
+				"cacheRead": 0.5625,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"low",
+					"high",
+					"max"
+				],
+				"defaultLevel": "max",
+				"effortMap": {
+					"max": "max"
+				},
+				"requiresEffort": true
+			},
+			"supportsComputerUse": false,
 			"compat": {
 				"thinkingFormat": "zai",
 				"reasoningContentField": "reasoning_content",
@@ -94967,7 +100078,7 @@
 		},
 		"deepseek/deepseek-v4-flash-free": {
 			"id": "deepseek/deepseek-v4-flash-free",
-			"name": "DeepSeek V4 Flash (Free)",
+			"name": "DeepSeek V4 Flash 0731 (Free)",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -94990,8 +100101,7 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false,
-			"supportsComputerUseConfig": false
+			"supportsComputerUse": false
 		},
 		"deepseek/deepseek-v4-pro": {
 			"id": "deepseek/deepseek-v4-pro",
@@ -95484,7 +100594,7 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12B",
+			"name": "Gemma 3 12B IT",
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
@@ -95978,6 +101088,37 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 32768,
+			"supportsComputerUse": false
+		},
+		"meta/muse-spark-1.1": {
+			"id": "meta/muse-spark-1.1",
+			"name": "Muse Spark 1.1",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 4.25,
+				"cacheRead": 0.125,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh"
+				]
+			},
 			"supportsComputerUse": false
 		},
 		"minimax/minimax-m2": {
@@ -97871,6 +103012,36 @@
 					"high"
 				]
 			}
+		},
+		"qwen/qwen3.7-flash": {
+			"id": "qwen/qwen3.7-flash",
+			"name": "Qwen3.7-Flash",
+			"api": "openai-completions",
+			"provider": "zenmux",
+			"baseUrl": "https://zenmux.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.03,
+				"output": 0.13,
+				"cacheRead": 0.003,
+				"cacheWrite": 0.038
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"efforts": [
+					"minimal",
+					"low",
+					"medium",
+					"high"
+				]
+			},
+			"supportsComputerUse": false
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -13109,7 +13109,8 @@
 			},
 			"contextWindow": 8192,
 			"maxTokens": 5000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"moonshotai/Kimi-K2.6": {
 			"id": "moonshotai/Kimi-K2.6",
@@ -13274,7 +13275,8 @@
 			},
 			"contextWindow": 32768,
 			"maxTokens": 5000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"thinkingmachines/inkling": {
 			"id": "thinkingmachines/inkling",
@@ -13317,7 +13319,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 32768,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"zai-org/GLM-4.7": {
 			"id": "zai-org/GLM-4.7",
@@ -15688,7 +15691,8 @@
 					"high": "claude-4-sonnet-thinking"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-4.5-opus-high": {
 			"id": "claude-4.5-opus-high",
@@ -15726,7 +15730,8 @@
 				}
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-4.5-sonnet": {
 			"id": "claude-4.5-sonnet",
@@ -15764,7 +15769,8 @@
 				}
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-4.6-opus-high": {
 			"id": "claude-4.6-opus-high",
@@ -15801,7 +15807,8 @@
 				}
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-4.6-opus-max": {
 			"id": "claude-4.6-opus-max",
@@ -15839,7 +15846,8 @@
 					"high": "claude-4.6-opus-max-thinking"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-4.6-sonnet-medium": {
 			"id": "claude-4.6-sonnet-medium",
@@ -15876,7 +15884,8 @@
 				}
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-fable-5-high": {
 			"id": "claude-fable-5-high",
@@ -15914,7 +15923,8 @@
 					"high": "claude-fable-5-thinking-high"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-fable-5-low": {
 			"id": "claude-fable-5-low",
@@ -15952,7 +15962,8 @@
 					"high": "claude-fable-5-thinking-low"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-fable-5-max": {
 			"id": "claude-fable-5-max",
@@ -15990,7 +16001,8 @@
 					"high": "claude-fable-5-thinking-max"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-fable-5-medium": {
 			"id": "claude-fable-5-medium",
@@ -16028,7 +16040,8 @@
 					"high": "claude-fable-5-thinking-medium"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-fable-5-xhigh": {
 			"id": "claude-fable-5-xhigh",
@@ -16066,7 +16079,8 @@
 					"high": "claude-fable-5-thinking-xhigh"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-high": {
 			"id": "claude-opus-4-7-high",
@@ -16104,7 +16118,8 @@
 					"high": "claude-opus-4-7-thinking-high"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-high-fast": {
 			"id": "claude-opus-4-7-high-fast",
@@ -16142,7 +16157,8 @@
 					"high": "claude-opus-4-7-thinking-high-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-low": {
 			"id": "claude-opus-4-7-low",
@@ -16180,7 +16196,8 @@
 					"high": "claude-opus-4-7-thinking-low"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-low-fast": {
 			"id": "claude-opus-4-7-low-fast",
@@ -16218,7 +16235,8 @@
 					"high": "claude-opus-4-7-thinking-low-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-max": {
 			"id": "claude-opus-4-7-max",
@@ -16256,7 +16274,8 @@
 					"high": "claude-opus-4-7-thinking-max"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-max-fast": {
 			"id": "claude-opus-4-7-max-fast",
@@ -16294,7 +16313,8 @@
 					"high": "claude-opus-4-7-thinking-max-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-medium": {
 			"id": "claude-opus-4-7-medium",
@@ -16332,7 +16352,8 @@
 					"high": "claude-opus-4-7-thinking-medium"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-medium-fast": {
 			"id": "claude-opus-4-7-medium-fast",
@@ -16370,7 +16391,8 @@
 					"high": "claude-opus-4-7-thinking-medium-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-xhigh": {
 			"id": "claude-opus-4-7-xhigh",
@@ -16408,7 +16430,8 @@
 					"high": "claude-opus-4-7-thinking-xhigh"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-7-xhigh-fast": {
 			"id": "claude-opus-4-7-xhigh-fast",
@@ -16446,7 +16469,8 @@
 					"high": "claude-opus-4-7-thinking-xhigh-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-high": {
 			"id": "claude-opus-4-8-high",
@@ -16484,7 +16508,8 @@
 					"high": "claude-opus-4-8-thinking-high"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-high-fast": {
 			"id": "claude-opus-4-8-high-fast",
@@ -16522,7 +16547,8 @@
 					"high": "claude-opus-4-8-thinking-high-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-low": {
 			"id": "claude-opus-4-8-low",
@@ -16560,7 +16586,8 @@
 					"high": "claude-opus-4-8-thinking-low"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-low-fast": {
 			"id": "claude-opus-4-8-low-fast",
@@ -16598,7 +16625,8 @@
 					"high": "claude-opus-4-8-thinking-low-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-max": {
 			"id": "claude-opus-4-8-max",
@@ -16636,7 +16664,8 @@
 					"high": "claude-opus-4-8-thinking-max"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-max-fast": {
 			"id": "claude-opus-4-8-max-fast",
@@ -16674,7 +16703,8 @@
 					"high": "claude-opus-4-8-thinking-max-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-medium": {
 			"id": "claude-opus-4-8-medium",
@@ -16712,7 +16742,8 @@
 					"high": "claude-opus-4-8-thinking-medium"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-medium-fast": {
 			"id": "claude-opus-4-8-medium-fast",
@@ -16750,7 +16781,8 @@
 					"high": "claude-opus-4-8-thinking-medium-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-xhigh": {
 			"id": "claude-opus-4-8-xhigh",
@@ -16788,7 +16820,8 @@
 					"high": "claude-opus-4-8-thinking-xhigh"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-4-8-xhigh-fast": {
 			"id": "claude-opus-4-8-xhigh-fast",
@@ -16826,7 +16859,8 @@
 					"high": "claude-opus-4-8-thinking-xhigh-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-high": {
 			"id": "claude-opus-5-high",
@@ -16864,7 +16898,8 @@
 					"high": "claude-opus-5-thinking-high"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-high-fast": {
 			"id": "claude-opus-5-high-fast",
@@ -16902,7 +16937,8 @@
 					"high": "claude-opus-5-thinking-high-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-low": {
 			"id": "claude-opus-5-low",
@@ -16940,7 +16976,8 @@
 					"high": "claude-opus-5-thinking-low"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-low-fast": {
 			"id": "claude-opus-5-low-fast",
@@ -16978,7 +17015,8 @@
 					"high": "claude-opus-5-thinking-low-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-medium": {
 			"id": "claude-opus-5-medium",
@@ -17016,7 +17054,8 @@
 					"high": "claude-opus-5-thinking-medium"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-medium-fast": {
 			"id": "claude-opus-5-medium-fast",
@@ -17054,7 +17093,8 @@
 					"high": "claude-opus-5-thinking-medium-fast"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-thinking-max": {
 			"id": "claude-opus-5-thinking-max",
@@ -17076,7 +17116,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-thinking-max-fast": {
 			"id": "claude-opus-5-thinking-max-fast",
@@ -17098,7 +17139,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": true,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-thinking-xhigh": {
 			"id": "claude-opus-5-thinking-xhigh",
@@ -17120,7 +17162,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-opus-5-thinking-xhigh-fast": {
 			"id": "claude-opus-5-thinking-xhigh-fast",
@@ -17142,7 +17185,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": true,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-sonnet-5-high": {
 			"id": "claude-sonnet-5-high",
@@ -17180,7 +17224,8 @@
 					"high": "claude-sonnet-5-thinking-high"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-sonnet-5-low": {
 			"id": "claude-sonnet-5-low",
@@ -17218,7 +17263,8 @@
 					"high": "claude-sonnet-5-thinking-low"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-sonnet-5-max": {
 			"id": "claude-sonnet-5-max",
@@ -17256,7 +17302,8 @@
 					"high": "claude-sonnet-5-thinking-max"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-sonnet-5-medium": {
 			"id": "claude-sonnet-5-medium",
@@ -17294,7 +17341,8 @@
 					"high": "claude-sonnet-5-thinking-medium"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"claude-sonnet-5-xhigh": {
 			"id": "claude-sonnet-5-xhigh",
@@ -17332,7 +17380,8 @@
 					"high": "claude-sonnet-5-thinking-xhigh"
 				}
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"composer-1": {
 			"id": "composer-1",
@@ -17352,7 +17401,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"composer-1.5": {
 			"id": "composer-1.5",
@@ -17372,7 +17422,8 @@
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"composer-2.5": {
 			"id": "composer-2.5",
@@ -17393,7 +17444,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"composer-2.5-fast": {
 			"id": "composer-2.5-fast",
@@ -17414,7 +17466,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"cursor-grok-4.5-high": {
 			"id": "cursor-grok-4.5-high",
@@ -17435,7 +17488,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"cursor-grok-4.5-high-fast": {
 			"id": "cursor-grok-4.5-high-fast",
@@ -17456,7 +17510,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"cursor-grok-4.5-low": {
 			"id": "cursor-grok-4.5-low",
@@ -17477,7 +17532,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"cursor-grok-4.5-low-fast": {
 			"id": "cursor-grok-4.5-low-fast",
@@ -17498,7 +17554,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"cursor-grok-4.5-medium": {
 			"id": "cursor-grok-4.5-medium",
@@ -17519,7 +17576,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"cursor-grok-4.5-medium-fast": {
 			"id": "cursor-grok-4.5-medium-fast",
@@ -17540,7 +17598,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"default": {
 			"id": "default",
@@ -17562,7 +17621,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3-flash": {
 			"id": "gemini-3-flash",
@@ -17594,7 +17654,8 @@
 				"requiresEffort": true
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3-pro": {
 			"id": "gemini-3-pro",
@@ -17623,7 +17684,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3.1-pro": {
 			"id": "gemini-3.1-pro",
@@ -17653,7 +17715,8 @@
 				"requiresEffort": true
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3.5-flash": {
 			"id": "gemini-3.5-flash",
@@ -17685,7 +17748,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3.6-flash-high": {
 			"id": "gemini-3.6-flash-high",
@@ -17707,7 +17771,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3.6-flash-low": {
 			"id": "gemini-3.6-flash-low",
@@ -17729,7 +17794,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3.6-flash-medium": {
 			"id": "gemini-3.6-flash-medium",
@@ -17751,7 +17817,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gemini-3.6-flash-minimal": {
 			"id": "gemini-3.6-flash-minimal",
@@ -17773,7 +17840,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"glm-5.2-high": {
 			"id": "glm-5.2-high",
@@ -17794,7 +17862,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"glm-5.2-max": {
 			"id": "glm-5.2-max",
@@ -17815,7 +17884,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5-mini": {
 			"id": "gpt-5-mini",
@@ -17846,7 +17916,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.1": {
 			"id": "gpt-5.1",
@@ -17877,7 +17948,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.1-codex-max": {
 			"id": "gpt-5.1-codex-max",
@@ -17907,7 +17979,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.1-codex-max-high": {
 			"id": "gpt-5.1-codex-max-high",
@@ -17937,7 +18010,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.1-codex-mini": {
 			"id": "gpt-5.1-codex-mini",
@@ -17965,7 +18039,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.1-high": {
 			"id": "gpt-5.1-high",
@@ -17986,7 +18061,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.1-low": {
 			"id": "gpt-5.1-low",
@@ -18008,7 +18084,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2": {
 			"id": "gpt-5.2",
@@ -18039,7 +18116,8 @@
 				]
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
@@ -18069,7 +18147,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex-fast": {
 			"id": "gpt-5.2-codex-fast",
@@ -18089,7 +18168,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex-high": {
 			"id": "gpt-5.2-codex-high",
@@ -18109,7 +18189,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex-high-fast": {
 			"id": "gpt-5.2-codex-high-fast",
@@ -18129,7 +18210,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex-low": {
 			"id": "gpt-5.2-codex-low",
@@ -18149,7 +18231,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex-low-fast": {
 			"id": "gpt-5.2-codex-low-fast",
@@ -18169,7 +18252,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex-xhigh": {
 			"id": "gpt-5.2-codex-xhigh",
@@ -18189,7 +18273,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-codex-xhigh-fast": {
 			"id": "gpt-5.2-codex-xhigh-fast",
@@ -18209,7 +18294,8 @@
 			},
 			"contextWindow": 272000,
 			"maxTokens": 64000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-fast": {
 			"id": "gpt-5.2-fast",
@@ -18231,7 +18317,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-high": {
 			"id": "gpt-5.2-high",
@@ -18262,7 +18349,8 @@
 				]
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-high-fast": {
 			"id": "gpt-5.2-high-fast",
@@ -18284,7 +18372,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-low": {
 			"id": "gpt-5.2-low",
@@ -18306,7 +18395,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-low-fast": {
 			"id": "gpt-5.2-low-fast",
@@ -18328,7 +18418,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-xhigh": {
 			"id": "gpt-5.2-xhigh",
@@ -18350,7 +18441,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.2-xhigh-fast": {
 			"id": "gpt-5.2-xhigh-fast",
@@ -18372,7 +18464,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
@@ -18403,7 +18496,8 @@
 				]
 			},
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-fast": {
 			"id": "gpt-5.3-codex-fast",
@@ -18424,7 +18518,8 @@
 			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-high": {
 			"id": "gpt-5.3-codex-high",
@@ -18445,7 +18540,8 @@
 			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-high-fast": {
 			"id": "gpt-5.3-codex-high-fast",
@@ -18466,7 +18562,8 @@
 			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-low": {
 			"id": "gpt-5.3-codex-low",
@@ -18487,7 +18584,8 @@
 			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-low-fast": {
 			"id": "gpt-5.3-codex-low-fast",
@@ -18508,7 +18606,8 @@
 			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-spark-preview": {
 			"id": "gpt-5.3-codex-spark-preview",
@@ -18529,7 +18628,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.5-low"
+			"contextPromotionTarget": "cursor/gpt-5.5-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-xhigh": {
 			"id": "gpt-5.3-codex-xhigh",
@@ -18550,7 +18650,8 @@
 			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.3-codex-xhigh-fast": {
 			"id": "gpt-5.3-codex-xhigh-fast",
@@ -18571,7 +18672,8 @@
 			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-high": {
 			"id": "gpt-5.4-high",
@@ -18592,7 +18694,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-high-fast": {
 			"id": "gpt-5.4-high-fast",
@@ -18613,7 +18716,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-low": {
 			"id": "gpt-5.4-low",
@@ -18634,7 +18738,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-medium": {
 			"id": "gpt-5.4-medium",
@@ -18655,7 +18760,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-medium-fast": {
 			"id": "gpt-5.4-medium-fast",
@@ -18676,7 +18782,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-mini-high": {
 			"id": "gpt-5.4-mini-high",
@@ -18698,7 +18805,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-mini-low": {
 			"id": "gpt-5.4-mini-low",
@@ -18720,7 +18828,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-mini-medium": {
 			"id": "gpt-5.4-mini-medium",
@@ -18742,7 +18851,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-mini-none": {
 			"id": "gpt-5.4-mini-none",
@@ -18764,7 +18874,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-mini-xhigh": {
 			"id": "gpt-5.4-mini-xhigh",
@@ -18786,7 +18897,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-nano-high": {
 			"id": "gpt-5.4-nano-high",
@@ -18808,7 +18920,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-nano-low": {
 			"id": "gpt-5.4-nano-low",
@@ -18830,7 +18943,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-nano-medium": {
 			"id": "gpt-5.4-nano-medium",
@@ -18852,7 +18966,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-nano-none": {
 			"id": "gpt-5.4-nano-none",
@@ -18874,7 +18989,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-nano-xhigh": {
 			"id": "gpt-5.4-nano-xhigh",
@@ -18896,7 +19012,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-xhigh": {
 			"id": "gpt-5.4-xhigh",
@@ -18917,7 +19034,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.4-xhigh-fast": {
 			"id": "gpt-5.4-xhigh-fast",
@@ -18938,7 +19056,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"supportsComputerUse": false,
-			"cursorMaxMode": false
+			"cursorMaxMode": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-extra-high": {
 			"id": "gpt-5.5-extra-high",
@@ -18961,7 +19080,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-extra-high-fast": {
 			"id": "gpt-5.5-extra-high-fast",
@@ -18984,7 +19104,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-high": {
 			"id": "gpt-5.5-high",
@@ -19007,7 +19128,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-high-fast": {
 			"id": "gpt-5.5-high-fast",
@@ -19030,7 +19152,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-low": {
 			"id": "gpt-5.5-low",
@@ -19053,7 +19176,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-low-fast": {
 			"id": "gpt-5.5-low-fast",
@@ -19076,7 +19200,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-medium": {
 			"id": "gpt-5.5-medium",
@@ -19099,7 +19224,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-medium-fast": {
 			"id": "gpt-5.5-medium-fast",
@@ -19122,7 +19248,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-none": {
 			"id": "gpt-5.5-none",
@@ -19145,7 +19272,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.5-none-fast": {
 			"id": "gpt-5.5-none-fast",
@@ -19168,7 +19296,8 @@
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "cursor/gpt-5.4-low"
+			"contextPromotionTarget": "cursor/gpt-5.4-low",
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-high": {
 			"id": "gpt-5.6-luna-high",
@@ -19190,7 +19319,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-high-fast": {
 			"id": "gpt-5.6-luna-high-fast",
@@ -19212,7 +19342,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-low": {
 			"id": "gpt-5.6-luna-low",
@@ -19234,7 +19365,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-low-fast": {
 			"id": "gpt-5.6-luna-low-fast",
@@ -19256,7 +19388,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-max": {
 			"id": "gpt-5.6-luna-max",
@@ -19278,7 +19411,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-max-fast": {
 			"id": "gpt-5.6-luna-max-fast",
@@ -19300,7 +19434,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-medium": {
 			"id": "gpt-5.6-luna-medium",
@@ -19322,7 +19457,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-medium-fast": {
 			"id": "gpt-5.6-luna-medium-fast",
@@ -19344,7 +19480,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-none": {
 			"id": "gpt-5.6-luna-none",
@@ -19366,7 +19503,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-none-fast": {
 			"id": "gpt-5.6-luna-none-fast",
@@ -19388,7 +19526,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-xhigh": {
 			"id": "gpt-5.6-luna-xhigh",
@@ -19410,7 +19549,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-luna-xhigh-fast": {
 			"id": "gpt-5.6-luna-xhigh-fast",
@@ -19432,7 +19572,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-high": {
 			"id": "gpt-5.6-sol-high",
@@ -19454,7 +19595,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-high-fast": {
 			"id": "gpt-5.6-sol-high-fast",
@@ -19476,7 +19618,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-low": {
 			"id": "gpt-5.6-sol-low",
@@ -19498,7 +19641,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-low-fast": {
 			"id": "gpt-5.6-sol-low-fast",
@@ -19520,7 +19664,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-max": {
 			"id": "gpt-5.6-sol-max",
@@ -19542,7 +19687,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-max-fast": {
 			"id": "gpt-5.6-sol-max-fast",
@@ -19564,7 +19710,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-medium": {
 			"id": "gpt-5.6-sol-medium",
@@ -19586,7 +19733,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-medium-fast": {
 			"id": "gpt-5.6-sol-medium-fast",
@@ -19608,7 +19756,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-none": {
 			"id": "gpt-5.6-sol-none",
@@ -19630,7 +19779,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-none-fast": {
 			"id": "gpt-5.6-sol-none-fast",
@@ -19652,7 +19802,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-xhigh": {
 			"id": "gpt-5.6-sol-xhigh",
@@ -19674,7 +19825,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-sol-xhigh-fast": {
 			"id": "gpt-5.6-sol-xhigh-fast",
@@ -19696,7 +19848,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-high": {
 			"id": "gpt-5.6-terra-high",
@@ -19718,7 +19871,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-high-fast": {
 			"id": "gpt-5.6-terra-high-fast",
@@ -19740,7 +19894,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-low": {
 			"id": "gpt-5.6-terra-low",
@@ -19762,7 +19917,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-low-fast": {
 			"id": "gpt-5.6-terra-low-fast",
@@ -19784,7 +19940,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-max": {
 			"id": "gpt-5.6-terra-max",
@@ -19806,7 +19963,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-max-fast": {
 			"id": "gpt-5.6-terra-max-fast",
@@ -19828,7 +19986,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-medium": {
 			"id": "gpt-5.6-terra-medium",
@@ -19850,7 +20009,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-medium-fast": {
 			"id": "gpt-5.6-terra-medium-fast",
@@ -19872,7 +20032,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-none": {
 			"id": "gpt-5.6-terra-none",
@@ -19894,7 +20055,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-none-fast": {
 			"id": "gpt-5.6-terra-none-fast",
@@ -19916,7 +20078,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-xhigh": {
 			"id": "gpt-5.6-terra-xhigh",
@@ -19938,7 +20101,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"gpt-5.6-terra-xhigh-fast": {
 			"id": "gpt-5.6-terra-xhigh-fast",
@@ -19960,7 +20124,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -19989,7 +20154,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
@@ -20019,7 +20185,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"kimi-k2.7-code": {
 			"id": "kimi-k2.7-code",
@@ -20050,7 +20217,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"kimi-k3-high": {
 			"id": "kimi-k3-high",
@@ -20071,7 +20239,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"kimi-k3-low": {
 			"id": "kimi-k3-low",
@@ -20092,7 +20261,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"kimi-k3-max": {
 			"id": "kimi-k3-max",
@@ -20113,7 +20283,8 @@
 			"contextWindow": 200000,
 			"maxTokens": 64000,
 			"cursorMaxMode": false,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		}
 	},
 	"deepseek": {
@@ -22864,7 +23035,7 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0,
+				"cacheRead": 0.028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -44962,7 +45133,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 384000,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"deepseek/deepseek-v4-flash:thinking": {
 			"id": "deepseek/deepseek-v4-flash:thinking",
@@ -58212,7 +58384,8 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"TEE/llama3-3-70b": {
 			"id": "TEE/llama3-3-70b",
@@ -58894,7 +59067,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"THUDM/GLM-4-32B-0414": {
 			"id": "THUDM/GLM-4-32B-0414",
@@ -61927,7 +62101,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mindai/macaron-v1-venti": {
 			"id": "mindai/macaron-v1-venti",
@@ -74287,7 +74462,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-haiku-4.5": {
 			"id": "anthropic/claude-haiku-4.5",
@@ -74348,7 +74524,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4": {
 			"id": "anthropic/claude-opus-4",
@@ -74440,7 +74617,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4.5": {
 			"id": "anthropic/claude-opus-4.5",
@@ -74501,7 +74679,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4.6": {
 			"id": "anthropic/claude-opus-4.6",
@@ -74593,7 +74772,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4.7": {
 			"id": "anthropic/claude-opus-4.7",
@@ -74688,7 +74868,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-4.8": {
 			"id": "anthropic/claude-opus-4.8",
@@ -74783,7 +74964,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-opus-5": {
 			"id": "anthropic/claude-opus-5",
@@ -74939,7 +75121,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"anthropic/claude-sonnet-4.6": {
 			"id": "anthropic/claude-sonnet-4.6",
@@ -75033,7 +75216,8 @@
 					"max"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"arcee-ai/trinity-large-preview": {
 			"id": "arcee-ai/trinity-large-preview",
@@ -75820,7 +76004,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"deepseek/deepseek-v4-flash:free": {
 			"id": "deepseek/deepseek-v4-flash:free",
@@ -76062,7 +76247,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.5-flash-preview-09-2025": {
 			"id": "google/gemini-2.5-flash-preview-09-2025",
@@ -76123,7 +76309,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-2.5-pro": {
 			"id": "google/gemini-2.5-pro",
@@ -76250,7 +76437,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-3-flash-preview": {
 			"id": "google/gemini-3-flash-preview",
@@ -76313,7 +76501,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-3-pro-image": {
 			"id": "google/gemini-3-pro-image",
@@ -76458,7 +76647,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-3.1-pro-preview": {
 			"id": "google/gemini-3.1-pro-preview",
@@ -76547,7 +76737,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-3.5-flash": {
 			"id": "google/gemini-3.5-flash",
@@ -76642,7 +76833,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-3.5-flash:batch": {
 			"id": "google/gemini-3.5-flash:batch",
@@ -76673,7 +76865,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemini-3.6-flash": {
 			"id": "google/gemini-3.6-flash",
@@ -76736,7 +76929,8 @@
 				],
 				"requiresEffort": true
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
@@ -77804,7 +77998,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
@@ -79756,7 +79951,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5-nano": {
 			"id": "openai/gpt-5-nano",
@@ -79817,7 +80013,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5-pro": {
 			"id": "openai/gpt-5-pro",
@@ -79878,7 +80075,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.1": {
 			"id": "openai/gpt-5.1",
@@ -80052,7 +80250,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.2": {
 			"id": "openai/gpt-5.2",
@@ -80197,7 +80396,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.3-chat": {
 			"id": "openai/gpt-5.3-chat",
@@ -80342,7 +80542,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.4-nano": {
 			"id": "openai/gpt-5.4-nano",
@@ -80403,7 +80604,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.4-pro": {
 			"id": "openai/gpt-5.4-pro",
@@ -80464,7 +80666,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.5": {
 			"id": "openai/gpt-5.5",
@@ -80559,7 +80762,8 @@
 				]
 			},
 			"supportsComputerUse": false,
-			"contextPromotionTarget": "openrouter/openai/gpt-5.4"
+			"contextPromotionTarget": "openrouter/openai/gpt-5.4",
+			"supportsComputerUseConfig": false
 		},
 		"openai/gpt-5.6-luna": {
 			"id": "openai/gpt-5.6-luna",
@@ -83223,7 +83427,8 @@
 					"high"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
@@ -84999,7 +85204,8 @@
 			},
 			"contextWindow": 524288,
 			"maxTokens": 8192,
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4": {
 			"id": "hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
@@ -88621,7 +88827,8 @@
 					"xhigh"
 				]
 			},
-			"supportsComputerUse": false
+			"supportsComputerUse": false,
+			"supportsComputerUseConfig": false
 		},
 		"olafangensan-glm-4.7-flash-heretic": {
 			"id": "olafangensan-glm-4.7-flash-heretic",

--- a/packages/catalog/src/provider-models/descriptors.ts
+++ b/packages/catalog/src/provider-models/descriptors.ts
@@ -21,6 +21,7 @@ import {
 	firepassModelManagerOptions,
 	fireworksModelManagerOptions,
 	githubCopilotModelManagerOptions,
+	gmiCloudModelManagerOptions,
 	groqModelManagerOptions,
 	huggingfaceModelManagerOptions,
 	kiloModelManagerOptions,
@@ -177,6 +178,14 @@ export const CATALOG_PROVIDERS = [
 		envVars: ["GITLAB_TOKEN"],
 		createModelManagerOptions: (config: ModelManagerConfig) => gitLabDuoWorkflowModelManagerOptions(config),
 		dynamicModelsAuthoritative: true,
+	},
+	{
+		id: "gmi-cloud",
+		defaultModel: "deepseek-ai/DeepSeek-V4-Flash",
+		envVars: ["GMI_API_KEY"],
+		createModelManagerOptions: (config: ModelManagerConfig) => gmiCloudModelManagerOptions(config),
+		dynamicModelsAuthoritative: true,
+		catalogDiscovery: { label: "GMI Cloud" },
 	},
 	{
 		id: "google",

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -894,11 +894,16 @@ export function projectOpenAIProReasoningAliases(models: readonly ModelSpec<Api>
 const GMI_CLOUD_BASE_URL = "https://api.gmi-serving.com/v1";
 
 /**
- * Bundled fallback seed for GMI Cloud. Generation has no `GMI_API_KEY`, so a
- * regen without credentials would leave the provider slice empty and the
- * declared `defaultModel` unresolvable on a fresh install before the async
- * runtime discovery fires. Live `/v1/models` discovery is authoritative and
- * replaces this seed.
+ * Bundled seed for GMI Cloud. Generation has no `GMI_API_KEY`, so a regen
+ * without credentials would leave the provider slice empty and the declared
+ * `defaultModel` unresolvable on a fresh install before the async runtime
+ * discovery fires. Live `/v1/models` discovery is authoritative for the model
+ * ID set and overrides context/max-token limits, but `mapWithBundledReference`
+ * keeps the reference's cost/reasoning/thinking — so these fields carry GMI's
+ * direct-tariff values: V4-Flash at $0.14/$0.28 per 1M with Think High/Max
+ * modes per GMI's launch post
+ * (https://www.gmicloud.ai/en/blog/deepseek-v4-is-here-we-tested-it), not
+ * discounted gateway-route pricing.
  */
 export const GMI_CLOUD_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
 	{
@@ -909,7 +914,7 @@ export const GMI_CLOUD_STATIC_MODELS: readonly ModelSpec<"openai-completions">[]
 		baseUrl: GMI_CLOUD_BASE_URL,
 		reasoning: true,
 		input: ["text"],
-		cost: { input: 0.14, output: 0.28, cacheRead: 0, cacheWrite: 0 },
+		cost: { input: 0.14, output: 0.28, cacheRead: 0.028, cacheWrite: 0 },
 		contextWindow: 1048576,
 		maxTokens: 384000,
 		thinking: { mode: "effort", efforts: [Effort.High, Effort.Max] },

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -888,6 +888,26 @@ export function projectOpenAIProReasoningAliases(models: readonly ModelSpec<Api>
 }
 
 // ---------------------------------------------------------------------------
+// 1b. GMI Cloud
+// ---------------------------------------------------------------------------
+
+export interface GmiCloudModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function gmiCloudModelManagerOptions(
+	config?: GmiCloudModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	return createSimpleOpenAICompletionsOptions(
+		"gmi-cloud" as Parameters<typeof getBundledModels>[0],
+		"https://api.gmi-serving.com/v1",
+		config,
+	);
+}
+
+// ---------------------------------------------------------------------------
 // 2. Groq
 // ---------------------------------------------------------------------------
 

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -891,6 +891,31 @@ export function projectOpenAIProReasoningAliases(models: readonly ModelSpec<Api>
 // 1b. GMI Cloud
 // ---------------------------------------------------------------------------
 
+const GMI_CLOUD_BASE_URL = "https://api.gmi-serving.com/v1";
+
+/**
+ * Bundled fallback seed for GMI Cloud. Generation has no `GMI_API_KEY`, so a
+ * regen without credentials would leave the provider slice empty and the
+ * declared `defaultModel` unresolvable on a fresh install before the async
+ * runtime discovery fires. Live `/v1/models` discovery is authoritative and
+ * replaces this seed.
+ */
+export const GMI_CLOUD_STATIC_MODELS: readonly ModelSpec<"openai-completions">[] = [
+	{
+		id: "deepseek-ai/DeepSeek-V4-Flash",
+		name: "DeepSeek V4 Flash",
+		api: "openai-completions",
+		provider: "gmi-cloud",
+		baseUrl: GMI_CLOUD_BASE_URL,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0.14, output: 0.28, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1048576,
+		maxTokens: 384000,
+		thinking: { mode: "effort", efforts: [Effort.High, Effort.Max] },
+	},
+];
+
 export interface GmiCloudModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
@@ -900,11 +925,7 @@ export interface GmiCloudModelManagerConfig {
 export function gmiCloudModelManagerOptions(
 	config?: GmiCloudModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	return createSimpleOpenAICompletionsOptions(
-		"gmi-cloud" as Parameters<typeof getBundledModels>[0],
-		"https://api.gmi-serving.com/v1",
-		config,
-	);
+	return createSimpleOpenAICompletionsOptions("gmi-cloud", GMI_CLOUD_BASE_URL, config);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/catalog/test/gmi-cloud-provider.test.ts
+++ b/packages/catalog/test/gmi-cloud-provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { CATALOG_PROVIDERS } from "@oh-my-pi/pi-catalog/provider-models/descriptors";
+import { GMI_CLOUD_STATIC_MODELS } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+
+describe("GMI Cloud provider", () => {
+	test("static seed covers the descriptor's default model", () => {
+		// Regression for the empty-slice bug: without this seed a regen run
+		// without a GMI_API_KEY bundles no gmi-cloud models, and the declared
+		// defaultModel is unresolvable at boot before async discovery fires.
+		const descriptor = CATALOG_PROVIDERS.find(provider => provider.id === "gmi-cloud");
+		expect(descriptor).toMatchObject({
+			defaultModel: "deepseek-ai/DeepSeek-V4-Flash",
+			envVars: ["GMI_API_KEY"],
+			dynamicModelsAuthoritative: true,
+		});
+		expect(GMI_CLOUD_STATIC_MODELS.map(model => model.id)).toContain("deepseek-ai/DeepSeek-V4-Flash");
+	});
+});


### PR DESCRIPTION
Adds GMI Cloud as a first-class chat-model provider, an OpenAI-compatible inference gateway at `https://api.gmi-serving.com/v1` with a `/v1/models` discovery endpoint and Bearer API-key auth.

Closes #5876.

## What this adds

Following the `adding-a-provider` contract (one catalog entry + one OpenAI-compat helper + one registry def + one `ALL` array line):

- **`packages/catalog`** — new `gmi-cloud` entry in `CATALOG_PROVIDERS` (`packages/catalog/src/provider-models/descriptors.ts`) with `envVars: ["GMI_API_KEY"]`, `dynamicModelsAuthoritative: true`, and `catalogDiscovery: { label: "GMI Cloud" }`. Runtime discovery helper `gmiCloudModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts`, a thin wrapper over `createSimpleOpenAICompletionsOptions` with base URL `https://api.gmi-serving.com/v1`.
- **`packages/ai`** — new registry definition `packages/ai/src/registry/gmi-cloud.ts` with an API-key paste login that validates the key against `https://api.gmi-serving.com/v1/models`, wired into the `ALL` array in `packages/ai/src/registry/registry.ts`. The compile-time `_CheckRegistryComplete` assertion keeps catalog and registry in sync.

`defaultModel` is `deepseek-ai/DeepSeek-V4-Flash` (cheap, capable). The `/v1/models` endpoint returns 75 models across Anthropic, OpenAI, Google, x-ai, DeepSeek, Qwen, Kimi, GLM, and others, all `owned_by: "GMI Cloud"`.

## Notes for review

- `providerId` is cast to `GeneratedProvider` (`"gmi-cloud" as Parameters<typeof getBundledModels>[0]`) until `bun run gen:models` seeds `gmi-cloud` into `models.json`, the same pattern `xai-oauth` and `vllm` use. I could not run `gen:models` here because it requires the `pi_natives` native addon (Rust build); the cast is forward-compatible and becomes a no-op once `gmi-cloud` is seeded. A maintainer run of `bun run gen:models` with a `GMI_API_KEY` will populate the bundled catalog.
- Verified: `bun --cwd packages/catalog run check` (biome + tsgo), `bun --cwd packages/ai run check` (biome + tsgo), and `bun --cwd packages/coding-agent run check:types` all pass clean. Runtime-verified end to end against the live OMP binary: `omp models refresh` discovered all 75 `gmi-cloud` models, and `omp launch -p --model gmi-cloud/anthropic/claude-fable-5` and `--model gmi-cloud/deepseek-ai/DeepSeek-V4-Flash` both completed successfully.

Per the issue triage: canonical provider id `gmi-cloud`, env var `GMI_API_KEY`, OpenAI-compatible API/model-list contract confirmed stable.