### PR TITLE
fix(ai): allow custom OAuth fingerprint header overrides

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom OAuth Anthropic-compatible endpoints with explicit header overrides still receiving generated Claude Code fingerprint headers instead. ([#5888](https://github.com/can1357/oh-my-pi/issues/5888))
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -100,6 +100,8 @@ export type AnthropicHeaderOptions = {
 	isCloudflareAiGateway?: boolean;
 	claudeCodeSessionId?: string;
 	claudeCodeBetas?: readonly string[];
+	/** Allow explicit fingerprint headers to replace OAuth defaults on non-official endpoints. */
+	allowAnthropicHeaderOverrides?: boolean;
 };
 
 export function normalizeAnthropicBaseUrl(baseUrl?: string): string | undefined {
@@ -225,22 +227,36 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 	const acceptHeader = oauthToken ? "application/json" : stream ? "text/event-stream" : "application/json";
 	const isCloudflare = options.isCloudflareAiGateway ?? false;
 	const honorAuthorization = !oauthToken && !isCloudflare;
+	const allowAnthropicHeaderOverrides =
+		oauthToken &&
+		options.allowAnthropicHeaderOverrides === true &&
+		!isCloudflare &&
+		!isOfficialAnthropicApiUrl(options.baseUrl);
 	const honorApiKey = !isCloudflare;
 	const modelHeaders: Record<string, string> = {};
+	const anthropicHeaderOverrides: Record<string, string> = {};
 	const filteredEnforcedKeys: string[] = [];
-	for (const [key, value] of Object.entries(options.modelHeaders ?? {})) {
-		const lowerKey = key.toLowerCase();
-		if (enforcedHeaderKeys.has(lowerKey)) {
-			// user-agent is always re-applied explicitly. authorization / x-api-key
-			// are silently re-applied in honoring branches and dropped + logged
-			// where the branch enforces its own credential.
-			if (lowerKey === "user-agent") continue;
-			if (lowerKey === "authorization" && honorAuthorization) continue;
-			if (lowerKey === "x-api-key" && honorApiKey) continue;
-			filteredEnforcedKeys.push(key);
-			continue;
+	const headerSource = options.modelHeaders;
+	if (headerSource) {
+		for (const key in headerSource) {
+			const value = headerSource[key];
+			const lowerKey = key.toLowerCase();
+			if (enforcedHeaderKeys.has(lowerKey)) {
+				if (allowAnthropicHeaderOverrides && overridableAnthropicHeaderKeys.has(lowerKey)) {
+					anthropicHeaderOverrides[key] = value;
+					continue;
+				}
+				// user-agent is always re-applied explicitly. authorization / x-api-key
+				// are silently re-applied in honoring branches and dropped + logged
+				// where the branch enforces its own credential.
+				if (lowerKey === "user-agent") continue;
+				if (lowerKey === "authorization" && honorAuthorization) continue;
+				if (lowerKey === "x-api-key" && honorApiKey) continue;
+				filteredEnforcedKeys.push(key);
+				continue;
+			}
+			modelHeaders[key] = value;
 		}
-		modelHeaders[key] = value;
 	}
 	if (filteredEnforcedKeys.length > 0) {
 		// Caller/env-supplied values (options.headers, ANTHROPIC_CUSTOM_HEADERS)
@@ -266,7 +282,7 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 		const userAgent = isClaudeCodeClientUserAgent(incomingUserAgent)
 			? incomingUserAgent
 			: `claude-cli/${claudeCodeVersion} (external, local-agent, agent-sdk/${claudeAgentSdkVersion})`;
-		return {
+		const headers = {
 			...modelHeaders,
 			...claudeCodeHeaders,
 			Accept: acceptHeader,
@@ -278,6 +294,7 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 			"User-Agent": userAgent,
 			...(incomingApiKey ? { "X-Api-Key": incomingApiKey } : {}),
 		};
+		return allowAnthropicHeaderOverrides ? mergeHeaders(headers, anthropicHeaderOverrides) : headers;
 	} else if (!isOfficialAnthropicApiUrl(options.baseUrl)) {
 		return {
 			...modelHeaders,
@@ -510,6 +527,10 @@ const enforcedHeaderKeys = new Set(
 		"x-client-request-id",
 		"cf-aig-authorization",
 	].map(key => key.toLowerCase()),
+);
+
+const overridableAnthropicHeaderKeys = new Set(
+	[...Object.keys(claudeCodeHeaders), "anthropic-beta", "User-Agent", "x-app"].map(key => key.toLowerCase()),
 );
 
 const CLAUDE_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:";
@@ -2791,6 +2812,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			dynamicHeaders,
 		),
 		isCloudflareAiGateway: model.provider === "cloudflare-ai-gateway",
+		allowAnthropicHeaderOverrides: model.compat.allowAnthropicHeaderOverrides,
 		claudeCodeSessionId,
 		claudeCodeBetas: oauthToken
 			? buildClaudeCodeBetas(

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -642,6 +642,48 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(headers.Authorization).toBe("Bearer sk-ant-oat-test");
 	});
 
+	it("honors opted-in OAuth fingerprint headers on non-official endpoints (#5888)", () => {
+		const options = buildAnthropicClientOptions({
+			model: buildModel({
+				...ANTHROPIC_MODEL_SPEC,
+				provider: "custom-anthropic",
+				baseUrl: "https://proxy.example.com/anthropic",
+				headers: {
+					"anthropic-beta": "custom-beta-token",
+					"x-app": "custom-app-token",
+					"X-Stainless-Runtime-Version": "custom-runtime-token",
+					Authorization: "should-not-leak",
+				},
+				compat: { allowAnthropicHeaderOverrides: true },
+			}),
+			apiKey: "sk-ant-oat-test",
+			stream: true,
+		});
+
+		expect(options.defaultHeaders["anthropic-beta"]).toBe("custom-beta-token");
+		expect(options.defaultHeaders["x-app"]).toBe("custom-app-token");
+		expect(options.defaultHeaders["X-Stainless-Runtime-Version"]).toBe("custom-runtime-token");
+		expect(options.defaultHeaders.Authorization).toBe("Bearer sk-ant-oat-test");
+	});
+
+	it("keeps OAuth fingerprint defaults on official endpoints despite the compat opt-in", () => {
+		const headers = buildAnthropicHeaders({
+			apiKey: "sk-ant-oat-test",
+			baseUrl: "https://api.anthropic.com",
+			isOAuth: true,
+			allowAnthropicHeaderOverrides: true,
+			modelHeaders: {
+				"anthropic-beta": "custom-beta-token",
+				"x-app": "custom-app-token",
+				"X-Stainless-Runtime-Version": "custom-runtime-token",
+			},
+		});
+
+		expect(headers["anthropic-beta"]).not.toBe("custom-beta-token");
+		expect(headers["x-app"]).toBe("cli");
+		expect(headers["X-Stainless-Runtime-Version"]).toBe("v24.3.0");
+	});
+
 	it("suppresses the client-level X-Api-Key when model.headers carries a custom Authorization (#3391)", () => {
 		const options = buildAnthropicClientOptions({
 			model: buildModel({

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an Anthropic compatibility flag for opting non-official OAuth endpoints into configured Claude Code fingerprint header overrides. ([#5888](https://github.com/can1357/oh-my-pi/issues/5888))
+
 ## [17.0.2] - 2026-07-17
 
 ### Changed

--- a/packages/catalog/src/compat/anthropic.ts
+++ b/packages/catalog/src/compat/anthropic.ts
@@ -109,6 +109,7 @@ export function buildAnthropicCompat(spec: ModelSpec<"anthropic-messages">): Res
 		signingEndpoint,
 		disableStrictTools: isAzure,
 		disableAdaptiveThinking: false,
+		allowAnthropicHeaderOverrides: false,
 		supportsEagerToolInputStreaming: official,
 		// Long cache retention is only sent to the official API by default;
 		// proxies opt in explicitly via `compat.supportsLongCacheRetention: true`.

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -415,6 +415,11 @@ export interface AnthropicCompat {
 	 */
 	requiresToolResultId?: boolean;
 	/**
+	 * Allow configured Claude Code fingerprint headers to replace generated
+	 * OAuth defaults on non-official Anthropic endpoints.
+	 */
+	allowAnthropicHeaderOverrides?: boolean;
+	/**
 	 * Replay unsigned `thinking` blocks from prior assistant turns as native
 	 * thinking instead of demoting them to text. Official Anthropic enforces
 	 * signature-based thinking-chain integrity, so unsigned blocks must stay

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom `anthropic-messages` OAuth providers being unable to opt into configured Claude Code fingerprint header overrides. ([#5888](https://github.com/can1357/oh-my-pi/issues/5888))
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -61,6 +61,7 @@ const OpenAICompatFields = {
 	"supportsImageDetailOriginal?": "boolean",
 	// anthropic-messages compat flags (same `compat` slot, per-api interpretation)
 	"supportsEagerToolInputStreaming?": "boolean",
+	"allowAnthropicHeaderOverrides?": "boolean",
 	"requiresToolResultId?": "boolean",
 	"replayUnsignedThinking?": "boolean",
 } as const;

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -584,6 +584,7 @@ describe("ModelRegistry", () => {
 						api: "anthropic-messages",
 						compat: {
 							supportsEagerToolInputStreaming: true,
+							allowAnthropicHeaderOverrides: true,
 						},
 						models: [
 							{
@@ -685,7 +686,10 @@ describe("ModelRegistry", () => {
 
 		test("custom Anthropic providers can opt into eager tool input streaming", () => {
 			const model = customAnthropicCompat.find("anthropic-proxy", "claude-haiku-4.5");
-			expect(model?.compat).toMatchObject({ supportsEagerToolInputStreaming: true });
+			expect(model?.compat).toMatchObject({
+				supportsEagerToolInputStreaming: true,
+				allowAnthropicHeaderOverrides: true,
+			});
 		});
 
 		test("custom Responses providers can disable original image detail", () => {


### PR DESCRIPTION
## Repro
A focused `bun /tmp/repro-5888.ts` probe called `buildAnthropicHeaders` for an OAuth request to `http://127.0.0.1:4569` with configured `anthropic-beta`, `x-app`, and `X-Stainless-Runtime-Version` values; before the fix it returned the generated Claude Code values and exited 1 on header-identity mismatch.

## Cause
`buildAnthropicHeaders` in `packages/ai/src/providers/anthropic.ts` filtered every key in `enforcedHeaderKeys` before constructing the OAuth branch, then spread `claudeCodeHeaders`, `sharedHeaders`, and the generated beta header after all remaining model headers. The Anthropic compat schema and resolved model compat had no opt-in boundary for non-official OAuth endpoints.

## Fix
- Add `compat.allowAnthropicHeaderOverrides` to catalog compat resolution and `models.yml` validation, defaulting it off.
- On non-official, non-Cloudflare OAuth endpoints only, case-insensitively reapply configured Claude Code fingerprint headers after generated defaults.
- Keep OAuth `Authorization`, API keys, Cloudflare gateway authentication, request/session IDs, and official Anthropic endpoint defaults outside the override set.
- Cover provider-level config propagation, custom-endpoint overrides, credential protection, and official-endpoint protection.

## Verification
`bun test packages/ai/test/anthropic-alignment.test.ts` passed 86 tests; `bun test packages/coding-agent/test/model-registry.test.ts` passed 84 tests; the opted-in `bun /tmp/repro-5888.ts` probe returned all three configured values and exited 0; `bun check` passed across the workspace.

Fixes #5888