### PR TITLE
fix(browser): bound scroll renderer acknowledgement wait

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `tab.scroll()` timing out after a queued wheel event waits too long for a busy renderer's acknowledgement ([#5905](https://github.com/can1357/oh-my-pi/issues/5905)).
+
 ## [17.0.3] - 2026-07-17
 
 ### Changed

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -182,7 +182,14 @@ export async function dispatchScroll(
 	dispatch: () => Promise<void>,
 	ackTimeoutMs = SCROLL_ACK_TIMEOUT_MS,
 ): Promise<void> {
-	await Promise.race([dispatch(), Bun.sleep(ackTimeoutMs)]);
+	const deadline = Promise.withResolvers<void>();
+	const timer = setTimeout(() => deadline.resolve(), ackTimeoutMs);
+	timer.unref();
+	try {
+		await Promise.race([dispatch(), deadline.promise]);
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 /**

--- a/packages/coding-agent/src/tools/browser/tab-worker.ts
+++ b/packages/coding-agent/src/tools/browser/tab-worker.ts
@@ -144,6 +144,8 @@ interface OpenDialogInfo {
  */
 const QUICK_OP_TIMEOUT_MS = 20_000;
 const ACTION_OP_TIMEOUT_MS = 8_000;
+/** Maximum wait for a renderer acknowledgement after a wheel event is queued. */
+const SCROLL_ACK_TIMEOUT_MS = 2_000;
 /** Headroom subtracted from the cell budget so a per-op deadline fires before it. */
 const OP_DEADLINE_SLACK_MS = CELL_BUDGET_SLACK_MS;
 /**
@@ -173,6 +175,14 @@ export function resolveOpTimeouts(cellTimeoutMs: number): OpTimeouts {
 		quickOpMs: Math.min(budgetBound, QUICK_OP_TIMEOUT_MS),
 		actionOpMs: Math.min(budgetBound, ACTION_OP_TIMEOUT_MS),
 	};
+}
+
+/** Queue a wheel event without treating a delayed renderer acknowledgement as dispatch failure. */
+export async function dispatchScroll(
+	dispatch: () => Promise<void>,
+	ackTimeoutMs = SCROLL_ACK_TIMEOUT_MS,
+): Promise<void> {
+	await Promise.race([dispatch(), Bun.sleep(ackTimeoutMs)]);
 }
 
 /**
@@ -1216,7 +1226,9 @@ export class WorkerCore {
 					await untilAborted(sig, () => page.keyboard.press(key));
 				}),
 			scroll: (deltaX, deltaY) =>
-				op("tab.scroll()", actionOpMs, sig => untilAborted(sig, () => page.mouse.wheel({ deltaX, deltaY }))),
+				op("tab.scroll()", actionOpMs, sig =>
+					untilAborted(sig, () => dispatchScroll(() => page.mouse.wheel({ deltaX, deltaY }))),
+				),
 			drag: (from, to) => op("tab.drag()", actionOpMs, sig => this.#drag(from, to, sig)),
 			waitFor: (selector, opts) => {
 				const w = waitMs(opts?.timeout);

--- a/packages/coding-agent/test/tools/browser-tab-timeouts.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-timeouts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { resolvePredicateTimeout } from "@oh-my-pi/pi-coding-agent/tools/browser/run-cancellation";
 import {
+	dispatchScroll,
 	normalizeSelector,
 	resolveOpTimeouts,
 	resolveWaitTimeout,
@@ -39,6 +40,20 @@ describe("browser per-op fail-fast ceilings", () => {
 		expect(actionOpMs).toBeGreaterThanOrEqual(1);
 		expect(quickOpMs).toBeGreaterThanOrEqual(1);
 		expect(actionOpMs).toBeLessThanOrEqual(budgetBound);
+	});
+});
+
+describe("browser scroll acknowledgement", () => {
+	it("returns after the acknowledgement deadline while the renderer remains stalled", async () => {
+		const acknowledgement = Promise.withResolvers<void>();
+
+		await expect(dispatchScroll(() => acknowledgement.promise, 1)).resolves.toBeUndefined();
+	});
+
+	it("preserves wheel dispatch failures received before the acknowledgement deadline", async () => {
+		await expect(dispatchScroll(() => Promise.reject(new Error("target closed")), 100)).rejects.toThrow(
+			"target closed",
+		);
 	});
 });
 

--- a/packages/coding-agent/test/tools/browser-tab-timeouts.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-timeouts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, vi } from "bun:test";
 import { resolvePredicateTimeout } from "@oh-my-pi/pi-coding-agent/tools/browser/run-cancellation";
 import {
 	dispatchScroll,
@@ -54,6 +54,19 @@ describe("browser scroll acknowledgement", () => {
 		await expect(dispatchScroll(() => Promise.reject(new Error("target closed")), 100)).rejects.toThrow(
 			"target closed",
 		);
+	});
+
+	it("cancels the acknowledgement deadline after a prompt dispatch", async () => {
+		vi.useFakeTimers();
+		try {
+			const timerCount = vi.getTimerCount();
+
+			await dispatchScroll(() => Promise.resolve());
+
+			expect(vi.getTimerCount()).toBe(timerCount);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 


### PR DESCRIPTION
## Repro
A stalled renderer acknowledgement reproduces the failure with `await untilAborted(AbortSignal.timeout(8_000), () => new Promise(() => {}))`: the current `tab.scroll()` composition aborted after 8001ms, matching the reported action deadline.

## Cause
`packages/coding-agent/src/tools/browser/tab-worker.ts` wrapped `page.mouse.wheel()` directly in the 8-second action deadline. Puppeteer waits for the renderer to acknowledge the queued `Input.dispatchMouseEvent`, so a saturated renderer turns a successfully queued scroll into a `tab.scroll()` timeout.

## Fix
- Route wheel dispatch through `dispatchScroll`, which preserves a prompt acknowledgement but stops waiting after two seconds when the renderer remains busy.
- Preserve wheel dispatch failures that arrive before the acknowledgement deadline.
- Add regression coverage for stalled acknowledgements and immediate dispatch failures, plus the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/tools/browser-tab-timeouts.test.ts` passed 16 tests; `bun run check` in `packages/coding-agent` passed; the controlled stalled-ack smoke check resolved in 2002ms instead of aborting at 8000ms. The live reporter URL could not be exercised in this harness because bundled Chromium could not load the workstation's missing `libglib-2.0.so.0`.

Fixes #5905