### PR TITLE
fix(advisor): keep advise when Cursor emits ungranted native tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed `xd://` mount notices triggering unsolicited model turns by deferring hidden notices until the next user prompt.
 - Fixed `xd://` device tools appearing in the direct tool inventory and prompting invalid function calls ([#5797](https://github.com/can1357/oh-my-pi/issues/5797)).
+- Fixed the Cursor-backed advisor losing entire turns when it selected server-native tools (`bash`, `grep`, etc.) outside its grant: exec-resolved native blocks are already rejected in-band by the advisor-scoped bridge, so they no longer trip the unavailable-tool quarantine and discard the `advise` emitted in the same turn ([#5900](https://github.com/can1357/oh-my-pi/issues/5900)).
 
 ## [17.0.2] - 2026-07-17
 

--- a/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
+++ b/packages/coding-agent/src/advisor/__tests__/advisor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "bun:test";
 import type { AgentMessage, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import type { TUI } from "@oh-my-pi/pi-tui";
 import { type } from "arktype";
 import type { ModelRegistry } from "../../config/model-registry";
@@ -517,6 +518,58 @@ describe("advisor", () => {
 			expect(quarantineAdvisorUnsafeOutput(message, new Set(["advise", "write", "delete"]))).toBeUndefined();
 			expect(message.stopReason).toBe("toolUse");
 			expect(message.content).toBe(originalContent);
+		});
+
+		it("keeps advise when Cursor emits exec-resolved native tools outside the grant (issue #5900)", () => {
+			const message = {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Investigating the networking design." },
+					{
+						type: "toolCall",
+						id: "tc-grep",
+						name: "grep",
+						arguments: { pattern: "backoff" },
+						[kCursorExecResolved]: true,
+					},
+					{
+						type: "toolCall",
+						id: "tc-bash",
+						name: "bash",
+						arguments: { command: "ls" },
+						[kCursorExecResolved]: true,
+					},
+					{
+						type: "toolCall",
+						id: "tc-advise",
+						name: "advise",
+						arguments: { note: "The retry backoff looks unbounded." },
+					},
+				],
+				stopReason: "toolUse",
+			} as unknown as AssistantMessage;
+			const originalContent = message.content;
+
+			// Grant is `advise` only (WATCHDOG.yml `tools: []`). The native grep/bash
+			// frames already ran server-side through the advisor-scoped bridge, which
+			// rejected them in-band; they must not discard the legitimate advise.
+			expect(quarantineAdvisorUnsafeOutput(message, new Set(["advise"]))).toBeUndefined();
+			expect(message.stopReason).toBe("toolUse");
+			expect(message.content).toBe(originalContent);
+			expect(JSON.stringify(message)).toContain("unbounded");
+		});
+
+		it("still quarantines an ungranted native tool that was not exec-resolved", () => {
+			const message = {
+				role: "assistant",
+				content: [{ type: "toolCall", id: "tc-bash", name: "bash", arguments: { command: "ls" } }],
+				stopReason: "toolUse",
+			} as unknown as AssistantMessage;
+
+			expect(quarantineAdvisorUnsafeOutput(message, new Set(["advise"]))).toBe(
+				"Advisor response quarantined: requested unavailable tool bash",
+			);
+			expect(message.stopReason).toBe("error");
 		});
 
 		it("sanitizes destructive advise notes even when advise is an allowed tool", () => {

--- a/packages/coding-agent/src/advisor/runtime.ts
+++ b/packages/coding-agent/src/advisor/runtime.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import type { AssistantMessage, ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import * as AIError from "@oh-my-pi/pi-ai/error";
+import { type CursorExecResolvedCarrier, kCursorExecResolved } from "@oh-my-pi/pi-ai/utils/block-symbols";
 import { logger } from "@oh-my-pi/pi-utils";
 import { obfuscateToolArguments, type SecretObfuscator } from "../secrets/obfuscator";
 import { formatSessionHistoryMarkdown, PRIMARY_CONTEXT_CUSTOM_TYPES } from "../session/session-history-format";
@@ -129,7 +130,20 @@ export function quarantineAdvisorUnsafeOutput(
 	const unavailableToolNames = new Set<string>();
 	const generatedParts: string[] = [];
 	for (const block of message.content) {
-		if (block.type === "toolCall" && !availableToolNames.has(block.name)) unavailableToolNames.add(block.name);
+		// Cursor exec-channel native blocks (bash/read/grep/...) are stamped
+		// kCursorExecResolved: they already ran server-side through the
+		// advisor-scoped CursorExecHandlers bridge, which rejects ungranted
+		// tools in-band ("Tool not available") and lets the model self-correct.
+		// Quarantining them would discard the legitimate advise emitted in the
+		// same turn (issue #5900). The scoped bridge is the grant gate here, not
+		// this pre-dispatch check.
+		if (
+			block.type === "toolCall" &&
+			!availableToolNames.has(block.name) &&
+			(block as CursorExecResolvedCarrier)[kCursorExecResolved] !== true
+		) {
+			unavailableToolNames.add(block.name);
+		}
 		if (block.type === "toolCall" && block.name === "advise" && typeof block.arguments.note === "string") {
 			generatedParts.push(block.arguments.note);
 		}


### PR DESCRIPTION
## Repro
A Cursor-backed advisor (`cursor/gpt-5.6-sol-medium`) with a restricted grant (`WATCHDOG.yml tools: []`, so only the always-present `advise`) still loses every turn after #5686. Cursor selects server-native tools (`bash`, `grep`, ...) that sit outside the grant; the turn is quarantined with `requested unavailable tools bash, grep` and the `advise` note never reaches the primary session. Driving the exact scenario through `quarantineAdvisorUnsafeOutput` (grant = `advise` only, exec-resolved `grep`+`bash`+`advise` in one turn) reproduces it: `stopReason` becomes `error`, the advise note is dropped.

## Cause
The remaining gap is *not* a missing native capability mask — `RequestContext` (`packages/catalog/src/discovery/cursor-gen/agent_pb.ts`) has no native-tool toggle; Cursor's native surface is server-side and cannot be masked per request. The defect is in `quarantineAdvisorUnsafeOutput` (`packages/coding-agent/src/advisor/runtime.ts`): it flags *every* `toolCall` block whose name is outside `availableToolNames` as a pre-dispatch hazard. But Cursor exec-channel native blocks are stamped `kCursorExecResolved` — they already ran server-side through the advisor-scoped `CursorExecHandlers` bridge (the real grant gate, which returns `Tool "grep" not available` in-band) and are skipped by `agent-loop.ts`. They are inert; quarantining them discards the legitimate `advise` emitted in the same turn.

## Fix
- `packages/coding-agent/src/advisor/runtime.ts`: skip blocks stamped `kCursorExecResolved` in the unavailable-tool check (import `kCursorExecResolved` + `CursorExecResolvedCarrier` from `@oh-my-pi/pi-ai/utils/block-symbols`). The scoped bridge remains the grant gate; genuinely ungranted MCP/native calls that were *not* exec-resolved still quarantine.
- `packages/coding-agent/src/advisor/__tests__/advisor.test.ts`: two regression tests — (1) a Cursor turn with exec-resolved native `grep`/`bash` plus `advise` under grant `advise` is left intact and preserves the note; (2) an ungranted native `bash` that was *not* exec-resolved still quarantines.
- `packages/coding-agent/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification
`bun test src/advisor/__tests__/advisor.test.ts` → 127 pass / 0 fail. Confirmed the new #5900 test fails without the source change (126 pass / 1 fail) and passes with it, so it defends the exact contract. `bun run check:types` clean. Fixes #5900