### PR TITLE
fix(kimi-code): preserve K3 native effort contract

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Kimi Code K3 requests to send native named efforts (`low`, `high`, `max`) and use adaptive effort rather than generic token budgets on explicit Anthropic transport overrides ([#5893](https://github.com/can1357/oh-my-pi/issues/5893)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
+++ b/packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { getBundledModel } from "@oh-my-pi/pi-catalog";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
 import * as kimiOauth from "../../registry/oauth/kimi";
-import type { Context } from "../../types";
+import type { Context, Model } from "../../types";
 import type { MessageCreateParamsStreaming } from "../anthropic-wire";
-import { streamKimi } from "../kimi";
+import { type KimiApiFormat, streamKimi } from "../kimi";
 import { streamOpenAIAnthropicShim } from "../openai-anthropic-shim";
 import {
 	applyChatCompletionsCompatPolicy,
@@ -38,8 +41,95 @@ const TITLE_CONTEXT: Context = {
 	],
 };
 
+const K3_MODEL = buildModel({
+	id: "k3",
+	name: "K3",
+	api: "openai-completions",
+	provider: "kimi-code",
+	baseUrl: "https://api.kimi.com/coding/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_048_576,
+	maxTokens: 32_000,
+	thinking: {
+		mode: "effort",
+		efforts: [Effort.Low, Effort.High, Effort.Max],
+		defaultLevel: Effort.Max,
+		requiresEffort: true,
+	},
+	compat: {
+		thinkingFormat: "kimi",
+		kimiApiFormat: "openai",
+		reasoningContentField: "reasoning_content",
+		supportsDeveloperRole: false,
+	},
+} satisfies ModelSpec<"openai-completions">);
+
+async function captureKimiPayload(
+	model: Model<"openai-completions">,
+	reasoning: Effort,
+	format?: KimiApiFormat,
+): Promise<unknown> {
+	let payload: unknown;
+	const stream = streamKimi(
+		model,
+		{
+			systemPrompt: [],
+			messages: [{ role: "user", content: "Reply OK", timestamp: 0 }],
+			tools: [],
+		},
+		{
+			...(format ? { format } : {}),
+			apiKey: "test-key",
+			reasoning,
+			onPayload: body => {
+				payload = body;
+				throw new Error("stop after payload capture");
+			},
+		},
+	);
+	await stream.result();
+	if (payload === undefined) throw new Error("Kimi request payload was not captured");
+	return payload;
+}
+
 afterEach(() => {
 	vi.restoreAllMocks();
+});
+
+describe("Kimi K3 thinking transport", () => {
+	it("sends every live named effort through Kimi's native thinking object by default", async () => {
+		vi.spyOn(kimiOauth, "getKimiCommonHeaders").mockReturnValue(KIMI_HEADERS);
+
+		for (const effort of [Effort.Low, Effort.High, Effort.Max]) {
+			const payload = await captureKimiPayload(K3_MODEL, effort);
+			expect(payload).toMatchObject({ thinking: { type: "enabled", effort } });
+			expect(payload).not.toHaveProperty("reasoning_effort");
+		}
+	});
+
+	it("uses adaptive named effort rather than a token budget for an explicit Anthropic override", async () => {
+		vi.spyOn(kimiOauth, "getKimiCommonHeaders").mockReturnValue(KIMI_HEADERS);
+
+		const payload = await captureKimiPayload(K3_MODEL, Effort.Max, "anthropic");
+
+		expect(payload).toMatchObject({
+			thinking: { type: "adaptive" },
+			output_config: { effort: Effort.Max },
+		});
+		expect(payload).not.toHaveProperty("thinking.budget_tokens");
+	});
+
+	it("keeps the legacy K2 default on the Anthropic transport", async () => {
+		vi.spyOn(kimiOauth, "getKimiCommonHeaders").mockReturnValue(KIMI_HEADERS);
+		const model = getBundledModel<"openai-completions">("kimi-code", "kimi-for-coding");
+
+		const payload = await captureKimiPayload(model, Effort.High);
+
+		expect(payload).toMatchObject({ thinking: { type: "enabled" } });
+		expect(payload).toHaveProperty("thinking.budget_tokens");
+	});
 });
 
 describe("Kimi K2.7 Code thinking policy", () => {

--- a/packages/ai/src/providers/kimi.ts
+++ b/packages/ai/src/providers/kimi.ts
@@ -5,8 +5,8 @@
  * - OpenAI: https://api.kimi.com/coding/v1/chat/completions
  * - Anthropic: https://api.kimi.com/coding/v1/messages
  *
- * The Anthropic API is generally more stable and recommended.
- * Note: Kimi calculates TPM rate limits based on max_tokens, not actual output.
+ * Each discovered model selects its server-declared protocol; legacy models
+ * without protocol metadata retain the Anthropic-compatible default.
  */
 
 import { getKimiCommonHeaders } from "../registry/oauth/kimi";
@@ -21,7 +21,7 @@ import {
 export type KimiApiFormat = OpenAIAnthropicApiFormat;
 
 export interface KimiOptions extends OpenAIAnthropicShimOptions {
-	/** API format: "openai" or "anthropic". Default: "anthropic" */
+	/** Explicit API format override. Defaults to the model's discovered protocol. */
 	format?: KimiApiFormat;
 }
 
@@ -36,7 +36,8 @@ export function streamKimi(
 ): AssistantMessageEventStream {
 	return streamOpenAIAnthropicShim(model, context, options, {
 		anthropicBaseUrl: model.baseUrl.replace(/\/v1\/?$/, ""),
-		defaultFormat: "anthropic",
+		defaultFormat: model.compat.kimiApiFormat ?? "anthropic",
+		anthropicThinkingMode: model.compat.thinkingFormat === "kimi" ? "anthropic-adaptive" : undefined,
 		extraHeaders: getKimiCommonHeaders,
 	});
 }

--- a/packages/ai/src/providers/openai-anthropic-shim.ts
+++ b/packages/ai/src/providers/openai-anthropic-shim.ts
@@ -10,7 +10,7 @@
 
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { ANTHROPIC_THINKING, mapAnthropicToolChoice } from "../stream";
-import type { Context, Model, ModelSpec, SimpleStreamOptions } from "../types";
+import type { Context, Model, ModelSpec, SimpleStreamOptions, ThinkingControlMode } from "../types";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { createProviderErrorMessage } from "./error-message";
 import { streamAnthropic, streamOpenAICompletions } from "./register-builtins";
@@ -29,6 +29,8 @@ export interface OpenAIAnthropicShimConfig {
 	openaiBaseUrl?: string;
 	/** Default API format when caller does not specify one. */
 	defaultFormat: OpenAIAnthropicApiFormat;
+	/** Thinking transport used when this provider's Anthropic endpoint differs from generic budget semantics. */
+	anthropicThinkingMode?: ThinkingControlMode;
 	/** Provider-specific headers (e.g. auth/session) merged ahead of user-supplied headers. */
 	extraHeaders?: () => Record<string, string>;
 }
@@ -67,6 +69,9 @@ export function streamOpenAIAnthropicShim(
 					contextWindow: model.contextWindow,
 					maxTokens: model.maxTokens,
 					reasoning: model.reasoning,
+					...(config.anthropicThinkingMode && model.thinking
+						? { thinking: { ...model.thinking, mode: config.anthropicThinkingMode } }
+						: {}),
 					input: model.input,
 					cost: model.cost,
 				} as ModelSpec<"anthropic-messages">);
@@ -95,6 +100,7 @@ export function streamOpenAIAnthropicShim(
 					fetch: options?.fetch,
 					thinkingEnabled,
 					thinkingBudgetTokens: thinkingBudget,
+					reasoning: config.anthropicThinkingMode ? reasoningEffort : undefined,
 					toolChoice: mapAnthropicToolChoice(options?.toolChoice),
 					serviceTier: options?.serviceTier,
 				});

--- a/packages/ai/src/providers/openai-shared.ts
+++ b/packages/ai/src/providers/openai-shared.ts
@@ -654,7 +654,7 @@ export type OpenAICompletionsParams = Omit<ChatCompletionCreateParamsStreaming, 
 	top_k?: number;
 	min_p?: number;
 	repetition_penalty?: number;
-	thinking?: { type: "enabled" | "disabled"; keep?: "all" };
+	thinking?: { type: "enabled" | "disabled"; effort?: string; keep?: "all" };
 	enable_thinking?: boolean;
 	preserve_thinking?: boolean;
 	chat_template_kwargs?: { enable_thinking?: boolean; preserve_thinking?: boolean };
@@ -943,6 +943,11 @@ export function applyChatCompletionsCompatPolicy(params: OpenAICompletionsParams
 				if (reasoning.wireEffort === "none") {
 					encodeChatCompletionsDisabledReasoning(params, reasoning.disableMode);
 					return;
+				}
+				if (reasoning.dialect === "kimi" && reasoning.wireEffort !== undefined) {
+					params.thinking = { type: "enabled", effort: reasoning.wireEffort };
+					if (policy.compat.thinkingKeep) params.thinking.keep = policy.compat.thinkingKeep;
+					break;
 				}
 				params.thinking = { type: "enabled" };
 				if (policy.compat.thinkingKeep) params.thinking.keep = policy.compat.thinkingKeep;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1183,7 +1183,7 @@ export function streamSimple<TApi extends Api>(
 			streamKimi(model as Model<"openai-completions">, context, {
 				...requestOptions,
 				apiKey,
-				format: requestOptions?.kimiApiFormat ?? "anthropic",
+				format: requestOptions?.kimiApiFormat,
 			}),
 		);
 	}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -539,7 +539,7 @@ export interface SimpleStreamOptions extends Omit<StreamOptions, "apiKey"> {
 	toolChoice?: ToolChoice;
 	/** OpenAI service tier for processing priority/cost control. Ignored by non-OpenAI providers. */
 	serviceTier?: ServiceTier;
-	/** API format for Kimi Code provider: "openai" or "anthropic" (default: "anthropic") */
+	/** Explicit Kimi Code API format override; omitted uses live per-model protocol metadata. */
 	kimiApiFormat?: "openai" | "anthropic";
 	/** API format for Synthetic provider: "openai" or "anthropic" (default: "openai") */
 	syntheticApiFormat?: "openai" | "anthropic";

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed authenticated Kimi Code discovery to preserve live effort levels, default effort, mandatory-thinking state, and per-model protocol metadata ([#5893](https://github.com/can1357/oh-my-pi/issues/5893)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Changed

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -86,6 +86,7 @@ function resolveReasoningDisableMode(
 		case "openrouter":
 			return "openrouter-enabled-false";
 		case "zai":
+		case "kimi":
 			return "zai-thinking-disabled";
 		case "qwen":
 			return "qwen-enable-thinking-false";
@@ -460,6 +461,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// is rejected by NIM's `additionalProperties: false` request schema
 		// (issue #2299).
 		thinkingFormat,
+		kimiApiFormat: undefined,
 		reasoningDisableMode: resolveReasoningDisableMode(thinkingFormat),
 		omitReasoningEffort: false,
 		includeEncryptedReasoning: true,

--- a/packages/catalog/src/model-cache.ts
+++ b/packages/catalog/src/model-cache.ts
@@ -7,7 +7,8 @@ import { getModelDbPath } from "@oh-my-pi/pi-utils";
 import type { Api, Model, ModelSpec } from "./types";
 
 // Rows persist ModelSpec JSON (sparse `compat`, never the resolved record);
-// the model manager rebuilds via `buildModel` on load. v8 invalidates Codex
+// the model manager rebuilds via `buildModel` on load. v9 invalidates Kimi
+// Code rows predating live effort and protocol metadata; v8 invalidated Codex
 // discovery rows predating provider-native V2 compaction metadata; v7
 // invalidated rows predating the Antigravity Gemini budget-mode migration
 // (cached specs still carrying `thinking.mode: "google-level"` and the old
@@ -15,7 +16,7 @@ import type { Api, Model, ModelSpec } from "./types";
 // unknown-limit sentinels (222222/8888); v5 invalidated rows predating
 // effort-tier variant collapsing (raw `-low`/`-high`/`-thinking` member ids);
 // v4 dropped the pre-efforts ThinkingConfig shape.
-const CACHE_SCHEMA_VERSION = 8;
+const CACHE_SCHEMA_VERSION = 9;
 
 interface CacheRow {
 	provider_id: string;

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -3,7 +3,7 @@ import {
 	type OpenAICompatibleModelMapperContext,
 	type OpenAICompatibleModelRecord,
 } from "../discovery/openai-compatible";
-import { Effort } from "../effort";
+import { Effort, THINKING_EFFORTS } from "../effort";
 import { FIREWORKS_FAST_SUFFIX, toFireworksPublicModelId } from "../fireworks-model-id";
 import {
 	isGlmVisionModelId,
@@ -2504,6 +2504,45 @@ export interface KimiCodeModelManagerConfig {
 	fetch?: FetchImpl;
 }
 
+function mapKimiThinking(entry: OpenAICompatibleModelRecord): ThinkingConfig | undefined {
+	const raw = entry.think_efforts;
+	if (!isRecord(raw) || raw.support !== true) return undefined;
+	const validEfforts = raw.valid_efforts;
+	if (!Array.isArray(validEfforts)) return undefined;
+	const efforts = THINKING_EFFORTS.filter(effort => validEfforts.includes(effort));
+	if (efforts.length === 0) return undefined;
+
+	const thinking: ThinkingConfig = { mode: "effort", efforts };
+	if (entry.supports_thinking_type === "only") {
+		thinking.requiresEffort = true;
+	}
+	if (typeof raw.default_effort === "string") {
+		const defaultLevel = THINKING_EFFORTS.find(effort => effort === raw.default_effort);
+		if (defaultLevel !== undefined && efforts.includes(defaultLevel)) {
+			thinking.defaultLevel = defaultLevel;
+		}
+	}
+	return thinking;
+}
+
+function kimiSupportsReasoning(entry: OpenAICompatibleModelRecord, modelId: string): boolean {
+	switch (entry.supports_thinking_type) {
+		case "only":
+		case "both":
+			return true;
+		case "no":
+			return false;
+		default:
+			return entry.supports_reasoning === true || modelId.includes("thinking");
+	}
+}
+
+function mapKimiApiFormat(protocol: unknown): OpenAICompat["kimiApiFormat"] {
+	if (protocol === "anthropic") return "anthropic";
+	if (protocol === null) return "openai";
+	return undefined;
+}
+
 export function kimiCodeModelManagerOptions(
 	config?: KimiCodeModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
@@ -2528,15 +2567,19 @@ export function kimiCodeModelManagerOptions(
 						_context: OpenAICompatibleModelMapperContext<"openai-completions">,
 					): ModelSpec<"openai-completions"> => {
 						const id = defaults.id;
+						const reasoning = kimiSupportsReasoning(entry, id);
+						const thinking = reasoning ? mapKimiThinking(entry) : undefined;
 						return {
 							...defaults,
 							name: typeof entry.display_name === "string" ? entry.display_name : defaults.name,
-							reasoning: entry.supports_reasoning === true || id.includes("thinking"),
+							reasoning,
 							input: entry.supports_image_in === true || id.includes("k2.5") ? ["text", "image"] : ["text"],
 							contextWindow: typeof entry.context_length === "number" ? entry.context_length : 262144,
 							maxTokens: 32000,
+							thinking,
 							compat: {
-								thinkingFormat: "zai",
+								thinkingFormat: thinking ? "kimi" : "zai",
+								kimiApiFormat: mapKimiApiFormat(entry.protocol),
 								reasoningContentField: "reasoning_content",
 								supportsDeveloperRole: false,
 							},

--- a/packages/catalog/src/types.ts
+++ b/packages/catalog/src/types.ts
@@ -148,7 +148,7 @@ export interface Usage {
 	};
 }
 
-export type OpenAIReasoningFormat = "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template";
+export type OpenAIReasoningFormat = "openai" | "openrouter" | "zai" | "kimi" | "qwen" | "qwen-chat-template";
 
 export type OpenAIReasoningDisableMode =
 	| "omit"
@@ -205,8 +205,10 @@ export interface OpenAICompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether tool call IDs must be normalized to Mistral format (exactly 9 alphanumeric chars). Default: auto-detected from URL. */
 	requiresMistralToolIds?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses thinking: { type: "enabled" | "disabled" } (also used by Moonshot Kimi), "qwen" uses top-level enable_thinking, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
+	/** Format for reasoning/thinking parameter. `"kimi"` uses `thinking: { type, effort }`; other values select their provider-native reasoning fields. Default: `"openai"`. */
 	thinkingFormat?: OpenAIReasoningFormat;
+	/** Kimi Code transport selected by live per-model protocol metadata. User settings take precedence. */
+	kimiApiFormat?: "openai" | "anthropic";
 	/** Request-time disable encoding for the selected reasoning/thinking format. Default: derived from `thinkingFormat`. */
 	reasoningDisableMode?: OpenAIReasoningDisableMode;
 	/** Whether the provider rejects `reasoning.effort`/`reasoning_effort` even when the model reasons natively. Default: false unless reasoning effort is unsupported. */
@@ -475,6 +477,8 @@ export interface ResolvedOpenAISharedCompat {
 	supportsReasoningParams: boolean;
 	supportsSamplingParams: boolean;
 	thinkingFormat: OpenAIReasoningFormat;
+	/** Kimi Code transport selected by live per-model protocol metadata. */
+	kimiApiFormat?: OpenAICompat["kimiApiFormat"];
 	reasoningDisableMode: OpenAIReasoningDisableMode;
 	omitReasoningEffort: boolean;
 	includeEncryptedReasoning: boolean;
@@ -528,6 +532,7 @@ export type ResolvedOpenAICompat = ResolvedOpenAISharedCompat &
 			| "supportsReasoningParams"
 			| "supportsSamplingParams"
 			| "thinkingFormat"
+			| "kimiApiFormat"
 			| "reasoningDisableMode"
 			| "omitReasoningEffort"
 			| "includeEncryptedReasoning"

--- a/packages/catalog/test/kimi-code-provider.test.ts
+++ b/packages/catalog/test/kimi-code-provider.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import { Effort } from "@oh-my-pi/pi-catalog/effort";
+import { kimiCodeModelManagerOptions } from "@oh-my-pi/pi-catalog/provider-models/openai-compat";
+import type { FetchImpl } from "@oh-my-pi/pi-catalog/types";
+
+const LIVE_K3 = {
+	id: "k3",
+	display_name: "K3",
+	context_length: 1_048_576,
+	supports_reasoning: true,
+	supports_thinking_type: "only",
+	think_efforts: {
+		support: true,
+		valid_efforts: ["low", "high", "max"],
+		default_effort: "max",
+	},
+	protocol: null,
+};
+
+async function discover(models: readonly Record<string, unknown>[]) {
+	const fetchImpl: FetchImpl = async () => Response.json({ data: models });
+	const fetchDynamicModels = kimiCodeModelManagerOptions({ apiKey: "test-key", fetch: fetchImpl }).fetchDynamicModels;
+	if (!fetchDynamicModels) throw new Error("Kimi Code dynamic discovery is not configured");
+	return (await fetchDynamicModels())?.map(buildModel) ?? [];
+}
+
+describe("Kimi Code provider catalog", () => {
+	it("uses live K3 effort, mandatory-thinking, and native-protocol metadata", async () => {
+		const models = await discover([LIVE_K3]);
+		const model = models.find(candidate => candidate.id === "k3");
+
+		expect(model).toMatchObject({
+			id: "k3",
+			name: "K3",
+			reasoning: true,
+			contextWindow: 1_048_576,
+			thinking: {
+				mode: "effort",
+				efforts: [Effort.Low, Effort.High, Effort.Max],
+				defaultLevel: Effort.Max,
+				requiresEffort: true,
+			},
+			compat: {
+				thinkingFormat: "kimi",
+				kimiApiFormat: "openai",
+			},
+		});
+	});
+
+	it("uses server protocol while preserving legacy K2 discovery defaults", async () => {
+		const models = await discover([
+			{ ...LIVE_K3, id: "k3-anthropic", protocol: "anthropic" },
+			{
+				id: "kimi-for-coding",
+				display_name: "K2.7 Code",
+				context_length: 262_144,
+				supports_reasoning: true,
+			},
+		]);
+		const anthropic = models.find(candidate => candidate.id === "k3-anthropic");
+		const legacy = models.find(candidate => candidate.id === "kimi-for-coding");
+
+		expect(anthropic?.compat.kimiApiFormat).toBe("anthropic");
+		expect(legacy?.compat).toMatchObject({ thinkingFormat: "zai" });
+		expect(legacy?.compat.kimiApiFormat).toBeUndefined();
+		expect(legacy?.thinking?.efforts).toEqual([Effort.Minimal, Effort.Low, Effort.Medium, Effort.High]);
+	});
+
+	it("lets supports_thinking_type override the legacy reasoning flag", async () => {
+		const models = await discover([
+			{ ...LIVE_K3, id: "non-thinking", supports_thinking_type: "no", think_efforts: undefined },
+		]);
+
+		expect(models[0]?.reasoning).toBe(false);
+		expect(models[0]?.thinking).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Kimi Code transport selection to follow live per-model protocol metadata by default while preserving explicit OpenAI and Anthropic overrides ([#5893](https://github.com/can1357/oh-my-pi/issues/5893)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -4748,14 +4748,15 @@ export const SETTINGS_SCHEMA = {
 
 	"providers.kimiApiFormat": {
 		type: "enum",
-		values: ["openai", "anthropic"] as const,
-		default: "anthropic",
+		values: ["auto", "openai", "anthropic"] as const,
+		default: "auto",
 		ui: {
 			tab: "providers",
 			group: "Protocol",
 			label: "Kimi API Format",
-			description: "API format for Kimi Code provider",
+			description: "API format for Kimi Code provider (auto follows live model metadata)",
 			options: [
+				{ value: "auto", label: "Auto", description: "Use the model's server-declared protocol" },
 				{ value: "openai", label: "OpenAI", description: "api.kimi.com" },
 				{ value: "anthropic", label: "Anthropic", description: "api.moonshot.ai" },
 			],

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -2712,6 +2712,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 			return result;
 		};
+		const kimiApiFormatSetting = settings.get("providers.kimiApiFormat");
+		const kimiApiFormat = kimiApiFormatSetting === "auto" ? undefined : kimiApiFormatSetting;
 		agent = new Agent({
 			initialState: {
 				systemPrompt,
@@ -2745,7 +2747,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			presencePenalty: settings.get("presencePenalty") >= 0 ? settings.get("presencePenalty") : undefined,
 			repetitionPenalty: settings.get("repetitionPenalty") >= 0 ? settings.get("repetitionPenalty") : undefined,
 			hideThinkingSummary: settings.get("omitThinking"),
-			kimiApiFormat: settings.get("providers.kimiApiFormat") ?? "anthropic",
+			kimiApiFormat,
 			preferWebsockets: preferOpenAICodexWebsockets,
 			getToolContext: tc => toolContextStore.getContext(tc),
 			getApiKey: requestModel => modelRegistry.resolver(requestModel, agent.sessionId),
@@ -3078,7 +3080,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					serviceTierResolver: agent.serviceTierResolver,
 					hideThinkingSummary: agent.hideThinkingSummary,
 					maxRetryDelayMs: agent.maxRetryDelayMs,
-					kimiApiFormat: settings.get("providers.kimiApiFormat") ?? "anthropic",
+					kimiApiFormat,
 					preferWebsockets: preferOpenAICodexWebsockets,
 					getToolContext: toolCall => toolContextStore.getContext(toolCall),
 					streamFn: settingsAwareStreamFn,


### PR DESCRIPTION
## Repro
With an authenticated Kimi Code account whose `GET /models` K3 entry reports nested `think_efforts.valid_efforts: ["low", "high", "max"]`, `default_effort: "max"`, `supports_thinking_type: "only"`, and `protocol: null`, run `omp models kimi-code --json | jq '.models[] | select(.id == "k3")'`; before this change the model resolved to `minimal/low/medium/high` and the default request path used Anthropic token-budget thinking instead of Kimi’s native named effort body.

## Cause
`kimiCodeModelManagerOptions` in `packages/catalog/src/provider-models/openai-compat.ts` discarded `think_efforts`, `supports_thinking_type`, and `protocol`, then stamped every discovered model with the K2-era `zai` dialect. `streamSimple` and `streamKimi` independently defaulted Kimi Code to Anthropic format, while `streamOpenAIAnthropicShim` treated explicit Anthropic requests as generic budget-based thinking.

## Fix
- Parse Kimi’s live effort ladder, default effort, mandatory-thinking state, and per-model protocol into catalog metadata; invalidate stale cached model rows.
- Add the Kimi named-effort dialect so native requests serialize `thinking: { type: "enabled", effort }` for `low`, `high`, and `max`.
- Make the default transport follow live model protocol metadata, retaining explicit OpenAI/Anthropic settings and legacy K2 behavior.
- Encode explicit K3 Anthropic overrides as adaptive thinking plus `output_config.effort`, not an invented token budget.
- Cover live-shaped discovery and actual outbound native/Anthropic bodies with regression tests.

## Verification
`bun test packages/catalog/test/kimi-code-provider.test.ts packages/ai/src/providers/__tests__/kimi-code-thinking.test.ts` passes (12 tests, 32 assertions). `bun check` passes across all workspace packages. The original live-shaped discovery repro now resolves `low/high/max`, default `max`, and `requiresEffort: true`. Fixes #5893