### PR TITLE
fix(session): deliver xdev mount notice as passive context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a mid-session `xd://` tool mount/unmount triggering an unsolicited second assistant response: the hidden mount notice is now delivered as passive context (folded into the next real turn, or appended to the transcript when idle) instead of a turn-forcing steer ([#5892](https://github.com/can1357/oh-my-pi/issues/5892)).
+
 ## [17.0.2] - 2026-07-17
 
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -518,8 +518,8 @@ const PREWALK_CONTINUE_MESSAGE_TYPE = "prewalk-continue";
  *  multi-site fixes, unnecessarily broad rewrites, and reported-test-only
  *  verification. */
 const PREWALK_CHECKLIST_MESSAGE_TYPE = "prewalk-checklist";
-/** Hidden steered notice announcing a mid-session `xd://` mount/unmount delta
- *  (see {@link AgentSession.#notifyXdevMountDelta}). */
+/** Hidden notice announcing a mid-session `xd://` mount/unmount delta, delivered
+ *  as passive context (see {@link AgentSession.#notifyXdevMountDelta}). */
 const XDEV_MOUNT_NOTICE_MESSAGE_TYPE = "xdev-mount-notice";
 /** Tools whose first successful call triggers the switch — once the todo
  *  gate is open (see {@link AgentSession.#prewalkTodoSeen}). Bash is
@@ -7307,12 +7307,21 @@ export class AgentSession {
 	}
 
 	/**
-	 * Announce a mid-session `xd://` mount delta to the model as a steered
-	 * system notice instead of rewriting the system prompt: the prompt (and
-	 * its provider cache prefix) stays byte-stable across MCP connects and
+	 * Announce a mid-session `xd://` mount delta to the model as passive
+	 * context instead of rewriting the system prompt: the prompt (and its
+	 * provider cache prefix) stays byte-stable across MCP connects and
 	 * disconnects, and the model learns about new devices from the notice
 	 * (docs + schema stay one `read xd://<tool>` away). The full docs join
 	 * the system prompt opportunistically on the next unrelated rebuild.
+	 *
+	 * The notice is tool-state, not a prompt: it MUST never force an
+	 * unsolicited assistant turn. A mid-turn mount folds the notice into the
+	 * next real turn via `#pendingNextTurnMessages` (a steer here would be
+	 * treated as pending work by the loop's stop-boundary poll and start a
+	 * second, unsolicited provider request — issue #5892). An idle mount lands
+	 * it directly in the transcript so it is context for whatever turn runs
+	 * next, without leaving a stale steer that could wake a spurious turn
+	 * (issues #5800, #5737).
 	 */
 	#notifyXdevMountDelta(previousMounted: ReadonlySet<string>): void {
 		const registry = this.#xdevRegistry;
@@ -7323,14 +7332,28 @@ export class AgentSession {
 		if (addedNames.length === 0 && removed.length === 0) return;
 		const summaries = new Map(registry.entries().map(entry => [entry.name, entry.summary]));
 		const added = addedNames.map(name => ({ name, summary: summaries.get(name) ?? "" }));
-		this.agent.steer({
+		const notice: CustomMessage = {
 			role: "custom",
 			customType: XDEV_MOUNT_NOTICE_MESSAGE_TYPE,
 			content: prompt.render(xdevMountNoticePrompt, { added, removed }),
 			attribution: "agent",
 			display: false,
 			timestamp: Date.now(),
-		});
+		};
+		if (this.isStreaming) {
+			// Fold into the next real turn as passive context; never force a turn.
+			this.#queueHiddenNextTurnMessage(notice, false);
+		} else {
+			// Idle: land it in the transcript so it is context for the next turn.
+			this.agent.appendMessage(notice);
+			this.sessionManager.appendCustomMessageEntry(
+				notice.customType,
+				notice.content,
+				notice.display,
+				notice.details,
+				notice.attribution,
+			);
+		}
 		if (this.settings.get("startup.quiet")) return;
 		const parts: string[] = [];
 		if (added.length > 0) parts.push(`mounted ${added.map(entry => entry.name).join(", ")}`);

--- a/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
+++ b/packages/coding-agent/test/agent-session-tool-rebuild-skip.test.ts
@@ -514,7 +514,7 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		expect(rebuildCount).toBe(2);
 	});
 
-	it("announces xd:// mount deltas as steered notices instead of rebuilding the prompt", async () => {
+	it("announces idle xd:// mount deltas as passive transcript context instead of rebuilding the prompt", async () => {
 		let rebuildCount = 0;
 		const { session } = newSession(
 			async toolNames => {
@@ -525,14 +525,19 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		);
 		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
 		const fetch = createMcpCustomTool("mcp__nucleus_fetch", "nucleus", "fetch", "Fetch nucleus");
+		// An idle mount is tool-state, not a prompt: it lands directly in the
+		// transcript as passive context and NEVER onto the turn-forcing steering
+		// queue (issue #5892).
 		const noticeTexts = () =>
+			session.agent.state.messages.flatMap(msg =>
+				msg.role === "custom" && msg.customType === "xdev-mount-notice" && typeof msg.content === "string"
+					? [msg.content]
+					: [],
+			);
+		const steeredNotices = () =>
 			session.agent
 				.peekSteeringQueue()
-				.flatMap(msg =>
-					msg.role === "custom" && msg.customType === "xdev-mount-notice" && typeof msg.content === "string"
-						? [msg.content]
-						: [],
-				);
+				.filter(msg => msg.role === "custom" && msg.customType === "xdev-mount-notice");
 
 		// First refresh: initial signature record → one rebuild; the MCP tool is
 		// discoverable, so it mounts as a device and is announced.
@@ -561,6 +566,9 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 		await session.refreshMCPTools([search]);
 		expect(rebuildCount).toBe(1);
 		expect(noticeTexts().length).toBe(noticeCount);
+
+		// No mount ever queued a turn-forcing steer.
+		expect(steeredNotices()).toEqual([]);
 	});
 
 	it("keeps xd:// mount deltas model-visible without rendering them during quiet startup", async () => {
@@ -578,9 +586,9 @@ describe("AgentSession refreshMCPTools rebuild skipping", () => {
 
 		expect(notices).toEqual([]);
 		expect(
-			session.agent
-				.peekSteeringQueue()
-				.some(message => message.role === "custom" && message.customType === "xdev-mount-notice"),
+			session.agent.state.messages.some(
+				message => message.role === "custom" && message.customType === "xdev-mount-notice",
+			),
 		).toBe(true);
 	});
 

--- a/packages/coding-agent/test/agent-session-xdev-mount-notice.test.ts
+++ b/packages/coding-agent/test/agent-session-xdev-mount-notice.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression (issue #5892): a mid-session `xd://` mount delta is tool-state,
+ * not a prompt. It must reach the model as passive context and NEVER force an
+ * unsolicited assistant turn. Before the fix, `#notifyXdevMountDelta` steered
+ * the hidden `xdev-mount-notice` onto the turn-forcing steering queue; a mount
+ * that happened while the assistant was still replying was then picked up by
+ * the agent loop's stop-boundary steering poll and started a second, unsolicited
+ * provider request.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { XdevRegistry } from "@oh-my-pi/pi-coding-agent/tools/xdev";
+import { Snowflake, TempDir } from "@oh-my-pi/pi-utils";
+import { type } from "arktype";
+
+function createBasicTool(name: string, label: string): AgentTool {
+	return {
+		name,
+		label,
+		description: `${label} tool`,
+		parameters: type({ value: "string" }),
+		strict: true,
+		async execute() {
+			return { content: [{ type: "text", text: `${name} executed` }] };
+		},
+	};
+}
+
+function createMcpCustomTool(name: string, serverName: string, mcpToolName: string, description: string): CustomTool {
+	return {
+		name,
+		label: `${serverName}/${mcpToolName}`,
+		description,
+		parameters: type({ q: "string" }),
+		strict: true,
+		mcpServerName: serverName,
+		mcpToolName,
+		async execute() {
+			return { content: [{ type: "text", text: `${name} executed` }] };
+		},
+	} as CustomTool;
+}
+
+describe("xdev mount notice must not trigger a second turn (#5892)", () => {
+	const sessions: AgentSession[] = [];
+	const authStorages: AuthStorage[] = [];
+	let tempDir: TempDir;
+	afterEach(async () => {
+		for (const session of sessions.splice(0)) await session.dispose();
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+		await tempDir?.remove();
+	});
+
+	it("does not start an unsolicited turn when an xd:// device mounts mid-reply", async () => {
+		tempDir = TempDir.createSync("@pi-xdev-5892-");
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		// The first turn parks open (via an async generator that awaits `mountDone`)
+		// so the mid-turn mount is sequenced while the assistant is genuinely
+		// streaming — no wall-clock timing.
+		const streamStarted = Promise.withResolvers<void>();
+		const mountDone = Promise.withResolvers<void>();
+		const mock = createMockModel({
+			responses: (async function* () {
+				streamStarted.resolve();
+				await mountDone.promise;
+				yield { content: ["first reply"], stopReason: "stop" };
+				yield { content: ["second unsolicited reply"], stopReason: "stop" };
+			})(),
+		});
+		const readTool = createBasicTool("read", "Read");
+		const writeTool = createBasicTool("write", "Write");
+		const toolRegistry = new Map<string, AgentTool>([
+			[readTool.name, readTool],
+			[writeTool.name, writeTool],
+		]);
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: { model, systemPrompt: ["initial"], tools: [readTool, writeTool] },
+			streamFn: mock.stream,
+		});
+		const authStorage = await AuthStorage.create(tempDir.join(`auth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, tempDir.join("models.yml"));
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry,
+			toolRegistry,
+			builtInToolNames: ["read", "write"],
+			ensureWriteRegistered: async () => true,
+			rebuildSystemPrompt: async toolNames => ({ systemPrompt: [`tools:${toolNames.join(",")}`] }),
+			xdevRegistry: new XdevRegistry([]),
+		});
+		sessions.push(session);
+
+		// A normal user turn begins streaming.
+		const running = session.prompt("hey");
+		await streamStarted.promise;
+
+		// Mid-reply: an MCP tool becomes available and mounts as an xd:// device.
+		const search = createMcpCustomTool("mcp__nucleus_search", "nucleus", "search", "Search nucleus");
+		await session.refreshMCPTools([search]);
+		// The mount is folded into the next real turn as passive context, never
+		// onto the turn-forcing steering queue.
+		expect(
+			session.agent.peekSteeringQueue().some(msg => msg.role === "custom" && msg.customType === "xdev-mount-notice"),
+		).toBe(false);
+
+		mountDone.resolve();
+		await running;
+		await session.waitForIdle();
+
+		// Exactly one provider request — the hidden notice did not spawn a second.
+		expect(mock.calls.length).toBe(1);
+	});
+});


### PR DESCRIPTION
## Repro

A normal user prompt begins streaming. Mid-reply, an `xd://` device mounts (e.g. an MCP server connects, calling `AgentSession.refreshMCPTools`). The session then produces a second, unsolicited assistant response even though the user sent only one message. Deterministic repro in `packages/coding-agent/test/agent-session-xdev-mount-notice.test.ts`: after one user turn the mock provider is called a second time (`mock.calls == 2`) purely from the hidden mount notice.

Command: `bun test test/agent-session-xdev-mount-notice.test.ts`

## Cause

`AgentSession.#notifyXdevMountDelta()` (`packages/coding-agent/src/session/agent-session.ts`) announced the mount delta by calling `this.agent.steer({ customType: "xdev-mount-notice", ... })`. That places the hidden notice on the **turn-forcing steering queue** — the same channel live user input uses. When the mount lands mid-turn, the agent loop's stop-boundary late-steering poll (`packages/agent/src/agent-loop.ts:1173`) sees a queued steer and runs another provider request. The notice is tool-state, not a prompt, so it should never force a turn (same hidden-steer class as #5800 / #5737).

## Fix

- `#notifyXdevMountDelta` no longer steers. While streaming it folds the notice into the next real turn via `#queueHiddenNextTurnMessage(notice, /*triggerTurn*/ false)` (passive context, injected alongside the next user message); while idle it appends the notice directly to the transcript and persists it, so it is context for whatever turn runs next without leaving a stale steer.
- Updated the two existing idle-mount tests in `agent-session-tool-rebuild-skip.test.ts` to read the notice from the transcript (not the steering queue) and assert no turn-forcing steer is ever queued.
- Added `agent-session-xdev-mount-notice.test.ts`: a deterministic mid-reply mount regression proving exactly one provider call.
- Refreshed the stale "steered notice" doc comment and added a changelog entry.

## Verification

`bun test test/agent-session-xdev-mount-notice.test.ts test/agent-session-tool-rebuild-skip.test.ts` → 19 pass. Broader run with `agent-session-checkpoint-rewind-branch.test.ts` and `agent-session-advisor-suppression.test.ts` → 43 pass. `bun run check:types` clean. Fixes #5892