### PR TITLE
fix(ai): preserve Kimi usage reset timestamps

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved Kimi rate-limit reset timestamps in duration-based usage windows so `omp usage` reports can render reset countdowns. ([#5899](https://github.com/can1357/oh-my-pi/issues/5899))
+
 ## [17.0.2] - 2026-07-17
 
 ### Fixed

--- a/packages/ai/src/usage/kimi.ts
+++ b/packages/ai/src/usage/kimi.ts
@@ -144,15 +144,17 @@ function buildUsageStatus(amount: UsageAmount): UsageStatus {
 }
 
 function toUsageLimit(row: KimiUsageRow, provider: string, index: number, accountId?: string): UsageLimit {
-	const window: UsageWindow | undefined =
-		row.window ??
-		(row.resetsAt
+	const window: UsageWindow | undefined = row.window
+		? row.window.resetsAt === undefined && row.resetsAt !== undefined
+			? { ...row.window, resetsAt: row.resetsAt }
+			: row.window
+		: row.resetsAt
 			? {
 					id: "default",
 					label: "Usage window",
 					resetsAt: row.resetsAt,
 				}
-			: undefined);
+			: undefined;
 
 	const amount = buildUsageAmount(row);
 	return {

--- a/packages/ai/test/kimi-usage.test.ts
+++ b/packages/ai/test/kimi-usage.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as kimiOauth from "../src/registry/oauth/kimi";
+import type { UsageFetchContext } from "../src/usage";
+import { kimiUsageProvider } from "../src/usage/kimi";
+
+const KIMI_HEADERS = Object.freeze({
+	"User-Agent": "KimiCLI/0.0.0",
+	"X-Msh-Platform": "kimi_cli",
+	"X-Msh-Version": "0.0.0",
+	"X-Msh-Device-Name": "test",
+	"X-Msh-Device-Model": "test",
+	"X-Msh-Os-Version": "test",
+	"X-Msh-Device-Id": "test",
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("Kimi usage provider", () => {
+	it("preserves reset timestamps when normalizing usage windows", async () => {
+		vi.spyOn(kimiOauth, "getKimiCommonHeaders").mockReturnValue(KIMI_HEADERS);
+		const summaryReset = "2026-07-23T17:45:55.083587Z";
+		const detailReset = "2026-07-17T18:45:55.083587Z";
+		const windowReset = "2026-07-18T18:45:55.083587Z";
+		const ignoredDetailReset = "2026-07-19T18:45:55.083587Z";
+		const payload = {
+			usage: { limit: "100", used: "20", remaining: "80", resetTime: summaryReset },
+			limits: [
+				{
+					window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+					detail: { limit: "100", used: "100", resetTime: detailReset },
+				},
+				{
+					window: { duration: 1, timeUnit: "TIME_UNIT_HOUR", resetTime: windowReset },
+					detail: { limit: "100", used: "50", resetTime: ignoredDetailReset },
+				},
+				{
+					window: { duration: 1, timeUnit: "TIME_UNIT_DAY" },
+					detail: { limit: "100", used: "25" },
+				},
+			],
+		};
+		const ctx: UsageFetchContext = {
+			fetch: async () => new Response(JSON.stringify(payload)),
+		};
+
+		const report = await kimiUsageProvider.fetchUsage(
+			{
+				provider: "kimi-code",
+				credential: { type: "oauth", accessToken: "test-token" },
+			},
+			ctx,
+		);
+
+		expect(report).not.toBeNull();
+		if (!report) throw new Error("Expected a Kimi usage report");
+		expect(report.limits[0].window?.resetsAt).toBe(Date.parse(summaryReset));
+		expect(report.limits[1].window?.resetsAt).toBe(Date.parse(detailReset));
+		expect(report.limits[2].window?.resetsAt).toBe(Date.parse(windowReset));
+		expect(report.limits[3].window?.resetsAt).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
A mocked Kimi `GET /coding/v1/usages` response with a duration window and `detail.resetTime` reproduced the omission via `PI_CODING_AGENT_DIR=<writable-temp-dir> bun kimi-reset-repro.ts`: the normalized window contained `durationMs` but no `resetsAt`, and the probe exited 1.

## Cause
`packages/ai/src/usage/kimi.ts` parsed `limits[].detail.resetTime` into `KimiUsageRow.resetsAt`, but `toUsageLimit` selected an existing `row.window` wholesale. Because `buildWindow` only saw Kimi's duration/time-unit object, that selected window had no reset timestamp and the detail-derived value was discarded.

## Fix
- Merge the detail-derived reset into an existing window only when that window has no reset of its own.
- Preserve window reset precedence, summary fallback behavior, and windows with no reset.
- Add a Kimi usage-provider regression test and an unreleased changelog entry.

## Verification
`bun test packages/ai/test/kimi-usage.test.ts` passes (1 test, 5 assertions); the original mocked provider probe now emits `resetsAt: 1784313955083` and exits 0; `bun check` passes across the repository. Fixes #5899